### PR TITLE
fix(ecc): checked `from_be_bytes`

### DIFF
--- a/benchmarks/guest/kitchen-sink/src/main.rs
+++ b/benchmarks/guest/kitchen-sink/src/main.rs
@@ -97,7 +97,7 @@ pub fn main() {
 
     let mut bytes = [0u8; 32];
     bytes[7] = 1 << 5; // 2^61 = modulus + 1
-    let mut res = Mersenne61::from_le_bytes(&bytes); // No need to start from reduced representation
+    let mut res = Mersenne61::from_le_bytes_unchecked(&bytes); // No need to start from reduced representation
     for _ in 0..61 {
         res += res.clone();
     }

--- a/benchmarks/guest/pairing/src/main.rs
+++ b/benchmarks/guest/pairing/src/main.rs
@@ -43,7 +43,7 @@ pub fn main() {
             // SAFETY: We're reading `6 * 32 == PAIR_ELEMENT_LEN` bytes from `input[idx..]`
             // per iteration. This is guaranteed to be in-bounds.
             let slice = unsafe { input.get_unchecked(start..start + 32) };
-            Fp::from_be_bytes(&slice[..32])
+            Fp::from_be_bytes_unchecked(&slice[..32])
         };
         // https://eips.ethereum.org/EIPS/eip-197, Fp2 is encoded as (a, b) where a * i + b
         let g1_x = read_fq_at(0);

--- a/book/src/custom-extensions/algebra.md
+++ b/book/src/custom-extensions/algebra.md
@@ -12,7 +12,7 @@ The functional part is provided by the `openvm-algebra-guest` crate, which is a 
   - `Repr` typically is `[u8; NUM_LIMBS]`, representing the number's underlying storage.
   - `MODULUS` is the compile-time known modulus.
   - `ZERO` and `ONE` represent the additive and multiplicative identities, respectively.
-  - Constructors include `from_repr`, `from_le_bytes`, `from_be_bytes`, `from_u8`, `from_u32`, and `from_u64`.
+  - Constructors include `from_repr`, `from_le_bytes`, `from_be_bytes`, `from_le_bytes_unchecked`, `from_be_bytes_unchecked`, `from_u8`, `from_u32`, and `from_u64`.
 
 - `Field` trait:
   Provides constants `ZERO` and `ONE` and methods for basic arithmetic operations within a field.

--- a/examples/ecc/src/main.rs
+++ b/examples/ecc/src/main.rs
@@ -22,13 +22,13 @@ openvm_ecc_guest::sw_macros::sw_init! {
 // ANCHOR: main
 pub fn main() {
     let x1 = Secp256k1Coord::from_u32(1);
-    let y1 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y1 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "EEA7767E580D75BC6FDD7F58D2A84C2614FB22586068DB63B346C6E60AF21842"
     ));
     let p1 = Secp256k1Point::from_xy_nonidentity(x1, y1).unwrap();
 
     let x2 = Secp256k1Coord::from_u32(2);
-    let y2 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y2 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "D1A847A8F879E0AEE32544DA5BA0B3BD1703A1F52867A5601FF6454DD8180499"
     ));
     let p2 = Secp256k1Point::from_xy_nonidentity(x2, y2).unwrap();

