### PR TITLE
refactor: make adapter width constant + single struct for record arena

### DIFF
--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -301,7 +301,7 @@ where
             WriteData: From<DynArray<u8>>,
         >,
 {
-    type RecordLayout = AdapterCoreLayout<FieldExpressionMetadata>;
+    type RecordLayout = AdapterCoreLayout<A, FieldExpressionMetadata>;
     type RecordMut<'a> = (A::RecordMut<'a>, FieldExpressionCoreRecordMut<'a>);
 
     fn execute<'buf, RA>(
@@ -317,10 +317,8 @@ where
             total_input_limbs: self.num_inputs() * self.expr.canonical_num_limbs(),
         };
 
-        let (mut adapter_record, mut core_record) = arena.alloc(AdapterCoreLayout::with_metadata(
-            A::WIDTH,
-            core_record_metadata,
-        ));
+        let (mut adapter_record, mut core_record) =
+            arena.alloc(AdapterCoreLayout::with_metadata(core_record_metadata));
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -20,8 +20,8 @@ use crate::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
         AdapterAirContext, AdapterExecutorE1, AdapterTraceStep, BasicAdapterInterface, EmptyLayout,
-        MinimalInstruction, RecordArena, Result, RowMajorMatrixArena, StepExecutorE1, TraceFiller,
-        TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        MatrixRecordArena, MinimalInstruction, RecordArena, Result, RowMajorMatrixArena,
+        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::{
         memory::online::{GuestMemory, TracingMemory},
@@ -155,7 +155,7 @@ where
             RecordMut<'a> = (),
         >,
 {
-    type RecordLayout = EmptyLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (); // TODO
 
     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -280,8 +280,8 @@ pub struct PublicValuesRecordArena<F> {
     pub trace_offset: usize,
 }
 
-impl<'a, F: PrimeField32> RecordArena<'a, EmptyLayout, ()> for PublicValuesRecordArena<F> {
-    fn alloc(&'a mut self, layout: EmptyLayout) -> () {
+impl<'a, A, F: PrimeField32> RecordArena<'a, EmptyLayout<A>, ()> for PublicValuesRecordArena<F> {
+    fn alloc(&'a mut self, layout: EmptyLayout<A>) -> () {
         todo!()
     }
 }

--- a/extensions/algebra/circuit/src/fp2_chip/mod.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/mod.rs
@@ -3,7 +3,7 @@ pub use addsub::*;
 
 mod muldiv;
 pub use muldiv::*;
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 use openvm_mod_circuit_builder::{FieldExpressionCoreAir, FieldExpressionStep};
 use openvm_rv32_adapters::{Rv32VecHeapAdapterAir, Rv32VecHeapAdapterStep};
 
@@ -19,5 +19,5 @@ pub(crate) type Fp2Chip<F, const BLOCKS: usize, const BLOCK_SIZE: usize> = NewVm
     F,
     Fp2Air<BLOCKS, BLOCK_SIZE>,
     Fp2Step<BLOCKS, BLOCK_SIZE>,
-    AdapterCoreRecordArena<F>,
+    MatrixRecordArena<F>,
 >;

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -8,9 +8,9 @@ use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, MinimalInstruction, RecordArena, Result, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -317,7 +317,7 @@ where
             WriteData: From<[u8; WRITE_LIMBS]>,
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut ModularIsEqualRecord<READ_LIMBS>);
 
     fn execute<'buf, RA>(
@@ -338,7 +338,7 @@ where
             Rv32ModularArithmeticOpcode::IS_EQ | Rv32ModularArithmeticOpcode::SETUP_ISEQ
         );
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
         [core_record.b, core_record.c] = self

--- a/extensions/algebra/circuit/src/modular_chip/mod.rs
+++ b/extensions/algebra/circuit/src/modular_chip/mod.rs
@@ -4,7 +4,7 @@ mod is_eq;
 pub use is_eq::*;
 mod muldiv;
 pub use muldiv::*;
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 use openvm_instructions::riscv::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use openvm_mod_circuit_builder::{FieldExpressionCoreAir, FieldExpressionStep};
 use openvm_rv32_adapters::{
@@ -27,7 +27,7 @@ pub(crate) type ModularChip<F, const BLOCKS: usize, const BLOCK_SIZE: usize> = N
     F,
     ModularAir<BLOCKS, BLOCK_SIZE>,
     ModularStep<BLOCKS, BLOCK_SIZE>,
-    AdapterCoreRecordArena<F>,
+    MatrixRecordArena<F>,
 >;
 
 // Must have TOTAL_LIMBS = NUM_LANES * LANE_SIZE
@@ -60,5 +60,5 @@ pub type ModularIsEqualChip<
     F,
     ModularIsEqualAir<NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
     VmModularIsEqualStep<NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
-    AdapterCoreRecordArena<F>,
+    MatrixRecordArena<F>,
 >;

--- a/extensions/bigint/circuit/src/lib.rs
+++ b/extensions/bigint/circuit/src/lib.rs
@@ -1,6 +1,6 @@
 use openvm_circuit::{
     self,
-    arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper},
+    arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper},
 };
 use openvm_rv32_adapters::{
     Rv32HeapAdapterAir, Rv32HeapAdapterStep, Rv32HeapBranchAdapterAir, Rv32HeapBranchAdapterStep,
@@ -29,7 +29,7 @@ pub type Rv32BaseAlu256Step = BaseAluStep<
     RV32_CELL_BITS,
 >;
 pub type Rv32BaseAlu256Chip<F> =
-    NewVmChipWrapper<F, Rv32BaseAlu256Air, Rv32BaseAlu256Step, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32BaseAlu256Air, Rv32BaseAlu256Step, MatrixRecordArena<F>>;
 
 /// LessThan256
 pub type Rv32LessThan256Air = VmAirWrapper<
@@ -42,7 +42,7 @@ pub type Rv32LessThan256Step = LessThanStep<
     RV32_CELL_BITS,
 >;
 pub type Rv32LessThan256Chip<F> =
-    NewVmChipWrapper<F, Rv32LessThan256Air, Rv32LessThan256Step, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32LessThan256Air, Rv32LessThan256Step, MatrixRecordArena<F>>;
 
 /// Multiplication256
 pub type Rv32Multiplication256Air = VmAirWrapper<
@@ -54,12 +54,8 @@ pub type Rv32Multiplication256Step = MultiplicationStep<
     INT256_NUM_LIMBS,
     RV32_CELL_BITS,
 >;
-pub type Rv32Multiplication256Chip<F> = NewVmChipWrapper<
-    F,
-    Rv32Multiplication256Air,
-    Rv32Multiplication256Step,
-    AdapterCoreRecordArena<F>,
->;
+pub type Rv32Multiplication256Chip<F> =
+    NewVmChipWrapper<F, Rv32Multiplication256Air, Rv32Multiplication256Step, MatrixRecordArena<F>>;
 
 /// Shift256
 pub type Rv32Shift256Air = VmAirWrapper<
@@ -72,7 +68,7 @@ pub type Rv32Shift256Step = ShiftStep<
     RV32_CELL_BITS,
 >;
 pub type Rv32Shift256Chip<F> =
-    NewVmChipWrapper<F, Rv32Shift256Air, Rv32Shift256Step, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32Shift256Air, Rv32Shift256Step, MatrixRecordArena<F>>;
 
 /// BranchEqual256
 pub type Rv32BranchEqual256Air = VmAirWrapper<
@@ -82,7 +78,7 @@ pub type Rv32BranchEqual256Air = VmAirWrapper<
 pub type Rv32BranchEqual256Step =
     BranchEqualStep<Rv32HeapBranchAdapterStep<2, INT256_NUM_LIMBS>, INT256_NUM_LIMBS>;
 pub type Rv32BranchEqual256Chip<F> =
-    NewVmChipWrapper<F, Rv32BranchEqual256Air, Rv32BranchEqual256Step, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32BranchEqual256Air, Rv32BranchEqual256Step, MatrixRecordArena<F>>;
 
 /// BranchLessThan256
 pub type Rv32BranchLessThan256Air = VmAirWrapper<
@@ -94,9 +90,5 @@ pub type Rv32BranchLessThan256Step = BranchLessThanStep<
     INT256_NUM_LIMBS,
     RV32_CELL_BITS,
 >;
-pub type Rv32BranchLessThan256Chip<F> = NewVmChipWrapper<
-    F,
-    Rv32BranchLessThan256Air,
-    Rv32BranchLessThan256Step,
-    AdapterCoreRecordArena<F>,
->;
+pub type Rv32BranchLessThan256Chip<F> =
+    NewVmChipWrapper<F, Rv32BranchLessThan256Air, Rv32BranchLessThan256Step, MatrixRecordArena<F>>;

--- a/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/mod.rs
@@ -7,7 +7,7 @@ pub use double::*;
 #[cfg(test)]
 mod tests;
 
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 use openvm_mod_circuit_builder::{FieldExpressionCoreAir, FieldExpressionStep};
 use openvm_rv32_adapters::{Rv32VecHeapAdapterAir, Rv32VecHeapAdapterStep};
 
@@ -35,5 +35,5 @@ pub(crate) type WeierstrassChip<
     F,
     WeierstrassAir<NUM_READS, BLOCKS, BLOCK_SIZE>,
     WeierstrassStep<NUM_READS, BLOCKS, BLOCK_SIZE>,
-    AdapterCoreRecordArena<F>,
+    MatrixRecordArena<F>,
 >;

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -6,8 +6,8 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, ImmInstruction, RecordArena, Result, StepExecutorE1,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, ImmInstruction, RecordArena, Result, StepExecutorE1,
         TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
@@ -211,10 +211,9 @@ pub struct Rv32AuipcStep<A> {
 impl<F, CTX, A> TraceStep<F, CTX> for Rv32AuipcStep<A>
 where
     F: PrimeField32,
-    A: 'static
-        + for<'a> AdapterTraceStep<F, CTX, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
+    A: 'static + AdapterTraceStep<F, CTX, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut Rv32AuipcCoreRecord);
 
     fn get_opcode_name(&self, _: usize) -> String {
@@ -230,7 +229,7 @@ where
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
     {
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/auipc/mod.rs
+++ b/extensions/rv32im/circuit/src/auipc/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use crate::adapters::{Rv32RdWriteAdapterAir, Rv32RdWriteAdapterStep};
 
@@ -11,4 +11,4 @@ mod tests;
 pub type Rv32AuipcAir = VmAirWrapper<Rv32RdWriteAdapterAir, Rv32AuipcCoreAir>;
 pub type Rv32AuipcStepWithAdapter = Rv32AuipcStep<Rv32RdWriteAdapterStep>;
 pub type Rv32AuipcChip<F> =
-    NewVmChipWrapper<F, Rv32AuipcAir, Rv32AuipcStepWithAdapter, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32AuipcAir, Rv32AuipcStepWithAdapter, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -7,9 +7,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, MinimalInstruction, RecordArena, Result, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -202,7 +202,7 @@ where
         >,
 {
     /// Instructions that use one trace row per instruction have implicit layout
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut BaseAluCoreRecord<NUM_LIMBS>);
 
     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -221,7 +221,7 @@ where
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = BaseAluOpcode::from_usize(opcode.local_opcode_idx(self.offset));
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/base_alu/mod.rs
+++ b/extensions/rv32im/circuit/src/base_alu/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{
     Rv32BaseAluAdapterAir, Rv32BaseAluAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
@@ -15,4 +15,4 @@ pub type Rv32BaseAluAir =
 pub type Rv32BaseAluStep =
     BaseAluStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32BaseAluChip<F> =
-    NewVmChipWrapper<F, Rv32BaseAluAir, Rv32BaseAluStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32BaseAluAir, Rv32BaseAluStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -3,8 +3,8 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, ImmInstruction, RecordArena, Result, StepExecutorE1,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, ImmInstruction, RecordArena, Result, StepExecutorE1,
         TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
@@ -159,7 +159,7 @@ where
     A: 'static
         + for<'a> AdapterTraceStep<F, CTX, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut BranchEqualCoreRecord<NUM_LIMBS>);
 
     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -179,7 +179,7 @@ where
 
         let branch_eq_opcode = BranchEqualOpcode::from_usize(opcode.local_opcode_idx(self.offset));
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/branch_eq/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
 use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep};
@@ -13,4 +13,4 @@ pub type Rv32BranchEqualAir =
     VmAirWrapper<Rv32BranchAdapterAir, BranchEqualCoreAir<RV32_REGISTER_NUM_LIMBS>>;
 pub type Rv32BranchEqualStep = BranchEqualStep<Rv32BranchAdapterStep, RV32_REGISTER_NUM_LIMBS>;
 pub type Rv32BranchEqualChip<F> =
-    NewVmChipWrapper<F, Rv32BranchEqualAir, Rv32BranchEqualStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32BranchEqualAir, Rv32BranchEqualStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -3,8 +3,8 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, ImmInstruction, RecordArena, Result, StepExecutorE1,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, ImmInstruction, RecordArena, Result, StepExecutorE1,
         TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
@@ -214,7 +214,7 @@ where
     A: 'static
         + for<'a> AdapterTraceStep<F, CTX, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (
         A::RecordMut<'a>,
         &'a mut BranchLessThanCoreRecord<NUM_LIMBS, LIMB_BITS>,
@@ -238,7 +238,7 @@ where
     {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/branch_lt/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep};
@@ -16,4 +16,4 @@ pub type Rv32BranchLessThanAir = VmAirWrapper<
 pub type Rv32BranchLessThanStep =
     BranchLessThanStep<Rv32BranchAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32BranchLessThanChip<F> =
-    NewVmChipWrapper<F, Rv32BranchLessThanAir, Rv32BranchLessThanStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32BranchLessThanAir, Rv32BranchLessThanStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -8,9 +8,9 @@ use num_integer::Integer;
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, MinimalInstruction, RecordArena, Result, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -414,7 +414,7 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut DivRemCoreRecords<NUM_LIMBS>);
 
     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -432,7 +432,7 @@ where
     {
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/divrem/mod.rs
+++ b/extensions/rv32im/circuit/src/divrem/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterStep};
@@ -13,4 +13,4 @@ pub type Rv32DivRemAir =
     VmAirWrapper<Rv32MultAdapterAir, DivRemCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 pub type Rv32DivRemStep = DivRemStep<Rv32MultAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32DivRemChip<F> =
-    NewVmChipWrapper<F, Rv32DivRemAir, Rv32DivRemStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32DivRemAir, Rv32DivRemStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
         get_record_from_slice, CustomBorrow, ExecutionBridge, ExecutionError, ExecutionState,
-        MultiRowLayout, MultiRowRecordArena, NewVmChipWrapper, RecordArena, Result, StepExecutorE1,
+        MatrixRecordArena, MultiRowLayout, NewVmChipWrapper, RecordArena, Result, StepExecutorE1,
         Streams, TraceFiller, TraceStep, VmStateMut,
     },
     system::memory::{
@@ -674,4 +674,4 @@ where
 }
 
 pub type Rv32HintStoreChip<F> =
-    NewVmChipWrapper<F, Rv32HintStoreAir, Rv32HintStoreStep<F>, MultiRowRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32HintStoreAir, Rv32HintStoreStep<F>, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -3,8 +3,8 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, ImmInstruction, RecordArena, Result, StepExecutorE1,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, ImmInstruction, RecordArena, Result, StepExecutorE1,
         TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
@@ -167,7 +167,7 @@ where
     A: 'static
         + for<'a> AdapterTraceStep<F, CTX, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut Rv32JalLuiStepRecord);
 
     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -188,7 +188,7 @@ where
     {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/jal_lui/mod.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use crate::adapters::{Rv32CondRdWriteAdapterAir, Rv32CondRdWriteAdapterStep};
 
@@ -11,4 +11,4 @@ mod tests;
 pub type Rv32JalLuiAir = VmAirWrapper<Rv32CondRdWriteAdapterAir, Rv32JalLuiCoreAir>;
 pub type Rv32JalLuiStepWithAdapter = Rv32JalLuiStep<Rv32CondRdWriteAdapterStep>;
 pub type Rv32JalLuiChip<F> =
-    NewVmChipWrapper<F, Rv32JalLuiAir, Rv32JalLuiStepWithAdapter, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32JalLuiAir, Rv32JalLuiStepWithAdapter, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -6,9 +6,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, RecordArena, Result, SignedImmInstruction,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, RecordArena, Result, SignedImmInstruction, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -217,7 +217,7 @@ where
             WriteData = [u8; RV32_REGISTER_NUM_LIMBS],
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut Rv32JalrCoreRecord);
 
     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -243,7 +243,7 @@ where
             JALR as usize
         );
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/jalr/mod.rs
+++ b/extensions/rv32im/circuit/src/jalr/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use crate::adapters::{Rv32JalrAdapterAir, Rv32JalrAdapterStep};
 
@@ -11,4 +11,4 @@ mod tests;
 pub type Rv32JalrAir = VmAirWrapper<Rv32JalrAdapterAir, Rv32JalrCoreAir>;
 pub type Rv32JalrStepWithAdapter = Rv32JalrStep<Rv32JalrAdapterStep>;
 pub type Rv32JalrChip<F> =
-    NewVmChipWrapper<F, Rv32JalrAir, Rv32JalrStepWithAdapter, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32JalrAir, Rv32JalrStepWithAdapter, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -6,9 +6,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, MinimalInstruction, RecordArena, Result, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -197,7 +197,7 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (
         A::RecordMut<'a>,
         &'a mut LessThanCoreRecord<NUM_LIMBS, LIMB_BITS>,
@@ -219,7 +219,7 @@ where
         debug_assert!(LIMB_BITS <= 8);
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
         A::start(*state.pc, state.memory, &mut adapter_record);
 
         let [rs1, rs2] = self

--- a/extensions/rv32im/circuit/src/less_than/mod.rs
+++ b/extensions/rv32im/circuit/src/less_than/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{
     Rv32BaseAluAdapterAir, Rv32BaseAluAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
@@ -15,4 +15,4 @@ pub type Rv32LessThanAir =
 pub type Rv32LessThanStep =
     LessThanStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32LessThanChip<F> =
-    NewVmChipWrapper<F, Rv32LessThanAir, Rv32LessThanStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32LessThanAir, Rv32LessThanStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -6,9 +6,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, RecordArena, Result, StepExecutorE1, TraceFiller,
-        TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, RecordArena, Result, StepExecutorE1, TraceFiller, TraceStep,
+        VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -200,7 +200,7 @@ where
             WriteData = [u32; NUM_CELLS],
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (
         A::RecordMut<'a>,
         &'a mut LoadSignExtendCoreRecord<NUM_CELLS>,
@@ -228,7 +228,7 @@ where
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),
         );
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterStep};
@@ -16,4 +16,4 @@ pub type Rv32LoadSignExtendAir = VmAirWrapper<
 pub type Rv32LoadSignExtendStep =
     LoadSignExtendStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32LoadSignExtendChip<F> =
-    NewVmChipWrapper<F, Rv32LoadSignExtendAir, Rv32LoadSignExtendStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32LoadSignExtendAir, Rv32LoadSignExtendStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -6,9 +6,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, RecordArena, Result, StepExecutorE1, TraceFiller,
-        TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, RecordArena, Result, StepExecutorE1, TraceFiller, TraceStep,
+        VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -270,7 +270,7 @@ where
             WriteData = [u32; NUM_CELLS],
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut LoadStoreCoreRecord<NUM_CELLS>);
 
     fn get_opcode_name(&self, opcode: usize) -> String {
@@ -291,7 +291,7 @@ where
     {
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/loadstore/mod.rs
+++ b/extensions/rv32im/circuit/src/loadstore/mod.rs
@@ -2,7 +2,7 @@ mod core;
 
 pub use core::*;
 
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
 use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterStep};
@@ -14,4 +14,4 @@ pub type Rv32LoadStoreAir =
     VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<RV32_REGISTER_NUM_LIMBS>>;
 pub type Rv32LoadStoreStep = LoadStoreStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS>;
 pub type Rv32LoadStoreChip<F> =
-    NewVmChipWrapper<F, Rv32LoadStoreAir, Rv32LoadStoreStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32LoadStoreAir, Rv32LoadStoreStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -6,9 +6,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, MinimalInstruction, RecordArena, Result, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -174,7 +174,7 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (
         A::RecordMut<'a>,
         &'a mut MultiplicationCoreRecord<NUM_LIMBS, LIMB_BITS>,
@@ -199,7 +199,7 @@ where
             MulOpcode::from_usize(opcode.local_opcode_idx(self.offset)),
             MulOpcode::MUL
         );
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/mul/mod.rs
+++ b/extensions/rv32im/circuit/src/mul/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterStep};
@@ -16,4 +16,4 @@ pub type Rv32MultiplicationAir = VmAirWrapper<
 pub type Rv32MultiplicationStep =
     MultiplicationStep<Rv32MultAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32MultiplicationChip<F> =
-    NewVmChipWrapper<F, Rv32MultiplicationAir, Rv32MultiplicationStep, AdapterCoreRecordArena<F>>;
+    NewVmChipWrapper<F, Rv32MultiplicationAir, Rv32MultiplicationStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -6,9 +6,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, MinimalInstruction, RecordArena, Result, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -244,7 +244,7 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (
         A::RecordMut<'a>,
         &'a mut MulHCoreRecord<NUM_LIMBS, LIMB_BITS>,
@@ -268,7 +268,7 @@ where
     {
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/mulh/mod.rs
+++ b/extensions/rv32im/circuit/src/mulh/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterStep};
@@ -12,5 +12,4 @@ mod tests;
 pub type Rv32MulHAir =
     VmAirWrapper<Rv32MultAdapterAir, MulHCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 pub type Rv32MulHStep = MulHStep<Rv32MultAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32MulHChip<F> =
-    NewVmChipWrapper<F, Rv32MulHAir, Rv32MulHStep, AdapterCoreRecordArena<F>>;
+pub type Rv32MulHChip<F> = NewVmChipWrapper<F, Rv32MulHAir, Rv32MulHStep, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -6,9 +6,9 @@ use std::{
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterExecutorE1,
-        AdapterTraceFiller, AdapterTraceStep, MinimalInstruction, RecordArena, Result,
-        StepExecutorE1, TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
+        get_record_from_slice, AdapterAirContext, AdapterExecutorE1, AdapterTraceFiller,
+        AdapterTraceStep, EmptyLayout, MinimalInstruction, RecordArena, Result, StepExecutorE1,
+        TraceFiller, TraceStep, VmAdapterInterface, VmCoreAir, VmStateMut,
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
@@ -288,7 +288,7 @@ where
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
 {
-    type RecordLayout = AdapterCoreLayout;
+    type RecordLayout = EmptyLayout<A>;
     type RecordMut<'a> = (
         A::RecordMut<'a>,
         &'a mut ShiftCoreRecord<NUM_LIMBS, LIMB_BITS>,
@@ -311,7 +311,7 @@ where
 
         let local_opcode = ShiftOpcode::from_usize(opcode.local_opcode_idx(self.offset));
 
-        let (mut adapter_record, core_record) = arena.alloc(AdapterCoreLayout::new(A::WIDTH));
+        let (mut adapter_record, core_record) = arena.alloc(EmptyLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/rv32im/circuit/src/shift/mod.rs
+++ b/extensions/rv32im/circuit/src/shift/mod.rs
@@ -1,4 +1,4 @@
-use openvm_circuit::arch::{AdapterCoreRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 
 use super::adapters::{
     Rv32BaseAluAdapterAir, Rv32BaseAluAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
@@ -14,5 +14,4 @@ pub type Rv32ShiftAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 pub type Rv32ShiftStep =
     ShiftStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32ShiftChip<F> =
-    NewVmChipWrapper<F, Rv32ShiftAir, Rv32ShiftStep, AdapterCoreRecordArena<F>>;
+pub type Rv32ShiftChip<F> = NewVmChipWrapper<F, Rv32ShiftAir, Rv32ShiftStep, MatrixRecordArena<F>>;

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -4,7 +4,7 @@
 use openvm_circuit::{
     arch::{
         execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
-        MultiRowRecordArena, NewVmChipWrapper, Result, StepExecutorE1, VmStateMut,
+        MatrixRecordArena, NewVmChipWrapper, Result, StepExecutorE1, VmStateMut,
     },
     system::memory::online::GuestMemory,
 };
@@ -45,7 +45,7 @@ pub const SHA256_BLOCK_CELLS: usize = SHA256_BLOCK_BITS / RV32_CELL_BITS;
 /// Number of rows we will do a read on for each SHA256 block
 pub const SHA256_NUM_READ_ROWS: usize = SHA256_BLOCK_CELLS / SHA256_READ_SIZE;
 
-pub type Sha256VmChip<F> = NewVmChipWrapper<F, Sha256VmAir, Sha256VmStep, MultiRowRecordArena<F>>;
+pub type Sha256VmChip<F> = NewVmChipWrapper<F, Sha256VmAir, Sha256VmStep, MatrixRecordArena<F>>;
 
 pub struct Sha256VmStep {
     pub inner: Sha256StepHelper,


### PR DESCRIPTION
First, deleted the `AdapterCoreRecordArena` and `MultiRowRecordArena` struct and have a single `MatrixRecordArena` struct. Previously thought Rust doesn't allow multiple implementations of the same trait on a single struct. Turns out it allows as long as they are not conflicting with each other (ie the generics are strictly non-overlapping). In this PR I made 2 implementations of `RecordArena` trait one with `AdapterCoreLayout` and one with `MultiRowLayout`. 
Second, removed the `adapter_width` field from `AdapterCoreLayout`, instead added a generic `A` which is the `AdapterStep` struct and has the `A::WIDTH` constant. Initially, wanted to make it work with a const generic `ADAPTER_WIDTH` but couldn't because rust doesn't allow generics in const expressions.

