### PR TITLE
perf: Compute initial memory Merkle tree using multiple threads

### DIFF
--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -501,7 +501,7 @@ impl<F: PrimeField32> MemoryController<F> {
     }
 
     /// Returns the final memory state if persistent.
-    pub fn finalize(&mut self, hasher: Option<&mut impl HasherChip<CHUNK, F>>) {
+    pub fn finalize(&mut self, hasher: Option<&mut (impl HasherChip<CHUNK, F> + Sync)>) {
         if self.final_state.is_some() {
             return;
         }

--- a/crates/vm/src/system/memory/tree/public_values.rs
+++ b/crates/vm/src/system/memory/tree/public_values.rs
@@ -38,7 +38,7 @@ impl<const CHUNK: usize, F: PrimeField32> UserPublicValuesProof<CHUNK, F> {
     pub fn compute(
         memory_dimensions: MemoryDimensions,
         num_public_values: usize,
-        hasher: &impl Hasher<CHUNK, F>,
+        hasher: &(impl Hasher<CHUNK, F> + Sync),
         final_memory: &MemoryImage<F>,
     ) -> Self {
         let proof = compute_merkle_proof_to_user_public_values_root(
@@ -61,7 +61,7 @@ impl<const CHUNK: usize, F: PrimeField32> UserPublicValuesProof<CHUNK, F> {
 fn compute_merkle_proof_to_user_public_values_root<const CHUNK: usize, F: PrimeField32>(
     memory_dimensions: MemoryDimensions,
     num_public_values: usize,
-    hasher: &impl Hasher<CHUNK, F>,
+    hasher: &(impl Hasher<CHUNK, F> + Sync),
     final_memory: &MemoryImage<F>,
 ) -> Vec<(bool, [F; CHUNK])> {
     assert_eq!(


### PR DESCRIPTION
**Metric**: tracegen
**Before**: 18,057.45 ms
**After**: 11,425.45 ms
**Percentage gain**: -36.7%

Workflow: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/13145453065