--- a/examples/pairing/src/main.rs
+++ b/examples/pairing/src/main.rs
@@ -27,31 +27,31 @@ openvm_algebra_complex_macros::complex_init! {
 // ANCHOR: main
 pub fn main() {
     let p0 = AffinePoint::new(
-        Fp::from_be_bytes(&hex!("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb")),
-        Fp::from_be_bytes(&hex!("08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"))
+        Fp::from_be_bytes_unchecked(&hex!("17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb")),
+        Fp::from_be_bytes_unchecked(&hex!("08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"))
     );
     let p1 = AffinePoint::new(
         Fp2::from_coeffs([
-            Fp::from_be_bytes(&hex!("1638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053")),
-            Fp::from_be_bytes(&hex!("0a4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c33577"))
+            Fp::from_be_bytes_unchecked(&hex!("1638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053")),
+            Fp::from_be_bytes_unchecked(&hex!("0a4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c33577"))
         ]),
         Fp2::from_coeffs([
-            Fp::from_be_bytes(&hex!("0468fb440d82b0630aeb8dca2b5256789a66da69bf91009cbfe6bd221e47aa8ae88dece9764bf3bd999d95d71e4c9899")),
-            Fp::from_be_bytes(&hex!("0f6d4552fa65dd2638b361543f887136a43253d9c66c411697003f7a13c308f5422e1aa0a59c8967acdefd8b6e36ccf3"))
+            Fp::from_be_bytes_unchecked(&hex!("0468fb440d82b0630aeb8dca2b5256789a66da69bf91009cbfe6bd221e47aa8ae88dece9764bf3bd999d95d71e4c9899")),
+            Fp::from_be_bytes_unchecked(&hex!("0f6d4552fa65dd2638b361543f887136a43253d9c66c411697003f7a13c308f5422e1aa0a59c8967acdefd8b6e36ccf3"))
         ]),
     );
     let q0 = AffinePoint::new(
-        Fp::from_be_bytes(&hex!("0572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4e")),
-        Fp::from_be_bytes(&hex!("166a9d8cabc673a322fda673779d8e3822ba3ecb8670e461f73bb9021d5fd76a4c56d9d4cd16bd1bba86881979749d28"))
+        Fp::from_be_bytes_unchecked(&hex!("0572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4e")),
+        Fp::from_be_bytes_unchecked(&hex!("166a9d8cabc673a322fda673779d8e3822ba3ecb8670e461f73bb9021d5fd76a4c56d9d4cd16bd1bba86881979749d28"))
     );
     let q1 = AffinePoint::new(
         Fp2::from_coeffs([
-            Fp::from_be_bytes(&hex!("024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8")),
-            Fp::from_be_bytes(&hex!("13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e"))
+            Fp::from_be_bytes_unchecked(&hex!("024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8")),
+            Fp::from_be_bytes_unchecked(&hex!("13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e"))
         ]),
         Fp2::from_coeffs([
-            Fp::from_be_bytes(&hex!("0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801")),
-            Fp::from_be_bytes(&hex!("0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be"))
+            Fp::from_be_bytes_unchecked(&hex!("0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801")),
+            Fp::from_be_bytes_unchecked(&hex!("0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be"))
         ]),
     );
 

--- a/extensions/algebra/guest/src/lib.rs
+++ b/extensions/algebra/guest/src/lib.rs
@@ -152,12 +152,20 @@ pub trait IntMod:
     fn from_repr(repr: Self::Repr) -> Self;
 
     /// Creates a new IntMod from an array of bytes, little endian.
+    /// Returns `None` if the integer value of `bytes` is greater than or equal to the modulus.
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self>;
+
+    /// Creates a new IntMod from an array of bytes, big endian.
+    /// Returns `None` if the integer value of `bytes` is greater than or equal to the modulus.
+    fn from_be_bytes(bytes: &[u8]) -> Option<Self>;
+
+    /// Creates a new IntMod from an array of bytes, little endian.
     /// Does not enforce the integer value of `bytes` must be less than the modulus.
-    fn from_le_bytes(bytes: &[u8]) -> Self;
+    fn from_le_bytes_unchecked(bytes: &[u8]) -> Self;
 
     /// Creates a new IntMod from an array of bytes, big endian.
     /// Does not enforce the integer value of `bytes` must be less than the modulus.
-    fn from_be_bytes(bytes: &[u8]) -> Self;
+    fn from_be_bytes_unchecked(bytes: &[u8]) -> Self;
 
     /// Creates a new IntMod from a u8.
     /// Does not enforce the integer value of `bytes` must be less than the modulus.

--- a/extensions/algebra/tests/programs/examples/little.rs
+++ b/extensions/algebra/tests/programs/examples/little.rs
@@ -34,7 +34,7 @@ pub fn main() {
     assert_eq!(res, inv);
 
     let two = Secp256k1Coord::from_u32(2);
-    let minus_two = Secp256k1Coord::from_le_bytes(&pow);
+    let minus_two = Secp256k1Coord::from_le_bytes_unchecked(&pow);
 
     assert_eq!(res - &minus_two, inv + &two);
 

--- a/extensions/algebra/tests/programs/examples/moduli_setup.rs
+++ b/extensions/algebra/tests/programs/examples/moduli_setup.rs
@@ -32,18 +32,18 @@ pub fn main() {
     }
     assert_eq!(res, Mersenne61::from_u32(1));
 
-    let mut non_reduced = Mersenne61::from_le_bytes(&[0xff; 32]);
+    let mut non_reduced = Mersenne61::from_le_bytes_unchecked(&[0xff; 32]);
     assert!(!non_reduced.is_reduced());
     let reduced = &non_reduced + &Mersenne61::ZERO;
     reduced.assert_reduced();
 
     assert_eq!(&non_reduced + &non_reduced, reduced.double());
 
-    non_reduced = Mersenne61::from_le_bytes(&Mersenne61::MODULUS);
+    non_reduced = Mersenne61::from_le_bytes_unchecked(&Mersenne61::MODULUS);
     assert!(!non_reduced.is_reduced());
 
     let mut bytes = [0u8; 32];
     bytes[7] = 1 << 5; // 2^61 = 2^{8*7 + 5} = modulus + 1
-    non_reduced = Mersenne61::from_le_bytes(&bytes);
+    non_reduced = Mersenne61::from_le_bytes_unchecked(&bytes);
     assert!(!non_reduced.is_reduced());
 }

--- a/extensions/ecc/tests/programs/Cargo.toml
+++ b/extensions/ecc/tests/programs/Cargo.toml
@@ -78,5 +78,9 @@ name = "ecdsa_recover_k256"
 required-features = ["k256"]
 
 [[example]]
+name = "sec1_decode"
+required-features = ["k256"]
+
+[[example]]
 name = "invalid_setup"
 required-features = ["k256", "p256"]

--- a/extensions/ecc/tests/programs/examples/decompress.rs
+++ b/extensions/ecc/tests/programs/examples/decompress.rs
@@ -48,24 +48,24 @@ openvm::init!("openvm_init_decompress_k256.rs");
 // test decompression under an honest host
 pub fn main() {
     let bytes = read_vec();
-    let x = Secp256k1Coord::from_le_bytes(&bytes[..32]);
-    let y = Secp256k1Coord::from_le_bytes(&bytes[32..64]);
+    let x = Secp256k1Coord::from_le_bytes_unchecked(&bytes[..32]);
+    let y = Secp256k1Coord::from_le_bytes_unchecked(&bytes[32..64]);
     let rec_id = y.as_le_bytes()[0] & 1;
 
     test_possible_decompression::<Secp256k1Point>(&x, &y, rec_id);
     // x = 5 is not on the x-coordinate of any point on the Secp256k1 curve
     test_impossible_decompression::<Secp256k1Point>(&Secp256k1Coord::from_u8(5), rec_id);
 
-    let x = Fp5mod8::from_le_bytes(&bytes[64..96]);
-    let y = Fp5mod8::from_le_bytes(&bytes[96..128]);
+    let x = Fp5mod8::from_le_bytes_unchecked(&bytes[64..96]);
+    let y = Fp5mod8::from_le_bytes_unchecked(&bytes[96..128]);
     let rec_id = y.as_le_bytes()[0] & 1;
 
     test_possible_decompression::<CurvePoint5mod8>(&x, &y, rec_id);
     // x = 3 is not on the x-coordinate of any point on the CurvePoint5mod8 curve
     test_impossible_decompression::<CurvePoint5mod8>(&Fp5mod8::from_u8(3), rec_id);
 
-    let x = Fp1mod4::from_le_bytes(&bytes[128..160]);
-    let y = Fp1mod4::from_le_bytes(&bytes[160..192]);
+    let x = Fp1mod4::from_le_bytes_unchecked(&bytes[128..160]);
+    let y = Fp1mod4::from_le_bytes_unchecked(&bytes[160..192]);
     let rec_id = y.as_le_bytes()[0] & 1;
 
     test_possible_decompression::<CurvePoint1mod4>(&x, &y, rec_id);

--- a/extensions/ecc/tests/programs/examples/ec.rs
+++ b/extensions/ecc/tests/programs/examples/ec.rs
@@ -14,25 +14,25 @@ pub fn main() {
     // Sample points got from https://asecuritysite.com/ecc/ecc_points2 and
     // https://learnmeabitcoin.com/technical/cryptography/elliptic-curve/#add
     let x1 = Secp256k1Coord::from_u32(1);
-    let y1 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y1 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "EEA7767E580D75BC6FDD7F58D2A84C2614FB22586068DB63B346C6E60AF21842"
     ));
     let x2 = Secp256k1Coord::from_u32(2);
-    let y2 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y2 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "D1A847A8F879E0AEE32544DA5BA0B3BD1703A1F52867A5601FF6454DD8180499"
     ));
     // This is the sum of (x1, y1) and (x2, y2).
