### PR TITLE
fix(recursion): final_poly & FRI missing randomness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4908,8 +4908,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.1#e540dbdd09ef20db7207ad7f2674bece75a2b803"
+version = "1.1.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.1.0#7f79ce233683ec8ca63a32cc4723ef920b23a6c5"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4936,8 +4936,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-sdk"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.1#e540dbdd09ef20db7207ad7f2674bece75a2b803"
+version = "1.1.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.1.0#7f79ce233683ec8ca63a32cc4723ef920b23a6c5"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -5068,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -5082,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -5092,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "ff 0.13.0",
  "halo2curves",
@@ -5107,7 +5107,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -5119,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -5133,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft",
@@ -5199,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -5210,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -5236,7 +5236,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -5250,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "rayon",
 ]
@@ -5273,7 +5273,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-dft",
@@ -5287,7 +5287,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -5304,7 +5304,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5325,7 +5325,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -5336,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "gcd",
  "p3-field",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -5364,7 +5364,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5374,7 +5374,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-air",
@@ -5392,7 +5392,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-openvm"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -3913,7 +3913,7 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openvm"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "bytemuck",
  "chrono",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "eyre",
  "num-bigint 0.4.6",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-execute"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "cargo-openvm",
  "clap",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-prove"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-utils"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-integration-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "eyre",
  "openvm-bigint-circuit",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-integration-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "eyre",
  "hex-literal",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-instructions",
  "quote",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-integration-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "eyre",
  "openvm-circuit",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4442,14 +4442,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "halo2curves-axiom",
  "itertools 0.14.0",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-integration-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "eyre",
  "num-bigint 0.4.6",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-prof"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-integration-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "eyre",
  "openvm",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-circuit",
  "openvm-circuit-primitives",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-integration-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "eyre",
  "openvm-circuit",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-toolchain-tests"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "derive_more 1.0.0",
  "eyre",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "elf",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.1.2"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.82"
 authors = ["OpenVM Authors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.0.1", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.0.1", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.1.0", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.1.0", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }
@@ -166,18 +166,18 @@ openvm-pairing-guest = { path = "extensions/pairing/guest", default-features = f
 openvm-benchmarks-utils = { path = "benchmarks/utils", default-features = false }
 
 # Plonky3
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", features = [
     "nightly-features",
-], rev = "1ba4e5c" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
-p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
-p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
-p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "1ba4e5c" }
+], rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-keccak-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-monty-31 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb" }
 
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 snark-verifier-sdk = { version = "0.2.0", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OpenVM is a performant and modular zkVM framework built for customization and ex
 
 ## Status
 
-As of May 2025, OpenVM v1.1.0 and later are recommended for production use. OpenVM completed an external [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-cantina-report.pdf) on [Cantina](https://cantina.xyz/) from January to March 2025 as well as an internal [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-internal/README.md) by members of the [Axiom](https://axiom.xyz/) team during the same timeframe.
+As of May 2025, OpenVM v1.2.0 and later are recommended for production use. OpenVM completed an external [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-cantina-report.pdf) on [Cantina](https://cantina.xyz/) from January to March 2025 as well as an internal [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-internal/README.md) by members of the [Axiom](https://axiom.xyz/) team during the same timeframe.
 
 ## For Users
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OpenVM is a performant and modular zkVM framework built for customization and ex
 
 ## Status
 
-As of May 2025, OpenVM v1.2.0 and later are recommended for production use. OpenVM completed an external [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-cantina-report.pdf) on [Cantina](https://cantina.xyz/) from January to March 2025 as well as an internal [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-internal/README.md) by members of the [Axiom](https://axiom.xyz/) team during the same timeframe.
+As of June 2025, OpenVM v1.2.0 and later are recommended for production use. OpenVM completed an external [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-cantina-report.pdf) on [Cantina](https://cantina.xyz/) from January to March 2025 as well as an internal [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-internal/README.md) by members of the [Axiom](https://axiom.xyz/) team during the same timeframe.
 
 ## For Users
 

--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -9,7 +9,7 @@ To use OpenVM for generating proofs, you must install the OpenVM command line to
 Begin the installation:
 
 ```bash
-cargo install --locked --git http://github.com/openvm-org/openvm.git --tag v1.1.2 cargo-openvm
+cargo install --locked --git http://github.com/openvm-org/openvm.git --tag v1.2.0 cargo-openvm
 ```
 
 This will globally install `cargo-openvm`. You can validate a successful installation with:
@@ -23,7 +23,7 @@ cargo openvm --version
 To build from source, clone the repository and begin the installation.
 
 ```bash
-git clone --branch v1.1.2 --single-branch https://github.com/openvm-org/openvm.git
+git clone --branch v1.2.0 --single-branch https://github.com/openvm-org/openvm.git
 cd openvm
 cargo install --locked --force --path crates/cli
 ```

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -33,7 +33,7 @@ The following chapters will guide you through:
 
 ## Security Status
 
-As of May 2025, OpenVM v1.1.0 and later are recommended for production use. OpenVM completed an external [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-cantina-report.pdf) on [Cantina](https://cantina.xyz/) from January to March 2025 as well as an internal [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-internal/README.md) by members of the [Axiom](https://axiom.xyz/) team during the same timeframe.
+As of June 2025, OpenVM v1.2.0 and later are recommended for production use. OpenVM completed an external [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-cantina-report.pdf) on [Cantina](https://cantina.xyz/) from January to March 2025 as well as an internal [audit](https://github.com/openvm-org/openvm/blob/main/audits/v1-internal/README.md) by members of the [Axiom](https://axiom.xyz/) team during the same timeframe.
 
 > 📖 **About this book**
 >

--- a/book/src/writing-apps/solidity.md
+++ b/book/src/writing-apps/solidity.md
@@ -1,6 +1,6 @@
 # Solidity SDK
 
-As a supplement to OpenVM, we provide a [Solidity SDK](https://github.com/openvm-org/openvm-solidity-sdk) containing OpenVM verifier contracts generated at official release commits using the `cargo openvm setup` [command](../advanced-usage/sdk.md#setup). The contracts are built at every _minor_ release as OpenVM guarantees verifier backward compatibility across patch releases. 
+As a supplement to OpenVM, we provide a [Solidity SDK](https://github.com/openvm-org/openvm-solidity-sdk) containing OpenVM verifier contracts generated at official release commits using the `cargo openvm setup` [command](../advanced-usage/sdk.md#setup). The contracts are built at every _minor_ release as OpenVM guarantees verifier backward compatibility across patch releases.
 
 Note that these builds are for the default aggregation VM config which should be sufficient for most users. If you use a custom config, you will need to manually generate the verifier contract using the [OpenVM SDK](../advanced-usage/sdk.md).
 
@@ -17,7 +17,7 @@ forge install openvm-org/openvm-solidity-sdk
 Once you have the SDK installed, you can import the SDK contracts into your Solidity project:
 
 ```solidity
-import "openvm-solidity-sdk/v1.1/OpenVmHalo2Verifier.sol";
+import "openvm-solidity-sdk/v1.2/OpenVmHalo2Verifier.sol";
 ```
 
 If you are using an already-deployed verifier contract, you can simply import the `IOpenVmHalo2Verifier` interface:

--- a/book/src/writing-apps/solidity.md
+++ b/book/src/writing-apps/solidity.md
@@ -23,7 +23,7 @@ import "openvm-solidity-sdk/v1.1/OpenVmHalo2Verifier.sol";
 If you are using an already-deployed verifier contract, you can simply import the `IOpenVmHalo2Verifier` interface:
 
 ```solidity
-import { IOpenVmHalo2Verifier } from "openvm-solidity-sdk/v1.1/interfaces/IOpenVmHalo2Verifier.sol";
+import { IOpenVmHalo2Verifier } from "openvm-solidity-sdk/v1.2/interfaces/IOpenVmHalo2Verifier.sol";
 
 contract MyContract {
     function myFunction() public view {
@@ -49,7 +49,7 @@ To deploy an instance of a verifier contract, you can clone the repo and simply 
 ```bash
 git clone --recursive https://github.com/openvm-org/openvm-solidity-sdk.git
 cd openvm-solidity-sdk
-forge create src/v1.1/OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier --rpc-url $RPC --private-key $PRIVATE_KEY --broadcast
+forge create src/v1.2/OpenVmHalo2Verifier.sol:OpenVmHalo2Verifier --rpc-url $RPC --private-key $PRIVATE_KEY --broadcast
 ```
 
 We recommend a direct deployment from the SDK repo since the proper compiler configurations are all pre-set.

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -103,13 +103,30 @@ pub fn verify_two_adic_pcs<C: Config>(
     builder.assert_usize_eq(proof.query_proofs.len(), RVar::from(config.num_queries));
     builder.assert_usize_eq(proof.commit_phase_commits.len(), log_max_height);
     let betas: Array<C, Ext<C::F, C::EF>> = builder.array(log_max_height);
-    iter_zip!(builder, proof.commit_phase_commits, betas).for_each(|ptr_vec, builder| {
-        let comm_ptr = ptr_vec[0];
-        let beta_ptr = ptr_vec[1];
+    let betas_squared: Array<C, Ext<C::F, C::EF>> = builder.array(log_max_height);
+    // `i_plus_one_arr[i] = i + 1`. This is needed to add "enumerate" to `iter_zip!`
+    // There is no risk of overflow because `log_max_height` is much less than `C::N::MODULUS`
+    let i_plus_one_arr: Array<C, Usize<C::N>> = builder.array(log_max_height);
+    let i_var: Usize<C::N> = builder.eval(C::N::ZERO);
+    iter_zip!(
+        builder,
+        proof.commit_phase_commits,
+        betas,
+        betas_squared,
+        i_plus_one_arr
+    )
+    .for_each(|ptr_vec, builder| {
+        let [comm_ptr, beta_ptr, beta_sq_ptr, i_plus_one_ptr] = ptr_vec.try_into().unwrap();
+
         let comm = builder.iter_ptr_get(&proof.commit_phase_commits, comm_ptr);
         challenger.observe_digest(builder, comm);
         let sample = challenger.sample_ext(builder);
         builder.iter_ptr_set(&betas, beta_ptr, sample);
+        builder.iter_ptr_set(&betas_squared, beta_sq_ptr, sample * sample);
+        builder.assign(&i_var, i_var.clone() + C::N::ONE);
+        // Note: this is a deep clone when `builder.flags.static == true`
+        let i_plus_one_clone: Usize<C::N> = builder.eval(i_var.clone());
+        builder.iter_ptr_set(&i_plus_one_arr, i_plus_one_ptr, i_plus_one_clone);
     });
 
     iter_zip!(builder, proof.final_poly).for_each(|ptr_vec, builder| {
@@ -337,6 +354,9 @@ pub fn verify_two_adic_pcs<C: Config>(
             },
         );
 
+        // Note[jpw]: we do not need to assert `ro[log_blowup] = 0` here because we include
+        // `ro[log_blowup]` in the `verify_query` low-degree test. See comments therein.
+
         let folded_eval = verify_query(
             builder,
             config,
@@ -344,8 +364,10 @@ pub fn verify_two_adic_pcs<C: Config>(
             &index_bits,
             &query_proof,
             &betas,
+            &betas_squared,
             &ro,
             log_max_lde_height,
+            &i_plus_one_arr,
         );
 
         builder.assert_ext_eq(folded_eval, final_poly_ct);
@@ -600,6 +622,7 @@ pub mod tests {
     use openvm_circuit::arch::instructions::program::Program;
     use openvm_native_compiler::{
         asm::AsmBuilder,
+        conversion::CompilerOptions,
         ir::{Array, RVar, DIGEST_SIZE},
     };
     use openvm_stark_backend::{
@@ -626,7 +649,6 @@ pub mod tests {
         utils::const_fri_config,
     };
 
-    #[allow(dead_code)]
     pub fn build_test_fri_with_cols_and_log2_rows(
         nb_cols: usize,
         nb_log2_rows: usize,
@@ -713,7 +735,8 @@ pub mod tests {
         );
         builder.halt();
 
-        let program = builder.compile_isa();
+        let program =
+            builder.compile_isa_with_options(CompilerOptions::default().with_cycle_tracker());
         let mut witness_stream = Vec::new();
         witness_stream.extend(proof.write());
         (program, witness_stream)

--- a/extensions/native/recursion/src/fri/two_adic_pcs.rs
+++ b/extensions/native/recursion/src/fri/two_adic_pcs.rs
@@ -51,16 +51,11 @@ pub fn verify_two_adic_pcs<C: Config>(
 {
     // Currently do not support other final poly len
     builder.assert_var_eq(RVar::from(config.log_final_poly_len), RVar::zero());
-    // The `proof.final_poly` length is in general `2^{log_final_poly_len + log_blowup}`.
-    // We require `log_final_poly_len = 0`, so `proof.final_poly` has length `2^log_blowup`.
-    // In fact, the FRI low-degree test requires that `proof.final_poly = [constant, 0, ..., 0]`.
-    builder.assert_usize_eq(proof.final_poly.len(), RVar::from(config.blowup));
+    // The `proof.final_poly` length is in general `2^{log_final_poly_len}`.
+    // We require `log_final_poly_len = 0`, so `proof.final_poly` has length `1`.
+    builder.assert_usize_eq(proof.final_poly.len(), RVar::one());
     // Constant term of final poly
     let final_poly_ct = builder.get(&proof.final_poly, 0);
-    for i in 1..config.blowup {
-        let term = builder.get(&proof.final_poly, i);
-        builder.assert_ext_eq(term, C::EF::ZERO.cons());
-    }
 
     let g = builder.generator();
 


### PR DESCRIPTION
Updating the recursive verifier to match with the fix in https://github.com/Plonky3/Plonky3/security/advisories/GHSA-f69f-5fx9-w9r9

## Final poly length
plonky3 has changed so that `proof.final_poly.len()` must equal
`config.final_poly_len()`. Since our recursion program only supports
final poly length = 0, we can remove the previous checks that higher
degree coefficients are zero.

## Missing randomness in mixed domain handling in FRI folding
The folding needs to add `beta^2` to roll in new terms from reduced
opening.

We introduce a new array `betas_squared` to precompute and cache the
squares since the `betas` are re-used across different FRI queries.
(Side note on optimization: Zach and I discussed and it seemed like
there is no difference between iter_zip'ing two arrays and loading them
both versus storing a pair in one array since we load each Ext as a
separate instruction).

I changed the recursion code to use `iter_zip` now that another
`betas_squared` needed to be passed in and we generally want to use
`iter_zip` everywhere. There is no enumerate support in `iter_zip`, so I
created another array of the indices to also zip over.

Note: I think we previously were just skipping and not checking
`ro[log_blowup]` corresponding to trace height 1 matrices. This is now
fixed as explained in the comments (the reasoning is slightly different
than in the Plonky3 implementation).