### PR TITLE
chore: impl `AsRef` for `SharedBitwiseOperationLookupChip` and `SharedRangeTupleCheckerChip`

### DIFF
--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -259,3 +259,11 @@ impl<const NUM_BITS: usize> ChipUsageGetter for SharedBitwiseOperationLookupChip
         self.0.trace_width()
     }
 }
+
+impl<const NUM_BITS: usize> AsRef<BitwiseOperationLookupChip<NUM_BITS>>
+    for SharedBitwiseOperationLookupChip<NUM_BITS>
+{
+    fn as_ref(&self) -> &BitwiseOperationLookupChip<NUM_BITS> {
+        &self.0
+    }
+}

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -267,11 +267,3 @@ impl<const NUM_BITS: usize> AsRef<BitwiseOperationLookupChip<NUM_BITS>>
         &self.0
     }
 }
-
-impl<const NUM_BITS: usize> AsMut<BitwiseOperationLookupChip<NUM_BITS>>
-    for SharedBitwiseOperationLookupChip<NUM_BITS>
-{
-    fn as_mut(&mut self) -> &mut BitwiseOperationLookupChip<NUM_BITS> {
-        &mut self.0
-    }
-}

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -267,3 +267,11 @@ impl<const NUM_BITS: usize> AsRef<BitwiseOperationLookupChip<NUM_BITS>>
         &self.0
     }
 }
+
+impl<const NUM_BITS: usize> AsMut<BitwiseOperationLookupChip<NUM_BITS>>
+    for SharedBitwiseOperationLookupChip<NUM_BITS>
+{
+    fn as_mut(&mut self) -> &mut BitwiseOperationLookupChip<NUM_BITS> {
+        &mut self.0
+    }
+}

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -239,3 +239,9 @@ impl<const N: usize> ChipUsageGetter for SharedRangeTupleCheckerChip<N> {
         self.0.trace_width()
     }
 }
+
+impl<const N: usize> AsRef<RangeTupleCheckerChip<N>> for SharedRangeTupleCheckerChip<N> {
+    fn as_ref(&self) -> &RangeTupleCheckerChip<N> {
+        &self.0
+    }
+}

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -245,9 +245,3 @@ impl<const N: usize> AsRef<RangeTupleCheckerChip<N>> for SharedRangeTupleChecker
         &self.0
     }
 }
-
-impl<const N: usize> AsMut<RangeTupleCheckerChip<N>> for SharedRangeTupleCheckerChip<N> {
-    fn as_mut(&mut self) -> &mut RangeTupleCheckerChip<N> {
-        &mut self.0
-    }
-}

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -245,3 +245,9 @@ impl<const N: usize> AsRef<RangeTupleCheckerChip<N>> for SharedRangeTupleChecker
         &self.0
     }
 }
+
+impl<const N: usize> AsMut<RangeTupleCheckerChip<N>> for SharedRangeTupleCheckerChip<N> {
+    fn as_mut(&mut self) -> &mut RangeTupleCheckerChip<N> {
+        &mut self.0
+    }
+}

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -276,9 +276,3 @@ impl AsRef<VariableRangeCheckerChip> for SharedVariableRangeCheckerChip {
         &self.0
     }
 }
-
-impl AsMut<VariableRangeCheckerChip> for SharedVariableRangeCheckerChip {
-    fn as_mut(&mut self) -> &mut VariableRangeCheckerChip {
-        &mut self.0
-    }
-}

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -276,3 +276,9 @@ impl AsRef<VariableRangeCheckerChip> for SharedVariableRangeCheckerChip {
         &self.0
     }
 }
+
+impl AsMut<VariableRangeCheckerChip> for SharedVariableRangeCheckerChip {
+    fn as_mut(&mut self) -> &mut VariableRangeCheckerChip {
+        &mut self.0
+    }
+}


### PR DESCRIPTION
Implement `AsRef` trait for `SharedBitwiseOperationLookupChip` and `SharedRangeTupleCheckerChip` so that the inner chip is accessible for serialization/deserialization