### PR TITLE
fix: update integration tests for new native address space restrictions

### DIFF
--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -70,6 +70,13 @@ impl DefaultSegmentationStrategy {
             max_cells_per_chip_in_segment: max_segment_len * 120,
         }
     }
+
+    pub fn new(max_segment_len: usize, max_cells_per_chip_in_segment: usize) -> Self {
+        Self {
+            max_segment_len,
+            max_cells_per_chip_in_segment,
+        }
+    }
 }
 
 impl SegmentationStrategy for DefaultSegmentationStrategy {

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -75,34 +75,34 @@ where
 fn test_vm_1() {
     let n = 6;
     /*
-    Instruction 0 assigns word[0]_1 to n.
+    Instruction 0 assigns word[0]_4 to n.
     Instruction 4 terminates
-    The remainder is a loop that decrements word[0]_1 until it reaches 0, then terminates.
-    Instruction 1 checks if word[0]_1 is 0 yet, and if so sets pc to 5 in order to terminate
-    Instruction 2 decrements word[0]_1 (using word[1]_1)
+    The remainder is a loop that decrements word[0]_4 until it reaches 0, then terminates.
+    Instruction 1 checks if word[0]_4 is 0 yet, and if so sets pc to 5 in order to terminate
+    Instruction 2 decrements word[0]_4 (using word[1]_4)
     Instruction 3 uses JAL as a simple jump to go back to instruction 1 (repeating the loop).
      */
     let instructions = vec![
-        // word[0]_1 <- word[n]_0
-        Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 1, 0, 0, 0),
-        // if word[0]_1 == 0 then pc += 3 * DEFAULT_PC_STEP
+        // word[0]_4 <- word[n]_0
+        Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 4, 0, 0, 0),
+        // if word[0]_4 == 0 then pc += 3 * DEFAULT_PC_STEP
         Instruction::from_isize(
             NativeBranchEqualOpcode(BEQ).global_opcode(),
             0,
             0,
             3 * DEFAULT_PC_STEP as isize,
-            1,
+            4,
             0,
         ),
-        // word[0]_1 <- word[0]_1 - word[1]_0
-        Instruction::large_from_isize(SUB.global_opcode(), 0, 0, 1, 1, 1, 0, 0),
-        // word[2]_1 <- pc + DEFAULT_PC_STEP, pc -= 2 * DEFAULT_PC_STEP
+        // word[0]_4 <- word[0]_4 - word[1]_4
+        Instruction::large_from_isize(SUB.global_opcode(), 0, 0, 1, 4, 4, 0, 0),
+        // word[2]_4 <- pc + DEFAULT_PC_STEP, pc -= 2 * DEFAULT_PC_STEP
         Instruction::from_isize(
             JAL.global_opcode(),
             2,
             -2 * DEFAULT_PC_STEP as isize,
             0,
-            1,
+            4,
             0,
         ),
         // terminate
@@ -119,7 +119,7 @@ fn test_vm_override_executor_height() {
     let fri_params = FriParameters::standard_fast();
     let e = BabyBearPoseidon2Engine::new(fri_params);
     let program = Program::<BabyBear>::from_instructions(&[
-        Instruction::large_from_isize(ADD.global_opcode(), 0, 4, 0, 1, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 4, 0, 4, 0, 0, 0),
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ]);
     let committed_exe = Arc::new(VmCommittedExe::<BabyBearPoseidon2Config>::commit(
@@ -225,14 +225,14 @@ fn test_vm_1_optional_air() {
     {
         let n = 6;
         let instructions = vec![
-            Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 1, 0, 0, 0),
-            Instruction::large_from_isize(SUB.global_opcode(), 0, 0, 1, 1, 1, 0, 0),
+            Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 4, 0, 0, 0),
+            Instruction::large_from_isize(SUB.global_opcode(), 0, 0, 1, 4, 4, 0, 0),
             Instruction::from_isize(
                 NativeBranchEqualOpcode(BNE).global_opcode(),
                 0,
                 0,
                 -(DEFAULT_PC_STEP as isize),
-                1,
+                4,
                 0,
             ),
             Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
@@ -305,7 +305,7 @@ fn test_vm_initial_memory() {
             7,
             101,
             2 * DEFAULT_PC_STEP as isize,
-            1,
+            4,
             0,
         ),
         Instruction::<BabyBear>::from_isize(
@@ -337,7 +337,7 @@ fn test_vm_initial_memory() {
 fn test_vm_1_persistent() {
     let engine = BabyBearPoseidon2Engine::new(FriParameters::standard_fast());
     let config = NativeConfig {
-        system: SystemConfig::new(3, MemoryConfig::new(1, 1, 16, 10, 6, 64, 1024), 0),
+        system: SystemConfig::new(3, MemoryConfig::new(2, 1, 16, 10, 6, 64, 1024), 0),
         native: Default::default(),
     }
     .with_continuations();
@@ -350,14 +350,14 @@ fn test_vm_1_persistent() {
 
     let n = 6;
     let instructions = vec![
-        Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 1, 0, 0, 0),
-        Instruction::large_from_isize(SUB.global_opcode(), 0, 0, 1, 1, 1, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 4, 0, 0, 0),
+        Instruction::large_from_isize(SUB.global_opcode(), 0, 0, 1, 4, 4, 0, 0),
         Instruction::from_isize(
             NativeBranchEqualOpcode(BNE).global_opcode(),
             0,
             0,
             -(DEFAULT_PC_STEP as isize),
-            1,
+            4,
             0,
         ),
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
@@ -379,14 +379,14 @@ fn test_vm_1_persistent() {
         );
         let mut digest = [BabyBear::ZERO; CHUNK];
         let compression = vm_poseidon2_hasher();
-        for _ in 0..15 {
+        for _ in 0..16 {
             digest = compression.compress(&digest, &digest);
         }
         assert_eq!(
             merkle_air_proof_input.raw.public_values[..8],
             // The value when you start with zeros and repeatedly hash the value with itself
-            // 15 times. We use 15 because addr_space_max_bits = 1 and pointer_max_bits = 16,
-            // so the height of the tree is 1 + 16 - 3 = 14. The leaf also must be hashed once
+            // 16 times. We use 16 because addr_space_max_bits = 2 and pointer_max_bits = 16,
+            // so the height of the tree is 2 + 16 - 3 = 15. The leaf also must be hashed once
             // with padding for security.
             digest
         );
@@ -400,37 +400,37 @@ fn test_vm_1_persistent() {
 
 fn gen_continuation_test_program<F: PrimeField32>(n: isize) -> Program<F> {
     // Simple Fibonacci program to compute nth Fibonacci number mod BabyBear (with F_0 = 1).
-    // Register [0]_1 <- stores the loop counter.
-    // Register [1]_1 <- stores F_i at the beginning of iteration i.
-    // Register [2]_1 <- stores F_{i+1} at the beginning of iteration i.
-    // Register [3]_1 is used as a temporary register.
+    // Register [0]_4 <- stores the loop counter.
+    // Register [1]_4 <- stores F_i at the beginning of iteration i.
+    // Register [2]_4 <- stores F_{i+1} at the beginning of iteration i.
+    // Register [3]_4 is used as a temporary register.
     Program::from_instructions(&[
-        // [0]_1 <- 0
-        Instruction::from_isize(ADD.global_opcode(), 0, 0, 0, 1, 0),
-        // [1]_1 <- 0
-        Instruction::from_isize(ADD.global_opcode(), 1, 0, 0, 1, 0),
-        // [2]_1 <- 1
-        Instruction::from_isize(ADD.global_opcode(), 2, 0, 1, 1, 0),
+        // [0]_4 <- 0
+        Instruction::from_isize(ADD.global_opcode(), 0, 0, 0, 4, 0),
+        // [1]_4 <- 0
+        Instruction::from_isize(ADD.global_opcode(), 1, 0, 0, 4, 0),
+        // [2]_4 <- 1
+        Instruction::from_isize(ADD.global_opcode(), 2, 0, 1, 4, 0),
         // loop_start
-        // [3]_1 <- [1]_1 + [2]_1
-        Instruction::large_from_isize(ADD.global_opcode(), 3, 1, 2, 1, 1, 1, 0),
-        // [1]_1 <- [2]_1
-        Instruction::large_from_isize(ADD.global_opcode(), 1, 2, 0, 1, 1, 0, 0),
-        // [2]_1 <- [3]_1
-        Instruction::large_from_isize(ADD.global_opcode(), 2, 3, 0, 1, 1, 0, 0),
-        // [0]_1 <- [0]_1 + 1
-        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 1, 1, 0, 0),
-        // if [0]_1 != n, pc <- pc - 3
+        // [3]_4 <- [1]_4 + [2]_4
+        Instruction::large_from_isize(ADD.global_opcode(), 3, 1, 2, 4, 4, 4, 0),
+        // [1]_4 <- [2]_4
+        Instruction::large_from_isize(ADD.global_opcode(), 1, 2, 0, 4, 4, 0, 0),
+        // [2]_4 <- [3]_4
+        Instruction::large_from_isize(ADD.global_opcode(), 2, 3, 0, 4, 4, 0, 0),
+        // [0]_4 <- [0]_4 + 1
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 4, 0, 0),
+        // if [0]_4 != n, pc <- pc - 4
         Instruction::from_isize(
             NativeBranchEqualOpcode(BNE).global_opcode(),
             n,
             0,
             -4 * DEFAULT_PC_STEP as isize,
             0,
-            1,
+            4,
         ),
-        // [0]_3 <- [1]_1
-        Instruction::from_isize(ADD.global_opcode(), 0, 1, 0, 3, 1),
+        // [0]_3 <- [1]_4
+        Instruction::from_isize(ADD.global_opcode(), 0, 1, 0, 3, 4),
         Instruction::from_isize(
             TERMINATE.global_opcode(),
             0,
@@ -518,42 +518,42 @@ fn test_vm_continuations_recover_state() {
 #[test]
 fn test_vm_without_field_arithmetic() {
     /*
-    Instruction 0 assigns word[0]_1 to 5.
-    Instruction 1 checks if word[0]_1 is *not* 4, and if so jumps to instruction 4.
+    Instruction 0 assigns word[0]_4 to 5.
+    Instruction 1 checks if word[0]_4 is *not* 4, and if so jumps to instruction 4.
     Instruction 2 is never run.
     Instruction 3 terminates.
-    Instruction 4 checks if word[0]_1 is 5, and if so jumps to instruction 3 to terminate.
+    Instruction 4 checks if word[0]_4 is 5, and if so jumps to instruction 3 to terminate.
      */
     let instructions = vec![
-        // word[0]_1 <- word[5]_0
-        Instruction::large_from_isize(ADD.global_opcode(), 0, 5, 0, 1, 0, 0, 0),
-        // if word[0]_1 != 4 then pc += 3 * DEFAULT_PC_STEP
+        // word[0]_4 <- word[5]_0
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 5, 0, 4, 0, 0, 0),
+        // if word[0]_4 != 4 then pc += 3 * DEFAULT_PC_STEP
         Instruction::from_isize(
             NativeBranchEqualOpcode(BNE).global_opcode(),
             0,
             4,
             3 * DEFAULT_PC_STEP as isize,
-            1,
+            4,
             0,
         ),
-        // word[2]_1 <- pc + DEFAULT_PC_STEP, pc -= 2 * DEFAULT_PC_STEP
+        // word[2]_4 <- pc + DEFAULT_PC_STEP, pc -= 2 * DEFAULT_PC_STEP
         Instruction::from_isize(
             JAL.global_opcode(),
             2,
             -2 * DEFAULT_PC_STEP as isize,
             0,
-            1,
+            4,
             0,
         ),
         // terminate
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
-        // if word[0]_1 == 5 then pc -= 1
+        // if word[0]_4 == 5 then pc -= 1
         Instruction::from_isize(
             NativeBranchEqualOpcode(BEQ).global_opcode(),
             0,
             5,
             -(DEFAULT_PC_STEP as isize),
-            1,
+            4,
             0,
         ),
     ];

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -298,7 +298,7 @@ fn test_vm_public_values() {
 
 #[test]
 fn test_vm_initial_memory() {
-    // Program that fails if mem[(1, 0)] != 101.
+    // Program that fails if mem[(1, 7)] != 101.
     let program = Program::from_instructions(&[
         Instruction::<BabyBear>::from_isize(
             NativeBranchEqualOpcode(BEQ).global_opcode(),
@@ -319,7 +319,7 @@ fn test_vm_initial_memory() {
         Instruction::<BabyBear>::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ]);
 
-    let init_memory: BTreeMap<_, _> = [((1, 7), BabyBear::from_canonical_u32(101))]
+    let init_memory: BTreeMap<_, _> = [((4, 7), BabyBear::from_canonical_u32(101))]
         .into_iter()
         .collect();
 
@@ -649,19 +649,19 @@ fn test_vm_fibonacci_old_cycle_tracker() {
 #[test]
 fn test_vm_field_extension_arithmetic() {
     let instructions = vec![
-        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 3, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 4, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 5, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 6, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 7, 0, 2, 1, 0, 0, 0),
-        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 1, 1),
-        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 1, 1),
-        Instruction::from_isize(FE4SUB.global_opcode(), 12, 0, 4, 1, 1),
-        Instruction::from_isize(BBE4MUL.global_opcode(), 12, 0, 4, 1, 1),
-        Instruction::from_isize(BBE4DIV.global_opcode(), 12, 0, 4, 1, 1),
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 3, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 4, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 5, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 6, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 7, 0, 2, 4, 0, 0, 0),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4SUB.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4MUL.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4DIV.global_opcode(), 12, 0, 4, 4, 4),
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
@@ -673,19 +673,19 @@ fn test_vm_field_extension_arithmetic() {
 #[test]
 fn test_vm_max_access_adapter_8() {
     let instructions = vec![
-        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 3, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 4, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 5, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 6, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 7, 0, 2, 1, 0, 0, 0),
-        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 1, 1),
-        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 1, 1),
-        Instruction::from_isize(FE4SUB.global_opcode(), 12, 0, 4, 1, 1),
-        Instruction::from_isize(BBE4MUL.global_opcode(), 12, 0, 4, 1, 1),
-        Instruction::from_isize(BBE4DIV.global_opcode(), 12, 0, 4, 1, 1),
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 3, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 4, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 5, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 6, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 7, 0, 2, 4, 0, 0, 0),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4SUB.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4MUL.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4DIV.global_opcode(), 12, 0, 4, 4, 4),
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
@@ -715,25 +715,25 @@ fn test_vm_max_access_adapter_8() {
 #[test]
 fn test_vm_field_extension_arithmetic_persistent() {
     let instructions = vec![
-        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 3, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 4, 0, 2, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 5, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 6, 0, 1, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 7, 0, 2, 1, 0, 0, 0),
-        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 1, 1),
-        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 1, 1),
-        Instruction::from_isize(FE4SUB.global_opcode(), 12, 0, 4, 1, 1),
-        Instruction::from_isize(BBE4MUL.global_opcode(), 12, 0, 4, 1, 1),
-        Instruction::from_isize(BBE4DIV.global_opcode(), 12, 0, 4, 1, 1),
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 3, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 4, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 5, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 6, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 7, 0, 2, 4, 0, 0, 0),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4SUB.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4MUL.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4DIV.global_opcode(), 12, 0, 4, 4, 4),
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
     let program = Program::from_instructions(&instructions);
     let config = NativeConfig {
-        system: SystemConfig::new(3, MemoryConfig::new(1, 1, 16, 10, 6, 64, 1024), 0)
+        system: SystemConfig::new(3, MemoryConfig::new(2, 1, 16, 10, 6, 64, 1024), 0)
             .with_continuations(),
         native: Default::default(),
     };
@@ -743,10 +743,10 @@ fn test_vm_field_extension_arithmetic_persistent() {
 #[test]
 fn test_vm_hint() {
     let instructions = vec![
-        Instruction::large_from_isize(ADD.global_opcode(), 16, 0, 0, 1, 0, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 20, 16, 16777220, 1, 1, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 32, 20, 0, 1, 1, 0, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 20, 20, 1, 1, 1, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 16, 0, 0, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 20, 16, 16777220, 4, 4, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 32, 20, 0, 4, 4, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 20, 20, 1, 4, 4, 0, 0),
         Instruction::from_isize(
             PHANTOM.global_opcode(),
             0,
@@ -755,39 +755,39 @@ fn test_vm_hint() {
             0,
             0,
         ),
-        Instruction::from_isize(HINT_STOREW.global_opcode(), 32, 0, 0, 1, 2),
-        Instruction::from_isize(LOADW.global_opcode(), 38, 0, 32, 1, 2),
-        Instruction::large_from_isize(ADD.global_opcode(), 44, 20, 0, 1, 1, 0, 0),
-        Instruction::from_isize(MUL.global_opcode(), 24, 38, 1, 1, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 20, 20, 24, 1, 1, 1, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 50, 16, 0, 1, 1, 0, 0),
+        Instruction::from_isize(HINT_STOREW.global_opcode(), 32, 0, 0, 4, 4),
+        Instruction::from_isize(LOADW.global_opcode(), 38, 0, 32, 4, 4),
+        Instruction::large_from_isize(ADD.global_opcode(), 44, 20, 0, 4, 4, 0, 0),
+        Instruction::from_isize(MUL.global_opcode(), 24, 38, 1, 4, 4),
+        Instruction::large_from_isize(ADD.global_opcode(), 20, 20, 24, 4, 4, 1, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 50, 16, 0, 4, 4, 0, 0),
         Instruction::from_isize(
             JAL.global_opcode(),
             24,
             6 * DEFAULT_PC_STEP as isize,
             0,
-            1,
+            4,
             0,
         ),
-        Instruction::from_isize(MUL.global_opcode(), 0, 50, 1, 1, 0),
-        Instruction::large_from_isize(ADD.global_opcode(), 0, 44, 0, 1, 1, 1, 0),
-        Instruction::from_isize(HINT_STOREW.global_opcode(), 0, 0, 0, 1, 2),
-        Instruction::large_from_isize(ADD.global_opcode(), 50, 50, 1, 1, 1, 0, 0),
+        Instruction::from_isize(MUL.global_opcode(), 0, 50, 1, 4, 4),
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 44, 0, 4, 4, 4, 0),
+        Instruction::from_isize(HINT_STOREW.global_opcode(), 0, 0, 0, 4, 4),
+        Instruction::large_from_isize(ADD.global_opcode(), 50, 50, 1, 4, 4, 0, 0),
         Instruction::from_isize(
             NativeBranchEqualOpcode(BNE).global_opcode(),
             50,
             38,
             -4 * (DEFAULT_PC_STEP as isize),
-            1,
-            1,
+            4,
+            4,
         ),
         Instruction::from_isize(
             NativeBranchEqualOpcode(BNE).global_opcode(),
             50,
             38,
             -5 * (DEFAULT_PC_STEP as isize),
-            1,
-            1,
+            4,
+            4,
         ),
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -4,22 +4,19 @@ use std::{
     sync::Arc,
 };
 
-use derive_more::derive::From;
 use openvm_circuit::{
     arch::{
         hasher::{poseidon2::vm_poseidon2_hasher, Hasher},
         ChipId, ExecutionSegment, MemoryConfig, SingleSegmentVmExecutor, SystemConfig,
-        SystemExecutor, SystemPeriphery, SystemTraceHeights, VirtualMachine, VmChipComplex,
-        VmComplexTraceHeights, VmConfig, VmInventoryError, VmInventoryTraceHeights,
+        SystemTraceHeights, VirtualMachine, VmComplexTraceHeights, VmConfig,
+        VmInventoryTraceHeights,
     },
-    derive::{AnyEnum, InstructionExecutor, VmConfig},
     system::{
         memory::{MemoryTraceHeights, VolatileMemoryTraceHeights, CHUNK},
         program::trace::VmCommittedExe,
     },
     utils::{air_test, air_test_with_min_segments},
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_instructions::{
     exe::VmExe,
     instruction::Instruction,
@@ -29,20 +26,14 @@ use openvm_instructions::{
     SysPhantom,
     SystemOpcode::*,
 };
-use openvm_keccak256_circuit::{
-    utils::keccak256, Keccak256, Keccak256Executor, Keccak256Periphery,
-};
-use openvm_keccak256_transpiler::Rv32KeccakOpcode::*;
-use openvm_native_circuit::{Native, NativeConfig, NativeExecutor, NativePeriphery};
+use openvm_native_circuit::NativeConfig;
 use openvm_native_compiler::{
     FieldArithmeticOpcode::*, FieldExtensionOpcode::*, NativeBranchEqualOpcode, NativeJalOpcode::*,
     NativeLoadStoreOpcode::*, NativePhantom,
 };
 use openvm_rv32im_transpiler::BranchEqualOpcode::*;
 use openvm_stark_backend::{
-    config::StarkGenericConfig,
-    engine::StarkEngine,
-    p3_field::{FieldAlgebra, PrimeField32},
+    config::StarkGenericConfig, engine::StarkEngine, p3_field::FieldAlgebra,
 };
 use openvm_stark_sdk::{
     config::{
@@ -54,10 +45,7 @@ use openvm_stark_sdk::{
     p3_baby_bear::BabyBear,
 };
 use rand::Rng;
-use serde::{Deserialize, Serialize};
 use test_log::test;
-
-const LIMB_BITS: usize = 29;
 
 pub fn gen_pointer<R>(rng: &mut R, len: usize) -> usize
 where

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -282,7 +282,7 @@ fn test_vm_public_values() {
 
 #[test]
 fn test_vm_initial_memory() {
-    // Program that fails if mem[(1, 7)] != 101.
+    // Program that fails if mem[(4, 7)] != 101.
     let program = Program::from_instructions(&[
         Instruction::<BabyBear>::from_isize(
             NativeBranchEqualOpcode(BEQ).global_opcode(),


### PR DESCRIPTION
Some tests relied on now-invalid behavior from the native extension and have been removed.