### PR TITLE
chore: use workspace dependencies and default parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,8 +78,7 @@ dependencies = [
  "afs-derive",
  "afs-stark-backend",
  "ax-sdk",
- "derive-new 0.6.0",
- "getset",
+ "derive-new",
  "itertools 0.13.0",
  "lazy_static",
  "num-bigint-dig",
@@ -93,7 +92,6 @@ dependencies = [
  "p3-fri",
  "p3-goldilocks",
  "p3-keccak",
- "p3-keccak-air",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-merkle-tree",
@@ -102,7 +100,6 @@ dependencies = [
  "p3-uni-stark",
  "p3-util",
  "parking_lot",
- "prime_factorization",
  "rand 0.8.5",
  "test-case",
 ]
@@ -534,34 +531,17 @@ dependencies = [
  "afs-primitives",
  "afs-stark-backend",
  "ax-sdk",
- "elliptic-curve",
- "ff 0.13.0",
  "hex-literal",
- "itertools 0.13.0",
- "k256",
  "num-bigint-dig",
  "num-traits",
  "p3-air",
  "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
  "p3-field",
- "p3-fri",
  "p3-matrix",
- "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-uni-stark",
  "p3-util",
  "rand 0.8.5",
- "serde",
- "serde_json",
  "sha3",
- "snark-verifier-sdk",
  "tracing",
- "zkhash",
 ]
 
 [[package]]
@@ -637,15 +617,8 @@ dependencies = [
  "axvm-platform",
  "color-eyre",
  "elf",
- "p3-air",
  "p3-baby-bear",
- "p3-commit",
  "p3-field",
- "p3-keccak-air",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-uni-stark",
- "p3-util",
  "rrs-lib",
  "stark-vm",
 ]
@@ -1188,17 +1161,6 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-new"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2777,7 +2739,6 @@ dependencies = [
 name = "poseidon2-air"
 version = "0.1.0"
 dependencies = [
- "afs-derive",
  "afs-primitives",
  "afs-stark-backend",
  "ark-ff 0.4.2",
@@ -2816,17 +2777,6 @@ checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn 2.0.79",
-]
-
-[[package]]
-name = "prime_factorization"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b43cd4d5e49fa3c769f72033129f07eeaa102c3db2aa11be0c7f1a0cb50f0c"
-dependencies = [
- "itertools 0.10.5",
- "num",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -3623,7 +3573,7 @@ dependencies = [
  "ax-sdk",
  "backtrace",
  "cfg-if",
- "derive-new 0.5.9",
+ "derive-new",
  "enum-utils",
  "enum_dispatch",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
     "toolchain/riscv/zkvm/lib",
     "toolchain/riscv/zkvm/platform",
     "toolchain/riscv/transpiler",
-    "vm"
+    "vm",
 ]
 resolver = "2"
 
@@ -48,10 +48,12 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+[profile.dev]
+opt-level = 1
+
 # For O1 optimization but still fast(ish) compile times
 [profile.fast]
 inherits = "dev"
-opt-level = 1
 debug-assertions = true
 # better recompile times
 incremental = true
@@ -60,13 +62,15 @@ lto = "thin"
 [workspace.dependencies]
 axvm-platform = { path = "toolchain/riscv/zkvm/platform", default-features = false }
 axvm = { path = "toolchain/riscv/zkvm/lib", default-features = false }
+afs-stark-backend = { path = "stark-backend", default-features = false }
 afs-compiler = { path = "toolchain/compiler", default-features = false }
 stark-vm = { path = "vm", default-features = false }
 afs-primitives = { path = "circuits/primitives", default-features = false }
-afs-stark-backend = { path = "stark-backend", default-features = false }
+ax-ecc-primitives = { path = "circuits/ecc", default-features = false }
 afs-derive = { path = "derive", default-features = false }
 ax-sdk = { path = "sdk", default-features = false }
 afs-transpiler = { path = "toolchain/riscv/transpiler", default-features = false }
+poseidon2-air = { path = "circuits/hashes/poseidon2-air", default-features = false }
 
 p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
 p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "95e56fa" }
@@ -101,13 +105,15 @@ zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9"
 
 itertools = "0.13.0"
 rayon = "1.10"
+parking_lot = "0.12.2"
 tracing = "0.1.40"
 serde = { version = "1.0.201", default-features = false, features = ["derive"] }
 serde_json = "1.0.117"
+toml = "0.8.14"
 bincode = "1.3.3"
 lazy_static = "1.5.0"
 once_cell = "1.19.0"
-derive-new = "0.5.1"
+derive-new = "0.6.0"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }
 backtrace = "0.3.71"
@@ -124,6 +130,7 @@ cfg-if = "1.0.0"
 inferno = "0.11.21"
 test-case = "3.3.1"
 test-log = "0.2.16"
+enum_dispatch = "0.3.13"
 
 # For local development. Add to your `.cargo/config.toml`
 # [patch."https://github.com/Plonky3/Plonky3.git"]

--- a/circuits/ecc/Cargo.toml
+++ b/circuits/ecc/Cargo.toml
@@ -5,36 +5,20 @@ edition = "2021"
 description = "Elliptic curve cryptography building blocks."
 
 [dependencies]
-afs-stark-backend = { path = "../../stark-backend" }
-afs-primitives = { path = "../primitives" }
-ax-sdk = { path = "../../sdk" }
 p3-air = { workspace = true }
 p3-field = { workspace = true }
-p3-commit = { workspace = true }
-p3-dft = { workspace = true }
-p3-fri = { workspace = true }
 p3-matrix = { workspace = true }
 p3-util = { workspace = true }
-p3-symmetric = { workspace = true }
-p3-challenger = { workspace = true }
-p3-bn254-fr = { workspace = true }
 p3-baby-bear = { workspace = true }
-p3-merkle-tree = { workspace = true }
-p3-poseidon2 = { workspace = true }
-p3-uni-stark = { workspace = true }
-itertools.workspace = true
+
+afs-stark-backend = { workspace = true }
+afs-primitives = { workspace = true }
+ax-sdk = { workspace = true }
 
 rand.workspace = true
 num-bigint-dig.workspace = true
 num-traits.workspace = true
-serde = { workspace = true }
-snark-verifier-sdk = { workspace = true }
-zkhash = { workspace = true }
-ff = { version = "0.13", features = ["derive", "derive_bits"] }
-serde_json = "1.0.121"
-tracing = { workspace = true }
-k256 = { workspace = true }
-elliptic-curve = { workspace = true, features = ["std"] }
+tracing.workspace = true
 
 [dev-dependencies]
 afs-primitives = { path = "../primitives" }

--- a/circuits/hashes/poseidon2-air/Cargo.toml
+++ b/circuits/hashes/poseidon2-air/Cargo.toml
@@ -13,13 +13,13 @@ p3-symmetric = { workspace = true }
 p3-poseidon2 = { workspace = true }
 p3-util = { workspace = true }
 zkhash = { workspace = true }
-rand = "0.8"
 
-afs-primitives = { path = "../../primitives" }
-afs-stark-backend = { path = "../../../stark-backend", default-features = false }
-afs-derive = { path = "../../../derive" }
-ax-sdk = { path = "../../../sdk" }
-lazy_static = "1.5.0"
+afs-primitives = { workspace = true }
+afs-stark-backend = { workspace = true }
+ax-sdk = { workspace = true }
+
+rand.workspace = true
+lazy_static.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
@@ -32,5 +32,5 @@ rand_xoshiro = "0.6.0"
 ark-ff = { version = "^0.4.0", default-features = false }
 
 [features]
-default = []
+default = ["parallel"]
 parallel = ["afs-stark-backend/parallel"]

--- a/circuits/primitives/Cargo.toml
+++ b/circuits/primitives/Cargo.toml
@@ -10,24 +10,22 @@ p3-air = { workspace = true }
 p3-baby-bear = { workspace = true, optional = true }
 p3-field = { workspace = true }
 p3-keccak = { workspace = true }
-p3-keccak-air = { workspace = true }
 p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true }
 p3-symmetric = { workspace = true }
 p3-util = { workspace = true }
