### PR TITLE
[chore] Optimize `alpha_pow` computation

### DIFF
--- a/extensions/native/compiler/src/ir/symbolic.rs
+++ b/extensions/native/compiler/src/ir/symbolic.rs
@@ -119,6 +119,12 @@ impl<N: PrimeField> RVar<N> {
             _ => panic!("RVar::value() called on non-const value"),
         }
     }
+    pub fn field_value(&self) -> N {
+        match self {
+            RVar::Const(c) => *c,
+            _ => panic!("RVar::field_value() called on non-const value"),
+        }
+    }
 }
 
 impl<N: Field> Hash for SymbolicVar<N> {


### PR DESCRIPTION
- `alpha_pow` is only computed once for each matrix.
- Let's say `w_i` is the width of i-th matrix. Before we have `max(w_i)` multiplication for `alpha_pow` and now we only need `sum(log(w_i))`. 
- `range_with_step` and `step_sizes` are added for a reverted change. It's not necessary but good to have. 
- Fixed a bug in `for_each_unrolled`.
- Based on metrics, we might revert the change on the static verifier part.