### PR TITLE
[book] small updates

### DIFF
--- a/book/src/custom-extensions/pairing.md
+++ b/book/src/custom-extensions/pairing.md
@@ -114,6 +114,11 @@ supported_modulus = [
 ]
 ```
 
+Also note that since this is a complicated computation, the `keygen` step requires quite a lot of memory. Run it with `RUST_MIN_STACK` set to a large value, e.g.
+```bash
+RUST_MIN_STACK=8388608 cargo openvm keygen
+```
+
 ### Full example code
 
 This example code contains hardcoded values and no inputs as an example that can be run via the CLI.

--- a/book/src/writing-apps/build.md
+++ b/book/src/writing-apps/build.md
@@ -5,7 +5,7 @@ First let's define some key terms used in cross-compilation:
 - **host** - the machine you're compiling and/or proving on. Note that one can compile and prove on different machines, but they are both called _host_ as they are traditional machine architectures.
 - **guest** - the executable to be run in a different VM architecture (e.g. the OpenVM runtime, or Android app).
 
-There are multiple things happening in the `cargo openvm build` command as in the section [here](./write-program.md). In short, this command compiles on host to an executable for guest target.
+The command `cargo openvm build` compiles the program on host to an executable for guest target.
 It first compiles the program normally on your _host_ platform with RISC-V and then transpiles it to a different target. See here for some explanation of [cross-compilation](https://rust-lang.github.io/rustup/cross-compilation.html).
 Right now we use `riscv32im-risc0-zkvm-elf` target which is available in the [Rust toolchain](https://doc.rust-lang.org/rustc/platform-support/riscv32im-risc0-zkvm-elf.html), but we will contribute an OpenVM target to Rust in the future.
 


### PR DESCRIPTION
- change wording in build, as the reference section changed (no longer running build)
- pairing keygen needs big memory