### PR TITLE
bench: switch to lto = thin for faster compiles

### DIFF
--- a/benchmarks/programs/ecrecover/Cargo.toml
+++ b/benchmarks/programs/ecrecover/Cargo.toml
@@ -25,4 +25,5 @@ std = ["openvm/std", "k256/std", "revm-precompile/std", "alloy-primitives/std"]
 
 [profile.release]
 panic = "abort"
-lto = "fat"     # decrease binary size
+lto = "thin"    # faster compile time
+debug = 2       # for flamegraph

--- a/ci/scripts/bench.py
+++ b/ci/scripts/bench.py
@@ -18,9 +18,9 @@ def run_cargo_command(
     memory_allocator,
     output_path,
 ):
-    # Command to run
+    # Command to run (for best performance but slower builds, use --profile maxperf)
     command = [
-        "cargo", "run", "--no-default-features", "--bin", bin_name, "--profile", "maxperf", "--features", ",".join(feature_flags), "--"
+        "cargo", "run", "--no-default-features", "--bin", bin_name, "--profile", "release", "--features", ",".join(feature_flags), "--"
     ]
 
     if app_log_blowup is not None:


### PR DESCRIPTION
Both in guest program compilation and also host VM compilation