### PR TITLE
fix(toolchain): sys_write and re-entrancy protection

### DIFF
--- a/crates/toolchain/axvm/src/lib.rs
+++ b/crates/toolchain/axvm/src/lib.rs
@@ -12,9 +12,6 @@ extern crate alloc;
 #[cfg(target_os = "zkvm")]
 use core::arch::asm;
 
-#[cfg(all(not(feature = "heap-embedded-alloc"), target_os = "zkvm"))]
-#[allow(unused_imports)]
-use axvm_platform::heap::bump::HEAP;
 #[cfg(target_os = "zkvm")]
 #[allow(unused_imports)]
 use axvm_platform::rust_rt;

--- a/crates/toolchain/platform/src/heap/mod.rs
+++ b/crates/toolchain/platform/src/heap/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #[cfg(not(feature = "heap-embedded-alloc"))]
-pub mod bump;
+mod bump;
 
 #[cfg(feature = "heap-embedded-alloc")]
 pub mod embedded;

--- a/crates/toolchain/platform/src/memory.rs
+++ b/crates/toolchain/platform/src/memory.rs
@@ -111,9 +111,9 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
     heap_pos += bytes;
 
     // Check to make sure heap doesn't collide with SYSTEM memory.
-    // if crate::memory::SYSTEM.start() < heap_pos {
-    //     super::rust_rt::terminate::<1>();
-    // }
+    if crate::memory::SYSTEM.start() < heap_pos {
+        super::rust_rt::terminate::<1>();
+    }
 
     unsafe { HEAP_POS = heap_pos };
     ptr

--- a/crates/toolchain/tests/programs/.cargo/config.toml
+++ b/crates/toolchain/tests/programs/.cargo/config.toml
@@ -1,10 +1,10 @@
-# Uncomment to build for axvm
-[build]
-target = "riscv32im-risc0-zkvm-elf"
+# # Uncomment to build for axvm
+# [build]
+# target = "riscv32im-risc0-zkvm-elf"
 
-[target.riscv32im-risc0-zkvm-elf]
-rustflags = ["-C", "passes=lower-atomic", "-C", "link-arg=-Ttext=0x002008000"]
+# [target.riscv32im-risc0-zkvm-elf]
+# rustflags = ["-C", "passes=lower-atomic", "-C", "link-arg=-Ttext=0x002008000"]
 
-[unstable]
-build-std = ["core", "alloc", "proc_macro", "panic_abort", "std"]
-build-std-features = ["compiler-builtins-mem"]
+# [unstable]
+# build-std = ["core", "alloc", "proc_macro", "panic_abort", "std"]
+# build-std-features = ["compiler-builtins-mem"]


### PR DESCRIPTION
Rust std library's `panic!` and `println!` macros write to STDOUT or STDERR via system call. This was missing from the PAL ABI.

Moreover the extern functions for std library use should never use macros like `todo!(), unimplemented!()` since these may in turn call other system functions for panic handling, which leads to re-entrancy and ultimately stack overflow from infinite panic-ing loops.