### PR TITLE
fix: use absolute paths in `VmConfig` derive macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ rustc-*
 # Bench metrics
 .bench_metrics/
 __pycache__/
+metrics.json
 
 # KZG trusted setup
 **/params

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,7 +4224,6 @@ dependencies = [
  "openvm-bigint-circuit",
  "openvm-build",
  "openvm-circuit",
- "openvm-circuit-primitives-derive",
  "openvm-ecc-guest",
  "openvm-instructions",
  "openvm-platform",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -66,3 +66,6 @@ harness = false
 
 [[bin]]
 name = "fib_e2e"
+
+[package.metadata.cargo-shear]
+ignored = ["derive_more"]

--- a/benchmarks/src/bin/ecrecover.rs
+++ b/benchmarks/src/bin/ecrecover.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use derive_more::derive::From;
 use eyre::Result;
 use k256::ecdsa::{SigningKey, VerifyingKey};
 use num_bigint::BigUint;
@@ -10,11 +9,10 @@ use openvm_algebra_transpiler::ModularTranspilerExtension;
 use openvm_benchmarks::utils::BenchmarkCli;
 use openvm_circuit::{
     arch::{
-        instructions::exe::VmExe, SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex,
-        VmConfig, VmInventoryError,
+        instructions::exe::VmExe, SystemConfig,
+        VmConfig,
     },
-    circuit_derive::{Chip, ChipUsageGetter},
-    derive::{AnyEnum, InstructionExecutor, VmConfig},
+    derive::VmConfig,
 };
 use openvm_ecc_circuit::{
     CurveConfig, WeierstrassExtension, WeierstrassExtensionExecutor, WeierstrassExtensionPeriphery,
@@ -30,7 +28,7 @@ use openvm_rv32im_circuit::{
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
-use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_sdk::{bench::run_with_metric_collection, p3_baby_bear::BabyBear};
 use openvm_transpiler::{transpiler::Transpiler, FromElf};
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};

--- a/benchmarks/src/bin/ecrecover.rs
+++ b/benchmarks/src/bin/ecrecover.rs
@@ -8,10 +8,7 @@ use openvm_algebra_circuit::{
 use openvm_algebra_transpiler::ModularTranspilerExtension;
 use openvm_benchmarks::utils::BenchmarkCli;
 use openvm_circuit::{
-    arch::{
-        instructions::exe::VmExe, SystemConfig,
-        VmConfig,
-    },
+    arch::{instructions::exe::VmExe, SystemConfig},
     derive::VmConfig,
 };
 use openvm_ecc_circuit::{

--- a/benchmarks/src/bin/ecrecover.rs
+++ b/benchmarks/src/bin/ecrecover.rs
@@ -25,7 +25,7 @@ use openvm_rv32im_circuit::{
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
-use openvm_stark_backend::p3_field::FieldAlgebra;
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::{bench::run_with_metric_collection, p3_baby_bear::BabyBear};
 use openvm_transpiler::{transpiler::Transpiler, FromElf};
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};

--- a/crates/toolchain/tests/Cargo.toml
+++ b/crates/toolchain/tests/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-openvm-circuit-primitives-derive.workspace = true
 openvm-stark-backend.workspace = true
 openvm-stark-sdk.workspace = true
 openvm-circuit = { workspace = true, features = ["test-utils"] }
@@ -35,3 +34,6 @@ num-bigint.workspace = true
 [features]
 default = ["parallel"]
 parallel = ["openvm-circuit/parallel"]
+
+[package.metadata.cargo-shear]
+ignored = ["derive_more", "openvm-stark-backend"]

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -3,7 +3,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use derive_more::derive::From;
 use eyre::Result;
 use num_bigint::BigUint;
 use openvm_algebra_circuit::{
@@ -14,13 +13,11 @@ use openvm_algebra_transpiler::{Fp2TranspilerExtension, ModularTranspilerExtensi
 use openvm_bigint_circuit::{Int256, Int256Executor, Int256Periphery};
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmExecutor,
-        VmInventoryError,
+        SystemConfig, VmConfig, VmExecutor,
     },
-    derive::{AnyEnum, InstructionExecutor, VmConfig},
+    derive::VmConfig,
     utils::air_test,
 };
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
 use openvm_ecc_guest::k256::{SECP256K1_MODULUS, SECP256K1_ORDER};
 use openvm_instructions::exe::VmExe;
 use openvm_platform::memory::MEM_SIZE;
@@ -31,7 +28,6 @@ use openvm_rv32im_circuit::{
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
-use openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use openvm_transpiler::{elf::Elf, transpiler::Transpiler, FromElf};
 use serde::{Deserialize, Serialize};

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -26,6 +26,7 @@ use openvm_rv32im_circuit::{
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
+use openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use openvm_transpiler::{elf::Elf, transpiler::Transpiler, FromElf};
 use serde::{Deserialize, Serialize};

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -12,9 +12,7 @@ use openvm_algebra_circuit::{
 use openvm_algebra_transpiler::{Fp2TranspilerExtension, ModularTranspilerExtension};
 use openvm_bigint_circuit::{Int256, Int256Executor, Int256Periphery};
 use openvm_circuit::{
-    arch::{
-        SystemConfig, VmConfig, VmExecutor,
-    },
+    arch::{SystemConfig, VmExecutor},
     derive::VmConfig,
     utils::air_test,
 };

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -347,14 +347,14 @@ pub fn vm_generic_config_derive(input: proc_macro::TokenStream) -> proc_macro::T
             let periphery_type = Ident::new(&format!("{}Periphery", name), name.span());
 
             TokenStream::from(quote! {
-                #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::openvm_circuit::derive::InstructionExecutor, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
+                #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::openvm_circuit::derive::InstructionExecutor, ::derive_more::derive::From, ::openvm_circuit::derive::AnyEnum)]
                 pub enum #executor_type<F: PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_executor_type<F>),
                     #(#executor_enum_fields)*
                 }
 
-                #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
+                #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::derive_more::derive::From, ::openvm_circuit::derive::AnyEnum)]
                 pub enum #periphery_type<F: PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_periphery_type<F>),

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -317,12 +317,15 @@ pub fn vm_generic_config_derive(input: proc_macro::TokenStream) -> proc_macro::T
                     #field_name_upper(#periphery_name<F>),
                 });
                 create_chip_complex.push(quote! {
-                    let complex: VmChipComplex<F, Self::Executor, Self::Periphery> = complex.extend(&self.#field_name)?;
+                    let complex: ::openvm_circuit::arch::VmChipComplex<F, Self::Executor, Self::Periphery> = complex.extend(&self.#field_name)?;
                 });
             }
 
             let (source_executor_type, source_periphery_type) = match &source {
-                Source::System(_) => (quote! { SystemExecutor }, quote! { SystemPeriphery }),
+                Source::System(_) => (
+                    quote! { ::openvm_circuit::arch::SystemExecutor },
+                    quote! { ::openvm_circuit::arch::SystemPeriphery },
+                ),
                 Source::Config(field_ident) => {
                     let field_type = fields
                         .iter()
@@ -344,34 +347,34 @@ pub fn vm_generic_config_derive(input: proc_macro::TokenStream) -> proc_macro::T
             let periphery_type = Ident::new(&format!("{}Periphery", name), name.span());
 
             TokenStream::from(quote! {
-                #[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum)]
-                pub enum #executor_type<F: PrimeField32> {
+                #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::openvm_circuit::derive::InstructionExecutor, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
+                pub enum #executor_type<F: ::openvm_stark_backend::p3_field::PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_executor_type<F>),
                     #(#executor_enum_fields)*
                 }
 
-                #[derive(ChipUsageGetter, Chip, From, AnyEnum)]
-                pub enum #periphery_type<F: PrimeField32> {
+                #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
+                pub enum #periphery_type<F: ::openvm_stark_backend::p3_field::PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_periphery_type<F>),
                     #(#periphery_enum_fields)*
                 }
 
-                impl<F: PrimeField32> VmConfig<F> for #name {
+                impl<F: ::openvm_stark_backend::p3_field::PrimeField32> ::openvm_circuit::arch::VmConfig<F> for #name {
                     type Executor = #executor_type<F>;
                     type Periphery = #periphery_type<F>;
 
-                    fn system(&self) -> &SystemConfig {
-                        VmConfig::<F>::system(&self.#source_name)
+                    fn system(&self) -> &::openvm_circuit::arch::SystemConfig {
+                        ::openvm_circuit::arch::VmConfig::<F>::system(&self.#source_name)
                     }
-                    fn system_mut(&mut self) -> &mut SystemConfig {
-                        VmConfig::<F>::system_mut(&mut self.#source_name)
+                    fn system_mut(&mut self) -> &mut ::openvm_circuit::arch::SystemConfig {
+                        ::openvm_circuit::arch::VmConfig::<F>::system_mut(&mut self.#source_name)
                     }
 
                     fn create_chip_complex(
                         &self,
-                    ) -> Result<VmChipComplex<F, Self::Executor, Self::Periphery>, VmInventoryError> {
+                    ) -> Result<::openvm_circuit::arch::VmChipComplex<F, Self::Executor, Self::Periphery>, ::openvm_circuit::arch::VmInventoryError> {
                         let complex = self.#source_name.create_chip_complex()?;
                         #(#create_chip_complex)*
                         Ok(complex)

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -348,20 +348,20 @@ pub fn vm_generic_config_derive(input: proc_macro::TokenStream) -> proc_macro::T
 
             TokenStream::from(quote! {
                 #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::openvm_circuit::derive::InstructionExecutor, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
-                pub enum #executor_type<F: ::openvm_stark_backend::p3_field::PrimeField32> {
+                pub enum #executor_type<F: ::openvm_circuit::openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_executor_type<F>),
                     #(#executor_enum_fields)*
                 }
 
                 #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
-                pub enum #periphery_type<F: ::openvm_stark_backend::p3_field::PrimeField32> {
+                pub enum #periphery_type<F: ::openvm_circuit::openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_periphery_type<F>),
                     #(#periphery_enum_fields)*
                 }
 
-                impl<F: ::openvm_stark_backend::p3_field::PrimeField32> ::openvm_circuit::arch::VmConfig<F> for #name {
+                impl<F: ::openvm_circuit::openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField32> ::openvm_circuit::arch::VmConfig<F> for #name {
                     type Executor = #executor_type<F>;
                     type Periphery = #periphery_type<F>;
 

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -348,20 +348,20 @@ pub fn vm_generic_config_derive(input: proc_macro::TokenStream) -> proc_macro::T
 
             TokenStream::from(quote! {
                 #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::openvm_circuit::derive::InstructionExecutor, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
-                pub enum #executor_type<F: ::openvm_circuit::openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField32> {
+                pub enum #executor_type<F: PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_executor_type<F>),
                     #(#executor_enum_fields)*
                 }
 
                 #[derive(::openvm_circuit::circuit_derive::ChipUsageGetter, ::openvm_circuit::circuit_derive::Chip, ::derive_more::From, ::openvm_circuit::derive::AnyEnum)]
-                pub enum #periphery_type<F: ::openvm_circuit::openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField32> {
+                pub enum #periphery_type<F: PrimeField32> {
                     #[any_enum]
                     #source_name_upper(#source_periphery_type<F>),
                     #(#periphery_enum_fields)*
                 }
 
-                impl<F: ::openvm_circuit::openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField32> ::openvm_circuit::arch::VmConfig<F> for #name {
+                impl<F: PrimeField32> ::openvm_circuit::arch::VmConfig<F> for #name {
                     type Executor = #executor_type<F>;
                     type Periphery = #periphery_type<F>;
 

--- a/extensions/algebra/circuit/src/config.rs
+++ b/extensions/algebra/circuit/src/config.rs
@@ -1,12 +1,9 @@
-use derive_more::derive::From;
 use num_bigint::BigUint;
 use openvm_circuit::arch::{
-    SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmInventoryError,
+    SystemConfig, VmConfig,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_derive::VmConfig;
 use openvm_rv32im_circuit::*;
-use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
 
 use super::*;

--- a/extensions/algebra/circuit/src/config.rs
+++ b/extensions/algebra/circuit/src/config.rs
@@ -1,7 +1,5 @@
 use num_bigint::BigUint;
-use openvm_circuit::arch::{
-    SystemConfig, VmConfig,
-};
+use openvm_circuit::arch::SystemConfig;
 use openvm_circuit_derive::VmConfig;
 use openvm_rv32im_circuit::*;
 use serde::{Deserialize, Serialize};

--- a/extensions/algebra/circuit/src/config.rs
+++ b/extensions/algebra/circuit/src/config.rs
@@ -2,6 +2,7 @@ use num_bigint::BigUint;
 use openvm_circuit::arch::SystemConfig;
 use openvm_circuit_derive::VmConfig;
 use openvm_rv32im_circuit::*;
+use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
 
 use super::*;

--- a/extensions/bigint/circuit/src/extension.rs
+++ b/extensions/bigint/circuit/src/extension.rs
@@ -5,7 +5,7 @@ use openvm_bigint_transpiler::{
 };
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemExecutor, SystemPeriphery, SystemPort, VmChipComplex, VmConfig,
+        SystemConfig, SystemPort, VmConfig,
         VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,

--- a/extensions/bigint/circuit/src/extension.rs
+++ b/extensions/bigint/circuit/src/extension.rs
@@ -5,8 +5,7 @@ use openvm_bigint_transpiler::{
 };
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemPort, VmConfig,
-        VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
+        SystemConfig, SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,
 };

--- a/extensions/ecc/circuit/src/config.rs
+++ b/extensions/ecc/circuit/src/config.rs
@@ -2,6 +2,7 @@ use openvm_algebra_circuit::*;
 use openvm_circuit::arch::SystemConfig;
 use openvm_circuit_derive::VmConfig;
 use openvm_rv32im_circuit::*;
+use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
 
 use super::*;

--- a/extensions/ecc/circuit/src/config.rs
+++ b/extensions/ecc/circuit/src/config.rs
@@ -1,7 +1,5 @@
 use openvm_algebra_circuit::*;
-use openvm_circuit::arch::{
-    SystemConfig, VmConfig,
-};
+use openvm_circuit::arch::SystemConfig;
 use openvm_circuit_derive::VmConfig;
 use openvm_rv32im_circuit::*;
 use serde::{Deserialize, Serialize};

--- a/extensions/ecc/circuit/src/config.rs
+++ b/extensions/ecc/circuit/src/config.rs
@@ -1,12 +1,9 @@
-use derive_more::derive::From;
 use openvm_algebra_circuit::*;
 use openvm_circuit::arch::{
-    SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmInventoryError,
+    SystemConfig, VmConfig,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_derive::VmConfig;
 use openvm_rv32im_circuit::*;
-use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
 
 use super::*;

--- a/extensions/keccak256/circuit/src/extension.rs
+++ b/extensions/keccak256/circuit/src/extension.rs
@@ -1,8 +1,7 @@
 use derive_more::derive::From;
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemPort, VmConfig,
-        VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
+        SystemConfig, SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,
 };

--- a/extensions/keccak256/circuit/src/extension.rs
+++ b/extensions/keccak256/circuit/src/extension.rs
@@ -1,7 +1,7 @@
 use derive_more::derive::From;
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemExecutor, SystemPeriphery, SystemPort, VmChipComplex, VmConfig,
+        SystemConfig, SystemPort, VmConfig,
         VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -6,8 +6,7 @@ use loadstore_native_adapter::NativeLoadStoreAdapterChip;
 use native_vectorized_adapter::NativeVectorizedAdapterChip;
 use openvm_circuit::{
     arch::{
-        ExecutionBridge, MemoryConfig, SystemConfig, SystemExecutor, SystemPeriphery, SystemPort,
-        VmChipComplex, VmConfig, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
+        ExecutionBridge, MemoryConfig, SystemConfig, SystemPort, VmConfig, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,
 };

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -6,7 +6,8 @@ use loadstore_native_adapter::NativeLoadStoreAdapterChip;
 use native_vectorized_adapter::NativeVectorizedAdapterChip;
 use openvm_circuit::{
     arch::{
-        ExecutionBridge, MemoryConfig, SystemConfig, SystemPort, VmConfig, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
+        ExecutionBridge, MemoryConfig, SystemConfig, SystemPort, VmExtension, VmInventory,
+        VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,
 };

--- a/extensions/pairing/circuit/src/config.rs
+++ b/extensions/pairing/circuit/src/config.rs
@@ -1,7 +1,5 @@
 use openvm_algebra_circuit::*;
-use openvm_circuit::arch::{
-    SystemConfig, VmConfig,
-};
+use openvm_circuit::arch::SystemConfig;
 use openvm_circuit_derive::VmConfig;
 use openvm_ecc_circuit::*;
 use openvm_rv32im_circuit::*;

--- a/extensions/pairing/circuit/src/config.rs
+++ b/extensions/pairing/circuit/src/config.rs
@@ -1,13 +1,10 @@
-use derive_more::derive::From;
 use openvm_algebra_circuit::*;
 use openvm_circuit::arch::{
-    SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmInventoryError,
+    SystemConfig, VmConfig,
 };
-use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};
-use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
+use openvm_circuit_derive::VmConfig;
 use openvm_ecc_circuit::*;
 use openvm_rv32im_circuit::*;
-use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
 
 use super::*;

--- a/extensions/pairing/circuit/src/config.rs
+++ b/extensions/pairing/circuit/src/config.rs
@@ -3,6 +3,7 @@ use openvm_circuit::arch::SystemConfig;
 use openvm_circuit_derive::VmConfig;
 use openvm_ecc_circuit::*;
 use openvm_rv32im_circuit::*;
+use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
 
 use super::*;

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -1,8 +1,7 @@
 use derive_more::derive::From;
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemPort, VmConfig,
-        VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
+        SystemConfig, SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,
 };

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -1,7 +1,7 @@
 use derive_more::derive::From;
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemExecutor, SystemPeriphery, SystemPort, VmChipComplex, VmConfig,
+        SystemConfig, SystemPort, VmConfig,
         VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,

--- a/extensions/sha256/circuit/src/extension.rs
+++ b/extensions/sha256/circuit/src/extension.rs
@@ -1,7 +1,7 @@
 use derive_more::derive::From;
 use openvm_circuit::{
     arch::{
-        SystemConfig, SystemExecutor, SystemPeriphery, VmChipComplex, VmConfig, VmExtension,
+        SystemConfig, VmConfig, VmExtension,
         VmInventory, VmInventoryBuilder, VmInventoryError,
     },
     system::phantom::PhantomChip,

--- a/extensions/sha256/circuit/src/extension.rs
+++ b/extensions/sha256/circuit/src/extension.rs
@@ -1,9 +1,6 @@
 use derive_more::derive::From;
 use openvm_circuit::{
-    arch::{
-        SystemConfig, VmConfig, VmExtension,
-        VmInventory, VmInventoryBuilder, VmInventoryError,
-    },
+    arch::{SystemConfig, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},
     system::phantom::PhantomChip,
 };
 use openvm_circuit_derive::{AnyEnum, InstructionExecutor, VmConfig};


### PR DESCRIPTION
- use absolute paths for structs used only in the derive macro