### PR TITLE
feat: Add Rv32HintLoadByKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ name = "openvm-rv32im-guest"
 version = "1.0.1-rc.0"
 dependencies = [
  "openvm-custom-insn",
+ "p3-field",
  "strum_macros",
 ]
 
@@ -4761,6 +4762,7 @@ dependencies = [
  "openvm-circuit",
  "openvm-instructions",
  "openvm-rv32im-circuit",
+ "openvm-rv32im-guest",
  "openvm-rv32im-transpiler",
  "openvm-stark-sdk",
  "openvm-toolchain-tests",

--- a/crates/toolchain/openvm/src/io/mod.rs
+++ b/crates/toolchain/openvm/src/io/mod.rs
@@ -56,6 +56,16 @@ fn hint_store_word(ptr: *mut u32) {
     }
 }
 
+/// Load hints by key and append into the input stream.
+#[allow(unused_variables)]
+#[inline(always)]
+pub fn hint_load_by_key(key: &[u8]) {
+    #[cfg(target_os = "zkvm")]
+    openvm_rv32im_guest::hint_load_by_key(key.as_ptr(), key.len() as u32);
+    #[cfg(not(target_os = "zkvm"))]
+    panic!("hint_load_by_key cannot run on non-zkVM platforms");
+}
+
 /// Read the next `len` bytes from the hint stream into a vector.
 pub(crate) fn read_vec_by_len(len: usize) -> Vec<u8> {
     let num_words = len.div_ceil(4);

--- a/docs/specs/isa-table.md
+++ b/docs/specs/isa-table.md
@@ -75,11 +75,12 @@ In the tables below, we provide the mapping between the `LocalOpcode` and `Phant
 
 #### Phantom Sub-Instructions
 
-| VM Extension | `PhantomDiscriminant` | ISA Phantom Sub-Instruction |
-| ------------- | ---------- | ------------- |
-| RV32IM | `Rv32Phantom::HintInput` | Rv32HintInput |
-| RV32IM | `Rv32Phantom::PrintStr` | Rv32PrintStr |
-| RV32IM | `Rv32Phantom::HintRandom` | Rv32HintRandom |
+| VM Extension | `PhantomDiscriminant`         | ISA Phantom Sub-Instruction |
+| ------------- |-------------------------------| ------------- |
+| RV32IM | `Rv32Phantom::HintInput`      | Rv32HintInput |
+| RV32IM | `Rv32Phantom::PrintStr`       | Rv32PrintStr |
+| RV32IM | `Rv32Phantom::HintRandom`     | Rv32HintRandom |
+| RV32IM | `Rv32Phantom::HintLoadByKey` | Rv32HintLoadByKey |
 
 ## Native Extension
 

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -113,7 +113,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub struct NativeLoadStoreCoreChip<F: Field, const NUM_CELLS: usize> {
     pub air: NativeLoadStoreCoreAir<NUM_CELLS>,
     pub streams: OnceLock<Arc<Mutex<Streams<F>>>>,
@@ -127,7 +126,10 @@ impl<F: Field, const NUM_CELLS: usize> NativeLoadStoreCoreChip<F, NUM_CELLS> {
         }
     }
     pub fn set_streams(&mut self, streams: Arc<Mutex<Streams<F>>>) {
-        self.streams.set(streams).unwrap();
+        self.streams
+            .set(streams)
+            .map_err(|_| "streams have already been set.")
+            .unwrap();
     }
 }
 

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -352,6 +352,10 @@ impl<F: PrimeField32> VmExtension<F> for Rv32I {
             phantom::Rv32PrintStrSubEx,
             PhantomDiscriminant(Rv32Phantom::PrintStr as u16),
         )?;
+        builder.add_phantom_sub_executor(
+            phantom::Rv32HintLoadByKeySubEx,
+            PhantomDiscriminant(Rv32Phantom::HintLoadByKey as u16),
+        )?;
 
         Ok(inventory)
     }
@@ -504,6 +508,7 @@ mod phantom {
         }
     }
     pub struct Rv32PrintStrSubEx;
+    pub struct Rv32HintLoadByKeySubEx;
 
     impl<F: Field> PhantomSubExecutor<F> for Rv32HintInputSubEx {
         fn phantom_execute(
@@ -578,5 +583,60 @@ mod phantom {
             print!("{peeked_str}");
             Ok(())
         }
+    }
+
+    impl<F: PrimeField32> PhantomSubExecutor<F> for Rv32HintLoadByKeySubEx {
+        fn phantom_execute(
+            &mut self,
+            memory: &MemoryController<F>,
+            streams: &mut Streams<F>,
+            _: PhantomDiscriminant,
+            a: F,
+            b: F,
+            _: u16,
+        ) -> eyre::Result<()> {
+            let ptr = unsafe_read_rv32_register(memory, a);
+            let len = unsafe_read_rv32_register(memory, b);
+            let key: Vec<u8> = (0..len)
+                .map(|i| {
+                    memory
+                        .unsafe_read_cell(F::TWO, F::from_canonical_u32(ptr + i))
+                        .as_canonical_u32() as u8
+                })
+                .collect();
+            if let Some(val) = streams.kv_store.get(&key) {
+                let to_push = hint_load_by_key_decode::<F>(val);
+                for input in to_push.into_iter().rev() {
+                    streams.input_stream.push_front(input);
+                }
+            } else {
+                bail!("Rv32HintLoadByKey: key not found");
+            }
+            Ok(())
+        }
+    }
+
+    pub fn hint_load_by_key_decode<F: PrimeField32>(value: &[u8]) -> Vec<Vec<F>> {
+        let mut offset = 0;
+        let len = extract_u32(value, offset) as usize;
+        offset += 4;
+        let mut ret = Vec::with_capacity(len);
+        for _ in 0..len {
+            let v_len = extract_u32(value, offset) as usize;
+            offset += 4;
+            let v = (0..v_len)
+                .map(|_| {
+                    let ret = F::from_canonical_u32(extract_u32(value, offset));
+                    offset += 4;
+                    ret
+                })
+                .collect();
+            ret.push(v);
+        }
+        ret
+    }
+
+    fn extract_u32(value: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes(value[offset..offset + 4].try_into().unwrap())
     }
 }

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -313,7 +313,10 @@ impl<F: PrimeField32> Rv32HintStoreChip<F> {
         }
     }
     pub fn set_streams(&mut self, streams: Arc<Mutex<Streams<F>>>) {
-        self.streams.set(streams).unwrap();
+        self.streams
+            .set(streams)
+            .map_err(|_| "streams have already been set.")
+            .unwrap();
     }
 }
 

--- a/extensions/rv32im/guest/Cargo.toml
+++ b/extensions/rv32im/guest/Cargo.toml
@@ -11,5 +11,8 @@ repository.workspace = true
 openvm-custom-insn = { workspace = true }
 strum_macros = { workspace = true }
 
+[target.'cfg(not(target_os = "zkvm"))'.dependencies]
+p3-field = { workspace = true }
+
 [features]
 default = []

--- a/extensions/rv32im/guest/src/io.rs
+++ b/extensions/rv32im/guest/src/io.rs
@@ -55,6 +55,18 @@ pub fn hint_random(len: usize) {
     );
 }
 
+/// Hint the VM to load values with key = [ptr: len] into input streams.
+#[inline(always)]
+pub fn hint_load_by_key(ptr: *const u8, len: u32) {
+    openvm_custom_insn::custom_insn_i!(
+        opcode = SYSTEM_OPCODE,
+        funct3 = PHANTOM_FUNCT3,
+        rd = In ptr,
+        rs1 = In len,
+        imm = Const PhantomImm::HintLoadByKey as u16,
+    );
+}
+
 /// Store rs1 to [[rd] + imm]_3.
 #[macro_export]
 macro_rules! reveal {

--- a/extensions/rv32im/guest/src/lib.rs
+++ b/extensions/rv32im/guest/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
+extern crate alloc;
 
 /// Library functions for user input/output.
 #[cfg(target_os = "zkvm")]
 mod io;
+
 #[cfg(target_os = "zkvm")]
 pub use io::*;
 use strum_macros::FromRepr;
@@ -28,4 +30,19 @@ pub enum PhantomImm {
     HintInput = 0,
     PrintStr,
     HintRandom,
+    HintLoadByKey,
+}
+
+/// Encode a 2d-array of field elements into bytes for `hint_load_by_key`
+#[cfg(not(target_os = "zkvm"))]
+pub fn hint_load_by_key_encode<F: p3_field::PrimeField32>(
+    value: &[alloc::vec::Vec<F>],
+) -> alloc::vec::Vec<u8> {
+    let len = value.len();
+    let mut ret = (len as u32).to_le_bytes().to_vec();
+    for v in value {
+        ret.extend((v.len() as u32).to_le_bytes());
+        ret.extend(v.iter().flat_map(|x| x.as_canonical_u32().to_le_bytes()));
+    }
+    ret
 }

--- a/extensions/rv32im/tests/Cargo.toml
+++ b/extensions/rv32im/tests/Cargo.toml
@@ -13,6 +13,7 @@ openvm-stark-sdk.workspace = true
 openvm-circuit = { workspace = true, features = ["test-utils"] }
 openvm-transpiler.workspace = true
 openvm-rv32im-circuit.workspace = true
+openvm-rv32im-guest.workspace = true
 openvm-rv32im-transpiler.workspace = true
 openvm = { workspace = true }
 openvm-toolchain-tests = { path = "../../../crates/toolchain/tests" }

--- a/extensions/rv32im/tests/programs/examples/hint_load_by_key.rs
+++ b/extensions/rv32im/tests/programs/examples/hint_load_by_key.rs
@@ -1,0 +1,32 @@
+#![cfg_attr(not(feature = "std"), no_main)]
+#![cfg_attr(not(feature = "std"), no_std)]
+use openvm::io::{hint_load_by_key, read_vec};
+
+openvm::entry!(main);
+
+pub fn main() {
+    const KEY: &str = "key";
+    hint_load_by_key(KEY.as_bytes());
+
+    let vec = read_vec();
+    // assert_eq!(vec.len(), 4);
+    if vec.len() != 4 {
+        openvm::process::panic();
+    }
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..4 {
+        if vec[i] != i as u8 {
+            openvm::process::panic();
+        }
+    }
+    let vec = read_vec();
+    if vec.len() != 3 {
+        openvm::process::panic();
+    }
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..3 {
+        if vec[i] != i as u8 {
+            openvm::process::panic();
+        }
+    }
+}

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -1,13 +1,16 @@
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
     use eyre::Result;
     use openvm_circuit::{
-        arch::{hasher::poseidon2::vm_poseidon2_hasher, ExecutionError, VmExecutor},
+        arch::{hasher::poseidon2::vm_poseidon2_hasher, ExecutionError, Streams, VmExecutor},
         system::memory::tree::public_values::UserPublicValuesProof,
         utils::{air_test, air_test_with_min_segments},
     };
     use openvm_instructions::exe::VmExe;
     use openvm_rv32im_circuit::{Rv32IConfig, Rv32ImConfig};
+    use openvm_rv32im_guest::hint_load_by_key_encode;
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
@@ -84,6 +87,29 @@ mod tests {
         let config = Rv32IConfig::default();
         let input = vec![[0, 1, 2, 3].map(F::from_canonical_u8).to_vec()];
         air_test_with_min_segments(config, exe, input, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_hint_load_by_key() -> Result<()> {
+        let elf = build_example_program_at_path(get_programs_dir!(), "hint_load_by_key")?;
+        let exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv32ITranspilerExtension)
+                .with_extension(Rv32MTranspilerExtension)
+                .with_extension(Rv32IoTranspilerExtension),
+        )?;
+        let config = Rv32IConfig::default();
+        // stdin will be read after reading kv_store
+        let stdin = vec![[0, 1, 2].map(F::from_canonical_u8).to_vec()];
+        let mut streams: Streams<F> = stdin.into();
+        let input = vec![[0, 1, 2, 3].map(F::from_canonical_u8).to_vec()];
+        streams.kv_store = Arc::new(HashMap::from([(
+            "key".as_bytes().to_vec(),
+            hint_load_by_key_encode(&input),
+        )]));
+        air_test_with_min_segments(config, exe, streams, 1);
         Ok(())
     }
 

--- a/extensions/rv32im/transpiler/src/instructions.rs
+++ b/extensions/rv32im/transpiler/src/instructions.rs
@@ -279,4 +279,6 @@ pub enum Rv32Phantom {
     PrintStr,
     /// Prepare given amount of random numbers for hinting.
     HintRandom,
+    /// Hint the VM to load values from the stream KV store into input streams.
+    HintLoadByKey,
 }

--- a/extensions/rv32im/transpiler/src/lib.rs
+++ b/extensions/rv32im/transpiler/src/lib.rs
@@ -91,6 +91,12 @@ impl<F: PrimeField32> TranspilerExtension<F> for Rv32ITranspilerExtension {
                         F::from_canonical_usize(RV32_REGISTER_NUM_LIMBS * dec_insn.rs1),
                         0,
                     ),
+                    PhantomImm::HintLoadByKey => Instruction::phantom(
+                        PhantomDiscriminant(Rv32Phantom::HintLoadByKey as u16),
+                        F::from_canonical_usize(RV32_REGISTER_NUM_LIMBS * dec_insn.rd),
+                        F::from_canonical_usize(RV32_REGISTER_NUM_LIMBS * dec_insn.rs1),
+                        0,
+                    ),
                 })
             }
             (RV32_ALU_OPCODE, _) => {


### PR DESCRIPTION
- Add `kv_store` into `Streams`. More details at `docs/specs/ISA.md`.
- Add a new phantom instruction `Rv32HintLoadByKey` which can hint data based on a key at runtime. More details at `docs/specs/ISA.md`.
- SDK support will be added in the future PRs.

close INT-3893