### PR TITLE
Fix: Ensure program trace for frequencies skips `None` instructions

### DIFF
--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -18,7 +18,7 @@ pub struct Program<F> {
     /// A map from program counter to instruction.
     /// Sometimes the instructions are enumerated as 0, 4, 8, etc.
     /// Maybe at some point we will replace this with a struct that would have a `Vec` under the hood and divide the incoming `pc` by whatever given.
-    instructions_and_debug_infos: Vec<Option<(Instruction<F>, Option<DebugInfo>)>>,
+    pub instructions_and_debug_infos: Vec<Option<(Instruction<F>, Option<DebugInfo>)>>,
     pub step: u32,
     pub pc_base: u32,
     /// The upper bound of the number of public values the program would publish.

--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -126,7 +126,7 @@ impl<F: Field> Program<F> {
         self.instructions_and_debug_infos.is_empty()
     }
 
-    pub fn non_none_instructions(&self) -> Vec<Instruction<F>> {
+    pub fn defined_instructions(&self) -> Vec<Instruction<F>> {
         self.instructions_and_debug_infos
             .iter()
             .flatten()
@@ -134,8 +134,9 @@ impl<F: Field> Program<F> {
             .collect()
     }
 
-    pub fn num_non_none_instructions(&self) -> usize {
-        self.non_none_instructions().len()
+    // if this is being called a lot, we may want to optimize this later
+    pub fn num_defined_instructions(&self) -> usize {
+        self.defined_instructions().len()
     }
 
     pub fn debug_infos(&self) -> Vec<Option<DebugInfo>> {
@@ -193,7 +194,7 @@ impl<F: Field> Program<F> {
 }
 impl<F: Field> Display for Program<F> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for instruction in self.non_none_instructions().iter() {
+        for instruction in self.defined_instructions().iter() {
             let Instruction {
                 opcode,
                 a,
@@ -215,7 +216,7 @@ impl<F: Field> Display for Program<F> {
 }
 
 pub fn display_program_with_pc<F: Field>(program: &Program<F>) {
-    for (pc, instruction) in program.non_none_instructions().iter().enumerate() {
+    for (pc, instruction) in program.defined_instructions().iter().enumerate() {
         let Instruction {
             opcode,
             a,

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -44,8 +44,10 @@ impl<F: PrimeField64> ProgramChip<F> {
 
     pub fn set_program(&mut self, mut program: Program<F>) {
         let true_program_length = program.len();
-        while !program.len().is_power_of_two() {
+        let mut number_actual_instructions = program.num_non_none_instructions();
+        while !number_actual_instructions.is_power_of_two() {
             program.push_instruction(padding_instruction());
+            number_actual_instructions += 1;
         }
         self.true_program_length = true_program_length;
         self.execution_frequencies = vec![0; program.len()];

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -44,7 +44,7 @@ impl<F: PrimeField64> ProgramChip<F> {
 
     pub fn set_program(&mut self, mut program: Program<F>) {
         let true_program_length = program.len();
-        let mut number_actual_instructions = program.num_non_none_instructions();
+        let mut number_actual_instructions = program.num_defined_instructions();
         while !number_actual_instructions.is_power_of_two() {
             program.push_instruction(padding_instruction());
             number_actual_instructions += 1;

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -49,7 +49,7 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
     for (index, frequency) in execution_frequencies.into_iter().enumerate() {
         let option = program.get_instruction_and_debug_info(index);
         if let Some((instruction, _)) = option {
-            program_cells.extend(vec![
+            program_cells.extend([
                 BabyBear::from_canonical_usize(frequency), // hacky: we should switch execution_frequencies into hashmap
                 BabyBear::from_canonical_usize(index * (DEFAULT_PC_STEP as usize)),
                 instruction.opcode.to_field(),

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -67,7 +67,7 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
 
     // Pad program cells with zeroes to make height a power of two.
     let width = 10;
-    let original_height = program.num_non_none_instructions();
+    let original_height = program.num_defined_instructions();
     let desired_height = original_height.next_power_of_two();
     let cells_to_add = (desired_height - original_height) * width;
     program_cells.extend(iter::repeat(BabyBear::ZERO).take(cells_to_add));

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -2,7 +2,7 @@ use std::{iter, sync::Arc};
 
 use openvm_instructions::{
     instruction::Instruction,
-    program::{Program, DEFAULT_PC_STEP},
+    program::{Program, DEFAULT_MAX_NUM_PUBLIC_VALUES, DEFAULT_PC_STEP},
     VmOpcode,
 };
 use openvm_native_compiler::{
@@ -35,10 +35,9 @@ assert_impl_all!(VmCommittedExe<BabyBearPoseidon2Config>: Serialize, Deserialize
 assert_impl_all!(VmCommittedExe<BabyBearPoseidon2RootConfig>: Serialize, DeserializeOwned);
 
 fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
-    let instructions = program.instructions();
     let bus = ProgramBus(READ_INSTRUCTION_BUS);
-    let mut chip = ProgramChip::new_with_program(program, bus);
-    let mut execution_frequencies = vec![0; instructions.len()];
+    let mut chip = ProgramChip::new_with_program(program.clone(), bus);
+    let mut execution_frequencies = vec![0; program.len()];
     for pc_idx in execution {
         execution_frequencies[pc_idx as usize] += 1;
         chip.get_instruction(pc_idx * DEFAULT_PC_STEP).unwrap();
@@ -47,29 +46,34 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
 
     let counter_air = DummyInteractionAir::new(9, true, bus.0);
     let mut program_cells = vec![];
-    for (pc_idx, instruction) in instructions.iter().enumerate() {
-        program_cells.extend(vec![
-            BabyBear::from_canonical_usize(execution_frequencies[pc_idx]), // hacky: we should switch execution_frequencies into hashmap
-            BabyBear::from_canonical_usize(pc_idx * (DEFAULT_PC_STEP as usize)),
-            instruction.opcode.to_field(),
-            instruction.a,
-            instruction.b,
-            instruction.c,
-            instruction.d,
-            instruction.e,
-            instruction.f,
-            instruction.g,
-        ]);
+    for index in 0..program.len() {
+        let option = program.get_instruction_and_debug_info(index);
+        if option.is_some() {
+            let instruction = option.unwrap().0;
+            program_cells.extend(vec![
+                BabyBear::from_canonical_usize(execution_frequencies[index]), // hacky: we should switch execution_frequencies into hashmap
+                BabyBear::from_canonical_usize(index * (DEFAULT_PC_STEP as usize)),
+                instruction.opcode.to_field(),
+                instruction.a,
+                instruction.b,
+                instruction.c,
+                instruction.d,
+                instruction.e,
+                instruction.f,
+                instruction.g,
+            ]);
+        }
     }
 
     // Pad program cells with zeroes to make height a power of two.
     let width = 10;
-    let desired_height = instructions.len().next_power_of_two();
-    let cells_to_add = (desired_height - instructions.len()) * width;
+    let original_height = program.num_non_none_instructions();
+    let desired_height = original_height.next_power_of_two();
+    let cells_to_add = (desired_height - original_height) * width;
     program_cells.extend(iter::repeat(BabyBear::ZERO).take(cells_to_add));
 
     let counter_trace = RowMajorMatrix::new(program_cells, 10);
-    println!("trace height = {}", instructions.len());
+    println!("trace height = {}", original_height);
     println!("counter trace height = {}", counter_trace.height());
 
     BabyBearPoseidon2Engine::run_test_fast(vec![
@@ -210,4 +214,64 @@ fn test_program_negative() {
         AirProofInput::simple_no_pis(Arc::new(counter_air), counter_trace),
     ])
     .expect("Verification failed");
+}
+
+#[test]
+fn test_program_with_none_instructions() {
+    let n = 2;
+
+    // see core/tests/mod.rs
+    let instructions = vec![
+        // word[0]_1 <- word[n]_0
+        Some(Instruction::large_from_isize(
+            VmOpcode::with_default_offset(STOREW),
+            n,
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+        )),
+        // word[1]_1 <- word[1]_1
+        Some(Instruction::large_from_isize(
+            VmOpcode::with_default_offset(STOREW),
+            1,
+            1,
+            0,
+            0,
+            1,
+            0,
+            1,
+        )),
+        // if word[0]_1 == n then pc += 3*DEFAULT_PC_STEP
+        Some(Instruction::from_isize(
+            VmOpcode::with_default_offset(NativeBranchEqualOpcode(BEQ)),
+            0,
+            n,
+            3 * DEFAULT_PC_STEP as isize,
+            1,
+            0,
+        )),
+        None,
+        None,
+        // terminate
+        Some(Instruction::from_isize(
+            VmOpcode::with_default_offset(TERMINATE),
+            0,
+            0,
+            0,
+            0,
+            0,
+        )),
+    ];
+
+    let program = Program::new_without_debug_infos_with_option(
+        &instructions,
+        DEFAULT_PC_STEP,
+        0,
+        DEFAULT_MAX_NUM_PUBLIC_VALUES,
+    );
+
+    interaction_test(program, vec![0, 2, 5]);
 }

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -46,12 +46,12 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
 
     let counter_air = DummyInteractionAir::new(9, true, bus.0);
     let mut program_cells = vec![];
-    for index in 0..program.len() {
+    for (index, frequency) in execution_frequencies.into_iter().enumerate() {
         let option = program.get_instruction_and_debug_info(index);
         if option.is_some() {
             let instruction = option.unwrap().0;
             program_cells.extend(vec![
-                BabyBear::from_canonical_usize(execution_frequencies[index]), // hacky: we should switch execution_frequencies into hashmap
+                BabyBear::from_canonical_usize(frequency), // hacky: we should switch execution_frequencies into hashmap
                 BabyBear::from_canonical_usize(index * (DEFAULT_PC_STEP as usize)),
                 instruction.opcode.to_field(),
                 instruction.a,

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -48,8 +48,7 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
     let mut program_cells = vec![];
     for (index, frequency) in execution_frequencies.into_iter().enumerate() {
         let option = program.get_instruction_and_debug_info(index);
-        if option.is_some() {
-            let instruction = option.unwrap().0;
+        if let Some((instruction, _)) = option {
             program_cells.extend(vec![
                 BabyBear::from_canonical_usize(frequency), // hacky: we should switch execution_frequencies into hashmap
                 BabyBear::from_canonical_usize(index * (DEFAULT_PC_STEP as usize)),
@@ -217,7 +216,7 @@ fn test_program_negative() {
 }
 
 #[test]
-fn test_program_with_none_instructions() {
+fn test_program_with_undefined_instructions() {
     let n = 2;
 
     // see core/tests/mod.rs

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -62,9 +62,10 @@ impl<F: PrimeField64> ProgramChip<F> {
         let common_trace = RowMajorMatrix::new_col(
             self.execution_frequencies
                 .into_iter()
-                .enumerate()
-                .filter(|(i, _)| self.program.get_instruction_and_debug_info(*i).is_some())
-                .map(|(_, x)| F::from_canonical_usize(x))
+                .zip_eq(self.program.instructions_and_debug_infos.iter())
+                .filter_map(|(frequency, option)| {
+                    option.as_ref().map(|_| F::from_canonical_usize(frequency))
+                })
                 .collect::<Vec<F>>(),
         );
         if let Some(cached_trace) = cached_trace {

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -62,7 +62,9 @@ impl<F: PrimeField64> ProgramChip<F> {
         let common_trace = RowMajorMatrix::new_col(
             self.execution_frequencies
                 .into_iter()
-                .map(|x| F::from_canonical_usize(x))
+                .enumerate()
+                .filter(|(i, _)| self.program.get_instruction_and_debug_info(*i).is_some())
+                .map(|(_, x)| F::from_canonical_usize(x))
                 .collect::<Vec<F>>(),
         );
         if let Some(cached_trace) = cached_trace {


### PR DESCRIPTION
Adds a `ProgramChip` test with a program that has `None` instructions. Fixes trace generation to pass this test: previously, the frequencies array was just directly being converted into the trace, even though the cached trace skipped the instructions that were `None`. Now those are skipped in trace generation for the frequencies as well.

Adds a constructor for `Program` that takes in a `Vec` of `Option<Instruction>`. Also changed the name of `Program::instructions()` to `Program::non_none_instructions` since the old name seemed misleading, and added `Program::num_non_none_instructions()` since that was the only use of `Program::instructions()` other than for display. These names don't seem very good so someone should suggest better ones.