### PR TITLE
chore: rename add_default_executor to add_executor

### DIFF
--- a/lib/recursion/src/bin/alu256_e2e.rs
+++ b/lib/recursion/src/bin/alu256_e2e.rs
@@ -113,8 +113,8 @@ where
     let vm_config = VmConfig {
         ..Default::default()
     }
-    .add_default_executor(ExecutorName::ArithmeticLogicUnit256)
-    .add_default_executor(ExecutorName::Shift256);
+    .add_executor(ExecutorName::ArithmeticLogicUnit256)
+    .add_executor(ExecutorName::Shift256);
     gen_vm_program_test_proof_input(program, vec![], vm_config)
 }
 

--- a/lib/recursion/src/bin/small_e2e.rs
+++ b/lib/recursion/src/bin/small_e2e.rs
@@ -68,9 +68,9 @@ where
     let fib_program = bench_program();
 
     let vm_config = VmConfig::default_with_no_executors()
-        .add_default_executor(ExecutorName::Keccak256)
-        .add_default_executor(ExecutorName::FieldArithmetic)
-        .add_default_executor(ExecutorName::FieldExtension);
+        .add_executor(ExecutorName::Keccak256)
+        .add_executor(ExecutorName::FieldArithmetic)
+        .add_executor(ExecutorName::FieldExtension);
     gen_vm_program_test_proof_input(fib_program, vec![], vm_config)
 }
 

--- a/lib/recursion/src/bin/tiny_e2e.rs
+++ b/lib/recursion/src/bin/tiny_e2e.rs
@@ -56,7 +56,7 @@ where
 {
     let fib_program = fibonacci_program(a, b, n);
 
-    let vm_config = VmConfig::core().add_default_executor(ExecutorName::FieldArithmetic);
+    let vm_config = VmConfig::core().add_executor(ExecutorName::FieldArithmetic);
     gen_vm_program_test_proof_input(fib_program, vec![], vm_config)
 }
 

--- a/toolchain/compiler/tests/ec_add.rs
+++ b/toolchain/compiler/tests/ec_add.rs
@@ -102,9 +102,9 @@ fn test_secp256k1_add(point_1: Point, point_2: Point, point_3: Point) {
     });
     execute_program_with_config(
         VmConfig::default()
-            .add_default_executor(ExecutorName::Secp256k1AddUnequal)
-            .add_default_executor(ExecutorName::Secp256k1Double)
-            .add_default_executor(ExecutorName::ArithmeticLogicUnit256)
+            .add_executor(ExecutorName::Secp256k1AddUnequal)
+            .add_executor(ExecutorName::Secp256k1Double)
+            .add_executor(ExecutorName::ArithmeticLogicUnit256)
             .add_canonical_modulus(),
         program,
         vec![],

--- a/toolchain/compiler/tests/keccak256.rs
+++ b/toolchain/compiler/tests/keccak256.rs
@@ -53,9 +53,9 @@ fn run_e2e_keccak_test(inputs: Vec<Vec<u8>>, expected_outputs: Vec<[u8; 32]>) {
         program,
         vec![],
         VmConfig::default_with_no_executors()
-            .add_default_executor(ExecutorName::FieldArithmetic)
-            .add_default_executor(ExecutorName::FieldExtension)
-            .add_default_executor(ExecutorName::Keccak256),
+            .add_executor(ExecutorName::FieldArithmetic)
+            .add_executor(ExecutorName::FieldExtension)
+            .add_executor(ExecutorName::Keccak256),
         &BabyBearPoseidon2Engine::new(FriParameters::standard_fast()),
     )
     .unwrap();

--- a/toolchain/compiler/tests/uint.rs
+++ b/toolchain/compiler/tests/uint.rs
@@ -91,7 +91,7 @@ fn test_compiler_256_mul() {
             max_segment_len: (1 << 25) - 100,
             ..Default::default()
         }
-        .add_default_executor(ExecutorName::U256Multiplication),
+        .add_executor(ExecutorName::U256Multiplication),
         program,
         vec![],
     );
@@ -284,7 +284,7 @@ fn test_compiler_256_sll_srl() {
             max_segment_len: (1 << 25) - 100,
             ..Default::default()
         }
