### PR TITLE
[feat] Leaf Verifier eDSL Program

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -2,13 +2,14 @@ name: VM STARK and Compiler Tests
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "stark-backend/**"
       - "circuits/primitives/**"
       - "vm/**"
+      - "axiom-vm/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -34,5 +35,10 @@ jobs:
 
       - name: Run vm crate tests
         working-directory: vm
+        run: |
+          cargo nextest run --cargo-profile=fast --features parallel
+
+      - name: Run axiom-vm crate tests
+        working-directory: axiom-vm
         run: |
           cargo nextest run --cargo-profile=fast --features parallel

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Cargo.lock
 .DS_Store
 **/root
 **/leaf
+!axiom-vm/src/verifier/leaf
 **/internal
 
 .cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "axiom-vm"
+version = "0.1.0"
+dependencies = [
+ "afs-compiler",
+ "afs-derive",
+ "afs-recursion",
+ "ax-sdk",
+ "p3-baby-bear",
+ "serde",
+ "serde_json",
+ "stark-vm",
+]
+
+[[package]]
 name = "axvm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "toolchain/riscv/zkvm/lib",
     "toolchain/riscv/zkvm/platform",
     "toolchain/riscv/transpiler",
-    "vm",
+    "vm", "axiom-vm",
 ]
 resolver = "2"
 
@@ -73,6 +73,7 @@ afs-primitives = { path = "circuits/primitives", default-features = false }
 ax-ecc-primitives = { path = "circuits/ecc", default-features = false }
 ax-ecc-lib = { path = "lib/ecc", default-features = false }
 afs-derive = { path = "derive", default-features = false }
+afs-recursion = { path = "lib/recursion", default-features = false }
 ax-sdk = { path = "sdk", default-features = false }
 afs-transpiler = { path = "toolchain/riscv/transpiler", default-features = false }
 poseidon2-air = { path = "circuits/hashes/poseidon2-air", default-features = false }

--- a/axiom-vm/Cargo.toml
+++ b/axiom-vm/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "axiom-vm"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+afs-compiler = { workspace = true, features = ["sdk"] }
+afs-derive = { workspace = true }
+afs-recursion = { workspace = true }
+ax-sdk = { workspace = true }
+p3-baby-bear = { workspace = true }
+stark-vm = { workspace = true, features = ["sdk"] }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = ["parallel"]
+parallel = ["stark-vm/parallel"]

--- a/axiom-vm/src/config.rs
+++ b/axiom-vm/src/config.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use afs_compiler::conversion::CompilerOptions;
+use ax_sdk::{
+    afs_stark_backend::{config::StarkGenericConfig, keygen::types::MultiStarkProvingKey},
+    config::{
+        baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},
+        FriParameters,
+    },
+    engine::{StarkEngine, StarkFriEngine},
+};
+use stark_vm::system::{program::trace::CommittedProgram, vm::config::VmConfig};
+
+use crate::verifier::leaf::LeafVmVerifierConfig;
+
+#[derive(Clone, Debug)]
+pub struct AxiomVmConfig {
+    pub poseidon2_max_constraint_degree: usize,
+    pub max_num_user_public_values: usize,
+    pub fri_params: FriParameters,
+    pub app_vm_config: VmConfig,
+    pub compiler_options: CompilerOptions,
+}
+
+pub struct AxiomVmProvingKey {
+    pub fri_params: FriParameters,
+    pub app_vm_config: VmConfig,
+    pub app_vm_pk: MultiStarkProvingKey<BabyBearPoseidon2Config>,
+    pub leaf_vm_config: VmConfig,
+    pub leaf_verifier_pk: MultiStarkProvingKey<BabyBearPoseidon2Config>,
+    pub committed_leaf_program: Arc<CommittedProgram<BabyBearPoseidon2Config>>,
+}
+
+impl AxiomVmProvingKey {
+    pub fn keygen(config: AxiomVmConfig) -> Self {
+        let engine = BabyBearPoseidon2Engine::new(config.fri_params);
+        let app_vm_pk = config.app_vm_config.generate_pk(engine.keygen_builder());
+        assert!(app_vm_pk.max_constraint_degree < 1 << config.fri_params.log_blowup);
+        assert!(config.poseidon2_max_constraint_degree < 1 << config.fri_params.log_blowup);
+        let leaf_vm_config = config.leaf_verifier_vm_config();
+        let leaf_verifier_pk = leaf_vm_config.generate_pk(engine.keygen_builder());
+        let leaf_program = LeafVmVerifierConfig {
+            max_num_user_public_values: config.max_num_user_public_values,
+            fri_params: config.fri_params,
+            app_vm_config: config.app_vm_config.clone(),
+            compiler_options: config.compiler_options.clone(),
+        }
+        .build_program(app_vm_pk.get_vk());
+        let committed_leaf_program =
+            Arc::new(leaf_program.commit::<BabyBearPoseidon2Config>(engine.config.pcs()));
+        Self {
+            fri_params: config.fri_params,
+            app_vm_config: config.app_vm_config,
+            app_vm_pk,
+            leaf_vm_config,
+            leaf_verifier_pk,
+            committed_leaf_program,
+        }
+    }
+}
+
+pub(crate) fn aggregation_vm_config(
+    num_public_values: usize,
+    poseidon2_max_constraint_degree: usize,
+) -> VmConfig {
+    VmConfig {
+        poseidon2_max_constraint_degree,
+        num_public_values,
+        ..VmConfig::default()
+    }
+}

