### PR TITLE
feat(new-execution): add execute functions for rv32im instructions

### DIFF
--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -287,8 +287,8 @@ where
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -3,7 +3,7 @@ use num_bigint::BigUint;
 use num_traits::Zero;
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, DynAdapterInterface, DynArray,
+        AdapterAirContext, AdapterRuntimeContext, DynAdapterInterface, DynArray, InsExecutorE1,
         MinimalInstruction, Result, VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
@@ -285,17 +285,6 @@ where
         Ok((ctx.into(), FieldExpressionRecord { inputs, flags }))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, _opcode: usize) -> String {
         self.name.clone()
     }
@@ -322,6 +311,20 @@ where
         for row in trace.rows_mut().skip(num_records) {
             row.copy_from_slice(&dummy_row);
         }
+    }
+}
+
+impl<Mem, Ctx, F> InsExecutorE1<Mem, Ctx, F> for FieldExpressionCoreChip
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }
 

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -1,9 +1,12 @@
 use itertools::Itertools;
 use num_bigint::BigUint;
 use num_traits::Zero;
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, DynAdapterInterface, DynArray, MinimalInstruction,
-    Result, VmAdapterInterface, VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, DynAdapterInterface, DynArray,
+        MinimalInstruction, Result, VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     var_range::SharedVariableRangeCheckerChip, SubAir, TraceSubRowGenerator,
@@ -280,6 +283,17 @@ where
 
         let ctx = AdapterRuntimeContext::<_, DynAdapterInterface<_>>::without_pc(writes);
         Ok((ctx.into(), FieldExpressionRecord { inputs, flags }))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, _opcode: usize) -> String {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -6,13 +6,16 @@ use openvm_instructions::{
 };
 use openvm_stark_backend::{
     interaction::{BusIndex, InteractionBuilder, PermutationCheckBus},
-    p3_field::FieldAlgebra,
+    p3_field::{FieldAlgebra, PrimeField32},
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::Streams;
-use crate::system::{memory::MemoryController, program::ProgramBus};
+use super::{Streams, VmExecutionState};
+use crate::system::{
+    memory::{online::GuestMemory, MemoryController},
+    program::ProgramBus,
+};
 
 pub type Result<T> = std::result::Result<T, ExecutionError>;
 
@@ -93,6 +96,19 @@ pub trait InstructionExecutor<F> {
     /// For display purposes. From absolute opcode as `usize`, return the string name of the opcode
     /// if it is a supported opcode by the present executor.
     fn get_opcode_name(&self, opcode: usize) -> String;
+}
+
+/// New trait for instruction execution
+pub trait InsExecutor<Mem, Ctx, F>
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>;
 }
 
 impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -99,12 +99,12 @@ pub trait InstructionExecutor<F> {
 }
 
 /// New trait for instruction execution
-pub trait InsExecutor<Mem, Ctx, F>
+pub trait InsExecutorE1<Mem, Ctx, F>
 where
     Mem: GuestMemory,
     F: PrimeField32,
 {
-    fn execute(
+    fn execute_e1(
         &mut self,
         state: &mut VmExecutionState<Mem, Ctx>,
         instruction: &Instruction<F>,

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -443,9 +443,7 @@ where
         state: &mut VmExecutionState<Mem, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()> {
-        self.core
-            .execute_instruction2::<Mem, Ctx>(state, instruction)?;
-        Ok(())
+        self.core.execute_instruction2(state, instruction)
     }
 }
 

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -99,6 +99,7 @@ impl TracegenVmExecutionState {
     where
         F: PrimeField32,
     {
+        // TODO(ayush): remove this clone
         let memory = memory_controller.memory_image().clone();
         let ctx = TracegenCtx::new(memory_controller.timestamp());
         TracegenVmExecutionState::new(pc, memory, ctx)

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, BasicAdapterInterface, MinimalInstruction,
-        Result, VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
+        AdapterAirContext, AdapterRuntimeContext, BasicAdapterInterface, InsExecutorE1,
+        MinimalInstruction, Result, VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::{memory::online::GuestMemory, public_values::columns::PublicValuesCoreColsView},
 };
@@ -160,17 +160,6 @@ impl<F: PrimeField32> VmCoreChip<F, AdapterInterface<F>> for PublicValuesCoreChi
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, opcode: usize) -> String {
         format!(
             "{:?}",
@@ -200,5 +189,19 @@ impl<F: PrimeField32> VmCoreChip<F, AdapterInterface<F>> for PublicValuesCoreChi
 
     fn air(&self) -> &Self::Air {
         &self.air
+    }
+}
+
+impl<Mem, Ctx, F> InsExecutorE1<Mem, Ctx, F> for PublicValuesCoreChip<F>
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -15,9 +15,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     arch::{
         AdapterAirContext, AdapterRuntimeContext, BasicAdapterInterface, MinimalInstruction,
-        Result, VmAdapterInterface, VmCoreAir, VmCoreChip,
+        Result, VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
-    system::public_values::columns::PublicValuesCoreColsView,
+    system::{memory::online::GuestMemory, public_values::columns::PublicValuesCoreColsView},
 };
 pub(crate) type AdapterInterface<F> = BasicAdapterInterface<F, MinimalInstruction<F>, 2, 0, 1, 1>;
 pub(crate) type AdapterInterfaceReads<F> = <AdapterInterface<F> as VmAdapterInterface<F>>::Reads;
@@ -158,6 +158,17 @@ impl<F: PrimeField32> VmCoreChip<F, AdapterInterface<F>> for PublicValuesCoreChi
         };
         let record = Self::Record { value, index };
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -162,8 +162,8 @@ impl<F: PrimeField32> VmCoreChip<F, AdapterInterface<F>> for PublicValuesCoreChi
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -7,8 +7,8 @@ use num_bigint::BigUint;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, VmExecutionState,
+        AdapterAirContext, AdapterRuntimeContext, InsExecutorE1, MinimalInstruction, Result,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -382,17 +382,6 @@ where
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, opcode: usize) -> String {
         format!(
             "{:?}",
@@ -434,6 +423,21 @@ where
 
     fn air(&self) -> &Self::Air {
         &self.air
+    }
+}
+
+impl<Mem, Ctx, F, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
+    InsExecutorE1<Mem, Ctx, F> for ModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }
 

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -384,8 +384,8 @@ where
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -5,9 +5,12 @@ use std::{
 
 use num_bigint::BigUint;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bigint::utils::big_uint_to_limbs,
@@ -377,6 +380,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -7,8 +7,8 @@ use openvm_circuit::{
     arch::{
         instructions::LocalOpcode,
         testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
-        AdapterRuntimeContext, Result, VmAdapterInterface, VmChipWrapper, VmCoreChip,
-        VmExecutionState,
+        AdapterRuntimeContext, InsExecutorE1, Result, VmAdapterInterface, VmChipWrapper,
+        VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -446,17 +446,6 @@ where
         self.chip.execute_instruction(instruction, from_pc, reads)
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, opcode: usize) -> String {
         <ModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS> as VmCoreChip<F, I>>::get_opcode_name(&self.chip, opcode)
     }
@@ -503,6 +492,21 @@ where
         <ModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS> as VmCoreChip<F, I>>::air(
             &self.chip,
         )
+    }
+}
+
+impl<Mem, Ctx, F, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
+    InsExecutorE1<Mem, Ctx, F> for BadModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }
 

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -3,10 +3,14 @@ use std::{array::from_fn, borrow::BorrowMut};
 use num_bigint::BigUint;
 use num_traits::Zero;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
-use openvm_circuit::arch::{
-    instructions::LocalOpcode,
-    testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
-    AdapterRuntimeContext, Result, VmAdapterInterface, VmChipWrapper, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        instructions::LocalOpcode,
+        testing::{VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
+        AdapterRuntimeContext, Result, VmAdapterInterface, VmChipWrapper, VmCoreChip,
+        VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bigint::utils::{big_uint_to_limbs, secp256k1_coord_prime, secp256k1_scalar_prime},
@@ -440,6 +444,17 @@ where
         // This will cause lt_marker to be all zeros except a 2.
         // There was a bug in this case which allowed b to be less than N.
         self.chip.execute_instruction(instruction, from_pc, reads)
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -448,8 +448,8 @@ where
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -170,8 +170,8 @@ where
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -1,8 +1,11 @@
 use std::borrow::{Borrow, BorrowMut};
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerBus,
@@ -163,6 +166,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, _opcode: usize) -> String {

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -2,8 +2,8 @@ use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, VmExecutionState,
+        AdapterAirContext, AdapterRuntimeContext, InsExecutorE1, MinimalInstruction, Result,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -168,17 +168,6 @@ where
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, _opcode: usize) -> String {
         format!("{:?}", CastfOpcode::CASTF)
     }
@@ -200,6 +189,20 @@ where
 
     fn air(&self) -> &Self::Air {
         &self.air
+    }
+}
+
+impl<Mem, Ctx, F> InsExecutorE1<Mem, Ctx, F> for CastFCoreChip
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }
 

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -177,8 +177,8 @@ where
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -1,9 +1,12 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use itertools::izip;
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
@@ -170,6 +173,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -3,8 +3,8 @@ use std::borrow::{Borrow, BorrowMut};
 use itertools::izip;
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, VmExecutionState,
+        AdapterAirContext, AdapterRuntimeContext, InsExecutorE1, MinimalInstruction, Result,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -175,17 +175,6 @@ where
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, opcode: usize) -> String {
         format!(
             "{:?}",
@@ -213,6 +202,20 @@ where
 
     fn air(&self) -> &Self::Air {
         &self.air
+    }
+}
+
+impl<Mem, Ctx, F> InsExecutorE1<Mem, Ctx, F> for FieldArithmeticCoreChip
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }
 

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -7,8 +7,8 @@ use std::{
 use itertools::izip;
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, VmExecutionState,
+        AdapterAirContext, AdapterRuntimeContext, InsExecutorE1, MinimalInstruction, Result,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -202,17 +202,6 @@ where
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, opcode: usize) -> String {
         format!(
             "{:?}",
@@ -239,6 +228,20 @@ where
 
     fn air(&self) -> &Self::Air {
         &self.air
+    }
+}
+
+impl<Mem, Ctx, F> InsExecutorE1<Mem, Ctx, F> for FieldExtensionCoreChip
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }
 

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -204,8 +204,8 @@ where
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -5,9 +5,12 @@ use std::{
 };
 
 use itertools::izip;
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
@@ -197,6 +200,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -4,9 +4,12 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
-use openvm_circuit::arch::{
-    instructions::LocalOpcode, AdapterAirContext, AdapterRuntimeContext, ExecutionError, Result,
-    Streams, VmAdapterInterface, VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        instructions::LocalOpcode, AdapterAirContext, AdapterRuntimeContext, ExecutionError,
+        Result, Streams, VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::instruction::Instruction;
@@ -174,6 +177,17 @@ where
             data,
         };
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -7,7 +7,8 @@ use std::{
 use openvm_circuit::{
     arch::{
         instructions::LocalOpcode, AdapterAirContext, AdapterRuntimeContext, ExecutionError,
-        Result, Streams, VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
+        InsExecutorE1, Result, Streams, VmAdapterInterface, VmCoreAir, VmCoreChip,
+        VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -179,17 +180,6 @@ where
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
-        &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
-        _instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
-        todo!("Implement execute_instruction2")
-    }
-
     fn get_opcode_name(&self, opcode: usize) -> String {
         format!(
             "{:?}",
@@ -209,5 +199,20 @@ where
 
     fn air(&self) -> &Self::Air {
         &self.air
+    }
+}
+
+impl<Mem, Ctx, F, const NUM_CELLS: usize> InsExecutorE1<Mem, Ctx, F>
+    for NativeLoadStoreCoreChip<F, NUM_CELLS>
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
+        &mut self,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
+    ) -> Result<()> {
+        todo!("Implement execute_e1")
     }
 }

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -181,8 +181,8 @@ where
 
     fn execute_instruction2<Mem, Ctx>(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
-        instruction: &Instruction<F>,
+        _state: &mut VmExecutionState<Mem, Ctx>,
+        _instruction: &Instruction<F>,
     ) -> Result<()>
     where
         Mem: GuestMemory,

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -37,8 +37,6 @@ use crate::adapters::{
     tracing_write_reg, Rv32RdWriteAdapterCols, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
 
-const RV32_LIMB_MAX: u32 = (1 << RV32_CELL_BITS) - 1;
-
 pub(super) const ADAPTER_WIDTH: usize = size_of::<Rv32RdWriteAdapterCols<u8>>();
 
 #[repr(C)]
@@ -313,10 +311,7 @@ where
             Rv32AuipcOpcode::from_usize(opcode.local_opcode_idx(Rv32AuipcOpcode::CLASS_OFFSET));
 
         let imm = imm.as_canonical_u32();
-
-        // TODO(ayush): should this be [u8; 4]?
         let rd_bytes = run_auipc(local_opcode, state.pc, imm);
-        let rd_bytes = rd_bytes.map(|x| x as u8);
 
         let rd_addr = a.as_canonical_u32();
         unsafe {

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -6,10 +6,13 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, ImmInstruction, Result, SingleTraceStep, VmAdapterInterface, VmCoreAir,
-        VmStateMut,
+        AdapterAirContext, AdapterRuntimeContext, ImmInstruction, Result, SingleTraceStep,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState, VmStateMut,
     },
-    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+    system::memory::{
+        online::{GuestMemory, TracingMemory},
+        MemoryAuxColsFactory,
+    },
 };
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
@@ -33,6 +36,8 @@ use serde::{Deserialize, Serialize};
 use crate::adapters::{
     tracing_write_reg, Rv32RdWriteAdapterCols, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
+
+const RV32_LIMB_MAX: u32 = (1 << RV32_CELL_BITS) - 1;
 
 pub(super) const ADAPTER_WIDTH: usize = size_of::<Rv32RdWriteAdapterCols<u8>>();
 
@@ -287,6 +292,119 @@ impl<F: PrimeField32, CTX> SingleTraceStep<F, CTX> for Rv32AuipcCoreChip {
 
     fn get_opcode_name(&self, _: usize) -> String {
         format!("{:?}", AUIPC)
+    }
+}
+
+// TODO(ayush): probably delete
+impl<F: PrimeField32, I: VmAdapterInterface<F>> VmCoreChip<F, I> for Rv32AuipcCoreChip
+where
+    I::Writes: From<[[F; RV32_REGISTER_NUM_LIMBS]; 1]>,
+{
+    type Record = Rv32AuipcCoreRecord<F>;
+    type Air = Rv32AuipcCoreAir;
+
+    #[allow(clippy::type_complexity)]
+    fn execute_instruction(
+        &self,
+        instruction: &Instruction<F>,
+        from_pc: u32,
+        _reads: I::Reads,
+    ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
+        let local_opcode = Rv32AuipcOpcode::from_usize(
+            instruction
+                .opcode
+                .local_opcode_idx(Rv32AuipcOpcode::CLASS_OFFSET),
+        );
+        let imm = instruction.c.as_canonical_u32();
+        let rd_data = run_auipc(local_opcode, from_pc, imm);
+        let rd_data_field = rd_data.map(F::from_canonical_u8);
+
+        let output = AdapterRuntimeContext::without_pc([rd_data_field]);
+
+        let imm_limbs = array::from_fn(|i| (imm >> (i * RV32_CELL_BITS)) & RV32_LIMB_MAX);
+        let pc_limbs: [u32; RV32_REGISTER_NUM_LIMBS] =
+            array::from_fn(|i| (from_pc >> (i * RV32_CELL_BITS)) & RV32_LIMB_MAX);
+
+        for i in 0..(RV32_REGISTER_NUM_LIMBS / 2) {
+            self.bitwise_lookup_chip
+                .request_range(rd_data[i * 2] as u32, rd_data[i * 2 + 1] as u32);
+        }
+
+        let mut need_range_check: Vec<u32> = Vec::new();
+        for limb in imm_limbs {
+            need_range_check.push(limb);
+        }
+
+        for (i, limb) in pc_limbs.iter().skip(1).enumerate() {
+            if i == pc_limbs.len() - 1 {
+                need_range_check.push((*limb) << (pc_limbs.len() * RV32_CELL_BITS - PC_BITS));
+            } else {
+                need_range_check.push(*limb);
+            }
+        }
+
+        for pair in need_range_check.chunks(2) {
+            self.bitwise_lookup_chip.request_range(pair[0], pair[1]);
+        }
+
+        Ok((
+            output,
+            Self::Record {
+                imm_limbs: imm_limbs.map(F::from_canonical_u32),
+                pc_limbs: array::from_fn(|i| F::from_canonical_u32(pc_limbs[i + 1])),
+                rd_data: rd_data.map(F::from_canonical_u8),
+            },
+        ))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        let Instruction {
+            opcode, a, c: imm, ..
+        } = instruction;
+
+        let local_opcode =
+            Rv32AuipcOpcode::from_usize(opcode.local_opcode_idx(Rv32AuipcOpcode::CLASS_OFFSET));
+
+        let imm = imm.as_canonical_u32();
+
+        // TODO(ayush): should this be [u8; 4]?
+        let rd_bytes = run_auipc(local_opcode, state.pc, imm);
+        let rd_bytes = rd_bytes.map(|x| x as u8);
+
+        let rd_addr = a.as_canonical_u32();
+        unsafe {
+            state.memory.write(RV32_REGISTER_AS, rd_addr, &rd_bytes);
+        }
+
+        state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+
+        Ok(())
+    }
+
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!(
+            "{:?}",
+            Rv32AuipcOpcode::from_usize(opcode - Rv32AuipcOpcode::CLASS_OFFSET)
+        )
+    }
+
+    fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
+        let core_cols: &mut Rv32AuipcCoreCols<F> = row_slice.borrow_mut();
+        core_cols.imm_limbs = record.imm_limbs;
+        core_cols.pc_limbs = record.pc_limbs;
+        core_cols.rd_data = record.rd_data;
+        core_cols.is_valid = F::ONE;
+    }
+
+    fn air(&self) -> &Self::Air {
+        &self.air
     }
 }
 

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
@@ -247,6 +250,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, ImmInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, ImmInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::utils::not;
 use openvm_circuit_primitives_derive::AlignedBorrow;
