### PR TITLE
chore: alter json format of proof to align with verifier contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4200,7 +4200,6 @@ dependencies = [
 name = "openvm-sdk"
 version = "1.0.0"
 dependencies = [
- "alloy-primitives",
  "alloy-sol-types",
  "async-trait",
  "bitcode",
@@ -6278,9 +6277,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,6 @@ snark-verifier = { version = "0.2.0", default-features = false }
 halo2curves-axiom = "0.7.0"
 
 cargo_metadata = "0.18"
-alloy-primitives = "0.8.25"
 alloy-sol-types = "0.8.25"
 tracing = "0.1.40"
 bon = "3.2.0"

--- a/book/src/writing-apps/verify.md
+++ b/book/src/writing-apps/verify.md
@@ -107,7 +107,7 @@ The EVM proof is written to `evm.proof` as a JSON of the following format:
   "app_vm_commit": "0x..",
   "user_public_values": "0x..",
   "proof_data": {
-    "accumulators": "0x..",
+    "accumulator": "0x..",
     "proof": "0x.."
   },
 }
@@ -118,11 +118,11 @@ where each field is a hex string. We explain what each field represents:
 - `app_exe_commit`: `32` bytes for the commitment of the app executable.
 - `app_vm_commit`: `32` bytes for the commitment of the app VM configuration.
 - `user_public_values`: concatenation of 32 byte chunks for user public values. The number of user public values is a configuration parameter.
-- `accumulators`: `12 * 32` bytes representing the KZG accumulator of the proof, where the proof is from a SNARK using the KZG commitment scheme.
+- `accumulator`: `12 * 32` bytes representing the KZG accumulator of the proof, where the proof is from a SNARK using the KZG commitment scheme.
 - `proof`: The rest of the proof required by the SNARK as a hex string of `43 * 32` bytes.
 
 ### EVM Proof: Calldata Format
 
 The `cargo openvm verify evm` command reads the EVM proof from JSON file and then simulates the call to the verifier contract using [Revm](https://github.com/bluealloy/revm/tree/main). This function should only be used for testing and development purposes but not for production.
 
-To verify the EVM proof in an EVM execution environment, the entries of the JSON can be passed as function arguments for the `verify` function, where the `proofData` argument is constructed by `proofData = abi.encodePacked(accumulators, proof)`.
+To verify the EVM proof in an EVM execution environment, the entries of the JSON can be passed as function arguments for the `verify` function, where the `proofData` argument is constructed by `proofData = abi.encodePacked(accumulator, proof)`.

--- a/book/src/writing-apps/verify.md
+++ b/book/src/writing-apps/verify.md
@@ -48,13 +48,24 @@ This command can take ~20mins on a `m6a.16xlarge` instance due to the keygen tim
 Upon a successful run, the command will write the files
 
 - `agg.pk`
-- `verifier.sol`
-- `verifier.bytecode.json`
+- `halo2/Halo2Verifier.sol`
+- `halo2/OpenVmHalo2Verifier.sol`
+- `halo2/interfaces/IOpenVmHalo2Verifier.sol`
+- `halo2/verifier.bytecode.json`
 
 to `~/.openvm/`, where `~` is the directory specified by environment variable `$HOME`. Every command that requires these files will look for them in this directory.
 
 The `agg.pk` contains all aggregation proving keys necessary for aggregating to a final EVM proof.
-The `verifier.sol` file contains a Solidity contract to verify the final EVM proof. The contract is named `Halo2Verifier` and proof verification is the fallback function of the contract.
+The `OpenVmHalo2Verifier.sol` file contains a Solidity contract to verify the final EVM proof. The contract is named `OpenVmHalo2Verifier` and it implements the `IOpenVmHalo2Verifier` interface.
+
+```solidity
+interface IOpenVmHalo2Verifier {
+    function verify(bytes calldata publicValues, bytes calldata proofData, bytes32 appExeCommit, bytes32 appVmCommit)
+        external
+        view;
+}
+```
+
 In addition, the command outputs a JSON file `verifier.bytecode.json` of the form
 
 ```json
@@ -92,30 +103,26 @@ The EVM proof is written to `evm.proof` as a JSON of the following format:
 
 ```json
 {
-  "accumulators": "0x..",
-  "exe_commit": "0x..",
-  "leaf_commit": "0x..",
+  "app_exe_commit": "0x..",
+  "app_vm_commit": "0x..",
   "user_public_values": "0x..",
-  "proof": "0x.."
+  "proof_data": {
+    "accumulators": "0x..",
+    "proof": "0x.."
+  },
 }
 ```
 
 where each field is a hex string. We explain what each field represents:
 
-- `accumulators`: `12 * 32` bytes representing the KZG accumulator of the proof, where the proof is from a SNARK using the KZG commitment scheme.
-- `exe_commit`: `32` bytes for the commitment of the app executable.
-- `leaf_commit`: `32` bytes for the commitment of the executable verifying app VM proofs.
+- `app_exe_commit`: `32` bytes for the commitment of the app executable.
+- `app_vm_commit`: `32` bytes for the commitment of the app VM configuration.
 - `user_public_values`: concatenation of 32 byte chunks for user public values. The number of user public values is a configuration parameter.
+- `accumulators`: `12 * 32` bytes representing the KZG accumulator of the proof, where the proof is from a SNARK using the KZG commitment scheme.
 - `proof`: The rest of the proof required by the SNARK as a hex string of `43 * 32` bytes.
 
 ### EVM Proof: Calldata Format
 
 The `cargo openvm verify evm` command reads the EVM proof from JSON file and then simulates the call to the verifier contract using [Revm](https://github.com/bluealloy/revm/tree/main). This function should only be used for testing and development purposes but not for production.
 
-To verify the EVM proof in an EVM execution environment, the EVM proof must be formatted into calldata bytes and sent to the fallback function of the verifier smart contract. The calldata bytes are formed by concatenating the fields of the EVM proof described above in the following order and format:
-
-1. `accumulators`: every `32` bytes are _reversed_ from little endian to big endian and concatenated.
-2. `exe_commit`: the `32` bytes are _reversed_ from little endian to big endian.
-3. `leaf_commit`: the `32` bytes are _reversed_ from little endian to big endian.
-4. `user_public_values`: every `32` bytes are _reversed_ from little endian to big endian and concatenated.
-5. `proof`: The rest of the proof is treated as raw bytes and concatenated.
+To verify the EVM proof in an EVM execution environment, the entries of the JSON can be passed as function arguments for the `verify` function, where the `proofData` argument is constructed by `proofData = abi.encodePacked(accumulators, proof)`.

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -51,7 +51,7 @@ impl VerifyCmd {
                     eyre::eyre!("Failed to read EVM verifier: {}\nPlease run 'cargo openvm evm-proving-setup' first", e)
                 })?;
                 let evm_proof = read_evm_proof_from_file(proof)?;
-                sdk.verify_evm_halo2_proof(&evm_verifier, &evm_proof)?;
+                sdk.verify_evm_halo2_proof(&evm_verifier, evm_proof)?;
             }
         }
         Ok(())

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -34,7 +34,6 @@ openvm-circuit = { workspace = true }
 openvm-continuations = { workspace = true }
 openvm = { workspace = true }
 
-alloy-primitives = { workspace = true, optional = true }
 alloy-sol-types = { workspace = true, optional = true, features = ["json"] }
 bitcode = { workspace = true }
 bon = { workspace = true }
@@ -62,7 +61,6 @@ evm-prove = ["openvm-native-recursion/evm-prove"]
 evm-verify = [
     "evm-prove",
     "openvm-native-recursion/evm-verify",
-    "dep:alloy-primitives",
     "dep:alloy-sol-types",
 ]
 bench-metrics = [

--- a/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
+++ b/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
@@ -35,7 +35,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     /// use with the `snark-verifier` verification.
     ///
     /// @dev The verifier expected proof format is:
-    /// proof[..12 * 32]: KZG accumulators
+    /// proof[..12 * 32]: KZG accumulator
     /// proof[12 * 32..13 * 32]: app exe commit
     /// proof[13 * 32..14 * 32]: app vm commit
     /// proof[14 * 32..(14 + PUBLIC_VALUES_LENGTH) * 32]: publicValues[0..PUBLIC_VALUES_LENGTH]
@@ -44,7 +44,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     /// @param publicValues The PVs revealed by the OpenVM guest program.
     /// @param proofData All components of the proof except the public values and
     /// app exe and vm commits. The expected format is:
-    /// `abi.encodePacked(kzgAccumulators, proofSuffix)`
+    /// `abi.encodePacked(kzgAccumulator, proofSuffix)`
     /// @param appExeCommit The commitment to the OpenVM application executable whose execution
     /// is being verified.
     /// @param appVmCommit The commitment to the VM configuration.
@@ -95,7 +95,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
 
         // The expected proof format using hex offsets:
         //
-        // proof[..0x180]: KZG accumulators
+        // proof[..0x180]: KZG accumulator
         // proof[0x180..0x1a0]: app exe commit
         // proof[0x1a0..0x1c0]: app vm commit
         // proof[0x1c0..(0x1c0 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
@@ -107,7 +107,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
             // Allocate the memory as a safety measure.
             mstore(0x40, add(proofPtr, fullProofLength))
 
-            // Copy the KZG accumulators (length 0x180) into the beginning of
+            // Copy the KZG accumulator (length 0x180) into the beginning of
             // the memory buffer
             calldatacopy(proofPtr, proofData.offset, 0x180)
 
@@ -119,7 +119,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
             // end of the memory buffer, leaving PUBLIC_VALUES_LENGTH words in
             // between for the publicValuesPayload.
             //
-            // Begin copying from the end of the KZG accumulators in the
+            // Begin copying from the end of the KZG accumulator in the
             // calldata buffer (0x180)
             let proofSuffixOffset := add(0x1c0, shl(5, PUBLIC_VALUES_LENGTH))
             calldatacopy(add(proofPtr, proofSuffixOffset), add(proofData.offset, 0x180), 0x560)

--- a/crates/sdk/contracts/test/OpenVmHalo2Verifier.t.sol
+++ b/crates/sdk/contracts/test/OpenVmHalo2Verifier.t.sol
@@ -52,9 +52,9 @@ contract TemplateTest is Test {
 
         uint256 proofSuffixOffset = 0x1c0 + (32 * publicValuesLength);
 
-        bytes memory kzgAccumulators = proof[0:0x180];
+        bytes memory kzgAccumulator = proof[0:0x180];
         bytes memory proofSuffix = proof[proofSuffixOffset:];
-        bytes memory _proofData = abi.encodePacked(kzgAccumulators, proofSuffix);
+        bytes memory _proofData = abi.encodePacked(kzgAccumulator, proofSuffix);
 
         require(keccak256(_proofData) == keccak256(proofDataExpected), "Partial proof mismatch");
 

--- a/crates/sdk/examples/sdk_evm.rs
+++ b/crates/sdk/examples/sdk_evm.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // 11. Verify the EVM proof
-    sdk.verify_evm_halo2_proof(&verifier, &proof)?;
+    sdk.verify_evm_halo2_proof(&verifier, proof)?;
     // ANCHOR_END: evm_verification
 
     Ok(())

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -327,7 +327,7 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
 
         let wrapper_pvs = agg_pk.halo2_pk.wrapper.pinning.metadata.num_pvs.clone();
         let pvs_length = match wrapper_pvs.first() {
-            // We subtract 14 to exclude the KZG accumulators and the app exe
+            // We subtract 14 to exclude the KZG accumulator and the app exe
             // and vm commits.
             Some(v) => v
                 .checked_sub(14)

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,10 +1,11 @@
 use std::{fs::read, marker::PhantomData, path::Path, sync::Arc};
 
 #[cfg(feature = "evm-verify")]
-use alloy_primitives::{Bytes, FixedBytes};
-#[cfg(feature = "evm-verify")]
-use alloy_sol_types::{sol, SolCall, SolValue};
+use alloy_sol_types::sol;
+use commit::commit_app_exe;
+use config::{AggregationTreeConfig, AppConfig};
 use eyre::Result;
+use keygen::{AppProvingKey, AppVerifyingKey};
 use openvm_build::{
     build_guest_package, find_unique_executable, get_package, GuestOptions, TargetFilter,
 };
@@ -41,9 +42,8 @@ use openvm_transpiler::{
 use snark_verifier_sdk::{evm::gen_evm_verifier_sol_code, halo2::aggregation::AggregationCircuit};
 
 use crate::{
-    commit::commit_app_exe,
-    config::{AggConfig, AggregationTreeConfig, AppConfig},
-    keygen::{AggProvingKey, AggStarkProvingKey, AppProvingKey, AppVerifyingKey},
+    config::AggConfig,
+    keygen::{AggProvingKey, AggStarkProvingKey},
     prover::{AppProver, StarkProver},
 };
 #[cfg(feature = "evm-prove")]
@@ -411,55 +411,9 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
     pub fn verify_evm_halo2_proof(
         &self,
         openvm_verifier: &types::EvmHalo2Verifier,
-        evm_proof: &EvmProof,
+        evm_proof: EvmProof,
     ) -> Result<u64> {
-        use crate::types::NUM_BN254_ACCUMULATORS;
-
-        let EvmProof {
-            accumulators,
-            proof,
-            user_public_values,
-            exe_commit,
-            leaf_commit,
-        } = evm_proof;
-        let mut exe_commit = *exe_commit;
-        let mut leaf_commit = *leaf_commit;
-        exe_commit.reverse();
-        leaf_commit.reverse();
-
-        assert_eq!(accumulators.len(), NUM_BN254_ACCUMULATORS * 32);
-        let mut evm_accumulators: Vec<u8> = Vec::with_capacity(accumulators.len());
-        accumulators
-            .chunks(32)
-            .for_each(|chunk| evm_accumulators.extend(chunk.iter().rev().cloned()));
-
-        let mut proof_data = evm_accumulators;
-        proof_data.extend(proof);
-
-        assert!(
-            user_public_values.len() % 32 == 0,
-            "User public values length must be a multiple of 32"
-        );
-
-        // Take the first byte of each 32 byte chunk, and pack them together
-        // into one payload.
-        let user_public_values: Bytes =
-            user_public_values
-                .chunks(32)
-                .fold(Vec::<u8>::new().into(), |acc: Bytes, chunk| {
-                    // We only care about the first byte, everything else should be 0-bytes
-                    (acc, FixedBytes::<1>::from(*chunk.first().unwrap()))
-                        .abi_encode_packed()
-                        .into()
-                });
-
-        let calldata = IOpenVmHalo2Verifier::verifyCall {
-            publicValues: user_public_values.clone(),
-            proofData: proof_data.into(),
-            appExeCommit: exe_commit.into(),
-            appVmCommit: leaf_commit.into(),
-        }
-        .abi_encode();
+        let calldata = evm_proof.verifier_calldata();
         let deployment_code = openvm_verifier.artifact.bytecode.clone();
 
         let gas_cost = snark_verifier::loader::evm::deploy_and_call(deployment_code, calldata)

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -76,10 +76,7 @@ impl EvmProof {
             proof_data,
         } = self;
 
-        let ProofData {
-            accumulator,
-            proof,
-        } = proof_data;
+        let ProofData { accumulator, proof } = proof_data;
 
         let mut proof_data = accumulator;
         proof_data.extend(proof);
@@ -159,10 +156,7 @@ impl TryFrom<EvmProof> for RawEvmProof {
         app_exe_commit.reverse();
         app_vm_commit.reverse();
 
-        let ProofData {
-            accumulator,
-            proof,
-        } = proof_data;
+        let ProofData { accumulator, proof } = proof_data;
 
         if proof.len() != NUM_BN254_PROOF * BN254_BYTES {
             return Err(EvmProofConversionError::InvalidLengthProof);

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -457,7 +457,7 @@ fn test_e2e_proof_generation_and_verification_with_pvs() {
         .unwrap();
 
     verify_evm_halo2_proof_with_fallback(&evm_verifier, &evm_proof).unwrap();
-    sdk.verify_evm_halo2_proof(&evm_verifier, &evm_proof)
+    sdk.verify_evm_halo2_proof(&evm_verifier, evm_proof)
         .unwrap();
 }
 

--- a/docs/specs/continuations.md
+++ b/docs/specs/continuations.md
@@ -30,7 +30,7 @@ wrapper is determined by the following parameters:
 - The Aggregation VM chip constraints (but **not** the App VM chips)
 
 Public values:
-- `accumulators`: `12 * 32` bytes representing the KZG accumulator of the SNARK proof.
+- `accumulator`: `12 * 32` bytes representing the KZG accumulator of the SNARK proof.
 - `exe_commit`: one `Bn254Fr` element (as `32` bytes) for the commitment of the app executable.
 - `leaf_commit`: one `Bn254Fr` element (as `32` bytes) for the commitment of the executable verifying app VM proofs.
 - `user_public_values`: sequence of `num_public_values` user-defined public values, each as a `Bn254Fr` element (`32` bytes). The number of user public values is a VM configuration parameter.

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -150,7 +150,7 @@ pub fn verify_two_adic_pcs<C: Config>(
     };
     builder.cycle_tracker_end("pre-compute-rounds-context");
 
-    // Accumulators of the reduced opening sums, reset per query. The array `ro` is indexed by
+    // Accumulator of the reduced opening sums, reset per query. The array `ro` is indexed by
     // log_height.
     let ro: Array<C, Ext<C::F, C::EF>> = builder.array(MAX_TWO_ADICITY + 1);
     let alpha_pow: Array<C, Ext<C::F, C::EF>> = builder.array(MAX_TWO_ADICITY + 1);
@@ -159,7 +159,7 @@ pub fn verify_two_adic_pcs<C: Config>(
         let query_proof = builder.iter_ptr_get(&proof.query_proofs, ptr_vec[0]);
         let index_bits = challenger.sample_bits(builder, log_max_lde_height);
 
-        // We reset the reduced opening accumulators at the start of each query.
+        // We reset the reduced opening accumulator at the start of each query.
         // We describe what `ro[log_height]` computes per query in pseduo-code, where `log_height`
         // is log2 of the size of the LDE domain: ro[log_height] = 0
         // alpha_pow[log_height] = 1


### PR DESCRIPTION
This PR alters the JSON proof outputted by `cargo openvm prove` to conform to the format of the verifier contract.

