### PR TITLE
[chore] Fix openvm links for example guest programs

### DIFF
--- a/examples/algebra/Cargo.toml
+++ b/examples/algebra/Cargo.toml
@@ -7,12 +7,14 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-algebra-complex-macros = { git = "https://github.com/openvm-org/openvm.git" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-platform = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-algebra-complex-macros = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
 serde = { version = "1.0.216", default-features = false }
-num-bigint = { version = "0.4.6", default-features = false, features = ["serde"] }
+num-bigint = { version = "0.4.6", default-features = false, features = [
+    "serde",
+] }
 
 [features]
 default = []

--- a/examples/i256/Cargo.toml
+++ b/examples/i256/Cargo.toml
@@ -7,13 +7,10 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-bigint-guest = { git = "https://github.com/openvm-org/openvm.git" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-platform = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-bigint-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
 
 [features]
 default = []
-std = [
-    "openvm/std",
-    "openvm-bigint-guest/std",
-]
+std = ["openvm/std", "openvm-bigint-guest/std"]

--- a/examples/keccak/Cargo.toml
+++ b/examples/keccak/Cargo.toml
@@ -7,14 +7,11 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-keccak256-guest = { git = "https://github.com/openvm-org/openvm.git" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-platform = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-keccak256-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [features]
 default = []
-std = [
-    "openvm/std",
-    "openvm-keccak256-guest/std",
-]
+std = ["openvm/std", "openvm-keccak256-guest/std"]

--- a/examples/pairing/Cargo.toml
+++ b/examples/pairing/Cargo.toml
@@ -7,13 +7,15 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-algebra-moduli-macros = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-algebra-complex-macros = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", features = ["bls12_381"] }
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-platform = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-algebra-moduli-macros = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-algebra-complex-macros = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop", features = [
+    "bls12_381",
+] }
 hex-literal = { version = "0.4.1", default-features = false }
 
 [features]
@@ -24,4 +26,3 @@ std = [
     "openvm-ecc-guest/std",
     "openvm-pairing-guest/std",
 ]
-

--- a/examples/sha256/Cargo.toml
+++ b/examples/sha256/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-sha256-guest = { git = "https://github.com/openvm-org/openvm.git" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-platform = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-sha256-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [features]

--- a/examples/u256/Cargo.toml
+++ b/examples/u256/Cargo.toml
@@ -7,13 +7,10 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-platform = { git = "https://github.com/openvm-org/openvm.git" }
-openvm-bigint-guest = { git = "https://github.com/openvm-org/openvm.git" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-platform = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
+openvm-bigint-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop" }
 
 [features]
 default = []
-std = [
-    "openvm/std",
-    "openvm-bigint-guest/std",
-]
+std = ["openvm/std", "openvm-bigint-guest/std"]


### PR DESCRIPTION
- Change the OpenVM links in the example guest programs to the `develop` branch so that the lint check passes