### PR TITLE
fix(ci): benchmark-e2e params dir

### DIFF
--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -168,9 +168,10 @@ jobs:
           if [[ "${E2E_BENCH}" == "true" ]]; then
             ROOT_ARG="--root_log_blowup ${{ inputs.root_log_blowup }}"
             INTERNAL_ARG="--internal_log_blowup ${{ inputs.internal_log_blowup }}"
-            echo "INPUT_ARGS=${ROOT_ARG} ${INTERNAL_ARG} ${INPUT_ARGS}" >> $GITHUB_ENV
             bash ./extensions/native/recursion/trusted_setup_s3.sh
-            echo "PARAMS_DIR=$(pwd)/params" >> $GITHUB_ENV
+            PARAMS_DIR=$(pwd)/params
+            PARAMS_ARG="--kzg-params-dir $PARAMS_DIR"
+            echo "INPUT_ARGS=${ROOT_ARG} ${INTERNAL_ARG} ${PARAMS_ARG} ${INPUT_ARGS}" >> $GITHUB_ENV
           fi
 
       - name: Set BIN_NAME

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -170,7 +170,7 @@ jobs:
             INTERNAL_ARG="--internal_log_blowup ${{ inputs.internal_log_blowup }}"
             echo "INPUT_ARGS=${ROOT_ARG} ${INTERNAL_ARG} ${INPUT_ARGS}" >> $GITHUB_ENV
             bash ./extensions/native/recursion/trusted_setup_s3.sh
-            export PARAMS_DIR=$(pwd)/params
+            echo "PARAMS_DIR=$(pwd)/params" >> $GITHUB_ENV
           fi
 
       - name: Set BIN_NAME

--- a/benchmarks/src/bin/fib_e2e.rs
+++ b/benchmarks/src/bin/fib_e2e.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use eyre::Result;
 use openvm_benchmarks::utils::BenchmarkCli;
 use openvm_circuit::arch::instructions::{exe::VmExe, program::DEFAULT_MAX_NUM_PUBLIC_VALUES};
-use openvm_native_recursion::halo2::utils::CacheHalo2ParamsReader;
+use openvm_native_recursion::halo2::utils::{CacheHalo2ParamsReader, DEFAULT_PARAMS_DIR};
 use openvm_rv32im_circuit::Rv32ImConfig;
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
@@ -29,7 +29,11 @@ async fn main() -> Result<()> {
     let agg_config = args.agg_config();
 
     let sdk = Sdk;
-    let halo2_params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
+    let halo2_params_reader = CacheHalo2ParamsReader::new(
+        args.kzg_params_dir
+            .clone()
+            .unwrap_or(PathBuf::from(DEFAULT_PARAMS_DIR)),
+    );
     let app_pk = Arc::new(sdk.app_keygen(app_config)?);
     let full_agg_pk = sdk.agg_keygen(agg_config, &halo2_params_reader)?;
     let elf = args.build_bench_program("fibonacci")?;

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -61,6 +61,9 @@ pub struct BenchmarkCli {
     #[arg(long)]
     pub halo2_wrapper_k: Option<usize>,
 
+    #[arg(long)]
+    pub kzg_params_dir: Option<PathBuf>,
+
     /// Max segment length for continuations
     #[arg(short, long, alias = "max_segment_length")]
     pub max_segment_length: Option<usize>,

--- a/ci/scripts/bench.py
+++ b/ci/scripts/bench.py
@@ -12,6 +12,7 @@ def run_cargo_command(
     internal_log_blowup,
     max_segment_length,
     output_path,
+    kzg_params_dir,
     profile="release"
 ):
     # Command to run (for best performance but slower builds, use --profile maxperf)
@@ -29,6 +30,8 @@ def run_cargo_command(
         command.extend(["--internal_log_blowup", internal_log_blowup])
     if max_segment_length is not None:
         command.extend(["--max_segment_length", max_segment_length])
+    if kzg_params_dir is not None:
+        command.extend(["--kzg-params-dir", kzg_params_dir])
     if "profiling" in feature_flags:
         # set guest build args and vm config to profiling
         command.extend(["--profiling"])
@@ -63,6 +66,7 @@ def bench():
     parser.add_argument('--root_log_blowup', type=str, help="Root level log blowup")
     parser.add_argument('--internal_log_blowup', type=str, help="Internal level log blowup")
     parser.add_argument('--max_segment_length', type=str, help="Max segment length for continuations")
+    parser.add_argument('--kzg-params-dir', type=str, help="Directory containing KZG trusted setup files")
     parser.add_argument('--features', type=str, help="Additional features")
     parser.add_argument('--output_path', type=str, required=True, help="The path to write the metrics to")
     args = parser.parse_args()
@@ -79,6 +83,7 @@ def bench():
         args.internal_log_blowup,
         args.max_segment_length,
         args.output_path,
+        args.kzg_params_dir
     )
 
 

--- a/extensions/native/recursion/src/halo2/utils.rs
+++ b/extensions/native/recursion/src/halo2/utils.rs
@@ -125,9 +125,10 @@ impl CacheHalo2ParamsReader {
         }
     }
     fn read_params_from_folder(&self, k: usize) -> Halo2Params {
+        let file_path = self.params_dir.as_path().join(format!("kzg_bn254_{k}.srs"));
         ParamsKZG::<Bn256>::read(&mut BufReader::new(
-            std::fs::File::open(self.params_dir.as_path().join(format!("kzg_bn254_{k}.srs")))
-                .expect("Params file does not exist"),
+            std::fs::File::open(&file_path)
+                .unwrap_or_else(|e| panic!("Params file {:?} does not exist: {e:?}", file_path)),
         ))
         .unwrap()
     }


### PR DESCRIPTION
add `--kzg-params-dir` to benchmark cli args to specify the kzg trusted setup directory.

workflow: https://github.com/openvm-org/openvm/actions/runs/12645324202/job/35234301358