### PR TITLE
chore: fix keccak address space `e = 2`

### DIFF
--- a/extensions/keccak256/circuit/src/columns.rs
+++ b/extensions/keccak256/circuit/src/columns.rs
@@ -48,8 +48,6 @@ pub struct KeccakInstructionCols<T> {
     pub src_ptr: T,
     /// Pointer to address space 1 `len` register
     pub len_ptr: T,
-    /// Memory address space
-    pub e: T,
     // Register values
     /// dst <- \[dst_ptr:4\]_1
     pub dst: [T; RV32_REGISTER_NUM_LIMBS],
@@ -140,7 +138,6 @@ impl<T: Copy> KeccakInstructionCols<T> {
         builder.assert_eq(self.dst_ptr, other.dst_ptr);
         builder.assert_eq(self.src_ptr, other.src_ptr);
         builder.assert_eq(self.len_ptr, other.len_ptr);
-        builder.assert_eq(self.e, other.e);
         assert_array_eq(builder, self.dst, other.dst);
         assert_array_eq(builder, self.src_limbs, other.src_limbs);
         builder.assert_eq(self.src, other.src);

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -69,8 +69,6 @@ where
             let src_read = memory.record_by_id(record.src_read);
             let len_read = memory.record_by_id(record.len_read);
 
-            let digest_writes = record.digest_writes.map(|id| memory.record_by_id(id));
-
             state = [0u64; 25];
             let src_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = from_fn(|i| src_read.data[i + 1]);
             let len_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = from_fn(|i| len_read.data[i + 1]);
@@ -82,7 +80,6 @@ where
                 dst_ptr: dst_read.pointer,
                 src_ptr: src_read.pointer,
                 len_ptr: len_read.pointer,
-                e: digest_writes[0].address_space,
                 dst: dst_read.data.clone().try_into().unwrap(),
                 src_limbs,
                 src: Val::<SC>::from_canonical_usize(record.input_blocks[0].src),


### PR DESCRIPTION
for safety to prevent keccak from being able to write to address space 0 or 1.

towards INT-3123