### PR TITLE
feat: Expose interface for initial memory

### DIFF
--- a/lib/recursion/tests/recursion.rs
+++ b/lib/recursion/tests/recursion.rs
@@ -54,14 +54,13 @@ where
         ..Default::default()
     };
 
-    let vm = VirtualMachine::new(vm_config, fib_program, vec![]);
-    vm.segments[0].core_chip.borrow_mut().public_values = vec![
-        Some(BabyBear::zero()),
-        Some(BabyBear::one()),
-        Some(BabyBear::from_canonical_u32(1346269)),
-    ];
+    let vm = VirtualMachine::new(vm_config).with_public_values(vec![
+        (0, BabyBear::zero()),
+        (1, BabyBear::one()),
+        (2, BabyBear::from_canonical_u32(1346269)),
+    ]);
 
-    let mut result = vm.execute_and_generate().unwrap();
+    let mut result = vm.execute_and_generate(fib_program).unwrap();
     assert_eq!(result.per_segment.len(), 1, "unexpected continuation");
     let proof_input = result.per_segment.remove(0);
     ProofInputForTest {

--- a/toolchain/compiler/tests/arithmetic.rs
+++ b/toolchain/compiler/tests/arithmetic.rs
@@ -424,7 +424,7 @@ fn assert_failed_assertion(
     builder: Builder<AsmConfig<BabyBear, BinomialExtensionField<BabyBear, 4>>>,
 ) {
     let program = builder.compile_isa();
-    let mut vm = VirtualMachine::new(VmConfig::default(), program, vec![]);
-    let result = vm.execute();
+    let vm = VirtualMachine::new(VmConfig::default());
+    let result = vm.execute(program);
     assert!(matches!(result, Err(Fail(_))));
 }

--- a/toolchain/riscv/transpiler/src/tests.rs
+++ b/toolchain/riscv/transpiler/src/tests.rs
@@ -44,7 +44,7 @@ fn test_tiny_asm_runtime() -> Result<()> {
     }
     let program = Program::from_instructions_and_step(&instructions, 4, elf.pc_start, elf.pc_base);
     let config = VmConfig::rv32();
-    let mut vm = VirtualMachine::new(config, program, vec![]);
+    let vm = VirtualMachine::new(config);
 
     // TODO: use "execute_and_generate" when it's implemented
     /*
@@ -61,7 +61,7 @@ fn test_tiny_asm_runtime() -> Result<()> {
     }
     */
 
-    vm.execute()?;
+    vm.execute(program)?;
     Ok(())
 }
 
@@ -75,7 +75,7 @@ fn test_runtime(elf_path: &str) -> Result<()> {
     setup_tracing();
     let program = Program::from_instructions_and_step(&instructions, 4, elf.pc_start, elf.pc_base);
     let config = VmConfig::rv32();
-    let mut vm = VirtualMachine::new(config, program, vec![]);
+    let vm = VirtualMachine::new(config);
 
     // TODO: use "execute_and_generate" when it's implemented
     /*
@@ -92,6 +92,6 @@ fn test_runtime(elf_path: &str) -> Result<()> {
     }
     */
 
-    vm.execute()?;
+    vm.execute(program)?;
     Ok(())
 }

--- a/vm/src/sdk/mod.rs
+++ b/vm/src/sdk/mod.rs
@@ -25,8 +25,8 @@ where
             let mut config = config;
             config.collect_metrics = true;
             {
-                let mut vm = VirtualMachine::new(config.clone(), program.clone(), input_stream.clone());
-                vm.execute().unwrap();
+                let mut vm = VirtualMachine::new(config.clone()).with_input_stream(input_stream.clone());
+                vm.execute(program.clone()).unwrap();
             }
             // Run again with metrics collection disabled and measure trace generation time
             config.collect_metrics = false;
@@ -34,9 +34,9 @@ where
         }
     }
 
-    let vm = VirtualMachine::new(config, program, input_stream);
+    let vm = VirtualMachine::new(config).with_input_stream(input_stream);
 
