### PR TITLE
feat: CLI prove use bin name for output path

### DIFF
--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -7,10 +7,10 @@ In this section we will build and run a fibonacci program.
 First, create a new Rust project.
 
 ```bash
-cargo init fibonacci
+cargo openvm init fibonacci
 ```
 
-In `Cargo.toml`, add the following dependency:
+This will generate an OpenVM-specific starter package. Notice `Cargo.toml` has the following dependency:
 
 ```toml
 [dependencies]
@@ -49,7 +49,7 @@ To build the program, run:
 cargo openvm build
 ```
 
-This will output an OpenVM executable file to `./openvm/app.vmexe`.
+This will output an OpenVM executable file to `./target/openvm/release/fibonacci.vmexe`.
 
 ## Keygen
 
@@ -59,7 +59,7 @@ Before generating any proofs, we will also need to generate the proving and veri
 cargo openvm keygen
 ```
 
-This will output a serialized proving key to `./openvm/app.pk` and a verification key to `./openvm/app.vk`.
+This will output a serialized proving key to `./target/openvm/app.pk` and a verification key to `./target/openvm/app.vk`.
 
 ## Proof Generation
 
@@ -72,7 +72,7 @@ OPENVM_FAST_TEST=1 cargo openvm prove app --input "0x010A00000000000000"
 The `--input` field is passed to the program which receives it via the `io::read` function.
 In our `main.rs` we called `read()` to get `n: u64`. The input here is `n = 10u64` _in little endian_. Note that this value must be padded to exactly 8 bytes (64 bits) and is prefixed with `0x01` to indicate that the input is composed of raw bytes.
 
-The serialized proof will be output to `./openvm/app.proof`.
+The serialized proof will be output to `./fibonacci.app.proof`.
 
 The `OPENVM_FAST_TEST` environment variable is used to enable fast proving for testing purposes. To run with proof with secure parameters, remove the environmental variable.
 

--- a/book/src/writing-apps/overview.md
+++ b/book/src/writing-apps/overview.md
@@ -22,7 +22,7 @@ cargo openvm run --input <path_to_input | hex_string>
 
 Note if your program doesn't require inputs, you can omit the `--input` flag.
 
-For more information on both commands, see the [build](./build.md) docs.
+For more information see the [build](./build.md) and [run](./run.md) docs.
 
 ### Inputs
 

--- a/book/src/writing-apps/prove.md
+++ b/book/src/writing-apps/prove.md
@@ -40,8 +40,7 @@ If `--exe` is not provided, the command will call `build` before generating a pr
 
 If your program doesn't require inputs, you can (and should) omit the `--input` flag.
 
-If `--proof` is not provided then the command will write the proof to `./[app | stark | evm].proof` by default.
-
+If `--proof` is not provided then the command will write the proof to `./${bin_name}.[app | stark | evm].proof` by default, where `bin_name` is the file stem of the executable run.
 
 The `app` subcommand generates an application-level proof, the `stark` command generates an aggregated root-level proof, while the `evm` command generates an end-to-end EVM proof. For more information on aggregation, see [this specification](https://github.com/openvm-org/openvm/blob/bf8df90b13f4e80bb76dbb71f255a12154c84838/docs/specs/continuations.md).
 

--- a/book/src/writing-apps/verify.md
+++ b/book/src/writing-apps/verify.md
@@ -10,7 +10,9 @@ cargo openvm verify app
     --proof <path_to_proof>
 ```
 
-Options `--manifest-path`, `--target-dir` are also available to `verify`. If you omit `--app_vk` and/or `--proof`, the command will search for those files at `${target_dir}/openvm/app.vk` and `./app.proof` respectively.
+Options `--manifest-path`, `--target-dir` are also available to `verify`. If you omit `--app_vk` the command will search for the verifying key at `${target_dir}/openvm/app.vk`.
+
+If you omit `--proof`, the command will search the working directory for files with the `.app.proof` extension. Note that for this default case a single proof is expected to be found, and `verify` will fail otherwise.
 
 ## EVM Level
 
