### PR TITLE
feat: remove deprecated #[clap] attribute

### DIFF
--- a/crates/cli/src/bin/cargo-openvm.rs
+++ b/crates/cli/src/bin/cargo-openvm.rs
@@ -17,7 +17,7 @@ pub enum Cargo {
 #[derive(clap::Args)]
 #[command(author, about, long_about = None, args_conflicts_with_subcommands = true, version = OPENVM_VERSION_MESSAGE)]
 pub struct VmCli {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: VmCliCommands,
 }
 

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -15,10 +15,10 @@ use crate::{
 #[derive(Parser)]
 #[command(name = "keygen", about = "Generate an application proving key")]
 pub struct KeygenCmd {
-    #[clap(long, action, help = "Path to app config TOML file", default_value = DEFAULT_APP_CONFIG_PATH)]
+    #[arg(long, action, help = "Path to app config TOML file", default_value = DEFAULT_APP_CONFIG_PATH)]
     config: PathBuf,
 
-    #[clap(
+    #[arg(
         long,
         action,
         help = "Path to output app proving key file",
@@ -26,7 +26,7 @@ pub struct KeygenCmd {
     )]
     output: PathBuf,
 
-    #[clap(
+    #[arg(
         long,
         action,
         help = "Path to output app verifying key file",

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -25,36 +25,36 @@ use crate::{
 #[derive(Parser)]
 #[command(name = "prove", about = "Generate a program proof")]
 pub struct ProveCmd {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: ProveSubCommand,
 }
 
 #[derive(Parser)]
 enum ProveSubCommand {
     App {
-        #[clap(long, action, help = "Path to app proving key", default_value = DEFAULT_APP_PK_PATH)]
+        #[arg(long, action, help = "Path to app proving key", default_value = DEFAULT_APP_PK_PATH)]
         app_pk: PathBuf,
 
-        #[clap(long, action, help = "Path to OpenVM executable", default_value = DEFAULT_APP_EXE_PATH)]
+        #[arg(long, action, help = "Path to OpenVM executable", default_value = DEFAULT_APP_EXE_PATH)]
         exe: PathBuf,
 
-        #[clap(long, value_parser, help = "Input to OpenVM program")]
+        #[arg(long, value_parser, help = "Input to OpenVM program")]
         input: Option<Input>,
 
-        #[clap(long, action, help = "Path to output proof", default_value = DEFAULT_APP_PROOF_PATH)]
+        #[arg(long, action, help = "Path to output proof", default_value = DEFAULT_APP_PROOF_PATH)]
         output: PathBuf,
     },
     Evm {
-        #[clap(long, action, help = "Path to app proving key", default_value = DEFAULT_APP_PK_PATH)]
+        #[arg(long, action, help = "Path to app proving key", default_value = DEFAULT_APP_PK_PATH)]
         app_pk: PathBuf,
 
-        #[clap(long, action, help = "Path to OpenVM executable", default_value = DEFAULT_APP_EXE_PATH)]
+        #[arg(long, action, help = "Path to OpenVM executable", default_value = DEFAULT_APP_EXE_PATH)]
         exe: PathBuf,
 
-        #[clap(long, value_parser, help = "Input to OpenVM program")]
+        #[arg(long, value_parser, help = "Input to OpenVM program")]
         input: Option<Input>,
 
-        #[clap(long, action, help = "Path to output proof", default_value = DEFAULT_EVM_PROOF_PATH)]
+        #[arg(long, action, help = "Path to output proof", default_value = DEFAULT_EVM_PROOF_PATH)]
         output: PathBuf,
     },
 }


### PR DESCRIPTION
updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.