### PR TITLE
fix: `VolatileBoundaryAir` range checks addresses

### DIFF
--- a/crates/circuits/primitives/src/utils.rs
+++ b/crates/circuits/primitives/src/utils.rs
@@ -66,3 +66,11 @@ pub fn assert_array_eq<AB: AirBuilder, I1: Into<AB::Expr>, I2: Into<AB::Expr>, c
         builder.assert_eq(x, y);
     }
 }
+
+/// Composes a list of limb values into a single field element
+#[inline]
+pub fn compose<F: FieldAlgebra>(a: &[impl Into<F> + Clone], limb_size: usize) -> F {
+    a.iter().enumerate().fold(F::ZERO, |acc, (i, x)| {
+        acc + x.clone().into() * F::from_canonical_usize(1 << (i * limb_size))
+    })
+}

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -164,7 +164,7 @@ impl VariableRangeCheckerChip {
 
     /// Range checks that `value` is `bits` bits by decomposing into `limbs` where all but
     /// last limb is `range_max_bits` bits. Assumes there are enough limbs.
-    pub(crate) fn decompose<F: Field>(&self, mut value: u32, bits: usize, limbs: &mut [F]) {
+    pub fn decompose<F: Field>(&self, mut value: u32, bits: usize, limbs: &mut [F]) {
         debug_assert!(
             limbs.len() >= bits.div_ceil(self.range_max_bits()),
             "Not enough limbs: len {}",

--- a/crates/circuits/sha256-air/src/utils.rs
+++ b/crates/circuits/sha256-air/src/utils.rs
@@ -1,5 +1,6 @@
 use std::array;
 
+pub(crate) use openvm_circuit_primitives::utils::compose;
 use openvm_circuit_primitives::{
     encoder::Encoder,
     utils::{not, select},
@@ -231,14 +232,6 @@ pub fn get_random_message(rng: &mut StdRng, len: usize) -> Vec<u8> {
     let mut random_message: Vec<u8> = vec![0u8; len];
     rng.fill(&mut random_message[..]);
     random_message
-}
-
-/// Composes a list of limb values into a single field element
-#[inline]
-pub fn compose<F: FieldAlgebra>(a: &[impl Into<F> + Clone], limb_size: usize) -> F {
-    a.iter().enumerate().fold(F::ZERO, |acc, (i, x)| {
-        acc + x.clone().into() * F::from_canonical_usize(1 << (i * limb_size))
-    })
 }
 
 /// Wrapper of `get_flag_pt` to get the flag pointer as an array

--- a/crates/circuits/sha256-air/src/utils.rs
+++ b/crates/circuits/sha256-air/src/utils.rs
@@ -1,6 +1,6 @@
 use std::array;
 
-pub(crate) use openvm_circuit_primitives::utils::compose;
+pub use openvm_circuit_primitives::utils::compose;
 use openvm_circuit_primitives::{
     encoder::Encoder,
     utils::{not, select},

--- a/docs/specs/memory.md
+++ b/docs/specs/memory.md
@@ -183,7 +183,7 @@ Assume that the MEMORY_BUS interactions and the constraints mentioned above are 
 
 ### Time goes forward
 
-In the connector chip, we constrain that the final timestamp is less than $`2^\text{timestamp\_max\_bits}`$. It is [guaranteed](https://github.com/openvm-org/stark-backend/blob/main/docs/interactions.md) that the total number of interaction messages is less than $p$. In our current circuit set, all chips increase timestamp [less than they do interactions](./circuit.md#inspection-of-vm-chip-timestamp-increments), which guarantees that the final timestamp cannot overflow: its actual (not mod $p$) value is less than $`2^\text{timestamp\_max\_bits}`$. Given that, our check that `timestamp - prev_timestamp - 1 < 2^timestamp\_max\_bits` guarantees that `prev_timestamp < timestamp` everywhere we check it.
+In the connector chip, we constrain that the final timestamp is less than $`2^\text{timestamp\_max\_bits}`$. It is [guaranteed](https://github.com/openvm-org/stark-backend/blob/main/docs/interactions.md) that the total number of interaction messages is less than $p$. In our current circuit set, all chips increase timestamp [less than they do interactions](./circuit.md#inspection-of-vm-chip-timestamp-increments), which guarantees that the final timestamp cannot overflow: its actual (not mod $p$) value is less than $`2^\text{timestamp\_max\_bits}`$. Given that, our check that `timestamp - prev_timestamp - 1 < 2^timestamp_max_bits` guarantees that `prev_timestamp < timestamp` everywhere we check it.
 
 ### Memory consistency
 

--- a/docs/specs/memory.md
+++ b/docs/specs/memory.md
@@ -183,7 +183,7 @@ Assume that the MEMORY_BUS interactions and the constraints mentioned above are 
 
 ### Time goes forward
 
-In the connector chip, we constrain that the final timestamp is less than $`2^\text{timestamp_max_bits}`$. It is [guaranteed](https://github.com/openvm-org/stark-backend/blob/main/docs/interactions.md) that the total number of interaction messages is less than $p$. In our current circuit set, all chips increase timestamp [less than they do interactions](./circuit.md#inspection-of-vm-chip-timestamp-increments), which guarantees that the final timestamp cannot overflow: its actual (not mod $p$) value is less than $`2^\text{timestamp_max_bits}`$. Given that, our check that `timestamp - prev_timestamp - 1 < 2^timestamp_max_bits` guarantees that `prev_timestamp < timestamp` everywhere we check it.
+In the connector chip, we constrain that the final timestamp is less than $`2^\text{timestamp\_max\_bits}`$. It is [guaranteed](https://github.com/openvm-org/stark-backend/blob/main/docs/interactions.md) that the total number of interaction messages is less than $p$. In our current circuit set, all chips increase timestamp [less than they do interactions](./circuit.md#inspection-of-vm-chip-timestamp-increments), which guarantees that the final timestamp cannot overflow: its actual (not mod $p$) value is less than $`2^\text{timestamp\_max\_bits}`$. Given that, our check that `timestamp - prev_timestamp - 1 < 2^timestamp\_max\_bits` guarantees that `prev_timestamp < timestamp` everywhere we check it.
 
 ### Memory consistency
 

--- a/docs/specs/memory.md
+++ b/docs/specs/memory.md
@@ -3,6 +3,7 @@
 - [Basic performed interactions](#basic-performed-interactions)
 - [Access adapters](#access-adapters)
 - [Boundary chips](#boundary-chips)
+- [Invariants](#invariants)
 - [Soundness proof](#soundness-proof)
   - [Time goes forward](#time-goes-forward)
   - [Memory consistency](#memory-consistency)
@@ -158,13 +159,31 @@ In **persistent** memory, we use `PersistentBoundaryChip` to handle the final me
 
 Both boundary chips perform, for every subsegment ever existed in our nice set, a receive interaction on birth and a send interaction on death.
 
+## Invariants
+
+The following invariants **must** be maintained by the memory architecture:
+1. In the MEMORY_BUS, the `timestamp` is always in range `[0, 2^timestamp_max_bits)` where `timestamp_max_bits <= F::bits() - 2` is a configuration constant.
+2. In the MEMORY_BUS, the `address_space` is always in range `[0, 2^as_height)` where `as_height <= F::bits() - 2` is a configuration constant.
+3. In the MEMORY_BUS, the `pointer` is always in range `[0, 2^pointer_max_bits)` where `pointer_max_bits <= F::bits() - 2` is a configuration constant.
+
+Invariant 1 is guaranteed by [time goes forward](#time-goes-forward) under the [assumption](./circuit.md#instruction-executors) that the timestamp increase during instruction execution is bounded by the number of AIR interactions.
+
+Invariant 2 and 3 are guaranteed at timestamp `0` in the MEMORY_BUS by the boundary chips:
+- VolatileBoundaryChip constrains the range checks outright.
+- PersistentBoundaryChip populates the MEMORY_BUS at timestamp `0` from the initial memory state, which is committed to in the public value `initial_memory_root`. PersistentBoundaryChip upholds Invariants 2 and 3 **assuming** that the initial memory state only contains addresses in the required range. This assumption needs to be checked outside the scope of the circuit.
+
+> [!IMPORTANT]
+> At all later timestamps, it is the responsibility of each chip to ensure their memory accesses maintain Invariants 2 and 3.
+
+We make the observation that if the `MemoryBridge` is used to add the interactions necessary for a write operation, then under the assumption that time goes forward, any attempt to write to an address out of range will lead to an unbalanced MEMORY_BUS because it will require a send at an earlier timestamp that was also out of bounds.
+
 ## Soundness proof
 
 Assume that the MEMORY_BUS interactions and the constraints mentioned above are satisfied.
 
 ### Time goes forward
 
-In the connector chip, we constrain that the final timestamp is less than $2^{29}$. It is [guaranteed](https://github.com/openvm-org/stark-backend/blob/main/docs/interactions.md) that the total number of interaction messages is less than $p$. In our current circuit set, all chips increase timestamp [less than they do interactions](./circuit.md#inspection-of-vm-chip-timestamp-increments), which guarantees that the final timestamp cannot overflow: its actual (not mod $p$) value is less than $2^{29}$. Given that, our check that `timestamp - prev_timestamp - 1 < 2^29` guarantees that `prev_timestamp < timestamp` everywhere we check it.
+In the connector chip, we constrain that the final timestamp is less than $`2^\text{timestamp_max_bits}`$. It is [guaranteed](https://github.com/openvm-org/stark-backend/blob/main/docs/interactions.md) that the total number of interaction messages is less than $p$. In our current circuit set, all chips increase timestamp [less than they do interactions](./circuit.md#inspection-of-vm-chip-timestamp-increments), which guarantees that the final timestamp cannot overflow: its actual (not mod $p$) value is less than $`2^\text{timestamp_max_bits}`$. Given that, our check that `timestamp - prev_timestamp - 1 < 2^timestamp_max_bits` guarantees that `prev_timestamp < timestamp` everywhere we check it.
 
 ### Memory consistency
 


### PR DESCRIPTION
VolatileBoundaryAir was using IsLessThanArray, which compares `x < y` **assuming** that `x, y` are both in a range `[0, max_bits)`. But for the volatile boundary case, we **must** range check this assumption, where `x = (addr_space, pointer)`.

We fix this by decomposing `addr_space, pointer` both into limbs and range checking.
I slightly optimized to only support `addr_space in [0, 2^range_max_bits)` and `pointer in [0, 2^{2*range_max_bits})` but did it with configurable constants so this could be changed to support a greater max bits in address space in the future.

Comparison Benchmark: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/13963291660 (no significant perf diff)

Closes INT-3664