### PR TITLE
[feat] Rename the "AXIOM_SERIALIZED_MODULI_" variable

### DIFF
--- a/toolchain/riscv/macros/moduli-setup/src/lib.rs
+++ b/toolchain/riscv/macros/moduli-setup/src/lib.rs
@@ -78,7 +78,7 @@ pub fn moduli_setup(input: TokenStream) -> TokenStream {
                                         .chain(modulus_bytes.iter().copied())
                                         .collect::<Vec<_>>();
                                 let serialized_name = syn::Ident::new(
-                                    &format!("AXIOM_SERIALIZED_MODULUS_{}", struct_name),
+                                    &format!("AXIOM_SERIALIZED_MODULUS_{}", mod_idx),
                                     span.into(),
                                 );
                                 let setup_function =


### PR DESCRIPTION
Now we don't name the variables by the struct name, which can be the same for two different things (in different crates), but use `mod_idx` instead (which is different for all of them)