### PR TITLE
fix(bench): verify_fibair use volatile memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,6 +4268,7 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "eyre",
+ "getset",
  "itertools 0.13.0",
  "metrics",
  "openvm",

--- a/benchmarks/src/bin/fib_e2e.rs
+++ b/benchmarks/src/bin/fib_e2e.rs
@@ -85,8 +85,7 @@ async fn main() -> Result<()> {
     stdin.write(&n);
     run_with_metric_collection("OUTPUT_PATH", || {
         let mut e2e_prover =
-            ContinuationProver::new(&halo2_params_reader, app_pk, app_committed_exe, full_agg_pk)
-                .with_profiling();
+            ContinuationProver::new(&halo2_params_reader, app_pk, app_committed_exe, full_agg_pk);
         e2e_prover.set_program_name("fib_e2e");
         let _proof = e2e_prover.generate_proof_for_evm(stdin);
     });

--- a/benchmarks/src/bin/verify_fibair.rs
+++ b/benchmarks/src/bin/verify_fibair.rs
@@ -1,15 +1,11 @@
 use clap::Parser;
 use eyre::Result;
-use openvm_benchmarks::utils::{bench_from_exe, BenchmarkCli};
+use openvm_benchmarks::utils::BenchmarkCli;
 use openvm_circuit::arch::instructions::program::DEFAULT_MAX_NUM_PUBLIC_VALUES;
 use openvm_native_circuit::NativeConfig;
 use openvm_native_compiler::conversion::CompilerOptions;
 use openvm_native_recursion::testing_utils::inner::build_verification_program;
-use openvm_sdk::config::AppConfig;
-/// Benchmark of aggregation VM performance.
-/// Proofs:
-/// 1. Prove Fibonacci AIR.
-/// 2. Verify the proof of 1. by execution VM program in STARK VM.
+use openvm_sdk::{config::AppConfig, prover::AppProver, Sdk};
 use openvm_stark_sdk::{
     bench::run_with_metric_collection,
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},
@@ -17,8 +13,11 @@ use openvm_stark_sdk::{
     engine::StarkFriEngine,
     openvm_stark_backend::Chip,
 };
-use tracing::info_span;
 
+/// Benchmark of aggregation VM performance.
+/// Proofs:
+/// 1. Prove Fibonacci AIR.
+/// 2. Verify the proof of 1. by execution VM program in STARK VM.
 fn main() -> Result<()> {
     let cli_args = BenchmarkCli::parse();
     let app_log_blowup = cli_args.app_log_blowup.unwrap_or(2);
@@ -30,36 +29,34 @@ fn main() -> Result<()> {
         FriParameters::standard_with_100_bits_conjectured_security(app_log_blowup),
     );
 
-    run_with_metric_collection("OUTPUT_PATH", || {
+    run_with_metric_collection("OUTPUT_PATH", || -> Result<()> {
         // run_test tries to setup tracing, but it will be ignored since run_with_metric_collection already sets it.
         let vdata = engine
             .run_test(vec![fib_chip.generate_air_proof_input()])
             .unwrap();
-        let leaf_fri_params =
+        // Unlike other apps, this "app" does not have continuations enabled.
+        let app_fri_params =
             FriParameters::standard_with_100_bits_conjectured_security(agg_log_blowup);
-        // FIXME: this should be benchmarked as a single segment VM.
         let app_vm_config = NativeConfig::aggregation(
             DEFAULT_MAX_NUM_PUBLIC_VALUES,
-            leaf_fri_params.max_constraint_degree().min(7),
-        )
-        .with_continuations();
+            app_fri_params.max_constraint_degree().min(7),
+        );
         let compiler_options = CompilerOptions::default();
         let app_config = AppConfig {
-            app_fri_params: leaf_fri_params.into(),
+            app_fri_params: app_fri_params.into(),
             app_vm_config,
-            leaf_fri_params: leaf_fri_params.into(),
+            leaf_fri_params: app_fri_params.into(),
             compiler_options,
         };
-        info_span!("Verify Fibonacci AIR").in_scope(|| {
-            let (program, input_stream) = build_verification_program(vdata, compiler_options);
-            bench_from_exe(
-                "verify_fibair",
-                app_config,
-                program,
-                input_stream.into(),
-                false,
-            )
-        })
+        let (program, input_stream) = build_verification_program(vdata, compiler_options);
+        let sdk = Sdk;
+        let app_pk = sdk.app_keygen(app_config)?;
+        let app_vk = app_pk.get_app_vk();
+        let committed_exe = sdk.commit_app_exe(app_fri_params, program.into())?;
+        let prover = AppProver::new(app_pk.app_vm_pk, committed_exe);
+        let proof = prover.generate_app_proof_without_continuations(input_stream.into());
+        sdk.verify_app_proof_without_continuations(&app_vk, &proof)?;
+        Ok(())
     })?;
     Ok(())
 }

--- a/benchmarks/src/bin/verify_fibair.rs
+++ b/benchmarks/src/bin/verify_fibair.rs
@@ -53,7 +53,8 @@ fn main() -> Result<()> {
         let app_pk = sdk.app_keygen(app_config)?;
         let app_vk = app_pk.get_app_vk();
         let committed_exe = sdk.commit_app_exe(app_fri_params, program.into())?;
-        let prover = AppProver::new(app_pk.app_vm_pk, committed_exe);
+        let prover =
+            AppProver::new(app_pk.app_vm_pk, committed_exe).with_program_name("verify_fibair");
         let proof = prover.generate_app_proof_without_continuations(input_stream.into());
         sdk.verify_app_proof_without_continuations(&app_vk, &proof)?;
         Ok(())

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -39,7 +39,7 @@ impl KeygenCmd {
     pub fn run(&self) -> Result<()> {
         let app_config = read_config_toml_or_default(&self.config)?;
         let app_pk = Sdk.app_keygen(app_config)?;
-        write_app_vk_to_file(app_pk.get_vk(), &self.vk_output)?;
+        write_app_vk_to_file(app_pk.get_app_vk(), &self.vk_output)?;
         write_app_pk_to_file(app_pk, &self.output)?;
         Ok(())
     }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -41,6 +41,7 @@ async-trait.workspace = true
 metrics.workspace = true
 tracing.workspace = true
 itertools.workspace = true
+getset.workspace = true
 
 [features]
 default = ["parallel"]

--- a/crates/sdk/examples/sdk.rs
+++ b/crates/sdk/examples/sdk.rs
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ANCHOR: verification
     // 10. Verify your program
-    let app_vk = app_pk.get_vk();
+    let app_vk = app_pk.get_app_vk();
     sdk.verify_app_proof(&app_vk, &proof)?;
     // ANCHOR_END: verification
 

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -91,7 +91,6 @@ where
                 vm_pk.max_constraint_degree
                     <= config.app_fri_params.fri_params.max_constraint_degree()
             );
-            assert!(config.app_vm_config.system().continuation_enabled);
             VmProvingKey {
                 fri_params: config.app_fri_params.fri_params,
                 vm_config: config.app_vm_config.clone(),
@@ -122,7 +121,7 @@ where
         self.app_vm_pk.vm_config.system().num_public_values
     }
 
-    pub fn get_vk(&self) -> AppVerifyingKey {
+    pub fn get_app_vk(&self) -> AppVerifyingKey {
         AppVerifyingKey {
             fri_params: self.app_vm_pk.fri_params,
             app_vm_vk: self.app_vm_pk.vm_pk.get_vk(),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -21,7 +21,7 @@ use openvm_native_recursion::{
     },
     types::InnerConfig,
 };
-use openvm_stark_backend::engine::StarkEngine;
+use openvm_stark_backend::{engine::StarkEngine, prover::types::Proof};
 use openvm_stark_sdk::{
     config::{
         baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},
@@ -161,8 +161,17 @@ impl Sdk {
         for seg_proof in &proof.per_segment {
             e.verify(&app_vk.app_vm_vk, seg_proof)?
         }
-        // TODO: verify continuation.
+        // TODO: verify continuation: requires App VC.
         Ok(())
+    }
+
+    pub fn verify_app_proof_without_continuations(
+        &self,
+        app_vk: &AppVerifyingKey,
+        proof: &Proof<SC>,
+    ) -> Result<(), VerificationError> {
+        let e = BabyBearPoseidon2Engine::new(app_vk.fri_params);
+        e.verify(&app_vk.app_vm_vk, proof)
     }
 
     pub fn agg_keygen(

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -2,11 +2,10 @@ use std::sync::Arc;
 
 #[cfg(feature = "bench-metrics")]
 use openvm_circuit::arch::SingleSegmentVmExecutor;
-use openvm_circuit::arch::Streams;
 use openvm_native_circuit::NativeConfig;
 use openvm_native_recursion::hints::Hintable;
 use openvm_stark_sdk::{
-    config::baby_bear_poseidon2::BabyBearPoseidon2Engine, engine::StarkFriEngine,
+    config::baby_bear_poseidon2::BabyBearPoseidon2Engine,
     openvm_stark_backend::prover::types::Proof,
 };
 use tracing::info_span;
@@ -37,13 +36,10 @@ pub struct AggStarkProver {
 
     pub num_children_internal: usize,
     pub max_internal_wrapper_layers: usize,
-
-    pub profile: bool,
 }
 pub struct LeafProver {
     prover: VmLocalProver<SC, NativeConfig, BabyBearPoseidon2Engine>,
     pub num_children_leaf: usize,
-    pub profile: bool,
 }
 
 impl AggStarkProver {
@@ -63,7 +59,6 @@ impl AggStarkProver {
             root_prover,
             num_children_internal: DEFAULT_NUM_CHILDREN_INTERNAL,
             max_internal_wrapper_layers: DEFAULT_MAX_INTERNAL_WRAPPER_LAYERS,
-            profile: false,
         }
     }
 
@@ -79,16 +74,6 @@ impl AggStarkProver {
 
     pub fn with_max_internal_wrapper_layers(mut self, max_internal_wrapper_layers: usize) -> Self {
         self.max_internal_wrapper_layers = max_internal_wrapper_layers;
-        self
-    }
-
-    pub fn set_profile(&mut self, profile: bool) -> &mut Self {
-        self.profile = profile;
-        self.leaf_prover.profile = profile;
-        self
-    }
-    pub fn with_profiling(mut self) -> Self {
-        self.set_profile(true);
         self
     }
 
@@ -156,7 +141,7 @@ impl AggStarkProver {
                             hgt = internal_node_height
                         )
                         .in_scope(|| {
-                            single_segment_prove(&self.internal_prover, input.write(), self.profile)
+                            SingleSegmentVmProver::prove(&self.internal_prover, input.write())
                         })
                     })
                     .collect()
@@ -207,15 +192,10 @@ impl LeafProver {
         Self {
             prover,
             num_children_leaf: DEFAULT_NUM_CHILDREN_LEAF,
-            profile: false,
         }
     }
     pub fn with_num_children_leaf(mut self, num_children_leaf: usize) -> Self {
         self.num_children_leaf = num_children_leaf;
-        self
-    }
-    pub fn with_profile(mut self) -> Self {
-        self.profile = true;
         self
     }
     pub fn generate_proof(&self, app_proofs: &ContinuationVmProof<SC>) -> Vec<Proof<SC>> {
@@ -232,29 +212,12 @@ impl LeafProver {
                 .enumerate()
                 .map(|(leaf_node_idx, input)| {
                     info_span!("leaf verifier proof", idx = leaf_node_idx).in_scope(|| {
-                        single_segment_prove(&self.prover, input.write_to_stream(), self.profile)
+                        SingleSegmentVmProver::prove(&self.prover, input.write_to_stream())
                     })
                 })
                 .collect::<Vec<_>>()
         })
     }
-}
-
-#[allow(unused)]
-fn single_segment_prove<E: StarkFriEngine<SC>>(
-    prover: &VmLocalProver<SC, NativeConfig, E>,
-    input: impl Into<Streams<F>> + Clone,
-    profile: bool,
-) -> Proof<SC> {
-    #[cfg(feature = "bench-metrics")]
-    if profile {
-        let mut vm_config = prover.pk.vm_config.clone();
-        vm_config.system.profiling = true;
-        let vm = SingleSegmentVmExecutor::new(vm_config);
-        vm.execute(prover.committed_exe.exe.clone(), input.clone())
-            .unwrap();
-    }
-    SingleSegmentVmProver::prove(prover, input)
 }
 
 fn heights_le(a: &[usize], b: &[usize]) -> bool {

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-#[cfg(feature = "bench-metrics")]
-use openvm_circuit::arch::SingleSegmentVmExecutor;
 use openvm_native_circuit::NativeConfig;
 use openvm_native_recursion::hints::Hintable;
 use openvm_stark_sdk::{

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -162,19 +162,6 @@ impl AggStarkProver {
                     .fri_params
                     .log_blowup as u64,
             );
-            #[cfg(feature = "bench-metrics")]
-            if self.profile {
-                let mut vm_config = self.root_prover.root_verifier_pk.vm_pk.vm_config.clone();
-                vm_config.system.profiling = true;
-                let vm = SingleSegmentVmExecutor::new(vm_config);
-                let exe = self
-                    .root_prover
-                    .root_verifier_pk
-                    .root_committed_exe
-                    .exe
-                    .clone();
-                vm.execute(exe, input.clone()).unwrap();
-            }
             SingleSegmentVmProver::prove(&self.root_prover, input)
         })
     }

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
+use getset::Getters;
 use openvm_circuit::arch::VmConfig;
 #[cfg(feature = "bench-metrics")]
 use openvm_circuit::arch::{instructions::exe::VmExe, VmExecutor};
-use openvm_stark_backend::Chip;
+use openvm_stark_backend::{prover::types::Proof, Chip};
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Engine;
 use tracing::info_span;
 
+use super::vm::SingleSegmentVmProver;
 use crate::{
     prover::vm::{
         local::VmLocalProver, types::VmProvingKey, ContinuationVmProof, ContinuationVmProver,
@@ -14,11 +16,10 @@ use crate::{
     NonRootCommittedExe, StdIn, F, SC,
 };
 
+#[derive(Getters)]
 pub struct AppProver<VC> {
-    /// If true, will run execution once with full metric collection for
-    /// flamegraphs (WARNING: this degrades performance).
-    pub profile: bool,
     pub program_name: Option<String>,
+    #[getset(get = "pub")]
     app_prover: VmLocalProver<SC, VC, BabyBearPoseidon2Engine>,
 }
 
@@ -31,21 +32,12 @@ impl<VC> AppProver<VC> {
         VC: VmConfig<F>,
     {
         Self {
-            profile: false,
             program_name: None,
             app_prover: VmLocalProver::<SC, VC, BabyBearPoseidon2Engine>::new(
                 app_vm_pk,
                 app_committed_exe,
             ),
         }
-    }
-    pub fn set_profile(&mut self, profile: bool) -> &mut Self {
-        self.profile = profile;
-        self
-    }
-    pub fn with_profiling(mut self) -> Self {
-        self.set_profile(true);
-        self
     }
     pub fn set_program_name(&mut self, program_name: impl AsRef<str>) -> &mut Self {
         self.program_name = Some(program_name.as_ref().to_string());
@@ -56,12 +48,17 @@ impl<VC> AppProver<VC> {
         self
     }
 
+    /// Generates proof for every continuation segment
     pub fn generate_app_proof(&self, input: StdIn) -> ContinuationVmProof<SC>
     where
         VC: VmConfig<F>,
         VC::Executor: Chip<SC>,
         VC::Periphery: Chip<SC>,
     {
+        assert!(
+            self.vm_config().system().continuation_enabled,
+            "Use generate_app_proof_without_continuations instead."
+        );
         info_span!(
             "app proof",
             group = self
@@ -71,28 +68,39 @@ impl<VC> AppProver<VC> {
         )
         .in_scope(|| {
             #[cfg(feature = "bench-metrics")]
-            if self.profile {
-                emit_app_execution_metrics(
-                    self.app_prover.pk.vm_config.clone(),
-                    self.app_prover.committed_exe.exe.clone(),
-                    input.clone(),
-                );
-            }
-            #[cfg(feature = "bench-metrics")]
             metrics::counter!("fri.log_blowup")
                 .absolute(self.app_prover.pk.fri_params.log_blowup as u64);
             ContinuationVmProver::prove(&self.app_prover, input)
         })
     }
-}
 
-#[cfg(feature = "bench-metrics")]
-fn emit_app_execution_metrics<VC: VmConfig<F>>(mut vm_config: VC, exe: VmExe<F>, input: StdIn)
-where
-    VC::Executor: Chip<SC>,
-    VC::Periphery: Chip<SC>,
-{
-    vm_config.system_mut().profiling = true;
-    let vm = VmExecutor::new(vm_config);
-    vm.execute_segments(exe, input).unwrap();
+    pub fn generate_app_proof_without_continuations(&self, input: StdIn) -> Proof<SC>
+    where
+        VC: VmConfig<F>,
+        VC::Executor: Chip<SC>,
+        VC::Periphery: Chip<SC>,
+    {
+        assert!(
+            !self.vm_config().system().continuation_enabled,
+            "Use generate_app_proof instead."
+        );
+        info_span!(
+            "app proof",
+            group = self
+                .program_name
+                .as_ref()
+                .unwrap_or(&"app_proof".to_string())
+        )
+        .in_scope(|| {
+            #[cfg(feature = "bench-metrics")]
+            metrics::counter!("fri.log_blowup")
+                .absolute(self.app_prover.pk.fri_params.log_blowup as u64);
+            SingleSegmentVmProver::prove(&self.app_prover, input)
+        })
+    }
+
+    /// App VM config
+    pub fn vm_config(&self) -> &VC {
+        self.app_prover.vm_config()
+    }
 }

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -2,8 +2,6 @@ use std::sync::Arc;
 
 use getset::Getters;
 use openvm_circuit::arch::VmConfig;
-#[cfg(feature = "bench-metrics")]
-use openvm_circuit::arch::{instructions::exe::VmExe, VmExecutor};
 use openvm_stark_backend::{prover::types::Proof, Chip};
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Engine;
 use tracing::info_span;

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -54,18 +54,6 @@ impl<VC> ContinuationProver<VC> {
         }
     }
 
-    /// Flag for enabling/disabling profiling.
-    pub fn set_profile(&mut self, profile: bool) -> &mut Self {
-        self.stark_prover.set_profile(profile);
-        // halo2 profiling is set in CompilerConfig when creating Halo2ProvingKey
-        self
-    }
-
-    pub fn with_profiling(mut self) -> Self {
-        self.set_profile(true);
-        self
-    }
-
     pub fn set_program_name(&mut self, program_name: impl AsRef<str>) -> &mut Self {
         self.stark_prover.set_program_name(program_name);
         self

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -37,11 +37,6 @@ impl<VC> StarkProver<VC> {
             agg_prover: AggStarkProver::new(agg_stark_pk, app_pk.leaf_committed_exe.clone()),
         }
     }
-    pub fn set_profile(&mut self, profile: bool) -> &mut Self {
-        self.app_prover.set_profile(profile);
-        self.agg_prover.set_profile(profile);
-        self
-    }
     pub fn set_program_name(&mut self, program_name: impl AsRef<str>) -> &mut Self {
         self.app_prover.set_program_name(program_name);
         self

--- a/crates/sdk/src/prover/vm/local.rs
+++ b/crates/sdk/src/prover/vm/local.rs
@@ -28,10 +28,7 @@ pub struct VmLocalProver<SC: StarkGenericConfig, VC, E: StarkFriEngine<SC>> {
     _marker: PhantomData<E>,
 }
 
-impl<SC: StarkGenericConfig, VC: VmConfig<Val<SC>>, E: StarkFriEngine<SC>> VmLocalProver<SC, VC, E>
-where
-    Val<SC>: PrimeField32,
-{
+impl<SC: StarkGenericConfig, VC, E: StarkFriEngine<SC>> VmLocalProver<SC, VC, E> {
     pub fn new(pk: Arc<VmProvingKey<SC, VC>>, committed_exe: Arc<VmCommittedExe<SC>>) -> Self {
         Self {
             pk,
@@ -56,6 +53,10 @@ where
 
     pub fn set_override_trace_heights(&mut self, overridden_heights: VmComplexTraceHeights) {
         self.overridden_heights = Some(overridden_heights);
+    }
+
+    pub fn vm_config(&self) -> &VC {
+        &self.pk.vm_config
     }
 }
 


### PR DESCRIPTION
Cleanup benchmark so verify_fibair actually uses volatile memory (it should not have continuations enabled).
In the process:
- rename `get_vk` to `get_app_vk`
- add non-continuation prove and verify functions to `AppProver`
- remove `profiling` flag from sdk provers: this should just be set in the VmConfig and we do not encourage rerunning execution twice

In this PR, the Fibonacci STARK number of rows is kept the same. In a future PR I may increase the number of rows in the to-be-verified STARK to make the benchmark bigger.