-    let x3 = Secp256k1Coord::from_le_bytes(&hex!(
+    let x3 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "BE675E31F8AC8200CBCC6B10CECCD6EB93FB07D99BB9E7C99CC9245C862D3AF2"
     ));
-    let y3 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y3 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "B44573B48FD3416DD256A8C0E1BAD03E88A78BF176778682589B9CB478FC1D79"
     ));
     // This is the double of (x2, y2).
-    let x4 = Secp256k1Coord::from_le_bytes(&hex!(
+    let x4 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "3BFFFFFF32333333333333333333333333333333333333333333333333333333"
     ));
-    let y4 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y4 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "AC54ECC4254A4EDCAB10CC557A9811ED1EF7CB8AFDC64820C6803D2C5F481639"
     ));
 
@@ -63,10 +63,10 @@ pub fn main() {
     let p1 = Secp256k1Point::from_xy(x1, y1).unwrap();
     let scalar = Secp256k1Scalar::from_u32(12345678);
     // Calculated with https://learnmeabitcoin.com/technical/cryptography/elliptic-curve/#ec-multiply-tool
-    let x5 = Secp256k1Coord::from_le_bytes(&hex!(
+    let x5 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "194A93387F790803D972AF9C4A40CB89D106A36F58EE2F31DC48A41768216D6D"
     ));
-    let y5 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y5 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "9E272F746DA7BED171E522610212B6AEEAAFDB2AD9F4B530B8E1B27293B19B2C"
     ));
     let result = msm(&[scalar], &[p1]);

--- a/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
+++ b/extensions/ecc/tests/programs/examples/ec_nonzero_a.rs
@@ -13,12 +13,12 @@ openvm::init!("openvm_init_ec_nonzero_a_p256.rs");
 pub fn main() {
     // Sample points got from https://asecuritysite.com/ecc/p256p
     let x1 = P256Coord::from_u32(5);
-    let y1 = P256Coord::from_le_bytes(&hex!(
+    let y1 = P256Coord::from_le_bytes_unchecked(&hex!(
         "ccfb4832085c4133c5a3d9643c50ca11de7a8199ce3b91fe061858aab9439245"
     ));
     let p1 = P256Point::from_xy(x1.clone(), y1.clone()).unwrap();
     let x2 = P256Coord::from_u32(6);
-    let y2 = P256Coord::from_le_bytes(&hex!(
+    let y2 = P256Coord::from_le_bytes_unchecked(&hex!(
         "cb23828228510d22e9c0e70fb802d1dc47007233e5856946c20a25542c4cb236"
     ));
     let p2 = P256Point::from_xy(x2.clone(), y2.clone()).unwrap();

--- a/extensions/ecc/tests/programs/examples/ec_two_curves.rs
+++ b/extensions/ecc/tests/programs/examples/ec_two_curves.rs
@@ -15,25 +15,25 @@ pub fn main() {
     // Sample points got from https://asecuritysite.com/ecc/ecc_points2 and
     // https://learnmeabitcoin.com/technical/cryptography/elliptic-curve/#add
     let x1 = Secp256k1Coord::from_u32(1);
-    let y1 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y1 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "EEA7767E580D75BC6FDD7F58D2A84C2614FB22586068DB63B346C6E60AF21842"
     ));
     let x2 = Secp256k1Coord::from_u32(2);
-    let y2 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y2 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "D1A847A8F879E0AEE32544DA5BA0B3BD1703A1F52867A5601FF6454DD8180499"
     ));
     // This is the sum of (x1, y1) and (x2, y2).
-    let x3 = Secp256k1Coord::from_le_bytes(&hex!(
+    let x3 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "BE675E31F8AC8200CBCC6B10CECCD6EB93FB07D99BB9E7C99CC9245C862D3AF2"
     ));
-    let y3 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y3 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "B44573B48FD3416DD256A8C0E1BAD03E88A78BF176778682589B9CB478FC1D79"
     ));
     // This is the double of (x2, y2).
