### PR TITLE
chore: separate XorBits subair from chip

### DIFF
--- a/chips/src/xor_bits/mod.rs
+++ b/chips/src/xor_bits/mod.rs
@@ -5,9 +5,19 @@ pub mod chip;
 pub mod columns;
 pub mod trace;
 
+// We separate XorBitsAir and XorBitsChip because we want a struct that specifies just the constraints of XOR,
+// while the chip needs some additional fields to receive interactions.
+
+/// AIR that computes the xor of two numbers of at most N bits each.
+/// This struct only implements SubAir.
 #[derive(Default)]
-/// A chip that computes the xor of two numbers of at most N bits each
+pub struct XorBitsAir<const N: usize>;
+
+#[derive(Default)]
+/// A chip that computes the xor of two numbers of at most N bits each.
+/// This chip consists of the AIR as well as a receiver to handle counting requests.
 pub struct XorBitsChip<const N: usize> {
+    air: XorBitsAir<N>,
     bus_index: usize,
 
     /// List of all requests sent to the chip
@@ -17,6 +27,7 @@ pub struct XorBitsChip<const N: usize> {
 impl<const N: usize> XorBitsChip<N> {
     pub fn new(bus_index: usize, pairs: Vec<(u32, u32)>) -> Self {
         Self {
+            air: XorBitsAir,
             bus_index,
             pairs: Mutex::new(pairs),
         }

--- a/chips/src/xor_limbs/air.rs
+++ b/chips/src/xor_limbs/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
 
@@ -13,16 +13,11 @@ impl<F: Field, const N: usize, const M: usize> BaseAir<F> for XorLimbsChip<N, M>
     }
 }
 
-impl<AB: AirBuilderWithPublicValues, const N: usize, const M: usize> Air<AB> for XorLimbsChip<N, M>
-where
-    AB: AirBuilder,
-    AB::Var: Clone,
-{
+impl<AB: AirBuilder, const N: usize, const M: usize> Air<AB> for XorLimbsChip<N, M> {
     fn eval(&self, builder: &mut AB) {
         let num_limbs = (N + M - 1) / M;
 
         let main = builder.main();
-        let _pis = builder.public_values();
 
         let (local, _next) = (main.row_slice(0), main.row_slice(1));
         let local: &[AB::Var] = (*local).borrow();


### PR DESCRIPTION
to reduce confusion:
- subair struct is all that's necessary to define constraints
- chip struct has additional stuff for handling requests