### PR TITLE
chore: update primitive crate to enable serde `std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,6 +3739,7 @@ dependencies = [
  "p3-poseidon2",
  "p3-symmetric",
  "rand",
+ "serde",
  "test-case",
  "tracing",
 ]

--- a/crates/circuits/primitives/Cargo.toml
+++ b/crates/circuits/primitives/Cargo.toml
@@ -20,6 +20,7 @@ num-traits.workspace = true
 lazy_static.workspace = true
 tracing.workspace = true
 bitcode.workspace = true
+serde = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 p3-dft = { workspace = true }


### PR DESCRIPTION
Duplicating fix #1343 on `develop`