### PR TITLE
perf: trivial opt to reduce alloc in recursion

### DIFF
--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -114,10 +114,13 @@ pub fn verify_two_adic_pcs<C: Config>(
                 builder.set(&alpha_pow, j, C::EF::ONE.cons());
             }
         } else {
-            iter_zip!(builder, ro, alpha_pow).for_each(|ptr_vec, builder| {
-                builder.iter_ptr_set(&ro, ptr_vec[0], C::EF::ZERO.cons());
-                builder.iter_ptr_set(&alpha_pow, ptr_vec[1], C::EF::ONE.cons());
-            });
+            let zero_ef = builder.eval(C::EF::ZERO.cons());
+            let one_ef = builder.eval(C::EF::ONE.cons());
+            for j in 0..32 {
+                // Use set_value here to save a copy.
+                builder.set_value(&ro, j, zero_ef);
+                builder.set_value(&alpha_pow, j, one_ef);
+            }
         }
         // **ATTENTION**: always check shape of user inputs.
         builder.assert_eq::<Usize<_>>(query_proof.input_proof.len(), rounds.len());

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -17,8 +17,14 @@ use crate::{
     fri::types::FriProofVariable,
 };
 
+// The maximum two-adicity of Felt `C::F`. This means `C::F` does not have a multiplicative subgroup
+// of order 2^{MAX_TWO_ADICITY + 1}. Currently set to 27 for BabyBear.
+pub const MAX_TWO_ADICITY: usize = 27;
+
 /// Notes:
 /// 1. FieldMerkleTreeMMCS sorts traces by height in descending order when committing data.
+/// 2. **Required** that `C::F` has two-adicity <= [MAX_TWO_ADICITY]. In particular this implies that all LDE matrices have
+///    `log2(lde_height) <= MAX_TWO_ADICITY`.
 ///
 /// Reference:
 /// <https://github.com/Plonky3/Plonky3/blob/27b3127dab047e07145c38143379edec2960b3e1/merkle-tree/src/merkle_tree.rs#L53>
@@ -100,15 +106,15 @@ pub fn verify_two_adic_pcs<C: Config>(
     builder.cycle_tracker_end("pre-compute-rounds-context");
 
     // Working variables for reduced opening, reset per query. Both arrays indexed by log_height.
-    let ro: Array<C, Ext<C::F, C::EF>> = builder.array(32);
-    let alpha_pow: Array<C, Ext<C::F, C::EF>> = builder.array(32);
+    let ro: Array<C, Ext<C::F, C::EF>> = builder.array(MAX_TWO_ADICITY + 1);
+    let alpha_pow: Array<C, Ext<C::F, C::EF>> = builder.array(MAX_TWO_ADICITY + 1);
 
     iter_zip!(builder, proof.query_proofs).for_each(|ptr_vec, builder| {
         let query_proof = builder.iter_ptr_get(&proof.query_proofs, ptr_vec[0]);
         let index_bits = challenger.sample_bits(builder, log_max_height);
 
         if builder.flags.static_only {
-            for j in 0..32 {
+            for j in 0..=MAX_TWO_ADICITY {
                 // ATTENTION: don't use set_value here, Fixed will share the same variable.
                 builder.set(&ro, j, C::EF::ZERO.cons());
                 builder.set(&alpha_pow, j, C::EF::ONE.cons());
@@ -116,7 +122,7 @@ pub fn verify_two_adic_pcs<C: Config>(
         } else {
             let zero_ef = builder.eval(C::EF::ZERO.cons());
             let one_ef = builder.eval(C::EF::ONE.cons());
-            for j in 0..32 {
+            for j in 0..=MAX_TWO_ADICITY {
                 // Use set_value here to save a copy.
                 builder.set_value(&ro, j, zero_ef);
                 builder.set_value(&alpha_pow, j, one_ef);


### PR DESCRIPTION
Trivial optimization to save a few allocations.

Reth benchmark comparison: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/13212925789
Metric: reth root circuit main cells used
After: (-309252 [-0.9%]) 34,194,443