### PR TITLE
chore: fix audit typos

### DIFF
--- a/audits/v1-internal/extension-algebra.md
+++ b/audits/v1-internal/extension-algebra.md
@@ -68,7 +68,7 @@ When `is_setup = 0`, we constrain that:
     So this constraint ensures that one entry of `lt_marker` is 2.
     - `sum_i lt_marker[i] = 3` which, together with the previous constraint, ensures that one entry of `lt_marker` is 1.
 
-So far, we have constrained that, on a non-setup row, `lt_marker` either has exactly one nonzero entry and it is 1, or it has two nonzero entires, a 1 and a 2.
+So far, we have constrained that, on a non-setup row, `lt_marker` either has exactly one nonzero entry and it is 1, or it has two nonzero entries, a 1 and a 2.
 Let `b_diff_idx` be such that `lt_marker[b_diff_idx] = 1` and let `c_diff_idx` be such that `lt_marker[c_diff_idx] = 2` if such an index exists, otherwise let `c_diff_idx = b_diff_idx`.
 
 Next, we iterate `i` from the most significant to the least significant limb's index (`NUM_LIMBS - 1` to 0), and we maintain a prefix sum `prefix_sum[i]` of `lt_marker` (since we are iterating backwards, this is really a suffix sum).

--- a/audits/v1-internal/extension-bigint.md
+++ b/audits/v1-internal/extension-bigint.md
@@ -17,7 +17,7 @@ Describe the main focus and any additional context:
 
 ## 2. Findings
 
