### PR TITLE
fix(new-execution): adapter offset should be boundary_idx + 1

### DIFF
--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -16,8 +16,10 @@ pub struct MeteredCtx<const PAGE_BITS: usize = 6> {
 }
 
 impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         constant_trace_heights: Vec<Option<usize>>,
+        has_public_values_chip: bool,
         continuations_enabled: bool,
         as_byte_alignment_bits: Vec<u8>,
         memory_dimensions: MemoryDimensions,
@@ -38,10 +40,19 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
                 .unzip();
 
         let memory_ctx = MemoryCtx::new(
+            has_public_values_chip,
             continuations_enabled,
             as_byte_alignment_bits,
             memory_dimensions,
         );
+
+        // Assert that the indices are correct
+        debug_assert_eq!(&air_names[memory_ctx.boundary_idx], "Boundary");
+        if let Some(merkle_tree_index) = memory_ctx.merkle_tree_index {
+            debug_assert_eq!(&air_names[merkle_tree_index], "Merkle");
+        }
+        debug_assert_eq!(&air_names[memory_ctx.adapter_offset], "AccessAdapter<2>");
+
         let segmentation_ctx = SegmentationCtx::new(air_names, widths, interactions);
 
         Self {

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -38,23 +38,24 @@ pub struct MemoryCtx<const PAGE_BITS: usize> {
     pub page_indices: BitSet,
     memory_dimensions: MemoryDimensions,
     as_byte_alignment_bits: Vec<u8>,
-    boundary_idx: usize,
-    merkle_tree_index: Option<usize>,
-    adapter_offset: usize,
+    pub boundary_idx: usize,
+    pub merkle_tree_index: Option<usize>,
+    pub adapter_offset: usize,
     chunk: u32,
     chunk_bits: u32,
 }
 
 impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
     pub fn new(
+        has_public_values_chip: bool,
         continuations_enabled: bool,
         as_byte_alignment_bits: Vec<u8>,
         memory_dimensions: MemoryDimensions,
     ) -> Self {
-        let boundary_idx = if continuations_enabled {
-            PUBLIC_VALUES_AIR_ID
-        } else {
+        let boundary_idx = if has_public_values_chip {
             PUBLIC_VALUES_AIR_ID + 1
+        } else {
+            PUBLIC_VALUES_AIR_ID
         };
 
         let merkle_tree_index = if continuations_enabled {
@@ -66,7 +67,7 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         let adapter_offset = if continuations_enabled {
             boundary_idx + 2
         } else {
-            boundary_idx
+            boundary_idx + 1
         };
 
         let chunk = if continuations_enabled {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -304,6 +304,7 @@ where
             executor.metrics = state.metrics;
         }
 
+        let has_public_values_chip = executor.chip_complex.config().has_public_values_chip();
         let continuations_enabled = executor
             .chip_complex
             .memory_controller()
@@ -323,6 +324,7 @@ where
 
         let ctx = MeteredCtx::new(
             constant_trace_heights,
+            has_public_values_chip,
             continuations_enabled,
             as_alignment,
             executor
@@ -711,6 +713,7 @@ where
             MeteredExecutionControl,
         );
 
+        let has_public_values_chip = executor.chip_complex.config().has_public_values_chip();
         let continuations_enabled = executor
             .chip_complex
             .memory_controller()
@@ -730,6 +733,7 @@ where
 
         let ctx = MeteredCtx::new(
             constant_trace_heights,
+            has_public_values_chip,
             continuations_enabled,
             as_alignment,
             self.config.system().memory_config.memory_dimensions(),


### PR DESCRIPTION
@Golovanov399 pointed out that the `adapter_offset` was being calculated incorrectly. i did a couple of things in this pr:
- fixed `adapter_offset` and index finding logic
- added a `debug_assert` to verify that the calculated indices are correct