### PR TITLE
chore: fix matrix multiplication by using values

### DIFF
--- a/examples/i256/src/main.rs
+++ b/examples/i256/src/main.rs
@@ -19,7 +19,7 @@ pub fn mult(a: &Matrix, b: &Matrix) -> Matrix {
     for i in 0..N {
         for j in 0..N {
             for k in 0..N {
-                c[i][j] += &a[i][k] * &b[k][j];
+                c[i][j] += a[i][k] * b[k][j];
             }
         }
     }


### PR DESCRIPTION
I changed the matrix multiplication to use values directly instead of references.
This fixes errors with the arithmetic operations and ensures the code works properly.