### PR TITLE
[feat] Leaf verifier program verifies public values root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "axvm-circuit",
  "axvm-native-compiler",
  "axvm-recursion",
+ "derivative",
  "p3-baby-bear",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ bincode = "1.3.3"
 lazy_static = "1.5.0"
 once_cell = "1.19.0"
 derive-new = "0.6.0"
+derivative = "2.2.0"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }
 enum-utils = "0.1.1"

--- a/axiom-vm/Cargo.toml
+++ b/axiom-vm/Cargo.toml
@@ -14,6 +14,7 @@ ax-stark-sdk = { workspace = true }
 p3-baby-bear = { workspace = true }
 axvm-circuit = { workspace = true }
 
+derivative = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/axiom-vm/src/config.rs
+++ b/axiom-vm/src/config.rs
@@ -37,10 +37,14 @@ impl AxiomVmProvingKey {
         let app_vm_pk = config.app_vm_config.generate_pk(engine.keygen_builder());
         assert!(app_vm_pk.max_constraint_degree < 1 << config.fri_params.log_blowup);
         assert!(config.poseidon2_max_constraint_degree < 1 << config.fri_params.log_blowup);
+        assert_eq!(
+            config.max_num_user_public_values,
+            config.app_vm_config.num_public_values
+        );
+        assert!(config.app_vm_config.continuation_enabled);
         let leaf_vm_config = config.leaf_verifier_vm_config();
         let leaf_verifier_pk = leaf_vm_config.generate_pk(engine.keygen_builder());
         let leaf_program = LeafVmVerifierConfig {
-            max_num_user_public_values: config.max_num_user_public_values,
             fri_params: config.fri_params,
             app_vm_config: config.app_vm_config.clone(),
             compiler_options: config.compiler_options.clone(),

--- a/axiom-vm/src/verifier/leaf/types.rs
+++ b/axiom-vm/src/verifier/leaf/types.rs
@@ -1,0 +1,90 @@
+use std::{array, borrow::BorrowMut};
+
+use ax_stark_sdk::ax_stark_backend::{
+    config::{Com, StarkGenericConfig, Val},
+    p3_field::PrimeField32,
+    prover::types::Proof,
+};
+use axvm_circuit::{
+    circuit_derive::AlignedBorrow,
+    system::{
+        connector::VmConnectorPvs,
+        memory::{merkle::MemoryMerklePvs, tree::public_values::UserPublicValuesProof},
+    },
+};
+use axvm_native_compiler::ir::{Builder, Config, Felt, DIGEST_SIZE};
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, AlignedBorrow)]
+#[repr(C)]
+pub struct LeafVmVerifierPvs<T> {
+    pub app_commit: [T; DIGEST_SIZE],
+    pub connector: VmConnectorPvs<T>,
+    pub memory: MemoryMerklePvs<T, DIGEST_SIZE>,
+    pub public_values_commit: [T; DIGEST_SIZE],
+}
+
+/// Input for the leaf VM verifier.
+#[derive(Serialize, Deserialize, Derivative)]
+#[serde(bound = "")]
+#[derivative(Clone(bound = "Com<SC>: Clone"))]
+pub struct LeafVmVerifierInput<SC: StarkGenericConfig> {
+    /// The proofs of the execution segments in the execution order.
+    pub proofs: Vec<Proof<SC>>,
+    /// The public values root proof. Leaf VM verifier only needs this when verifying the last
+    /// segment.
+    pub public_values_root_proof: Option<UserPublicValuesRootProof<Val<SC>>>,
+}
+
+/// Proof that the merkle root of public values is in the memory state. Can be extracted from
+/// `axvm-circuit::system::memory::public_values::UserPublicValuesProof`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct UserPublicValuesRootProof<F> {
+    /// Sibling hashes for proving the merkle root of public values. For a specific VM, the path
+    /// is constant. So we don't need the boolean which indicates if a node is a left child or right
+    /// child.
+    pub sibling_hashes: Vec<[F; DIGEST_SIZE]>,
+    pub public_values_commit: [F; DIGEST_SIZE],
+}
+
+impl<F: PrimeField32> LeafVmVerifierPvs<Felt<F>> {
+    pub(crate) fn uninit<C: Config<F = F>>(builder: &mut Builder<C>) -> Self {
+        Self {
+            app_commit: array::from_fn(|_| builder.uninit()),
+            connector: VmConnectorPvs {
+                initial_pc: builder.uninit(),
+                final_pc: builder.uninit(),
+                exit_code: builder.uninit(),
+                is_terminate: builder.uninit(),
+            },
+            memory: MemoryMerklePvs {
+                initial_root: array::from_fn(|_| builder.uninit()),
+                final_root: array::from_fn(|_| builder.uninit()),
+            },
+            public_values_commit: array::from_fn(|_| builder.uninit()),
+        }
+    }
+}
+
+impl<F: Default + Clone> LeafVmVerifierPvs<Felt<F>> {
+    pub fn flatten(self) -> Vec<Felt<F>> {
+        let mut v = vec![Felt(0, Default::default()); LeafVmVerifierPvs::<u8>::width()];
+        *v.as_mut_slice().borrow_mut() = self;
+        v
+    }
+}
+
+impl<F: Clone> UserPublicValuesRootProof<F> {
+    pub fn extract(pvs_proof: &UserPublicValuesProof<{ DIGEST_SIZE }, F>) -> Self {
+        Self {
+            sibling_hashes: pvs_proof
+                .proof
+                .clone()
+                .into_iter()
+                .map(|(_, hash)| hash)
+                .collect(),
+            public_values_commit: pvs_proof.public_values_commit.clone(),
+        }
+    }
+}

