### PR TITLE
fix(new-execution): disable loads from address space 1

### DIFF
--- a/docs/specs/ISA.md
+++ b/docs/specs/ISA.md
@@ -327,7 +327,7 @@ unsigned integer, and convert to field element. In the instructions below, `[c:4
 #### Load/Store
 
 For all load/store instructions, we assume the operand `c` is in `[0, 2^16)`, and we fix address spaces `d = 1`.
-The address space `e` can be `0` or `2` for load instructions, and `2`, `3`, or `4` for store instructions.
+The address space `e` is `2` for load instructions, and can be `2`, `3`, or `4` for store instructions.
 The operand `g` must be a boolean. We let `sign_extend(decompose(c)[0:2], g)` denote the `i32` defined by first taking
 the unsigned integer encoding of `c` as 16 bits, then sign extending it to 32 bits using the sign bit `g`, and considering
 the 32 bits as the 2's complement of an `i32`.

--- a/docs/specs/ISA.md
+++ b/docs/specs/ISA.md
@@ -117,7 +117,7 @@ address spaces and the size of each address space are configurable constants.
 - Valid pointers are field elements that lie in `[0, 2^pointer_max_bits)`, for
   configuration constant `pointer_max_bits`. When accessing an address out of `[0, 2^pointer_max_bits)`, the VM should
   panic.
-
+- For the register address space (address space `1`), the maximum valid pointer value is `128`, corresponding to 32 registers with 4 byte limbs each.
 These configuration constants must satisfy `addr_space_height, pointer_max_bits <= F::bits() - 2`. We use the following notation
 to denote cells in memory:
 
@@ -171,7 +171,7 @@ structures during runtime execution:
 - `hint_space`: a vector of vectors of field elements used to store hints during runtime execution
   via [phantom sub-instructions](#phantom-sub-instructions) such as `NativeHintLoad`. The outer `hint_space` vector is append-only, but
   each internal `hint_space[hint_id]` vector may be mutated, including deletions, by the host.
-- `kv_store`: a read-only key-value store for hints. Executors(e.g. `Rv32HintLoadByKey`) can read data from `kv_store` 
+- `kv_store`: a read-only key-value store for hints. Executors(e.g. `Rv32HintLoadByKey`) can read data from `kv_store`
   at runtime. `kv_store` is designed for general purposes so both key and value are byte arrays. Encoding of key/value
   are decided by each executor. Users need to use the corresponding encoding when adding data to `kv_store`.
 
@@ -327,7 +327,7 @@ unsigned integer, and convert to field element. In the instructions below, `[c:4
 #### Load/Store
 
 For all load/store instructions, we assume the operand `c` is in `[0, 2^16)`, and we fix address spaces `d = 1`.
-The address space `e` can be `0`, `1`, or `2` for load instructions, and `2`, `3`, or `4` for store instructions.
+The address space `e` can be `0` or `2` for load instructions, and `2`, `3`, or `4` for store instructions.
 The operand `g` must be a boolean. We let `sign_extend(decompose(c)[0:2], g)` denote the `i32` defined by first taking
 the unsigned integer encoding of `c` as 16 bits, then sign extending it to 32 bits using the sign bit `g`, and considering
 the 32 bits as the 2's complement of an `i32`.

--- a/docs/specs/ISA.md
+++ b/docs/specs/ISA.md
@@ -117,7 +117,7 @@ address spaces and the size of each address space are configurable constants.
 - Valid pointers are field elements that lie in `[0, 2^pointer_max_bits)`, for
   configuration constant `pointer_max_bits`. When accessing an address out of `[0, 2^pointer_max_bits)`, the VM should
   panic.
-- For the register address space (address space `1`), the maximum valid pointer value is `128`, corresponding to 32 registers with 4 byte limbs each.
+- For the register address space (address space `1`), valid pointers lie in `[0, 128)`, corresponding to 32 registers with 4 byte limbs each.
 These configuration constants must satisfy `addr_space_height, pointer_max_bits <= F::bits() - 2`. We use the following notation
 to denote cells in memory:
 

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -368,6 +368,7 @@ where
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
         debug_assert!(e.as_canonical_u32() != RV32_IMM_AS);
+        debug_assert!(e.as_canonical_u32() != RV32_REGISTER_AS);
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),
@@ -449,6 +450,7 @@ where
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
         debug_assert!(e.as_canonical_u32() != RV32_IMM_AS);
+        debug_assert!(e.as_canonical_u32() != RV32_REGISTER_AS);
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -91,7 +91,7 @@ fn set_and_execute(
 
     let is_load = [LOADW, LOADHU, LOADBU].contains(&opcode);
     let mem_as = mem_as.unwrap_or(if is_load {
-        *[1, 2].choose(rng).unwrap()
+        2
     } else {
         *[2, 3, 4].choose(rng).unwrap()
     });
@@ -109,9 +109,6 @@ fn set_and_execute(
             some_prev_data = [F::ZERO; RV32_REGISTER_NUM_LIMBS];
         }
         tester.write(1, a, some_prev_data);
-        if mem_as == 1 && ptr_val - shift_amount == 0 {
-            read_data = [F::ZERO; RV32_REGISTER_NUM_LIMBS];
-        }
         tester.write(mem_as, (ptr_val - shift_amount) as usize, read_data);
     } else {
         if mem_as == 4 {


### PR DESCRIPTION
- update isa spec to specify that loads are only allowed from address space 2
- update isa spec to specify that the maximum valid pointer value in address space 1 is 127
- add a `debug_assert` that load address space is not 1 in loadstore instructions

Towards INT-4237