### PR TITLE
fix: memory accesses in metered execution should match exactly the memory accesses in `e3`

### DIFF
--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -648,6 +648,12 @@ pub struct FriReducedOpeningStep<F: Field> {
     phantom: std::marker::PhantomData<F>,
 }
 
+impl<F: PrimeField32> Default for FriReducedOpeningStep<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<F: PrimeField32> FriReducedOpeningStep<F> {
     pub fn new() -> Self {
         Self {

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -608,7 +608,9 @@ where
                 let read_data = memory_read_from_state(state, e.as_canonical_u32(), ptr_val);
                 read_data
             }
-            STOREW | STOREH | STOREB => read_rv32_register_from_state(state, ptr_val).to_le_bytes(),
+            STOREW | STOREH | STOREB => {
+                read_rv32_register_from_state(state, a.as_canonical_u32()).to_le_bytes()
+            }
         };
 
         // We need to keep values of some cells to keep them unchanged when writing to those cells

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -605,7 +605,6 @@ where
 
         let read_data = match local_opcode {
             LOADW | LOADB | LOADH | LOADBU | LOADHU => {
-                
                 memory_read_from_state(state, e.as_canonical_u32(), ptr_val)
             }
             STOREW | STOREH | STOREB => {

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -605,8 +605,8 @@ where
 
         let read_data = match local_opcode {
             LOADW | LOADB | LOADH | LOADBU | LOADHU => {
-                let read_data = memory_read_from_state(state, e.as_canonical_u32(), ptr_val);
-                read_data
+                
+                memory_read_from_state(state, e.as_canonical_u32(), ptr_val)
             }
             STOREW | STOREH | STOREB => {
                 read_rv32_register_from_state(state, a.as_canonical_u32()).to_le_bytes()
@@ -659,7 +659,7 @@ where
 
         match local_opcode {
             STOREW | STOREH | STOREB => {
-                let rs1 = read_rv32_register(&state.memory, b.as_canonical_u32());
+                let rs1 = read_rv32_register(state.memory, b.as_canonical_u32());
                 let imm_extended = c.as_canonical_u32() + g.as_canonical_u32() * 0xffff0000;
                 let ptr = rs1.wrapping_add(imm_extended) & !3;
                 if e.as_canonical_u32() == 4 {

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -565,7 +565,7 @@ where
 
     fn read<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Self::ReadData
     where
@@ -630,7 +630,7 @@ where
 
     fn write<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
         data: &Self::WriteData,
     ) where
@@ -654,7 +654,7 @@ where
             return;
         }
 
-        let rs1 = read_rv32_register(state.memory, a.as_canonical_u32());
+        let rs1 = read_rv32_register_from_state(state, a.as_canonical_u32());
 
         match local_opcode {
             STOREW | STOREH | STOREB => {

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -596,12 +596,12 @@ where
 
         let local_opcode = Rv32HintStoreOpcode::from_usize(opcode.local_opcode_idx(self.offset));
 
-        let mem_ptr = read_rv32_register(&state.memory, b.as_canonical_u32());
+        let mem_ptr = read_rv32_register(state.memory, b.as_canonical_u32());
 
         let num_words = if local_opcode == HINT_STOREW {
             1
         } else {
-            read_rv32_register(&state.memory, a.as_canonical_u32())
+            read_rv32_register(state.memory, a.as_canonical_u32())
         };
 
         debug_assert!(mem_ptr <= (1 << self.pointer_max_bits));

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -309,7 +309,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -332,7 +332,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -296,17 +296,20 @@ where
         core_row.opcode_loadb_flag0 = F::from_bool(record.is_byte && ((shift & 1) == 0));
     }
 }
-
 impl<F, A, const NUM_CELLS: usize, const LIMB_BITS: usize> StepExecutorE1<F>
     for LoadSignExtendStep<A, NUM_CELLS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + for<'a> AdapterExecutorE1<F, ReadData = [u8; NUM_CELLS], WriteData = [u8; NUM_CELLS]>,
+        + AdapterExecutorE1<
+            F,
+            ReadData = (([u32; NUM_CELLS], [u8; NUM_CELLS]), u8),
+            WriteData = [u32; NUM_CELLS],
+        >,
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<F, GuestMemory, Ctx>,
+        state: &mut VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -314,30 +317,14 @@ where
     {
         let Instruction { opcode, .. } = instruction;
 
+        let ((_prev_data, read_data), shift_amount) = self.adapter.read(state, instruction);
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),
         );
+        let write_data = run_write_data_sign_extend(local_opcode, read_data, shift_amount as usize);
 
-        let mut data = self.adapter.read(state, instruction);
-
-        match local_opcode {
-            LOADB => {
-                let ext = (data[0] >> 7) * u8::MAX;
-                for i in 1..NUM_CELLS {
-                    data[i] = ext;
-                }
-            }
-            LOADH => {
-                let ext = (data[NUM_CELLS / 2 - 1] >> 7) * u8::MAX;
-                for i in NUM_CELLS / 2..NUM_CELLS {
-                    data[i] = ext;
-                }
-            }
-            _ => unreachable!(),
-        }
-
-        self.adapter.write(state, instruction, &data);
-
+        self.adapter
+            .write(state, instruction, &write_data.map(u32::from));
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
@@ -345,7 +332,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -379,7 +379,7 @@ where
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<GuestMemory, Ctx>,
+        state: &mut VmStateMut<F, GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -399,7 +399,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -371,11 +371,15 @@ impl<F, A, const NUM_CELLS: usize> StepExecutorE1<F> for LoadStoreStep<A, NUM_CE
 where
     F: PrimeField32,
     A: 'static
-        + for<'a> AdapterExecutorE1<F, ReadData = [u8; NUM_CELLS], WriteData = [u8; NUM_CELLS]>,
+        + AdapterExecutorE1<
+            F,
+            ReadData = (([u32; NUM_CELLS], [u8; NUM_CELLS]), u8),
+            WriteData = [u32; NUM_CELLS],
+        >,
 {
     fn execute_e1<Ctx>(
         &self,
-        state: &mut VmStateMut<F, GuestMemory, Ctx>,
+        state: &mut VmStateMut<GuestMemory, Ctx>,
         instruction: &Instruction<F>,
     ) -> Result<()>
     where
@@ -383,22 +387,11 @@ where
     {
         let Instruction { opcode, .. } = instruction;
 
-        let mut data = self.adapter.read(state, instruction);
-        let local_opcode = opcode.local_opcode_idx(self.offset);
+        let ((prev_data, read_data), shift_amount) = self.adapter.read(state, instruction);
+        let local_opcode = Rv32LoadStoreOpcode::from_usize(opcode.local_opcode_idx(self.offset));
+        let write_data = run_write_data(local_opcode, read_data, prev_data, shift_amount as usize);
 
-        // Need to zero extend the data for loadbu and loadhu
-        if local_opcode == LOADBU as usize {
-            data.iter_mut().skip(1).for_each(|x| {
-                *x = 0;
-            });
-        } else if local_opcode == LOADHU as usize {
-            data.iter_mut().skip(NUM_CELLS / 2).for_each(|x| {
-                *x = 0;
-            });
-        }
-
-        self.adapter.write(state, instruction, &data);
-
+        self.adapter.write(state, instruction, &write_data);
         *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
 
         Ok(())
@@ -406,7 +399,7 @@ where
 
     fn execute_metered(
         &self,
-        state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
+        state: &mut VmStateMut<GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
         chip_index: usize,
     ) -> Result<()> {


### PR DESCRIPTION
This replaces this [PR](https://github.com/openvm-org/openvm/pull/1739)

I have been using execute_e1 in metered_execution in most places, but after an offline discussion with @shuklaayush  realized that memory accesses in e2 should be exactly the same as in e3. This PR fixes it for loadstore and hintstore. Fixed e2 keccak and sha2 in corresponding branches since they haven't been merged yet. I believe all other places should be correct.

Resolves INT-4204