### PR TITLE
fix: plonky3 FRI verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=b051e8978da9c829a76b262abf4a9736c8d1681e#b051e8978da9c829a76b262abf4a9736c8d1681e"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=39e79c5998907d008319e02fe885d48054c6444b#39e79c5998907d008319e02fe885d48054c6444b"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4180,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=b051e8978da9c829a76b262abf4a9736c8d1681e#b051e8978da9c829a76b262abf4a9736c8d1681e"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=39e79c5998907d008319e02fe885d48054c6444b#39e79c5998907d008319e02fe885d48054c6444b"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "ff 0.13.0",
  "halo2curves",
@@ -4343,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4355,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -4369,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -4418,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft",
@@ -4435,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4458,7 +4458,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -4472,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4487,7 +4487,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "rayon",
 ]
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-dft",
@@ -4509,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -4526,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "gcd",
  "p3-field",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -4586,7 +4586,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4596,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-air",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "b051e8978da9c829a76b262abf4a9736c8d1681e", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "b051e8978da9c829a76b262abf4a9736c8d1681e", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "39e79c5998907d008319e02fe885d48054c6444b", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "39e79c5998907d008319e02fe885d48054c6444b", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }
@@ -160,18 +160,18 @@ openvm-pairing-transpiler = { path = "extensions/pairing/transpiler", default-fe
 openvm-pairing-guest = { path = "extensions/pairing/guest", default-features = false }
 
 # Plonky3
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
     "nightly-features",
-], rev = "88d7f05" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "88d7f05" }
+], rev = "1ba4e5c" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
 
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 snark-verifier-sdk = { version = "0.2.0", default-features = false, features = [

--- a/audits/v1-internal/stark-backend.md
+++ b/audits/v1-internal/stark-backend.md
@@ -90,22 +90,22 @@ are determined in part from the prover's private randomness.
 **Context:** https://github.com/openvm-org/stark-backend/blob/fdb808bec40ff21dce7e462c2c18dbb997207adb/crates/stark-backend/src/verifier/mod.rs#L54
 
 **Description:**
-To protect against weak Fiat-Shamir, everything in the proof input should be observed in the Fiat-Shamir transcript. 
+To protect against weak Fiat-Shamir, everything in the proof input should be observed in the Fiat-Shamir transcript.
 The `Proof` contains the `air_ids` of the AIRs used in the proof, where the protocol will verify the proof against this subset of the AIRs specified in the verification key.
 This finding is similar in nature to [Cantina #152](https://cantina.xyz/code/c486d600-bed0-4fc6-aed1-de759fd29fa2/findings/152).
 
 We also ensure that everything in the `Proof` is observed:
 - `commitments`: [preprocessed](https://github.com/openvm-org/stark-backend/blob/fdb808bec40ff21dce7e462c2c18dbb997207adb/crates/stark-backend/src/verifier/mod.rs#L88), [main](https://github.com/openvm-org/stark-backend/blob/fdb808bec40ff21dce7e462c2c18dbb997207adb/crates/stark-backend/src/verifier/mod.rs#L92), [after challenge](https://github.com/openvm-org/stark-backend/blob/fdb808bec40ff21dce7e462c2c18dbb997207adb/crates/stark-backend/src/interaction/fri_log_up.rs#L195) assuming `<=1` phase, [quotient](https://github.com/openvm-org/stark-backend/blob/fdb808bec40ff21dce7e462c2c18dbb997207adb/crates/stark-backend/src/verifier/mod.rs#L145)
   - We note that `observe_slice` does not observe the length of the slice, which is acceptable for commitments because the number of commitments is recorded in the verifying key, _assuming_ that the proof shape is validated against the verifying key (see Finding 2.5 below)
-- `opening: OpeningProof`: 
-  - `proof: PcsProof<SC>` is of concrete type `FriProof` and is observed as part of FRI verify: [commit_phase_commits](https://github.com/Plonky3/Plonky3/blob/88d7f059500fd956a7c1eb121e08653e5974728d/fri/src/verifier.rs#L40), [final_poly](https://github.com/Plonky3/Plonky3/blob/88d7f059500fd956a7c1eb121e08653e5974728d/fri/src/verifier.rs#L49), [pow_witness](https://github.com/Plonky3/Plonky3/blob/88d7f059500fd956a7c1eb121e08653e5974728d/fri/src/verifier.rs#L56). 
-    - `query_proofs` consists entirely of sibling hashes in Merkle proofs, which are not observed because they are determined from the opening value and Merkle root. 
-  - `opened_values` is observed as part of FRI verify [here](https://github.com/Plonky3/Plonky3/blob/88d7f05/fri/src/two_adic_pcs.rs#L405)
+- `opening: OpeningProof`:
+  - `proof: PcsProof<SC>` is of concrete type `FriProof` and is observed as part of FRI verify: [commit_phase_commits](https://github.com/Plonky3/Plonky3/blob/1ba4e5c9500fd956a7c1eb121e08653e5974728d/fri/src/verifier.rs#L40), [final_poly](https://github.com/Plonky3/Plonky3/blob/1ba4e5c9500fd956a7c1eb121e08653e5974728d/fri/src/verifier.rs#L49), [pow_witness](https://github.com/Plonky3/Plonky3/blob/1ba4e5c9500fd956a7c1eb121e08653e5974728d/fri/src/verifier.rs#L56).
+    - `query_proofs` consists entirely of sibling hashes in Merkle proofs, which are not observed because they are determined from the opening value and Merkle root.
+  - `opened_values` is observed as part of FRI verify [here](https://github.com/Plonky3/Plonky3/blob/1ba4e5c/fri/src/two_adic_pcs.rs#L405)
 
 **Recommendation:**
 Observe the `air_ids` and also the number of AIRs.
 
-**Resolution:** 
+**Resolution:**
 - https://github.com/openvm-org/stark-backend/pull/56 (https://github.com/openvm-org/stark-backend/commit/2c535dc35542bf2d9c957104a327ce99e8bc7c59)
 - https://github.com/openvm-org/openvm/pull/1502 (https://github.com/openvm-org/openvm/commit/70c0d62cd0001e3defb2cf0f8e08b1c969e0a87a)
 


### PR DESCRIPTION
Update stark-backend for https://github.com/openvm-org/stark-backend/pull/62 

Update plonky3 commit to include the patch https://github.com/Plonky3/Plonky3/pull/759 fixing the Rust FRI verifier. 
Description of the security issue: https://github.com/Plonky3/Plonky3/security/advisories/GHSA-m23j-cj9m-ppg9