### PR TITLE
refactor: ELF and Program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4356,12 +4356,16 @@ name = "openvm-instructions"
 version = "1.1.2"
 dependencies = [
  "backtrace",
+ "bitcode",
+ "criterion",
  "derive-new 0.6.0",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-instructions-derive",
  "openvm-stark-backend",
+ "p3-baby-bear",
+ "rand",
  "serde",
  "strum",
  "strum_macros",

--- a/benchmarks/prove/src/bin/fib_e2e.rs
+++ b/benchmarks/prove/src/bin/fib_e2e.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use clap::Parser;
 use eyre::Result;
 use openvm_benchmarks_prove::util::BenchmarkCli;
-use openvm_circuit::arch::instructions::{exe::VmExe, program::DEFAULT_MAX_NUM_PUBLIC_VALUES};
+use openvm_circuit::arch::{instructions::exe::VmExe, DEFAULT_MAX_NUM_PUBLIC_VALUES};
 use openvm_native_recursion::halo2::utils::{CacheHalo2ParamsReader, DEFAULT_PARAMS_DIR};
 use openvm_rv32im_circuit::Rv32ImConfig;
 use openvm_rv32im_transpiler::{

--- a/benchmarks/prove/src/bin/verify_fibair.rs
+++ b/benchmarks/prove/src/bin/verify_fibair.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use eyre::Result;
 use openvm_benchmarks_prove::util::BenchmarkCli;
-use openvm_circuit::arch::instructions::program::DEFAULT_MAX_NUM_PUBLIC_VALUES;
+use openvm_circuit::arch::DEFAULT_MAX_NUM_PUBLIC_VALUES;
 use openvm_native_circuit::NativeConfig;
 use openvm_native_compiler::conversion::CompilerOptions;
 use openvm_native_recursion::testing_utils::inner::build_verification_program;

--- a/crates/sdk/src/commit.rs
+++ b/crates/sdk/src/commit.rs
@@ -42,9 +42,6 @@ impl AppExecutionCommit<F> {
         app_exe: &NonRootCommittedExe,
         leaf_vm_verifier_exe: &NonRootCommittedExe,
     ) -> Self {
-        assert!(
-            app_exe.exe.program.max_num_public_values <= app_vm_config.system().num_public_values
-        );
         let exe_commit = app_exe
             .compute_exe_commit(&app_vm_config.system().memory_config)
             .into();

--- a/crates/sdk/src/config/mod.rs
+++ b/crates/sdk/src/config/mod.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use openvm_circuit::arch::instructions::program::DEFAULT_MAX_NUM_PUBLIC_VALUES;
+use openvm_circuit::arch::DEFAULT_MAX_NUM_PUBLIC_VALUES;
 use openvm_continuations::verifier::{
     common::types::VmVerifierPvs, internal::types::InternalVmVerifierPvs,
 };

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -208,14 +208,12 @@ fn dummy_app_committed_exe(fri_params: FriParameters) -> Arc<NonRootCommittedExe
 }
 
 fn dummy_app_program() -> Program<F> {
-    let mut ret = Program::from_instructions(&[Instruction::from_isize(
+    Program::from_instructions(&[Instruction::from_isize(
         TERMINATE.global_opcode(),
         0,
         0,
         0,
         0,
         0,
-    )]);
-    ret.max_num_public_values = 0;
-    ret
+    )])
 }

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -115,9 +115,7 @@ fn app_committed_exe_for_test(app_log_blowup: usize) -> Arc<VmCommittedExe<SC>> 
             builder.assign(&b, c);
         });
         builder.halt();
