### PR TITLE
[refactor] Add Halo2ParamsReader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,7 @@ dependencies = [
  "axvm-circuit",
  "axvm-keccak256-circuit",
  "axvm-keccak256-transpiler",
+ "axvm-native-recursion",
  "axvm-rv32im-transpiler",
  "axvm-sdk",
  "axvm-transpiler",

--- a/crates/axvm-sdk/src/prover/halo2.rs
+++ b/crates/axvm-sdk/src/prover/halo2.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ax_stark_sdk::ax_stark_backend::prover::types::Proof;
 use axvm_native_compiler::prelude::Witness;
 use axvm_native_recursion::{
-    halo2::{utils::read_params, EvmProof, Halo2Params},
+    halo2::{utils::Halo2ParamsReader, EvmProof, Halo2Params},
     witness::Witnessable,
 };
 use tracing::info_span;
@@ -16,15 +16,11 @@ pub struct Halo2Prover {
 }
 
 impl Halo2Prover {
-    pub fn new(halo2_pk: Halo2ProvingKey) -> Self {
+    pub fn new(reader: &impl Halo2ParamsReader, halo2_pk: Halo2ProvingKey) -> Self {
         let verifier_k = halo2_pk.verifier.pinning.metadata.config_params.k;
         let wrapper_k = halo2_pk.wrapper.pinning.metadata.config_params.k;
-        let verifier_srs = read_params(verifier_k as u32);
-        let wrapper_srs = if verifier_k != wrapper_k {
-            read_params(wrapper_k as u32)
-        } else {
-            verifier_srs.clone()
-        };
+        let verifier_srs = reader.read_params(verifier_k);
+        let wrapper_srs = reader.read_params(wrapper_k);
         Self {
             halo2_pk,
             verifier_srs,
@@ -34,15 +30,12 @@ impl Halo2Prover {
     pub fn prove_for_evm(&self, root_proof: &Proof<RootSC>) -> EvmProof {
         let mut witness = Witness::default();
         root_proof.write(&mut witness);
-        let snark = info_span!("halo2 outer recursion", group = "halo2_outer").in_scope(|| {
-            self.halo2_pk
-                .verifier
-                .prove_with_loaded_params(&self.verifier_srs, witness)
-        });
+        let snark = info_span!("halo2 outer recursion", group = "halo2_outer")
+            .in_scope(|| self.halo2_pk.verifier.prove(&self.verifier_srs, witness));
         info_span!("halo2_wrapper", group = "halo2_wrapper").in_scope(|| {
             self.halo2_pk
                 .wrapper
-                .prove_for_evm_with_loaded_params(&self.wrapper_srs, snark)
+                .prove_for_evm(&self.wrapper_srs, snark)
         })
     }
 }

--- a/crates/axvm-sdk/src/prover/mod.rs
+++ b/crates/axvm-sdk/src/prover/mod.rs
@@ -10,6 +10,8 @@ mod agg;
 pub use agg::*;
 mod app;
 pub use app::*;
+use axvm_native_recursion::halo2::utils::Halo2ParamsReader;
+
 mod halo2;
 #[allow(unused_imports)]
 pub use halo2::*;
@@ -33,6 +35,7 @@ pub struct ContinuationProver<VC> {
 
 impl<VC> ContinuationProver<VC> {
     pub fn new(
+        reader: &impl Halo2ParamsReader,
         app_pk: Arc<AppProvingKey<VC>>,
         app_committed_exe: Arc<NonRootCommittedExe>,
         agg_pk: AggProvingKey,
@@ -47,7 +50,7 @@ impl<VC> ContinuationProver<VC> {
         let stark_prover = StarkProver::new(app_pk, app_committed_exe, agg_stark_pk);
         Self {
             stark_prover,
-            halo2_prover: Halo2Prover::new(halo2_pk),
+            halo2_prover: Halo2Prover::new(reader, halo2_pk),
         }
     }
 

--- a/crates/axvm-sdk/src/static_verifier/mod.rs
+++ b/crates/axvm-sdk/src/static_verifier/mod.rs
@@ -13,7 +13,7 @@ use axvm_native_recursion::{
     config::outer::{new_from_outer_multi_vk, OuterConfig},
     digest::DigestVariable,
     fri::TwoAdicFriPcsVariable,
-    halo2::{verifier::Halo2VerifierProvingKey, DslOperations, Halo2Prover},
+    halo2::{verifier::Halo2VerifierProvingKey, DslOperations, Halo2Params, Halo2Prover},
     hints::Hintable,
     stark::StarkVerifier,
     utils::const_fri_config,
@@ -34,14 +34,14 @@ impl RootVerifierProvingKey {
     /// Keygen the static verifier for this root verifier.
     pub fn keygen_static_verifier(
         &self,
-        halo2_k: usize,
+        params: &Halo2Params,
         root_proof: Proof<RootSC>,
     ) -> Halo2VerifierProvingKey {
         let mut witness = Witness::default();
         root_proof.write(&mut witness);
         let dsl_operations = build_static_verifier_operations(self, &root_proof);
         Halo2VerifierProvingKey {
-            pinning: Halo2Prover::keygen(halo2_k, dsl_operations.clone(), witness),
+            pinning: Halo2Prover::keygen(params, dsl_operations.clone(), witness),
             dsl_ops: dsl_operations,
         }
     }

--- a/crates/cargo-axiom/Cargo.toml
+++ b/crates/cargo-axiom/Cargo.toml
@@ -17,6 +17,7 @@ axvm-build = { workspace = true }
 axvm-transpiler = { workspace = true }
 axvm-circuit = { workspace = true }
 axvm-keccak256-circuit = { workspace = true }
+axvm-native-recursion = { workspace = true, features = ["static-verifier"] }
 axvm-rv32im-transpiler = { workspace = true }
 axvm-sdk = { workspace = true }
 axvm-keccak256-transpiler = { workspace = true }

--- a/crates/cargo-axiom/src/commands/prove.rs
+++ b/crates/cargo-axiom/src/commands/prove.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
+use axvm_native_recursion::halo2::utils::CacheHalo2ParamsReader;
 use axvm_sdk::{
     commit::AppExecutionCommit,
     config::SdkVmConfig,
@@ -74,12 +75,15 @@ impl ProveCmd {
                 input,
                 output,
             } => {
+                // FIXME: read path from config.
+                let params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
                 let (app_pk, committed_exe, input) = Self::prepare_execution(app_pk, exe, input)?;
                 println!("Generating EVM proof, this may take a lot of compute and memory...");
                 let agg_pk = read_agg_pk_from_file(AGG_PK_PATH).map_err(|e| {
                     eyre::eyre!("Failed to read aggregation proving key: {}\nPlease run 'cargo axiom evm-proving-setup' first", e)
                 })?;
-                let evm_proof = Sdk.generate_evm_proof(app_pk, committed_exe, agg_pk, input)?;
+                let evm_proof =
+                    Sdk.generate_evm_proof(&params_reader, app_pk, committed_exe, agg_pk, input)?;
                 write_evm_proof_to_file(evm_proof, output)?;
             }
         }

--- a/crates/cargo-axiom/src/commands/setup.rs
+++ b/crates/cargo-axiom/src/commands/setup.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use axvm_native_recursion::halo2::utils::CacheHalo2ParamsReader;
 use axvm_sdk::{
     config::AggConfig,
     fs::{write_agg_pk_to_file, write_evm_verifier_to_file},
@@ -24,9 +25,11 @@ impl EvmProvingSetupCmd {
             println!("Aggregation proving key and verifier contract already exist");
             return Ok(());
         }
+        // FIXME: read path from config.
+        let params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
         let agg_config = AggConfig::default();
-        let agg_pk = Sdk.agg_keygen(agg_config)?;
-        let verifier = Sdk.generate_snark_verifier_contract(&agg_pk)?;
+        let agg_pk = Sdk.agg_keygen(agg_config, &params_reader)?;
+        let verifier = Sdk.generate_snark_verifier_contract(&params_reader, &agg_pk)?;
         write_agg_pk_to_file(agg_pk, AGG_PK_PATH)?;
         write_evm_verifier_to_file(verifier, VERIFIER_PATH)?;
         Ok(())

--- a/extensions/native/recursion/src/halo2/testing_utils.rs
+++ b/extensions/native/recursion/src/halo2/testing_utils.rs
@@ -11,7 +11,7 @@ use snark_verifier_sdk::Snark;
 use crate::{
     config::outer::new_from_outer_multi_vk,
     halo2::{
-        utils::sort_chips,
+        utils::{sort_chips, CacheHalo2ParamsReader, Halo2ParamsReader},
         verifier::{generate_halo2_verifier_proving_key, Halo2VerifierProvingKey},
     },
     witness::Witnessable,
@@ -21,6 +21,9 @@ pub fn run_static_verifier_test(
     test_proof_input: ProofInputForTest<BabyBearPoseidon2RootConfig>,
     fri_params: FriParameters,
 ) -> (Halo2VerifierProvingKey, Snark) {
+    let k = 21;
+    let halo2_params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
+    let params = &halo2_params_reader.read_params(k);
     let test_proof_input = ProofInputForTest {
         per_air: sort_chips(test_proof_input.per_air),
     };
@@ -39,8 +42,12 @@ pub fn run_static_verifier_test(
         step = "static_verifier_keygen"
     )
     .entered();
-    let stark_verifier_circuit =
-        generate_halo2_verifier_proving_key(21, advice, &vparams.fri_params, &vparams.data.proof);
+    let stark_verifier_circuit = generate_halo2_verifier_proving_key(
+        params,
+        advice,
+        &vparams.fri_params,
+        &vparams.data.proof,
+    );
     info_span.exit();
 
     let info_span = tracing::info_span!(
@@ -50,7 +57,7 @@ pub fn run_static_verifier_test(
     .entered();
     let mut witness = Witness::default();
     vparams.data.proof.write(&mut witness);
-    let static_verifier_snark = stark_verifier_circuit.prove(witness);
+    let static_verifier_snark = stark_verifier_circuit.prove(params, witness);
     info_span.exit();
     (stark_verifier_circuit, static_verifier_snark)
 }


### PR DESCRIPTION
**Breaking change** to SDK APIs. Replace`read_params` with `Halo2ParamsReader`.

closes INT-2855
