### PR TITLE
[perf] Store blocks in a potentially smarter way

### DIFF
--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -108,27 +108,6 @@ impl BlockMap {
             .filter(|(_, idx)| *idx > 0)
             .map(|(address, idx)| (address, &self.storage[idx - 1]))
     }
-
-    /// Merges the block starting at `address` and the one immediately after it. The blocks must have the same size.
-    pub fn merge_block_with_next(&mut self, address: &(u32, u32)) {
-        let &(address_space, pointer) = address;
-        let left = *self.id.get(address).unwrap();
-        let size = self.storage[left - 1].size;
-        let timestamp = self.storage[left - 1].timestamp.max(
-            self.storage[self
-                .id
-                .get(&(address_space, pointer + size as u32))
-                .unwrap()
-                - 1]
-            .timestamp,
-        );
-        self.storage[left - 1].size += size;
-        self.storage[left - 1].timestamp = timestamp;
-        for i in 0..size {
-            self.id
-                .insert(&(address_space, pointer + size as u32 + i as u32), left);
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -406,7 +385,7 @@ impl<F: PrimeField32> OfflineMemory<F> {
                 self.block_data
                     .set_range(&(address_space, mid_ptr), half_size, block);
             }
-            if query >= mid_ptr {
+            if query >= cur_ptr + half_size_u32 {
                 // The left is finalized; add it to the partition.
                 let block = BlockData {
                     pointer: cur_ptr,
@@ -499,8 +478,15 @@ impl<F: PrimeField32> OfflineMemory<F> {
             .timestamp;
 
         let timestamp = max(left_timestamp, right_timestamp);
-        self.block_data
-            .merge_block_with_next(&(address_space, pointer));
+        self.block_data.set_range(
+            &(address_space, pointer),
+            2 * size,
+            BlockData {
+                pointer,
+                size: 2 * size,
+                timestamp,
+            },
+        );
         records.add_record(AccessAdapterRecord {
             timestamp,
             address_space: F::from_canonical_u32(address_space),

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -25,6 +25,91 @@ struct BlockData {
     size: usize,
 }
 
+struct BlockMap {
+    /// Block ids. 0 is a special value standing for the default block.
+    id: AddressMap<usize, PAGE_SIZE>,
+    /// The place where non-default blocks are stored.
+    storage: Vec<BlockData>,
+    initial_block_size: usize,
+}
+
+impl BlockMap {
+    pub fn from_mem_config(mem_config: &MemoryConfig, initial_block_size: usize) -> Self {
+        assert!(initial_block_size.is_power_of_two());
+        Self {
+            id: AddressMap::from_mem_config(mem_config),
+            storage: vec![],
+            initial_block_size,
+        }
+    }
+
+    fn initial_block_data(pointer: u32, initial_block_size: usize) -> BlockData {
+        let aligned_pointer = (pointer / initial_block_size as u32) * initial_block_size as u32;
+        BlockData {
+            pointer: aligned_pointer,
+            size: initial_block_size,
+            timestamp: INITIAL_TIMESTAMP,
+        }
+    }
+
+    pub fn get_without_adding(&self, address: &(u32, u32)) -> BlockData {
+        let idx = self.id.get(address).unwrap_or(&0);
+        if idx == &0 {
+            Self::initial_block_data(address.1, self.initial_block_size)
+        } else {
+            self.storage[idx - 1].clone()
+        }
+    }
+
+    pub fn get(&mut self, address: &(u32, u32)) -> &BlockData {
+        let (address_space, pointer) = *address;
+        let idx = self.id.get(&(address_space, pointer)).unwrap_or(&0);
+        if idx == &0 {
+            let pointer = pointer - pointer % self.initial_block_size as u32;
+            self.set_range(
+                &(address_space, pointer),
+                self.initial_block_size,
+                Self::initial_block_data(pointer, self.initial_block_size),
+            );
+            self.storage.last().unwrap()
+        } else {
+            &self.storage[idx - 1]
+        }
+    }
+
+    pub fn get_mut(&mut self, address: &(u32, u32)) -> &mut BlockData {
+        let (address_space, pointer) = *address;
+        let idx = self.id.get(&(address_space, pointer)).unwrap_or(&0);
+        if idx == &0 {
+            let pointer = pointer - pointer % self.initial_block_size as u32;
+            self.set_range(
+                &(address_space, pointer),
+                self.initial_block_size,
+                Self::initial_block_data(pointer, self.initial_block_size),
+            );
+            self.storage.last_mut().unwrap()
+        } else {
+            &mut self.storage[idx - 1]
+        }
+    }
+
+    pub fn set_range(&mut self, address: &(u32, u32), len: usize, block: BlockData) {
+        let (address_space, pointer) = address;
+        self.storage.push(block);
+        for i in 0..len {
+            self.id
+                .insert(&(*address_space, pointer + i as u32), self.storage.len());
+        }
+    }
+
+    pub fn items(&self) -> impl Iterator<Item = ((u32, u32), &BlockData)> + '_ {
+        self.id
+            .items()
+            .filter(|(_, idx)| *idx > 0)
+            .map(|(address, idx)| (address, &self.storage[idx - 1]))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct MemoryRecord<T> {
     pub address_space: T,
@@ -53,10 +138,9 @@ impl<T: Copy> MemoryRecord<T> {
 }
 
 pub struct OfflineMemory<F> {
-    block_data: AddressMap<BlockData, PAGE_SIZE>,
+    block_data: BlockMap,
     data: Vec<PagedVec<F, PAGE_SIZE>>,
     as_offset: u32,
-    initial_block_size: usize,
     timestamp: u32,
     timestamp_max_bits: usize,
 
@@ -77,13 +161,10 @@ impl<F: PrimeField32> OfflineMemory<F> {
         range_checker: SharedVariableRangeCheckerChip,
         config: MemoryConfig,
     ) -> Self {
-        assert!(initial_block_size.is_power_of_two());
-
         Self {
-            block_data: AddressMap::from_mem_config(&config),
+            block_data: BlockMap::from_mem_config(&config, initial_block_size),
             data: Self::memory_image_to_paged_vec(initial_memory, config),
             as_offset: config.as_offset,
-            initial_block_size,
             timestamp: INITIAL_TIMESTAMP + 1,
             timestamp_max_bits: config.clk_max_bits,
             memory_bus,
@@ -231,18 +312,15 @@ impl<F: PrimeField32> OfflineMemory<F> {
             .collect();
 
         for &(address_space, pointer) in to_access.iter() {
-            let block = self.block_data.get(&(address_space, pointer)).unwrap();
-            if block.size > 0 && (block.pointer != pointer || block.size != N) {
+            let block = self.block_data.get(&(address_space, pointer));
+            if block.pointer != pointer || block.size != N {
                 self.access(address_space, pointer, N, adapter_records);
             }
         }
 
         let mut equipartition = TimestampedEquipartition::<F, N>::new();
         for (address_space, pointer) in to_access {
-            let block = self.block_data.get(&(address_space, pointer)).unwrap();
-            if block.size == 0 {
-                continue;
-            }
+            let block = self.block_data.get(&(address_space, pointer));
 
             debug_assert_eq!(block.pointer % N as u32, 0);
             debug_assert_eq!(block.size, N);
@@ -304,10 +382,8 @@ impl<F: PrimeField32> OfflineMemory<F> {
                     size: half_size,
                     timestamp,
                 };
-                for i in 0..half_size_u32 {
-                    self.block_data
-                        .insert(&(address_space, mid_ptr + i), block.clone());
-                }
+                self.block_data
+                    .set_range(&(address_space, mid_ptr), half_size, block);
             }
             if query >= cur_ptr + half_size_u32 {
                 // The left is finalized; add it to the partition.
@@ -316,10 +392,8 @@ impl<F: PrimeField32> OfflineMemory<F> {
                     size: half_size,
                     timestamp,
                 };
-                for i in 0..half_size_u32 {
-                    self.block_data
-                        .insert(&(address_space, cur_ptr + i), block.clone());
-                }
+                self.block_data
+                    .set_range(&(address_space, cur_ptr), half_size, block);
             }
             if mid_ptr <= query {
                 cur_ptr = mid_ptr;
@@ -342,21 +416,13 @@ impl<F: PrimeField32> OfflineMemory<F> {
 
         let mut prev_timestamp = None;
 
-        for i in 0..size as u32 {
-            let block = self.block_data.get(&(address_space, pointer + i));
-            if block.is_none() || block.unwrap().size == 0 {
-                self.block_data.insert(
-                    &(address_space, pointer + i),
-                    Self::initial_block_data(pointer + i, self.initial_block_size),
-                );
-            }
-            let block = self
-                .block_data
-                .get_mut(&(address_space, pointer + i))
-                .unwrap();
+        let mut i = 0;
+        while i < size as u32 {
+            let block = self.block_data.get_mut(&(address_space, pointer + i));
             debug_assert!(i == 0 || prev_timestamp == Some(block.timestamp));
             prev_timestamp = Some(block.timestamp);
             block.timestamp = self.timestamp;
+            i = block.pointer + block.size as u32;
         }
         prev_timestamp.unwrap()
     }
@@ -403,31 +469,24 @@ impl<F: PrimeField32> OfflineMemory<F> {
     ) {
         let left_block = self.block_data.get(&(address_space, pointer));
 
-        let left_timestamp = left_block.map(|b| b.timestamp).unwrap_or(INITIAL_TIMESTAMP);
-        let mut size = left_block
-            .map(|b| b.size)
-            .unwrap_or(self.initial_block_size);
-        if size == 0 {
-            size = self.initial_block_size;
-        }
+        let left_timestamp = left_block.timestamp;
+        let size = left_block.size;
 
         let right_timestamp = self
             .block_data
             .get(&(address_space, pointer + size as u32))
-            .map(|b| b.timestamp)
-            .unwrap_or(INITIAL_TIMESTAMP);
+            .timestamp;
 
         let timestamp = max(left_timestamp, right_timestamp);
-        for i in 0..2 * size as u32 {
-            self.block_data.insert(
-                &(address_space, pointer + i),
-                BlockData {
-                    pointer,
-                    size: 2 * size,
-                    timestamp,
-                },
-            );
-        }
+        self.block_data.set_range(
+            &(address_space, pointer),
+            2 * size,
+            BlockData {
+                pointer,
+                size: 2 * size,
+                timestamp,
+            },
+        );
         records.add_record(AccessAdapterRecord {
             timestamp,
             address_space: F::from_canonical_u32(address_space),
@@ -441,21 +500,8 @@ impl<F: PrimeField32> OfflineMemory<F> {
     }
 
     fn block_containing(&mut self, address_space: u32, pointer: u32) -> BlockData {
-        if let Some(block_data) = self.block_data.get(&(address_space, pointer)) {
-            if block_data.size > 0 {
-                return block_data.clone();
-            }
-        }
-        Self::initial_block_data(pointer, self.initial_block_size)
-    }
-
-    fn initial_block_data(pointer: u32, initial_block_size: usize) -> BlockData {
-        let aligned_pointer = (pointer / initial_block_size as u32) * initial_block_size as u32;
-        BlockData {
-            pointer: aligned_pointer,
-            size: initial_block_size,
-            timestamp: INITIAL_TIMESTAMP,
-        }
+        self.block_data
+            .get_without_adding(&(address_space, pointer))
     }
 
     pub fn get(&self, address_space: u32, pointer: u32) -> F {

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -65,7 +65,8 @@ impl BlockMap {
         let (address_space, pointer) = *address;
         let idx = self.id.get(&(address_space, pointer)).unwrap_or(&0);
         if idx == &0 {
-            let pointer = pointer - pointer % self.initial_block_size as u32;
+            // `initial_block_size` is a power of two, as asserted in `from_mem_config`.
+            let pointer = pointer & (self.initial_block_size as u32 - 1);
             self.set_range(
                 &(address_space, pointer),
                 self.initial_block_size,

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -66,7 +66,7 @@ impl BlockMap {
         let idx = self.id.get(&(address_space, pointer)).unwrap_or(&0);
         if idx == &0 {
             // `initial_block_size` is a power of two, as asserted in `from_mem_config`.
-            let pointer = pointer & (self.initial_block_size as u32 - 1);
+            let pointer = pointer & !(self.initial_block_size as u32 - 1);
             self.set_range(
                 &(address_space, pointer),
                 self.initial_block_size,


### PR DESCRIPTION
**Metric:** tracegen
**Before:** 21246 ms
**After:** 19288 ms
**Percentage gain:** -9.2%

Source: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/13120710102

---
This resolves INT-3235.

_Quote from the ticket._
Currently one actual block corresponds to several memory addresses. Whenever we modify the block itself (e.g. change the timestamp), we have to change it for every memory address it covers.
We could instead store the blocks we constructed in a separate storage (Vec), and in the positions we will store a simple usize denoting the block index in the storage. This also kind of simplifies the concept of the "default" block (we assign 0 to be a fictious index meaning "not initialized yet"), and generally makes the block data memory take less space and probably makes constructing it easier. Also, we can now only change the block of size 4 once and not touch 4 of its copies.
One drawback is that we don't remove the erased blocks from the storage, which means that we can potentially run out of memory because of this storage. On the other hand, this will probably happen about when we run out of timestamps anyway.
_End of quote._

Side note: I also tried to merge a block with the next in a smarter way: instead of creating a completely new block, just modify one of the existing ones. This is worse for some reason: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/13122033497