### PR TITLE
[chore] Disable unnecessary metric collection

### DIFF
--- a/vm/src/system/vm/segment.rs
+++ b/vm/src/system/vm/segment.rs
@@ -139,7 +139,11 @@ impl<F: PrimeField32> ExecutionSegment<F> {
             );
 
             let opcode = instruction.opcode;
-            let prev_trace_cells = self.current_trace_cells();
+            let prev_trace_cells = if collect_metrics {
+                self.current_trace_cells()
+            } else {
+                BTreeMap::new()
+            };
 
             // runtime only instruction handling
             // FIXME: assumes CoreOpcode has offset 0:


### PR DESCRIPTION
Before this PR, even if `collect_metrics` is not enabled, VM execution still counts `current_trace_cells` for every instruction. `current_trace_cells` returns a `BTreeMap<String, usize>` where the key is the AIR name. This significantly slows down VM execution.