### PR TITLE
Add `cargo openvm run` to the app-level-cli CI job

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -48,14 +48,14 @@ jobs:
         run: |
           cargo install --force --locked --path .
 
-      - name: Build book examples
+      - name: Build and run book examples
         working-directory: examples
         run: |
           for dir in */; do
             if [ -f "${dir}Cargo.toml" ]; then
               echo "Building ${dir%/}"
               cd "$dir"
-              cargo openvm build
+              cargo openvm build && cargo openvm run
               cd ..
             fi
           done


### PR DESCRIPTION
Currently, the CI workflow for testing examples (the `app-level-cli` job) just built every example with `cargo openvm build` but this change makes it run as well with `cargo openvm build && cargo openvm run`