### PR TITLE
[chore] Support Serde for stark/VM outcome structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ version = "0.1.0"
 dependencies = [
  "ax-circuit-derive",
  "ax-stark-backend",
+ "axvm-instructions",
  "derive_more 0.99.18",
  "ff 0.13.0",
  "itertools 0.13.0",
@@ -495,6 +496,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "static_assertions",
  "toml",
  "tracing",
  "tracing-forest",
@@ -515,6 +517,7 @@ dependencies = [
  "p3-baby-bear",
  "serde",
  "serde_json",
+ "static_assertions",
 ]
 
 [[package]]
@@ -582,6 +585,7 @@ dependencies = [
  "axvm-instructions",
  "backtrace",
  "cfg-if",
+ "derivative",
  "derive-new",
  "derive_more 1.0.0",
  "enum-utils",
@@ -616,6 +620,7 @@ dependencies = [
  "rand_xoshiro",
  "rustc-hash 2.0.0",
  "serde",
+ "static_assertions",
  "strum",
  "strum_macros",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ eyre = "0.6.12"
 tempfile = "3.13.0"
 thiserror = "1.0.65"
 rustc-hash = "2.0.0"
+static_assertions = "1.1.0"
 
 # cryptography
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/axiom-vm/Cargo.toml
+++ b/axiom-vm/Cargo.toml
@@ -17,6 +17,7 @@ axvm-circuit = { workspace = true }
 derivative = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+static_assertions.workspace = true
 
 [features]
 default = ["parallel"]

--- a/axiom-vm/src/verifier/internal/types.rs
+++ b/axiom-vm/src/verifier/internal/types.rs
@@ -1,9 +1,12 @@
 use std::{array, borrow::BorrowMut};
 
-use ax_stark_sdk::ax_stark_backend::{
-    config::{Com, StarkGenericConfig, Val},
-    p3_field::PrimeField32,
-    prover::types::Proof,
+use ax_stark_sdk::{
+    ax_stark_backend::{
+        config::{Com, StarkGenericConfig, Val},
+        p3_field::PrimeField32,
+        prover::types::Proof,
+    },
+    config::baby_bear_poseidon2::BabyBearPoseidon2Config,
 };
 use axvm_circuit::circuit_derive::AlignedBorrow;
 use axvm_native_compiler::{
@@ -11,7 +14,8 @@ use axvm_native_compiler::{
     prelude::DIGEST_SIZE,
 };
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use static_assertions::assert_impl_all;
 
 use crate::verifier::common::types::VmVerifierPvs;
 
@@ -36,6 +40,7 @@ pub struct InternalVmVerifierInput<SC: StarkGenericConfig> {
     /// The proofs of leaf verifier or internal verifier in the execution order.
     pub proofs: Vec<Proof<SC>>,
 }
+assert_impl_all!(InternalVmVerifierInput<BabyBearPoseidon2Config>: Serialize, DeserializeOwned);
 
 impl<F: PrimeField32> InternalVmVerifierPvs<Felt<F>> {
     pub fn uninit<C: Config<F = F>>(builder: &mut Builder<C>) -> Self {

--- a/axiom-vm/src/verifier/leaf/types.rs
+++ b/axiom-vm/src/verifier/leaf/types.rs
@@ -1,11 +1,16 @@
-use ax_stark_sdk::ax_stark_backend::{
-    config::{Com, StarkGenericConfig, Val},
-    prover::types::Proof,
+use ax_stark_sdk::{
+    ax_stark_backend::{
+        config::{Com, StarkGenericConfig, Val},
+        prover::types::Proof,
+    },
+    config::baby_bear_poseidon2::BabyBearPoseidon2Config,
 };
 use axvm_circuit::system::memory::tree::public_values::UserPublicValuesProof;
 use axvm_native_compiler::ir::DIGEST_SIZE;
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use p3_baby_bear::BabyBear;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use static_assertions::assert_impl_all;
 
 /// Input for the leaf VM verifier.
 #[derive(Serialize, Deserialize, Derivative)]
@@ -18,6 +23,7 @@ pub struct LeafVmVerifierInput<SC: StarkGenericConfig> {
     /// segment.
     pub public_values_root_proof: Option<UserPublicValuesRootProof<Val<SC>>>,
 }
+assert_impl_all!(LeafVmVerifierInput<BabyBearPoseidon2Config>: Serialize, DeserializeOwned);
 
 /// Proof that the merkle root of public values is in the memory state. Can be extracted from
 /// `axvm-circuit::system::memory::public_values::UserPublicValuesProof`.
@@ -29,6 +35,7 @@ pub struct UserPublicValuesRootProof<F> {
     pub sibling_hashes: Vec<[F; DIGEST_SIZE]>,
     pub public_values_commit: [F; DIGEST_SIZE],
 }
+assert_impl_all!(UserPublicValuesRootProof<BabyBear>: Serialize, DeserializeOwned);
 
 impl<F: Clone> UserPublicValuesRootProof<F> {
     pub fn extract(pvs_proof: &UserPublicValuesProof<{ DIGEST_SIZE }, F>) -> Self {

--- a/axiom-vm/src/verifier/root/types.rs
+++ b/axiom-vm/src/verifier/root/types.rs
@@ -1,13 +1,17 @@
 use std::array;
 
-use ax_stark_sdk::ax_stark_backend::{
-    config::{Com, StarkGenericConfig, Val},
-    p3_field::PrimeField32,
-    prover::types::Proof,
+use ax_stark_sdk::{
+    ax_stark_backend::{
+        config::{Com, StarkGenericConfig, Val},
+        p3_field::PrimeField32,
+        prover::types::Proof,
+    },
+    config::baby_bear_poseidon2::BabyBearPoseidon2Config,
 };
 use axvm_native_compiler::ir::{Builder, Config, Felt, DIGEST_SIZE};
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use static_assertions::assert_impl_all;
 
 #[derive(Debug)]
 pub struct RootVmVerifierPvs<T> {
@@ -29,6 +33,7 @@ pub struct RootVmVerifierInput<SC: StarkGenericConfig> {
     /// Public values to expose directly
     pub public_values: Vec<Val<SC>>,
 }
+assert_impl_all!(RootVmVerifierInput<BabyBearPoseidon2Config>: Serialize, DeserializeOwned);
 
 impl<F: PrimeField32> RootVmVerifierPvs<Felt<F>> {
     pub fn uninit<C: Config<F = F>>(builder: &mut Builder<C>, num_public_values: usize) -> Self {

--- a/stark-backend/src/prover/types.rs
+++ b/stark-backend/src/prover/types.rs
@@ -79,7 +79,11 @@ impl<SC: StarkGenericConfig> ProofInput<SC> {
     }
 }
 
-#[derive(Derivative)]
+#[derive(Serialize, Deserialize, Derivative)]
+#[serde(bound(
+    serialize = "ProverTraceData<SC>: Serialize",
+    deserialize = "ProverTraceData<SC>: Deserialize<'de>"
+))]
 #[derivative(Clone(bound = "Com<SC>: Clone"))]
 pub struct CommittedTraceData<SC: StarkGenericConfig> {
     pub raw_data: Arc<RowMajorMatrix<Val<SC>>>,

--- a/stark-sdk/Cargo.toml
+++ b/stark-sdk/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true, default-features = false, features = [
 rand.workspace = true
 metrics.workspace = true
 serde_json.workspace = true
+static_assertions.workspace = true
 toml = "0.8.14"
 derive_more = "0.99.18"
 ff = { version = "0.13", features = ["derive", "derive_bits"] }
@@ -45,6 +46,9 @@ tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 metrics-tracing-context = "0.16.0"
 metrics-util = "0.17.0"
+
+[dev-dependencies]
+axvm-instructions.workspace = true
 
 [features]
 default = ["parallel"]

--- a/stark-sdk/src/config/baby_bear_blake3.rs
+++ b/stark-sdk/src/config/baby_bear_blake3.rs
@@ -6,10 +6,15 @@ use super::{
     },
     FriParameters,
 };
-use crate::config::baby_bear_bytehash::BabyBearByteHashEngineWithDefaultHash;
+use crate::{
+    assert_sc_compatible_with_serde,
+    config::baby_bear_bytehash::BabyBearByteHashEngineWithDefaultHash,
+};
 
 pub type BabyBearBlake3Config = BabyBearByteHashConfig<Blake3>;
 pub type BabyBearBlake3Engine = BabyBearByteHashEngine<Blake3>;
+
+assert_sc_compatible_with_serde!(BabyBearBlake3Config);
 
 /// `pcs_log_degree` is the upper bound on the log_2(PCS polynomial degree).
 pub fn default_engine(pcs_log_degree: usize) -> BabyBearBlake3Engine {

--- a/stark-sdk/src/config/baby_bear_keccak.rs
+++ b/stark-sdk/src/config/baby_bear_keccak.rs
@@ -6,10 +6,15 @@ use super::{
     },
     FriParameters,
 };
-use crate::config::baby_bear_bytehash::BabyBearByteHashEngineWithDefaultHash;
+use crate::{
+    assert_sc_compatible_with_serde,
+    config::baby_bear_bytehash::BabyBearByteHashEngineWithDefaultHash,
+};
 
 pub type BabyBearKeccakConfig = BabyBearByteHashConfig<Keccak256Hash>;
 pub type BabyBearKeccakEngine = BabyBearByteHashEngine<Keccak256Hash>;
+
+assert_sc_compatible_with_serde!(BabyBearKeccakConfig);
 
 /// `pcs_log_degree` is the upper bound on the log_2(PCS polynomial degree).
 pub fn default_engine(pcs_log_degree: usize) -> BabyBearKeccakEngine {

--- a/stark-sdk/src/config/baby_bear_poseidon2.rs
+++ b/stark-sdk/src/config/baby_bear_poseidon2.rs
@@ -20,7 +20,10 @@ use super::{
     instrument::{HashStatistics, InstrumentCounter, Instrumented, StarkHashStatistics},
     FriParameters,
 };
-use crate::engine::{StarkEngine, StarkEngineWithHashInstrumentation, StarkFriEngine};
+use crate::{
+    assert_sc_compatible_with_serde,
+    engine::{StarkEngine, StarkEngineWithHashInstrumentation, StarkFriEngine},
+};
 
 const RATE: usize = 8;
 // permutation width
@@ -46,6 +49,8 @@ type Pcs<P> = TwoAdicFriPcs<Val, Dft, ValMmcs<P>, ChallengeMmcs<P>>;
 pub type BabyBearPermutationConfig<P> = StarkConfig<Pcs<P>, Challenge, Challenger<P>>;
 pub type BabyBearPoseidon2Config = BabyBearPermutationConfig<Perm>;
 pub type BabyBearPoseidon2Engine = BabyBearPermutationEngine<Perm>;
+
+assert_sc_compatible_with_serde!(BabyBearPoseidon2Config);
 
 pub struct BabyBearPermutationEngine<P>
 where

--- a/stark-sdk/src/config/baby_bear_poseidon2_outer.rs
+++ b/stark-sdk/src/config/baby_bear_poseidon2_outer.rs
@@ -22,7 +22,10 @@ use super::{
     instrument::{HashStatistics, InstrumentCounter, Instrumented, StarkHashStatistics},
     FriParameters,
 };
-use crate::engine::{StarkEngine, StarkEngineWithHashInstrumentation, StarkFriEngine};
+use crate::{
+    assert_sc_compatible_with_serde,
+    engine::{StarkEngine, StarkEngineWithHashInstrumentation, StarkFriEngine},
+};
 
 const WIDTH: usize = 3;
 /// Poseidon rate in F. <Poseidon RATE>(2) * <# of F in a N>(8) = 16
@@ -44,6 +47,8 @@ type Pcs<P> = TwoAdicFriPcs<Val, Dft, ValMmcs<P>, ChallengeMmcs<P>>;
 pub type BabyBearPermutationOuterConfig<P> = StarkConfig<Pcs<P>, Challenge, Challenger<P>>;
 pub type BabyBearPoseidon2OuterConfig = BabyBearPermutationOuterConfig<Perm>;
 pub type BabyBearPoseidon2OuterEngine = BabyBearPermutationOuterEngine<Perm>;
+
+assert_sc_compatible_with_serde!(BabyBearPoseidon2OuterConfig);
 
 pub struct BabyBearPermutationOuterEngine<P>
 where

--- a/stark-sdk/src/config/goldilocks_poseidon.rs
+++ b/stark-sdk/src/config/goldilocks_poseidon.rs
@@ -16,7 +16,10 @@ use super::{
     instrument::{HashStatistics, Instrumented, StarkHashStatistics},
     FriParameters,
 };
-use crate::engine::{StarkEngine, StarkEngineWithHashInstrumentation};
+use crate::{
+    assert_sc_compatible_with_serde,
+    engine::{StarkEngine, StarkEngineWithHashInstrumentation},
+};
 
 const RATE: usize = 4;
 // permutation width
@@ -42,6 +45,8 @@ type Pcs<P> = TwoAdicFriPcs<Val, Dft, ValMmcs<P>, ChallengeMmcs<P>>;
 pub type GoldilocksPermutationConfig<P> = StarkConfig<Pcs<P>, Challenge, Challenger<P>>;
 pub type GoldilocksPoseidonConfig = GoldilocksPermutationConfig<Perm>;
 pub type GoldilocksPoseidonEngine = GoldilocksPermutationEngine<Perm>;
+
+assert_sc_compatible_with_serde!(GoldilocksPoseidonConfig);
 
 pub struct GoldilocksPermutationEngine<P>
 where

--- a/stark-sdk/src/utils.rs
+++ b/stark-sdk/src/utils.rs
@@ -45,3 +45,12 @@ macro_rules! any_rap_arc_vec {
         }
     };
 }
+
+#[macro_export]
+macro_rules! assert_sc_compatible_with_serde {
+    ($sc:ty) => {
+        static_assertions::assert_impl_all!(ax_stark_backend::keygen::types::MultiStarkProvingKey<$sc>: serde::Serialize, serde::de::DeserializeOwned);
+        static_assertions::assert_impl_all!(ax_stark_backend::keygen::types::MultiStarkVerifyingKey<$sc>: serde::Serialize, serde::de::DeserializeOwned);
+        static_assertions::assert_impl_all!(ax_stark_backend::prover::types::Proof<$sc>: serde::Serialize, serde::de::DeserializeOwned);
+    };
+}

--- a/stark-sdk/tests/serde_type.rs
+++ b/stark-sdk/tests/serde_type.rs
@@ -1,0 +1,6 @@
+use axvm_instructions::exe::AxVmExe;
+use p3_baby_bear::BabyBear;
+use serde::{de::DeserializeOwned, Serialize};
+use static_assertions::assert_impl_all;
+
+assert_impl_all!(AxVmExe<BabyBear>: Serialize, DeserializeOwned);

--- a/toolchain/instructions/Cargo.toml
+++ b/toolchain/instructions/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 p3-field.workspace = true
 axvm-instructions-derive.workspace = true
 
-backtrace.workspace = true
+backtrace = { workspace = true, features = ["serde"] }
 derive-new.workspace = true
 itertools.workspace = true
 strum.workspace = true

--- a/toolchain/instructions/src/exe.rs
+++ b/toolchain/instructions/src/exe.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use p3_field::Field;
+use serde::{Deserialize, Serialize};
 
 use crate::program::Program;
 
@@ -8,7 +9,11 @@ use crate::program::Program;
 pub type MemoryImage<F> = BTreeMap<(F, F), F>;
 
 /// Executable program for AxVM.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "F: Serialize",
+    deserialize = "F: std::cmp::Ord + Deserialize<'de>"
+))]
 pub struct AxVmExe<F> {
     /// Program to execute.
     pub program: Program<F>,

--- a/toolchain/instructions/src/instruction.rs
+++ b/toolchain/instructions/src/instruction.rs
@@ -1,5 +1,6 @@
 use backtrace::Backtrace;
 use p3_field::Field;
+use serde::{Deserialize, Serialize};
 
 use crate::{utils::isize_to_field, PhantomInstruction, SystemOpcode, UsizeOpcode};
 
@@ -7,7 +8,7 @@ use crate::{utils::isize_to_field, PhantomInstruction, SystemOpcode, UsizeOpcode
 pub const NUM_OPERANDS: usize = 7;
 
 #[allow(clippy::too_many_arguments)]
-#[derive(Clone, Debug, PartialEq, Eq, derive_new::new)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_new::new, Serialize, Deserialize)]
 pub struct Instruction<F> {
     pub opcode: usize,
     pub a: F,
@@ -106,7 +107,7 @@ impl<T: Default> Default for Instruction<T> {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DebugInfo {
     pub dsl_instruction: String,
     pub trace: Option<Backtrace>,

--- a/toolchain/instructions/src/program.rs
+++ b/toolchain/instructions/src/program.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fmt, fmt::Display};
 
 use itertools::Itertools;
 use p3_field::Field;
+use serde::{Deserialize, Serialize};
 
 use crate::instruction::{DebugInfo, Instruction};
 
@@ -12,7 +13,7 @@ pub const DEFAULT_PC_STEP: u32 = 4;
 pub const DEFAULT_MAX_NUM_PUBLIC_VALUES: usize = 32;
 const MAX_ALLOWED_PC: u32 = (1 << PC_BITS) - 1;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Program<F> {
     /// A map from program counter to instruction.
     /// Sometimes the instructions are enumerated as 0, 4, 8, etc.

--- a/toolchain/native-compiler/src/conversion/mod.rs
+++ b/toolchain/native-compiler/src/conversion/mod.rs
@@ -12,10 +12,11 @@ use axvm_instructions::{
 use num_bigint_dig::BigUint;
 use p3_field::{ExtensionField, PrimeField32, PrimeField64};
 use program::DEFAULT_PC_STEP;
+use serde::{Deserialize, Serialize};
 
 use crate::asm::{AsmInstruction, AssemblyCode};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompilerOptions {
     // The compiler will ensure that the heap pointer is aligned to be a multiple of `word_size`.
     pub word_size: usize,

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -49,6 +49,8 @@ inferno = { workspace = true, optional = true }
 thiserror.workspace = true
 rustc-hash.workspace = true
 eyre.workspace = true
+derivative.workspace = true
+static_assertions.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { workspace = true }

--- a/vm/src/system/program/tests/mod.rs
+++ b/vm/src/system/program/tests/mod.rs
@@ -2,8 +2,12 @@ use std::{iter, sync::Arc};
 
 use ax_stark_backend::prover::types::AirProofInput;
 use ax_stark_sdk::{
-    config::baby_bear_poseidon2::BabyBearPoseidon2Engine,
-    dummy_airs::interaction::dummy_interaction_air::DummyInteractionAir, engine::StarkFriEngine,
+    config::{
+        baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},
+        baby_bear_poseidon2_outer::BabyBearPoseidon2OuterConfig,
+    },
+    dummy_airs::interaction::dummy_interaction_air::DummyInteractionAir,
+    engine::StarkFriEngine,
 };
 use axvm_instructions::{
     instruction::Instruction,
@@ -12,6 +16,8 @@ use axvm_instructions::{
 use p3_baby_bear::BabyBear;
 use p3_field::AbstractField;
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use serde::{de::DeserializeOwned, Serialize};
+use static_assertions::assert_impl_all;
 
 use crate::{
     arch::{
@@ -21,8 +27,11 @@ use crate::{
         },
         READ_INSTRUCTION_BUS,
     },
-    system::program::ProgramChip,
+    system::program::{trace::AxVmCommittedExe, ProgramChip},
 };
+
+assert_impl_all!(AxVmCommittedExe<BabyBearPoseidon2Config>: Serialize, DeserializeOwned);
+assert_impl_all!(AxVmCommittedExe<BabyBearPoseidon2OuterConfig>: Serialize, DeserializeOwned);
 
 fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
     let instructions = program.instructions();

--- a/vm/src/system/program/trace.rs
+++ b/vm/src/system/program/trace.rs
@@ -1,7 +1,7 @@
 use std::{borrow::BorrowMut, sync::Arc};
 
 use ax_stark_backend::{
-    config::{Domain, StarkGenericConfig, Val},
+    config::{Com, Domain, StarkGenericConfig, Val},
     p3_commit::PolynomialSpace,
     prover::{
         helper::AirProofInputTestHelper,
@@ -9,13 +9,21 @@ use ax_stark_backend::{
     },
 };
 use axvm_instructions::{exe::AxVmExe, program::Program, SystemOpcode, UsizeOpcode};
+use derivative::Derivative;
 use itertools::Itertools;
 use p3_field::{Field, PrimeField64};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::{Instruction, ProgramChip, ProgramExecutionCols, EXIT_CODE_FAIL};
 
+#[derive(Serialize, Deserialize, Derivative)]
+#[serde(bound(
+    serialize = "AxVmExe<Val<SC>>: Serialize, CommittedTraceData<SC>: Serialize",
+    deserialize = "AxVmExe<Val<SC>>: Deserialize<'de>, CommittedTraceData<SC>: Deserialize<'de>"
+))]
+#[derivative(Clone(bound = "Com<SC>: Clone"))]
 pub struct AxVmCommittedExe<SC: StarkGenericConfig> {
     /// Raw executable.
     pub exe: AxVmExe<Val<SC>>,


### PR DESCRIPTION
- Derive `Serialize`/`Deserialize` all stark/VM outcome structs.
- Add compile-time check for `Serialize`/`Deserialize` implementation.