### PR TITLE
chore: fix macro usage order to prevent potential compilation errors

### DIFF
--- a/examples/u256/src/main.rs
+++ b/examples/u256/src/main.rs
@@ -2,10 +2,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::needless_range_loop)]
 
-openvm::entry!(main);
 use core::array;
-
 use openvm_bigint_guest::U256;
+
+openvm::entry!(main);
 
 const N: usize = 16;
 type Matrix = [[U256; N]; N];


### PR DESCRIPTION
I noticed that `openvm::entry!(main);` was placed before the `use` statements. This could lead to compilation issues since the macro might reference types or functions that haven't been declared yet.

P.S. In Rust, `use` statements should always come before their usage. I've moved the macro after the imports to ensure proper compilation.  
