### PR TITLE
fix(new-execution): return segments in `execute_metered`

### DIFF
--- a/crates/vm/src/arch/execution_mode/metered/mod.rs
+++ b/crates/vm/src/arch/execution_mode/metered/mod.rs
@@ -18,7 +18,7 @@ const SEGMENT_CHECK_INTERVAL: u64 = 100;
 
 // TODO(ayush): fix these values
 const MAX_TRACE_HEIGHT: u32 = (1 << 23) - 100;
-const MAX_TRACE_CELLS: usize = 1_200_000_000; // 1.2B
+const MAX_TRACE_CELLS: usize = 2_000_000_000; // 2B
 const MAX_INTERACTIONS: usize = BabyBear::ORDER_U32 as usize;
 
 pub struct MeteredExecutionControl<'a> {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, collections::VecDeque, marker::PhantomData, mem, sync::Arc};
+use std::{borrow::Borrow, collections::VecDeque, marker::PhantomData, sync::Arc};
 
 use openvm_circuit::system::program::trace::compute_exe_commit;
 use openvm_instructions::{exe::VmExe, program::Program};
@@ -521,7 +521,7 @@ where
             None => return Err(ExecutionError::DidNotTerminate),
         };
 
-        todo!("record segments")
+        Ok(exec_state.ctx.segments)
     }
 
     pub fn execute_and_generate<SC: StarkGenericConfig>(


### PR DESCRIPTION
- also increased the max trace cells threshold to 2bn for now