### PR TITLE
[docs] Add contributor documentations for circuit primitives

### DIFF
--- a/crates/circuits/primitives/src/README.md
+++ b/crates/circuits/primitives/src/README.md
@@ -8,11 +8,11 @@ The following modules contain standalone `Air`'s:
 - [range_tuple](./range_tuple/mod.rs)
 - [var_range](./var_range/mod.rs)
 - [xor](./xor/README.md)
+- [bitwise_op_lookup](./bitwise_op_lookup/mod.rs)
 
 The following modules contain `SubAir`'s:
 - [assert_less_than](./assert_less_than/mod.rs)
 - [bigint](./bigint/README.md)
-- [bitwise_op_lookup](./bitwise_op_lookup/mod.rs)
 - [encoder](./encoder/mod.rs)
 - [is_equal](./is_equal/mod.rs)
 - [is_equal_array](./is_equal_array/moxd.rs)

--- a/crates/circuits/primitives/src/README.md
+++ b/crates/circuits/primitives/src/README.md
@@ -1,0 +1,74 @@
+# Circuit Primitives
+
+This crate contains a collection of primitives for use when building circuits. The primitives are separated into two types: standalone [Air](https://github.com/Plonky3/Plonky3/blob/main/air/src/air.rs) and [SubAir](./sub_air.rs).
+
+The following modules contain standalone `Air`'s:
+- [range](./range/README.md)
+- [range_gate](./range_gate/README.md)
+- [range_tuple](./range_tuple/mod.rs)
+- [var_range](./var_range/mod.rs)
+- [xor](./xor/README.md)
+
+The following modules contain `SubAir`'s:
+- [assert_less_than](./assert_less_than/mod.rs)
+- [bigint](./bigint/README.md)
+- [bitwise_op_lookup](./bitwise_op_lookup/mod.rs)
+- [encoder](./encoder/mod.rs)
+- [is_equal](./is_equal/mod.rs)
+- [is_equal_array](./is_equal_array/moxd.rs)
+- [is_less_than](./is_less_than/mod.rs)
+- [is_less_than_array](./is_less_than_array/mod.rs)
+- [is_zero](./is_zero/mod.rs)
+
+## SubAir
+
+Trait with associated types intended to allow re-use of constraint logic inside other AIRs.
+
+A `SubAir` is **not** an `Air` itself.
+It is a struct that holds the means to generate a particular set of constraints, meant to be re-usable within other AIRs.
+
+The trait is designed to be maximally flexible, but typical implementations will separate the `AirContext` into two parts: `Io` and `AuxCols`. 
+The `Io` part will consist of expressions (built using `AB::Expr`) that the `SubAir` does not own, while the `AuxCols` are any internal columns that the `SubAir` requires to generate its constraints. 
+The `AuxCols` are columns that the `SubAir` fully owns and should be internally determined by the `SubAir` from the `Io` part. These `AuxCols` are typically just slices of `AB::Var`.
+
+This trait only owns the constraints, but it is expected that the `TraceSubRowGenerator` trait
+or some analogous functionality is also implemented so that the trace generation of the `AuxCols`
+of each row can be done purely in terms of the `Io` part.
+
+```rust
+pub trait SubAir<AB: AirBuilder> {
+    /// Type to define the context, typically in terms of `AB::Expr` that are needed
+    /// to define the SubAir's constraints.
+    type AirContext<'a>
+    where
+        Self: 'a,
+        AB: 'a,
+        AB::Var: 'a,
+        AB::Expr: 'a;
+
+    fn eval<'a>(&'a self, builder: &'a mut AB, ctx: Self::AirContext<'a>)
+    where
+        AB::Var: 'a,
+        AB::Expr: 'a;
+}
+```
+
+Helper for generation of the trace on a subset of the columns in a single row
+of the trace matrix.
+
+```rust
+pub trait TraceSubRowGenerator<F> {
+    /// The minimal amount of information needed to generate the sub-row of the trace matrix.
+    /// This type has a lifetime so other context, such as references to other chips, can be provided.
+    type TraceContext<'a>
+    where
+        Self: 'a;
+    /// The type for the columns to mutate. Often this can be `&'a mut Cols<F>` if `Cols` is on the stack.
+    /// For structs that use the heap, this should be a struct that contains mutable slices.
+    type ColsMut<'a>
+    where
+        Self: 'a;
+
+    fn generate_subrow<'a>(&'a self, ctx: Self::TraceContext<'a>, sub_row: Self::ColsMut<'a>);
+}
+```

--- a/crates/circuits/primitives/src/range/README.md
+++ b/crates/circuits/primitives/src/range/README.md
@@ -3,36 +3,40 @@
 This chip is initialized with a `max` value and gets requests to verify that a number is in the range `[0, max)`. It has only two columns `counter` and `mult`. The `counter` column is preprocessed and the `mult` is left unconstrained.
 
 The `RangeCheckerAir` adds interaction constraints:
+
 ```
     self.bus.receive(prep_local.counter).eval(builder, local.mult);
 ```
+
 This adds the constraint that on every row, the AIR will receive the `counter` field with multiplicity `mult`.
 
 Suppose we have another AIR that wants to constrain that the value in column `x` is within `[0, max)` whenever another boolean column `cond` is 1. It will do so by adding constraint
-``` 
+
+```
     self.bus.send(x).eval(builder, cond);
 ```
