### PR TITLE
fix(test): add setup instruction to fp2 tests

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: ["**"]
     paths:
-      - "crates/circuits/primitives/**"
+      - "crates/circuits/**"
       - "crates/vm/**"
       - "extensions/**"
       - ".github/workflows/extension-tests.yml"
@@ -48,7 +48,7 @@ jobs:
         id: filter
         with:
           filters: |
-            - "crates/circuits/primitives/**"
+            - "crates/circuits/**"
             - "crates/vm/**"
             - "extensions/${{ matrix.extensions.path }}/**"
             - ".github/workflows/extension-tests.yml"

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -114,8 +114,9 @@ mod tests {
     #[test]
     fn test_fp2_addsub() {
         let mut tester: VmChipTestBuilder<F> = VmChipTestBuilder::default();
+        let modulus = BN254_MODULUS.clone();
         let config = ExprBuilderConfig {
-            modulus: BN254_MODULUS.clone(),
+            modulus: modulus.clone(),
             num_limbs: NUM_LIMBS,
             limb_bits: LIMB_BITS,
         };
@@ -177,6 +178,15 @@ mod tests {
                     .map(BabyBear::from_canonical_u32)
             })
             .collect_vec();
+        let modulus =
+            biguint_to_limbs::<NUM_LIMBS>(modulus, LIMB_BITS).map(BabyBear::from_canonical_u32);
+        let zero = [BabyBear::ZERO; NUM_LIMBS];
+        let setup_instruction = rv32_write_heap_default(
+            &mut tester,
+            vec![modulus, zero],
+            vec![zero; 2],
+            chip.0.core.air.offset + Fp2Opcode::SETUP_ADDSUB as usize,
+        );
         let instruction1 = rv32_write_heap_default(
             &mut tester,
             x_limbs.clone(),
@@ -189,6 +199,7 @@ mod tests {
             y_limbs,
             chip.0.core.air.offset + Fp2Opcode::SUB as usize,
         );
+        tester.execute(&mut chip, &setup_instruction);
         tester.execute(&mut chip, &instruction1);
         tester.execute(&mut chip, &instruction2);
         let tester = tester.build().load(chip).load(bitwise_chip).finalize();

--- a/extensions/algebra/moduli-setup/src/lib.rs
+++ b/extensions/algebra/moduli-setup/src/lib.rs
@@ -877,7 +877,7 @@ pub fn moduli_init(input: TokenStream) -> TokenStream {
         mod openvm_intrinsics_ffi {
             #(#externs)*
         }
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, non_upper_case_globals)]
         pub mod openvm_intrinsics_meta_do_not_type_this_by_yourself {
             pub const two_modular_limbs_list: [u8; #total_limbs_cnt] = [#(#two_modular_limbs_flattened_list),*];
             pub const limb_list_borders: [usize; #cnt_limbs_list_len] = [#(#limb_list_borders),*];

--- a/extensions/algebra/tests/programs/examples/complex-secp256k1.rs
+++ b/extensions/algebra/tests/programs/examples/complex-secp256k1.rs
@@ -21,6 +21,7 @@ openvm_algebra_complex_macros::complex_init! {
 }
 
 pub fn main() {
+    setup_all_moduli();
     setup_all_complex_extensions();
     let mut a = Complex::new(
         Secp256k1Coord::from_repr(core::array::from_fn(|_| 10)),

--- a/extensions/algebra/tests/programs/examples/complex-two-modulos.rs
+++ b/extensions/algebra/tests/programs/examples/complex-two-modulos.rs
@@ -23,6 +23,7 @@ openvm_algebra_complex_macros::complex_init! {
 }
 
 pub fn main() {
+    setup_all_moduli();
     setup_all_complex_extensions();
     let a = Complex1::new(Mod1::ZERO, Mod1::from_u32(998244352));
     let b = Complex2::new(Mod2::ZERO, Mod2::from_u32(1000000006));


### PR DESCRIPTION
@luffykai the modular (fp not fp2) tests weren't failing because they don't seem to use exprbuilder in the same way. Can you fix it?