### PR TITLE
fix(new-execution): make rv32im hintstore work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1682,6 +1683,12 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "const-default"
@@ -2156,6 +2163,31 @@ name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4060,6 +4092,7 @@ dependencies = [
  "clap",
  "criterion",
  "derive_more 1.0.0",
+ "divan",
  "eyre",
  "openvm-benchmarks-utils",
  "openvm-circuit",
@@ -6986,6 +7019,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
+ "rustix 1.0.5",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
  "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]

--- a/benchmarks/execute/Cargo.toml
+++ b/benchmarks/execute/Cargo.toml
@@ -26,6 +26,7 @@ tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+divan = { version = "0.1.21" }
 
 [features]
 default = ["jemalloc"]
@@ -36,12 +37,16 @@ jemalloc-prof = ["openvm-circuit/jemalloc-prof"]
 nightly-features = ["openvm-circuit/nightly-features"]
 profiling = ["openvm-circuit/function-span", "openvm-transpiler/function-span"]
 
-[[bench]]
-name = "fibonacci_execute"
-harness = false
+# [[bench]]
+# name = "fibonacci_execute"
+# harness = false
+
+# [[bench]]
+# name = "regex_execute"
+# harness = false
 
 [[bench]]
-name = "regex_execute"
+name = "execute"
 harness = false
 
 [package.metadata.cargo-shear]

--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -1,0 +1,57 @@
+use divan;
+use eyre::Result;
+use openvm_benchmarks_utils::{get_elf_path, get_programs_dir, read_elf_file};
+use openvm_circuit::arch::{instructions::exe::VmExe, VmExecutor};
+use openvm_rv32im_circuit::Rv32ImConfig;
+use openvm_rv32im_transpiler::{
+    Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
+};
+use openvm_stark_sdk::p3_baby_bear::BabyBear;
+use openvm_transpiler::{transpiler::Transpiler, FromElf};
+use std::path::PathBuf;
+
+static AVAILABLE_PROGRAMS: &[&str] = &[
+    "fibonacci_recursive",
+    "fibonacci_iterative",
+    "quicksort",
+    "bubblesort",
+    // "pairing",
+    // "keccak256",
+    // "keccak256_iter",
+    // "sha256",
+    // "sha256_iter",
+    // "revm_transfer",
+    // "revm_snailtracer",
+];
+
+fn main() {
+    divan::main();
+}
+
+/// Run a specific OpenVM program
+fn run_program(program: &str) -> Result<()> {
+    let program_dir = get_programs_dir().join(program);
+    let elf_path = get_elf_path(&program_dir);
+    let elf = read_elf_file(&elf_path)?;
+
+    let vm_config = Rv32ImConfig::default();
+
+    let transpiler = Transpiler::<BabyBear>::default()
+        .with_extension(Rv32ITranspilerExtension)
+        .with_extension(Rv32IoTranspilerExtension)
+        .with_extension(Rv32MTranspilerExtension);
+
+    let exe = VmExe::from_elf(elf, transpiler)?;
+
+    let executor = VmExecutor::new(vm_config);
+    executor
+        .execute_e1(exe, vec![])
+        .expect("Failed to execute program");
+
+    Ok(())
+}
+
+#[divan::bench(args = AVAILABLE_PROGRAMS, sample_count=10)]
+fn benchmark_execute(program: &str) {
+    run_program(program).unwrap();
+}

--- a/benchmarks/execute/benches/fibonacci_execute.rs
+++ b/benchmarks/execute/benches/fibonacci_execute.rs
@@ -5,7 +5,8 @@ use openvm_rv32im_circuit::Rv32ImConfig;
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
-use openvm_sdk::StdIn;
+// TODO(ayush): add this back
+// use openvm_sdk::StdIn;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -28,10 +29,11 @@ fn benchmark_function(c: &mut Criterion) {
 
     group.bench_function("execute", |b| {
         b.iter(|| {
-            let n = 100_000u64;
-            let mut stdin = StdIn::default();
-            stdin.write(&n);
-            executor.execute(exe.clone(), stdin).unwrap();
+            // TODO(ayush): add this back
+            // let n = 100_000u64;
+            // let mut stdin = StdIn::default();
+            // stdin.write(&n);
+            executor.execute(exe.clone(), vec![]).unwrap();
         })
     });
 

--- a/benchmarks/execute/benches/regex_execute.rs
+++ b/benchmarks/execute/benches/regex_execute.rs
@@ -1,47 +1,47 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use openvm_benchmarks_utils::{build_elf, get_programs_dir};
-use openvm_circuit::arch::{instructions::exe::VmExe, VmExecutor};
-use openvm_keccak256_circuit::Keccak256Rv32Config;
-use openvm_keccak256_transpiler::Keccak256TranspilerExtension;
-use openvm_rv32im_transpiler::{
-    Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
-};
-use openvm_sdk::StdIn;
-use openvm_stark_sdk::p3_baby_bear::BabyBear;
-use openvm_transpiler::{transpiler::Transpiler, FromElf};
+// TODO(ayush): add this back
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use openvm_benchmarks_utils::{build_elf, get_programs_dir};
+// use openvm_circuit::arch::{instructions::exe::VmExe, VmExecutor};
+// use openvm_keccak256_circuit::Keccak256Rv32Config;
+// use openvm_keccak256_transpiler::Keccak256TranspilerExtension;
+// use openvm_rv32im_transpiler::{
+//     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
+// };
+// use openvm_sdk::StdIn;
+// use openvm_stark_sdk::p3_baby_bear::BabyBear;
+// use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
-fn benchmark_function(c: &mut Criterion) {
-    let program_dir = get_programs_dir().join("regex");
-    let elf = build_elf(&program_dir, "release").unwrap();
+// fn benchmark_function(c: &mut Criterion) {
+//     let program_dir = get_programs_dir().join("regex");
+//     let elf = build_elf(&program_dir, "release").unwrap();
 
-    let exe = VmExe::from_elf(
-        elf,
-        Transpiler::<BabyBear>::default()
-            .with_extension(Rv32ITranspilerExtension)
-            .with_extension(Rv32MTranspilerExtension)
-            .with_extension(Rv32IoTranspilerExtension)
-            .with_extension(Keccak256TranspilerExtension),
-    )
-    .unwrap();
+//     let exe = VmExe::from_elf(
+//         elf,
+//         Transpiler::<BabyBear>::default()
+//             .with_extension(Rv32ITranspilerExtension)
+//             .with_extension(Rv32MTranspilerExtension)
+//             .with_extension(Rv32IoTranspilerExtension)
+//             .with_extension(Keccak256TranspilerExtension),
+//     )
+//     .unwrap();
 
-    let mut group = c.benchmark_group("regex");
-    group.sample_size(10);
-    let config = Keccak256Rv32Config::default();
-    let executor = VmExecutor::<BabyBear, Keccak256Rv32Config>::new(config);
+//     let mut group = c.benchmark_group("regex");
+//     group.sample_size(10);
+//     let config = Keccak256Rv32Config::default();
+//     let executor = VmExecutor::<BabyBear, Keccak256Rv32Config>::new(config);
 
-    let data = include_str!("../../guest/regex/regex_email.txt");
+//     let data = include_str!("../../guest/regex/regex_email.txt");
 
-    let fe_bytes = data.to_owned().into_bytes();
-    group.bench_function("execute", |b| {
-        b.iter(|| {
-            executor
-                .execute(exe.clone(), black_box(StdIn::from_bytes(&fe_bytes)))
-                .unwrap();
-        })
-    });
+//     let fe_bytes = data.to_owned().into_bytes();
+//     group.bench_function("execute", |b| {
+//         b.iter(|| {
+//             let input = black_box(Stdin::from_bytes(&fe_bytes));
+//             executor.execute(exe.clone(), input).unwrap();
+//         })
+//     });
 
-    group.finish();
-}
+//     group.finish();
+// }
 
-criterion_group!(benches, benchmark_function);
-criterion_main!(benches);
+// criterion_group!(benches, benchmark_function);
+// criterion_main!(benches);

--- a/crates/vm/src/arch/execution_control.rs
+++ b/crates/vm/src/arch/execution_control.rs
@@ -26,6 +26,7 @@ where
     fn new(chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>) -> Self;
 
     /// Determines if execution should stop
+    // TODO(ayush): rename to should_suspend
     fn should_stop(&mut self, chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>)
         -> bool;
 

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -101,7 +101,7 @@ pub struct MemoryController<F> {
     // Store separately to avoid smart pointer reference each time
     range_checker_bus: VariableRangeCheckerBus,
     // addr_space -> Memory data structure
-    pub(crate) memory: TracingMemory<F>,
+    pub memory: TracingMemory<F>,
     /// A reference to the `OfflineMemory`. Will be populated after `finalize()`.
     pub offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     pub access_adapters: AccessAdapterInventory<F>,

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterRuntimeContext, AdapterTraceStep,
-        BasicAdapterInterface, MinimalInstruction, Result, SingleTraceStep, StepExecutorE1,
+        BasicAdapterInterface, MinimalInstruction, Result, StepExecutorE1, TraceStep,
         VmAdapterInterface, VmCoreAir, VmCoreChip, VmStateMut,
     },
     system::{
@@ -141,7 +141,7 @@ where
     }
 }
 
