### PR TITLE
feat(new-execution): `TracingMemory` and removal of records/logs

### DIFF
--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -45,6 +45,7 @@ pub struct MemoryConfig {
     /// space `0` in memory.
     pub as_height: usize,
     /// The offset of the address space. Should be fixed to equal `1`.
+    // TODO[jpw]: remove this and make constant
     pub as_offset: u32,
     pub pointer_max_bits: usize,
     /// All timestamps must be in the range `[0, 2^clk_max_bits)`. Maximum allowed: 29.

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -68,6 +68,15 @@ pub enum ExecutionError {
     FailedWithExitCode(u32),
 }
 
+/// Global VM state accessible during instruction execution.
+/// The state is generic in guest memory `MEM` and additional host state `CTX`.
+/// The host state is execution context specific.
+pub struct VmState<MEM, CTX> {
+    pub pc: u32,
+    pub memory: MEM,
+    pub ctx: CTX,
+}
+
 pub trait InstructionExecutor<F> {
     /// Runtime execution of the instruction, if the instruction is owned by the
     /// current instance. May internally store records of this call for later trace generation.

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -66,6 +66,8 @@ pub enum ExecutionError {
     DidNotTerminate,
     #[error("program exit code {0}")]
     FailedWithExitCode(u32),
+    #[error("trace buffer out of bounds: requested {requested} but capacity is {capacity}")]
+    TraceBufferOutOfBounds { requested: usize, capacity: usize },
 }
 
 /// Global VM state accessible during instruction execution.

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use std::cell::RefCell;
 
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -77,6 +77,7 @@ pub struct VmState<MEM, CTX> {
     pub ctx: CTX,
 }
 
+// TODO: old
 pub trait InstructionExecutor<F> {
     /// Runtime execution of the instruction, if the instruction is owned by the
     /// current instance. May internally store records of this call for later trace generation.
@@ -93,21 +94,6 @@ pub trait InstructionExecutor<F> {
 }
 
 impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
-    fn execute(
-        &mut self,
-        memory: &mut MemoryController<F>,
-        instruction: &Instruction<F>,
-        prev_state: ExecutionState<u32>,
-    ) -> Result<ExecutionState<u32>> {
-        self.borrow_mut().execute(memory, instruction, prev_state)
-    }
-
-    fn get_opcode_name(&self, opcode: usize) -> String {
-        self.borrow().get_opcode_name(opcode)
-    }
-}
-
-impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for Rc<RefCell<C>> {
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -71,10 +71,10 @@ pub enum ExecutionError {
 /// Global VM state accessible during instruction execution.
 /// The state is generic in guest memory `MEM` and additional host state `CTX`.
 /// The host state is execution context specific.
-pub struct VmState<MEM, CTX> {
-    pub pc: u32,
-    pub memory: MEM,
-    pub ctx: CTX,
+pub struct VmStateMut<'a, MEM, CTX> {
+    pub pc: &'a mut u32,
+    pub memory: &'a mut MEM,
+    pub ctx: &'a mut CTX,
 }
 
 // TODO: old

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -498,6 +498,10 @@ impl<F: PrimeField32> SystemBase<F> {
         self.connector_chip.air.execution_bus
     }
 
+    pub fn offline_memory(&self) -> Arc<Mutex<OfflineMemory<F>>> {
+        self.memory_controller.offline_memory().clone()
+    }
+
     /// Return trace heights of SystemBase. Usually this is for aggregation and not useful for
     /// regular users.
     pub fn get_system_trace_heights(&self) -> SystemTraceHeights {

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -494,10 +494,6 @@ impl<F: PrimeField32> SystemBase<F> {
         self.memory_controller.memory_bridge()
     }
 
-    pub fn offline_memory(&self) -> Arc<Mutex<OfflineMemory<F>>> {
-        self.memory_controller.offline_memory().clone()
-    }
-
     pub fn execution_bus(&self) -> ExecutionBus {
         self.connector_chip.air.execution_bus
     }
@@ -557,7 +553,6 @@ impl<F: PrimeField32> SystemComplex<F> {
             )
         };
         let memory_bridge = memory_controller.memory_bridge();
-        let offline_memory = memory_controller.offline_memory();
         let program_chip = ProgramChip::new(program_bus);
         let connector_chip = VmConnectorChip::new(
             execution_bus,
@@ -576,7 +571,7 @@ impl<F: PrimeField32> SystemComplex<F> {
                     config.num_public_values,
                     config.max_constraint_degree as u32 - 1,
                 ),
-                offline_memory,
+                memory_controller.offline_memory.clone(),
             );
             inventory
                 .add_executor(chip, [PublishOpcode::PUBLISH.global_opcode()])

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -238,6 +238,9 @@ pub trait SingleTraceStep<F, CTX> {
     fn generate_public_values(&self) -> Vec<F> {
         vec![]
     }
+
+    /// Displayable opcode name for logging and debugging purposes.
+    fn get_opcode_name(&self, opcode: usize) -> String;
 }
 
 pub struct NewVmChipWrapper<F, AIR, C> {
@@ -307,8 +310,7 @@ where
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {
-        "NewWrapper".to_string()
-        // self.inner.get_opcode_name(opcode)
+        self.inner.get_opcode_name(opcode)
     }
 }
 

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -1,6 +1,6 @@
 use std::{
     array::from_fn,
-    borrow::Borrow,
+    borrow::{Borrow, BorrowMut},
     marker::PhantomData,
     sync::{Arc, Mutex},
 };
@@ -22,7 +22,7 @@ use openvm_stark_backend::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::{ExecutionState, InstructionExecutor, Result, VmState};
-use crate::system::memory::{MemoryController, OfflineMemory};
+use crate::system::memory::{online::TracingMemory, MemoryController, OfflineMemory};
 
 /// The interface between primitive AIR and machine adapter AIR.
 pub trait VmAdapterInterface<T> {
@@ -215,10 +215,10 @@ pub struct AdapterAirContext<T, I: VmAdapterInterface<T>> {
 /// instruction execution and trace generation.
 /// It is expected that no additional memory allocation is necessary and the trace buffer
 /// is sufficient, with possible overwriting.
-pub trait SingleTraceStep<F> {
+pub trait SingleTraceStep<F, CTX> {
     fn execute(
         &mut self,
-        state: &mut VmState<OfflineMemory<F>, ()>,
+        state: &mut VmState<TracingMemory, CTX>,
         instruction: &Instruction<F>,
         row_slice: &mut [F],
     ) -> Result<()>;

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -332,7 +332,7 @@ where
         let rows_used = self.current_trace_height();
         let height = next_power_of_two_or_zero(rows_used);
         // This should be automatic since trace_buffer's height is a power of two:
-        assert!(height * self.width <= self.trace_buffer.len());
+        assert!(height.checked_mul(self.width).unwrap() <= self.trace_buffer.len());
         self.trace_buffer.truncate(height * self.width);
         let mem_helper = self.mem_helper.as_borrowed();
         // This zip only goes through used rows.

--- a/crates/vm/src/arch/testing/memory/air.rs
+++ b/crates/vm/src/arch/testing/memory/air.rs
@@ -1,46 +1,155 @@
-use std::{borrow::Borrow, mem::size_of};
+use std::{mem::size_of, sync::Arc};
 
-use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
+    config::{StarkGenericConfig, Val},
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
-    p3_matrix::Matrix,
+    p3_field::{FieldAlgebra, PrimeField32},
+    p3_matrix::{dense::RowMajorMatrix, Matrix},
+    prover::types::AirProofInput,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
+    AirRef, Chip, ChipUsageGetter,
 };
 
 use crate::system::memory::{offline_checker::MemoryBus, MemoryAddress};
 
-#[derive(Clone, Copy, Debug, AlignedBorrow, derive_new::new)]
 #[repr(C)]
-pub struct DummyMemoryInteractionCols<T, const BLOCK_SIZE: usize> {
-    pub address: MemoryAddress<T, T>,
-    pub data: [T; BLOCK_SIZE],
-    pub timestamp: T,
+#[derive(Clone, Copy)]
+pub struct DummyMemoryInteractionColsRef<'a, T> {
+    pub address: MemoryAddress<&'a T, &'a T>,
+    pub data: &'a [T],
+    pub timestamp: &'a T,
     /// The send frequency. Send corresponds to write. To read, set to negative.
-    pub count: T,
+    pub count: &'a T,
 }
 
-#[derive(Clone, Copy, Debug, derive_new::new)]
-pub struct MemoryDummyAir<const BLOCK_SIZE: usize> {
-    pub bus: MemoryBus,
+#[repr(C)]
+pub struct DummyMemoryInteractionColsMut<'a, T> {
+    pub address: MemoryAddress<&'a mut T, &'a mut T>,
+    pub data: &'a mut [T],
+    pub timestamp: &'a mut T,
+    /// The send frequency. Send corresponds to write. To read, set to negative.
+    pub count: &'a mut T,
 }
 
-impl<const BLOCK_SIZE: usize, F> BaseAirWithPublicValues<F> for MemoryDummyAir<BLOCK_SIZE> {}
-impl<const BLOCK_SIZE: usize, F> PartitionedBaseAir<F> for MemoryDummyAir<BLOCK_SIZE> {}
-impl<const BLOCK_SIZE: usize, F> BaseAir<F> for MemoryDummyAir<BLOCK_SIZE> {
-    fn width(&self) -> usize {
-        size_of::<DummyMemoryInteractionCols<u8, BLOCK_SIZE>>()
+impl<'a, T> DummyMemoryInteractionColsRef<'a, T> {
+    pub fn from_slice(slice: &'a [T]) -> Self {
+        let (address, slice) = slice.split_at(size_of::<MemoryAddress<u8, u8>>());
+        let (count, slice) = slice.split_last().unwrap();
+        let (timestamp, data) = slice.split_last().unwrap();
+        Self {
+            address: MemoryAddress::new(&address[0], &address[1]),
+            data,
+            timestamp,
+            count,
+        }
     }
 }
 
-impl<const BLOCK_SIZE: usize, AB: InteractionBuilder> Air<AB> for MemoryDummyAir<BLOCK_SIZE> {
+impl<'a, T> DummyMemoryInteractionColsMut<'a, T> {
+    pub fn from_mut_slice(slice: &'a mut [T]) -> Self {
+        let (addr_space, slice) = slice.split_first_mut().unwrap();
+        let (ptr, slice) = slice.split_first_mut().unwrap();
+        let (count, slice) = slice.split_last_mut().unwrap();
+        let (timestamp, data) = slice.split_last_mut().unwrap();
+        Self {
+            address: MemoryAddress::new(addr_space, ptr),
+            data,
+            timestamp,
+            count,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, derive_new::new)]
+pub struct MemoryDummyAir {
+    pub bus: MemoryBus,
+    pub block_size: usize,
+}
+
+impl<F> BaseAirWithPublicValues<F> for MemoryDummyAir {}
+impl<F> PartitionedBaseAir<F> for MemoryDummyAir {}
+impl<F> BaseAir<F> for MemoryDummyAir {
+    fn width(&self) -> usize {
+        self.block_size + 4
+    }
+}
+
+impl<AB: InteractionBuilder> Air<AB> for MemoryDummyAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
         let local = main.row_slice(0);
-        let local: &DummyMemoryInteractionCols<AB::Var, BLOCK_SIZE> = (*local).borrow();
+        let local = DummyMemoryInteractionColsRef::from_slice(&local);
 
         self.bus
-            .send(local.address, local.data.to_vec(), local.timestamp)
-            .eval(builder, local.count);
+            .send(
+                MemoryAddress::new(*local.address.address_space, *local.address.pointer),
+                local.data.to_vec(),
+                *local.timestamp,
+            )
+            .eval(builder, *local.count);
+    }
+}
+
+#[derive(Clone)]
+pub struct MemoryDummyChip<F> {
+    pub air: MemoryDummyAir,
+    pub trace: Vec<F>,
+}
+
+impl<F> MemoryDummyChip<F> {
+    pub fn new(air: MemoryDummyAir) -> Self {
+        Self {
+            air,
+            trace: Vec::new(),
+        }
+    }
+}
+
+impl<F: PrimeField32> MemoryDummyChip<F> {
+    pub fn send(&mut self, addr_space: u32, ptr: u32, data: &[F], timestamp: u32) {
+        self.push(addr_space, ptr, data, timestamp, F::ONE);
+    }
+
+    pub fn receive(&mut self, addr_space: u32, ptr: u32, data: &[F], timestamp: u32) {
+        self.push(addr_space, ptr, data, timestamp, F::NEG_ONE);
+    }
+
+    pub fn push(&mut self, addr_space: u32, ptr: u32, data: &[F], timestamp: u32, count: F) {
+        assert_eq!(data.len(), self.air.block_size);
+        self.trace.push(F::from_canonical_u32(addr_space));
+        self.trace.push(F::from_canonical_u32(ptr));
+        self.trace.extend_from_slice(data);
+        self.trace.push(F::from_canonical_u32(timestamp));
+        self.trace.push(count);
+    }
+}
+
+impl<SC: StarkGenericConfig> Chip<SC> for MemoryDummyChip<Val<SC>>
+where
+    Val<SC>: PrimeField32,
+{
+    fn air(&self) -> AirRef<SC> {
+        Arc::new(self.air)
+    }
+
+    fn generate_air_proof_input(mut self) -> AirProofInput<SC> {
+        let height = self.current_trace_height().next_power_of_two();
+        let width = self.trace_width();
+        self.trace.resize(height * width, Val::<SC>::ZERO);
+
+        AirProofInput::simple_no_pis(RowMajorMatrix::new(self.trace, width))
+    }
+}
+
+impl<F: PrimeField32> ChipUsageGetter for MemoryDummyChip<F> {
+    fn air_name(&self) -> String {
+        format!("MemoryDummyAir<{}>", self.air.block_size)
+    }
+    fn current_trace_height(&self) -> usize {
+        self.trace.len() / self.trace_width()
+    }
+    fn trace_width(&self) -> usize {
+        BaseAir::<F>::width(&self.air)
     }
 }

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -17,12 +17,12 @@ pub struct MemoryTester<F> {
     /// Map from `block_size` to [MemoryDummyChip] of that block size
     pub chip_for_block: HashMap<usize, MemoryDummyChip<F>>,
     // TODO: make this just TracedMemory?
-    pub controller: Rc<RefCell<MemoryController<F>>>,
+    pub controller: MemoryController<F>,
 }
 
 impl<F: PrimeField32> MemoryTester<F> {
-    pub fn new(controller: Rc<RefCell<MemoryController<F>>>) -> Self {
-        let bus = controller.borrow().memory_bus;
+    pub fn new(controller: MemoryController<F>) -> Self {
+        let bus = controller.memory_bus;
         let mut chip_for_block = HashMap::new();
         for log_block_size in 0..6 {
             let block_size = 1 << log_block_size;
@@ -37,7 +37,7 @@ impl<F: PrimeField32> MemoryTester<F> {
 
     // TODO: change interface by implementing GuestMemory trait after everything works
     pub fn read<const N: usize>(&mut self, addr_space: usize, ptr: usize) -> [F; N] {
-        let mut controller = self.controller.borrow_mut();
+        let controller = &mut self.controller;
         let t = controller.memory.timestamp();
         // TODO: hack
         let (t_prev, data) = if addr_space <= 2 {
@@ -70,7 +70,7 @@ impl<F: PrimeField32> MemoryTester<F> {
 
     // TODO: see read
     pub fn write<const N: usize>(&mut self, addr_space: usize, ptr: usize, data: [F; N]) {
-        let mut controller = self.controller.borrow_mut();
+        let controller = &mut self.controller;
         let t = controller.memory.timestamp();
         // TODO: hack
         let (t_prev, data_prev) = if addr_space <= 2 {

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -1,17 +1,9 @@
-use std::{array::from_fn, borrow::BorrowMut as _, cell::RefCell, mem::size_of, rc::Rc, sync::Arc};
+use std::{array::from_fn, cell::RefCell, collections::HashMap, rc::Rc};
 
-use air::{DummyMemoryInteractionCols, MemoryDummyAir};
+use air::{MemoryDummyAir, MemoryDummyChip};
 use openvm_circuit::system::memory::MemoryController;
-use openvm_stark_backend::{
-    config::{StarkGenericConfig, Val},
-    p3_field::{FieldAlgebra, PrimeField32},
-    p3_matrix::dense::RowMajorMatrix,
-    prover::types::AirProofInput,
-    AirRef, Chip, ChipUsageGetter,
-};
-use rand::{seq::SliceRandom, Rng};
-
-use crate::system::memory::{offline_checker::MemoryBus, MemoryAddress, RecordId};
+use openvm_stark_backend::p3_field::PrimeField32;
+use rand::Rng;
 
 pub mod air;
 
@@ -22,117 +14,92 @@ const WORD_SIZE: usize = 1;
 ///
 /// It will create a [air::MemoryDummyAir] to add messages to MemoryBus.
 pub struct MemoryTester<F> {
-    pub bus: MemoryBus,
+    /// Map from `block_size` to [MemoryDummyChip] of that block size
+    pub chip_for_block: HashMap<usize, MemoryDummyChip<F>>,
+    // TODO: make this just TracedMemory?
     pub controller: Rc<RefCell<MemoryController<F>>>,
-    /// Log of record ids
-    pub records: Vec<RecordId>,
 }
 
 impl<F: PrimeField32> MemoryTester<F> {
     pub fn new(controller: Rc<RefCell<MemoryController<F>>>) -> Self {
         let bus = controller.borrow().memory_bus;
+        let mut chip_for_block = HashMap::new();
+        for log_block_size in 0..6 {
+            let block_size = 1 << log_block_size;
+            let chip = MemoryDummyChip::new(MemoryDummyAir::new(bus, block_size));
+            chip_for_block.insert(block_size, chip);
+        }
         Self {
-            bus,
+            chip_for_block,
             controller,
-            records: Vec::new(),
         }
     }
 
-    /// Returns the cell value at the current timestamp according to `MemoryController`.
-    pub fn read_cell(&mut self, address_space: usize, pointer: usize) -> F {
-        let [addr_space, pointer] = [address_space, pointer].map(F::from_canonical_usize);
-        // core::BorrowMut confuses compiler
-        let (record_id, value) =
-            RefCell::borrow_mut(&self.controller).read_cell(addr_space, pointer);
-        self.records.push(record_id);
-        value
-    }
-
-    pub fn write_cell(&mut self, address_space: usize, pointer: usize, value: F) {
-        let [addr_space, pointer] = [address_space, pointer].map(F::from_canonical_usize);
-        let (record_id, _) =
-            RefCell::borrow_mut(&self.controller).write_cell(addr_space, pointer, value);
-        self.records.push(record_id);
-    }
-
-    pub fn read<const N: usize>(&mut self, address_space: usize, pointer: usize) -> [F; N] {
-        from_fn(|i| self.read_cell(address_space, pointer + i))
-    }
-
-    pub fn write<const N: usize>(
-        &mut self,
-        address_space: usize,
-        mut pointer: usize,
-        cells: [F; N],
-    ) {
-        for cell in cells {
-            self.write_cell(address_space, pointer, cell);
-            pointer += 1;
-        }
-    }
-}
-
-impl<SC: StarkGenericConfig> Chip<SC> for MemoryTester<Val<SC>>
-where
-    Val<SC>: PrimeField32,
-{
-    fn air(&self) -> AirRef<SC> {
-        Arc::new(MemoryDummyAir::<WORD_SIZE>::new(self.bus))
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
-        let offline_memory = self.controller.borrow().offline_memory();
-        let offline_memory = offline_memory.lock().unwrap();
-
-        let height = self.records.len().next_power_of_two();
-        let width = self.trace_width();
-        let mut values = Val::<SC>::zero_vec(2 * height * width);
-        // This zip only goes through records. The padding rows between records.len()..height
-        // are filled with zeros - in particular count = 0 so nothing is added to bus.
-        for (row, id) in values.chunks_mut(2 * width).zip(self.records) {
-            let (first, second) = row.split_at_mut(width);
-            let row: &mut DummyMemoryInteractionCols<Val<SC>, WORD_SIZE> = first.borrow_mut();
-            let record = offline_memory.record_by_id(id);
-            row.address = MemoryAddress {
-                address_space: record.address_space,
-                pointer: record.pointer,
+    // TODO: change interface by implementing GuestMemory trait after everything works
+    pub fn read<const N: usize>(&mut self, addr_space: usize, ptr: usize) -> [F; N] {
+        let mut controller = self.controller.borrow_mut();
+        let t = controller.memory.timestamp();
+        // TODO: hack
+        let (t_prev, data) = if addr_space <= 2 {
+            let (t_prev, data) = unsafe {
+                controller
+                    .memory
+                    .read::<u8, N, 4>(addr_space as u32, ptr as u32)
             };
-            row.data
-                .copy_from_slice(record.prev_data_slice().unwrap_or(record.data_slice()));
-            row.timestamp = Val::<SC>::from_canonical_u32(record.prev_timestamp);
-            row.count = -Val::<SC>::ONE;
+            (t_prev, data.map(F::from_canonical_u8))
+        } else {
+            unsafe {
+                controller
+                    .memory
+                    .read::<F, N, 1>(addr_space as u32, ptr as u32)
+            }
+        };
+        self.chip_for_block.get_mut(&N).unwrap().receive(
+            addr_space as u32,
+            ptr as u32,
+            &data,
+            t_prev,
+        );
+        self.chip_for_block
+            .get_mut(&N)
+            .unwrap()
+            .send(addr_space as u32, ptr as u32, &data, t);
 
-            let row: &mut DummyMemoryInteractionCols<Val<SC>, WORD_SIZE> = second.borrow_mut();
-            row.address = MemoryAddress {
-                address_space: record.address_space,
-                pointer: record.pointer,
+        data
+    }
+
+    // TODO: see read
+    pub fn write<const N: usize>(&mut self, addr_space: usize, ptr: usize, data: [F; N]) {
+        let mut controller = self.controller.borrow_mut();
+        let t = controller.memory.timestamp();
+        // TODO: hack
+        let (t_prev, data_prev) = if addr_space <= 2 {
+            let (t_prev, data_prev) = unsafe {
+                controller.memory.write::<u8, N, 4>(
+                    addr_space as u32,
+                    ptr as u32,
+                    &data.map(|x| x.as_canonical_u32() as u8),
+                )
             };
-            row.data.copy_from_slice(record.data_slice());
-            row.timestamp = Val::<SC>::from_canonical_u32(record.timestamp);
-            row.count = Val::<SC>::ONE;
-        }
-        AirProofInput::simple_no_pis(RowMajorMatrix::new(values, width))
+            (t_prev, data_prev.map(F::from_canonical_u8))
+        } else {
+            unsafe {
+                controller
+                    .memory
+                    .write::<F, N, 1>(addr_space as u32, ptr as u32, &data)
+            }
+        };
+        self.chip_for_block.get_mut(&N).unwrap().receive(
+            addr_space as u32,
+            ptr as u32,
+            &data_prev,
+            t_prev,
+        );
+        self.chip_for_block
+            .get_mut(&N)
+            .unwrap()
+            .send(addr_space as u32, ptr as u32, &data, t);
     }
-}
-
-impl<F: PrimeField32> ChipUsageGetter for MemoryTester<F> {
-    fn air_name(&self) -> String {
-        "MemoryDummyAir".to_string()
-    }
-    fn current_trace_height(&self) -> usize {
-        self.records.len()
-    }
-
-    fn trace_width(&self) -> usize {
-        size_of::<DummyMemoryInteractionCols<u8, WORD_SIZE>>()
-    }
-}
-
-pub fn gen_address_space<R>(rng: &mut R) -> usize
-where
-    R: Rng + ?Sized,
-{
-    *[1, 2].choose(rng).unwrap()
 }
 
 pub fn gen_pointer<R>(rng: &mut R, len: usize) -> usize

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -1,13 +1,13 @@
-use std::{array::from_fn, cell::RefCell, collections::HashMap, rc::Rc};
+use std::collections::HashMap;
 
 use air::{MemoryDummyAir, MemoryDummyChip};
 use openvm_circuit::system::memory::MemoryController;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::Rng;
 
-pub mod air;
+use crate::system::memory::INITIAL_TIMESTAMP;
 
-const WORD_SIZE: usize = 1;
+pub mod air;
 
 /// A dummy testing chip that will add unconstrained messages into the [MemoryBus].
 /// Stores a log of raw messages to send/receive to the [MemoryBus].
@@ -99,6 +99,25 @@ impl<F: PrimeField32> MemoryTester<F> {
             .get_mut(&N)
             .unwrap()
             .send(addr_space as u32, ptr as u32, &data, t);
+    }
+
+    /// Fills in dummy memory chips to balance the memory bus with the initial and final boundary
+    /// messages. Taking a volatile memory approach: any touched address will be initialized with
+    /// zero.
+    pub fn finalize(&mut self) {
+        let memory = &self.controller.memory;
+        // TODO[jpw]: assuming the last block size matches initial block size, after adding
+        // adapters, fix this
+        for ((addr_space, ptr), metadata) in memory.touched_blocks() {
+            let block_size = metadata.block_size as usize;
+            let chip = self.chip_for_block.get_mut(&block_size).unwrap();
+            let mut data = F::zero_vec(block_size);
+            chip.send(addr_space, ptr, &data, INITIAL_TIMESTAMP);
+            for (i, v) in data.iter_mut().enumerate() {
+                *v = memory.data().get_f(addr_space, ptr + i as u32);
+            }
+            chip.receive(addr_space, ptr, &data, metadata.timestamp);
+        }
     }
 }
 

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -1,9 +1,4 @@
-use std::{
-    cell::RefCell,
-    iter::zip,
-    rc::Rc,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
@@ -40,7 +35,6 @@ use crate::{
             offline_checker::{MemoryBridge, MemoryBus},
             MemoryController, OfflineMemory, SharedMemoryHelper,
         },
-        poseidon2::Poseidon2PeripheryChip,
         program::ProgramBus,
     },
 };
@@ -314,7 +308,9 @@ where
     }
 
     pub fn finalize(mut self) -> Self {
-        if let Some(memory_tester) = self.memory.take() {
+        if let Some(mut memory_tester) = self.memory.take() {
+            // Balance memory boundaries
+            memory_tester.finalize();
             let memory_controller = memory_tester.controller;
             let range_checker = memory_controller.range_checker.clone();
             drop(memory_controller);

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -204,10 +204,6 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
         self.memory.controller.borrow().mem_config.pointer_max_bits
     }
 
-    pub fn offline_memory_mutex_arc(&self) -> Arc<Mutex<OfflineMemory<F>>> {
-        self.memory_controller().borrow().offline_memory().clone()
-    }
-
     pub fn get_default_register(&mut self, increment: usize) -> usize {
         self.default_register += increment;
         self.default_register - increment

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -42,7 +42,7 @@ use crate::{
             MemoryBaseAuxCols, MemoryBridge, MemoryBus, MemoryReadAuxCols,
             MemoryReadOrImmediateAuxCols, MemoryWriteAuxCols, AUX_LEN,
         },
-        online::{Memory, MemoryLogEntry},
+        online::{MemoryLogEntry, TracingMemory},
         persistent::PersistentBoundaryChip,
         tree::MemoryNode,
     },
@@ -97,7 +97,7 @@ pub struct MemoryController<F> {
     // Store separately to avoid smart pointer reference each time
     range_checker_bus: VariableRangeCheckerBus,
     // addr_space -> Memory data structure
-    memory: Memory,
+    memory: TracingMemory,
     /// A reference to the `OfflineMemory`. Will be populated after `finalize()`.
     offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     pub access_adapters: AccessAdapterInventory<F>,
@@ -242,7 +242,7 @@ impl<F: PrimeField32> MemoryController<F> {
                     range_checker.clone(),
                 ),
             },
-            memory: Memory::new(&mem_config),
+            memory: TracingMemory::new(&mem_config),
             offline_memory: Arc::new(Mutex::new(OfflineMemory::new(
                 initial_memory,
                 1,
@@ -293,7 +293,8 @@ impl<F: PrimeField32> MemoryController<F> {
             memory_bus,
             mem_config,
             interface_chip,
-            memory: Memory::new(&mem_config), // it is expected that the memory will be set later
+            memory: TracingMemory::new(&mem_config), /* it is expected that the memory will be
+                                                      * set later */
             offline_memory: Arc::new(Mutex::new(OfflineMemory::new(
                 AddressMap::from_mem_config(&mem_config),
                 CHUNK,
@@ -350,7 +351,7 @@ impl<F: PrimeField32> MemoryController<F> {
         let mut offline_memory = self.offline_memory.lock().unwrap();
         offline_memory.set_initial_memory(memory.clone(), self.mem_config);
 
-        self.memory = Memory::from_image(memory.clone(), self.mem_config.access_capacity);
+        self.memory = TracingMemory::from_image(memory.clone(), self.mem_config.access_capacity);
 
         match &mut self.interface_chip {
             MemoryInterface::Volatile { .. } => {

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -344,7 +344,7 @@ impl<F: PrimeField32> OfflineMemory<F> {
         query: u32,
         records: &mut AccessAdapterInventory<F>,
     ) {
-        let lim = (self.data[(address_space - self.as_offset) as usize].memory_size()) as u32;
+        let lim = (self.data[(address_space - self.as_offset) as usize].bytes_capacity()) as u32;
         if query == lim {
             return;
         }

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -520,7 +520,7 @@ impl<F: PrimeField32> OfflineMemory<F> {
     pub fn aux_cols_factory(&self) -> MemoryAuxColsFactory<F> {
         let range_bus = self.range_checker.bus();
         MemoryAuxColsFactory {
-            range_checker: self.range_checker.clone(),
+            range_checker: self.range_checker.as_ref(),
             timestamp_lt_air: AssertLtSubAir::new(range_bus, self.timestamp_max_bits),
             _marker: Default::default(),
         }

--- a/crates/vm/src/system/memory/offline.rs
+++ b/crates/vm/src/system/memory/offline.rs
@@ -6,7 +6,7 @@ use openvm_circuit_primitives::{
 use openvm_stark_backend::p3_field::PrimeField32;
 use rustc_hash::FxHashSet;
 
-use super::{AddressMap, PagedVec, PAGE_SIZE};
+use super::{AddressMap, PagedVec, SharedMemoryHelper, PAGE_SIZE};
 use crate::{
     arch::MemoryConfig,
     system::memory::{

--- a/crates/vm/src/system/memory/offline_checker/columns.rs
+++ b/crates/vm/src/system/memory/offline_checker/columns.rs
@@ -40,9 +40,7 @@ impl<const N: usize, T> MemoryWriteAuxCols<T, N> {
             prev_data,
         }
     }
-}
 
-impl<const N: usize, T> MemoryWriteAuxCols<T, N> {
     pub fn from_base(base: MemoryBaseAuxCols<T>, prev_data: [T; N]) -> Self {
         Self { base, prev_data }
     }
@@ -53,6 +51,12 @@ impl<const N: usize, T> MemoryWriteAuxCols<T, N> {
 
     pub fn prev_data(&self) -> &[T; N] {
         &self.prev_data
+    }
+
+    /// Sets the previous timestamp and data **without** updating the less than auxiliary columns.
+    pub fn set_prev(&mut self, timestamp: T, data: [T; N]) {
+        self.base.prev_timestamp = timestamp;
+        self.prev_data = data;
     }
 }
 

--- a/crates/vm/src/system/memory/offline_checker/columns.rs
+++ b/crates/vm/src/system/memory/offline_checker/columns.rs
@@ -1,6 +1,8 @@
 //! Defines auxiliary columns for memory operations: `MemoryReadAuxCols`,
 //! `MemoryReadWithImmediateAuxCols`, and `MemoryWriteAuxCols`.
 
+use std::ops::DerefMut;
+
 use openvm_circuit_primitives::is_less_than::LessThanAuxCols;
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -104,5 +106,11 @@ impl<T, const N: usize> AsRef<MemoryReadAuxCols<T>> for MemoryWriteAuxCols<T, N>
         //  - Thus, the memory layout of `MemoryWriteAuxCols<T, N>` begins with a valid
         //    `MemoryReadAuxCols<T>`.
         unsafe { &*(self as *const MemoryWriteAuxCols<T, N> as *const MemoryReadAuxCols<T>) }
+    }
+}
+
+impl<T, const N: usize> AsMut<MemoryBaseAuxCols<T>> for MemoryWriteAuxCols<T, N> {
+    fn as_mut(&mut self) -> &mut MemoryBaseAuxCols<T> {
+        &mut self.base
     }
 }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -275,26 +275,26 @@ impl TracingMemory {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::TracingMemory;
-    use crate::arch::MemoryConfig;
+// #[cfg(test)]
+// mod tests {
+//     use super::TracingMemory;
+//     use crate::arch::MemoryConfig;
 
-    #[test]
-    fn test_write_read() {
-        let mut memory = TracingMemory::new(&MemoryConfig::default());
-        let address_space = 1;
+//     #[test]
+//     fn test_write_read() {
+//         let mut memory = TracingMemory::new(&MemoryConfig::default());
+//         let address_space = 1;
 
-        unsafe {
-            memory.write(address_space, 0, &[1u8, 2, 3, 4]);
+//         unsafe {
+//             memory.write(address_space, 0, &[1u8, 2, 3, 4]);
 
-            let (_, data) = memory.read::<u8, 2>(address_space, 0);
-            assert_eq!(data, [1u8, 2]);
+//             let (_, data) = memory.read::<u8, 2>(address_space, 0);
+//             assert_eq!(data, [1u8, 2]);
 
-            memory.write(address_space, 2, &[100u8]);
+//             memory.write(address_space, 2, &[100u8]);
 
-            let (_, data) = memory.read::<u8, 4>(address_space, 0);
-            assert_eq!(data, [1u8, 2, 100, 4]);
-        }
-    }
-}
+//             let (_, data) = memory.read::<u8, 4>(address_space, 0);
+//             assert_eq!(data, [1u8, 2, 100, 4]);
+//         }
+//     }
+// }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -272,6 +272,10 @@ impl TracingMemory {
         (t_prev, values_prev)
     }
 
+    pub fn increment_timestamp(&mut self) {
+        self.timestamp += 1;
+    }
+
     pub fn increment_timestamp_by(&mut self, amount: u32) {
         self.timestamp += amount;
     }

--- a/crates/vm/src/system/memory/paged_vec.rs
+++ b/crates/vm/src/system/memory/paged_vec.rs
@@ -299,6 +299,18 @@ impl<const PAGE_SIZE: usize> AddressMap<PAGE_SIZE> {
             })
     }
 
+    pub fn get_f<F: PrimeField32>(&self, addr_space: u32, ptr: u32) -> F {
+        debug_assert_ne!(addr_space, 0);
+        // TODO: fix this
+        unsafe {
+            if addr_space <= 2 {
+                F::from_canonical_u8(self.get::<u8>((addr_space, ptr)))
+            } else {
+                self.get::<F>((addr_space, ptr))
+            }
+        }
+    }
+
     /// # Safety
     /// - `T` **must** be the correct type for a single memory cell for `addr_space`
     /// - Assumes `addr_space` is within the configured memory and not out of bounds

--- a/crates/vm/src/system/memory/paged_vec.rs
+++ b/crates/vm/src/system/memory/paged_vec.rs
@@ -103,7 +103,8 @@ impl<const PAGE_SIZE: usize> PagedVec<PAGE_SIZE> {
         }
     }
 
-    pub fn memory_size(&self) -> usize {
+    /// Total capacity across available pages, in bytes.
+    pub fn bytes_capacity(&self) -> usize {
         self.pages.len().checked_mul(PAGE_SIZE).unwrap()
     }
 
@@ -213,7 +214,7 @@ impl<T: Copy, const PAGE_SIZE: usize> Iterator for PagedVecIter<'_, T, PAGE_SIZE
             self.current_index_in_page = 0;
         }
         let global_index = self.current_page * PAGE_SIZE + self.current_index_in_page;
-        if global_index + size_of::<T>() > self.vec.memory_size() {
+        if global_index + size_of::<T>() > self.vec.bytes_capacity() {
             return None;
         }
 

--- a/crates/vm/src/system/memory/paged_vec.rs
+++ b/crates/vm/src/system/memory/paged_vec.rs
@@ -102,7 +102,7 @@ impl<const PAGE_SIZE: usize> PagedVec<PAGE_SIZE> {
     }
 
     pub fn memory_size(&self) -> usize {
-        self.pages.len() * PAGE_SIZE
+        self.pages.len().checked_mul(PAGE_SIZE).unwrap()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -248,8 +248,14 @@ impl<const PAGE_SIZE: usize> AddressMap<PAGE_SIZE> {
         // TMP: hardcoding for now
         let mut cell_size = vec![1, 1];
         cell_size.resize(as_cnt, 4);
+        let paged_vecs = cell_size
+            .iter()
+            .map(|&cell_size| {
+                PagedVec::new(mem_size.checked_mul(cell_size).unwrap().div_ceil(PAGE_SIZE))
+            })
+            .collect();
         Self {
-            paged_vecs: vec![PagedVec::new(mem_size.div_ceil(PAGE_SIZE)); as_cnt],
+            paged_vecs,
             cell_size,
             as_offset,
         }

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -1,5 +1,6 @@
 pub mod connector;
 pub mod memory;
+// Necessary for the PublicValuesChip
 pub mod native_adapter;
 /// Chip to handle phantom instructions.
 /// The Air will always constrain a NOP which advances pc by DEFAULT_PC_STEP.

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -27,7 +27,7 @@ use openvm_stark_backend::{
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
 
-use crate::system::memory::{OfflineMemory, RecordId};
+use crate::system::memory::{online::GuestMemory, OfflineMemory, RecordId};
 
 /// R reads(R<=2), W writes(W<=1).
 /// Operands: b for the first read, c for the second read, a for the first write.
@@ -226,18 +226,22 @@ impl<F: PrimeField32, const R: usize, const W: usize> VmAdapterChip<F>
 
         let mut reads = Vec::with_capacity(R);
         if R >= 1 {
-            reads.push(memory.read::<F, 1>(e, b));
+            reads.push(unsafe {
+                memory
+                    .memory_image()
+                    .read::<F, 1>(e.as_canonical_u32(), b.as_canonical_u32())
+            });
         }
         if R >= 2 {
-            reads.push(memory.read::<F, 1>(f, c));
+            reads.push(unsafe {
+                memory
+                    .memory_image()
+                    .read::<F, 1>(f.as_canonical_u32(), c.as_canonical_u32())
+            });
         }
-        let i_reads: [_; R] = std::array::from_fn(|i| reads[i].1);
-
         Ok((
-            i_reads,
-            Self::ReadRecord {
-                reads: reads.try_into().unwrap(),
-            },
+            reads.try_into().unwrap(),
+            Self::ReadRecord { reads: todo!() },
         ))
     }
 
@@ -253,8 +257,9 @@ impl<F: PrimeField32, const R: usize, const W: usize> VmAdapterChip<F>
         let Instruction { a, d, .. } = *instruction;
         let mut writes = Vec::with_capacity(W);
         if W >= 1 {
-            let (record_id, _) = memory.write(d, a, &output.writes[0]);
-            writes.push((record_id, output.writes[0]));
+            todo!();
+            // let (record_id, _) = memory.write(d, a, &output.writes[0]);
+            // writes.push((record_id, output.writes[0]));
         }
 
         Ok((

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -31,14 +31,12 @@ use serde::{Deserialize, Serialize};
 
 use super::{tmp_convert_to_u8s, RV32_REGISTER_NUM_LIMBS};
 
-/// This adapter doesn't read anything, and writes to \[a:4\]_d, where d == 1
 #[derive(Debug)]
 pub struct Rv32RdWriteAdapterChip<F: Field> {
     pub air: Rv32RdWriteAdapterAir,
     _marker: PhantomData<F>,
 }
 
-/// This adapter doesn't read anything, and **maybe** writes to \[a:4\]_d, where d == 1
 #[derive(Debug)]
 pub struct Rv32CondRdWriteAdapterChip<F: Field> {
     /// Do not use the inner air directly, use `air` instead.
@@ -92,16 +90,18 @@ pub struct Rv32RdWriteAdapterCols<T> {
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow)]
 pub struct Rv32CondRdWriteAdapterCols<T> {
-    inner: Rv32RdWriteAdapterCols<T>,
+    pub inner: Rv32RdWriteAdapterCols<T>,
     pub needs_write: T,
 }
 
+/// This adapter doesn't read anything, and writes to \[a:4\]_d, where d == 1
 #[derive(Clone, Copy, Debug, derive_new::new)]
 pub struct Rv32RdWriteAdapterAir {
     pub(super) memory_bridge: MemoryBridge,
     pub(super) execution_bridge: ExecutionBridge,
 }
 
+/// This adapter doesn't read anything, and **maybe** writes to \[a:4\]_d, where d == 1
 #[derive(Clone, Copy, Debug, derive_new::new)]
 pub struct Rv32CondRdWriteAdapterAir {
     inner: Rv32RdWriteAdapterAir,

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -1,83 +1,25 @@
-use std::{
-    borrow::{Borrow, BorrowMut},
-    marker::PhantomData,
-};
+use std::borrow::Borrow;
 
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, BasicAdapterInterface, ExecutionBridge,
-        ExecutionBus, ExecutionState, ImmInstruction, Result, VmAdapterAir, VmAdapterChip,
-        VmAdapterInterface,
+        AdapterAirContext, BasicAdapterInterface, ExecutionBridge, ExecutionState, ImmInstruction,
+        VmAdapterAir,
     },
-    system::{
-        memory::{
-            offline_checker::{MemoryBridge, MemoryWriteAuxCols},
-            MemoryAddress, MemoryController, OfflineMemory, RecordId,
-        },
-        program::ProgramBus,
+    system::memory::{
+        offline_checker::{MemoryBridge, MemoryWriteAuxCols},
+        MemoryAddress,
     },
 };
 use openvm_circuit_primitives::utils::not;
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{
-    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS,
-};
+use openvm_instructions::{program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
-    p3_field::{Field, FieldAlgebra, PrimeField32},
+    p3_field::{Field, FieldAlgebra},
 };
-use serde::{Deserialize, Serialize};
 
-use super::{tmp_convert_to_u8s, RV32_REGISTER_NUM_LIMBS};
-
-#[derive(Debug)]
-pub struct Rv32RdWriteAdapterChip<F: Field> {
-    pub air: Rv32RdWriteAdapterAir,
-    _marker: PhantomData<F>,
-}
-
-#[derive(Debug)]
-pub struct Rv32CondRdWriteAdapterChip<F: Field> {
-    /// Do not use the inner air directly, use `air` instead.
-    inner: Rv32RdWriteAdapterChip<F>,
-    pub air: Rv32CondRdWriteAdapterAir,
-}
-
-impl<F: PrimeField32> Rv32RdWriteAdapterChip<F> {
-    pub fn new(
-        execution_bus: ExecutionBus,
-        program_bus: ProgramBus,
-        memory_bridge: MemoryBridge,
-    ) -> Self {
-        Self {
-            air: Rv32RdWriteAdapterAir {
-                execution_bridge: ExecutionBridge::new(execution_bus, program_bus),
-                memory_bridge,
-            },
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<F: PrimeField32> Rv32CondRdWriteAdapterChip<F> {
-    pub fn new(
-        execution_bus: ExecutionBus,
-        program_bus: ProgramBus,
-        memory_bridge: MemoryBridge,
-    ) -> Self {
-        let inner = Rv32RdWriteAdapterChip::new(execution_bus, program_bus, memory_bridge);
-        let air = Rv32CondRdWriteAdapterAir { inner: inner.air };
-        Self { inner, air }
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Rv32RdWriteWriteRecord {
-    pub from_state: ExecutionState<u32>,
-    pub rd_id: Option<RecordId>,
-}
+use super::RV32_REGISTER_NUM_LIMBS;
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow)]
@@ -238,134 +180,5 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32CondRdWriteAdapterAir {
     fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &Rv32CondRdWriteAdapterCols<_> = local.borrow();
         cols.inner.from_state.pc
-    }
-}
-
-impl<F: PrimeField32> VmAdapterChip<F> for Rv32RdWriteAdapterChip<F> {
-    type ReadRecord = ();
-    type WriteRecord = Rv32RdWriteWriteRecord;
-    type Air = Rv32RdWriteAdapterAir;
-    type Interface = BasicAdapterInterface<F, ImmInstruction<F>, 0, 1, 0, RV32_REGISTER_NUM_LIMBS>;
-
-    fn preprocess(
-        &mut self,
-        _memory: &mut MemoryController<F>,
-        instruction: &Instruction<F>,
-    ) -> Result<(
-        <Self::Interface as VmAdapterInterface<F>>::Reads,
-        Self::ReadRecord,
-    )> {
-        let d = instruction.d;
-        debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
-
-        Ok(([], ()))
-    }
-
-    fn postprocess(
-        &mut self,
-        memory: &mut MemoryController<F>,
-        instruction: &Instruction<F>,
-        from_state: ExecutionState<u32>,
-        output: AdapterRuntimeContext<F, Self::Interface>,
-        _read_record: &Self::ReadRecord,
-    ) -> Result<(ExecutionState<u32>, Self::WriteRecord)> {
-        let Instruction { a, d, .. } = *instruction;
-        let (rd_id, _) = memory.write(d, a, &tmp_convert_to_u8s(output.writes[0]));
-
-        Ok((
-            ExecutionState {
-                pc: output.to_pc.unwrap_or(from_state.pc + DEFAULT_PC_STEP),
-                timestamp: memory.timestamp(),
-            },
-            Self::WriteRecord {
-                from_state,
-                rd_id: Some(rd_id),
-            },
-        ))
-    }
-
-    fn generate_trace_row(
-        &self,
-        row_slice: &mut [F],
-        _read_record: Self::ReadRecord,
-        write_record: Self::WriteRecord,
-        memory: &OfflineMemory<F>,
-    ) {
-        let aux_cols_factory = memory.aux_cols_factory();
-        let adapter_cols: &mut Rv32RdWriteAdapterCols<F> = row_slice.borrow_mut();
-        adapter_cols.from_state = write_record.from_state.map(F::from_canonical_u32);
-        let rd = memory.record_by_id(write_record.rd_id.unwrap());
-        adapter_cols.rd_ptr = rd.pointer;
-        aux_cols_factory.generate_write_aux(rd, &mut adapter_cols.rd_aux_cols);
-    }
-
-    fn air(&self) -> &Self::Air {
-        &self.air
-    }
-}
-
-impl<F: PrimeField32> VmAdapterChip<F> for Rv32CondRdWriteAdapterChip<F> {
-    type ReadRecord = ();
-    type WriteRecord = Rv32RdWriteWriteRecord;
-    type Air = Rv32CondRdWriteAdapterAir;
-    type Interface = BasicAdapterInterface<F, ImmInstruction<F>, 0, 1, 0, RV32_REGISTER_NUM_LIMBS>;
-
-    fn preprocess(
-        &mut self,
-        memory: &mut MemoryController<F>,
-        instruction: &Instruction<F>,
-    ) -> Result<(
-        <Self::Interface as VmAdapterInterface<F>>::Reads,
-        Self::ReadRecord,
-    )> {
-        self.inner.preprocess(memory, instruction)
-    }
-
-    fn postprocess(
-        &mut self,
-        memory: &mut MemoryController<F>,
-        instruction: &Instruction<F>,
-        from_state: ExecutionState<u32>,
-        output: AdapterRuntimeContext<F, Self::Interface>,
-        _read_record: &Self::ReadRecord,
-    ) -> Result<(ExecutionState<u32>, Self::WriteRecord)> {
-        let Instruction { a, d, .. } = *instruction;
-        let rd_id = if instruction.f != F::ZERO {
-            let (rd_id, _) = memory.write(d, a, &tmp_convert_to_u8s(output.writes[0]));
-            Some(rd_id)
-        } else {
-            memory.increment_timestamp();
-            None
-        };
-
-        Ok((
-            ExecutionState {
-                pc: output.to_pc.unwrap_or(from_state.pc + DEFAULT_PC_STEP),
-                timestamp: memory.timestamp(),
-            },
-            Self::WriteRecord { from_state, rd_id },
-        ))
-    }
-
-    fn generate_trace_row(
-        &self,
-        row_slice: &mut [F],
-        _read_record: Self::ReadRecord,
-        write_record: Self::WriteRecord,
-        memory: &OfflineMemory<F>,
-    ) {
-        let aux_cols_factory = memory.aux_cols_factory();
-        let adapter_cols: &mut Rv32CondRdWriteAdapterCols<F> = row_slice.borrow_mut();
-        adapter_cols.inner.from_state = write_record.from_state.map(F::from_canonical_u32);
-        if let Some(rd_id) = write_record.rd_id {
-            let rd = memory.record_by_id(rd_id);
-            adapter_cols.inner.rd_ptr = rd.pointer;
-            aux_cols_factory.generate_write_aux(rd, &mut adapter_cols.inner.rd_aux_cols);
-            adapter_cols.needs_write = F::ONE;
-        }
-    }
-
-    fn air(&self) -> &Self::Air {
-        &self.air
     }
 }

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -34,7 +34,6 @@ use crate::adapters::{
     tracing_write_reg, Rv32RdWriteAdapterCols, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
 
-const RV32_LIMB_MAX: u32 = (1 << RV32_CELL_BITS) - 1;
 pub(super) const ADAPTER_WIDTH: usize = size_of::<Rv32RdWriteAdapterCols<u8>>();
 
 #[repr(C)]

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -284,6 +284,10 @@ impl<F: PrimeField32, CTX> SingleTraceStep<F, CTX> for Rv32AuipcCoreChip {
         self.bitwise_lookup_chip
             .request_range(pc_limbs[2] as u32, (pc_limbs[3] as u32) << msl_shift);
     }
+
+    fn get_opcode_name(&self, _: usize) -> String {
+        format!("{:?}", AUIPC)
+    }
 }
 
 // returns rd_data

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -229,7 +229,7 @@ impl<F: PrimeField32, CTX> SingleTraceStep<F, CTX> for Rv32AuipcCoreChip {
         let adapter_row: &mut Rv32RdWriteAdapterCols<F> = adapter_row.borrow_mut();
         let core_row: &mut Rv32AuipcCoreCols<F> = core_row.borrow_mut();
 
-        let from_timestamp = state.memory.timestamp;
+        let from_timestamp = state.memory.timestamp();
         let imm = instruction.c.as_canonical_u32();
         let rd_data = run_auipc(Rv32AuipcOpcode::AUIPC, *state.pc, imm);
 
@@ -245,7 +245,7 @@ impl<F: PrimeField32, CTX> SingleTraceStep<F, CTX> for Rv32AuipcCoreChip {
             data_prev.map(F::from_canonical_u8),
         );
         core_row.rd_data = rd_data.map(F::from_canonical_u8);
-        // We decompose during generate trace later:
+        // We decompose during fill_trace_row later:
         core_row.imm_limbs[0] = instruction.c;
 
         *state.pc += DEFAULT_PC_STEP;

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -35,7 +35,7 @@ use crate::adapters::{
 };
 
 const RV32_LIMB_MAX: u32 = (1 << RV32_CELL_BITS) - 1;
-const ADAPTER_WIDTH: usize = size_of::<Rv32RdWriteAdapterCols<u8>>();
+pub(super) const ADAPTER_WIDTH: usize = size_of::<Rv32RdWriteAdapterCols<u8>>();
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow)]
@@ -48,7 +48,7 @@ pub struct Rv32AuipcCoreCols<T> {
     pub rd_data: [T; RV32_REGISTER_NUM_LIMBS],
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Rv32AuipcCoreAir {
     pub bus: BitwiseOperationLookupBus,
 }
@@ -203,6 +203,7 @@ pub struct Rv32AuipcCoreRecord<F> {
 }
 
 pub struct Rv32AuipcCoreChip {
+    // TODO[jpw]: do we still need air in here?
     pub air: Rv32AuipcCoreAir,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }

--- a/extensions/rv32im/circuit/src/auipc/mod.rs
+++ b/extensions/rv32im/circuit/src/auipc/mod.rs
@@ -1,6 +1,6 @@
-use openvm_circuit::arch::VmChipWrapper;
+use openvm_circuit::arch::{NewVmChipWrapper, VmAirWrapper};
 
-use crate::adapters::Rv32RdWriteAdapterChip;
+use crate::adapters::Rv32RdWriteAdapterAir;
 
 mod core;
 pub use core::*;
@@ -8,4 +8,5 @@ pub use core::*;
 #[cfg(test)]
 mod tests;
 
-pub type Rv32AuipcChip<F> = VmChipWrapper<F, Rv32RdWriteAdapterChip<F>, Rv32AuipcCoreChip>;
+pub type Rv32AuipcAir = VmAirWrapper<Rv32RdWriteAdapterAir, Rv32AuipcCoreAir>;
+pub type Rv32AuipcChip<F> = NewVmChipWrapper<F, Rv32AuipcAir, Rv32AuipcCoreChip>;

--- a/extensions/rv32im/circuit/src/auipc/tests.rs
+++ b/extensions/rv32im/circuit/src/auipc/tests.rs
@@ -1,6 +1,6 @@
 use std::borrow::BorrowMut;
 
-use openvm_circuit::arch::{testing::VmChipTestBuilder, VmAdapterChip};
+use openvm_circuit::arch::{testing::VmChipTestBuilder, VmAdapterChip, VmAirWrapper};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };
@@ -18,13 +18,33 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 
-use super::{run_auipc, Rv32AuipcChip, Rv32AuipcCoreChip, Rv32AuipcCoreCols};
-use crate::adapters::{Rv32RdWriteAdapterChip, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
+use super::{run_auipc, Rv32AuipcChip, Rv32AuipcCoreChip, Rv32AuipcCoreCols, ADAPTER_WIDTH};
+use crate::adapters::{
+    Rv32RdWriteAdapterAir, Rv32RdWriteAdapterChip, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+};
 
 const IMM_BITS: usize = 24;
 const BITWISE_OP_LOOKUP_BUS: BusIndex = 9;
+const MAX_INS_CAPACITY: usize = 128;
 
 type F = BabyBear;
+
+fn create_test_chip(
+    tester: &VmChipTestBuilder<F>,
+) -> (
+    Rv32AuipcChip<F>,
+    SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+) {
+    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
+    let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
+    let adapter_air = Rv32RdWriteAdapterAir::new(tester.memory_bridge(), tester.execution_bridge());
+    let core = Rv32AuipcCoreChip::new(bitwise_chip.clone());
+    let air = VmAirWrapper::new(adapter_air, core.air);
+    (
+        Rv32AuipcChip::<F>::new(air, core, MAX_INS_CAPACITY, tester.memory_helper()),
+        bitwise_chip,
+    )
+}
 
 fn set_and_execute(
     tester: &mut VmChipTestBuilder<F>,
@@ -46,7 +66,7 @@ fn set_and_execute(
 
     let rd_data = run_auipc(opcode, initial_pc, imm as u32);
 
-    assert_eq!(rd_data.map(F::from_canonical_u32), tester.read::<4>(1, a));
+    assert_eq!(rd_data.map(F::from_canonical_u8), tester.read::<4>(1, a));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -59,17 +79,9 @@ fn set_and_execute(
 #[test]
 fn rand_auipc_test() {
     let mut rng = create_seeded_rng();
-    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
-    let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
 
     let mut tester = VmChipTestBuilder::default();
-    let adapter = Rv32RdWriteAdapterChip::<F>::new(
-        tester.execution_bus(),
-        tester.program_bus(),
-        tester.memory_bridge(),
-    );
-    let core = Rv32AuipcCoreChip::new(bitwise_chip.clone());
-    let mut chip = Rv32AuipcChip::<F>::new(adapter, core, tester.offline_memory_mutex_arc());
+    let (mut chip, bitwise_chip) = create_test_chip(&tester);
 
     let num_tests: usize = 100;
     for _ in 0..num_tests {
@@ -98,18 +110,8 @@ fn run_negative_auipc_test(
     expected_error: VerificationError,
 ) {
     let mut rng = create_seeded_rng();
-    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
-    let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
-
     let mut tester = VmChipTestBuilder::default();
-    let adapter = Rv32RdWriteAdapterChip::<F>::new(
-        tester.execution_bus(),
-        tester.program_bus(),
-        tester.memory_bridge(),
-    );
-    let adapter_width = BaseAir::<F>::width(adapter.air());
-    let core = Rv32AuipcCoreChip::new(bitwise_chip.clone());
-    let mut chip = Rv32AuipcChip::<F>::new(adapter, core, tester.offline_memory_mutex_arc());
+    let (mut chip, bitwise_chip) = create_test_chip(&tester);
 
     set_and_execute(
         &mut tester,
@@ -129,7 +131,7 @@ fn run_negative_auipc_test(
     {
         let mut trace_row = auipc_trace.row_slice(0).to_vec();
 
-        let (_, core_row) = trace_row.split_at_mut(adapter_width);
+        let (_, core_row) = trace_row.split_at_mut(ADAPTER_WIDTH);
 
         let core_cols: &mut Rv32AuipcCoreCols<F> = core_row.borrow_mut();
 
@@ -254,17 +256,8 @@ fn overflow_negative_tests() {
 #[test]
 fn execute_roundtrip_sanity_test() {
     let mut rng = create_seeded_rng();
-    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
-    let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
-
     let mut tester = VmChipTestBuilder::default();
-    let adapter = Rv32RdWriteAdapterChip::<F>::new(
-        tester.execution_bus(),
-        tester.program_bus(),
-        tester.memory_bridge(),
-    );
-    let inner = Rv32AuipcCoreChip::new(bitwise_chip);
-    let mut chip = Rv32AuipcChip::<F>::new(adapter, inner, tester.offline_memory_mutex_arc());
+    let (mut chip, _) = create_test_chip(&tester);
 
     let num_tests: usize = 100;
     for _ in 0..num_tests {

--- a/extensions/rv32im/circuit/src/auipc/tests.rs
+++ b/extensions/rv32im/circuit/src/auipc/tests.rs
@@ -1,6 +1,6 @@
 use std::borrow::BorrowMut;
 
-use openvm_circuit::arch::{testing::VmChipTestBuilder, VmAdapterChip, VmAirWrapper};
+use openvm_circuit::arch::{testing::VmChipTestBuilder, VmAirWrapper};
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
 };
@@ -8,7 +8,6 @@ use openvm_instructions::{instruction::Instruction, program::PC_BITS, LocalOpcod
 use openvm_rv32im_transpiler::Rv32AuipcOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::BusIndex,
-    p3_air::BaseAir,
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     utils::disable_debug_builder,
@@ -19,9 +18,7 @@ use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 
 use super::{run_auipc, Rv32AuipcChip, Rv32AuipcCoreChip, Rv32AuipcCoreCols, ADAPTER_WIDTH};
-use crate::adapters::{
-    Rv32RdWriteAdapterAir, Rv32RdWriteAdapterChip, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
-};
+use crate::adapters::{Rv32RdWriteAdapterAir, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 
 const IMM_BITS: usize = 24;
 const BITWISE_OP_LOOKUP_BUS: BusIndex = 9;

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -361,40 +361,41 @@ impl<F: PrimeField32> VmAdapterChip<F> for Rv32BaseAluAdapterTestChip<F> {
     )> {
         let Instruction { b, c, d, e, .. } = *instruction;
 
-        let rs1 = memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, b);
-        let (rs2, rs2_data, rs2_imm) = if e.is_zero() {
-            let c_u32 = c.as_canonical_u32();
-            memory.increment_timestamp();
-            let mask1 = (1 << 9) - 1;
-            let mask2 = (1 << 3) - 2;
-            (
-                None,
-                [
-                    (c_u32 & mask1) as u16,
-                    ((c_u32 >> 8) & mask2) as u16,
-                    (c_u32 >> 16) as u16,
-                    (c_u32 >> 16) as u16,
-                ]
-                .map(F::from_canonical_u16),
-                c,
-            )
-        } else {
-            let rs2_read = memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(e, c);
-            (
-                Some(rs2_read.0),
-                rs2_read.1.map(F::from_canonical_u8),
-                F::ZERO,
-            )
-        };
+        todo!()
+        // let rs1 = memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, b);
+        // let (rs2, rs2_data, rs2_imm) = if e.is_zero() {
+        //     let c_u32 = c.as_canonical_u32();
+        //     memory.increment_timestamp();
+        //     let mask1 = (1 << 9) - 1;
+        //     let mask2 = (1 << 3) - 2;
+        //     (
+        //         None,
+        //         [
+        //             (c_u32 & mask1) as u16,
+        //             ((c_u32 >> 8) & mask2) as u16,
+        //             (c_u32 >> 16) as u16,
+        //             (c_u32 >> 16) as u16,
+        //         ]
+        //         .map(F::from_canonical_u16),
+        //         c,
+        //     )
+        // } else {
+        //     let rs2_read = memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(e, c);
+        //     (
+        //         Some(rs2_read.0),
+        //         rs2_read.1.map(F::from_canonical_u8),
+        //         F::ZERO,
+        //     )
+        // };
 
-        Ok((
-            [rs1.1.map(F::from_canonical_u8), rs2_data],
-            Self::ReadRecord {
-                rs1: rs1.0,
-                rs2,
-                rs2_imm,
-            },
-        ))
+        // Ok((
+        //     [rs1.1.map(F::from_canonical_u8), rs2_data],
+        //     Self::ReadRecord {
+        //         rs1: rs1.0,
+        //         rs2,
+        //         rs2_imm,
+        //     },
+        // ))
     }
 
     fn postprocess(

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -329,15 +329,16 @@ impl<F: PrimeField32> VmExtension<F> for Rv32I {
         );
         inventory.add_executor(jalr_chip, Rv32JalrOpcode::iter().map(|x| x.global_opcode()))?;
 
-        let auipc_chip = Rv32AuipcChip::new(
-            Rv32RdWriteAdapterChip::new(execution_bus, program_bus, memory_bridge),
-            Rv32AuipcCoreChip::new(bitwise_lu_chip.clone()),
-            offline_memory.clone(),
-        );
-        inventory.add_executor(
-            auipc_chip,
-            Rv32AuipcOpcode::iter().map(|x| x.global_opcode()),
-        )?;
+        // TODO
+        // let auipc_chip = Rv32AuipcChip::new(
+        //     Rv32RdWriteAdapterChip::new(execution_bus, program_bus, memory_bridge),
+        //     Rv32AuipcCoreChip::new(bitwise_lu_chip.clone()),
+        //     offline_memory.clone(),
+        // );
+        // inventory.add_executor(
+        //     auipc_chip,
+        //     Rv32AuipcOpcode::iter().map(|x| x.global_opcode()),
+        // )?;
 
         // There is no downside to adding phantom sub-executors, so we do it in the base extension.
         builder.add_phantom_sub_executor(

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -312,15 +312,16 @@ impl<F: PrimeField32> VmExtension<F> for Rv32I {
             BranchLessThanOpcode::iter().map(|x| x.global_opcode()),
         )?;
 
-        let jal_lui_chip = Rv32JalLuiChip::new(
-            Rv32CondRdWriteAdapterChip::new(execution_bus, program_bus, memory_bridge),
-            Rv32JalLuiCoreChip::new(bitwise_lu_chip.clone()),
-            offline_memory.clone(),
-        );
-        inventory.add_executor(
-            jal_lui_chip,
-            Rv32JalLuiOpcode::iter().map(|x| x.global_opcode()),
-        )?;
+        // TODO
+        // let jal_lui_chip = Rv32JalLuiChip::new(
+        //     Rv32CondRdWriteAdapterChip::new(execution_bus, program_bus, memory_bridge),
+        //     Rv32JalLuiCoreChip::new(bitwise_lu_chip.clone()),
+        //     offline_memory.clone(),
+        // );
+        // inventory.add_executor(
+        //     jal_lui_chip,
+        //     Rv32JalLuiOpcode::iter().map(|x| x.global_opcode()),
+        // )?;
 
         let jalr_chip = Rv32JalrChip::new(
             Rv32JalrAdapterChip::new(execution_bus, program_bus, memory_bridge),

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -337,14 +337,14 @@ impl<F: PrimeField32> InstructionExecutor<F> for Rv32HintStoreChip<F> {
         let local_opcode =
             Rv32HintStoreOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
 
-        let (mem_ptr_read, mem_ptr_limbs) =
-            memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, mem_ptr_ptr);
+        let (mem_ptr_read, mem_ptr_limbs) = todo!();
+        // memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, mem_ptr_ptr);
         let (num_words, num_words_read) = if local_opcode == HINT_STOREW {
             memory.increment_timestamp();
             (1, None)
         } else {
-            let (num_words_read, num_words_limbs) =
-                memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, num_words_ptr);
+            let (num_words_read, num_words_limbs) = todo!();
+            // memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, num_words_ptr);
             (u32::from_le_bytes(num_words_limbs), Some(num_words_read))
         };
         debug_assert_ne!(num_words, 0);
@@ -377,12 +377,12 @@ impl<F: PrimeField32> InstructionExecutor<F> for Rv32HintStoreChip<F> {
 
             let data: [F; RV32_REGISTER_NUM_LIMBS] =
                 std::array::from_fn(|_| streams.hint_stream.pop_front().unwrap());
-            let (write, _) = memory.write(
-                e,
-                F::from_canonical_u32(mem_ptr + (RV32_REGISTER_NUM_LIMBS as u32 * word_index)),
-                &tmp_convert_to_u8s(data),
-            );
-            record.hints.push((data, write));
+            // let (write, _) = memory.write(
+            //     e,
+            //     F::from_canonical_u32(mem_ptr + (RV32_REGISTER_NUM_LIMBS as u32 * word_index)),
+            //     &tmp_convert_to_u8s(data),
+            // );
+            // record.hints.push((data, write));
         }
 
         self.height += record.hints.len();

--- a/extensions/rv32im/circuit/src/hintstore/tests.rs
+++ b/extensions/rv32im/circuit/src/hintstore/tests.rs
@@ -40,15 +40,9 @@ fn set_and_execute(
     rng: &mut StdRng,
     opcode: Rv32HintStoreOpcode,
 ) {
-    let mem_ptr = rng.gen_range(
-        0..(1
-            << (tester
-                .memory_controller()
-                .borrow()
-                .mem_config()
-                .pointer_max_bits
-                - 2)),
-    ) << 2;
+    let mem_ptr = rng
+        .gen_range(0..(1 << (tester.memory_controller().mem_config().pointer_max_bits - 2)))
+        << 2;
     let b = gen_pointer(rng, 4);
 
     tester.write(1, b, decompose(mem_ptr));
@@ -80,15 +74,9 @@ fn set_and_execute_buffer(
     rng: &mut StdRng,
     opcode: Rv32HintStoreOpcode,
 ) {
-    let mem_ptr = rng.gen_range(
-        0..(1
-            << (tester
-                .memory_controller()
-                .borrow()
-                .mem_config()
-                .pointer_max_bits
-                - 2)),
-    ) << 2;
+    let mem_ptr = rng
+        .gen_range(0..(1 << (tester.memory_controller().mem_config().pointer_max_bits - 2)))
+        << 2;
     let b = gen_pointer(rng, 4);
 
     tester.write(1, b, decompose(mem_ptr));
@@ -140,7 +128,7 @@ fn rand_hintstore_test() {
     let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
     let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
 
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
 
     let mut chip = Rv32HintStoreChip::<F>::new(
         tester.execution_bus(),
@@ -187,7 +175,7 @@ fn run_negative_hintstore_test(
     let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
     let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
 
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
 
     let mut chip = Rv32HintStoreChip::<F>::new(
         tester.execution_bus(),

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -1,11 +1,11 @@
-use std::{
-    array,
-    borrow::{Borrow, BorrowMut},
-};
+use std::borrow::{Borrow, BorrowMut};
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, ImmInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, ImmInstruction, Result, SingleTraceStep, VmAdapterInterface, VmCoreAir,
+        VmStateMut,
+    },
+    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
@@ -25,7 +25,13 @@ use openvm_stark_backend::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, RV_J_TYPE_IMM_BITS};
+use crate::adapters::{
+    tracing_write_reg, Rv32CondRdWriteAdapterCols, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+    RV_J_TYPE_IMM_BITS,
+};
+
+pub(super) const ADAPTER_WIDTH: usize = size_of::<Rv32CondRdWriteAdapterCols<u8>>();
+const ADDITIONAL_BITS: u32 = 0b11000000;
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow)]
@@ -36,7 +42,7 @@ pub struct Rv32JalLuiCoreCols<T> {
     pub is_lui: T,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Rv32JalLuiCoreAir {
     pub bus: BitwiseOperationLookupBus,
 }
@@ -166,86 +172,88 @@ impl Rv32JalLuiCoreChip {
     }
 }
 
-impl<F: PrimeField32, I: VmAdapterInterface<F>> VmCoreChip<F, I> for Rv32JalLuiCoreChip
-where
-    I::Writes: From<[[F; RV32_REGISTER_NUM_LIMBS]; 1]>,
-{
-    type Record = Rv32JalLuiCoreRecord<F>;
-    type Air = Rv32JalLuiCoreAir;
-
-    #[allow(clippy::type_complexity)]
-    fn execute_instruction(
-        &self,
+impl<F: PrimeField32, CTX> SingleTraceStep<F, CTX> for Rv32JalLuiCoreChip {
+    fn execute(
+        &mut self,
+        state: VmStateMut<TracingMemory, CTX>,
         instruction: &Instruction<F>,
-        from_pc: u32,
-        _reads: I::Reads,
-    ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
+        row_slice: &mut [F],
+    ) -> Result<()> {
+        let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(ADAPTER_WIDTH) };
+        let adapter_row: &mut Rv32CondRdWriteAdapterCols<F> = adapter_row.borrow_mut();
+        let core_row: &mut Rv32JalLuiCoreCols<F> = core_row.borrow_mut();
+
         let local_opcode = Rv32JalLuiOpcode::from_usize(
             instruction
                 .opcode
                 .local_opcode_idx(Rv32JalLuiOpcode::CLASS_OFFSET),
         );
-        let imm = instruction.c;
-
+        let from_timestamp = state.memory.timestamp();
+        // `c` can be "negative" as a field element
+        let imm_f = instruction.c.as_canonical_u32();
         let signed_imm = match local_opcode {
             JAL => {
-                // Note: signed_imm is a signed integer and imm is a field element
-                (imm + F::from_canonical_u32(1 << (RV_J_TYPE_IMM_BITS - 1))).as_canonical_u32()
-                    as i32
-                    - (1 << (RV_J_TYPE_IMM_BITS - 1))
+                if imm_f < (1 << (RV_J_TYPE_IMM_BITS - 1)) {
+                    imm_f as i32
+                } else {
+                    let neg_imm_f = F::ORDER_U32 - imm_f;
+                    debug_assert!(neg_imm_f < (1 << (RV_J_TYPE_IMM_BITS - 1)));
+                    -(neg_imm_f as i32)
+                }
             }
-            LUI => imm.as_canonical_u32() as i32,
+            LUI => imm_f as i32,
         };
-        let (to_pc, rd_data) = run_jal_lui(local_opcode, from_pc, signed_imm);
+        let (to_pc, rd_data) = run_jal_lui(local_opcode, *state.pc, signed_imm);
 
-        for i in 0..(RV32_REGISTER_NUM_LIMBS / 2) {
-            self.bitwise_lookup_chip
-                .request_range(rd_data[i * 2], rd_data[i * 2 + 1]);
+        if instruction.f != F::ZERO {
+            let rd_ptr = instruction.a.as_canonical_u32();
+            let (t_prev, data_prev) = tracing_write_reg(state.memory, rd_ptr, &rd_data);
+            adapter_row.inner.rd_ptr = instruction.a;
+            adapter_row.inner.rd_aux_cols.set_prev(
+                F::from_canonical_u32(t_prev),
+                data_prev.map(F::from_canonical_u8),
+            );
+            adapter_row.needs_write = F::ONE;
+        } else {
+            state.memory.increment_timestamp();
+        }
+        adapter_row.inner.from_state.pc = F::from_canonical_u32(*state.pc);
+        adapter_row.inner.from_state.timestamp = F::from_canonical_u32(from_timestamp);
+        core_row.rd_data = rd_data.map(F::from_canonical_u8);
+        core_row.imm = instruction.c;
+        core_row.is_jal = F::from_bool(local_opcode == JAL);
+        core_row.is_lui = F::from_bool(local_opcode == LUI);
+
+        *state.pc = to_pc;
+        Ok(())
+    }
+
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(ADAPTER_WIDTH) };
+        let adapter_row: &mut Rv32CondRdWriteAdapterCols<F> = adapter_row.borrow_mut();
+        let core_row: &mut Rv32JalLuiCoreCols<F> = core_row.borrow_mut();
+
+        if adapter_row.needs_write == F::ONE {
+            let timestamp = adapter_row.inner.from_state.timestamp.as_canonical_u32();
+            mem_helper.fill_from_prev(timestamp, adapter_row.inner.rd_aux_cols.as_mut());
         }
 
-        if local_opcode == JAL {
-            let last_limb_bits = PC_BITS - RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1);
-            let additional_bits = (last_limb_bits..RV32_CELL_BITS).fold(0, |acc, x| acc + (1 << x));
-            self.bitwise_lookup_chip
-                .request_xor(rd_data[3], additional_bits);
+        let rd_data = core_row.rd_data.map(|x| x.as_canonical_u32());
+        for pair in rd_data.chunks_exact(2) {
+            self.bitwise_lookup_chip.request_range(pair[0], pair[1]);
         }
-
-        let rd_data = rd_data.map(F::from_canonical_u32);
-
-        let output = AdapterRuntimeContext {
-            to_pc: Some(to_pc),
-            writes: [rd_data].into(),
-        };
-
-        Ok((
-            output,
-            Rv32JalLuiCoreRecord {
-                rd_data,
-                imm,
-                is_jal: local_opcode == JAL,
-                is_lui: local_opcode == LUI,
-            },
-        ))
+        if core_row.is_jal == F::ONE {
+            self.bitwise_lookup_chip
+                .request_xor(rd_data[3], ADDITIONAL_BITS);
+        }
     }
 
-    fn get_opcode_name(&self, opcode: usize) -> String {
-        format!(
-            "{:?}",
-            Rv32JalLuiOpcode::from_usize(opcode - Rv32JalLuiOpcode::CLASS_OFFSET)
-        )
-    }
-
-    fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
-        let core_cols: &mut Rv32JalLuiCoreCols<F> = row_slice.borrow_mut();
-        core_cols.rd_data = record.rd_data;
-        core_cols.imm = record.imm;
-        core_cols.is_jal = F::from_bool(record.is_jal);
-        core_cols.is_lui = F::from_bool(record.is_lui);
-    }
-
-    fn air(&self) -> &Self::Air {
-        &self.air
-    }
+    // fn get_opcode_name(&self, opcode: usize) -> String {
+    //     format!(
+    //         "{:?}",
+    //         Rv32JalLuiOpcode::from_usize(opcode - Rv32JalLuiOpcode::CLASS_OFFSET)
+    //     )
+    // }
 }
 
 // returns (to_pc, rd_data)
@@ -253,12 +261,10 @@ pub(super) fn run_jal_lui(
     opcode: Rv32JalLuiOpcode,
     pc: u32,
     imm: i32,
-) -> (u32, [u32; RV32_REGISTER_NUM_LIMBS]) {
+) -> (u32, [u8; RV32_REGISTER_NUM_LIMBS]) {
     match opcode {
         JAL => {
-            let rd_data = array::from_fn(|i| {
-                ((pc + DEFAULT_PC_STEP) >> (8 * i)) & ((1 << RV32_CELL_BITS) - 1)
-            });
+            let rd_data = (pc + DEFAULT_PC_STEP).to_le_bytes();
             let next_pc = pc as i32 + imm;
             assert!(next_pc >= 0);
             (next_pc as u32, rd_data)
@@ -266,9 +272,14 @@ pub(super) fn run_jal_lui(
         LUI => {
             let imm = imm as u32;
             let rd = imm << 12;
-            let rd_data =
-                array::from_fn(|i| (rd >> (RV32_CELL_BITS * i)) & ((1 << RV32_CELL_BITS) - 1));
-            (pc + DEFAULT_PC_STEP, rd_data)
+            (pc + DEFAULT_PC_STEP, rd.to_le_bytes())
         }
     }
+}
+
+#[test]
+fn test_additional_bits() {
+    let last_limb_bits = PC_BITS - RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1);
+    let additional_bits = (last_limb_bits..RV32_CELL_BITS).fold(0, |acc, x| acc + (1u32 << x));
+    assert_eq!(additional_bits, ADDITIONAL_BITS);
 }

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -248,12 +248,12 @@ impl<F: PrimeField32, CTX> SingleTraceStep<F, CTX> for Rv32JalLuiCoreChip {
         }
     }
 
-    // fn get_opcode_name(&self, opcode: usize) -> String {
-    //     format!(
-    //         "{:?}",
-    //         Rv32JalLuiOpcode::from_usize(opcode - Rv32JalLuiOpcode::CLASS_OFFSET)
-    //     )
-    // }
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!(
+            "{:?}",
+            Rv32JalLuiOpcode::from_usize(opcode - Rv32JalLuiOpcode::CLASS_OFFSET)
+        )
+    }
 }
 
 // returns (to_pc, rd_data)

--- a/extensions/rv32im/circuit/src/jal_lui/mod.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/mod.rs
@@ -1,6 +1,6 @@
-use openvm_circuit::arch::VmChipWrapper;
+use openvm_circuit::arch::{NewVmChipWrapper, VmAirWrapper};
 
-use crate::adapters::Rv32CondRdWriteAdapterChip;
+use crate::adapters::Rv32CondRdWriteAdapterAir;
 
 mod core;
 pub use core::*;
@@ -8,4 +8,5 @@ pub use core::*;
 #[cfg(test)]
 mod tests;
 
-pub type Rv32JalLuiChip<F> = VmChipWrapper<F, Rv32CondRdWriteAdapterChip<F>, Rv32JalLuiCoreChip>;
+pub type Rv32JalLuiAir = VmAirWrapper<Rv32CondRdWriteAdapterAir, Rv32JalLuiCoreAir>;
+pub type Rv32JalLuiChip<F> = NewVmChipWrapper<F, Rv32JalLuiAir, Rv32JalLuiCoreChip>;

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -95,7 +95,7 @@ fn rand_jalr_test() {
     let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
     let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
 
     let adapter = Rv32JalrAdapterChip::<F>::new(
         tester.execution_bus(),
@@ -150,7 +150,7 @@ fn run_negative_jalr_test(
     let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
     let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
 
     let adapter = Rv32JalrAdapterChip::<F>::new(
         tester.execution_bus(),
@@ -307,7 +307,7 @@ fn execute_roundtrip_sanity_test() {
     let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
     let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
 
     let adapter = Rv32JalrAdapterChip::<F>::new(
         tester.execution_bus(),

--- a/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
@@ -55,13 +55,7 @@ fn set_and_execute(
         _ => unreachable!(),
     };
     let ptr_val = rng.gen_range(
-        0..(1
-            << (tester
-                .memory_controller()
-                .borrow()
-                .mem_config()
-                .pointer_max_bits
-                - alignment)),
+        0..(1 << (tester.memory_controller().mem_config().pointer_max_bits - alignment)),
     ) << alignment;
 
     let rs1 = rs1
@@ -128,7 +122,7 @@ fn rand_load_sign_extend_test() {
     setup_tracing();
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
     let adapter = Rv32LoadStoreAdapterChip::<F>::new(
         tester.execution_bus(),
         tester.program_bus(),
@@ -190,7 +184,7 @@ fn run_negative_loadstore_test(
 ) {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
     let adapter = Rv32LoadStoreAdapterChip::<F>::new(
         tester.execution_bus(),
         tester.program_bus(),
@@ -298,7 +292,7 @@ fn loadstore_negative_tests() {
 fn execute_roundtrip_sanity_test() {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
     let adapter = Rv32LoadStoreAdapterChip::<F>::new(
         tester.execution_bus(),
         tester.program_bus(),

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -55,13 +55,7 @@ fn set_and_execute(
     };
 
     let ptr_val = rng.gen_range(
-        0..(1
-            << (tester
-                .memory_controller()
-                .borrow()
-                .mem_config()
-                .pointer_max_bits
-                - alignment)),
+        0..(1 << (tester.memory_controller().mem_config().pointer_max_bits - alignment)),
     ) << alignment;
 
     let rs1 = rs1
@@ -148,7 +142,7 @@ fn rand_loadstore_test() {
     setup_tracing();
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
     let adapter = Rv32LoadStoreAdapterChip::<F>::new(
         tester.execution_bus(),
         tester.program_bus(),
@@ -253,7 +247,7 @@ fn run_negative_loadstore_test(
 ) {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
     let adapter = Rv32LoadStoreAdapterChip::<F>::new(
         tester.execution_bus(),
         tester.program_bus(),
@@ -436,7 +430,7 @@ fn negative_wrong_address_space_tests() {
 fn execute_roundtrip_sanity_test() {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
     let adapter = Rv32LoadStoreAdapterChip::<F>::new(
         tester.execution_bus(),
         tester.program_bus(),

--- a/extensions/rv32im/circuit/src/shift/tests.rs
+++ b/extensions/rv32im/circuit/src/shift/tests.rs
@@ -57,7 +57,7 @@ fn run_rv32_shift_rand_test(opcode: ShiftOpcode, num_ops: usize) {
         ),
         ShiftCoreChip::new(
             bitwise_chip.clone(),
-            tester.memory_controller().borrow().range_checker.clone(),
+            tester.memory_controller().range_checker.clone(),
             ShiftOpcode::CLASS_OFFSET,
         ),
         tester.offline_memory_mutex_arc(),
@@ -145,7 +145,7 @@ fn run_rv32_shift_negative_test(
     let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
     let bitwise_chip = SharedBitwiseOperationLookupChip::<RV32_CELL_BITS>::new(bitwise_bus);
     let mut tester: VmChipTestBuilder<BabyBear> = VmChipTestBuilder::default();
-    let range_checker_chip = tester.memory_controller().borrow().range_checker.clone();
+    let range_checker_chip = tester.memory_controller().range_checker.clone();
     let mut chip = Rv32ShiftTestChip::<F>::new(
         TestAdapterChip::new(
             vec![[b.map(F::from_canonical_u32), c.map(F::from_canonical_u32)].concat()],


### PR DESCRIPTION
- deleting `Vm{Adapter,Core}Chip` traits
- no more records, directly use trace buffer
- jal_lui chip is a demonstration of the new changes with working unit tests
- changed unit tester

- [x] need to add some dummy volatile memory to the tester to balance based on touched addresses