@@ -201,6 +204,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -225,18 +225,18 @@ where
         let branch_eq_opcode =
             BranchEqualOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
 
-        let rs1 = a.as_canonical_u32();
-        let rs2 = b.as_canonical_u32();
+        let rs1_addr = a.as_canonical_u32();
+        let rs2_addr = b.as_canonical_u32();
 
-        let rs1_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1) };
-        let rs2_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs2) };
+        let rs1_bytes: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1_addr) };
+        let rs2_bytes: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs2_addr) };
 
         // TODO(ayush): avoid this conversion
-        let rs1_data: [u32; NUM_LIMBS] = rs1_data.map(|x| x as u32);
-        let rs2_data: [u32; NUM_LIMBS] = rs2_data.map(|y| y as u32);
+        let rs1_bytes: [u32; NUM_LIMBS] = rs1_bytes.map(|x| x as u32);
+        let rs2_bytes: [u32; NUM_LIMBS] = rs2_bytes.map(|y| y as u32);
 
         // TODO(ayush): probably don't need the other values
-        let (cmp_result, _, _) = run_eq::<F, NUM_LIMBS>(branch_eq_opcode, &rs1_data, &rs2_data);
+        let (cmp_result, _, _) = run_eq::<F, NUM_LIMBS>(branch_eq_opcode, &rs1_bytes, &rs2_bytes);
 
         if cmp_result {
             let imm = imm.as_canonical_u32();

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::utils::not;
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS, LocalOpcode};
 use openvm_rv32im_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -214,7 +214,39 @@ where
     where
         Mem: GuestMemory,
     {
-        todo!("Implement execute_instruction2")
+        let Instruction {
+            opcode,
+            a,
+            b,
+            c: imm,
+            ..
+        } = instruction;
+
+        let branch_eq_opcode =
+            BranchEqualOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
+
+        let rs1 = a.as_canonical_u32();
+        let rs2 = b.as_canonical_u32();
+
+        let rs1_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1) };
+        let rs2_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs2) };
+
+        // TODO(ayush): avoid this conversion
+        let rs1_data: [u32; NUM_LIMBS] = rs1_data.map(|x| x as u32);
+        let rs2_data: [u32; NUM_LIMBS] = rs2_data.map(|y| y as u32);
+
+        // TODO(ayush): probably don't need the other values
+        let (cmp_result, _, _) = run_eq::<F, NUM_LIMBS>(branch_eq_opcode, &rs1_data, &rs2_data);
+
+        if cmp_result {
+            let imm = imm.as_canonical_u32();
+            state.pc = state.pc.wrapping_add(imm);
+        } else {
+            // TODO(ayush): why not DEFAULT_PC_STEP or some constant?
+            state.pc = state.pc.wrapping_add(self.air.pc_step);
+        }
+
+        Ok(())
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -348,19 +348,19 @@ where
 
         let blt_opcode = BranchLessThanOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
 