--- a/axiom-vm/src/verifier/leaf/vars.rs
+++ b/axiom-vm/src/verifier/leaf/vars.rs
@@ -1,0 +1,69 @@
+use std::array;
+
+use ax_stark_sdk::ax_stark_backend::{
+    config::{StarkGenericConfig, Val},
+    p3_field::AbstractField,
+    prover::types::Proof,
+};
+use axvm_native_compiler::prelude::*;
+use axvm_recursion::{
+    hints::{Hintable, InnerVal},
+    types::InnerConfig,
+};
+
+use crate::verifier::leaf::types::{LeafVmVerifierInput, UserPublicValuesRootProof};
+
+#[derive(DslVariable, Clone)]
+pub struct UserPublicValuesRootProofVariable<const CHUNK: usize, C: Config> {
+    /// Sibling hashes for proving the merkle root of public values. For a specific VM, the path
+    /// is constant. So we don't need the boolean which indicates if a node is a left child or right
+    /// child.
+    pub sibling_hashes: Array<C, [Felt<C::F>; CHUNK]>,
+    pub public_values_commit: [Felt<C::F>; CHUNK],
+}
+
+type C = InnerConfig;
+type F = InnerVal;
+
+impl<SC: StarkGenericConfig> LeafVmVerifierInput<SC> {
+    pub fn write_to_stream<C: Config<N = Val<SC>>>(&self) -> Vec<Vec<Val<SC>>>
+    where
+        Vec<Proof<SC>>: Hintable<C>,
+        UserPublicValuesRootProof<Val<SC>>: Hintable<C>,
+    {
+        let mut ret = Hintable::<C>::write(&self.proofs);
+        if let Some(pvs_root_proof) = &self.public_values_root_proof {
+            ret.extend(Hintable::<C>::write(pvs_root_proof));
+        }
+        ret
+    }
+}
+
+impl Hintable<C> for UserPublicValuesRootProof<F> {
+    type HintVariable = UserPublicValuesRootProofVariable<{ DIGEST_SIZE }, C>;
+    fn read(builder: &mut Builder<C>) -> Self::HintVariable {
+        let len = builder.hint_var();
+        let sibling_hashes = builder.array(len);
+        builder.range(0, len).for_each(|i, builder| {
+            // FIXME: add hint support for slices.
+            let hash = array::from_fn(|_| builder.hint_felt());
+            builder.set_value(&sibling_hashes, i, hash);
+        });
+        let public_values_commit = array::from_fn(|_| builder.hint_felt());
+        Self::HintVariable {
+            sibling_hashes,
+            public_values_commit,
+        }
+    }
+    fn write(&self) -> Vec<Vec<<C as Config>::N>> {
+        let len = <<C as Config>::N>::from_canonical_usize(self.sibling_hashes.len());
+        let mut stream = len.write();
+        stream.extend(self.sibling_hashes.iter().flat_map(write_field_slice));
+        stream.extend(write_field_slice(&self.public_values_commit));
+        stream
+    }
+}
+
+fn write_field_slice(arr: &[F; DIGEST_SIZE]) -> Vec<Vec<<C as Config>::N>> {
+    arr.iter().flat_map(|x| x.write()).collect()
+}

