### PR TITLE
chore: make "parallel" into optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,7 @@ p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" 
 p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
 p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
 p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa", features = [
-    "parallel",
-] }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
 p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -7,13 +7,13 @@ edition.workspace = true
 [dependencies]
 cli-table = "0.4.9"
 csv = "1.3.0"
-afs = { path = "../bin/afs" }
-olap = { path = "../bin/olap" }
-afs-stark-backend = { path = "../stark-backend" }
+afs = { path = "../bin/afs", default-features = false }
+olap = { path = "../bin/olap", default-features = false }
+afs-stark-backend = { path = "../stark-backend", default-features = false }
 logical-interface = { path = "../logical-interface" }
 afs-derive = { path = "../derive" }
 afs-test-utils = { path = "../test-utils" }
-afs-chips = { path = "../chips" }
+afs-chips = { path = "../chips", default-features = false }
 serde = { version = "1.0.203", features = ["derive"] }
 clap = { version = "4.5.4", features = ["derive"] }
 color-eyre = "0.6.3"
@@ -32,3 +32,7 @@ chrono = "0.4.38"
 itertools = "0.13.0"
 tracing-appender = "0.2.3"
 regex = "1.10.5"
+
+[features]
+default = ["parallel"]
+parallel = ["afs/parallel", "olap/parallel"]

--- a/bin/afs/Cargo.toml
+++ b/bin/afs/Cargo.toml
@@ -17,10 +17,10 @@ tokio = { version = "1.38.0", features = ["rt", "macros"] }
 toml = "0.8.14"
 p3-baby-bear = { workspace = true }
 p3-util = { workspace = true }
-afs-stark-backend = { path = "../../stark-backend" }
+afs-stark-backend = { path = "../../stark-backend", default-features = false }
 afs-derive = { path = "../../derive" }
 afs-test-utils = { path = "../../test-utils" }
-afs-chips = { path = "../../chips" }
+afs-chips = { path = "../../chips", default-features = false }
 bin-common = { path = "../common" }
 p3-uni-stark = { workspace = true }
 p3-field = { workspace = true }
@@ -30,3 +30,7 @@ p3-keccak = { workspace = true }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
+
+[features]
+default = ["parallel"]
+parallel = ["afs-chips/parallel"]

--- a/bin/olap/Cargo.toml
+++ b/bin/olap/Cargo.toml
@@ -10,9 +10,9 @@ bincode = "1.3.3"
 clap = { version = "4.5.4", features = ["derive"] }
 color-eyre = "0.6.3"
 serde = { version = "1.0.203", features = ["derive"] }
-afs-chips = { path = "../../chips" }
+afs-chips = { path = "../../chips", default-features = false }
 afs-test-utils = { path = "../../test-utils" }
-afs-stark-backend = { path = "../../stark-backend" }
+afs-stark-backend = { path = "../../stark-backend", default-features = false }
 afs-derive = { path = "../../derive" }
 bin-common = { path = "../common" }
 logical-interface = { path = "../../logical-interface" }
@@ -23,3 +23,7 @@ p3-field = { workspace = true }
 p3-blake3 = { workspace = true }
 p3-keccak = { workspace = true }
 tracing = "0.1.40"
+
+[features]
+default = ["parallel"]
+parallel = ["afs-chips/parallel"]

--- a/chips/Cargo.toml
+++ b/chips/Cargo.toml
@@ -20,7 +20,7 @@ p3-uni-stark = { workspace = true }
 rand = "0.8"
 derive-new = "0.5"
 
-afs-stark-backend = { path = "../stark-backend" }
+afs-stark-backend = { path = "../stark-backend", default-features = false }
 afs-derive = { path = "../derive" }
 afs-test-utils = { path = "../test-utils" }
 parking_lot = "0.12.2"
@@ -49,5 +49,6 @@ tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 test-case = "3.3.1"
 
 [features]
-default = ["test-traits"]
-test-traits = ["p3-baby-bear"]
+default = ["parallel"]
+test-traits = ["p3-baby-bear"]            # traits for testing
+parallel = ["afs-stark-backend/parallel"]

--- a/chips/src/merkle_proof/mod.rs
+++ b/chips/src/merkle_proof/mod.rs
@@ -4,6 +4,9 @@ pub mod columns;
 mod round_flags;
 mod trace;
 
+#[cfg(test)]
+pub mod tests;
+
 #[derive(Clone)]
 pub struct MerkleProofOp<T, const DEPTH: usize, const DIGEST_WIDTH: usize>
 where

--- a/chips/src/merkle_proof/tests.rs
+++ b/chips/src/merkle_proof/tests.rs
@@ -3,7 +3,7 @@ use afs_test_utils::config::baby_bear_poseidon2::run_simple_test_no_pis;
 use p3_keccak::KeccakF;
 use p3_symmetric::{PseudoCompressionFunction, TruncatedPermutation};
 
