### PR TITLE
chore: fix fibonacci runtime bench

### DIFF
--- a/benchmarks/benches/fibonacci_execute.rs
+++ b/benchmarks/benches/fibonacci_execute.rs
@@ -5,6 +5,7 @@ use openvm_rv32im_circuit::Rv32ImConfig;
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
+use openvm_sdk::StdIn;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use openvm_transpiler::{transpiler::Transpiler, FromElf};
 use pprof::criterion::{Output, PProfProfiler};
@@ -26,7 +27,10 @@ fn benchmark_function(c: &mut Criterion) {
 
     group.bench_function("execute", |b| {
         b.iter(|| {
-            executor.execute(exe.clone(), vec![]).unwrap();
+            let n = 100_000u64;
+            let mut stdin = StdIn::default();
+            stdin.write(&n);
+            executor.execute(exe.clone(), stdin).unwrap();
         })
     });
 


### PR DESCRIPTION
This wasn't updated after some changes because it's not run in CI.