### PR TITLE
chore(prof): split benchmark output into separate benchmarks by group

### DIFF
--- a/crates/prof/src/aggregate.rs
+++ b/crates/prof/src/aggregate.rs
@@ -1,10 +1,9 @@
 use std::{collections::HashMap, io::Write};
 
 use eyre::Result;
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::types::{BencherValue, Labels, MdTableCell, MetricDb};
+use crate::types::{BencherValue, BenchmarkOutput, Labels, MdTableCell, MetricDb};
 
 type MetricName = String;
 type MetricsByName = HashMap<MetricName, Vec<(f64, Labels)>>;
@@ -29,9 +28,8 @@ pub struct AggregateMetrics {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BencherAggregateMetrics {
-    // BMF max depth is 2
     #[serde(flatten)]
-    pub by_group: HashMap<String, BencherValue>,
+    pub by_group: HashMap<String, HashMap<String, BencherValue>>,
     /// In seconds
     pub total_proof_time: BencherValue,
     /// In seconds
@@ -232,17 +230,14 @@ impl AggregateMetrics {
         let by_group = self
             .by_group
             .iter()
-            .flat_map(|(group_name, metrics)| {
-                metrics
+            .map(|(group_name, metrics)| {
+                let metrics = metrics
                     .iter()
                     .flat_map(|(metric_name, stats)| {
                         [
+                            (format!("{metric_name}::sum"), stats.sum.into()),
                             (
-                                format!("{group_name}::{metric_name}::sum"),
-                                stats.sum.into(),
-                            ),
-                            (
-                                format!("{group_name}::{metric_name}"),
+                                metric_name.clone(),
                                 BencherValue {
                                     value: stats.avg.val,
                                     lower_value: Some(stats.min.val),
@@ -251,7 +246,8 @@ impl AggregateMetrics {
                             ),
                         ]
                     })
-                    .collect_vec()
+                    .collect();
+                (group_name.clone(), metrics)
             })
             .collect();
         let total_proof_time = self.total_proof_time.into();
@@ -339,6 +335,28 @@ impl AggregateMetrics {
             .find(|k| group_weight(k) == 0)
             .unwrap_or_else(|| self.by_group.keys().next().unwrap())
             .clone()
+    }
+}
+
+impl BenchmarkOutput {
+    pub fn insert(&mut self, name: &str, metrics: BencherAggregateMetrics) {
+        for (group_name, metrics) in metrics.by_group {
+            self.by_name
+                .entry(format!("{name}::{group_name}"))
+                .or_default()
+                .extend(metrics);
+        }
+        self.by_name.insert(
+            name.to_owned(),
+            HashMap::from_iter([("total_proof_time".to_owned(), metrics.total_proof_time)]),
+        );
+        self.by_name.insert(
+            name.to_owned(),
+            HashMap::from_iter([(
+                "total_par_proof_time".to_owned(),
+                metrics.total_par_proof_time,
+            )]),
+        );
     }
 }
 

--- a/crates/prof/src/main.rs
+++ b/crates/prof/src/main.rs
@@ -72,9 +72,7 @@ fn main() -> Result<()> {
             }
         }
 
-        output
-            .by_name
-            .insert(aggregated.name(), aggregated.to_bencher_metrics());
+        output.insert(&aggregated.name(), aggregated.to_bencher_metrics());
         let mut writer = Vec::new();
         aggregated.write_markdown(&mut writer, VM_METRIC_NAMES)?;
 

--- a/crates/prof/src/types.rs
+++ b/crates/prof/src/types.rs
@@ -3,8 +3,6 @@ use std::collections::{BTreeMap, HashMap};
 use num_format::{Locale, ToFormattedString};
 use serde::{Deserialize, Serialize};
 
-use crate::aggregate::BencherAggregateMetrics;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metric {
     pub name: String,
@@ -39,8 +37,9 @@ pub struct BencherValue {
 /// Benchmark output in [Bencher Metric Format](https://bencher.dev/docs/reference/bencher-metric-format/).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct BenchmarkOutput {
+    // BMF max depth is 2
     #[serde(flatten)]
-    pub by_name: HashMap<String, BencherAggregateMetrics>,
+    pub by_name: HashMap<String, HashMap<String, BencherValue>>,
 }
 
 impl Labels {


### PR DESCRIPTION
Too many metrics in one benchmark is hard for bencher to manage