### PR TITLE
chore: auto-implement `Rap` when builder is not `Sync`

### DIFF
--- a/stark-backend/src/interaction/rap.rs
+++ b/stark-backend/src/interaction/rap.rs
@@ -18,7 +18,7 @@ use super::{utils::generate_rlc_elements, AirBridge, InteractiveAir};
 impl<AB, A> Rap<AB> for A
 where
     A: InteractiveAir<AB>,
-    AB: PairBuilder + PermutationAirBuilderWithExposedValues + PartitionedAirBuilder + Sync,
+    AB: PairBuilder + PermutationAirBuilderWithExposedValues + PartitionedAirBuilder,
 {
     fn eval(&self, builder: &mut AB) {
         // Constraits for the main trace:

--- a/stark-backend/src/rap.rs
+++ b/stark-backend/src/rap.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// Does not inherit [Air](p3_air::Air) trait to allow overrides for technical reasons
 /// around dynamic dispatch.
-pub trait Rap<AB>
+pub trait Rap<AB>: Sync
 where
     AB: PairBuilder + PermutationAirBuilder,
 {


### PR DESCRIPTION
Unnecessary `Sync` requirement on `AirBuilder` in auto implementation of `Rap`