### PR TITLE
fix: Poseidon2 verify_batch `start_top_level` is not constrained only at start

### DIFF
--- a/extensions/native/circuit/src/poseidon2/air.rs
+++ b/extensions/native/circuit/src/poseidon2/air.rs
@@ -417,7 +417,6 @@ impl<AB: InteractionBuilder, const SBOX_REGISTERS: usize> Air<AB>
 
         let mut when_top_level_not_end =
             builder.when(incorporate_row + incorporate_sibling - end_top_level);
-        when_top_level_not_end.assert_zero(next.start_top_level);
         when_top_level_not_end
             .assert_eq(next_top_level_specific.dim_base_pointer, dim_base_pointer);
 

--- a/extensions/native/circuit/src/poseidon2/air.rs
+++ b/extensions/native/circuit/src/poseidon2/air.rs
@@ -114,15 +114,7 @@ impl<AB: InteractionBuilder, const SBOX_REGISTERS: usize> Air<AB>
         builder
             .when(end.clone())
             .assert_zero(next.incorporate_sibling);
-        builder
-            .when(end.clone())
-            .when(next.incorporate_row)
-            .assert_one(next.start_top_level);
-        // start_top_level is not used and does not affect anything on non-top level rows, but
-        // we constrain it to zero for clarity
-        builder
-            .when(not::<AB::Expr>(incorporate_row + incorporate_sibling))
-            .assert_zero(start_top_level);
+        builder.assert_eq(end.clone() * next.incorporate_row, next.start_top_level);
 
         // ensure that inside row rows are actually contiguous
         builder

--- a/extensions/native/circuit/src/poseidon2/air.rs
+++ b/extensions/native/circuit/src/poseidon2/air.rs
@@ -420,7 +420,7 @@ impl<AB: InteractionBuilder, const SBOX_REGISTERS: usize> Air<AB>
 
         let mut when_top_level_not_end =
             builder.when(incorporate_row + incorporate_sibling - end_top_level);
-
+        when_top_level_not_end.assert_zero(next.start_top_level);
         when_top_level_not_end
             .assert_eq(next_top_level_specific.dim_base_pointer, dim_base_pointer);
 

--- a/extensions/native/circuit/src/poseidon2/air.rs
+++ b/extensions/native/circuit/src/poseidon2/air.rs
@@ -118,6 +118,11 @@ impl<AB: InteractionBuilder, const SBOX_REGISTERS: usize> Air<AB>
             .when(end.clone())
             .when(next.incorporate_row)
             .assert_one(next.start_top_level);
+        // start_top_level is not used and does not affect anything on non-top level rows, but
+        // we constrain it to zero for clarity
+        builder
+            .when(not::<AB::Expr>(incorporate_row + incorporate_sibling))
+            .assert_zero(start_top_level);
 
         // ensure that inside row rows are actually contiguous
         builder


### PR DESCRIPTION
**Finding Link:** https://cantina.xyz/code/c486d600-bed0-4fc6-aed1-de759fd29fa2/findings/167

### Description of Fix

While the variable was called `start_top_level`, we only constrained that the top level has `start_top_level = 1` but never that it must be equal to `0` on non-top levels. We change the existing constraint so that it enforces `start_top_level = 1` iff its the start of a top level (meaning previous row is `end` and current row is `incorporate_row`).

Closes INT-3567