### PR TITLE
feat: rv32im working execution + tracegen + prove (aka integration tests)

### DIFF
--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -142,13 +142,12 @@ pub fn ins_executor_e1_executor_derive(input: TokenStream) -> TokenStream {
                 .push(syn::parse_quote! { #inner_ty: ::openvm_circuit::arch::InsExecutorE1<F> });
             quote! {
                 impl #impl_generics ::openvm_circuit::arch::InsExecutorE1<F> for #name #ty_generics #where_clause {
-                    fn execute_e1<Mem, Ctx>(
+                    fn execute_e1<Ctx>(
                         &mut self,
-                        state: ::openvm_circuit::arch::VmStateMut<Mem, Ctx>,
+                        state: ::openvm_circuit::arch::VmStateMut<::openvm_circuit::system::memory::online::GuestMemory, Ctx>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                     ) -> ::openvm_circuit::arch::Result<()>
                     where
-                        Mem: ::openvm_circuit::system::memory::online::GuestMemory,
                         F: ::openvm_stark_backend::p3_field::PrimeField32
                     {
                         self.0.execute_e1(state, instruction)
@@ -190,13 +189,12 @@ pub fn ins_executor_e1_executor_derive(input: TokenStream) -> TokenStream {
 
             quote! {
                 impl #impl_generics ::openvm_circuit::arch::InsExecutorE1<#first_ty_generic> for #name #ty_generics {
-                    fn execute_e1<Mem, Ctx>(
+                    fn execute_e1<Ctx>(
                         &mut self,
-                        state: ::openvm_circuit::arch::VmStateMut<Mem, Ctx>,
+                        state: ::openvm_circuit::arch::VmStateMut<::openvm_circuit::system::memory::online::GuestMemory, Ctx>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<#first_ty_generic>,
                     ) -> ::openvm_circuit::arch::Result<()>
                     where
-                        Mem: ::openvm_circuit::system::memory::online::GuestMemory,
                         #first_ty_generic: ::openvm_stark_backend::p3_field::PrimeField32
                     {
                         match self {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -113,13 +113,12 @@ pub trait InstructionExecutor<F> {
 
 /// New trait for instruction execution
 pub trait InsExecutorE1<F> {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
-        Mem: GuestMemory,
         F: PrimeField32;
 }
 
@@ -127,13 +126,12 @@ impl<F, C> InsExecutorE1<F> for RefCell<C>
 where
     C: InsExecutorE1<F>,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
-        Mem: GuestMemory,
         F: PrimeField32,
     {
         self.borrow_mut().execute_e1(state, instruction)

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -365,11 +365,11 @@ impl<T: FieldAlgebra> From<(u32, Option<T>)> for PcIncOrSet<T> {
 pub trait PhantomSubExecutor<F>: Send {
     fn phantom_execute(
         &mut self,
-        memory: &MemoryController<F>,
+        memory: &GuestMemory,
         streams: &mut Streams<F>,
         discriminant: PhantomDiscriminant,
-        a: F,
-        b: F,
+        a: u32,
+        b: u32,
         c_upper: u16,
     ) -> eyre::Result<()>;
 }

--- a/crates/vm/src/arch/execution_control.rs
+++ b/crates/vm/src/arch/execution_control.rs
@@ -18,8 +18,6 @@ where
     F: PrimeField32,
     VC: VmConfig<F>,
 {
-    /// Guest memory type
-    type Mem: GuestMemory;
     /// Host context
     type Ctx;
 
@@ -55,9 +53,9 @@ where
 
     /// Execute a single instruction
     // TODO(ayush): change instruction to Instruction<u32> / PInstruction
-    fn execute_instruction<Mem: GuestMemory>(
+    fn execute_instruction(
         &mut self,
-        vm_state: &mut ExecutionSegmentState<Mem>,
+        vm_state: &mut ExecutionSegmentState,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -88,7 +86,6 @@ where
     VC: VmConfig<F>,
 {
     type Ctx = TracegenCtx;
-    type Mem = AddressMap<PAGE_SIZE>;
 
     fn new(chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>) -> Self {
         Self {
@@ -153,9 +150,9 @@ where
     }
 
     /// Execute a single instruction
-    fn execute_instruction<Mem: GuestMemory>(
+    fn execute_instruction(
         &mut self,
-        state: &mut ExecutionSegmentState<Mem>,
+        state: &mut ExecutionSegmentState,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -197,7 +194,6 @@ where
     VC::Executor: InsExecutorE1<F>,
 {
     type Ctx = ();
-    type Mem = AddressMap<PAGE_SIZE>;
 
     fn new(_chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>) -> Self {
         Self { final_memory: None }
@@ -235,9 +231,9 @@ where
     }
 
     /// Execute a single instruction
-    fn execute_instruction<Mem: GuestMemory>(
+    fn execute_instruction(
         &mut self,
-        state: &mut ExecutionSegmentState<Mem>,
+        state: &mut ExecutionSegmentState,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -374,24 +374,18 @@ where
     type ReadData;
     type WriteData;
 
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory;
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData;
 
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData)
-    where
-        Mem: GuestMemory;
+    fn write(&self, memory: &mut GuestMemory, instruction: &Instruction<F>, data: &Self::WriteData);
 }
 
 // TODO: Rename core/step to operator
 pub trait StepExecutorE1<F> {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory;
+    ) -> Result<()>;
 }
 
 const DEFAULT_RECORDS_CAPACITY: usize = 1 << 20;
@@ -401,14 +395,11 @@ where
     F: PrimeField32,
     S: StepExecutorE1<F>,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         self.step.execute_e1(state, instruction)
     }
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -33,6 +33,7 @@ use crate::{
         connector::{VmConnectorPvs, DEFAULT_SUSPEND_EXIT_CODE},
         memory::{
             merkle::MemoryMerklePvs,
+            online::GuestMemory,
             paged_vec::AddressMap,
             tree::public_values::{UserPublicValuesProof, UserPublicValuesProofError},
             MemoryImage, CHUNK,
@@ -351,7 +352,7 @@ where
             }
 
             let exec_state = metrics_span("execute_time_ms", || {
-                segment.execute_from_pc(state.pc, Some(state.memory))
+                segment.execute_from_pc(state.pc, Some(GuestMemory::new(state.memory)))
             })?;
 
             if exec_state.is_terminated {

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -269,7 +269,7 @@ impl<F: PrimeField32> MemoryController<F> {
     }
 
     pub fn memory_image(&self) -> &MemoryImage {
-        &self.memory.data
+        &self.memory.data.memory
     }
 
     pub fn set_override_trace_heights(&mut self, overridden_heights: MemoryTraceHeights) {
@@ -496,7 +496,7 @@ impl<F: PrimeField32> MemoryController<F> {
             debug_assert!(ptr % min_block_size as u32 == 0);
 
             let values = (0..block_size)
-                .map(|i| self.memory.data.get_f::<F>(addr_space, ptr + i))
+                .map(|i| self.memory.data.memory.get_f::<F>(addr_space, ptr + i))
                 .collect::<Vec<_>>();
             self.memory.execute_splits::<false>(
                 MemoryAddress::new(addr_space, ptr),

--- a/crates/vm/src/system/memory/paged_vec.rs
+++ b/crates/vm/src/system/memory/paged_vec.rs
@@ -358,40 +358,40 @@ impl<const PAGE_SIZE: usize> AddressMap<PAGE_SIZE> {
     }
 }
 
-impl<const PAGE_SIZE: usize> GuestMemory for AddressMap<PAGE_SIZE> {
-    unsafe fn read<T, const BLOCK_SIZE: usize>(&self, addr_space: u32, ptr: u32) -> [T; BLOCK_SIZE]
-    where
-        T: Copy + Debug,
-    {
-        debug_assert_eq!(
-            size_of::<T>(),
-            self.cell_size[(addr_space - self.as_offset) as usize]
-        );
-        let read = self
-            .paged_vecs
-            .get_unchecked((addr_space - self.as_offset) as usize)
-            .get((ptr as usize) * size_of::<T>());
-        read
-    }
+// impl<const PAGE_SIZE: usize> GuestMemory for AddressMap<PAGE_SIZE> {
+//     unsafe fn read<T, const BLOCK_SIZE: usize>(&self, addr_space: u32, ptr: u32) -> [T;
+// BLOCK_SIZE]     where
+//         T: Copy + Debug,
+//     {
+//         debug_assert_eq!(
+//             size_of::<T>(),
+//             self.cell_size[(addr_space - self.as_offset) as usize]
+//         );
+//         let read = self
+//             .paged_vecs
+//             .get_unchecked((addr_space - self.as_offset) as usize)
+//             .get((ptr as usize) * size_of::<T>());
+//         read
+//     }
 
-    unsafe fn write<T, const BLOCK_SIZE: usize>(
-        &mut self,
-        addr_space: u32,
-        ptr: u32,
-        values: &[T; BLOCK_SIZE],
-    ) where
-        T: Copy + Debug,
-    {
-        debug_assert_eq!(
-            size_of::<T>(),
-            self.cell_size[(addr_space - self.as_offset) as usize],
-            "addr_space={addr_space}"
-        );
-        self.paged_vecs
-            .get_unchecked_mut((addr_space - self.as_offset) as usize)
-            .set((ptr as usize) * size_of::<T>(), values);
-    }
-}
+//     unsafe fn write<T, const BLOCK_SIZE: usize>(
+//         &mut self,
+//         addr_space: u32,
+//         ptr: u32,
+//         values: &[T; BLOCK_SIZE],
+//     ) where
+//         T: Copy + Debug,
+//     {
+//         debug_assert_eq!(
+//             size_of::<T>(),
+//             self.cell_size[(addr_space - self.as_offset) as usize],
+//             "addr_space={addr_space}"
+//         );
+//         self.paged_vecs
+//             .get_unchecked_mut((addr_space - self.as_offset) as usize)
+//             .set((ptr as usize) * size_of::<T>(), values);
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -247,10 +247,7 @@ where
     type WriteData = [F; W];
 
     #[inline(always)]
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         assert!(R <= 2);
 
         let &Instruction { b, c, e, f, .. } = instruction;
@@ -270,10 +267,12 @@ where
     }
 
     #[inline(always)]
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(
+        &self,
+        memory: &mut GuestMemory,
+        instruction: &Instruction<F>,
+        data: &Self::WriteData,
+    ) {
         assert!(W <= 1);
 
         let &Instruction { a, d, .. } = instruction;

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -128,13 +128,12 @@ impl<F> InsExecutorE1<F> for PhantomChip<F>
 where
     F: PrimeField32,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<(), ExecutionError>
     where
-        Mem: GuestMemory,
         F: PrimeField32,
     {
         let &Instruction {

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -155,21 +155,21 @@ where
                 })?;
             let mut streams = self.streams.get().unwrap().lock().unwrap();
             // TODO(ayush): implement phantom subexecutor for new traits
-            // sub_executor
-            //     .as_mut()
-            //     .phantom_execute(
-            //         state.memory,
-            //         &mut streams,
-            //         discriminant,
-            //         a,
-            //         b,
-            //         (c_u32 >> 16) as u16,
-            //     )
-            //     .map_err(|e| ExecutionError::Phantom {
-            //         pc: *state.pc,
-            //         discriminant,
-            //         inner: e,
-            //     })?;
+            sub_executor
+                .as_mut()
+                .phantom_execute(
+                    state.memory,
+                    &mut streams,
+                    discriminant,
+                    a.as_canonical_u32(),
+                    b.as_canonical_u32(),
+                    (c_u32 >> 16) as u16,
+                )
+                .map_err(|e| ExecutionError::Phantom {
+                    pc: *state.pc,
+                    discriminant,
+                    inner: e,
+                })?;
         }
 
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
@@ -185,52 +185,26 @@ impl<F: PrimeField32> InstructionExecutor<F> for PhantomChip<F> {
         instruction: &Instruction<F>,
         from_state: ExecutionState<u32>,
     ) -> Result<ExecutionState<u32>, ExecutionError> {
-        let &Instruction {
-            opcode, a, b, c, ..
-        } = instruction;
-        assert_eq!(opcode, self.air.phantom_opcode);
-
-        let c_u32 = c.as_canonical_u32();
-        let discriminant = PhantomDiscriminant(c_u32 as u16);
-        // If not a system phantom sub-instruction (which is handled in
-        // ExecutionSegment), look for a phantom sub-executor to handle it.
-        if SysPhantom::from_repr(discriminant.0).is_none() {
-            let sub_executor = self
-                .phantom_executors
-                .get_mut(&discriminant)
-                .ok_or_else(|| ExecutionError::PhantomNotFound {
-                    pc: from_state.pc,
-                    discriminant,
-                })?;
-            let mut streams = self.streams.get().unwrap().lock().unwrap();
-            sub_executor
-                .as_mut()
-                .phantom_execute(
-                    memory,
-                    &mut streams,
-                    discriminant,
-                    a,
-                    b,
-                    (c_u32 >> 16) as u16,
-                )
-                .map_err(|e| ExecutionError::Phantom {
-                    pc: from_state.pc,
-                    discriminant,
-                    inner: e,
-                })?;
-        }
-
+        let mut pc = from_state.pc;
         self.rows.push(PhantomCols {
-            pc: F::from_canonical_u32(from_state.pc),
-            operands: [a, b, c],
-            timestamp: F::from_canonical_u32(from_state.timestamp),
+            pc: F::from_canonical_u32(pc),
+            operands: [instruction.a, instruction.b, instruction.c],
+            timestamp: F::from_canonical_u32(memory.memory.timestamp),
             is_valid: F::ONE,
         });
+
+        let state = VmStateMut {
+            pc: &mut pc,
+            memory: &mut memory.memory.data,
+            ctx: &mut (),
+        };
+        self.execute_e1(state, instruction)?;
         memory.increment_timestamp();
-        Ok(ExecutionState::new(
-            from_state.pc + DEFAULT_PC_STEP,
-            from_state.timestamp + 1,
-        ))
+
+        Ok(ExecutionState {
+            pc,
+            timestamp: memory.memory.timestamp,
+        })
     }
 
     fn get_opcode_name(&self, _: usize) -> String {

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -209,14 +209,11 @@ where
     F: PrimeField32,
     A: 'static + for<'a> AdapterExecutorE1<F, ReadData = [F; 2], WriteData = [F; 0]>,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let [value, index] = self.adapter.read(state.memory, instruction);
 
         let idx: usize = index.as_canonical_u32() as usize;

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -426,15 +426,14 @@ where
     }
 }
 
-impl<Mem, Ctx, F, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
-    InsExecutorE1<Mem, Ctx, F> for ModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
+impl<Ctx, F, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
+    InsExecutorE1<Ctx, F> for ModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
 {
     fn execute_e1(
         &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
+        _state: &mut VmExecutionState<Ctx>,
         _instruction: &Instruction<F>,
     ) -> Result<()> {
         todo!("Implement execute_e1")

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -495,15 +495,14 @@ where
     }
 }
 
-impl<Mem, Ctx, F, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
-    InsExecutorE1<Mem, Ctx, F> for BadModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
+impl<Ctx, F, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
+    InsExecutorE1<Ctx, F> for BadModularIsEqualCoreChip<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
 {
     fn execute_e1(
         &mut self,
-        _state: &mut VmExecutionState<Mem, Ctx>,
+        _state: &mut VmExecutionState<Ctx>,
         _instruction: &Instruction<F>,
     ) -> Result<()> {
         todo!("Implement execute_e1")

--- a/extensions/native/circuit/src/adapters/alu_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/alu_native_adapter.rs
@@ -12,6 +12,7 @@ use openvm_circuit::{
     system::{
         memory::{
             offline_checker::{MemoryBridge, MemoryReadOrImmediateAuxCols, MemoryWriteAuxCols},
+            online::GuestMemory,
             MemoryAddress, MemoryController, OfflineMemory,
         },
         native_adapter::{NativeReadRecord, NativeWriteRecord},
@@ -199,15 +200,14 @@ where
     }
 }
 
-impl<Mem, F> AdapterExecutorE1<Mem, F> for AluNativeAdapterStep
+impl<F> AdapterExecutorE1<F> for AluNativeAdapterStep
 where
-    Mem: GuestMemory,
     F: PrimeField32,
 {
     type ReadData = (F, F);
     type WriteData = F;
 
-    fn read(memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData {
+    fn read(memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { b, c, e, f, .. } = instruction;
 
         let [read1]: [F; 1] = unsafe { memory.read(e.as_canonical_u32(), b.as_canonical_u32()) };
@@ -216,7 +216,7 @@ where
         (read1, read2)
     }
 
-    fn write(memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData) {
+    fn write(memory: &mut GuestMemory, instruction: &Instruction<F>, data: &Self::WriteData) {
         let Instruction { a, .. } = instruction;
 
         unsafe { memory.write(AS::Native, a.as_canonical_u32(), &[data]) };

--- a/extensions/native/circuit/src/adapters/branch_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/branch_native_adapter.rs
@@ -12,6 +12,7 @@ use openvm_circuit::{
     system::{
         memory::{
             offline_checker::{MemoryBridge, MemoryReadOrImmediateAuxCols},
+            online::GuestMemory,
             MemoryAddress, MemoryController, OfflineMemory,
         },
         native_adapter::NativeReadRecord,
@@ -195,15 +196,14 @@ where
     }
 }
 
-impl<Mem, F> AdapterExecutorE1<Mem, F> for BranchNativeAdapterStep
+impl<F> AdapterExecutorE1<F> for BranchNativeAdapterStep
 where
-    Mem: GuestMemory,
     F: PrimeField32,
 {
     type ReadData = (F, F);
     type WriteData = ();
 
-    fn read(memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData {
+    fn read(memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { a, b, d, e, .. } = instruction;
 
         let read1 = unsafe { memory.read(d.as_canonical_u32(), a.as_canonical_u32()) };
@@ -212,7 +212,7 @@ where
         (read1, read2)
     }
 
-    fn write(_memory: &mut Mem, _instruction: &Instruction<F>, _data: &Self::WriteData) {}
+    fn write(_memory: &mut GuestMemory, _instruction: &Instruction<F>, _data: &Self::WriteData) {}
 }
 
 // impl<F: PrimeField32> VmAdapterChip<F> for BranchNativeAdapterChip<F> {

--- a/extensions/native/circuit/src/adapters/convert_adapter.rs
+++ b/extensions/native/circuit/src/adapters/convert_adapter.rs
@@ -204,23 +204,22 @@ where
     }
 }
 
-impl<Mem, F, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterExecutorE1<Mem, F>
+impl<F, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterExecutorE1<F>
     for ConvertAdapterStep<READ_SIZE, WRITE_SIZE>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
 {
     type ReadData = [F; READ_SIZE];
     type WriteData = [F; WRITE_SIZE];
 
-    fn read(memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData {
+    fn read(memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { b, e, .. } = instruction;
 
         let read = unsafe { memory.read(e.as_canonical_u32(), b.as_canonical_u32()) };
         read
     }
 
-    fn write(memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData) {
+    fn write(memory: &mut GuestMemory, instruction: &Instruction<F>, data: &Self::WriteData) {
         let Instruction { a, d, .. } = instruction;
 
         unsafe {

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -243,16 +243,15 @@ where
     }
 }
 
-impl<Mem, F, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterExecutorE1<Mem, F>
+impl<F, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterExecutorE1<F>
     for NativeLoadStoreAdapterStep<READ_SIZE, WRITE_SIZE>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
 {
     type ReadData = (F, [F; NUM_CELLS]);
     type WriteData = [F; NUM_CELLS];
 
-    fn read(memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData {
+    fn read(memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction {
             opcode,
             a,
@@ -294,7 +293,7 @@ where
         (read_cell, data_read)
     }
 
-    fn write(memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData) {
+    fn write(memory: &mut GuestMemory, instruction: &Instruction<F>, data: &Self::WriteData) {
         let Instruction {
             opcode,
             a,

--- a/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
@@ -214,15 +214,14 @@ where
     }
 }
 
-impl<Mem, F, const N: usize> AdapterExecutorE1<Mem, F> for NativeVectorizedAdapterChip<N>
+impl<F, const N: usize> AdapterExecutorE1<F> for NativeVectorizedAdapterChip<N>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
 {
     type ReadData = ([F; N], [F; N]);
     type WriteData = [F; N];
 
-    fn read(memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData {
+    fn read(memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { b, c, d, e, .. } = instruction;
 
         let y_val: [F; N] = unsafe { memory.read(d.as_canonical_u32(), b.as_cas_canonical_u32()) };
@@ -232,7 +231,7 @@ where
         (y_val, z_val)
     }
 
-    fn write(memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData) {
+    fn write(memory: &mut GuestMemory, instruction: &Instruction<F>, data: &Self::WriteData) {
         let Instruction { a, d, .. } = instruction;
 
         unsafe { memory.write(d.as_canonical_u32(), a.as_cas_canonical_u32(), &data) };

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -181,15 +181,14 @@ where
     }
 }
 
-impl<Mem, Ctx, F, A> StepExecutorE1<Mem, Ctx, F> for CastFStep<A>
+impl<Ctx, F, A> StepExecutorE1<Ctx, F> for CastFStep<A>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
-    A: 'static + for<'a> AdapterExecutorE1<Mem, F, ReadData = [F; 1], WriteData = [F; 4]>,
+    A: 'static + for<'a> AdapterExecutorE1<F, ReadData = [F; 1], WriteData = [F; 4]>,
 {
     fn execute_e1(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
+        state: &mut VmExecutionState<Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()> {
         let Instruction {

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -195,15 +195,14 @@ where
     }
 }
 
-impl<Mem, Ctx, F, A> StepExecutorE1<Mem, Ctx, F> for FieldArithmeticStep<A>
+impl<Ctx, F, A> StepExecutorE1<Ctx, F> for FieldArithmeticStep<A>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
-    A: 'static + for<'a> AdapterExecutorE1<Mem, F, ReadData = (F, F), WriteData = F>,
+    A: 'static + for<'a> AdapterExecutorE1<F, ReadData = (F, F), WriteData = F>,
 {
     fn execute_e1(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
+        state: &mut VmExecutionState<Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()> {
         let Instruction {

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -216,9 +216,8 @@ where
     }
 }
 
-impl<Mem, Ctx, F, A> StepExecutorE1<Mem, Ctx, F> for FieldExtensionStep<A>
+impl<Ctx, F, A> StepExecutorE1<Ctx, F> for FieldExtensionStep<A>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterExecutorE1<
@@ -230,7 +229,7 @@ where
 {
     fn execute_e1(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
+        state: &mut VmExecutionState<Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()> {
         let Instruction {

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -206,10 +206,9 @@ where
     }
 }
 
-impl<Mem, Ctx, F, A, const NUM_CELLS: usize> StepExecutorE1<Mem, Ctx, F>
+impl<Ctx, F, A, const NUM_CELLS: usize> StepExecutorE1<Ctx, F>
     for NativeLoadStoreStep<A, F, NUM_CELLS>
 where
-    Mem: GuestMemory,
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterExecutorE1<
@@ -221,7 +220,7 @@ where
 {
     fn execute_e1(
         &mut self,
-        state: &mut VmExecutionState<Mem, Ctx>,
+        state: &mut VmExecutionState<Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()> {
         let Instruction {

--- a/extensions/rv32-adapters/src/heap.rs
+++ b/extensions/rv32-adapters/src/heap.rs
@@ -173,19 +173,18 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize, const WRIT
     type WriteData = [[u8; WRITE_SIZE]; 1];
 
     #[inline(always)]
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let read_data = AdapterExecutorE1::<F>::read(&self.0, memory, instruction);
         read_data.map(|r| r[0])
     }
 
     #[inline(always)]
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(
+        &self,
+        memory: &mut GuestMemory,
+        instruction: &Instruction<F>,
+        data: &Self::WriteData,
+    ) {
         AdapterExecutorE1::<F>::write(&self.0, memory, instruction, data);
     }
 }

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -194,10 +194,7 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterExe
     type ReadData = [[u8; READ_SIZE]; NUM_READS];
     type WriteData = ();
 
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { a, b, d, e, .. } = *instruction;
 
         let d = d.as_canonical_u32();
@@ -218,10 +215,12 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterExe
         })
     }
 
-    fn write<Mem>(&self, _memory: &mut Mem, _instruction: &Instruction<F>, _data: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(
+        &self,
+        _memory: &mut GuestMemory,
+        _instruction: &Instruction<F>,
+        _data: &Self::WriteData,
+    ) {
         // This function intentionally does nothing
     }
 }

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -444,10 +444,7 @@ impl<
     type ReadData = [[[u8; READ_SIZE]; BLOCKS_PER_READ]; NUM_READS];
     type WriteData = [[u8; WRITE_SIZE]; BLOCKS_PER_WRITE];
 
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { b, c, d, e, .. } = *instruction;
 
         let d = d.as_canonical_u32();
@@ -470,10 +467,12 @@ impl<
         })
     }
 
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(
+        &self,
+        memory: &mut GuestMemory,
+        instruction: &Instruction<F>,
+        data: &Self::WriteData,
+    ) {
         let Instruction { a, d, e, .. } = *instruction;
         let rd_val = new_read_rv32_register(memory, d.as_canonical_u32(), a.as_canonical_u32());
         assert!(rd_val as usize + WRITE_SIZE * BLOCKS_PER_WRITE - 1 < (1 << self.pointer_max_bits));

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -285,10 +285,7 @@ where
     type WriteData = [[u8; RV32_REGISTER_NUM_LIMBS]; 1];
 
     #[inline(always)]
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { b, c, d, e, .. } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
@@ -315,10 +312,7 @@ where
     }
 
     #[inline(always)]
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, rd: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(&self, memory: &mut GuestMemory, instruction: &Instruction<F>, rd: &Self::WriteData) {
         let Instruction { a, d, .. } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -194,10 +194,7 @@ where
     type WriteData = ();
 
     #[inline(always)]
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { a, b, d, e, .. } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
@@ -212,9 +209,11 @@ where
     }
 
     #[inline(always)]
-    fn write<Mem>(&self, _memory: &mut Mem, _instruction: &Instruction<F>, _data: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(
+        &self,
+        _memory: &mut GuestMemory,
+        _instruction: &Instruction<F>,
+        _data: &Self::WriteData,
+    ) {
     }
 }

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -242,10 +242,7 @@ where
     type WriteData = [u8; RV32_REGISTER_NUM_LIMBS];
 
     #[inline(always)]
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { b, d, .. } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
@@ -257,10 +254,12 @@ where
     }
 
     #[inline(always)]
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(
+        &self,
+        memory: &mut GuestMemory,
+        instruction: &Instruction<F>,
+        data: &Self::WriteData,
+    ) {
         let Instruction {
             a, d, f: enabled, ..
         } = instruction;

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -539,10 +539,7 @@ where
     );
     type WriteData = [u8; RV32_REGISTER_NUM_LIMBS];
 
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction {
             opcode,
             a,
@@ -597,10 +594,12 @@ where
         ((prev_data, read_data), shift_amount)
     }
 
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, data: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(
+        &self,
+        memory: &mut GuestMemory,
+        instruction: &Instruction<F>,
+        data: &Self::WriteData,
+    ) {
         // TODO(ayush): remove duplication with read
         let &Instruction {
             opcode,

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -53,10 +53,7 @@ pub fn decompose<F: PrimeField32>(value: u32) -> [F; RV32_REGISTER_NUM_LIMBS] {
 }
 
 #[inline(always)]
-pub fn memory_read<Mem, const N: usize>(memory: &Mem, address_space: u32, ptr: u32) -> [u8; N]
-where
-    Mem: GuestMemory,
-{
+pub fn memory_read<const N: usize>(memory: &GuestMemory, address_space: u32, ptr: u32) -> [u8; N] {
     debug_assert!(
         address_space == RV32_REGISTER_AS
             || address_space == RV32_MEMORY_AS
@@ -71,14 +68,12 @@ where
 }
 
 #[inline(always)]
-pub fn memory_write<Mem, const N: usize>(
-    memory: &mut Mem,
+pub fn memory_write<const N: usize>(
+    memory: &mut GuestMemory,
     address_space: u32,
     ptr: u32,
     data: &[u8; N],
-) where
-    Mem: GuestMemory,
-{
+) {
     debug_assert!(
         address_space == RV32_REGISTER_AS
             || address_space == RV32_MEMORY_AS
@@ -224,7 +219,7 @@ pub fn read_rv32_register<F: PrimeField32>(
 }
 
 #[inline(always)]
-pub fn new_read_rv32_register<Mem: GuestMemory>(memory: &Mem, address_space: u32, ptr: u32) -> u32 {
+pub fn new_read_rv32_register(memory: &GuestMemory, address_space: u32, ptr: u32) -> u32 {
     u32::from_le_bytes(memory_read(memory, address_space, ptr))
 }
 

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -218,6 +218,7 @@ pub fn read_rv32_register<F: PrimeField32>(
     (record.0, val)
 }
 
+// TODO(AG): if "register", why `address_space` is not hardcoded to be 1?
 #[inline(always)]
 pub fn new_read_rv32_register(memory: &GuestMemory, address_space: u32, ptr: u32) -> u32 {
     u32::from_le_bytes(memory_read(memory, address_space, ptr))

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -227,10 +227,7 @@ where
     type WriteData = [[u8; RV32_REGISTER_NUM_LIMBS]; 1];
 
     #[inline(always)]
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         let Instruction { b, c, d, .. } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
@@ -244,10 +241,7 @@ where
     }
 
     #[inline(always)]
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, rd: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(&self, memory: &mut GuestMemory, instruction: &Instruction<F>, rd: &Self::WriteData) {
         let Instruction { a, d, .. } = *instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -265,17 +265,10 @@ where
     type WriteData = [u8; RV32_REGISTER_NUM_LIMBS];
 
     #[inline(always)]
-    fn read<Mem>(&self, _memory: &mut Mem, _instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
-    }
+    fn read(&self, _memory: &mut GuestMemory, _instruction: &Instruction<F>) -> Self::ReadData {}
 
     #[inline(always)]
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, rd: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(&self, memory: &mut GuestMemory, instruction: &Instruction<F>, rd: &Self::WriteData) {
         let Instruction { a, d, .. } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
@@ -382,18 +375,12 @@ where
     type WriteData = [u8; RV32_REGISTER_NUM_LIMBS];
 
     #[inline(always)]
-    fn read<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>) -> Self::ReadData
-    where
-        Mem: GuestMemory,
-    {
+    fn read(&self, memory: &mut GuestMemory, instruction: &Instruction<F>) -> Self::ReadData {
         <Rv32RdWriteAdapterStep as AdapterExecutorE1<F>>::read(&self.inner, memory, instruction)
     }
 
     #[inline(always)]
-    fn write<Mem>(&self, memory: &mut Mem, instruction: &Instruction<F>, rd: &Self::WriteData)
-    where
-        Mem: GuestMemory,
-    {
+    fn write(&self, memory: &mut GuestMemory, instruction: &Instruction<F>, rd: &Self::WriteData) {
         let Instruction { f: enabled, .. } = instruction;
 
         if *enabled != F::ZERO {

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -310,14 +310,11 @@ where
     A: 'static
         + for<'a> AdapterExecutorE1<F, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, c: imm, .. } = instruction;
 
         let local_opcode =

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -283,14 +283,11 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = BaseAluOpcode::from_usize(opcode.local_opcode_idx(self.offset));

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -230,14 +230,11 @@ where
     F: PrimeField32,
     A: 'static + for<'a> AdapterExecutorE1<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let branch_eq_opcode = BranchEqualOpcode::from_usize(opcode.local_opcode_idx(self.offset));

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -358,14 +358,11 @@ where
     F: PrimeField32,
     A: 'static + for<'a> AdapterExecutorE1<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let blt_opcode = BranchLessThanOpcode::from_usize(opcode.local_opcode_idx(self.offset));

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -542,14 +542,11 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = *instruction;
 
         // Determine opcode and operation type

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -462,14 +462,11 @@ impl<F> StepExecutorE1<F> for Rv32HintStoreStep<F>
 where
     F: PrimeField32,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let &Instruction {
             opcode,
             a: num_words_ptr,

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -255,14 +255,11 @@ where
     A: 'static
         + for<'a> AdapterExecutorE1<F, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, c: imm, .. } = instruction;
 
         let local_opcode =

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -332,14 +332,11 @@ where
             WriteData = [u8; RV32_REGISTER_NUM_LIMBS],
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, c, g, .. } = instruction;
 
         let local_opcode =

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -335,14 +335,11 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         let less_than_opcode = LessThanOpcode::from_usize(opcode.local_opcode_idx(self.offset));

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -314,14 +314,11 @@ where
             WriteData = [u8; NUM_CELLS],
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -378,14 +378,11 @@ where
             WriteData = [u8; NUM_CELLS],
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         // Get the local opcode for this instruction

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -234,14 +234,11 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         // Verify the opcode is MUL

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -324,14 +324,11 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         let mulh_opcode = MulHOpcode::from_usize(opcode.local_opcode_idx(MulHOpcode::CLASS_OFFSET));

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -397,14 +397,11 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    fn execute_e1<Mem, Ctx>(
+    fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<Mem, Ctx>,
+        state: VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
-    ) -> Result<()>
-    where
-        Mem: GuestMemory,
-    {
+    ) -> Result<()> {
         let Instruction { opcode, .. } = instruction;
 
         let shift_opcode = ShiftOpcode::from_usize(opcode.local_opcode_idx(self.offset));


### PR DESCRIPTION
This resolves INT-3913.

As a _side effect_, this removes `GuestMemory` trait -- it is a struct now with underlying `AddressMap<PAGE_SIZE>` (I didn't make `type GuestMemory = ...` because the vaguely called `read` and `write` methods would be too vaguely called for `AddressMap`). `VmStateMut` is generic over `MEM` though.

I didn't fully implement `TraceStep` and `StepExecutorE1` for the phantom chip because it's relatively easy and I'm not sure it would be better expressible in terms of `NewVmChipWrapper`.

`PhantomSubExecutor` also changed a little (now accepts `u32` instead of `F`, for example, and also `GuestMemory` instead of what it needed before).