### PR TITLE
[feat] Make the `openvm::entry!` macro a proc-macro attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,6 +3424,7 @@ dependencies = [
  "hex-literal",
  "num-bigint 0.4.6",
  "num-traits",
+ "openvm-entry",
  "openvm-platform",
  "openvm-rv32im-guest",
  "serde",
@@ -3859,6 +3860,15 @@ dependencies = [
  "openvm-transpiler",
  "rrs-lib",
  "strum",
+]
+
+[[package]]
+name = "openvm-entry"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ openvm-sha256-air = { path = "crates/circuits/sha256-air", default-features = fa
 openvm-circuit-primitives = { path = "crates/circuits/primitives", default-features = false }
 openvm-circuit-primitives-derive = { path = "crates/circuits/primitives/derive", default-features = false }
 openvm = { path = "crates/toolchain/openvm", default-features = false }
+openvm-entry = { path = "crates/toolchain/openvm/entry", default-features = false }
 openvm-build = { path = "crates/toolchain/build", default-features = false }
 openvm-instructions = { path = "crates/toolchain/instructions", default-features = false }
 openvm-instructions-derive = { path = "crates/toolchain/instructions/derive", default-features = false }

--- a/benchmarks/programs/base64_json/src/main.rs
+++ b/benchmarks/programs/base64_json/src/main.rs
@@ -7,7 +7,7 @@ use base64::engine::{general_purpose, Engine};
 use openvm_json_program::UserProfile;
 use serde_json_core::de::from_str;
 
-#[openvm::entry]
+#[openvm::main]
 fn main() {
     let data_b64 = openvm::io::read_vec();
     let data_b64 = core::str::from_utf8(&data_b64).expect("Invalid UTF-8");

--- a/benchmarks/programs/base64_json/src/main.rs
+++ b/benchmarks/programs/base64_json/src/main.rs
@@ -7,8 +7,7 @@ use base64::engine::{general_purpose, Engine};
 use openvm_json_program::UserProfile;
 use serde_json_core::de::from_str;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 fn main() {
     let data_b64 = openvm::io::read_vec();
     let data_b64 = core::str::from_utf8(&data_b64).expect("Invalid UTF-8");

--- a/benchmarks/programs/bincode/src/main.rs
+++ b/benchmarks/programs/bincode/src/main.rs
@@ -7,8 +7,7 @@ mod types;
 use bincode::{config::standard, decode_from_slice};
 use types::Players;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 fn main() {
     // nothing up our sleeves, state and stream are first 20 digits of pi
     // const STATE: u64 = 3141592653;

--- a/benchmarks/programs/bincode/src/main.rs
+++ b/benchmarks/programs/bincode/src/main.rs
@@ -7,7 +7,7 @@ mod types;
 use bincode::{config::standard, decode_from_slice};
 use types::Players;
 
-#[openvm::entry]
+#[openvm::main]
 fn main() {
     // nothing up our sleeves, state and stream are first 20 digits of pi
     // const STATE: u64 = 3141592653;

--- a/benchmarks/programs/ecrecover/src/main.rs
+++ b/benchmarks/programs/ecrecover/src/main.rs
@@ -3,26 +3,24 @@
 
 extern crate alloc;
 
-use alloy_primitives::{B256, B512, Bytes, keccak256};
+use alloy_primitives::{keccak256, Bytes, B256, B512};
 use k256::{
     ecdsa::{Error, RecoveryId, Signature},
     Secp256k1,
 };
 use openvm::io::read_vec;
 use openvm_algebra_guest::field::FieldExtension;
+use openvm_ecc_guest::AffinePoint;
 #[allow(unused_imports)]
 use openvm_ecc_guest::{
     algebra::IntMod, ecdsa::VerifyingKey, k256::Secp256k1Point, weierstrass::WeierstrassPoint,
 };
-use openvm_ecc_guest::AffinePoint;
 #[allow(unused_imports, clippy::single_component_path_imports)]
 use openvm_keccak256_guest;
 // export native keccak
 use revm_precompile::{
-    Error as PrecompileError, PrecompileOutput, PrecompileResult, utilities::right_pad,
+    utilities::right_pad, Error as PrecompileError, PrecompileOutput, PrecompileResult,
 };
-
-openvm::entry!(main);
 
 openvm_algebra_guest::moduli_macros::moduli_init! {
     "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F",
@@ -32,6 +30,7 @@ openvm_ecc_guest::sw_macros::sw_init! {
     Secp256k1Point,
 }
 
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();
@@ -42,7 +41,6 @@ pub fn main() {
         let recovered = ec_recover_run(&Bytes::from(input), 3000).unwrap();
         assert_eq!(recovered.bytes.as_ref(), expected_address);
     }
-
 }
 
 // OpenVM version of ecrecover precompile.

--- a/benchmarks/programs/ecrecover/src/main.rs
+++ b/benchmarks/programs/ecrecover/src/main.rs
@@ -30,7 +30,7 @@ openvm_ecc_guest::sw_macros::sw_init! {
     Secp256k1Point,
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/benchmarks/programs/fibonacci/src/main.rs
+++ b/benchmarks/programs/fibonacci/src/main.rs
@@ -3,7 +3,7 @@
 
 use openvm::io::{read, reveal};
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let n: u64 = read();
     let mut a: u64 = 0;

--- a/benchmarks/programs/fibonacci/src/main.rs
+++ b/benchmarks/programs/fibonacci/src/main.rs
@@ -3,8 +3,7 @@
 
 use openvm::io::{read, reveal};
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let n: u64 = read();
     let mut a: u64 = 0;

--- a/benchmarks/programs/regex/src/main.rs
+++ b/benchmarks/programs/regex/src/main.rs
@@ -5,10 +5,9 @@ use core::mem::transmute;
 
 use regex::Regex;
 
-openvm::entry!(main);
-
 const PATTERN: &str = r"(?m)(\r\n|^)From:([^\r\n]+<)?(?P<email>[^<>]+)>?";
 
+#[openvm::entry]
 pub fn main() {
     let data = openvm::io::read_vec();
     let data = core::str::from_utf8(&data).expect("Invalid UTF-8");

--- a/benchmarks/programs/regex/src/main.rs
+++ b/benchmarks/programs/regex/src/main.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 
 const PATTERN: &str = r"(?m)(\r\n|^)From:([^\r\n]+<)?(?P<email>[^<>]+)>?";
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let data = openvm::io::read_vec();
     let data = core::str::from_utf8(&data).expect("Invalid UTF-8");

--- a/benchmarks/programs/revm_transfer/src/main.rs
+++ b/benchmarks/programs/revm_transfer/src/main.rs
@@ -10,8 +10,7 @@ use alloy_primitives::{address, TxKind, U256};
 use openvm_keccak256_guest; // export native keccak
 use revm::{db::BenchmarkDB, primitives::Bytecode, Evm};
 
-openvm::entry!(main);
-
+#[openvm::entry]
 fn main() {
     let mut evm = Evm::builder()
         .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))

--- a/benchmarks/programs/revm_transfer/src/main.rs
+++ b/benchmarks/programs/revm_transfer/src/main.rs
@@ -10,7 +10,7 @@ use alloy_primitives::{address, TxKind, U256};
 use openvm_keccak256_guest; // export native keccak
 use revm::{db::BenchmarkDB, primitives::Bytecode, Evm};
 
-#[openvm::entry]
+#[openvm::main]
 fn main() {
     let mut evm = Evm::builder()
         .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))

--- a/benchmarks/programs/rkyv/src/main.rs
+++ b/benchmarks/programs/rkyv/src/main.rs
@@ -9,8 +9,7 @@ use core::hint::black_box;
 use rkyv::{access_unchecked, Archive};
 use types::Players;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 fn main() {
     // Uncomment to generate a minecraft save file:
     // // nothing up our sleeves, state and stream are first 20 digits of pi

--- a/benchmarks/programs/rkyv/src/main.rs
+++ b/benchmarks/programs/rkyv/src/main.rs
@@ -9,7 +9,7 @@ use core::hint::black_box;
 use rkyv::{access_unchecked, Archive};
 use types::Players;
 
-#[openvm::entry]
+#[openvm::main]
 fn main() {
     // Uncomment to generate a minecraft save file:
     // // nothing up our sleeves, state and stream are first 20 digits of pi

--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -27,8 +27,7 @@ The `read` function takes input from the stdin (it also works with OpenVM runtim
 // src/main.rs
 use openvm::io::{read, reveal};
 
-openvm::entry!(main);
-
+#[openvm::entry]
 fn main() {
     let n: u64 = read();
     let mut a: u64 = 0;

--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -27,7 +27,7 @@ The `read` function takes input from the stdin (it also works with OpenVM runtim
 // src/main.rs
 use openvm::io::{read, reveal};
 
-#[openvm::entry]
+#[openvm::main]
 fn main() {
     let n: u64 = read();
     let mut a: u64 = 0;

--- a/book/src/writing-apps/write-program.md
+++ b/book/src/writing-apps/write-program.md
@@ -7,7 +7,7 @@ See the example [fibonacci program](https://github.com/openvm-org/openvm-example
 The guest program should be a `no_std` Rust crate. As long as it is `no_std`, you can import any other
 `no_std` crates and write Rust as you normally would. Import the `openvm` library crate to use `openvm` intrinsic functions (for example `openvm::io::*`).
 
-The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `#[openvm::entry]` proc-macro attribute. You should still create a `main` function, but prepend it with the `#[openvm::entry]` attribute to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with std you should still name the function `main`.
+The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `#[openvm::main]` proc-macro attribute. You should still create a `main` function, but prepend it with the `#[openvm::main]` attribute to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with std you should still name the function `main`.
 
 To support both `std` and `no_std` execution, the top of your guest program should have:
 

--- a/book/src/writing-apps/write-program.md
+++ b/book/src/writing-apps/write-program.md
@@ -7,7 +7,7 @@ See the example [fibonacci program](https://github.com/openvm-org/openvm-example
 The guest program should be a `no_std` Rust crate. As long as it is `no_std`, you can import any other
 `no_std` crates and write Rust as you normally would. Import the `openvm` library crate to use `openvm` intrinsic functions (for example `openvm::io::*`).
 
-The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `openvm::entry!` macro. You should still create a `main` function, and then add `openvm::entry!(main)` for the macro to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with std you should still name the function `main`.
+The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `#[openvm::entry]` proc-macro attribute. You should still create a `main` function, but prepend it with the `#[openvm::entry]` attribute to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with std you should still name the function `main`.
 
 To support both `std` and `no_std` execution, the top of your guest program should have:
 

--- a/crates/cli/example/src/main.rs
+++ b/crates/cli/example/src/main.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(target_os = "zkvm", no_main)]
 #![cfg_attr(target_os = "zkvm", no_std)]
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/crates/cli/example/src/main.rs
+++ b/crates/cli/example/src/main.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(target_os = "zkvm", no_main)]
 #![cfg_attr(target_os = "zkvm", no_std)]
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/crates/sdk/guest/src/main.rs
+++ b/crates/sdk/guest/src/main.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(target_os = "zkvm", no_main)]
 #![cfg_attr(target_os = "zkvm", no_std)]
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/crates/sdk/guest/src/main.rs
+++ b/crates/sdk/guest/src/main.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(target_os = "zkvm", no_main)]
 #![cfg_attr(target_os = "zkvm", no_std)]
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/crates/toolchain/openvm/Cargo.toml
+++ b/crates/toolchain/openvm/Cargo.toml
@@ -14,6 +14,7 @@ openvm-platform = { workspace = true, features = [
     "export-getrandom",
 ] }
 openvm-rv32im-guest = { workspace = true }
+openvm-entry = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["alloc"] }
 hex-literal.workspace = true
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
@@ -33,4 +34,4 @@ getrandom = ["openvm-platform/getrandom"]
 # The zkVM uses a bump-pointer heap allocator by default which does not free
 # memory. This will use a slower linked-list heap allocator to reclaim memory.
 heap-embedded-alloc = ["openvm-platform/heap-embedded-alloc"]
-std = ["serde/std"]
+std = ["serde/std", "openvm-entry/std"]

--- a/crates/toolchain/openvm/entry/Cargo.toml
+++ b/crates/toolchain/openvm/entry/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "openvm-entry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["parsing"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[features]
+std = []
+default = []

--- a/crates/toolchain/openvm/entry/src/lib.rs
+++ b/crates/toolchain/openvm/entry/src/lib.rs
@@ -17,11 +17,11 @@ use syn::{parse_macro_input, ItemFn};
 /// #![no_main]
 /// #![no_std]
 ///
-/// #[openvm::entry]
+/// #[openvm::main]
 /// fn main() { }
 /// ```
 #[proc_macro_attribute]
-pub fn entry(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
 
     let fn_name = &input.sig.ident;

--- a/crates/toolchain/openvm/entry/src/lib.rs
+++ b/crates/toolchain/openvm/entry/src/lib.rs
@@ -1,0 +1,58 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+/// Used for defining the guest's entrypoint and main function.
+///
+/// When `#![no_main]` is used, the programs entrypoint and main function is left undefined. The
+/// `entry` attribute is required to indicate the main function and link it to an entrypoint provided
+/// by the `openvm` crate.
+///
+/// When `std` is enabled, the entrypoint will be linked automatically and this macro is not
+/// required.
+///
+/// # Example
+///
+/// ```ignore
+/// #![no_main]
+/// #![no_std]
+///
+/// #[openvm::entry]
+/// fn main() { }
+/// ```
+#[proc_macro_attribute]
+pub fn entry(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+
+    let fn_name = &input.sig.ident;
+    let fn_block = &input.block;
+    let fn_attrs = &input.attrs;
+    let fn_vis = &input.vis;
+    let fn_sig = &input.sig;
+
+    // Here, implement the transformation logic you need.
+    // For demonstration, let's assume we want to print a message before the function executes.
+
+    let expanded = quote! {
+        // Type check the given path
+        #[cfg(all(not(feature = "std"), target_os = "zkvm"))]
+        const ZKVM_ENTRY: fn() = #fn_name;
+
+        // Include generated main in a module so we don't conflict
+        // with any other definitions of "main" in this file.
+        #[cfg(all(not(feature = "std"), target_os = "zkvm"))]
+        mod zkvm_generated_main {
+            #[no_mangle]
+            fn main() {
+                super::ZKVM_ENTRY()
+            }
+        }
+
+        #(#fn_attrs)*
+        #fn_vis #fn_sig {
+            #fn_block
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/toolchain/openvm/src/lib.rs
+++ b/crates/toolchain/openvm/src/lib.rs
@@ -54,7 +54,7 @@ fn _fault() -> ! {
 //     }
 // }
 
-pub use openvm_entry::entry;
+pub use openvm_entry::main;
 
 #[cfg(target_os = "zkvm")]
 #[no_mangle]

--- a/crates/toolchain/openvm/src/lib.rs
+++ b/crates/toolchain/openvm/src/lib.rs
@@ -54,49 +54,7 @@ fn _fault() -> ! {
 //     }
 // }
 
-/// Used for defining the guest's entrypoint and main function.
-///
-/// When `#![no_main]` is used, the programs entrypoint and main function is left undefined. The
-/// `entry` macro is required to indicate the main function and link it to an entrypoint provided
-/// by the `openvm` crate.
-///
-/// When `std` is enabled, the entrypoint will be linked automatically and this macro is not
-/// required.
-///
-/// # Example
-///
-/// ```ignore
-/// #![no_main]
-/// #![no_std]
-///
-/// openvm::entry!(main);
-///
-/// fn main() { }
-/// ```
-#[cfg(all(not(feature = "std"), target_os = "zkvm"))]
-#[macro_export]
-macro_rules! entry {
-    ($path:path) => {
-        // Type check the given path
-        const ZKVM_ENTRY: fn() = $path;
-
-        // Include generated main in a module so we don't conflict
-        // with any other definitions of "main" in this file.
-        mod zkvm_generated_main {
-            #[no_mangle]
-            fn main() {
-                super::ZKVM_ENTRY()
-            }
-        }
-    };
-}
-/// This macro does nothing. You should name the function `main` so that the normal rust main function
-/// setup is used.
-#[cfg(any(feature = "std", not(target_os = "zkvm")))]
-#[macro_export]
-macro_rules! entry {
-    ($path:path) => {};
-}
+pub use openvm_entry::entry;
 
 #[cfg(target_os = "zkvm")]
 #[no_mangle]

--- a/docs/crates/benchmarks.md
+++ b/docs/crates/benchmarks.md
@@ -27,7 +27,7 @@ not on the machine doing the compilation (the "host machine"), although we will 
 The guest program should be a `no_std` Rust crate. As long as it is `no_std`, you can import any other
 `no_std` crates and write Rust as you normally would. Import the `openvm` library crate to use `openvm` intrinsic functions (for example `openvm::io::*`).
 
-The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `openvm::entry!` macro. You should still create a `main` function, and then add `openvm::entry!(main)` for the macro to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with testing when `std` feature is enabled (see below), you should still name it `main`.
+The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `#[openvm::entry]` proc-macro attribute. You should still create a `main` function, but prepend it with the `#[openvm::entry]` attribute to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with testing when `std` feature is enabled (see below), you should still name it `main`.
 
 To support host machine execution, the top of your guest program should have:
 

--- a/docs/crates/benchmarks.md
+++ b/docs/crates/benchmarks.md
@@ -27,7 +27,7 @@ not on the machine doing the compilation (the "host machine"), although we will 
 The guest program should be a `no_std` Rust crate. As long as it is `no_std`, you can import any other
 `no_std` crates and write Rust as you normally would. Import the `openvm` library crate to use `openvm` intrinsic functions (for example `openvm::io::*`).
 
-The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `#[openvm::entry]` proc-macro attribute. You should still create a `main` function, but prepend it with the `#[openvm::entry]` attribute to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with testing when `std` feature is enabled (see below), you should still name it `main`.
+The guest program also needs `#![no_main]` because `no_std` does not have certain default handlers. These are provided by the `#[openvm::main]` proc-macro attribute. You should still create a `main` function, but prepend it with the `#[openvm::main]` attribute to set up the function to run as a normal `main` function. While the function can be named anything when `target_os = "zkvm"`, for compatibility with testing when `std` feature is enabled (see below), you should still name it `main`.
 
 To support host machine execution, the top of your guest program should have:
 

--- a/docs/crates/integration-tests.md
+++ b/docs/crates/integration-tests.md
@@ -22,8 +22,7 @@ The `examples` folder contains the test programs in `rust`.
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/docs/crates/integration-tests.md
+++ b/docs/crates/integration-tests.md
@@ -22,7 +22,7 @@ The `examples` folder contains the test programs in `rust`.
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/examples/algebra/src/main.rs
+++ b/examples/algebra/src/main.rs
@@ -3,8 +3,6 @@
 
 use openvm_algebra_guest::{moduli_macros::*, IntMod};
 
-openvm::entry!(main);
-
 // This macro will create two structs, `Mod1` and `Mod2`,
 // one for arithmetic modulo 998244353, and the other for arithmetic modulo 1000000007.
 moduli_declare! {
@@ -32,6 +30,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex1 { mod_idx = 0 }, Complex2 { mod_idx = 1 },
 }
 
+#[openvm::entry]
 pub fn main() {
     // Since we only use an arithmetic operation with `Mod1` and not `Mod2`,
     // we only need to call `setup_0()` here.

--- a/examples/algebra/src/main.rs
+++ b/examples/algebra/src/main.rs
@@ -30,7 +30,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex1 { mod_idx = 0 }, Complex2 { mod_idx = 1 },
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     // Since we only use an arithmetic operation with `Mod1` and not `Mod2`,
     // we only need to call `setup_0()` here.

--- a/examples/ecc/src/main.rs
+++ b/examples/ecc/src/main.rs
@@ -22,8 +22,7 @@ openvm_ecc_guest::sw_macros::sw_init! {
 // ANCHOR_END: init
 
 // ANCHOR: main
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/examples/ecc/src/main.rs
+++ b/examples/ecc/src/main.rs
@@ -22,7 +22,7 @@ openvm_ecc_guest::sw_macros::sw_init! {
 // ANCHOR_END: init
 
 // ANCHOR: main
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/examples/i256/src/main.rs
+++ b/examples/i256/src/main.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::needless_range_loop)]
 
-openvm::entry!(main);
 use core::array;
 
 use openvm_bigint_guest::I256;
@@ -34,6 +33,7 @@ pub fn get_identity_matrix() -> Matrix {
     res
 }
 
+#[openvm::entry]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let b: Matrix = get_matrix(-28);

--- a/examples/i256/src/main.rs
+++ b/examples/i256/src/main.rs
@@ -33,7 +33,7 @@ pub fn get_identity_matrix() -> Matrix {
     res
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let b: Matrix = get_matrix(-28);

--- a/examples/keccak/src/main.rs
+++ b/examples/keccak/src/main.rs
@@ -12,7 +12,7 @@ use openvm_keccak256_guest::keccak256;
 // ANCHOR_END: imports
 
 // ANCHOR: main
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let test_vectors = [
         (

--- a/examples/keccak/src/main.rs
+++ b/examples/keccak/src/main.rs
@@ -12,8 +12,7 @@ use openvm_keccak256_guest::keccak256;
 // ANCHOR_END: imports
 
 // ANCHOR: main
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let test_vectors = [
         (

--- a/examples/pairing/src/main.rs
+++ b/examples/pairing/src/main.rs
@@ -25,8 +25,7 @@ openvm_algebra_complex_macros::complex_init! {
 // ANCHOR_END: init
 
 // ANCHOR: main
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     // ANCHOR: setup
     setup_0();

--- a/examples/pairing/src/main.rs
+++ b/examples/pairing/src/main.rs
@@ -25,7 +25,7 @@ openvm_algebra_complex_macros::complex_init! {
 // ANCHOR_END: init
 
 // ANCHOR: main
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     // ANCHOR: setup
     setup_0();

--- a/examples/sha256/src/main.rs
+++ b/examples/sha256/src/main.rs
@@ -12,8 +12,7 @@ use openvm_sha256_guest::sha256;
 // ANCHOR_END: imports
 
 // ANCHOR: main
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let test_vectors = [(
         "",

--- a/examples/sha256/src/main.rs
+++ b/examples/sha256/src/main.rs
@@ -12,7 +12,7 @@ use openvm_sha256_guest::sha256;
 // ANCHOR_END: imports
 
 // ANCHOR: main
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let test_vectors = [(
         "",

--- a/examples/u256/src/main.rs
+++ b/examples/u256/src/main.rs
@@ -33,7 +33,7 @@ pub fn get_identity_matrix() -> Matrix {
     res
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let b: Matrix = get_matrix(28);

--- a/examples/u256/src/main.rs
+++ b/examples/u256/src/main.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::needless_range_loop)]
 
-openvm::entry!(main);
 use core::array;
 
 use openvm_bigint_guest::U256;
@@ -34,6 +33,7 @@ pub fn get_identity_matrix() -> Matrix {
     res
 }
 
+#[openvm::entry]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let b: Matrix = get_matrix(28);

--- a/extensions/algebra/tests/programs/examples/complex-redundant-modulus.rs
+++ b/extensions/algebra/tests/programs/examples/complex-redundant-modulus.rs
@@ -3,8 +3,6 @@
 
 use openvm_algebra_guest::IntMod;
 
-openvm::entry!(main);
-
 openvm_algebra_moduli_macros::moduli_declare! {
     Mod1 { modulus = "998244353" },
     Mod2 { modulus = "1000000007" },
@@ -23,6 +21,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex2 { mod_idx = 2 },
 }
 
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_complex_extensions();

--- a/extensions/algebra/tests/programs/examples/complex-redundant-modulus.rs
+++ b/extensions/algebra/tests/programs/examples/complex-redundant-modulus.rs
@@ -21,7 +21,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex2 { mod_idx = 2 },
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_complex_extensions();

--- a/extensions/algebra/tests/programs/examples/complex-secp256k1.rs
+++ b/extensions/algebra/tests/programs/examples/complex-secp256k1.rs
@@ -18,7 +18,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex { mod_idx = 0},
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_complex_extensions();

--- a/extensions/algebra/tests/programs/examples/complex-secp256k1.rs
+++ b/extensions/algebra/tests/programs/examples/complex-secp256k1.rs
@@ -3,8 +3,6 @@
 
 use openvm_algebra_guest::{field::ComplexConjugate, DivAssignUnsafe, DivUnsafe, IntMod};
 
-openvm::entry!(main);
-
 openvm_algebra_moduli_macros::moduli_declare! {
     Secp256k1Coord { modulus = "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F" }
 }
@@ -20,6 +18,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex { mod_idx = 0},
 }
 
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_complex_extensions();

--- a/extensions/algebra/tests/programs/examples/complex-two-modulos.rs
+++ b/extensions/algebra/tests/programs/examples/complex-two-modulos.rs
@@ -20,7 +20,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex1 { mod_idx = 0 }, Complex2 { mod_idx = 1 },
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_complex_extensions();

--- a/extensions/algebra/tests/programs/examples/complex-two-modulos.rs
+++ b/extensions/algebra/tests/programs/examples/complex-two-modulos.rs
@@ -3,8 +3,6 @@
 
 use openvm_algebra_guest::IntMod;
 
-openvm::entry!(main);
-
 openvm_algebra_moduli_macros::moduli_declare! {
     Mod1 { modulus = "998244353" },
     Mod2 { modulus = "1000000007" }
@@ -22,6 +20,7 @@ openvm_algebra_complex_macros::complex_init! {
     Complex1 { mod_idx = 0 }, Complex2 { mod_idx = 1 },
 }
 
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_complex_extensions();

--- a/extensions/algebra/tests/programs/examples/little.rs
+++ b/extensions/algebra/tests/programs/examples/little.rs
@@ -11,7 +11,7 @@ openvm_algebra_moduli_macros::moduli_init!(
     "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F"
 );
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     let mut pow = Secp256k1Coord::MODULUS;

--- a/extensions/algebra/tests/programs/examples/little.rs
+++ b/extensions/algebra/tests/programs/examples/little.rs
@@ -3,8 +3,6 @@
 
 use openvm_algebra_guest::{DivUnsafe, IntMod};
 
-openvm::entry!(main);
-
 openvm_algebra_moduli_macros::moduli_declare! {
     Secp256k1Coord { modulus = "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F" }
 }
@@ -13,6 +11,7 @@ openvm_algebra_moduli_macros::moduli_init!(
     "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F"
 );
 
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     let mut pow = Secp256k1Coord::MODULUS;

--- a/extensions/algebra/tests/programs/examples/moduli_setup.rs
+++ b/extensions/algebra/tests/programs/examples/moduli_setup.rs
@@ -20,7 +20,7 @@ openvm_algebra_moduli_macros::moduli_init! {
     "0x1fffffffffffffff",
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     let x = Bls12381::from_repr(core::array::from_fn(|i| i as u8));

--- a/extensions/algebra/tests/programs/examples/moduli_setup.rs
+++ b/extensions/algebra/tests/programs/examples/moduli_setup.rs
@@ -5,7 +5,6 @@ extern crate alloc;
 
 use openvm_algebra_guest::IntMod;
 
-openvm::entry!(main);
 openvm_algebra_moduli_macros::moduli_declare! {
     Bls12381 { modulus = "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787" },
     Mod1e18 { modulus = "1000000000000000003" },
@@ -21,6 +20,7 @@ openvm_algebra_moduli_macros::moduli_init! {
     "0x1fffffffffffffff",
 }
 
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     let x = Bls12381::from_repr(core::array::from_fn(|i| i as u8));

--- a/extensions/bigint/tests/programs/examples/matrix-power-signed.rs
+++ b/extensions/bigint/tests/programs/examples/matrix-power-signed.rs
@@ -48,7 +48,7 @@ pub fn matrix_exp(mut base: Matrix, mut exp: I256) -> Matrix {
     result
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let c = matrix_exp(a, I256::from_i32(1234567));

--- a/extensions/bigint/tests/programs/examples/matrix-power-signed.rs
+++ b/extensions/bigint/tests/programs/examples/matrix-power-signed.rs
@@ -6,7 +6,6 @@ use core::array;
 
 use openvm::io::print;
 use openvm_bigint_guest::I256;
-openvm::entry!(main);
 
 const N: usize = 16;
 type Matrix = [[I256; N]; N];
@@ -49,6 +48,7 @@ pub fn matrix_exp(mut base: Matrix, mut exp: I256) -> Matrix {
     result
 }
 
+#[openvm::entry]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let c = matrix_exp(a, I256::from_i32(1234567));

--- a/extensions/bigint/tests/programs/examples/matrix-power-unsigned.rs
+++ b/extensions/bigint/tests/programs/examples/matrix-power-unsigned.rs
@@ -3,7 +3,6 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::eq_op)]
 
-openvm::entry!(main);
 use core::array;
 
 use openvm::io::print;
@@ -50,6 +49,7 @@ pub fn bin_exp(mut base: Matrix, mut exp: U256) -> Matrix {
     result
 }
 
+#[openvm::entry]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let c = bin_exp(a, U256::from_u32(1234567));

--- a/extensions/bigint/tests/programs/examples/matrix-power-unsigned.rs
+++ b/extensions/bigint/tests/programs/examples/matrix-power-unsigned.rs
@@ -49,7 +49,7 @@ pub fn bin_exp(mut base: Matrix, mut exp: U256) -> Matrix {
     result
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let a: Matrix = get_identity_matrix();
     let c = bin_exp(a, U256::from_u32(1234567));

--- a/extensions/ecc/tests/programs/examples/decompress.rs
+++ b/extensions/ecc/tests/programs/examples/decompress.rs
@@ -16,7 +16,7 @@ openvm_ecc_sw_macros::sw_init! {
     Secp256k1Point,
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_0();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/decompress.rs
+++ b/extensions/ecc/tests/programs/examples/decompress.rs
@@ -8,8 +8,6 @@ use openvm_ecc_guest::{
     weierstrass::{FromCompressed, WeierstrassPoint},
 };
 
-openvm::entry!(main);
-
 openvm_algebra_moduli_macros::moduli_init! {
     "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F",
     "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141"
@@ -18,6 +16,7 @@ openvm_ecc_sw_macros::sw_init! {
     Secp256k1Point,
 }
 
+#[openvm::entry]
 pub fn main() {
     setup_0();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ec.rs
+++ b/extensions/ecc/tests/programs/examples/ec.rs
@@ -19,7 +19,7 @@ openvm_ecc_sw_macros::sw_init! {
     Secp256k1Point,
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ec.rs
+++ b/extensions/ecc/tests/programs/examples/ec.rs
@@ -19,8 +19,7 @@ openvm_ecc_sw_macros::sw_init! {
     Secp256k1Point,
 }
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
+++ b/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
@@ -21,7 +21,7 @@ openvm_ecc_sw_macros::sw_init! {
     P256Point,
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
+++ b/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
@@ -12,8 +12,6 @@ use openvm_ecc_guest::{
     CyclicGroup, Group,
 };
 
-openvm::entry!(main);
-
 openvm_algebra_moduli_macros::moduli_init! {
     "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
     "0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
@@ -23,6 +21,7 @@ openvm_ecc_sw_macros::sw_init! {
     P256Point,
 }
 
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ec_two_curves.rs
+++ b/extensions/ecc/tests/programs/examples/ec_two_curves.rs
@@ -23,7 +23,7 @@ openvm_ecc_sw_macros::sw_init! {
     P256Point,
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ec_two_curves.rs
+++ b/extensions/ecc/tests/programs/examples/ec_two_curves.rs
@@ -23,8 +23,7 @@ openvm_ecc_sw_macros::sw_init! {
     P256Point,
 }
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ecdsa.rs
+++ b/extensions/ecc/tests/programs/examples/ecdsa.rs
@@ -13,7 +13,6 @@ use openvm_ecc_guest::{
     algebra::IntMod, ecdsa::VerifyingKey, k256::Secp256k1Point, weierstrass::WeierstrassPoint,
 };
 use openvm_keccak256_guest::keccak256;
-openvm::entry!(main);
 
 openvm_algebra_moduli_macros::moduli_init! {
     "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F",
@@ -24,6 +23,7 @@ openvm_ecc_sw_macros::sw_init! {
 }
 
 // Ref: https://docs.rs/k256/latest/k256/ecdsa/index.html
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/ecc/tests/programs/examples/ecdsa.rs
+++ b/extensions/ecc/tests/programs/examples/ecdsa.rs
@@ -23,7 +23,7 @@ openvm_ecc_sw_macros::sw_init! {
 }
 
 // Ref: https://docs.rs/k256/latest/k256/ecdsa/index.html
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/keccak256/tests/programs/examples/keccak.rs
+++ b/extensions/keccak256/tests/programs/examples/keccak.rs
@@ -9,7 +9,7 @@ use core::hint::black_box;
 use hex::FromHex;
 use openvm_keccak256_guest::keccak256;
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let test_vectors = [
         ("", "C5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470"), // ShortMsgKAT_256 Len = 0

--- a/extensions/keccak256/tests/programs/examples/keccak.rs
+++ b/extensions/keccak256/tests/programs/examples/keccak.rs
@@ -9,8 +9,7 @@ use core::hint::black_box;
 use hex::FromHex;
 use openvm_keccak256_guest::keccak256;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let test_vectors = [
         ("", "C5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470"), // ShortMsgKAT_256 Len = 0

--- a/extensions/pairing/tests/programs/examples/bls_ec.rs
+++ b/extensions/pairing/tests/programs/examples/bls_ec.rs
@@ -15,8 +15,7 @@ openvm_ecc_sw_macros::sw_init! {
     Bls12_381G1Affine,
 }
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/pairing/tests/programs/examples/bls_ec.rs
+++ b/extensions/pairing/tests/programs/examples/bls_ec.rs
@@ -15,7 +15,7 @@ openvm_ecc_sw_macros::sw_init! {
     Bls12_381G1Affine,
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     setup_all_moduli();
     setup_all_curves();

--- a/extensions/pairing/tests/programs/examples/final_exp_hint.rs
+++ b/extensions/pairing/tests/programs/examples/final_exp_hint.rs
@@ -12,13 +12,12 @@ use openvm_pairing_guest::{
     pairing::PairingCheck,
 };
 
-openvm::entry!(main);
-
 openvm_algebra_moduli_macros::moduli_init! {
     "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab",
     "0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
 }
 
+#[openvm::entry]
 pub fn main() {
     let (p, q, expected): (Vec<AffinePoint<Fp>>, Vec<AffinePoint<Fp2>>, (Fp12, Fp12)) = read();
     let actual = Bls12_381::pairing_check_hint(&p, &q);

--- a/extensions/pairing/tests/programs/examples/final_exp_hint.rs
+++ b/extensions/pairing/tests/programs/examples/final_exp_hint.rs
@@ -17,7 +17,7 @@ openvm_algebra_moduli_macros::moduli_init! {
     "0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let (p, q, expected): (Vec<AffinePoint<Fp>>, Vec<AffinePoint<Fp2>>, (Fp12, Fp12)) = read();
     let actual = Bls12_381::pairing_check_hint(&p, &q);

--- a/extensions/pairing/tests/programs/examples/fp12_mul.rs
+++ b/extensions/pairing/tests/programs/examples/fp12_mul.rs
@@ -6,8 +6,6 @@
 use openvm::io::read_vec;
 use openvm_algebra_guest::{field::FieldExtension, IntMod};
 
-openvm::entry!(main);
-
 #[cfg(feature = "bn254")]
 mod bn254 {
     use openvm_pairing_guest::bn254::{Fp, Fp12};
@@ -76,6 +74,7 @@ mod bls12_381 {
     }
 }
 
+#[openvm::entry]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/fp12_mul.rs
+++ b/extensions/pairing/tests/programs/examples/fp12_mul.rs
@@ -74,7 +74,7 @@ mod bls12_381 {
     }
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_check.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_check.rs
@@ -9,8 +9,6 @@ use openvm::io::read_vec;
 use openvm_ecc_guest::AffinePoint;
 use openvm_pairing_guest::pairing::PairingCheck;
 
-openvm::entry!(main);
-
 #[cfg(feature = "bn254")]
 mod bn254 {
     use alloc::format;
@@ -90,6 +88,7 @@ mod bls12_381 {
     }
 }
 
+#[openvm::entry]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_check.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_check.rs
@@ -88,7 +88,7 @@ mod bls12_381 {
     }
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_line.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_line.rs
@@ -7,8 +7,6 @@ use openvm::io::read_vec;
 use openvm_algebra_guest::{field::FieldExtension, IntMod};
 use openvm_pairing_guest::pairing::{EvaluatedLine, LineMulDType, LineMulMType};
 
-openvm::entry!(main);
-
 #[cfg(feature = "bn254")]
 mod bn254 {
     use openvm_pairing_guest::bn254::{Bn254, Fp, Fp12, Fp2};
@@ -113,6 +111,7 @@ mod bls12_381 {
     }
 }
 
+#[openvm::entry]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_line.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_line.rs
@@ -111,7 +111,7 @@ mod bls12_381 {
     }
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
@@ -98,7 +98,7 @@ mod bls12_381 {
     }
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
@@ -10,8 +10,6 @@ use openvm_algebra_guest::{field::FieldExtension, IntMod};
 use openvm_ecc_guest::AffinePoint;
 use openvm_pairing_guest::pairing::MultiMillerLoop;
 
-openvm::entry!(main);
-
 #[cfg(feature = "bn254")]
 mod bn254 {
     use openvm_pairing_guest::bn254::{Bn254, Fp, Fp2};
@@ -100,6 +98,7 @@ mod bls12_381 {
     }
 }
 
+#[openvm::entry]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
@@ -160,7 +160,7 @@ mod bls12_381 {
     }
 }
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
@@ -8,8 +8,6 @@ use openvm_algebra_guest::IntMod;
 use openvm_ecc_guest::AffinePoint;
 use openvm_pairing_guest::pairing::MillerStep;
 
-openvm::entry!(main);
-
 #[cfg(feature = "bn254")]
 mod bn254 {
     use openvm_pairing_guest::bn254::{Bn254, Fp, Fp2};
@@ -162,6 +160,7 @@ mod bls12_381 {
     }
 }
 
+#[openvm::entry]
 pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();

--- a/extensions/rv32im/tests/programs/examples/collatz.rs
+++ b/extensions/rv32im/tests/programs/examples/collatz.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let mut x: u32 = core::hint::black_box(837799);
     let mut count: u32 = 0;

--- a/extensions/rv32im/tests/programs/examples/collatz.rs
+++ b/extensions/rv32im/tests/programs/examples/collatz.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let mut x: u32 = core::hint::black_box(837799);
     let mut count: u32 = 0;

--- a/extensions/rv32im/tests/programs/examples/fibonacci.rs
+++ b/extensions/rv32im/tests/programs/examples/fibonacci.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/extensions/rv32im/tests/programs/examples/fibonacci.rs
+++ b/extensions/rv32im/tests/programs/examples/fibonacci.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let n = core::hint::black_box(1 << 10);
     let mut a: u32 = 0;

--- a/extensions/rv32im/tests/programs/examples/hashmap.rs
+++ b/extensions/rv32im/tests/programs/examples/hashmap.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 
 use std::collections::HashMap;
 
-#[openvm::entry]
+#[openvm::main]
 fn main() {
     let mut map = HashMap::new();
     map.insert(1, 2);

--- a/extensions/rv32im/tests/programs/examples/hashmap.rs
+++ b/extensions/rv32im/tests/programs/examples/hashmap.rs
@@ -5,8 +5,7 @@ extern crate alloc;
 
 use std::collections::HashMap;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 fn main() {
     let mut map = HashMap::new();
     map.insert(1, 2);

--- a/extensions/rv32im/tests/programs/examples/hint.rs
+++ b/extensions/rv32im/tests/programs/examples/hint.rs
@@ -2,8 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use openvm::io::read_vec;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let vec = read_vec();
     // assert_eq!(vec.len(), 4);

--- a/extensions/rv32im/tests/programs/examples/hint.rs
+++ b/extensions/rv32im/tests/programs/examples/hint.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use openvm::io::read_vec;
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let vec = read_vec();
     // assert_eq!(vec.len(), 4);

--- a/extensions/rv32im/tests/programs/examples/print.rs
+++ b/extensions/rv32im/tests/programs/examples/print.rs
@@ -3,7 +3,7 @@
 
 use openvm::io::print;
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     print("Hello, world!");
 }

--- a/extensions/rv32im/tests/programs/examples/print.rs
+++ b/extensions/rv32im/tests/programs/examples/print.rs
@@ -3,8 +3,7 @@
 
 use openvm::io::print;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     print("Hello, world!");
 }

--- a/extensions/rv32im/tests/programs/examples/read.rs
+++ b/extensions/rv32im/tests/programs/examples/read.rs
@@ -3,8 +3,6 @@
 extern crate alloc;
 use openvm::io::read;
 
-openvm::entry!(main);
-
 #[derive(serde::Deserialize)]
 struct Foo {
     bar: u32,
@@ -12,6 +10,7 @@ struct Foo {
 }
 
 #[allow(clippy::disallowed_names)]
+#[openvm::entry]
 pub fn main() {
     let foo: Foo = read();
     if foo.baz.len() != 4 {

--- a/extensions/rv32im/tests/programs/examples/read.rs
+++ b/extensions/rv32im/tests/programs/examples/read.rs
@@ -10,7 +10,7 @@ struct Foo {
 }
 
 #[allow(clippy::disallowed_names)]
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let foo: Foo = read();
     if foo.baz.len() != 4 {

--- a/extensions/rv32im/tests/programs/examples/reveal.rs
+++ b/extensions/rv32im/tests/programs/examples/reveal.rs
@@ -3,8 +3,7 @@
 
 use openvm::io::reveal;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let x: u32 = core::hint::black_box(123);
     let y: u32 = core::hint::black_box(456);

--- a/extensions/rv32im/tests/programs/examples/reveal.rs
+++ b/extensions/rv32im/tests/programs/examples/reveal.rs
@@ -3,7 +3,7 @@
 
 use openvm::io::reveal;
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let x: u32 = core::hint::black_box(123);
     let y: u32 = core::hint::black_box(456);

--- a/extensions/rv32im/tests/programs/examples/tiny-mem-test.rs
+++ b/extensions/rv32im/tests/programs/examples/tiny-mem-test.rs
@@ -3,8 +3,7 @@
 extern crate alloc;
 use alloc::vec::Vec;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let mut v = Vec::new();
     for i in 1..10 {

--- a/extensions/rv32im/tests/programs/examples/tiny-mem-test.rs
+++ b/extensions/rv32im/tests/programs/examples/tiny-mem-test.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 use alloc::vec::Vec;
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let mut v = Vec::new();
     for i in 1..10 {

--- a/extensions/sha256/tests/programs/examples/sha.rs
+++ b/extensions/sha256/tests/programs/examples/sha.rs
@@ -9,7 +9,7 @@ use core::hint::black_box;
 use hex::FromHex;
 use openvm_sha256_guest::sha256;
 
-#[openvm::entry]
+#[openvm::main]
 pub fn main() {
     let test_vectors = [
         ("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),

--- a/extensions/sha256/tests/programs/examples/sha.rs
+++ b/extensions/sha256/tests/programs/examples/sha.rs
@@ -9,8 +9,7 @@ use core::hint::black_box;
 use hex::FromHex;
 use openvm_sha256_guest::sha256;
 
-openvm::entry!(main);
-
+#[openvm::entry]
 pub fn main() {
     let test_vectors = [
         ("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),


### PR DESCRIPTION
This resolves INT-2784. Now, instead of `openvm::entry!(main)`, we just write `#[openvm::entry]` before `fn main`.