### PR TITLE
feat: update openvm-prof to support new execution metrics

### DIFF
--- a/benchmarks/metrics.md
+++ b/benchmarks/metrics.md
@@ -1,0 +1,110 @@
+| Summary | Proof Time (s) | Parallel Proof Time (s) |
+|:---|---:|---:|
+| Total | <span style='color: green'>(+0 [NaN%])</span> 0 | <span style='color: green'>(+0 [NaN%])</span> 0 |
+
+
+| regex_program |||||
+|:---|---:|---:|---:|---:|
+|metric|avg|sum|max|min|
+| `main_cells_used     ` |  165,891,228 |  165,891,228 |  165,891,228 |  165,891,228 |
+| `total_cycles        ` |  4,165,416 |  4,165,416 |  4,165,416 |  4,165,416 |
+| `execute_metered_time_ms` | -          |  462 | -          | -          |
+| `execute_metered_insn_mi/s` | -          |  9.01 | -          | -          |
+| `execute_e3_time_ms  ` |  505 |  505 |  505 |  505 |
+| `execute_e3_insn_mi/s` |  8.24 |  8.24 |  8.24 |  8.24 |
+| `trace_gen_time_ms   ` |  1,110 |  1,110 |  1,110 |  1,110 |
+| `stark_prove_excluding_trace_time_ms` |  20,583 |  20,583 |  20,583 |  20,583 |
+| `main_trace_commit_time_ms` |  4,004 |  4,004 |  4,004 |  4,004 |
+| `generate_perm_trace_time_ms` |  2,310 |  2,310 |  2,310 |  2,310 |
+| `perm_trace_commit_time_ms` |  4,557 |  4,557 |  4,557 |  4,557 |
+| `quotient_poly_compute_time_ms` |  3,769 |  3,769 |  3,769 |  3,769 |
+| `quotient_poly_commit_time_ms` |  1,556 |  1,556 |  1,556 |  1,556 |
+| `pcs_opening_time_ms ` |  4,372 |  4,372 |  4,372 |  4,372 |
+
+
+
+<details>
+<summary>Detailed Metrics</summary>
+
+| group | num_segments | keygen_time_ms | insns | fri.log_blowup | execute_metered_time_ms | execute_metered_insn_mi/s | commit_exe_time_ms |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| regex_program | 1 | 689 | 4,165,417 | 1 | 462 | 9.01 | 50 | 
+
+| group | air_name | quotient_deg | interactions | constraints |
+| --- | --- | --- | --- | --- |
+| regex_program | AccessAdapterAir<16> | 2 | 5 | 12 | 
+| regex_program | AccessAdapterAir<2> | 2 | 5 | 12 | 
+| regex_program | AccessAdapterAir<32> | 2 | 5 | 12 | 
+| regex_program | AccessAdapterAir<4> | 2 | 5 | 12 | 
+| regex_program | AccessAdapterAir<8> | 2 | 5 | 12 | 
+| regex_program | BitwiseOperationLookupAir<8> | 2 | 2 | 4 | 
+| regex_program | KeccakVmAir | 2 | 321 | 4,513 | 
+| regex_program | MemoryMerkleAir<8> | 2 | 4 | 39 | 
+| regex_program | PersistentBoundaryAir<8> | 2 | 3 | 7 | 
+| regex_program | PhantomAir | 2 | 3 | 5 | 
+| regex_program | Poseidon2PeripheryAir<BabyBearParameters>, 1> | 2 | 1 | 286 | 
+| regex_program | ProgramAir | 1 | 1 | 4 | 
+| regex_program | RangeTupleCheckerAir<2> | 1 | 1 | 4 | 
+| regex_program | Rv32HintStoreAir | 2 | 18 | 28 | 
+| regex_program | VariableRangeCheckerAir | 1 | 1 | 4 | 
+| regex_program | VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<4, 8> | 2 | 20 | 37 | 
+| regex_program | VmAirWrapper<Rv32BaseAluAdapterAir, LessThanCoreAir<4, 8> | 2 | 18 | 40 | 
+| regex_program | VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<4, 8> | 2 | 24 | 91 | 
+| regex_program | VmAirWrapper<Rv32BranchAdapterAir, BranchEqualCoreAir<4> | 2 | 11 | 20 | 
+| regex_program | VmAirWrapper<Rv32BranchAdapterAir, BranchLessThanCoreAir<4, 8> | 2 | 13 | 35 | 
+| regex_program | VmAirWrapper<Rv32CondRdWriteAdapterAir, Rv32JalLuiCoreAir> | 2 | 10 | 18 | 
+| regex_program | VmAirWrapper<Rv32JalrAdapterAir, Rv32JalrCoreAir> | 2 | 16 | 20 | 
+| regex_program | VmAirWrapper<Rv32LoadStoreAdapterAir, LoadSignExtendCoreAir<4, 8> | 2 | 18 | 33 | 
+| regex_program | VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<4> | 2 | 17 | 40 | 
+| regex_program | VmAirWrapper<Rv32MultAdapterAir, DivRemCoreAir<4, 8> | 2 | 25 | 84 | 
+| regex_program | VmAirWrapper<Rv32MultAdapterAir, MulHCoreAir<4, 8> | 2 | 24 | 31 | 
+| regex_program | VmAirWrapper<Rv32MultAdapterAir, MultiplicationCoreAir<4, 8> | 2 | 19 | 19 | 
+| regex_program | VmAirWrapper<Rv32RdWriteAdapterAir, Rv32AuipcCoreAir> | 2 | 12 | 14 | 
+| regex_program | VmConnectorAir | 2 | 5 | 11 | 
+
+| group | air_name | segment | rows | prep_cols | perm_cols | main_cols | cells |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| regex_program | AccessAdapterAir<8> | 0 | 131,072 |  | 16 | 17 | 4,325,376 | 
+| regex_program | BitwiseOperationLookupAir<8> | 0 | 65,536 | 3 | 8 | 2 | 655,360 | 
+| regex_program | KeccakVmAir | 0 | 32 |  | 1,056 | 3,163 | 135,008 | 
+| regex_program | MemoryMerkleAir<8> | 0 | 131,072 |  | 16 | 32 | 6,291,456 | 
+| regex_program | PersistentBoundaryAir<8> | 0 | 131,072 |  | 12 | 20 | 4,194,304 | 
+| regex_program | PhantomAir | 0 | 1 |  | 12 | 6 | 18 | 
+| regex_program | Poseidon2PeripheryAir<BabyBearParameters>, 1> | 0 | 16,384 |  | 8 | 300 | 5,046,272 | 
+| regex_program | ProgramAir | 0 | 131,072 |  | 8 | 10 | 2,359,296 | 
+| regex_program | RangeTupleCheckerAir<2> | 0 | 524,288 | 2 | 8 | 1 | 4,718,592 | 
+| regex_program | Rv32HintStoreAir | 0 | 16,384 |  | 44 | 32 | 1,245,184 | 
+| regex_program | VariableRangeCheckerAir | 0 | 262,144 | 2 | 8 | 1 | 2,359,296 | 
+| regex_program | VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<4, 8> | 0 | 2,097,152 |  | 52 | 36 | 184,549,376 | 
+| regex_program | VmAirWrapper<Rv32BaseAluAdapterAir, LessThanCoreAir<4, 8> | 0 | 65,536 |  | 40 | 37 | 5,046,272 | 
+| regex_program | VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<4, 8> | 0 | 262,144 |  | 52 | 53 | 27,525,120 | 
+| regex_program | VmAirWrapper<Rv32BranchAdapterAir, BranchEqualCoreAir<4> | 0 | 524,288 |  | 28 | 26 | 28,311,552 | 
+| regex_program | VmAirWrapper<Rv32BranchAdapterAir, BranchLessThanCoreAir<4, 8> | 0 | 262,144 |  | 32 | 32 | 16,777,216 | 
+| regex_program | VmAirWrapper<Rv32CondRdWriteAdapterAir, Rv32JalLuiCoreAir> | 0 | 131,072 |  | 28 | 18 | 6,029,312 | 
+| regex_program | VmAirWrapper<Rv32JalrAdapterAir, Rv32JalrCoreAir> | 0 | 131,072 |  | 36 | 28 | 8,388,608 | 
+| regex_program | VmAirWrapper<Rv32LoadStoreAdapterAir, LoadSignExtendCoreAir<4, 8> | 0 | 1,024 |  | 52 | 36 | 90,112 | 
+| regex_program | VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<4> | 0 | 2,097,152 |  | 52 | 41 | 195,035,136 | 
+| regex_program | VmAirWrapper<Rv32MultAdapterAir, DivRemCoreAir<4, 8> | 0 | 128 |  | 72 | 59 | 16,768 | 
+| regex_program | VmAirWrapper<Rv32MultAdapterAir, MulHCoreAir<4, 8> | 0 | 256 |  | 72 | 39 | 28,416 | 
+| regex_program | VmAirWrapper<Rv32MultAdapterAir, MultiplicationCoreAir<4, 8> | 0 | 65,536 |  | 52 | 31 | 5,439,488 | 
+| regex_program | VmAirWrapper<Rv32RdWriteAdapterAir, Rv32AuipcCoreAir> | 0 | 65,536 |  | 28 | 20 | 3,145,728 | 
+| regex_program | VmConnectorAir | 0 | 2 | 1 | 16 | 5 | 42 | 
+
+| group | segment | trace_gen_time_ms | total_cycles | total_cells | stark_prove_excluding_trace_time_ms | quotient_poly_compute_time_ms | quotient_poly_commit_time_ms | perm_trace_commit_time_ms | pcs_opening_time_ms | main_trace_commit_time_ms | main_cells_used | insns | generate_perm_trace_time_ms | execute_e3_time_ms | execute_e3_insn_mi/s |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| regex_program | 0 | 1,110 | 4,165,416 | 511,713,308 | 20,583 | 3,769 | 1,556 | 4,557 | 4,372 | 4,004 | 165,891,228 | 4,165,417 | 2,310 | 505 | 8.24 | 
+
+| group | segment | trace_height_constraint | weighted_sum | threshold |
+| --- | --- | --- | --- | --- |
+| regex_program | 0 | 0 | 11,438,918 | 2,013,265,921 | 
+| regex_program | 0 | 1 | 32,222,272 | 2,013,265,921 | 
+| regex_program | 0 | 2 | 5,719,459 | 2,013,265,921 | 
+| regex_program | 0 | 3 | 37,992,516 | 2,013,265,921 | 
+| regex_program | 0 | 4 | 524,288 | 2,013,265,921 | 
+| regex_program | 0 | 5 | 262,144 | 2,013,265,921 | 
+| regex_program | 0 | 6 | 13,161,280 | 2,013,265,921 | 
+| regex_program | 0 | 7 | 265,216 | 2,013,265,921 | 
+| regex_program | 0 | 8 | 102,651,053 | 2,013,265,921 | 
+
+</details>
+

