### PR TITLE
fix: broken links

### DIFF
--- a/book/src/custom-extensions/bigint.md
+++ b/book/src/custom-extensions/bigint.md
@@ -31,7 +31,7 @@ When using the `U256` struct with `target_os = "zkvm"`, the struct utilizes effi
 
 ### Example matrix multiplication using `U256`
 
-See the full example [here](https://github.com/openvm-org/openvm/blob/main/crates/toolchain/tests/programs/examples/matrix-power.rs).
+See the full example [here](https://github.com/openvm-org/openvm/blob/main/extensions/bigint/tests/programs/examples/book-example2.rs).
 
 ```rust
 #![cfg_attr(not(feature = "std"), no_main)]
@@ -111,7 +111,7 @@ When using the `I256` struct with `target_os = "zkvm"`, the struct utilizes effi
 
 ### Example matrix multiplication using `I256`
 
-See the full example [here](https://github.com/openvm-org/openvm/blob/main/crates/toolchain/tests/programs/examples/matrix-power-signed.rs).
+See the full example [here](https://github.com/openvm-org/openvm/blob/main/extensions/bigint/tests/programs/examples/matrix-power-signed.rs).
 
 ```rust
 #![cfg_attr(not(feature = "std"), no_main)]

--- a/book/src/custom-extensions/ecc.md
+++ b/book/src/custom-extensions/ecc.md
@@ -63,7 +63,7 @@ For the basic operations provided by the `WeierstrassPoint` trait, the scalar fi
 
 ## Example program
 
-See a working example [here](https://github.com/openvm-org/openvm/blob/main/crates/toolchain/tests/programs/examples/ec.rs).
+See a working example [here](https://github.com/openvm-org/openvm/blob/main/extensions/ecc/tests/programs/examples/ec.rs).
 
 To use the ECC extension, add the following dependencies to `Cargo.toml`:
 

--- a/book/src/custom-extensions/keccak.md
+++ b/book/src/custom-extensions/keccak.md
@@ -10,7 +10,7 @@ The OpenVM Keccak256 Guest extension provides two functions for using in your gu
 - `keccak256(input: &[u8]) -> [u8; 32]`: Computes the Keccak-256 hash of the input data and returns it as an array of 32 bytes.
 - `set_keccak256(input: &[u8], output: &mut [u8; 32])`: Sets the output to the Keccak-256 hash of the input data into the provided output buffer.
 
-See the full example [here](https://github.com/openvm-org/openvm/blob/main/crates/toolchain/tests/programs/examples/keccak.rs).
+See the full example [here](https://github.com/openvm-org/openvm/blob/main/extensions/keccak256/tests/programs/examples/keccak.rs).
 
 ### Example:
 


### PR DESCRIPTION
Hi! I’ve fixed some broken links in the documentation for the `bigint`, `ecc`, and `keccak` extensions. The updated links now point to the correct paths within the repository.
