### PR TITLE
chore: `io::print` should not newline

### DIFF
--- a/crates/toolchain/axvm/src/io.rs
+++ b/crates/toolchain/axvm/src/io.rs
@@ -86,7 +86,12 @@ pub fn reveal(x: u32, index: usize) {
 #[allow(unused_variables)]
 pub fn print<S: AsRef<str>>(s: S) {
     #[cfg(all(not(target_os = "zkvm"), feature = "std"))]
-    println!("{}", s.as_ref());
+    print!("{}", s.as_ref());
     #[cfg(target_os = "zkvm")]
     axvm_rv32im_guest::print_str_from_bytes(s.as_ref().as_bytes());
+}
+
+pub fn println<S: AsRef<str>>(s: S) {
+    print(s);
+    print("\n");
 }

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -563,7 +563,7 @@ mod phantom {
                 })
                 .collect::<eyre::Result<Vec<u8>>>()?;
             let peeked_str = String::from_utf8(bytes)?;
-            println!("{peeked_str}");
+            print!("{peeked_str}");
             Ok(())
         }
     }


### PR DESCRIPTION
For compatibility with how Rust std lib uses print.