### PR TITLE
[docs] RV32IM Extension specs

### DIFF
--- a/extensions/rv32im/circuit/src/README.md
+++ b/extensions/rv32im/circuit/src/README.md
@@ -18,63 +18,99 @@ Details about the constraints and assumptions for each statement are available i
 
 #### 1. [ALU adapter](./adapters/alu.rs)
 
-Given `rs1`, `rs2`, and `rd` pointers, and a boolean indicating if `rs2` is an immediate value,
-this circuit proves the following:
+Given
+
+- `rs1`, `rs2`, and `rd` are register addresses
+- `rs2_as` is a boolean indicating if `rs2` is an immediate value
+- `from_pc` is the current program address
+
+This circuit proves the following:
 
 - A memory read from register `rs1` is performed
-- If `rs2` is not an immediate value, a memory read from register `rs2` is performed
+- If `rs2_as` is false, a memory read from register `rs2` is performed
 - A memory write to register `rd` is performed with the result of the operation
-- The instruction is executed successfully by the VM and the program counter is incremented by 4
+- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
 
 #### 2. [Branch adapter](./adapters/branch.rs)
 
-Given `rs1`, `rs2`, and the destination pointer `to_pc`, this circuit proves the following:
+Given
+
+- `rs1`, `rs2`, and `rd` are register addresses
+- `from_pc` is the current program address
+- `to_pc` is the destination program address
+
+This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from register `rs2` is performed
-- The instruction is executed successfully by the VM and the program counter is set to `to_pc`
+- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `to_pc`.
 
 #### 3. [JALR adapter](./adapters/jalr.rs)
 
-Given `rd`, `rs1`, the destination pointer `to_pc`, and a flag indicating if `rd` is `x0`, this circuit proves the following:
+Given
+
+- `rd`, `rs1` are register addresses
+- `from_pc` is the current program address
+- `to_pc` is the destination program address
+
+This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory write to register `rd` is performed if `rd` is not `x0`
-- The instruction is executed successfully by the VM and the program counter is set to `to_pc`
+- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `to_pc`
 
 #### 4. [Load/store adapter](./adapters/loadstore.rs)
 
-Given `rd`, `rs1`, immediate value `imm`, address space `mem_as`, and a flag indicating if the instruction is a load or store, this circuit proves the following:
+Given
 
-If the instruction is a load:
+- `rd`, `rs1` are register addresses
+- `imm` is the immediate value
+- `mem_as` is an address space
+- `is_load` is a boolean indicating if the instruction is a load
+- `from_pc` is the current program address
 
-- A memory read from register `rs1` is performed
-- A memory read from `mem_as` is performed at `rs1 + imm`
-- A memory write to register `rd` is performed if `rd` is not `x0`
-- The instruction is executed successfully by the VM and the program counter is incremented by 4
+This circuit proves the following:
 
-If the instruction is a store:
+- If `is_load` is true:
+  - `mem_as` is in `{0, 1, 2}`
+  - A memory read from register `rs1` is performed
+  - A memory read from `mem_as` is performed at `val(rs1) + imm` where `val(rs1)` is the value read from register `rs1`
+  - A memory write to register `rd` is performed if `rd` is not `x0`
+  - The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
 
-- A memory read from register `rs1` is performed
-- A memory read from register `rd` is performed
-- A memory write to `mem_as` is performed at `rs1 + imm`
-- The instruction is executed successfully by the VM and the program counter is incremented by 4
+- Otherwise:
+  - `mem_as` is in `{2, 3, 4}`
+  - A memory read from register `rs1` is performed
+  - A memory read from register `rd` is performed
+  - A memory write to `mem_as` is performed at `val(rs1) + imm` where `val(rs1)` is the value read from register `rs1`
+  - The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
 
 #### 5. [Multiplication adapter](./adapters/mul.rs)
 
-Given `rd`, `rs1`, `rs2`,this circuit proves the following:
+Given
+
+- `rd`, `rs1`, `rs2` are register addresses
+- `from_pc` is the current program address
+
+This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from register `rs2` is performed
 - A memory write to register `rd` is performed with the result of the multiplication
-- The instruction is executed successfully by the VM and the program counter is incremented by 4
+- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
 
 #### 6. [Rdwrite adapter](./adapters/rdwrite.rs)
 
-Given `rd`, the destination pointer `to_pc`, and a flag indicating if `rd` is `x0`, this circuit proves the following:
+Given
+
+- `rd` is a register address
+- `from_pc` is the current program address
+- `to_pc` is the destination program address
+
+This circuit proves the following:
 
 - A memory write to register `rd` is performed if `rd` is not `x0`
-- The instruction is executed successfully by the VM and the program counter is set to `to_pc`
+- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `to_pc`
 
 ### Core
 
