### PR TITLE
Feat/Make `Program` support `Option<(Instruction<F>, Option<DebugInfo>)>`

### DIFF
--- a/benchmarks/src/bin/fib_e2e.rs
+++ b/benchmarks/src/bin/fib_e2e.rs
@@ -185,10 +185,7 @@ async fn main() -> Result<()> {
 fn generate_fib_exe(app_fri_params: FriParameters) -> Arc<AxVmCommittedExe<SC>> {
     let elf = build_bench_program("fibonacci").unwrap();
     let mut exe: AxVmExe<_> = elf.into();
-    println!(
-        "Program size: {}",
-        exe.program.instructions_and_debug_infos.len()
-    );
+    println!("Program size: {}", exe.program.len());
     println!("Init memory size: {}", exe.init_memory.len());
     exe.program.max_num_public_values = NUM_PUBLIC_VALUES;
 

--- a/toolchain/native-compiler/src/conversion/mod.rs
+++ b/toolchain/native-compiler/src/conversion/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use axvm_circuit::arch::{
     instructions::{program::Program, *},
     Modulus,
@@ -691,16 +689,16 @@ pub fn convert_program<F: PrimeField32, EF: ExtensionField<F>>(
         }
     }
 
-    let mut instructions_and_debug_infos = HashMap::new();
-    instructions_and_debug_infos.insert(0, (init_register_0, init_debug_info));
+    let mut result = Program::new_empty(DEFAULT_PC_STEP, 0, DEFAULT_MAX_NUM_PUBLIC_VALUES);
+    result.push_instruction_and_debug_info(init_register_0, init_debug_info);
     for block in program.blocks.iter() {
         for (instruction, debug_info) in block.0.iter().zip(block.1.iter()) {
-            let cur_size = instructions_and_debug_infos.len() as u32;
+            let cur_size = result.len() as u32;
             let cur_pc = cur_size * DEFAULT_PC_STEP;
 
             let labels =
                 |label: F| F::from_canonical_u32(block_start[label.as_canonical_u64() as usize]);
-            let result = convert_instruction(
+            let local_result = convert_instruction(
                 instruction.clone(),
                 debug_info.clone(),
                 F::from_canonical_u32(cur_pc),
@@ -708,18 +706,9 @@ pub fn convert_program<F: PrimeField32, EF: ExtensionField<F>>(
                 &options,
             );
 
-            for (local_pc, (instruction, debug_info)) in result.instructions_and_debug_infos {
-                let existing = instructions_and_debug_infos
-                    .insert(cur_pc + local_pc, (instruction.clone(), debug_info.clone()));
-                assert!(existing.is_none(), "pc should not already exist");
-            }
+            result.append(local_result);
         }
     }
 
-    Program {
-        instructions_and_debug_infos,
-        step: DEFAULT_PC_STEP,
-        pc_base: 0,
-        max_num_public_values: DEFAULT_MAX_NUM_PUBLIC_VALUES,
-    }
+    result
 }

--- a/vm/src/system/program/mod.rs
+++ b/vm/src/system/program/mod.rs
@@ -119,10 +119,7 @@ impl<F: PrimeField64> ProgramChip<F> {
     pub fn set_program(&mut self, mut program: Program<F>) {
         let true_program_length = program.len();
         while !program.len().is_power_of_two() {
-            program.instructions_and_debug_infos.insert(
-                program.pc_base + program.len() as u32 * program.step,
-                (padding_instruction(), None),
-            );
+            program.push_instruction(padding_instruction());
         }
         self.true_program_length = true_program_length;
         self.execution_frequencies = vec![0; program.len()];
@@ -151,14 +148,12 @@ impl<F: PrimeField64> ProgramChip<F> {
         let pc_index = self.get_pc_index(pc)?;
         self.execution_frequencies[pc_index] += 1;
         self.program
-            .instructions_and_debug_infos
-            .get(&pc)
-            .cloned()
+            .get_instruction_and_debug_info(pc_index)
             .ok_or(ExecutionError::PcNotFound(
                 pc,
                 self.program.step,
                 self.program.pc_base,
-                self.program.instructions_and_debug_infos.len(),
+                self.program.len(),
             ))
     }
 }

--- a/vm/src/system/program/trace.rs
+++ b/vm/src/system/program/trace.rs
@@ -88,17 +88,16 @@ impl<F: PrimeField64> ProgramChip<F> {
 pub(crate) fn generate_cached_trace<F: PrimeField64>(program: &Program<F>) -> RowMajorMatrix<F> {
     let width = ProgramExecutionCols::<F>::width();
     let mut instructions = program
-        .instructions_and_debug_infos
-        .iter()
-        .sorted_by_key(|(pc, _)| *pc)
-        .map(|(&pc, (instruction, _))| (pc, instruction))
-        .collect::<Vec<_>>();
+        .enumerate_by_pc()
+        .into_iter()
+        .map(|(pc, instruction, _)| (pc, instruction))
+        .collect_vec();
 
     let padding = padding_instruction();
     while !instructions.len().is_power_of_two() {
         instructions.push((
             program.pc_base + instructions.len() as u32 * program.step,
-            &padding,
+            padding.clone(),
         ));
     }
 


### PR DESCRIPTION
INT-2654

`Program` is changed to be more object oriented -- the `instruction_and_debug_infos` field (which is now a `Vec<Option<..>>`) is now private, and accessing instructions/debug infos now always goes through methods of `Program`.

Changed the `convert_program` function in `src/conversion/mod.rs` from using a `HashMap` to use the `append` method that I added to `Program`.

There is currently no constructor for `Program` that actually leads to `None` being present in the `Vec`, so this should change, either in this PR if we have an idea of what that should look like, or once we actually need it.