### PR TITLE
feat: ensure all CLI commit outputs are in hex + fix verify STARK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,6 +4830,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "metrics",
+ "num-bigint 0.4.6",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -82,9 +82,9 @@ impl CommitCmd {
             &committed_exe,
             &app_pk.leaf_committed_exe,
         )
-        .to_bn254_commit();
-        println!("exe commit: {:?}", commits.exe_commit);
-        println!("vm commit: {:?}", commits.vm_commit);
+        .to_bytes();
+        println!("exe commit: {:?}", commits.exe_commit_to_bn254());
+        println!("vm commit: {:?}", commits.vm_commit_to_bn254());
 
         let (manifest_path, _) = get_manifest_path_and_dir(&self.cargo_args.manifest_path)?;
         let target_dir = get_target_dir(&self.cargo_args.target_dir, &manifest_path);

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -81,10 +81,9 @@ impl CommitCmd {
             &app_pk.app_vm_pk.vm_config,
             &committed_exe,
             &app_pk.leaf_committed_exe,
-        )
-        .to_bytes();
-        println!("exe commit: {:?}", commits.exe_commit_to_bn254());
-        println!("vm commit: {:?}", commits.vm_commit_to_bn254());
+        );
+        println!("exe commit: {:?}", commits.app_exe_commit.to_bn254());
+        println!("vm commit: {:?}", commits.app_vm_commit.to_bn254());
 
         let (manifest_path, _) = get_manifest_path_and_dir(&self.cargo_args.manifest_path)?;
         let target_dir = get_target_dir(&self.cargo_args.target_dir, &manifest_path);

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -153,10 +153,9 @@ impl ProveCmd {
                     &app_pk.app_vm_pk.vm_config,
                     &committed_exe,
                     &app_pk.leaf_committed_exe,
-                )
-                .to_bytes();
-                println!("exe commit: {:?}", commits.exe_commit_to_bn254());
-                println!("vm commit: {:?}", commits.vm_commit_to_bn254());
+                );
+                println!("exe commit: {:?}", commits.app_exe_commit.to_bn254());
+                println!("vm commit: {:?}", commits.app_vm_commit.to_bn254());
 
                 let agg_stark_pk = read_agg_stark_pk_from_file(default_agg_stark_pk_path()).map_err(|e| {
                     eyre::eyre!("Failed to read aggregation proving key: {}\nPlease run 'cargo openvm setup' first", e)
@@ -197,8 +196,8 @@ impl ProveCmd {
                     &committed_exe,
                     &app_pk.leaf_committed_exe,
                 );
-                println!("exe commit: {:?}", commits.exe_commit_to_bn254());
-                println!("vm commit: {:?}", commits.vm_commit_to_bn254());
+                println!("exe commit: {:?}", commits.app_exe_commit.to_bn254());
+                println!("vm commit: {:?}", commits.app_vm_commit.to_bn254());
 
                 println!("Generating EVM proof, this may take a lot of compute and memory...");
                 let agg_pk = read_default_agg_pk().map_err(|e| {

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -8,10 +8,11 @@ use openvm_sdk::{
     commit::AppExecutionCommit,
     config::{AggregationTreeConfig, SdkVmConfig},
     fs::{
-        encode_to_file, read_agg_stark_pk_from_file, read_app_pk_from_file, read_exe_from_file,
-        write_app_proof_to_file,
+        read_agg_stark_pk_from_file, read_app_pk_from_file, read_exe_from_file,
+        write_app_proof_to_file, write_to_file_json,
     },
     keygen::AppProvingKey,
+    types::VmStarkProofBytes,
     NonRootCommittedExe, Sdk,
 };
 
@@ -152,9 +153,10 @@ impl ProveCmd {
                     &app_pk.app_vm_pk.vm_config,
                     &committed_exe,
                     &app_pk.leaf_committed_exe,
-                );
-                println!("exe commit: {:?}", commits.exe_commit);
-                println!("vm commit: {:?}", commits.vm_commit);
+                )
+                .to_bytes();
+                println!("exe commit: {:?}", commits.exe_commit_to_bn254());
+                println!("vm commit: {:?}", commits.vm_commit_to_bn254());
 
                 let agg_stark_pk = read_agg_stark_pk_from_file(default_agg_stark_pk_path()).map_err(|e| {
                     eyre::eyre!("Failed to read aggregation proving key: {}\nPlease run 'cargo openvm setup' first", e)
@@ -166,12 +168,14 @@ impl ProveCmd {
                     read_to_stdin(&run_args.input)?,
                 )?;
 
+                let stark_proof_bytes = VmStarkProofBytes::new(commits, stark_proof)?;
+
                 let proof_path = if let Some(proof) = proof {
                     proof
                 } else {
                     &PathBuf::from(format!("{}.stark.proof", target_name))
                 };
-                encode_to_file(proof_path, stark_proof)?;
+                write_to_file_json(proof_path, stark_proof_bytes)?;
             }
             #[cfg(feature = "evm-prove")]
             ProveSubCommand::Evm {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -4,9 +4,10 @@ use clap::Parser;
 use eyre::Result;
 use openvm_sdk::{
     fs::{
-        decode_from_file, read_agg_stark_pk_from_file, read_app_proof_from_file,
-        read_app_vk_from_file,
+        read_agg_stark_pk_from_file, read_app_proof_from_file, read_app_vk_from_file,
+        read_from_file_json,
     },
+    types::VmStarkProofBytes,
     Sdk,
 };
 
@@ -121,8 +122,15 @@ impl VerifyCmd {
                     files[0].clone()
                 };
                 println!("Verifying STARK proof at {}", proof_path.display());
-                let stark_proof = decode_from_file(proof_path)?;
-                sdk.verify_e2e_stark_proof(&agg_stark_pk, &stark_proof)?;
+                let stark_proof_bytes: VmStarkProofBytes = read_from_file_json(proof_path)?;
+                let expected_exe_commit = stark_proof_bytes.app_commit.exe_commit_to_bn254();
+                let expected_vm_commit = stark_proof_bytes.app_commit.vm_commit_to_bn254();
+                sdk.verify_e2e_stark_proof(
+                    &agg_stark_pk,
+                    &stark_proof_bytes.try_into()?,
+                    &expected_exe_commit,
+                    &expected_vm_commit,
+                )?;
             }
             #[cfg(feature = "evm-verify")]
             VerifySubCommand::Evm { proof } => {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -123,8 +123,8 @@ impl VerifyCmd {
                 };
                 println!("Verifying STARK proof at {}", proof_path.display());
                 let stark_proof_bytes: VmStarkProofBytes = read_from_file_json(proof_path)?;
-                let expected_exe_commit = stark_proof_bytes.app_commit.exe_commit_to_bn254();
-                let expected_vm_commit = stark_proof_bytes.app_commit.vm_commit_to_bn254();
+                let expected_exe_commit = stark_proof_bytes.app_commit.app_exe_commit.to_bn254();
+                let expected_vm_commit = stark_proof_bytes.app_commit.app_vm_commit.to_bn254();
                 sdk.verify_e2e_stark_proof(
                     &agg_stark_pk,
                     &stark_proof_bytes.try_into()?,

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -57,6 +57,7 @@ tempfile.workspace = true
 hex.workspace = true
 forge-fmt = { workspace = true, optional = true }
 rrs-lib = { workspace = true }
+num-bigint = { workspace = true }
 
 [features]
 default = ["parallel", "jemalloc", "evm-verify"]

--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -298,7 +298,7 @@ impl Encode for [F; DIGEST_SIZE] {
 }
 
 /// Encodes length of slice and then each element
-fn encode_slice<T: Encode, W: Write>(slice: &[T], writer: &mut W) -> Result<()> {
+pub(crate) fn encode_slice<T: Encode, W: Write>(slice: &[T], writer: &mut W) -> Result<()> {
     slice.len().encode(writer)?;
     for elt in slice {
         elt.encode(writer)?;
@@ -610,7 +610,7 @@ impl Decode for [F; DIGEST_SIZE] {
 }
 
 /// Decodes a vector of elements
-fn decode_vec<T: Decode, R: Read>(reader: &mut R) -> Result<Vec<T>> {
+pub(crate) fn decode_vec<T: Decode, R: Read>(reader: &mut R) -> Result<Vec<T>> {
     let len = usize::decode(reader)?;
     let mut vec = Vec::with_capacity(len);
 

--- a/crates/sdk/src/commit.rs
+++ b/crates/sdk/src/commit.rs
@@ -19,8 +19,9 @@ use serde_with::serde_as;
 
 use crate::{types::BN254_BYTES, NonRootCommittedExe, F, SC};
 
-/// Wrapper for an array of big-endian bytes, representing a Bn254. Each commit can be
-/// converted to a Bn254 and/or base-F::MODULUS number as a u32 digest.
+/// Wrapper for an array of big-endian bytes, representing an unsigned big integer. Each commit can
+/// be converted to a Bn254Fr using the trivial identification as natural numbers or into a `u32`
+/// digest by decomposing the big integer base-`F::MODULUS`.
 #[serde_as]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct CommitBytes(#[serde_as(as = "serde_with::hex::Hex")] [u8; BN254_BYTES]);

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -210,7 +210,7 @@ pub fn write_to_file_json<T: Serialize, P: AsRef<Path>>(path: P, data: T) -> Res
         create_dir_all(parent).map_err(|e| write_error(&path, e.into()))?;
     }
     File::create(&path)
-        .and_then(|file| serde_json::to_writer(file, &data).map_err(|e| e.into()))
+        .and_then(|file| serde_json::to_writer_pretty(file, &data).map_err(|e| e.into()))
         .map_err(|e| write_error(&path, e.into()))?;
     Ok(())
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -408,8 +408,8 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
             pvs.connector.initial_pc,
         );
         let app_commit = AppExecutionCommit::from_field_commit(exe_commit, vm_commit);
-        let exe_commit_bn254 = app_commit.exe_commit_to_bn254();
-        let vm_commit_bn254 = app_commit.vm_commit_to_bn254();
+        let exe_commit_bn254 = app_commit.app_exe_commit.to_bn254();
+        let vm_commit_bn254 = app_commit.app_vm_commit.to_bn254();
 
         if exe_commit_bn254 != *expected_exe_commit {
             return Err(eyre::eyre!(

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -24,7 +24,7 @@ use openvm_circuit::{
 };
 use openvm_continuations::verifier::{
     common::types::VmVerifierPvs,
-    internal::types::VmStarkProof,
+    internal::types::{InternalVmVerifierPvs, VmStarkProof},
     root::{types::RootVmVerifierInput, RootVmVerifierConfig},
 };
 pub use openvm_continuations::{
@@ -37,6 +37,7 @@ use openvm_stark_sdk::{
     config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters},
     engine::StarkFriEngine,
     openvm_stark_backend::Chip,
+    p3_bn254_fr::Bn254Fr,
 };
 use openvm_transpiler::{
     elf::Elf,
@@ -330,6 +331,8 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         &self,
         agg_stark_pk: &AggStarkProvingKey,
         proof: &VmStarkProof<SC>,
+        expected_exe_commit: &Bn254Fr,
+        expected_vm_commit: &Bn254Fr,
     ) -> Result<AppExecutionCommit> {
         if proof.proof.per_air.len() < 3 {
             return Err(eyre::eyre!(
@@ -343,22 +346,37 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
         } else if proof.proof.per_air[2].air_id != PUBLIC_VALUES_AIR_ID {
             return Err(eyre::eyre!("Missing public values AIR"));
         }
+        let public_values_air_proof_data = &proof.proof.per_air[2];
 
-        let vm_commit = proof.proof.commitments.main_trace[PROGRAM_CACHED_TRACE_INDEX].as_ref();
+        let program_commit =
+            proof.proof.commitments.main_trace[PROGRAM_CACHED_TRACE_INDEX].as_ref();
         let internal_commit: &[_; CHUNK] = &agg_stark_pk
             .internal_committed_exe
             .get_program_commit()
             .into();
 
-        let vm_pk = if vm_commit == internal_commit {
-            &agg_stark_pk.internal_vm_pk
+        let (vm_pk, vm_commit) = if program_commit == internal_commit {
+            let internal_pvs: &InternalVmVerifierPvs<_> = public_values_air_proof_data
+                .public_values
+                .as_slice()
+                .borrow();
+            if internal_commit != &internal_pvs.extra_pvs.internal_program_commit {
+                return Err(eyre::eyre!(
+                    "Invalid internal program commit: expected {:?}, got {:?}",
+                    internal_commit,
+                    internal_pvs.extra_pvs.internal_program_commit
+                ));
+            }
+            (
+                &agg_stark_pk.internal_vm_pk,
+                internal_pvs.extra_pvs.leaf_verifier_commit,
+            )
         } else {
-            &agg_stark_pk.leaf_vm_pk
+            (&agg_stark_pk.leaf_vm_pk, *program_commit)
         };
         let e = E::new(vm_pk.fri_params);
         e.verify(&vm_pk.vm_pk.get_vk(), &proof.proof)?;
 
-        let public_values_air_proof_data = &proof.proof.per_air[2];
         let pvs: &VmVerifierPvs<_> =
             public_values_air_proof_data.public_values[..VmVerifierPvs::<u8>::width()].borrow();
 
@@ -383,12 +401,30 @@ impl<E: StarkFriEngine<SC>> GenericSdk<E> {
             ));
         }
 
-        let start_pc = pvs.connector.initial_pc;
-        let initial_memory_root = &pvs.memory.initial_root;
-        let exe_commit = compute_exe_commit(&hasher, vm_commit, initial_memory_root, start_pc);
-        Ok(AppExecutionCommit::from_field_commit(
-            *vm_commit, exe_commit,
-        ))
+        let exe_commit = compute_exe_commit(
+            &hasher,
+            &pvs.app_commit,
+            &pvs.memory.initial_root,
+            pvs.connector.initial_pc,
+        );
+        let app_commit = AppExecutionCommit::from_field_commit(exe_commit, vm_commit);
+        let exe_commit_bn254 = app_commit.exe_commit_to_bn254();
+        let vm_commit_bn254 = app_commit.vm_commit_to_bn254();
+
+        if exe_commit_bn254 != *expected_exe_commit {
+            return Err(eyre::eyre!(
+                "Invalid app exe commit: expected {:?}, got {:?}",
+                expected_exe_commit,
+                exe_commit_bn254
+            ));
+        } else if vm_commit_bn254 != *expected_vm_commit {
+            return Err(eyre::eyre!(
+                "Invalid app vm commit: expected {:?}, got {:?}",
+                expected_vm_commit,
+                vm_commit_bn254
+            ));
+        }
+        Ok(app_commit)
     }
 
     #[cfg(feature = "evm-prove")]

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,13 +1,24 @@
-use std::iter::{once, repeat};
+use std::{
+    io::Cursor,
+    iter::{once, repeat},
+};
 
+use eyre::Result;
 use itertools::Itertools;
+use openvm_continuations::{verifier::internal::types::VmStarkProof, SC};
 use openvm_native_recursion::halo2::{wrapper::EvmVerifierByteCode, Fr, RawEvmProof};
+use openvm_stark_backend::proof::Proof;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
 
+use crate::{
+    codec::{decode_vec, encode_slice, Decode, Encode},
+    commit::AppExecutionCommitBytes,
+};
+
 /// Number of bytes in a Bn254Fr.
-const BN254_BYTES: usize = 32;
+pub(crate) const BN254_BYTES: usize = 32;
 /// Number of Bn254Fr in `accumulator` field.
 pub const NUM_BN254_ACCUMULATOR: usize = 12;
 /// Number of Bn254Fr in `proof` field for a circuit with only 1 advice column.
@@ -36,12 +47,9 @@ pub struct ProofData {
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EvmProof {
-    #[serde_as(as = "serde_with::hex::Hex")]
-    /// 1 Bn254Fr public value for app exe commit in big-endian bytes.
-    pub app_exe_commit: [u8; BN254_BYTES],
-    #[serde_as(as = "serde_with::hex::Hex")]
-    /// 1 Bn254Fr public value for app vm commit in big-endian bytes.
-    pub app_vm_commit: [u8; BN254_BYTES],
+    #[serde(flatten)]
+    /// Bn254Fr public value app commits.
+    pub app_commit: AppExecutionCommitBytes,
     #[serde_as(as = "serde_with::hex::Hex")]
     /// User public values packed into bytes.
     pub user_public_values: Vec<u8>,
@@ -71,8 +79,7 @@ impl EvmProof {
 
         let EvmProof {
             user_public_values,
-            app_exe_commit,
-            app_vm_commit,
+            app_commit,
             proof_data,
         } = self;
 
@@ -84,8 +91,8 @@ impl EvmProof {
         IOpenVmHalo2Verifier::verifyCall {
             publicValues: user_public_values.into(),
             proofData: proof_data.into(),
-            appExeCommit: app_exe_commit.into(),
-            appVmCommit: app_vm_commit.into(),
+            appExeCommit: app_commit.app_exe_commit.into(),
+            appVmCommit: app_commit.app_vm_commit.into(),
         }
         .abi_encode()
     }
@@ -130,10 +137,13 @@ impl TryFrom<RawEvmProof> for EvmProof {
                 acc
             },
         );
-
-        Ok(Self {
+        let app_commit = AppExecutionCommitBytes {
             app_exe_commit,
             app_vm_commit,
+        };
+
+        Ok(Self {
+            app_commit,
             user_public_values,
             proof_data: ProofData {
                 accumulator: evm_accumulator,
@@ -147,14 +157,13 @@ impl TryFrom<EvmProof> for RawEvmProof {
     type Error = EvmProofConversionError;
     fn try_from(evm_openvm_proof: EvmProof) -> Result<Self, Self::Error> {
         let EvmProof {
-            mut app_exe_commit,
-            mut app_vm_commit,
+            mut app_commit,
             user_public_values,
             proof_data,
         } = evm_openvm_proof;
 
-        app_exe_commit.reverse();
-        app_vm_commit.reverse();
+        app_commit.app_exe_commit.reverse();
+        app_commit.app_vm_commit.reverse();
 
         let ProofData { accumulator, proof } = proof_data;
 
@@ -183,8 +192,8 @@ impl TryFrom<EvmProof> for RawEvmProof {
             let mut ret = Vec::new();
             for chunk in &reversed_accumulator
                 .iter()
-                .chain(&app_exe_commit)
-                .chain(&app_vm_commit)
+                .chain(&app_commit.app_exe_commit)
+                .chain(&app_commit.app_vm_commit)
                 .chain(&user_public_values)
                 .chunks(BN254_BYTES)
             {
@@ -194,5 +203,45 @@ impl TryFrom<EvmProof> for RawEvmProof {
             ret
         };
         Ok(RawEvmProof { instances, proof })
+    }
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VmStarkProofBytes {
+    #[serde(flatten)]
+    pub app_commit: AppExecutionCommitBytes,
+    #[serde_as(as = "serde_with::hex::Hex")]
+    pub user_public_values: Vec<u8>,
+    #[serde_as(as = "serde_with::hex::Hex")]
+    pub proof: Vec<u8>,
+}
+
+impl VmStarkProofBytes {
+    pub fn new(app_commit: AppExecutionCommitBytes, proof: VmStarkProof<SC>) -> Result<Self> {
+        let mut user_public_values = Vec::new();
+        encode_slice(&proof.user_public_values, &mut user_public_values)?;
+        Ok(Self {
+            app_commit,
+            user_public_values,
+            proof: proof.proof.encode_to_vec()?,
+        })
+    }
+}
+
+impl TryFrom<VmStarkProofBytes> for VmStarkProof<SC> {
+    type Error = std::io::Error;
+    fn try_from(proof: VmStarkProofBytes) -> Result<Self, std::io::Error> {
+        let VmStarkProofBytes {
+            proof,
+            user_public_values,
+            ..
+        } = proof;
+        let mut reader = Cursor::new(user_public_values);
+        let user_public_values = decode_vec(&mut reader)?;
+        Ok(Self {
+            user_public_values,
+            proof: Proof::decode_from_bytes(&proof)?,
+        })
     }
 }

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -350,8 +350,8 @@ fn test_static_verifier_custom_pv_handler() {
         &app_committed_exe,
         &app_pk.leaf_committed_exe,
     );
-    let exe_commit = commits.exe_commit_to_bn254();
-    let leaf_verifier_commit = commits.vm_commit_to_bn254();
+    let exe_commit = commits.app_exe_commit.to_bn254();
+    let leaf_verifier_commit = commits.app_vm_commit.to_bn254();
 
     let pv_handler = CustomPvHandler {
         exe_commit,

--- a/guest-libs/verify_stark/guest/tests/integration_test.rs
+++ b/guest-libs/verify_stark/guest/tests/integration_test.rs
@@ -58,6 +58,8 @@ mod tests {
 
         let commits =
             AppExecutionCommit::compute(&vm_config, &committed_app_exe, &app_pk.leaf_committed_exe);
+        let exe_commit = commits.app_exe_commit.to_u32_digest();
+        let vm_commit = commits.app_vm_commit.to_u32_digest();
 
         let agg_pk = AggStarkProvingKey::keygen(AggStarkConfig {
             max_num_user_public_values: DEFAULT_MAX_NUM_PUBLIC_VALUES,
@@ -106,17 +108,13 @@ mod tests {
             .collect();
 
         let mut stdin = StdIn::default();
-        let key = compute_hint_key_for_verify_openvm_stark(
-            ASM_FILENAME,
-            &commits.exe_commit,
-            &commits.vm_commit,
-            &pvs,
-        );
+        let key =
+            compute_hint_key_for_verify_openvm_stark(ASM_FILENAME, &exe_commit, &vm_commit, &pvs);
         let value = encode_proof_to_kv_store_value(&e2e_stark_proof.proof);
         stdin.add_key_value(key, value);
 
-        stdin.write(&commits.exe_commit);
-        stdin.write(&commits.vm_commit);
+        stdin.write(&exe_commit);
+        stdin.write(&vm_commit);
         stdin.write(&pvs);
 
         sdk.execute(verify_exe, vm_config, stdin)?;


### PR DESCRIPTION
Resolves INT-3880 and INT-4073. Implements the following:

- All CLI commit outputs are in hex
- `cargo openvm prove stark` outputs a JSON similar to `cargo openvm prove evm`
- Updates STARK verification to check app executable and VM commits

`cargo openvm prove stark` output looks like this:
```
{
  "app_exe_commit": "004807b0289c7eeaa279e610af936bec5fa6f677d4f2da64bb53f39d37debe3c",
  "app_vm_commit": "00249a27204ce75ed124a9cc45a722cab52744d57400c6967901260e5a510cd2",
  "user_public_values": "200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  "proof": "0100000002000..."
}
```