-use afs_chips::{
+use crate::{
     keccak_permute::KeccakPermuteAir,
     merkle_proof::{MerkleProofAir, MerkleProofOp},
 };
@@ -29,7 +29,7 @@ fn generate_digests(leaf_hashes: Vec<[u8; 32]>) -> Vec<Vec<[u8; 32]>> {
 }
 
 #[test]
-#[ignore = "integration test takes too long"]
+#[ignore = "proving takes too long"]
 fn test_merkle_proof_prove() {
     const DEPTH: usize = 8;
 

--- a/chips/src/utils.rs
+++ b/chips/src/utils.rs
@@ -1,24 +1,21 @@
 use p3_air::{AirBuilder, VirtualPairCol};
-use p3_field::Field;
+#[cfg(any(feature = "test-traits", test))]
+use p3_baby_bear::BabyBear;
+use p3_field::{AbstractField, Field};
 
 // TODO: Ideally upstream PrimeField implements From<T>
 pub trait FieldFrom<T> {
     fn from_val(value: T) -> Self;
 }
 
-#[cfg(feature = "test-traits")]
-use p3_baby_bear::BabyBear;
-#[cfg(feature = "test-traits")]
-use p3_field::AbstractField;
-
-#[cfg(feature = "test-traits")]
+#[cfg(any(feature = "test-traits", test))]
 impl FieldFrom<u8> for BabyBear {
     fn from_val(value: u8) -> Self {
         BabyBear::from_canonical_u8(value)
     }
 }
 
-#[cfg(feature = "test-traits")]
+#[cfg(any(feature = "test-traits", test))]
 impl FieldFrom<BabyBear> for BabyBear {
     fn from_val(value: BabyBear) -> Self {
         value

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 p3-air = { workspace = true }
-p3-baby-bear = { workspace = true, optional = true }
+p3-baby-bear = { workspace = true }
 p3-commit = { workspace = true }
 p3-field = { workspace = true }
 p3-keccak = { workspace = true }
@@ -21,7 +21,7 @@ zkhash = { workspace = true }
 rand = "0.8"
 
 afs-chips = { path = "../chips" }
-afs-stark-backend = { path = "../stark-backend" }
+afs-stark-backend = { path = "../stark-backend", default-features = false }
 afs-derive = { path = "../derive" }
 afs-test-utils = { path = "../test-utils" }
 parking_lot = "0.12.2"
@@ -54,5 +54,5 @@ rand_xoshiro = "0.6.0"
 ark-ff = { version = "^0.4.0", default-features = false }
 
 [features]
-default = ["test-traits"]
-test-traits = ["p3-baby-bear"]
+default = ["parallel"]
+parallel = ["afs-stark-backend/parallel"]

--- a/stark-backend/Cargo.toml
+++ b/stark-backend/Cargo.toml
@@ -46,4 +46,5 @@ csv = "1.3.0"
 eyre = "0.6.12"
 
 [features]
-default = []
+default = ["parallel"]
+parallel = ["p3-maybe-rayon/parallel"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -3,11 +3,11 @@ name = "stark-vm"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Aggregation VM STARK"
+description = "Virtual Machine STARK"
 
 [dependencies]
 p3-air = { workspace = true }
-p3-baby-bear = { workspace = true, optional = true }
+p3-baby-bear = { workspace = true }
 p3-commit = { workspace = true }
 p3-field = { workspace = true }
 p3-keccak = { workspace = true }
@@ -18,12 +18,10 @@ p3-symmetric = { workspace = true }
 p3-poseidon2 = { workspace = true }
 p3-util = { workspace = true }
 p3-uni-stark = { workspace = true }
-rand = "0.8"
-poseidon2-air = { path = "../poseidon2-air" }
-rayon = "1.8"
 
-afs-chips = { path = "../chips" }
-afs-stark-backend = { path = "../stark-backend" }
+poseidon2-air = { path = "../poseidon2-air", default-features = false }
+afs-chips = { path = "../chips", default-features = false }
+afs-stark-backend = { path = "../stark-backend", default-features = false }
 afs-derive = { path = "../derive" }
 afs-test-utils = { path = "../test-utils" }
 parking_lot = "0.12.2"
@@ -32,6 +30,7 @@ itertools = "0.13.0"
 getset = "0.1.2"
 derive-new = "0.5.1"
 
+rand = "0.8"
 serde = "1.0.203"
 serde_derive = "1.0.203"
 toml = "0.8.14"
@@ -56,5 +55,5 @@ rand_xoshiro = "0.6.0"
 ark-ff = { version = "^0.4.0", default-features = false }
 
 [features]
-default = ["test-traits"]
-test-traits = ["p3-baby-bear"]
+default = ["parallel"]
+parallel = ["afs-stark-backend/parallel"]

--- a/vm/src/memory/offline_checker/trace.rs
+++ b/vm/src/memory/offline_checker/trace.rs
@@ -12,7 +12,7 @@ use afs_chips::is_equal_vec::IsEqualVecAir;
 use afs_chips::is_less_than_tuple::IsLessThanTupleAir;
 use afs_chips::range_gate::RangeCheckerGateChip;
 use afs_chips::sub_chip::LocalTraceInstructions;
-use rayon::prelude::*;
+use p3_maybe_rayon::prelude::*;
 
 impl<const WORD_SIZE: usize, F: PrimeField32> MemoryChip<WORD_SIZE, F> {
     /// Each row in the trace follow the same order as the Cols struct:


### PR DESCRIPTION
For flamegraphs it is useful to be able to run benchmarks in single-threaded mode, so we do not make "parallel" feature always on for `p3-maybe-rayon`. Instead we add it as a feature to all downstream packages and make it default-on.