### PR TITLE
feat: Print captured backtrace when eDSL program fails

### DIFF
--- a/compiler/src/ir/builder.rs
+++ b/compiler/src/ir/builder.rs
@@ -47,21 +47,14 @@ impl<T> TracedVec<T> {
         self.traces.push(None);
     }
 
-    /// Pushes a value to the vector and records a backtrace if SP1_DEBUG is enabled
+    /// Pushes a value to the vector and records a backtrace if RUST_BACKTRACE is enabled
     pub fn trace_push(&mut self, value: T) {
         self.vec.push(value);
-        match std::env::var("SP1_DEBUG")
-            .unwrap_or("false".to_string())
-            .to_lowercase()
-            .as_str()
-        {
-            "true" => {
-                self.traces.push(Some(Backtrace::new_unresolved()));
-            }
-            _ => {
-                self.traces.push(None);
-            }
-        };
+        if std::env::var_os("RUST_BACKTRACE").is_none() {
+            self.traces.push(None);
+        } else {
+            self.traces.push(Some(Backtrace::new_unresolved()));
+        }
     }
 
     pub fn extend<I: IntoIterator<Item = (T, Option<Backtrace>)>>(&mut self, iter: I) {

--- a/compiler/src/ir/utils.rs
+++ b/compiler/src/ir/utils.rs
@@ -77,7 +77,7 @@ impl<C: Config> Builder<C> {
         self.eval(e)
     }
 
-    /// Exponentializes a variable to an array of bits in little endian.
+    /// Exponentiates a variable to an array of bits in little endian.
     pub fn exp_bits<V>(&mut self, x: V, power_bits: &Array<C, Var<C::N>>) -> V
     where
         V::Expression: AbstractField,
@@ -125,7 +125,7 @@ impl<C: Config> Builder<C> {
         result
     }
 
-    /// Exponetiates a varibale to a list of reversed bits with a given length.
+    /// Exponentiates a variable to a list of reversed bits with a given length.
     ///
     /// Reference: [p3_util::reverse_bits_len]
     pub fn exp_reverse_bits_len<V>(
@@ -171,7 +171,7 @@ impl<C: Config> Builder<C> {
         result
     }
 
-    /// Exponentiates a variable to a list of bits in little endian insid a circuit.
+    /// Exponentiates a variable to a list of bits in little endian inside a circuit.
     pub fn exp_power_of_2_v_circuit<V>(
         &mut self,
         base: impl Into<V::Expression>,


### PR DESCRIPTION
Improves eDSL debugging experience by printing the stack trace containing the failed builder.assert.