-        let rs1 = a.as_canonical_u32();
-        let rs2 = b.as_canonical_u32();
+        let rs1_addr = a.as_canonical_u32();
+        let rs2_addr = b.as_canonical_u32();
 
         // TODO(ayush): why even have NUM_LIMBS when it is equal to RV32_REGISTER_NUM_LIMBS?
-        let rs1_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1) };
-        let rs2_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs2) };
+        let rs1_bytes: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1_addr) };
+        let rs2_bytes: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs2_addr) };
 
         // TODO(ayush): why is this conversion necessary?
-        let rs1_data: [u32; NUM_LIMBS] = rs1_data.map(|x| x as u32);
-        let rs2_data: [u32; NUM_LIMBS] = rs2_data.map(|y| y as u32);
+        let rs1_bytes: [u32; NUM_LIMBS] = rs1_bytes.map(|x| x as u32);
+        let rs2_bytes: [u32; NUM_LIMBS] = rs2_bytes.map(|y| y as u32);
 
         let (cmp_result, _, _, _) =
-            run_cmp::<NUM_LIMBS, LIMB_BITS>(blt_opcode, &rs1_data, &rs2_data);
+            run_cmp::<NUM_LIMBS, LIMB_BITS>(blt_opcode, &rs1_bytes, &rs2_bytes);
 
         if cmp_result {
             let imm = imm.as_canonical_u32();

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, ImmInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, ImmInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
@@ -323,6 +326,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -15,7 +15,9 @@ use openvm_circuit_primitives::{
     utils::not,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
+use openvm_instructions::{
+    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS, LocalOpcode,
+};
 use openvm_rv32im_transpiler::BranchLessThanOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -336,7 +338,38 @@ where
     where
         Mem: GuestMemory,
     {
-        todo!("Implement execute_instruction2")
+        let Instruction {
+            opcode,
+            a,
+            b,
+            c: imm,
+            ..
+        } = instruction;
+
+        let blt_opcode = BranchLessThanOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
+
+        let rs1 = a.as_canonical_u32();
+        let rs2 = b.as_canonical_u32();
+
+        // TODO(ayush): why even have NUM_LIMBS when it is equal to RV32_REGISTER_NUM_LIMBS?
+        let rs1_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1) };
+        let rs2_data: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs2) };
+
+        // TODO(ayush): why is this conversion necessary?
+        let rs1_data: [u32; NUM_LIMBS] = rs1_data.map(|x| x as u32);
+        let rs2_data: [u32; NUM_LIMBS] = rs2_data.map(|y| y as u32);
+
+        let (cmp_result, _, _, _) =
+            run_cmp::<NUM_LIMBS, LIMB_BITS>(blt_opcode, &rs1_data, &rs2_data);
+
+        if cmp_result {
+            let imm = imm.as_canonical_u32();
+            state.pc = state.pc.wrapping_add(imm);
+        } else {
+            state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        }
+
+        Ok(())
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -5,9 +5,12 @@ use std::{
 
 use num_bigint::BigUint;
 use num_integer::Integer;
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
@@ -515,6 +518,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -366,7 +366,6 @@ where
         };
 
         let (to_pc, rd_bytes) = run_jal_lui(local_opcode, state.pc, signed_imm);
