### PR TITLE
[chore] Add AxVmCommittedExe

### DIFF
--- a/axiom-vm/src/config.rs
+++ b/axiom-vm/src/config.rs
@@ -8,7 +8,7 @@ use ax_stark_sdk::{
     },
     engine::{StarkEngine, StarkFriEngine},
 };
-use axvm_circuit::{arch::VmConfig, system::program::trace::CommittedProgram};
+use axvm_circuit::{arch::VmConfig, system::program::trace::AxVmCommittedExe};
 use axvm_native_compiler::conversion::CompilerOptions;
 
 use crate::verifier::leaf::LeafVmVerifierConfig;
@@ -28,7 +28,7 @@ pub struct AxiomVmProvingKey {
     pub app_vm_pk: MultiStarkProvingKey<BabyBearPoseidon2Config>,
     pub leaf_vm_config: VmConfig,
     pub leaf_verifier_pk: MultiStarkProvingKey<BabyBearPoseidon2Config>,
-    pub committed_leaf_program: Arc<CommittedProgram<BabyBearPoseidon2Config>>,
+    pub committed_leaf_program: Arc<AxVmCommittedExe<BabyBearPoseidon2Config>>,
 }
 
 impl AxiomVmProvingKey {
@@ -46,8 +46,10 @@ impl AxiomVmProvingKey {
             compiler_options: config.compiler_options.clone(),
         }
         .build_program(app_vm_pk.get_vk());
-        let committed_leaf_program =
-            Arc::new(CommittedProgram::commit(&leaf_program, engine.config.pcs()));
+        let committed_leaf_program = Arc::new(AxVmCommittedExe::commit(
+            leaf_program.into(),
+            engine.config.pcs(),
+        ));
         Self {
             fri_params: config.fri_params,
             app_vm_config: config.app_vm_config,

--- a/axiom-vm/tests/integration_test.rs
+++ b/axiom-vm/tests/integration_test.rs
@@ -13,7 +13,7 @@ use axvm_circuit::{
     arch::{
         ExecutorName, MemoryConfig, PersistenceType, SingleSegmentVmExecutor, VmConfig, VmExecutor,
     },
-    system::program::trace::CommittedProgram,
+    system::program::trace::AxVmCommittedExe,
 };
 use axvm_native_compiler::{conversion::CompilerOptions, prelude::*};
 use axvm_recursion::{hints::Hintable, types::InnerConfig};
@@ -62,11 +62,14 @@ fn test_1() {
         builder.halt();
         builder.compile_isa()
     };
-    let committed_program = Arc::new(CommittedProgram::commit(&program, engine.config.pcs()));
+    let committed_exe = Arc::new(AxVmCommittedExe::commit(
+        program.into(),
+        engine.config.pcs(),
+    ));
 
     let app_vm = VmExecutor::new(axiom_vm_pk.app_vm_config.clone());
     let app_vm_result = app_vm
-        .execute_and_generate_with_cached_program(committed_program, vec![])
+        .execute_and_generate_with_cached_program(committed_exe, vec![])
         .unwrap();
     assert!(app_vm_result.per_segment.len() > 1);
     let app_vm_seg_proofs: Vec<_> = app_vm_result
@@ -78,7 +81,7 @@ fn test_1() {
     let leaf_vm = SingleSegmentVmExecutor::new(axiom_vm_pk.leaf_vm_config);
     leaf_vm
         .execute(
-            axiom_vm_pk.committed_leaf_program.program.clone(),
+            axiom_vm_pk.committed_leaf_program.exe.clone(),
             app_vm_seg_proofs.write(),
         )
         .unwrap();

--- a/toolchain/instructions/src/exe.rs
+++ b/toolchain/instructions/src/exe.rs
@@ -14,7 +14,7 @@ pub struct AxVmExe<F> {
     pub program: Program<F>,
     /// Start address of pc.
     pub pc_start: u32,
-    /// Initial memory image in address space 2.
+    /// Initial memory image.
     pub init_memory: MemoryImage<F>,
 }
 

--- a/vm/src/system/connector/tests.rs
+++ b/vm/src/system/connector/tests.rs
@@ -23,7 +23,7 @@ use p3_field::AbstractField;
 use super::VmConnectorPvs;
 use crate::{
     arch::{SingleSegmentVmExecutor, VmConfig, CONNECTOR_AIR_ID},
-    system::program::trace::CommittedProgram,
+    system::program::trace::AxVmCommittedExe,
 };
 
 type F = BabyBear;
@@ -84,11 +84,12 @@ fn test_impl(
         )];
 
         let program = Program::from_instructions(&instructions);
-        let committed_program = Arc::new(CommittedProgram::commit(&program, engine.config.pcs()));
-        let executor = SingleSegmentVmExecutor::new(vm_config);
-        let mut proof_input = executor
-            .execute_and_generate(committed_program, vec![])
-            .unwrap();
+        let committed_exe = Arc::new(AxVmCommittedExe::commit(
+            program.into(),
+            engine.config.pcs(),
+        ));
+        let vm = SingleSegmentVmExecutor::new(vm_config);
+        let mut proof_input = vm.execute_and_generate(committed_exe, vec![]).unwrap();
         let connector_air_input = proof_input
             .per_air
             .iter_mut()

--- a/vm/src/system/memory/manager/dimensions.rs
+++ b/vm/src/system/memory/manager/dimensions.rs
@@ -1,4 +1,7 @@
 use derive_new::new;
+use p3_util::log2_strict_usize;
+
+use crate::{arch::MemoryConfig, system::memory::CHUNK};
 
 // indicates that there are 2^`as_height` address spaces numbered starting from `as_offset`,
 // and that each address space has 2^`address_height` addresses numbered starting from 0
@@ -15,5 +18,15 @@ pub struct MemoryDimensions {
 impl MemoryDimensions {
     pub fn overall_height(&self) -> usize {
         self.as_height + self.address_height
+    }
+}
+
+impl MemoryConfig {
+    pub fn memory_dimensions(&self) -> MemoryDimensions {
+        MemoryDimensions {
+            as_height: self.as_height,
+            address_height: self.pointer_max_bits - log2_strict_usize(CHUNK),
+            as_offset: 1,
+        }
     }
 }

--- a/vm/tests/integration_test.rs
+++ b/vm/tests/integration_test.rs
@@ -16,7 +16,7 @@ use axvm_circuit::{
     },
     intrinsics::hashes::keccak::hasher::utils::keccak256,
     sdk::{air_test, air_test_with_min_segments},
-    system::{memory::CHUNK, program::trace::CommittedProgram},
+    system::{memory::CHUNK, program::trace::AxVmCommittedExe},
 };
 use axvm_instructions::{
     exe::AxVmExe,
@@ -200,14 +200,17 @@ fn test_vm_public_values() {
         ];
 
         let program = Program::from_instructions(&instructions);
-        let committed_program = Arc::new(CommittedProgram::commit(&program, engine.config.pcs()));
+        let committed_exe = Arc::new(AxVmCommittedExe::commit(
+            program.clone().into(),
+            engine.config.pcs(),
+        ));
         let vm = SingleSegmentVmExecutor::new(vm_config);
-        let pvs = vm.execute(program.clone(), vec![]).unwrap();
+        let pvs = vm.execute(program, vec![]).unwrap();
         assert_eq!(
             pvs,
             vec![None, None, Some(BabyBear::from_canonical_u32(12))]
         );
-        let proof_input = vm.execute_and_generate(committed_program, vec![]).unwrap();
+        let proof_input = vm.execute_and_generate(committed_exe, vec![]).unwrap();
         engine
             .prove_then_verify(&pk, proof_input)
             .expect("Verification failed");


### PR DESCRIPTION
Add `AxVmCommittedExe`. Decide to put exe commitment into `axiom-vm` because Merkle root is only needed when proving recursively but VM is somehow agnostic to recursion.

closes INT-2468