--- a/crates/prof/src/aggregate.rs
+++ b/crates/prof/src/aggregate.rs
@@ -165,7 +165,7 @@ impl AggregateMetrics {
         let mut total_par_proof_time = MdTableCell::new(0.0, Some(0.0));
         for (group_name, metrics) in &self.by_group {
             let stats = metrics.get(PROOF_TIME_LABEL);
-            let execute_stats = metrics.get(EXECUTE_TIME_LABEL);
+            let execute_metered_stats = metrics.get(EXECUTE_METERED_TIME_LABEL);
             if stats.is_none() {
                 continue;
             }
@@ -189,21 +189,23 @@ impl AggregateMetrics {
                 *total_par_proof_time.diff.as_mut().unwrap() += max.diff.unwrap_or(0.0);
 
                 // Account for the fact that execution is serial
-                // Add total execution time for the app proofs, and subtract the max segment
-                // execution time
+                // Use execute_metered_time_ms directly (no summing needed since it's not
+                // per-segment)
                 if group_name != "leaf"
                     && group_name != "root"
                     && group_name != "halo2_outer"
                     && group_name != "halo2_wrapper"
                     && !group_name.starts_with("internal")
                 {
-                    let execute_stats = execute_stats.unwrap();
-                    total_par_proof_time.val +=
-                        (execute_stats.sum.val - execute_stats.max.val) / 1000.0;
-                    *total_par_proof_time.diff.as_mut().unwrap() +=
-                        (execute_stats.sum.diff.unwrap_or(0.0)
-                            - execute_stats.max.diff.unwrap_or(0.0))
-                            / 1000.0;
+                    if let Some(execute_metered_stats) = execute_metered_stats {
+                        // For metered metrics without segment labels, we just use the value
+                        // directly Count is 1, so avg = sum = max = min =
+                        // value
+                        total_par_proof_time.val += execute_metered_stats.avg.val / 1000.0;
+                        if let Some(diff) = execute_metered_stats.avg.diff {
+                            *total_par_proof_time.diff.as_mut().unwrap() += diff / 1000.0;
+                        }
+                    }
                 }
             }
         }
@@ -295,11 +297,22 @@ impl AggregateMetrics {
             for metric_name in names {
                 let summary = summaries.get(metric_name);
                 if let Some(summary) = summary {
-                    writeln!(
-                        writer,
-                        "| `{:<20}` | {:<10} | {:<10} | {:<10} | {:<10} |",
-                        metric_name, summary.avg, summary.sum, summary.max, summary.min,
-                    )?;
+                    // Special handling for execute_metered metrics (not aggregated across segments)
+                    if metric_name == EXECUTE_METERED_TIME_LABEL
+                        || metric_name == EXECUTE_METERED_INSN_MI_S_LABEL
+                    {
+                        writeln!(
+                            writer,
+                            "| `{:<20}` | {:<10} | {:<10} | {:<10} | {:<10} |",
+                            metric_name, "-", summary.sum, "-", "-",
+                        )?;
+                    } else {
+                        writeln!(
+                            writer,
+                            "| `{:<20}` | {:<10} | {:<10} | {:<10} | {:<10} |",
+                            metric_name, summary.avg, summary.sum, summary.max, summary.min,
+                        )?;
+                    }
                 }
             }
             writeln!(writer)?;
@@ -384,7 +397,11 @@ pub const PROOF_TIME_LABEL: &str = "total_proof_time_ms";
 pub const CELLS_USED_LABEL: &str = "main_cells_used";
 pub const CYCLES_LABEL: &str = "total_cycles";
 pub const EXECUTE_E1_TIME_LABEL: &str = "execute_e1_time_ms";
+pub const EXECUTE_E1_INSN_MI_S_LABEL: &str = "execute_e1_insn_mi/s";
 pub const EXECUTE_METERED_TIME_LABEL: &str = "execute_metered_time_ms";
+pub const EXECUTE_METERED_INSN_MI_S_LABEL: &str = "execute_metered_insn_mi/s";
+pub const EXECUTE_E3_TIME_LABEL: &str = "execute_e3_time_ms";
+pub const EXECUTE_E3_INSN_MI_S_LABEL: &str = "execute_e3_insn_mi/s";
 pub const EXECUTE_TIME_LABEL: &str = "execute_time_ms";
 pub const TRACE_GEN_TIME_LABEL: &str = "trace_gen_time_ms";
 pub const PROVE_EXCL_TRACE_TIME_LABEL: &str = "stark_prove_excluding_trace_time_ms";
@@ -394,7 +411,11 @@ pub const VM_METRIC_NAMES: &[&str] = &[
     CELLS_USED_LABEL,
     CYCLES_LABEL,
     EXECUTE_E1_TIME_LABEL,
+    EXECUTE_E1_INSN_MI_S_LABEL,
     EXECUTE_METERED_TIME_LABEL,
+    EXECUTE_METERED_INSN_MI_S_LABEL,
+    EXECUTE_E3_TIME_LABEL,
+    EXECUTE_E3_INSN_MI_S_LABEL,
     EXECUTE_TIME_LABEL,
     TRACE_GEN_TIME_LABEL,
     PROVE_EXCL_TRACE_TIME_LABEL,


### PR DESCRIPTION
## Summary
- Add support for execute_e1, execute_metered, and execute_e3 metrics in openvm-prof
- Update parallel proof time calculation to use execute_metered_time_ms directly (without summing across segments)
- Display execute_metered metrics with only sum values (dashes in avg/max/min columns) to indicate they are not aggregated

## Changes
1. Added new metric constants for e1, metered, and e3 execution times and instruction rates
2. Updated `VM_METRIC_NAMES` to include all new metrics
3. Modified `compute_total()` to use `execute_metered_time_ms` directly instead of summing `execute_time_ms` per segment
4. Updated markdown output formatting to show execute_metered metrics with dashes in non-sum columns

## Test plan
- Tested with provided `benchmarks/metrics.json` file
- Verified new metrics appear correctly in markdown output
- Confirmed execute_metered metrics display only sum values with dashes in other columns

🤖 Generated with [Claude Code](https://claude.ai/code)