### PR TITLE
chore: switch `IsZeroChip` to `AB::Expr` for re-usability

### DIFF
--- a/chips/src/is_equal/air.rs
+++ b/chips/src/is_equal/air.rs
@@ -2,10 +2,11 @@ use std::borrow::Borrow;
 
 use super::columns::{IsEqualAuxCols, IsEqualCols, IsEqualIOCols, NUM_COLS};
 use super::IsEqualChip;
+use crate::is_zero::columns::IsZeroIOCols;
+use crate::is_zero::IsZeroChip;
 use crate::sub_chip::{AirConfig, SubAir};
 use afs_stark_backend::interaction::Chip;
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::AbstractField;
 use p3_field::Field;
 use p3_matrix::Matrix;
 
@@ -40,7 +41,10 @@ impl<AB: AirBuilder> SubAir<AB> for IsEqualChip {
     type AuxView = IsEqualAuxCols<AB::Var>;
 
     fn eval(&self, builder: &mut AB, io: Self::IoView, aux: Self::AuxView) {
-        builder.assert_eq((io.x - io.y) * aux.inv + io.is_equal, AB::F::one());
-        builder.assert_eq((io.x - io.y) * io.is_equal, AB::F::zero());
+        let is_zero_io = IsZeroIOCols {
+            x: io.x - io.y,
+            is_zero: io.is_equal.into(),
+        };
+        SubAir::eval(&IsZeroChip, builder, is_zero_io, aux.inv.into());
     }
 }

--- a/chips/src/is_zero/air.rs
+++ b/chips/src/is_zero/air.rs
@@ -32,17 +32,21 @@ impl<AB: AirBuilder> Air<AB> for IsZeroChip {
 
         let local = main.row_slice(0);
         let is_zero_cols: &IsZeroCols<_> = (*local).borrow();
+        let io = IsZeroIOCols {
+            x: is_zero_cols.io.x.into(),
+            is_zero: is_zero_cols.io.is_zero.into(),
+        };
 
-        SubAir::<AB>::eval(self, builder, is_zero_cols.io, is_zero_cols.inv);
+        SubAir::eval(self, builder, io, is_zero_cols.inv.into());
     }
 }
 
 impl<AB: AirBuilder> SubAir<AB> for IsZeroChip {
-    type IoView = IsZeroIOCols<AB::Var>;
-    type AuxView = AB::Var;
+    type IoView = IsZeroIOCols<AB::Expr>;
+    type AuxView = AB::Expr;
 
     fn eval(&self, builder: &mut AB, io: Self::IoView, inv: Self::AuxView) {
-        builder.assert_eq(io.x * io.is_zero, AB::F::zero());
+        builder.assert_eq(io.x.clone() * io.is_zero.clone(), AB::F::zero());
         builder.assert_eq(io.is_zero + io.x * inv, AB::F::one());
     }
 }

--- a/chips/src/is_zero/columns.rs
+++ b/chips/src/is_zero/columns.rs
@@ -10,20 +10,23 @@ pub struct IsZeroCols<T> {
 }
 
 #[derive(Copy, Clone)]
-pub struct IsZeroIOCols<F> {
-    pub x: F,
-    pub is_zero: F,
+pub struct IsZeroIOCols<T> {
+    pub x: T,
+    pub is_zero: T,
 }
 
-impl<F: Clone> IsZeroCols<F> {
-    pub const fn new(x: F, is_zero: F, inv: F) -> IsZeroCols<F> {
+impl<T> IsZeroCols<T> {
+    pub const fn new(x: T, is_zero: T, inv: T) -> IsZeroCols<T> {
         IsZeroCols {
             io: IsZeroIOCols { x, is_zero },
             inv,
         }
     }
 
-    pub fn flatten(&self) -> Vec<F> {
+    pub fn flatten(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
         vec![self.io.x.clone(), self.io.is_zero.clone(), self.inv.clone()]
     }
 

--- a/chips/src/is_zero/mod.rs
+++ b/chips/src/is_zero/mod.rs
@@ -9,7 +9,7 @@ use p3_field::Field;
 
 #[derive(Default)]
 /// A chip that checks if a number equals 0
-pub struct IsZeroChip {}
+pub struct IsZeroChip;
 
 impl IsZeroChip {
     pub fn request<F: Field>(x: F) -> bool {


### PR DESCRIPTION
Demonstrate how to make a SubAir allow taking in arithmetic expressions for re-usability.
The result is ugly enough that I think it's also ok to disregard this PR and keep things as is.

An annoyance is that `AB::Expr` does not implement `Copy`, only `Clone` so there are more clones necessary.