### PR TITLE
chore: runs-on for benchmark

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,10 +1,4 @@
 images:
-    # Assuming you have specified a custom policy (`EC2InstanceCustomPolicy`)
-    # so that the runner VMs are able to transparently access ECR
-    # preinstall: |
-    #   #!/bin/bash
-    #   echo "Doing custom things before job starts"
-    #   su - runner -c "aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 123456789012.dkr.ecr.us-east-1.amazonaws.com"
   arm64-rust-dev-32gb:
     platform: "linux"
     arch: "arm64"
@@ -18,6 +12,3 @@ images:
     owner: "912452651013"
     name: "arm64-rust-dev-1024gb"
     ami: "ami-06dd8940c223fd887"
-
- 
-  

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -13,7 +13,7 @@ on:
           - tiny_e2e
           - alu256_e2e
           - small_e2e
-      aws_instance_type:
+      instance_type:
         type: string
         required: false
         description: The type of runner to start ({1,2,4,8,16,32,48,64}cpu-linux-arm64)
@@ -24,7 +24,7 @@ on:
         type: string
         required: true
         description: The name of the benchmark to run
-      aws_instance_type:
+      instance_type:
         type: string
         required: false
         description: The type of runner to start ({1,2,4,8,16,32,48,64}cpu-linux-arm64)
@@ -40,7 +40,7 @@ env:
 jobs:
   bench-new:
     name: Run benchmark on workflow ref/branch
-    runs-on: [runs-on,"runner=${{ inputs.aws_instance_type }}",image=arm64-rust-dev-32gb]
+    runs-on: [runs-on,"runner=${{ inputs.instance_type }}",image=arm64-rust-dev-32gb]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -146,7 +146,7 @@ jobs:
             done
           fi
           echo "Commit: ${commit_url}" >> $RESULT_PATH
-          echo "AWS Instance Type: [${{ inputs.aws_instance_type }}](https://instances.vantage.sh/aws/ec2/${{ inputs.aws_instance_type }})" >> $RESULT_PATH
+          echo "AWS Instance Type: [${{ inputs.instance_type }}](https://instances.vantage.sh/aws/ec2/${{ inputs.instance_type }})" >> $RESULT_PATH
           echo "[Benchmark Workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $RESULT_PATH
           s5cmd cp $RESULT_PATH "${{ env.S3_PATH }}/${current_sha}-${{ inputs.benchmark_name }}.md"
 

--- a/.github/workflows/recursion-bench.yml
+++ b/.github/workflows/recursion-bench.yml
@@ -47,7 +47,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'run-benchmark-e2e'))) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     with:
-      aws_instance_type: r7g.16xlarge
+      instance_type: 64cpu-linux-arm64
       benchmark_name: tiny_e2e
     secrets: inherit
 
@@ -61,7 +61,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'run-benchmark-e2e'))) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     with:
-      aws_instance_type: r7g.16xlarge
+      instance_type: 64cpu-linux-arm64
       benchmark_name: alu256_e2e
     secrets: inherit
 
@@ -75,6 +75,6 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'run-benchmark-e2e'))) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     with:
-      aws_instance_type: r7g.16xlarge
+      instance_type: 64cpu-linux-arm64
       benchmark_name: small_e2e
     secrets: inherit


### PR DESCRIPTION
This PR switches to use runs-on for benchmark

Infra changes not directly reflected in the PR:
- runner instances and s3 storage all switch to use axiom-sandbox account
-  s3://axiom-workflow-data-sandbox-us-east-1 and s3://axiom-public-data-sandbox-us-east-1 are created, and data is synced from the staging account
- runner instance profile added corresponding permission for these two buckets

currently the largest instance type supported is 64cpu (128G mem for c7 family and 256G mem for m7 family). Let me know if larger instances are required, we need to create additional labels for those instance types first.

The runner instance is ephemeral per job (which means the next job can't access the previous instance). So I merged two jobs (bench-new and update-gh) to one job.

This is one example run triggered manually through gh actions: https://github.com/axiom-crypto/afs-prototype/actions/runs/11487835481/job/32022400280
closes INT-2384