### PR TITLE
docs: fix broken link continuations.md

### DIFF
--- a/docs/specs/continuations.md
+++ b/docs/specs/continuations.md
@@ -203,7 +203,7 @@ memory argument.
 
 The overall runtime execution of a program is broken into **segments** (the logic of when to segment can be custom and
 depend on many factors). Each segment is proven in a separate STARK VM circuit as described
-in [STARK Architecture](./stark.md). The public values of the circuit must contain the pre- and post-state commitments
+in [Circuit Architecture](./circuit.md). The public values of the circuit must contain the pre- and post-state commitments
 to the segment. The state consists of the active program counter and the full state of memory. (Recall in our
 architecture that registers are part of memory, so register state is included in memory state).
 


### PR DESCRIPTION
Hi! This PR fixes a broken link in `continuations.md`, based on the changes from #1048.
![image](https://github.com/user-attachments/assets/f5e248cc-a212-4c07-886f-41a8367786c0)


The previous link was incorrect, and now it correctly points to `circuit.md`.