-    let x4 = Secp256k1Coord::from_le_bytes(&hex!(
+    let x4 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "3BFFFFFF32333333333333333333333333333333333333333333333333333333"
     ));
-    let y4 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y4 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "AC54ECC4254A4EDCAB10CC557A9811ED1EF7CB8AFDC64820C6803D2C5F481639"
     ));
 
@@ -64,10 +64,10 @@ pub fn main() {
     let p1 = Secp256k1Point::from_xy(x1, y1).unwrap();
     let scalar = Secp256k1Scalar::from_u32(12345678);
     // Calculated with https://learnmeabitcoin.com/technical/cryptography/elliptic-curve/#ec-multiply-tool
-    let x5 = Secp256k1Coord::from_le_bytes(&hex!(
+    let x5 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "194A93387F790803D972AF9C4A40CB89D106A36F58EE2F31DC48A41768216D6D"
     ));
-    let y5 = Secp256k1Coord::from_le_bytes(&hex!(
+    let y5 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
         "9E272F746DA7BED171E522610212B6AEEAAFDB2AD9F4B530B8E1B27293B19B2C"
     ));
     let result = msm(&[scalar], &[p1]);
@@ -77,12 +77,12 @@ pub fn main() {
 
     // Sample points got from https://asecuritysite.com/ecc/p256p
     let x1 = P256Coord::from_u32(5);
-    let y1 = P256Coord::from_le_bytes(&hex!(
+    let y1 = P256Coord::from_le_bytes_unchecked(&hex!(
         "ccfb4832085c4133c5a3d9643c50ca11de7a8199ce3b91fe061858aab9439245"
     ));
     let p1 = P256Point::from_xy(x1.clone(), y1.clone()).unwrap();
     let x2 = P256Coord::from_u32(6);
-    let y2 = P256Coord::from_le_bytes(&hex!(
+    let y2 = P256Coord::from_le_bytes_unchecked(&hex!(
         "cb23828228510d22e9c0e70fb802d1dc47007233e5856946c20a25542c4cb236"
     ));
     let p2 = P256Point::from_xy(x2.clone(), y2.clone()).unwrap();

--- a/extensions/ecc/tests/programs/examples/sec1_decode.rs
+++ b/extensions/ecc/tests/programs/examples/sec1_decode.rs
@@ -1,0 +1,25 @@
+#![cfg_attr(not(feature = "std"), no_main)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use openvm::io::read;
+use openvm_ecc_test_programs::Sec1DecodingTestVector;
+#[allow(unused_imports)]
+use openvm_k256::{ecdsa::VerifyingKey, Secp256k1Coord, Secp256k1Point};
+
+openvm::entry!(main);
+
+openvm::init!("openvm_init_ec_k256.rs");
+
+pub fn main() {
+    let test_vectors: Vec<Sec1DecodingTestVector> = read();
+    for vector in test_vectors {
+        assert_eq!(
+            vector.ok,
+            VerifyingKey::from_sec1_bytes(&vector.bytes).is_ok()
+        );
+    }
+}

--- a/extensions/ecc/tests/programs/src/lib.rs
+++ b/extensions/ecc/tests/programs/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
 
@@ -15,5 +19,14 @@ pub struct RecoveryTestVector {
     #[serde_as(as = "Bytes")]
     pub sig: [u8; 64],
     pub recid: u8,
+    pub ok: bool,
+}
+
+#[repr(C)]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct Sec1DecodingTestVector {
+    #[serde_as(as = "Bytes")]
+    pub bytes: Vec<u8>,
     pub ok: bool,
 }

--- a/extensions/ecc/tests/src/lib.rs
+++ b/extensions/ecc/tests/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod test_vectors;
 
 #[cfg(test)]
@@ -28,7 +29,9 @@ mod tests {
     };
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
-    use crate::test_vectors::{K256_RECOVERY_TEST_VECTORS, P256_RECOVERY_TEST_VECTORS};
+    use crate::test_vectors::{
+        k256_sec1_decoding_test_vectors, K256_RECOVERY_TEST_VECTORS, P256_RECOVERY_TEST_VECTORS,
+    };
 
     type F = BabyBear;
 
@@ -214,6 +217,24 @@ mod tests {
         let openvm_exe = VmExe::from_elf(elf, config.transpiler())?;
         let mut input = StdIn::default();
         input.write(&K256_RECOVERY_TEST_VECTORS.to_vec());
+        air_test_with_min_segments(config, openvm_exe, input, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_k256_vk_from_sec1_bytes() -> Result<()> {
+        let config =
+            toml::from_str::<AppConfig<SdkVmConfig>>(include_str!("../programs/openvm_k256.toml"))?
+                .app_vm_config;
+        let elf = build_example_program_at_path_with_features(
+            get_programs_dir!(),
+            "sec1_decode",
+            ["k256"],
+            &NoInitFile, // using already created file
+        )?;
+        let openvm_exe = VmExe::from_elf(elf, config.transpiler())?;
+        let mut input = StdIn::default();
+        input.write(&k256_sec1_decoding_test_vectors());
         air_test_with_min_segments(config, openvm_exe, input, 1);
         Ok(())
     }

--- a/extensions/ecc/tests/src/test_vectors.rs
+++ b/extensions/ecc/tests/src/test_vectors.rs
@@ -16,12 +16,36 @@ pub struct RecoveryTestVector {
     pub ok: bool,
 }
 
-#[allow(dead_code)]
 pub const P256_RECOVERY_TEST_VECTORS: &[RecoveryTestVector] = &[RecoveryTestVector {pk:hex!("020000000000000000000000000000000000000000000000000000000000000000"),msg:hex!("00000000000000000000FFFFFFFF03030BFFFFFFFFFF030BFFFFFFFFFFFFF8FC"),sig:hex!("00000000ffffffff00000000000000004319055258e8617b0c46353d039cdaaf0000000000000000000000000000000000000000000000000000000000000001"),recid:2,ok:false,
 },
 RecoveryTestVector{pk:hex!("020000000000000000000000000000000000000000000000000000000000000000"),msg:hex!("000000000000000000000000000000000000000000000000000CFD5E267CBB5E"),sig:hex!("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296000000000000000000000000000000000000000000000000000cfd5e267cbb5e"),recid:1,ok:false
 }];
 
-#[allow(dead_code)]
 pub const K256_RECOVERY_TEST_VECTORS: &[RecoveryTestVector] = &[RecoveryTestVector{pk:hex!("020000000000000000000000000000000000000000000000000000000000000000"),msg:hex!("0000000000000000000000000000000000000000000000000000000000000000"),sig:hex!("0000000000000000000000000000000000000000000000000000000000000001ffffffffbffffffffffffffffeffbaffaeff6f7000000100000000dbd0364140"),recid:1,ok:false}
 ];
+
+#[repr(C)]
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Sec1DecodingTestVector {
+    #[serde_as(as = "Bytes")]
+    pub bytes: Vec<u8>,
+    pub ok: bool,
+}
+
+pub fn k256_sec1_decoding_test_vectors() -> Vec<Sec1DecodingTestVector> {
+    vec![
+    Sec1DecodingTestVector {
+        bytes: hex!("04" "0000000000000000000000000000000000000000000000000000000000000000" "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f").to_vec(),
+        ok: false,
+    },
+    Sec1DecodingTestVector {
+        bytes: hex!("04" "0000000000000000000000000000000000000000000000000000000000000001" "4218f20ae6c646b363db68605822fb14264ca8d2587fdd6fbc750d587e76a7ee").to_vec(),
+        ok: true,
+    },
+    Sec1DecodingTestVector {
+        bytes: hex!("04" "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30" "4218f20ae6c646b363db68605822fb14264ca8d2587fdd6fbc750d587e76a7ee").to_vec(),
+        ok: false,
+    },
+]
+}

--- a/guest-libs/ff_derive/src/lib.rs
+++ b/guest-libs/ff_derive/src/lib.rs
@@ -49,10 +49,10 @@ impl ReprEndianness {
     fn from_repr(&self, name: &syn::Ident, limbs: usize) -> proc_macro2::TokenStream {
         let read_repr = match self {
             ReprEndianness::Big => quote! {
-                <#name as ::openvm_algebra_guest::IntMod>::from_be_bytes(&r.as_ref())
+                <#name as ::openvm_algebra_guest::IntMod>::from_be_bytes(&r.as_ref()).unwrap()
             },
             ReprEndianness::Little => quote! {
-                <#name as ::openvm_algebra_guest::IntMod>::from_le_bytes(&r.as_ref())
+                <#name as ::openvm_algebra_guest::IntMod>::from_le_bytes(&r.as_ref()).unwrap()
             },
         };
 

--- a/guest-libs/k256/src/coord.rs
+++ b/guest-libs/k256/src/coord.rs
@@ -9,13 +9,19 @@ use crate::internal::Secp256k1Coord;
 
 impl Copy for Secp256k1Coord {}
 
+impl Default for Secp256k1Coord {
+    fn default() -> Self {
+        <Self as IntMod>::ZERO
+    }
+}
+
 impl ConditionallySelectable for Secp256k1Coord {
     fn conditional_select(
         a: &Secp256k1Coord,
         b: &Secp256k1Coord,
         choice: Choice,
     ) -> Secp256k1Coord {
-        Secp256k1Coord::from_le_bytes(
+        Secp256k1Coord::from_le_bytes_unchecked(
             &a.as_le_bytes()
                 .iter()
                 .zip(b.as_le_bytes().iter())

--- a/guest-libs/k256/src/scalar.rs
+++ b/guest-libs/k256/src/scalar.rs
@@ -54,7 +54,7 @@ impl ConditionallySelectable for Secp256k1Scalar {
         b: &Secp256k1Scalar,
         choice: Choice,
     ) -> Secp256k1Scalar {
-        Secp256k1Scalar::from_le_bytes(
+        Secp256k1Scalar::from_le_bytes_unchecked(
             &a.as_le_bytes()
                 .iter()
                 .zip(b.as_le_bytes().iter())
@@ -131,7 +131,7 @@ impl PrimeField for Secp256k1Scalar {
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        let ret = Self::from_be_bytes(bytes.as_slice());
+        let ret = Self::from_be_bytes_unchecked(bytes.as_slice());
         CtOption::new(ret, (ret.is_reduced() as u8).into())
     }
 
@@ -156,7 +156,7 @@ impl Reduce<U256> for Secp256k1Scalar {
     type Bytes = FieldBytes;
 
     fn reduce(w: U256) -> Self {
-        Self::from_le_bytes(&w.to_le_bytes())
+        <Self as openvm_algebra_guest::Reduce>::reduce_le_bytes(&w.to_le_bytes())
     }
 
     #[inline]
@@ -202,13 +202,13 @@ impl FromUintUnchecked for Secp256k1Scalar {
     type Uint = U256;
 
     fn from_uint_unchecked(uint: Self::Uint) -> Self {
-        Self::from_le_bytes(&uint.to_le_bytes())
+        Self::from_le_bytes_unchecked(&uint.to_le_bytes())
     }
 }
 
 impl From<ScalarPrimitive<Secp256k1>> for Secp256k1Scalar {
     fn from(scalar: ScalarPrimitive<Secp256k1>) -> Self {
-        Self::from_le_bytes(&scalar.as_uint().to_le_bytes())
+        Self::from_le_bytes_unchecked(&scalar.as_uint().to_le_bytes())
     }
 }
 

--- a/guest-libs/k256/tests/lib.rs
+++ b/guest-libs/k256/tests/lib.rs
@@ -193,25 +193,25 @@ mod host_tests {
         // Sample points got from https://asecuritysite.com/ecc/ecc_points2 and
         // https://learnmeabitcoin.com/technical/cryptography/elliptic-curve/#add
         let x1 = Secp256k1Coord::from_u32(1);
-        let y1 = Secp256k1Coord::from_le_bytes(&hex!(
+        let y1 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "EEA7767E580D75BC6FDD7F58D2A84C2614FB22586068DB63B346C6E60AF21842"
         ));
         let x2 = Secp256k1Coord::from_u32(2);
-        let y2 = Secp256k1Coord::from_le_bytes(&hex!(
+        let y2 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "D1A847A8F879E0AEE32544DA5BA0B3BD1703A1F52867A5601FF6454DD8180499"
         ));
         // This is the sum of (x1, y1) and (x2, y2).
-        let x3 = Secp256k1Coord::from_le_bytes(&hex!(
+        let x3 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "BE675E31F8AC8200CBCC6B10CECCD6EB93FB07D99BB9E7C99CC9245C862D3AF2"
         ));
-        let y3 = Secp256k1Coord::from_le_bytes(&hex!(
+        let y3 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "B44573B48FD3416DD256A8C0E1BAD03E88A78BF176778682589B9CB478FC1D79"
         ));
         // This is the double of (x2, y2).
-        let x4 = Secp256k1Coord::from_le_bytes(&hex!(
+        let x4 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "3BFFFFFF32333333333333333333333333333333333333333333333333333333"
         ));
-        let y4 = Secp256k1Coord::from_le_bytes(&hex!(
+        let y4 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "AC54ECC4254A4EDCAB10CC557A9811ED1EF7CB8AFDC64820C6803D2C5F481639"
         ));
 
@@ -244,10 +244,10 @@ mod host_tests {
         let p1 = Secp256k1Point::from_xy(x1, y1).unwrap();
         let scalar = Secp256k1Scalar::from_u32(12345678);
         // Calculated with https://learnmeabitcoin.com/technical/cryptography/elliptic-curve/#ec-multiply-tool
-        let x5 = Secp256k1Coord::from_le_bytes(&hex!(
+        let x5 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "194A93387F790803D972AF9C4A40CB89D106A36F58EE2F31DC48A41768216D6D"
         ));
-        let y5 = Secp256k1Coord::from_le_bytes(&hex!(
+        let y5 = Secp256k1Coord::from_le_bytes_unchecked(&hex!(
             "9E272F746DA7BED171E522610212B6AEEAAFDB2AD9F4B530B8E1B27293B19B2C"
         ));
         let result = msm(&[scalar], &[p1]);

--- a/guest-libs/p256/src/coord.rs
+++ b/guest-libs/p256/src/coord.rs
@@ -9,9 +9,15 @@ use crate::internal::P256Coord;
 
 impl Copy for P256Coord {}
 
+impl Default for P256Coord {
+    fn default() -> Self {
+        <Self as IntMod>::ZERO
+    }
+}
+
 impl ConditionallySelectable for P256Coord {
     fn conditional_select(a: &P256Coord, b: &P256Coord, choice: Choice) -> P256Coord {
-        P256Coord::from_le_bytes(
+        P256Coord::from_le_bytes_unchecked(
             &a.as_le_bytes()
                 .iter()
                 .zip(b.as_le_bytes().iter())

--- a/guest-libs/p256/src/point.rs
+++ b/guest-libs/p256/src/point.rs
@@ -179,13 +179,15 @@ impl DecompressPoint<NistP256> for P256Point {
     fn decompress(x_bytes: &FieldBytes, y_is_odd: Choice) -> CtOption<Self> {
         use openvm_ecc_guest::weierstrass::FromCompressed;
 
-        let x = P256Coord::from_be_bytes(x_bytes.as_slice());
+        let x = P256Coord::from_be_bytes_unchecked(x_bytes.as_slice());
         let rec_id = y_is_odd.unwrap_u8();
-        let y = <P256Point as FromCompressed<P256Coord>>::decompress(x, &rec_id);
-        match y {
-            Some(point) => CtOption::new(point, 1.into()),
-            None => CtOption::new(P256Point::default(), 0.into()),
-        }
+        CtOption::new(x, (x.is_reduced() as u8).into()).and_then(|x| {
+            let y = <P256Point as FromCompressed<P256Coord>>::decompress(x, &rec_id);
+            match y {
+                Some(point) => CtOption::new(point, 1.into()),
+                None => CtOption::new(P256Point::default(), 0.into()),
+            }
+        })
     }
 }
 

--- a/guest-libs/p256/src/scalar.rs
+++ b/guest-libs/p256/src/scalar.rs
@@ -46,7 +46,7 @@ impl ConstantTimeEq for P256Scalar {
 
 impl ConditionallySelectable for P256Scalar {
     fn conditional_select(a: &P256Scalar, b: &P256Scalar, choice: Choice) -> P256Scalar {
-        P256Scalar::from_le_bytes(
+        P256Scalar::from_le_bytes_unchecked(
             &a.as_le_bytes()
                 .iter()
                 .zip(b.as_le_bytes().iter())
@@ -129,7 +129,7 @@ impl PrimeField for P256Scalar {
     /// Returns None if the byte array does not contain a big-endian integer in the range
     /// [0, p).
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        let ret = Self::from_be_bytes(bytes.as_slice());
+        let ret = Self::from_be_bytes_unchecked(bytes.as_slice());
         CtOption::new(ret, (ret.is_reduced() as u8).into())
     }
 
@@ -154,7 +154,7 @@ impl Reduce<U256> for P256Scalar {
     type Bytes = FieldBytes;
 
     fn reduce(w: U256) -> Self {
-        Self::from_le_bytes(&w.to_le_bytes())
+        <Self as openvm_algebra_guest::Reduce>::reduce_le_bytes(&w.to_le_bytes())
     }
 
     #[inline]
@@ -200,13 +200,13 @@ impl FromUintUnchecked for P256Scalar {
     type Uint = U256;
 
     fn from_uint_unchecked(uint: Self::Uint) -> Self {
-        Self::from_le_bytes(&uint.to_le_bytes())
+        Self::from_le_bytes_unchecked(&uint.to_le_bytes())
     }
 }
 
 impl From<ScalarPrimitive<NistP256>> for P256Scalar {
     fn from(scalar: ScalarPrimitive<NistP256>) -> Self {
-        Self::from_le_bytes(&scalar.as_uint().to_le_bytes())
+        Self::from_le_bytes_unchecked(&scalar.as_uint().to_le_bytes())
     }
 }
 

--- a/guest-libs/p256/tests/lib.rs
+++ b/guest-libs/p256/tests/lib.rs
@@ -192,12 +192,12 @@ mod host_tests {
     fn test_host_p256() {
         // Sample points got from https://asecuritysite.com/ecc/p256p
         let x1 = P256Coord::from_u32(5);
-        let y1 = P256Coord::from_le_bytes(&hex!(
+        let y1 = P256Coord::from_le_bytes_unchecked(&hex!(
             "ccfb4832085c4133c5a3d9643c50ca11de7a8199ce3b91fe061858aab9439245"
         ));
         let p1 = P256Point::from_xy(x1, y1).unwrap();
         let x2 = P256Coord::from_u32(6);
-        let y2 = P256Coord::from_le_bytes(&hex!(
+        let y2 = P256Coord::from_le_bytes_unchecked(&hex!(
             "cb23828228510d22e9c0e70fb802d1dc47007233e5856946c20a25542c4cb236"
         ));
         let p2 = P256Point::from_xy(x2, y2).unwrap();

--- a/guest-libs/pairing/src/bls12_381/utils.rs
+++ b/guest-libs/pairing/src/bls12_381/utils.rs
@@ -7,7 +7,7 @@ use crate::bls12_381::G2Affine as OpenVmG2Affine;
 
 pub(crate) fn convert_bls12381_halo2_fq_to_fp(x: Fq) -> Fp {
     let bytes = x.to_bytes();
-    Fp::from_le_bytes(&bytes)
+    Fp::from_le_bytes_unchecked(&bytes)
 }
 
 pub(crate) fn convert_bls12381_halo2_fq2_to_fp2(x: Fq2) -> Fp2 {

--- a/guest-libs/pairing/src/bn254/utils.rs
+++ b/guest-libs/pairing/src/bn254/utils.rs
@@ -7,7 +7,7 @@ use crate::bn254::G2Affine as OpenVmG2Affine;
 
 pub(crate) fn convert_bn254_halo2_fq_to_fp(x: Fq) -> Fp {
     let bytes = x.to_bytes();
-    Fp::from_le_bytes(&bytes)
+    Fp::from_le_bytes_unchecked(&bytes)
 }
 
 pub(crate) fn convert_bn254_halo2_fq2_to_fp2(x: Fq2) -> Fp2 {

--- a/guest-libs/pairing/tests/lib.rs
+++ b/guest-libs/pairing/tests/lib.rs
@@ -421,8 +421,8 @@ mod bn254 {
         let ps = ps
             .into_iter()
             .map(|pt| {
-                let [x, y] =
-                    [pt.x, pt.y].map(|x| openvm_pairing::bn254::Fp::from_le_bytes(&x.to_bytes()));
+                let [x, y] = [pt.x, pt.y]
+                    .map(|x| openvm_pairing::bn254::Fp::from_le_bytes_unchecked(&x.to_bytes()));
                 AffinePoint::new(x, y)
             })
             .collect::<Vec<_>>();
@@ -883,7 +883,7 @@ mod bls12_381 {
             .into_iter()
             .map(|pt| {
                 let [x, y] = [pt.x, pt.y]
-                    .map(|x| openvm_pairing::bls12_381::Fp::from_le_bytes(&x.to_bytes()));
+                    .map(|x| openvm_pairing::bls12_381::Fp::from_le_bytes_unchecked(&x.to_bytes()));
                 AffinePoint::new(x, y)
             })
             .collect::<Vec<_>>();

--- a/guest-libs/pairing/tests/programs/examples/pairing_check.rs
+++ b/guest-libs/pairing/tests/programs/examples/pairing_check.rs
@@ -27,10 +27,14 @@ mod bn254 {
         let q0 = &io[32 * 4..32 * 8];
         let q1 = &io[32 * 8..32 * 12];
 
-        let s0_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s0[..32]), Fp::from_le_bytes(&s0[32..64]));
-        let s1_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s1[..32]), Fp::from_le_bytes(&s1[32..64]));
+        let s0_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s0[..32]),
+            Fp::from_le_bytes_unchecked(&s0[32..64]),
+        );
+        let s1_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s1[..32]),
+            Fp::from_le_bytes_unchecked(&s1[32..64]),
+        );
         let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..64]), Fp2::from_bytes(&q0[64..128]));
         let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..64]), Fp2::from_bytes(&q1[64..128]));
 
@@ -60,10 +64,14 @@ mod bls12_381 {
         let q0 = &io[48 * 4..48 * 8];
         let q1 = &io[48 * 8..48 * 12];
 
-        let s0_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s0[..48]), Fp::from_le_bytes(&s0[48..96]));
-        let s1_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s1[..48]), Fp::from_le_bytes(&s1[48..96]));
+        let s0_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s0[..48]),
+            Fp::from_le_bytes_unchecked(&s0[48..96]),
+        );
+        let s1_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s1[..48]),
+            Fp::from_le_bytes_unchecked(&s1[48..96]),
+        );
         let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..96]), Fp2::from_bytes(&q0[96..192]));
         let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..96]), Fp2::from_bytes(&q1[96..192]));
 

--- a/guest-libs/pairing/tests/programs/examples/pairing_check_fallback.rs
+++ b/guest-libs/pairing/tests/programs/examples/pairing_check_fallback.rs
@@ -98,10 +98,14 @@ mod bn254 {
         let q0 = &io[32 * 4..32 * 8];
         let q1 = &io[32 * 8..32 * 12];
 
-        let s0_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s0[..32]), Fp::from_le_bytes(&s0[32..64]));
-        let s1_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s1[..32]), Fp::from_le_bytes(&s1[32..64]));
+        let s0_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s0[..32]),
+            Fp::from_le_bytes_unchecked(&s0[32..64]),
+        );
+        let s1_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s1[..32]),
+            Fp::from_le_bytes_unchecked(&s1[32..64]),
+        );
         let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..64]), Fp2::from_bytes(&q0[64..128]));
         let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..64]), Fp2::from_bytes(&q1[64..128]));
 
@@ -204,10 +208,14 @@ mod bls12_381 {
         let q0 = &io[48 * 4..48 * 8];
         let q1 = &io[48 * 8..48 * 12];
 
-        let s0_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s0[..48]), Fp::from_le_bytes(&s0[48..96]));
-        let s1_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s1[..48]), Fp::from_le_bytes(&s1[48..96]));
+        let s0_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s0[..48]),
+            Fp::from_le_bytes_unchecked(&s0[48..96]),
+        );
+        let s1_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s1[..48]),
+            Fp::from_le_bytes_unchecked(&s1[48..96]),
+        );
         let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..96]), Fp2::from_bytes(&q0[96..192]));
         let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..96]), Fp2::from_bytes(&q1[96..192]));
 

