### PR TITLE
chore: `VmCoreChip` only depends on interface

### DIFF
--- a/vm/src/arch/chips.rs
+++ b/vm/src/arch/chips.rs
@@ -114,7 +114,7 @@ impl<F, C: VmChip<F>> VmChip<F> for Rc<RefCell<C>> {
     }
 }
 
-#[derive(Debug, Clone, EnumDiscriminants)]
+#[derive(Clone, EnumDiscriminants)]
 #[strum_discriminants(derive(Serialize, Deserialize))]
 #[strum_discriminants(name(ExecutorName))]
 #[enum_dispatch(InstructionExecutor<F>)]
@@ -147,7 +147,7 @@ pub enum AxVmInstructionExecutor<F: PrimeField32> {
     Secp256k1Double(Rc<RefCell<EcDoubleChip<F>>>),
 }
 
-#[derive(Debug, Clone, IntoStaticStr, Chip)]
+#[derive(Clone, IntoStaticStr, Chip)]
 #[enum_dispatch(VmChip<F>)]
 pub enum AxVmChip<F: PrimeField32> {
     Core(Rc<RefCell<CoreChip<F>>>),

--- a/vm/src/intrinsics/modular_v2/mod.rs
+++ b/vm/src/intrinsics/modular_v2/mod.rs
@@ -9,7 +9,7 @@ use p3_field::PrimeField32;
 
 use crate::{
     arch::{AdapterRuntimeContext, VmCoreChip},
-    rv32im::adapters::{Rv32HeapAdapter, Rv32HeapAdapterInterface},
+    rv32im::adapters::Rv32HeapAdapterInterface,
     utils::{biguint_to_limbs, limbs_to_biguint},
 };
 
@@ -75,7 +75,7 @@ impl<const NUM_LIMBS: usize, const LIMB_SIZE: usize> ModularAddSubV2CoreChip<NUM
 }
 
 impl<F: PrimeField32, const NUM_LIMBS: usize, const LIMB_SIZE: usize>
-    VmCoreChip<F, Rv32HeapAdapter<F, NUM_LIMBS, NUM_LIMBS>>
+    VmCoreChip<F, Rv32HeapAdapterInterface<F, NUM_LIMBS, NUM_LIMBS>>
     for ModularAddSubV2CoreChip<NUM_LIMBS, LIMB_SIZE>
 {
     type Record = ();

--- a/vm/src/rv32im/adapters/rv32_heap.rs
+++ b/vm/src/rv32im/adapters/rv32_heap.rs
@@ -86,6 +86,7 @@ impl<F, const READ_SIZE: usize, const WRITE_SIZE: usize> BaseAir<F>
     }
 }
 
+// TODO: delete and use BasicAdapterInterface
 pub struct Rv32HeapAdapterInterface<
     T: AbstractField,
     const READ_SIZE: usize,

--- a/vm/src/rv32im/branch_eq/tests.rs
+++ b/vm/src/rv32im/branch_eq/tests.rs
@@ -7,7 +7,7 @@ use crate::{
         instructions::{BranchEqualOpcode, UsizeOpcode},
         VmCoreChip,
     },
-    rv32im::adapters::Rv32BranchAdapter,
+    rv32im::adapters::Rv32BranchAdapterInterface,
     system::program::Instruction,
 };
 
