### PR TITLE
Feat: new segmentation rule

### DIFF
--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -19,6 +19,14 @@ use super::{
 use crate::system::memory::BOUNDARY_AIR_OFFSET;
 
 const DEFAULT_MAX_SEGMENT_LEN: usize = (1 << 22) - 100;
+
+// a heuristic number for the maximum number of cells per chip in a segment
+// a few reasons for this number:
+//  1. `VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<4, 8>` is
+//    the chip with the most cells in a segment from the reth-benchmark.
+//  2. `VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<4, 8>`:
+//    its trace width is 36 and its after challenge trace width is 80.
+const DEFAULT_MAX_CELLS_PER_CHIP_IN_SEGMENT: usize = DEFAULT_MAX_SEGMENT_LEN * 120;
 // sbox is decomposed to have this max degree for Poseidon2. We set to 3 so quotient_degree = 2
 // allows log_blowup = 1
 const DEFAULT_POSEIDON2_MAX_CONSTRAINT_DEGREE: usize = 3;
@@ -88,6 +96,9 @@ pub struct SystemConfig {
     pub num_public_values: usize,
     /// When continuations are enabled, a heuristic used to determine when to segment execution.
     pub max_segment_len: usize,
+    /// When continuations are enabled, whenever a chip has more than this number of cells,
+    /// a new segment is created.
+    pub max_cells_per_chip_in_segment: usize,
     /// Whether to collect detailed profiling metrics.
     /// **Warning**: this slows down the runtime.
     pub profiling: bool,
@@ -111,6 +122,7 @@ impl SystemConfig {
             memory_config,
             num_public_values,
             max_segment_len: DEFAULT_MAX_SEGMENT_LEN,
+            max_cells_per_chip_in_segment: DEFAULT_MAX_CELLS_PER_CHIP_IN_SEGMENT,
             profiling: false,
         }
     }
@@ -137,6 +149,11 @@ impl SystemConfig {
 
     pub fn with_max_segment_len(mut self, max_segment_len: usize) -> Self {
         self.max_segment_len = max_segment_len;
+        self
+    }
+
+    pub fn with_max_cells_per_chip_in_segment(mut self, max_cells_per_chip_in_segment: usize) -> Self {
+        self.max_cells_per_chip_in_segment = max_cells_per_chip_in_segment;
         self
     }
 

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -251,6 +251,7 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
             return false;
         }
         self.since_last_segment_check = 0;
+
         let heights = self.chip_complex.dynamic_trace_heights();
         for (i, height) in heights.enumerate() {
             if height > self.system_config().max_segment_len {
@@ -262,7 +263,17 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
                 return true;
             }
         }
-
+        for (i, num_cells) in self.current_trace_cells().into_iter().enumerate() {
+            if num_cells > self.system_config().max_cells_per_chip_in_segment {
+                tracing::info!(
+                    "Should segment because chip {} has {} cells which exceeds limit {}",
+                    self.air_names[i],
+                    num_cells,
+                    self.system_config().max_cells_per_chip_in_segment,
+                );
+                return true;
+            }
+        }
         false
     }
 


### PR DESCRIPTION
## Issue
The current segmentation rule is whenever any chip's height exceed the limit, a new segment is created. But the total memory needed to store chip's trace matrices is not only dominated by its height, but also by its width.

In practice, it will happen that a wide chip like `KeccakVmAir` (`Prep Cols = 0, Main Cols = 3164, Perm Cols = 1288`) includes many inputs (e.g. `2^19` rows) but this height is still less than the limit (e.g. `2^21`). In this case, the total number of cells in all chips may exceed some limit like GPU memory size.

In practice (e.g. proving [reth](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/12605224576/job/35133524341) guest program), we have seen rows' distribution of `KeccakVmAir` like this:
| Segment number | Rows | Cells |
|-|-|-|
| 0 | Rows = 1 | Cells = 4_452 |
| 1 | Rows = 1 | Cells = 4_452 |
| 2 | Rows = 524_288  | Cells = 2_334_130_176 | 
| 3 | Rows = 65_536   | Cells = 291_766_272   |
| 4 | Rows = 16_384   | Cells = 72_941_568  |
| 5 | Rows = 16_384   | Cells = 72_941_568 |
| 6 | Rows = 16_384   | Cells = 72_941_568 |
| 7 | Rows = 131_072  | Cells = 583_532_544 |
| 8 | Rows = 524_288  | Cells = 2_334_130_176 |

## Changes
Therefor in this PR, we add a new segmentation rule to allow the creation of new segment when the number of cells in any one of the chips has exceed limit.