### PR TITLE
[chore] Rename BigIntVar to BigUintVar

### DIFF
--- a/compiler/src/ir/bits.rs
+++ b/compiler/src/ir/bits.rs
@@ -1,6 +1,6 @@
 use p3_field::AbstractField;
 
-use super::{Array, BigIntVar, Builder, Config, DslIr, Felt, MemIndex, RVar, Var};
+use super::{Array, BigUintVar, Builder, Config, DslIr, Felt, MemIndex, RVar, Var};
 
 pub const NUM_BITS: usize = 31;
 
@@ -32,12 +32,12 @@ impl<C: Config> Builder<C> {
         output
     }
 
-    pub fn num2bits_bigint(&mut self, bigint: &BigIntVar<C>) -> Array<C, Var<C::N>> {
+    pub fn num2bits_biguint(&mut self, biguint: &BigUintVar<C>) -> Array<C, Var<C::N>> {
         let repr_size = self.bigint_repr_size;
         let num_limbs = (256 + repr_size - 1) / repr_size;
         let bits = self.dyn_array((num_limbs * repr_size) as usize);
         for i in 0..num_limbs as usize {
-            let limb = self.get(bigint, i);
+            let limb = self.get(biguint, i);
             let limb_bits = self.num2bits_v(limb, repr_size);
             for j in 0..repr_size as usize {
                 let val = self.get(&limb_bits, j);

--- a/compiler/src/ir/elliptic_curve.rs
+++ b/compiler/src/ir/elliptic_curve.rs
@@ -2,7 +2,7 @@ use num_bigint_dig::BigUint;
 use num_traits::{FromPrimitive, Zero};
 use p3_field::{AbstractField, PrimeField64};
 
-use crate::ir::{modular_arithmetic::BigIntVar, Builder, Config};
+use crate::ir::{modular_arithmetic::BigUintVar, Builder, Config};
 
 impl<C: Config> Builder<C>
 where
@@ -10,9 +10,9 @@ where
 {
     pub fn ec_add(
         &mut self,
-        point_1: &(BigIntVar<C>, BigIntVar<C>),
-        point_2: &(BigIntVar<C>, BigIntVar<C>),
-    ) -> (BigIntVar<C>, BigIntVar<C>) {
+        point_1: &(BigUintVar<C>, BigUintVar<C>),
+        point_2: &(BigUintVar<C>, BigUintVar<C>),
+    ) -> (BigUintVar<C>, BigUintVar<C>) {
         let (x1, y1) = point_1;
         let (x2, y2) = point_2;
 
@@ -46,7 +46,7 @@ where
                             .if_eq(xs_equal * ys_opposite, C::N::one())
                             .then_or_else(
                                 |builder| {
-                                    let zero = builder.eval_bigint(BigUint::zero());
+                                    let zero = builder.eval_biguint(BigUint::zero());
                                     builder.assign(&result_x, zero.clone());
                                     builder.assign(&result_y, zero);
                                 },
@@ -58,9 +58,9 @@ where
                                         .then_or_else(
                                             |builder| {
                                                 let two = builder
-                                                    .eval_bigint(BigUint::from_u8(2).unwrap());
+                                                    .eval_biguint(BigUint::from_u8(2).unwrap());
                                                 let three = builder
-                                                    .eval_bigint(BigUint::from_u8(3).unwrap());
+                                                    .eval_biguint(BigUint::from_u8(3).unwrap());
                                                 let two_y = builder.secp256k1_coord_mul(&two, y1);
                                                 let x_squared = builder.secp256k1_coord_mul(x1, x1);
                                                 let three_x_squared =

--- a/compiler/src/ir/instructions.rs
+++ b/compiler/src/ir/instructions.rs
@@ -1,5 +1,5 @@
 use super::{Array, Config, Ext, Felt, MemIndex, Ptr, RVar, TracedVec, Var};
-use crate::ir::modular_arithmetic::BigIntVar;
+use crate::ir::modular_arithmetic::BigUintVar;
 
 /// An intermeddiate instruction set for implementing programs.
 ///
@@ -35,9 +35,9 @@ pub enum DslIr<C: Config> {
     /// Add a field element and an ext field immediate (ext = felt + ext field imm).
     AddEFFI(Ext<C::F, C::EF>, Felt<C::F>, C::EF),
     /// Add two modular BigInts over coordinate field.
-    AddSecp256k1Coord(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    AddSecp256k1Coord(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
     /// Add two modular BigInts over scalar field.
-    AddSecp256k1Scalar(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    AddSecp256k1Scalar(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
 
     // Subtractions.
     /// Subtracts two variables (var = var - var).
@@ -63,9 +63,9 @@ pub enum DslIr<C: Config> {
     /// Subtracts an extension field element and a field element (ext = ext - felt).
     SubEF(Ext<C::F, C::EF>, Ext<C::F, C::EF>, Felt<C::F>),
     /// Subtracts two modular BigInts over coordinate field.
-    SubSecp256k1Coord(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    SubSecp256k1Coord(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
     /// Subtracts two modular BigInts over scalar field.
-    SubSecp256k1Scalar(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    SubSecp256k1Scalar(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
 
     // Multiplications.
     /// Multiplies two variables (var = var * var).
@@ -85,9 +85,9 @@ pub enum DslIr<C: Config> {
     /// Multiplies an extension field element and a field element (ext = ext * felt).
     MulEF(Ext<C::F, C::EF>, Ext<C::F, C::EF>, Felt<C::F>),
     /// Multiplies two modular BigInts over coordinate field.
-    MulSecp256k1Coord(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    MulSecp256k1Coord(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
     /// Multiplies two modular BigInts over scalar field.
-    MulSecp256k1Scalar(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    MulSecp256k1Scalar(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
 
     // Divisions.
     /// Divides two variables (var = var / var).
@@ -107,9 +107,9 @@ pub enum DslIr<C: Config> {
     /// Divides an extension field element and a field element (ext = ext / felt).
     DivEF(Ext<C::F, C::EF>, Ext<C::F, C::EF>, Felt<C::F>),
     /// Subtracts two modular BigInts over coordinate field.
-    DivSecp256k1Coord(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    DivSecp256k1Coord(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
     /// Multiplies two modular BigInts over scalar field.
-    DivSecp256k1Scalar(BigIntVar<C>, BigIntVar<C>, BigIntVar<C>),
+    DivSecp256k1Scalar(BigUintVar<C>, BigUintVar<C>, BigUintVar<C>),
 
     // Negations.
     /// Negates a variable (var = -var).

--- a/compiler/tests/modular_arithmetic.rs
+++ b/compiler/tests/modular_arithmetic.rs
@@ -28,10 +28,10 @@ fn test_compiler_modular_arithmetic_1() {
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::default();
 
-    let a_var = builder.eval_bigint(a);
-    let b_var = builder.eval_bigint(b);
+    let a_var = builder.eval_biguint(a);
+    let b_var = builder.eval_biguint(b);
     let r_var = builder.secp256k1_coord_mul(&a_var, &b_var);
-    let r_check_var = builder.eval_bigint(r);
+    let r_check_var = builder.eval_biguint(r);
     builder.assert_secp256k1_coord_eq(&r_var, &r_check_var);
     builder.halt();
 
@@ -59,10 +59,10 @@ fn test_compiler_modular_arithmetic_2() {
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::default();
 
-    let a_var = builder.eval_bigint(a);
-    let b_var = builder.eval_bigint(b);
+    let a_var = builder.eval_biguint(a);
+    let b_var = builder.eval_biguint(b);
     let r_var = builder.secp256k1_coord_mul(&a_var, &b_var);
-    let r_check_var = builder.eval_bigint(r);
+    let r_check_var = builder.eval_biguint(r);
     builder.assert_secp256k1_coord_eq(&r_var, &r_check_var);
     builder.halt();
 
@@ -83,11 +83,11 @@ fn test_compiler_modular_arithmetic_conditional() {
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::default();
 
-    let a_var = builder.eval_bigint(a);
-    let b_var = builder.eval_bigint(b);
+    let a_var = builder.eval_biguint(a);
+    let b_var = builder.eval_biguint(b);
     let product_var = builder.secp256k1_coord_mul(&a_var, &b_var);
-    let r_var = builder.eval_bigint(r);
-    let s_var = builder.eval_bigint(s);
+    let r_var = builder.eval_biguint(r);
+    let s_var = builder.eval_biguint(s);
 
     let should_be_1: Var<F> = builder.uninit();
     let should_be_2: Var<F> = builder.uninit();
@@ -122,9 +122,9 @@ fn test_compiler_modular_arithmetic_negative() {
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::default();
 
-    let one = builder.eval_bigint(BigUint::one());
+    let one = builder.eval_biguint(BigUint::one());
     let one_times_one = builder.secp256k1_coord_mul(&one, &one);
-    let zero = builder.eval_bigint(BigUint::zero());
+    let zero = builder.eval_biguint(BigUint::zero());
     builder.assert_secp256k1_coord_eq(&one_times_one, &zero);
     builder.halt();
 
@@ -145,11 +145,11 @@ fn test_compiler_modular_scalar_arithmetic_conditional() {
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::default();
 
-    let a_var = builder.eval_bigint(a);
-    let b_var = builder.eval_bigint(b);
+    let a_var = builder.eval_biguint(a);
+    let b_var = builder.eval_biguint(b);
     let product_var = builder.secp256k1_scalar_mul(&a_var, &b_var);
-    let r_var = builder.eval_bigint(r);
-    let s_var = builder.eval_bigint(s);
+    let r_var = builder.eval_biguint(r);
+    let s_var = builder.eval_biguint(s);
 
     let should_be_1: Var<F> = builder.uninit();
     let should_be_2: Var<F> = builder.uninit();
@@ -184,9 +184,9 @@ fn test_compiler_modular_scalar_arithmetic_negative() {
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::default();
 
-    let one = builder.eval_bigint(BigUint::one());
+    let one = builder.eval_biguint(BigUint::one());
     let one_times_one = builder.secp256k1_scalar_mul(&one, &one);
-    let zero = builder.eval_bigint(BigUint::zero());
+    let zero = builder.eval_biguint(BigUint::zero());
     builder.assert_secp256k1_scalar_eq(&one_times_one, &zero);
     builder.halt();
 
@@ -204,7 +204,7 @@ impl Fraction {
         Self { num, denom }
     }
 
-    fn to_bigint(&self) -> BigUint {
+    fn to_biguint(&self) -> BigUint {
         let sign = signum(self.num) * signum(self.denom);
         let num = BigUint::from_isize(abs(self.num)).unwrap();
         let denom = BigUint::from_isize(abs(self.denom)).unwrap();
@@ -248,12 +248,12 @@ fn test_ec_add(point_1: Point, point_2: Point, point_3: Point) {
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::default();
 
-    let x1_var = builder.eval_bigint(point_1.x.to_bigint());
-    let y1_var = builder.eval_bigint(point_1.y.to_bigint());
-    let x2_var = builder.eval_bigint(point_2.x.to_bigint());
-    let y2_var = builder.eval_bigint(point_2.y.to_bigint());
-    let x3_check = builder.eval_bigint(point_3.x.to_bigint());
-    let y3_check = builder.eval_bigint(point_3.y.to_bigint());
+    let x1_var = builder.eval_biguint(point_1.x.to_biguint());
+    let y1_var = builder.eval_biguint(point_1.y.to_biguint());
+    let x2_var = builder.eval_biguint(point_2.x.to_biguint());
+    let y2_var = builder.eval_biguint(point_2.y.to_biguint());
+    let x3_check = builder.eval_biguint(point_3.x.to_biguint());
+    let y3_check = builder.eval_biguint(point_3.y.to_biguint());
 
     let (x3_var, y3_var) = builder.ec_add(&(x1_var, y1_var), &(x2_var, y2_var));
 

--- a/ecc/src/ec_mul.rs
+++ b/ecc/src/ec_mul.rs
@@ -1,6 +1,6 @@
 use afs_compiler::{
     ir::{
-        Array, BigIntVar, Builder, Config, MemIndex, MemVariable, Ptr, RVar, Var, Variable,
+        Array, BigUintVar, Builder, Config, MemIndex, MemVariable, Ptr, RVar, Var, Variable,
         NUM_ELEMS,
     },
     prelude::DslVariable,
@@ -10,8 +10,8 @@ use p3_field::{AbstractField, PrimeField64};
 // pub type EcPoint<C> = (BigIntVar<C>, BigIntVar<C>);
 #[derive(DslVariable, Clone, Debug)]
 pub struct EcPoint<C: Config> {
-    pub x: BigIntVar<C>,
-    pub y: BigIntVar<C>,
+    pub x: BigUintVar<C>,
+    pub y: BigUintVar<C>,
 }
 
 pub const BIGINT_MAX_BITS: usize = 256;
@@ -19,7 +19,7 @@ pub const BIGINT_MAX_BITS: usize = 256;
 pub fn scalar_multiply<C>(
     builder: &mut Builder<C>,
     point: &EcPoint<C>,
-    scalar: BigIntVar<C>,
+    scalar: BigUintVar<C>,
     window_bits: usize,
 ) -> EcPoint<C>
 where
@@ -33,8 +33,8 @@ where
 
     let x_zero = builder.secp256k1_coord_is_zero(x);
     let y_zero = builder.secp256k1_coord_is_zero(y);
-    let result_x: BigIntVar<C> = builder.uninit_bigint();
-    let result_y: BigIntVar<C> = builder.uninit_bigint();
+    let result_x: BigUintVar<C> = builder.uninit_biguint();
+    let result_y: BigUintVar<C> = builder.uninit_biguint();
 
     builder.secp256k1_coord_set_to_zero(&result_x);
     builder.secp256k1_coord_set_to_zero(&result_y);
@@ -64,7 +64,7 @@ where
                     cache_vec
                 })
                 .collect::<Vec<_>>();
-            let bits = builder.num2bits_bigint(&scalar);
+            let bits = builder.num2bits_biguint(&scalar);
             for (i, cache_vec) in cached_points_jacobian.iter().enumerate() {
                 let window_sum: Var<C::N> = builder.uninit();
                 builder.assign(&window_sum, RVar::zero());

--- a/ecc/src/tests/mod.rs
+++ b/ecc/src/tests/mod.rs
@@ -19,11 +19,11 @@ fn test_ec_mul(
     type EF = BinomialExtensionField<BabyBear, 4>;
     let mut builder = AsmBuilder::<F, EF>::bigint_builder();
 
-    let x1_var = builder.eval_bigint(point_1.0);
-    let y1_var = builder.eval_bigint(point_1.1);
-    let x2_var = builder.eval_bigint(point_2.0);
-    let y2_var = builder.eval_bigint(point_2.1);
-    let s = builder.eval_bigint(scalar);
+    let x1_var = builder.eval_biguint(point_1.0);
+    let y1_var = builder.eval_biguint(point_1.1);
+    let x2_var = builder.eval_biguint(point_2.0);
+    let y2_var = builder.eval_biguint(point_2.1);
+    let s = builder.eval_biguint(scalar);
 
     let EcPoint {
         x: x3_var,

--- a/primitives/src/bigint/modular_multiplication/mod.rs
+++ b/primitives/src/bigint/modular_multiplication/mod.rs
@@ -236,7 +236,7 @@ mod test {
     const LIMB_BITS: usize = 10;
     const NUM_LIMB: usize = 26;
 
-    fn evaluate_bigint(limbs: &[BabyBear], limb_bits: usize) -> BigUint {
+    fn evaluate_biguint(limbs: &[BabyBear], limb_bits: usize) -> BigUint {
         let mut res = BigUint::zero();
         let base = BigUint::from_u64(1 << limb_bits).unwrap();
         for limb in limbs.iter().rev() {
@@ -299,8 +299,8 @@ mod test {
             r,
             carries: _carries,
         } = cols.clone();
-        let generated_r = evaluate_bigint(&r, LIMB_BITS);
-        let generated_q = evaluate_bigint(&q, LIMB_BITS);
+        let generated_r = evaluate_biguint(&r, LIMB_BITS);
+        let generated_q = evaluate_biguint(&q, LIMB_BITS);
         assert_eq!(generated_r, expected_r);
         assert_eq!(generated_q, expected_q);
 

--- a/primitives/src/modular_multiplication/bigint/air.rs
+++ b/primitives/src/modular_multiplication/bigint/air.rs
@@ -108,12 +108,10 @@ impl ModularArithmeticBigIntAir {
     }
 
     pub fn secp256k1_scalar_prime() -> BigUint {
-        let lol = BigUint::from_str(
+        BigUint::from_str(
             "115792089237316195423570985008687907852837564279074904382605163141518161494337",
         )
-        .unwrap();
-        print!("{:?}", lol);
-        lol
+        .unwrap()
     }
 
     pub fn default_for_secp256k1_coord(limb_bits: usize) -> Self {

--- a/vm/src/modular_multiplication/mod.rs
+++ b/vm/src/modular_multiplication/mod.rs
@@ -17,7 +17,7 @@ pub mod air;
 #[cfg(test)]
 mod tests;
 
-pub fn elems_to_bigint<F: PrimeField64>(elems: Vec<F>, repr_bits: usize) -> BigUint {
+pub fn elems_to_biguint<F: PrimeField64>(elems: Vec<F>, repr_bits: usize) -> BigUint {
     let mut bits = vec![];
     for elem in elems {
         let mut elem = elem.as_canonical_u64() as usize;
@@ -58,12 +58,12 @@ fn take_limb(deque: &mut VecDeque<usize>, limb_size: usize) -> usize {
     }
 }
 
-pub fn bigint_to_elems<F: PrimeField64>(
-    bigint: BigUint,
+pub fn biguint_to_elems<F: PrimeField64>(
+    biguint: BigUint,
     repr_bits: usize,
     num_elems: usize,
 ) -> Vec<F> {
-    let mut bits = big_uint_to_bits(bigint);
+    let mut bits = big_uint_to_bits(biguint);
     (0..num_elems)
         .map(|_| F::from_canonical_usize(take_limb(&mut bits, repr_bits)))
         .collect()
@@ -137,8 +137,8 @@ impl<F: PrimeField32> InstructionExecutor<F> for ModularArithmeticChip<F> {
             })
             .collect();
 
-        let argument_1 = elems_to_bigint(argument_1_elems, repr_bits);
-        let argument_2 = elems_to_bigint(argument_2_elems, repr_bits);
+        let argument_1 = elems_to_biguint(argument_1_elems, repr_bits);
+        let argument_2 = elems_to_biguint(argument_2_elems, repr_bits);
         let result = match instruction.opcode {
             SECP256K1_COORD_ADD | SECP256K1_SCALAR_ADD => argument_1.clone() + argument_2.clone(),
             SECP256K1_COORD_SUB | SECP256K1_SCALAR_SUB => {
@@ -155,7 +155,7 @@ impl<F: PrimeField32> InstructionExecutor<F> for ModularArithmeticChip<F> {
 
             _ => panic!(),
         } % modulus;
-        let result_elems = bigint_to_elems(result, repr_bits, num_elems);
+        let result_elems = biguint_to_elems(result, repr_bits, num_elems);
         for (i, &elem) in result_elems.iter().enumerate() {
             memory_chip.write_cell(
                 instruction.e,
@@ -178,7 +178,7 @@ impl<F: PrimeField32> InstructionExecutor<F> for ModularArithmeticChip<F> {
 }
 
 impl<F: PrimeField32> ModularArithmeticChip<F> {
-    pub fn new(memory_chip: MemoryChipRef<F>, modulus: BigUint, bigint_limb_size: usize) -> Self {
+    pub fn new(memory_chip: MemoryChipRef<F>, modulus: BigUint, biguint_limb_size: usize) -> Self {
         Self {
             air: ModularArithmeticVmAir {
                 air: ModularArithmeticBigIntAir::new(
@@ -188,7 +188,7 @@ impl<F: PrimeField32> ModularArithmeticChip<F> {
                     0,
                     30,
                     30,
-                    bigint_limb_size,
+                    biguint_limb_size,
                     16,
                     1 << 15,
                 ),
@@ -257,8 +257,8 @@ impl<F: PrimeField32> ModularArithmeticChip<F> {
             })
             .collect();
 
-        let argument_1 = elems_to_bigint(argument_1_elems, repr_bits);
-        let argument_2 = elems_to_bigint(argument_2_elems, repr_bits);
+        let argument_1 = elems_to_biguint(argument_1_elems, repr_bits);
+        let argument_2 = elems_to_biguint(argument_2_elems, repr_bits);
         let result = match instruction.opcode {
             SECP256K1_COORD_ADD | SECP256K1_SCALAR_ADD => argument_1.clone() + argument_2.clone(),
             SECP256K1_COORD_SUB | SECP256K1_SCALAR_SUB => {
@@ -275,7 +275,7 @@ impl<F: PrimeField32> ModularArithmeticChip<F> {
 
             _ => panic!(),
         } % modulus;
-        let result_elems = bigint_to_elems(result, repr_bits, num_elems);
+        let result_elems = biguint_to_elems(result, repr_bits, num_elems);
         for (i, &elem) in result_elems.iter().enumerate() {
             vm.memory_chip.borrow_mut().write_cell(
                 instruction.e,

--- a/vm/src/modular_multiplication/tests/mod.rs
+++ b/vm/src/modular_multiplication/tests/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         testing::MachineChipTestBuilder,
     },
     cpu::trace::Instruction,
-    modular_multiplication::{bigint_to_elems, ModularArithmeticChip},
+    modular_multiplication::{biguint_to_elems, ModularArithmeticChip},
 };
 
 #[test]
@@ -80,11 +80,11 @@ fn test_modular_multiplication_runtime() {
         let num_elems = 9;
         let repr_bits = 30;
 
-        for (i, &elem) in bigint_to_elems(a, repr_bits, num_elems).iter().enumerate() {
+        for (i, &elem) in biguint_to_elems(a, repr_bits, num_elems).iter().enumerate() {
             let address = address1 + i;
             tester.write_cell(1, address, elem);
         }
-        for (i, &elem) in bigint_to_elems(b, repr_bits, num_elems).iter().enumerate() {
+        for (i, &elem) in biguint_to_elems(b, repr_bits, num_elems).iter().enumerate() {
             let address = address2 + i;
             tester.write_cell(1, address, elem);
         }
@@ -108,7 +108,7 @@ fn test_modular_multiplication_runtime() {
         } else {
             tester.execute(&mut coord_chip, instruction);
         }
-        for (i, &elem) in bigint_to_elems::<BabyBear>(r, repr_bits, num_elems)
+        for (i, &elem) in biguint_to_elems::<BabyBear>(r, repr_bits, num_elems)
             .iter()
             .enumerate()
         {


### PR DESCRIPTION
`BigIntVar` is actually unsigned. Correct the name.