### PR TITLE
[feat] Builder Static Mode

### DIFF
--- a/compiler/src/ir/builder.rs
+++ b/compiler/src/ir/builder.rs
@@ -103,6 +103,8 @@ pub struct BuilderFlags {
     pub(crate) static_loop: bool,
     /// If true, panic when `builder.break_loop` is called.
     pub(crate) disable_break: bool,
+    /// If true, branching/looping/heap memory is disabled.
+    pub static_only: bool,
 }
 
 /// A builder for the DSL.
@@ -116,8 +118,8 @@ pub struct Builder<C: Config> {
     pub(crate) witness_var_count: u32,
     pub(crate) witness_felt_count: u32,
     pub(crate) witness_ext_count: u32,
-    pub(crate) flags: BuilderFlags,
-    pub(crate) is_sub_builder: bool,
+    pub flags: BuilderFlags,
+    pub is_sub_builder: bool,
 }
 
 impl<C: Config> Builder<C> {
@@ -609,6 +611,10 @@ impl<'a, C: Config> IfBuilder<'a, C> {
             }
             _ => (),
         }
+        assert!(
+            !self.builder.flags.static_only,
+            "Cannot use dynamic branch in static mode"
+        );
 
         // Execute the `then` block and collect the instructions.
         let mut f_builder = Builder::<C>::new_sub_builder(
@@ -683,6 +689,10 @@ impl<'a, C: Config> IfBuilder<'a, C> {
             }
             _ => (),
         }
