### PR TITLE
[feat] Add constructors for ECDSA verifying key on `main`

### DIFF
--- a/extensions/ecc/guest/src/ecdsa.rs
+++ b/extensions/ecc/guest/src/ecdsa.rs
@@ -1,7 +1,8 @@
+use alloc::vec::Vec;
 use core::ops::{Add, AddAssign, Mul};
 
 use ecdsa::{self, hazmat::bits2field, Error, RecoveryId, Result};
-use elliptic_curve::PrimeCurve;
+use elliptic_curve::{sec1::Tag, PrimeCurve};
 use openvm_algebra_guest::{DivUnsafe, IntMod, Reduce};
 
 use crate::{
@@ -25,15 +26,112 @@ pub struct PublicKey<C: IntrinsicCurve> {
     point: <C as IntrinsicCurve>::Point,
 }
 
-impl<C: IntrinsicCurve> PublicKey<C> {
-    pub fn into_inner(self) -> <C as IntrinsicCurve>::Point {
-        self.point
+impl<C: IntrinsicCurve> PublicKey<C>
+where
+    C::Point: WeierstrassPoint + Group + FromCompressed<Coordinate<C>>,
+    Coordinate<C>: IntMod,
+    for<'a> &'a Coordinate<C>: Mul<&'a Coordinate<C>, Output = Coordinate<C>>,
+{
+    pub fn new(point: <C as IntrinsicCurve>::Point) -> Self {
+        Self { point }
+    }
+
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.is_empty() {
+            return Err(Error::new());
+        }
+
+        // Validate tag
+        let tag = Tag::from_u8(bytes[0]).unwrap();
+
+        // Validate length
+        let expected_len = tag.message_len(Coordinate::<C>::NUM_LIMBS);
+        if bytes.len() != expected_len {
+            return Err(Error::new());
+        }
+
+        match tag {
+            Tag::Identity => {
+                let point = <<C as IntrinsicCurve>::Point as WeierstrassPoint>::IDENTITY;
+                Ok(Self { point })
+            }
+
+            Tag::CompressedEvenY | Tag::CompressedOddY => {
+                let x = Coordinate::<C>::from_be_bytes(&bytes[1..]);
+                let rec_id = bytes[0] & 1;
+                let point = FromCompressed::decompress(x, &rec_id);
+                Ok(Self { point })
+            }
+
+            Tag::Uncompressed => {
+                let (x_bytes, y_bytes) = bytes[1..].split_at(Coordinate::<C>::NUM_LIMBS);
+                let x = Coordinate::<C>::from_be_bytes(x_bytes);
+                let y = Coordinate::<C>::from_be_bytes(y_bytes);
+                let point = <C as IntrinsicCurve>::Point::from_xy(x, y).unwrap();
+                Ok(Self { point })
+            }
+
+            _ => Err(Error::new()),
+        }
+    }
+
+    pub fn to_sec1_bytes(&self, compress: bool) -> Vec<u8> {
+        if self.point.is_identity() {
+            return vec![0x00];
+        }
+
+        let (x, y) = self.point.clone().into_coords();
+
+        if compress {
+            let mut bytes = Vec::<u8>::with_capacity(1 + Coordinate::<C>::NUM_LIMBS);
+            let tag = if y.as_le_bytes()[0] & 1 == 1 {
+                Tag::CompressedOddY
+            } else {
+                Tag::CompressedEvenY
+            };
+            bytes.push(tag.into());
+            bytes.extend_from_slice(x.to_be_bytes().as_ref());
+            bytes
+        } else {
+            let mut bytes = Vec::<u8>::with_capacity(1 + Coordinate::<C>::NUM_LIMBS * 2);
+            bytes.push(Tag::Uncompressed.into());
+            bytes.extend_from_slice(x.to_be_bytes().as_ref());
+            bytes.extend_from_slice(y.to_be_bytes().as_ref());
+            bytes
+        }
+    }
+
+    pub fn as_affine(&self) -> &<C as IntrinsicCurve>::Point {
+        &self.point
     }
 }
 
-impl<C: IntrinsicCurve> VerifyingKey<C> {
+impl<C: IntrinsicCurve> VerifyingKey<C>
+where
+    C::Point: WeierstrassPoint + Group + FromCompressed<Coordinate<C>>,
+    Coordinate<C>: IntMod,
+    for<'a> &'a Coordinate<C>: Mul<&'a Coordinate<C>, Output = Coordinate<C>>,
+{
+    pub fn new(public_key: PublicKey<C>) -> Self {
+        Self { inner: public_key }
+    }
+
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self> {
+        let public_key = PublicKey::<C>::from_sec1_bytes(bytes)?;
+        Ok(Self::new(public_key))
+    }
+
+    pub fn from_affine(point: <C as IntrinsicCurve>::Point) -> Result<Self> {
+        let public_key = PublicKey::<C>::new(point);
+        Ok(Self::new(public_key))
+    }
+
+    pub fn to_sec1_bytes(&self, compress: bool) -> Vec<u8> {
+        self.inner.to_sec1_bytes(compress)
+    }
+
     pub fn as_affine(&self) -> &<C as IntrinsicCurve>::Point {
-        &self.inner.point
+        self.inner.as_affine()
     }
 }
 

--- a/extensions/ecc/tests/programs/examples/ecdsa.rs
+++ b/extensions/ecc/tests/programs/examples/ecdsa.rs
@@ -45,14 +45,34 @@ pub fn main() {
         "0200866db99873b09fc2fb1e3ba549b156e96d1a567e3284f5f0e859a83320cb8b"
     ))
     .unwrap();
-    // sec1 encoding, the first byte is for compression flag
-    let expected_key = expected_key.to_encoded_point(false);
-    let public_key = recovered_key.as_affine();
-    let mut buffer = [0u8; 64];
-    buffer[..32].copy_from_slice(&public_key.x().to_be_bytes());
-    buffer[32..].copy_from_slice(&public_key.y().to_be_bytes());
-    assert_eq!(&buffer, &expected_key.as_bytes()[1..]);
 
+    // Test sec1 encoding and decoding
+    let expected_key_uncompressed = expected_key.to_encoded_point(false);
+    let public_key_uncompressed = recovered_key.to_sec1_bytes(false);
+    assert_eq!(
+        &public_key_uncompressed,
+        &expected_key_uncompressed.as_bytes()
+    );
+
+    let expected_key_compressed = expected_key.to_encoded_point(true);
+    let public_key_compressed = recovered_key.to_sec1_bytes(true);
+    assert_eq!(&public_key_compressed, &expected_key_compressed.as_bytes());
+
+    let public_key_uncompressed_decoded =
+        VerifyingKey::<Secp256k1>::from_sec1_bytes(&public_key_uncompressed).unwrap();
+    let public_key_compressed_decoded =
+        VerifyingKey::<Secp256k1>::from_sec1_bytes(&public_key_compressed).unwrap();
+
+    assert_eq!(
+        public_key_uncompressed_decoded.as_affine(),
+        recovered_key.as_affine()
+    );
+    assert_eq!(
+        public_key_compressed_decoded.as_affine(),
+        recovered_key.as_affine()
+    );
+
+    // Test verification
     recovered_key
         .verify_prehashed(&prehash, &signature)
         .unwrap();


### PR DESCRIPTION
Add constructors for ECDSA verifying key on `main` (mirror commit of https://github.com/openvm-org/openvm/pull/1348).