### PR TITLE
refactor: Inteface for batch read/write

### DIFF
--- a/vm/src/arch/testing/memory/mod.rs
+++ b/vm/src/arch/testing/memory/mod.rs
@@ -50,7 +50,7 @@ impl<F: PrimeField32> MemoryTester<F> {
         let read = RefCell::borrow_mut(&self.chip).read_cell(addr_space, pointer);
         let address = MemoryAddress::new(addr_space, pointer);
         self.records
-            .push(self.bus.read(address, read.data, read.prev_timestamp));
+            .push(self.bus.read(address, read.data, read.prev_timestamps[0]));
         self.records
             .push(self.bus.write(address, read.data, read.timestamp));
         read.value()
@@ -62,7 +62,7 @@ impl<F: PrimeField32> MemoryTester<F> {
         let address = MemoryAddress::new(addr_space, pointer);
         self.records.push(
             self.bus
-                .read(address, write.prev_data, write.prev_timestamp),
+                .read(address, write.prev_data, write.prev_timestamps[0]),
         );
         self.records
             .push(self.bus.write(address, write.data, write.timestamp));

--- a/vm/src/cpu/columns.rs
+++ b/vm/src/cpu/columns.rs
@@ -206,12 +206,12 @@ impl<T: Clone> CpuAuxCols<T> {
         let reads_aux_cols = array::from_fn(|_| {
             start = end;
             end += MemoryReadAuxCols::<WORD_SIZE, T>::width(&cpu_air.memory_offline_checker);
-            MemoryReadAuxCols::from_slice(&slc[start..end])
+            MemoryReadAuxCols::from_slice(&slc[start..end], cpu_air.memory_offline_checker)
         });
         let writes_aux_cols = array::from_fn(|_| {
             start = end;
             end += MemoryWriteAuxCols::<WORD_SIZE, T>::width(&cpu_air.memory_offline_checker);
-            MemoryWriteAuxCols::from_slice(&slc[start..end])
+            MemoryWriteAuxCols::from_slice(&slc[start..end], cpu_air.memory_offline_checker)
         });
 
         Self {

--- a/vm/src/field_extension/chip.rs
+++ b/vm/src/field_extension/chip.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 pub const BETA: usize = 11;
-pub const EXTENSION_DEGREE: usize = 4;
+pub const EXT_DEG: usize = 4;
 
 /// Records an arithmetic operation that happened at run-time.
 #[derive(Clone, Debug)]
@@ -28,15 +28,15 @@ pub(crate) struct FieldExtensionArithmeticRecord<F> {
     /// Timestamp at start of instruction
     pub(crate) timestamp: usize,
     pub(crate) instruction: Instruction<F>,
-    pub(crate) x: [F; EXTENSION_DEGREE],
-    pub(crate) y: [F; EXTENSION_DEGREE],
-    pub(crate) z: [F; EXTENSION_DEGREE],
+    pub(crate) x: [F; EXT_DEG],
+    pub(crate) y: [F; EXT_DEG],
+    pub(crate) z: [F; EXT_DEG],
     /// Memory accesses for reading `x`.
-    pub(crate) x_reads: [MemoryReadRecord<1, F>; EXTENSION_DEGREE],
+    pub(crate) x_read: MemoryReadRecord<EXT_DEG, F>,
     /// Memory accesses for reading `y`.
-    pub(crate) y_reads: [MemoryReadRecord<1, F>; EXTENSION_DEGREE],
+    pub(crate) y_read: MemoryReadRecord<EXT_DEG, F>,
     /// Memory accesses for writing `z`.
-    pub(crate) z_writes: [MemoryWriteRecord<1, F>; EXTENSION_DEGREE],
+    pub(crate) z_write: MemoryWriteRecord<EXT_DEG, F>,
 }
 
 /// A chip for performing arithmetic operations over the field extension
@@ -76,14 +76,14 @@ impl<F: PrimeField32> FieldExtensionArithmeticChip<F> {
 
     pub fn accesses_per_instruction(opcode: Opcode) -> usize {
         assert!(FIELD_EXTENSION_INSTRUCTIONS.contains(&opcode));
-        3 * EXTENSION_DEGREE
+        3 * EXT_DEG
     }
 
     pub fn process(
         &mut self,
         instruction: Instruction<F>,
         from_state: ExecutionState<usize>,
-    ) -> [F; EXTENSION_DEGREE] {
+    ) -> [F; EXT_DEG] {
         let Instruction {
             opcode,
             op_a,
@@ -96,15 +96,19 @@ impl<F: PrimeField32> FieldExtensionArithmeticChip<F> {
 
         assert!(FIELD_EXTENSION_INSTRUCTIONS.contains(&opcode));
 
-        let x_reads = self.read_extension_element(d, op_b);
-        let x: [F; EXTENSION_DEGREE] = array::from_fn(|i| x_reads[i].value());
+        assert_ne!(d, F::zero());
+        assert_ne!(e, F::zero());
 
-        let y_reads = self.read_extension_element(e, op_c);
-        let y: [F; EXTENSION_DEGREE] = array::from_fn(|i| y_reads[i].value());
+        let mut memory_chip = self.memory_chip.borrow_mut();
+
+        let x_read = memory_chip.read(d, op_b);
+        let x: [F; EXT_DEG] = x_read.data;
+
+        let y_read = memory_chip.read(e, op_c);
+        let y: [F; EXT_DEG] = y_read.data;
 
         let z = FieldExtensionArithmetic::solve(opcode, x, y).unwrap();
-
-        let z_writes = self.write_extension_element(d, op_a, z);
+        let z_write = memory_chip.write(d, op_a, z);
 
         self.records.push(FieldExtensionArithmeticRecord {
             timestamp: from_state.timestamp,
@@ -113,43 +117,12 @@ impl<F: PrimeField32> FieldExtensionArithmeticChip<F> {
             x,
             y,
             z,
-            x_reads,
-            y_reads,
-            z_writes,
+            x_read,
+            y_read,
+            z_write,
         });
 
         z
-    }
-
-    fn read_extension_element(
-        &mut self,
-        address_space: F,
-        address: F,
-    ) -> [MemoryReadRecord<1, F>; EXTENSION_DEGREE] {
-        assert_ne!(address_space, F::zero());
-
-        array::from_fn(|i| {
-            self.memory_chip
-                .borrow_mut()
-                .read_cell(address_space, address + F::from_canonical_usize(i))
-        })
-    }
-
-    fn write_extension_element(
-        &mut self,
-        address_space: F,
-        address: F,
-        result: [F; EXTENSION_DEGREE],
-    ) -> [MemoryWriteRecord<1, F>; EXTENSION_DEGREE] {
-        assert_ne!(address_space, F::zero());
-
-        array::from_fn(|i| {
-            self.memory_chip.borrow_mut().write_cell(
-                address_space,
-                address + F::from_canonical_usize(i),
-                result[i],
-            )
-        })
     }
 
     pub fn current_height(&self) -> usize {
@@ -165,9 +138,9 @@ impl FieldExtensionArithmetic {
     /// Returns None for opcodes not in cpu::FIELD_EXTENSION_INSTRUCTIONS.
     pub(crate) fn solve<T: Field>(
         op: Opcode,
-        x: [T; EXTENSION_DEGREE],
-        y: [T; EXTENSION_DEGREE],
-    ) -> Option<[T; EXTENSION_DEGREE]> {
+        x: [T; EXT_DEG],
+        y: [T; EXT_DEG],
+    ) -> Option<[T; EXT_DEG]> {
         match op {
             Opcode::FE4ADD => Some(Self::add(x, y)),
             Opcode::FE4SUB => Some(Self::subtract(x, y)),
@@ -177,10 +150,7 @@ impl FieldExtensionArithmetic {
         }
     }
 
-    pub(crate) fn add<V, E>(
-        x: [V; EXTENSION_DEGREE],
-        y: [V; EXTENSION_DEGREE],
-    ) -> [E; EXTENSION_DEGREE]
+    pub(crate) fn add<V, E>(x: [V; EXT_DEG], y: [V; EXT_DEG]) -> [E; EXT_DEG]
     where
         V: Copy,
         V: Add<V, Output = E>,
@@ -188,10 +158,7 @@ impl FieldExtensionArithmetic {
         array::from_fn(|i| x[i] + y[i])
     }
 
-    pub(crate) fn subtract<V, E>(
-        x: [V; EXTENSION_DEGREE],
-        y: [V; EXTENSION_DEGREE],
-    ) -> [E; EXTENSION_DEGREE]
+    pub(crate) fn subtract<V, E>(x: [V; EXT_DEG], y: [V; EXT_DEG]) -> [E; EXT_DEG]
     where
         V: Copy,
         V: Sub<V, Output = E>,
@@ -199,10 +166,7 @@ impl FieldExtensionArithmetic {
         array::from_fn(|i| x[i] - y[i])
     }
 
-    pub(crate) fn multiply<V, E>(
-        x: [V; EXTENSION_DEGREE],
-        y: [V; EXTENSION_DEGREE],
-    ) -> [E; EXTENSION_DEGREE]
+    pub(crate) fn multiply<V, E>(x: [V; EXT_DEG], y: [V; EXT_DEG]) -> [E; EXT_DEG]
     where
         E: AbstractField,
         V: Copy,
@@ -221,14 +185,11 @@ impl FieldExtensionArithmetic {
         ]
     }
 
-    pub(crate) fn divide<F: Field>(
-        x: [F; EXTENSION_DEGREE],
-        y: [F; EXTENSION_DEGREE],
-    ) -> [F; EXTENSION_DEGREE] {
+    pub(crate) fn divide<F: Field>(x: [F; EXT_DEG], y: [F; EXT_DEG]) -> [F; EXT_DEG] {
         Self::multiply(x, Self::invert(y))
     }
 
-    pub(crate) fn invert<T: Field>(a: [T; EXTENSION_DEGREE]) -> [T; EXTENSION_DEGREE] {
+    pub(crate) fn invert<T: Field>(a: [T; EXT_DEG]) -> [T; EXT_DEG] {
         // Let a = (a0, a1, a2, a3) represent the element we want to invert.
         // Define a' = (a0, -a1, a2, -a3).  By construction, the product b = a * a' will have zero
         // degree-1 and degree-3 coefficients.

--- a/vm/src/field_extension/columns.rs
+++ b/vm/src/field_extension/columns.rs
@@ -4,7 +4,7 @@ use afs_derive::AlignedBorrow;
 use afs_primitives::is_less_than::IsLessThanAir;
 
 use crate::{
-    field_extension::{air::FieldExtensionArithmeticAir, chip::EXTENSION_DEGREE},
+    field_extension::{air::FieldExtensionArithmeticAir, chip::EXT_DEG},
     memory::offline_checker::{
         bridge::MemoryOfflineChecker,
         columns::{MemoryOfflineCheckerAuxCols, MemoryReadAuxCols, MemoryWriteAuxCols},
@@ -30,9 +30,9 @@ pub struct FieldExtensionArithmeticIoCols<T> {
     pub op_c: T,
     pub d: T,
     pub e: T,
-    pub x: [T; EXTENSION_DEGREE],
-    pub y: [T; EXTENSION_DEGREE],
-    pub z: [T; EXTENSION_DEGREE],
+    pub x: [T; EXT_DEG],
+    pub y: [T; EXT_DEG],
+    pub z: [T; EXT_DEG],
 }
 
 #[repr(C)]
@@ -48,13 +48,13 @@ pub struct FieldExtensionArithmeticAuxCols<T> {
     // whether the opcode is BBE4DIV
     pub is_div: T,
     /// `divisor_inv` is y.inverse() when opcode is BBE4DIV and zero otherwise.
-    pub divisor_inv: [T; EXTENSION_DEGREE],
+    pub divisor_inv: [T; EXT_DEG],
     /// The aux columns for the x reads.
-    pub read_x_aux_cols: [MemoryOfflineCheckerAuxCols<1, T>; EXTENSION_DEGREE],
+    pub read_x_aux_cols: MemoryOfflineCheckerAuxCols<EXT_DEG, T>,
     /// The aux columns for the y reads.
-    pub read_y_aux_cols: [MemoryOfflineCheckerAuxCols<1, T>; EXTENSION_DEGREE],
+    pub read_y_aux_cols: MemoryOfflineCheckerAuxCols<EXT_DEG, T>,
     /// The aux columns for the z writes.
-    pub write_aux_cols: [MemoryOfflineCheckerAuxCols<1, T>; EXTENSION_DEGREE],
+    pub write_aux_cols: MemoryOfflineCheckerAuxCols<EXT_DEG, T>,
 }
 
 impl<T> FieldExtensionArithmeticCols<T> {
@@ -86,9 +86,9 @@ impl<T> FieldExtensionArithmeticCols<T> {
                 is_mul: next(),
                 is_div: next(),
                 divisor_inv: array::from_fn(|_| next()),
-                read_x_aux_cols: array::from_fn(|_| MemoryReadAuxCols::try_from_iter(iter, lt_air)),
-                read_y_aux_cols: array::from_fn(|_| MemoryReadAuxCols::try_from_iter(iter, lt_air)),
-                write_aux_cols: array::from_fn(|_| MemoryWriteAuxCols::try_from_iter(iter, lt_air)),
+                read_x_aux_cols: MemoryReadAuxCols::try_from_iter(iter, lt_air),
+                read_y_aux_cols: MemoryReadAuxCols::try_from_iter(iter, lt_air),
+                write_aux_cols: MemoryWriteAuxCols::try_from_iter(iter, lt_air),
             },
         }
     }
@@ -130,7 +130,7 @@ impl<T: Clone> FieldExtensionArithmeticIoCols<T> {
 
 impl<T> FieldExtensionArithmeticAuxCols<T> {
     pub fn get_width(oc: &MemoryOfflineChecker) -> usize {
-        EXTENSION_DEGREE + 5 + 12 * MemoryOfflineCheckerAuxCols::<1, T>::width(oc)
+        EXT_DEG + 5 + 3 * MemoryOfflineCheckerAuxCols::<EXT_DEG, T>::width(oc)
     }
 }
 
@@ -144,15 +144,9 @@ impl<T: Clone> FieldExtensionArithmeticAuxCols<T> {
             self.is_div.clone(),
         ];
         result.extend_from_slice(&self.divisor_inv);
-        for mem_oc_aux_cols in self.read_x_aux_cols.iter().cloned() {
-            result.extend(mem_oc_aux_cols.flatten());
-        }
-        for mem_oc_aux_cols in self.read_y_aux_cols.iter().cloned() {
-            result.extend(mem_oc_aux_cols.flatten());
-        }
-        for mem_oc_aux_cols in self.write_aux_cols.iter().cloned() {
-            result.extend(mem_oc_aux_cols.flatten());
-        }
+        result.extend(self.read_x_aux_cols.clone().flatten());
+        result.extend(self.read_y_aux_cols.clone().flatten());
+        result.extend(self.write_aux_cols.clone().flatten());
         result
     }
 }

--- a/vm/src/memory/offline_checker/columns.rs
+++ b/vm/src/memory/offline_checker/columns.rs
@@ -29,26 +29,29 @@ pub type MemoryWriteAuxCols<const WORD_SIZE: usize, T> = MemoryOfflineCheckerAux
 pub struct MemoryOfflineCheckerAuxCols<const WORD_SIZE: usize, T> {
     // TODO[jpw]: Remove this; read does not need old_data
     pub(super) prev_data: [T; WORD_SIZE],
-    pub(super) prev_timestamp: T,
+    // TODO[zach]: Should be just prev_timestamp: T.
+    pub(super) prev_timestamps: [T; WORD_SIZE],
     pub(super) is_immediate: T,
     pub(super) is_zero_aux: T,
     // TODO[jpw]: IsLessThan should be optimized to AssertLessThan
-    pub(super) clk_lt: T,
-    pub(super) clk_lt_aux: IsLessThanAuxCols<T>,
+    // TODO[zach]: Should be just clk_lt: T.
+    pub(super) clk_lt: [T; WORD_SIZE],
+    // TODO[zach]: Should be just clk_lt_aux: IsLessThanAuxCols<T>.
+    pub(super) clk_lt_aux: [IsLessThanAuxCols<T>; WORD_SIZE],
 }
 
 impl<const WORD_SIZE: usize, T> MemoryOfflineCheckerAuxCols<WORD_SIZE, T> {
     pub fn new(
         prev_data: [T; WORD_SIZE],
-        prev_timestamp: T,
+        prev_timestamps: [T; WORD_SIZE],
         is_immediate: T,
         is_zero_aux: T,
-        clk_lt: T,
-        clk_lt_aux: IsLessThanAuxCols<T>,
+        clk_lt: [T; WORD_SIZE],
+        clk_lt_aux: [IsLessThanAuxCols<T>; WORD_SIZE],
     ) -> Self {
         Self {
             prev_data,
-            prev_timestamp,
+            prev_timestamps,
             is_immediate,
             is_zero_aux,
             clk_lt,
@@ -60,11 +63,11 @@ impl<const WORD_SIZE: usize, T> MemoryOfflineCheckerAuxCols<WORD_SIZE, T> {
 // Straightforward implementations for from_slice, flatten, width functions for the above structs below
 
 impl<const WORD_SIZE: usize, T: Clone> MemoryOfflineCheckerCols<WORD_SIZE, T> {
-    pub fn from_slice(slc: &[T]) -> Self {
+    pub fn from_slice(slc: &[T], oc: MemoryOfflineChecker) -> Self {
         let op_width = MemoryOperation::<WORD_SIZE, T>::width();
         Self {
             io: MemoryOperation::<WORD_SIZE, T>::from_slice(&slc[..op_width]),
-            aux: MemoryOfflineCheckerAuxCols::<WORD_SIZE, T>::from_slice(&slc[op_width..]),
+            aux: MemoryOfflineCheckerAuxCols::<WORD_SIZE, T>::from_slice(&slc[op_width..], oc),
         }
     }
 }
@@ -85,14 +88,19 @@ impl<const WORD_SIZE: usize, T> MemoryOfflineCheckerCols<WORD_SIZE, T> {
 }
 
 impl<const WORD_SIZE: usize, T: Clone> MemoryOfflineCheckerAuxCols<WORD_SIZE, T> {
-    pub fn from_slice(slc: &[T]) -> Self {
+    pub fn from_slice(slc: &[T], oc: MemoryOfflineChecker) -> Self {
+        let mut pos = 3 * WORD_SIZE + 2;
         Self {
             prev_data: array::from_fn(|i| slc[i].clone()),
-            prev_timestamp: slc[WORD_SIZE].clone(),
-            is_immediate: slc[WORD_SIZE + 1].clone(),
-            is_zero_aux: slc[WORD_SIZE + 2].clone(),
-            clk_lt: slc[WORD_SIZE + 3].clone(),
-            clk_lt_aux: IsLessThanAuxCols::from_slice(&slc[WORD_SIZE + 4..]),
+            prev_timestamps: array::from_fn(|i| slc[WORD_SIZE + i].clone()),
+            is_immediate: slc[2 * WORD_SIZE].clone(),
+            is_zero_aux: slc[2 * WORD_SIZE + 1].clone(),
+            clk_lt: array::from_fn(|i| slc[2 * WORD_SIZE + 2 + i].clone()),
+            clk_lt_aux: array::from_fn(|_| {
+                let width = IsLessThanAuxCols::<T>::width(&oc.timestamp_lt_air);
+                pos += width;
+                IsLessThanAuxCols::from_slice(&slc[pos - width..pos])
+            }),
         }
     }
 }
@@ -101,33 +109,33 @@ impl<const WORD_SIZE: usize, T> MemoryOfflineCheckerAuxCols<WORD_SIZE, T> {
     pub fn flatten(self) -> Vec<T> {
         self.prev_data
             .into_iter()
-            .chain(iter::once(self.prev_timestamp))
+            .chain(self.prev_timestamps)
             .chain(iter::once(self.is_immediate))
             .chain(iter::once(self.is_zero_aux))
-            .chain(iter::once(self.clk_lt))
-            .chain(self.clk_lt_aux.flatten())
+            .chain(self.clk_lt)
+            .chain(self.clk_lt_aux.into_iter().flat_map(|x| x.flatten()))
             .collect()
     }
 
     pub fn try_from_iter<I: Iterator<Item = T>>(iter: &mut I, lt_air: &IsLessThanAir) -> Self {
         Self {
             prev_data: array::from_fn(|_| iter.next().unwrap()),
-            prev_timestamp: iter.next().unwrap(),
+            prev_timestamps: array::from_fn(|_| iter.next().unwrap()),
             is_immediate: iter.next().unwrap(),
             is_zero_aux: iter.next().unwrap(),
-            clk_lt: iter.next().unwrap(),
-            clk_lt_aux: IsLessThanAuxCols::try_from_iter(iter, lt_air),
+            clk_lt: array::from_fn(|_| iter.next().unwrap()),
+            clk_lt_aux: array::from_fn(|_| IsLessThanAuxCols::try_from_iter(iter, lt_air)),
         }
     }
 
     pub fn width(oc: &MemoryOfflineChecker) -> usize {
-        WORD_SIZE + 4 + IsLessThanAuxCols::<T>::width(&oc.timestamp_lt_air)
+        3 * WORD_SIZE + 2 + WORD_SIZE * IsLessThanAuxCols::<T>::width(&oc.timestamp_lt_air)
     }
 }
 
 impl<const WORD_SIZE: usize, F: Field> MemoryOfflineCheckerAuxCols<WORD_SIZE, F> {
     pub fn disabled(mem_oc: MemoryOfflineChecker) -> Self {
-        let width = MemoryReadAuxCols::<1, F>::width(&mem_oc);
-        MemoryOfflineCheckerAuxCols::from_slice(&vec![F::zero(); width])
+        let width = MemoryReadAuxCols::<WORD_SIZE, F>::width(&mem_oc);
+        MemoryOfflineCheckerAuxCols::from_slice(&vec![F::zero(); width], mem_oc)
     }
 }

--- a/vm/src/memory/offline_checker/tests.rs
+++ b/vm/src/memory/offline_checker/tests.rs
@@ -17,7 +17,9 @@ use crate::{
     memory::{
         manager::{dimensions::MemoryDimensions, trace_builder::MemoryTraceBuilder, MemoryChip},
         offline_checker::{
-            bridge::MemoryOfflineChecker, bus::MemoryBus, columns::MemoryOfflineCheckerCols,
+            bridge::MemoryOfflineChecker,
+            bus::MemoryBus,
+            columns::{MemoryOfflineCheckerAuxCols, MemoryOfflineCheckerCols},
             operation::MemoryOperation,
         },
     },
@@ -43,7 +45,10 @@ impl<AB: InteractionBuilder> Air<AB> for OfflineCheckerDummyAir {
         let main = &builder.main();
 
         let local = main.row_slice(0);
-        let local = MemoryOfflineCheckerCols::<TEST_WORD_SIZE, AB::Var>::from_slice(&local);
+        let local = MemoryOfflineCheckerCols::<TEST_WORD_SIZE, AB::Var>::from_slice(
+            &local,
+            self.offline_checker,
+        );
 
         self.offline_checker
             .subair_eval(builder, local.io.into_expr::<AB>(), local.aux, true);
@@ -140,6 +145,11 @@ fn volatile_memory_offline_checker_test() {
     let accesses_buffer = mem_trace_builder.take_accesses_buffer();
     let mut checker_trace = vec![];
     for (op, aux_cols) in zip_eq(mem_ops, accesses_buffer) {
+        println!(
+            "{} {}",
+            MemoryOfflineCheckerAuxCols::<1, Val>::width(&offline_checker),
+            aux_cols.clone().flatten().len()
+        );
         checker_trace.extend(op.flatten());
         checker_trace.extend(aux_cols.flatten());
     }

--- a/vm/src/poseidon2/columns.rs
+++ b/vm/src/poseidon2/columns.rs
@@ -182,7 +182,10 @@ impl<const WIDTH: usize, T: Clone> Poseidon2VmAuxCols<WIDTH, T> {
         for _ in 0..3 + 2 * WIDTH {
             start = end;
             end += MemoryOfflineCheckerAuxCols::<1, T>::width(&air.mem_oc);
-            mem_oc_aux_cols.push(MemoryOfflineCheckerAuxCols::from_slice(&slc[start..end]));
+            mem_oc_aux_cols.push(MemoryOfflineCheckerAuxCols::from_slice(
+                &slc[start..end],
+                air.mem_oc,
+            ));
         }
 
         Self {

--- a/vm/tests/integration_test.rs
+++ b/vm/tests/integration_test.rs
@@ -241,6 +241,7 @@ fn test_vm_field_extension_arithmetic() {
         Instruction::from_isize(STOREW, 1, 6, 0, 0, 1),
         Instruction::from_isize(STOREW, 2, 7, 0, 0, 1),
         Instruction::from_isize(FE4ADD, 8, 0, 4, 1, 1),
+        Instruction::from_isize(FE4ADD, 8, 0, 4, 1, 1),
         Instruction::from_isize(FE4SUB, 12, 0, 4, 1, 1),
         Instruction::from_isize(BBE4MUL, 12, 0, 4, 1, 1),
         Instruction::from_isize(BBE4DIV, 12, 0, 4, 1, 1),


### PR DESCRIPTION
Add MemoryChip::read and MemoryChip::write. Note that the interface is slightly leaky; when you call memory_bridge.read/write with MemoryOfflineCheckerAuxCols<N>, the timestamp must be incremented by N (while a true batch access would only increment timestamp by 1).

Closes INT-1988