### PR TITLE
[refactor] Add trait PartitionedBaseAir

### DIFF
--- a/db/page/src/execution_air/air.rs
+++ b/db/page/src/execution_air/air.rs
@@ -1,7 +1,10 @@
 use std::borrow::Borrow;
 
 use afs_primitives::sub_chip::AirConfig;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -9,6 +12,7 @@ use p3_matrix::Matrix;
 use super::{columns::ExecutionCols, ExecutionAir};
 
 impl<F: Field> BaseAirWithPublicValues<F> for ExecutionAir {}
+impl<F: Field> PartitionedBaseAir<F> for ExecutionAir {}
 impl<F: Field> BaseAir<F> for ExecutionAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/group_by/group_by_input/air.rs
+++ b/db/page/src/group_by/group_by_input/air.rs
@@ -5,8 +5,9 @@ use afs_primitives::{
     sub_chip::{AirConfig, SubAir},
 };
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::Field;
@@ -19,6 +20,14 @@ use super::{
 use crate::common::{page::Page, page_cols::PageCols};
 
 impl<F: Field> BaseAirWithPublicValues<F> for GroupByAir {}
+impl<F: Field> PartitionedBaseAir<F> for GroupByAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.page_width]
+    }
+    fn common_main_width(&self) -> usize {
+        <Self as BaseAir<F>>::width(self) - self.page_width
+    }
+}
 impl<F: Field> BaseAir<F> for GroupByAir {
     fn width(&self) -> usize {
         self.get_width()

--- a/db/page/src/group_by/receiving_indexed_output_page_air/air.rs
+++ b/db/page/src/group_by/receiving_indexed_output_page_air/air.rs
@@ -1,7 +1,8 @@
 use afs_primitives::sub_chip::AirConfig;
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, BaseAir};
 use p3_field::Field;
@@ -11,6 +12,14 @@ use super::ReceivingIndexedOutputPageAir;
 use crate::{common::page_cols::PageCols, indexed_output_page_air::columns::IndexedOutputPageCols};
 
 impl<F: Field> BaseAirWithPublicValues<F> for ReceivingIndexedOutputPageAir {}
+impl<F: Field> PartitionedBaseAir<F> for ReceivingIndexedOutputPageAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.page_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.aux_width()
+    }
+}
 impl<F: Field> BaseAir<F> for ReceivingIndexedOutputPageAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/indexed_output_page_air/air.rs
+++ b/db/page/src/indexed_output_page_air/air.rs
@@ -4,8 +4,9 @@ use afs_primitives::{
     utils::{implies, or},
 };
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -18,6 +19,14 @@ use super::{
 use crate::common::page_cols::PageCols;
 
 impl<F: Field> BaseAirWithPublicValues<F> for IndexedOutputPageAir {}
+impl<F: Field> PartitionedBaseAir<F> for IndexedOutputPageAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.page_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.aux_width()
+    }
+}
 impl<F: Field> BaseAir<F> for IndexedOutputPageAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/inner_join/final_table/mod.rs
+++ b/db/page/src/inner_join/final_table/mod.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 
 use afs_primitives::var_range::VariableRangeCheckerChip;
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, BaseAir};
 use p3_field::{Field, PrimeField};
@@ -87,6 +88,14 @@ impl FinalTableAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for FinalTableAir {}
+impl<F: Field> PartitionedBaseAir<F> for FinalTableAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.table_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.aux_width()
+    }
+}
 impl<F: Field> BaseAir<F> for FinalTableAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/inner_join/initial_table/air.rs
+++ b/db/page/src/inner_join/initial_table/air.rs
@@ -1,6 +1,7 @@
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::Field;
@@ -9,6 +10,14 @@ use p3_matrix::Matrix;
 use super::{columns::TableCols, InitialTableAir};
 
 impl<F: Field> BaseAirWithPublicValues<F> for InitialTableAir {}
+impl<F: Field> PartitionedBaseAir<F> for InitialTableAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.table_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.aux_width()
+    }
+}
 impl<F: Field> BaseAir<F> for InitialTableAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/inner_join/intersector/air.rs
+++ b/db/page/src/inner_join/intersector/air.rs
@@ -3,7 +3,10 @@ use afs_primitives::{
     sub_chip::{AirConfig, SubAir},
     utils::or,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -14,6 +17,7 @@ use super::{
 };
 
 impl<F: Field> BaseAirWithPublicValues<F> for IntersectorAir {}
+impl<F: Field> PartitionedBaseAir<F> for IntersectorAir {}
 impl<F: Field> BaseAir<F> for IntersectorAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/multitier_page_rw_checker/internal_page_air/air.rs
+++ b/db/page/src/multitier_page_rw_checker/internal_page_air/air.rs
@@ -5,8 +5,9 @@ use afs_primitives::{
     utils::implies,
 };
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -22,7 +23,16 @@ impl<F: Field, const COMMITMENT_LEN: usize> BaseAir<F> for InternalPageAir<COMMI
         self.air_width()
     }
 }
-
+impl<F: Field, const COMMITMENT_LEN: usize> PartitionedBaseAir<F>
+    for InternalPageAir<COMMITMENT_LEN>
+{
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.cached_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.main_width()
+    }
+}
 impl<F: Field, const COMMITMENT_LEN: usize> BaseAirWithPublicValues<F>
     for InternalPageAir<COMMITMENT_LEN>
 {

--- a/db/page/src/multitier_page_rw_checker/leaf_page_air/air.rs
+++ b/db/page/src/multitier_page_rw_checker/leaf_page_air/air.rs
@@ -3,8 +3,9 @@ use afs_primitives::{
     sub_chip::{AirConfig, SubAir},
 };
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::Field;
@@ -21,7 +22,14 @@ impl<F: Field, const COMMITMENT_LEN: usize> BaseAir<F> for LeafPageAir<COMMITMEN
         self.air_width()
     }
 }
-
+impl<F: Field, const COMMITMENT_LEN: usize> PartitionedBaseAir<F> for LeafPageAir<COMMITMENT_LEN> {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.cached_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.main_width()
+    }
+}
 impl<F: Field, const COMMITMENT_LEN: usize> BaseAirWithPublicValues<F>
     for LeafPageAir<COMMITMENT_LEN>
 {

--- a/db/page/src/multitier_page_rw_checker/root_signal_air/air.rs
+++ b/db/page/src/multitier_page_rw_checker/root_signal_air/air.rs
@@ -1,7 +1,8 @@
 use afs_primitives::sub_chip::AirConfig;
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::Field;
@@ -13,6 +14,11 @@ impl<F: Field, const COMMITMENT_LEN: usize> BaseAir<F> for RootSignalAir<COMMITM
     fn width(&self) -> usize {
         self.air_width()
     }
+}
+
+impl<F: Field, const COMMITMENT_LEN: usize> PartitionedBaseAir<F>
+    for RootSignalAir<COMMITMENT_LEN>
+{
 }
 
 impl<F: Field, const COMMITMENT_LEN: usize> BaseAirWithPublicValues<F>

