### PR TITLE
feat: make base_alu tests pass and make register address u8

### DIFF
--- a/crates/toolchain/instructions/src/riscv.rs
+++ b/crates/toolchain/instructions/src/riscv.rs
@@ -1,6 +1,7 @@
 /// 32-bit register stored as 4 bytes (4 limbs of 8-bits) in OpenVM memory.
 pub const RV32_REGISTER_NUM_LIMBS: usize = 4;
 pub const RV32_CELL_BITS: usize = 8;
+pub const RV32_MAX_REGISTER_ADDRESS: usize = u8::MAX as usize;
 
 pub const RV32_IMM_AS: u32 = 0;
 pub const RV32_REGISTER_AS: u32 = 1;

--- a/crates/toolchain/instructions/src/riscv.rs
+++ b/crates/toolchain/instructions/src/riscv.rs
@@ -1,8 +1,8 @@
 /// 32-bit register stored as 4 bytes (4 limbs of 8-bits) in OpenVM memory.
 pub const RV32_REGISTER_NUM_LIMBS: usize = 4;
 pub const RV32_CELL_BITS: usize = 8;
-pub const RV32_MAX_REGISTER_ADDRESS: usize = u8::MAX as usize;
 
+pub const RV32_MAX_REGISTER_ADDRESS: u32 = u8::MAX as u32;
 pub const RV32_IMM_AS: u32 = 0;
 pub const RV32_REGISTER_AS: u32 = 1;
 pub const RV32_MEMORY_AS: u32 = 2;

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use air::{MemoryDummyAir, MemoryDummyChip};
 use openvm_circuit::system::memory::MemoryController;
+use openvm_instructions::riscv::RV32_MAX_REGISTER_ADDRESS;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::Rng;
 
@@ -106,4 +107,18 @@ where
 {
     const MAX_MEMORY: usize = 1 << 29;
     rng.gen_range(0..MAX_MEMORY - len) / len * len
+}
+
+/// Generates a register address that is not equal to [other] if provided.
+pub fn gen_register_address<R>(rng: &mut R, other: Option<usize>) -> usize
+where
+    R: Rng + ?Sized,
+{
+    let mut addr = rng.gen_range(0..RV32_MAX_REGISTER_ADDRESS >> 2) << 2;
+    if let Some(other) = other {
+        while addr == other {
+            addr = rng.gen_range(0..RV32_MAX_REGISTER_ADDRESS >> 2) << 2;
+        }
+    }
+    addr
 }

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -116,9 +116,9 @@ where
 {
     let mut addr = rng.gen_range(0..RV32_MAX_REGISTER_ADDRESS >> 2) << 2;
     if let Some(other) = other {
-        while addr == other {
+        while addr == other as u32 {
             addr = rng.gen_range(0..RV32_MAX_REGISTER_ADDRESS >> 2) << 2;
         }
     }
-    addr
+    addr as usize
 }

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -314,7 +314,7 @@ impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceFiller<F>
                     adapter_row.reads_aux[1].as_mut(),
                 );
             } else {
-                let rs2_imm = adapter_row.rs2.as_canonical_u32();
+                let rs2_imm = record.rs2;
                 let mask = (1 << RV32_CELL_BITS) - 1;
                 self.bitwise_lookup_chip
                     .request_range(rs2_imm & mask, (rs2_imm >> 8) & mask);

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -12,19 +12,19 @@ use openvm_instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS};
 use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 
 mod alu;
-mod branch;
-mod jalr;
-mod loadstore;
-mod mul;
-mod rdwrite;
+// mod branch;
+// mod jalr;
+// mod loadstore;
+// mod mul;
+// mod rdwrite;
 
 pub use alu::*;
-pub use branch::*;
-pub use jalr::*;
-pub use loadstore::*;
-pub use mul::*;
+// pub use branch::*;
+// pub use jalr::*;
+// pub use loadstore::*;
+// pub use mul::*;
 pub use openvm_instructions::riscv::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-pub use rdwrite::*;
