### PR TITLE
fix: add boolean checks for `count` in `AssertLessThan` and `IsLessThan`

### DIFF
--- a/crates/circuits/primitives/src/assert_less_than/mod.rs
+++ b/crates/circuits/primitives/src/assert_less_than/mod.rs
@@ -25,7 +25,7 @@ pub struct AssertLessThanIo<T> {
     /// Will only apply constraints when `count != 0`.
     /// Range checks are done with multiplicity `count`.
     /// If `count == 0` then no range checks are done.
-    /// In practice `count` is always boolean.
+    /// `count` is constrained to be boolean.
     ///
     /// N.B.: in fact range checks could always be done, if the aux
     /// subrow values are set to 0 when `count == 0`. This would slightly
@@ -119,9 +119,6 @@ impl AssertLtSubAir {
         // deg(intermed_val) = deg(io)
         let intermed_val = io.y - io.x - AB::Expr::ONE;
 
-        // `count` must be a boolean
-        builder.assert_bool(io.count.clone());
-
         // Construct lower from lower_decomp:
         // - each limb of lower_decomp will be range checked
         // deg(lower) = 1
@@ -147,6 +144,10 @@ impl AssertLtSubAir {
         count: impl Into<AB::Expr>,
     ) {
         let count = count.into();
+
+        // `count` must be a boolean
+        builder.assert_bool(count.clone());
+
         let mut bits_remaining = self.max_bits;
         // we range check the limbs of the lower_decomp so that we know each element
         // of lower_decomp has the correct number of bits

--- a/crates/circuits/primitives/src/assert_less_than/mod.rs
+++ b/crates/circuits/primitives/src/assert_less_than/mod.rs
@@ -25,8 +25,7 @@ pub struct AssertLessThanIo<T> {
     /// Will only apply constraints when `count != 0`.
     /// Range checks are done with multiplicity `count`.
     /// If `count == 0` then no range checks are done.
-    /// In practice `count` is always boolean, although this is not enforced
-    /// by the subair.
+    /// In practice `count` is always boolean.
     ///
     /// N.B.: in fact range checks could always be done, if the aux
     /// subrow values are set to 0 when `count == 0`. This would slightly
@@ -119,6 +118,9 @@ impl AssertLtSubAir {
         // this is the desired intermediate value (i.e. y - x - 1)
         // deg(intermed_val) = deg(io)
         let intermed_val = io.y - io.x - AB::Expr::ONE;
+
+        // `count` must be a boolean
+        builder.assert_bool(io.count.clone());
 
         // Construct lower from lower_decomp:
         // - each limb of lower_decomp will be range checked

--- a/crates/circuits/primitives/src/assert_less_than/tests.rs
+++ b/crates/circuits/primitives/src/assert_less_than/tests.rs
@@ -263,6 +263,10 @@ fn test_assert_less_than_with_negative_count() {
     row1.aux.lower_decomp[2] = BabyBear::from_canonical_u32(0);
     row1.aux.lower_decomp[3] = BabyBear::from_canonical_u32(0);
 
-    BabyBearPoseidon2Engine::run_simple_test_no_pis_fast(airs, vec![trace, range_trace])
-        .expect("Verification failed");
+    disable_debug_builder();
+    assert_eq!(
+        BabyBearPoseidon2Engine::run_simple_test_no_pis_fast(airs, vec![trace, range_trace],).err(),
+        Some(VerificationError::OodEvaluationMismatch),
+        "Expected verification to fail, but it passed"
+    );
 }

--- a/crates/circuits/primitives/src/is_less_than/mod.rs
+++ b/crates/circuits/primitives/src/is_less_than/mod.rs
@@ -27,8 +27,7 @@ pub struct IsLessThanIo<T> {
     pub out: T,
     /// Range checks are done with multiplicity `count`.
     /// If `count == 0` then no range checks are done.
-    /// In practice `count` is always boolean, although this is not enforced
-    /// by the subair.
+    /// `count` is constrained to be boolean.
     ///
     /// N.B.: in fact range checks could always be done, if the aux
     /// subrow values are set to 0 when `count == 0`. This would slightly
@@ -39,6 +38,7 @@ pub struct IsLessThanIo<T> {
     /// we currently use this more complex constraint.
     pub count: T,
 }
+
 impl<T> IsLessThanIo<T> {
     pub fn new(x: impl Into<T>, y: impl Into<T>, out: impl Into<T>, count: impl Into<T>) -> Self {
         Self {
@@ -148,6 +148,10 @@ impl IsLtSubAir {
         count: impl Into<AB::Expr>,
     ) {
         let count = count.into();
+
+        // `count` must be a boolean
+        builder.assert_bool(count.clone());
+
         let mut bits_remaining = self.max_bits;
         // we range check the limbs of the lower_decomp so that we know each element
         // of lower_decomp has the correct number of bits


### PR DESCRIPTION
Closes INT-3631

Added a boolean check of `count` in both subairs to make the constraints self contained and not depend on any input assumptions