### PR TITLE
[feat] Fix critical AIR id in VM

### DIFF
--- a/vm/src/arch/chips.rs
+++ b/vm/src/arch/chips.rs
@@ -125,7 +125,6 @@ pub enum AxVmChip<F: PrimeField32> {
     Jal(Rc<RefCell<KernelJalChip<F>>>),
     FieldArithmetic(Rc<RefCell<FieldArithmeticChip<F>>>),
     FieldExtension(Rc<RefCell<FieldExtensionChip<F>>>),
-    PublicValues(Rc<RefCell<PublicValuesChip<F>>>),
     Poseidon2(Rc<RefCell<Poseidon2Chip<F>>>),
     RangeChecker(Arc<VariableRangeCheckerChip>),
     RangeTupleChecker(Arc<RangeTupleCheckerChip<2>>),

--- a/vm/src/system/memory/manager/mod.rs
+++ b/vm/src/system/memory/manager/mod.rs
@@ -63,6 +63,8 @@ use crate::system::memory::{
 };
 
 pub const CHUNK: usize = 8;
+/// The offset of the Merkle AIR in AIRs of MemoryController.
+pub const MERKLE_AIR_OFFSET: usize = 1;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TimestampedValues<T, const N: usize> {
@@ -488,10 +490,12 @@ impl<F: PrimeField32> MemoryController<F> {
                     hasher,
                 );
 
+                debug_assert_eq!(traces.len(), MERKLE_AIR_OFFSET);
                 traces.push(expand_trace);
                 let mut expand_pvs = vec![];
                 expand_pvs.extend(initial_node.hash());
                 expand_pvs.extend(final_node.hash());
+                debug_assert_eq!(pvs.len(), MERKLE_AIR_OFFSET);
                 pvs.push(expand_pvs);
                 (records, Some(final_memory_values))
             }
@@ -555,6 +559,7 @@ impl<F: PrimeField32> MemoryController<F> {
                 ..
             } => {
                 airs.push(Arc::new(boundary_chip.air.clone()));
+                debug_assert_eq!(airs.len(), MERKLE_AIR_OFFSET);
                 airs.push(Arc::new(merkle_chip.air.clone()));
             }
         }

--- a/vm/src/system/vm/mod.rs
+++ b/vm/src/system/vm/mod.rs
@@ -11,7 +11,6 @@ use parking_lot::Mutex;
 pub use segment::ExecutionSegment;
 
 use crate::{
-    arch::AxVmChip,
     intrinsics::hashes::poseidon2::CHUNK,
     system::{
         memory::Equipartition,
@@ -180,9 +179,12 @@ impl<F: PrimeField32> SingleSegmentVM<F> {
         input: Vec<Vec<F>>,
     ) -> Result<Vec<Option<F>>, ExecutionError> {
         let segment = self.execute_impl(program, input.into())?;
-        let pv_chip = find_chip!(segment.chip_set, AxVmChip::PublicValues);
-        let borrowed_pv_chip = pv_chip.borrow();
-        let pvs = borrowed_pv_chip.core.get_custom_public_values();
+        let pvs = if let Some(pv_chip) = segment.chip_set.public_values_chip {
+            let borrowed_pv_chip = pv_chip.borrow();
+            borrowed_pv_chip.core.get_custom_public_values()
+        } else {
+            vec![]
+        };
         Ok(pvs)
     }
 


### PR DESCRIPTION
`PROGRAM_AIR_ID`/`CONNECTOR_AIR_ID`/`PUBLIC_VALUES_AIR_ID`/`MERKLE_AIR_ID` are fixed now.

closes INT-2451.