### PR TITLE
refactor: MemoryChip

### DIFF
--- a/compiler/tests/arithmetic.rs
+++ b/compiler/tests/arithmetic.rs
@@ -12,7 +12,6 @@ use stark_vm::{
     vm::{config::VmConfig, VirtualMachine},
 };
 
-#[allow(dead_code)]
 const WORD_SIZE: usize = 1;
 
 #[test]

--- a/compiler/tests/array.rs
+++ b/compiler/tests/array.rs
@@ -112,7 +112,6 @@ pub struct Point<C: Config> {
 //
 //     builder.halt();
 //
-//     const WORD_SIZE: usize = 1;
 //     let program = builder.compile_isa();
 //     execute_program(program, vec![]);
 // }

--- a/compiler/tests/modular_arithmetic.rs
+++ b/compiler/tests/modular_arithmetic.rs
@@ -8,7 +8,6 @@ use p3_baby_bear::BabyBear;
 use p3_field::{extension::BinomialExtensionField, AbstractField};
 use rand::RngCore;
 
-#[allow(dead_code)]
 const WORD_SIZE: usize = 1;
 
 fn secp256k1_coord_prime() -> BigUint {

--- a/vm/src/arch/chips.rs
+++ b/vm/src/arch/chips.rs
@@ -13,12 +13,11 @@ use crate::{
     arch::columns::ExecutionState,
     cpu::{trace::Instruction, CpuChip},
     field_arithmetic::FieldArithmeticChip,
-    // field_extension::chip::FieldExtensionArithmeticChip,
-    memory::manager::MemoryManager,
-    // poseidon2::Poseidon2Chip,
+    field_extension::chip::FieldExtensionArithmeticChip,
+    memory::manager::MemoryChipRef,
+    poseidon2::Poseidon2Chip,
     program::ProgramChip,
 };
-use crate::{field_extension::chip::FieldExtensionArithmeticChip, poseidon2::Poseidon2Chip};
 
 #[enum_dispatch]
 pub trait InstructionExecutor<F> {
@@ -93,7 +92,7 @@ pub enum InstructionExecutorVariant<F: PrimeField32> {
 pub enum MachineChipVariant<F: PrimeField32> {
     Cpu(Rc<RefCell<CpuChip<F>>>),
     Program(Rc<RefCell<ProgramChip<F>>>),
-    Memory(Rc<RefCell<MemoryManager<F>>>),
+    Memory(MemoryChipRef<F>),
     FieldArithmetic(Rc<RefCell<FieldArithmeticChip<F>>>),
     FieldExtension(Rc<RefCell<FieldExtensionArithmeticChip<F>>>),
     Poseidon2(Rc<RefCell<Poseidon2Chip<16, F>>>),

--- a/vm/src/arch/testing/execution/mod.rs
+++ b/vm/src/arch/testing/execution/mod.rs
@@ -44,7 +44,7 @@ impl<F: PrimeField32> ExecutionTester<F> {
     ) {
         let initial_state = ExecutionState {
             pc: self.next_elem_size_usize(),
-            timestamp: memory_tester.manager.borrow().timestamp(),
+            timestamp: memory_tester.chip.borrow().timestamp(),
         };
         tracing::debug!(?initial_state.timestamp);
 

--- a/vm/src/arch/testing/memory/mod.rs
+++ b/vm/src/arch/testing/memory/mod.rs
@@ -11,7 +11,7 @@ use rand::{seq::SliceRandom, Rng};
 use crate::{
     arch::chips::MachineChip,
     memory::{
-        manager::MemoryManager,
+        manager::{MemoryChip, MemoryChipRef},
         offline_checker::bus::{MemoryBus, MemoryBusInteraction},
         MemoryAddress, OpType,
     },
@@ -28,42 +28,50 @@ const WORD_SIZE: usize = 1;
 #[derive(Clone, Debug)]
 pub struct MemoryTester<F: PrimeField32> {
     pub bus: MemoryBus,
-    pub manager: Rc<RefCell<MemoryManager<F>>>,
+    pub chip: MemoryChipRef<F>,
     /// Log of raw bus messages
     pub records: Vec<MemoryBusInteraction<F, 1>>,
 }
 
 impl<F: PrimeField32> MemoryTester<F> {
-    pub fn new(manager: Rc<RefCell<MemoryManager<F>>>) -> Self {
-        let bus = manager.borrow().memory_bus;
+    pub fn new(chip: MemoryChipRef<F>) -> Self {
+        let bus = chip.borrow().memory_bus;
         Self {
             bus,
-            manager,
+            chip,
             records: Vec::new(),
         }
     }
 
-    /// Returns the cell value at the current timestamp according to [MemoryManager].
+    /// Returns the cell value at the current timestamp according to [MemoryChip].
     pub fn read_cell(&mut self, address_space: usize, pointer: usize) -> F {
         let [addr_space, pointer] = [address_space, pointer].map(F::from_canonical_usize);
         // core::BorrowMut confuses compiler
-        let op = RefCell::borrow_mut(&mut self.manager).read_word(addr_space, pointer);
+        let access = RefCell::borrow_mut(&self.chip).read(addr_space, pointer);
         let address = MemoryAddress::new(addr_space, pointer);
-        self.records
-            .push(self.bus.read(address, op.op.cell.data, op.old_cell.clk));
-        self.records
-            .push(self.bus.write(address, op.op.cell.data, op.op.cell.clk));
-        op.op.cell.data[0]
+        self.records.push(
+            self.bus
+                .read(address, access.op.cell.data, access.old_cell.clk),
+        );
+        self.records.push(
+            self.bus
+                .write(address, access.op.cell.data, access.op.cell.clk),
+        );
+        access.op.cell.data[0]
     }
 
     pub fn write_cell(&mut self, address_space: usize, pointer: usize, value: F) {
         let [addr_space, pointer] = [address_space, pointer].map(F::from_canonical_usize);
-        let op = RefCell::borrow_mut(&mut self.manager).write_word(addr_space, pointer, [value]);
+        let access = RefCell::borrow_mut(&self.chip).write(addr_space, pointer, value);
         let address = MemoryAddress::new(addr_space, pointer);
-        self.records
-            .push(self.bus.read(address, op.old_cell.data, op.old_cell.clk));
-        self.records
-            .push(self.bus.write(address, op.op.cell.data, op.op.cell.clk));
+        self.records.push(
+            self.bus
+                .read(address, access.old_cell.data, access.old_cell.clk),
+        );
+        self.records.push(
+            self.bus
+                .write(address, access.op.cell.data, access.op.cell.clk),
+        );
     }
 
     pub fn read<const N: usize>(&mut self, address_space: usize, pointer: usize) -> [F; N] {

--- a/vm/src/cpu/columns.rs
+++ b/vm/src/cpu/columns.rs
@@ -184,7 +184,7 @@ impl<F: PrimeField32> CpuAuxCols<F> {
             operation_flags.insert(opcode, F::from_bool(opcode == Opcode::NOP));
         }
 
-        let mut mem_trace_builder = MemoryTraceBuilder::new(chip.memory_manager.clone());
+        let mut mem_trace_builder = MemoryTraceBuilder::new(chip.memory_chip.clone());
         let mem_ops: [_; CPU_MAX_ACCESSES_PER_CYCLE] = array::from_fn(|i| {
             if i < CPU_MAX_READS_PER_CYCLE {
                 mem_trace_builder.disabled_read(F::one())

--- a/vm/src/cpu/mod.rs
+++ b/vm/src/cpu/mod.rs
@@ -1,5 +1,4 @@
 use core::panic;
-use std::{cell::RefCell, rc::Rc};
 
 pub use air::CpuAir;
 use p3_field::PrimeField32;
@@ -9,9 +8,8 @@ use crate::{
         bus::ExecutionBus,
         instructions::{Opcode, Opcode::*},
     },
-    memory::manager::MemoryManager,
+    memory::manager::MemoryChipRef,
 };
-
 // TODO[zach]: Restore tests once we have control flow chip.
 //#[cfg(test)]
 //pub mod tests;
@@ -85,16 +83,16 @@ pub struct CpuChip<F: PrimeField32> {
     /// Program counter at the start of the current segment.
     pub start_state: CpuState,
     pub public_values: Vec<Option<F>>,
-    pub memory_manager: Rc<RefCell<MemoryManager<F>>>,
+    pub memory_chip: MemoryChipRef<F>,
 }
 
 impl<F: PrimeField32> CpuChip<F> {
     pub fn new(
         options: CpuOptions,
         execution_bus: ExecutionBus,
-        memory_manager: Rc<RefCell<MemoryManager<F>>>,
+        memory_chip: MemoryChipRef<F>,
     ) -> Self {
-        Self::from_state(options, execution_bus, memory_manager, CpuState::initial())
+        Self::from_state(options, execution_bus, memory_chip, CpuState::initial())
     }
 
     /// Sets the current state of the CPU.
@@ -106,10 +104,10 @@ impl<F: PrimeField32> CpuChip<F> {
     pub fn from_state(
         options: CpuOptions,
         execution_bus: ExecutionBus,
-        memory_manager: Rc<RefCell<MemoryManager<F>>>,
+        memory_chip: MemoryChipRef<F>,
         state: CpuState,
     ) -> Self {
-        let memory_offline_checker = memory_manager.borrow().make_offline_checker();
+        let memory_offline_checker = memory_chip.borrow().make_offline_checker();
         Self {
             air: CpuAir {
                 options,
@@ -120,7 +118,7 @@ impl<F: PrimeField32> CpuChip<F> {
             state,
             start_state: state,
             public_values: vec![None; options.num_public_values],
-            memory_manager,
+            memory_chip,
         }
     }
 }

--- a/vm/src/cpu/tests/mod.rs
+++ b/vm/src/cpu/tests/mod.rs
@@ -266,7 +266,7 @@ fn air_test_change<
     let program_trace = RowMajorMatrix::new(program_cells, width);
 
     let memory_interface_trace = segment
-        .memory_manager
+        .memory_chip
         .borrow()
         .generate_memory_interface_trace();
     let range_checker_trace = segment.range_checker.generate_trace();
@@ -291,7 +291,7 @@ fn air_test_change<
     let mut all_public_values = vec![segment.get_cpu_pis(), vec![], vec![], vec![], vec![]];
 
     let MemoryInterface::Volatile(memory_audit_chip) =
-        &segment.memory_manager.borrow().interface_chip;
+        &segment.memory_chip.borrow().interface_chip;
 
     let test_result = if field_arithmetic_enabled {
         run_simple_test(

--- a/vm/src/cpu/trace.rs
+++ b/vm/src/cpu/trace.rs
@@ -28,10 +28,7 @@ use crate::{
         },
     },
     cpu::WORD_SIZE,
-    memory::{
-        compose, decompose,
-        manager::{operation::MemoryOperation, trace_builder::MemoryTraceBuilder},
-    },
+    memory::manager::{operation::MemoryOperation, trace_builder::MemoryTraceBuilder},
     vm::ExecutionSegment,
 };
 
@@ -214,7 +211,7 @@ impl<F: PrimeField32> CpuChip<F> {
 
         debug_assert_eq!(
             timestamp,
-            vm.memory_manager.borrow().timestamp().as_canonical_u32() as usize
+            vm.memory_chip.borrow().timestamp().as_canonical_u32() as usize
         );
 
         let mut hint_stream = vm.hint_stream.clone();
@@ -263,8 +260,8 @@ impl<F: PrimeField32> CpuChip<F> {
 
             let mut mem_ops: [_; CPU_MAX_ACCESSES_PER_CYCLE] =
                 core::array::from_fn(|_| MemoryOperation::<1, F>::default());
-            let mut mem_read_trace_builder = MemoryTraceBuilder::new(vm.memory_manager.clone());
-            let mut mem_write_trace_builder = MemoryTraceBuilder::new(vm.memory_manager.clone());
+            let mut mem_read_trace_builder = MemoryTraceBuilder::new(vm.memory_chip.clone());
+            let mut mem_write_trace_builder = MemoryTraceBuilder::new(vm.memory_chip.clone());
             let mut num_reads = 0;
             let mut num_writes = 0;
 
@@ -276,8 +273,8 @@ impl<F: PrimeField32> CpuChip<F> {
                     assert!(num_reads <= CPU_MAX_READS_PER_CYCLE);
 
                     mem_ops[num_reads - 1] =
-                        mem_read_trace_builder.read_word($addr_space, $pointer);
-                    compose(mem_ops[num_reads - 1].cell.data)
+                        mem_read_trace_builder.read_cell($addr_space, $pointer);
+                    mem_ops[num_reads - 1].cell.data[0]
                 }};
             }
 
@@ -300,9 +297,8 @@ impl<F: PrimeField32> CpuChip<F> {
                     num_writes += 1;
                     assert!(num_writes <= CPU_MAX_WRITES_PER_CYCLE);
 
-                    let word = decompose($data);
                     mem_ops[CPU_MAX_READS_PER_CYCLE + num_writes - 1] =
-                        mem_write_trace_builder.write_word($addr_space, $pointer, word);
+                        mem_write_trace_builder.write_cell($addr_space, $pointer, $data);
                 }};
             }
 
@@ -430,8 +426,8 @@ impl<F: PrimeField32> CpuChip<F> {
                         hint_stream.extend(hint);
                     }
                     HINT_BITS => {
-                        let val = vm.memory_manager.borrow_mut().unsafe_read_word(d, a);
-                        let mut val = val[0].as_canonical_u32();
+                        let val = vm.memory_chip.borrow_mut().unsafe_read_cell(d, a);
+                        let mut val = val.as_canonical_u32();
 
                         let len = c.as_canonical_u32();
                         hint_stream = VecDeque::new();

--- a/vm/src/field_arithmetic/tests.rs
+++ b/vm/src/field_arithmetic/tests.rs
@@ -32,7 +32,7 @@ fn field_arithmetic_air_test() {
 
     let mut tester = MachineChipTestBuilder::default();
     let mut field_arithmetic_chip =
-        FieldArithmeticChip::new(tester.execution_bus(), tester.get_memory_manager());
+        FieldArithmeticChip::new(tester.execution_bus(), tester.memory_chip());
 
     let mut rng = create_seeded_rng();
 
@@ -118,7 +118,7 @@ fn field_arithmetic_air_test() {
 fn field_arithmetic_air_zero_div_zero() {
     let mut tester = MachineChipTestBuilder::default();
     let mut field_arithmetic_chip =
-        FieldArithmeticChip::new(tester.execution_bus(), tester.get_memory_manager());
+        FieldArithmeticChip::new(tester.execution_bus(), tester.memory_chip());
     tester.write_cell(1, 0, BabyBear::zero());
     tester.write_cell(1, 1, BabyBear::one());
 
@@ -151,7 +151,7 @@ fn field_arithmetic_air_zero_div_zero() {
 fn field_arithmetic_air_test_panic() {
     let mut tester = MachineChipTestBuilder::default();
     let mut field_arithmetic_chip =
-        FieldArithmeticChip::new(tester.execution_bus(), tester.get_memory_manager());
+        FieldArithmeticChip::new(tester.execution_bus(), tester.memory_chip());
     tester.write_cell(1, 0, BabyBear::zero());
     // should panic
     tester.execute(

--- a/vm/src/field_arithmetic/trace.rs
+++ b/vm/src/field_arithmetic/trace.rs
@@ -63,13 +63,9 @@ fn generate_row<F: Field>(
 
 impl<F: PrimeField32> FieldArithmeticChip<F> {
     fn make_blank_row(&self) -> FieldArithmeticCols<F> {
-        let mut trace_builder = MemoryTraceBuilder::new(self.memory_manager.clone());
+        let mut trace_builder = MemoryTraceBuilder::new(self.memory_chip.clone());
 
-        let timestamp = self
-            .memory_manager
-            .borrow_mut()
-            .timestamp()
-            .as_canonical_u32() as usize;
+        let timestamp = self.memory_chip.borrow_mut().timestamp().as_canonical_u32() as usize;
 
         trace_builder.disabled_op(F::one(), OpType::Read);
         trace_builder.disabled_op(F::one(), OpType::Read);

--- a/vm/src/field_extension/columns.rs
+++ b/vm/src/field_extension/columns.rs
@@ -8,8 +8,6 @@ use crate::{
     memory::offline_checker::{bridge::MemoryOfflineChecker, columns::MemoryOfflineCheckerAuxCols},
 };
 
-const WORD_SIZE: usize = 1;
-
 /// Columns for field extension chip.
 ///
 /// IO columns for opcode, x, y, result.
@@ -52,11 +50,11 @@ pub struct FieldExtensionArithmeticAuxCols<T> {
     // the field extension inverse of x
     pub inv: [T; EXTENSION_DEGREE],
     /// The aux columns for the x reads.
-    pub read_x_aux_cols: [MemoryOfflineCheckerAuxCols<WORD_SIZE, T>; EXTENSION_DEGREE],
+    pub read_x_aux_cols: [MemoryOfflineCheckerAuxCols<1, T>; EXTENSION_DEGREE],
     /// The aux columns for the y reads.
-    pub read_y_aux_cols: [MemoryOfflineCheckerAuxCols<WORD_SIZE, T>; EXTENSION_DEGREE],
+    pub read_y_aux_cols: [MemoryOfflineCheckerAuxCols<1, T>; EXTENSION_DEGREE],
     /// The aux columns for the z writes.
-    pub write_aux_cols: [MemoryOfflineCheckerAuxCols<WORD_SIZE, T>; EXTENSION_DEGREE],
+    pub write_aux_cols: [MemoryOfflineCheckerAuxCols<1, T>; EXTENSION_DEGREE],
 }
 
 impl<T> FieldExtensionArithmeticCols<T> {

--- a/vm/src/field_extension/tests.rs
+++ b/vm/src/field_extension/tests.rs
@@ -27,8 +27,7 @@ fn field_extension_air_test() {
     type F = BabyBear;
 
     let mut tester = MachineChipTestBuilder::default();
-    let mut chip =
-        FieldExtensionArithmeticChip::new(tester.execution_bus(), tester.get_memory_manager());
+    let mut chip = FieldExtensionArithmeticChip::new(tester.execution_bus(), tester.memory_chip());
 
     let mut rng = create_seeded_rng();
     let num_ops: usize = 1 << 3;

--- a/vm/src/memory/audit/air.rs
+++ b/vm/src/memory/audit/air.rs
@@ -14,13 +14,13 @@ use super::columns::AuditCols;
 use crate::{cpu::RANGE_CHECKER_BUS, memory::offline_checker::bus::MemoryBus};
 
 #[derive(Clone, Debug)]
-pub struct MemoryAuditAir<const WORD_SIZE: usize> {
+pub struct MemoryAuditAir {
     pub memory_bus: MemoryBus,
     pub addr_lt_air: IsLessThanTupleAir,
     pub for_testing: bool,
 }
 
-impl<const WORD_SIZE: usize> MemoryAuditAir<WORD_SIZE> {
+impl MemoryAuditAir {
     pub fn new(
         memory_bus: MemoryBus,
         addr_space_max_bits: usize,
@@ -40,23 +40,23 @@ impl<const WORD_SIZE: usize> MemoryAuditAir<WORD_SIZE> {
     }
 
     pub fn air_width(&self) -> usize {
-        AuditCols::<WORD_SIZE, usize>::width(self)
+        AuditCols::<usize>::width(self)
     }
 }
 
-impl<const WORD_SIZE: usize, F: Field> BaseAir<F> for MemoryAuditAir<WORD_SIZE> {
+impl<F: Field> BaseAir<F> for MemoryAuditAir {
     fn width(&self) -> usize {
         self.air_width()
     }
 }
 
-impl<const WORD_SIZE: usize, AB: InteractionBuilder> Air<AB> for MemoryAuditAir<WORD_SIZE> {
+impl<AB: InteractionBuilder> Air<AB> for MemoryAuditAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
 
         let [local, next] = [0, 1].map(|i| {
             let row = main.row_slice(i);
-            AuditCols::<WORD_SIZE, AB::Var>::from_slice(&row, self)
+            AuditCols::<AB::Var>::from_slice(&row, self)
         });
 
         // TODO[jpw]: ideally make this work for testing too

--- a/vm/src/memory/audit/bridge.rs
+++ b/vm/src/memory/audit/bridge.rs
@@ -4,18 +4,18 @@ use p3_field::AbstractField;
 use super::{air::MemoryAuditAir, columns::AuditCols};
 use crate::memory::MemoryAddress;
 
-impl<const WORD_SIZE: usize> MemoryAuditAir<WORD_SIZE> {
+impl MemoryAuditAir {
     pub fn eval_interactions<AB: InteractionBuilder>(
         &self,
         builder: &mut AB,
-        local: AuditCols<WORD_SIZE, AB::Var>,
+        local: AuditCols<AB::Var>,
     ) {
         let mult = AB::Expr::one() - local.is_extra;
         // Write the initial memory values at initial timestamps
         self.memory_bus
             .write(
                 MemoryAddress::new(local.addr_space, local.pointer),
-                local.initial_data,
+                [local.initial_data],
                 AB::Expr::zero(),
             )
             .eval(builder, mult.clone());

--- a/vm/src/memory/audit/mod.rs
+++ b/vm/src/memory/audit/mod.rs
@@ -15,13 +15,13 @@ pub mod trace;
 mod tests;
 
 #[derive(Clone, Debug)]
-pub struct MemoryAuditChip<const WORD_SIZE: usize, F: PrimeField32> {
-    pub air: MemoryAuditAir<WORD_SIZE>,
-    initial_memory: BTreeMap<(F, F), [F; WORD_SIZE]>,
+pub struct MemoryAuditChip<F: PrimeField32> {
+    pub air: MemoryAuditAir,
+    initial_memory: BTreeMap<(F, F), F>,
     range_checker: Arc<RangeCheckerGateChip>,
 }
 
-impl<const WORD_SIZE: usize, F: PrimeField32> MemoryAuditChip<WORD_SIZE, F> {
+impl<F: PrimeField32> MemoryAuditChip<F> {
     pub fn new(
         memory_bus: MemoryBus,
         addr_space_max_bits: usize,
@@ -42,7 +42,7 @@ impl<const WORD_SIZE: usize, F: PrimeField32> MemoryAuditChip<WORD_SIZE, F> {
         }
     }
 
-    pub fn touch_address(&mut self, addr_space: F, pointer: F, old_data: [F; WORD_SIZE]) {
+    pub fn touch_address(&mut self, addr_space: F, pointer: F, old_data: F) {
         self.initial_memory
             .entry((addr_space, pointer))
             .or_insert(old_data);

--- a/vm/src/memory/manager/interface.rs
+++ b/vm/src/memory/manager/interface.rs
@@ -3,19 +3,17 @@ use std::collections::HashMap;
 use p3_field::PrimeField32;
 use p3_matrix::dense::RowMajorMatrix;
 
-use super::AccessCell;
+use super::TimestampedValue;
 use crate::memory::audit::MemoryAuditChip;
 
 #[derive(Clone, Debug)]
-pub enum MemoryInterface<const NUM_WORDS: usize, const WORD_SIZE: usize, F: PrimeField32> {
-    Volatile(MemoryAuditChip<WORD_SIZE, F>),
+pub enum MemoryInterface<const NUM_WORDS: usize, F: PrimeField32> {
+    Volatile(MemoryAuditChip<F>),
     // Persistent(MemoryExpandInterfaceChip<NUM_WORDS, WORD_SIZE, F>),
 }
 
-impl<const NUM_WORDS: usize, const WORD_SIZE: usize, F: PrimeField32>
-    MemoryInterface<NUM_WORDS, WORD_SIZE, F>
-{
-    pub fn touch_address(&mut self, addr_space: F, pointer: F, data: [F; WORD_SIZE]) {
+impl<const NUM_WORDS: usize, F: PrimeField32> MemoryInterface<NUM_WORDS, F> {
+    pub fn touch_address(&mut self, addr_space: F, pointer: F, data: F) {
         match self {
             MemoryInterface::Volatile(ref mut audit_chip) => {
                 audit_chip.touch_address(addr_space, pointer, data);
@@ -34,7 +32,7 @@ impl<const NUM_WORDS: usize, const WORD_SIZE: usize, F: PrimeField32>
 
     pub fn generate_trace(
         &self,
-        final_memory: HashMap<(F, F), AccessCell<WORD_SIZE, F>>,
+        final_memory: HashMap<(F, F), TimestampedValue<F>>,
     ) -> RowMajorMatrix<F> {
         match self {
             MemoryInterface::Volatile(ref audit_chip) => {
@@ -48,7 +46,7 @@ impl<const NUM_WORDS: usize, const WORD_SIZE: usize, F: PrimeField32>
 
     pub fn generate_trace_with_height(
         &self,
-        final_memory: HashMap<(F, F), AccessCell<WORD_SIZE, F>>,
+        final_memory: HashMap<(F, F), TimestampedValue<F>>,
         trace_height: usize,
     ) -> RowMajorMatrix<F> {
         match self {

--- a/vm/src/memory/mod.rs
+++ b/vm/src/memory/mod.rs
@@ -1,7 +1,4 @@
-use std::array;
-
 use afs_derive::AlignedBorrow;
-use p3_field::{AbstractField, Field};
 
 pub mod audit;
 // pub mod expand;
@@ -45,18 +42,4 @@ impl<S, T> MemoryAddress<S, T> {
             pointer: a.pointer.into(),
         }
     }
-}
-
-// panics if the word is not equal to decompose(elem) for some elem: F
-pub fn compose<const WORD_SIZE: usize, F: Field>(word: [F; WORD_SIZE]) -> F {
-    for &cell in word.iter().skip(1) {
-        assert_eq!(cell, F::zero());
-    }
-    word[0]
-}
-
-pub fn decompose<const WORD_SIZE: usize, F: AbstractField>(field_elem: F) -> [F; WORD_SIZE] {
-    let mut array = array::from_fn(|_| F::zero());
-    array[0] = field_elem;
-    array
 }

--- a/vm/src/modular_multiplication/mod.rs
+++ b/vm/src/modular_multiplication/mod.rs
@@ -101,23 +101,23 @@ impl<F: PrimeField32> ModularArithmeticChip<F> {
         };
         // TODO[zach]: update for word size
         let address1 = vm
-            .memory_manager
+            .memory_chip
             .borrow_mut()
-            .read_word(instruction.d, instruction.op_a)
+            .read(instruction.d, instruction.op_a)
             .op
             .cell
             .data[0];
         let address2 = vm
-            .memory_manager
+            .memory_chip
             .borrow_mut()
-            .read_word(instruction.d, op_input_2)
+            .read(instruction.d, op_input_2)
             .op
             .cell
             .data[0];
         let output_address = vm
-            .memory_manager
+            .memory_chip
             .borrow_mut()
-            .read_word(instruction.d, op_result)
+            .read(instruction.d, op_result)
             .op
             .cell
             .data[0];
@@ -128,9 +128,9 @@ impl<F: PrimeField32> ModularArithmeticChip<F> {
         let repr_bits = air.air.repr_bits;
         let argument_1_elems = (0..num_elems)
             .map(|i| {
-                vm.memory_manager
+                vm.memory_chip
                     .borrow_mut()
-                    .read_word(instruction.e, address1 + F::from_canonical_usize(i))
+                    .read(instruction.e, address1 + F::from_canonical_usize(i))
                     .op
                     .cell
                     .data[0]
@@ -138,9 +138,9 @@ impl<F: PrimeField32> ModularArithmeticChip<F> {
             .collect();
         let argument_2_elems = (0..num_elems)
             .map(|i| {
-                vm.memory_manager
+                vm.memory_chip
                     .borrow_mut()
-                    .read_word(instruction.e, address2 + F::from_canonical_usize(i))
+                    .read(instruction.e, address2 + F::from_canonical_usize(i))
                     .op
                     .cell
                     .data[0]
@@ -166,10 +166,10 @@ impl<F: PrimeField32> ModularArithmeticChip<F> {
         } % modulus;
         let result_elems = bigint_to_elems(result, repr_bits, num_elems);
         for (i, &elem) in result_elems.iter().enumerate() {
-            vm.memory_manager.borrow_mut().write_word(
+            vm.memory_chip.borrow_mut().write(
                 instruction.e,
                 output_address + F::from_canonical_usize(i),
-                [elem],
+                elem,
             );
         }
         chip.ops.push(VmModularArithmetic {

--- a/vm/src/modular_multiplication/tests/mod.rs
+++ b/vm/src/modular_multiplication/tests/mod.rs
@@ -80,7 +80,7 @@ fn test_modular_multiplication_runtime() {
 
     for (i, &elem) in bigint_to_elems(a, repr_bits, num_elems).iter().enumerate() {
         let address = address1 + i;
-        segment.memory_manager.borrow_mut().write_word(
+        segment.memory_chip.borrow_mut().write_word(
             BabyBear::one(),
             BabyBear::from_canonical_usize(address),
             [elem],
@@ -88,7 +88,7 @@ fn test_modular_multiplication_runtime() {
     }
     for (i, &elem) in bigint_to_elems(b, repr_bits, num_elems).iter().enumerate() {
         let address = address2 + i;
-        segment.memory_manager.borrow_mut().write_word(
+        segment.memory_chip.borrow_mut().write_word(
             BabyBear::one(),
             BabyBear::from_canonical_usize(address),
             [elem],
@@ -107,7 +107,7 @@ fn test_modular_multiplication_runtime() {
     );
     for (i, &elem) in bigint_to_elems(r, repr_bits, num_elems).iter().enumerate() {
         let address = address3 + i;
-        segment.memory_manager.borrow_mut().write_word(
+        segment.memory_chip.borrow_mut().write_word(
             BabyBear::one(),
             BabyBear::from_canonical_usize(address),
             [elem],

--- a/vm/src/poseidon2/tests.rs
+++ b/vm/src/poseidon2/tests.rs
@@ -67,7 +67,7 @@ fn tester_with_random_poseidon2_ops(num_ops: usize) -> MachineChipTester {
     let mut chip = Poseidon2Chip::from_poseidon2_config(
         Poseidon2Config::<16, _>::new_p3_baby_bear_16(),
         tester.execution_bus(),
-        tester.get_memory_manager(),
+        tester.memory_chip(),
     );
 
     let mut rng = create_seeded_rng();
@@ -187,7 +187,7 @@ fn poseidon2_negative_test() {
 //     let mut chip = Poseidon2Chip::<16, BabyBear>::from_poseidon2_config(
 //         Poseidon2Config::default(),
 //         ExecutionBus(0),
-//         MemoryTester::new(MemoryBus(1)).get_memory_manager(),
+//         MemoryTester::new(MemoryBus(1)).chip(),
 //     );
 //
 //     let outs: [[BabyBear; CHUNKS]; NUM_OPS] =

--- a/vm/src/poseidon2/trace.rs
+++ b/vm/src/poseidon2/trace.rs
@@ -43,9 +43,9 @@ impl<const WIDTH: usize, F: PrimeField32> MachineChip<F> for Poseidon2Chip<WIDTH
 }
 impl<const WIDTH: usize, F: PrimeField32> Poseidon2Chip<WIDTH, F> {
     pub fn blank_row(&self) -> Poseidon2VmCols<WIDTH, F> {
-        let timestamp = self.memory_manager.borrow().timestamp();
+        let timestamp = self.memory_chip.borrow().timestamp();
         let mut blank = Poseidon2VmCols::<WIDTH, F>::blank_row(&self.air.inner, timestamp);
-        let mut mem_trace_builder = MemoryTraceBuilder::new(self.memory_manager.clone());
+        let mut mem_trace_builder = MemoryTraceBuilder::new(self.memory_chip.clone());
         for _ in 0..3 {
             mem_trace_builder.disabled_read(blank.io.d);
             mem_trace_builder.increment_clk();


### PR DESCRIPTION
* Rename `MemoryManager` to `MemoryChip`
* Change memory state to use new type `TimestampedValue` rather than `AccessCell`
* Remove `WORD_SIZE` from `MemoryAuditChip`

Resolves INT-1994