### PR TITLE
[chore] Strip debug_info when not collecting metrics

### DIFF
--- a/toolchain/instructions/src/program.rs
+++ b/toolchain/instructions/src/program.rs
@@ -77,6 +77,17 @@ impl<F: Field> Program<F> {
         }
     }
 
+    pub fn strip_debug_infos(self) -> Self {
+        Self {
+            instructions_and_debug_infos: self
+                .instructions_and_debug_infos
+                .into_iter()
+                .map(|opt| opt.map(|(ins, _)| (ins, None)))
+                .collect(),
+            ..self
+        }
+    }
+
     pub fn from_instructions(instructions: &[Instruction<F>]) -> Self {
         Self::new_without_debug_infos(
             instructions,

--- a/vm/src/arch/segment.rs
+++ b/vm/src/arch/segment.rs
@@ -90,6 +90,11 @@ impl<F: PrimeField32> ExecutionSegment<F> {
     ) -> Self {
         let mut chip_set = config.create_chip_set();
         chip_set.set_streams(streams);
+        let program = if config.collect_metrics {
+            program
+        } else {
+            program.strip_debug_infos()
+        };
         chip_set.set_program(program);
 
         if let Some(initial_memory) = initial_memory {


### PR DESCRIPTION
Mostly for eDSL program. Comparing to `fib_e2e` in https://github.com/axiom-crypto/afs-prototype/blob/gh-pages/benchmarks-pr/838/individual/fib_e2e-2-2-2-2-64cpu-linux-arm64-mimalloc.md , ~15% execution time reduce.