### PR TITLE
feat: Borrow cols in memory checker

### DIFF
--- a/vm/src/cpu/air.rs
+++ b/vm/src/cpu/air.rs
@@ -335,7 +335,7 @@ impl<AB: AirBuilderWithPublicValues + InteractionBuilder> Air<AB> for CpuAir {
                     MemoryAddress::new(read.address_space, read.pointer),
                     read.value,
                     op_timestamp.clone(),
-                    read_aux_cols,
+                    &read_aux_cols,
                 )
                 .eval(builder, read.enabled);
             op_timestamp += read.enabled.into();
@@ -347,7 +347,7 @@ impl<AB: AirBuilderWithPublicValues + InteractionBuilder> Air<AB> for CpuAir {
                     MemoryAddress::new(write.address_space, write.pointer),
                     [write.value],
                     op_timestamp.clone(),
-                    write_aux_cols,
+                    &write_aux_cols,
                 )
                 .eval(builder, write.enabled);
             op_timestamp += write.enabled.into();

--- a/vm/src/field_arithmetic/bridge.rs
+++ b/vm/src/field_arithmetic/bridge.rs
@@ -49,7 +49,7 @@ impl FieldArithmeticAir {
                 operand1.memory_address(),
                 operand1.value,
                 timestamp.clone(),
-                aux.read_x_aux_cols,
+                &aux.read_x_aux_cols,
             )
             .eval(builder, is_valid);
         timestamp += is_valid.into();
@@ -59,7 +59,7 @@ impl FieldArithmeticAir {
                 operand2.memory_address(),
                 operand2.value,
                 timestamp.clone(),
-                aux.read_y_aux_cols,
+                &aux.read_y_aux_cols,
             )
             .eval(builder, is_valid);
         timestamp += is_valid.into();
@@ -69,7 +69,7 @@ impl FieldArithmeticAir {
                 result.memory_address(),
                 [result.value],
                 timestamp,
-                aux.write_z_aux_cols,
+                &aux.write_z_aux_cols,
             )
             .eval(builder, is_valid);
     }

--- a/vm/src/field_extension/bridge.rs
+++ b/vm/src/field_extension/bridge.rs
@@ -56,7 +56,7 @@ impl FieldExtensionArithmeticAir {
                 MemoryAddress::new(d, op_b),
                 x,
                 timestamp_pp(),
-                read_x_aux_cols,
+                &read_x_aux_cols,
             )
             .eval(builder, is_valid);
 
@@ -66,7 +66,7 @@ impl FieldExtensionArithmeticAir {
                 MemoryAddress::new(e, op_c),
                 y,
                 timestamp_pp(),
-                read_y_aux_cols,
+                &read_y_aux_cols,
             )
             .eval(builder, is_valid);
 
@@ -76,7 +76,7 @@ impl FieldExtensionArithmeticAir {
                 MemoryAddress::new(d, op_a),
                 z,
                 timestamp_pp(),
-                write_aux_cols,
+                &write_aux_cols,
             )
             .eval(builder, is_valid);
 

