### PR TITLE
feat: traits for generalized E3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,6 +4915,7 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tracing",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5466,6 +5466,7 @@ dependencies = [
  "serde-big-array",
  "strum",
  "test-case",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,7 @@ rrs-lib = "0.1.0"
 rand = { version = "0.8.5", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 serde-big-array = "0.5.1"
+zerocopy = "0.8.25"
 
 # default-features = false for no_std for use in guest programs
 itertools = { version = "0.14.0", default-features = false }

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -35,6 +35,7 @@ eyre.workspace = true
 derivative.workspace = true
 static_assertions.workspace = true
 getset.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -35,7 +35,7 @@ eyre.workspace = true
 derivative.workspace = true
 static_assertions.workspace = true
 getset.workspace = true
-zerocopy.workspace = true
+zerocopy = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 test-log.workspace = true

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -355,7 +355,7 @@ where
 pub trait AdapterTraceStep<F, CTX> {
     type ReadData;
     type WriteData;
-    // @dev This can either be a &mut _ directory or a struct with &mut _ fields.
+    // @dev This can either be a &mut _ type or a struct with &mut _ fields.
     // The latter is helpful if we want to directly write certain values in place into a trace
     // matrix.
     type RecordMut<'a>

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -343,48 +343,49 @@ where
     }
 }
 