-    let mut result = vm.execute_and_generate().unwrap();
+    let mut result = vm.execute_and_generate(program).unwrap();
     assert_eq!(
         result.per_segment.len(),
         1,

--- a/vm/src/system/memory/manager/interface.rs
+++ b/vm/src/system/memory/manager/interface.rs
@@ -2,7 +2,7 @@ use p3_field::PrimeField32;
 
 use crate::system::memory::{
     merkle::MemoryMerkleChip, persistent::PersistentBoundaryChip, volatile::VolatileBoundaryChip,
-    CHUNK,
+    Equipartition, CHUNK,
 };
 
 #[derive(Clone, Debug)]
@@ -13,6 +13,7 @@ pub enum MemoryInterface<F> {
     Persistent {
         boundary_chip: PersistentBoundaryChip<F, CHUNK>,
         merkle_chip: MemoryMerkleChip<CHUNK, F>,
+        initial_memory: Equipartition<F, CHUNK>,
     },
 }
 
@@ -25,6 +26,7 @@ impl<F: PrimeField32> MemoryInterface<F> {
             MemoryInterface::Persistent {
                 boundary_chip,
                 merkle_chip,
+                ..
             } => {
                 boundary_chip.touch_address(addr_space, pointer);
                 merkle_chip.touch_address(addr_space, pointer);

--- a/vm/src/system/memory/tests.rs
+++ b/vm/src/system/memory/tests.rs
@@ -30,7 +30,7 @@ use rand::{
     Rng,
 };
 
-use super::{MemoryAuxColsFactory, MemoryController, MemoryReadRecord, TimestampedEquipartition};
+use super::{Equipartition, MemoryAuxColsFactory, MemoryController, MemoryReadRecord};
 use crate::{
     arch::{testing::memory::gen_pointer, ExecutionBus},
     intrinsics::hashes::poseidon2::Poseidon2Chip,
@@ -272,7 +272,7 @@ fn test_memory_controller_persistent() {
         memory_config,
         range_checker.clone(),
         merkle_bus,
-        TimestampedEquipartition::new(),
+        Equipartition::new(),
     );
     let aux_factory = memory_controller.aux_cols_factory();
 

--- a/vm/src/system/program/util.rs
+++ b/vm/src/system/program/util.rs
@@ -17,12 +17,12 @@ pub fn execute_program_with_config(
     program: Program<BabyBear>,
     input_stream: Vec<Vec<BabyBear>>,
 ) {
-    let mut vm = VirtualMachine::new(config, program, input_stream);
-    vm.execute().unwrap();
+    let vm = VirtualMachine::new(config).with_input_stream(input_stream);
+    vm.execute(program).unwrap();
 }
 
 pub fn execute_program(program: Program<BabyBear>, input_stream: Vec<Vec<BabyBear>>) {
-    let mut vm = VirtualMachine::new(
+    let vm = VirtualMachine::new(
         VmConfig {
             num_public_values: 4,
             max_segment_len: (1 << 25) - 100,
@@ -32,10 +32,9 @@ pub fn execute_program(program: Program<BabyBear>, input_stream: Vec<Vec<BabyBea
         .add_canonical_modulus()
         .add_default_executor(ExecutorName::Secp256k1AddUnequal)
         .add_default_executor(ExecutorName::Secp256k1Double),
-        program,
-        input_stream,
-    );
-    vm.execute().unwrap();
+    )
+    .with_input_stream(input_stream);
+    vm.execute(program).unwrap();
 }
 
 pub fn execute_program_with_public_values(
@@ -43,18 +42,13 @@ pub fn execute_program_with_public_values(
     input_stream: Vec<Vec<BabyBear>>,
     public_values: &[(usize, BabyBear)],
 ) {
-    let mut vm = VirtualMachine::new(
-        VmConfig {
-            num_public_values: 4,
-            ..Default::default()
-        },
-        program,
-        input_stream,
-    );
-    for &(index, value) in public_values {
-        vm.segments[0].core_chip.borrow_mut().public_values[index] = Some(value);
-    }
-    vm.execute().unwrap()
+    let vm = VirtualMachine::new(VmConfig {
+        num_public_values: 4,
+        ..Default::default()
+    })
+    .with_input_stream(input_stream)
+    .with_public_values(public_values.to_vec());
+    vm.execute(program).unwrap()
 }
 
 impl<F: Copy + Display> Display for Program<F> {

--- a/vm/src/system/vm/chip_set.rs
+++ b/vm/src/system/vm/chip_set.rs
@@ -70,8 +70,8 @@ use crate::{
     },
     system::{
         memory::{
-            merkle::MemoryMerkleBus, offline_checker::MemoryBus, MemoryController,
-            MemoryControllerRef, TimestampedEquipartition, CHUNK,
+            merkle::MemoryMerkleBus, offline_checker::MemoryBus, Equipartition, MemoryController,
+            MemoryControllerRef, CHUNK,
         },
         program::{bridge::ProgramBus, ProgramChip},
         vm::{
@@ -178,7 +178,7 @@ impl VmConfig {
                     self.memory_config,
                     range_checker.clone(),
                     merkle_bus,
-                    TimestampedEquipartition::<F, CHUNK>::new(),
+                    Equipartition::<F, CHUNK>::new(),
                 )))
             }
         };

--- a/vm/src/system/vm/segment.rs
+++ b/vm/src/system/vm/segment.rs
@@ -24,6 +24,7 @@ use crate::{
     intrinsics::hashes::poseidon2::Poseidon2Chip,
     kernels::core::{CoreChip, Streams},
     system::{
+        memory::{Equipartition, CHUNK},
         program::{DebugInfo, ExecutionError, Program},
         vm::{chip_set::VmChipSet, config::PersistenceType},
     },
@@ -99,6 +100,17 @@ impl<F: PrimeField32> ExecutionSegment<F> {
             collected_metrics: Default::default(),
             cycle_tracker: CycleTracker::new(),
         }
+    }
+
+    pub fn set_initial_memory(&mut self, memory: Equipartition<F, CHUNK>) {
+        self.chip_set
+            .memory_controller
+            .borrow_mut()
+            .set_initial_memory(memory);
+    }
+
+    pub fn did_terminate(&self) -> bool {
+        self.core_chip.borrow().state.is_done
     }
 
     /// Stopping is triggered by should_segment()


### PR DESCRIPTION
Also simplifies VirtualMachine interface

Closes INT-2376

copilot:

This pull request includes several updates to the `VirtualMachine` initialization and memory management across various files. The changes primarily focus on simplifying the `VirtualMachine` creation process and updating the memory management system to use the `Equipartition` structure instead of `TimestampedEquipartition`.

### VirtualMachine Initialization Updates:
* Simplified the `VirtualMachine` creation by removing redundant parameters and using methods like `with_public_values` and `with_input_stream`. (`lib/recursion/tests/recursion.rs`, `toolchain/compiler/tests/arithmetic.rs`, `toolchain/riscv/transpiler/src/tests.rs`, `vm/src/sdk/mod.rs`) [[1]](diffhunk://#diff-89f16eeb91a7262edb1e77d6afed93d92768f82f727ae7b18cf844f9ed7b6051L57-R63) [[2]](diffhunk://#diff-532225f36b1632cfa86023b9ad3e7ece7d9da10e53fc61cccfe1aa32b8d8514dL427-R428) [[3]](diffhunk://#diff-8a077f531185ff8f3ee0d085de2464aa6584878d9e3c20d7b17ec5ac3c1f2635L47-R47) [[4]](diffhunk://#diff-8a077f531185ff8f3ee0d085de2464aa6584878d9e3c20d7b17ec5ac3c1f2635L64-R64) [[5]](diffhunk://#diff-8a077f531185ff8f3ee0d085de2464aa6584878d9e3c20d7b17ec5ac3c1f2635L78-R78) [[6]](diffhunk://#diff-8a077f531185ff8f3ee0d085de2464aa6584878d9e3c20d7b17ec5ac3c1f2635L95-R95) [[7]](diffhunk://#diff-eb59320acc36f4b85d6165385f363404e90463b2b1318df78518a42c0925f2e8L28-R39)

### Memory Management Updates:
* Replaced `TimestampedEquipartition` with `Equipartition` in memory management to streamline the memory initialization process. (`vm/src/system/memory/manager/interface.rs`, `vm/src/system/memory/manager/memory.rs`, `vm/src/system/memory/manager/mod.rs`, `vm/src/system/memory/tests.rs`) [[1]](diffhunk://#diff-2e598c1dd60a62bd8b4b95e752e6e654e0be159d797c82a805c9372522cf8b41L5-R5) [[2]](diffhunk://#diff-2e598c1dd60a62bd8b4b95e752e6e654e0be159d797c82a805c9372522cf8b41R16) [[3]](diffhunk://#diff-2e598c1dd60a62bd8b4b95e752e6e654e0be159d797c82a805c9372522cf8b41R29) [[4]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL11-R11) [[5]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL99-R116) [[6]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL470-R470) [[7]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL493-R493) [[8]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL510-R510) [[9]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL527-R527) [[10]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL660-R660) [[11]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL763-R763) [[12]](diffhunk://#diff-2871615f495cadb4c5263b789980feada0571748772d6f93169c2ef45b8a8c0fL820-R820) [[13]](diffhunk://#diff-93fe3b8e221ccbcf9e99cd6d14975d98cb2375b565fc061e05cbd1b2596f4fa8L199-L200) [[14]](diffhunk://#diff-93fe3b8e221ccbcf9e99cd6d14975d98cb2375b565fc061e05cbd1b2596f4fa8L228-L234) [[15]](diffhunk://#diff-93fe3b8e221ccbcf9e99cd6d14975d98cb2375b565fc061e05cbd1b2596f4fa8L244-R276) [[16]](diffhunk://#diff-93fe3b8e221ccbcf9e99cd6d14975d98cb2375b565fc061e05cbd1b2596f4fa8R464-R487) [[17]](diffhunk://#diff-93fe3b8e221ccbcf9e99cd6d14975d98cb2375b565fc061e05cbd1b2596f4fa8R550) [[18]](diffhunk://#diff-93fe3b8e221ccbcf9e99cd6d14975d98cb2375b565fc061e05cbd1b2596f4fa8R592) [[19]](diffhunk://#diff-93fe3b8e221ccbcf9e99cd6d14975d98cb2375b565fc061e05cbd1b2596f4fa8R630) [[20]](diffhunk://#diff-05e619e10aaac4308a22e39d68667bd4671521b1d94ec47c986a7b7b9976f451L33-R33) [[21]](diffhunk://#diff-05e619e10aaac4308a22e39d68667bd4671521b1d94ec47c986a7b7b9976f451L275-R275)

These changes aim to improve the codebase by making the `VirtualMachine` initialization more concise and updating the memory management system to be more efficient and easier to understand.