--- a/guest-libs/pairing/tests/programs/examples/pairing_miller_loop.rs
+++ b/guest-libs/pairing/tests/programs/examples/pairing_miller_loop.rs
@@ -26,10 +26,14 @@ mod bn254 {
         let q1 = &io[32 * 8..32 * 12];
         let f_cmp = &io[32 * 12..32 * 24];
 
-        let s0_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s0[..32]), Fp::from_le_bytes(&s0[32..64]));
-        let s1_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s1[..32]), Fp::from_le_bytes(&s1[32..64]));
+        let s0_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s0[..32]),
+            Fp::from_le_bytes_unchecked(&s0[32..64]),
+        );
+        let s1_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s1[..32]),
+            Fp::from_le_bytes_unchecked(&s1[32..64]),
+        );
         let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..64]), Fp2::from_bytes(&q0[64..128]));
         let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..64]), Fp2::from_bytes(&q1[64..128]));
 
@@ -60,10 +64,14 @@ mod bls12_381 {
         let q1 = &io[48 * 8..48 * 12];
         let f_cmp = &io[48 * 12..48 * 24];
 
-        let s0_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s0[..48]), Fp::from_le_bytes(&s0[48..96]));
-        let s1_cast =
-            AffinePoint::new(Fp::from_le_bytes(&s1[..48]), Fp::from_le_bytes(&s1[48..96]));
+        let s0_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s0[..48]),
+            Fp::from_le_bytes_unchecked(&s0[48..96]),
+        );
+        let s1_cast = AffinePoint::new(
+            Fp::from_le_bytes_unchecked(&s1[..48]),
+            Fp::from_le_bytes_unchecked(&s1[48..96]),
+        );
         let q0_cast = AffinePoint::new(Fp2::from_bytes(&q0[..96]), Fp2::from_bytes(&q0[96..192]));
         let q1_cast = AffinePoint::new(Fp2::from_bytes(&q1[..96]), Fp2::from_bytes(&q1[96..192]));
 


### PR DESCRIPTION
Fixes some panics in `from_sec1_bytes` where it should error instead.

However the root cause of many places is that `IntMod::from_{le,be}_bytes` previously does not require the input bytes to be reduced. While this is a feature of how we represent field elements up to equivalence, in practice in cryptographic applications other implementations always require the input to be in canonical (reduced) from. To match other implementations and prevent future errors, I have renamed the former `from_{le,be}_bytes` to `from_{le,be}_bytes_unchecked` and added new checked versions that return `Option`.

Also fixed implementations of `Decompress` for p256,k256 such that it rejects when the input `x` bytes are not reduced.