### PR TITLE
chore: Add debug assertions for the setup row of Mod Builder chips

### DIFF
--- a/crates/circuits/mod-builder/src/builder.rs
+++ b/crates/circuits/mod-builder/src/builder.rs
@@ -566,6 +566,20 @@ impl FieldExpr {
 
     pub fn execute(&self, inputs: Vec<BigUint>, flags: Vec<bool>) -> Vec<BigUint> {
         assert!(self.builder.is_finalized());
+
+        #[cfg(debug_assertions)]
+        {
+            let is_setup = self.builder.needs_setup() && flags.iter().all(|&x| !x);
+            if is_setup {
+                assert_eq!(inputs[0], self.builder.prime);
+                // Check that inputs.iter().skip(1) has all the setup values as a prefix
+                assert!(inputs.len() > self.setup_values.len());
+                for (expected, actual) in self.setup_values.iter().zip(inputs.iter().skip(1)) {
+                    assert_eq!(expected, actual);
+                }
+            }
+        }
+
         let mut vars = vec![BigUint::zero(); self.num_variables];
         for i in 0..self.constraints.len() {
             let r = self.computes[i].compute(&inputs, &vars, &flags, &self.prime);

--- a/extensions/algebra/tests/programs/examples/invalid-setup.rs
+++ b/extensions/algebra/tests/programs/examples/invalid-setup.rs
@@ -1,0 +1,22 @@
+#![cfg_attr(not(feature = "std"), no_main)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use openvm_algebra_guest::IntMod;
+
+openvm::entry!(main);
+
+openvm_algebra_moduli_macros::moduli_declare! {
+    Mod1 { modulus = "998244353" },
+    Mod2 { modulus = "1000000007" }
+}
+
+// the order of the moduli here does not match the order in the config
+openvm_algebra_moduli_macros::moduli_init! {
+    "1000000007",
+    "998244353",
+}
+
+pub fn main() {
+    // this should cause a debug assertion to fail
+    setup_all_moduli();
+}

--- a/extensions/algebra/tests/src/lib.rs
+++ b/extensions/algebra/tests/src/lib.rs
@@ -120,4 +120,25 @@ mod tests {
         air_test(config, openvm_exe);
         Ok(())
     }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_setup() {
+        let elf = build_example_program_at_path(get_programs_dir!(), "invalid-setup").unwrap();
+        let openvm_exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv32ITranspilerExtension)
+                .with_extension(Rv32MTranspilerExtension)
+                .with_extension(Rv32IoTranspilerExtension)
+                .with_extension(Fp2TranspilerExtension)
+                .with_extension(ModularTranspilerExtension),
+        )
+        .unwrap();
+        let config = Rv32ModularConfig::new(vec![
+            BigUint::from_str("998244353").unwrap(),
+            BigUint::from_str("1000000007").unwrap(),
+        ]);
+        air_test(config, openvm_exe);
+    }
 }

--- a/extensions/ecc/tests/programs/Cargo.toml
+++ b/extensions/ecc/tests/programs/Cargo.toml
@@ -73,3 +73,7 @@ required-features = ["k256"]
 [[example]]
 name = "ecdsa"
 required-features = ["k256"]
+
+[[example]]
+name = "invalid_setup"
+required-features = ["k256", "p256"]

--- a/extensions/ecc/tests/programs/examples/invalid_setup.rs
+++ b/extensions/ecc/tests/programs/examples/invalid_setup.rs
@@ -1,0 +1,26 @@
+#![cfg_attr(not(feature = "std"), no_main)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[allow(unused_imports)]
+use openvm_ecc_guest::{k256::Secp256k1Point, p256::P256Point};
+
+openvm_algebra_moduli_macros::moduli_init! {
+    "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F",
+    "0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141",
+    "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+    "0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+}
+
+// the order of the curves here does not match the order in supported_curves
+openvm_ecc_sw_macros::sw_init! {
+    P256Point,
+    Secp256k1Point,
+}
+
+openvm::entry!(main);
+
+pub fn main() {
+    setup_all_moduli();
+    // this should cause a debug assertion to fail
+    setup_all_curves();
+}

--- a/extensions/ecc/tests/src/lib.rs
+++ b/extensions/ecc/tests/src/lib.rs
@@ -274,4 +274,28 @@ mod tests {
         air_test(config, openvm_exe);
         Ok(())
     }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_setup() {
+        let elf = build_example_program_at_path_with_features(
+            get_programs_dir!(),
+            "invalid_setup",
+            ["k256", "p256"],
+        )
+        .unwrap();
+        let openvm_exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv32ITranspilerExtension)
+                .with_extension(Rv32MTranspilerExtension)
+                .with_extension(Rv32IoTranspilerExtension)
+                .with_extension(EccTranspilerExtension)
+                .with_extension(ModularTranspilerExtension),
+        )
+        .unwrap();
+        let config =
+            Rv32WeierstrassConfig::new(vec![SECP256K1_CONFIG.clone(), P256_CONFIG.clone()]);
+        air_test(config, openvm_exe);
+    }
 }


### PR DESCRIPTION
Added debug assertions in execute to check the values in the setup row are correct.

Added `#[should_panic]` tests:
- for ecc that fail since the order of curves in `sw_init!` does not match the config
- for algebra that fail since the order of moduli in `moduli_init!` does not match the config.

Closes INT-3698