@@ -84,7 +120,7 @@ Given `rd`, the destination pointer `to_pc`, and a flag indicating if `rd` is `x
 
 Given:
 
-- `b`, `c` are decompositions of the operands
+- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the result
 - `opcode` indicating the operation to be performed
 
@@ -97,10 +133,10 @@ This circuit proves that:
 
 Given:
 
-- `a`, `b` are decompositions of the operands
-- `opcode_beq_flag` and `opcode_bne_flag` indicating if the instruction is a branch equal or branch not equal
+- `a`, `b` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `opcode_beq_flag` and `opcode_bne_flag` indicating if the instruction is `beq` or `bne`
 - `imm` is the immediate value
-- `to_pc` is the destination pointer
+- `to_pc` is the destination program address
 
 This circuit proves that:
 
@@ -111,10 +147,10 @@ This circuit proves that:
 
 Given:
 
-- `a`, `b` are decompositions of the operands
+- `a`, `b` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
 - Flags indicating if the instruction is one of `blt`, `bltu`, `bge`, `bgeu`
 - `imm` is the immediate value
-- `to_pc` is the destination pointer
+- `to_pc` is the destination program address
 
 This circuit proves that:
 
@@ -127,7 +163,7 @@ This circuit proves that:
 
 Given:
 
-- `b`, `c` are decompositions of the operands
+- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
 - `q` is the quotient
 - `r` is the remainder
 - `a` is the decomposition of the result
@@ -146,35 +182,39 @@ This circuit proves that:
 
 Given:
 
-- `rd` is the decomposition of the operand
+- `rd` is the decomposition of the result
 - `imm` is the immediate value
-- `to_pc` is the destination pointer
+- `to_pc` is the destination program address
 - `opcode` indicating the operation to be performed
 
 This circuit proves that:
 
-- If `opcode` is `jal`, then `to_pc == pc + imm` and `decompose(rd) == pc + 4`
-- If `opcode` is `lui`, then `to_pc == pc + 4` and `decompose(rd) == imm * 2^8`
+- `rd` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- If `opcode` is `jal`, then `to_pc == pc + imm` and `compose(rd) == pc + 4`
+- If `opcode` is `lui`, then `to_pc == pc + 4` and `compose(rd) == imm * 2^8`
 
 #### 6. [JALR](./jalr/core.rs)
 
 Given:
 
-- `rd`, `rs1` are decompositions of the operands
+- `rs1` are decompositions of the operands and its limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `rd` is the decomposition of the result
 - `imm` is the immediate value
-- `to_pc_limbs` are the decomposition of the destination pointer
+- `to_pc_limbs` are the decomposition of the destination program address
+- `from_pc` is the current program address
 
 This circuit proves that:
 
+- `rd` limbs are in range `[0, 2^RV32_CELL_BITS)`
 - `compose(to_pc_limbs) == compose(rs1) + imm`
-- `compose(rd) == pc + 4`
+- `compose(rd) == from_pc + 4`
 - `to_pc_limbs` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 7. [AUIPC](./auipc/core.rs)
 
 Given:
 
-- `rd` is the decomposition of the operands
+- `rd` is the decomposition of the result
 - `imm_limbs` are the decomposition of the immediate value
 - `pc_limbs` are the decomposition of the program counter
 
@@ -188,7 +228,7 @@ This circuit proves that:
 
 Given:
 
-- `b`, `c` are decompositions of the operands
+- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
 - `a` is the result
 - `opcode` indicating the operation to be performed
 
@@ -202,8 +242,8 @@ This circuit proves that:
 
 Given:
 
-- `read_data` is the data read from `aligned(mem_as[rs1 + imm])` if the instruction is load, otherwise it is the data read from `rd`
-- `write_data` is the data to be written to `rd` if the instruction is load, otherwise it is the data to be written to `mem_as[rs1 + imm]`
+- `read_data` is the data read from `aligned(mem_as[val(rs1) + imm])` if the instruction is load, otherwise it is the data read from `rd`
+- `write_data` is the data to be written to `rd` if the instruction is load, otherwise it is the data to be written to `mem_as[val(rs1) + imm]`
 - Flags indicating which instruction is being executed
 
 This circuit proves that `write_data == shift(read_data)` with shift amount adjusted for the instruction.
@@ -212,33 +252,33 @@ This circuit proves that `write_data == shift(read_data)` with shift amount adju
 
 Given:
 
-- `b`, `c` are decompositions of the operands
+- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the lower 32 bits of the result
 - `opcode` indicating the operation to be performed
 
 This circuit proves that:
 
-- `compose(a) == compose(b) * compose(c) % 2^32`
+- `compose(a) == (compose(b) * compose(c)) % 2^32`
 - `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 11. [MULH](./mulh/core.rs)
 
 Given:
 
-- `b`, `c` are decompositions of the operands
+- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the upper 32 bits of the result
 - `opcode` indicating the operation to be performed
 
 This circuit proves that:
 
