### PR TITLE
fix(new-execution): prevent segmentation in single segment executor

### DIFF
--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -62,11 +62,7 @@ pub(super) fn compute_root_proof_heights(
         .execute_metered(root_exe.clone(), root_input.write(), widths, interactions)
         .unwrap();
     let res = vm
-        .execute_with_max_heights_and_compute_heights(
-            root_exe,
-            root_input.write(),
-            &max_trace_heights,
-        )
+        .execute_and_compute_heights(root_exe, root_input.write(), &max_trace_heights)
         .unwrap();
     let air_heights: Vec<_> = res
         .air_heights

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -44,7 +44,7 @@ impl RootVerifierLocalProver {
             .unwrap();
         let result = self
             .executor_for_heights
-            .execute_with_max_heights_and_compute_heights(
+            .execute_and_compute_heights(
                 self.root_verifier_pk.root_committed_exe.exe.clone(),
                 input.write(),
                 &max_trace_heights,
@@ -73,7 +73,7 @@ impl SingleSegmentVmProver<RootSC> for RootVerifierLocalProver {
             .map(|&height| height as u32)
             .collect_vec();
         let mut proof_input = vm
-            .execute_with_max_heights_and_generate(
+            .execute_and_generate(
                 self.root_verifier_pk.root_committed_exe.clone(),
                 input,
                 &trace_heights,

--- a/crates/sdk/src/prover/vm/local.rs
+++ b/crates/sdk/src/prover/vm/local.rs
@@ -186,11 +186,7 @@ where
             )
             .expect("execute_metered failed");
         let proof_input = executor
-            .execute_with_max_heights_and_generate(
-                self.committed_exe.clone(),
-                input,
-                &max_trace_heights,
-            )
+            .execute_and_generate(self.committed_exe.clone(), input, &max_trace_heights)
             .unwrap();
 
         let vm = VirtualMachine::new(e, executor.config);

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -109,7 +109,7 @@ fn run_leaf_verifier(
         &leaf_vm_vk.num_interactions(),
     )?;
 
-    let exe_result = executor.execute_with_max_heights_and_compute_heights(
+    let exe_result = executor.execute_and_compute_heights(
         leaf_committed_exe.exe.clone(),
         verifier_input.write_to_stream(),
         &max_trace_heights,

--- a/crates/vm/src/arch/execution_mode/metered/bounded.rs
+++ b/crates/vm/src/arch/execution_mode/metered/bounded.rs
@@ -19,9 +19,9 @@ pub struct MeteredCtxBounded {
     num_access_adapters: u8,
     as_byte_alignment_bits: Vec<u8>,
     pub memory_dimensions: MemoryDimensions,
-
     // Indices of leaf nodes in the memory merkle tree
     pub leaf_indices: Vec<u64>,
+
     pub instret_last_segment_check: u64,
     pub segments: Vec<Segment>,
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -645,82 +645,6 @@ where
         self.trace_height_constraints = constraints;
     }
 
-    /// Executes a program, compute the trace heights, and returns the public values.
-    pub fn execute_and_compute_heights(
-        &self,
-        exe: impl Into<VmExe<F>>,
-        input: impl Into<Streams<F>>,
-    ) -> Result<SingleSegmentVmExecutionResult<F>, ExecutionError> {
-        let segment = {
-            let mut segment = self.execute_impl(exe.into(), input.into(), None)?;
-            segment.chip_complex.finalize_memory();
-            segment
-        };
-        let air_heights = segment.chip_complex.current_trace_heights();
-        let vm_heights = segment.chip_complex.get_internal_trace_heights();
-        let public_values = if let Some(pv_chip) = segment.chip_complex.public_values_chip() {
-            pv_chip.step.get_custom_public_values()
-        } else {
-            vec![]
-        };
-        Ok(SingleSegmentVmExecutionResult {
-            public_values,
-            air_heights,
-            vm_heights,
-        })
-    }
-
-    /// Executes a program and returns its proof input.
-    pub fn execute_and_generate<SC: StarkGenericConfig>(
-        &self,
-        committed_exe: Arc<VmCommittedExe<SC>>,
-        input: impl Into<Streams<F>>,
-    ) -> Result<ProofInput<SC>, GenerationError>
-    where
-        Domain<SC>: PolynomialSpace<Val = F>,
-        VC::Executor: Chip<SC>,
-        VC::Periphery: Chip<SC>,
-    {
-        let segment = self.execute_impl(committed_exe.exe.clone(), input, None)?;
-        let proof_input = tracing::info_span!("trace_gen").in_scope(|| {
-            segment.generate_proof_input(Some(committed_exe.committed_program.clone()))
-        })?;
-        Ok(proof_input)
-    }
-
-    fn execute_impl(
-        &self,
-        exe: VmExe<F>,
-        input: impl Into<Streams<F>>,
-        trace_heights: Option<&[u32]>,
-    ) -> Result<VmSegmentExecutor<F, VC, TracegenExecutionControl>, ExecutionError> {
-        let chip_complex = create_and_initialize_chip_complex(
-            &self.config,
-            exe.program.clone(),
-            None,
-            trace_heights,
-        )
-        .unwrap();
-
-        let ctrl = TracegenExecutionControl::default();
-        let mut segment = VmSegmentExecutor::new(
-            chip_complex,
-            self.trace_height_constraints.clone(),
-            exe.fn_bounds.clone(),
-            ctrl,
-        );
-
-        if let Some(overridden_heights) = self.overridden_heights.as_ref() {
-            segment.set_override_trace_heights(overridden_heights.clone());
-        }
-
-        let mut exec_state = VmSegmentState::new(0, exe.pc_start, None, input.into(), ());
-        metrics_span("execute_time_ms", || {
-            segment.execute_from_state(&mut exec_state)
-        })?;
-        Ok(segment)
-    }
-
     pub fn execute_e1(
         &self,
         exe: VmExe<F>,
@@ -777,7 +701,10 @@ where
                     .segmentation_strategy
                     .max_trace_height() as u32,
             )
-            .with_max_cells(self.config.system().segmentation_strategy.max_cells());
+            .with_max_cells(self.config.system().segmentation_strategy.max_cells())
+            // TODO(ayush): this is temporary way to prevent segmentation
+            //              add a metered execution mode with no segmentation
+            .with_segment_check_insns(u64::MAX);
         let mut executor = VmSegmentExecutor::<F, VC, _>::new(
             chip_complex,
             self.trace_height_constraints.clone(),
@@ -830,8 +757,41 @@ where
         Ok(segment.trace_heights)
     }
 
+    fn execute_impl(
+        &self,
+        exe: VmExe<F>,
+        input: impl Into<Streams<F>>,
+        trace_heights: Option<&[u32]>,
+    ) -> Result<VmSegmentExecutor<F, VC, TracegenExecutionControl>, ExecutionError> {
+        let chip_complex = create_and_initialize_chip_complex(
+            &self.config,
+            exe.program.clone(),
+            None,
+            trace_heights,
+        )
+        .unwrap();
+
+        let ctrl = TracegenExecutionControl::default();
+        let mut segment = VmSegmentExecutor::new(
+            chip_complex,
+            self.trace_height_constraints.clone(),
+            exe.fn_bounds.clone(),
+            ctrl,
+        );
+
+        if let Some(overridden_heights) = self.overridden_heights.as_ref() {
+            segment.set_override_trace_heights(overridden_heights.clone());
+        }
+
+        let mut exec_state = VmSegmentState::new(0, exe.pc_start, None, input.into(), ());
+        metrics_span("execute_time_ms", || {
+            segment.execute_from_state(&mut exec_state)
+        })?;
+        Ok(segment)
+    }
+
     /// Executes a program and returns its proof input.
-    pub fn execute_with_max_heights_and_generate<SC: StarkGenericConfig>(
+    pub fn execute_and_generate<SC: StarkGenericConfig>(
         &self,
         committed_exe: Arc<VmCommittedExe<SC>>,
         input: impl Into<Streams<F>>,
@@ -851,7 +811,7 @@ where
     }
 
     /// Executes a program, compute the trace heights, and returns the public values.
-    pub fn execute_with_max_heights_and_compute_heights(
+    pub fn execute_and_compute_heights(
         &self,
         exe: impl Into<VmExe<F>>,
         input: impl Into<Streams<F>>,

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -146,11 +146,7 @@ fn test_vm_override_executor_height() {
         .unwrap();
 
     let res = executor
-        .execute_with_max_heights_and_compute_heights(
-            committed_exe.exe.clone(),
-            vec![],
-            &max_trace_heights,
-        )
+        .execute_and_compute_heights(committed_exe.exe.clone(), vec![], &max_trace_heights)
         .unwrap();
     // Memory trace heights are not computed during execution.
     assert_eq!(
@@ -214,7 +210,7 @@ fn test_vm_override_executor_height() {
         Some(overridden_heights),
     );
     let proof_input = executor
-        .execute_with_max_heights_and_generate(committed_exe, vec![], &max_trace_heights)
+        .execute_and_generate(committed_exe, vec![], &max_trace_heights)
         .unwrap();
     let air_heights: Vec<_> = proof_input
         .per_air
@@ -320,7 +316,7 @@ fn test_vm_public_values() {
             .unwrap();
 
         let exe_result = single_vm
-            .execute_with_max_heights_and_compute_heights(program, vec![], &max_trace_heights)
+            .execute_and_compute_heights(program, vec![], &max_trace_heights)
             .unwrap();
         assert_eq!(
             exe_result.public_values,
@@ -331,7 +327,7 @@ fn test_vm_public_values() {
             .concat(),
         );
         let proof_input = single_vm
-            .execute_with_max_heights_and_generate(committed_exe, vec![], &max_trace_heights)
+            .execute_and_generate(committed_exe, vec![], &max_trace_heights)
             .unwrap();
         vm.engine
             .prove_then_verify(&pk, proof_input)

--- a/extensions/native/compiler/tests/public_values.rs
+++ b/extensions/native/compiler/tests/public_values.rs
@@ -46,7 +46,7 @@ fn test_compiler_public_values() {
         .unwrap();
 
     let exe_result = executor
-        .execute_with_max_heights_and_compute_heights(program, vec![], &max_trace_heights)
+        .execute_and_compute_heights(program, vec![], &max_trace_heights)
         .unwrap();
     assert_eq!(
         exe_result


### PR DESCRIPTION
- added a `segment_check_insns` paramter in `MeteredCtx`. this is set to `u64::MAX` to prevent segmentation in `SingleSegmentExecutor`
- removed unused functions from `SingleSegmentExecutor`