### PR TITLE
Memory profiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "aurora-engine-modexp"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +436,31 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
+dependencies = [
+ "aws-lc-sys",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "paste",
 ]
 
 [[package]]
@@ -684,17 +715,17 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper",
- "hyper-rustls",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -853,6 +884,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.11.0",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.96",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1180,6 +1252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1362,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1329,6 +1430,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1792,6 +1903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2222,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2383,25 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
+ "indexmap 2.7.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
  "indexmap 2.7.1",
  "slab",
  "tokio",
@@ -2505,6 +2647,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,7 +2733,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2597,6 +2748,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,12 +2776,49 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.32",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http 1.2.0",
+ "hyper 1.5.2",
+ "hyper-util",
+ "rustls 0.23.21",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.5.2",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2623,7 +2832,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -2847,6 +3056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,6 +3186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +3210,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,6 +3232,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
+dependencies = [
+ "bindgen 0.70.1",
+ "errno",
  "libc",
 ]
 
@@ -3076,6 +3318,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3136,6 +3387,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "metrics-derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,6 +3409,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12779523996a67c13c84906a876ac6fe4d07a6e1adb54978378e13f199251a62"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "indexmap 2.7.1",
+ "ipnet",
+ "metrics 0.24.1",
+ "metrics-util 0.19.0",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a82c8add4382f29a122fa64fff1891453ed0f6b2867d971e7d60cb8dfa322ff"
+dependencies = [
+ "libc",
+ "libproc",
+ "mach2",
+ "metrics 0.24.1",
+ "once_cell",
+ "procfs",
+ "rlimit",
+ "windows",
+]
+
+[[package]]
 name = "metrics-tracing-context"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,8 +3454,25 @@ dependencies = [
  "indexmap 2.7.1",
  "itoa",
  "lockfree-object-pool",
- "metrics",
- "metrics-util",
+ "metrics 0.23.0",
+ "metrics-util 0.17.0",
+ "once_cell",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "metrics-tracing-context"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58744e0a46768f65da39b17da285c12a9e6542f3b22840845e39bdb857ae8d"
+dependencies = [
+ "indexmap 2.7.1",
+ "itoa",
+ "lockfree-object-pool",
+ "metrics 0.24.1",
+ "metrics-util 0.19.0",
  "once_cell",
  "tracing",
  "tracing-core",
@@ -3175,12 +3490,32 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
- "metrics",
+ "metrics 0.23.0",
  "num_cpus",
  "ordered-float",
  "quanta",
  "radix_trie",
- "sketches-ddsketch",
+ "sketches-ddsketch 0.2.2",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "metrics 0.24.1",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "rand",
+ "rand_xoshiro",
+ "sketches-ddsketch 0.3.0",
 ]
 
 [[package]]
@@ -3191,6 +3526,12 @@ checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
 dependencies = [
  "libmimalloc-sys",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3242,6 +3583,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3539,7 +3890,7 @@ dependencies = [
  "eyre",
  "hex",
  "k256",
- "metrics",
+ "metrics 0.24.1",
  "num-bigint 0.4.6",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
@@ -3673,7 +4024,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "lazy_static",
- "metrics",
+ "metrics 0.24.1",
  "metrics-derive",
  "once_cell",
  "openvm-circuit",
@@ -4032,7 +4383,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "lazy_static",
- "metrics",
+ "metrics 0.24.1",
  "num-bigint 0.4.6",
  "num-integer",
  "openvm-circuit",
@@ -4076,7 +4427,7 @@ dependencies = [
  "cfg-if",
  "itertools 0.13.0",
  "lazy_static",
- "metrics",
+ "metrics 0.24.1",
  "once_cell",
  "openvm-circuit",
  "openvm-native-circuit",
@@ -4246,9 +4597,16 @@ dependencies = [
  "clap",
  "eyre",
  "itertools 0.13.0",
+ "metrics 0.24.1",
+ "metrics-exporter-prometheus",
+ "metrics-process",
+ "metrics-tracing-context 0.18.0",
+ "metrics-util 0.19.0",
  "num-format",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4361,7 +4719,7 @@ dependencies = [
  "eyre",
  "getset",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.24.1",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
@@ -4484,7 +4842,7 @@ dependencies = [
  "derivative",
  "derive-new 0.7.0",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "mimalloc",
  "p3-air",
  "p3-challenger",
@@ -4511,9 +4869,9 @@ dependencies = [
  "derive_more 0.99.18",
  "ff 0.13.0",
  "itertools 0.13.0",
- "metrics",
- "metrics-tracing-context",
- "metrics-util",
+ "metrics 0.23.0",
+ "metrics-tracing-context 0.16.0",
+ "metrics-util 0.17.0",
  "openvm-stark-backend",
  "p3-baby-bear",
  "p3-blake3",
@@ -5291,6 +5649,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.8.0",
+ "hex",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.8.0",
+ "hex",
+]
+
+[[package]]
 name = "proptest"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5631,6 +6011,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5757,8 +6146,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5770,7 +6173,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -5783,12 +6198,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -5924,7 +6357,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6148,6 +6594,12 @@ name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -6678,7 +7130,17 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls 0.23.21",
  "tokio",
 ]
 
@@ -7082,6 +7544,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7113,11 +7587,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
-    "nightly-features",
+  "nightly-features",
 ], rev = "b0591e9" }
 p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
@@ -187,9 +187,9 @@ p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e
 p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 
 snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier", branch = "zkvm-v0.1", default-features = false, features = [
-    "loader_halo2",
-    "halo2-axiom",
-    "display",
+  "loader_halo2",
+  "halo2-axiom",
+  "display",
 ] }
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 halo2curves-axiom = "0.5.3"
@@ -210,7 +210,7 @@ strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }
 enum-utils = "0.1.1"
 backtrace = "0.3.71"
-metrics = "0.23.0"
+metrics = "0.24.1"
 metrics-derive = "0.1.0"
 cfg-if = "1.0.0"
 inferno = "0.11.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
-  "nightly-features",
+    "nightly-features",
 ], rev = "b0591e9" }
 p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