-        .add_default_executor(ExecutorName::Shift256),
+        .add_executor(ExecutorName::Shift256),
         program,
         vec![],
     );
@@ -343,7 +343,7 @@ fn test_compiler_256_sra() {
             max_segment_len: (1 << 25) - 100,
             ..Default::default()
         }
-        .add_default_executor(ExecutorName::Shift256),
+        .add_executor(ExecutorName::Shift256),
         program,
         vec![],
     );

--- a/vm/src/system/program/util.rs
+++ b/vm/src/system/program/util.rs
@@ -28,10 +28,10 @@ pub fn execute_program(program: Program<BabyBear>, input_stream: Vec<Vec<BabyBea
             max_segment_len: (1 << 25) - 100,
             ..Default::default()
         }
-        .add_default_executor(ExecutorName::ArithmeticLogicUnit256)
+        .add_executor(ExecutorName::ArithmeticLogicUnit256)
         .add_canonical_modulus()
-        .add_default_executor(ExecutorName::Secp256k1AddUnequal)
-        .add_default_executor(ExecutorName::Secp256k1Double),
+        .add_executor(ExecutorName::Secp256k1AddUnequal)
+        .add_executor(ExecutorName::Secp256k1Double),
     )
     .with_input_stream(input_stream);
     vm.execute(program).unwrap();

--- a/vm/src/system/vm/config.rs
+++ b/vm/src/system/vm/config.rs
@@ -76,7 +76,7 @@ impl VmConfig {
         config.add_modular_support(enabled_modulus)
     }
 
