### PR TITLE
feat: Pairing check hint for target_os != zkvm

### DIFF
--- a/extensions/pairing/guest/src/bls12_381/mod.rs
+++ b/extensions/pairing/guest/src/bls12_381/mod.rs
@@ -7,7 +7,8 @@ use openvm_ecc_guest::{weierstrass::IntrinsicCurve, CyclicGroup, Group};
 mod fp12;
 mod fp2;
 mod pairing;
-mod utils;
+#[cfg(not(target_os = "zkvm"))]
+pub(crate) mod utils;
 
 pub use fp12::*;
 pub use fp2::*;
@@ -17,7 +18,6 @@ use lazy_static::lazy_static;
 #[cfg(not(target_os = "zkvm"))]
 use num_bigint::BigUint;
 use openvm_ecc_sw_setup::sw_declare;
-pub(crate) use utils::*;
 
 use crate::pairing::PairingIntrinsics;
 

--- a/extensions/pairing/guest/src/bls12_381/mod.rs
+++ b/extensions/pairing/guest/src/bls12_381/mod.rs
@@ -7,7 +7,7 @@ use openvm_ecc_guest::{weierstrass::IntrinsicCurve, CyclicGroup, Group};
 mod fp12;
 mod fp2;
 mod pairing;
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(all(feature = "halo2curves", not(target_os = "zkvm")))]
 pub(crate) mod utils;
 
 pub use fp12::*;

--- a/extensions/pairing/guest/src/bls12_381/mod.rs
+++ b/extensions/pairing/guest/src/bls12_381/mod.rs
@@ -7,6 +7,7 @@ use openvm_ecc_guest::{weierstrass::IntrinsicCurve, CyclicGroup, Group};
 mod fp12;
 mod fp2;
 mod pairing;
+mod utils;
 
 pub use fp12::*;
 pub use fp2::*;
@@ -16,6 +17,7 @@ use lazy_static::lazy_static;
 #[cfg(not(target_os = "zkvm"))]
 use num_bigint::BigUint;
 use openvm_ecc_sw_setup::sw_declare;
+pub(crate) use utils::*;
 
 use crate::pairing::PairingIntrinsics;
 

--- a/extensions/pairing/guest/src/bls12_381/pairing.rs
+++ b/extensions/pairing/guest/src/bls12_381/pairing.rs
@@ -20,6 +20,15 @@ use crate::pairing::{
     Evaluatable, EvaluatedLine, FromLineMType, LineMulMType, MillerStep, MultiMillerLoop,
     PairingCheck, PairingCheckError, PairingIntrinsics, UnevaluatedLine,
 };
