### PR TITLE
feat: verify app and leaf proof during e2e proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=c662bccdfafaa36fa19ab0a96ff3a0947f8331d0#c662bccdfafaa36fa19ab0a96ff3a0947f8331d0"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=9f7368b3c73fc559a92684b2ecf6c7d9ed00368b#9f7368b3c73fc559a92684b2ecf6c7d9ed00368b"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=c662bccdfafaa36fa19ab0a96ff3a0947f8331d0#c662bccdfafaa36fa19ab0a96ff3a0947f8331d0"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=9f7368b3c73fc559a92684b2ecf6c7d9ed00368b#9f7368b3c73fc559a92684b2ecf6c7d9ed00368b"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "c662bccdfafaa36fa19ab0a96ff3a0947f8331d0", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "c662bccdfafaa36fa19ab0a96ff3a0947f8331d0", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "9f7368b3c73fc559a92684b2ecf6c7d9ed00368b", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "9f7368b3c73fc559a92684b2ecf6c7d9ed00368b", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -248,7 +248,7 @@ where
         let leaf_controller = LeafProvingController {
             num_children: DEFAULT_NUM_CHILDREN_LEAF,
         };
-        leaf_controller.generate_proof(&leaf_prover, &app_proof);
+        leaf_controller.generate_proof(&leaf_prover, &app_proof)?;
     }
     Ok(())
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -201,7 +201,7 @@ impl Sdk {
         VC::Periphery: Chip<SC>,
     {
         let stark_prover = StarkProver::new(app_pk, app_exe, agg_stark_pk);
-        let proof = stark_prover.generate_root_verifier_input(inputs);
+        let proof = stark_prover.generate_root_verifier_input(inputs)?;
         Ok(proof)
     }
 
@@ -218,7 +218,7 @@ impl Sdk {
         VC::Periphery: Chip<SC>,
     {
         let e2e_prover = ContinuationProver::new(reader, app_pk, app_exe, agg_pk);
-        let proof = e2e_prover.generate_proof_for_evm(inputs);
+        let proof = e2e_prover.generate_proof_for_evm(inputs)?;
         Ok(proof)
     }
 

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -56,13 +56,16 @@ impl<VC> ContinuationProver<VC> {
         self
     }
 
-    pub fn generate_proof_for_evm(&self, input: StdIn) -> EvmProof
+    pub fn generate_proof_for_evm(&self, input: StdIn) -> eyre::Result<EvmProof>
     where
         VC: VmConfig<F>,
         VC::Executor: Chip<SC>,
         VC::Periphery: Chip<SC>,
     {
-        let root_proof = self.stark_prover.generate_proof_for_outer_recursion(input);
-        self.halo2_prover.prove_for_evm(&root_proof)
+        let root_proof = self
+            .stark_prover
+            .generate_proof_for_outer_recursion(input)?;
+        let evm_proof = self.halo2_prover.prove_for_evm(&root_proof);
+        Ok(evm_proof)
     }
 }


### PR DESCRIPTION
@nyunyunyunyu I wanted to verify the proofs after proving whenever there are multi-proofs so there can be early stopping. This was quite awkward to do with our current SDK. This PR is only partial and I'm not sure it's the right way to do it.