### PR TITLE
refactor: Move `Streams` into `VmStateMut`

### DIFF
--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -251,7 +251,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -312,7 +312,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -328,7 +328,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/crates/sdk/src/prover/vm/local.rs
+++ b/crates/sdk/src/prover/vm/local.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, mem, sync::Arc};
+use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use openvm_circuit::{

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -38,10 +38,11 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<F>,
+                        streams: &mut ::openvm_circuit::arch::Streams<F>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         from_state: ::openvm_circuit::arch::ExecutionState<u32>,
                     ) -> ::openvm_circuit::arch::Result<::openvm_circuit::arch::ExecutionState<u32>> {
-                        self.0.execute(memory, instruction, from_state)
+                        self.0.execute(memory, streams, instruction, from_state)
                     }
 
                     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -79,7 +80,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                 multiunzip(variants.iter().map(|(variant_name, field)| {
                     let field_ty = &field.ty;
                     let execute_arm = quote! {
-                        #name::#variant_name(x) => <#field_ty as ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic>>::execute(x, memory, instruction, from_state)
+                        #name::#variant_name(x) => <#field_ty as ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic>>::execute(x, memory, streams, instruction, from_state)
                     };
                     let get_opcode_name_arm = quote! {
                         #name::#variant_name(x) => <#field_ty as ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic>>::get_opcode_name(x, opcode)
@@ -92,6 +93,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<#first_ty_generic>,
+                        streams: &mut ::openvm_circuit::arch::Streams<F>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<#first_ty_generic>,
                         from_state: ::openvm_circuit::arch::ExecutionState<u32>,
                     ) -> ::openvm_circuit::arch::Result<::openvm_circuit::arch::ExecutionState<u32>> {
@@ -144,7 +146,7 @@ pub fn ins_executor_e1_executor_derive(input: TokenStream) -> TokenStream {
                 impl #impl_generics ::openvm_circuit::arch::InsExecutorE1<F> for #name #ty_generics #where_clause {
                     fn execute_e1<Ctx>(
                         &self,
-                        state: &mut ::openvm_circuit::arch::VmStateMut<::openvm_circuit::system::memory::online::GuestMemory, Ctx>,
+                        state: &mut ::openvm_circuit::arch::VmStateMut<F, ::openvm_circuit::system::memory::online::GuestMemory, Ctx>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                     ) -> ::openvm_circuit::arch::Result<()>
                     where
@@ -155,7 +157,7 @@ pub fn ins_executor_e1_executor_derive(input: TokenStream) -> TokenStream {
 
                     fn execute_metered(
                         &self,
-                        state: &mut ::openvm_circuit::arch::VmStateMut<::openvm_circuit::system::memory::online::GuestMemory, ::openvm_circuit::arch::execution_mode::metered::MeteredCtx>,
+                        state: &mut ::openvm_circuit::arch::VmStateMut<F, ::openvm_circuit::system::memory::online::GuestMemory, ::openvm_circuit::arch::execution_mode::metered::MeteredCtx>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         chip_index: usize,
                     ) -> ::openvm_circuit::arch::Result<()>
@@ -207,7 +209,7 @@ pub fn ins_executor_e1_executor_derive(input: TokenStream) -> TokenStream {
                 impl #impl_generics ::openvm_circuit::arch::InsExecutorE1<#first_ty_generic> for #name #ty_generics {
                     fn execute_e1<Ctx>(
                         &self,
-                        state: &mut ::openvm_circuit::arch::VmStateMut<::openvm_circuit::system::memory::online::GuestMemory, Ctx>,
+                        state: &mut ::openvm_circuit::arch::VmStateMut<F,::openvm_circuit::system::memory::online::GuestMemory, Ctx>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<#first_ty_generic>,
                     ) -> ::openvm_circuit::arch::Result<()>
                     where
@@ -220,7 +222,7 @@ pub fn ins_executor_e1_executor_derive(input: TokenStream) -> TokenStream {
 
                     fn execute_metered(
                         &self,
-                        state: &mut ::openvm_circuit::arch::VmStateMut<::openvm_circuit::system::memory::online::GuestMemory, ::openvm_circuit::arch::execution_mode::metered::MeteredCtx>,
+                        state: &mut ::openvm_circuit::arch::VmStateMut<F, ::openvm_circuit::system::memory::online::GuestMemory, ::openvm_circuit::arch::execution_mode::metered::MeteredCtx>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<#first_ty_generic>,
                         chip_index: usize,
                     ) -> ::openvm_circuit::arch::Result<()> {

--- a/crates/vm/src/arch/execution_control.rs
+++ b/crates/vm/src/arch/execution_control.rs
@@ -21,28 +21,28 @@ where
     /// Determines if execution should suspend
     fn should_suspend(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> bool;
 
     /// Called before execution begins
     fn on_start(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     );
 
     /// Called after suspend or terminate
     fn on_suspend_or_terminate(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         exit_code: Option<u32>,
     );
 
     fn on_suspend(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) {
         self.on_suspend_or_terminate(state, chip_complex, None);
@@ -50,7 +50,7 @@ where
 
     fn on_terminate(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         exit_code: u32,
     ) {
@@ -61,7 +61,7 @@ where
     // TODO(ayush): change instruction to Instruction<u32> / PInstruction
     fn execute_instruction(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>

--- a/crates/vm/src/arch/execution_mode/e1.rs
+++ b/crates/vm/src/arch/execution_mode/e1.rs
@@ -32,7 +32,7 @@ where
 
     fn should_suspend(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         _chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> bool {
         if let Some(clk_end) = self.clk_end {
@@ -44,14 +44,14 @@ where
 
     fn on_start(
         &self,
-        _state: &mut VmSegmentState<Self::Ctx>,
+        _state: &mut VmSegmentState<F, Self::Ctx>,
         _chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) {
     }
 
     fn on_suspend_or_terminate(
         &self,
-        _state: &mut VmSegmentState<Self::Ctx>,
+        _state: &mut VmSegmentState<F, Self::Ctx>,
         _chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         _exit_code: Option<u32>,
     ) {
@@ -60,7 +60,7 @@ where
     /// Execute a single instruction
     fn execute_instruction(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -73,6 +73,7 @@ where
             let mut vm_state = VmStateMut {
                 pc: &mut state.pc,
                 memory: state.memory.as_mut().unwrap(),
+                streams: &mut state.streams,
                 ctx: &mut state.ctx,
             };
             executor.execute_e1(&mut vm_state, instruction)?;

--- a/crates/vm/src/arch/execution_mode/tracegen/normal.rs
+++ b/crates/vm/src/arch/execution_mode/tracegen/normal.rs
@@ -36,7 +36,7 @@ where
 
     fn should_suspend(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         _chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> bool {
         state.clk >= self.clk_end
@@ -44,7 +44,7 @@ where
 
     fn on_start(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) {
         chip_complex
@@ -54,7 +54,7 @@ where
 
     fn on_suspend_or_terminate(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         exit_code: Option<u32>,
     ) {
@@ -67,7 +67,7 @@ where
     /// Execute a single instruction
     fn execute_instruction(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -82,6 +82,7 @@ where
             let memory_controller = &mut chip_complex.base.memory_controller;
             let new_state = executor.execute(
                 memory_controller,
+                &mut state.streams,
                 instruction,
                 ExecutionState::new(state.pc, timestamp),
             )?;

--- a/crates/vm/src/arch/execution_mode/tracegen/segmentation.rs
+++ b/crates/vm/src/arch/execution_mode/tracegen/segmentation.rs
@@ -7,7 +7,7 @@ use crate::{
         execution_control::ExecutionControl, ExecutionError, ExecutionState, InstructionExecutor,
         VmChipComplex, VmConfig, VmSegmentState,
     },
-    system::memory::{MemoryImage, INITIAL_TIMESTAMP},
+    system::memory::INITIAL_TIMESTAMP,
 };
 
 /// Check segment every 100 instructions.
@@ -40,7 +40,7 @@ where
     }
     fn should_suspend(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> bool {
         // Avoid checking segment too often.
@@ -58,7 +58,7 @@ where
 
     fn on_start(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) {
         chip_complex
@@ -68,7 +68,7 @@ where
 
     fn on_suspend_or_terminate(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
         exit_code: Option<u32>,
     ) {
@@ -81,7 +81,7 @@ where
     /// Execute a single instruction
     fn execute_instruction(
         &self,
-        state: &mut VmSegmentState<Self::Ctx>,
+        state: &mut VmSegmentState<F, Self::Ctx>,
         instruction: &Instruction<F>,
         chip_complex: &mut VmChipComplex<F, VC::Executor, VC::Periphery>,
     ) -> Result<(), ExecutionError>
@@ -96,6 +96,7 @@ where
             let memory_controller = &mut chip_complex.base.memory_controller;
             let new_state = executor.execute(
                 memory_controller,
+                &mut state.streams,
                 instruction,
                 ExecutionState::new(state.pc, timestamp),
             )?;

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -13,31 +13,38 @@ use openvm_stark_backend::{
     Chip,
 };
 
+#[cfg(feature = "bench-metrics")]
+use super::InstructionExecutor;
 use super::{
-    execution_control::ExecutionControl, ExecutionError, GenerationError, SystemConfig,
+    execution_control::ExecutionControl, ExecutionError, GenerationError, Streams, SystemConfig,
     VmChipComplex, VmComplexTraceHeights, VmConfig,
 };
 #[cfg(feature = "bench-metrics")]
 use crate::metrics::VmMetrics;
-use crate::{
-    arch::{instructions::*, InstructionExecutor},
-    system::memory::online::GuestMemory,
-};
+use crate::{arch::instructions::*, system::memory::online::GuestMemory};
 
-pub struct VmSegmentState<Ctx> {
+pub struct VmSegmentState<F, Ctx> {
     pub clk: u64,
     pub pc: u32,
     pub memory: Option<GuestMemory>,
+    pub streams: Streams<F>,
     pub exit_code: Option<u32>,
     pub ctx: Ctx,
 }
 
-impl<Ctx> VmSegmentState<Ctx> {
-    pub fn new(clk: u64, pc: u32, memory: Option<GuestMemory>, ctx: Ctx) -> Self {
+impl<F, Ctx> VmSegmentState<F, Ctx> {
+    pub fn new(
+        clk: u64,
+        pc: u32,
+        memory: Option<GuestMemory>,
+        streams: Streams<F>,
+        ctx: Ctx,
+    ) -> Self {
         Self {
             clk,
             pc,
             memory,
+            streams,
             ctx,
             exit_code: None,
         }
@@ -105,7 +112,7 @@ where
     /// Stopping is triggered by should_stop() or if VM is terminated
     pub fn execute_from_state(
         &mut self,
-        state: &mut VmSegmentState<Ctrl::Ctx>,
+        state: &mut VmSegmentState<F, Ctrl::Ctx>,
     ) -> Result<(), ExecutionError> {
         let mut prev_backtrace: Option<Backtrace> = None;
 
@@ -133,7 +140,7 @@ where
     // TODO(ayush): clean this up, separate to smaller functions
     fn execute_instruction(
         &mut self,
-        state: &mut VmSegmentState<Ctrl::Ctx>,
+        state: &mut VmSegmentState<F, Ctrl::Ctx>,
         prev_backtrace: &mut Option<Backtrace>,
     ) -> Result<(), ExecutionError> {
         let pc = state.pc;
@@ -208,7 +215,7 @@ where
     }
 
     /// Returns bool of whether to switch to next segment or not.
-    fn should_suspend(&mut self, state: &mut VmSegmentState<Ctrl::Ctx>) -> bool {
+    fn should_suspend(&mut self, state: &mut VmSegmentState<F, Ctrl::Ctx>) -> bool {
         if !self.system_config().continuation_enabled {
             return false;
         }

--- a/crates/vm/src/system/memory/offline_checker/columns.rs
+++ b/crates/vm/src/system/memory/offline_checker/columns.rs
@@ -1,8 +1,6 @@
 //! Defines auxiliary columns for memory operations: `MemoryReadAuxCols`,
 //! `MemoryReadWithImmediateAuxCols`, and `MemoryWriteAuxCols`.
 
-use std::ops::DerefMut;
-
 use openvm_circuit_primitives::is_less_than::LessThanAuxCols;
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::p3_field::PrimeField32;

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -7,7 +7,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    adapter::{AccessAdapterInventory, AdapterInventoryTraceCursor},
+    adapter::AccessAdapterInventory,
     offline_checker::MemoryBus,
     paged_vec::{AddressMap, PAGE_SIZE},
     Address, MemoryAddress, PagedVec,

--- a/crates/vm/src/system/memory/paged_vec.rs
+++ b/crates/vm/src/system/memory/paged_vec.rs
@@ -1,10 +1,4 @@
-use std::{
-    alloc::{alloc, Layout},
-    fmt::Debug,
-    marker::PhantomData,
-    mem::MaybeUninit,
-    ptr,
-};
+use std::{fmt::Debug, marker::PhantomData, mem::MaybeUninit, ptr};
 
 use itertools::{zip_eq, Itertools};
 use openvm_instructions::exe::SparseMemoryImage;

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -279,7 +279,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -312,7 +312,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/crates/vm/src/system/phantom/tests.rs
+++ b/crates/vm/src/system/phantom/tests.rs
@@ -1,5 +1,3 @@
-use std::sync::{Arc, Mutex};
-
 use openvm_instructions::{instruction::Instruction, SystemOpcode};
 use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
@@ -16,7 +14,6 @@ fn test_nops_and_terminate() {
         tester.program_bus(),
         SystemOpcode::CLASS_OFFSET,
     );
-    chip.set_streams(Arc::new(Mutex::new(Default::default())));
 
     let nop = Instruction::from_isize(SystemOpcode::PHANTOM.global_opcode(), 0, 0, 0, 0, 0);
     let mut state: ExecutionState<F> = ExecutionState::new(F::ZERO, F::ONE);

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -164,7 +164,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -232,7 +232,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -260,7 +260,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -719,13 +719,8 @@ fn test_hint_load_1() {
 
     let program = Program::from_instructions(&instructions);
 
-    let chip_complex = create_and_initialize_chip_complex(
-        &test_native_config(),
-        program,
-        vec![vec![F::ONE, F::TWO]].into(),
-        None,
-    )
-    .unwrap();
+    let chip_complex =
+        create_and_initialize_chip_complex(&test_native_config(), program, None).unwrap();
     let ctrl = TracegenExecutionControlWithSegmentation::new(chip_complex.air_names());
     let ctx = ExecutionControl::<F, NativeConfig>::initialize_context(&ctrl);
     let mut segment = VmSegmentExecutor::<F, NativeConfig, _>::new(
@@ -735,10 +730,10 @@ fn test_hint_load_1() {
         ctrl,
     );
 
-    let mut exec_state = VmSegmentState::new(0, 0, None, ctx);
+    let mut exec_state = VmSegmentState::new(0, 0, None, vec![vec![F::ONE, F::TWO]].into(), ctx);
     segment.execute_from_state(&mut exec_state).unwrap();
 
-    let streams = segment.chip_complex.take_streams();
+    let streams = exec_state.streams;
     assert!(streams.input_stream.is_empty());
     assert_eq!(streams.hint_stream, VecDeque::from(vec![F::ZERO]));
     assert_eq!(streams.hint_space, vec![vec![F::ONE, F::TWO]]);
@@ -766,13 +761,8 @@ fn test_hint_load_2() {
 
     let program = Program::from_instructions(&instructions);
 
-    let chip_complex = create_and_initialize_chip_complex(
-        &test_native_config(),
-        program,
-        vec![vec![F::ONE, F::TWO], vec![F::TWO, F::ONE]].into(),
-        None,
-    )
-    .unwrap();
+    let chip_complex =
+        create_and_initialize_chip_complex(&test_native_config(), program, None).unwrap();
     let ctrl = TracegenExecutionControlWithSegmentation::new(chip_complex.air_names());
     let ctx = ExecutionControl::<F, NativeConfig>::initialize_context(&ctrl);
     let mut segment = VmSegmentExecutor::<F, NativeConfig, _>::new(
@@ -782,7 +772,13 @@ fn test_hint_load_2() {
         ctrl,
     );
 
-    let mut exec_state = VmSegmentState::new(0, 0, None, ctx);
+    let mut exec_state = VmSegmentState::new(
+        0,
+        0,
+        None,
+        vec![vec![F::ONE, F::TWO], vec![F::TWO, F::ONE]].into(),
+        ctx,
+    );
     segment.execute_from_state(&mut exec_state).unwrap();
 
     let [read] = unsafe {
@@ -794,7 +790,7 @@ fn test_hint_load_2() {
             .read::<F, 1>(4, 32)
     };
     assert_eq!(read, F::ZERO);
-    let streams = segment.chip_complex.take_streams();
+    let streams = exec_state.streams;
     assert!(streams.input_stream.is_empty());
     assert_eq!(streams.hint_stream, VecDeque::from(vec![F::ONE]));
     assert_eq!(

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -311,7 +311,7 @@ where
 {
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -425,7 +425,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -463,7 +463,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -94,7 +94,7 @@ impl KeccakVmStep {
 impl<F: PrimeField32> StepExecutorE1<F> for KeccakVmStep {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -125,7 +125,8 @@ impl<F: PrimeField32> StepExecutorE1<F> for KeccakVmStep {
         // TODO(ayush): read in a single call
         let mut message = Vec::with_capacity(len as usize);
         for offset in (0..len as usize).step_by(KECCAK_WORD_SIZE) {
-            let read = memory_read_from_state::<_, KECCAK_WORD_SIZE>(state, e, src + offset as u32);
+            let read =
+                memory_read_from_state::<F, _, KECCAK_WORD_SIZE>(state, e, src + offset as u32);
             let copy_len = std::cmp::min(KECCAK_WORD_SIZE, (len as usize) - offset);
             message.extend_from_slice(&read[..copy_len]);
         }
@@ -142,7 +143,7 @@ impl<F: PrimeField32> StepExecutorE1<F> for KeccakVmStep {
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {
@@ -170,7 +171,8 @@ impl<F: PrimeField32> StepExecutorE1<F> for KeccakVmStep {
 
         let mut message = Vec::with_capacity(len as usize);
         for offset in (0..len as usize).step_by(KECCAK_WORD_SIZE) {
-            let read = memory_read_from_state::<_, KECCAK_WORD_SIZE>(state, e, src + offset as u32);
+            let read =
+                memory_read_from_state::<F, _, KECCAK_WORD_SIZE>(state, e, src + offset as u32);
             let copy_len = std::cmp::min(KECCAK_WORD_SIZE, (len as usize) - offset);
             message.extend_from_slice(&read[..copy_len]);
         }
@@ -182,7 +184,7 @@ impl<F: PrimeField32> StepExecutorE1<F> for KeccakVmStep {
         hasher.finalize(&mut output);
 
         for (i, word) in output.chunks_exact(KECCAK_WORD_SIZE).enumerate() {
-            memory_write_from_state::<_, KECCAK_WORD_SIZE>(
+            memory_write_from_state::<F, _, KECCAK_WORD_SIZE>(
                 state,
                 e,
                 dst + (i * KECCAK_WORD_SIZE) as u32,

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -29,7 +29,7 @@ use crate::{columns::NUM_KECCAK_VM_COLS, utils::num_keccak_f, KeccakVmStep, KECC
 impl<F: PrimeField32, CTX> TraceStep<F, CTX> for KeccakVmStep {
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,

--- a/extensions/native/circuit/src/adapters/alu_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/alu_native_adapter.rs
@@ -244,7 +244,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -261,7 +261,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/native/circuit/src/adapters/branch_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/branch_native_adapter.rs
@@ -227,7 +227,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -244,7 +244,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        _state: &mut VmStateMut<GuestMemory, Ctx>,
+        _state: &mut VmStateMut<F, GuestMemory, Ctx>,
         _instruction: &Instruction<F>,
         _data: &Self::WriteData,
     ) {

--- a/extensions/native/circuit/src/adapters/convert_adapter.rs
+++ b/extensions/native/circuit/src/adapters/convert_adapter.rs
@@ -217,7 +217,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -233,7 +233,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -330,7 +330,7 @@ where
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -374,7 +374,7 @@ where
 
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/native/circuit/src/adapters/mod.rs
+++ b/extensions/native/circuit/src/adapters/mod.rs
@@ -53,7 +53,7 @@ where
 
 #[inline(always)]
 pub fn memory_read_native_from_state<Ctx, F, const N: usize>(
-    state: &mut VmStateMut<GuestMemory, Ctx>,
+    state: &mut VmStateMut<F, GuestMemory, Ctx>,
     ptr: u32,
 ) -> [F; N]
 where
@@ -69,7 +69,7 @@ where
 
 #[inline(always)]
 pub fn memory_read_or_imm_native_from_state<Ctx, F>(
-    state: &mut VmStateMut<GuestMemory, Ctx>,
+    state: &mut VmStateMut<F, GuestMemory, Ctx>,
     addr_space: u32,
     ptr_or_imm: F,
 ) -> F
@@ -89,7 +89,7 @@ where
 
 #[inline(always)]
 pub fn memory_write_native_from_state<Ctx, F, const N: usize>(
-    state: &mut VmStateMut<GuestMemory, Ctx>,
+    state: &mut VmStateMut<F, GuestMemory, Ctx>,
     ptr: u32,
     data: &[F; N],
 ) where

--- a/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
@@ -225,7 +225,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -245,7 +245,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/native/circuit/src/branch_eq/core.rs
+++ b/extensions/native/circuit/src/branch_eq/core.rs
@@ -53,7 +53,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -111,7 +111,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -140,7 +140,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -134,7 +134,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -200,7 +200,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -226,7 +226,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -102,7 +102,7 @@ impl<F: PrimeField32> VmExtension<F> for Native {
 
         let range_checker = &builder.system_base().range_checker_chip;
 
-        let mut load_store_chip = NativeLoadStoreChip::<F, 1>::new(
+        let load_store_chip = NativeLoadStoreChip::<F, 1>::new(
             VmAirWrapper::new(
                 NativeLoadStoreAdapterAir::new(
                     memory_bridge,
@@ -117,13 +117,12 @@ impl<F: PrimeField32> VmExtension<F> for Native {
             MAX_INS_CAPACITY,
             builder.system_base().memory_controller.helper(),
         );
-        load_store_chip.step.set_streams(builder.streams().clone());
         inventory.add_executor(
             load_store_chip,
             NativeLoadStoreOpcode::iter().map(|x| x.global_opcode()),
         )?;
 
-        let mut block_load_store_chip = NativeLoadStoreChip::<F, BLOCK_LOAD_STORE_SIZE>::new(
+        let block_load_store_chip = NativeLoadStoreChip::<F, BLOCK_LOAD_STORE_SIZE>::new(
             VmAirWrapper::new(
                 NativeLoadStoreAdapterAir::new(
                     memory_bridge,
@@ -138,9 +137,6 @@ impl<F: PrimeField32> VmExtension<F> for Native {
             MAX_INS_CAPACITY,
             builder.system_base().memory_controller.helper(),
         );
-        block_load_store_chip
-            .step
-            .set_streams(builder.streams().clone());
         inventory.add_executor(
             block_load_store_chip,
             NativeLoadStore4Opcode::iter().map(|x| x.global_opcode()),
@@ -224,7 +220,7 @@ impl<F: PrimeField32> VmExtension<F> for Native {
                 ExecutionBridge::new(execution_bus, program_bus),
                 memory_bridge,
             ),
-            FriReducedOpeningStep::new(builder.streams().clone()),
+            FriReducedOpeningStep::new(),
             MAX_INS_CAPACITY,
             builder.system_base().memory_controller.helper(),
         );
@@ -238,7 +234,6 @@ impl<F: PrimeField32> VmExtension<F> for Native {
             builder.system_port(),
             Poseidon2Config::default(),
             VerifyBatchBus::new(builder.new_bus_idx()),
-            builder.streams().clone(),
             // TODO: this may use too much memory.
             MAX_INS_CAPACITY,
             builder.system_base().memory_controller.helper(),

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -147,7 +147,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -209,7 +209,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -233,7 +233,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -174,7 +174,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -237,7 +237,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -265,7 +265,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/native/circuit/src/jal/mod.rs
+++ b/extensions/native/circuit/src/jal/mod.rs
@@ -174,7 +174,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -277,7 +277,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -330,7 +330,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/native/circuit/src/loadstore/mod.rs
+++ b/extensions/native/circuit/src/loadstore/mod.rs
@@ -12,7 +12,7 @@ use super::adapters::loadstore_native_adapter::{
 
 pub type NativeLoadStoreAir<const NUM_CELLS: usize> =
     VmAirWrapper<NativeLoadStoreAdapterAir<NUM_CELLS>, NativeLoadStoreCoreAir<NUM_CELLS>>;
-pub type NativeLoadStoreStep<F, const NUM_CELLS: usize> =
-    NativeLoadStoreCoreStep<NativeLoadStoreAdapterStep<NUM_CELLS>, F, NUM_CELLS>;
+pub type NativeLoadStoreStep<const NUM_CELLS: usize> =
+    NativeLoadStoreCoreStep<NativeLoadStoreAdapterStep<NUM_CELLS>, NUM_CELLS>;
 pub type NativeLoadStoreChip<F, const NUM_CELLS: usize> =
-    NewVmChipWrapper<F, NativeLoadStoreAir<NUM_CELLS>, NativeLoadStoreStep<F, NUM_CELLS>>;
+    NewVmChipWrapper<F, NativeLoadStoreAir<NUM_CELLS>, NativeLoadStoreStep<NUM_CELLS>>;

--- a/extensions/native/circuit/src/poseidon2/mod.rs
+++ b/extensions/native/circuit/src/poseidon2/mod.rs
@@ -1,7 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use openvm_circuit::{
-    arch::{ExecutionBridge, NewVmChipWrapper, Streams, SystemPort},
+    arch::{ExecutionBridge, NewVmChipWrapper, SystemPort},
     system::memory::SharedMemoryHelper,
 };
 use openvm_native_compiler::conversion::AS;
@@ -30,7 +30,6 @@ pub fn new_native_poseidon2_chip<F: PrimeField32, const SBOX_REGISTERS: usize>(
     port: SystemPort,
     poseidon2_config: Poseidon2Config<F>,
     verify_batch_bus: VerifyBatchBus,
-    streams: Arc<Mutex<Streams<F>>>,
     max_ins_capacity: usize,
     mem_helper: SharedMemoryHelper<F>,
 ) -> NativePoseidon2Chip<F, SBOX_REGISTERS> {
@@ -42,7 +41,7 @@ pub fn new_native_poseidon2_chip<F: PrimeField32, const SBOX_REGISTERS: usize>(
             subair: Arc::new(Poseidon2SubAir::new(poseidon2_config.constants.into())),
             address_space: F::from_canonical_u32(AS::Native as u32),
         },
-        NativePoseidon2Step::new(poseidon2_config, streams),
+        NativePoseidon2Step::new(poseidon2_config),
         max_ins_capacity,
         mem_helper,
     )

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -397,7 +397,7 @@ impl<
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -425,7 +425,7 @@ impl<
 
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/rv32-adapters/src/heap.rs
+++ b/extensions/rv32-adapters/src/heap.rs
@@ -174,7 +174,7 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize, const WRIT
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -186,7 +186,7 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize, const WRIT
 
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -294,7 +294,7 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterExe
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -322,7 +322,7 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterExe
 
     fn write<Ctx>(
         &self,
-        _state: &mut VmStateMut<GuestMemory, Ctx>,
+        _state: &mut VmStateMut<F, GuestMemory, Ctx>,
         _instruction: &Instruction<F>,
         _data: &Self::WriteData,
     ) where

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -466,7 +466,7 @@ impl<
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -496,7 +496,7 @@ impl<
 
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/rv32-adapters/src/vec_heap_two_reads.rs
+++ b/extensions/rv32-adapters/src/vec_heap_two_reads.rs
@@ -524,7 +524,7 @@ impl<
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -554,7 +554,7 @@ impl<
 
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -288,7 +288,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -318,7 +318,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         rd: &Self::WriteData,
     ) where

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -197,7 +197,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -219,7 +219,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        _state: &mut VmStateMut<GuestMemory, Ctx>,
+        _state: &mut VmStateMut<F, GuestMemory, Ctx>,
         _instruction: &Instruction<F>,
         _data: &Self::WriteData,
     ) where

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -246,7 +246,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -265,7 +265,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -566,7 +566,7 @@ where
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -630,7 +630,7 @@ where
 
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -98,8 +98,8 @@ pub fn memory_write<const N: usize>(
 }
 
 #[inline(always)]
-pub fn memory_read_from_state<Ctx, const N: usize>(
-    state: &mut VmStateMut<GuestMemory, Ctx>,
+pub fn memory_read_from_state<F, Ctx, const N: usize>(
+    state: &mut VmStateMut<F, GuestMemory, Ctx>,
     address_space: u32,
     ptr: u32,
 ) -> [u8; N]
@@ -112,8 +112,8 @@ where
 }
 
 #[inline(always)]
-pub fn memory_write_from_state<Ctx, const N: usize>(
-    state: &mut VmStateMut<GuestMemory, Ctx>,
+pub fn memory_write_from_state<F, Ctx, const N: usize>(
+    state: &mut VmStateMut<F, GuestMemory, Ctx>,
     address_space: u32,
     ptr: u32,
     data: &[u8; N],
@@ -243,8 +243,8 @@ pub fn new_read_rv32_register(memory: &GuestMemory, address_space: u32, ptr: u32
 // TODO(AG): if "register", why `address_space` is not hardcoded to be 1?
 // TODO(jpw): remove new_
 #[inline(always)]
-pub fn new_read_rv32_register_from_state<Ctx>(
-    state: &mut VmStateMut<GuestMemory, Ctx>,
+pub fn new_read_rv32_register_from_state<F, Ctx>(
+    state: &mut VmStateMut<F, GuestMemory, Ctx>,
     address_space: u32,
     ptr: u32,
 ) -> u32

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -230,7 +230,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -251,7 +251,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         rd: &Self::WriteData,
     ) where

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -267,7 +267,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        _state: &mut VmStateMut<GuestMemory, Ctx>,
+        _state: &mut VmStateMut<F, GuestMemory, Ctx>,
         _instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -278,7 +278,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         rd: &Self::WriteData,
     ) where
@@ -392,7 +392,7 @@ where
     #[inline(always)]
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -404,7 +404,7 @@ where
     #[inline(always)]
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         rd: &Self::WriteData,
     ) where

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -228,7 +228,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -312,7 +312,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -335,7 +335,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -210,7 +210,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -286,7 +286,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -307,7 +307,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -173,7 +173,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -230,7 +230,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -258,7 +258,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -236,7 +236,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -361,7 +361,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -387,7 +387,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -411,7 +411,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -545,7 +545,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -582,7 +582,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -582,7 +582,7 @@ impl<F: PrimeField32> VmExtension<F> for Rv32Io {
             chip
         };
 
-        let mut hintstore_chip = Rv32HintStoreChip::<F>::new(
+        let hintstore_chip = Rv32HintStoreChip::<F>::new(
             Rv32HintStoreAir::new(
                 ExecutionBridge::new(execution_bus, program_bus),
                 memory_bridge,
@@ -598,7 +598,6 @@ impl<F: PrimeField32> VmExtension<F> for Rv32Io {
             MAX_INS_CAPACITY,
             builder.system_base().memory_controller.helper(),
         );
-        hintstore_chip.step.set_streams(builder.streams().clone());
 
         inventory.add_executor(
             hintstore_chip,

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -183,7 +183,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -257,7 +257,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -292,7 +292,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -218,7 +218,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -334,7 +334,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -365,7 +365,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -207,7 +207,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -338,7 +338,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -365,7 +365,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -224,7 +224,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -317,7 +317,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -350,7 +350,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -296,7 +296,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -381,7 +381,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -409,7 +409,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -170,7 +170,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -237,7 +237,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -265,7 +265,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -244,7 +244,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -327,7 +327,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -353,7 +353,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -285,7 +285,7 @@ where
 
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,
@@ -400,7 +400,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -423,7 +423,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -76,7 +76,7 @@ impl Sha256VmStep {
 impl<F: PrimeField32> StepExecutorE1<F> for Sha256VmStep {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -107,7 +107,8 @@ impl<F: PrimeField32> StepExecutorE1<F> for Sha256VmStep {
         // TODO(ayush): read in a single call
         let mut message = Vec::with_capacity(len as usize);
         for offset in (0..len as usize).step_by(SHA256_READ_SIZE) {
-            let read = memory_read_from_state::<_, SHA256_READ_SIZE>(state, e, src + offset as u32);
+            let read =
+                memory_read_from_state::<F, _, SHA256_READ_SIZE>(state, e, src + offset as u32);
             let copy_len = std::cmp::min(SHA256_READ_SIZE, (len as usize) - offset);
             message.extend_from_slice(&read[..copy_len]);
         }
@@ -123,7 +124,7 @@ impl<F: PrimeField32> StepExecutorE1<F> for Sha256VmStep {
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {
@@ -155,7 +156,8 @@ impl<F: PrimeField32> StepExecutorE1<F> for Sha256VmStep {
 
         let mut message = Vec::with_capacity(len as usize);
         for offset in (0..len as usize).step_by(SHA256_READ_SIZE) {
-            let read = memory_read_from_state::<_, SHA256_READ_SIZE>(state, e, src + offset as u32);
+            let read =
+                memory_read_from_state::<F, _, SHA256_READ_SIZE>(state, e, src + offset as u32);
             let copy_len = std::cmp::min(SHA256_READ_SIZE, (len as usize) - offset);
             message.extend_from_slice(&read[..copy_len]);
         }

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -33,7 +33,7 @@ use crate::{
 impl<F: PrimeField32, CTX> TraceStep<F, CTX> for Sha256VmStep {
     fn execute(
         &mut self,
-        state: VmStateMut<TracingMemory<F>, CTX>,
+        state: VmStateMut<F, TracingMemory<F>, CTX>,
         instruction: &Instruction<F>,
         trace: &mut [F],
         trace_offset: &mut usize,


### PR DESCRIPTION
Previously some chips hold `Arc<Mutex<Streams>>` to read from `Streams`. Move `Streams` into `VmStateMut` so it has all data about VM state.