### PR TITLE
chore: Remove old FIXME

### DIFF
--- a/extensions/native/recursion/src/stark/mod.rs
+++ b/extensions/native/recursion/src/stark/mod.rs
@@ -877,7 +877,7 @@ where
             alpha,
             accumulator: SymbolicExt::ZERO,
             public_values,
-            exposed_values_after_challenge, // FIXME
+            exposed_values_after_challenge,
             _marker: PhantomData,
         };
         folder.eval_constraints(constraints);


### PR DESCRIPTION
From ininitial implementation of verifier that did not handle RAP phases