### PR TITLE
feat: `GenericSdk<E: StarkFriEngine<BabyBearPoseidon2Config>>`

### DIFF
--- a/benchmarks/src/bin/fib_e2e.rs
+++ b/benchmarks/src/bin/fib_e2e.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     ));
     let agg_config = args.agg_config();
 
-    let sdk = Sdk;
+    let sdk = Sdk::default();
     let halo2_params_reader = CacheHalo2ParamsReader::new(
         args.kzg_params_dir
             .clone()

--- a/benchmarks/src/bin/fib_e2e.rs
+++ b/benchmarks/src/bin/fib_e2e.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     ));
     let agg_config = args.agg_config();
 
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     let halo2_params_reader = CacheHalo2ParamsReader::new(
         args.kzg_params_dir
             .clone()

--- a/benchmarks/src/bin/kitchen_sink.rs
+++ b/benchmarks/src/bin/kitchen_sink.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
         .build();
     let exe = VmExe::from_elf(elf, vm_config.transpiler())?;
 
-    let sdk = Sdk;
+    let sdk = Sdk::default();
     let app_config = args.app_config(vm_config.clone());
     let app_pk = Arc::new(sdk.app_keygen(app_config)?);
     let app_committed_exe = commit_app_exe(app_pk.app_fri_params(), exe);

--- a/benchmarks/src/bin/kitchen_sink.rs
+++ b/benchmarks/src/bin/kitchen_sink.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
         .build();
     let exe = VmExe::from_elf(elf, vm_config.transpiler())?;
 
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     let app_config = args.app_config(vm_config.clone());
     let app_pk = Arc::new(sdk.app_keygen(app_config)?);
     let app_committed_exe = commit_app_exe(app_pk.app_fri_params(), exe);

--- a/benchmarks/src/bin/pairing.rs
+++ b/benchmarks/src/bin/pairing.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
         ]))
         .pairing(PairingExtension::new(vec![PairingCurve::Bn254]))
         .build();
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     let exe = sdk.transpile(elf, vm_config.transpiler()).unwrap();
 
     run_with_metric_collection("OUTPUT_PATH", || -> Result<()> {

--- a/benchmarks/src/bin/pairing.rs
+++ b/benchmarks/src/bin/pairing.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
         ]))
         .pairing(PairingExtension::new(vec![PairingCurve::Bn254]))
         .build();
-    let sdk = Sdk;
+    let sdk = Sdk::default();
     let exe = sdk.transpile(elf, vm_config.transpiler()).unwrap();
 
     run_with_metric_collection("OUTPUT_PATH", || -> Result<()> {

--- a/benchmarks/src/bin/verify_fibair.rs
+++ b/benchmarks/src/bin/verify_fibair.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
             compiler_options,
         };
         let (program, input_stream) = build_verification_program(vdata, compiler_options);
-        let sdk = Sdk;
+        let sdk = Sdk::default();
         let app_pk = sdk.app_keygen(app_config)?;
         let app_vk = app_pk.get_app_vk();
         let committed_exe = sdk.commit_app_exe(app_fri_params, program.into())?;

--- a/benchmarks/src/bin/verify_fibair.rs
+++ b/benchmarks/src/bin/verify_fibair.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
             compiler_options,
         };
         let (program, input_stream) = build_verification_program(vdata, compiler_options);
-        let sdk = Sdk::default();
+        let sdk = Sdk::new();
         let app_pk = sdk.app_keygen(app_config)?;
         let app_vk = app_pk.get_app_vk();
         let committed_exe = sdk.commit_app_exe(app_fri_params, program.into())?;

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -232,7 +232,7 @@ where
     let prover = AppProver::new(app_pk.app_vm_pk, committed_exe).with_program_name(bench_name);
     let app_proof = prover.generate_app_proof(input_stream);
     // 6. Verify STARK proofs, including boundary conditions.
