### PR TITLE
feat: RISC-V multiplication extension runtime

### DIFF
--- a/primitives/src/range_tuple/air.rs
+++ b/primitives/src/range_tuple/air.rs
@@ -9,31 +9,30 @@ use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use super::columns::{RangeTupleCols, RangeTuplePreprocessedCols, NUM_RANGE_TUPLE_COLS};
 use crate::range_tuple::bus::RangeTupleCheckerBus;
 
-#[derive(Clone, Default, Debug)]
-pub struct RangeTupleCheckerAir {
-    pub bus: RangeTupleCheckerBus,
+#[derive(Clone, Copy, Debug)]
+pub struct RangeTupleCheckerAir<const N: usize> {
+    pub bus: RangeTupleCheckerBus<N>,
 }
 
-impl RangeTupleCheckerAir {
+impl<const N: usize> RangeTupleCheckerAir<N> {
     pub fn height(&self) -> u32 {
         self.bus.sizes.iter().product()
     }
 }
+impl<F: Field, const N: usize> BaseAirWithPublicValues<F> for RangeTupleCheckerAir<N> {}
+impl<F: Field, const N: usize> PartitionedBaseAir<F> for RangeTupleCheckerAir<N> {}
 
-impl<F: Field> BaseAirWithPublicValues<F> for RangeTupleCheckerAir {}
-impl<F: Field> PartitionedBaseAir<F> for RangeTupleCheckerAir {}
-impl<F: Field> BaseAir<F> for RangeTupleCheckerAir {
+impl<F: Field, const N: usize> BaseAir<F> for RangeTupleCheckerAir<N> {
     fn width(&self) -> usize {
         NUM_RANGE_TUPLE_COLS
     }
 
     fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
-        let mut unrolled_matrix =
-            Vec::with_capacity((self.height() as usize) * self.bus.sizes.len());
-        let mut row = vec![0u32; self.bus.sizes.len()];
+        let mut unrolled_matrix = Vec::with_capacity((self.height() as usize) * N);
+        let mut row = [0u32; N];
         for _ in 0..self.height() {
-            unrolled_matrix.extend(row.clone());
-            for i in (0..self.bus.sizes.len()).rev() {
+            unrolled_matrix.extend(row);
+            for i in (0..N).rev() {
                 if row[i] < self.bus.sizes[i] - 1 {
                     row[i] += 1;
                     break;
@@ -46,12 +45,12 @@ impl<F: Field> BaseAir<F> for RangeTupleCheckerAir {
                 .iter()
                 .map(|&v| F::from_canonical_u32(v))
                 .collect(),
-            self.bus.sizes.len(),
+            N,
         ))
     }
 }
 
-impl<AB: InteractionBuilder + PairBuilder> Air<AB> for RangeTupleCheckerAir {
+impl<AB: InteractionBuilder + PairBuilder, const N: usize> Air<AB> for RangeTupleCheckerAir<N> {
     fn eval(&self, builder: &mut AB) {
         let preprocessed = builder.preprocessed();
         let prep_local = preprocessed.row_slice(0);

--- a/primitives/src/range_tuple/bus.rs
+++ b/primitives/src/range_tuple/bus.rs
@@ -1,14 +1,14 @@
 use afs_stark_backend::interaction::{InteractionBuilder, InteractionType};
 use p3_field::AbstractField;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct RangeTupleCheckerBus {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RangeTupleCheckerBus<const N: usize> {
     pub index: usize,
-    pub sizes: Vec<u32>,
+    pub sizes: [u32; N],
 }
 
-impl RangeTupleCheckerBus {
-    pub fn new(index: usize, sizes: Vec<u32>) -> Self {
+impl<const N: usize> RangeTupleCheckerBus<N> {
+    pub fn new(index: usize, sizes: [u32; N]) -> Self {
         Self { index, sizes }
     }
 

--- a/primitives/src/range_tuple/mod.rs
+++ b/primitives/src/range_tuple/mod.rs
@@ -2,25 +2,25 @@
 
 use std::sync::{atomic::AtomicU32, Arc};
 
-pub mod air;
-pub mod bus;
-pub mod columns;
-pub mod trace;
+mod air;
+mod bus;
+mod columns;
+mod trace;
 
 #[cfg(test)]
 pub mod tests;
 
-pub use air::RangeTupleCheckerAir;
-use bus::RangeTupleCheckerBus;
+pub use air::*;
+pub use bus::*;
 
-#[derive(Clone, Default, Debug)]
-pub struct RangeTupleCheckerChip {
-    pub air: RangeTupleCheckerAir,
+#[derive(Clone, Debug)]
+pub struct RangeTupleCheckerChip<const N: usize> {
+    pub air: RangeTupleCheckerAir<N>,
     count: Vec<Arc<AtomicU32>>,
 }
 
-impl RangeTupleCheckerChip {
-    pub fn new(bus: RangeTupleCheckerBus) -> Self {
+impl<const N: usize> RangeTupleCheckerChip<N> {
+    pub fn new(bus: RangeTupleCheckerBus<N>) -> Self {
         let range_max = bus.sizes.iter().product();
         let count = (0..range_max)
             .map(|_| Arc::new(AtomicU32::new(0)))
@@ -32,11 +32,11 @@ impl RangeTupleCheckerChip {
         }
     }
 
-    pub fn bus(&self) -> &RangeTupleCheckerBus {
+    pub fn bus(&self) -> &RangeTupleCheckerBus<N> {
         &self.air.bus
     }
 
-    pub fn sizes(&self) -> &Vec<u32> {
+    pub fn sizes(&self) -> &[u32; N] {
         &self.air.bus.sizes
     }
 

--- a/primitives/src/range_tuple/tests.rs
+++ b/primitives/src/range_tuple/tests.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::{array, iter};
 
 use afs_stark_backend::{prover::USE_DEBUG_BUILDER, rap::AnyRap, verifier::VerificationError};
 use ax_sdk::{
@@ -20,11 +20,9 @@ fn test_range_tuple_chip() {
     const LIST_LEN: usize = 64;
 
     let bus_index = 0;
-    let sizes = (0..3)
-        .map(|_| 1 << rng.gen_range(1..5))
-        .collect::<Vec<u32>>();
+    let sizes: [u32; 3] = array::from_fn(|_| 1 << rng.gen_range(1..5));
 
-    let bus = RangeTupleCheckerBus::new(bus_index, sizes.clone());
+    let bus = RangeTupleCheckerBus::new(bus_index, sizes);
     let range_checker = RangeTupleCheckerChip::new(bus);
 
     // generates a valid random tuple given sizes
@@ -84,9 +82,9 @@ fn test_range_tuple_chip() {
 #[test]
 fn negative_test_range_tuple_chip() {
     let bus_index = 0;
-    let sizes = vec![2, 2, 8];
+    let sizes = [2, 2, 8];
 
-    let bus = RangeTupleCheckerBus::new(bus_index, sizes.clone());
+    let bus = RangeTupleCheckerBus::new(bus_index, sizes);
     let range_checker = RangeTupleCheckerChip::new(bus);
 
     let height = sizes.iter().product();

--- a/primitives/src/range_tuple/trace.rs
+++ b/primitives/src/range_tuple/trace.rs
@@ -3,7 +3,7 @@ use p3_matrix::dense::RowMajorMatrix;
 
 use super::RangeTupleCheckerChip;
 
-impl RangeTupleCheckerChip {
+impl<const N: usize> RangeTupleCheckerChip<N> {
     pub fn generate_trace<F: PrimeField32>(&self) -> RowMajorMatrix<F> {
         let rows = self
             .count

--- a/vm/src/arch/adapters/mod.rs
+++ b/vm/src/arch/adapters/mod.rs
@@ -1,10 +1,12 @@
 mod rv32_alu;
 mod rv32_heap;
 mod rv32_loadstore;
+mod rv32_mul;
 
 pub use rv32_alu::*;
 pub use rv32_heap::*;
 pub use rv32_loadstore::*;
+pub use rv32_mul::*;
 
 /// 32-bit register stored as 4 bytes (4 lanes of 8-bits)
 pub const RV32_REGISTER_NUM_LANES: usize = 4;

--- a/vm/src/arch/adapters/rv32_mul.rs
+++ b/vm/src/arch/adapters/rv32_mul.rs
@@ -1,0 +1,185 @@
+use std::{marker::PhantomData, mem::size_of};
+
+use afs_derive::AlignedBorrow;
+use afs_stark_backend::interaction::InteractionBuilder;
+use p3_air::{Air, AirBuilderWithPublicValues, BaseAir, PairBuilder};
+use p3_field::{AbstractField, Field, PrimeField32};
+
+use super::RV32_REGISTER_NUM_LANES;
+use crate::{
+    arch::{
+        ExecutionBridge, ExecutionBus, ExecutionState, InstructionOutput, IntegrationInterface,
+        MachineAdapter, MachineAdapterInterface, Result,
+    },
+    memory::{
+        offline_checker::{MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxCols},
+        MemoryChip, MemoryChipRef, MemoryReadRecord, MemoryWriteRecord,
+    },
+    program::{bridge::ProgramBus, Instruction},
+};
+
+/// Reads instructions of the form OP a, b, c, d where [a:4]_d = [b:4]_d op [c:4]_d.
+/// Operand d can only be 1, and there is no immediate support.
+#[derive(Debug)]
+pub struct Rv32MultAdapter<F: Field> {
+    _marker: std::marker::PhantomData<F>,
+    pub air: Rv32MultAdapterAir,
+}
+
+impl<F: PrimeField32> Rv32MultAdapter<F> {
+    pub fn new(
+        execution_bus: ExecutionBus,
+        program_bus: ProgramBus,
+        memory_chip: MemoryChipRef<F>,
+    ) -> Self {
+        let memory_bridge = memory_chip.borrow().memory_bridge();
+        Self {
+            _marker: std::marker::PhantomData,
+            air: Rv32MultAdapterAir {
+                _execution_bridge: ExecutionBridge::new(execution_bus, program_bus),
+                _memory_bridge: memory_bridge,
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Rv32MultReadRecord<F: Field> {
+    /// Reads from operand registers
+    pub rs1: MemoryReadRecord<F, RV32_REGISTER_NUM_LANES>,
+    pub rs2: MemoryReadRecord<F, RV32_REGISTER_NUM_LANES>,
+}
+
+#[derive(Debug)]
+pub struct Rv32MultWriteRecord<F: Field> {
+    pub from_state: ExecutionState<usize>,
+    /// Write to destination register
+    pub rd: MemoryWriteRecord<F, RV32_REGISTER_NUM_LANES>,
+}
+
+/// Interface for reading two RV32 registers
+pub struct Rv32MultAdapterInterface<T>(PhantomData<T>);
+
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct Rv32MultProcessedInstruction<T> {
+    /// Absolute opcode number
+    pub opcode: T,
+}
+
+impl<T: AbstractField> MachineAdapterInterface<T> for Rv32MultAdapterInterface<T> {
+    type Reads = [[T; RV32_REGISTER_NUM_LANES]; 2];
+    type Writes = [T; RV32_REGISTER_NUM_LANES];
+    type ProcessedInstruction = Rv32MultProcessedInstruction<T>;
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct Rv32MultAdapterCols<T> {
+    pub from_state: ExecutionState<T>,
+    pub rs1_index: T,
+    pub rs2_index: T,
+    pub reads_aux: [MemoryReadAuxCols<T, RV32_REGISTER_NUM_LANES>; 2],
+    pub writes_aux: MemoryWriteAuxCols<T, RV32_REGISTER_NUM_LANES>,
+}
+
+impl<T> Rv32MultAdapterCols<T> {
+    pub fn width() -> usize {
+        size_of::<Rv32MultAdapterCols<u8>>()
+    }
+}
+
+#[derive(Clone, Copy, Debug, derive_new::new)]
+pub struct Rv32MultAdapterAir {
+    pub(super) _execution_bridge: ExecutionBridge,
+    pub(super) _memory_bridge: MemoryBridge,
+}
+
+impl<F: Field> BaseAir<F> for Rv32MultAdapterAir {
+    fn width(&self) -> usize {
+        size_of::<Rv32MultAdapterCols<u8>>()
+    }
+}
+
+impl<AB: InteractionBuilder> Air<AB> for Rv32MultAdapterAir {
+    fn eval(&self, _builder: &mut AB) {
+        todo!();
+    }
+}
+
+impl<F: PrimeField32> MachineAdapter<F> for Rv32MultAdapter<F> {
+    type ReadRecord = Rv32MultReadRecord<F>;
+    type WriteRecord = Rv32MultWriteRecord<F>;
+    type Air = Rv32MultAdapterAir;
+    type Cols<T> = Rv32MultAdapterCols<T>;
+    type Interface<T: AbstractField> = Rv32MultAdapterInterface<T>;
+
+    fn preprocess(
+        &mut self,
+        memory: &mut MemoryChip<F>,
+        instruction: &Instruction<F>,
+    ) -> Result<(
+        <Self::Interface<F> as MachineAdapterInterface<F>>::Reads,
+        Self::ReadRecord,
+    )> {
+        let Instruction {
+            op_b: b,
+            op_c: c,
+            d,
+            ..
+        } = *instruction;
+
+        debug_assert_eq!(d.as_canonical_u32(), 1);
+
+        let rs1 = memory.read::<RV32_REGISTER_NUM_LANES>(d, b);
+        let rs2 = memory.read::<RV32_REGISTER_NUM_LANES>(d, c);
+
+        Ok(([rs1.data, rs2.data], Self::ReadRecord { rs1, rs2 }))
+    }
+
+    fn postprocess(
+        &mut self,
+        memory: &mut MemoryChip<F>,
+        instruction: &Instruction<F>,
+        from_state: ExecutionState<usize>,
+        output: InstructionOutput<F, Self::Interface<F>>,
+        _read_record: &Self::ReadRecord,
+    ) -> Result<(ExecutionState<usize>, Self::WriteRecord)> {
+        // TODO: timestamp delta debug check
+
+        let Instruction { op_a: a, d, .. } = *instruction;
+        let rd = memory.write(d, a, output.writes);
+
+        Ok((
+            ExecutionState {
+                pc: from_state.pc + 4,
+                timestamp: memory.timestamp().as_canonical_u32() as usize,
+            },
+            Self::WriteRecord { from_state, rd },
+        ))
+    }
+
+    fn generate_trace_row(
+        &self,
+        _row_slice: &mut Self::Cols<F>,
+        _read_record: Self::ReadRecord,
+        _write_record: Self::WriteRecord,
+    ) {
+        todo!();
+    }
+
+    fn eval_adapter_constraints<
+        AB: InteractionBuilder<F = F> + PairBuilder + AirBuilderWithPublicValues,
+    >(
+        _air: &Self::Air,
+        _builder: &mut AB,
+        _local: &Self::Cols<AB::Var>,
+        _interface: IntegrationInterface<AB::Expr, Self::Interface<AB::Expr>>,
+    ) -> AB::Expr {
+        todo!();
+    }
+
+    fn air(&self) -> Self::Air {
+        self.air
+    }
+}

--- a/vm/src/arch/chips.rs
+++ b/vm/src/arch/chips.rs
@@ -30,7 +30,10 @@ use crate::{
     modular_addsub::ModularAddSubChip,
     modular_multdiv::ModularMultDivChip,
     new_alu::Rv32ArithmeticLogicChip,
+    new_divrem::Rv32DivRemChip,
     new_lt::Rv32LessThanChip,
+    new_mul::Rv32MultiplicationChip,
+    new_mulh::Rv32MulHChip,
     new_shift::Rv32ShiftChip,
     program::{ExecutionError, Instruction, ProgramChip},
     shift::ShiftChip,
@@ -189,7 +192,10 @@ pub enum InstructionExecutorVariant<F: PrimeField32> {
     ArithmeticLogicUnitRv32(Rc<RefCell<Rv32ArithmeticLogicChip<F>>>),
     ArithmeticLogicUnit256(Rc<RefCell<ArithmeticLogicChip<F, 32, 8>>>),
     LessThanRv32(Rc<RefCell<Rv32LessThanChip<F>>>),
+    MultiplicationRv32(Rc<RefCell<Rv32MultiplicationChip<F>>>),
+    MultiplicationHighRv32(Rc<RefCell<Rv32MulHChip<F>>>),
     U256Multiplication(Rc<RefCell<UintMultiplicationChip<F, 32, 8>>>),
+    DivRemRv32(Rc<RefCell<Rv32DivRemChip<F>>>),
     ShiftRv32(Rc<RefCell<Rv32ShiftChip<F>>>),
     Shift256(Rc<RefCell<ShiftChip<F, 32, 8>>>),
     LoadStoreRv32(Rc<RefCell<Rv32LoadStoreChip<F>>>),
@@ -209,13 +215,16 @@ pub enum MachineChipVariant<F: PrimeField32> {
     FieldExtension(Rc<RefCell<FieldExtensionArithmeticChip<F>>>),
     Poseidon2(Rc<RefCell<Poseidon2Chip<F>>>),
     RangeChecker(Arc<VariableRangeCheckerChip>),
-    RangeTupleChecker(Arc<RangeTupleCheckerChip>),
+    RangeTupleChecker(Arc<RangeTupleCheckerChip<2>>),
     Keccak256(Rc<RefCell<KeccakVmChip<F>>>),
     ByteXor(Arc<XorLookupChip<8>>),
     ArithmeticLogicUnitRv32(Rc<RefCell<Rv32ArithmeticLogicChip<F>>>),
     ArithmeticLogicUnit256(Rc<RefCell<ArithmeticLogicChip<F, 32, 8>>>),
     LessThanRv32(Rc<RefCell<Rv32LessThanChip<F>>>),
+    MultiplicationRv32(Rc<RefCell<Rv32MultiplicationChip<F>>>),
+    MultiplicationHighRv32(Rc<RefCell<Rv32MulHChip<F>>>),
     U256Multiplication(Rc<RefCell<UintMultiplicationChip<F, 32, 8>>>),
+    DivRemRv32(Rc<RefCell<Rv32DivRemChip<F>>>),
     ShiftRv32(Rc<RefCell<Rv32ShiftChip<F>>>),
     Shift256(Rc<RefCell<ShiftChip<F, 32, 8>>>),
     Ui(Rc<RefCell<UiChip<F>>>),
@@ -250,7 +259,7 @@ impl<F: PrimeField32> MachineChip<F> for Arc<VariableRangeCheckerChip> {
     }
 }
 
-impl<F: PrimeField32> MachineChip<F> for Arc<RangeTupleCheckerChip> {
+impl<F: PrimeField32, const N: usize> MachineChip<F> for Arc<RangeTupleCheckerChip<N>> {
     fn generate_trace(self) -> RowMajorMatrix<F> {
         RangeTupleCheckerChip::generate_trace(&self)
     }
@@ -259,7 +268,7 @@ impl<F: PrimeField32> MachineChip<F> for Arc<RangeTupleCheckerChip> {
     where
         Domain<SC>: PolynomialSpace<Val = F>,
     {
-        Box::new(self.air.clone())
+        Box::new(self.air)
     }
 
     fn air_name(&self) -> String {

--- a/vm/src/arch/instructions.rs
+++ b/vm/src/arch/instructions.rs
@@ -232,3 +232,38 @@ pub enum Rv32LoadStoreOpcode {
     LOADBU,
     LOADHU,
 }
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EnumCount, EnumIter, FromRepr, UsizeOpcode,
+)]
+#[opcode_offset = 0x350]
+#[repr(usize)]
+#[allow(non_camel_case_types)]
+pub enum MulOpcode {
+    MUL,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EnumCount, EnumIter, FromRepr, UsizeOpcode,
+)]
+#[opcode_offset = 0x355]
+#[repr(usize)]
+#[allow(non_camel_case_types)]
+pub enum MulHOpcode {
+    MULH,
+    MULHSU,
+    MULHU,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EnumCount, EnumIter, FromRepr, UsizeOpcode,
+)]
+#[opcode_offset = 0x360]
+#[repr(usize)]
+#[allow(non_camel_case_types)]
+pub enum DivRemOpcode {
+    DIV,
+    DIVU,
+    REM,
+    REMU,
+}

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -11,7 +11,10 @@ pub mod memory;
 pub mod modular_addsub;
 pub mod modular_multdiv;
 pub mod new_alu;
+pub mod new_divrem;
 pub mod new_lt;
+pub mod new_mul;
+pub mod new_mulh;
 pub mod new_shift;
 pub mod program;
 /// SDK functions for running and proving programs in the VM.

--- a/vm/src/new_divrem/integration.rs
+++ b/vm/src/new_divrem/integration.rs
@@ -1,0 +1,249 @@
+use std::{array, mem::size_of, sync::Arc};
+
+use afs_derive::AlignedBorrow;
+use afs_primitives::{
+    bigint::utils::big_uint_to_num_limbs,
+    range_tuple::{RangeTupleCheckerBus, RangeTupleCheckerChip},
+};
+use afs_stark_backend::interaction::InteractionBuilder;
+use itertools::fold;
+use num_bigint_dig::BigUint;
+use p3_air::{Air, AirBuilderWithPublicValues, BaseAir, PairBuilder};
+use p3_field::{Field, PrimeField32};
+
+use crate::{
+    arch::{
+        instructions::{DivRemOpcode, UsizeOpcode},
+        InstructionOutput, IntegrationInterface, MachineAdapter, MachineAdapterInterface,
+        MachineIntegration, Reads, Result, Writes,
+    },
+    program::Instruction,
+};
+
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct DivRemCols<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub a: [T; NUM_LIMBS],
+    pub b: [T; NUM_LIMBS],
+    pub c: [T; NUM_LIMBS],
+
+    // TODO: add auxiliary columns
+    pub opcode_div_flag: T,
+    pub opcode_divu_flag: T,
+    pub opcode_rem_flag: T,
+    pub opcode_remu_flag: T,
+}
+
+impl<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> DivRemCols<T, NUM_LIMBS, LIMB_BITS> {
+    pub fn width() -> usize {
+        size_of::<DivRemCols<u8, NUM_LIMBS, LIMB_BITS>>()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct DivRemAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub bus: RangeTupleCheckerBus<2>,
+}
+
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAir<F>
+    for DivRemAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn width(&self) -> usize {
+        DivRemCols::<F, NUM_LIMBS, LIMB_BITS>::width()
+    }
+}
+
+impl<AB: InteractionBuilder, const NUM_LIMBS: usize, const LIMB_BITS: usize> Air<AB>
+    for DivRemAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn eval(&self, _builder: &mut AB) {
+        todo!();
+    }
+}
+
+#[derive(Debug)]
+pub struct DivRemIntegration<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub air: DivRemAir<NUM_LIMBS, LIMB_BITS>,
+    pub range_tuple_chip: Arc<RangeTupleCheckerChip<2>>,
+    offset: usize,
+}
+
+impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> DivRemIntegration<NUM_LIMBS, LIMB_BITS> {
+    pub fn new(range_tuple_chip: Arc<RangeTupleCheckerChip<2>>, offset: usize) -> Self {
+        Self {
+            air: DivRemAir {
+                bus: *range_tuple_chip.bus(),
+            },
+            range_tuple_chip,
+            offset,
+        }
+    }
+}
+
+impl<F: PrimeField32, A: MachineAdapter<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    MachineIntegration<F, A> for DivRemIntegration<NUM_LIMBS, LIMB_BITS>
+where
+    Reads<F, A::Interface<F>>: Into<[[F; NUM_LIMBS]; 2]>,
+    Writes<F, A::Interface<F>>: From<[F; NUM_LIMBS]>,
+{
+    // TODO: update for trace generation
+    type Record = u32;
+    type Cols<T> = DivRemCols<T, NUM_LIMBS, LIMB_BITS>;
+    type Air = DivRemAir<NUM_LIMBS, LIMB_BITS>;
+
+    #[allow(clippy::type_complexity)]
+    fn execute_instruction(
+        &self,
+        instruction: &Instruction<F>,
+        _from_pc: F,
+        reads: <A::Interface<F> as MachineAdapterInterface<F>>::Reads,
+    ) -> Result<(InstructionOutput<F, A::Interface<F>>, Self::Record)> {
+        let Instruction { opcode, .. } = instruction;
+        let opcode = DivRemOpcode::from_usize(opcode - self.offset);
+
+        let data: [[F; NUM_LIMBS]; 2] = reads.into();
+        let x = data[0].map(|x| x.as_canonical_u32());
+        let y = data[1].map(|y| y.as_canonical_u32());
+        let (q, r, _x_sign, _y_sign) = solve_divrem::<NUM_LIMBS, LIMB_BITS>(
+            opcode == DivRemOpcode::DIV || opcode == DivRemOpcode::REM,
+            &x,
+            &y,
+        );
+
+        let z = if opcode == DivRemOpcode::DIV || opcode == DivRemOpcode::DIVU {
+            &q
+        } else {
+            &r
+        };
+
+        // Integration doesn't modify PC directly, so we let Adapter handle the increment
+        let output: InstructionOutput<F, A::Interface<F>> = InstructionOutput {
+            to_pc: None,
+            writes: z.map(F::from_canonical_u32).into(),
+        };
+
+        // TODO: send RangeTupleChecker requests
+        // TODO: create Record and return
+
+        Ok((output, 0))
+    }
+
+    fn get_opcode_name(&self, _opcode: usize) -> String {
+        todo!()
+    }
+
+    fn generate_trace_row(&self, _row_slice: &mut Self::Cols<F>, _record: Self::Record) {
+        todo!()
+    }
+
+    /// Returns `(to_pc, interface)`.
+    fn eval_primitive<AB: InteractionBuilder<F = F> + PairBuilder + AirBuilderWithPublicValues>(
+        _air: &Self::Air,
+        _builder: &mut AB,
+        _local: &Self::Cols<AB::Var>,
+        _local_adapter: &A::Cols<AB::Var>,
+    ) -> IntegrationInterface<AB::Expr, A::Interface<AB::Expr>> {
+        todo!()
+    }
+
+    fn air(&self) -> Self::Air {
+        self.air
+    }
+}
+
+// Returns (quotient, remainder, x_sign, y_sign)
+pub(super) fn solve_divrem<const NUM_LIMBS: usize, const LIMB_BITS: usize>(
+    signed: bool,
+    x: &[u32; NUM_LIMBS],
+    y: &[u32; NUM_LIMBS],
+) -> ([u32; NUM_LIMBS], [u32; NUM_LIMBS], u32, u32) {
+    let x_sign = if signed {
+        x[NUM_LIMBS - 1] >> (LIMB_BITS - 1)
+    } else {
+        0
+    };
+    let y_sign = if signed {
+        y[NUM_LIMBS - 1] >> (LIMB_BITS - 1)
+    } else {
+        0
+    };
+
+    assert!(x_sign == 0 || x_sign == 1);
+    assert!(y_sign == 0 || y_sign == 1);
+
+    let zero_divisor = fold(y, true, |b, y_val| b && (*y_val == 0));
+    let overflow = fold(&y[1..], y[0] == 1 << (LIMB_BITS - 1), |b, y_val| {
+        b && (*y_val == 0)
+    }) && fold(x, true, |b, x_val| b && (*x_val == (1 << LIMB_BITS) - 1))
+        && x_sign == 1
+        && y_sign == 1;
+
+    if zero_divisor {
+        return ([(1 << LIMB_BITS) - 1; NUM_LIMBS], *x, x_sign, y_sign);
+    } else if overflow {
+        return (*x, [0; NUM_LIMBS], x_sign, y_sign);
+    }
+
+    let x_abs = if x_sign == 1 {
+        get_2s_complement::<NUM_LIMBS, LIMB_BITS>(x)
+    } else {
+        *x
+    };
+    let y_abs = if y_sign == 1 {
+        get_2s_complement::<NUM_LIMBS, LIMB_BITS>(y)
+    } else {
+        *y
+    };
+
+    let x_big = limbs_to_biguint::<NUM_LIMBS, LIMB_BITS>(&x_abs);
+    let y_big = limbs_to_biguint::<NUM_LIMBS, LIMB_BITS>(&y_abs);
+    let q_big = x_big.clone() / y_big.clone();
+    let r_big = x_big.clone() % y_big.clone();
+
+    let q = if x_sign + y_sign == 1 {
+        get_2s_complement::<NUM_LIMBS, LIMB_BITS>(&biguint_to_limbs::<NUM_LIMBS, LIMB_BITS>(&q_big))
+    } else {
+        biguint_to_limbs::<NUM_LIMBS, LIMB_BITS>(&q_big)
+    };
+
+    // In C |q * y| <= |x|, which means if x is negative then r <= 0 and vice versa.
+    let r = if x_sign == 1 {
+        get_2s_complement::<NUM_LIMBS, LIMB_BITS>(&biguint_to_limbs::<NUM_LIMBS, LIMB_BITS>(&r_big))
+    } else {
+        biguint_to_limbs::<NUM_LIMBS, LIMB_BITS>(&r_big)
+    };
+
+    (q, r, x_sign, y_sign)
+}
+
+fn limbs_to_biguint<const NUM_LIMBS: usize, const LIMB_BITS: usize>(
+    x: &[u32; NUM_LIMBS],
+) -> BigUint {
+    let base = BigUint::new(vec![1 << LIMB_BITS]);
+    let mut res = BigUint::new(vec![0]);
+    for val in x.iter().rev() {
+        res *= base.clone();
+        res += BigUint::new(vec![*val]);
+    }
+    res
+}
+
+fn biguint_to_limbs<const NUM_LIMBS: usize, const LIMB_BITS: usize>(
+    x: &BigUint,
+) -> [u32; NUM_LIMBS] {
+    let res_vec = big_uint_to_num_limbs(x, LIMB_BITS, NUM_LIMBS);
+    array::from_fn(|i| res_vec[i] as u32)
+}
+
+fn get_2s_complement<const NUM_LIMBS: usize, const LIMB_BITS: usize>(
+    x: &[u32; NUM_LIMBS],
+) -> [u32; NUM_LIMBS] {
+    let mut carry = 1u32;
+    let mut result = [0; NUM_LIMBS];
+    for i in 0..NUM_LIMBS {
+        result[i] = (1 << LIMB_BITS) + carry - 1 - x[i];
+        carry = result[i] >> LIMB_BITS;
+        result[i] %= 1 << LIMB_BITS;
+    }
+    result
+}

--- a/vm/src/new_divrem/mod.rs
+++ b/vm/src/new_divrem/mod.rs
@@ -1,0 +1,10 @@
+use crate::arch::{MachineChipWrapper, Rv32MultAdapter};
+
+mod integration;
+pub use integration::*;
+
+#[cfg(test)]
+mod tests;
+
+// TODO: Remove new_* prefix when completed
+pub type Rv32DivRemChip<F> = MachineChipWrapper<F, Rv32MultAdapter<F>, DivRemIntegration<4, 8>>;

--- a/vm/src/new_divrem/tests.rs
+++ b/vm/src/new_divrem/tests.rs
@@ -1,0 +1,103 @@
+use super::integration::solve_divrem;
+
+const RV32_NUM_LIMBS: usize = 4;
+const RV32_LIMB_BITS: usize = 8;
+
+#[test]
+fn solve_divrem_unsigned_sanity_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [98, 188, 163, 229];
+    let y: [u32; RV32_NUM_LIMBS] = [123, 34, 0, 0];
+    let q: [u32; RV32_NUM_LIMBS] = [245, 168, 6, 0];
+    let r: [u32; RV32_NUM_LIMBS] = [171, 4, 0, 0];
+
+    let (res_q, res_r, x_sign, y_sign) =
+        solve_divrem::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(false, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(q[i], res_q[i]);
+        assert_eq!(r[i], res_r[i]);
+    }
+    assert_eq!(x_sign, 0);
+    assert_eq!(y_sign, 0);
+}
+
+#[test]
+fn solve_divrem_unsigned_zero_divisor_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [98, 188, 163, 229];
+    let y: [u32; RV32_NUM_LIMBS] = [0, 0, 0, 0];
+    let q: [u32; RV32_NUM_LIMBS] = [255, 255, 255, 255];
+
+    let (res_q, res_r, x_sign, y_sign) =
+        solve_divrem::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(false, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(q[i], res_q[i]);
+        assert_eq!(x[i], res_r[i]);
+    }
+    assert_eq!(x_sign, 0);
+    assert_eq!(y_sign, 0);
+}
+
+#[test]
+fn solve_divrem_signed_sanity_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [98, 188, 163, 229];
+    let y: [u32; RV32_NUM_LIMBS] = [123, 34, 0, 0];
+    let q: [u32; RV32_NUM_LIMBS] = [74, 60, 255, 255];
+    let r: [u32; RV32_NUM_LIMBS] = [212, 240, 255, 255];
+
+    let (res_q, res_r, x_sign, y_sign) =
+        solve_divrem::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(true, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(q[i], res_q[i]);
+        assert_eq!(r[i], res_r[i]);
+    }
+    assert_eq!(x_sign, 1);
+    assert_eq!(y_sign, 0);
+}
+
+#[test]
+fn solve_divrem_signed_zero_divisor_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [98, 188, 163, 229];
+    let y: [u32; RV32_NUM_LIMBS] = [0, 0, 0, 0];
+    let q: [u32; RV32_NUM_LIMBS] = [255, 255, 255, 255];
+
+    let (res_q, res_r, x_sign, y_sign) =
+        solve_divrem::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(true, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(q[i], res_q[i]);
+        assert_eq!(x[i], res_r[i]);
+    }
+    assert_eq!(x_sign, 1);
+    assert_eq!(y_sign, 0);
+}
+
+#[test]
+fn solve_divrem_signed_overflow_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [0, 0, 0, 128];
+    let y: [u32; RV32_NUM_LIMBS] = [255, 255, 255, 255];
+    let r: [u32; RV32_NUM_LIMBS] = [0, 0, 0, 0];
+
+    let (res_q, res_r, x_sign, y_sign) =
+        solve_divrem::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(true, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(x[i], res_q[i]);
+        assert_eq!(r[i], res_r[i]);
+    }
+    assert_eq!(x_sign, 1);
+    assert_eq!(y_sign, 1);
+}
+
+#[test]
+fn solve_divrem_signed_min_dividend_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [0, 0, 0, 128];
+    let y: [u32; RV32_NUM_LIMBS] = [123, 34, 255, 255];
+    let q: [u32; RV32_NUM_LIMBS] = [236, 147, 0, 0];
+    let r: [u32; RV32_NUM_LIMBS] = [156, 149, 255, 255];
+
+    let (res_q, res_r, x_sign, y_sign) =
+        solve_divrem::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(true, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(q[i], res_q[i]);
+        assert_eq!(r[i], res_r[i]);
+    }
+    assert_eq!(x_sign, 1);
+    assert_eq!(y_sign, 1);
+}

--- a/vm/src/new_mul/integration.rs
+++ b/vm/src/new_mul/integration.rs
@@ -1,0 +1,158 @@
+use std::{mem::size_of, sync::Arc};
+
+use afs_derive::AlignedBorrow;
+use afs_primitives::range_tuple::{RangeTupleCheckerBus, RangeTupleCheckerChip};
+use afs_stark_backend::interaction::InteractionBuilder;
+use p3_air::{Air, AirBuilderWithPublicValues, BaseAir, PairBuilder};
+use p3_field::{Field, PrimeField32};
+
+use crate::{
+    arch::{
+        instructions::{MulOpcode, UsizeOpcode},
+        InstructionOutput, IntegrationInterface, MachineAdapter, MachineAdapterInterface,
+        MachineIntegration, Reads, Result, Writes,
+    },
+    program::Instruction,
+};
+
+// TODO: Replace current multiplication module upon completion
+
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct MultiplicationCols<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub a: [T; NUM_LIMBS],
+    pub b: [T; NUM_LIMBS],
+    pub c: [T; NUM_LIMBS],
+
+    pub is_valid: T,
+}
+
+impl<T, const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    MultiplicationCols<T, NUM_LIMBS, LIMB_BITS>
+{
+    pub fn width() -> usize {
+        size_of::<MultiplicationCols<u8, NUM_LIMBS, LIMB_BITS>>()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct MultiplicationAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub bus: RangeTupleCheckerBus<2>,
+}
+
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAir<F>
+    for MultiplicationAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn width(&self) -> usize {
+        MultiplicationCols::<F, NUM_LIMBS, LIMB_BITS>::width()
+    }
+}
+
+impl<AB: InteractionBuilder, const NUM_LIMBS: usize, const LIMB_BITS: usize> Air<AB>
+    for MultiplicationAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn eval(&self, _builder: &mut AB) {
+        todo!();
+    }
+}
+
+#[derive(Debug)]
+pub struct MultiplicationIntegration<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub air: MultiplicationAir<NUM_LIMBS, LIMB_BITS>,
+    pub range_tuple_chip: Arc<RangeTupleCheckerChip<2>>,
+    offset: usize,
+}
+
+impl<const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    MultiplicationIntegration<NUM_LIMBS, LIMB_BITS>
+{
+    pub fn new(range_tuple_chip: Arc<RangeTupleCheckerChip<2>>, offset: usize) -> Self {
+        Self {
+            air: MultiplicationAir {
+                bus: *range_tuple_chip.bus(),
+            },
+            range_tuple_chip,
+            offset,
+        }
+    }
+}
+
+impl<F: PrimeField32, A: MachineAdapter<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    MachineIntegration<F, A> for MultiplicationIntegration<NUM_LIMBS, LIMB_BITS>
+where
+    Reads<F, A::Interface<F>>: Into<[[F; NUM_LIMBS]; 2]>,
+    Writes<F, A::Interface<F>>: From<[F; NUM_LIMBS]>,
+{
+    // TODO: update for trace generation
+    type Record = u32;
+    type Cols<T> = MultiplicationCols<T, NUM_LIMBS, LIMB_BITS>;
+    type Air = MultiplicationAir<NUM_LIMBS, LIMB_BITS>;
+
+    #[allow(clippy::type_complexity)]
+    fn execute_instruction(
+        &self,
+        instruction: &Instruction<F>,
+        _from_pc: F,
+        reads: <A::Interface<F> as MachineAdapterInterface<F>>::Reads,
+    ) -> Result<(InstructionOutput<F, A::Interface<F>>, Self::Record)> {
+        let Instruction { opcode, .. } = instruction;
+        assert_eq!(MulOpcode::from_usize(opcode - self.offset), MulOpcode::MUL);
+
+        let data: [[F; NUM_LIMBS]; 2] = reads.into();
+        let x = data[0].map(|x| x.as_canonical_u32());
+        let y = data[1].map(|y| y.as_canonical_u32());
+        let z = solve_mul::<NUM_LIMBS, LIMB_BITS>(&x, &y);
+
+        // Integration doesn't modify PC directly, so we let Adapter handle the increment
+        let output: InstructionOutput<F, A::Interface<F>> = InstructionOutput {
+            to_pc: None,
+            writes: z.map(F::from_canonical_u32).into(),
+        };
+
+        // TODO: send RangeTupleChecker requests
+        // TODO: create Record and return
+
+        Ok((output, 0))
+    }
+
+    fn get_opcode_name(&self, _opcode: usize) -> String {
+        todo!()
+    }
+
+    fn generate_trace_row(&self, _row_slice: &mut Self::Cols<F>, _record: Self::Record) {
+        todo!()
+    }
+
+    /// Returns `(to_pc, interface)`.
+    fn eval_primitive<AB: InteractionBuilder<F = F> + PairBuilder + AirBuilderWithPublicValues>(
+        _air: &Self::Air,
+        _builder: &mut AB,
+        _local: &Self::Cols<AB::Var>,
+        _local_adapter: &A::Cols<AB::Var>,
+    ) -> IntegrationInterface<AB::Expr, A::Interface<AB::Expr>> {
+        todo!()
+    }
+
+    fn air(&self) -> Self::Air {
+        self.air
+    }
+}
+
+pub(super) fn solve_mul<const NUM_LIMBS: usize, const LIMB_BITS: usize>(
+    x: &[u32; NUM_LIMBS],
+    y: &[u32; NUM_LIMBS],
+) -> [u32; NUM_LIMBS] {
+    let mut result = [0; NUM_LIMBS];
+    let mut carry = [0; NUM_LIMBS];
+    for i in 0..NUM_LIMBS {
+        if i > 0 {
+            result[i] = carry[i - 1];
+        }
+        for j in 0..=i {
+            result[i] += x[j] * y[i - j];
+        }
+        carry[i] = result[i] >> LIMB_BITS;
+        result[i] %= 1 << LIMB_BITS;
+    }
+    result
+}

--- a/vm/src/new_mul/mod.rs
+++ b/vm/src/new_mul/mod.rs
@@ -1,0 +1,11 @@
+use crate::arch::{MachineChipWrapper, Rv32MultAdapter};
+
+mod integration;
+pub use integration::*;
+
+#[cfg(test)]
+mod tests;
+
+// TODO: Replace current uint_multiplication module upon completion
+pub type Rv32MultiplicationChip<F> =
+    MachineChipWrapper<F, Rv32MultAdapter<F>, MultiplicationIntegration<4, 8>>;

--- a/vm/src/new_mul/tests.rs
+++ b/vm/src/new_mul/tests.rs
@@ -1,0 +1,15 @@
+use super::integration::solve_mul;
+
+const RV32_NUM_LIMBS: usize = 4;
+const RV32_LIMB_BITS: usize = 8;
+
+#[test]
+fn solve_mul_sanity_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [197, 85, 150, 32];
+    let y: [u32; RV32_NUM_LIMBS] = [51, 109, 78, 142];
+    let z: [u32; RV32_NUM_LIMBS] = [63, 247, 125, 232];
+    let result = solve_mul::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(&x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(z[i], result[i])
+    }
+}

--- a/vm/src/new_mulh/integration.rs
+++ b/vm/src/new_mulh/integration.rs
@@ -1,0 +1,191 @@
+use std::{mem::size_of, sync::Arc};
+
+use afs_derive::AlignedBorrow;
+use afs_primitives::range_tuple::{RangeTupleCheckerBus, RangeTupleCheckerChip};
+use afs_stark_backend::interaction::InteractionBuilder;
+use p3_air::{Air, AirBuilderWithPublicValues, BaseAir, PairBuilder};
+use p3_field::{Field, PrimeField32};
+
+use crate::{
+    arch::{
+        instructions::{MulHOpcode, UsizeOpcode},
+        InstructionOutput, IntegrationInterface, MachineAdapter, MachineAdapterInterface,
+        MachineIntegration, Reads, Result, Writes,
+    },
+    program::Instruction,
+};
+
+// TODO: Replace current ALU module upon completion
+
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct MulHCols<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub a: [T; NUM_LIMBS],
+    pub b: [T; NUM_LIMBS],
+    pub c: [T; NUM_LIMBS],
+
+    pub a_mul: [T; NUM_LIMBS],
+    pub b_ext: T,
+    pub c_ext: T,
+
+    pub opcode_mulh_flag: T,
+    pub opcode_mulhsu_flag: T,
+    pub opcode_mulhu_flag: T,
+}
+
+impl<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> MulHCols<T, NUM_LIMBS, LIMB_BITS> {
+    pub fn width() -> usize {
+        size_of::<MulHCols<u8, NUM_LIMBS, LIMB_BITS>>()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct MulHAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub bus: RangeTupleCheckerBus<2>,
+}
+
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAir<F>
+    for MulHAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn width(&self) -> usize {
+        MulHCols::<F, NUM_LIMBS, LIMB_BITS>::width()
+    }
+}
+
+impl<AB: InteractionBuilder, const NUM_LIMBS: usize, const LIMB_BITS: usize> Air<AB>
+    for MulHAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn eval(&self, _builder: &mut AB) {
+        todo!();
+    }
+}
+
+#[derive(Debug)]
+pub struct MulHIntegration<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    pub air: MulHAir<NUM_LIMBS, LIMB_BITS>,
+    pub range_tuple_chip: Arc<RangeTupleCheckerChip<2>>,
+    offset: usize,
+}
+
+impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> MulHIntegration<NUM_LIMBS, LIMB_BITS> {
+    pub fn new(range_tuple_chip: Arc<RangeTupleCheckerChip<2>>, offset: usize) -> Self {
+        Self {
+            air: MulHAir {
+                bus: *range_tuple_chip.bus(),
+            },
+            range_tuple_chip,
+            offset,
+        }
+    }
+}
+
+impl<F: PrimeField32, A: MachineAdapter<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    MachineIntegration<F, A> for MulHIntegration<NUM_LIMBS, LIMB_BITS>
+where
+    Reads<F, A::Interface<F>>: Into<[[F; NUM_LIMBS]; 2]>,
+    Writes<F, A::Interface<F>>: From<[F; NUM_LIMBS]>,
+{
+    // TODO: update for trace generation
+    type Record = u32;
+    type Cols<T> = MulHCols<T, NUM_LIMBS, LIMB_BITS>;
+    type Air = MulHAir<NUM_LIMBS, LIMB_BITS>;
+
+    #[allow(clippy::type_complexity)]
+    fn execute_instruction(
+        &self,
+        instruction: &Instruction<F>,
+        _from_pc: F,
+        reads: <A::Interface<F> as MachineAdapterInterface<F>>::Reads,
+    ) -> Result<(InstructionOutput<F, A::Interface<F>>, Self::Record)> {
+        let Instruction { opcode, .. } = instruction;
+        let opcode = MulHOpcode::from_usize(opcode - self.offset);
+
+        let data: [[F; NUM_LIMBS]; 2] = reads.into();
+        let x = data[0].map(|x| x.as_canonical_u32());
+        let y = data[1].map(|y| y.as_canonical_u32());
+        let (z, _z_mul, _x_ext, _y_ext) = solve_mulh::<NUM_LIMBS, LIMB_BITS>(opcode, &x, &y);
+
+        // Integration doesn't modify PC directly, so we let Adapter handle the increment
+        let output: InstructionOutput<F, A::Interface<F>> = InstructionOutput {
+            to_pc: None,
+            writes: z.map(F::from_canonical_u32).into(),
+        };
+
+        // TODO: send RangeTupleChecker requests
+        // TODO: create Record and return
+
+        Ok((output, 0))
+    }
+
+    fn get_opcode_name(&self, _opcode: usize) -> String {
+        todo!()
+    }
+
+    fn generate_trace_row(&self, _row_slice: &mut Self::Cols<F>, _record: Self::Record) {
+        todo!()
+    }
+
+    /// Returns `(to_pc, interface)`.
+    fn eval_primitive<AB: InteractionBuilder<F = F> + PairBuilder + AirBuilderWithPublicValues>(
+        _air: &Self::Air,
+        _builder: &mut AB,
+        _local: &Self::Cols<AB::Var>,
+        _local_adapter: &A::Cols<AB::Var>,
+    ) -> IntegrationInterface<AB::Expr, A::Interface<AB::Expr>> {
+        todo!()
+    }
+
+    fn air(&self) -> Self::Air {
+        self.air
+    }
+}
+
+// returns mulh[[s]u], mul, x_ext, y_ext
+pub(super) fn solve_mulh<const NUM_LIMBS: usize, const LIMB_BITS: usize>(
+    opcode: MulHOpcode,
+    x: &[u32; NUM_LIMBS],
+    y: &[u32; NUM_LIMBS],
+) -> ([u32; NUM_LIMBS], [u32; NUM_LIMBS], u32, u32) {
+    let mut mul = [0; NUM_LIMBS];
+    let mut carry = vec![0; 2 * NUM_LIMBS];
+    for i in 0..NUM_LIMBS {
+        if i > 0 {
+            mul[i] = carry[i - 1];
+        }
+        for j in 0..=i {
+            mul[i] += x[j] * y[i - j];
+        }
+        carry[i] = mul[i] >> LIMB_BITS;
+        mul[i] %= 1 << LIMB_BITS;
+    }
+
+    let x_ext = (x[NUM_LIMBS - 1] >> (LIMB_BITS - 1))
+        * if opcode == MulHOpcode::MULHU {
+            0
+        } else {
+            (1 << LIMB_BITS) - 1
+        };
+    let y_ext = (y[NUM_LIMBS - 1] >> (LIMB_BITS - 1))
+        * if opcode == MulHOpcode::MULH {
+            (1 << LIMB_BITS) - 1
+        } else {
+            0
+        };
+
+    let mut mulh = [0; NUM_LIMBS];
+    let mut x_prefix = 0;
+    let mut y_prefix = 0;
+
+    for i in 0..NUM_LIMBS {
+        x_prefix += x[i];
+        y_prefix += y[i];
+        mulh[i] = carry[NUM_LIMBS + i - 1] + x_prefix * y_ext + y_prefix * x_ext;
+        for j in (i + 1)..NUM_LIMBS {
+            mulh[i] += x[j] * y[NUM_LIMBS + i - j];
+        }
+        carry[NUM_LIMBS + i] = mulh[i] >> LIMB_BITS;
+        mulh[i] %= 1 << LIMB_BITS;
+    }
+
+    (mulh, mul, x_ext, y_ext)
+}

--- a/vm/src/new_mulh/mod.rs
+++ b/vm/src/new_mulh/mod.rs
@@ -1,0 +1,10 @@
+use crate::arch::{MachineChipWrapper, Rv32MultAdapter};
+
+mod integration;
+pub use integration::*;
+
+#[cfg(test)]
+mod tests;
+
+// TODO: Remove new_* prefix when completed
+pub type Rv32MulHChip<F> = MachineChipWrapper<F, Rv32MultAdapter<F>, MulHIntegration<4, 8>>;

--- a/vm/src/new_mulh/tests.rs
+++ b/vm/src/new_mulh/tests.rs
@@ -1,0 +1,69 @@
+use super::integration::solve_mulh;
+use crate::arch::instructions::MulHOpcode;
+
+const RV32_NUM_LIMBS: usize = 4;
+const RV32_LIMB_BITS: usize = 8;
+
+#[test]
+fn solve_mulh_sanity_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [197, 85, 150, 32];
+    let y: [u32; RV32_NUM_LIMBS] = [51, 109, 78, 142];
+    let z: [u32; RV32_NUM_LIMBS] = [130, 9, 135, 241];
+    let z_mul: [u32; RV32_NUM_LIMBS] = [63, 247, 125, 232];
+    let (res, res_mul, x_ext, y_ext) =
+        solve_mulh::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(MulHOpcode::MULH, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(z[i], res[i]);
+        assert_eq!(z_mul[i], res_mul[i]);
+    }
+    assert_eq!(x_ext, 0);
+    assert_eq!(y_ext, 255);
+}
+
+#[test]
+fn solve_mulhu_sanity_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [197, 85, 150, 32];
+    let y: [u32; RV32_NUM_LIMBS] = [51, 109, 78, 142];
+    let z: [u32; RV32_NUM_LIMBS] = [71, 95, 29, 18];
+    let z_mul: [u32; RV32_NUM_LIMBS] = [63, 247, 125, 232];
+    let (res, res_mul, x_ext, y_ext) =
+        solve_mulh::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(MulHOpcode::MULHU, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(z[i], res[i]);
+        assert_eq!(z_mul[i], res_mul[i]);
+    }
+    assert_eq!(x_ext, 0);
+    assert_eq!(y_ext, 0);
+}
+
+#[test]
+fn solve_mulhsu_pos_sanity_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [197, 85, 150, 32];
+    let y: [u32; RV32_NUM_LIMBS] = [51, 109, 78, 142];
+    let z: [u32; RV32_NUM_LIMBS] = [71, 95, 29, 18];
+    let z_mul: [u32; RV32_NUM_LIMBS] = [63, 247, 125, 232];
+    let (res, res_mul, x_ext, y_ext) =
+        solve_mulh::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(MulHOpcode::MULHSU, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(z[i], res[i]);
+        assert_eq!(z_mul[i], res_mul[i]);
+    }
+    assert_eq!(x_ext, 0);
+    assert_eq!(y_ext, 0);
+}
+
+#[test]
+fn solve_mulhsu_neg_sanity_test() {
+    let x: [u32; RV32_NUM_LIMBS] = [197, 85, 150, 160];
+    let y: [u32; RV32_NUM_LIMBS] = [51, 109, 78, 142];
+    let z: [u32; RV32_NUM_LIMBS] = [174, 40, 246, 202];
+    let z_mul: [u32; RV32_NUM_LIMBS] = [63, 247, 125, 104];
+    let (res, res_mul, x_ext, y_ext) =
+        solve_mulh::<RV32_NUM_LIMBS, RV32_LIMB_BITS>(MulHOpcode::MULHSU, &x, &y);
+    for i in 0..RV32_NUM_LIMBS {
+        assert_eq!(z[i], res[i]);
+        assert_eq!(z_mul[i], res_mul[i]);
+    }
+    assert_eq!(x_ext, 255);
+    assert_eq!(y_ext, 0);
+}

--- a/vm/src/uint_multiplication/air.rs
+++ b/vm/src/uint_multiplication/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use afs_primitives::range_tuple::bus::RangeTupleCheckerBus;
+use afs_primitives::range_tuple::RangeTupleCheckerBus;
 use afs_stark_backend::{
     interaction::InteractionBuilder,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
@@ -18,7 +18,7 @@ use crate::{
 pub struct UintMultiplicationAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub(super) execution_bridge: ExecutionBridge,
     pub(super) memory_bridge: MemoryBridge,
-    pub bus: RangeTupleCheckerBus,
+    pub bus: RangeTupleCheckerBus<2>,
 
     pub(super) offset: usize,
 }

--- a/vm/src/uint_multiplication/mod.rs
+++ b/vm/src/uint_multiplication/mod.rs
@@ -41,7 +41,7 @@ pub struct UintMultiplicationChip<T: PrimeField32, const NUM_LIMBS: usize, const
     pub air: UintMultiplicationAir<NUM_LIMBS, LIMB_BITS>,
     data: Vec<UintMultiplicationRecord<T, NUM_LIMBS, LIMB_BITS>>,
     memory_chip: MemoryChipRef<T>,
-    pub range_tuple_chip: Arc<RangeTupleCheckerChip>,
+    pub range_tuple_chip: Arc<RangeTupleCheckerChip<2>>,
 
     offset: usize,
 }
@@ -53,7 +53,7 @@ impl<T: PrimeField32, const NUM_LIMBS: usize, const LIMB_BITS: usize>
         execution_bus: ExecutionBus,
         program_bus: ProgramBus,
         memory_chip: MemoryChipRef<T>,
-        range_tuple_chip: Arc<RangeTupleCheckerChip>,
+        range_tuple_chip: Arc<RangeTupleCheckerChip<2>>,
         offset: usize,
     ) -> Self {
         assert!(LIMB_BITS < 16, "LIMB_BITS {} >= 16", LIMB_BITS);
@@ -79,7 +79,7 @@ impl<T: PrimeField32, const NUM_LIMBS: usize, const LIMB_BITS: usize>
             air: UintMultiplicationAir {
                 execution_bridge: ExecutionBridge::new(execution_bus, program_bus),
                 memory_bridge,
-                bus: bus.clone(),
+                bus: *bus,
                 offset,
             },
             data: vec![],

--- a/vm/src/uint_multiplication/tests.rs
+++ b/vm/src/uint_multiplication/tests.rs
@@ -1,6 +1,6 @@
 use std::{array, borrow::BorrowMut, iter, sync::Arc};
 
-use afs_primitives::range_tuple::{bus::RangeTupleCheckerBus, RangeTupleCheckerChip};
+use afs_primitives::range_tuple::{RangeTupleCheckerBus, RangeTupleCheckerChip};
 use afs_stark_backend::{utils::disable_debug_builder, verifier::VerificationError};
 use ax_sdk::utils::create_seeded_rng;
 use p3_baby_bear::BabyBear;
@@ -88,9 +88,9 @@ fn run_negative_uint_multiplication_test<const NUM_LIMBS: usize, const LIMB_BITS
 ) {
     let bus = RangeTupleCheckerBus::new(
         RANGE_TUPLE_CHECKER_BUS,
-        vec![1 << LIMB_BITS, (NUM_LIMBS * (1 << LIMB_BITS)) as u32],
+        [1 << LIMB_BITS, (NUM_LIMBS * (1 << LIMB_BITS)) as u32],
     );
-    let range_tuple_chip: Arc<RangeTupleCheckerChip> = Arc::new(RangeTupleCheckerChip::new(bus));
+    let range_tuple_chip: Arc<RangeTupleCheckerChip<2>> = Arc::new(RangeTupleCheckerChip::new(bus));
 
     let mut tester = MachineChipTestBuilder::default();
     let mut chip = UintMultiplicationChip::<F, NUM_LIMBS, LIMB_BITS>::new(
@@ -138,9 +138,9 @@ fn uint_multiplication_rand_air_test() {
 
     let bus = RangeTupleCheckerBus::new(
         RANGE_TUPLE_CHECKER_BUS,
-        vec![1 << LIMB_BITS, (NUM_LIMBS * (1 << LIMB_BITS)) as u32],
+        [1 << LIMB_BITS, (NUM_LIMBS * (1 << LIMB_BITS)) as u32],
     );
-    let range_tuple_chip: Arc<RangeTupleCheckerChip> = Arc::new(RangeTupleCheckerChip::new(bus));
+    let range_tuple_chip: Arc<RangeTupleCheckerChip<2>> = Arc::new(RangeTupleCheckerChip::new(bus));
 
     let mut tester = MachineChipTestBuilder::default();
     let mut chip = UintMultiplicationChip::<F, NUM_LIMBS, LIMB_BITS>::new(

--- a/vm/src/vm/config.rs
+++ b/vm/src/vm/config.rs
@@ -92,10 +92,25 @@ fn default_executor_range(executor: ExecutorName) -> (Range<usize>, usize) {
             LessThanOpcode::COUNT,
             LessThanOpcode::default_offset(),
         ),
+        ExecutorName::MultiplicationRv32 => (
+            MulOpcode::default_offset(),
+            MulOpcode::COUNT,
+            MulOpcode::default_offset(),
+        ),
+        ExecutorName::MultiplicationHighRv32 => (
+            MulHOpcode::default_offset(),
+            MulHOpcode::COUNT,
+            MulHOpcode::default_offset(),
+        ),
         ExecutorName::U256Multiplication => (
             U256Opcode::default_offset() + 11,
             1,
             U256Opcode::default_offset(),
+        ),
+        ExecutorName::DivRemRv32 => (
+            DivRemOpcode::default_offset(),
+            DivRemOpcode::COUNT,
+            DivRemOpcode::default_offset(),
         ),
         ExecutorName::ShiftRv32 => (
             ShiftOpcode::default_offset(),


### PR DESCRIPTION
Resolves INT-2295.
- Modifies `RangeTupleChecker` to determine tuple size at compile time
- Implements RV32 multiplication extension runtime support using the Adapter-Integration framework