### PR TITLE
fix: alignment in unsafe rust

### DIFF
--- a/benchmarks/programs/kitchen-sink/src/main.rs
+++ b/benchmarks/programs/kitchen-sink/src/main.rs
@@ -82,8 +82,8 @@ pub fn main() {
         hash.extend_from_slice(&digest2);
 
         // SAFETY: internally I256 is represented as [u8; 32]
-        let i1 = unsafe { transmute::<[u8; 32], I256>(digest1) };
-        let i2 = unsafe { transmute::<[u8; 32], I256>(digest2) };
+        let i1 = I256::from_le_bytes(digest1);
+        let i2 = I256::from_le_bytes(digest2);
 
         black_box(&i1 + &i2);
         black_box(&i1 - &i2);

--- a/crates/toolchain/openvm/src/io/read.rs
+++ b/crates/toolchain/openvm/src/io/read.rs
@@ -63,10 +63,11 @@ impl WordRead for Reader {
         let remainder = bytes.chunks_exact_mut(WORD_SIZE).into_remainder();
         if !remainder.is_empty() {
             num_padded_bytes += WORD_SIZE - remainder.len();
-            let mut padded = MaybeUninit::<[u8; WORD_SIZE]>::uninit();
-            hint_store_word(padded.as_mut_ptr() as *mut u32);
+            let mut padded = MaybeUninit::<u32>::uninit();
+            hint_store_word(padded.as_mut_ptr());
             let padded = unsafe { padded.assume_init() };
-            remainder.copy_from_slice(&padded[..remainder.len()]);
+            // We use native endian so its equivalent to transmuting u32 to [u8; 4]
+            remainder.copy_from_slice(&padded.to_ne_bytes()[..remainder.len()]);
         }
         // If we reached EOF, then we set to 0.
         // Otherwise, we need to subtract the padding as well.

--- a/extensions/bigint/guest/src/i256.rs
+++ b/extensions/bigint/guest/src/i256.rs
@@ -34,6 +34,11 @@ impl I256 {
     /// The zero constant.
     pub const ZERO: Self = Self { limbs: [0u8; 32] };
 
+    /// Construct [I256] from little-endian bytes.
+    pub const fn from_le_bytes(bytes: [u8; 32]) -> Self {
+        Self { limbs: bytes }
+    }
+
     /// Value of this I256 as a BigInt.
     #[cfg(not(target_os = "zkvm"))]
     pub fn as_bigint(&self) -> BigInt {

--- a/extensions/bigint/guest/src/u256.rs
+++ b/extensions/bigint/guest/src/u256.rs
@@ -36,6 +36,11 @@ impl U256 {
     /// The zero constant.
     pub const ZERO: Self = Self { limbs: [0u8; 32] };
 
+    /// Construct [U256] from little-endian bytes.
+    pub const fn from_le_bytes(bytes: [u8; 32]) -> Self {
+        Self { limbs: bytes }
+    }
+
     /// Value of this U256 as a BigUint.
     #[cfg(not(target_os = "zkvm"))]
     pub fn as_biguint(&self) -> BigUint {

--- a/extensions/pairing/tests/programs/examples/fp12_mul.rs
+++ b/extensions/pairing/tests/programs/examples/fp12_mul.rs
@@ -32,8 +32,8 @@ mod bn254 {
         let f1 = &io[32 * 12..32 * 24];
         let r_cmp = &io[32 * 24..32 * 36];
 
-        let f0_cast = unsafe { &*(f0.as_ptr() as *const Fp12) };
-        let f1_cast = unsafe { &*(f1.as_ptr() as *const Fp12) };
+        let f0_cast = Fp12::from_bytes(f0);
+        let f1_cast = Fp12::from_bytes(f1);
 
         let r = f0_cast * f1_cast;
         let mut r_bytes = [0u8; 32 * 12];
@@ -71,8 +71,8 @@ mod bls12_381 {
         let f1 = &io[48 * 12..48 * 24];
         let r_cmp = &io[48 * 24..48 * 36];
 
-        let f0_cast = unsafe { &*(f0.as_ptr() as *const Fp12) };
-        let f1_cast = unsafe { &*(f1.as_ptr() as *const Fp12) };
+        let f0_cast = Fp12::from_bytes(f0);
+        let f1_cast = Fp12::from_bytes(f1);
 
         let r = f0_cast * f1_cast;
         let mut r_bytes = [0u8; 48 * 12];

--- a/extensions/pairing/tests/programs/examples/pairing_check.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_check.rs
@@ -15,7 +15,7 @@ openvm::entry!(main);
 mod bn254 {
     use alloc::format;
 
-    use openvm_algebra_guest::IntMod;
+    use openvm_algebra_guest::{field::FieldExtension, IntMod};
     use openvm_pairing_guest::bn254::{Bn254, Fp, Fp2};
 
     use super::*;
@@ -37,10 +37,12 @@ mod bn254 {
         let q0 = &io[32 * 4..32 * 8];
         let q1 = &io[32 * 8..32 * 12];
 
-        let s0_cast = unsafe { &*(s0.as_ptr() as *const AffinePoint<Fp>) };
-        let s1_cast = unsafe { &*(s1.as_ptr() as *const AffinePoint<Fp>) };
-        let q0_cast = unsafe { &*(q0.as_ptr() as *const AffinePoint<Fp2>) };
-        let q1_cast = unsafe { &*(q1.as_ptr() as *const AffinePoint<Fp2>) };
+        let s0_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s0[..32]), Fp::from_le_bytes(&s0[32..64]));
+        let s1_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s1[..32]), Fp::from_le_bytes(&s1[32..64]));
+        let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..64]), Fp2::from_bytes(&q0[64..128]));
+        let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..64]), Fp2::from_bytes(&q1[64..128]));
 
         let f = Bn254::pairing_check(
             &[s0_cast.clone(), s1_cast.clone()],
@@ -55,7 +57,7 @@ mod bls12_381 {
 
     use alloc::format;
 
-    use openvm_algebra_guest::IntMod;
+    use openvm_algebra_guest::{field::FieldExtension, IntMod};
     use openvm_pairing_guest::bls12_381::{Bls12_381, Fp, Fp2};
 
     use super::*;
@@ -77,10 +79,12 @@ mod bls12_381 {
         let q0 = &io[48 * 4..48 * 8];
         let q1 = &io[48 * 8..48 * 12];
 
-        let s0_cast = unsafe { &*(s0.as_ptr() as *const AffinePoint<Fp>) };
-        let s1_cast = unsafe { &*(s1.as_ptr() as *const AffinePoint<Fp>) };
-        let q0_cast = unsafe { &*(q0.as_ptr() as *const AffinePoint<Fp2>) };
-        let q1_cast = unsafe { &*(q1.as_ptr() as *const AffinePoint<Fp2>) };
+        let s0_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s0[..48]), Fp::from_le_bytes(&s0[48..96]));
+        let s1_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s1[..48]), Fp::from_le_bytes(&s1[48..96]));
+        let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..96]), Fp2::from_bytes(&q0[96..192]));
+        let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..96]), Fp2::from_bytes(&q1[96..192]));
 
         let f = Bls12_381::pairing_check(
             &[s0_cast.clone(), s1_cast.clone()],

--- a/extensions/pairing/tests/programs/examples/pairing_check_fallback.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_check_fallback.rs
@@ -109,10 +109,12 @@ mod bn254 {
         let q0 = &io[32 * 4..32 * 8];
         let q1 = &io[32 * 8..32 * 12];
 
-        let s0_cast = unsafe { &*(s0.as_ptr() as *const AffinePoint<Fp>) };
-        let s1_cast = unsafe { &*(s1.as_ptr() as *const AffinePoint<Fp>) };
-        let q0_cast = unsafe { &*(q0.as_ptr() as *const AffinePoint<Fp2>) };
-        let q1_cast = unsafe { &*(q1.as_ptr() as *const AffinePoint<Fp2>) };
+        let s0_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s0[..32]), Fp::from_le_bytes(&s0[32..64]));
+        let s1_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s1[..32]), Fp::from_le_bytes(&s1[32..64]));
+        let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..64]), Fp2::from_bytes(&q0[64..128]));
+        let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..64]), Fp2::from_bytes(&q1[64..128]));
 
         let f = Bn254Wrapper::pairing_check(
             &[s0_cast.clone(), s1_cast.clone()],
@@ -222,10 +224,12 @@ mod bls12_381 {
         let q0 = &io[48 * 4..48 * 8];
         let q1 = &io[48 * 8..48 * 12];
 
-        let s0_cast = unsafe { &*(s0.as_ptr() as *const AffinePoint<Fp>) };
-        let s1_cast = unsafe { &*(s1.as_ptr() as *const AffinePoint<Fp>) };
-        let q0_cast = unsafe { &*(q0.as_ptr() as *const AffinePoint<Fp2>) };
-        let q1_cast = unsafe { &*(q1.as_ptr() as *const AffinePoint<Fp2>) };
+        let s0_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s0[..48]), Fp::from_le_bytes(&s0[48..96]));
+        let s1_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s1[..48]), Fp::from_le_bytes(&s1[48..96]));
+        let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..96]), Fp2::from_bytes(&q0[96..192]));
+        let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..96]), Fp2::from_bytes(&q1[96..192]));
 
         let f = Bls12_381Wrapper::pairing_check(
             &[s0_cast.clone(), s1_cast.clone()],

--- a/extensions/pairing/tests/programs/examples/pairing_line.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_line.rs
@@ -30,10 +30,16 @@ mod bn254 {
         let l1 = &io[32 * 4..32 * 8];
         let expected = &io[32 * 8..32 * 18];
 
-        let l0_cast = unsafe { &*(l0.as_ptr() as *const EvaluatedLine<Fp2>) };
-        let l1_cast = unsafe { &*(l1.as_ptr() as *const EvaluatedLine<Fp2>) };
+        let l0_cast = EvaluatedLine {
+            b: Fp2::from_bytes(&l0[..64]),
+            c: Fp2::from_bytes(&l0[64..128]),
+        };
+        let l1_cast = EvaluatedLine {
+            b: Fp2::from_bytes(&l1[..64]),
+            c: Fp2::from_bytes(&l1[64..128]),
+        };
 
-        let r = Bn254::mul_013_by_013(l0_cast, l1_cast);
+        let r = Bn254::mul_013_by_013(&l0_cast, &l1_cast);
         let mut r_bytes = [0u8; 32 * 10];
         let mut i = 0;
         for x in r {
@@ -50,10 +56,16 @@ mod bn254 {
         let x = &io[32 * 12..32 * 22];
         let expected = &io[32 * 22..32 * 34];
 
-        let f_cast = unsafe { &*(f.as_ptr() as *const Fp12) };
-        let x_cast = unsafe { &*(x.as_ptr() as *const [Fp2; 5]) };
+        let f_cast = Fp12::from_bytes(f);
+        let x_cast = [
+            Fp2::from_bytes(&x[..64]),
+            Fp2::from_bytes(&x[64..128]),
+            Fp2::from_bytes(&x[128..192]),
+            Fp2::from_bytes(&x[192..256]),
+            Fp2::from_bytes(&x[256..320]),
+        ];
 
-        let r = Bn254::mul_by_01234(f_cast, x_cast);
+        let r = Bn254::mul_by_01234(&f_cast, &x_cast);
         let mut r_bytes = [0u8; 32 * 12];
         let mut i = 0;
         for x in r.to_coeffs() {
@@ -86,10 +98,16 @@ mod bls12_381 {
         let l1 = &io[48 * 4..48 * 8];
         let expected = &io[48 * 8..48 * 18];
 
-        let l0_cast = unsafe { &*(l0.as_ptr() as *const EvaluatedLine<Fp2>) };
-        let l1_cast = unsafe { &*(l1.as_ptr() as *const EvaluatedLine<Fp2>) };
+        let l0_cast = EvaluatedLine {
+            b: Fp2::from_bytes(&l0[..48 * 2]),
+            c: Fp2::from_bytes(&l0[48 * 2..48 * 4]),
+        };
+        let l1_cast = EvaluatedLine {
+            b: Fp2::from_bytes(&l1[..48 * 2]),
+            c: Fp2::from_bytes(&l1[48 * 2..48 * 4]),
+        };
 
-        let r = Bls12_381::mul_023_by_023(l0_cast, l1_cast);
+        let r = Bls12_381::mul_023_by_023(&l0_cast, &l1_cast);
         let mut r_bytes = [0u8; 48 * 10];
         let mut i = 0;
         for x in r {
@@ -106,10 +124,16 @@ mod bls12_381 {
         let x = &io[48 * 12..48 * 22];
         let expected = &io[48 * 22..48 * 34];
 
-        let f_cast = unsafe { &*(f.as_ptr() as *const Fp12) };
-        let x_cast = unsafe { &*(x.as_ptr() as *const [Fp2; 5]) };
+        let f_cast = Fp12::from_bytes(f);
+        let x_cast = [
+            Fp2::from_bytes(&x[..48 * 2]),
+            Fp2::from_bytes(&x[48 * 2..48 * 4]),
+            Fp2::from_bytes(&x[48 * 4..48 * 6]),
+            Fp2::from_bytes(&x[48 * 6..48 * 8]),
+            Fp2::from_bytes(&x[48 * 8..48 * 10]),
+        ];
 
-        let r = Bls12_381::mul_by_02345(f_cast, x_cast);
+        let r = Bls12_381::mul_by_02345(&f_cast, &x_cast);
         let mut r_bytes = [0u8; 48 * 12];
         let mut i = 0;
         for x in r.to_coeffs() {

--- a/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
@@ -36,15 +36,14 @@ mod bn254 {
         let q1 = &io[32 * 8..32 * 12];
         let f_cmp = &io[32 * 12..32 * 24];
 
-        let s0_cast = unsafe { &*(s0.as_ptr() as *const AffinePoint<Fp>) };
-        let s1_cast = unsafe { &*(s1.as_ptr() as *const AffinePoint<Fp>) };
-        let q0_cast = unsafe { &*(q0.as_ptr() as *const AffinePoint<Fp2>) };
-        let q1_cast = unsafe { &*(q1.as_ptr() as *const AffinePoint<Fp2>) };
+        let s0_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s0[..32]), Fp::from_le_bytes(&s0[32..64]));
+        let s1_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s1[..32]), Fp::from_le_bytes(&s1[32..64]));
+        let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..64]), Fp2::from_bytes(&q0[64..128]));
+        let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..64]), Fp2::from_bytes(&q1[64..128]));
 
