### PR TITLE
chore: add `MemoryAuxColsFactory` to `generate_trace_row`

### DIFF
--- a/vm/src/arch/testing/test_adapter.rs
+++ b/vm/src/arch/testing/test_adapter.rs
@@ -14,7 +14,10 @@ use crate::{
         AdapterAirContext, AdapterRuntimeContext, DynAdapterInterface, DynArray, ExecutionBridge,
         ExecutionState, MinimalInstruction, Result, VmAdapterAir, VmAdapterChip,
     },
-    system::{memory::MemoryController, program::Instruction},
+    system::{
+        memory::{MemoryAuxColsFactory, MemoryController},
+        program::Instruction,
+    },
 };
 
 // Replaces A: VmAdapterChip while testing VmCoreChip functionality, as it has no
@@ -108,6 +111,7 @@ impl<F: PrimeField32> VmAdapterChip<F> for TestAdapterChip<F> {
         row_slice: &mut [F],
         _read_record: Self::ReadRecord,
         write_record: Self::WriteRecord,
+        _aux_cols_factory: &MemoryAuxColsFactory<F>,
     ) {
         let cols: &mut TestAdapterCols<F> = row_slice.borrow_mut();
         cols.from_pc = F::from_canonical_u32(write_record.from_pc);

--- a/vm/src/kernels/adapters/convert_adapter.rs
+++ b/vm/src/kernels/adapters/convert_adapter.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     cell::RefCell,
+    marker::PhantomData,
 };
 
 use afs_derive::AlignedBorrow;
@@ -39,7 +40,7 @@ pub struct VectorWriteRecord<F: Field, const WRITE_SIZE: usize> {
 #[derive(Clone, Debug)]
 pub struct ConvertAdapterChip<F: Field, const READ_SIZE: usize, const WRITE_SIZE: usize> {
     pub air: ConvertAdapterAir<READ_SIZE, WRITE_SIZE>,
-    aux_cols_factory: MemoryAuxColsFactory<F>,
+    _marker: PhantomData<F>,
 }
 
 impl<F: PrimeField32, const READ_SIZE: usize, const WRITE_SIZE: usize>
@@ -52,13 +53,12 @@ impl<F: PrimeField32, const READ_SIZE: usize, const WRITE_SIZE: usize>
     ) -> Self {
         let memory_controller = RefCell::borrow(&memory_controller);
         let memory_bridge = memory_controller.memory_bridge();
-        let aux_cols_factory = memory_controller.aux_cols_factory();
         Self {
             air: ConvertAdapterAir {
                 execution_bridge: ExecutionBridge::new(execution_bus, program_bus),
                 memory_bridge,
             },
-            aux_cols_factory,
+            _marker: PhantomData,
         }
     }
 }
@@ -201,9 +201,9 @@ impl<F: PrimeField32, const READ_SIZE: usize, const WRITE_SIZE: usize> VmAdapter
         row_slice: &mut [F],
         read_record: Self::ReadRecord,
         write_record: Self::WriteRecord,
+        aux_cols_factory: &MemoryAuxColsFactory<F>,
     ) {
         let row_slice: &mut ConvertAdapterCols<_, READ_SIZE, WRITE_SIZE> = row_slice.borrow_mut();
-        let aux_cols_factory = &self.aux_cols_factory;
 
         row_slice.from_state = write_record.from_state.map(F::from_canonical_u32);
         row_slice.a_idx = write_record.writes[0].pointer;

--- a/vm/src/kernels/adapters/native_vectorized_adapter.rs
+++ b/vm/src/kernels/adapters/native_vectorized_adapter.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     cell::RefCell,
+    marker::PhantomData,
 };
 
 use afs_derive::AlignedBorrow;
@@ -28,7 +29,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct NativeVectorizedAdapterChip<F: Field, const N: usize> {
     pub air: NativeVectorizedAdapterAir<N>,
-    aux_cols_factory: MemoryAuxColsFactory<F>,
+    _marker: PhantomData<F>,
 }
 
 impl<F: PrimeField32, const N: usize> NativeVectorizedAdapterChip<F, N> {
@@ -39,13 +40,12 @@ impl<F: PrimeField32, const N: usize> NativeVectorizedAdapterChip<F, N> {
     ) -> Self {
         let memory_controller = RefCell::borrow(&memory_controller);
         let memory_bridge = memory_controller.memory_bridge();
-        let aux_cols_factory = memory_controller.aux_cols_factory();
         Self {
             air: NativeVectorizedAdapterAir {
                 execution_bridge: ExecutionBridge::new(execution_bus, program_bus),
                 memory_bridge,
             },
-            aux_cols_factory,
+            _marker: PhantomData,
         }
     }
 }
