### PR TITLE
fix(new-execution): diff inv marker in native branch eq chip

### DIFF
--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -57,8 +57,10 @@ where
         } = self.final_state.unwrap();
         // important that this sort be stable,
         // because we need the initial root to be first and the final root to be second
-        rows.reverse();
-        rows.swap(0, 1);
+        if rows.len() > 1 {
+            rows.reverse();
+            rows.swap(0, 1);
+        }
 
         let width = MemoryMerkleCols::<Val<SC>, CHUNK>::width();
         let mut height = rows.len().next_power_of_two();

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -57,8 +57,8 @@ where
         } = self.final_state.unwrap();
         // important that this sort be stable,
         // because we need the initial root to be first and the final root to be second
+        rows.reverse();
         if rows.len() > 1 {
-            rows.reverse();
             rows.swap(0, 1);
         }
 

--- a/crates/vm/src/system/poseidon2/trace.rs
+++ b/crates/vm/src/system/poseidon2/trace.rs
@@ -23,7 +23,7 @@ where
     }
 
     fn generate_air_proof_input(self) -> AirProofInput<SC> {
-        let height = next_power_of_two_or_zero(self.current_trace_height());
+        let height = self.current_trace_height().next_power_of_two();
         let width = self.trace_width();
 
         let mut inputs = Vec::with_capacity(height);

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -591,7 +591,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize, CTX> TraceStep<F, CTX>
             unreachable!()
         }
 
-        *state.pc += DEFAULT_PC_STEP;
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
         Ok(())
     }
 
@@ -975,7 +975,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SBOX_R
         } else {
             unreachable!()
         }
-        *state.pc += DEFAULT_PC_STEP;
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         height
     }


### PR DESCRIPTION
- fixes calculation of `diff_idx` and `diff_inv_val` in `NativeBranchEqualStep`

This was introduced when I copied over the logic from `BranchEqualStep` to create `NativeBranchEqualStep`