### PR TITLE
chore: Remove generation of `use crate;` in moduli_setup

### DIFF
--- a/lib/ecc/src/sw.rs
+++ b/lib/ecc/src/sw.rs
@@ -1,5 +1,15 @@
+use core::{
+    fmt::Debug,
+    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+};
+
+use axvm::intrinsics::IntMod;
 #[cfg(target_os = "zkvm")]
-use axvm_platform::constants::SwBaseFunct7;
+use {
+    axvm_platform::constants::{Custom1Funct3, ModArithBaseFunct7, SwBaseFunct7, CUSTOM_1},
+    axvm_platform::custom_insn_r,
+    core::mem::MaybeUninit,
+};
 
 axvm::moduli_setup! {
     IntModN = "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F";

--- a/toolchain/riscv/setup-macro/src/lib.rs
+++ b/toolchain/riscv/setup-macro/src/lib.rs
@@ -73,29 +73,7 @@ pub fn moduli_setup(input: TokenStream) -> TokenStream {
 
     let mut moduli = Vec::new();
 
-    output.push(TokenStream::from(quote::quote! {
-        use core::{
-            fmt::{self, Debug},
-            iter::{Product, Sum},
-            ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
-        };
-
-        // TODO[jpw]: change to axvm-ecc
-        use axvm::intrinsics::IntMod;
-        #[cfg(not(target_os = "zkvm"))]
-        use {
-            axvm::intrinsics::{biguint_to_limbs, uint_mod_inverse},
-            num_bigint_dig::{traits::ModInverse, BigUint, Sign, ToBigInt},
-        };
-        #[cfg(target_os = "zkvm")]
-        use {
-            axvm_platform::{
-                constants::{Custom1Funct3, ModArithBaseFunct7, CUSTOM_1},
-                custom_insn_r,
-            },
-            core::mem::MaybeUninit,
-        };
-    }));
+    let span = proc_macro::Span::call_site();
 
     for stmt in stmts {
         let result: Result<TokenStream, &str> = match stmt.clone() {
@@ -106,10 +84,7 @@ pub fn moduli_setup(input: TokenStream) -> TokenStream {
 
                         if let syn::Expr::Lit(lit) = &*assign.right {
                             if let syn::Lit::Str(str_lit) = &lit.lit {
-                                let struct_name = syn::Ident::new(
-                                    &struct_name,
-                                    proc_macro::Span::call_site().into(),
-                                );
+                                let struct_name = syn::Ident::new(&struct_name, span.into());
 
                                 let modulus_bytes = string_to_bytes(&str_lit.value());
                                 let mut limbs = modulus_bytes.len();
@@ -133,534 +108,536 @@ pub fn moduli_setup(input: TokenStream) -> TokenStream {
                                 let block_size =
                                     syn::Lit::new(block_size.to_string().parse::<_>().unwrap());
 
-                                let result = TokenStream::from(quote::quote! {
+                                let result = TokenStream::from(
+                                    quote::quote_spanned! { span.into() =>
 
-                                    #[derive(Clone, Eq)]
-                                    #[repr(C, align(#block_size))]
-                                    pub struct #struct_name([u8; #limbs]);
+                                        #[derive(Clone, Eq)]
+                                        #[repr(C, align(#block_size))]
+                                        pub struct #struct_name([u8; #limbs]);
 
-                                    impl #struct_name {
-                                        #[inline(always)]
-                                        const fn from_const_u8(val: u8) -> Self {
-                                            let mut bytes = [0; #limbs];
-                                            bytes[0] = val;
-                                            Self(bytes)
-                                        }
+                                        impl #struct_name {
+                                            #[inline(always)]
+                                            const fn from_const_u8(val: u8) -> Self {
+                                                let mut bytes = [0; #limbs];
+                                                bytes[0] = val;
+                                                Self(bytes)
+                                            }
 
-                                        #[inline(always)]
-                                        fn add_assign_impl(&mut self, other: &Self) {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                *self = Self::from_biguint(
-                                                    (self.as_biguint() + other.as_biguint()) % Self::modulus_biguint(),
-                                                );
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::AddMod as usize
-                                                        + Self::MOD_IDX
-                                                            * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    self as *mut Self,
-                                                    self as *const Self,
-                                                    other as *const Self
-                                                )
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn sub_assign_impl(&mut self, other: &Self) {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                let modulus = Self::modulus_biguint();
-                                                *self = Self::from_biguint(
-                                                    (self.as_biguint() + modulus.clone() - other.as_biguint()) % modulus,
-                                                );
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::SubMod as usize
-                                                        + Self::MOD_IDX
-                                                            * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    self as *mut Self,
-                                                    self as *const Self,
-                                                    other as *const Self
-                                                )
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn mul_assign_impl(&mut self, other: &Self) {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                *self = Self::from_biguint(
-                                                    (self.as_biguint() * other.as_biguint()) % Self::modulus_biguint(),
-                                                );
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::MulMod as usize
-                                                        + Self::MOD_IDX
-                                                            * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    self as *mut Self,
-                                                    self as *const Self,
-                                                    other as *const Self
-                                                )
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn div_assign_impl(&mut self, other: &Self) {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                let modulus = Self::modulus_biguint();
-                                                let inv = uint_mod_inverse(&other.as_biguint(), &modulus);
-                                                *self = Self::from_biguint((self.as_biguint() * inv) % modulus);
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::DivMod as usize
-                                                        + Self::MOD_IDX
-                                                            * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    self as *mut Self,
-                                                    self as *const Self,
-                                                    other as *const Self
-                                                )
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn add_refs_impl(&self, other: &Self) -> Self {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                let mut res = self.clone();
-                                                res += other;
-                                                res
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                let mut uninit: MaybeUninit<#struct_name> = MaybeUninit::uninit();
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::AddMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    uninit.as_mut_ptr(),
-                                                    self as *const #struct_name,
-                                                    other as *const #struct_name
-                                                );
-                                                unsafe { uninit.assume_init() }
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn sub_refs_impl(&self, other: &Self) -> Self {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                let mut res = self.clone();
-                                                res -= other;
-                                                res
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                let mut uninit: MaybeUninit<#struct_name> = MaybeUninit::uninit();
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::SubMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    uninit.as_mut_ptr(),
-                                                    self as *const #struct_name,
-                                                    other as *const #struct_name
-                                                );
-                                                unsafe { uninit.assume_init() }
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn mul_refs_impl(&self, other: &Self) -> Self {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                let mut res = self.clone();
-                                                res *= other;
-                                                res
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                let mut uninit: MaybeUninit<#struct_name> = MaybeUninit::uninit();
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::MulMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    uninit.as_mut_ptr(),
-                                                    self as *const #struct_name,
-                                                    other as *const #struct_name
-                                                );
-                                                unsafe { uninit.assume_init() }
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn div_refs_impl(&self, other: &Self) -> Self {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                let mut res = self.clone();
-                                                res /= other;
-                                                res
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                let mut uninit: MaybeUninit<#struct_name> = MaybeUninit::uninit();
-                                                custom_insn_r!(
-                                                    CUSTOM_1,
-                                                    Custom1Funct3::ModularArithmetic as usize,
-                                                    ModArithBaseFunct7::DivMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                    uninit.as_mut_ptr(),
-                                                    self as *const #struct_name,
-                                                    other as *const #struct_name
-                                                );
-                                                unsafe { uninit.assume_init() }
-                                            }
-                                        }
-
-                                        #[inline(always)]
-                                        fn eq_impl(&self, other: &Self) -> bool {
-                                            #[cfg(not(target_os = "zkvm"))]
-                                            {
-                                                self.as_le_bytes() == other.as_le_bytes()
-                                            }
-                                            #[cfg(target_os = "zkvm")]
-                                            {
-                                                let mut x: u32;
-                                                unsafe {
-                                                    core::arch::asm!(
-                                                        ".insn r {opcode}, {funct3}, {funct7}, {rd}, {rs1}, {rs2}",
-                                                        opcode = const CUSTOM_1,
-                                                        funct3 = const Custom1Funct3::ModularArithmetic as usize,
-                                                        funct7 = const ModArithBaseFunct7::IsEqMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
-                                                        rd = out(reg) x,
-                                                        rs1 = in(reg) self as *const #struct_name,
-                                                        rs2 = in(reg) other as *const #struct_name
+                                            #[inline(always)]
+                                            fn add_assign_impl(&mut self, other: &Self) {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    *self = Self::from_biguint(
+                                                        (self.as_biguint() + other.as_biguint()) % Self::modulus_biguint(),
                                                     );
                                                 }
-                                                x != 0
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::AddMod as usize
+                                                            + Self::MOD_IDX
+                                                                * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        self as *mut Self,
+                                                        self as *const Self,
+                                                        other as *const Self
+                                                    )
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn sub_assign_impl(&mut self, other: &Self) {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    let modulus = Self::modulus_biguint();
+                                                    *self = Self::from_biguint(
+                                                        (self.as_biguint() + modulus.clone() - other.as_biguint()) % modulus,
+                                                    );
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::SubMod as usize
+                                                            + Self::MOD_IDX
+                                                                * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        self as *mut Self,
+                                                        self as *const Self,
+                                                        other as *const Self
+                                                    )
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn mul_assign_impl(&mut self, other: &Self) {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    *self = Self::from_biguint(
+                                                        (self.as_biguint() * other.as_biguint()) % Self::modulus_biguint(),
+                                                    );
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::MulMod as usize
+                                                            + Self::MOD_IDX
+                                                                * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        self as *mut Self,
+                                                        self as *const Self,
+                                                        other as *const Self
+                                                    )
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn div_assign_impl(&mut self, other: &Self) {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    let modulus = Self::modulus_biguint();
+                                                    let inv = axvm::intrinsics::uint_mod_inverse(&other.as_biguint(), &modulus);
+                                                    *self = Self::from_biguint((self.as_biguint() * inv) % modulus);
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::DivMod as usize
+                                                            + Self::MOD_IDX
+                                                                * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        self as *mut Self,
+                                                        self as *const Self,
+                                                        other as *const Self
+                                                    )
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn add_refs_impl(&self, other: &Self) -> Self {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    let mut res = self.clone();
+                                                    res += other;
+                                                    res
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    let mut uninit: core::mem::MaybeUninit<#struct_name> = core::mem::MaybeUninit::uninit();
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::AddMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        uninit.as_mut_ptr(),
+                                                        self as *const #struct_name,
+                                                        other as *const #struct_name
+                                                    );
+                                                    unsafe { uninit.assume_init() }
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn sub_refs_impl(&self, other: &Self) -> Self {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    let mut res = self.clone();
+                                                    res -= other;
+                                                    res
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    let mut uninit: core::mem::MaybeUninit<#struct_name> = core::mem::MaybeUninit::uninit();
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::SubMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        uninit.as_mut_ptr(),
+                                                        self as *const #struct_name,
+                                                        other as *const #struct_name
+                                                    );
+                                                    unsafe { uninit.assume_init() }
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn mul_refs_impl(&self, other: &Self) -> Self {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    let mut res = self.clone();
+                                                    res *= other;
+                                                    res
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    let mut uninit: core::mem::MaybeUninit<#struct_name> = core::mem::MaybeUninit::uninit();
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::MulMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        uninit.as_mut_ptr(),
+                                                        self as *const #struct_name,
+                                                        other as *const #struct_name
+                                                    );
+                                                    unsafe { uninit.assume_init() }
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn div_refs_impl(&self, other: &Self) -> Self {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    let mut res = self.clone();
+                                                    res /= other;
+                                                    res
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    let mut uninit: core::mem::MaybeUninit<#struct_name> = core::mem::MaybeUninit::uninit();
+                                                    axvm_platform::custom_insn_r!(
+                                                        axvm_platform::constants::CUSTOM_1,
+                                                        axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                        axvm_platform::constants::ModArithBaseFunct7::DivMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                        uninit.as_mut_ptr(),
+                                                        self as *const #struct_name,
+                                                        other as *const #struct_name
+                                                    );
+                                                    unsafe { uninit.assume_init() }
+                                                }
+                                            }
+
+                                            #[inline(always)]
+                                            fn eq_impl(&self, other: &Self) -> bool {
+                                                #[cfg(not(target_os = "zkvm"))]
+                                                {
+                                                    self.as_le_bytes() == other.as_le_bytes()
+                                                }
+                                                #[cfg(target_os = "zkvm")]
+                                                {
+                                                    let mut x: u32;
+                                                    unsafe {
+                                                        core::arch::asm!(
+                                                            ".insn r {opcode}, {funct3}, {funct7}, {rd}, {rs1}, {rs2}",
+                                                            opcode = const axvm_platform::constants::CUSTOM_1,
+                                                            funct3 = const axvm_platform::constants::Custom1Funct3::ModularArithmetic as usize,
+                                                            funct7 = const axvm_platform::constants::ModArithBaseFunct7::IsEqMod as usize + Self::MOD_IDX * (axvm_platform::constants::MODULAR_ARITHMETIC_MAX_KINDS as usize),
+                                                            rd = out(reg) x,
+                                                            rs1 = in(reg) self as *const #struct_name,
+                                                            rs2 = in(reg) other as *const #struct_name
+                                                        );
+                                                    }
+                                                    x != 0
+                                                }
                                             }
                                         }
-                                    }
 
-                                    impl IntMod for #struct_name {
-                                        type Repr = [u8; #limbs];
-                                        type SelfRef<'a> = &'a Self;
+                                        impl axvm::intrinsics::IntMod for #struct_name {
+                                            type Repr = [u8; #limbs];
+                                            type SelfRef<'a> = &'a Self;
 
-                                        const MOD_IDX: usize = #mod_idx;
+                                            const MOD_IDX: usize = #mod_idx;
 
-                                        const MODULUS: Self::Repr = [#(#modulus_bytes),*];
+                                            const MODULUS: Self::Repr = [#(#modulus_bytes),*];
 
-                                        const ZERO: Self = Self([0; #limbs]);
+                                            const ZERO: Self = Self([0; #limbs]);
 
-                                        const ONE: Self = Self::from_const_u8(1);
+                                            const ONE: Self = Self::from_const_u8(1);
 
-                                        fn from_repr(repr: Self::Repr) -> Self {
-                                            Self(repr)
+                                            fn from_repr(repr: Self::Repr) -> Self {
+                                                Self(repr)
+                                            }
+
+                                            fn from_le_bytes(bytes: &[u8]) -> Self {
+                                                let mut arr = [0u8; #limbs];
+                                                arr.copy_from_slice(bytes);
+                                                Self(arr)
+                                            }
+
+                                            fn from_u8(val: u8) -> Self {
+                                                Self::from_const_u8(val)
+                                            }
+
+                                            fn from_u32(val: u32) -> Self {
+                                                let mut bytes = [0; #limbs];
+                                                bytes[..4].copy_from_slice(&val.to_le_bytes());
+                                                Self(bytes)
+                                            }
+
+                                            fn from_u64(val: u64) -> Self {
+                                                let mut bytes = [0; #limbs];
+                                                bytes[..8].copy_from_slice(&val.to_le_bytes());
+                                                Self(bytes)
+                                            }
+
+                                            fn as_le_bytes(&self) -> &[u8] {
+                                                &(self.0)
+                                            }
+
+                                            #[cfg(not(target_os = "zkvm"))]
+                                            fn modulus_biguint() -> num_bigint_dig::BigUint {
+                                                num_bigint_dig::BigUint::from_bytes_le(&Self::MODULUS)
+                                            }
+
+                                            #[cfg(not(target_os = "zkvm"))]
+                                            fn from_biguint(biguint: num_bigint_dig::BigUint) -> Self {
+                                                Self(axvm::intrinsics::biguint_to_limbs(&biguint))
+                                            }
+
+                                            #[cfg(not(target_os = "zkvm"))]
+                                            fn as_biguint(&self) -> num_bigint_dig::BigUint {
+                                                num_bigint_dig::BigUint::from_bytes_le(self.as_le_bytes())
+                                            }
+
+                                            fn double(&self) -> Self {
+                                                self + self
+                                            }
+
+                                            fn square(&self) -> Self {
+                                                self * self
+                                            }
+
+                                            fn cube(&self) -> Self {
+                                                &self.square() * self
+                                            }
                                         }
 
-                                        fn from_le_bytes(bytes: &[u8]) -> Self {
-                                            let mut arr = [0u8; #limbs];
-                                            arr.copy_from_slice(bytes);
-                                            Self(arr)
+                                        impl<'a> core::ops::AddAssign<&'a #struct_name> for #struct_name {
+                                            #[inline(always)]
+                                            fn add_assign(&mut self, other: &'a #struct_name) {
+                                                self.add_assign_impl(other);
+                                            }
                                         }
 
-                                        fn from_u8(val: u8) -> Self {
-                                            Self::from_const_u8(val)
+                                        impl core::ops::AddAssign for #struct_name {
+                                            #[inline(always)]
+                                            fn add_assign(&mut self, other: Self) {
+                                                self.add_assign_impl(&other);
+                                            }
                                         }
 
-                                        fn from_u32(val: u32) -> Self {
-                                            let mut bytes = [0; #limbs];
-                                            bytes[..4].copy_from_slice(&val.to_le_bytes());
-                                            Self(bytes)
+                                        impl core::ops::Add for #struct_name {
+                                            type Output = Self;
+                                            #[inline(always)]
+                                            fn add(mut self, other: Self) -> Self::Output {
+                                                self += other;
+                                                self
+                                            }
                                         }
 
-                                        fn from_u64(val: u64) -> Self {
-                                            let mut bytes = [0; #limbs];
-                                            bytes[..8].copy_from_slice(&val.to_le_bytes());
-                                            Self(bytes)
+                                        impl<'a> core::ops::Add<&'a #struct_name> for #struct_name {
+                                            type Output = Self;
+                                            #[inline(always)]
+                                            fn add(mut self, other: &'a #struct_name) -> Self::Output {
+                                                self += other;
+                                                self
+                                            }
                                         }
 
-                                        fn as_le_bytes(&self) -> &[u8] {
-                                            &(self.0)
-                                        }
-
-                                        #[cfg(not(target_os = "zkvm"))]
-                                        fn modulus_biguint() -> BigUint {
-                                            BigUint::from_bytes_le(&Self::MODULUS)
-                                        }
-
-                                        #[cfg(not(target_os = "zkvm"))]
-                                        fn from_biguint(biguint: BigUint) -> Self {
-                                            Self(biguint_to_limbs(&biguint))
-                                        }
-
-                                        #[cfg(not(target_os = "zkvm"))]
-                                        fn as_biguint(&self) -> BigUint {
-                                            BigUint::from_bytes_le(self.as_le_bytes())
-                                        }
-
-                                        fn double(&self) -> Self {
-                                            self + self
-                                        }
-
-                                        fn square(&self) -> Self {
-                                            self * self
-                                        }
-
-                                        fn cube(&self) -> Self {
-                                            &self.square() * self
-                                        }
-                                    }
-
-                                    impl<'a> AddAssign<&'a #struct_name> for #struct_name {
-                                        #[inline(always)]
-                                        fn add_assign(&mut self, other: &'a #struct_name) {
-                                            self.add_assign_impl(other);
-                                        }
-                                    }
-
-                                    impl AddAssign for #struct_name {
-                                        #[inline(always)]
-                                        fn add_assign(&mut self, other: Self) {
-                                            self.add_assign_impl(&other);
-                                        }
-                                    }
-
-                                    impl Add for #struct_name {
-                                        type Output = Self;
-                                        #[inline(always)]
-                                        fn add(mut self, other: Self) -> Self::Output {
-                                            self += other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Add<&'a #struct_name> for #struct_name {
-                                        type Output = Self;
-                                        #[inline(always)]
-                                        fn add(mut self, other: &'a #struct_name) -> Self::Output {
-                                            self += other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Add<&'a #struct_name> for &#struct_name {
-                                        type Output = #struct_name;
-                                        #[inline(always)]
-                                        fn add(self, other: &'a #struct_name) -> Self::Output {
-                                            self.add_refs_impl(other)
-                                        }
-                                    }
-
-                                    impl<'a> SubAssign<&'a #struct_name> for #struct_name {
-                                        #[inline(always)]
-                                        fn sub_assign(&mut self, other: &'a #struct_name) {
-                                            self.sub_assign_impl(other);
-                                        }
-                                    }
-
-                                    impl SubAssign for #struct_name {
-                                        #[inline(always)]
-                                        fn sub_assign(&mut self, other: Self) {
-                                            self.sub_assign_impl(&other);
-                                        }
-                                    }
-
-                                    impl Sub for #struct_name {
-                                        type Output = Self;
-                                        #[inline(always)]
-                                        fn sub(mut self, other: Self) -> Self::Output {
-                                            self -= other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Sub<&'a #struct_name> for #struct_name {
-                                        type Output = Self;
-                                        #[inline(always)]
-                                        fn sub(mut self, other: &'a #struct_name) -> Self::Output {
-                                            self -= other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Sub<&'a #struct_name> for &#struct_name {
-                                        type Output = #struct_name;
-                                        #[inline(always)]
-                                        fn sub(self, other: &'a #struct_name) -> Self::Output {
-                                            self.sub_refs_impl(other)
-                                        }
-                                    }
-
-                                    impl<'a> MulAssign<&'a #struct_name> for #struct_name {
-                                        #[inline(always)]
-                                        fn mul_assign(&mut self, other: &'a #struct_name) {
-                                            self.mul_assign_impl(other);
-                                        }
-                                    }
-
-                                    impl MulAssign for #struct_name {
-                                        #[inline(always)]
-                                        fn mul_assign(&mut self, other: Self) {
-                                            self.mul_assign_impl(&other);
-                                        }
-                                    }
-
-                                    impl Mul for #struct_name {
-                                        type Output = Self;
-                                        #[inline(always)]
-                                        fn mul(mut self, other: Self) -> Self::Output {
-                                            self *= other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Mul<&'a #struct_name> for #struct_name {
-                                        type Output = Self;
-                                        #[inline(always)]
-                                        fn mul(mut self, other: &'a #struct_name) -> Self::Output {
-                                            self *= other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Mul<&'a #struct_name> for &#struct_name {
-                                        type Output = #struct_name;
-                                        #[inline(always)]
-                                        fn mul(self, other: &'a #struct_name) -> Self::Output {
-                                            self.mul_refs_impl(other)
-                                        }
-                                    }
-
-                                    impl<'a> DivAssign<&'a #struct_name> for #struct_name {
-                                        /// Undefined behaviour when denominator is not coprime to N
-                                        #[inline(always)]
-                                        fn div_assign(&mut self, other: &'a #struct_name) {
-                                            self.div_assign_impl(other);
-                                        }
-                                    }
-
-                                    impl DivAssign for #struct_name {
-                                        /// Undefined behaviour when denominator is not coprime to N
-                                        #[inline(always)]
-                                        fn div_assign(&mut self, other: Self) {
-                                            self.div_assign_impl(&other);
-                                        }
-                                    }
-
-                                    impl Div for #struct_name {
-                                        type Output = Self;
-                                        /// Undefined behaviour when denominator is not coprime to N
-                                        #[inline(always)]
-                                        fn div(mut self, other: Self) -> Self::Output {
-                                            self /= other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Div<&'a #struct_name> for #struct_name {
-                                        type Output = Self;
-                                        /// Undefined behaviour when denominator is not coprime to N
-                                        #[inline(always)]
-                                        fn div(mut self, other: &'a #struct_name) -> Self::Output {
-                                            self /= other;
-                                            self
-                                        }
-                                    }
-
-                                    impl<'a> Div<&'a #struct_name> for &#struct_name {
-                                        type Output = #struct_name;
-                                        /// Undefined behaviour when denominator is not coprime to N
-                                        #[inline(always)]
-                                        fn div(self, other: &'a #struct_name) -> Self::Output {
-                                            self.div_refs_impl(other)
-                                        }
-                                    }
-
-                                    impl PartialEq for #struct_name {
-                                        #[inline(always)]
-                                        fn eq(&self, other: &Self) -> bool {
-                                            self.eq_impl(other)
-                                        }
-                                    }
-
-                                    impl<'a> Sum<&'a #struct_name> for #struct_name {
-                                        fn sum<I: Iterator<Item = &'a #struct_name>>(iter: I) -> Self {
-                                            iter.fold(Self::ZERO, |acc, x| &acc + x)
-                                        }
-                                    }
-
-                                    impl Sum for #struct_name {
-                                        fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-                                            iter.fold(Self::ZERO, |acc, x| &acc + &x)
-                                        }
-                                    }
-
-                                    impl<'a> Product<&'a #struct_name> for #struct_name {
-                                        fn product<I: Iterator<Item = &'a #struct_name>>(iter: I) -> Self {
-                                            iter.fold(Self::ONE, |acc, x| &acc * x)
-                                        }
-                                    }
-
-                                    impl Product for #struct_name {
-                                        fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-                                            iter.fold(Self::ONE, |acc, x| &acc * &x)
-                                        }
-                                    }
-
-                                    impl Neg for #struct_name {
-                                        type Output = #struct_name;
-                                        fn neg(self) -> Self::Output {
-                                            Self::ZERO - &self
-                                        }
-                                    }
-
-                                    impl Debug for #struct_name {
-                                        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                                            write!(f, "{:?}", self.as_le_bytes())
-                                        }
-                                    }
-
-                                    #[cfg(not(target_os = "zkvm"))]
-                                    mod helper {
-                                        use super::*;
-                                        impl Mul<u32> for #struct_name {
+                                        impl<'a> core::ops::Add<&'a #struct_name> for &#struct_name {
                                             type Output = #struct_name;
                                             #[inline(always)]
-                                            fn mul(self, other: u32) -> Self::Output {
-                                                let mut res = self.clone();
-                                                res *= #struct_name::from_u32(other);
-                                                res
+                                            fn add(self, other: &'a #struct_name) -> Self::Output {
+                                                self.add_refs_impl(other)
                                             }
                                         }
 
-                                        impl Mul<u32> for &#struct_name {
+                                        impl<'a> core::ops::SubAssign<&'a #struct_name> for #struct_name {
+                                            #[inline(always)]
+                                            fn sub_assign(&mut self, other: &'a #struct_name) {
+                                                self.sub_assign_impl(other);
+                                            }
+                                        }
+
+                                        impl core::ops::SubAssign for #struct_name {
+                                            #[inline(always)]
+                                            fn sub_assign(&mut self, other: Self) {
+                                                self.sub_assign_impl(&other);
+                                            }
+                                        }
+
+                                        impl core::ops::Sub for #struct_name {
+                                            type Output = Self;
+                                            #[inline(always)]
+                                            fn sub(mut self, other: Self) -> Self::Output {
+                                                self -= other;
+                                                self
+                                            }
+                                        }
+
+                                        impl<'a> core::ops::Sub<&'a #struct_name> for #struct_name {
+                                            type Output = Self;
+                                            #[inline(always)]
+                                            fn sub(mut self, other: &'a #struct_name) -> Self::Output {
+                                                self -= other;
+                                                self
+                                            }
+                                        }
+
+                                        impl<'a> core::ops::Sub<&'a #struct_name> for &#struct_name {
                                             type Output = #struct_name;
                                             #[inline(always)]
-                                            fn mul(self, other: u32) -> Self::Output {
-                                                let mut res = self.clone();
-                                                res *= #struct_name::from_u32(other);
-                                                res
+                                            fn sub(self, other: &'a #struct_name) -> Self::Output {
+                                                self.sub_refs_impl(other)
                                             }
                                         }
-                                    }
 
-                                });
+                                        impl<'a> core::ops::MulAssign<&'a #struct_name> for #struct_name {
+                                            #[inline(always)]
+                                            fn mul_assign(&mut self, other: &'a #struct_name) {
+                                                self.mul_assign_impl(other);
+                                            }
+                                        }
+
+                                        impl core::ops::MulAssign for #struct_name {
+                                            #[inline(always)]
+                                            fn mul_assign(&mut self, other: Self) {
+                                                self.mul_assign_impl(&other);
+                                            }
+                                        }
+
+                                        impl core::ops::Mul for #struct_name {
+                                            type Output = Self;
+                                            #[inline(always)]
+                                            fn mul(mut self, other: Self) -> Self::Output {
+                                                self *= other;
+                                                self
+                                            }
+                                        }
+
+                                        impl<'a> core::ops::Mul<&'a #struct_name> for #struct_name {
+                                            type Output = Self;
+                                            #[inline(always)]
+                                            fn mul(mut self, other: &'a #struct_name) -> Self::Output {
+                                                self *= other;
+                                                self
+                                            }
+                                        }
+
+                                        impl<'a> core::ops::Mul<&'a #struct_name> for &#struct_name {
+                                            type Output = #struct_name;
+                                            #[inline(always)]
+                                            fn mul(self, other: &'a #struct_name) -> Self::Output {
+                                                self.mul_refs_impl(other)
+                                            }
+                                        }
+
+                                        impl<'a> core::ops::DivAssign<&'a #struct_name> for #struct_name {
+                                            /// Undefined behaviour when denominator is not coprime to N
+                                            #[inline(always)]
+                                            fn div_assign(&mut self, other: &'a #struct_name) {
+                                                self.div_assign_impl(other);
+                                            }
+                                        }
+
+                                        impl core::ops::DivAssign for #struct_name {
+                                            /// Undefined behaviour when denominator is not coprime to N
+                                            #[inline(always)]
+                                            fn div_assign(&mut self, other: Self) {
+                                                self.div_assign_impl(&other);
+                                            }
+                                        }
+
+                                        impl core::ops::Div for #struct_name {
+                                            type Output = Self;
+                                            /// Undefined behaviour when denominator is not coprime to N
+                                            #[inline(always)]
+                                            fn div(mut self, other: Self) -> Self::Output {
+                                                self /= other;
+                                                self
+                                            }
+                                        }
+
+                                        impl<'a> core::ops::Div<&'a #struct_name> for #struct_name {
+                                            type Output = Self;
+                                            /// Undefined behaviour when denominator is not coprime to N
+                                            #[inline(always)]
+                                            fn div(mut self, other: &'a #struct_name) -> Self::Output {
+                                                self /= other;
+                                                self
+                                            }
+                                        }
+
+                                        impl<'a> core::ops::Div<&'a #struct_name> for &#struct_name {
+                                            type Output = #struct_name;
+                                            /// Undefined behaviour when denominator is not coprime to N
+                                            #[inline(always)]
+                                            fn div(self, other: &'a #struct_name) -> Self::Output {
+                                                self.div_refs_impl(other)
+                                            }
+                                        }
+
+                                        impl PartialEq for #struct_name {
+                                            #[inline(always)]
+                                            fn eq(&self, other: &Self) -> bool {
+                                                self.eq_impl(other)
+                                            }
+                                        }
+
+                                        impl<'a> core::iter::Sum<&'a #struct_name> for #struct_name {
+                                            fn sum<I: Iterator<Item = &'a #struct_name>>(iter: I) -> Self {
+                                                iter.fold(Self::ZERO, |acc, x| &acc + x)
+                                            }
+                                        }
+
+                                        impl core::iter::Sum for #struct_name {
+                                            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                                                iter.fold(Self::ZERO, |acc, x| &acc + &x)
+                                            }
+                                        }
+
+                                        impl<'a> core::iter::Product<&'a #struct_name> for #struct_name {
+                                            fn product<I: Iterator<Item = &'a #struct_name>>(iter: I) -> Self {
+                                                iter.fold(Self::ONE, |acc, x| &acc * x)
+                                            }
+                                        }
+
+                                        impl core::iter::Product for #struct_name {
+                                            fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+                                                iter.fold(Self::ONE, |acc, x| &acc * &x)
+                                            }
+                                        }
+
+                                        impl core::ops::Neg for #struct_name {
+                                            type Output = #struct_name;
+                                            fn neg(self) -> Self::Output {
+                                                Self::ZERO - &self
+                                            }
+                                        }
+
+                                        impl core::fmt::Debug for #struct_name {
+                                            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                                                write!(f, "{:?}", self.as_le_bytes())
+                                            }
+                                        }
+
+                                        #[cfg(not(target_os = "zkvm"))]
+                                        mod helper {
+                                            use super::*;
+                                            impl core::ops::Mul<u32> for #struct_name {
+                                                type Output = #struct_name;
+                                                #[inline(always)]
+                                                fn mul(self, other: u32) -> Self::Output {
+                                                    let mut res = self.clone();
+                                                    res *= #struct_name::from_u32(other);
+                                                    res
+                                                }
+                                            }
+
+                                            impl core::ops::Mul<u32> for &#struct_name {
+                                                type Output = #struct_name;
+                                                #[inline(always)]
+                                                fn mul(self, other: u32) -> Self::Output {
+                                                    let mut res = self.clone();
+                                                    res *= #struct_name::from_u32(other);
+                                                    res
+                                                }
+                                            }
+                                        }
+
+                                    },
+                                );
 
                                 moduli.push(modulus_bytes);
                                 mod_idx += 1;

--- a/toolchain/tests/programs/examples/little.rs
+++ b/toolchain/tests/programs/examples/little.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(target_os = "zkvm", no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use axvm::intrinsics::IntMod;
+
 axvm::moduli_setup! {
     IntModN = "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F";
 }

--- a/toolchain/tests/programs/examples/moduli_setup.rs
+++ b/toolchain/tests/programs/examples/moduli_setup.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(target_os = "zkvm", no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use axvm::intrinsics::IntMod;
+
 axvm::entry!(main);
 axvm::moduli_setup! {
     bls12381 = "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787";


### PR DESCRIPTION
This is towards INТ-2573, and also I feel that this is somewhat on the way to INТ-2538, though not directly.

This change makes it so that the `moduli_setup!` macro no longer imports anything, which was really weird and cursed (sorry for that). It makes it kinda harder to modify the macro though, because of all these long paths before everything we use from the crates, but we are unlikely to modify it on a regular basis anyway.