### PR TITLE
feat: `OpenVmHalo2Verifier`

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install solc # svm should support arm64 linux
         run: (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install architecture specific tools
         run: |
           arch=$(uname -m)
@@ -74,8 +77,24 @@ jobs:
         run: |
           bash ../../extensions/native/recursion/trusted_setup_s3.sh
 
+      - name: Run openvm-sdk contracts/ tests
+        working-directory: crates/sdk/contracts
+        run: |
+          forge fmt --check
+          forge build --sizes
+          forge test
+
+      - name: Check IOpenVmHalo2Verifier.sol abi correctness
+        working-directory: crates/sdk/contracts
+        run: |
+          forge build
+          jq -S '.abi' ./out/IOpenVmHalo2Verifier.sol/IOpenVmHalo2Verifier.json > compiled_abi.json
+          jq -S . ./abi/IOpenVmHalo2Verifier.json > expected_abi_sorted.json
+          diff -u expected_abi_sorted.json compiled_abi.json
+
       - name: Run openvm-sdk crate tests
         working-directory: crates/sdk
         run: |
           export RUST_BACKTRACE=1
           cargo nextest run --cargo-profile=fast --test-threads=2 --features parallel
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "toolchain/tests/rv32im-test-vectors/riscv-tests"]
 	path = crates/toolchain/tests/rv32im-test-vectors/riscv-tests
 	url = https://github.com/riscv-software-src/riscv-tests.git
+[submodule "crates/sdk/contracts/lib/forge-std"]
+	path = crates/sdk/contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,16 +80,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-primitives"
-version = "0.8.21"
+name = "alloy-json-abi"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478bedf4d24e71ea48428d1bc278553bd7c6ae07c30ca063beb0b09fe58a9e74"
+checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "foldhash",
  "hashbrown 0.15.2",
  "indexmap 2.7.1",
@@ -126,6 +138,80 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.7.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.98",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
 ]
 
 [[package]]
@@ -1033,6 +1119,9 @@ name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1604,7 +1693,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -1612,6 +1710,18 @@ name = "derive_more-impl"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1656,6 +1766,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2313,6 +2429,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -2888,6 +3005,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4071,6 +4199,8 @@ dependencies = [
 name = "openvm-sdk"
 version = "1.0.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "async-trait",
  "bitcode",
  "bon",
@@ -4079,6 +4209,7 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "getset",
+ "hex",
  "itertools 0.14.0",
  "metrics",
  "openvm",
@@ -4109,6 +4240,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "snark-verifier",
+ "snark-verifier-sdk",
+ "tempfile",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -4989,6 +5123,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -5893,6 +6028,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,9 +184,12 @@ snark-verifier-sdk = { version = "0.2.0", default-features = false, features = [
     "loader_halo2",
     "halo2-axiom",
 ] }
+snark-verifier = { version = "0.2.0", default-features = false }
 halo2curves-axiom = "0.7.0"
 
 cargo_metadata = "0.18"
+alloy-primitives = "0.8.25"
+alloy-sol-types = "0.8.25"
 tracing = "0.1.40"
 bon = "3.2.0"
 serde_json = "1.0.117"

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{read, write},
+    fs::{create_dir_all, read, write},
     path::PathBuf,
 };
 
@@ -146,6 +146,9 @@ pub(crate) fn build(build_args: &BuildArgs) -> Result<Option<PathBuf>> {
         let exe = Sdk::new().transpile(elf, transpiler)?;
         let committed_exe = commit_app_exe(app_config.app_fri_params.fri_params, exe.clone());
         write_exe_to_file(exe, output_path)?;
+        if let Some(parent) = build_args.committed_exe_output.parent() {
+            create_dir_all(parent)?;
+        }
         write(
             &build_args.committed_exe_output,
             committed_exe_as_bn254(&committed_exe).value.to_bytes(),

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -11,13 +11,14 @@ use openvm_native_recursion::halo2::utils::CacheHalo2ParamsReader;
 use openvm_sdk::{
     config::AggConfig,
     fs::{
-        write_agg_pk_to_file, write_evm_verifier_to_folder, EVM_VERIFIER_ARTIFACT_FILENAME,
-        EVM_VERIFIER_SOL_FILENAME,
+        write_agg_pk_to_file, write_openvm_halo2_verifier_to_folder,
+        OPENVM_HALO2_VERIFIER_BASE_NAME, OPENVM_HALO2_VERIFIER_INTERFACE_NAME,
+        OPENVM_HALO2_VERIFIER_PARENT_NAME,
     },
     DefaultStaticVerifierPvHandler, Sdk,
 };
 
-use crate::default::{DEFAULT_AGG_PK_PATH, DEFAULT_PARAMS_DIR, DEFAULT_VERIFIER_FOLDER};
+use crate::default::{DEFAULT_AGG_PK_PATH, DEFAULT_OPENVM_HALO2_VERIFIER_PATH, DEFAULT_PARAMS_DIR};
 
 #[derive(Parser)]
 #[command(
@@ -29,11 +30,15 @@ pub struct EvmProvingSetupCmd {}
 impl EvmProvingSetupCmd {
     pub async fn run(&self) -> Result<()> {
         if PathBuf::from(DEFAULT_AGG_PK_PATH).exists()
-            && PathBuf::from(DEFAULT_VERIFIER_FOLDER)
-                .join(EVM_VERIFIER_ARTIFACT_FILENAME)
+            && PathBuf::from(DEFAULT_OPENVM_HALO2_VERIFIER_PATH)
+                .join(OPENVM_HALO2_VERIFIER_PARENT_NAME)
                 .exists()
-            && PathBuf::from(DEFAULT_VERIFIER_FOLDER)
-                .join(EVM_VERIFIER_SOL_FILENAME)
+            && PathBuf::from(DEFAULT_OPENVM_HALO2_VERIFIER_PATH)
+                .join(OPENVM_HALO2_VERIFIER_BASE_NAME)
+                .exists()
+            && PathBuf::from(DEFAULT_OPENVM_HALO2_VERIFIER_PATH)
+                .join("interfaces")
+                .join(OPENVM_HALO2_VERIFIER_INTERFACE_NAME)
                 .exists()
         {
             println!("Aggregation proving key and verifier contract already exist");
@@ -53,13 +58,13 @@ impl EvmProvingSetupCmd {
         let agg_pk = sdk.agg_keygen(agg_config, &params_reader, &DefaultStaticVerifierPvHandler)?;
 
         println!("Generating verifier contract...");
-        let verifier = sdk.generate_snark_verifier_contract(&params_reader, &agg_pk)?;
+        let verifier = sdk.generate_openvm_halo2_verifier_contract(&params_reader, &agg_pk)?;
 
         println!("Writing proving key to file...");
         write_agg_pk_to_file(agg_pk, DEFAULT_AGG_PK_PATH)?;
 
         println!("Writing verifier contract to file...");
-        write_evm_verifier_to_folder(verifier, DEFAULT_VERIFIER_FOLDER)?;
+        write_openvm_halo2_verifier_to_folder(verifier, DEFAULT_OPENVM_HALO2_VERIFIER_PATH)?;
 
         Ok(())
     }

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -11,14 +11,13 @@ use openvm_native_recursion::halo2::utils::CacheHalo2ParamsReader;
 use openvm_sdk::{
     config::AggConfig,
     fs::{
-        write_agg_pk_to_file, write_openvm_halo2_verifier_to_folder,
-        OPENVM_HALO2_VERIFIER_BASE_NAME, OPENVM_HALO2_VERIFIER_INTERFACE_NAME,
-        OPENVM_HALO2_VERIFIER_PARENT_NAME,
+        write_agg_pk_to_file, write_evm_halo2_verifier_to_folder, EVM_HALO2_VERIFIER_BASE_NAME,
+        EVM_HALO2_VERIFIER_INTERFACE_NAME, EVM_HALO2_VERIFIER_PARENT_NAME,
     },
     DefaultStaticVerifierPvHandler, Sdk,
 };
 
-use crate::default::{DEFAULT_AGG_PK_PATH, DEFAULT_OPENVM_HALO2_VERIFIER_PATH, DEFAULT_PARAMS_DIR};
+use crate::default::{DEFAULT_AGG_PK_PATH, DEFAULT_EVM_HALO2_VERIFIER_PATH, DEFAULT_PARAMS_DIR};
 
 #[derive(Parser)]
 #[command(
@@ -30,15 +29,15 @@ pub struct EvmProvingSetupCmd {}
 impl EvmProvingSetupCmd {
     pub async fn run(&self) -> Result<()> {
         if PathBuf::from(DEFAULT_AGG_PK_PATH).exists()
-            && PathBuf::from(DEFAULT_OPENVM_HALO2_VERIFIER_PATH)
-                .join(OPENVM_HALO2_VERIFIER_PARENT_NAME)
+            && PathBuf::from(DEFAULT_EVM_HALO2_VERIFIER_PATH)
+                .join(EVM_HALO2_VERIFIER_PARENT_NAME)
                 .exists()
-            && PathBuf::from(DEFAULT_OPENVM_HALO2_VERIFIER_PATH)
-                .join(OPENVM_HALO2_VERIFIER_BASE_NAME)
+            && PathBuf::from(DEFAULT_EVM_HALO2_VERIFIER_PATH)
+                .join(EVM_HALO2_VERIFIER_BASE_NAME)
                 .exists()
-            && PathBuf::from(DEFAULT_OPENVM_HALO2_VERIFIER_PATH)
+            && PathBuf::from(DEFAULT_EVM_HALO2_VERIFIER_PATH)
                 .join("interfaces")
-                .join(OPENVM_HALO2_VERIFIER_INTERFACE_NAME)
+                .join(EVM_HALO2_VERIFIER_INTERFACE_NAME)
                 .exists()
         {
             println!("Aggregation proving key and verifier contract already exist");
@@ -58,13 +57,13 @@ impl EvmProvingSetupCmd {
         let agg_pk = sdk.agg_keygen(agg_config, &params_reader, &DefaultStaticVerifierPvHandler)?;
 
         println!("Generating verifier contract...");
-        let verifier = sdk.generate_openvm_halo2_verifier_contract(&params_reader, &agg_pk)?;
+        let verifier = sdk.generate_halo2_verifier_solidity(&params_reader, &agg_pk)?;
 
         println!("Writing proving key to file...");
         write_agg_pk_to_file(agg_pk, DEFAULT_AGG_PK_PATH)?;
 
         println!("Writing verifier contract to file...");
-        write_openvm_halo2_verifier_to_folder(verifier, DEFAULT_OPENVM_HALO2_VERIFIER_PATH)?;
+        write_evm_halo2_verifier_to_folder(verifier, DEFAULT_EVM_HALO2_VERIFIER_PATH)?;
 
         Ok(())
     }

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -4,14 +4,15 @@ use clap::Parser;
 use eyre::Result;
 use openvm_sdk::{
     fs::{
-        read_app_proof_from_file, read_app_vk_from_file, read_evm_proof_from_file,
-        read_evm_verifier_from_folder,
+        read_app_proof_from_file, read_app_vk_from_file, read_evm_halo2_verifier_from_folder,
+        read_evm_proof_from_file,
     },
     Sdk,
 };
 
 use crate::default::{
-    DEFAULT_APP_PROOF_PATH, DEFAULT_APP_VK_PATH, DEFAULT_EVM_PROOF_PATH, DEFAULT_VERIFIER_FOLDER,
+    DEFAULT_APP_PROOF_PATH, DEFAULT_APP_VK_PATH, DEFAULT_EVM_HALO2_VERIFIER_PATH,
+    DEFAULT_EVM_PROOF_PATH,
 };
 
 #[derive(Parser)]
@@ -46,11 +47,11 @@ impl VerifyCmd {
                 sdk.verify_app_proof(&app_vk, &app_proof)?;
             }
             VerifySubCommand::Evm { proof } => {
-                let evm_verifier = read_evm_verifier_from_folder(DEFAULT_VERIFIER_FOLDER).map_err(|e| {
+                let evm_verifier = read_evm_halo2_verifier_from_folder(DEFAULT_EVM_HALO2_VERIFIER_PATH).map_err(|e| {
                     eyre::eyre!("Failed to read EVM verifier: {}\nPlease run 'cargo openvm evm-proving-setup' first", e)
                 })?;
                 let evm_proof = read_evm_proof_from_file(proof)?;
-                sdk.verify_evm_proof(&evm_verifier, &evm_proof)?;
+                sdk.verify_evm_halo2_proof(&evm_verifier, &evm_proof)?;
             }
         }
         Ok(())

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -7,6 +7,8 @@ pub const DEFAULT_AGG_PK_PATH: &str = concat!(env!("HOME"), "/.openvm/agg.pk");
 pub const DEFAULT_VERIFIER_FOLDER: &str = concat!(env!("HOME"), "/.openvm/");
 pub const DEFAULT_PARAMS_DIR: &str = concat!(env!("HOME"), "/.openvm/params/");
 
+pub const DEFAULT_OPENVM_HALO2_VERIFIER_PATH: &str = concat!(env!("HOME"), "/.openvm/halo2/");
+
 pub const DEFAULT_APP_CONFIG_PATH: &str = "./openvm.toml";
 pub const DEFAULT_APP_EXE_PATH: &str = "./openvm/app.vmexe";
 pub const DEFAULT_COMMITTED_APP_EXE_PATH: &str = "./openvm/committed_app_exe.bytes";

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -4,10 +4,9 @@ use openvm_stark_sdk::config::FriParameters;
 pub const DEFAULT_MANIFEST_DIR: &str = ".";
 
 pub const DEFAULT_AGG_PK_PATH: &str = concat!(env!("HOME"), "/.openvm/agg.pk");
-pub const DEFAULT_VERIFIER_FOLDER: &str = concat!(env!("HOME"), "/.openvm/");
 pub const DEFAULT_PARAMS_DIR: &str = concat!(env!("HOME"), "/.openvm/params/");
 
-pub const DEFAULT_OPENVM_HALO2_VERIFIER_PATH: &str = concat!(env!("HOME"), "/.openvm/halo2/");
+pub const DEFAULT_EVM_HALO2_VERIFIER_PATH: &str = concat!(env!("HOME"), "/.openvm/halo2/");
 
 pub const DEFAULT_APP_CONFIG_PATH: &str = "./openvm.toml";
 pub const DEFAULT_APP_EXE_PATH: &str = "./openvm/app.vmexe";

--- a/crates/cli/tests/app_e2e.rs
+++ b/crates/cli/tests/app_e2e.rs
@@ -24,8 +24,7 @@ fn test_cli_app_e2e() -> Result<()> {
             "--exe-output",
             temp_exe.to_str().unwrap(),
         ],
-    )
-    .unwrap_or_else(|e| panic!("{:?}", e));
+    )?;
 
     run_cmd(
         "cargo",
@@ -39,8 +38,7 @@ fn test_cli_app_e2e() -> Result<()> {
             "--vk-output",
             temp_vk.to_str().unwrap(),
         ],
-    )
-    .unwrap_or_else(|e| panic!("{:?}", e));
+    )?;
 
     run_cmd(
         "cargo",
@@ -52,8 +50,7 @@ fn test_cli_app_e2e() -> Result<()> {
             "--config",
             "example/openvm.toml",
         ],
-    )
-    .unwrap_or_else(|e| panic!("{:?}", e));
+    )?;
 
     run_cmd(
         "cargo",
@@ -68,8 +65,7 @@ fn test_cli_app_e2e() -> Result<()> {
             "--output",
             temp_proof.to_str().unwrap(),
         ],
-    )
-    .unwrap_or_else(|e| panic!("{:?}", e));
+    )?;
 
     run_cmd(
         "cargo",
@@ -82,8 +78,7 @@ fn test_cli_app_e2e() -> Result<()> {
             "--proof",
             temp_proof.to_str().unwrap(),
         ],
-    )
-    .unwrap_or_else(|e| panic!("{:?}", e));
+    )?;
 
     Ok(())
 }

--- a/crates/cli/tests/app_e2e.rs
+++ b/crates/cli/tests/app_e2e.rs
@@ -24,7 +24,8 @@ fn test_cli_app_e2e() -> Result<()> {
             "--exe-output",
             temp_exe.to_str().unwrap(),
         ],
-    )?;
+    )
+    .unwrap_or_else(|e| panic!("{:?}", e));
 
     run_cmd(
         "cargo",
@@ -38,7 +39,8 @@ fn test_cli_app_e2e() -> Result<()> {
             "--vk-output",
             temp_vk.to_str().unwrap(),
         ],
-    )?;
+    )
+    .unwrap_or_else(|e| panic!("{:?}", e));
 
     run_cmd(
         "cargo",
@@ -50,7 +52,8 @@ fn test_cli_app_e2e() -> Result<()> {
             "--config",
             "example/openvm.toml",
         ],
-    )?;
+    )
+    .unwrap_or_else(|e| panic!("{:?}", e));
 
     run_cmd(
         "cargo",
@@ -65,7 +68,8 @@ fn test_cli_app_e2e() -> Result<()> {
             "--output",
             temp_proof.to_str().unwrap(),
         ],
-    )?;
+    )
+    .unwrap_or_else(|e| panic!("{:?}", e));
 
     run_cmd(
         "cargo",
@@ -78,7 +82,8 @@ fn test_cli_app_e2e() -> Result<()> {
             "--proof",
             temp_proof.to_str().unwrap(),
         ],
-    )?;
+    )
+    .unwrap_or_else(|e| panic!("{:?}", e));
 
     Ok(())
 }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+
 p3-fri = { workspace = true }
 openvm-algebra-circuit = { workspace = true }
 openvm-algebra-transpiler = { workspace = true }
