### PR TITLE
feat: HashProvider implemented on Poseidon2Chip

### DIFF
--- a/vm/src/poseidon2/air.rs
+++ b/vm/src/poseidon2/air.rs
@@ -39,8 +39,11 @@ impl<AB: AirBuilder, const WIDTH: usize> Air<AB> for Poseidon2Chip<WIDTH, AB::F>
         // boolean constraints for alloc/cmp markers
         builder.assert_bool(cols.io.is_alloc);
         builder.assert_bool(cols.io.cmp);
-        // can only be comparing if row is allocated
+        builder.assert_bool(cols.aux.is_opcode);
+        // can only be compressing if row is allocated
         builder.assert_eq(cols.io.is_alloc * cols.io.cmp, cols.io.cmp);
+        // can only be opcode if row is allocated
+        builder.assert_eq(cols.io.is_alloc * cols.aux.is_opcode, cols.aux.is_opcode);
         // immediates
         for (i, operand) in [cols.io.a, cols.io.b, cols.io.c].into_iter().enumerate() {
             builder

--- a/vm/src/poseidon2/columns.rs
+++ b/vm/src/poseidon2/columns.rs
@@ -37,6 +37,7 @@ pub struct Poseidon2ChipAuxCols<const WIDTH: usize, T> {
     pub addresses: [T; 3],
     pub d_is_zero: T,
     pub is_zero_inv: T,
+    pub is_opcode: T,
     pub internal: Poseidon2Cols<WIDTH, T>,
 }
 
@@ -123,13 +124,14 @@ impl<T: Field> Poseidon2ChipIoCols<T> {
 
 impl<const WIDTH: usize, T: Clone> Poseidon2ChipAuxCols<WIDTH, T> {
     pub fn get_width(air: &Poseidon2Air<WIDTH, T>) -> usize {
-        3 + 2 + Poseidon2Cols::<WIDTH, T>::get_width(air)
+        4 + 2 + Poseidon2Cols::<WIDTH, T>::get_width(air)
     }
 
     pub fn flatten(&self) -> Vec<T> {
         let mut result = self.addresses.to_vec();
         result.push(self.d_is_zero.clone());
         result.push(self.is_zero_inv.clone());
+        result.push(self.is_opcode.clone());
         result.extend(self.internal.flatten());
         result
     }
@@ -139,6 +141,7 @@ impl<const WIDTH: usize, T: Clone> Poseidon2ChipAuxCols<WIDTH, T> {
             addresses: from_fn(|i| slice[i].clone()),
             d_is_zero: slice[3].clone(),
             is_zero_inv: slice[4].clone(),
+            is_opcode: slice[5].clone(),
             internal: Poseidon2Cols::from_slice(&slice[5..], index_map),
         }
     }
@@ -149,6 +152,7 @@ impl<const WIDTH: usize, T: Field> Poseidon2ChipAuxCols<WIDTH, T> {
             addresses: [T::zero(); 3],
             d_is_zero: T::zero(),
             is_zero_inv: T::one(),
+            is_opcode: T::zero(),
             internal: Poseidon2Cols::blank_row(air),
         }
     }


### PR DESCRIPTION
* HashProvider::hash() for Poseidon2Chip
* new `is_opcode` column
* Operates as receiving multiplicity for opcode requests and `is_alloc - is_opcode` receiving multiplicity for ExpandChip requests, as per [this ticket](https://linear.app/intrinsictech/issue/INT-1781/make-poseidon2-chip-support-direct-requests)