-rand = "0.8"
-derive-new = "0.6.0"
 
-afs-stark-backend = { path = "../../stark-backend", default-features = false }
-afs-derive = { path = "../../derive" }
-parking_lot = "0.12.2"
+afs-stark-backend = { workspace = true }
+afs-derive = { workspace = true }
+
+parking_lot.workspace = true
+rand.workspace = true
+derive-new.workspace = true
 itertools.workspace = true
-getset = "0.1.2"
-num-bigint-dig = "0.8.4"
-num-traits = "0.2.19"
-num-integer = "0.1.45"
-prime_factorization = "1.0.4"
-lazy_static = "1.5.0"
+num-bigint-dig.workspace = true
+num-traits.workspace = true
+num-integer.workspace = true
+lazy_static.workspace = true
 
 [dev-dependencies]
 p3-uni-stark = { workspace = true }
@@ -44,6 +42,6 @@ test-case = "3.3.1"
 ax-sdk = { path = "../../sdk" }
 
 [features]
-default = []
+default = ["parallel"]
 test-traits = ["p3-baby-bear"]            # traits for testing
 parallel = ["afs-stark-backend/parallel"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -27,11 +27,16 @@ zkhash = { workspace = true }
 itertools.workspace = true
 tracing.workspace = true
 
+afs-stark-backend = { workspace = true }
+afs-derive = { workspace = true }
+
 serde = { workspace = true, default-features = false, features = [
     "derive",
     "alloc",
 ] }
-rand = "0.8.5"
+rand.workspace = true
+metrics.workspace = true
+serde_json.workspace = true
 toml = "0.8.14"
 derive_more = "0.99.18"
 ff = { version = "0.13", features = ["derive", "derive_bits"] }
@@ -39,12 +44,7 @@ tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 metrics-tracing-context = "0.16.0"
 metrics-util = "0.17.0"
-metrics = { workspace = true }
-serde_json = { workspace = true }
-
-afs-stark-backend = { path = "../stark-backend", default-features = false }
-afs-derive = { path = "../derive" }
 
 [features]
-default = []
+default = ["parallel"]
 parallel = ["afs-stark-backend/parallel"]

--- a/stark-backend/Cargo.toml
+++ b/stark-backend/Cargo.toml
@@ -14,6 +14,7 @@ p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true }
 p3-uni-stark = { workspace = true }
 p3-util = { workspace = true }
