### PR TITLE
fix(castf): handle range check correctly for padding rows

### DIFF
--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -81,7 +81,7 @@ where
                         _ => unreachable!(),
                     },
                 )
-                .eval(builder, AB::Expr::ONE);
+                .eval(builder, cols.is_valid);
         }
 
         AdapterAirContext {

--- a/extensions/native/circuit/src/castf/tests.rs
+++ b/extensions/native/circuit/src/castf/tests.rs
@@ -68,7 +68,7 @@ fn castf_rand_test() {
         CastFCoreChip::new(tester.range_checker(), 0),
         tester.offline_memory_mutex_arc(),
     );
-    let num_tests: usize = 1;
+    let num_tests: usize = 3;
 
     for _ in 0..num_tests {
         let y = generate_uint_number(&mut rng);


### PR DESCRIPTION
Fixes the bug below.  The root cause was that the range check interaction in CASTF did not condition the send on row validity.

```
 $ cargo test --package openvm-native-circuit --lib -- castf::tests::castf_rand_test --exact --show-output

running 1 test
test castf::tests::castf_rand_test ... FAILED

successes:

successes:

failures:

---- castf::tests::castf_rand_test stdout ----
Bus 4 failed to balance the multiplicities for fields=[0, 8]. The bus connections for this were:
   Air idx: 2, Air name: VmAirWrapper<ConvertAdapterAir<1, 4>, CastFCoreAir>, interaction type: Send, count: 1
   Air idx: 2, Air name: VmAirWrapper<ConvertAdapterAir<1, 4>, CastFCoreAir>, interaction type: Send, count: 1
   Air idx: 2, Air name: VmAirWrapper<ConvertAdapterAir<1, 4>, CastFCoreAir>, interaction type: Send, count: 1
Bus 4 failed to balance the multiplicities for fields=[0, 6]. The bus connections for this were:
   Air idx: 2, Air name: VmAirWrapper<ConvertAdapterAir<1, 4>, CastFCoreAir>, interaction type: Send, count: 1
thread 'castf::tests::castf_rand_test' panicked at /Users/zhangzhuo/.cargo/git/checkouts/stark-backend-bcfa8b09bc28ca79/8c9f94b/crates/stark-backend/src/air_builders/debug/check_constraints.rs:164:9:
LogUp multiset equality check failed.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    castf::tests::castf_rand_test

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 15 filtered out; finished in 0.13s

error: test failed, to rerun pass `-p openvm-native-circuit --lib`
```

I  found this bug during debuging kernel codes, some simple codes like
```
VmOpcode(293) 44 16775749 0 1 5 0 0 // castf native_as[16775749] to x11 register
VmOpcode(293) 44 16775748 0 1 5 0 0 // repeat 
VmOpcode(293) 44 16775741 0 1 5 0 0 // repeat 
```
will fail.   So i managed to reproduce it using provided unittest.

(repeating castf twice will be ok, 3 times will trigger logup err)