### PR TITLE
feat: vectorize native load store 

### DIFF
--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -116,7 +116,7 @@ fn test_vm_1() {
      */
     let instructions = vec![
         // word[0]_1 <- word[n]_0
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), n, 0, 0, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, n, 0, 1, 0, 0, 0),
         // if word[0]_1 == 0 then pc += 3 * DEFAULT_PC_STEP
         Instruction::from_isize(
             VmOpcode::with_default_offset(NativeBranchEqualOpcode(BEQ)),
@@ -151,7 +151,7 @@ fn test_vm_override_executor_height() {
     let fri_params = FriParameters::standard_fast();
     let e = BabyBearPoseidon2Engine::new(fri_params);
     let program = Program::<BabyBear>::from_instructions(&[
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 4, 0, 0, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 4, 0, 1, 0, 0, 0),
         Instruction::from_isize(VmOpcode::with_default_offset(TERMINATE), 0, 0, 0, 0, 0),
     ]);
     let committed_exe = Arc::new(VmCommittedExe::<BabyBearPoseidon2Config>::commit(
@@ -255,7 +255,7 @@ fn test_vm_1_optional_air() {
     {
         let n = 6;
         let instructions = vec![
-            Instruction::from_isize(VmOpcode::with_default_offset(STOREW), n, 0, 0, 0, 1),
+            Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, n, 0, 1, 0, 0, 0),
             Instruction::large_from_isize(VmOpcode::with_default_offset(SUB), 0, 0, 1, 1, 1, 0, 0),
             Instruction::from_isize(
                 VmOpcode::with_default_offset(NativeBranchEqualOpcode(BNE)),
@@ -384,7 +384,7 @@ fn test_vm_1_persistent() {
 
     let n = 6;
     let instructions = vec![
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), n, 0, 0, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, n, 0, 1, 0, 0, 0),
         Instruction::large_from_isize(VmOpcode::with_default_offset(SUB), 0, 0, 1, 1, 1, 0, 0),
         Instruction::from_isize(
             VmOpcode::with_default_offset(NativeBranchEqualOpcode(BNE)),
@@ -518,7 +518,7 @@ fn test_vm_without_field_arithmetic() {
      */
     let instructions = vec![
         // word[0]_1 <- word[5]_0
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 5, 0, 0, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 5, 0, 1, 0, 0, 0),
         // if word[0]_1 != 4 then pc += 3 * DEFAULT_PC_STEP
         Instruction::from_isize(
             VmOpcode::with_default_offset(NativeBranchEqualOpcode(BNE)),
@@ -558,11 +558,11 @@ fn test_vm_without_field_arithmetic() {
 #[test]
 fn test_vm_fibonacci_old() {
     let instructions = vec![
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 9, 0, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 2, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 3, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 0, 0, 0, 0, 2),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 1, 0, 2),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 9, 0, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 2, 1, 0, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 3, 1, 0, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 0, 0, 2, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 1, 1, 0, 2, 0, 0, 0),
         Instruction::from_isize(
             VmOpcode::with_default_offset(NativeBranchEqualOpcode(BEQ)),
             2,
@@ -598,11 +598,11 @@ fn test_vm_fibonacci_old_cycle_tracker() {
     let instructions = vec![
         Instruction::debug(PhantomDiscriminant(SysPhantom::CtStart as u16)),
         Instruction::debug(PhantomDiscriminant(SysPhantom::CtStart as u16)),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 9, 0, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 2, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 3, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 0, 0, 0, 0, 2),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 1, 0, 2),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 9, 0, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 2, 1, 0, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 3, 1, 0, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 0, 0, 2, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 1, 1, 0, 2, 0, 0, 0),
         Instruction::debug(PhantomDiscriminant(SysPhantom::CtEnd as u16)),
         Instruction::debug(PhantomDiscriminant(SysPhantom::CtStart as u16)),
         Instruction::from_isize(
@@ -641,14 +641,14 @@ fn test_vm_fibonacci_old_cycle_tracker() {
 #[test]
 fn test_vm_field_extension_arithmetic() {
     let instructions = vec![
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 1, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 2, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 3, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 4, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 5, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 6, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 7, 0, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 1, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 2, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 3, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 4, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 5, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 6, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 7, 0, 2, 1, 0, 0, 0),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4ADD), 8, 0, 4, 1, 1),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4ADD), 8, 0, 4, 1, 1),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4SUB), 12, 0, 4, 1, 1),
@@ -665,14 +665,14 @@ fn test_vm_field_extension_arithmetic() {
 #[test]
 fn test_vm_max_access_adapter_8() {
     let instructions = vec![
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 1, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 2, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 3, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 4, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 5, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 6, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 7, 0, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 1, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 2, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 3, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 4, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 5, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 6, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 7, 0, 2, 1, 0, 0, 0),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4ADD), 8, 0, 4, 1, 1),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4ADD), 8, 0, 4, 1, 1),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4SUB), 12, 0, 4, 1, 1),
@@ -707,14 +707,14 @@ fn test_vm_max_access_adapter_8() {
 #[test]
 fn test_vm_field_extension_arithmetic_persistent() {
     let instructions = vec![
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 0, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 1, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 2, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 3, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 4, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 5, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 1, 6, 0, 0, 1),
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 2, 7, 0, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 1, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 2, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 3, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 4, 0, 2, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 5, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 6, 0, 1, 1, 0, 0, 0),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 7, 0, 2, 1, 0, 0, 0),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4ADD), 8, 0, 4, 1, 1),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4ADD), 8, 0, 4, 1, 1),
         Instruction::from_isize(VmOpcode::with_default_offset(FE4SUB), 12, 0, 4, 1, 1),
