### PR TITLE
[chore] Strip debug_info when not collecting metrics in new_segment

### DIFF
--- a/vm/src/arch/new_segment.rs
+++ b/vm/src/arch/new_segment.rs
@@ -63,6 +63,11 @@ impl<F: PrimeField32, VmConfig: VmGenericConfig<F>> ExecutionSegment<F, VmConfig
     ) -> Self {
         let mut chip_complex = config.create_chip_complex().unwrap();
         chip_complex.set_streams(init_streams);
+        let program = if config.system().collect_metrics {
+            program.strip_debug_infos()
+        } else {
+            program
+        };
         chip_complex.set_program(program);
 
         if let Some(initial_memory) = initial_memory {


### PR DESCRIPTION
Do same as #865 for `new_segment`