### PR TITLE
feat: truncate patch on verifier version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,6 +4909,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.1#e540dbdd09ef20db7207ad7f2674bece75a2b803"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4936,6 +4937,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.1#e540dbdd09ef20db7207ad7f2674bece75a2b803"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-openvm"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -3913,7 +3913,7 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openvm"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "eyre",
  "num-bigint 0.4.6",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-execute"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "cargo-openvm",
  "clap",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-prove"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-utils"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-integration-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "eyre",
  "openvm-bigint-circuit",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-integration-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "eyre",
  "hex-literal",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-instructions",
  "quote",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-integration-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "eyre",
  "openvm-circuit",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4442,14 +4442,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "halo2curves-axiom",
  "itertools 0.14.0",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-integration-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "eyre",
  "num-bigint 0.4.6",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-prof"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "clap",
  "eyre",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-integration-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "eyre",
  "openvm",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-circuit",
  "openvm-circuit-primitives",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-integration-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "eyre",
  "openvm-circuit",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-toolchain-tests"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "derive_more 1.0.0",
  "eyre",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "elf",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 rust-version = "1.82"
 authors = ["OpenVM Authors"]

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -13,7 +13,7 @@ use crate::{
     codec::{Decode, Encode},
     keygen::{AggProvingKey, AppProvingKey, AppVerifyingKey},
     types::{EvmHalo2Verifier, EvmProof},
-    F, SC,
+    F, OPENVM_VERSION, SC,
 };
 
 pub const EVM_HALO2_VERIFIER_INTERFACE_NAME: &str = "IOpenVmHalo2Verifier.sol";
@@ -134,7 +134,7 @@ pub fn write_evm_halo2_verifier_to_folder<P: AsRef<Path>>(
     let folder = folder
         .as_ref()
         .join("src")
-        .join(format!("v{}", env!("CARGO_PKG_VERSION")));
+        .join(format!("v{}", OPENVM_VERSION));
     if !folder.exists() {
         create_dir_all(&folder)?; // Make sure directories exist
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -67,6 +67,11 @@ pub const EVM_HALO2_VERIFIER_INTERFACE: &str =
     include_str!("../contracts/src/IOpenVmHalo2Verifier.sol");
 pub const EVM_HALO2_VERIFIER_TEMPLATE: &str =
     include_str!("../contracts/template/OpenVmHalo2Verifier.sol");
+pub const OPENVM_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION_MAJOR"),
+    ".",
+    env!("CARGO_PKG_VERSION_MINOR")
+);
 
 #[cfg(feature = "evm-verify")]
 sol! {
@@ -346,12 +351,10 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
             "OpenVM Halo2 verifier contract does not support more than 8192 public values"
         );
 
-        let openvm_version = env!("CARGO_PKG_VERSION");
-
         // Fill out the public values length and OpenVM version in the template
         let openvm_verifier_code = EVM_HALO2_VERIFIER_TEMPLATE
             .replace("{PUBLIC_VALUES_LENGTH}", &pvs_length.to_string())
-            .replace("{OPENVM_VERSION}", openvm_version);
+            .replace("{OPENVM_VERSION}", OPENVM_VERSION);
 
         let formatter_config = FormatterConfig {
             line_length: 120,
@@ -401,7 +404,7 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         // Create temp dir
         let temp_dir = tempdir().wrap_err("Failed to create temp dir")?;
         let temp_path = temp_dir.path();
-        let root_path = Path::new("src").join(format!("v{}", openvm_version));
+        let root_path = Path::new("src").join(format!("v{}", OPENVM_VERSION));
 
         // Make interfaces dir
         let interfaces_path = root_path.join("interfaces");
@@ -491,11 +494,11 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         let bytecode = parsed
             .get("contracts")
             .expect("No 'contracts' field found")
-            .get(format!("src/v{}/OpenVmHalo2Verifier.sol", openvm_version))
+            .get(format!("src/v{}/OpenVmHalo2Verifier.sol", OPENVM_VERSION))
             .unwrap_or_else(|| {
                 panic!(
                     "No 'src/v{}/OpenVmHalo2Verifier.sol' field found",
-                    openvm_version
+                    OPENVM_VERSION
                 )
             })
             .get("OpenVmHalo2Verifier")


### PR DESCRIPTION
Truncates the patch version from halo2 verifier.

Also bumps the openvm version to 1.1.2 