--- a/axiom-vm/tests/integration_test.rs
+++ b/axiom-vm/tests/integration_test.rs
@@ -1,33 +1,44 @@
-use std::sync::Arc;
+use std::{borrow::Borrow, sync::Arc};
 
 use ax_stark_sdk::{
     ax_stark_backend::{config::StarkGenericConfig, p3_field::AbstractField},
     config::{
-        baby_bear_poseidon2::BabyBearPoseidon2Engine,
+        baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},
         fri_params::standard_fri_params_with_100_bits_conjectured_security,
     },
     engine::{StarkEngine, StarkFriEngine},
 };
-use axiom_vm::config::{AxiomVmConfig, AxiomVmProvingKey};
+use axiom_vm::{
+    config::{AxiomVmConfig, AxiomVmProvingKey},
+    verifier::leaf::types::{LeafVmVerifierInput, LeafVmVerifierPvs, UserPublicValuesRootProof},
+};
 use axvm_circuit::{
-    arch::{ExecutorName, SingleSegmentVmExecutor, VmConfig, VmExecutor},
-    system::program::trace::AxVmCommittedExe,
+    arch::{
+        hasher::poseidon2::vm_poseidon2_hasher, ExecutorName, SingleSegmentVmExecutor, VmConfig,
+        VmExecutor,
+    },
+    system::{
+        memory::tree::public_values::compute_user_public_values_proof,
+        program::{trace::AxVmCommittedExe, ExecutionError},
+    },
 };
 use axvm_native_compiler::{conversion::CompilerOptions, prelude::*};
-use axvm_recursion::{hints::Hintable, types::InnerConfig};
+use axvm_recursion::types::InnerConfig;
 use p3_baby_bear::BabyBear;
 
