### PR TITLE
[chore] Rename output dir & default app config

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -61,10 +61,10 @@ printf '\xA0\x86\x01\x00\x00\x00\x00\x00' | cargo run --features std
 #### Local Builds
 
 By default, if you run `cargo build` or `cargo run` from the guest program root directory, it will
-build with target set to your **host** machine, while running `bench_from_exe` in the bench script will build with target set to `openvm`. If you want to directly build for `openvm` (more specifically a special RISC-V target), copy the `.cargo` folder from [here](./programs/revm_contract_deployment/.cargo) to the guest program root directory and uncomment the `.cargo/config.toml` file. (This config is equivalent to what the `build_bench_program` function does behind the scenes.) You can then `cargo build` or `cargo build --release` and it will output a RISC-V ELF file to `target/riscv32im-risc0-zkvm-elf/release/*`. You can install [cargo-binutils](https://github.com/rust-embedded/cargo-binutils) to be able to disassemble the ELF file:
+build with target set to your **host** machine, while running `bench_from_exe` in the bench script will build with target set to `openvm`. If you want to directly build for `openvm` (more specifically a special RISC-V target), copy the `.cargo` folder from [here](./programs/revm_contract_deployment/.cargo) to the guest program root directory and uncomment the `.cargo/config.toml` file. (This config is equivalent to what the `build_bench_program` function does behind the scenes.) You can then `cargo build` or `cargo build --release` and it will output a RISC-V ELF file to `target/zkvm-elf/release/*`. You can install [cargo-binutils](https://github.com/rust-embedded/cargo-binutils) to be able to disassemble the ELF file:
 
 ```bash
-rust-objdump -d target/riscv32im-risc0-zkvm-elf/release/openvm-fibonacci-program
+rust-objdump -d target/zkvm-elf/release/openvm-fibonacci-program
 ```
 
 ## Adding a Benchmark to CI

--- a/book/src/advanced-usage/testing-program.md
+++ b/book/src/advanced-usage/testing-program.md
@@ -18,7 +18,7 @@ First to build the guest program:
 cargo axiom build
 ```
 
-This compiles the guest program into an [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) that can be found at `target/riscv32im-risc0-zkvm-elf` directory.
+This compiles the guest program into an [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) that can be found at `target/zkvm-elf` directory.
 Next, a host program is needed to run the ELF with openvm runtime. This is where one can configure the openvm with different parameters. There are a few steps:
 
 ```rust

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -9,7 +9,7 @@ use openvm_sdk::{
 };
 
 use crate::{
-    default::{DEFAULT_APP_PK_PATH, DEFAULT_APP_VK_PATH},
+    default::{default_app_config, DEFAULT_APP_PK_PATH, DEFAULT_APP_VK_PATH},
     util::read_to_struct_toml,
 };
 
@@ -17,7 +17,7 @@ use crate::{
 #[command(name = "keygen", about = "Generate an application proving key")]
 pub struct KeygenCmd {
     #[clap(long, action, help = "Path to app config TOML file")]
-    config: PathBuf,
+    config: Option<PathBuf>,
 
     #[clap(
         long,
@@ -38,7 +38,11 @@ pub struct KeygenCmd {
 
 impl KeygenCmd {
     pub fn run(&self) -> Result<()> {
-        let app_config: AppConfig<SdkVmConfig> = read_to_struct_toml(&self.config)?;
+        let app_config: AppConfig<SdkVmConfig> = if let Some(config) = self.config.as_ref() {
+            read_to_struct_toml(config)?
+        } else {
+            default_app_config()
+        };
         let app_pk = Sdk.app_keygen(app_config)?;
         write_app_vk_to_file(app_pk.get_vk(), &self.vk_output)?;
         write_app_pk_to_file(app_pk, &self.output)?;

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -1,3 +1,6 @@
+use openvm_sdk::config::{AppConfig, SdkVmConfig};
+use openvm_stark_sdk::config::FriParameters;
+
 pub const DEFAULT_MANIFEST_DIR: &str = ".";
 
 pub const DEFAULT_AGG_PK_PATH: &str = concat!(env!("HOME"), "/.openvm/agg.pk");
@@ -8,3 +11,16 @@ pub const DEFAULT_APP_PK_PATH: &str = "./openvm/app.pk";
 pub const DEFAULT_APP_VK_PATH: &str = "./openvm/app.vk";
 pub const DEFAULT_APP_PROOF_PATH: &str = "./openvm/app.proof";
 pub const DEFAULT_EVM_PROOF_PATH: &str = "./openvm/evm.proof";
+
+pub fn default_app_config() -> AppConfig<SdkVmConfig> {
+    AppConfig {
+        app_fri_params: FriParameters::standard_with_100_bits_conjectured_security(2),
+        app_vm_config: SdkVmConfig::builder()
+            .system(Default::default())
+            .rv32i(Default::default())
+            .rv32m(Default::default())
+            .build(),
+        leaf_fri_params: FriParameters::standard_with_100_bits_conjectured_security(2).into(),
+        compiler_options: Default::default(),
+    }
+}

--- a/crates/toolchain/build/src/lib.rs
+++ b/crates/toolchain/build/src/lib.rs
@@ -72,7 +72,7 @@ pub fn get_target_dir(manifest_path: impl AsRef<Path>) -> PathBuf {
 pub fn get_dir_with_profile(target_dir: impl AsRef<Path>, profile: &str) -> PathBuf {
     target_dir
         .as_ref()
-        .join("riscv32im-risc0-zkvm-elf")
+        .join("zkvm-elf")
         .join(profile)
 }
 
@@ -120,7 +120,7 @@ pub fn guest_methods(
         .map(|target| {
             target_dir
                 .as_ref()
-                .join("riscv32im-risc0-zkvm-elf")
+                .join("zkvm-elf")
                 .join(profile)
                 .join(&target.name)
                 .to_path_buf()
@@ -158,7 +158,7 @@ pub fn cargo_command(subcmd: &str, rust_flags: &[&str]) -> Command {
         "+nightly-2024-10-30",
         subcmd,
         "--target",
-        "riscv32im-risc0-zkvm-elf",
+        "zkvm-elf",
     ];
 
     if std::env::var("OPENVM_BUILD_LOCKED").is_ok() {
@@ -308,7 +308,7 @@ pub fn build_guest_package(
     let stderr = child.stderr.take().unwrap();
 
     tty_println(&format!(
-        "{}: Starting build for riscv32im-risc0-zkvm-elf",
+        "{}: Starting build for zkvm-elf",
         pkg.name
     ));
 

--- a/crates/toolchain/openvm/src/pal_abi.rs
+++ b/crates/toolchain/openvm/src/pal_abi.rs
@@ -1,6 +1,6 @@
 /// For rust std library compatibility, we need to define the ABI specified in
 /// <https://github.com/rust-lang/rust/blob/3dc1b9f5c00ca5535505c1ec46ccd43b8d9cfa19/library/std/src/sys/pal/zkvm/abi.rs>
-/// while we are using target = "riscv32im-risc0-zkvm-elf".
+/// while we are using target = "zkvm-elf".
 /// This will be removed once a dedicated rust toolchain is used because OpenVM does not handle system
 /// operations in the same way: there is no operating system and even the standard library should be
 /// directly handled with intrinsics.

--- a/crates/toolchain/tests/programs/.cargo/config.toml
+++ b/crates/toolchain/tests/programs/.cargo/config.toml
@@ -1,8 +1,8 @@
 # # Uncomment to build for openvm
 # [build]
-# target = "riscv32im-risc0-zkvm-elf"
+# target = "zkvm-elf"
 # 
-# [target.riscv32im-risc0-zkvm-elf]
+# [target.zkvm-elf]
 # rustflags = ["-C", "passes=lower-atomic", "-C", "link-arg=-Ttext=0x002008000"]
 # 
 # [unstable]

--- a/crates/toolchain/tests/programs/README.md
+++ b/crates/toolchain/tests/programs/README.md
@@ -11,7 +11,7 @@ WARNING: to prevent from building for your host machine, make sure you do not ha
 Build example with full command:
 
 ```bash
-cargo +nightly build -Z build-std=alloc,core,proc_macro,panic_abort --target riscv32im-risc0-zkvm-elf --example fibonacci
+cargo +nightly build -Z build-std=alloc,core,proc_macro,panic_abort --target zkvm-elf --example fibonacci
 ```
 
 Also works with just `cargo +nightly build` because we have a `.cargo/config.toml` that specifies the target and unstable build features (if uncommented).
@@ -19,14 +19,14 @@ Also works with just `cargo +nightly build` because we have a `.cargo/config.tom
 After this the ELF will be found via
 
 ```bash
-file target/riscv32im-risc0-zkvm-elf/debug/examples/openvm-fibonacci-program
-target/riscv32im-risc0-zkvm-elf/debug/examples/openvm-fibonacci-program: ELF 32-bit LSB executable, UCB RISC-V, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
+file target/zkvm-elf/debug/examples/openvm-fibonacci-program
+target/zkvm-elf/debug/examples/openvm-fibonacci-program: ELF 32-bit LSB executable, UCB RISC-V, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
 To disassemble the ELF to read the instructions, [install cargo-binutils](https://github.com/rust-embedded/cargo-binutils) and run
 
 ```bash
-rust-objdump -d target/riscv32im-risc0-zkvm-elf/debug/examples/openvm-fibonacci-program
+rust-objdump -d target/zkvm-elf/debug/examples/openvm-fibonacci-program
 ```
 
 where `-d` is short for `--disassemble`.

--- a/crates/toolchain/tests/src/utils.rs
+++ b/crates/toolchain/tests/src/utils.rs
@@ -56,7 +56,7 @@ pub fn build_example_program_at_path_with_features<S: AsRef<str>>(
         .map(|target| {
             target_dir
                 .as_ref()
-                .join("riscv32im-risc0-zkvm-elf")
+                .join("zkvm-elf")
                 .join(profile)
                 .join("examples")
                 .join(&target.name)


### PR DESCRIPTION
- Rename output dir from `riscv32im-risc0-zkvm-elf` to `zkvm-elf`.
- Have a default AppConfig if not speicified.