@@ -93,11 +95,11 @@ cargo openvm prove evm --input <path_to_input>
 cargo openvm verify evm --proof <path_to_proof>
 ```
 
-If `proof` is omitted, the `verify` command will search for the proof at `./openvm/evm.proof`.
+If `proof` is omitted, the `verify` command will search for a file with extension `.evm.proof` in the working directory.
 
 ### EVM Proof: JSON Format
 
-The EVM proof is written to `evm.proof` as a JSON of the following format:
+The EVM proof is written as a JSON of the following format:
 
 ```json
 {

--- a/book/src/writing-apps/write-program.md
+++ b/book/src/writing-apps/write-program.md
@@ -2,16 +2,17 @@
 
 ## Writing a guest program
 
-See the example [fibonacci program](https://github.com/openvm-org/openvm-example-fibonacci).
+To initialize an OpenVM guest program package, you can use the following CLI command:
 
-The guest program should be a `no_std` Rust crate. As long as it is `no_std`, you can import any other
-`no_std` crates and write Rust as you normally would. Import the `openvm` library crate to use `openvm` intrinsic functions (for example `openvm::io::*`).
+```bash
+cargo openvm init
+```
 
-More examples of guest programs can be found in the [benchmarks/guest](https://github.com/openvm-org/openvm/tree/main/benchmarks/guest) directory.
+For a guest program example, see this [fibonacci program](https://github.com/openvm-org/openvm-example-fibonacci). More examples can be found in the [benchmarks/guest](https://github.com/openvm-org/openvm/tree/main/benchmarks/guest) directory.
 
 ## Handling I/O
 
-The program can take input from stdin, with some functions provided by `openvm::io`.
+The program can take input from stdin, with some functions provided by `openvm::io`. Make sure to import the `openvm` library crate to use `openvm` intrinsic functions.
 
 `openvm::io::read` takes from stdin and deserializes it into a generic type `T`, so one should specify the type when calling it:
 

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -11,9 +11,7 @@ use openvm_sdk::{commit::AppExecutionCommit, fs::write_to_file_json, Sdk};
 use super::{RunArgs, RunCargoArgs};
 use crate::{
     commands::{load_app_pk, load_or_build_and_commit_exe},
-    util::{
-        get_manifest_path_and_dir, get_single_target_name, get_target_dir, get_target_output_dir,
-    },
+    util::{get_manifest_path_and_dir, get_target_dir, get_target_output_dir},
 };
 
 #[derive(Parser)]
@@ -76,7 +74,7 @@ impl CommitCmd {
             init_file_name: self.init_file_name.clone(),
             input: None,
         };
-        let committed_exe =
+        let (committed_exe, target_name) =
             load_or_build_and_commit_exe(&sdk, &run_args, &self.cargo_args, &app_pk)?;
 
         let commits = AppExecutionCommit::compute(
@@ -91,7 +89,6 @@ impl CommitCmd {
         let (manifest_path, _) = get_manifest_path_and_dir(&self.cargo_args.manifest_path)?;
         let target_dir = get_target_dir(&self.cargo_args.target_dir, &manifest_path);
         let target_output_dir = get_target_output_dir(&target_dir, &self.cargo_args.profile);
-        let target_name = get_single_target_name(&self.cargo_args)?;
 
         let commit_name = format!("{}.commit.json", &target_name);
         let commit_path = target_output_dir.join(&commit_name);

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -113,10 +113,10 @@ impl InitCmd {
             .path
             .clone()
             .unwrap_or(PathBuf::from(".").canonicalize()?);
+        args.push(path.to_str().unwrap());
 
         let mut cmd = Command::new("cargo");
         cmd.args(&args);
-        cmd.current_dir(&path);
 
         let status = cmd.status()?;
         if !status.success() {

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -38,11 +38,10 @@ enum ProveSubCommand {
         #[arg(
             long,
             action,
-            default_value = DEFAULT_APP_PROOF_PATH,
-            help = "Path to app proof output",
+            help = "Path to app proof output, by default will be ./${bin_name}.app.proof",
             help_heading = "Output"
         )]
-        proof: PathBuf,
+        proof: Option<PathBuf>,
 
         #[arg(
             long,
@@ -62,11 +61,10 @@ enum ProveSubCommand {
         #[arg(
             long,
             action,
-            default_value = DEFAULT_STARK_PROOF_PATH,
-            help = "Path to STARK proof output",
+            help = "Path to STARK proof output, by default will be ./${bin_name}.stark.proof",
             help_heading = "Output"
         )]
-        proof: PathBuf,
+        proof: Option<PathBuf>,
 
         #[arg(
             long,
@@ -90,11 +88,10 @@ enum ProveSubCommand {
         #[arg(
             long,
             action,
-            default_value = DEFAULT_EVM_PROOF_PATH,
-            help = "Path to EVM proof output",
+            help = "Path to EVM proof output, by default will be ./${bin_name}.evm.proof",
             help_heading = "Output"
         )]
-        proof: PathBuf,
+        proof: Option<PathBuf>,
 
         #[arg(
             long,
@@ -126,12 +123,18 @@ impl ProveCmd {
             } => {
                 let sdk = Sdk::new();
                 let app_pk = load_app_pk(app_pk, cargo_args)?;
-                let committed_exe =
+                let (committed_exe, target_name) =
                     load_or_build_and_commit_exe(&sdk, run_args, cargo_args, &app_pk)?;
 
                 let app_proof =
                     sdk.generate_app_proof(app_pk, committed_exe, read_to_stdin(&run_args.input)?)?;
-                write_app_proof_to_file(app_proof, proof)?;
+
+                let proof_path = if let Some(proof) = proof {
+                    proof
+                } else {
+                    &PathBuf::from(format!("{}.app.proof", target_name))
+                };
+                write_app_proof_to_file(app_proof, proof_path)?;
             }
             ProveSubCommand::Stark {
                 app_pk,
@@ -142,7 +145,7 @@ impl ProveCmd {
             } => {
                 let sdk = Sdk::new().with_agg_tree_config(*agg_tree_config);
                 let app_pk = load_app_pk(app_pk, cargo_args)?;
-                let committed_exe =
+                let (committed_exe, target_name) =
                     load_or_build_and_commit_exe(&sdk, run_args, cargo_args, &app_pk)?;
 
                 let commits = AppExecutionCommit::compute(
@@ -163,7 +166,12 @@ impl ProveCmd {
                     read_to_stdin(&run_args.input)?,
                 )?;
 
-                encode_to_file(proof, stark_proof)?;
+                let proof_path = if let Some(proof) = proof {
+                    proof
+                } else {
+                    &PathBuf::from(format!("{}.stark.proof", target_name))
+                };
+                encode_to_file(proof_path, stark_proof)?;
             }
             #[cfg(feature = "evm-prove")]
             ProveSubCommand::Evm {
@@ -177,7 +185,7 @@ impl ProveCmd {
 
                 let sdk = Sdk::new().with_agg_tree_config(*agg_tree_config);
                 let app_pk = load_app_pk(app_pk, cargo_args)?;
-                let committed_exe =
+                let (committed_exe, target_name) =
                     load_or_build_and_commit_exe(&sdk, run_args, cargo_args, &app_pk)?;
 
                 let commits = AppExecutionCommit::compute(
@@ -201,7 +209,12 @@ impl ProveCmd {
                     read_to_stdin(&run_args.input)?,
                 )?;
 
-                write_evm_proof_to_file(evm_proof, proof)?;
+                let proof_path = if let Some(proof) = proof {
+                    proof
+                } else {
+                    &PathBuf::from(format!("{}.evm.proof", target_name))
+                };
+                write_evm_proof_to_file(evm_proof, proof_path)?;
             }
         }
         Ok(())
@@ -224,12 +237,13 @@ pub(crate) fn load_app_pk(
     Ok(Arc::new(read_app_pk_from_file(app_pk_path)?))
 }
 
+// Returns (committed_exe, target_name) where target_name has no extension
 pub(crate) fn load_or_build_and_commit_exe(
     sdk: &Sdk,
     run_args: &RunArgs,
     cargo_args: &RunCargoArgs,
     app_pk: &Arc<AppProvingKey<SdkVmConfig>>,
-) -> Result<Arc<NonRootCommittedExe>> {
+) -> Result<(Arc<NonRootCommittedExe>, String)> {
     let exe_path = if let Some(exe) = &run_args.exe {
         exe
     } else {
@@ -243,5 +257,8 @@ pub(crate) fn load_or_build_and_commit_exe(
 
     let app_exe = read_exe_from_file(exe_path)?;
     let committed_exe = sdk.commit_app_exe(app_pk.app_fri_params(), app_exe)?;
-    Ok(committed_exe)
+    Ok((
+        committed_exe,
+        exe_path.file_stem().unwrap().to_str().unwrap().to_string(),
+    ))
 }

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -78,6 +78,8 @@ impl VerifyCmd {
                     let files = get_files_with_ext(Path::new("."), "app.proof")?;
                     if files.len() > 1 {
                         return Err(eyre::eyre!("multiple .app.proof files found, please specify the path using option --proof"));
+                    } else if files.len() == 0 {
+                        return Err(eyre::eyre!("no .app.proof file found, please specify the path using option --proof"));
                     }
                     files[0].clone()
                 };
@@ -105,6 +107,8 @@ impl VerifyCmd {
                     let files = get_files_with_ext(Path::new("."), "evm.proof")?;
                     if files.len() > 1 {
                         return Err(eyre::eyre!("multiple .evm.proof files found, please specify the path using option --proof"));
+                    } else if files.len() == 0 {
+                        return Err(eyre::eyre!("no .evm.proof file found, please specify the path using option --proof"));
                     }
                     files[0].clone()
                 };

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -8,10 +8,6 @@ pub const DEFAULT_MANIFEST_DIR: &str = ".";
 pub const DEFAULT_APP_PK_NAME: &str = "app.pk";
 pub const DEFAULT_APP_VK_NAME: &str = "app.vk";
 
-pub const DEFAULT_APP_PROOF_PATH: &str = "./app.proof";
-pub const DEFAULT_STARK_PROOF_PATH: &str = "./stark.proof";
-pub const DEFAULT_EVM_PROOF_PATH: &str = "./evm.proof";
-
 pub fn default_agg_stark_pk_path() -> String {
     env::var("HOME").unwrap() + "/.openvm/agg_stark.pk"
 }

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::read_to_string,
+    fs::{read_dir, read_to_string},
     path::{Path, PathBuf},
 };
 
@@ -144,4 +144,20 @@ pub fn get_single_target_name(cargo_args: &RunCargoArgs) -> Result<String> {
         cargo_args.bin[0].clone()
     };
     Ok(single_target_name)
+}
+
+pub fn get_files_with_ext(dir: &Path, extension: &str) -> Result<Vec<PathBuf>> {
+    let dir = dir.canonicalize()?;
+    let mut files = Vec::new();
+    for entry in read_dir(dir)? {
+        let path = entry?.path();
+        if path.is_file()
+            && path
+                .to_str()
+                .is_some_and(|path_str| path_str.ends_with(extension))
+        {
+            files.push(path);
+        }
+    }
+    Ok(files)
 }

--- a/crates/cli/tests/app_e2e.rs
+++ b/crates/cli/tests/app_e2e.rs
@@ -10,7 +10,7 @@ fn test_cli_app_e2e() -> Result<()> {
     let exe_path = "tests/programs/fibonacci/target/openvm/release/openvm-cli-example-test.vmexe";
     let temp_pk = temp_dir.path().join("app.pk");
     let temp_vk = temp_dir.path().join("app.vk");
-    let temp_proof = temp_dir.path().join("fibonacci.apppf");
+    let temp_proof = temp_dir.path().join("fibonacci.app.proof");
 
     run_cmd(
         "cargo",


### PR DESCRIPTION
Resolves INT-4074. Primarily accomplishes the following:

- `cargo openvm prove` outputs proofs to `${bin_name}.app.proof` instead of `app.proof`, where `bin_name` is the file stem of the executable (same for `stark` and `evm`)
- `cargo openvm verify` by default searches the working directory for files with extension `.app.proof`

Additionally, the following are also in this PR:

- `cargo openvm init ${dir}` creates directory `dir` if it doesn't already exist
- Updates to the book to reflect recent CLI changes