### PR TITLE
[fix] Native ASM compiler checks stack overflow

### DIFF
--- a/extensions/native/compiler/src/asm/compiler.rs
+++ b/extensions/native/compiler/src/asm/compiler.rs
@@ -41,7 +41,9 @@ impl<F> Var<F> {
     /// Gets the frame pointer for a var.
     pub const fn fp(&self) -> i32 {
         // Vars are stored in stack positions 1, 2, 9, 10, 17, 18, ...
-        STACK_TOP - (8 * (self.0 / 2) + 1 + (self.0 % 2)) as i32
+        let offset = (8 * (self.0 / 2) + 1 + (self.0 % 2)) as i32;
+        assert!(offset < STACK_TOP, "Var fp overflow");
+        STACK_TOP - offset
     }
 }
 
@@ -49,7 +51,9 @@ impl<F> Felt<F> {
     /// Gets the frame pointer for a felt.
     pub const fn fp(&self) -> i32 {
         // Felts are stored in stack positions 3, 4, 11, 12, 19, 20, ...
-        STACK_TOP - (((self.0 >> 1) << 3) + 3 + (self.0 & 1)) as i32
+        let offset = (((self.0 >> 1) << 3) + 3 + (self.0 & 1)) as i32;
+        assert!(offset < STACK_TOP, "Felt fp overflow");
+        STACK_TOP - offset
     }
 }
 
@@ -57,6 +61,8 @@ impl<F, EF> Ext<F, EF> {
     /// Gets the frame pointer for an extension element
     pub const fn fp(&self) -> i32 {
         // Exts are stored in stack positions 5-8, 13-16, 21-24, ...
+        let offset = 8 * self.0 as i32;
+        assert!(offset < STACK_TOP, "Ext fp overflow");
         STACK_TOP - 8 * self.0 as i32
     }
 }


### PR DESCRIPTION
All frame pointers are known at compile time. So we can check stack overflow at compile time.