### PR TITLE
feat(sdk): hardware and language independent encoding of inner STARK `Proof`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4489,6 +4489,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "openvm-transpiler",
+ "p3-fri",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -1,4 +1,3 @@
-use openvm_circuit::arch::SystemConfig;
 use openvm_sdk::config::{AppConfig, SdkVmConfig, DEFAULT_APP_LOG_BLOWUP, DEFAULT_LEAF_LOG_BLOWUP};
 use openvm_stark_sdk::config::FriParameters;
 

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -1,3 +1,4 @@
+use openvm_circuit::arch::SystemConfig;
 use openvm_sdk::config::{AppConfig, SdkVmConfig, DEFAULT_APP_LOG_BLOWUP, DEFAULT_LEAF_LOG_BLOWUP};
 use openvm_stark_sdk::config::FriParameters;
 

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+p3-fri = { workspace = true }
 openvm-algebra-circuit = { workspace = true }
 openvm-algebra-transpiler = { workspace = true }
 openvm-bigint-circuit = { workspace = true }

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -1,0 +1,195 @@
+use openvm_native_compiler::ir::DIGEST_SIZE;
+use openvm_stark_backend::{
+    config::{Com, PcsProof, StarkGenericConfig},
+    p3_commit::OpenedValues,
+    p3_field::{FieldExtensionAlgebra, PrimeField32},
+    proof::{AdjacentOpenedValues, OpeningProof, Proof},
+};
+
+use super::{F, SC}; // BabyBearPoseidon2Config
+
+type Challenge = <SC as StarkGenericConfig>::Challenge;
+
+// We need to know:
+// - Pcs is TwoAdicFriPcs
+// - Com<SC>: Into<[F; 8]>
+pub fn encode_proof(proof: &Proof<SC>) -> Vec<u32> {
+    let mut encoded = Vec::new();
+    // main
+    encoded.push(proof.commitments.main_trace.len().try_into().unwrap());
+    for &com in &proof.commitments.main_trace {
+        encoded.extend(encode_commitment(com));
+    }
+    // after challenge
+    encoded.push(proof.commitments.after_challenge.len().try_into().unwrap());
+    for &com in &proof.commitments.after_challenge {
+        encoded.extend(encode_commitment(com));
+    }
+    // quotient
+    encoded.extend(encode_commitment(proof.commitments.quotient));
+
+    // Encode OpeningProof
+    encoded.extend(encode_opening_proof(&proof.opening));
+
+    // Encode per_air data
+    encoded.push(proof.per_air.len().try_into().unwrap());
+    for air_data in &proof.per_air {
+        encoded.extend(encode_air_proof_data(air_data));
+    }
+
+    // Encode rap_phase_seq_proof if it exists
+    encoded.push(if proof.rap_phase_seq_proof.is_some() {
+        1
+    } else {
+        0
+    });
+    if let Some(rap_proof) = &proof.rap_phase_seq_proof {
+        encoded.extend(encode_rap_phase_seq_proof(rap_proof));
+    }
+
+    encoded
+}
+
+fn encode_opening_proof(opening: &OpeningProof<PcsProof<SC>, Challenge>) -> Vec<u32> {
+    let mut encoded = Vec::new();
+
+    // Encode PCS proof (this would depend on the PcsProof structure)
+    encoded.extend(encode_pcs_proof(&opening.proof));
+
+    // Encode OpenedValues
+    encoded.extend(encode_opened_values(&opening.values));
+
+    encoded
+}
+
+fn encode_opened_values(values: &OpenedValues<SC::Challenge>) -> Vec<u32> {
+    let mut encoded = Vec::new();
+
+    // Encode preprocessed values
+    encoded.push(values.preprocessed.len().try_into().unwrap());
+    for adjacent in &values.preprocessed {
+        encoded.extend(encode_adjacent_opened_values(adjacent));
+    }
+
+    // Encode main values
+    encoded.push(values.main.len().try_into().unwrap());
+    for matrices in &values.main {
+        encoded.push(matrices.len().try_into().unwrap());
+        for adjacent in matrices {
+            encoded.extend(encode_adjacent_opened_values(adjacent));
+        }
+    }
+
+    // Encode after_challenge values
+    encoded.push(values.after_challenge.len().try_into().unwrap());
+    for matrices in &values.after_challenge {
+        encoded.push(matrices.len().try_into().unwrap());
+        for adjacent in matrices {
+            encoded.extend(encode_adjacent_opened_values(adjacent));
+        }
+    }
+
+    // Encode quotient values
+    encoded.push(values.quotient.len().try_into().unwrap());
+    for rap in &values.quotient {
+        encoded.push(rap.len().try_into().unwrap());
+        for chunk in rap {
+            encoded.push(chunk.len().try_into().unwrap());
+            for &val in chunk {
+                encoded.push(encode_challenge(val));
+            }
+        }
+    }
+
+    encoded
+}
+
+fn encode_adjacent_opened_values(adjacent: &AdjacentOpenedValues<Challenge>) -> Vec<u32> {
+    let mut encoded = Vec::new();
+
+    // Encode local values
+    encoded.push(adjacent.local.len().try_into().unwrap());
+    for &val in &adjacent.local {
+        encoded.push(encode_challenge(val));
+    }
+
+    // Encode next values
+    encoded.push(adjacent.next.len().try_into().unwrap());
+    for &val in &adjacent.next {
+        encoded.push(encode_challenge(val));
+    }
+
+    encoded
+}
+
+fn encode_air_proof_data(data: &AirProofData<Val<SC>, SC::Challenge>) -> Vec<u32> {
+    let mut encoded = Vec::new();
+
+    // Encode air_id
+    encoded.push(data.air_id.try_into().unwrap());
+
+    // Encode degree
+    encoded.push(data.degree.try_into().unwrap());
+
+    // Encode exposed_values_after_challenge
+    encoded.push(
+        data.exposed_values_after_challenge
+            .len()
+            .try_into()
+            .unwrap(),
+    );
+    for phase in &data.exposed_values_after_challenge {
+        encoded.push(phase.len().try_into().unwrap());
+        for &val in phase {
+            encoded.push(encode_challenge(val));
+        }
+    }
+
+    // Encode public_values
+    encoded.push(data.public_values.len().try_into().unwrap());
+    for &val in &data.public_values {
+        encoded.push(encode_val(val));
+    }
+
+    encoded
+}
+
+// Helper function to encode PcsProof (depends on actual structure)
+fn encode_pcs_proof(proof: &PcsProof<SC>) -> Vec<u32> {
+    // Implementation would depend on the structure of PcsProof<SC>
+    // For example, if it contains FRI proofs, commitments, etc.
+    // This is a placeholder
+    let mut encoded = Vec::new();
+
+    // You would need to implement this based on PcsProof structure
+    // ...
+
+    encoded
+}
+
+// Function to encode RapPhaseSeqPartialProof
+fn encode_rap_phase_seq_proof(proof: &RapPhaseSeqPartialProof<SC>) -> Vec<u32> {
+    // Implementation would depend on the structure of RapPhaseSeqPartialProof<SC>
+    // This is a placeholder
+    let mut encoded = Vec::new();
+
+    // You would need to implement this based on RapPhaseSeqPartialProof structure
+    // ...
+
+    encoded
+}
+
+fn encode_commitment(com: Com<SC>) -> [u32; DIGEST_SIZE] {
+    let com_array: [F; DIGEST_SIZE] = com.into();
+    com_array.map(encode_val)
+}
+
+// Helper function to encode Challenge type
+fn encode_challenge(challenge: <SC as StarkGenericConfig>::Challenge) -> Vec<u32> {
+    let base_slice: &[F] = challenge.as_base_slice();
+    base_slice.iter().copied().map(encode_val).collect()
+}
+
+fn encode_val<F: PrimeField32>(val: F) -> u32 {
+    val.as_canonical_u32()
+}

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -1,195 +1,210 @@
+use std::io::{self, Result};
+
 use openvm_native_compiler::ir::DIGEST_SIZE;