-        let f = Bn254::multi_miller_loop(
-            &[s0_cast.clone(), s1_cast.clone()],
-            &[q0_cast.clone(), q1_cast.clone()],
-        );
+        let f = Bn254::multi_miller_loop(&[s0_cast, s1_cast], &[q0_cast, q1_cast]);
         let mut f_bytes = [0u8; 32 * 12];
         f.to_coeffs()
             .iter()
@@ -80,10 +79,12 @@ mod bls12_381 {
         let q1 = &io[48 * 8..48 * 12];
         let f_cmp = &io[48 * 12..48 * 24];
 
-        let s0_cast = unsafe { &*(s0.as_ptr() as *const AffinePoint<Fp>) };
-        let s1_cast = unsafe { &*(s1.as_ptr() as *const AffinePoint<Fp>) };
-        let q0_cast = unsafe { &*(q0.as_ptr() as *const AffinePoint<Fp2>) };
-        let q1_cast = unsafe { &*(q1.as_ptr() as *const AffinePoint<Fp2>) };
+        let s0_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s0[..48]), Fp::from_le_bytes(&s0[48..96]));
+        let s1_cast =
+            AffinePoint::new(Fp::from_le_bytes(&s1[..48]), Fp::from_le_bytes(&s1[48..96]));
+        let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..96]), Fp2::from_bytes(&q0[96..192]));
+        let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..96]), Fp2::from_bytes(&q1[96..192]));
 
         let f = Bls12_381::multi_miller_loop(
             &[s0_cast.clone(), s1_cast.clone()],

--- a/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
@@ -12,6 +12,7 @@ openvm::entry!(main);
 
 #[cfg(feature = "bn254")]
 mod bn254 {
+    use openvm_algebra_guest::field::FieldExtension;
     use openvm_pairing_guest::bn254::{Bn254, Fp, Fp2};
 
     use super::*;
@@ -31,9 +32,9 @@ mod bn254 {
         let pt = &io[32 * 4..32 * 8];
         let l = &io[32 * 8..32 * 12];
 
-        let s_cast = unsafe { &*(s.as_ptr() as *const AffinePoint<Fp2>) };
+        let s_cast = AffinePoint::new(Fp2::from_bytes(&s[..64]), Fp2::from_bytes(&s[64..128]));
 
-        let (pt_cmp, l_cmp) = Bn254::miller_double_step(s_cast);
+        let (pt_cmp, l_cmp) = Bn254::miller_double_step(&s_cast);
         let mut pt_bytes = [0u8; 32 * 4];
         let mut l_bytes = [0u8; 32 * 4];
 
@@ -60,9 +61,9 @@ mod bn254 {
         let l0 = &io[32 * 12..32 * 16];
         let l1 = &io[32 * 16..32 * 20];
 
-        let s_cast = unsafe { &*(s.as_ptr() as *const AffinePoint<Fp2>) };
-        let q_cast = unsafe { &*(q.as_ptr() as *const AffinePoint<Fp2>) };
-        let (pt_cmp, l0_cmp, l1_cmp) = Bn254::miller_double_and_add_step(s_cast, q_cast);
+        let s_cast = AffinePoint::new(Fp2::from_bytes(&s[..64]), Fp2::from_bytes(&s[64..128]));
+        let q_cast = AffinePoint::new(Fp2::from_bytes(&q[..64]), Fp2::from_bytes(&q[64..128]));
+        let (pt_cmp, l0_cmp, l1_cmp) = Bn254::miller_double_and_add_step(&s_cast, &q_cast);
         let mut pt_bytes = [0u8; 32 * 4];
         let mut l0_bytes = [0u8; 32 * 4];
         let mut l1_bytes = [0u8; 32 * 4];
@@ -90,6 +91,7 @@ mod bn254 {
 
 #[cfg(feature = "bls12_381")]
 mod bls12_381 {
+    use openvm_algebra_guest::field::FieldExtension;
     use openvm_pairing_guest::bls12_381::{Bls12_381, Fp, Fp2};
 
     use super::*;
@@ -109,9 +111,9 @@ mod bls12_381 {
         let pt = &io[48 * 4..48 * 8];
         let l = &io[48 * 8..48 * 12];
 
-        let s_cast = unsafe { &*(s.as_ptr() as *const AffinePoint<Fp2>) };
+        let s_cast = AffinePoint::new(Fp2::from_bytes(&s[..96]), Fp2::from_bytes(&s[96..192]));
 
-        let (pt_cmp, l_cmp) = Bls12_381::miller_double_step(s_cast);
+        let (pt_cmp, l_cmp) = Bls12_381::miller_double_step(&s_cast);
         let mut pt_bytes = [0u8; 48 * 4];
         let mut l_bytes = [0u8; 48 * 4];
 
@@ -136,9 +138,9 @@ mod bls12_381 {
         let l0 = &io[48 * 12..48 * 16];
         let l1 = &io[48 * 16..48 * 20];
 
-        let s_cast = unsafe { &*(s.as_ptr() as *const AffinePoint<Fp2>) };
-        let q_cast = unsafe { &*(q.as_ptr() as *const AffinePoint<Fp2>) };
-        let (pt_cmp, l0_cmp, l1_cmp) = Bls12_381::miller_double_and_add_step(s_cast, q_cast);
+        let s_cast = AffinePoint::new(Fp2::from_bytes(&s[..96]), Fp2::from_bytes(&s[96..192]));
+        let q_cast = AffinePoint::new(Fp2::from_bytes(&q[..96]), Fp2::from_bytes(&q[96..192]));
+        let (pt_cmp, l0_cmp, l1_cmp) = Bls12_381::miller_double_and_add_step(&s_cast, &q_cast);
         let mut pt_bytes = [0u8; 48 * 4];
         let mut l0_bytes = [0u8; 48 * 4];
         let mut l1_bytes = [0u8; 48 * 4];


### PR DESCRIPTION
Rust treats `[u8; LEN]` as having alignment of `1`, so if you unsafely transmute or convert a slice to `[T; LEN]` which expects alignment of `align_of<T>()`, then this may result in misaligned load/store instructions, often during operations like memcpy. OpenVM RV32 does not support misaligned access (see https://github.com/openvm-org/openvm/pull/1474), so we make sure all our use of unsafe Rust has proper alignment.