### PR TITLE
chore: Update book to specify order of items in init! macros

### DIFF
--- a/book/src/custom-extensions/algebra.md
+++ b/book/src/custom-extensions/algebra.md
@@ -106,6 +106,8 @@ supported_modulus = ["1157920892373161954235709850086879078532699846656405640394
 ```
 
 The `supported_modulus` parameter is a list of moduli that the guest program will use. They must be provided in decimal format in the `.toml` file.
+The order of moduli in `[app_vm_config.modular]` must match the order in the `moduli_init!` macro.
+Similarly, the order of moduli in `[app_vm_config.fp2]` must match the order in the `complex_init!` macro.
 
 ### Example program
 

--- a/book/src/custom-extensions/ecc.md
+++ b/book/src/custom-extensions/ecc.md
@@ -102,4 +102,6 @@ a = "0"
 b = "7"
 ```
 
-The `supported_modulus` parameter is a list of moduli that the guest program will use. The `ecc.supported_curves` parameter is a list of supported curves that the guest program will use. They must be provided in decimal format in the `.toml` file. For multiple curves create multiple `[[app_vm_config.ecc.supported_curves]]` sections.
+The `supported_modulus` parameter is a list of moduli that the guest program will use. As mentioned in the [algebra extension](./algebra.md) chapter, the order of moduli in `[app_vm_config.modular]` must match the order in the `moduli_init!` macro.
+
+The `ecc.supported_curves` parameter is a list of supported curves that the guest program will use. They must be provided in decimal format in the `.toml` file. For multiple curves create multiple `[[app_vm_config.ecc.supported_curves]]` sections. The order of curves in `[[app_vm_config.ecc.supported_curves]]` must match the order in the `sw_init!` macro.


### PR DESCRIPTION
Added a note to the algebra and ecc extension pages that mentions that the order of items in the `moduli_init`, `complex_init` and `sw_init` macros must match the order in the vm config toml file.

Closes INT-3696