### PR TITLE
refactor: Move `instruction` in `InstructionExecutor`

### DIFF
--- a/vm/src/arch/chips.rs
+++ b/vm/src/arch/chips.rs
@@ -24,7 +24,7 @@ use crate::{
 pub trait InstructionExecutor<F> {
     fn execute(
         &mut self,
-        instruction: &Instruction<F>,
+        instruction: Instruction<F>,
         from_state: ExecutionState<usize>,
     ) -> ExecutionState<usize>;
 }
@@ -48,7 +48,7 @@ pub trait MachineChip<F> {
 impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for Rc<RefCell<C>> {
     fn execute(
         &mut self,
-        instruction: &Instruction<F>,
+        instruction: Instruction<F>,
         prev_state: ExecutionState<usize>,
     ) -> ExecutionState<usize> {
         self.borrow_mut().execute(instruction, prev_state)

--- a/vm/src/arch/testing/execution/mod.rs
+++ b/vm/src/arch/testing/execution/mod.rs
@@ -48,15 +48,16 @@ impl<F: PrimeField32> ExecutionTester<F> {
         };
         tracing::debug!(?initial_state.timestamp);
 
+        let instruction_cols = InstructionCols::from_instruction(&instruction);
         let final_state = executor.execute(
-            &instruction,
+            instruction,
             initial_state.map(|x| x.as_canonical_u32() as usize),
         );
         self.records.push(DummyExecutionInteractionCols {
             count: F::neg_one(), // send
             initial_state,
             final_state: final_state.map(F::from_canonical_usize),
-            instruction: InstructionCols::from_instruction(&instruction),
+            instruction: instruction_cols,
         })
     }
 

--- a/vm/src/cpu/trace.rs
+++ b/vm/src/cpu/trace.rs
@@ -295,7 +295,7 @@ impl<F: PrimeField32> CpuChip<F> {
                 let executor = vm.executors.get_mut(&opcode).unwrap();
                 let next_state = InstructionExecutor::execute(
                     executor,
-                    &instruction,
+                    instruction,
                     ExecutionState::new(pc_usize, timestamp),
                 );
                 next_pc = F::from_canonical_usize(next_state.pc);

--- a/vm/src/field_arithmetic/mod.rs
+++ b/vm/src/field_arithmetic/mod.rs
@@ -58,7 +58,7 @@ impl<F: PrimeField32> FieldArithmeticChip<F> {
 impl<F: PrimeField32> InstructionExecutor<F> for FieldArithmeticChip<F> {
     fn execute(
         &mut self,
-        instruction: &Instruction<F>,
+        instruction: Instruction<F>,
         from_state: ExecutionState<usize>,
     ) -> ExecutionState<usize> {
         let Instruction {
@@ -70,7 +70,7 @@ impl<F: PrimeField32> InstructionExecutor<F> for FieldArithmeticChip<F> {
             e: x_as,
             op_f: y_as,
             ..
-        } = instruction.clone();
+        } = instruction;
         assert!(FIELD_ARITHMETIC_INSTRUCTIONS.contains(&opcode));
 
         let mut memory_chip = self.memory_chip.borrow_mut();

--- a/vm/src/field_extension/chip.rs
+++ b/vm/src/field_extension/chip.rs
@@ -51,39 +51,9 @@ pub struct FieldExtensionArithmeticChip<F: PrimeField32> {
 impl<F: PrimeField32> InstructionExecutor<F> for FieldExtensionArithmeticChip<F> {
     fn execute(
         &mut self,
-        instruction: &Instruction<F>,
-        from_state: ExecutionState<usize>,
-    ) -> ExecutionState<usize> {
-        self.process(instruction.clone(), from_state);
-
-        ExecutionState {
-            pc: from_state.pc + 1,
-            timestamp: from_state.timestamp + Self::accesses_per_instruction(instruction.opcode),
-        }
-    }
-}
-
-impl<F: PrimeField32> FieldExtensionArithmeticChip<F> {
-    pub fn new(execution_bus: ExecutionBus, memory: MemoryChipRef<F>) -> Self {
-        let air =
-            FieldExtensionArithmeticAir::new(execution_bus, memory.borrow().make_offline_checker());
-        Self {
-            air,
-            records: vec![],
-            memory_chip: memory,
-        }
-    }
-
-    pub fn accesses_per_instruction(opcode: Opcode) -> usize {
-        assert!(FIELD_EXTENSION_INSTRUCTIONS.contains(&opcode));
-        3 * EXT_DEG
-    }
-
-    pub fn process(
-        &mut self,
         instruction: Instruction<F>,
         from_state: ExecutionState<usize>,
-    ) -> [F; EXT_DEG] {
+    ) -> ExecutionState<usize> {
         let Instruction {
             opcode,
             op_a,
@@ -122,7 +92,27 @@ impl<F: PrimeField32> FieldExtensionArithmeticChip<F> {
             z_write,
         });
 
-        z
+        ExecutionState {
+            pc: from_state.pc + 1,
+            timestamp: from_state.timestamp + Self::accesses_per_instruction(opcode),
+        }
+    }
+}
+
+impl<F: PrimeField32> FieldExtensionArithmeticChip<F> {
+    pub fn new(execution_bus: ExecutionBus, memory: MemoryChipRef<F>) -> Self {
+        let air =
+            FieldExtensionArithmeticAir::new(execution_bus, memory.borrow().make_offline_checker());
+        Self {
+            air,
+            records: vec![],
+            memory_chip: memory,
+        }
+    }
+
+    pub fn accesses_per_instruction(opcode: Opcode) -> usize {
+        assert!(FIELD_EXTENSION_INSTRUCTIONS.contains(&opcode));
+        3 * EXT_DEG
     }
 
     pub fn current_height(&self) -> usize {

--- a/vm/src/hashes/keccak/hasher/mod.rs
+++ b/vm/src/hashes/keccak/hasher/mod.rs
@@ -104,7 +104,7 @@ impl<F: PrimeField32> KeccakVmChip<F> {
 impl<F: PrimeField32> InstructionExecutor<F> for KeccakVmChip<F> {
     fn execute(
         &mut self,
-        instruction: &Instruction<F>,
+        instruction: Instruction<F>,
         from_state: ExecutionState<usize>,
     ) -> ExecutionState<usize> {
         let Instruction {
@@ -116,7 +116,7 @@ impl<F: PrimeField32> InstructionExecutor<F> for KeccakVmChip<F> {
             e,
             op_f: f,
             ..
-        } = instruction.clone();
+        } = instruction;
         debug_assert_eq!(opcode, Opcode::KECCAK256);
 
         let mut memory = self.memory_chip.borrow_mut();


### PR DESCRIPTION
The executor shouldn't need to clone the instruction