### PR TITLE
chore: add custom RISCV instruction constants

### DIFF
--- a/toolchain/riscv/axvm/src/intrinsics/io.rs
+++ b/toolchain/riscv/axvm/src/intrinsics/io.rs
@@ -1,12 +1,18 @@
 #[cfg(target_os = "zkvm")]
-use axvm_platform::constants::CUSTOM_0;
+use axvm_platform::constants::{Custom0Funct3, CUSTOM_0};
 
 /// Store the next 4 bytes from the hint stream to [[rd] + imm]_2.
 #[cfg(target_os = "zkvm")]
 #[macro_export]
 macro_rules! hint_store_u32 {
     ($x:ident, $imm:expr) => {
-        axvm_platform::custom_insn_i!(axvm_platform::constants::CUSTOM_0, 0b001, $x, "x0", $imm)
+        axvm_platform::custom_insn_i!(
+            axvm_platform::constants::CUSTOM_0,
+            axvm_platform::constants::Custom0Funct3::HintStoreW as u8,
+            $x,
+            "x0",
+            $imm
+        )
     };
 }
 
@@ -14,7 +20,7 @@ macro_rules! hint_store_u32 {
 #[inline(always)]
 pub fn hint_input() {
     #[cfg(target_os = "zkvm")]
-    axvm_platform::custom_insn_i!(CUSTOM_0, 0b011, "x0", "x0", 0);
+    axvm_platform::custom_insn_i!(CUSTOM_0, Custom0Funct3::HintInput as u8, "x0", "x0", 0);
     #[cfg(not(target_os = "zkvm"))]
     todo!()
 }

--- a/toolchain/riscv/platform/src/constants.rs
+++ b/toolchain/riscv/platform/src/constants.rs
@@ -1,2 +1,68 @@
 pub const CUSTOM_0: u8 = 0x0b;
 pub const CUSTOM_1: u8 = 0x2b;
+
+/// Different funct3 for custom RISC-V instructions using the [CUSTOM_0] 7-bit opcode prefix.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Custom0Funct3 {
+    Terminate = 0,
+    HintStoreW,
+    Reveal,
+    HintInput,
+    Keccak256 = 0b100,
+    Int256 = 0b101,
+}
+
+/// Different funct3 for custom RISC-V instructions using the [CUSTOM_1] 7-bit opcode prefix.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Custom1Funct3 {
+    ModularArithmetic = 0,
+    ShortWeierstrass,
+}
+
+/// funct7 options for 256-bit integer instructions.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Int256Funct7 {
+    Add = 0,
+    Sub,
+    Xor,
+    Or,
+    And,
+    Sll,
+    Srl,
+    Sra,
+    Slt,
+    Sltu,
+    Beq,
+    Bne,
+    Blt,
+    Bge,
+    Bltu,
+    Bgeu,
+    Mul,
+}
+
+pub const MODULAR_ARITHMETIC_MAX_KINDS: u8 = 8;
+
+/// Modular arithmetic is configurable. The funct7 field equals `mod_idx * MODULAR_ARITHMETIC_MAX_KINDS + base_funct7`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ModArithBaseFunct7 {
+    AddMod = 0,
+    SubMod,
+    MulMod,
+    DivMod,
+    IsEqMod,
+}
+
+pub const SHORT_WEIERSTRASS_MAX_KINDS: u8 = 8;
+
+/// Short Weierstrass curves are configurable. The funct7 field equals `curve_idx * SHORT_WEIERSTRASS_MAX_KINDS + base_funct7`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SwBaseFunct7 {
+    SwAddNe = 0,
+    SwDouble,
+}


### PR DESCRIPTION
Todo: the transpiler should use these constants instead of hardcoding.