### PR TITLE
refactor: Add type `EvmProof` into openvm-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,7 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-transpiler",
  "serde",
+ "serde-big-array",
  "static_assertions",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,6 +4491,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "static_assertions",
+ "thiserror 1.0.69",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,7 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-transpiler",
  "serde",
+ "serde_json",
  "serde_with",
  "static_assertions",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,7 +4488,7 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-transpiler",
  "serde",
- "serde-big-array",
+ "serde_with",
  "static_assertions",
  "tracing",
 ]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -46,7 +46,7 @@ tracing.workspace = true
 itertools.workspace = true
 getset.workspace = true
 clap = { workspace = true, features = ["derive"] }
-serde-big-array.workspace = true
+serde_with = { workspace = true, features = ["hex"] }
 
 [features]
 default = ["parallel"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -47,6 +47,7 @@ itertools.workspace = true
 getset.workspace = true
 clap = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["hex"] }
+serde_json.workspace = true
 
 [features]
 default = ["parallel"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -46,6 +46,7 @@ tracing.workspace = true
 itertools.workspace = true
 getset.workspace = true
 clap = { workspace = true, features = ["derive"] }
+serde-big-array.workspace = true
 
 [features]
 default = ["parallel"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -48,6 +48,7 @@ getset.workspace = true
 clap = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["hex"] }
 serde_json.workspace = true
+thiserror.workspace = true
 
 [features]
 default = ["parallel"]

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -10,7 +10,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     keygen::{AggProvingKey, AppProvingKey, AppVerifyingKey},
-    types::EvmOpenvmProof,
+    types::EvmProof,
     F, SC,
 };
 
@@ -62,11 +62,11 @@ pub fn write_agg_pk_to_file<P: AsRef<Path>>(agg_pk: AggProvingKey, path: P) -> R
     write_to_file_bitcode(path, agg_pk)
 }
 
-pub fn read_evm_proof_from_file<P: AsRef<Path>>(path: P) -> Result<EvmOpenvmProof> {
+pub fn read_evm_proof_from_file<P: AsRef<Path>>(path: P) -> Result<EvmProof> {
     read_from_file_bitcode(path)
 }
 
-pub fn write_evm_proof_to_file<P: AsRef<Path>>(proof: EvmOpenvmProof, path: P) -> Result<()> {
+pub fn write_evm_proof_to_file<P: AsRef<Path>>(proof: EvmProof, path: P) -> Result<()> {
     write_to_file_bitcode(path, proof)
 }
 

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{create_dir_all, read, write},
+    fs::{create_dir_all, read, write, File},
     path::Path,
 };
 
@@ -63,11 +63,13 @@ pub fn write_agg_pk_to_file<P: AsRef<Path>>(agg_pk: AggProvingKey, path: P) -> R
 }
 
 pub fn read_evm_proof_from_file<P: AsRef<Path>>(path: P) -> Result<EvmProof> {
-    read_from_file_bitcode(path)
+    let proof: EvmProof = serde_json::from_reader(File::open(path)?)?;
+    Ok(proof)
 }
 
 pub fn write_evm_proof_to_file<P: AsRef<Path>>(proof: EvmProof, path: P) -> Result<()> {
-    write_to_file_bitcode(path, proof)
+    serde_json::to_writer(File::create(path)?, &proof)?;
+    Ok(())
 }
 
 pub fn read_evm_verifier_from_file<P: AsRef<Path>>(path: P) -> Result<EvmVerifier> {

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -5,11 +5,12 @@ use std::{
 
 use eyre::Result;
 use openvm_circuit::arch::{instructions::exe::VmExe, ContinuationVmProof, VmConfig};
-use openvm_native_recursion::halo2::{wrapper::EvmVerifier, EvmProof};
+use openvm_native_recursion::halo2::wrapper::EvmVerifier;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     keygen::{AggProvingKey, AppProvingKey, AppVerifyingKey},
+    types::EvmOpenvmProof,
     F, SC,
 };
 
@@ -61,11 +62,11 @@ pub fn write_agg_pk_to_file<P: AsRef<Path>>(agg_pk: AggProvingKey, path: P) -> R
     write_to_file_bitcode(path, agg_pk)
 }
 
