### PR TITLE
[fix] rm assert on double chip vars

### DIFF
--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -231,7 +231,6 @@ where
             vec![x_biguint.clone(), y_biguint.clone()],
             vec![is_double_flag],
         );
-        assert_eq!(vars.len(), 3); // x1^2, x3, y3
 
         let writes = self
             .air


### PR DESCRIPTION
if autosave happens on the numerator `3x^2 + a`, the vars will be 4 instead of 3