### PR TITLE
[feat] Add Halo2 Proving Key into axvm-sdk

### DIFF
--- a/.github/workflows/axvm-sdk.yml
+++ b/.github/workflows/axvm-sdk.yml
@@ -72,4 +72,4 @@ jobs:
         working-directory: crates/axvm-sdk
         run: |
           export RUST_BACKTRACE=1
-          cargo nextest run --cargo-profile=fast --test-threads=4 --features parallel,static-verifier
+          cargo nextest run --cargo-profile=fast --test-threads=2 --features parallel

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -176,8 +176,6 @@ jobs:
           echo "E2E_BENCH=${E2E_BENCH}" >> $GITHUB_ENV
 
           if [[ "${E2E_BENCH}" == "true" ]]; then
-            echo "Adding static-verifier feature flag"
-            echo "FEATURE_FLAGS=${FEATURE_FLAGS},static-verifier" >> $GITHUB_ENV
             ROOT_ARG="--root_log_blowup ${{ inputs.root_log_blowup }}"
             INTERNAL_ARG="--internal_log_blowup ${{ inputs.internal_log_blowup }}"
             echo "INPUT_ARGS=${ROOT_ARG} ${INTERNAL_ARG} ${INPUT_ARGS}" >> $GITHUB_ENV

--- a/crates/axvm-sdk/Cargo.toml
+++ b/crates/axvm-sdk/Cargo.toml
@@ -20,7 +20,7 @@ axvm-pairing-circuit = { workspace = true }
 axvm-pairing-transpiler = { workspace = true }
 axvm-native-circuit = { workspace = true }
 axvm-native-compiler = { workspace = true }
-axvm-native-recursion = { workspace = true }
+axvm-native-recursion = { workspace = true, features = ["static-verifier"] }
 axvm-rv32im-circuit = { workspace = true }
 axvm-rv32im-transpiler = { workspace = true }
 axvm-transpiler = { workspace = true }
@@ -44,6 +44,5 @@ tracing.workspace = true
 [features]
 default = ["parallel"]
 bench-metrics = ["axvm-native-recursion/bench-metrics"]
-static-verifier = ["axvm-native-recursion/static-verifier"]
 parallel = ["axvm-circuit/parallel"]
 test-utils = ["axvm-circuit/test-utils"]

