### PR TITLE
chore: ec2 on demand runner for benchmarking

### DIFF
--- a/.github/workflows/ec2-on-demand.yml
+++ b/.github/workflows/ec2-on-demand.yml
@@ -3,9 +3,9 @@ name: Sample workflow to use EC2 instances on demand
 on:
   workflow_dispatch:
 
-  push:
-    branches:
-      - jpw/sample-workflow-ec2-on-demand
+  # push:
+  #   branches:
+  #     - jpw/sample-workflow-ec2-on-demand
 
 jobs:
   start-runner:


### PR DESCRIPTION
Workflow to spin up an ec2 instance of a specified type (changing disk size is not tested but hopefully can be done through AMI changes) and run anything as a normal github workflow.

The temp runners have write access to a s3 bucket `axiom-workflow-data-staging-us-east-1` which can be accessed using `s5cmd`.

Example workflow here that does benchmarks: https://github.com/axiom-crypto/afs-prototype/actions/runs/10024892727/job/27707488071