+use openvm_native_recursion::hints::{
+    InnerBatchOpening, InnerFriProof, InnerQueryProof, InnerValMmcs,
+};
 use openvm_stark_backend::{
     config::{Com, PcsProof, StarkGenericConfig},
+    interaction::fri_log_up::FriLogUpPartialProof,
     p3_commit::OpenedValues,
-    p3_field::{FieldExtensionAlgebra, PrimeField32},
-    proof::{AdjacentOpenedValues, OpeningProof, Proof},
+    p3_field::{extension::BinomialExtensionField, FieldExtensionAlgebra, PrimeField32},
+    proof::{AdjacentOpenedValues, AirProofData, OpeningProof, Proof},
 };
 
 use super::{F, SC}; // BabyBearPoseidon2Config
 
-type Challenge = <SC as StarkGenericConfig>::Challenge;
+type Challenge = BinomialExtensionField<F, 4>;
+
+/// Hardware and language independent encoding.
+/// Vector lengths must be unsigned integers at most `u32::MAX`.
+// @dev Private trait right now just for implementation sanity
+trait Encode {
+    fn encode(&self) -> Result<Vec<u8>>;
+}
 
 // We need to know:
 // - Pcs is TwoAdicFriPcs
 // - Com<SC>: Into<[F; 8]>
