### PR TITLE
Grammar Fixes

### DIFF
--- a/book/src/custom-extensions/keccak.md
+++ b/book/src/custom-extensions/keccak.md
@@ -5,7 +5,7 @@ The functional part is provided by the `openvm-keccak-guest` crate, which is a g
 
 ## Functions for guest code
 
-The OpenVM Keccak256 Guest extension provides two functions for using in your guest code:
+The OpenVM Keccak256 Guest extension provides two functions for use in your guest code:
 
 - `keccak256(input: &[u8]) -> [u8; 32]`: Computes the Keccak-256 hash of the input data and returns it as an array of 32 bytes.
 - `set_keccak256(input: &[u8], output: &mut [u8; 32])`: Sets the output to the Keccak-256 hash of the input data into the provided output buffer.

--- a/book/src/custom-extensions/overview.md
+++ b/book/src/custom-extensions/overview.md
@@ -25,7 +25,7 @@ Our design for the configuration procedure above was inspired by the [EVMMAX pro
 
 ## Configuration
 
-To use these extensions, you must populate a `openvm.toml` in your package root directory (where the `Cargo.toml` file is located).
+To use these extensions, you must populate an `openvm.toml` in your package root directory (where the `Cargo.toml` file is located).
 We will explain in each extension how to configure the `openvm.toml` file.
 
 The template `openvm.toml` file is as follows:

--- a/book/src/custom-extensions/pairing.md
+++ b/book/src/custom-extensions/pairing.md
@@ -62,7 +62,7 @@ We also have access to each of the specific functions that the pairing check uti
 
 ### Multi-Miller loop
 
-The multi-Miller loop requires the MultiMillerLoop trait can also be ran separately via:
+The multi-Miller loop requires the MultiMillerLoop trait can also be run separately via:
 
 ```rust
 let f = Bls12_381::multi_miller_loop(


### PR DESCRIPTION
keccak.md

"for using in" → "for use in" (grammatical correction).

overview.m

"a openvm.toml" → "an openvm.toml" (article correction).

pairing.md

"be ran" → "be run" (correct verb tense).