@@ -207,9 +207,9 @@ impl<F: PrimeField32, const N: usize> VmAdapterChip<F> for NativeVectorizedAdapt
         row_slice: &mut [F],
         read_record: Self::ReadRecord,
         write_record: Self::WriteRecord,
+        aux_cols_factory: &MemoryAuxColsFactory<F>,
     ) {
         let row_slice: &mut NativeVectorizedAdapterCols<_, N> = row_slice.borrow_mut();
-        let aux_cols_factory = &self.aux_cols_factory;
 
         row_slice.from_state = write_record.from_state.map(F::from_canonical_u32);
         row_slice.a_idx = write_record.a.pointer;

--- a/vm/src/rv32im/adapters/rv32_alu.rs
+++ b/vm/src/rv32im/adapters/rv32_alu.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::{Borrow, BorrowMut},
     cell::RefCell,
+    marker::PhantomData,
 };
 
 use afs_derive::AlignedBorrow;
@@ -32,7 +33,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct Rv32BaseAluAdapterChip<F: Field> {
     pub air: Rv32BaseAluAdapterAir,
-    aux_cols_factory: MemoryAuxColsFactory<F>,
+    _marker: PhantomData<F>,
 }
 
 impl<F: PrimeField32> Rv32BaseAluAdapterChip<F> {
@@ -43,13 +44,12 @@ impl<F: PrimeField32> Rv32BaseAluAdapterChip<F> {
     ) -> Self {
         let memory_controller = RefCell::borrow(&memory_controller);
         let memory_bridge = memory_controller.memory_bridge();
-        let aux_cols_factory = memory_controller.aux_cols_factory();
         Self {
             air: Rv32BaseAluAdapterAir {
                 execution_bridge: ExecutionBridge::new(execution_bus, program_bus),
                 memory_bridge,
             },
-            aux_cols_factory,
+            _marker: PhantomData,
         }
     }
 }
@@ -277,9 +277,9 @@ impl<F: PrimeField32> VmAdapterChip<F> for Rv32BaseAluAdapterChip<F> {
         row_slice: &mut [F],
         read_record: Self::ReadRecord,
         write_record: Self::WriteRecord,
+        aux_cols_factory: &MemoryAuxColsFactory<F>,
     ) {
         let row_slice: &mut Rv32BaseAluAdapterCols<_> = row_slice.borrow_mut();
-        let aux_cols_factory = &self.aux_cols_factory;
         row_slice.from_state = write_record.from_state.map(F::from_canonical_u32);
         row_slice.rd_ptr = write_record.rd.pointer;
         row_slice.rs1_ptr = read_record.rs1.pointer;

--- a/vm/src/rv32im/adapters/rv32_loadstore.rs
+++ b/vm/src/rv32im/adapters/rv32_loadstore.rs
@@ -20,7 +20,7 @@ use crate::{
     system::{
         memory::{
             offline_checker::{MemoryReadAuxCols, MemoryWriteAuxCols},
-            MemoryController, MemoryReadRecord, MemoryWriteRecord,
+            MemoryAuxColsFactory, MemoryController, MemoryReadRecord, MemoryWriteRecord,
         },
         program::Instruction,
     },
@@ -261,6 +261,7 @@ impl<F: PrimeField32, const NUM_CELLS: usize> VmAdapterChip<F>
         _row_slice: &mut [F],
         _read_record: Self::ReadRecord,
         _write_record: Self::WriteRecord,
+        _aux_cols_factory: &MemoryAuxColsFactory<F>,
     ) {
         todo!()
     }

--- a/vm/src/rv32im/adapters/rv32_mul.rs
+++ b/vm/src/rv32im/adapters/rv32_mul.rs
@@ -14,7 +14,8 @@ use crate::{
     system::{
         memory::{
             offline_checker::{MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxCols},
-            MemoryController, MemoryControllerRef, MemoryReadRecord, MemoryWriteRecord,
+            MemoryAuxColsFactory, MemoryController, MemoryControllerRef, MemoryReadRecord,
+            MemoryWriteRecord,
         },
         program::{bridge::ProgramBus, Instruction},
     },
@@ -176,6 +177,7 @@ impl<F: PrimeField32> VmAdapterChip<F> for Rv32MultAdapter<F> {
         _row_slice: &mut [F],
         _read_record: Self::ReadRecord,
         _write_record: Self::WriteRecord,
+        _aux_cols_factory: &MemoryAuxColsFactory<F>,
     ) {
         todo!();
     }


### PR DESCRIPTION
Resolves INT-2364.

Adds `MemoryAuxColsFactory` argument to `VmAdapterChip.generate_trace_row()`, removes from the structs.