### PR TITLE
Make offline memory pub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.0-rc.0#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=powdr#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.0-rc.0#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=powdr#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
 dependencies = [
  "derivative",
  "derive_more 0.99.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.0.0-rc.0", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.0.0-rc.0", default-features = false }
+openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "powdr", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "powdr", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -208,7 +208,7 @@ impl<'a, F: PrimeField32> VmInventoryBuilder<'a, F> {
 pub struct VmInventory<E, P> {
     /// Lookup table to executor ID. We store executors separately due to mutable borrow issues.
     instruction_lookup: FxHashMap<VmOpcode, ExecutorId>,
-    executors: Vec<E>,
+    pub executors: Vec<E>,
     pub(super) periphery: Vec<P>,
     /// Order of insertion. The reverse of this will be the order the chips are destroyed
     /// to generate trace.

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -101,7 +101,7 @@ pub struct MemoryController<F> {
     memory: Memory<F>,
 
     /// A reference to the `OfflineMemory`. Will be populated after `finalize()`.
-    offline_memory: Arc<Mutex<OfflineMemory<F>>>,
+    pub offline_memory: Arc<Mutex<OfflineMemory<F>>>,
 
     access_adapters: AccessAdapterInventory<F>,
 


### PR DESCRIPTION
In powdr-openvm, we use dummy chips for witgen of autoprecompiles. These chips must access the "real" offline memory. However, in our current set up we cannot do that, since the dummy chips are not part of the vm. This PR makes the offline memory public, so that we can pass the "real" memory to the dummy chips.