### PR TITLE
feat(recursion): add clarifying OOB check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=2c535dc35542bf2d9c957104a327ce99e8bc7c59#2c535dc35542bf2d9c957104a327ce99e8bc7c59"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=463fa434efa1f6690f5ef2bef5d8b07566b07cf2#463fa434efa1f6690f5ef2bef5d8b07566b07cf2"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=2c535dc35542bf2d9c957104a327ce99e8bc7c59#2c535dc35542bf2d9c957104a327ce99e8bc7c59"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=463fa434efa1f6690f5ef2bef5d8b07566b07cf2#463fa434efa1f6690f5ef2bef5d8b07566b07cf2"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=463fa434efa1f6690f5ef2bef5d8b07566b07cf2#463fa434efa1f6690f5ef2bef5d8b07566b07cf2"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=46f581fa46db1b61293f12b6fbc092542ad0aa45#46f581fa46db1b61293f12b6fbc092542ad0aa45"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=463fa434efa1f6690f5ef2bef5d8b07566b07cf2#463fa434efa1f6690f5ef2bef5d8b07566b07cf2"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=46f581fa46db1b61293f12b6fbc092542ad0aa45#46f581fa46db1b61293f12b6fbc092542ad0aa45"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "463fa434efa1f6690f5ef2bef5d8b07566b07cf2", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "463fa434efa1f6690f5ef2bef5d8b07566b07cf2", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "46f581fa46db1b61293f12b6fbc092542ad0aa45", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "46f581fa46db1b61293f12b6fbc092542ad0aa45", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "2c535dc35542bf2d9c957104a327ce99e8bc7c59", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "2c535dc35542bf2d9c957104a327ce99e8bc7c59", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "463fa434efa1f6690f5ef2bef5d8b07566b07cf2", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "463fa434efa1f6690f5ef2bef5d8b07566b07cf2", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/extensions/native/recursion/src/stark/mod.rs
+++ b/extensions/native/recursion/src/stark/mod.rs
@@ -348,6 +348,7 @@ where
             });
 
             // Observe single commitment to all trace matrices in this phase.
+            builder.assert_usize_eq(after_challenge_commits.len(), RVar::one());
             let commit = builder.get(after_challenge_commits, phase_idx);
             challenger.observe_digest(builder, commit);
         });
@@ -546,6 +547,7 @@ where
                     );
                 });
         });
+        // T05b: the shape of `opening.values.main` has been validated
         {
             let batch_commit = builder.get(main_trace_commits, main_commit_idx.clone());
             builder.set_value(
@@ -623,6 +625,7 @@ where
                 );
                 builder.assign(&round_idx, round_idx.clone() + RVar::one());
             });
+        // T05c: the shape of `opening.values.main` has been validated
 
         // 4. Quotient domains and openings
 

--- a/extensions/native/recursion/src/stark/mod.rs
+++ b/extensions/native/recursion/src/stark/mod.rs
@@ -166,7 +166,7 @@ where
         // (T01b): `num_challenges_to_sample.len() < 2`.
 
         let num_phases = RVar::from(num_challenges_to_sample.len());
-        // Here the shape of `exposed_values_after_challenge` is not verified. But it's verified later.
+        // Here the shape of `exposed_values_after_challenge` is not verified. But it's verified later (T01c).
         assert_cumulative_sums(builder, air_proofs, &num_challenges_to_sample);
 
         let air_perm_by_height = if builder.flags.static_only {
@@ -336,6 +336,7 @@ where
                         let values = builder.get(&exposed_values, phase_idx);
                         let values_len =
                             builder.get(&air_advice.num_exposed_values_after_challenge, phase_idx);
+                        // (T01c): shape of `exposed_values_after_challenge` is verified
                         builder.assert_usize_eq(values_len, values.len());
 
                         iter_zip!(builder, values).for_each(|ptr_vec, builder| {
@@ -436,7 +437,7 @@ where
             builder
                 .if_eq(advice.preprocessed_data.len(), RVar::one())
                 .then(|builder| {
-                    // Assumption: (T05b) `opening.values.preprocessed` has been validated.
+                    // Assumption: (T05a) `opening.values.preprocessed` has been validated.
                     let prep = builder.get(&opening.values.preprocessed, round_idx.clone());
                     let batch_commit = builder.get(&advice.preprocessed_data, RVar::zero());
                     let prep_width =


### PR DESCRIPTION
In recursion program, add a check that the number of after challenge commitments equals the number of phases as recorded in the vkey. This is just for clarity and not a soundness fix: the control flow is already determined by `num_phases` from the vkey, and even if an out of bounds memory access were made, it is equivalent to if an array of the correct length 1 were provided, but where the value was incorrect -- this would still be caught by the verification algorithm.

Add some more comments in recursion program.

Updates stark-backend commit to sync with https://github.com/openvm-org/stark-backend/pull/57