-        let rd_bytes = rd_bytes.map(|x| x as u8);
 
         let rd_addr = a.as_canonical_u32();
         unsafe {

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -2,10 +2,13 @@ use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, ImmInstruction, Result, SingleTraceStep, VmAdapterInterface, VmCoreAir,
-        VmStateMut,
+        AdapterAirContext, AdapterRuntimeContext, ImmInstruction, Result, SingleTraceStep,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState, VmStateMut,
     },
-    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+    system::memory::{
+        online::{GuestMemory, TracingMemory},
+        MemoryAuxColsFactory,
+    },
 };
 use openvm_circuit_primitives::bitwise_op_lookup::{
     BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip,
@@ -253,6 +256,99 @@ impl<F: PrimeField32, CTX> SingleTraceStep<F, CTX> for Rv32JalLuiCoreChip {
             "{:?}",
             Rv32JalLuiOpcode::from_usize(opcode - Rv32JalLuiOpcode::CLASS_OFFSET)
         )
+    }
+}
+
+impl<F: PrimeField32, I: VmAdapterInterface<F>> VmCoreChip<F, I> for Rv32JalLuiCoreChip
+where
+    I::Writes: From<[[F; RV32_REGISTER_NUM_LIMBS]; 1]>,
+{
+    type Record = Rv32JalLuiCoreRecord<F>;
+    type Air = Rv32JalLuiCoreAir;
+
+    #[allow(clippy::type_complexity)]
+    fn execute_instruction(
+        &self,
+        instruction: &Instruction<F>,
+        from_pc: u32,
+        _reads: I::Reads,
+    ) -> Result<(AdapterRuntimeContext<F, I>, Self::Record)> {
+        let local_opcode = Rv32JalLuiOpcode::from_usize(
+            instruction
+                .opcode
+                .local_opcode_idx(Rv32JalLuiOpcode::CLASS_OFFSET),
+        );
+        let imm = instruction.c;
+
+        let signed_imm = match local_opcode {
+            JAL => {
+                // Note: signed_imm is a signed integer and imm is a field element
+                (imm + F::from_canonical_u32(1 << (RV_J_TYPE_IMM_BITS - 1))).as_canonical_u32()
+                    as i32
+                    - (1 << (RV_J_TYPE_IMM_BITS - 1))
+            }
+            LUI => imm.as_canonical_u32() as i32,
+        };
+        let (to_pc, rd_data) = run_jal_lui(local_opcode, from_pc, signed_imm);
+
+        for i in 0..(RV32_REGISTER_NUM_LIMBS / 2) {
+            self.bitwise_lookup_chip
+                .request_range(rd_data[i * 2] as u32, rd_data[i * 2 + 1] as u32);
+        }
+
+        if local_opcode == JAL {
+            let last_limb_bits = PC_BITS - RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1);
+            let additional_bits = (last_limb_bits..RV32_CELL_BITS).fold(0, |acc, x| acc + (1 << x));
+            self.bitwise_lookup_chip
+                .request_xor(rd_data[3] as u32, additional_bits);
+        }
+
+        let rd_data = rd_data.map(F::from_canonical_u8);
+
+        let output = AdapterRuntimeContext {
+            to_pc: Some(to_pc),
+            writes: [rd_data].into(),
+        };
+
+        Ok((
+            output,
+            Rv32JalLuiCoreRecord {
+                rd_data,
+                imm,
+                is_jal: local_opcode == JAL,
+                is_lui: local_opcode == LUI,
+            },
+        ))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
+    }
+
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!(
+            "{:?}",
+            Rv32JalLuiOpcode::from_usize(opcode - Rv32JalLuiOpcode::CLASS_OFFSET)
+        )
+    }
+
+    fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
+        let core_cols: &mut Rv32JalLuiCoreCols<F> = row_slice.borrow_mut();
+        core_cols.rd_data = record.rd_data;
+        core_cols.imm = record.imm;
+        core_cols.is_jal = F::from_bool(record.is_jal);
+        core_cols.is_lui = F::from_bool(record.is_lui);
+    }
+
+    fn air(&self) -> &Self::Air {
+        &self.air
     }
 }
 

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -343,12 +343,12 @@ where
             LUI => imm as i32,
         };
 
-        let (to_pc, rd_data) = run_jal_lui(local_opcode, state.pc, signed_imm);
-        let rd_data = rd_data.map(|x| x as u8);
+        let (to_pc, rd_bytes) = run_jal_lui(local_opcode, state.pc, signed_imm);
+        let rd_bytes = rd_bytes.map(|x| x as u8);
 