-- `compose(a) == compose(b) * compose(c) / 2^32`
+- `compose(a) == floor(compose(b) * compose(c) / 2^32)`
 - `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 12. [Shift](./shift/core.rs)
 
 Given:
 
-- `b`, `c` are decompositions of the operands
+- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the result
 - `opcode` indicating the operation to be performed
 

--- a/extensions/rv32im/circuit/src/README.md
+++ b/extensions/rv32im/circuit/src/README.md
@@ -1,0 +1,77 @@
+# RV32IM Extension Circuit
+
+This directory contains the circuit implementation of the RV32IM extension.
+
+## Design
+
+The RV32IM chips consist of a series of an adapter chip and a core chip.
+
+- The adapter chip is responsible for adapting the input and output of the core chip to the format expected by the VM, and handling any interactions with the VM.
+- The core chip is responsible for implementing the logic of the RISC-V instructions.
+
+## Circuit statements
+
+This section describes the statements that each circuit is responsible for proving.
+Details about the constraints and assumptions for each statement are available in the implementation of the circuit.
+
+### Adapter
+
+#### 1. [ALU adapter](./adapters/alu.rs)
+
+Given `rs1`, `rs2`, and `rd` pointers, and a boolean indicating if `rs2` is an immediate value,
+this circuit proves the following:
+
+- A memory read from register `rs1` is performed
+- If `rs2` is not an immediate value, a memory read from register `rs2` is performed
+- A memory write to register `rd` is performed with the result of the operation
+- The instruction is executed successfully by the VM and the program counter is incremented by 4
+
+#### 2. [Branch adapter](./adapters/branch.rs)
+
+Given `rs1`, `rs2`, and the destination pointer `to_pc`, this circuit proves the following:
+
+- A memory read from register `rs1` is performed
+- A memory read from register `rs2` is performed
+- The instruction is executed successfully by the VM and the program counter is set to `to_pc`
+
+#### 3. [JALR adapter](./adapters/jalr.rs)
+
+Given `rd`, `rs1`, the destination pointer `to_pc`, and a flag indicating if `rd` is `x0`, this circuit proves the following:
+
+- A memory read from register `rs1` is performed
+- A memory write to register `rd` is performed if `rd` is not `x0`
+- The instruction is executed successfully by the VM and the program counter is set to `to_pc`
+
+#### 4. [Load/store adapter](./adapters/loadstore.rs)
+
+Given `rd`, `rs1`, immediate value `imm`, address space `mem_as`, and a flag indicating if the instruction is a load or store, this circuit proves the following:
+
+If the instruction is a load:
+
+- A memory read from register `rs1` is performed
+- A memory read from `mem_as` is performed at `rs1 + imm`
+- A memory write to register `rd` is performed if `rd` is not `x0`
+- The instruction is executed successfully by the VM and the program counter is incremented by 4
+
+If the instruction is a store:
+
+- A memory read from register `rs1` is performed
+- A memory read from register `rd` is performed
+- A memory write to `mem_as` is performed at `rs1 + imm`
+- The instruction is executed successfully by the VM and the program counter is incremented by 4
+
+#### 5. [Multiplication adapter](./adapters/mul.rs)
+
+Given `rd`, `rs1`, `rs2`,this circuit proves the following:
+
+- A memory read from register `rs1` is performed
+- A memory read from register `rs2` is performed
+- A memory write to register `rd` is performed with the result of the multiplication
+- The instruction is executed successfully by the VM and the program counter is incremented by 4
+
+#### 6. [Rdwrite adapter](./adapters/rdwrite.rs)
+
+Given `rd`, the destination pointer `to_pc`, and a flag indicating if `rd` is `x0`, this circuit proves the following:
+
+- A memory write to register `rd` is performed if `rd` is not `x0`
+- The instruction is executed successfully by the VM and the program counter is set to `to_pc`

--- a/extensions/rv32im/circuit/src/README.md
+++ b/extensions/rv32im/circuit/src/README.md
@@ -176,9 +176,8 @@ Given:
 
 This circuit proves that:
 
-- `compose(rd) == compose(pc_limbs) + compose(imm_limbs) * 2^12`
+- `compose(rd) == compose(pc_limbs) + compose(imm_limbs) * 2^8`
 - `compose(pc_limbs) == pc` and `compose(pc_limbs) < 2^PC_MAX_BITS`
-- `compose(imm_limbs) < 2^12`
 
 #### 8. [Less_than](./less_than/core.rs)
 

--- a/extensions/rv32im/circuit/src/README.md
+++ b/extensions/rv32im/circuit/src/README.md
@@ -4,15 +4,15 @@ This directory contains the circuit implementation of the RV32IM extension.
 
 ## Design
 
-The RV32IM chips consist of a series of an adapter chip and a core chip.
+The RV32IM chips is composed of two main components: an adapter chip and a core chip
 
-- The adapter chip is responsible for adapting the input and output of the core chip to the format expected by the VM, and handling any interactions with the VM.
+- The adapter chip adapts the core chip's I/O to the VM's expected format and manages interactions with the VM.
 - The core chip is responsible for implementing the logic of the RISC-V instructions.
 
 ## Circuit statements
 
-This section describes the statements that each circuit is responsible for proving.
-Details about the constraints and assumptions for each statement are available in the implementation of the circuit.
+This section outlines the specific statements that each circuit is designed to prove.
+For further details, including the underlying constraints and assumptions, please refer to the circuit implementation.
 
 ### Adapter
 
@@ -64,7 +64,7 @@ This circuit proves the following:
 Given
 
 - `rd`, `rs1` are register addresses
-- `imm` is the immediate value
+- `imm` is an immediate value
 - `mem_as` is an address space
 - `is_load` is a boolean indicating if the instruction is a load
 - `from_pc` is the current program address
@@ -74,7 +74,7 @@ This circuit proves the following:
 - If `is_load` is true:
   - `mem_as` is in `{0, 1, 2}`
   - A memory read from register `rs1` is performed
-  - A memory read from `mem_as` is performed at `val(rs1) + imm` where `val(rs1)` is the value read from register `rs1`
+  - A memory read from `mem_as` is performed at address `val(rs1) + imm` where `val(rs1)` is the value read from register `rs1`
   - A memory write to register `rd` is performed if `rd` is not `x0`
   - The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
 
@@ -82,7 +82,7 @@ This circuit proves the following:
   - `mem_as` is in `{2, 3, 4}`
   - A memory read from register `rs1` is performed
   - A memory read from register `rd` is performed
-  - A memory write to `mem_as` is performed at `val(rs1) + imm` where `val(rs1)` is the value read from register `rs1`
+  - A memory write to `mem_as` is performed at address `val(rs1) + imm` where `val(rs1)` is the value read from register `rs1`
   - The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
 
 #### 5. [Multiplication adapter](./adapters/mul.rs)
@@ -114,27 +114,27 @@ This circuit proves the following:
 
 ### Core
 
-**Note:** For the core chips, we do not need to constrain the instructions operands (which is given in the statement), since they are already constrained by the adapter through execution bus. The main goal is to constrain the result matches the specification of the instruction.
+**Note:** For the core chips, it is not necessary to constrain the instruction operands (as specified in the statement), because the adapter already constrains them via the execution bus. The primary objective is to ensure that the result conforms to the instruction's specification.
 
 #### 1. [Base ALU](./base_alu/core.rs)
 
 Given:
 
-- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `b` and `c` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the result
-- `opcode` indicating the operation to be performed
+- `opcode` indicates the operation to be performed
 
 This circuit proves that:
 
 - `compose(a) == compose(b) op compose(c)`
-- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- Each limb of `a` is within the range `[0, 2^RV32_CELL_BITS)`
 
-#### 2. [Branch_Eq](./branch_eq/core.rs)
+#### 2. [Branch Eq](./branch_eq/core.rs)
 
 Given:
 
-- `a`, `b` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
-- `opcode_beq_flag` and `opcode_bne_flag` indicating if the instruction is `beq` or `bne`
+- `a` and `b` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
+- `opcode_beq_flag` and `opcode_bne_flag` indicate if the instruction is `beq` or `bne`
 - `imm` is the immediate value
 - `to_pc` is the destination program address
 
@@ -143,11 +143,11 @@ This circuit proves that:
 - If `opcode_beq_flag` is true and `a` is equal to `b`, then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
 - If `opcode_bne_flag` is true and `a` is not equal to `b`, then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
 
-#### 3. [Branch_Lt](./branch_lt/core.rs)
+#### 3. [Branch Lt](./branch_lt/core.rs)
 
 Given:
 
-- `a`, `b` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `a` and `b` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
 - Flags indicating if the instruction is one of `blt`, `bltu`, `bge`, `bgeu`
 - `imm` is the immediate value
 - `to_pc` is the destination program address
@@ -163,9 +163,9 @@ This circuit proves that:
 
 Given:
 
-- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
-- `q` is the quotient
-- `r` is the remainder
+- `b` and `c` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
+- `q` is the decomposition of the quotient
+- `r` is the decomposition of the remainder
 - `a` is the decomposition of the result
 - Flags indicating if the instruction is `div`, `divu`, `rem`, `remu`
 
@@ -174,7 +174,7 @@ This circuit proves that:
 - `compose(b) = compose(c) * compose(q) + compose(r)`
 - `0 <= |compose(r)| < |compose(c)|`
 - If `compose(c) == 0`, then `compose(q) == -1` for signed operations and `compose(q) == 2^32 - 1` for unsigned operations
-- `q` and `r` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- Each limb of `q` and `r` is in the range `[0, 2^RV32_CELL_BITS)`
 - `a = q` if the instruction is `div` or `divu`
 - `a = r` if the instruction is `rem` or `remu`
 
@@ -185,30 +185,36 @@ Given:
 - `rd` is the decomposition of the result
 - `imm` is the immediate value
 - `to_pc` is the destination program address
-- `opcode` indicating the operation to be performed
+- `opcode` indicates the operation to be performed
 
 This circuit proves that:
 
-- `rd` limbs are in range `[0, 2^RV32_CELL_BITS)`
-- If `opcode` is `jal`, then `to_pc == pc + imm` and `compose(rd) == pc + 4`
-- If `opcode` is `lui`, then `to_pc == pc + 4` and `compose(rd) == imm * 2^8`
+- Each limb of `rd` is in the range `[0, 2^RV32_CELL_BITS)`
+- If `opcode` is `jal`, then
+  - `to_pc == pc + imm`
+  - `compose(rd) == pc + 4`
+  - The most significant limb of `rd` is in the range `[0, 2^(PC_BITS - RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1))`
+- If `opcode` is `lui`, then
+  - `to_pc == pc + 4`
+  - `compose(rd) == imm * 2^8`
 
 #### 6. [JALR](./jalr/core.rs)
 
 Given:
 
-- `rs1` are decompositions of the operands and its limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `rs1` is the decomposition of the operand, with its limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
 - `rd` is the decomposition of the result
 - `imm` is the immediate value
-- `to_pc_limbs` are the decomposition of the destination program address
-- `from_pc` is the current program address
+- `to_pc_limbs` is the decomposition into 16-bit limbs of the destination program address
 
 This circuit proves that:
 
-- `rd` limbs are in range `[0, 2^RV32_CELL_BITS)`
 - `compose(to_pc_limbs) == compose(rs1) + imm`
-- `compose(rd) == from_pc + 4`
-- `to_pc_limbs` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- `compose(rd) == pc + 4`
+- Each limb of `rd` is in the range `[0, 2^RV32_CELL_BITS)`
+- The most significant limb of `rd` is in the range `[0, 2^(PC_BITS - RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1))`
+- `to_pc_limbs[0]` is in the range `[0, 2^15)`
+- `to_pc_limbs[1]` is in the range `[0, 2^(PC_BITS - 16))`
 
 #### 7. [AUIPC](./auipc/core.rs)
 
@@ -221,70 +227,71 @@ Given:
 This circuit proves that:
 
 - `compose(rd) == compose(pc_limbs) + compose(imm_limbs) * 2^8`
-- `compose(pc_limbs) == pc` and `compose(pc_limbs) < 2^PC_MAX_BITS`
-- `rd`, `imm_limbs`, `pc_limbs` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- `compose(pc_limbs) == pc`
+- Each limb of `rd`, `imm_limbs`, and `pc_limbs` is in the range `[0, 2^RV32_CELL_BITS)`
+- The most significant limb of `pc_limbs` is in the range `[0, 2^(PC_BITS - RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1))`
 
-#### 8. [Less_than](./less_than/core.rs)
+#### 8. [Less than](./less_than/core.rs)
 
 Given:
 
-- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `b`, `c` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
 - `a` is the result
-- `opcode` indicating the operation to be performed
+- `opcode` indicates the operation to be performed
 
 This circuit proves that:
 
 - If `opcode` is `slt` and `compose(b) < compose(c)` (signed comparison), then `a` is 1.
-- If `opcode` is `sltu`, then `compose(b) < compose(c)` (unsigned comparison), then `a` is 1.
+- If `opcode` is `sltu` and `compose(b) < compose(c)` (unsigned comparison), then `a` is 1.
 - Otherwise, `a` is 0.
 
-#### 9. [Load_sign_extend](./load_sign_extend/core.rs) and [Loadstore](./loadstore/core.rs)
+#### 9. [Load sign extend](./load_sign_extend/core.rs) and [Loadstore](./loadstore/core.rs)
 
 Given:
 
-- `read_data` is the data read from `aligned(mem_as[val(rs1) + imm])` if the instruction is load, otherwise it is the data read from `rd`
-- `write_data` is the data to be written to `rd` if the instruction is load, otherwise it is the data to be written to `mem_as[val(rs1) + imm]`
-- Flags indicating which instruction is being executed
+- `read_data` is the data read from `mem_as[aligned(val(rs1) + imm)]` if the instruction is load, otherwise it is the data read from register `rd`
+- `write_data` is the data to be written to register `rd` if the instruction is load, otherwise it is the data to be written to `mem_as[aligned(val(rs1) + imm)]`
+- `opcode` indicates the operation to be performed
 
-This circuit proves that `write_data == shift(read_data)` with shift amount adjusted for the instruction.
+This circuit proves that `write_data` equals `shift(read_data)`, where the shift amount is adjusted according to the instruction.
 
-#### 10. [Mul](./mul/core.rs)
+#### 10. [Multiplication](./mul/core.rs)
 
 Given:
 
-- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `b`, `c` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the lower 32 bits of the result
-- `opcode` indicating the operation to be performed
+- `opcode` indicates the operation to be performed
 
 This circuit proves that:
 
 - `compose(a) == (compose(b) * compose(c)) % 2^32`
-- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- Each limb of `a` is in the range `[0, 2^RV32_CELL_BITS)`
 
 #### 11. [MULH](./mulh/core.rs)
 
 Given:
 
-- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `b`, `c` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the upper 32 bits of the result
-- `opcode` indicating the operation to be performed
+- `opcode` indicates the operation to be performed
 
 This circuit proves that:
 
-- `compose(a) == floor(compose(b) * compose(c) / 2^32)`
-- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- `compose(a) == floor((compose(b) * compose(c)) / 2^32)`
+- Each limb of `a` is in the range `[0, 2^RV32_CELL_BITS)`
 
 #### 12. [Shift](./shift/core.rs)
 
 Given:
 
-- `b`, `c` are decompositions of the operands and their limbs are assumed to be in range `[0, 2^RV32_CELL_BITS)`
+- `b`, `c` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^RV32_CELL_BITS)`
 - `a` is the decomposition of the result