+
 where the bus index must equal that used for `RangeChecker`.
 
 Now during trace generation, every time the requester chip want to range check `x` with non-zero `cond`, it will increment the `mult` trace value in `RangeChecker`'s trace by `cond`. All `mult` trace values start at 0.
 
-If the non-materialized send and receive multisets on the shared bus are equal, so the range check is satisfied.
+If the non-materialized send and receive multisets on the shared bus are equal, then the range check is satisfied.
 
 ## Example
 
 To give a concrete example, let's say `max` is 8 and the trace of Requester looks like this:
 
-| x | cond |
-|---|------|
-| 4 | 1    |
-| 1 | 1    |
-| 1 | 1    |
+| x    | cond |
+| ---- | ---- |
+| 4    | 1    |
+| 1    | 1    |
+| 1    | 1    |
 | 1000 | 0    |
 
 Then if the `mult` trace values in `RangeChecker` were properly updated, the `RangeChecker` trace would look like this:
 
 | counter | mult |
-|---------|------|
+| ------- | ---- |
 | 0       | 0    |
 | 1       | 2    |
 | 2       | 0    |
@@ -43,10 +47,12 @@ Then if the `mult` trace values in `RangeChecker` were properly updated, the `Ra
 | 7       | 0    |
 
 In this example, the multisets on the shared bus will be:
+
 - Send multiset: `1 * [4] + 1 * [1] + 1 * [1]`
 - Receive multiset: `2 * [1] + 1 * [4]`
 
 These multisets are equal, so the range check is satisfied.
 
 ### ⚠️ Caution
-We almost always prefer to use the [VariableRangeCheckerChip](../var_range/mod.rs) instead of this chip.
+
+We almost always prefer to use the [VariableRangeCheckerChip](../var_range/README.md) instead of this chip.

--- a/crates/circuits/primitives/src/range/README.md
+++ b/crates/circuits/primitives/src/range/README.md
@@ -1,0 +1,52 @@
+# Range Checker
+
+This chip is initialized with a `max` value and gets requests to verify that a number is in the range `[0, max)`. It has only two columns `counter` and `mult`. The `counter` column is preprocessed and the `mult` is left unconstrained.
+
+The `RangeCheckerAir` adds interaction constraints:
+```
+    self.bus.receive(prep_local.counter).eval(builder, local.mult);
+```
+This adds the constraint that on every row, the AIR will receive the `counter` field with multiplicity `mult`.
+
+Suppose we have another AIR that wants to constrain that the value in column `x` is within `[0, max)` whenever another boolean column `cond` is 1. It will do so by adding constraint
+``` 
+    self.bus.send(x).eval(builder, cond);
+```
+where the bus index must equal that used for `RangeChecker`.
+
+Now during trace generation, every time the requester chip want to range check `x` with non-zero `cond`, it will increment the `mult` trace value in `RangeChecker`'s trace by `cond`. All `mult` trace values start at 0.
+
+If the non-materialized send and receive multisets on the shared bus are equal, so the range check is satisfied.
+
+## Example
+
+To give a concrete example, let's say `max` is 8 and the trace of Requester looks like this:
+
+| x | cond |
+|---|------|
+| 4 | 1    |
+| 1 | 1    |
+| 1 | 1    |
+| 1000 | 0    |
+
+Then if the `mult` trace values in `RangeChecker` were properly updated, the `RangeChecker` trace would look like this:
+
+| counter | mult |
+|---------|------|
+| 0       | 0    |
+| 1       | 2    |
+| 2       | 0    |
+| 3       | 0    |
+| 4       | 1    |
+| 5       | 0    |
+| 6       | 0    |
+| 7       | 0    |
+
+In this example, the multisets on the shared bus will be:
+- Send multiset: `1 * [4] + 1 * [1] + 1 * [1]`
+- Receive multiset: `2 * [1] + 1 * [4]`
+
+These multisets are equal, so the range check is satisfied.
+
+### ⚠️ Caution
+We almost always prefer to use the [VariableRangeCheckerChip](../var_range/mod.rs) instead of this chip.

--- a/crates/circuits/primitives/src/range_gate/README.md
+++ b/crates/circuits/primitives/src/range_gate/README.md
@@ -1,0 +1,22 @@
+# Range Gate
+
+This chip gets requests to verify that a number is in the range `[0, MAX)`.
+In the trace, there is a counter column and a multiplicity column. 
+The counter column is generated using a gate, as opposed tothe [RangeCheckerChip](../range/README.md).
+
+The `RangeCheckerGateAir` constrains that the `counter` column is increasing from 0 to `MAX - 1` and also leaves the `mult` column unconstrained.
+
+```rust
+    builder
+        .when_first_row()
+        .assert_eq(local.counter, AB::Expr::ZERO);
+    builder
+        .when_transition()
+        .assert_eq(local.counter + AB::Expr::ONE, next.counter);
+    builder.when_last_row().assert_eq(
+        local.counter,
+        AB::F::from_canonical_u32(self.bus.range_max - 1),
+    );
+```
+
+Other than that, the interaction constraints work similarly to the [RangeCheckerChip](../range/README.md).

--- a/crates/circuits/primitives/src/range_gate/README.md
+++ b/crates/circuits/primitives/src/range_gate/README.md
@@ -1,8 +1,9 @@
 # Range Gate
 
 This chip gets requests to verify that a number is in the range `[0, MAX)`.
-In the trace, there is a counter column and a multiplicity column. 
-The counter column is generated using a gate, as opposed tothe [RangeCheckerChip](../range/README.md).
+In the trace, there is a counter column and a multiplicity column.
+The counter column is generated using constraints (gates), as opposed to the [RangeCheckerChip](../range/README.md) which uses preprocessed trace.
+The difference is that this chip does not use any preprocessed trace.
 
 The `RangeCheckerGateAir` constrains that the `counter` column is increasing from 0 to `MAX - 1` and also leaves the `mult` column unconstrained.
 

--- a/crates/circuits/primitives/src/var_range/README.md
+++ b/crates/circuits/primitives/src/var_range/README.md
@@ -2,6 +2,6 @@
 
 This chip is similar in functionality to the [Range Checker](../range/README.md) but is more general. It is initialized with a `range_max_bits` value and provides a lookup table for range checking a variable `x` has `b` bits where `b` can be any integer in `[0, range_max_bits]`. In other words, this chip can be used to range check for different bit sizes. We define `0` to have `0` bits.
 
-The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, \mathtt{range\_max\_bits}]$.
+The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, \mathtt{range\\_max\\_bits}]$.
 
 The functionality and usage of the chip are very similar to those of the [Range Checker](../range/README.md) chip.

--- a/crates/circuits/primitives/src/var_range/README.md
+++ b/crates/circuits/primitives/src/var_range/README.md
@@ -2,6 +2,6 @@
 
 This chip is similar in functionality to the [Range Checker](../range/README.md) but is more general. It is initialized with a `range_max_bits` value and provides a lookup table for range checking a variable `x` has `b` bits where `b` can be any integer in `[0, range_max_bits]`. In other words, this chip can be used to range check for different bit sizes. We define `0` to have `0` bits.
 
-The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, range\_max\_bits]$.
+The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, \mathtt{range_max_bits}]$.
 
 The functionality and usage of the chip are very similar to those of the [Range Checker](../range/README.md) chip.

--- a/crates/circuits/primitives/src/var_range/README.md
+++ b/crates/circuits/primitives/src/var_range/README.md
@@ -3,3 +3,5 @@
 This chip is similar in functionality to the [Range Checker](../range/README.md) but is more general. It is initialized with a `range_max_bits` value and provides a lookup table for range checking a variable `x` has `b` bits where `b` can be any integer in `[0, range_max_bits]`. In other words, this chip can be used to range check for different bit sizes. We define `0` to have `0` bits.
 
 The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, range\_max\_bits]$.
+
+The functionality and usage of the chip are very similar to those of the [Range Checker](../range/README.md) chip.

--- a/crates/circuits/primitives/src/var_range/README.md
+++ b/crates/circuits/primitives/src/var_range/README.md
@@ -2,6 +2,6 @@
 
 This chip is similar in functionality to the [Range Checker](../range/README.md) but is more general. It is initialized with a `range_max_bits` value and provides a lookup table for range checking a variable `x` has `b` bits where `b` can be any integer in `[0, range_max_bits]`. In other words, this chip can be used to range check for different bit sizes. We define `0` to have `0` bits.
 
-The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, \mathtt{range_max_bits}]$.
+The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, \mathtt{range\_max\_bits}]$.
 
 The functionality and usage of the chip are very similar to those of the [Range Checker](../range/README.md) chip.

--- a/crates/circuits/primitives/src/var_range/README.md
+++ b/crates/circuits/primitives/src/var_range/README.md
@@ -1,0 +1,5 @@
+# Variable Range Checker
+
+This chip is similar in functionality to the [Range Checker](../range/README.md) but is more general. It is initialized with a `range_max_bits` value and provides a lookup table for range checking a variable `x` has `b` bits where `b` can be any integer in `[0, range_max_bits]`. In other words, this chip can be used to range check for different bit sizes. We define `0` to have `0` bits.
+
+The chip has three columns `value, max_bits, mult`. The `value, max_bits` columns are preprocessed and the `mult` column is left unconstrained. The `(value, max_bits)` preprocessed trace is populated with `(x, b)` for all $x \in [0, 2^b)$ and $b \in [0, range\_max\_bits]$.

--- a/crates/circuits/primitives/src/xor/README.md
+++ b/crates/circuits/primitives/src/xor/README.md
@@ -1,0 +1,15 @@
+# XOR Chip
+
+This chip gets requests to compute the xor of two numbers `x` and `y` of at most `M` bits.
+
+It generates a preprocessed table with a row for each possible triple `(x, y, x^y)`
+and keeps count of the number of times each triple is requested for the single main trace column.
+
+The `XorLookupAir` adds interaction constraints for each triple `(x, y, x^y)` requested.
+```rust
+    self.bus
+        .receive(prep_local.x, prep_local.y, prep_local.z)
+        .eval(builder, local.mult);
+```
+
+Then similar to the [RangeCheckerChip](../range/README.md), if the non-materialized send and receive multisets on the shared `XorBus` are equal, then the xor lookup is satisfied.


### PR DESCRIPTION
- Added a README for `circuits/primitives`, which includes links to each circuit in the directory.
- Specifically added README for `range_check`, `range_gate`, and `xor`.
- For the SubAir primitives, I linked directly to mod.rs, as it already contains detailed inline comments.

Closes INT-3090