### PR TITLE
feat(all): remove deprecated #[clap] attribute

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -12,13 +12,13 @@ use crate::{
 #[derive(Parser)]
 #[command(name = "run", about = "Run an OpenVM program")]
 pub struct RunCmd {
-    #[clap(long, action, help = "Path to OpenVM executable", default_value = DEFAULT_APP_EXE_PATH)]
+    #[arg(long, action, help = "Path to OpenVM executable", default_value = DEFAULT_APP_EXE_PATH)]
     exe: PathBuf,
 
-    #[clap(long, action, help = "Path to app config TOML file", default_value = DEFAULT_APP_CONFIG_PATH)]
+    #[arg(long, action, help = "Path to app config TOML file", default_value = DEFAULT_APP_CONFIG_PATH)]
     config: PathBuf,
 
-    #[clap(long, value_parser, help = "Input to OpenVM program")]
+    #[arg(long, value_parser, help = "Input to OpenVM program")]
     input: Option<Input>,
 }
 

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -17,21 +17,21 @@ use crate::default::{
 #[derive(Parser)]
 #[command(name = "verify", about = "Verify a proof")]
 pub struct VerifyCmd {
-    #[clap(subcommand)]
+    #[arg(subcommand)]
     command: VerifySubCommand,
 }
 
 #[derive(Parser)]
 enum VerifySubCommand {
     App {
-        #[clap(long, action, help = "Path to app verifying key", default_value = DEFAULT_APP_VK_PATH)]
+        #[arg(long, action, help = "Path to app verifying key", default_value = DEFAULT_APP_VK_PATH)]
         app_vk: PathBuf,
 
-        #[clap(long, action, help = "Path to app proof", default_value = DEFAULT_APP_PROOF_PATH)]
+        #[arg(long, action, help = "Path to app proof", default_value = DEFAULT_APP_PROOF_PATH)]
         proof: PathBuf,
     },
     Evm {
-        #[clap(long, action, help = "Path to EVM proof", default_value = DEFAULT_EVM_PROOF_PATH)]
+        #[arg(long, action, help = "Path to EVM proof", default_value = DEFAULT_EVM_PROOF_PATH)]
         proof: PathBuf,
     },
 }

--- a/crates/sdk/src/bin/program_executor.rs
+++ b/crates/sdk/src/bin/program_executor.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 struct ExecutorArgs {
-    #[clap(long)]
+    #[arg(long)]
     program_dir: PathBuf,
     // input -> what type?
 }


### PR DESCRIPTION
follow up: https://github.com/openvm-org/openvm/pull/1443

Fix all warnings reported by `cargo check --features clap/deprecated`

```
warning: use of deprecated function `<ExecutorArgs as clap::Args>::augment_args::old_attribute`: Attribute `#[clap(...)]` has been deprecated in favor of `#[arg(...)]`
 --> crates/sdk/src/bin/program_executor.rs:7:7
  |
7 |     #[clap(long)]
  |       ^^^^
  |
  = note: `#[warn(deprecated)]` on by default
...
```