### PR TITLE
fix: misaligned accesses to sha256

### DIFF
--- a/crates/toolchain/platform/src/aligned_buf.rs
+++ b/crates/toolchain/platform/src/aligned_buf.rs
@@ -1,0 +1,65 @@
+extern crate alloc;
+use {core::mem::MaybeUninit};
+
+use alloc::alloc::{alloc, dealloc, handle_alloc_error, Layout};
+use core::ptr::NonNull;
+
+// Register, Memory, and IO address spaces require 4-byte alignment
+pub const MIN_ALIGN: usize = 4;
+
+/// Bytes aligned to 4 bytes.
+pub struct AlignedBuf {
+    pub ptr: *mut u8,
+    pub layout: Layout,
+}
+
+impl AlignedBuf {
+    /// Allocate a new buffer whose start address is aligned to 4 bytes.
+    pub fn uninit(len: usize) -> Self {
+        let layout = Layout::from_size_align(len, MIN_ALIGN).unwrap();
+        if layout.size() == 0 {
+            return Self {
+                ptr: NonNull::<u32>::dangling().as_ptr() as *mut u8,
+                layout,
+            };
+        }
+        // SAFETY: `len` is nonzero
+        let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            handle_alloc_error(layout);
+        }
+        AlignedBuf { ptr, layout }
+    }
+
+    /// Allocate a new buffer whose start address is aligned to 4 bytes
+    /// and copy the given data into it.
+    ///
+    /// # Safety
+    /// - `bytes` must not be null
+    /// - `len` should not be zero
+    ///
+    /// See [alloc]. In particular `data` should not be empty.
+    pub unsafe fn new(bytes: *const u8, len: usize) -> Self {
+        let buf = Self::uninit(len);
+        // SAFETY:
+        // - src and dst are not null
+        // - src and dst are allocated for size
+        // - no alignment requirements on u8
+        // - non-overlapping since ptr is newly allocated
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes, buf.ptr, len);
+        }
+
+        buf
+    }
+}
+
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        if self.layout.size() != 0 {
+            unsafe {
+                dealloc(self.ptr, self.layout);
+            }
+        }
+    }
+}

--- a/crates/toolchain/platform/src/lib.rs
+++ b/crates/toolchain/platform/src/lib.rs
@@ -13,7 +13,7 @@ pub mod heap;
 #[cfg(all(feature = "export-libm", target_os = "zkvm"))]
 mod libm_extern;
 #[cfg(target_os = "zkvm")]
-pub mod aligned_buf;
+pub mod alloc;
 
 pub mod memory;
 pub mod print;

--- a/crates/toolchain/platform/src/lib.rs
+++ b/crates/toolchain/platform/src/lib.rs
@@ -12,6 +12,9 @@ mod getrandom;
 pub mod heap;
 #[cfg(all(feature = "export-libm", target_os = "zkvm"))]
 mod libm_extern;
+#[cfg(target_os = "zkvm")]
+pub mod aligned_buf;
+
 pub mod memory;
 pub mod print;
 #[cfg(feature = "rust-runtime")]

--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -127,9 +127,9 @@ impl<F: PrimeField32> StepExecutorE1<F> for KeccakVmStep {
 
     fn execute_metered(
         &mut self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
-        instruction: &Instruction<F>,
-        chip_index: usize,
+        _state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        _instruction: &Instruction<F>,
+        _chip_index: usize,
     ) -> Result<()> {
         todo!()
     }

--- a/extensions/keccak256/guest/src/lib.rs
+++ b/extensions/keccak256/guest/src/lib.rs
@@ -3,10 +3,7 @@
 #[cfg(target_os = "zkvm")]
 extern crate alloc;
 #[cfg(target_os = "zkvm")]
-use {
-    core::mem::MaybeUninit,
-    openvm_platform::aligned_buf::{AlignedBuf, MIN_ALIGN},
-};
+use {core::mem::MaybeUninit, openvm_platform::alloc::AlignedBuf};
 
 /// This is custom-0 defined in RISC-V spec document
 pub const OPCODE: u8 = 0x0b;
@@ -30,6 +27,47 @@ pub fn keccak256(input: &[u8]) -> [u8; 32] {
     }
 }
 
