### PR TITLE
feat: memory-efficient `ContinuationProver`

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -32,7 +32,9 @@ jobs:
     steps:
       - uses: runs-on/action@v1
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-10-30
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -118,6 +118,7 @@ where
     VC: VmConfig<F>,
 {
     pub chip_complex: VmChipComplex<F, VC::Executor, VC::Periphery>,
+    /// Memory image after segment was executed. Not used in trace generation.
     pub final_memory: Option<MemoryImage<F>>,
 
     pub since_last_segment_check: usize,


### PR DESCRIPTION
We modify the `execute_segments` function to `execute_and_then` so that it takes an arbitrary closure that can directly operate on the segment execution result. This way in the `ContinuationProver` implementation of `VmLocalProver` where execution segments are proven serially, we do not need to keep all segment's results (and traces) in memory before starting proving of a single segment.