### PR TITLE
feat: add #[repr(C)] to stack-allocated *Record structs

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,7 +22,7 @@ jobs:
   tests:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - family=m7a.48xlarge
+      - family=m7a.24xlarge
       - disk=large
       - extras=s3-cache
 

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -164,6 +164,7 @@ where
     }
 }
 
+#[repr(C)]
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct FieldExpressionRecord {

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -164,7 +164,6 @@ where
     }
 }
 
-#[repr(C)]
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct FieldExpressionRecord {

--- a/crates/toolchain/instructions/src/instruction.rs
+++ b/crates/toolchain/instructions/src/instruction.rs
@@ -7,6 +7,7 @@ use crate::{utils::isize_to_field, LocalOpcode, PhantomDiscriminant, SystemOpcod
 /// Number of operands of an instruction.
 pub const NUM_OPERANDS: usize = 7;
 
+#[repr(C)]
 #[allow(clippy::too_many_arguments)]
 #[derive(Clone, Debug, PartialEq, Eq, derive_new::new, Serialize, Deserialize)]
 pub struct Instruction<F> {

--- a/crates/toolchain/instructions/src/lib.rs
+++ b/crates/toolchain/instructions/src/lib.rs
@@ -29,6 +29,7 @@ pub trait LocalOpcode {
     }
 }
 
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, derive_new::new, Serialize, Deserialize)]
 pub struct VmOpcode(usize);
 

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -113,8 +113,8 @@ impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for Rc<RefCell<C>> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Default, AlignedBorrow, Serialize, Deserialize)]
 #[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Default, AlignedBorrow, Serialize, Deserialize)]
 pub struct ExecutionState<T> {
     pub pc: T,
     pub timestamp: T,

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -58,11 +58,13 @@ pub const MERKLE_AIR_OFFSET: usize = 1;
 /// The offset of the boundary AIR in AIRs of MemoryController.
 pub const BOUNDARY_AIR_OFFSET: usize = 0;
 
+#[repr(C)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct RecordId(pub usize);
 
 pub type MemoryImage<F> = AddressMap<F, PAGE_SIZE>;
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TimestampedValues<T, const N: usize> {
     pub timestamp: u32,

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -18,6 +18,7 @@ use crate::{
 
 pub const INITIAL_TIMESTAMP: u32 = 0;
 
+#[repr(C)]
 #[derive(Clone, Default, PartialEq, Eq, Debug)]
 struct BlockData {
     pointer: u32,

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -54,6 +54,7 @@ impl<F: PrimeField32, const R: usize, const W: usize> NativeAdapterChip<F, R, W>
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NativeReadRecord<F: Field, const R: usize> {
     #[serde(with = "BigArray")]
@@ -70,6 +71,7 @@ impl<F: Field, const R: usize> NativeReadRecord<F, R> {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct NativeWriteRecord<F: Field, const W: usize> {

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -98,6 +98,7 @@ impl<AB: InteractionBuilder + AirBuilderWithPublicValues> VmCoreAir<AB, AdapterI
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PublicValuesRecord<F> {
     value: F,

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -271,9 +271,9 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModularIsEqualCoreRecord<T, const READ_LIMBS: usize> {
-    pub is_setup: bool,
     #[serde(with = "BigArray")]
     pub b: [T; READ_LIMBS],
     #[serde(with = "BigArray")]
@@ -283,6 +283,7 @@ pub struct ModularIsEqualCoreRecord<T, const READ_LIMBS: usize> {
     pub eq_marker: [T; READ_LIMBS],
     pub b_diff_idx: usize,
     pub c_diff_idx: usize,
+    pub is_setup: bool,
 }
 
 pub struct ModularIsEqualCoreChip<

--- a/extensions/native/circuit/src/adapters/convert_adapter.rs
+++ b/extensions/native/circuit/src/adapters/convert_adapter.rs
@@ -28,12 +28,14 @@ use openvm_stark_backend::{
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VectorReadRecord<const NUM_READS: usize, const READ_SIZE: usize> {
     #[serde(with = "BigArray")]
     pub reads: [RecordId; NUM_READS],
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VectorWriteRecord<const WRITE_SIZE: usize> {
     pub from_state: ExecutionState<u32>,

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -73,6 +73,7 @@ impl<F: PrimeField32, const NUM_CELLS: usize> NativeLoadStoreAdapterChip<F, NUM_
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct NativeLoadStoreReadRecord<F: Field, const NUM_CELLS: usize> {
@@ -88,6 +89,7 @@ pub struct NativeLoadStoreReadRecord<F: Field, const NUM_CELLS: usize> {
     pub e: F,
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct NativeLoadStoreWriteRecord<F: Field, const NUM_CELLS: usize> {

--- a/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
@@ -50,12 +50,14 @@ impl<F: PrimeField32, const N: usize> NativeVectorizedAdapterChip<F, N> {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NativeVectorizedReadRecord<const N: usize> {
     pub b: RecordId,
     pub c: RecordId,
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NativeVectorizedWriteRecord<const N: usize> {
     pub from_state: ExecutionState<u32>,

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -103,6 +103,7 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CastFRecord<F> {
     pub in_val: F,

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -104,6 +104,7 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FieldArithmeticRecord<F> {
     pub opcode: FieldArithmeticOpcode,

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -132,6 +132,7 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FieldExtensionRecord<F> {
     pub opcode: FieldExtensionOpcode,

--- a/extensions/native/circuit/src/jal/mod.rs
+++ b/extensions/native/circuit/src/jal/mod.rs
@@ -150,6 +150,7 @@ impl JalRangeCheckAir {
     }
 }
 
+#[repr(C)]
 #[derive(Serialize, Deserialize)]
 pub struct JalRangeCheckRecord {
     pub state: ExecutionState<u32>,

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -34,6 +34,7 @@ pub struct NativeLoadStoreCoreCols<T, const NUM_CELLS: usize> {
     pub data: [T; NUM_CELLS],
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NativeLoadStoreCoreRecord<F, const NUM_CELLS: usize> {
     pub opcode: NativeLoadStoreOpcode,

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -24,6 +24,7 @@ use crate::poseidon2::{
     CHUNK,
 };
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct VerifyBatchRecord<F: Field> {
@@ -53,6 +54,7 @@ impl<F: PrimeField32> VerifyBatchRecord<F> {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct TopLevelRecord<F: Field> {
@@ -62,6 +64,7 @@ pub struct TopLevelRecord<F: Field> {
     pub incorporate_sibling: Option<IncorporateSiblingRecord<F>>,
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct IncorporateSiblingRecord<F: Field> {
@@ -70,6 +73,7 @@ pub struct IncorporateSiblingRecord<F: Field> {
     pub p2_input: [F; 2 * CHUNK],
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct IncorporateRowRecord<F: Field> {
@@ -81,6 +85,7 @@ pub struct IncorporateRowRecord<F: Field> {
     pub p2_input: [F; 2 * CHUNK],
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct InsideRowRecord<F: Field> {
@@ -88,6 +93,7 @@ pub struct InsideRowRecord<F: Field> {
     pub p2_input: [F; 2 * CHUNK],
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CellRecord {
     pub read: RecordId,
@@ -97,6 +103,7 @@ pub struct CellRecord {
     pub row_end: usize,
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct SimplePoseidonRecord<F: Field> {
@@ -117,6 +124,7 @@ pub struct SimplePoseidonRecord<F: Field> {
     pub p2_input: [F; 2 * CHUNK],
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(bound = "F: Field")]
 pub struct NativePoseidon2RecordSet<F: Field> {

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -24,7 +24,6 @@ use crate::poseidon2::{
     CHUNK,
 };
 
-#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct VerifyBatchRecord<F: Field> {
@@ -54,7 +53,6 @@ impl<F: PrimeField32> VerifyBatchRecord<F> {
     }
 }
 
-#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct TopLevelRecord<F: Field> {
@@ -73,7 +71,6 @@ pub struct IncorporateSiblingRecord<F: Field> {
     pub p2_input: [F; 2 * CHUNK],
 }
 
-#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct IncorporateRowRecord<F: Field> {
@@ -85,7 +82,6 @@ pub struct IncorporateRowRecord<F: Field> {
     pub p2_input: [F; 2 * CHUNK],
 }
 
-#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct InsideRowRecord<F: Field> {
@@ -124,7 +120,6 @@ pub struct SimplePoseidonRecord<F: Field> {
     pub p2_input: [F; 2 * CHUNK],
 }
 
-#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(bound = "F: Field")]
 pub struct NativePoseidon2RecordSet<F: Field> {

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -274,6 +274,7 @@ impl<
     }
 }
 
+#[repr(C)]
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Rv32IsEqualModReadRecord<
@@ -287,6 +288,7 @@ pub struct Rv32IsEqualModReadRecord<
     pub reads: [[RecordId; BLOCKS_PER_READ]; NUM_READS],
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Rv32IsEqualModWriteRecord {
     pub from_state: ExecutionState<u32>,

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -201,6 +201,7 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize>
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Rv32HeapBranchReadRecord<const NUM_READS: usize, const READ_SIZE: usize> {
     #[serde(with = "BigArray")]

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -97,6 +97,7 @@ impl<
     }
 }
 
+#[repr(C)]
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
@@ -118,6 +119,7 @@ pub struct Rv32VecHeapReadRecord<
     pub reads: [[RecordId; BLOCKS_PER_READ]; NUM_READS],
 }
 
+#[repr(C)]
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Rv32VecHeapWriteRecord<const BLOCKS_PER_WRITE: usize, const WRITE_SIZE: usize> {

--- a/extensions/rv32-adapters/src/vec_heap_two_reads.rs
+++ b/extensions/rv32-adapters/src/vec_heap_two_reads.rs
@@ -107,6 +107,7 @@ impl<
     }
 }
 
+#[repr(C)]
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
@@ -130,6 +131,7 @@ pub struct Rv32VecHeapTwoReadsReadRecord<
     pub reads2: [RecordId; BLOCKS_PER_READ2],
 }
 
+#[repr(C)]
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Rv32VecHeapTwoReadsWriteRecord<const BLOCKS_PER_WRITE: usize, const WRITE_SIZE: usize> {

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -64,6 +64,7 @@ impl<F: PrimeField32> Rv32BaseAluAdapterChip<F> {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct Rv32BaseAluReadRecord<F: Field> {
@@ -77,6 +78,7 @@ pub struct Rv32BaseAluReadRecord<F: Field> {
     pub rs2_imm: F,
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct Rv32BaseAluWriteRecord<F: Field> {

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -54,6 +54,7 @@ impl<F: PrimeField32> Rv32BranchAdapterChip<F> {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Rv32BranchReadRecord {
     /// Read register value from address space d = 1
@@ -62,6 +63,7 @@ pub struct Rv32BranchReadRecord {
     pub rs2: RecordId,
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Rv32BranchWriteRecord {
     pub from_state: ExecutionState<u32>,

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -53,11 +53,13 @@ impl<F: PrimeField32> Rv32JalrAdapterChip<F> {
         }
     }
 }
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Rv32JalrReadRecord {
     pub rs1: RecordId,
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Rv32JalrWriteRecord {
     pub from_state: ExecutionState<u32>,

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -121,28 +121,29 @@ impl<F: PrimeField32> Rv32LoadStoreAdapterChip<F> {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct Rv32LoadStoreReadRecord<F: Field> {
     pub rs1_record: RecordId,
-    pub rs1_ptr: F,
     /// This will be a read from a register in case of Stores and a read from RISC-V memory in case of Loads.
     pub read: RecordId,
-
+    pub rs1_ptr: F,
     pub imm: F,
     pub imm_sign: F,
-    pub mem_ptr_limbs: [u32; 2],
     pub mem_as: F,
+    pub mem_ptr_limbs: [u32; 2],
     pub shift_amount: u32,
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct Rv32LoadStoreWriteRecord<F: Field> {
-    pub from_state: ExecutionState<u32>,
     /// This will be a write to a register in case of Load and a write to RISC-V memory in case of Stores.
     /// For better struct packing, `RecordId(usize::MAX)` is used to indicate that there is no write.
     pub write_id: RecordId,
+    pub from_state: ExecutionState<u32>,
     pub rd_rs2_ptr: F,
 }
 

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -54,6 +54,7 @@ impl<F: PrimeField32> Rv32MultAdapterChip<F> {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Rv32MultReadRecord {
     /// Reads from operand registers
@@ -61,6 +62,7 @@ pub struct Rv32MultReadRecord {
     pub rs2: RecordId,
 }
 
+#[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Rv32MultWriteRecord {
     pub from_state: ExecutionState<u32>,

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -74,6 +74,7 @@ impl<F: PrimeField32> Rv32CondRdWriteAdapterChip<F> {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Rv32RdWriteWriteRecord {
     pub from_state: ExecutionState<u32>,

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -179,6 +179,7 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Rv32AuipcCoreRecord<F> {
     pub imm_limbs: [F; RV32_REGISTER_NUM_LIMBS - 1],

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -165,6 +165,7 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "T: Serialize + DeserializeOwned")]
 pub struct BaseAluCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -133,17 +133,18 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BranchEqualCoreRecord<T, const NUM_LIMBS: usize> {
-    pub opcode: BranchEqualOpcode,
     #[serde(with = "BigArray")]
     pub a: [T; NUM_LIMBS],
     #[serde(with = "BigArray")]
     pub b: [T; NUM_LIMBS],
     pub cmp_result: T,
     pub imm: T,
-    pub diff_idx: usize,
     pub diff_inv_val: T,
+    pub diff_idx: usize,
+    pub opcode: BranchEqualOpcode,
 }
 
 #[derive(Debug)]

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -186,9 +186,9 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BranchLessThanCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
-    pub opcode: BranchLessThanOpcode,
     #[serde(with = "BigArray")]
     pub a: [T; NUM_LIMBS],
     #[serde(with = "BigArray")]
@@ -200,6 +200,7 @@ pub struct BranchLessThanCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: 
     pub b_msb_f: T,
     pub diff_val: T,
     pub diff_idx: usize,
+    pub opcode: BranchLessThanOpcode,
 }
 
 pub struct BranchLessThanCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -379,10 +379,10 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> DivRemCoreChip<NUM_LIMBS, L
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "T: Serialize + DeserializeOwned")]
 pub struct DivRemCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
-    pub opcode: DivRemOpcode,
     #[serde(with = "BigArray")]
     pub b: [T; NUM_LIMBS],
     #[serde(with = "BigArray")]
@@ -405,6 +405,7 @@ pub struct DivRemCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub r_inv: [T; NUM_LIMBS],
     pub lt_diff_val: T,
     pub lt_diff_idx: usize,
+    pub opcode: DivRemOpcode,
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -139,6 +139,7 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct Rv32JalLuiCoreRecord<F: Field> {

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -46,6 +46,7 @@ pub struct Rv32JalrCoreCols<T> {
     pub imm_sign: T,
 }
 
+#[repr(C)]
 #[derive(Serialize, Deserialize)]
 pub struct Rv32JalrCoreRecord<F> {
     pub imm: F,

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -163,10 +163,10 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "T: Serialize + DeserializeOwned")]
 pub struct LessThanCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
-    pub opcode: LessThanOpcode,
     #[serde(with = "BigArray")]
     pub b: [T; NUM_LIMBS],
     #[serde(with = "BigArray")]
@@ -176,6 +176,7 @@ pub struct LessThanCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize>
     pub c_msb_f: T,
     pub diff_val: T,
     pub diff_idx: usize,
+    pub opcode: LessThanOpcode,
 }
 
 pub struct LessThanCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -45,16 +45,17 @@ pub struct LoadSignExtendCoreCols<T, const NUM_CELLS: usize> {
     pub prev_data: [T; NUM_CELLS],
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Serialize + DeserializeOwned")]
 pub struct LoadSignExtendCoreRecord<F, const NUM_CELLS: usize> {
-    pub opcode: Rv32LoadStoreOpcode,
-    pub most_sig_bit: bool,
     #[serde(with = "BigArray")]
     pub shifted_read_data: [F; NUM_CELLS],
     #[serde(with = "BigArray")]
     pub prev_data: [F; NUM_CELLS],
+    pub opcode: Rv32LoadStoreOpcode,
     pub shift_amount: u32,
+    pub most_sig_bit: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -56,6 +56,7 @@ pub struct LoadStoreCoreCols<T, const NUM_CELLS: usize> {
     pub write_data: [T; NUM_CELLS],
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "F: Serialize + DeserializeOwned")]
 pub struct LoadStoreCoreRecord<F, const NUM_CELLS: usize> {

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -140,6 +140,7 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> MultiplicationCoreChip<NUM_
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "T: Serialize + DeserializeOwned")]
 pub struct MultiplicationCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -219,6 +219,7 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> MulHCoreChip<NUM_LIMBS, LIM
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MulHCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub opcode: MulHOpcode,

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -237,21 +237,22 @@ where
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "T: Serialize + DeserializeOwned")]
 pub struct ShiftCoreRecord<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
-    pub opcode: ShiftOpcode,
     #[serde(with = "BigArray")]
     pub a: [T; NUM_LIMBS],
     #[serde(with = "BigArray")]
     pub b: [T; NUM_LIMBS],
     #[serde(with = "BigArray")]
     pub c: [T; NUM_LIMBS],
+    pub b_sign: T,
     #[serde(with = "BigArray")]
     pub bit_shift_carry: [u32; NUM_LIMBS],
     pub bit_shift: usize,
     pub limb_shift: usize,
-    pub b_sign: T,
+    pub opcode: ShiftOpcode,
 }
 
 pub struct ShiftCoreChip<const NUM_LIMBS: usize, const LIMB_BITS: usize> {


### PR DESCRIPTION
## Summary
- Add `#[repr(C)]` attribute to all structs with names ending in `Record` or `Records` that are entirely stack-allocated (contain no `Vec` fields or nested `Vec` fields)
- This ensures these structs can be safely transmuted to raw byte buffers for serialization and FFI purposes
- Reorganized a few struct fields for potentially better alignment (assuming `usize = u64` and `T = u32`)

## Test plan
Verify that there are no regressions in any tests that use these structs

🤖 Generated with [Claude Code](https://claude.ai/code) (only partially, much intervention was needed)

Closes INT-3525