### PR TITLE
feat: optimize `Group::is_identity`

### DIFF
--- a/extensions/ecc/guest/src/weierstrass.rs
+++ b/extensions/ecc/guest/src/weierstrass.rs
@@ -471,6 +471,10 @@ macro_rules! impl_sw_group_ops {
             fn double_assign(&mut self) {
                 self.double_assign_impl::<true>();
             }
+
+            fn is_identity(&self) -> bool {
+                self == &<Self as Group>::IDENTITY
+            }
         }
 
         impl core::ops::Add<&$struct_name> for $struct_name {


### PR DESCRIPTION
For some reason, the cycle count on ecrecover benchmark halves when the `Group::is_identity` default implementation is overridden (even when overridden with the same code as the default implementation). My guess is the compiler refuses to inline the default implementation for some reason.