-pub fn encode_proof(proof: &Proof<SC>) -> Vec<u32> {
+// For simplicity, we only implement for fixed `BabyBearPoseidon2Config`
+pub fn encode_proof(proof: &Proof<SC>) -> Result<Vec<u8>> {
     let mut encoded = Vec::new();
-    // main
-    encoded.push(proof.commitments.main_trace.len().try_into().unwrap());
-    for &com in &proof.commitments.main_trace {
-        encoded.extend(encode_commitment(com));
-    }
-    // after challenge
-    encoded.push(proof.commitments.after_challenge.len().try_into().unwrap());
-    for &com in &proof.commitments.after_challenge {
-        encoded.extend(encode_commitment(com));
-    }
-    // quotient
-    encoded.extend(encode_commitment(proof.commitments.quotient));
+
+    // Encode commitments
+    encoded.extend(encode_commitments(&proof.commitments.main_trace)?);
+    encoded.extend(encode_commitments(&proof.commitments.after_challenge)?);
+    let quotient_commit: [F; DIGEST_SIZE] = proof.commitments.quotient.into();
+    encoded.extend(quotient_commit.encode()?);
 
     // Encode OpeningProof
-    encoded.extend(encode_opening_proof(&proof.opening));
+    encoded.extend(encode_opening_proof(&proof.opening)?);
 
     // Encode per_air data
-    encoded.push(proof.per_air.len().try_into().unwrap());
-    for air_data in &proof.per_air {
-        encoded.extend(encode_air_proof_data(air_data));
-    }
+    encode_slice(&proof.per_air)?;
+    // Encode logup witness
+    encoded.extend(proof.rap_phase_seq_proof.encode()?);
 
-    // Encode rap_phase_seq_proof if it exists
-    encoded.push(if proof.rap_phase_seq_proof.is_some() {
-        1
-    } else {
-        0
-    });
-    if let Some(rap_proof) = &proof.rap_phase_seq_proof {
-        encoded.extend(encode_rap_phase_seq_proof(rap_proof));
-    }
-
-    encoded
+    Ok(encoded)
 }
 
-fn encode_opening_proof(opening: &OpeningProof<PcsProof<SC>, Challenge>) -> Vec<u32> {
+// Helper function to encode OpeningProof
+fn encode_opening_proof(opening: &OpeningProof<PcsProof<SC>, Challenge>) -> Result<Vec<u8>> {
     let mut encoded = Vec::new();
 
-    // Encode PCS proof (this would depend on the PcsProof structure)
-    encoded.extend(encode_pcs_proof(&opening.proof));
+    // Encode PCS proof
+    encoded.extend(encode_pcs_proof(&opening.proof)?);
 
     // Encode OpenedValues
-    encoded.extend(encode_opened_values(&opening.values));
+    encoded.extend(opening.values.encode()?);
 
-    encoded
+    Ok(encoded)
 }
 
-fn encode_opened_values(values: &OpenedValues<SC::Challenge>) -> Vec<u32> {
-    let mut encoded = Vec::new();
+impl Encode for OpenedValues<Challenge> {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut encoded = Vec::new();
 
-    // Encode preprocessed values
-    encoded.push(values.preprocessed.len().try_into().unwrap());
-    for adjacent in &values.preprocessed {
-        encoded.extend(encode_adjacent_opened_values(adjacent));
-    }
+        // Encode preprocessed values
+        encoded.extend(encode_slice(&values.preprocessed)?);
 
-    // Encode main values
-    encoded.push(values.main.len().try_into().unwrap());
-    for matrices in &values.main {
-        encoded.push(matrices.len().try_into().unwrap());
-        for adjacent in matrices {
-            encoded.extend(encode_adjacent_opened_values(adjacent));
+        // Encode main values
+        let main_len: u32 = values.main.len().try_into().map_err(io::Error::other)?;
+        encoded.extend(main_len.to_le_bytes().to_vec());
+        for matrices in &values.main {
+            encoded.extend(encode_slice(matrices)?);
         }
-    }
 
-    // Encode after_challenge values
-    encoded.push(values.after_challenge.len().try_into().unwrap());
-    for matrices in &values.after_challenge {
-        encoded.push(matrices.len().try_into().unwrap());
-        for adjacent in matrices {
-            encoded.extend(encode_adjacent_opened_values(adjacent));
-        }
-    }
-
-    // Encode quotient values
-    encoded.push(values.quotient.len().try_into().unwrap());
-    for rap in &values.quotient {
-        encoded.push(rap.len().try_into().unwrap());
-        for chunk in rap {
-            encoded.push(chunk.len().try_into().unwrap());
-            for &val in chunk {
-                encoded.push(encode_challenge(val));
-            }
-        }
-    }
-
-    encoded
-}
-
-fn encode_adjacent_opened_values(adjacent: &AdjacentOpenedValues<Challenge>) -> Vec<u32> {
-    let mut encoded = Vec::new();
-
-    // Encode local values
-    encoded.push(adjacent.local.len().try_into().unwrap());
-    for &val in &adjacent.local {
-        encoded.push(encode_challenge(val));
-    }
-
-    // Encode next values
-    encoded.push(adjacent.next.len().try_into().unwrap());
-    for &val in &adjacent.next {
-        encoded.push(encode_challenge(val));
-    }
-
-    encoded
-}
-
-fn encode_air_proof_data(data: &AirProofData<Val<SC>, SC::Challenge>) -> Vec<u32> {
-    let mut encoded = Vec::new();
-
-    // Encode air_id
-    encoded.push(data.air_id.try_into().unwrap());
-
-    // Encode degree
-    encoded.push(data.degree.try_into().unwrap());
-
-    // Encode exposed_values_after_challenge
-    encoded.push(
-        data.exposed_values_after_challenge
+        // Encode after_challenge values
+        let after_challenge_len: u32 = values
+            .after_challenge
             .len()
             .try_into()
-            .unwrap(),
-    );
-    for phase in &data.exposed_values_after_challenge {
-        encoded.push(phase.len().try_into().unwrap());
-        for &val in phase {
-            encoded.push(encode_challenge(val));
+            .map_err(io::Error::other)?;
+        encoded.extend(after_challenge_len.to_le_bytes().to_vec());
+        for matrices in &values.after_challenge {
+            encoded.extend(encode_slice(matrices)?);
+        }
+
+        // Encode quotient values
+        let quotient_len: u32 = values.quotient.len().try_into().map_err(io::Error::other)?;
+        encoded.extend(quotient_len.to_le_bytes().to_vec());
+        for rap in &values.quotient {
+            let rap_len: u32 = rap.len().try_into().map_err(io::Error::other)?;
+            encoded.extend(rap_len.to_le_bytes().to_vec());
+            for chunk in rap {
+                encoded.extend(encode_slice(chunk)?);
+            }
+        }
+
+        Ok(encoded)
+    }
+}
+
+impl Encode for AdjacentOpenedValues<Challenge> {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let local = encode_slice(&self.local)?;
+        let next = encode_slice(&self.next)?;
+        Ok([local, next].concat())
+    }
+}
+
+impl Encode for AirProofData<F, Challenge> {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut encoded = Vec::new();
+        encoded.extend(self.air_id.encode()?);
+        encoded.extend(self.degree.encode()?);
+        encoded.extend(self.exposed_values_after_challenge.len().encode()?);
+        for exposed_vals in &self.exposed_values_after_challenge {
+            encode_slice(exposed_vals)?;
+        }
+        encode_slice(&self.public_values)?;
+        Ok(encoded)
+    }
+}
+
+// PcsProof<SC> = InnerFriProof where Pcs = TwoAdicFriPcs
+impl Encode for InnerFriProof {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut encoded = Vec::new();
+        encoded.extend(encode_commitments(&self.commit_phase_commits)?);
+        encode_slice(&self.query_proofs)?;
+        encode_slice(&self.final_poly)?;
+        encoded.extend(self.pow_witness.encode()?);
+
+        Ok(encoded)
+    }
+}
+
+impl Encode for InnerQueryProof {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut encoded = Vec::new();
+        encoded.extend(encode_slice(&self.input_proof)?);
+        encoded.extend(encode_slice(&self.commit_phase_openings)?);
+        Ok(encoded)
+    }
+}
+
+impl Encode for InnerBatchOpening {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut encoded = Vec::new();
+        encoded.extend(self.opened_values.len().encode()?);
+        for vals in &self.opened_values {
+            encoded.extend(encode_slice(vals)?);
+        }
+        // Opening proof is just a vector of siblings
+        encoded.extend(encode_slice(&self.opening_proof)?);
+        Ok(encoded)
+    }
+}
+
+impl Encode for Option<FriLogUpPartialProof<F>> {
+    fn encode(&self) -> Result<Vec<u8>> {
+        match self {
+            // If exists, `F` will be < MODULUS < 2^31 so it will
+            // never collide with u32::MAX
+            Some(FriLogUpPartialProof { logup_pow_witness }) => logup_pow_witness.encode(),
+            None => Ok(u32::MAX.to_le_bytes().to_vec()),
         }
     }
+}
 
