### PR TITLE
chore: rename `*ProvingKey` to `*PartialProvingKey`

### DIFF
--- a/stark-backend/src/keygen/mod.rs
+++ b/stark-backend/src/keygen/mod.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 
 use self::types::{
-    create_commit_to_air_graph, MultiStarkProvingKey, ProverOnlySinglePreprocessedData,
-    StarkProvingKey, StarkVerifyingKey, TraceWidth, VerifierSinglePreprocessedData,
+    create_commit_to_air_graph, MultiStarkPartialProvingKey, ProverOnlySinglePreprocessedData,
+    StarkPartialProvingKey, StarkPartialVerifyingKey, TraceWidth, VerifierSinglePreprocessedData,
 };
 
 /// Constants for interactive AIRs
@@ -30,22 +30,22 @@ pub struct MultiStarkKeygenBuilder<'a, SC: StarkGenericConfig> {
     /// `placeholder_main_matrix_in_commit[commit_idx][mat_idx] =` matrix width, it is used to store
     /// a placeholder of a main trace matrix that must be committed during proving
     placeholder_main_matrix_in_commit: Vec<Vec<usize>>,
-    pk: MultiStarkProvingKey<SC>,
+    partial_pk: MultiStarkPartialProvingKey<SC>,
 }
 
 impl<'a, SC: StarkGenericConfig> MultiStarkKeygenBuilder<'a, SC> {
     pub fn new(config: &'a SC) -> Self {
         Self {
             config,
-            pk: MultiStarkProvingKey::empty(),
+            partial_pk: MultiStarkPartialProvingKey::empty(),
             placeholder_main_matrix_in_commit: vec![vec![]],
         }
     }
 
     /// Generates proving key, resetting the state of the builder.
     /// The verifying key can be obtained from the proving key.
-    pub fn generate_pk(&mut self) -> MultiStarkProvingKey<SC> {
-        let mut pk = std::mem::take(&mut self.pk);
+    pub fn generate_partial_pk(&mut self) -> MultiStarkPartialProvingKey<SC> {
+        let mut pk = std::mem::take(&mut self.partial_pk);
         // Determine global num challenges to sample
         let num_phases = pk
             .per_air
@@ -168,7 +168,7 @@ impl<'a, SC: StarkGenericConfig> MultiStarkKeygenBuilder<'a, SC> {
             &num_exposed_values,
         );
         let quotient_degree = 1 << log_quotient_degree;
-        let vk = StarkVerifyingKey {
+        let vk = StarkPartialVerifyingKey {
             degree,
             preprocessed_data: prep_verifier_data,
             width,
@@ -178,12 +178,12 @@ impl<'a, SC: StarkGenericConfig> MultiStarkKeygenBuilder<'a, SC> {
             num_exposed_values_after_challenge: num_exposed_values,
             num_challenges_to_sample,
         };
-        let pk = StarkProvingKey {
+        let pk = StarkPartialProvingKey {
             vk,
             preprocessed_data: prep_prover_data,
         };
 
-        self.pk.per_air.push(pk);
+        self.partial_pk.per_air.push(pk);
     }
 
     /// Default way to add a single Interactive AIR.

--- a/stark-backend/src/keygen/types.rs
+++ b/stark-backend/src/keygen/types.rs
@@ -25,9 +25,9 @@ pub struct TraceWidth {
     serialize = "PcsProverData<SC>: Serialize",
     deserialize = "PcsProverData<SC>: Deserialize<'de>"
 ))]
-pub struct StarkProvingKey<SC: StarkGenericConfig> {
+pub struct StarkPartialProvingKey<SC: StarkGenericConfig> {
     /// Verifying key
-    pub vk: StarkVerifyingKey<SC>,
+    pub vk: StarkPartialVerifyingKey<SC>,
     /// Prover only data for preprocessed trace
     pub preprocessed_data: Option<ProverOnlySinglePreprocessedData<SC>>,
 }
@@ -41,7 +41,7 @@ pub struct StarkProvingKey<SC: StarkGenericConfig> {
     serialize = "Com<SC>: Serialize",
     deserialize = "Com<SC>: Deserialize<'de>"
 ))]
-pub struct StarkVerifyingKey<SC: StarkGenericConfig> {
+pub struct StarkPartialVerifyingKey<SC: StarkGenericConfig> {
     /// Height of trace matrix.
     pub degree: usize,
     /// Preprocessed trace data, if any
@@ -101,8 +101,8 @@ pub struct VerifierSinglePreprocessedData<SC: StarkGenericConfig> {
     serialize = "PcsProverData<SC>: Serialize",
     deserialize = "PcsProverData<SC>: Deserialize<'de>"
 ))]
-pub struct MultiStarkProvingKey<SC: StarkGenericConfig> {
-    pub per_air: Vec<StarkProvingKey<SC>>,
+pub struct MultiStarkPartialProvingKey<SC: StarkGenericConfig> {
+    pub per_air: Vec<StarkPartialProvingKey<SC>>,
     /// Number of multi-matrix commitments that hold commitments to the partitioned main trace matrices across all AIRs.
     pub num_main_trace_commitments: usize,
     /// Mapping from commit_idx to global AIR index for matrix in commitment, in oder.
@@ -112,13 +112,13 @@ pub struct MultiStarkProvingKey<SC: StarkGenericConfig> {
     pub num_challenges_to_sample: Vec<usize>,
 }
 
-impl<SC: StarkGenericConfig> Default for MultiStarkProvingKey<SC> {
+impl<SC: StarkGenericConfig> Default for MultiStarkPartialProvingKey<SC> {
     fn default() -> Self {
         Self::empty()
     }
 }
 
-impl<SC: StarkGenericConfig> MultiStarkProvingKey<SC> {
+impl<SC: StarkGenericConfig> MultiStarkPartialProvingKey<SC> {
     /// Empty with 1 main trace commitment
     pub fn empty() -> Self {
         Self {
@@ -132,7 +132,7 @@ impl<SC: StarkGenericConfig> MultiStarkProvingKey<SC> {
     }
 
     pub fn new(
-        per_air: Vec<StarkProvingKey<SC>>,
+        per_air: Vec<StarkPartialProvingKey<SC>>,
         num_main_trace_commitments: usize,
         num_challenges_to_sample: Vec<usize>,
     ) -> Self {
@@ -150,8 +150,8 @@ impl<SC: StarkGenericConfig> MultiStarkProvingKey<SC> {
         }
     }
 
-    pub fn vk(&self) -> MultiStarkVerifyingKey<SC> {
-        MultiStarkVerifyingKey {
+    pub fn partial_vk(&self) -> MultiStarkPartialVerifyingKey<SC> {
+        MultiStarkPartialVerifyingKey {
             per_air: self.per_air.iter().map(|pk| pk.vk.clone()).collect(),
             main_commit_to_air_graph: self.main_commit_to_air_graph.clone(),
             num_main_trace_commitments: self.num_main_trace_commitments,
@@ -186,8 +186,8 @@ impl<SC: StarkGenericConfig> MultiStarkProvingKey<SC> {
     serialize = "Com<SC>: Serialize",
     deserialize = "Com<SC>: Deserialize<'de>"
 ))]
-pub struct MultiStarkVerifyingKey<SC: StarkGenericConfig> {
-    pub per_air: Vec<StarkVerifyingKey<SC>>,
+pub struct MultiStarkPartialVerifyingKey<SC: StarkGenericConfig> {
+    pub per_air: Vec<StarkPartialVerifyingKey<SC>>,
     /// Number of multi-matrix commitments that hold commitments to the partitioned main trace matrices across all AIRs.
     pub num_main_trace_commitments: usize,
     /// Mapping from commit_idx to global AIR index for matrix in commitment, in oder.
@@ -197,9 +197,9 @@ pub struct MultiStarkVerifyingKey<SC: StarkGenericConfig> {
     pub num_challenges_to_sample: Vec<usize>,
 }
 
-impl<SC: StarkGenericConfig> MultiStarkVerifyingKey<SC> {
+impl<SC: StarkGenericConfig> MultiStarkPartialVerifyingKey<SC> {
     pub fn new(
-        per_air: Vec<StarkVerifyingKey<SC>>,
+        per_air: Vec<StarkPartialVerifyingKey<SC>>,
         num_main_trace_commitments: usize,
         num_challenges_to_sample: Vec<usize>,
     ) -> Self {

--- a/stark-backend/src/prover/mod.rs
+++ b/stark-backend/src/prover/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     air_builders::debug::check_constraints::check_constraints,
     commit::CommittedSingleMatrixView,
     config::{Com, PcsProof, PcsProverData},
-    keygen::types::MultiStarkProvingKey,
+    keygen::types::MultiStarkPartialProvingKey,
     prover::trace::SingleRapCommittedTraceView,
     rap::AnyRap,
 };
@@ -62,7 +62,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkProver<'c, SC> {
     pub fn prove<'a>(
         &self,
         challenger: &mut SC::Challenger,
-        pk: &'a MultiStarkProvingKey<SC>,
+        pk: &'a MultiStarkPartialProvingKey<SC>,
         main_trace_data: MultiAirCommittedTraceData<'a, SC>,
         public_values: &'a [Vec<Val<SC>>],
     ) -> Proof<SC>
@@ -277,7 +277,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkProver<'c, SC> {
     pub fn prove_raps_with_committed_traces<'a>(
         &self,
         challenger: &mut SC::Challenger,
-        pk: &'a MultiStarkProvingKey<SC>,
+        partial_pk: &'a MultiStarkPartialProvingKey<SC>,
         raps: Vec<&'a dyn AnyRap<SC>>,
         trace_views: Vec<SingleRapCommittedTraceView<'a, SC>>,
         main_pcs_data: &[(Com<SC>, &PcsProverData<SC>)],
@@ -303,7 +303,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkProver<'c, SC> {
         let alpha: SC::Challenge = challenger.sample_ext_element();
         tracing::debug!("alpha: {alpha:?}");
 
-        let quotient_degrees = pk
+        let quotient_degrees = partial_pk
             .per_air
             .iter()
             .map(|pk| pk.vk.quotient_degree)
@@ -348,7 +348,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkProver<'c, SC> {
 
         let main_data: Vec<_> = main_pcs_data
             .iter()
-            .zip_eq(&pk.main_commit_to_air_graph.commit_to_air_index)
+            .zip_eq(&partial_pk.main_commit_to_air_graph.commit_to_air_index)
             .map(|((_, data), mat_to_air_index)| {
                 let domains = mat_to_air_index
                     .iter()

--- a/stark-backend/src/prover/trace.rs
+++ b/stark-backend/src/prover/trace.rs
@@ -8,7 +8,7 @@ use tracing::info_span;
 use crate::{
     commit::CommittedSingleMatrixView,
     config::{Com, PcsProverData},
-    keygen::types::MultiStarkVerifyingKey,
+    keygen::types::MultiStarkPartialVerifyingKey,
     rap::AnyRap,
 };
 
@@ -52,7 +52,7 @@ impl<'a, SC: StarkGenericConfig> TraceCommitmentBuilder<'a, SC> {
 
     pub fn view<'b>(
         &'b self,
-        vk: &MultiStarkVerifyingKey<SC>,
+        vk: &MultiStarkPartialVerifyingKey<SC>,
         airs: Vec<&'b dyn AnyRap<SC>>,
     ) -> MultiAirCommittedTraceData<'b, SC>
     where

--- a/stark-backend/src/verifier/mod.rs
+++ b/stark-backend/src/verifier/mod.rs
@@ -11,7 +11,7 @@ mod error;
 pub use error::*;
 
 use crate::{
-    keygen::types::MultiStarkVerifyingKey,
+    keygen::types::MultiStarkPartialVerifyingKey,
     prover::{opener::AdjacentOpenedValues, types::Proof},
     rap::AnyRap,
 };
@@ -34,7 +34,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
     pub fn verify(
         &self,
         challenger: &mut SC::Challenger,
-        vk: MultiStarkVerifyingKey<SC>,
+        vk: MultiStarkPartialVerifyingKey<SC>,
         raps: Vec<&dyn AnyRap<SC>>,
         proof: Proof<SC>,
         public_values: &[Vec<Val<SC>>],
@@ -82,7 +82,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkVerifier<'c, SC> {
     pub fn verify_raps(
         &self,
         challenger: &mut SC::Challenger,
-        vk: MultiStarkVerifyingKey<SC>,
+        vk: MultiStarkPartialVerifyingKey<SC>,
         raps: Vec<&dyn AnyRap<SC>>,
         proof: Proof<SC>,
         public_values: &[Vec<Val<SC>>],

--- a/stark-backend/tests/cached_lookup/instrumented.rs
+++ b/stark-backend/tests/cached_lookup/instrumented.rs
@@ -1,6 +1,6 @@
 use std::fs::{self, File};
 
-use afs_stark_backend::{keygen::types::MultiStarkVerifyingKey, prover::types::Proof};
+use afs_stark_backend::{keygen::types::MultiStarkPartialVerifyingKey, prover::types::Proof};
 use afs_test_utils::{
     config::{
         baby_bear_poseidon2::{self, engine_from_perm},
@@ -26,7 +26,7 @@ use super::prove::{get_data_sizes, prove, BenchParams};
 
 fn instrumented_verify<SC: StarkGenericConfig, E: StarkEngineWithHashInstrumentation<SC>>(
     engine: &mut E,
-    vk: MultiStarkVerifyingKey<SC>,
+    vk: MultiStarkPartialVerifyingKey<SC>,
     air: DummyInteractionAir,
     proof: Proof<SC>,
     pis: Vec<Vec<Val<SC>>>,

--- a/stark-backend/tests/cached_lookup/mod.rs
+++ b/stark-backend/tests/cached_lookup/mod.rs
@@ -79,8 +79,8 @@ pub fn prove_and_verify_indexless_lookups(
     );
     // Auto-adds sender matrix
     keygen_builder.add_air(&sender_air, sender_degree, 0);
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
+    let partial_pk = keygen_builder.generate_partial_pk();
+    let partial_vk = partial_pk.partial_vk();
 
     let prover = MultiTraceStarkProver::new(&config);
     // Must add trace matrices in the same order as above
@@ -95,11 +95,11 @@ pub fn prove_and_verify_indexless_lookups(
     trace_builder.load_trace(sender_trace);
     trace_builder.commit_current();
 
-    let main_trace_data = trace_builder.view(&vk, vec![&receiver_air, &sender_air]);
+    let main_trace_data = trace_builder.view(&partial_vk, vec![&receiver_air, &sender_air]);
     let pis = vec![vec![]; 2];
 
     let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &pis);
+    let proof = prover.prove(&mut challenger, &partial_pk, main_trace_data, &pis);
 
     // Verify the proof:
     // Start from clean challenger
@@ -107,7 +107,7 @@ pub fn prove_and_verify_indexless_lookups(
     let verifier = MultiTraceStarkVerifier::new(prover.config);
     verifier.verify(
         &mut challenger,
-        vk,
+        partial_vk,
         vec![&receiver_air, &sender_air],
         proof,
         &pis,

--- a/stark-backend/tests/cached_lookup/prove.rs
+++ b/stark-backend/tests/cached_lookup/prove.rs
@@ -6,7 +6,7 @@ use std::{
 
 use afs_stark_backend::{
     config::{Com, PcsProof, PcsProverData},
-    keygen::types::MultiStarkVerifyingKey,
+    keygen::types::MultiStarkPartialVerifyingKey,
     prover::{trace::TraceCommitmentBuilder, types::Proof},
 };
 use afs_test_utils::{
@@ -31,7 +31,7 @@ pub fn prove<SC: StarkGenericConfig, E: StarkEngine<SC>>(
     trace: Vec<(u32, Vec<u32>)>,
     partition: bool,
 ) -> (
-    MultiStarkVerifyingKey<SC>,
+    MultiStarkPartialVerifyingKey<SC>,
     DummyInteractionAir,
     Proof<SC>,
     Vec<Vec<Val<SC>>>,
@@ -88,8 +88,8 @@ where
     } else {
         keygen_builder.add_air(&air, degree, 0);
     }
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
+    let partial_pk = keygen_builder.generate_partial_pk();
+    let partial_vk = partial_pk.partial_vk();
 
     let mut benchmarks = ProverBenchmarks::default();
     let prover = engine.prover();
@@ -113,14 +113,14 @@ where
     benchmarks.main_commit_time = start.elapsed().as_micros();
 
     start = Instant::now();
-    let main_trace_data = trace_builder.view(&vk, vec![&air]);
+    let main_trace_data = trace_builder.view(&partial_vk, vec![&air]);
     let pis = vec![vec![]];
 
     let mut challenger = engine.new_challenger();
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &pis);
+    let proof = prover.prove(&mut challenger, &partial_pk, main_trace_data, &pis);
     benchmarks.prove_time = start.elapsed().as_micros();
 
-    (vk, air, proof, pis, benchmarks)
+    (partial_vk, air, proof, pis, benchmarks)
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]

--- a/stark-backend/tests/integration_test.rs
+++ b/stark-backend/tests/integration_test.rs
@@ -1,12 +1,11 @@
 #![feature(trait_upcasting)]
 #![allow(incomplete_features)]
 
-use afs_stark_backend::keygen::MultiStarkKeygenBuilder;
-use afs_stark_backend::prover::trace::TraceCommitmentBuilder;
-use afs_stark_backend::prover::MultiTraceStarkProver;
-use afs_stark_backend::verifier::MultiTraceStarkVerifier;
 /// Test utils
-use afs_test_utils::{config, utils};
+use afs_test_utils::{
+    config::{self, baby_bear_poseidon2::run_simple_test},
+    utils,
+};
 use p3_baby_bear::BabyBear;
 use p3_field::AbstractField;
 
@@ -23,8 +22,6 @@ fn test_single_fib_stark() {
     use fib_air::trace::generate_trace_rows;
 
     let log_trace_degree = 3;
-    let perm = config::baby_bear_poseidon2::random_perm();
-    let config = config::baby_bear_poseidon2::default_config(&perm, log_trace_degree);
 
     // Public inputs:
     let a = 0u32;
@@ -37,30 +34,9 @@ fn test_single_fib_stark() {
         .to_vec();
     let air = FibonacciAir;
 
-    let mut keygen_builder = MultiStarkKeygenBuilder::new(&config);
-    keygen_builder.add_air(&air, n, pis.len());
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
-
     let trace = generate_trace_rows::<Val>(a, b, n);
 
-    let prover = MultiTraceStarkProver::new(&config);
-    let mut trace_builder = TraceCommitmentBuilder::new(prover.pcs());
-    trace_builder.load_trace(trace);
-    trace_builder.commit_current();
-
-    let main_trace_data = trace_builder.view(&vk, vec![&air]);
-
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &[pis.clone()]);
-
-    // Verify the proof:
-    // Start from clean challenger
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let verifier = MultiTraceStarkVerifier::new(prover.config);
-    verifier
-        .verify(&mut challenger, vk, vec![&air], proof, &[pis])
-        .expect("Verification failed");
+    run_simple_test(vec![&air], vec![trace], vec![pis]).expect("Verification failed");
 }
 
 #[test]
@@ -69,8 +45,6 @@ fn test_single_fib_triples_stark() {
     use fib_triples_air::trace::generate_trace_rows;
 
     let log_trace_degree = 3;
-    let perm = config::baby_bear_poseidon2::random_perm();
-    let config = config::baby_bear_poseidon2::default_config(&perm, log_trace_degree);
 
     // Public inputs:
     let a = 0u32;
@@ -84,30 +58,9 @@ fn test_single_fib_triples_stark() {
 
     let air = FibonacciAir;
 
-    let mut keygen_builder = MultiStarkKeygenBuilder::new(&config);
-    keygen_builder.add_air(&air, n, pis.len());
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
-
     let trace = generate_trace_rows::<Val>(a, b, n);
 
-    let prover = MultiTraceStarkProver::new(&config);
-    let mut trace_builder = TraceCommitmentBuilder::new(prover.pcs());
-    trace_builder.load_trace(trace);
-    trace_builder.commit_current();
-
-    let main_trace_data = trace_builder.view(&vk, vec![&air]);
-
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &[pis.clone()]);
-
-    // Verify the proof:
-    // Start from clean challenger
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let verifier = MultiTraceStarkVerifier::new(prover.config);
-    verifier
-        .verify(&mut challenger, vk, vec![&air], proof, &[pis])
-        .expect("Verification failed");
+    run_simple_test(vec![&air], vec![trace], vec![pis]).expect("Verification failed");
 }
 
 #[test]
@@ -116,8 +69,6 @@ fn test_single_fib_selector_stark() {
     use fib_selector_air::trace::generate_trace_rows;
 
     let log_trace_degree = 3;
-    let perm = config::baby_bear_poseidon2::random_perm();
-    let config = config::baby_bear_poseidon2::default_config(&perm, log_trace_degree);
 
     // Public inputs:
     let a = 0u32;
@@ -132,30 +83,9 @@ fn test_single_fib_selector_stark() {
 
     let air = FibonacciSelectorAir::new(sels, false);
 
-    let mut keygen_builder = MultiStarkKeygenBuilder::new(&config);
-    keygen_builder.add_air(&air, n, pis.len());
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
-
     let trace = generate_trace_rows::<Val>(a, b, air.sels());
 
-    let prover = MultiTraceStarkProver::new(&config);
-    let mut trace_builder = TraceCommitmentBuilder::new(prover.pcs());
-    trace_builder.load_trace(trace);
-    trace_builder.commit_current();
-
-    let main_trace_data = trace_builder.view(&vk, vec![&air]);
-
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &[pis.clone()]);
-
-    // Verify the proof:
-    // Start from clean challenger
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let verifier = MultiTraceStarkVerifier::new(prover.config);
-    verifier
-        .verify(&mut challenger, vk, vec![&air], proof, &[pis])
-        .expect("Verification failed");
+    run_simple_test(vec![&air], vec![trace], vec![pis]).expect("Verification failed");
 }
 
 #[test]
@@ -165,8 +95,6 @@ fn test_double_fib_starks() {
 
     let log_n1 = 3;
     let log_n2 = 5;
-    let perm = config::baby_bear_poseidon2::random_perm();
-    let config = config::baby_bear_poseidon2::default_config(&perm, log_n1.max(log_n2));
 
     // Public inputs:
     let a = 0u32;
@@ -186,33 +114,10 @@ fn test_double_fib_starks() {
     let air1 = FibonacciAir;
     let air2 = FibonacciSelectorAir::new(sels, false);
 
-    let mut keygen_builder = MultiStarkKeygenBuilder::new(&config);
-    keygen_builder.add_air(&air1, n1, pis1.len());
-    keygen_builder.add_air(&air2, n2, pis2.len());
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
-
     let trace1 = fib_air::trace::generate_trace_rows::<Val>(a, b, n1);
     let trace2 = fib_selector_air::trace::generate_trace_rows::<Val>(a, b, air2.sels());
 
-    let prover = MultiTraceStarkProver::new(&config);
-    let mut trace_builder = TraceCommitmentBuilder::new(prover.pcs());
-    trace_builder.load_trace(trace1);
-    trace_builder.load_trace(trace2);
-    trace_builder.commit_current();
-
-    let main_trace_data = trace_builder.view(&vk, vec![&air1, &air2]);
-    let pis_all = [pis1, pis2];
-
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &pis_all);
-
-    // Verify the proof:
-    // Start from clean challenger
-    let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let verifier = MultiTraceStarkVerifier::new(prover.config);
-    verifier
-        .verify(&mut challenger, vk, vec![&air1, &air2], proof, &pis_all)
+    run_simple_test(vec![&air1, &air2], vec![trace1, trace2], vec![pis1, pis2])
         .expect("Verification failed");
 }
 

--- a/test-utils/src/config/baby_bear_poseidon2.rs
+++ b/test-utils/src/config/baby_bear_poseidon2.rs
@@ -190,14 +190,31 @@ pub fn random_instrumented_perm() -> InstrPerm {
     Instrumented::new(perm)
 }
 
+/// Runs a single end-to-end test for a given set of chips and traces.
+/// This includes proving/verifying key generation, creating a proof, and verifying the proof.
+/// This function should only be used on chips where the main trace is **not** partitioned.
+///
+/// Do not use this if you want to generate proofs for different traces with the same proving key.
+///
+/// - `chips`, `traces`, `public_values` should be zipped.
 pub fn run_simple_test(
     chips: Vec<&dyn AnyRap<BabyBearPoseidon2Config>>,
     traces: Vec<DenseMatrix<BabyBear>>,
+    public_values: Vec<Vec<BabyBear>>,
 ) -> Result<(), VerificationError> {
     let max_trace_height = traces.iter().map(|trace| trace.height()).max().unwrap();
     let max_log_degree = log2_strict_usize(max_trace_height);
     let engine = default_engine(max_log_degree);
-    engine.run_simple_test(chips, traces)
+    engine.run_simple_test(chips, traces, public_values)
+}
+
+/// [run_simple_test] without public values
+pub fn run_simple_test_no_pis(
+    chips: Vec<&dyn AnyRap<BabyBearPoseidon2Config>>,
+    traces: Vec<DenseMatrix<BabyBear>>,
+) -> Result<(), VerificationError> {
+    let num_chips = chips.len();
+    run_simple_test(chips, traces, vec![vec![]; num_chips])
 }
 
 /// Logs hash count statistics to stdout and returns as struct.

--- a/test-utils/src/engine.rs
+++ b/test-utils/src/engine.rs
@@ -31,10 +31,16 @@ pub trait StarkEngine<SC: StarkGenericConfig> {
         MultiTraceStarkVerifier::new(self.config())
     }
 
+    /// Runs a single end-to-end test for a given set of chips and traces.
+    /// This includes proving/verifying key generation, creating a proof, and verifying the proof.
+    /// This function should only be used on chips where the main trace is **not** partitioned.
+    ///
+    /// - `chips`, `traces`, `public_values` should be zipped.
     fn run_simple_test(
         &self,
         chips: Vec<&dyn AnyRap<SC>>,
         traces: Vec<DenseMatrix<Val<SC>>>,
+        public_values: Vec<Vec<Val<SC>>>,
     ) -> Result<(), VerificationError>
     where
         SC::Pcs: Sync,
@@ -44,7 +50,7 @@ pub trait StarkEngine<SC: StarkGenericConfig> {
         SC::Challenge: Send + Sync,
         PcsProof<SC>: Send + Sync,
     {
-        run_simple_test_impl(self, chips, traces)
+        run_simple_test_impl(self, chips, traces, public_values)
     }
 }
 
@@ -53,11 +59,11 @@ pub trait StarkEngineWithHashInstrumentation<SC: StarkGenericConfig>: StarkEngin
     fn stark_hash_statistics<T>(&self, custom: T) -> StarkHashStatistics<T>;
 }
 
-/// This function assumes that all chips have no public inputs
 fn run_simple_test_impl<SC: StarkGenericConfig, E: StarkEngine<SC> + ?Sized>(
     engine: &E,
     chips: Vec<&dyn AnyRap<SC>>,
     traces: Vec<DenseMatrix<Val<SC>>>,
+    public_values: Vec<Vec<Val<SC>>>,
 ) -> Result<(), VerificationError>
 where
     SC::Pcs: Sync,
@@ -72,11 +78,15 @@ where
     let mut keygen_builder = engine.keygen_builder();
 
     for i in 0..chips.len() {
-        keygen_builder.add_air(chips[i] as &dyn AnyRap<SC>, traces[i].height(), 0);
+        keygen_builder.add_air(
+            chips[i] as &dyn AnyRap<SC>,
+            traces[i].height(),
+            public_values[i].len(),
+        );
     }
 
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
+    let partial_pk = keygen_builder.generate_partial_pk();
+    let partial_vk = partial_pk.partial_vk();
 
     let prover = engine.prover();
     let mut trace_builder = TraceCommitmentBuilder::new(prover.pcs());
@@ -87,16 +97,19 @@ where
     trace_builder.commit_current();
 
     let main_trace_data = trace_builder.view(
-        &vk,
+        &partial_vk,
         chips.iter().map(|&chip| chip as &dyn AnyRap<SC>).collect(),
     );
 
-    let pis = vec![vec![]; vk.per_air.len()];
-
     let mut challenger = engine.new_challenger();
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &pis);
+    let proof = prover.prove(
+        &mut challenger,
+        &partial_pk,
+        main_trace_data,
+        &public_values,
+    );
 
     let mut challenger = engine.new_challenger();
     let verifier = engine.verifier();
-    verifier.verify(&mut challenger, vk, chips, proof, &pis)
+    verifier.verify(&mut challenger, partial_vk, chips, proof, &public_values)
 }

--- a/test-utils/src/interaction/mod.rs
+++ b/test-utils/src/interaction/mod.rs
@@ -29,8 +29,8 @@ pub fn verify_interactions(
         let height = trace.height();
         keygen_builder.add_air(*air, height, pis.len());
     }
-    let pk = keygen_builder.generate_pk();
-    let vk = pk.vk();
+    let partial_pk = keygen_builder.generate_partial_pk();
+    let partial_vk = partial_pk.partial_vk();
 
     let prover = MultiTraceStarkProver::new(&config);
     let mut trace_builder = TraceCommitmentBuilder::new(prover.pcs());
@@ -39,14 +39,14 @@ pub fn verify_interactions(
     }
     trace_builder.commit_current();
 
-    let main_trace_data = trace_builder.view(&vk, airs.clone());
+    let main_trace_data = trace_builder.view(&partial_vk, airs.clone());
 
     let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
-    let proof = prover.prove(&mut challenger, &pk, main_trace_data, &pis);
+    let proof = prover.prove(&mut challenger, &partial_pk, main_trace_data, &pis);
 
     // Verify the proof:
     // Start from clean challenger
     let mut challenger = config::baby_bear_poseidon2::Challenger::new(perm.clone());
     let verifier = MultiTraceStarkVerifier::new(prover.config);
-    verifier.verify(&mut challenger, vk, airs, proof, &pis)
+    verifier.verify(&mut challenger, partial_vk, airs, proof, &pis)
 }


### PR DESCRIPTION
- `run_simple_test` now works with public values (`run_simple_test_no_pis` is version without)
- Also changed integration tests to use `run_simple_test`

Only changed `pk` to `partial_pk` in external functions. I kept just `pk` in internal functions because (1) it's tedious to change, (2) if we do create a full `pk` in the future we'd need to change it back anyways.