### PR TITLE
feat: Convert mdBook publish to workflow dispatch

### DIFF
--- a/.github/workflows/publish-mdbook.yml
+++ b/.github/workflows/publish-mdbook.yml
@@ -1,10 +1,13 @@
 name: Publish mdBook to Vercel
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - "book/**"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to deploy"
+        required: true
+        type: string
+        default: "main"
 
 permissions:
   contents: write
@@ -16,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
- Converts mdBook publish to a workflow_dispatch instead of `push`
- Run the workflow w/ the desired tag to publish the mdBook to prod