### PR TITLE
chore: remove OldCoreChip executor from `rv32` config

### DIFF
--- a/toolchain/riscv/transpiler/src/tests.rs
+++ b/toolchain/riscv/transpiler/src/tests.rs
@@ -44,7 +44,7 @@ fn test_rv32im_runtime(elf_path: &str) -> Result<()> {
     let instructions = transpile::<BabyBear>(&elf.instructions);
     setup_tracing();
     let program = Program::from_instructions_and_step(&instructions, 4, elf.pc_start, elf.pc_base);
-    let config = VmConfig::rv32();
+    let config = VmConfig::rv32im();
     let vm = VirtualMachine::new(config);
 
     // TODO: use "execute_and_generate" when it's implemented
@@ -61,7 +61,7 @@ fn test_intrinsic_runtime(elf_path: &str) -> Result<()> {
     let instructions = transpile::<BabyBear>(&elf.instructions);
     setup_tracing();
     let program = Program::from_instructions_and_step(&instructions, 4, elf.pc_start, elf.pc_base);
-    let config = VmConfig::rv32().add_canonical_modulus();
+    let config = VmConfig::rv32im().add_canonical_modulus();
     let vm = VirtualMachine::new(config);
 
     vm.execute(program)?;

--- a/vm/src/system/vm/config.rs
+++ b/vm/src/system/vm/config.rs
@@ -153,14 +153,11 @@ impl VmConfig {
         .add_executor(ExecutorName::Core)
     }
 
-    pub fn rv32() -> Self {
-        Self::core()
+    pub fn rv32i() -> Self {
+        Self::default_with_no_executors()
             .add_executor(ExecutorName::Nop)
             .add_executor(ExecutorName::ArithmeticLogicUnitRv32)
             .add_executor(ExecutorName::LessThanRv32)
-            .add_executor(ExecutorName::MultiplicationRv32)
-            .add_executor(ExecutorName::MultiplicationHighRv32)
-            .add_executor(ExecutorName::DivRemRv32)
             .add_executor(ExecutorName::ShiftRv32)
             .add_executor(ExecutorName::LoadStoreRv32)
             .add_executor(ExecutorName::LoadSignExtendRv32)
@@ -171,6 +168,13 @@ impl VmConfig {
             .add_executor(ExecutorName::AuipcRv32)
     }
 
+    pub fn rv32im() -> Self {
+        Self::rv32i()
+            .add_executor(ExecutorName::MultiplicationRv32)
+            .add_executor(ExecutorName::MultiplicationHighRv32)
+            .add_executor(ExecutorName::DivRemRv32)
+    }
+
     pub fn aggregation(poseidon2_max_constraint_degree: usize) -> Self {
         VmConfig {
             poseidon2_max_constraint_degree,
@@ -178,9 +182,7 @@ impl VmConfig {
             ..VmConfig::default()
         }
     }
-}
 
-impl VmConfig {
     pub fn read_config_file(file: &str) -> Result<Self, String> {
         let file_str = std::fs::read_to_string(file)
             .map_err(|_| format!("Could not load config file from: {file}"))?;


### PR DESCRIPTION
separate `rv32` into `rv32i` and `rv32im`