### PR TITLE
chore: remove re-exported testing constants

### DIFF
--- a/crates/circuits/sha256-air/src/tests.rs
+++ b/crates/circuits/sha256-air/src/tests.rs
@@ -1,7 +1,8 @@
 use std::{array, cmp::max, sync::Arc};
 
 use openvm_circuit::arch::{
-    instructions::riscv::RV32_CELL_BITS, testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
+    instructions::riscv::RV32_CELL_BITS,
+    testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -7,13 +7,6 @@ use openvm_poseidon2_air::Poseidon2Config;
 use openvm_stark_backend::{p3_field::PrimeField32, ChipUsageGetter, Stateful};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-// TODO[jpw]: re-exporting hardcoded bus constants for tests. Import paths should be
-// updated directly but it changes many files.
-#[cfg(any(test, feature = "test-utils"))]
-pub use super::testing::{
-    BITWISE_OP_LOOKUP_BUS, BYTE_XOR_BUS, EXECUTION_BUS, MEMORY_BUS, MEMORY_MERKLE_BUS,
-    POSEIDON2_DIRECT_BUS, RANGE_TUPLE_CHECKER_BUS, READ_INSTRUCTION_BUS,
-};
 use super::{
     segment::{DefaultSegmentationStrategy, SegmentationStrategy},
     AnyEnum, InstructionExecutor, SystemComplex, SystemExecutor, SystemPeriphery, VmChipComplex,

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -815,7 +815,7 @@ mod tests {
 
     use super::MemoryController;
     use crate::{
-        arch::{MemoryConfig, MEMORY_BUS},
+        arch::{testing::MEMORY_BUS, MemoryConfig},
         system::memory::offline_checker::MemoryBus,
     };
 

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -18,7 +18,7 @@ use rand::RngCore;
 
 use super::DirectCompressionBus;
 use crate::{
-    arch::{MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
+    arch::testing::{MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
     system::memory::{
         merkle::{
             columns::MemoryMerkleCols, tests::util::HashTestChip, MemoryDimensions,

--- a/crates/vm/src/system/memory/merkle/tests/util.rs
+++ b/crates/vm/src/system/memory/merkle/tests/util.rs
@@ -12,7 +12,7 @@ use openvm_stark_sdk::dummy_airs::interaction::dummy_interaction_air::DummyInter
 
 use crate::arch::{
     hasher::{Hasher, HasherChip},
-    POSEIDON2_DIRECT_BUS,
+    testing::POSEIDON2_DIRECT_BUS,
 };
 
 pub fn test_hash_sum<const CHUNK: usize, F: Field>(

--- a/crates/vm/src/system/memory/tests.rs
+++ b/crates/vm/src/system/memory/tests.rs
@@ -31,8 +31,8 @@ use rand::{
 use super::{merkle::DirectCompressionBus, MemoryController};
 use crate::{
     arch::{
-        testing::memory::gen_pointer, MemoryConfig, MEMORY_BUS, MEMORY_MERKLE_BUS,
-        POSEIDON2_DIRECT_BUS,
+        testing::{memory::gen_pointer, MEMORY_BUS, MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
+        MemoryConfig,
     },
     system::{
         memory::{

--- a/crates/vm/src/system/poseidon2/tests.rs
+++ b/crates/vm/src/system/poseidon2/tests.rs
@@ -10,8 +10,7 @@ use rand::RngCore;
 use crate::{
     arch::{
         hasher::{Hasher, HasherChip},
-        testing::VmChipTestBuilder,
-        POSEIDON2_DIRECT_BUS,
+        testing::{VmChipTestBuilder, POSEIDON2_DIRECT_BUS},
     },
     system::poseidon2::{
         Poseidon2PeripheryChip, PERIPHERY_POSEIDON2_CHUNK_SIZE, PERIPHERY_POSEIDON2_WIDTH,

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -28,7 +28,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use static_assertions::assert_impl_all;
 
 use crate::{
-    arch::{instructions::SystemOpcode::*, READ_INSTRUCTION_BUS},
+    arch::{instructions::SystemOpcode::*, testing::READ_INSTRUCTION_BUS},
     system::program::{trace::VmCommittedExe, ProgramBus, ProgramChip},
 };
 

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -91,7 +91,7 @@ mod tests {
     use halo2curves_axiom::{bn256::Fq2, ff::Field};
     use itertools::Itertools;
     use openvm_algebra_transpiler::Fp2Opcode;
-    use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+    use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
     use openvm_circuit_primitives::bitwise_op_lookup::{
         BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
     };

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -130,7 +130,7 @@ mod tests {
     use halo2curves_axiom::{bn256::Fq2, ff::Field};
     use itertools::Itertools;
     use openvm_algebra_transpiler::Fp2Opcode;
-    use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+    use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
     use openvm_circuit_primitives::bitwise_op_lookup::{
         BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
     };

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -4,7 +4,8 @@ use num_bigint::BigUint;
 use num_traits::Zero;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::arch::{
-    instructions::LocalOpcode, testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
+    instructions::LocalOpcode,
+    testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
 };
 use openvm_circuit_primitives::{
     bigint::utils::{big_uint_to_limbs, secp256k1_coord_prime, secp256k1_scalar_prime},

--- a/extensions/bigint/circuit/src/tests.rs
+++ b/extensions/bigint/circuit/src/tests.rs
@@ -4,8 +4,8 @@ use openvm_bigint_transpiler::{
 };
 use openvm_circuit::{
     arch::{
-        testing::VmChipTestBuilder, InstructionExecutor, BITWISE_OP_LOOKUP_BUS,
-        RANGE_TUPLE_CHECKER_BUS,
+        testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS, RANGE_TUPLE_CHECKER_BUS},
+        InstructionExecutor,
     },
     utils::generate_long_number,
 };

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Num, Zero};
-use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
 use openvm_circuit_primitives::{
     bigint::utils::{secp256k1_coord_prime, secp256r1_coord_prime},
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},

--- a/extensions/keccak256/circuit/src/tests.rs
+++ b/extensions/keccak256/circuit/src/tests.rs
@@ -1,10 +1,7 @@
 use std::borrow::BorrowMut;
 
 use hex::FromHex;
-use openvm_circuit::arch::{
-    testing::{VmChipTestBuilder, VmChipTester},
-    BITWISE_OP_LOOKUP_BUS,
-};
+use openvm_circuit::arch::testing::{VmChipTestBuilder, VmChipTester, BITWISE_OP_LOOKUP_BUS};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };

--- a/extensions/pairing/circuit/src/fp12_chip/mul.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/mul.rs
@@ -76,7 +76,7 @@ pub fn fp12_mul_expr(
 mod tests {
     use halo2curves_axiom::{bn256::Fq12, ff::Field};
     use itertools::Itertools;
-    use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+    use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
     use openvm_circuit_primitives::bitwise_op_lookup::{
         BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
     };

--- a/extensions/pairing/circuit/src/fp12_chip/tests.rs
+++ b/extensions/pairing/circuit/src/fp12_chip/tests.rs
@@ -1,5 +1,8 @@
 use num_bigint::BigUint;
-use openvm_circuit::arch::{testing::VmChipTestBuilder, VmChipWrapper, BITWISE_OP_LOOKUP_BUS};
+use openvm_circuit::arch::{
+    testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+    VmChipWrapper,
+};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };

--- a/extensions/pairing/circuit/src/pairing_chip/line/d_type/tests.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/d_type/tests.rs
@@ -2,7 +2,7 @@ use halo2curves_axiom::{
     bn256::{Fq, Fq12, Fq2, G1Affine},
     ff::Field,
 };
-use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };

--- a/extensions/pairing/circuit/src/pairing_chip/line/m_type/tests.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/line/m_type/tests.rs
@@ -2,7 +2,7 @@ use halo2curves_axiom::{
     bls12_381::{Fq, Fq12, Fq2, G1Affine},
     ff::Field,
 };
-use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_and_add_step.rs
@@ -106,7 +106,7 @@ pub fn miller_double_and_add_step_expr(
 #[cfg(test)]
 mod tests {
     use halo2curves_axiom::bn256::G2Affine;
-    use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+    use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
     use openvm_circuit_primitives::bitwise_op_lookup::{
         BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
     };

--- a/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
+++ b/extensions/pairing/circuit/src/pairing_chip/miller_double_step.rs
@@ -92,7 +92,7 @@ pub fn miller_double_step_expr(
 
 #[cfg(test)]
 mod tests {
-    use openvm_circuit::arch::{testing::VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
+    use openvm_circuit::arch::testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS};
     use openvm_circuit_primitives::bitwise_op_lookup::{
         BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
     };

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -2,8 +2,8 @@ use std::borrow::BorrowMut;
 
 use openvm_circuit::{
     arch::{
-        testing::{TestAdapterChip, VmChipTestBuilder},
-        ExecutionBridge, VmAdapterChip, VmChipWrapper, BITWISE_OP_LOOKUP_BUS,
+        testing::{TestAdapterChip, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+        ExecutionBridge, VmAdapterChip, VmChipWrapper,
     },
     utils::generate_long_number,
 };

--- a/extensions/rv32im/circuit/src/branch_lt/tests.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/tests.rs
@@ -2,9 +2,9 @@ use std::borrow::BorrowMut;
 
 use openvm_circuit::{
     arch::{
-        testing::{memory::gen_pointer, TestAdapterChip, VmChipTestBuilder},
+        testing::{memory::gen_pointer, TestAdapterChip, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
         BasicAdapterInterface, ExecutionBridge, ImmInstruction, InstructionExecutor, VmAdapterChip,
-        VmChipWrapper, VmCoreChip, BITWISE_OP_LOOKUP_BUS,
+        VmChipWrapper, VmCoreChip,
     },
     utils::{generate_long_number, i32_to_f},
 };

--- a/extensions/rv32im/circuit/src/divrem/tests.rs
+++ b/extensions/rv32im/circuit/src/divrem/tests.rs
@@ -2,9 +2,11 @@ use std::{array, borrow::BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        testing::{memory::gen_pointer, TestAdapterChip, VmChipTestBuilder},
-        ExecutionBridge, InstructionExecutor, VmAdapterChip, VmChipWrapper, BITWISE_OP_LOOKUP_BUS,
-        RANGE_TUPLE_CHECKER_BUS,
+        testing::{
+            memory::gen_pointer, TestAdapterChip, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
+            RANGE_TUPLE_CHECKER_BUS,
+        },
+        ExecutionBridge, InstructionExecutor, VmAdapterChip, VmChipWrapper,
     },
     utils::generate_long_number,
 };

--- a/extensions/rv32im/circuit/src/hintstore/tests.rs
+++ b/extensions/rv32im/circuit/src/hintstore/tests.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use openvm_circuit::arch::{
-    testing::{memory::gen_pointer, VmChipTestBuilder},
-    Streams, BITWISE_OP_LOOKUP_BUS,
+    testing::{memory::gen_pointer, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+    Streams,
 };
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,

--- a/extensions/rv32im/circuit/src/jal_lui/tests.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/tests.rs
@@ -1,6 +1,9 @@
 use std::borrow::BorrowMut;
 
-use openvm_circuit::arch::{testing::VmChipTestBuilder, VmAdapterChip, BITWISE_OP_LOOKUP_BUS};
+use openvm_circuit::arch::{
+    testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+    VmAdapterChip,
+};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -1,6 +1,9 @@
 use std::{array, borrow::BorrowMut};
 
-use openvm_circuit::arch::{testing::VmChipTestBuilder, VmAdapterChip, BITWISE_OP_LOOKUP_BUS};
+use openvm_circuit::arch::{
+    testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+    VmAdapterChip,
+};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };

--- a/extensions/rv32im/circuit/src/less_than/tests.rs
+++ b/extensions/rv32im/circuit/src/less_than/tests.rs
@@ -2,8 +2,8 @@ use std::borrow::BorrowMut;
 
 use openvm_circuit::{
     arch::{
-        testing::{TestAdapterChip, VmChipTestBuilder},
-        ExecutionBridge, VmAdapterChip, VmChipWrapper, BITWISE_OP_LOOKUP_BUS,
+        testing::{TestAdapterChip, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+        ExecutionBridge, VmAdapterChip, VmChipWrapper,
     },
     utils::{generate_long_number, i32_to_f},
 };

--- a/extensions/rv32im/circuit/src/mul/tests.rs
+++ b/extensions/rv32im/circuit/src/mul/tests.rs
@@ -2,8 +2,8 @@ use std::borrow::BorrowMut;
 
 use openvm_circuit::{
     arch::{
-        testing::{TestAdapterChip, VmChipTestBuilder},
-        ExecutionBridge, VmAdapterChip, VmChipWrapper, RANGE_TUPLE_CHECKER_BUS,
+        testing::{TestAdapterChip, VmChipTestBuilder, RANGE_TUPLE_CHECKER_BUS},
+        ExecutionBridge, VmAdapterChip, VmChipWrapper,
     },
     utils::generate_long_number,
 };

--- a/extensions/rv32im/circuit/src/mulh/tests.rs
+++ b/extensions/rv32im/circuit/src/mulh/tests.rs
@@ -2,9 +2,11 @@ use std::borrow::BorrowMut;
 
 use openvm_circuit::{
     arch::{
-        testing::{memory::gen_pointer, TestAdapterChip, VmChipTestBuilder},
-        ExecutionBridge, InstructionExecutor, VmAdapterChip, VmChipWrapper, BITWISE_OP_LOOKUP_BUS,
-        RANGE_TUPLE_CHECKER_BUS,
+        testing::{
+            memory::gen_pointer, TestAdapterChip, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
+            RANGE_TUPLE_CHECKER_BUS,
+        },
+        ExecutionBridge, InstructionExecutor, VmAdapterChip, VmChipWrapper,
     },
     utils::generate_long_number,
 };

--- a/extensions/rv32im/circuit/src/shift/tests.rs
+++ b/extensions/rv32im/circuit/src/shift/tests.rs
@@ -2,8 +2,8 @@ use std::{array, borrow::BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        testing::{TestAdapterChip, VmChipTestBuilder},
-        ExecutionBridge, VmAdapterChip, VmChipWrapper, BITWISE_OP_LOOKUP_BUS,
+        testing::{TestAdapterChip, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+        ExecutionBridge, VmAdapterChip, VmChipWrapper,
     },
     utils::generate_long_number,
 };

--- a/extensions/sha256/circuit/src/sha256_chip/tests.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/tests.rs
@@ -1,6 +1,6 @@
 use openvm_circuit::arch::{
-    testing::{memory::gen_pointer, VmChipTestBuilder},
-    SystemPort, BITWISE_OP_LOOKUP_BUS,
+    testing::{memory::gen_pointer, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+    SystemPort,
 };
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,


### PR DESCRIPTION
closes INT-2902