### PR TITLE
chore: Add tests for some constants in the pairing extension

### DIFF
--- a/extensions/pairing/guest/src/bls12_381/pairing.rs
+++ b/extensions/pairing/guest/src/bls12_381/pairing.rs
@@ -15,7 +15,7 @@ use {
     openvm_rv32im_guest::hint_buffer_u32,
 };
 
-use super::{Bls12_381, Fp, Fp12, Fp2};
+use super::{Bls12_381, Fp, Fp12, Fp2, BLS12_381_PSEUDO_BINARY_ENCODING, BLS12_381_SEED_ABS};
 use crate::pairing::{
     exp_check_fallback, Evaluatable, EvaluatedLine, FromLineMType, LineMulMType, MillerStep,
     MultiMillerLoop, PairingCheck, PairingCheckError, PairingIntrinsics, UnevaluatedLine,
@@ -127,12 +127,8 @@ impl MultiMillerLoop for Bls12_381 {
     type Fp = Fp;
     type Fp12 = Fp12;
 
-    const SEED_ABS: u64 = 0xd201000000010000;
-    const PSEUDO_BINARY_ENCODING: &[i8] = &[
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
-        1, 0, 1, 1,
-    ];
+    const SEED_ABS: u64 = BLS12_381_SEED_ABS;
+    const PSEUDO_BINARY_ENCODING: &[i8] = &BLS12_381_PSEUDO_BINARY_ENCODING;
 
     fn evaluate_lines_vec(f: Self::Fp12, lines: Vec<EvaluatedLine<Self::Fp2>>) -> Self::Fp12 {
         let mut f = f;

--- a/extensions/pairing/guest/src/bls12_381/tests.rs
+++ b/extensions/pairing/guest/src/bls12_381/tests.rs
@@ -16,7 +16,8 @@ use crate::{
             convert_bls12381_halo2_fq2_to_fp2, convert_bls12381_halo2_fq_to_fp,
             convert_g2_affine_halo2_to_openvm,
         },
-        Bls12_381, G2Affine as OpenVmG2Affine,
+        Bls12_381, G2Affine as OpenVmG2Affine, BLS12_381_PSEUDO_BINARY_ENCODING,
+        BLS12_381_SEED_ABS,
     },
     pairing::{
         fp2_invert_assign, fp6_invert_assign, fp6_square_assign, FinalExp, MultiMillerLoop,
@@ -302,4 +303,15 @@ fn test_bls12381_pairing_check_hint_host() {
 fn test_bls12381_final_exponent() {
     let final_exp = (BLS12_381_MODULUS.pow(12) - BigUint::one()) / BLS12_381_ORDER.clone();
     assert_eq!(Bls12_381::FINAL_EXPONENT.to_vec(), final_exp.to_bytes_be());
+}
+
+#[test]
+fn test_bls12381_pseudo_binary_encoding() {
+    let mut x: i128 = 0;
+    let mut power_of_2 = 1;
+    for b in BLS12_381_PSEUDO_BINARY_ENCODING.iter() {
+        x += (*b as i128) * power_of_2;
+        power_of_2 *= 2;
+    }
+    assert_eq!(x.unsigned_abs(), BLS12_381_SEED_ABS as u128);
 }

--- a/extensions/pairing/guest/src/bn254/mod.rs
+++ b/extensions/pairing/guest/src/bn254/mod.rs
@@ -132,6 +132,14 @@ mod g2 {
     );
     impl_sw_affine!(G2Affine, Fp2, THREE, B);
     impl_sw_group_ops!(G2Affine, Fp2);
+
+    #[test]
+    fn test_g2_curve_equation_b() {
+        use openvm_algebra_guest::DivUnsafe;
+        let b = Fp2::new(Fp::from_const_u8(3), Fp::ZERO)
+            .div_unsafe(Fp2::new(Fp::from_const_u8(9), Fp::ONE));
+        assert_eq!(b, B);
+    }
 }
 
 pub struct Bn254;

--- a/extensions/pairing/guest/src/bn254/pairing.rs
+++ b/extensions/pairing/guest/src/bn254/pairing.rs
@@ -11,7 +11,7 @@ use {
     openvm_rv32im_guest::hint_buffer_u32,
 };
 
-use super::{Bn254, Fp, Fp12, Fp2};
+use super::{Bn254, Fp, Fp12, Fp2, BN254_PSEUDO_BINARY_ENCODING, BN254_SEED};
 use crate::pairing::{
     exp_check_fallback, Evaluatable, EvaluatedLine, FromLineDType, LineMulDType, MillerStep,
     MultiMillerLoop, PairingCheck, PairingCheckError, PairingIntrinsics, UnevaluatedLine,
@@ -129,12 +129,8 @@ impl MultiMillerLoop for Bn254 {
     type Fp = Fp;
     type Fp12 = Fp12;
 
-    const SEED_ABS: u64 = 0x44e992b44a6909f1;
-    const PSEUDO_BINARY_ENCODING: &[i8] = &[
-        0, 0, 0, 1, 0, 1, 0, -1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1, 0, -1, 0, 0, 0, 1, 0, -1, 0, 0, 0,
-        0, -1, 0, 0, 1, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0, 1, 0, -1, 0, 0, 0, -1, 0,
-        -1, 0, 0, 0, 1, 0, -1, 0, 1,
-    ];
+    const SEED_ABS: u64 = BN254_SEED;
+    const PSEUDO_BINARY_ENCODING: &[i8] = &BN254_PSEUDO_BINARY_ENCODING;
 
     fn evaluate_lines_vec(f: Self::Fp12, lines: Vec<EvaluatedLine<Self::Fp2>>) -> Self::Fp12 {
         let mut f = f;

--- a/extensions/pairing/guest/src/bn254/tests.rs
+++ b/extensions/pairing/guest/src/bn254/tests.rs
@@ -1,7 +1,7 @@
 use group::{ff::Field, prime::PrimeCurveAffine};
 use halo2curves_axiom::bn256::{
     Fq, Fq12, Fq2, Fq6, G1Affine, G2Affine, G2Prepared, Gt, FROBENIUS_COEFF_FQ12_C1,
-    FROBENIUS_COEFF_FQ6_C1,
+    FROBENIUS_COEFF_FQ6_C1, XI_TO_Q_MINUS_1_OVER_2,
 };
 use num_bigint::BigUint;
 use num_traits::One;
@@ -18,6 +18,7 @@ use crate::{
             convert_g2_affine_halo2_to_openvm,
         },
         Bn254, G2Affine as OpenVmG2Affine, BN254_MODULUS, BN254_ORDER,
+        BN254_PSEUDO_BINARY_ENCODING, BN254_SEED,
     },
     pairing::{
         fp2_invert_assign, fp6_invert_assign, fp6_square_assign, FinalExp, MultiMillerLoop,
@@ -301,4 +302,24 @@ fn test_bn254_frobenius_coeffs_fq6() {
             i,
         )
     }
+}
+
+#[test]
+fn test_bn254_pseudo_binary_encoding() {
+    let mut x: i128 = 0;
+    let mut power_of_2 = 1;
+    for b in BN254_PSEUDO_BINARY_ENCODING.iter() {
+        x += (*b as i128) * power_of_2;
+        power_of_2 *= 2;
+    }
+    assert_eq!(x.unsigned_abs(), 6 * (BN254_SEED as u128) + 2);
+}
+
+#[test]
+fn test_bn254_xi_to_q_minus_1_over_2() {
+    assert_eq!(
+        Bn254::XI_TO_Q_MINUS_1_OVER_2,
+        convert_bn254_halo2_fq2_to_fp2(XI_TO_Q_MINUS_1_OVER_2),
+        "XI_TO_Q_MINUS_1_OVER_2 failed",
+    )
 }


### PR DESCRIPTION
As part of the pairing internal security review, I found some unvalidated constants so I'm adding tests for them here.