-        let mut program = builder.compile_isa();
-        program.max_num_public_values = NUM_PUB_VALUES;
-        program
+        builder.compile_isa()
     };
     Sdk::new()
         .commit_app_exe(
@@ -343,10 +341,6 @@ fn test_static_verifier_custom_pv_handler() {
     let app_pk = sdk.app_keygen(app_config.clone()).unwrap();
     let app_committed_exe = app_committed_exe_for_test(app_log_blowup);
     println!("app_config: {:?}", app_config.app_vm_config);
-    println!(
-        "app_committed_exe max_num_public_values: {:?}",
-        app_committed_exe.exe.program.max_num_public_values
-    );
     let params_reader = CacheHalo2ParamsReader::new_with_default_params_dir();
 
     // Generate PK using custom PV handler

--- a/crates/toolchain/instructions/Cargo.toml
+++ b/crates/toolchain/instructions/Cargo.toml
@@ -21,3 +21,11 @@ num-bigint.workspace = true
 num-traits.workspace = true
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+p3-baby-bear.workspace = true
+bitcode.workspace = true
+rand.workspace = true
+
+[[bench]]
+name = "program_serde"
+harness = false

--- a/crates/toolchain/instructions/benches/program_serde.rs
+++ b/crates/toolchain/instructions/benches/program_serde.rs
@@ -1,0 +1,39 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use openvm_instructions::{instruction::Instruction, program::Program, VmOpcode};
+use p3_baby_bear::BabyBear;
+use rand::prelude::*;
+
+type F = BabyBear;
+
+fn random_instruction(rng: &mut impl Rng) -> Instruction<F> {
+    Instruction::new(
+        VmOpcode::from_usize(rng.gen()),
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+    )
+}
+
+fn program_serde_bench(c: &mut Criterion) {
+    let mut rng = StdRng::from_seed([42; 32]);
+    let instructions: Vec<_> = (0..100_000).map(|_| random_instruction(&mut rng)).collect();
+    let program: Program<F> = Program::from_instructions(&instructions);
+    c.bench_function("bitcode serialize Program with 100000 instructions", |b| {
+        b.iter(|| bitcode::serialize(black_box(&program)))
+    });
+    let bytes = bitcode::serialize(&program).unwrap();
+    println!("Result length in bytes: {}", bytes.len());
+    c.bench_function(
+        "bitcode deserialize Program with 100000 instructions",
+        |b| b.iter(|| bitcode::deserialize::<'_, Program<F>>(black_box(&bytes))),
+    );
+}
+
+criterion_group!(benches, program_serde_bench);
+criterion_main!(benches);

--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -2,7 +2,7 @@ use std::{fmt, fmt::Display};
 
 use itertools::Itertools;
 use openvm_stark_backend::p3_field::Field;
-use serde::{Deserialize, Serialize};
+use serde::{de::Deserializer, Deserialize, Serialize, Serializer};
 
 use crate::instruction::{DebugInfo, Instruction};
 
@@ -10,31 +10,30 @@ pub const PC_BITS: usize = 30;
 /// We use default PC step of 4 whenever possible for consistency with RISC-V, where 4 comes
 /// from the fact that each standard RISC-V instruction is 32-bits = 4 bytes.
 pub const DEFAULT_PC_STEP: u32 = 4;
-pub const DEFAULT_MAX_NUM_PUBLIC_VALUES: usize = 32;
 pub const MAX_ALLOWED_PC: u32 = (1 << PC_BITS) - 1;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(bound(serialize = "F: Serialize", deserialize = "F: Deserialize<'de>"))]
 pub struct Program<F> {
     /// A map from program counter to instruction.
     /// Sometimes the instructions are enumerated as 0, 4, 8, etc.
     /// Maybe at some point we will replace this with a struct that would have a `Vec` under the
     /// hood and divide the incoming `pc` by whatever given.
+    #[serde(
+        serialize_with = "serialize_instructions_and_debug_infos",
+        deserialize_with = "deserialize_instructions_and_debug_infos"
+    )]
     pub instructions_and_debug_infos: Vec<Option<(Instruction<F>, Option<DebugInfo>)>>,
     pub step: u32,
     pub pc_base: u32,
-    /// The upper bound of the number of public values the program would publish.
-    /// Currently, this won't result any constraint. But users should always be aware of the limit
-    /// of public values when they write programs.
-    pub max_num_public_values: usize,
 }
 
 impl<F: Field> Program<F> {
-    pub fn new_empty(step: u32, pc_base: u32, max_num_public_values: usize) -> Self {
+    pub fn new_empty(step: u32, pc_base: u32) -> Self {
         Self {
             instructions_and_debug_infos: vec![],
             step,
             pc_base,
-            max_num_public_values,
         }
     }
 
@@ -42,7 +41,6 @@ impl<F: Field> Program<F> {
         instructions: &[Instruction<F>],
         step: u32,
         pc_base: u32,
-        max_num_public_values: usize,
     ) -> Self {
         Self {
             instructions_and_debug_infos: instructions
@@ -51,7 +49,6 @@ impl<F: Field> Program<F> {
                 .collect(),
             step,
             pc_base,
-            max_num_public_values,
         }
     }
 
@@ -59,7 +56,6 @@ impl<F: Field> Program<F> {
         instructions: &[Option<Instruction<F>>],
         step: u32,
         pc_base: u32,
-        max_num_public_values: usize,
     ) -> Self {
         Self {
             instructions_and_debug_infos: instructions
@@ -68,7 +64,6 @@ impl<F: Field> Program<F> {
                 .collect(),
             step,
             pc_base,
-            max_num_public_values,
         }
     }
 
@@ -86,7 +81,6 @@ impl<F: Field> Program<F> {
                 .collect(),
             step: DEFAULT_PC_STEP,
             pc_base: 0,
-            max_num_public_values: DEFAULT_MAX_NUM_PUBLIC_VALUES,
         }
     }
 
@@ -102,12 +96,7 @@ impl<F: Field> Program<F> {
     }
 
     pub fn from_instructions(instructions: &[Instruction<F>]) -> Self {
-        Self::new_without_debug_infos(
-            instructions,
-            DEFAULT_PC_STEP,
-            0,
-            DEFAULT_MAX_NUM_PUBLIC_VALUES,
-        )
+        Self::new_without_debug_infos(instructions, DEFAULT_PC_STEP, 0)
     }
 
     pub fn len(&self) -> usize {
@@ -223,4 +212,27 @@ pub fn display_program_with_pc<F: Field>(program: &Program<F>) {
             pc, opcode, a, b, c, d, e, f, g
         );
     }
+}
+
+// `debug_info` is stick with a specific binary. Serializ
+fn serialize_instructions_and_debug_infos<F: Serialize, S: Serializer>(
+    data: &[Option<(Instruction<F>, Option<DebugInfo>)>],
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let ins_data: Vec<_> = data
+        .iter()
+        .map(|o| o.as_ref().map(|(ins, _)| ins))
+        .collect();
+    ins_data.serialize(serializer)
+}
+
+#[allow(clippy::type_complexity)]
+fn deserialize_instructions_and_debug_infos<'de, F: Deserialize<'de>, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<Option<(Instruction<F>, Option<DebugInfo>)>>, D::Error> {
+    let inst_data: Vec<Option<Instruction<F>>> = Deserialize::deserialize(deserializer)?;
+    Ok(inst_data
+        .into_iter()
+        .map(|ins_opt| ins_opt.map(|ins| (ins, None)))
+        .collect())
 }

--- a/crates/toolchain/transpiler/src/elf.rs
+++ b/crates/toolchain/transpiler/src/elf.rs
@@ -19,8 +19,6 @@ use openvm_instructions::exe::FnBound;
 use openvm_instructions::{exe::FnBounds, program::MAX_ALLOWED_PC};
 use openvm_platform::WORD_SIZE;
 
-pub const ELF_DEFAULT_MAX_NUM_PUBLIC_VALUES: usize = 32;
-
 /// RISC-V 32IM ELF (Executable and Linkable Format) File.
 ///
 /// This file represents a binary in the ELF format, specifically the RISC-V 32IM architecture
@@ -40,9 +38,6 @@ pub struct Elf {
     pub(crate) pc_base: u32,
     /// The initial memory image, useful for global constants.
     pub(crate) memory_image: BTreeMap<u32, u32>,
-    /// The upper bound of the number of public values the program would publish.
-    /// TODO: read from project config.
-    pub(crate) max_num_public_values: usize,
     /// Debug info for spanning benchmark metrics by function.
     pub(crate) fn_bounds: FnBounds,
 }
@@ -61,7 +56,6 @@ impl Elf {
             pc_start,
             pc_base,
             memory_image,
-            max_num_public_values: ELF_DEFAULT_MAX_NUM_PUBLIC_VALUES,
             fn_bounds,
         }
     }

--- a/crates/toolchain/transpiler/src/lib.rs
+++ b/crates/toolchain/transpiler/src/lib.rs
@@ -33,7 +33,6 @@ impl<F: PrimeField32> FromElf for VmExe<F> {
             &instructions,
             DEFAULT_PC_STEP,
             elf.pc_base,
-            elf.max_num_public_values,
         );
         let init_memory = elf_memory_image_to_openvm_memory_image(elf.memory_image);
 

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use derive_new::new;
 use openvm_circuit::system::memory::MemoryTraceHeights;
-use openvm_instructions::program::DEFAULT_MAX_NUM_PUBLIC_VALUES;
 use openvm_poseidon2_air::Poseidon2Config;
 use openvm_stark_backend::{p3_field::PrimeField32, ChipUsageGetter};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -17,6 +16,7 @@ use crate::system::memory::BOUNDARY_AIR_OFFSET;
 // sbox is decomposed to have this max degree for Poseidon2. We set to 3 so quotient_degree = 2
 // allows log_blowup = 1
 const DEFAULT_POSEIDON2_MAX_CONSTRAINT_DEGREE: usize = 3;
+pub const DEFAULT_MAX_NUM_PUBLIC_VALUES: usize = 32;
 /// Width of Poseidon2 VM uses.
 pub const POSEIDON2_WIDTH: usize = 16;
 /// Returns a Poseidon2 config for the VM.

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -2,7 +2,7 @@ use std::iter;
 
 use openvm_instructions::{
     instruction::Instruction,
-    program::{Program, DEFAULT_MAX_NUM_PUBLIC_VALUES, DEFAULT_PC_STEP},
+    program::{Program, DEFAULT_PC_STEP},
     LocalOpcode,
 };
 use openvm_native_compiler::{
@@ -265,12 +265,7 @@ fn test_program_with_undefined_instructions() {
         )),
     ];
 
