### PR TITLE
feat: Do not build a `BTreeMap` when we don't need to

### DIFF
--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -1,7 +1,6 @@
 use openvm_stark_backend::{interaction::PermutationCheckBus, p3_field::PrimeField32};
-use rustc_hash::FxHashSet;
 
-use super::{controller::dimensions::MemoryDimensions, Equipartition, MemoryImage};
+use super::{controller::dimensions::MemoryDimensions, MemoryImage};
 mod air;
 mod columns;
 mod trace;
@@ -17,7 +16,6 @@ pub(super) use trace::SerialReceiver;
 
 pub struct MemoryMerkleChip<const CHUNK: usize, F> {
     pub air: MemoryMerkleAir<CHUNK>,
-    touched_nodes: FxHashSet<(usize, u32, u32)>,
     final_state: Option<FinalState<CHUNK, F>>,
     // TODO(AG): how are these two different? Doesn't one just end up being copied to the other?
     trace_height: Option<usize>,
@@ -40,15 +38,12 @@ impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
     ) -> Self {
         assert!(memory_dimensions.as_height > 0);
         assert!(memory_dimensions.address_height > 0);
-        let mut touched_nodes = FxHashSet::default();
-        touched_nodes.insert((memory_dimensions.overall_height(), 0, 0));
         Self {
             air: MemoryMerkleAir {
                 memory_dimensions,
                 merkle_bus,
                 compression_bus,
             },
-            touched_nodes,
             final_state: None,
             trace_height: None,
             overridden_height: None,
@@ -59,16 +54,20 @@ impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
     }
 }
 
-fn memory_to_partition<F: PrimeField32, const N: usize>(
+fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
     memory: &MemoryImage,
-) -> Equipartition<F, N> {
-    let mut memory_partition = Equipartition::new();
+    md: &MemoryDimensions,
+) -> Vec<(u64, [F; N])> {
+    let mut memory_partition = Vec::new();
     for ((address_space, pointer), value) in memory.items() {
-        let label = (address_space, pointer / N as u32);
-        let chunk = memory_partition
-            .entry(label)
-            .or_insert_with(|| [F::default(); N]);
-        chunk[(pointer % N as u32) as usize] = value;
+        let label = md.label_to_index((address_space, pointer / N as u32));
+        if memory_partition
+            .last()
+            .is_none_or(|(last_label, _)| *last_label < label)
+        {
+            memory_partition.push((label, [F::ZERO; N]));
+        }
+        memory_partition.last_mut().unwrap().1[(pointer % N as u32) as usize] = value;
     }
     memory_partition
 }


### PR DESCRIPTION
Reth 21000000 tracegen [8.5](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/main/reth-b0d199966a0fb8aa4291bb898eb0ff7e1e721e75-fed5988df0993a3c5d0456cee0859ea17aacab67004fa00ee1a04f807143bb1a.md) -> [7.4](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/main/reth-33b8740cda3bb42b88c936c1b3ffa31e174c022b-dd1b108a50ec92cb6c91ff4b8e25fa58a5cd4628f28487650c8f9774eef505d1.md)