### PR TITLE
[fix] fix expected opcode of field expression chip

### DIFF
--- a/vm/src/intrinsics/ecc/sw/tests.rs
+++ b/vm/src/intrinsics/ecc/sw/tests.rs
@@ -33,6 +33,7 @@ fn test_add_ne() {
     let core = FieldExpressionCoreChip::new(
         expr,
         EccOpcode::default_offset(),
+        vec![EccOpcode::EC_ADD_NE as usize],
         tester.memory_controller().borrow().range_checker.clone(),
         "EcAddNe",
     );
@@ -118,6 +119,7 @@ fn test_double() {
     let core = FieldExpressionCoreChip::new(
         expr,
         EccOpcode::default_offset(),
+        vec![EccOpcode::EC_DOUBLE as usize],
         tester.memory_controller().borrow().range_checker.clone(),
         "EcDouble",
     );
@@ -168,6 +170,9 @@ fn test_double() {
         data_as as isize,
     );
     tester.execute(&mut chip, instruction);
+    let tester = tester.build().load(chip).finalize();
+
+    tester.simple_test().expect("Verification failed");
 }
 
 lazy_static::lazy_static! {

--- a/vm/src/kernels/ecc/mod.rs
+++ b/vm/src/kernels/ecc/mod.rs
@@ -11,7 +11,7 @@ use p3_field::PrimeField32;
 
 use super::adapters::native_vec_heap_adapter::NativeVecHeapAdapterChip;
 use crate::{
-    arch::{ExecutionState, InstructionExecutor, Result, VmChipWrapper},
+    arch::{instructions::EccOpcode, ExecutionState, InstructionExecutor, Result, VmChipWrapper},
     intrinsics::{
         ecc::sw::{ec_add_ne_expr, ec_double_expr},
         field_expression::FieldExpressionCoreChip,
@@ -43,6 +43,7 @@ impl<F: PrimeField32, const NUM_LIMBS: usize> KernelEcAddNeChip<F, NUM_LIMBS> {
         let core = FieldExpressionCoreChip::new(
             expr,
             offset,
+            vec![EccOpcode::EC_ADD_NE as usize],
             memory_controller.borrow().range_checker.clone(),
             "EcAddNe",
         );
@@ -74,6 +75,7 @@ impl<F: PrimeField32, const NUM_LIMBS: usize> KernelEcDoubleChip<F, NUM_LIMBS> {
         let core = FieldExpressionCoreChip::new(
             expr,
             offset,
+            vec![EccOpcode::EC_DOUBLE as usize],
             memory_controller.borrow().range_checker.clone(),
             "EcDouble",
         );


### PR DESCRIPTION
Previous the test for double only runs "execution" part, so didn't catch it