-        let rd = a.as_canonical_u32();
+        let rd_addr = a.as_canonical_u32();
         unsafe {
-            state.memory.write(RV32_REGISTER_AS, rd, &rd_data);
+            state.memory.write(RV32_REGISTER_AS, rd_addr, &rd_bytes);
         }
 
         state.pc = to_pc;

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, Result, SignedImmInstruction, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, Result, SignedImmInstruction, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
@@ -262,6 +265,17 @@ where
                 imm_sign: g,
             },
         ))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -18,6 +18,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction,
     program::{DEFAULT_PC_STEP, PC_BITS},
+    riscv::RV32_REGISTER_AS,
     LocalOpcode,
 };
 use openvm_rv32im_transpiler::Rv32JalrOpcode::{self, *};
@@ -275,7 +276,48 @@ where
     where
         Mem: GuestMemory,
     {
-        todo!("Implement execute_instruction2")
+        let Instruction {
+            opcode,
+            b,
+            a,
+            c,
+            f: enabled,
+            g,
+            ..
+        } = *instruction;
+
+        let local_opcode =
+            Rv32JalrOpcode::from_usize(opcode.local_opcode_idx(Rv32JalrOpcode::CLASS_OFFSET));
+
+        let rs1 = b.as_canonical_u32();
+        let rs1_data: [u8; RV32_REGISTER_NUM_LIMBS] =
+            unsafe { state.memory.read(RV32_REGISTER_AS, rs1) };
+
+        // TODO(ayush): directly read as u32 from memory
+        let rs1_data = rs1_data
+            .iter()
+            .enumerate()
+            .fold(0u32, |acc, (i, &limb)| acc | ((limb as u32) << (i * 8)));
+
+        let imm = c.as_canonical_u32();
+        let imm_sign = g.as_canonical_u32();
+        let imm_extended = imm + imm_sign * 0xffff0000;
+
+        // TODO(ayush): should this be [u8; 4]?
+        let (to_pc, rd_data) = run_jalr(local_opcode, state.pc, imm_extended, rs1_data);
+        let rd_data = rd_data.map(|x| x as u8);
+
+        // TODO(ayush): do i need this enabled check?
+        if enabled != F::ZERO {
+            let rd = a.as_canonical_u32();
+            unsafe {
+                state.memory.write(RV32_REGISTER_AS, rd, &rd_data);
+            }
+        }
+
+        state.pc = to_pc;
+
+        Ok(())
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -15,7 +15,12 @@ use openvm_circuit_primitives::{
     utils::not,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
+use openvm_instructions::{
+    instruction::Instruction,
+    program::DEFAULT_PC_STEP,
+    riscv::{RV32_IMM_AS, RV32_REGISTER_AS},
+    LocalOpcode,
+};
 use openvm_rv32im_transpiler::LessThanOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -302,43 +307,48 @@ where
         Mem: GuestMemory,
     {
         let Instruction {
-            opcode, a, b, c, ..
+            opcode, a, b, c, e, ..
         } = instruction;
+
         let less_than_opcode = LessThanOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
 
-        // Read register values
-        let b_val = unsafe {
-            state
-                .memory
-                .read::<F, NUM_LIMBS>(RV32_REGISTER_AS, b.as_canonical_u32())
-        };
-        let c_val = unsafe {
-            state
-                .memory
-                .read::<F, NUM_LIMBS>(RV32_REGISTER_AS, c.as_canonical_u32())
+        let rs1_addr = b.as_canonical_u32();
+        let rs1_bytes: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1_addr) };
+
+        let rs2_bytes = if e.as_canonical_u32() == RV32_IMM_AS {
+            // Use immediate value
+            let imm = c.as_canonical_u32();
+            // Convert imm from u32 to [u8; NUM_LIMBS]
+            let imm_bytes = imm.to_le_bytes();
+            // TODO(ayush): remove this
+            let mut rs2_bytes = [0u8; NUM_LIMBS];
+            rs2_bytes[..NUM_LIMBS].copy_from_slice(&imm_bytes[..NUM_LIMBS]);
+            rs2_bytes
+        } else {
+            // Read from register
+            let rs2_addr = c.as_canonical_u32();
+            let rs2_bytes: [u8; NUM_LIMBS] =
+                unsafe { state.memory.read(RV32_REGISTER_AS, rs2_addr) };
+            rs2_bytes
         };
 
-        // Convert to u32 arrays for processing
-        let b_u32 = b_val.map(|x| x.as_canonical_u32());
-        let c_u32 = c_val.map(|x| x.as_canonical_u32());
+        // TODO(ayush): avoid this conversion
+        let rs1_bytes: [u32; NUM_LIMBS] = rs1_bytes.map(|x| x as u32);
+        let rs2_bytes: [u32; NUM_LIMBS] = rs2_bytes.map(|y| y as u32);
 
         // Run the comparison
-        let (cmp_result, diff_idx, _, _) =
-            run_less_than::<NUM_LIMBS, LIMB_BITS>(less_than_opcode, &b_u32, &c_u32);
-
-        // Prepare result
-        let mut result = [F::ZERO; NUM_LIMBS];
-        result[0] = F::from_bool(cmp_result);
+        let (cmp_result, _, _, _) =
+            run_less_than::<NUM_LIMBS, LIMB_BITS>(less_than_opcode, &rs1_bytes, &rs2_bytes);
+        // TODO(ayush): can i write just [u8; 1]?
+        let rd_bytes = (cmp_result as u32).to_le_bytes();
 
         // Write the result back to the destination register
+        let rd_addr = a.as_canonical_u32();
         unsafe {
-            state
-                .memory
-                .write(RV32_REGISTER_AS, a.as_canonical_u32(), &result);
+            state.memory.write(RV32_REGISTER_AS, rd_addr, &rd_bytes);
         }
 
-        // Update PC
-        state.pc += DEFAULT_PC_STEP;
+        state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
     }

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
@@ -288,6 +291,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -3,8 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, Result, VmAdapterInterface, VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, Result, VmAdapterInterface, VmCoreAir,
+        VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     utils::select,
@@ -251,6 +255,17 @@ where
                 shift_amount,
             },
         ))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -15,7 +15,12 @@ use openvm_circuit_primitives::{
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::{
+    instruction::Instruction,
+    program::DEFAULT_PC_STEP,
+    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
+    LocalOpcode,
+};
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -265,101 +270,60 @@ where
     where
         Mem: GuestMemory,
     {
-        // Extract opcode and instruction fields
         let Instruction {
             opcode,
-            a, // rd/rs2 register
-            b, // rs1 register
-            c, // immediate value
-            d, // register address space
-            e, // memory address space
-            g, // immediate sign extension
+            a,
+            b,
+            c,
             f: enabled,
+            g,
             ..
-        } = *instruction;
+        } = instruction;
 
-        // Only proceed if instruction is enabled
-        if enabled == F::ZERO {
-            // Update PC and return if instruction is not enabled
-            state.pc += 4; // Assuming DEFAULT_PC_STEP is 4
-            return Ok(());
-        }
-
-        // Get the local opcode specific to this instruction type
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),
         );
 
-        const RV32_REGISTER_AS: u32 = 1;
-        const RV32_MEMORY_AS: u32 = 2;
+        let rs1_addr = b.as_canonical_u32();
+        let rs1_bytes: [u8; RV32_REGISTER_NUM_LIMBS] =
+            unsafe { state.memory.read(RV32_REGISTER_AS, rs1_addr) };
+        let rs1_val = u32::from_le_bytes(rs1_bytes);
 
