### PR TITLE
feat: improved debugging for interactions (logup)

### DIFF
--- a/stark-backend/src/interaction/debug.rs
+++ b/stark-backend/src/interaction/debug.rs
@@ -1,0 +1,66 @@
+use std::collections::{BTreeMap, HashMap};
+
+use itertools::Itertools;
+use p3_field::Field;
+use p3_matrix::{dense::RowMajorMatrixView, Matrix};
+
+use super::{AirBridge, InteractionType};
+
+/// The actual interactions that are sent/received during a single run
+/// of trace generation. For debugging purposes only.
+#[derive(Default, Clone, Debug)]
+pub struct LogicalInteractions<F: Field> {
+    /// Bus index => (fields => (air_idx, interaction_type, count))
+    #[allow(clippy::type_complexity)]
+    pub at_bus: BTreeMap<usize, HashMap<Vec<F>, Vec<(usize, InteractionType, F)>>>,
+}
+
+pub fn generate_logical_interactions<F, A>(
+    air_idx: usize,
+    air: &A,
+    preprocessed: &Option<RowMajorMatrixView<F>>,
+    partitioned_main: &[RowMajorMatrixView<F>],
+    logical_interactions: &mut LogicalInteractions<F>,
+) where
+    F: Field,
+    A: AirBridge<F> + ?Sized,
+{
+    let all_interactions = air.all_interactions();
+    if all_interactions.is_empty() {
+        return;
+    }
+
+    let height = partitioned_main[0].height();
+
+    for n in 0..height {
+        let preprocessed_row = preprocessed
+            .as_ref()
+            .map(|preprocessed| {
+                // manual implementation of row_slice because of a drop issue
+                &preprocessed.values[n * preprocessed.width..(n + 1) * preprocessed.width]
+            })
+            .unwrap_or(&[]);
+        let main_row: Vec<F> = partitioned_main
+            .iter()
+            .flat_map(|main_part| main_part.row_slice(n).to_vec())
+            .collect();
+        for (interaction, interaction_type) in &all_interactions {
+            let fields = interaction
+                .fields
+                .iter()
+                .map(|columns| columns.apply::<F, F>(preprocessed_row, &main_row))
+                .collect_vec();
+            let count = interaction.count.apply::<F, F>(preprocessed_row, &main_row);
+            if count.is_zero() {
+                continue;
+            }
+            logical_interactions
+                .at_bus
+                .entry(interaction.argument_index)
+                .or_default()
+                .entry(fields)
+                .or_default()
+                .push((air_idx, *interaction_type, count));
+        }
+    }
+}

--- a/stark-backend/src/interaction/mod.rs
+++ b/stark-backend/src/interaction/mod.rs
@@ -4,6 +4,8 @@ use p3_air::{Air, AirBuilder, PermutationAirBuilder, VirtualPairCol};
 use p3_field::Field;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 
+/// Interaction debugging tools
+pub mod debug;
 pub mod rap;
 pub mod trace;
 mod utils;

--- a/stark-backend/src/prover/mod.rs
+++ b/stark-backend/src/prover/mod.rs
@@ -10,7 +10,7 @@ use p3_uni_stark::{Domain, StarkGenericConfig, Val};
 use tracing::instrument;
 
 use crate::{
-    air_builders::debug::check_constraints::{check_constraints, check_cumulative_sums},
+    air_builders::debug::check_constraints::{check_constraints, check_logup},
     commit::CommittedSingleMatrixView,
     config::{Com, PcsProof, PcsProverData},
     keygen::types::MultiStarkPartialProvingKey,
@@ -183,7 +183,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkProver<'c, SC> {
                     partitioned_main.push(partitioned_main_trace.as_slice());
                     permutation.push(perm_trace);
                 }
-                check_cumulative_sums(&raps, &preprocessed, &partitioned_main, &permutation);
+                check_logup(&raps, &preprocessed, &partitioned_main);
             }
         });
 


### PR DESCRIPTION
Now it will tell you which bus it failed on, and the exact `fields` that failed to balance, together with which AIR indices were involved.

I tested by turning debug constraints on for a negative test, and it prints out the info.