### PR TITLE
fix: completeness of ModBuilder trace generation

### DIFF
--- a/crates/circuits/mod-builder/src/field_variable.rs
+++ b/crates/circuits/mod-builder/src/field_variable.rs
@@ -78,8 +78,12 @@ impl FieldVariable {
             Box::new(expr),
             Box::new(SymbolicExpr::Var(builder.num_variables)),
         );
-        let (q_limbs, _) =
-            constraint_expr.constraint_limbs(&builder.prime, builder.limb_bits, builder.num_limbs);
+        let (q_limbs, _) = constraint_expr.constraint_limbs(
+            &builder.prime,
+            builder.limb_bits,
+            builder.num_limbs,
+            builder.proper_max(),
+        );
         q_limbs
     }
 
@@ -263,6 +267,7 @@ impl FieldVariable {
         let prime = builder.prime.clone();
         let limb_bits = builder.limb_bits;
         let num_limbs = builder.num_limbs;
+        let proper_max = builder.proper_max().clone();
         drop(builder);
 
         // This is a dummy variable, will be replaced later so the index within it doesn't matter.
@@ -277,7 +282,8 @@ impl FieldVariable {
             )),
             Box::new(self.expr.clone()),
         );
-        let carry_bits = new_constraint.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs);
+        let carry_bits =
+            new_constraint.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs, &proper_max);
         if carry_bits > self.range_checker_bits {
             self.save();
         }
@@ -289,7 +295,8 @@ impl FieldVariable {
             )),
             Box::new(self.expr.clone()),
         );
-        let carry_bits = new_constraint.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs);
+        let carry_bits =
+            new_constraint.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs, &proper_max);
         if carry_bits > self.range_checker_bits {
             other.save();
         }

