### PR TITLE
chore: update plonky3 and stark-backend commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "0.2.0-alpha"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=dd3a03c#dd3a03c0e12fada12622bcae2df207b625e2a619"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4339,6 +4340,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "0.2.0-alpha"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=dd3a03c#dd3a03c0e12fada12622bcae2df207b625e2a619"
 dependencies = [
  "derive_more 0.99.18",
  "ff 0.13.0",
@@ -4355,7 +4357,7 @@ dependencies = [
  "p3-goldilocks",
  "p3-keccak",
  "p3-merkle-tree",
- "p3-poseidon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd)",
+ "p3-poseidon",
  "p3-poseidon2",
  "p3-symmetric",
  "rand",
@@ -4471,6 +4473,7 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4479,6 +4482,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4492,6 +4496,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -4501,6 +4506,7 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "ff 0.13.0",
  "halo2curves",
@@ -4515,6 +4521,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4526,6 +4533,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -4539,6 +4547,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4551,6 +4560,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -4567,6 +4577,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -4585,12 +4596,13 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft",
  "p3-field",
  "p3-mds",
- "p3-poseidon 0.1.0",
+ "p3-poseidon",
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
@@ -4601,6 +4613,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4611,6 +4624,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4622,6 +4636,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -4635,6 +4650,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4649,6 +4665,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "rayon",
 ]
@@ -4656,6 +4673,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-dft",
@@ -4669,6 +4687,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-commit",
@@ -4685,6 +4704,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -4705,16 +4725,6 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-dependencies = [
- "p3-field",
- "p3-mds",
- "p3-symmetric",
- "rand",
-]
-
-[[package]]
-name = "p3-poseidon"
-version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
@@ -4726,6 +4736,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "gcd",
  "p3-field",
@@ -4753,6 +4764,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4762,6 +4774,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-air",
@@ -4779,6 +4792,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,8 +4312,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
-version = "0.1.2-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v0.1.2-alpha#a97c6664ac29808662b5709f4e4462ce7fb53af0"
+version = "0.2.0-alpha"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=dd3a03c#dd3a03c0e12fada12622bcae2df207b625e2a619"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4339,8 +4339,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-sdk"
-version = "0.1.2-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v0.1.2-alpha#a97c6664ac29808662b5709f4e4462ce7fb53af0"
+version = "0.2.0-alpha"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=dd3a03c#dd3a03c0e12fada12622bcae2df207b625e2a619"
 dependencies = [
  "derive_more 0.99.18",
  "ff 0.13.0",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4482,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "ff 0.13.0",
  "halo2curves",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4533,10 +4533,11 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
+ "p3-dft",
  "p3-field",
  "p3-matrix",
  "p3-util",
@@ -4546,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4559,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -4576,7 +4577,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -4587,6 +4588,7 @@ dependencies = [
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
+ "rand",
  "serde",
  "tracing",
 ]
@@ -4594,12 +4596,13 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft",
  "p3-field",
  "p3-mds",
+ "p3-poseidon",
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
@@ -4610,17 +4613,18 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-matrix",
+ "p3-maybe-rayon",
  "p3-util",
 ]
 
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4632,20 +4636,21 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-air",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
+ "rand",
  "tracing",
 ]
 
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4660,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "rayon",
 ]
@@ -4668,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-dft",
@@ -4682,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-commit",
@@ -4699,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -4720,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4731,7 +4736,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "gcd",
  "p3-field",
@@ -4743,7 +4748,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -4759,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4769,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-air",
@@ -4787,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=9b267c4#9b267c411cc8965c709b27d7b0ef81e225603c59"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,7 +4313,6 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "0.2.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=dd3a03c#dd3a03c0e12fada12622bcae2df207b625e2a619"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4340,7 +4339,6 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "0.2.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=dd3a03c#dd3a03c0e12fada12622bcae2df207b625e2a619"
 dependencies = [
  "derive_more 0.99.18",
  "ff 0.13.0",
@@ -4357,7 +4355,7 @@ dependencies = [
  "p3-goldilocks",
  "p3-keccak",
  "p3-merkle-tree",
- "p3-poseidon",
+ "p3-poseidon 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd)",
  "p3-poseidon2",
  "p3-symmetric",
  "rand",
@@ -4473,7 +4471,6 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4482,7 +4479,6 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4496,7 +4492,6 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -4506,7 +4501,6 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "ff 0.13.0",
  "halo2curves",
@@ -4521,7 +4515,6 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4533,7 +4526,6 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -4547,7 +4539,6 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4560,7 +4551,6 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -4577,7 +4567,6 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -4596,13 +4585,12 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft",
  "p3-field",
  "p3-mds",
- "p3-poseidon",
+ "p3-poseidon 0.1.0",
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
@@ -4613,7 +4601,6 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4624,7 +4611,6 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4636,7 +4622,6 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -4650,7 +4635,6 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4665,7 +4649,6 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "rayon",
 ]
@@ -4673,7 +4656,6 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-dft",
@@ -4687,7 +4669,6 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-commit",
@@ -4704,7 +4685,6 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -4725,6 +4705,16 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
+dependencies = [
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "rand",
+]
+
+[[package]]
+name = "p3-poseidon"
+version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "p3-field",
@@ -4736,7 +4726,6 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "gcd",
  "p3-field",
@@ -4764,7 +4753,6 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -4774,7 +4762,6 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "itertools 0.13.0",
  "p3-air",
@@ -4792,7 +4779,6 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=784b7dd#784b7dd1fa87c1202e63350cc8182d7c5327a7af"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ openvm-platform = { path = "crates/toolchain/platform", default-features = false
 openvm-transpiler = { path = "crates/toolchain/transpiler", default-features = false }
 openvm-circuit = { path = "crates/vm", default-features = false }
 openvm-circuit-derive = { path = "crates/vm/derive", default-features = false }
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v0.1.2-alpha", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v0.1.2-alpha", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "dd3a03c", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "dd3a03c", default-features = false }
 
 # Extensions
 openvm-algebra-circuit = { path = "extensions/algebra/circuit", default-features = false }
@@ -144,31 +144,31 @@ openvm-rv32im-transpiler = { path = "extensions/rv32im/transpiler", default-feat
 openvm-rv32im-guest = { path = "extensions/rv32im/guest", default-features = false }
 
 # Plonky3
-p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
+p3-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
     "nightly-features",
-], rev = "9b267c4" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
-p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "9b267c4" }
+], rev = "784b7dd" }
+p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-keccak = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-blake3 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-poseidon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "784b7dd" }
 
 snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier", branch = "zkvm-v0.1", default-features = false, features = [
     "loader_halo2",

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,7 +34,7 @@ This can then be fed into `bench_from_exe` which will generate a proof of the ex
 
 #### Providing Inputs
 
-Inputs must be directly provided to the `bench_from_exe` function: the `input_stream: Vec<Vec<F>>` is a vector of vectors, where `input_stream[i]` will be what is provided to the guest program on the `i`-th call of `openvm::io::read_vec()`. Currently you must manually convert from `u8` to `F` using `AbstractField::from_canonical_u8`.
+Inputs must be directly provided to the `bench_from_exe` function: the `input_stream: Vec<Vec<F>>` is a vector of vectors, where `input_stream[i]` will be what is provided to the guest program on the `i`-th call of `openvm::io::read_vec()`. Currently you must manually convert from `u8` to `F` using `FieldAlgebra::from_canonical_u8`.
 
 You can find an example of passing in a single `Vec<u8>` input in [base64_json](./src/bin/base64_json.rs).
 

--- a/benchmarks/src/bin/base64_json.rs
+++ b/benchmarks/src/bin/base64_json.rs
@@ -14,7 +14,7 @@ use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
 use openvm_sdk::{config::AppConfig, keygen::leaf_keygen, prover::AggStarkProver, StdIn};
-use openvm_stark_backend::{config::Com, p3_field::AbstractField};
+use openvm_stark_backend::{config::Com, p3_field::FieldAlgebra};
 use openvm_stark_sdk::{
     bench::run_with_metric_collection,
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},

--- a/benchmarks/src/bin/ecrecover.rs
+++ b/benchmarks/src/bin/ecrecover.rs
@@ -37,7 +37,7 @@ use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
 use openvm_sdk::{config::AppConfig, StdIn};
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::{
     bench::run_with_metric_collection,
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},

--- a/benchmarks/src/bin/fibonacci.rs
+++ b/benchmarks/src/bin/fibonacci.rs
@@ -23,7 +23,7 @@ use openvm_sdk::{
     prover::{AggStarkProver, AppProver, LeafProver},
     Sdk, StdIn,
 };
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::{
     bench::run_with_metric_collection,
     config::{

--- a/benchmarks/src/bin/regex.rs
+++ b/benchmarks/src/bin/regex.rs
@@ -14,7 +14,7 @@ use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
 use openvm_sdk::{config::AppConfig, StdIn};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::{
     bench::run_with_metric_collection,
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},

--- a/benchmarks/src/bin/revm_transfer.rs
+++ b/benchmarks/src/bin/revm_transfer.rs
@@ -13,7 +13,7 @@ use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
 use openvm_sdk::{config::AppConfig, StdIn};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::{
     bench::run_with_metric_collection,
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},

--- a/crates/circuits/mod-builder/src/builder.rs
+++ b/crates/circuits/mod-builder/src/builder.rs
@@ -15,7 +15,7 @@ use openvm_circuit_primitives::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField64},
+    p3_field::{Field, FieldAlgebra, PrimeField64},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/mod-builder/src/builder.rs
+++ b/crates/circuits/mod-builder/src/builder.rs
@@ -15,7 +15,7 @@ use openvm_circuit_primitives::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField64},
+    p3_field::{FieldAlgebra, Field, PrimeField64},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -13,7 +13,7 @@ use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     rap::BaseAirWithPublicValues,
 };

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -13,7 +13,7 @@ use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     rap::BaseAirWithPublicValues,
 };

--- a/crates/circuits/mod-builder/src/symbolic_expr.rs
+++ b/crates/circuits/mod-builder/src/symbolic_expr.rs
@@ -9,7 +9,7 @@ use num_traits::{FromPrimitive, One, Zero};
 use openvm_circuit_primitives::bigint::{
     check_carry_to_zero::get_carry_max_abs_and_bits, utils::big_uint_mod_inverse, OverflowInt,
 };
-use openvm_stark_backend::{p3_air::AirBuilder, p3_field::AbstractField, p3_util::log2_ceil_usize};
+use openvm_stark_backend::{p3_air::AirBuilder, p3_field::FieldAlgebra, p3_util::log2_ceil_usize};
 
 /// Example: If there are 4 inputs (x1, y1, x2, y2), and one intermediate variable lambda,
 /// Mul(Var(0), Var(0)) - Input(0) - Input(2) =>

