### PR TITLE
fix: `getrandom` pulling in `std`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "crates/circuits/primitives/**"
       - "crates/vm/**"
+      - "crates/toolchain/**"
       - "crates/sdk/**"
       - "crates/cli/**"
       - "examples/**"

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "crates/circuits/**"
       - "crates/vm/**"
+      - "crates/toolchain/**"
       - "extensions/**"
       - "Cargo.toml"
       - ".github/workflows/extension-tests.yml"
@@ -51,6 +52,7 @@ jobs:
           filters: |
             - "crates/circuits/**"
             - "crates/vm/**"
+            - "crates/toolchain/**"
             - "extensions/${{ matrix.extensions.path }}/**"
             - ".github/workflows/extension-tests.yml"
       - name: Skip if no changes

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "crates/circuits/**"
       - "crates/vm/**"
+      - "crates/toolchain/**"
       - "extensions/**"
       - "guest-libs/**"
       - "Cargo.toml"
@@ -52,6 +53,7 @@ jobs:
           filters: |
             - "crates/circuits/**"
             - "crates/vm/**"
+            - "crates/toolchain/**"
             - "extensions/**"
             - "guest-libs/${{ matrix.crate.path }}/**"
             - ".github/workflows/guest-lib-tests.yml"

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -7,11 +7,7 @@ on:
     branches: ["**"]
     paths:
       - "crates/vm/**"
-      - "crates/toolchain/platform/**"
-      - "crates/toolchain/instructions/**"
-      - "crates/toolchain/build/**"
-      - "crates/toolchain/macros/**"
-      - "crates/toolchain/tests/**"
+      - "crates/toolchain/**"
       - "Cargo.toml"
       - ".github/workflows/riscv.yml"
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "crates/circuits/primitives/**"
       - "crates/vm/**"
+      - "crates/toolchain/**"
       - "crates/sdk/**"
       - "Cargo.toml"
       - ".github/workflows/sdk.yml"

--- a/crates/toolchain/openvm/Cargo.toml
+++ b/crates/toolchain/openvm/Cargo.toml
@@ -37,4 +37,4 @@ heap-embedded-alloc = ["openvm-platform/heap-embedded-alloc"]
 std = ["serde/std", "openvm-platform/std"]
 
 [package.metadata.cargo-shear]
-ignored = ["openvm-custom-insn"]
+ignored = ["openvm-custom-insn", "getrandom"]

--- a/crates/toolchain/openvm/Cargo.toml
+++ b/crates/toolchain/openvm/Cargo.toml
@@ -16,8 +16,8 @@ serde = { workspace = true, features = ["alloc"] }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-getrandom = { version = "0.3", optional = true }
-getrandom-v02 = { version = "0.2", package = "getrandom", features = [
+getrandom = { version = "0.3", default-features = false, optional = true }
+getrandom-v02 = { version = "0.2", package = "getrandom", default-features = false, features = [
     "custom",
 ], optional = true }
 

--- a/crates/toolchain/openvm/src/getrandom.rs
+++ b/crates/toolchain/openvm/src/getrandom.rs
@@ -13,10 +13,14 @@ unsafe extern "Rust" fn __getrandom_v03_custom(
     Err(getrandom::Error::UNSUPPORTED)
 }
 
+/// This entrypoint for getrandom is used for versions < 0.3
+// The ABI is defined here: https://github.com/rust-random/getrandom/blob/ce4144b2c16fe1422037c93e267e6a52336e0834/src/custom.rs#L74
+// @dev If you try to use the `getrandom_v02::Error`, it somehow triggers std library
 #[cfg(feature = "getrandom-unsupported")]
-pub fn __getrandom_v02_custom(_dest: &mut [u8]) -> Result<(), getrandom_v02::Error> {
-    Err(getrandom_v02::Error::UNSUPPORTED)
+#[no_mangle]
+unsafe fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
+    __getrandom_v03_custom(dest, len)
+        .map_err(|e| e.raw_os_error().unwrap_or(2))
+        .err()
+        .unwrap_or(0) as u32
 }
-// https://docs.rs/getrandom/0.2.16/src/getrandom/custom.rs.html#74
-#[cfg(feature = "getrandom-unsupported")]
-getrandom_v02::register_custom_getrandom!(__getrandom_v02_custom);


### PR DESCRIPTION
For reasons I am not entirely clear on, when you use `getrandom_v02::Error`, the `getrandom` crate pulls in `std` library. But if you just directly implement what the `register_custom_getrandom!` macro does, this goes away...

Fixes CI failure.

Full disclosure: I got the idea from https://github.com/risc0/risc0/pull/3106/files#diff-fd010fc66ba8d918981d2705c0d10cd65d19db599969bb29bb14caffa62d3b65R95