### PR TITLE
fix: typos

### DIFF
--- a/crates/circuits/sha256-air/src/air.rs
+++ b/crates/circuits/sha256-air/src/air.rs
@@ -314,7 +314,7 @@ impl Sha256Air {
         &self,
         builder: &mut AB,
         local: &Sha256DigestCols<AB::Var>,
-        is_lastest_block: AB::Expr,
+        is_latest_block: AB::Expr,
     ) {
         // Constrain that next block's `prev_hash` is equal to the current block's `hash`
         let composed_hash: [[<AB as AirBuilder>::Expr; SHA256_WORD_U16S]; SHA256_HASH_WORDS] =
@@ -328,7 +328,7 @@ impl Sha256Air {
             });
         // Need to handle the case if this is the very last block of the trace matrix
         let next_global_block_idx = select(
-            is_lastest_block,
+            is_latest_block,
             AB::Expr::ONE,
             local.flags.global_block_idx + AB::Expr::ONE,
         );

--- a/extensions/sha256/circuit/src/sha256_chip/air.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/air.rs
@@ -134,25 +134,25 @@ impl Sha256VmAir {
         local: &Sha256VmRoundCols<AB::Var>,
         next: &Sha256VmRoundCols<AB::Var>,
     ) {
-        let next_is_lastest_row = next.inner.flags.is_digest_row * next.inner.flags.is_last_block;
+        let next_is_latest_row = next.inner.flags.is_digest_row * next.inner.flags.is_last_block;
 
-        // Constrain `padding_occured`
+        // Constrain `padding_occurred`
         builder.assert_bool(local.control.padding_occurred);
         builder
-            .when(next_is_lastest_row.clone())
+            .when(next_is_latest_row.clone())
             .assert_one(local.control.padding_occurred);
 
         builder
-            .when(next_is_lastest_row.clone())
+            .when(next_is_latest_row.clone())
             .assert_zero(next.control.padding_occurred);
 
         builder
-            .when(local.control.padding_occurred - next_is_lastest_row.clone())
+            .when(local.control.padding_occurred - next_is_latest_row.clone())
             .assert_one(next.control.padding_occurred);
 
         builder
             .when_transition()
-            .when(not(next.inner.flags.is_first_4_rows) - next_is_lastest_row)
+            .when(not(next.inner.flags.is_first_4_rows) - next_is_latest_row)
             .assert_eq(
                 next.control.padding_occurred,
                 local.control.padding_occurred,


### PR DESCRIPTION
Corrects the misspelling of "lastest" to "latest" in variable names and function parameters across SHA256-related files:
- extensions/sha256/circuit/src/sha256_chip/air.rs
- crates/circuits/sha256-air/src/air.rs