### PR TITLE
chore: feature gate `revm` and `alloy` imports

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # list of features generated using:
           # echo -e "\033[1;32mAll unique features across workspace:\033[0m" && cargo metadata --format-version=1 --no-deps | jq -r '.packages[].features | to_entries[] | .key' | sort -u | sed 's/^/• /'
-          cargo clippy --all-targets --all --tests --features "aggregation bench-metrics bls12_381 bn254 default entrypoint export-getrandom export-libm function-span getrandom halo2-compiler halo2curves heap-embedded-alloc k256 mimalloc nightly-features panic-handler parallel rust-runtime static-verifier std test-utils unstable" -- -D warnings
+          cargo clippy --all-targets --all --tests --features "aggregation bench-metrics bls12_381 bn254 default entrypoint evm-prove evm-verify export-getrandom export-libm function-span getrandom halo2-compiler halo2curves heap-embedded-alloc k256 mimalloc nightly-features panic-handler parallel rust-runtime static-verifier std test-utils unstable" -- -D warnings
           cargo clippy --all-targets --all --tests --no-default-features --features "jemalloc jemalloc-prof" -- -D warnings
 
       - name: Run fmt, clippy for guest

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -45,8 +45,8 @@ jobs:
         run: |
           # list of features generated using:
           # echo -e "\033[1;32mAll unique features across workspace:\033[0m" && cargo metadata --format-version=1 --no-deps | jq -r '.packages[].features | to_entries[] | .key' | sort -u | sed 's/^/• /'
-          cargo clippy --all-targets --all --tests --features "aggregation bench-metrics bls12_381 bn254 default entrypoint evm-prove evm-verify export-getrandom export-libm function-span getrandom halo2-compiler halo2curves heap-embedded-alloc k256 mimalloc nightly-features panic-handler parallel rust-runtime static-verifier std test-utils unstable" -- -D warnings
-          cargo clippy --all-targets --all --tests --no-default-features --features "jemalloc jemalloc-prof" -- -D warnings
+          cargo clippy --all-targets --all --tests --features "aggregation bench-metrics bls12_381 bn254 default entrypoint evm-prove evm-verify export-getrandom export-libm function-span getrandom halo2-compiler halo2curves heap-embedded-alloc k256 jemalloc jemalloc-prof nightly-features panic-handler parallel rust-runtime static-verifier std test-utils unstable" -- -D warnings
+          cargo clippy --all-targets --all --tests --no-default-features --features "mimalloc" -- -D warnings
 
       - name: Run fmt, clippy for guest
         run: |

--- a/benchmarks/execute/Cargo.toml
+++ b/benchmarks/execute/Cargo.toml
@@ -30,9 +30,8 @@ tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
-default = ["mimalloc"]
+default = ["jemalloc"]
 profiling = ["openvm-sdk/profiling"]
-aggregation = []
 mimalloc = ["openvm-circuit/mimalloc"]
 jemalloc = ["openvm-circuit/jemalloc"]
 jemalloc-prof = ["openvm-circuit/jemalloc-prof"]

--- a/benchmarks/prove/Cargo.toml
+++ b/benchmarks/prove/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 openvm-benchmarks-utils.workspace = true
 openvm-circuit.workspace = true
-openvm-sdk.workspace = true
+openvm-sdk = { workspace = true, features = ["evm-verify"] }
 openvm-stark-backend.workspace = true
 openvm-stark-sdk.workspace = true
 openvm-transpiler.workspace = true
@@ -43,11 +43,10 @@ tracing.workspace = true
 [dev-dependencies]
 
 [features]
-default = ["parallel", "mimalloc", "bench-metrics"]
+default = ["parallel", "jemalloc", "bench-metrics"]
 bench-metrics = ["openvm-native-recursion/bench-metrics"]
 profiling = ["openvm-sdk/profiling"]
 aggregation = []
-static-verifier = ["openvm-native-recursion/static-verifier"]
 parallel = ["openvm-native-recursion/parallel"]
 mimalloc = ["openvm-circuit/mimalloc"]
 jemalloc = ["openvm-circuit/jemalloc"]

