### PR TITLE
perf: precompute alpha pow accumulators per matrix

### DIFF
--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -95,7 +95,7 @@ pub fn verify_two_adic_pcs<C: Config>(
         compute_rounds_context(builder, &rounds, log_blowup, alpha, &mut static_alpha_pows);
     builder.cycle_tracker_end("pre-compute-rounds-context");
 
-    // Working variables for reduced opening, reset per query. Both arrays indexed by log_height.
+    // Accumulators of the reduced opening sums, reset per query. The array `ro` is indexed by log_height.
     let ro: Array<C, Ext<C::F, C::EF>> = builder.array(MAX_TWO_ADICITY + 1);
 
     iter_zip!(builder, proof.query_proofs).for_each(|ptr_vec, builder| {


### PR DESCRIPTION
All `alpha` power calculations in the reduced opening computation in 2-adic FRI verification only depend on the general shape of the proot input (number of matrices, matrix widths, number of out-of-domain points to open at). The key observation is that **none of this depends on the FRI query** so it should be precomputed and cached as part of the `RoundContext`.

Also, some alpha power calculations in the static verifier can be memoized even further, which is now done in a `static_alpha_pows` vector.

Reth comparison benchmark: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/13229825060

## Metrics
Reth root circuit main cells used: 
- before: 33,353,572
- after: 32,952,509 (-1.2%)

Reth halo2_outer main cells used: 
- before: 58,181,721
- after: 57,429,149 (-1.2%)
