### PR TITLE
fix: Add p256 feature to clippy when linting ecc test guest programs

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -57,8 +57,8 @@ jobs:
               echo "Running cargo fmt, clippy for $crate_path"
               cargo +nightly fmt --manifest-path "$crate_path/Cargo.toml" --all -- --check
               if [[ "$crate_path" == *"extensions/ecc/tests/programs"* ]]; then
-                echo "Running cargo clippy with k256 feature for $crate_path"
-                cargo clippy --manifest-path "$crate_path/Cargo.toml" --all-targets --features "std k256" -- -D warnings
+                echo "Running cargo clippy with k256 and p256 features for $crate_path"
+                cargo clippy --manifest-path "$crate_path/Cargo.toml" --all-targets --features "std k256 p256" -- -D warnings
               elif [[ "$crate_path" == *"extensions/pairing/tests/programs"* ]]; then
                 echo "Running cargo clippy with openvm_pairing_guest::bn254 feature for $crate_path"
                 cargo clippy --manifest-path "$crate_path/Cargo.toml" --all-targets --features "std bn254" -- -D warnings

--- a/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
+++ b/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
@@ -1,13 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use core::hint::black_box;
-
 use hex_literal::hex;
 use openvm_algebra_guest::IntMod;
 use openvm_ecc_guest::{
-    msm,
-    p256::{P256Coord, P256Point, P256Scalar},
+    p256::{P256Coord, P256Point},
     weierstrass::WeierstrassPoint,
     CyclicGroup, Group,
 };
@@ -57,7 +54,7 @@ pub fn main() {
 
     // Test generator
     let (gen_x, gen_y) = P256Point::GENERATOR.into_coords();
-    let generator = P256Point::from_xy(gen_x, gen_y).unwrap();
+    let _generator = P256Point::from_xy(gen_x, gen_y).unwrap();
     let (neg_x, neg_y) = P256Point::NEG_GENERATOR.into_coords();
-    let neg_generator = P256Point::from_xy(neg_x, neg_y).unwrap();
+    let _neg_generator = P256Point::from_xy(neg_x, neg_y).unwrap();
 }


### PR DESCRIPTION
The linter did not lint some guest programs in the ecc tests because the `p256` feature was not enabled.