@@ -34,6 +35,8 @@ openvm-circuit = { workspace = true }
 openvm-continuations = { workspace = true }
 openvm = { workspace = true }
 
+alloy-primitives = { workspace = true }
+alloy-sol-types = { workspace = true, features = ["json"] }
 bitcode = { workspace = true }
 bon = { workspace = true }
 derivative = { workspace = true }
@@ -49,6 +52,10 @@ clap = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["hex"] }
 serde_json.workspace = true
 thiserror.workspace = true
+snark-verifier = { workspace = true }
+snark-verifier-sdk.workspace = true
+tempfile.workspace = true
+hex.workspace = true
 
 [features]
 default = ["parallel"]

--- a/crates/sdk/contracts/.gitignore
+++ b/crates/sdk/contracts/.gitignore
@@ -1,0 +1,14 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/crates/sdk/contracts/abi/IOpenVmHalo2Verifier.json
+++ b/crates/sdk/contracts/abi/IOpenVmHalo2Verifier.json
@@ -1,0 +1,30 @@
+[
+    {
+        "type": "function",
+        "name": "verify",
+        "inputs": [
+            {
+                "name": "publicValues",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "proofData",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "appExeCommit",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "appVmCommit",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "view"
+    }
+]

--- a/crates/sdk/contracts/foundry.toml
+++ b/crates/sdk/contracts/foundry.toml
@@ -1,0 +1,31 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+verbosity = 2
+solc = "0.8.19"
+optimizer = true
+optimizer_runs = 100000
+evm_version = "shanghai"
+show_progress = true
+fs_permissions = [{ access = "read", path = "./template"}, { access = "read", path = "./test/helpers/MockDeps.sol"}]
+ffi = true
+
+[profile.default.optimizer_details]
+  constantOptimizer = false
+  yul = false
+
+[fuzz]
+  runs = 256
+
+[fmt]
+  bracket_spacing = true
+  int_types = "long"
+  line_length = 120
+  multiline_func_header = "attributes_first"
+  number_underscore = "thousands"
+  quote_style = "double"
+  single_line_statement_blocks = "single"
+  tab_width = 4
+  wrap_comments = false
+  

--- a/crates/sdk/contracts/src/IOpenVmHalo2Verifier.sol
+++ b/crates/sdk/contracts/src/IOpenVmHalo2Verifier.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IOpenVmHalo2Verifier {
+    function verify(bytes calldata publicValues, bytes calldata proofData, bytes32 appExeCommit, bytes32 appVmCommit)
+        external
+        view;
+}

--- a/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
+++ b/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
@@ -39,12 +39,12 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     /// proof[12 * 32..13 * 32]: app exe commit
     /// proof[13 * 32..14 * 32]: app vm commit
     /// proof[14 * 32..(14 + PUBLIC_VALUES_LENGTH) * 32]: publicValues[0..PUBLIC_VALUES_LENGTH]
-    /// proof[(14 + PUBLIC_VALUES_LENGTH) * 32..]: Public Values Suffix
+    /// proof[(14 + PUBLIC_VALUES_LENGTH) * 32..]: Proof Suffix
     ///
     /// @param publicValues The PVs revealed by the OpenVM guest program.
     /// @param proofData All components of the proof except the public values and
     /// app exe and vm commits. The expected format is:
-    /// `abi.encodePacked(kzgAccumulators, pvsSuffix)`
+    /// `abi.encodePacked(kzgAccumulators, proofSuffix)`
     /// @param appExeCommit The commitment to the OpenVM application executable whose execution
     /// is being verified.
     /// @param appVmCommit The commitment to the VM configuration.
@@ -99,7 +99,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
         // proof[0x180..0x1a0]: app exe commit
         // proof[0x1a0..0x1c0]: app vm commit
         // proof[0x1c0..(0x1c0 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
-        // proof[(0x1c0 + PUBLIC_VALUES_LENGTH * 32)..]: Public Values Suffix
+        // proof[(0x1c0 + PUBLIC_VALUES_LENGTH * 32)..]: Proof Suffix
 
         /// @solidity memory-safe-assembly
         assembly {
@@ -115,14 +115,14 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
             mstore(add(proofPtr, 0x180), appExeCommit)
             mstore(add(proofPtr, 0x1a0), appVmCommit)
 
-            // Copy the Public Values Suffix (length 43 * 32 = 0x560) into the
+            // Copy the Proof Suffix (length 43 * 32 = 0x560) into the
             // end of the memory buffer, leaving PUBLIC_VALUES_LENGTH words in
             // between for the publicValuesPayload.
             //
             // Begin copying from the end of the KZG accumulators in the
             // calldata buffer (0x180)
-            let pvsSuffixOffset := add(0x1c0, shl(5, PUBLIC_VALUES_LENGTH))
-            calldatacopy(add(proofPtr, pvsSuffixOffset), add(proofData.offset, 0x180), 0x560)
+            let proofSuffixOffset := add(0x1c0, shl(5, PUBLIC_VALUES_LENGTH))
+            calldatacopy(add(proofPtr, proofSuffixOffset), add(proofData.offset, 0x180), 0x560)
 
             // Copy each byte of the public values into the proof. It copies the
             // most significant bytes of public values first.

--- a/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
+++ b/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import { Halo2Verifier } from "./Halo2Verifier.sol";
+import { IOpenVmHalo2Verifier } from "./interfaces/IOpenVmHalo2Verifier.sol";
+
+type MemoryPointer is uint256;
+
+/// @notice This contract provides a thin wrapper around the Halo2 verifier
+/// outputted by `snark-verifier`, exposing a more user-friendly interface.
+contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
+    /// @dev Invalid public values length
+    error InvalidPublicValuesLength(uint256 expected, uint256 actual);
+
+    /// @dev Invalid proof data length
+    error InvalidProofDataLength(uint256 expected, uint256 actual);
+
+    /// @dev Proof verification failed
+    error ProofVerificationFailed();
+
+    /// @dev The length of the proof data, in bytes.
+    uint256 private constant PROOF_DATA_LENGTH = (12 + 43) * 32;
+
+    /// @dev The length of the public values, in bytes. This value is set by
+    /// OpenVM and is guaranteed to be no larger than 8192.
+    uint256 private constant PUBLIC_VALUES_LENGTH = {PUBLIC_VALUES_LENGTH};
+
+    /// @dev The length of the full proof, in bytes
+    uint256 private constant FULL_PROOF_LENGTH = (12 + 2 + PUBLIC_VALUES_LENGTH + 43) * 32;
+
+    /// @dev The version of OpenVM that generated this verifier.
+    string public constant OPENVM_VERSION = "{OPENVM_VERSION}";
+
+    /// @notice A wrapper that constructs the proof into the right format for
+    /// use with the `snark-verifier` verification.
+    ///
+    /// @dev The verifier expected proof format is:
+    /// proof[..12 * 32]: KZG accumulators
+    /// proof[12 * 32..13 * 32]: app exe commit
+    /// proof[13 * 32..14 * 32]: app vm commit
+    /// proof[14 * 32..(14 + PUBLIC_VALUES_LENGTH) * 32]: publicValues[0..PUBLIC_VALUES_LENGTH]
+    /// proof[(14 + PUBLIC_VALUES_LENGTH) * 32..]: Public Values Suffix
+    ///
+    /// @param publicValues The PVs revealed by the OpenVM guest program.
+    /// @param proofData All components of the proof except the public values and
+    /// app exe and vm commits. The expected format is:
+    /// `abi.encodePacked(kzgAccumulators, pvsSuffix)`
+    /// @param appExeCommit The commitment to the OpenVM application executable whose execution
+    /// is being verified.
+    /// @param appVmCommit The commitment to the VM configuration.
+    function verify(bytes calldata publicValues, bytes calldata proofData, bytes32 appExeCommit, bytes32 appVmCommit) external view {
+        if (publicValues.length != PUBLIC_VALUES_LENGTH) revert InvalidPublicValuesLength(PUBLIC_VALUES_LENGTH, publicValues.length);
+        if (proofData.length != PROOF_DATA_LENGTH) revert InvalidProofDataLength(PROOF_DATA_LENGTH, proofData.length);
+
+        // We will format the public values and construct the full proof payload
+        // below.
+
+        MemoryPointer proofPtr = _constructProof(publicValues, proofData, appExeCommit, appVmCommit);
+
+        uint256 fullProofLength = FULL_PROOF_LENGTH;
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Self-call using the proof as calldata
+            if iszero(staticcall(gas(), address(), proofPtr, fullProofLength, 0, 0)) {
+                mstore(0x00, 0xd611c318) // ProofVerificationFailed()
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    /// @dev The assembly code should perform the same function as the following
+    /// solidity code:
+    //
+    /// ```solidity
+    /// bytes memory proof =
+    ///     abi.encodePacked(proofData[0:0x180], appExeCommit, appVmCommit, publicValuesPayload, proofData[0x180:]);
+    /// ```
+    //
+    /// where `publicValuesPayload` is a memory payload with each byte in
+    /// `publicValues` separated into its own `bytes32` word.
+    ///
+    /// This function does not clean the memory it allocates. Since it is the
+    /// only memory write that occurs in the call frame, we know that
+    /// the memory region cannot have been dirtied.
+    ///
+    /// @return proofPtr Memory pointer to the beginning of the constructed
+    /// proof. This pointer does not follow `bytes memory` semantics.
+    function _constructProof(bytes calldata publicValues, bytes calldata proofData, bytes32 appExeCommit, bytes32 appVmCommit)
+        internal
+        pure
+        returns (MemoryPointer proofPtr)
+    {
+        uint256 fullProofLength = FULL_PROOF_LENGTH;
+
+        // The expected proof format using hex offsets:
+        //
+        // proof[..0x180]: KZG accumulators
+        // proof[0x180..0x1a0]: app exe commit
+        // proof[0x1a0..0x1c0]: app vm commit
+        // proof[0x1c0..(0x1c0 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
+        // proof[(0x1c0 + PUBLIC_VALUES_LENGTH * 32)..]: Public Values Suffix
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            proofPtr := mload(0x40)
+            // Allocate the memory as a safety measure.
+            mstore(0x40, add(proofPtr, fullProofLength))
+
+            // Copy the KZG accumulators (length 0x180) into the beginning of
+            // the memory buffer
+            calldatacopy(proofPtr, proofData.offset, 0x180)
+
+            // Copy the App Exe Commit and App Vm Commit into the memory buffer
+            mstore(add(proofPtr, 0x180), appExeCommit)
+            mstore(add(proofPtr, 0x1a0), appVmCommit)
+
+            // Copy the Public Values Suffix (length 43 * 32 = 0x560) into the
+            // end of the memory buffer, leaving PUBLIC_VALUES_LENGTH words in
+            // between for the publicValuesPayload.
+            //
+            // Begin copying from the end of the KZG accumulators in the
+            // calldata buffer (0x180)
+            let pvsSuffixOffset := add(0x1c0, shl(5, PUBLIC_VALUES_LENGTH))
+            calldatacopy(add(proofPtr, pvsSuffixOffset), add(proofData.offset, 0x180), 0x560)
+
+            // Copy each byte of the public values into the proof. It copies the
+            // most significant bytes of public values first.
+            let publicValuesMemOffset := add(add(proofPtr, 0x1c0), 0x1f)
+            for { let i := 0 } iszero(eq(i, PUBLIC_VALUES_LENGTH)) { i := add(i, 1) } {
+                calldatacopy(add(publicValuesMemOffset, shl(5, i)), add(publicValues.offset, i), 0x01)
+            }
+        }
+    }
+}

--- a/crates/sdk/contracts/test/OpenVmHalo2Verifier.t.sol
+++ b/crates/sdk/contracts/test/OpenVmHalo2Verifier.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import { LibString } from "./helpers/LibString.sol";
+import { Test, console2, safeconsole as console } from "forge-std/Test.sol";
+import { IOpenVmHalo2Verifier } from "../src/IOpenVmHalo2Verifier.sol";
+
+contract TemplateTest is Test {
+    bytes proofData;
+    bytes32 appExeCommit = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    bytes32 appVmCommit = 0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE;
+    bytes guestPvs;
+
+    uint256 publicValuesLength;
+    uint256 fullProofWords;
+    uint256 fullProofLength;
+
+    string _code = vm.readFile("template/OpenVmHalo2Verifier.sol");
+    string deps = vm.readFile("test/helpers/MockDeps.sol");
+
+    function setUp() public {
+        proofData = new bytes(55 * 32);
+        for (uint256 i = 0; i < 55; i++) {
+            for (uint256 j = 0; j < 32; j++) {
+                proofData[i * 32 + j] = bytes1(uint8(i));
+            }
+        }
+    }
+
+    /// forge-config: default.fuzz.runs = 10
+    function testFuzz_ProofFormat(uint256 _publicValuesLength) public {
+        publicValuesLength = bound(_publicValuesLength, 1, 10_000);
+        publicValuesLength = 8;
+        fullProofWords = (12 + 2 + publicValuesLength + 43);
+        fullProofLength = fullProofWords * 32;
+
+        guestPvs = new bytes(publicValuesLength);
+        for (uint256 i = 0; i < publicValuesLength; i++) {
+            guestPvs[i] = bytes1(uint8(i));
+        }
+
+        IOpenVmHalo2Verifier verifier = _compileAndDeployOpenVmVerifier(publicValuesLength);
+
+        (bool success,) = address(verifier).delegatecall(
+            abi.encodeCall(IOpenVmHalo2Verifier.verify, (guestPvs, proofData, appExeCommit, appVmCommit))
+        );
+        require(success, "Verification failed");
+    }
+
+    fallback(bytes calldata proof) external returns (bytes memory) {
+        bytes memory proofDataExpected = proofData;
+
+        uint256 guestPvsSuffixOffset = 0x1c0 + (32 * publicValuesLength);
+
+        bytes memory kzgAccumulators = proof[0:0x180];
+        bytes memory guestPvsSuffix = proof[guestPvsSuffixOffset:];
+        bytes memory _proofData = abi.encodePacked(kzgAccumulators, guestPvsSuffix);
+
+        require(keccak256(_proofData) == keccak256(proofDataExpected), "Partial proof mismatch");
+
+        bytes memory _appExeCommit = proof[0x180:0x1a0];
+        bytes memory _appVmCommit = proof[0x1a0:0x1c0];
+
+        require(bytes32(_appExeCommit) == appExeCommit, "App exe commit mismatch");
+        require(bytes32(_appVmCommit) == appVmCommit, "App vm commit mismatch");
+
+        bytes calldata _guestPvs = proof[0x1c0:0x1c0 + 32 * publicValuesLength];
+        for (uint256 i = 0; i < publicValuesLength; ++i) {
+            uint256 expected = uint256(uint8(guestPvs[i]));
+            uint256 actual = uint256(bytes32(_guestPvs[i * 32:(i + 1) * 32]));
+            require(expected == actual, "Guest PVs hash mismatch");
+        }
+
+        // Suppress return value warning
+        assembly {
+            return(0x00, 0x00)
+        }
+    }
+
+    function test_RevertWhen_InvalidPublicValuesLength() public {
+        publicValuesLength = 32;
+        IOpenVmHalo2Verifier verifier = _compileAndDeployOpenVmVerifier(publicValuesLength);
+
+        bytes memory invalidPvs = new bytes(0);
+        bytes4 sig = bytes4(keccak256("InvalidPublicValuesLength(uint256,uint256)"));
+
+        vm.expectRevert(abi.encodeWithSelector(sig, 32, invalidPvs.length));
+        verifier.verify(invalidPvs, hex"", bytes32(0), bytes32(0));
+    }
+
+    function test_RevertWhen_InvalidProofDataLength() public {
+        publicValuesLength = 32;
+        IOpenVmHalo2Verifier verifier = _compileAndDeployOpenVmVerifier(publicValuesLength);
+
+        bytes memory invalidProofData = new bytes(0);
+        bytes4 sig = bytes4(keccak256("InvalidProofDataLength(uint256,uint256)"));
+
+        bytes memory pvs = new bytes(publicValuesLength);
+
+        vm.expectRevert(abi.encodeWithSelector(sig, 55 * 32, invalidProofData.length));
+        verifier.verify(pvs, invalidProofData, appExeCommit, appVmCommit);
+    }
+
+    function test_RevertWhen_ProofVerificationFailed() public {
+        publicValuesLength = 32;
+        IOpenVmHalo2Verifier verifier = _compileAndDeployOpenVmVerifier(publicValuesLength);
+
+        bytes memory _proofData = new bytes(55 * 32);
+        bytes memory pvs = new bytes(publicValuesLength);
+
+        bytes4 sig = bytes4(keccak256("ProofVerificationFailed()"));
+
+        vm.expectRevert(abi.encodeWithSelector(sig));
+        verifier.verify(pvs, _proofData, appExeCommit, appVmCommit);
+    }
+
+    function _compileAndDeployOpenVmVerifier(uint256 _publicValuesLength)
+        private
+        returns (IOpenVmHalo2Verifier verifier)
+    {
+        string memory code = LibString.replace(_code, "{PUBLIC_VALUES_LENGTH}", LibString.toString(_publicValuesLength));
+
+        // `code` will look like this:
+        //
+        // // SPDX-License-Identifier: MIT
+        // pragma solidity 0.8.19;
+        //
+        // import { Halo2Verifier } ...
+        // import { IOpenVmHalo2Verifier } ...
+        //
+        // contract OpenVmHalo2Verifier { .. }
+        //
+        // We want to replace the `import` statements with inlined deps for JIT
+        // compilation.
+        string memory inlinedCode = LibString.replace(
+            code,
+            "import { Halo2Verifier } from \"./Halo2Verifier.sol\";\nimport { IOpenVmHalo2Verifier } from \"./interfaces/IOpenVmHalo2Verifier.sol\";",
+            deps
+        );
+
+        // Must use solc 0.8.19
+        string[] memory commands = new string[](3);
+        commands[0] = "sh";
+        commands[1] = "-c";
+        commands[2] = string.concat(
+            "echo ",
+            "'",
+            inlinedCode,
+            "'",
+            " | solc --no-optimize-yul --bin --optimize --optimize-runs 100000 - ",
+            " | awk 'BEGIN{found=0} /:OpenVmHalo2Verifier/ {found=1; next} found && /^Binary:/ {getline; print; exit}'"
+        );
+
+        bytes memory compiledVerifier = vm.ffi(commands);
+
+        assembly {
+            verifier := create(0, add(compiledVerifier, 0x20), mload(compiledVerifier))
+            if iszero(extcodesize(verifier)) { revert(0, 0) }
+        }
+    }
+}

--- a/crates/sdk/contracts/test/OpenVmHalo2Verifier.t.sol
+++ b/crates/sdk/contracts/test/OpenVmHalo2Verifier.t.sol
@@ -50,11 +50,11 @@ contract TemplateTest is Test {
     fallback(bytes calldata proof) external returns (bytes memory) {
         bytes memory proofDataExpected = proofData;
 
-        uint256 guestPvsSuffixOffset = 0x1c0 + (32 * publicValuesLength);
+        uint256 proofSuffixOffset = 0x1c0 + (32 * publicValuesLength);
 
         bytes memory kzgAccumulators = proof[0:0x180];
-        bytes memory guestPvsSuffix = proof[guestPvsSuffixOffset:];
-        bytes memory _proofData = abi.encodePacked(kzgAccumulators, guestPvsSuffix);
+        bytes memory proofSuffix = proof[proofSuffixOffset:];
+        bytes memory _proofData = abi.encodePacked(kzgAccumulators, proofSuffix);
 
         require(keccak256(_proofData) == keccak256(proofDataExpected), "Partial proof mismatch");
 

--- a/crates/sdk/contracts/test/helpers/LibString.sol
+++ b/crates/sdk/contracts/test/helpers/LibString.sol
@@ -1,0 +1,1628 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @notice Library for byte related operations.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/LibBytes.sol)
+library LibBytes {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          STRUCTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Goated bytes storage struct that totally MOGs, no cap, fr.
+    /// Uses less gas and bytecode than Solidity's native bytes storage. It's meta af.
+    /// Packs length with the first 31 bytes if <255 bytes, so it’s mad tight.
+    struct BytesStorage {
+        bytes32 _spacer;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         CONSTANTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The constant returned when the `search` is not found in the bytes.
+    uint256 internal constant NOT_FOUND = type(uint256).max;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                  BYTE STORAGE OPERATIONS                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Sets the value of the bytes storage `$` to `s`.
+    function set(BytesStorage storage $, bytes memory s) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := mload(s)
+            let packed := or(0xff, shl(8, n))
+            for { let i := 0 } 1 { } {
+                if iszero(gt(n, 0xfe)) {
+                    i := 0x1f
+                    packed := or(n, shl(8, mload(add(s, i))))
+                    if iszero(gt(n, i)) { break }
+                }
+                let o := add(s, 0x20)
+                mstore(0x00, $.slot)
+                for { let p := keccak256(0x00, 0x20) } 1 { } {
+                    sstore(add(p, shr(5, i)), mload(add(o, i)))
+                    i := add(i, 0x20)
+                    if iszero(lt(i, n)) { break }
+                }
+                break
+            }
+            sstore($.slot, packed)
+        }
+    }
+
+    /// @dev Sets the value of the bytes storage `$` to `s`.
+    function setCalldata(BytesStorage storage $, bytes calldata s) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let packed := or(0xff, shl(8, s.length))
+            for { let i := 0 } 1 { } {
+                if iszero(gt(s.length, 0xfe)) {
+                    i := 0x1f
+                    packed := or(s.length, shl(8, shr(8, calldataload(s.offset))))
+                    if iszero(gt(s.length, i)) { break }
+                }
+                mstore(0x00, $.slot)
+                for { let p := keccak256(0x00, 0x20) } 1 { } {
+                    sstore(add(p, shr(5, i)), calldataload(add(s.offset, i)))
+                    i := add(i, 0x20)
+                    if iszero(lt(i, s.length)) { break }
+                }
+                break
+            }
+            sstore($.slot, packed)
+        }
+    }
+
+    /// @dev Sets the value of the bytes storage `$` to the empty bytes.
+    function clear(BytesStorage storage $) internal {
+        delete $._spacer;
+    }
+
+    /// @dev Returns whether the value stored is `$` is the empty bytes "".
+    function isEmpty(BytesStorage storage $) internal view returns (bool) {
+        return uint256($._spacer) & 0xff == uint256(0);
+    }
+
+    /// @dev Returns the length of the value stored in `$`.
+    function length(BytesStorage storage $) internal view returns (uint256 result) {
+        result = uint256($._spacer);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := and(0xff, result)
+            result := or(mul(shr(8, result), eq(0xff, n)), mul(n, iszero(eq(0xff, n))))
+        }
+    }
+
+    /// @dev Returns the value stored in `$`.
+    function get(BytesStorage storage $) internal view returns (bytes memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            let o := add(result, 0x20)
+            let packed := sload($.slot)
+            let n := shr(8, packed)
+            for { let i := 0 } 1 { } {
+                if iszero(eq(or(packed, 0xff), packed)) {
+                    mstore(o, packed)
+                    n := and(0xff, packed)
+                    i := 0x1f
+                    if iszero(gt(n, i)) { break }
+                }
+                mstore(0x00, $.slot)
+                for { let p := keccak256(0x00, 0x20) } 1 { } {
+                    mstore(add(o, i), sload(add(p, shr(5, i))))
+                    i := add(i, 0x20)
+                    if iszero(lt(i, n)) { break }
+                }
+                break
+            }
+            mstore(result, n) // Store the length of the memory.
+            mstore(add(o, n), 0) // Zeroize the slot after the bytes.
+            mstore(0x40, add(add(o, n), 0x20)) // Allocate memory.
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      BYTES OPERATIONS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns `subject` all occurrences of `needle` replaced with `replacement`.
+    function replace(bytes memory subject, bytes memory needle, bytes memory replacement)
+        internal
+        pure
+        returns (bytes memory result)
+    {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            let needleLen := mload(needle)
+            let replacementLen := mload(replacement)
+            let d := sub(result, subject) // Memory difference.
+            let i := add(subject, 0x20) // Subject bytes pointer.
+            mstore(0x00, add(i, mload(subject))) // End of subject.
+            if iszero(gt(needleLen, mload(subject))) {
+                let subjectSearchEnd := add(sub(mload(0x00), needleLen), 1)
+                let h := 0 // The hash of `needle`.
+                if iszero(lt(needleLen, 0x20)) { h := keccak256(add(needle, 0x20), needleLen) }
+                let s := mload(add(needle, 0x20))
+                for { let m := shl(3, sub(0x20, and(needleLen, 0x1f))) } 1 { } {
+                    let t := mload(i)
+                    // Whether the first `needleLen % 32` bytes of `subject` and `needle` matches.
+                    if iszero(shr(m, xor(t, s))) {
+                        if h {
+                            if iszero(eq(keccak256(i, needleLen), h)) {
+                                mstore(add(i, d), t)
+                                i := add(i, 1)
+                                if iszero(lt(i, subjectSearchEnd)) { break }
+                                continue
+                            }
+                        }
+                        // Copy the `replacement` one word at a time.
+                        for { let j := 0 } 1 { } {
+                            mstore(add(add(i, d), j), mload(add(add(replacement, 0x20), j)))
+                            j := add(j, 0x20)
+                            if iszero(lt(j, replacementLen)) { break }
+                        }
+                        d := sub(add(d, replacementLen), needleLen)
+                        if needleLen {
+                            i := add(i, needleLen)
+                            if iszero(lt(i, subjectSearchEnd)) { break }
+                            continue
+                        }
+                    }
+                    mstore(add(i, d), t)
+                    i := add(i, 1)
+                    if iszero(lt(i, subjectSearchEnd)) { break }
+                }
+            }
+            let end := mload(0x00)
+            let n := add(sub(d, add(result, 0x20)), end)
+            // Copy the rest of the bytes one word at a time.
+            for { } lt(i, end) { i := add(i, 0x20) } { mstore(add(i, d), mload(i)) }
+            let o := add(i, d)
+            mstore(o, 0) // Zeroize the slot after the bytes.
+            mstore(0x40, add(o, 0x20)) // Allocate memory.
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from left to right, starting from `from`.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function indexOf(bytes memory subject, bytes memory needle, uint256 from) internal pure returns (uint256 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := not(0) // Initialize to `NOT_FOUND`.
+            for { let subjectLen := mload(subject) } 1 { } {
+                if iszero(mload(needle)) {
+                    result := from
+                    if iszero(gt(from, subjectLen)) { break }
+                    result := subjectLen
+                    break
+                }
+                let needleLen := mload(needle)
+                let subjectStart := add(subject, 0x20)
+
+                subject := add(subjectStart, from)
+                let end := add(sub(add(subjectStart, subjectLen), needleLen), 1)
+                let m := shl(3, sub(0x20, and(needleLen, 0x1f)))
+                let s := mload(add(needle, 0x20))
+
+                if iszero(and(lt(subject, end), lt(from, subjectLen))) { break }
+
+                if iszero(lt(needleLen, 0x20)) {
+                    for { let h := keccak256(add(needle, 0x20), needleLen) } 1 { } {
+                        if iszero(shr(m, xor(mload(subject), s))) {
+                            if eq(keccak256(subject, needleLen), h) {
+                                result := sub(subject, subjectStart)
+                                break
+                            }
+                        }
+                        subject := add(subject, 1)
+                        if iszero(lt(subject, end)) { break }
+                    }
+                    break
+                }
+                for { } 1 { } {
+                    if iszero(shr(m, xor(mload(subject), s))) {
+                        result := sub(subject, subjectStart)
+                        break
+                    }
+                    subject := add(subject, 1)
+                    if iszero(lt(subject, end)) { break }
+                }
+                break
+            }
+        }
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from left to right.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function indexOf(bytes memory subject, bytes memory needle) internal pure returns (uint256) {
+        return indexOf(subject, needle, 0);
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from right to left, starting from `from`.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function lastIndexOf(bytes memory subject, bytes memory needle, uint256 from)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        /// @solidity memory-safe-assembly
+        assembly {
+            for { } 1 { } {
+                result := not(0) // Initialize to `NOT_FOUND`.
+                let needleLen := mload(needle)
+                if gt(needleLen, mload(subject)) { break }
+                let w := result
+
+                let fromMax := sub(mload(subject), needleLen)
+                if iszero(gt(fromMax, from)) { from := fromMax }
+
+                let end := add(add(subject, 0x20), w)
+                subject := add(add(subject, 0x20), from)
+                if iszero(gt(subject, end)) { break }
+                // As this function is not too often used,
+                // we shall simply use keccak256 for smaller bytecode size.
+                for { let h := keccak256(add(needle, 0x20), needleLen) } 1 { } {
+                    if eq(keccak256(subject, needleLen), h) {
+                        result := sub(subject, add(end, 1))
+                        break
+                    }
+                    subject := add(subject, w) // `sub(subject, 1)`.
+                    if iszero(gt(subject, end)) { break }
+                }
+                break
+            }
+        }
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from right to left.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function lastIndexOf(bytes memory subject, bytes memory needle) internal pure returns (uint256) {
+        return lastIndexOf(subject, needle, type(uint256).max);
+    }
+
+    /// @dev Returns true if `needle` is found in `subject`, false otherwise.
+    function contains(bytes memory subject, bytes memory needle) internal pure returns (bool) {
+        return indexOf(subject, needle) != NOT_FOUND;
+    }
+
+    /// @dev Returns whether `subject` starts with `needle`.
+    function startsWith(bytes memory subject, bytes memory needle) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := mload(needle)
+            // Just using keccak256 directly is actually cheaper.
+            let t := eq(keccak256(add(subject, 0x20), n), keccak256(add(needle, 0x20), n))
+            result := lt(gt(n, mload(subject)), t)
+        }
+    }
+
+    /// @dev Returns whether `subject` ends with `needle`.
+    function endsWith(bytes memory subject, bytes memory needle) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := mload(needle)
+            let notInRange := gt(n, mload(subject))
+            // `subject + 0x20 + max(subject.length - needle.length, 0)`.
+            let t := add(add(subject, 0x20), mul(iszero(notInRange), sub(mload(subject), n)))
+            // Just using keccak256 directly is actually cheaper.
+            result := gt(eq(keccak256(t, n), keccak256(add(needle, 0x20), n)), notInRange)
+        }
+    }
+
+    /// @dev Returns `subject` repeated `times`.
+    function repeat(bytes memory subject, uint256 times) internal pure returns (bytes memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let l := mload(subject) // Subject length.
+            if iszero(or(iszero(times), iszero(l))) {
+                result := mload(0x40)
+                subject := add(subject, 0x20)
+                let o := add(result, 0x20)
+                for { } 1 { } {
+                    // Copy the `subject` one word at a time.
+                    for { let j := 0 } 1 { } {
+                        mstore(add(o, j), mload(add(subject, j)))
+                        j := add(j, 0x20)
+                        if iszero(lt(j, l)) { break }
+                    }
+                    o := add(o, l)
+                    times := sub(times, 1)
+                    if iszero(times) { break }
+                }
+                mstore(o, 0) // Zeroize the slot after the bytes.
+                mstore(0x40, add(o, 0x20)) // Allocate memory.
+                mstore(result, sub(o, add(result, 0x20))) // Store the length.
+            }
+        }
+    }
+
+    /// @dev Returns a copy of `subject` sliced from `start` to `end` (exclusive).
+    /// `start` and `end` are byte offsets.
+    function slice(bytes memory subject, uint256 start, uint256 end) internal pure returns (bytes memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let l := mload(subject) // Subject length.
+            if iszero(gt(l, end)) { end := l }
+            if iszero(gt(l, start)) { start := l }
+            if lt(start, end) {
+                result := mload(0x40)
+                let n := sub(end, start)
+                let i := add(subject, start)
+                let w := not(0x1f)
+                // Copy the `subject` one word at a time, backwards.
+                for { let j := and(add(n, 0x1f), w) } 1 { } {
+                    mstore(add(result, j), mload(add(i, j)))
+                    j := add(j, w) // `sub(j, 0x20)`.
+                    if iszero(j) { break }
+                }
+                let o := add(add(result, 0x20), n)
+                mstore(o, 0) // Zeroize the slot after the bytes.
+                mstore(0x40, add(o, 0x20)) // Allocate memory.
+                mstore(result, n) // Store the length.
+            }
+        }
+    }
+
+    /// @dev Returns a copy of `subject` sliced from `start` to the end of the bytes.
+    /// `start` is a byte offset.
+    function slice(bytes memory subject, uint256 start) internal pure returns (bytes memory result) {
+        result = slice(subject, start, type(uint256).max);
+    }
+
+    /// @dev Returns a copy of `subject` sliced from `start` to `end` (exclusive).
+    /// `start` and `end` are byte offsets. Faster than Solidity's native slicing.
+    function sliceCalldata(bytes calldata subject, uint256 start, uint256 end)
+        internal
+        pure
+        returns (bytes calldata result)
+    {
+        /// @solidity memory-safe-assembly
+        assembly {
+            end := xor(end, mul(xor(end, subject.length), lt(subject.length, end)))
+            start := xor(start, mul(xor(start, subject.length), lt(subject.length, start)))
+            result.offset := add(subject.offset, start)
+            result.length := mul(lt(start, end), sub(end, start))
+        }
+    }
+
+    /// @dev Returns a copy of `subject` sliced from `start` to the end of the bytes.
+    /// `start` is a byte offset. Faster than Solidity's native slicing.
+    function sliceCalldata(bytes calldata subject, uint256 start) internal pure returns (bytes calldata result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            start := xor(start, mul(xor(start, subject.length), lt(subject.length, start)))
+            result.offset := add(subject.offset, start)
+            result.length := mul(lt(start, subject.length), sub(subject.length, start))
+        }
+    }
+
+    /// @dev Reduces the size of `subject` to `n`.
+    /// If `n` is greater than the size of `subject`, this will be a no-op.
+    function truncate(bytes memory subject, uint256 n) internal pure returns (bytes memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := subject
+            mstore(mul(lt(n, mload(result)), result), n)
+        }
+    }
+
+    /// @dev Returns a copy of `subject`, with the length reduced to `n`.
+    /// If `n` is greater than the size of `subject`, this will be a no-op.
+    function truncatedCalldata(bytes calldata subject, uint256 n) internal pure returns (bytes calldata result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result.offset := subject.offset
+            result.length := xor(n, mul(xor(n, subject.length), lt(subject.length, n)))
+        }
+    }
+
+    /// @dev Returns all the indices of `needle` in `subject`.
+    /// The indices are byte offsets.
+    function indicesOf(bytes memory subject, bytes memory needle) internal pure returns (uint256[] memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let searchLen := mload(needle)
+            if iszero(gt(searchLen, mload(subject))) {
+                result := mload(0x40)
+                let i := add(subject, 0x20)
+                let o := add(result, 0x20)
+                let subjectSearchEnd := add(sub(add(i, mload(subject)), searchLen), 1)
+                let h := 0 // The hash of `needle`.
+                if iszero(lt(searchLen, 0x20)) { h := keccak256(add(needle, 0x20), searchLen) }
+                let s := mload(add(needle, 0x20))
+                for { let m := shl(3, sub(0x20, and(searchLen, 0x1f))) } 1 { } {
+                    let t := mload(i)
+                    // Whether the first `searchLen % 32` bytes of `subject` and `needle` matches.
+                    if iszero(shr(m, xor(t, s))) {
+                        if h {
+                            if iszero(eq(keccak256(i, searchLen), h)) {
+                                i := add(i, 1)
+                                if iszero(lt(i, subjectSearchEnd)) { break }
+                                continue
+                            }
+                        }
+                        mstore(o, sub(i, add(subject, 0x20))) // Append to `result`.
+                        o := add(o, 0x20)
+                        i := add(i, searchLen) // Advance `i` by `searchLen`.
+                        if searchLen {
+                            if iszero(lt(i, subjectSearchEnd)) { break }
+                            continue
+                        }
+                    }
+                    i := add(i, 1)
+                    if iszero(lt(i, subjectSearchEnd)) { break }
+                }
+                mstore(result, shr(5, sub(o, add(result, 0x20)))) // Store the length of `result`.
+                // Allocate memory for result.
+                // We allocate one more word, so this array can be recycled for {split}.
+                mstore(0x40, add(o, 0x20))
+            }
+        }
+    }
+
+    /// @dev Returns an arrays of bytess based on the `delimiter` inside of the `subject` bytes.
+    function split(bytes memory subject, bytes memory delimiter) internal pure returns (bytes[] memory result) {
+        uint256[] memory indices = indicesOf(subject, delimiter);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let w := not(0x1f)
+            let indexPtr := add(indices, 0x20)
+            let indicesEnd := add(indexPtr, shl(5, add(mload(indices), 1)))
+            mstore(add(indicesEnd, w), mload(subject))
+            mstore(indices, add(mload(indices), 1))
+            for { let prevIndex := 0 } 1 { } {
+                let index := mload(indexPtr)
+                mstore(indexPtr, 0x60)
+                if iszero(eq(index, prevIndex)) {
+                    let element := mload(0x40)
+                    let l := sub(index, prevIndex)
+                    mstore(element, l) // Store the length of the element.
+                    // Copy the `subject` one word at a time, backwards.
+                    for { let o := and(add(l, 0x1f), w) } 1 { } {
+                        mstore(add(element, o), mload(add(add(subject, prevIndex), o)))
+                        o := add(o, w) // `sub(o, 0x20)`.
+                        if iszero(o) { break }
+                    }
+                    mstore(add(add(element, 0x20), l), 0) // Zeroize the slot after the bytes.
+                    // Allocate memory for the length and the bytes, rounded up to a multiple of 32.
+                    mstore(0x40, add(element, and(add(l, 0x3f), w)))
+                    mstore(indexPtr, element) // Store the `element` into the array.
+                }
+                prevIndex := add(index, mload(delimiter))
+                indexPtr := add(indexPtr, 0x20)
+                if iszero(lt(indexPtr, indicesEnd)) { break }
+            }
+            result := indices
+            if iszero(mload(delimiter)) {
+                result := add(indices, 0x20)
+                mstore(result, sub(mload(indices), 2))
+            }
+        }
+    }
+
+    /// @dev Returns a concatenated bytes of `a` and `b`.
+    /// Cheaper than `bytes.concat()` and does not de-align the free memory pointer.
+    function concat(bytes memory a, bytes memory b) internal pure returns (bytes memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            let w := not(0x1f)
+            let aLen := mload(a)
+            // Copy `a` one word at a time, backwards.
+            for { let o := and(add(aLen, 0x20), w) } 1 { } {
+                mstore(add(result, o), mload(add(a, o)))
+                o := add(o, w) // `sub(o, 0x20)`.
+                if iszero(o) { break }
+            }
+            let bLen := mload(b)
+            let output := add(result, aLen)
+            // Copy `b` one word at a time, backwards.
+            for { let o := and(add(bLen, 0x20), w) } 1 { } {
+                mstore(add(output, o), mload(add(b, o)))
+                o := add(o, w) // `sub(o, 0x20)`.
+                if iszero(o) { break }
+            }
+            let totalLen := add(aLen, bLen)
+            let last := add(add(result, 0x20), totalLen)
+            mstore(last, 0) // Zeroize the slot after the bytes.
+            mstore(result, totalLen) // Store the length.
+            mstore(0x40, add(last, 0x20)) // Allocate memory.
+        }
+    }
+
+    /// @dev Returns whether `a` equals `b`.
+    function eq(bytes memory a, bytes memory b) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := eq(keccak256(add(a, 0x20), mload(a)), keccak256(add(b, 0x20), mload(b)))
+        }
+    }
+
+    /// @dev Returns whether `a` equals `b`, where `b` is a null-terminated small bytes.
+    function eqs(bytes memory a, bytes32 b) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // These should be evaluated on compile time, as far as possible.
+            let m := not(shl(7, div(not(iszero(b)), 255))) // `0x7f7f ...`.
+            let x := not(or(m, or(b, add(m, and(b, m)))))
+            let r := shl(7, iszero(iszero(shr(128, x))))
+            r := or(r, shl(6, iszero(iszero(shr(64, shr(r, x))))))
+            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            r := or(r, shl(4, lt(0xffff, shr(r, x))))
+            r := or(r, shl(3, lt(0xff, shr(r, x))))
+            // forgefmt: disable-next-item
+            result := gt(eq(mload(a), add(iszero(x), xor(31, shr(3, r)))),
+                xor(shr(add(8, r), b), shr(add(8, r), mload(add(a, 0x20)))))
+        }
+    }
+
+    /// @dev Returns 0 if `a == b`, -1 if `a < b`, +1 if `a > b`.
+    /// If `a` == b[:a.length]`, and `a.length < b.length`, returns -1.
+    function cmp(bytes memory a, bytes memory b) internal pure returns (int256 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let aLen := mload(a)
+            let bLen := mload(b)
+            let n := and(xor(aLen, mul(xor(aLen, bLen), lt(bLen, aLen))), not(0x1f))
+            if n {
+                for { let i := 0x20 } 1 { } {
+                    let x := mload(add(a, i))
+                    let y := mload(add(b, i))
+                    if iszero(or(xor(x, y), eq(i, n))) {
+                        i := add(i, 0x20)
+                        continue
+                    }
+                    result := sub(gt(x, y), lt(x, y))
+                    break
+                }
+            }
+            // forgefmt: disable-next-item
+            if iszero(result) {
+                let l := 0x201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201
+                let x := and(mload(add(add(a, 0x20), n)), shl(shl(3, byte(sub(aLen, n), l)), not(0)))
+                let y := and(mload(add(add(b, 0x20), n)), shl(shl(3, byte(sub(bLen, n), l)), not(0)))
+                result := sub(gt(x, y), lt(x, y))
+                if iszero(result) { result := sub(gt(aLen, bLen), lt(aLen, bLen)) }
+            }
+        }
+    }
+
+    /// @dev Directly returns `a` without copying.
+    function directReturn(bytes memory a) internal pure {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Assumes that the bytes does not start from the scratch space.
+            let retStart := sub(a, 0x20)
+            let retUnpaddedSize := add(mload(a), 0x40)
+            // Right pad with zeroes. Just in case the bytes is produced
+            // by a method that doesn't zero right pad.
+            mstore(add(retStart, retUnpaddedSize), 0)
+            mstore(retStart, 0x20) // Store the return offset.
+            // End the transaction, returning the bytes.
+            return(retStart, and(not(0x1f), add(0x1f, retUnpaddedSize)))
+        }
+    }
+
+    /// @dev Directly returns `a` with minimal copying.
+    function directReturn(bytes[] memory a) internal pure {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := mload(a) // `a.length`.
+            let o := add(a, 0x20) // Start of elements in `a`.
+            let u := a // Highest memory slot.
+            let w := not(0x1f)
+            for { let i := 0 } iszero(eq(i, n)) { i := add(i, 1) } {
+                let c := add(o, shl(5, i)) // Location of pointer to `a[i]`.
+                let s := mload(c) // `a[i]`.
+                let l := mload(s) // `a[i].length`.
+                let r := and(l, 0x1f) // `a[i].length % 32`.
+                let z := add(0x20, and(l, w)) // Offset of last word in `a[i]` from `s`.
+                // If `s` comes before `o`, or `s` is not zero right padded.
+                if iszero(lt(lt(s, o), or(iszero(r), iszero(shl(shl(3, r), mload(add(s, z))))))) {
+                    let m := mload(0x40)
+                    mstore(m, l) // Copy `a[i].length`.
+                    for { } 1 { } {
+                        mstore(add(m, z), mload(add(s, z))) // Copy `a[i]`, backwards.
+                        z := add(z, w) // `sub(z, 0x20)`.
+                        if iszero(z) { break }
+                    }
+                    let e := add(add(m, 0x20), l)
+                    mstore(e, 0) // Zeroize the slot after the copied bytes.
+                    mstore(0x40, add(e, 0x20)) // Allocate memory.
+                    s := m
+                }
+                mstore(c, sub(s, o)) // Convert to calldata offset.
+                let t := add(l, add(s, 0x20))
+                if iszero(lt(t, u)) { u := t }
+            }
+            let retStart := add(a, w) // Assumes `a` doesn't start from scratch space.
+            mstore(retStart, 0x20) // Store the return offset.
+            return(retStart, add(0x40, sub(u, retStart))) // End the transaction.
+        }
+    }
+
+    /// @dev Returns the word at `offset`, without any bounds checks.
+    function load(bytes memory a, uint256 offset) internal pure returns (bytes32 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(add(add(a, 0x20), offset))
+        }
+    }
+
+    /// @dev Returns the word at `offset`, without any bounds checks.
+    function loadCalldata(bytes calldata a, uint256 offset) internal pure returns (bytes32 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := calldataload(add(a.offset, offset))
+        }
+    }
+
+    /// @dev Returns a slice representing a static struct in the calldata. Performs bounds checks.
+    function staticStructInCalldata(bytes calldata a, uint256 offset) internal pure returns (bytes calldata result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let l := sub(a.length, 0x20)
+            result.offset := add(a.offset, offset)
+            result.length := sub(a.length, offset)
+            if or(shr(64, or(l, a.offset)), gt(offset, l)) { revert(l, 0x00) }
+        }
+    }
+
+    /// @dev Returns a slice representing a dynamic struct in the calldata. Performs bounds checks.
+    function dynamicStructInCalldata(bytes calldata a, uint256 offset) internal pure returns (bytes calldata result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let l := sub(a.length, 0x20)
+            let s := calldataload(add(a.offset, offset)) // Relative offset of `result` from `a.offset`.
+            result.offset := add(a.offset, s)
+            result.length := sub(a.length, s)
+            if or(shr(64, or(s, or(l, a.offset))), gt(offset, l)) { revert(l, 0x00) }
+        }
+    }
+
+    /// @dev Returns bytes in calldata. Performs bounds checks.
+    function bytesInCalldata(bytes calldata a, uint256 offset) internal pure returns (bytes calldata result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let l := sub(a.length, 0x20)
+            let s := calldataload(add(a.offset, offset)) // Relative offset of `result` from `a.offset`.
+            result.offset := add(add(a.offset, s), 0x20)
+            result.length := calldataload(add(a.offset, s))
+            // forgefmt: disable-next-item
+            if or(shr(64, or(result.length, or(s, or(l, a.offset)))),
+                or(gt(add(s, result.length), l), gt(offset, l))) { revert(l, 0x00) }
+        }
+    }
+
+    /// @dev Returns empty calldata bytes. For silencing the compiler.
+    function emptyCalldata() internal pure returns (bytes calldata result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result.length := 0
+        }
+    }
+}
+
+/// @notice Library for converting numbers into strings and other string operations.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/LibString.sol)
+/// @author Modified from Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/LibString.sol)
+///
+/// @dev Note:
+/// For performance and bytecode compactness, most of the string operations are restricted to
+/// byte strings (7-bit ASCII), except where otherwise specified.
+/// Usage of byte string operations on charsets with runes spanning two or more bytes
+/// can lead to undefined behavior.
+library LibString {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          STRUCTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Goated string storage struct that totally MOGs, no cap, fr.
+    /// Uses less gas and bytecode than Solidity's native string storage. It's meta af.
+    /// Packs length with the first 31 bytes if <255 bytes, so it’s mad tight.
+    struct StringStorage {
+        bytes32 _spacer;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        CUSTOM ERRORS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The length of the output is too small to contain all the hex digits.
+    error HexLengthInsufficient();
+
+    /// @dev The length of the string is more than 32 bytes.
+    error TooBigForSmallString();
+
+    /// @dev The input string must be a 7-bit ASCII.
+    error StringNot7BitASCII();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         CONSTANTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The constant returned when the `search` is not found in the string.
+    uint256 internal constant NOT_FOUND = type(uint256).max;
+
+    /// @dev Lookup for '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+    uint128 internal constant ALPHANUMERIC_7_BIT_ASCII = 0x7fffffe07fffffe03ff000000000000;
+
+    /// @dev Lookup for 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+    uint128 internal constant LETTERS_7_BIT_ASCII = 0x7fffffe07fffffe0000000000000000;
+
+    /// @dev Lookup for 'abcdefghijklmnopqrstuvwxyz'.
+    uint128 internal constant LOWERCASE_7_BIT_ASCII = 0x7fffffe000000000000000000000000;
+
+    /// @dev Lookup for 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+    uint128 internal constant UPPERCASE_7_BIT_ASCII = 0x7fffffe0000000000000000;
+
+    /// @dev Lookup for '0123456789'.
+    uint128 internal constant DIGITS_7_BIT_ASCII = 0x3ff000000000000;
+
+    /// @dev Lookup for '0123456789abcdefABCDEF'.
+    uint128 internal constant HEXDIGITS_7_BIT_ASCII = 0x7e0000007e03ff000000000000;
+
+    /// @dev Lookup for '01234567'.
+    uint128 internal constant OCTDIGITS_7_BIT_ASCII = 0xff000000000000;
+
+    /// @dev Lookup for '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c'.
+    uint128 internal constant PRINTABLE_7_BIT_ASCII = 0x7fffffffffffffffffffffff00003e00;
+
+    /// @dev Lookup for '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.
+    uint128 internal constant PUNCTUATION_7_BIT_ASCII = 0x78000001f8000001fc00fffe00000000;
+
+    /// @dev Lookup for ' \t\n\r\x0b\x0c'.
+    uint128 internal constant WHITESPACE_7_BIT_ASCII = 0x100003e00;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                 STRING STORAGE OPERATIONS                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Sets the value of the string storage `$` to `s`.
+    function set(StringStorage storage $, string memory s) internal {
+        LibBytes.set(bytesStorage($), bytes(s));
+    }
+
+    /// @dev Sets the value of the string storage `$` to `s`.
+    function setCalldata(StringStorage storage $, string calldata s) internal {
+        LibBytes.setCalldata(bytesStorage($), bytes(s));
+    }
+
+    /// @dev Sets the value of the string storage `$` to the empty string.
+    function clear(StringStorage storage $) internal {
+        delete $._spacer;
+    }
+
+    /// @dev Returns whether the value stored is `$` is the empty string "".
+    function isEmpty(StringStorage storage $) internal view returns (bool) {
+        return uint256($._spacer) & 0xff == uint256(0);
+    }
+
+    /// @dev Returns the length of the value stored in `$`.
+    function length(StringStorage storage $) internal view returns (uint256) {
+        return LibBytes.length(bytesStorage($));
+    }
+
+    /// @dev Returns the value stored in `$`.
+    function get(StringStorage storage $) internal view returns (string memory) {
+        return string(LibBytes.get(bytesStorage($)));
+    }
+
+    /// @dev Helper to cast `$` to a `BytesStorage`.
+    function bytesStorage(StringStorage storage $) internal pure returns (LibBytes.BytesStorage storage casted) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            casted.slot := $.slot
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                     DECIMAL OPERATIONS                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the base 10 decimal representation of `value`.
+    function toString(uint256 value) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // The maximum value of a uint256 contains 78 digits (1 byte per digit), but
+            // we allocate 0xa0 bytes to keep the free memory pointer 32-byte word aligned.
+            // We will need 1 word for the trailing zeros padding, 1 word for the length,
+            // and 3 words for a maximum of 78 digits.
+            result := add(mload(0x40), 0x80)
+            mstore(0x40, add(result, 0x20)) // Allocate memory.
+            mstore(result, 0) // Zeroize the slot after the string.
+
+            let end := result // Cache the end of the memory to calculate the length later.
+            let w := not(0) // Tsk.
+            // We write the string from rightmost digit to leftmost digit.
+            // The following is essentially a do-while loop that also handles the zero case.
+            for { let temp := value } 1 { } {
+                result := add(result, w) // `sub(result, 1)`.
+                // Store the character to the pointer.
+                // The ASCII index of the '0' character is 48.
+                mstore8(result, add(48, mod(temp, 10)))
+                temp := div(temp, 10) // Keep dividing `temp` until zero.
+                if iszero(temp) { break }
+            }
+            let n := sub(end, result)
+            result := sub(result, 0x20) // Move the pointer 32 bytes back to make room for the length.
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the base 10 decimal representation of `value`.
+    function toString(int256 value) internal pure returns (string memory result) {
+        if (value >= 0) return toString(uint256(value));
+        unchecked {
+            result = toString(~uint256(value) + 1);
+        }
+        /// @solidity memory-safe-assembly
+        assembly {
+            // We still have some spare memory space on the left,
+            // as we have allocated 3 words (96 bytes) for up to 78 digits.
+            let n := mload(result) // Load the string length.
+            mstore(result, 0x2d) // Store the '-' character.
+            result := sub(result, 1) // Move back the string pointer by a byte.
+            mstore(result, add(n, 1)) // Update the string length.
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   HEXADECIMAL OPERATIONS                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the hexadecimal representation of `value`,
+    /// left-padded to an input length of `byteCount` bytes.
+    /// The output is prefixed with "0x" encoded using 2 hexadecimal digits per byte,
+    /// giving a total length of `byteCount * 2 + 2` bytes.
+    /// Reverts if `byteCount` is too small for the output to contain all the digits.
+    function toHexString(uint256 value, uint256 byteCount) internal pure returns (string memory result) {
+        result = toHexStringNoPrefix(value, byteCount);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := add(mload(result), 2) // Compute the length.
+            mstore(result, 0x3078) // Store the "0x" prefix.
+            result := sub(result, 2) // Move the pointer.
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`,
+    /// left-padded to an input length of `byteCount` bytes.
+    /// The output is not prefixed with "0x" and is encoded using 2 hexadecimal digits per byte,
+    /// giving a total length of `byteCount * 2` bytes.
+    /// Reverts if `byteCount` is too small for the output to contain all the digits.
+    function toHexStringNoPrefix(uint256 value, uint256 byteCount) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // We need 0x20 bytes for the trailing zeros padding, `byteCount * 2` bytes
+            // for the digits, 0x02 bytes for the prefix, and 0x20 bytes for the length.
+            // We add 0x20 to the total and round down to a multiple of 0x20.
+            // (0x20 + 0x20 + 0x02 + 0x20) = 0x62.
+            result := add(mload(0x40), and(add(shl(1, byteCount), 0x42), not(0x1f)))
+            mstore(0x40, add(result, 0x20)) // Allocate memory.
+            mstore(result, 0) // Zeroize the slot after the string.
+
+            let end := result // Cache the end to calculate the length later.
+            // Store "0123456789abcdef" in scratch space.
+            mstore(0x0f, 0x30313233343536373839616263646566)
+
+            let start := sub(result, add(byteCount, byteCount))
+            let w := not(1) // Tsk.
+            let temp := value
+            // We write the string from rightmost digit to leftmost digit.
+            // The following is essentially a do-while loop that also handles the zero case.
+            for { } 1 { } {
+                result := add(result, w) // `sub(result, 2)`.
+                mstore8(add(result, 1), mload(and(temp, 15)))
+                mstore8(result, mload(and(shr(4, temp), 15)))
+                temp := shr(8, temp)
+                if iszero(xor(result, start)) { break }
+            }
+            if temp {
+                mstore(0x00, 0x2194895a) // `HexLengthInsufficient()`.
+                revert(0x1c, 0x04)
+            }
+            let n := sub(end, result)
+            result := sub(result, 0x20)
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`.
+    /// The output is prefixed with "0x" and encoded using 2 hexadecimal digits per byte.
+    /// As address are 20 bytes long, the output will left-padded to have
+    /// a length of `20 * 2 + 2` bytes.
+    function toHexString(uint256 value) internal pure returns (string memory result) {
+        result = toHexStringNoPrefix(value);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := add(mload(result), 2) // Compute the length.
+            mstore(result, 0x3078) // Store the "0x" prefix.
+            result := sub(result, 2) // Move the pointer.
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`.
+    /// The output is prefixed with "0x".
+    /// The output excludes leading "0" from the `toHexString` output.
+    /// `0x00: "0x0", 0x01: "0x1", 0x12: "0x12", 0x123: "0x123"`.
+    function toMinimalHexString(uint256 value) internal pure returns (string memory result) {
+        result = toHexStringNoPrefix(value);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let o := eq(byte(0, mload(add(result, 0x20))), 0x30) // Whether leading zero is present.
+            let n := add(mload(result), 2) // Compute the length.
+            mstore(add(result, o), 0x3078) // Store the "0x" prefix, accounting for leading zero.
+            result := sub(add(result, o), 2) // Move the pointer, accounting for leading zero.
+            mstore(result, sub(n, o)) // Store the length, accounting for leading zero.
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`.
+    /// The output excludes leading "0" from the `toHexStringNoPrefix` output.
+    /// `0x00: "0", 0x01: "1", 0x12: "12", 0x123: "123"`.
+    function toMinimalHexStringNoPrefix(uint256 value) internal pure returns (string memory result) {
+        result = toHexStringNoPrefix(value);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let o := eq(byte(0, mload(add(result, 0x20))), 0x30) // Whether leading zero is present.
+            let n := mload(result) // Get the length.
+            result := add(result, o) // Move the pointer, accounting for leading zero.
+            mstore(result, sub(n, o)) // Store the length, accounting for leading zero.
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`.
+    /// The output is encoded using 2 hexadecimal digits per byte.
+    /// As address are 20 bytes long, the output will left-padded to have
+    /// a length of `20 * 2` bytes.
+    function toHexStringNoPrefix(uint256 value) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // We need 0x20 bytes for the trailing zeros padding, 0x20 bytes for the length,
+            // 0x02 bytes for the prefix, and 0x40 bytes for the digits.
+            // The next multiple of 0x20 above (0x20 + 0x20 + 0x02 + 0x40) is 0xa0.
+            result := add(mload(0x40), 0x80)
+            mstore(0x40, add(result, 0x20)) // Allocate memory.
+            mstore(result, 0) // Zeroize the slot after the string.
+
+            let end := result // Cache the end to calculate the length later.
+            mstore(0x0f, 0x30313233343536373839616263646566) // Store the "0123456789abcdef" lookup.
+
+            let w := not(1) // Tsk.
+            // We write the string from rightmost digit to leftmost digit.
+            // The following is essentially a do-while loop that also handles the zero case.
+            for { let temp := value } 1 { } {
+                result := add(result, w) // `sub(result, 2)`.
+                mstore8(add(result, 1), mload(and(temp, 15)))
+                mstore8(result, mload(and(shr(4, temp), 15)))
+                temp := shr(8, temp)
+                if iszero(temp) { break }
+            }
+            let n := sub(end, result)
+            result := sub(result, 0x20)
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`.
+    /// The output is prefixed with "0x", encoded using 2 hexadecimal digits per byte,
+    /// and the alphabets are capitalized conditionally according to
+    /// https://eips.ethereum.org/EIPS/eip-55
+    function toHexStringChecksummed(address value) internal pure returns (string memory result) {
+        result = toHexString(value);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let mask := shl(6, div(not(0), 255)) // `0b010000000100000000 ...`
+            let o := add(result, 0x22)
+            let hashed := and(keccak256(o, 40), mul(34, mask)) // `0b10001000 ... `
+            let t := shl(240, 136) // `0b10001000 << 240`
+            for { let i := 0 } 1 { } {
+                mstore(add(i, i), mul(t, byte(i, hashed)))
+                i := add(i, 1)
+                if eq(i, 20) { break }
+            }
+            mstore(o, xor(mload(o), shr(1, and(mload(0x00), and(mload(o), mask)))))
+            o := add(o, 0x20)
+            mstore(o, xor(mload(o), shr(1, and(mload(0x20), and(mload(o), mask)))))
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`.
+    /// The output is prefixed with "0x" and encoded using 2 hexadecimal digits per byte.
+    function toHexString(address value) internal pure returns (string memory result) {
+        result = toHexStringNoPrefix(value);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := add(mload(result), 2) // Compute the length.
+            mstore(result, 0x3078) // Store the "0x" prefix.
+            result := sub(result, 2) // Move the pointer.
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the hexadecimal representation of `value`.
+    /// The output is encoded using 2 hexadecimal digits per byte.
+    function toHexStringNoPrefix(address value) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            // Allocate memory.
+            // We need 0x20 bytes for the trailing zeros padding, 0x20 bytes for the length,
+            // 0x02 bytes for the prefix, and 0x28 bytes for the digits.
+            // The next multiple of 0x20 above (0x20 + 0x20 + 0x02 + 0x28) is 0x80.
+            mstore(0x40, add(result, 0x80))
+            mstore(0x0f, 0x30313233343536373839616263646566) // Store the "0123456789abcdef" lookup.
+
+            result := add(result, 2)
+            mstore(result, 40) // Store the length.
+            let o := add(result, 0x20)
+            mstore(add(o, 40), 0) // Zeroize the slot after the string.
+            value := shl(96, value)
+            // We write the string from rightmost digit to leftmost digit.
+            // The following is essentially a do-while loop that also handles the zero case.
+            for { let i := 0 } 1 { } {
+                let p := add(o, add(i, i))
+                let temp := byte(i, value)
+                mstore8(add(p, 1), mload(and(temp, 15)))
+                mstore8(p, mload(shr(4, temp)))
+                i := add(i, 1)
+                if eq(i, 20) { break }
+            }
+        }
+    }
+
+    /// @dev Returns the hex encoded string from the raw bytes.
+    /// The output is encoded using 2 hexadecimal digits per byte.
+    function toHexString(bytes memory raw) internal pure returns (string memory result) {
+        result = toHexStringNoPrefix(raw);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := add(mload(result), 2) // Compute the length.
+            mstore(result, 0x3078) // Store the "0x" prefix.
+            result := sub(result, 2) // Move the pointer.
+            mstore(result, n) // Store the length.
+        }
+    }
+
+    /// @dev Returns the hex encoded string from the raw bytes.
+    /// The output is encoded using 2 hexadecimal digits per byte.
+    function toHexStringNoPrefix(bytes memory raw) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := mload(raw)
+            result := add(mload(0x40), 2) // Skip 2 bytes for the optional prefix.
+            mstore(result, add(n, n)) // Store the length of the output.
+
+            mstore(0x0f, 0x30313233343536373839616263646566) // Store the "0123456789abcdef" lookup.
+            let o := add(result, 0x20)
+            let end := add(raw, n)
+            for { } iszero(eq(raw, end)) { } {
+                raw := add(raw, 1)
+                mstore8(add(o, 1), mload(and(mload(raw), 15)))
+                mstore8(o, mload(and(shr(4, mload(raw)), 15)))
+                o := add(o, 2)
+            }
+            mstore(o, 0) // Zeroize the slot after the string.
+            mstore(0x40, add(o, 0x20)) // Allocate memory.
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   RUNE STRING OPERATIONS                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the number of UTF characters in the string.
+    function runeCount(string memory s) internal pure returns (uint256 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            if mload(s) {
+                mstore(0x00, div(not(0), 255))
+                mstore(0x20, 0x0202020202020202020202020202020202020202020202020303030304040506)
+                let o := add(s, 0x20)
+                let end := add(o, mload(s))
+                for { result := 1 } 1 { result := add(result, 1) } {
+                    o := add(o, byte(0, mload(shr(250, mload(o)))))
+                    if iszero(lt(o, end)) { break }
+                }
+            }
+        }
+    }
+
+    /// @dev Returns if this string is a 7-bit ASCII string.
+    /// (i.e. all characters codes are in [0..127])
+    function is7BitASCII(string memory s) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := 1
+            let mask := shl(7, div(not(0), 255))
+            let n := mload(s)
+            if n {
+                let o := add(s, 0x20)
+                let end := add(o, n)
+                let last := mload(end)
+                mstore(end, 0)
+                for { } 1 { } {
+                    if and(mask, mload(o)) {
+                        result := 0
+                        break
+                    }
+                    o := add(o, 0x20)
+                    if iszero(lt(o, end)) { break }
+                }
+                mstore(end, last)
+            }
+        }
+    }
+
+    /// @dev Returns if this string is a 7-bit ASCII string,
+    /// AND all characters are in the `allowed` lookup.
+    /// Note: If `s` is empty, returns true regardless of `allowed`.
+    function is7BitASCII(string memory s, uint128 allowed) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := 1
+            if mload(s) {
+                let allowed_ := shr(128, shl(128, allowed))
+                let o := add(s, 0x20)
+                for { let end := add(o, mload(s)) } 1 { } {
+                    result := and(result, shr(byte(0, mload(o)), allowed_))
+                    o := add(o, 1)
+                    if iszero(and(result, lt(o, end))) { break }
+                }
+            }
+        }
+    }
+
+    /// @dev Converts the bytes in the 7-bit ASCII string `s` to
+    /// an allowed lookup for use in `is7BitASCII(s, allowed)`.
+    /// To save runtime gas, you can cache the result in an immutable variable.
+    function to7BitASCIIAllowedLookup(string memory s) internal pure returns (uint128 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            if mload(s) {
+                let o := add(s, 0x20)
+                for { let end := add(o, mload(s)) } 1 { } {
+                    result := or(result, shl(byte(0, mload(o)), 1))
+                    o := add(o, 1)
+                    if iszero(lt(o, end)) { break }
+                }
+                if shr(128, result) {
+                    mstore(0x00, 0xc9807e0d) // `StringNot7BitASCII()`.
+                    revert(0x1c, 0x04)
+                }
+            }
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   BYTE STRING OPERATIONS                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    // For performance and bytecode compactness, byte string operations are restricted
+    // to 7-bit ASCII strings. All offsets are byte offsets, not UTF character offsets.
+    // Usage of byte string operations on charsets with runes spanning two or more bytes
+    // can lead to undefined behavior.
+
+    /// @dev Returns `subject` all occurrences of `needle` replaced with `replacement`.
+    function replace(string memory subject, string memory needle, string memory replacement)
+        internal
+        pure
+        returns (string memory)
+    {
+        return string(LibBytes.replace(bytes(subject), bytes(needle), bytes(replacement)));
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from left to right, starting from `from`.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function indexOf(string memory subject, string memory needle, uint256 from) internal pure returns (uint256) {
+        return LibBytes.indexOf(bytes(subject), bytes(needle), from);
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from left to right.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function indexOf(string memory subject, string memory needle) internal pure returns (uint256) {
+        return LibBytes.indexOf(bytes(subject), bytes(needle), 0);
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from right to left, starting from `from`.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function lastIndexOf(string memory subject, string memory needle, uint256 from) internal pure returns (uint256) {
+        return LibBytes.lastIndexOf(bytes(subject), bytes(needle), from);
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from right to left.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function lastIndexOf(string memory subject, string memory needle) internal pure returns (uint256) {
+        return LibBytes.lastIndexOf(bytes(subject), bytes(needle), type(uint256).max);
+    }
+
+    /// @dev Returns true if `needle` is found in `subject`, false otherwise.
+    function contains(string memory subject, string memory needle) internal pure returns (bool) {
+        return LibBytes.contains(bytes(subject), bytes(needle));
+    }
+
+    /// @dev Returns whether `subject` starts with `needle`.
+    function startsWith(string memory subject, string memory needle) internal pure returns (bool) {
+        return LibBytes.startsWith(bytes(subject), bytes(needle));
+    }
+
+    /// @dev Returns whether `subject` ends with `needle`.
+    function endsWith(string memory subject, string memory needle) internal pure returns (bool) {
+        return LibBytes.endsWith(bytes(subject), bytes(needle));
+    }
+
+    /// @dev Returns `subject` repeated `times`.
+    function repeat(string memory subject, uint256 times) internal pure returns (string memory) {
+        return string(LibBytes.repeat(bytes(subject), times));
+    }
+
+    /// @dev Returns a copy of `subject` sliced from `start` to `end` (exclusive).
+    /// `start` and `end` are byte offsets.
+    function slice(string memory subject, uint256 start, uint256 end) internal pure returns (string memory) {
+        return string(LibBytes.slice(bytes(subject), start, end));
+    }
+
+    /// @dev Returns a copy of `subject` sliced from `start` to the end of the string.
+    /// `start` is a byte offset.
+    function slice(string memory subject, uint256 start) internal pure returns (string memory) {
+        return string(LibBytes.slice(bytes(subject), start, type(uint256).max));
+    }
+
+    /// @dev Returns all the indices of `needle` in `subject`.
+    /// The indices are byte offsets.
+    function indicesOf(string memory subject, string memory needle) internal pure returns (uint256[] memory) {
+        return LibBytes.indicesOf(bytes(subject), bytes(needle));
+    }
+
+    /// @dev Returns an arrays of strings based on the `delimiter` inside of the `subject` string.
+    function split(string memory subject, string memory delimiter) internal pure returns (string[] memory result) {
+        bytes[] memory a = LibBytes.split(bytes(subject), bytes(delimiter));
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := a
+        }
+    }
+
+    /// @dev Returns a concatenated string of `a` and `b`.
+    /// Cheaper than `string.concat()` and does not de-align the free memory pointer.
+    function concat(string memory a, string memory b) internal pure returns (string memory) {
+        return string(LibBytes.concat(bytes(a), bytes(b)));
+    }
+
+    /// @dev Returns a copy of the string in either lowercase or UPPERCASE.
+    /// WARNING! This function is only compatible with 7-bit ASCII strings.
+    function toCase(string memory subject, bool toUpper) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := mload(subject)
+            if n {
+                result := mload(0x40)
+                let o := add(result, 0x20)
+                let d := sub(subject, result)
+                let flags := shl(add(70, shl(5, toUpper)), 0x3ffffff)
+                for { let end := add(o, n) } 1 { } {
+                    let b := byte(0, mload(add(d, o)))
+                    mstore8(o, xor(and(shr(b, flags), 0x20), b))
+                    o := add(o, 1)
+                    if eq(o, end) { break }
+                }
+                mstore(result, n) // Store the length.
+                mstore(o, 0) // Zeroize the slot after the string.
+                mstore(0x40, add(o, 0x20)) // Allocate memory.
+            }
+        }
+    }
+
+    /// @dev Returns a string from a small bytes32 string.
+    /// `s` must be null-terminated, or behavior will be undefined.
+    function fromSmallString(bytes32 s) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            let n := 0
+            for { } byte(n, s) { n := add(n, 1) } { } // Scan for '\0'.
+            mstore(result, n) // Store the length.
+            let o := add(result, 0x20)
+            mstore(o, s) // Store the bytes of the string.
+            mstore(add(o, n), 0) // Zeroize the slot after the string.
+            mstore(0x40, add(result, 0x40)) // Allocate memory.
+        }
+    }
+
+    /// @dev Returns the small string, with all bytes after the first null byte zeroized.
+    function normalizeSmallString(bytes32 s) internal pure returns (bytes32 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            for { } byte(result, s) { result := add(result, 1) } { } // Scan for '\0'.
+            mstore(0x00, s)
+            mstore(result, 0x00)
+            result := mload(0x00)
+        }
+    }
+
+    /// @dev Returns the string as a normalized null-terminated small string.
+    function toSmallString(string memory s) internal pure returns (bytes32 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(s)
+            if iszero(lt(result, 33)) {
+                mstore(0x00, 0xec92f9a3) // `TooBigForSmallString()`.
+                revert(0x1c, 0x04)
+            }
+            result := shl(shl(3, sub(32, result)), mload(add(s, result)))
+        }
+    }
+
+    /// @dev Returns a lowercased copy of the string.
+    /// WARNING! This function is only compatible with 7-bit ASCII strings.
+    function lower(string memory subject) internal pure returns (string memory result) {
+        result = toCase(subject, false);
+    }
+
+    /// @dev Returns an UPPERCASED copy of the string.
+    /// WARNING! This function is only compatible with 7-bit ASCII strings.
+    function upper(string memory subject) internal pure returns (string memory result) {
+        result = toCase(subject, true);
+    }
+
+    /// @dev Escapes the string to be used within HTML tags.
+    function escapeHTML(string memory s) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            let end := add(s, mload(s))
+            let o := add(result, 0x20)
+            // Store the bytes of the packed offsets and strides into the scratch space.
+            // `packed = (stride << 5) | offset`. Max offset is 20. Max stride is 6.
+            mstore(0x1f, 0x900094)
+            mstore(0x08, 0xc0000000a6ab)
+            // Store "&quot;&amp;&#39;&lt;&gt;" into the scratch space.
+            mstore(0x00, shl(64, 0x2671756f743b26616d703b262333393b266c743b2667743b))
+            for { } iszero(eq(s, end)) { } {
+                s := add(s, 1)
+                let c := and(mload(s), 0xff)
+                // Not in `["\"","'","&","<",">"]`.
+                if iszero(and(shl(c, 1), 0x500000c400000000)) {
+                    mstore8(o, c)
+                    o := add(o, 1)
+                    continue
+                }
+                let t := shr(248, mload(c))
+                mstore(o, mload(and(t, 0x1f)))
+                o := add(o, shr(5, t))
+            }
+            mstore(o, 0) // Zeroize the slot after the string.
+            mstore(result, sub(o, add(result, 0x20))) // Store the length.
+            mstore(0x40, add(o, 0x20)) // Allocate memory.
+        }
+    }
+
+    /// @dev Escapes the string to be used within double-quotes in a JSON.
+    /// If `addDoubleQuotes` is true, the result will be enclosed in double-quotes.
+    function escapeJSON(string memory s, bool addDoubleQuotes) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            let o := add(result, 0x20)
+            if addDoubleQuotes {
+                mstore8(o, 34)
+                o := add(1, o)
+            }
+            // Store "\\u0000" in scratch space.
+            // Store "0123456789abcdef" in scratch space.
+            // Also, store `{0x08:"b", 0x09:"t", 0x0a:"n", 0x0c:"f", 0x0d:"r"}`.
+            // into the scratch space.
+            mstore(0x15, 0x5c75303030303031323334353637383961626364656662746e006672)
+            // Bitmask for detecting `["\"","\\"]`.
+            let e := or(shl(0x22, 1), shl(0x5c, 1))
+            for { let end := add(s, mload(s)) } iszero(eq(s, end)) { } {
+                s := add(s, 1)
+                let c := and(mload(s), 0xff)
+                if iszero(lt(c, 0x20)) {
+                    if iszero(and(shl(c, 1), e)) {
+                        // Not in `["\"","\\"]`.
+                        mstore8(o, c)
+                        o := add(o, 1)
+                        continue
+                    }
+                    mstore8(o, 0x5c) // "\\".
+                    mstore8(add(o, 1), c)
+                    o := add(o, 2)
+                    continue
+                }
+                if iszero(and(shl(c, 1), 0x3700)) {
+                    // Not in `["\b","\t","\n","\f","\d"]`.
+                    mstore8(0x1d, mload(shr(4, c))) // Hex value.
+                    mstore8(0x1e, mload(and(c, 15))) // Hex value.
+                    mstore(o, mload(0x19)) // "\\u00XX".
+                    o := add(o, 6)
+                    continue
+                }
+                mstore8(o, 0x5c) // "\\".
+                mstore8(add(o, 1), mload(add(c, 8)))
+                o := add(o, 2)
+            }
+            if addDoubleQuotes {
+                mstore8(o, 34)
+                o := add(1, o)
+            }
+            mstore(o, 0) // Zeroize the slot after the string.
+            mstore(result, sub(o, add(result, 0x20))) // Store the length.
+            mstore(0x40, add(o, 0x20)) // Allocate memory.
+        }
+    }
+
+    /// @dev Escapes the string to be used within double-quotes in a JSON.
+    function escapeJSON(string memory s) internal pure returns (string memory result) {
+        result = escapeJSON(s, false);
+    }
+
+    /// @dev Encodes `s` so that it can be safely used in a URI,
+    /// just like `encodeURIComponent` in JavaScript.
+    /// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+    /// See: https://datatracker.ietf.org/doc/html/rfc2396
+    /// See: https://datatracker.ietf.org/doc/html/rfc3986
+    function encodeURIComponent(string memory s) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40)
+            // Store "0123456789ABCDEF" in scratch space.
+            // Uppercased to be consistent with JavaScript's implementation.
+            mstore(0x0f, 0x30313233343536373839414243444546)
+            let o := add(result, 0x20)
+            for { let end := add(s, mload(s)) } iszero(eq(s, end)) { } {
+                s := add(s, 1)
+                let c := and(mload(s), 0xff)
+                // If not in `[0-9A-Z-a-z-_.!~*'()]`.
+                if iszero(and(1, shr(c, 0x47fffffe87fffffe03ff678200000000))) {
+                    mstore8(o, 0x25) // '%'.
+                    mstore8(add(o, 1), mload(and(shr(4, c), 15)))
+                    mstore8(add(o, 2), mload(and(c, 15)))
+                    o := add(o, 3)
+                    continue
+                }
+                mstore8(o, c)
+                o := add(o, 1)
+            }
+            mstore(result, sub(o, add(result, 0x20))) // Store the length.
+            mstore(o, 0) // Zeroize the slot after the string.
+            mstore(0x40, add(o, 0x20)) // Allocate memory.
+        }
+    }
+
+    /// @dev Returns whether `a` equals `b`.
+    function eq(string memory a, string memory b) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := eq(keccak256(add(a, 0x20), mload(a)), keccak256(add(b, 0x20), mload(b)))
+        }
+    }
+
+    /// @dev Returns whether `a` equals `b`, where `b` is a null-terminated small string.
+    function eqs(string memory a, bytes32 b) internal pure returns (bool result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // These should be evaluated on compile time, as far as possible.
+            let m := not(shl(7, div(not(iszero(b)), 255))) // `0x7f7f ...`.
+            let x := not(or(m, or(b, add(m, and(b, m)))))
+            let r := shl(7, iszero(iszero(shr(128, x))))
+            r := or(r, shl(6, iszero(iszero(shr(64, shr(r, x))))))
+            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            r := or(r, shl(4, lt(0xffff, shr(r, x))))
+            r := or(r, shl(3, lt(0xff, shr(r, x))))
+            // forgefmt: disable-next-item
+            result := gt(eq(mload(a), add(iszero(x), xor(31, shr(3, r)))),
+                xor(shr(add(8, r), b), shr(add(8, r), mload(add(a, 0x20)))))
+        }
+    }
+
+    /// @dev Returns 0 if `a == b`, -1 if `a < b`, +1 if `a > b`.
+    /// If `a` == b[:a.length]`, and `a.length < b.length`, returns -1.
+    function cmp(string memory a, string memory b) internal pure returns (int256) {
+        return LibBytes.cmp(bytes(a), bytes(b));
+    }
+
+    /// @dev Packs a single string with its length into a single word.
+    /// Returns `bytes32(0)` if the length is zero or greater than 31.
+    function packOne(string memory a) internal pure returns (bytes32 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // We don't need to zero right pad the string,
+            // since this is our own custom non-standard packing scheme.
+            result :=
+                mul(
+                    // Load the length and the bytes.
+                    mload(add(a, 0x1f)),
+                    // `length != 0 && length < 32`. Abuses underflow.
+                    // Assumes that the length is valid and within the block gas limit.
+                    lt(sub(mload(a), 1), 0x1f)
+                )
+        }
+    }
+
+    /// @dev Unpacks a string packed using {packOne}.
+    /// Returns the empty string if `packed` is `bytes32(0)`.
+    /// If `packed` is not an output of {packOne}, the output behavior is undefined.
+    function unpackOne(bytes32 packed) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := mload(0x40) // Grab the free memory pointer.
+            mstore(0x40, add(result, 0x40)) // Allocate 2 words (1 for the length, 1 for the bytes).
+            mstore(result, 0) // Zeroize the length slot.
+            mstore(add(result, 0x1f), packed) // Store the length and bytes.
+            mstore(add(add(result, 0x20), mload(result)), 0) // Right pad with zeroes.
+        }
+    }
+
+    /// @dev Packs two strings with their lengths into a single word.
+    /// Returns `bytes32(0)` if combined length is zero or greater than 30.
+    function packTwo(string memory a, string memory b) internal pure returns (bytes32 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let aLen := mload(a)
+            // We don't need to zero right pad the strings,
+            // since this is our own custom non-standard packing scheme.
+            result :=
+                mul(
+                    or( // Load the length and the bytes of `a` and `b`.
+                    shl(shl(3, sub(0x1f, aLen)), mload(add(a, aLen))), mload(sub(add(b, 0x1e), aLen))),
+                    // `totalLen != 0 && totalLen < 31`. Abuses underflow.
+                    // Assumes that the lengths are valid and within the block gas limit.
+                    lt(sub(add(aLen, mload(b)), 1), 0x1e)
+                )
+        }
+    }
+
+    /// @dev Unpacks strings packed using {packTwo}.
+    /// Returns the empty strings if `packed` is `bytes32(0)`.
+    /// If `packed` is not an output of {packTwo}, the output behavior is undefined.
+    function unpackTwo(bytes32 packed) internal pure returns (string memory resultA, string memory resultB) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            resultA := mload(0x40) // Grab the free memory pointer.
+            resultB := add(resultA, 0x40)
+            // Allocate 2 words for each string (1 for the length, 1 for the byte). Total 4 words.
+            mstore(0x40, add(resultB, 0x40))
+            // Zeroize the length slots.
+            mstore(resultA, 0)
+            mstore(resultB, 0)
+            // Store the lengths and bytes.
+            mstore(add(resultA, 0x1f), packed)
+            mstore(add(resultB, 0x1f), mload(add(add(resultA, 0x20), mload(resultA))))
+            // Right pad with zeroes.
+            mstore(add(add(resultA, 0x20), mload(resultA)), 0)
+            mstore(add(add(resultB, 0x20), mload(resultB)), 0)
+        }
+    }
+
+    /// @dev Directly returns `a` without copying.
+    function directReturn(string memory a) internal pure {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Assumes that the string does not start from the scratch space.
+            let retStart := sub(a, 0x20)
+            let retUnpaddedSize := add(mload(a), 0x40)
+            // Right pad with zeroes. Just in case the string is produced
+            // by a method that doesn't zero right pad.
+            mstore(add(retStart, retUnpaddedSize), 0)
+            mstore(retStart, 0x20) // Store the return offset.
+            // End the transaction, returning the string.
+            return(retStart, and(not(0x1f), add(0x1f, retUnpaddedSize)))
+        }
+    }
+}