+/// Native hook for keccak256 for use with `alloy-primitives` "native-keccak" feature.
+///
+/// # Safety
+///
+/// The VM accepts the preimage by pointer and length, and writes the
+/// 32-byte hash.
+/// - `bytes` must point to an input buffer at least `len` long.
+/// - `output` must point to a buffer that is at least 32-bytes long.
+///
+/// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
+/// [`sha3`]: https://docs.rs/sha3/latest/sha3/
+/// [`tiny_keccak`]: https://docs.rs/tiny-keccak/latest/tiny_keccak/
+#[cfg(target_os = "zkvm")]
+#[inline(always)]
+#[no_mangle]
+extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8) {
+    // SAFETY: assuming safety assumptions of the inputs, we handle all cases where `bytes` or
+    // `output` are not aligned to 4 bytes.
+    const MIN_ALIGN: usize = 4;
+    unsafe {
+        if bytes as usize % MIN_ALIGN != 0 {
+            let aligned_buff = AlignedBuf::new(bytes, len, MIN_ALIGN);
+            if output as usize % MIN_ALIGN != 0 {
+                let aligned_out = AlignedBuf::uninit(32, MIN_ALIGN);
+                __native_keccak256(aligned_buff.ptr, len, aligned_out.ptr);
+                core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
+            } else {
+                __native_keccak256(aligned_buff.ptr, len, output);
+            }
+        } else {
+            if output as usize % MIN_ALIGN != 0 {
+                let aligned_out = AlignedBuf::uninit(32, MIN_ALIGN);
+                __native_keccak256(bytes, len, aligned_out.ptr);
+                core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
+            } else {
+                __native_keccak256(bytes, len, output);
+            }
+        };
+    }
+}
+
 /// keccak256 intrinsic binding
 ///
 /// # Safety
@@ -50,46 +88,6 @@ fn __native_keccak256(bytes: *const u8, len: usize, output: *mut u8) {
         rs1 = In bytes,
         rs2 = In len
     );