--- a/crates/circuits/mod-builder/src/symbolic_expr.rs
+++ b/crates/circuits/mod-builder/src/symbolic_expr.rs
@@ -190,26 +190,26 @@ impl SymbolicExpr {
     /// Returns maximum absolute positive and negative value of the expression.
     /// That is, if `(r, l) = expr.max_abs(p)` then `l,r >= 0` and `-l <= expr <= r`.
     /// Needed in `constraint_limbs` to estimate the number of limbs of q.
-    fn max_abs(&self, prime: &BigUint) -> (BigUint, BigUint) {
+    ///
+    /// It is assumed that any `Input` or `Var` is a non-negative big integer with value
+    /// in the range `[0, proper_max]`.
+    fn max_abs(&self, proper_max: &BigUint) -> (BigUint, BigUint) {
         match self {
-            SymbolicExpr::Input(_) | SymbolicExpr::Var(_) => {
-                // Input and variable are field elements so are in [0, p)
-                (prime.clone() - BigUint::one(), BigUint::zero())
-            }
+            SymbolicExpr::Input(_) | SymbolicExpr::Var(_) => (proper_max.clone(), BigUint::zero()),
             SymbolicExpr::Const(_, val, _) => (val.clone(), BigUint::zero()),
             SymbolicExpr::Add(lhs, rhs) => {
-                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(prime);
-                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(prime);
+                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(proper_max);
+                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(proper_max);
                 (lhs_max_pos + rhs_max_pos, lhs_max_neg + rhs_max_neg)
             }
             SymbolicExpr::Sub(lhs, rhs) => {
-                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(prime);
-                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(prime);
+                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(proper_max);
+                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(proper_max);
                 (lhs_max_pos + rhs_max_neg, lhs_max_neg + rhs_max_pos)
             }
             SymbolicExpr::Mul(lhs, rhs) => {
-                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(prime);
-                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(prime);
+                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(proper_max);
+                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(proper_max);
                 (
                     max(&lhs_max_pos * &rhs_max_pos, &lhs_max_neg * &rhs_max_neg),
                     max(&lhs_max_pos * &rhs_max_neg, &lhs_max_neg * &rhs_max_pos),
@@ -220,13 +220,13 @@ impl SymbolicExpr {
                 unreachable!()
             }
             SymbolicExpr::IntAdd(lhs, s) => {
-                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(prime);
+                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(proper_max);
                 let scalar = BigUint::from_usize(s.unsigned_abs()).unwrap();
                 // Optimization opportunity: since `s` is a constant, we can likely do better than this bound.
                 (lhs_max_pos + &scalar, lhs_max_neg + &scalar)
             }
             SymbolicExpr::IntMul(lhs, s) => {
-                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(prime);
+                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(proper_max);
                 let scalar = BigUint::from_usize(s.unsigned_abs()).unwrap();
                 if *s < 0 {
                     (lhs_max_neg * &scalar, lhs_max_pos * &scalar)
@@ -235,8 +235,8 @@ impl SymbolicExpr {
                 }
             }
             SymbolicExpr::Select(_, lhs, rhs) => {
-                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(prime);
-                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(prime);
+                let (lhs_max_pos, lhs_max_neg) = lhs.max_abs(proper_max);
+                let (rhs_max_pos, rhs_max_neg) = rhs.max_abs(proper_max);
                 (max(lhs_max_pos, rhs_max_pos), max(lhs_max_neg, rhs_max_neg))
             }
         }
@@ -281,14 +281,17 @@ impl SymbolicExpr {
 
     /// Returns the maximum possible size, in bits, of each carry in `self.expr - q * p`.
     /// self should be a constraint expr.
+    ///
+    /// The cached value `proper_max` should equal `2^{limb_bits * num_limbs} - 1`.
     pub fn constraint_carry_bits_with_pq(
         &self,
         prime: &BigUint,
         limb_bits: usize,
         num_limbs: usize,
+        proper_max: &BigUint,
     ) -> usize {
         let without_pq = self.constraint_limb_max_abs(limb_bits, num_limbs);
-        let (q_limbs, _) = self.constraint_limbs(prime, limb_bits, num_limbs);
+        let (q_limbs, _) = self.constraint_limbs(prime, limb_bits, num_limbs, proper_max);
         let canonical_limb_max_abs = (1 << limb_bits) - 1;
         let limb_max_abs =
             without_pq + canonical_limb_max_abs * canonical_limb_max_abs * min(q_limbs, num_limbs);
@@ -327,23 +330,30 @@ impl SymbolicExpr {
     /// Returns (q_limbs, carry_limbs) where q_limbs is the number of limbs in q
     /// and carry_limbs is the number of limbs in the carry of the constraint self.expr - q * p = 0.
     /// self should be a constraint expression.
+    ///
+    /// The cached value `proper_max` should equal `2^{limb_bits * num_limbs} - 1`.
     pub fn constraint_limbs(
         &self,
         prime: &BigUint,
         limb_bits: usize,
         num_limbs: usize,
+        proper_max: &BigUint,
     ) -> (usize, usize) {
-        let (max_pos_abs, max_neg_abs) = self.max_abs(prime);
+        println!("{}", self);
+        let (max_pos_abs, max_neg_abs) = self.max_abs(proper_max);
         let max_abs = max(max_pos_abs, max_neg_abs);
         let max_q_abs = (&max_abs + prime - BigUint::one()) / prime;
         let q_bits = max_q_abs.bits() as usize;
         let p_bits = prime.bits() as usize;
         let q_limbs = q_bits.div_ceil(limb_bits);
+        // Attention! This must match with prime_overflow in `FieldExpr::generate_subrow`
         let p_limbs = p_bits.div_ceil(limb_bits);
         let qp_limbs = q_limbs + p_limbs - 1;
 
         let expr_limbs = self.expr_limbs(num_limbs);
+        println!("expr_limbs={}", expr_limbs);
         let carry_limbs = max(expr_limbs, qp_limbs);
+        println!("qp_limbs={}", qp_limbs);
         (q_limbs, carry_limbs)
     }
 

--- a/crates/circuits/mod-builder/src/symbolic_expr.rs
+++ b/crates/circuits/mod-builder/src/symbolic_expr.rs
@@ -339,7 +339,6 @@ impl SymbolicExpr {
         num_limbs: usize,
         proper_max: &BigUint,
     ) -> (usize, usize) {
-        println!("{}", self);
         let (max_pos_abs, max_neg_abs) = self.max_abs(proper_max);
         let max_abs = max(max_pos_abs, max_neg_abs);
         let max_q_abs = (&max_abs + prime - BigUint::one()) / prime;
@@ -351,9 +350,7 @@ impl SymbolicExpr {
         let qp_limbs = q_limbs + p_limbs - 1;
 
         let expr_limbs = self.expr_limbs(num_limbs);
-        println!("expr_limbs={}", expr_limbs);
         let carry_limbs = max(expr_limbs, qp_limbs);
-        println!("qp_limbs={}", qp_limbs);
         (q_limbs, carry_limbs)
     }
 

--- a/crates/circuits/mod-builder/src/tests.rs
+++ b/crates/circuits/mod-builder/src/tests.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use num_bigint::BigUint;
+use num_traits::One;
 use openvm_circuit_primitives::{bigint::utils::*, TraceSubRowGenerator};
 use openvm_stark_backend::{
     p3_air::BaseAir, p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix,
@@ -344,7 +345,12 @@ fn test_select2() {
 
 fn test_symbolic_limbs(expr: SymbolicExpr, expected_q: usize, expected_carry: usize) {
     let prime = secp256k1_coord_prime();
-    let (q, carry) = expr.constraint_limbs(&prime, LIMB_BITS, 32);
+    let (q, carry) = expr.constraint_limbs(
+        &prime,
+        LIMB_BITS,
+        32,
+        &((BigUint::one() << 256) - BigUint::one()),
+    );
     assert_eq!(q, expected_q);
     assert_eq!(carry, expected_carry);
 }

--- a/extensions/algebra/circuit/src/fp2.rs
+++ b/extensions/algebra/circuit/src/fp2.rs
@@ -69,6 +69,7 @@ impl Fp2 {
         let prime = builder.prime.clone();
         let limb_bits = builder.limb_bits;
         let num_limbs = builder.num_limbs;
+        let proper_max = builder.proper_max().clone();
         drop(builder);
 
         // These are dummy variables, will be replaced later so the index within it doesn't matter.
@@ -95,24 +96,28 @@ impl Fp2 {
 
         // Constraint 1: x0 = y0*z0 - y1*z1
         let constraint1 = &self.c0.expr - &other.c0.expr * &fake_z0 + &other.c1.expr * &fake_z1;
-        let carry_bits = constraint1.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs);
+        let carry_bits =
+            constraint1.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs, &proper_max);
         if carry_bits > self.c0.range_checker_bits {
             self.save();
         }
         let constraint1 = &self.c0.expr - &other.c0.expr * &fake_z0 + &other.c1.expr * &fake_z1;
-        let carry_bits = constraint1.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs);
+        let carry_bits =
+            constraint1.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs, &proper_max);
         if carry_bits > self.c0.range_checker_bits {
             other.save();
         }
 
         // Constraint 2: x1 = y1*z0 + y0*z1
         let constraint2 = &self.c1.expr - &other.c1.expr * &fake_z0 - &other.c0.expr * &fake_z1;
-        let carry_bits = constraint2.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs);
+        let carry_bits =
+            constraint2.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs, &proper_max);
         if carry_bits > self.c0.range_checker_bits {
             self.save();
         }
         let constraint2 = &self.c1.expr - &other.c1.expr * &fake_z0 - &other.c0.expr * &fake_z1;
-        let carry_bits = constraint2.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs);
+        let carry_bits =
+            constraint2.constraint_carry_bits_with_pq(&prime, limb_bits, num_limbs, &proper_max);
         if carry_bits > self.c0.range_checker_bits {
             other.save();
         }

--- a/extensions/algebra/tests/programs/examples/moduli_setup.rs
+++ b/extensions/algebra/tests/programs/examples/moduli_setup.rs
@@ -42,7 +42,7 @@ pub fn main() {
     let reduced = &non_reduced + &Mersenne61::ZERO;
     reduced.assert_reduced();
 
-    // assert_eq!(&non_reduced + &non_reduced, reduced.double());
+    assert_eq!(&non_reduced + &non_reduced, reduced.double());
 
     non_reduced = Mersenne61::from_le_bytes(&Mersenne61::MODULUS);
     assert!(!non_reduced.is_reduced());

--- a/extensions/algebra/tests/programs/examples/moduli_setup.rs
+++ b/extensions/algebra/tests/programs/examples/moduli_setup.rs
@@ -39,6 +39,10 @@ pub fn main() {
 
     let mut non_reduced = Mersenne61::from_le_bytes(&[0xff; 32]);
     assert!(!non_reduced.is_reduced());
+    let reduced = &non_reduced + &Mersenne61::ZERO;
+    reduced.assert_reduced();
+
+    // assert_eq!(&non_reduced + &non_reduced, reduced.double());
 
     non_reduced = Mersenne61::from_le_bytes(&Mersenne61::MODULUS);
     assert!(!non_reduced.is_reduced());


### PR DESCRIPTION
Previously the trace generation for ModBuilder was not calculating the number of limbs necessary in a way consistent with the constraints. This was because there were some underestimates when the prime is much smaller than $`2^\textrm{num\_limbs * limb\_bits}`$. We fix it by updating all calculations to use the theoretical bound that an input or saved var have big integer value in $`[0, 2^\text{num\_limbs * limb\_bits})`$ rather than $[0, p)$.

This causes no soundness bugs, but it does affect completeness of tracegen.

closes INT-3641