### PR TITLE
fix(sw-macro): host `set_up_once` undefined

### DIFF
--- a/extensions/ecc/sw-macros/src/lib.rs
+++ b/extensions/ecc/sw-macros/src/lib.rs
@@ -202,6 +202,11 @@ pub fn sw_declare(input: TokenStream) -> TokenStream {
                     });
                 }
 
+                #[cfg(not(target_os = "zkvm"))]
+                fn set_up_once() {
+                    // No-op for non-ZKVM targets
+                }
+
                 fn is_identity_impl<const CHECK_SETUP: bool>(&self) -> bool {
                     use openvm_algebra_guest::IntMod;
                     // Safety: Self::set_up_once() ensures IntMod::set_up_once() has been called.


### PR DESCRIPTION
When the `sw-macro` generated struct is compiled for host (`target_os != "zkvm"`), there is no `set_up_once()` function. Apparently the compiler didn't catch this and the trait implementation of `fn set_up_once { Self::set_up_once() }` becomes an infinite loop.