### PR TITLE
fix: check the heap size on memory initialization

### DIFF
--- a/crates/toolchain/platform/src/heap/embedded.rs
+++ b/crates/toolchain/platform/src/heap/embedded.rs
@@ -22,8 +22,10 @@ pub fn init() {
         static _end: u8;
     }
     let heap_pos: usize = unsafe { (&_end) as *const u8 as usize };
-    let heap_size: usize = crate::memory::GUEST_MAX_MEM
-        .checked_sub(heap_pos)
-        .expect("Not enough memory for heap");
+    if heap_pos > crate::memory::GUEST_MAX_MEM {
+        crate::print::println("Not enough memory for heap.");
+        crate::rust_rt::terminate::<1>();
+    }
+    let heap_size: usize = crate::memory::GUEST_MAX_MEM - heap_pos;
     unsafe { HEAP.init(heap_pos, heap_size) }
 }

--- a/crates/toolchain/platform/src/heap/embedded.rs
+++ b/crates/toolchain/platform/src/heap/embedded.rs
@@ -22,6 +22,8 @@ pub fn init() {
         static _end: u8;
     }
     let heap_pos: usize = unsafe { (&_end) as *const u8 as usize };
-    let heap_size: usize = crate::memory::GUEST_MAX_MEM - heap_pos;
+    let heap_size: usize = crate::memory::GUEST_MAX_MEM
+        .checked_sub(heap_pos)
+        .expect("Not enough memory for heap");
     unsafe { HEAP.init(heap_pos, heap_size) }
 }


### PR DESCRIPTION
This resolves INT-3659.

The problem was that we could potentially try to initialize about `usize::MAX` of heap memory due to unchecked subtraction.