### PR TITLE
refactor: Remove timestamp from MemoryChip

### DIFF
--- a/vm/src/arch/testing/execution/mod.rs
+++ b/vm/src/arch/testing/execution/mod.rs
@@ -8,7 +8,6 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_uni_stark::{Domain, StarkGenericConfig};
 use rand::{rngs::StdRng, RngCore};
 
-use super::MemoryTester;
 use crate::{
     arch::{
         bus::ExecutionBus,
@@ -38,13 +37,13 @@ impl<F: PrimeField32> ExecutionTester<F> {
 
     pub fn execute<E: InstructionExecutor<F>>(
         &mut self,
-        memory_tester: &mut MemoryTester<F>, // should merge MemoryTester and ExecutionTester into one struct (MachineChipTestBuilder?)
+        timestamp: usize,
         executor: &mut E,
         instruction: Instruction<F>,
     ) {
         let initial_state = ExecutionState {
             pc: self.next_elem_size_usize(),
-            timestamp: memory_tester.chip.borrow().timestamp(),
+            timestamp: F::from_canonical_usize(timestamp),
         };
         tracing::debug!(?initial_state.timestamp);
 

--- a/vm/src/memory/offline_checker/tests.rs
+++ b/vm/src/memory/offline_checker/tests.rs
@@ -71,6 +71,7 @@ fn volatile_memory_offline_checker_test() {
         mem_config,
         range_checker.clone(),
     )));
+    let mut timestamp = 1;
     let offline_checker =
         MemoryOfflineChecker::new(memory_bus, mem_config.clk_max_bits, mem_config.decomp);
 
@@ -92,7 +93,7 @@ fn volatile_memory_offline_checker_test() {
     for (addr_space, pointer) in all_addresses.iter() {
         let value = Val::from_canonical_u32(rng.next_u32() % MAX_VAL);
         mem_ops.push({
-            let write = mem_trace_builder.write_cell(*addr_space, *pointer, value);
+            let write = mem_trace_builder.write_cell(*addr_space, *pointer, value, &mut timestamp);
             MemoryOperation {
                 addr_space: write.address_space,
                 pointer: write.pointer,
@@ -110,7 +111,7 @@ fn volatile_memory_offline_checker_test() {
         let value = Val::from_canonical_u32(rng.next_u32() % MAX_VAL);
 
         let mem_op = if rng.gen_bool(0.5) {
-            let write = mem_trace_builder.write_cell(addr_space, pointer, value);
+            let write = mem_trace_builder.write_cell(addr_space, pointer, value, &mut timestamp);
             MemoryOperation {
                 addr_space: write.address_space,
                 pointer: write.pointer,
@@ -119,7 +120,7 @@ fn volatile_memory_offline_checker_test() {
                 enabled: Val::one(),
             }
         } else {
-            let read = mem_trace_builder.read_cell(addr_space, pointer);
+            let read = mem_trace_builder.read_cell(addr_space, pointer, &mut timestamp);
             MemoryOperation {
                 addr_space: read.address_space,
                 pointer: read.pointer,


### PR DESCRIPTION
MemoryChip no longer owns the timestamp. Read/write functions on MemoryChip now
receive the (mutable) timestamp (which is incremented appropriately).
