### PR TITLE
chore: `pub` chip fields necessary for serialization/deserialization

### DIFF
--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -108,8 +108,8 @@ impl<AB: InteractionBuilder + PairBuilder, const NUM_BITS: usize> Air<AB>
 
 pub struct BitwiseOperationLookupChip<const NUM_BITS: usize> {
     pub air: BitwiseOperationLookupAir<NUM_BITS>,
-    count_range: Vec<AtomicU32>,
-    count_xor: Vec<AtomicU32>,
+    pub count_range: Vec<AtomicU32>,
+    pub count_xor: Vec<AtomicU32>,
 }
 
 #[derive(Clone)]

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -101,7 +101,7 @@ impl<AB: InteractionBuilder + PairBuilder, const N: usize> Air<AB> for RangeTupl
 #[derive(Debug)]
 pub struct RangeTupleCheckerChip<const N: usize> {
     pub air: RangeTupleCheckerAir<N>,
-    count: Vec<Arc<AtomicU32>>,
+    pub count: Vec<Arc<AtomicU32>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -99,7 +99,7 @@ impl<AB: InteractionBuilder + PairBuilder> Air<AB> for VariableRangeCheckerAir {
 
 pub struct VariableRangeCheckerChip {
     pub air: VariableRangeCheckerAir,
-    count: Vec<AtomicU32>,
+    pub count: Vec<AtomicU32>,
 }
 
 #[derive(Clone)]

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -197,8 +197,8 @@ impl<'a, F: PrimeField32> VmInventoryBuilder<'a, F> {
 pub struct VmInventory<E, P> {
     /// Lookup table to executor ID. We store executors separately due to mutable borrow issues.
     instruction_lookup: FxHashMap<VmOpcode, ExecutorId>,
-    executors: Vec<E>,
-    pub(super) periphery: Vec<P>,
+    pub executors: Vec<E>,
+    pub periphery: Vec<P>,
     /// Order of insertion. The reverse of this will be the order the chips are destroyed
     /// to generate trace.
     insertion_order: Vec<ChipId>,

--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -219,7 +219,7 @@ impl<F> GenericAccessAdapterChip<F> {
 pub struct AccessAdapterChip<F, const N: usize> {
     air: AccessAdapterAir<N>,
     range_checker: SharedVariableRangeCheckerChip,
-    records: Vec<AccessAdapterRecord<F>>,
+    pub records: Vec<AccessAdapterRecord<F>>,
     overridden_height: Option<usize>,
 }
 impl<F, const N: usize> AccessAdapterChip<F, N> {

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -59,7 +59,7 @@ pub const MERKLE_AIR_OFFSET: usize = 1;
 pub const BOUNDARY_AIR_OFFSET: usize = 0;
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecordId(pub usize);
 
 pub type MemoryImage<F> = AddressMap<F, PAGE_SIZE>;

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -568,8 +568,8 @@ impl<F: Field> FriReducedOpeningRecord<F> {
 
 pub struct FriReducedOpeningChip<F: Field> {
     air: FriReducedOpeningAir,
-    records: Vec<FriReducedOpeningRecord<F>>,
-    height: usize,
+    pub records: Vec<FriReducedOpeningRecord<F>>,
+    pub height: usize,
     offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     streams: Arc<Mutex<Streams<F>>>,
 }

--- a/extensions/native/circuit/src/jal/mod.rs
+++ b/extensions/native/circuit/src/jal/mod.rs
@@ -164,7 +164,7 @@ pub struct JalRangeCheckRecord {
 /// the same chip is just to save columns.
 pub struct JalRangeCheckChip<F> {
     air: JalRangeCheckAir,
-    records: Vec<JalRangeCheckRecord>,
+    pub records: Vec<JalRangeCheckRecord>,
     offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     range_checker_chip: SharedVariableRangeCheckerChip,
     /// If true, ignore execution errors.

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -129,8 +129,8 @@ pub struct NativePoseidon2RecordSet<F: Field> {
 
 pub struct NativePoseidon2Chip<F: Field, const SBOX_REGISTERS: usize> {
     pub(super) air: NativePoseidon2Air<F, SBOX_REGISTERS>,
-    pub(super) record_set: NativePoseidon2RecordSet<F>,
-    pub(super) height: usize,
+    pub record_set: NativePoseidon2RecordSet<F>,
+    pub height: usize,
     pub(super) offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     pub(super) subchip: Poseidon2SubChip<F, SBOX_REGISTERS>,
     pub(super) streams: Arc<Mutex<Streams<F>>>,

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -275,8 +275,8 @@ pub struct Rv32HintStoreRecord<F: Field> {
 
 pub struct Rv32HintStoreChip<F: Field> {
     air: Rv32HintStoreAir,
-    records: Vec<Rv32HintStoreRecord<F>>,
-    height: usize,
+    pub records: Vec<Rv32HintStoreRecord<F>>,
+    pub height: usize,
     offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     pub streams: OnceLock<Arc<Mutex<Streams<F>>>>,
     bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,


### PR DESCRIPTION
These are public chip fields that were previously used to implement `Stateful`. Exposing them publicly allows an external repo to handle serialization and deserialization of those fields. The list of these fields is tracked here: https://docs.google.com/document/d/1yFUDUlXcObTYrLBWoDV0I-zmBQJ1kIQ9LAv-_fCPb8U