### PR TITLE
fix: recursion max trace height check

### DIFF
--- a/extensions/native/recursion/src/vars.rs
+++ b/extensions/native/recursion/src/vars.rs
@@ -58,6 +58,7 @@ pub struct TraceHeightConstraintSystem<C: Config> {
     pub height_constraints: Vec<LinearConstraintVariable<C>>,
     /// Optional hard constraints on the height of each trace, derived from the above
     /// `height_constraints` to ensure that c_{ij} * a_j does not overflow the field.
+    /// `height` should be less than `height_max`.
     pub height_maxes: Array<C, OptionalVar<C>>,
 }
 

--- a/extensions/native/recursion/src/view.rs
+++ b/extensions/native/recursion/src/view.rs
@@ -87,7 +87,7 @@ pub fn get_advice_per_air<C: Config>(
         } else {
             OptionalVar {
                 is_some: Usize::from(1),
-                // Because `C::F::ORDER_U32 / max_coefficient * max_coefficient < C::F::ORDER_U32`,
+                // Because `C::F::ORDER_U32` is prime and `max_coefficient > 1`, `floor(C::F::ORDER_U32 / max_coefficient) * max_coefficient < C::F::ORDER_U32`,
                 // `height * max_coefficient` cannot overflow `C::F`.
                 value: builder.constant(C::N::from_canonical_u32(
                     C::F::ORDER_U32 / max_coefficient + 1,

--- a/extensions/native/recursion/src/view.rs
+++ b/extensions/native/recursion/src/view.rs
@@ -87,8 +87,11 @@ pub fn get_advice_per_air<C: Config>(
         } else {
             OptionalVar {
                 is_some: Usize::from(1),
-                value: builder
-                    .constant(C::N::from_canonical_u32(C::F::ORDER_U32 / max_coefficient)),
+                // Because `C::F::ORDER_U32 / max_coefficient * max_coefficient < C::F::ORDER_U32`,
+                // `height * max_coefficient` cannot overflow `C::F`.
+                value: builder.constant(C::N::from_canonical_u32(
+                    C::F::ORDER_U32 / max_coefficient + 1,
+                )),
             }
         };
         builder.set(&height_maxes, i, height_max);


### PR DESCRIPTION
[Here](https://github.com/openvm-org/openvm/blob/18096f4194b76b743463c0fb39955f24d010e9bf/extensions/native/recursion/src/view.rs#L91) sets `height_max` to `C::F::ORDER_U32 / max_coefficient`. 
Because we check `height < height_max`, `C::F::ORDER_U32 / max_coefficient` is a valid value for `height`.
`C::F::ORDER_U32 / max_coefficient * max_coefficient < C::F::ORDER_U32` because `C::F::ORDER_U32` is a prime and
`max_coefficient > 1`.

closes INT-3636