### PR TITLE
docs: update specs on misaligned RV32 access not allowed

### DIFF
--- a/docs/specs/ISA.md
+++ b/docs/specs/ISA.md
@@ -332,9 +332,9 @@ We will use shorthand `r32{c,g}(b) := i32([b:4]_1) + sign_extend(decompose(c)[0:
 signed 32-bit addition with the value of the register `[b:4]_1`. For consistency with other notation,
 we define the shorthand `r32{c}(b)` to mean `r32{c,g}(b)` where `g` is set to the most significant bit of `c`.
 Memory access to `ptr: i32` in address space `e` is only valid if `0 <= ptr < 2^addr_max_bits` and
-`ptr` is naturally aligned (i.e., `ptr` must be divisible by the size of the access in bytes), in
+`ptr` is naturally aligned (i.e., `ptr` must be divisible by the data size in bytes), in
 which case it is an access to `F::from_canonical_u32(ptr as u32)`.
-The size of the access is `1` for LOADB_RV32, LOADBU_RV32, STOREB_RV32, `2` for LOADH_RV32, LOADHU_RV32, STOREH_RV32, and `4` for LOADW_RV32, STOREW_RV32.
+The data size is `1` for LOADB_RV32, LOADBU_RV32, STOREB_RV32, `2` for LOADH_RV32, LOADHU_RV32, STOREH_RV32, and `4` for LOADW_RV32, STOREW_RV32.
 
 All load/store instructions always do block accesses of block size `4`, even for LOADB_RV32 and STOREB_RV32.
 

--- a/docs/specs/ISA.md
+++ b/docs/specs/ISA.md
@@ -331,8 +331,10 @@ the 32 bits as the 2's complement of an `i32`.
 We will use shorthand `r32{c,g}(b) := i32([b:4]_1) + sign_extend(decompose(c)[0:2], g)` as `i32`. This means performing
 signed 32-bit addition with the value of the register `[b:4]_1`. For consistency with other notation,
 we define the shorthand `r32{c}(b)` to mean `r32{c,g}(b)` where `g` is set to the most significant bit of `c`.
-Memory access to `ptr: i32` is only valid if `0 <= ptr < 2^addr_max_bits` and the access is aligned to the data size, in
+Memory access to `ptr: i32` is only valid if `0 <= ptr < 2^addr_max_bits`, in
 which case it is an access to `F::from_canonical_u32(ptr as u32)`.
+The load/store instructions do not require any alignment assumptions on `ptr` (i.e., `ptr` does not need to be a multiple of the memory access size in bytes) -- execution will proceed regardless.
+However, misaligned memory accesses _may_ slow down execution.
 
 All load/store instructions always do block accesses of block size `4`, even for LOADB_RV32 and STOREB_RV32.
 

--- a/docs/specs/ISA.md
+++ b/docs/specs/ISA.md
@@ -331,10 +331,10 @@ the 32 bits as the 2's complement of an `i32`.
 We will use shorthand `r32{c,g}(b) := i32([b:4]_1) + sign_extend(decompose(c)[0:2], g)` as `i32`. This means performing
 signed 32-bit addition with the value of the register `[b:4]_1`. For consistency with other notation,
 we define the shorthand `r32{c}(b)` to mean `r32{c,g}(b)` where `g` is set to the most significant bit of `c`.
-Memory access to `ptr: i32` is only valid if `0 <= ptr < 2^addr_max_bits`, in
+Memory access to `ptr: i32` in address space `e` is only valid if `0 <= ptr < 2^addr_max_bits` and
+`ptr` is naturally aligned (i.e., `ptr` must be divisible by the size of the access in bytes), in
 which case it is an access to `F::from_canonical_u32(ptr as u32)`.
-The load/store instructions do not require any alignment assumptions on `ptr` (i.e., `ptr` does not need to be a multiple of the memory access size in bytes) -- execution will proceed regardless.
-However, misaligned memory accesses _may_ slow down execution.
+The size of the access is `1` for LOADB_RV32, LOADBU_RV32, STOREB_RV32, `2` for LOADH_RV32, LOADHU_RV32, STOREH_RV32, and `4` for LOADW_RV32, STOREW_RV32.
 
 All load/store instructions always do block accesses of block size `4`, even for LOADB_RV32 and STOREB_RV32.
 

--- a/docs/specs/RISCV.md
+++ b/docs/specs/RISCV.md
@@ -36,6 +36,16 @@ We now specify the custom instructions for the default set of VM extensions.
 
 ## RV32IM Extension
 
+The RV32IM extension supports the RV32I Base Integer Instruction Set, Version 2.1 with `XLEN=32`
+and the "M" Extension for Integer Multiplication and Division, Version 2.0 with `XLEN=32`, following
+the specification of the [RISC-V Instruction Set Manual Volume I: Unprivileged ISA](https://lf-riscv.atlassian.net/wiki/spaces/HOME/pages/16154769/RISC-V+Technical+Specifications) (Version 20240411).
+
+**Memory Alignment**: Chapter 2.6 of _loc. cit._ specifies that the behavior of
+loads and stores whose effective addresses are not naturally aligned to the referenced datatype
+(i.e., the effective address is not divisible by the size of the access in bytes) depends on the
+execution environment interface (EEI). The OpenVM execution environment guarantees that misaligned
+loads and store are fully supported, so execution of the instruction will never fail due to issues of alignment. However aligned memory accesses are _preferred_, and misaligned accesses may result in slower execution.
+
 In addition to the standard RV32IM opcodes, we support the following additional instructions to handle system interactions
 
 | RISC-V Inst | FMT | opcode[6:0] | funct3 | imm[0:11] | RISC-V description and notes                                                                                                                                               |

--- a/docs/specs/RISCV.md
+++ b/docs/specs/RISCV.md
@@ -43,8 +43,9 @@ the specification of the [RISC-V Instruction Set Manual Volume I: Unprivileged I
 **Memory Alignment**: Chapter 2.6 of _loc. cit._ specifies that the behavior of
 loads and stores whose effective addresses are not naturally aligned to the referenced datatype
 (i.e., the effective address is not divisible by the size of the access in bytes) depends on the
-execution environment interface (EEI). The OpenVM execution environment guarantees that misaligned
-loads and store are fully supported, so execution of the instruction will never fail due to issues of alignment. However aligned memory accesses are _preferred_, and misaligned accesses may result in slower execution.
+execution environment interface (EEI). The OpenVM execution environment does not support misaligned
+loads and stores. More specifically, guest execution considers misaligned accesses invalid
+and host execution will raise an exception resulting in a fatal trap.
 
 In addition to the standard RV32IM opcodes, we support the following additional instructions to handle system interactions
 

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -285,7 +285,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
             .when(not::<AB::Expr>(is_valid.clone()))
             .assert_zero(local_cols.mem_as);
 
-        // read_as is 2 for loads and 1 for stores
+        // read_as is [local_cols.mem_as] for loads and 1 for stores
         let read_as = select::<AB::Expr>(
             is_load.clone(),
             local_cols.mem_as,
@@ -310,7 +310,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
 
         let write_aux_cols = MemoryWriteAuxCols::from_base(local_cols.write_base_aux, ctx.reads.0);
 
-        // write_as is 1 for loads and 2 for stores
+        // write_as is 1 for loads and [local_cols.mem_as] for stores
         let write_as = select::<AB::Expr>(
             is_load.clone(),
             AB::F::from_canonical_u32(RV32_REGISTER_AS),

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -399,22 +399,7 @@ impl<F: PrimeField32> VmAdapterChip<F> for Rv32LoadStoreAdapterChip<F> {
         let imm_extended = imm + imm_sign * 0xffff0000;
 
         let ptr_val = rs1_val.wrapping_add(imm_extended);
-        // Memory access at un-aligned addresses (i.e., addresses not divisible by the access size)
-        // are supported, but we will shift if possible to do an aligned access when possible
-        // No matter the access size (1, 2, 4), the block access is always size 4
-        let shift_amount = match local_opcode {
-            LOADW | STOREW => 0, // access size 4, not allowed to shift
-            LOADH | LOADHU | STOREH => {
-                // access size 2, can shift either 0 or 2
-                // if ptr_val is 0 or 2 (mod 4), this will shift to a multiple of 4.
-                // otherwise it will shift by 2 if ptr_val = 3 (mod 4) but still have bad alignment
-                ptr_val & 0b10
-            }
-            LOADB | LOADBU | STOREB => {
-                // best to do an aligned block access at ptr_val - ptr_val % 4
-                ptr_val & 0b11
-            }
-        };
+        let shift_amount = ptr_val % 4;
         assert!(
             ptr_val < (1 << self.air.pointer_max_bits),
             "ptr_val: {ptr_val} = rs1_val: {rs1_val} + imm_extended: {imm_extended} >= 2 ** {}",

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -307,7 +307,9 @@ pub(super) fn run_write_data_sign_extend<
             }
             write_data[0] = read_data[shift];
         }
-        _ => unreachable!("memory block access shift miscalculation: {opcode:?}, shift: {shift}"),
+        _ => unreachable!(
+            "unaligned memory access not supported by this execution environment: {opcode:?}, shift: {shift}"
+        ),
     };
     write_data
 }

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -307,6 +307,9 @@ pub(super) fn run_write_data_sign_extend<
             }
             write_data[0] = read_data[shift];
         }
+        // Currently the adapter AIR requires `ptr_val` to be aligned to the data size in bytes.
+        // The circuit requires that `shift = ptr_val % 4` so that `ptr_val - shift` is a multiple of 4.
+        // This requirement is non-trivial to remove, because we use it to ensure that `ptr_val - shift + 4 <= 2^pointer_max_bits`.
         _ => unreachable!(
             "unaligned memory access not supported by this execution environment: {opcode:?}, shift: {shift}"
         ),

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -307,7 +307,7 @@ pub(super) fn run_write_data_sign_extend<
             }
             write_data[0] = read_data[shift];
         }
-        _ => unreachable!(),
+        _ => unreachable!("memory block access shift miscalculation: {opcode:?}, shift: {shift}"),
     };
     write_data
 }

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -374,6 +374,9 @@ pub(super) fn run_write_data<F: PrimeField32, const NUM_CELLS: usize>(
             write_data[shift..(NUM_CELLS / 2 + shift)]
                 .copy_from_slice(&read_data[..(NUM_CELLS / 2)]);
         }
+        // Currently the adapter AIR requires `ptr_val` to be aligned to the data size in bytes.
+        // The circuit requires that `shift = ptr_val % 4` so that `ptr_val - shift` is a multiple of 4.
+        // This requirement is non-trivial to remove, because we use it to ensure that `ptr_val - shift + 4 <= 2^pointer_max_bits`.
         _ => unreachable!(
             "unaligned memory access not supported by this execution environment: {opcode:?}, shift: {shift}"
         ),

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -374,7 +374,9 @@ pub(super) fn run_write_data<F: PrimeField32, const NUM_CELLS: usize>(
             write_data[shift..(NUM_CELLS / 2 + shift)]
                 .copy_from_slice(&read_data[..(NUM_CELLS / 2)]);
         }
-        _ => unreachable!("memory block access shift miscalculation: {opcode:?}, shift: {shift}"),
+        _ => unreachable!(
+            "unaligned memory access not supported by this execution environment: {opcode:?}, shift: {shift}"
+        ),
     };
     write_data
 }

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -374,9 +374,7 @@ pub(super) fn run_write_data<F: PrimeField32, const NUM_CELLS: usize>(
             write_data[shift..(NUM_CELLS / 2 + shift)]
                 .copy_from_slice(&read_data[..(NUM_CELLS / 2)]);
         }
-        _ => unreachable!(
-            "unaligned memory access not supported by this execution environment: {opcode:?}, shift: {shift}"
-        ),
+        _ => unreachable!("memory block access shift miscalculation: {opcode:?}, shift: {shift}"),
     };
     write_data
 }

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -374,7 +374,9 @@ pub(super) fn run_write_data<F: PrimeField32, const NUM_CELLS: usize>(
             write_data[shift..(NUM_CELLS / 2 + shift)]
                 .copy_from_slice(&read_data[..(NUM_CELLS / 2)]);
         }
-        _ => unreachable!(),
+        _ => unreachable!(
+            "unaligned memory access not supported by this execution environment: {opcode:?}, shift: {shift}"
+        ),
     };
     write_data
 }

--- a/extensions/sha256/guest/src/lib.rs
+++ b/extensions/sha256/guest/src/lib.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(target_os = "zkvm")]
-use core::mem::MaybeUninit;
-
 /// This is custom-0 defined in RISC-V spec document
 pub const OPCODE: u8 = 0x0b;
 pub const SHA256_FUNCT3: u8 = 0b100;


### PR DESCRIPTION
RISC-V spec says that 
>  Loads and stores whose effective address is not naturally aligned to the referenced datatype (i.e., the effective address is not divisible by the size of the access in bytes) have behavior dependent on the EEI.

Our circuits already support arbitrary misaligned accesses, so this PR just updated execution (in the LoadStore Adapter `preprocess`) so trace generation actually handles misaligned accesses properly.

Reminder on how it works: 
If you want to access `ptr_val`, then the circuit will do block access of size 4 on `[ptr_val - shift_amt..ptr_val - shift_amt + 4]` where `shift_amt` can be `0,1,2,3` for byte accesses, `0,2` for half word, and `0` only for word. The block access will always work regardless of alignment because the memory access adapter will handle misalignment behind the scenes. The `shift_amt` could just be set to 0 always, but we try to set it advantageously to keep the block accesses aligned when possible.