### PR TITLE
[feat] Extend implementation for Variable/MemVariable

### DIFF
--- a/toolchain/native-compiler/src/ir/ptr.rs
+++ b/toolchain/native-compiler/src/ir/ptr.rs
@@ -16,7 +16,7 @@ pub struct SymbolicPtr<N: Field> {
 
 impl<C: Config> Builder<C> {
     /// Allocates an array on the heap.
-    pub(crate) fn alloc(&mut self, len: impl Into<RVar<C::N>>, size: usize) -> Ptr<C::N> {
+    pub fn alloc(&mut self, len: impl Into<RVar<C::N>>, size: usize) -> Ptr<C::N> {
         assert!(
             !self.flags.static_only,
             "Cannot allocate memory in static mode"

--- a/toolchain/native-compiler/src/ir/var.rs
+++ b/toolchain/native-compiler/src/ir/var.rs
@@ -1,3 +1,6 @@
+use std::array;
+
+use itertools::izip;
 use p3_field::PrimeField;
 
 use super::{Builder, Config, Ptr, RVar};
@@ -47,4 +50,56 @@ pub trait FromConstant<C: Config> {
     type Constant;
 
     fn constant(value: Self::Constant, builder: &mut Builder<C>) -> Self;
+}
+
+impl<C: Config, T: Variable<C>, const N: usize> Variable<C> for [T; N] {
+    type Expression = [T; N];
+
+    fn uninit(builder: &mut Builder<C>) -> Self {
+        array::from_fn(|_| T::uninit(builder))
+    }
+
+    fn assign(&self, src: Self::Expression, builder: &mut Builder<C>) {
+        self.iter()
+            .zip(src)
+            .for_each(|(d, s)| d.assign(s.into(), builder));
+    }
+
+    fn assert_eq(
+        lhs: impl Into<Self::Expression>,
+        rhs: impl Into<Self::Expression>,
+        builder: &mut Builder<C>,
+    ) {
+        izip!(lhs.into(), rhs.into()).for_each(|(l, r)| T::assert_eq(l, r, builder));
+    }
+
+    fn assert_ne(
+        _lhs: impl Into<Self::Expression>,
+        _rhs: impl Into<Self::Expression>,
+        _builder: &mut Builder<C>,
+    ) {
+        unimplemented!("assert_ne cannot be implemented for slices")
+    }
+}
+
+impl<C: Config, T: MemVariable<C>, const N: usize> MemVariable<C> for [T; N] {
+    fn size_of() -> usize {
+        N * T::size_of()
+    }
+
+    fn load(&self, ptr: Ptr<C::N>, index: MemIndex<C::N>, builder: &mut Builder<C>) {
+        for (i, v) in self.iter().enumerate() {
+            let mut v_idx = index;
+            v_idx.offset += i * T::size_of();
+            v.load(ptr, v_idx, builder);
+        }
+    }
+
+    fn store(&self, ptr: Ptr<C::N>, index: MemIndex<C::N>, builder: &mut Builder<C>) {
+        for (i, v) in self.iter().enumerate() {
+            let mut v_idx = index;
+            v_idx.offset += i * T::size_of();
+            v.store(ptr, v_idx, builder);
+        }
+    }
 }


### PR DESCRIPTION
- Extend `DslVariable` macro to support generics. But the struct must have a generic parameter `C: Config`.
- Implement `Variable`/`MemVariable` for a slice of `Variable`/`MemVariable`.