@@ -187,9 +187,9 @@ p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e
 p3-bn254-fr = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9" }
 
 snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier", branch = "zkvm-v0.1", default-features = false, features = [
-  "loader_halo2",
-  "halo2-axiom",
-  "display",
+    "loader_halo2",
+    "halo2-axiom",
+    "display",
 ] }
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 halo2curves-axiom = "0.5.3"

--- a/crates/prof/Cargo.toml
+++ b/crates/prof/Cargo.toml
@@ -16,3 +16,11 @@ clap = { workspace = true, features = ["derive"] }
 eyre.workspace = true
 itertools = { workspace = true, features = ["use_std"] }
 num-format = "0.4"
+
+metrics = { workspace = true }
+metrics-exporter-prometheus = "0.16.1"
+metrics-process = "2.4.0"
+metrics-tracing-context = "0.18.0"
+metrics-util = "0.19.0"
+tracing = { workspace = true }
+tracing-subscriber = "0.3.19"

--- a/crates/prof/src/lib.rs
+++ b/crates/prof/src/lib.rs
@@ -8,6 +8,7 @@ use eyre::Result;
 use crate::types::{Labels, Metric, MetricDb, MetricsFile};
 
 pub mod aggregate;
+pub mod recorder;
 pub mod summary;
 pub mod types;
 

--- a/crates/prof/src/recorder.rs
+++ b/crates/prof/src/recorder.rs
@@ -21,7 +21,7 @@ pub fn install_prometheus_recorder() -> &'static PrometheusRecorder {
 /// The default Prometheus recorder handle. We use a global static to ensure that it is only
 /// installed once.
 static PROMETHEUS_RECORDER_HANDLE: LazyLock<PrometheusRecorder> =