-- `opcode` indicating the operation to be performed
+- `opcode` indicates the operation to be performed
 
 This circuit proves that:
 
-- If `opcode` is `sll`, then `compose(a) == compose(b) << (compose(c) % 32)`
-- If `opcode` is `srl`, then `compose(a) == compose(b) >> (compose(c) % 32)`
-- If `opcode` is `sra`, then `compose(a) == sign_extend(compose(b) >> (compose(c) % 32))`
-- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
+- If `opcode` is `sll`, then `compose(a) == compose(b) << (compose(c) % (RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS))`
+- If `opcode` is `srl`, then `compose(a) == compose(b) >> (compose(c) % (RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS))`
+- If `opcode` is `sra`, then `compose(a) == sign_extend(compose(b) >> (compose(c) % (RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS)))`
+- Each limb of `a` is in the range `[0, 2^RV32_CELL_BITS)`

--- a/extensions/rv32im/circuit/src/README.md
+++ b/extensions/rv32im/circuit/src/README.md
@@ -88,7 +88,10 @@ Given:
 - `a` is the decomposition of the result
 - `opcode` indicating the operation to be performed
 
-This circuit proves that `a` is the correct decomposition of the result of the operation `opcode` applied to `compose(b)` and `compose(c)`.
+This circuit proves that:
+
+- `compose(a) == compose(b) op compose(c)`
+- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 2. [Branch_Eq](./branch_eq/core.rs)
 
