### PR TITLE
[fix] CastFV in halo2

### DIFF
--- a/extensions/native/compiler/src/constraints/halo2/compiler.rs
+++ b/extensions/native/compiler/src/constraints/halo2/compiler.rs
@@ -10,15 +10,13 @@ use axvm_circuit::metrics::cycle_tracker::CycleTracker;
 use itertools::Itertools;
 use p3_baby_bear::BabyBear;
 use p3_bn254_fr::Bn254Fr;
-use p3_field::{ExtensionField, PrimeField, PrimeField32};
+use p3_field::{ExtensionField, PrimeField};
 use snark_verifier_sdk::snark_verifier::{
     halo2_base::{
-        gates::{
-            circuit::builder::BaseCircuitBuilder, GateInstructions, RangeChip, RangeInstructions,
-        },
+        gates::{circuit::builder::BaseCircuitBuilder, GateInstructions, RangeChip},
         halo2_proofs::halo2curves::bn256::Fr,
         utils::{biguint_to_fe, ScalarField},
-        Context, QuantumCell,
+        Context,
     },
     util::arithmetic::PrimeField as _,
 };
@@ -28,7 +26,6 @@ use crate::{
     constraints::halo2::{
         baby_bear::{
             AssignedBabyBear, AssignedBabyBearExt4, BabyBearChip, BabyBearExt4, BabyBearExt4Chip,
-            BABYBEAR_MAX_BITS,
         },
         poseidon2_perm::{Poseidon2Params, Poseidon2State},
     },
@@ -251,21 +248,7 @@ impl<C: Config + Debug> Halo2ConstraintCompiler<C> {
                     }
                     DslIr::CastFV(a, b) => {
                         let felt = felts[&b.0];
-                        #[allow(clippy::comparison_chain)]
-                        let reduced_felt = if felt.max_bits > BABYBEAR_MAX_BITS {
-                            f_chip.reduce(ctx, felt)
-                        } else if felt.max_bits == BABYBEAR_MAX_BITS {
-                            // Ensure cast is canonical
-                            f_chip.range.check_less_than(
-                                ctx,
-                                felt.value,
-                                QuantumCell::Constant(Fr::from(BabyBear::ORDER_U32 as u64)),
-                                BABYBEAR_MAX_BITS,
-                            );
-                            felt
-                        } else {
-                            felt
-                        };
+                        let reduced_felt = f_chip.reduce(ctx, felt);
                         vars.insert(a.0, reduced_felt.value);
                     }
                     DslIr::CircuitNum2BitsV(value, bits, output) => {


### PR DESCRIPTION
Because a BabyBear could be negative, we should call `.reduce` no matter what `max_bits` is.