--- a/vm/src/hashes/keccak/hasher/bridge.rs
+++ b/vm/src/hashes/keccak/hasher/bridge.rs
@@ -152,7 +152,7 @@ impl KeccakVmAir {
             [opcode.a, opcode.b, opcode.c],
             [opcode.d, opcode.d, opcode.f],
             [opcode.dst, opcode.src, opcode.len],
-            mem_aux,
+            &mem_aux,
         ) {
             memory_bridge
                 .read(
@@ -193,7 +193,7 @@ impl KeccakVmAir {
         for (i, (input, is_padding, mem_aux)) in izip!(
             local.sponge.block_bytes,
             local.sponge.is_padding_byte,
-            mem_aux
+            &mem_aux
         )
         .enumerate()
         {
@@ -254,7 +254,7 @@ impl KeccakVmAir {
                     MemoryAddress::new(opcode.e, opcode.dst + AB::F::from_canonical_usize(i)),
                     [digest_byte],
                     timestamp,
-                    mem_aux[i].clone(),
+                    &mem_aux[i],
                 )
                 .eval(builder, local.inner.export)
         }

--- a/vm/src/hashes/poseidon2/air.rs
+++ b/vm/src/hashes/poseidon2/air.rs
@@ -83,7 +83,7 @@ impl<AB: InteractionBuilder> Air<AB> for Poseidon2VmAir<AB::F> {
             [cols.io.a, cols.io.b, cols.io.c],
             [cols.aux.dst_ptr, cols.aux.lhs_ptr, cols.aux.rhs_ptr],
             [cols.io.is_opcode, cols.io.is_opcode, cols.io.cmp],
-            cols.aux.ptr_aux_cols,
+            &cols.aux.ptr_aux_cols,
         ) {
             memory_bridge
                 .read(
@@ -104,7 +104,7 @@ impl<AB: InteractionBuilder> Air<AB> for Poseidon2VmAir<AB::F> {
                 MemoryAddress::new(cols.io.e, cols.aux.lhs_ptr),
                 cols.aux.internal.io.input[..CHUNK].try_into().unwrap(),
                 timestamp_pp(),
-                input1_aux_cols,
+                &input1_aux_cols,
             )
             .eval(builder, cols.io.is_opcode);
 
@@ -114,7 +114,7 @@ impl<AB: InteractionBuilder> Air<AB> for Poseidon2VmAir<AB::F> {
                 MemoryAddress::new(cols.io.e, cols.aux.rhs_ptr),
                 cols.aux.internal.io.input[CHUNK..].try_into().unwrap(),
                 timestamp_pp(),
-                input2_aux_cols,
+                &input2_aux_cols,
             )
             .eval(builder, cols.io.is_opcode);
 
@@ -124,7 +124,7 @@ impl<AB: InteractionBuilder> Air<AB> for Poseidon2VmAir<AB::F> {
                 MemoryAddress::new(cols.io.e, cols.aux.dst_ptr),
                 cols.aux.internal.io.output[..CHUNK].try_into().unwrap(),
                 timestamp_pp(),
-                output1_aux_cols,
+                &output1_aux_cols,
             )
             .eval(builder, cols.io.is_opcode);
 
@@ -135,7 +135,7 @@ impl<AB: InteractionBuilder> Air<AB> for Poseidon2VmAir<AB::F> {
                 MemoryAddress::new(cols.io.e, pointer),
                 cols.aux.internal.io.output[CHUNK..].try_into().unwrap(),
                 timestamp_pp(),
-                output2_aux_cols,
+                &output2_aux_cols,
             )
             .eval(builder, cols.io.is_opcode - cols.io.cmp);
 

--- a/vm/src/memory/offline_checker/bridge.rs
+++ b/vm/src/memory/offline_checker/bridge.rs
@@ -1,4 +1,4 @@
-use std::{iter::zip, marker::PhantomData};
+use std::iter::zip;
 
 use afs_primitives::{
     is_less_than::{columns::IsLessThanIoCols, IsLessThanAir},
@@ -28,29 +28,25 @@ use crate::{
 /// The [MemoryBridge] is used within AIR evaluation functions to constrain logical memory operations (read/write).
 /// It adds all necessary constraints and interactions.
 #[derive(Clone, Debug)]
-pub struct MemoryBridge<V> {
+pub struct MemoryBridge {
     offline_checker: MemoryOfflineChecker,
-    _marker: PhantomData<V>,
 }
 
-impl<V> MemoryBridge<V> {
+impl MemoryBridge {
     /// Create a new [MemoryBridge] with the provided offline_checker.
     pub fn new(offline_checker: MemoryOfflineChecker) -> Self {
-        Self {
-            offline_checker,
-            _marker: PhantomData,
-        }
+        Self { offline_checker }
     }
 
     /// Prepare a logical memory read operation.
     #[must_use]
-    pub fn read<T, const N: usize>(
+    pub fn read<'a, T, V, const N: usize>(
         &self,
         address: MemoryAddress<impl Into<T>, impl Into<T>>,
         data: [impl Into<T>; N],
         timestamp: impl Into<T>,
-        aux: MemoryReadAuxCols<N, V>,
-    ) -> MemoryReadOperation<T, V, N> {
+        aux: &'a MemoryReadAuxCols<N, V>,
+    ) -> MemoryReadOperation<'a, T, V, N> {
         MemoryReadOperation {
             offline_checker: self.offline_checker,
             address: MemoryAddress::from(address),
@@ -62,13 +58,13 @@ impl<V> MemoryBridge<V> {
 
     /// Prepare a logical memory read or immediate operation.
     #[must_use]
-    pub fn read_or_immediate<T>(
+    pub fn read_or_immediate<'a, T, V>(
         &self,
         address: MemoryAddress<impl Into<T>, impl Into<T>>,
         data: impl Into<T>,
         timestamp: impl Into<T>,
-        aux: MemoryReadOrImmediateAuxCols<V>,
-    ) -> MemoryReadOrImmediateOperation<T, V> {
+        aux: &'a MemoryReadOrImmediateAuxCols<V>,
+    ) -> MemoryReadOrImmediateOperation<'a, T, V> {
         MemoryReadOrImmediateOperation {
             offline_checker: self.offline_checker,
             address: MemoryAddress::from(address),
@@ -80,13 +76,13 @@ impl<V> MemoryBridge<V> {
 
     /// Prepare a logical memory write operation.
     #[must_use]
-    pub fn write<T, const N: usize>(
+    pub fn write<'a, T, V, const N: usize>(
         &self,
         address: MemoryAddress<impl Into<T>, impl Into<T>>,
         data: [impl Into<T>; N],
         timestamp: impl Into<T>,
-        aux: MemoryWriteAuxCols<N, V>,
-    ) -> MemoryWriteOperation<T, V, N> {
+        aux: &'a MemoryWriteAuxCols<N, V>,
+    ) -> MemoryWriteOperation<'a, T, V, N> {
         MemoryWriteOperation {
             offline_checker: self.offline_checker,
             address: MemoryAddress::from(address),
@@ -105,15 +101,15 @@ impl<V> MemoryBridge<V> {
 /// The generic `T` type is intended to be `AB::Expr` where `AB` is the [AirBuilder].
 /// The auxiliary columns are not expected to be expressions, so the generic `V` type is intended
 /// to be `AB::Var`.
-pub struct MemoryReadOperation<T, V, const N: usize> {
+pub struct MemoryReadOperation<'a, T, V, const N: usize> {
     offline_checker: MemoryOfflineChecker,
     address: MemoryAddress<T, T>,
     data: [T; N],
     timestamp: T,
-    aux: MemoryReadAuxCols<N, V>,
+    aux: &'a MemoryReadAuxCols<N, V>,
 }
 
-impl<F: AbstractField, V: Copy + Into<F>, const N: usize> MemoryReadOperation<F, V, N> {
+impl<'a, F: AbstractField, V: Copy + Into<F>, const N: usize> MemoryReadOperation<'a, F, V, N> {
     /// Evaluate constraints and send/receive interactions.
     pub fn eval<AB>(self, builder: &mut AB, enabled: impl Into<AB::Expr>)
     where
@@ -152,15 +148,15 @@ impl<F: AbstractField, V: Copy + Into<F>, const N: usize> MemoryReadOperation<F,
 /// The generic `T` type is intended to be `AB::Expr` where `AB` is the [AirBuilder].
 /// The auxiliary columns are not expected to be expressions, so the generic `V` type is intended
 /// to be `AB::Var`.
-pub struct MemoryReadOrImmediateOperation<T, V> {
+pub struct MemoryReadOrImmediateOperation<'a, T, V> {
     offline_checker: MemoryOfflineChecker,
     address: MemoryAddress<T, T>,
     data: T,
     timestamp: T,
-    aux: MemoryReadOrImmediateAuxCols<V>,
+    aux: &'a MemoryReadOrImmediateAuxCols<V>,
 }
 
-impl<F: AbstractField, V: Copy + Into<F>> MemoryReadOrImmediateOperation<F, V> {
+impl<'a, F: AbstractField, V: Copy + Into<F>> MemoryReadOrImmediateOperation<'a, F, V> {
     /// Evaluate constraints and send/receive interactions.
     pub fn eval<AB>(self, builder: &mut AB, enabled: impl Into<AB::Expr>)
     where
@@ -214,16 +210,16 @@ impl<F: AbstractField, V: Copy + Into<F>> MemoryReadOrImmediateOperation<F, V> {
 /// Includes constraints for `timestamp_prev < timestamp`.
 ///
 /// **Note:** This can be used as a logical read operation by setting `data_prev = data`.
-pub struct MemoryWriteOperation<T, V, const N: usize> {
+pub struct MemoryWriteOperation<'a, T, V, const N: usize> {
     offline_checker: MemoryOfflineChecker,
     address: MemoryAddress<T, T>,
     data: [T; N],
     /// The timestamp of the current read
     timestamp: T,
-    aux: MemoryWriteAuxCols<N, V>,
+    aux: &'a MemoryWriteAuxCols<N, V>,
 }
 
-impl<T: AbstractField, V: Copy + Into<T>, const N: usize> MemoryWriteOperation<T, V, N> {
+impl<'a, T: AbstractField, V: Copy + Into<T>, const N: usize> MemoryWriteOperation<'a, T, V, N> {
     /// Evaluate constraints and send/receive interactions. `enabled` must be boolean.
     pub fn eval<AB>(self, builder: &mut AB, enabled: impl Into<AB::Expr>)
     where

--- a/vm/src/modular_arithmetic/bridge.rs
+++ b/vm/src/modular_arithmetic/bridge.rs
@@ -30,7 +30,7 @@ impl ModularArithmeticAir {
                     .try_into()
                     .unwrap_or_else(|_| unreachable!()),
                 timestamp.clone() + timestamp_delta.clone(),
-                aux.x_address_aux_cols,
+                &aux.x_address_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();
@@ -43,7 +43,7 @@ impl ModularArithmeticAir {
                     .try_into()
                     .unwrap_or_else(|_| unreachable!()),
                 timestamp.clone() + timestamp_delta.clone(),
-                aux.y_address_aux_cols,
+                &aux.y_address_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();
@@ -56,7 +56,7 @@ impl ModularArithmeticAir {
                     .try_into()
                     .unwrap_or_else(|_| unreachable!()),
                 timestamp.clone() + timestamp_delta.clone(),
-                aux.z_address_aux_cols,
+                &aux.z_address_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();
@@ -66,7 +66,7 @@ impl ModularArithmeticAir {
                 MemoryAddress::new(io.x.address_space, io.x.address),
                 io.x.data.try_into().unwrap_or_else(|_| unreachable!()),
                 timestamp.clone() + timestamp_delta.clone(),
-                aux.read_x_aux_cols,
+                &aux.read_x_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();
@@ -76,7 +76,7 @@ impl ModularArithmeticAir {
                 MemoryAddress::new(io.y.address_space, io.y.address),
                 io.y.data.try_into().unwrap_or_else(|_| unreachable!()),
                 timestamp.clone() + timestamp_delta.clone(),
-                aux.read_y_aux_cols,
+                &aux.read_y_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();
@@ -86,7 +86,7 @@ impl ModularArithmeticAir {
                 MemoryAddress::new(io.z.address_space, io.z.address),
                 io.z.data.try_into().unwrap_or_else(|_| unreachable!()),
                 timestamp.clone() + timestamp_delta.clone(),
-                aux.write_z_aux_cols,
+                &aux.write_z_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();

--- a/vm/src/uint_arithmetic/bridge.rs
+++ b/vm/src/uint_arithmetic/bridge.rs
@@ -29,7 +29,7 @@ impl<const ARG_SIZE: usize, const LIMB_SIZE: usize> UintArithmeticAir<ARG_SIZE, 
         for (ptr, value, mem_aux) in izip!(
             [io.z.ptr, io.x.ptr, io.y.ptr],
             [io.z.address, io.x.address, io.y.address],
-            aux.read_ptr_aux_cols
+            &aux.read_ptr_aux_cols
         ) {
             memory_bridge
                 .read(
@@ -49,7 +49,7 @@ impl<const ARG_SIZE: usize, const LIMB_SIZE: usize> UintArithmeticAir<ARG_SIZE, 
                 MemoryAddress::new(io.x.address_space, io.x.address),
                 io.x.data.try_into().unwrap_or_else(|_| unreachable!()),
                 timestamp + timestamp_delta.clone(),
-                aux.read_x_aux_cols,
+                &aux.read_x_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();
@@ -60,7 +60,7 @@ impl<const ARG_SIZE: usize, const LIMB_SIZE: usize> UintArithmeticAir<ARG_SIZE, 
                 MemoryAddress::new(io.y.address_space, io.y.address),
                 io.y.data.try_into().unwrap_or_else(|_| unreachable!()),
                 timestamp + timestamp_delta.clone(),
-                aux.read_y_aux_cols,
+                &aux.read_y_aux_cols,
             )
             .eval(builder, aux.is_valid);
         timestamp_delta += AB::Expr::one();
@@ -75,7 +75,7 @@ impl<const ARG_SIZE: usize, const LIMB_SIZE: usize> UintArithmeticAir<ARG_SIZE, 
                     .try_into()
                     .unwrap_or_else(|_| unreachable!()),
                 timestamp + timestamp_delta.clone(),
-                aux.write_z_aux_cols,
+                &aux.write_z_aux_cols,
             )
             .eval(builder, enabled.clone());
         timestamp_delta += enabled;
@@ -86,7 +86,7 @@ impl<const ARG_SIZE: usize, const LIMB_SIZE: usize> UintArithmeticAir<ARG_SIZE, 
                 MemoryAddress::new(io.z.address_space, io.z.address),
                 [io.cmp_result],
                 timestamp + timestamp_delta.clone(),
-                aux.write_cmp_aux_cols,
+                &aux.write_cmp_aux_cols,
             )
             .eval(builder, enabled.clone());
         timestamp_delta += enabled;


### PR DESCRIPTION
Also removes unneeded generic paramter on `MemoryBridge`