-pub fn read_evm_proof_from_file<P: AsRef<Path>>(path: P) -> Result<EvmProof> {
+pub fn read_evm_proof_from_file<P: AsRef<Path>>(path: P) -> Result<EvmOpenvmProof> {
     read_from_file_bitcode(path)
 }
 
-pub fn write_evm_proof_to_file<P: AsRef<Path>>(proof: EvmProof, path: P) -> Result<()> {
+pub fn write_evm_proof_to_file<P: AsRef<Path>>(proof: EvmOpenvmProof, path: P) -> Result<()> {
     write_to_file_bitcode(path, proof)
 }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -54,7 +54,11 @@ pub mod prover;
 
 mod stdin;
 pub use stdin::*;
+
+use crate::types::EvmOpenvmProof;
+
 pub mod fs;
+pub mod types;
 
 pub type NonRootCommittedExe = VmCommittedExe<SC>;
 
@@ -232,7 +236,7 @@ impl Sdk {
         app_exe: Arc<NonRootCommittedExe>,
         agg_pk: AggProvingKey,
         inputs: StdIn,
-    ) -> Result<EvmProof>
+    ) -> Result<EvmOpenvmProof>
     where
         VC::Executor: Chip<SC>,
         VC::Periphery: Chip<SC>,
@@ -255,9 +259,10 @@ impl Sdk {
     pub fn verify_evm_proof(
         &self,
         evm_verifier: &EvmVerifier,
-        evm_proof: &EvmProof,
+        evm_openvm_proof: &EvmOpenvmProof,
     ) -> Result<u64> {
-        let gas_cost = Halo2WrapperProvingKey::evm_verify(evm_verifier, evm_proof)
+        let evm_proof: EvmProof = evm_openvm_proof.clone().into();
+        let gas_cost = Halo2WrapperProvingKey::evm_verify(evm_verifier, &evm_proof)
             .map_err(|reason| eyre::eyre!("Sdk::verify_evm_proof: {reason:?}"))?;
         Ok(gas_cost)
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -259,9 +259,9 @@ impl Sdk {
     pub fn verify_evm_proof(
         &self,
         evm_verifier: &EvmVerifier,
-        evm_openvm_proof: &EvmProof,
+        evm_proof: &EvmProof,
     ) -> Result<u64> {
-        let evm_proof: RawEvmProof = evm_openvm_proof.clone().into();
+        let evm_proof: RawEvmProof = evm_proof.clone().into();
         let gas_cost = Halo2WrapperProvingKey::evm_verify(evm_verifier, &evm_proof)
             .map_err(|reason| eyre::eyre!("Sdk::verify_evm_proof: {reason:?}"))?;
         Ok(gas_cost)

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -261,7 +261,7 @@ impl Sdk {
         evm_verifier: &EvmVerifier,
         evm_proof: &EvmProof,
     ) -> Result<u64> {
-        let evm_proof: RawEvmProof = evm_proof.clone().into();
+        let evm_proof: RawEvmProof = evm_proof.clone().try_into()?;
         let gas_cost = Halo2WrapperProvingKey::evm_verify(evm_verifier, &evm_proof)
             .map_err(|reason| eyre::eyre!("Sdk::verify_evm_proof: {reason:?}"))?;
         Ok(gas_cost)

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -26,7 +26,7 @@ pub use openvm_continuations::{
 use openvm_native_recursion::halo2::{
     utils::Halo2ParamsReader,
     wrapper::{EvmVerifier, Halo2WrapperProvingKey},
-    EvmProof,
+    RawEvmProof,
 };
 use openvm_stark_backend::{engine::StarkEngine, proof::Proof};
 use openvm_stark_sdk::{
@@ -55,7 +55,7 @@ pub mod prover;
 mod stdin;
 pub use stdin::*;
 
-use crate::types::EvmOpenvmProof;
+use crate::types::EvmProof;
 
 pub mod fs;
 pub mod types;
@@ -236,7 +236,7 @@ impl Sdk {
         app_exe: Arc<NonRootCommittedExe>,
         agg_pk: AggProvingKey,
         inputs: StdIn,
-    ) -> Result<EvmOpenvmProof>
+    ) -> Result<EvmProof>
     where
         VC::Executor: Chip<SC>,
         VC::Periphery: Chip<SC>,
@@ -259,9 +259,9 @@ impl Sdk {
     pub fn verify_evm_proof(
         &self,
         evm_verifier: &EvmVerifier,
-        evm_openvm_proof: &EvmOpenvmProof,
+        evm_openvm_proof: &EvmProof,
     ) -> Result<u64> {
-        let evm_proof: EvmProof = evm_openvm_proof.clone().into();
+        let evm_proof: RawEvmProof = evm_openvm_proof.clone().into();
         let gas_cost = Halo2WrapperProvingKey::evm_verify(evm_verifier, &evm_proof)
             .map_err(|reason| eyre::eyre!("Sdk::verify_evm_proof: {reason:?}"))?;
         Ok(gas_cost)

--- a/crates/sdk/src/prover/halo2.rs
+++ b/crates/sdk/src/prover/halo2.rs
@@ -40,7 +40,8 @@ impl Halo2Prover {
             self.halo2_pk
                 .wrapper
                 .prove_for_evm(&self.wrapper_srs, snark)
-                .into()
+                .try_into()
+                .unwrap()
         })
     }
 }

--- a/crates/sdk/src/prover/halo2.rs
+++ b/crates/sdk/src/prover/halo2.rs
@@ -8,7 +8,7 @@ use openvm_native_recursion::{
 use openvm_stark_sdk::openvm_stark_backend::proof::Proof;
 use tracing::info_span;
 
-use crate::{keygen::Halo2ProvingKey, types::EvmOpenvmProof, RootSC};
+use crate::{keygen::Halo2ProvingKey, types::EvmProof, RootSC};
 
 pub struct Halo2Prover {
     halo2_pk: Halo2ProvingKey,
@@ -28,7 +28,7 @@ impl Halo2Prover {
             wrapper_srs,
         }
     }
-    pub fn prove_for_evm(&self, root_proof: &Proof<RootSC>) -> EvmOpenvmProof {
+    pub fn prove_for_evm(&self, root_proof: &Proof<RootSC>) -> EvmProof {
         let mut witness = Witness::default();
         root_proof.write(&mut witness);
         let snark = info_span!("prove", group = "halo2_outer").in_scope(|| {

--- a/crates/sdk/src/prover/halo2.rs
+++ b/crates/sdk/src/prover/halo2.rs
@@ -2,13 +2,14 @@ use std::sync::Arc;
 
 use openvm_native_compiler::prelude::Witness;
 use openvm_native_recursion::{
-    halo2::{utils::Halo2ParamsReader, EvmProof, Halo2Params},
+    halo2::{utils::Halo2ParamsReader, Halo2Params},
     witness::Witnessable,
 };
 use openvm_stark_sdk::openvm_stark_backend::proof::Proof;
 use tracing::info_span;
 
-use crate::{keygen::Halo2ProvingKey, RootSC};
+use crate::{keygen::Halo2ProvingKey, types::EvmOpenvmProof, RootSC};
+
 pub struct Halo2Prover {
     halo2_pk: Halo2ProvingKey,
     verifier_srs: Arc<Halo2Params>,
@@ -27,7 +28,7 @@ impl Halo2Prover {
             wrapper_srs,
         }
     }
-    pub fn prove_for_evm(&self, root_proof: &Proof<RootSC>) -> EvmProof {
+    pub fn prove_for_evm(&self, root_proof: &Proof<RootSC>) -> EvmOpenvmProof {
         let mut witness = Witness::default();
         root_proof.write(&mut witness);
         let snark = info_span!("prove", group = "halo2_outer").in_scope(|| {
@@ -39,6 +40,7 @@ impl Halo2Prover {
             self.halo2_pk
                 .wrapper
                 .prove_for_evm(&self.wrapper_srs, snark)
+                .into()
         })
     }
 }

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use openvm_circuit::arch::VmConfig;
-use openvm_native_recursion::halo2::EvmProof;
 use openvm_stark_sdk::openvm_stark_backend::Chip;
 
 use crate::{keygen::AppProvingKey, stdin::StdIn, NonRootCommittedExe, F, SC};
@@ -23,7 +22,7 @@ pub mod vm;
 #[allow(unused_imports)]
 pub use stark::*;
 
-use crate::{keygen::AggProvingKey, prover::halo2::Halo2Prover};
+use crate::{keygen::AggProvingKey, prover::halo2::Halo2Prover, types::EvmOpenvmProof};
 
 pub struct ContinuationProver<VC> {
     stark_prover: StarkProver<VC>,
@@ -56,7 +55,7 @@ impl<VC> ContinuationProver<VC> {
         self
     }
 
-    pub fn generate_proof_for_evm(&self, input: StdIn) -> EvmProof
+    pub fn generate_proof_for_evm(&self, input: StdIn) -> EvmOpenvmProof
     where
         VC: VmConfig<F>,
         VC::Executor: Chip<SC>,

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -22,7 +22,7 @@ pub mod vm;
 #[allow(unused_imports)]
 pub use stark::*;
 
-use crate::{keygen::AggProvingKey, prover::halo2::Halo2Prover, types::EvmOpenvmProof};
+use crate::{keygen::AggProvingKey, prover::halo2::Halo2Prover, types::EvmProof};
 
 pub struct ContinuationProver<VC> {
     stark_prover: StarkProver<VC>,
@@ -55,7 +55,7 @@ impl<VC> ContinuationProver<VC> {
         self
     }
 
-    pub fn generate_proof_for_evm(&self, input: StdIn) -> EvmOpenvmProof
+    pub fn generate_proof_for_evm(&self, input: StdIn) -> EvmProof
     where
         VC: VmConfig<F>,
         VC::Executor: Chip<SC>,

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,0 +1,85 @@
+use itertools::Itertools;
+use openvm_native_recursion::halo2::{EvmProof, Fr};
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
+
+const BN254_BYTES: usize = 32;
+const NUM_BN254_ACCUMULATORS: usize = 12;
+const NUM_BN254_PROOF: usize = 43;
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct EvmOpenvmProof {
+    #[serde(with = "BigArray")]
+    pub accumulators: [u8; BN254_BYTES * NUM_BN254_ACCUMULATORS],
+    pub exe_commit: [u8; BN254_BYTES],
+    pub leaf_commit: [u8; BN254_BYTES],
+    pub user_public_values: Vec<u8>,
+    #[serde(with = "BigArray")]
+    pub proof: [u8; BN254_BYTES * NUM_BN254_PROOF],
+}
+
+impl EvmOpenvmProof {
+    /// Return bytes calldata to be passed to the verifier contract.
+    pub fn verifier_calldata(&self) -> Vec<u8> {
+        let evm_proof: EvmProof = self.clone().into();
+        evm_proof.verifier_calldata()
+    }
+}
+
+impl From<EvmProof> for EvmOpenvmProof {
+    fn from(evm_proof: EvmProof) -> Self {
+        let EvmProof { instances, proof } = evm_proof;
+        assert_eq!(instances.len(), 1);
+        assert!(NUM_BN254_ACCUMULATORS + 2 < instances[0].len());
+        let accumulators = instances[0][0..NUM_BN254_ACCUMULATORS]
+            .iter()
+            .flat_map(|f| f.to_bytes())
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        let exe_commit = instances[0][NUM_BN254_ACCUMULATORS].to_bytes();
+        let leaf_commit = instances[0][NUM_BN254_ACCUMULATORS + 1].to_bytes();
+        let user_public_values = instances[0][NUM_BN254_ACCUMULATORS + 2..]
+            .iter()
+            .flat_map(|f| f.to_bytes())
+            .collect::<Vec<_>>();
+        Self {
+            accumulators,
+            exe_commit,
+            leaf_commit,
+            user_public_values,
+            proof: proof.try_into().unwrap(),
+        }
+    }
+}
+
+impl From<EvmOpenvmProof> for EvmProof {
+    fn from(evm_openvm_proof: EvmOpenvmProof) -> Self {
+        let EvmOpenvmProof {
+            accumulators,
+            exe_commit,
+            leaf_commit,
+            user_public_values,
+            proof,
+        } = evm_openvm_proof;
+        let instances = {
+            assert_eq!(user_public_values.len() % BN254_BYTES, 0);
+            let mut ret = Vec::new();
+            for chunk in &accumulators
+                .iter()
+                .chain(&exe_commit)
+                .chain(&leaf_commit)
+                .chain(&user_public_values)
+                .chunks(BN254_BYTES)
+            {
+                let c = chunk.copied().collect::<Vec<_>>().try_into().unwrap();
+                ret.push(Fr::from_bytes(&c).unwrap());
+            }
+            vec![ret]
+        };
+        EvmProof {
+            instances,
+            proof: proof.to_vec(),
+        }
+    }
+}

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -3,22 +3,30 @@ use openvm_native_recursion::halo2::{Fr, RawEvmProof};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
+/// Number of bytes in a Bn254Fr.
 const BN254_BYTES: usize = 32;
+/// Number of Bn254Fr in `accumulators` field.
 const NUM_BN254_ACCUMULATORS: usize = 12;
+/// Number of Bn254Fr in `proof` field for a circuit with only 1 advice column.
 const NUM_BN254_PROOF: usize = 43;
 
 #[serde_as]
 #[derive(Clone, Deserialize, Serialize)]
 pub struct EvmProof {
     #[serde_as(as = "serde_with::hex::Hex")]
+    /// Bn254Fr public values for accumulators in flatten little-endian bytes. Length is `NUM_BN254_ACCUMULATORS * BN254_BYTES`.
     pub accumulators: Vec<u8>,
     #[serde_as(as = "serde_with::hex::Hex")]
+    /// 1 Bn254Fr public value for exe commit in little-endian bytes.
     pub exe_commit: [u8; BN254_BYTES],
     #[serde_as(as = "serde_with::hex::Hex")]
+    /// 1 Bn254Fr public value for leaf commit in little-endian bytes.
     pub leaf_commit: [u8; BN254_BYTES],
     #[serde_as(as = "serde_with::hex::Hex")]
+    /// Bn254Fr user public values in little-endian bytes.
     pub user_public_values: Vec<u8>,
     #[serde_as(as = "serde_with::hex::Hex")]
+    /// Bn254Fr proof in little-endian bytes. The circuit only has 1 advice column, so the proof is of length `NUM_BN254_PROOF * BN254_BYTES`.
     pub proof: Vec<u8>,
 }
 

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,45 +1,48 @@
 use itertools::Itertools;
-use openvm_native_recursion::halo2::{EvmProof, Fr};
+use openvm_native_recursion::halo2::{Fr, RawEvmProof};
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
+use serde_with::serde_as;
 
 const BN254_BYTES: usize = 32;
 const NUM_BN254_ACCUMULATORS: usize = 12;
 const NUM_BN254_PROOF: usize = 43;
 
+#[serde_as]
 #[derive(Clone, Deserialize, Serialize)]
-pub struct EvmOpenvmProof {
-    #[serde(with = "BigArray")]
-    pub accumulators: [u8; BN254_BYTES * NUM_BN254_ACCUMULATORS],
+pub struct EvmProof {
+    #[serde_as(as = "serde_with::hex::Hex")]
+    pub accumulators: Vec<u8>,
+    #[serde_as(as = "serde_with::hex::Hex")]
     pub exe_commit: [u8; BN254_BYTES],
+    #[serde_as(as = "serde_with::hex::Hex")]
     pub leaf_commit: [u8; BN254_BYTES],
+    #[serde_as(as = "serde_with::hex::Hex")]
     pub user_public_values: Vec<u8>,
-    #[serde(with = "BigArray")]
-    pub proof: [u8; BN254_BYTES * NUM_BN254_PROOF],
+    #[serde_as(as = "serde_with::hex::Hex")]
+    pub proof: Vec<u8>,
 }
 
-impl EvmOpenvmProof {
+impl EvmProof {
     /// Return bytes calldata to be passed to the verifier contract.
     pub fn verifier_calldata(&self) -> Vec<u8> {
-        let evm_proof: EvmProof = self.clone().into();
+        let evm_proof: RawEvmProof = self.clone().into();
         evm_proof.verifier_calldata()
     }
 }
 
-impl From<EvmProof> for EvmOpenvmProof {
-    fn from(evm_proof: EvmProof) -> Self {
-        let EvmProof { instances, proof } = evm_proof;
+impl From<RawEvmProof> for EvmProof {
+    fn from(evm_proof: RawEvmProof) -> Self {
+        let RawEvmProof { instances, proof } = evm_proof;
         assert_eq!(instances.len(), 1);
-        assert!(NUM_BN254_ACCUMULATORS + 2 < instances[0].len());
-        let accumulators = instances[0][0..NUM_BN254_ACCUMULATORS]
+        assert!(NUM_BN254_ACCUMULATORS + 2 < instances.len());
+        assert_eq!(proof.len(), NUM_BN254_PROOF * BN254_BYTES);
+        let accumulators = instances[0..NUM_BN254_ACCUMULATORS]
             .iter()
             .flat_map(|f| f.to_bytes())
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-        let exe_commit = instances[0][NUM_BN254_ACCUMULATORS].to_bytes();
-        let leaf_commit = instances[0][NUM_BN254_ACCUMULATORS + 1].to_bytes();
-        let user_public_values = instances[0][NUM_BN254_ACCUMULATORS + 2..]
+            .collect::<Vec<_>>();
+        let exe_commit = instances[NUM_BN254_ACCUMULATORS].to_bytes();
+        let leaf_commit = instances[NUM_BN254_ACCUMULATORS + 1].to_bytes();
+        let user_public_values = instances[NUM_BN254_ACCUMULATORS + 2..]
             .iter()
             .flat_map(|f| f.to_bytes())
             .collect::<Vec<_>>();
@@ -48,22 +51,25 @@ impl From<EvmProof> for EvmOpenvmProof {
             exe_commit,
             leaf_commit,
             user_public_values,
-            proof: proof.try_into().unwrap(),
+            proof,
         }
     }
 }
 
-impl From<EvmOpenvmProof> for EvmProof {
-    fn from(evm_openvm_proof: EvmOpenvmProof) -> Self {
-        let EvmOpenvmProof {
+impl From<EvmProof> for RawEvmProof {
+    fn from(evm_openvm_proof: EvmProof) -> Self {
+        let EvmProof {
             accumulators,
             exe_commit,
             leaf_commit,
             user_public_values,
             proof,
         } = evm_openvm_proof;
+        assert_eq!(proof.len(), NUM_BN254_PROOF * BN254_BYTES);
         let instances = {
+            assert_eq!(accumulators.len(), NUM_BN254_ACCUMULATORS * BN254_BYTES);
             assert_eq!(user_public_values.len() % BN254_BYTES, 0);
+            assert!(!user_public_values.is_empty());
             let mut ret = Vec::new();
             for chunk in &accumulators
                 .iter()
@@ -75,11 +81,8 @@ impl From<EvmOpenvmProof> for EvmProof {
                 let c = chunk.copied().collect::<Vec<_>>().try_into().unwrap();
                 ret.push(Fr::from_bytes(&c).unwrap());
             }
-            vec![ret]
+            ret
         };
-        EvmProof {
-            instances,
-            proof: proof.to_vec(),
-        }
+        RawEvmProof { instances, proof }
     }
 }

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -33,7 +33,6 @@ impl EvmProof {
 impl From<RawEvmProof> for EvmProof {
     fn from(evm_proof: RawEvmProof) -> Self {
         let RawEvmProof { instances, proof } = evm_proof;
-        assert_eq!(instances.len(), 1);
         assert!(NUM_BN254_ACCUMULATORS + 2 < instances.len());
         assert_eq!(proof.len(), NUM_BN254_PROOF * BN254_BYTES);
         let accumulators = instances[0..NUM_BN254_ACCUMULATORS]

--- a/extensions/native/recursion/src/halo2/mod.rs
+++ b/extensions/native/recursion/src/halo2/mod.rs
@@ -17,6 +17,7 @@ use openvm_stark_backend::p3_field::extension::BinomialExtensionField;
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, p3_bn254_fr::Bn254Fr};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use snark_verifier_sdk::{
+    evm::encode_calldata,
     halo2::{gen_dummy_snark_from_vk, gen_snark_shplonk},
     snark_verifier::halo2_base::{
         gates::{
@@ -25,7 +26,7 @@ use snark_verifier_sdk::{
         },
         halo2_proofs::{
             dev::MockProver,
-            halo2curves::bn256::{Bn256, Fr, G1Affine},
+            halo2curves::bn256::{Bn256, G1Affine},
             plonk::{keygen_pk2, ProvingKey},
             poly::{commitment::Params, kzg::commitment::ParamsKZG},
             SerdeFormat,
@@ -37,6 +38,7 @@ use snark_verifier_sdk::{
 use crate::halo2::utils::Halo2ParamsReader;
 
 pub type Halo2Params = ParamsKZG<Bn256>;
+pub use snark_verifier_sdk::snark_verifier::halo2_base::halo2_proofs::halo2curves::bn256::Fr;
 
 /// A prover that can generate proofs with the Halo2
 #[derive(Debug, Clone)]
@@ -68,6 +70,13 @@ pub struct Halo2ProvingMetadata {
     pub break_points: MultiPhaseThreadBreakPoints,
     /// Number of public values per column in order.
     pub num_pvs: Vec<usize>,
+}
+
+impl EvmProof {
+    /// Return bytes calldata to be passed to the verifier contract.
+    pub fn verifier_calldata(&self) -> Vec<u8> {
+        encode_calldata(&self.instances, &self.proof)
+    }
 }
 
 impl Halo2ProvingPinning {

--- a/extensions/native/recursion/src/halo2/mod.rs
+++ b/extensions/native/recursion/src/halo2/mod.rs
@@ -45,8 +45,8 @@ pub use snark_verifier_sdk::snark_verifier::halo2_base::halo2_proofs::halo2curve
 pub struct Halo2Prover;
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct EvmProof {
-    pub instances: Vec<Vec<Fr>>,
+pub struct RawEvmProof {
+    pub instances: Vec<Fr>,
     pub proof: Vec<u8>,
 }
 
@@ -72,10 +72,10 @@ pub struct Halo2ProvingMetadata {
     pub num_pvs: Vec<usize>,
 }
 
-impl EvmProof {
+impl RawEvmProof {
     /// Return bytes calldata to be passed to the verifier contract.
     pub fn verifier_calldata(&self) -> Vec<u8> {
-        encode_calldata(&self.instances, &self.proof)
+        encode_calldata(&[self.instances.clone()], &self.proof)
     }
 }
 

--- a/extensions/native/recursion/src/halo2/wrapper.rs
+++ b/extensions/native/recursion/src/halo2/wrapper.rs
@@ -105,6 +105,7 @@ impl Halo2WrapperProvingKey {
         let k = self.pinning.metadata.config_params.k;
         let prover_circuit = self.generate_circuit_object_for_proving(k, snark_to_verify);
         let mut pvs = prover_circuit.instances();
+        assert_eq!(pvs.len(), 1);
         let proof = gen_evm_proof_shplonk(params, &self.pinning.pk, prover_circuit, pvs.clone());
         #[cfg(feature = "bench-metrics")]
         metrics::gauge!("total_proof_time_ms").set(start.elapsed().as_millis() as f64);

--- a/extensions/native/recursion/src/halo2/wrapper.rs
+++ b/extensions/native/recursion/src/halo2/wrapper.rs
@@ -16,7 +16,7 @@ use snark_verifier_sdk::{
 
 use crate::halo2::{
     utils::{Halo2ParamsReader, KZG_PARAMS_FOR_SVK},
-    EvmProof, Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning,
+    Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning, RawEvmProof,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,10 +78,10 @@ impl Halo2WrapperProvingKey {
         }
     }
     /// A helper function for testing to verify the proof of this circuit with evm verifier.
-    pub fn evm_verify(evm_verifier: &EvmVerifier, evm_proof: &EvmProof) -> Result<u64, String> {
+    pub fn evm_verify(evm_verifier: &EvmVerifier, evm_proof: &RawEvmProof) -> Result<u64, String> {
         evm_verify(
             evm_verifier.0.clone(),
-            evm_proof.instances.clone(),
+            vec![evm_proof.instances.clone()],
             evm_proof.proof.clone(),
         )
     }
@@ -99,18 +99,18 @@ impl Halo2WrapperProvingKey {
             None,
         ))
     }
-    pub fn prove_for_evm(&self, params: &Halo2Params, snark_to_verify: Snark) -> EvmProof {
+    pub fn prove_for_evm(&self, params: &Halo2Params, snark_to_verify: Snark) -> RawEvmProof {
         #[cfg(feature = "bench-metrics")]
         let start = std::time::Instant::now();
         let k = self.pinning.metadata.config_params.k;
         let prover_circuit = self.generate_circuit_object_for_proving(k, snark_to_verify);
-        let pvs = prover_circuit.instances();
+        let mut pvs = prover_circuit.instances();
         let proof = gen_evm_proof_shplonk(params, &self.pinning.pk, prover_circuit, pvs.clone());
         #[cfg(feature = "bench-metrics")]
         metrics::gauge!("total_proof_time_ms").set(start.elapsed().as_millis() as f64);
 
-        EvmProof {
-            instances: pvs,
+        RawEvmProof {
+            instances: pvs.pop().unwrap(),
             proof,
         }
     }


### PR DESCRIPTION
- Rename the existing `EvmProof` into `RawEvmProof`
- Add a more semantic type `EvmProof` into `openvm-sdk`. 
- [Breaking change] Replace all `RawEvmProof` usages in the SDK interface with `EvmProof`
- Serialize `EvmProof` in json instead of `bitcode`. All fields are represented as bytes.

closes INT-3596