-    LazyLock::new(|| PrometheusRecorder::new());
+    LazyLock::new(PrometheusRecorder::new);
 
 pub struct PrometheusRecorder {
     handle: Arc<PrometheusHandle>,

--- a/crates/prof/src/recorder.rs
+++ b/crates/prof/src/recorder.rs
@@ -1,0 +1,130 @@
+//! Prometheus recorder
+use std::{
+    sync::{atomic::AtomicBool, Arc, LazyLock},
+    thread,
+    time::Duration,
+};
+
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_process::Collector;
+use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
+use metrics_util::layers::Layer;
+use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+/// Installs the Prometheus recorder as the global recorder.
+///
+/// Caution: This only configures the global recorder and does not spawn the exporter.
+pub fn install_prometheus_recorder() -> &'static PrometheusRecorder {
+    &PROMETHEUS_RECORDER_HANDLE
+}
+
+/// The default Prometheus recorder handle. We use a global static to ensure that it is only
+/// installed once.
+static PROMETHEUS_RECORDER_HANDLE: LazyLock<PrometheusRecorder> =
+    LazyLock::new(|| PrometheusRecorder::new());
+
+pub struct PrometheusRecorder {
+    handle: Arc<PrometheusHandle>,
+    spawned: AtomicBool,
+}
+
+impl PrometheusRecorder {
+    /// Installs Prometheus as the metrics recorder.
+    ///
+    /// Caution: This only configures the global recorder and does not spawn the exporter.
+    /// Callers must run `PrometheusHandle.run_upkeep` manually.
+    fn new() -> Self {
+        // Set up tracing:
+        let subscriber = Registry::default().with(MetricsLayer::new());
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("Error initializing the tracing subscriber");
+
+        // Prepare metrics.
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = Arc::new(recorder.handle());
+        let recorder_with_tracing = TracingContextLayer::all().layer(recorder);
+        metrics::set_global_recorder(recorder_with_tracing).unwrap();
+
+        Self {
+            handle,
+            spawned: AtomicBool::new(false),
+        }
+    }
+
+    // Creates a thread that regularly collects process metrics.
+    // Necessary to avoid the VM starving the process.
+    pub fn spawn_process_metrics_thread(&self, interval: Duration) {
+        if self
+            .spawned
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return;
+        }
+
+        let handle = self.handle().clone();
+        thread::spawn(move || {
+            let collector = Collector::default();
+            collector.describe();
+
+            loop {
+                collector.collect();
+                handle.run_upkeep();
+                thread::sleep(interval);
+            }
+        });
+    }
+
+    pub fn handle(&self) -> &PrometheusHandle {
+        &self.handle
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use metrics::{counter, describe_counter};
+    use tracing::{span, Level};
+
+    use super::*;
+    // Dependencies using different version of the `metrics` crate (to be exact, 0.21 vs 0.22)
+    // may not be able to communicate with each other through the global recorder.
+    //
+    // This test ensures that `metrics-process` dependency plays well with the current
+    // `metrics-exporter-prometheus` dependency version.
+    #[test]
+    fn test_prometheus_recorder_process_metrics() {
+        // initialize the lazy handle
+        let handle = &PROMETHEUS_RECORDER_HANDLE.handle;
+        let span = span!(Level::TRACE, "my_span", test = "process_metrics");
+        let _guard = span.enter();
+
+        let collector = Collector::default();
+        collector.collect();
+        let metrics = handle.render();
+        assert!(
+            metrics.contains("process_cpu_seconds_total{test=\"process_metrics\"} 0"),
+            "{metrics:?}"
+        );
+    }
+
+    #[test]
+    fn test_prometheus_metrics_tracing_context() {
+        let handle = &PROMETHEUS_RECORDER_HANDLE.handle;
+        let span = span!(Level::TRACE, "my_span", test = "tracing_context");
+        let _guard = span.enter();
+
+        describe_counter!("example_metric", "A counter for demonstration purposes");
+        counter!("example_metric").increment(42);
+
+        let metrics = handle.render();
+        assert!(
+            metrics.contains("example_metric{test=\"tracing_context\"} 42"),
+            "{metrics:?}"
+        );
+    }
+}


### PR DESCRIPTION
Hi, 

Here is the PR for #1029 which implements metrics recorder for Prometheus. Previous discussion can be found in #1201. 

The PR implements a recoder that:
1. **Ttarts a thread which collects process-metrics for a given Duration**. It is important that the [process metrics](https://docs.rs/metrics-process/latest/metrics_process/) (memory/cpu usage.. etc) in it's own separate thread spawned is, otherwise, in an async task will be block anytime the VM performs any of it's cpu-intesive computations. 
2. **`[metrics_context_tracing](https://docs.rs/metrics-tracing-context/latest/metrics_tracing_context/)` enabled**( as stated in the [docs](https://github.com/openvm-org/openvm/blob/main/docs/crates/metrics.md)). so any metric recorded within a span, the span is automatically added as a metric label. However, this does not apply to the process metrics metrics regularly collected in the previous point, because they run in a separate thread. 

**Usage:** In this [repo](https://github.com/alv-around/openvm-memory-profiler-examples), I made two examples how the memory profiler could work with both (pull/push) prometheus exporters.