### PR TITLE
fix: `addr_space_max_bits` in `VolatileBoundaryChip` constructor

### DIFF
--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -41,7 +41,7 @@ pub trait VmConfig<F: PrimeField32>: Clone + Serialize + DeserializeOwned {
 pub struct MemoryConfig {
     /// The maximum height of the address space. This means the trie has `as_height` layers for searching the address space. The allowed address spaces are those in the range `[as_offset, as_offset + 2^as_height)` where `as_offset` is currently fixed to `1` to not allow address space `0` in memory.
     pub as_height: usize,
-    /// The offset of the address space.
+    /// The offset of the address space. Should be fixed to equal `1`.
     pub as_offset: u32,
     pub pointer_max_bits: usize,
     /// All timestamps must be in the range `[0, 2^clk_max_bits)`. Maximum allowed: 29.

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -232,13 +232,19 @@ impl<F: PrimeField32> MemoryController<F> {
     ) -> Self {
         let range_checker_bus = range_checker.bus();
         let initial_memory = AddressMap::from_mem_config(&mem_config);
+        assert!(mem_config.pointer_max_bits <= F::bits() - 2);
+        assert!(mem_config.as_height <= F::bits() - 2);
+        let addr_space_max_bits = log2_strict_usize(
+            (mem_config.as_offset + 2u32.pow(mem_config.as_height as u32)).next_power_of_two()
+                as usize,
+        );
         Self {
             memory_bus,
             mem_config,
             interface_chip: MemoryInterface::Volatile {
                 boundary_chip: VolatileBoundaryChip::new(
                     memory_bus,
-                    mem_config.as_height,
+                    addr_space_max_bits,
                     mem_config.pointer_max_bits,
                     range_checker.clone(),
                 ),
@@ -273,6 +279,7 @@ impl<F: PrimeField32> MemoryController<F> {
         merkle_bus: PermutationCheckBus,
         compression_bus: PermutationCheckBus,
     ) -> Self {
+        assert_eq!(mem_config.as_offset, 1);
         let memory_dims = MemoryDimensions {
             as_height: mem_config.as_height,
             address_height: mem_config.pointer_max_bits - log2_strict_usize(CHUNK),

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -233,7 +233,7 @@ impl<F: PrimeField32> MemoryController<F> {
         let range_checker_bus = range_checker.bus();
         let initial_memory = AddressMap::from_mem_config(&mem_config);
         assert!(mem_config.pointer_max_bits <= F::bits() - 2);
-        assert!(mem_config.as_height <= F::bits() - 2);
+        assert!(mem_config.as_height < F::bits() - 2);
         let addr_space_max_bits = log2_strict_usize(
             (mem_config.as_offset + 2u32.pow(mem_config.as_height as u32)).next_power_of_two()
                 as usize,

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -693,7 +693,7 @@ fn test_vm_hint() {
     type F = BabyBear;
 
     let input_stream: Vec<Vec<F>> = vec![vec![F::TWO]];
-    let config = test_native_config();
+    let config = NativeConfig::new(SystemConfig::default(), Default::default());
     air_test_with_min_segments(config, program, input_stream, 1);
 }
 

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -335,6 +335,7 @@ fn test_vm_1_persistent() {
     let engine = BabyBearPoseidon2Engine::new(FriParameters::standard_fast());
     let config = test_native_continuations_config();
     let ptr_max_bits = config.system.memory_config.pointer_max_bits;
+    let as_height = config.system.memory_config.as_height;
     let airs = VmConfig::<BabyBear>::create_chip_complex(&config)
         .unwrap()
         .airs::<BabyBearPoseidon2Config>();
@@ -373,14 +374,14 @@ fn test_vm_1_persistent() {
         );
         let mut digest = [BabyBear::ZERO; CHUNK];
         let compression = vm_poseidon2_hasher();
-        for _ in 0..=ptr_max_bits {
+        for _ in 0..ptr_max_bits + as_height - 2 {
             digest = compression.compress(&digest, &digest);
         }
         assert_eq!(
             merkle_air_proof_input.raw.public_values[..8],
             // The value when you start with zeros and repeatedly hash the value with itself
-            // 16 times. We use 16 because addr_space_max_bits = 2 and pointer_max_bits = 16,
-            // so the height of the tree is 2 + 16 - 3 = 15. The leaf also must be hashed once
+            // ptr_max_bits + as_height - 2 times.
+            // The height of the tree is ptr_max_bits + as_height - log2(8). The leaf also must be hashed once
             // with padding for security.
             digest
         );

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -7,8 +7,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         hasher::{poseidon2::vm_poseidon2_hasher, Hasher},
-        ChipId, ExecutionSegment, SingleSegmentVmExecutor, SystemConfig, SystemTraceHeights,
-        VirtualMachine, VmComplexTraceHeights, VmConfig, VmInventoryTraceHeights,
+        ChipId, ExecutionSegment, MemoryConfig, SingleSegmentVmExecutor, SystemConfig,
+        SystemTraceHeights, VirtualMachine, VmComplexTraceHeights, VmConfig,
+        VmInventoryTraceHeights,
     },
     system::{
         memory::{MemoryTraceHeights, VolatileMemoryTraceHeights, CHUNK},
@@ -56,7 +57,7 @@ where
 
 fn test_native_config() -> NativeConfig {
     NativeConfig {
-        system: SystemConfig::default(),
+        system: SystemConfig::new(3, MemoryConfig::new(2, 1, 16, 29, 15, 32, 1024), 0),
         native: Default::default(),
     }
 }

--- a/docs/specs/memory.md
+++ b/docs/specs/memory.md
@@ -163,7 +163,7 @@ Both boundary chips perform, for every subsegment ever existed in our nice set, 
 
 The following invariants **must** be maintained by the memory architecture:
 1. In the MEMORY_BUS, the `timestamp` is always in range `[0, 2^timestamp_max_bits)` where `timestamp_max_bits <= F::bits() - 2` is a configuration constant.
-2. In the MEMORY_BUS, the `address_space` is always in range `[0, 2^as_height)` where `as_height <= F::bits() - 2` is a configuration constant. (Our current implementation only supports `as_height` at most the max bits supported by the VariableRangeCheckerBus).
+2. In the MEMORY_BUS, the `address_space` is always in range `[0, 1 + 2^as_height)` where `as_height` is a configuration constant satisfying `as_height < F::bits() - 2`. (Our current implementation only supports `as_height` less than the max bits supported by the VariableRangeCheckerBus).
 3. In the MEMORY_BUS, the `pointer` is always in range `[0, 2^pointer_max_bits)` where `pointer_max_bits <= F::bits() - 2` is a configuration constant.
 
 Invariant 1 is guaranteed by [time goes forward](#time-goes-forward) under the [assumption](./circuit.md#instruction-executors) that the timestamp increase during instruction execution is bounded by the number of AIR interactions.


### PR DESCRIPTION
We were using `as_height` but it is actually `log2(1 + 2^as_height)`.