### PR TITLE
chore: fix the guest compiler's rust toolchain version

### DIFF
--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -122,11 +122,11 @@ jobs:
           arch=$(uname -m)
           case $arch in
             arm64|aarch64)
-              rustup component add rust-src --toolchain nightly-aarch64-unknown-linux-gnu
+              rustup component add rust-src --toolchain nightly-2024-10-30-aarch64-unknown-linux-gnu
               S5CMD_BIN="s5cmd_2.2.2_linux_arm64.deb"
               ;;
             x86_64|amd64)
-              rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+              rustup component add rust-src --toolchain nightly-2024-10-30-x86_64-unknown-linux-gnu
               S5CMD_BIN="s5cmd_2.2.2_linux_amd64.deb"
               ;;
             *)

--- a/.github/workflows/ecc.yml
+++ b/.github/workflows/ecc.yml
@@ -44,17 +44,17 @@ jobs:
       - name: Run ecc-circuits crate tests
         working-directory: extensions/ecc/circuit
         run: |
-          cargo nextest run --cargo-profile=fast 
+          cargo nextest run --cargo-profile=fast
 
       - name: Run pairing-circuits crate tests
         working-directory: extensions/pairing/circuit
         run: |
-          RUST_MIN_STACK=8388608 cargo nextest run --cargo-profile=fast 
+          RUST_MIN_STACK=8388608 cargo nextest run --cargo-profile=fast
 
       - name: Install cargo-axiom
         working-directory: crates/cargo-axiom
         run: |
-          rustup component add rust-src --toolchain nightly-aarch64-unknown-linux-gnu
+          rustup component add rust-src --toolchain nightly-2024-10-30-aarch64-unknown-linux-gnu
           cargo install --force --locked --path .
 
       - name: Build axvm-ecc-guest crate for axvm

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -49,5 +49,5 @@ jobs:
       - name: Run RISC-V test vector tests
         working-directory: crates/toolchain/tests
         run: |
-          rustup component add rust-src --toolchain nightly-aarch64-unknown-linux-gnu
+          rustup component add rust-src --toolchain nightly-2024-10-30-aarch64-unknown-linux-gnu
           cargo nextest run --cargo-profile=fast --run-ignored only -- test_rv32im_riscv_vector_runtime

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Run transpiler tests
         working-directory: crates/toolchain/transpiler
         run: |
-          rustup component add rust-src --toolchain nightly-aarch64-unknown-linux-gnu
+          rustup component add rust-src --toolchain nightly-2024-10-30-aarch64-unknown-linux-gnu
           cargo nextest run --cargo-profile=fast
 
       - name: Run toolchain tests
         working-directory: crates/toolchain/tests
         run: |
-          rustup component add rust-src --toolchain nightly-aarch64-unknown-linux-gnu
+          rustup component add rust-src --toolchain nightly-2024-10-30-aarch64-unknown-linux-gnu
           cargo nextest run --cargo-profile=fast

--- a/crates/cargo-axiom/src/lib.rs
+++ b/crates/cargo-axiom/src/lib.rs
@@ -5,7 +5,7 @@ use std::process::{Command, Stdio};
 
 use eyre::{Context, Result};
 
-pub const RUSTUP_TOOLCHAIN_NAME: &str = "nightly";
+pub const RUSTUP_TOOLCHAIN_NAME: &str = "nightly-2024-10-30";
 
 pub const AXVM_VERSION_MESSAGE: &str = concat!(
     "axvm",

--- a/crates/toolchain/build/src/lib.rs
+++ b/crates/toolchain/build/src/lib.rs
@@ -21,7 +21,7 @@ pub use self::config::{DockerOptions, GuestOptions};
 mod config;
 
 #[allow(dead_code)]
-const RUSTUP_TOOLCHAIN_NAME: &str = "axiom";
+const RUSTUP_TOOLCHAIN_NAME: &str = "nightly-2024-10-30";
 
 /// Returns the given cargo Package from the metadata in the Cargo.toml manifest
 /// within the provided `manifest_dir`.


### PR DESCRIPTION
We must use nightly for -Z but we fix a nightly version for stability.