### PR TITLE
fix: don't segment due to fixed-size traces

### DIFF
--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -251,6 +251,10 @@ impl<const NUM_BITS: usize> ChipUsageGetter for SharedBitwiseOperationLookupChip
         self.0.air_name()
     }
 
+    fn constant_trace_height(&self) -> Option<usize> {
+        self.0.constant_trace_height()
+    }
+
     fn current_trace_height(&self) -> usize {
         self.0.current_trace_height()
     }

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -231,6 +231,10 @@ impl<const N: usize> ChipUsageGetter for SharedRangeTupleCheckerChip<N> {
         self.0.air_name()
     }
 
+    fn constant_trace_height(&self) -> Option<usize> {
+        self.0.constant_trace_height()
+    }
+
     fn current_trace_height(&self) -> usize {
         self.0.current_trace_height()
     }

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -262,6 +262,10 @@ impl ChipUsageGetter for SharedVariableRangeCheckerChip {
         self.0.air_name()
     }
 
+    fn constant_trace_height(&self) -> Option<usize> {
+        self.0.constant_trace_height()
+    }
+
     fn current_trace_height(&self) -> usize {
         self.0.current_trace_height()
     }

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -956,10 +956,16 @@ impl<F: PrimeField32, E, P> VmChipComplex<F, E, P> {
             .into_iter()
             .chain(self._public_values_chip().map(|c| c.current_trace_cells()))
             .chain(self.memory_controller().current_trace_cells())
-            .chain(
-                self.chips_excluding_pv_chip()
-                    .map(|c| c.current_trace_cells()),
-            )
+            .chain(self.chips_excluding_pv_chip().map(|c| match c {
+                Either::Executor(c) => c.current_trace_cells(),
+                Either::Periphery(c) => {
+                    if c.constant_trace_height().is_some() {
+                        0
+                    } else {
+                        c.current_trace_cells()
+                    }
+                }
+            }))
             .chain([0]) // range_checker_chip
             .collect()
     }


### PR DESCRIPTION
This fix only affects logging and segmentation logic during execution under certain misconfigured parameter settings. It does not affect any circuit soundness.

Fixes two separate issues around segmentation with respect to fixed-size traces: the first being that `constant_trace_height` was not implemented for some wrapper types, and the second being that
`VmChipComplex::current_trace_cells` did not check if a chip had constant trace height.