-// TODO[jpw]: switch read,write to store into abstract buffer, then fill_trace_row using buffer
 /// A helper trait for expressing generic state accesses within the implementation of
 /// [TraceStep]. Note that this is only a helper trait when the same interface of state access
 /// is reused or shared by multiple implementations. It is not required to implement this trait if
 /// it is easier to implement the [TraceStep] trait directly without this trait.
 pub trait AdapterTraceStep<F, CTX> {
-    /// Adapter row width
-    const WIDTH: usize;
     type ReadData;
     type WriteData;
-    /// The minimal amount of information needed to generate the sub-row of the trace matrix.
-    /// This type has a lifetime so other context, such as references to other chips, can be
-    /// provided.
-    type TraceContext<'a>
+    type RecordMut<'a>
     where
         Self: 'a;
 
-    fn start(pc: u32, memory: &TracingMemory<F>, adapter_row: &mut [F]);
+    // /// The minimal amount of information needed to generate the sub-row of the trace matrix.
+    // /// This type has a lifetime so other context, such as references to other chips, can be
+    // /// provided.
+    // type TraceContext<'a>
+    // where
+    //     Self: 'a;
+
+    fn start(pc: u32, memory: &TracingMemory<F>, record: Self::RecordMut<'_>);
 
     fn read(
         &self,
         memory: &mut TracingMemory<F>,
         instruction: &Instruction<F>,
-        adapter_row: &mut [F],
+        record: Self::RecordMut<'_>,
     ) -> Self::ReadData;
 
     fn write(
         &self,
         memory: &mut TracingMemory<F>,
         instruction: &Instruction<F>,
-        adapter_row: &mut [F],
         data: &Self::WriteData,
+        record: Self::RecordMut<'_>,
     );
 
-    // Note[jpw]: should we reuse TraceSubRowGenerator trait instead?
-    /// Post-execution filling of rest of adapter row.
-    fn fill_trace_row(
-        &self,
-        mem_helper: &MemoryAuxColsFactory<F>,
-        ctx: Self::TraceContext<'_>,
-        adapter_row: &mut [F],
-    );
+    // // Note[jpw]: should we reuse TraceSubRowGenerator trait instead?
+    // /// Post-execution filling of rest of adapter row.
+    // fn fill_trace_row(
+    //     &self,
+    //     mem_helper: &MemoryAuxColsFactory<F>,
+    //     ctx: Self::TraceContext<'_>,
+    //     adapter_row: &mut [F],
+    // );
 }
 
 pub trait AdapterExecutorE1<F>

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -173,7 +173,7 @@ pub trait TraceFiller<F, CTX> {
     /// Populates `row_slice`. This function will always be called after
     /// [`TraceStep::execute`], so the `row_slice` should already contain context necessary to
     /// fill in the rest of the row. This function will be called for each row in the trace which
-    /// being used, and all other rows in the trace will be filled with zeroes.
+    /// is being used, and for all other rows in the trace see `fill_dummy_trace_row`.
     ///
     /// The provided `row_slice` will have length equal to the width of the AIR.
     fn fill_trace_row(&self, _mem_helper: &MemoryAuxColsFactory<F>, _row_slice: &mut [F]) {

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -152,6 +152,13 @@ pub struct AdapterAirContext<T, I: VmAdapterInterface<T>> {
     pub instruction: I::ProcessedInstruction,
 }
 
+/// Given some minimum metadata of type `Layout` that specifies the record size, the `RecordArena`
+/// should allocate a buffer, of size possibly larger than the record, and then return mutable
+/// pointers to the record within the buffer.
+pub trait RecordArena<Layout, RecordMut> {
+    fn alloc(&mut self, layout: Layout) -> RecordMut;
+}
+
 /// Interface for trace generation of a single instruction.The trace is provided as a mutable
 /// buffer during both instruction execution and trace generation.
 /// It is expected that no additional memory allocation is necessary and the trace buffer

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -387,7 +387,7 @@ pub trait AdapterTraceStep<F, CTX> {
     );
 }
 
-// NOTE[jpw]: cannot re-use `TraceSubRowGenerator` trait because we need associated constant
+// NOTE[jpw]: cannot reuse `TraceSubRowGenerator` trait because we need associated constant
 // `WIDTH`.
 pub trait AdapterTraceFiller<F> {
     /// Adapter sub-air column width

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -786,9 +786,11 @@ pub struct MemoryAuxColsFactory<'a, T> {
 // parallelized trace generation.
 impl<F: PrimeField32> MemoryAuxColsFactory<'_, F> {
     /// Fill the trace assuming `prev_timestamp` is already provided in `buffer`.
-    pub fn fill_from_prev(&self, timestamp: u32, buffer: &mut MemoryBaseAuxCols<F>) {
-        let prev_timestamp = buffer.prev_timestamp.as_canonical_u32();
+    pub fn fill(&self, prev_timestamp: u32, timestamp: u32, buffer: &mut MemoryBaseAuxCols<F>) {
         self.generate_timestamp_lt(prev_timestamp, timestamp, &mut buffer.timestamp_lt_aux);
+        // Safety: even if prev_timestamp were obtained by transmute_ref from
+        // `buffer.prev_timestamp`, this should still work because it is a direct assignment
+        buffer.prev_timestamp = F::from_canonical_u32(prev_timestamp);
     }
 
     fn generate_timestamp_lt(
@@ -805,18 +807,6 @@ impl<F: PrimeField32> MemoryAuxColsFactory<'_, F> {
             (self.range_checker, prev_timestamp, timestamp),
             &mut buffer.lower_decomp,
         );
-    }
-
-    fn generate_timestamp_lt_cols(
-        &self,
-        prev_timestamp: u32,
-        timestamp: u32,
-    ) -> LessThanAuxCols<F, AUX_LEN> {
-        debug_assert!(prev_timestamp < timestamp);
-        let mut decomp = [F::ZERO; AUX_LEN];
-        self.timestamp_lt_air
-            .generate_subrow((self.range_checker, prev_timestamp, timestamp), &mut decomp);
-        LessThanAuxCols::new(decomp)
     }
 }
 

--- a/crates/vm/src/system/memory/offline_checker/columns.rs
+++ b/crates/vm/src/system/memory/offline_checker/columns.rs
@@ -1,8 +1,6 @@
 //! Defines auxiliary columns for memory operations: `MemoryReadAuxCols`,
 //! `MemoryReadWithImmediateAuxCols`, and `MemoryWriteAuxCols`.
 
-use std::ops::DerefMut;
-
 use openvm_circuit_primitives::is_less_than::LessThanAuxCols;
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -11,8 +9,8 @@ use crate::system::memory::offline_checker::bridge::AUX_LEN;
 
 // repr(C) is needed to make sure that the compiler does not reorder the fields
 // we assume the order of the fields when using borrow or borrow_mut
-#[repr(C)]
 /// Base structure for auxiliary memory columns.
+#[repr(C)]
 #[derive(Clone, Copy, Debug, AlignedBorrow)]
 pub struct MemoryBaseAuxCols<T> {
     /// The previous timestamps in which the cells were accessed.
@@ -61,9 +59,8 @@ impl<const N: usize, T> MemoryWriteAuxCols<T, N> {
         &self.prev_data
     }
 
-    /// Sets the previous timestamp and data **without** updating the less than auxiliary columns.
-    pub fn set_prev(&mut self, timestamp: T, data: [T; N]) {
-        self.base.prev_timestamp = timestamp;
+    /// Sets the previous data **without** updating the less than auxiliary columns.
+    pub fn set_prev_data(&mut self, data: [T; N]) {
         self.prev_data = data;
     }
 }

--- a/crates/vm/src/system/memory/offline_checker/mod.rs
+++ b/crates/vm/src/system/memory/offline_checker/mod.rs
@@ -5,3 +5,14 @@ mod columns;
 pub use bridge::*;
 pub use bus::*;
 pub use columns::*;
+
+#[repr(C)]
+pub struct MemoryReadAuxRecord {
+    pub prev_timestamp: u32,
+}
+
+#[repr(C)]
+pub struct MemoryWriteAuxRecord<DATA> {
+    pub prev_timestamp: u32,
+    pub prev_data: DATA,
+}

--- a/crates/vm/src/system/memory/offline_checker/mod.rs
+++ b/crates/vm/src/system/memory/offline_checker/mod.rs
@@ -5,14 +5,10 @@ mod columns;
 pub use bridge::*;
 pub use bus::*;
 pub use columns::*;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable)]
 pub struct MemoryReadAuxRecord {
     pub prev_timestamp: u32,
-}
-
-#[repr(C)]
-pub struct MemoryWriteAuxRecord<DATA> {
-    pub prev_timestamp: u32,
-    pub prev_data: DATA,
 }

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -195,16 +195,13 @@ impl<F, CTX, const R: usize, const W: usize> AdapterTraceStep<F, CTX> for Native
 where
     F: PrimeField32,
 {
-    const WIDTH: usize = size_of::<NativeAdapterCols<u8, R, W>>();
     type ReadData = [[F; 1]; R];
     type WriteData = [[F; 1]; W];
-    type TraceContext<'a> = ();
+    type RecordMut<'a> = (); // TODO
 
     #[inline(always)]
-    fn start(pc: u32, memory: &TracingMemory<F>, adapter_row: &mut [F]) {
-        let adapter_row: &mut NativeAdapterCols<F, R, W> = adapter_row.borrow_mut();
-        adapter_row.from_state.pc = F::from_canonical_u32(pc);
-        adapter_row.from_state.timestamp = F::from_canonical_u32(memory.timestamp);
+    fn start(pc: u32, memory: &TracingMemory<F>, record: ()) {
+        todo!()
     }
 
     #[inline(always)]
@@ -212,7 +209,7 @@ where
         &self,
         memory: &mut TracingMemory<F>,
         instruction: &Instruction<F>,
-        adapter_row: &mut [F],
+        record: (),
     ) -> Self::ReadData {
         todo!("Implement read operation");
     }
@@ -222,20 +219,10 @@ where
         &self,
         memory: &mut TracingMemory<F>,
         instruction: &Instruction<F>,
-        adapter_row: &mut [F],
         data: &Self::WriteData,
+        record: (),
     ) {
         todo!("Implement write operation");
-    }
-
-    #[inline(always)]
-    fn fill_trace_row(
-        &self,
-        mem_helper: &MemoryAuxColsFactory<F>,
-        bitwise_lookup_chip: Self::TraceContext<'_>,
-        adapter_row: &mut [F],
-    ) {
-        todo!("Implement fill_trace_row operation");
     }
 }
 

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -5,8 +5,8 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        AdapterAirContext, AdapterRuntimeContext, BasicAdapterInterface, ExecutionBridge,
-        ExecutionBus, ExecutionState, MinimalInstruction, Result, VmAdapterAir, VmAdapterInterface,
+        AdapterAirContext, BasicAdapterInterface, ExecutionBridge, ExecutionBus, ExecutionState,
+        MinimalInstruction, Result, VmAdapterAir, VmAdapterInterface,
     },
     system::{
         memory::{

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -200,7 +200,7 @@ where
     type RecordMut<'a> = (); // TODO
 
     #[inline(always)]
-    fn start(pc: u32, memory: &TracingMemory<F>, record: ()) {
+    fn start(pc: u32, memory: &TracingMemory<F>, record: &mut ()) {
         todo!()
     }
 
@@ -209,7 +209,7 @@ where
         &self,
         memory: &mut TracingMemory<F>,
         instruction: &Instruction<F>,
-        record: (),
+        record: &mut (),
     ) -> Self::ReadData {
         todo!("Implement read operation");
     }
@@ -220,7 +220,7 @@ where
         memory: &mut TracingMemory<F>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
-        record: (),
+        record: &mut (),
     ) {
         todo!("Implement write operation");
     }

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -171,7 +171,7 @@ where
         arena: &mut RA,
     ) -> Result<()>
     where
