### PR TITLE
refactor: CLI Build & Setup

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -12,18 +12,11 @@ use openvm_build::{
     GuestOptions,
 };
 use openvm_circuit::arch::{InitFileGenerator, OPENVM_DEFAULT_INIT_FILE_NAME};
-use openvm_sdk::{
-    commit::{commit_app_exe, committed_exe_as_bn254},
-    fs::write_exe_to_file,
-    Sdk,
-};
+use openvm_sdk::{commit::commit_app_exe, fs::write_exe_to_file, Sdk};
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE};
 
 use crate::{
-    default::{
-        DEFAULT_APP_CONFIG_PATH, DEFAULT_APP_EXE_PATH, DEFAULT_COMMITTED_APP_EXE_PATH,
-        DEFAULT_EXE_COMMIT_PATH,
-    },
+    default::{DEFAULT_APP_CONFIG_PATH, DEFAULT_APP_EXE_PATH, DEFAULT_COMMITTED_APP_EXE_PATH},
     util::{find_manifest_dir, read_config_toml_or_default},
 };
 
@@ -77,14 +70,6 @@ pub struct BuildArgs {
         help_heading = "OpenVM Options"
     )]
     pub committed_exe_output: PathBuf,
-
-    #[arg(
-        long,
-        default_value = DEFAULT_EXE_COMMIT_PATH,
-        help = "Output path for the exe commit (bn254 commit of committed program)",
-        help_heading = "OpenVM Options"
-    )]
-    pub exe_commit_output: PathBuf,
 
     #[arg(
         long,
@@ -428,13 +413,6 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Vec<
             let committed_exe = commit_app_exe(app_config.app_fri_params.fri_params, exe.clone());
             write_exe_to_file(exe, output_path)?;
 
