### PR TITLE
fix: benchmarks should use range bits = 16

### DIFF
--- a/bin/afs/src/commands/keygen/mod.rs
+++ b/bin/afs/src/commands/keygen/mod.rs
@@ -13,6 +13,8 @@ use p3_uni_stark::{StarkGenericConfig, Val};
 use serde::Serialize;
 use tracing::info;
 
+use crate::RANGE_CHECK_BITS;
+
 /// `afs keygen` command
 /// Uses information from config.toml to generate partial proving and verifying keys and
 /// saves them to the specified `output-folder` as *.partial.pk and *.partial.vk.
@@ -72,7 +74,7 @@ where
 
         let idx_limb_bits = limb_bits;
 
-        let idx_decomp = 8;
+        let idx_decomp = RANGE_CHECK_BITS;
 
         let page_controller: PageController<SC> = PageController::new(
             page_bus_index,

--- a/bin/afs/src/commands/prove/mod.rs
+++ b/bin/afs/src/commands/prove/mod.rs
@@ -31,6 +31,8 @@ use p3_uni_stark::{Domain, StarkGenericConfig, Val};
 use serde::de::DeserializeOwned;
 use tracing::info_span;
 
+use crate::RANGE_CHECK_BITS;
+
 /// `afs prove` command
 /// Uses information from config.toml to generate a proof of the changes made by a .afi file to a table
 /// saves the proof in `output-folder` as */prove.bin.
@@ -171,7 +173,7 @@ where
 
         let checker_trace_degree = config.page.max_rw_ops * 4;
         let idx_limb_bits = config.page.bits_per_fe;
-        let idx_decomp = 8;
+        let idx_decomp = RANGE_CHECK_BITS;
 
         let mut page_controller: PageController<SC> = PageController::new(
             page_bus_index,

--- a/bin/afs/src/commands/verify/mod.rs
+++ b/bin/afs/src/commands/verify/mod.rs
@@ -17,6 +17,8 @@ use color_eyre::eyre::Result;
 use p3_field::PrimeField64;
 use p3_uni_stark::{StarkGenericConfig, Val};
 
+use crate::RANGE_CHECK_BITS;
+
 /// `afs verify` command
 /// Uses information from config.toml to verify a proof using the verifying key in `output-folder`
 /// as */prove.bin.
@@ -101,7 +103,7 @@ where
         let ops_bus_index = 2;
 
         let idx_limb_bits = config.page.bits_per_fe;
-        let idx_decomp = 8;
+        let idx_decomp = RANGE_CHECK_BITS;
         println!("Verifying proof file: {}", proof_file);
 
         let encoded_vk =

--- a/bin/afs/src/lib.rs
+++ b/bin/afs/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod cli;
 pub mod commands;
+
+const RANGE_CHECK_BITS: usize = 16;

--- a/bin/olap/src/lib.rs
+++ b/bin/olap/src/lib.rs
@@ -2,5 +2,7 @@ pub mod cli;
 pub mod commands;
 pub mod operations;
 
+pub const RANGE_CHECK_BITS: usize = 16;
+
 pub const KEYS_FOLDER: &str = "bin/olap/tmp/keys";
 pub const CACHE_FOLDER: &str = "bin/olap/tmp/cache";

--- a/bin/olap/src/operations/filter.rs
+++ b/bin/olap/src/operations/filter.rs
@@ -3,7 +3,8 @@ use std::time::Instant;
 use afs_chips::single_page_index_scan::page_index_scan_input::Comp;
 use afs_test_utils::page_config::PageConfig;
 use logical_interface::afs_input::{operation::FilterOp, types::AfsOperation};
-use p3_util::log2_strict_usize;
+
+use crate::RANGE_CHECK_BITS;
 
 pub const PAGE_BUS_INDEX: usize = 0;
 pub const RANGE_BUS_INDEX: usize = 1;
@@ -29,7 +30,7 @@ pub fn filter_setup(
     let page_width = 1 + idx_len + data_len;
     let page_height = config.page.height;
     let idx_limb_bits = config.page.bits_per_fe;
-    let idx_decomp = log2_strict_usize(page_height);
+    let idx_decomp = RANGE_CHECK_BITS;
     let range_max = 1 << idx_decomp;
     (
         start,

--- a/bin/olap/src/operations/inner_join.rs
+++ b/bin/olap/src/operations/inner_join.rs
@@ -9,7 +9,7 @@ use logical_interface::{
     mock_db::MockDb,
 };
 
-use crate::commands::CommonCommands;
+use crate::{commands::CommonCommands, RANGE_CHECK_BITS};
 
 const RANGE_BUS: usize = 0;
 const T1_INTERSECTOR_BUS: usize = 1;
@@ -49,7 +49,7 @@ pub fn inner_join_setup(
     let mut db = MockDb::from_file(&common.db_path);
     let height = config.page.height;
     let bits_per_fe = config.page.bits_per_fe;
-    let range_chip_idx_decomp = 4;
+    let range_chip_idx_decomp = RANGE_CHECK_BITS;
 
     let inner_join_op = InnerJoinOp::parse(op.args).unwrap();
 


### PR DESCRIPTION
Previously was using range bits `decomp = 8`. This leads to more permutation columns for interactions.