@@ -135,7 +138,7 @@ This circuit proves that:
 - `compose(b) = compose(c) * compose(q) + compose(r)`
 - `0 <= |compose(r)| < |compose(c)|`
 - If `compose(c) == 0`, then `compose(q) == -1` for signed operations and `compose(q) == 2^32 - 1` for unsigned operations
-- `q` and `r` are the correct decompositions of the quotient and remainder
+- `q` and `r` limbs are in range `[0, 2^RV32_CELL_BITS)`
 - `a = q` if the instruction is `div` or `divu`
 - `a = r` if the instruction is `rem` or `remu`
 
@@ -165,6 +168,7 @@ This circuit proves that:
 
 - `compose(to_pc_limbs) == compose(rs1) + imm`
 - `compose(rd) == pc + 4`
+- `to_pc_limbs` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 7. [AUIPC](./auipc/core.rs)
 
@@ -178,6 +182,7 @@ This circuit proves that:
 
 - `compose(rd) == compose(pc_limbs) + compose(imm_limbs) * 2^8`
 - `compose(pc_limbs) == pc` and `compose(pc_limbs) < 2^PC_MAX_BITS`
+- `rd`, `imm_limbs`, `pc_limbs` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 8. [Less_than](./less_than/core.rs)
 
@@ -189,9 +194,9 @@ Given:
 
 This circuit proves that:
 
-- If `opcode` is `slt` and `compose(b) < compose(c)` (signed comparison), then `compose(a) == 1`.
-- If `opcode` is `sltu`, then `compose(b) < compose(c)` (unsigned comparison), then `compose(a) == 1`.
-- Otherwise, `compose(a) == 0`.
+- If `opcode` is `slt` and `compose(b) < compose(c)` (signed comparison), then `a` is 1.
+- If `opcode` is `sltu`, then `compose(b) < compose(c)` (unsigned comparison), then `a` is 1.
+- Otherwise, `a` is 0.
 
 #### 9. [Load_sign_extend](./load_sign_extend/core.rs) and [Loadstore](./loadstore/core.rs)
 
@@ -211,7 +216,10 @@ Given:
 - `a` is the decomposition of the lower 32 bits of the result
 - `opcode` indicating the operation to be performed
 
-This circuit proves that `a` is the correct decomposition of the lower 32 bits of `compose(b) * compose(c)`.
+This circuit proves that:
+
+- `compose(a) == compose(b) * compose(c) % 2^32`
+- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 11. [MULH](./mulh/core.rs)
 
@@ -221,7 +229,10 @@ Given:
 - `a` is the decomposition of the upper 32 bits of the result
 - `opcode` indicating the operation to be performed
 