-            if let Some(parent) = build_args.exe_commit_output.parent() {
-                create_dir_all(parent)?;
-            }
-            write(
-                &build_args.exe_commit_output,
-                committed_exe_as_bn254(&committed_exe).value.to_bytes(),
-            )?;
             if let Some(parent) = build_args.committed_exe_output.parent() {
                 create_dir_all(parent)?;
             }

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use eyre::Result;
@@ -37,10 +37,19 @@ pub struct KeygenCmd {
 
 impl KeygenCmd {
     pub fn run(&self) -> Result<()> {
-        let app_config = read_config_toml_or_default(&self.config)?;
-        let app_pk = Sdk::new().app_keygen(app_config)?;
-        write_app_vk_to_file(app_pk.get_app_vk(), &self.vk_output)?;
-        write_app_pk_to_file(app_pk, &self.output)?;
+        keygen(&self.config, &self.output, &self.vk_output)?;
         Ok(())
     }
+}
+
+pub(crate) fn keygen(
+    config: impl AsRef<Path>,
+    output: impl AsRef<Path>,
+    vk_output: impl AsRef<Path>,
+) -> Result<()> {
+    let app_config = read_config_toml_or_default(config)?;
+    let app_pk = Sdk::new().app_keygen(app_config)?;
+    write_app_vk_to_file(app_pk.get_app_vk(), vk_output.as_ref())?;
+    write_app_pk_to_file(app_pk, output.as_ref())?;
+    Ok(())
 }

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -7,15 +7,18 @@ pub const DEFAULT_MANIFEST_DIR: &str = ".";
 
 pub const DEFAULT_APP_CONFIG_PATH: &str = "./openvm.toml";
 pub const DEFAULT_APP_EXE_PATH: &str = "./openvm/app.vmexe";
-pub const DEFAULT_EXE_COMMIT_PATH: &str = "./openvm/exe_commit.bytes";
 pub const DEFAULT_COMMITTED_APP_EXE_PATH: &str = "./openvm/committed_app_exe.bc";
 pub const DEFAULT_APP_PK_PATH: &str = "./openvm/app.pk";
 pub const DEFAULT_APP_VK_PATH: &str = "./openvm/app.vk";
 pub const DEFAULT_APP_PROOF_PATH: &str = "./openvm/app.proof";
 pub const DEFAULT_EVM_PROOF_PATH: &str = "./openvm/evm.proof";
 
-pub fn default_agg_pk_path() -> String {
-    env::var("HOME").unwrap() + "/.openvm/agg.pk"
+pub fn default_agg_stark_pk_path() -> String {
+    env::var("HOME").unwrap() + "/.openvm/agg_stark.pk"
+}
+
+pub fn default_agg_halo2_pk_path() -> String {
+    env::var("HOME").unwrap() + "/.openvm/agg_halo2.pk"
 }
 
 pub fn default_asm_path() -> String {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -4,27 +4,40 @@ use std::{
 };
 
 use eyre::Result;
-use openvm_sdk::config::{AppConfig, SdkVmConfig};
+use openvm_sdk::{
+    config::{AppConfig, SdkVmConfig},
+    fs::{read_agg_halo2_pk_from_file, read_agg_stark_pk_from_file},
+    keygen::AggProvingKey,
+};
 use serde::de::DeserializeOwned;
 
-use crate::default::default_app_config;
+use crate::default::{default_agg_halo2_pk_path, default_agg_stark_pk_path, default_app_config};
 
-pub(crate) fn read_to_struct_toml<T: DeserializeOwned>(path: &PathBuf) -> Result<T> {
-    let toml = read_to_string(path.as_ref() as &Path)?;
+pub(crate) fn read_to_struct_toml<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {
+    let toml = read_to_string(path)?;
     let ret = toml::from_str(&toml)?;
     Ok(ret)
 }
 
-pub fn read_config_toml_or_default(config: &PathBuf) -> Result<AppConfig<SdkVmConfig>> {
-    if config.exists() {
+pub fn read_config_toml_or_default(config: impl AsRef<Path>) -> Result<AppConfig<SdkVmConfig>> {
+    if config.as_ref().exists() {
         read_to_struct_toml(config)
     } else {
         println!(
             "{:?} not found, using default application configuration",
-            config
+            config.as_ref()
         );
         Ok(default_app_config())
     }
+}
+
+pub fn read_default_agg_pk() -> Result<AggProvingKey> {
+    let agg_stark_pk = read_agg_stark_pk_from_file(default_agg_stark_pk_path())?;
+    let halo2_pk = read_agg_halo2_pk_from_file(default_agg_halo2_pk_path())?;
+    Ok(AggProvingKey {
+        agg_stark_pk,
+        halo2_pk,
+    })
 }
 
 pub fn find_manifest_dir(mut current_dir: PathBuf) -> Result<PathBuf> {

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use cargo_openvm::{
     commands::{build, BuildArgs, BuildCargoArgs},
-    default::{DEFAULT_APP_EXE_PATH, DEFAULT_COMMITTED_APP_EXE_PATH, DEFAULT_EXE_COMMIT_PATH},
+    default::{DEFAULT_APP_EXE_PATH, DEFAULT_COMMITTED_APP_EXE_PATH},
 };
 use eyre::Result;
 use openvm_build::RUSTC_TARGET;
@@ -18,7 +18,6 @@ fn default_build_args(example: &str) -> BuildArgs {
             .join("openvm.toml"),
         exe_output: PathBuf::from(DEFAULT_APP_EXE_PATH),
         committed_exe_output: PathBuf::from(DEFAULT_COMMITTED_APP_EXE_PATH),
-        exe_commit_output: PathBuf::from(DEFAULT_EXE_COMMIT_PATH),
         init_file_name: OPENVM_DEFAULT_INIT_FILE_NAME.to_string(),
     }
 }

--- a/crates/sdk/src/commit.rs
+++ b/crates/sdk/src/commit.rs
@@ -85,7 +85,3 @@ pub fn commit_app_exe(
     let app_engine = BabyBearPoseidon2Engine::new(app_fri_params);
     Arc::new(VmCommittedExe::<SC>::commit(exe, app_engine.config.pcs()))
 }
-
-pub fn committed_exe_as_bn254(committed_exe: &NonRootCommittedExe) -> Bn254Fr {
-    babybear_digest_to_bn254(&committed_exe.get_program_commit().into())
-}

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -11,7 +11,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     codec::{Decode, Encode},
-    keygen::{AggProvingKey, AppProvingKey, AppVerifyingKey},
+    keygen::{AggStarkProvingKey, AppProvingKey, AppVerifyingKey, Halo2ProvingKey},
     types::{EvmHalo2Verifier, EvmProof},
     F, OPENVM_VERSION, SC,
 };
@@ -74,12 +74,19 @@ pub fn write_root_verifier_input_to_file<P: AsRef<Path>>(
     encode_to_file(path, input)
 }
 
-pub fn read_agg_pk_from_file<P: AsRef<Path>>(path: P) -> Result<AggProvingKey> {
+pub fn read_agg_stark_pk_from_file<P: AsRef<Path>>(path: P) -> Result<AggStarkProvingKey> {
+    read_from_file_bitcode(path)
+}
+pub fn read_agg_halo2_pk_from_file<P: AsRef<Path>>(path: P) -> Result<Halo2ProvingKey> {
     read_from_file_bitcode(path)
 }
 
-pub fn write_agg_pk_to_file<P: AsRef<Path>>(agg_pk: AggProvingKey, path: P) -> Result<()> {
-    write_to_file_bitcode(path, agg_pk)
+pub fn write_agg_halo2_pk_to_file<P: AsRef<Path>>(pk: &Halo2ProvingKey, path: P) -> Result<()> {
+    write_to_file_bitcode(path, pk)
+}
+
+pub fn write_agg_stark_pk_to_file<P: AsRef<Path>>(pk: &AggStarkProvingKey, path: P) -> Result<()> {
+    write_to_file_bitcode(path, pk)
 }
 
 pub fn read_evm_proof_from_file<P: AsRef<Path>>(path: P) -> Result<EvmProof> {


### PR DESCRIPTION
- `cargo openvm setup` supports skipping halo2 proving keys.
- `cargo openvm setup` outputs halo2 PK and stark PK as separated files.
- `cargo openvm build` outputs `AppExecutionCommit` in json. The old output(`exe_commit.bytes`) was incorrect.

close INT-3950