### PR TITLE
chore: make CASTF unit test match

### DIFF
--- a/extensions/native/circuit/src/castf/tests.rs
+++ b/extensions/native/circuit/src/castf/tests.rs
@@ -45,7 +45,7 @@ fn prepare_castf_rand_write_execute(
     tester.execute(
         chip,
         &Instruction::from_usize(
-            VmOpcode::from_usize(CastfOpcode::CASTF as usize),
+            VmOpcode::with_default_offset(CastfOpcode::CASTF),
             [address_x, address_y, 0, as_x, as_y],
         ),
     );

--- a/extensions/native/circuit/src/castf/tests.rs
+++ b/extensions/native/circuit/src/castf/tests.rs
@@ -65,7 +65,7 @@ fn castf_rand_test() {
             tester.program_bus(),
             tester.memory_bridge(),
         ),
-        CastFCoreChip::new(tester.range_checker(), 0),
+        CastFCoreChip::new(tester.range_checker(), CastfOpcode::default_offset()),
         tester.offline_memory_mutex_arc(),
     );
     let num_tests: usize = 1;

--- a/extensions/native/circuit/src/castf/tests.rs
+++ b/extensions/native/circuit/src/castf/tests.rs
@@ -1,7 +1,7 @@
 use std::borrow::BorrowMut;
 
 use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder};
-use openvm_instructions::{instruction::Instruction, VmOpcode};
+use openvm_instructions::{instruction::Instruction, UsizeOpcode, VmOpcode};
 use openvm_native_compiler::CastfOpcode;
 use openvm_stark_backend::{
     p3_field::FieldAlgebra, utils::disable_debug_builder, verifier::VerificationError, Chip,
@@ -89,7 +89,7 @@ fn negative_castf_overflow_test() {
             tester.program_bus(),
             tester.memory_bridge(),
         ),
-        CastFCoreChip::new(range_checker_chip.clone(), 0),
+        CastFCoreChip::new(range_checker_chip.clone(), CastfOpcode::default_offset()),
         tester.offline_memory_mutex_arc(),
     );
 
@@ -127,7 +127,7 @@ fn negative_castf_memread_test() {
             tester.program_bus(),
             tester.memory_bridge(),
         ),
-        CastFCoreChip::new(range_checker_chip.clone(), 0),
+        CastFCoreChip::new(range_checker_chip.clone(), CastfOpcode::default_offset()),
         tester.offline_memory_mutex_arc(),
     );
 
@@ -165,7 +165,7 @@ fn negative_castf_memwrite_test() {
             tester.program_bus(),
             tester.memory_bridge(),
         ),
-        CastFCoreChip::new(range_checker_chip.clone(), 0),
+        CastFCoreChip::new(range_checker_chip.clone(), CastfOpcode::default_offset()),
         tester.offline_memory_mutex_arc(),
     );
 
@@ -203,7 +203,7 @@ fn negative_castf_as_test() {
             tester.program_bus(),
             tester.memory_bridge(),
         ),
-        CastFCoreChip::new(range_checker_chip.clone(), 0),
+        CastFCoreChip::new(range_checker_chip.clone(), CastfOpcode::default_offset()),
         tester.offline_memory_mutex_arc(),
     );
 


### PR DESCRIPTION
https://github.com/openvm-org/openvm/pull/1206#issuecomment-2585623395

It doesn't matter for unit test because unit tester doesn't check against program code, but fixing the unit test so the usage matches how it should be used in practice.

We will more thoroughly address a better handling of offsets soon.