-    let program = Program::new_without_debug_infos_with_option(
-        &instructions,
-        DEFAULT_PC_STEP,
-        0,
-        DEFAULT_MAX_NUM_PUBLIC_VALUES,
-    );
+    let program = Program::new_without_debug_infos_with_option(&instructions, DEFAULT_PC_STEP, 0);
 
     interaction_test(program, vec![0, 2, 5]);
 }

--- a/extensions/native/compiler/src/conversion/mod.rs
+++ b/extensions/native/compiler/src/conversion/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::instructions::program::Program;
 use openvm_instructions::{
     instruction::{DebugInfo, Instruction},
-    program::{DEFAULT_MAX_NUM_PUBLIC_VALUES, DEFAULT_PC_STEP},
+    program::DEFAULT_PC_STEP,
     LocalOpcode, PhantomDiscriminant, PublishOpcode, SysPhantom, SystemOpcode, VmOpcode,
 };
 use openvm_rv32im_transpiler::BranchEqualOpcode;
@@ -565,7 +565,7 @@ pub fn convert_program<F: PrimeField32, EF: ExtensionField<F>>(
         }
     }
 
-    let mut result = Program::new_empty(DEFAULT_PC_STEP, 0, DEFAULT_MAX_NUM_PUBLIC_VALUES);
+    let mut result = Program::new_empty(DEFAULT_PC_STEP, 0);
     result.push_instruction_and_debug_info(init_register_0, init_debug_info);
     for block in program.blocks.iter() {
         for (instruction, debug_info) in block.0.iter().zip(block.1.iter()) {


### PR DESCRIPTION
- Remove `max_num_public_values` in `Program`/`Elf`.
- Improve serialization/deserialization of `Program`.

For a Program with 100,000 instructions:
Previous:
- Serialize: 3.1969ms
- Deserialize: 3.2417ms
- Size: 3625020 bytes

Now:
- Serialize: 1.3015ms
- Deserialize: 1.9343ms
- Size: 4000024 bytes

closes INT-3131
closes INT-3771