### PR TITLE
chore: Add `#[ignore]` to pairing fallback tests

### DIFF
--- a/extensions/pairing/tests/src/lib.rs
+++ b/extensions/pairing/tests/src/lib.rs
@@ -676,6 +676,7 @@ mod bls12_381 {
         Ok(())
     }
 
+    #[ignore]
     #[test]
     fn test_bls12_381_pairing_check_fallback() -> Result<()> {
         let elf = build_example_program_at_path_with_features(


### PR DESCRIPTION
The pairing hint fallback tests take forever to run (14 mins compared to 1-3 mins for other extensions), and they are triggered in the CI workflow.

This PR adds `#[ignore]` to these tests.