### PR TITLE
chore: fix broken links and clean up READMEs  

### DIFF
--- a/crates/circuits/primitives/src/README.md
+++ b/crates/circuits/primitives/src/README.md
@@ -15,7 +15,7 @@ The following modules contain `SubAir`'s:
 - [bigint](./bigint/README.md)
 - [encoder](./encoder/mod.rs)
 - [is_equal](./is_equal/mod.rs)
-- [is_equal_array](./is_equal_array/moxd.rs)
+- [is_equal_array](./is_equal_array/mod.rs)
 - [is_less_than](./is_less_than/mod.rs)
 - [is_less_than_array](./is_less_than_array/mod.rs)
 - [is_zero](./is_zero/mod.rs)

--- a/extensions/ecc/sw-macros/README.md
+++ b/extensions/ecc/sw-macros/README.md
@@ -2,7 +2,7 @@
 
 Procedural macros for use in guest program to generate short Weierstrass elliptic curve struct with custom intrinsics for compile-time modulus.
 
-The workflow of this macro is very similar to the [`openvm-algebra-moduli-macros`](../moduli-macros/README.md) crate. We recommend reading it first.
+The workflow of this macro is very similar to the [`openvm-algebra-moduli-macros`](../../algebra/moduli-macros/README.md) crate. We recommend reading it first.
 
 ## Example
 
@@ -38,7 +38,7 @@ pub fn main() {
 
 ## Full story
 
-Again, the principle is the same as in the [`openvm-algebra-moduli-macros`](../moduli-macros/README.md) crate. Here we emphasize the core differences.
+Again, the principle is the same as in the [`openvm-algebra-moduli-macros`](../../algebra/moduli-macros/README.md) crate. Here we emphasize the core differences.
 
 The crate provides two macros: `sw_declare!` and `sw_init!`. The signatures are:
 


### PR DESCRIPTION
Hi! While working on the documentation, I noticed some broken links and typos in the `README.md` files. In this PR, I:  

1. **In `crates/circuits/primitives/src/README.md`:**  
   - Fixed a typo in the `is_equal_array` module path (changed `moxd.rs` to `mod.rs`). Looks like someone was typing too fast.

2. **In `extensions/ecc/sw-macros/README.md`:**  
   - Updated the relative paths to `openvm-algebra-moduli-macros` to point to the correct location (now pointing to `../../algebra/moduli-macros/README.md`).  

These changes are purely cosmetic, but they'll help avoid confusion for anyone new to the project. 