### PR TITLE
fix(new-execution): use unpadded height for segmentation

### DIFF
--- a/crates/vm/src/arch/execution_mode/metered/exact.rs
+++ b/crates/vm/src/arch/execution_mode/metered/exact.rs
@@ -84,6 +84,7 @@ impl MeteredCtxExact {
         }
     }
 
+    // TODO(ayush): fix this for native
     #[allow(clippy::type_complexity)]
     fn calculate_splits_and_merges(
         &self,

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -25,7 +25,7 @@ use strum::IntoEnumIterator;
 use crate::{adapters::*, *};
 
 // TODO(ayush): this should be decided after e2 execution
-const MAX_INS_CAPACITY: usize = 1 << 22;
+const MAX_INS_CAPACITY: usize = 1 << 23;
 
 /// Config for a VM with base extension and IO extension
 #[derive(Clone, Debug, VmConfig, derive_new::new, Serialize, Deserialize)]


### PR DESCRIPTION
- use unpadded height when calculating max height and total cells during segmentation
- use default segmentation thresholds from reth benchmark