### PR TITLE
Use `Rv32VecHeapTwoReadsAdapterChip` for line mulitiplication

### DIFF
--- a/vm/src/arch/chip_set.rs
+++ b/vm/src/arch/chip_set.rs
@@ -943,11 +943,10 @@ impl VmConfig {
                 }
                 ExecutorName::EcLineMulBy01234 => {
                     let chip = Rc::new(RefCell::new(EcLineMulBy01234Chip::new(
-                        Rv32VecHeapAdapterChip::<F, 2, 12, 12, 32, 32>::new(
+                        Rv32VecHeapTwoReadsAdapterChip::<F, 12, 10, 12, 32, 32>::new(
                             execution_bus,
                             program_bus,
                             memory_controller.clone(),
-                            bitwise_lookup_chip.clone(),
                         ),
                         memory_controller.clone(),
                         config32,
@@ -959,11 +958,10 @@ impl VmConfig {
                 }
                 ExecutorName::EcLineMulBy02345 => {
                     let chip = Rc::new(RefCell::new(EcLineMulBy02345Chip::new(
-                        Rv32VecHeapAdapterChip::<F, 2, 36, 36, 16, 16>::new(
+                        Rv32VecHeapTwoReadsAdapterChip::<F, 36, 30, 36, 16, 16>::new(
                             execution_bus,
                             program_bus,
                             memory_controller.clone(),
-                            bitwise_lookup_chip.clone(),
                         ),
                         memory_controller.clone(),
                         config48,

--- a/vm/src/arch/chips.rs
+++ b/vm/src/arch/chips.rs
@@ -139,11 +139,11 @@ pub enum AxVmExecutor<F: PrimeField32> {
     /// Only for BN254 for now
     EcLineMul013By013(Rc<RefCell<EcLineMul013By013Chip<F, 4, 10, 32>>>),
     /// Only for BN254 for now
-    EcLineMulBy01234(Rc<RefCell<EcLineMulBy01234Chip<F, 12, 12, 32>>>),
+    EcLineMulBy01234(Rc<RefCell<EcLineMulBy01234Chip<F, 12, 10, 12, 32>>>),
     /// Only for BLS12-381 for now
     EcLineMul023By023(Rc<RefCell<EcLineMul023By023Chip<F, 12, 30, 16>>>),
     /// Only for BLS12-381 for now
-    EcLineMulBy02345(Rc<RefCell<EcLineMulBy02345Chip<F, 36, 36, 16>>>),
+    EcLineMulBy02345(Rc<RefCell<EcLineMulBy02345Chip<F, 36, 30, 36, 16>>>),
     MillerDoubleStepRv32_32(Rc<RefCell<MillerDoubleStepChip<F, 4, 8, 32>>>),
     MillerDoubleStepRv32_48(Rc<RefCell<MillerDoubleStepChip<F, 12, 24, 16>>>),
     MillerDoubleAndAddStepRv32_32(Rc<RefCell<MillerDoubleAndAddStepChip<F, 4, 12, 32>>>),

--- a/vm/src/intrinsics/ecc/pairing/line/d_type/tests.rs
+++ b/vm/src/intrinsics/ecc/pairing/line/d_type/tests.rs
@@ -133,15 +133,10 @@ fn test_mul_013_by_013() {
 #[test]
 fn test_mul_by_01234() {
     let mut tester: VmChipTestBuilder<F> = VmChipTestBuilder::default();
-    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
-    let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV32_CELL_BITS>::new(
-        bitwise_bus,
-    ));
-    let adapter = Rv32VecHeapAdapterChip::<F, 2, 12, 12, BLOCK_SIZE, BLOCK_SIZE>::new(
+    let adapter = Rv32VecHeapTwoReadsAdapterChip::<F, 12, 10, 12, BLOCK_SIZE, BLOCK_SIZE>::new(
         tester.execution_bus(),
         tester.program_bus(),
         tester.memory_controller(),
-        bitwise_chip.clone(),
     );
     let mut chip = EcLineMulBy01234Chip::new(
         adapter,
@@ -157,15 +152,10 @@ fn test_mul_by_01234() {
 
     let mut rng = StdRng::seed_from_u64(8);
     let f = Fq12::random(&mut rng);
-    let mut rng = StdRng::seed_from_u64(12);
     let x0 = Fq2::random(&mut rng);
-    let mut rng = StdRng::seed_from_u64(1);
     let x1 = Fq2::random(&mut rng);
-    let mut rng = StdRng::seed_from_u64(5);
     let x2 = Fq2::random(&mut rng);
-    let mut rng = StdRng::seed_from_u64(77);
     let x3 = Fq2::random(&mut rng);
-    let mut rng = StdRng::seed_from_u64(31);
     let x4 = Fq2::random(&mut rng);
 
     let input_f = bn254_fq12_to_biguint_vec(f);
@@ -175,7 +165,6 @@ fn test_mul_by_01234() {
         bn254_fq2_to_biguint_vec(x2),
         bn254_fq2_to_biguint_vec(x3),
         bn254_fq2_to_biguint_vec(x4),
-        bn254_fq2_to_biguint_vec(Fq2::zero()),
     ]
     .concat();
 
@@ -220,7 +209,7 @@ fn test_mul_by_01234() {
     );
 
     tester.execute(&mut chip, instruction);
-    let tester = tester.build().load(chip).load(bitwise_chip).finalize();
+    let tester = tester.build().load(chip).finalize();
     tester.simple_test().expect("Verification failed");
 }
 

--- a/vm/src/intrinsics/ecc/pairing/line/m_type/mul_by_02345.rs
+++ b/vm/src/intrinsics/ecc/pairing/line/m_type/mul_by_02345.rs
@@ -14,7 +14,7 @@ use p3_field::PrimeField32;
 
 use crate::{
     arch::VmChipWrapper, intrinsics::field_expression::FieldExpressionCoreChip,
-    rv32im::adapters::Rv32VecHeapAdapterChip, system::memory::MemoryControllerRef,
+    rv32im::adapters::Rv32VecHeapTwoReadsAdapterChip, system::memory::MemoryControllerRef,
 };
 
 // Input: 2 Fp12: 2 x 12 field elements
@@ -22,26 +22,42 @@ use crate::{
 #[derive(Chip, ChipUsageGetter, InstructionExecutor)]
 pub struct EcLineMulBy02345Chip<
     F: PrimeField32,
-    const INPUT_BLOCKS: usize,
+    const INPUT_BLOCKS1: usize,
+    const INPUT_BLOCKS2: usize,
     const OUTPUT_BLOCKS: usize,
     const BLOCK_SIZE: usize,
 >(
     pub  VmChipWrapper<
         F,
-        Rv32VecHeapAdapterChip<F, 2, INPUT_BLOCKS, OUTPUT_BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
+        Rv32VecHeapTwoReadsAdapterChip<
+            F,
+            INPUT_BLOCKS1,
+            INPUT_BLOCKS2,
+            OUTPUT_BLOCKS,
+            BLOCK_SIZE,
+            BLOCK_SIZE,
+        >,
         FieldExpressionCoreChip,
     >,
 );
 
 impl<
         F: PrimeField32,
-        const INPUT_BLOCKS: usize,
+        const INPUT_BLOCKS1: usize,
+        const INPUT_BLOCKS2: usize,
         const OUTPUT_BLOCKS: usize,
         const BLOCK_SIZE: usize,
-    > EcLineMulBy02345Chip<F, INPUT_BLOCKS, OUTPUT_BLOCKS, BLOCK_SIZE>
+    > EcLineMulBy02345Chip<F, INPUT_BLOCKS1, INPUT_BLOCKS2, OUTPUT_BLOCKS, BLOCK_SIZE>
 {
     pub fn new(
-        adapter: Rv32VecHeapAdapterChip<F, 2, INPUT_BLOCKS, OUTPUT_BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
+        adapter: Rv32VecHeapTwoReadsAdapterChip<
+            F,
+            INPUT_BLOCKS1,
+            INPUT_BLOCKS2,
+            OUTPUT_BLOCKS,
+            BLOCK_SIZE,
+            BLOCK_SIZE,
+        >,
         memory_controller: MemoryControllerRef<F>,
         config: ExprBuilderConfig,
         xi: [isize; 2],
@@ -85,8 +101,6 @@ pub fn mul_by_02345_expr(
 
     let mut f = Fp12::new(builder.clone());
     let mut x0 = Fp2::new(builder.clone());
-    // x1 is unused; required for input sizes to balance to 12 on the adapter
-    let _x1 = Fp2::new(builder.clone());
     let mut x2 = Fp2::new(builder.clone());
     let mut x3 = Fp2::new(builder.clone());
     let mut x4 = Fp2::new(builder.clone());


### PR DESCRIPTION
- Use `Rv32VecHeapTwoReadsAdapterChip` for line mul
- Note that `Rv32VecHeapTwoReadsAdapterChip` does not yet include the `BitwiseOperationLookupChip`