### PR TITLE
fix typo Update sdk.md

### DIFF
--- a/book/src/advanced-usage/sdk.md
+++ b/book/src/advanced-usage/sdk.md
@@ -77,7 +77,7 @@ After generating a proof, you can verify it. To do so, you need your verifying k
 
 ### Setup
 
-To generate an EVM proof, you'll first need to ensure that you have followed the [CLI installation steps](../../getting-started/install.md). get the appropraite KZG params by running the following command.
+To generate an EVM proof, you'll first need to ensure that you have followed the [CLI installation steps](../../getting-started/install.md). get the appropriate KZG params by running the following command.
 
 ```bash
 cargo openvm setup


### PR DESCRIPTION
# Fix Typo in sdk.md

## Description

This pull request fixes a typo in the `sdk.md` file. The word **appropraite** was corrected to **appropriate**.

### Original:
> ...get the appropraite KZG params by running the following command.

### Fixed:
> ...get the appropriate KZG params by running the following command.

## Changes Made
- Corrected the typo on line 77 of `book/src/advanced-usage/sdk.md`.

## Checklist
- [x] Verified the correction aligns with the intended meaning.
- [x] Built and tested documentation locally (if applicable).

---

Let me know if further edits are needed. Thank you!
