### PR TITLE
ci(new-execution): run codspeed instrumentation on push

### DIFF
--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -68,7 +68,7 @@ jobs:
       - runs-on=${{ github.run_id }}
       - runner=8cpu-linux-x64
       - extras=s3-cache
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request'
 
     env:
       CODSPEED_RUNNER_MODE: instrumentation


### PR DESCRIPTION
- enable codspeed instrumentation workflow on push. walltime seems unreliable so it's better to track instrumentation too. instrumentation takes time so it's still disabled for prs