-impl<F, CTX, A> SingleTraceStep<F, CTX> for PublicValuesStep<A, F>
+impl<F, CTX, A> TraceStep<F, CTX> for PublicValuesStep<A, F>
 where
     F: PrimeField32,
     A: 'static
@@ -164,7 +164,9 @@ where
         &mut self,
         state: VmStateMut<TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
-        row_slice: &mut [F],
+        trace: &mut [F],
+        trace_offset: &mut usize,
+        width: usize,
     ) -> Result<()> {
         todo!("Implement execute function");
     }

--- a/extensions/algebra/moduli-macros/src/lib.rs
+++ b/extensions/algebra/moduli-macros/src/lib.rs
@@ -746,8 +746,6 @@ pub fn moduli_init(input: TokenStream) -> TokenStream {
 
     for (mod_idx, item) in items.into_iter().enumerate() {
         let modulus = item.value();
-        println!("[init] modulus #{} = {}", mod_idx, modulus);
-
         let modulus_bytes = string_to_bytes(&modulus);
         let mut limbs = modulus_bytes.len();
         let mut block_size = 32;

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -151,7 +151,7 @@ impl<A> CastFStep<A> {
     }
 }
 
-impl<F, CTX, A> SingleTraceStep<F, CTX> for CastFStep<A>
+impl<F, CTX, A> TraceStep<F, CTX> for CastFStep<A>
 where
     F: PrimeField32,
     A: 'static

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -7,7 +7,7 @@ use itertools::izip;
 use openvm_circuit::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterRuntimeContext, InsExecutorE1,
-        MinimalInstruction, Result, SingleTraceStep, StepExecutorE1, VmAdapterInterface, VmCoreAir,
+        MinimalInstruction, Result, StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir,
         VmCoreChip, VmExecutionState,
     },
     system::memory::online::GuestMemory,