-Classify by **severity** according to [cantina critiera](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
+Classify by **severity** according to [cantina criteria](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
 
 Findings include anything that could warrant change or unexpected behavior that should be brought to light. They range from severe to informational.
 

--- a/audits/v1-internal/extension-native.md
+++ b/audits/v1-internal/extension-native.md
@@ -11,7 +11,7 @@ The focus of this review is the native extension chips and transpiler.
 
 ## 2. Findings
 
-Classify by **severity** according to [cantina critiera](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
+Classify by **severity** according to [cantina criteria](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
 
 Findings include anything that could warrant change or unexpected behavior that should be brought to light. They range from severe to informational.
 
@@ -236,7 +236,7 @@ Aside from the issues found above, one observation from reviewing the AIRs is
 that the AIRs are not always consistent with whether or not they enforce if an
 instruction is syntactically valid. For example, many AIRs constrain that an
 unused operand is 0 (as in the spec), and `BranchNativeAdapterAir` constrains
-`d` and `e` to be either 0 or 4. But other AIRs do not inforce syntactic
+`d` and `e` to be either 0 or 4. But other AIRs do not enforce syntactic
 validity: `NativeLoadStoreAir` does not constrain that `a == 0` when `opcode ==
 HINT_STOREW`, and `NativePoseidon2Air` does not constrain that `g` is either the
 inverse of 1 or 4 when `opcode == VERIFY_BATCH`. This is not necessarily a

--- a/audits/v1-internal/isa.md
+++ b/audits/v1-internal/isa.md
@@ -9,7 +9,7 @@ Commit: 336f1a475e5aa3513c4c5a266399f4128c119bba
 
 ## 2. Findings
 
-Classify by **severity** according to [cantina critiera](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
+Classify by **severity** according to [cantina criteria](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
 
 Findings include anything that could warrant change or unexpected behavior that should be brought to light. They range from severe to informational.
 

--- a/audits/v1-internal/native-compiler.md
+++ b/audits/v1-internal/native-compiler.md
@@ -39,7 +39,7 @@ save columns, `RANGE_CHECK` is put into the existing `JalChip`.
 **Context:** https://github.com/openvm-org/openvm/blob/336f1a475e5aa3513c4c5a266399f4128c119bba/extensions/native/compiler/src/conversion/mod.rs#L274
 
 **Description:** 
-ASM compiler compiles `Assert*` DSL instructions into a conditonal jump + a ASM instruction `Trap`, which only results a phantom instruction. The expolit can generate a valid execution trace which ignores all assertions in the program.
+ASM compiler compiles `Assert*` DSL instructions into a conditional jump + a ASM instruction `Trap`, which only results a phantom instruction. The expolit can generate a valid execution trace which ignores all assertions in the program.
 
 **Proof of concept:** N/A
 
@@ -92,7 +92,7 @@ Most DSL instructions are trivially converted into the corresponding ASM instruc
 - `If*`. This kind of instructions append 1 branch instruction before the then/else closure.
 - `ZipFor` appends 1 branch instruction after the loop body.
 - `Alloc` computes the allocation size then increases `HEAP_PTR` by the allocation size. Finding `2.1` about this.
-- `Assert*` results an if branch which panics if the condition is satisified. Finding `2.2` about this.
+- `Assert*` results an if branch which panics if the condition is satisfied. Finding `2.2` about this.
 - Debug instructions like `Print*`/`CycleTracker*`/
 
 Notably, immediate `Ext` DSL instructions result 5 ASM instruction - the compiler needs to write the immediate `Ext` as 4 `Felt`s first.
@@ -103,6 +103,6 @@ doesn't support jump and heap allocation. So it's simpler than the ASM compiler.
 are simply converted into the corresponding Halo2 circuit constraints.
 
 Non-trivial instructions:
-- `BabyBearChip` operations. https://github.com/openvm-org/openvm/pull/1407 add more explaination how it works.
-- Poseidon2 operations. The implementaion is copied from an audited codebase.
+- `BabyBearChip` operations. https://github.com/openvm-org/openvm/pull/1407 add more explanation how it works.
+- Poseidon2 operations. The implementation is copied from an audited codebase.
 - Bit decomposition. Had a finding in 2.3.

--- a/audits/v1-internal/recursion-program.md
+++ b/audits/v1-internal/recursion-program.md
@@ -107,7 +107,7 @@ https://github.com/openvm-org/openvm/commit/485e5e524c8f0d1ec1f8725fa76a5c7f5f9c
 
 ### 3.1 Out of bound access
 
-When using `builder.get`/`builder.set` to read/write an element from an `Array`, the index has to be less than the length of the array. Otherwise, there could be potiential exploits:
+When using `builder.get`/`builder.set` to read/write an element from an `Array`, the index has to be less than the length of the array. Otherwise, there could be potential exploits:
 - The exploit could put an unexpected value into an irrelated object in the nearby memory and let it be the returned value.
 - If the index could be an arbitrary value, the exploit could overwrite any address and take the control flow.
 
@@ -120,6 +120,6 @@ This is a dynamic-only issue because the compiler will panic at compile if there
 
 ### 3.2 Constraint Evaluation
 
-AIR Constraints only depend on the VK. So constraint evalutation of a specific AIR could be represented as a long list of 
+AIR Constraints only depend on the VK. So constraint evaluation of a specific AIR could be represented as a long list of 
 instructions without loops or branches. In the recursion verifier program, we use `RecursiveVerifierConstraintFolder` to
-convert constraints into a big expresssion. The logic is simple and safe at DSL level.
+convert constraints into a big expression. The logic is simple and safe at DSL level.

--- a/audits/v1-internal/riscv-transpiler.md
+++ b/audits/v1-internal/riscv-transpiler.md
@@ -30,7 +30,7 @@ VM Extension (intrinsic functions): document how to add new custom RISC-V instru
 
 ## 2. Findings
 
-Classify by **severity** according to [cantina critiera](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
+Classify by **severity** according to [cantina criteria](https://docs.cantina.xyz/cantina-docs/cantina-competitions/judging-process/finding-severity-criteria) in terms of likelihood and impact.
 
 Findings include anything that could warrant change or unexpected behavior that should be brought to light. They range from severe to informational.
 
@@ -113,7 +113,7 @@ Currently, we have two way to handle a RISC-V instruction that has `rd = x0`:
 1. Transpile to a `NOP` if it has no side effects
 2. Transpile to an OpenVM instruction that executes the expected side effect and does not change the value of `[0:4]_1` (side effect here could include raising an exception)
 
-For the available RISC-V instructions that OpenVM supports, it is guaranteed that only `rd` can be written to during its execution, so the two cases above are sufficient. However, we need to carefully reconsider that everytime we add a new instruction.
+For the available RISC-V instructions that OpenVM supports, it is guaranteed that only `rd` can be written to during its execution, so the two cases above are sufficient. However, we need to carefully reconsider that every time we add a new instruction.
 
 On the second case, the following instructions that allow `rd = x0` and can still possibly write into `rd`:
 

--- a/audits/v1-internal/rust-toolchain.md
+++ b/audits/v1-internal/rust-toolchain.md
@@ -45,7 +45,7 @@ pub fn init() {
 }
 ```
 
-If we turn out to have a lot of unitialized data or otherwise make `_end` very far in memory, then `heap_pos` may exceed `crate::memory::GUEST_MAX_MEM`, which will probably lead to just a crash.
+If we turn out to have a lot of uninitialized data or otherwise make `_end` very far in memory, then `heap_pos` may exceed `crate::memory::GUEST_MAX_MEM`, which will probably lead to just a crash.
 
 <!-- **Proof of concept:** (optional) sample code/patch or other way to demonstrate the exploit -->
 

--- a/audits/v1-internal/stark-backend.md
+++ b/audits/v1-internal/stark-backend.md
@@ -23,7 +23,7 @@ multiplicity, `b` a bus index, `sigma` a message, and `h_beta` a polynomial in
 `\beta` with coefficients given by the message `sigma`.
 
 The goal is that summands for one bus cannot cancel algebraically with summands
-from another bus. But these terms are not indepedent for different bus indices;
+from another bus. But these terms are not independent for different bus indices;
 if $X^b + c$ can be factored into $P(X) \cdot Q(X)$, then we can always write
 $1/(X^b + c)$ into a linear combination of $1/P(X)$ and $1/Q(X)$ via partial
 fraction decomposition.


### PR DESCRIPTION
```bash
codespell --skip="Cargo.lock,./book/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,target" --ignore-words=.codespellignore -w
```