### PR TITLE
[fix] `build_guest_package` didn't target any specific package, there was no way to build examples with it

### DIFF
--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -60,7 +60,7 @@ pub fn build_bench_program(program_name: &str) -> Result<Elf> {
     let target_dir = tempdir()?;
     // Build guest with default features
     let guest_opts = GuestOptions::default().with_target_dir(target_dir.path());
-    if let Err(Some(code)) = build_guest_package(&pkg, &guest_opts, None) {
+    if let Err(Some(code)) = build_guest_package(&pkg, &guest_opts, None, &None) {
         std::process::exit(code);
     }
     // Assumes the package has a single target binary

--- a/book/src/writing-apps/build.md
+++ b/book/src/writing-apps/build.md
@@ -37,34 +37,24 @@ The following flags are available for the `cargo openvm build` command:
   cargo openvm build --features my_feature
   ```
 
-- `--bin`
+- `--bin <NAME>`
 
-  **Description**: Restricts the build to binary targets. If your project has multiple target types (binaries, libraries, examples, etc.), using `--bin` ensures only binary targets are considered.
-
-  **Usage Example**:
-
-  ```bash
-  cargo openvm build --bin
-  ```
-
-- `--example`
-
-  **Description**: Restricts the build to example targets. Projects often include code samples or demos under the examples directory, and this flag focuses on compiling those.
+  **Description**: Restricts the build to the binary target with the given name, similar to `cargo build --bin <NAME>`. If your project has multiple target types (binaries, libraries, examples, etc.), using `--bin <NAME>` narrows down the build to the binary target with the given name.
 
   **Usage Example**:
 
   ```bash
-  cargo openvm build --example
+  cargo openvm build --bin my_bin
   ```
 
-- `--name <NAME>`
+- `--example <NAME>`
 
-  **Description**: Filters targets by name. Only targets whose names contain the given substring will be built.
+  **Description**: Restricts the build to the example target with the given name, similar to `cargo build --example <NAME>`. Projects often include code samples or demos under the examples directory, and this flag focuses on compiling a specific example.
 
-  **Usage Example**: To build only targets that have `client` in their name:
+  **Usage Example**:
 
   ```bash
-  cargo openvm build --name client
+  cargo openvm build --example my_example
   ```
 
 - `--no-transpile`

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -71,10 +71,10 @@ impl Sdk {
         &self,
         guest_opts: GuestOptions,
         pkg_dir: P,
-        target_filter: &TargetFilter,
+        target_filter: &Option<TargetFilter>,
     ) -> Result<Elf> {
         let pkg = get_package(pkg_dir.as_ref());
-        let target_dir = match build_guest_package(&pkg, &guest_opts, None) {
+        let target_dir = match build_guest_package(&pkg, &guest_opts, None, target_filter) {
             Ok(target_dir) => target_dir,
             Err(Some(code)) => {
                 return Err(eyre::eyre!("Failed to build guest: code = {}", code));

--- a/crates/toolchain/tests/src/utils.rs
+++ b/crates/toolchain/tests/src/utils.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use eyre::Result;
-use openvm_build::{build_guest_package, get_package, is_debug, GuestOptions};
+use openvm_build::{build_guest_package, get_package, is_debug, GuestOptions, TargetFilter};
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE};
 use tempfile::tempdir;
 
@@ -41,10 +41,17 @@ pub fn build_example_program_at_path_with_features<S: AsRef<str>>(
     let target_dir = tempdir()?;
     // Build guest with default features
     let guest_opts = GuestOptions::default()
-        .with_options(["--example", example_name])
         .with_features(features)
         .with_target_dir(target_dir.path());
-    if let Err(Some(code)) = build_guest_package(&pkg, &guest_opts, None) {
+    if let Err(Some(code)) = build_guest_package(
+        &pkg,
+        &guest_opts,
+        None,
+        &Some(TargetFilter {
+            name: example_name.to_string(),
+            kind: "example".to_string(),
+        }),
+    ) {
         std::process::exit(code);
     }
     // Assumes the package has a single target binary


### PR DESCRIPTION
In order to fix it, the signature was also changed. Now `cargo build`

- Doesn't have the `--name` flag,
- Has either `--bin <name>` or `--example <name>` flags (as opposed to previous `--bin` and `--name`),
- Cannot filter just by name,
- `--bin <name>` looks for packages with name _exactly_ `<name>`, as opposed to previous behaviour where it was looking for packages with substring `<name>` (similar to how `cargo test` works); the same about `--example <name>`.

---
Copilot:
This pull request introduces significant changes to the build process and command-line interface (CLI) for building guest packages. The main focus is on enhancing the flexibility of target filtering and improving the handling of example targets.

### Enhancements to Target Filtering:

* [`crates/cli/src/commands/build.rs`](diffhunk://#diff-5cf96c1ea25909290230ffb02f135e8ad2285a6d304f45279d44e1dd4addf911L45-L47): Modified the `BuildArgs` and `BinTypeFilter` structs to replace boolean flags with optional string fields for specifying target names directly. This change allows for more precise filtering of target builds. [[1]](diffhunk://#diff-5cf96c1ea25909290230ffb02f135e8ad2285a6d304f45279d44e1dd4addf911L45-L47) [[2]](diffhunk://#diff-5cf96c1ea25909290230ffb02f135e8ad2285a6d304f45279d44e1dd4addf911L76-R96)
* [`crates/toolchain/build/src/lib.rs`](diffhunk://#diff-3cef689a0974567c454c23f11e0f81c50a333523a745733d02f38e87b7759042R253): Updated the `TargetFilter` struct to use exact target names instead of substrings and adjusted the `build_guest_package` function to accept an optional `TargetFilter`. This improves the specificity of target selection during the build process. [[1]](diffhunk://#diff-3cef689a0974567c454c23f11e0f81c50a333523a745733d02f38e87b7759042R253) [[2]](diffhunk://#diff-3cef689a0974567c454c23f11e0f81c50a333523a745733d02f38e87b7759042R292-R298) [[3]](diffhunk://#diff-3cef689a0974567c454c23f11e0f81c50a333523a745733d02f38e87b7759042L323-R374)

### Handling of Example Targets:

* [`crates/toolchain/build/src/lib.rs`](diffhunk://#diff-3cef689a0974567c454c23f11e0f81c50a333523a745733d02f38e87b7759042L72-R85): Enhanced the `get_dir_with_profile` function to include an additional parameter for handling example targets, ensuring that the correct directory structure is used for examples.
* [`crates/toolchain/tests/src/utils.rs`](diffhunk://#diff-81b84dc1e0bd4a68f5d61a84491cc8357ba4bfdee41f6f4455f02feb497bc1cbL44-R54): Updated the `build_example_program_at_path_with_features` function to utilize the new `TargetFilter` for building example programs, providing better support for example-specific builds.

### Code Adjustments and Refactoring:

* [`benchmarks/src/utils.rs`](diffhunk://#diff-19dffeb7252fc36f09b359a4b803fa0e74978f618734bbacb49deb2a44b4dfefL63-R63): Adjusted the `build_bench_program` function to pass the optional `TargetFilter` when building guest packages, aligning with the new filtering mechanism.
* [`crates/sdk/src/lib.rs`](diffhunk://#diff-d668ed813435f4e1e8ac1287d633435f39d3e1bc3411e7748a394f96ba62a6a6L74-R77): Modified the `Sdk` implementation to handle the optional `TargetFilter` when building guest packages, ensuring compatibility with the updated build process.

### Import Updates:

* [`crates/toolchain/tests/src/utils.rs`](diffhunk://#diff-81b84dc1e0bd4a68f5d61a84491cc8357ba4bfdee41f6f4455f02feb497bc1cbL7-R7): Added the `TargetFilter` import to support the updated target filtering logic in test utilities.