--- a/db/page/src/page_access_by_row_id/air.rs
+++ b/db/page/src/page_access_by_row_id/air.rs
@@ -1,8 +1,9 @@
 use std::{borrow::Borrow, iter};
 
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use itertools::Itertools;
 use p3_air::{Air, AirBuilder, BaseAir};
@@ -41,6 +42,14 @@ impl PageAccessByRowIdAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for PageAccessByRowIdAir {}
+impl<F: Field> PartitionedBaseAir<F> for PageAccessByRowIdAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.page_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.air_width() - self.page_width()
+    }
+}
 impl<F: Field> BaseAir<F> for PageAccessByRowIdAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/page_rw_checker/final_page/air.rs
+++ b/db/page/src/page_rw_checker/final_page/air.rs
@@ -1,7 +1,8 @@
 use afs_primitives::sub_chip::{AirConfig, SubAir};
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -14,6 +15,14 @@ use super::{
 use crate::{common::page_cols::PageCols, indexed_output_page_air::columns::IndexedOutputPageCols};
 
 impl<F: Field> BaseAirWithPublicValues<F> for IndexedPageWriteAir {}
+impl<F: Field> PartitionedBaseAir<F> for IndexedPageWriteAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.page_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.aux_width()
+    }
+}
 impl<F: Field> BaseAir<F> for IndexedPageWriteAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/page_rw_checker/initial_page/air.rs
+++ b/db/page/src/page_rw_checker/initial_page/air.rs
@@ -1,5 +1,8 @@
 use afs_primitives::sub_chip::{AirConfig, SubAir};
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -30,6 +33,7 @@ impl PageReadAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for PageReadAir {}
+impl<F: Field> PartitionedBaseAir<F> for PageReadAir {}
 impl<F: Field> BaseAir<F> for PageReadAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/page_rw_checker/offline_checker/air.rs
+++ b/db/page/src/page_rw_checker/offline_checker/air.rs
@@ -2,7 +2,10 @@ use afs_primitives::{
     sub_chip::SubAir,
     utils::{and, implies, or},
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -10,6 +13,7 @@ use p3_matrix::Matrix;
 use super::{columns::PageOfflineCheckerCols, PageOfflineChecker};
 
 impl<F: Field> BaseAirWithPublicValues<F> for PageOfflineChecker {}
+impl<F: Field> PartitionedBaseAir<F> for PageOfflineChecker {}
 impl<F: Field> BaseAir<F> for PageOfflineChecker {
     fn width(&self) -> usize {
         self.air_width()

--- a/db/page/src/single_page_index_scan/page_index_scan_input/air.rs
+++ b/db/page/src/single_page_index_scan/page_index_scan_input/air.rs
@@ -11,8 +11,9 @@ use afs_primitives::{
     var_range::bus::VariableRangeCheckerBus,
 };
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilderWithPublicValues, BaseAir};
 use p3_field::Field;
@@ -194,6 +195,14 @@ impl<F: Field> BaseAir<F> for PageIndexScanInputAir {
                 )
             }
         }
