### PR TITLE
chore: update p3 dependency to commit cccb11d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
  "num-integer",
  "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -220,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nums"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3c74f925fb8cfc49a8022f2afce48a0683b70f9e439885594e84c5edbf5b01"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +247,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p3-air"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -242,6 +256,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "num-bigint",
  "p3-field",
@@ -255,6 +270,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -266,6 +282,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "p3-challenger",
@@ -278,6 +295,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -289,10 +307,13 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "num-bigint",
+ "num-integer",
  "num-traits",
+ "nums",
  "p3-util",
  "rand",
  "serde",
@@ -301,6 +322,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "p3-challenger",
@@ -318,6 +340,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "num-bigint",
  "p3-dft",
@@ -333,6 +356,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -342,6 +366,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "p3-symmetric",
  "tiny-keccak",
@@ -350,6 +375,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "p3-field",
@@ -363,10 +389,12 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "p3-dft",
@@ -380,6 +408,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "p3-commit",
@@ -395,6 +424,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "gcd",
  "p3-field",
@@ -406,6 +436,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "p3-field",
@@ -415,6 +446,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "itertools",
  "p3-air",
@@ -432,6 +464,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=cccb11d#cccb11d998dce7af2064d8d07044432babd1d539"
 dependencies = [
  "serde",
 ]
@@ -749,15 +782,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[patch.unused]]
-name = "p3-blake3"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "p3-bn254-fr"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "p3-keccak-air"
-version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [ "chips",
-    "stark-middleware",
-    "stark-middleware/derive"
-]
+members = ["chips", "stark-middleware", "stark-middleware/derive"]
 resolver = "2"
 
 [workspace.package]
@@ -22,28 +19,28 @@ debug = true
 debug-assertions = true
 
 [workspace.dependencies]
-p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
+p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
-  "nightly-features",
-], rev = "95e56fa" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
+    "nightly-features",
+], rev = "cccb11d" }
+p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
+p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "cccb11d" }
 
 # For local development. Add to your `.cargo/config.toml`
 # [patch."https://github.com/Plonky3/Plonky3.git"]

--- a/chips/tests/config/poseidon2.rs
+++ b/chips/tests/config/poseidon2.rs
@@ -18,7 +18,7 @@ type ValMmcs =
     FieldMerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
 type Challenge = BinomialExtensionField<Val, 4>;
 type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
-pub type Challenger = DuplexChallenger<Val, Perm, 16>;
+pub type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type Dft = Radix2DitParallel;
 type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 pub type StarkConfigPoseidon2 = StarkConfig<Pcs, Challenge, Challenger>;
@@ -26,7 +26,7 @@ pub type StarkConfigPoseidon2 = StarkConfig<Pcs, Challenge, Challenger>;
 use rand::{rngs::StdRng, SeedableRng};
 
 /// `pcs_log_degree` is the upper bound on the log_2(PCS polynomial degree).
-pub fn default_config(perm: &Perm, pcs_log_degree: usize) -> StarkConfigPoseidon2 {
+pub fn default_config(perm: &Perm) -> StarkConfigPoseidon2 {
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let val_mmcs = ValMmcs::new(hash, compress);
@@ -38,7 +38,7 @@ pub fn default_config(perm: &Perm, pcs_log_degree: usize) -> StarkConfigPoseidon
         proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
     };
-    let pcs = Pcs::new(pcs_log_degree, dft, val_mmcs, fri_config);
+    let pcs = Pcs::new(dft, val_mmcs, fri_config);
     StarkConfigPoseidon2::new(pcs)
 }
 