--- a/crates/circuits/mod-builder/src/tests.rs
+++ b/crates/circuits/mod-builder/src/tests.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use num_bigint_dig::BigUint;
 use openvm_circuit_primitives::{bigint::utils::*, TraceSubRowGenerator};
 use openvm_stark_backend::{
-    p3_air::BaseAir, p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix,
+    p3_air::BaseAir, p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix,
 };
 use openvm_stark_sdk::{
     any_rap_arc_vec, config::baby_bear_blake3::BabyBearBlake3Engine, engine::StarkFriEngine,

--- a/crates/circuits/poseidon2-air/src/babybear.rs
+++ b/crates/circuits/poseidon2-air/src/babybear.rs
@@ -1,7 +1,7 @@
 use std::array::from_fn;
 
 use lazy_static::lazy_static;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use zkhash::{
     ark_ff::PrimeField as _, fields::babybear::FpBabyBear as HorizenBabyBear,
@@ -53,7 +53,7 @@ lazy_static! {
         horizen_round_consts().ending_full_round_constants;
 }
 
-pub(crate) fn babybear_internal_linear_layer<FA: AbstractField, const WIDTH: usize>(
+pub(crate) fn babybear_internal_linear_layer<FA: FieldAlgebra, const WIDTH: usize>(
     state: &mut [FA; WIDTH],
     int_diag_m1_matrix: &[FA::F; WIDTH],
 ) {

--- a/crates/circuits/poseidon2-air/src/babybear.rs
+++ b/crates/circuits/poseidon2-air/src/babybear.rs
@@ -9,9 +9,9 @@ use zkhash::{
 };
 
 use super::{
-    Poseidon2Constants, BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS, BABY_BEAR_POSEIDON2_PARTIAL_ROUNDS,
-    POSEIDON2_WIDTH,
+    BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS, BABY_BEAR_POSEIDON2_PARTIAL_ROUNDS, POSEIDON2_WIDTH,
 };
+use crate::Poseidon2Constants;
 
 pub(crate) fn horizen_to_p3_babybear(horizen_babybear: HorizenBabyBear) -> BabyBear {
     BabyBear::from_canonical_u64(horizen_babybear.into_bigint().0[0])

--- a/crates/circuits/poseidon2-air/src/config.rs
+++ b/crates/circuits/poseidon2-air/src/config.rs
@@ -4,13 +4,16 @@ use p3_poseidon2::ExternalLayerConstants;
 use p3_poseidon2_air::RoundConstants;
 
 use super::{
-    BABYBEAR_BEGIN_EXT_CONSTS, BABYBEAR_END_EXT_CONSTS, BABYBEAR_PARTIAL_CONSTS,
-    BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS, BABY_BEAR_POSEIDON2_PARTIAL_ROUNDS, POSEIDON2_WIDTH,
+    // BABYBEAR_BEGIN_EXT_CONSTS, BABYBEAR_END_EXT_CONSTS, BABYBEAR_PARTIAL_CONSTS,
+    BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS,
+    BABY_BEAR_POSEIDON2_PARTIAL_ROUNDS,
+    POSEIDON2_WIDTH,
 };
+use crate::{BABYBEAR_BEGIN_EXT_CONSTS, BABYBEAR_END_EXT_CONSTS, BABYBEAR_PARTIAL_CONSTS};
 
 // Currently only contains round constants, but this struct may contain other configuration parameters in the future.
-#[derive(Clone, Copy, Debug)]
-pub struct Poseidon2Config<F> {
+#[derive(Clone, Debug)]
+pub struct Poseidon2Config<F: Field> {
     pub constants: Poseidon2Constants<F>,
 }
 
@@ -30,13 +33,17 @@ pub struct Poseidon2Constants<F> {
     pub ending_full_round_constants: [[F; POSEIDON2_WIDTH]; BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS],
 }
 
-impl<F: Field> Poseidon2Constants<F> {
-    // FIXME[stephenh]: PR https://github.com/Plonky3/Plonky3/pull/588 is now merged.
-    // We can remove Poseidon2Constants and use Plonky3RoundConstants directly after updating the plonky3 commit.
-    pub fn to_round_constants(&self) -> Plonky3RoundConstants<F> {
-        unsafe { std::mem::transmute_copy(self) }
+impl<F: Field> Into<Plonky3RoundConstants<F>> for Poseidon2Constants<F> {
+    fn into(self) -> Plonky3RoundConstants<F> {
+        Plonky3RoundConstants::new(
+            self.beginning_full_round_constants,
+            self.partial_round_constants,
+            self.ending_full_round_constants,
+        )
     }
+}
 
+impl<F: Field> Poseidon2Constants<F> {
     pub fn to_external_internal_constants(
         &self,
     ) -> (ExternalLayerConstants<F, POSEIDON2_WIDTH>, Vec<F>) {

--- a/crates/circuits/poseidon2-air/src/config.rs
+++ b/crates/circuits/poseidon2-air/src/config.rs
@@ -4,10 +4,7 @@ use p3_poseidon2::ExternalLayerConstants;
 use p3_poseidon2_air::RoundConstants;
 
 use super::{
-    // BABYBEAR_BEGIN_EXT_CONSTS, BABYBEAR_END_EXT_CONSTS, BABYBEAR_PARTIAL_CONSTS,
-    BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS,
-    BABY_BEAR_POSEIDON2_PARTIAL_ROUNDS,
-    POSEIDON2_WIDTH,
+    BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS, BABY_BEAR_POSEIDON2_PARTIAL_ROUNDS, POSEIDON2_WIDTH,
 };
 use crate::{BABYBEAR_BEGIN_EXT_CONSTS, BABYBEAR_END_EXT_CONSTS, BABYBEAR_PARTIAL_CONSTS};
 
@@ -33,12 +30,12 @@ pub struct Poseidon2Constants<F> {
     pub ending_full_round_constants: [[F; POSEIDON2_WIDTH]; BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS],
 }
 
-impl<F: Field> Into<Plonky3RoundConstants<F>> for Poseidon2Constants<F> {
-    fn into(self) -> Plonky3RoundConstants<F> {
+impl<F: Field> From<Poseidon2Constants<F>> for Plonky3RoundConstants<F> {
+    fn from(constants: Poseidon2Constants<F>) -> Self {
         Plonky3RoundConstants::new(
-            self.beginning_full_round_constants,
-            self.partial_round_constants,
-            self.ending_full_round_constants,
+            constants.beginning_full_round_constants,
+            constants.partial_round_constants,
+            constants.ending_full_round_constants,
         )
     }
 }

--- a/crates/circuits/poseidon2-air/src/permute.rs
+++ b/crates/circuits/poseidon2-air/src/permute.rs
@@ -1,7 +1,7 @@
 use std::{any::TypeId, marker::PhantomData};
 
 use derivative::Derivative;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::{BabyBear, BabyBearInternalLayerParameters};
 use p3_monty_31::InternalLayerBaseParameters;
 use p3_poseidon2::{
@@ -15,7 +15,7 @@ use super::{babybear_internal_linear_layer, BABY_BEAR_POSEIDON2_SBOX_DEGREE};
 const WIDTH: usize = crate::POSEIDON2_WIDTH;
 
 pub trait Poseidon2MatrixConfig: Clone + Sync {
-    fn int_diag_m1_matrix<F: AbstractField>() -> [F; WIDTH];
+    fn int_diag_m1_matrix<F: FieldAlgebra>() -> [F; WIDTH];
 }
 
 /// This type needs to implement GenericPoseidon2LinearLayers generic in F so that our Poseidon2SubAir can also
@@ -28,7 +28,7 @@ pub struct BabyBearPoseidon2LinearLayers;
 // clause that FA needs be multipliable by BabyBear.
 // TODO[jpw/stephen]: This is clearly not the best way to do this, but it would
 // require some reworking in plonky3 to get around the generics.
-impl<FA: AbstractField> GenericPoseidon2LinearLayers<FA, WIDTH> for BabyBearPoseidon2LinearLayers {
+impl<FA: FieldAlgebra> GenericPoseidon2LinearLayers<FA, WIDTH> for BabyBearPoseidon2LinearLayers {
     fn internal_linear_layer(state: &mut [FA; WIDTH]) {
         let diag_m1_matrix = &<BabyBearInternalLayerParameters as InternalLayerBaseParameters<
             _,
@@ -57,15 +57,15 @@ impl<FA: AbstractField> GenericPoseidon2LinearLayers<FA, WIDTH> for BabyBearPose
 
 #[derive(Debug, Derivative)]
 #[derivative(Clone)]
-pub struct Poseidon2InternalLayer<F: AbstractField, LinearLayers> {
+pub struct Poseidon2InternalLayer<F: FieldAlgebra, LinearLayers> {
     pub internal_constants: Vec<F>,
     _marker: PhantomData<LinearLayers>,
 }
 
-impl<AF: AbstractField, LinearLayers> InternalLayerConstructor<AF>
-    for Poseidon2InternalLayer<AF::F, LinearLayers>
+impl<FA: FieldAlgebra, LinearLayers> InternalLayerConstructor<FA>
+    for Poseidon2InternalLayer<FA::F, LinearLayers>
 {
-    fn new_from_constants(internal_constants: Vec<AF::F>) -> Self {
+    fn new_from_constants(internal_constants: Vec<FA::F>) -> Self {
         Self {
             internal_constants,
             _marker: PhantomData,
@@ -73,7 +73,7 @@ impl<AF: AbstractField, LinearLayers> InternalLayerConstructor<AF>
     }
 }
 
-impl<FA: AbstractField, LinearLayers, const WIDTH: usize>
+impl<FA: FieldAlgebra, LinearLayers, const WIDTH: usize>
     InternalLayer<FA, WIDTH, BABY_BEAR_POSEIDON2_SBOX_DEGREE>
     for Poseidon2InternalLayer<FA::F, LinearLayers>
 where
@@ -90,12 +90,12 @@ where
 
 #[derive(Debug, Derivative)]
 #[derivative(Clone)]
-pub struct Poseidon2ExternalLayer<F: AbstractField, LinearLayers, const WIDTH: usize> {
+pub struct Poseidon2ExternalLayer<F: FieldAlgebra, LinearLayers, const WIDTH: usize> {
     pub constants: ExternalLayerConstants<F, WIDTH>,
     _marker: PhantomData<LinearLayers>,
 }
 
-impl<FA: AbstractField, LinearLayers, const WIDTH: usize> ExternalLayerConstructor<FA, WIDTH>
+impl<FA: FieldAlgebra, LinearLayers, const WIDTH: usize> ExternalLayerConstructor<FA, WIDTH>
     for Poseidon2ExternalLayer<FA::F, LinearLayers, WIDTH>
 {
     fn new_from_constants(external_layer_constants: ExternalLayerConstants<FA::F, WIDTH>) -> Self {
@@ -106,7 +106,7 @@ impl<FA: AbstractField, LinearLayers, const WIDTH: usize> ExternalLayerConstruct
     }
 }
 
-impl<FA: AbstractField, LinearLayers, const WIDTH: usize>
+impl<FA: FieldAlgebra, LinearLayers, const WIDTH: usize>
     ExternalLayer<FA, WIDTH, BABY_BEAR_POSEIDON2_SBOX_DEGREE>
     for Poseidon2ExternalLayer<FA::F, LinearLayers, WIDTH>
 where
@@ -128,7 +128,7 @@ where
     }
 }
 
-fn external_permute_state<FA: AbstractField, LinearLayers, const WIDTH: usize>(
+fn external_permute_state<FA: FieldAlgebra, LinearLayers, const WIDTH: usize>(
     state: &mut [FA; WIDTH],
     constants: &[[FA::F; WIDTH]],
 ) where

--- a/crates/circuits/poseidon2-air/src/tests.rs
+++ b/crates/circuits/poseidon2-air/src/tests.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, sync::Arc};
 
 use openvm_stark_backend::{
-    p3_air::BaseAir, p3_field::AbstractField, utils::disable_debug_builder,
+    p3_air::BaseAir, p3_field::FieldAlgebra, utils::disable_debug_builder,
     verifier::VerificationError,
 };
 use openvm_stark_sdk::{

--- a/crates/circuits/primitives/src/assert_less_than/mod.rs
+++ b/crates/circuits/primitives/src/assert_less_than/mod.rs
@@ -3,7 +3,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::AirBuilder,
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
 };
 
 use crate::{

--- a/crates/circuits/primitives/src/assert_less_than/mod.rs
+++ b/crates/circuits/primitives/src/assert_less_than/mod.rs
@@ -3,7 +3,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::AirBuilder,
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
 };
 
 use crate::{

--- a/crates/circuits/primitives/src/assert_less_than/tests.rs
+++ b/crates/circuits/primitives/src/assert_less_than/tests.rs
@@ -7,7 +7,7 @@ use derive_new::new;
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/crates/circuits/primitives/src/assert_less_than/tests.rs
+++ b/crates/circuits/primitives/src/assert_less_than/tests.rs
@@ -7,7 +7,7 @@ use derive_new::new;
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,
@@ -191,7 +191,7 @@ fn test_assert_less_than_negative_2() {
     let range_trace = range_checker.generate_trace();
 
     // Make the trace invalid
-    trace.values[2] = AbstractField::from_canonical_u64(1 << decomp as u64);
+    trace.values[2] = FieldAlgebra::from_canonical_u64(1 << decomp as u64);
 
     disable_debug_builder();
     assert_eq!(

--- a/crates/circuits/primitives/src/bigint/check_carry_mod_to_zero.rs
+++ b/crates/circuits/primitives/src/bigint/check_carry_mod_to_zero.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use num_bigint_dig::BigUint;
-use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::AbstractField};
+use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::FieldAlgebra};
 
 use super::{
     check_carry_to_zero::{CheckCarryToZeroCols, CheckCarryToZeroSubAir},

--- a/crates/circuits/primitives/src/bigint/check_carry_to_zero.rs
+++ b/crates/circuits/primitives/src/bigint/check_carry_to_zero.rs
@@ -1,4 +1,4 @@
-use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::AbstractField};
+use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::FieldAlgebra};
 
 use super::{utils::range_check, OverflowInt};
 use crate::SubAir;

--- a/crates/circuits/primitives/src/bitwise_op_lookup/bus.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/bus.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -20,7 +20,7 @@ impl BitwiseOperationLookupBus {
         y: impl Into<T>,
     ) -> BitwiseOperationLookupBusInteraction<T>
     where
-        T: AbstractField,
+        T: FieldAlgebra,
     {
         self.push(x, y, T::ZERO, T::ZERO, InteractionType::Send)
     }
@@ -33,7 +33,7 @@ impl BitwiseOperationLookupBus {
         z: impl Into<T>,
     ) -> BitwiseOperationLookupBusInteraction<T>
     where
-        T: AbstractField,
+        T: FieldAlgebra,
     {
         self.push(x, y, z, T::ONE, InteractionType::Send)
     }
@@ -78,7 +78,7 @@ pub struct BitwiseOperationLookupBusInteraction<T> {
     pub interaction_type: InteractionType,
 }
 
-impl<T: AbstractField> BitwiseOperationLookupBusInteraction<T> {
+impl<T: FieldAlgebra> BitwiseOperationLookupBusInteraction<T> {
     pub fn eval<AB>(self, builder: &mut AB, count: impl Into<AB::Expr>)
     where
         AB: InteractionBuilder<Expr = T>,

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir, PairBuilder},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
     rap::{get_air_name, AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir, PairBuilder},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
     rap::{get_air_name, AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/bitwise_op_lookup/tests/dummy.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/tests/dummy.rs
@@ -1,7 +1,7 @@
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/primitives/src/bitwise_op_lookup/tests/dummy.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/tests/dummy.rs
@@ -1,7 +1,7 @@
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/primitives/src/bitwise_op_lookup/tests/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/tests/mod.rs
@@ -2,7 +2,7 @@ use std::{iter, sync::Arc};
 
 use dummy::DummyAir;
 use openvm_stark_backend::{
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::dense::RowMajorMatrix,
     p3_maybe_rayon::prelude::{IntoParallelRefIterator, ParallelIterator},
     prover::USE_DEBUG_BUILDER,
@@ -88,7 +88,7 @@ fn test_bitwise_operation_lookup() {
                         };
                         [x, y, z, op as u32].into_iter()
                     })
-                    .map(AbstractField::from_canonical_u32)
+                    .map(FieldAlgebra::from_canonical_u32)
                     .collect(),
                 4,
             )
@@ -122,7 +122,7 @@ fn run_negative_test(bad_row: (u32, u32, u32, BitwiseOperation)) {
                     };
                     [x, y, z, op as u32].into_iter()
                 })
-                .map(AbstractField::from_canonical_u32)
+                .map(FieldAlgebra::from_canonical_u32)
                 .collect(),
             4,
         ),

--- a/crates/circuits/primitives/src/encoder/mod.rs
+++ b/crates/circuits/primitives/src/encoder/mod.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
 };
 
 use crate::SubAir;

--- a/crates/circuits/primitives/src/encoder/mod.rs
+++ b/crates/circuits/primitives/src/encoder/mod.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
 };
 
 use crate::SubAir;

--- a/crates/circuits/primitives/src/is_equal/tests.rs
+++ b/crates/circuits/primitives/src/is_equal/tests.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
@@ -82,8 +82,8 @@ impl<F: Field> IsEqualChip<F> {
     [0,23,97]
 )]
 fn test_single_is_equal(x: u32, y: u32) {
-    let x = AbstractField::from_canonical_u32(x);
-    let y = AbstractField::from_canonical_u32(y);
+    let x = FieldAlgebra::from_canonical_u32(x);
+    let y = FieldAlgebra::from_canonical_u32(y);
 
     let chip = IsEqualChip {
         pairs: vec![(x, y)],
@@ -103,18 +103,18 @@ fn test_single_is_equal(x: u32, y: u32) {
     [0,23,97]
 )]
 fn test_single_is_zero_fail(x: u32, y: u32) {
-    let x = AbstractField::from_canonical_u32(x);
-    let y = AbstractField::from_canonical_u32(y);
+    let x = FieldAlgebra::from_canonical_u32(x);
+    let y = FieldAlgebra::from_canonical_u32(y);
 
     let chip = IsEqualChip {
         pairs: vec![(x, y)],
     };
 
     let mut trace = chip.generate_trace();
-    trace.values[2] = if trace.values[2] == AbstractField::ONE {
-        AbstractField::ZERO
+    trace.values[2] = if trace.values[2] == FieldAlgebra::ONE {
+        FieldAlgebra::ZERO
     } else {
-        AbstractField::ONE
+        FieldAlgebra::ONE
     };
 
     disable_debug_builder();

--- a/crates/circuits/primitives/src/is_equal/tests.rs
+++ b/crates/circuits/primitives/src/is_equal/tests.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/is_equal_array/tests.rs
+++ b/crates/circuits/primitives/src/is_equal_array/tests.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
@@ -92,15 +92,15 @@ impl<F: Field, const N: usize> IsEqArrayChip<F, N> {
 #[test_case([92, 27, 32], [92, 27, 32], 1; "92, 27, 32 == 92, 27, 32")]
 #[test_case([1, 27, 4], [1, 2, 43], 0; "1, 27, 4 != 1, 2, 43")]
 fn test_is_eq_array_single_row(x: [u32; 3], y: [u32; 3], is_equal: u32) {
-    let x = x.map(AbstractField::from_canonical_u32);
-    let y = y.map(AbstractField::from_canonical_u32);
+    let x = x.map(FieldAlgebra::from_canonical_u32);
+    let y = y.map(FieldAlgebra::from_canonical_u32);
 
     let chip = IsEqArrayChip::new(vec![(x, y)]);
     let air = chip.air;
     let trace = chip.generate_trace();
     let row: &IsEqArrayCols<BabyBear, 3> = trace.values.as_slice().borrow();
 
-    assert_eq!(row.out, AbstractField::from_canonical_u32(is_equal));
+    assert_eq!(row.out, FieldAlgebra::from_canonical_u32(is_equal));
 
     BabyBearPoseidon2Engine::run_simple_test_no_pis_fast(any_rap_arc_vec![air], vec![trace])
         .expect("Verification failed");
@@ -117,8 +117,8 @@ fn test_is_eq_array_multi_rows() {
     .into_iter()
     .map(|(x, y)| {
         (
-            x.map(AbstractField::from_canonical_u32),
-            y.map(AbstractField::from_canonical_u32),
+            x.map(FieldAlgebra::from_canonical_u32),
+            y.map(FieldAlgebra::from_canonical_u32),
         )
     })
     .collect();
@@ -139,8 +139,8 @@ fn test_is_eq_array_multi_rows() {
 #[test_case([92, 27, 32], [92, 27, 32]; "92, 27, 32 == 92, 27, 32")]
 #[test_case([1, 27, 4], [1, 2, 43]; "1, 27, 4 != 1, 2, 43")]
 fn test_is_eq_array_single_row_fail(x: [u32; 3], y: [u32; 3]) {
-    let x = x.map(AbstractField::from_canonical_u32);
-    let y = y.map(AbstractField::from_canonical_u32);
+    let x = x.map(FieldAlgebra::from_canonical_u32);
+    let y = y.map(FieldAlgebra::from_canonical_u32);
 
     let chip = IsEqArrayChip::new(vec![(x, y)]);
     let air = chip.air;
@@ -164,7 +164,7 @@ fn test_is_eq_array_fail_rand() {
     let mut rng = create_seeded_rng();
     let pairs: Vec<_> = (0..height)
         .map(|_| {
-            let x = from_fn(|_| AbstractField::from_wrapped_u32(rng.gen::<u32>()));
+            let x = from_fn(|_| FieldAlgebra::from_wrapped_u32(rng.gen::<u32>()));
             (x, x)
         })
         .collect();
@@ -176,7 +176,7 @@ fn test_is_eq_array_fail_rand() {
     for i in 0..height {
         for j in 0..N {
             let mut prank_trace = trace.clone();
-            prank_trace.row_mut(i)[j] += AbstractField::from_wrapped_u32(rng.gen::<u32>() + 1);
+            prank_trace.row_mut(i)[j] += FieldAlgebra::from_wrapped_u32(rng.gen::<u32>() + 1);
             assert_eq!(
                 BabyBearPoseidon2Engine::run_simple_test_no_pis_fast(
                     any_rap_arc_vec![air],

--- a/crates/circuits/primitives/src/is_equal_array/tests.rs
+++ b/crates/circuits/primitives/src/is_equal_array/tests.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/is_less_than/mod.rs
+++ b/crates/circuits/primitives/src/is_less_than/mod.rs
@@ -1,7 +1,7 @@
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::AirBuilder,
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
 };
 
 use crate::{

--- a/crates/circuits/primitives/src/is_less_than/mod.rs
+++ b/crates/circuits/primitives/src/is_less_than/mod.rs
@@ -1,7 +1,7 @@
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::AirBuilder,
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
 };
 
 use crate::{

--- a/crates/circuits/primitives/src/is_less_than/tests.rs
+++ b/crates/circuits/primitives/src/is_less_than/tests.rs
@@ -4,7 +4,7 @@ use derive_new::new;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/is_less_than/tests.rs
+++ b/crates/circuits/primitives/src/is_less_than/tests.rs
@@ -4,7 +4,7 @@ use derive_new::new;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
@@ -161,7 +161,7 @@ fn test_is_less_than_negative() {
     let mut trace = chip.generate_trace();
     let range_trace = range_checker.generate_trace();
 
-    trace.values[2] = AbstractField::from_canonical_u64(0);
+    trace.values[2] = FieldAlgebra::from_canonical_u64(0);
 
     disable_debug_builder();
     assert_eq!(

--- a/crates/circuits/primitives/src/is_less_than_array/mod.rs
+++ b/crates/circuits/primitives/src/is_less_than_array/mod.rs
@@ -3,7 +3,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::AirBuilder,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
 };
 
 use crate::{

--- a/crates/circuits/primitives/src/is_less_than_array/tests.rs
+++ b/crates/circuits/primitives/src/is_less_than_array/tests.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
@@ -149,7 +149,7 @@ fn test_is_less_than_tuple_chip_negative() {
     let mut trace = chip.generate_trace();
     let range_checker_trace = range_checker.generate_trace();
 
-    trace.values[2] = AbstractField::from_canonical_u64(0);
+    trace.values[2] = FieldAlgebra::from_canonical_u64(0);
 
     disable_debug_builder();
     assert_eq!(

--- a/crates/circuits/primitives/src/is_less_than_array/tests.rs
+++ b/crates/circuits/primitives/src/is_less_than_array/tests.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/is_zero/tests.rs
+++ b/crates/circuits/primitives/src/is_zero/tests.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
@@ -84,7 +84,7 @@ fn test_single_is_zero(x: u32) {
     let air = chip.air;
     let trace = chip.generate_trace();
 
-    assert_eq!(trace.get(0, 1), AbstractField::from_bool(x == 0));
+    assert_eq!(trace.get(0, 1), FieldAlgebra::from_bool(x == 0));
 
     BabyBearPoseidon2Engine::run_simple_test_no_pis_fast(any_rap_arc_vec![air], vec![trace])
         .expect("Verification failed");
@@ -95,7 +95,7 @@ fn test_single_is_zero(x: u32) {
 fn test_vec_is_zero(x_vec: [u32; 4], expected: [u32; 4]) {
     let x_vec = x_vec
         .into_iter()
-        .map(AbstractField::from_canonical_u32)
+        .map(FieldAlgebra::from_canonical_u32)
         .collect();
     let chip = IsZeroChip::new(x_vec);
     let air = chip.air;
@@ -104,7 +104,7 @@ fn test_vec_is_zero(x_vec: [u32; 4], expected: [u32; 4]) {
     for (i, value) in expected.iter().enumerate() {
         assert_eq!(
             trace.values[3 * i + 1],
-            AbstractField::from_canonical_u32(*value)
+            FieldAlgebra::from_canonical_u32(*value)
         );
     }
 
@@ -115,7 +115,7 @@ fn test_vec_is_zero(x_vec: [u32; 4], expected: [u32; 4]) {
 #[test_case(97 ; "97 => 0")]
 #[test_case(0 ; "0 => 1")]
 fn test_single_is_zero_fail(x: u32) {
-    let x = AbstractField::from_canonical_u32(x);
+    let x = FieldAlgebra::from_canonical_u32(x);
     let chip = IsZeroChip::new(vec![x]);
     let air = chip.air;
     let mut trace = chip.generate_trace();

--- a/crates/circuits/primitives/src/is_zero/tests.rs
+++ b/crates/circuits/primitives/src/is_zero/tests.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/offline_checker/air.rs
+++ b/crates/circuits/primitives/src/offline_checker/air.rs
@@ -3,7 +3,7 @@ use std::iter;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField},
+    p3_field::{FieldAlgebra, Field, PrimeField},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/primitives/src/range/bus.rs
+++ b/crates/circuits/primitives/src/range/bus.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
 };
 
 /// Represents a bus for `x` where `x` must lie in the range `[0, range_max)`.
@@ -64,7 +64,7 @@ pub struct RangeCheckBusInteraction<T> {
     pub interaction_type: InteractionType,
 }
 
-impl<T: AbstractField> RangeCheckBusInteraction<T> {
+impl<T: FieldAlgebra> RangeCheckBusInteraction<T> {
     /// Finalizes and sends/receives over the RangeCheck bus.
     pub fn eval<AB>(self, builder: &mut AB, count: impl Into<AB::Expr>)
     where
@@ -74,7 +74,7 @@ impl<T: AbstractField> RangeCheckBusInteraction<T> {
     }
 }
 
-impl<T: AbstractField> BitsCheckBusInteraction<T> {
+impl<T: FieldAlgebra> BitsCheckBusInteraction<T> {
     /// Send interaction(s) to range check for max bits over the RangeCheck bus.
     pub fn eval<AB>(self, builder: &mut AB, count: impl Into<AB::Expr>)
     where

--- a/crates/circuits/primitives/src/range/tests/list/air.rs
+++ b/crates/circuits/primitives/src/range/tests/list/air.rs
@@ -3,7 +3,7 @@ use std::borrow::Borrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/primitives/src/range/tests/list/air.rs
+++ b/crates/circuits/primitives/src/range/tests/list/air.rs
@@ -3,7 +3,7 @@ use std::borrow::Borrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/primitives/src/range_gate/mod.rs
+++ b/crates/circuits/primitives/src/range_gate/mod.rs
@@ -12,7 +12,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_util::indices_arr,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/range_gate/mod.rs
+++ b/crates/circuits/primitives/src/range_gate/mod.rs
@@ -12,7 +12,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_util::indices_arr,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/circuits/primitives/src/range_gate/tests.rs
+++ b/crates/circuits/primitives/src/range_gate/tests.rs
@@ -1,7 +1,7 @@
 use std::{iter, sync::Arc};
 
 use openvm_stark_backend::{
-    p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
+    p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
     rap::AnyRap, utils::disable_debug_builder, verifier::VerificationError,
 };
 use openvm_stark_sdk::{
@@ -50,7 +50,7 @@ fn test_range_gate_chip() {
                         range_checker.add_count(v);
                         iter::once(1).chain(iter::once(v))
                     })
-                    .map(AbstractField::from_wrapped_u32)
+                    .map(FieldAlgebra::from_wrapped_u32)
                     .collect(),
                 2,
             )
@@ -91,7 +91,7 @@ fn negative_test_range_gate_chip() {
                     range_checker.count[i as usize].load(std::sync::atomic::Ordering::Relaxed);
                 iter::once(i + 1).chain(iter::once(count))
             })
-            .map(AbstractField::from_wrapped_u32)
+            .map(FieldAlgebra::from_wrapped_u32)
             .collect(),
         2,
     );

--- a/crates/circuits/primitives/src/range_tuple/bus.rs
+++ b/crates/circuits/primitives/src/range_tuple/bus.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -44,7 +44,7 @@ pub struct RangeTupleCheckerBusInteraction<T> {
     pub interaction_type: InteractionType,
 }
 
-impl<T: AbstractField> RangeTupleCheckerBusInteraction<T> {
+impl<T: FieldAlgebra> RangeTupleCheckerBusInteraction<T> {
     pub fn eval<AB>(self, builder: &mut AB, count: impl Into<AB::Expr>)
     where
         AB: InteractionBuilder<Expr = T>,

--- a/crates/circuits/primitives/src/range_tuple/tests.rs
+++ b/crates/circuits/primitives/src/range_tuple/tests.rs
@@ -1,7 +1,7 @@
 use std::{array, iter, sync::Arc};
 
 use openvm_stark_backend::{
-    p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
+    p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
     rap::AnyRap,
 };
 use openvm_stark_sdk::{
@@ -61,7 +61,7 @@ fn test_range_tuple_chip() {
                         range_checker.add_count(&v);
                         iter::once(1).chain(v)
                     })
-                    .map(AbstractField::from_wrapped_u32)
+                    .map(FieldAlgebra::from_wrapped_u32)
                     .collect(),
                 sizes.len() + 1,
             )
@@ -101,7 +101,7 @@ fn test_range_tuple_chip() {
 //                 v.reverse();
 //                 v.into_iter().chain(iter::once(0))
 //             })
-//             .map(AbstractField::from_wrapped_u32)
+//             .map(FieldAlgebra::from_wrapped_u32)
 //             .collect(),
 //         sizes.len() + 1,
 //     );

--- a/crates/circuits/primitives/src/utils.rs
+++ b/crates/circuits/primitives/src/utils.rs
@@ -1,7 +1,7 @@
 use itertools::zip_eq;
 use openvm_stark_backend::{
     p3_air::{AirBuilder, VirtualPairCol},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
 };
 
 /// Return either 0 if n is zero or the next power of two of n.

--- a/crates/circuits/primitives/src/utils.rs
+++ b/crates/circuits/primitives/src/utils.rs
@@ -1,7 +1,7 @@
 use itertools::zip_eq;
 use openvm_stark_backend::{
     p3_air::{AirBuilder, VirtualPairCol},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
 };
 
 /// Return either 0 if n is zero or the next power of two of n.
@@ -14,28 +14,28 @@ pub const fn next_power_of_two_or_zero(n: usize) -> usize {
     }
 }
 
-pub fn not<F: AbstractField>(a: impl Into<F>) -> F {
+pub fn not<F: FieldAlgebra>(a: impl Into<F>) -> F {
     F::ONE - a.into()
 }
 
-pub fn and<F: AbstractField>(a: impl Into<F>, b: impl Into<F>) -> F {
+pub fn and<F: FieldAlgebra>(a: impl Into<F>, b: impl Into<F>) -> F {
     a.into() * b.into()
 }
 
 /// Assumes that a and b are boolean
-pub fn or<F: AbstractField>(a: impl Into<F>, b: impl Into<F>) -> F {
+pub fn or<F: FieldAlgebra>(a: impl Into<F>, b: impl Into<F>) -> F {
     let a = a.into();
     let b = b.into();
     a.clone() + b.clone() - and(a, b)
 }
 
 /// Assumes that a and b are boolean
-pub fn implies<F: AbstractField>(a: impl Into<F>, b: impl Into<F>) -> F {
+pub fn implies<F: FieldAlgebra>(a: impl Into<F>, b: impl Into<F>) -> F {
     or(F::ONE - a.into(), b.into())
 }
 
 /// Assumes that `cond` is boolean. Returns `a` if `cond` is true, otherwise returns `b`.
-pub fn select<F: AbstractField>(cond: impl Into<F>, a: impl Into<F>, b: impl Into<F>) -> F {
+pub fn select<F: FieldAlgebra>(cond: impl Into<F>, a: impl Into<F>, b: impl Into<F>) -> F {
     let cond = cond.into();
     cond.clone() * a.into() + (F::ONE - cond) * b.into()
 }

--- a/crates/circuits/primitives/src/var_range/bus.rs
+++ b/crates/circuits/primitives/src/var_range/bus.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
 };
 
 // Represents a bus for (x, bits) where either (x, bits) = (0, 0) or
@@ -45,7 +45,7 @@ impl VariableRangeCheckerBus {
         max_bits: usize,
     ) -> VariableRangeCheckerBusInteraction<T>
     where
-        T: AbstractField,
+        T: FieldAlgebra,
     {
         debug_assert!(max_bits <= self.range_max_bits);
         self.push(
@@ -78,7 +78,7 @@ pub struct VariableRangeCheckerBusInteraction<T> {
     pub interaction_type: InteractionType,
 }
 
-impl<T: AbstractField> VariableRangeCheckerBusInteraction<T> {
+impl<T: FieldAlgebra> VariableRangeCheckerBusInteraction<T> {
     pub fn eval<AB>(self, builder: &mut AB, count: impl Into<AB::Expr>)
     where
         AB: InteractionBuilder<Expr = T>,

--- a/crates/circuits/primitives/src/var_range/tests/dummy_airs.rs
+++ b/crates/circuits/primitives/src/var_range/tests/dummy_airs.rs
@@ -1,7 +1,7 @@
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/primitives/src/var_range/tests/dummy_airs.rs
+++ b/crates/circuits/primitives/src/var_range/tests/dummy_airs.rs
@@ -1,7 +1,7 @@
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/circuits/primitives/src/var_range/tests/mod.rs
+++ b/crates/circuits/primitives/src/var_range/tests/mod.rs
@@ -1,7 +1,7 @@
 use std::{iter, sync::Arc};
 
 use openvm_stark_backend::{
-    p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
+    p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
     prover::USE_DEBUG_BUILDER, rap::AnyRap, verifier::VerificationError,
 };
 use openvm_stark_sdk::{
@@ -64,7 +64,7 @@ fn test_variable_range_checker_chip_send() {
                         var_range_checker.add_count(val, bits as usize);
                         iter::once(val).chain(iter::once(bits))
                     })
-                    .map(AbstractField::from_canonical_u32)
+                    .map(FieldAlgebra::from_canonical_u32)
                     .collect(),
                 2,
             )
@@ -116,7 +116,7 @@ fn negative_test_variable_range_checker_chip_send() {
                 var_range_checker.add_count(val, bits as usize);
                 iter::once(val).chain(iter::once(bits))
             })
-            .map(AbstractField::from_canonical_u32)
+            .map(FieldAlgebra::from_canonical_u32)
             .collect(),
         2,
     );
@@ -177,7 +177,7 @@ fn test_variable_range_checker_chip_range_check() {
                         var_range_checker.add_count(val, MAX_BITS);
                         iter::once(val)
                     })
-                    .map(AbstractField::from_canonical_u32)
+                    .map(FieldAlgebra::from_canonical_u32)
                     .collect(),
                 1,
             )
@@ -227,7 +227,7 @@ fn negative_test_variable_range_checker_chip_range_check() {
                 var_range_checker.add_count(val, MAX_BITS);
                 iter::once(val)
             })
-            .map(AbstractField::from_canonical_u32)
+            .map(FieldAlgebra::from_canonical_u32)
             .collect(),
         1,
     );

--- a/crates/circuits/primitives/src/xor/bus.rs
+++ b/crates/circuits/primitives/src/xor/bus.rs
@@ -1,6 +1,6 @@
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
 };
 
 /// Represents a bus for `(x, y, x ^ y)` identified by a unique bus index (`usize`).
@@ -53,7 +53,7 @@ pub struct XorBusInteraction<T> {
     pub interaction_type: InteractionType,
 }
 
-impl<T: AbstractField> XorBusInteraction<T> {
+impl<T: FieldAlgebra> XorBusInteraction<T> {
     /// Finalizes and sends/receives over the Xor bus.
     pub fn eval<AB>(self, builder: &mut AB, count: impl Into<AB::Expr>)
     where

--- a/crates/circuits/primitives/src/xor/lookup/tests.rs
+++ b/crates/circuits/primitives/src/xor/lookup/tests.rs
@@ -1,7 +1,7 @@
 use std::{iter, sync::Arc};
 
 use openvm_stark_backend::{
-    p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
+    p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
     rap::AnyRap, utils::disable_debug_builder, verifier::VerificationError,
 };
 use openvm_stark_sdk::{
@@ -59,7 +59,7 @@ fn test_xor_limbs_chip() {
                         let z = xor_chip.request(x, y);
                         iter::once(count).chain(fields).chain(iter::once(z))
                     })
-                    .map(AbstractField::from_wrapped_u32)
+                    .map(FieldAlgebra::from_wrapped_u32)
                     .collect(),
                 4,
             )
@@ -123,7 +123,7 @@ fn negative_test_xor_limbs_chip() {
                     iter::once(count).chain(fields).chain(iter::once(z))
                 }
             })
-            .map(AbstractField::from_wrapped_u32)
+            .map(FieldAlgebra::from_wrapped_u32)
             .collect(),
         4,
     );

--- a/crates/sdk/src/commit.rs
+++ b/crates/sdk/src/commit.rs
@@ -16,7 +16,7 @@ use openvm_stark_backend::{config::StarkGenericConfig, p3_field::PrimeField32};
 use openvm_stark_sdk::{
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},
     engine::StarkFriEngine,
-    openvm_stark_backend::p3_field::AbstractField,
+    openvm_stark_backend::p3_field::FieldAlgebra,
     p3_baby_bear::BabyBear,
     p3_bn254_fr::Bn254Fr,
 };

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -22,7 +22,7 @@ use openvm_stark_sdk::{
     },
     engine::StarkFriEngine,
     openvm_stark_backend::{
-        config::StarkGenericConfig, p3_field::AbstractField, prover::types::Proof, Chip,
+        config::StarkGenericConfig, p3_field::FieldAlgebra, prover::types::Proof, Chip,
     },
 };
 

--- a/crates/sdk/src/static_verifier/mod.rs
+++ b/crates/sdk/src/static_verifier/mod.rs
@@ -13,7 +13,7 @@ use openvm_native_recursion::{
 };
 use openvm_stark_sdk::{
     openvm_stark_backend::{
-        p3_field::{AbstractField, PrimeField32},
+        p3_field::{FieldAlgebra, PrimeField32},
         prover::types::Proof,
     },
     p3_baby_bear::BabyBear,

--- a/crates/sdk/src/stdin.rs
+++ b/crates/sdk/src/stdin.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use openvm_circuit::arch::Streams;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use serde::{Deserialize, Serialize};
 
 use crate::F;

--- a/crates/sdk/src/verifier/common/mod.rs
+++ b/crates/sdk/src/verifier/common/mod.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 };
 use openvm_native_compiler::{ir::Config, prelude::*};
 use openvm_native_recursion::{digest::DigestVariable, vars::StarkProofVariable};
-use openvm_stark_sdk::openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_sdk::openvm_stark_backend::p3_field::FieldAlgebra;
 
 use crate::verifier::internal::types::InternalVmVerifierPvs;
 

--- a/crates/sdk/src/verifier/leaf/mod.rs
+++ b/crates/sdk/src/verifier/leaf/mod.rs
@@ -11,7 +11,7 @@ use openvm_native_recursion::{
 use openvm_stark_sdk::{
     config::{baby_bear_poseidon2::BabyBearPoseidon2Config, FriParameters},
     openvm_stark_backend::{
-        keygen::types::MultiStarkVerifyingKey, p3_field::AbstractField, p3_util::log2_strict_usize,
+        keygen::types::MultiStarkVerifyingKey, p3_field::FieldAlgebra, p3_util::log2_strict_usize,
         prover::types::Proof,
     },
 };

--- a/crates/sdk/src/verifier/leaf/vars.rs
+++ b/crates/sdk/src/verifier/leaf/vars.rs
@@ -4,7 +4,7 @@ use openvm_native_compiler::prelude::*;
 use openvm_native_recursion::hints::Hintable;
 use openvm_stark_sdk::openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     prover::types::Proof,
 };
 

--- a/crates/sdk/src/verifier/root/mod.rs
+++ b/crates/sdk/src/verifier/root/mod.rs
@@ -8,7 +8,7 @@ use openvm_native_recursion::{
 };
 use openvm_stark_sdk::{
     config::FriParameters,
-    openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, p3_field::AbstractField},
+    openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, p3_field::FieldAlgebra},
 };
 
 use crate::{

--- a/crates/sdk/src/verifier/utils.rs
+++ b/crates/sdk/src/verifier/utils.rs
@@ -2,7 +2,7 @@ use std::array;
 
 use openvm_native_compiler::prelude::*;
 use openvm_native_recursion::{hints::Hintable, types::InnerConfig};
-use openvm_stark_sdk::{openvm_stark_backend::p3_field::AbstractField, p3_baby_bear::BabyBear};
+use openvm_stark_sdk::{openvm_stark_backend::p3_field::FieldAlgebra, p3_baby_bear::BabyBear};
 
 pub(crate) fn assign_array_to_slice<C: Config>(
     builder: &mut Builder<C>,

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -27,7 +27,7 @@ use openvm_stark_sdk::{
         fri_params::standard_fri_params_with_100_bits_conjectured_security,
     },
     engine::{StarkEngine, StarkFriEngine},
-    openvm_stark_backend::{p3_field::AbstractField, Chip},
+    openvm_stark_backend::{p3_field::FieldAlgebra, Chip},
     p3_baby_bear::BabyBear,
 };
 use openvm_transpiler::transpiler::Transpiler;

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -4,7 +4,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, PhantomDiscriminant, VmOpcode,
 };
-use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::AbstractField};
+use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::FieldAlgebra};
 use thiserror::Error;
 
 use super::Streams;
@@ -274,7 +274,7 @@ impl<AB: InteractionBuilder> ExecutionBridgeInteractor<AB> {
     }
 }
 
-impl<T: AbstractField> From<(u32, Option<T>)> for PcIncOrSet<T> {
+impl<T: FieldAlgebra> From<(u32, Option<T>)> for PcIncOrSet<T> {
     fn from((pc_inc, to_pc): (u32, Option<T>)) -> Self {
         match to_pc {
             None => PcIncOrSet::Inc(T::from_canonical_u32(pc_inc)),

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -14,7 +14,7 @@ use openvm_instructions::{
 use openvm_stark_backend::{
     config::{Domain, StarkGenericConfig},
     p3_commit::PolynomialSpace,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::Matrix,
     prover::types::{AirProofInput, CommittedTraceData, ProofInput},
     rap::AnyRap,
@@ -1048,7 +1048,7 @@ pub fn generate_air_proof_input<SC: StarkGenericConfig, C: Chip<SC>>(
             height >= main.height(),
             "Overridden height must be greater than or equal to the used height"
         );
-        main.pad_to_height(height, AbstractField::ZERO);
+        main.pad_to_height(height, FieldAlgebra::ZERO);
     }
     proof_input
 }

--- a/crates/vm/src/arch/hasher/poseidon2.rs
+++ b/crates/vm/src/arch/hasher/poseidon2.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use openvm_poseidon2_air::p3_symmetric::Permutation;
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 
 use crate::{

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     },
     config::{StarkGenericConfig, Val},
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,
@@ -995,7 +995,7 @@ mod conversions {
 
     // AdapterRuntimeContext: FlatInterface -> BasicInterface
     impl<
-            T: AbstractField,
+            T: FieldAlgebra,
             PI,
             const NUM_READS: usize,
             const NUM_WRITES: usize,

--- a/crates/vm/src/arch/testing/execution/mod.rs
+++ b/crates/vm/src/arch/testing/execution/mod.rs
@@ -3,7 +3,7 @@ use std::{borrow::BorrowMut, mem::size_of, sync::Arc};
 use air::{DummyExecutionInteractionCols, ExecutionDummyAir};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     prover::types::AirProofInput,
     rap::AnyRap,

--- a/crates/vm/src/arch/testing/execution/mod.rs
+++ b/crates/vm/src/arch/testing/execution/mod.rs
@@ -3,7 +3,7 @@ use std::{borrow::BorrowMut, mem::size_of, sync::Arc};
 use air::{DummyExecutionInteractionCols, ExecutionDummyAir};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     prover::types::AirProofInput,
     rap::AnyRap,

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -4,7 +4,7 @@ use air::{DummyMemoryInteractionCols, MemoryDummyAir};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionType,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     prover::types::AirProofInput,
     rap::AnyRap,

--- a/crates/vm/src/arch/testing/program/mod.rs
+++ b/crates/vm/src/arch/testing/program/mod.rs
@@ -4,7 +4,7 @@ use air::ProgramDummyAir;
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     prover::types::AirProofInput,
     rap::AnyRap,

--- a/crates/vm/src/arch/testing/program/mod.rs
+++ b/crates/vm/src/arch/testing/program/mod.rs
@@ -4,7 +4,7 @@ use air::ProgramDummyAir;
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     prover::types::AirProofInput,
     rap::AnyRap,

--- a/crates/vm/src/arch/testing/test_adapter.rs
+++ b/crates/vm/src/arch/testing/test_adapter.rs
@@ -9,7 +9,7 @@ use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use crate::{

--- a/crates/vm/src/arch/testing/test_adapter.rs
+++ b/crates/vm/src/arch/testing/test_adapter.rs
@@ -9,7 +9,7 @@ use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use crate::{

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -10,7 +10,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
     rap::{AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -10,7 +10,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
     rap::{AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/vm/src/system/connector/tests.rs
+++ b/crates/vm/src/system/connector/tests.rs
@@ -7,7 +7,7 @@ use openvm_instructions::{
     instruction::Instruction, program::Program, SystemOpcode::TERMINATE, VmOpcode,
 };
 use openvm_stark_backend::{
-    config::StarkGenericConfig, engine::StarkEngine, p3_field::AbstractField,
+    config::StarkGenericConfig, engine::StarkEngine, p3_field::FieldAlgebra,
     prover::types::AirProofInput, utils::disable_debug_builder,
 };
 use openvm_stark_sdk::{

--- a/crates/vm/src/system/memory/adapter/air.rs
+++ b/crates/vm/src/system/memory/adapter/air.rs
@@ -7,7 +7,7 @@ use openvm_circuit_primitives::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/vm/src/system/memory/manager/memory.rs
+++ b/crates/vm/src/system/memory/manager/memory.rs
@@ -410,7 +410,7 @@ impl<F: PrimeField32> Memory<F> {
 
 #[cfg(test)]
 mod tests {
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
     use super::{BlockData, Memory};

--- a/crates/vm/src/system/memory/manager/mod.rs
+++ b/crates/vm/src/system/memory/manager/mod.rs
@@ -726,7 +726,7 @@ mod tests {
     use std::sync::Arc;
 
     use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use rand::{prelude::SliceRandom, thread_rng, Rng};
 

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, iter};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, iter};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use openvm_stark_backend::{
-    interaction::InteractionType, p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix,
+    interaction::InteractionType, p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix,
     prover::types::AirProofInput, Chip, ChipUsageGetter,
 };
 use openvm_stark_sdk::{

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -2,7 +2,7 @@ use std::{borrow::BorrowMut, cmp::Reverse, sync::Arc};
 
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     prover::types::AirProofInput,
     rap::AnyRap,

--- a/crates/vm/src/system/memory/offline_checker/bridge.rs
+++ b/crates/vm/src/system/memory/offline_checker/bridge.rs
@@ -6,7 +6,7 @@ use openvm_circuit_primitives::{
     SubAir,
 };
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, p3_air::AirBuilder, p3_field::AbstractField,
+    interaction::InteractionBuilder, p3_air::AirBuilder, p3_field::FieldAlgebra,
 };
 
 use super::bus::MemoryBus;
@@ -116,7 +116,7 @@ pub struct MemoryReadOperation<'a, T, V, const N: usize> {
 /// The max degree of constraints is:
 /// eval_timestamps: deg(enabled) + max(1, deg(self.timestamp))
 /// eval_bulk_access: refer to [MemoryOfflineChecker::eval_bulk_access]
-impl<F: AbstractField, V: Copy + Into<F>, const N: usize> MemoryReadOperation<'_, F, V, N> {
+impl<F: FieldAlgebra, V: Copy + Into<F>, const N: usize> MemoryReadOperation<'_, F, V, N> {
     /// Evaluate constraints and send/receive interactions.
     pub fn eval<AB>(self, builder: &mut AB, enabled: impl Into<AB::Expr>)
     where
@@ -170,7 +170,7 @@ pub struct MemoryReadOrImmediateOperation<'a, T, V> {
 /// is_immediate check: deg(aux.is_immediate) + max(deg(data), deg(address.pointer))
 /// eval_timestamps: deg(enabled) + max(1, deg(self.timestamp))
 /// eval_bulk_access: refer to [MemoryOfflineChecker::eval_bulk_access]
-impl<F: AbstractField, V: Copy + Into<F>> MemoryReadOrImmediateOperation<'_, F, V> {
+impl<F: FieldAlgebra, V: Copy + Into<F>> MemoryReadOrImmediateOperation<'_, F, V> {
     /// Evaluate constraints and send/receive interactions.
     pub fn eval<AB>(self, builder: &mut AB, enabled: impl Into<AB::Expr>)
     where
@@ -230,7 +230,7 @@ pub struct MemoryWriteOperation<'a, T, V, const N: usize> {
 /// The max degree of constraints is:
 /// eval_timestamps: deg(enabled) + max(1, deg(self.timestamp))
 /// eval_bulk_access: refer to [MemoryOfflineChecker::eval_bulk_access]
-impl<T: AbstractField, V: Copy + Into<T>, const N: usize> MemoryWriteOperation<'_, T, V, N> {
+impl<T: FieldAlgebra, V: Copy + Into<T>, const N: usize> MemoryWriteOperation<'_, T, V, N> {
     /// Evaluate constraints and send/receive interactions. `enabled` must be boolean.
     pub fn eval<AB>(self, builder: &mut AB, enabled: impl Into<AB::Expr>)
     where

--- a/crates/vm/src/system/memory/offline_checker/bus.rs
+++ b/crates/vm/src/system/memory/offline_checker/bus.rs
@@ -2,7 +2,7 @@ use std::iter;
 
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, InteractionType},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
 };
 
 use crate::system::memory::MemoryAddress;
@@ -59,7 +59,7 @@ pub struct MemoryBusInteraction<T> {
     pub timestamp: T,
 }
 
-impl<T: AbstractField> MemoryBusInteraction<T> {
+impl<T: FieldAlgebra> MemoryBusInteraction<T> {
     /// Finalizes and sends/receives the memory operation with the specified count over the bus.
     ///
     /// A read corresponds to a receive, and a write corresponds to a send.

--- a/crates/vm/src/system/memory/offline_checker/columns.rs
+++ b/crates/vm/src/system/memory/offline_checker/columns.rs
@@ -5,7 +5,7 @@ use std::{array, borrow::Borrow, iter};
 
 use openvm_circuit_primitives::is_less_than::LessThanAuxCols;
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 
 use crate::system::memory::offline_checker::bridge::AUX_LEN;
 
@@ -97,7 +97,7 @@ impl<const N: usize, T> MemoryWriteAuxCols<T, N> {
     }
 }
 
-impl<const N: usize, F: AbstractField + Copy> MemoryWriteAuxCols<F, N> {
+impl<const N: usize, F: FieldAlgebra + Copy> MemoryWriteAuxCols<F, N> {
     pub fn disabled() -> Self {
         let width = MemoryWriteAuxCols::<F, N>::width();
         MemoryWriteAuxCols::from_slice(&F::zero_vec(width))
@@ -145,7 +145,7 @@ impl<const N: usize, T> MemoryReadAuxCols<T, N> {
     }
 }
 
-impl<const N: usize, F: AbstractField + Copy> MemoryReadAuxCols<F, N> {
+impl<const N: usize, F: FieldAlgebra + Copy> MemoryReadAuxCols<F, N> {
     pub fn disabled() -> Self {
         let width = MemoryReadAuxCols::<F, N>::width();
         MemoryReadAuxCols::from_slice(&F::zero_vec(width))
@@ -175,7 +175,7 @@ impl<const N: usize, T: Clone> MemoryHeapReadAuxCols<T, N> {
     }
 }
 
-impl<const N: usize, F: AbstractField + Copy> MemoryHeapReadAuxCols<F, N> {
+impl<const N: usize, F: FieldAlgebra + Copy> MemoryHeapReadAuxCols<F, N> {
     pub fn disabled() -> Self {
         let width = MemoryReadAuxCols::<F, 1>::width();
         let address = MemoryReadAuxCols::from_slice(&F::zero_vec(width));
@@ -212,7 +212,7 @@ impl<const N: usize, T: Clone> MemoryHeapWriteAuxCols<T, N> {
     }
 }
 
-impl<const N: usize, F: AbstractField + Copy> MemoryHeapWriteAuxCols<F, N> {
+impl<const N: usize, F: FieldAlgebra + Copy> MemoryHeapWriteAuxCols<F, N> {
     pub fn disabled() -> Self {
         let width = MemoryReadAuxCols::<F, 1>::width();
         let address = MemoryReadAuxCols::from_slice(&F::zero_vec(width));
@@ -277,7 +277,7 @@ impl<T> MemoryReadOrImmediateAuxCols<T> {
     }
 }
 
-impl<F: AbstractField + Copy> MemoryReadOrImmediateAuxCols<F> {
+impl<F: FieldAlgebra + Copy> MemoryReadOrImmediateAuxCols<F> {
     pub fn disabled() -> Self {
         let width = MemoryReadOrImmediateAuxCols::<F>::width();
         MemoryReadOrImmediateAuxCols::from_slice(&F::zero_vec(width))

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator, ParallelSliceMut},
     prover::types::AirProofInput,

--- a/crates/vm/src/system/memory/tests.rs
+++ b/crates/vm/src/system/memory/tests.rs
@@ -11,7 +11,7 @@ use openvm_poseidon2_air::Poseidon2Config;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},

--- a/crates/vm/src/system/memory/tree/public_values.rs
+++ b/crates/vm/src/system/memory/tree/public_values.rs
@@ -139,7 +139,7 @@ pub fn extract_public_values<const CHUNK: usize, F: PrimeField32>(
 #[cfg(test)]
 mod tests {
     use openvm_instructions::exe::MemoryImage;
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
     use super::{UserPublicValuesProof, PUBLIC_VALUES_ADDRESS_SPACE_OFFSET};

--- a/crates/vm/src/system/memory/volatile/mod.rs
+++ b/crates/vm/src/system/memory/volatile/mod.rs
@@ -16,7 +16,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/crates/vm/src/system/memory/volatile/mod.rs
+++ b/crates/vm/src/system/memory/volatile/mod.rs
@@ -16,7 +16,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/crates/vm/src/system/memory/volatile/tests.rs
+++ b/crates/vm/src/system/memory/volatile/tests.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, iter, sync::Arc};
 
 use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
 use openvm_stark_backend::{
-    p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix, prover::types::AirProofInput, Chip,
+    p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix, prover::types::AirProofInput, Chip,
 };
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 /// R reads(R<=2), W writes(W<=1).

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 /// R reads(R<=2), W writes(W<=1).

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -13,7 +13,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -13,7 +13,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/crates/vm/src/system/phantom/tests.rs
+++ b/crates/vm/src/system/phantom/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use openvm_instructions::{instruction::Instruction, SystemOpcode, VmOpcode};
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use parking_lot::Mutex;
 

--- a/crates/vm/src/system/poseidon2/chip.rs
+++ b/crates/vm/src/system/poseidon2/chip.rs
@@ -21,7 +21,7 @@ pub struct Poseidon2PeripheryBaseChip<F: PrimeField32, const SBOX_REGISTERS: usi
 
 impl<F: PrimeField32, const SBOX_REGISTERS: usize> Poseidon2PeripheryBaseChip<F, SBOX_REGISTERS> {
     pub fn new(poseidon2_config: Poseidon2Config<F>, bus_idx: usize) -> Self {
-        let subchip = Poseidon2SubChip::new(poseidon2_config);
+        let subchip = Poseidon2SubChip::new(poseidon2_config.constants);
         Self {
             air: Arc::new(Poseidon2PeripheryAir::new(subchip.air.clone(), bus_idx)),
             subchip,

--- a/crates/vm/src/system/poseidon2/tests.rs
+++ b/crates/vm/src/system/poseidon2/tests.rs
@@ -1,5 +1,5 @@
 use openvm_poseidon2_air::Poseidon2Config;
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::{
     dummy_airs::interaction::dummy_interaction_air::{DummyInteractionChip, DummyInteractionData},
     p3_baby_bear::BabyBear,

--- a/crates/vm/src/system/poseidon2/trace.rs
+++ b/crates/vm/src/system/poseidon2/trace.rs
@@ -4,7 +4,7 @@ use openvm_circuit_primitives::utils::next_power_of_two_or_zero;
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/crates/vm/src/system/program/bus.rs
+++ b/crates/vm/src/system/program/bus.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::AbstractField};
+use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::FieldAlgebra};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ProgramBus(pub usize);

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -10,7 +10,7 @@ use openvm_native_compiler::{
 };
 use openvm_rv32im_transpiler::BranchEqualOpcode::*;
 use openvm_stark_backend::{
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
 };

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -7,7 +7,7 @@ use openvm_instructions::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, AirBuilderWithPublicValues, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -7,7 +7,7 @@ use openvm_instructions::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, AirBuilderWithPublicValues, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/crates/vm/src/system/public_values/tests.rs
+++ b/crates/vm/src/system/public_values/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilderWithPublicValues},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
     rap::{AnyRap, PartitionedBaseAir},

--- a/crates/vm/src/system/public_values/tests.rs
+++ b/crates/vm/src/system/public_values/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilderWithPublicValues},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::types::AirProofInput,
     rap::{AnyRap, PartitionedBaseAir},

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -43,7 +43,7 @@ use openvm_rv32im_transpiler::BranchEqualOpcode::*;
 use openvm_stark_backend::{
     config::StarkGenericConfig,
     engine::StarkEngine,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
 };
 use openvm_stark_sdk::{
     config::{
@@ -78,6 +78,7 @@ fn air_test_with_compress_poseidon2(
     let fri_params = if matches!(std::env::var("OPENVM_FAST_TEST"), Ok(x) if &x == "1") {
         FriParameters {
             log_blowup: 3,
+            log_final_poly_len: 0,
             num_queries: 2,
             proof_of_work_bits: 0,
         }

--- a/extensions/algebra/circuit/src/fp2.rs
+++ b/extensions/algebra/circuit/src/fp2.rs
@@ -172,7 +172,7 @@ mod tests {
     use openvm_mod_circuit_builder::{test_utils::*, FieldExpr, FieldExprCols};
     use openvm_pairing_guest::bn254::BN254_MODULUS;
     use openvm_stark_backend::{
-        p3_air::BaseAir, p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix,
+        p3_air::BaseAir, p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix,
     };
     use openvm_stark_sdk::{
         any_rap_arc_vec, config::baby_bear_blake3::BabyBearBlake3Engine, engine::StarkFriEngine,

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -97,7 +97,7 @@ mod tests {
     };
     use openvm_pairing_guest::bn254::BN254_MODULUS;
     use openvm_rv32_adapters::{rv32_write_heap_default, Rv32VecHeapAdapterChip};
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use rand::{rngs::StdRng, SeedableRng};
 

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -136,7 +136,7 @@ mod tests {
     };
     use openvm_pairing_guest::bn254::BN254_MODULUS;
     use openvm_rv32_adapters::{rv32_write_heap_default, Rv32VecHeapAdapterChip};
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use rand::{rngs::StdRng, SeedableRng};
 

--- a/extensions/algebra/circuit/src/modular_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/modular_chip/addsub.rs
@@ -19,7 +19,7 @@ use openvm_mod_circuit_builder::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/algebra/circuit/src/modular_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/modular_chip/addsub.rs
@@ -19,7 +19,7 @@ use openvm_mod_circuit_builder::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -21,7 +21,7 @@ use openvm_instructions::{instruction::Instruction, UsizeOpcode};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -21,7 +21,7 @@ use openvm_instructions::{instruction::Instruction, UsizeOpcode};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/algebra/circuit/src/modular_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/modular_chip/muldiv.rs
@@ -19,7 +19,7 @@ use openvm_mod_circuit_builder::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/algebra/circuit/src/modular_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/modular_chip/muldiv.rs
@@ -19,7 +19,7 @@ use openvm_mod_circuit_builder::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -22,7 +22,7 @@ use openvm_rv32_adapters::{
     rv32_write_heap_default, write_ptr_reg, Rv32IsEqualModAdapterChip, Rv32VecHeapAdapterChip,
 };
 use openvm_rv32im_circuit::adapters::RV32_REGISTER_NUM_LIMBS;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::Rng;
 

--- a/extensions/bigint/circuit/src/tests.rs
+++ b/extensions/bigint/circuit/src/tests.rs
@@ -24,7 +24,7 @@ use openvm_rv32im_circuit::{
 use openvm_rv32im_transpiler::{
     BaseAluOpcode, BranchEqualOpcode, BranchLessThanOpcode, LessThanOpcode, MulOpcode, ShiftOpcode,
 };
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::Rng;
 

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -13,7 +13,7 @@ use openvm_mod_circuit_builder::{
     test_utils::biguint_to_limbs, ExprBuilderConfig, FieldExpressionCoreChip,
 };
 use openvm_rv32_adapters::{rv32_write_heap_default, Rv32VecHeapAdapterChip};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 use super::{EcAddNeChip, EcDoubleChip};

--- a/extensions/ecc/tests/src/lib.rs
+++ b/extensions/ecc/tests/src/lib.rs
@@ -14,7 +14,7 @@ mod tests {
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
     use openvm_sdk::config::SdkVmConfig;
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::{openvm_stark_backend, p3_baby_bear::BabyBear};
     use openvm_toolchain_tests::{build_example_program_at_path_with_features, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
@@ -63,7 +63,7 @@ mod tests {
         let coords: Vec<_> = [p.x.to_bytes(), p.y.to_bytes()]
             .concat()
             .into_iter()
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect();
         air_test_with_min_segments(config, openvm_exe, vec![coords], 1);
         Ok(())

--- a/extensions/keccak256/circuit/src/air.rs
+++ b/extensions/keccak256/circuit/src/air.rs
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     air_builders::sub::SubAirBuilder,
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };
@@ -625,7 +625,7 @@ impl KeccakVmAir {
 
     /// Amount to advance timestamp by after execution of one opcode instruction.
     /// This is an upper bound dependant on the length `len` operand, which is unbounded.
-    pub fn timestamp_change<T: AbstractField>(len: impl Into<T>) -> T {
+    pub fn timestamp_change<T: FieldAlgebra>(len: impl Into<T>) -> T {
         // actual number is ceil(len / 136) * (3 + 17) + KECCAK_DIGEST_WRITES
         // digest writes only done on last row of multi-block
         // add another KECCAK_ABSORB_READS to round up so we don't deal with padding

--- a/extensions/keccak256/circuit/src/tests.rs
+++ b/extensions/keccak256/circuit/src/tests.rs
@@ -11,7 +11,7 @@ use openvm_circuit_primitives::bitwise_op_lookup::{
 use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_keccak256_transpiler::Rv32KeccakOpcode;
 use openvm_stark_backend::{
-    p3_field::AbstractField, utils::disable_debug_builder, verifier::VerificationError,
+    p3_field::FieldAlgebra, utils::disable_debug_builder, verifier::VerificationError,
 };
 use openvm_stark_sdk::{
     config::baby_bear_blake3::BabyBearBlake3Config, p3_baby_bear::BabyBear,

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -5,7 +5,7 @@ use openvm_instructions::riscv::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/extensions/native/circuit/examples/fibonacci.rs
+++ b/extensions/native/circuit/examples/fibonacci.rs
@@ -3,7 +3,7 @@ use openvm_native_compiler::{
     asm::AsmBuilder,
     ir::{Felt, Var},
 };
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 fn fibonacci(n: u32) -> u32 {

--- a/extensions/native/circuit/examples/fibonacci.rs
+++ b/extensions/native/circuit/examples/fibonacci.rs
@@ -44,7 +44,6 @@ fn main() {
     let expected_value = F::from_canonical_u32(fibonacci(n_val));
     builder.assert_felt_eq(a, expected_value);
 
-    //builder.print_f(a);
     builder.halt();
 
     let program = builder.compile_isa();

--- a/extensions/native/circuit/src/adapters/branch_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/branch_native_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 #[derive(Debug)]

--- a/extensions/native/circuit/src/adapters/branch_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/branch_native_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 #[derive(Debug)]

--- a/extensions/native/circuit/src/adapters/convert_adapter.rs
+++ b/extensions/native/circuit/src/adapters/convert_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 #[derive(Debug)]

--- a/extensions/native/circuit/src/adapters/convert_adapter.rs
+++ b/extensions/native/circuit/src/adapters/convert_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 #[derive(Debug)]

--- a/extensions/native/circuit/src/adapters/jal_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/jal_native_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 #[derive(Debug)]

--- a/extensions/native/circuit/src/adapters/jal_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/jal_native_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 #[derive(Debug)]

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -25,7 +25,7 @@ use openvm_native_compiler::NativeLoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 pub struct NativeLoadStoreInstruction<T> {

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -25,7 +25,7 @@ use openvm_native_compiler::NativeLoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 pub struct NativeLoadStoreInstruction<T> {

--- a/extensions/native/circuit/src/adapters/native_vec_heap_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vec_heap_adapter.rs
@@ -26,7 +26,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 /// This adapter reads from R (R <= 2) pointers and writes to 1 pointer.

--- a/extensions/native/circuit/src/adapters/native_vec_heap_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vec_heap_adapter.rs
@@ -26,7 +26,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 /// This adapter reads from R (R <= 2) pointers and writes to 1 pointer.

--- a/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 #[allow(dead_code)]

--- a/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 #[allow(dead_code)]

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -15,7 +15,7 @@ use openvm_rv32im_circuit::adapters::RV32_REGISTER_NUM_LIMBS;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 // LIMB_BITS is the size of the limbs in bits.

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -15,7 +15,7 @@ use openvm_rv32im_circuit::adapters::RV32_REGISTER_NUM_LIMBS;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 // LIMB_BITS is the size of the limbs in bits.

--- a/extensions/native/circuit/src/castf/tests.rs
+++ b/extensions/native/circuit/src/castf/tests.rs
@@ -4,7 +4,7 @@ use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder};
 use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_native_compiler::CastfOpcode;
 use openvm_stark_backend::{
-    p3_field::AbstractField, utils::disable_debug_builder, verifier::VerificationError, Chip,
+    p3_field::FieldAlgebra, utils::disable_debug_builder, verifier::VerificationError, Chip,
 };
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2::BabyBearPoseidon2Engine, engine::StarkFriEngine,

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -11,7 +11,7 @@ use openvm_native_compiler::FieldArithmeticOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -11,7 +11,7 @@ use openvm_native_compiler::FieldArithmeticOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/native/circuit/src/field_arithmetic/tests.rs
+++ b/extensions/native/circuit/src/field_arithmetic/tests.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
 use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::FieldArithmeticOpcode;
 use openvm_stark_backend::{
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     prover::USE_DEBUG_BUILDER,
     utils::disable_debug_builder,
     verifier::VerificationError,

--- a/extensions/native/circuit/src/field_arithmetic/tests.rs
+++ b/extensions/native/circuit/src/field_arithmetic/tests.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
 use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::FieldArithmeticOpcode;
 use openvm_stark_backend::{
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     prover::USE_DEBUG_BUILDER,
     utils::disable_debug_builder,
     verifier::VerificationError,

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -15,7 +15,7 @@ use openvm_native_compiler::FieldExtensionOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -15,7 +15,7 @@ use openvm_native_compiler::FieldExtensionOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 
@@ -252,7 +252,7 @@ impl FieldExtension {
 
     pub(crate) fn multiply<V, E>(x: [V; EXT_DEG], y: [V; EXT_DEG]) -> [E; EXT_DEG]
     where
-        E: AbstractField,
+        E: FieldAlgebra,
         V: Copy,
         V: Mul<V, Output = E>,
         E: Mul<V, Output = E>,

--- a/extensions/native/circuit/src/field_extension/tests.rs
+++ b/extensions/native/circuit/src/field_extension/tests.rs
@@ -10,7 +10,7 @@ use openvm_circuit::arch::testing::{
 use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::FieldExtensionOpcode;
 use openvm_stark_backend::{
-    p3_field::{extension::BinomialExtensionField, AbstractExtensionField, AbstractField},
+    p3_field::{extension::BinomialExtensionField, FieldAlgebra, FieldExtensionAlgebra},
     utils::disable_debug_builder,
     verifier::VerificationError,
     ChipUsageGetter,

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -30,7 +30,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -30,7 +30,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/extensions/native/circuit/src/fri/tests.rs
+++ b/extensions/native/circuit/src/fri/tests.rs
@@ -3,7 +3,7 @@ use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder};
 use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::FriOpcode::{self, FRI_REDUCED_OPENING};
 use openvm_stark_backend::{
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     utils::disable_debug_builder,
     verifier::VerificationError,
 };

--- a/extensions/native/circuit/src/fri/tests.rs
+++ b/extensions/native/circuit/src/fri/tests.rs
@@ -3,7 +3,7 @@ use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder};
 use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::FriOpcode::{self, FRI_REDUCED_OPENING};
 use openvm_stark_backend::{
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     utils::disable_debug_builder,
     verifier::VerificationError,
 };

--- a/extensions/native/circuit/src/jal/core.rs
+++ b/extensions/native/circuit/src/jal/core.rs
@@ -10,7 +10,7 @@ use openvm_native_compiler::NativeJalOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/native/circuit/src/jal/core.rs
+++ b/extensions/native/circuit/src/jal/core.rs
@@ -10,7 +10,7 @@ use openvm_native_compiler::NativeJalOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/native/circuit/src/jal/tests.rs
+++ b/extensions/native/circuit/src/jal/tests.rs
@@ -9,7 +9,7 @@ use openvm_instructions::{
 use openvm_native_compiler::NativeJalOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     utils::disable_debug_builder,
     verifier::VerificationError,

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -14,7 +14,7 @@ use openvm_native_compiler::NativeLoadStoreOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use parking_lot::Mutex;

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -14,7 +14,7 @@ use openvm_native_compiler::NativeLoadStoreOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use parking_lot::Mutex;

--- a/extensions/native/circuit/src/loadstore/tests.rs
+++ b/extensions/native/circuit/src/loadstore/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use openvm_circuit::arch::{testing::VmChipTestBuilder, Streams};
 use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::NativeLoadStoreOpcode::{self, *};
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use parking_lot::Mutex;
 use rand::{rngs::StdRng, Rng};

--- a/extensions/native/circuit/src/poseidon2/air.rs
+++ b/extensions/native/circuit/src/poseidon2/air.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
     air_builders::sub::SubAirBuilder,
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/extensions/native/circuit/src/poseidon2/air.rs
+++ b/extensions/native/circuit/src/poseidon2/air.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
     air_builders::sub::SubAirBuilder,
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
 };

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -55,7 +55,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2BaseChip<F, SB
         offset: usize,
     ) -> Self {
         let memory_bridge = memory_controller.borrow().memory_bridge();
-        let subchip = Poseidon2SubChip::new(poseidon2_config);
+        let subchip = Poseidon2SubChip::new(poseidon2_config.constants);
         Self {
             air: Arc::new(NativePoseidon2Air::new(
                 ExecutionBridge::new(execution_bus, program_bus),

--- a/extensions/native/circuit/src/poseidon2/columns.rs
+++ b/extensions/native/circuit/src/poseidon2/columns.rs
@@ -4,7 +4,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::AlignedBorrow;
 use openvm_poseidon2_air::Poseidon2SubCols;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 
 use super::NATIVE_POSEIDON2_CHUNK_SIZE;
 
@@ -39,7 +39,7 @@ pub struct NativePoseidon2MemoryCols<T> {
     pub chunk_write_aux: [MemoryWriteAuxCols<T, NATIVE_POSEIDON2_CHUNK_SIZE>; 2],
 }
 
-impl<F: AbstractField + Copy> NativePoseidon2MemoryCols<F> {
+impl<F: FieldAlgebra + Copy> NativePoseidon2MemoryCols<F> {
     pub fn blank() -> Self {
         Self {
             from_state: ExecutionState::default(),

--- a/extensions/native/circuit/src/poseidon2/tests.rs
+++ b/extensions/native/circuit/src/poseidon2/tests.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder, VmChipTester};
 use openvm_instructions::{instruction::Instruction, Poseidon2Opcode, UsizeOpcode, VmOpcode};
 use openvm_poseidon2_air::Poseidon2Config;
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField64};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField64};
 use openvm_stark_sdk::{
     config::{
         baby_bear_blake3::{BabyBearBlake3Config, BabyBearBlake3Engine},

--- a/extensions/native/circuit/src/poseidon2/trace.rs
+++ b/extensions/native/circuit/src/poseidon2/trace.rs
@@ -3,7 +3,7 @@ use std::{borrow::BorrowMut, iter::repeat, sync::Arc};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,

--- a/extensions/native/compiler/derive/tests/hintable.rs
+++ b/extensions/native/compiler/derive/tests/hintable.rs
@@ -1,7 +1,7 @@
 use openvm_native_compiler::prelude::*;
 use openvm_native_compiler_derive::Hintable;
 use openvm_native_recursion::{hints::InnerVal, types::InnerConfig};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 
 #[derive(Hintable)]
 struct TestStruct {

--- a/extensions/native/compiler/src/constraints/halo2/baby_bear.rs
+++ b/extensions/native/compiler/src/constraints/halo2/baby_bear.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use openvm_stark_backend::p3_field::{
     extension::{BinomialExtensionField, BinomiallyExtendable},
-    AbstractExtensionField, AbstractField, Field, PrimeField32, PrimeField64,
+    FieldExtensionAlgebra, FieldAlgebra, Field, PrimeField32, PrimeField64,
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use snark_verifier_sdk::snark_verifier::{

--- a/extensions/native/compiler/src/constraints/halo2/baby_bear.rs
+++ b/extensions/native/compiler/src/constraints/halo2/baby_bear.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use openvm_stark_backend::p3_field::{
     extension::{BinomialExtensionField, BinomiallyExtendable},
-    FieldExtensionAlgebra, FieldAlgebra, Field, PrimeField32, PrimeField64,
+    Field, FieldAlgebra, FieldExtensionAlgebra, PrimeField32, PrimeField64,
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use snark_verifier_sdk::snark_verifier::{

--- a/extensions/native/compiler/src/constraints/mod.rs
+++ b/extensions/native/compiler/src/constraints/mod.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use std::marker::PhantomData;
 
-use openvm_stark_backend::p3_field::{FieldExtensionAlgebra, Field, PrimeField};
+use openvm_stark_backend::p3_field::{Field, FieldExtensionAlgebra, PrimeField};
 use serde::{Deserialize, Serialize};
 
 use self::opcodes::ConstraintOpcode;

--- a/extensions/native/compiler/src/constraints/mod.rs
+++ b/extensions/native/compiler/src/constraints/mod.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use std::marker::PhantomData;
 
-use openvm_stark_backend::p3_field::{AbstractExtensionField, Field, PrimeField};
+use openvm_stark_backend::p3_field::{FieldExtensionAlgebra, Field, PrimeField};
 use serde::{Deserialize, Serialize};
 
 use self::opcodes::ConstraintOpcode;

--- a/extensions/native/compiler/src/ir/bits.rs
+++ b/extensions/native/compiler/src/ir/bits.rs
@@ -1,4 +1,4 @@
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 
 use super::{Array, Builder, Config, DslIr, Felt, MemIndex, RVar, Var};
 

--- a/extensions/native/compiler/src/ir/builder.rs
+++ b/extensions/native/compiler/src/ir/builder.rs
@@ -1,7 +1,7 @@
 use std::{iter::Zip, vec::IntoIter};
 
 use backtrace::Backtrace;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use serde::{Deserialize, Serialize};
 
 use super::{

--- a/extensions/native/compiler/src/ir/collections.rs
+++ b/extensions/native/compiler/src/ir/collections.rs
@@ -2,7 +2,7 @@ use alloc::rc::Rc;
 use std::cell::RefCell;
 
 use itertools::Itertools;
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use serde::{Deserialize, Serialize};
 
 use super::{

--- a/extensions/native/compiler/src/ir/poseidon.rs
+++ b/extensions/native/compiler/src/ir/poseidon.rs
@@ -1,4 +1,4 @@
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 
 use super::{Array, Builder, Config, DslIr, Ext, Felt, Usize, Var};
 

--- a/extensions/native/compiler/src/ir/symbolic.rs
+++ b/extensions/native/compiler/src/ir/symbolic.rs
@@ -11,9 +11,7 @@ use std::{
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-use openvm_stark_backend::p3_field::{
-    FieldAlgebra, ExtensionField, Field, FieldArray, PrimeField,
-};
+use openvm_stark_backend::p3_field::{ExtensionField, Field, FieldAlgebra, FieldArray, PrimeField};
 use serde::{Deserialize, Serialize};
 
 use super::{utils::prime_field_to_usize, Ext, Felt, Usize, Var};

--- a/extensions/native/compiler/src/ir/symbolic.rs
+++ b/extensions/native/compiler/src/ir/symbolic.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use openvm_stark_backend::p3_field::{
-    AbstractField, ExtensionField, Field, FieldArray, PrimeField,
+    FieldAlgebra, ExtensionField, Field, FieldArray, PrimeField,
 };
 use serde::{Deserialize, Serialize};
 
@@ -298,7 +298,7 @@ pub trait ExtensionOperand<F: Field, EF: ExtensionField<F>> {
     fn to_operand(self) -> ExtOperand<F, EF>;
 }
 
-impl<N: Field> AbstractField for SymbolicVar<N> {
+impl<N: Field> FieldAlgebra for SymbolicVar<N> {
     type F = N;
 
     const ZERO: Self = SymbolicVar::Const(N::ZERO, FieldArray([N::ZERO; 4]));
@@ -343,7 +343,7 @@ impl<N: Field> NotSymbolicVar for Var<N> {}
 impl<N: PrimeField> NotSymbolicVar for Usize<N> {}
 impl<N: Field> NotSymbolicVar for RVar<N> {}
 
-impl<F: Field> AbstractField for SymbolicFelt<F> {
+impl<F: Field> FieldAlgebra for SymbolicFelt<F> {
     type F = F;
 
     const ZERO: Self = SymbolicFelt::Const(F::ZERO, FieldArray([F::ZERO; 4]));
@@ -381,7 +381,7 @@ impl<F: Field> AbstractField for SymbolicFelt<F> {
     }
 }
 
-impl<F: Field, EF: ExtensionField<F>> AbstractField for SymbolicExt<F, EF> {
+impl<F: Field, EF: ExtensionField<F>> FieldAlgebra for SymbolicExt<F, EF> {
     type F = EF;
 
     const ZERO: Self = SymbolicExt::Const(EF::ZERO, FieldArray([EF::ZERO; 4]));

--- a/extensions/native/compiler/src/ir/types.rs
+++ b/extensions/native/compiler/src/ir/types.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use std::{cell::RefCell, collections::HashMap, hash::Hash};
 
 use openvm_stark_backend::p3_field::{
-    FieldExtensionAlgebra, FieldAlgebra, ExtensionField, Field, PrimeField,
+    ExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra, PrimeField,
 };
 use serde::{Deserialize, Serialize};
 

--- a/extensions/native/compiler/src/ir/types.rs
+++ b/extensions/native/compiler/src/ir/types.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use std::{cell::RefCell, collections::HashMap, hash::Hash};
 
 use openvm_stark_backend::p3_field::{
-    AbstractExtensionField, AbstractField, ExtensionField, Field, PrimeField,
+    FieldExtensionAlgebra, FieldAlgebra, ExtensionField, Field, PrimeField,
 };
 use serde::{Deserialize, Serialize};
 

--- a/extensions/native/compiler/src/ir/utils.rs
+++ b/extensions/native/compiler/src/ir/utils.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Mul, MulAssign};
 
-use openvm_stark_backend::p3_field::{AbstractExtensionField, AbstractField, PrimeField};
+use openvm_stark_backend::p3_field::{FieldAlgebra, FieldExtensionAlgebra, PrimeField};
 
 use super::{
     Array, Builder, CanSelect, Config, DslIr, Ext, Felt, MemIndex, RVar, SymbolicExt, Var, Variable,
@@ -94,7 +94,7 @@ impl<C: Config> Builder<C> {
     /// Exponentiates a variable to an array of bits in little endian.
     pub fn exp_bits<V>(&mut self, x: V, power_bits: &Array<C, Var<C::N>>) -> V
     where
-        V::Expression: AbstractField,
+        V::Expression: FieldAlgebra,
         V: Copy + Mul<Output = V::Expression> + Variable<C>,
     {
         let result: V = self.eval(V::Expression::ONE);
@@ -149,7 +149,7 @@ impl<C: Config> Builder<C> {
         bit_len: impl Into<RVar<C::N>>,
     ) -> V
     where
-        V::Expression: AbstractField,
+        V::Expression: FieldAlgebra,
         V: Copy + Mul<Output = V::Expression> + Variable<C> + CanSelect<C>,
     {
         let result: V = self.eval(V::Expression::ONE);
@@ -214,7 +214,7 @@ impl<C: Config> Builder<C> {
 
     /// Creates an ext from a slice of felts.
     pub fn ext_from_base_slice(&mut self, arr: &[Felt<C::F>]) -> Ext<C::F, C::EF> {
-        assert!(arr.len() <= <C::EF as AbstractExtensionField<C::F>>::D);
+        assert!(arr.len() <= <C::EF as FieldExtensionAlgebra<C::F>>::D);
         let mut res = SymbolicExt::from_f(C::EF::ZERO);
         for i in 0..arr.len() {
             res += arr[i] * SymbolicExt::from_f(C::EF::monomial(i));

--- a/extensions/native/compiler/tests/arithmetic.rs
+++ b/extensions/native/compiler/tests/arithmetic.rs
@@ -6,7 +6,7 @@ use openvm_native_compiler::{
     ir::{Builder, Ext, ExtConst, Felt, SymbolicExt, Var},
 };
 use openvm_stark_backend::p3_field::{
-    extension::BinomialExtensionField, FieldExtensionAlgebra, FieldAlgebra, Field,
+    extension::BinomialExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra,
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{thread_rng, Rng};

--- a/extensions/native/compiler/tests/arithmetic.rs
+++ b/extensions/native/compiler/tests/arithmetic.rs
@@ -6,7 +6,7 @@ use openvm_native_compiler::{
     ir::{Builder, Ext, ExtConst, Felt, SymbolicExt, Var},
 };
 use openvm_stark_backend::p3_field::{
-    extension::BinomialExtensionField, AbstractExtensionField, AbstractField, Field,
+    extension::BinomialExtensionField, FieldExtensionAlgebra, FieldAlgebra, Field,
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{thread_rng, Rng};

--- a/extensions/native/compiler/tests/array.rs
+++ b/extensions/native/compiler/tests/array.rs
@@ -5,7 +5,7 @@ use openvm_native_compiler::{
     prelude::{Builder, MemIndex, MemVariable, Ptr, Variable},
 };
 use openvm_native_compiler_derive::DslVariable;
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 #[derive(DslVariable, Clone, Debug)]

--- a/extensions/native/compiler/tests/conditionals.rs
+++ b/extensions/native/compiler/tests/conditionals.rs
@@ -1,6 +1,6 @@
 use openvm_native_circuit::execute_program;
 use openvm_native_compiler::{asm::AsmBuilder, ir::Var};
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 type F = BabyBear;

--- a/extensions/native/compiler/tests/cycle_tracker.rs
+++ b/extensions/native/compiler/tests/cycle_tracker.rs
@@ -1,6 +1,6 @@
 use openvm_native_circuit::execute_program;
 use openvm_native_compiler::{asm::AsmBuilder, conversion::CompilerOptions, ir::Var};
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 type F = BabyBear;

--- a/extensions/native/compiler/tests/ext.rs
+++ b/extensions/native/compiler/tests/ext.rs
@@ -4,7 +4,7 @@ use openvm_native_compiler::{
     ir::{Ext, Felt},
 };
 use openvm_stark_backend::p3_field::{
-    extension::BinomialExtensionField, AbstractExtensionField, AbstractField,
+    extension::BinomialExtensionField, FieldExtensionAlgebra, FieldAlgebra,
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{thread_rng, Rng};

--- a/extensions/native/compiler/tests/ext.rs
+++ b/extensions/native/compiler/tests/ext.rs
@@ -4,7 +4,7 @@ use openvm_native_compiler::{
     ir::{Ext, Felt},
 };
 use openvm_stark_backend::p3_field::{
-    extension::BinomialExtensionField, FieldExtensionAlgebra, FieldAlgebra,
+    extension::BinomialExtensionField, FieldAlgebra, FieldExtensionAlgebra,
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{thread_rng, Rng};

--- a/extensions/native/compiler/tests/for_loops.rs
+++ b/extensions/native/compiler/tests/for_loops.rs
@@ -3,7 +3,7 @@ use openvm_native_compiler::{
     asm::{AsmBuilder, AsmConfig},
     ir::{Array, RVar, SymbolicVar, Var},
 };
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 type F = BabyBear;

--- a/extensions/native/compiler/tests/fri_ro_eval.rs
+++ b/extensions/native/compiler/tests/fri_ro_eval.rs
@@ -4,7 +4,7 @@ use openvm_native_compiler::{
     conversion::{convert_program, CompilerOptions},
     ir::{Array, Ext, Felt},
 };
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{thread_rng, Rng};
 

--- a/extensions/native/compiler/tests/hint.rs
+++ b/extensions/native/compiler/tests/hint.rs
@@ -3,7 +3,7 @@ use openvm_native_compiler::{
     asm::AsmBuilder,
     ir::{Felt, RVar, Var},
 };
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField, Field};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra, Field};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 type F = BabyBear;

--- a/extensions/native/compiler/tests/hint.rs
+++ b/extensions/native/compiler/tests/hint.rs
@@ -3,7 +3,7 @@ use openvm_native_compiler::{
     asm::AsmBuilder,
     ir::{Felt, RVar, Var},
 };
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra, Field};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, Field, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 type F = BabyBear;

--- a/extensions/native/compiler/tests/io.rs
+++ b/extensions/native/compiler/tests/io.rs
@@ -3,7 +3,7 @@ use openvm_native_compiler::{
     asm::{AsmBuilder, AsmCompiler},
     conversion::{convert_program, CompilerOptions},
 };
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 type F = BabyBear;

--- a/extensions/native/compiler/tests/loops.rs
+++ b/extensions/native/compiler/tests/loops.rs
@@ -1,6 +1,6 @@
 use openvm_native_circuit::execute_program;
 use openvm_native_compiler::{asm::AsmBuilder, ir::Var};
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 #[test]

--- a/extensions/native/compiler/tests/poseidon2.rs
+++ b/extensions/native/compiler/tests/poseidon2.rs
@@ -4,7 +4,7 @@ use openvm_native_compiler::{
     ir::{Array, Var, PERMUTATION_WIDTH},
     prelude::RVar,
 };
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::{config::baby_bear_poseidon2::default_perm, p3_baby_bear::BabyBear};
 use p3_symmetric::Permutation;
 use rand::{thread_rng, Rng};

--- a/extensions/native/compiler/tests/ptr_struct.rs
+++ b/extensions/native/compiler/tests/ptr_struct.rs
@@ -5,7 +5,7 @@ use openvm_native_compiler::{
     prelude::{Builder, MemIndex, MemVariable, Ptr, Variable},
 };
 use openvm_native_compiler_derive::DslVariable;
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{thread_rng, Rng};
 

--- a/extensions/native/compiler/tests/public_values.rs
+++ b/extensions/native/compiler/tests/public_values.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{SingleSegmentVmExecutor, SystemConfig};
 use openvm_native_circuit::{execute_program, Native, NativeConfig};
 use openvm_native_compiler::{asm::AsmBuilder, prelude::*};
-use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, AbstractField};
+use openvm_stark_backend::p3_field::{extension::BinomialExtensionField, FieldAlgebra};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 type F = BabyBear;

--- a/extensions/native/recursion/Cargo.toml
+++ b/extensions/native/recursion/Cargo.toml
@@ -37,7 +37,7 @@ tempfile = "3.14.0"
 bitcode = { workspace = true }
 
 [features]
-default = ["parallel", "mimalloc"]
+default = ["parallel", "mimalloc", "static-verifier"]
 parallel = ["openvm-stark-backend/parallel"]
 static-verifier = [
     "openvm-native-compiler/halo2-compiler",

--- a/extensions/native/recursion/src/challenger/duplex.rs
+++ b/extensions/native/recursion/src/challenger/duplex.rs
@@ -2,7 +2,7 @@ use openvm_native_compiler::{
     ir::{RVar, DIGEST_SIZE, PERMUTATION_WIDTH},
     prelude::{Array, Builder, Config, Ext, Felt, Var},
 };
-use openvm_stark_backend::p3_field::{AbstractField, Field};
+use openvm_stark_backend::p3_field::{Field, FieldAlgebra};
 
 use crate::{
     challenger::{
@@ -220,7 +220,7 @@ mod tests {
     use openvm_stark_backend::{
         config::{StarkGenericConfig, Val},
         p3_challenger::{CanObserve, CanSample},
-        p3_field::AbstractField,
+        p3_field::FieldAlgebra,
     };
     use openvm_stark_sdk::{
         config::baby_bear_poseidon2::{default_engine, BabyBearPoseidon2Config},

--- a/extensions/native/recursion/src/challenger/multi_field32.rs
+++ b/extensions/native/recursion/src/challenger/multi_field32.rs
@@ -1,5 +1,5 @@
 use openvm_native_compiler::ir::{Array, Builder, Config, Ext, Felt, RVar, Var};
-use openvm_stark_backend::p3_field::{AbstractField, Field};
+use openvm_stark_backend::p3_field::{Field, FieldAlgebra};
 
 use crate::{
     challenger::{

--- a/extensions/native/recursion/src/challenger/multi_field32.rs
+++ b/extensions/native/recursion/src/challenger/multi_field32.rs
@@ -92,7 +92,6 @@ impl<C: Config> MultiField32ChallengerVariable<C> {
 
     pub fn sample_bits(&mut self, builder: &mut Builder<C>, bits: usize) -> Var<C::N> {
         let rand_f = self.sample(builder);
-        builder.print_f(rand_f);
         let rand_f_bits = builder.num2bits_f_circuit(rand_f);
         builder.bits2num_v_circuit(&rand_f_bits[0..bits])
     }
@@ -100,7 +99,6 @@ impl<C: Config> MultiField32ChallengerVariable<C> {
     pub fn check_witness(&mut self, builder: &mut Builder<C>, bits: usize, witness: Felt<C::F>) {
         self.observe(builder, witness);
         let element = self.sample_bits(builder, bits);
-        builder.print_v(element);
         builder.assert_var_eq(element, C::N::from_canonical_usize(0));
     }
 }
@@ -130,7 +128,6 @@ impl<C: Config> CanSampleBitsVariable<C> for MultiField32ChallengerVariable<C> {
         nb_bits: RVar<C::N>,
     ) -> Array<C, Var<C::N>> {
         let rand_f = self.sample(builder);
-        builder.print_f(rand_f);
         let rand_f_bits = builder.num2bits_f_circuit(rand_f);
         builder.vec(rand_f_bits[..nb_bits.value()].to_vec())
     }

--- a/extensions/native/recursion/src/challenger/multi_field32.rs
+++ b/extensions/native/recursion/src/challenger/multi_field32.rs
@@ -92,6 +92,7 @@ impl<C: Config> MultiField32ChallengerVariable<C> {
 
     pub fn sample_bits(&mut self, builder: &mut Builder<C>, bits: usize) -> Var<C::N> {
         let rand_f = self.sample(builder);
+        builder.print_f(rand_f);
         let rand_f_bits = builder.num2bits_f_circuit(rand_f);
         builder.bits2num_v_circuit(&rand_f_bits[0..bits])
     }
@@ -99,6 +100,7 @@ impl<C: Config> MultiField32ChallengerVariable<C> {
     pub fn check_witness(&mut self, builder: &mut Builder<C>, bits: usize, witness: Felt<C::F>) {
         self.observe(builder, witness);
         let element = self.sample_bits(builder, bits);
+        builder.print_v(element);
         builder.assert_var_eq(element, C::N::from_canonical_usize(0));
     }
 }
@@ -128,6 +130,7 @@ impl<C: Config> CanSampleBitsVariable<C> for MultiField32ChallengerVariable<C> {
         nb_bits: RVar<C::N>,
     ) -> Array<C, Var<C::N>> {
         let rand_f = self.sample(builder);
+        builder.print_f(rand_f);
         let rand_f_bits = builder.num2bits_f_circuit(rand_f);
         builder.vec(rand_f_bits[..nb_bits.value()].to_vec())
     }

--- a/extensions/native/recursion/src/fri/domain.rs
+++ b/extensions/native/recursion/src/fri/domain.rs
@@ -1,7 +1,7 @@
 use openvm_native_compiler::prelude::*;
 use openvm_stark_backend::{
     p3_commit::{LagrangeSelectors, TwoAdicMultiplicativeCoset},
-    p3_field::{AbstractField, Field, TwoAdicField},
+    p3_field::{Field, FieldAlgebra, TwoAdicField},
 };
 
 use super::types::FriConfigVariable;

--- a/extensions/native/recursion/src/fri/hints.rs
+++ b/extensions/native/recursion/src/fri/hints.rs
@@ -85,7 +85,6 @@ impl Hintable<C> for InnerFriProof {
     type HintVariable = FriProofVariable<C>;
 
     fn read(builder: &mut Builder<C>) -> Self::HintVariable {
-        println!("reading final poly as hintable");
         let commit_phase_commits = Vec::<InnerDigest>::read(builder);
         let query_proofs = Vec::<InnerQueryProof>::read(builder);
         let final_poly = builder.hint_exts();
@@ -99,7 +98,6 @@ impl Hintable<C> for InnerFriProof {
     }
 
     fn write(&self) -> Vec<Vec<<C as Config>::F>> {
-        println!("writing final poly as hintable");
         let mut stream = Vec::new();
 
         stream.extend(Vec::<InnerDigest>::write(

--- a/extensions/native/recursion/src/fri/hints.rs
+++ b/extensions/native/recursion/src/fri/hints.rs
@@ -85,9 +85,10 @@ impl Hintable<C> for InnerFriProof {
     type HintVariable = FriProofVariable<C>;
 
     fn read(builder: &mut Builder<C>) -> Self::HintVariable {
+        println!("reading final poly as hintable");
         let commit_phase_commits = Vec::<InnerDigest>::read(builder);
         let query_proofs = Vec::<InnerQueryProof>::read(builder);
-        let final_poly = builder.hint_ext();
+        let final_poly = builder.hint_exts();
         let pow_witness = builder.hint_felt();
         Self::HintVariable {
             commit_phase_commits,
@@ -98,6 +99,7 @@ impl Hintable<C> for InnerFriProof {
     }
 
     fn write(&self) -> Vec<Vec<<C as Config>::F>> {
+        println!("writing final poly as hintable");
         let mut stream = Vec::new();
 
         stream.extend(Vec::<InnerDigest>::write(
@@ -108,7 +110,7 @@ impl Hintable<C> for InnerFriProof {
                 .collect(),
         ));
         stream.extend(Vec::<InnerQueryProof>::write(&self.query_proofs));
-        stream.extend(vec![self.final_poly].write());
+        stream.extend(self.final_poly.write());
         stream.push(vec![self.pow_witness]);
 
         stream

--- a/extensions/native/recursion/src/fri/mod.rs
+++ b/extensions/native/recursion/src/fri/mod.rs
@@ -61,10 +61,6 @@ pub fn verify_shape_and_sample_challenges<C: Config>(
         });
 
     challenger.check_witness(builder, config.proof_of_work_bits, proof.pow_witness);
-    println!(
-        "check witness: {:?}, {:?}",
-        config.proof_of_work_bits, proof.pow_witness
-    );
 
     let log_max_height =
         builder.eval_expr(proof.commit_phase_commits.len() + RVar::from(config.log_blowup));

--- a/extensions/native/recursion/src/fri/mod.rs
+++ b/extensions/native/recursion/src/fri/mod.rs
@@ -9,12 +9,8 @@ use openvm_native_compiler::{
 use openvm_stark_backend::p3_field::{Field, FieldAlgebra, TwoAdicField};
 pub use two_adic_pcs::*;
 
-use self::types::{
-    DimensionsVariable, FriChallengesVariable, FriConfigVariable, FriProofVariable,
-    FriQueryProofVariable,
-};
+use self::types::{DimensionsVariable, FriConfigVariable, FriQueryProofVariable};
 use crate::{
-    challenger::ChallengerVariable,
     digest::{CanPoseidon2Digest, DigestVariable},
     outer_poseidon2::Poseidon2CircuitBuilder,
     utils::cond_eval,
@@ -26,94 +22,6 @@ pub mod hints;
 pub mod two_adic_pcs;
 pub mod types;
 pub mod witness;
-
-/// Reference: https://github.com/Plonky3/Plonky3/blob/4809fa7bedd9ba8f6f5d3267b1592618e3776c57/fri/src/verifier.rs#L27
-pub fn verify_shape_and_sample_challenges<C: Config>(
-    builder: &mut Builder<C>,
-    config: &FriConfigVariable<C>,
-    proof: &FriProofVariable<C>,
-    challenger: &mut impl ChallengerVariable<C>,
-) -> FriChallengesVariable<C> {
-    let betas: Array<C, Ext<C::F, C::EF>> = builder.array(proof.commit_phase_commits.len());
-
-    builder
-        .range(0, proof.commit_phase_commits.len())
-        .for_each(|i, builder| {
-            let comm = builder.get(&proof.commit_phase_commits, i);
-            challenger.observe_digest(builder, comm);
-            let sample = challenger.sample_ext(builder);
-            builder.set(&betas, i, sample);
-        });
-
-    builder
-        .range(0, proof.final_poly.len())
-        .for_each(|i, builder| {
-            let final_poly_elem = builder.get(&proof.final_poly, i);
-            let final_poly_elem_felts = builder.ext2felt(final_poly_elem);
-            challenger.observe_slice(builder, final_poly_elem_felts);
-        });
-
-    let num_query_proofs = proof.query_proofs.len().clone();
-    builder
-        .if_ne(num_query_proofs, RVar::from(config.num_queries))
-        .then(|builder| {
-            builder.error();
-        });
-
-    challenger.check_witness(builder, config.proof_of_work_bits, proof.pow_witness);
-
-    let log_max_height =
-        builder.eval_expr(proof.commit_phase_commits.len() + RVar::from(config.log_blowup));
-    let query_indices = builder.array(config.num_queries);
-    builder.range(0, config.num_queries).for_each(|i, builder| {
-        let index_bits = challenger.sample_bits(builder, log_max_height);
-        builder.set(&query_indices, i, index_bits);
-    });
-
-    FriChallengesVariable {
-        query_indices,
-        betas,
-    }
-}
-
-/// Verifies a set of FRI challenges.
-///
-/// Reference: https://github.com/Plonky3/Plonky3/blob/4809fa7bedd9ba8f6f5d3267b1592618e3776c57/fri/src/verifier.rs#L67
-#[allow(clippy::type_complexity)]
-pub fn verify_challenges<C: Config>(
-    builder: &mut Builder<C>,
-    config: &FriConfigVariable<C>,
-    proof: &FriProofVariable<C>,
-    challenges: &FriChallengesVariable<C>,
-    reduced_openings: &Array<C, Array<C, Ext<C::F, C::EF>>>,
-) where
-    C::F: TwoAdicField,
-    C::EF: TwoAdicField,
-{
-    let log_max_height =
-        builder.eval_expr(proof.commit_phase_commits.len() + RVar::from(config.log_blowup));
-    builder
-        .range(0, challenges.query_indices.len())
-        .for_each(|i, builder| {
-            let index_bits = builder.get(&challenges.query_indices, i);
-            let query_proof = builder.get(&proof.query_proofs, i);
-            let ro = builder.get(reduced_openings, i);
-
-            let folded_eval = verify_query(
-                builder,
-                config,
-                &proof.commit_phase_commits,
-                &index_bits,
-                &query_proof,
-                &challenges.betas,
-                &ro,
-                log_max_height,
-            );
-
-            let final_poly_elem = builder.get(&proof.final_poly, 0);
-            builder.assert_ext_eq(folded_eval, final_poly_elem);
-        });
-}
 
 /// Verifies a FRI query.
 ///

--- a/extensions/native/recursion/src/fri/mod.rs
+++ b/extensions/native/recursion/src/fri/mod.rs
@@ -6,7 +6,7 @@ use openvm_native_compiler::{
     },
     prelude::MemVariable,
 };
-use openvm_stark_backend::p3_field::{AbstractField, Field, TwoAdicField};
+use openvm_stark_backend::p3_field::{Field, FieldAlgebra, TwoAdicField};
 pub use two_adic_pcs::*;
 
 use self::types::{

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -9,8 +9,7 @@ use super::{
     types::{
         DimensionsVariable, FriConfigVariable, TwoAdicPcsMatsVariable, TwoAdicPcsRoundVariable,
     },
-    verify_batch, verify_challenges, verify_shape_and_sample_challenges, NestedOpenedValues,
-    TwoAdicMultiplicativeCosetVariable,
+    verify_batch, verify_query, NestedOpenedValues, TwoAdicMultiplicativeCosetVariable,
 };
 use crate::{
     challenger::ChallengerVariable, commit::PcsVariable, digest::DigestVariable,
@@ -29,6 +28,7 @@ use crate::{
 /// Reference:
 /// <https://github.com/Plonky3/Plonky3/blob/27b3127dab047e07145c38143379edec2960b3e1/merkle-tree/src/mmcs.rs#L87>
 /// <https://github.com/Plonky3/Plonky3/blob/27b3127dab047e07145c38143379edec2960b3e1/merkle-tree/src/merkle_tree.rs#L100>
+/// <https://github.com/Plonky3/Plonky3/blob/784b7dd1fa87c1202e63350cc8182d7c5327a7af/fri/src/verifier.rs#L22>
 pub fn verify_two_adic_pcs<C: Config>(
     builder: &mut Builder<C>,
     config: &FriConfigVariable<C>,
@@ -47,21 +47,40 @@ pub fn verify_two_adic_pcs<C: Config>(
     let blowup = config.blowup;
     let alpha = challenger.sample_ext(builder);
 
-    builder.cycle_tracker_start("stage-d-1-verify-shape-and-sample-challenges");
-    let fri_challenges = verify_shape_and_sample_challenges(builder, config, &proof, challenger);
-    builder.cycle_tracker_end("stage-d-1-verify-shape-and-sample-challenges");
+    builder.cycle_tracker_start("stage-d-verifier-verify");
+    let betas: Array<C, Ext<C::F, C::EF>> = builder.array(proof.commit_phase_commits.len());
+    builder
+        .range(0, proof.commit_phase_commits.len())
+        .for_each(|i, builder| {
+            let comm = builder.get(&proof.commit_phase_commits, i);
+            challenger.observe_digest(builder, comm);
+            let sample = challenger.sample_ext(builder);
+            builder.set(&betas, i, sample);
+        });
+    builder
+        .range(0, proof.final_poly.len())
+        .for_each(|i, builder| {
+            let final_poly_elem = builder.get(&proof.final_poly, i);
+            let final_poly_elem_felts = builder.ext2felt(final_poly_elem);
+            challenger.observe_slice(builder, final_poly_elem_felts);
+        });
+    let num_query_proofs = proof.query_proofs.len().clone();
+    builder
+        .if_ne(num_query_proofs, RVar::from(config.num_queries))
+        .then(|builder| {
+            builder.error();
+        });
 
-    let log_global_max_height =
+    challenger.check_witness(builder, config.proof_of_work_bits, proof.pow_witness);
+
+    let log_max_height =
         builder.eval_expr(proof.commit_phase_commits.len() + RVar::from(log_blowup));
 
-    let reduced_openings: Array<_, Array<_, Ext<_, _>>> = builder.array(proof.query_proofs.len());
-
-    builder.cycle_tracker_start("stage-d-2-fri-fold");
     builder
         .range(0, proof.query_proofs.len())
         .for_each(|i, builder| {
             let query_proof = builder.get(&proof.query_proofs, i);
-            let index_bits = builder.get(&fri_challenges.query_indices, i);
+            let index_bits = challenger.sample_bits(builder, log_max_height);
 
             let ro: Array<C, Ext<C::F, C::EF>> = builder.array(32);
             let alpha_pow: Array<C, Ext<C::F, C::EF>> = builder.array(32);
@@ -130,8 +149,7 @@ pub fn verify_two_adic_pcs<C: Config>(
                 });
                 let permed_opened_values = NestedOpenedValues::Felt(permed_opened_values);
 
-                let bits_reduced: Usize<_> =
-                    builder.eval(log_global_max_height - log_batch_max_height);
+                let bits_reduced: Usize<_> = builder.eval(log_max_height - log_batch_max_height);
                 let index_bits_shifted_v1 = index_bits.shift(builder, bits_reduced);
 
                 builder.cycle_tracker_start("verify-batch");
@@ -163,8 +181,7 @@ pub fn verify_two_adic_pcs<C: Config>(
                         let cur_ro = builder.get(&ro, log_height);
                         let cur_alpha_pow = builder.get(&alpha_pow, log_height);
 
-                        let bits_reduced: Usize<_> =
-                            builder.eval(log_global_max_height - log_height);
+                        let bits_reduced: Usize<_> = builder.eval(log_max_height - log_height);
                         let index_bits_shifted = index_bits.shift(builder, bits_reduced);
 
                         let two_adic_generator = config.get_two_adic_generator(builder, log_height);
@@ -211,13 +228,22 @@ pub fn verify_two_adic_pcs<C: Config>(
                 builder.cycle_tracker_end("compute-reduced-opening");
             });
 
-            builder.set_value(&reduced_openings, i, ro);
-        });
-    builder.cycle_tracker_end("stage-d-2-fri-fold");
+            let folded_eval = verify_query(
+                builder,
+                config,
+                &proof.commit_phase_commits,
+                &index_bits,
+                &query_proof,
+                &betas,
+                &ro,
+                log_max_height,
+            );
 
-    builder.cycle_tracker_start("stage-d-3-verify-challenges");
-    verify_challenges(builder, config, &proof, &fri_challenges, &reduced_openings);
-    builder.cycle_tracker_end("stage-d-3-verify-challenges");
+            let final_poly_elem = builder.get(&proof.final_poly, 0);
+            builder.print_e(folded_eval);
+            builder.assert_ext_eq(folded_eval, final_poly_elem);
+        });
+    builder.cycle_tracker_end("stage-d-verifier-verify");
 }
 
 impl<C: Config> FromConstant<C> for TwoAdicPcsRoundVariable<C>

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -240,7 +240,6 @@ pub fn verify_two_adic_pcs<C: Config>(
             );
 
             let final_poly_elem = builder.get(&proof.final_poly, 0);
-            builder.print_e(folded_eval);
             builder.assert_ext_eq(folded_eval, final_poly_elem);
         });
     builder.cycle_tracker_end("stage-d-verifier-verify");

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -39,6 +39,8 @@ pub fn verify_two_adic_pcs<C: Config>(
     C::F: TwoAdicField,
     C::EF: TwoAdicField,
 {
+    builder.assert_var_eq(RVar::from(config.log_final_poly_len), RVar::from(0));
+
     let g = builder.generator();
 
     let log_blowup = config.log_blowup;

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -1,7 +1,7 @@
 use openvm_native_compiler::prelude::*;
 use openvm_stark_backend::{
     p3_commit::TwoAdicMultiplicativeCoset,
-    p3_field::{AbstractField, TwoAdicField},
+    p3_field::{FieldAlgebra, TwoAdicField},
 };
 use p3_symmetric::Hash;
 

--- a/extensions/native/recursion/src/fri/types.rs
+++ b/extensions/native/recursion/src/fri/types.rs
@@ -6,6 +6,7 @@ use crate::{digest::DigestVariable, fri::TwoAdicMultiplicativeCosetVariable};
 pub struct FriConfigVariable<C: Config> {
     pub log_blowup: usize,
     pub blowup: usize,
+    pub log_final_poly_len: usize,
     pub num_queries: usize,
     pub proof_of_work_bits: usize,
     pub generators: Array<C, Felt<C::F>>,
@@ -34,7 +35,7 @@ impl<C: Config> FriConfigVariable<C> {
 pub struct FriProofVariable<C: Config> {
     pub commit_phase_commits: Array<C, DigestVariable<C>>,
     pub query_proofs: Array<C, FriQueryProofVariable<C>>,
-    pub final_poly: Ext<C::F, C::EF>,
+    pub final_poly: Array<C, Ext<C::F, C::EF>>,
     pub pow_witness: Felt<C::F>,
 }
 

--- a/extensions/native/recursion/src/fri/witness.rs
+++ b/extensions/native/recursion/src/fri/witness.rs
@@ -61,9 +61,6 @@ impl Witnessable<C> for OuterFriProof {
     type WitnessVariable = FriProofVariable<C>;
 
     fn read(&self, builder: &mut Builder<C>) -> Self::WitnessVariable {
-        println!("reading final poly as witnessable");
-        println!("final poly len: {:?}", self.final_poly.len());
-
         let commit_phase_commits = self.commit_phase_commits.read(builder);
         let query_proofs = self.query_proofs.read(builder);
         let final_poly = self.final_poly.read(builder);
@@ -77,7 +74,6 @@ impl Witnessable<C> for OuterFriProof {
     }
 
     fn write(&self, witness: &mut Witness<OuterConfig>) {
-        println!("writing final poly as witnessable");
         self.commit_phase_commits.write(witness);
         <Vec<_> as Witnessable<C>>::write(&self.query_proofs, witness);
         self.final_poly.write(witness);

--- a/extensions/native/recursion/src/fri/witness.rs
+++ b/extensions/native/recursion/src/fri/witness.rs
@@ -61,6 +61,9 @@ impl Witnessable<C> for OuterFriProof {
     type WitnessVariable = FriProofVariable<C>;
 
     fn read(&self, builder: &mut Builder<C>) -> Self::WitnessVariable {
+        println!("reading final poly as witnessable");
+        println!("final poly len: {:?}", self.final_poly.len());
+
         let commit_phase_commits = self.commit_phase_commits.read(builder);
         let query_proofs = self.query_proofs.read(builder);
         let final_poly = self.final_poly.read(builder);
@@ -74,6 +77,7 @@ impl Witnessable<C> for OuterFriProof {
     }
 
     fn write(&self, witness: &mut Witness<OuterConfig>) {
+        println!("writing final poly as witnessable");
         self.commit_phase_commits.write(witness);
         <Vec<_> as Witnessable<C>>::write(&self.query_proofs, witness);
         self.final_poly.write(witness);

--- a/extensions/native/recursion/src/halo2/tests/mod.rs
+++ b/extensions/native/recursion/src/halo2/tests/mod.rs
@@ -5,7 +5,7 @@ use openvm_native_compiler::{
     ir::{Builder, Witness},
 };
 use openvm_stark_backend::p3_field::{
-    reduce_32 as reduce_32_gt, split_32 as split_32_gt, AbstractField,
+    reduce_32 as reduce_32_gt, split_32 as split_32_gt, FieldAlgebra,
 };
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, p3_bn254_fr::Bn254Fr};
 use snark_verifier_sdk::{

--- a/extensions/native/recursion/src/halo2/tests/multi_field32.rs
+++ b/extensions/native/recursion/src/halo2/tests/multi_field32.rs
@@ -1,7 +1,7 @@
 use openvm_native_compiler::ir::{Builder, SymbolicExt, Witness};
 use openvm_stark_backend::{
     p3_challenger::{CanObserve, CanSample, FieldChallenger},
-    p3_field::{extension::BinomialExtensionField, AbstractField},
+    p3_field::{extension::BinomialExtensionField, FieldAlgebra},
 };
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2_root::root_perm, p3_baby_bear::BabyBear, p3_bn254_fr::Bn254Fr,

--- a/extensions/native/recursion/src/halo2/tests/outer_poseidon2.rs
+++ b/extensions/native/recursion/src/halo2/tests/outer_poseidon2.rs
@@ -1,5 +1,5 @@
 use openvm_native_compiler::ir::{Builder, Felt, Var, Witness};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2_root::root_perm, p3_baby_bear::BabyBear, p3_bn254_fr::Bn254Fr,
 };

--- a/extensions/native/recursion/src/hints.rs
+++ b/extensions/native/recursion/src/hints.rs
@@ -7,7 +7,7 @@ use openvm_native_compiler::ir::{
 use openvm_stark_backend::{
     keygen::types::TraceWidth,
     p3_commit::ExtensionMmcs,
-    p3_field::{extension::BinomialExtensionField, AbstractExtensionField, AbstractField, Field},
+    p3_field::{extension::BinomialExtensionField, FieldExtensionAlgebra, Field, FieldAlgebra},
     p3_util::log2_strict_usize,
     prover::{
         opener::{AdjacentOpenedValues, OpenedValues, OpeningProof},
@@ -72,7 +72,7 @@ impl<C: Config> Hintable<C> for usize {
     }
 
     fn write(&self) -> Vec<Vec<C::N>> {
-        vec![vec![AbstractField::from_canonical_usize(*self)]]
+        vec![vec![FieldAlgebra::from_canonical_usize(*self)]]
     }
 }
 
@@ -218,7 +218,7 @@ impl<C: Config> Hintable<C> for Vec<u8> {
     fn write(&self) -> Vec<Vec<C::N>> {
         vec![self
             .iter()
-            .map(|x| AbstractField::from_canonical_u8(*x))
+            .map(|x| FieldAlgebra::from_canonical_u8(*x))
             .collect()]
     }
 }
@@ -475,7 +475,7 @@ mod test {
         asm::AsmBuilder,
         ir::{Ext, Felt, Var},
     };
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
 
     use crate::hints::{Hintable, InnerChallenge, InnerVal};
 

--- a/extensions/native/recursion/src/hints.rs
+++ b/extensions/native/recursion/src/hints.rs
@@ -7,7 +7,7 @@ use openvm_native_compiler::ir::{
 use openvm_stark_backend::{
     keygen::types::TraceWidth,
     p3_commit::ExtensionMmcs,
-    p3_field::{extension::BinomialExtensionField, FieldExtensionAlgebra, Field, FieldAlgebra},
+    p3_field::{extension::BinomialExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra},
     p3_util::log2_strict_usize,
     prover::{
         opener::{AdjacentOpenedValues, OpenedValues, OpeningProof},

--- a/extensions/native/recursion/src/outer_poseidon2.rs
+++ b/extensions/native/recursion/src/outer_poseidon2.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use openvm_native_compiler::ir::{Builder, Config, DslIr, Felt, Var};
-use openvm_stark_backend::p3_field::{AbstractField, Field};
+use openvm_stark_backend::p3_field::{Field, FieldAlgebra};
 
 use crate::{utils::reduce_32, vars::OuterDigestVariable, OUTER_DIGEST_SIZE};
 

--- a/extensions/native/recursion/src/stark/mod.rs
+++ b/extensions/native/recursion/src/stark/mod.rs
@@ -13,7 +13,7 @@ use openvm_stark_backend::{
         verifier::GenericVerifierConstraintFolder,
     },
     p3_commit::LagrangeSelectors,
-    p3_field::{FieldExtensionAlgebra, FieldAlgebra, TwoAdicField},
+    p3_field::{FieldAlgebra, FieldExtensionAlgebra, TwoAdicField},
     p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair},
     prover::{opener::AdjacentOpenedValues, types::Proof},
 };

--- a/extensions/native/recursion/src/stark/mod.rs
+++ b/extensions/native/recursion/src/stark/mod.rs
@@ -13,7 +13,7 @@ use openvm_stark_backend::{
         verifier::GenericVerifierConstraintFolder,
     },
     p3_commit::LagrangeSelectors,
-    p3_field::{AbstractExtensionField, AbstractField, TwoAdicField},
+    p3_field::{FieldExtensionAlgebra, FieldAlgebra, TwoAdicField},
     p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair},
     prover::{opener::AdjacentOpenedValues, types::Proof},
 };

--- a/extensions/native/recursion/src/testing_utils.rs
+++ b/extensions/native/recursion/src/testing_utils.rs
@@ -74,19 +74,6 @@ pub mod inner {
             )
             .unwrap();
 
-        println!("here, we generated the proof, let's inspect");
-        println!(
-            "final poly len: {:?} and {:?}",
-            vparams.data.proof.opening.proof.final_poly.len(),
-            vparams.fri_params.log_final_poly_len
-        );
-        println!("fri params: {:?}", vparams.fri_params);
-
-        println!(
-            "final poly: {:?}",
-            vparams.data.proof.opening.proof.final_poly
-        );
-
         recursive_stark_test(
             vparams,
             CompilerOptions::default(),

--- a/extensions/native/recursion/src/testing_utils.rs
+++ b/extensions/native/recursion/src/testing_utils.rs
@@ -74,6 +74,19 @@ pub mod inner {
             )
             .unwrap();
 
+        println!("here, we generated the proof, let's inspect");
+        println!(
+            "final poly len: {:?} and {:?}",
+            vparams.data.proof.opening.proof.final_poly.len(),
+            vparams.fri_params.log_final_poly_len
+        );
+        println!("fri params: {:?}", vparams.fri_params);
+
+        println!(
+            "final poly: {:?}",
+            vparams.data.proof.opening.proof.final_poly
+        );
+
         recursive_stark_test(
             vparams,
             CompilerOptions::default(),

--- a/extensions/native/recursion/src/tests.rs
+++ b/extensions/native/recursion/src/tests.rs
@@ -113,6 +113,7 @@ fn test_fibonacci() {
         fibonacci_test_proof_input::<BabyBearPoseidon2Config>(1 << 24),
         FriParameters {
             log_blowup: 3,
+            log_final_poly_len: 0,
             num_queries: 2,
             proof_of_work_bits: 0,
         },

--- a/extensions/native/recursion/src/utils.rs
+++ b/extensions/native/recursion/src/utils.rs
@@ -30,6 +30,7 @@ pub fn const_fri_config<C: Config>(
     FriConfigVariable {
         log_blowup: params.log_blowup,
         blowup: 1 << params.log_blowup,
+        log_final_poly_len: params.log_final_poly_len,
         num_queries: params.num_queries,
         proof_of_work_bits: params.proof_of_work_bits,
         subgroups,

--- a/extensions/native/recursion/src/utils.rs
+++ b/extensions/native/recursion/src/utils.rs
@@ -1,7 +1,7 @@
 use openvm_native_compiler::ir::{Builder, CanSelect, Config, Felt, MemVariable, Var};
 use openvm_stark_backend::{
     p3_commit::TwoAdicMultiplicativeCoset,
-    p3_field::{AbstractField, TwoAdicField},
+    p3_field::{FieldAlgebra, TwoAdicField},
 };
 use openvm_stark_sdk::config::FriParameters;
 

--- a/extensions/native/recursion/tests/cached_trace.rs
+++ b/extensions/native/recursion/tests/cached_trace.rs
@@ -15,7 +15,7 @@
 // use itertools::Itertools;
 // use openvm_stark_backend::p3_air::{Air, BaseAir};
 // use openvm_stark_sdk::p3_baby_bear::BabyBear;
-// use openvm_stark_backend::p3_field::AbstractField;
+// use openvm_stark_backend::p3_field::FieldAlgebra;
 // use openvm_stark_backend::p3_matrix::{dense::RowMajorMatrix, Matrix};
 // use openvm_stark_backend::p3_util::log2_ceil_usize;
 // use rand::{rngs::StdRng, SeedableRng};

--- a/extensions/native/recursion/tests/recursion.rs
+++ b/extensions/native/recursion/tests/recursion.rs
@@ -5,7 +5,7 @@ use openvm_native_recursion::testing_utils::inner::run_recursive_test;
 use openvm_stark_backend::{
     config::{Domain, StarkGenericConfig},
     p3_commit::PolynomialSpace,
-    p3_field::{extension::BinomialExtensionField, AbstractField},
+    p3_field::{extension::BinomialExtensionField, FieldAlgebra},
 };
 use openvm_stark_sdk::{
     config::fri_params::standard_fri_params_with_100_bits_conjectured_security,

--- a/extensions/pairing/circuit/src/fp12.rs
+++ b/extensions/pairing/circuit/src/fp12.rs
@@ -208,7 +208,7 @@ mod tests {
     use openvm_mod_circuit_builder::{test_utils::*, *};
     use openvm_pairing_guest::bn254::BN254_MODULUS;
     use openvm_stark_backend::{
-        p3_air::BaseAir, p3_field::AbstractField, p3_matrix::dense::RowMajorMatrix,
+        p3_air::BaseAir, p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix,
     };
     use openvm_stark_sdk::{
         any_rap_arc_vec, config::baby_bear_blake3::BabyBearBlake3Engine, engine::StarkFriEngine,

--- a/extensions/pairing/circuit/src/fp12_chip/mul.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/mul.rs
@@ -83,7 +83,7 @@ mod tests {
     };
     use openvm_pairing_guest::bn254::{BN254_MODULUS, BN254_XI_ISIZE};
     use openvm_rv32_adapters::rv32_write_heap_default_with_increment;
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use rand::{rngs::StdRng, SeedableRng};
 

--- a/extensions/pairing/circuit/src/fp12_chip/tests.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/tests.rs
@@ -21,7 +21,7 @@ use openvm_pairing_guest::{
 };
 use openvm_pairing_transpiler::{Bls12381Fp12Opcode, Bn254Fp12Opcode, Fp12Opcode};
 use openvm_rv32_adapters::{rv32_write_heap_default, Rv32VecHeapAdapterChip};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 use super::{fp12_add_expr, fp12_mul_expr, fp12_sub_expr};

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/tests.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/tests.rs
@@ -26,7 +26,7 @@ use openvm_rv32_adapters::{
     rv32_write_heap_default, rv32_write_heap_default_with_increment, Rv32VecHeapAdapterChip,
     Rv32VecHeapTwoReadsAdapterChip,
 };
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{rngs::StdRng, SeedableRng};
 

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/tests.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/tests.rs
@@ -20,7 +20,7 @@ use openvm_pairing_transpiler::PairingOpcode;
 use openvm_rv32_adapters::{
     rv32_write_heap_default_with_increment, Rv32VecHeapAdapterChip, Rv32VecHeapTwoReadsAdapterChip,
 };
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{rngs::StdRng, SeedableRng};
 

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
@@ -114,7 +114,7 @@ mod tests {
     };
     use openvm_pairing_transpiler::PairingOpcode;
     use openvm_rv32_adapters::{rv32_write_heap_default, Rv32VecHeapAdapterChip};
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use rand::{rngs::StdRng, SeedableRng};
 

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
@@ -104,7 +104,7 @@ mod tests {
     };
     use openvm_pairing_transpiler::PairingOpcode;
     use openvm_rv32_adapters::{rv32_write_heap_default, Rv32VecHeapAdapterChip};
-    use openvm_stark_backend::p3_field::AbstractField;
+    use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use rand::{rngs::StdRng, SeedableRng};
 

--- a/extensions/pairing/tests/src/lib.rs
+++ b/extensions/pairing/tests/src/lib.rs
@@ -29,7 +29,7 @@ mod bn254 {
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::{openvm_stark_backend::p3_field::AbstractField, p3_baby_bear::BabyBear};
+    use openvm_stark_sdk::{openvm_stark_backend::p3_field::FieldAlgebra, p3_baby_bear::BabyBear};
     use openvm_toolchain_tests::{build_example_program_at_path_with_features, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
     use rand::SeedableRng;
@@ -77,7 +77,7 @@ mod bn254 {
             .into_iter()
             .flat_map(|fp12| fp12.to_coeffs())
             .flat_map(|fp2| fp2.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         air_test_with_min_segments(get_testing_config(), openvm_exe, vec![io], 1);
@@ -119,7 +119,7 @@ mod bn254 {
             .chain(r0)
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         // Test mul_by_01234
@@ -131,7 +131,7 @@ mod bn254 {
             .chain(r1.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -170,7 +170,7 @@ mod bn254 {
         let io0 = [s.x, s.y, pt.x, pt.y, l.b, l.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         // Test miller_double_and_add_step
@@ -178,7 +178,7 @@ mod bn254 {
         let io1 = [s.x, s.y, q.x, q.y, pt.x, pt.y, l0.b, l0.c, l1.b, l1.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -220,7 +220,7 @@ mod bn254 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -229,7 +229,7 @@ mod bn254 {
             .chain(f.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -276,7 +276,7 @@ mod bn254 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -284,7 +284,7 @@ mod bn254 {
             .flat_map(|pt| [pt.x, pt.y].into_iter())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -322,7 +322,7 @@ mod bls12_381 {
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::{openvm_stark_backend::p3_field::AbstractField, p3_baby_bear::BabyBear};
+    use openvm_stark_sdk::{openvm_stark_backend::p3_field::FieldAlgebra, p3_baby_bear::BabyBear};
     use openvm_toolchain_tests::{build_example_program_at_path_with_features, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
     use rand::SeedableRng;
@@ -370,7 +370,7 @@ mod bls12_381 {
             .into_iter()
             .flat_map(|fp12| fp12.to_coeffs())
             .flat_map(|fp2| fp2.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         air_test_with_min_segments(get_testing_config(), openvm_exe, vec![io], 1);
@@ -412,7 +412,7 @@ mod bls12_381 {
             .chain(r0)
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         // Test mul_by_02345
@@ -425,7 +425,7 @@ mod bls12_381 {
             .chain(r1.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -464,7 +464,7 @@ mod bls12_381 {
         let io0 = [s.x, s.y, pt.x, pt.y, l.b, l.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         // Test miller_double_and_add_step
@@ -472,7 +472,7 @@ mod bls12_381 {
         let io1 = [s.x, s.y, q.x, q.y, pt.x, pt.y, l0.b, l0.c, l1.b, l1.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -520,7 +520,7 @@ mod bls12_381 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -529,7 +529,7 @@ mod bls12_381 {
             .chain(f.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -575,7 +575,7 @@ mod bls12_381 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -583,7 +583,7 @@ mod bls12_381 {
             .flat_map(|pt| [pt.x, pt.y].into_iter())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(AbstractField::from_canonical_u8)
+            .map(FieldAlgebra::from_canonical_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 /// This adapter reads from NUM_READS <= 2 pointers and writes to a register.

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 /// This adapter reads from NUM_READS <= 2 pointers and writes to a register.

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -37,7 +37,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 /// This adapter reads from NUM_READS <= 2 pointers.

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -37,7 +37,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 /// This adapter reads from NUM_READS <= 2 pointers.

--- a/extensions/rv32-adapters/src/test_utils.rs
+++ b/extensions/rv32-adapters/src/test_utils.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder};
 use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_circuit::adapters::{RV32_REGISTER_NUM_LIMBS, RV_IS_TYPE_IMM_BITS};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{rngs::StdRng, Rng};
 

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 /// This adapter reads from R (R <= 2) pointers and writes to 1 pointer.

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 /// This adapter reads from R (R <= 2) pointers and writes to 1 pointer.

--- a/extensions/rv32-adapters/src/vec_heap_two_reads.rs
+++ b/extensions/rv32-adapters/src/vec_heap_two_reads.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 /// This adapter reads from 2 pointers and writes to 1 pointer.

--- a/extensions/rv32-adapters/src/vec_heap_two_reads.rs
+++ b/extensions/rv32-adapters/src/vec_heap_two_reads.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_circuit::adapters::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 /// This adapter reads from 2 pointers and writes to 1 pointer.

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -28,7 +28,7 @@ use openvm_instructions::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use super::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -28,7 +28,7 @@ use openvm_instructions::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use super::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/hintstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/hintstore.rs
@@ -30,7 +30,7 @@ use openvm_instructions::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use super::{compose, RV32_REGISTER_NUM_LIMBS};

--- a/extensions/rv32im/circuit/src/adapters/hintstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/hintstore.rs
@@ -30,7 +30,7 @@ use openvm_instructions::{
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use super::{compose, RV32_REGISTER_NUM_LIMBS};

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -25,7 +25,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -25,7 +25,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use super::{compose, RV32_REGISTER_NUM_LIMBS};

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -36,7 +36,7 @@ use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use super::{compose, RV32_REGISTER_NUM_LIMBS};

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -1,7 +1,7 @@
 use std::ops::Mul;
 
 use openvm_circuit::system::memory::{MemoryController, MemoryReadRecord};
-use openvm_stark_backend::p3_field::{AbstractField, PrimeField32};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 
 mod alu;
 mod branch;
@@ -61,7 +61,7 @@ pub fn unsafe_read_rv32_register<F: PrimeField32>(memory: &MemoryController<F>, 
     compose(data)
 }
 
-pub fn abstract_compose<T: AbstractField, V: Mul<T, Output = T>>(
+pub fn abstract_compose<T: FieldAlgebra, V: Mul<T, Output = T>>(
     data: [V; RV32_REGISTER_NUM_LIMBS],
 ) -> T {
     data.into_iter()

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -25,7 +25,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -25,7 +25,7 @@ use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32AuipcOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32AuipcOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/auipc/tests.rs
+++ b/extensions/rv32im/circuit/src/auipc/tests.rs
@@ -8,7 +8,7 @@ use openvm_instructions::{instruction::Instruction, program::PC_BITS, UsizeOpcod
 use openvm_rv32im_transpiler::Rv32AuipcOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     utils::disable_debug_builder,
     verifier::VerificationError,

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::BaseAluOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::BaseAluOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -14,7 +14,7 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_transpiler::BaseAluOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -14,7 +14,7 @@ use openvm_rv32im_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -14,7 +14,7 @@ use openvm_rv32im_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/branch_eq/tests.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/tests.rs
@@ -9,7 +9,7 @@ use openvm_instructions::{instruction::Instruction, program::PC_BITS, UsizeOpcod
 use openvm_rv32im_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::BranchLessThanOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::BranchLessThanOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/branch_lt/tests.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/tests.rs
@@ -15,7 +15,7 @@ use openvm_instructions::{instruction::Instruction, program::PC_BITS, UsizeOpcod
 use openvm_rv32im_transpiler::BranchLessThanOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -21,7 +21,7 @@ use openvm_rv32im_transpiler::DivRemOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -21,7 +21,7 @@ use openvm_rv32im_transpiler::DivRemOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/divrem/tests.rs
+++ b/extensions/rv32im/circuit/src/divrem/tests.rs
@@ -16,7 +16,7 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_transpiler::DivRemOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field},
+    p3_field::{Field, FieldAlgebra},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/divrem/tests.rs
+++ b/extensions/rv32im/circuit/src/divrem/tests.rs
@@ -16,7 +16,7 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_transpiler::DivRemOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field},
+    p3_field::{FieldAlgebra, Field},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/hintstore/core.rs
+++ b/extensions/rv32im/circuit/src/hintstore/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32HintStoreOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use parking_lot::Mutex;

--- a/extensions/rv32im/circuit/src/hintstore/core.rs
+++ b/extensions/rv32im/circuit/src/hintstore/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32HintStoreOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use parking_lot::Mutex;

--- a/extensions/rv32im/circuit/src/hintstore/tests.rs
+++ b/extensions/rv32im/circuit/src/hintstore/tests.rs
@@ -14,7 +14,7 @@ use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_rv32im_transpiler::Rv32HintStoreOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32JalLuiOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32JalLuiOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/jal_lui/tests.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/tests.rs
@@ -8,7 +8,7 @@ use openvm_instructions::{instruction::Instruction, program::PC_BITS, UsizeOpcod
 use openvm_rv32im_transpiler::Rv32JalLuiOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     utils::disable_debug_builder,
     verifier::VerificationError,

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::Rv32JalrOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::Rv32JalrOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -8,7 +8,7 @@ use openvm_instructions::{instruction::Instruction, program::PC_BITS, UsizeOpcod
 use openvm_rv32im_transpiler::Rv32JalrOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     utils::disable_debug_builder,
     verifier::VerificationError,

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::LessThanOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::LessThanOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/less_than/tests.rs
+++ b/extensions/rv32im/circuit/src/less_than/tests.rs
@@ -14,7 +14,7 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_transpiler::LessThanOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{AbstractField, PrimeField32},
+    p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -17,7 +17,7 @@ use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
@@ -8,7 +8,7 @@ use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -9,7 +9,7 @@ use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -9,7 +9,7 @@ use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -11,7 +11,7 @@ use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -15,7 +15,7 @@ use openvm_rv32im_transpiler::MulOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -15,7 +15,7 @@ use openvm_rv32im_transpiler::MulOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 

--- a/extensions/rv32im/circuit/src/mul/tests.rs
+++ b/extensions/rv32im/circuit/src/mul/tests.rs
@@ -12,7 +12,7 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_transpiler::MulOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::MulHOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::MulHOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/mulh/tests.rs
+++ b/extensions/rv32im/circuit/src/mulh/tests.rs
@@ -16,7 +16,7 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_transpiler::MulHOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -19,7 +19,7 @@ use openvm_rv32im_transpiler::ShiftOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{AbstractField, Field, PrimeField32},
+    p3_field::{FieldAlgebra, Field, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -19,7 +19,7 @@ use openvm_rv32im_transpiler::ShiftOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{FieldAlgebra, Field, PrimeField32},
+    p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;

--- a/extensions/rv32im/circuit/src/shift/tests.rs
+++ b/extensions/rv32im/circuit/src/shift/tests.rs
@@ -14,7 +14,7 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_rv32im_transpiler::ShiftOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::AbstractField,
+    p3_field::FieldAlgebra,
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,

--- a/extensions/rv32im/circuit/src/test_utils.rs
+++ b/extensions/rv32im/circuit/src/test_utils.rs
@@ -1,6 +1,6 @@
 use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder};
 use openvm_instructions::{instruction::Instruction, VmOpcode};
-use openvm_stark_backend::p3_field::AbstractField;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::{rngs::StdRng, Rng};
 

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -11,7 +11,7 @@ mod tests {
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::{openvm_stark_backend::p3_field::AbstractField, p3_baby_bear::BabyBear};
+    use openvm_stark_sdk::{openvm_stark_backend::p3_field::FieldAlgebra, p3_baby_bear::BabyBear};
     use openvm_toolchain_tests::{
         build_example_program_at_path, build_example_program_at_path_with_features,
         get_programs_dir,


### PR DESCRIPTION
Closes INT-2853

Main changes:
- renamed `AbstractField` -> `FieldAlgebra` and `AbstractExtensionField` -> `FieldExtensionAlgebra`
- modified the recursive verifier to reflect the recent changes to FRI verifying in Plonky3
- Removed the unsafe usage in poseidon2-air

Easiest to review commit by commit

Needs:
- https://github.com/Plonky3/Plonky3/pull/597
before tests can pass.