### PR TITLE
perf: lock-free cycle count increment

### DIFF
--- a/benchmarks/benches/regex_execute.rs
+++ b/benchmarks/benches/regex_execute.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use openvm_benchmarks::utils::build_bench_program;
 use openvm_circuit::arch::{instructions::exe::VmExe, VmExecutor};
 use openvm_keccak256_circuit::Keccak256Rv32Config;
@@ -33,7 +33,7 @@ fn benchmark_function(c: &mut Criterion) {
     group.bench_function("execute", |b| {
         b.iter(|| {
             executor
-                .execute(exe.clone(), StdIn::from_bytes(&fe_bytes))
+                .execute(exe.clone(), black_box(StdIn::from_bytes(&fe_bytes)))
                 .unwrap();
         })
     });

--- a/benchmarks/examples/regex_execute.rs
+++ b/benchmarks/examples/regex_execute.rs
@@ -27,7 +27,9 @@ fn main() {
 
     let data = include_str!("../programs/regex/regex_email.txt");
 
+    let timer = std::time::Instant::now();
     executor
         .execute(exe.clone(), StdIn::from_bytes(data.as_bytes()))
         .unwrap();
+    println!("execute_time: {:?}", timer.elapsed());
 }

--- a/crates/vm/src/metrics/mod.rs
+++ b/crates/vm/src/metrics/mod.rs
@@ -14,6 +14,7 @@ pub mod cycle_tracker;
 
 #[derive(Clone, Debug, Default)]
 pub struct VmMetrics {
+    pub cycle_count: usize,
     pub chip_heights: Vec<(String, usize)>,
     /// Maps (dsl_ir, opcode) to number of times opcode was executed
     pub counts: BTreeMap<(Option<String>, String), usize>,
@@ -42,7 +43,7 @@ where
         opcode: VmOpcode,
         dsl_instr: Option<String>,
     ) {
-        counter!("total_cycles").increment(1u64);
+        self.metrics.cycle_count += 1;
 
         if self.system_config().profiling {
             let executor = self.chip_complex.inventory.get_executor(opcode).unwrap();
@@ -60,6 +61,7 @@ where
     }
 
     pub fn finalize_metrics(&mut self) {
+        counter!("total_cycles").absolute(self.metrics.cycle_count as u64);
         counter!("main_cells_used")
             .absolute(self.current_trace_cells().into_iter().sum::<usize>() as u64);
 


### PR DESCRIPTION
A stupid but important performance optimization when metric collection is turned on: every instruction increments the cycle count. When this is done directly via `metric::Counter` the metric recorder acquires a lock every time. This has significant (2x) performance impact on execution.