### PR TITLE
[feat] Implement Stateful for VmChipComplex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3499,7 +3499,7 @@ dependencies = [
  "openvm-algebra-transpiler",
  "openvm-build",
  "openvm-circuit",
- "openvm-circuit-derive",
+ "openvm-circuit-primitives-derive",
  "openvm-ecc-circuit",
  "openvm-ecc-transpiler",
  "openvm-keccak256-circuit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3499,6 +3499,7 @@ dependencies = [
  "openvm-algebra-transpiler",
  "openvm-build",
  "openvm-circuit",
+ "openvm-circuit-derive",
  "openvm-ecc-circuit",
  "openvm-ecc-transpiler",
  "openvm-keccak256-circuit",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 openvm-build.workspace = true
 openvm-circuit.workspace = true
-openvm-circuit-derive.workspace = true
+openvm-circuit-primitives-derive.workspace = true
 openvm-sdk.workspace = true
 openvm-stark-backend.workspace = true
 openvm-stark-sdk.workspace = true

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [dependencies]
 openvm-build.workspace = true
 openvm-circuit.workspace = true
+openvm-circuit-derive.workspace = true
 openvm-sdk.workspace = true
 openvm-stark-backend.workspace = true
 openvm-stark-sdk.workspace = true

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use itertools::Itertools;
 use num_bigint_dig::BigUint;
 use openvm_circuit::arch::{
@@ -7,7 +5,7 @@ use openvm_circuit::arch::{
     Result, VmAdapterInterface, VmCoreAir, VmCoreChip,
 };
 use openvm_circuit_primitives::{
-    var_range::VariableRangeCheckerChip, SubAir, TraceSubRowGenerator,
+    var_range::SharedVariableRangeCheckerChip, SubAir, TraceSubRowGenerator,
 };
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
@@ -170,7 +168,7 @@ pub struct FieldExpressionRecord {
 
 pub struct FieldExpressionCoreChip {
     pub air: FieldExpressionCoreAir,
-    pub range_checker: Arc<VariableRangeCheckerChip>,
+    pub range_checker: SharedVariableRangeCheckerChip,
 
     pub name: String,
 
@@ -184,7 +182,7 @@ impl FieldExpressionCoreChip {
         offset: usize,
         local_opcode_idx: Vec<usize>,
         opcode_flag_idx: Vec<usize>,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         name: &str,
         should_finalize: bool,
     ) -> Self {
@@ -277,7 +275,7 @@ where
 
     fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
         self.air.expr.generate_subrow(
-            (&self.range_checker, record.inputs, record.flags),
+            (self.range_checker.as_ref(), record.inputs, record.flags),
             row_slice,
         );
     }

--- a/crates/circuits/primitives/derive/src/lib.rs
+++ b/crates/circuits/primitives/derive/src/lib.rs
@@ -310,3 +310,91 @@ pub fn chip_usage_getter_derive(input: TokenStream) -> TokenStream {
         Data::Union(_) => unimplemented!("Unions are not supported"),
     }
 }
+
+#[proc_macro_derive(BytesStateful)]
+pub fn bytes_stateful_derive(input: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+
+    let name = &ast.ident;
+    let generics = &ast.generics;
+    let (impl_generics, ty_generics, _) = generics.split_for_impl();
+
+    match &ast.data {
+        Data::Struct(inner) => {
+            // Check if the struct has only one unnamed field
+            let inner_ty = match &inner.fields {
+                Fields::Unnamed(fields) => {
+                    if fields.unnamed.len() != 1 {
+                        panic!("Only one unnamed field is supported");
+                    }
+                    fields.unnamed.first().unwrap().ty.clone()
+                }
+                _ => panic!("Only unnamed fields are supported"),
+            };
+            // Use full path ::openvm_circuit... so it can be used either within or outside the vm crate.
+            // Assume F is already generic of the field.
+            let mut new_generics = generics.clone();
+            let where_clause = new_generics.make_where_clause();
+            where_clause
+                .predicates
+                .push(syn::parse_quote! { #inner_ty: ::openvm_stark_backend::Stateful<Vec<u8>> });
+
+            quote! {
+                impl #impl_generics ::openvm_stark_backend::Stateful<Vec<u8>> for #name #ty_generics #where_clause {
+                    fn load_state(&mut self, state: Vec<u8>) {
+                        self.0.load_state(state)
+                    }
+
+                    fn store_state(&self) -> Vec<u8> {
+                        self.0.store_state()
+                    }
+                }
+            }
+            .into()
+        }
+        Data::Enum(e) => {
+            let variants = e
+                .variants
+                .iter()
+                .map(|variant| {
+                    let variant_name = &variant.ident;
+
+                    let mut fields = variant.fields.iter();
+                    let field = fields.next().unwrap();
+                    assert!(fields.next().is_none(), "Only one field is supported");
+                    (variant_name, field)
+                })
+                .collect::<Vec<_>>();
+            // Use full path ::openvm_stark_backend... so it can be used either within or outside the vm crate.
+            let (load_state_arms, store_state_arms): (Vec<_>, Vec<_>) =
+                multiunzip(variants.iter().map(|(variant_name, field)| {
+                    let field_ty = &field.ty;
+                    let load_state_arm = quote! {
+                        #name::#variant_name(x) => <#field_ty as ::openvm_stark_backend::Stateful<Vec<u8>>>::load_state(x, state)
+                    };
+                    let store_state_arm = quote! {
+                        #name::#variant_name(x) => <#field_ty as ::openvm_stark_backend::Stateful<Vec<u8>>>::store_state(x)
+                    };
+
+                    (load_state_arm, store_state_arm)
+                }));
+            quote! {
+                impl #impl_generics ::openvm_stark_backend::Stateful<Vec<u8>> for #name #ty_generics {
+                    fn load_state(&mut self, state: Vec<u8>) {
+                        match self {
+                            #(#load_state_arms,)*
+                        }
+                    }
+
+                    fn store_state(&self) -> Vec<u8> {
+                        match self {
+                            #(#store_state_arms,)*
+                        }
+                    }
+                }
+            }
+            .into()
+        }
+        _ => unimplemented!(),
+    }
+}

--- a/crates/sdk/src/config/global.rs
+++ b/crates/sdk/src/config/global.rs
@@ -11,8 +11,8 @@ use openvm_circuit::{
     arch::{
         SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmInventoryError,
     },
-    circuit_derive::{Chip, ChipUsageGetter},
-    derive::{AnyEnum, InstructionExecutor, Stateful},
+    circuit_derive::{BytesStateful, Chip, ChipUsageGetter},
+    derive::{AnyEnum, InstructionExecutor},
 };
 use openvm_ecc_circuit::{
     WeierstrassExtension, WeierstrassExtensionExecutor, WeierstrassExtensionPeriphery,
@@ -63,7 +63,7 @@ pub struct SdkVmConfig {
     pub castf: Option<CastFExtension>,
 }
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum SdkVmConfigExecutor<F: PrimeField32> {
     #[any_enum]
     System(SystemExecutor<F>),
@@ -93,7 +93,7 @@ pub enum SdkVmConfigExecutor<F: PrimeField32> {
     CastF(CastFExtensionExecutor<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum SdkVmConfigPeriphery<F: PrimeField32> {
     #[any_enum]
     System(SystemPeriphery<F>),

--- a/crates/sdk/src/config/global.rs
+++ b/crates/sdk/src/config/global.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
         SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmInventoryError,
     },
     circuit_derive::{Chip, ChipUsageGetter},
-    derive::{AnyEnum, InstructionExecutor},
+    derive::{AnyEnum, InstructionExecutor, Stateful},
 };
 use openvm_ecc_circuit::{
     WeierstrassExtension, WeierstrassExtensionExecutor, WeierstrassExtensionPeriphery,
@@ -63,7 +63,7 @@ pub struct SdkVmConfig {
     pub castf: Option<CastFExtension>,
 }
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
 pub enum SdkVmConfigExecutor<F: PrimeField32> {
     #[any_enum]
     System(SystemExecutor<F>),
@@ -93,7 +93,7 @@ pub enum SdkVmConfigExecutor<F: PrimeField32> {
     CastF(CastFExtensionExecutor<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
 pub enum SdkVmConfigPeriphery<F: PrimeField32> {
     #[any_enum]
     System(SystemPeriphery<F>),

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -113,94 +113,6 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(Stateful)]
-pub fn stateful_derive(input: TokenStream) -> TokenStream {
-    let ast: syn::DeriveInput = syn::parse(input).unwrap();
-
-    let name = &ast.ident;
-    let generics = &ast.generics;
-    let (impl_generics, ty_generics, _) = generics.split_for_impl();
-
-    match &ast.data {
-        Data::Struct(inner) => {
-            // Check if the struct has only one unnamed field
-            let inner_ty = match &inner.fields {
-                Fields::Unnamed(fields) => {
-                    if fields.unnamed.len() != 1 {
-                        panic!("Only one unnamed field is supported");
-                    }
-                    fields.unnamed.first().unwrap().ty.clone()
-                }
-                _ => panic!("Only unnamed fields are supported"),
-            };
-            // Use full path ::openvm_circuit... so it can be used either within or outside the vm crate.
-            // Assume F is already generic of the field.
-            let mut new_generics = generics.clone();
-            let where_clause = new_generics.make_where_clause();
-            where_clause
-                .predicates
-                .push(syn::parse_quote! { #inner_ty: ::openvm_stark_backend::Stateful<Vec<u8>> });
-
-            quote! {
-                impl #impl_generics ::openvm_stark_backend::Stateful<Vec<u8>> for #name #ty_generics #where_clause {
-                    fn load_state(&mut self, state: Vec<u8>) {
-                        self.0.load_state(state)
-                    }
-
-                    fn store_state(&self) -> Vec<u8> {
-                        self.0.store_state()
-                    }
-                }
-            }
-            .into()
-        }
-        Data::Enum(e) => {
-            let variants = e
-                .variants
-                .iter()
-                .map(|variant| {
-                    let variant_name = &variant.ident;
-
-                    let mut fields = variant.fields.iter();
-                    let field = fields.next().unwrap();
-                    assert!(fields.next().is_none(), "Only one field is supported");
-                    (variant_name, field)
-                })
-                .collect::<Vec<_>>();
-            // Use full path ::openvm_stark_backend... so it can be used either within or outside the vm crate.
-            let (load_state_arms, store_state_arms): (Vec<_>, Vec<_>) =
-                multiunzip(variants.iter().map(|(variant_name, field)| {
-                    let field_ty = &field.ty;
-                    let load_state_arm = quote! {
-                        #name::#variant_name(x) => <#field_ty as ::openvm_stark_backend::Stateful<Vec<u8>>>::load_state(x, state)
-                    };
-                    let store_state_arm = quote! {
-                        #name::#variant_name(x) => <#field_ty as ::openvm_stark_backend::Stateful<Vec<u8>>>::store_state(x)
-                    };
-
-                    (load_state_arm, store_state_arm)
-                }));
-            quote! {
-                impl #impl_generics ::openvm_stark_backend::Stateful<Vec<u8>> for #name #ty_generics {
-                    fn load_state(&mut self, state: Vec<u8>) {
-                        match self {
-                            #(#load_state_arms,)*
-                        }
-                    }
-
-                    fn store_state(&self) -> Vec<u8> {
-                        match self {
-                            #(#store_state_arms,)*
-                        }
-                    }
-                }
-            }
-            .into()
-        }
-        _ => unimplemented!(),
-    }
-}
-
 /// Derives `AnyEnum` trait on an enum type.
 /// By default an enum arm will just return `self` as `&dyn Any`.
 ///
@@ -396,14 +308,14 @@ pub fn vm_generic_config_derive(input: proc_macro::TokenStream) -> proc_macro::T
             let executor_type = Ident::new(&format!("{}Executor", name), name.span());
             let periphery_type = Ident::new(&format!("{}Periphery", name), name.span());
             TokenStream::from(quote! {
-                #[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, ::openvm_circuit::derive::Stateful)]
+                #[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, ::openvm_circuit_primitives_derive::BytesStateful)]
                 pub enum #executor_type<F: PrimeField32> {
                     #[any_enum]
                     #system_name_upper(SystemExecutor<F>),
                     #(#executor_enum_fields)*
                 }
 
-                #[derive(ChipUsageGetter, Chip, From, AnyEnum, ::openvm_circuit_derive::Stateful)]
+                #[derive(ChipUsageGetter, Chip, From, AnyEnum, ::openvm_circuit_primitives_derive::BytesStateful)]
                 pub enum #periphery_type<F: PrimeField32> {
                     #[any_enum]
                     #system_name_upper(SystemPeriphery<F>),

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -403,7 +403,7 @@ pub fn vm_generic_config_derive(input: proc_macro::TokenStream) -> proc_macro::T
                     #(#executor_enum_fields)*
                 }
 
-                #[derive(ChipUsageGetter, Chip, From, AnyEnum)]
+                #[derive(ChipUsageGetter, Chip, From, AnyEnum, ::openvm_circuit_derive::Stateful)]
                 pub enum #periphery_type<F: PrimeField32> {
                     #[any_enum]
                     #system_name_upper(SystemPeriphery<F>),

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use openvm_circuit::system::memory::MemoryTraceHeights;
 use openvm_instructions::program::DEFAULT_MAX_NUM_PUBLIC_VALUES;
 use openvm_poseidon2_air::Poseidon2Config;
-use openvm_stark_backend::{p3_field::PrimeField32, ChipUsageGetter};
+use openvm_stark_backend::{p3_field::PrimeField32, ChipUsageGetter, Stateful};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 // TODO[jpw]: re-exporting hardcoded bus constants for tests. Import paths should be
@@ -30,8 +30,8 @@ pub fn vm_poseidon2_config<F: PrimeField32>() -> Poseidon2Config<F> {
 }
 
 pub trait VmConfig<F: PrimeField32>: Clone + Serialize + DeserializeOwned {
-    type Executor: InstructionExecutor<F> + AnyEnum + ChipUsageGetter;
-    type Periphery: AnyEnum + ChipUsageGetter;
+    type Executor: InstructionExecutor<F> + AnyEnum + ChipUsageGetter + Stateful<Vec<u8>>;
+    type Periphery: AnyEnum + ChipUsageGetter + Stateful<Vec<u8>>;
 
     /// Must contain system config
     fn system(&self) -> &SystemConfig;

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -10,12 +10,12 @@ use getset::Getters;
 use itertools::Itertools;
 #[cfg(feature = "bench-metrics")]
 use metrics::counter;
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor};
 use openvm_circuit_primitives::{
     utils::next_power_of_two_or_zero,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::{
     program::Program, PhantomDiscriminant, PublishOpcode, SystemOpcode, UsizeOpcode, VmOpcode,
 };
@@ -558,13 +558,13 @@ impl<F: PrimeField32> Stateful<SystemBaseState<F>> for SystemBase<F> {
     }
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, InstructionExecutor, Stateful)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, InstructionExecutor, BytesStateful)]
 pub enum SystemExecutor<F: PrimeField32> {
     PublicValues(PublicValuesChip<F>),
     Phantom(RefCell<PhantomChip<F>>),
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, Stateful)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, BytesStateful)]
 pub enum SystemPeriphery<F: PrimeField32> {
     /// Poseidon2 chip with direct compression interactions
     Poseidon2(Poseidon2PeripheryChip<F>),

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -12,7 +12,7 @@ use metrics::counter;
 use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful};
 use openvm_circuit_primitives::{
     utils::next_power_of_two_or_zero,
-    var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
+    var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip},
 };
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_instructions::{
@@ -439,7 +439,7 @@ pub type SystemComplex<F> = VmChipComplex<F, SystemExecutor<F>, SystemPeriphery<
 /// for the VM architecture.
 pub struct SystemBase<F> {
     // RangeCheckerChip **must** be the last chip to have trace generation called on
-    pub range_checker_chip: Arc<VariableRangeCheckerChip>,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
     pub memory_controller: MemoryController<F>,
     pub connector_chip: VmConnectorChip<F>,
     pub program_chip: ProgramChip<F>,
@@ -507,7 +507,7 @@ impl<F: PrimeField32> SystemComplex<F> {
             VariableRangeCheckerBus::new(RANGE_CHECKER_BUS, config.memory_config.decomp);
         let mut bus_idx_max = RANGE_CHECKER_BUS;
 
-        let range_checker = Arc::new(VariableRangeCheckerChip::new(range_bus));
+        let range_checker = SharedVariableRangeCheckerChip::new(range_bus);
         let memory_controller = if config.continuation_enabled {
             bus_idx_max += 2;
             MemoryController::with_persistent_memory(
@@ -683,7 +683,7 @@ impl<F: PrimeField32, E, P> VmChipComplex<F, E, P> {
         &self.base.memory_controller
     }
 
-    pub fn range_checker_chip(&self) -> &Arc<VariableRangeCheckerChip> {
+    pub fn range_checker_chip(&self) -> &SharedVariableRangeCheckerChip {
         &self.base.range_checker_chip
     }
 
@@ -1120,7 +1120,7 @@ impl AnyEnum for () {
     }
 }
 
-impl AnyEnum for Arc<VariableRangeCheckerChip> {
+impl AnyEnum for SharedVariableRangeCheckerChip {
     fn as_any_kind(&self) -> &dyn Any {
         self
     }

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -402,7 +402,7 @@ impl<E: Stateful<Vec<u8>>, P: Stateful<Vec<u8>>> Stateful<VmInventoryState> for 
     }
 
     fn store_state(&self) -> VmInventoryState {
-        // TODO: parallelize this.
+        // TODO: parallelize this. Now some implementations of Executor/Periphery are not Send + Sync.
         let executors = self.executors.iter().map(|e| e.store_state()).collect();
         let periphery = self.periphery.iter().map(|p| p.store_state()).collect();
         VmInventoryState {

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -10,12 +10,12 @@ use openvm_stark_backend::{
     p3_field::PrimeField32,
     prover::types::{CommittedTraceData, ProofInput},
     utils::metrics_span,
-    Chip,
+    Chip, Stateful,
 };
 
 use super::{
-    ExecutionError, Streams, SystemBase, SystemConfig, VmChipComplex, VmComplexTraceHeights,
-    VmConfig,
+    ExecutionError, Streams, SystemBase, SystemConfig, VmChipComplex, VmChipComplexState,
+    VmComplexTraceHeights, VmConfig,
 };
 #[cfg(feature = "bench-metrics")]
 use crate::metrics::VmMetrics;
@@ -81,6 +81,31 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
                 fn_bounds,
                 ..Default::default()
             },
+            since_last_segment_check: 0,
+        }
+    }
+
+    /// Creates a new execution segment just for proving.
+    pub fn new_for_proving(
+        config: &VC,
+        program: Program<F>,
+        vm_chip_complex_state: VmChipComplexState<F>,
+    ) -> Self {
+        let mut chip_complex = config.create_chip_complex().unwrap();
+        let program = if !config.system().profiling {
+            program.strip_debug_infos()
+        } else {
+            program
+        };
+        chip_complex.set_program(program);
+        chip_complex.load_state(vm_chip_complex_state);
+        let air_names = chip_complex.air_names();
+        Self {
+            chip_complex,
+            final_memory: None,
+            air_names,
+            #[cfg(feature = "bench-metrics")]
+            metrics: Default::default(),
             since_last_segment_check: 0,
         }
     }
@@ -273,5 +298,8 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
     /// Includes constant trace heights.
     pub fn current_trace_heights(&self) -> Vec<usize> {
         self.chip_complex.current_trace_heights()
+    }
+    pub fn store_chip_complex_state(&self) -> VmChipComplexState<F> {
+        self.chip_complex.store_state()
     }
 }

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -4,7 +4,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
@@ -170,7 +172,7 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
         self.memory.controller.clone()
     }
 
-    pub fn range_checker(&self) -> Arc<VariableRangeCheckerChip> {
+    pub fn range_checker(&self) -> SharedVariableRangeCheckerChip {
         self.memory.controller.borrow().range_checker.clone()
     }
 
@@ -241,10 +243,10 @@ impl VmChipTestBuilder<BabyBear> {
 impl<F: PrimeField32> Default for VmChipTestBuilder<F> {
     fn default() -> Self {
         let mem_config = MemoryConfig::new(2, 1, 29, 29, 17, 64, 1 << 22);
-        let range_checker = Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
+        let range_checker = SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
             RANGE_CHECKER_BUS,
             mem_config.decomp,
-        )));
+        ));
         let memory_controller = MemoryController::with_volatile_memory(
             MemoryBus(MEMORY_BUS),
             mem_config,

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 
 pub mod dimensions;
-mod interface;
+pub mod interface;
 
 pub const CHUNK: usize = 8;
 /// The offset of the Merkle AIR in AIRs of MemoryController.
@@ -693,6 +693,13 @@ impl<F: PrimeField32> MemoryController<F> {
     /// and store the returned reference for later use.
     pub fn offline_memory(&self) -> Arc<Mutex<OfflineMemory<F>>> {
         self.offline_memory.clone()
+    }
+    pub fn get_memory_logs(&self) -> Vec<MemoryLogEntry<F>> {
+        // TODO: can we avoid clone?
+        self.memory.log.clone()
+    }
+    pub fn set_memory_logs(&mut self, logs: Vec<MemoryLogEntry<F>>) {
+        self.memory.log = logs;
     }
 }
 

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -12,7 +12,7 @@ use openvm_circuit_primitives::{
     assert_less_than::{AssertLtSubAir, LessThanAuxCols},
     is_zero::IsZeroSubAir,
     utils::next_power_of_two_or_zero,
-    var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
     TraceSubRowGenerator,
 };
 use openvm_stark_backend::{
@@ -91,7 +91,7 @@ pub struct MemoryController<F> {
 
     #[getset(get = "pub")]
     pub(crate) mem_config: MemoryConfig,
-    pub range_checker: Arc<VariableRangeCheckerChip>,
+    pub range_checker: SharedVariableRangeCheckerChip,
     // Store separately to avoid smart pointer reference each time
     range_checker_bus: VariableRangeCheckerBus,
 
@@ -226,7 +226,7 @@ impl<F: PrimeField32> MemoryController<F> {
     pub fn with_volatile_memory(
         memory_bus: MemoryBus,
         mem_config: MemoryConfig,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
     ) -> Self {
         let range_checker_bus = range_checker.bus();
         let initial_memory = MemoryImage::default();
@@ -267,7 +267,7 @@ impl<F: PrimeField32> MemoryController<F> {
     pub fn with_persistent_memory(
         memory_bus: MemoryBus,
         mem_config: MemoryConfig,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         merkle_bus: MemoryMerkleBus,
         compression_bus: DirectCompressionBus,
     ) -> Self {
@@ -697,7 +697,7 @@ impl<F: PrimeField32> MemoryController<F> {
 }
 
 pub struct MemoryAuxColsFactory<T> {
-    pub(crate) range_checker: Arc<VariableRangeCheckerChip>,
+    pub(crate) range_checker: SharedVariableRangeCheckerChip,
     pub(crate) timestamp_lt_air: AssertLtSubAir,
     pub(crate) _marker: PhantomData<T>,
 }
@@ -753,7 +753,7 @@ impl<F: PrimeField32> MemoryAuxColsFactory<F> {
         debug_assert!(prev_timestamp < timestamp);
         let mut decomp = [F::ZERO; AUX_LEN];
         self.timestamp_lt_air.generate_subrow(
-            (&self.range_checker, prev_timestamp, timestamp),
+            (self.range_checker.as_ref(), prev_timestamp, timestamp),
             &mut decomp,
         );
         LessThanAuxCols::new(decomp)
@@ -762,9 +762,10 @@ impl<F: PrimeField32> MemoryAuxColsFactory<F> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
-    use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+    use openvm_circuit_primitives::var_range::{
+        SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+    };
     use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use rand::{prelude::SliceRandom, thread_rng, Rng};
@@ -784,7 +785,7 @@ mod tests {
         let memory_bus = MemoryBus(MEMORY_BUS);
         let memory_config = MemoryConfig::default();
         let range_bus = VariableRangeCheckerBus::new(RANGE_CHECKER_BUS, memory_config.decomp);
-        let range_checker = Arc::new(VariableRangeCheckerChip::new(range_bus));
+        let range_checker = SharedVariableRangeCheckerChip::new(range_bus);
 
         let mut memory_controller = MemoryController::with_volatile_memory(
             memory_bus,

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -5,7 +5,7 @@ mod controller;
 pub mod merkle;
 mod offline;
 pub mod offline_checker;
-mod online;
+pub mod online;
 mod persistent;
 #[cfg(test)]
 mod tests;

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -1,7 +1,7 @@
-use std::{array, cmp::max, sync::Arc};
+use std::{array, cmp::max};
 
 use openvm_circuit_primitives::{
-    assert_less_than::AssertLtSubAir, var_range::VariableRangeCheckerChip,
+    assert_less_than::AssertLtSubAir, var_range::SharedVariableRangeCheckerChip,
 };
 use openvm_stark_backend::p3_field::PrimeField32;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -41,7 +41,7 @@ pub struct OfflineMemory<F> {
     timestamp_max_bits: usize,
 
     memory_bus: MemoryBus,
-    range_checker: Arc<VariableRangeCheckerChip>,
+    range_checker: SharedVariableRangeCheckerChip,
 
     log: Vec<Option<MemoryRecord<F>>>,
 }
@@ -54,7 +54,7 @@ impl<F: PrimeField32> OfflineMemory<F> {
         initial_memory: MemoryImage<F>,
         initial_block_size: usize,
         memory_bus: MemoryBus,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         timestamp_max_bits: usize,
     ) -> Self {
         assert!(initial_block_size.is_power_of_two());
@@ -446,9 +446,9 @@ impl<F: PrimeField32> OfflineMemory<F> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+    use openvm_circuit_primitives::var_range::{
+        SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+    };
     use openvm_stark_backend::p3_field::FieldAlgebra;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
@@ -486,9 +486,7 @@ mod tests {
             initial_memory,
             8,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
         assert_eq!(
@@ -535,9 +533,7 @@ mod tests {
             initial_memory,
             1,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
         let address_space = 1;
@@ -563,9 +559,7 @@ mod tests {
             initial_memory,
             1,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
 
@@ -710,9 +704,7 @@ mod tests {
             initial_memory,
             8,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
 
@@ -827,9 +819,7 @@ mod tests {
             initial_memory,
             1,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
 
@@ -851,9 +841,7 @@ mod tests {
             initial_memory,
             8,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
 
@@ -875,9 +863,7 @@ mod tests {
             initial_memory,
             4,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
 
@@ -893,9 +879,7 @@ mod tests {
             initial_memory,
             8,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
         // Make block 0:4 in address space 1 active.
@@ -965,9 +949,7 @@ mod tests {
             initial_memory,
             8,
             MemoryBus(0),
-            Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
-                1, 29,
-            ))),
+            SharedVariableRangeCheckerChip::new(VariableRangeCheckerBus::new(1, 29)),
             29,
         );
 

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -2,10 +2,11 @@ use std::{array, fmt::Debug};
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
 
 use crate::system::memory::{offline::INITIAL_TIMESTAMP, MemoryImage, RecordId};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MemoryLogEntry<T> {
     Read {
         address_space: u32,

--- a/crates/vm/src/system/memory/tests.rs
+++ b/crates/vm/src/system/memory/tests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_poseidon2_air::Poseidon2Config;
 use openvm_stark_backend::{
@@ -205,7 +205,7 @@ fn test_memory_controller() {
     let memory_bus = MemoryBus(MEMORY_BUS);
     let memory_config = MemoryConfig::default();
     let range_bus = VariableRangeCheckerBus::new(RANGE_CHECKER_BUS, memory_config.decomp);
-    let range_checker = Arc::new(VariableRangeCheckerChip::new(range_bus));
+    let range_checker = SharedVariableRangeCheckerChip::new(range_bus);
 
     let mut memory_controller =
         MemoryController::with_volatile_memory(memory_bus, memory_config, range_checker.clone());
@@ -241,7 +241,7 @@ fn test_memory_controller_persistent() {
     let compression_bus = DirectCompressionBus(POSEIDON2_DIRECT_BUS);
     let memory_config = MemoryConfig::default();
     let range_bus = VariableRangeCheckerBus::new(RANGE_CHECKER_BUS, memory_config.decomp);
-    let range_checker = Arc::new(VariableRangeCheckerChip::new(range_bus));
+    let range_checker = SharedVariableRangeCheckerChip::new(range_bus);
 
     let mut memory_controller = MemoryController::with_persistent_memory(
         memory_bus,

--- a/crates/vm/src/system/memory/tests.rs
+++ b/crates/vm/src/system/memory/tests.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use itertools::Itertools;
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_poseidon2_air::Poseidon2Config;
 use openvm_stark_backend::{

--- a/crates/vm/src/system/memory/volatile/tests.rs
+++ b/crates/vm/src/system/memory/volatile/tests.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, iter, sync::Arc};
 
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_stark_backend::{
     p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix, prover::types::AirProofInput, Chip,
 };
@@ -42,7 +42,7 @@ fn boundary_air_test() {
     }
 
     let range_bus = VariableRangeCheckerBus::new(RANGE_CHECKER_BUS, DECOMP);
-    let range_checker = Arc::new(VariableRangeCheckerChip::new(range_bus));
+    let range_checker = SharedVariableRangeCheckerChip::new(range_bus);
     let mut boundary_chip =
         VolatileBoundaryChip::new(memory_bus, 2, LIMB_BITS, range_checker.clone());
 
@@ -110,7 +110,7 @@ fn boundary_air_test() {
     // test trace height override
     {
         let overridden_height = boundary_api.main_trace_height() * 2;
-        let range_checker = Arc::new(VariableRangeCheckerChip::new(range_bus));
+        let range_checker = SharedVariableRangeCheckerChip::new(range_bus);
         let mut boundary_chip =
             VolatileBoundaryChip::new(memory_bus, 2, LIMB_BITS, range_checker.clone());
         boundary_chip.set_overridden_height(overridden_height);

--- a/crates/vm/src/system/memory/volatile/tests.rs
+++ b/crates/vm/src/system/memory/volatile/tests.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashSet, iter, sync::Arc};
 
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_stark_backend::{
     p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix, prover::types::AirProofInput, Chip,
 };

--- a/crates/vm/src/system/poseidon2/mod.rs
+++ b/crates/vm/src/system/poseidon2/mod.rs
@@ -24,7 +24,7 @@ pub mod tests;
 pub mod air;
 mod chip;
 pub use chip::*;
-use openvm_circuit_derive::Stateful;
+use openvm_circuit_primitives_derive::BytesStateful;
 
 use crate::arch::hasher::{Hasher, HasherChip};
 pub mod columns;
@@ -33,7 +33,7 @@ pub mod trace;
 pub const PERIPHERY_POSEIDON2_WIDTH: usize = 16;
 pub const PERIPHERY_POSEIDON2_CHUNK_SIZE: usize = 8;
 
-#[derive(Stateful)]
+#[derive(BytesStateful)]
 pub enum Poseidon2PeripheryChip<F: PrimeField32> {
     Register0(Poseidon2PeripheryBaseChip<F, 0>),
     Register1(Poseidon2PeripheryBaseChip<F, 1>),

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -2,7 +2,7 @@ use openvm_instructions::{
     instruction::{DebugInfo, Instruction},
     program::Program,
 };
-use openvm_stark_backend::{p3_field::PrimeField64, ChipUsageGetter};
+use openvm_stark_backend::{p3_field::PrimeField64, ChipUsageGetter, Stateful};
 
 use crate::{arch::ExecutionError, system::program::trace::padding_instruction};
 
@@ -101,5 +101,15 @@ impl<F: PrimeField64> ChipUsageGetter for ProgramChip<F> {
 
     fn trace_width(&self) -> usize {
         1
+    }
+}
+
+impl<F: PrimeField64> Stateful<Vec<u8>> for ProgramChip<F> {
+    fn load_state(&mut self, state: Vec<u8>) {
+        self.execution_frequencies = bitcode::deserialize(&state).unwrap();
+    }
+
+    fn store_state(&self) -> Vec<u8> {
+        bitcode::serialize(&self.execution_frequencies).unwrap()
     }
 }

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -4,9 +4,10 @@ use derive_more::derive::From;
 use openvm_circuit::{
     arch::{
         hasher::{poseidon2::vm_poseidon2_hasher, Hasher},
-        ChipId, ExitCode, MemoryConfig, SingleSegmentVmExecutor, SystemConfig, SystemExecutor,
-        SystemPeriphery, SystemTraceHeights, VirtualMachine, VmChipComplex, VmComplexTraceHeights,
-        VmConfig, VmInventoryError, VmInventoryTraceHeights,
+        ChipId, ExecutionSegment, ExitCode, MemoryConfig, SingleSegmentVmExecutor, Streams,
+        SystemConfig, SystemExecutor, SystemPeriphery, SystemTraceHeights, VirtualMachine,
+        VmChipComplex, VmComplexTraceHeights, VmConfig, VmExecutorResult, VmInventoryError,
+        VmInventoryTraceHeights,
     },
     derive::{AnyEnum, InstructionExecutor, VmConfig},
     system::{
@@ -437,16 +438,13 @@ fn test_vm_1_persistent() {
         .expect("Verification failed");
 }
 
-#[test]
-fn test_vm_continuations() {
-    let n = 200000;
-
+fn gen_continuation_test_program<F: PrimeField32>(n: isize) -> Program<F> {
     // Simple Fibonacci program to compute nth Fibonacci number mod BabyBear (with F_0 = 1).
     // Register [0]_1 <- stores the loop counter.
     // Register [1]_1 <- stores F_i at the beginning of iteration i.
     // Register [2]_1 <- stores F_{i+1} at the beginning of iteration i.
     // Register [3]_1 is used as a temporary register.
-    let program = Program::from_instructions(&[
+    Program::from_instructions(&[
         // [0]_1 <- 0
         Instruction::from_isize(VmOpcode::with_default_offset(ADD), 0, 0, 0, 1, 0),
         // [1]_1 <- 0
@@ -481,8 +479,13 @@ fn test_vm_continuations() {
             0,
             0,
         ),
-    ]);
+    ])
+}
 
+#[test]
+fn test_vm_continuations() {
+    let n = 200000;
+    let program = gen_continuation_test_program(n);
     let config = NativeConfig {
         system: SystemConfig::new(3, MemoryConfig::default(), 0).with_max_segment_len(200000),
         native: Default::default(),
@@ -507,6 +510,44 @@ fn test_vm_continuations() {
         UserPublicValuesProof::compute(memory_dimensions, num_public_values, &hasher, &final_state);
     assert_eq!(pv_proof.public_values.len(), num_public_values);
     assert_eq!(pv_proof.public_values[0], expected_output);
+}
+
+#[test]
+fn test_vm_continuations_recover_state() {
+    let n = 2000;
+    let program = gen_continuation_test_program(n);
+    let config = NativeConfig {
+        system: SystemConfig::new(3, MemoryConfig::default(), 0).with_max_segment_len(500),
+        native: Default::default(),
+    }
+    .with_continuations();
+    let engine = BabyBearPoseidon2Engine::new(FriParameters::standard_fast());
+    let vm = VirtualMachine::new(engine, config.clone());
+    let pk = vm.keygen();
+    let segments = vm
+        .executor
+        .execute_segments(program.clone(), Streams::default())
+        .unwrap();
+    let states: Vec<_> = segments
+        .iter()
+        .map(|s| s.store_chip_complex_state())
+        .collect();
+    let proof_inputs_per_seg = states
+        .into_iter()
+        .map(|s| {
+            ExecutionSegment::new_for_proving(&config, program.clone(), s)
+                .generate_proof_input(None)
+        })
+        .collect();
+    let proofs = vm.prove(
+        &pk,
+        VmExecutorResult {
+            per_segment: proof_inputs_per_seg,
+            final_memory: None,
+        },
+    );
+    vm.verify(&pk.get_vk(), proofs)
+        .expect("Verification failed");
 }
 
 #[test]

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -21,7 +21,7 @@ use crate::Fp2;
 
 // Input: Fp2 * 2
 // Output: Fp2
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct Fp2AddSubChip<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>(
     pub  VmChipWrapper<
         F,

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -35,7 +35,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
         adapter: Rv32VecHeapAdapterChip<F, 2, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let (expr, is_add_flag, is_sub_flag) = fp2_addsub_expr(config, range_checker.bus());

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip, SymbolicExpr,
 };
@@ -21,7 +21,7 @@ use crate::Fp2;
 
 // Input: Fp2 * 2
 // Output: Fp2
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct Fp2MulDivChip<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>(
     pub  VmChipWrapper<
         F,

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip, SymbolicExpr,
@@ -35,7 +35,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
         adapter: Rv32VecHeapAdapterChip<F, 2, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let (expr, is_mul_flag, is_div_flag) = fp2_muldiv_expr(config, range_checker.bus());

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip, SymbolicExpr,

--- a/extensions/algebra/circuit/src/fp2_extension.rs
+++ b/extensions/algebra/circuit/src/fp2_extension.rs
@@ -5,11 +5,11 @@ use openvm_circuit::{
     arch::{SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::{UsizeOpcode, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
 use openvm_rv32_adapters::Rv32VecHeapAdapterChip;
@@ -27,7 +27,7 @@ pub struct Fp2Extension {
     pub supported_modulus: Vec<BigUint>,
 }
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, AnyEnum, From, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, AnyEnum, From, BytesStateful)]
 pub enum Fp2ExtensionExecutor<F: PrimeField32> {
     // 32 limbs prime
     Fp2AddSubRv32_32(Fp2AddSubChip<F, 2, 32>),
@@ -37,7 +37,7 @@ pub enum Fp2ExtensionExecutor<F: PrimeField32> {
     Fp2MulDivRv32_48(Fp2MulDivChip<F, 6, 16>),
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, Stateful)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, BytesStateful)]
 pub enum Fp2ExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     // We put this only to get the <F> generic to work

--- a/extensions/algebra/circuit/src/modular_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/modular_chip/addsub.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip, FieldVariable,
@@ -57,7 +59,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
         adapter: Rv32VecHeapAdapterChip<F, 2, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let (expr, is_add_flag, is_sub_flag) = addsub_expr(config, range_checker.bus());

--- a/extensions/algebra/circuit/src/modular_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/modular_chip/addsub.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip, FieldVariable,
 };
@@ -43,7 +43,7 @@ pub fn addsub_expr(
     )
 }
 
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct ModularAddSubChip<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>(
     pub  VmChipWrapper<
         F,

--- a/extensions/algebra/circuit/src/modular_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/modular_chip/muldiv.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip, FieldVariable, SymbolicExpr,
 };
@@ -57,7 +57,7 @@ pub fn muldiv_expr(
     )
 }
 
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct ModularMulDivChip<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>(
     pub  VmChipWrapper<
         F,

--- a/extensions/algebra/circuit/src/modular_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/modular_chip/muldiv.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip, FieldVariable, SymbolicExpr,
@@ -71,7 +73,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
         adapter: Rv32VecHeapAdapterChip<F, 2, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let (expr, is_mul_flag, is_div_flag) = muldiv_expr(config, range_checker.bus());

--- a/extensions/algebra/circuit/src/modular_extension.rs
+++ b/extensions/algebra/circuit/src/modular_extension.rs
@@ -6,11 +6,11 @@ use openvm_circuit::{
     arch::{SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::{UsizeOpcode, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
 use openvm_rv32_adapters::{Rv32IsEqualModAdapterChip, Rv32VecHeapAdapterChip};
@@ -30,7 +30,7 @@ pub struct ModularExtension {
     pub supported_modulus: Vec<BigUint>,
 }
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, AnyEnum, From, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, AnyEnum, From, BytesStateful)]
 pub enum ModularExtensionExecutor<F: PrimeField32> {
     // 32 limbs prime
     ModularAddSubRv32_32(ModularAddSubChip<F, 1, 32>),
@@ -42,7 +42,7 @@ pub enum ModularExtensionExecutor<F: PrimeField32> {
     ModularIsEqualRv32_48(ModularIsEqualChip<F, 3, 16, 48>),
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, Stateful)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, BytesStateful)]
 pub enum ModularExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     // We put this only to get the <F> generic to work

--- a/extensions/bigint/circuit/src/extension.rs
+++ b/extensions/bigint/circuit/src/extension.rs
@@ -10,12 +10,12 @@ use openvm_circuit::{
     },
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful, VmConfig};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::{program::DEFAULT_PC_STEP, UsizeOpcode, VmOpcode};
 use openvm_rv32im_circuit::{
     Rv32I, Rv32IExecutor, Rv32IPeriphery, Rv32Io, Rv32IoExecutor, Rv32IoPeriphery, Rv32M,
@@ -70,7 +70,7 @@ fn default_range_tuple_checker_sizes() -> [u32; 2] {
     [1 << 8, 32 * (1 << 8)]
 }
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum Int256Executor<F: PrimeField32> {
     BaseAlu256(Rv32BaseAlu256Chip<F>),
     LessThan256(Rv32LessThan256Chip<F>),
@@ -80,7 +80,7 @@ pub enum Int256Executor<F: PrimeField32> {
     Shift256(Rv32Shift256Chip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum Int256Periphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     /// Only needed for multiplication extension

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, iter, rc::Rc, sync::Arc};
+use std::{cell::RefCell, iter, rc::Rc};
 
 use itertools::{zip_eq, Itertools};
 use num_bigint_dig::BigUint;
@@ -9,7 +9,7 @@ use openvm_circuit::arch::{
 };
 use openvm_circuit_primitives::{
     bigint::utils::big_uint_to_num_limbs,
-    var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
     SubAir, TraceSubRowGenerator,
 };
 use openvm_ecc_transpiler::Rv32WeierstrassOpcode;
@@ -161,13 +161,13 @@ where
 
 pub struct EcDoubleCoreChip {
     pub air: EcDoubleCoreAir,
-    pub range_checker: Arc<VariableRangeCheckerChip>,
+    pub range_checker: SharedVariableRangeCheckerChip,
 }
 
 impl EcDoubleCoreChip {
     pub fn new(
         config: ExprBuilderConfig,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         a_biguint: BigUint,
         offset: usize,
     ) -> Self {
@@ -258,7 +258,7 @@ where
     fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
         self.air.expr.generate_subrow(
             (
-                &self.range_checker,
+                self.range_checker.as_ref(),
                 vec![record.x, record.y],
                 vec![record.is_double_flag],
             ),

--- a/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
@@ -13,9 +13,9 @@ use std::sync::Mutex;
 
 use num_bigint_dig::BigUint;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::SharedVariableRangeCheckerChip;
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_ecc_transpiler::Rv32WeierstrassOpcode;
 use openvm_mod_circuit_builder::{ExprBuilderConfig, FieldExpressionCoreChip};
 use openvm_rv32_adapters::Rv32VecHeapAdapterChip;
@@ -25,7 +25,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 /// BLOCKS: how many blocks do we need to represent one input or output
 /// For example, for bls12_381, BLOCK_SIZE = 16, each element has 3 blocks and with two elements per input AffinePoint, BLOCKS = 6.
 /// For secp256k1, BLOCK_SIZE = 32, BLOCKS = 2.
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct EcAddNeChip<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>(
     VmChipWrapper<
         F,
@@ -61,7 +61,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
     }
 }
 
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct EcDoubleChip<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>(
     VmChipWrapper<
         F,

--- a/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use num_bigint_dig::BigUint;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
+use openvm_circuit_primitives::var_range::SharedVariableRangeCheckerChip;
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_ecc_transpiler::Rv32WeierstrassOpcode;
 use openvm_mod_circuit_builder::{ExprBuilderConfig, FieldExpressionCoreChip};
@@ -41,7 +41,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
         adapter: Rv32VecHeapAdapterChip<F, 2, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let expr = ec_add_ne_expr(config, range_checker.bus());
@@ -75,7 +75,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
 {
     pub fn new(
         adapter: Rv32VecHeapAdapterChip<F, 1, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         config: ExprBuilderConfig,
         offset: usize,
         a: BigUint,

--- a/extensions/ecc/circuit/src/weierstrass_extension.rs
+++ b/extensions/ecc/circuit/src/weierstrass_extension.rs
@@ -7,11 +7,11 @@ use openvm_circuit::{
     arch::{SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_ecc_guest::{
     k256::{SECP256K1_MODULUS, SECP256K1_ORDER},
     p256::{CURVE_A as P256_A, CURVE_B as P256_B, P256_MODULUS, P256_ORDER},
@@ -63,7 +63,7 @@ pub struct WeierstrassExtension {
     pub supported_curves: Vec<CurveConfig>,
 }
 
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, AnyEnum, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, AnyEnum, BytesStateful)]
 pub enum WeierstrassExtensionExecutor<F: PrimeField32> {
     // 32 limbs prime
     EcAddNeRv32_32(EcAddNeChip<F, 2, 32>),
@@ -73,7 +73,7 @@ pub enum WeierstrassExtensionExecutor<F: PrimeField32> {
     EcDoubleRv32_48(EcDoubleChip<F, 6, 16>),
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, Stateful)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, BytesStateful)]
 pub enum WeierstrassExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     Phantom(PhantomChip<F>),

--- a/extensions/keccak256/circuit/src/extension.rs
+++ b/extensions/keccak256/circuit/src/extension.rs
@@ -6,9 +6,9 @@ use openvm_circuit::{
     },
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful, VmConfig};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::*;
 use openvm_rv32im_circuit::{
     Rv32I, Rv32IExecutor, Rv32IPeriphery, Rv32Io, Rv32IoExecutor, Rv32IoPeriphery, Rv32M,
@@ -49,12 +49,12 @@ impl Default for Keccak256Rv32Config {
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct Keccak256;
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum Keccak256Executor<F: PrimeField32> {
     Keccak256(KeccakVmChip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum Keccak256Periphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     Phantom(PhantomChip<F>),

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -1,13 +1,12 @@
-use std::{
-    borrow::{Borrow, BorrowMut},
-    sync::Arc,
-};
+use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::arch::{
     AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
     VmCoreAir, VmCoreChip,
 };
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::instruction::Instruction;
 use openvm_native_compiler::CastfOpcode;
@@ -105,11 +104,11 @@ pub struct CastFRecord<F> {
 
 pub struct CastFCoreChip {
     pub air: CastFCoreAir,
-    pub range_checker_chip: Arc<VariableRangeCheckerChip>,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
 impl CastFCoreChip {
-    pub fn new(range_checker_chip: Arc<VariableRangeCheckerChip>, offset: usize) -> Self {
+    pub fn new(range_checker_chip: SharedVariableRangeCheckerChip, offset: usize) -> Self {
         Self {
             air: CastFCoreAir {
                 bus: range_checker_chip.bus(),

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -10,8 +10,8 @@ use openvm_circuit::{
     },
     system::{native_adapter::NativeAdapterChip, phantom::PhantomChip},
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful, VmConfig};
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::{
     program::DEFAULT_PC_STEP, PhantomDiscriminant, Poseidon2Opcode, UsizeOpcode, VmOpcode,
 };
@@ -77,7 +77,7 @@ impl NativeConfig {
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct Native;
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum NativeExecutor<F: PrimeField32> {
     LoadStore(NativeLoadStoreChip<F, 1>),
     BlockLoadStore(NativeLoadStoreChip<F, 4>),
@@ -89,7 +89,7 @@ pub enum NativeExecutor<F: PrimeField32> {
     FriReducedOpening(FriReducedOpeningChip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum NativePeriphery<F: PrimeField32> {
     Phantom(PhantomChip<F>),
 }
@@ -320,12 +320,12 @@ pub(crate) mod phantom {
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct CastFExtension;
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum CastFExtensionExecutor<F: PrimeField32> {
     CastF(CastFChip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum CastFExtensionPeriphery<F: PrimeField32> {
     Placeholder(CastFChip<F>),
 }

--- a/extensions/native/circuit/src/poseidon2/mod.rs
+++ b/extensions/native/circuit/src/poseidon2/mod.rs
@@ -1,9 +1,14 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+pub use columns::*;
 use openvm_circuit::{
     arch::{ExecutionBus, ExecutionError, ExecutionState, InstructionExecutor},
-    system::{memory::MemoryController, program::ProgramBus},
+    system::{
+        memory::{offline_checker::MemoryBridge, MemoryController, OfflineMemory},
+        program::ProgramBus,
+    },
 };
+use openvm_circuit_primitives_derive::BytesStateful;
 use openvm_instructions::instruction::Instruction;
 use openvm_poseidon2_air::Poseidon2Config;
 use openvm_stark_backend::{
@@ -19,11 +24,6 @@ pub use air::*;
 mod chip;
 pub use chip::*;
 mod columns;
-use std::sync::Mutex;
-
-pub use columns::*;
-use openvm_circuit::system::memory::{offline_checker::MemoryBridge, OfflineMemory};
-use openvm_circuit_derive::Stateful;
 
 mod trace;
 
@@ -33,7 +33,7 @@ mod tests;
 pub const NATIVE_POSEIDON2_WIDTH: usize = 16;
 pub const NATIVE_POSEIDON2_CHUNK_SIZE: usize = 8;
 
-#[derive(Stateful)]
+#[derive(BytesStateful)]
 pub enum NativePoseidon2Chip<F: Field> {
     Register0(NativePoseidon2BaseChip<F, 0>),
     Register1(NativePoseidon2BaseChip<F, 1>),

--- a/extensions/pairing/circuit/src/fp12_chip/mul.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/mul.rs
@@ -6,7 +6,7 @@ use std::{
 
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -35,7 +35,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>
         config: ExprBuilderConfig,
         xi: [isize; 2],
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let expr = fp12_mul_expr(config, range_checker.bus(), xi);

--- a/extensions/pairing/circuit/src/fp12_chip/mul.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/mul.rs
@@ -6,7 +6,9 @@ use std::{
 
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/fp12_chip/mul.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/mul.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -20,7 +20,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use crate::Fp12;
 // Input: Fp12 * 2
 // Output: Fp12
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct Fp12MulChip<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize>(
     pub  VmChipWrapper<
         F,

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_013_by_013.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_013_by_013.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -41,7 +41,7 @@ impl<
 {
     pub fn new(
         adapter: Rv32VecHeapAdapterChip<F, 2, INPUT_BLOCKS, OUTPUT_BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         config: ExprBuilderConfig,
         xi: [isize; 2],
         offset: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_013_by_013.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_013_by_013.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -20,7 +20,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 // Input: line0.b, line0.c, line1.b, line1.c <Fp2>: 2 x 4 field elements
 // Output: 5 Fp2 coefficients -> 10 field elements
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct EcLineMul013By013Chip<
     F: PrimeField32,
     const INPUT_BLOCKS: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_013_by_013.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_013_by_013.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_by_01234.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_by_01234.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -62,7 +62,7 @@ impl<
         config: ExprBuilderConfig,
         xi: [isize; 2],
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         assert!(

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_by_01234.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_by_01234.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -22,7 +22,7 @@ use crate::Fp12;
 
 // Input: Fp12 (12 field elements), [Fp2; 5] (5 x 2 field elements)
 // Output: Fp12 (12 field elements)
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct EcLineMulBy01234Chip<
     F: PrimeField32,
     const INPUT_BLOCKS1: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_by_01234.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/mul_by_01234.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/pairing_chip/line/evaluate_line.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/evaluate_line.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -59,7 +59,7 @@ impl<
         >,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let expr = evaluate_line_expr(config, range_checker.bus());

--- a/extensions/pairing/circuit/src/pairing_chip/line/evaluate_line.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/evaluate_line.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/pairing_chip/line/evaluate_line.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/evaluate_line.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -20,7 +20,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 // Input: UnevaluatedLine<Fp2>, (Fp, Fp)
 // Output: EvaluatedLine<Fp2>
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct EvaluateLineChip<
     F: PrimeField32,
     const INPUT_BLOCKS1: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_023_by_023.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_023_by_023.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -41,7 +41,7 @@ impl<
 {
     pub fn new(
         adapter: Rv32VecHeapAdapterChip<F, 2, INPUT_BLOCKS, OUTPUT_BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         config: ExprBuilderConfig,
         xi: [isize; 2],
         offset: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_023_by_023.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_023_by_023.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -20,7 +20,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 // Input: line0.b, line0.c, line1.b, line1.c <Fp2>: 2 x 4 field elements
 // Output: 5 Fp2 coefficients -> 10 field elements
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct EcLineMul023By023Chip<
     F: PrimeField32,
     const INPUT_BLOCKS: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_023_by_023.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_023_by_023.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_by_02345.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_by_02345.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -22,7 +22,7 @@ use crate::Fp12;
 
 // Input: 2 Fp12: 2 x 12 field elements
 // Output: Fp12 -> 12 field elements
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct EcLineMulBy02345Chip<
     F: PrimeField32,
     const INPUT_BLOCKS1: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_by_02345.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_by_02345.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -59,7 +59,7 @@ impl<
             BLOCK_SIZE,
             BLOCK_SIZE,
         >,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         config: ExprBuilderConfig,
         xi: [isize; 2],
         offset: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_by_02345.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/mul_by_02345.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -43,7 +43,7 @@ impl<
         adapter: Rv32VecHeapAdapterChip<F, 2, INPUT_BLOCKS, OUTPUT_BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let expr = miller_double_and_add_step_expr(config, range_checker.bus());

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -20,7 +20,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 // Input: two AffinePoint<Fp2>: 4 field elements each
 // Output: (AffinePoint<Fp2>, UnevaluatedLine<Fp2>, UnevaluatedLine<Fp2>) -> 2*2 + 2*2 + 2*2 = 12 field elements
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct MillerDoubleAndAddStepChip<
     F: PrimeField32,
     const INPUT_BLOCKS: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
@@ -7,7 +7,9 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
@@ -6,11 +6,11 @@ use std::{
 
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
-use openvm_circuit_derive::{InstructionExecutor, Stateful};
+use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
 };
@@ -20,7 +20,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 // Input: AffinePoint<Fp2>: 4 field elements
 // Output: (AffinePoint<Fp2>, Fp2, Fp2) -> 8 field elements
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, BytesStateful)]
 pub struct MillerDoubleStepChip<
     F: PrimeField32,
     const INPUT_BLOCKS: usize,

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_algebra_circuit::Fp2;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::{InstructionExecutor, Stateful};
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, SharedVariableRangeCheckerChip};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreChip,
@@ -43,7 +43,7 @@ impl<
         adapter: Rv32VecHeapAdapterChip<F, 1, INPUT_BLOCKS, OUTPUT_BLOCKS, BLOCK_SIZE, BLOCK_SIZE>,
         config: ExprBuilderConfig,
         offset: usize,
-        range_checker: Arc<VariableRangeCheckerChip>,
+        range_checker: SharedVariableRangeCheckerChip,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     ) -> Self {
         let expr = miller_double_step_expr(config, range_checker.bus());

--- a/extensions/pairing/circuit/src/pairing_extension.rs
+++ b/extensions/pairing/circuit/src/pairing_extension.rs
@@ -5,11 +5,11 @@ use openvm_circuit::{
     arch::{SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_ecc_circuit::CurveConfig;
 use openvm_instructions::{PhantomDiscriminant, UsizeOpcode, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
@@ -64,7 +64,7 @@ pub struct PairingExtension {
     pub supported_curves: Vec<PairingCurve>,
 }
 
-#[derive(Chip, ChipUsageGetter, InstructionExecutor, AnyEnum, Stateful)]
+#[derive(Chip, ChipUsageGetter, InstructionExecutor, AnyEnum, BytesStateful)]
 pub enum PairingExtensionExecutor<F: PrimeField32> {
     // bn254 (32 limbs)
     MillerDoubleStepRv32_32(MillerDoubleStepChip<F, 4, 8, 32>),
@@ -82,7 +82,7 @@ pub enum PairingExtensionExecutor<F: PrimeField32> {
     EcLineMulBy02345(EcLineMulBy02345Chip<F, 36, 30, 36, 16>),
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, Stateful)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, BytesStateful)]
 pub enum PairingExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     Phantom(PhantomChip<F>),

--- a/extensions/rv32im/circuit/src/adapters/hintstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/hintstore.rs
@@ -2,7 +2,6 @@ use std::{
     array,
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
-    sync::Arc,
 };
 
 use openvm_circuit::{
@@ -19,7 +18,9 @@ use openvm_circuit::{
         program::ProgramBus,
     },
 };
-use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+use openvm_circuit_primitives::var_range::{
+    SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -40,7 +41,7 @@ use crate::adapters::RV32_CELL_BITS;
 /// It writes to the memory at the intermediate pointer.
 pub struct Rv32HintStoreAdapterChip<F: Field> {
     pub air: Rv32HintStoreAdapterAir,
-    pub range_checker_chip: Arc<VariableRangeCheckerChip>,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
     _marker: PhantomData<F>,
 }
 
@@ -50,7 +51,7 @@ impl<F: PrimeField32> Rv32HintStoreAdapterChip<F> {
         program_bus: ProgramBus,
         memory_bridge: MemoryBridge,
         pointer_max_bits: usize,
-        range_checker_chip: Arc<VariableRangeCheckerChip>,
+        range_checker_chip: SharedVariableRangeCheckerChip,
     ) -> Self {
         assert!(range_checker_chip.range_max_bits() >= 16);
         Self {

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -2,7 +2,6 @@ use std::{
     array,
     borrow::{Borrow, BorrowMut},
     marker::PhantomData,
-    sync::Arc,
 };
 
 use openvm_circuit::{
@@ -22,7 +21,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     utils::select,
-    var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -94,7 +93,7 @@ impl<AB: InteractionBuilder> VmAdapterInterface<AB::Expr> for Rv32LoadStoreAdapt
 /// In case of Stores, reads from rs2 and writes to the shifted intermediate pointer.
 pub struct Rv32LoadStoreAdapterChip<F: Field> {
     pub air: Rv32LoadStoreAdapterAir,
-    pub range_checker_chip: Arc<VariableRangeCheckerChip>,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
     offset: usize,
     _marker: PhantomData<F>,
 }
@@ -105,7 +104,7 @@ impl<F: PrimeField32> Rv32LoadStoreAdapterChip<F> {
         program_bus: ProgramBus,
         memory_bridge: MemoryBridge,
         pointer_max_bits: usize,
-        range_checker_chip: Arc<VariableRangeCheckerChip>,
+        range_checker_chip: SharedVariableRangeCheckerChip,
         offset: usize,
     ) -> Self {
         assert!(range_checker_chip.range_max_bits() >= 15);

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -6,12 +6,12 @@ use openvm_circuit::{
     },
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful, VmConfig};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::{program::DEFAULT_PC_STEP, PhantomDiscriminant, UsizeOpcode, VmOpcode};
 use openvm_rv32im_transpiler::{
     BaseAluOpcode, BranchEqualOpcode, BranchLessThanOpcode, DivRemOpcode, LessThanOpcode,
@@ -150,7 +150,7 @@ fn default_range_tuple_checker_sizes() -> [u32; 2] {
 // ============ Executor and Periphery Enums for Extension ============
 
 /// RISC-V 32-bit Base (RV32I) Instruction Executors
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum Rv32IExecutor<F: PrimeField32> {
     // Rv32 (for standard 32-bit integers):
     BaseAlu(Rv32BaseAluChip<F>),
@@ -166,7 +166,7 @@ pub enum Rv32IExecutor<F: PrimeField32> {
 }
 
 /// RISC-V 32-bit Multiplication Extension (RV32M) Instruction Executors
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum Rv32MExecutor<F: PrimeField32> {
     Multiplication(Rv32MultiplicationChip<F>),
     MultiplicationHigh(Rv32MulHChip<F>),
@@ -174,19 +174,19 @@ pub enum Rv32MExecutor<F: PrimeField32> {
 }
 
 /// RISC-V 32-bit Io Instruction Executors
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum Rv32IoExecutor<F: PrimeField32> {
     HintStore(Rv32HintStoreChip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum Rv32IPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     // We put this only to get the <F> generic to work
     Phantom(PhantomChip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum Rv32MPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     /// Only needed for multiplication extension
@@ -195,7 +195,7 @@ pub enum Rv32MPeriphery<F: PrimeField32> {
     Phantom(PhantomChip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum Rv32IoPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     // We put this only to get the <F> generic to work

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -1,7 +1,6 @@
 use std::{
     array,
     borrow::{Borrow, BorrowMut},
-    sync::Arc,
 };
 
 use openvm_circuit::arch::{
@@ -10,7 +9,7 @@ use openvm_circuit::arch::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -175,13 +174,13 @@ where
 pub struct Rv32JalrCoreChip {
     pub air: Rv32JalrCoreAir,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
-    pub range_checker_chip: Arc<VariableRangeCheckerChip>,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
 impl Rv32JalrCoreChip {
     pub fn new(
         bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
-        range_checker_chip: Arc<VariableRangeCheckerChip>,
+        range_checker_chip: SharedVariableRangeCheckerChip,
         offset: usize,
     ) -> Self {
         assert!(range_checker_chip.range_max_bits() >= 16);

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -1,7 +1,6 @@
 use std::{
     array,
     borrow::{Borrow, BorrowMut},
-    sync::Arc,
 };
 
 use openvm_circuit::arch::{
@@ -9,7 +8,7 @@ use openvm_circuit::arch::{
 };
 use openvm_circuit_primitives::{
     utils::select,
-    var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, UsizeOpcode};
@@ -176,11 +175,11 @@ where
 
 pub struct LoadSignExtendCoreChip<const NUM_CELLS: usize, const LIMB_BITS: usize> {
     pub air: LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>,
-    pub range_checker_chip: Arc<VariableRangeCheckerChip>,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
 impl<const NUM_CELLS: usize, const LIMB_BITS: usize> LoadSignExtendCoreChip<NUM_CELLS, LIMB_BITS> {
-    pub fn new(range_checker_chip: Arc<VariableRangeCheckerChip>, offset: usize) -> Self {
+    pub fn new(range_checker_chip: SharedVariableRangeCheckerChip, offset: usize) -> Self {
         Self {
             air: LoadSignExtendCoreAir::<NUM_CELLS, LIMB_BITS> {
                 range_bus: range_checker_chip.bus(),

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -1,7 +1,6 @@
 use std::{
     array,
     borrow::{Borrow, BorrowMut},
-    sync::Arc,
 };
 
 use openvm_circuit::arch::{
@@ -11,7 +10,7 @@ use openvm_circuit::arch::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, UsizeOpcode};
@@ -252,13 +251,13 @@ pub struct ShiftCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 pub struct ShiftCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub air: ShiftCoreAir<NUM_LIMBS, LIMB_BITS>,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
-    pub range_checker_chip: Arc<VariableRangeCheckerChip>,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
 impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftCoreChip<NUM_LIMBS, LIMB_BITS> {
     pub fn new(
         bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
-        range_checker_chip: Arc<VariableRangeCheckerChip>,
+        range_checker_chip: SharedVariableRangeCheckerChip,
         offset: usize,
     ) -> Self {
         assert_eq!(NUM_LIMBS % 2, 0, "Number of limbs must be divisible by 2");

--- a/extensions/sha256/circuit/src/extension.rs
+++ b/extensions/sha256/circuit/src/extension.rs
@@ -6,11 +6,11 @@ use openvm_circuit::{
     },
     system::phantom::PhantomChip,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, Stateful, VmConfig};
+use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_primitives_derive::{BytesStateful, Chip, ChipUsageGetter};
 use openvm_instructions::*;
 use openvm_rv32im_circuit::{
     Rv32I, Rv32IExecutor, Rv32IPeriphery, Rv32Io, Rv32IoExecutor, Rv32IoPeriphery, Rv32M,
@@ -52,12 +52,12 @@ impl Default for Sha256Rv32Config {
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct Sha256;
 
-#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, Stateful)]
+#[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum, BytesStateful)]
 pub enum Sha256Executor<F: PrimeField32> {
     Sha256(Sha256VmChip<F>),
 }
 
-#[derive(From, ChipUsageGetter, Chip, AnyEnum, Stateful)]
+#[derive(From, ChipUsageGetter, Chip, AnyEnum, BytesStateful)]
 pub enum Sha256Periphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     Phantom(PhantomChip<F>),


### PR DESCRIPTION
1st commit:
- Implement `Stateful` for system chips.
- Implement `SharedVariableRangeCheckerChip`.

2st commit:
- Implement `Stateful` for `VmChipComplex`.
- Add `ExecutionSegment::new_for_proving` which constructs a `ExecutionSegment` just for proving.
- Add `ExecutionSegment::store_chip_complex_state` to store states.

Note: some memory states need to clone. We should to try to avoid it in the future.

closes INT-2951