### PR TITLE
feat: new execution remove redundant controller memory e1

### DIFF
--- a/crates/vm/src/arch/execution_control.rs
+++ b/crates/vm/src/arch/execution_control.rs
@@ -55,9 +55,9 @@ where
 
     /// Execute a single instruction
     // TODO(ayush): change instruction to Instruction<u32> / PInstruction
-    fn execute_instruction(
+    fn execute_instruction<Mem: GuestMemory>(
         &mut self,
-        vm_state: &mut ExecutionSegmentState,
+        vm_state: &mut ExecutionSegmentState<Mem>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -153,9 +153,9 @@ where
     }
 
     /// Execute a single instruction
-    fn execute_instruction(
+    fn execute_instruction<Mem: GuestMemory>(
         &mut self,
-        state: &mut ExecutionSegmentState,
+        state: &mut ExecutionSegmentState<Mem>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -235,9 +235,9 @@ where
     }
 
     /// Execute a single instruction
-    fn execute_instruction(
+    fn execute_instruction<Mem: GuestMemory>(
         &mut self,
-        state: &mut ExecutionSegmentState,
+        state: &mut ExecutionSegmentState<Mem>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -247,10 +247,9 @@ where
         let &Instruction { opcode, .. } = instruction;
 
         if let Some(executor) = chip_complex.inventory.get_mut_executor(&opcode) {
-            let memory_controller = &mut chip_complex.base.memory_controller;
             let vm_state = VmStateMut {
                 pc: &mut state.pc,
-                memory: &mut memory_controller.memory.data,
+                memory: state.memory.as_mut().unwrap(),
                 ctx: &mut (),
             };
             executor.execute_e1(vm_state, instruction)?;

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -246,7 +246,9 @@ where
         if let Some(overridden_heights) = self.overridden_heights.as_ref() {
             segment.set_override_trace_heights(overridden_heights.clone());
         }
-        let state = metrics_span("execute_time_ms", || segment.execute_from_pc(from_state.pc))?;
+        let state = metrics_span("execute_time_ms", || {
+            segment.execute_from_pc(from_state.pc, None)
+        })?;
 
         if state.is_terminated {
             return Ok(VmExecutorOneSegmentResult {
@@ -339,7 +341,7 @@ where
                 // TODO(ayush): avoid clones
                 exe.program.clone(),
                 state.input,
-                Some(state.memory),
+                None,
                 self.trace_height_constraints.clone(),
                 exe.fn_bounds.clone(),
             );
@@ -348,7 +350,9 @@ where
                 segment.metrics = state.metrics;
             }
 
-            let exec_state = metrics_span("execute_time_ms", || segment.execute_from_pc(state.pc))?;
+            let exec_state = metrics_span("execute_time_ms", || {
+                segment.execute_from_pc(state.pc, Some(state.memory))
+            })?;
 
             if exec_state.is_terminated {
                 // Check exit code for the final segment
@@ -561,7 +565,9 @@ where
         if let Some(overridden_heights) = self.overridden_heights.as_ref() {
             segment.set_override_trace_heights(overridden_heights.clone());
         }
-        metrics_span("execute_time_ms", || segment.execute_from_pc(exe.pc_start))?;
+        metrics_span("execute_time_ms", || {
+            segment.execute_from_pc(exe.pc_start, None)
+        })?;
         Ok(segment)
     }
 }


### PR DESCRIPTION
This resolves INT-4012 by not using memory controller's memory in E1 execution.