+        assert!(
+            !self.builder.flags.static_only,
+            "Cannot use dynamic branch in static mode"
+        );
         let mut then_builder = Builder::<C>::new_sub_builder(
             self.builder.stack_ptr,
             self.builder.nb_public_values,
@@ -858,6 +868,10 @@ impl<'a, C: Config> RangeBuilder<'a, C> {
         &mut self,
         mut f: impl FnMut(RVar<C::N>, &mut Builder<C>) -> Result<(), BreakLoop>,
     ) {
+        assert!(
+            !self.builder.flags.static_only,
+            "Cannot use dynamic loop in static mode"
+        );
         let step_size = C::N::from_canonical_usize(self.step_size);
         let loop_variable: Var<C::N> = self.builder.uninit();
         let mut loop_body_builder = Builder::<C>::new_sub_builder(

--- a/compiler/src/ir/collections.rs
+++ b/compiler/src/ir/collections.rs
@@ -133,7 +133,12 @@ impl<C: Config, V: MemVariable<C>> Array<C, V> {
 impl<C: Config> Builder<C> {
     /// Initialize an array of fixed length `len`. The entries will be uninitialized.
     pub fn array<V: MemVariable<C>>(&mut self, len: impl Into<RVar<C::N>>) -> Array<C, V> {
-        self.dyn_array(len)
+        let len = len.into();
+        if self.flags.static_only {
+            self.uninit_fixed_array(len.value())
+        } else {
+            self.dyn_array(len)
+        }
     }
 
     /// Creates an array from a vector.

--- a/compiler/src/ir/poseidon.rs
+++ b/compiler/src/ir/poseidon.rs
@@ -14,9 +14,9 @@ impl<C: Config> Builder<C> {
         let output = match array {
             Array::Fixed(values) => {
                 assert_eq!(values.borrow().len(), PERMUTATION_WIDTH);
-                self.array::<Felt<C::F>>(Usize::from(PERMUTATION_WIDTH))
+                self.dyn_array::<Felt<C::F>>(Usize::from(PERMUTATION_WIDTH))
             }
-            Array::Dyn(_, len) => self.array::<Felt<C::F>>(len.clone()),
+            Array::Dyn(_, len) => self.dyn_array::<Felt<C::F>>(len.clone()),
         };
         self.operations.push(DslIr::Poseidon2PermuteBabyBear(
             output.clone(),

--- a/compiler/src/ir/ptr.rs
+++ b/compiler/src/ir/ptr.rs
@@ -17,6 +17,10 @@ pub struct SymbolicPtr<N: Field> {
 impl<C: Config> Builder<C> {
     /// Allocates an array on the heap.
     pub(crate) fn alloc(&mut self, len: impl Into<RVar<C::N>>, size: usize) -> Ptr<C::N> {
+        assert!(
+            !self.flags.static_only,
+            "Cannot allocate memory in static mode"
+        );
         let ptr = Ptr::uninit(self);
         self.push(DslIr::Alloc(ptr, len.into(), size));
         ptr

--- a/compiler/src/ir/utils.rs
+++ b/compiler/src/ir/utils.rs
@@ -167,11 +167,11 @@ impl<C: Config> Builder<C> {
     /// Multiplies `base` by `2^{log_power}`.
     pub fn sll<V>(&mut self, base: impl Into<V::Expression>, shift: RVar<C::N>) -> V
     where
-        V: Variable<C> + Copy + Add<Output = V::Expression>,
+        V: Variable<C> + Clone + Add<Output = V::Expression>,
     {
         let result: V = self.eval(base);
         self.range(0, shift)
-            .for_each(|_, builder| builder.assign(&result, result + result));
+            .for_each(|_, builder| builder.assign(&result, result.clone() + result.clone()));
         result
     }
 

--- a/compiler/tests/array.rs
+++ b/compiler/tests/array.rs
@@ -189,10 +189,10 @@ fn test_array_eq() {
     type EF = BinomialExtensionField<BabyBear, 4>;
 
     let mut builder = AsmBuilder::<F, EF>::default();
-    let mut arr1: Array<_, Var<_>> = builder.array(2);
+    let mut arr1: Array<_, Var<_>> = builder.dyn_array(2);
     builder.set(&mut arr1, 0, F::one());
     builder.set(&mut arr1, 1, F::two());
-    let mut arr2: Array<_, Var<_>> = builder.array(2);
+    let mut arr2: Array<_, Var<_>> = builder.dyn_array(2);
     builder.set(&mut arr2, 0, F::one());
     builder.set(&mut arr2, 1, F::two());
     builder.assert_var_array_eq(&arr1, &arr2);
@@ -210,10 +210,10 @@ fn test_array_eq_neg() {
     type EF = BinomialExtensionField<BabyBear, 4>;
 
     let mut builder = AsmBuilder::<F, EF>::default();
-    let mut arr1: Array<_, Var<_>> = builder.array(2);
+    let mut arr1: Array<_, Var<_>> = builder.dyn_array(2);
     builder.set(&mut arr1, 0, F::one());
     builder.set(&mut arr1, 1, F::two());
-    let mut arr2: Array<_, Var<_>> = builder.array(2);
+    let mut arr2: Array<_, Var<_>> = builder.dyn_array(2);
     builder.set(&mut arr2, 0, F::one());
     builder.set(&mut arr2, 1, F::one());
     builder.assert_var_array_eq(&arr1, &arr2);

--- a/compiler/tests/for_loops.rs
+++ b/compiler/tests/for_loops.rs
@@ -56,10 +56,10 @@ fn test_compiler_nested_array_loop() {
     let outer_len = 100;
     let inner_len = 10;
 
-    let mut array: Array<C, Array<C, Var<_>>> = builder.array(outer_len);
+    let mut array: Array<C, Array<C, Var<_>>> = builder.dyn_array(outer_len);
 
     builder.range(0, array.len()).for_each(|i, builder| {
-        let mut inner_array = builder.array::<Var<_>>(inner_len);
+        let mut inner_array = builder.dyn_array::<Var<_>>(inner_len);
         builder.range(0, inner_array.len()).for_each(|j, builder| {
             builder.set(&mut inner_array, j, i + j); //(j * F::from_canonical_u16(300)));
         });
@@ -90,7 +90,7 @@ fn test_compiler_break() {
     let len = 100;
     let break_len = 10;
 
-    let mut array: Array<C, Var<_>> = builder.array(len);
+    let mut array: Array<C, Var<_>> = builder.dyn_array(len);
 
     builder
         .range(0, array.len())
@@ -126,7 +126,7 @@ fn test_compiler_break() {
 
     // Test the break instructions in a nested loop.
 
-    let mut array: Array<C, Var<_>> = builder.array(len);
+    let mut array: Array<C, Var<_>> = builder.dyn_array(len);
     builder
         .range(0, array.len())
         .may_break()

--- a/recursion/src/challenger.rs
+++ b/recursion/src/challenger.rs
@@ -1,8 +1,7 @@
 use afs_compiler::{
-    ir::{DIGEST_SIZE, PERMUTATION_WIDTH},
+    ir::{RVar, DIGEST_SIZE, PERMUTATION_WIDTH},
     prelude::{
-        Array, Builder, Config, DslVariable, Ext, Felt, MemIndex, MemVariable, Ptr, Usize, Var,
-        Variable,
+        Array, Builder, Config, DslVariable, Ext, Felt, MemIndex, MemVariable, Ptr, Var, Variable,
     },
 };
 use p3_field::AbstractField;
@@ -29,11 +28,8 @@ pub trait FeltChallenger<C: Config>:
 }
 
 pub trait CanSampleBitsVariable<C: Config> {
-    fn sample_bits(
-        &mut self,
-        builder: &mut Builder<C>,
-        nb_bits: Usize<C::N>,
-    ) -> Array<C, Var<C::N>>;
+    fn sample_bits(&mut self, builder: &mut Builder<C>, nb_bits: RVar<C::N>)
+        -> Array<C, Var<C::N>>;
 }
 
 /// Reference: [p3_challenger::DuplexChallenger]
@@ -204,7 +200,7 @@ impl<C: Config> DuplexChallengerVariable<C> {
     fn sample_bits(
         &mut self,
         builder: &mut Builder<C>,
-        nb_bits: Usize<C::N>,
+        nb_bits: RVar<C::N>,
     ) -> Array<C, Var<C::N>> {
         let rand_f = self.sample(builder);
         let mut bits = builder.num2bits_f(rand_f);
@@ -216,14 +212,9 @@ impl<C: Config> DuplexChallengerVariable<C> {
         bits
     }
 
-    pub fn check_witness(
-        &mut self,
-        builder: &mut Builder<C>,
-        nb_bits: Var<C::N>,
-        witness: Felt<C::F>,
-    ) {
+    pub fn check_witness(&mut self, builder: &mut Builder<C>, nb_bits: usize, witness: Felt<C::F>) {
         self.observe(builder, witness);
-        let element_bits = self.sample_bits(builder, nb_bits.into());
+        let element_bits = self.sample_bits(builder, RVar::from(nb_bits));
         builder.range(0, nb_bits).for_each(|i, builder| {
             let element = builder.get(&element_bits, i);
             builder.assert_var_eq(element, C::N::zero());
@@ -254,7 +245,7 @@ impl<C: Config> CanSampleBitsVariable<C> for DuplexChallengerVariable<C> {
     fn sample_bits(
         &mut self,
         builder: &mut Builder<C>,
-        nb_bits: Usize<C::N>,
+        nb_bits: RVar<C::N>,
     ) -> Array<C, Var<C::N>> {
         DuplexChallengerVariable::sample_bits(self, builder, nb_bits)
     }
@@ -280,7 +271,7 @@ impl<C: Config> FeltChallenger<C> for DuplexChallengerVariable<C> {
 mod tests {
     use afs_compiler::{
         asm::{AsmBuilder, AsmConfig},
-        ir::{Felt, Usize, Var, PERMUTATION_WIDTH},
+        ir::Felt,
         util::execute_program_and_generate_traces,
     };
     use afs_test_utils::{
@@ -310,7 +301,6 @@ mod tests {
 
         let mut builder = AsmBuilder::<F, EF>::default();
 
-        let width: Var<_> = builder.eval(F::from_canonical_usize(PERMUTATION_WIDTH));
         let mut challenger = DuplexChallengerVariable::<AsmConfig<F, EF>>::new(&mut builder);
         let one: Felt<_> = builder.eval(F::one());
         let two: Felt<_> = builder.eval(F::two());

--- a/recursion/src/fri/domain.rs
+++ b/recursion/src/fri/domain.rs
@@ -6,17 +6,17 @@ use super::types::FriConfigVariable;
 use crate::commit::PolynomialSpaceVariable;
 
 /// Reference: [p3_commit::TwoAdicMultiplicativeCoset]
-#[derive(DslVariable, Clone, Copy)]
+#[derive(DslVariable, Clone)]
 pub struct TwoAdicMultiplicativeCosetVariable<C: Config> {
-    pub log_n: Var<C::N>,
-    pub size: Var<C::N>,
+    pub log_n: Usize<C::N>,
+    pub size: Usize<C::N>,
     pub shift: Felt<C::F>,
     pub g: Felt<C::F>,
 }
 
 impl<C: Config> TwoAdicMultiplicativeCosetVariable<C> {
-    pub fn size(&self) -> Var<C::N> {
-        self.size
+    pub fn size(&self) -> RVar<C::N> {
+        self.size.clone().into()
     }
 
     pub fn first_point(&self) -> Felt<C::F> {
@@ -35,11 +35,11 @@ where
     type Constant = TwoAdicMultiplicativeCoset<C::F>;
 
     fn constant(value: Self::Constant, builder: &mut Builder<C>) -> Self {
-        let log_d_val = value.log_n as u32;
         let g_val = C::F::two_adic_generator(value.log_n);
         TwoAdicMultiplicativeCosetVariable::<C> {
-            log_n: builder.eval::<Var<_>, _>(C::N::from_canonical_u32(log_d_val)),
-            size: builder.eval::<Var<_>, _>(C::N::from_canonical_u32(1 << (log_d_val))),
+            // builder.eval is necessary to assign a variable in the dynamic mode.
+            log_n: builder.eval(RVar::from(value.log_n)),
+            size: builder.eval(RVar::from(1 << value.log_n)),
             shift: builder.eval(value.shift),
             g: builder.eval(g_val),
         }
@@ -66,8 +66,7 @@ where
         point: Ext<<C as Config>::F, <C as Config>::EF>,
     ) -> LagrangeSelectors<Ext<<C as Config>::F, <C as Config>::EF>> {
         let unshifted_point: Ext<_, _> = builder.eval(point * self.shift.inverse());
-        let z_h_expr = builder
-            .exp_power_of_2_v::<Ext<_, _>>(unshifted_point, Usize::Var(self.log_n))
+        let z_h_expr = builder.exp_power_of_2_v::<Ext<_, _>>(unshifted_point, self.log_n.clone())
             - C::EF::one();
         let z_h: Ext<_, _> = builder.eval(z_h_expr);
 
@@ -84,8 +83,8 @@ where
         builder: &mut Builder<C>,
         point: Ext<<C as Config>::F, <C as Config>::EF>,
     ) -> Ext<<C as Config>::F, <C as Config>::EF> {
-        let unshifted_power = builder
-            .exp_power_of_2_v::<Ext<_, _>>(point * self.shift.inverse(), Usize::Var(self.log_n));
+        let unshifted_power =
+            builder.exp_power_of_2_v::<Ext<_, _>>(point * self.shift.inverse(), self.log_n.clone());
         builder.eval(unshifted_power - C::EF::one())
     }
 
@@ -97,24 +96,27 @@ where
     ) -> Array<C, Self> {
         let log_num_chunks = log_num_chunks.into();
         let num_chunks = num_chunks.into();
-        let log_n: Var<_> = builder.eval(self.log_n - log_num_chunks);
-        let size = builder.sll(C::N::one(), RVar::Val(log_n));
+        let log_n = builder.eval_expr(self.log_n.clone() - log_num_chunks);
+        let size: Usize<_> = builder.sll(RVar::one(), log_n);
 
         let g_dom = self.gen();
         let g = builder.exp_power_of_2_v::<Felt<C::F>>(g_dom, log_num_chunks);
 
         let domain_power: Felt<_> = builder.eval(C::F::one());
 
-        let mut domains = builder.dyn_array(num_chunks);
+        let mut domains = builder.array(num_chunks);
 
         builder.range(0, num_chunks).for_each(|i, builder| {
+            let log_n = builder.eval(log_n);
             let domain = TwoAdicMultiplicativeCosetVariable {
                 log_n,
-                size,
+                size: size.clone(),
                 shift: builder.eval(self.shift * domain_power),
                 g,
             };
-            builder.set(&mut domains, i, domain);
+            // FIXME: here must use `builder.set_value`. `builder.set` will convert `Usize::Const`
+            // to `Usize::Var` because it calls `builder.eval`.
+            builder.set_value(&mut domains, i, domain);
             builder.assign(&domain_power, domain_power * g_dom);
         });
 
@@ -123,8 +125,9 @@ where
 
     fn split_domains_const(&self, builder: &mut Builder<C>, log_num_chunks: usize) -> Vec<Self> {
         let num_chunks = 1 << log_num_chunks;
-        let log_n: Var<_> = builder.eval(self.log_n - C::N::from_canonical_usize(log_num_chunks));
-        let size = builder.sll(C::N::one(), RVar::Val(log_n));
+        let log_n: Usize<_> =
+            builder.eval(self.log_n.clone() - C::N::from_canonical_usize(log_num_chunks));
+        let size: Usize<_> = builder.sll(RVar::one(), RVar::from(log_n.clone()));
 
         let g_dom = self.gen();
         let g = builder.exp_power_of_2_v::<Felt<C::F>>(g_dom, log_num_chunks);
@@ -134,8 +137,8 @@ where
 
         for _ in 0..num_chunks {
             domains.push(TwoAdicMultiplicativeCosetVariable {
-                log_n,
-                size,
+                log_n: log_n.clone(),
+                size: size.clone(),
                 shift: builder.eval(self.shift * domain_power),
                 g,
             });
@@ -164,21 +167,28 @@ pub(crate) mod tests {
         fri_params::default_fri_params,
     };
     use p3_commit::{Pcs, PolynomialSpace};
+    use p3_field::PrimeField;
     use p3_uni_stark::{Domain, StarkGenericConfig, Val};
     use rand::{thread_rng, Rng};
 
     use super::*;
     use crate::utils::const_fri_config;
 
-    pub(crate) fn domain_assertions<F: TwoAdicField, C: Config<N = F, F = F>>(
+    pub(crate) fn domain_assertions<F: TwoAdicField + PrimeField, C: Config<N = F, F = F>>(
         builder: &mut Builder<C>,
         domain: &TwoAdicMultiplicativeCosetVariable<C>,
         domain_val: &TwoAdicMultiplicativeCoset<F>,
         zeta_val: C::EF,
     ) {
         // Assert the domain parameters are the same.
-        builder.assert_var_eq(domain.log_n, F::from_canonical_usize(domain_val.log_n));
-        builder.assert_var_eq(domain.size, F::from_canonical_usize(1 << domain_val.log_n));
+        builder.assert_var_eq(
+            domain.log_n.clone(),
+            F::from_canonical_usize(domain_val.log_n),
+        );
+        builder.assert_var_eq(
+            domain.size.clone(),
+            F::from_canonical_usize(1 << domain_val.log_n),
+        );
         builder.assert_felt_eq(domain.shift, domain_val.shift);
 
         // Get a random point.
@@ -196,8 +206,7 @@ pub(crate) mod tests {
         builder.assert_ext_eq(zp, zp_val.cons());
     }
 
-    #[test]
-    fn test_domain() {
+    fn test_domain_impl(static_only: bool) {
         type SC = BabyBearPoseidon2Config;
         type F = Val<SC>;
         type EF = <SC as StarkGenericConfig>::Challenge;
@@ -213,6 +222,7 @@ pub(crate) mod tests {
 
         // Initialize a builder.
         let mut builder = AsmBuilder::<F, EF>::default();
+        builder.flags.static_only = static_only;
 
         let config_var = const_fri_config(&mut builder, &default_fri_params());
         for i in 0..5 {
@@ -273,5 +283,14 @@ pub(crate) mod tests {
         const WORD_SIZE: usize = 1;
         let program = builder.compile_isa::<WORD_SIZE>();
         execute_program_and_generate_traces::<WORD_SIZE>(program, vec![]);
+    }
+    #[test]
+    fn test_domain_static() {
+        test_domain_impl(true);
+    }
+
+    #[test]
+    fn test_domain_dynamic() {
+        test_domain_impl(false);
     }
 }

--- a/recursion/src/fri/mod.rs
+++ b/recursion/src/fri/mod.rs
@@ -26,7 +26,7 @@ pub fn verify_shape_and_sample_challenges<C: Config>(
     proof: &FriProofVariable<C>,
     challenger: &mut DuplexChallengerVariable<C>,
 ) -> FriChallengesVariable<C> {
-    let mut betas: Array<C, Ext<C::F, C::EF>> = builder.dyn_array(proof.commit_phase_commits.len());
+    let mut betas: Array<C, Ext<C::F, C::EF>> = builder.array(proof.commit_phase_commits.len());
 
     builder
         .range(0, proof.commit_phase_commits.len())
@@ -37,20 +37,20 @@ pub fn verify_shape_and_sample_challenges<C: Config>(
             builder.set(&mut betas, i, sample);
         });
 
-    let num_query_proofs = proof.query_proofs.len().materialize(builder);
+    let num_query_proofs = proof.query_proofs.len().clone();
     builder
-        .if_ne(num_query_proofs, config.num_queries)
+        .if_ne(num_query_proofs, RVar::from(config.num_queries))
         .then(|builder| {
             builder.error();
         });
 
     challenger.check_witness(builder, config.proof_of_work_bits, proof.pow_witness);
 
-    let num_commit_phase_commits = proof.commit_phase_commits.len().materialize(builder);
-    let log_max_height: Var<_> = builder.eval(num_commit_phase_commits + config.log_blowup);
+    let log_max_height =
+        builder.eval_expr(proof.commit_phase_commits.len() + RVar::from(config.log_blowup));
     let mut query_indices = builder.array(config.num_queries);
     builder.range(0, config.num_queries).for_each(|i, builder| {
-        let index_bits = challenger.sample_bits(builder, Usize::Var(log_max_height));
+        let index_bits = challenger.sample_bits(builder, log_max_height);
         builder.set(&mut query_indices, i, index_bits);
     });
 
@@ -74,8 +74,8 @@ pub fn verify_challenges<C: Config>(
     C::F: TwoAdicField,
     C::EF: TwoAdicField,
 {
-    let nb_commit_phase_commits = proof.commit_phase_commits.len().materialize(builder);
-    let log_max_height = builder.eval(nb_commit_phase_commits + config.log_blowup);
+    let log_max_height =
+        builder.eval_expr(proof.commit_phase_commits.len() + RVar::from(config.log_blowup));
     builder
         .range(0, challenges.query_indices.len())
         .for_each(|i, builder| {
@@ -91,7 +91,7 @@ pub fn verify_challenges<C: Config>(
                 &query_proof,
                 &challenges.betas,
                 &ro,
-                RVar::Val(log_max_height),
+                log_max_height,
             );
 
             builder.assert_ext_eq(folded_eval, proof.final_poly);
@@ -224,6 +224,7 @@ pub fn verify_batch<C: Config>(
 
     // The height of the current layer (padded).
     let current_height = builder.get(&dimensions, index).height;
+    let current_height = builder.materialize(current_height.into());
 
     // Reduce all the tables that have the same height to a single root.
     let root = match opened_values {
@@ -305,6 +306,10 @@ pub fn reduce_fast<C: Config>(
     curr_height_padded: Var<C::N>,
     opened_values: &Array<C, Array<C, Felt<C::F>>>,
 ) -> Array<C, Felt<C::F>> {
+    assert!(
+        !builder.flags.static_only,
+        "reduce_fast cannot be used in static mode"
+    );
     builder.cycle_tracker_start("verify-batch-reduce-fast");
     let nb_opened_values: Var<_> = builder.eval(C::N::zero());
     let mut nested_opened_values = builder.dyn_array(8192);
@@ -341,6 +346,10 @@ pub fn reduce_fast_ext<C: Config>(
     curr_height_padded: Var<C::N>,
     opened_values: &Array<C, Array<C, Ext<C::F, C::EF>>>,
 ) -> Array<C, Felt<C::F>> {
+    assert!(
+        !builder.flags.static_only,
+        "reduce_fast_ext cannot be used in static mode"
+    );
     builder.cycle_tracker_start("verify-batch-reduce-fast-ext");
     let nb_opened_values: Var<_> = builder.eval(C::N::zero());
     let mut nested_opened_values = builder.dyn_array(8192);

--- a/recursion/src/fri/two_adic_pcs.rs
+++ b/recursion/src/fri/two_adic_pcs.rs
@@ -39,7 +39,8 @@ pub fn verify_two_adic_pcs<C: Config>(
     builder.cycle_tracker_end("stage-d-1-verify-shape-and-sample-challenges");
 
     let commit_phase_commits_len = fri_proof.commit_phase_commits.len().materialize(builder);
-    let log_global_max_height: Var<_> = builder.eval(commit_phase_commits_len + log_blowup);
+    let log_global_max_height: Var<_> =
+        builder.eval(commit_phase_commits_len + RVar::from(log_blowup));
 
     let mut reduced_openings: Array<_, Array<_, Ext<_, _>>> =
         builder.array(proof.query_openings.len());
@@ -72,7 +73,7 @@ pub fn verify_two_adic_pcs<C: Config>(
                 builder.range(0, mats.len()).for_each(|k, builder| {
                     let mat = builder.get(&mats, k);
                     let domain = mat.domain;
-                    let height_log2: Var<_> = builder.eval(domain.log_n + log_blowup);
+                    let height_log2: Var<_> = builder.eval(domain.log_n + RVar::from(log_blowup));
                     builder.set_value(&mut batch_heights_log2, k, height_log2);
                 });
                 let mut batch_dims: Array<C, DimensionsVariable<C>> = builder.array(mats.len());
@@ -80,7 +81,7 @@ pub fn verify_two_adic_pcs<C: Config>(
                     let mat = builder.get(&mats, k);
                     let domain = mat.domain;
                     let dim = DimensionsVariable::<C> {
-                        height: builder.eval(domain.size() * blowup),
+                        height: builder.eval(domain.size() * RVar::from(blowup)),
                     };
                     builder.set_value(&mut batch_dims, k, dim);
                 });
@@ -119,7 +120,8 @@ pub fn verify_two_adic_pcs<C: Config>(
                         let mat_values = mat.values;
                         let domain = mat.domain;
                         let log2_domain_size = domain.log_n;
-                        let log_height: Var<C::N> = builder.eval(log2_domain_size + log_blowup);
+                        let log_height: Var<C::N> =
+                            builder.eval(log2_domain_size + RVar::from(log_blowup));
 
                         let cur_ro = builder.get(&ro, log_height);
                         let cur_alpha_pow = builder.get(&alpha_pow, log_height);
@@ -231,7 +233,7 @@ where
     }
 }
 
-#[derive(DslVariable, Clone)]
+#[derive(Clone)]
 pub struct TwoAdicFriPcsVariable<C: Config> {
     pub config: FriConfigVariable<C>,
 }

--- a/recursion/src/fri/types.rs
+++ b/recursion/src/fri/types.rs
@@ -4,12 +4,12 @@ use crate::fri::TwoAdicMultiplicativeCosetVariable;
 
 pub type DigestVariable<C> = Array<C, Felt<<C as Config>::F>>;
 
-#[derive(DslVariable, Clone)]
+#[derive(Clone)]
 pub struct FriConfigVariable<C: Config> {
-    pub log_blowup: Var<C::N>,
-    pub blowup: Var<C::N>,
-    pub num_queries: Var<C::N>,
-    pub proof_of_work_bits: Var<C::N>,
+    pub log_blowup: usize,
+    pub blowup: usize,
+    pub num_queries: usize,
+    pub proof_of_work_bits: usize,
     pub generators: Array<C, Felt<C::F>>,
     pub subgroups: Array<C, TwoAdicMultiplicativeCosetVariable<C>>,
 }

--- a/recursion/src/utils.rs
+++ b/recursion/src/utils.rs
@@ -1,6 +1,5 @@
 use afs_compiler::{asm::AsmConfig, ir::Builder};
 use afs_test_utils::config::FriParameters;
-use itertools::Itertools;
 use p3_baby_bear::BabyBear;
 use p3_commit::TwoAdicMultiplicativeCoset;
 use p3_field::{extension::BinomialExtensionField, AbstractField, TwoAdicField};
@@ -17,8 +16,8 @@ pub fn const_fri_config(
     params: &FriParameters,
 ) -> FriConfigVariable<RecursionConfig> {
     let two_adicity = Val::TWO_ADICITY;
-    let mut generators = builder.dyn_array(two_adicity);
-    let mut subgroups = builder.dyn_array(two_adicity);
+    let mut generators = builder.array(two_adicity);
+    let mut subgroups = builder.array(two_adicity);
     for i in 0..Val::TWO_ADICITY {
         let constant_generator = Val::two_adic_generator(i);
         builder.set(&mut generators, i, constant_generator);
@@ -28,43 +27,16 @@ pub fn const_fri_config(
             shift: Val::one(),
         };
         let domain_value: TwoAdicMultiplicativeCosetVariable<_> = builder.constant(constant_domain);
-        builder.set(&mut subgroups, i, domain_value);
+        // FIXME: here must use `builder.set_value`. `builder.set` will convert `Usize::Const`
+        // to `Usize::Var` because it calls `builder.eval`.
+        builder.set_value(&mut subgroups, i, domain_value);
     }
     FriConfigVariable {
-        log_blowup: builder.eval(BabyBear::from_canonical_usize(params.log_blowup)),
-        blowup: builder.eval(BabyBear::from_canonical_usize(1 << params.log_blowup)),
-        num_queries: builder.eval(BabyBear::from_canonical_usize(params.num_queries)),
-        proof_of_work_bits: builder.eval(BabyBear::from_canonical_usize(params.proof_of_work_bits)),
+        log_blowup: params.log_blowup,
+        blowup: 1 << params.log_blowup,
+        num_queries: params.num_queries,
+        proof_of_work_bits: params.proof_of_work_bits,
         subgroups,
         generators,
-    }
-}
-
-#[allow(dead_code)]
-pub fn static_const_fri_config(
-    builder: &mut RecursionBuilder,
-    params: &FriParameters,
-) -> FriConfigVariable<RecursionConfig> {
-    let two_addicity = Val::TWO_ADICITY;
-    let generators = (0..two_addicity)
-        .map(|i| builder.constant(Val::two_adic_generator(i)))
-        .collect_vec();
-    let subgroups = (0..two_addicity)
-        .map(|i| {
-            let constant_domain = TwoAdicMultiplicativeCoset {
-                log_n: i,
-                shift: Val::one(),
-            };
-            builder.constant(constant_domain)
-        })
-        .collect_vec();
-
-    FriConfigVariable {
-        log_blowup: builder.eval(BabyBear::from_canonical_usize(params.log_blowup)),
-        blowup: builder.eval(BabyBear::from_canonical_usize(1 << params.log_blowup)),
-        num_queries: builder.eval(BabyBear::from_canonical_usize(params.num_queries)),
-        proof_of_work_bits: builder.eval(BabyBear::from_canonical_usize(params.proof_of_work_bits)),
-        subgroups: builder.vec(subgroups),
-        generators: builder.vec(generators),
     }
 }


### PR DESCRIPTION
Add static mode for `builder`. In this mode, dynamic loop/branching and heap memory are disallowed.

Detailed changes:
- `Usize::Const` is a compile-time variable and it should only be allowed in static mode. I tried to use it in both mode to enable optimization automatically but it brings too much complexity.
- In static mode, trying to use dynamic `if`/`for_each` and `builder.alloc` will panic.

TODOs:
- Now variable structs with `Usize` field(s) must use `builder.set_value` because of `DslVariable` doesn't handle it well. Need to fix the macro.

Progress towards static verifier:
- `fri/domain.rs` seems working in the static version since the testing passed.
- `fri/two_adic_pcs/rs` needs rewrite or refactor. 