@@ -735,7 +735,7 @@ fn test_vm_field_extension_arithmetic_persistent() {
 #[test]
 fn test_vm_hint() {
     let instructions = vec![
-        Instruction::from_isize(VmOpcode::with_default_offset(STOREW), 0, 0, 16, 0, 1),
+        Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 16, 0, 0, 1, 0, 0, 0),
         Instruction::large_from_isize(
             VmOpcode::with_default_offset(ADD),
             20,
@@ -811,55 +811,66 @@ fn test_vm_compress_poseidon2_as2() {
     let lhs_ptr = gen_pointer(&mut rng, CHUNK) as isize;
     for i in 0..CHUNK as isize {
         // [lhs_ptr + i]_2 <- rnd()
-        instructions.push(Instruction::from_isize(
-            VmOpcode::with_default_offset(STOREW),
+        instructions.push(Instruction::large_from_isize(
+            VmOpcode::with_default_offset(ADD),
+            lhs_ptr + i,
             rng.gen_range(1..1 << 20),
-            i,
-            lhs_ptr,
             0,
             2,
+            0,
+            0,
+            0,
         ));
     }
     let rhs_ptr = gen_pointer(&mut rng, CHUNK) as isize;
     for i in 0..CHUNK as isize {
         // [rhs_ptr + i]_2 <- rnd()
-        instructions.push(Instruction::from_isize(
-            VmOpcode::with_default_offset(STOREW),
+        instructions.push(Instruction::large_from_isize(
+            VmOpcode::with_default_offset(ADD),
+            rhs_ptr + i,
             rng.gen_range(1..1 << 20),
-            i,
-            rhs_ptr,
             0,
             2,
+            0,
+            0,
+            0,
         ));
     }
     let dst_ptr = gen_pointer(&mut rng, CHUNK) as isize;
 
     // [11]_1 <- lhs_ptr
-    instructions.push(Instruction::from_isize(
-        VmOpcode::with_default_offset(STOREW),
+    instructions.push(Instruction::large_from_isize(
+        VmOpcode::with_default_offset(ADD),
+        11,
         lhs_ptr,
         0,
-        11,
-        0,
         1,
+        0,
+        0,
+        0,
     ));
+
     // [22]_1 <- rhs_ptr
-    instructions.push(Instruction::from_isize(
-        VmOpcode::with_default_offset(STOREW),
+    instructions.push(Instruction::large_from_isize(
+        VmOpcode::with_default_offset(ADD),
+        22,
         rhs_ptr,
         0,
-        22,
-        0,
         1,
-    ));
-    // [33]_1 <- rhs_ptr
-    instructions.push(Instruction::from_isize(
-        VmOpcode::with_default_offset(STOREW),
-        dst_ptr,
         0,
+        0,
+        0,
+    ));
+    // [33]_1 <- dst_ptr
+    instructions.push(Instruction::large_from_isize(
+        VmOpcode::with_default_offset(ADD),
         33,
         0,
+        dst_ptr,
         1,
+        0,
+        0,
+        0,
     ));
 
     instructions.push(Instruction::from_isize(
@@ -911,45 +922,53 @@ fn instructions_for_keccak256_test(input: &[u8]) -> Vec<Instruction<BabyBear>> {
     // [jpw] Cheating here and assuming src, dst, len all bit in a byte so we skip writing the other register bytes
     // src = word[b]_1 <- 0
     let src = 0;
-    instructions.push(Instruction::from_isize(
-        VmOpcode::with_default_offset(STOREW),
+    instructions.push(Instruction::large_from_isize(
+        VmOpcode::with_default_offset(ADD),
+        b,
         src,
         0,
-        b,
-        0,
         1,
+        0,
+        0,
+        0,
     ));
     // dst word[a]_1 <- 3 // use weird offset
     let dst = 8;
-    instructions.push(Instruction::from_isize(
-        VmOpcode::with_default_offset(STOREW),
+    instructions.push(Instruction::large_from_isize(
+        VmOpcode::with_default_offset(ADD),
+        a,
         dst,
         0,
-        a,
-        0,
         1,
+        0,
+        0,
+        0,
     ));
     // word[c]_1 <- len // emulate stack
-    instructions.push(Instruction::from_isize(
-        VmOpcode::with_default_offset(STOREW),
+    instructions.push(Instruction::large_from_isize(
+        VmOpcode::with_default_offset(ADD),
+        c,
         input.len() as isize,
         0,
-        c,
-        0,
         1,
+        0,
+        0,
+        0,
     ));
 
     let expected = keccak256(input);
     tracing::debug!(?input, ?expected);
 
     for (i, byte) in input.iter().enumerate() {
-        instructions.push(Instruction::from_isize(
-            VmOpcode::with_default_offset(STOREW),
+        instructions.push(Instruction::large_from_isize(
+            VmOpcode::with_default_offset(ADD),
+            src + i as isize,
             *byte as isize,
             0,
-            src + i as isize,
-            0,
             2,
+            0,
+            0,
+            0,
         ));
     }
     // dst = word[a]_1, src = word[b]_1, len = word[c]_1,

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -182,13 +182,14 @@ fn test_vm_override_executor_height() {
             chips: vec![
                 (ChipId::Executor(0), 0),
                 (ChipId::Executor(1), 0),
-                (ChipId::Executor(2), 1),
+                (ChipId::Executor(2), 0),
                 (ChipId::Executor(3), 0),
                 (ChipId::Executor(4), 0),
                 (ChipId::Executor(5), 0),
-                (ChipId::Executor(6), 0),
+                (ChipId::Executor(6), 1), // corresponds to FieldArithmeticChip
                 (ChipId::Executor(7), 0),
                 (ChipId::Executor(8), 0),
+                (ChipId::Executor(9), 0),
             ]
             .into_iter()
             .collect(),
@@ -204,15 +205,16 @@ fn test_vm_override_executor_height() {
     };
     let inventory_overridden_heights = VmInventoryTraceHeights {
         chips: vec![
-            (ChipId::Executor(0), 1),
-            (ChipId::Executor(1), 2),
-            (ChipId::Executor(2), 4),
-            (ChipId::Executor(3), 8),
-            (ChipId::Executor(4), 16),
-            (ChipId::Executor(5), 8),
-            (ChipId::Executor(6), 4),
-            (ChipId::Executor(7), 2),
-            (ChipId::Executor(8), 1),
+            (ChipId::Executor(0), 16),
+            (ChipId::Executor(1), 32),
+            (ChipId::Executor(2), 64),
+            (ChipId::Executor(3), 128),
+            (ChipId::Executor(4), 256),
+            (ChipId::Executor(5), 512),
+            (ChipId::Executor(6), 1024),
+            (ChipId::Executor(7), 2048),
+            (ChipId::Executor(8), 4096),
+            (ChipId::Executor(9), 8192),
         ]
         .into_iter()
         .collect(),
@@ -237,7 +239,7 @@ fn test_vm_override_executor_height() {
     // heights by hands whenever something changes.
     assert_eq!(
         air_heights,
-        vec![2, 2, 1, 1, 8, 4, 2, 1, 2, 4, 8, 16, 8, 4, 2, 262144]
+        vec![2, 2, 16, 1, 8, 4, 2, 8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 262144]
     );
 }
 

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -756,7 +756,7 @@ fn test_vm_hint() {
             0,
             0,
         ),
-        Instruction::from_isize(VmOpcode::with_default_offset(SHINTW), 32, 0, 0, 1, 2),
+        Instruction::from_isize(VmOpcode::with_default_offset(HINT_STOREW), 32, 0, 0, 1, 2),
         Instruction::from_isize(VmOpcode::with_default_offset(LOADW), 38, 0, 32, 1, 2),
         Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 44, 20, 0, 1, 1, 0, 0),
         Instruction::from_isize(VmOpcode::with_default_offset(MUL), 24, 38, 1, 1, 0),
@@ -772,7 +772,7 @@ fn test_vm_hint() {
         ),
         Instruction::from_isize(VmOpcode::with_default_offset(MUL), 0, 50, 1, 1, 0),
         Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 0, 44, 0, 1, 1, 1, 0),
-        Instruction::from_isize(VmOpcode::with_default_offset(SHINTW), 0, 0, 0, 1, 2),
+        Instruction::from_isize(VmOpcode::with_default_offset(HINT_STOREW), 0, 0, 0, 1, 2),
         Instruction::large_from_isize(VmOpcode::with_default_offset(ADD), 50, 50, 1, 1, 1, 0, 0),
         Instruction::from_isize(
             VmOpcode::with_default_offset(NativeBranchEqualOpcode(BNE)),

--- a/docs/specs/RISCV.md
+++ b/docs/specs/RISCV.md
@@ -199,7 +199,7 @@ The transpilation will only be valid for programs where:
 | RISC-V Inst    | OpenVM Instruction                                               |
 | -------------- | ---------------------------------------------------------------- |
 | terminate      | TERMINATE `_, _, utof(imm)`                                      |
-| hintstorew     | HINTSTOREW_RV32 `0, ind(rd), utof(sign_extend_16(imm)), 1, 2`    |
+| hintstorew     | HINT_STOREW_RV32 `0, ind(rd), utof(sign_extend_16(imm)), 1, 2`    |
 | reveal         | REVEAL_RV32 `0, ind(rd), utof(sign_extend_16(imm)), 1, 3`        |
 | hintinput      | PHANTOM `_, _, HintInputRv32 as u16`                             |
 | printstr       | PHANTOM `ind(rd), ind(rs1), PrintStrRv32 as u16`                 |

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -158,8 +158,9 @@ impl<AB: InteractionBuilder, const NUM_CELLS: usize> VmAdapterAir<AB>
         timestamp_delta += is_valid.clone();
 
         // TODO[yi]: Remove when vectorizing
+        // TODO[yi]: Decrease degree
         // read data, disabled if SHINTW
-        // data pointer = [c]_d + [f]_d * g + b, degree 2
+        // data pointer = [c]_d + b, degree 2
         builder
             .when(is_valid.clone() - is_shintw.clone())
             .assert_eq(

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -253,20 +253,22 @@ impl<F: PrimeField32, const NUM_CELLS: usize> VmAdapterChip<F>
 
         let (data_read_as, data_write_as) = {
             match local_opcode {
-                LOADW => (e, d),
-                STOREW | SHINTW => (d, e),
+                LOADW | LOADW4 => (e, d),
+                STOREW | STOREW4 | SHINTW | SHINTW4 => (d, e),
             }
         };
         let (data_read_ptr, data_write_ptr) = {
             match local_opcode {
-                LOADW => (read_cell.1 + b, a),
-                STOREW | SHINTW => (a, read_cell.1 + b),
+                LOADW | LOADW4 => (read_cell.1 + b, a),
+                STOREW | STOREW4 | SHINTW | SHINTW4 => (a, read_cell.1 + b),
             }
         };
 
         let data_read = match local_opcode {
-            SHINTW => None,
-            LOADW | STOREW => Some(memory.read::<NUM_CELLS>(data_read_as, data_read_ptr)),
+            SHINTW | SHINTW4 => None,
+            LOADW | LOADW4 | STOREW | STOREW4 => {
+                Some(memory.read::<NUM_CELLS>(data_read_as, data_read_ptr))
+            }
         };
         let record = NativeLoadStoreReadRecord {
             pointer_read: read_cell.0,

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -172,7 +172,7 @@ impl<AB: InteractionBuilder, const NUM_CELLS: usize> VmAdapterAir<AB>
             cols.data_write_as,
             utils::select::<AB::Expr>(is_loadw.clone(), cols.d, cols.e),
         );
-        // TODO[yi]: Do we need to check for overflow?
+
         builder.assert_eq(
             is_valid.clone() * cols.data_write_pointer,
             is_loadw.clone() * cols.a

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -17,7 +17,8 @@ use openvm_instructions::{
 };
 use openvm_native_compiler::{
     FieldArithmeticOpcode, FieldExtensionOpcode, FriOpcode, NativeBranchEqualOpcode,
-    NativeJalOpcode, NativeLoadStoreOpcode, NativePhantom,
+    NativeJalOpcode, NativeLoadStoreOpcode, NativePhantom, BLOCK_LOAD_STORE_OPCODES,
+    SINGLE_LOAD_STORE_OPCODES,
 };
 use openvm_poseidon2_air::Poseidon2Config;
 use openvm_rv32im_circuit::BranchEqualCoreChip;
@@ -116,13 +117,9 @@ impl<F: PrimeField32> VmExtension<F> for Native {
 
         inventory.add_executor(
             load_store_chip,
-            [
-                NativeLoadStoreOpcode::LOADW,
-                NativeLoadStoreOpcode::STOREW,
-                NativeLoadStoreOpcode::HINT_STOREW,
-            ]
-            .iter()
-            .map(|&opcode| VmOpcode::with_default_offset(opcode)),
+            SINGLE_LOAD_STORE_OPCODES
+                .iter()
+                .map(|&opcode| VmOpcode::with_default_offset(opcode)),
         )?;
 
         let mut block_load_store_chip = NativeLoadStoreChip::<F, 4>::new(
@@ -141,13 +138,9 @@ impl<F: PrimeField32> VmExtension<F> for Native {
 
         inventory.add_executor(
             block_load_store_chip,
-            [
-                NativeLoadStoreOpcode::LOADW4,
-                NativeLoadStoreOpcode::STOREW4,
-                NativeLoadStoreOpcode::HINT_STOREW4,
-            ]
-            .iter()
-            .map(|&opcode| VmOpcode::with_default_offset(opcode)),
+            BLOCK_LOAD_STORE_OPCODES
+                .iter()
+                .map(|&opcode| VmOpcode::with_default_offset(opcode)),
         )?;
 
         let branch_equal_chip = NativeBranchEqChip::new(

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -72,6 +72,7 @@ pub struct Native;
 #[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum)]
 pub enum NativeExecutor<F: PrimeField32> {
     LoadStore(NativeLoadStoreChip<F, 1>),
+    BlockLoadStore(NativeLoadStoreChip<F, 4>),
     BranchEqual(NativeBranchEqChip<F>),
     Jal(NativeJalChip<F>),
     FieldArithmetic(FieldArithmeticChip<F>),
@@ -115,7 +116,38 @@ impl<F: PrimeField32> VmExtension<F> for Native {
 
         inventory.add_executor(
             load_store_chip,
-            NativeLoadStoreOpcode::iter().map(VmOpcode::with_default_offset),
+            [
+                NativeLoadStoreOpcode::LOADW,
+                NativeLoadStoreOpcode::STOREW,
+                NativeLoadStoreOpcode::SHINTW,
+            ]
+            .iter()
+            .map(|&opcode| VmOpcode::with_default_offset(opcode)),
+        )?;
+
+        let mut block_load_store_chip = NativeLoadStoreChip::<F, 4>::new(
+            NativeLoadStoreAdapterChip::new(
+                execution_bus,
+                program_bus,
+                memory_bridge,
+                NativeLoadStoreOpcode::default_offset(),
+            ),
+            NativeLoadStoreCoreChip::new(NativeLoadStoreOpcode::default_offset()),
+            offline_memory.clone(),
+        );
+        block_load_store_chip
+            .core
+            .set_streams(builder.streams().clone());
+
+        inventory.add_executor(
+            block_load_store_chip,
+            [
+                NativeLoadStoreOpcode::LOADW4,
+                NativeLoadStoreOpcode::STOREW4,
+                NativeLoadStoreOpcode::SHINTW4,
+            ]
+            .iter()
+            .map(|&opcode| VmOpcode::with_default_offset(opcode)),
         )?;
 
         let branch_equal_chip = NativeBranchEqChip::new(

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -119,7 +119,7 @@ impl<F: PrimeField32> VmExtension<F> for Native {
             [
                 NativeLoadStoreOpcode::LOADW,
                 NativeLoadStoreOpcode::STOREW,
-                NativeLoadStoreOpcode::SHINTW,
+                NativeLoadStoreOpcode::HINT_STOREW,
             ]
             .iter()
             .map(|&opcode| VmOpcode::with_default_offset(opcode)),
@@ -144,7 +144,7 @@ impl<F: PrimeField32> VmExtension<F> for Native {
             [
                 NativeLoadStoreOpcode::LOADW4,
                 NativeLoadStoreOpcode::STOREW4,
-                NativeLoadStoreOpcode::SHINTW4,
+                NativeLoadStoreOpcode::HINT_STOREW4,
             ]
             .iter()
             .map(|&opcode| VmOpcode::with_default_offset(opcode)),

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -18,7 +18,7 @@ use openvm_instructions::{
 use openvm_native_compiler::{
     FieldArithmeticOpcode, FieldExtensionOpcode, FriOpcode, NativeBranchEqualOpcode,
     NativeJalOpcode, NativeLoadStoreOpcode, NativePhantom, BLOCK_LOAD_STORE_OPCODES,
-    SINGLE_LOAD_STORE_OPCODES,
+    BLOCK_LOAD_STORE_SIZE, SINGLE_LOAD_STORE_OPCODES,
 };
 use openvm_poseidon2_air::Poseidon2Config;
 use openvm_rv32im_circuit::BranchEqualCoreChip;
@@ -122,7 +122,7 @@ impl<F: PrimeField32> VmExtension<F> for Native {
                 .map(|&opcode| VmOpcode::with_default_offset(opcode)),
         )?;
 
-        let mut block_load_store_chip = NativeLoadStoreChip::<F, 4>::new(
+        let mut block_load_store_chip = NativeLoadStoreChip::<F, BLOCK_LOAD_STORE_SIZE>::new(
             NativeLoadStoreAdapterChip::new(
                 execution_bus,
                 program_bus,

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -10,7 +10,9 @@ use openvm_circuit::arch::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::instruction::Instruction;
-use openvm_native_compiler::NativeLoadStoreOpcode;
+use openvm_native_compiler::{
+    NativeLoadStoreOpcode, BLOCK_LOAD_STORE_OPCODES, SINGLE_LOAD_STORE_OPCODES,
+};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
@@ -86,17 +88,9 @@ where
         let expected_opcode = flags
             .iter()
             .zip(if NUM_CELLS == 1 {
-                [
-                    NativeLoadStoreOpcode::LOADW,
-                    NativeLoadStoreOpcode::STOREW,
-                    NativeLoadStoreOpcode::HINT_STOREW,
-                ]
+                SINGLE_LOAD_STORE_OPCODES
             } else if NUM_CELLS == 4 {
-                [
-                    NativeLoadStoreOpcode::LOADW4,
-                    NativeLoadStoreOpcode::STOREW4,
-                    NativeLoadStoreOpcode::HINT_STOREW4,
-                ]
+                BLOCK_LOAD_STORE_OPCODES
             } else {
                 panic!("Unsupported number of cells: {}", NUM_CELLS);
             })

--- a/extensions/native/circuit/src/loadstore/tests.rs
+++ b/extensions/native/circuit/src/loadstore/tests.rs
@@ -67,7 +67,7 @@ fn gen_test_data(rng: &mut StdRng, is_immediate: bool, opcode: NativeLoadStoreOp
         cd_val: F::from_canonical_u32(222),
         data_val: F::from_canonical_u32(444),
         is_load,
-        is_hint: matches!(opcode, NativeLoadStoreOpcode::SHINTW),
+        is_hint: matches!(opcode, NativeLoadStoreOpcode::HINT_STOREW),
     }
 }
 
@@ -171,7 +171,7 @@ fn rand_native_loadstore_test() {
     let (mut rng, mut tester, mut chip) = setup();
     for _ in 0..20 {
         set_and_execute(&mut tester, &mut chip, &mut rng, false, STOREW);
-        set_and_execute(&mut tester, &mut chip, &mut rng, false, SHINTW);
+        set_and_execute(&mut tester, &mut chip, &mut rng, false, HINT_STOREW);
         set_and_execute(&mut tester, &mut chip, &mut rng, false, LOADW);
     }
     let tester = tester.build().load(chip).finalize();

--- a/extensions/native/circuit/src/loadstore/tests.rs
+++ b/extensions/native/circuit/src/loadstore/tests.rs
@@ -4,7 +4,7 @@ use openvm_circuit::arch::{testing::VmChipTestBuilder, Streams};
 use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::NativeLoadStoreOpcode::{self, *};
 use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
-use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
+use openvm_stark_sdk::{config::setup_tracing, p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 
 use super::{
@@ -168,6 +168,7 @@ fn set_and_execute(
 
 #[test]
 fn rand_native_loadstore_test() {
+    setup_tracing();
     let (mut rng, mut tester, mut chip) = setup();
     for _ in 0..20 {
         set_and_execute(&mut tester, &mut chip, &mut rng, false, STOREW);

--- a/extensions/native/circuit/src/loadstore/tests.rs
+++ b/extensions/native/circuit/src/loadstore/tests.rs
@@ -173,9 +173,6 @@ fn rand_native_loadstore_test() {
         set_and_execute(&mut tester, &mut chip, &mut rng, false, STOREW);
         set_and_execute(&mut tester, &mut chip, &mut rng, false, SHINTW);
         set_and_execute(&mut tester, &mut chip, &mut rng, false, LOADW);
-
-        set_and_execute(&mut tester, &mut chip, &mut rng, true, STOREW);
-        set_and_execute(&mut tester, &mut chip, &mut rng, true, SHINTW);
     }
     let tester = tester.build().load(chip).finalize();
     tester.simple_test().expect("Verification failed");

--- a/extensions/native/compiler/src/asm/compiler.rs
+++ b/extensions/native/compiler/src/asm/compiler.rs
@@ -1108,33 +1108,17 @@ impl<F: PrimeField32 + TwoAdicField, EF: ExtensionField<F> + TwoAdicField> AsmCo
     }
 
     fn load_ext(&mut self, val: Ext<F, EF>, addr: i32, offset: F, debug_info: Option<DebugInfo>) {
-        for i in 0..EF::D {
-            self.push(
-                AsmInstruction::LoadFI(
-                    val.fp() + i as i32,
-                    addr,
-                    F::from_canonical_usize(i),
-                    F::ONE,
-                    offset,
-                ),
-                debug_info.clone(),
-            )
-        }
+        self.push(
+            AsmInstruction::LoadEI(val.fp(), addr, F::ZERO, F::ONE, offset),
+            debug_info.clone(),
+        );
     }
 
     fn store_ext(&mut self, val: Ext<F, EF>, addr: i32, offset: F, debug_info: Option<DebugInfo>) {
-        for i in 0..EF::D {
-            self.push(
-                AsmInstruction::StoreFI(
-                    val.fp() + i as i32,
-                    addr,
-                    F::from_canonical_usize(i),
-                    F::ONE,
-                    offset,
-                ),
-                debug_info.clone(),
-            )
-        }
+        self.push(
+            AsmInstruction::StoreEI(val.fp(), addr, F::ZERO, F::ONE, offset),
+            debug_info.clone(),
+        );
     }
 
     fn add_ext_exti(

--- a/extensions/native/compiler/src/asm/instruction.rs
+++ b/extensions/native/compiler/src/asm/instruction.rs
@@ -12,10 +12,20 @@ pub enum AsmInstruction<F, EF> {
     /// Load a value from the address stored at src(fp) into dst(fp) with given index and offset.
     LoadFI(i32, i32, F, F, F),
 
+    /// Load extension word (dst, src, var_index, size, offset).
+    ///
+    /// Load an extension from the address stored at src(fp) into dst(fp) with given index and offset.
+    LoadEI(i32, i32, F, F, F),
+
     /// Store word (val, addr, var_index, size, offset)
     ///
     /// Store a value from val(fp) into the address stored at addr(fp) with given index and offset.
     StoreFI(i32, i32, F, F, F),
+
+    /// Store extension word (val, addr, var_index, size, offset)
+    ///
+    /// Store an extension from val(fp) into the address stored at addr(fp) with given index and offset.
+    StoreEI(i32, i32, F, F, F),
 
     /// Set dst = imm.
     ImmF(i32, F),
@@ -132,6 +142,9 @@ pub enum AsmInstruction<F, EF> {
     /// Stores the next hint stream word into value stored at addr + value.
     StoreHintWordI(i32, F),
 
+    /// Stores the next hint stream ext into value stored at addr + value.
+    StoreHintExtI(i32, F),
+
     /// Publish(val, index).
     Publish(i32, i32),
 
@@ -154,10 +167,24 @@ impl<F: PrimeField32, EF: ExtensionField<F>> AsmInstruction<F, EF> {
                     dst, src, var_index, size, offset
                 )
             }
+            AsmInstruction::LoadEI(dst, src, var_index, size, offset) => {
+                write!(
+                    f,
+                    "lei   ({})fp, ({})fp, {}, {}, {}",
+                    dst, src, var_index, size, offset
+                )
+            }
             AsmInstruction::StoreFI(dst, src, var_index, size, offset) => {
                 write!(
                     f,
                     "swi   ({})fp, ({})fp, {}, {}, {}",
+                    dst, src, var_index, size, offset
+                )
+            }
+            AsmInstruction::StoreEI(dst, src, var_index, size, offset) => {
+                write!(
+                    f,
+                    "sei   ({})fp, ({})fp, {}, {}, {}",
                     dst, src, var_index, size, offset
                 )
             }
@@ -314,6 +341,9 @@ impl<F: PrimeField32, EF: ExtensionField<F>> AsmInstruction<F, EF> {
             AsmInstruction::HintInputVec() => write!(f, "hint_vec"),
             AsmInstruction::StoreHintWordI(dst, offset) => {
                 write!(f, "shintw ({})fp {}", dst, offset)
+            }
+            AsmInstruction::StoreHintExtI(dst, offset) => {
+                write!(f, "shinte ({})fp {}", dst, offset)
             }
             AsmInstruction::Publish(val, index) => {
                 write!(f, "commit ({})fp ({})fp", val, index)

--- a/extensions/native/compiler/src/conversion/mod.rs
+++ b/extensions/native/compiler/src/conversion/mod.rs
@@ -342,10 +342,32 @@ fn convert_instruction<F: PrimeField32, EF: ExtensionField<F>>(
                 AS::Native,
             ),
         ],
+        AsmInstruction::LoadEI(dst, src, index, size, offset) => vec![
+            // mem[dst] <- mem[mem[src] + index * size + offset]
+            inst(
+                options.opcode_with_offset(NativeLoadStoreOpcode::LOADW4),
+                i32_f(dst),
+                index * size + offset,
+                i32_f(src),
+                AS::Native,
+                AS::Native,
+            ),
+        ],
         AsmInstruction::StoreFI(val, addr, index, size, offset) => vec![
             // mem[mem[addr] + index * size + offset] <- mem[val]
             inst(
                 options.opcode_with_offset(NativeLoadStoreOpcode::STOREW),
+                i32_f(val),
+                index * size + offset,
+                i32_f(addr),
+                AS::Native,
+                AS::Native,
+            ),
+        ],
+        AsmInstruction::StoreEI(val, addr, index, size, offset) => vec![
+            // mem[mem[addr] + index * size + offset] <- mem[val]
+            inst(
+                options.opcode_with_offset(NativeLoadStoreOpcode::STOREW4),
                 i32_f(val),
                 index * size + offset,
                 i32_f(addr),
@@ -490,6 +512,14 @@ fn convert_instruction<F: PrimeField32, EF: ExtensionField<F>>(
         ],
         AsmInstruction::StoreHintWordI(val, offset) => vec![inst(
             options.opcode_with_offset(NativeLoadStoreOpcode::SHINTW),
+            F::ZERO,
+            offset,
+            i32_f(val),
+            AS::Native,
+            AS::Native,
+        )],
+        AsmInstruction::StoreHintExtI(val, offset) => vec![inst(
+            options.opcode_with_offset(NativeLoadStoreOpcode::SHINTW4),
             F::ZERO,
             offset,
             i32_f(val),

--- a/extensions/native/compiler/src/conversion/mod.rs
+++ b/extensions/native/compiler/src/conversion/mod.rs
@@ -517,7 +517,7 @@ fn convert_instruction<F: PrimeField32, EF: ExtensionField<F>>(
             panic!(
                 "Unsupported instruction {:?}, field arithmetic is disabled",
                 instruction
-            )       
+            )
         },
         AsmInstruction::CopyF(dst, src) => if options.field_arithmetic_enabled {
             vec![inst_med(

--- a/extensions/native/compiler/src/conversion/mod.rs
+++ b/extensions/native/compiler/src/conversion/mod.rs
@@ -511,7 +511,7 @@ fn convert_instruction<F: PrimeField32, EF: ExtensionField<F>>(
             Instruction::phantom(PhantomDiscriminant(NativePhantom::HintBits as u16), i32_f(src), F::from_canonical_u32(len), AS::Native as u16)
         ],
         AsmInstruction::StoreHintWordI(val, offset) => vec![inst(
-            options.opcode_with_offset(NativeLoadStoreOpcode::SHINTW),
+            options.opcode_with_offset(NativeLoadStoreOpcode::HINT_STOREW),
             F::ZERO,
             offset,
             i32_f(val),
@@ -519,7 +519,7 @@ fn convert_instruction<F: PrimeField32, EF: ExtensionField<F>>(
             AS::Native,
         )],
         AsmInstruction::StoreHintExtI(val, offset) => vec![inst(
-            options.opcode_with_offset(NativeLoadStoreOpcode::SHINTW4),
+            options.opcode_with_offset(NativeLoadStoreOpcode::HINT_STOREW4),
             F::ZERO,
             offset,
             i32_f(val),

--- a/extensions/native/compiler/src/lib.rs
+++ b/extensions/native/compiler/src/lib.rs
@@ -47,6 +47,9 @@ pub enum NativeLoadStoreOpcode {
     STOREW,
     /// Instruction to write the next hint word into memory.
     SHINTW,
+    LOADW4,
+    STOREW4,
+    SHINTW4,
 }
 
 #[derive(Copy, Clone, Debug, UsizeOpcode)]

--- a/extensions/native/compiler/src/lib.rs
+++ b/extensions/native/compiler/src/lib.rs
@@ -53,6 +53,18 @@ pub enum NativeLoadStoreOpcode {
     HINT_STOREW4,
 }
 
+pub const SINGLE_LOAD_STORE_OPCODES: [NativeLoadStoreOpcode; 3] = [
+    NativeLoadStoreOpcode::LOADW,
+    NativeLoadStoreOpcode::STOREW,
+    NativeLoadStoreOpcode::HINT_STOREW,
+];
+
+pub const BLOCK_LOAD_STORE_OPCODES: [NativeLoadStoreOpcode; 3] = [
+    NativeLoadStoreOpcode::LOADW4,
+    NativeLoadStoreOpcode::STOREW4,
+    NativeLoadStoreOpcode::HINT_STOREW4,
+];
+
 #[derive(Copy, Clone, Debug, UsizeOpcode)]
 #[opcode_offset = 0x110]
 pub struct NativeBranchEqualOpcode(pub BranchEqualOpcode);

--- a/extensions/native/compiler/src/lib.rs
+++ b/extensions/native/compiler/src/lib.rs
@@ -42,14 +42,15 @@ pub mod prelude {
 )]
 #[opcode_offset = 0x100]
 #[repr(usize)]
+#[allow(non_camel_case_types)]
 pub enum NativeLoadStoreOpcode {
     LOADW,
     STOREW,
     /// Instruction to write the next hint word into memory.
-    SHINTW,
+    HINT_STOREW,
     LOADW4,
     STOREW4,
-    SHINTW4,
+    HINT_STOREW4,
 }
 
 #[derive(Copy, Clone, Debug, UsizeOpcode)]

--- a/extensions/native/compiler/src/lib.rs
+++ b/extensions/native/compiler/src/lib.rs
@@ -65,6 +65,8 @@ pub const BLOCK_LOAD_STORE_OPCODES: [NativeLoadStoreOpcode; 3] = [
     NativeLoadStoreOpcode::HINT_STOREW4,
 ];
 
+pub const BLOCK_LOAD_STORE_SIZE: usize = 4;
+
 #[derive(Copy, Clone, Debug, UsizeOpcode)]
 #[opcode_offset = 0x110]
 pub struct NativeBranchEqualOpcode(pub BranchEqualOpcode);


### PR DESCRIPTION
- Adds vectorized native load / store / hint chip.  
- Renames SHINTW to HINT_STOREW for consistency.
- Adds LOADW4, STOREW4, HINT_STOREW4 opcodes and uses them for Ext.
- Updates ISA docs to be consistent.

Closes INT-2941, INT-2620, INT-2621.