### PR TITLE
fix(bench): fix the issue segment cycle counters being [0,0,0,..,$value]

### DIFF
--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -1034,7 +1034,7 @@ impl<F: PrimeField32, E, P> VmChipComplex<F, E, P> {
     }
 
     #[cfg(feature = "bench-metrics")]
-    fn finalize_metrics(&self, metrics: &mut VmMetrics)
+    pub fn finalize_metrics(&self, metrics: &mut VmMetrics)
     where
         E: ChipUsageGetter,
         P: ChipUsageGetter,

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -126,7 +126,7 @@ where
     pub(crate) air_names: Vec<String>,
     /// Metrics collected for this execution segment alone.
     #[cfg(feature = "bench-metrics")]
-    pub(crate) metrics: VmMetrics,
+    pub metrics: VmMetrics,
 }
 
 pub struct ExecutionSegmentState {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -187,7 +187,6 @@ where
         #[cfg(feature = "bench-metrics")]
         {
             segment.metrics = from_state.metrics;
-            segment.metrics.clear();
         }
         if let Some(overridden_heights) = self.overridden_heights.as_ref() {
             segment.set_override_trace_heights(overridden_heights.clone());
@@ -215,7 +214,7 @@ where
             .expect("final memory should be set in continuations segment");
         let streams = segment.chip_complex.take_streams();
         #[cfg(feature = "bench-metrics")]
-        let metrics = mem::take(&mut segment.metrics);
+        let metrics = VmMetrics::new_from(&mut segment.metrics);
         Ok(VmExecutorOneSegmentResult {
             segment,
             next_state: Some(VmExecutorNextSegmentState {

--- a/crates/vm/src/metrics/mod.rs
+++ b/crates/vm/src/metrics/mod.rs
@@ -86,14 +86,14 @@ impl VmMetrics {
         self.current_trace_cells = now_trace_cells;
     }
 
-    /// Clear statistics that are local to a segment
+    /// Build a new metrics object from an existing one.
     // Important: chip and cycle count metrics should start over for SegmentationStrategy,
     // but we need to carry over the cycle tracker so spans can cross segments
-    pub(super) fn clear(&mut self) {
-        *self = Self {
-            cycle_tracker: mem::take(&mut self.cycle_tracker),
-            fn_bounds: mem::take(&mut self.fn_bounds),
-            current_fn: mem::take(&mut self.current_fn),
+    pub fn new_from(other: &mut Self) -> Self {
+        Self {
+            cycle_tracker: mem::take(&mut other.cycle_tracker),
+            fn_bounds: mem::take(&mut other.fn_bounds),
+            current_fn: mem::take(&mut other.current_fn),
             ..Default::default()
         }
     }


### PR DESCRIPTION
current codes will emit cycle counter metrics as `[0,0,0,0, ..., $count_of_last_segment]`.

The reason is when `finalize_metric` is called, the metric inside a segment has already be move out (to the new segment, and then the cycle_counter is cleared before new segment execution).

This PR will keep local metrics inside local segment to fix the issue.

I also want to make `finalize_metrics` public.  This can help with outside metric recorder. 

a further question is, what about make segment.metrics public? then caller can access metric directly without need of MetricRecorder? 