### PR TITLE
chore: make `VecAutoHintable` not generic in `C`

### DIFF
--- a/recursion/src/fri/hints.rs
+++ b/recursion/src/fri/hints.rs
@@ -29,7 +29,7 @@ impl Hintable<C> for InnerDigest {
     }
 }
 
-impl VecAutoHintable<C> for InnerDigest {}
+impl VecAutoHintable for InnerDigest {}
 
 impl Hintable<C> for InnerCommitPhaseStep {
     type HintVariable = FriCommitPhaseProofStepVariable<C>;
@@ -53,7 +53,7 @@ impl Hintable<C> for InnerCommitPhaseStep {
     }
 }
 
-impl VecAutoHintable<C> for InnerCommitPhaseStep {}
+impl VecAutoHintable for InnerCommitPhaseStep {}
 
 impl Hintable<C> for InnerQueryProof {
     type HintVariable = FriQueryProofVariable<C>;
@@ -76,7 +76,7 @@ impl Hintable<C> for InnerQueryProof {
     }
 }
 
-impl VecAutoHintable<C> for InnerQueryProof {}
+impl VecAutoHintable for InnerQueryProof {}
 
 impl Hintable<C> for InnerFriProof {
     type HintVariable = FriProofVariable<C>;
@@ -132,8 +132,8 @@ impl Hintable<C> for InnerBatchOpening {
     }
 }
 
-impl VecAutoHintable<C> for InnerBatchOpening {}
-impl VecAutoHintable<C> for Vec<InnerBatchOpening> {}
+impl VecAutoHintable for InnerBatchOpening {}
+impl VecAutoHintable for Vec<InnerBatchOpening> {}
 
 impl Hintable<C> for InnerPcsProof {
     type HintVariable = TwoAdicPcsProofVariable<C>;

--- a/recursion/src/hints.rs
+++ b/recursion/src/hints.rs
@@ -94,24 +94,26 @@ impl Hintable<InnerConfig> for InnerChallenge {
     }
 }
 
-pub trait VecAutoHintable<C: Config>: Hintable<C> {}
+/// Implement this on a type `T` that also implements `Hintable<C: Config>`
+/// so that `Hintable<C>` is auto implemented on `Vec<T>`
+pub trait VecAutoHintable {}
 
-impl VecAutoHintable<InnerConfig> for Vec<usize> {}
+impl VecAutoHintable for Vec<usize> {}
 
-impl VecAutoHintable<InnerConfig> for Vec<InnerVal> {}
+impl VecAutoHintable for Vec<InnerVal> {}
 
-impl VecAutoHintable<InnerConfig> for Vec<Vec<InnerChallenge>> {}
+impl VecAutoHintable for Vec<Vec<InnerChallenge>> {}
 
-impl VecAutoHintable<InnerConfig> for AdjacentOpenedValues<InnerChallenge> {}
+impl VecAutoHintable for AdjacentOpenedValues<InnerChallenge> {}
 
-impl VecAutoHintable<InnerConfig> for Vec<AdjacentOpenedValues<InnerChallenge>> {}
+impl VecAutoHintable for Vec<AdjacentOpenedValues<InnerChallenge>> {}
 
-impl VecAutoHintable<InnerConfig> for Vec<Vec<AdjacentOpenedValues<InnerChallenge>>> {}
+impl VecAutoHintable for Vec<Vec<AdjacentOpenedValues<InnerChallenge>>> {}
 
-impl<I: VecAutoHintable<InnerConfig>> Hintable<InnerConfig> for Vec<I> {
-    type HintVariable = Array<InnerConfig, I::HintVariable>;
+impl<C: Config, I: VecAutoHintable + Hintable<C>> Hintable<C> for Vec<I> {
+    type HintVariable = Array<C, I::HintVariable>;
 
-    fn read(builder: &mut Builder<InnerConfig>) -> Self::HintVariable {
+    fn read(builder: &mut Builder<C>) -> Self::HintVariable {
         let len = builder.hint_var();
         let mut arr = builder.dyn_array(len);
         builder.range(0, len).for_each(|i, builder| {
@@ -121,10 +123,10 @@ impl<I: VecAutoHintable<InnerConfig>> Hintable<InnerConfig> for Vec<I> {
         arr
     }
 
-    fn write(&self) -> Vec<Vec<<InnerConfig as Config>::N>> {
+    fn write(&self) -> Vec<Vec<<C as Config>::N>> {
         let mut stream = Vec::new();
 
-        let len = InnerVal::from_canonical_usize(self.len());
+        let len = C::N::from_canonical_usize(self.len());
         stream.push(vec![len]);
 
         self.iter().for_each(|i| {


### PR DESCRIPTION
Previously `VecAutoHintable` was generic in `C` and then the auto-implementation of `Vec<I>` for `I: VecAutoHintable<C>` was only done for `C = InnerConfig`. I tried to make it generci in `C`, but then it says that another crate may implement `VecAutoHintable<C>` for `u8` since `C` can be user-defined. This kind of defeats the purpose of `VecAutoHintable` overall, so instead I make `VecAutoHintable` not generic in `C` at all. This seems fine for all of our use cases -- we could separately add a `VecAutoHintableConfigSpecific<C>` that then auto implemented `VecAutoHintable` if we wanted to further gate some implementations, but that seems overkill for now.