-    let sdk = Sdk;
+    let sdk = Sdk::default();
     sdk.verify_app_proof(&app_vk, &app_proof)
         .expect("Verification failed");
     if let Some(leaf_vm_config) = leaf_vm_config {

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -232,7 +232,7 @@ where
     let prover = AppProver::new(app_pk.app_vm_pk, committed_exe).with_program_name(bench_name);
     let app_proof = prover.generate_app_proof(input_stream);
     // 6. Verify STARK proofs, including boundary conditions.
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     sdk.verify_app_proof(&app_vk, &app_proof)
         .expect("Verification failed");
     if let Some(leaf_vm_config) = leaf_vm_config {

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -143,7 +143,7 @@ pub(crate) fn build(build_args: &BuildArgs) -> Result<Option<PathBuf>> {
 
         let data = read(elf_path.clone())?;
         let elf = Elf::decode(&data, MEM_SIZE as u32)?;
-        let exe = Sdk::default().transpile(elf, transpiler)?;
+        let exe = Sdk::new().transpile(elf, transpiler)?;
         let committed_exe = commit_app_exe(app_config.app_fri_params.fri_params, exe.clone());
         write_exe_to_file(exe, output_path)?;
         write(

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -143,7 +143,7 @@ pub(crate) fn build(build_args: &BuildArgs) -> Result<Option<PathBuf>> {
 
         let data = read(elf_path.clone())?;
         let elf = Elf::decode(&data, MEM_SIZE as u32)?;
-        let exe = Sdk.transpile(elf, transpiler)?;
+        let exe = Sdk::default().transpile(elf, transpiler)?;
         let committed_exe = commit_app_exe(app_config.app_fri_params.fri_params, exe.clone());
         write_exe_to_file(exe, output_path)?;
         write(

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -38,7 +38,7 @@ pub struct KeygenCmd {
 impl KeygenCmd {
     pub fn run(&self) -> Result<()> {
         let app_config = read_config_toml_or_default(&self.config)?;
-        let app_pk = Sdk.app_keygen(app_config)?;
+        let app_pk = Sdk::default().app_keygen(app_config)?;
         write_app_vk_to_file(app_pk.get_app_vk(), &self.vk_output)?;
         write_app_pk_to_file(app_pk, &self.output)?;
         Ok(())

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -38,7 +38,7 @@ pub struct KeygenCmd {
 impl KeygenCmd {
     pub fn run(&self) -> Result<()> {
         let app_config = read_config_toml_or_default(&self.config)?;
-        let app_pk = Sdk::default().app_keygen(app_config)?;
+        let app_pk = Sdk::new().app_keygen(app_config)?;
         write_app_vk_to_file(app_pk.get_app_vk(), &self.vk_output)?;
         write_app_pk_to_file(app_pk, &self.output)?;
         Ok(())

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -61,6 +61,7 @@ enum ProveSubCommand {
 
 impl ProveCmd {
     pub fn run(&self) -> Result<()> {
+        let sdk = Sdk::new();
         match &self.command {
             ProveSubCommand::App {
                 app_pk,
@@ -68,8 +69,9 @@ impl ProveCmd {
                 input,
                 output,
             } => {
-                let (app_pk, committed_exe, input) = Self::prepare_execution(app_pk, exe, input)?;
-                let app_proof = Sdk::new().generate_app_proof(app_pk, committed_exe, input)?;
+                let (app_pk, committed_exe, input) =
+                    Self::prepare_execution(&sdk, app_pk, exe, input)?;
+                let app_proof = sdk.generate_app_proof(app_pk, committed_exe, input)?;
                 write_app_proof_to_file(app_proof, output)?;
             }
             ProveSubCommand::Evm {
@@ -79,18 +81,14 @@ impl ProveCmd {
                 output,
             } => {
                 let params_reader = CacheHalo2ParamsReader::new(DEFAULT_PARAMS_DIR);
-                let (app_pk, committed_exe, input) = Self::prepare_execution(app_pk, exe, input)?;
+                let (app_pk, committed_exe, input) =
+                    Self::prepare_execution(&sdk, app_pk, exe, input)?;
                 println!("Generating EVM proof, this may take a lot of compute and memory...");
                 let agg_pk = read_agg_pk_from_file(DEFAULT_AGG_PK_PATH).map_err(|e| {
                     eyre::eyre!("Failed to read aggregation proving key: {}\nPlease run 'cargo openvm setup' first", e)
                 })?;
-                let evm_proof = Sdk::new().generate_evm_proof(
-                    &params_reader,
-                    app_pk,
-                    committed_exe,
-                    agg_pk,
-                    input,
-                )?;
+                let evm_proof =
+                    sdk.generate_evm_proof(&params_reader, app_pk, committed_exe, agg_pk, input)?;
                 write_evm_proof_to_file(evm_proof, output)?;
             }
         }
@@ -98,6 +96,7 @@ impl ProveCmd {
     }
 
     fn prepare_execution(
+        sdk: &Sdk,
         app_pk: &PathBuf,
         exe: &PathBuf,
         input: &Option<Input>,
@@ -108,7 +107,7 @@ impl ProveCmd {
     )> {
         let app_pk: Arc<AppProvingKey<SdkVmConfig>> = Arc::new(read_app_pk_from_file(app_pk)?);
         let app_exe = read_exe_from_file(exe)?;
-        let committed_exe = Sdk::new().commit_app_exe(app_pk.app_fri_params(), app_exe)?;
+        let committed_exe = sdk.commit_app_exe(app_pk.app_fri_params(), app_exe)?;
 
         let commits = AppExecutionCommit::compute(
             &app_pk.app_vm_pk.vm_config,

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -69,7 +69,7 @@ impl ProveCmd {
                 output,
             } => {
                 let (app_pk, committed_exe, input) = Self::prepare_execution(app_pk, exe, input)?;
-                let app_proof = Sdk::default().generate_app_proof(app_pk, committed_exe, input)?;
+                let app_proof = Sdk::new().generate_app_proof(app_pk, committed_exe, input)?;
                 write_app_proof_to_file(app_proof, output)?;
             }
             ProveSubCommand::Evm {
@@ -84,7 +84,7 @@ impl ProveCmd {
                 let agg_pk = read_agg_pk_from_file(DEFAULT_AGG_PK_PATH).map_err(|e| {
                     eyre::eyre!("Failed to read aggregation proving key: {}\nPlease run 'cargo openvm setup' first", e)
                 })?;
-                let evm_proof = Sdk::default().generate_evm_proof(
+                let evm_proof = Sdk::new().generate_evm_proof(
                     &params_reader,
                     app_pk,
                     committed_exe,
@@ -108,7 +108,7 @@ impl ProveCmd {
     )> {
         let app_pk: Arc<AppProvingKey<SdkVmConfig>> = Arc::new(read_app_pk_from_file(app_pk)?);
         let app_exe = read_exe_from_file(exe)?;
-        let committed_exe = Sdk::default().commit_app_exe(app_pk.app_fri_params(), app_exe)?;
+        let committed_exe = Sdk::new().commit_app_exe(app_pk.app_fri_params(), app_exe)?;
 
         let commits = AppExecutionCommit::compute(
             &app_pk.app_vm_pk.vm_config,

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -69,7 +69,7 @@ impl ProveCmd {
                 output,
             } => {
                 let (app_pk, committed_exe, input) = Self::prepare_execution(app_pk, exe, input)?;
-                let app_proof = Sdk.generate_app_proof(app_pk, committed_exe, input)?;
+                let app_proof = Sdk::default().generate_app_proof(app_pk, committed_exe, input)?;
                 write_app_proof_to_file(app_proof, output)?;
             }
             ProveSubCommand::Evm {
@@ -84,8 +84,13 @@ impl ProveCmd {
                 let agg_pk = read_agg_pk_from_file(DEFAULT_AGG_PK_PATH).map_err(|e| {
                     eyre::eyre!("Failed to read aggregation proving key: {}\nPlease run 'cargo openvm setup' first", e)
                 })?;
-                let evm_proof =
-                    Sdk.generate_evm_proof(&params_reader, app_pk, committed_exe, agg_pk, input)?;
+                let evm_proof = Sdk::default().generate_evm_proof(
+                    &params_reader,
+                    app_pk,
+                    committed_exe,
+                    agg_pk,
+                    input,
+                )?;
                 write_evm_proof_to_file(evm_proof, output)?;
             }
         }
@@ -103,7 +108,7 @@ impl ProveCmd {
     )> {
         let app_pk: Arc<AppProvingKey<SdkVmConfig>> = Arc::new(read_app_pk_from_file(app_pk)?);
         let app_exe = read_exe_from_file(exe)?;
-        let committed_exe = Sdk.commit_app_exe(app_pk.app_fri_params(), app_exe)?;
+        let committed_exe = Sdk::default().commit_app_exe(app_pk.app_fri_params(), app_exe)?;
 
         let commits = AppExecutionCommit::compute(
             &app_pk.app_vm_pk.vm_config,

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -27,7 +27,8 @@ impl RunCmd {
     pub fn run(&self) -> Result<()> {
         let exe = read_exe_from_file(&self.exe)?;
         let app_config = read_config_toml_or_default(&self.config)?;
-        let output = Sdk.execute(exe, app_config.app_vm_config, read_to_stdin(&self.input)?)?;
+        let output =
+            Sdk::default().execute(exe, app_config.app_vm_config, read_to_stdin(&self.input)?)?;
         println!("Execution output: {:?}", output);
         Ok(())
     }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -28,7 +28,7 @@ impl RunCmd {
         let exe = read_exe_from_file(&self.exe)?;
         let app_config = read_config_toml_or_default(&self.config)?;
         let output =
-            Sdk::default().execute(exe, app_config.app_vm_config, read_to_stdin(&self.input)?)?;
+            Sdk::new().execute(exe, app_config.app_vm_config, read_to_stdin(&self.input)?)?;
         println!("Execution output: {:?}", output);
         Ok(())
     }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -27,8 +27,8 @@ impl RunCmd {
     pub fn run(&self) -> Result<()> {
         let exe = read_exe_from_file(&self.exe)?;
         let app_config = read_config_toml_or_default(&self.config)?;
-        let output =
-            Sdk::new().execute(exe, app_config.app_vm_config, read_to_stdin(&self.input)?)?;
+        let sdk = Sdk::new();
+        let output = sdk.execute(exe, app_config.app_vm_config, read_to_stdin(&self.input)?)?;
         println!("Execution output: {:?}", output);
         Ok(())
     }

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -47,7 +47,7 @@ impl EvmProvingSetupCmd {
         Self::download_params(10, 24).await?;
         let params_reader = CacheHalo2ParamsReader::new(DEFAULT_PARAMS_DIR);
         let agg_config = AggConfig::default();
-        let sdk = Sdk::default();
+        let sdk = Sdk::new();
 
         println!("Generating proving key...");
         let agg_pk = sdk.agg_keygen(agg_config, &params_reader, &DefaultStaticVerifierPvHandler)?;

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -47,12 +47,13 @@ impl EvmProvingSetupCmd {
         Self::download_params(10, 24).await?;
         let params_reader = CacheHalo2ParamsReader::new(DEFAULT_PARAMS_DIR);
         let agg_config = AggConfig::default();
+        let sdk = Sdk::default();
 
         println!("Generating proving key...");
-        let agg_pk = Sdk.agg_keygen(agg_config, &params_reader, &DefaultStaticVerifierPvHandler)?;
+        let agg_pk = sdk.agg_keygen(agg_config, &params_reader, &DefaultStaticVerifierPvHandler)?;
 
         println!("Generating verifier contract...");
-        let verifier = Sdk.generate_snark_verifier_contract(&params_reader, &agg_pk)?;
+        let verifier = sdk.generate_snark_verifier_contract(&params_reader, &agg_pk)?;
 
         println!("Writing proving key to file...");
         write_agg_pk_to_file(agg_pk, DEFAULT_AGG_PK_PATH)?;

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -42,14 +42,14 @@ impl VerifyCmd {
             VerifySubCommand::App { app_vk, proof } => {
                 let app_vk = read_app_vk_from_file(app_vk)?;
                 let app_proof = read_app_proof_from_file(proof)?;
-                Sdk.verify_app_proof(&app_vk, &app_proof)?;
+                Sdk::default().verify_app_proof(&app_vk, &app_proof)?;
             }
             VerifySubCommand::Evm { proof } => {
                 let evm_verifier = read_evm_verifier_from_folder(DEFAULT_VERIFIER_FOLDER).map_err(|e| {
                     eyre::eyre!("Failed to read EVM verifier: {}\nPlease run 'cargo openvm evm-proving-setup' first", e)
                 })?;
                 let evm_proof = read_evm_proof_from_file(proof)?;
-                Sdk.verify_evm_proof(&evm_verifier, &evm_proof)?;
+                Sdk::default().verify_evm_proof(&evm_verifier, &evm_proof)?;
             }
         }
         Ok(())

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -42,14 +42,14 @@ impl VerifyCmd {
             VerifySubCommand::App { app_vk, proof } => {
                 let app_vk = read_app_vk_from_file(app_vk)?;
                 let app_proof = read_app_proof_from_file(proof)?;
-                Sdk::default().verify_app_proof(&app_vk, &app_proof)?;
+                Sdk::new().verify_app_proof(&app_vk, &app_proof)?;
             }
             VerifySubCommand::Evm { proof } => {
                 let evm_verifier = read_evm_verifier_from_folder(DEFAULT_VERIFIER_FOLDER).map_err(|e| {
                     eyre::eyre!("Failed to read EVM verifier: {}\nPlease run 'cargo openvm evm-proving-setup' first", e)
                 })?;
                 let evm_proof = read_evm_proof_from_file(proof)?;
-                Sdk::default().verify_evm_proof(&evm_verifier, &evm_proof)?;
+                Sdk::new().verify_evm_proof(&evm_verifier, &evm_proof)?;
             }
         }
         Ok(())

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -38,18 +38,19 @@ enum VerifySubCommand {
 
 impl VerifyCmd {
     pub fn run(&self) -> Result<()> {
+        let sdk = Sdk::new();
         match &self.command {
             VerifySubCommand::App { app_vk, proof } => {
                 let app_vk = read_app_vk_from_file(app_vk)?;
                 let app_proof = read_app_proof_from_file(proof)?;
-                Sdk::new().verify_app_proof(&app_vk, &app_proof)?;
+                sdk.verify_app_proof(&app_vk, &app_proof)?;
             }
             VerifySubCommand::Evm { proof } => {
                 let evm_verifier = read_evm_verifier_from_folder(DEFAULT_VERIFIER_FOLDER).map_err(|e| {
                     eyre::eyre!("Failed to read EVM verifier: {}\nPlease run 'cargo openvm evm-proving-setup' first", e)
                 })?;
                 let evm_proof = read_evm_proof_from_file(proof)?;
-                Sdk::new().verify_evm_proof(&evm_verifier, &evm_proof)?;
+                sdk.verify_evm_proof(&evm_verifier, &evm_proof)?;
             }
         }
         Ok(())

--- a/crates/sdk/examples/sdk_app.rs
+++ b/crates/sdk/examples/sdk_app.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// ```
     // ANCHOR: build
     // 1. Build the VmConfig with the extensions needed.
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
 
     // 2a. Build the ELF with guest options and a target filter.
     let guest_opts = GuestOptions::default();

--- a/crates/sdk/examples/sdk_app.rs
+++ b/crates/sdk/examples/sdk_app.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// ```
     // ANCHOR: build
     // 1. Build the VmConfig with the extensions needed.
-    let sdk = Sdk;
+    let sdk = Sdk::default();
 
     // 2a. Build the ELF with guest options and a target filter.
     let guest_opts = GuestOptions::default();

--- a/crates/sdk/examples/sdk_evm.rs
+++ b/crates/sdk/examples/sdk_evm.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// ```
     // ANCHOR: build
     // 1. Build the VmConfig with the extensions needed.
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
 
     // 2a. Build the ELF with guest options and a target filter.
     let guest_opts = GuestOptions::default();

--- a/crates/sdk/examples/sdk_evm.rs
+++ b/crates/sdk/examples/sdk_evm.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// ```
     // ANCHOR: build
     // 1. Build the VmConfig with the extensions needed.
-    let sdk = Sdk;
+    let sdk = Sdk::default();
 
     // 2a. Build the ELF with guest options and a target filter.
     let guest_opts = GuestOptions::default();

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fs::read, path::Path, sync::Arc};
+use std::{fs::read, marker::PhantomData, path::Path, sync::Arc};
 
 use commit::commit_app_exe;
 use config::AppConfig;
@@ -77,9 +77,21 @@ pub struct VerifiedContinuationVmPayload {
     pub user_public_values: Vec<F>,
 }
 
-pub struct Sdk;
+pub struct GenericSdk<E: StarkFriEngine<SC>> {
+    _phantom: PhantomData<E>,
+}
 
-impl Sdk {
+impl<E: StarkFriEngine<SC>> Default for GenericSdk<E> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub type Sdk = GenericSdk<BabyBearPoseidon2Engine>;
+
+impl<E: StarkFriEngine<SC>> GenericSdk<E> {
     pub fn build<P: AsRef<Path>>(
         &self,
         guest_opts: GuestOptions,
@@ -178,7 +190,7 @@ impl Sdk {
         app_vk: &AppVerifyingKey,
         proof: &ContinuationVmProof<SC>,
     ) -> Result<VerifiedContinuationVmPayload, VmVerificationError> {
-        let engine = BabyBearPoseidon2Engine::new(app_vk.fri_params);
+        let engine = E::new(app_vk.fri_params);
         let VerifiedExecutionPayload {
             exe_commit,
             final_memory_root,
@@ -200,7 +212,7 @@ impl Sdk {
         app_vk: &AppVerifyingKey,
         proof: &Proof<SC>,
     ) -> Result<(), VerificationError> {
-        let e = BabyBearPoseidon2Engine::new(app_vk.fri_params);
+        let e = E::new(app_vk.fri_params);
         e.verify(&app_vk.app_vm_vk, proof)
     }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -92,6 +92,10 @@ impl<E: StarkFriEngine<SC>> Default for GenericSdk<E> {
 pub type Sdk = GenericSdk<BabyBearPoseidon2Engine>;
 
 impl<E: StarkFriEngine<SC>> GenericSdk<E> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn build<P: AsRef<Path>>(
         &self,
         guest_opts: GuestOptions,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -28,7 +28,7 @@ use openvm_native_recursion::halo2::{
     wrapper::{EvmVerifier, Halo2WrapperProvingKey},
     RawEvmProof,
 };
-use openvm_stark_backend::{engine::StarkEngine, proof::Proof};
+use openvm_stark_backend::proof::Proof;
 use openvm_stark_sdk::{
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},
     engine::StarkFriEngine,

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -90,11 +90,12 @@ fn app_committed_exe_for_test(app_log_blowup: usize) -> Arc<VmCommittedExe<SC>> 
         program.max_num_public_values = NUM_PUB_VALUES;
         program
     };
-    Sdk.commit_app_exe(
-        FriParameters::new_for_testing(app_log_blowup),
-        program.into(),
-    )
-    .unwrap()
+    Sdk::default()
+        .commit_app_exe(
+            FriParameters::new_for_testing(app_log_blowup),
+            program.into(),
+        )
+        .unwrap()
 }
 
 fn agg_config_for_test() -> AggConfig {
@@ -308,7 +309,8 @@ fn test_static_verifier_custom_pv_handler() {
     println!("test setup");
     let app_log_blowup = 1;
     let app_config = small_test_app_config(app_log_blowup);
-    let app_pk = Sdk.app_keygen(app_config.clone()).unwrap();
+    let sdk = Sdk::default();
+    let app_pk = sdk.app_keygen(app_config.clone()).unwrap();
     let app_committed_exe = app_committed_exe_for_test(app_log_blowup);
     println!("app_config: {:?}", app_config.app_vm_config);
     println!(
@@ -331,19 +333,19 @@ fn test_static_verifier_custom_pv_handler() {
         exe_commit,
         leaf_verifier_commit,
     };
-    let agg_pk = Sdk
+    let agg_pk = sdk
         .agg_keygen(agg_config_for_test(), &params_reader, &pv_handler)
         .unwrap();
 
     // Generate verifier contract
     println!("generate verifier contract");
-    let evm_verifier = Sdk
+    let evm_verifier = sdk
         .generate_snark_verifier_contract(&params_reader, &agg_pk)
         .unwrap();
 
     // Generate and verify proof
     println!("generate and verify proof");
-    let evm_proof = Sdk
+    let evm_proof = sdk
         .generate_evm_proof(
             &params_reader,
             Arc::new(app_pk),
@@ -352,27 +354,28 @@ fn test_static_verifier_custom_pv_handler() {
             StdIn::default(),
         )
         .unwrap();
-    assert!(Sdk.verify_evm_proof(&evm_verifier, &evm_proof).is_ok());
+    assert!(sdk.verify_evm_proof(&evm_verifier, &evm_proof).is_ok());
 }
 
 #[test]
 fn test_e2e_proof_generation_and_verification() {
     let app_log_blowup = 1;
     let app_config = small_test_app_config(app_log_blowup);
-    let app_pk = Sdk.app_keygen(app_config).unwrap();
+    let sdk = Sdk::default();
+    let app_pk = sdk.app_keygen(app_config).unwrap();
     let params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
-    let agg_pk = Sdk
+    let agg_pk = sdk
         .agg_keygen(
             agg_config_for_test(),
             &params_reader,
             &DefaultStaticVerifierPvHandler,
         )
         .unwrap();
-    let evm_verifier = Sdk
+    let evm_verifier = sdk
         .generate_snark_verifier_contract(&params_reader, &agg_pk)
         .unwrap();
 
-    let evm_proof = Sdk
+    let evm_proof = sdk
         .generate_evm_proof(
             &params_reader,
             Arc::new(app_pk),
@@ -381,12 +384,12 @@ fn test_e2e_proof_generation_and_verification() {
             StdIn::default(),
         )
         .unwrap();
-    assert!(Sdk.verify_evm_proof(&evm_verifier, &evm_proof).is_ok());
+    assert!(sdk.verify_evm_proof(&evm_verifier, &evm_proof).is_ok());
 }
 
 #[test]
 fn test_sdk_guest_build_and_transpile() {
-    let sdk = Sdk;
+    let sdk = Sdk::default();
     let guest_opts = GuestOptions::default()
         // .with_features(vec!["zkvm"])
         // .with_options(vec!["--release"]);
@@ -410,7 +413,7 @@ fn test_sdk_guest_build_and_transpile() {
 #[test]
 fn test_inner_proof_codec_roundtrip() -> eyre::Result<()> {
     // generate a proof
-    let sdk = Sdk;
+    let sdk = Sdk::default();
     let mut pkg_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).to_path_buf();
     pkg_dir.push("guest");
     let elf = sdk.build(Default::default(), pkg_dir, &Default::default())?;

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -90,7 +90,7 @@ fn app_committed_exe_for_test(app_log_blowup: usize) -> Arc<VmCommittedExe<SC>> 
         program.max_num_public_values = NUM_PUB_VALUES;
         program
     };
-    Sdk::default()
+    Sdk::new()
         .commit_app_exe(
             FriParameters::new_for_testing(app_log_blowup),
             program.into(),
@@ -309,7 +309,7 @@ fn test_static_verifier_custom_pv_handler() {
     println!("test setup");
     let app_log_blowup = 1;
     let app_config = small_test_app_config(app_log_blowup);
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     let app_pk = sdk.app_keygen(app_config.clone()).unwrap();
     let app_committed_exe = app_committed_exe_for_test(app_log_blowup);
     println!("app_config: {:?}", app_config.app_vm_config);
@@ -361,7 +361,7 @@ fn test_static_verifier_custom_pv_handler() {
 fn test_e2e_proof_generation_and_verification() {
     let app_log_blowup = 1;
     let app_config = small_test_app_config(app_log_blowup);
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     let app_pk = sdk.app_keygen(app_config).unwrap();
     let params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
     let agg_pk = sdk
@@ -389,7 +389,7 @@ fn test_e2e_proof_generation_and_verification() {
 
 #[test]
 fn test_sdk_guest_build_and_transpile() {
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     let guest_opts = GuestOptions::default()
         // .with_features(vec!["zkvm"])
         // .with_options(vec!["--release"]);
@@ -413,7 +413,7 @@ fn test_sdk_guest_build_and_transpile() {
 #[test]
 fn test_inner_proof_codec_roundtrip() -> eyre::Result<()> {
     // generate a proof
-    let sdk = Sdk::default();
+    let sdk = Sdk::new();
     let mut pkg_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).to_path_buf();
     pkg_dir.push("guest");
     let elf = sdk.build(Default::default(), pkg_dir, &Default::default())?;


### PR DESCRIPTION
This change introduces a generic type for Sdk (with a typedef for `Sdk` that uses `BabyBearPoseidon2Engine`). This is to allow Sdk usage with different engines that still use the same `StarkGenericConfig = BabyBearPoseidon2Config`.

This will require changes in other repos, but it is inevitable since `let sdk = Sdk;` is now an invalid assignment.