### PR TITLE
fix: new block initialization in memory access adapters

### DIFF
--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -123,6 +123,37 @@ fn rand_rv32_alu_test(opcode: BaseAluOpcode, num_ops: usize) {
     let mut tester = VmChipTestBuilder::default();
     let (mut chip, bitwise_chip) = create_test_chip(&tester);
 
+    // TODO(AG): make a more meaningful test for memory accesses
+    tester.write(2, 1024, [F::ONE; 4]);
+    tester.write(2, 1028, [F::ONE; 4]);
+    let sm = tester.read(2, 1024);
+    assert_eq!(sm, [F::ONE; 8]);
+
+    for _ in 0..num_ops {
+        set_and_execute(&mut tester, &mut chip, &mut rng, opcode, None, None, None);
+    }
+
+    let tester = tester.build().load(chip).load(bitwise_chip).finalize();
+    tester.simple_test().expect("Verification failed");
+}
+
+#[test_case(ADD, 100)]
+#[test_case(SUB, 100)]
+#[test_case(XOR, 100)]
+#[test_case(OR, 100)]
+#[test_case(AND, 100)]
+fn rand_rv32_alu_test_persistent(opcode: BaseAluOpcode, num_ops: usize) {
+    let mut rng = create_seeded_rng();
+
+    let mut tester = VmChipTestBuilder::default_persistent();
+    let (mut chip, bitwise_chip) = create_test_chip(&tester);
+
+    // TODO(AG): make a more meaningful test for memory accesses
+    tester.write(2, 1024, [F::ONE; 4]);
+    tester.write(2, 1028, [F::ONE; 4]);
+    let sm = tester.read(2, 1024);
+    assert_eq!(sm, [F::ONE; 8]);
+
     for _ in 0..num_ops {
         set_and_execute(&mut tester, &mut chip, &mut rng, opcode, None, None, None);
     }


### PR DESCRIPTION
I used to handle creating new blocks in a wrong way when `align > initial_block_size`, now I hopefully do it right.
Also added persistent base alu tests, although nothing changed for the persistent case,
and added a dummy access in all of them that used to fail.