--- a/axiom-vm/src/lib.rs
+++ b/axiom-vm/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod verifier;

--- a/axiom-vm/src/verifier/leaf/mod.rs
+++ b/axiom-vm/src/verifier/leaf/mod.rs
@@ -1,0 +1,251 @@
+use std::{array, borrow::BorrowMut};
+
+use afs_compiler::{conversion::CompilerOptions, prelude::*};
+use afs_derive::AlignedBorrow;
+use afs_recursion::{
+    challenger::duplex::DuplexChallengerVariable,
+    digest::DigestVariable,
+    fri::TwoAdicFriPcsVariable,
+    hints::{Hintable, InnerVal},
+    stark::StarkVerifier,
+    types::{new_from_inner_multi_vk, InnerConfig},
+    utils::const_fri_config,
+    vars::StarkProofVariable,
+};
+use ax_sdk::{
+    afs_stark_backend::{
+        keygen::types::MultiStarkVerifyingKey, p3_field::AbstractField, prover::types::Proof,
+    },
+    config::{baby_bear_poseidon2::BabyBearPoseidon2Config, FriParameters},
+};
+use stark_vm::system::{
+    connector::VmConnectorPvs,
+    memory::merkle::MemoryMerklePvs,
+    program::Program,
+    vm::{
+        chip_set::{CONNECTOR_AIR_ID, MERKLE_AIR_ID, PROGRAM_CACHED_TRACE_INDEX},
+        config::VmConfig,
+    },
+};
+
+use crate::config::{aggregation_vm_config, AxiomVmConfig};
+
+type C = InnerConfig;
+type F = InnerVal;
+
+#[derive(Debug, AlignedBorrow)]
+#[repr(C)]
+pub struct LeafVmVerifierPvs<T, const CHUNK: usize> {
+    // TODO: is to right to assume a trace commitment [T; CHUNK]?
+    pub app_pc_start: T,
+    pub app_commit: [T; CHUNK],
+    pub connector: VmConnectorPvs<T>,
+    pub memory: MemoryMerklePvs<T, CHUNK>,
+    pub public_values_commit: [T; CHUNK],
+}
+
+impl<const CHUNK: usize> LeafVmVerifierPvs<Felt<F>, { CHUNK }> {
+    fn uninit(builder: &mut Builder<C>) -> Self {
+        Self {
+            app_pc_start: builder.uninit(),
+            app_commit: array::from_fn(|_| builder.uninit()),
+            connector: VmConnectorPvs {
+                initial_pc: builder.uninit(),
+                final_pc: builder.uninit(),
+                exit_code: builder.uninit(),
+                is_terminate: builder.uninit(),
+            },
+            memory: MemoryMerklePvs {
+                initial_root: array::from_fn(|_| builder.uninit()),
+                final_root: array::from_fn(|_| builder.uninit()),
+            },
+            public_values_commit: array::from_fn(|_| builder.uninit()),
+        }
+    }
+}
+
+impl<const CHUNK: usize> LeafVmVerifierPvs<Felt<F>, { CHUNK }> {
+    pub fn flatten(self) -> Vec<Felt<F>> {
+        let mut v = vec![Felt(0, Default::default()); LeafVmVerifierPvs::<u8, CHUNK>::width()];
+        *v.as_mut_slice().borrow_mut() = self;
+        v
+    }
+}
+
+/// Config to generate
+pub struct LeafVmVerifierConfig {
+    #[allow(unused)]
+    pub max_num_user_public_values: usize,
+    pub fri_params: FriParameters,
+    pub app_vm_config: VmConfig,
+    pub compiler_options: CompilerOptions,
+}
+
+impl LeafVmVerifierConfig {
+    pub fn build_program(
+        self,
+        app_vm_vk: MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
+    ) -> Program<F> {
+        let m_advice = new_from_inner_multi_vk(&app_vm_vk);
+        let mut builder = Builder::<C>::default();
+
+        {
+            let pcs = TwoAdicFriPcsVariable {
+                config: const_fri_config(&mut builder, &self.fri_params),
+            };
+            let proofs: Array<C, StarkProofVariable<_>> =
+                <Vec<Proof<BabyBearPoseidon2Config>> as Hintable<C>>::read(&mut builder);
+            // At least 1 proof should be provided.
+            builder.assert_ne::<Usize<_>>(proofs.len(), RVar::zero());
+
+            let pvs = LeafVmVerifierPvs::<Felt<F>, { DIGEST_SIZE }>::uninit(&mut builder);
+            builder.range(0, proofs.len()).for_each(|i, builder| {
+                let proof = builder.get(&proofs, i);
+                StarkVerifier::verify::<DuplexChallengerVariable<C>>(
+                    builder, &pcs, &m_advice, &proof,
+                );
+                {
+                    // TODO: Add app_pc_start
+                    builder.assign(&pvs.app_pc_start, F::zero());
+                    let t_id = RVar::from(PROGRAM_CACHED_TRACE_INDEX);
+                    let commit = builder.get(&proof.commitments.main_trace, t_id);
+                    let commit = if let DigestVariable::Felt(commit) = commit {
+                        commit
+                    } else {
+                        unreachable!()
+                    };
+                    builder.if_eq(i, RVar::zero()).then_or_else(
+                        |builder| assign_slice(builder, &pvs.app_commit, &commit, 0),
+                        |builder| assert_slice(builder, &pvs.app_commit, &commit, 0),
+                    );
+                }
+                {
+                    let a_id = RVar::from(CONNECTOR_AIR_ID);
+                    let a_input = builder.get(&proof.per_air, a_id);
+                    let connector_pvs = &pvs.connector;
+                    let input_pvs = &a_input.public_values;
+                    builder.if_eq(i, RVar::zero()).then_or_else(
+                        |builder| assign_connector(builder, connector_pvs, input_pvs),
+                        |builder| {
+                            // assert prev.final_pc == curr.initial_pc
+                            let initial_pc = builder.get(input_pvs, 0);
+                            builder.assert_felt_eq(connector_pvs.final_pc, initial_pc);
+                            // Update final_pc
+                            let final_pc = builder.get(input_pvs, 1);
+                            builder.assign(&connector_pvs.final_pc, final_pc);
+                            // assert prev.is_terminate == 0
+                            builder.assert_felt_eq(connector_pvs.is_terminate, F::zero());
+                            // Update is_terminate
+                            let is_terminate = builder.get(input_pvs, 3);
+                            builder.assign(&connector_pvs.is_terminate, is_terminate);
+                            // Update exit_code
+                            let exit_code = builder.get(input_pvs, 2);
+                            builder.assign(&connector_pvs.exit_code, exit_code);
+                        },
+                    );
+                }
+                {
+                    let a_id = RVar::from(MERKLE_AIR_ID);
+                    let a_input = builder.get(&proof.per_air, a_id);
+                    builder.if_eq(i, RVar::zero()).then_or_else(
+                        |builder| {
+                            assign_slice(
+                                builder,
+                                &pvs.memory.initial_root,
+                                &a_input.public_values,
+                                0,
+                            );
+                            assign_slice(
+                                builder,
+                                &pvs.memory.final_root,
+                                &a_input.public_values,
+                                DIGEST_SIZE,
+                            );
+                        },
+                        |builder| {
+                            // assert prev.final_root == curr.initial_root
+                            assert_slice(
+                                builder,
+                                &pvs.memory.final_root,
+                                &a_input.public_values,
+                                0,
+                            );
+                            // Update final_root
+                            assign_slice(
+                                builder,
+                                &pvs.memory.final_root,
+                                &a_input.public_values,
+                                DIGEST_SIZE,
+                            );
+                        },
+                    );
+                }
+                // TODO: decommit user public value address space.
+                for j in 0..DIGEST_SIZE {
+                    builder.assign(&pvs.public_values_commit[j], F::zero());
+                }
+            });
+            for pv in pvs.flatten() {
+                builder.commit_public_value(pv);
+            }
+
+            builder.halt();
+        }
+
+        builder.compile_isa_with_options(self.compiler_options)
+    }
+}
+
+impl AxiomVmConfig {
+    pub fn leaf_verifier_vm_config(&self) -> VmConfig {
+        aggregation_vm_config(
+            LeafVmVerifierPvs::<u8, DIGEST_SIZE>::width(),
+            self.poseidon2_max_constraint_degree,
+        )
+    }
+}
+
+fn assign_slice<const CHUNK: usize>(
+    builder: &mut Builder<C>,
+    dst_slice: &[Felt<F>; CHUNK],
+    src: &Array<C, Felt<F>>,
+    src_offset: usize,
+) {
+    for (i, dst) in dst_slice.iter().enumerate() {
+        let pv = builder.get(src, i + src_offset);
+        builder.assign(dst, pv);
+    }
+}
+
+fn assert_slice<const CHUNK: usize>(
+    builder: &mut Builder<C>,
+    dst_slice: &[Felt<F>; CHUNK],
+    src: &Array<C, Felt<F>>,
+    src_offset: usize,
+) {
+    for (i, &dst) in dst_slice.iter().enumerate() {
+        let pv = builder.get(src, i + src_offset);
+        builder.assert_felt_eq(dst, pv);
+    }
+}
+
+fn assign_connector(
+    builder: &mut Builder<C>,
+    dst: &VmConnectorPvs<Felt<F>>,
+    src: &Array<C, Felt<F>>,
+) {
+    let VmConnectorPvs {
+        initial_pc,
+        final_pc,
+        exit_code,
+        is_terminate,
+    } = dst;
+    let v = builder.get(src, RVar::from(0));
+    builder.assign(initial_pc, v);
+    let v = builder.get(src, RVar::from(1));
+    builder.assign(final_pc, v);
+    let v = builder.get(src, RVar::from(2));
+    builder.assign(exit_code, v);
+    let v = builder.get(src, RVar::from(3));
+    builder.assign(is_terminate, v);
+}

