### PR TITLE
[feat] CastVF & VM Chip Height Override

### DIFF
--- a/toolchain/native-compiler/src/asm/compiler.rs
+++ b/toolchain/native-compiler/src/asm/compiler.rs
@@ -285,6 +285,12 @@ impl<F: PrimeField32 + TwoAdicField, EF: ExtensionField<F> + TwoAdicField> AsmCo
                 DslIr::MulEFI(dst, lhs, rhs) => {
                     self.mul_ext_felti(dst, lhs, rhs, debug_info);
                 }
+                DslIr::CastFV(dst, src) => {
+                    self.push(
+                        AsmInstruction::AddFI(dst.fp(), src.fp(), F::ZERO),
+                        debug_info,
+                    );
+                }
                 DslIr::IfEq(lhs, rhs, then_block, else_block) => {
                     let if_compiler = IfCompiler {
                         compiler: self,

--- a/toolchain/native-compiler/src/constraints/halo2/baby_bear.rs
+++ b/toolchain/native-compiler/src/constraints/halo2/baby_bear.rs
@@ -18,6 +18,8 @@ use snark_verifier_sdk::snark_verifier::{
     util::arithmetic::{Field as _, PrimeField as _},
 };
 
+pub(crate) const BABYBEAR_MAX_BITS: usize = 31;
+
 #[derive(Copy, Clone, Debug)]
 pub struct AssignedBabyBear {
     pub value: AssignedValue<Fr>,
@@ -50,10 +52,10 @@ impl BabyBearChip {
 
     pub fn load_witness(&self, ctx: &mut Context<Fr>, value: BabyBear) -> AssignedBabyBear {
         let value = ctx.load_witness(Fr::from(PrimeField64::as_canonical_u64(&value)));
-        self.range.range_check(ctx, value, 31);
+        self.range.range_check(ctx, value, BABYBEAR_MAX_BITS);
         AssignedBabyBear {
             value,
-            max_bits: 31,
+            max_bits: BABYBEAR_MAX_BITS,
         }
     }
 
@@ -67,7 +69,7 @@ impl BabyBearChip {
         let (_, r) = signed_div_mod(&self.range, ctx, a.value, BabyBear::ORDER_U32, a.max_bits);
         let r = AssignedBabyBear {
             value: r,
-            max_bits: 31,
+            max_bits: BABYBEAR_MAX_BITS,
         };
         debug_assert_eq!(a.to_baby_bear(), r.to_baby_bear());
         r

--- a/toolchain/native-compiler/src/constraints/halo2/compiler.rs
+++ b/toolchain/native-compiler/src/constraints/halo2/compiler.rs
@@ -20,6 +20,7 @@ use crate::{
     constraints::halo2::{
         baby_bear::{
             AssignedBabyBear, AssignedBabyBearExt4, BabyBearChip, BabyBearExt4, BabyBearExt4Chip,
+            BABYBEAR_MAX_BITS,
         },
         poseidon2_perm::{Poseidon2Params, Poseidon2State},
     },
@@ -238,6 +239,15 @@ impl<C: Config + Debug> Halo2ConstraintCompiler<C> {
                 DslIr::NegE(a, b) => {
                     let x = ext_chip.neg(ctx, exts[&b.0]);
                     exts.insert(a.0, x);
+                }
+                DslIr::CastFV(a, b) => {
+                    let felt = felts[&b.0];
+                    let reduced_felt = if felt.max_bits > BABYBEAR_MAX_BITS {
+                        f_chip.reduce(ctx, felt)
+                    } else {
+                        felt
+                    };
+                    vars.insert(a.0, reduced_felt.value);
                 }
                 DslIr::CircuitNum2BitsV(value, bits, output) => {
                     let shortened_bits = bits.min(Fr::NUM_BITS as usize);

--- a/toolchain/native-compiler/src/ir/builder.rs
+++ b/toolchain/native-compiler/src/ir/builder.rs
@@ -190,20 +190,10 @@ impl<C: Config> Builder<C> {
         dst.assign(expr.into(), self);
     }
 
-    /// Casts a Felt to a Var. Please use carefully.
+    /// Casts a Felt to a Var.
     pub fn cast_felt_to_var(&mut self, felt: Felt<C::F>) -> Var<C::N> {
-        if self.flags.static_only {
-            panic!("Cannot cast a Felt to a Var in static mode");
-        }
         let var: Var<_> = self.uninit();
-        let buffer = self.alloc(1, 1);
-        let idx = MemIndex {
-            index: RVar::zero(),
-            offset: 0,
-            size: 1,
-        };
-        felt.store(buffer, idx, self);
-        var.load(buffer, idx, self);
+        self.operations.push(DslIr::CastFV(var, felt));
         var
     }
 

--- a/toolchain/native-compiler/src/ir/instructions.rs
+++ b/toolchain/native-compiler/src/ir/instructions.rs
@@ -108,6 +108,9 @@ pub enum DslIr<C: Config> {
     /// Compares a variable and an immediate
     LessThanVI(Var<C::N>, Var<C::N>, C::N),
 
+    /// Cast a Felt to a Var.
+    CastFV(Var<C::N>, Felt<C::F>),
+
     // =======
 
     // Control flow.

--- a/vm/src/arch/chip_set.rs
+++ b/vm/src/arch/chip_set.rs
@@ -122,11 +122,30 @@ pub struct VmChipSet<F: PrimeField32> {
     /// PublicValuesChip is disabled when num_public_values == 0.
     pub public_values_chip: Option<Rc<RefCell<PublicValuesChip<F>>>>,
     pub chips: Vec<AxVmChip<F>>,
+    pub overridden_executor_heights: Option<BTreeMap<ExecutorName, usize>>,
     pub memory_controller: MemoryControllerRef<F>,
     pub range_checker_chip: Arc<VariableRangeCheckerChip>,
 }
 
 impl<F: PrimeField32> VmChipSet<F> {
+    /// Returns the AIR ID of the given executor if it exists.
+    pub fn get_executor_air_id(&self, executor: ExecutorName) -> Option<usize> {
+        let mut air_id = PUBLIC_VALUES_AIR_ID;
+        if self.public_values_chip.is_some() {
+            air_id += 1;
+        }
+        air_id += self.memory_controller.borrow().air_names().len();
+        for chip in &self.chips {
+            if let AxVmChip::Executor(chip) = chip {
+                let name: ExecutorName = chip.into();
+                if name == executor {
+                    return Some(air_id);
+                }
+            }
+            air_id += 1
+        }
+        None
+    }
     pub(crate) fn set_program(&mut self, program: Program<F>) {
         self.program_chip.set_program(program);
     }
@@ -200,11 +219,27 @@ impl<F: PrimeField32> VmChipSet<F> {
         }
         // Non-system chips: ONLY AirProofInput generation to release strong references.
         // Will be added after MemoryController for AIR ordering.
-        let non_sys_inputs: Vec<_> = self
-            .chips
-            .into_iter()
-            .map(|chip| chip.generate_air_proof_input())
-            .collect();
+        let non_sys_inputs: Vec<_> =
+            self.chips
+                .into_iter()
+                .map(|chip| {
+                    if let AxVmChip::Executor(executor) = chip {
+                        let height = self.overridden_executor_heights.as_ref().and_then(
+                            |overridden_heights| {
+                                let executor_name: ExecutorName = (&executor).into();
+                                overridden_heights.get(&executor_name).copied()
+                            },
+                        );
+                        if let Some(height) = height {
+                            executor.generate_air_proof_input_with_height(height)
+                        } else {
+                            executor.generate_air_proof_input()
+                        }
+                    } else {
+                        chip.generate_air_proof_input()
+                    }
+                })
+                .collect();
         // System: Memory Controller
         {
             // memory
@@ -1296,6 +1331,7 @@ impl VmConfig {
             connector_chip,
             public_values_chip,
             chips,
+            overridden_executor_heights: self.overridden_executor_heights.clone(),
             memory_controller,
             range_checker_chip: range_checker,
         }

--- a/vm/src/arch/chips.rs
+++ b/vm/src/arch/chips.rs
@@ -5,10 +5,17 @@ use ax_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChip, range_tuple::RangeTupleCheckerChip,
     var_range::VariableRangeCheckerChip,
 };
+use ax_stark_backend::{
+    config::{Domain, StarkGenericConfig},
+    p3_commit::PolynomialSpace,
+    prover::types::AirProofInput,
+    Chip,
+};
 use axvm_instructions::instruction::Instruction;
 use derive_more::From;
 use enum_dispatch::enum_dispatch;
 use p3_field::PrimeField32;
+use p3_matrix::Matrix;
 use serde::{Deserialize, Serialize};
 use strum::EnumDiscriminants;
 
@@ -155,4 +162,26 @@ pub enum AxVmChip<F: PrimeField32> {
     BitwiseOperationLookup(Arc<BitwiseOperationLookupChip<8>>),
     // Instruction Executors
     Executor(AxVmExecutor<F>),
+}
+
+impl<F: PrimeField32> AxVmExecutor<F> {
+    /// Generates an AIR proof input of the chip with the given height.
+    pub fn generate_air_proof_input_with_height<SC: StarkGenericConfig>(
+        self,
+        height: usize,
+    ) -> AirProofInput<SC>
+    where
+        Domain<SC>: PolynomialSpace<Val = F>,
+    {
+        let height = height.next_power_of_two();
+        let mut proof_input = self.generate_air_proof_input();
+        let main = proof_input.raw.common_main.as_mut().unwrap();
+        assert!(
+            height >= main.height(),
+            "Overridden height must be greater than or equal to the used height"
+        );
+        // Assumption: an all-0 row is a valid dummy row for all chips.
+        main.pad_to_height(height, F::ZERO);
+        proof_input
+    }
 }

--- a/vm/src/arch/config.rs
+++ b/vm/src/arch/config.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use ax_poseidon2_air::poseidon2::Poseidon2Config;
 use ax_stark_backend::{
     config::{StarkGenericConfig, Val},
@@ -34,11 +36,13 @@ pub struct MemoryConfig {
     pub pointer_max_bits: usize,
     pub clk_max_bits: usize,
     pub decomp: usize,
+    /// Maximum N AccessAdapter AIR to support.
+    pub max_access_adapter_n: usize,
 }
 
 impl Default for MemoryConfig {
     fn default() -> Self {
-        Self::new(29, 1, 29, 29, 16)
+        Self::new(29, 1, 29, 29, 16, 64)
     }
 }
 
@@ -46,6 +50,8 @@ impl Default for MemoryConfig {
 pub struct VmConfig {
     /// List of all executors except modular executors.
     pub executors: Vec<ExecutorName>,
+    /// Optional. Can be used to override the height of the trace of an executor.
+    pub overridden_executor_heights: Option<BTreeMap<ExecutorName, usize>>,
     /// List of all supported modulus
     pub supported_modulus: Vec<BigUint>,
     /// List of all supported Complex extensions, stored as indices of supported_modulus.
@@ -95,6 +101,7 @@ impl VmConfig {
     ) -> Self {
         VmConfig {
             executors: Vec::new(),
+            overridden_executor_heights: None,
             continuation_enabled,
             poseidon2_max_constraint_degree,
             memory_config,
@@ -249,6 +256,11 @@ impl VmConfig {
         VmConfig {
             poseidon2_max_constraint_degree,
             continuation_enabled: false,
+            memory_config: MemoryConfig {
+                // By default, eDSL never uses AccessAdapterAir with N > 8.
+                max_access_adapter_n: 8,
+                ..Default::default()
+            },
             num_public_values,
             max_segment_len: (1 << 24) - 100,
             ..VmConfig::default()

--- a/vm/src/arch/testing/mod.rs
+++ b/vm/src/arch/testing/mod.rs
@@ -210,7 +210,7 @@ impl VmChipTestBuilder<BabyBear> {
 
 impl<F: PrimeField32> Default for VmChipTestBuilder<F> {
     fn default() -> Self {
-        let mem_config = MemoryConfig::new(2, 1, 29, 29, 17);
+        let mem_config = MemoryConfig::new(2, 1, 29, 29, 17, 64);
         let range_checker = Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
             RANGE_CHECKER_BUS,
             mem_config.decomp,


### PR DESCRIPTION
- Add a new eDSL `CastVL` to convert a `Felt` to a `Var`.
- `VmConfig` can use `overridden_executor_heights` field to override height of a executor chip.
- `MemConfig` can specify `max_access_adapter_n`. `AccessAdapterAir` with `N>max_access_adapter_n` will be disabled.
- `AccessAdapterAir` with `N=16/32/64` are disabled in aggregation VM.