### PR TITLE
chore: change cli input format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,7 @@ dependencies = [
  "openvm-native-recursion",
  "openvm-rv32im-transpiler",
  "openvm-sdk",
+ "openvm-stark-backend",
  "openvm-stark-sdk",
  "openvm-transpiler",
  "prettytable-rs",

--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -66,7 +66,7 @@ This will output a serialized proving key to `./openvm/app.pk` and a verificatio
 Now we are ready to generate a proof! Simply run:
 
 ```bash
-OPENVM_FAST_TEST=1 cargo openvm prove app --input "0x0A00000000000000"
+OPENVM_FAST_TEST=1 cargo openvm prove app --input "0x010A00000000000000"
 ```
 
 The `--input` field is passed to the program which receives it via the `io::read` function.
@@ -91,5 +91,5 @@ The process should exit with no errors.
 If necessary, the executable can also be run _without_ proof generation. This can be useful for testing purposes.
 
 ```bash
-cargo openvm run --input "0x0A00000000000000"
+cargo openvm run --input "0x010A00000000000000"
 ```

--- a/book/src/writing-apps/overview.md
+++ b/book/src/writing-apps/overview.md
@@ -26,10 +26,10 @@ For more information on both commands, see the [build](./build.md) docs.
 
 ### Inputs
 
-The `--input` field needs to either be a hex string or a file path to a json file that contains the key `input` and an array of hex strings. Note that if your hex string represents a single number, it should be written in little-endian format (as this is what the VM expects).
-Each hex string (either in the file as the direct input) is either:
-- Hex strings of bytes, which is prefixed with 0x01
-- Hex strings of native field elements (represented as u32, little endian), prefixed with 0x02
+The `--input` field needs to either be a single hex string or a file path to a json file that contains the key `input` and an array of hex strings. Note that if your hex string represents a single number, it should be written in little-endian format (as this is what the VM expects). Also note that if you need to provide multiple input streams, you have to use the file path option.
+Each hex string (either in the file or as the direct input) is either:
+- Hex string of bytes, which is prefixed with 0x01
+- Hex string of native field elements (represented as u32, little endian), prefixed with 0x02
 
 To see how more complex inputs can be converted into a VM-readable format, see the **Using StdIn** section of the [SDK](../advanced-usage/sdk.md) doc.
 

--- a/book/src/writing-apps/overview.md
+++ b/book/src/writing-apps/overview.md
@@ -26,7 +26,12 @@ For more information on both commands, see the [build](./build.md) docs.
 
 ### Inputs
 
-The `--input` field needs to either be a hex string or a file path to a file that will be read as bytes. Note that if your hex string represents a single number, it should be written in little-endian format (as this is what the VM expects). To see how more complex inputs can be converted into a VM-readable format, see the **Using StdIn** section of the [SDK](../advanced-usage/sdk.md) doc.
+The `--input` field needs to either be a hex string or a file path to a json file that contains the key `input` and an array of hex strings. Note that if your hex string represents a single number, it should be written in little-endian format (as this is what the VM expects).
+Each hex string (either in the file as the direct input) is either:
+- Hex strings of bytes, which is prefixed with 0x01
+- Hex strings of native field elements (represented as u32, little endian), prefixed with 0x02
+
+To see how more complex inputs can be converted into a VM-readable format, see the **Using StdIn** section of the [SDK](../advanced-usage/sdk.md) doc.
 
 ## Generating a Proof
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,6 +26,7 @@ openvm-rv32im-transpiler = { workspace = true }
 openvm-sdk = { workspace = true }
 openvm-keccak256-transpiler = { workspace = true }
 openvm-stark-sdk.workspace = true
+openvm-stark-backend.workspace = true
 
 aws-sdk-s3 = "1.78"
 aws-config = "1.5"

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -19,7 +19,7 @@ use crate::{
         DEFAULT_AGG_PK_PATH, DEFAULT_APP_EXE_PATH, DEFAULT_APP_PK_PATH, DEFAULT_APP_PROOF_PATH,
         DEFAULT_EVM_PROOF_PATH, DEFAULT_PARAMS_DIR,
     },
-    util::{read_to_stdin, Input},
+    input::{read_to_stdin, Input},
 };
 
 #[derive(Parser)]

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -6,7 +6,8 @@ use openvm_sdk::{fs::read_exe_from_file, Sdk};
 
 use crate::{
     default::{DEFAULT_APP_CONFIG_PATH, DEFAULT_APP_EXE_PATH},
-    util::{read_config_toml_or_default, read_to_stdin, Input},
+    input::{read_to_stdin, Input},
+    util::read_config_toml_or_default,
 };
 
 #[derive(Parser)]