@@ -26,24 +26,18 @@ fn execute_pc_increment_sanity_test() {
     let x: [F; RV32_NUM_LIMBS] = [19, 4, 1790, 60].map(F::from_canonical_u32);
     let y: [F; RV32_NUM_LIMBS] = [19, 32, 1804, 60].map(F::from_canonical_u32);
 
-    let result =
-        <BranchEqualCoreChip<RV32_NUM_LIMBS> as VmCoreChip<F, Rv32BranchAdapter<F>>>::execute_instruction(
-            &core,
-            &instruction,
-            F::zero(),
-            [x, y],
-        );
+    let result = <BranchEqualCoreChip<RV32_NUM_LIMBS> as VmCoreChip<
+        F,
+        Rv32BranchAdapterInterface<F>,
+    >>::execute_instruction(&core, &instruction, F::zero(), [x, y]);
     let (output, _) = result.expect("execute_instruction failed");
     assert!(output.to_pc.is_none());
 
     instruction.opcode = BranchEqualOpcode::BNE.as_usize();
-    let result =
-        <BranchEqualCoreChip<RV32_NUM_LIMBS> as VmCoreChip<F, Rv32BranchAdapter<F>>>::execute_instruction(
-            &core,
-            &instruction,
-            F::zero(),
-            [x, y],
-        );
+    let result = <BranchEqualCoreChip<RV32_NUM_LIMBS> as VmCoreChip<
+        F,
+        Rv32BranchAdapterInterface<F>,
+    >>::execute_instruction(&core, &instruction, F::zero(), [x, y]);
     let (output, _) = result.expect("execute_instruction failed");
     assert!(output.to_pc.is_some());
     assert_eq!(output.to_pc.unwrap(), F::from_canonical_u8(8));

--- a/vm/src/rv32im/branch_lt/tests.rs
+++ b/vm/src/rv32im/branch_lt/tests.rs
@@ -11,7 +11,7 @@ use crate::{
         VmCoreChip,
     },
     kernels::core::BYTE_XOR_BUS,
-    rv32im::adapters::Rv32BranchAdapter,
+    rv32im::adapters::Rv32BranchAdapterInterface,
     system::program::Instruction,
 };
 
@@ -33,7 +33,7 @@ fn execute_pc_increment_sanity_test() {
 
     let result = <BranchLessThanCoreChip<RV32_NUM_LIMBS, RV32_LIMB_BITS> as VmCoreChip<
         F,
-        Rv32BranchAdapter<F>,
+        Rv32BranchAdapterInterface<F>,
     >>::execute_instruction(&core, &instruction, F::zero(), [x, x]);
     let (output, _) = result.expect("execute_instruction failed");
     assert!(output.to_pc.is_none());
@@ -41,7 +41,7 @@ fn execute_pc_increment_sanity_test() {
     instruction.opcode = BranchLessThanOpcode::BGE.as_usize();
     let result = <BranchLessThanCoreChip<RV32_NUM_LIMBS, RV32_LIMB_BITS> as VmCoreChip<
         F,
-        Rv32BranchAdapter<F>,
+        Rv32BranchAdapterInterface<F>,
     >>::execute_instruction(&core, &instruction, F::zero(), [x, x]);
     let (output, _) = result.expect("execute_instruction failed");
     assert!(output.to_pc.is_some());

--- a/vm/src/rv32im/new_divrem/core.rs
+++ b/vm/src/rv32im/new_divrem/core.rs
@@ -14,8 +14,8 @@ use p3_field::{Field, PrimeField32};
 use crate::{
     arch::{
         instructions::{DivRemOpcode, UsizeOpcode},
-        AdapterAirContext, AdapterRuntimeContext, Reads, Result, VmAdapterChip, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, Writes,
+        AdapterAirContext, AdapterRuntimeContext, Result, VmAdapterInterface, VmCoreAir,
+        VmCoreChip,
     },
     system::program::Instruction,
 };
@@ -95,11 +95,11 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> DivRemCoreChip<NUM_LIMBS, L
     }
 }
 
-impl<F: PrimeField32, A: VmAdapterChip<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
-    VmCoreChip<F, A> for DivRemCoreChip<NUM_LIMBS, LIMB_BITS>
+impl<F: PrimeField32, I: VmAdapterInterface<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    VmCoreChip<F, I> for DivRemCoreChip<NUM_LIMBS, LIMB_BITS>
 where
