### PR TITLE
Fix broken link to build.md in run.md

### DIFF
--- a/book/src/writing-apps/run.md
+++ b/book/src/writing-apps/run.md
@@ -15,7 +15,7 @@ If your program doesn't require inputs, you can (and should) omit the `--input` 
 
 ## Run Flags
 
-Many of the options for `cargo openvm run` will be passed to `cargo openvm build` if `--exe` is not specified. For more information on `build` (or `run`'s **Feature Selection**, **Compilation**, **Output**, **Display**, and/or **Manifest** options) see [Compiling](./writing-apps/build.md).
+Many of the options for `cargo openvm run` will be passed to `cargo openvm build` if `--exe` is not specified. For more information on `build` (or `run`'s **Feature Selection**, **Compilation**, **Output**, **Display**, and/or **Manifest** options) see [Compiling](./build.md).
 
 ### OpenVM Options
 


### PR DESCRIPTION
Replaced the incorrect relative link to build.md in run.md with the correct path. This resolves a documentation error where the file could not be found, ensuring users can now access the compilation instructions directly from the run command documentation.