### PR TITLE
chore: remove unused InstructionCols struct

### DIFF
--- a/vm/src/arch/execution.rs
+++ b/vm/src/arch/execution.rs
@@ -1,9 +1,7 @@
-use std::{array::from_fn, mem::size_of};
-
 use afs_derive::AlignedBorrow;
 use afs_stark_backend::interaction::InteractionBuilder;
-use axvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
-use p3_field::{AbstractField, Field};
+use axvm_instructions::program::DEFAULT_PC_STEP;
+use p3_field::AbstractField;
 
 use crate::system::program::{ExecutionError, ProgramBus};
 
@@ -14,16 +12,6 @@ pub type Result<T> = std::result::Result<T, ExecutionError>;
 pub struct ExecutionState<T> {
     pub pc: T,
     pub timestamp: T,
-}
-
-pub const NUM_OPERANDS: usize = 7;
-pub const NUM_INSTRUCTION_COLS: usize = size_of::<InstructionCols<u8>>();
-
-#[derive(Clone, Copy, Debug, PartialEq, Default, AlignedBorrow)]
-#[repr(C)]
-pub struct InstructionCols<T> {
-    pub opcode: T,
-    pub operands: [T; NUM_OPERANDS],
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -76,53 +64,6 @@ impl<T> ExecutionState<T> {
 
     pub fn map<U: Clone, F: Fn(T) -> U>(self, function: F) -> ExecutionState<U> {
         ExecutionState::from_iter(&mut self.flatten().map(function).into_iter())
-    }
-}
-
-impl<F: AbstractField> InstructionCols<F> {
-    pub fn new<const N: usize>(opcode: impl Into<F>, operands: [impl Into<F>; N]) -> Self {
-        let mut operands_iter = operands.into_iter();
-        debug_assert!(N <= NUM_OPERANDS);
-        let operands = from_fn(|_| operands_iter.next().map(Into::into).unwrap_or(F::zero()));
-        Self {
-            opcode: opcode.into(),
-            operands,
-        }
-    }
-}
-
-impl<T> InstructionCols<T> {
-    // TODO[jpw]: avoid Vec
-    pub fn flatten(&self) -> Vec<T>
-    where
-        T: Clone,
-    {
-        let mut result = vec![self.opcode.clone()];
-        result.extend(self.operands.clone());
-        result
-    }
-    pub fn get_width() -> usize {
-        1 + NUM_OPERANDS
-    }
-}
-
-impl<F: Field> InstructionCols<F> {
-    pub fn from_instruction(instruction: &Instruction<F>) -> Self {
-        let Instruction {
-            opcode,
-            a,
-            b,
-            c,
-            d,
-            e,
-            f,
-            g,
-            ..
-        } = instruction;
-        Self {
-            opcode: F::from_canonical_usize(*opcode),
-            operands: [a, b, c, d, e, f, g].map(|&f| f),
-        }
     }
 }
 

--- a/vm/src/arch/testing/execution/mod.rs
+++ b/vm/src/arch/testing/execution/mod.rs
@@ -47,31 +47,6 @@ impl<F: PrimeField32> ExecutionTester<F> {
     pub fn last_to_pc(&self) -> F {
         self.records.last().unwrap().final_state.pc
     }
-
-    // for use by CoreChip, needs to be modified to setup memorytester (or just merge them before writing CoreChip)
-    /*fn test_execution_with_expected_changes<F: PrimeField64, E: InstructionExecutor<F>>(
-        &mut self,
-        executor: &mut E,
-        instruction: Instruction<F>,
-        expected_pc_change: usize,
-        expected_timestamp_change: usize,
-    ) {
-        let initial_state = ExecutionState {
-            pc: self.next_elem_size_usize::<F>(),
-            timestamp: self.next_elem_size_usize::<F>(),
-        };
-        let final_state = ExecutionState {
-            pc: initial_state.pc + expected_pc_change,
-            timestamp: initial_state.timestamp + expected_timestamp_change,
-        };
-        assert_eq!(executor.execute(&instruction, initial_state), final_state);
-        self.executions.push(Execution {
-            initial_state,
-            final_state,
-            instruction: InstructionCols::from_instruction(&instruction)
-                .map(|elem| elem.as_canonical_u64() as usize),
-        });
-    }*/
 }
 
 impl<SC: StarkGenericConfig> Chip<SC> for ExecutionTester<Val<SC>>


### PR DESCRIPTION
Was previously used only in `CoreChip`