### PR TITLE
[chore] Remove unused `sw_init` which doesn't make sense anyway...

### DIFF
--- a/crates/toolchain/tests/programs/examples/pairing_check.rs
+++ b/crates/toolchain/tests/programs/examples/pairing_check.rs
@@ -28,10 +28,6 @@ mod bn254 {
         Fp2 { mod_idx = 0 },
     }
 
-    openvm_ecc_sw_setup::sw_init! {
-        Fp,
-    }
-
     pub fn test_pairing_check(io: &[u8]) {
         setup_0();
         setup_all_complex_extensions();
@@ -70,10 +66,6 @@ mod bls12_381 {
 
     openvm_algebra_complex_macros::complex_init! {
         Fp2 { mod_idx = 0 },
-    }
-
-    openvm_ecc_sw_setup::sw_init! {
-        Fp,
     }
 
     pub fn test_pairing_check(io: &[u8]) {


### PR DESCRIPTION
...and can confuse people (including myself) into wondering why this even works.

For the context:
- we have `sw_declare!`d a type `Bn254G1Affine` with underlying `IntMod` type `Bn254Fp` -- it needs some functions like `sw_add_ne_extern_Bn254Fp` to be defined in order to work,
- we then `pub type Fp = Bn254Fp`,
- then, in the tests, we use `sw_init! { Fp }` -- which defines functions called like `sw_add_ne_extern_Fp`;
- this may cast an impression of types `Fp` and `Bn254Fp` being interchangeable in all contexts, while in reality we just didn't need to `sw_init` in this test at all.