### PR TITLE
docs: solidity sdk

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Compiling](./writing-apps/build.md)
 - [Generating Proofs](./writing-apps/prove.md)
 - [Verifying Proofs](./writing-apps/verify.md)
+- [Solidity SDK](./writing-apps/solidity.md)
 
 # Using Extensions
 

--- a/book/src/writing-apps/solidity.md
+++ b/book/src/writing-apps/solidity.md
@@ -1,0 +1,52 @@
+# Solidity SDK
+
+As a supplement to OpenVM, we provide a [Solidity SDK](https://github.com/openvm-org/openvm-solidity-sdk) containing OpenVM verifier contracts generated at each official release commit using the `cargo openvm setup` command. Note that these builds are for the default aggregation VM config which should be sufficient for most users. If you use a custom config, you will need to manually generate the verifier contract using the [OpenVM SDK](../advanced-usage/sdk.md).
+
+## Installation
+
+To install the Solidity SDK as a dependency into your forge project, run the following command:
+
+```bash
+forge install openvm-org/openvm-solidity-sdk
+```
+
+## Usage
+
+Once you have the SDK installed, you can import the SDK contracts into your solidity project:
+
+```solidity
+import "openvm-solidity-sdk/v1.1.1/OpenVmHalo2Verifier.sol";
+```
+
+If you are using an already-deployed verifier contract, you can simply import the `IOpenVmHalo2Verifier` interface:
+
+```solidity
+import { IOpenVmHalo2Verifier } from "openvm-solidity-sdk/v1.1.1/interfaces/IOpenVmHalo2Verifier.sol";
+
+contract MyContract {
+    function myFunction() public view {
+        // ... snip ...
+
+        IOpenVmHalo2Verifier(verifierAddress)
+            .verify(publicValues, proofData, appExeCommit, appVmCommit);
+
+        // ... snip ...
+    }
+}
+```
+
+The arguments to the `verify` function are the fields in the [EVM Proof JSON Format](./verify.md#evm-proof-json-format).
+
+If you want to import the verifier contract into your own repository for testing purposes, note that it is locked to Solidity version `0.8.19`. If your project uses a different version, the import may not compile. As a workaround, you can compile the contract separately and use `vm.etch()` to inject the raw bytecode into your tests.
+
+## Deployment
+
+To deploy an instance of a verifier contract, you can clone the repo and simply use `forge create`:
+
+```bash
+git clone --recursive https://github.com/openvm-org/openvm-solidity-sdk.git
+cd openvm-solidity-sdk
+forge create src/v1.1.1/OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier --rpc-url $RPC --private-key $PRIVATE_KEY --broadcast
+```
+
+We recommend a direct deployment from the SDK repo since the proper compiler configurations are all pre-set.

--- a/book/src/writing-apps/solidity.md
+++ b/book/src/writing-apps/solidity.md
@@ -14,16 +14,16 @@ forge install openvm-org/openvm-solidity-sdk
 
 ## Usage
 
-Once you have the SDK installed, you can import the SDK contracts into your solidity project:
+Once you have the SDK installed, you can import the SDK contracts into your Solidity project:
 
 ```solidity
-import "openvm-solidity-sdk/v1.1.1/OpenVmHalo2Verifier.sol";
+import "openvm-solidity-sdk/v1.1/OpenVmHalo2Verifier.sol";
 ```
 
 If you are using an already-deployed verifier contract, you can simply import the `IOpenVmHalo2Verifier` interface:
 
 ```solidity
-import { IOpenVmHalo2Verifier } from "openvm-solidity-sdk/v1.1.1/interfaces/IOpenVmHalo2Verifier.sol";
+import { IOpenVmHalo2Verifier } from "openvm-solidity-sdk/v1.1/interfaces/IOpenVmHalo2Verifier.sol";
 
 contract MyContract {
     function myFunction() public view {
@@ -49,7 +49,7 @@ To deploy an instance of a verifier contract, you can clone the repo and simply 
 ```bash
 git clone --recursive https://github.com/openvm-org/openvm-solidity-sdk.git
 cd openvm-solidity-sdk
-forge create src/v1.1.1/OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier --rpc-url $RPC --private-key $PRIVATE_KEY --broadcast
+forge create src/v1.1/OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier --rpc-url $RPC --private-key $PRIVATE_KEY --broadcast
 ```
 
 We recommend a direct deployment from the SDK repo since the proper compiler configurations are all pre-set.

--- a/book/src/writing-apps/solidity.md
+++ b/book/src/writing-apps/solidity.md
@@ -1,6 +1,8 @@
 # Solidity SDK
 
-As a supplement to OpenVM, we provide a [Solidity SDK](https://github.com/openvm-org/openvm-solidity-sdk) containing OpenVM verifier contracts generated at each official release commit using the `cargo openvm setup` command. Note that these builds are for the default aggregation VM config which should be sufficient for most users. If you use a custom config, you will need to manually generate the verifier contract using the [OpenVM SDK](../advanced-usage/sdk.md).
+As a supplement to OpenVM, we provide a [Solidity SDK](https://github.com/openvm-org/openvm-solidity-sdk) containing OpenVM verifier contracts generated at official release commits using the `cargo openvm setup` [command](../advanced-usage/sdk.md#setup). The contracts are built at every _minor_ release as OpenVM guarantees verifier backward compatibility across patch releases. 
+
+Note that these builds are for the default aggregation VM config which should be sufficient for most users. If you use a custom config, you will need to manually generate the verifier contract using the [OpenVM SDK](../advanced-usage/sdk.md).
 
 ## Installation
 
@@ -36,6 +38,7 @@ contract MyContract {
 ```
 
 The arguments to the `verify` function are the fields in the [EVM Proof JSON Format](./verify.md#evm-proof-json-format).
+Since the builds use the default aggregation VM config, the number of public values is fixed to 32.
 
 If you want to import the verifier contract into your own repository for testing purposes, note that it is locked to Solidity version `0.8.19`. If your project uses a different version, the import may not compile. As a workaround, you can compile the contract separately and use `vm.etch()` to inject the raw bytecode into your tests.
 


### PR DESCRIPTION
Adds instructions on using the solidity sdk to the book.

Closes INT-3974