### PR TITLE
feat: Change execute to take &Instruction

### DIFF
--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -231,7 +231,7 @@ where
             inputs.push(input);
         }
 
-        let Instruction { opcode, .. } = instruction.clone();
+        let Instruction { opcode, .. } = instruction;
         let local_opcode_idx = opcode.local_opcode_idx(self.air.offset);
         let mut flags = vec![];
 

--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -167,11 +167,10 @@ impl<F: Field> Program<F> {
     pub fn get_instruction_and_debug_info(
         &self,
         index: usize,
-    ) -> Option<(Instruction<F>, Option<DebugInfo>)> {
+    ) -> Option<&(Instruction<F>, Option<DebugInfo>)> {
         self.instructions_and_debug_infos
             .get(index)
-            .cloned()
-            .flatten()
+            .and_then(|x| x.as_ref())
     }
 
     pub fn push_instruction_and_debug_info(

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -38,7 +38,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<F>,
-                        instruction: ::openvm_circuit::arch::instructions::instruction::Instruction<F>,
+                        instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         from_state: ::openvm_circuit::arch::ExecutionState<u32>,
                     ) -> ::openvm_circuit::arch::Result<::openvm_circuit::arch::ExecutionState<u32>> {
                         self.0.execute(memory, instruction, from_state)
@@ -92,7 +92,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<#first_ty_generic>,
-                        instruction: ::openvm_circuit::arch::instructions::instruction::Instruction<#first_ty_generic>,
+                        instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<#first_ty_generic>,
                         from_state: ::openvm_circuit::arch::ExecutionState<u32>,
                     ) -> ::openvm_circuit::arch::Result<::openvm_circuit::arch::ExecutionState<u32>> {
                         match self {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -66,7 +66,7 @@ pub trait InstructionExecutor<F> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>>;
 
@@ -79,7 +79,7 @@ impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         prev_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>> {
         self.borrow_mut().execute(memory, instruction, prev_state)
@@ -94,7 +94,7 @@ impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for Rc<RefCell<C>> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         prev_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>> {
         self.borrow_mut().execute(memory, instruction, prev_state)

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -214,16 +214,16 @@ where
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>> {
-        let (reads, read_record) = self.adapter.preprocess(memory, &instruction)?;
+        let (reads, read_record) = self.adapter.preprocess(memory, instruction)?;
         let (output, core_record) =
             self.core
-                .execute_instruction(&instruction, from_state.pc, reads)?;
+                .execute_instruction(instruction, from_state.pc, reads)?;
         let (to_state, write_record) =
             self.adapter
-                .postprocess(memory, &instruction, from_state, output, &read_record)?;
+                .postprocess(memory, instruction, from_state, output, &read_record)?;
         self.records.push((read_record, write_record, core_record));
         Ok(to_state)
     }

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -93,7 +93,7 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
     pub fn execute<E: InstructionExecutor<F>>(
         &mut self,
         executor: &mut E,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
     ) {
         let initial_pc = self.next_elem_size_u32();
         self.execute_with_pc(executor, instruction, initial_pc);
@@ -102,7 +102,7 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
     pub fn execute_with_pc<E: InstructionExecutor<F>>(
         &mut self,
         executor: &mut E,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         initial_pc: u32,
     ) {
         let initial_state = ExecutionState {
@@ -114,7 +114,7 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
         let final_state = executor
             .execute(
                 &mut *self.memory.controller.borrow_mut(),
-                instruction.clone(),
+                instruction,
                 initial_state,
             )
             .expect("Expected the execution not to fail");

--- a/crates/vm/src/arch/testing/program/mod.rs
+++ b/crates/vm/src/arch/testing/program/mod.rs
@@ -32,7 +32,7 @@ impl<F: PrimeField32> ProgramTester<F> {
         }
     }
 
-    pub fn execute(&mut self, instruction: Instruction<F>, initial_state: &ExecutionState<u32>) {
+    pub fn execute(&mut self, instruction: &Instruction<F>, initial_state: &ExecutionState<u32>) {
         self.records.push(ProgramExecutionCols {
             pc: F::from_canonical_u32(initial_state.pc),
             opcode: instruction.opcode.to_field(),

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -123,10 +123,10 @@ impl<F: PrimeField32> InstructionExecutor<F> for PhantomChip<F> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>, ExecutionError> {
-        let Instruction {
+        let &Instruction {
             opcode, a, b, c, ..
         } = instruction;
         assert_eq!(opcode, self.air.phantom_opcode);

--- a/crates/vm/src/system/phantom/tests.rs
+++ b/crates/vm/src/system/phantom/tests.rs
@@ -29,7 +29,7 @@ fn test_nops_and_terminate() {
     let mut state: ExecutionState<F> = ExecutionState::new(F::ZERO, F::ONE);
     let num_nops = 5;
     for _ in 0..num_nops {
-        tester.execute_with_pc(&mut chip, nop.clone(), state.pc.as_canonical_u32());
+        tester.execute_with_pc(&mut chip, &nop, state.pc.as_canonical_u32());
         let new_state = tester.execution.records.last().unwrap().final_state;
         assert_eq!(state.pc + F::from_canonical_usize(4), new_state.pc);
         assert_eq!(state.timestamp + F::ONE, new_state.timestamp);

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -72,7 +72,7 @@ impl<F: PrimeField64> ProgramChip<F> {
     pub fn get_instruction(
         &mut self,
         pc: u32,
-    ) -> Result<(Instruction<F>, Option<DebugInfo>), ExecutionError> {
+    ) -> Result<&(Instruction<F>, Option<DebugInfo>), ExecutionError> {
         let pc_index = self.get_pc_index(pc)?;
         self.execution_frequencies[pc_index] += 1;
         self.program

--- a/docs/crates/vm.md
+++ b/docs/crates/vm.md
@@ -11,7 +11,7 @@ pub trait InstructionExecutor<F> {
     /// current instance. May internally store records of this call for later trace generation.
     fn execute(
         &mut self,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
   ) -> Result<ExecutionState<u32>>;
 }

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -189,8 +189,8 @@ mod tests {
             y_limbs,
             chip.0.core.air.offset + Fp2Opcode::SUB as usize,
         );
-        tester.execute(&mut chip, instruction1);
-        tester.execute(&mut chip, instruction2);
+        tester.execute(&mut chip, &instruction1);
+        tester.execute(&mut chip, &instruction2);
         let tester = tester.build().load(chip).load(bitwise_chip).finalize();
         tester.simple_test().expect("Verification failed");
     }

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -233,8 +233,8 @@ mod tests {
             y_limbs,
             chip.0.core.air.offset + Fp2Opcode::DIV as usize,
         );
-        tester.execute(&mut chip, instruction1);
-        tester.execute(&mut chip, instruction2);
+        tester.execute(&mut chip, &instruction1);
+        tester.execute(&mut chip, &instruction2);
         let tester = tester.build().load(chip).load(bitwise_chip).finalize();
         tester.simple_test().expect("Verification failed");
     }

--- a/extensions/algebra/circuit/src/modular_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/modular_chip/addsub.rs
@@ -155,7 +155,7 @@ where
     ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
         let num_limbs = self.air.expr.canonical_num_limbs();
         let limb_bits = self.air.expr.canonical_limb_bits();
-        let Instruction { opcode, .. } = instruction.clone();
+        let Instruction { opcode, .. } = instruction;
         let local_opcode_idx = opcode.local_opcode_idx(self.air.offset);
         let data: DynArray<_> = reads.into();
         let data = data.0;

--- a/extensions/algebra/circuit/src/modular_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/modular_chip/muldiv.rs
@@ -170,7 +170,7 @@ where
     ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
         let num_limbs = self.air.expr.canonical_num_limbs();
         let limb_bits = self.air.expr.canonical_limb_bits();
-        let Instruction { opcode, .. } = instruction.clone();
+        let Instruction { opcode, .. } = instruction;
         let local_opcode_idx = opcode.local_opcode_idx(self.air.offset);
         let data: DynArray<_> = reads.into();
         let data = data.0;

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -154,7 +154,7 @@ fn test_addsub(opcode_offset: usize, modulus: BigUint) {
             ptr_as as isize,
             data_as as isize,
         );
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
 
         let expected_limbs = biguint_to_limbs::<NUM_LIMBS>(expected_answer, LIMB_BITS);
         for (i, expected) in expected_limbs.into_iter().enumerate() {
@@ -284,7 +284,7 @@ fn test_muldiv(opcode_offset: usize, modulus: BigUint) {
             ptr_as as isize,
             data_as as isize,
         );
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
 
         let expected_limbs = biguint_to_limbs::<NUM_LIMBS>(expected_answer, LIMB_BITS);
         for (i, expected) in expected_limbs.into_iter().enumerate() {
@@ -336,7 +336,7 @@ fn test_is_equal<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_LIM
             vec![[F::ZERO; TOTAL_LIMBS]],
             opcode_offset + Rv32ModularArithmeticOpcode::SETUP_ISEQ as usize,
         );
-        tester.execute(&mut chip, setup_instruction);
+        tester.execute(&mut chip, &setup_instruction);
     }
     for _ in 0..num_tests {
         let b = generate_field_element::<TOTAL_LIMBS, LIMB_BITS>(&modulus, &mut rng);
@@ -352,7 +352,7 @@ fn test_is_equal<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_LIM
             vec![c.map(F::from_canonical_u32)],
             opcode_offset + Rv32ModularArithmeticOpcode::IS_EQ as usize,
         );
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
     }
 
     // Special case where b == c are close to the prime
@@ -365,7 +365,7 @@ fn test_is_equal<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_LIM
         vec![b.map(F::from_canonical_u32)],
         opcode_offset + Rv32ModularArithmeticOpcode::IS_EQ as usize,
     );
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
 
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");

--- a/extensions/bigint/circuit/src/tests.rs
+++ b/extensions/bigint/circuit/src/tests.rs
@@ -63,7 +63,7 @@ fn run_int_256_rand_execute<E: InstructionExecutor<F>>(
 
             tester.execute_with_pc(
                 executor,
-                instruction,
+                &instruction,
                 rng.gen_range((ABS_MAX_BRANCH as u32)..(1 << (PC_BITS - 1))),
             );
 
@@ -78,7 +78,7 @@ fn run_int_256_rand_execute<E: InstructionExecutor<F>>(
                 vec![c.map(F::from_canonical_u32)],
                 opcode,
             );
-            tester.execute(executor, instruction);
+            tester.execute(executor, &instruction);
         }
     }
 }

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -138,7 +138,7 @@ fn test_add_ne() {
         vec![one_limbs, one_limbs],
         chip.0.core.air.offset + Rv32WeierstrassOpcode::SETUP_EC_ADD_NE as usize,
     );
-    tester.execute(&mut chip, setup_instruction);
+    tester.execute(&mut chip, &setup_instruction);
 
     let instruction = rv32_write_heap_default(
         &mut tester,
@@ -147,7 +147,7 @@ fn test_add_ne() {
         chip.0.core.air.offset + Rv32WeierstrassOpcode::EC_ADD_NE as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
 
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
 
@@ -204,7 +204,7 @@ fn test_double() {
         vec![],
         chip.0.core.air.offset + Rv32WeierstrassOpcode::SETUP_EC_DOUBLE as usize,
     );
-    tester.execute(&mut chip, setup_instruction);
+    tester.execute(&mut chip, &setup_instruction);
 
     let instruction = rv32_write_heap_default(
         &mut tester,
@@ -213,7 +213,7 @@ fn test_double() {
         chip.0.core.air.offset + Rv32WeierstrassOpcode::EC_DOUBLE as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
 
     tester.simple_test().expect("Verification failed");
@@ -294,7 +294,7 @@ fn test_p256_double() {
         vec![],
         chip.0.core.air.offset + Rv32WeierstrassOpcode::SETUP_EC_DOUBLE as usize,
     );
-    tester.execute(&mut chip, setup_instruction);
+    tester.execute(&mut chip, &setup_instruction);
 
     let instruction = rv32_write_heap_default(
         &mut tester,
@@ -303,7 +303,7 @@ fn test_p256_double() {
         chip.0.core.air.offset + Rv32WeierstrassOpcode::EC_DOUBLE as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
 
     tester.simple_test().expect("Verification failed");

--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -132,10 +132,10 @@ impl<F: PrimeField32> InstructionExecutor<F> for KeccakVmChip<F> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>, ExecutionError> {
-        let Instruction {
+        let &Instruction {
             opcode,
             a,
             b,

--- a/extensions/keccak256/circuit/src/tests.rs
+++ b/extensions/keccak256/circuit/src/tests.rs
@@ -64,7 +64,7 @@ fn build_keccak256_test(
 
         tester.execute(
             &mut chip,
-            Instruction::from_isize(
+            &Instruction::from_isize(
                 VmOpcode::from_usize(Rv32KeccakOpcode::KECCAK256 as usize),
                 a as isize,
                 b as isize,

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -134,7 +134,7 @@ where
         _from_pc: u32,
         reads: I::Reads,
     ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
-        let Instruction { opcode, .. } = instruction.clone();
+        let Instruction { opcode, .. } = instruction;
 
         assert_eq!(
             opcode.local_opcode_idx(self.air.offset),

--- a/extensions/native/circuit/src/castf/tests.rs
+++ b/extensions/native/circuit/src/castf/tests.rs
@@ -44,7 +44,7 @@ fn prepare_castf_rand_write_execute(
 
     tester.execute(
         chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::from_usize(CastfOpcode::CASTF as usize),
             [address_x, address_y, 0, as_x, as_y],
         ),

--- a/extensions/native/circuit/src/field_arithmetic/tests.rs
+++ b/extensions/native/circuit/src/field_arithmetic/tests.rs
@@ -85,7 +85,7 @@ fn new_field_arithmetic_air_test() {
         }
         tester.execute(
             &mut chip,
-            Instruction::from_usize(
+            &Instruction::from_usize(
                 VmOpcode::from_usize(opcode as usize),
                 [result_address, address1, address2, result_as, as1, as2],
             ),
@@ -135,7 +135,7 @@ fn new_field_arithmetic_air_zero_div_zero() {
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::from_usize(FieldArithmeticOpcode::DIV as usize),
             [5, 6, 7, 1, 1, 1],
         ),
@@ -179,7 +179,7 @@ fn new_field_arithmetic_air_test_panic() {
     // should panic
     tester.execute(
         &mut chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::from_usize(FieldArithmeticOpcode::DIV as usize),
             [0, 0, 0, 1, 1, 1],
         ),

--- a/extensions/native/circuit/src/field_extension/tests.rs
+++ b/extensions/native/circuit/src/field_extension/tests.rs
@@ -65,7 +65,7 @@ fn new_field_extension_air_test() {
 
         tester.execute(
             &mut chip,
-            Instruction::from_usize(
+            &Instruction::from_usize(
                 VmOpcode::from_usize(opcode as usize),
                 [result_address, address1, address2, as_d, as_e],
             ),

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -348,10 +348,10 @@ impl<F: PrimeField32> InstructionExecutor<F> for FriReducedOpeningChip<F> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>, ExecutionError> {
-        let Instruction {
+        let &Instruction {
             a: a_ptr_ptr,
             b: b_ptr_ptr,
             c: result_ptr,
@@ -401,7 +401,7 @@ impl<F: PrimeField32> InstructionExecutor<F> for FriReducedOpeningChip<F> {
         self.records.push(FriReducedOpeningRecord {
             pc: F::from_canonical_u32(from_state.pc),
             start_timestamp: F::from_canonical_u32(from_state.timestamp),
-            instruction,
+            instruction: instruction.clone(),
             alpha_read: alpha_read.0,
             length_read: length_read.0,
             a_ptr_read: a_ptr_read.0,

--- a/extensions/native/circuit/src/fri/tests.rs
+++ b/extensions/native/circuit/src/fri/tests.rs
@@ -111,7 +111,7 @@ fn fri_mat_opening_air_test() {
 
         tester.execute(
             &mut chip,
-            Instruction::from_usize(
+            &Instruction::from_usize(
                 VmOpcode::from_usize(FRI_REDUCED_OPENING as usize + offset),
                 [
                     a_pointer_pointer,

--- a/extensions/native/circuit/src/jal/tests.rs
+++ b/extensions/native/circuit/src/jal/tests.rs
@@ -37,7 +37,7 @@ fn set_and_execute(
 
     tester.execute_with_pc(
         chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::with_default_offset(JAL),
             [a, imm as usize, 0, d, 0, 0, 0],
         ),

--- a/extensions/native/circuit/src/loadstore/tests.rs
+++ b/extensions/native/circuit/src/loadstore/tests.rs
@@ -198,7 +198,7 @@ fn set_and_execute(
 
     tester.execute_with_pc(
         chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::with_default_offset(opcode),
             [data.a, data.b, data.c, data.d, data.e, data.f, data.g]
                 .map(|x| x.as_canonical_u32() as usize),

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -79,10 +79,10 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> InstructionExecutor<F>
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>, ExecutionError> {
-        let Instruction {
+        let &Instruction {
             opcode,
             a,
             b,

--- a/extensions/native/circuit/src/poseidon2/mod.rs
+++ b/extensions/native/circuit/src/poseidon2/mod.rs
@@ -73,7 +73,7 @@ impl<F: PrimeField32> InstructionExecutor<F> for NativePoseidon2Chip<F> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>, ExecutionError> {
         match self {

--- a/extensions/native/circuit/src/poseidon2/tests.rs
+++ b/extensions/native/circuit/src/poseidon2/tests.rs
@@ -101,7 +101,7 @@ fn tester_with_random_poseidon2_ops(
             }
         }
 
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
 
         match opcode {
             Poseidon2Opcode::COMP_POS2 => {

--- a/extensions/pairing/circuit/src/fp12_chip/mul.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/mul.rs
@@ -170,7 +170,7 @@ mod tests {
             512,
             chip.0.core.air.offset + Fp12Opcode::MUL as usize,
         );
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
         let tester = tester.build().load(chip).load(bitwise_chip).finalize();
         tester.simple_test().expect("Verification failed");
     }

--- a/extensions/pairing/circuit/src/fp12_chip/tests.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/tests.rs
@@ -90,7 +90,7 @@ fn test_fp12_fn<
         y_limbs,
         chip.core.air.offset + local_opcode_idx,
     );
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
 
     let run_tester = tester.build().load(chip).load(bitwise_chip).finalize();
     run_tester.simple_test().expect("Verification failed");

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/tests.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/tests.rs
@@ -130,7 +130,7 @@ fn test_mul_013_by_013() {
         chip.0.core.air.offset + PairingOpcode::MUL_013_BY_013 as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");
 }
@@ -220,7 +220,7 @@ fn test_mul_by_01234() {
         chip.0.core.air.offset + PairingOpcode::MUL_BY_01234 as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");
 }
@@ -289,7 +289,7 @@ fn test_evaluate_line() {
         chip.0.core.air.offset + PairingOpcode::EVALUATE_LINE as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");
 }

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/tests.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/tests.rs
@@ -125,7 +125,7 @@ fn test_mul_023_by_023() {
         chip.0.core.air.offset + PairingOpcode::MUL_023_BY_023 as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");
 }
@@ -217,7 +217,7 @@ fn test_mul_by_02345() {
         chip.0.core.air.offset + PairingOpcode::MUL_BY_02345 as usize,
     );
 
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");
 }

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
@@ -209,7 +209,7 @@ mod tests {
             chip.0.core.air.offset + PairingOpcode::MILLER_DOUBLE_AND_ADD_STEP as usize,
         );
 
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
         let tester = tester.build().load(chip).load(bitwise_chip).finalize();
         tester.simple_test().expect("Verification failed");
     }

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
@@ -181,7 +181,7 @@ mod tests {
             chip.0.core.air.offset + PairingOpcode::MILLER_DOUBLE_STEP as usize,
         );
 
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
         let tester = tester.build().load(chip).load(bitwise_chip).finalize();
         tester.simple_test().expect("Verification failed");
     }
@@ -250,7 +250,7 @@ mod tests {
             chip.0.core.air.offset + PairingOpcode::MILLER_DOUBLE_STEP as usize,
         );
 
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
         let tester = tester.build().load(chip).load(bitwise_chip).finalize();
         tester.simple_test().expect("Verification failed");
     }

--- a/extensions/rv32im/circuit/src/auipc/tests.rs
+++ b/extensions/rv32im/circuit/src/auipc/tests.rs
@@ -38,7 +38,7 @@ fn set_and_execute(
 
     tester.execute_with_pc(
         chip,
-        Instruction::from_usize(VmOpcode::with_default_offset(opcode), [a, 0, imm, 1, 0]),
+        &Instruction::from_usize(VmOpcode::with_default_offset(opcode), [a, 0, imm, 1, 0]),
         initial_pc.unwrap_or(rng.gen_range(0..(1 << PC_BITS))),
     );
     let initial_pc = tester.execution.last_from_pc().as_canonical_u32();

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -74,7 +74,7 @@ fn run_rv32_alu_rand_test(opcode: BaseAluOpcode, num_ops: usize) {
 
         let (instruction, rd) =
             rv32_rand_write_register_or_imm(&mut tester, b, c, c_imm, opcode as usize, &mut rng);
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
 
         let a = run_alu::<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>(opcode, &b, &c)
             .map(F::from_canonical_u32);
@@ -147,7 +147,7 @@ fn run_rv32_alu_negative_test(
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 1]),
+        &Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 1]),
     );
 
     let trace_width = chip.trace_width();

--- a/extensions/rv32im/circuit/src/branch_eq/tests.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/tests.rs
@@ -53,7 +53,7 @@ fn run_rv32_branch_eq_rand_execute<E: InstructionExecutor<F>>(
 
     tester.execute_with_pc(
         chip,
-        Instruction::from_isize(
+        &Instruction::from_isize(
             VmOpcode::from_usize(opcode as usize),
             rs1 as isize,
             rs2 as isize,
@@ -145,7 +145,7 @@ fn run_rv32_beq_negative_test(
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::from_usize(opcode as usize),
             [0, 0, imm as usize, 1, 1],
         ),

--- a/extensions/rv32im/circuit/src/branch_lt/tests.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/tests.rs
@@ -64,7 +64,7 @@ fn run_rv32_branch_lt_rand_execute<E: InstructionExecutor<F>>(
 
     tester.execute_with_pc(
         chip,
-        Instruction::from_isize(
+        &Instruction::from_isize(
             VmOpcode::from_usize(opcode as usize),
             rs1 as isize,
             rs2 as isize,
@@ -208,7 +208,7 @@ fn run_rv32_blt_negative_test(
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::from_usize(opcode as usize),
             [0, 0, imm as usize, 1, 1],
         ),

--- a/extensions/rv32im/circuit/src/divrem/tests.rs
+++ b/extensions/rv32im/circuit/src/divrem/tests.rs
@@ -78,7 +78,7 @@ fn run_rv32_divrem_rand_write_execute<E: InstructionExecutor<F>>(
         run_divrem::<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>(is_signed, &b, &c);
     tester.execute(
         chip,
-        Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [rd, rs1, rs2, 1, 0]),
+        &Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [rd, rs1, rs2, 1, 0]),
     );
 
     assert_eq!(
@@ -263,11 +263,11 @@ fn run_rv32_divrem_negative_test(
     };
     tester.execute(
         &mut chip,
-        Instruction::from_usize(VmOpcode::from_usize(div_opcode as usize), [0, 0, 0, 1, 1]),
+        &Instruction::from_usize(VmOpcode::from_usize(div_opcode as usize), [0, 0, 0, 1, 1]),
     );
     tester.execute(
         &mut chip,
-        Instruction::from_usize(VmOpcode::from_usize(rem_opcode as usize), [0, 0, 0, 1, 1]),
+        &Instruction::from_usize(VmOpcode::from_usize(rem_opcode as usize), [0, 0, 0, 1, 1]),
     );
 
     let (q, r, b_sign, c_sign, q_sign, case) =

--- a/extensions/rv32im/circuit/src/hintstore/tests.rs
+++ b/extensions/rv32im/circuit/src/hintstore/tests.rs
@@ -83,7 +83,7 @@ fn set_and_execute(
 
     tester.execute(
         chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::with_default_offset(opcode),
             [0, b, imm as usize, 1, 2],
         ),

--- a/extensions/rv32im/circuit/src/jal_lui/tests.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/tests.rs
@@ -49,7 +49,7 @@ fn set_and_execute(
 
     tester.execute_with_pc(
         chip,
-        Instruction::large_from_isize(
+        &Instruction::large_from_isize(
             VmOpcode::with_default_offset(opcode),
             a as isize,
             0,

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -57,7 +57,7 @@ fn set_and_execute(
 
     tester.execute_with_pc(
         chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::with_default_offset(opcode),
             [a, b, imm as usize, 1, 0, (a != 0) as usize, 0],
         ),

--- a/extensions/rv32im/circuit/src/less_than/tests.rs
+++ b/extensions/rv32im/circuit/src/less_than/tests.rs
@@ -74,7 +74,7 @@ fn run_rv32_lt_rand_test(opcode: LessThanOpcode, num_ops: usize) {
 
         let (instruction, rd) =
             rv32_rand_write_register_or_imm(&mut tester, b, c, c_imm, opcode as usize, &mut rng);
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
 
         let (cmp, _, _, _) =
             run_less_than::<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>(opcode, &b, &c);
@@ -87,12 +87,12 @@ fn run_rv32_lt_rand_test(opcode: LessThanOpcode, num_ops: usize) {
     let b = [101, 128, 202, 255];
     let (instruction, _) =
         rv32_rand_write_register_or_imm(&mut tester, b, b, None, opcode as usize, &mut rng);
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
 
     let b = [36, 0, 0, 0];
     let (instruction, _) =
         rv32_rand_write_register_or_imm(&mut tester, b, b, Some(36), opcode as usize, &mut rng);
-    tester.execute(&mut chip, instruction);
+    tester.execute(&mut chip, &instruction);
 
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");
@@ -154,7 +154,7 @@ fn run_rv32_lt_negative_test(
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 1]),
+        &Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 1]),
     );
 
     let trace_width = chip.trace_width();

--- a/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
@@ -91,7 +91,7 @@ fn set_and_execute(
 
     tester.execute(
         chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::with_default_offset(opcode),
             [a, b, imm as usize, 1, 2],
         ),

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -89,7 +89,7 @@ fn set_and_execute(
 
     tester.execute(
         chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::with_default_offset(opcode),
             [a, b, imm as usize, 1, mem_as],
         ),

--- a/extensions/rv32im/circuit/src/mul/tests.rs
+++ b/extensions/rv32im/circuit/src/mul/tests.rs
@@ -74,7 +74,7 @@ fn run_rv32_mul_rand_test(num_ops: usize) {
             &mut rng,
         );
         instruction.e = F::ZERO;
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
 
         let (a, _) = run_mul::<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>(&b, &c);
         assert_eq!(
@@ -138,7 +138,7 @@ fn run_rv32_mul_negative_test(
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(
+        &Instruction::from_usize(
             VmOpcode::from_usize(MulOpcode::MUL as usize),
             [0, 0, 0, 1, 0],
         ),

--- a/extensions/rv32im/circuit/src/mulh/tests.rs
+++ b/extensions/rv32im/circuit/src/mulh/tests.rs
@@ -62,7 +62,7 @@ fn run_rv32_mulh_rand_write_execute<E: InstructionExecutor<F>>(
     let (a, _, _, _, _) = run_mulh::<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>(opcode, &b, &c);
     tester.execute(
         chip,
-        Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [rd, rs1, rs2, 1, 0]),
+        &Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [rd, rs1, rs2, 1, 0]),
     );
 
     assert_eq!(
@@ -175,7 +175,7 @@ fn run_rv32_mulh_negative_test(
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 0]),
+        &Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 0]),
     );
 
     let trace_width = chip.trace_width();

--- a/extensions/rv32im/circuit/src/shift/tests.rs
+++ b/extensions/rv32im/circuit/src/shift/tests.rs
@@ -78,7 +78,7 @@ fn run_rv32_shift_rand_test(opcode: ShiftOpcode, num_ops: usize) {
 
         let (instruction, rd) =
             rv32_rand_write_register_or_imm(&mut tester, b, c, c_imm, opcode as usize, &mut rng);
-        tester.execute(&mut chip, instruction);
+        tester.execute(&mut chip, &instruction);
 
         let (a, _, _) = run_shift::<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>(opcode, &b, &c);
         assert_eq!(
@@ -155,7 +155,7 @@ fn run_rv32_shift_negative_test(
 
     tester.execute(
         &mut chip,
-        Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 1]),
+        &Instruction::from_usize(VmOpcode::from_usize(opcode as usize), [0, 0, 0, 1, 1]),
     );
 
     let bit_shift = prank_vals

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -101,10 +101,10 @@ impl<F: PrimeField32> InstructionExecutor<F> for Sha256VmChip<F> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
-        instruction: Instruction<F>,
+        instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>, ExecutionError> {
-        let Instruction {
+        let &Instruction {
             opcode,
             a,
             b,

--- a/extensions/sha256/circuit/src/sha256_chip/tests.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/tests.rs
@@ -56,7 +56,7 @@ fn set_and_execute(
 
     tester.execute(
         chip,
-        Instruction::from_usize(VmOpcode::with_default_offset(opcode), [rd, rs1, rs2, 1, 2]),
+        &Instruction::from_usize(VmOpcode::with_default_offset(opcode), [rd, rs1, rs2, 1, 2]),
     );
 
     let output = sha256_solve(message);


### PR DESCRIPTION
It seems wrong to take `Instruction`, since `InstructionExecutor` doesn't take ownership of the instruction; it just borrows it to execute.

Should also reduce the amount of data cloned (some copying still takes place because of record creation).