### PR TITLE
refactor: move `RecordArena` into `TracegenCtx`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,7 +5412,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.1.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=0aa464b8a93c19bb76ae3f46036587735023c2c1#0aa464b8a93c19bb76ae3f46036587735023c2c1"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad#37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -5440,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.1.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=0aa464b8a93c19bb76ae3f46036587735023c2c1#0aa464b8a93c19bb76ae3f46036587735023c2c1"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad#37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad"
 dependencies = [
  "dashmap",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "0aa464b8a93c19bb76ae3f46036587735023c2c1", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "0aa464b8a93c19bb76ae3f46036587735023c2c1", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -206,7 +206,7 @@ impl<F, A> FieldExpressionMetadata<F, A> {
 
 impl<F, A> AdapterCoreMetadata for FieldExpressionMetadata<F, A>
 where
-    A: AdapterTraceStep<F, ()>,
+    A: AdapterTraceStep<F>,
 {
     #[inline(always)]
     fn get_adapter_width() -> usize {
@@ -358,7 +358,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let (mut adapter_record, mut core_record) = state.ctx.alloc(self.get_record_layout());
 
         A::start(*state.pc, state.memory, &mut adapter_record);

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -346,25 +346,20 @@ impl<A> FieldExpressionStep<A> {
     }
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for FieldExpressionStep<A>
+impl<F, A> TraceStep<F> for FieldExpressionStep<A>
 where
     F: PrimeField32,
-    A: 'static
-        + AdapterTraceStep<F, CTX, ReadData: Into<DynArray<u8>>, WriteData: From<DynArray<u8>>>,
+    A: 'static + AdapterTraceStep<F, ReadData: Into<DynArray<u8>>, WriteData: From<DynArray<u8>>>,
 {
     type RecordLayout = FieldExpressionRecordLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, FieldExpressionCoreRecordMut<'a>);
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
-        let (mut adapter_record, mut core_record) = arena.alloc(self.get_record_layout());
+    ) -> Result<()> {
+        let (mut adapter_record, mut core_record) = state.ctx.alloc(self.get_record_layout());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -397,10 +392,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for FieldExpressionStep<A>
+impl<F, A> TraceFiller<F> for FieldExpressionStep<A>
 where
     F: PrimeField32 + Send + Sync + Clone,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         // Get the core record from the row slice

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -176,6 +176,24 @@ where
     }
 }
 
+impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
+    fn execute(
+        &mut self,
+        memory: &mut MemoryController<F>,
+        streams: &mut Streams<F>,
+        rng: &mut StdRng,
+        instruction: &Instruction<F>,
+        prev_state: ExecutionState<u32>,
+    ) -> Result<ExecutionState<u32>> {
+        self.borrow_mut()
+            .execute(memory, streams, rng, instruction, prev_state)
+    }
+
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        self.borrow().get_opcode_name(opcode)
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Default, AlignedBorrow, Serialize, Deserialize)]
 pub struct ExecutionState<T> {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -176,24 +176,6 @@ where
     }
 }
 
-impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
-    fn execute(
-        &mut self,
-        memory: &mut MemoryController<F>,
-        streams: &mut Streams<F>,
-        rng: &mut StdRng,
-        instruction: &Instruction<F>,
-        prev_state: ExecutionState<u32>,
-    ) -> Result<ExecutionState<u32>> {
-        self.borrow_mut()
-            .execute(memory, streams, rng, instruction, prev_state)
-    }
-
-    fn get_opcode_name(&self, opcode: usize) -> String {
-        self.borrow().get_opcode_name(opcode)
-    }
-}
-
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Default, AlignedBorrow, Serialize, Deserialize)]
 pub struct ExecutionState<T> {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -16,12 +16,12 @@ use super::{
     execution_mode::{metered::MeteredCtx, E1E2ExecutionCtx},
     Streams,
 };
-use crate::system::{
-    memory::{
-        online::{GuestMemory, TracingMemory},
-        MemoryController,
+use crate::{
+    arch::MatrixRecordArena,
+    system::{
+        memory::online::{GuestMemory, TracingMemory},
+        program::ProgramBus,
     },
-    program::ProgramBus,
 };
 
 pub type Result<T> = std::result::Result<T, ExecutionError>;
@@ -102,21 +102,23 @@ impl<F: PrimeField32, CTX> VmStateMut<'_, F, TracingMemory<F>, CTX> {
 }
 
 // TODO: old
-pub trait InstructionExecutor<F> {
+// TEMPORARY: same as TraceStep but without associated types
+pub trait InstructionExecutor<F, RA = MatrixRecordArena<F>> {
     /// Runtime execution of the instruction, if the instruction is owned by the
     /// current instance. May internally store records of this call for later trace generation.
     fn execute(
         &mut self,
-        memory: &mut MemoryController<F>,
-        streams: &mut Streams<F>,
-        rng: &mut StdRng,
+        state: VmStateMut<F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        from_state: ExecutionState<u32>,
-    ) -> Result<ExecutionState<u32>>;
+    ) -> Result<()>;
 
     /// For display purposes. From absolute opcode as `usize`, return the string name of the opcode
     /// if it is a supported opcode by the present executor.
     fn get_opcode_name(&self, opcode: usize) -> String;
+
+    // TEMP patch to keep Chip struct holding matrix but we will first create the chip with no
+    // matrix, keep matrix arena in CTX, then after execution move the matrices into Chip struct
+    fn give_me_my_arena(&mut self, arena: RA);
 }
 
 /// New trait for instruction execution
@@ -176,21 +178,21 @@ where
     }
 }
 
-impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
+impl<F, C: InstructionExecutor<F, RA>, RA> InstructionExecutor<F, RA> for RefCell<C> {
     fn execute(
         &mut self,
-        memory: &mut MemoryController<F>,
-        streams: &mut Streams<F>,
-        rng: &mut StdRng,
+        state: VmStateMut<F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        prev_state: ExecutionState<u32>,
-    ) -> Result<ExecutionState<u32>> {
-        self.borrow_mut()
-            .execute(memory, streams, rng, instruction, prev_state)
+    ) -> Result<()> {
+        self.borrow_mut().execute(state, instruction)
     }
 
     fn get_opcode_name(&self, opcode: usize) -> String {
         self.borrow().get_opcode_name(opcode)
+    }
+
+    fn give_me_my_arena(&mut self, arena: RA) {
+        self.borrow_mut().give_me_my_arena(arena)
     }
 }
 

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -140,8 +140,6 @@ pub trait InsExecutorE1<F> {
     ) -> Result<()>
     where
         F: PrimeField32;
-
-    fn set_trace_height(&mut self, height: usize);
 }
 
 impl<F, C> InsExecutorE1<F> for RefCell<C>
@@ -171,10 +169,6 @@ where
     {
         self.borrow_mut()
             .execute_metered(state, instruction, chip_index)
-    }
-
-    fn set_trace_height(&mut self, height: usize) {
-        self.borrow_mut().set_trace_height(height);
     }
 }
 

--- a/crates/vm/src/arch/execution_mode/tracegen.rs
+++ b/crates/vm/src/arch/execution_mode/tracegen.rs
@@ -22,17 +22,7 @@ impl<F> TracegenCtx<F>
 where
     F: PrimeField32,
 {
-    pub fn new(count: usize) -> Self {
-        let arenas = (0..count)
-            .map(|_| MatrixRecordArena::with_capacity(0, 0))
-            .collect();
-        Self {
-            arenas,
-            instret_end: None,
-        }
-    }
-
-    pub fn new_with_capacity(capacities: &[(usize, usize)]) -> Self {
+    pub fn new_with_capacity(capacities: &[(usize, usize)], instret_end: Option<u64>) -> Self {
         let arenas = capacities
             .iter()
             .map(|&(height, width)| MatrixRecordArena::with_capacity(height, width))
@@ -40,7 +30,7 @@ where
 
         Self {
             arenas,
-            instret_end: None,
+            instret_end,
         }
     }
 }

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -204,6 +204,8 @@ pub struct VmInventory<E, P> {
     /// Order of insertion. The reverse of this will be the order the chips are destroyed
     /// to generate trace.
     pub insertion_order: Vec<ChipId>,
+    /// TEMP: just shoving this somewhere
+    pub executor_id_to_air_id: Vec<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -248,6 +250,7 @@ impl<E, P> VmInventory<E, P> {
             executors: Vec::new(),
             periphery: Vec::new(),
             insertion_order: Vec::new(),
+            executor_id_to_air_id: Vec::new(),
         }
     }
 
@@ -261,6 +264,7 @@ impl<E, P> VmInventory<E, P> {
             executors: self.executors.into_iter().map(|e| e.into()).collect(),
             periphery: self.periphery.into_iter().map(|p| p.into()).collect(),
             insertion_order: self.insertion_order,
+            executor_id_to_air_id: self.executor_id_to_air_id,
         }
     }
 
