### PR TITLE
fix: prevent starting with is_exhausted in NativePoseidon

### DIFF
--- a/extensions/native/circuit/src/poseidon2/columns.rs
+++ b/extensions/native/circuit/src/poseidon2/columns.rs
@@ -55,9 +55,9 @@ pub struct NativePoseidon2Cols<T, const SBOX_REGISTERS: usize> {
     /// Pointer to the beginning of the `opened_values` array.
     pub opened_base_pointer: T,
 
-    /// For rows that are not inside-row, this field should be 0. Otherwise, it indicates whether
-    /// inside-row cells are exhausted.
-    pub is_exhausted: [T; CHUNK],
+    /// For rows that are not inside-row, this field should be 0. Otherwise, `is_exhausted[i]`
+    /// indicates that cell `i + 1` inside a chunk is exhausted.
+    pub is_exhausted: [T; CHUNK - 1],
 
     pub specific: [T; max3(
         TopLevelSpecificCols::<usize>::width(),

--- a/extensions/native/circuit/src/poseidon2/trace.rs
+++ b/extensions/native/circuit/src/poseidon2/trace.rs
@@ -285,7 +285,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Chip<F, SBOX_R
             cell.opened_index = F::from_canonical_usize(parent.final_opened_index);
         }
 
-        cols.is_exhausted = std::array::from_fn(|i| F::from_bool(i >= cells.len()));
+        cols.is_exhausted = std::array::from_fn(|i| F::from_bool(i + 1 >= cells.len()));
 
         cols.initial_opened_index = F::from_canonical_usize(parent.initial_opened_index);
         cols.opened_base_pointer = grandparent.opened_base_pointer;
@@ -401,7 +401,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Chip<F, SBOX_R
         cols.simple = F::ONE;
         cols.end_inside_row = F::ZERO;
         cols.end_top_level = F::ZERO;
-        cols.is_exhausted = [F::ZERO; CHUNK];
+        cols.is_exhausted = [F::ZERO; CHUNK - 1];
 
         cols.start_timestamp = F::from_canonical_u32(from_state.timestamp);
         let specific: &mut SimplePoseidonSpecificCols<F> =


### PR DESCRIPTION
Could have also been fixed more simply with `builder.assert_zero(is_exhausted[0])`, but this feels wasteful then we are just adding an all zero column and a bunch of unnecessary constraints.