--- a/crates/sdk/contracts/test/helpers/MockDeps.sol
+++ b/crates/sdk/contracts/test/helpers/MockDeps.sol
@@ -1,0 +1,12 @@
+interface IOpenVmHalo2Verifier {
+    function verify(bytes calldata publicValues, bytes calldata proofData, bytes32 appExeCommit, bytes32 appVmCommit)
+        external
+        view;
+}
+
+contract Halo2Verifier {
+    /// Mock verifier always reverts
+    fallback(bytes calldata) external returns (bytes memory) {
+        revert("Verification failed");
+    }
+}

--- a/crates/sdk/examples/sdk_evm.rs
+++ b/crates/sdk/examples/sdk_evm.rs
@@ -96,7 +96,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // 9. Generate the SNARK verifier smart contract
-    let verifier = sdk.generate_openvm_halo2_verifier_contract(&halo2_params_reader, &agg_pk)?;
+    let verifier = sdk.generate_halo2_verifier_solidity(&halo2_params_reader, &agg_pk)?;
 
     // 10. Generate an EVM proof
     let proof = sdk.generate_evm_proof(
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // 11. Verify the EVM proof
-    sdk.verify_openvm_halo2_proof(&verifier, &proof)?;
+    sdk.verify_evm_halo2_proof(&verifier, &proof)?;
     // ANCHOR_END: evm_verification
 
     Ok(())

--- a/crates/sdk/examples/sdk_evm.rs
+++ b/crates/sdk/examples/sdk_evm.rs
@@ -96,7 +96,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // 9. Generate the SNARK verifier smart contract
-    let verifier = sdk.generate_snark_verifier_contract(&halo2_params_reader, &agg_pk)?;
+    let verifier = sdk.generate_openvm_halo2_verifier_contract(&halo2_params_reader, &agg_pk)?;
 
     // 10. Generate an EVM proof
     let proof = sdk.generate_evm_proof(
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // 11. Verify the EVM proof
-    sdk.verify_evm_proof(&verifier, &proof)?;
+    sdk.verify_openvm_halo2_proof(&verifier, &proof)?;
     // ANCHOR_END: evm_verification
 
     Ok(())

--- a/crates/sdk/guest/src/main.rs
+++ b/crates/sdk/guest/src/main.rs
@@ -4,7 +4,7 @@
 openvm::entry!(main);
 
 pub fn main() {
-    let n = core::hint::black_box(1 << 10);
+    let n = core::hint::black_box(1 << 3);
     let mut a: u32 = 0;
     let mut b: u32 = 1;
     for _ in 1..n {
@@ -15,4 +15,7 @@ pub fn main() {
     if a == 0 {
         panic!();
     }
+
+    openvm::io::reveal_u32(a, 0);
+    openvm::io::reveal_u32(b, 1);
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,8 +1,17 @@
-use std::{fs::read, marker::PhantomData, path::Path, sync::Arc};
+use std::{
+    env,
+    fs::{create_dir_all, read, write},
+    marker::PhantomData,
+    path::Path,
+    process::Command,
+    sync::Arc,
+};
 
+use alloy_primitives::{Bytes, FixedBytes};
+use alloy_sol_types::{sol, SolCall, SolValue};
 use commit::commit_app_exe;
 use config::AppConfig;
-use eyre::Result;
+use eyre::{Context, Result};
 use keygen::{AppProvingKey, AppVerifyingKey};
 use openvm_build::{
     build_guest_package, find_unique_executable, get_package, GuestOptions, TargetFilter,
@@ -25,7 +34,7 @@ pub use openvm_continuations::{
 };
 use openvm_native_recursion::halo2::{
     utils::Halo2ParamsReader,
-    wrapper::{EvmVerifier, Halo2WrapperProvingKey},
+    wrapper::{EvmVerifier, EvmVerifierByteCode, Halo2WrapperProvingKey},
     RawEvmProof,
 };
 use openvm_stark_backend::proof::Proof;
@@ -40,11 +49,23 @@ use openvm_transpiler::{
     transpiler::{Transpiler, TranspilerError},
     FromElf,
 };
+use snark_verifier_sdk::{
+    evm::{evm_verify, gen_evm_verifier_sol_code},
+    halo2::aggregation::AggregationCircuit,
+    snark_verifier::halo2_base::halo2_proofs::poly::commitment::Params,
+    SHPLONK,
+};
+use tempfile::tempdir;
 
 use crate::{
     config::AggConfig,
+    fs::{
+        OPENVM_HALO2_VERIFIER_BASE_NAME, OPENVM_HALO2_VERIFIER_INTERFACE_NAME,
+        OPENVM_HALO2_VERIFIER_PARENT_NAME,
+    },
     keygen::{AggProvingKey, AggStarkProvingKey},
     prover::{AppProver, ContinuationProver, StarkProver},
+    types::{EvmProof, OpenVmEvmHalo2Verifier, NUM_BN254_ACCUMULATORS},
 };
 
 pub mod codec;
@@ -56,12 +77,20 @@ pub mod prover;
 mod stdin;
 pub use stdin::*;
 
-use crate::types::EvmProof;
-
 pub mod fs;
 pub mod types;
 
 pub type NonRootCommittedExe = VmCommittedExe<SC>;
+
+pub const OPENVM_HALO2_VERIFIER_INTERFACE: &str =
+    include_str!("../contracts/src/IOpenVmHalo2Verifier.sol");
+pub const OPENVM_HALO2_VERIFIER_TEMPLATE: &str =
+    include_str!("../contracts/template/OpenVmHalo2Verifier.sol");
+
+sol! {
+    IOpenVmHalo2Verifier,
+    concat!(env!("CARGO_MANIFEST_DIR"), "/contracts/abi/IOpenVmHalo2Verifier.json"),
+}
 
 /// The payload of a verified guest VM execution with user public values extracted and
 /// verified.
@@ -273,6 +302,152 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         Ok(evm_verifier)
     }
 
+    pub fn generate_openvm_halo2_verifier_contract(
+        &self,
+        reader: &impl Halo2ParamsReader,
+        agg_pk: &AggProvingKey,
+    ) -> Result<OpenVmEvmHalo2Verifier> {
+        let params = reader.read_params(agg_pk.halo2_pk.wrapper.pinning.metadata.config_params.k);
+        let pinning = &agg_pk.halo2_pk.wrapper.pinning;
+
+        assert_eq!(
+            pinning.metadata.config_params.k as u32,
+            params.k(),
+            "Provided params don't match circuit config"
+        );
+
+        let halo2_verifier_code = gen_evm_verifier_sol_code::<AggregationCircuit, SHPLONK>(
+            &params,
+            pinning.pk.get_vk(),
+            pinning.metadata.num_pvs.clone(),
+        );
+
+        let wrapper_pvs = agg_pk.halo2_pk.wrapper.pinning.metadata.num_pvs.clone();
+        let pvs_length = match wrapper_pvs.first() {
+            // We subtract 14 to exclude the KZG accumulators and the app exe
+            // and vm commits.
+            Some(v) => v
+                .checked_sub(14)
+                .expect("Unexpected number of static verifier wrapper public values"),
+            _ => panic!("Unexpected amount of instance columns in the static verifier wrapper"),
+        };
+
+        assert!(
+            pvs_length <= 8192,
+            "OpenVM Halo2 verifier contract does not support more than 8192 public values"
+        );
+
+        // Fill out the public values length and OpenVM version in the template
+        let openvm_verifier_code = OPENVM_HALO2_VERIFIER_TEMPLATE
+            .replace("{PUBLIC_VALUES_LENGTH}", &pvs_length.to_string())
+            .replace("{OPENVM_VERSION}", env!("CARGO_PKG_VERSION"));
+
+        // Create temp dir
+        let temp_dir = tempdir().wrap_err("Failed to create temp dir")?;
+        let temp_path = temp_dir.path();
+
+        // Make interfaces dir
+        let interfaces_path = temp_path.join("interfaces");
+        create_dir_all(&interfaces_path)?;
+
+        // Write the files to the temp dir. This is only for compilation
+        // purposes.
+        write(
+            interfaces_path.join(OPENVM_HALO2_VERIFIER_INTERFACE_NAME),
+            OPENVM_HALO2_VERIFIER_INTERFACE,
+        )?;
+        write(
+            temp_path.join(OPENVM_HALO2_VERIFIER_PARENT_NAME),
+            &halo2_verifier_code,
+        )?;
+        write(
+            temp_path.join(OPENVM_HALO2_VERIFIER_BASE_NAME),
+            &openvm_verifier_code,
+        )?;
+
+        // Run solc from the temp dir
+        let output = Command::new("solc")
+            .current_dir(temp_path)
+            .arg("OpenVmHalo2Verifier.sol")
+            .arg("--no-optimize-yul")
+            .arg("--bin")
+            .arg("--optimize")
+            .arg("--optimize-runs")
+            .arg("100000")
+            .output()?;
+
+        if !output.status.success() {
+            eyre::bail!(
+                "solc exited with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let bytecode = Self::extract_binary(
+            &output.stdout,
+            "OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier",
+        );
+
+        let evm_verifier = OpenVmEvmHalo2Verifier {
+            halo2_verifier_code,
+            openvm_verifier_code,
+            openvm_verifier_interface: OPENVM_HALO2_VERIFIER_INTERFACE.to_string(),
+            artifact: EvmVerifierByteCode {
+                sol_compiler_version: "0.8.19".to_string(),
+                sol_compiler_options: "--no-optimize-yul --bin --optimize --optimize-runs 100000"
+                    .to_string(),
+                bytecode,
+            },
+        };
+        Ok(evm_verifier)
+    }
+
+    /// We will split the output by whitespace and look for the following
+    /// sequence:
+    /// [
+    ///     ...
+    ///     "=======",
+    ///     "OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier",
+    ///     "=======",
+    ///     "Binary:"
+    ///     "[compiled bytecode]"
+    ///     ...
+    /// ]
+    ///
+    /// Once we find "OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier," we can skip
+    /// to the appropriate offset to get the compiled bytecode.
+    fn extract_binary(output: &[u8], contract_name: &str) -> Vec<u8> {
+        let split = Self::split_by_ascii_whitespace(output);
+        let contract_name_bytes = contract_name.as_bytes();
+
+        for i in 0..split.len().saturating_sub(3) {
+            if split[i] == contract_name_bytes {
+                return hex::decode(split[i + 3]).expect("Invalid hex in Binary");
+            }
+        }
+
+        panic!("Contract '{}' not found", contract_name);
+    }
+
+    fn split_by_ascii_whitespace(bytes: &[u8]) -> Vec<&[u8]> {
+        let mut split = Vec::new();
+        let mut start = None;
+        for (idx, byte) in bytes.iter().enumerate() {
+            if byte.is_ascii_whitespace() {
+                if let Some(start) = start.take() {
+                    split.push(&bytes[start..idx]);
+                }
+            } else if start.is_none() {
+                start = Some(idx);
+            }
+        }
+        if let Some(last) = start {
+            split.push(&bytes[last..]);
+        }
+        split
+    }
+
     pub fn verify_evm_proof(
         &self,
         evm_verifier: &EvmVerifier,
@@ -281,6 +456,83 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         let evm_proof: RawEvmProof = evm_proof.clone().try_into()?;
         let gas_cost = Halo2WrapperProvingKey::evm_verify(evm_verifier, &evm_proof)
             .map_err(|reason| eyre::eyre!("Sdk::verify_evm_proof: {reason:?}"))?;
+        Ok(gas_cost)
+    }
+
+    /// `OpenVmHalo2Verifier` wraps the `snark-verifer` contract, meaning that
+    /// the default `fallback` interface can still be used. This function uses
+    /// the fallback interface as opposed to the `verify(..)` interface.
+    pub fn verify_openvm_halo2_proof(
+        &self,
+        openvm_verifier: &OpenVmEvmHalo2Verifier,
+        evm_proof: &EvmProof,
+    ) -> Result<u64> {
+        let evm_proof: RawEvmProof = evm_proof.clone().try_into()?;
+        let gas_cost = evm_verify(
+            openvm_verifier.artifact.bytecode.clone(),
+            vec![evm_proof.instances.clone()],
+            evm_proof.proof.clone(),
+        )
+        .map_err(|reason| eyre::eyre!("Sdk::verify_openvm_evm_proof: {reason:?}"))?;
+        Ok(gas_cost)
+    }
+
+    /// Uses the `verify(..)` interface of the `OpenVmHalo2Verifier` contract.
+    pub fn verify_openvm_halo2_proof_with_wrapped_interface(
+        &self,
+        openvm_verifier: &OpenVmEvmHalo2Verifier,
+        evm_proof: &EvmProof,
+    ) -> Result<u64> {
+        let EvmProof {
+            accumulators,
+            proof,
+            user_public_values,
+            exe_commit,
+            leaf_commit,
+        } = evm_proof;
+        let mut exe_commit = *exe_commit;
+        let mut leaf_commit = *leaf_commit;
+        exe_commit.reverse();
+        leaf_commit.reverse();
+
+        assert_eq!(accumulators.len(), NUM_BN254_ACCUMULATORS * 32);
+        let mut evm_accumulators: Vec<u8> = Vec::with_capacity(accumulators.len());
+        accumulators
+            .chunks(32)
+            .for_each(|chunk| evm_accumulators.extend(chunk.iter().rev().cloned()));
+
+        let mut proof_data = evm_accumulators;
+        proof_data.extend(proof);
+
+        assert!(
+            user_public_values.len() % 32 == 0,
+            "User public values length must be a multiple of 32"
+        );
+
+        // Take the first byte of each 32 byte chunk, and pack them together
+        // into one payload.
+        let user_public_values: Bytes =
+            user_public_values
+                .chunks(32)
+                .fold(Vec::<u8>::new().into(), |acc: Bytes, chunk| {
+                    // We only care about the first byte, everything else should be 0-bytes
+                    (acc, FixedBytes::<1>::from(*chunk.first().unwrap()))
+                        .abi_encode_packed()
+                        .into()
+                });
+
+        let calldata = IOpenVmHalo2Verifier::verifyCall {
+            publicValues: user_public_values.clone(),
+            proofData: proof_data.into(),
+            appExeCommit: exe_commit.into(),
+            appVmCommit: leaf_commit.into(),
+        }
+        .abi_encode();
+        let deployment_code = openvm_verifier.artifact.bytecode.clone();
+
+        let gas_cost = snark_verifier::loader::evm::deploy_and_call(deployment_code, calldata)
+            .map_err(|reason| eyre::eyre!("Sdk::verify_openvm_evm_proof: {reason:?}"))?;
+
         Ok(gas_cost)
     }
 }

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -12,7 +12,7 @@ pub const NUM_BN254_ACCUMULATORS: usize = 12;
 const NUM_BN254_PROOF: usize = 43;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct OpenVmEvmHalo2Verifier {
+pub struct EvmHalo2Verifier {
     pub halo2_verifier_code: String,
     pub openvm_verifier_code: String,
     pub openvm_verifier_interface: String,

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use openvm_native_recursion::halo2::{Fr, RawEvmProof};
+use openvm_native_recursion::halo2::{wrapper::EvmVerifierByteCode, Fr, RawEvmProof};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
@@ -7,12 +7,20 @@ use thiserror::Error;
 /// Number of bytes in a Bn254Fr.
 const BN254_BYTES: usize = 32;
 /// Number of Bn254Fr in `accumulators` field.
-const NUM_BN254_ACCUMULATORS: usize = 12;
+pub const NUM_BN254_ACCUMULATORS: usize = 12;
 /// Number of Bn254Fr in `proof` field for a circuit with only 1 advice column.
 const NUM_BN254_PROOF: usize = 43;
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OpenVmEvmHalo2Verifier {
+    pub halo2_verifier_code: String,
+    pub openvm_verifier_code: String,
+    pub openvm_verifier_interface: String,
+    pub artifact: EvmVerifierByteCode,
+}
+
 #[serde_as]
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EvmProof {
     #[serde_as(as = "serde_with::hex::Hex")]
     /// Bn254Fr public values for accumulators in flatten little-endian bytes. Length is `NUM_BN254_ACCUMULATORS * BN254_BYTES`.

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -37,7 +37,6 @@ use openvm_sdk::{
     codec::{Decode, Encode},
     commit::AppExecutionCommit,
     config::{AggConfig, AggStarkConfig, AppConfig, Halo2Config, SdkSystemConfig, SdkVmConfig},
-    fs::{read_agg_pk_from_file, write_agg_pk_to_file},
     keygen::AppProvingKey,
     types::{EvmHalo2Verifier, EvmProof},
     DefaultStaticVerifierPvHandler, Sdk, StdIn,
@@ -392,8 +391,7 @@ fn test_static_verifier_custom_pv_handler() {
         .clone()
         .try_into()
         .expect("failed to convert evm proof");
-    Halo2WrapperProvingKey::evm_verify(&evm_verifier, &evm_proof)
-        .unwrap();
+    Halo2WrapperProvingKey::evm_verify(&evm_verifier, &evm_proof).unwrap();
 }
 
 #[test]
@@ -434,22 +432,13 @@ fn test_e2e_proof_generation_and_verification_with_pvs() {
     let app_pk = sdk.app_keygen(app_config).unwrap();
 
     let params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
-    let agg_pk = match read_agg_pk_from_file("./temp") {
-        Ok(agg_pk) => agg_pk,
-        Err(_) => {
-            let a = sdk
-                .agg_keygen(
-                    agg_config_for_test(),
-                    &params_reader,
-                    &DefaultStaticVerifierPvHandler,
-                )
-                .unwrap();
-
-            write_agg_pk_to_file(a.clone(), "./temp").expect("failed to write agg pk to file");
-
-            a
-        }
-    };
+    let agg_pk = sdk
+        .agg_keygen(
+            agg_config_for_test(),
+            &params_reader,
+            &DefaultStaticVerifierPvHandler,
+        )
+        .unwrap();
 
     let evm_verifier = sdk
         .generate_halo2_verifier_solidity(&params_reader, &agg_pk)
@@ -465,8 +454,7 @@ fn test_e2e_proof_generation_and_verification_with_pvs() {
         )
         .unwrap();
 
-    verify_evm_halo2_proof_with_fallback(&evm_verifier, &evm_proof)
-        .unwrap();
+    verify_evm_halo2_proof_with_fallback(&evm_verifier, &evm_proof).unwrap();
     sdk.verify_evm_halo2_proof(&evm_verifier, &evm_proof)
         .unwrap();
 }


### PR DESCRIPTION
This PR adds a new verifier contract generation that wraps the original `snark-verifier` output (via inheritance). The goal of this wrapper `OpenVmHalo2Verifier` is to expose a more friendly interface to users that cleanly separates out the guest program public values. `OpenVmHalo2Verifier` exposes the following interface:

```solidity
interface IOpenVmHalo2Verifier {
    function verify(bytes calldata publicValues, bytes calldata proofData, bytes32 appExeCommit, bytes32 appVmCommit)
        external
        view;
}
```

- `publicValues`: The bytes revealed in the OpenVM guest program packed together.
- `proofData`: Defined as `abi.encodePacked(KZG accumulators, publicValuesSuffix)`
- `appExeCommit`: The commitment to the OpenVM application executable whose execution is being verified.
- `appVmCommit`: The commitment to the VM configuration (aka `leaf_exe_commit`)

Once received, the proof is constructed into the format expected by `snark-verifier`. The expected format is `abi.encodePacked(proofData[0:0x180], appExeCommit, appVmExeCommit, publicValuesPayload, proofData[0x180:])` where `publicValuesPayload` is a memory payload with each byte in `publicValues` separated into its own `bytes32` word.

Since `OpenVmHalo2Verifier` inherits the `snark-verifier` output, the proof is forwarded via self-call.

## Verifier Generation

The smart contract is written as a template that does not compile in isolation. During generation, the OpenVM SDK will fill out the maximum amount of public values and the OpenVM version with which the generation happened.

Given an output folder, the relevant contracts are written into the following folder structure:

```
halo2/
├── interfaces/
│   └── IOpenVmHalo2Verifier.sol
├── OpenVmHalo2Verifier.sol
├── Halo2Verifier.sol
```

`cargo openvm setup` will now generate this output directly into the `~/.openvm/` dir.

Closes INT-3710