### PR TITLE
perf: Remove touch address for VolatileMemory

### DIFF
--- a/crates/vm/src/system/memory/controller/interface.rs
+++ b/crates/vm/src/system/memory/controller/interface.rs
@@ -22,9 +22,7 @@ pub enum MemoryInterface<F> {
 impl<F: PrimeField32> MemoryInterface<F> {
     pub fn touch_address(&mut self, addr_space: u32, pointer: u32) {
         match self {
-            MemoryInterface::Volatile { boundary_chip } => {
-                boundary_chip.touch_address(addr_space, pointer);
-            }
+            MemoryInterface::Volatile { .. } => {}
             MemoryInterface::Persistent {
                 boundary_chip,
                 merkle_chip,
@@ -38,11 +36,7 @@ impl<F: PrimeField32> MemoryInterface<F> {
 
     pub fn touch_range(&mut self, addr_space: u32, pointer: u32, len: u32) {
         match self {
-            MemoryInterface::Volatile { boundary_chip } => {
-                for offset in 0..len {
-                    boundary_chip.touch_address(addr_space, pointer + offset);
-                }
-            }
+            MemoryInterface::Volatile { .. } => {}
             MemoryInterface::Persistent {
                 boundary_chip,
                 merkle_chip,


### PR DESCRIPTION
VolatileMemory does not need to internally maintain touched addresses as it is given `final_memory` in `finalize`. This does mean that `current_trace_height` is no longer known until finalization.