### PR TITLE
docs: Add comment explaining the `is_identity` optimization

### DIFF
--- a/extensions/ecc/guest/src/weierstrass.rs
+++ b/extensions/ecc/guest/src/weierstrass.rs
@@ -463,6 +463,11 @@ macro_rules! impl_sw_group_ops {
                 self.double_assign_impl::<true>();
             }
 
+            // This implementation is the same as the default implementation in the `Group` trait,
+            // but it was found that overriding the default implementation reduced the cycle count 
+            // by 50% on the ecrecover benchmark.
+            // We hypothesize that this is due to compiler optimizations that are not possible when
+            // the `is_identity` function is defined in a different source file.
             fn is_identity(&self) -> bool {
                 self == &<Self as Group>::IDENTITY
             }

--- a/extensions/ecc/guest/src/weierstrass.rs
+++ b/extensions/ecc/guest/src/weierstrass.rs
@@ -464,7 +464,7 @@ macro_rules! impl_sw_group_ops {
             }
 
             // This implementation is the same as the default implementation in the `Group` trait,
-            // but it was found that overriding the default implementation reduced the cycle count 
+            // but it was found that overriding the default implementation reduced the cycle count
             // by 50% on the ecrecover benchmark.
             // We hypothesize that this is due to compiler optimizations that are not possible when
             // the `is_identity` function is defined in a different source file.


### PR DESCRIPTION
A recent PR (#1709) introduced the optimization of overriding the default implementation of `Group::is_identity` in the `impl_sw_group_ops` macro. The overridden implementation was identical to the default one. This PR adds a comment to explain the code duplication.