-    Reads<F, A::Interface<F>>: Into<[[F; NUM_LIMBS]; 2]>,
-    Writes<F, A::Interface<F>>: From<[F; NUM_LIMBS]>,
+    I::Reads: Into<[[F; NUM_LIMBS]; 2]>,
+    I::Writes: From<[F; NUM_LIMBS]>,
 {
     // TODO: update for trace generation
     type Record = u32;
@@ -110,8 +110,8 @@ where
         &self,
         instruction: &Instruction<F>,
         _from_pc: F,
-        reads: <A::Interface<F> as VmAdapterInterface<F>>::Reads,
-    ) -> Result<(AdapterRuntimeContext<F, A::Interface<F>>, Self::Record)> {
+        reads: I::Reads,
+    ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
         let Instruction { opcode, .. } = instruction;
         let local_opcode_index = DivRemOpcode::from_usize(opcode - self.offset);
 
@@ -133,10 +133,7 @@ where
         };
 
         // Core doesn't modify PC directly, so we let Adapter handle the increment
-        let output: AdapterRuntimeContext<F, A::Interface<F>> = AdapterRuntimeContext {
-            to_pc: None,
-            writes: z.map(F::from_canonical_u32).into(),
-        };
+        let output = AdapterRuntimeContext::without_pc(z.map(F::from_canonical_u32));
 
         // TODO: send RangeTupleChecker requests
         // TODO: create Record and return

--- a/vm/src/rv32im/new_mulh/core.rs
+++ b/vm/src/rv32im/new_mulh/core.rs
@@ -9,8 +9,8 @@ use p3_field::{Field, PrimeField32};
 use crate::{
     arch::{
         instructions::{MulHOpcode, UsizeOpcode},
-        AdapterAirContext, AdapterRuntimeContext, Reads, Result, VmAdapterChip, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, Writes,
+        AdapterAirContext, AdapterRuntimeContext, Result, VmAdapterInterface, VmCoreAir,
+        VmCoreChip,
     },
     system::program::Instruction,
 };
@@ -94,11 +94,11 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> MulHCoreChip<NUM_LIMBS, LIM
     }
 }
 
-impl<F: PrimeField32, A: VmAdapterChip<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
-    VmCoreChip<F, A> for MulHCoreChip<NUM_LIMBS, LIMB_BITS>
+impl<F: PrimeField32, I: VmAdapterInterface<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    VmCoreChip<F, I> for MulHCoreChip<NUM_LIMBS, LIMB_BITS>
 where
-    Reads<F, A::Interface<F>>: Into<[[F; NUM_LIMBS]; 2]>,
-    Writes<F, A::Interface<F>>: From<[F; NUM_LIMBS]>,
+    I::Reads: Into<[[F; NUM_LIMBS]; 2]>,
+    I::Writes: From<[F; NUM_LIMBS]>,
 {
     // TODO: update for trace generation
     type Record = u32;
@@ -109,8 +109,8 @@ where
         &self,
         instruction: &Instruction<F>,
         _from_pc: F,
-        reads: <A::Interface<F> as VmAdapterInterface<F>>::Reads,
-    ) -> Result<(AdapterRuntimeContext<F, A::Interface<F>>, Self::Record)> {
+        reads: I::Reads,
+    ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
         let Instruction { opcode, .. } = instruction;
         let local_opcode_index = MulHOpcode::from_usize(opcode - self.offset);
 
@@ -120,11 +120,7 @@ where
         let (z, _z_mul, _x_ext, _y_ext) =
             solve_mulh::<NUM_LIMBS, LIMB_BITS>(local_opcode_index, &x, &y);
 
-        // Core doesn't modify PC directly, so we let Adapter handle the increment
-        let output: AdapterRuntimeContext<F, A::Interface<F>> = AdapterRuntimeContext {
-            to_pc: None,
-            writes: z.map(F::from_canonical_u32).into(),
-        };
+        let output = AdapterRuntimeContext::without_pc(z.map(F::from_canonical_u32));
 
         // TODO: send RangeTupleChecker requests
         // TODO: create Record and return

--- a/vm/src/rv32im/new_shift/core.rs
+++ b/vm/src/rv32im/new_shift/core.rs
@@ -12,8 +12,8 @@ use p3_field::{Field, PrimeField32};
 use crate::{
     arch::{
         instructions::{ShiftOpcode, UsizeOpcode},
-        AdapterAirContext, AdapterRuntimeContext, Reads, Result, VmAdapterChip, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, Writes,
+        AdapterAirContext, AdapterRuntimeContext, Result, VmAdapterInterface, VmCoreAir,
+        VmCoreChip,
     },
     system::program::Instruction,
 };
@@ -114,11 +114,11 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftCoreChip<NUM_LIMBS, LI
     }
 }
 
