### PR TITLE
perf: set default `num_children_internal=3`

### DIFF
--- a/crates/sdk/src/config/mod.rs
+++ b/crates/sdk/src/config/mod.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_ROOT_LOG_BLOWUP: usize = 3;
 
 // Aggregation Tree Defaults
 const DEFAULT_NUM_CHILDREN_LEAF: usize = 1;
-const DEFAULT_NUM_CHILDREN_INTERNAL: usize = 4;
+const DEFAULT_NUM_CHILDREN_INTERNAL: usize = 3;
 const DEFAULT_MAX_INTERNAL_WRAPPER_LAYERS: usize = 4;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
The total proving time of `num_children_internal=4` vs 3 is about the same, but 4 leads to the `internal.0` verifier circuit's size being larger than the leaf verifier, so for the sake of having smaller circuits, we switch to `3` as the default.

This is configurable via CLI and SDK, so it's just a default for convenience.