### PR TITLE
refactor: VM Executor for E1/E2

### DIFF
--- a/crates/sdk/src/prover/vm/local.rs
+++ b/crates/sdk/src/prover/vm/local.rs
@@ -98,7 +98,7 @@ where
             match vm.executor.execute_and_then(
                 exe.clone(),
                 input.clone(),
-                |seg_idx, mut seg| {
+                |seg_idx, seg| {
                     final_memory = Some(
                         seg.chip_complex
                             .memory_controller()

--- a/crates/sdk/src/prover/vm/local.rs
+++ b/crates/sdk/src/prover/vm/local.rs
@@ -99,7 +99,14 @@ where
                 exe.clone(),
                 input.clone(),
                 |seg_idx, mut seg| {
-                    final_memory = mem::take(&mut seg.ctrl.final_memory);
+                    final_memory = Some(
+                        seg.chip_complex
+                            .memory_controller()
+                            .memory
+                            .data
+                            .memory
+                            .clone(),
+                    );
                     let proof_input = info_span!("trace_gen", segment = seg_idx)
                         .in_scope(|| seg.generate_proof_input(Some(committed_program.clone())))?;
                     info_span!("prove_segment", segment = seg_idx)

--- a/crates/vm/src/arch/execution_control.rs
+++ b/crates/vm/src/arch/execution_control.rs
@@ -4,6 +4,10 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use super::{ExecutionError, VmChipComplex, VmConfig, VmSegmentState};
 
 /// Trait for execution control, determining segmentation and stopping conditions
+/// Invariants:
+/// - `ExecutionControl` should be stateless.
+/// - For E3/E4, `ExecutionControl` is for a specific execution and cannot be used for another
+///   execution with different inputs or segmentation criteria.
 pub trait ExecutionControl<F, VC>
 where
     F: PrimeField32,

--- a/crates/vm/src/arch/execution_control.rs
+++ b/crates/vm/src/arch/execution_control.rs
@@ -12,30 +12,32 @@ where
     /// Host context
     type Ctx;
 
+    fn initialize_context(&self) -> Self::Ctx;
+
     /// Determines if execution should suspend
     fn should_suspend(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> bool;
 
     /// Called before execution begins
     fn on_start(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     );
 
     /// Called after suspend or terminate
     fn on_suspend_or_terminate(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         exit_code: Option<u32>,
     );
 
     fn on_suspend(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) {
@@ -43,7 +45,7 @@ where
     }
 
     fn on_terminate(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         exit_code: u32,
@@ -54,7 +56,7 @@ where
     /// Execute a single instruction
     // TODO(ayush): change instruction to Instruction<u32> / PInstruction
     fn execute_instruction(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,

--- a/crates/vm/src/arch/execution_mode/e1.rs
+++ b/crates/vm/src/arch/execution_mode/e1.rs
@@ -26,8 +26,12 @@ where
 {
     type Ctx = E1Ctx;
 
+    fn initialize_context(&self) -> Self::Ctx {
+        ()
+    }
+
     fn should_suspend(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         _chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> bool {
@@ -39,14 +43,14 @@ where
     }
 
     fn on_start(
-        &mut self,
+        &self,
         _state: &mut VmSegmentState<Self::Ctx>,
         _chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) {
     }
 
     fn on_suspend_or_terminate(
-        &mut self,
+        &self,
         _state: &mut VmSegmentState<Self::Ctx>,
         _chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         _exit_code: Option<u32>,
@@ -55,7 +59,7 @@ where
 
     /// Execute a single instruction
     fn execute_instruction(
-        &mut self,
+        &self,
         state: &mut VmSegmentState<Self::Ctx>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,

--- a/crates/vm/src/arch/execution_mode/metered/bounded.rs
+++ b/crates/vm/src/arch/execution_mode/metered/bounded.rs
@@ -19,6 +19,8 @@ pub struct MeteredCtxBounded {
 
     // Indices of leaf nodes in the memory merkle tree
     pub leaf_indices: Vec<u64>,
+    pub clk_last_segment_check: u64,
+    pub num_segments: usize,
 }
 
 impl MeteredCtxBounded {
@@ -36,6 +38,8 @@ impl MeteredCtxBounded {
             as_byte_alignment_bits,
             memory_dimensions,
             leaf_indices: Vec::new(),
+            clk_last_segment_check: 0,
+            num_segments: 0,
         }
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/bounded.rs
+++ b/crates/vm/src/arch/execution_mode/metered/bounded.rs
@@ -20,7 +20,7 @@ pub struct MeteredCtxBounded {
     // Indices of leaf nodes in the memory merkle tree
     pub leaf_indices: Vec<u64>,
     pub clk_last_segment_check: u64,
-    pub num_segments: usize,
+    pub segments: Vec<Segment>,
 }
 
 impl MeteredCtxBounded {
@@ -39,7 +39,7 @@ impl MeteredCtxBounded {
             memory_dimensions,
             leaf_indices: Vec::new(),
             clk_last_segment_check: 0,
-            num_segments: 0,
+            segments: Vec::new(),
         }
     }
 }
@@ -184,4 +184,11 @@ fn calculate_merkle_node_updates(
     }
 
     diff
+}
+
+#[derive(derive_new::new, Debug)]
+pub struct Segment {
+    pub clk_start: u64,
+    pub num_cycles: u64,
+    pub trace_heights: Vec<u32>,
 }

--- a/crates/vm/src/arch/execution_mode/tracegen/mod.rs
+++ b/crates/vm/src/arch/execution_mode/tracegen/mod.rs
@@ -4,4 +4,6 @@ mod segmentation;
 pub use normal::TracegenExecutionControl;
 pub use segmentation::TracegenExecutionControlWithSegmentation;
 
-pub type TracegenCtx = ();
+pub struct TracegenCtx {
+    pub since_last_segment_check: usize,
+}

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -10,18 +10,20 @@ use crate::{
 };
 
 /// VM pure executor(E1/E2 executor) which doesn't consider trace generation.
-/// Note: This executor doesn't hold any VM state.
-pub struct VmPureExecutor<F: PrimeField32, VC: VmConfig<F>> {
+/// Note: This executor doesn't hold any VM state and can be used for multiple execution.
+pub struct InterpretedInstance<F: PrimeField32, VC: VmConfig<F>> {
     exe: VmExe<F>,
     vm_config: VC,
 }
 
-impl<F: PrimeField32, VC: VmConfig<F>> VmPureExecutor<F, VC> {
+impl<F: PrimeField32, VC: VmConfig<F>> InterpretedInstance<F, VC> {
     pub fn new(vm_config: VC, exe: impl Into<VmExe<F>>) -> Self {
         let exe = exe.into();
         Self { exe, vm_config }
     }
 
+    /// Execute the VM program with the given execution control and inputs. Returns the final VM
+    /// state with the `ExecutionControl` context.
     pub fn execute<CTRL: ExecutionControl<F, VC>>(
         &self,
         ctrl: CTRL,

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -19,6 +19,7 @@ pub mod vm;
 pub use openvm_instructions as instructions;
 
 pub mod hasher;
+pub mod pure_execution;
 /// Testing framework
 #[cfg(any(test, feature = "test-utils"))]
 pub mod testing;

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -19,7 +19,7 @@ pub mod vm;
 pub use openvm_instructions as instructions;
 
 pub mod hasher;
-pub mod pure_execution;
+pub mod interpreter;
 /// Testing framework
 #[cfg(any(test, feature = "test-utils"))]
 pub mod testing;

--- a/crates/vm/src/arch/pure_execution.rs
+++ b/crates/vm/src/arch/pure_execution.rs
@@ -1,0 +1,104 @@
+use openvm_instructions::{exe::VmExe, program::Program, LocalOpcode, SystemOpcode};
+use openvm_stark_backend::p3_field::{Field, PrimeField32};
+
+use crate::{
+    arch::{
+        execution_control::ExecutionControl, execution_mode::E1E2ExecutionCtx, ExecutionError,
+        Streams, VmChipComplex, VmConfig, VmSegmentState,
+    },
+    system::memory::{online::GuestMemory, AddressMap},
+};
+
+/// VM pure executor(E1/E2 executor) which doesn't consider trace generation.
+/// Note: This executor doesn't hold any VM state.
+pub struct VmPureExecutor<F: PrimeField32, VC: VmConfig<F>> {
+    exe: VmExe<F>,
+    vm_config: VC,
+}
+
+impl<F: PrimeField32, VC: VmConfig<F>> VmPureExecutor<F, VC> {
+    pub fn new(vm_config: VC, exe: impl Into<VmExe<F>>) -> Self {
+        let exe = exe.into();
+        Self { exe, vm_config }
+    }
+
+    pub fn execute<CTRL: ExecutionControl<F, VC>>(
+        &self,
+        ctrl: CTRL,
+        inputs: impl Into<Streams<F>>,
+    ) -> Result<VmSegmentState<CTRL::Ctx>, ExecutionError>
+    where
+        CTRL::Ctx: E1E2ExecutionCtx,
+    {
+        // Initialize the chip complex
+        let mut chip_complex = self.vm_config.create_chip_complex().unwrap();
+        let inputs = inputs.into();
+        chip_complex.set_streams(inputs);
+        // Initialize the memory
+        let memory = if self.vm_config.system().continuation_enabled {
+            let mem_config = self.vm_config.system().memory_config;
+            Some(GuestMemory::new(AddressMap::from_sparse(
+                mem_config.as_offset,
+                1 << mem_config.as_height,
+                1 << mem_config.pointer_max_bits,
+                self.exe.init_memory.clone(),
+            )))
+        } else {
+            Some(GuestMemory::new(Default::default()))
+        };
+
+        // Initialize the context
+        let ctx = ctrl.initialize_context();
+        let mut vm_state = VmSegmentState {
+            clk: 0,
+            pc: self.exe.pc_start,
+            memory,
+            exit_code: None,
+            ctx,
+        };
+
+        // Start execution
+        ctrl.on_start(&mut vm_state, &mut chip_complex);
+        let program = &self.exe.program;
+
+        loop {
+            if ctrl.should_suspend(&mut vm_state, &chip_complex) {
+                ctrl.on_suspend(&mut vm_state, &mut chip_complex);
+            }
+
+            // Fetch the next instruction
+            let pc = vm_state.pc;
+            let pc_index = get_pc_index(program, vm_state.pc)?;
+            let (inst, _) = program.get_instruction_and_debug_info(pc_index).ok_or(
+                ExecutionError::PcNotFound {
+                    pc,
+                    step: program.step,
+                    pc_base: program.pc_base,
+                    program_len: program.len(),
+                },
+            )?;
+            if inst.opcode == SystemOpcode::TERMINATE.global_opcode() {
+                let exit_code = inst.c.as_canonical_u32();
+                vm_state.exit_code = Some(exit_code);
+                ctrl.on_terminate(&mut vm_state, &mut chip_complex, exit_code);
+                return Ok(vm_state);
+            }
+            ctrl.execute_instruction(&mut vm_state, inst, &mut chip_complex)?;
+        }
+    }
+}
+
+fn get_pc_index<F: Field>(program: &Program<F>, pc: u32) -> Result<usize, ExecutionError> {
+    let step = program.step;
+    let pc_base = program.pc_base;
+    let pc_index = ((pc - pc_base) / step) as usize;
+    if !(0..program.len()).contains(&pc_index) {
+        return Err(ExecutionError::PcOutOfBounds {
+            pc,
+            step,
+            pc_base,
+            program_len: program.len(),
+        });
+    }
+    Ok(pc_index)
+}

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -299,6 +299,7 @@ where
         #[cfg(feature = "bench-metrics")]
         let metrics = segment.metrics.partial_take();
 
+        // TODO(ayush): this can probably be avoided
         let memory = segment
             .chip_complex
             .base

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -8,8 +8,12 @@ use std::{
 use openvm_circuit::{
     arch::{
         create_and_initialize_chip_complex,
-        execution_mode::tracegen::TracegenExecutionControlWithSegmentation,
+        execution_control::ExecutionControl,
+        execution_mode::{
+            e1::E1ExecutionControl, tracegen::TracegenExecutionControlWithSegmentation,
+        },
         hasher::{poseidon2::vm_poseidon2_hasher, Hasher},
+        pure_execution::VmPureExecutor,
         ChipId, MemoryConfig, SingleSegmentVmExecutor, SystemConfig, SystemTraceHeights,
         VirtualMachine, VmComplexTraceHeights, VmConfig, VmInventoryTraceHeights,
         VmSegmentExecutor, VmSegmentState,
@@ -723,6 +727,7 @@ fn test_hint_load_1() {
     )
     .unwrap();
     let ctrl = TracegenExecutionControlWithSegmentation::new(chip_complex.air_names());
+    let ctx = ExecutionControl::<F, NativeConfig>::initialize_context(&ctrl);
     let mut segment = VmSegmentExecutor::<F, NativeConfig, _>::new(
         chip_complex,
         vec![],
@@ -730,7 +735,7 @@ fn test_hint_load_1() {
         ctrl,
     );
 
-    let mut exec_state = VmSegmentState::new(0, 0, None, ());
+    let mut exec_state = VmSegmentState::new(0, 0, None, ctx);
     segment.execute_from_state(&mut exec_state).unwrap();
 
     let streams = segment.chip_complex.take_streams();
@@ -769,6 +774,7 @@ fn test_hint_load_2() {
     )
     .unwrap();
     let ctrl = TracegenExecutionControlWithSegmentation::new(chip_complex.air_names());
+    let ctx = ExecutionControl::<F, NativeConfig>::initialize_context(&ctrl);
     let mut segment = VmSegmentExecutor::<F, NativeConfig, _>::new(
         chip_complex,
         vec![],
@@ -776,7 +782,7 @@ fn test_hint_load_2() {
         ctrl,
     );
 
-    let mut exec_state = VmSegmentState::new(0, 0, None, ());
+    let mut exec_state = VmSegmentState::new(0, 0, None, ctx);
     segment.execute_from_state(&mut exec_state).unwrap();
 
     let [read] = unsafe {
@@ -795,4 +801,78 @@ fn test_hint_load_2() {
         streams.hint_space,
         vec![vec![F::ONE, F::TWO], vec![F::TWO, F::ONE]]
     );
+}
+
+#[test]
+fn test_vm_pure_execution_non_continuation() {
+    type F = BabyBear;
+    let n = 6;
+    /*
+    Instruction 0 assigns word[0]_4 to n.
+    Instruction 4 terminates
+    The remainder is a loop that decrements word[0]_4 until it reaches 0, then terminates.
+    Instruction 1 checks if word[0]_4 is 0 yet, and if so sets pc to 5 in order to terminate
+    Instruction 2 decrements word[0]_4 (using word[1]_4)
+    Instruction 3 uses JAL as a simple jump to go back to instruction 1 (repeating the loop).
+     */
+    let instructions = vec![
+        // word[0]_4 <- word[n]_0
+        Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 4, 0, 0, 0),
+        // if word[0]_4 == 0 then pc += 3 * DEFAULT_PC_STEP
+        Instruction::from_isize(
+            NativeBranchEqualOpcode(BEQ).global_opcode(),
+            0,
+            0,
+            3 * DEFAULT_PC_STEP as isize,
+            4,
+            0,
+        ),
+        // word[0]_4 <- word[0]_4 - word[1]_4
+        Instruction::large_from_isize(SUB.global_opcode(), 0, 0, 1, 4, 4, 0, 0),
+        // word[2]_4 <- pc + DEFAULT_PC_STEP, pc -= 2 * DEFAULT_PC_STEP
+        Instruction::from_isize(
+            JAL.global_opcode(),
+            2,
+            -2 * DEFAULT_PC_STEP as isize,
+            0,
+            4,
+            0,
+        ),
+        // terminate
+        Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
+    ];
+
+    let program = Program::from_instructions(&instructions);
+
+    let executor = VmPureExecutor::<F, _>::new(test_native_config(), program);
+    executor
+        .execute(E1ExecutionControl::new(None), vec![])
+        .expect("Failed to execute");
+}
+
+#[test]
+fn test_vm_pure_execution_continuation() {
+    type F = BabyBear;
+    let instructions = vec![
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 3, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 4, 0, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 5, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 6, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(ADD.global_opcode(), 7, 0, 2, 4, 0, 0, 0),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4ADD.global_opcode(), 8, 0, 4, 4, 4),
+        Instruction::from_isize(FE4SUB.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4MUL.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(BBE4DIV.global_opcode(), 12, 0, 4, 4, 4),
+        Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
+    ];
+
+    let program = Program::from_instructions(&instructions);
+    let executor = VmPureExecutor::<F, _>::new(test_native_continuations_config(), program);
+    executor
+        .execute(E1ExecutionControl::new(None), vec![])
+        .expect("Failed to execute");
 }

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -13,7 +13,7 @@ use openvm_circuit::{
             e1::E1ExecutionControl, tracegen::TracegenExecutionControlWithSegmentation,
         },
         hasher::{poseidon2::vm_poseidon2_hasher, Hasher},
-        pure_execution::VmPureExecutor,
+        interpreter::InterpretedInstance,
         ChipId, MemoryConfig, SingleSegmentVmExecutor, SystemConfig, SystemTraceHeights,
         VirtualMachine, VmComplexTraceHeights, VmConfig, VmInventoryTraceHeights,
         VmSegmentExecutor, VmSegmentState,
@@ -844,7 +844,7 @@ fn test_vm_pure_execution_non_continuation() {
 
     let program = Program::from_instructions(&instructions);
 
-    let executor = VmPureExecutor::<F, _>::new(test_native_config(), program);
+    let executor = InterpretedInstance::<F, _>::new(test_native_config(), program);
     executor
         .execute(E1ExecutionControl::new(None), vec![])
         .expect("Failed to execute");
@@ -871,7 +871,7 @@ fn test_vm_pure_execution_continuation() {
     ];
 
     let program = Program::from_instructions(&instructions);
-    let executor = VmPureExecutor::<F, _>::new(test_native_continuations_config(), program);
+    let executor = InterpretedInstance::<F, _>::new(test_native_continuations_config(), program);
     executor
         .execute(E1ExecutionControl::new(None), vec![])
         .expect("Failed to execute");


### PR DESCRIPTION
- Add `InterpretedInstance` for E1/E2.
- Enforce `ExecutionControl` to be stateless.
- `InterpretedInstance` E2 is not tested because context initialization is tricky. Will address in the future PR.

close INT-4043