--- a/benchmarks/prove/src/bin/fib_e2e.rs
+++ b/benchmarks/prove/src/bin/fib_e2e.rs
@@ -10,7 +10,7 @@ use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
 use openvm_sdk::{
-    commit::commit_app_exe, prover::ContinuationProver, DefaultStaticVerifierPvHandler, Sdk, StdIn,
+    commit::commit_app_exe, prover::EvmHalo2Prover, DefaultStaticVerifierPvHandler, Sdk, StdIn,
 };
 use openvm_stark_sdk::{
     bench::run_with_metric_collection, config::baby_bear_poseidon2::BabyBearPoseidon2Engine,
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
     let mut stdin = StdIn::default();
     stdin.write(&n);
     run_with_metric_collection("OUTPUT_PATH", || {
-        let mut e2e_prover = ContinuationProver::<_, BabyBearPoseidon2Engine>::new(
+        let mut e2e_prover = EvmHalo2Prover::<_, BabyBearPoseidon2Engine>::new(
             &halo2_params_reader,
             app_pk,
             app_committed_exe,

--- a/benchmarks/prove/src/bin/kitchen_sink.rs
+++ b/benchmarks/prove/src/bin/kitchen_sink.rs
@@ -10,7 +10,7 @@ use openvm_ecc_circuit::{WeierstrassExtension, P256_CONFIG, SECP256K1_CONFIG};
 use openvm_native_recursion::halo2::utils::{CacheHalo2ParamsReader, DEFAULT_PARAMS_DIR};
 use openvm_pairing_circuit::{PairingCurve, PairingExtension};
 use openvm_sdk::{
-    commit::commit_app_exe, config::SdkVmConfig, prover::ContinuationProver,
+    commit::commit_app_exe, config::SdkVmConfig, prover::EvmHalo2Prover,
     DefaultStaticVerifierPvHandler, Sdk, StdIn,
 };
 use openvm_stark_sdk::{
@@ -80,7 +80,7 @@ fn main() -> Result<()> {
     )?;
 
     run_with_metric_collection("OUTPUT_PATH", || -> Result<()> {
-        let mut prover = ContinuationProver::<_, BabyBearPoseidon2Engine>::new(
+        let mut prover = EvmHalo2Prover::<_, BabyBearPoseidon2Engine>::new(
             &halo2_params_reader,
             app_pk,
             app_committed_exe,

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,7 @@ vergen = { version = "8", default-features = false, features = [
 [dependencies]
 openvm-build = { workspace = true }
 openvm-transpiler = { workspace = true }
-openvm-native-recursion = { workspace = true, features = ["static-verifier"] }
+openvm-native-recursion = { workspace = true }
 openvm-sdk = { workspace = true }
 openvm-stark-sdk.workspace = true
 openvm-stark-backend.workspace = true
@@ -39,5 +39,16 @@ toml = { workspace = true }
 bitcode.workspace = true
 
 [features]
-default = []
+default = ["parallel", "jemalloc", "evm-verify", "bench-metrics"]
+evm-prove = ["openvm-sdk/evm-prove"]
+evm-verify = ["evm-prove", "openvm-sdk/evm-verify"]
 bench-metrics = ["openvm-sdk/bench-metrics"]
+# for guest profiling:
+profiling = ["openvm-sdk/profiling"]
+# performance features:
+# (rayon is always imported because of halo2, so "parallel" feature is redundant)
+parallel = ["openvm-sdk/parallel"]
+mimalloc = ["openvm-sdk/mimalloc"]
+jemalloc = ["openvm-sdk/jemalloc"]
+jemalloc-prof = ["openvm-sdk/jemalloc-prof"]
+nightly-features = ["openvm-sdk/nightly-features"]

--- a/crates/cli/src/bin/cargo-openvm.rs
+++ b/crates/cli/src/bin/cargo-openvm.rs
@@ -1,7 +1,4 @@
-use cargo_openvm::{
-    commands::{BuildCmd, EvmProvingSetupCmd, KeygenCmd, ProveCmd, RunCmd, VerifyCmd},
-    OPENVM_VERSION_MESSAGE,
-};
+use cargo_openvm::{commands::*, OPENVM_VERSION_MESSAGE};
 use clap::{Parser, Subcommand};
 use eyre::Result;
 use openvm_stark_sdk::config::setup_tracing_with_log_level;
@@ -27,6 +24,7 @@ pub enum VmCliCommands {
     Keygen(KeygenCmd),
     Prove(ProveCmd),
     Run(RunCmd),
+    #[cfg(feature = "evm-verify")]
     Setup(EvmProvingSetupCmd),
     Verify(VerifyCmd),
 }
@@ -41,6 +39,7 @@ async fn main() -> Result<()> {
         VmCliCommands::Run(cmd) => cmd.run(),
         VmCliCommands::Keygen(cmd) => cmd.run(),
         VmCliCommands::Prove(cmd) => cmd.run(),
+        #[cfg(feature = "evm-verify")]
         VmCliCommands::Setup(cmd) => cmd.run().await,
         VmCliCommands::Verify(cmd) => cmd.run(),
     }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -10,7 +10,9 @@ pub use prove::*;
 mod run;
 pub use run::*;
 
+#[cfg(feature = "evm-verify")]
 mod setup;
+#[cfg(feature = "evm-verify")]
 pub use setup::*;
 
 mod verify;

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-
 p3-fri = { workspace = true }
 openvm-algebra-circuit = { workspace = true }
 openvm-algebra-transpiler = { workspace = true }
@@ -35,8 +34,8 @@ openvm-circuit = { workspace = true }
 openvm-continuations = { workspace = true }
 openvm = { workspace = true }
 
-alloy-primitives = { workspace = true }
-alloy-sol-types = { workspace = true, features = ["json"] }
+alloy-primitives = { workspace = true, optional = true }
+alloy-sol-types = { workspace = true, optional = true, features = ["json"] }
 bitcode = { workspace = true }
 bon = { workspace = true }
 derivative = { workspace = true }
@@ -58,12 +57,26 @@ tempfile.workspace = true
 hex.workspace = true
 
 [features]
-default = ["parallel"]
+default = ["parallel", "jemalloc", "evm-verify"]
+evm-prove = ["openvm-native-recursion/evm-prove"]
+evm-verify = [
+    "evm-prove",
+    "openvm-native-recursion/evm-verify",
+    "dep:alloy-primitives",
+    "dep:alloy-sol-types",
+]
 bench-metrics = [
     "openvm-circuit/bench-metrics",
     "openvm-native-recursion/bench-metrics",
     "openvm-native-compiler/bench-metrics",
 ]
+# for guest profiling:
 profiling = ["openvm-circuit/function-span", "openvm-transpiler/function-span"]
-parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils"]
+# performance features:
+# (rayon is always imported because of halo2, so "parallel" feature is redundant)
+parallel = ["openvm-circuit/parallel"]
+mimalloc = ["openvm-circuit/mimalloc"]
+jemalloc = ["openvm-circuit/jemalloc"]
+jemalloc-prof = ["openvm-circuit/jemalloc-prof"]
+nightly-features = ["openvm-circuit/nightly-features"]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,18 +1,10 @@
-use std::{
-    env,
-    fs::{create_dir_all, read, write},
-    marker::PhantomData,
-    path::Path,
-    process::Command,
-    sync::Arc,
-};
+use std::{fs::read, marker::PhantomData, path::Path, sync::Arc};
 
+#[cfg(feature = "evm-verify")]
 use alloy_primitives::{Bytes, FixedBytes};
+#[cfg(feature = "evm-verify")]
 use alloy_sol_types::{sol, SolCall, SolValue};
-use commit::commit_app_exe;
-use config::{AggregationTreeConfig, AppConfig};
-use eyre::{Context, Result};
-use keygen::{AppProvingKey, AppVerifyingKey};
+use eyre::Result;
 use openvm_build::{
     build_guest_package, find_unique_executable, get_package, GuestOptions, TargetFilter,
 };
@@ -32,7 +24,7 @@ pub use openvm_continuations::{
     static_verifier::{DefaultStaticVerifierPvHandler, StaticVerifierPvHandler},
     RootSC, C, F, SC,
 };
-use openvm_native_recursion::halo2::{utils::Halo2ParamsReader, wrapper::EvmVerifierByteCode};
+use openvm_native_recursion::halo2::utils::Halo2ParamsReader;
 use openvm_stark_backend::proof::Proof;
 use openvm_stark_sdk::{
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},
@@ -45,22 +37,17 @@ use openvm_transpiler::{
     transpiler::{Transpiler, TranspilerError},
     FromElf,
 };
-use snark_verifier_sdk::{
-    evm::gen_evm_verifier_sol_code, halo2::aggregation::AggregationCircuit,
-    snark_verifier::halo2_base::halo2_proofs::poly::commitment::Params, SHPLONK,
-};
-use tempfile::tempdir;
+#[cfg(feature = "evm-verify")]
+use snark_verifier_sdk::{evm::gen_evm_verifier_sol_code, halo2::aggregation::AggregationCircuit};
 
 use crate::{
-    config::AggConfig,
-    fs::{
-        EVM_HALO2_VERIFIER_BASE_NAME, EVM_HALO2_VERIFIER_INTERFACE_NAME,
-        EVM_HALO2_VERIFIER_PARENT_NAME,
-    },
-    keygen::{AggProvingKey, AggStarkProvingKey},
-    prover::{AppProver, ContinuationProver, StarkProver},
-    types::{EvmHalo2Verifier, EvmProof, NUM_BN254_ACCUMULATORS},
+    commit::commit_app_exe,
+    config::{AggConfig, AggregationTreeConfig, AppConfig},
+    keygen::{AggProvingKey, AggStarkProvingKey, AppProvingKey, AppVerifyingKey},
+    prover::{AppProver, StarkProver},
 };
+#[cfg(feature = "evm-prove")]
+use crate::{prover::ContinuationProver, types::EvmProof};
 
 pub mod codec;
 pub mod commit;
@@ -81,6 +68,7 @@ pub const EVM_HALO2_VERIFIER_INTERFACE: &str =
 pub const EVM_HALO2_VERIFIER_TEMPLATE: &str =
     include_str!("../contracts/template/OpenVmHalo2Verifier.sol");
 
+#[cfg(feature = "evm-verify")]
 sol! {
     IOpenVmHalo2Verifier,
     concat!(env!("CARGO_MANIFEST_DIR"), "/contracts/abi/IOpenVmHalo2Verifier.json"),
@@ -280,6 +268,7 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         Ok(proof)
     }
 
+    #[cfg(feature = "evm-prove")]
     pub fn generate_evm_proof<VC: VmConfig<F>>(
         &self,
         reader: &impl Halo2ParamsReader,
@@ -298,11 +287,29 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         Ok(proof)
     }
 
+    #[cfg(feature = "evm-verify")]
     pub fn generate_halo2_verifier_solidity(
         &self,
         reader: &impl Halo2ParamsReader,
         agg_pk: &AggProvingKey,
-    ) -> Result<EvmHalo2Verifier> {
+    ) -> Result<types::EvmHalo2Verifier> {
+        use std::{
+            fs::{create_dir_all, write},
+            process::Command,
+        };
+
+        use eyre::Context;
+        use openvm_native_recursion::halo2::wrapper::EvmVerifierByteCode;
+        use snark_verifier::halo2_base::halo2_proofs::poly::commitment::Params;
+        use snark_verifier_sdk::SHPLONK;
+        use tempfile::tempdir;
+        use types::EvmHalo2Verifier;
+
+        use crate::fs::{
+            EVM_HALO2_VERIFIER_BASE_NAME, EVM_HALO2_VERIFIER_INTERFACE_NAME,
+            EVM_HALO2_VERIFIER_PARENT_NAME,
+        };
+
         let params = reader.read_params(agg_pk.halo2_pk.wrapper.pinning.metadata.config_params.k);
         let pinning = &agg_pk.halo2_pk.wrapper.pinning;
 
@@ -399,12 +406,15 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         Ok(evm_verifier)
     }
 
+    #[cfg(feature = "evm-verify")]
     /// Uses the `verify(..)` interface of the `OpenVmHalo2Verifier` contract.
     pub fn verify_evm_halo2_proof(
         &self,
-        openvm_verifier: &EvmHalo2Verifier,
+        openvm_verifier: &types::EvmHalo2Verifier,
         evm_proof: &EvmProof,
     ) -> Result<u64> {
+        use crate::types::NUM_BN254_ACCUMULATORS;
+
         let EvmProof {
             accumulators,
             proof,
@@ -473,6 +483,7 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
 ///
 /// Once we find "OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier," we can skip
 /// to the appropriate offset to get the compiled bytecode.
+#[cfg(feature = "evm-verify")]
 fn extract_binary(output: &[u8], contract_name: &str) -> Vec<u8> {
     let split = split_by_ascii_whitespace(output);
     let contract_name_bytes = contract_name.as_bytes();
@@ -486,6 +497,7 @@ fn extract_binary(output: &[u8], contract_name: &str) -> Vec<u8> {
     panic!("Contract '{}' not found", contract_name);
 }
 
+#[cfg(feature = "evm-verify")]
 fn split_by_ascii_whitespace(bytes: &[u8]) -> Vec<&[u8]> {
     let mut split = Vec::new();
     let mut start = None;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -47,7 +47,7 @@ use crate::{
     prover::{AppProver, StarkProver},
 };
 #[cfg(feature = "evm-prove")]
-use crate::{prover::ContinuationProver, types::EvmProof};
+use crate::{prover::EvmHalo2Prover, types::EvmProof};
 
 pub mod codec;
 pub mod commit;
@@ -282,7 +282,7 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         VC::Periphery: Chip<SC>,
     {
         let e2e_prover =
-            ContinuationProver::<VC, E>::new(reader, app_pk, app_exe, agg_pk, self.agg_tree_config);
+            EvmHalo2Prover::<VC, E>::new(reader, app_pk, app_exe, agg_pk, self.agg_tree_config);
         let proof = e2e_prover.generate_proof_for_evm(inputs);
         Ok(proof)
     }

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -7,16 +7,16 @@ mod stark;
 pub mod vm;
 
 pub use agg::*;
-#[cfg(feature = "evm-prove")]
-pub use api::*;
 pub use app::*;
+#[cfg(feature = "evm-prove")]
+pub use evm::*;
 #[cfg(feature = "evm-prove")]
 pub use halo2::*;
 pub use root::*;
 pub use stark::*;
 
 #[cfg(feature = "evm-prove")]
-mod api {
+mod evm {
     use std::sync::Arc;
 
     use openvm_circuit::arch::VmConfig;
@@ -32,12 +32,12 @@ mod api {
         NonRootCommittedExe, F, SC,
     };
 
-    pub struct ContinuationProver<VC, E: StarkFriEngine<SC>> {
-        stark_prover: StarkProver<VC, E>,
-        halo2_prover: Halo2Prover,
+    pub struct EvmHalo2Prover<VC, E: StarkFriEngine<SC>> {
+        pub stark_prover: StarkProver<VC, E>,
+        pub halo2_prover: Halo2Prover,
     }
 
-    impl<VC, E: StarkFriEngine<SC>> ContinuationProver<VC, E> {
+    impl<VC, E: StarkFriEngine<SC>> EvmHalo2Prover<VC, E> {
         pub fn new(
             reader: &impl Halo2ParamsReader,
             app_pk: Arc<AppProvingKey<VC>>,

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -32,13 +32,11 @@ mod api {
         NonRootCommittedExe, F, SC,
     };
 
-    #[cfg(feature = "evm-prove")]
     pub struct ContinuationProver<VC, E: StarkFriEngine<SC>> {
         stark_prover: StarkProver<VC, E>,
         halo2_prover: Halo2Prover,
     }
 
-    #[cfg(feature = "evm-prove")]
     impl<VC, E: StarkFriEngine<SC>> ContinuationProver<VC, E> {
         pub fn new(
             reader: &impl Halo2ParamsReader,

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -1,71 +1,80 @@
-use std::sync::Arc;
-
-use openvm_circuit::arch::VmConfig;
-use openvm_stark_sdk::{engine::StarkFriEngine, openvm_stark_backend::Chip};
-
-use crate::{
-    config::AggregationTreeConfig, keygen::AppProvingKey, stdin::StdIn, NonRootCommittedExe, F, SC,
-};
-
 mod agg;
-pub use agg::*;
 mod app;
-pub use app::*;
-use openvm_native_recursion::halo2::utils::Halo2ParamsReader;
-
+#[cfg(feature = "evm-prove")]
 mod halo2;
-#[allow(unused_imports)]
-pub use halo2::*;
 mod root;
-pub use root::*;
 mod stark;
 pub mod vm;
 
-#[allow(unused_imports)]
+pub use agg::*;
+#[cfg(feature = "evm-prove")]
+pub use api::*;
+pub use app::*;
+#[cfg(feature = "evm-prove")]
+pub use halo2::*;
+pub use root::*;
 pub use stark::*;
 
-use crate::{keygen::AggProvingKey, prover::halo2::Halo2Prover, types::EvmProof};
+#[cfg(feature = "evm-prove")]
+mod api {
+    use std::sync::Arc;
 
-pub struct ContinuationProver<VC, E: StarkFriEngine<SC>> {
-    pub stark_prover: StarkProver<VC, E>,
-    pub halo2_prover: Halo2Prover,
-}
+    use openvm_circuit::arch::VmConfig;
+    use openvm_native_recursion::halo2::utils::Halo2ParamsReader;
+    use openvm_stark_sdk::{engine::StarkFriEngine, openvm_stark_backend::Chip};
 
-impl<VC, E: StarkFriEngine<SC>> ContinuationProver<VC, E> {
-    pub fn new(
-        reader: &impl Halo2ParamsReader,
-        app_pk: Arc<AppProvingKey<VC>>,
-        app_committed_exe: Arc<NonRootCommittedExe>,
-        agg_pk: AggProvingKey,
-        agg_tree_config: AggregationTreeConfig,
-    ) -> Self
-    where
-        VC: VmConfig<F>,
-    {
-        let AggProvingKey {
-            agg_stark_pk,
-            halo2_pk,
-        } = agg_pk;
-        let stark_prover =
-            StarkProver::new(app_pk, app_committed_exe, agg_stark_pk, agg_tree_config);
-        Self {
-            stark_prover,
-            halo2_prover: Halo2Prover::new(reader, halo2_pk),
+    use super::{Halo2Prover, StarkProver};
+    use crate::{
+        config::AggregationTreeConfig,
+        keygen::{AggProvingKey, AppProvingKey},
+        stdin::StdIn,
+        types::EvmProof,
+        NonRootCommittedExe, F, SC,
+    };
+
+    #[cfg(feature = "evm-prove")]
+    pub struct ContinuationProver<VC, E: StarkFriEngine<SC>> {
+        stark_prover: StarkProver<VC, E>,
+        halo2_prover: Halo2Prover,
+    }
+
+    #[cfg(feature = "evm-prove")]
+    impl<VC, E: StarkFriEngine<SC>> ContinuationProver<VC, E> {
+        pub fn new(
+            reader: &impl Halo2ParamsReader,
+            app_pk: Arc<AppProvingKey<VC>>,
+            app_committed_exe: Arc<NonRootCommittedExe>,
+            agg_pk: AggProvingKey,
+            agg_tree_config: AggregationTreeConfig,
+        ) -> Self
+        where
+            VC: VmConfig<F>,
+        {
+            let AggProvingKey {
+                agg_stark_pk,
+                halo2_pk,
+            } = agg_pk;
+            let stark_prover =
+                StarkProver::new(app_pk, app_committed_exe, agg_stark_pk, agg_tree_config);
+            Self {
+                stark_prover,
+                halo2_prover: Halo2Prover::new(reader, halo2_pk),
+            }
         }
-    }
 
-    pub fn set_program_name(&mut self, program_name: impl AsRef<str>) -> &mut Self {
-        self.stark_prover.set_program_name(program_name);
-        self
-    }
+        pub fn set_program_name(&mut self, program_name: impl AsRef<str>) -> &mut Self {
+            self.stark_prover.set_program_name(program_name);
+            self
+        }
 
-    pub fn generate_proof_for_evm(&self, input: StdIn) -> EvmProof
-    where
-        VC: VmConfig<F>,
-        VC::Executor: Chip<SC>,
-        VC::Periphery: Chip<SC>,
-    {
-        let root_proof = self.stark_prover.generate_proof_for_outer_recursion(input);
-        self.halo2_prover.prove_for_evm(&root_proof)
+        pub fn generate_proof_for_evm(&self, input: StdIn) -> EvmProof
+        where
+            VC: VmConfig<F>,
+            VC::Executor: Chip<SC>,
+            VC::Periphery: Chip<SC>,
+        {
+            let root_proof = self.stark_prover.generate_proof_for_outer_recursion(input);
+            self.halo2_prover.prove_for_evm(&root_proof)
+        }
     }
 }

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -52,6 +52,7 @@ pub enum EvmProofConversionError {
 }
 
 impl EvmProof {
+    #[cfg(feature = "evm-prove")]
     /// Return bytes calldata to be passed to the verifier contract.
     pub fn verifier_calldata(&self) -> Vec<u8> {
         let evm_proof: RawEvmProof = self.clone().try_into().unwrap();

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -293,6 +293,7 @@ fn test_public_values_and_leaf_verification() {
     }
 }
 
+#[cfg(feature = "evm-verify")]
 #[test]
 fn test_static_verifier_custom_pv_handler() {
     // Define custom public values handler and implement StaticVerifierPvHandler trait on it
@@ -394,6 +395,7 @@ fn test_static_verifier_custom_pv_handler() {
     Halo2WrapperProvingKey::evm_verify(&evm_verifier, &evm_proof).unwrap();
 }
 
+#[cfg(feature = "evm-verify")]
 #[test]
 fn test_e2e_proof_generation_and_verification_with_pvs() {
     let mut pkg_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).to_path_buf();

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -46,7 +46,7 @@ openvm-native-compiler.workspace = true
 openvm-rv32im-transpiler.workspace = true
 
 [features]
-default = ["parallel", "mimalloc"]
+default = ["parallel", "jemalloc"]
 parallel = ["openvm-stark-backend/parallel"]
 test-utils = ["dep:openvm-stark-sdk"]
 bench-metrics = ["dep:metrics", "openvm-stark-backend/bench-metrics"]

--- a/extensions/bigint/circuit/Cargo.toml
+++ b/extensions/bigint/circuit/Cargo.toml
@@ -31,7 +31,7 @@ openvm-circuit = { workspace = true, features = ["test-utils"] }
 openvm-rv32-adapters = { workspace = true, features = ["test-utils"] }
 
 [features]
-default = ["parallel", "mimalloc"]
+default = ["parallel", "jemalloc"]
 parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils"]
 # performance features:

--- a/extensions/keccak256/circuit/Cargo.toml
+++ b/extensions/keccak256/circuit/Cargo.toml
@@ -36,7 +36,7 @@ openvm-circuit = { workspace = true, features = ["test-utils"] }
 hex.workspace = true
 
 [features]
-default = ["parallel", "mimalloc"]
+default = ["parallel", "jemalloc"]
 parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils"]
 # performance features:

--- a/extensions/native/recursion/Cargo.toml
+++ b/extensions/native/recursion/Cargo.toml
@@ -18,10 +18,7 @@ p3-dft = { workspace = true }
 p3-fri = { workspace = true }
 p3-symmetric = { workspace = true }
 p3-merkle-tree = { workspace = true }
-snark-verifier-sdk = { workspace = true, features = [
-    "loader_evm",
-    "revm",
-], optional = true }
+snark-verifier-sdk = { workspace = true, optional = true }
 itertools.workspace = true
 rand.workspace = true
 serde.workspace = true
@@ -39,20 +36,25 @@ tempfile = "3.14.0"
 bitcode = { workspace = true }
 
 [features]
-default = ["parallel", "mimalloc"]
-parallel = ["openvm-stark-backend/parallel"]
+default = ["parallel", "jemalloc"]
 static-verifier = [
     "openvm-native-compiler/halo2-compiler",
-    "dep:snark-verifier-sdk",
+    "snark-verifier-sdk",
     "dep:once_cell",
     "dep:serde_with",
 ]
+evm-prove = ["static-verifier", "snark-verifier-sdk/loader_evm"]
+evm-verify = [
+    "evm-prove",
+    "snark-verifier-sdk/revm",
+] # evm-verify needs REVM to simulate EVM contract verification
 test-utils = ["openvm-circuit/test-utils"]
 bench-metrics = [
     "dep:metrics",
     "openvm-circuit/bench-metrics",
     "openvm-native-compiler/bench-metrics",
 ]
+parallel = ["openvm-stark-backend/parallel"]
 mimalloc = ["openvm-stark-backend/mimalloc"]
 jemalloc = ["openvm-stark-backend/jemalloc"]
 nightly-features = ["openvm-circuit/nightly-features"]

--- a/extensions/native/recursion/src/halo2/mod.rs
+++ b/extensions/native/recursion/src/halo2/mod.rs
@@ -17,7 +17,6 @@ use openvm_stark_backend::p3_field::extension::BinomialExtensionField;
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, p3_bn254_fr::Bn254Fr};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use snark_verifier_sdk::{
-    evm::encode_calldata,
     halo2::{gen_dummy_snark_from_vk, gen_snark_shplonk},
     snark_verifier::halo2_base::{
         gates::{
@@ -74,8 +73,9 @@ pub struct Halo2ProvingMetadata {
 
 impl RawEvmProof {
     /// Return bytes calldata to be passed to the verifier contract.
+    #[cfg(feature = "evm-prove")]
     pub fn verifier_calldata(&self) -> Vec<u8> {
-        encode_calldata(&[self.instances.clone()], &self.proof)
+        snark_verifier_sdk::evm::encode_calldata(&[self.instances.clone()], &self.proof)
     }
 }
 

--- a/extensions/rv32im/circuit/Cargo.toml
+++ b/extensions/rv32im/circuit/Cargo.toml
@@ -32,7 +32,7 @@ openvm-stark-sdk = { workspace = true }
 openvm-circuit = { workspace = true, features = ["test-utils"] }
 
 [features]
-default = ["parallel", "mimalloc"]
+default = ["parallel", "jemalloc"]
 parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils", "dep:openvm-stark-sdk"]
 # performance features:

--- a/extensions/sha256/circuit/Cargo.toml
+++ b/extensions/sha256/circuit/Cargo.toml
@@ -29,7 +29,7 @@ openvm-stark-sdk = { workspace = true }
 openvm-circuit = { workspace = true, features = ["test-utils"] }
 
 [features]
-default = ["parallel", "mimalloc"]
+default = ["parallel", "jemalloc"]
 parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils"]
 # performance features:


### PR DESCRIPTION
Previously we were very sloppy with enabling of features: `openvm-native-recursion` was always enabling the `snark-verifier` feature "revm" which imports a fixed version of revm only used for testing purposes. Since revm version changes rather frequently, this can cause Cargo dependency conflicts if someone wants to use the SDK with another version of revm.

I've added new features "evm-prove" and "evm-verify" to `openvm-native-recursion`, `openvm-sdk`, `cargo-openvm` so that 
- "evm-prove" allows for generation of EVM halo2 proofs, which just enables some additional features in `snark-verifier` but no additional other dependencies.
- "evm-verify" allows for revm simulation of EVM contract calls to verify halo2 proofs. This includes imports of `revm` and some `alloy` crates, with fixed versions. If you enable this feature (on by default), the revm and alloy versions will be fixed in the cargo tree.

Also added some re-exported features to SDK and CLI, and switched default memory allocator to `jemalloc` since that's what we mostly use.