### PR TITLE
[fix] more precise autosave

### DIFF
--- a/circuits/ecc/src/field_expression/field_variable.rs
+++ b/circuits/ecc/src/field_expression/field_variable.rs
@@ -48,6 +48,7 @@ pub struct FieldVariable {
 impl FieldVariable {
     // Returns the index of the new variable.
     // There should be no division in the expression.
+    /// This function is idempotent, i.e., if you already saved, then saving again does nothing.
     pub fn save(&mut self) -> usize {
         if let SymbolicExpr::Var(var_id) = self.expr {
             // If self.expr is already a Var, no need to save


### PR DESCRIPTION
Discovered the bug in #606 

1. when we are composing the equation, we keep track of the equation and its max_overflow_bits
2. however the equation here is the "compute" equation, e.g. `x5 * y1 + x2 *y4  + x3*y3`
3. So far everything is correct, but when we range check the carry, we are using the "constraint" equation, which is `compute - result - qp`
4. And while "compute" didn't overflow, "constraint" overflow with additional terms.