@@ -329,22 +333,12 @@ impl<E, P> VmInventory<E, P> {
         self.executors.get_mut(*id)
     }
 
-    pub fn get_mut_executor_with_index(&mut self, opcode: &VmOpcode) -> Option<(&mut E, usize)> {
+    pub fn get_mut_executor_with_air_id(&mut self, opcode: &VmOpcode) -> Option<(&mut E, usize)> {
         let id = *self.instruction_lookup.get(opcode)?;
 
         self.executors.get_mut(id).map(|executor| {
-            // TODO(ayush): cache this somewhere
-            let insertion_id = self
-                .insertion_order
-                .iter()
-                .rev()
-                .position(|chip_id| match chip_id {
-                    ChipId::Executor(exec_id) => *exec_id == id,
-                    _ => false,
-                })
-                .unwrap();
-
-            (executor, insertion_id)
+            let air_id = self.executor_id_to_air_id[id];
+            (executor, air_id)
         })
     }
 

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -10,7 +10,7 @@ use getset::Getters;
 use itertools::{zip_eq, Itertools};
 #[cfg(feature = "bench-metrics")]
 use metrics::counter;
-use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor};
+use openvm_circuit_derive::{AnyEnum, InsExecutorE1};
 use openvm_circuit_primitives::{
     utils::next_power_of_two_or_zero,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
@@ -35,8 +35,8 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    vm_poseidon2_config, ExecutionBus, GenerationError, InstructionExecutor, PhantomSubExecutor,
-    SystemConfig, SystemTraceHeights,
+    vm_poseidon2_config, ExecutionBus, GenerationError, PhantomSubExecutor, SystemConfig,
+    SystemTraceHeights,
 };
 #[cfg(feature = "bench-metrics")]
 use crate::metrics::VmMetrics;
