### PR TITLE
[chore] Remove unnecessary constraints in RV32IM extension

### DIFF
--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -153,10 +153,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
         );
         self.bitwise_lookup_bus
             .send_range(rs2_limbs[0].clone(), rs2_limbs[1].clone())
-            .eval(
-                builder,
-                not(local.rs2_as) * ctx.instruction.is_valid.clone(),
-            );
+            .eval(builder, ctx.instruction.is_valid.clone() - local.rs2_as);
 
         self.memory_bridge
             .read(

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -211,12 +211,6 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
         // constrain is_load == 1 and rd == x0 when write_count == 0
         builder.assert_bool(write_count);
         builder.when(write_count).assert_one(is_valid.clone());
-        builder
-            .when(is_valid.clone() - write_count)
-            .assert_one(is_load.clone());
-        builder
-            .when(is_valid.clone() - write_count)
-            .assert_zero(local_cols.rd_rs2_ptr);
 
         // read rs1
         self.memory_bridge

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -239,10 +239,6 @@ where
             .when(nonzero_q)
             .when(not(cols.zero_divisor))
             .assert_eq(cols.q_sign, cols.sign_xor);
-        builder
-            .when_ne(cols.q_sign, cols.sign_xor)
-            .when(not(cols.zero_divisor))
-            .assert_zero(cols.q_sign);
 
         // Check that the signs of b and c are correct.
         let sign_mask = AB::F::from_canonical_u32(1 << (LIMB_BITS - 1));


### PR DESCRIPTION
Removed unnecessary or duplicated constraints in the RV32IM extension.