### PR TITLE
chore: Remove Debug derive from chips

### DIFF
--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -103,7 +103,6 @@ impl<AB: InteractionBuilder + PairBuilder, const NUM_BITS: usize> Air<AB>
 // for x ^ y and range check. Interactions are of form [x, y, z] where z is either x ^ y for
 // XOR or 0 for range check.
 
-#[derive(Debug)]
 pub struct BitwiseOperationLookupChip<const NUM_BITS: usize> {
     pub air: BitwiseOperationLookupAir<NUM_BITS>,
     count_range: Vec<AtomicU32>,

--- a/crates/circuits/primitives/src/range/mod.rs
+++ b/crates/circuits/primitives/src/range/mod.rs
@@ -79,7 +79,6 @@ impl<AB: InteractionBuilder + PairBuilder> Air<AB> for RangeCheckerAir {
     }
 }
 
-#[derive(Debug)]
 pub struct RangeCheckerChip {
     pub air: RangeCheckerAir,
     count: Vec<AtomicU32>,

--- a/crates/circuits/primitives/src/range/tests/list/mod.rs
+++ b/crates/circuits/primitives/src/range/tests/list/mod.rs
@@ -8,7 +8,6 @@ pub mod air;
 pub mod columns;
 pub mod trace;
 
-#[derive(Debug)]
 pub struct ListChip {
     pub air: ListAir,
     pub vals: Vec<u32>,

--- a/crates/circuits/primitives/src/range_gate/mod.rs
+++ b/crates/circuits/primitives/src/range_gate/mod.rs
@@ -82,7 +82,6 @@ impl<AB: InteractionBuilder> Air<AB> for RangeCheckerGateAir {
 /// [0, MAX). In the trace, there is a counter column and a multiplicity
 /// column. The counter column is generated using a gate, as opposed to
 /// the other RangeCheckerChip.
-#[derive(Debug)]
 pub struct RangeCheckerGateChip {
     pub air: RangeCheckerGateAir,
     pub count: Vec<AtomicU32>,

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -94,7 +94,6 @@ impl<AB: InteractionBuilder + PairBuilder> Air<AB> for VariableRangeCheckerAir {
     }
 }
 
-#[derive(Debug)]
 pub struct VariableRangeCheckerChip {
     pub air: VariableRangeCheckerAir,
     count: Vec<AtomicU32>,

--- a/crates/circuits/sha256-air/src/tests.rs
+++ b/crates/circuits/sha256-air/src/tests.rs
@@ -44,7 +44,6 @@ impl<AB: InteractionBuilder> Air<AB> for Sha256TestAir {
 }
 
 // A wrapper Chip purely for testing purposes
-#[derive(Debug)]
 pub struct Sha256TestChip {
     pub air: Sha256TestAir,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<8>>,

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -22,7 +22,6 @@ const WORD_SIZE: usize = 1;
 /// Stores a log of raw messages to send/receive to the [MemoryBus].
 ///
 /// It will create a [air::MemoryDummyAir] to add messages to MemoryBus.
-#[derive(Debug)]
 pub struct MemoryTester<F> {
     pub bus: MemoryBus,
     pub controller: Rc<RefCell<MemoryController<F>>>,

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -61,7 +61,6 @@ pub const MEMORY_MERKLE_BUS: usize = 12;
 
 const RANGE_CHECKER_BUS: usize = 4;
 
-#[derive(Debug)]
 pub struct VmChipTestBuilder<F: PrimeField32> {
     pub memory: MemoryTester<F>,
     pub execution: ExecutionTester<F>,
@@ -300,7 +299,7 @@ where
             self = self.load(memory_tester); // dummy memory interactions
             {
                 let air_proof_inputs = Rc::try_unwrap(memory_controller)
-                    .unwrap()
+                    .unwrap_or_else(|_| panic!("Memory controller was not dropped"))
                     .into_inner()
                     .generate_air_proof_inputs();
                 self.air_proof_inputs.extend(

--- a/crates/vm/src/arch/testing/test_adapter.rs
+++ b/crates/vm/src/arch/testing/test_adapter.rs
@@ -22,7 +22,6 @@ use crate::{
 
 // Replaces A: VmAdapterChip while testing VmCoreChip functionality, as it has no
 // constraints and thus cannot cause a failure.
-#[derive(Debug)]
 pub struct TestAdapterChip<F> {
     /// List of the return values of `preprocess` this chip should provide on each sequential call.
     pub prank_reads: VecDeque<Vec<F>>,

--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -28,7 +28,6 @@ mod columns;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, Clone)]
 pub struct AccessAdapterInventory<F> {
     chips: Vec<GenericAccessAdapterChip<F>>,
     air_names: Vec<String>,
@@ -165,7 +164,7 @@ pub trait GenericAccessAdapterChipTrait<F> {
         F: PrimeField32;
 }
 
-#[derive(Debug, Clone, Chip, ChipUsageGetter)]
+#[derive(Chip, ChipUsageGetter)]
 #[enum_dispatch(GenericAccessAdapterChipTrait<F>)]
 #[chip(where = "F: PrimeField32")]
 enum GenericAccessAdapterChip<F> {
@@ -197,7 +196,6 @@ impl<F> GenericAccessAdapterChip<F> {
         }
     }
 }
-#[derive(Debug, Clone)]
 pub struct AccessAdapterChip<F, const N: usize> {
     air: AccessAdapterAir<N>,
     range_checker: Arc<VariableRangeCheckerChip>,

--- a/crates/vm/src/system/memory/controller/interface.rs
+++ b/crates/vm/src/system/memory/controller/interface.rs
@@ -8,7 +8,6 @@ use crate::system::memory::{
 };
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
 pub enum MemoryInterface<F> {
     Volatile {
         boundary_chip: VolatileBoundaryChip<F>,

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -84,7 +84,7 @@ pub type TimestampedEquipartition<F, const N: usize> =
 /// If a key is not present in the map, then the block is uninitialized (and therefore zero).
 pub type Equipartition<F, const N: usize> = BTreeMap<(u32, u32), [F; N]>;
 
-#[derive(Debug, Getters)]
+#[derive(Getters)]
 pub struct MemoryController<F> {
     pub memory_bus: MemoryBus,
     pub interface_chip: MemoryInterface<F>,
@@ -691,7 +691,6 @@ impl<F: PrimeField32> MemoryController<F> {
     }
 }
 
-#[derive(Clone, Debug)]
 pub struct MemoryAuxColsFactory<T> {
     pub(crate) range_checker: Arc<VariableRangeCheckerChip>,
     pub(crate) timestamp_lt_air: AssertLtSubAir,

--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -14,7 +14,6 @@ pub use columns::*;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug)]
 pub struct MemoryMerkleChip<const CHUNK: usize, F> {
     pub air: MemoryMerkleAir<CHUNK>,
     touched_nodes: FxHashSet<(usize, u32, u32)>,

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -33,7 +33,6 @@ pub struct MemoryRecord<T> {
     pub prev_data: Option<Vec<T>>,
 }
 
-#[derive(Debug)]
 pub struct OfflineMemory<F> {
     block_data: FxHashMap<Address, BlockData>,
     data: FxHashMap<Address, F>,

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -120,7 +120,6 @@ impl<const CHUNK: usize, AB: InteractionBuilder> Air<AB> for PersistentBoundaryA
     }
 }
 
-#[derive(Debug)]
 pub struct PersistentBoundaryChip<F, const CHUNK: usize> {
     pub air: PersistentBoundaryAir<CHUNK>,
     touched_labels: TouchedLabels<F, CHUNK>,

--- a/crates/vm/src/system/memory/volatile/mod.rs
+++ b/crates/vm/src/system/memory/volatile/mod.rs
@@ -130,7 +130,6 @@ impl<AB: InteractionBuilder> Air<AB> for VolatileBoundaryAir {
     }
 }
 
-#[derive(Debug)]
 pub struct VolatileBoundaryChip<F> {
     pub air: VolatileBoundaryAir,
     touched_addresses: FxHashSet<(u32, u32)>,

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -245,7 +245,6 @@ pub struct ModularIsEqualCoreRecord<T, const READ_LIMBS: usize> {
     pub c_diff_idx: usize,
 }
 
-#[derive(Debug)]
 pub struct ModularIsEqualCoreChip<
     const READ_LIMBS: usize,
     const WRITE_LIMBS: usize,

--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -67,7 +67,6 @@ pub const KECCAK_DIGEST_BYTES: usize = 32;
 /// Number of 64-bit digest limbs.
 pub const KECCAK_DIGEST_U64S: usize = KECCAK_DIGEST_BYTES / 8;
 
-#[derive(Debug)]
 pub struct KeccakVmChip<F: PrimeField32> {
     pub air: KeccakVmAir,
     /// IO and memory data necessary for each opcode call

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -101,7 +101,6 @@ pub struct CastFRecord<F> {
     pub out_val: [F; RV32_REGISTER_NUM_LIMBS],
 }
 
-#[derive(Debug)]
 pub struct CastFCoreChip {
     pub air: CastFCoreAir,
     pub range_checker_chip: Arc<VariableRangeCheckerChip>,

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -109,7 +109,6 @@ pub struct FieldArithmeticRecord<F> {
     pub c: F,
 }
 
-#[derive(Debug)]
 pub struct FieldArithmeticCoreChip {
     pub air: FieldArithmeticCoreAir,
 }

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -137,7 +137,6 @@ pub struct FieldExtensionRecord<F> {
     pub z: [F; EXT_DEG],
 }
 
-#[derive(Debug)]
 pub struct FieldExtensionCoreChip {
     pub air: FieldExtensionCoreAir,
 }

--- a/extensions/native/circuit/src/jal/core.rs
+++ b/extensions/native/circuit/src/jal/core.rs
@@ -69,7 +69,6 @@ pub struct JalRecord<F> {
     pub imm: F,
 }
 
-#[derive(Debug)]
 pub struct JalCoreChip {
     pub air: JalCoreAir,
 }

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -24,7 +24,6 @@ use super::{
     NATIVE_POSEIDON2_WIDTH,
 };
 
-#[derive(Debug)]
 pub struct NativePoseidon2BaseChip<F: Field, const SBOX_REGISTERS: usize> {
     pub air: Arc<NativePoseidon2Air<F, SBOX_REGISTERS>>,
     pub subchip: Poseidon2SubChip<F, SBOX_REGISTERS>,

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -226,7 +226,6 @@ impl<
     }
 }
 
-#[derive(Debug)]
 pub struct Rv32IsEqualModAdapterChip<
     F: Field,
     const NUM_READS: usize,

--- a/extensions/rv32-adapters/src/heap.rs
+++ b/extensions/rv32-adapters/src/heap.rs
@@ -102,7 +102,6 @@ impl<
     }
 }
 
-#[derive(Debug)]
 pub struct Rv32HeapAdapterChip<
     F: Field,
     const NUM_READS: usize,

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -166,7 +166,6 @@ impl<AB: InteractionBuilder, const NUM_READS: usize, const READ_SIZE: usize> VmA
     }
 }
 
-#[derive(Debug)]
 pub struct Rv32HeapBranchAdapterChip<F: Field, const NUM_READS: usize, const READ_SIZE: usize> {
     pub air: Rv32HeapBranchAdapterAir<NUM_READS, READ_SIZE>,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<RV32_CELL_BITS>>,

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -46,7 +46,7 @@ use openvm_stark_backend::{
 ///   (and `rs[1]` if `R = 2`).
 /// * Writes take the form of `BLOCKS_PER_WRITE` consecutive writes of
 ///   size `WRITE_SIZE` to the heap, starting from the address in `rd`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Rv32VecHeapAdapterChip<
     F: Field,
     const NUM_READS: usize,

--- a/extensions/rv32-adapters/src/vec_heap_two_reads.rs
+++ b/extensions/rv32-adapters/src/vec_heap_two_reads.rs
@@ -46,7 +46,6 @@ use openvm_stark_backend::{
 /// * NOTE that the two reads can read different numbers of blocks.
 /// * Writes take the form of `BLOCKS_PER_WRITE` consecutive writes of
 ///   size `WRITE_SIZE` to the heap, starting from the address in `rd`.
-#[derive(Debug)]
 pub struct Rv32VecHeapTwoReadsAdapterChip<
     F: Field,
     const BLOCKS_PER_READ1: usize,

--- a/extensions/rv32im/circuit/src/adapters/hintstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/hintstore.rs
@@ -37,7 +37,6 @@ use crate::adapters::RV32_CELL_BITS;
 
 /// This chip reads rs1 and gets a intermediate memory pointer address with rs1 + imm.
 /// It writes to the memory at the intermediate pointer.
-#[derive(Debug)]
 pub struct Rv32HintStoreAdapterChip<F: Field> {
     pub air: Rv32HintStoreAdapterAir,
     pub range_checker_chip: Arc<VariableRangeCheckerChip>,

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -91,7 +91,6 @@ impl<AB: InteractionBuilder> VmAdapterInterface<AB::Expr> for Rv32LoadStoreAdapt
 /// This chip reads rs1 and gets a intermediate memory pointer address with rs1 + imm.
 /// In case of Loads, reads from the shifted intermediate pointer and writes to rd.
 /// In case of Stores, reads from rs2 and writes to the shifted intermediate pointer.
-#[derive(Debug)]
 pub struct Rv32LoadStoreAdapterChip<F: Field> {
     pub air: Rv32LoadStoreAdapterAir,
     pub range_checker_chip: Arc<VariableRangeCheckerChip>,

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -132,7 +132,6 @@ pub struct Rv32AuipcCoreRecord<F> {
     pub rd_data: [F; RV32_REGISTER_NUM_LIMBS],
 }
 
-#[derive(Debug)]
 pub struct Rv32AuipcCoreChip {
     pub air: Rv32AuipcCoreAir,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<RV32_CELL_BITS>>,

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -165,7 +165,6 @@ pub struct BaseAluCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> 
     pub c: [T; NUM_LIMBS],
 }
 
-#[derive(Debug)]
 pub struct BaseAluCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub air: BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<LIMB_BITS>>,

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -187,7 +187,6 @@ pub struct BranchLessThanCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: 
     pub diff_idx: usize,
 }
 
-#[derive(Debug)]
 pub struct BranchLessThanCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub air: BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<LIMB_BITS>>,

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -304,7 +304,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub struct DivRemCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub air: DivRemCoreAir<NUM_LIMBS, LIMB_BITS>,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<LIMB_BITS>>,

--- a/extensions/rv32im/circuit/src/hintstore/core.rs
+++ b/extensions/rv32im/circuit/src/hintstore/core.rs
@@ -91,7 +91,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub struct Rv32HintStoreCoreChip<F: Field> {
     pub air: Rv32HintStoreCoreAir,
     pub streams: OnceLock<Arc<Mutex<Streams<F>>>>,

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -140,7 +140,6 @@ pub struct Rv32JalLuiCoreRecord<F: Field> {
     pub is_lui: bool,
 }
 
-#[derive(Debug)]
 pub struct Rv32JalLuiCoreChip {
     pub air: Rv32JalLuiCoreAir,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<RV32_CELL_BITS>>,

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -170,7 +170,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub struct Rv32JalrCoreChip {
     pub air: Rv32JalrCoreAir,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<RV32_CELL_BITS>>,

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -163,7 +163,6 @@ pub struct LessThanCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize>
     pub diff_idx: usize,
 }
 
-#[derive(Debug)]
 pub struct LessThanCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub air: LessThanCoreAir<NUM_LIMBS, LIMB_BITS>,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<LIMB_BITS>>,

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -169,7 +169,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub struct LoadSignExtendCoreChip<const NUM_CELLS: usize, const LIMB_BITS: usize> {
     pub air: LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>,
     pub range_checker_chip: Arc<VariableRangeCheckerChip>,

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -176,7 +176,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub struct MulHCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub air: MulHCoreAir<NUM_LIMBS, LIMB_BITS>,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<LIMB_BITS>>,

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -242,7 +242,6 @@ pub struct ShiftCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub b_sign: T,
 }
 
-#[derive(Debug)]
 pub struct ShiftCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub air: ShiftCoreAir<NUM_LIMBS, LIMB_BITS>,
     pub bitwise_lookup_chip: Arc<BitwiseOperationLookupChip<LIMB_BITS>>,

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -44,7 +44,6 @@ const SHA256_WRITE_SIZE: usize = 32;
 pub const SHA256_BLOCK_CELLS: usize = SHA256_BLOCK_BITS / RV32_CELL_BITS;
 /// Number of rows we will do a read on for each SHA256 block
 pub const SHA256_NUM_READ_ROWS: usize = SHA256_BLOCK_CELLS / SHA256_READ_SIZE;
-#[derive(Debug)]
 pub struct Sha256VmChip<F: PrimeField32> {
     pub air: Sha256VmAir,
     /// IO and memory data necessary for each opcode call


### PR DESCRIPTION
Derived implementation will recursively print everything, which is not useful. Also causes derive(Debug) to spread to lots of other types that contain the chips.