@@ -531,7 +531,7 @@ impl<F: PrimeField32> SystemBase<F> {
     }
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, InstructionExecutor, InsExecutorE1)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, InsExecutorE1)]
 pub enum SystemExecutor<F: PrimeField32> {
     PublicValues(PublicValuesChip<F>),
     Phantom(RefCell<PhantomChip<F>>),

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -10,7 +10,7 @@ use getset::Getters;
 use itertools::{zip_eq, Itertools};
 #[cfg(feature = "bench-metrics")]
 use metrics::counter;
-use openvm_circuit_derive::{AnyEnum, InsExecutorE1};
+use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor};
 use openvm_circuit_primitives::{
     utils::next_power_of_two_or_zero,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
@@ -41,7 +41,7 @@ use super::{
 #[cfg(feature = "bench-metrics")]
 use crate::metrics::VmMetrics;
 use crate::{
-    arch::{ExecutionBridge, VmAirWrapper},
+    arch::{ExecutionBridge, InstructionExecutor, VmAirWrapper},
     system::{
         connector::VmConnectorChip,
         memory::{
@@ -531,7 +531,7 @@ impl<F: PrimeField32> SystemBase<F> {
     }
 }
 
-#[derive(ChipUsageGetter, Chip, AnyEnum, From, InsExecutorE1)]
+#[derive(ChipUsageGetter, Chip, AnyEnum, From, InstructionExecutor, InsExecutorE1)]
 pub enum SystemExecutor<F: PrimeField32> {
     PublicValues(PublicValuesChip<F>),
     Phantom(RefCell<PhantomChip<F>>),

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -377,6 +377,7 @@ where
 }
 
 // TEMP[jpw]: buffer should be inside CTX
+#[derive(Default)]
 pub struct MatrixRecordArena<F> {
     pub trace_buffer: Vec<F>,
     pub width: usize,
@@ -1010,10 +1011,6 @@ where
         F: PrimeField32,
     {
         self.step.execute_metered(state, instruction, chip_index)
-    }
-
-    fn set_trace_height(&mut self, height: usize) {
-        self.set_trace_buffer_height(height);
     }
 }
 

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -14,8 +14,6 @@ use openvm_stark_backend::{
 use rand::rngs::StdRng;
 use tracing::instrument;
 
-#[cfg(feature = "bench-metrics")]
-use super::InstructionExecutor;
 use super::{
     execution_control::ExecutionControl, ExecutionError, GenerationError, Streams, SystemConfig,
     VmChipComplex, VmComplexTraceHeights, VmConfig,

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -260,6 +260,8 @@ where
         self.metrics.cycle_count += 1;
 
         if self.system_config().profiling {
+            use crate::arch::InstructionExecutor;
+
             let executor = self.chip_complex.inventory.get_executor(opcode).unwrap();
             let opcode_name = executor.get_opcode_name(opcode.as_usize());
             self.metrics.update_trace_cells(

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -421,6 +421,12 @@ where
             }
 
             let instret_end = state.instret + num_insns;
+            let capacities = main_widths
+                .iter()
+                .zip(trace_heights.iter())
+                .map(|(&w, &h)| (w, h as usize))
+                .collect::<Vec<_>>();
+            let ctx = TracegenCtx::new_with_capacity(&capacities);
             let ctx = TracegenCtx::new(Some(instret_end));
             let mut exec_state =
                 VmSegmentState::new(state.instret, state.pc, None, state.input, state.rng, ctx);

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -184,7 +184,7 @@ pub struct NativeAdapterStep<F, const R: usize, const W: usize> {
     _phantom: PhantomData<F>,
 }
 
-impl<F, CTX, const R: usize, const W: usize> AdapterTraceStep<F, CTX> for NativeAdapterStep<F, R, W>
+impl<F, const R: usize, const W: usize> AdapterTraceStep<F> for NativeAdapterStep<F, R, W>
 where
     F: PrimeField32,
 {
@@ -253,7 +253,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX, const R: usize, const W: usize> AdapterTraceFiller<F, CTX>
+impl<F: PrimeField32, const R: usize, const W: usize> AdapterTraceFiller<F>
     for NativeAdapterStep<F, R, W>
 {
     #[inline(always)]

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -184,14 +184,13 @@ where
         &self,
         state: &mut VmStateMut<F, GuestMemory, MeteredCtx>,
         instruction: &Instruction<F>,
-        _chip_index: usize,
+        chip_index: usize,
     ) -> Result<(), ExecutionError> {
         self.execute_e1(state, instruction)?;
+        state.ctx.trace_heights[chip_index] += 1;
 
         Ok(())
     }
-
-    fn set_trace_height(&mut self, _height: usize) {}
 }
 
 impl<F, RA> InstructionExecutor<F, RA> for PhantomChip<F, RA>

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -143,10 +143,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for PublicValuesCoreStep<A, F>
+impl<F, A> TraceStep<F> for PublicValuesCoreStep<A, F>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, CTX, ReadData = [[F; 1]; 2], WriteData = [[F; 1]; 0]>,
+    A: 'static + AdapterTraceStep<F, ReadData = [[F; 1]; 2], WriteData = [[F; 1]; 0]>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut PublicValuesRecord<F>);
@@ -160,14 +160,13 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
     {
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -200,10 +199,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for PublicValuesCoreStep<A, F>
+impl<F, A> TraceFiller<F> for PublicValuesCoreStep<A, F>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -67,7 +67,7 @@ where
         log_blowup += 1;
     }
     let engine = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(log_blowup));
-    let vm = VirtualMachine::new(engine, config);
+    let mut vm = VirtualMachine::new(engine, config);
     let pk = vm.keygen();
     let vk = pk.get_vk();
     let exe = exe.into();
@@ -81,6 +81,7 @@ where
             &vk.num_interactions(),
         )
         .unwrap();
+    vm.set_main_widths(vk.main_widths());
     let mut result = vm.execute_and_generate(exe, input, &segments).unwrap();
     let final_memory = Option::take(&mut result.final_memory);
     let global_airs = vm.config().create_chip_complex().unwrap().airs();

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -775,13 +775,8 @@ fn test_hint_load_1() {
     assert_eq!(segments.len(), 1);
     let segment = segments.pop().unwrap();
 
-    let chip_complex = create_and_initialize_chip_complex(
-        &test_native_config(),
-        program,
-        None,
-        Some(&segment.trace_heights),
-    )
-    .unwrap();
+    let chip_complex =
+        create_and_initialize_chip_complex(&test_native_config(), program, None).unwrap();
 
     let mut executor = VmSegmentExecutor::<F, NativeConfig, _>::new(
         chip_complex,
@@ -791,7 +786,7 @@ fn test_hint_load_1() {
     );
 
     let capacities = zip_eq(vk.main_widths(), segment.trace_heights)
-        .map(|(w, h)| (w, h as usize))
+        .map(|(w, h)| (h as usize, w))
         .collect_vec();
     let ctx = TracegenCtx::new_with_capacity(&capacities, Some(segment.num_insns));
     let mut exec_state = VmSegmentState::new(0, 0, None, input.into(), rng, ctx);
@@ -843,13 +838,8 @@ fn test_hint_load_2() {
     assert_eq!(segments.len(), 1);
     let segment = segments.pop().unwrap();
 
-    let chip_complex = create_and_initialize_chip_complex(
-        &test_native_config(),
-        program,
-        None,
-        Some(&segment.trace_heights),
-    )
-    .unwrap();
+    let chip_complex =
+        create_and_initialize_chip_complex(&test_native_config(), program, None).unwrap();
 
     let mut executor = VmSegmentExecutor::<F, NativeConfig, _>::new(
         chip_complex,
@@ -859,7 +849,7 @@ fn test_hint_load_2() {
     );
 
     let capacities = zip_eq(vk.main_widths(), segment.trace_heights)
-        .map(|(w, h)| (w, h as usize))
+        .map(|(w, h)| (h as usize, w))
         .collect_vec();
     let ctx = TracegenCtx::new_with_capacity(&capacities, Some(segment.num_insns));
     let mut exec_state = VmSegmentState::new(0, 0, None, input.into(), rng, ctx);

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -5,6 +5,7 @@ use std::{
     sync::Arc,
 };
 
+use itertools::{zip_eq, Itertools};
 use openvm_circuit::{
     arch::{
         create_and_initialize_chip_complex,
@@ -759,7 +760,7 @@ fn test_hint_load_1() {
     let rng = StdRng::seed_from_u64(0);
 
     let engine = BabyBearPoseidon2Engine::new(FriParameters::standard_fast());
-    let vm = VirtualMachine::new(engine, test_native_config());
+    let mut vm = VirtualMachine::new(engine, test_native_config());
     let pk = vm.keygen();
     let vk = pk.get_vk();
     let mut segments = vm
@@ -789,7 +790,10 @@ fn test_hint_load_1() {
         TracegenExecutionControl,
     );
 
-    let ctx = TracegenCtx::new(Some(segment.num_insns));
+    let capacities = zip_eq(vk.main_widths(), segment.trace_heights)
+        .map(|(w, h)| (w, h as usize))
+        .collect_vec();
+    let ctx = TracegenCtx::new_with_capacity(&capacities, Some(segment.num_insns));
     let mut exec_state = VmSegmentState::new(0, 0, None, input.into(), rng, ctx);
     executor.execute_from_state(&mut exec_state).unwrap();
 
@@ -854,7 +858,10 @@ fn test_hint_load_2() {
         TracegenExecutionControl,
     );
 
-    let ctx = TracegenCtx::new(Some(segment.num_insns));
+    let capacities = zip_eq(vk.main_widths(), segment.trace_heights)
+        .map(|(w, h)| (w, h as usize))
+        .collect_vec();
+    let ctx = TracegenCtx::new_with_capacity(&capacities, Some(segment.num_insns));
     let mut exec_state = VmSegmentState::new(0, 0, None, input.into(), rng, ctx);
     executor.execute_from_state(&mut exec_state).unwrap();
 

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -226,7 +226,7 @@ mod tests {
             bitwise_chip.clone(),
             tester.range_checker(),
         );
-        chip.set_trace_height(MAX_INS_CAPACITY);
+        tester.set_arena_capacity(&chip, MAX_INS_CAPACITY);
 
         let num_ops = 10;
         for _ in 0..num_ops {

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -265,7 +265,7 @@ mod tests {
             bitwise_chip.clone(),
             tester.range_checker(),
         );
-        chip.set_trace_height(MAX_INS_CAPACITY);
+        tester.set_arena_capacity(&chip, MAX_INS_CAPACITY);
 
         assert_eq!(
             chip.expr().builder.num_variables,

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -128,7 +128,7 @@ impl SizedRecord<KeccakVmRecordLayout> for KeccakVmRecordMut<'_> {
     }
 }
 
-impl<F: PrimeField32, CTX> TraceStep<F, CTX> for KeccakVmStep {
+impl<F: PrimeField32> TraceStep<F> for KeccakVmStep {
     type RecordLayout = KeccakVmRecordLayout;
     type RecordMut<'a> = KeccakVmRecordMut<'a>;
 
@@ -138,13 +138,9 @@ impl<F: PrimeField32, CTX> TraceStep<F, CTX> for KeccakVmStep {
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let &Instruction {
             opcode,
             a,
@@ -163,7 +159,9 @@ impl<F: PrimeField32, CTX> TraceStep<F, CTX> for KeccakVmStep {
 
         let num_reads = len.div_ceil(KECCAK_WORD_SIZE);
         let num_blocks = num_keccak_f(len);
-        let record = arena.alloc(KeccakVmRecordLayout::new(KeccakVmMetadata { len }));
+        let record = state
+            .ctx
+            .alloc(KeccakVmRecordLayout::new(KeccakVmMetadata { len }));
 
         record.inner.from_pc = *state.pc;
         record.inner.timestamp = state.memory.timestamp();

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -140,7 +140,10 @@ impl<F: PrimeField32> TraceStep<F> for KeccakVmStep {
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction {
             opcode,
             a,
@@ -237,7 +240,7 @@ impl<F: PrimeField32> TraceStep<F> for KeccakVmStep {
     }
 }
 
-impl<F: PrimeField32, CTX> TraceFiller<F, CTX> for KeccakVmStep {
+impl<F: PrimeField32> TraceFiller<F> for KeccakVmStep {
     fn fill_trace(
         &self,
         mem_helper: &MemoryAuxColsFactory<F>,

--- a/extensions/native/circuit/src/adapters/alu_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/alu_native_adapter.rs
@@ -149,7 +149,7 @@ pub struct AluNativeAdapterRecord<F> {
 #[derive(derive_new::new)]
 pub struct AluNativeAdapterStep;
 
-impl<F: PrimeField32, CTX> AdapterTraceStep<F, CTX> for AluNativeAdapterStep {
+impl<F: PrimeField32> AdapterTraceStep<F> for AluNativeAdapterStep {
     const WIDTH: usize = size_of::<AluNativeAdapterCols<u8>>();
     type ReadData = [F; 2];
     type WriteData = [F; 1];
@@ -208,7 +208,7 @@ impl<F: PrimeField32, CTX> AdapterTraceStep<F, CTX> for AluNativeAdapterStep {
     }
 }
 
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for AluNativeAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for AluNativeAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &AluNativeAdapterRecord<F> =

--- a/extensions/native/circuit/src/adapters/branch_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/branch_native_adapter.rs
@@ -138,7 +138,7 @@ pub struct BranchNativeAdapterRecord<F> {
 #[derive(derive_new::new)]
 pub struct BranchNativeAdapterStep;
 
-impl<F, CTX> AdapterTraceStep<F, CTX> for BranchNativeAdapterStep
+impl<F> AdapterTraceStep<F> for BranchNativeAdapterStep
 where
     F: PrimeField32,
 {
@@ -191,7 +191,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for BranchNativeAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for BranchNativeAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &BranchNativeAdapterRecord<F> =

--- a/extensions/native/circuit/src/adapters/convert_adapter.rs
+++ b/extensions/native/circuit/src/adapters/convert_adapter.rs
@@ -138,7 +138,7 @@ pub struct ConvertAdapterRecord<F, const READ_SIZE: usize, const WRITE_SIZE: usi
 #[derive(derive_new::new)]
 pub struct ConvertAdapterStep<const READ_SIZE: usize, const WRITE_SIZE: usize>;
 
-impl<F: PrimeField32, CTX, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterTraceStep<F, CTX>
+impl<F: PrimeField32, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterTraceStep<F>
     for ConvertAdapterStep<READ_SIZE, WRITE_SIZE>
 {
     const WIDTH: usize = size_of::<ConvertAdapterCols<u8, READ_SIZE, WRITE_SIZE>>();
@@ -195,8 +195,8 @@ impl<F: PrimeField32, CTX, const READ_SIZE: usize, const WRITE_SIZE: usize> Adap
     }
 }
 
-impl<F: PrimeField32, CTX, const READ_SIZE: usize, const WRITE_SIZE: usize>
-    AdapterTraceFiller<F, CTX> for ConvertAdapterStep<READ_SIZE, WRITE_SIZE>
+impl<F: PrimeField32, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterTraceFiller<F>
+    for ConvertAdapterStep<READ_SIZE, WRITE_SIZE>
 {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut row_slice: &mut [F]) {

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -194,7 +194,7 @@ pub struct NativeLoadStoreAdapterStep<const NUM_CELLS: usize> {
     offset: usize,
 }
 
-impl<F: PrimeField32, CTX, const NUM_CELLS: usize> AdapterTraceStep<F, CTX>
+impl<F: PrimeField32, const NUM_CELLS: usize> AdapterTraceStep<F>
     for NativeLoadStoreAdapterStep<NUM_CELLS>
 {
     const WIDTH: usize = std::mem::size_of::<NativeLoadStoreAdapterCols<u8, NUM_CELLS>>();
@@ -286,7 +286,7 @@ impl<F: PrimeField32, CTX, const NUM_CELLS: usize> AdapterTraceStep<F, CTX>
     }
 }
 
-impl<F: PrimeField32, CTX, const NUM_CELLS: usize> AdapterTraceFiller<F, CTX>
+impl<F: PrimeField32, const NUM_CELLS: usize> AdapterTraceFiller<F>
     for NativeLoadStoreAdapterStep<NUM_CELLS>
 {
     #[inline(always)]

--- a/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
@@ -141,9 +141,7 @@ pub struct NativeVectorizedAdapterRecord<F, const N: usize> {
 #[derive(derive_new::new)]
 pub struct NativeVectorizedAdapterStep<const N: usize>;
 
-impl<F: PrimeField32, CTX, const N: usize> AdapterTraceStep<F, CTX>
-    for NativeVectorizedAdapterStep<N>
-{
+impl<F: PrimeField32, const N: usize> AdapterTraceStep<F> for NativeVectorizedAdapterStep<N> {
     const WIDTH: usize = size_of::<NativeVectorizedAdapterCols<u8, N>>();
     type ReadData = [[F; N]; 2];
     type WriteData = [F; N];
@@ -205,9 +203,7 @@ impl<F: PrimeField32, CTX, const N: usize> AdapterTraceStep<F, CTX>
     }
 }
 
-impl<F: PrimeField32, CTX, const N: usize> AdapterTraceFiller<F, CTX>
-    for NativeVectorizedAdapterStep<N>
-{
+impl<F: PrimeField32, const N: usize> AdapterTraceFiller<F> for NativeVectorizedAdapterStep<N> {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &NativeVectorizedAdapterRecord<F, N> =

--- a/extensions/native/circuit/src/branch_eq/core.rs
+++ b/extensions/native/circuit/src/branch_eq/core.rs
@@ -36,10 +36,10 @@ pub struct NativeBranchEqualStep<A> {
     pub pc_step: u32,
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for NativeBranchEqualStep<A>
+impl<F, A> TraceStep<F> for NativeBranchEqualStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, CTX, ReadData: Into<[F; 2]>, WriteData = ()>,
+    A: 'static + AdapterTraceStep<F, ReadData: Into<[F; 2]>, WriteData = ()>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut NativeBranchEqualCoreRecord<F>);
@@ -53,15 +53,11 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let &Instruction { opcode, c: imm, .. } = instruction;
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/native/circuit/src/branch_eq/core.rs
+++ b/extensions/native/circuit/src/branch_eq/core.rs
@@ -55,7 +55,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction { opcode, c: imm, .. } = instruction;
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
@@ -82,10 +85,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for NativeBranchEqualStep<A>
+impl<F, A> TraceFiller<F> for NativeBranchEqualStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -126,11 +126,10 @@ pub struct CastFCoreStep<A> {
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for CastFCoreStep<A>
+impl<F, A> TraceStep<F> for CastFCoreStep<A>
 where
     F: PrimeField32,
-    A: 'static
-        + AdapterTraceStep<F, CTX, ReadData = [F; 1], WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
+    A: 'static + AdapterTraceStep<F, ReadData = [F; 1], WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut CastFCoreRecord);
@@ -141,14 +140,10 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+    ) -> Result<()> {
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -142,7 +142,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
@@ -163,10 +166,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for CastFCoreStep<A>
+impl<F, A> TraceFiller<F> for CastFCoreStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -126,10 +126,10 @@ pub struct FieldArithmeticCoreStep<A> {
     adapter: A,
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for FieldArithmeticCoreStep<A>
+impl<F, A> TraceStep<F> for FieldArithmeticCoreStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, CTX, ReadData = [F; 2], WriteData = [F; 1]>,
+    A: 'static + AdapterTraceStep<F, ReadData = [F; 2], WriteData = [F; 1]>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut FieldArithmeticRecord<F>);
@@ -143,15 +143,11 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let &Instruction { opcode, .. } = instruction;
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -145,7 +145,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction { opcode, .. } = instruction;
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
@@ -170,10 +173,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for FieldArithmeticCoreStep<A>
+impl<F, A> TraceFiller<F> for FieldArithmeticCoreStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -172,7 +172,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
@@ -201,10 +204,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for FieldExtensionCoreStep<A>
+impl<F, A> TraceFiller<F> for FieldExtensionCoreStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -153,10 +153,10 @@ pub struct FieldExtensionCoreStep<A> {
     adapter: A,
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for FieldExtensionCoreStep<A>
+impl<F, A> TraceStep<F> for FieldExtensionCoreStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, CTX, ReadData = [[F; EXT_DEG]; 2], WriteData = [F; EXT_DEG]>,
+    A: 'static + AdapterTraceStep<F, ReadData = [[F; EXT_DEG]; 2], WriteData = [F; EXT_DEG]>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut FieldExtensionRecord<F>);
@@ -170,16 +170,12 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let &Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -694,7 +694,7 @@ impl<F: PrimeField32> FriReducedOpeningStep<F> {
     }
 }
 
-impl<F, CTX> TraceStep<F, CTX> for FriReducedOpeningStep<F>
+impl<F> TraceStep<F> for FriReducedOpeningStep<F>
 where
     F: PrimeField32,
 {
@@ -708,13 +708,9 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let &Instruction {
             a,
             b,
@@ -736,7 +732,7 @@ where
         let metadata = FriReducedOpeningMetadata {
             length: length as usize,
         };
-        let record = arena.alloc(MultiRowLayout::new(metadata));
+        let record = state.ctx.alloc(MultiRowLayout::new(metadata));
 
         record.common.from_pc = *state.pc;
         record.common.timestamp = timestamp_start;

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -710,7 +710,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction {
             a,
             b,
@@ -858,7 +861,7 @@ where
     }
 }
 
-impl<F, CTX> TraceFiller<F, CTX> for FriReducedOpeningStep<F>
+impl<F> TraceFiller<F> for FriReducedOpeningStep<F>
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/jal_rangecheck/mod.rs
+++ b/extensions/native/circuit/src/jal_rangecheck/mod.rs
@@ -183,7 +183,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction {
             opcode, a, b, c, ..
         } = instruction;
@@ -235,7 +238,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX> TraceFiller<F, CTX> for JalRangeCheckStep {
+impl<F: PrimeField32> TraceFiller<F> for JalRangeCheckStep {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut row_slice: &mut [F]) {
         let record: &mut JalRangeCheckRecord<F> =
             unsafe { get_record_from_slice(&mut row_slice, ()) };

--- a/extensions/native/circuit/src/jal_rangecheck/mod.rs
+++ b/extensions/native/circuit/src/jal_rangecheck/mod.rs
@@ -158,7 +158,7 @@ pub struct JalRangeCheckStep {
     range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<F, CTX> TraceStep<F, CTX> for JalRangeCheckStep
+impl<F> TraceStep<F> for JalRangeCheckStep
 where
     F: PrimeField32,
 {
@@ -181,13 +181,9 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let &Instruction {
             opcode, a, b, c, ..
         } = instruction;
@@ -197,7 +193,7 @@ where
                 || opcode == NativeRangeCheckOpcode::RANGE_CHECK.global_opcode()
         );
 
-        let record = arena.alloc(EmptyMultiRowLayout::default());
+        let record = state.ctx.alloc(EmptyMultiRowLayout::default());
 
         record.from_pc = *state.pc;
         record.from_timestamp = state.memory.timestamp;

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -153,7 +153,10 @@ where
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
@@ -188,11 +191,10 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_CELLS: usize> TraceFiller<F, CTX>
-    for NativeLoadStoreCoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> TraceFiller<F> for NativeLoadStoreCoreStep<A, NUM_CELLS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -131,11 +131,10 @@ impl<A, const NUM_CELLS: usize> NativeLoadStoreCoreStep<A, NUM_CELLS> {
     }
 }
 
-impl<F, CTX, A, const NUM_CELLS: usize> TraceStep<F, CTX> for NativeLoadStoreCoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> TraceStep<F> for NativeLoadStoreCoreStep<A, NUM_CELLS>
 where
     F: PrimeField32,
-    A: 'static
-        + AdapterTraceStep<F, CTX, ReadData = (F, [F; NUM_CELLS]), WriteData = [F; NUM_CELLS]>,
+    A: 'static + AdapterTraceStep<F, ReadData = (F, [F; NUM_CELLS]), WriteData = [F; NUM_CELLS]>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (
@@ -152,16 +151,12 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let &Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -116,20 +116,20 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> SizedRecord<NativePoseidon2Re
     }
 }
 
-impl<F: PrimeField32, const SBOX_REGISTERS: usize, CTX> TraceStep<F, CTX>
+impl<F: PrimeField32, const SBOX_REGISTERS: usize> TraceStep<F>
     for NativePoseidon2Step<F, SBOX_REGISTERS>
 {
     type RecordLayout = MultiRowLayout<NativePoseidon2Metadata>;
     type RecordMut<'a> = NativePoseidon2RecordMut<'a, F, SBOX_REGISTERS>;
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> openvm_circuit::arch::Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
     {
+        let arena = state.ctx;
         let init_timestamp_u32 = state.memory.timestamp;
         if instruction.opcode == PERM_POS2.global_opcode()
             || instruction.opcode == COMP_POS2.global_opcode()
@@ -634,7 +634,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize, CTX> TraceStep<F, CTX>
     }
 }
 
-impl<F: PrimeField32, const SBOX_REGISTERS: usize, CTX> TraceFiller<F, CTX>
+impl<F: PrimeField32, const SBOX_REGISTERS: usize> TraceFiller<F>
     for NativePoseidon2Step<F, SBOX_REGISTERS>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -282,12 +282,11 @@ impl<
 
 impl<
         F: PrimeField32,
-        CTX,
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCK_SIZE: usize,
         const TOTAL_READ_SIZE: usize,
-    > AdapterTraceStep<F, CTX>
+    > AdapterTraceStep<F>
     for Rv32IsEqualModeAdapterStep<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
 where
     F: PrimeField32,
@@ -370,12 +369,11 @@ where
 
 impl<
         F: PrimeField32,
-        CTX,
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCK_SIZE: usize,
         const TOTAL_READ_SIZE: usize,
-    > AdapterTraceFiller<F, CTX>
+    > AdapterTraceFiller<F>
     for Rv32IsEqualModeAdapterStep<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {

--- a/extensions/rv32-adapters/src/heap.rs
+++ b/extensions/rv32-adapters/src/heap.rs
@@ -120,12 +120,8 @@ impl<const NUM_READS: usize, const READ_SIZE: usize, const WRITE_SIZE: usize>
     }
 }
 
-impl<
-        F: PrimeField32,
-        const NUM_READS: usize,
-        const READ_SIZE: usize,
-        const WRITE_SIZE: usize,
-    > AdapterTraceStep<F> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
+impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize, const WRITE_SIZE: usize>
+    AdapterTraceStep<F> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
 where
     F: PrimeField32,
 {
@@ -161,12 +157,8 @@ where
     }
 }
 
-impl<
-        F: PrimeField32,
-        const NUM_READS: usize,
-        const READ_SIZE: usize,
-        const WRITE_SIZE: usize,
-    > AdapterTraceFiller<F> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
+impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize, const WRITE_SIZE: usize>
+    AdapterTraceFiller<F> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, adapter_row: &mut [F]) {
         AdapterTraceFiller::<F>::fill_trace_row(&self.0, mem_helper, adapter_row);

--- a/extensions/rv32-adapters/src/heap.rs
+++ b/extensions/rv32-adapters/src/heap.rs
@@ -122,11 +122,10 @@ impl<const NUM_READS: usize, const READ_SIZE: usize, const WRITE_SIZE: usize>
 
 impl<
         F: PrimeField32,
-        CTX,
         const NUM_READS: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > AdapterTraceStep<F, CTX> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
+    > AdapterTraceStep<F> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
 where
     F: PrimeField32,
 {
@@ -147,7 +146,7 @@ where
         instruction: &Instruction<F>,
         record: &mut Self::RecordMut<'_>,
     ) -> Self::ReadData {
-        let read_data = AdapterTraceStep::<F, CTX>::read(&self.0, memory, instruction, record);
+        let read_data = AdapterTraceStep::<F>::read(&self.0, memory, instruction, record);
         read_data.map(|r| r[0])
     }
 
@@ -158,20 +157,19 @@ where
         data: Self::WriteData,
         record: &mut Self::RecordMut<'_>,
     ) {
-        AdapterTraceStep::<F, CTX>::write(&self.0, memory, instruction, data, record);
+        AdapterTraceStep::<F>::write(&self.0, memory, instruction, data, record);
     }
 }
 
 impl<
         F: PrimeField32,
-        CTX,
         const NUM_READS: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > AdapterTraceFiller<F, CTX> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
+    > AdapterTraceFiller<F> for Rv32HeapAdapterStep<NUM_READS, READ_SIZE, WRITE_SIZE>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, adapter_row: &mut [F]) {
-        AdapterTraceFiller::<F, CTX>::fill_trace_row(&self.0, mem_helper, adapter_row);
+        AdapterTraceFiller::<F>::fill_trace_row(&self.0, mem_helper, adapter_row);
     }
 }
 

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -204,7 +204,7 @@ impl<const NUM_READS: usize, const READ_SIZE: usize>
     }
 }
 
-impl<F: PrimeField32, CTX, const NUM_READS: usize, const READ_SIZE: usize> AdapterTraceStep<F, CTX>
+impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterTraceStep<F>
     for Rv32HeapBranchAdapterStep<NUM_READS, READ_SIZE>
 {
     const WIDTH: usize = Rv32HeapBranchAdapterCols::<F, NUM_READS, READ_SIZE>::width();
@@ -262,8 +262,8 @@ impl<F: PrimeField32, CTX, const NUM_READS: usize, const READ_SIZE: usize> Adapt
     }
 }
 
-impl<F: PrimeField32, CTX, const NUM_READS: usize, const READ_SIZE: usize>
-    AdapterTraceFiller<F, CTX> for Rv32HeapBranchAdapterStep<NUM_READS, READ_SIZE>
+impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize>
+    AdapterTraceFiller<F> for Rv32HeapBranchAdapterStep<NUM_READS, READ_SIZE>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32HeapBranchAdapterRecord<NUM_READS> =

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -262,8 +262,8 @@ impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterTra
     }
 }
 
-impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize>
-    AdapterTraceFiller<F> for Rv32HeapBranchAdapterStep<NUM_READS, READ_SIZE>
+impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterTraceFiller<F>
+    for Rv32HeapBranchAdapterStep<NUM_READS, READ_SIZE>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32HeapBranchAdapterRecord<NUM_READS> =

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -308,13 +308,12 @@ pub struct Rv32VecHeapAdapterStep<
 
 impl<
         F: PrimeField32,
-        CTX,
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCKS_PER_WRITE: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > AdapterTraceStep<F, CTX>
+    > AdapterTraceStep<F>
     for Rv32VecHeapAdapterStep<NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>
 {
     const WIDTH: usize = Rv32VecHeapAdapterCols::<
@@ -430,13 +429,12 @@ impl<
 
 impl<
         F: PrimeField32,
-        CTX,
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCKS_PER_WRITE: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > AdapterTraceFiller<F, CTX>
+    > AdapterTraceFiller<F>
     for Rv32VecHeapAdapterStep<NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {

--- a/extensions/rv32-adapters/src/vec_heap_two_reads.rs
+++ b/extensions/rv32-adapters/src/vec_heap_two_reads.rs
@@ -352,13 +352,12 @@ impl<
 
 impl<
         F: PrimeField32,
-        CTX,
         const BLOCKS_PER_READ1: usize,
         const BLOCKS_PER_READ2: usize,
         const BLOCKS_PER_WRITE: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > AdapterTraceStep<F, CTX>
+    > AdapterTraceStep<F>
     for Rv32VecHeapTwoReadsAdapterStep<
         BLOCKS_PER_READ1,
         BLOCKS_PER_READ2,
@@ -482,13 +481,12 @@ impl<
 
 impl<
         F: PrimeField32,
-        CTX,
         const BLOCKS_PER_READ1: usize,
         const BLOCKS_PER_READ2: usize,
         const BLOCKS_PER_WRITE: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > AdapterTraceFiller<F, CTX>
+    > AdapterTraceFiller<F>
     for Rv32VecHeapTwoReadsAdapterStep<
         BLOCKS_PER_READ1,
         BLOCKS_PER_READ2,

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -189,7 +189,7 @@ pub struct Rv32BaseAluAdapterRecord {
     pub writes_aux: MemoryWriteBytesAuxRecord<RV32_REGISTER_NUM_LIMBS>,
 }
 
-impl<F: PrimeField32, CTX, const LIMB_BITS: usize> AdapterTraceStep<F, CTX>
+impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceStep<F>
     for Rv32BaseAluAdapterStep<LIMB_BITS>
 {
     const WIDTH: usize = size_of::<Rv32BaseAluAdapterCols<u8>>();
@@ -269,7 +269,7 @@ impl<F: PrimeField32, CTX, const LIMB_BITS: usize> AdapterTraceStep<F, CTX>
     }
 }
 
-impl<F: PrimeField32, CTX, const LIMB_BITS: usize> AdapterTraceFiller<F, CTX>
+impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceFiller<F>
     for Rv32BaseAluAdapterStep<LIMB_BITS>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -121,7 +121,7 @@ pub struct Rv32BranchAdapterRecord {
 #[derive(derive_new::new)]
 pub struct Rv32BranchAdapterStep;
 
-impl<F, CTX> AdapterTraceStep<F, CTX> for Rv32BranchAdapterStep
+impl<F> AdapterTraceStep<F> for Rv32BranchAdapterStep
 where
     F: PrimeField32,
 {
@@ -177,7 +177,7 @@ where
         // This function is intentionally left empty
     }
 }
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for Rv32BranchAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32BranchAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32BranchAdapterRecord =

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -162,7 +162,7 @@ pub struct Rv32JalrAdapterRecord {
 #[derive(derive_new::new)]
 pub struct Rv32JalrAdapterStep;
 
-impl<F, CTX> AdapterTraceStep<F, CTX> for Rv32JalrAdapterStep
+impl<F> AdapterTraceStep<F> for Rv32JalrAdapterStep
 where
     F: PrimeField32,
 {
@@ -228,7 +228,7 @@ where
         }
     }
 }
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for Rv32JalrAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32JalrAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32JalrAdapterRecord = unsafe { get_record_from_slice(&mut adapter_row, ()) };

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -327,7 +327,7 @@ pub struct Rv32LoadStoreAdapterStep {
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<F, CTX> AdapterTraceStep<F, CTX> for Rv32LoadStoreAdapterStep
+impl<F> AdapterTraceStep<F> for Rv32LoadStoreAdapterStep
 where
     F: PrimeField32,
 {
@@ -485,7 +485,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for Rv32LoadStoreAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32LoadStoreAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         // TODO(ayush): should this be here?

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -145,7 +145,7 @@ pub struct Rv32MultAdapterRecord {
 #[derive(derive_new::new)]
 pub struct Rv32MultAdapterStep;
 
-impl<F, CTX> AdapterTraceStep<F, CTX> for Rv32MultAdapterStep
+impl<F> AdapterTraceStep<F> for Rv32MultAdapterStep
 where
     F: PrimeField32,
 {
@@ -213,7 +213,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for Rv32MultAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32MultAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32MultAdapterRecord = unsafe { get_record_from_slice(&mut adapter_row, ()) };

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -336,7 +336,7 @@ where
         instruction: &Instruction<F>,
         record: &mut Self::RecordMut<'_>,
     ) -> Self::ReadData {
-        <Rv32RdWriteAdapterStep as AdapterTraceStep<F, CTX>>::read(
+        <Rv32RdWriteAdapterStep as AdapterTraceStep<F>>::read(
             &self.inner,
             memory,
             instruction,
@@ -355,7 +355,7 @@ where
         let Instruction { f: enabled, .. } = instruction;
 
         if enabled.is_one() {
-            <Rv32RdWriteAdapterStep as AdapterTraceStep<F, CTX>>::write(
+            <Rv32RdWriteAdapterStep as AdapterTraceStep<F>>::write(
                 &self.inner,
                 memory,
                 instruction,
@@ -380,7 +380,7 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32CondRdWriteAdapterStep {
 
         if record.rd_ptr != u32::MAX {
             unsafe {
-                <Rv32RdWriteAdapterStep as AdapterTraceFiller<F, CTX>>::fill_trace_row(
+                <Rv32RdWriteAdapterStep as AdapterTraceFiller<F>>::fill_trace_row(
                     &self.inner,
                     mem_helper,
                     adapter_row

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -203,7 +203,7 @@ pub struct Rv32RdWriteAdapterRecord {
 #[derive(derive_new::new)]
 pub struct Rv32RdWriteAdapterStep;
 
-impl<F, CTX> AdapterTraceStep<F, CTX> for Rv32RdWriteAdapterStep
+impl<F> AdapterTraceStep<F> for Rv32RdWriteAdapterStep
 where
     F: PrimeField32,
 {
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for Rv32RdWriteAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32RdWriteAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32RdWriteAdapterRecord =
@@ -314,7 +314,7 @@ pub struct Rv32CondRdWriteAdapterStep {
     inner: Rv32RdWriteAdapterStep,
 }
 
-impl<F, CTX> AdapterTraceStep<F, CTX> for Rv32CondRdWriteAdapterStep
+impl<F> AdapterTraceStep<F> for Rv32CondRdWriteAdapterStep
 where
     F: PrimeField32,
 {
@@ -369,7 +369,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX> AdapterTraceFiller<F, CTX> for Rv32CondRdWriteAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32CondRdWriteAdapterStep {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32RdWriteAdapterRecord =

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -227,6 +227,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -208,10 +208,10 @@ pub struct Rv32AuipcStep<A> {
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for Rv32AuipcStep<A>
+impl<F, A> TraceStep<F> for Rv32AuipcStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, CTX, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
+    A: 'static + AdapterTraceStep<F, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut Rv32AuipcCoreRecord);
@@ -222,14 +222,12 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -248,10 +246,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for Rv32AuipcStep<A>
+impl<F, A> TraceFiller<F> for Rv32AuipcStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/auipc/tests.rs
+++ b/extensions/rv32im/circuit/src/auipc/tests.rs
@@ -52,7 +52,7 @@ fn create_test_chip(
         Rv32AuipcStep::new(Rv32RdWriteAdapterStep::new(), bitwise_chip.clone()),
         tester.memory_helper(),
     );
-    chip.set_trace_buffer_height(MAX_INS_CAPACITY);
+    tester.set_arena_capacity(&chip, MAX_INS_CAPACITY);
 
     (chip, bitwise_chip)
 }
@@ -95,7 +95,7 @@ fn rand_auipc_test() {
     for _ in 0..num_tests {
         set_and_execute(&mut tester, &mut chip, &mut rng, AUIPC, None, None);
     }
-
+    tester.give_away_arena(&mut chip);
     let tester = tester.build().load(chip).load(bitwise_chip).finalize();
     tester.simple_test().expect("Verification failed");
 }
@@ -312,30 +312,31 @@ fn dense_record_arena_test() {
     let mut tester = VmChipTestBuilder::default();
     let (mut sparse_chip, bitwise_chip) = create_test_chip(&tester);
 
-    {
-        let mut dense_chip = create_test_chip_dense(&mut tester);
+    todo!("get dense arena working");
+    // {
+    //     let mut dense_chip = create_test_chip_dense(&mut tester);
 
-        let num_ops: usize = 100;
-        for _ in 0..num_ops {
-            set_and_execute(&mut tester, &mut dense_chip, &mut rng, AUIPC, None, None);
-        }
+    //     let num_ops: usize = 100;
+    //     for _ in 0..num_ops {
+    //         set_and_execute(&mut tester, &mut dense_chip, &mut rng, AUIPC, None, None);
+    //     }
 
-        type Record<'a> = (
-            &'a mut Rv32RdWriteAdapterRecord,
-            &'a mut Rv32AuipcCoreRecord,
-        );
+    //     type Record<'a> = (
+    //         &'a mut Rv32RdWriteAdapterRecord,
+    //         &'a mut Rv32AuipcCoreRecord,
+    //     );
 
-        let mut record_interpreter = dense_chip.arena.get_record_seeker::<Record, _>();
-        record_interpreter.transfer_to_matrix_arena(
-            &mut sparse_chip.arena,
-            EmptyAdapterCoreLayout::<F, Rv32RdWriteAdapterStep>::new(),
-        );
-    }
+    //     let mut record_interpreter = dense_chip.arena.get_record_seeker::<Record, _>();
+    //     record_interpreter.transfer_to_matrix_arena(
+    //         &mut sparse_chip.arena,
+    //         EmptyAdapterCoreLayout::<F, Rv32RdWriteAdapterStep>::new(),
+    //     );
+    // }
 
-    let tester = tester
-        .build()
-        .load(sparse_chip)
-        .load(bitwise_chip)
-        .finalize();
-    tester.simple_test().expect("Verification failed");
+    // let tester = tester
+    //     .build()
+    //     .load(sparse_chip)
+    //     .load(bitwise_chip)
+    //     .finalize();
+    // tester.simple_test().expect("Verification failed");
 }

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -189,14 +189,13 @@ pub struct BaseAluStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub offset: usize,
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
     for BaseAluStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
@@ -211,9 +210,8 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
@@ -221,7 +219,7 @@ where
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = BaseAluOpcode::from_usize(opcode.local_opcode_idx(self.offset));
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -243,11 +241,11 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
     for BaseAluStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -211,8 +211,7 @@ impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
     for BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static
-        + for<'a> AdapterTraceStep<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
+    A: 'static + for<'a> AdapterTraceStep<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (
@@ -234,6 +233,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -207,12 +207,12 @@ pub struct BranchLessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
     pub offset: usize,
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
     for BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + for<'a> AdapterTraceStep<F, CTX, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
+        + for<'a> AdapterTraceStep<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (
@@ -229,16 +229,14 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -262,11 +260,11 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
     for BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -402,14 +402,13 @@ pub struct DivRemCoreRecords<const NUM_LIMBS: usize> {
     pub local_opcode: u8,
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
     for DivRemStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
@@ -423,16 +422,14 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -467,11 +464,11 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
     for DivRemStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -427,6 +427,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -372,7 +372,7 @@ impl Rv32HintStoreStep {
     }
 }
 
-impl<F, CTX> TraceStep<F, CTX> for Rv32HintStoreStep
+impl<F> TraceStep<F> for Rv32HintStoreStep
 where
     F: PrimeField32,
 {
@@ -391,13 +391,11 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let &Instruction {
             opcode, a, b, d, e, ..
         } = instruction;
@@ -416,7 +414,7 @@ where
             read_rv32_register(state.memory.data(), a)
         };
 
-        let record = arena.alloc(MultiRowLayout::new(Rv32HintStoreMetadata {
+        let record = state.ctx.alloc(MultiRowLayout::new(Rv32HintStoreMetadata {
             num_words: num_words as usize,
         }));
 
@@ -481,7 +479,7 @@ where
     }
 }
 
-impl<F: PrimeField32, CTX> TraceFiller<F, CTX> for Rv32HintStoreStep {
+impl<F: PrimeField32> TraceFiller<F> for Rv32HintStoreStep {
     fn fill_trace(
         &self,
         mem_helper: &MemoryAuxColsFactory<F>,

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -396,6 +396,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction {
             opcode, a, b, d, e, ..
         } = instruction;

--- a/extensions/rv32im/circuit/src/hintstore/tests.rs
+++ b/extensions/rv32im/circuit/src/hintstore/tests.rs
@@ -247,24 +247,25 @@ fn dense_record_arena_test() {
     let mut tester = VmChipTestBuilder::default();
     let (mut sparse_chip, bitwise_chip) = create_test_chip(&mut tester);
 
-    {
-        let mut dense_chip = create_test_chip_dense(&mut tester);
+    todo!("get this working again");
+    // {
+    //     let mut dense_chip = create_test_chip_dense(&mut tester);
 
-        let num_ops: usize = 100;
-        for _ in 0..num_ops {
-            set_and_execute(&mut tester, &mut dense_chip, &mut rng, HINT_STOREW);
-        }
+    //     let num_ops: usize = 100;
+    //     for _ in 0..num_ops {
+    //         set_and_execute(&mut tester, &mut dense_chip, &mut rng, HINT_STOREW);
+    //     }
 
-        let mut record_interpreter = dense_chip
-            .arena
-            .get_record_seeker::<_, Rv32HintStoreLayout>();
-        record_interpreter.transfer_to_matrix_arena(&mut sparse_chip.arena);
-    }
+    //     let mut record_interpreter = dense_chip
+    //         .arena
+    //         .get_record_seeker::<_, Rv32HintStoreLayout>();
+    //     record_interpreter.transfer_to_matrix_arena(&mut sparse_chip.arena);
+    // }
 
-    let tester = tester
-        .build()
-        .load(sparse_chip)
-        .load(bitwise_chip)
-        .finalize();
-    tester.simple_test().expect("Verification failed");
+    // let tester = tester
+    //     .build()
+    //     .load(sparse_chip)
+    //     .load(bitwise_chip)
+    //     .finalize();
+    // tester.simple_test().expect("Verification failed");
 }

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -184,6 +184,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -161,11 +161,11 @@ pub struct Rv32JalLuiStep<A> {
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for Rv32JalLuiStep<A>
+impl<F, A> TraceStep<F> for Rv32JalLuiStep<A>
 where
     F: PrimeField32,
     A: 'static
-        + for<'a> AdapterTraceStep<F, CTX, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
+        + for<'a> AdapterTraceStep<F, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
 {
     type RecordLayout = EmptyAdapterCoreLayout<F, A>;
     type RecordMut<'a> = (A::RecordMut<'a>, &'a mut Rv32JalLuiStepRecord);
@@ -179,16 +179,14 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -210,10 +208,10 @@ where
     }
 }
 
-impl<F, CTX, A> TraceFiller<F, CTX> for Rv32JalLuiStep<A>
+impl<F, A> TraceFiller<F> for Rv32JalLuiStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -233,6 +233,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let Instruction { opcode, c, g, .. } = *instruction;
 
         debug_assert_eq!(

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -206,13 +206,12 @@ impl<A> Rv32JalrStep<A> {
     }
 }
 
-impl<F, CTX, A> TraceStep<F, CTX> for Rv32JalrStep<A>
+impl<F, A> TraceStep<F> for Rv32JalrStep<A>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData = [u8; RV32_REGISTER_NUM_LIMBS],
             WriteData = [u8; RV32_REGISTER_NUM_LIMBS],
         >,
@@ -229,13 +228,11 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let Instruction { opcode, c, g, .. } = *instruction;
 
         debug_assert_eq!(
@@ -243,7 +240,7 @@ where
             JALR as usize
         );
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -273,10 +270,10 @@ where
         Ok(())
     }
 }
-impl<F, CTX, A> TraceFiller<F, CTX> for Rv32JalrStep<A>
+impl<F, A> TraceFiller<F> for Rv32JalrStep<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -185,14 +185,13 @@ pub struct LessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub offset: usize,
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
     for LessThanStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
@@ -209,17 +208,15 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         debug_assert!(LIMB_BITS <= 8);
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
         A::start(*state.pc, state.memory, &mut adapter_record);
 
         let [rs1, rs2] = self
@@ -253,11 +250,11 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
     for LessThanStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -213,6 +213,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         debug_assert!(LIMB_BITS <= 8);
         let Instruction { opcode, .. } = instruction;
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -219,6 +219,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -188,14 +188,13 @@ pub struct LoadSignExtendStep<A, const NUM_CELLS: usize, const LIMB_BITS: usize>
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<F, CTX, A, const NUM_CELLS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
+impl<F, A, const NUM_CELLS: usize, const LIMB_BITS: usize> TraceStep<F>
     for LoadSignExtendStep<A, NUM_CELLS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData = (([u32; NUM_CELLS], [u8; NUM_CELLS]), u8),
             WriteData = [u32; NUM_CELLS],
         >,
@@ -215,20 +214,18 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),
         );
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -260,11 +257,11 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_CELLS: usize, const LIMB_BITS: usize> TraceFiller<F, CTX>
+impl<F, A, const NUM_CELLS: usize, const LIMB_BITS: usize> TraceFiller<F>
     for LoadSignExtendStep<A, NUM_CELLS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -259,13 +259,12 @@ pub struct LoadStoreStep<A, const NUM_CELLS: usize> {
     pub offset: usize,
 }
 
-impl<F, CTX, A, const NUM_CELLS: usize> TraceStep<F, CTX> for LoadStoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> TraceStep<F> for LoadStoreStep<A, NUM_CELLS>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData = (([u32; NUM_CELLS], [u8; NUM_CELLS]), u8),
             WriteData = [u32; NUM_CELLS],
         >,
@@ -282,16 +281,14 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -320,10 +317,10 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_CELLS: usize> TraceFiller<F, CTX> for LoadStoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> TraceFiller<F> for LoadStoreStep<A, NUM_CELLS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -286,6 +286,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -190,6 +190,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let Instruction { opcode, .. } = instruction;
 
         debug_assert_eq!(

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -162,14 +162,13 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
     for MultiplicationStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
@@ -186,20 +185,18 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let Instruction { opcode, .. } = instruction;
 
         debug_assert_eq!(
             MulOpcode::from_usize(opcode.local_opcode_idx(self.offset)),
             MulOpcode::MUL
         );
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -221,11 +218,11 @@ where
         Ok(())
     }
 }
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
     for MultiplicationStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -263,6 +263,7 @@ where
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -232,14 +232,13 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> MulHStep<A, NUM_LIMBS, L
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
     for MulHStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
         + for<'a> AdapterTraceStep<
             F,
-            CTX,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
         >,
@@ -259,16 +258,14 @@ where
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
     ) -> Result<()>
     where
         RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
         let Instruction { opcode, .. } = instruction;
 
-        let (mut adapter_record, core_record) = arena.alloc(EmptyAdapterCoreLayout::new());
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
 
@@ -297,11 +294,11 @@ where
     }
 }
 
-impl<F, CTX, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F, CTX>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
     for MulHStep<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceFiller<F, CTX>,
+    A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
         )?;
         let config = Rv32IConfig::default();
 
-        let vm = VirtualMachine::new(default_engine(), config.clone());
+        let mut vm = VirtualMachine::new(default_engine(), config.clone());
         let pk = vm.keygen();
         let vk = pk.get_vk();
         let segments = vm
@@ -196,6 +196,7 @@ mod tests {
             )
             .unwrap();
 
+        vm.set_main_widths(vk.main_widths());
         let final_memory = vm.executor.execute(exe, vec![], &segments)?.unwrap();
         let hasher = vm_poseidon2_hasher::<F>();
         let pv_proof = UserPublicValuesProof::compute(

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -150,7 +150,10 @@ impl<F: PrimeField32> TraceStep<F> for Sha256VmStep {
         &mut self,
         state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
+    {
         let Instruction {
             opcode,
             a,
@@ -239,7 +242,7 @@ impl<F: PrimeField32> TraceStep<F> for Sha256VmStep {
     }
 }
 
-impl<F: PrimeField32, CTX> TraceFiller<F, CTX> for Sha256VmStep {
+impl<F: PrimeField32> TraceFiller<F> for Sha256VmStep {
     fn fill_trace(
         &self,
         mem_helper: &MemoryAuxColsFactory<F>,

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -138,7 +138,7 @@ impl SizedRecord<Sha256VmRecordLayout> for Sha256VmRecordMut<'_> {
     }
 }
 
-impl<F: PrimeField32, CTX> TraceStep<F, CTX> for Sha256VmStep {
+impl<F: PrimeField32> TraceStep<F> for Sha256VmStep {
     type RecordLayout = Sha256VmRecordLayout;
     type RecordMut<'a> = Sha256VmRecordMut<'a>;
 
@@ -148,13 +148,9 @@ impl<F: PrimeField32, CTX> TraceStep<F, CTX> for Sha256VmStep {
 
     fn execute<'buf, RA>(
         &mut self,
-        state: VmStateMut<F, TracingMemory<F>, CTX>,
+        state: VmStateMut<'buf, F, TracingMemory<F>, RA>,
         instruction: &Instruction<F>,
-        arena: &'buf mut RA,
-    ) -> Result<()>
-    where
-        RA: RecordArena<'buf, Self::RecordLayout, Self::RecordMut<'buf>>,
-    {
+    ) -> Result<()> {
         let Instruction {
             opcode,
             a,
@@ -172,7 +168,7 @@ impl<F: PrimeField32, CTX> TraceStep<F, CTX> for Sha256VmStep {
         let len = read_rv32_register(state.memory.data(), c.as_canonical_u32());
 
         let num_blocks = get_sha256_num_blocks(len);
-        let record = arena.alloc(MultiRowLayout {
+        let record = state.ctx.alloc(MultiRowLayout {
             metadata: Sha256VmMetadata { num_blocks },
         });
 


### PR DESCRIPTION
This is a partial PR merging into another feature branch `feat/new-exec-device` where I'll collect the overall work into generalizing chips for different tracegen and `ProverBackend`s.

The integration tests in `rv32im/tests` work and `VirtualMachine, VmExecutor` were updated for the correct flow, assuming you call `set_main_widths` ahead of time (a temporary measure).

The unit test framework is really not designed for this, so I only demonstrate `rand_auipc_test` works -- I'm not going to update all the tests to use `give_away_arena` since this is all going to change in the next PR.

Overall summary:
- chore change to `TraceStep` so remove useless `<CTX>` generic
- `InstructionExecutor` is now basically `TraceStep` without the associate types, but still implemented on the old `Chip` struct that contains a trace matrix
- however now the flow is that the `**Chip` is created with empty matrix, the record arena is owned by `TracegenCtx`, and then after all the records are populated, we give the record arenas to the chips via `give_me_my_arena` (function intentionally named to make sure we remove it later)

The goal here is just to do the initial refactor to get the `RecordArena` into the correct place. Coming soon: blowing everything up to support different `RA, PB` generics.

closes INT-4062