### PR TITLE
fix: fix `From` macro import

### DIFF
--- a/extensions/algebra/circuit/src/modular_extension.rs
+++ b/extensions/algebra/circuit/src/modular_extension.rs
@@ -1,4 +1,4 @@
-use derive_more::derive::From;
+use derive_more::From;
 use num_bigint::BigUint;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{


### PR DESCRIPTION
`derive_more::From` should be imported directly, not via `derive::From`.
Fixed to avoid compilation issues.