+
 rayon = { workspace = true, optional = true }
 itertools.workspace = true
 tracing.workspace = true
@@ -53,7 +54,7 @@ csv = "1.3.0"
 eyre = "0.6.12"
 
 [features]
-default = []
+default = ["parallel"]
 parallel = ["p3-maybe-rayon/parallel", "dep:rayon"]
 jemalloc = ["dep:tikv-jemallocator"]
 jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]

--- a/toolchain/compiler/Cargo.toml
+++ b/toolchain/compiler/Cargo.toml
@@ -10,9 +10,14 @@ edition = "2021"
 p3-field = { workspace = true }
 p3-baby-bear = { workspace = true }
 p3-bn254-fr = { workspace = true }
-afs-derive = { path = "../../derive" }
-ax-sdk = { path = "../../sdk" }
-stark-vm = { path = "../../vm" }
+zkhash = { workspace = true }
+
+afs-derive = { workspace = true }
+ax-sdk = { workspace = true }
+stark-vm = { workspace = true }
+# disable jemalloc to be compatible with afs-starkbackend
+snark-verifier-sdk = { workspace = true, optional = true }
+
 tracing.workspace = true
 itertools.workspace = true
 serde.workspace = true
@@ -23,9 +28,6 @@ num-bigint-dig.workspace = true
 num-bigint.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
