### PR TITLE
chore: String::new() over "".to_string() 

### DIFF
--- a/extensions/native/recursion/src/halo2/wrapper.rs
+++ b/extensions/native/recursion/src/halo2/wrapper.rs
@@ -217,7 +217,7 @@ fn gen_evm_verifier(
         sol_code,
         artifact: EvmVerifierByteCode {
             sol_compiler_version: "0.8.19".to_string(),
-            sol_compiler_options: "".to_string(),
+            sol_compiler_options: String::new(),
             bytecode: byte_code,
         },
     }


### PR DESCRIPTION
PR: https://github.com/openvm-org/openvm/pull/1487  Introduced `"".to_string()`

other place use `String::new()` keep consistency
https://github.com/openvm-org/openvm/blob/efb782371b0fad77c597b77be64bfab75b20c5a6/crates/prof/src/types.rs#L128