### PR TITLE
fix: constrain `pc` to be same for intermediate keccak rows

### DIFF
--- a/extensions/keccak256/circuit/src/air.rs
+++ b/extensions/keccak256/circuit/src/air.rs
@@ -132,6 +132,7 @@ impl KeccakVmAir {
         // then we want _parts_ of opcode instruction to stay the same
         // between blocks.
         let mut block_transition = builder.when(local.is_last_round() * not(next.is_new_start()));
+        block_transition.assert_eq(local.instruction.pc, next.instruction.pc);
         block_transition.assert_eq(local.instruction.is_enabled, next.instruction.is_enabled);
         // dst is only going to be used for writes in the last input block
         assert_array_eq(

--- a/extensions/keccak256/circuit/src/columns.rs
+++ b/extensions/keccak256/circuit/src/columns.rs
@@ -133,6 +133,7 @@ impl<T: Copy> KeccakInstructionCols<T> {
     where
         T: Into<AB::Expr>,
     {
+        builder.assert_eq(self.pc, other.pc);
         builder.assert_eq(self.is_enabled, other.is_enabled);
         builder.assert_eq(self.start_timestamp, other.start_timestamp);
         builder.assert_eq(self.dst_ptr, other.dst_ptr);


### PR DESCRIPTION
Closes INT-3648