+    }
+}
+impl<F: Field> PartitionedBaseAir<F> for PageIndexScanInputAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.page_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.aux_width()
     }
 }
 impl<F: Field> BaseAirWithPublicValues<F> for PageIndexScanInputAir {

--- a/db/page/src/single_page_index_scan/page_index_scan_output.rs
+++ b/db/page/src/single_page_index_scan/page_index_scan_output.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use afs_primitives::var_range::VariableRangeCheckerChip;
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, interaction::InteractionBuilder,
-    rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use itertools::Itertools;
 use p3_air::{Air, BaseAir};
@@ -36,6 +37,14 @@ impl PageIndexScanOutputAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for PageIndexScanOutputAir {}
+impl<F: Field> PartitionedBaseAir<F> for PageIndexScanOutputAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.page_width()]
+    }
+    fn common_main_width(&self) -> usize {
+        self.aux_width()
+    }
+}
 impl<F: Field> BaseAir<F> for PageIndexScanOutputAir {
     fn width(&self) -> usize {
         BaseAir::<F>::width(&self.inner)

--- a/ecc/primitives/src/field_expression/builder.rs
+++ b/ecc/primitives/src/field_expression/builder.rs
@@ -10,7 +10,10 @@ use afs_primitives::{
     sub_chip::{AirConfig, LocalTraceInstructions},
     var_range::VariableRangeCheckerChip,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use num_bigint_dig::{BigInt, BigUint, Sign};
 use num_traits::Zero;
 use p3_air::{Air, AirBuilder, BaseAir};
@@ -94,6 +97,7 @@ impl Deref for FieldExprChip {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for FieldExprChip {}
+impl<F: Field> PartitionedBaseAir<F> for FieldExprChip {}
 impl<F: Field> BaseAir<F> for FieldExprChip {
     fn width(&self) -> usize {
         self.num_limbs * (self.builder.num_input + self.builder.num_variables)

--- a/poseidon2-air/src/poseidon2/air.rs
+++ b/poseidon2-air/src/poseidon2/air.rs
@@ -1,7 +1,10 @@
 use std::borrow::Borrow;
 
 use afs_primitives::sub_chip::{AirConfig, SubAir};
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::BabyBear;
 use p3_field::{AbstractField, Field};
@@ -180,6 +183,7 @@ impl Default for Poseidon2Air<16, BabyBear> {
 }
 
 impl<const WIDTH: usize, F: Field> BaseAirWithPublicValues<F> for Poseidon2Air<WIDTH, F> {}
+impl<const WIDTH: usize, F: Field> PartitionedBaseAir<F> for Poseidon2Air<WIDTH, F> {}
 impl<const WIDTH: usize, F: Field> BaseAir<F> for Poseidon2Air<WIDTH, F> {
     fn width(&self) -> usize {
         self.get_width()

--- a/primitives/src/assert_less_than/air.rs
+++ b/primitives/src/assert_less_than/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -81,6 +84,7 @@ impl<const AUX_LEN: usize> AirConfig for AssertLessThanAir<AUX_LEN> {
 }
 
 impl<F: Field, const AUX_LEN: usize> BaseAirWithPublicValues<F> for AssertLessThanAir<AUX_LEN> {}
+impl<F: Field, const AUX_LEN: usize> PartitionedBaseAir<F> for AssertLessThanAir<AUX_LEN> {}
 impl<F: Field, const AUX_LEN: usize> BaseAir<F> for AssertLessThanAir<AUX_LEN> {
     fn width(&self) -> usize {
         AssertLessThanCols::<F, AUX_LEN>::width()

--- a/primitives/src/assert_sorted/air.rs
+++ b/primitives/src/assert_sorted/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -27,6 +30,7 @@ impl AssertSortedAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for AssertSortedAir {}
+impl<F: Field> PartitionedBaseAir<F> for AssertSortedAir {}
 impl<F: Field> BaseAir<F> for AssertSortedAir {
     fn width(&self) -> usize {
         AssertSortedCols::<F>::get_width(

--- a/primitives/src/bigint/modular_arithmetic/add.rs
+++ b/primitives/src/bigint/modular_arithmetic/add.rs
@@ -1,6 +1,9 @@
 use std::{ops::Deref, sync::Arc};
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use num_bigint_dig::{BigInt, BigUint, Sign};
 use p3_air::{Air, BaseAir};
 use p3_field::{Field, PrimeField64};
@@ -30,6 +33,7 @@ impl AirConfig for ModularAdditionAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for ModularAdditionAir {}
+impl<F: Field> PartitionedBaseAir<F> for ModularAdditionAir {}
 impl<F: Field> BaseAir<F> for ModularAdditionAir {
     fn width(&self) -> usize {
         self.arithmetic.width()

--- a/primitives/src/bigint/modular_arithmetic/div.rs
+++ b/primitives/src/bigint/modular_arithmetic/div.rs
@@ -1,6 +1,9 @@
 use std::{ops::Deref, sync::Arc};
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use num_bigint_dig::{BigInt, BigUint, Sign};
 use p3_air::{Air, BaseAir};
 use p3_field::{Field, PrimeField64};
@@ -29,6 +32,7 @@ impl Deref for ModularDivisionAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for ModularDivisionAir {}
+impl<F: Field> PartitionedBaseAir<F> for ModularDivisionAir {}
 impl<F: Field> BaseAir<F> for ModularDivisionAir {
     fn width(&self) -> usize {
         self.arithmetic.width()

--- a/primitives/src/bigint/modular_arithmetic/mul.rs
+++ b/primitives/src/bigint/modular_arithmetic/mul.rs
@@ -1,6 +1,9 @@
 use std::{ops::Deref, sync::Arc};
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use num_bigint_dig::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use p3_air::{Air, BaseAir};
@@ -27,6 +30,7 @@ impl Deref for ModularMultiplicationAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for ModularMultiplicationAir {}
+impl<F: Field> PartitionedBaseAir<F> for ModularMultiplicationAir {}
 impl<F: Field> BaseAir<F> for ModularMultiplicationAir {
     fn width(&self) -> usize {
         self.arithmetic.width()

--- a/primitives/src/bigint/modular_arithmetic/sub.rs
+++ b/primitives/src/bigint/modular_arithmetic/sub.rs
@@ -1,6 +1,9 @@
 use std::{ops::Deref, sync::Arc};
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use num_bigint_dig::{BigInt, BigUint, Sign};
 use p3_air::{Air, BaseAir};
 use p3_field::{Field, PrimeField64};
@@ -29,6 +32,7 @@ impl Deref for ModularSubtractionAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for ModularSubtractionAir {}
+impl<F: Field> PartitionedBaseAir<F> for ModularSubtractionAir {}
 impl<F: Field> BaseAir<F> for ModularSubtractionAir {
     fn width(&self) -> usize {
         self.arithmetic.width()

--- a/primitives/src/bigint/tests/check_carry_mod_zero_test.rs
+++ b/primitives/src/bigint/tests/check_carry_mod_zero_test.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Borrow, sync::Arc};
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use ax_sdk::{
     any_rap_vec, config::baby_bear_blake3::BabyBearBlake3Engine, engine::StarkFriEngine,
     utils::create_seeded_rng,
@@ -86,6 +89,7 @@ impl AirConfig for TestCarryAir<N> {
 }
 
 impl<F: Field, const N: usize> BaseAirWithPublicValues<F> for TestCarryAir<N> {}
+impl<F: Field, const N: usize> PartitionedBaseAir<F> for TestCarryAir<N> {}
 impl<F: Field, const N: usize> BaseAir<F> for TestCarryAir<N> {
     fn width(&self) -> usize {
         TestCarryCols::<N, F>::get_width()

--- a/primitives/src/bigint/tests/check_carry_to_zero_test.rs
+++ b/primitives/src/bigint/tests/check_carry_to_zero_test.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Borrow, sync::Arc};
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use ax_sdk::{
     any_rap_vec, config::baby_bear_blake3::BabyBearBlake3Engine, engine::StarkFriEngine,
     utils::create_seeded_rng,
@@ -80,6 +83,7 @@ impl AirConfig for TestCarryAir<N> {
 }
 
 impl<F: Field, const N: usize> BaseAirWithPublicValues<F> for TestCarryAir<N> {}
+impl<F: Field, const N: usize> PartitionedBaseAir<F> for TestCarryAir<N> {}
 impl<F: Field, const N: usize> BaseAir<F> for TestCarryAir<N> {
     fn width(&self) -> usize {
         TestCarryCols::<N, F>::get_width()

--- a/primitives/src/bitwise_op_lookup/air.rs
+++ b/primitives/src/bitwise_op_lookup/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir, PairBuilder};
 use p3_field::{AbstractField, Field};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -25,6 +28,10 @@ pub struct BitwiseOperationLookupAir<const NUM_BITS: usize> {
 }
 
 impl<F: Field, const NUM_BITS: usize> BaseAirWithPublicValues<F>
+    for BitwiseOperationLookupAir<NUM_BITS>
+{
+}
+impl<F: Field, const NUM_BITS: usize> PartitionedBaseAir<F>
     for BitwiseOperationLookupAir<NUM_BITS>
 {
 }

--- a/primitives/src/bitwise_op_lookup/tests/dummy.rs
+++ b/primitives/src/bitwise_op_lookup/tests/dummy.rs
@@ -1,4 +1,7 @@
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -16,6 +19,7 @@ impl DummyAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for DummyAir {}
+impl<F: Field> PartitionedBaseAir<F> for DummyAir {}
 impl<F: Field> BaseAir<F> for DummyAir {
     fn width(&self) -> usize {
         4

--- a/primitives/src/ecc/air.rs
+++ b/primitives/src/ecc/air.rs
@@ -1,6 +1,9 @@
 use std::ops::Deref;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use num_bigint_dig::BigUint;
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -87,6 +90,7 @@ impl EcAirConfig {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for EcAddUnequalAir {}
+impl<F: Field> PartitionedBaseAir<F> for EcAddUnequalAir {}
 impl<F: Field> BaseAir<F> for EcAddUnequalAir {
     fn width(&self) -> usize {
         EcAddCols::<F, DefaultLimbConfig>::width(self)
@@ -98,6 +102,7 @@ impl AirConfig for EcAddUnequalAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for EcDoubleAir {}
+impl<F: Field> PartitionedBaseAir<F> for EcDoubleAir {}
 impl<F: Field> BaseAir<F> for EcDoubleAir {
     fn width(&self) -> usize {
         EcDoubleCols::<F, DefaultLimbConfig>::width(self)

--- a/primitives/src/is_equal/air.rs
+++ b/primitives/src/is_equal/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -18,6 +18,7 @@ impl IsEqualAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for IsEqualAir {}
+impl<F: Field> PartitionedBaseAir<F> for IsEqualAir {}
 impl<F: Field> BaseAir<F> for IsEqualAir {
     fn width(&self) -> usize {
         NUM_COLS

--- a/primitives/src/is_equal_vec/air.rs
+++ b/primitives/src/is_equal_vec/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -36,6 +36,7 @@ impl AirConfig for IsEqualVecAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for IsEqualVecAir {}
+impl<F: Field> PartitionedBaseAir<F> for IsEqualVecAir {}
 impl<F: Field> BaseAir<F> for IsEqualVecAir {
     fn width(&self) -> usize {
         self.get_width()

--- a/primitives/src/is_less_than/air.rs
+++ b/primitives/src/is_less_than/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -85,6 +88,7 @@ impl AirConfig for IsLessThanAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for IsLessThanAir {}
+impl<F: Field> PartitionedBaseAir<F> for IsLessThanAir {}
 impl<F: Field> BaseAir<F> for IsLessThanAir {
     fn width(&self) -> usize {
         IsLessThanCols::<F>::width(self)

--- a/primitives/src/is_less_than_bits/air.rs
+++ b/primitives/src/is_less_than_bits/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::AbstractField;
 use p3_matrix::Matrix;
@@ -24,6 +24,7 @@ impl AirConfig for IsLessThanBitsAir {
 }
 
 impl<F> BaseAirWithPublicValues<F> for IsLessThanBitsAir {}
+impl<F> PartitionedBaseAir<F> for IsLessThanBitsAir {}
 impl<F> BaseAir<F> for IsLessThanBitsAir {
     fn width(&self) -> usize {
         3 + (self.limb_bits + 1)

--- a/primitives/src/is_less_than_tuple/air.rs
+++ b/primitives/src/is_less_than_tuple/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -121,6 +124,7 @@ impl AirConfig for IsLessThanTupleAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for IsLessThanTupleAir {}
+impl<F: Field> PartitionedBaseAir<F> for IsLessThanTupleAir {}
 impl<F: Field> BaseAir<F> for IsLessThanTupleAir {
     fn width(&self) -> usize {
         IsLessThanTupleCols::<F>::width(self)

--- a/primitives/src/is_less_than_tuple_bits/air.rs
+++ b/primitives/src/is_less_than_tuple_bits/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -55,6 +55,7 @@ impl AirConfig for IsLessThanTupleBitsAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for IsLessThanTupleBitsAir {}
+impl<F: Field> PartitionedBaseAir<F> for IsLessThanTupleBitsAir {}
 impl<F: Field> BaseAir<F> for IsLessThanTupleBitsAir {
     fn width(&self) -> usize {
         IsLessThanTupleBitsCols::<F>::get_width(self.limb_bits().clone(), self.tuple_len())

--- a/primitives/src/is_zero/air.rs
+++ b/primitives/src/is_zero/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -19,6 +19,7 @@ impl IsZeroAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for IsZeroAir {}
+impl<F: Field> PartitionedBaseAir<F> for IsZeroAir {}
 impl<F: Field> BaseAir<F> for IsZeroAir {
     fn width(&self) -> usize {
         NUM_COLS

--- a/primitives/src/merkle_proof/air.rs
+++ b/primitives/src/merkle_proof/air.rs
@@ -9,6 +9,9 @@ use super::{
     MerkleProofAir,
 };
 
+impl<F, const DEPTH: usize, const DIGEST_WIDTH: usize> PartitionedBaseAir<F>
+    for MerkleProofAir<DEPTH, DIGEST_WIDTH>
+{ }
 impl<F, const DEPTH: usize, const DIGEST_WIDTH: usize> BaseAir<F>
     for MerkleProofAir<DEPTH, DIGEST_WIDTH>
 {

--- a/primitives/src/offline_checker/air.rs
+++ b/primitives/src/offline_checker/air.rs
@@ -1,6 +1,9 @@
 use std::iter;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field, PrimeField};
 use p3_matrix::Matrix;
@@ -26,6 +29,7 @@ impl<F: PrimeField, Operation: OfflineCheckerOperation<F>> AirConfig
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for OfflineChecker {}
+impl<F: Field> PartitionedBaseAir<F> for OfflineChecker {}
 impl<F: Field> BaseAir<F> for OfflineChecker {
     fn width(&self) -> usize {
         self.air_width()

--- a/primitives/src/range/air.rs
+++ b/primitives/src/range/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir, PairBuilder};
 use p3_field::Field;
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -22,6 +25,7 @@ impl RangeCheckerAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for RangeCheckerAir {}
+impl<F: Field> PartitionedBaseAir<F> for RangeCheckerAir {}
 impl<F: Field> BaseAir<F> for RangeCheckerAir {
     fn width(&self) -> usize {
         NUM_RANGE_COLS

--- a/primitives/src/range/tests/list/air.rs
+++ b/primitives/src/range/tests/list/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -15,6 +18,7 @@ pub struct ListAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for ListAir {}
+impl<F: Field> PartitionedBaseAir<F> for ListAir {}
 impl<F: Field> BaseAir<F> for ListAir {
     fn width(&self) -> usize {
         NUM_LIST_COLS

--- a/primitives/src/range_gate/air.rs
+++ b/primitives/src/range_gate/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -14,6 +17,7 @@ pub struct RangeCheckerGateAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for RangeCheckerGateAir {}
+impl<F: Field> PartitionedBaseAir<F> for RangeCheckerGateAir {}
 impl<F: Field> BaseAir<F> for RangeCheckerGateAir {
     fn width(&self) -> usize {
         NUM_RANGE_GATE_COLS

--- a/primitives/src/range_tuple/air.rs
+++ b/primitives/src/range_tuple/air.rs
@@ -1,4 +1,7 @@
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir, PairBuilder};
 use p3_field::Field;
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -18,6 +21,7 @@ impl RangeTupleCheckerAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for RangeTupleCheckerAir {}
+impl<F: Field> PartitionedBaseAir<F> for RangeTupleCheckerAir {}
 impl<F: Field> BaseAir<F> for RangeTupleCheckerAir {
     fn width(&self) -> usize {
         NUM_RANGE_TUPLE_COLS

--- a/primitives/src/sum/columns.rs
+++ b/primitives/src/sum/columns.rs
@@ -1,5 +1,5 @@
 use afs_derive::AlignedBorrow;
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::BaseAir;
 
 use super::SumAir;
@@ -56,3 +56,4 @@ impl<T: Clone> BaseAir<T> for SumAir {
 }
 
 impl<T: Clone> BaseAirWithPublicValues<T> for SumAir {}
+impl<T: Clone> PartitionedBaseAir<T> for SumAir {}

--- a/primitives/src/var_range/air.rs
+++ b/primitives/src/var_range/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir, PairBuilder};
 use p3_field::Field;
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -25,6 +28,7 @@ impl VariableRangeCheckerAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for VariableRangeCheckerAir {}
+impl<F: Field> PartitionedBaseAir<F> for VariableRangeCheckerAir {}
 impl<F: Field> BaseAir<F> for VariableRangeCheckerAir {
     fn width(&self) -> usize {
         NUM_VARIABLE_RANGE_COLS

--- a/primitives/src/var_range/tests/dummy_airs.rs
+++ b/primitives/src/var_range/tests/dummy_airs.rs
@@ -1,4 +1,7 @@
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -17,6 +20,7 @@ impl TestSendAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for TestSendAir {}
+impl<F: Field> PartitionedBaseAir<F> for TestSendAir {}
 impl<F: Field> BaseAir<F> for TestSendAir {
     fn width(&self) -> usize {
         2
@@ -51,6 +55,7 @@ impl TestRangeCheckAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for TestRangeCheckAir {}
+impl<F: Field> PartitionedBaseAir<F> for TestRangeCheckAir {}
 impl<F: Field> BaseAir<F> for TestRangeCheckAir {
     fn width(&self) -> usize {
         1

--- a/primitives/src/xor/bits/air.rs
+++ b/primitives/src/xor/bits/air.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Borrow, iter::zip};
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -30,6 +33,7 @@ impl<const N: usize> AirConfig for XorBitsAir<N> {
 }
 
 impl<F: Field, const N: usize> BaseAirWithPublicValues<F> for XorBitsAir<N> {}
+impl<F: Field, const N: usize> PartitionedBaseAir<F> for XorBitsAir<N> {}
 impl<F: Field, const N: usize> BaseAir<F> for XorBitsAir<N> {
     fn width(&self) -> usize {
         XorCols::<N, F>::get_width()

--- a/primitives/src/xor/bits/tests/xor_requester/air.rs
+++ b/primitives/src/xor/bits/tests/xor_requester/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -14,6 +17,7 @@ pub struct XorRequesterAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for XorRequesterAir {}
+impl<F: Field> PartitionedBaseAir<F> for XorRequesterAir {}
 impl<F: Field> BaseAir<F> for XorRequesterAir {
     fn width(&self) -> usize {
         NUM_XOR_REQUESTER_COLS

--- a/primitives/src/xor/limbs/air.rs
+++ b/primitives/src/xor/limbs/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -22,6 +25,7 @@ impl<const N: usize, const M: usize> XorLimbsAir<N, M> {
 }
 
 impl<F: Field, const N: usize, const M: usize> BaseAirWithPublicValues<F> for XorLimbsAir<N, M> {}
+impl<F: Field, const N: usize, const M: usize> PartitionedBaseAir<F> for XorLimbsAir<N, M> {}
 impl<F: Field, const N: usize, const M: usize> BaseAir<F> for XorLimbsAir<N, M> {
     fn width(&self) -> usize {
         XorLimbsCols::<N, M, F>::get_width()

--- a/primitives/src/xor/lookup/air.rs
+++ b/primitives/src/xor/lookup/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir, PairBuilder};
 use p3_field::Field;
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -14,6 +17,7 @@ pub struct XorLookupAir<const M: usize> {
 }
 
 impl<F: Field, const M: usize> BaseAirWithPublicValues<F> for XorLookupAir<M> {}
+impl<F: Field, const M: usize> PartitionedBaseAir<F> for XorLookupAir<M> {}
 impl<F: Field, const M: usize> BaseAir<F> for XorLookupAir<M> {
     fn width(&self) -> usize {
         NUM_XOR_LOOKUP_COLS

--- a/recursion/src/bin/small_e2e.rs
+++ b/recursion/src/bin/small_e2e.rs
@@ -15,7 +15,7 @@ use ax_sdk::{
     bench::run_with_metric_collection,
     config::{
         baby_bear_poseidon2::BabyBearPoseidon2Engine,
-        fri_params::standard_fri_params_with_100_bits_conjectured_security, FriParameters,
+        fri_params::standard_fri_params_with_100_bits_conjectured_security,
     },
     engine::{StarkForTest, StarkFriEngine},
 };

--- a/recursion/tests/cached_trace.rs
+++ b/recursion/tests/cached_trace.rs
@@ -1,8 +1,10 @@
 use afs_compiler::util::execute_program;
 use afs_recursion::testing_utils::inner::build_verification_program;
 use afs_stark_backend::{
-    air_builders::PartitionedAirBuilder, engine::VerificationData,
-    prover::trace::TraceCommitmentBuilder, rap::BaseAirWithPublicValues,
+    air_builders::PartitionedAirBuilder,
+    engine::VerificationData,
+    prover::trace::TraceCommitmentBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
     verifier::VerificationError,
 };
 use ax_sdk::{
@@ -22,6 +24,14 @@ use rand::{rngs::StdRng, SeedableRng};
 pub struct SumAir(pub usize);
 
 impl<F> BaseAirWithPublicValues<F> for SumAir {}
+impl<F> PartitionedBaseAir<F> for SumAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.0]
+    }
+    fn common_main_width(&self) -> usize {
+        1
+    }
+}
 impl<F> BaseAir<F> for SumAir {
     fn width(&self) -> usize {
         self.0 + 1

--- a/sdk/src/interaction/dummy_interaction_air.rs
+++ b/sdk/src/interaction/dummy_interaction_air.rs
@@ -7,7 +7,7 @@
 use afs_stark_backend::{
     air_builders::PartitionedAirBuilder,
     interaction::{InteractionBuilder, InteractionType},
-    rap::BaseAirWithPublicValues,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, BaseAir};
 use p3_field::Field;
@@ -55,6 +55,22 @@ impl DummyInteractionAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for DummyInteractionAir {}
+impl<F: Field> PartitionedBaseAir<F> for DummyInteractionAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        if self.partition {
+            vec![1]
+        } else {
+            vec![]
+        }
+    }
+    fn common_main_width(&self) -> usize {
+        if self.partition {
+            self.field_width
+        } else {
+            1 + self.field_width
+        }
+    }
+}
 impl<F: Field> BaseAir<F> for DummyInteractionAir {
     fn width(&self) -> usize {
         1 + self.field_width

--- a/sdk/src/utils.rs
+++ b/sdk/src/utils.rs
@@ -1,4 +1,4 @@
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use itertools::Itertools;
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{AbstractField, PrimeField};
@@ -7,6 +7,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 
 pub struct FibonacciAir;
 
+impl<F> PartitionedBaseAir<F> for FibonacciAir {}
 impl<F> BaseAir<F> for FibonacciAir {
     fn width(&self) -> usize {
         2

--- a/stark-backend/src/rap.rs
+++ b/stark-backend/src/rap.rs
@@ -18,6 +18,18 @@ pub trait BaseAirWithPublicValues<F>: BaseAir<F> {
     }
 }
 
+/// An AIR with 1 or more main trace partitions.
+pub trait PartitionedBaseAir<F>: BaseAir<F> {
+    /// By default, an AIR has no cached main trace.
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![]
+    }
+    /// By default, an AIR has only one private main trace.
+    fn common_main_width(&self) -> usize {
+        self.width()
+    }
+}
+
 /// An AIR that works with a particular `AirBuilder` which allows preprocessing
 /// and injected randomness.
 ///
@@ -53,6 +65,7 @@ pub trait AnyRap<SC: StarkGenericConfig>:
     + for<'a> Rap<ProverConstraintFolder<'a, SC>> // for prover quotient polynomial calculation
     + for<'a> Rap<DebugConstraintBuilder<'a, SC>> // for debugging
     + BaseAirWithPublicValues<Val<SC>>
+    + PartitionedBaseAir<Val<SC>>
 {
     fn as_any(&self) -> &dyn Any;
     /// Name for display purposes
@@ -66,6 +79,7 @@ where
         + for<'a> Rap<ProverConstraintFolder<'a, SC>>
         + for<'a> Rap<DebugConstraintBuilder<'a, SC>>
         + BaseAirWithPublicValues<Val<SC>>
+        + PartitionedBaseAir<Val<SC>>
         + 'static,
 {
     fn as_any(&self) -> &dyn Any {

--- a/stark-backend/tests/fib_air/air.rs
+++ b/stark-backend/tests/fib_air/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_matrix::Matrix;
 
@@ -8,6 +8,7 @@ use super::columns::{FibonacciCols, NUM_FIBONACCI_COLS};
 
 pub struct FibonacciAir;
 
+impl<F> PartitionedBaseAir<F> for FibonacciAir {}
 impl<F> BaseAir<F> for FibonacciAir {
     fn width(&self) -> usize {
         NUM_FIBONACCI_COLS

--- a/stark-backend/tests/fib_selector_air/air.rs
+++ b/stark-backend/tests/fib_selector_air/air.rs
@@ -1,6 +1,9 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder};
 use p3_field::{AbstractField, Field};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -26,6 +29,7 @@ impl FibonacciSelectorAir {
     }
 }
 
+impl<F: Field> PartitionedBaseAir<F> for FibonacciSelectorAir {}
 impl<F: Field> BaseAir<F> for FibonacciSelectorAir {
     fn width(&self) -> usize {
         NUM_FIBONACCI_COLS

--- a/stark-backend/tests/fib_triples_air/air.rs
+++ b/stark-backend/tests/fib_triples_air/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_stark_backend::rap::BaseAirWithPublicValues;
+use afs_stark_backend::rap::{BaseAirWithPublicValues, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_matrix::Matrix;
 
@@ -8,6 +8,7 @@ use super::columns::{FibonacciCols, NUM_FIBONACCI_COLS};
 
 pub struct FibonacciAir;
 
+impl<F> PartitionedBaseAir<F> for FibonacciAir {}
 impl<F> BaseAir<F> for FibonacciAir {
     fn width(&self) -> usize {
         NUM_FIBONACCI_COLS

--- a/stark-backend/tests/partitioned_sum_air/air.rs
+++ b/stark-backend/tests/partitioned_sum_air/air.rs
@@ -3,7 +3,10 @@
 //!
 //! Constrains x == a_0 + ... + a_w
 
-use afs_stark_backend::{air_builders::PartitionedAirBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    air_builders::PartitionedAirBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::AbstractField;
 use p3_matrix::Matrix;
@@ -12,6 +15,14 @@ use p3_matrix::Matrix;
 pub struct SumAir(pub usize);
 
 impl<F> BaseAirWithPublicValues<F> for SumAir {}
+impl<F> PartitionedBaseAir<F> for SumAir {
+    fn cached_main_widths(&self) -> Vec<usize> {
+        vec![self.0]
+    }
+    fn common_main_width(&self) -> usize {
+        1
+    }
+}
 impl<F> BaseAir<F> for SumAir {
     fn width(&self) -> usize {
         self.0 + 1

--- a/vm/src/alu/air.rs
+++ b/vm/src/alu/air.rs
@@ -1,7 +1,10 @@
 use std::{array, borrow::Borrow};
 
 use afs_primitives::{utils, xor::bus::XorBus};
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -19,6 +22,10 @@ pub struct ArithmeticLogicAir<const ARG_SIZE: usize, const LIMB_SIZE: usize> {
     pub bus: XorBus,
 }
 
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> PartitionedBaseAir<F>
+    for ArithmeticLogicAir<NUM_LIMBS, LIMB_BITS>
+{
+}
 impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAir<F>
     for ArithmeticLogicAir<NUM_LIMBS, LIMB_BITS>
 {

--- a/vm/src/arch/testing/execution/air.rs
+++ b/vm/src/arch/testing/execution/air.rs
@@ -1,7 +1,10 @@
 use std::{borrow::Borrow, mem::size_of};
 
 use afs_derive::AlignedBorrow;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -23,6 +26,7 @@ pub struct ExecutionDummyAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for ExecutionDummyAir {}
+impl<F: Field> PartitionedBaseAir<F> for ExecutionDummyAir {}
 impl<F: Field> BaseAir<F> for ExecutionDummyAir {
     fn width(&self) -> usize {
         size_of::<DummyExecutionInteractionCols<u8>>()

--- a/vm/src/arch/testing/memory/air.rs
+++ b/vm/src/arch/testing/memory/air.rs
@@ -1,7 +1,10 @@
 use std::{borrow::Borrow, mem::size_of};
 
 use afs_derive::AlignedBorrow;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_matrix::Matrix;
 
@@ -23,6 +26,7 @@ pub struct MemoryDummyAir<const BLOCK_SIZE: usize> {
 }
 
 impl<const BLOCK_SIZE: usize, F> BaseAirWithPublicValues<F> for MemoryDummyAir<BLOCK_SIZE> {}
+impl<const BLOCK_SIZE: usize, F> PartitionedBaseAir<F> for MemoryDummyAir<BLOCK_SIZE> {}
 impl<const BLOCK_SIZE: usize, F> BaseAir<F> for MemoryDummyAir<BLOCK_SIZE> {
     fn width(&self) -> usize {
         size_of::<DummyMemoryInteractionCols<u8, BLOCK_SIZE>>()

--- a/vm/src/arch/testing/program/air.rs
+++ b/vm/src/arch/testing/program/air.rs
@@ -1,4 +1,7 @@
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -12,6 +15,7 @@ pub struct ProgramDummyAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for ProgramDummyAir {}
+impl<F: Field> PartitionedBaseAir<F> for ProgramDummyAir {}
 impl<F: Field> BaseAir<F> for ProgramDummyAir {
     fn width(&self) -> usize {
         ProgramTester::<F>::width()

--- a/vm/src/castf/air.rs
+++ b/vm/src/castf/air.rs
@@ -1,7 +1,10 @@
 use std::borrow::Borrow;
 
 use afs_primitives::var_range::bus::VariableRangeCheckerBus;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -24,6 +27,7 @@ pub struct CastFAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for CastFAir {}
+impl<F: Field> PartitionedBaseAir<F> for CastFAir {}
 impl<F: Field> BaseAir<F> for CastFAir {
     fn width(&self) -> usize {
         CastFCols::<F>::width()

--- a/vm/src/core/air.rs
+++ b/vm/src/core/air.rs
@@ -4,7 +4,10 @@ use afs_primitives::{
     is_equal::{columns::IsEqualIoCols, IsEqualAir},
     sub_chip::SubAir,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use itertools::izip;
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -27,6 +30,7 @@ pub struct CoreAir {
     pub memory_bridge: MemoryBridge,
 }
 
+impl<F: Field> PartitionedBaseAir<F> for CoreAir {}
 impl<F: Field> BaseAir<F> for CoreAir {
     fn width(&self) -> usize {
         CoreCols::<F>::get_width(self)

--- a/vm/src/ecc/air.rs
+++ b/vm/src/ecc/air.rs
@@ -8,7 +8,10 @@ use afs_primitives::{
     },
     sub_chip::SubAir,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -24,6 +27,7 @@ pub struct EcAddUnequalVmAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for EcAddUnequalVmAir {}
+impl<F: Field> PartitionedBaseAir<F> for EcAddUnequalVmAir {}
 impl<F: Field> BaseAir<F> for EcAddUnequalVmAir {
     fn width(&self) -> usize {
         EcAddUnequalCols::<F>::width(&self.air.config)
@@ -76,6 +80,7 @@ pub struct EcDoubleVmAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for EcDoubleVmAir {}
+impl<F: Field> PartitionedBaseAir<F> for EcDoubleVmAir {}
 impl<F: Field> BaseAir<F> for EcDoubleVmAir {
     fn width(&self) -> usize {
         EcDoubleCols::<F>::width(&self.air.config)

--- a/vm/src/field_arithmetic/air.rs
+++ b/vm/src/field_arithmetic/air.rs
@@ -1,5 +1,8 @@
 use afs_primitives::sub_chip::AirConfig;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use itertools::izip;
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -29,6 +32,7 @@ impl AirConfig for FieldArithmeticAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for FieldArithmeticAir {}
+impl<F: Field> PartitionedBaseAir<F> for FieldArithmeticAir {}
 impl<F: Field> BaseAir<F> for FieldArithmeticAir {
     fn width(&self) -> usize {
         FieldArithmeticCols::<F>::get_width()

--- a/vm/src/field_extension/air.rs
+++ b/vm/src/field_extension/air.rs
@@ -1,5 +1,8 @@
 use afs_primitives::sub_chip::AirConfig;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use itertools::izip;
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
@@ -29,6 +32,7 @@ impl AirConfig for FieldExtensionArithmeticAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for FieldExtensionArithmeticAir {}
+impl<F: Field> PartitionedBaseAir<F> for FieldExtensionArithmeticAir {}
 impl<F: Field> BaseAir<F> for FieldExtensionArithmeticAir {
     fn width(&self) -> usize {
         FieldExtensionArithmeticCols::<F>::get_width()

--- a/vm/src/hashes/keccak/hasher/air.rs
+++ b/vm/src/hashes/keccak/hasher/air.rs
@@ -2,7 +2,9 @@ use std::borrow::Borrow;
 
 use afs_primitives::{utils::not, xor::bus::XorBus};
 use afs_stark_backend::{
-    air_builders::sub::SubAirBuilder, interaction::InteractionBuilder, rap::BaseAirWithPublicValues,
+    air_builders::sub::SubAirBuilder,
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::AbstractField;
@@ -25,6 +27,7 @@ pub struct KeccakVmAir {
 }
 
 impl<F> BaseAirWithPublicValues<F> for KeccakVmAir {}
+impl<F> PartitionedBaseAir<F> for KeccakVmAir {}
 impl<F> BaseAir<F> for KeccakVmAir {
     fn width(&self) -> usize {
         NUM_KECCAK_VM_COLS

--- a/vm/src/hashes/poseidon2/air.rs
+++ b/vm/src/hashes/poseidon2/air.rs
@@ -1,7 +1,10 @@
 use std::borrow::Borrow;
 
 use afs_primitives::sub_chip::AirConfig;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use derive_new::new;
 use itertools::izip;
 use p3_air::{Air, AirBuilder, BaseAir};
@@ -32,6 +35,7 @@ impl<F> AirConfig for Poseidon2VmAir<F> {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for Poseidon2VmAir<F> {}
+impl<F: Field> PartitionedBaseAir<F> for Poseidon2VmAir<F> {}
 impl<F: Field> BaseAir<F> for Poseidon2VmAir<F> {
     fn width(&self) -> usize {
         Poseidon2VmCols::<F>::width(self)

--- a/vm/src/memory/adapter/air.rs
+++ b/vm/src/memory/adapter/air.rs
@@ -4,7 +4,10 @@ use afs_primitives::is_less_than::{
     columns::{IsLessThanAuxCols, IsLessThanIoCols},
     IsLessThanAir,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::AbstractField;
 use p3_matrix::Matrix;
@@ -21,6 +24,7 @@ pub struct AccessAdapterAir<const N: usize> {
 }
 
 impl<T, const N: usize> BaseAirWithPublicValues<T> for AccessAdapterAir<N> {}
+impl<T, const N: usize> PartitionedBaseAir<T> for AccessAdapterAir<N> {}
 impl<T, const N: usize> BaseAir<T> for AccessAdapterAir<N> {
     fn width(&self) -> usize {
         size_of::<AccessAdapterCols<u8, N>>()

--- a/vm/src/memory/audit/air.rs
+++ b/vm/src/memory/audit/air.rs
@@ -6,7 +6,10 @@ use afs_primitives::{
     utils::{implies, or},
     var_range::bus::VariableRangeCheckerBus,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -46,6 +49,7 @@ impl MemoryAuditAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for MemoryAuditAir {}
+impl<F: Field> PartitionedBaseAir<F> for MemoryAuditAir {}
 impl<F: Field> BaseAir<F> for MemoryAuditAir {
     fn width(&self) -> usize {
         self.air_width()

--- a/vm/src/memory/expand/air.rs
+++ b/vm/src/memory/expand/air.rs
@@ -9,6 +9,7 @@ pub struct ExpandAir<const CHUNK: usize> {
     pub memory_dimensions: MemoryDimensions,
 }
 
+impl<const CHUNK: usize, F: Field> PartitionedBaseAir<F> for ExpandAir<CHUNK> { }
 impl<const CHUNK: usize, F: Field> BaseAir<F> for ExpandAir<CHUNK> {
     fn width(&self) -> usize {
         ExpandCols::<CHUNK, F>::get_width()

--- a/vm/src/memory/expand_interface/air.rs
+++ b/vm/src/memory/expand_interface/air.rs
@@ -10,6 +10,9 @@ pub struct MemoryExpandInterfaceAir<const NUM_WORDS: usize, const WORD_SIZE: usi
     pub memory_dimensions: MemoryDimensions,
 }
 
+impl<const NUM_WORDS: usize, const WORD_SIZE: usize, F: Field> PartitionedBaseAir<F>
+    for MemoryExpandInterfaceAir<NUM_WORDS, WORD_SIZE>
+{ }
 impl<const NUM_WORDS: usize, const WORD_SIZE: usize, F: Field> BaseAir<F>
     for MemoryExpandInterfaceAir<NUM_WORDS, WORD_SIZE>
 {

--- a/vm/src/memory/tests.rs
+++ b/vm/src/memory/tests.rs
@@ -10,7 +10,7 @@ use afs_derive::AlignedBorrow;
 use afs_primitives::var_range::{bus::VariableRangeCheckerBus, VariableRangeCheckerChip};
 use afs_stark_backend::{
     interaction::InteractionBuilder,
-    rap::{AnyRap, BaseAirWithPublicValues},
+    rap::{AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},
 };
 use ax_sdk::{
     config::baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},
@@ -62,6 +62,7 @@ struct MemoryRequesterAir {
 }
 
 impl<T> BaseAirWithPublicValues<T> for MemoryRequesterAir {}
+impl<T> PartitionedBaseAir<T> for MemoryRequesterAir {}
 impl<T> BaseAir<T> for MemoryRequesterAir {
     fn width(&self) -> usize {
         mem::size_of::<MemoryRequesterCols<u8>>()

--- a/vm/src/modular_addsub/air.rs
+++ b/vm/src/modular_addsub/air.rs
@@ -5,7 +5,10 @@ use afs_primitives::bigint::{
     utils::{big_uint_to_limbs, secp256k1_coord_prime},
     OverflowInt,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -23,6 +26,10 @@ pub struct ModularAddSubAir<const NUM_LIMBS: usize, const LIMB_SIZE: usize> {
     pub(super) subair: CheckCarryModToZeroSubAir,
 }
 
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_SIZE: usize> PartitionedBaseAir<F>
+    for ModularAddSubAir<NUM_LIMBS, LIMB_SIZE>
+{
+}
 impl<F: Field, const NUM_LIMBS: usize, const LIMB_SIZE: usize> BaseAir<F>
     for ModularAddSubAir<NUM_LIMBS, LIMB_SIZE>
 {

--- a/vm/src/modular_multdiv/air.rs
+++ b/vm/src/modular_multdiv/air.rs
@@ -5,7 +5,10 @@ use afs_primitives::bigint::{
     utils::{big_uint_to_limbs, secp256k1_coord_prime},
     OverflowInt,
 };
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -27,6 +30,10 @@ pub struct ModularMultDivAir<
     pub(super) subair: CheckCarryModToZeroSubAir,
 }
 
+impl<F: Field, const CARRY_LIMBS: usize, const NUM_LIMBS: usize, const LIMB_SIZE: usize>
+    PartitionedBaseAir<F> for ModularMultDivAir<CARRY_LIMBS, NUM_LIMBS, LIMB_SIZE>
+{
+}
 impl<F: Field, const CARRY_LIMBS: usize, const NUM_LIMBS: usize, const LIMB_SIZE: usize> BaseAir<F>
     for ModularMultDivAir<CARRY_LIMBS, NUM_LIMBS, LIMB_SIZE>
 {

--- a/vm/src/program/air.rs
+++ b/vm/src/program/air.rs
@@ -1,4 +1,7 @@
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir, PairBuilder};
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
@@ -6,6 +9,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use super::{columns::ProgramPreprocessedCols, ProgramAir};
 
 impl<F: Field> BaseAirWithPublicValues<F> for ProgramAir<F> {}
+impl<F: Field> PartitionedBaseAir<F> for ProgramAir<F> {}
 impl<F: Field> BaseAir<F> for ProgramAir<F> {
     fn width(&self) -> usize {
         1

--- a/vm/src/shift/air.rs
+++ b/vm/src/shift/air.rs
@@ -1,7 +1,10 @@
 use std::borrow::Borrow;
 
 use afs_primitives::{utils, var_range::bus::VariableRangeCheckerBus, xor::bus::XorBus};
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -20,6 +23,10 @@ pub struct ShiftAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub range_bus: VariableRangeCheckerBus,
 }
 
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> PartitionedBaseAir<F>
+    for ShiftAir<NUM_LIMBS, LIMB_BITS>
+{
+}
 impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAir<F>
     for ShiftAir<NUM_LIMBS, LIMB_BITS>
 {

--- a/vm/src/ui/air.rs
+++ b/vm/src/ui/air.rs
@@ -1,7 +1,10 @@
 use std::borrow::Borrow;
 
 use afs_primitives::var_range::bus::VariableRangeCheckerBus;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -21,6 +24,7 @@ pub struct UiAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for UiAir {}
+impl<F: Field> PartitionedBaseAir<F> for UiAir {}
 impl<F: Field> BaseAir<F> for UiAir {
     fn width(&self) -> usize {
         UiCols::<F>::width()

--- a/vm/src/uint_multiplication/air.rs
+++ b/vm/src/uint_multiplication/air.rs
@@ -1,7 +1,10 @@
 use std::borrow::Borrow;
 
 use afs_primitives::range_tuple::bus::RangeTupleCheckerBus;
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
@@ -18,6 +21,10 @@ pub struct UintMultiplicationAir<const NUM_LIMBS: usize, const LIMB_BITS: usize>
     pub bus: RangeTupleCheckerBus,
 }
 
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> PartitionedBaseAir<F>
+    for UintMultiplicationAir<NUM_LIMBS, LIMB_BITS>
+{
+}
 impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAir<F>
     for UintMultiplicationAir<NUM_LIMBS, LIMB_BITS>
 {

--- a/vm/src/vm/connector.rs
+++ b/vm/src/vm/connector.rs
@@ -1,4 +1,7 @@
-use afs_stark_backend::{interaction::InteractionBuilder, rap::BaseAirWithPublicValues};
+use afs_stark_backend::{
+    interaction::InteractionBuilder,
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+};
 use p3_air::{Air, BaseAir, PairBuilder};
 use p3_field::{AbstractField, Field, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -11,6 +14,7 @@ pub struct VmConnectorAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for VmConnectorAir {}
+impl<F: Field> PartitionedBaseAir<F> for VmConnectorAir {}
 impl<F: Field> BaseAir<F> for VmConnectorAir {
     fn width(&self) -> usize {
         2


### PR DESCRIPTION
Add trait `PartitionedBaseAir`. Now an AIR can tell widths of its cached/common main traces respectively. 