-    pub fn add_default_executor(mut self, executor: ExecutorName) -> Self {
+    pub fn add_executor(mut self, executor: ExecutorName) -> Self {
         // Some executors need to be handled in a special way, and cannot be added like other executors.
         // Adding these will cause a panic in the `create_chip_set` function.
         self.executors.push(executor);
@@ -119,10 +119,10 @@ impl VmConfig {
 impl Default for VmConfig {
     fn default() -> Self {
         Self::default_with_no_executors()
-            .add_default_executor(ExecutorName::Core)
-            .add_default_executor(ExecutorName::FieldArithmetic)
-            .add_default_executor(ExecutorName::FieldExtension)
-            .add_default_executor(ExecutorName::Poseidon2)
+            .add_executor(ExecutorName::Core)
+            .add_executor(ExecutorName::FieldArithmetic)
+            .add_executor(ExecutorName::FieldExtension)
+            .add_executor(ExecutorName::Poseidon2)
     }
 }
 
@@ -153,24 +153,24 @@ impl VmConfig {
             false,
             vec![],
         )
-        .add_default_executor(ExecutorName::Core)
+        .add_executor(ExecutorName::Core)
     }
 
     pub fn rv32() -> Self {
         Self::core()
-            .add_default_executor(ExecutorName::ArithmeticLogicUnitRv32)
-            .add_default_executor(ExecutorName::LessThanRv32)
-            .add_default_executor(ExecutorName::MultiplicationRv32)
-            .add_default_executor(ExecutorName::MultiplicationHighRv32)
-            .add_default_executor(ExecutorName::DivRemRv32)
-            .add_default_executor(ExecutorName::ShiftRv32)
-            .add_default_executor(ExecutorName::LoadStoreRv32)
-            .add_default_executor(ExecutorName::LoadSignExtendRv32)
-            .add_default_executor(ExecutorName::BranchEqualRv32)
-            .add_default_executor(ExecutorName::BranchLessThanRv32)
-            .add_default_executor(ExecutorName::JalLuiRv32)
-            .add_default_executor(ExecutorName::JalrRv32)
-            .add_default_executor(ExecutorName::AuipcRv32)
+            .add_executor(ExecutorName::ArithmeticLogicUnitRv32)
+            .add_executor(ExecutorName::LessThanRv32)
+            .add_executor(ExecutorName::MultiplicationRv32)
+            .add_executor(ExecutorName::MultiplicationHighRv32)
+            .add_executor(ExecutorName::DivRemRv32)
+            .add_executor(ExecutorName::ShiftRv32)
+            .add_executor(ExecutorName::LoadStoreRv32)
+            .add_executor(ExecutorName::LoadSignExtendRv32)
+            .add_executor(ExecutorName::BranchEqualRv32)
+            .add_executor(ExecutorName::BranchLessThanRv32)
+            .add_executor(ExecutorName::JalLuiRv32)
+            .add_executor(ExecutorName::JalrRv32)
+            .add_executor(ExecutorName::AuipcRv32)
     }
 
     pub fn aggregation(poseidon2_max_constraint_degree: usize) -> Self {

--- a/vm/tests/integration_test.rs
+++ b/vm/tests/integration_test.rs
@@ -39,7 +39,7 @@ where
 }
 
 fn vm_config_with_field_arithmetic() -> VmConfig {
-    VmConfig::core().add_default_executor(ExecutorName::FieldArithmetic)
+    VmConfig::core().add_executor(ExecutorName::FieldArithmetic)
 }
 
 fn air_test(vm: VirtualMachine<BabyBear>, program: Program<BabyBear>) {
@@ -80,7 +80,7 @@ fn air_test_with_compress_poseidon2(
         },
         ..VmConfig::core()
     }
-    .add_default_executor(ExecutorName::Poseidon2);
+    .add_executor(ExecutorName::Poseidon2);
     let pk = vm_config.generate_pk(engine.keygen_builder());
 
     let vm = VirtualMachine::new(vm_config);
@@ -196,7 +196,7 @@ fn test_vm_1_persistent() {
         memory_config: MemoryConfig::new(1, 16, 10, 6, PersistenceType::Persistent),
         ..VmConfig::core()
     }
-    .add_default_executor(ExecutorName::FieldArithmetic);
+    .add_executor(ExecutorName::FieldArithmetic);
     let pk = config.generate_pk(engine.keygen_builder());
 
     let n = 6;
@@ -293,7 +293,7 @@ fn test_vm_continuations() {
         },
         ..VmConfig::core()
     }
-    .add_default_executor(ExecutorName::FieldArithmetic);
+    .add_executor(ExecutorName::FieldArithmetic);
 
     let vm = VirtualMachine::new(config).with_program_inputs(vec![(0, expected_output)]);
 
@@ -464,8 +464,8 @@ fn test_vm_field_extension_arithmetic() {
 
     let vm = VirtualMachine::new(
         VmConfig::core()
-            .add_default_executor(ExecutorName::FieldArithmetic)
-            .add_default_executor(ExecutorName::FieldExtension),
+            .add_executor(ExecutorName::FieldArithmetic)
+            .add_executor(ExecutorName::FieldExtension),
     );
 
     air_test(vm, program);
@@ -497,8 +497,8 @@ fn test_vm_field_extension_arithmetic_persistent() {
             memory_config: MemoryConfig::new(1, 16, 10, 6, PersistenceType::Persistent),
             ..VmConfig::core()
         }
-        .add_default_executor(ExecutorName::FieldArithmetic)
-        .add_default_executor(ExecutorName::FieldExtension),
+        .add_executor(ExecutorName::FieldArithmetic)
+        .add_executor(ExecutorName::FieldExtension),
     );
 
     air_test(vm, program);
@@ -739,7 +739,7 @@ fn test_vm_keccak() {
     let program = Program::from_instructions(&instructions);
 
     air_test(
-        VirtualMachine::new(VmConfig::core().add_default_executor(ExecutorName::Keccak256)),
+        VirtualMachine::new(VmConfig::core().add_executor(ExecutorName::Keccak256)),
         program,
     );
 }
@@ -764,7 +764,7 @@ fn test_vm_keccak_non_full_round() {
     let program = Program::from_instructions(&instructions);
 
     air_test(
-        VirtualMachine::new(VmConfig::core().add_default_executor(ExecutorName::Keccak256)),
+        VirtualMachine::new(VmConfig::core().add_executor(ExecutorName::Keccak256)),
         program,
     );
 }


### PR DESCRIPTION
Renames `VmConfig.add_default_executor()` to `add_executor()`

Resolves INT-2440.