### PR TITLE
[chore] Remove unused field `bigint_limb_size`

### DIFF
--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -41,7 +41,6 @@ pub fn execute_program(program: Program<BabyBear>, input_stream: Vec<Vec<BabyBea
         VmConfig {
             num_public_values: 4,
             max_segment_len: (1 << 25) - 100,
-            bigint_limb_size: 8,
             ..Default::default()
         }
         .add_default_executor(ExecutorName::ArithmeticLogicUnit256)

--- a/compiler/tests/uint.rs
+++ b/compiler/tests/uint.rs
@@ -89,7 +89,6 @@ fn test_compiler_256_mul() {
         VmConfig {
             num_public_values: 4,
             max_segment_len: (1 << 25) - 100,
-            bigint_limb_size: 8,
             ..Default::default()
         }
         .add_default_executor(ExecutorName::U256Multiplication),
@@ -283,7 +282,6 @@ fn test_compiler_256_sll_srl() {
         VmConfig {
             num_public_values: 4,
             max_segment_len: (1 << 25) - 100,
-            bigint_limb_size: 8,
             ..Default::default()
         }
         .add_default_executor(ExecutorName::Shift256),
@@ -343,7 +341,6 @@ fn test_compiler_256_sra() {
         VmConfig {
             num_public_values: 4,
             max_segment_len: (1 << 25) - 100,
-            bigint_limb_size: 8,
             ..Default::default()
         }
         .add_default_executor(ExecutorName::Shift256),

--- a/recursion/src/bin/alu256_e2e.rs
+++ b/recursion/src/bin/alu256_e2e.rs
@@ -109,7 +109,6 @@ where
     let program = bench_program();
 
     let vm_config = VmConfig {
-        bigint_limb_size: 8,
         ..Default::default()
     }
     .add_default_executor(ExecutorName::ArithmeticLogicUnit256)

--- a/vm/src/vm/config.rs
+++ b/vm/src/vm/config.rs
@@ -175,7 +175,6 @@ pub struct VmConfig {
     /*pub max_program_length: usize,
     pub max_operations: usize,*/
     pub collect_metrics: bool,
-    pub bigint_limb_size: usize,
 }
 
 impl VmConfig {
@@ -185,7 +184,6 @@ impl VmConfig {
         num_public_values: usize,
         max_segment_len: usize,
         collect_metrics: bool,
-        bigint_limb_size: usize,
         // Come from CompilerOptions. We can also pass in the whole compiler option if we need more fields from it.
         enabled_modulus: Vec<BigUint>,
     ) -> Self {
@@ -196,7 +194,6 @@ impl VmConfig {
             num_public_values,
             max_segment_len,
             collect_metrics,
-            bigint_limb_size,
             modular_executors: Vec::new(),
         };
         config.add_modular_support(enabled_modulus)
@@ -281,7 +278,6 @@ impl VmConfig {
             0,
             DEFAULT_MAX_SEGMENT_LEN,
             false,
-            8,
             vec![],
         )
     }
@@ -299,7 +295,6 @@ impl VmConfig {
             0,
             DEFAULT_MAX_SEGMENT_LEN,
             false,
-            8,
             vec![],
         )
         .add_default_executor(ExecutorName::Core)


### PR DESCRIPTION
Remove `bigint_limb_size` which is not used anywhere.