-This circuit proves that `a` is the correct decomposition of the upper 32 bits of `compose(b) * compose(c)`.
+This circuit proves that:
+
+- `compose(a) == compose(b) * compose(c) / 2^32`
+- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`
 
 #### 12. [Shift](./shift/core.rs)
 
@@ -236,4 +247,4 @@ This circuit proves that:
 - If `opcode` is `sll`, then `compose(a) == compose(b) << (compose(c) % 32)`
 - If `opcode` is `srl`, then `compose(a) == compose(b) >> (compose(c) % 32)`
 - If `opcode` is `sra`, then `compose(a) == sign_extend(compose(b) >> (compose(c) % 32))`
-- `a` is the correct decomposition of the result to 8-bit limbs
+- `a` limbs are in range `[0, 2^RV32_CELL_BITS)`

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -155,7 +155,10 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
         );
         self.bitwise_lookup_bus
             .send_range(rs2_limbs[0].clone(), rs2_limbs[1].clone())
-            .eval(builder, ctx.instruction.is_valid.clone() - local.rs2_as);
+            .eval(
+                builder,
+                not(local.rs2_as) * ctx.instruction.is_valid.clone(),
+            );
 
         self.memory_bridge
             .read(

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -91,7 +91,7 @@ pub struct Rv32BaseAluAdapterCols<T> {
     pub from_state: ExecutionState<T>,
     pub rd_ptr: T,
     pub rs1_ptr: T,
-    // Pointer if rs2 was a read, immediate value otherwise
+    /// Pointer if rs2 was a read, immediate value otherwise
     pub rs2: T,
     /// 1 if rs2 was a read, 0 if an immediate
     pub rs2_as: T,
@@ -137,7 +137,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
             timestamp + AB::F::from_canonical_usize(timestamp_delta - 1)
         };
 
-        // // if rs2 is an immediate value, constrain that its 4-byte representation is correct
+        // If rs2 is an immediate value, constrain that:
+        // 1. It's a 16-bit two's complement integer (stored in rs2_limbs[0] and rs2_limbs[1])
+        // 2. It's properly sign-extended to 32-bits (the upper limbs must match the sign bit)
         let rs2_limbs = ctx.reads[1].clone();
         let rs2_sign = rs2_limbs[2].clone();
         let rs2_imm = rs2_limbs[0].clone()
@@ -153,10 +155,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
         );
         self.bitwise_lookup_bus
             .send_range(rs2_limbs[0].clone(), rs2_limbs[1].clone())
-            .eval(
-                builder,
-                not(local.rs2_as) * ctx.instruction.is_valid.clone(),
-            );
+            .eval(builder, ctx.instruction.is_valid.clone() - local.rs2_as);
 
         self.memory_bridge
             .read(

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -72,6 +72,8 @@ pub struct Rv32JalrAdapterCols<T> {
     pub rs1_aux_cols: MemoryReadAuxCols<T>,
     pub rd_ptr: T,
     pub rd_aux_cols: MemoryWriteAuxCols<T, RV32_REGISTER_NUM_LIMBS>,
+    /// Only writes if `needs_write`.
+    /// Sets `needs_write` to 0 iff `rd == x0`
     pub needs_write: T,
 }
 

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -216,6 +216,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
         // This constraint ensures that the memory write only occurs when `is_valid == 1`.
         builder.assert_bool(write_count);
         builder.when(write_count).assert_one(is_valid.clone());
+        builder
+            .when(is_valid.clone() - write_count)
+            .assert_one(is_load.clone());
+        builder
+            .when(is_valid.clone() - write_count)
+            .assert_zero(local_cols.rd_rs2_ptr);
 
         // read rs1
         self.memory_bridge

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -164,7 +164,12 @@ pub struct Rv32LoadStoreAdapterCols<T> {
     pub mem_as: T,
     /// prev_data will be provided by the core chip to make a complete MemoryWriteAuxCols
     pub write_base_aux: MemoryBaseAuxCols<T>,
-    /// needs_write is 1 if rd != x0 and 0 if rd == x0 in case of Load
+    /// Only writes if `needs_write`.
+    /// If the instruction is a Load:
+    /// - Sets `needs_write` to 0 iff `rd == x0`
+    ///
+    /// Otherwise:
+    /// - Sets `needs_write` to 1
     pub needs_write: T,
 }
 
@@ -208,15 +213,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
 
         let write_count = local_cols.needs_write;
 
-        // constrain is_load == 1 and rd == x0 when write_count == 0
+        // This constraint ensures that the memory write only occurs when `is_valid == 1`.
         builder.assert_bool(write_count);
         builder.when(write_count).assert_one(is_valid.clone());
-        builder
-            .when(is_valid.clone() - write_count)
-            .assert_one(is_load.clone());
-        builder
-            .when(is_valid.clone() - write_count)
-            .assert_zero(local_cols.rd_rs2_ptr);
 
         // read rs1
         self.memory_bridge

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -93,7 +93,7 @@ where
         // For ADD, define carry[i] = (b[i] + c[i] + carry[i - 1] - a[i]) / 2^LIMB_BITS. If
         // each carry[i] is boolean and 0 <= a[i] < 2^LIMB_BITS, it can be proven that
         // a[i] = (b[i] + c[i]) % 2^LIMB_BITS as necessary. The same holds for SUB when
-        // carry[i] is (a[i] + b[i] - c[i] + carry[i - 1]) / 2^LIMB_BITS.
+        // carry[i] is (a[i] + c[i] - b[i] + carry[i - 1]) / 2^LIMB_BITS.
         let mut carry_add: [AB::Expr; NUM_LIMBS] = array::from_fn(|_| AB::Expr::ZERO);
         let mut carry_sub: [AB::Expr; NUM_LIMBS] = array::from_fn(|_| AB::Expr::ZERO);
         let carry_divide = AB::F::from_canonical_usize(1 << LIMB_BITS).inverse();

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -86,13 +86,17 @@ where
             cols.cmp_result * cols.opcode_beq_flag + not(cols.cmp_result) * cols.opcode_bne_flag;
         let mut sum = cmp_eq.clone();
 
-        // For BEQ, inv_marker is filled with 0 except at the lowest index i such that
-        // a[i] != b[i]. If such an i exists inv_marker[i] is the inverse of a[i] - b[i],
-        // meaning sum should be 1.
+        // For BEQ, inv_marker is used to check equality of a and b:
+        // - If a == b, all inv_marker values must be 0 (sum = 0)
+        // - If a != b, inv_marker contains 0s for all positions except ONE position i where a[i] != b[i]
+        // - At this position, inv_marker[i] contains the multiplicative inverse of (a[i] - b[i])
+        // - This ensures inv_marker[i] * (a[i] - b[i]) = 1, making the sum = 1
+        // Note: There might be multiple valid inv_marker if a != b.
+        // But as long as the trace can provide at least one, that’s sufficient to prove a != b.
         //
-        // Note if cmp_eq == 0, then it is impossible to have sum != 0 if a == b. If
-        // cmp_eq == 1, then it is impossible for a[i] - b[i] == 0 to pass for all i if
-        // a != b.
+        // Note:
+        // - If cmp_eq == 0, then it is impossible to have sum != 0 if a == b.
+        // - If cmp_eq == 1, then it is impossible for a[i] - b[i] == 0 to pass for all i if a != b.
         for i in 0..NUM_LIMBS {
             sum += (a[i] - b[i]) * inv_marker[i];
             builder.assert_zero(cmp_eq.clone() * (a[i] - b[i]));

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -299,10 +299,11 @@ where
         }
         // - If r_prime != c, then prefix_sum = 1 so marker[i] must be 1 iff i is the first index where diff != 0.
         //   Constrains that diff == lt_diff where lt_diff is non-zero.
-        // - If r_prime == c, then prefix_sum = 0 and lt_diff = 0.
+        // - If r_prime == c, then prefix_sum = 0.
         //   Here, prefix_sum cannot be 1 because all diff are zero, making diff == lt_diff fails.
 
         builder.when(is_valid.clone()).assert_one(prefix_sum);
+        // Range check to ensure lt_diff is non-zero.
         self.bitwise_lookup_bus
             .send_range(cols.lt_diff - AB::Expr::ONE, AB::F::ZERO)
             .eval(builder, is_valid.clone() - special_case);

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -240,6 +240,10 @@ where
             .when(nonzero_q)
             .when(not(cols.zero_divisor))
             .assert_eq(cols.q_sign, cols.sign_xor);
+        builder
+            .when_ne(cols.q_sign, cols.sign_xor)
+            .when(not(cols.zero_divisor))
+            .assert_zero(cols.q_sign);
 
         // Check that the signs of b and c are correct.
         let sign_mask = AB::F::from_canonical_u32(1 << (LIMB_BITS - 1));

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -54,7 +54,7 @@ pub struct DivRemCoreCols<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 
     // Auxiliary columns to constrain that 0 <= |r| < |c|. When sign_xor == 1 we have
     // r_prime = -r, and when sign_xor == 0 we have r_prime = r. Each r_inv[i] is the
-    // field inverse of r_prime - 2^LIMB_BITS, ensures each r_prime[i] is in range.
+    // field inverse of r_prime[i] - 2^LIMB_BITS, ensures each r_prime[i] is in range.
     pub r_prime: [T; NUM_LIMBS],
     pub r_inv: [T; NUM_LIMBS],
     pub lt_marker: [T; NUM_LIMBS],
@@ -120,8 +120,7 @@ where
         let q = &cols.q;
         let r = &cols.r;
 
-        // Constrain that b = (c * q + r') % 2^{NUM_LIMBS * LIMB_BITS} and range check
-        // each element in q.
+        // Constrain that b = (c * q + r) % 2^{NUM_LIMBS * LIMB_BITS} and range checkeach element in q.
         let b_ext = cols.b_sign * AB::F::from_canonical_u32((1 << LIMB_BITS) - 1);
         let c_ext = cols.c_sign * AB::F::from_canonical_u32((1 << LIMB_BITS) - 1);
         let carry_divide = AB::F::from_canonical_u32(1 << LIMB_BITS).inverse();
@@ -142,7 +141,7 @@ where
                 .eval(builder, is_valid.clone());
         }
 
-        // Constrain that the upper limbs of b = c * q + r' are all equal to b_ext and
+        // Constrain that the upper limbs of b = c * q + r are all equal to b_ext and
         // range check each element in r.
         let q_ext = cols.q_sign * AB::F::from_canonical_u32((1 << LIMB_BITS) - 1);
         let mut carry_ext: [AB::Expr; NUM_LIMBS] = array::from_fn(|_| AB::Expr::ZERO);
@@ -211,13 +210,8 @@ where
             .assert_one(r_sum * cols.r_sum_inv);
 
         // Constrain the correctness of b_sign and c_sign. Note that we do not need to
-        // check that the sign of r is b_sign since we cannot have r' <_u c (or c <_u r'
+        // check that the sign of r is b_sign since we cannot have r_prime < c (or c < r_prime
         // if c is negative) if this is not the case.
-        //
-        // To constrain the correctness of q_sign we make sure if q is non-zero then
-        // q_sign = b_sign ^ c_sign, and if q_sign = 1 then q is non-zero. Note q_sum
-        // is guaranteed to be non-zero if q is non-zero since we've range checked each
-        // limb of q to be within [0, 2^LIMB_BITS) already.
         let signed = cols.opcode_div_flag + cols.opcode_rem_flag;
 
         builder.assert_bool(cols.b_sign);
@@ -233,16 +227,19 @@ where
             cols.sign_xor,
         );
 
+        // To constrain the correctness of q_sign we make sure if q is non-zero then
+        // q_sign = b_sign ^ c_sign, and if q is zero then q_sign = 0.
+        // Note:
+        // - q_sum is guaranteed to be non-zero if q is non-zero since we've range checked each
+        // limb of q to be within [0, 2^LIMB_BITS) already.
+        // - If q is zero and q_ext satisfies the constraint b = c * q + r, then q_sign must be 0.
+        // Thus, we do not need additional constraints in case q is zero.
         let nonzero_q = q.iter().fold(AB::Expr::ZERO, |acc, q| acc + *q);
         builder.assert_bool(cols.q_sign);
         builder
             .when(nonzero_q)
             .when(not(cols.zero_divisor))
             .assert_eq(cols.q_sign, cols.sign_xor);
-        builder
-            .when_ne(cols.q_sign, cols.sign_xor)
-            .when(not(cols.zero_divisor))
-            .assert_zero(cols.q_sign);
 
         // Check that the signs of b and c are correct.
         let sign_mask = AB::F::from_canonical_u32(1 << (LIMB_BITS - 1));
@@ -253,9 +250,9 @@ where
             )
             .eval(builder, signed.clone());
 
-        // Constrain that 0 <= |r| < |c| by checking that r' <_u c (unsigned LT). By
+        // Constrain that 0 <= |r| < |c| by checking that r_prime < c (unsigned LT). By
         // definition, the sign of r must be b_sign. If c is negative then we want
-        // to constrain c <_u r'. If c is positive, then we want to constrain r' <_u c.
+        // to constrain c < r_prime. If c is positive, then we want to constrain r_prime < c.
         //
         // Because we already constrain that r and q are correct for special cases,
         // we skip the range check when special_case = 1.
@@ -263,14 +260,14 @@ where
         let mut carry_lt: [AB::Expr; NUM_LIMBS] = array::from_fn(|_| AB::Expr::ZERO);
 
         for i in 0..NUM_LIMBS {
-            // When the signs of r (i.e. b) and c are the same, r' = r.
+            // When the signs of r (i.e. b) and c are the same, r_prime = r.
             builder.when(not(cols.sign_xor)).assert_eq(r[i], r_p[i]);
 
-            // When the signs of r and c are different, r' = -r. To constrain this, we
-            // first ensure each r[i] + r'[i] + carry[i - 1] is in {0, 2^LIMB_BITS}, and
-            // that when the sum is 0 then r'[i] = 0 as well. Passing both constraints
-            // implies that 0 <= r'[i] <= 2^LIMB_BITS, and in order to ensure r'[i] !=
-            // 2^LIMB_BITS we check that r'[i] - 2^LIMB_BITS has an inverse in F.
+            // When the signs of r and c are different, r_prime = -r. To constrain this, we
+            // first ensure each r[i] + r_prime[i] + carry[i - 1] is in {0, 2^LIMB_BITS}, and
+            // that when the sum is 0 then r_prime[i] = 0 as well. Passing both constraints
+            // implies that 0 <= r_prime[i] <= 2^LIMB_BITS, and in order to ensure r_prime[i] !=
+            // 2^LIMB_BITS we check that r_prime[i] - 2^LIMB_BITS has an inverse in F.
             let last_carry = if i > 0 {
                 carry_lt[i - 1].clone()
             } else {
@@ -300,6 +297,10 @@ where
             builder.assert_zero(not::<AB::Expr>(prefix_sum.clone()) * diff.clone());
             builder.when(marker[i]).assert_eq(cols.lt_diff, diff);
         }
+        // - If r_prime != c, then prefix_sum = 1 so marker[i] must be 1 iff i is the first index where diff != 0.
+        //   Constrains that diff == lt_diff where lt_diff is non-zero.
+        // - If r_prime == c, then prefix_sum = 0 and lt_diff = 0.
+        //   Here, prefix_sum cannot be 1 because all diff are zero, making diff == lt_diff fails.
 
         builder.when(is_valid.clone()).assert_one(prefix_sum);
         self.bitwise_lookup_bus

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -100,12 +100,14 @@ where
                 acc + val * AB::Expr::from_canonical_u32(1 << (i * RV32_CELL_BITS))
             });
 
+        // Constrain that imm * 2^4 is the correct composition of intermed_val in case of LUI
         builder.when(is_lui).assert_eq(
             intermed_val.clone(),
             imm * AB::F::from_canonical_u32(1 << (12 - RV32_CELL_BITS)),
         );
 
         let intermed_val = rd[0] + intermed_val * AB::Expr::from_canonical_u32(1 << RV32_CELL_BITS);
+        // Constrain that from_pc + DEFAULT_PC_STEP is the correct composition of intermed_val in case of JAL
         builder.when(is_jal).assert_eq(
             intermed_val,
             from_pc + AB::F::from_canonical_u32(DEFAULT_PC_STEP),

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -97,7 +97,7 @@ where
 
         builder.assert_bool(is_valid);
 
-        // composed = composed(rd_data) - rd[0]
+        // composed is the composition of 3 most significant limbs of rd
         let composed = rd
             .iter()
             .enumerate()
@@ -130,7 +130,7 @@ where
 
         builder.assert_bool(imm_sign);
 
-        // constrain to_pc_least_sig_bit + 2 * to_pc_limbs = rs1 + imm as a i32 addition with 2 limbs
+        // Constrain to_pc_least_sig_bit + 2 * to_pc_limbs = rs1 + imm as a i32 addition with 2 limbs
         // RISC-V spec explicitly sets the least significant bit of `to_pc` to 0
         let rs1_limbs_01 = rs1[0] + rs1[1] * AB::F::from_canonical_u32(1 << RV32_CELL_BITS);
         let rs1_limbs_23 = rs1[2] + rs1[3] * AB::F::from_canonical_u32(1 << RV32_CELL_BITS);

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -107,7 +107,11 @@ where
 
         let least_sig_limb = from_pc + AB::F::from_canonical_u32(DEFAULT_PC_STEP) - composed;
 
-        // rd_data is the final data needed
+        // rd_data is the final decomposition of `from_pc + DEFAULT_PC_STEP` we need.
+        // The range check on `least_sig_limb` also ensures that `rd_data` correctly represents `from_pc + DEFAULT_PC_STEP`.
+        // Specifically, if `rd_data` does not match the expected limb, then `least_sig_limb` becomes
+        // the real `least_sig_limb` plus the difference between `composed` and the three most significant limbs of `from_pc + DEFAULT_PC_STEP`.
+        // In that case, `least_sig_limb` >= 2^RV32_CELL_BITS.
         let rd_data = array::from_fn(|i| {
             if i == 0 {
                 least_sig_limb.clone()

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -119,9 +119,9 @@ where
         let limb_mask = data_most_sig_bit * AB::Expr::from_canonical_u32((1 << LIMB_BITS) - 1);
 
         // there are three parts to write_data:
-        //      1st limb is always shifted_read_data
-        //      2nd to (NUM_CELLS/2)th limbs are read_data if loadh and sign extended if loadb
-        //      (NUM_CELLS/2 + 1)th to last limbs are always sign extended limbs
+        // - 1st limb is always shifted_read_data
+        // - 2nd to (NUM_CELLS/2)th limbs are read_data if loadh and sign extended if loadb
+        // - (NUM_CELLS/2 + 1)th to last limbs are always sign extended limbs
         let write_data: [AB::Expr; NUM_CELLS] = array::from_fn(|i| {
             if i == 0 {
                 (is_loadh + is_loadb0) * shifted_read_data[i].into()

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -137,21 +137,23 @@ where
             })
         };
 
-        // constrain that is_load matches the opcode
+        // Constrain that is_load matches the opcode
         builder.assert_eq(
             is_load,
             opcode_when(&[LoadW0, LoadHu0, LoadHu2, LoadBu0, LoadBu1, LoadBu2, LoadBu3]),
         );
         builder.when(is_load).assert_one(is_valid);
 
-        // there are three parts to write_data:
-        // 1st limb is always read_data
-        // 2nd to (NUM_CELLS/2)th limbs are read_data if loadw/loadhu/storew/storeh
-        //                                  prev_data if storeb
-        //                                  zero if loadbu
-        // (NUM_CELLS/2 + 1)th to last limbs are read_data if loadw/storew
-        //                                  prev_data if storeb/storeh
-        //                                  zero if loadbu/loadhu
+        // There are three parts to write_data:
+        // - 1st limb is always read_data
+        // - 2nd to (NUM_CELLS/2)th limbs are:
+        //   - read_data if loadw/loadhu/storew/storeh
+        //   - prev_data if storeb
+        //   - zero if loadbu
+        // - (NUM_CELLS/2 + 1)th to last limbs are:
+        //   - read_data if loadw/storew
+        //   - prev_data if storeb/storeh
+        //   - zero if loadbu/loadhu
         // Shifting needs to be carefully handled in case by case basis
         // refer to [run_write_data] for the expected behavior in each case
         for (i, cell) in write_data.iter().enumerate() {

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -69,6 +69,8 @@ where
         let b = &cols.b;
         let c = &cols.c;
 
+        // Define carry[i] = (sum_{k=0}^{i} b[k] * c[i - k] + carry[i - 1] - a[i]) / 2^LIMB_BITS.
+        // If 0 <= a[i], carry[i] < 2^LIMB_BITS, it can be proven that a[i] = sum_{k=0}^{i} (b[k] * c[i - k]) % 2^LIMB_BITS as necessary.
         let mut carry: [AB::Expr; NUM_LIMBS] = array::from_fn(|_| AB::Expr::ZERO);
         let carry_divide = AB::F::from_canonical_u32(1 << LIMB_BITS).inverse();
 

--- a/extensions/rv32im/guest/src/io.rs
+++ b/extensions/rv32im/guest/src/io.rs
@@ -55,7 +55,7 @@ pub fn hint_random(len: usize) {
     );
 }
 
-/// Store rs1 to [[rd] + imm]_2.
+/// Store rs1 to [[rd] + imm]_3.
 #[macro_export]
 macro_rules! reveal {
     ($rd:ident, $rs1:ident, $imm:expr) => {


### PR DESCRIPTION
- Added more detailed code comments for the circuit implementation
- Removed unnecessary constraints
- Added a README describing the statements each circuit must prove. Although it doesn’t prove circuit soundness by itself, it outlines the goal to be met when the circuit is modified.