-        RA: RecordArena<Self::RecordLayout, Self::RecordMut<'buf>>,
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
         Self: 'buf,
     {
         todo!()
@@ -243,8 +243,8 @@ pub struct PublicValuesRecordArena<F> {
     inner: MatrixRecordArena<F>,
 }
 
-impl<F: PrimeField32> RecordArena<EmptyLayout, ()> for PublicValuesRecordArena<F> {
-    fn alloc(&mut self, layout: EmptyLayout) -> () {
+impl<'a, F: PrimeField32> RecordArena<'a, EmptyLayout, ()> for PublicValuesRecordArena<F> {
+    fn alloc(&'a mut self, layout: EmptyLayout) -> () {
         todo!()
     }
 }

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterRuntimeContext, AdapterTraceStep,
-        BasicAdapterInterface, MinimalInstruction, Result, StepExecutorE1, TraceStep,
-        VmAdapterInterface, VmCoreAir, VmCoreChip, VmStateMut,
+        BasicAdapterInterface, EmptyLayout, MinimalInstruction, RecordArena, Result,
+        StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir, VmCoreChip, VmStateMut,
     },
     system::{
         memory::{
@@ -153,6 +153,9 @@ where
             RecordMut<'a> = (),
         >,
 {
+    type RecordLayout = EmptyLayout;
+    type RecordMut<'a> = (); // TODO
+
     fn get_opcode_name(&self, opcode: usize) -> String {
         format!(
             "{:?}",
@@ -160,41 +163,41 @@ where
         )
     }
 
-    fn execute(
+    fn execute<'buf, RA>(
         &mut self,
         state: VmStateMut<TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
-        trace: &mut [F],
-        trace_offset: &mut usize,
-        width: usize,
-    ) -> Result<()> {
-        todo!("Implement execute function");
+        arena: &mut RA,
+    ) -> Result<()>
+    where
+        RA: RecordArena<Self::RecordLayout, Self::RecordMut<'buf>>,
+        Self: 'buf,
+    {
+        todo!()
     }
 
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
-        todo!("Implement fill_trace_row function");
+    // fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    // let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
-        // let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+    // self.adapter.fill_trace_row(mem_helper, (), adapter_row);
 
-        // self.adapter.fill_trace_row(mem_helper, (), adapter_row);
+    // let core_row: &mut PublicValuesCoreColsView<_, F> = core_row.borrow_mut();
 
-        // let core_row: &mut PublicValuesCoreColsView<_, F> = core_row.borrow_mut();
+    // // TODO(ayush): add this check
+    // // debug_assert_eq!(core_row.width(), BaseAir::<F>::width(&self.air));
 
-        // // TODO(ayush): add this check
-        // // debug_assert_eq!(core_row.width(), BaseAir::<F>::width(&self.air));
+    // core_row.is_valid = F::ONE;
+    // core_row.value = record.value;
+    // core_row.index = record.index;
 
-        // core_row.is_valid = F::ONE;
-        // core_row.value = record.value;
-        // core_row.index = record.index;
+    // let idx: usize = record.index.as_canonical_u32() as usize;
 
-        // let idx: usize = record.index.as_canonical_u32() as usize;
+    // let pt = self.air.encoder.get_flag_pt(idx);
 
-        // let pt = self.air.encoder.get_flag_pt(idx);
-
-        // for (i, var) in core_row.custom_pv_vars.iter_mut().enumerate() {
-        //     *var = F::from_canonical_u32(pt[i]);
-        // }
-    }
+    // for (i, var) in core_row.custom_pv_vars.iter_mut().enumerate() {
+    //     *var = F::from_canonical_u32(pt[i]);
+    // }
+    // }
 
     fn generate_public_values(&self) -> Vec<F> {
         self.get_custom_public_values()

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -18,8 +18,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     arch::{
         AdapterAirContext, AdapterExecutorE1, AdapterRuntimeContext, AdapterTraceStep,
-        BasicAdapterInterface, EmptyLayout, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir, VmCoreChip, VmStateMut,
+        BasicAdapterInterface, EmptyLayout, MatrixRecordArena, MinimalInstruction, RecordArena,
+        Result, RowMajorMatrixArena, StepExecutorE1, TraceStep, VmAdapterInterface, VmCoreAir,
+        VmCoreChip, VmStateMut,
     },
     system::{
         memory::{
@@ -235,6 +236,32 @@ where
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
+    }
+}
+
+pub struct PublicValuesRecordArena<F> {
+    inner: MatrixRecordArena<F>,
+}
+
+impl<F: PrimeField32> RecordArena<EmptyLayout, ()> for PublicValuesRecordArena<F> {
+    fn alloc(&mut self, layout: EmptyLayout) -> () {
+        todo!()
+    }
+}
+
+impl<F: Field> RowMajorMatrixArena for PublicValuesRecordArena<F> {
+    fn with_capacity(height: usize, width: usize) -> Self {
+        Self {
+            inner: MatrixRecordArena::with_capacity(height, width),
+        }
+    }
+
+    fn width(&self) -> usize {
+        self.inner.width()
+    }
+
+    fn trace_offset(&self) -> usize {
+        self.inner.trace_offset()
     }
 }
 

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -150,7 +150,7 @@ where
             CTX,
             ReadData = [[F; 1]; 2],
             WriteData = [[F; 1]; 0],
-            TraceContext<'a> = (),
+            RecordMut<'a> = (),
         >,
 {
     fn get_opcode_name(&self, opcode: usize) -> String {

--- a/crates/vm/src/system/public_values/mod.rs
+++ b/crates/vm/src/system/public_values/mod.rs
@@ -1,7 +1,7 @@
-use core::PublicValuesStep;
+use core::{PublicValuesRecordArena, PublicValuesStep};
 
 use crate::{
-    arch::{NewVmChipWrapper, VmAirWrapper},
+    arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper},
     system::{
         native_adapter::{NativeAdapterAir, NativeAdapterStep},
         public_values::core::PublicValuesCoreAir,
@@ -17,4 +17,9 @@ mod tests;
 
 pub type PublicValuesAir = VmAirWrapper<NativeAdapterAir<2, 0>, PublicValuesCoreAir>;
 pub type PublicValuesStepWithAdapter<F> = PublicValuesStep<NativeAdapterStep<F, 2, 0>, F>;
-pub type PublicValuesChip<F> = NewVmChipWrapper<F, PublicValuesAir, PublicValuesStepWithAdapter<F>>;
+pub type PublicValuesChip<F> = NewVmChipWrapper<
+    F,
+    PublicValuesAir,
+    PublicValuesStepWithAdapter<F>,
+    PublicValuesRecordArena<F>,
+>;

--- a/extensions/rv32im/circuit/Cargo.toml
+++ b/extensions/rv32im/circuit/Cargo.toml
@@ -21,6 +21,7 @@ derive-new.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 rand.workspace = true
 eyre.workspace = true
+zerocopy = { workspace = true, features = ["derive"] }
 
 # for div_rem:
 num-bigint.workspace = true

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -135,14 +135,13 @@ pub fn tracing_read<F, const N: usize>(
     memory: &mut TracingMemory<F>,
     address_space: u32,
     ptr: u32,
-    aux_cols: &mut MemoryReadAuxCols<F>, /* TODO[jpw]: switch to raw u8
-                                          * buffer */
+    prev_timestamp: &mut u32,
 ) -> [u8; N]
 where
     F: PrimeField32,
 {
     let (t_prev, data) = timed_read(memory, address_space, ptr);
-    aux_cols.set_prev(F::from_canonical_u32(t_prev));
+    *prev_timestamp = t_prev;
     data
 }
 
@@ -154,17 +153,14 @@ pub fn tracing_write<F, const N: usize>(
     address_space: u32,
     ptr: u32,
     data: &[u8; N],
-    aux_cols: &mut MemoryWriteAuxCols<F, N>, /* TODO[jpw]: switch to raw
-                                              * u8
-                                              * buffer */
+    prev_timestamp: &mut u32,
+    prev_data: &mut [u8; N],
 ) where
     F: PrimeField32,
 {
     let (t_prev, data_prev) = timed_write(memory, address_space, ptr, data);
-    aux_cols.set_prev(
-        F::from_canonical_u32(t_prev),
-        data_prev.map(F::from_canonical_u8),
-    );
+    *prev_timestamp = t_prev;
+    *prev_data = data_prev;
 }
 
 // TODO(ayush): this is bad but not sure how to avoid

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -25,6 +25,7 @@ pub use loadstore::*;
 pub use mul::*;
 pub use openvm_instructions::riscv::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 pub use rdwrite::*;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// 256-bit heap integer stored as 32 bytes (32 limbs of 8-bits)
 pub const INT256_NUM_LIMBS: usize = 32;
@@ -36,6 +37,13 @@ pub const RV_IS_TYPE_IMM_BITS: usize = 12;
 pub const RV_B_TYPE_IMM_BITS: usize = 13;
 
 pub const RV_J_TYPE_IMM_BITS: usize = 21;
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable)]
+pub struct Rv32WordWriteAuxRecord {
+    pub prev_timestamp: u32,
+    pub prev_data: [u8; RV32_REGISTER_NUM_LIMBS],
+}
 
 /// Convert the RISC-V register data (32 bits represented as 4 bytes, where each byte is represented
 /// as a field element) back into its value as u32.
@@ -137,13 +145,13 @@ pub fn tracing_read<F, const N: usize>(
     memory: &mut TracingMemory<F>,
     address_space: u32,
     ptr: u32,
-    record: &mut MemoryReadAuxRecord,
+    prev_timestamp: &mut u32,
 ) -> [u8; N]
 where
     F: PrimeField32,
 {
     let (t_prev, data) = timed_read(memory, address_space, ptr);
-    *record.prev_timestamp = t_prev;
+    *prev_timestamp = t_prev;
     data
 }
 
@@ -155,13 +163,14 @@ pub fn tracing_write<F, const N: usize>(
     address_space: u32,
     ptr: u32,
     data: &[u8; N],
-    record: &mut MemoryWriteAuxRecord<[u8; N]>,
+    prev_timestamp: &mut u32,
+    prev_data: &mut [u8; N],
 ) where
     F: PrimeField32,
 {
     let (t_prev, data_prev) = timed_write(memory, address_space, ptr, data);
-    *record.prev_timestamp = t_prev;
-    *record.prev_data = data_prev;
+    *prev_timestamp = t_prev;
+    *prev_data = data_prev;
 }
 
 // TODO(ayush): this is bad but not sure how to avoid

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -29,7 +29,6 @@ use openvm_stark_backend::{
     p3_field::{Field, FieldAlgebra, PrimeField32},
     rap::BaseAirWithPublicValues,
 };
-use serde::{Deserialize, Serialize};
 
 use crate::adapters::{Rv32RdWriteAdapterCols, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 
@@ -239,7 +238,7 @@ where
         let local_opcode =
             Rv32AuipcOpcode::from_usize(opcode.local_opcode_idx(Rv32AuipcOpcode::CLASS_OFFSET));
 
-        let mut row_slice = &mut trace[*trace_offset..*trace_offset + width];
+        let row_slice = &mut trace[*trace_offset..*trace_offset + width];
         let (adapter_row, core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
         A::start(*state.pc, state.memory, adapter_row);

--- a/extensions/rv32im/circuit/src/base_alu/mod.rs
+++ b/extensions/rv32im/circuit/src/base_alu/mod.rs
@@ -14,4 +14,5 @@ pub type Rv32BaseAluAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 pub type Rv32BaseAluStep =
     BaseAluStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32BaseAluChip<F> = NewVmChipWrapper<F, Rv32BaseAluAir, Rv32BaseAluStep>;
+pub type Rv32BaseAluChip<F> =
+    NewVmChipWrapper<F, Rv32BaseAluAir, Rv32BaseAluStep, Rv32BaseAluRecordArena<F>>;


### PR DESCRIPTION
This is targeting a new branch `feat/new-execution-e4` which we should merge into `feat/new-execution` only after we get everything compiling again. 

Review this only after all E1/2/3 tasks are resolved and "E4" becomes a blocker.

This PR introduces the traits necessary to unify E3 and what we were formerly calling E4 into a single E3 generic over a new concept of `RecordArena`. Basically `RecordArena` is a virtual allocator for records, which is backed by either the `RowMajorMatrix` itself or a more compact raw byte buffer (the latter is for hardware acceleration purposes).

As discussed offline, the `NewVmChipWrapper` struct no longer makes sense and we should move `RecordArena` parts into `CTX`. For now I made do by making some traits specific to RowMajorMatrix-backed arenas -- these can be changed later as needed.

I included one example of `Rv32BaseAlu` all compiled and working. Unfortunately everything else no longer compiles.

My thinking is we can merge this first and then @arayikhalatyan can speed-run the switching of most of the traits to get everything compiling again, and then we can re-run tests to make everything still works. (The alternative to get things to compile incrementally seems more painful?)

closes INT-3969