### PR TITLE
fix: Update Mod Builder symbolic expression multiplication test

### DIFF
--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -9,6 +9,7 @@ on:
       - "crates/circuits/primitives/**"
       - "crates/circuits/poseidon2-air/**"
       - "crates/circuits/sha256-air/**"
+      - "crates/circuits/mod-builder/**"
       - "Cargo.toml"
 
 concurrency:
@@ -47,5 +48,10 @@ jobs:
 
       - name: Run tests for sha256-air
         working-directory: crates/circuits/sha256-air
+        run: |
+          cargo nextest run --cargo-profile fast --features parallel
+
+      - name: Run tests for mod-builder
+        working-directory: crates/circuits/mod-builder
         run: |
           cargo nextest run --cargo-profile fast --features parallel

--- a/crates/circuits/mod-builder/src/tests.rs
+++ b/crates/circuits/mod-builder/src/tests.rs
@@ -387,9 +387,9 @@ fn test_symbolic_limbs_mul() {
         Box::new(SymbolicExpr::Var(0)),
         Box::new(SymbolicExpr::Var(1)),
     );
-    // x * y = pq, q can be up to p so can limbs as p.
-    // x * y and p * q  both have 63 limbs.
-    let expected_q = 32;
-    let expected_carry = 63;
+    // x * y = pq, and x,y can be up to 2^256 - 1 so q can be up to ceil((2^256 - 1)^2 / p) which has 257 bits, which is 33 limbs
+    // x * y has 63 limbs, but p * q can have 64 limbs since q is 33 limbs
+    let expected_q = 33;
+    let expected_carry = 64;
     test_symbolic_limbs(expr, expected_q, expected_carry);
 }


### PR DESCRIPTION
The symbolic expression multiplication unit test was being run with an incorrect expected result. The test became out-of-date after #1473 changed the `max_abs` method.

This PR updates the test with the correct expected result and adds the Mod Builder crate's unit tests to the CI workflow.

This change has no impact on the functionality of the Mod Builder crate as it only updates the tests.