### PR TITLE
chore: public `get_height()` of `FriReducedOpeningChip`

### DIFF
--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -560,7 +560,7 @@ pub struct FriReducedOpeningRecord<F: Field> {
 }
 
 impl<F: Field> FriReducedOpeningRecord<F> {
-    fn get_height(&self) -> usize {
+    pub fn get_height(&self) -> usize {
         // 2 for instruction rows
         self.a_rws.len() + 2
     }


### PR DESCRIPTION
Public `get_height()` method used to deserialize `FriReducedOpeningChip`