### PR TITLE
chore: store `PcsProverData` as `Arc`

### DIFF
--- a/stark-backend/Cargo.toml
+++ b/stark-backend/Cargo.toml
@@ -19,13 +19,14 @@ itertools = "0.13.0"
 serde = { version = "1.0", default-features = false, features = [
     "derive",
     "alloc",
+    "rc",
 ] }
 tracing = "0.1.37"
 derivative = "2.2.0"
 
 [dev-dependencies]
 afs-derive = { path = "../derive" }
-afs-test-utils = { path = "../test-utils"}
+afs-test-utils = { path = "../test-utils" }
 
 p3-dft = { workspace = true }
 p3-merkle-tree = { workspace = true }

--- a/stark-backend/src/keygen/types.rs
+++ b/stark-backend/src/keygen/types.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use derivative::Derivative;
 use itertools::Itertools;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
@@ -62,7 +64,7 @@ pub struct StarkPartialVerifyingKey<SC: StarkGenericConfig> {
 
 /// Prover only data for preprocessed trace for a single AIR.
 /// Currently assumes each AIR has it's own preprocessed commitment
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "PcsProverData<SC>: Serialize",
     deserialize = "PcsProverData<SC>: Deserialize<'de>"
@@ -71,7 +73,7 @@ pub struct ProverOnlySinglePreprocessedData<SC: StarkGenericConfig> {
     /// Preprocessed trace matrix.
     pub trace: RowMajorMatrix<Val<SC>>,
     /// Prover data, such as a Merkle tree, for the trace commitment.
-    pub data: PcsProverData<SC>,
+    pub data: Arc<PcsProverData<SC>>,
 }
 
 /// Verifier data for preprocessed trace for a single AIR.

--- a/stark-backend/src/prover/mod.rs
+++ b/stark-backend/src/prover/mod.rs
@@ -224,7 +224,7 @@ impl<'c, SC: StarkGenericConfig> MultiTraceStarkProver<'c, SC> {
                 let domain = main.domain;
                 let preprocessed = pk.preprocessed_data.as_ref().map(|p| {
                     // TODO: currently assuming each chip has it's own preprocessed commitment
-                    CommittedSingleMatrixView::new(&p.data, 0)
+                    CommittedSingleMatrixView::new(p.data.as_ref(), 0)
                 });
                 let matrix_ptrs = &pk.vk.main_graph.matrix_ptrs;
                 assert_eq!(main.partitioned_main_trace.len(), matrix_ptrs.len());


### PR DESCRIPTION
To avoid cloning since `PcsProverData` does not derive clone.