-impl<F: PrimeField32, A: VmAdapterChip<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
-    VmCoreChip<F, A> for ShiftCoreChip<NUM_LIMBS, LIMB_BITS>
+impl<F: PrimeField32, I: VmAdapterInterface<F>, const NUM_LIMBS: usize, const LIMB_BITS: usize>
+    VmCoreChip<F, I> for ShiftCoreChip<NUM_LIMBS, LIMB_BITS>
 where
-    Reads<F, A::Interface<F>>: Into<[[F; NUM_LIMBS]; 2]>,
-    Writes<F, A::Interface<F>>: From<[[F; NUM_LIMBS]; 1]>,
+    I::Reads: Into<[[F; NUM_LIMBS]; 2]>,
+    I::Writes: From<[[F; NUM_LIMBS]; 1]>,
 {
     // TODO: update for trace generation
     type Record = u32;
@@ -129,8 +129,8 @@ where
         &self,
         instruction: &Instruction<F>,
         _from_pc: F,
-        reads: <A::Interface<F> as VmAdapterInterface<F>>::Reads,
-    ) -> Result<(AdapterRuntimeContext<F, A::Interface<F>>, Self::Record)> {
+        reads: I::Reads,
+    ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
         let Instruction { opcode, .. } = instruction;
         let local_opcode_index = ShiftOpcode::from_usize(opcode - self.offset);
 
@@ -141,10 +141,7 @@ where
             solve_shift::<NUM_LIMBS, LIMB_BITS>(local_opcode_index, &x, &y);
 
         // Core doesn't modify PC directly, so we let Adapter handle the increment
-        let output: AdapterRuntimeContext<F, A::Interface<F>> = AdapterRuntimeContext {
-            to_pc: None,
-            writes: [z.map(F::from_canonical_u32)].into(),
-        };
+        let output = AdapterRuntimeContext::without_pc([z.map(F::from_canonical_u32)]);
 
         // TODO: send XorLookupChip and VariableRangeCheckerChip requests
         // TODO: create Record and return

--- a/vm/src/system/vm/segment.rs
+++ b/vm/src/system/vm/segment.rs
@@ -77,7 +77,6 @@ use crate::{
     },
 };
 
-#[derive(Debug)]
 pub struct ExecutionSegment<F: PrimeField32> {
     pub config: VmConfig,
     pub program_chip: ProgramChip<F>,
@@ -190,11 +189,8 @@ impl<F: PrimeField32> ExecutionSegment<F> {
 
         for (range, executor, offset) in config.clone().executors {
             for opcode in range.clone() {
-                if let Some(old_executor) = executors.get(&opcode) {
-                    panic!(
-                        "Attempting to override an executor for opcode {} ({:?} -> {:?})",
-                        opcode, old_executor, executor
-                    );
+                if executors.contains_key(&opcode) {
+                    panic!("Attempting to override an executor for opcode {opcode}");
                 }
             }
             match executor {
@@ -474,11 +470,8 @@ impl<F: PrimeField32> ExecutionSegment<F> {
 
         for (range, executor, offset, modulus) in config.clone().modular_executors {
             for opcode in range.clone() {
-                if let Some(old_executor) = executors.get(&opcode) {
-                    panic!(
-                        "Attempting to override an executor for opcode {} ({:?} -> {:?})",
-                        opcode, old_executor, executor
-                    );
+                if executors.contains_key(&opcode) {
+                    panic!("Attempting to override an executor for opcode {opcode}");
                 }
             }
             match executor {


### PR DESCRIPTION
Change `VmCoreChip<F, I>` to depend only on VmAdapterInterface instead of whole VmAdapterChip trait