### PR TITLE
Fix broken link in verify_stark README

### DIFF
--- a/guest-libs/verify_stark/README.md
+++ b/guest-libs/verify_stark/README.md
@@ -1,1 +1,1 @@
-See [book](https://book.openvm.dev/guest-libs/verify-stark.html)
+See [verify-stark.md](https://github.com/openvm-org/openvm/blob/main/book/src/guest-libs/verify-stark.md)


### PR DESCRIPTION
Replaced the outdated and broken link to the online documentation in guest-libs/verify_stark/README.md with a direct link to the source documentation file on GitHub. This ensures users can always access the latest documentation, even if the online book is unavailable or not yet published.