### PR TITLE
fix(metrics): cycle count emission across segments

### DIFF
--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -126,7 +126,7 @@ where
     pub(crate) air_names: Vec<String>,
     /// Metrics collected for this execution segment alone.
     #[cfg(feature = "bench-metrics")]
-    pub(crate) metrics: VmMetrics,
+    pub metrics: VmMetrics,
 }
 
 pub struct ExecutionSegmentState {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -187,7 +187,6 @@ where
         #[cfg(feature = "bench-metrics")]
         {
             segment.metrics = from_state.metrics;
-            segment.metrics.clear();
         }
         if let Some(overridden_heights) = self.overridden_heights.as_ref() {
             segment.set_override_trace_heights(overridden_heights.clone());

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -215,7 +215,7 @@ where
             .expect("final memory should be set in continuations segment");
         let streams = segment.chip_complex.take_streams();
         #[cfg(feature = "bench-metrics")]
-        let metrics = mem::take(&mut segment.metrics);
+        let metrics = segment.metrics.partial_take();
         Ok(VmExecutorOneSegmentResult {
             segment,
             next_state: Some(VmExecutorNextSegmentState {

--- a/crates/vm/src/metrics/mod.rs
+++ b/crates/vm/src/metrics/mod.rs
@@ -88,7 +88,7 @@ impl VmMetrics {
 
     /// Take the cycle tracker and fn bounds information for use in
     /// next segment. Leave the rest of the metrics for recording purposes.
-    pub(super) fn partial_take(&mut self) -> Self {
+    pub fn partial_take(&mut self) -> Self {
         Self {
             cycle_tracker: mem::take(&mut self.cycle_tracker),
             fn_bounds: mem::take(&mut self.fn_bounds),
@@ -100,7 +100,7 @@ impl VmMetrics {
     /// Clear statistics that are local to a segment
     // Important: chip and cycle count metrics should start over for SegmentationStrategy,
     // but we need to carry over the cycle tracker so spans can cross segments
-    pub(super) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         *self = self.partial_take();
     }
 

--- a/crates/vm/src/metrics/mod.rs
+++ b/crates/vm/src/metrics/mod.rs
@@ -86,16 +86,22 @@ impl VmMetrics {
         self.current_trace_cells = now_trace_cells;
     }
 
-    /// Clear statistics that are local to a segment
-    // Important: chip and cycle count metrics should start over for SegmentationStrategy,
-    // but we need to carry over the cycle tracker so spans can cross segments
-    pub(super) fn clear(&mut self) {
-        *self = Self {
+    /// Take the cycle tracker and fn bounds information for use in
+    /// next segment. Leave the rest of the metrics for recording purposes.
+    pub(super) fn partial_take(&mut self) -> Self {
+        Self {
             cycle_tracker: mem::take(&mut self.cycle_tracker),
             fn_bounds: mem::take(&mut self.fn_bounds),
             current_fn: mem::take(&mut self.current_fn),
             ..Default::default()
         }
+    }
+
+    /// Clear statistics that are local to a segment
+    // Important: chip and cycle count metrics should start over for SegmentationStrategy,
+    // but we need to carry over the cycle tracker so spans can cross segments
+    pub(super) fn clear(&mut self) {
+        *self = self.partial_take();
     }
 
     #[cfg(feature = "function-span")]


### PR DESCRIPTION
Previously when proving with multiple segments, we execute all segments, but we take the `metrics` from each `segment` before trace generation. When we do trace generation, we finalize memory and then finalize metrics and emit, but at this point the metrics in `segment` are partially empty. This led to the cycle count emission to always be those of the last segment.

The `take` from `metrics` was only needed to get the cycle tracker and function symbol information, so now we do a `partial_take` to avoid cloning.

Old reth benchmark: https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/main/reth-bb4d597ec9b5edfc486d022fa2ae29202f7e6281-e2fa8f8fba28e8315642c3ddeb11fcd29a7e53d06ecdeba44aae28ee1aef837e.md
New reth benchmark: https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/main/reth-bb4d597ec9b5edfc486d022fa2ae29202f7e6281-e2fa8f8fba28e8315642c3ddeb11fcd29a7e53d06ecdeba44aae28ee1aef837e.md

closes INT-3496