### PR TITLE
fix: Add constraint to SHA extension that checks if the appended length is a multiple of 8

### DIFF
--- a/extensions/sha256/circuit/src/sha256_chip/air.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/air.rs
@@ -362,7 +362,9 @@ impl Sha256VmAir {
 
         // We constrain that the appended length is in bytes
         builder.when(is_last_padding_row.clone()).assert_zero(
-            local.inner.message_schedule.w[3][0] + local.inner.message_schedule.w[3][1],
+            local.inner.message_schedule.w[3][0]
+                + local.inner.message_schedule.w[3][1]
+                + local.inner.message_schedule.w[3][2],
         );
 
         // We can't support messages longer than 2^30 bytes


### PR DESCRIPTION
We have a bug where the message length (in bits) that is appended to the message as part of the SHA-256 padding algorithm is not constrained to be a multiple of 8 (and hence being a length in bytes) but rather to be a multiple of 4 [here](https://github.com/openvm-org/openvm/blob/550feca5cc7bf022c5b41e9d39fe39fa7a2da84f/extensions/sha256/circuit/src/sha256_chip/air.rs#L363C1-L367C1). But we assume that it is a multiple of 8 in another constraint [here](https://github.com/openvm-org/openvm/blob/550feca5cc7bf022c5b41e9d39fe39fa7a2da84f/extensions/sha256/circuit/src/sha256_chip/air.rs#L358C1-L362C1).

The fix is to correctly constrain that the appended length is a multiple of 8. Since the length is stored in little endian, we check that it's first three bits are zero.