### PR TITLE
draft: Rv32VectorizedHeapAdapter

### DIFF
--- a/vm/src/intrinsics/modular_v2/tests.rs
+++ b/vm/src/intrinsics/modular_v2/tests.rs
@@ -12,7 +12,7 @@ use crate::{
         testing::VmChipTestBuilder,
         ExecutionBridge, VmChipWrapper,
     },
-    rv32im::adapters::Rv32HeapAdapter,
+    rv32im::adapters::{Rv32HeapAdapter, Rv32VecHeapAdapter},
     system::program::Instruction,
     utils::biguint_to_limbs,
 };
@@ -247,7 +247,7 @@ fn test_vec_heap_adapter() {
 
     let execution_bridge = ExecutionBridge::new(tester.execution_bus(), tester.program_bus());
     let memory_bridge = tester.memory_controller().borrow().memory_bridge();
-    let adapter = Rv32HeapAdapter::new(execution_bridge, memory_bridge);
+    let adapter = Rv32VecHeapAdapter::new(execution_bridge, memory_bridge);
     let coord_chip = ModularAddSubV2CoreChip::<NUM_LIMBS, LIMB_SIZE>::new(
         coord_modulus.clone(),
         tester.memory_controller().borrow().range_checker.clone(),

--- a/vm/src/rv32im/adapters/mod.rs
+++ b/vm/src/rv32im/adapters/mod.rs
@@ -59,3 +59,23 @@ pub fn read_rv32_register<F: PrimeField32>(
     let val = compose(record.data);
     (record, val)
 }
+
+pub fn batch_read_rv32_registers<
+    F: PrimeField32,
+    const NUM_READS: usize,
+    const NUM_CELLS: usize,
+>(
+    memory: &mut MemoryController<F>,
+    address_space: F,
+    pointer: F,
+) -> (MemoryReadRecord<F, NUM_CELLS>, [u32; NUM_READS]) {
+    debug_assert_eq!(address_space, F::one());
+    let record = memory.read::<NUM_CELLS>(address_space, pointer);
+    let vals = record
+        .data
+        .chunks(RV32_REGISTER_NUM_LANES)
+        .map(|x| compose(x.try_into().unwrap()))
+        .collect::<Vec<_>>();
+    let vals: [u32; NUM_READS] = vals.try_into().unwrap();
+    (record, vals)
+}

--- a/vm/src/rv32im/adapters/rv32_vec_heap.rs
+++ b/vm/src/rv32im/adapters/rv32_vec_heap.rs
@@ -1,30 +1,38 @@
-use std::{marker::PhantomData, mem::size_of};
+use std::{array::from_fn, marker::PhantomData, mem::size_of};
 
+use afs_derive::AlignedBorrow;
 use p3_air::BaseAir;
 use p3_field::{AbstractField, Field, PrimeField32};
 
 use super::{
-    Rv32RegisterHeapReadAuxCols, Rv32RegisterHeapReadRecord, Rv32RegisterHeapWriteAuxCols,
-    Rv32RegisterHeapWriteRecord,
+    batch_read_rv32_registers, read_rv32_register, Rv32RegisterHeapReadAuxCols,
+    Rv32RegisterHeapReadRecord, Rv32RegisterHeapWriteAuxCols, Rv32RegisterHeapWriteRecord,
+    RV32_REGISTER_NUM_LANES,
 };
 use crate::{
     arch::{
-        AdapterRuntimeContext, ExecutionBridge, ExecutionState, Result, VmAdapterChip,
-        VmAdapterInterface,
+        AdapterRuntimeContext, BasicAdapterInterface, ExecutionBridge, ExecutionState, Result,
+        VmAdapterChip, VmAdapterInterface,
     },
     rv32im::adapters::{read_heap_from_rv32_register, write_heap_from_rv32_register},
     system::{
-        memory::{offline_checker::MemoryBridge, HeapAddress, MemoryController},
+        memory::{
+            offline_checker::{MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxCols},
+            HeapAddress, MemoryController, MemoryReadRecord, MemoryWriteRecord,
+        },
         program::Instruction,
     },
 };
 
+#[derive(Clone)]
 pub struct Rv32VecHeapAdapter<
     F: Field,
     const NUM_READS: usize,
     const NUM_WRITES: usize,
     const READ_SIZE: usize,
     const WRITE_SIZE: usize,
+    const READ_CELLS: usize,
+    const WRITE_CELLS: usize,
 > {
     pub air: Rv32VecHeapAdapterAir<NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>,
     _marker: PhantomData<F>,
@@ -36,9 +44,16 @@ impl<
         const NUM_WRITES: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > Rv32VecHeapAdapter<F, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>
+        const READ_CELLS: usize,
+        const WRITE_CELLS: usize,
+    > Rv32VecHeapAdapter<F, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE, READ_CELLS, WRITE_CELLS>
 {
+    /// ## Panics
+    /// If `READ_CELLS != NUM_READS * READ_SIZE` or `WRITE_CELLS != NUM_WRITES * WRITE_SIZE`.
+    /// This is a runtime assertion until Rust const generics expressions are stabilized.
     pub fn new(execution_bridge: ExecutionBridge, memory_bridge: MemoryBridge) -> Self {
+        assert_eq!(READ_CELLS, NUM_READS * READ_SIZE);
+        assert_eq!(WRITE_CELLS, NUM_WRITES * WRITE_SIZE);
         Self {
             air: Rv32VecHeapAdapterAir::new(execution_bridge, memory_bridge),
             _marker: PhantomData,
@@ -46,9 +61,18 @@ impl<
     }
 }
 
+/// Represents first reads a RV register, and then a batch read at the pointer.
 #[derive(Clone, Debug)]
-pub struct Rv32VecHeapProcessedInstruction<T> {
-    pub _marker: PhantomData<T>,
+pub struct Rv32RegisterHeapBatchReadRecord<T, const READ_SIZE: usize> {
+    pub address_read: MemoryReadRecord<T, RV32_REGISTER_NUM_LANES>,
+    pub data_read: MemoryReadRecord<T, READ_SIZE>,
+}
+
+/// Represents first reads a RV register, and then a batch write at the pointer.
+#[derive(Clone, Debug)]
+pub struct Rv32RegisterHeapBatchWriteRecord<T, const WRITE_SIZE: usize> {
+    pub address_read: MemoryReadRecord<T, RV32_REGISTER_NUM_LANES>,
+    pub data_write: MemoryWriteRecord<T, WRITE_SIZE>,
 }
 
 #[derive(Clone)]
@@ -90,29 +114,29 @@ impl<
     }
 }
 
-pub struct Rv32VecHeapAdapterInterface<
-    T,
-    const NUM_READS: usize,
-    const NUM_WRITES: usize,
-    const READ_SIZE: usize,
-    const WRITE_SIZE: usize,
-> {
-    _marker: PhantomData<T>,
-}
+// pub struct Rv32VecHeapAdapterInterface<
+//     T,
+//     const NUM_READS: usize,
+//     const NUM_WRITES: usize,
+//     const READ_SIZE: usize,
+//     const WRITE_SIZE: usize,
+// > {
+//     _marker: PhantomData<T>,
+// }
 
-impl<
-        T: AbstractField,
-        const NUM_READS: usize,
-        const NUM_WRITES: usize,
-        const READ_SIZE: usize,
-        const WRITE_SIZE: usize,
-    > VmAdapterInterface<T>
-    for Rv32VecHeapAdapterInterface<T, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>
-{
-    type Reads = [[T; READ_SIZE]; NUM_READS];
-    type Writes = [[T; WRITE_SIZE]; NUM_WRITES];
-    type ProcessedInstruction = ();
-}
+// impl<
+//         T: AbstractField,
+//         const NUM_READS: usize,
+//         const NUM_WRITES: usize,
+//         const READ_SIZE: usize,
+//         const WRITE_SIZE: usize,
+//     > VmAdapterInterface<T>
+//     for BasicAdapterInterface<T, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>
+// {
+//     type Reads = [[T; READ_SIZE]; NUM_READS];
+//     type Writes = [[T; WRITE_SIZE]; NUM_WRITES];
+//     type ProcessedInstruction = ();
+// }
 
 pub struct Rv32VecHeapAdapterCols<
     T,
@@ -121,10 +145,24 @@ pub struct Rv32VecHeapAdapterCols<
     const READ_SIZE: usize,
     const WRITE_SIZE: usize,
 > {
-    pub read_aux: [Rv32RegisterHeapReadAuxCols<T, READ_SIZE>; NUM_READS],
-    pub write_aux: [Rv32RegisterHeapWriteAuxCols<T, WRITE_SIZE>; NUM_WRITES],
+    pub read_aux: [Rv32RegisterHeapBatchReadAuxCols<T, READ_SIZE>; NUM_READS],
+    pub write_aux: [Rv32RegisterHeapBatchWriteAuxCols<T, WRITE_SIZE>; NUM_WRITES],
     pub read_addresses: [HeapAddress<T, T>; NUM_READS],
     pub write_addresses: [HeapAddress<T, T>; NUM_WRITES],
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, AlignedBorrow)]
+pub struct Rv32RegisterHeapBatchReadAuxCols<T, const READ_SIZE: usize> {
+    pub address: MemoryReadAuxCols<T, RV32_REGISTER_NUM_LANES>,
+    pub data: MemoryReadAuxCols<T, READ_SIZE>,
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct Rv32RegisterHeapBatchWriteAuxCols<T, const WRITE_SIZE: usize> {
+    pub address: MemoryReadAuxCols<T, RV32_REGISTER_NUM_LANES>,
+    pub data: MemoryWriteAuxCols<T, WRITE_SIZE>,
 }
 
 impl<
@@ -133,11 +171,14 @@ impl<
         const NUM_WRITES: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > VmAdapterChip<F> for Rv32VecHeapAdapter<F, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>
+        const READ_CELLS: usize,
+        const WRITE_CELLS: usize,
+    > VmAdapterChip<F>
+    for Rv32VecHeapAdapter<F, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE, READ_CELLS, WRITE_CELLS>
 {
-    type ReadRecord = [Rv32RegisterHeapReadRecord<F, READ_SIZE>; NUM_READS];
-    type WriteRecord = [Rv32RegisterHeapWriteRecord<F, WRITE_SIZE>; NUM_WRITES];
-    type Interface = Rv32VecHeapAdapterInterface<F, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>;
+    type ReadRecord = Rv32RegisterHeapReadRecord<F, READ_CELLS>;
+    type WriteRecord = Rv32RegisterHeapWriteRecord<F, WRITE_CELLS>;
+    type Interface = BasicAdapterInterface<F, NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>;
     type Air = Rv32VecHeapAdapterAir<NUM_READS, NUM_WRITES, READ_SIZE, WRITE_SIZE>;
 
     fn preprocess(
@@ -156,18 +197,17 @@ impl<
         } = *instruction;
         debug_assert_eq!(d.as_canonical_u32(), 1);
 
-        let mut read_record = vec![];
-        for _ in 0..NUM_READS {
-            let x_read = read_heap_from_rv32_register::<F, READ_SIZE>(memory, d, e, address_ptr);
-            read_record.push(x_read);
-        }
-        let reads = read_record
-            .iter()
-            .map(|x| x.data_read.data)
-            .collect::<Vec<_>>();
-        let reads: [[F; READ_SIZE]; NUM_READS] = reads.try_into().unwrap();
-        let read_record: [Rv32RegisterHeapReadRecord<F, READ_SIZE>; NUM_READS] =
-            read_record.try_into().unwrap();
+        let read_record =
+            batch_read_heap_from_rv32_register::<F, READ_CELLS>(memory, d, e, address_ptr);
+        // let reads = read_record
+        //     .iter()
+        //     .map(|x| x.data_read.data)
+        //     .collect::<Vec<_>>();
+        let mut read_record_it = read_record.data_read.data.into_iter();
+        let reads: [[F; READ_SIZE]; NUM_READS] =
+            from_fn(|_| from_fn(|_| read_record_it.next().unwrap()));
+        // let read_record: [Rv32RegisterHeapReadRecord<F, READ_SIZE>; NUM_READS] =
+        //     read_record.try_into().unwrap();
 
         Ok((reads, read_record))
     }
@@ -188,23 +228,18 @@ impl<
         } = *instruction;
         debug_assert_eq!(d.as_canonical_u32(), 1);
 
-        let mut write_record = vec![];
-        for i in 0..NUM_WRITES {
-            let x_write = write_heap_from_rv32_register::<F, WRITE_SIZE>(
-                memory,
-                d,
-                e,
-                address_out,
-                output.writes[i],
-            );
-            write_record.push(x_write);
-        }
+        let write_record = batch_write_heap_from_rv32_register::<
+            F,
+            NUM_WRITES,
+            WRITE_SIZE,
+            WRITE_CELLS,
+        >(memory, d, e, address_out, output.writes);
         let write_record: [Rv32RegisterHeapWriteRecord<F, WRITE_SIZE>; NUM_WRITES] =
             write_record.try_into().unwrap();
 
         Ok((
             ExecutionState {
-                pc: from_state.pc + 4 * NUM_WRITES as u32,
+                pc: output.to_pc.unwrap_or(from_state.pc + 4),
                 timestamp: memory.timestamp(),
             },
             write_record,
@@ -222,5 +257,50 @@ impl<
 
     fn air(&self) -> &Self::Air {
         &self.air
+    }
+}
+
+/// First lookup the heap pointer from register, and then read the data at the pointer.
+pub fn batch_read_heap_from_rv32_register<
+    F: PrimeField32,
+    // const NUM_READS: usize,
+    // const READ_SIZE: usize,
+    const READ_CELLS: usize,
+>(
+    memory: &mut MemoryController<F>,
+    ptr_address_space: F,
+    data_address_space: F,
+    ptr_pointer: F,
+) -> Rv32RegisterHeapReadRecord<F, READ_CELLS> {
+    let (address_read, data_address) = read_rv32_register(memory, ptr_address_space, ptr_pointer);
+    let data_read =
+        memory.read::<READ_CELLS>(data_address_space, F::from_canonical_u32(data_address));
+
+    Rv32RegisterHeapReadRecord {
+        address_read,
+        data_read,
+    }
+}
+
+/// First lookup the heap pointer from register, and then write the data at the pointer.
+pub fn batch_write_heap_from_rv32_register<
+    F: PrimeField32,
+    const NUM_WRITES: usize,
+    const WRITE_SIZE: usize,
+    const WRITE_CELLS: usize,
+>(
+    memory: &mut MemoryController<F>,
+    ptr_address_space: F,
+    data_address_space: F,
+    ptr_pointer: F,
+    data: [[F; WRITE_SIZE]; NUM_WRITES],
+) -> Rv32RegisterHeapWriteRecord<F, WRITE_CELLS> {
+    let (address_read, val) = read_rv32_register(memory, ptr_address_space, ptr_pointer);
+    let data_write =
+        memory.write::<WRITE_CELLS>(data_address_space, F::from_canonical_u32(val), data);
+
+    Rv32RegisterHeapWriteRecord {
+        address_read,
+        data_write,
     }
 }


### PR DESCRIPTION
Draft of `Rv32VectorizedHeapAdapter`. Utilizes Cols and AuxCols from rv32_heap.rs. Still needs tests.