-        // Safely read rs1 register value
-        let rs1_val = unsafe {
-            let rs1_bytes: [u8; NUM_CELLS] =
-                state.memory.read(RV32_REGISTER_AS, b.as_canonical_u32());
-            u32::from_le_bytes(rs1_bytes[0..4].try_into().unwrap())
-        };
-
-        // Calculate memory address
         let imm = c.as_canonical_u32();
         let imm_sign = g.as_canonical_u32();
         let imm_extended = imm + imm_sign * 0xffff0000;
+
         let ptr_val = rs1_val.wrapping_add(imm_extended);
         let shift_amount = ptr_val % 4;
-        let aligned_ptr = ptr_val - shift_amount;
+        let ptr_val = ptr_val - shift_amount; // aligned ptr
 
-        // Read memory or register based on opcode
-        let read_data = unsafe {
-            match local_opcode {
-                LOADB | LOADH => state
-                    .memory
-                    .read::<u8, NUM_CELLS>(RV32_MEMORY_AS, aligned_ptr),
-                _ => unreachable!("Only LOADB and LOADH are supported by this core chip"),
-            }
+        let read_bytes: [u8; RV32_REGISTER_NUM_LIMBS] = match local_opcode {
+            LOADB | LOADH => unsafe { state.memory.read(RV32_MEMORY_AS, ptr_val) },
+            _ => unreachable!("Only LOADB and LOADH are supported by LoadSignExtendCoreChip chip"),
         };
+        // TODO(ayush): handle NUM_CELLS and RV32_REGISTER_NUM_LIMBS properly
+        let read_data: [F; NUM_CELLS] = array::from_fn(|i| F::from_canonical_u8(read_bytes[i]));
 
-        // Convert to field elements for processing
-        let read_data_f: [F; NUM_CELLS] = array::from_fn(|i| F::from_canonical_u8(read_data[i]));
-
-        // Placeholder for prev_data (not actually used in calculation but needed for API)
-        let prev_data = unsafe {
-            let prev: [u8; NUM_CELLS] = state.memory.read(RV32_REGISTER_AS, a.as_canonical_u32());
-            array::from_fn(|i| F::from_canonical_u8(prev[i]))
-        };
-
-        // Generate the write data with sign extension
+        // TODO(ayush): clean this up for e1
         let write_data = run_write_data_sign_extend::<_, NUM_CELLS, LIMB_BITS>(
             local_opcode,
-            read_data_f,
-            prev_data,
+            read_data,
+            [F::ZERO; NUM_CELLS],
             shift_amount,
         );
-
-        // Convert back to bytes for writing to memory
         let write_bytes: [u8; NUM_CELLS] =
             array::from_fn(|i| write_data[i].as_canonical_u32() as u8);
 
-        // Write result to destination register
-        unsafe {
-            state
-                .memory
-                .write(RV32_REGISTER_AS, a.as_canonical_u32(), &write_bytes);
+        // Only proceed if instruction is enabled
+        if *enabled != F::ZERO {
+            // Write result to destination register
+            let rd_addr = a.as_canonical_u32();
+            unsafe {
+                state.memory.write(RV32_REGISTER_AS, rd_addr, &write_bytes);
+            }
         }
 
-        // Update program counter
-        state.pc += 4; // Assuming DEFAULT_PC_STEP is 4
-
-        // Tracking the most significant bit for range checking (done at verification time)
-        let most_sig_limb = match local_opcode {
-            LOADB => write_data[0],
-            LOADH => write_data[NUM_CELLS / 2 - 1],
-            _ => unreachable!(),
-        }
-        .as_canonical_u32();
-
-        let most_sig_bit = most_sig_limb & (1 << (LIMB_BITS - 1));
-        self.range_checker_chip
-            .add_count(most_sig_limb - most_sig_bit, LIMB_BITS - 1);
+        state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
     }

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -1,7 +1,11 @@
 use std::borrow::{Borrow, BorrowMut};
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, Result, VmAdapterInterface, VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, Result, VmAdapterInterface, VmCoreAir,
+        VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
@@ -295,6 +299,17 @@ where
                 write_data,
             },
         ))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
     system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS, LocalOpcode};
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -309,7 +309,96 @@ where
     where
         Mem: GuestMemory,
     {
-        todo!("Implement execute_instruction2")
+        let Instruction {
+            opcode,
+            a,
+            b,
+            c,
+            d,
+            e,
+            g,
+            f: enabled,
+            ..
+        } = *instruction;
+
+        // Return early if instruction is disabled
+        if enabled == F::ZERO {
+            return Ok(());
+        }
+
+        // Get the local opcode for this instruction
+        let local_opcode =
+            Rv32LoadStoreOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
+
+        // Read the register value (rs1)
+        let rs1_val = {
+            let rs1_bytes = unsafe { state.memory.read::<u8, NUM_CELLS>(RV32_REGISTER_AS, b) };
+            u32::from_le_bytes(rs1_bytes[0..4].try_into().unwrap())
+        };
+
+        // Calculate memory address
+        let imm = c.as_canonical_u32();
+        let imm_sign = g.as_canonical_u32();
+        let imm_extended = imm + imm_sign * 0xffff0000;
+        let ptr_val = rs1_val.wrapping_add(imm_extended);
+        let shift_amount = ptr_val % 4;
+        let aligned_ptr = ptr_val - shift_amount;
+
+        // Read data based on the opcode
+        let read_data = match local_opcode {
+            LOADW | LOADBU | LOADHU => {
+                // For loads, read from memory
+                unsafe {
+                    state
+                        .memory
+                        .read::<u8, NUM_CELLS>(RV32_MEMORY_AS, aligned_ptr)
+                }
+            }
+            STOREW | STOREH | STOREB => {
+                // For stores, read the register value to be stored
+                unsafe { state.memory.read::<u8, NUM_CELLS>(RV32_REGISTER_AS, a) }
+            }
+        };
+
+        // For stores, we need the previous memory content to preserve unchanged bytes
+        let prev_data = match local_opcode {
+            STOREW | STOREH | STOREB => {
+                // For stores, read current memory content
+                unsafe {
+                    state
+                        .memory
+                        .read::<u8, NUM_CELLS>(RV32_MEMORY_AS, aligned_ptr)
+                }
+            }
+            LOADW | LOADBU | LOADHU => {
+                // For loads, read current register content
+                unsafe { state.memory.read::<u8, NUM_CELLS>(RV32_REGISTER_AS, a) }
+            }
+        };
+
+        // Convert data to field elements for processing
+        let read_data_f = read_data.map(F::from_canonical_u8);
+        let prev_data_f = prev_data.map(F::from_canonical_u8);
+
+        // Process the data according to the load/store type and alignment
+        let write_data_f = run_write_data(local_opcode, read_data_f, prev_data_f, shift_amount);
+
+        // Convert back to bytes for writing
+        let write_data = write_data_f.map(|x| x.as_canonical_u32() as u8);
+
+        // Write data based on the opcode
+        match local_opcode {
+            LOADW | LOADBU | LOADHU => {
+                // For loads, write to register
+                unsafe { state.memory.write(RV32_REGISTER_AS, a, &write_data) };
+            }
+            STOREW | STOREH | STOREB => {
+                // For stores, write to memory
+                unsafe { state.memory.write(RV32_MEMORY_AS, aligned_ptr, &write_data) };
+            }
+        }
+
+        Ok(())
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip};
 use openvm_circuit_primitives_derive::AlignedBorrow;
