### PR TITLE
refactor: FriReducedOpeningAir

### DIFF
--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -277,20 +277,18 @@ impl FriReducedOpeningAir {
             let mut next_ins = builder.when(next.general.is_ins_row);
             let mut local_non_ins =
                 next_ins.when_ne(local.prefix.general.is_ins_row, AB::Expr::ONE);
-            // The row after a workload row can only be the first instruction row.
+            // An instruction row after a workload row must be the first instruction row.
             local_non_ins.assert_one(next.general.a_or_is_first);
         }
         {
             let mut when_first_row = builder.when_first_row();
-            let mut when_enabled = when_first_row
-                .when(local.prefix.general.is_ins_row + local.prefix.general.is_workload_row);
             // First row must be a workload row.
-            when_enabled.assert_one(local.prefix.general.is_workload_row);
-            // Workload rows must start with the first element.
-            when_enabled.assert_zero(local.prefix.data.idx);
+            when_first_row.assert_one(local.prefix.general.is_workload_row);
+            // Initial workload rows must start with the first element.
+            when_first_row.assert_zero(local.prefix.data.idx);
             // local.result is all 0s.
             assert_array_eq(
-                &mut when_enabled,
+                &mut when_first_row,
                 local.prefix.data.result,
                 [AB::Expr::ZERO; EXT_DEG],
             );

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -68,13 +68,9 @@ struct Instruction1Cols<T> {
 
     b_ptr_ptr: T,
     b_ptr_aux: MemoryReadAuxCols<T>,
-
-    /// A trick to reduce 1 degree. When `is_ins_row = 1`, `write_a_x_is_first = write_a * is_first`.
-    /// This field must align in both Instruction1Cols and Instruction2Cols.
-    write_a_x_is_first: T,
 }
 const INS_1_WIDTH: usize = Instruction1Cols::<u8>::width();
-const_assert_eq!(INS_1_WIDTH, 26);
+const_assert_eq!(INS_1_WIDTH, 25);
 const_assert_eq!(
     offset_of!(WorkloadCols<u8>, prefix),
     offset_of!(Instruction1Cols<u8>, prefix)
@@ -98,20 +94,12 @@ struct Instruction2Cols<T> {
 
     is_init_ptr: T,
     is_init_aux: MemoryReadAuxCols<T>,
-
-    /// A trick to reduce 1 degree. When `is_ins_row = 1`, `write_a_x_is_first = write_a * is_first`.
-    /// This field must align in both Instruction1Cols and Instruction2Cols.
-    write_a_x_is_first: T,
 }
 const INS_2_WIDTH: usize = Instruction2Cols::<u8>::width();
-const_assert_eq!(INS_2_WIDTH, 26);
+const_assert_eq!(INS_2_WIDTH, 25);
 const_assert_eq!(
     offset_of!(WorkloadCols<u8>, prefix) + offset_of!(PrefixCols<u8>, general),
     offset_of!(Instruction2Cols<u8>, general)
-);
-const_assert_eq!(
-    offset_of!(Instruction1Cols<u8>, write_a_x_is_first),
-    offset_of!(Instruction2Cols<u8>, write_a_x_is_first)
 );
 
 pub const OVERALL_WIDTH: usize = const_max(const_max(WL_WIDTH, INS_1_WIDTH), INS_2_WIDTH);
@@ -324,13 +312,6 @@ impl FriReducedOpeningAir {
         let next: &Instruction2Cols<AB::Var> = next_slice[..INS_2_WIDTH].borrow();
         // `is_ins_row` already indicates enabled.
         let mut is_ins_row = builder.when(local.prefix.general.is_ins_row);
-        // These constraints of `is_ins_row` apply to both Instruction1Cols and Instruction2Cols. It's a trick to reduce 1 degree.
-        // `write_a` refers to a random field in Instruction2Cols but `write_a_x_is_first` must be 0 because `is_first` is 0.
-        is_ins_row.assert_eq(
-            local.write_a_x_is_first,
-            local.prefix.data.write_a * local.prefix.general.a_or_is_first,
-        );
-        is_ins_row.assert_bool(local.write_a_x_is_first);
         let mut is_first_ins = is_ins_row.when(local.prefix.general.a_or_is_first);
         // ATTENTION: degree of is_first_ins is 2
         is_first_ins.assert_one(next.general.is_ins_row);
@@ -739,7 +720,6 @@ fn record_to_rows<F: PrimeField32>(
             a_ptr_aux,
             b_ptr_ptr,
             b_ptr_aux,
-            write_a_x_is_first: write_a,
         };
     }
     // Instruction2Cols
@@ -762,7 +742,6 @@ fn record_to_rows<F: PrimeField32>(
             hint_id_ptr,
             is_init_ptr,
             is_init_aux,
-            write_a_x_is_first: F::ZERO,
         };
     }
 }

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -244,11 +244,6 @@ impl FriReducedOpeningAir {
             let mut when_transition = builder.when_transition();
             let mut builder = when_transition.when(local.prefix.general.is_workload_row);
             // ATTENTION: degree of builder is 2
-            // local.timestamp = next.timestamp + 2
-            builder.assert_eq(
-                local.prefix.general.timestamp,
-                start_timestamp + AB::Expr::TWO,
-            );
             // local.idx = next.idx + 1
             builder.assert_eq(local_data.idx + AB::Expr::ONE, next.data.idx);
             // local.alpha = next.alpha


### PR DESCRIPTION
Removes an unnecessary column, duplicate constraint, and removes a constraint that was allowing a trace of all dummy rows. Makes reasoning about the constraints a bit easier.