### PR TITLE
bench: switch app,agg to log_blowup=2

### DIFF
--- a/benchmarks/src/bin/fibonacci.rs
+++ b/benchmarks/src/bin/fibonacci.rs
@@ -16,8 +16,8 @@ use tracing::info_span;
 
 fn main() -> Result<()> {
     // TODO[jpw]: benchmark different combinations
-    let app_log_blowup = 1;
-    let agg_log_blowup = 1;
+    let app_log_blowup = 2;
+    let agg_log_blowup = 2;
 
     let elf = build_bench_program("fibonacci")?;
     run_with_metric_collection("OUTPUT_PATH", || -> Result<()> {

--- a/benchmarks/src/bin/regex.rs
+++ b/benchmarks/src/bin/regex.rs
@@ -16,8 +16,8 @@ use tracing::info_span;
 
 fn main() -> Result<()> {
     // TODO[jpw]: benchmark different combinations
-    let app_log_blowup = 1;
-    let agg_log_blowup = 1;
+    let app_log_blowup = 2;
+    let agg_log_blowup = 2;
 
     let elf = build_bench_program("regex")?;
     run_with_metric_collection("OUTPUT_PATH", || -> Result<()> {

--- a/benchmarks/src/bin/revm_contract_deployment.rs
+++ b/benchmarks/src/bin/revm_contract_deployment.rs
@@ -15,8 +15,8 @@ use tracing::info_span;
 
 fn main() -> Result<()> {
     // TODO[jpw]: benchmark different combinations
-    let app_log_blowup = 1;
-    // let agg_log_blowup = 1;
+    let app_log_blowup = 2;
+    // let agg_log_blowup = 2;
 
     // https://etherscan.io/tx/0xa40b41d5a00b8b1a1d591dc60882521942f5b98b277bb3e8ba6e0edda0a2e550
     let bytecode_hex = include_str!("../../programs/revm_contract_deployment/usdc/FiatTokenV1.bin");

--- a/benchmarks/src/bin/verify_fibair.rs
+++ b/benchmarks/src/bin/verify_fibair.rs
@@ -17,8 +17,8 @@ use eyre::Result;
 use tracing::info_span;
 
 fn main() -> Result<()> {
-    let app_log_blowup = 1;
-    let agg_log_blowup = 1;
+    let app_log_blowup = 2;
+    let agg_log_blowup = 2;
 
     let n = 16; // STARK to calculate 16th Fibonacci number.
     let fib_chip = FibonacciChip::new(0, 1, n);


### PR DESCRIPTION
log_blowup=2 makes proving time slower but uses 1/3 as many fri repetitions, which should greatly reduce verifier cost