@@ -162,7 +162,7 @@ impl<A> FieldArithmeticStep<A> {
     }
 }
 
-impl<F, CTX, A> SingleTraceStep<F, CTX> for FieldArithmeticStep<A>
+impl<F, CTX, A> TraceStep<F, CTX> for FieldArithmeticStep<A>
 where
     F: PrimeField32,
     A: 'static

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -183,7 +183,7 @@ impl FieldExtensionChip {
     }
 }
 
-impl<F, CTX, A> SingleTraceStep<F, CTX> for FieldExtensionStep<A>
+impl<F, CTX, A> TraceStep<F, CTX> for FieldExtensionStep<A>
 where
     F: PrimeField32,
     A: 'static

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -173,8 +173,7 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_CELLS: usize> SingleTraceStep<F, CTX>
-    for NativeLoadStoreStep<A, F, NUM_CELLS>
+impl<F, CTX, A, const NUM_CELLS: usize> TraceStep<F, CTX> for NativeLoadStoreStep<A, F, NUM_CELLS>
 where
     F: PrimeField32,
     A: 'static

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_circuit::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterTraceStep, ImmInstruction, Result,
-        SingleTraceStep, StepExecutorE1, VmAdapterInterface, VmCoreAir, VmStateMut,
+        StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -207,7 +207,7 @@ impl<A> Rv32AuipcStep<A> {
     }
 }
 
-impl<F, CTX, A> SingleTraceStep<F, CTX> for Rv32AuipcStep<A>
+impl<F, CTX, A> TraceStep<F, CTX> for Rv32AuipcStep<A>
 where
     F: PrimeField32,
     A: 'static
@@ -227,13 +227,16 @@ where
         &mut self,
         state: VmStateMut<TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
-        row_slice: &mut [F],
+        trace: &mut [F],
+        trace_offset: &mut usize,
+        width: usize,
     ) -> Result<()> {
         let Instruction { opcode, c: imm, .. } = instruction;
 
         let local_opcode =
             Rv32AuipcOpcode::from_usize(opcode.local_opcode_idx(Rv32AuipcOpcode::CLASS_OFFSET));
 
+        let mut row_slice = &mut trace[*trace_offset..*trace_offset + width];
         let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
         A::start(*state.pc, state.memory, adapter_row);
@@ -253,6 +256,8 @@ where
 
         // TODO(ayush): add increment_pc function to vmstate
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+
+        *trace_offset += width;
 
         Ok(())
     }

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_circuit::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterTraceStep, MinimalInstruction, Result,
-        SingleTraceStep, StepExecutorE1, VmAdapterInterface, VmCoreAir, VmStateMut,
+        StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -192,7 +192,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAluStep<A, NUM_LIMBS
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> SingleTraceStep<F, CTX>
+impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
     for BaseAluStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
@@ -213,12 +213,15 @@ where
         &mut self,
         state: VmStateMut<TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
-        row_slice: &mut [F],
+        trace: &mut [F],
+        trace_offset: &mut usize,
+        width: usize,
     ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = BaseAluOpcode::from_usize(opcode.local_opcode_idx(self.offset));
 
+        let mut row_slice = &mut trace[*trace_offset..*trace_offset + width];
         let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
         A::start(*state.pc, state.memory, adapter_row);