+// pub use rdwrite::*;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// 256-bit heap integer stored as 32 bytes (32 limbs of 8-bits)

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -90,7 +90,7 @@ fn set_and_execute(
         )
     };
 
-    let (instruction, rd) = rv32_rand_write_register_or_imm(
+let (instruction, rd) = rv32_rand_write_register_or_imm(
         tester,
         b,
         c,

--- a/extensions/rv32im/circuit/src/lib.rs
+++ b/extensions/rv32im/circuit/src/lib.rs
@@ -1,37 +1,37 @@
 pub mod adapters;
 
-mod auipc;
+// mod auipc;
 mod base_alu;
-mod branch_eq;
-mod branch_lt;
-mod divrem;
-mod hintstore;
-mod jal_lui;
-mod jalr;
-mod less_than;
-mod load_sign_extend;
-mod loadstore;
-mod mul;
-mod mulh;
-mod shift;
+// mod branch_eq;
+// mod branch_lt;
+// mod divrem;
+// mod hintstore;
+// mod jal_lui;
+// mod jalr;
+// mod less_than;
+// mod load_sign_extend;
+// mod loadstore;
+// mod mul;
+// mod mulh;
+// mod shift;
 
-pub use auipc::*;
+// pub use auipc::*;
 pub use base_alu::*;
-pub use branch_eq::*;
-pub use branch_lt::*;
-pub use divrem::*;
-pub use hintstore::*;
-pub use jal_lui::*;
-pub use jalr::*;
-pub use less_than::*;
-pub use load_sign_extend::*;
-pub use loadstore::*;
-pub use mul::*;
-pub use mulh::*;
-pub use shift::*;
+// pub use branch_eq::*;
+// pub use branch_lt::*;
+// pub use divrem::*;
+// pub use hintstore::*;
+// pub use jal_lui::*;
+// pub use jalr::*;
+// pub use less_than::*;
+// pub use load_sign_extend::*;
+// pub use loadstore::*;
+// pub use mul::*;
+// pub use mulh::*;
+// pub use shift::*;
 
-mod extension;
-pub use extension::*;
+// mod extension;
+// pub use extension::*;
 
 #[cfg(any(test, feature = "test-utils"))]
 mod test_utils;

--- a/extensions/rv32im/circuit/src/test_utils.rs
+++ b/extensions/rv32im/circuit/src/test_utils.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::testing::{memory::gen_pointer, VmChipTestBuilder};
+use openvm_circuit::arch::testing::{memory::gen_register_address, VmChipTestBuilder};
 use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_stark_backend::{p3_field::FieldAlgebra, verifier::VerificationError};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
@@ -18,9 +18,9 @@ pub fn rv32_rand_write_register_or_imm<const NUM_LIMBS: usize>(
 ) -> (Instruction<BabyBear>, usize) {
     let rs2_is_imm = imm.is_some();
 
-    let rs1 = gen_pointer(rng, NUM_LIMBS);
-    let rs2 = imm.unwrap_or_else(|| gen_pointer(rng, NUM_LIMBS));
-    let rd = gen_pointer(rng, NUM_LIMBS);
+    let rs1 = gen_register_address(rng, None);
+    let rs2 = imm.unwrap_or_else(|| gen_register_address(rng, Some(rs1)));
+    let rd = gen_register_address(rng, None);
 
     tester.write::<NUM_LIMBS>(1, rs1, rs1_writes.map(BabyBear::from_canonical_u8));
     if !rs2_is_imm {


### PR DESCRIPTION
This PR makes the `base_alu` unit tests run so we have a working example with the new `e4` traits. As discussed with @jonathanpwang we can set the register addresses to be in `0..255` so we can keep them in `u8` to save space

The main PR for porting the chips is [here](https://github.com/openvm-org/openvm/pull/1692)