### PR TITLE
chore: update toolchain to rust stable 1.85.1

### DIFF
--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -133,7 +133,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: runs-on/action@v1
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install tools
         run: |
-          rustup component add rust-src --toolchain nightly-2024-10-30
+          rustup component add rust-src --toolchain nightly-2025-02-14
 
       - name: Install cargo-openvm
         working-directory: crates/cli

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       # separately and copy over the index as a hack
       - name: Build index page
         run: |
-          cargo doc --workspace --no-deps --exclude "openvm-benchmarks" --exclude "*-tests" --exclude "*-test" --target-dir target/doc-nodeps
+          cargo +nightly doc --workspace --no-deps --exclude "openvm-benchmarks" --exclude "*-tests" --exclude "*-test" --target-dir target/doc-nodeps
           cp target/doc-nodeps/doc/index.html target/doc/
           cp target/doc-nodeps/doc/crates.js target/doc/
         env:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -85,5 +85,5 @@ jobs:
         if: hashFiles(format('extensions/{0}/tests', matrix.extension.path)) != ''
         working-directory: extensions/${{ matrix.extension.path }}/tests
         run: |
-          rustup component add rust-src --toolchain nightly-2024-10-30
+          rustup component add rust-src --toolchain nightly-2025-02-14
           cargo nextest run --cargo-profile=fast --no-tests=pass

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Run fmt
         run: |
-          cargo fmt --all -- --check
+          rustup install nightly
+          cargo +nightly fmt --all -- --check
 
       - name: Run clippy
         run: |

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -55,7 +55,7 @@ jobs:
             # Check if Cargo.toml exists in the directory
             if [ -f "$crate_path/Cargo.toml" ]; then
               echo "Running cargo fmt, clippy for $crate_path"
-              cargo fmt --manifest-path "$crate_path/Cargo.toml" --all -- --check
+              cargo +nightly fmt --manifest-path "$crate_path/Cargo.toml" --all -- --check
               if [[ "$crate_path" == *"extensions/ecc/tests/programs"* ]]; then
                 echo "Running cargo clippy with k256 feature for $crate_path"
                 cargo clippy --manifest-path "$crate_path/Cargo.toml" --all-targets --features "std k256" -- -D warnings

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Run fmt
         run: |
           rustup install nightly
+          rustup component add --toolchain nightly rustfmt
           cargo +nightly fmt --all -- --check
 
       - name: Run clippy

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-10-30
+          toolchain: nightly-2025-02-14
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -55,5 +55,5 @@ jobs:
       - name: Run RISC-V test vector tests
         working-directory: crates/toolchain/tests
         run: |
-          rustup component add rust-src --toolchain nightly-2024-10-30
+          rustup component add rust-src --toolchain nightly-2025-02-14
           cargo nextest run --cargo-profile=fast --run-ignored only -- test_rv32im_riscv_vector_runtime

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -44,11 +44,11 @@ jobs:
           case $arch in
             arm64|aarch64)
               S5CMD_BIN="s5cmd_2.2.2_linux_arm64.deb"
-              rustup component add rust-src --toolchain nightly-2024-10-30-aarch64-unknown-linux-gnu
+              rustup component add rust-src --toolchain nightly-2025-02-14-aarch64-unknown-linux-gnu
               ;;
             x86_64|amd64)
               S5CMD_BIN="s5cmd_2.2.2_linux_amd64.deb"
-              rustup component add rust-src --toolchain nightly-2024-10-30-x86_64-unknown-linux-gnu
+              rustup component add rust-src --toolchain nightly-2025-02-14-x86_64-unknown-linux-gnu
               ;;
             *)
               echo "Unsupported architecture: $arch"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=4a223981722e75bf97c6807e4d56935196d86edf#4a223981722e75bf97c6807e4d56935196d86edf"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=b051e8978da9c829a76b262abf4a9736c8d1681e#b051e8978da9c829a76b262abf4a9736c8d1681e"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=4a223981722e75bf97c6807e4d56935196d86edf#4a223981722e75bf97c6807e4d56935196d86edf"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=b051e8978da9c829a76b262abf4a9736c8d1681e#b051e8978da9c829a76b262abf4a9736c8d1681e"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "colored",
  "num-traits",
  "rand",
 ]