-    // Encode public_values
-    encoded.push(data.public_values.len().try_into().unwrap());
-    for &val in &data.public_values {
-        encoded.push(encode_val(val));
+impl Encode for Challenge {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let base_slice: &[F] = self.as_base_slice();
+        encode_slice(base_slice)
     }
-
-    encoded
 }
 
-// Helper function to encode PcsProof (depends on actual structure)
-fn encode_pcs_proof(proof: &PcsProof<SC>) -> Vec<u32> {
-    // Implementation would depend on the structure of PcsProof<SC>
-    // For example, if it contains FRI proofs, commitments, etc.
-    // This is a placeholder
-    let mut encoded = Vec::new();
-
-    // You would need to implement this based on PcsProof structure
-    // ...
-
-    encoded
+/// Encodes length of slice and then each commitment
+fn encode_commitments(commitments: &[Com<SC>]) -> Result<Vec<u8>> {
+    let coms: Vec<[F; DIGEST_SIZE]> = commitments.iter().copied().map(Into::into).collect();
+    encode_slice(&coms)
 }
 
-// Function to encode RapPhaseSeqPartialProof
-fn encode_rap_phase_seq_proof(proof: &RapPhaseSeqPartialProof<SC>) -> Vec<u32> {
-    // Implementation would depend on the structure of RapPhaseSeqPartialProof<SC>
-    // This is a placeholder
-    let mut encoded = Vec::new();
-
-    // You would need to implement this based on RapPhaseSeqPartialProof structure
-    // ...
-
-    encoded
+// Can't implement Encode on Com<SC> because Rust complains about associated trait types when you don't own the trait (in this case SC)
+impl Encode for [F; DIGEST_SIZE] {
+    fn encode(&self) -> Result<Vec<u8>> {
+        encode_slice(self)
+    }
 }
 
-fn encode_commitment(com: Com<SC>) -> [u32; DIGEST_SIZE] {
-    let com_array: [F; DIGEST_SIZE] = com.into();
-    com_array.map(encode_val)
+fn encode_slice<T: Encode>(slice: &[T]) -> Result<Vec<u8>> {
+    let mut encoded = slice.len().encode()?;
+    for elt in slice {
+        encoded.extend(elt.encode()?);
+    }
+    Ok(encoded)
 }
 
-// Helper function to encode Challenge type
-fn encode_challenge(challenge: <SC as StarkGenericConfig>::Challenge) -> Vec<u32> {
-    let base_slice: &[F] = challenge.as_base_slice();
-    base_slice.iter().copied().map(encode_val).collect()
+impl Encode for F {
+    fn encode(&self) -> Result<Vec<u8>> {
+        Ok(self.as_canonical_u32().to_le_bytes().to_vec())
+    }
 }
 
-fn encode_val<F: PrimeField32>(val: F) -> u32 {
-    val.as_canonical_u32()
+impl Encode for usize {
+    fn encode(&self) -> Result<Vec<u8>> {
+        let x: u32 = (*self).try_into().map_err(io::Error::other)?;
+        Ok(x.to_le_bytes().to_vec())
+    }
 }

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -18,8 +18,8 @@ type Challenge = BinomialExtensionField<F, 4>;
 
 /// Hardware and language independent encoding.
 /// Uses the Writer pattern for more efficient encoding without intermediate buffers.
-// @dev Private trait right now just for implementation sanity
-trait Encode {
+// @dev Trait just for implementation sanity
+pub trait Encode {
     /// Writes the encoded representation of `self` to the given writer.
     fn encode<W: Write>(&self, writer: &mut W) -> Result<()>;
 
@@ -132,6 +132,7 @@ impl Encode for InnerFriProof {
 
 impl Encode for InnerQueryProof {
     fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        // Input proof for MerkleTree MMCS is just vector of sibling hashes
         encode_slice(&self.input_proof, writer)?;
         encode_slice(&self.commit_phase_openings, writer)?;
         Ok(())

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Result};
+use std::io::{self, Result, Write};
 
 use openvm_native_compiler::ir::DIGEST_SIZE;
 use openvm_native_recursion::hints::{
@@ -17,194 +17,195 @@ use super::{F, SC}; // BabyBearPoseidon2Config
 type Challenge = BinomialExtensionField<F, 4>;
 
 /// Hardware and language independent encoding.
-/// Vector lengths must be unsigned integers at most `u32::MAX`.
+/// Uses the Writer pattern for more efficient encoding without intermediate buffers.
 // @dev Private trait right now just for implementation sanity
 trait Encode {
-    fn encode(&self) -> Result<Vec<u8>>;
+    /// Writes the encoded representation of `self` to the given writer.
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()>;
+
+    /// Convenience method to encode into a Vec<u8>
+    fn encode_to_vec(&self) -> Result<Vec<u8>> {
+        let mut buffer = Vec::new();
+        self.encode(&mut buffer)?;
+        Ok(buffer)
+    }
 }
 
 // We need to know:
 // - Pcs is TwoAdicFriPcs
 // - Com<SC>: Into<[F; 8]>
 // For simplicity, we only implement for fixed `BabyBearPoseidon2Config`
-pub fn encode_proof(proof: &Proof<SC>) -> Result<Vec<u8>> {
-    let mut encoded = Vec::new();
-
+pub fn encode_proof<W: Write>(proof: &Proof<SC>, writer: &mut W) -> Result<()> {
     // Encode commitments
-    encoded.extend(encode_commitments(&proof.commitments.main_trace)?);
-    encoded.extend(encode_commitments(&proof.commitments.after_challenge)?);
+    encode_commitments(&proof.commitments.main_trace, writer)?;
+    encode_commitments(&proof.commitments.after_challenge, writer)?;
     let quotient_commit: [F; DIGEST_SIZE] = proof.commitments.quotient.into();
-    encoded.extend(quotient_commit.encode()?);
+    quotient_commit.encode(writer)?;
 
     // Encode OpeningProof
-    encoded.extend(encode_opening_proof(&proof.opening)?);
+    encode_opening_proof(&proof.opening, writer)?;
 
     // Encode per_air data
-    encode_slice(&proof.per_air)?;
-    // Encode logup witness
-    encoded.extend(proof.rap_phase_seq_proof.encode()?);
+    encode_slice(&proof.per_air, writer)?;
 
-    Ok(encoded)
+    // Encode logup witness
+    proof.rap_phase_seq_proof.encode(writer)?;
+
+    Ok(())
 }
 
 // Helper function to encode OpeningProof
-fn encode_opening_proof(opening: &OpeningProof<PcsProof<SC>, Challenge>) -> Result<Vec<u8>> {
-    let mut encoded = Vec::new();
-
+fn encode_opening_proof<W: Write>(
+    opening: &OpeningProof<PcsProof<SC>, Challenge>,
+    writer: &mut W,
+) -> Result<()> {
     // Encode PCS proof
-    encoded.extend(encode_pcs_proof(&opening.proof)?);
+    encode_pcs_proof(&opening.proof, writer)?;
 
     // Encode OpenedValues
-    encoded.extend(opening.values.encode()?);
+    opening.values.encode(writer)?;
 
-    Ok(encoded)
+    Ok(())
 }
 
 impl Encode for OpenedValues<Challenge> {
-    fn encode(&self) -> Result<Vec<u8>> {
-        let mut encoded = Vec::new();
-
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
         // Encode preprocessed values
-        encoded.extend(encode_slice(&values.preprocessed)?);
+        encode_slice(&self.preprocessed, writer)?;
 
         // Encode main values
-        let main_len: u32 = values.main.len().try_into().map_err(io::Error::other)?;
-        encoded.extend(main_len.to_le_bytes().to_vec());
-        for matrices in &values.main {
-            encoded.extend(encode_slice(matrices)?);
+        (self.main.len() as u32).encode(writer)?;
+        for matrices in &self.main {
+            encode_slice(matrices, writer)?;
         }
 
         // Encode after_challenge values
-        let after_challenge_len: u32 = values
-            .after_challenge
-            .len()
-            .try_into()
-            .map_err(io::Error::other)?;
-        encoded.extend(after_challenge_len.to_le_bytes().to_vec());
-        for matrices in &values.after_challenge {
-            encoded.extend(encode_slice(matrices)?);
+        self.after_challenge.len().encode(writer)?;
+        for matrices in &self.after_challenge {
+            encode_slice(matrices, writer)?;
         }
 
         // Encode quotient values
-        let quotient_len: u32 = values.quotient.len().try_into().map_err(io::Error::other)?;
-        encoded.extend(quotient_len.to_le_bytes().to_vec());
-        for rap in &values.quotient {
-            let rap_len: u32 = rap.len().try_into().map_err(io::Error::other)?;
-            encoded.extend(rap_len.to_le_bytes().to_vec());
+        self.quotient.len().encode(writer)?;
+        for rap in &self.quotient {
+            (rap.len() as u32).encode(writer)?;
             for chunk in rap {
-                encoded.extend(encode_slice(chunk)?);
+                encode_slice(chunk, writer)?;
             }
         }
 
-        Ok(encoded)
+        Ok(())
     }
 }
 
 impl Encode for AdjacentOpenedValues<Challenge> {
-    fn encode(&self) -> Result<Vec<u8>> {
-        let local = encode_slice(&self.local)?;
-        let next = encode_slice(&self.next)?;
-        Ok([local, next].concat())
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        encode_slice(&self.local, writer)?;
+        encode_slice(&self.next, writer)?;
+        Ok(())
     }
 }
 
 impl Encode for AirProofData<F, Challenge> {
-    fn encode(&self) -> Result<Vec<u8>> {
-        let mut encoded = Vec::new();
-        encoded.extend(self.air_id.encode()?);
-        encoded.extend(self.degree.encode()?);
-        encoded.extend(self.exposed_values_after_challenge.len().encode()?);
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        self.air_id.encode(writer)?;
+        self.degree.encode(writer)?;
+        self.exposed_values_after_challenge.len().encode(writer)?;
         for exposed_vals in &self.exposed_values_after_challenge {
-            encode_slice(exposed_vals)?;
+            encode_slice(exposed_vals, writer)?;
         }
-        encode_slice(&self.public_values)?;
-        Ok(encoded)
+        encode_slice(&self.public_values, writer)?;
+        Ok(())
     }
 }
 
 // PcsProof<SC> = InnerFriProof where Pcs = TwoAdicFriPcs
 impl Encode for InnerFriProof {
-    fn encode(&self) -> Result<Vec<u8>> {
-        let mut encoded = Vec::new();
-        encoded.extend(encode_commitments(&self.commit_phase_commits)?);
-        encode_slice(&self.query_proofs)?;
-        encode_slice(&self.final_poly)?;
-        encoded.extend(self.pow_witness.encode()?);
-
-        Ok(encoded)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        encode_commitments(&self.commit_phase_commits, writer)?;
+        encode_slice(&self.query_proofs, writer)?;
+        encode_slice(&self.final_poly, writer)?;
+        self.pow_witness.encode(writer)?;
+        Ok(())
     }
 }
 
 impl Encode for InnerQueryProof {
-    fn encode(&self) -> Result<Vec<u8>> {
-        let mut encoded = Vec::new();
-        encoded.extend(encode_slice(&self.input_proof)?);
-        encoded.extend(encode_slice(&self.commit_phase_openings)?);
-        Ok(encoded)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        encode_slice(&self.input_proof, writer)?;
+        encode_slice(&self.commit_phase_openings, writer)?;
+        Ok(())
     }
 }
 
 impl Encode for InnerBatchOpening {
-    fn encode(&self) -> Result<Vec<u8>> {
-        let mut encoded = Vec::new();
-        encoded.extend(self.opened_values.len().encode()?);
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        self.opened_values.len().encode(writer)?;
         for vals in &self.opened_values {
-            encoded.extend(encode_slice(vals)?);
+            encode_slice(vals, writer)?;
         }
         // Opening proof is just a vector of siblings
-        encoded.extend(encode_slice(&self.opening_proof)?);
-        Ok(encoded)
+        encode_slice(&self.opening_proof, writer)?;
+        Ok(())
     }
 }
 
 impl Encode for Option<FriLogUpPartialProof<F>> {
-    fn encode(&self) -> Result<Vec<u8>> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
         match self {
             // If exists, `F` will be < MODULUS < 2^31 so it will
             // never collide with u32::MAX
-            Some(FriLogUpPartialProof { logup_pow_witness }) => logup_pow_witness.encode(),
-            None => Ok(u32::MAX.to_le_bytes().to_vec()),
+            Some(FriLogUpPartialProof { logup_pow_witness }) => logup_pow_witness.encode(writer),
+            None => writer.write_all(&u32::MAX.to_le_bytes()),
         }
     }
 }
 
 impl Encode for Challenge {
-    fn encode(&self) -> Result<Vec<u8>> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
         let base_slice: &[F] = self.as_base_slice();
-        encode_slice(base_slice)
+        // Fixed length slice, so don't encode length
+        for val in base_slice {
+            val.encode(writer)?;
+        }
+        Ok(())
     }
 }
 
 /// Encodes length of slice and then each commitment
-fn encode_commitments(commitments: &[Com<SC>]) -> Result<Vec<u8>> {
+fn encode_commitments<W: Write>(commitments: &[Com<SC>], writer: &mut W) -> Result<()> {
     let coms: Vec<[F; DIGEST_SIZE]> = commitments.iter().copied().map(Into::into).collect();
-    encode_slice(&coms)
+    encode_slice(&coms, writer)
 }
 
 // Can't implement Encode on Com<SC> because Rust complains about associated trait types when you don't own the trait (in this case SC)
 impl Encode for [F; DIGEST_SIZE] {
-    fn encode(&self) -> Result<Vec<u8>> {
-        encode_slice(self)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        for val in self {
+            val.encode(writer)?;
+        }
+        Ok(())
     }
 }
 
-fn encode_slice<T: Encode>(slice: &[T]) -> Result<Vec<u8>> {
-    let mut encoded = slice.len().encode()?;
+/// Encodes length of slice and then each element
+fn encode_slice<T: Encode, W: Write>(slice: &[T], writer: &mut W) -> Result<()> {
+    slice.len().encode(writer)?;
     for elt in slice {
-        encoded.extend(elt.encode()?);
+        elt.encode(writer)?;
     }
-    Ok(encoded)
+    Ok(())
 }
 
 impl Encode for F {
-    fn encode(&self) -> Result<Vec<u8>> {
-        Ok(self.as_canonical_u32().to_le_bytes().to_vec())
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        writer.write_all(&self.as_canonical_u32().to_le_bytes())
     }
 }
 
 impl Encode for usize {
-    fn encode(&self) -> Result<Vec<u8>> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
         let x: u32 = (*self).try_into().map_err(io::Error::other)?;
-        Ok(x.to_le_bytes().to_vec())
+        writer.write_all(&x.to_le_bytes())
     }
 }

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -66,6 +66,14 @@ pub fn decode_proof_from_bytes(bytes: &[u8]) -> Result<Proof<SC>> {
 //
 /// Encode a proof using FRI as the PCS with `BabyBearPoseidon2Config`.
 /// The Merkle tree hashes have digest `[F; 8]`.
+/// ```
+/// pub struct Proof<SC: StarkGenericConfig> {
+///     pub commitments: Commitments<Com<SC>>,
+///     pub opening: OpeningProof<PcsProof<SC>, SC::Challenge>,
+///     pub per_air: Vec<AirProofData<Val<SC>, SC::Challenge>>,
+///     pub rap_phase_seq_proof: Option<RapPhaseSeqPartialProof<SC>>,
+/// }
+/// ```
 pub fn encode_proof<W: Write>(proof: &Proof<SC>, writer: &mut W) -> Result<()> {
     writer.write_all(&CODEC_VERSION.to_le_bytes())?;
     // Encode commitments
@@ -88,6 +96,12 @@ pub fn encode_proof<W: Write>(proof: &Proof<SC>, writer: &mut W) -> Result<()> {
 }
 
 // Helper function to encode OpeningProof
+// ```
+// pub struct OpeningProof<PcsProof, Challenge> {
+//    pub proof: PcsProof,
+//    pub values: OpenedValues<Challenge>,
+// }
+// ```
 fn encode_opening_proof<W: Write>(
     opening: &OpeningProof<PcsProof<SC>, Challenge>,
     writer: &mut W,
@@ -136,6 +150,15 @@ impl Encode for AdjacentOpenedValues<Challenge> {
 }
 
 impl Encode for AirProofData<F, Challenge> {
+    /// Encodes the struct
+    /// ```
+    /// pub struct OpenedValues<Challenge> {
+    ///     pub preprocessed: Vec<AdjacentOpenedValues<Challenge>>,
+    ///     pub main: Vec<Vec<AdjacentOpenedValues<Challenge>>>,
+    ///     pub after_challenge: Vec<Vec<AdjacentOpenedValues<Challenge>>>,
+    ///     pub quotient: Vec<Vec<Vec<Challenge>>>,
+    /// }
+    /// ```
     fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
         self.air_id.encode(writer)?;
         self.degree.encode(writer)?;
@@ -478,6 +501,7 @@ impl Decode for Option<FriLogUpPartialProof<F>> {
         reader.read_exact(&mut bytes)?;
 
         let value = u32::from_le_bytes(bytes);
+        // When `Option<FriLogUpPartialProof<F>>` is None, it's encoded as `u32::max`.
         if value == u32::MAX {
             return Ok(None);
         }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -47,6 +47,7 @@ use crate::{
     prover::{AppProver, ContinuationProver, StarkProver},
 };
 
+pub mod codec;
 pub mod commit;
 pub mod config;
 pub mod keygen;


### PR DESCRIPTION
This doesn't yet change any SDK output methods, but adds a codec to encode/decode the inner STARK proof, specialized to BabyBearPoseidon2Config and FRI.

Closes INT-3598