-}
-
-/// Native hook for keccak256 for use with `alloy-primitives` "native-keccak" feature.
-///
-/// # Safety
-///
-/// The VM accepts the preimage by pointer and length, and writes the
-/// 32-byte hash.
-/// - `bytes` must point to an input buffer at least `len` long.
-/// - `output` must point to a buffer that is at least 32-bytes long.
-///
-/// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
-/// [`sha3`]: https://docs.rs/sha3/latest/sha3/
-/// [`tiny_keccak`]: https://docs.rs/tiny-keccak/latest/tiny_keccak/
-#[cfg(target_os = "zkvm")]
-#[inline(always)]
-#[no_mangle]
-extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8) {
-    // SAFETY: assuming safety assumptions of the inputs, we handle all cases where `bytes` or
-    // `output` are not aligned to 4 bytes.
-    unsafe {
-        if bytes as usize % MIN_ALIGN != 0 {
-            let aligned_buff = AlignedBuf::new(bytes, len);
-            if output as usize % MIN_ALIGN != 0 {
-                let aligned_out = AlignedBuf::uninit(32);
-                __native_keccak256(aligned_buff.ptr, len, aligned_out.ptr);
-                core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
-            } else {
-                __native_keccak256(aligned_buff.ptr, len, output);
-            }
-        } else {
-            if output as usize % MIN_ALIGN != 0 {
-                let aligned_out = AlignedBuf::uninit(32);
-                __native_keccak256(bytes, len, aligned_out.ptr);
-                core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
-            } else {
-                __native_keccak256(bytes, len, output);
-            }
-        };
-    }
 }
 
 /// Sets `output` to the keccak256 hash of `input`.

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -2,7 +2,9 @@
 //! variable length inputs read from VM memory.
 
 use openvm_circuit::{
-    arch::{NewVmChipWrapper, Result, StepExecutorE1, VmStateMut},
+    arch::{
+        execution_mode::metered::MeteredCtx, NewVmChipWrapper, Result, StepExecutorE1, VmStateMut,
+    },
     system::memory::online::GuestMemory,
 };
 use openvm_circuit_primitives::{
@@ -70,7 +72,7 @@ impl Sha256VmStep {
 impl<F: PrimeField32> StepExecutorE1<F> for Sha256VmStep {
     fn execute_e1<Ctx>(
         &mut self,
-        state: VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()> {
         let &Instruction {
@@ -103,6 +105,15 @@ impl<F: PrimeField32> StepExecutorE1<F> for Sha256VmStep {
 
         memory_write(state.memory, e, dst, hasher.finalize().as_ref());
         Ok(())
+    }
+
+    fn execute_metered(
+        &mut self,
+        _state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        _instruction: &Instruction<F>,
+        _chip_index: usize,
+    ) -> Result<()> {
+        todo!()
     }
 }
 

--- a/extensions/sha256/guest/src/lib.rs
+++ b/extensions/sha256/guest/src/lib.rs
@@ -1,5 +1,10 @@
 #![no_std]
 
+#[cfg(target_os = "zkvm")]
+extern crate alloc;
+#[cfg(target_os = "zkvm")]
+use {core::mem::MaybeUninit, openvm_platform::aligned_buf::{AlignedBuf, MIN_ALIGN}};
+
 /// This is custom-0 defined in RISC-V spec document
 pub const OPCODE: u8 = 0x0b;
 pub const SHA256_FUNCT3: u8 = 0b100;
@@ -8,12 +13,37 @@ pub const SHA256_FUNCT7: u8 = 0x1;
 /// The sha256 cryptographic hash function.
 #[inline(always)]
 pub fn sha256(input: &[u8]) -> [u8; 32] {
-    let mut output = [0u8; 32];
-    set_sha256(input, &mut output);
-    output
+    #[cfg(not(target_os = "zkvm"))]
+    {
+        let mut output = [0u8; 32];
+        set_sha256(input, &mut output);
+        output
+    }
+    #[cfg(target_os = "zkvm")]
+    {
+        let mut output = MaybeUninit::<[u8; 32]>::uninit();
+        zkvm_sha256_impl(input.as_ptr(), input.len(), output.as_mut_ptr() as *mut u8);
+        unsafe { output.assume_init() }
+    }
 }
 
-/// zkvm native implementation of sha256
+/// sha256 intrinsic binding
+///
+/// # Safety
+///
+/// The VM accepts the preimage by pointer and length, and writes the
+/// 32-byte hash.
+/// - `bytes` must point to an input buffer at least `len` long.
+/// - `output` must point to a buffer that is at least 32-bytes long.
+/// - `bytes` and `output` must be 4-byte aligned.
+#[cfg(target_os = "zkvm")]
+#[inline(always)]
+fn __native_sha256(bytes: *const u8, len: usize, output: *mut u8) {
+    openvm_platform::custom_insn_r!(opcode = OPCODE, funct3 = SHA256_FUNCT3, funct7 = SHA256_FUNCT7, rd = In output, rs1 = In bytes, rs2 = In len);
+}
+
+/// Native hook for sha256
+///
 /// # Safety
 ///
 /// The VM accepts the preimage by pointer and length, and writes the
@@ -21,12 +51,33 @@ pub fn sha256(input: &[u8]) -> [u8; 32] {
 /// - `bytes` must point to an input buffer at least `len` long.
 /// - `output` must point to a buffer that is at least 32-bytes long.
 ///
-/// [`sha2-256`]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+/// [`sha2`]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 #[cfg(target_os = "zkvm")]
 #[inline(always)]
 #[no_mangle]
 extern "C" fn zkvm_sha256_impl(bytes: *const u8, len: usize, output: *mut u8) {
-    openvm_platform::custom_insn_r!(opcode = OPCODE, funct3 = SHA256_FUNCT3, funct7 = SHA256_FUNCT7, rd = In output, rs1 = In bytes, rs2 = In len);
+    // SAFETY: assuming safety assumptions of the inputs, we handle all cases where `bytes` or
+    // `output` are not aligned to 4 bytes.
+    unsafe {
+        if bytes as usize % MIN_ALIGN != 0 {
+            let aligned_buff = AlignedBuf::new(bytes, len);
+            if output as usize % MIN_ALIGN != 0 {
+                let aligned_out = AlignedBuf::uninit(32);
+                __native_sha256(aligned_buff.ptr, len, aligned_out.ptr);
+                core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
+            } else {
+                __native_sha256(aligned_buff.ptr, len, output);
+            }
+        } else {
+            if output as usize % MIN_ALIGN != 0 {
+                let aligned_out = AlignedBuf::uninit(32);
+                __native_sha256(bytes, len, aligned_out.ptr);
+                core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
+            } else {
+                __native_sha256(bytes, len, output);
+            }
+        };
+    }
 }
 
 /// Sets `output` to the sha256 hash of `input`.

--- a/extensions/sha256/guest/src/lib.rs
+++ b/extensions/sha256/guest/src/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
 
 #[cfg(target_os = "zkvm")]
-extern crate alloc;
-#[cfg(target_os = "zkvm")]
-use {core::mem::MaybeUninit, openvm_platform::aligned_buf::{AlignedBuf, MIN_ALIGN}};
+use openvm_platform::alloc::AlignedBuf;
 
 /// This is custom-0 defined in RISC-V spec document
 pub const OPCODE: u8 = 0x0b;
@@ -13,33 +11,9 @@ pub const SHA256_FUNCT7: u8 = 0x1;
 /// The sha256 cryptographic hash function.
 #[inline(always)]
 pub fn sha256(input: &[u8]) -> [u8; 32] {
-    #[cfg(not(target_os = "zkvm"))]
-    {
-        let mut output = [0u8; 32];
-        set_sha256(input, &mut output);
-        output
-    }
-    #[cfg(target_os = "zkvm")]
-    {
-        let mut output = MaybeUninit::<[u8; 32]>::uninit();
-        zkvm_sha256_impl(input.as_ptr(), input.len(), output.as_mut_ptr() as *mut u8);
-        unsafe { output.assume_init() }
-    }
-}
-
-/// sha256 intrinsic binding
-///
-/// # Safety
-///
-/// The VM accepts the preimage by pointer and length, and writes the
-/// 32-byte hash.
-/// - `bytes` must point to an input buffer at least `len` long.
-/// - `output` must point to a buffer that is at least 32-bytes long.
-/// - `bytes` and `output` must be 4-byte aligned.
-#[cfg(target_os = "zkvm")]
-#[inline(always)]
-fn __native_sha256(bytes: *const u8, len: usize, output: *mut u8) {
-    openvm_platform::custom_insn_r!(opcode = OPCODE, funct3 = SHA256_FUNCT3, funct7 = SHA256_FUNCT7, rd = In output, rs1 = In bytes, rs2 = In len);
+    let mut output = [0u8; 32];
+    set_sha256(input, &mut output);
+    output
 }
 
 /// Native hook for sha256
@@ -58,11 +32,17 @@ fn __native_sha256(bytes: *const u8, len: usize, output: *mut u8) {
 extern "C" fn zkvm_sha256_impl(bytes: *const u8, len: usize, output: *mut u8) {
     // SAFETY: assuming safety assumptions of the inputs, we handle all cases where `bytes` or
     // `output` are not aligned to 4 bytes.
+    // The minimum alignment required for the input and output buffers
+    const MIN_ALIGN: usize = 4;
+    // The preferred alignment for the input buffer, since the input is read in chunks of 16 bytes
+    const INPUT_ALIGN: usize = 16;
+    // The preferred alignment for the output buffer, since the output is written in chunks of 32 bytes
+    const OUTPUT_ALIGN: usize = 32;
     unsafe {
         if bytes as usize % MIN_ALIGN != 0 {
-            let aligned_buff = AlignedBuf::new(bytes, len);
+            let aligned_buff = AlignedBuf::new(bytes, len, INPUT_ALIGN);
             if output as usize % MIN_ALIGN != 0 {
-                let aligned_out = AlignedBuf::uninit(32);
+                let aligned_out = AlignedBuf::uninit(32, OUTPUT_ALIGN);
                 __native_sha256(aligned_buff.ptr, len, aligned_out.ptr);
                 core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
             } else {
@@ -70,7 +50,7 @@ extern "C" fn zkvm_sha256_impl(bytes: *const u8, len: usize, output: *mut u8) {
             }
         } else {
             if output as usize % MIN_ALIGN != 0 {
-                let aligned_out = AlignedBuf::uninit(32);
+                let aligned_out = AlignedBuf::uninit(32, OUTPUT_ALIGN);
                 __native_sha256(bytes, len, aligned_out.ptr);
                 core::ptr::copy_nonoverlapping(aligned_out.ptr as *const u8, output, 32);
             } else {
@@ -78,6 +58,21 @@ extern "C" fn zkvm_sha256_impl(bytes: *const u8, len: usize, output: *mut u8) {
             }
         };
     }
+}
+
+/// sha256 intrinsic binding
+///
+/// # Safety
+///
+/// The VM accepts the preimage by pointer and length, and writes the
+/// 32-byte hash.
+/// - `bytes` must point to an input buffer at least `len` long.
+/// - `output` must point to a buffer that is at least 32-bytes long.
+/// - `bytes` and `output` must be 4-byte aligned.
+#[cfg(target_os = "zkvm")]
+#[inline(always)]
+fn __native_sha256(bytes: *const u8, len: usize, output: *mut u8) {
+    openvm_platform::custom_insn_r!(opcode = OPCODE, funct3 = SHA256_FUNCT3, funct7 = SHA256_FUNCT7, rd = In output, rs1 = In bytes, rs2 = In len);
 }
 
 /// Sets `output` to the sha256 hash of `input`.


### PR DESCRIPTION
Fixes misaligned accesses to sha256. Moved Aligned_buf to openvm platform so both `sha2` and `keccak` can access it