@@ -241,6 +244,8 @@ where
             .write(state.memory, instruction, adapter_row, &rd);
 
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+
+        *trace_offset += width;
 
         Ok(())
     }

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_circuit::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterTraceStep, ImmInstruction, Result,
-        SingleTraceStep, StepExecutorE1, VmAdapterInterface, VmCoreAir, VmStateMut,
+        StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -157,7 +157,7 @@ impl<A, const NUM_LIMBS: usize> BranchEqualStep<A, NUM_LIMBS> {
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize> SingleTraceStep<F, CTX> for BranchEqualStep<A, NUM_LIMBS>
+impl<F, CTX, A, const NUM_LIMBS: usize> TraceStep<F, CTX> for BranchEqualStep<A, NUM_LIMBS>
 where
     F: PrimeField32,
     A: 'static
@@ -177,12 +177,15 @@ where
         &mut self,
         state: VmStateMut<TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
-        row_slice: &mut [F],
+        trace: &mut [F],
+        trace_offset: &mut usize,
+        width: usize,
     ) -> Result<()> {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let branch_eq_opcode = BranchEqualOpcode::from_usize(opcode.local_opcode_idx(self.offset));
 
+        let mut row_slice = &mut trace[*trace_offset..*trace_offset + width];
         let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
         A::start(*state.pc, state.memory, adapter_row);
@@ -206,6 +209,8 @@ where
         } else {
             *state.pc = state.pc.wrapping_add(self.pc_step);
         }
