### PR TITLE
fix: ensure all `AlignedBorrow` cols use `repr(C)`

### DIFF
--- a/crates/circuits/primitives/src/range/tests/list/columns.rs
+++ b/crates/circuits/primitives/src/range/tests/list/columns.rs
@@ -3,6 +3,7 @@ use core::mem::{size_of, transmute};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::p3_util::indices_arr;
 
+#[repr(C)]
 #[derive(Default, AlignedBorrow)]
 pub struct ListCols<T> {
     pub val: T,

--- a/crates/circuits/primitives/src/range_gate/mod.rs
+++ b/crates/circuits/primitives/src/range_gate/mod.rs
@@ -23,6 +23,7 @@ pub use crate::range::RangeCheckBus;
 #[cfg(test)]
 mod tests;
 
+#[repr(C)]
 #[derive(Copy, Clone, Default, AlignedBorrow)]
 pub struct RangeGateCols<T> {
     /// Column with sequential values from 0 to range_max-1

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -8,6 +8,7 @@ use std::{
     sync::{atomic::AtomicU32, Arc},
 };
 
+use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
@@ -26,7 +27,8 @@ pub mod tests;
 
 pub use bus::*;
 
-#[derive(Default, Copy, Clone)]
+#[repr(C)]
+#[derive(Default, Copy, Clone, AlignedBorrow)]
 pub struct RangeTupleCols<T> {
     /// Number of range checks requested for each tuple combination
     pub mult: T,

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -46,6 +46,7 @@ pub struct PhantomAir {
     pub phantom_opcode: VmOpcode,
 }
 
+#[repr(C)]
 #[derive(AlignedBorrow, Copy, Clone, Serialize, Deserialize)]
 pub struct PhantomCols<T> {
     pub pc: T,


### PR DESCRIPTION
I have ensured that all `*Cols` structs that are stack allocatable, in other words all structs in the codebase that derive `AlignedBorrow`, have `repr(C)` for stable memory layout.

Closes INT-3477