+#[cfg(all(feature = "halo2curves", not(target_os = "zkvm")))]
+use crate::{
+    bls12_381::{
+        convert_bls12381_fp2_to_halo2_fq2, convert_bls12381_fp_to_halo2_fq,
+        convert_bls12381_halo2_fq12_to_fp12,
+    },
+    halo2curves_shims::bls12_381::Bls12_381 as Halo2CurvesBls12_381,
+    pairing::FinalExp,
+};
 
 // TODO[jpw]: make macro
 impl Evaluatable<Fp, Fp2> for UnevaluatedLine<Fp2> {
@@ -36,12 +45,12 @@ impl Evaluatable<Fp, Fp2> for UnevaluatedLine<Fp2> {
         {
             let mut uninit: MaybeUninit<EvaluatedLine<Fp2>> = MaybeUninit::uninit();
             custom_insn_r!(
-                opcode = OPCODE,
-                funct3 = PAIRING_FUNCT3,
-                funct7 = shifted_funct7::<Bls12_381>(PairingBaseFunct7::EvaluateLine),
-                rd = In uninit.as_mut_ptr(),
-                rs1 = In self as *const UnevaluatedLine<Fp2>,
-                rs2 = In xy_frac as *const (Fp, Fp)
+                OPCODE,
+                PAIRING_FUNCT3,
+                shifted_funct7::<Bls12_381>(PairingBaseFunct7::EvaluateLine),
+                uninit.as_mut_ptr(),
+                self as *const UnevaluatedLine<Fp2>,
+                xy_frac as *const (Fp, Fp)
             );
             unsafe { uninit.assume_init() }
         }
@@ -80,12 +89,12 @@ impl LineMulMType<Fp2, Fp12> for Bls12_381 {
         {
             let mut uninit: MaybeUninit<[Fp2; 5]> = MaybeUninit::uninit();
             custom_insn_r!(
-                opcode = OPCODE,
-                funct3 = PAIRING_FUNCT3,
-                funct7 = shifted_funct7::<Bls12_381>(PairingBaseFunct7::Mul023By023),
-                rd = In uninit.as_mut_ptr(),
-                rs1 = In l0 as *const EvaluatedLine<Fp2>,
-                rs2 = In l1 as *const EvaluatedLine<Fp2>
+                OPCODE,
+                PAIRING_FUNCT3,
+                shifted_funct7::<Bls12_381>(PairingBaseFunct7::Mul023By023),
+                uninit.as_mut_ptr(),
+                l0 as *const EvaluatedLine<Fp2>,
+                l1 as *const EvaluatedLine<Fp2>
             );
             unsafe { uninit.assume_init() }
         }
@@ -150,12 +159,12 @@ impl LineMulMType<Fp2, Fp12> for Bls12_381 {
         {
             let mut uninit: MaybeUninit<Fp12> = MaybeUninit::uninit();
             custom_insn_r!(
-                opcode = OPCODE,
-                funct3 = PAIRING_FUNCT3,
-                funct7 = shifted_funct7::<Bls12_381>(PairingBaseFunct7::MulBy02345),
-                rd = In uninit.as_mut_ptr(),
-                rs1 = In f as *const Fp12,
-                rs2 = In x as *const [Fp2; 5]
+                OPCODE,
+                PAIRING_FUNCT3,
+                shifted_funct7::<Bls12_381>(PairingBaseFunct7::MulBy02345),
+                uninit.as_mut_ptr(),
+                f as *const Fp12,
+                x as *const [Fp2; 5]
             );
             unsafe { uninit.assume_init() }
         }
@@ -275,7 +284,35 @@ impl PairingCheck for Bls12_381 {
     ) -> (Self::Fp12, Self::Fp12) {
         #[cfg(not(target_os = "zkvm"))]
         {
-            todo!()
+            #[cfg(not(feature = "halo2curves"))]
+            panic!("`halo2curves` feature must be enabled to use pairing check hint");
+
+            #[cfg(feature = "halo2curves")]
+            {
+                let p_halo2 = P
+                    .iter()
+                    .map(|p| {
+                        AffinePoint::new(
+                            convert_bls12381_fp_to_halo2_fq(p.x.clone()),
+                            convert_bls12381_fp_to_halo2_fq(p.y.clone()),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let q_halo2 = Q
+                    .iter()
+                    .map(|q| {
+                        AffinePoint::new(
+                            convert_bls12381_fp2_to_halo2_fq2(q.x.clone()),
+                            convert_bls12381_fp2_to_halo2_fq2(q.y.clone()),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let fq12 = Halo2CurvesBls12_381::multi_miller_loop(&p_halo2, &q_halo2);
+                let (c_fq12, s_fq12) = Halo2CurvesBls12_381::final_exp_hint(&fq12);
+                let c = convert_bls12381_halo2_fq12_to_fp12(c_fq12);
+                let s = convert_bls12381_halo2_fq12_to_fp12(s_fq12);
+                (c, s)
+            }
         }
         #[cfg(target_os = "zkvm")]
         {
@@ -284,13 +321,13 @@ impl PairingCheck for Bls12_381 {
             let p_fat_ptr = (P.as_ptr() as u32, P.len() as u32);
             let q_fat_ptr = (Q.as_ptr() as u32, Q.len() as u32);
             unsafe {
-                custom_insn_r!(
-                    opcode = OPCODE,
-                    funct3 = PAIRING_FUNCT3,
-                    funct7 = ((Bls12_381::PAIRING_IDX as u8) * PairingBaseFunct7::PAIRING_MAX_KINDS + PairingBaseFunct7::HintFinalExp as u8),
-                    rd = Const "x0",
-                    rs1 = In &p_fat_ptr,
-                    rs2 = In &q_fat_ptr
+                core::arch::asm!(
+                    ".insn r {opcode}, {funct3}, {funct7}, x0, {rs1}, {rs2}",
+                    opcode = const OPCODE,
+                    funct3 = const PAIRING_FUNCT3,
+                    funct7 = const ((Bls12_381::PAIRING_IDX as u8) * PairingBaseFunct7::PAIRING_MAX_KINDS + PairingBaseFunct7::HintFinalExp as u8),
+                    rs1 = in(reg) &p_fat_ptr,
+                    rs2 = in(reg) &q_fat_ptr
                 );
                 let mut ptr = hint.as_ptr() as *const u8;
                 // NOTE[jpw]: this loop could be unrolled using seq_macro and hint_store_u32(ptr, $imm)

--- a/extensions/pairing/guest/src/bls12_381/pairing.rs
+++ b/extensions/pairing/guest/src/bls12_381/pairing.rs
@@ -285,7 +285,7 @@ impl PairingCheck for Bls12_381 {
         #[cfg(not(target_os = "zkvm"))]
         {
             #[cfg(not(feature = "halo2curves"))]
-            panic!("`halo2curves` feature must be enabled to use pairing check hint");
+            panic!("`halo2curves` feature must be enabled to use pairing check hint on host");
 
             #[cfg(feature = "halo2curves")]
             {

--- a/extensions/pairing/guest/src/bls12_381/pairing.rs
+++ b/extensions/pairing/guest/src/bls12_381/pairing.rs
@@ -22,7 +22,7 @@ use crate::pairing::{
 };
 #[cfg(all(feature = "halo2curves", not(target_os = "zkvm")))]
 use crate::{
-    bls12_381::{
+    bls12_381::utils::{
         convert_bls12381_fp2_to_halo2_fq2, convert_bls12381_fp_to_halo2_fq,
         convert_bls12381_halo2_fq12_to_fp12,
     },

--- a/extensions/pairing/guest/src/bls12_381/pairing.rs
+++ b/extensions/pairing/guest/src/bls12_381/pairing.rs
@@ -45,12 +45,12 @@ impl Evaluatable<Fp, Fp2> for UnevaluatedLine<Fp2> {
         {
             let mut uninit: MaybeUninit<EvaluatedLine<Fp2>> = MaybeUninit::uninit();
             custom_insn_r!(
-                OPCODE,
-                PAIRING_FUNCT3,
-                shifted_funct7::<Bls12_381>(PairingBaseFunct7::EvaluateLine),
-                uninit.as_mut_ptr(),
-                self as *const UnevaluatedLine<Fp2>,
-                xy_frac as *const (Fp, Fp)
+                opcode = OPCODE,
+                funct3 = PAIRING_FUNCT3,
+                funct7 = shifted_funct7::<Bls12_381>(PairingBaseFunct7::EvaluateLine),
+                rd = In uninit.as_mut_ptr(),
+                rs1 = In self as *const UnevaluatedLine<Fp2>,
+                rs2 = In xy_frac as *const (Fp, Fp)
             );
             unsafe { uninit.assume_init() }
         }
@@ -89,12 +89,12 @@ impl LineMulMType<Fp2, Fp12> for Bls12_381 {
         {
             let mut uninit: MaybeUninit<[Fp2; 5]> = MaybeUninit::uninit();
             custom_insn_r!(
-                OPCODE,
-                PAIRING_FUNCT3,
-                shifted_funct7::<Bls12_381>(PairingBaseFunct7::Mul023By023),
-                uninit.as_mut_ptr(),
-                l0 as *const EvaluatedLine<Fp2>,
-                l1 as *const EvaluatedLine<Fp2>
+                opcode = OPCODE,
+                funct3 = PAIRING_FUNCT3,
+                funct7 = shifted_funct7::<Bls12_381>(PairingBaseFunct7::Mul023By023),
+                rd = In uninit.as_mut_ptr(),
+                rs1 = In l0 as *const EvaluatedLine<Fp2>,
+                rs2 = In l1 as *const EvaluatedLine<Fp2>
             );
             unsafe { uninit.assume_init() }
         }
@@ -159,12 +159,12 @@ impl LineMulMType<Fp2, Fp12> for Bls12_381 {
         {
             let mut uninit: MaybeUninit<Fp12> = MaybeUninit::uninit();
             custom_insn_r!(
-                OPCODE,
-                PAIRING_FUNCT3,
-                shifted_funct7::<Bls12_381>(PairingBaseFunct7::MulBy02345),
-                uninit.as_mut_ptr(),
-                f as *const Fp12,
-                x as *const [Fp2; 5]
+                opcode = OPCODE,
+                funct3 = PAIRING_FUNCT3,
+                funct7 = shifted_funct7::<Bls12_381>(PairingBaseFunct7::MulBy02345),
+                rd = In uninit.as_mut_ptr(),
+                rs1 = In f as *const Fp12,
+                rs2 = In x as *const [Fp2; 5]
             );
             unsafe { uninit.assume_init() }
         }
@@ -321,13 +321,13 @@ impl PairingCheck for Bls12_381 {
             let p_fat_ptr = (P.as_ptr() as u32, P.len() as u32);
             let q_fat_ptr = (Q.as_ptr() as u32, Q.len() as u32);
             unsafe {
-                core::arch::asm!(
-                    ".insn r {opcode}, {funct3}, {funct7}, x0, {rs1}, {rs2}",
-                    opcode = const OPCODE,
-                    funct3 = const PAIRING_FUNCT3,
-                    funct7 = const ((Bls12_381::PAIRING_IDX as u8) * PairingBaseFunct7::PAIRING_MAX_KINDS + PairingBaseFunct7::HintFinalExp as u8),
-                    rs1 = in(reg) &p_fat_ptr,
-                    rs2 = in(reg) &q_fat_ptr
+                custom_insn_r!(
+                    opcode = OPCODE,
+                    funct3 = PAIRING_FUNCT3,
+                    funct7 = ((Bls12_381::PAIRING_IDX as u8) * PairingBaseFunct7::PAIRING_MAX_KINDS + PairingBaseFunct7::HintFinalExp as u8),
+                    rd = Const "x0",
+                    rs1 = In &p_fat_ptr,
+                    rs2 = In &q_fat_ptr
                 );
                 let mut ptr = hint.as_ptr() as *const u8;
                 // NOTE[jpw]: this loop could be unrolled using seq_macro and hint_store_u32(ptr, $imm)

--- a/extensions/pairing/guest/src/bls12_381/tests.rs
+++ b/extensions/pairing/guest/src/bls12_381/tests.rs
@@ -6,12 +6,15 @@ use openvm_algebra_guest::{field::FieldExtension, IntMod};
 use openvm_ecc_guest::{weierstrass::WeierstrassPoint, AffinePoint};
 use rand::{rngs::StdRng, SeedableRng};
 
-use super::{convert_bls12381_fp12_to_halo2_fq12, Fp, Fp12, Fp2};
+use super::{Fp, Fp12, Fp2};
 use crate::{
     bls12_381::{
-        convert_bls12381_halo2_fq12_to_fp12, convert_bls12381_halo2_fq2_to_fp2,
-        convert_bls12381_halo2_fq_to_fp, convert_g2_affine_halo2_to_openvm, Bls12_381,
-        G2Affine as OpenVmG2Affine,
+        utils::{
+            convert_bls12381_fp12_to_halo2_fq12, convert_bls12381_halo2_fq12_to_fp12,
+            convert_bls12381_halo2_fq2_to_fp2, convert_bls12381_halo2_fq_to_fp,
+            convert_g2_affine_halo2_to_openvm,
+        },
+        Bls12_381, G2Affine as OpenVmG2Affine,
     },
     pairing::{
         fp2_invert_assign, fp6_invert_assign, fp6_square_assign, FinalExp, MultiMillerLoop,

--- a/extensions/pairing/guest/src/bls12_381/tests.rs
+++ b/extensions/pairing/guest/src/bls12_381/tests.rs
@@ -8,60 +8,18 @@ use openvm_algebra_guest::{field::FieldExtension, IntMod};
 use openvm_ecc_guest::{weierstrass::WeierstrassPoint, AffinePoint};
 use rand::{rngs::StdRng, SeedableRng};
 
-use super::{Fp, Fp12, Fp2};
+use super::{convert_bls12381_fp12_to_halo2_fq12, Fp, Fp12, Fp2};
 use crate::{
-    bls12_381::{Bls12_381, G2Affine as OpenVmG2Affine},
+    bls12_381::{
+        convert_bls12381_halo2_fq12_to_fp12, convert_bls12381_halo2_fq2_to_fp2,
+        convert_bls12381_halo2_fq_to_fp, convert_g2_affine_halo2_to_openvm, Bls12_381,
+        G2Affine as OpenVmG2Affine,
+    },
     pairing::{
-        fp2_invert_assign, fp6_invert_assign, fp6_square_assign, MultiMillerLoop, PairingIntrinsics,
+        fp2_invert_assign, fp6_invert_assign, fp6_square_assign, FinalExp, MultiMillerLoop,
+        PairingCheck, PairingIntrinsics,
     },
 };
-
-fn convert_bls12381_halo2_fq_to_fp(x: Fq) -> Fp {
-    let bytes = x.to_bytes();
-    Fp::from_le_bytes(&bytes)
-}
-
-fn convert_bls12381_halo2_fq2_to_fp2(x: Fq2) -> Fp2 {
-    Fp2::new(
-        convert_bls12381_halo2_fq_to_fp(x.c0),
-        convert_bls12381_halo2_fq_to_fp(x.c1),
-    )
-}
-
-fn convert_bls12381_halo2_fq12_to_fp12(x: Fq12) -> Fp12 {
-    Fp12 {
-        c: x.to_coeffs().map(convert_bls12381_halo2_fq2_to_fp2),
-    }
-}
-
-fn convert_bls12381_fp_to_halo2_fq(x: Fp) -> Fq {
-    let bytes =
-        x.0.chunks(8)
-            .map(|b| u64::from_le_bytes(b.try_into().unwrap()))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-    Fq::from_raw_unchecked(bytes)
-}
-
-fn convert_bls12381_fp2_to_halo2_fq2(x: Fp2) -> Fq2 {
-    Fq2 {
-        c0: convert_bls12381_fp_to_halo2_fq(x.c0.clone()),
-        c1: convert_bls12381_fp_to_halo2_fq(x.c1.clone()),
-    }
-}
-
-fn convert_bls12381_fp12_to_halo2_fq12(x: Fp12) -> Fq12 {
-    let c = x.to_coeffs();
-    Fq12::from_coeffs(c.map(convert_bls12381_fp2_to_halo2_fq2))
-}
-
-fn convert_g2_affine_halo2_to_openvm(p: G2Affine) -> OpenVmG2Affine {
-    OpenVmG2Affine::from_xy_unchecked(
-        convert_bls12381_halo2_fq2_to_fp2(p.x),
-        convert_bls12381_halo2_fq2_to_fp2(p.y),
-    )
-}
 
 #[test]
 fn test_bls12381_frobenius_coeffs() {
@@ -299,4 +257,40 @@ fn test_bls12381_g2_affine() {
             assert_eq!(convert_g2_affine_halo2_to_openvm(expected), actual);
         }
     }
+}
+
+#[test]
+fn test_bls12381_pairing_check_hint_host() {
+    let mut rng = StdRng::seed_from_u64(83);
+    let h2c_p = G1Affine::random(&mut rng);
+    let h2c_q = G2Affine::random(&mut rng);
+
+    let p = AffinePoint {
+        x: convert_bls12381_halo2_fq_to_fp(h2c_p.x),
+        y: convert_bls12381_halo2_fq_to_fp(h2c_p.y),
+    };
+    let q = AffinePoint {
+        x: convert_bls12381_halo2_fq2_to_fp2(h2c_q.x),
+        y: convert_bls12381_halo2_fq2_to_fp2(h2c_q.y),
+    };
+
+    let (c, s) = Bls12_381::pairing_check_hint(&[p], &[q]);
+
+    let p_cmp = AffinePoint {
+        x: h2c_p.x,
+        y: h2c_p.y,
+    };
+    let q_cmp = AffinePoint {
+        x: h2c_q.x,
+        y: h2c_q.y,
+    };
+
+    let f_cmp =
+        crate::halo2curves_shims::bls12_381::Bls12_381::multi_miller_loop(&[p_cmp], &[q_cmp]);
+    let (c_cmp, s_cmp) = crate::halo2curves_shims::bls12_381::Bls12_381::final_exp_hint(&f_cmp);
+    let c_cmp = convert_bls12381_halo2_fq12_to_fp12(c_cmp);
+    let s_cmp = convert_bls12381_halo2_fq12_to_fp12(s_cmp);
+
+    assert_eq!(c, c_cmp);
+    assert_eq!(s, s_cmp);
 }

--- a/extensions/pairing/guest/src/bls12_381/tests.rs
+++ b/extensions/pairing/guest/src/bls12_381/tests.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 use group::ff::Field;
 use halo2curves_axiom::bls12_381::{
     Fq, Fq12, Fq2, Fq6, G1Affine, G2Affine, G2Prepared, MillerLoopResult, FROBENIUS_COEFF_FQ12_C1,

--- a/extensions/pairing/guest/src/bls12_381/utils.rs
+++ b/extensions/pairing/guest/src/bls12_381/utils.rs
@@ -1,0 +1,49 @@
+use halo2curves_axiom::bls12_381::{Fq, Fq12, Fq2, G2Affine};
+use openvm_algebra_guest::{field::FieldExtension, IntMod};
+use openvm_ecc_guest::weierstrass::WeierstrassPoint;
+
+use super::{Fp, Fp12, Fp2};
+use crate::bls12_381::G2Affine as OpenVmG2Affine;
+
+pub(crate) fn convert_bls12381_halo2_fq_to_fp(x: Fq) -> Fp {
+    let bytes = x.to_bytes();
+    Fp::from_le_bytes(&bytes)
+}
+
+pub(crate) fn convert_bls12381_halo2_fq2_to_fp2(x: Fq2) -> Fp2 {
+    Fp2::new(
+        convert_bls12381_halo2_fq_to_fp(x.c0),
+        convert_bls12381_halo2_fq_to_fp(x.c1),
+    )
+}
+
+pub(crate) fn convert_bls12381_halo2_fq12_to_fp12(x: Fq12) -> Fp12 {
+    Fp12 {
+        c: x.to_coeffs().map(convert_bls12381_halo2_fq2_to_fp2),
+    }
+}
+
+pub(crate) fn convert_bls12381_fp_to_halo2_fq(x: Fp) -> Fq {
+    Fq::from_bytes(&x.0).unwrap()
+}
+
+pub(crate) fn convert_bls12381_fp2_to_halo2_fq2(x: Fp2) -> Fq2 {
+    Fq2 {
+        c0: convert_bls12381_fp_to_halo2_fq(x.c0.clone()),
+        c1: convert_bls12381_fp_to_halo2_fq(x.c1.clone()),
+    }
+}
+
+#[allow(unused)]
+pub(crate) fn convert_bls12381_fp12_to_halo2_fq12(x: Fp12) -> Fq12 {
+    let c = x.to_coeffs();
+    Fq12::from_coeffs(c.map(convert_bls12381_fp2_to_halo2_fq2))
+}
+
+#[allow(unused)]
+pub(crate) fn convert_g2_affine_halo2_to_openvm(p: G2Affine) -> OpenVmG2Affine {
+    OpenVmG2Affine::from_xy_unchecked(
+        convert_bls12381_halo2_fq2_to_fp2(p.x),
+        convert_bls12381_halo2_fq2_to_fp2(p.y),
+    )
+}

--- a/extensions/pairing/guest/src/bn254/mod.rs
+++ b/extensions/pairing/guest/src/bn254/mod.rs
@@ -18,7 +18,7 @@ use crate::pairing::PairingIntrinsics;
 mod fp12;
 mod fp2;
 pub mod pairing;
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(all(feature = "halo2curves", not(target_os = "zkvm")))]
 pub(crate) mod utils;
 
 pub use fp12::*;

--- a/extensions/pairing/guest/src/bn254/mod.rs
+++ b/extensions/pairing/guest/src/bn254/mod.rs
@@ -18,9 +18,11 @@ use crate::pairing::PairingIntrinsics;
 mod fp12;
 mod fp2;
 pub mod pairing;
+mod utils;
 
 pub use fp12::*;
 pub use fp2::*;
+pub(crate) use utils::*;
 
 #[cfg(all(test, feature = "halo2curves", not(target_os = "zkvm")))]
 pub mod tests;

--- a/extensions/pairing/guest/src/bn254/mod.rs
+++ b/extensions/pairing/guest/src/bn254/mod.rs
@@ -18,11 +18,11 @@ use crate::pairing::PairingIntrinsics;
 mod fp12;
 mod fp2;
 pub mod pairing;
-mod utils;
+#[cfg(not(target_os = "zkvm"))]
+pub(crate) mod utils;
 
 pub use fp12::*;
 pub use fp2::*;
-pub(crate) use utils::*;
 
 #[cfg(all(test, feature = "halo2curves", not(target_os = "zkvm")))]
 pub mod tests;

--- a/extensions/pairing/guest/src/bn254/pairing.rs
+++ b/extensions/pairing/guest/src/bn254/pairing.rs
@@ -317,7 +317,7 @@ impl PairingCheck for Bn254 {
         #[cfg(not(target_os = "zkvm"))]
         {
             #[cfg(not(feature = "halo2curves"))]
-            panic!("`halo2curves` feature must be enabled to use pairing check hint");
+            panic!("`halo2curves` feature must be enabled to use pairing check hint on host");
 
             #[cfg(feature = "halo2curves")]
             {

--- a/extensions/pairing/guest/src/bn254/pairing.rs
+++ b/extensions/pairing/guest/src/bn254/pairing.rs
@@ -41,12 +41,12 @@ impl Evaluatable<Fp, Fp2> for UnevaluatedLine<Fp2> {
         {
             let mut uninit: MaybeUninit<EvaluatedLine<Fp2>> = MaybeUninit::uninit();
             custom_insn_r!(
-                OPCODE,
-                PAIRING_FUNCT3,
-                shifted_funct7::<Bn254>(PairingBaseFunct7::EvaluateLine),
-                uninit.as_mut_ptr(),
-                self as *const UnevaluatedLine<Fp2>,
-                xy_frac as *const (Fp, Fp)
+                opcode = OPCODE,
+                funct3 = PAIRING_FUNCT3,
+                funct7 = shifted_funct7::<Bn254>(PairingBaseFunct7::EvaluateLine),
+                rd = In uninit.as_mut_ptr(),
+                rs1 = In self as *const UnevaluatedLine<Fp2>,
+                rs2 = In xy_frac as *const (Fp, Fp)
             );
             unsafe { uninit.assume_init() }
         }
@@ -92,12 +92,12 @@ impl LineMulDType<Fp2, Fp12> for Bn254 {
         {
             let mut uninit: MaybeUninit<[Fp2; 5]> = MaybeUninit::uninit();
             custom_insn_r!(
-                OPCODE,
-                PAIRING_FUNCT3,
-                shifted_funct7::<Bn254>(PairingBaseFunct7::Mul013By013),
-                uninit.as_mut_ptr(),
-                l0 as *const EvaluatedLine<Fp2>,
-                l1 as *const EvaluatedLine<Fp2>
+                opcode = OPCODE,
+                funct3 = PAIRING_FUNCT3,
+                funct7 = shifted_funct7::<Bn254>(PairingBaseFunct7::Mul013By013),
+                rd = In uninit.as_mut_ptr(),
+                rs1 = In l0 as *const EvaluatedLine<Fp2>,
+                rs2 = In l1 as *const EvaluatedLine<Fp2>
             );
             unsafe { uninit.assume_init() }
         }
@@ -161,12 +161,12 @@ impl LineMulDType<Fp2, Fp12> for Bn254 {
         {
             let mut uninit: MaybeUninit<Fp12> = MaybeUninit::uninit();
             custom_insn_r!(
-                OPCODE,
-                PAIRING_FUNCT3,
-                shifted_funct7::<Bn254>(PairingBaseFunct7::MulBy01234),
-                uninit.as_mut_ptr(),
-                f as *const Fp12,
-                x as *const [Fp2; 5]
+                opcode = OPCODE,
+                funct3 = PAIRING_FUNCT3,
+                funct7 = shifted_funct7::<Bn254>(PairingBaseFunct7::MulBy01234),
+                rd = In uninit.as_mut_ptr(),
+                rs1 = In f as *const Fp12,
+                rs2 = In x as *const [Fp2; 5]
             );
             unsafe { uninit.assume_init() }
         }
@@ -353,13 +353,13 @@ impl PairingCheck for Bn254 {
             let p_fat_ptr = (P.as_ptr() as u32, P.len() as u32);
             let q_fat_ptr = (Q.as_ptr() as u32, Q.len() as u32);
             unsafe {
-                core::arch::asm!(
-                    ".insn r {opcode}, {funct3}, {funct7}, x0, {rs1}, {rs2}",
-                    opcode = const OPCODE,
-                    funct3 = const PAIRING_FUNCT3,
-                    funct7 = const ((Bn254::PAIRING_IDX as u8) * PairingBaseFunct7::PAIRING_MAX_KINDS + PairingBaseFunct7::HintFinalExp as u8),
-                    rs1 = in(reg) &p_fat_ptr,
-                    rs2 = in(reg) &q_fat_ptr
+                custom_insn_r!(
+                    opcode = OPCODE,
+                    funct3 = PAIRING_FUNCT3,
+                    funct7 = ((Bn254::PAIRING_IDX as u8) * PairingBaseFunct7::PAIRING_MAX_KINDS + PairingBaseFunct7::HintFinalExp as u8),
+                    rd = Const "x0",
+                    rs1 = In &p_fat_ptr,
+                    rs2 = In &q_fat_ptr
                 );
                 let mut ptr = hint.as_ptr() as *const u8;
                 // NOTE[jpw]: this loop could be unrolled using seq_macro and hint_store_u32(ptr, $imm)

--- a/extensions/pairing/guest/src/bn254/pairing.rs
+++ b/extensions/pairing/guest/src/bn254/pairing.rs
@@ -18,7 +18,7 @@ use crate::pairing::{
 };
 #[cfg(all(feature = "halo2curves", not(target_os = "zkvm")))]
 use crate::{
-    bn254::{
+    bn254::utils::{
         convert_bn254_fp2_to_halo2_fq2, convert_bn254_fp_to_halo2_fq,
         convert_bn254_halo2_fq12_to_fp12,
     },

--- a/extensions/pairing/guest/src/bn254/tests.rs
+++ b/extensions/pairing/guest/src/bn254/tests.rs
@@ -12,7 +12,8 @@ use super::{Fp, Fp12, Fp2};
 use crate::{
     bn254::{Bn254, G2Affine as OpenVmG2Affine},
     pairing::{
-        fp2_invert_assign, fp6_invert_assign, fp6_square_assign, MultiMillerLoop, PairingIntrinsics,
+        fp2_invert_assign, fp6_invert_assign, fp6_square_assign, FinalExp, MultiMillerLoop,
+        PairingCheck, PairingIntrinsics,
     },
 };
 
@@ -285,4 +286,39 @@ fn test_bn254_g2_affine() {
             assert_eq!(convert_g2_affine_halo2_to_openvm(expected), actual);
         }
     }
+}
+
+#[test]
+fn test_bn254_pairing_check_hint_host() {
+    let mut rng = StdRng::seed_from_u64(83);
+    let h2c_p = G1Affine::random(&mut rng);
+    let h2c_q = G2Affine::random(&mut rng);
+
+    let p = AffinePoint {
+        x: convert_bn254_halo2_fq_to_fp(h2c_p.x),
+        y: convert_bn254_halo2_fq_to_fp(h2c_p.y),
+    };
+    let q = AffinePoint {
+        x: convert_bn254_halo2_fq2_to_fp2(h2c_q.x),
+        y: convert_bn254_halo2_fq2_to_fp2(h2c_q.y),
+    };
+
+    let (c, u) = Bn254::pairing_check_hint(&[p], &[q]);
+
+    let p_cmp = AffinePoint {
+        x: h2c_p.x,
+        y: h2c_p.y,
+    };
+    let q_cmp = AffinePoint {
+        x: h2c_q.x,
+        y: h2c_q.y,
+    };
+
+    let f_cmp = crate::halo2curves_shims::bn254::Bn254::multi_miller_loop(&[p_cmp], &[q_cmp]);
+    let (c_cmp, u_cmp) = crate::halo2curves_shims::bn254::Bn254::final_exp_hint(&f_cmp);
+    let c_cmp = convert_bn254_halo2_fq12_to_fp12(c_cmp);
+    let u_cmp = convert_bn254_halo2_fq12_to_fp12(u_cmp);
+
+    assert_eq!(c, c_cmp);
+    assert_eq!(u, u_cmp);
 }

--- a/extensions/pairing/guest/src/bn254/tests.rs
+++ b/extensions/pairing/guest/src/bn254/tests.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 use group::{ff::Field, prime::PrimeCurveAffine};
 use halo2curves_axiom::bn256::{
     Fq, Fq12, Fq2, Fq6, G1Affine, G2Affine, G2Prepared, Gt, FROBENIUS_COEFF_FQ12_C1,
@@ -10,59 +8,16 @@ use rand::{rngs::StdRng, SeedableRng};
 
 use super::{Fp, Fp12, Fp2};
 use crate::{
-    bn254::{Bn254, G2Affine as OpenVmG2Affine},
+    bn254::{
+        convert_bn254_fp12_to_halo2_fq12, convert_bn254_halo2_fq12_to_fp12,
+        convert_bn254_halo2_fq2_to_fp2, convert_bn254_halo2_fq_to_fp,
+        convert_g2_affine_halo2_to_openvm, Bn254, G2Affine as OpenVmG2Affine,
+    },
     pairing::{
         fp2_invert_assign, fp6_invert_assign, fp6_square_assign, FinalExp, MultiMillerLoop,
         PairingCheck, PairingIntrinsics,
     },
 };
-
-fn convert_bn254_halo2_fq_to_fp(x: Fq) -> Fp {
-    let bytes = x.to_bytes();
-    Fp::from_le_bytes(&bytes)
-}
-
-fn convert_bn254_halo2_fq2_to_fp2(x: Fq2) -> Fp2 {
-    Fp2::new(
-        convert_bn254_halo2_fq_to_fp(x.c0),
-        convert_bn254_halo2_fq_to_fp(x.c1),
-    )
-}
-
-fn convert_bn254_halo2_fq12_to_fp12(x: Fq12) -> Fp12 {
-    Fp12 {
-        c: x.to_coeffs().map(convert_bn254_halo2_fq2_to_fp2),
-    }
-}
-
-fn convert_bn254_fp_to_halo2_fq(x: Fp) -> Fq {
-    let bytes =
-        x.0.chunks(8)
-            .map(|b| u64::from_le_bytes(b.try_into().unwrap()))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-    Fq::from_raw(bytes)
-}
-
-fn convert_bn254_fp2_to_halo2_fq2(x: Fp2) -> Fq2 {
-    Fq2 {
-        c0: convert_bn254_fp_to_halo2_fq(x.c0.clone()),
-        c1: convert_bn254_fp_to_halo2_fq(x.c1.clone()),
-    }
-}
-
-fn convert_bn254_fp12_to_halo2_fq12(x: Fp12) -> Fq12 {
-    let c = x.to_coeffs();
-    Fq12::from_coeffs(c.map(convert_bn254_fp2_to_halo2_fq2))
-}
-
-fn convert_g2_affine_halo2_to_openvm(p: G2Affine) -> OpenVmG2Affine {
-    OpenVmG2Affine::from_xy_unchecked(
-        convert_bn254_halo2_fq2_to_fp2(p.x),
-        convert_bn254_halo2_fq2_to_fp2(p.y),
-    )
-}
 
 #[test]
 fn test_bn254_frobenius_coeffs() {

--- a/extensions/pairing/guest/src/bn254/tests.rs
+++ b/extensions/pairing/guest/src/bn254/tests.rs
@@ -9,9 +9,12 @@ use rand::{rngs::StdRng, SeedableRng};
 use super::{Fp, Fp12, Fp2};
 use crate::{
     bn254::{
-        convert_bn254_fp12_to_halo2_fq12, convert_bn254_halo2_fq12_to_fp12,
-        convert_bn254_halo2_fq2_to_fp2, convert_bn254_halo2_fq_to_fp,
-        convert_g2_affine_halo2_to_openvm, Bn254, G2Affine as OpenVmG2Affine,
+        utils::{
+            convert_bn254_fp12_to_halo2_fq12, convert_bn254_halo2_fq12_to_fp12,
+            convert_bn254_halo2_fq2_to_fp2, convert_bn254_halo2_fq_to_fp,
+            convert_g2_affine_halo2_to_openvm,
+        },
+        Bn254, G2Affine as OpenVmG2Affine,
     },
     pairing::{
         fp2_invert_assign, fp6_invert_assign, fp6_square_assign, FinalExp, MultiMillerLoop,

--- a/extensions/pairing/guest/src/bn254/utils.rs
+++ b/extensions/pairing/guest/src/bn254/utils.rs
@@ -1,0 +1,49 @@
+use halo2curves_axiom::bn256::{Fq, Fq12, Fq2, G2Affine};
+use openvm_algebra_guest::{field::FieldExtension, IntMod};
+use openvm_ecc_guest::weierstrass::WeierstrassPoint;
+
+use super::{Fp, Fp12, Fp2};
+use crate::bn254::G2Affine as OpenVmG2Affine;
+
+pub(crate) fn convert_bn254_halo2_fq_to_fp(x: Fq) -> Fp {
+    let bytes = x.to_bytes();
+    Fp::from_le_bytes(&bytes)
+}
+
+pub(crate) fn convert_bn254_halo2_fq2_to_fp2(x: Fq2) -> Fp2 {
+    Fp2::new(
+        convert_bn254_halo2_fq_to_fp(x.c0),
+        convert_bn254_halo2_fq_to_fp(x.c1),
+    )
+}
+
+pub(crate) fn convert_bn254_halo2_fq12_to_fp12(x: Fq12) -> Fp12 {
+    Fp12 {
+        c: x.to_coeffs().map(convert_bn254_halo2_fq2_to_fp2),
+    }
+}
+
+pub(crate) fn convert_bn254_fp_to_halo2_fq(x: Fp) -> Fq {
+    Fq::from_bytes(&x.0).unwrap()
+}
+
+pub(crate) fn convert_bn254_fp2_to_halo2_fq2(x: Fp2) -> Fq2 {
+    Fq2 {
+        c0: convert_bn254_fp_to_halo2_fq(x.c0.clone()),
+        c1: convert_bn254_fp_to_halo2_fq(x.c1.clone()),
+    }
+}
+
+#[allow(unused)]
+pub(crate) fn convert_bn254_fp12_to_halo2_fq12(x: Fp12) -> Fq12 {
+    let c = x.to_coeffs();
+    Fq12::from_coeffs(c.map(convert_bn254_fp2_to_halo2_fq2))
+}
+
+#[allow(unused)]
+pub(crate) fn convert_g2_affine_halo2_to_openvm(p: G2Affine) -> OpenVmG2Affine {
+    OpenVmG2Affine::from_xy_unchecked(
+        convert_bn254_halo2_fq2_to_fp2(p.x),
+        convert_bn254_halo2_fq2_to_fp2(p.y),
+    )
+}


### PR DESCRIPTION
- Adds pairing check hint for BN254 and BLS12-381 using halo2curves_shims
- Adds test for pairing check hint
- Moves conversion functions into utils.rs file

Towards INT-2963