--- a/chips/tests/integration_test.rs
+++ b/chips/tests/integration_test.rs
@@ -35,10 +35,8 @@ fn test_list_range_checker() {
     const LOG_TRACE_DEGREE_LIST: usize = 6;
     const LIST_LEN: usize = 1 << LOG_TRACE_DEGREE_LIST;
 
-    let log_trace_degree_max: usize = std::cmp::max(LOG_TRACE_DEGREE_LIST, LOG_TRACE_DEGREE_RANGE);
-
     let perm = config::poseidon2::random_perm();
-    let config = config::poseidon2::default_config(&perm, log_trace_degree_max);
+    let config = config::poseidon2::default_config(&perm);
 
     // Creating a RangeCheckerChip
     let range_checker = Arc::new(RangeCheckerChip::<MAX>::new(bus_index));

--- a/stark-middleware/tests/cached_lookup/mod.rs
+++ b/stark-middleware/tests/cached_lookup/mod.rs
@@ -8,7 +8,6 @@ use afs_middleware::{
 use p3_baby_bear::BabyBear;
 use p3_field::AbstractField;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_util::log2_ceil_usize;
 
 use crate::{config, interaction::dummy_interaction_air::DummyInteractionAir};
 
@@ -21,12 +20,9 @@ fn prove_and_verify_indexless_lookups(
 ) -> Result<(), VerificationError> {
     let sender_degree = sender.len();
     let receiver_degree = receiver.len();
-    let [sender_log_degree, receiver_log_degree] =
-        [sender_degree, receiver_degree].map(log2_ceil_usize);
 
     let perm = config::poseidon2::random_perm();
-    let config =
-        config::poseidon2::default_config(&perm, sender_log_degree.max(receiver_log_degree));
+    let config = config::poseidon2::default_config(&perm);
 
     let sender_air = DummyInteractionAir::new(sender[0].1.len(), true, 0);
     let receiver_air = DummyInteractionAir::new(receiver[0].1.len(), false, 0);

--- a/stark-middleware/tests/config/poseidon2.rs
+++ b/stark-middleware/tests/config/poseidon2.rs
@@ -18,7 +18,7 @@ type ValMmcs =
     FieldMerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
 type Challenge = BinomialExtensionField<Val, 4>;
 type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
-pub type Challenger = DuplexChallenger<Val, Perm, 16>;
+pub type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type Dft = Radix2DitParallel;
 type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 pub type StarkConfigPoseidon2 = StarkConfig<Pcs, Challenge, Challenger>;
@@ -26,7 +26,7 @@ pub type StarkConfigPoseidon2 = StarkConfig<Pcs, Challenge, Challenger>;
 use rand::{rngs::StdRng, SeedableRng};
 
 /// `pcs_log_degree` is the upper bound on the log_2(PCS polynomial degree).
-pub fn default_config(perm: &Perm, pcs_log_degree: usize) -> StarkConfigPoseidon2 {
+pub fn default_config(perm: &Perm) -> StarkConfigPoseidon2 {
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let val_mmcs = ValMmcs::new(hash, compress);
@@ -38,7 +38,7 @@ pub fn default_config(perm: &Perm, pcs_log_degree: usize) -> StarkConfigPoseidon
         proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
     };
-    let pcs = Pcs::new(pcs_log_degree, dft, val_mmcs, fri_config);
+    let pcs = Pcs::new(dft, val_mmcs, fri_config);
     StarkConfigPoseidon2::new(pcs)
 }
 

--- a/stark-middleware/tests/integration_test.rs
+++ b/stark-middleware/tests/integration_test.rs
@@ -38,7 +38,7 @@ fn test_single_fib_stark() {
 
     let log_trace_degree = 3;
     let perm = config::poseidon2::random_perm();
-    let config = config::poseidon2::default_config(&perm, log_trace_degree);
+    let config = config::poseidon2::default_config(&perm);
 
     // Public inputs:
     let a = 0u32;
@@ -84,7 +84,7 @@ fn test_single_fib_triples_stark() {
 
     let log_trace_degree = 3;
     let perm = config::poseidon2::random_perm();
-    let config = config::poseidon2::default_config(&perm, log_trace_degree);
+    let config = config::poseidon2::default_config(&perm);
 
     // Public inputs:
     let a = 0u32;
@@ -131,7 +131,7 @@ fn test_single_fib_selector_stark() {
 
     let log_trace_degree = 3;
     let perm = config::poseidon2::random_perm();
-    let config = config::poseidon2::default_config(&perm, log_trace_degree);
+    let config = config::poseidon2::default_config(&perm);
 
     // Public inputs:
     let a = 0u32;
@@ -180,7 +180,7 @@ fn test_double_fib_starks() {
     let log_n1 = 3;
     let log_n2 = 5;
     let perm = config::poseidon2::random_perm();
-    let config = config::poseidon2::default_config(&perm, log_n1.max(log_n2));
+    let config = config::poseidon2::default_config(&perm);
 
     // Public inputs:
     let a = 0u32;

--- a/stark-middleware/tests/interaction/mod.rs
+++ b/stark-middleware/tests/interaction/mod.rs
@@ -27,9 +27,8 @@ fn verify_interactions(
     airs: Vec<&dyn ProverVerifierRap<StarkConfigPoseidon2>>,
     pis: Vec<Vec<Val>>,
 ) -> Result<(), VerificationError> {
-    let log_trace_degree = 3;
     let perm = config::poseidon2::random_perm();
-    let config = config::poseidon2::default_config(&perm, log_trace_degree);
+    let config = config::poseidon2::default_config(&perm);
 
     let mut keygen_builder = MultiStarkKeygenBuilder::new(&config);
     for ((air, trace), pis) in airs.iter().zip_eq(&traces).zip_eq(&pis) {

--- a/stark-middleware/tests/partitioned_sum_air/mod.rs
+++ b/stark-middleware/tests/partitioned_sum_air/mod.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use p3_baby_bear::BabyBear;
 use p3_field::AbstractField;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_util::log2_ceil_usize;
 use rand::{rngs::StdRng, SeedableRng};
 
 use crate::{config, utils::generate_random_matrix};
@@ -22,10 +21,9 @@ type Val = BabyBear;
 fn prove_and_verify_sum_air(x: Vec<Val>, ys: Vec<Vec<Val>>) -> Result<(), VerificationError> {
     assert_eq!(x.len(), ys.len());
     let degree = x.len();
-    let log_degree = log2_ceil_usize(degree);
 
     let perm = config::poseidon2::random_perm();
-    let config = config::poseidon2::default_config(&perm, log_degree);
+    let config = config::poseidon2::default_config(&perm);
 
     let x_trace = RowMajorMatrix::new(x, 1);
     let y_width = ys[0].len();


### PR DESCRIPTION
Bump plonky3 dependency to https://github.com/Plonky3/Plonky3/commit/cccb11d998dce7af2064d8d07044432babd1d539

- Removes the need for passing log quotient degree as a config parameter
- Draft because `test_interaction_stark_multi_sender_receiver_happy_path` is failing for me on debug for some reason (cc @nyunyunyunyu)