### PR TITLE
feat: Root Verifier ASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,6 +4828,7 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-transpiler",
  "p3-fri",
+ "rrs-lib",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -17,7 +17,9 @@ use openvm_sdk::{
     DefaultStaticVerifierPvHandler, Sdk,
 };
 
-use crate::default::{DEFAULT_AGG_PK_PATH, DEFAULT_EVM_HALO2_VERIFIER_PATH, DEFAULT_PARAMS_DIR};
+use crate::default::{
+    DEFAULT_AGG_PK_PATH, DEFAULT_ASM_PATH, DEFAULT_EVM_HALO2_VERIFIER_PATH, DEFAULT_PARAMS_DIR,
+};
 
 #[derive(Parser)]
 #[command(
@@ -56,11 +58,17 @@ impl EvmProvingSetupCmd {
         println!("Generating proving key...");
         let agg_pk = sdk.agg_keygen(agg_config, &params_reader, &DefaultStaticVerifierPvHandler)?;
 
+        println!("Generating root verifier ASM...");
+        let root_verifier_asm = sdk.generate_root_verifier_asm(&agg_pk.agg_stark_pk);
+
         println!("Generating verifier contract...");
         let verifier = sdk.generate_halo2_verifier_solidity(&params_reader, &agg_pk)?;
 
         println!("Writing proving key to file...");
         write_agg_pk_to_file(agg_pk, DEFAULT_AGG_PK_PATH)?;
+
+        println!("Writing root verifier ASM to file...");
+        write(DEFAULT_ASM_PATH, root_verifier_asm)?;
 
         println!("Writing verifier contract to file...");
         write_evm_halo2_verifier_to_folder(verifier, DEFAULT_EVM_HALO2_VERIFIER_PATH)?;

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -4,6 +4,7 @@ use openvm_stark_sdk::config::FriParameters;
 pub const DEFAULT_MANIFEST_DIR: &str = ".";
 
 pub const DEFAULT_AGG_PK_PATH: &str = concat!(env!("HOME"), "/.openvm/agg.pk");
+pub const DEFAULT_ASM_PATH: &str = concat!(env!("HOME"), "/.openvm/root.asm");
 pub const DEFAULT_PARAMS_DIR: &str = concat!(env!("HOME"), "/.openvm/params/");
 
 pub const DEFAULT_EVM_HALO2_VERIFIER_PATH: &str = concat!(env!("HOME"), "/.openvm/halo2/");

--- a/crates/continuations/src/verifier/internal/mod.rs
+++ b/crates/continuations/src/verifier/internal/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 pub mod types;
-mod vars;
+pub mod vars;
 
 /// Config to generate internal VM verifier program.
 pub struct InternalVmVerifierConfig {

--- a/crates/continuations/src/verifier/internal/vars.rs
+++ b/crates/continuations/src/verifier/internal/vars.rs
@@ -5,8 +5,11 @@ use openvm_native_recursion::{hints::Hintable, vars::StarkProofVariable};
 use openvm_stark_sdk::openvm_stark_backend::proof::Proof;
 
 use crate::{
-    verifier::{internal::types::InternalVmVerifierInput, utils::write_field_slice},
-    C, SC,
+    verifier::{
+        internal::types::{E2eStarkProof, InternalVmVerifierInput},
+        utils::write_field_slice,
+    },
+    C, F, SC,
 };
 
 #[derive(DslVariable, Clone)]
@@ -14,6 +17,12 @@ pub struct InternalVmVerifierInputVariable<C: Config> {
     pub self_program_commit: [Felt<C::F>; DIGEST_SIZE],
     /// The proofs of the execution segments in the execution order.
     pub proofs: Array<C, StarkProofVariable<C>>,
+}
+
+#[derive(DslVariable, Clone)]
+pub struct E2eStarkProofVariable<C: Config> {
+    pub proof: StarkProofVariable<C>,
+    pub user_public_values: Array<C, Felt<C::F>>,
 }
 
 impl Hintable<C> for InternalVmVerifierInput<SC> {
@@ -31,6 +40,25 @@ impl Hintable<C> for InternalVmVerifierInput<SC> {
     fn write(&self) -> Vec<Vec<<C as Config>::N>> {
         let mut stream = write_field_slice(&self.self_program_commit);
         stream.extend(self.proofs.write());
+        stream
+    }
+}
+
+impl Hintable<C> for E2eStarkProof<SC> {
+    type HintVariable = E2eStarkProofVariable<C>;
+
+    fn read(builder: &mut Builder<C>) -> Self::HintVariable {
+        let proof = Proof::<SC>::read(builder);
+        let user_public_values = Vec::<F>::read(builder);
+        Self::HintVariable {
+            proof,
+            user_public_values,
+        }
+    }
+
+    fn write(&self) -> Vec<Vec<<C as Config>::N>> {
+        let mut stream = self.proof.write();
+        stream.extend(self.user_public_values.write());
         stream
     }
 }

--- a/crates/continuations/src/verifier/root/mod.rs
+++ b/crates/continuations/src/verifier/root/mod.rs
@@ -1,11 +1,12 @@
 use std::array;
 
 use openvm_circuit::arch::instructions::program::Program;
-use openvm_native_compiler::{conversion::CompilerOptions, prelude::*};
+use openvm_native_compiler::{asm::HEAP_START_ADDRESS, conversion::CompilerOptions, prelude::*};
 use openvm_native_recursion::{
     fri::TwoAdicFriPcsVariable, hints::Hintable, types::new_from_inner_multi_vk,
     utils::const_fri_config,
 };
+use openvm_stark_backend::proof::Proof;
 use openvm_stark_sdk::{
     config::FriParameters,
     openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, p3_field::FieldAlgebra},
@@ -30,7 +31,7 @@ mod vars;
 pub struct RootVmVerifierConfig {
     pub leaf_fri_params: FriParameters,
     pub internal_fri_params: FriParameters,
-    pub num_public_values: usize,
+    pub num_user_public_values: usize,
     pub internal_vm_verifier_commit: [F; DIGEST_SIZE],
     pub compiler_options: CompilerOptions,
 }
@@ -40,73 +41,163 @@ impl RootVmVerifierConfig {
         leaf_vm_vk: &MultiStarkVerifyingKey<SC>,
         internal_vm_vk: &MultiStarkVerifyingKey<SC>,
     ) -> Program<F> {
-        let leaf_advice = new_from_inner_multi_vk(leaf_vm_vk);
-        let internal_advice = new_from_inner_multi_vk(internal_vm_vk);
         let mut builder = Builder::<C>::default();
 
-        {
-            builder.cycle_tracker_start("ReadProofsFromInput");
-            let RootVmVerifierInputVariable {
-                proofs,
-                public_values,
-            } = RootVmVerifierInput::<SC>::read(&mut builder);
-            builder.cycle_tracker_end("ReadProofsFromInput");
-            builder.cycle_tracker_start("InitializePcsConst");
-            let leaf_pcs = TwoAdicFriPcsVariable {
-                config: const_fri_config(&mut builder, &self.leaf_fri_params),
-            };
-            let internal_pcs = TwoAdicFriPcsVariable {
-                config: const_fri_config(&mut builder, &self.internal_fri_params),
-            };
-            builder.cycle_tracker_end("InitializePcsConst");
-            builder.cycle_tracker_start("VerifyProofs");
-            let internal_program_commit =
-                array::from_fn(|i| builder.eval(self.internal_vm_verifier_commit[i]));
-            let non_leaf_verifier = NonLeafVerifierVariables {
-                internal_program_commit,
-                leaf_pcs,
-                leaf_advice,
-                internal_pcs,
-                internal_advice,
-            };
-            let (merged_pvs, expected_leaf_commit) =
-                non_leaf_verifier.verify_internal_or_leaf_verifier_proofs(&mut builder, &proofs);
-            builder.cycle_tracker_end("VerifyProofs");
+        builder.cycle_tracker_start("ReadProofsFromInput");
+        let root_verifier_input = RootVmVerifierInput::<SC>::read(&mut builder);
+        builder.cycle_tracker_end("ReadProofsFromInput");
+        let pvs = self.verifier_impl(
+            &mut builder,
+            leaf_vm_vk,
+            internal_vm_vk,
+            root_verifier_input,
+        );
+        pvs.flatten()
+            .into_iter()
+            .for_each(|v| builder.commit_public_value(v));
+        builder.halt();
+        builder.compile_isa_with_options(self.compiler_options)
+    }
 
-            // App Program should terminate
-            builder.assert_felt_eq(merged_pvs.connector.is_terminate, F::ONE);
-            // App Program should exit successfully
-            builder.assert_felt_eq(merged_pvs.connector.exit_code, F::ZERO);
+    /// Build instructions which can be called as a kernel function in RISC-V guest programs.
+    /// Inputs for generated instructions:
+    /// - expected `app_exe_commit`, `app_vm_commit` and user public values should be stored from
+    ///   `HEAP_START_ADDRESS` in the native address space .
+    ///
+    /// These instructions take a proof from the input stream and verify the proof. Then these
+    /// instructions check if the public values are consistent with the expected public values
+    /// from RISC-V guest programs.
+    pub fn build_kernel_asm(
+        &self,
+        leaf_vm_vk: &MultiStarkVerifyingKey<SC>,
+        internal_vm_vk: &MultiStarkVerifyingKey<SC>,
+    ) -> Program<F> {
+        let mut builder = Builder::<C>::default();
 
-            builder.cycle_tracker_start("ExtractPublicValues");
-            builder.assert_usize_eq(public_values.len(), RVar::from(self.num_public_values));
-            let public_values_vec: Vec<Felt<F>> = (0..self.num_public_values)
-                .map(|i| builder.get(&public_values, i))
-                .collect();
-            let hasher = VariableP2Hasher::new(&mut builder);
-            let pv_commit = hasher.merkle_root(&mut builder, &public_values_vec);
-            builder.assert_eq::<[_; DIGEST_SIZE]>(merged_pvs.public_values_commit, pv_commit);
-            builder.cycle_tracker_end("ExtractPublicValues");
-
-            let pvs = RootVmVerifierPvs {
-                exe_commit: compute_exe_commit(
-                    &mut builder,
-                    &hasher,
-                    merged_pvs.app_commit,
-                    merged_pvs.memory.initial_root,
-                    merged_pvs.connector.initial_pc,
-                ),
-                leaf_verifier_commit: expected_leaf_commit,
-                public_values: public_values_vec,
-            };
-            pvs.flatten()
-                .into_iter()
-                .for_each(|v| builder.commit_public_value(v));
-
-            builder.halt();
+        const BYTE_PER_WORD: usize = 4;
+        let num_public_values = self.num_user_public_values + DIGEST_SIZE * 2;
+        let num_bytes = num_public_values * BYTE_PER_WORD;
+        // Move heap pointer in order to keep input arguments from address space 2.
+        let heap_addr: Var<F> = builder.eval(F::from_canonical_u32(
+            HEAP_START_ADDRESS as u32 + num_bytes as u32,
+        ));
+        builder.store_heap_ptr(Ptr { address: heap_addr });
+        let expected_pvs: Vec<Felt<_>> = (0..num_public_values)
+            .map(|i| {
+                let fs: [Felt<_>; BYTE_PER_WORD] = array::from_fn(|j| {
+                    let ptr = Ptr {
+                        address: builder.eval(F::from_canonical_u32(
+                            HEAP_START_ADDRESS as u32 + (i * 4) as u32,
+                        )),
+                    };
+                    let idx = MemIndex {
+                        index: RVar::from(j),
+                        offset: 0,
+                        size: 1,
+                    };
+                    let f = Felt::uninit(&mut builder);
+                    f.load(ptr, idx, &mut builder);
+                    f
+                });
+                builder.eval(
+                    fs[0]
+                        + fs[1] * F::from_canonical_u32(1 << 8)
+                        + fs[2] * F::from_canonical_u32(1 << 16)
+                        + fs[3] * F::from_canonical_u32(1 << 24),
+                )
+            })
+            .collect();
+        let expected_pvs = RootVmVerifierPvs::<Felt<F>>::from_flatten(expected_pvs);
+        let user_pvs = builder.array(self.num_user_public_values);
+        for (i, &pv) in expected_pvs.public_values.iter().enumerate() {
+            builder.set(&user_pvs, i, pv);
         }
 
+        builder.cycle_tracker_start("ReadFromStdin");
+        let proof = Proof::<SC>::read(&mut builder);
+        builder.cycle_tracker_end("ReadFromStdin");
+        let proofs = builder.array(1);
+        builder.set(&proofs, 0, proof);
+        let pvs = self.verifier_impl(
+            &mut builder,
+            leaf_vm_vk,
+            internal_vm_vk,
+            RootVmVerifierInputVariable {
+                proofs,
+                public_values: user_pvs,
+            },
+        );
+        builder.assert_eq::<[Felt<_>; DIGEST_SIZE]>(pvs.exe_commit, expected_pvs.exe_commit);
+        builder.assert_eq::<[Felt<_>; DIGEST_SIZE]>(
+            pvs.leaf_verifier_commit,
+            expected_pvs.leaf_verifier_commit,
+        );
+
         builder.compile_isa_with_options(self.compiler_options)
+    }
+
+    fn verifier_impl(
+        &self,
+        builder: &mut Builder<C>,
+        leaf_vm_vk: &MultiStarkVerifyingKey<SC>,
+        internal_vm_vk: &MultiStarkVerifyingKey<SC>,
+        root_verifier_input: RootVmVerifierInputVariable<C>,
+    ) -> RootVmVerifierPvs<Felt<F>> {
+        let leaf_advice = new_from_inner_multi_vk(leaf_vm_vk);
+        let internal_advice = new_from_inner_multi_vk(internal_vm_vk);
+        let RootVmVerifierInputVariable {
+            proofs,
+            public_values,
+        } = root_verifier_input;
+
+        builder.cycle_tracker_start("InitializePcsConst");
+        let leaf_pcs = TwoAdicFriPcsVariable {
+            config: const_fri_config(builder, &self.leaf_fri_params),
+        };
+        let internal_pcs = TwoAdicFriPcsVariable {
+            config: const_fri_config(builder, &self.internal_fri_params),
+        };
+        builder.cycle_tracker_end("InitializePcsConst");
+        builder.cycle_tracker_start("VerifyProofs");
+        let internal_program_commit =
+            array::from_fn(|i| builder.eval(self.internal_vm_verifier_commit[i]));
+        let non_leaf_verifier = NonLeafVerifierVariables {
+            internal_program_commit,
+            leaf_pcs,
+            leaf_advice,
+            internal_pcs,
+            internal_advice,
+        };
+        let (merged_pvs, expected_leaf_commit) =
+            non_leaf_verifier.verify_internal_or_leaf_verifier_proofs(builder, &proofs);
+        builder.cycle_tracker_end("VerifyProofs");
+
+        // App Program should terminate
+        builder.assert_felt_eq(merged_pvs.connector.is_terminate, F::ONE);
+        // App Program should exit successfully
+        builder.assert_felt_eq(merged_pvs.connector.exit_code, F::ZERO);
+
+        builder.cycle_tracker_start("ExtractPublicValues");
+        builder.assert_usize_eq(public_values.len(), RVar::from(self.num_user_public_values));
+        let public_values_vec: Vec<Felt<F>> = (0..self.num_user_public_values)
+            .map(|i| builder.get(&public_values, i))
+            .collect();
+        let hasher = VariableP2Hasher::new(builder);
+        let pv_commit = hasher.merkle_root(builder, &public_values_vec);
+        builder.assert_eq::<[_; DIGEST_SIZE]>(merged_pvs.public_values_commit, pv_commit);
+        builder.cycle_tracker_end("ExtractPublicValues");
+
+        RootVmVerifierPvs {
+            exe_commit: compute_exe_commit(
+                builder,
+                &hasher,
+                merged_pvs.app_commit,
+                merged_pvs.memory.initial_root,
+                merged_pvs.connector.initial_pc,
+            ),
+            leaf_verifier_commit: expected_leaf_commit,
+            public_values: public_values_vec,
+        }
     }
 }
 

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -55,6 +55,7 @@ snark-verifier-sdk.workspace = true
 tempfile.workspace = true
 hex.workspace = true
 forge-fmt = { workspace = true, optional = true }
+rrs-lib = { workspace = true }
 
 [features]
 default = ["parallel", "jemalloc", "evm-verify"]

--- a/crates/sdk/src/keygen/asm.rs
+++ b/crates/sdk/src/keygen/asm.rs
@@ -1,0 +1,106 @@
+use openvm_circuit::arch::instructions::{
+    instruction::{Instruction, NUM_OPERANDS},
+    program::Program,
+    LocalOpcode,
+};
+use openvm_continuations::F;
+use openvm_native_compiler::{asm::A0, conversion::AS, NativeJalOpcode};
+use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
+use rrs_lib::instruction_formats::IType;
+
+const OPCODE: u32 = 0x0b;
+const FUNCT3: u32 = 0b111;
+const LONG_FORM_INSTRUCTION_INDICATOR: u32 = (FUNCT3 << 12) + OPCODE;
+const GAP_INDICATOR: u32 = (1 << 25) + (FUNCT3 << 12) + OPCODE;
+
+pub fn program_to_asm(mut program: Program<F>) -> String {
+    let pc_diff = handle_pc_diff(&mut program);
+    let assembly_and_comments = convert_program_to_u32s_and_comments(&program, pc_diff);
+    let mut asm_output = String::new();
+    for (u32s, comment) in &assembly_and_comments {
+        for (idx, x) in u32s.iter().enumerate() {
+            asm_output.push_str(&u32_to_directive(*x));
+            if idx == 0 {
+                asm_output.push_str(" // ");
+                asm_output.push_str(comment);
+            }
+            asm_output.push('\n');
+        }
+    }
+    asm_output
+}
+
+fn u32_to_directive(x: u32) -> String {
+    let opcode = x & 0b1111111;
+    let dec_insn = IType::new(x);
+    format!(
+        ".insn i {}, {}, x{}, x{}, {}",
+        opcode, dec_insn.funct3, dec_insn.rd, dec_insn.rs1, dec_insn.imm
+    )
+}
+
+/// In order to use native instructions in kernel functions, native instructions need to be
+/// converted to RISC-V machine code(long form instructions) first. Then Rust compiler compiles the
+/// whole program into an ELF. Finally, the ELF is transpiled into an OpenVm Exe.
+/// In the perspective of the native compiler and the transpiler, the PC step between 2 native
+/// instructions is 4. However, in the ELF, each native instruction takes longer than 4 bytes, so
+/// the instructions after the code blocks use the actual lengths of the native instructions to
+/// compute PC offsets. To solve this problem, we need the gap indicator to pad the native code
+/// block in order to align the PC of the following instructions.
+/// More details about long form instructions and gap indicators can be found in
+/// `docs/specs/transpiler.md`.
+fn handle_pc_diff(program: &mut Program<F>) -> usize {
+    const GAP_INDICATOR_WIDTH: usize = 2;
+    const LONG_FORM_NATIVE_INSTRUCTION_WIDTH: usize = 10;
+    const PC_STEP: usize = 4;
+    // For GAP_INDICATOR, whose width is 2.
+    let mut pc_diff = GAP_INDICATOR_WIDTH;
+    // For each native instruction
+    pc_diff += program.num_defined_instructions() * (LONG_FORM_NATIVE_INSTRUCTION_WIDTH - 1);
+    // For next jal
+    pc_diff += LONG_FORM_NATIVE_INSTRUCTION_WIDTH - 1;
+    let jal = Instruction::<F> {
+        opcode: NativeJalOpcode::JAL.global_opcode(),
+        a: F::from_canonical_usize(A0 as usize), // A0
+        // +1 means the next instruction after the gap
+        b: F::from_canonical_usize(PC_STEP * (pc_diff + 1)),
+        c: F::from_canonical_usize(0),
+        d: F::from_canonical_u32(AS::Native as u32),
+        e: F::from_canonical_usize(0),
+        f: F::from_canonical_usize(0),
+        g: F::from_canonical_usize(0),
+    };
+    program.push_instruction(jal);
+    pc_diff
+}
+
+fn convert_program_to_u32s_and_comments(
+    program: &Program<F>,
+    pc_diff: usize,
+) -> Vec<(Vec<u32>, String)> {
+    program
+        .defined_instructions()
+        .iter()
+        .map(|ins| {
+            (
+                vec![
+                    LONG_FORM_INSTRUCTION_INDICATOR,
+                    NUM_OPERANDS as u32,
+                    ins.opcode.as_usize() as u32,
+                    ins.a.as_canonical_u32(),
+                    ins.b.as_canonical_u32(),
+                    ins.c.as_canonical_u32(),
+                    ins.d.as_canonical_u32(),
+                    ins.e.as_canonical_u32(),
+                    ins.f.as_canonical_u32(),
+                    ins.g.as_canonical_u32(),
+                ],
+                format!("{:?}", ins.opcode),
+            )
+        })
+        .chain(std::iter::once((
+            vec![GAP_INDICATOR, pc_diff as u32],
+            "GAP_INDICATOR".to_string(),
+        )))
+        .collect()
+}

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -46,6 +46,7 @@ use crate::{
     NonRootCommittedExe, RootSC, F, SC,
 };
 
+pub mod asm;
 pub(crate) mod dummy;
 pub mod perm;
 pub mod static_verifier;
@@ -321,7 +322,7 @@ impl AggStarkProvingKey {
             let root_program = RootVmVerifierConfig {
                 leaf_fri_params: config.leaf_fri_params,
                 internal_fri_params: config.internal_fri_params,
-                num_public_values: config.max_num_user_public_values,
+                num_user_public_values: config.max_num_user_public_values,
                 internal_vm_verifier_commit: internal_committed_exe.get_program_commit().into(),
                 compiler_options: config.compiler_options,
             }
@@ -369,7 +370,7 @@ impl AggStarkProvingKey {
         self.internal_committed_exe.get_program_commit().into()
     }
 
-    pub fn num_public_values(&self) -> usize {
+    pub fn num_user_public_values(&self) -> usize {
         self.root_verifier_pk
             .vm_pk
             .vm_config

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -21,7 +21,8 @@ use openvm_circuit::{
     },
 };
 use openvm_continuations::verifier::{
-    internal::types::E2eStarkProof, root::types::RootVmVerifierInput,
+    internal::types::E2eStarkProof,
+    root::{types::RootVmVerifierInput, RootVmVerifierConfig},
 };
 pub use openvm_continuations::{
     static_verifier::{DefaultStaticVerifierPvHandler, StaticVerifierPvHandler},
@@ -59,6 +60,8 @@ pub mod prover;
 
 mod stdin;
 pub use stdin::*;
+
+use crate::keygen::asm::program_to_asm;
 
 pub mod fs;
 pub mod types;
@@ -251,6 +254,24 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
     ) -> Result<AggProvingKey> {
         let agg_pk = AggProvingKey::keygen(config, reader, pv_handler);
         Ok(agg_pk)
+    }
+
+    pub fn generate_root_verifier_asm(&self, agg_stark_pk: &AggStarkProvingKey) -> String {
+        let kernel_asm = RootVmVerifierConfig {
+            leaf_fri_params: agg_stark_pk.leaf_vm_pk.fri_params,
+            internal_fri_params: agg_stark_pk.internal_vm_pk.fri_params,
+            num_user_public_values: agg_stark_pk.num_user_public_values(),
+            internal_vm_verifier_commit: agg_stark_pk
+                .internal_committed_exe
+                .get_program_commit()
+                .into(),
+            compiler_options: Default::default(),
+        }
+        .build_kernel_asm(
+            &agg_stark_pk.leaf_vm_pk.vm_pk.get_vk(),
+            &agg_stark_pk.internal_vm_pk.vm_pk.get_vk(),
+        );
+        program_to_asm(kernel_asm)
     }
 
     pub fn generate_root_verifier_input<VC: VmConfig<F>>(

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -34,7 +34,7 @@ impl<VC, E: StarkFriEngine<SC>> StarkProver<VC, E> {
         );
         assert_eq!(
             app_pk.app_vm_pk.vm_config.system().num_public_values,
-            agg_stark_pk.num_public_values(),
+            agg_stark_pk.num_user_public_values(),
             "App VM is incompatible with Agg VM  because of the number of public values"
         );
 

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -37,7 +37,7 @@ use openvm_sdk::{
     codec::{Decode, Encode},
     commit::AppExecutionCommit,
     config::{AggConfig, AggStarkConfig, AppConfig, Halo2Config, SdkSystemConfig, SdkVmConfig},
-    keygen::AppProvingKey,
+    keygen::{AggStarkProvingKey, AppProvingKey},
     types::{EvmHalo2Verifier, EvmProof},
     DefaultStaticVerifierPvHandler, Sdk, StdIn,
 };
@@ -579,4 +579,12 @@ fn test_segmentation_retry() {
         })
         .sum();
     assert!(new_total_height < total_height);
+}
+
+#[test]
+fn test_root_verifier_asm_generate() {
+    let agg_stark_config = agg_stark_config_for_test();
+    let agg_pk = AggStarkProvingKey::keygen(agg_stark_config);
+    let sdk = Sdk::new();
+    sdk.generate_root_verifier_asm(&agg_pk);
 }

--- a/extensions/native/compiler/src/asm/compiler.rs
+++ b/extensions/native/compiler/src/asm/compiler.rs
@@ -15,7 +15,7 @@ pub const MEMORY_BITS: usize = 29;
 pub const MEMORY_TOP: u32 = (1 << MEMORY_BITS) - 4;
 
 // The memory location for the start of the heap.
-pub(crate) const HEAP_START_ADDRESS: i32 = 1 << 24;
+pub const HEAP_START_ADDRESS: i32 = 1 << 24;
 
 /// The heap pointer address.
 pub(crate) const HEAP_PTR: i32 = HEAP_START_ADDRESS - 4;


### PR DESCRIPTION
- Add a function `build_kernel_asm` into `RootVmVerifierConfig`. The generated ASM can be used in kernel functions for guest program to verify starks. More details could be found in the doc comments of the function.
- Fix a confusing naming. `num_public_values` is actually the number of user public values instead of the number of public values of the proof. Use `num_user_public_values` instead.

closes INT-3894