### PR TITLE
fix: WeierstrassConfig zip moduli

### DIFF
--- a/extensions/ecc/circuit/src/config.rs
+++ b/extensions/ecc/circuit/src/config.rs
@@ -29,8 +29,10 @@ pub struct Rv32WeierstrassConfig {
 
 impl Rv32WeierstrassConfig {
     pub fn new(curves: Vec<CurveConfig>) -> Self {
-        let mut primes: Vec<_> = curves.iter().map(|c| c.modulus.clone()).collect();
-        primes.extend(curves.iter().map(|c| c.scalar.clone()));
+        let primes: Vec<_> = curves
+            .iter()
+            .flat_map(|c| [c.modulus.clone(), c.scalar.clone()])
+            .collect();
         Self {
             system: SystemConfig::default().with_continuations(),
             base: Default::default(),

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -281,9 +281,9 @@ where
         // So the computation is like doing setup.
         // Thus we will copy over the first row (which is a setup row) and set is_valid = 0.
         let first_row = trace.rows().nth(0).unwrap().collect::<Vec<_>>();
-        let first_row_core = first_row.split_at(adapter_width).1;
+        let (_, first_row_core) = first_row.split_at(adapter_width);
         for row in trace.rows_mut().skip(num_records) {
-            let core_row = row.split_at_mut(adapter_width).1;
+            let (_, core_row) = row.split_at_mut(adapter_width);
             core_row.copy_from_slice(first_row_core);
             core_row[0] = F::ZERO; // is_valid = 0
         }

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -205,12 +205,6 @@ where
         let limb_bits = self.air.expr.canonical_limb_bits();
         let Instruction { opcode, .. } = instruction.clone();
         let local_opcode_idx = opcode.local_opcode_idx(self.air.offset);
-        println!(
-            "ecdouble: {:?}, p={:?}, a={:?}",
-            Rv32WeierstrassOpcode::from_repr(local_opcode_idx),
-            self.air.a_biguint,
-            self.air.expr.prime
-        );
         let data: DynArray<_> = reads.into();
         let data = data.0;
         debug_assert_eq!(data.len(), 2 * num_limbs);

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -205,6 +205,12 @@ where
         let limb_bits = self.air.expr.canonical_limb_bits();
         let Instruction { opcode, .. } = instruction.clone();
         let local_opcode_idx = opcode.local_opcode_idx(self.air.offset);
+        println!(
+            "ecdouble: {:?}, p={:?}, a={:?}",
+            Rv32WeierstrassOpcode::from_repr(local_opcode_idx),
+            self.air.a_biguint,
+            self.air.expr.prime
+        );
         let data: DynArray<_> = reads.into();
         let data = data.0;
         debug_assert_eq!(data.len(), 2 * num_limbs);

--- a/extensions/ecc/tests/programs/Cargo.toml
+++ b/extensions/ecc/tests/programs/Cargo.toml
@@ -45,6 +45,10 @@ name = "ec_nonzero_a"
 required-features = ["p256"]
 
 [[example]]
+name = "ec_two_curves"
+required-features = ["k256", "p256"]
+
+[[example]]
 name = "decompress"
 required-features = ["k256"]
 

--- a/extensions/ecc/tests/programs/examples/ec.rs
+++ b/extensions/ecc/tests/programs/examples/ec.rs
@@ -12,9 +12,7 @@ use openvm_ecc_guest::{
 
 openvm_algebra_moduli_setup::moduli_init! {
     "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F",
-    "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141",
-    "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-    "0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+    "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141"
 }
 
 openvm_ecc_sw_setup::sw_init! {

--- a/extensions/ecc/tests/programs/examples/ec_two_curves.rs
+++ b/extensions/ecc/tests/programs/examples/ec_two_curves.rs
@@ -6,9 +6,9 @@ use openvm_algebra_guest::IntMod;
 use openvm_ecc_guest::{
     k256::{Secp256k1Coord, Secp256k1Point, Secp256k1Scalar},
     msm,
-    p256::{P256Coord, P256Point, P256Scalar},
+    p256::{P256Coord, P256Point},
     weierstrass::WeierstrassPoint,
-    CyclicGroup, Group,
+    Group,
 };
 
 openvm_algebra_moduli_setup::moduli_init! {

--- a/extensions/ecc/tests/src/lib.rs
+++ b/extensions/ecc/tests/src/lib.rs
@@ -61,6 +61,28 @@ mod tests {
     }
 
     #[test]
+    fn test_ec_two_curves() -> Result<()> {
+        let elf = build_example_program_at_path_with_features(
+            get_programs_dir!(),
+            "ec_two_curves",
+            ["k256", "p256"],
+        )?;
+        let openvm_exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv32ITranspilerExtension)
+                .with_extension(Rv32MTranspilerExtension)
+                .with_extension(Rv32IoTranspilerExtension)
+                .with_extension(EccTranspilerExtension)
+                .with_extension(ModularTranspilerExtension),
+        )?;
+        let config =
+            Rv32WeierstrassConfig::new(vec![SECP256K1_CONFIG.clone(), P256_CONFIG.clone()]);
+        air_test(config, openvm_exe);
+        Ok(())
+    }
+
+    #[test]
     fn test_decompress() -> Result<()> {
         use openvm_ecc_guest::halo2curves::{group::Curve, secp256k1::Secp256k1Affine};
 


### PR DESCRIPTION
WeierstrassConfig (only used for testing) auto creates the moduli. It is more natural to do `coordinate,scalar` per curve instead of doing all coordinate first.