+
+        *trace_offset += width;
 
         Ok(())
     }

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -6,12 +6,13 @@ use std::{
 use openvm_circuit::{
     arch::{
         ExecutionBridge, ExecutionBus, ExecutionError, ExecutionState, InsExecutorE1,
-        InstructionExecutor, Streams, VmStateMut,
+        InstructionExecutor, NewVmChipWrapper, Result, StepExecutorE1, Streams, TraceStep,
+        VmStateMut,
     },
     system::{
         memory::{
             offline_checker::{MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxCols},
-            online::GuestMemory,
+            online::{GuestMemory, TracingMemory},
             MemoryAddress, MemoryAuxColsFactory, MemoryController, OfflineMemory, RecordId,
         },
         program::ProgramBus,
@@ -42,12 +43,15 @@ use openvm_stark_backend::{
     rap::{AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},
     Chip, ChipUsageGetter,
 };
+use rand::distributions::weighted;
 use serde::{Deserialize, Serialize};
 
-use crate::adapters::{decompose, tmp_convert_to_u8s};
+use crate::adapters::{
+    decompose, memory_read, memory_write, tmp_convert_to_u8s, tracing_read, tracing_write,
+};
 
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;
 
 #[repr(C)]
 #[derive(AlignedBorrow, Debug)]
@@ -72,7 +76,7 @@ pub struct Rv32HintStoreCols<T> {
     pub num_words_aux_cols: MemoryReadAuxCols<T>,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, derive_new::new)]
 pub struct Rv32HintStoreAir {
     pub execution_bridge: ExecutionBridge,
     pub memory_bridge: MemoryBridge,
@@ -279,124 +283,39 @@ pub struct Rv32HintStoreRecord<F: Field> {
     pub hints: Vec<([F; RV32_REGISTER_NUM_LIMBS], RecordId)>,
 }
 
-pub struct Rv32HintStoreChip<F: Field> {
-    air: Rv32HintStoreAir,
-    pub records: Vec<Rv32HintStoreRecord<F>>,
-    pub height: usize,
+pub struct Rv32HintStoreStep<F: Field> {
+    pointer_max_bits: usize,
+    offset: usize,
     offline_memory: Arc<Mutex<OfflineMemory<F>>>,
     pub streams: OnceLock<Arc<Mutex<Streams<F>>>>,
     bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
-impl<F: PrimeField32> Rv32HintStoreChip<F> {
+impl<F: PrimeField32> Rv32HintStoreStep<F> {
     pub fn new(
-        execution_bus: ExecutionBus,
-        program_bus: ProgramBus,
         bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
-        memory_bridge: MemoryBridge,
         offline_memory: Arc<Mutex<OfflineMemory<F>>>,
         pointer_max_bits: usize,
         offset: usize,
     ) -> Self {
-        let air = Rv32HintStoreAir {
-            execution_bridge: ExecutionBridge::new(execution_bus, program_bus),
-            memory_bridge,
-            bitwise_operation_lookup_bus: bitwise_lookup_chip.bus(),
-            offset,
-            pointer_max_bits,
-        };
         Self {
-            records: vec![],
-            air,
-            height: 0,
+            pointer_max_bits,
+            offset,
             offline_memory,
             streams: OnceLock::new(),
             bitwise_lookup_chip,
         }
     }
+
     pub fn set_streams(&mut self, streams: Arc<Mutex<Streams<F>>>) {
         self.streams.set(streams).unwrap();
     }
 }
 
-impl<F: PrimeField32> InstructionExecutor<F> for Rv32HintStoreChip<F> {
-    fn execute(
-        &mut self,
-        memory: &mut MemoryController<F>,
-        instruction: &Instruction<F>,
-        from_state: ExecutionState<u32>,
-    ) -> Result<ExecutionState<u32>, ExecutionError> {
-        let &Instruction {
-            opcode,
-            a: num_words_ptr,
-            b: mem_ptr_ptr,
-            d,
-            e,
-            ..
-        } = instruction;
-        debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
-        debug_assert_eq!(e.as_canonical_u32(), RV32_MEMORY_AS);
-        let local_opcode =
-            Rv32HintStoreOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
-
-        let (mem_ptr_read, mem_ptr_limbs) = todo!();
-        // memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, mem_ptr_ptr);
-        let (num_words, num_words_read) = if local_opcode == HINT_STOREW {
-            memory.increment_timestamp();
-            (1, None)
-        } else {
-            let (num_words_read, num_words_limbs) = todo!();
-            // memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, num_words_ptr);
-            (u32::from_le_bytes(num_words_limbs), Some(num_words_read))
-        };
-        debug_assert_ne!(num_words, 0);
-        debug_assert!(num_words <= (1 << self.air.pointer_max_bits));
-
-        let mem_ptr = u32::from_le_bytes(mem_ptr_limbs);
-
-        debug_assert!(mem_ptr <= (1 << self.air.pointer_max_bits));
-
-        let mut streams = self.streams.get().unwrap().lock().unwrap();
-        if streams.hint_stream.len() < RV32_REGISTER_NUM_LIMBS * num_words as usize {
-            return Err(ExecutionError::HintOutOfBounds { pc: from_state.pc });
-        }
-
-        let mut record = Rv32HintStoreRecord {
-            from_state,
-            instruction: instruction.clone(),
-            mem_ptr_read,
-            mem_ptr,
-            num_words,
-            num_words_read,
-            hints: vec![],
-        };
-
-        for word_index in 0..num_words {
-            if word_index != 0 {
-                memory.increment_timestamp();
-                memory.increment_timestamp();
-            }
-
-            let data: [F; RV32_REGISTER_NUM_LIMBS] =
-                std::array::from_fn(|_| streams.hint_stream.pop_front().unwrap());
-            // let (write, _) = memory.write(
-            //     e,
-            //     F::from_canonical_u32(mem_ptr + (RV32_REGISTER_NUM_LIMBS as u32 * word_index)),
-            //     &tmp_convert_to_u8s(data),
-            // );
-            // record.hints.push((data, write));
-        }
-
-        self.height += record.hints.len();
-        self.records.push(record);
-
-        let next_state = ExecutionState {
-            pc: from_state.pc + DEFAULT_PC_STEP,
-            timestamp: memory.timestamp(),
-        };
-        Ok(next_state)
-    }
-
+impl<F, CTX> TraceStep<F, CTX> for Rv32HintStoreStep<F>
+where
+    F: PrimeField32,
+{
     fn get_opcode_name(&self, opcode: usize) -> String {
         if opcode == HINT_STOREW.global_opcode().as_usize() {
             String::from("HINT_STOREW")
@@ -406,128 +325,142 @@ impl<F: PrimeField32> InstructionExecutor<F> for Rv32HintStoreChip<F> {
             unreachable!("unsupported opcode: {}", opcode)
         }
     }
-}
 
-impl<F: Field> ChipUsageGetter for Rv32HintStoreChip<F> {
-    fn air_name(&self) -> String {
-        "Rv32HintStoreAir".to_string()
-    }
+    fn execute(
+        &mut self,
+        state: VmStateMut<TracingMemory, CTX>,
+        instruction: &Instruction<F>,
+        trace: &mut [F],
+        trace_offset: &mut usize,
+        width: usize,
+    ) -> Result<()> {
+        let &Instruction {
+            opcode,
+            a: num_words_ptr,
+            b: mem_ptr_ptr,
+            d,
+            e,
+            ..
+        } = instruction;
 
-    fn current_trace_height(&self) -> usize {
-        self.height
-    }
+        debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
+        debug_assert_eq!(e.as_canonical_u32(), RV32_MEMORY_AS);
 
-    fn trace_width(&self) -> usize {
-        Rv32HintStoreCols::<F>::width()
-    }
-}
+        let local_opcode = Rv32HintStoreOpcode::from_usize(opcode.local_opcode_idx(self.offset));
 
-impl<F: PrimeField32> Rv32HintStoreChip<F> {
-    // returns number of used u32s
-    fn record_to_rows(
-        record: Rv32HintStoreRecord<F>,
-        aux_cols_factory: &MemoryAuxColsFactory<F>,
-        slice: &mut [F],
-        memory: &OfflineMemory<F>,
-        bitwise_lookup_chip: &SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
-        pointer_max_bits: usize,
-    ) -> usize {
-        let width = Rv32HintStoreCols::<F>::width();
-        let cols: &mut Rv32HintStoreCols<F> = slice[..width].borrow_mut();
+        let mut row: &mut Rv32HintStoreCols<F> =
+            trace[*trace_offset..*trace_offset + width].borrow_mut();
 
-        cols.is_single = F::from_bool(record.num_words_read.is_none());
-        cols.is_buffer = F::from_bool(record.num_words_read.is_some());
-        cols.is_buffer_start = cols.is_buffer;
+        row.from_state.pc = F::from_canonical_u32(*state.pc);
+        row.from_state.timestamp = F::from_canonical_u32(state.memory.timestamp);
 
-        cols.from_state = record.from_state.map(F::from_canonical_u32);
-        cols.mem_ptr_ptr = record.instruction.b;
-        aux_cols_factory.generate_read_aux(
-            memory.record_by_id(record.mem_ptr_read),
-            &mut cols.mem_ptr_aux_cols,
+        row.mem_ptr_ptr = mem_ptr_ptr;
+        let mem_ptr_limbs: [u8; RV32_REGISTER_NUM_LIMBS] = tracing_read(
+            state.memory,
+            RV32_REGISTER_AS,
+            mem_ptr_ptr.as_canonical_u32(),
+            &mut row.mem_ptr_aux_cols,
         );
+        let mem_ptr = u32::from_le_bytes(mem_ptr_limbs);
+        debug_assert!(mem_ptr <= (1 << self.pointer_max_bits));
 
-        cols.num_words_ptr = record.instruction.a;
-        if let Some(num_words_read) = record.num_words_read {
-            aux_cols_factory.generate_read_aux(
-                memory.record_by_id(num_words_read),
-                &mut cols.num_words_aux_cols,
+        row.num_words_ptr = num_words_ptr;
+        let num_words = if local_opcode == HINT_STOREW {
+            row.is_single = F::ONE;
+            state.memory.increment_timestamp();
+            1
+        } else {
+            row.is_buffer_start = F::ONE;
+            row.is_buffer = F::ONE;
+            let num_words_limbs: [u8; RV32_REGISTER_NUM_LIMBS] = tracing_read(
+                state.memory,
+                RV32_REGISTER_AS,
+                num_words_ptr.as_canonical_u32(),
+                &mut row.num_words_aux_cols,
             );
-        }
+            u32::from_le_bytes(num_words_limbs)
+        };
+        debug_assert_ne!(num_words, 0);
+        debug_assert!(num_words <= (1 << self.pointer_max_bits));
 
-        let mut mem_ptr = record.mem_ptr;
-        let mut rem_words = record.num_words;
-        let mut used_u32s = 0;
+        let mut streams = self.streams.get().unwrap().lock().unwrap();
+        if streams.hint_stream.len() < RV32_REGISTER_NUM_LIMBS * num_words as usize {
+            return Err(ExecutionError::HintOutOfBounds { pc: *state.pc });
+        }
 
         let mem_ptr_msl = mem_ptr >> ((RV32_REGISTER_NUM_LIMBS - 1) * RV32_CELL_BITS);
-        let rem_words_msl = rem_words >> ((RV32_REGISTER_NUM_LIMBS - 1) * RV32_CELL_BITS);
-        bitwise_lookup_chip.request_range(
-            mem_ptr_msl << (RV32_REGISTER_NUM_LIMBS * RV32_CELL_BITS - pointer_max_bits),
-            rem_words_msl << (RV32_REGISTER_NUM_LIMBS * RV32_CELL_BITS - pointer_max_bits),
+        let num_words_msl = num_words >> ((RV32_REGISTER_NUM_LIMBS - 1) * RV32_CELL_BITS);
+        // TODO(ayush): see if this can be moved to fill_trace_row
+        self.bitwise_lookup_chip.request_range(
+            mem_ptr_msl << (RV32_REGISTER_NUM_LIMBS * RV32_CELL_BITS - self.pointer_max_bits),
+            num_words_msl << (RV32_REGISTER_NUM_LIMBS * RV32_CELL_BITS - self.pointer_max_bits),
         );
-        for (i, &(data, write)) in record.hints.iter().enumerate() {
+
+        for word_index in 0..(num_words as usize) {
+            let offset = *trace_offset + word_index * width;
+            let mut row: &mut Rv32HintStoreCols<F> = trace[offset..offset + width].borrow_mut();
+
+            if word_index != 0 {
+                row.is_buffer = F::ONE;
+                row.from_state.timestamp = F::from_canonical_u32(state.memory.timestamp);
+
+                state.memory.increment_timestamp();
+                state.memory.increment_timestamp();
+            }
+
+            // TODO(ayush): why is hint_stream F if composed of u8 limbs?
+            let data_f: [F; RV32_REGISTER_NUM_LIMBS] =
+                std::array::from_fn(|_| streams.hint_stream.pop_front().unwrap());
+            let data: [u8; RV32_REGISTER_NUM_LIMBS] =
+                data_f.map(|byte| byte.as_canonical_u32() as u8);
+
             for half in 0..(RV32_REGISTER_NUM_LIMBS / 2) {
-                bitwise_lookup_chip.request_range(
-                    data[2 * half].as_canonical_u32(),
-                    data[2 * half + 1].as_canonical_u32(),
-                );
+                self.bitwise_lookup_chip
+                    .request_range(data[2 * half] as u32, data[2 * half + 1] as u32);
             }
 
-            let cols: &mut Rv32HintStoreCols<F> = slice[used_u32s..used_u32s + width].borrow_mut();
-            cols.from_state.timestamp =
-                F::from_canonical_u32(record.from_state.timestamp + (3 * i as u32));
-            cols.data = data;
-            aux_cols_factory.generate_write_aux(memory.record_by_id(write), &mut cols.write_aux);
-            cols.rem_words_limbs = decompose(rem_words);
-            cols.mem_ptr_limbs = decompose(mem_ptr);
-            if i != 0 {
-                cols.is_buffer = F::ONE;
-            }
-            used_u32s += width;
-            mem_ptr += RV32_REGISTER_NUM_LIMBS as u32;
-            rem_words -= 1;
-        }
+            let mem_ptr_word = mem_ptr + (RV32_REGISTER_NUM_LIMBS * word_index) as u32;
 
-        used_u32s
-    }
-
-    fn generate_trace(self) -> RowMajorMatrix<F> {
-        let width = self.trace_width();
-        let height = next_power_of_two_or_zero(self.height);
-        let mut flat_trace = F::zero_vec(width * height);
-
-        let memory = self.offline_memory.lock().unwrap();
-
-        let aux_cols_factory = memory.aux_cols_factory();
-
-        let mut used_u32s = 0;
-        for record in self.records {
-            used_u32s += Self::record_to_rows(
-                record,
-                &aux_cols_factory,
-                &mut flat_trace[used_u32s..],
-                &memory,
-                &self.bitwise_lookup_chip,
-                self.air.pointer_max_bits,
+            row.data = data_f;
+            tracing_write(
+                state.memory,
+                RV32_MEMORY_AS,
+                mem_ptr_word,
+                &data,
+                &mut row.write_aux,
             );
+
+            row.rem_words_limbs = decompose(num_words - word_index as u32);
+            row.mem_ptr_limbs = decompose(mem_ptr_word);
         }
-        // padding rows can just be all zeros
-        RowMajorMatrix::new(flat_trace, width)
+
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+
+        *trace_offset += (num_words as usize) * width;
+
+        Ok(())
+    }
+
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let row: &mut Rv32HintStoreCols<F> = row_slice.borrow_mut();
+
+        let mut timestamp = row.from_state.timestamp.as_canonical_u32();
+
+        if row.is_single.is_one() || row.is_buffer_start.is_one() {
+            mem_helper.fill_from_prev(timestamp, row.mem_ptr_aux_cols.as_mut());
+        }
+        timestamp += 1;
+
+        if row.is_buffer_start.is_one() {
+            mem_helper.fill_from_prev(timestamp, row.num_words_aux_cols.as_mut());
+        }
+        timestamp += 1;
+
+        mem_helper.fill_from_prev(timestamp, row.write_aux.as_mut());
     }
 }
 
-impl<SC: StarkGenericConfig> Chip<SC> for Rv32HintStoreChip<Val<SC>>
-where
-    Val<SC>: PrimeField32,
-{
-    fn air(&self) -> Arc<dyn AnyRap<SC>> {
-        Arc::new(self.air)
-    }
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
-        AirProofInput::simple_no_pis(self.generate_trace())
-    }
-}
-
-impl<F> InsExecutorE1<F> for Rv32HintStoreChip<F>
+impl<F> StepExecutorE1<F> for Rv32HintStoreStep<F>
 where
     F: PrimeField32,
 {
@@ -535,10 +468,9 @@ where
         &mut self,
         state: VmStateMut<Mem, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<(), ExecutionError>
+    ) -> Result<()>
     where
         Mem: GuestMemory,
-        F: PrimeField32,
     {
         let &Instruction {
             opcode,
@@ -548,46 +480,55 @@ where
             e,
             ..
         } = instruction;
+
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
         debug_assert_eq!(e.as_canonical_u32(), RV32_MEMORY_AS);
-        let local_opcode =
-            Rv32HintStoreOpcode::from_usize(opcode.local_opcode_idx(self.air.offset));
 
-        // TODO(ayush): fix this
-        // let (mem_ptr_read, mem_ptr_limbs) = todo!();
-        // memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, mem_ptr_ptr);
-        // let (num_words, num_words_read) = if local_opcode == HINT_STOREW {
-        //     (1, None)
-        // } else {
-        //     let (num_words_read, num_words_limbs) = todo!();
-        //     // memory.read::<u8, RV32_REGISTER_NUM_LIMBS>(d, num_words_ptr);
-        //     (u32::from_le_bytes(num_words_limbs), Some(num_words_read))
-        // };
-        // debug_assert_ne!(num_words, 0);
-        // debug_assert!(num_words <= (1 << self.air.pointer_max_bits));
+        let local_opcode = Rv32HintStoreOpcode::from_usize(opcode.local_opcode_idx(self.offset));
 
-        // let mem_ptr = u32::from_le_bytes(mem_ptr_limbs);
+        let mem_ptr_limbs = memory_read(
+            state.memory,
+            RV32_REGISTER_AS,
+            mem_ptr_ptr.as_canonical_u32(),
+        );
+        let mem_ptr = u32::from_le_bytes(mem_ptr_limbs);
+        debug_assert!(mem_ptr <= (1 << self.pointer_max_bits));
 
-        // debug_assert!(mem_ptr <= (1 << self.air.pointer_max_bits));
+        let num_words = if local_opcode == HINT_STOREW {
+            1
+        } else {
+            let num_words_limbs = memory_read(
+                state.memory,
+                RV32_REGISTER_AS,
+                num_words_ptr.as_canonical_u32(),
+            );
+            u32::from_le_bytes(num_words_limbs)
+        };
+        debug_assert_ne!(num_words, 0);
+        debug_assert!(num_words <= (1 << self.pointer_max_bits));
 
-        // let mut streams = self.streams.get().unwrap().lock().unwrap();
-        // if streams.hint_stream.len() < RV32_REGISTER_NUM_LIMBS * num_words as usize {
-        //     return Err(ExecutionError::HintOutOfBounds { pc: *state.pc });
-        // }
+        let mut streams = self.streams.get().unwrap().lock().unwrap();
+        if streams.hint_stream.len() < RV32_REGISTER_NUM_LIMBS * num_words as usize {
+            return Err(ExecutionError::HintOutOfBounds { pc: *state.pc });
+        }
 
-        // for word_index in 0..num_words {
-        //     let data: [F; RV32_REGISTER_NUM_LIMBS] =
-        //         std::array::from_fn(|_| streams.hint_stream.pop_front().unwrap());
-        //     // let (write, _) = memory.write(
-        //     //     e,
-        //     //     F::from_canonical_u32(mem_ptr + (RV32_REGISTER_NUM_LIMBS as u32 *
-        // word_index)),     //     &tmp_convert_to_u8s(data),
-        //     // );
-        //     // record.hints.push((data, write));
-        // }
+        for word_index in 0..num_words {
+            // TODO(ayush): why is hint_stream F if composed of u8 limbs?
+            let data: [u8; RV32_REGISTER_NUM_LIMBS] = std::array::from_fn(|_| {
+                streams.hint_stream.pop_front().unwrap().as_canonical_u32() as u8
+            });
+            memory_write(
+                state.memory,
+                RV32_MEMORY_AS,
+                mem_ptr + (RV32_REGISTER_NUM_LIMBS as u32 * word_index),
+                &data,
+            );
+        }
 
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
     }
 }
+
+pub type Rv32HintStoreChip<F> = NewVmChipWrapper<F, Rv32HintStoreAir, Rv32HintStoreStep<F>>;

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -6,7 +6,7 @@ use std::{
 use openvm_circuit::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterTraceStep, MinimalInstruction, Result,
-        SingleTraceStep, StepExecutorE1, VmAdapterInterface, VmCoreAir, VmStateMut,
+        StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -223,7 +223,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> MulHStep<A, NUM_LIMBS, L
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> SingleTraceStep<F, CTX>
+impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
     for MulHStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
@@ -247,12 +247,15 @@ where
         &mut self,
         state: VmStateMut<TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
-        row_slice: &mut [F],
+        trace: &mut [F],
+        trace_offset: &mut usize,
+        width: usize,
     ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         let mulh_opcode = MulHOpcode::from_usize(opcode.local_opcode_idx(MulHOpcode::CLASS_OFFSET));
 
+        let mut row_slice = &mut trace[*trace_offset..*trace_offset + width];
         let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
         A::start(*state.pc, state.memory, adapter_row);
@@ -296,6 +299,8 @@ where
             .write(state.memory, instruction, adapter_row, &a);
 
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+
+        *trace_offset += width;
 
         Ok(())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.85.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
- make `Rv32HintStoreChip` use the `NewVmChipWrapper`
- rename `SingleTraceStep` to `TraceStep` and update it to work for chips whose execution creates multiple trace rows
- comment out criterion execute benchmarks for now 