@@ -192,6 +195,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -5,8 +5,8 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, VmExecutionState,
+        AdapterAirContext, AdapterRuntimeContext, InsExecutorE1, MinimalInstruction, Result,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -199,14 +199,35 @@ where
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("{:?}", MulOpcode::from_usize(opcode - self.air.offset))
+    }
+
+    fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
+        let row_slice: &mut MultiplicationCoreCols<_, NUM_LIMBS, LIMB_BITS> =
+            row_slice.borrow_mut();
+        row_slice.a = record.a;
+        row_slice.b = record.b;
+        row_slice.c = record.c;
+        row_slice.is_valid = F::ONE;
+    }
+
+    fn air(&self) -> &Self::Air {
+        &self.air
+    }
+}
+
+impl<Mem, Ctx, F, const NUM_LIMBS: usize, const LIMB_BITS: usize> InsExecutorE1<Mem, Ctx, F>
+    for MultiplicationCoreChip<NUM_LIMBS, LIMB_BITS>
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
         &mut self,
         state: &mut VmExecutionState<Mem, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction {
             opcode, a, b, c, ..
         } = instruction;
@@ -240,23 +261,6 @@ where
         state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
-    }
-
-    fn get_opcode_name(&self, opcode: usize) -> String {
-        format!("{:?}", MulOpcode::from_usize(opcode - self.air.offset))
-    }
-
-    fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
-        let row_slice: &mut MultiplicationCoreCols<_, NUM_LIMBS, LIMB_BITS> =
-            row_slice.borrow_mut();
-        row_slice.a = record.a;
-        row_slice.b = record.b;
-        row_slice.c = record.c;
-        row_slice.is_valid = F::ONE;
-    }
-
-    fn air(&self) -> &Self::Air {
-        &self.air
     }
 }
 

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -15,7 +15,7 @@ use openvm_circuit_primitives::{
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
 use openvm_rv32im_transpiler::MulHOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -299,7 +299,63 @@ where
     where
         Mem: GuestMemory,
     {
-        todo!("Implement execute_instruction2")
+        let Instruction {
+            opcode, a, b, c, d, ..
+        } = instruction;
+        let mulh_opcode = MulHOpcode::from_usize(opcode.local_opcode_idx(MulHOpcode::CLASS_OFFSET));
+
+        // Read the register values (rs1 and rs2)
+        let rs1_values = unsafe {
+            state
+                .memory
+                .read::<F, NUM_LIMBS>(RV32_REGISTER_AS, b.as_canonical_u32())
+        };
+        let rs2_values = unsafe {
+            state
+                .memory
+                .read::<F, NUM_LIMBS>(RV32_REGISTER_AS, c.as_canonical_u32())
+        };
+
+        // Convert field elements to u32 for calculation
+        let b_values = rs1_values.map(|x| x.as_canonical_u32());
+        let c_values = rs2_values.map(|x| x.as_canonical_u32());
+
+        // Execute the multiplication high operation
+        let (a_values, a_mul, carry, b_ext, c_ext) =
+            run_mulh::<NUM_LIMBS, LIMB_BITS>(mulh_opcode, &b_values, &c_values);
+
+        // Update range tuple counts for proving
+        for i in 0..NUM_LIMBS {
+            self.range_tuple_chip.add_count(&[a_mul[i], carry[i]]);
+            self.range_tuple_chip
+                .add_count(&[a_values[i], carry[NUM_LIMBS + i]]);
+        }
+
+        // Request bitwise operation lookup for sign checks
+        if mulh_opcode != MulHOpcode::MULHU {
+            let b_sign_mask = if b_ext == 0 { 0 } else { 1 << (LIMB_BITS - 1) };
+            let c_sign_mask = if c_ext == 0 { 0 } else { 1 << (LIMB_BITS - 1) };
+            self.bitwise_lookup_chip.request_range(
+                (b_values[NUM_LIMBS - 1] - b_sign_mask) << 1,
+                (c_values[NUM_LIMBS - 1] - c_sign_mask)
+                    << ((mulh_opcode == MulHOpcode::MULH) as u32),
+            );
+        }
+
+        // Convert result back to field elements
+        let result = a_values.map(F::from_canonical_u32);
+
+        // Write the result to the destination register
+        unsafe {
+            state
+                .memory
+                .write(RV32_REGISTER_AS, a.as_canonical_u32(), &result);
+        }
+
+        // Update PC
+        state.pc += DEFAULT_PC_STEP;
+
+        Ok(())
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
@@ -286,6 +289,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -5,8 +5,8 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-        VmCoreAir, VmCoreChip, VmExecutionState,
+        AdapterAirContext, AdapterRuntimeContext, InsExecutorE1, MinimalInstruction, Result,
+        VmAdapterInterface, VmCoreAir, VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
 };
@@ -344,14 +344,62 @@ where
         Ok((output, record))
     }
 