--- a/crates/axvm-sdk/src/config.rs
+++ b/crates/axvm-sdk/src/config.rs
@@ -53,6 +53,22 @@ pub struct AggConfig {
     pub compiler_options: CompilerOptions,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Halo2Config {
+    /// Log degree for the outer recursion verifier circuit.
+    pub verifier_k: usize,
+    /// If not specified, keygen will tune wrapper_k automatically.
+    pub wrapper_k: Option<usize>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct FullAggConfig {
+    /// STARK aggregation config
+    pub agg_config: AggConfig,
+    /// STARK-to-SNARK and SNARK-to-SNARK aggregation config
+    pub halo2_config: Halo2Config,
+}
+
 #[derive(Builder, Clone, Debug)]
 pub struct SdkVmConfig {
     pub system: SystemConfig,

--- a/crates/axvm-sdk/src/io.rs
+++ b/crates/axvm-sdk/src/io.rs
@@ -1,19 +1,10 @@
 use std::collections::VecDeque;
 
-use ax_stark_sdk::p3_bn254_fr::Bn254Fr;
 use axvm_circuit::arch::Streams;
 use p3_field::AbstractField;
 use serde::{Deserialize, Serialize};
 
 use crate::F;
-
-pub(crate) type Fr = Bn254Fr;
-
-#[derive(Clone, Deserialize, Serialize)]
-pub struct EvmProof {
-    pub instances: Vec<Vec<Fr>>,
-    pub proof: Vec<u8>,
-}
 
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct StdIn {

--- a/crates/axvm-sdk/src/lib.rs
+++ b/crates/axvm-sdk/src/lib.rs
@@ -19,9 +19,10 @@ use axvm_circuit::{
     prover::ContinuationVmProof,
     system::program::trace::AxVmCommittedExe,
 };
-#[cfg(feature = "static-verifier")]
-use axvm_native_recursion::halo2::verifier::Halo2VerifierCircuit;
-use axvm_native_recursion::types::InnerConfig;
+use axvm_native_recursion::{
+    halo2::{verifier::Halo2VerifierProvingKey, EvmProof},
+    types::InnerConfig,
+};
 use axvm_transpiler::{elf::Elf, transpiler::Transpiler};
 use bincode::{deserialize, serialize};
 use config::{AggConfig, AppConfig};
@@ -33,7 +34,6 @@ use prover::{generate_leaf_committed_exe, StarkProver};
 pub mod commit;
 pub mod config;
 pub mod prover;
-#[cfg(feature = "static-verifier")]
 pub mod static_verifier;
 
 pub mod keygen;
@@ -169,15 +169,13 @@ impl Sdk {
         Ok((agg_pk, leaf_exe))
     }
 
-    #[cfg(feature = "static-verifier")]
     pub fn generate_static_verifier_circuit(
         &self,
         _agg_pk: AggProvingKey,
-    ) -> Result<Halo2VerifierCircuit> {
+    ) -> Result<Halo2VerifierProvingKey> {
         todo!()
     }
 
-    #[cfg(feature = "static-verifier")]
     #[allow(clippy::too_many_arguments)]
     pub fn generate_e2e_proof<VC: VmConfig<F>, P: AsRef<Path>>(
         &self,
@@ -185,7 +183,7 @@ impl Sdk {
         _app_exe: Arc<AxVmCommittedExe<SC>>,
         _agg_pk: AggProvingKey,
         _leaf_exe: Arc<AxVmCommittedExe<SC>>,
-        _static_verifier: Halo2VerifierCircuit,
+        _static_verifier: Halo2VerifierProvingKey,
         _inputs: StdIn,
         _output_path: Option<P>,
     ) -> Result<EvmProof>
@@ -196,12 +194,10 @@ impl Sdk {
         todo!()
     }
 
-    #[cfg(feature = "static-verifier")]
     pub fn load_e2e_proof_from_file<P: AsRef<Path>>(&self, _e2e_proof_path: P) -> Result<EvmProof> {
         todo!()
     }
 
-    #[cfg(feature = "static-verifier")]
     pub fn generate_snark_verifier_contract<VC: VmConfig<F>, P: AsRef<Path>>(
         &self,
         _evm_proof: EvmProof,
@@ -216,7 +212,6 @@ impl Sdk {
         todo!()
     }
 
-    #[cfg(feature = "static-verifier")]
     pub fn evm_verify_snark<P: AsRef<Path>>(
         &self,
         _evm_proof: EvmProof,

--- a/crates/axvm-sdk/src/prover/halo2.rs
+++ b/crates/axvm-sdk/src/prover/halo2.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use ax_stark_sdk::ax_stark_backend::prover::types::Proof;
+use axvm_native_compiler::prelude::Witness;
+use axvm_native_recursion::{
+    halo2::{utils::read_params, EvmProof, Halo2Params},
+    witness::Witnessable,
+};
+
+use crate::{keygen::Halo2ProvingKey, OuterSC};
+pub struct Halo2Prover {
+    halo2_pk: Halo2ProvingKey,
+    verifier_srs: Arc<Halo2Params>,
+    wrapper_srs: Arc<Halo2Params>,
+}
+
+impl Halo2Prover {
+    pub fn new(halo2_pk: Halo2ProvingKey) -> Self {
+        let verifier_k = halo2_pk.verifier.pinning.metadata.config_params.k;
+        let wrapper_k = halo2_pk.wrapper.pinning.metadata.config_params.k;
+        let verifier_srs = read_params(verifier_k as u32);
+        let wrapper_srs = if verifier_k != wrapper_k {
+            read_params(wrapper_k as u32)
+        } else {
+            verifier_srs.clone()
+        };
+        Self {
+            halo2_pk,
+            verifier_srs,
+            wrapper_srs,
+        }
+    }
+    pub fn prove_for_evm(&self, root_proof: &Proof<OuterSC>) -> EvmProof {
+        let mut witness = Witness::default();
+        root_proof.write(&mut witness);
+        let snark = self
+            .halo2_pk
+            .verifier
+            .prove_with_loaded_params(&self.verifier_srs, witness);
+        self.halo2_pk
+            .wrapper
+            .prove_for_evm_with_loaded_params(&self.wrapper_srs, snark)
+    }
+}

--- a/crates/axvm-sdk/src/prover/mod.rs
+++ b/crates/axvm-sdk/src/prover/mod.rs
@@ -32,7 +32,9 @@ use crate::{
 
 mod exe;
 pub use exe::*;
+pub mod halo2;
 mod root;
+
 pub use root::*;
 
 const DEFAULT_NUM_CHILDREN_LEAF: usize = 2;

--- a/crates/axvm-sdk/src/static_verifier/mod.rs
+++ b/crates/axvm-sdk/src/static_verifier/mod.rs
@@ -14,7 +14,7 @@ use axvm_native_recursion::{
     config::outer::{new_from_outer_multi_vk, OuterConfig},
     digest::DigestVariable,
     fri::TwoAdicFriPcsVariable,
-    halo2::{verifier::Halo2VerifierCircuit, DslOperations, Halo2Prover},
+    halo2::{verifier::Halo2VerifierProvingKey, DslOperations, Halo2Prover},
     hints::Hintable,
     stark::StarkVerifier,
     utils::const_fri_config,
@@ -38,11 +38,11 @@ impl RootVerifierProvingKey {
         &self,
         halo2_k: usize,
         root_proof: Proof<OuterSC>,
-    ) -> Halo2VerifierCircuit {
+    ) -> Halo2VerifierProvingKey {
         let mut witness = Witness::default();
         root_proof.write(&mut witness);
         let dsl_operations = build_static_verifier_operations(self, &root_proof);
-        Halo2VerifierCircuit {
+        Halo2VerifierProvingKey {
             pinning: Halo2Prover::keygen(halo2_k, dsl_operations.clone(), witness),
             dsl_ops: dsl_operations,
         }

--- a/extensions/native/recursion/src/halo2/testing_utils.rs
+++ b/extensions/native/recursion/src/halo2/testing_utils.rs
@@ -12,7 +12,7 @@ use crate::{
     config::outer::new_from_outer_multi_vk,
     halo2::{
         utils::sort_chips,
-        verifier::{generate_halo2_verifier_circuit, Halo2VerifierCircuit},
+        verifier::{generate_halo2_verifier_proving_key, Halo2VerifierProvingKey},
     },
     witness::Witnessable,
 };
@@ -20,7 +20,7 @@ use crate::{
 pub fn run_static_verifier_test(
     test_proof_input: ProofInputForTest<BabyBearPoseidon2OuterConfig>,
     fri_params: FriParameters,
-) -> (Halo2VerifierCircuit, Snark) {
+) -> (Halo2VerifierProvingKey, Snark) {
     let test_proof_input = ProofInputForTest {
         per_air: sort_chips(test_proof_input.per_air),
     };
@@ -40,7 +40,7 @@ pub fn run_static_verifier_test(
     )
     .entered();
     let stark_verifier_circuit =
-        generate_halo2_verifier_circuit(21, advice, &vparams.fri_params, &vparams.data.proof);
+        generate_halo2_verifier_proving_key(21, advice, &vparams.fri_params, &vparams.data.proof);
     info_span.exit();
 
     let info_span = tracing::info_span!(

--- a/extensions/native/recursion/src/halo2/tests/mod.rs
+++ b/extensions/native/recursion/src/halo2/tests/mod.rs
@@ -20,7 +20,7 @@ use snark_verifier_sdk::{
 use crate::{
     config::outer::OuterConfig,
     halo2::{
-        utils::gen_kzg_params, wrapper::Halo2WrapperCircuit, CircuitBuilderStage::Prover,
+        utils::gen_kzg_params, wrapper::Halo2WrapperProvingKey, CircuitBuilderStage::Prover,
         DslOperations, Halo2Prover, Halo2ProvingMetadata, Halo2ProvingPinning,
     },
     utils::{reduce_32, split_32},
@@ -163,7 +163,7 @@ fn test_split_32() {
 #[test]
 fn test_wrapper_select_k() {
     let (dummy_snark, _, _) = snarks_dummy_circuit();
-    let wrapper_k = Halo2WrapperCircuit::select_k(dummy_snark);
+    let wrapper_k = Halo2WrapperProvingKey::select_k(dummy_snark);
     assert_eq!(wrapper_k, 22);
 }
 

--- a/extensions/native/recursion/src/halo2/utils.rs
+++ b/extensions/native/recursion/src/halo2/utils.rs
@@ -24,9 +24,11 @@ use snark_verifier_sdk::{
     NativeLoader, PlonkVerifier, Snark, SHPLONK,
 };
 
-static TESTING_KZG_PARAMS_23: Lazy<ParamsKZG<Bn256>> = Lazy::new(|| gen_kzg_params(23));
+use crate::halo2::Halo2Params;
 
-pub(crate) fn gen_kzg_params(k: u32) -> ParamsKZG<Bn256> {
+static TESTING_KZG_PARAMS_23: Lazy<Halo2Params> = Lazy::new(|| gen_kzg_params(23));
+
+pub(crate) fn gen_kzg_params(k: u32) -> Halo2Params {
     let mut rng = StdRng::seed_from_u64(42);
     ParamsKZG::setup(k, &mut rng)
 }
@@ -51,10 +53,10 @@ lazy_static! {
           }
        "#).unwrap();
     /// Hacking because of bad interface. This is to construct a fake KZG params to pass Svk(which only requires ParamsKZG.g[0]) to AggregationCircuit.
-    static ref FAKE_KZG_PARAMS: ParamsKZG<Bn256> = KZGCommitmentScheme::new_params(1);
+    static ref FAKE_KZG_PARAMS: Halo2Params = KZGCommitmentScheme::new_params(1);
 }
 
-pub static KZG_PARAMS_FOR_SVK: Lazy<ParamsKZG<Bn256>> = Lazy::new(|| {
+pub static KZG_PARAMS_FOR_SVK: Lazy<Halo2Params> = Lazy::new(|| {
     if std::env::var("RANDOM_SRS").is_ok() {
         read_params(1).as_ref().clone()
     } else {
@@ -62,7 +64,7 @@ pub static KZG_PARAMS_FOR_SVK: Lazy<ParamsKZG<Bn256>> = Lazy::new(|| {
     }
 });
 
-fn build_kzg_params_for_svk(g: G1Affine) -> ParamsKZG<Bn256> {
+fn build_kzg_params_for_svk(g: G1Affine) -> Halo2Params {
     FAKE_KZG_PARAMS.from_parts(
         1,
         vec![g],
@@ -85,7 +87,7 @@ pub(crate) fn verify_snark(dk: &KzgDecidingKey<Bn256>, snark: &Snark) {
 
 /// When `RANDOM_SRS` is set, this function will return a random params which should only be used
 /// for testing purpose.
-pub(crate) fn read_params(k: u32) -> Arc<ParamsKZG<Bn256>> {
+pub fn read_params(k: u32) -> Arc<Halo2Params> {
     if std::env::var("RANDOM_SRS").is_ok() {
         let mut ret = TESTING_KZG_PARAMS_23.clone();
         ret.downsize(k);

--- a/extensions/native/recursion/src/halo2/verifier.rs
+++ b/extensions/native/recursion/src/halo2/verifier.rs
@@ -8,37 +8,51 @@ use snark_verifier_sdk::Snark;
 
 use crate::{
     config::outer::OuterConfig,
-    halo2::{DslOperations, Halo2Prover, Halo2ProvingPinning},
+    halo2::{DslOperations, Halo2Params, Halo2Prover, Halo2ProvingPinning},
     stark::outer::build_circuit_verify_operations,
     types::MultiStarkVerificationAdvice,
     witness::Witnessable,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Halo2VerifierCircuit {
+pub struct Halo2VerifierProvingKey {
     pub pinning: Halo2ProvingPinning,
     pub dsl_ops: DslOperations<OuterConfig>,
 }
 
 /// Generate a Halo2 verifier circuit for a given stark.
-pub fn generate_halo2_verifier_circuit(
+pub fn generate_halo2_verifier_proving_key(
     halo2_k: usize,
     advice: MultiStarkVerificationAdvice<OuterConfig>,
     fri_params: &FriParameters,
     proof: &Proof<BabyBearPoseidon2OuterConfig>,
-) -> Halo2VerifierCircuit {
+) -> Halo2VerifierProvingKey {
     let mut witness = Witness::default();
     proof.write(&mut witness);
     let dsl_operations = build_circuit_verify_operations(advice, fri_params, proof);
-    Halo2VerifierCircuit {
+    Halo2VerifierProvingKey {
         pinning: Halo2Prover::keygen(halo2_k, dsl_operations.clone(), witness),
         dsl_ops: dsl_operations,
     }
 }
 
-impl Halo2VerifierCircuit {
+impl Halo2VerifierProvingKey {
     pub fn prove(&self, witness: Witness<OuterConfig>) -> Snark {
         Halo2Prover::prove(
+            self.pinning.metadata.config_params.clone(),
+            self.pinning.metadata.break_points.clone(),
+            &self.pinning.pk,
+            self.dsl_ops.clone(),
+            witness,
+        )
+    }
+    pub fn prove_with_loaded_params(
+        &self,
+        params: &Halo2Params,
+        witness: Witness<OuterConfig>,
+    ) -> Snark {
+        Halo2Prover::prove_with_loaded_params(
+            params,
             self.pinning.metadata.config_params.clone(),
             self.pinning.metadata.break_points.clone(),
             &self.pinning.pk,


### PR DESCRIPTION
- Add `Halo2ProvingKey` for static verifier and wrapper. Open to any better name.
- Add `FullAggProvingKey` for both Agg stark proving key and halo2 proving key. Open to any better name.
- Remove `static-verifier` feature in `axvm-sdk` which should always need it.
- No test yet because `StarkProver` looks weird right now. Will refactor it in the next PR.