### PR TITLE
fix: circuit flamegraphs with segmentation

### DIFF
--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -178,6 +178,12 @@ where
         );
         let pc = exe.pc_start;
         let mut state = VmExecutorNextSegmentState::new(memory, input, pc);
+
+        #[cfg(feature = "bench-metrics")]
+        {
+            state.metrics.fn_bounds = exe.fn_bounds.clone();
+        }
+
         let mut segment_idx = 0;
 
         loop {


### PR DESCRIPTION
The circuit flamegraphs being generated were incorrect due to a bug in the multi-segment execution logic. In particular, each segment takes the metric data from the previous segment, but the first segment was using an empty metrics struct instead of being initialized with the correct `fn_bounds` data.