-    fn execute_instruction2<Mem, Ctx>(
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("{:?}", ShiftOpcode::from_usize(opcode - self.air.offset))
+    }
+
+    fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
+        for carry_val in record.bit_shift_carry {
+            self.range_checker_chip
+                .add_count(carry_val, record.bit_shift);
+        }
+
+        let num_bits_log = (NUM_LIMBS * LIMB_BITS).ilog2();
+        self.range_checker_chip.add_count(
+            (((record.c[0].as_canonical_u32() as usize)
+                - record.bit_shift
+                - record.limb_shift * LIMB_BITS)
+                >> num_bits_log) as u32,
+            LIMB_BITS - num_bits_log as usize,
+        );
+
+        let row_slice: &mut ShiftCoreCols<_, NUM_LIMBS, LIMB_BITS> = row_slice.borrow_mut();
+        row_slice.a = record.a;
+        row_slice.b = record.b;
+        row_slice.c = record.c;
+        row_slice.bit_multiplier_left = match record.opcode {
+            ShiftOpcode::SLL => F::from_canonical_usize(1 << record.bit_shift),
+            _ => F::ZERO,
+        };
+        row_slice.bit_multiplier_right = match record.opcode {
+            ShiftOpcode::SLL => F::ZERO,
+            _ => F::from_canonical_usize(1 << record.bit_shift),
+        };
+        row_slice.b_sign = record.b_sign;
+        row_slice.bit_shift_marker = array::from_fn(|i| F::from_bool(i == record.bit_shift));
+        row_slice.limb_shift_marker = array::from_fn(|i| F::from_bool(i == record.limb_shift));
+        row_slice.bit_shift_carry = record.bit_shift_carry.map(F::from_canonical_u32);
+        row_slice.opcode_sll_flag = F::from_bool(record.opcode == ShiftOpcode::SLL);
+        row_slice.opcode_srl_flag = F::from_bool(record.opcode == ShiftOpcode::SRL);
+        row_slice.opcode_sra_flag = F::from_bool(record.opcode == ShiftOpcode::SRA);
+    }
+
+    fn air(&self) -> &Self::Air {
+        &self.air
+    }
+}
+
+impl<Mem, Ctx, F, const NUM_LIMBS: usize, const LIMB_BITS: usize> InsExecutorE1<Mem, Ctx, F>
+    for ShiftCoreChip<NUM_LIMBS, LIMB_BITS>
+where
+    Mem: GuestMemory,
+    F: PrimeField32,
+{
+    fn execute_e1(
         &mut self,
         state: &mut VmExecutionState<Mem, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction {
             opcode, a, b, c, e, ..
         } = instruction;
@@ -395,50 +443,6 @@ where
         state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
-    }
-
-    fn get_opcode_name(&self, opcode: usize) -> String {
-        format!("{:?}", ShiftOpcode::from_usize(opcode - self.air.offset))
-    }
-
-    fn generate_trace_row(&self, row_slice: &mut [F], record: Self::Record) {
-        for carry_val in record.bit_shift_carry {
-            self.range_checker_chip
-                .add_count(carry_val, record.bit_shift);
-        }
-
-        let num_bits_log = (NUM_LIMBS * LIMB_BITS).ilog2();
-        self.range_checker_chip.add_count(
-            (((record.c[0].as_canonical_u32() as usize)
-                - record.bit_shift
-                - record.limb_shift * LIMB_BITS)
-                >> num_bits_log) as u32,
-            LIMB_BITS - num_bits_log as usize,
-        );
-
-        let row_slice: &mut ShiftCoreCols<_, NUM_LIMBS, LIMB_BITS> = row_slice.borrow_mut();
-        row_slice.a = record.a;
-        row_slice.b = record.b;
-        row_slice.c = record.c;
-        row_slice.bit_multiplier_left = match record.opcode {
-            ShiftOpcode::SLL => F::from_canonical_usize(1 << record.bit_shift),
-            _ => F::ZERO,
-        };
-        row_slice.bit_multiplier_right = match record.opcode {
-            ShiftOpcode::SLL => F::ZERO,
-            _ => F::from_canonical_usize(1 << record.bit_shift),
-        };
-        row_slice.b_sign = record.b_sign;
-        row_slice.bit_shift_marker = array::from_fn(|i| F::from_bool(i == record.bit_shift));
-        row_slice.limb_shift_marker = array::from_fn(|i| F::from_bool(i == record.limb_shift));
-        row_slice.bit_shift_carry = record.bit_shift_carry.map(F::from_canonical_u32);
-        row_slice.opcode_sll_flag = F::from_bool(record.opcode == ShiftOpcode::SLL);
-        row_slice.opcode_srl_flag = F::from_bool(record.opcode == ShiftOpcode::SRL);
-        row_slice.opcode_sra_flag = F::from_bool(record.opcode == ShiftOpcode::SRA);
-    }
-
-    fn air(&self) -> &Self::Air {
-        &self.air
     }
 }
 

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -17,7 +17,10 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS, LocalOpcode,
+    instruction::Instruction,
+    program::DEFAULT_PC_STEP,
+    riscv::{RV32_IMM_AS, RV32_REGISTER_AS},
+    LocalOpcode,
 };
 use openvm_rv32im_transpiler::ShiftOpcode;
 use openvm_stark_backend::{
@@ -350,43 +353,46 @@ where
         Mem: GuestMemory,
     {
         let Instruction {
-            opcode, a, b, c, ..
-        } = *instruction;
+            opcode, a, b, c, e, ..
+        } = instruction;
+
         let shift_opcode = ShiftOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
 
-        // Read source register rs1 (b)
-        let rs1_data = unsafe {
-            state
-                .memory
-                .read::<F, NUM_LIMBS>(RV32_REGISTER_AS, b.as_canonical_u32())
+        let rs1_addr = b.as_canonical_u32();
+        let rs1_bytes: [u8; NUM_LIMBS] = unsafe { state.memory.read(RV32_REGISTER_AS, rs1_addr) };
+
+        let rs2_bytes = if e.as_canonical_u32() == RV32_IMM_AS {
+            // Use immediate value
+            let imm = c.as_canonical_u32();
+            // Convert imm from u32 to [u8; NUM_LIMBS]
+            let imm_bytes = imm.to_le_bytes();
+            // TODO(ayush): remove this
+            let mut rs2_bytes = [0u8; NUM_LIMBS];
+            rs2_bytes[..NUM_LIMBS].copy_from_slice(&imm_bytes[..NUM_LIMBS]);
+            rs2_bytes
+        } else {
+            // Read from register
+            let rs2_addr = c.as_canonical_u32();
+            let rs2_bytes: [u8; NUM_LIMBS] =
+                unsafe { state.memory.read(RV32_REGISTER_AS, rs2_addr) };
+            rs2_bytes
         };
 
-        // Read source register rs2 or immediate (c)
-        let rs2_data = unsafe {
-            state
-                .memory
-                .read::<F, NUM_LIMBS>(RV32_REGISTER_AS, c.as_canonical_u32())
-        };
-
-        // Convert data to u32 arrays
-        let b_u32 = rs1_data.map(|x| x.as_canonical_u32());
-        let c_u32 = rs2_data.map(|y| y.as_canonical_u32());
+        // TODO(ayush): avoid this conversion
+        let rs1_bytes: [u32; NUM_LIMBS] = rs1_bytes.map(|x| x as u32);
+        let rs2_bytes: [u32; NUM_LIMBS] = rs2_bytes.map(|y| y as u32);
 
         // Execute the shift operation
-        let (result, _, _) = run_shift::<NUM_LIMBS, LIMB_BITS>(shift_opcode, &b_u32, &c_u32);
+        let (rd_bytes, _, _) =
+            run_shift::<NUM_LIMBS, LIMB_BITS>(shift_opcode, &rs1_bytes, &rs2_bytes);
+        let rd_bytes = rd_bytes.map(|x| x as u8);
 
-        // Convert result back to field elements
-        let result_f = result.map(F::from_canonical_u32);
-
-        // Write the result to the destination register (a)
+        let rd_addr = a.as_canonical_u32();
         unsafe {
-            state
-                .memory
-                .write(RV32_REGISTER_AS, a.as_canonical_u32(), &result_f);
+            state.memory.write(RV32_REGISTER_AS, rd_addr, &rd_bytes);
         }
 
-        // Increment program counter
-        state.pc += DEFAULT_PC_STEP;
+        state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
     }

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -3,9 +3,12 @@ use std::{
     borrow::{Borrow, BorrowMut},
 };
 
-use openvm_circuit::arch::{
-    AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
-    VmCoreAir, VmCoreChip,
+use openvm_circuit::{
+    arch::{
+        AdapterAirContext, AdapterRuntimeContext, MinimalInstruction, Result, VmAdapterInterface,
+        VmCoreAir, VmCoreChip, VmExecutionState,
+    },
+    system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
@@ -334,6 +337,17 @@ where
         };
 
         Ok((output, record))
+    }
+
+    fn execute_instruction2<Mem, Ctx>(
+        &mut self,
+        state: &mut VmExecutionState<Mem, Ctx>,
+        instruction: &Instruction<F>,
+    ) -> Result<()>
+    where
+        Mem: GuestMemory,
+    {
+        todo!("Implement execute_instruction2")
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {


### PR DESCRIPTION
- introduce a new generic `InsExecutorE1` trait 
- add `InsExecutor::execute_e1` for rv32im instructions