### PR TITLE
chore: Remove Vec from MemoryRecord interface

### DIFF
--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -98,7 +98,7 @@ where
                 pointer: record.pointer,
             };
             row.data
-                .copy_from_slice(record.prev_data.as_ref().unwrap_or(&record.data));
+                .copy_from_slice(record.prev_data_slice().unwrap_or(record.data_slice()));
             row.timestamp = Val::<SC>::from_canonical_u32(record.prev_timestamp);
             row.count = -Val::<SC>::ONE;
 
@@ -107,7 +107,7 @@ where
                 address_space: record.address_space,
                 pointer: record.pointer,
             };
-            row.data.copy_from_slice(&record.data);
+            row.data.copy_from_slice(record.data_slice());
             row.timestamp = Val::<SC>::from_canonical_u32(record.timestamp);
             row.count = Val::<SC>::ONE;
         }

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -740,7 +740,7 @@ impl<F: PrimeField32> MemoryAuxColsFactory<F> {
     ) {
         buffer
             .prev_data
-            .copy_from_slice(write.prev_data.as_ref().unwrap());
+            .copy_from_slice(write.prev_data_slice().unwrap());
         self.generate_base_aux(write, &mut buffer.base);
     }
 
@@ -783,7 +783,7 @@ impl<F: PrimeField32> MemoryAuxColsFactory<F> {
         &self,
         write: &MemoryRecord<F>,
     ) -> MemoryWriteAuxCols<F, N> {
-        let prev_data = write.prev_data.clone().unwrap();
+        let prev_data = write.prev_data_slice().unwrap();
         MemoryWriteAuxCols::new(
             prev_data.try_into().unwrap(),
             F::from_canonical_u32(write.prev_timestamp),

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -31,9 +31,25 @@ pub struct MemoryRecord<T> {
     pub pointer: T,
     pub timestamp: u32,
     pub prev_timestamp: u32,
-    pub data: Vec<T>,
+    data: Vec<T>,
     /// None if a read.
-    pub prev_data: Option<Vec<T>>,
+    prev_data: Option<Vec<T>>,
+}
+
+impl<T> MemoryRecord<T> {
+    pub fn data_slice(&self) -> &[T] {
+        self.data.as_slice()
+    }
+
+    pub fn prev_data_slice(&self) -> Option<&[T]> {
+        self.prev_data.as_deref()
+    }
+}
+
+impl<T: Copy> MemoryRecord<T> {
+    pub fn data_at(&self, index: usize) -> T {
+        self.data[index]
+    }
 }
 
 pub struct OfflineMemory<F> {

--- a/crates/vm/src/system/memory/tests.rs
+++ b/crates/vm/src/system/memory/tests.rs
@@ -166,30 +166,30 @@ fn generate_trace<F: PrimeField32>(
         row.pointer = record.pointer;
         row.timestamp = F::from_canonical_u32(record.timestamp);
 
-        match (record.data.len(), &record.prev_data) {
+        match (record.data_slice().len(), &record.prev_data_slice()) {
             (1, &None) => {
                 aux_factory.generate_read_aux(&record, &mut row.read_1_aux);
-                row.data_1 = record.data.try_into().unwrap();
+                row.data_1 = record.data_slice().try_into().unwrap();
                 row.is_read_1 = F::ONE;
             }
             (1, &Some(_)) => {
                 aux_factory.generate_write_aux(&record, &mut row.write_1_aux);
-                row.data_1 = record.data.try_into().unwrap();
+                row.data_1 = record.data_slice().try_into().unwrap();
                 row.is_write_1 = F::ONE;
             }
             (4, &None) => {
                 aux_factory.generate_read_aux(&record, &mut row.read_4_aux);
-                row.data_4 = record.data.try_into().unwrap();
+                row.data_4 = record.data_slice().try_into().unwrap();
                 row.is_read_4 = F::ONE;
             }
             (4, &Some(_)) => {
                 aux_factory.generate_write_aux(&record, &mut row.write_4_aux);
-                row.data_4 = record.data.try_into().unwrap();
+                row.data_4 = record.data_slice().try_into().unwrap();
                 row.is_write_4 = F::ONE;
             }
             (MAX, &None) => {
                 aux_factory.generate_read_aux(&record, &mut row.read_max_aux);
-                row.data_max = record.data.try_into().unwrap();
+                row.data_max = record.data_slice().try_into().unwrap();
                 row.is_read_max = F::ONE;
             }
             _ => panic!("unexpected pattern"),

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -70,8 +70,14 @@ where
             let len_read = memory.record_by_id(record.len_read);
 
             state = [0u64; 25];
-            let src_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = from_fn(|i| src_read.data[i + 1]);
-            let len_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = from_fn(|i| len_read.data[i + 1]);
+            let src_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = src_read.data_slice()
+                [..RV32_REGISTER_NUM_LIMBS - 1]
+                .try_into()
+                .unwrap();
+            let len_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = len_read.data_slice()
+                [..RV32_REGISTER_NUM_LIMBS - 1]
+                .try_into()
+                .unwrap();
             let mut instruction = KeccakInstructionCols {
                 pc: record.pc,
                 is_enabled: Val::<SC>::ONE,
@@ -80,7 +86,7 @@ where
                 dst_ptr: dst_read.pointer,
                 src_ptr: src_read.pointer,
                 len_ptr: len_read.pointer,
-                dst: dst_read.data.clone().try_into().unwrap(),
+                dst: dst_read.data_slice().try_into().unwrap(),
                 src_limbs,
                 src: Val::<SC>::from_canonical_usize(record.input_blocks[0].src),
                 len_limbs,
@@ -175,7 +181,7 @@ where
                         row_mut
                             .mem_oc
                             .partial_block
-                            .copy_from_slice(&partial_read.data[1..]);
+                            .copy_from_slice(&partial_read.data_slice()[1..]);
                     }
                     for (i, is_padding) in row_mut.sponge.is_padding_byte.iter_mut().enumerate() {
                         *is_padding = Val::<SC>::from_bool(i >= block.remaining_len);
@@ -196,7 +202,7 @@ where
                     .map(|r| {
                         memory
                             .record_by_id(*r)
-                            .data
+                            .data_slice()
                             .last()
                             .unwrap()
                             .as_canonical_u32()

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -71,11 +71,11 @@ where
 
             state = [0u64; 25];
             let src_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = src_read.data_slice()
-                [..RV32_REGISTER_NUM_LIMBS - 1]
+                [1..RV32_REGISTER_NUM_LIMBS]
                 .try_into()
                 .unwrap();
             let len_limbs: [_; RV32_REGISTER_NUM_LIMBS - 1] = len_read.data_slice()
-                [..RV32_REGISTER_NUM_LIMBS - 1]
+                [1..RV32_REGISTER_NUM_LIMBS]
                 .try_into()
                 .unwrap();
             let mut instruction = KeccakInstructionCols {

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -1,6 +1,5 @@
 use core::ops::Deref;
 use std::{
-    array,
     borrow::{Borrow, BorrowMut},
     mem::offset_of,
     sync::{Arc, Mutex},
@@ -573,10 +572,10 @@ fn record_to_rows<F: PrimeField32>(
     let a_ptr_read = memory.record_by_id(record.a_ptr_read);
     let b_ptr_read = memory.record_by_id(record.b_ptr_read);
 
-    let length = length_read.data[0].as_canonical_u32() as usize;
-    let alpha: [F; EXT_DEG] = array::from_fn(|i| alpha_read.data[i]);
-    let a_ptr = a_ptr_read.data[0];
-    let b_ptr = b_ptr_read.data[0];
+    let length = length_read.data_at(0).as_canonical_u32() as usize;
+    let alpha: [F; EXT_DEG] = alpha_read.data_slice().try_into().unwrap();
+    let a_ptr = a_ptr_read.data_at(0);
+    let b_ptr = b_ptr_read.data_at(0);
 
     let mut result = [F::ZERO; EXT_DEG];
 
@@ -597,8 +596,8 @@ fn record_to_rows<F: PrimeField32>(
     {
         let a_read = memory.record_by_id(a_record_id);
         let b_read = memory.record_by_id(b_record_id);
-        let a = a_read.data[0];
-        let b: [F; EXT_DEG] = array::from_fn(|i| b_read.data[i]);
+        let a = a_read.data_at(0);
+        let b: [F; EXT_DEG] = b_read.data_slice().try_into().unwrap();
 
         let start = i * OVERALL_WIDTH;
         let cols: &mut WorkloadCols<F> = slice[start..start + WL_WIDTH].borrow_mut();

--- a/extensions/native/circuit/src/poseidon2/trace.rs
+++ b/extensions/native/circuit/src/poseidon2/trace.rs
@@ -114,7 +114,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Chip<F, SBOX_R
             &mut specific.read_final_height_or_sibling_array_start,
         );
         specific.root_is_on_right = F::from_bool(root_is_on_right);
-        specific.sibling_array_start = read_sibling_array_start.data[0];
+        specific.sibling_array_start = read_sibling_array_start.data_at(0);
     }
     fn correct_last_top_level_row(
         &self,

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -399,7 +399,7 @@ impl<
         let rs = read_record.rs.map(|r| memory.record_by_id(r));
         for (i, r) in rs.iter().enumerate() {
             row_slice.rs_ptr[i] = r.pointer;
-            row_slice.rs_val[i].copy_from_slice(&r.data);
+            row_slice.rs_val[i].copy_from_slice(r.data_slice());
             aux_cols_factory.generate_read_aux(r, &mut row_slice.rs_read_aux[i]);
             for (j, x) in read_record.reads[i].iter().enumerate() {
                 let read = memory.record_by_id(*x);
@@ -414,7 +414,9 @@ impl<
         // Range checks
         let need_range_check: [u32; 2] = from_fn(|i| {
             if i < NUM_READS {
-                rs[i].data[RV32_REGISTER_NUM_LIMBS - 1].as_canonical_u32()
+                rs[i]
+                    .data_at(RV32_REGISTER_NUM_LIMBS - 1)
+                    .as_canonical_u32()
             } else {
                 0
             }

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -290,7 +290,7 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> VmAdapterC
 
         for (i, rs_read) in rs_reads.iter().enumerate() {
             row_slice.rs_ptr[i] = rs_read.pointer;
-            row_slice.rs_val[i].copy_from_slice(&rs_read.data);
+            row_slice.rs_val[i].copy_from_slice(rs_read.data_slice());
             aux_cols_factory.generate_read_aux(rs_read, &mut row_slice.rs_read_aux[i]);
         }
 
@@ -302,7 +302,11 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> VmAdapterC
         // Range checks:
         let need_range_check: Vec<u32> = rs_reads
             .iter()
-            .map(|record| record.data[RV32_REGISTER_NUM_LIMBS - 1].as_canonical_u32())
+            .map(|record| {
+                record
+                    .data_at(RV32_REGISTER_NUM_LIMBS - 1)
+                    .as_canonical_u32()
+            })
             .chain(once(0)) // in case NUM_READS is odd
             .collect();
         debug_assert!(self.air.address_bits <= RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS);

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -502,11 +502,11 @@ pub(super) fn vec_heap_generate_trace_row_impl<
         .collect::<Vec<_>>();
 
     row_slice.rd_ptr = rd.pointer;
-    row_slice.rd_val.copy_from_slice(&rd.data);
+    row_slice.rd_val.copy_from_slice(rd.data_slice());
 
     for (i, r) in rs.iter().enumerate() {
         row_slice.rs_ptr[i] = r.pointer;
-        row_slice.rs_val[i].copy_from_slice(&r.data);
+        row_slice.rs_val[i].copy_from_slice(r.data_slice());
         aux_cols_factory.generate_read_aux(r, &mut row_slice.rs_read_aux[i]);
     }
 
@@ -528,7 +528,11 @@ pub(super) fn vec_heap_generate_trace_row_impl<
     let need_range_check: Vec<u32> = rs
         .iter()
         .chain(std::iter::repeat(&rd).take(2))
-        .map(|record| record.data[RV32_REGISTER_NUM_LIMBS - 1].as_canonical_u32())
+        .map(|record| {
+            record
+                .data_at(RV32_REGISTER_NUM_LIMBS - 1)
+                .as_canonical_u32()
+        })
         .collect();
     debug_assert!(address_bits <= RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS);
     let limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - address_bits;

--- a/extensions/rv32-adapters/src/vec_heap_two_reads.rs
+++ b/extensions/rv32-adapters/src/vec_heap_two_reads.rs
@@ -531,9 +531,9 @@ pub(super) fn vec_heap_two_reads_generate_trace_row_impl<
     row_slice.rs1_ptr = rs1.pointer;
     row_slice.rs2_ptr = rs2.pointer;
 
-    row_slice.rd_val.copy_from_slice(&rd.data);
-    row_slice.rs1_val.copy_from_slice(&rs1.data);
-    row_slice.rs2_val.copy_from_slice(&rs2.data);
+    row_slice.rd_val.copy_from_slice(rd.data_slice());
+    row_slice.rs1_val.copy_from_slice(rs1.data_slice());
+    row_slice.rs2_val.copy_from_slice(rs2.data_slice());
 
     aux_cols_factory.generate_read_aux(rs1, &mut row_slice.rs1_read_aux);
     aux_cols_factory.generate_read_aux(rs2, &mut row_slice.rs2_read_aux);
@@ -561,7 +561,10 @@ pub(super) fn vec_heap_two_reads_generate_trace_row_impl<
         &read_record.rd,
     ]
     .map(|record| {
-        memory.record_by_id(*record).data[RV32_REGISTER_NUM_LIMBS - 1].as_canonical_u32()
+        memory
+            .record_by_id(*record)
+            .data_at(RV32_REGISTER_NUM_LIMBS - 1)
+            .as_canonical_u32()
     });
     debug_assert!(address_bits <= RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS);
     let limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - address_bits;

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -466,7 +466,7 @@ impl<F: PrimeField32> VmAdapterChip<F> for Rv32LoadStoreAdapterChip<F> {
         let adapter_cols: &mut Rv32LoadStoreAdapterCols<_> = row_slice.borrow_mut();
         adapter_cols.from_state = write_record.from_state.map(F::from_canonical_u32);
         let rs1 = memory.record_by_id(read_record.rs1_record);
-        adapter_cols.rs1_data.copy_from_slice(&rs1.data);
+        adapter_cols.rs1_data.copy_from_slice(rs1.data_slice());
         aux_cols_factory.generate_read_aux(rs1, &mut adapter_cols.rs1_aux_cols);
         adapter_cols.rs1_ptr = read_record.rs1_ptr;
         adapter_cols.rd_rs2_ptr = write_record.rd_rs2_ptr;

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -60,10 +60,16 @@ where
             let len_read = offline_memory.record_by_id(record.len_read);
 
             self.bitwise_lookup_chip.request_range(
-                dst_read.data[RV32_REGISTER_NUM_LIMBS - 1].as_canonical_u32() * mem_ptr_shift,
-                src_read.data[RV32_REGISTER_NUM_LIMBS - 1].as_canonical_u32() * mem_ptr_shift,
+                dst_read
+                    .data_at(RV32_REGISTER_NUM_LIMBS - 1)
+                    .as_canonical_u32()
+                    * mem_ptr_shift,
+                src_read
+                    .data_at(RV32_REGISTER_NUM_LIMBS - 1)
+                    .as_canonical_u32()
+                    * mem_ptr_shift,
             );
-            let len = compose(len_read.data.clone().try_into().unwrap());
+            let len = compose(len_read.data_slice().try_into().unwrap());
             let mut state = &None;
             for (i, input_message) in record.input_message.iter().enumerate() {
                 let input_message = input_message
@@ -217,9 +223,9 @@ where
                                 cols.rd_ptr = dst_read.pointer;
                                 cols.rs1_ptr = src_read.pointer;
                                 cols.rs2_ptr = len_read.pointer;
-                                cols.dst_ptr.copy_from_slice(&dst_read.data);
-                                cols.src_ptr.copy_from_slice(&src_read.data);
-                                cols.len_data.copy_from_slice(&len_read.data);
+                                cols.dst_ptr.copy_from_slice(dst_read.data_slice());
+                                cols.src_ptr.copy_from_slice(src_read.data_slice());
+                                cols.len_data.copy_from_slice(len_read.data_slice());
                                 memory_aux_cols_factory
                                     .generate_read_aux(dst_read, &mut cols.register_reads_aux[0]);
                                 memory_aux_cols_factory


### PR DESCRIPTION
This allows us to change out the implementation (e.g., SmallVec) without affecting the interface