+type SC = BabyBearPoseidon2Config;
 type C = InnerConfig;
 type F = BabyBear;
 #[test]
 fn test_1() {
     let axiom_vm_config = AxiomVmConfig {
         poseidon2_max_constraint_degree: 7,
-        max_num_user_public_values: 100,
+        max_num_user_public_values: 16,
         fri_params: standard_fri_params_with_100_bits_conjectured_security(3),
         app_vm_config: VmConfig {
             max_segment_len: 200,
             continuation_enabled: true,
+            num_public_values: 16,
             ..Default::default()
         }
         .add_executor(ExecutorName::BranchEqual)
@@ -40,11 +51,12 @@ fn test_1() {
             ..Default::default()
         },
     };
+    let max_num_user_public_values = axiom_vm_config.max_num_user_public_values;
     let axiom_vm_pk = AxiomVmProvingKey::keygen(axiom_vm_config);
     let engine = BabyBearPoseidon2Engine::new(axiom_vm_pk.fri_params);
 
     let program = {
-        let n = 100;
+        let n = 200;
         let mut builder = Builder::<C>::default();
         let a: Felt<F> = builder.eval(F::zero());
         let b: Felt<F> = builder.eval(F::one());
@@ -57,27 +69,103 @@ fn test_1() {
         builder.halt();
         builder.compile_isa()
     };
-    let committed_exe = Arc::new(AxVmCommittedExe::commit(
+    let committed_exe = Arc::new(AxVmCommittedExe::<SC>::commit(
         program.into(),
         engine.config.pcs(),
     ));
+
+    let expected_program_commit: [F; DIGEST_SIZE] =
+        committed_exe.committed_program.prover_data.commit.into();
 
     let app_vm = VmExecutor::new(axiom_vm_pk.app_vm_config.clone());
     let app_vm_result = app_vm
         .execute_and_generate_with_cached_program(committed_exe, vec![])
         .unwrap();
-    assert!(app_vm_result.per_segment.len() > 1);
-    let app_vm_seg_proofs: Vec<_> = app_vm_result
+    assert!(app_vm_result.per_segment.len() > 2);
+
+    let pv_proof = compute_user_public_values_proof(
+        app_vm.config.memory_config.memory_dimensions(),
+        max_num_user_public_values,
+        &vm_poseidon2_hasher(),
+        app_vm_result.final_memory.as_ref().unwrap(),
+    );
+    let pv_root_proof = UserPublicValuesRootProof::extract(&pv_proof);
+    let expected_pv_commit = pv_root_proof.public_values_commit;
+    let mut app_vm_seg_proofs: Vec<_> = app_vm_result
         .per_segment
         .into_iter()
         .map(|proof_input| engine.prove(&axiom_vm_pk.app_vm_pk, proof_input))
         .collect();
 
     let leaf_vm = SingleSegmentVmExecutor::new(axiom_vm_pk.leaf_vm_config);
-    leaf_vm
-        .execute(
-            axiom_vm_pk.committed_leaf_program.exe.clone(),
-            app_vm_seg_proofs.write(),
+    let last_proof = app_vm_seg_proofs.pop().unwrap();
+
+    let run_leaf_verifier =
+        |verifier_input: LeafVmVerifierInput<SC>| -> Result<Vec<F>, ExecutionError> {
+            let runtime_pvs = leaf_vm.execute(
+                axiom_vm_pk.committed_leaf_program.exe.clone(),
+                verifier_input.write_to_stream(),
+            )?;
+            let runtime_pvs: Vec<_> = runtime_pvs.into_iter().map(|v| v.unwrap()).collect();
+            Ok(runtime_pvs)
+        };
+
+    // Verify all segments except the last one.
+    let (first_seg_final_pc, first_seg_final_mem_root) = {
+        let runtime_pvs = run_leaf_verifier(LeafVmVerifierInput {
+            proofs: app_vm_seg_proofs,
+            public_values_root_proof: None,
+        })
+        .expect("failed to verify the first segment");
+        let leaf_vm_pvs: &LeafVmVerifierPvs<F> = runtime_pvs.as_slice().borrow();
+
+        assert_eq!(leaf_vm_pvs.app_commit, expected_program_commit);
+        assert_eq!(leaf_vm_pvs.connector.is_terminate, F::zero());
+        assert_eq!(leaf_vm_pvs.connector.initial_pc, F::zero());
+        (
+            leaf_vm_pvs.connector.final_pc,
+            leaf_vm_pvs.memory.final_root,
         )
-        .unwrap();
+    };
+    // Verify the last segment with the correct public values root proof.
+    {
+        let runtime_pvs = run_leaf_verifier(LeafVmVerifierInput {
+            proofs: vec![last_proof.clone()],
+            public_values_root_proof: Some(pv_root_proof.clone()),
+        })
+        .expect("failed to verify the second segment");
+        let leaf_vm_pvs: &LeafVmVerifierPvs<F> = runtime_pvs.as_slice().borrow();
+        assert_eq!(leaf_vm_pvs.app_commit, expected_program_commit);
+        assert_eq!(leaf_vm_pvs.connector.initial_pc, first_seg_final_pc);
+        assert_eq!(leaf_vm_pvs.connector.is_terminate, F::one());
+        assert_eq!(leaf_vm_pvs.connector.exit_code, F::zero());
+        assert_eq!(leaf_vm_pvs.memory.initial_root, first_seg_final_mem_root);
+        assert_eq!(leaf_vm_pvs.public_values_commit, expected_pv_commit);
+    }
+    // Failure: The public value root proof has a wrong public values commit.
+    {
+        let mut wrong_pv_root_proof = pv_root_proof.clone();
+        wrong_pv_root_proof.public_values_commit[0] += F::one();
+        let execution_result = run_leaf_verifier(LeafVmVerifierInput {
+            proofs: vec![last_proof.clone()],
+            public_values_root_proof: Some(wrong_pv_root_proof),
+        });
+        match execution_result.err().unwrap() {
+            ExecutionError::Fail(_) => {}
+            _ => panic!("Expected execution to fail"),
+        }
+    }
+    // Failure: The public value root proof has a wrong path proof.
+    {
+        let mut wrong_pv_root_proof = pv_root_proof.clone();
+        wrong_pv_root_proof.sibling_hashes[0][0] += F::one();
+        let execution_result = run_leaf_verifier(LeafVmVerifierInput {
+            proofs: vec![last_proof],
+            public_values_root_proof: Some(wrong_pv_root_proof),
+        });
+        match execution_result.err().unwrap() {
+            ExecutionError::Fail(_) => {}
+            _ => panic!("Expected execution to fail"),
+        }
+    }
 }

--- a/stark-backend/Cargo.toml
+++ b/stark-backend/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true, default-features = false, features = [
     "alloc",
     "rc",
 ] }
-derivative = "2.2.0"
+derivative = { workspace = true }
 metrics = { workspace = true, optional = true }
 cfg-if = { workspace = true }
 thiserror.workspace = true

--- a/toolchain/native-compiler/src/conversion/mod.rs
+++ b/toolchain/native-compiler/src/conversion/mod.rs
@@ -335,13 +335,13 @@ fn convert_print_instruction<F: PrimeField32, EF: ExtensionField<F>>(
             PhantomInstruction::PrintF,
             i32_f(src),
             F::zero(),
-            0,
+            2,
         )],
         AsmInstruction::PrintF(src) => vec![Instruction::phantom(
             PhantomInstruction::PrintF,
             i32_f(src),
             F::zero(),
-            0,
+            2,
         )],
         AsmInstruction::PrintE(src) => (0..EF::D as i32)
             .map(|i| {
@@ -349,7 +349,7 @@ fn convert_print_instruction<F: PrimeField32, EF: ExtensionField<F>>(
                     PhantomInstruction::PrintF,
                     i32_f(src + i * word_size_i32),
                     F::zero(),
-                    0,
+                    2,
                 )
             })
             .collect(),

--- a/toolchain/native-compiler/src/ir/builder.rs
+++ b/toolchain/native-compiler/src/ir/builder.rs
@@ -206,6 +206,23 @@ impl<C: Config> Builder<C> {
         dst.assign(expr.into(), self);
     }
 
+    /// Casts a Felt to a Var. Please use carefully.
+    pub fn cast_felt_to_var(&mut self, felt: Felt<C::F>) -> Var<C::N> {
+        if self.flags.static_only {
+            panic!("Cannot cast a Felt to a Var in static mode");
+        }
+        let var: Var<_> = self.uninit();
+        let buffer = self.alloc(1, 1);
+        let idx = MemIndex {
+            index: RVar::zero(),
+            offset: 0,
+            size: 1,
+        };
+        felt.store(buffer, idx, self);
+        var.load(buffer, idx, self);
+        var
+    }
+
     /// Asserts that two expressions are equal.
     pub fn assert_eq<V: Variable<C>>(
         &mut self,


### PR DESCRIPTION
- When verifying the last segment, leaf verifier program reads a public values root proof from input stream and verify it's consistent with its final memory state.
- Fix a bug of `builder.print_v`/`builder.print_f`/`builder.print_e`. It was using a wrong address space `0`(IMM) instead of `2`(memory).

closes INT-1731