-# disable jemalloc to be compatible with afs-starkbackend
-snark-verifier-sdk = { workspace = true, optional = true }
-zkhash = { workspace = true }
 metrics = { workspace = true, optional = true }
 cfg-if = { workspace = true }
 strum = { workspace = true }
@@ -40,7 +42,7 @@ rand = "0.8.5"
 afs-compiler = { path = ".", features = ["sdk"] }
 
 [features]
-default = []
+default = ["parallel"]
 halo2-compiler = ["dep:snark-verifier-sdk"]
 parallel = ["stark-vm/parallel"]
 sdk = ["stark-vm/sdk"]

--- a/toolchain/riscv/transpiler/Cargo.toml
+++ b/toolchain/riscv/transpiler/Cargo.toml
@@ -7,15 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-p3-air = { workspace = true }
-p3-baby-bear = { workspace = true }
 p3-field = { workspace = true }
-p3-keccak-air = { workspace = true }
-p3-commit = { workspace = true }
-p3-matrix = { workspace = true }
-p3-maybe-rayon = { workspace = true }
-p3-util = { workspace = true }
-p3-uni-stark = { workspace = true }
 
 axvm-platform = { workspace = true }
 stark-vm = { workspace = true }
@@ -23,3 +15,6 @@ stark-vm = { workspace = true }
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "7706273" }
 elf = "0.7.4"
 rrs-lib = "0.1.0"
+
+[dev-dependencies]
+p3-baby-bear = { workspace = true }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -14,20 +14,19 @@ p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true }
 p3-util = { workspace = true }
 
-poseidon2-air = { path = "../circuits/hashes/poseidon2-air", default-features = false }
-afs-primitives = { path = "../circuits/primitives", default-features = false }
-afs-stark-backend = { path = "../stark-backend", default-features = false }
-afs-derive = { path = "../derive" }
-ax-sdk = { path = "../sdk", default-features = false, optional = true }
-ax-ecc-primitives = { path = "../circuits/ecc", default-features = false }
+poseidon2-air = { workspace = true }
+afs-primitives = { workspace = true }
+afs-stark-backend = { workspace = true }
+afs-derive = { workspace = true }
+ax-sdk = { workspace = true, optional = true }
+ax-ecc-primitives = { workspace = true }
 
-toml = "0.8.14"
 enum-utils = "0.1.1"
 strum = { workspace = true }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-num-bigint-dig = "0.8.4"
-num-traits = "0.2.19"
-enum_dispatch = "0.3.13"
+num-bigint-dig.workspace = true
+num-traits.workspace = true
+enum_dispatch.workspace = true
 itertools.workspace = true
 tracing.workspace = true
 strum_macros.workspace = true
@@ -35,6 +34,7 @@ derive-new.workspace = true
 backtrace.workspace = true
 rand.workspace = true
 serde.workspace = true
+toml.workspace = true
 hex-literal.workspace = true
 once_cell.workspace = true
 cfg-if.workspace = true
@@ -58,7 +58,7 @@ test-case.workspace = true
 test-log.workspace = true
 
 [features]
-default = []
+default = ["parallel", "mimalloc"]
 parallel = ["afs-stark-backend/parallel"]
 sdk = ["dep:ax-sdk"]
 bench-metrics = [
@@ -67,3 +67,6 @@ bench-metrics = [
     "dep:inferno",
     "afs-stark-backend/bench-metrics",
 ]
+mimalloc = ["afs-stark-backend/mimalloc"]
+jemalloc = ["afs-stark-backend/jemalloc"]
+jemalloc-prof = ["afs-stark-backend/jemalloc-prof"]


### PR DESCRIPTION
Use workspace to manage internal crate dependencies, which use default-features false.
Then make each crate default to use "parallel" for faster testing without writing extra commands.
Defaults the `dev` profile to `opt-level=1` so we don't need to type `--profile=fast` all the time.