--- a/crates/cli/src/input.rs
+++ b/crates/cli/src/input.rs
@@ -1,0 +1,118 @@
+use std::{fs::read, path::PathBuf, str::FromStr};
+
+use eyre::Result;
+use openvm_sdk::{StdIn, F};
+use openvm_stark_backend::p3_field::FieldAlgebra;
+
+/// Input can be either:
+/// (1) one single hex string
+/// (2) A JSON file containing an array of hex strings.
+/// Each hex string (either in the file or the direct input) is either:
+/// - Hex strings of bytes, which is prefixed with 0x01
+/// - Hex strings of native field elements (represented as u32, little endian), prefixed with 0x02
+#[derive(Debug, Clone)]
+pub enum Input {
+    FilePath(PathBuf),
+    HexBytes(Vec<u8>),
+}
+
+impl FromStr for Input {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if is_valid_hex_string(s) {
+            let bytes = decode_hex_string(s).map_err(|e| e.to_string())?;
+            Ok(Input::HexBytes(bytes))
+        } else if PathBuf::from(s).exists() {
+            Ok(Input::FilePath(PathBuf::from(s)))
+        } else {
+            Err("Input must be a valid file path or hex string.".to_string())
+        }
+    }
+}
+
+pub fn is_valid_hex_string(s: &str) -> bool {
+    if s.len() % 2 != 0 {
+        return false;
+    }
+    // All hex digits with optional 0x prefix
+    s.starts_with("0x") && s[2..].chars().all(|c| c.is_ascii_hexdigit())
+        || s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+pub fn decode_hex_string(s: &str) -> Result<Vec<u8>> {
+    // Remove 0x prefix if present
+    let s = s.trim_start_matches("0x");
+    if s.is_empty() {
+        return Ok(Vec::new());
+    }
+    hex::decode(s).map_err(|e| eyre::eyre!("Invalid hex: {}", e))
+}
+
+pub fn read_bytes_into_stdin(stdin: &mut StdIn, bytes: &[u8]) -> Result<()> {
+    // should either write_bytes or write_field
+    match bytes[0] {
+        0x01 => {
+            stdin.write_bytes(&bytes[1..]);
+            Ok(())
+        }
+        0x02 => {
+            let data = &bytes[1..];
+            if data.len() % 4 != 0 {
+                return Err(eyre::eyre!(
+                    "Invalid input format: incorrect number of bytes"
+                ));
+            }
+            let mut fields = Vec::with_capacity(data.len() / 4);
+            for chunk in data.chunks(4) {
+                if chunk.len() != 4 {
+                    return Err(eyre::eyre!(
+                        "Invalid input format: incorrect number of bytes"
+                    ));
+                }
+                let value = u32::from_le_bytes(chunk.try_into().unwrap());
+                fields.push(F::from_canonical_u32(value));
+            }
+            stdin.write_field(&fields);
+            Ok(())
+        }
+        _ => Err(eyre::eyre!(
+            "Invalid input format: the first byte must be 0x01 or 0x02"
+        )),
+    }
+}
+
+pub fn read_to_stdin(input: &Option<Input>) -> Result<StdIn> {
+    match input {
+        Some(Input::FilePath(path)) => {
+            let mut stdin = StdIn::default();
+            // read the json
+            let bytes = read(path)?;
+            let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+            json["input"]
+                .as_array()
+                .ok_or_else(|| eyre::eyre!("Input must be an array under 'input' key"))?
+                .iter()
+                .try_for_each(|inner| {
+                    inner
+                        .as_str()
+                        .ok_or_else(|| eyre::eyre!("Each value must be a hex string"))
+                        .and_then(|s| {
+                            if !is_valid_hex_string(s) {
+                                return Err(eyre::eyre!("Invalid hex string"));
+                            }
+                            let bytes = decode_hex_string(s)?;
+                            read_bytes_into_stdin(&mut stdin, &bytes)
+                        })
+                })?;
+
+            Ok(stdin)
+        }
+        Some(Input::HexBytes(bytes)) => {
+            let mut stdin = StdIn::default();
+            read_bytes_into_stdin(&mut stdin, bytes)?;
+            Ok(stdin)
+        }
+        None => Ok(StdIn::default()),
+    }
+}

--- a/crates/cli/src/input.rs
+++ b/crates/cli/src/input.rs
@@ -13,7 +13,7 @@ use openvm_stark_backend::p3_field::FieldAlgebra;
 #[derive(Debug, Clone)]
 pub enum Input {
     FilePath(PathBuf),
-    HexBytes(Vec<u8>),
+    HexBytes(String),
 }
 
 impl FromStr for Input {
@@ -21,8 +21,9 @@ impl FromStr for Input {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if is_valid_hex_string(s) {
-            let bytes = decode_hex_string(s).map_err(|e| e.to_string())?;
-            Ok(Input::HexBytes(bytes))
+            // let bytes = decode_hex_string(s).map_err(|e| e.to_string())?;
+            // Ok(Input::HexBytes(bytes))
+            Ok(Input::HexBytes(s.to_string()))
         } else if PathBuf::from(s).exists() {
             Ok(Input::FilePath(PathBuf::from(s)))
         } else {
@@ -108,9 +109,10 @@ pub fn read_to_stdin(input: &Option<Input>) -> Result<StdIn> {
 
             Ok(stdin)
         }
-        Some(Input::HexBytes(bytes)) => {
+        Some(Input::HexBytes(hex_str)) => {
             let mut stdin = StdIn::default();
-            read_bytes_into_stdin(&mut stdin, bytes)?;
+            let bytes = decode_hex_string(hex_str)?;
+            read_bytes_into_stdin(&mut stdin, &bytes)?;
             Ok(stdin)
         }
         None => Ok(StdIn::default()),

--- a/crates/cli/src/input.rs
+++ b/crates/cli/src/input.rs
@@ -21,8 +21,6 @@ impl FromStr for Input {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if is_valid_hex_string(s) {
-            // let bytes = decode_hex_string(s).map_err(|e| e.to_string())?;
-            // Ok(Input::HexBytes(bytes))
             Ok(Input::HexBytes(s.to_string()))
         } else if PathBuf::from(s).exists() {
             Ok(Input::FilePath(PathBuf::from(s)))
@@ -65,12 +63,7 @@ pub fn read_bytes_into_stdin(stdin: &mut StdIn, bytes: &[u8]) -> Result<()> {
                 ));
             }
             let mut fields = Vec::with_capacity(data.len() / 4);
-            for chunk in data.chunks(4) {
-                if chunk.len() != 4 {
-                    return Err(eyre::eyre!(
-                        "Invalid input format: incorrect number of bytes"
-                    ));
-                }
+            for chunk in data.chunks_exact(4) {
                 let value = u32::from_le_bytes(chunk.try_into().unwrap());
                 fields.push(F::from_canonical_u32(value));
             }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod default;
+pub mod input;
 mod util;
 
 use std::process::{Command, Stdio};

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -10,14 +10,6 @@ use serde::de::DeserializeOwned;
 
 use crate::default::default_app_config;
 
-pub(crate) fn write_status(style: &dyn Display, status: &str, msg: &str) {
-    println!("{style}{status:>12}{style:#} {msg}");
-}
-
-pub(crate) fn classical_exe_path(elf_path: &Path) -> PathBuf {
-    elf_path.with_extension("vmexe")
-}
-
 pub(crate) fn read_to_struct_toml<T: DeserializeOwned>(path: &PathBuf) -> Result<T> {
     let toml = read_to_string(path.as_ref() as &Path)?;
     let ret = toml::from_str(&toml)?;

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,76 +1,27 @@
 use std::{
-    fs::{read, read_to_string},
+    fmt::Display,
+    fs::read_to_string,
     path::{Path, PathBuf},
-    str::FromStr,
 };
 
 use eyre::Result;
-use openvm_sdk::{
-    config::{AppConfig, SdkVmConfig},
-    StdIn,
-};
+use openvm_sdk::config::{AppConfig, SdkVmConfig};
 use serde::de::DeserializeOwned;
 
 use crate::default::default_app_config;
 
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub(crate) enum Input {
-    FilePath(PathBuf),
-    HexBytes(Vec<u8>),
+pub(crate) fn write_status(style: &dyn Display, status: &str, msg: &str) {
+    println!("{style}{status:>12}{style:#} {msg}");
 }
 
-impl FromStr for Input {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if is_valid_hex_string(s) {
-            // Remove 0x prefix if present
-            let s = if s.starts_with("0x") {
-                s.strip_prefix("0x").unwrap()
-            } else {
-                s
-            };
-            if s.is_empty() {
-                return Ok(Input::HexBytes(Vec::new()));
-            }
-            if !s.chars().all(|c| c.is_ascii_hexdigit()) {
-                return Err("Invalid hex string.".to_string());
-            }
-            let bytes = hex::decode(s).map_err(|e| e.to_string())?;
-            Ok(Input::HexBytes(bytes))
-        } else if PathBuf::from(s).exists() {
-            Ok(Input::FilePath(PathBuf::from(s)))
-        } else {
-            Err("Input must be a valid file path or hex string.".to_string())
-        }
-    }
-}
-
-pub(crate) fn is_valid_hex_string(s: &str) -> bool {
-    if s.len() % 2 != 0 {
-        return false;
-    }
-    // All hex digits with optional 0x prefix
-    s.starts_with("0x") && s[2..].chars().all(|c| c.is_ascii_hexdigit())
-        || s.chars().all(|c| c.is_ascii_hexdigit())
+pub(crate) fn classical_exe_path(elf_path: &Path) -> PathBuf {
+    elf_path.with_extension("vmexe")
 }
 
 pub(crate) fn read_to_struct_toml<T: DeserializeOwned>(path: &PathBuf) -> Result<T> {
     let toml = read_to_string(path.as_ref() as &Path)?;
     let ret = toml::from_str(&toml)?;
     Ok(ret)
-}
-
-pub(crate) fn read_to_stdin(input: &Option<Input>) -> Result<StdIn> {
-    match input {
-        Some(Input::FilePath(path)) => {
-            let bytes = read(path)?;
-            Ok(StdIn::from_bytes(&bytes))
-        }
-        Some(Input::HexBytes(bytes)) => Ok(StdIn::from_bytes(bytes)),
-        None => Ok(StdIn::default()),
-    }
 }
 
 pub(crate) fn read_config_toml_or_default(config: &PathBuf) -> Result<AppConfig<SdkVmConfig>> {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt::Display,
     fs::read_to_string,
     path::{Path, PathBuf},
 };


### PR DESCRIPTION
breaking changes:
CLI input is now either 
1. one single hex string
1. a JSON file containing an array of hex strings.

Each hex string (either in the file or the direct input) is either:
1. Hex strings of bytes, which is prefixed with 0x01
1. Hex strings of native field elements (represented as u32, little endian), prefixed with 0x02