### PR TITLE
feat: Add e2e stark proof support

### DIFF
--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -2,17 +2,17 @@ use std::{path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use eyre::Result;
+#[cfg(feature = "evm-prove")]
+use openvm_sdk::fs::write_evm_proof_to_file;
 use openvm_sdk::{
     commit::AppExecutionCommit,
-    config::SdkVmConfig,
-    fs::{encode_to_file, read_app_pk_from_file, read_exe_from_file, write_app_proof_to_file},
+    config::{AggregationTreeConfig, SdkVmConfig},
+    fs::{
+        encode_to_file, read_agg_pk_from_file, read_app_pk_from_file, read_exe_from_file,
+        write_app_proof_to_file,
+    },
     keygen::AppProvingKey,
     NonRootCommittedExe, Sdk, StdIn,
-};
-#[cfg(feature = "evm-prove")]
-use openvm_sdk::{
-    config::AggregationTreeConfig,
-    fs::{read_agg_pk_from_file, write_evm_proof_to_file},
 };
 
 use crate::{

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 use openvm_sdk::{
     commit::AppExecutionCommit,
     config::SdkVmConfig,
-    fs::{read_app_pk_from_file, read_exe_from_file, write_app_proof_to_file},
+    fs::{encode_to_file, read_app_pk_from_file, read_exe_from_file, write_app_proof_to_file},
     keygen::AppProvingKey,
     NonRootCommittedExe, Sdk, StdIn,
 };
@@ -42,6 +42,22 @@ enum ProveSubCommand {
         #[arg(long, action, help = "Path to output proof", default_value = DEFAULT_APP_PROOF_PATH)]
         output: PathBuf,
     },
+    Stark {
+        #[arg(long, action, help = "Path to app proving key", default_value = DEFAULT_APP_PK_PATH)]
+        app_pk: PathBuf,
+
+        #[arg(long, action, help = "Path to OpenVM executable", default_value = DEFAULT_APP_EXE_PATH)]
+        exe: PathBuf,
+
+        #[arg(long, value_parser, help = "Input to OpenVM program")]
+        input: Option<Input>,
+
+        #[arg(long, action, help = "Path to output proof", default_value = DEFAULT_APP_PROOF_PATH)]
+        output: PathBuf,
+
+        #[command(flatten)]
+        agg_tree_config: AggregationTreeConfig,
+    },
     #[cfg(feature = "evm-prove")]
     Evm {
         #[arg(long, action, help = "Path to app proving key", default_value = DEFAULT_APP_PK_PATH)]
@@ -75,6 +91,28 @@ impl ProveCmd {
                     Self::prepare_execution(&sdk, app_pk, exe, input)?;
                 let app_proof = sdk.generate_app_proof(app_pk, committed_exe, input)?;
                 write_app_proof_to_file(app_proof, output)?;
+            }
+            ProveSubCommand::Stark {
+                app_pk,
+                exe,
+                input,
+                output,
+                agg_tree_config,
+            } => {
+                let mut sdk = sdk;
+                sdk.set_agg_tree_config(*agg_tree_config);
+                let (app_pk, committed_exe, input) =
+                    Self::prepare_execution(&sdk, app_pk, exe, input)?;
+                let agg_pk = read_agg_pk_from_file(DEFAULT_AGG_PK_PATH).map_err(|e| {
+                    eyre::eyre!("Failed to read aggregation proving key: {}\nPlease run 'cargo openvm setup' first", e)
+                })?;
+                let stark_proof = sdk.generate_e2e_stark_proof(
+                    app_pk,
+                    committed_exe,
+                    agg_pk.agg_stark_pk,
+                    input,
+                )?;
+                encode_to_file(output, stark_proof)?;
             }
             #[cfg(feature = "evm-prove")]
             ProveSubCommand::Evm {

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -3,7 +3,9 @@ use std::io::{self, Cursor, Read, Result, Write};
 use openvm_circuit::{
     arch::ContinuationVmProof, system::memory::tree::public_values::UserPublicValuesProof,
 };
-use openvm_continuations::verifier::root::types::RootVmVerifierInput;
+use openvm_continuations::verifier::{
+    internal::types::E2eStarkProof, root::types::RootVmVerifierInput,
+};
 use openvm_native_compiler::ir::DIGEST_SIZE;
 use openvm_native_recursion::hints::{InnerBatchOpening, InnerFriProof, InnerQueryProof};
 use openvm_stark_backend::{
@@ -17,7 +19,6 @@ use openvm_stark_backend::{
 use p3_fri::CommitPhaseProofStep;
 
 use super::{F, SC};
-use crate::types::E2eStarkProof; // BabyBearPoseidon2Config
 
 type Challenge = BinomialExtensionField<F, 4>;
 
@@ -60,7 +61,7 @@ impl Encode for ContinuationVmProof<SC> {
     }
 }
 
-impl Encode for E2eStarkProof {
+impl Encode for E2eStarkProof<SC> {
     fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
         self.proof.encode(writer)?;
         encode_slice(&self.user_public_values, writer)
@@ -331,7 +332,7 @@ impl Decode for ContinuationVmProof<SC> {
     }
 }
 
-impl Decode for E2eStarkProof {
+impl Decode for E2eStarkProof<SC> {
     fn decode<R: Read>(reader: &mut R) -> Result<Self> {
         let proof = Proof::decode(reader)?;
         let user_public_values = decode_vec(reader)?;

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -16,7 +16,8 @@ use openvm_stark_backend::{
 };
 use p3_fri::CommitPhaseProofStep;
 
-use super::{F, SC}; // BabyBearPoseidon2Config
+use super::{F, SC};
+use crate::types::E2eStarkProof; // BabyBearPoseidon2Config
 
 type Challenge = BinomialExtensionField<F, 4>;
 
@@ -56,6 +57,13 @@ impl Encode for ContinuationVmProof<SC> {
     fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
         encode_slice(&self.per_segment, writer)?;
         self.user_public_values.encode(writer)
+    }
+}
+
+impl Encode for E2eStarkProof {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<()> {
+        self.proof.encode(writer)?;
+        encode_slice(&self.user_public_values, writer)
     }
 }
 
@@ -318,6 +326,17 @@ impl Decode for ContinuationVmProof<SC> {
         let user_public_values = UserPublicValuesProof::decode(reader)?;
         Ok(Self {
             per_segment,
+            user_public_values,
+        })
+    }
+}
+
+impl Decode for E2eStarkProof {
+    fn decode<R: Read>(reader: &mut R) -> Result<Self> {
+        let proof = Proof::decode(reader)?;
+        let user_public_values = decode_vec(reader)?;
+        Ok(Self {
+            proof,
             user_public_values,
         })
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -58,6 +58,8 @@ pub mod prover;
 mod stdin;
 pub use stdin::*;
 
+use crate::types::E2eStarkProof;
+
 pub mod fs;
 pub mod types;
 
@@ -265,6 +267,23 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         let stark_prover =
             StarkProver::<VC, E>::new(app_pk, app_exe, agg_stark_pk, self.agg_tree_config);
         let proof = stark_prover.generate_root_verifier_input(inputs);
+        Ok(proof)
+    }
+
+    pub fn generate_e2e_stark_proof<VC: VmConfig<F>>(
+        &self,
+        app_pk: Arc<AppProvingKey<VC>>,
+        app_exe: Arc<NonRootCommittedExe>,
+        agg_stark_pk: AggStarkProvingKey,
+        inputs: StdIn,
+    ) -> Result<E2eStarkProof>
+    where
+        VC::Executor: Chip<SC>,
+        VC::Periphery: Chip<SC>,
+    {
+        let stark_prover =
+            StarkProver::<VC, E>::new(app_pk, app_exe, agg_stark_pk, self.agg_tree_config);
+        let proof = stark_prover.generate_e2e_stark_proof(inputs);
         Ok(proof)
     }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -20,7 +20,9 @@ use openvm_circuit::{
         program::trace::VmCommittedExe,
     },
 };
-use openvm_continuations::verifier::root::types::RootVmVerifierInput;
+use openvm_continuations::verifier::{
+    internal::types::E2eStarkProof, root::types::RootVmVerifierInput,
+};
 pub use openvm_continuations::{
     static_verifier::{DefaultStaticVerifierPvHandler, StaticVerifierPvHandler},
     RootSC, C, F, SC,
@@ -57,8 +59,6 @@ pub mod prover;
 
 mod stdin;
 pub use stdin::*;
-
-use crate::types::E2eStarkProof;
 
 pub mod fs;
 pub mod types;
@@ -276,7 +276,7 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         app_exe: Arc<NonRootCommittedExe>,
         agg_stark_pk: AggStarkProvingKey,
         inputs: StdIn,
-    ) -> Result<E2eStarkProof>
+    ) -> Result<E2eStarkProof<SC>>
     where
         VC::Executor: Chip<SC>,
         VC::Periphery: Chip<SC>,

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use openvm_circuit::arch::ContinuationVmProof;
 use openvm_continuations::verifier::{
-    internal::types::InternalVmVerifierInput, leaf::types::LeafVmVerifierInput,
+    internal::types::{E2eStarkProof, InternalVmVerifierInput},
+    leaf::types::LeafVmVerifierInput,
     root::types::RootVmVerifierInput,
 };
 use openvm_native_circuit::NativeConfig;
@@ -18,7 +19,6 @@ use crate::{
         vm::{local::VmLocalProver, SingleSegmentVmProver},
         RootVerifierLocalProver,
     },
-    types::E2eStarkProof,
     NonRootCommittedExe, RootSC, F, SC,
 };
 
@@ -104,7 +104,7 @@ impl<E: StarkFriEngine<SC>> AggStarkProver<E> {
         &self,
         leaf_proofs: Vec<Proof<SC>>,
         public_values: Vec<F>,
-    ) -> E2eStarkProof {
+    ) -> E2eStarkProof<SC> {
         let mut internal_node_idx = -1;
         let mut internal_node_height = 0;
         let mut proofs = leaf_proofs;
@@ -147,7 +147,10 @@ impl<E: StarkFriEngine<SC>> AggStarkProver<E> {
     }
 
     /// Wrap the e2e stark proof until its heights meet the requirements of the root verifier.
-    pub fn wrap_e2e_stark_proof(&self, e2e_stark_proof: E2eStarkProof) -> RootVmVerifierInput<SC> {
+    pub fn wrap_e2e_stark_proof(
+        &self,
+        e2e_stark_proof: E2eStarkProof<SC>,
+    ) -> RootVmVerifierInput<SC> {
         let internal_commit = self
             .internal_prover
             .committed_exe
@@ -211,7 +214,7 @@ pub fn wrap_e2e_stark_proof<E: StarkFriEngine<SC>>(
     root_prover: &RootVerifierLocalProver,
     internal_commit: [F; DIGEST_SIZE],
     max_internal_wrapper_layers: usize,
-    e2e_stark_proof: E2eStarkProof,
+    e2e_stark_proof: E2eStarkProof<SC>,
 ) -> RootVmVerifierInput<SC> {
     let E2eStarkProof {
         mut proof,

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use openvm_circuit::arch::VmConfig;
-use openvm_continuations::verifier::root::types::RootVmVerifierInput;
+use openvm_continuations::verifier::{
+    internal::types::E2eStarkProof, root::types::RootVmVerifierInput,
+};
 use openvm_stark_backend::{proof::Proof, Chip};
 use openvm_stark_sdk::engine::StarkFriEngine;
 
@@ -9,7 +11,6 @@ use crate::{
     config::AggregationTreeConfig,
     keygen::{AggStarkProvingKey, AppProvingKey},
     prover::{agg::AggStarkProver, app::AppProver},
-    types::E2eStarkProof,
     NonRootCommittedExe, RootSC, StdIn, F, SC,
 };
 
@@ -70,7 +71,7 @@ impl<VC, E: StarkFriEngine<SC>> StarkProver<VC, E> {
         self.agg_prover.generate_root_verifier_input(app_proof)
     }
 
-    pub fn generate_e2e_stark_proof(&self, input: StdIn) -> E2eStarkProof
+    pub fn generate_e2e_stark_proof(&self, input: StdIn) -> E2eStarkProof<SC>
     where
         VC: VmConfig<F>,
         VC::Executor: Chip<SC>,

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -9,6 +9,7 @@ use crate::{
     config::AggregationTreeConfig,
     keygen::{AggStarkProvingKey, AppProvingKey},
     prover::{agg::AggStarkProver, app::AppProver},
+    types::E2eStarkProof,
     NonRootCommittedExe, RootSC, StdIn, F, SC,
 };
 
@@ -67,5 +68,17 @@ impl<VC, E: StarkFriEngine<SC>> StarkProver<VC, E> {
     {
         let app_proof = self.app_prover.generate_app_proof(input);
         self.agg_prover.generate_root_verifier_input(app_proof)
+    }
+
+    pub fn generate_e2e_stark_proof(&self, input: StdIn) -> E2eStarkProof
+    where
+        VC: VmConfig<F>,
+        VC::Executor: Chip<SC>,
+        VC::Periphery: Chip<SC>,
+    {
+        let app_proof = self.app_prover.generate_app_proof(input);
+        let leaf_proofs = self.agg_prover.generate_leaf_proofs(&app_proof);
+        self.agg_prover
+            .generate_e2e_stark_proof(leaf_proofs, app_proof.user_public_values.public_values)
     }
 }

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,9 +1,7 @@
 use std::iter::{once, repeat};
 
 use itertools::Itertools;
-use openvm_continuations::{F, SC};
 use openvm_native_recursion::halo2::{wrapper::EvmVerifierByteCode, Fr, RawEvmProof};
-use openvm_stark_backend::proof::Proof;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
@@ -49,12 +47,6 @@ pub struct EvmProof {
     pub user_public_values: Vec<u8>,
     /// The concatenation of `accumulator` and `proof`.
     pub proof_data: ProofData,
-}
-
-#[derive(Clone, Deserialize, Serialize)]
-pub struct E2eStarkProof {
-    pub proof: Proof<SC>,
-    pub user_public_values: Vec<F>,
 }
 
 #[derive(Debug, Error)]

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,7 +1,9 @@
 use std::iter::{once, repeat};
 
 use itertools::Itertools;
+use openvm_continuations::{F, SC};
 use openvm_native_recursion::halo2::{wrapper::EvmVerifierByteCode, Fr, RawEvmProof};
+use openvm_stark_backend::proof::Proof;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
@@ -47,6 +49,12 @@ pub struct EvmProof {
     pub user_public_values: Vec<u8>,
     /// The concatenation of `accumulator` and `proof`.
     pub proof_data: ProofData,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct E2eStarkProof {
+    pub proof: Proof<SC>,
+    pub user_public_values: Vec<F>,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
- Add new type `E2eStarkProof` as the format of the final internal proof. `E2eStarkProof` supports `Encode` so it can be deserialized in other languages.
- Add function `wrap_e2e_stark_proof` to wrap the final internal proof to `RootVerifierInput`.
- Add `cargo openvm prove stark` to generate e2e stark proof.

closes INT-3784