### PR TITLE
perf: More efficient touch_range

### DIFF
--- a/crates/vm/src/system/memory/controller/interface.rs
+++ b/crates/vm/src/system/memory/controller/interface.rs
@@ -20,20 +20,6 @@ pub enum MemoryInterface<F> {
 }
 
 impl<F: PrimeField32> MemoryInterface<F> {
-    pub fn touch_address(&mut self, addr_space: u32, pointer: u32) {
-        match self {
-            MemoryInterface::Volatile { .. } => {}
-            MemoryInterface::Persistent {
-                boundary_chip,
-                merkle_chip,
-                ..
-            } => {
-                boundary_chip.touch_address(addr_space, pointer);
-                merkle_chip.touch_address(addr_space, pointer);
-            }
-        }
-    }
-
     pub fn touch_range(&mut self, addr_space: u32, pointer: u32, len: u32) {
         match self {
             MemoryInterface::Volatile { .. } => {}
@@ -42,10 +28,8 @@ impl<F: PrimeField32> MemoryInterface<F> {
                 merkle_chip,
                 ..
             } => {
-                for offset in 0..len {
-                    boundary_chip.touch_address(addr_space, pointer + offset);
-                    merkle_chip.touch_address(addr_space, pointer + offset);
-                }
+                boundary_chip.touch_range(addr_space, pointer, len);
+                merkle_chip.touch_range(addr_space, pointer, len);
             }
         }
     }

--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -69,11 +69,12 @@ impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
         }
     }
 
-    pub fn touch_address(&mut self, address_space: u32, address: u32) {
-        self.touch_node(
-            0,
-            address_space - self.air.memory_dimensions.as_offset,
-            address / CHUNK as u32,
-        );
+    pub fn touch_range(&mut self, address_space: u32, address: u32, len: u32) {
+        let as_label = address_space - self.air.memory_dimensions.as_offset;
+        let first_address_label = address / CHUNK as u32;
+        let last_address_label = (address + len - 1) / CHUNK as u32;
+        for address_label in first_address_label..=last_address_label {
+            self.touch_node(0, as_label, address_label);
+        }
     }
 }

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -84,9 +84,7 @@ fn test<const CHUNK: usize>(
     let mut chip =
         MemoryMerkleChip::<CHUNK, _>::new(memory_dimensions, merkle_bus, COMPRESSION_BUS);
     for &(address_space, label) in touched_labels.iter() {
-        for i in 0..CHUNK as u32 {
-            chip.touch_address(address_space, label * CHUNK as u32 + i);
-        }
+        chip.touch_range(address_space, label * CHUNK as u32, CHUNK as u32);
     }
 
     let final_partition = memory_to_partition(final_memory);

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -187,9 +187,12 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
         self.overridden_height = Some(overridden_height);
     }
 
-    pub fn touch_address(&mut self, address_space: u32, pointer: u32) {
-        let label = pointer / CHUNK as u32;
-        self.touched_labels.touch(address_space, label);
+    pub fn touch_range(&mut self, address_space: u32, pointer: u32, len: u32) {
+        let start_label = pointer / CHUNK as u32;
+        let end_label = (pointer + len - 1) / CHUNK as u32;
+        for label in start_label..=end_label {
+            self.touched_labels.touch(address_space, label);
+        }
     }
 
     pub fn finalize(


### PR DESCRIPTION
Previously `touch_range` was implemented by calling `touch_address` on each address in `pointer..pointer + len`. But for persistent memory, in both `MemoryMerkleChip` and `PersistentBoundaryChip`, we actually care about touched aligned blocks of size 8. So most of the triggered calls to `touch_address` via a single `touch_range` were redundant, repeatedly querying the same hashmap at the same block index.