### PR TITLE
fix: Don't segment if continuation is disabled

### DIFF
--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -331,6 +331,9 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
     ///
     /// Default config: switch if any runtime chip height exceeds 1<<20 - 100
     fn should_segment(&mut self) -> bool {
+        if !self.system_config().continuation_enabled {
+            return false;
+        }
         // Avoid checking segment too often.
         if self.since_last_segment_check != SEGMENT_CHECK_INTERVAL {
             self.since_last_segment_check += 1;


### PR DESCRIPTION
If continuation is disabled, VM runtime doesn't segment. This might cause a trace cannot be proven because of its height is too large but this is out of scope of VM runtime.