### PR TITLE
[chore] set/set_value of Array doesn't require `&mut`

### DIFF
--- a/compiler/src/ir/bits.rs
+++ b/compiler/src/ir/bits.rs
@@ -133,16 +133,16 @@ impl<C: Config> Builder<C> {
         let bit_len = bit_len.into();
         let num_bits = NUM_BITS;
 
-        let mut result_bits = self.dyn_array::<Var<_>>(num_bits);
+        let result_bits = self.dyn_array::<Var<_>>(num_bits);
         self.range(0, bit_len).for_each(|i, builder| {
             let idx = builder.eval_expr(bit_len - i - RVar::one());
             let entry = builder.get(index_bits, idx);
-            builder.set_value(&mut result_bits, i, entry);
+            builder.set_value(&result_bits, i, entry);
         });
 
         let zero = self.eval(C::N::zero());
         self.range(bit_len, num_bits).for_each(|i, builder| {
-            builder.set_value(&mut result_bits, i, zero);
+            builder.set_value(&result_bits, i, zero);
         });
 
         result_bits

--- a/compiler/src/ir/collections.rs
+++ b/compiler/src/ir/collections.rs
@@ -133,11 +133,11 @@ impl<C: Config, V: MemVariable<C>> Array<C, V> {
                 }
 
                 let slice_len = builder.eval_expr(end - start);
-                let mut slice = builder.dyn_array(slice_len);
+                let slice = builder.dyn_array(slice_len);
                 builder.range(0, slice_len).for_each(|i, builder| {
                     let idx = builder.eval_expr(start + i);
                     let value = builder.get(self, idx);
-                    builder.set(&mut slice, i, value);
+                    builder.set(&slice, i, value);
                 });
 
                 slice
@@ -280,7 +280,7 @@ impl<C: Config> Builder<C> {
 
     pub fn set<V: MemVariable<C>, I: Into<RVar<C::N>>, Expr: Into<V::Expression>>(
         &mut self,
-        slice: &mut Array<C, V>,
+        slice: &Array<C, V>,
         index: I,
         value: Expr,
     ) {
@@ -314,7 +314,7 @@ impl<C: Config> Builder<C> {
 
     pub fn set_value<V: MemVariable<C>, I: Into<RVar<C::N>>>(
         &mut self,
-        slice: &mut Array<C, V>,
+        slice: &Array<C, V>,
         index: I,
         value: V,
     ) {
@@ -474,10 +474,10 @@ impl<C: Config, V: FromConstant<C> + MemVariable<C>> FromConstant<C> for Array<C
     type Constant = Vec<V::Constant>;
 
     fn constant(value: Self::Constant, builder: &mut Builder<C>) -> Self {
-        let mut array = builder.dyn_array(value.len());
+        let array = builder.dyn_array(value.len());
         for (i, val) in value.into_iter().enumerate() {
             let val = V::constant(val, builder);
-            builder.set(&mut array, i, val);
+            builder.set(&array, i, val);
         }
         array
     }

--- a/compiler/src/ir/modular_arithmetic.rs
+++ b/compiler/src/ir/modular_arithmetic.rs
@@ -25,11 +25,11 @@ where
     C::N: PrimeField64,
 {
     pub fn eval_bigint(&mut self, bigint: BigUint) -> BigIntVar<C> {
-        let mut array = self.dyn_array(NUM_ELEMS);
+        let array = self.dyn_array(NUM_ELEMS);
 
         let elems: Vec<C::N> = bigint_to_elems(bigint, REPR_BITS, NUM_ELEMS);
         for (i, &elem) in elems.iter().enumerate() {
-            self.set(&mut array, i, elem);
+            self.set(&array, i, elem);
         }
 
         array

--- a/compiler/src/ir/poseidon.rs
+++ b/compiler/src/ir/poseidon.rs
@@ -47,12 +47,12 @@ impl<C: Config> Builder<C> {
         right: &Array<C, Felt<C::F>>,
     ) -> Array<C, Felt<C::F>> {
         let perm_width = PERMUTATION_WIDTH;
-        let mut input = self.dyn_array(perm_width);
+        let input = self.dyn_array(perm_width);
         for i in 0..DIGEST_SIZE {
             let a = self.get(left, i);
             let b = self.get(right, i);
-            self.set(&mut input, i, a);
-            self.set(&mut input, i + DIGEST_SIZE, b);
+            self.set(&input, i, a);
+            self.set(&input, i + DIGEST_SIZE, b);
         }
         self.poseidon2_permute_mut(&input);
         input
@@ -79,9 +79,9 @@ impl<C: Config> Builder<C> {
     /// Reference: [p3_symmetric::PaddingFreeSponge]
     pub fn poseidon2_hash(&mut self, array: &Array<C, Felt<C::F>>) -> Array<C, Felt<C::F>> {
         let perm_width = PERMUTATION_WIDTH;
-        let mut state: Array<C, Felt<C::F>> = self.dyn_array(perm_width);
+        let state: Array<C, Felt<C::F>> = self.dyn_array(perm_width);
         self.range(0, perm_width).for_each(|i, builder| {
-            builder.set(&mut state, i, C::F::zero());
+            builder.set(&state, i, C::F::zero());
         });
 
         let break_flag: Var<_> = self.eval(C::N::zero());
@@ -102,7 +102,7 @@ impl<C: Config> Builder<C> {
                     .for_each(|j, builder| {
                         let index = builder.eval_expr(i + j);
                         let element = builder.get(array, index);
-                        builder.set_value(&mut state, j, element);
+                        builder.set_value(&state, j, element);
                         builder
                             .if_eq(index, last_index.clone())
                             .then_may_break(|builder| {
@@ -125,9 +125,9 @@ impl<C: Config> Builder<C> {
     ) -> Array<C, Felt<C::F>> {
         self.cycle_tracker_start("poseidon2-hash");
         let perm_width = PERMUTATION_WIDTH;
-        let mut state: Array<C, Felt<C::F>> = self.dyn_array(perm_width);
+        let state: Array<C, Felt<C::F>> = self.dyn_array(perm_width);
         self.range(0, perm_width).for_each(|i, builder| {
-            builder.set(&mut state, i, C::F::zero());
+            builder.set(&state, i, C::F::zero());
         });
 
         let idx: Var<_> = self.eval(C::N::zero());
@@ -136,7 +136,7 @@ impl<C: Config> Builder<C> {
             builder.range(0, subarray.len()).for_each(|j, builder| {
                 builder.cycle_tracker_start("poseidon2-hash-setup");
                 let element = builder.get(&subarray, j);
-                builder.set_value(&mut state, idx, element);
+                builder.set_value(&state, idx, element);
                 builder.assign(&idx, idx + C::N::one());
                 builder.cycle_tracker_end("poseidon2-hash-setup");
                 builder
@@ -164,9 +164,9 @@ impl<C: Config> Builder<C> {
         self.cycle_tracker_start("poseidon2-hash-ext");
         let hash_rate = HASH_RATE;
         let perm_width = PERMUTATION_WIDTH;
-        let mut state: Array<C, Felt<C::F>> = self.dyn_array(perm_width);
+        let state: Array<C, Felt<C::F>> = self.dyn_array(perm_width);
         self.range(hash_rate, perm_width).for_each(|i, builder| {
-            builder.set(&mut state, i, C::F::zero());
+            builder.set(&state, i, C::F::zero());
         });
 
         let idx: Var<_> = self.eval(C::N::zero());
@@ -177,7 +177,7 @@ impl<C: Config> Builder<C> {
                 let felts = builder.ext2felt(element);
                 for i in 0..4 {
                     let felt = builder.get(&felts, i);
-                    builder.set_value(&mut state, idx, felt);
+                    builder.set_value(&state, idx, felt);
                     builder.assign(&idx, idx + C::N::one());
                     builder
                         .if_eq(idx, C::N::from_canonical_usize(HASH_RATE))

--- a/compiler/tests/array.rs
+++ b/compiler/tests/array.rs
@@ -27,11 +27,11 @@ pub struct Point<C: Config> {
 //     let len: usize = 1000;
 //     let mut rng = thread_rng();
 //
-//     let mut static_array = builder.array::<Var<_>>(len);
+//     let static_array = builder.array::<Var<_>>(len);
 //
 //     // Put values statically
 //     for i in 0..len {
-//         builder.set(&mut static_array, i, F::one());
+//         builder.set(&static_array, i, F::one());
 //     }
 //     // Assert values set.
 //     for i in 0..len {
@@ -40,18 +40,18 @@ pub struct Point<C: Config> {
 //     }
 //
 //     let dyn_len: Var<_> = builder.eval(F::from_canonical_usize(len));
-//     let mut var_array = builder.array::<Var<_>>(dyn_len);
-//     let mut felt_array = builder.array::<Felt<_>>(dyn_len);
-//     let mut ext_array = builder.array::<Ext<_, _>>(dyn_len);
+//     let var_array = builder.array::<Var<_>>(dyn_len);
+//     let felt_array = builder.array::<Felt<_>>(dyn_len);
+//     let ext_array = builder.array::<Ext<_, _>>(dyn_len);
 //     // Put values statically
 //     let var_vals = (0..len).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
 //     let felt_vals = (0..len).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
 //     let ext_vals = (0..len).map(|_| rng.gen::<EF>()).collect::<Vec<_>>();
 //     for i in 0..len {
 //
-//         builder.set(&mut var_array, i, var_vals[i]);
-//         builder.set(&mut felt_array, i, felt_vals[i]);
-//         builder.set(&mut ext_array, i, ext_vals[i].cons());
+//         builder.set(&var_array, i, var_vals[i]);
+//         builder.set(&felt_array, i, felt_vals[i]);
+//         builder.set(&ext_array, i, ext_vals[i].cons());
 //     }
 //     // Assert values set.
 //     for i in 0..len {
@@ -65,9 +65,9 @@ pub struct Point<C: Config> {
 //
 //     // Put values dynamically
 //     builder.range(0, dyn_len).for_each(|i, builder| {
-//         builder.set(&mut var_array, i, i * 2);
-//         builder.set(&mut felt_array, i, F::from_canonical_u32(3));
-//         builder.set(&mut ext_array, i, EF::from_canonical_u32(4).cons());
+//         builder.set(&var_array, i, i * 2);
+//         builder.set(&felt_array, i, F::from_canonical_u32(3));
+//         builder.set(&ext_array, i, EF::from_canonical_u32(4).cons());
 //     });
 //
 //     // Assert values set.
@@ -81,14 +81,14 @@ pub struct Point<C: Config> {
 //     });
 //
 //     // Test the derived macro and mixed size allocations.
-//     let mut point_array = builder.dyn_array::<Point<_>>(len);
+//     let point_array = builder.dyn_array::<Point<_>>(len);
 //
 //     builder.range(0, dyn_len).for_each(|i, builder| {
 //         let x: Var<_> = builder.eval(F::two());
 //         let y: Felt<_> = builder.eval(F::one());
 //         let z: Ext<_, _> = builder.eval(EF::one().cons());
 //         let point = Point { x, y, z };
-//         builder.set(&mut point_array, i, point);
+//         builder.set(&point_array, i, point);
 //     });
 //
 //     builder.range(0, dyn_len).for_each(|i, builder| {
@@ -98,10 +98,10 @@ pub struct Point<C: Config> {
 //         builder.assert_ext_eq(point.z, EF::one().cons());
 //     });
 //
-//     let mut array = builder.dyn_array::<Array<_, Var<_>>>(len);
+//     let array = builder.dyn_array::<Array<_, Var<_>>>(len);
 //
 //     builder.range(0, array.len()).for_each(|i, builder| {
-//         builder.set(&mut array, i, var_array.clone());
+//         builder.set(&array, i, var_array.clone());
 //     });
 //
 //     // TODO: this part of the test is extremely slow.
@@ -125,19 +125,19 @@ fn test_fixed_array_const() {
 
     // Sum all the values of an array.
     let len: usize = 1000;
-    let mut fixed_array = builder.vec(vec![Usize::from(1); len]);
+    let fixed_array = builder.vec(vec![Usize::from(1); len]);
 
     // Put values statically
     builder.range(0, fixed_array.len()).for_each(|i, builder| {
-        builder.set_value(&mut fixed_array, i, Usize::from(2));
+        builder.set_value(&fixed_array, i, Usize::from(2));
     });
     // Assert values set.
     builder.range(0, fixed_array.len()).for_each(|i, builder| {
         let value = builder.get(&fixed_array, i);
         builder.assert_eq::<Usize<_>>(value, Usize::from(2));
     });
-    let mut fixed_2d = builder.uninit_fixed_array(1);
-    builder.set_value(&mut fixed_2d, RVar::zero(), fixed_array);
+    let fixed_2d = builder.uninit_fixed_array(1);
+    builder.set_value(&fixed_2d, RVar::zero(), fixed_array);
 
     assert_eq!(
         builder.operations.vec.len(),
@@ -155,13 +155,13 @@ fn test_fixed_array_var() {
 
     // Sum all the values of an array.
     let len: usize = 1000;
-    let mut fixed_array = builder.uninit_fixed_array(len);
+    let fixed_array = builder.uninit_fixed_array(len);
 
     // Put values statically
     builder.range(0, fixed_array.len()).for_each(|i, builder| {
         let one: Var<_> = builder.eval(F::one());
         // `len` instructions
-        builder.set(&mut fixed_array, i, Usize::Var(one));
+        builder.set(&fixed_array, i, Usize::Var(one));
     });
     // Assert values set.
     builder.range(0, fixed_array.len()).for_each(|i, builder| {
@@ -170,8 +170,8 @@ fn test_fixed_array_var() {
         // `len` instructions of `assert_eq`
         builder.assert_eq::<Var<_>>(value, RVar::from(2));
     });
-    let mut fixed_2d = builder.uninit_fixed_array(1);
-    builder.set_value(&mut fixed_2d, RVar::zero(), fixed_array);
+    let fixed_2d = builder.uninit_fixed_array(1);
+    builder.set_value(&fixed_2d, RVar::zero(), fixed_array);
 
     assert_eq!(
         builder.operations.vec.len(),
@@ -186,12 +186,12 @@ fn test_array_eq() {
     type EF = BinomialExtensionField<BabyBear, 4>;
 
     let mut builder = AsmBuilder::<F, EF>::default();
-    let mut arr1: Array<_, Var<_>> = builder.dyn_array(2);
-    builder.set(&mut arr1, 0, F::one());
-    builder.set(&mut arr1, 1, F::two());
-    let mut arr2: Array<_, Var<_>> = builder.dyn_array(2);
-    builder.set(&mut arr2, 0, F::one());
-    builder.set(&mut arr2, 1, F::two());
+    let arr1: Array<_, Var<_>> = builder.dyn_array(2);
+    builder.set(&arr1, 0, F::one());
+    builder.set(&arr1, 1, F::two());
+    let arr2: Array<_, Var<_>> = builder.dyn_array(2);
+    builder.set(&arr2, 0, F::one());
+    builder.set(&arr2, 1, F::two());
     builder.assert_var_array_eq(&arr1, &arr2);
 
     builder.halt();
@@ -207,12 +207,12 @@ fn test_array_eq_neg() {
     type EF = BinomialExtensionField<BabyBear, 4>;
 
     let mut builder = AsmBuilder::<F, EF>::default();
-    let mut arr1: Array<_, Var<_>> = builder.dyn_array(2);
-    builder.set(&mut arr1, 0, F::one());
-    builder.set(&mut arr1, 1, F::two());
-    let mut arr2: Array<_, Var<_>> = builder.dyn_array(2);
-    builder.set(&mut arr2, 0, F::one());
-    builder.set(&mut arr2, 1, F::one());
+    let arr1: Array<_, Var<_>> = builder.dyn_array(2);
+    builder.set(&arr1, 0, F::one());
+    builder.set(&arr1, 1, F::two());
+    let arr2: Array<_, Var<_>> = builder.dyn_array(2);
+    builder.set(&arr2, 0, F::one());
+    builder.set(&arr2, 1, F::one());
     builder.assert_var_array_eq(&arr1, &arr2);
 
     builder.halt();

--- a/compiler/tests/for_loops.rs
+++ b/compiler/tests/for_loops.rs
@@ -55,14 +55,14 @@ fn test_compiler_nested_array_loop() {
     let outer_len = 100;
     let inner_len = 10;
 
-    let mut array: Array<C, Array<C, Var<_>>> = builder.dyn_array(outer_len);
+    let array: Array<C, Array<C, Var<_>>> = builder.dyn_array(outer_len);
 
     builder.range(0, array.len()).for_each(|i, builder| {
-        let mut inner_array = builder.dyn_array::<Var<_>>(inner_len);
+        let inner_array = builder.dyn_array::<Var<_>>(inner_len);
         builder.range(0, inner_array.len()).for_each(|j, builder| {
-            builder.set(&mut inner_array, j, i + j); //(j * F::from_canonical_u16(300)));
+            builder.set(&inner_array, j, i + j); //(j * F::from_canonical_u16(300)));
         });
-        builder.set(&mut array, i, inner_array);
+        builder.set(&array, i, inner_array);
     });
 
     // Test that the array is correctly initialized.
@@ -89,13 +89,13 @@ fn test_compiler_break() {
     let len = 100;
     let break_len = 10;
 
-    let mut array: Array<C, Var<_>> = builder.dyn_array(len);
+    let array: Array<C, Var<_>> = builder.dyn_array(len);
 
     builder
         .range(0, array.len())
         .may_break()
         .for_each(|i, builder| {
-            builder.set(&mut array, i, i);
+            builder.set(&array, i, i);
 
             builder
                 .if_eq(i, RVar::from(break_len))
@@ -125,7 +125,7 @@ fn test_compiler_break() {
 
     // Test the break instructions in a nested loop.
 
-    let mut array: Array<C, Var<_>> = builder.dyn_array(len);
+    let array: Array<C, Var<_>> = builder.dyn_array(len);
     builder
         .range(0, array.len())
         .may_break()
@@ -139,7 +139,7 @@ fn test_compiler_break() {
                     .then_may_break(|builder| builder.break_loop())
             });
 
-            builder.set(&mut array, i, counter);
+            builder.set(&array, i, counter);
             Ok(())
         });
 
@@ -174,12 +174,12 @@ fn test_compiler_constant_break() {
     let len = 100;
     let break_len = 10;
 
-    let mut array: Array<C, Var<_>> = builder.uninit_fixed_array(len);
+    let array: Array<C, Var<_>> = builder.uninit_fixed_array(len);
     builder
         .range(0, array.len())
         .may_break()
         .for_each(|i, builder| {
-            builder.set(&mut array, i, i);
+            builder.set(&array, i, i);
 
             builder
                 .if_eq(i, RVar::from(break_len))
@@ -200,12 +200,12 @@ fn test_compiler_constant_var_break() {
     let len = 100;
     let break_len: Var<_> = builder.eval(RVar::from(10));
 
-    let mut array: Array<C, Var<_>> = builder.uninit_fixed_array(len);
+    let array: Array<C, Var<_>> = builder.uninit_fixed_array(len);
     builder
         .range(0, array.len())
         .may_break()
         .for_each(|i, builder| {
-            builder.set(&mut array, i, i);
+            builder.set(&array, i, i);
 
             builder
                 .if_eq(i, RVar::from(break_len))

--- a/compiler/tests/keccak256.rs
+++ b/compiler/tests/keccak256.rs
@@ -24,14 +24,14 @@ fn run_e2e_keccak_test(inputs: Vec<Vec<u8>>, expected_outputs: Vec<[u8; 32]>) {
 
     for (input, output) in zip(inputs, expected_outputs) {
         let len: Var<_> = builder.eval(F::from_canonical_usize(input.len()));
-        let mut input_arr = builder.dyn_array(len);
+        let input_arr = builder.dyn_array(len);
         for (i, byte) in input.into_iter().enumerate() {
-            builder.set(&mut input_arr, i, F::from_canonical_u8(byte));
+            builder.set(&input_arr, i, F::from_canonical_u8(byte));
         }
-        let mut expected: Array<_, Var<_>> = builder.dyn_array(KECCAK_DIGEST_U16S);
+        let expected: Array<_, Var<_>> = builder.dyn_array(KECCAK_DIGEST_U16S);
         for i in 0..KECCAK_DIGEST_U16S {
             builder.set(
-                &mut expected,
+                &expected,
                 i,
                 F::from_canonical_u16(output[2 * i] as u16 + ((output[2 * i + 1] as u16) << 8)),
             );

--- a/compiler/tests/poseidon2.rs
+++ b/compiler/tests/poseidon2.rs
@@ -27,9 +27,9 @@ fn test_compiler_poseidon2_permute() {
     // Execture the permutation in the VM
     // Initialize an array and populate it with the entries.
     let var_width: Var<F> = builder.eval(F::from_canonical_usize(PERMUTATION_WIDTH));
-    let mut random_state = builder.array(var_width);
+    let random_state = builder.array(var_width);
     for (i, val) in random_state_vals.iter().enumerate() {
-        builder.set(&mut random_state, i, *val);
+        builder.set(&random_state, i, *val);
     }
 
     // Assert that the values are set correctly.
@@ -62,16 +62,16 @@ fn test_compiler_poseidon2_hash_1() {
     let random_state_vals: [F; 42] = rng.gen();
     println!("{:?}", random_state_vals);
     let rlen = random_state_vals.len();
-    let mut random_state_v1 = builder.dyn_array(rlen);
+    let random_state_v1 = builder.dyn_array(rlen);
     for (i, val) in random_state_vals.iter().enumerate() {
-        builder.set(&mut random_state_v1, i, *val);
+        builder.set(&random_state_v1, i, *val);
     }
-    let mut random_state_v2 = builder.dyn_array(rlen);
+    let random_state_v2 = builder.dyn_array(rlen);
     for (i, val) in random_state_vals.iter().enumerate() {
-        builder.set(&mut random_state_v2, i, *val);
+        builder.set(&random_state_v2, i, *val);
     }
-    let mut nested_random_state = builder.dyn_array(RVar::one());
-    builder.set(&mut nested_random_state, RVar::zero(), random_state_v2);
+    let nested_random_state = builder.dyn_array(RVar::one());
+    builder.set(&nested_random_state, RVar::zero(), random_state_v2);
 
     let result = builder.poseidon2_hash(&random_state_v1);
     let result_x = builder.poseidon2_hash_x(&nested_random_state);

--- a/compiler/tests/ptr_struct.rs
+++ b/compiler/tests/ptr_struct.rs
@@ -28,11 +28,11 @@ fn test_compiler_array() {
     let len: usize = 3;
     let mut rng = thread_rng();
 
-    let mut static_array = builder.array::<Var<_>>(len);
+    let static_array = builder.array::<Var<_>>(len);
 
     // Put values statically
     for i in 0..len {
-        builder.set(&mut static_array, i, F::one());
+        builder.set(&static_array, i, F::one());
     }
     // Assert values set.
     for i in 0..len {
@@ -41,17 +41,17 @@ fn test_compiler_array() {
     }
 
     let dyn_len: Var<_> = builder.eval(F::from_canonical_usize(len));
-    let mut var_array = builder.array::<Var<_>>(dyn_len);
-    let mut felt_array = builder.array::<Felt<_>>(dyn_len);
-    let mut ext_array = builder.array::<Ext<_, _>>(dyn_len);
+    let var_array = builder.array::<Var<_>>(dyn_len);
+    let felt_array = builder.array::<Felt<_>>(dyn_len);
+    let ext_array = builder.array::<Ext<_, _>>(dyn_len);
     // Put values statically
     let var_vals = (0..len).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
     let felt_vals = (0..len).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
     let ext_vals = (0..len).map(|_| rng.gen::<EF>()).collect::<Vec<_>>();
     for i in 0..len {
-        builder.set(&mut var_array, i, var_vals[i]);
-        builder.set(&mut felt_array, i, felt_vals[i]);
-        builder.set(&mut ext_array, i, ext_vals[i].cons());
+        builder.set(&var_array, i, var_vals[i]);
+        builder.set(&felt_array, i, felt_vals[i]);
+        builder.set(&ext_array, i, ext_vals[i].cons());
     }
     // Assert values set.
     for i in 0..len {
@@ -66,12 +66,12 @@ fn test_compiler_array() {
     // Put values dynamically
     builder.range(0, dyn_len).for_each(|i, builder| {
         builder.set(
-            &mut var_array,
+            &var_array,
             i,
             i * RVar::from_field(F::from_canonical_u32(2)),
         );
-        builder.set(&mut felt_array, i, F::from_canonical_u32(3));
-        builder.set(&mut ext_array, i, EF::from_canonical_u32(4).cons());
+        builder.set(&felt_array, i, F::from_canonical_u32(3));
+        builder.set(&ext_array, i, EF::from_canonical_u32(4).cons());
     });
 
     // Assert values set.
@@ -85,7 +85,7 @@ fn test_compiler_array() {
     });
 
     // Test the derived macro and mixed size allocations.
-    let mut point_array = builder.dyn_array::<Point<_>>(len);
+    let point_array = builder.dyn_array::<Point<_>>(len);
 
     builder.range(0, dyn_len).for_each(|i, builder| {
         let x: Var<_> = builder.eval(F::two());
@@ -102,7 +102,7 @@ fn test_compiler_array() {
             y: y_ptr,
             z: z_ptr,
         };
-        builder.set(&mut point_array, i, point);
+        builder.set(&point_array, i, point);
     });
 
     builder.range(0, dyn_len).for_each(|i, builder| {
@@ -115,10 +115,10 @@ fn test_compiler_array() {
         builder.assert_ext_eq(z, EF::one().cons());
     });
 
-    let mut array = builder.dyn_array::<Array<_, Var<_>>>(len);
+    let array = builder.dyn_array::<Array<_, Var<_>>>(len);
 
     builder.range(0, array.len()).for_each(|i, builder| {
-        builder.set(&mut array, i, var_array.clone());
+        builder.set(&array, i, var_array.clone());
     });
 
     // TODO: this part of the test is extremely slow.

--- a/compiler/tests/public_values.rs
+++ b/compiler/tests/public_values.rs
@@ -20,9 +20,9 @@ fn test_compiler_public_values() {
     let b: Felt<_> = builder.constant(public_value_1);
 
     let dyn_len: Var<_> = builder.eval(F::from_canonical_usize(2));
-    let mut var_array = builder.dyn_array::<Felt<_>>(dyn_len);
-    builder.set(&mut var_array, RVar::zero(), a);
-    builder.set(&mut var_array, RVar::one(), b);
+    let var_array = builder.dyn_array::<Felt<_>>(dyn_len);
+    builder.set(&var_array, RVar::zero(), a);
+    builder.set(&var_array, RVar::one(), b);
 
     builder.commit_public_values(&var_array);
 
@@ -47,9 +47,9 @@ fn test_compiler_public_values_no_initial() {
     let b: Felt<_> = builder.constant(public_value_1);
 
     let dyn_len: Var<_> = builder.eval(F::from_canonical_usize(2));
-    let mut var_array = builder.dyn_array::<Felt<_>>(dyn_len);
-    builder.set(&mut var_array, RVar::zero(), a);
-    builder.set(&mut var_array, RVar::one(), b);
+    let var_array = builder.dyn_array::<Felt<_>>(dyn_len);
+    builder.set(&var_array, RVar::zero(), a);
+    builder.set(&var_array, RVar::one(), b);
 
     builder.commit_public_values(&var_array);
 
@@ -72,9 +72,9 @@ fn test_compiler_public_values_negative() {
     let b: Felt<_> = builder.constant(public_value_1);
 
     let dyn_len: Var<_> = builder.eval(F::from_canonical_usize(2));
-    let mut var_array = builder.dyn_array::<Felt<_>>(dyn_len);
-    builder.set(&mut var_array, RVar::zero(), a);
-    builder.set(&mut var_array, RVar::one(), b);
+    let var_array = builder.dyn_array::<Felt<_>>(dyn_len);
+    builder.set(&var_array, RVar::zero(), a);
+    builder.set(&var_array, RVar::one(), b);
 
     builder.commit_public_values(&var_array);
 

--- a/recursion/src/challenger/duplex.rs
+++ b/recursion/src/challenger/duplex.rs
@@ -25,14 +25,14 @@ pub struct DuplexChallengerVariable<C: Config> {
 impl<C: Config> DuplexChallengerVariable<C> {
     /// Creates a new duplex challenger with the default state.
     pub fn new(builder: &mut Builder<C>) -> Self {
-        let mut sponge_state = builder.dyn_array(PERMUTATION_WIDTH);
-        let mut input_buffer = builder.dyn_array(PERMUTATION_WIDTH);
-        let mut output_buffer = builder.dyn_array(PERMUTATION_WIDTH);
+        let sponge_state = builder.dyn_array(PERMUTATION_WIDTH);
+        let input_buffer = builder.dyn_array(PERMUTATION_WIDTH);
+        let output_buffer = builder.dyn_array(PERMUTATION_WIDTH);
 
         builder.range(0, sponge_state.len()).for_each(|i, builder| {
-            builder.set(&mut sponge_state, i, C::F::zero());
-            builder.set(&mut input_buffer, i, C::F::zero());
-            builder.set(&mut output_buffer, i, C::F::zero());
+            builder.set(&sponge_state, i, C::F::zero());
+            builder.set(&input_buffer, i, C::F::zero());
+            builder.set(&output_buffer, i, C::F::zero());
         });
 
         DuplexChallengerVariable::<C> {
@@ -46,22 +46,22 @@ impl<C: Config> DuplexChallengerVariable<C> {
     /// Creates a new challenger with the same state as an existing challenger.
     #[allow(dead_code)]
     pub fn copy(&self, builder: &mut Builder<C>) -> Self {
-        let mut sponge_state = builder.dyn_array(PERMUTATION_WIDTH);
+        let sponge_state = builder.dyn_array(PERMUTATION_WIDTH);
         builder.range(0, PERMUTATION_WIDTH).for_each(|i, builder| {
             let element = builder.get(&self.sponge_state, i);
-            builder.set(&mut sponge_state, i, element);
+            builder.set(&sponge_state, i, element);
         });
         let nb_inputs = builder.eval(self.nb_inputs);
-        let mut input_buffer = builder.dyn_array(PERMUTATION_WIDTH);
+        let input_buffer = builder.dyn_array(PERMUTATION_WIDTH);
         builder.range(0, PERMUTATION_WIDTH).for_each(|i, builder| {
             let element = builder.get(&self.input_buffer, i);
-            builder.set(&mut input_buffer, i, element);
+            builder.set(&input_buffer, i, element);
         });
         let nb_outputs = builder.eval(self.nb_outputs);
-        let mut output_buffer = builder.dyn_array(PERMUTATION_WIDTH);
+        let output_buffer = builder.dyn_array(PERMUTATION_WIDTH);
         builder.range(0, PERMUTATION_WIDTH).for_each(|i, builder| {
             let element = builder.get(&self.output_buffer, i);
-            builder.set(&mut output_buffer, i, element);
+            builder.set(&output_buffer, i, element);
         });
         DuplexChallengerVariable::<C> {
             sponge_state,
@@ -99,22 +99,22 @@ impl<C: Config> DuplexChallengerVariable<C> {
         let zero: Var<_> = builder.eval(C::N::zero());
         let zero_felt: Felt<_> = builder.eval(C::F::zero());
         builder.range(0, PERMUTATION_WIDTH).for_each(|i, builder| {
-            builder.set(&mut self.sponge_state, i, zero_felt);
+            builder.set(&self.sponge_state, i, zero_felt);
         });
         builder.assign(&self.nb_inputs, zero);
         builder.range(0, PERMUTATION_WIDTH).for_each(|i, builder| {
-            builder.set(&mut self.input_buffer, i, zero_felt);
+            builder.set(&self.input_buffer, i, zero_felt);
         });
         builder.assign(&self.nb_outputs, zero);
         builder.range(0, PERMUTATION_WIDTH).for_each(|i, builder| {
-            builder.set(&mut self.output_buffer, i, zero_felt);
+            builder.set(&self.output_buffer, i, zero_felt);
         });
     }
 
     pub fn duplexing(&mut self, builder: &mut Builder<C>) {
         builder.range(0, self.nb_inputs).for_each(|i, builder| {
             let element = builder.get(&self.input_buffer, i);
-            builder.set(&mut self.sponge_state, i, element);
+            builder.set(&self.sponge_state, i, element);
         });
         builder.assign(&self.nb_inputs, C::N::zero());
 
@@ -124,7 +124,7 @@ impl<C: Config> DuplexChallengerVariable<C> {
 
         for i in 0..PERMUTATION_WIDTH {
             let element = builder.get(&self.sponge_state, i);
-            builder.set(&mut self.output_buffer, i, element);
+            builder.set(&self.output_buffer, i, element);
             builder.assign(&self.nb_outputs, self.nb_outputs + C::N::one());
         }
     }
@@ -132,7 +132,7 @@ impl<C: Config> DuplexChallengerVariable<C> {
     fn observe(&mut self, builder: &mut Builder<C>, value: Felt<C::F>) {
         builder.assign(&self.nb_outputs, C::N::zero());
 
-        builder.set(&mut self.input_buffer, self.nb_inputs, value);
+        builder.set(&self.input_buffer, self.nb_inputs, value);
         builder.assign(&self.nb_inputs, self.nb_inputs + C::N::one());
 
         builder
@@ -183,10 +183,10 @@ impl<C: Config> DuplexChallengerVariable<C> {
         C::N: Field,
     {
         let rand_f = self.sample(builder);
-        let mut bits = builder.num2bits_f(rand_f, C::N::bits() as u32);
+        let bits = builder.num2bits_f(rand_f, C::N::bits() as u32);
 
         builder.range(nb_bits, bits.len()).for_each(|i, builder| {
-            builder.set(&mut bits, i, C::N::zero());
+            builder.set(&bits, i, C::N::zero());
         });
 
         bits

--- a/recursion/src/digest.rs
+++ b/recursion/src/digest.rs
@@ -92,18 +92,18 @@ impl<C: Config> FromConstant<C> for DigestVariable<C> {
     fn constant(value: Self::Constant, builder: &mut Builder<C>) -> Self {
         match value {
             DigestVal::F(value) => {
-                let mut array = builder.array(value.len());
+                let array = builder.array(value.len());
                 for (i, val) in value.into_iter().enumerate() {
                     let val = Felt::constant(val, builder);
-                    builder.set(&mut array, i, val);
+                    builder.set(&array, i, val);
                 }
                 Self::Felt(array)
             }
             DigestVal::N(value) => {
-                let mut array = builder.array(value.len());
+                let array = builder.array(value.len());
                 for (i, val) in value.into_iter().enumerate() {
                     let val = Var::constant(val, builder);
-                    builder.set(&mut array, i, val);
+                    builder.set(&array, i, val);
                 }
                 Self::Var(array)
             }

--- a/recursion/src/fri/domain.rs
+++ b/recursion/src/fri/domain.rs
@@ -104,7 +104,7 @@ where
 
         let domain_power: Felt<_> = builder.eval(C::F::one());
 
-        let mut domains = builder.array(num_chunks);
+        let domains = builder.array(num_chunks);
 
         builder.range(0, num_chunks).for_each(|i, builder| {
             let log_n = builder.eval(log_n);
@@ -116,7 +116,7 @@ where
             };
             // FIXME: here must use `builder.set_value`. `builder.set` will convert `Usize::Const`
             // to `Usize::Var` because it calls `builder.eval`.
-            builder.set_value(&mut domains, i, domain);
+            builder.set_value(&domains, i, domain);
             builder.assign(&domain_power, domain_power * g_dom);
         });
 

--- a/recursion/src/fri/mod.rs
+++ b/recursion/src/fri/mod.rs
@@ -34,7 +34,7 @@ pub fn verify_shape_and_sample_challenges<C: Config>(
     proof: &FriProofVariable<C>,
     challenger: &mut impl ChallengerVariable<C>,
 ) -> FriChallengesVariable<C> {
-    let mut betas: Array<C, Ext<C::F, C::EF>> = builder.array(proof.commit_phase_commits.len());
+    let betas: Array<C, Ext<C::F, C::EF>> = builder.array(proof.commit_phase_commits.len());
 
     builder
         .range(0, proof.commit_phase_commits.len())
@@ -42,7 +42,7 @@ pub fn verify_shape_and_sample_challenges<C: Config>(
             let comm = builder.get(&proof.commit_phase_commits, i);
             challenger.observe_digest(builder, comm);
             let sample = challenger.sample_ext(builder);
-            builder.set(&mut betas, i, sample);
+            builder.set(&betas, i, sample);
         });
 
     let num_query_proofs = proof.query_proofs.len().clone();
@@ -56,10 +56,10 @@ pub fn verify_shape_and_sample_challenges<C: Config>(
 
     let log_max_height =
         builder.eval_expr(proof.commit_phase_commits.len() + RVar::from(config.log_blowup));
-    let mut query_indices = builder.array(config.num_queries);
+    let query_indices = builder.array(config.num_queries);
     builder.range(0, config.num_queries).for_each(|i, builder| {
         let index_bits = challenger.sample_bits(builder, log_max_height);
-        builder.set(&mut query_indices, i, index_bits);
+        builder.set(&query_indices, i, index_bits);
     });
 
     FriChallengesVariable {
@@ -154,7 +154,7 @@ where
             let i_plus_one = builder.eval_expr(i + RVar::one());
             let index_pair = index_bits.shift(builder, i_plus_one);
 
-            let mut evals: Array<C, Ext<C::F, C::EF>> = builder.array(2);
+            let evals: Array<C, Ext<C::F, C::EF>> = builder.array(2);
             let eval_0: Ext<C::F, C::EF>;
             let eval_1: Ext<C::F, C::EF>;
             if builder.flags.static_only {
@@ -164,13 +164,13 @@ where
                     step.sibling_value,
                     folded_eval,
                 );
-                builder.set_value(&mut evals, 0, eval_0);
-                builder.set_value(&mut evals, 1, eval_1);
+                builder.set_value(&evals, 0, eval_0);
+                builder.set_value(&evals, 1, eval_1);
             } else {
-                builder.set_value(&mut evals, 0, folded_eval);
-                builder.set_value(&mut evals, 1, folded_eval);
+                builder.set_value(&evals, 0, folded_eval);
+                builder.set_value(&evals, 1, folded_eval);
                 // This is faster than branching.
-                builder.set_value(&mut evals, index_sibling_mod_2, step.sibling_value);
+                builder.set_value(&evals, index_sibling_mod_2, step.sibling_value);
                 eval_0 = builder.get(&evals, 0);
                 eval_1 = builder.get(&evals, 1);
             }
@@ -178,11 +178,11 @@ where
             let dims = DimensionsVariable::<C> {
                 height: builder.sll(C::N::one(), log_folded_height),
             };
-            let mut dims_slice: Array<C, DimensionsVariable<C>> = builder.array(1);
-            builder.set_value(&mut dims_slice, 0, dims);
+            let dims_slice: Array<C, DimensionsVariable<C>> = builder.array(1);
+            builder.set_value(&dims_slice, 0, dims);
 
-            let mut opened_values = builder.array(1);
-            builder.set_value(&mut opened_values, 0, evals);
+            let opened_values = builder.array(1);
+            builder.set_value(&opened_values, 0, evals);
             builder.cycle_tracker_start("verify-batch-ext");
             verify_batch::<C>(
                 builder,
@@ -410,7 +410,7 @@ where
 {
     builder.cycle_tracker_start("verify-batch-reduce-fast");
     let nb_opened_values: Usize<_> = builder.eval(C::N::zero());
-    let mut nested_opened_values = builder.array(8192);
+    let nested_opened_values = builder.array(8192);
     let start_dim_idx: Usize<_> = builder.eval(dim_idx.clone());
     builder.cycle_tracker_start("verify-batch-reduce-fast-setup");
     builder
@@ -422,7 +422,7 @@ where
                 .then(|builder| {
                     let opened_values = builder.get(opened_values, i);
                     builder.set_value(
-                        &mut nested_opened_values,
+                        &nested_opened_values,
                         nb_opened_values.clone(),
                         opened_values.clone(),
                     );

--- a/recursion/src/hints.rs
+++ b/recursion/src/hints.rs
@@ -115,10 +115,10 @@ impl<C: Config, I: VecAutoHintable + Hintable<C>> Hintable<C> for Vec<I> {
 
     fn read(builder: &mut Builder<C>) -> Self::HintVariable {
         let len = builder.hint_var();
-        let mut arr = builder.dyn_array(len);
+        let arr = builder.dyn_array(len);
         builder.range(0, len).for_each(|i, builder| {
             let hint = I::read(builder);
-            builder.set(&mut arr, i, hint);
+            builder.set(&arr, i, hint);
         });
         arr
     }
@@ -234,10 +234,10 @@ impl Hintable<InnerConfig> for Vec<Vec<InnerChallenge>> {
 
     fn read(builder: &mut Builder<InnerConfig>) -> Self::HintVariable {
         let len = builder.hint_var();
-        let mut arr = builder.dyn_array(len);
+        let arr = builder.dyn_array(len);
         builder.range(0, len).for_each(|i, builder| {
             let hint = Vec::<InnerChallenge>::read(builder);
-            builder.set(&mut arr, i, hint);
+            builder.set(&arr, i, hint);
         });
         arr
     }

--- a/recursion/src/utils.rs
+++ b/recursion/src/utils.rs
@@ -10,11 +10,11 @@ pub fn const_fri_config<C: Config>(
     params: &FriParameters,
 ) -> FriConfigVariable<C> {
     let two_adicity = C::F::TWO_ADICITY;
-    let mut generators = builder.array(two_adicity);
-    let mut subgroups = builder.array(two_adicity);
+    let generators = builder.array(two_adicity);
+    let subgroups = builder.array(two_adicity);
     for i in 0..C::F::TWO_ADICITY {
         let constant_generator = C::F::two_adic_generator(i);
-        builder.set(&mut generators, i, constant_generator);
+        builder.set(&generators, i, constant_generator);
 
         let constant_domain = TwoAdicMultiplicativeCoset {
             log_n: i,
@@ -23,7 +23,7 @@ pub fn const_fri_config<C: Config>(
         let domain_value: TwoAdicMultiplicativeCosetVariable<_> = builder.constant(constant_domain);
         // FIXME: here must use `builder.set_value`. `builder.set` will convert `Usize::Const`
         // to `Usize::Var` because it calls `builder.eval`.
-        builder.set_value(&mut subgroups, i, domain_value);
+        builder.set_value(&subgroups, i, domain_value);
     }
     FriConfigVariable {
         log_blowup: params.log_blowup,


### PR DESCRIPTION
`Array::Fixed` owns `RefCell` so `&mut` is unnecessary now. Move this chore change from #341 .