### PR TITLE
feat: LoadSignExtend supports 1 byte aligned lb and 2 byte aligned lh

### DIFF
--- a/vm/src/rv32im/loadstore/core.rs
+++ b/vm/src/rv32im/loadstore/core.rs
@@ -83,7 +83,7 @@ impl<AB, I, const NUM_CELLS: usize> VmCoreAir<AB, I> for LoadStoreCoreAir<NUM_CE
 where
     AB: InteractionBuilder,
     I: VmAdapterInterface<AB::Expr>,
-    I::Reads: From<[[AB::Var; NUM_CELLS]; 2]>,
+    I::Reads: From<([AB::Var; NUM_CELLS], [AB::Expr; NUM_CELLS])>,
     I::Writes: From<[[AB::Expr; NUM_CELLS]; 1]>,
     I::ProcessedInstruction: From<LoadStoreInstruction<AB::Expr>>,
 {
@@ -223,7 +223,7 @@ where
 
         AdapterAirContext {
             to_pc: None,
-            reads: [prev_data, read_data].into(),
+            reads: (prev_data, read_data.map(|x| x.into())).into(),
             writes: [write_data.map(|x| x.into())].into(),
             instruction: LoadStoreInstruction {
                 is_valid: is_valid.into(),


### PR DESCRIPTION
Resolves INT-2481

feat: LoadSignExtend now supports 1 byte aligned lb and 2 byte aligned lh

if shift amount is >=2 we shift `read_data` by 2, so in CoreAir we only have to handle shift amount 0 or 1. Moreover, for `loadh` it can only be 0. The new version uses 2 additional columns for supporting the shifts (+1 for `shift_most_sig_bit` to unshift the `read_data` and +1 for the additional `loadb` opcode)

Number of columns after the change(34):
`VmAirWrapper<Rv32LoadStoreAdapterAir, LoadSignExtendCoreAir<4, 8> | Rows = 256        | Cells = 28_160      | Prep Cols = 0     | Main Cols = [34]  | Perm Cols = [76]`
Number of columns before the change(32):
`VmAirWrapper<Rv32LoadStoreAdapterAir, LoadSignExtendCoreAir<4, 8> | Rows = 1          | Cells = 108         | Prep Cols = 0     | Main Cols = [32]  | Perm Cols = [76] `
