### PR TITLE
feat(toolchain): support `getrandom` v0.2 and v0.3 simultaneously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,6 +4302,7 @@ version = "1.3.0-rc.1"
 dependencies = [
  "bytemuck",
  "chrono",
+ "getrandom 0.2.15",
  "getrandom 0.3.1",
  "num-bigint 0.4.6",
  "openvm-custom-insn",

--- a/crates/toolchain/openvm/Cargo.toml
+++ b/crates/toolchain/openvm/Cargo.toml
@@ -17,6 +17,9 @@ bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
 getrandom = { version = "0.3", optional = true }
+getrandom-v02 = { version = "0.2", package = "getrandom", features = [
+    "custom",
+], optional = true }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
 num-bigint.workspace = true
@@ -27,7 +30,7 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 [features]
 default = ["getrandom-unsupported"]
 # Defines a custom getrandom backend that always errors. This feature should be enabled if you are sure getrandom is never used but it is pulled in as a compilation dependency.
-getrandom-unsupported = ["dep:getrandom"]
+getrandom-unsupported = ["dep:getrandom", "dep:getrandom-v02"]
 # The zkVM uses a bump-pointer heap allocator by default which does not free
 # memory. This will use a slower linked-list heap allocator to reclaim memory.
 heap-embedded-alloc = ["openvm-platform/heap-embedded-alloc"]

--- a/crates/toolchain/openvm/src/getrandom.rs
+++ b/crates/toolchain/openvm/src/getrandom.rs
@@ -12,3 +12,11 @@ unsafe extern "Rust" fn __getrandom_v03_custom(
 ) -> Result<(), getrandom::Error> {
     Err(getrandom::Error::UNSUPPORTED)
 }
+
+#[cfg(feature = "getrandom-unsupported")]
+pub fn __getrandom_v02_custom(_dest: &mut [u8]) -> Result<(), getrandom_v02::Error> {
+    Err(getrandom_v02::Error::UNSUPPORTED)
+}
+// https://docs.rs/getrandom/0.2.16/src/getrandom/custom.rs.html#74
+#[cfg(feature = "getrandom-unsupported")]
+getrandom_v02::register_custom_getrandom!(__getrandom_v02_custom);

--- a/extensions/rv32im/tests/programs/Cargo.toml
+++ b/extensions/rv32im/tests/programs/Cargo.toml
@@ -14,13 +14,13 @@ serde = { version = "1.0", default-features = false, features = [
     "derive",
 ] }
 getrandom = { version = "0.3", optional = true }
+getrandom-v02 = { version = "0.2", package = "getrandom", optional = true }
 
 [features]
 default = []
 std = ["serde/std", "openvm/std"]
 heap-embedded-alloc = ["openvm/heap-embedded-alloc"]
 getrandom-unsupported = ["openvm/getrandom-unsupported"]
-getrandom = ["dep:getrandom"]
 
 [profile.release]
 panic = "abort"
@@ -30,3 +30,7 @@ lto = "thin"    # turn on lto = fat to decrease binary size, but this optimizes 
 [[example]]
 name = "getrandom"
 required-features = ["getrandom"]
+
+[[example]]
+name = "getrandom_v02"
+required-features = ["getrandom-v02"]

--- a/extensions/rv32im/tests/programs/examples/getrandom_v02.rs
+++ b/extensions/rv32im/tests/programs/examples/getrandom_v02.rs
@@ -1,13 +1,15 @@
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#[cfg(feature = "getrandom-v02")]
+#[cfg(feature = "getrandom")]
 compile_error!("this program is not compatible with getrandom v0.2");
-
-use getrandom::Error;
+use getrandom_v02::Error;
+// For this to work, need to enable the "custom" feature in getrandom-v02
+#[cfg(all(feature = "getrandom-v02", not(feature = "getrandom-unsupported")))]
+getrandom_v02::register_custom_getrandom!(__getrandom_v02_custom);
 
 fn get_random_u128() -> Result<u128, Error> {
     let mut buf = [0u8; 16];
-    getrandom::fill(&mut buf)?;
+    getrandom_v02::getrandom(&mut buf)?;
     Ok(u128::from_ne_bytes(buf))
 }
 
@@ -32,11 +34,10 @@ pub fn main() {
 }
 
 // custom user-specified getrandom
-#[cfg(all(feature = "getrandom", not(feature = "getrandom-unsupported")))]
-#[no_mangle]
-unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
-    for i in 0..len {
-        *dest.add(i) = 0u8;
+#[cfg(all(feature = "getrandom-v02", not(feature = "getrandom-unsupported")))]
+pub fn __getrandom_v02_custom(dest: &mut [u8]) -> Result<(), Error> {
+    for byte in dest {
+        *byte = 0u8;
     }
     Ok(())
 }

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -276,13 +276,15 @@ mod tests {
         executor.execute(exe, vec![]).unwrap();
     }
 
-    #[test_case(vec!["getrandom", "getrandom-unsupported"])]
-    #[test_case(vec!["getrandom"])]
-    fn test_getrandom_unsupported(features: Vec<&str>) {
+    #[test_case("getrandom", vec!["getrandom", "getrandom-unsupported"])]
+    #[test_case("getrandom", vec!["getrandom"])]
+    #[test_case("getrandom_v02", vec!["getrandom-v02", "getrandom-unsupported"])]
+    #[test_case("getrandom_v02", vec!["getrandom-v02/custom"])]
+    fn test_getrandom_unsupported(program: &str, features: Vec<&str>) {
         let config = Rv32ImConfig::default();
         let elf = build_example_program_at_path_with_features(
             get_programs_dir!(),
-            "getrandom",
+            program,
             &features,
             &config,
         )


### PR DESCRIPTION
With the v1.3.0-rc release, we moved to supporting `getrandom v0.3`. However some libraries like `ecdsa` still use `getrandom v0.2` and it would give the unsupported backend error.

Turns out it is possible to support both simultaneously.

Closes INT-4187