### PR TITLE
Bugfix cli bench profile option

### DIFF
--- a/crates/cli/src/commands/bench.rs
+++ b/crates/cli/src/commands/bench.rs
@@ -46,8 +46,12 @@ impl BenchCmd {
             setup_tracing();
         }
 
-        let elf_path = build(&self.build_args)?.unwrap();
-        let (exe, _vm_config) = execute(elf_path, &self.build_args.config, &self.input).unwrap();
+        let _elf_path = build(&self.build_args)?.unwrap();
+        let (exe, _vm_config) = execute(
+            self.build_args.exe_output.clone(),
+            &self.build_args.config,
+            &self.input,
+        )?;
 
         let app_log_blowup = 2;
         let engine = BabyBearPoseidon2Engine::new(

--- a/crates/cli/src/commands/bench.rs
+++ b/crates/cli/src/commands/bench.rs
@@ -28,8 +28,8 @@ pub struct BenchCmd {
     #[clap(long, action)]
     output: Option<PathBuf>,
 
-    #[clap(long, action)]
-    profile: bool,
+    #[clap(long, action, default_value = "false", help = "enable tracing")]
+    tracing: bool,
 
     #[clap(long, action)]
     verbose: bool,
@@ -40,7 +40,7 @@ pub struct BenchCmd {
 
 impl BenchCmd {
     pub fn run(&self) -> Result<()> {
-        if self.profile {
+        if self.tracing {
             setup_tracing();
         }
         let elf_path = build(&self.build_args)?.unwrap();

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -17,7 +17,7 @@ use crate::{
 #[command(name = "build", about = "Compile an OpenVM program")]
 pub struct BuildCmd {
     #[clap(flatten)]
-    pub(crate) build_args: BuildArgs,
+    build_args: BuildArgs,
 }
 
 impl BuildCmd {

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -17,7 +17,7 @@ use crate::{
 #[command(name = "build", about = "Compile an OpenVM program")]
 pub struct BuildCmd {
     #[clap(flatten)]
-    build_args: BuildArgs,
+    pub(crate) build_args: BuildArgs,
 }
 
 impl BuildCmd {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -61,10 +61,6 @@ pub(crate) fn write_status(style: &dyn Display, status: &str, msg: &str) {
     println!("{style}{status:>12}{style:#} {msg}");
 }
 
-pub(crate) fn classical_exe_path(elf_path: &Path) -> PathBuf {
-    elf_path.with_extension("vmexe")
-}
-
 pub(crate) fn read_to_struct_toml<T: DeserializeOwned>(path: &PathBuf) -> Result<T> {
     let toml = read_to_string(path.as_ref() as &Path)?;
     let ret = toml::from_str(&toml)?;


### PR DESCRIPTION
This PR fixes the broken cli command `bench`.

1. It renames the argument which enables tracing to `tracing`. The previous name was collisioning with another argument by the name of `profile` in charge of setting the compiler profile. See more details in #1386.
2. After the rename the command was still not working. This is because, the command was calling some functions which are not currently used in the comands `build` and `run`. I rewrite that part so that `bench` reuses the code from `build` and `run` to avoid the splitting of functionality. **The command does should now work again.** Howerver, I would suggest to apply further this approach, so that bench reuses as much funcitonality from the other commands (such as keygen, prove and verify). 