### PR TITLE
perf: Improve replay iteration speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,6 +3700,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "serde-big-array",
+ "smallvec",
  "static_assertions",
  "test-case",
  "test-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,7 @@ rrs-lib = "0.1.0"
 rand = { version = "0.8.5", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 serde-big-array = "0.5.1"
+smallvec = "1.13.2"
 
 # default-features = false for no_std for use in guest programs
 itertools = { version = "0.13.0", default-features = false }

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -42,6 +42,7 @@ static_assertions.workspace = true
 async-trait.workspace = true
 getset.workspace = true
 rayon = { workspace = true, optional = true }
+smallvec.workspace = true
 
 [dev-dependencies]
 p3-dft = { workspace = true }

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -492,7 +492,7 @@ impl<F: PrimeField32> MemoryController<F> {
                 if address_space != 0 {
                     interface_chip.touch_range(address_space, pointer, data.len() as u32);
                 }
-                offline_memory.write(address_space, pointer, data, adapter_records);
+                offline_memory.write(address_space, pointer, &data, adapter_records);
             }
             MemoryLogEntry::IncrementTimestampBy(amount) => {
                 offline_memory.increment_timestamp_by(amount);

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -8,6 +8,7 @@ pub mod offline_checker;
 pub mod online;
 pub mod paged_vec;
 mod persistent;
+mod smallvec;
 #[cfg(test)]
 mod tests;
 pub mod tree;

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -1,7 +1,9 @@
 use std::fmt::Debug;
 
+use openvm_circuit::system::memory::smallvec::SerdeSmallVec;
 use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 use super::paged_vec::{AddressMap, PAGE_SIZE};
 use crate::{
@@ -19,7 +21,7 @@ pub enum MemoryLogEntry<T> {
     Write {
         address_space: u32,
         pointer: u32,
-        data: Vec<T>,
+        data: SerdeSmallVec<[T; 4]>,
     },
     IncrementTimestampBy(u32),
 }
@@ -72,7 +74,7 @@ impl<F: PrimeField32> Memory<F> {
         self.log.push(MemoryLogEntry::Write {
             address_space,
             pointer,
-            data: values.to_vec(),
+            data: SmallVec::from_slice(&values).into(),
         });
         self.timestamp += 1;
 

--- a/crates/vm/src/system/memory/smallvec.rs
+++ b/crates/vm/src/system/memory/smallvec.rs
@@ -1,0 +1,81 @@
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{Deserialize, Serialize};
+use smallvec::{Array, SmallVec};
+
+pub struct SerdeSmallVec<A: Array>(SmallVec<A>);
+
+impl<A: Array> Debug for SerdeSmallVec<A>
+where
+    A::Item: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<A: Array> Clone for SerdeSmallVec<A>
+where
+    A::Item: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<A: Array> From<SmallVec<A>> for SerdeSmallVec<A> {
+    fn from(smallvec: SmallVec<A>) -> Self {
+        Self(smallvec)
+    }
+}
+
+impl<A: Array> From<SerdeSmallVec<A>> for SmallVec<A> {
+    fn from(wrapper: SerdeSmallVec<A>) -> Self {
+        wrapper.0
+    }
+}
+
+// Implement Deref so SerdeSmallVec behaves exactly like SmallVec
+impl<A: Array> Deref for SerdeSmallVec<A> {
+    type Target = SmallVec<A>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Implement DerefMut to allow mutable access
+impl<A: Array> DerefMut for SerdeSmallVec<A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// Implement Serialize and Deserialize only when needed
+impl<A: Array + Serialize> Serialize for SerdeSmallVec<A>
+where
+    A::Item: Serialize, // Ensure the item type is serializable
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.as_slice().serialize(serializer)
+    }
+}
+
+impl<'de, A: Array + Deserialize<'de>> Deserialize<'de> for SerdeSmallVec<A>
+where
+    A::Item: Deserialize<'de>, // Ensure the item type is deserializable
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = Vec::<A::Item>::deserialize(deserializer)?;
+        Ok(Self(SmallVec::from_vec(vec)))
+    }
+}


### PR DESCRIPTION
Previously 18% of finalize was spent just calling `Iterator::next()` (locally for reth block 2100000).