@@ -1225,16 +1224,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "const-default"
@@ -2154,15 +2143,15 @@ dependencies = [
 
 [[package]]
 name = "halo2-axiom"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f81aee7974478f9e3ea0cfd349d2a59a3482f7844386486a98e4af9ed8bada6"
+checksum = "62f0ca78d12ac5c893f286d7cdfe3869290305ab8cac376e2592cdc8396da102"
 dependencies = [
  "blake2b_simd",
  "crossbeam",
  "ff 0.13.0",
  "group 0.13.0",
- "halo2curves-axiom 0.7.0",
+ "halo2curves-axiom",
  "itertools 0.11.0",
  "maybe-rayon",
  "pairing 0.23.0",
@@ -2176,8 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "halo2-base"
-version = "0.4.1"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.4.1-git#2fe813b3ccd4f224da195d61829effb20599dcbd"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678cf3adc0a39d7b4d9b82315a655201aa24a430dd1902b162c508047f56ac69"
 dependencies = [
  "getset",
  "halo2-axiom",
@@ -2196,8 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "halo2-ecc"
-version = "0.4.1"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.4.1-git#2fe813b3ccd4f224da195d61829effb20599dcbd"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c00681fdd1febaf552d8814e9f5a6a142d81a1514102190da07039588b366"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",
@@ -2254,33 +2245,6 @@ dependencies = [
  "static_assertions",
  "subtle",
  "unroll",
-]
-
-[[package]]
-name = "halo2curves-axiom"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75bb262279138550a603b35a73da944fcde987a321eb550c05276ce7b0a4e692"
-dependencies = [
- "blake2b_simd",
- "digest 0.10.7",
- "ff 0.13.0",
- "group 0.13.0",
- "hex",
- "lazy_static",
- "maybe-rayon",
- "num-bigint 0.4.6",
- "num-traits",
- "pairing 0.23.0",
- "pasta_curves 0.5.1",
- "paste",
- "rand",
- "rand_core",
- "serde",
- "serde_arrays",
- "sha2",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -3250,7 +3214,7 @@ version = "1.0.0-rc.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "halo2curves-axiom 0.5.3",
+ "halo2curves-axiom",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
@@ -3286,7 +3250,7 @@ dependencies = [
 name = "openvm-algebra-guest"
 version = "1.0.0-rc.2"
 dependencies = [
- "halo2curves-axiom 0.5.3",
+ "halo2curves-axiom",
  "num-bigint 0.4.6",
  "openvm-algebra-complex-macros",
  "openvm-algebra-moduli-macros",
@@ -3577,7 +3541,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "group 0.13.0",
- "halo2curves-axiom 0.5.3",
+ "halo2curves-axiom",
  "hex-literal",
  "k256",
  "lazy_static",
@@ -3737,7 +3701,7 @@ dependencies = [
 name = "openvm-mod-circuit-builder"
 version = "1.0.0-rc.2"
 dependencies = [
- "halo2curves-axiom 0.5.3",
+ "halo2curves-axiom",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
@@ -3859,7 +3823,7 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "halo2curves-axiom 0.5.3",
+ "halo2curves-axiom",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
@@ -3888,7 +3852,7 @@ name = "openvm-pairing-guest"
 version = "1.0.0-rc.2"
 dependencies = [
  "group 0.13.0",
- "halo2curves-axiom 0.5.3",
+ "halo2curves-axiom",
  "hex-literal",
  "itertools 0.14.0",
  "lazy_static",
@@ -4828,9 +4792,9 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "poseidon-primitives"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd95570f7ea849b4187298b5bb229643e44e1d47ddf3979d0db8a1c28be26a8"
+checksum = "6e4aaeda7a092e21165cc5f0cbc738e72a46f31c03c3cbd87b71ceae9d2d93bc"
 dependencies = [
  "bitvec",
  "ff 0.13.0",
@@ -5719,8 +5683,9 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "snark-verifier"
-version = "0.1.8"
-source = "git+https://github.com/axiom-crypto/snark-verifier?branch=zkvm-v0.1#0e381253735fc0d75a6f6239c4fd9d155b4f1a5e"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e4c4ed1edca41687fe2d8a09ba30badb0a5cc7fa56dd1159d62aeab7c99ace"
 dependencies = [
  "halo2-base",
  "halo2-ecc",
@@ -5740,10 +5705,10 @@ dependencies = [
 
 [[package]]
 name = "snark-verifier-sdk"
-version = "0.1.8"
-source = "git+https://github.com/axiom-crypto/snark-verifier?branch=zkvm-v0.1#0e381253735fc0d75a6f6239c4fd9d155b4f1a5e"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "babff70ce6292fce03f692d68569f76b8f6710dbac7be7fe5f32c915909c9065"
 dependencies = [
- "ark-std 0.3.0",
  "bincode",
  "ethereum-types",
  "getset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "4a223981722e75bf97c6807e4d56935196d86edf", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "4a223981722e75bf97c6807e4d56935196d86edf", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "b051e8978da9c829a76b262abf4a9736c8d1681e", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "b051e8978da9c829a76b262abf4a9736c8d1681e", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,13 +173,12 @@ p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05"
 p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
 p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
 
-snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier", branch = "zkvm-v0.1", default-features = false, features = [
+zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
+snark-verifier-sdk = { version = "0.2.0", default-features = false, features = [
     "loader_halo2",
     "halo2-axiom",
-    "display",
 ] }
-zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
-halo2curves-axiom = "0.5.3"
+halo2curves-axiom = "0.7.0"
 
 tracing = "0.1.40"
 bon = "3.2.0"

--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -51,6 +51,6 @@ cargo openvm --version
 In order for the `cargo-openvm` build command to work, you must install certain Rust nightly components:
 
 ```bash
-rustup install nightly-2024-10-30
-rustup component add rust-src --toolchain nightly-2024-10-30
+rustup install nightly-2025-02-14
+rustup component add rust-src --toolchain nightly-2025-02-14
 ```

--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -6,16 +6,10 @@ To use OpenVM for generating proofs, you must install the OpenVM command line to
 
 ## Option 1: Install Via Git URL (Recommended)
 
-You will need the nightly toolchain. You can install it with:
+Begin the installation:
 
 ```bash
-rustup toolchain install nightly
-```
-
-Then, begin the installation.
-
-```bash
-cargo +nightly install --locked --git http://github.com/openvm-org/openvm.git cargo-openvm
+cargo install --locked --git http://github.com/openvm-org/openvm.git cargo-openvm
 ```
 
 This will globally install `cargo-openvm`. You can validate a successful installation with:
@@ -26,18 +20,12 @@ cargo openvm --version
 
 ## Option 2: Build from source
 
-To build from source, you will need the nightly toolchain. You can install it with:
-
-```bash
-rustup toolchain install nightly
-```
-
-Then, clone the repository and begin the installation.
+To build from source, clone the repository and begin the installation.
 
 ```bash
 git clone https://github.com/openvm-org/openvm.git
 cd openvm
-cargo +nightly install --locked --force --path crates/cli
+cargo install --locked --force --path crates/cli
 ```
 
 This will globally install `cargo-openvm`. You can validate a successful installation with:

--- a/ci/scripts/utils.sh
+++ b/ci/scripts/utils.sh
@@ -111,11 +111,11 @@ install_s5cmd() {
     arch=$(uname -m)
     case $arch in
     arm64|aarch64)
-        rustup component add rust-src --toolchain nightly-2024-10-30-aarch64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-2025-02-14-aarch64-unknown-linux-gnu
         S5CMD_BIN="s5cmd_2.2.2_linux_arm64.deb"
         ;;
     x86_64|amd64)
-        rustup component add rust-src --toolchain nightly-2024-10-30-x86_64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-2025-02-14-x86_64-unknown-linux-gnu
         S5CMD_BIN="s5cmd_2.2.2_linux_amd64.deb"
         ;;
     *)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Stdio};
 
 use eyre::{Context, Result};
 
-pub const RUSTUP_TOOLCHAIN_NAME: &str = "nightly-2024-10-30";
+pub const RUSTUP_TOOLCHAIN_NAME: &str = "nightly-2025-02-14";
 
 pub const OPENVM_VERSION_MESSAGE: &str = concat!(
     "openvm",

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -31,7 +31,7 @@ pub trait Encode {
     /// Writes the encoded representation of `self` to the given writer.
     fn encode<W: Write>(&self, writer: &mut W) -> Result<()>;
 
-    /// Convenience method to encode into a Vec<u8>
+    /// Convenience method to encode into a `Vec<u8>`
     fn encode_to_vec(&self) -> Result<Vec<u8>> {
         let mut buffer = Vec::new();
         self.encode(&mut buffer)?;

--- a/crates/toolchain/build/src/lib.rs
+++ b/crates/toolchain/build/src/lib.rs
@@ -21,7 +21,7 @@ mod config;
 
 /// The rustc compiler [target](https://doc.rust-lang.org/rustc/targets/index.html).
 pub const RUSTC_TARGET: &str = "riscv32im-risc0-zkvm-elf";
-const RUSTUP_TOOLCHAIN_NAME: &str = "nightly-2024-10-30";
+const RUSTUP_TOOLCHAIN_NAME: &str = "nightly-2025-02-14";
 const BUILD_LOCKED_ENV: &str = "OPENVM_BUILD_LOCKED";
 const SKIP_BUILD_ENV: &str = "OPENVM_SKIP_BUILD";
 const GUEST_LOGFILE_ENV: &str = "OPENVM_GUEST_LOGFILE";

--- a/crates/toolchain/openvm/src/host.rs
+++ b/crates/toolchain/openvm/src/host.rs
@@ -2,12 +2,12 @@
 
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
-pub use std::*;
+pub use input::*;
 
 #[cfg(feature = "std")]
-mod std {
+mod input {
     use alloc::vec::Vec;
-    use core::cell::RefCell;
+    use std::cell::RefCell;
 
     /// Simulated input stream on host
     pub enum HostInputStream {
@@ -59,9 +59,7 @@ mod std {
 pub fn hint_input() {
     #[cfg(feature = "std")]
     {
-        let mut hints = HINTS.borrow_mut();
-        match &mut (*hints) {
-            #[cfg(feature = "std")]
+        HINTS.with_borrow_mut(|hints| match hints {
             HostInputStream::Stdin => {
                 use std::io::Read;
                 let mut buf = Vec::new();
@@ -75,7 +73,7 @@ pub fn hint_input() {
                 let hint = hints.pop().expect("No hint stream available");
                 HINT_STREAM.replace(hint);
             }
-        }
+        });
     }
     #[cfg(not(feature = "std"))]
     unimplemented!("hint_input not supported on no_std host")
@@ -85,7 +83,7 @@ pub fn hint_input() {
 pub fn read_n_bytes(_n: usize) -> Vec<u8> {
     #[cfg(feature = "std")]
     {
-        HINT_STREAM.borrow_mut().drain(.._n).collect()
+        HINT_STREAM.with_borrow_mut(|stream| stream.drain(.._n).collect())
     }
     #[cfg(not(feature = "std"))]
     {

--- a/crates/toolchain/openvm/src/host.rs
+++ b/crates/toolchain/openvm/src/host.rs
@@ -1,38 +1,39 @@
 //! Hints emulation for the non-zkVM environment.
 
 use alloc::vec::Vec;
+#[cfg(feature = "std")]
 use core::cell::RefCell;
 
 /// Simulated input stream on host
 pub enum HostInputStream {
     /// Read directly from stdin
-    #[cfg(feature = "std")]
     Stdin,
     /// Directly set from a test using [`set_hints`].
     Internal(Vec<Vec<u8>>),
 }
 
 impl HostInputStream {
-    const fn new() -> Self {
-        #[cfg(feature = "std")]
-        {
-            Self::Stdin
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            Self::Internal(Vec::new())
-        }
+    pub const fn new() -> Self {
+        Self::Stdin
     }
 }
 
-/// Hint streams in the non-zkVM environment.
-#[thread_local]
-pub static HINTS: RefCell<HostInputStream> = RefCell::new(HostInputStream::new());
-/// Current hint stream in the non-zkVM environment.
-#[thread_local]
-pub static HINT_STREAM: RefCell<Vec<u8>> = RefCell::new(Vec::new());
+impl Default for HostInputStream {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "std")]
+thread_local! {
+    /// Hint streams in the non-zkVM environment.
+    pub static HINTS: RefCell<HostInputStream> = RefCell::new(HostInputStream::new());
+    /// Current hint stream in the non-zkVM environment.
+    pub static HINT_STREAM: RefCell<Vec<u8>> = RefCell::new(Vec::new());
+}
 
 /// Set the hints and reset the current hint stream.
+#[cfg(feature = "std")]
 pub fn set_hints(hints: Vec<Vec<u8>>) {
     HINTS.replace(HostInputStream::Internal(
         hints
@@ -52,28 +53,40 @@ pub fn set_hints(hints: Vec<Vec<u8>>) {
 
 /// Read the next hint stream from the hints.
 pub fn hint_input() {
-    let mut hints = HINTS.borrow_mut();
-    match &mut (*hints) {
-        #[cfg(feature = "std")]
-        HostInputStream::Stdin => {
-            use std::io::Read;
-            let mut buf = Vec::new();
-            std::io::stdin()
-                .read_to_end(&mut buf)
-                .expect("Failed to read from stdin");
-            let hint = [&(buf.len() as u32).to_le_bytes(), &buf[..]].concat();
-            HINT_STREAM.replace(hint);
-        }
-        HostInputStream::Internal(hints) => {
-            let hint = hints.pop().expect("No hint stream available");
-            HINT_STREAM.replace(hint);
+    #[cfg(feature = "std")]
+    {
+        let mut hints = HINTS.borrow_mut();
+        match &mut (*hints) {
+            #[cfg(feature = "std")]
+            HostInputStream::Stdin => {
+                use std::io::Read;
+                let mut buf = Vec::new();
+                std::io::stdin()
+                    .read_to_end(&mut buf)
+                    .expect("Failed to read from stdin");
+                let hint = [&(buf.len() as u32).to_le_bytes(), &buf[..]].concat();
+                HINT_STREAM.replace(hint);
+            }
+            HostInputStream::Internal(hints) => {
+                let hint = hints.pop().expect("No hint stream available");
+                HINT_STREAM.replace(hint);
+            }
         }
     }
+    #[cfg(not(feature = "std"))]
+    unimplemented!("hint_input not supported on no_std host")
 }
 
 /// Read the next `n` bytes from the hint stream.
-pub fn read_n_bytes(n: usize) -> Vec<u8> {
-    HINT_STREAM.borrow_mut().drain(..n).collect()
+pub fn read_n_bytes(_n: usize) -> Vec<u8> {
+    #[cfg(feature = "std")]
+    {
+        HINT_STREAM.borrow_mut().drain(.._n).collect()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        unimplemented!("hint_stream not supported on no_std host")
+    }
 }
 
 /// Read the next 4 bytes from the hint stream as a `u32`.
@@ -82,7 +95,7 @@ pub fn read_u32() -> u32 {
     u32::from_le_bytes(bytes.try_into().unwrap())
 }
 
-#[cfg(all(test, not(target_os = "zkvm")))]
+#[cfg(all(feature = "std", test, not(target_os = "zkvm")))]
 mod tests {
     use alloc::vec;
 

--- a/crates/toolchain/openvm/src/host.rs
+++ b/crates/toolchain/openvm/src/host.rs
@@ -1,6 +1,7 @@
 //! Hints emulation for the non-zkVM environment.
 
 use alloc::vec::Vec;
+
 #[cfg(feature = "std")]
 pub use input::*;
 

--- a/crates/toolchain/openvm/src/host.rs
+++ b/crates/toolchain/openvm/src/host.rs
@@ -32,9 +32,9 @@ mod input {
 
     thread_local! {
         /// Hint streams in the non-zkVM environment.
-        pub static HINTS: RefCell<HostInputStream> = RefCell::new(HostInputStream::new());
+        pub static HINTS: RefCell<HostInputStream> = const { RefCell::new(HostInputStream::new()) };
         /// Current hint stream in the non-zkVM environment.
-        pub static HINT_STREAM: RefCell<Vec<u8>> = RefCell::new(Vec::new());
+        pub static HINT_STREAM: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
     }
 
     /// Set the hints and reset the current hint stream.

--- a/crates/toolchain/openvm/src/lib.rs
+++ b/crates/toolchain/openvm/src/lib.rs
@@ -2,9 +2,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(rustdoc::broken_intra_doc_links)]
-// #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![feature(thread_local)]
 
 #[macro_use]
 extern crate alloc;

--- a/crates/toolchain/openvm/src/serde/deserializer.rs
+++ b/crates/toolchain/openvm/src/serde/deserializer.rs
@@ -191,7 +191,7 @@ impl<'de, R: WordRead + 'de> Deserializer<'de, R> {
     fn try_take_dword(&mut self) -> Result<u64> {
         let low = self.try_take_word()? as u64;
         let high = self.try_take_word()? as u64;
-        Ok(low | high << 32)
+        Ok(low | (high << 32))
     }
 }
 

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -584,7 +584,7 @@ where
 
     /// Verify segment proofs, checking continuation boundary conditions between segments if VM memory is persistent
     /// The behavior of this function differs depending on whether continuations is enabled or not.
-    /// We recommend to call the functions [`Self::verify_segments`] or [`Self::verify_single`] directly instead.
+    /// We recommend to call the functions [`verify_segments`] or [`verify_single`] directly instead.
     pub fn verify(
         &self,
         vk: &MultiStarkVerifyingKey<SC>,

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -477,7 +477,7 @@ impl<F: PrimeField32> MemoryController<F> {
         }
     }
 
-    /// Low-level API to replay a single memory access log entry and populate the [OfflineMemory], [MemoryInterface], and [AccessAdapterInventory].
+    /// Low-level API to replay a single memory access log entry and populate the [OfflineMemory], [MemoryInterface], and `AccessAdapterInventory`.
     pub fn replay_access(
         entry: MemoryLogEntry<F>,
         offline_memory: &mut OfflineMemory<F>,

--- a/extensions/algebra/complex-macros/src/lib.rs
+++ b/extensions/algebra/complex-macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_diagnostic)]
-
 extern crate proc_macro;
 
 use openvm_macros_common::MacroArgs;

--- a/extensions/algebra/moduli-macros/src/lib.rs
+++ b/extensions/algebra/moduli-macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_diagnostic)]
-
 extern crate proc_macro;
 
 use std::sync::atomic::AtomicUsize;

--- a/extensions/ecc/sw-macros/src/lib.rs
+++ b/extensions/ecc/sw-macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_diagnostic)]
-
 extern crate proc_macro;
 
 use openvm_macros_common::MacroArgs;

--- a/extensions/native/compiler/src/ir/builder.rs
+++ b/extensions/native/compiler/src/ir/builder.rs
@@ -306,7 +306,7 @@ impl<C: Config> Builder<C> {
     /// Only works for Felt == BabyBear and in the VM.
     ///
     /// Uses bit decomposition hint, which has large constant factor overhead, so prefer
-    /// [assert_less_than_slow_small_rhs] when rhs is small.
+    /// [Self::assert_less_than_slow_small_rhs] when rhs is small.
     pub fn assert_less_than_slow_bit_decomp(&mut self, lhs: Var<C::N>, rhs: Var<C::N>) {
         let lhs = self.unsafe_cast_var_to_felt(lhs);
         let rhs = self.unsafe_cast_var_to_felt(rhs);

--- a/extensions/native/compiler/src/ir/verify_batch.rs
+++ b/extensions/native/compiler/src/ir/verify_batch.rs
@@ -21,7 +21,7 @@ impl<C: Config> Builder<C> {
         ));
     }
 
-    /// Version of [`verify_batch_felt`] where `opened_values` are extension field elements.
+    /// Version of [`Self::verify_batch_felt`] where `opened_values` are extension field elements.
     /// - Requires `dimensions.len() == opened_values.len()`
     /// - `proof` is an array of arrays where inner arrays are of length `CHUNK`
     /// - `commit.len() = CHUNK`

--- a/extensions/native/recursion/rust-toolchain.toml
+++ b/extensions/native/recursion/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-10-30"
+channel = "nightly-2025-02-14"

--- a/extensions/native/recursion/rust-toolchain.toml
+++ b/extensions/native/recursion/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2025-02-14"

--- a/extensions/pairing/guest/src/pairing/line.rs
+++ b/extensions/pairing/guest/src/pairing/line.rs
@@ -1,7 +1,7 @@
 /// A line function on Fp12 x Fp12 in a sparse representation.
-/// Let Fp12 = Fp2[w] / (w^6 - \xi). Then the line function is
-/// L(x,y) = 1 + b (x/y) w' + c (1/y) w'^3
-/// where w' = w for D-type and w' = w^-1 for M-type twists
+/// Let `Fp12 = Fp2[w] / (w^6 - \xi)`. Then the line function is
+/// `L(x,y) = 1 + b (x/y) w' + c (1/y) w'^3`
+/// where `w' = w` for D-type and `w' = w^{-1}` for M-type twists
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct UnevaluatedLine<Fp2> {

--- a/extensions/pairing/tests/programs/examples/fp12_mul.rs
+++ b/extensions/pairing/tests/programs/examples/fp12_mul.rs
@@ -1,4 +1,3 @@
-#![feature(cfg_match)]
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(unused_imports)]
@@ -90,9 +89,12 @@ pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();
 
-    cfg_match! {
-        cfg(feature = "bn254") => { bn254::test_fp12_mul(&io) }
-        cfg(feature = "bls12_381") => { bls12_381::test_fp12_mul(&io) }
-        _ => { panic!("No curve feature enabled") }
+    #[cfg(feature = "bn254")]
+    {
+        bn254::test_fp12_mul(&io)
+    }
+    #[cfg(feature = "bls12_381")]
+    {
+        bls12_381::test_fp12_mul(&io)
     }
 }

--- a/extensions/pairing/tests/programs/examples/pairing_check.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_check.rs
@@ -1,4 +1,3 @@
-#![feature(cfg_match)]
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(unused_imports)]
@@ -98,9 +97,12 @@ pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();
 
-    cfg_match! {
-        cfg(feature = "bn254") => { bn254::test_pairing_check(&io); }
-        cfg(feature = "bls12_381") => { bls12_381::test_pairing_check(&io); }
-        _ => { panic!("No curve feature enabled") }
+    #[cfg(feature = "bn254")]
+    {
+        bn254::test_pairing_check(&io);
+    }
+    #[cfg(feature = "bls12_381")]
+    {
+        bls12_381::test_pairing_check(&io);
     }
 }

--- a/extensions/pairing/tests/programs/examples/pairing_check_fallback.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_check_fallback.rs
@@ -1,4 +1,3 @@
-#![feature(cfg_match)]
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(unused_imports)]
@@ -249,9 +248,12 @@ pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();
 
-    cfg_match! {
-        cfg(feature = "bn254") => { bn254::test_pairing_check(&io); }
-        cfg(feature = "bls12_381") => { bls12_381::test_pairing_check(&io); }
-        _ => { panic!("No curve feature enabled") }
+    #[cfg(feature = "bn254")]
+    {
+        bn254::test_pairing_check(&io);
+    }
+    #[cfg(feature = "bls12_381")]
+    {
+        bls12_381::test_pairing_check(&io);
     }
 }

--- a/extensions/pairing/tests/programs/examples/pairing_line.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_line.rs
@@ -1,4 +1,3 @@
-#![feature(cfg_match)]
 #![allow(unused_imports)]
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -149,19 +148,18 @@ pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();
 
-    cfg_match! {
-        cfg(feature = "bn254") => {
-            bn254::setup_0();
-            bn254::setup_all_complex_extensions();
-            bn254::test_mul_013_by_013(&io[..32 * 18]);
-            bn254::test_mul_by_01234(&io[32 * 18..32 * 52]);
-        }
-        cfg(feature = "bls12_381") => {
-            bls12_381::setup_0();
-            bls12_381::setup_all_complex_extensions();
-            bls12_381::test_mul_023_by_023(&io[..48 * 18]);
-            bls12_381::test_mul_by_02345(&io[48 * 18..48 * 52]);
-        }
-        _ => { panic!("No curve feature enabled") }
+    #[cfg(feature = "bn254")]
+    {
+        bn254::setup_0();
+        bn254::setup_all_complex_extensions();
+        bn254::test_mul_013_by_013(&io[..32 * 18]);
+        bn254::test_mul_by_01234(&io[32 * 18..32 * 52]);
+    }
+    #[cfg(feature = "bls12_381")]
+    {
+        bls12_381::setup_0();
+        bls12_381::setup_all_complex_extensions();
+        bls12_381::test_mul_023_by_023(&io[..48 * 18]);
+        bls12_381::test_mul_by_02345(&io[48 * 18..48 * 52]);
     }
 }

--- a/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_loop.rs
@@ -1,4 +1,3 @@
-#![feature(cfg_match)]
 #![allow(unused_imports)]
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -105,9 +104,12 @@ pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();
 
-    cfg_match! {
-        cfg(feature = "bn254") => { bn254::test_miller_loop(&io); }
-        cfg(feature = "bls12_381") => { bls12_381::test_miller_loop(&io); }
-        _ => { panic!("No curve feature enabled") }
+    #[cfg(feature = "bn254")]
+    {
+        bn254::test_miller_loop(&io);
+    }
+    #[cfg(feature = "bls12_381")]
+    {
+        bls12_381::test_miller_loop(&io);
     }
 }

--- a/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
+++ b/extensions/pairing/tests/programs/examples/pairing_miller_step.rs
@@ -1,4 +1,3 @@
-#![feature(cfg_match)]
 #![allow(unused_imports)]
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -168,19 +167,18 @@ pub fn main() {
     #[allow(unused_variables)]
     let io = read_vec();
 
-    cfg_match! {
-        cfg(feature = "bn254") => {
-            bn254::setup_0();
-            bn254::setup_all_complex_extensions();
-            bn254::test_miller_step(&io[..32 * 12]);
-            bn254::test_miller_double_and_add_step(&io[32 * 12..]);
-        }
-        cfg(feature = "bls12_381") => {
-            bls12_381::setup_0();
-            bls12_381::setup_all_complex_extensions();
-            bls12_381::test_miller_step(&io[..48 * 12]);
-            bls12_381::test_miller_double_and_add_step(&io[48 * 12..]);
-        }
-        _ => { panic!("No curve feature enabled") }
+    #[cfg(feature = "bn254")]
+    {
+        bn254::setup_0();
+        bn254::setup_all_complex_extensions();
+        bn254::test_miller_step(&io[..32 * 12]);
+        bn254::test_miller_double_and_add_step(&io[32 * 12..]);
+    }
+    #[cfg(feature = "bls12_381")]
+    {
+        bls12_381::setup_0();
+        bls12_381::setup_all_complex_extensions();
+        bls12_381::test_miller_step(&io[..48 * 12]);
+        bls12_381::test_miller_double_and_add_step(&io[48 * 12..]);
     }
 }

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -12,9 +12,7 @@ use openvm_stark_backend::{
     p3_air::BaseAir,
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
-    p3_maybe_rayon::prelude::{
-        IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSliceMut,
-    },
+    p3_maybe_rayon::prelude::*,
     prover::types::AirProofInput,
     rap::get_air_name,
     AirRef, Chip, ChipUsageGetter,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-10-30"     # "1.82.0"
+channel = "1.85.1"
 components = ["clippy", "rustfmt"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
 style_edition = "2021"
 imports_granularity = "Crate"
-# unstable features:
-# group_imports = "StdExternalCrate"
+# unstable features: use cargo +nightly fmt
+group_imports = "StdExternalCrate"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,4 @@
-group_imports = "StdExternalCrate"
+style_edition = "2021"
 imports_granularity = "Crate"
+# unstable features:
+# group_imports = "StdExternalCrate"


### PR DESCRIPTION
The default toolchain is rust 1.85.1 now -- the codebase uses stable Rust and does not use unstable features (previously this was blocked by snark-verifier using unstable features).

We still use "group_imports" in rustfmt.toml, which is unstable. So for full functionality, use `cargo +nightly fmt`. In a separate PR, we can add instructions on how to configure IDEs to use nightly for formatting only.

Unfortunately, `cargo openvm build` must still rely on a nightly install: it needs to rebuild the std library of a tier 3 target, which is an unstable `cargo` feature.
I updated the nightly toolchain to `nightly-2025-02-14`, which is when Rust 1.86.0 branched from master.

The book has been updated accordingly.

closes INT-3534