--- a/axiom-vm/src/verifier/mod.rs
+++ b/axiom-vm/src/verifier/mod.rs
@@ -1,0 +1,1 @@
+pub mod leaf;

--- a/axiom-vm/tests/integration_test.rs
+++ b/axiom-vm/tests/integration_test.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use afs_compiler::{conversion::CompilerOptions, prelude::*};
+use afs_recursion::{hints::Hintable, types::InnerConfig};
+use ax_sdk::{
+    afs_stark_backend::{config::StarkGenericConfig, p3_field::AbstractField},
+    config::{
+        baby_bear_poseidon2::BabyBearPoseidon2Engine,
+        fri_params::standard_fri_params_with_100_bits_conjectured_security,
+    },
+    engine::{StarkEngine, StarkFriEngine},
+};
+use axiom_vm::config::{AxiomVmConfig, AxiomVmProvingKey};
+use p3_baby_bear::BabyBear;
+use stark_vm::system::vm::{
+    config::{MemoryConfig, PersistenceType, VmConfig},
+    SingleSegmentVM, VirtualMachine,
+};
+
+type C = InnerConfig;
+type F = BabyBear;
+#[test]
+fn test_1() {
+    let axiom_vm_config = AxiomVmConfig {
+        poseidon2_max_constraint_degree: 7,
+        max_num_user_public_values: 100,
+        fri_params: standard_fri_params_with_100_bits_conjectured_security(3),
+        app_vm_config: VmConfig {
+            max_segment_len: 200,
+            memory_config: MemoryConfig {
+                persistence_type: PersistenceType::Persistent,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        compiler_options: CompilerOptions {
+            enable_cycle_tracker: true,
+            compile_prints: true,
+            ..Default::default()
+        },
+    };
+    let axiom_vm_pk = AxiomVmProvingKey::keygen(axiom_vm_config);
+    let engine = BabyBearPoseidon2Engine::new(axiom_vm_pk.fri_params);
+
+    let program = {
+        let n = 100;
+        let mut builder = Builder::<C>::default();
+        let a: Felt<F> = builder.eval(F::zero());
+        let b: Felt<F> = builder.eval(F::one());
+        let c: Felt<F> = builder.uninit();
+        builder.range(0, n).for_each(|_, builder| {
+            builder.assign(&c, a + b);
+            builder.assign(&a, b);
+            builder.assign(&b, c);
+        });
+        builder.halt();
+        builder.compile_isa()
+    };
+    let committed_program = Arc::new(program.commit(engine.config.pcs()));
+
+    let app_vm = VirtualMachine::new(axiom_vm_pk.app_vm_config.clone());
+    let app_vm_result = app_vm
+        .execute_and_generate_with_cached_program(committed_program)
+        .unwrap();
+    assert!(app_vm_result.per_segment.len() > 1);
+    let app_vm_seg_proofs: Vec<_> = app_vm_result
+        .per_segment
+        .into_iter()
+        .map(|proof_input| engine.prove(&axiom_vm_pk.app_vm_pk, proof_input))
+        .collect();
+
+    let leaf_vm = SingleSegmentVM::new(axiom_vm_pk.leaf_vm_config);
+    leaf_vm
+        .execute(
+            axiom_vm_pk.committed_leaf_program.program.clone(),
+            app_vm_seg_proofs.write(),
+        )
+        .unwrap();
+}

--- a/lib/recursion/src/digest.rs
+++ b/lib/recursion/src/digest.rs
@@ -18,6 +18,12 @@ impl<C: Config> DigestVal<C> {
             DigestVal::N(v) => v.len(),
         }
     }
+    pub fn is_empty(&self) -> bool {
+        match self {
+            DigestVal::F(v) => v.is_empty(),
+            DigestVal::N(v) => v.is_empty(),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/lib/recursion/src/hints.rs
+++ b/lib/recursion/src/hints.rs
@@ -127,6 +127,7 @@ impl VecAutoHintable for Vec<AdjacentOpenedValues<InnerChallenge>> {}
 impl VecAutoHintable for Vec<Vec<AdjacentOpenedValues<InnerChallenge>>> {}
 
 impl VecAutoHintable for AirProofData<BabyBearPoseidon2Config> {}
+impl VecAutoHintable for Proof<BabyBearPoseidon2Config> {}
 
 impl<C: Config, I: VecAutoHintable + Hintable<C>> Hintable<C> for Vec<I> {
     type HintVariable = Array<C, I::HintVariable>;

--- a/lib/recursion/src/lib.rs
+++ b/lib/recursion/src/lib.rs
@@ -1,7 +1,7 @@
-mod challenger;
+pub mod challenger;
 mod commit;
 pub mod config;
-mod digest;
+pub mod digest;
 mod folder;
 pub mod fri;
 mod helper;
@@ -10,7 +10,7 @@ mod outer_poseidon2;
 pub mod stark;
 pub mod testing_utils;
 pub mod types;
-mod utils;
+pub mod utils;
 pub mod vars;
 mod view;
 pub mod witness;

--- a/lib/recursion/src/stark/mod.rs
+++ b/lib/recursion/src/stark/mod.rs
@@ -72,7 +72,12 @@ impl VerifierProgram<InnerConfig> {
         let pcs = TwoAdicFriPcsVariable {
             config: const_fri_config(&mut builder, fri_params),
         };
-        StarkVerifier::verify::<DuplexChallengerVariable<_>>(&mut builder, &pcs, constants, &input);
+        StarkVerifier::verify::<DuplexChallengerVariable<_>>(
+            &mut builder,
+            &pcs,
+            &constants,
+            &input,
+        );
 
         builder.cycle_tracker_end("VerifierProgram");
         builder.halt();
@@ -94,7 +99,7 @@ where
     pub fn verify<CH: ChallengerVariable<C>>(
         builder: &mut Builder<C>,
         pcs: &TwoAdicFriPcsVariable<C>,
-        m_advice: MultiStarkVerificationAdvice<C>,
+        m_advice: &MultiStarkVerificationAdvice<C>,
         proof: &StarkProofVariable<C>,
     ) {
         let mut challenger = CH::new(builder);
@@ -106,7 +111,7 @@ where
     pub fn verify_raps(
         builder: &mut Builder<C>,
         pcs: &TwoAdicFriPcsVariable<C>,
-        m_advice: MultiStarkVerificationAdvice<C>,
+        m_advice: &MultiStarkVerificationAdvice<C>,
         challenger: &mut impl ChallengerVariable<C>,
         proof: &StarkProofVariable<C>,
     ) where
@@ -114,7 +119,7 @@ where
         C::EF: TwoAdicField,
     {
         let air_ids = proof.get_air_ids(builder);
-        let m_advice_var = get_advice_per_air(builder, &m_advice, &air_ids);
+        let m_advice_var = get_advice_per_air(builder, m_advice, &air_ids);
         let StarkProofVariable::<C> {
             commitments,
             opening,

--- a/lib/recursion/src/stark/outer.rs
+++ b/lib/recursion/src/stark/outer.rs
@@ -22,7 +22,7 @@ pub fn build_circuit_verify_operations(
     let pcs = TwoAdicFriPcsVariable {
         config: const_fri_config(&mut builder, fri_params),
     };
-    StarkVerifier::verify::<MultiField32ChallengerVariable<_>>(&mut builder, &pcs, advice, &input);
+    StarkVerifier::verify::<MultiField32ChallengerVariable<_>>(&mut builder, &pcs, &advice, &input);
 
     builder.cycle_tracker_end("VerifierProgram");
     builder.operations

--- a/toolchain/compiler/src/ir/types.rs
+++ b/toolchain/compiler/src/ir/types.rs
@@ -205,7 +205,7 @@ impl<C: Config> Variable<C> for Usize<C::N> {
         rhs: impl Into<Self::Expression>,
         builder: &mut Builder<C>,
     ) {
-        Var::<C::N>::assert_eq(lhs, rhs, builder);
+        Var::<C::N>::assert_ne(lhs, rhs, builder);
     }
 
     fn eval(builder: &mut Builder<C>, expr: impl Into<Self::Expression>) -> Self {

--- a/vm/src/system/vm/chip_set.rs
+++ b/vm/src/system/vm/chip_set.rs
@@ -102,6 +102,8 @@ pub const RANGE_TUPLE_CHECKER_BUS: usize = 11;
 pub const MEMORY_MERKLE_BUS: usize = 12;
 
 pub const PROGRAM_AIR_ID: usize = 0;
+/// ProgramAir is the first AIR so its cached trace should be the first main trace.
+pub const PROGRAM_CACHED_TRACE_INDEX: usize = 0;
 pub const CONNECTOR_AIR_ID: usize = 1;
 /// If PublicValuesAir is **enabled**, its AIR ID is 2. PublicValuesAir is always disabled when
 /// using persistent memory.

--- a/vm/src/system/vm/mod.rs
+++ b/vm/src/system/vm/mod.rs
@@ -150,6 +150,24 @@ impl<F: PrimeField32> VirtualMachine<F> {
                 .collect(),
         })
     }
+    pub fn execute_and_generate_with_cached_program<SC: StarkGenericConfig>(
+        mut self,
+        committed_program: Arc<CommittedProgram<SC>>,
+    ) -> Result<VirtualMachineResult<SC>, ExecutionError>
+    where
+        Domain<SC>: PolynomialSpace<Val = F>,
+    {
+        let segments = self.execute_segments(committed_program.program.clone())?;
+
+        Ok(VirtualMachineResult {
+            per_segment: segments
+                .into_iter()
+                .map(|seg| {
+                    seg.generate_proof_input(Some(committed_program.committed_trace_data.clone()))
+                })
+                .collect(),
+        })
+    }
 }
 
 /// A single segment VM.


### PR DESCRIPTION
## Details
- Add `axiom-vm` crate which should own all continuation proving logic. `axiom-vm` is unstable now.
- Fix `Usize::assert_ne`. The bug exists for a long time because the function was never used.
- Now `ProgramChip::generated_cached_trace` pads programs.

@zlangley 
## TODOs
### Public value address space
- Leaf verifier program needs to decommit public value address space and commit public values into a format which doesn't base on memory config, because uppers layer should not know App VM config.
- Impelment hintable variables for the proof of the public value address space.
- AxiomVm/Vm interface change for the proof of the public value address space.
- Currently branching on `Felt` is not supported. So we cannot only commit the public value address space only when `is_terminate`. Need compiler support or a new opcode.
### Public values
- Expose `pc_start` as a public value in `ProgramChip`.
### Internal verifier
- Refactor leaf program generation function to share the implementation. 