### PR TITLE
chore: replace num-bigint-dig with num-bigint throughout

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,0 @@
-[patch."https://github.com/openvm-org/openvm.git"]
-openvm = { path = "crates/toolchain/openvm" }
-openvm-platform = { path = "crates/toolchain/platform" }
-openvm-algebra-guest = { path = "extensions/algebra/guest" }
-openvm-algebra-moduli-setup = { path = "extensions/algebra/moduli-setup" }
-openvm-algebra-complex-macros = { path = "extensions/algebra/guest/src/field/complex-macros" }
-openvm-bigint-guest = { path = "extensions/bigint/guest" }
-openvm-ecc-guest = { path = "extensions/ecc/guest" }
-openvm-pairing-guest = { path = "extensions/pairing/guest" }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,8 @@
 openvm = { path = "crates/toolchain/openvm" }
 openvm-platform = { path = "crates/toolchain/platform" }
 openvm-algebra-guest = { path = "extensions/algebra/guest" }
+openvm-algebra-moduli-setup = { path = "extensions/algebra/moduli-setup" }
 openvm-algebra-complex-macros = { path = "extensions/algebra/guest/src/field/complex-macros" }
+openvm-bigint-guest = { path = "extensions/bigint/guest" }
+openvm-ecc-guest = { path = "extensions/ecc/guest" }
+openvm-pairing-guest = { path = "extensions/pairing/guest" }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[patch."https://github.com/openvm-org/openvm.git"]
+openvm = { path = "crates/toolchain/openvm" }
+openvm-platform = { path = "crates/toolchain/platform" }
+openvm-algebra-guest = { path = "extensions/algebra/guest" }
+openvm-algebra-complex-macros = { path = "extensions/algebra/guest/src/field/complex-macros" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,6 @@ dependencies = [
  "eyre",
  "goblin",
  "hex",
- "num-bigint-dig",
  "openvm-build",
  "openvm-circuit",
  "openvm-keccak256-circuit",
@@ -3226,23 +3225,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
  "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -3376,7 +3359,7 @@ dependencies = [
  "bytemuck",
  "chrono",
  "hex-literal",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-traits",
  "openvm-platform",
  "openvm-rv32im-guest",
@@ -3391,7 +3374,7 @@ dependencies = [
  "derive_more 1.0.0",
  "halo2curves-axiom",
  "itertools 0.13.0",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-traits",
  "openvm-algebra-transpiler",
  "openvm-circuit",
@@ -3427,7 +3410,7 @@ name = "openvm-algebra-guest"
 version = "0.2.0-alpha"
 dependencies = [
  "halo2curves-axiom",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "openvm",
  "openvm-algebra-complex-macros",
  "openvm-algebra-moduli-setup",
@@ -3451,7 +3434,7 @@ name = "openvm-algebra-tests"
 version = "0.2.0-alpha"
 dependencies = [
  "eyre",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
@@ -3494,7 +3477,7 @@ dependencies = [
  "hex",
  "k256",
  "metrics",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
  "openvm-build",
@@ -3552,7 +3535,7 @@ dependencies = [
 name = "openvm-bigint-guest"
 version = "0.2.0-alpha"
 dependencies = [
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-traits",
  "openvm",
  "openvm-platform",
@@ -3565,7 +3548,6 @@ name = "openvm-bigint-integration-tests"
 version = "0.2.0-alpha"
 dependencies = [
  "eyre",
- "num-bigint-dig",
  "openvm",
  "openvm-bigint-circuit",
  "openvm-bigint-transpiler",
@@ -3680,7 +3662,7 @@ dependencies = [
  "derive-new",
  "itertools 0.13.0",
  "lazy_static",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit-primitives-derive",
  "openvm-stark-backend",
@@ -3723,7 +3705,7 @@ dependencies = [
  "eyre",
  "itertools 0.13.0",
  "lazy_static",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "once_cell",
@@ -3759,7 +3741,6 @@ dependencies = [
  "k256",
  "lazy_static",
  "num-bigint 0.4.6",
- "num-bigint-dig",
  "num-traits",
  "openvm",
  "openvm-algebra-guest",
@@ -3822,7 +3803,7 @@ dependencies = [
  "backtrace",
  "derive-new",
  "itertools 0.13.0",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-traits",
  "openvm-instructions-derive",
  "openvm-stark-backend",
@@ -3932,7 +3913,7 @@ dependencies = [
  "hex-literal",
  "itertools 0.13.0",
  "lazy_static",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit",
  "openvm-circuit-primitives",
@@ -4099,7 +4080,7 @@ dependencies = [
  "eyre",
  "halo2curves-axiom",
  "itertools 0.13.0",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "num-traits",
  "once_cell",
  "openvm-algebra-circuit",
@@ -4132,7 +4113,6 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "num-bigint 0.4.6",
- "num-bigint-dig",
  "num-traits",
  "openvm",
  "openvm-algebra-complex-macros",
@@ -4153,7 +4133,6 @@ name = "openvm-pairing-integration-tests"
 version = "0.2.0-alpha"
 dependencies = [
  "eyre",
- "num-bigint-dig",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
@@ -4547,7 +4526,7 @@ version = "0.2.0-alpha"
 dependencies = [
  "derive_more 1.0.0",
  "eyre",
- "num-bigint-dig",
+ "num-bigint 0.4.6",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
@@ -4587,7 +4566,6 @@ dependencies = [
  "derive_more 1.0.0",
  "elf",
  "eyre",
- "num-bigint-dig",
  "openvm-algebra-transpiler",
  "openvm-build",
  "openvm-circuit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,6 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 k256 = { version = "0.13.3", default-features = false }
 elliptic-curve = { version = "0.13.8", default-features = false }
 ecdsa = { version = "0.16.9", default-features = false }
-num-bigint-dig = { version = "0.8.4", default-features = false }
 num-bigint = { version = "0.4.6", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -40,7 +40,7 @@ k256 = { workspace = true, features = ["ecdsa"] }
 tiny-keccak.workspace = true
 derive-new.workspace = true
 derive_more = { workspace = true, features = ["from"] }
-num-bigint-dig = { workspace = true, features = ["std", "serde"] }
+num-bigint = { workspace = true, features = ["std", "serde"] }
 serde.workspace = true
 bincode = { version = "2.0.0-rc.3" }
 

--- a/benchmarks/src/bin/ecrecover.rs
+++ b/benchmarks/src/bin/ecrecover.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use derive_more::derive::From;
 use eyre::Result;
 use k256::ecdsa::{SigningKey, VerifyingKey};
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_circuit::{
     ModularExtension, ModularExtensionExecutor, ModularExtensionPeriphery,
 };

--- a/crates/circuits/mod-builder/Cargo.toml
+++ b/crates/circuits/mod-builder/Cargo.toml
@@ -18,7 +18,7 @@ halo2curves-axiom = { workspace = true, optional = true }
 openvm-pairing-guest = { workspace = true, optional = true }
 
 rand.workspace = true
-num-bigint-dig.workspace = true
+num-bigint.workspace = true
 num-traits.workspace = true
 tracing.workspace = true
 

--- a/crates/circuits/mod-builder/src/builder.rs
+++ b/crates/circuits/mod-builder/src/builder.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, ops::Deref, rc::Rc};
 
-use num_bigint_dig::{BigInt, BigUint, Sign};
+use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::Zero;
 use openvm_circuit_primitives::{
     bigint::{
@@ -31,7 +31,7 @@ pub struct ExprBuilderConfig {
 
 impl ExprBuilderConfig {
     pub fn check_valid(&self) {
-        assert!(self.modulus.bits() <= self.num_limbs * self.limb_bits);
+        assert!(self.modulus.bits() <= (self.num_limbs * self.limb_bits) as u64);
     }
 }
 

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_circuit::arch::{
     AdapterAirContext, AdapterRuntimeContext, DynAdapterInterface, DynArray, MinimalInstruction,
     Result, VmAdapterInterface, VmCoreAir, VmCoreChip,

--- a/crates/circuits/mod-builder/src/test_utils/bls12381.rs
+++ b/crates/circuits/mod-builder/src/test_utils/bls12381.rs
@@ -2,7 +2,7 @@ use halo2curves_axiom::{
     bls12_381::{Fq, Fq12, Fq2},
     ff::Field,
 };
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_pairing_guest::algebra::field::FieldExtension;
 use openvm_stark_sdk::utils::create_seeded_rng_with_seed;
 

--- a/crates/circuits/mod-builder/src/test_utils/bn254.rs
+++ b/crates/circuits/mod-builder/src/test_utils/bn254.rs
@@ -2,7 +2,7 @@ use halo2curves_axiom::{
     bn256::{Fq, Fq12, Fq2},
     ff::Field,
 };
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_pairing_guest::algebra::field::FieldExtension;
 use openvm_stark_sdk::utils::create_seeded_rng_with_seed;
 

--- a/crates/circuits/mod-builder/src/test_utils/mod.rs
+++ b/crates/circuits/mod-builder/src/test_utils/mod.rs
@@ -1,6 +1,6 @@
 use std::{array, cell::RefCell, rc::Rc, sync::Arc};
 
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use openvm_circuit::utils::generate_long_number;
 use openvm_circuit_primitives::{

--- a/crates/circuits/mod-builder/src/tests.rs
+++ b/crates/circuits/mod-builder/src/tests.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_circuit_primitives::{bigint::utils::*, TraceSubRowGenerator};
 use openvm_stark_backend::{
     p3_air::BaseAir, p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix,
@@ -64,7 +64,7 @@ fn test_div() {
 
     let x = generate_random_biguint(&prime);
     let y = generate_random_biguint(&prime);
-    let y_inv = big_uint_mod_inverse(&y, &prime);
+    let y_inv = y.modinv(&prime).unwrap();
     let expected = (&x * &y_inv) % prime;
     let inputs = vec![x, y];
 

--- a/crates/circuits/mod-builder/src/utils.rs
+++ b/crates/circuits/mod-builder/src/utils.rs
@@ -1,4 +1,4 @@
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 
 // little endian.

--- a/crates/circuits/primitives/Cargo.toml
+++ b/crates/circuits/primitives/Cargo.toml
@@ -15,7 +15,7 @@ openvm-circuit-primitives-derive = { workspace = true }
 rand.workspace = true
 derive-new.workspace = true
 itertools.workspace = true
-num-bigint-dig.workspace = true
+num-bigint.workspace = true
 num-traits.workspace = true
 lazy_static.workspace = true
 tracing.workspace = true

--- a/crates/circuits/primitives/src/bigint/check_carry_mod_to_zero.rs
+++ b/crates/circuits/primitives/src/bigint/check_carry_mod_to_zero.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::FieldAlgebra};
 
 use super::{

--- a/crates/circuits/primitives/src/bigint/mod.rs
+++ b/crates/circuits/primitives/src/bigint/mod.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Sub},
 };
 
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_stark_backend::p3_util::log2_ceil_usize;
 
 pub mod check_carry_mod_to_zero;

--- a/crates/circuits/primitives/src/bigint/utils.rs
+++ b/crates/circuits/primitives/src/bigint/utils.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Cow, cmp::max, collections::VecDeque, iter::repeat, ops::Neg, str::FromStr};
+use std::{cmp::max, collections::VecDeque, iter::repeat, ops::Neg, str::FromStr};
 
-use num_bigint_dig::{algorithms::mod_inverse, BigInt, BigUint, Sign};
+use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::{FromPrimitive, Num, One, ToPrimitive, Zero};
 use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::PrimeField64};
 
@@ -72,13 +72,6 @@ pub fn big_uint_sub(x: BigUint, y: BigUint) -> BigInt {
         std::cmp::Ordering::Equal => BigInt::zero(),
         std::cmp::Ordering::Greater => BigInt::from_biguint(Sign::Plus, x - y),
     }
-}
-
-pub fn big_uint_mod_inverse(x: &BigUint, modulus: &BigUint) -> BigUint {
-    mod_inverse(Cow::Borrowed(x), Cow::Borrowed(modulus))
-        .unwrap()
-        .to_biguint()
-        .unwrap()
 }
 
 // little endian.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,7 +51,6 @@ prettytable-rs = "0.10"
 textwrap = "0.16.0"
 ctrlc = "3.4.2"
 toml = { workspace = true }
-num-bigint-dig = { workspace = true, features = ["serde"] }
 
 [features]
 default = ["parallel", "mimalloc"]

--- a/crates/toolchain/instructions/Cargo.toml
+++ b/crates/toolchain/instructions/Cargo.toml
@@ -17,7 +17,7 @@ itertools.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 serde.workspace = true
-num-bigint-dig.workspace = true
+num-bigint.workspace = true
 num-traits.workspace = true
 
 [dev-dependencies]

--- a/crates/toolchain/instructions/src/utils.rs
+++ b/crates/toolchain/instructions/src/utils.rs
@@ -1,4 +1,4 @@
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::Num;
 use openvm_stark_backend::p3_field::Field;
 

--- a/crates/toolchain/openvm/Cargo.toml
+++ b/crates/toolchain/openvm/Cargo.toml
@@ -19,7 +19,7 @@ hex-literal.workspace = true
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-num-bigint-dig.workspace = true
+num-bigint.workspace = true
 num-traits.workspace = true
 
 [dev-dependencies]

--- a/crates/toolchain/openvm/src/utils.rs
+++ b/crates/toolchain/openvm/src/utils.rs
@@ -1,8 +1,5 @@
 #[cfg(not(target_os = "zkvm"))]
-use num_bigint_dig::{
-    traits::ModInverse,
-    {BigUint, Sign, ToBigInt},
-};
+use num_bigint::BigUint;
 
 #[inline]
 #[cfg(not(target_os = "zkvm"))]
@@ -12,19 +9,4 @@ pub fn biguint_to_limbs<const NUM_LIMBS: usize>(x: &BigUint) -> [u8; NUM_LIMBS] 
     let mut sm = x.to_bytes_le();
     sm.resize(NUM_LIMBS, 0);
     sm.try_into().unwrap()
-}
-
-#[inline]
-#[cfg(not(target_os = "zkvm"))]
-#[allow(dead_code)]
-/// Find the modular inverse of BigUint 'x'
-pub fn uint_mod_inverse(x: &BigUint, modulus: &BigUint) -> BigUint {
-    let signed_inv = x.mod_inverse(modulus).unwrap();
-    if signed_inv.sign() == Sign::Minus {
-        modulus.to_bigint().unwrap() + signed_inv
-    } else {
-        signed_inv
-    }
-    .to_biguint()
-    .unwrap()
 }

--- a/crates/toolchain/tests/Cargo.toml
+++ b/crates/toolchain/tests/Cargo.toml
@@ -47,7 +47,7 @@ derive_more = { workspace = true, features = ["from"] }
 openvm-circuit-derive.workspace = true
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-num-bigint-dig.workspace = true
+num-bigint.workspace = true
 
 [features]
 default = ["parallel"]

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use derive_more::derive::From;
 use eyre::Result;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_circuit::{
     Fp2Extension, Fp2ExtensionExecutor, Fp2ExtensionPeriphery, ModularExtension,
     ModularExtensionExecutor, ModularExtensionPeriphery,

--- a/crates/toolchain/transpiler/Cargo.toml
+++ b/crates/toolchain/transpiler/Cargo.toml
@@ -16,7 +16,6 @@ eyre.workspace = true
 thiserror.workspace = true
 elf = "0.7.4"
 rrs-lib.workspace = true
-num-bigint-dig.workspace = true
 tracing.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 

--- a/examples/algebra/Cargo.toml
+++ b/examples/algebra/Cargo.toml
@@ -12,6 +12,7 @@ openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
 openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git" }
 openvm-algebra-complex-macros = { git = "https://github.com/openvm-org/openvm.git" }
 serde = { version = "1.0.216", default-features = false }
+num-bigint = { version = "0.4.6", default-features = false, features = ["serde"] }
 
 [features]
 default = []

--- a/examples/algebra/Cargo.toml
+++ b/examples/algebra/Cargo.toml
@@ -12,9 +12,6 @@ openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
 openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git" }
 openvm-algebra-complex-macros = { git = "https://github.com/openvm-org/openvm.git" }
 serde = { version = "1.0.216", default-features = false }
-num-bigint-dig = { version = "0.8.4", default-features = false, features = [
-    "serde",
-] }
 
 [features]
 default = []

--- a/extensions/algebra/circuit/Cargo.toml
+++ b/extensions/algebra/circuit/Cargo.toml
@@ -21,7 +21,7 @@ openvm-rv32-adapters = { workspace = true }
 openvm-algebra-transpiler = { workspace = true }
 
 itertools = { workspace = true }
-num-bigint-dig = { workspace = true, features = ["serde"] }
+num-bigint = { workspace = true, features = ["serde"] }
 num-traits = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true }

--- a/extensions/algebra/circuit/src/config.rs
+++ b/extensions/algebra/circuit/src/config.rs
@@ -1,5 +1,5 @@
 use derive_more::derive::From;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_circuit::arch::{
     SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmInventoryError,
 };

--- a/extensions/algebra/circuit/src/fp2.rs
+++ b/extensions/algebra/circuit/src/fp2.rs
@@ -167,7 +167,7 @@ impl Fp2 {
 #[cfg(test)]
 mod tests {
     use halo2curves_axiom::bn256::Fq2;
-    use num_bigint_dig::BigUint;
+    use num_bigint::BigUint;
     use openvm_circuit_primitives::TraceSubRowGenerator;
     use openvm_mod_circuit_builder::{test_utils::*, FieldExpr, FieldExprCols};
     use openvm_pairing_guest::bn254::BN254_MODULUS;

--- a/extensions/algebra/circuit/src/fp2_extension.rs
+++ b/extensions/algebra/circuit/src/fp2_extension.rs
@@ -1,5 +1,5 @@
 use derive_more::derive::From;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_circuit::{
     arch::{SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -3,7 +3,7 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::arch::{
     AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -1,15 +1,13 @@
 use std::array::from_fn;
 
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::Zero;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::arch::{
     instructions::UsizeOpcode, testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
 };
 use openvm_circuit_primitives::{
-    bigint::utils::{
-        big_uint_mod_inverse, big_uint_to_limbs, secp256k1_coord_prime, secp256k1_scalar_prime,
-    },
+    bigint::utils::{big_uint_to_limbs, secp256k1_coord_prime, secp256k1_scalar_prime},
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
 };
 use openvm_instructions::{instruction::Instruction, riscv::RV32_CELL_BITS, VmOpcode};
@@ -241,7 +239,7 @@ fn test_muldiv(opcode_offset: usize, modulus: BigUint) {
         }
         let expected_answer = match op - MUL_LOCAL {
             0 => (&a * &b) % &modulus,
-            1 => (&a * big_uint_mod_inverse(&b, &modulus)) % &modulus,
+            1 => (&a * b.modinv(&modulus).unwrap()) % &modulus,
             2 => a.clone() % &modulus,
             _ => panic!(),
         };

--- a/extensions/algebra/circuit/src/modular_extension.rs
+++ b/extensions/algebra/circuit/src/modular_extension.rs
@@ -1,5 +1,5 @@
 use derive_more::derive::From;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{
     self,

--- a/extensions/algebra/guest/Cargo.toml
+++ b/extensions/algebra/guest/Cargo.toml
@@ -17,7 +17,7 @@ serde-big-array = "0.5.1"
 strum_macros = { workspace = true }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-num-bigint-dig.workspace = true
+num-bigint.workspace = true
 halo2curves-axiom = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/extensions/algebra/guest/src/lib.rs
+++ b/extensions/algebra/guest/src/lib.rs
@@ -51,7 +51,7 @@ use core::{
 
 pub use field::Field;
 #[cfg(not(target_os = "zkvm"))]
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 pub use openvm_algebra_complex_macros as complex_macros;
 pub use openvm_algebra_moduli_setup as moduli_setup;
 pub use serde_big_array::BigArray;

--- a/extensions/algebra/moduli-setup/src/lib.rs
+++ b/extensions/algebra/moduli-setup/src/lib.rs
@@ -195,7 +195,7 @@ pub fn moduli_declare(input: TokenStream) -> TokenStream {
                     #[cfg(not(target_os = "zkvm"))]
                     {
                         let modulus = Self::modulus_biguint();
-                        let inv = openvm::utils::uint_mod_inverse(&other.as_biguint(), &modulus);
+                        let inv = other.as_biguint().modinv(&modulus).unwrap();
                         *self = Self::from_biguint((self.as_biguint() * inv) % modulus);
                     }
                     #[cfg(target_os = "zkvm")]
@@ -287,7 +287,7 @@ pub fn moduli_declare(input: TokenStream) -> TokenStream {
                     #[cfg(not(target_os = "zkvm"))]
                     {
                         let modulus = Self::modulus_biguint();
-                        let inv = openvm::utils::uint_mod_inverse(&other.as_biguint(), &modulus);
+                        let inv = other.as_biguint().modinv(&modulus).unwrap();
                         Self::from_biguint((self.as_biguint() * inv) % modulus)
                     }
                     #[cfg(target_os = "zkvm")]
@@ -380,18 +380,18 @@ pub fn moduli_declare(input: TokenStream) -> TokenStream {
                     }
 
                     #[cfg(not(target_os = "zkvm"))]
-                    fn modulus_biguint() -> num_bigint_dig::BigUint {
-                        num_bigint_dig::BigUint::from_bytes_le(&Self::MODULUS)
+                    fn modulus_biguint() -> num_bigint::BigUint {
+                        num_bigint::BigUint::from_bytes_le(&Self::MODULUS)
                     }
 
                     #[cfg(not(target_os = "zkvm"))]
-                    fn from_biguint(biguint: num_bigint_dig::BigUint) -> Self {
+                    fn from_biguint(biguint: num_bigint::BigUint) -> Self {
                         Self(openvm::utils::biguint_to_limbs(&biguint))
                     }
 
                     #[cfg(not(target_os = "zkvm"))]
-                    fn as_biguint(&self) -> num_bigint_dig::BigUint {
-                        num_bigint_dig::BigUint::from_bytes_le(self.as_le_bytes())
+                    fn as_biguint(&self) -> num_bigint::BigUint {
+                        num_bigint::BigUint::from_bytes_le(self.as_le_bytes())
                     }
 
                     fn neg_assign(&mut self) {

--- a/extensions/algebra/tests/Cargo.toml
+++ b/extensions/algebra/tests/Cargo.toml
@@ -22,8 +22,7 @@ openvm = { workspace = true }
 openvm-toolchain-tests = { path = "../../../crates/toolchain/tests" }
 openvm-ecc-circuit.workspace = true
 eyre.workspace = true
-num-bigint-dig.workspace = true
-
+num-bigint.workspace = true
 
 [features]
 default = ["parallel"]

--- a/extensions/algebra/tests/programs/Cargo.toml
+++ b/extensions/algebra/tests/programs/Cargo.toml
@@ -11,6 +11,7 @@ openvm-platform = { path = "../../../../crates/toolchain/platform" }
 openvm-algebra-guest = { path = "../../guest" }
 openvm-algebra-moduli-setup = { path = "../../moduli-setup", default-features = false }
 openvm-algebra-complex-macros = { path = "../../guest/src/field/complex-macros", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = [
     "alloc",
     "derive",

--- a/extensions/algebra/tests/programs/Cargo.toml
+++ b/extensions/algebra/tests/programs/Cargo.toml
@@ -11,7 +11,6 @@ openvm-platform = { path = "../../../../crates/toolchain/platform" }
 openvm-algebra-guest = { path = "../../guest" }
 openvm-algebra-moduli-setup = { path = "../../moduli-setup", default-features = false }
 openvm-algebra-complex-macros = { path = "../../guest/src/field/complex-macros", default-features = false }
-num-bigint-dig = { version = "0.8", default-features = false }
 serde = { version = "1.0", default-features = false, features = [
     "alloc",
     "derive",

--- a/extensions/algebra/tests/src/lib.rs
+++ b/extensions/algebra/tests/src/lib.rs
@@ -3,7 +3,7 @@ mod tests {
     use std::str::FromStr;
 
     use eyre::Result;
-    use num_bigint_dig::BigUint;
+    use num_bigint::BigUint;
     use openvm_algebra_circuit::{Rv32ModularConfig, Rv32ModularWithFp2Config};
     use openvm_algebra_transpiler::{Fp2TranspilerExtension, ModularTranspilerExtension};
     use openvm_circuit::utils::air_test;

--- a/extensions/bigint/guest/Cargo.toml
+++ b/extensions/bigint/guest/Cargo.toml
@@ -15,7 +15,7 @@ strum_macros = { workspace = true }
 serde = { workspace = true, features = ["alloc"] }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-num-bigint-dig.workspace = true
+num-bigint.workspace = true
 num-traits.workspace = true
 
 [features]

--- a/extensions/bigint/guest/src/i256.rs
+++ b/extensions/bigint/guest/src/i256.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(not(target_os = "zkvm"))]
-use {super::bigint_to_limbs, num_bigint_dig::BigInt};
+use {super::bigint_to_limbs, num_bigint::BigInt};
 #[cfg(target_os = "zkvm")]
 use {
     super::{Int256Funct7, BEQ256_FUNCT3, INT256_FUNCT3, OPCODE},

--- a/extensions/bigint/guest/src/u256.rs
+++ b/extensions/bigint/guest/src/u256.rs
@@ -13,7 +13,7 @@ use {
     openvm_platform::custom_insn_r,
 };
 #[cfg(not(target_os = "zkvm"))]
-use {num_bigint_dig::BigUint, num_traits::One, openvm::utils::biguint_to_limbs};
+use {num_bigint::BigUint, num_traits::One, openvm::utils::biguint_to_limbs};
 
 use crate::impl_bin_op;
 

--- a/extensions/bigint/guest/src/utils.rs
+++ b/extensions/bigint/guest/src/utils.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_os = "zkvm"))]
-use num_bigint_dig::BigInt;
+use num_bigint::BigInt;
 
 #[inline]
 #[cfg(not(target_os = "zkvm"))]

--- a/extensions/bigint/tests/Cargo.toml
+++ b/extensions/bigint/tests/Cargo.toml
@@ -22,9 +22,6 @@ openvm = { workspace = true }
 openvm-toolchain-tests = { path = "../../../crates/toolchain/tests" }
 eyre.workspace = true
 
-[target.'cfg(not(target_os = "zkvm"))'.dependencies]
-num-bigint-dig.workspace = true
-
 [features]
 default = ["parallel"]
 parallel = ["openvm-circuit/parallel"]

--- a/extensions/ecc/circuit/Cargo.toml
+++ b/extensions/ecc/circuit/Cargo.toml
@@ -20,7 +20,7 @@ openvm-algebra-circuit = { workspace = true }
 openvm-rv32-adapters = { workspace = true }
 openvm-ecc-transpiler = { workspace = true }
 
-num-bigint-dig = { workspace = true }
+num-bigint = { workspace = true }
 num-traits = { workspace = true }
 strum = { workspace = true }
 derive_more = { workspace = true }

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, iter, rc::Rc};
 
 use itertools::{zip_eq, Itertools};
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::One;
 use openvm_circuit::arch::{
     AdapterAirContext, AdapterRuntimeContext, DynAdapterInterface, DynArray, MinimalInstruction,

--- a/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use std::sync::Mutex;
 
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_circuit::{arch::VmChipWrapper, system::memory::OfflineMemory};
 use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::var_range::SharedVariableRangeCheckerChip;

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Num, Zero};
 use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
 use openvm_circuit_primitives::{

--- a/extensions/ecc/circuit/src/weierstrass_extension.rs
+++ b/extensions/ecc/circuit/src/weierstrass_extension.rs
@@ -1,5 +1,5 @@
 use derive_more::derive::From;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Zero};
 use once_cell::sync::Lazy;
 use openvm_algebra_guest::IntMod;
@@ -224,7 +224,7 @@ pub(crate) mod phantom {
     use std::iter::repeat;
 
     use eyre::bail;
-    use num_bigint_dig::BigUint;
+    use num_bigint::BigUint;
     use num_integer::Integer;
     use num_traits::One;
     use openvm_circuit::{

--- a/extensions/ecc/guest/Cargo.toml
+++ b/extensions/ecc/guest/Cargo.toml
@@ -30,7 +30,6 @@ halo2curves-axiom = { workspace = true, optional = true }
 group = "0.13.0"
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-num-bigint-dig.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
 lazy_static.workspace = true

--- a/extensions/ecc/guest/src/k256.rs
+++ b/extensions/ecc/guest/src/k256.rs
@@ -4,7 +4,7 @@ use hex_literal::hex;
 #[cfg(not(target_os = "zkvm"))]
 use lazy_static::lazy_static;
 #[cfg(not(target_os = "zkvm"))]
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_guest::{Field, IntMod};
 use openvm_algebra_moduli_setup::moduli_declare;
 use openvm_ecc_sw_setup::sw_declare;

--- a/extensions/ecc/guest/src/p256.rs
+++ b/extensions/ecc/guest/src/p256.rs
@@ -4,7 +4,7 @@ use hex_literal::hex;
 #[cfg(not(target_os = "zkvm"))]
 use lazy_static::lazy_static;
 #[cfg(not(target_os = "zkvm"))]
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_guest::{Field, IntMod};
 
 use super::group::{CyclicGroup, Group};

--- a/extensions/pairing/circuit/Cargo.toml
+++ b/extensions/pairing/circuit/Cargo.toml
@@ -27,7 +27,7 @@ openvm-rv32-adapters = { workspace = true }
 openvm-ecc-circuit = { workspace = true }
 openvm-pairing-transpiler = { workspace = true }
 
-num-bigint-dig = { workspace = true }
+num-bigint = { workspace = true }
 num-traits = { workspace = true }
 strum = { workspace = true }
 derive_more = { workspace = true }

--- a/extensions/pairing/circuit/src/fp12_chip/tests.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/tests.rs
@@ -1,4 +1,4 @@
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_circuit::arch::{testing::VmChipTestBuilder, VmChipWrapper, BITWISE_OP_LOOKUP_BUS};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,

--- a/extensions/pairing/circuit/src/pairing_extension.rs
+++ b/extensions/pairing/circuit/src/pairing_extension.rs
@@ -1,5 +1,5 @@
 use derive_more::derive::From;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Zero};
 use openvm_circuit::{
     arch::{SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},

--- a/extensions/pairing/guest/Cargo.toml
+++ b/extensions/pairing/guest/Cargo.toml
@@ -28,7 +28,6 @@ halo2curves-axiom = { workspace = true, optional = true }
 group = "0.13.0"
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-num-bigint-dig.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
 lazy_static.workspace = true

--- a/extensions/pairing/guest/src/bls12_381/mod.rs
+++ b/extensions/pairing/guest/src/bls12_381/mod.rs
@@ -14,7 +14,7 @@ use hex_literal::hex;
 #[cfg(not(target_os = "zkvm"))]
 use lazy_static::lazy_static;
 #[cfg(not(target_os = "zkvm"))]
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_ecc_sw_setup::sw_declare;
 
 use crate::pairing::PairingIntrinsics;

--- a/extensions/pairing/guest/src/bn254/mod.rs
+++ b/extensions/pairing/guest/src/bn254/mod.rs
@@ -4,7 +4,7 @@ use hex_literal::hex;
 #[cfg(not(target_os = "zkvm"))]
 use lazy_static::lazy_static;
 #[cfg(not(target_os = "zkvm"))]
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use openvm_algebra_guest::{Field, IntMod};
 use openvm_algebra_moduli_setup::moduli_declare;
 use openvm_ecc_guest::{

--- a/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/mod.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/mod.rs
@@ -1,7 +1,7 @@
 use core::mem::transmute;
 
 use halo2curves_axiom::bls12_381::{Fq12, MillerLoopResult};
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::Pow;
 use openvm_algebra_guest::ExpBytes;
 

--- a/extensions/pairing/guest/src/halo2curves_shims/bn254/tests/mod.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bn254/tests/mod.rs
@@ -4,7 +4,7 @@ use halo2curves_axiom::{
     bn256::{Fq12, Gt},
     pairing::MillerLoopResult,
 };
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use num_traits::Pow;
 use openvm_algebra_guest::ExpBytes;
 

--- a/extensions/pairing/guest/src/tests/ec_msm.rs
+++ b/extensions/pairing/guest/src/tests/ec_msm.rs
@@ -2,7 +2,7 @@ use std::{ops::Mul, str::FromStr};
 
 use ax_sdk::utils::create_seeded_rng;
 use elliptic_curve::group::cofactor::CofactorCurveAffine;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use rand::Rng;
 use snark_verifier_sdk::snark_verifier::{
     halo2_base::{

--- a/extensions/pairing/guest/src/tests/mod.rs
+++ b/extensions/pairing/guest/src/tests/mod.rs
@@ -2,7 +2,7 @@ use std::{ops::Mul, str::FromStr};
 
 use afs_compiler::{asm::AsmBuilder, conversion::CompilerOptions};
 use ax_sdk::utils::create_seeded_rng;
-use num_bigint_dig::BigUint;
+use num_bigint::BigUint;
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
 use rand::Rng;

--- a/extensions/pairing/tests/Cargo.toml
+++ b/extensions/pairing/tests/Cargo.toml
@@ -26,7 +26,6 @@ openvm-platform = { workspace = true }
 openvm = { workspace = true }
 openvm-toolchain-tests = { workspace = true }
 eyre.workspace = true
-num-bigint-dig.workspace = true
 rand.workspace = true
 
 [features]


### PR DESCRIPTION
Replaces usage of `num-bigint-dig` with the more standard `num-bigint`.