### PR TITLE
feat: new traits for VM extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5411,8 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
-version = "1.1.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad#37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad"
+version = "1.2.0-rc.0"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -5439,8 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-sdk"
-version = "1.1.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad#37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad"
+version = "1.2.0-rc.0"
 dependencies = [
  "dashmap",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "cb1ca5fdc3153064c3f5721905b29ae1d69407e0", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "cb1ca5fdc3153064c3f5721905b29ae1d69407e0", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "ffeeb442d9877e0e85441db48f90dbc13be9d942", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "ffeeb442d9877e0e85441db48f90dbc13be9d942", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "37aa9a7e8e5535908720bf0dedcf9bdc96eda4ad", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "cb1ca5fdc3153064c3f5721905b29ae1d69407e0", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "cb1ca5fdc3153064c3f5721905b29ae1d69407e0", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "ffeeb442d9877e0e85441db48f90dbc13be9d942", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "ffeeb442d9877e0e85441db48f90dbc13be9d942", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", rev = "6b74a2cc7f29f2b90b44400c9f937250ce387103", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "6b74a2cc7f29f2b90b44400c9f937250ce387103", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/crates/circuits/poseidon2-air/src/config.rs
+++ b/crates/circuits/poseidon2-air/src/config.rs
@@ -15,7 +15,7 @@ pub struct Poseidon2Config<F> {
     pub constants: Poseidon2Constants<F>,
 }
 
-impl<F: PrimeField32> Default for Poseidon2Config<F> {
+impl<F: Field> Default for Poseidon2Config<F> {
     fn default() -> Self {
         Self {
             constants: default_baby_bear_rc(),

--- a/crates/circuits/primitives/derive/src/lib.rs
+++ b/crates/circuits/primitives/derive/src/lib.rs
@@ -129,9 +129,10 @@ pub fn chip_derive(input: TokenStream) -> TokenStream {
         Data::Struct(inner) => {
             let generics = &ast.generics;
             let mut new_generics = generics.clone();
+            new_generics.params.push(syn::parse_quote! { R });
             new_generics
                 .params
-                .push(syn::parse_quote! { SC: openvm_stark_backend::config::StarkGenericConfig });
+                .push(syn::parse_quote! { PB: openvm_stark_backend::prover::hal::ProverBackend });
             let (impl_generics, _, _) = new_generics.split_for_impl();
 
             // Check if the struct has only one unnamed field
@@ -148,17 +149,11 @@ pub fn chip_derive(input: TokenStream) -> TokenStream {
             let where_clause = new_generics.make_where_clause();
             where_clause
                 .predicates
-                .push(syn::parse_quote! { #inner_ty: openvm_stark_backend::Chip<SC> });
+                .push(syn::parse_quote! { #inner_ty: openvm_stark_backend::Chip<R, PB> });
             quote! {
-                impl #impl_generics openvm_stark_backend::Chip<SC> for #name #ty_generics #where_clause {
-                    fn air(&self) -> openvm_stark_backend::AirRef<SC> {
-                        self.0.air()
-                    }
-                    fn generate_air_proof_input(self) -> openvm_stark_backend::prover::types::AirProofInput<SC> {
-                        self.0.generate_air_proof_input()
-                    }
-                    fn generate_air_proof_input_with_id(self, air_id: usize) -> (usize, openvm_stark_backend::prover::types::AirProofInput<SC>) {
-                        self.0.generate_air_proof_input_with_id(air_id)
+                impl #impl_generics openvm_stark_backend::Chip<R, PB> for #name #ty_generics #where_clause {
+                    fn generate_proving_ctx(&self, records: R) -> openvm_stark_backend::prover::types::AirProvingContext<PB> {
+                        self.0.generate_proving_ctx(records)
                     }
                 }
             }.into()
@@ -177,34 +172,32 @@ pub fn chip_derive(input: TokenStream) -> TokenStream {
                 })
                 .collect::<Vec<_>>();
 
-            let (air_arms, generate_air_proof_input_arms, generate_air_proof_input_with_id_arms): (Vec<_>, Vec<_>, Vec<_>) =
-                multiunzip(variants.iter().map(|(variant_name, field)| {
+            let (generate_proving_ctx_arms, where_predicates): (Vec<_>, Vec<_>) =
+                variants.iter().map(|(variant_name, field)| {
                 let field_ty = &field.ty;
-                let air_arm = quote! {
-                    #name::#variant_name(x) => <#field_ty as openvm_stark_backend::Chip<SC>>::air(x)
+                let generate_proving_ctx_arm = quote! {
+                    #name::#variant_name(x) => <#field_ty as openvm_stark_backend::Chip<R, PB>>::generate_proving_ctx(x, records)
                 };
-                let generate_air_proof_input_arm = quote! {
-                    #name::#variant_name(x) => <#field_ty as openvm_stark_backend::Chip<SC>>::generate_air_proof_input(x)
-                };
-                let generate_air_proof_input_with_id_arm = quote! {
-                    #name::#variant_name(x) => <#field_ty as openvm_stark_backend::Chip<SC>>::generate_air_proof_input_with_id(x, air_id)
-                };
-                (air_arm, generate_air_proof_input_arm, generate_air_proof_input_with_id_arm)
-            }));
+                let where_predicate =
+                    syn::parse_quote! { #field_ty: openvm_stark_backend::Chip<R, PB> };
+                (generate_proving_ctx_arm, where_predicate)
+            }).collect();
 
-            // Attach an extra generic SC: StarkGenericConfig to the impl_generics
+            // Attach extra generics R and PB to the impl_generics
             let generics = &ast.generics;
             let mut new_generics = generics.clone();
+            new_generics.params.push(syn::parse_quote! { R });
             new_generics
                 .params
-                .push(syn::parse_quote! { SC: openvm_stark_backend::config::StarkGenericConfig });
+                .push(syn::parse_quote! { PB: openvm_stark_backend::prover::hal::ProverBackend });
             let (impl_generics, _, _) = new_generics.split_for_impl();
 
             // Implement Chip whenever the inner type implements Chip
             let mut new_generics = generics.clone();
             let where_clause = new_generics.make_where_clause();
-            where_clause.predicates.push(syn::parse_quote! { openvm_stark_backend::config::Domain<SC>: openvm_stark_backend::p3_commit::PolynomialSpace<Val = F>
-            });
+            for predicate in where_predicates {
+                where_clause.predicates.push(predicate);
+            }
             let attributes = ast.attrs.iter().find(|&attr| attr.path().is_ident("chip"));
             if let Some(attr) = attributes {
                 let mut fail_flag = false;
@@ -238,20 +231,10 @@ pub fn chip_derive(input: TokenStream) -> TokenStream {
             }
 
             quote! {
-                impl #impl_generics openvm_stark_backend::Chip<SC> for #name #ty_generics #where_clause {
-                    fn air(&self) -> openvm_stark_backend::AirRef<SC> {
+                impl #impl_generics openvm_stark_backend::Chip<R, PB> for #name #ty_generics #where_clause {
+                    fn generate_proving_ctx(&self, records: R) -> openvm_stark_backend::prover::types::AirProvingContext<PB> {
                         match self {
-                            #(#air_arms,)*
-                        }
-                    }
-                    fn generate_air_proof_input(self) -> openvm_stark_backend::prover::types::AirProofInput<SC> {
-                        match self {
-                            #(#generate_air_proof_input_arms,)*
-                        }
-                    }
-                    fn generate_air_proof_input_with_id(self, air_id: usize) -> (usize, openvm_stark_backend::prover::types::AirProofInput<SC>) {
-                        match self {
-                            #(#generate_air_proof_input_with_id_arms,)*
+                            #(#generate_proving_ctx_arms,)*
                         }
                     }
                 }

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -11,9 +11,9 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir, PairBuilder},
     p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::{cpu::CpuBackend, types::AirProvingContext},
     rap::{get_air_name, BaseAirWithPublicValues, PartitionedBaseAir},
-    AirRef, Chip, ChipUsageGetter,
+    Chip, ChipUsageGetter,
 };
 
 mod bus;
@@ -112,10 +112,8 @@ pub struct BitwiseOperationLookupChip<const NUM_BITS: usize> {
     pub count_xor: Vec<AtomicU32>,
 }
 
-#[derive(Clone)]
-pub struct SharedBitwiseOperationLookupChip<const NUM_BITS: usize>(
-    Arc<BitwiseOperationLookupChip<NUM_BITS>>,
-);
+pub type SharedBitwiseOperationLookupChip<const NUM_BITS: usize> =
+    Arc<BitwiseOperationLookupChip<NUM_BITS>>;
 
 impl<const NUM_BITS: usize> BitwiseOperationLookupChip<NUM_BITS> {
     pub fn new(bus: BitwiseOperationLookupBus) -> Self {
@@ -177,57 +175,12 @@ impl<const NUM_BITS: usize> BitwiseOperationLookupChip<NUM_BITS> {
     }
 }
 
-impl<const NUM_BITS: usize> SharedBitwiseOperationLookupChip<NUM_BITS> {
-    pub fn new(bus: BitwiseOperationLookupBus) -> Self {
-        Self(Arc::new(BitwiseOperationLookupChip::new(bus)))
-    }
-    pub fn bus(&self) -> BitwiseOperationLookupBus {
-        self.0.bus()
-    }
-
-    pub fn air_width(&self) -> usize {
-        self.0.air_width()
-    }
-
-    pub fn request_range(&self, x: u32, y: u32) {
-        self.0.request_range(x, y);
-    }
-
-    pub fn request_xor(&self, x: u32, y: u32) -> u32 {
-        self.0.request_xor(x, y)
-    }
-
-    pub fn clear(&self) {
-        self.0.clear()
-    }
-
-    pub fn generate_trace<F: Field>(&self) -> RowMajorMatrix<F> {
-        self.0.generate_trace()
-    }
-}
-
-impl<SC: StarkGenericConfig, const NUM_BITS: usize> Chip<SC>
+impl<R, SC: StarkGenericConfig, const NUM_BITS: usize> Chip<R, CpuBackend<SC>>
     for BitwiseOperationLookupChip<NUM_BITS>
 {
-    fn air(&self) -> AirRef<SC> {
-        Arc::new(self.air)
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_proving_ctx(&self, _: R) -> AirProvingContext<CpuBackend<SC>> {
         let trace = self.generate_trace::<Val<SC>>();
-        AirProofInput::simple_no_pis(trace)
-    }
-}
-
-impl<SC: StarkGenericConfig, const NUM_BITS: usize> Chip<SC>
-    for SharedBitwiseOperationLookupChip<NUM_BITS>
-{
-    fn air(&self) -> AirRef<SC> {
-        self.0.air()
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
-        self.0.generate_air_proof_input()
+        AirProvingContext::simple_no_pis(Arc::new(trace))
     }
 }
 
@@ -243,31 +196,5 @@ impl<const NUM_BITS: usize> ChipUsageGetter for BitwiseOperationLookupChip<NUM_B
     }
     fn trace_width(&self) -> usize {
         NUM_BITWISE_OP_LOOKUP_COLS
-    }
-}
-
-impl<const NUM_BITS: usize> ChipUsageGetter for SharedBitwiseOperationLookupChip<NUM_BITS> {
-    fn air_name(&self) -> String {
-        self.0.air_name()
-    }
-
-    fn constant_trace_height(&self) -> Option<usize> {
-        self.0.constant_trace_height()
-    }
-
-    fn current_trace_height(&self) -> usize {
-        self.0.current_trace_height()
-    }
-
-    fn trace_width(&self) -> usize {
-        self.0.trace_width()
-    }
-}
-
-impl<const NUM_BITS: usize> AsRef<BitwiseOperationLookupChip<NUM_BITS>>
-    for SharedBitwiseOperationLookupChip<NUM_BITS>
-{
-    fn as_ref(&self) -> &BitwiseOperationLookupChip<NUM_BITS> {
-        &self.0
     }
 }

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -16,9 +16,9 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir, PairBuilder},
     p3_field::{Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::{cpu::CpuBackend, types::AirProvingContext},
     rap::{get_air_name, BaseAirWithPublicValues, PartitionedBaseAir},
-    AirRef, Chip, ChipUsageGetter,
+    Chip, ChipUsageGetter,
 };
 
 mod bus;
@@ -105,8 +105,7 @@ pub struct RangeTupleCheckerChip<const N: usize> {
     pub count: Vec<Arc<AtomicU32>>,
 }
 
-#[derive(Debug, Clone)]
-pub struct SharedRangeTupleCheckerChip<const N: usize>(Arc<RangeTupleCheckerChip<N>>);
+pub type SharedRangeTupleCheckerChip<const N: usize> = Arc<RangeTupleCheckerChip<N>>;
 
 impl<const N: usize> RangeTupleCheckerChip<N> {
     pub fn new(bus: RangeTupleCheckerBus<N>) -> Self {
@@ -160,55 +159,13 @@ impl<const N: usize> RangeTupleCheckerChip<N> {
     }
 }
 
-impl<const N: usize> SharedRangeTupleCheckerChip<N> {
-    pub fn new(bus: RangeTupleCheckerBus<N>) -> Self {
-        Self(Arc::new(RangeTupleCheckerChip::new(bus)))
-    }
-    pub fn bus(&self) -> &RangeTupleCheckerBus<N> {
-        self.0.bus()
-    }
-
-    pub fn sizes(&self) -> &[u32; N] {
-        self.0.sizes()
-    }
-
-    pub fn add_count(&self, ids: &[u32]) {
-        self.0.add_count(ids);
-    }
-
-    pub fn clear(&self) {
-        self.0.clear();
-    }
-
-    pub fn generate_trace<F: Field>(&self) -> RowMajorMatrix<F> {
-        self.0.generate_trace()
-    }
-}
-
-impl<SC: StarkGenericConfig, const N: usize> Chip<SC> for RangeTupleCheckerChip<N>
+impl<R, SC: StarkGenericConfig, const N: usize> Chip<R, CpuBackend<SC>> for RangeTupleCheckerChip<N>
 where
     Val<SC>: PrimeField32,
 {
-    fn air(&self) -> AirRef<SC> {
-        Arc::new(self.air)
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_proving_ctx(&self, _: R) -> AirProvingContext<CpuBackend<SC>> {
         let trace = self.generate_trace::<Val<SC>>();
-        AirProofInput::simple_no_pis(trace)
-    }
-}
-
-impl<SC: StarkGenericConfig, const N: usize> Chip<SC> for SharedRangeTupleCheckerChip<N>
-where
-    Val<SC>: PrimeField32,
-{
-    fn air(&self) -> AirRef<SC> {
-        self.0.air()
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
-        self.0.generate_air_proof_input()
+        AirProvingContext::simple_no_pis(Arc::new(trace))
     }
 }
 
@@ -224,29 +181,5 @@ impl<const N: usize> ChipUsageGetter for RangeTupleCheckerChip<N> {
     }
     fn trace_width(&self) -> usize {
         NUM_RANGE_TUPLE_COLS
-    }
-}
-
-impl<const N: usize> ChipUsageGetter for SharedRangeTupleCheckerChip<N> {
-    fn air_name(&self) -> String {
-        self.0.air_name()
-    }
-
-    fn constant_trace_height(&self) -> Option<usize> {
-        self.0.constant_trace_height()
-    }
-
-    fn current_trace_height(&self) -> usize {
-        self.0.current_trace_height()
-    }
-
-    fn trace_width(&self) -> usize {
-        self.0.trace_width()
-    }
-}
-
-impl<const N: usize> AsRef<RangeTupleCheckerChip<N>> for SharedRangeTupleCheckerChip<N> {
-    fn as_ref(&self) -> &RangeTupleCheckerChip<N> {
-        &self.0
     }
 }

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -16,9 +16,9 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir, PairBuilder},
     p3_field::{Field, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::{cpu::CpuBackend, types::AirProvingContext},
     rap::{get_air_name, BaseAirWithPublicValues, PartitionedBaseAir},
-    AirRef, Chip, ChipUsageGetter,
+    Chip, ChipUsageGetter,
 };
 use tracing::instrument;
 
@@ -102,8 +102,7 @@ pub struct VariableRangeCheckerChip {
     pub count: Vec<AtomicU32>,
 }
 
-#[derive(Clone)]
-pub struct SharedVariableRangeCheckerChip(Arc<VariableRangeCheckerChip>);
+pub type SharedVariableRangeCheckerChip = Arc<VariableRangeCheckerChip>;
 
 impl VariableRangeCheckerChip {
     pub fn new(bus: VariableRangeCheckerBus) -> Self {
@@ -186,60 +185,14 @@ impl VariableRangeCheckerChip {
     }
 }
 
-impl SharedVariableRangeCheckerChip {
-    pub fn new(bus: VariableRangeCheckerBus) -> Self {
-        Self(Arc::new(VariableRangeCheckerChip::new(bus)))
-    }
-
-    pub fn bus(&self) -> VariableRangeCheckerBus {
-        self.0.bus()
-    }
-
-    pub fn range_max_bits(&self) -> usize {
-        self.0.range_max_bits()
-    }
-
-    pub fn air_width(&self) -> usize {
-        self.0.air_width()
-    }
-
-    pub fn add_count(&self, value: u32, max_bits: usize) {
-        self.0.add_count(value, max_bits)
-    }
-
-    pub fn clear(&self) {
-        self.0.clear()
-    }
-
-    pub fn generate_trace<F: Field>(&self) -> RowMajorMatrix<F> {
-        self.0.generate_trace()
-    }
-}
-
-impl<SC: StarkGenericConfig> Chip<SC> for VariableRangeCheckerChip
+// We allow any `R` type so this can work with arbitrary record arenas.
+impl<R, SC: StarkGenericConfig> Chip<R, CpuBackend<SC>> for VariableRangeCheckerChip
 where
     Val<SC>: PrimeField32,
 {
-    fn air(&self) -> AirRef<SC> {
-        Arc::new(self.air)
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_proving_ctx(&self, _: R) -> AirProvingContext<CpuBackend<SC>> {
         let trace = self.generate_trace::<Val<SC>>();
-        AirProofInput::simple_no_pis(trace)
-    }
-}
-
-impl<SC: StarkGenericConfig> Chip<SC> for SharedVariableRangeCheckerChip
-where
-    Val<SC>: PrimeField32,
-{
-    fn air(&self) -> AirRef<SC> {
-        self.0.air()
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
-        self.0.generate_air_proof_input()
+        AirProvingContext::simple_no_pis(Arc::new(trace))
     }
 }
 
@@ -255,29 +208,5 @@ impl ChipUsageGetter for VariableRangeCheckerChip {
     }
     fn trace_width(&self) -> usize {
         NUM_VARIABLE_RANGE_COLS
-    }
-}
-
-impl ChipUsageGetter for SharedVariableRangeCheckerChip {
-    fn air_name(&self) -> String {
-        self.0.air_name()
-    }
-
-    fn constant_trace_height(&self) -> Option<usize> {
-        self.0.constant_trace_height()
-    }
-
-    fn current_trace_height(&self) -> usize {
-        self.0.current_trace_height()
-    }
-
-    fn trace_width(&self) -> usize {
-        self.0.trace_width()
-    }
-}
-
-impl AsRef<VariableRangeCheckerChip> for SharedVariableRangeCheckerChip {
-    fn as_ref(&self) -> &VariableRangeCheckerChip {
-        &self.0
     }
 }

--- a/crates/circuits/primitives/src/xor/lookup/mod.rs
+++ b/crates/circuits/primitives/src/xor/lookup/mod.rs
@@ -19,9 +19,9 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir, PairBuilder},
     p3_field::Field,
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::{cpu::CpuBackend, types::AirProvingContext},
     rap::{get_air_name, BaseAirWithPublicValues, PartitionedBaseAir},
-    AirRef, Chip, ChipUsageGetter,
+    Chip, ChipUsageGetter,
 };
 
 use super::bus::XorBus;
@@ -170,14 +170,10 @@ impl<const M: usize> XorLookupChip<M> {
     }
 }
 
-impl<SC: StarkGenericConfig, const M: usize> Chip<SC> for XorLookupChip<M> {
-    fn air(&self) -> AirRef<SC> {
-        Arc::new(self.air)
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+impl<R, SC: StarkGenericConfig, const M: usize> Chip<R, CpuBackend<SC>> for XorLookupChip<M> {
+    fn generate_proving_ctx(&self, _: R) -> AirProvingContext<CpuBackend<SC>> {
         let trace = self.generate_trace::<Val<SC>>();
-        AirProofInput::simple_no_pis(trace)
+        AirProvingContext::simple_no_pis(Arc::new(trace))
     }
 }
 

--- a/crates/circuits/sha256-air/src/tests.rs
+++ b/crates/circuits/sha256-air/src/tests.rs
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     rap::{get_air_name, BaseAirWithPublicValues, PartitionedBaseAir},
     utils::disable_debug_builder,
     verifier::VerificationError,
@@ -64,14 +64,14 @@ where
         Arc::new(self.air.clone())
     }
 
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
         let trace = crate::generate_trace::<Val<SC>>(
             &self.step,
             self.bitwise_lookup_chip.as_ref(),
             <Sha256Air as BaseAir<Val<SC>>>::width(&self.air.sub_air),
             self.records,
         );
-        AirProofInput::simple_no_pis(trace)
+        AirProvingContext::simple_no_pis(trace)
     }
 }
 

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -7,7 +7,7 @@ use openvm_poseidon2_air::Poseidon2Config;
 use openvm_stark_backend::{
     config::{Domain, StarkGenericConfig},
     p3_commit::PolynomialSpace,
-    p3_field::PrimeField32,
+    p3_field::Field,
     prover::hal::ProverBackend,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -33,7 +33,7 @@ pub const POSEIDON2_WIDTH: usize = 16;
 /// Offset for address space indices. This is used to distinguish between different memory spaces.
 pub const ADDR_SPACE_OFFSET: u32 = 1;
 /// Returns a Poseidon2 config for the VM.
-pub fn vm_poseidon2_config<F: PrimeField32>() -> Poseidon2Config<F> {
+pub fn vm_poseidon2_config<F: Field>() -> Poseidon2Config<F> {
     Poseidon2Config::default()
 }
 
@@ -64,9 +64,8 @@ where
 pub trait VmExecutionConfig<F> {
     type Executor: AnyEnum;
 
-    fn create_executors(
-        &self,
-    ) -> Result<ExecutorInventory<Self::Executor, F>, ExecutorInventoryError>;
+    fn create_executors(&self)
+        -> Result<ExecutorInventory<Self::Executor>, ExecutorInventoryError>;
 }
 
 pub trait VmCircuitConfig<SC: StarkGenericConfig> {

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -79,7 +79,7 @@ where
     SC: StarkGenericConfig,
     PB: ProverBackend,
 {
-    type SystemChipComplex: SystemChipComplex<PB>;
+    type SystemChipComplex: SystemChipComplex<RA, PB>;
 
     fn create_chip_complex(
         &self,

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -395,9 +395,26 @@ where
         self.chips.push(Box::new(chip));
     }
 
+    /// Adds a chip and associates it to the next executor.
+    /// **Caution:** you must add chips in the order matching the order that executors were added in
+    /// the [VmExecutionExtension] implementation.
     pub fn add_executor_chip<C: Chip<RA, PB> + 'static>(&mut self, chip: C) {
         self.executor_idx_to_air_idx.push(self.chips.len());
         self.chips.push(Box::new(chip));
+    }
+}
+
+// SharedVariableRangeCheckerChip is only used by the CPU backend.
+impl<SC, RA> ChipInventory<SC, RA, CpuBackend<SC>>
+where
+    SC: StarkGenericConfig,
+{
+    pub fn range_checker(&self) -> Result<&SharedVariableRangeCheckerChip, ChipInventoryError> {
+        self.find_chip::<SharedVariableRangeCheckerChip>()
+            .next()
+            .ok_or_else(|| ChipInventoryError::ChipNotFound {
+                name: "VariableRangeCheckerChip".to_string(),
+            })
     }
 }
 

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -73,6 +73,24 @@ pub const BOUNDARY_AIR_ID: usize = PUBLIC_VALUES_AIR_ID + 1 + BOUNDARY_AIR_OFFSE
 /// Merkle AIR commits start/final memory states.
 pub const MERKLE_AIR_ID: usize = CONNECTOR_AIR_ID + 1 + MERKLE_AIR_OFFSET;
 
+/// Extension of VM execution. Allows registration of custom execution of new instructions by
+/// opcode.
+pub trait VmExecutionExtension {
+    fn build(&self, inventory: &mut ExecutorInventory) -> Result<(), VmInventoryError>;
+}
+
+/// Extension of the VM circuit. Allows _in-order_ addition of new AIRs with interactions.
+pub trait VmCircuitExtension<SC> {
+    fn build(&self, inventory: &mut AirInventory) -> Result<(), VmInventoryError>;
+}
+
+/// Extension of VM trace generation.
+/// The implementation **must** add chips in the same order and number matching the AIRs in
+/// [`VmCircuitExtension`].
+pub trait VmProverExtension<RA, PB> {
+    fn build(&self, inventory: &mut ChipInventory) -> Result<(), VmInventoryError>;
+}
+
 /// Configuration for a processor extension.
 ///
 /// There are two associated types:

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -25,8 +25,6 @@ use openvm_stark_backend::{
 use rustc_hash::FxHashMap;
 
 use super::{GenerationError, PhantomSubExecutor, SystemConfig};
-#[cfg(feature = "bench-metrics")]
-use crate::metrics::VmMetrics;
 use crate::{
     arch::MatrixRecordArena,
     system::{
@@ -613,7 +611,6 @@ where
         mut self,
         record_arenas: Vec<RA>,
         trace_height_constraints: &[LinearConstraint],
-        #[cfg(feature = "bench-metrics")] metrics: &mut VmMetrics,
     ) -> Result<ProvingContext<PB>, GenerationError> {
         if trace_height_constraints.is_empty() {
             tracing::warn!("generating proof input without trace height constraints");
@@ -695,6 +692,7 @@ where
         })
     }
 
+    // TODO[jpw]: This doesn't belong here!
     // #[cfg(feature = "bench-metrics")]
     // fn finalize_metrics(&self, metrics: &mut VmMetrics)
     // where

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -17,7 +17,6 @@ use openvm_stark_backend::{
     p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
-    prover::types::AirProofInput,
     rap::{get_air_name, AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},
     AirRef, Chip, ChipUsageGetter,
 };

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -21,9 +21,8 @@ pub use openvm_instructions as instructions;
 pub mod hasher;
 pub mod interpreter;
 /// Testing framework
-#[cfg(any(test, feature = "test-utils"))]
-pub mod testing;
-
+// #[cfg(any(test, feature = "test-utils"))]
+// pub mod testing;
 pub use config::*;
 pub use execution::*;
 pub use extensions::*;

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 
 use super::{
     execution_control::ExecutionControl, ExecutionError, GenerationError, Streams, SystemConfig,
-    VmChipComplex, VmComplexTraceHeights, VmConfig,
+    VmChipComplex, VmConfig,
 };
 #[cfg(feature = "bench-metrics")]
 use crate::metrics::VmMetrics;

--- a/crates/vm/src/arch/testing/execution/mod.rs
+++ b/crates/vm/src/arch/testing/execution/mod.rs
@@ -5,7 +5,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     AirRef, Chip, ChipUsageGetter,
 };
 
@@ -56,7 +56,7 @@ where
         Arc::new(ExecutionDummyAir::new(self.bus))
     }
 
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
         let height = self.records.len().next_power_of_two();
         let width = self.trace_width();
         let mut values = Val::<SC>::zero_vec(height * width);
@@ -65,7 +65,7 @@ where
         for (row, record) in values.chunks_mut(width).zip(self.records) {
             *row.borrow_mut() = record;
         }
-        AirProofInput::simple_no_pis(RowMajorMatrix::new(values, width))
+        AirProvingContext::simple_no_pis(RowMajorMatrix::new(values, width))
     }
 }
 impl<F: Field> ChipUsageGetter for ExecutionTester<F> {

--- a/crates/vm/src/arch/testing/memory/air.rs
+++ b/crates/vm/src/arch/testing/memory/air.rs
@@ -6,7 +6,7 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
     AirRef, Chip, ChipUsageGetter,
 };
@@ -133,12 +133,12 @@ where
         Arc::new(self.air)
     }
 
-    fn generate_air_proof_input(mut self) -> AirProofInput<SC> {
+    fn generate_air_proof_input(mut self) -> AirProvingContext<SC> {
         let height = self.current_trace_height().next_power_of_two();
         let width = self.trace_width();
         self.trace.resize(height * width, Val::<SC>::ZERO);
 
-        AirProofInput::simple_no_pis(RowMajorMatrix::new(self.trace, width))
+        AirProvingContext::simple_no_pis(RowMajorMatrix::new(self.trace, width))
     }
 }
 

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
     interaction::{BusIndex, PermutationCheckBus},
     p3_field::PrimeField32,
     p3_matrix::dense::{DenseMatrix, RowMajorMatrix},
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     verifier::VerificationError,
     AirRef, Chip, ChipUsageGetter,
 };
@@ -383,7 +383,7 @@ impl<F: PrimeField32> Default for VmChipTestBuilder<F> {
 
 pub struct VmChipTester<SC: StarkGenericConfig> {
     pub memory: Option<MemoryTester<Val<SC>>>,
-    pub air_proof_inputs: Vec<(AirRef<SC>, AirProofInput<SC>)>,
+    pub air_proof_inputs: Vec<(AirRef<SC>, AirProvingContext<SC>)>,
 }
 
 impl<SC: StarkGenericConfig> Default for VmChipTester<SC> {
@@ -461,7 +461,7 @@ where
 
     pub fn load_air_proof_input(
         mut self,
-        air_proof_input: (AirRef<SC>, AirProofInput<SC>),
+        air_proof_input: (AirRef<SC>, AirProvingContext<SC>),
     ) -> Self {
         self.air_proof_inputs.push(air_proof_input);
         self

--- a/crates/vm/src/arch/testing/program/mod.rs
+++ b/crates/vm/src/arch/testing/program/mod.rs
@@ -6,7 +6,7 @@ use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     AirRef, Chip, ChipUsageGetter,
 };
 
@@ -57,7 +57,7 @@ impl<SC: StarkGenericConfig> Chip<SC> for ProgramTester<Val<SC>> {
         Arc::new(ProgramDummyAir::new(self.bus))
     }
 
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
         let height = self.records.len().next_power_of_two();
         let width = self.trace_width();
         let mut values = Val::<SC>::zero_vec(height * width);
@@ -67,7 +67,7 @@ impl<SC: StarkGenericConfig> Chip<SC> for ProgramTester<Val<SC>> {
             *(row[..width - 1]).borrow_mut() = record;
             row[width - 1] = Val::<SC>::ONE;
         }
-        AirProofInput::simple_no_pis(RowMajorMatrix::new(values, width))
+        AirProvingContext::simple_no_pis(RowMajorMatrix::new(values, width))
     }
 }
 

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -62,10 +62,22 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum GenerationError {
-    #[error("generated trace heights violate constraints")]
-    TraceHeightsLimitExceeded,
-    #[error(transparent)]
-    Execution(#[from] ExecutionError),
+    #[error("unexpected number of arenas: {actual} (expected num_airs={expected})")]
+    UnexpectedNumArenas { actual: usize, expected: usize },
+    #[error("force_trace_heights len incorrect: {actual} (expected num_airs={expected})")]
+    UnexpectedForceTraceHeightsLen { actual: usize, expected: usize },
+    #[error("trace height of air {air_idx} has height {height} greater than maximum {max_height}")]
+    TraceHeightsLimitExceeded {
+        air_idx: usize,
+        height: usize,
+        max_height: usize,
+    },
+    #[error("trace heights violate linear constraint {constraint_idx} ({value} >= {threshold})")]
+    LinearTraceHeightConstraintExceeded {
+        constraint_idx: usize,
+        value: u64,
+        threshold: u32,
+    },
 }
 
 /// A trait for key-value store for `Streams`.

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -88,6 +88,26 @@ impl<F: Field> BaseAir<F> for VmConnectorAir {
 }
 
 impl VmConnectorAir {
+    pub fn new(
+        execution_bus: ExecutionBus,
+        program_bus: ProgramBus,
+        range_bus: VariableRangeCheckerBus,
+        timestamp_max_bits: usize,
+    ) -> Self {
+        assert!(
+            range_bus.range_max_bits * 2 >= timestamp_max_bits,
+            "Range checker not large enough: range_max_bits={}, timestamp_max_bits={}",
+            range_bus.range_max_bits,
+            timestamp_max_bits
+        );
+        Self {
+            execution_bus,
+            program_bus,
+            range_bus,
+            timestamp_max_bits,
+        }
+    }
+
     /// Returns (low_bits, high_bits) to range check.
     fn timestamp_limb_bits(&self) -> (usize, usize) {
         let range_max_bits = self.range_bus.range_max_bits;

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -15,7 +15,6 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder},
     p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
     AirRef, Chip, ChipUsageGetter,
 };

--- a/crates/vm/src/system/connector/tests.rs
+++ b/crates/vm/src/system/connector/tests.rs
@@ -8,7 +8,7 @@ use openvm_instructions::{
 };
 use openvm_stark_backend::{
     config::StarkGenericConfig, engine::StarkEngine, p3_field::FieldAlgebra,
-    prover::types::AirProofInput, utils::disable_debug_builder,
+    prover::types::AirProvingContext, utils::disable_debug_builder,
 };
 use openvm_stark_sdk::{
     config::{
@@ -65,7 +65,7 @@ fn test_vm_connector_wrong_is_terminate() {
 fn test_impl(
     should_pass: bool,
     exit_code: u32,
-    f: impl FnOnce(&mut AirProofInput<BabyBearPoseidon2Config>),
+    f: impl FnOnce(&mut AirProvingContext<BabyBearPoseidon2Config>),
 ) {
     let vm_config = SystemConfig::default();
     let engine = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));

--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -85,14 +85,14 @@ impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
         self.air_names.clone()
     }
     pub fn generate_proving_ctx<SC: StarkGenericConfig>(
-        self,
+        &self,
     ) -> Vec<AirProvingContext<CpuBackend<SC>>>
     where
         F: PrimeField32,
         Domain<SC>: PolynomialSpace<Val = F>,
     {
         self.chips
-            .into_iter()
+            .iter()
             .map(|chip| chip.generate_proving_ctx(()))
             .collect()
     }

--- a/crates/vm/src/system/memory/controller/interface.rs
+++ b/crates/vm/src/system/memory/controller/interface.rs
@@ -1,9 +1,22 @@
 use openvm_stark_backend::{interaction::PermutationCheckBus, p3_field::PrimeField32};
 
 use crate::system::memory::{
-    merkle::MemoryMerkleChip, persistent::PersistentBoundaryChip, volatile::VolatileBoundaryChip,
+    merkle::{MemoryMerkleAir, MemoryMerkleChip},
+    persistent::{PersistentBoundaryAir, PersistentBoundaryChip},
+    volatile::{VolatileBoundaryAir, VolatileBoundaryChip},
     MemoryImage, CHUNK,
 };
+
+#[derive(Clone)]
+pub enum MemoryInterfaceAirs {
+    Volatile {
+        boundary: VolatileBoundaryAir,
+    },
+    Persistent {
+        boundary: PersistentBoundaryAir<CHUNK>,
+        merkle: MemoryMerkleAir<CHUNK>,
+    },
+}
 
 #[allow(clippy::large_enum_variant)]
 pub enum MemoryInterface<F> {

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -16,7 +16,6 @@ use openvm_stark_backend::{
     p3_field::PrimeField32,
     p3_maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator},
     p3_util::{log2_ceil_usize, log2_strict_usize},
-    prover::types::AirProofInput,
     AirRef, Chip, ChipUsageGetter,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -671,6 +671,17 @@ pub struct SharedMemoryHelper<F> {
     pub(crate) _marker: PhantomData<F>,
 }
 
+impl<F> SharedMemoryHelper<F> {
+    pub fn new(range_checker: SharedVariableRangeCheckerChip, timestamp_max_bits: usize) -> Self {
+        let timestamp_lt_air = AssertLtSubAir::new(range_checker.bus(), timestamp_max_bits);
+        Self {
+            range_checker,
+            timestamp_lt_air,
+            _marker: PhantomData,
+        }
+    }
+}
+
 /// A helper for generating trace values in auxiliary memory columns related to the offline memory
 /// argument.
 pub struct MemoryAuxColsFactory<'a, F> {

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -530,6 +530,10 @@ impl<F: PrimeField32> MemoryController<F> {
         }
     }
 
+    // @dev: Memory is complicated and allowed to break all the rules (e.g., 1 arena per chip) and
+    // there's no need for any memory chip to implement the Chip trait. We do it when convenient,
+    // but all that matters is that you can tracegen all the trace matrices for the memory AIRs
+    // _somehow_.
     pub fn generate_proving_ctx<SC: StarkGenericConfig>(
         self,
     ) -> Vec<AirProvingContext<CpuBackend<SC>>>
@@ -541,7 +545,7 @@ impl<F: PrimeField32> MemoryController<F> {
         let access_adapters = self.memory.access_adapter_inventory;
         match self.interface_chip {
             MemoryInterface::Volatile { boundary_chip } => {
-                ret.push(boundary_chip.generate_proving_ctx());
+                ret.push(boundary_chip.generate_proving_ctx(()));
             }
             MemoryInterface::Persistent {
                 merkle_chip,
@@ -549,12 +553,12 @@ impl<F: PrimeField32> MemoryController<F> {
                 ..
             } => {
                 debug_assert_eq!(ret.len(), BOUNDARY_AIR_OFFSET);
-                ret.push(boundary_chip.generate_proving_ctx());
+                ret.push(boundary_chip.generate_proving_ctx(()));
                 debug_assert_eq!(ret.len(), MERKLE_AIR_OFFSET);
                 ret.push(merkle_chip.generate_proving_ctx());
             }
         }
-        ret.extend(access_adapters.generate_proving_ctxs());
+        ret.extend(access_adapters.generate_proving_ctx());
         ret
     }
 

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -535,15 +535,15 @@ impl<F: PrimeField32> MemoryController<F> {
     // but all that matters is that you can tracegen all the trace matrices for the memory AIRs
     // _somehow_.
     pub fn generate_proving_ctx<SC: StarkGenericConfig>(
-        self,
+        &mut self,
     ) -> Vec<AirProvingContext<CpuBackend<SC>>>
     where
         Domain<SC>: PolynomialSpace<Val = F>,
     {
         let mut ret = Vec::new();
 
-        let access_adapters = self.memory.access_adapter_inventory;
-        match self.interface_chip {
+        let access_adapters = &self.memory.access_adapter_inventory;
+        match &mut self.interface_chip {
             MemoryInterface::Volatile { boundary_chip } => {
                 ret.push(boundary_chip.generate_proving_ctx(()));
             }

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -666,22 +666,20 @@ impl<F: PrimeField32> MemoryController<F> {
 }
 
 /// Owned version of [MemoryAuxColsFactory].
-pub struct SharedMemoryHelper<T> {
+pub struct SharedMemoryHelper<F> {
     pub(crate) range_checker: SharedVariableRangeCheckerChip,
     pub(crate) timestamp_lt_air: AssertLtSubAir,
-    pub(crate) _marker: PhantomData<T>,
+    pub(crate) _marker: PhantomData<F>,
 }
 
 /// A helper for generating trace values in auxiliary memory columns related to the offline memory
 /// argument.
-pub struct MemoryAuxColsFactory<'a, T> {
+pub struct MemoryAuxColsFactory<'a, F> {
     pub(crate) range_checker: &'a VariableRangeCheckerChip,
     pub(crate) timestamp_lt_air: AssertLtSubAir,
-    pub(crate) _marker: PhantomData<T>,
+    pub(crate) _marker: PhantomData<F>,
 }
 
-// NOTE[jpw]: The `make_*_aux_cols` functions should be thread-safe so they can be used in
-// parallelized trace generation.
 impl<F: PrimeField32> MemoryAuxColsFactory<'_, F> {
     /// Fill the trace assuming `prev_timestamp` is already provided in `buffer`.
     pub fn fill(&self, prev_timestamp: u32, timestamp: u32, buffer: &mut MemoryBaseAuxCols<F>) {
@@ -714,8 +712,8 @@ impl<F: PrimeField32> MemoryAuxColsFactory<'_, F> {
     }
 }
 
-impl<T> SharedMemoryHelper<T> {
-    pub fn as_borrowed(&self) -> MemoryAuxColsFactory<'_, T> {
+impl<F> SharedMemoryHelper<F> {
+    pub fn as_borrowed(&self) -> MemoryAuxColsFactory<'_, F> {
         MemoryAuxColsFactory {
             range_checker: self.range_checker.as_ref(),
             timestamp_lt_air: self.timestamp_lt_air,

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -10,7 +10,7 @@ use openvm_stark_backend::{
 
 use crate::system::memory::merkle::{MemoryDimensions, MemoryMerkleCols, MemoryMerklePvs};
 
-#[derive(Clone, Debug, derive_new::new)]
+#[derive(Clone, Debug)]
 pub struct MemoryMerkleAir<const CHUNK: usize> {
     pub memory_dimensions: MemoryDimensions,
     pub merkle_bus: PermutationCheckBus,

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -10,7 +10,7 @@ use openvm_stark_backend::{
 
 use crate::system::memory::merkle::{MemoryDimensions, MemoryMerkleCols, MemoryMerklePvs};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, derive_new::new)]
 pub struct MemoryMerkleAir<const CHUNK: usize> {
     pub memory_dimensions: MemoryDimensions,
     pub merkle_bus: PermutationCheckBus,

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     interaction::{PermutationCheckBus, PermutationInteractionType},
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     Chip, ChipUsageGetter,
 };
 use openvm_stark_sdk::{
@@ -22,17 +22,16 @@ use rand::RngCore;
 use super::memory_to_partition;
 use crate::{
     arch::{
-        ADDR_SPACE_OFFSET,
         testing::{MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
+        ADDR_SPACE_OFFSET,
     },
     system::memory::{
         merkle::{
             columns::MemoryMerkleCols, tests::util::HashTestChip, MemoryDimensions,
             MemoryMerkleChip,
         },
-        AddressMap,
         tree::MemoryNode,
-        Equipartition, MemoryImage,
+        AddressMap, Equipartition, MemoryImage,
     },
 };
 
@@ -166,7 +165,7 @@ fn test<const CHUNK: usize>(
         dummy_interaction_trace_rows,
         dummy_interaction_air.field_width() + 1,
     );
-    let dummy_interaction_api = AirProofInput::simple_no_pis(dummy_interaction_trace);
+    let dummy_interaction_api = AirProvingContext::simple_no_pis(dummy_interaction_trace);
 
     BabyBearPoseidon2Engine::run_test_fast(
         vec![
@@ -266,9 +265,10 @@ fn expand_test_no_accesses() {
     };
     let mut hash_test_chip = HashTestChip::new();
 
-    let memory = AddressMap::new(
-        vec![1 << memory_dimensions.address_height; 1 + (1 << memory_dimensions.addr_space_height)],
-    );
+    let memory = AddressMap::new(vec![
+        1 << memory_dimensions.address_height;
+        1 + (1 << memory_dimensions.addr_space_height)
+    ]);
     let tree = MemoryNode::<DEFAULT_CHUNK, _>::tree_from_memory(
         memory_dimensions,
         &memory,
@@ -303,9 +303,10 @@ fn expand_test_negative() {
 
     let mut hash_test_chip = HashTestChip::new();
 
-    let memory = AddressMap::new(
-        vec![1 << memory_dimensions.address_height; 1 + (1 << memory_dimensions.addr_space_height)],
-    );
+    let memory = AddressMap::new(vec![
+        1 << memory_dimensions.address_height;
+        1 + (1 << memory_dimensions.addr_space_height)
+    ]);
     let tree = MemoryNode::<DEFAULT_CHUNK, _>::tree_from_memory(
         memory_dimensions,
         &memory,

--- a/crates/vm/src/system/memory/merkle/tests/util.rs
+++ b/crates/vm/src/system/memory/merkle/tests/util.rs
@@ -6,7 +6,7 @@ use openvm_stark_backend::{
     p3_commit::PolynomialSpace,
     p3_field::Field,
     p3_matrix::dense::RowMajorMatrix,
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
 };
 use openvm_stark_sdk::dummy_airs::interaction::dummy_interaction_air::DummyInteractionAir;
 
@@ -47,11 +47,11 @@ impl<const CHUNK: usize, F: Field> HashTestChip<CHUNK, F> {
         }
         RowMajorMatrix::new(rows, width)
     }
-    pub fn generate_air_proof_input<SC: StarkGenericConfig>(&self) -> AirProofInput<SC>
+    pub fn generate_air_proof_input<SC: StarkGenericConfig>(&self) -> AirProvingContext<SC>
     where
         Domain<SC>: PolynomialSpace<Val = F>,
     {
-        AirProofInput::simple_no_pis(self.trace())
+        AirProvingContext::simple_no_pis(self.trace())
     }
 }
 

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -46,7 +46,7 @@ where
     F: PrimeField32,
 {
     // TODO: switch to using records
-    pub fn generate_proving_ctx<SC>(self) -> AirProvingContext<CpuBackend<SC>>
+    pub fn generate_proving_ctx<SC>(&mut self) -> AirProvingContext<CpuBackend<SC>>
     where
         SC: StarkGenericConfig,
         Domain<SC>: PolynomialSpace<Val = F>,
@@ -60,7 +60,7 @@ where
             mut rows,
             init_root,
             final_root,
-        } = self.final_state.unwrap();
+        } = self.final_state.take().unwrap();
         // important that this sort be stable,
         // because we need the initial root to be first and the final root to be second
         rows.reverse();

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -147,3 +147,10 @@ impl<SC: StarkGenericConfig> MemoryAirInventory<SC> {
         airs
     }
 }
+
+/// This is O(1) and returns the length of
+/// [`MemoryAirInventory::into_airs`].
+pub fn num_memory_airs(is_persistent: bool, max_access_adapter_n: usize) -> usize {
+    // boundary + { merkle if is_persistent } + access_adapters
+    1 + usize::from(is_persistent) + log2_strict_usize(max_access_adapter_n)
+}

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -1,4 +1,14 @@
+use std::sync::Arc;
+
+use openvm_circuit_primitives::{is_less_than::IsLtSubAir, var_range::VariableRangeCheckerBus};
 use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_stark_backend::{
+    config::{StarkGenericConfig, Val},
+    interaction::PermutationCheckBus,
+    p3_field::Field,
+    p3_util::{log2_ceil_usize, log2_strict_usize},
+    AirRef,
+};
 
 pub mod adapter;
 mod controller;
@@ -14,11 +24,14 @@ pub mod volatile;
 pub use controller::*;
 pub use online::{Address, AddressMap, INITIAL_TIMESTAMP};
 
-#[derive(PartialEq, Copy, Clone, Debug, Eq)]
-pub enum OpType {
-    Read = 0,
-    Write = 1,
-}
+use crate::{
+    arch::{MemoryConfig, ADDR_SPACE_OFFSET},
+    system::memory::{
+        adapter::AccessAdapterAir, dimensions::MemoryDimensions, interface::MemoryInterfaceAirs,
+        merkle::MemoryMerkleAir, offline_checker::MemoryBridge, persistent::PersistentBoundaryAir,
+        volatile::VolatileBoundaryAir,
+    },
+};
 
 /// The full pointer to a location in memory consists of an address space and a pointer within
 /// the address space.
@@ -49,9 +62,88 @@ impl<S, T> MemoryAddress<S, T> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, AlignedBorrow)]
-#[repr(C)]
-pub struct HeapAddress<S, T> {
-    pub address: MemoryAddress<S, T>,
-    pub data: MemoryAddress<S, T>,
+#[derive(Clone)]
+pub struct MemoryAirInventory<SC: StarkGenericConfig> {
+    pub bridge: MemoryBridge,
+    pub interface: MemoryInterfaceAirs,
+    pub access_adapters: Vec<AirRef<SC>>,
+}
+
+impl<SC: StarkGenericConfig> MemoryAirInventory<SC> {
+    pub fn new(
+        bridge: MemoryBridge,
+        mem_config: &MemoryConfig,
+        range_bus: VariableRangeCheckerBus,
+        merkle_compression_buses: Option<(PermutationCheckBus, PermutationCheckBus)>,
+    ) -> Self {
+        let memory_bus = bridge.memory_bus();
+        let interface = if let Some((merkle_bus, compression_bus)) = merkle_compression_buses {
+            // Persistent memory
+            let memory_dims = MemoryDimensions {
+                addr_space_height: mem_config.addr_space_height,
+                address_height: mem_config.pointer_max_bits - log2_strict_usize(CHUNK),
+            };
+            let boundary = PersistentBoundaryAir::<CHUNK> {
+                memory_dims,
+                memory_bus,
+                merkle_bus,
+                compression_bus,
+            };
+            let merkle = MemoryMerkleAir::<CHUNK> {
+                memory_dimensions: memory_dims,
+                merkle_bus,
+                compression_bus,
+            };
+            MemoryInterfaceAirs::Persistent { boundary, merkle }
+        } else {
+            // Volatile memory
+            let addr_space_height = mem_config.addr_space_height;
+            assert!(addr_space_height < Val::<SC>::bits() - 2);
+            let addr_space_max_bits =
+                log2_ceil_usize((ADDR_SPACE_OFFSET + 2u32.pow(addr_space_height as u32)) as usize);
+            let boundary = VolatileBoundaryAir::new(
+                memory_bus,
+                addr_space_max_bits,
+                mem_config.pointer_max_bits,
+                range_bus,
+            );
+            MemoryInterfaceAirs::Volatile { boundary }
+        };
+        // Memory access adapters
+        let lt_air = IsLtSubAir::new(range_bus, mem_config.clk_max_bits);
+        let maan = mem_config.max_access_adapter_n;
+        assert!(matches!(maan, 2 | 4 | 8 | 16 | 32));
+        let access_adapters: Vec<AirRef<SC>> = [
+            Arc::new(AccessAdapterAir::<2> { memory_bus, lt_air }) as AirRef<SC>,
+            Arc::new(AccessAdapterAir::<4> { memory_bus, lt_air }) as AirRef<SC>,
+            Arc::new(AccessAdapterAir::<8> { memory_bus, lt_air }) as AirRef<SC>,
+            Arc::new(AccessAdapterAir::<16> { memory_bus, lt_air }) as AirRef<SC>,
+            Arc::new(AccessAdapterAir::<32> { memory_bus, lt_air }) as AirRef<SC>,
+        ]
+        .into_iter()
+        .take(log2_strict_usize(maan))
+        .collect();
+
+        Self {
+            bridge,
+            interface,
+            access_adapters,
+        }
+    }
+
+    /// The order of memory AIRs is boundary, merkle (if exists), access adapters
+    pub fn into_airs(self) -> Vec<AirRef<SC>> {
+        let mut airs: Vec<AirRef<SC>> = Vec::new();
+        match self.interface {
+            MemoryInterfaceAirs::Volatile { boundary } => {
+                airs.push(Arc::new(boundary));
+            }
+            MemoryInterfaceAirs::Persistent { boundary, merkle } => {
+                airs.push(Arc::new(boundary));
+                airs.push(Arc::new(merkle));
+            }
+        }
+        airs.extend(self.access_adapters);
+        airs
+    }
 }

--- a/crates/vm/src/system/memory/offline_checker/bridge.rs
+++ b/crates/vm/src/system/memory/offline_checker/bridge.rs
@@ -1,3 +1,4 @@
+use getset::{CopyGetters, Getters};
 use openvm_circuit_primitives::{
     assert_less_than::{AssertLessThanIo, AssertLtSubAir},
     is_zero::{IsZeroIo, IsZeroSubAir},
@@ -40,6 +41,10 @@ impl MemoryBridge {
         Self {
             offline_checker: MemoryOfflineChecker::new(memory_bus, clk_max_bits, range_bus),
         }
+    }
+
+    pub fn memory_bus(&self) -> MemoryBus {
+        self.offline_checker.memory_bus
     }
 
     /// Prepare a logical memory read operation.
@@ -256,9 +261,11 @@ impl<T: FieldAlgebra, V: Copy + Into<T>, const N: usize> MemoryWriteOperation<'_
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, CopyGetters)]
 struct MemoryOfflineChecker {
+    #[get_copy = "pub"]
     memory_bus: MemoryBus,
+    #[get_copy = "pub"]
     timestamp_lt_air: AssertLtSubAir,
 }
 

--- a/crates/vm/src/system/memory/offline_checker/bridge.rs
+++ b/crates/vm/src/system/memory/offline_checker/bridge.rs
@@ -1,4 +1,4 @@
-use getset::{CopyGetters, Getters};
+use getset::CopyGetters;
 use openvm_circuit_primitives::{
     assert_less_than::{AssertLessThanIo, AssertLtSubAir},
     is_zero::{IsZeroIo, IsZeroSubAir},
@@ -45,6 +45,10 @@ impl MemoryBridge {
 
     pub fn memory_bus(&self) -> MemoryBus {
         self.offline_checker.memory_bus
+    }
+
+    pub fn range_bus(&self) -> VariableRangeCheckerBus {
+        self.offline_checker.timestamp_lt_air.bus
     }
 
     /// Prepare a logical memory read operation.

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -52,7 +52,7 @@ pub struct PersistentBoundaryCols<T, const CHUNK: usize> {
 /// - if `expand_direction` is 1, sends `[0, 0, address_space_label, leaf_label]` to `merkle_bus`.
 /// - if `expand_direction` is -1, receives `[1, 0, address_space_label, leaf_label]` from
 ///   `merkle_bus`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, derive_new::new)]
 pub struct PersistentBoundaryAir<const CHUNK: usize> {
     pub memory_dims: MemoryDimensions,
     pub memory_bus: MemoryBus,

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -52,7 +52,7 @@ pub struct PersistentBoundaryCols<T, const CHUNK: usize> {
 /// - if `expand_direction` is 1, sends `[0, 0, address_space_label, leaf_label]` to `merkle_bus`.
 /// - if `expand_direction` is -1, receives `[1, 0, address_space_label, leaf_label]` from
 ///   `merkle_bus`.
-#[derive(Clone, Debug, derive_new::new)]
+#[derive(Clone, Debug)]
 pub struct PersistentBoundaryAir<const CHUNK: usize> {
     pub memory_dims: MemoryDimensions,
     pub memory_bus: MemoryBus,

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -13,9 +13,9 @@ use openvm_stark_backend::{
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
-    prover::types::AirProofInput,
+    prover::{cpu::CpuBackend, types::AirProvingContext},
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
-    AirRef, Chip, ChipUsageGetter,
+    Chip, ChipUsageGetter,
 };
 use rustc_hash::FxHashSet;
 use tracing::instrument;
@@ -244,15 +244,12 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
     }
 }
 
-impl<const CHUNK: usize, SC: StarkGenericConfig> Chip<SC> for PersistentBoundaryChip<Val<SC>, CHUNK>
+impl<const CHUNK: usize, RA, SC> Chip<RA, CpuBackend<SC>> for PersistentBoundaryChip<Val<SC>, CHUNK>
 where
+    SC: StarkGenericConfig,
     Val<SC>: PrimeField32,
 {
-    fn air(&self) -> AirRef<SC> {
-        Arc::new(self.air.clone())
-    }
-
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_proving_ctx(&self, _: RA) -> AirProvingContext<CpuBackend<SC>> {
         let trace = {
             let width = PersistentBoundaryCols::<Val<SC>, CHUNK>::width();
             // Boundary AIR should always present in order to fix the AIR ID of merkle AIR.
@@ -267,13 +264,13 @@ where
             }
             let mut rows = Val::<SC>::zero_vec(height * width);
 
-            let touched_labels = match self.touched_labels {
+            let touched_labels = match &self.touched_labels {
                 TouchedLabels::Final(touched_labels) => touched_labels,
                 _ => panic!("Cannot generate trace before finalization"),
             };
 
             rows.par_chunks_mut(2 * width)
-                .zip(touched_labels.into_par_iter())
+                .zip(touched_labels.par_iter())
                 .for_each(|(row, touched_label)| {
                     let (initial_row, final_row) = row.split_at_mut(width);
                     *initial_row.borrow_mut() = PersistentBoundaryCols {
@@ -294,9 +291,9 @@ where
                         timestamp: Val::<SC>::from_canonical_u32(touched_label.final_timestamp),
                     };
                 });
-            RowMajorMatrix::new(rows, width)
+            Arc::new(RowMajorMatrix::new(rows, width))
         };
-        AirProofInput::simple_no_pis(trace)
+        AirProvingContext::simple_no_pis(trace)
     }
 }
 

--- a/crates/vm/src/system/memory/tests.rs
+++ b/crates/vm/src/system/memory/tests.rs
@@ -15,7 +15,7 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     rap::{BaseAirWithPublicValues, PartitionedBaseAir},
     Chip,
 };
@@ -228,7 +228,7 @@ fn test_memory_controller() {
     let mut airs = memory_controller.airs();
     let mut air_proof_inputs = memory_controller.generate_air_proof_inputs();
     airs.push(memory_requester_air);
-    air_proof_inputs.push(AirProofInput::simple_no_pis(memory_requester_trace));
+    air_proof_inputs.push(AirProvingContext::simple_no_pis(memory_requester_trace));
     airs.push(range_checker.air());
     air_proof_inputs.push(range_checker.generate_air_proof_input());
 
@@ -278,7 +278,7 @@ fn test_memory_controller_persistent() {
         range_checker.air(),
     ]);
     air_proof_inputs.extend([
-        AirProofInput::simple_no_pis(memory_requester_trace),
+        AirProvingContext::simple_no_pis(memory_requester_trace),
         poseidon_chip.generate_air_proof_input(),
         range_checker.generate_air_proof_input(),
     ]);

--- a/crates/vm/src/system/memory/volatile/tests.rs
+++ b/crates/vm/src/system/memory/volatile/tests.rs
@@ -5,7 +5,7 @@ use openvm_circuit_primitives::var_range::{
 };
 use openvm_stark_backend::{
     interaction::BusIndex, p3_field::FieldAlgebra, p3_matrix::dense::RowMajorMatrix,
-    prover::types::AirProofInput, Chip,
+    prover::types::AirProvingContext, Chip,
 };
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},
@@ -107,7 +107,7 @@ fn boundary_air_test() {
 
     boundary_chip.finalize(final_memory.clone());
     let boundary_air = boundary_chip.air();
-    let boundary_api: AirProofInput<BabyBearPoseidon2Config> =
+    let boundary_api: AirProvingContext<BabyBearPoseidon2Config> =
         boundary_chip.generate_air_proof_input();
     // test trace height override
     {
@@ -117,7 +117,7 @@ fn boundary_air_test() {
             VolatileBoundaryChip::new(memory_bus, 2, LIMB_BITS, range_checker.clone());
         boundary_chip.set_overridden_height(overridden_height);
         boundary_chip.finalize(final_memory.clone());
-        let boundary_api: AirProofInput<BabyBearPoseidon2Config> =
+        let boundary_api: AirProvingContext<BabyBearPoseidon2Config> =
             boundary_chip.generate_air_proof_input();
         assert_eq!(
             boundary_api.main_trace_height(),
@@ -135,8 +135,8 @@ fn boundary_air_test() {
         vec![
             boundary_api,
             range_checker.generate_air_proof_input(),
-            AirProofInput::simple_no_pis(init_memory_trace),
-            AirProofInput::simple_no_pis(final_memory_trace),
+            AirProvingContext::simple_no_pis(init_memory_trace),
+            AirProvingContext::simple_no_pis(final_memory_trace),
         ],
     )
     .expect("Verification failed");

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -4,7 +4,6 @@ use derive_more::derive::From;
 use openvm_circuit_derive::AnyEnum;
 use openvm_circuit_primitives::var_range::{VariableRangeCheckerAir, VariableRangeCheckerBus};
 use openvm_instructions::{LocalOpcode, PublishOpcode, SystemOpcode};
-use openvm_poseidon2_air::Poseidon2SubAir;
 use openvm_stark_backend::{
     config::StarkGenericConfig,
     interaction::{LookupBus, PermutationCheckBus},
@@ -43,7 +42,7 @@ use crate::{
         },
         native_adapter::{NativeAdapterAir, NativeAdapterStep},
         phantom::{PhantomAir, PhantomChip},
-        poseidon2::{air::Poseidon2PeripheryAir, new_poseidon2_periphery_air},
+        poseidon2::new_poseidon2_periphery_air,
         program::{ProgramBus, ProgramChip},
         public_values::{PublicValuesChip, PublicValuesCoreAir, PublicValuesStep},
     },
@@ -70,7 +69,6 @@ pub struct SystemPort {
 
 #[derive(Clone)]
 pub struct SystemAirInventory<SC: StarkGenericConfig> {
-    pub config: SystemConfig,
     pub program: ProgramAir,
     pub connector: VmConnectorAir,
     pub memory: MemoryAirInventory<SC>,
@@ -81,7 +79,7 @@ pub struct SystemAirInventory<SC: StarkGenericConfig> {
 
 impl<SC: StarkGenericConfig> SystemAirInventory<SC> {
     pub fn new(
-        config: SystemConfig,
+        config: &SystemConfig,
         port: SystemPort,
         merkle_compression_buses: Option<(PermutationCheckBus, PermutationCheckBus)>,
     ) -> Self {
@@ -127,7 +125,6 @@ impl<SC: StarkGenericConfig> SystemAirInventory<SC> {
         };
 
         Self {
-            config,
             program,
             connector,
             memory,
@@ -209,9 +206,9 @@ impl<SC: StarkGenericConfig> VmCircuitConfig<SC> for SystemConfig {
             program_bus,
             memory_bridge,
         };
-        let system = SystemAirInventory::new(self.clone(), system_port, merkle_compression_buses);
+        let system = SystemAirInventory::new(self, system_port, merkle_compression_buses);
 
-        let mut inventory = AirInventory::new(system, bus_idx_mgr);
+        let mut inventory = AirInventory::new(self.clone(), system, bus_idx_mgr);
 
         let range_checker = VariableRangeCheckerAir::new(range_bus);
         // Range checker is always the first AIR in the inventory

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -27,7 +27,7 @@ use program::ProgramAir;
 use public_values::PublicValuesAir;
 
 use crate::{
-    arch::{ExecutionBridge, SystemConfig, SystemPort, VmAirWrapper, ADDR_SPACE_OFFSET},
+    arch::{ExecutionBridge, ExecutionBus, SystemConfig, VmAirWrapper, ADDR_SPACE_OFFSET},
     system::{
         memory::{
             adapter::AccessAdapterAir, dimensions::MemoryDimensions, merkle::MemoryMerkleAir,
@@ -35,9 +35,18 @@ use crate::{
             volatile::VolatileBoundaryAir, CHUNK,
         },
         native_adapter::NativeAdapterAir,
+        program::ProgramBus,
         public_values::core::PublicValuesCoreAir,
     },
 };
+
+/// SystemPort combines system resources needed by most extensions
+#[derive(Clone, Copy)]
+pub struct SystemPort {
+    pub execution_bus: ExecutionBus,
+    pub program_bus: ProgramBus,
+    pub memory_bridge: MemoryBridge,
+}
 
 #[derive(Clone)]
 pub struct SystemAirs<SC: StarkGenericConfig> {

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use openvm_circuit_primitives::{is_less_than::IsLtSubAir, var_range::VariableRangeCheckerBus};
+use derive_more::derive::From;
+use openvm_circuit_derive::AnyEnum;
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerAir, VariableRangeCheckerBus};
+use openvm_instructions::SystemOpcode;
+use openvm_poseidon2_air::Poseidon2SubAir;
 use openvm_stark_backend::{
-    config::{StarkGenericConfig, Val},
-    interaction::PermutationCheckBus,
-    p3_field::Field,
-    p3_util::{log2_ceil_usize, log2_strict_usize},
+    config::StarkGenericConfig,
+    interaction::{LookupBus, PermutationCheckBus},
     AirRef,
 };
 
@@ -27,18 +29,33 @@ use program::ProgramAir;
 use public_values::PublicValuesAir;
 
 use crate::{
-    arch::{ExecutionBridge, ExecutionBus, SystemConfig, VmAirWrapper, ADDR_SPACE_OFFSET},
+    arch::{
+        vm_poseidon2_config, AirInventory, AirInventoryError, BusIndexManager, ExecutionBridge,
+        ExecutionBus, ExecutorInventory, ExecutorInventoryError, SystemConfig, VmAirWrapper,
+        VmCircuitConfig, VmExecutionConfig,
+    },
     system::{
+        connector::VmConnectorChip,
         memory::{
-            adapter::AccessAdapterAir, dimensions::MemoryDimensions, merkle::MemoryMerkleAir,
-            offline_checker::MemoryBridge, persistent::PersistentBoundaryAir,
-            volatile::VolatileBoundaryAir, CHUNK,
+            offline_checker::{MemoryBridge, MemoryBus},
+            MemoryAirInventory, MemoryController,
         },
         native_adapter::NativeAdapterAir,
-        program::ProgramBus,
-        public_values::core::PublicValuesCoreAir,
+        phantom::PhantomAir,
+        poseidon2::air::Poseidon2PeripheryAir,
+        program::{ProgramBus, ProgramChip},
+        public_values::{core::PublicValuesCoreAir, PublicValuesChip},
     },
 };
+
+/// **If** internal poseidon2 chip exists, then its periphery index is 0.
+const POSEIDON2_EXT_AIR_IDX: usize = 1;
+
+#[derive(AnyEnum, From)]
+pub enum SystemExecutor<F> {
+    PublicValues(PublicValuesChip<F>),
+    // Phantom(PhantomChip<F>),
+}
 
 /// SystemPort combines system resources needed by most extensions
 #[derive(Clone, Copy)]
@@ -49,30 +66,28 @@ pub struct SystemPort {
 }
 
 #[derive(Clone)]
-pub struct SystemAirs<SC: StarkGenericConfig> {
+pub struct SystemAirInventory<SC: StarkGenericConfig> {
     pub config: SystemConfig,
     pub program: ProgramAir,
     pub connector: VmConnectorAir,
-    pub memory_bridge: MemoryBridge,
-    /// The order of memory AIRs is boundary, merkle (if exists), access adapters
-    pub memory: Vec<AirRef<SC>>,
+    pub memory: MemoryAirInventory<SC>,
     /// Public values AIR exists if and only if continuations is disabled and `num_public_values`
     /// is greater than 0.
     pub public_values: Option<PublicValuesAir>,
 }
 
-impl<SC: StarkGenericConfig> SystemAirs<SC> {
+impl<SC: StarkGenericConfig> SystemAirInventory<SC> {
     pub fn new(
         config: SystemConfig,
         port: SystemPort,
-        range_bus: VariableRangeCheckerBus,
-        merkle_compression_bus: Option<(PermutationCheckBus, PermutationCheckBus)>,
+        merkle_compression_buses: Option<(PermutationCheckBus, PermutationCheckBus)>,
     ) -> Self {
         let SystemPort {
             execution_bus,
             program_bus,
             memory_bridge,
         } = port;
+        let range_bus = memory_bridge.range_bus();
         let program = ProgramAir::new(program_bus);
         let connector = VmConnectorAir::new(
             execution_bus,
@@ -82,55 +97,14 @@ impl<SC: StarkGenericConfig> SystemAirs<SC> {
         );
         assert_eq!(
             config.continuation_enabled,
-            merkle_compression_bus.is_some()
+            merkle_compression_buses.is_some()
         );
-        let memory_bus = memory_bridge.memory_bus();
-        let mem_config = &config.memory_config;
-        // TODO: consider making MemoryAirInventory to hold this
-        let mut memory: Vec<AirRef<SC>> = Vec::new();
-        if let Some((merkle_bus, compression_bus)) = merkle_compression_bus {
-            // Persistent memory
-            let memory_dims = MemoryDimensions {
-                addr_space_height: mem_config.addr_space_height,
-                address_height: mem_config.pointer_max_bits - log2_strict_usize(CHUNK),
-            };
-            let boundary = PersistentBoundaryAir::<CHUNK>::new(
-                memory_dims,
-                memory_bus,
-                merkle_bus,
-                compression_bus,
-            );
-            let merkle = MemoryMerkleAir::<CHUNK>::new(memory_dims, merkle_bus, compression_bus);
-            memory.push(Arc::new(boundary));
-            memory.push(Arc::new(merkle));
-        } else {
-            // Volatile memory
-            let addr_space_height = mem_config.addr_space_height;
-            assert!(addr_space_height < Val::<SC>::bits() - 2);
-            let addr_space_max_bits =
-                log2_ceil_usize((ADDR_SPACE_OFFSET + 2u32.pow(addr_space_height as u32)) as usize);
-            let boundary = VolatileBoundaryAir::new(
-                memory_bus,
-                addr_space_max_bits,
-                mem_config.pointer_max_bits,
-                range_bus,
-            );
-            memory.push(Arc::new(boundary));
-        }
-        // Memory access adapters
-        let lt_air = IsLtSubAir::new(range_bus, config.memory_config.clk_max_bits);
-        let maan = mem_config.max_access_adapter_n;
-        assert!(matches!(maan, 2 | 4 | 8 | 16 | 32));
-        memory.extend(
-            [
-                Arc::new(AccessAdapterAir::<2> { memory_bus, lt_air }) as AirRef<SC>,
-                Arc::new(AccessAdapterAir::<4> { memory_bus, lt_air }) as AirRef<SC>,
-                Arc::new(AccessAdapterAir::<8> { memory_bus, lt_air }) as AirRef<SC>,
-                Arc::new(AccessAdapterAir::<16> { memory_bus, lt_air }) as AirRef<SC>,
-                Arc::new(AccessAdapterAir::<32> { memory_bus, lt_air }) as AirRef<SC>,
-            ]
-            .into_iter()
-            .take(log2_strict_usize(maan)),
+
+        let memory = MemoryAirInventory::new(
+            memory_bridge,
+            &config.memory_config,
+            range_bus,
+            merkle_compression_buses,
         );
 
         let public_values = if config.has_public_values_chip() {
@@ -151,7 +125,6 @@ impl<SC: StarkGenericConfig> SystemAirs<SC> {
 
         Self {
             config,
-            memory_bridge,
             program,
             connector,
             memory,
@@ -161,9 +134,213 @@ impl<SC: StarkGenericConfig> SystemAirs<SC> {
 
     pub fn port(&self) -> SystemPort {
         SystemPort {
-            memory_bridge: self.memory_bridge,
+            memory_bridge: self.memory.bridge,
             program_bus: self.program.bus,
             execution_bus: self.connector.execution_bus,
+        }
+    }
+
+    pub fn into_airs(self) -> Vec<AirRef<SC>> {
+        let mut airs: Vec<AirRef<SC>> = Vec::new();
+        airs.push(Arc::new(self.program));
+        airs.push(Arc::new(self.connector));
+        if let Some(public_values) = self.public_values {
+            airs.push(Arc::new(public_values));
+        }
+        airs.extend(self.memory.into_airs());
+        airs
+    }
+}
+
+impl<F> VmExecutionConfig<F> for SystemConfig {
+    type Executor = SystemExecutor<F>;
+
+    fn create_executors(
+        &self,
+    ) -> Result<ExecutorInventory<Self::Executor, F>, ExecutorInventoryError> {
+    }
+}
+
+impl<SC: StarkGenericConfig> VmCircuitConfig<SC> for SystemConfig {
+    /// Every VM circuit within the OpenVM circuit architecture **must** be initialized from the
+    /// [SystemConfig].
+    fn create_circuit(&self) -> Result<AirInventory<SC>, AirInventoryError> {
+        let mut bus_idx_mgr = BusIndexManager::new();
+        let execution_bus = ExecutionBus::new(bus_idx_mgr.new_bus_idx());
+        let memory_bus = MemoryBus::new(bus_idx_mgr.new_bus_idx());
+        let program_bus = ProgramBus::new(bus_idx_mgr.new_bus_idx());
+        let range_bus =
+            VariableRangeCheckerBus::new(bus_idx_mgr.new_bus_idx(), self.memory_config.decomp);
+
+        let merkle_compression_buses = if self.continuation_enabled {
+            let merkle_bus = PermutationCheckBus::new(bus_idx_mgr.new_bus_idx());
+            let compression_bus = PermutationCheckBus::new(bus_idx_mgr.new_bus_idx());
+            Some((merkle_bus, compression_bus))
+        } else {
+            None
+        };
+        let memory_bridge =
+            MemoryBridge::new(memory_bus, self.memory_config.clk_max_bits, range_bus);
+        let system_port = SystemPort {
+            execution_bus,
+            program_bus,
+            memory_bridge,
+        };
+        let system = SystemAirInventory::new(self.clone(), system_port, merkle_compression_buses);
+
+        let mut inventory = AirInventory::new(system, bus_idx_mgr);
+
+        let range_checker = VariableRangeCheckerAir::new(range_bus);
+        // Range checker is always the first AIR in the inventory
+        inventory.add_air(range_checker);
+
+        if self.continuation_enabled {
+            assert_eq!(inventory.ext_airs().len(), POSEIDON2_EXT_AIR_IDX);
+            // Add direct poseidon2 AIR for persistent memory.
+            // Currently we never use poseidon2 opcodes when continuations is enabled: we will need
+            // special handling when that happens
+            let (_, compression_bus) = merkle_compression_buses.unwrap();
+            let direct_bus_idx = compression_bus.index;
+            let air = Poseidon2PeripheryAir::new(
+                Arc::new(Poseidon2SubAir::new(vm_poseidon2_config().constants.into())),
+                LookupBus::new(direct_bus_idx),
+            );
+            inventory.add_air(air);
+        }
+        let execution_bridge = ExecutionBridge::new(execution_bus, program_bus);
+        let phantom = PhantomAir {
+            execution_bridge,
+            phantom_opcode: SystemOpcode::PHANTOM.global_opcode(),
+        };
+        inventory.add_air(phantom);
+
+        Ok(inventory)
+    }
+}
+
+// =================== CPU Backend Specific System Chip Complex Constructor ==================
+
+/// Base system chips for CPU backend. These chips must exactly correspond to the AIRs in
+/// [SystemAirInventory]. The following don't execute instructions, but are essential
+/// for the VM architecture.
+pub struct SystemBase<F> {
+    pub program_chip: ProgramChip<F>,
+    pub connector_chip: VmConnectorChip<F>,
+    /// Contains all memory chips
+    pub memory_controller: MemoryController<F>,
+    pub public_values: Option<PublicValuesChip<F>>,
+}
+
+impl<F: PrimeField32> SystemComplex<F> {
+    pub fn new(config: SystemConfig) -> Self {
+        let mut bus_idx_mgr = BusIndexManager::new();
+        let execution_bus = ExecutionBus::new(bus_idx_mgr.new_bus_idx());
+        let memory_bus = MemoryBus::new(bus_idx_mgr.new_bus_idx());
+        let program_bus = ProgramBus::new(bus_idx_mgr.new_bus_idx());
+        let range_bus =
+            VariableRangeCheckerBus::new(bus_idx_mgr.new_bus_idx(), config.memory_config.decomp);
+
+        let range_checker = SharedVariableRangeCheckerChip::new(range_bus);
+        let memory_controller = if config.continuation_enabled {
+            MemoryController::with_persistent_memory(
+                memory_bus,
+                config.memory_config.clone(),
+                range_checker.clone(),
+                PermutationCheckBus::new(bus_idx_mgr.new_bus_idx()),
+                PermutationCheckBus::new(bus_idx_mgr.new_bus_idx()),
+            )
+        } else {
+            MemoryController::with_volatile_memory(
+                memory_bus,
+                config.memory_config.clone(),
+                range_checker.clone(),
+            )
+        };
+        let memory_bridge = memory_controller.memory_bridge();
+        let program_chip = ProgramChip::new(program_bus);
+        let connector_chip = VmConnectorChip::new(
+            execution_bus,
+            program_bus,
+            range_checker.clone(),
+            config.memory_config.clk_max_bits,
+        );
+
+        let mut inventory = VmInventory::new();
+        // PublicValuesChip is required when num_public_values > 0 in single segment mode.
+        if config.has_public_values_chip() {
+            assert_eq!(inventory.executors().len(), Self::PV_EXECUTOR_IDX);
+
+            let chip = PublicValuesChip::new(
+                VmAirWrapper::new(
+                    NativeAdapterAir::new(
+                        ExecutionBridge::new(execution_bus, program_bus),
+                        memory_bridge,
+                    ),
+                    PublicValuesCoreAir::new(
+                        config.num_public_values,
+                        config.max_constraint_degree as u32 - 1,
+                    ),
+                ),
+                PublicValuesCoreStep::new(
+                    NativeAdapterStep::new(),
+                    config.num_public_values,
+                    config.max_constraint_degree as u32 - 1,
+                ),
+                memory_controller.helper(),
+            );
+
+            inventory
+                .add_executor(chip, [PublishOpcode::PUBLISH.global_opcode()])
+                .unwrap();
+        }
+        if config.continuation_enabled {
+            assert_eq!(inventory.periphery().len(), Self::POSEIDON2_PERIPHERY_IDX);
+            // Add direct poseidon2 chip for persistent memory.
+            // This is **not** an instruction executor.
+            // Currently we never use poseidon2 opcodes when continuations is enabled: we will need
+            // special handling when that happens
+            let direct_bus_idx = memory_controller
+                .interface_chip
+                .compression_bus()
+                .unwrap()
+                .index;
+            let chip = Poseidon2PeripheryChip::new(
+                vm_poseidon2_config(),
+                direct_bus_idx,
+                config.max_constraint_degree,
+            );
+            inventory.add_periphery_chip(chip);
+        }
+        let phantom_opcode = SystemOpcode::PHANTOM.global_opcode();
+        let phantom_chip = PhantomChip::new(execution_bus, program_bus, SystemOpcode::CLASS_OFFSET);
+        inventory
+            .add_executor(RefCell::new(phantom_chip), [phantom_opcode])
+            .unwrap();
+
+        let base = SystemBase {
+            program_chip,
+            connector_chip,
+            memory_controller,
+            range_checker_chip: range_checker,
+        };
+
+        let max_trace_height = if TypeId::of::<F>() == TypeId::of::<BabyBear>() {
+            let min_log_blowup = log2_ceil_usize(config.max_constraint_degree - 1);
+            1 << (BabyBear::TWO_ADICITY - min_log_blowup)
+        } else {
+            tracing::warn!(
+                "constructing SystemComplex for unrecognized field; using max_trace_height = 2^30"
+            );
+            1 << 30
+        };
+
+        Self {
+            config,
+            base,
+            inventory,
+            bus_idx_mgr,
+            overridden_inventory_heights: None,
+            max_trace_height,
         }
     }
 }

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -268,7 +268,7 @@ where
         let connector_ctx = self.connector_chip.generate_proving_ctx(());
 
         let pv_ctx = self.public_values_chip.map(|chip| {
-            let mut arena = record_arenas.remove(PUBLIC_VALUES_AIR_ID);
+            let arena = record_arenas.remove(PUBLIC_VALUES_AIR_ID);
             chip.generate_proving_ctx(arena)
         });
         let memory_ctxs = self.memory_controller.generate_proving_ctx();

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -192,8 +192,6 @@ impl<F, const R: usize, const W: usize> Default for NativeAdapterStep<F, R, W> {
     }
 }
 
-pub type NativeAdapterChip<F, const R: usize, const W: usize> = NativeAdapterStep<F, R, W>;
-
 impl<F, const R: usize, const W: usize> AdapterTraceStep<F> for NativeAdapterStep<F, R, W>
 where
     F: PrimeField32,
@@ -264,7 +262,7 @@ where
 }
 
 impl<F: PrimeField32, const R: usize, const W: usize> AdapterTraceFiller<F>
-    for NativeAdapterChip<F, R, W>
+    for NativeAdapterStep<F, R, W>
 {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -179,10 +179,19 @@ pub struct NativeAdapterRecord<F, const R: usize, const W: usize> {
 /// R reads(R<=2), W writes(W<=1).
 /// Operands: b for the first read, c for the second read, a for the first write.
 /// If an operand is not used, its address space and pointer should be all 0.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct NativeAdapterStep<F, const R: usize, const W: usize> {
     _phantom: PhantomData<F>,
 }
+
+impl<F, const R: usize, const W: usize> Default for NativeAdapterStep<F, R, W> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
 pub type NativeAdapterChip<F, const R: usize, const W: usize> = NativeAdapterStep<F, R, W>;
 
 impl<F, const R: usize, const W: usize> AdapterTraceStep<F> for NativeAdapterStep<F, R, W>

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -179,10 +179,11 @@ pub struct NativeAdapterRecord<F, const R: usize, const W: usize> {
 /// R reads(R<=2), W writes(W<=1).
 /// Operands: b for the first read, c for the second read, a for the first write.
 /// If an operand is not used, its address space and pointer should be all 0.
-#[derive(Debug, derive_new::new)]
+#[derive(Debug, Default)]
 pub struct NativeAdapterStep<F, const R: usize, const W: usize> {
     _phantom: PhantomData<F>,
 }
+pub type NativeAdapterChip<F, const R: usize, const W: usize> = NativeAdapterStep<F, R, W>;
 
 impl<F, const R: usize, const W: usize> AdapterTraceStep<F> for NativeAdapterStep<F, R, W>
 where
@@ -254,7 +255,7 @@ where
 }
 
 impl<F: PrimeField32, const R: usize, const W: usize> AdapterTraceFiller<F>
-    for NativeAdapterStep<F, R, W>
+    for NativeAdapterChip<F, R, W>
 {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -1,3 +1,7 @@
+//! Chip to handle phantom instructions.
+//! The Air will always constrain a NOP which advances pc by DEFAULT_PC_STEP.
+//! The runtime executor will execute different phantom instructions that may
+//! affect trace generation based on the operand.
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit_primitives::AlignedBytesBorrow;

--- a/crates/vm/src/system/phantom/tests.rs
+++ b/crates/vm/src/system/phantom/tests.rs
@@ -2,14 +2,14 @@ use openvm_instructions::{instruction::Instruction, SystemOpcode};
 use openvm_stark_backend::p3_field::{FieldAlgebra, PrimeField32};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
-use super::PhantomChip;
+use super::PhantomExecutor;
 use crate::arch::{instructions::LocalOpcode, testing::VmChipTestBuilder, ExecutionState};
 type F = BabyBear;
 
 #[test]
 fn test_nops_and_terminate() {
     let mut tester = VmChipTestBuilder::default();
-    let mut chip = PhantomChip::<F>::new(
+    let mut chip = PhantomExecutor::<F>::new(
         tester.execution_bus(),
         tester.program_bus(),
         SystemOpcode::CLASS_OFFSET,

--- a/crates/vm/src/system/poseidon2/air.rs
+++ b/crates/vm/src/system/poseidon2/air.rs
@@ -22,7 +22,7 @@ use super::columns::Poseidon2PeripheryCols;
 #[derive(Clone, new, Debug)]
 pub struct Poseidon2PeripheryAir<F: Field, const SBOX_REGISTERS: usize> {
     pub(super) subair: Arc<Poseidon2SubAir<F, SBOX_REGISTERS>>,
-    pub(super) bus: LookupBus,
+    pub bus: LookupBus,
 }
 
 impl<F: Field, const SBOX_REGISTERS: usize> BaseAirWithPublicValues<F>

--- a/crates/vm/src/system/poseidon2/mod.rs
+++ b/crates/vm/src/system/poseidon2/mod.rs
@@ -76,7 +76,7 @@ impl<RA, SC: StarkGenericConfig> Chip<RA, CpuBackend<SC>> for Poseidon2Periphery
 where
     Val<SC>: PrimeField32,
 {
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
         match self {
             Poseidon2PeripheryChip::Register0(chip) => chip.generate_air_proof_input(),
             Poseidon2PeripheryChip::Register1(chip) => chip.generate_air_proof_input(),

--- a/crates/vm/src/system/poseidon2/mod.rs
+++ b/crates/vm/src/system/poseidon2/mod.rs
@@ -10,13 +10,13 @@
 
 use std::sync::Arc;
 
+use openvm_circuit_primitives::Chip;
 use openvm_poseidon2_air::{Poseidon2Config, Poseidon2SubAir};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     interaction::{BusIndex, LookupBus},
     p3_field::PrimeField32,
-    prover::cpu::CpuBackend,
-    AirRef, Chip, ChipUsageGetter,
+    AirRef, ChipUsageGetter,
 };
 
 #[cfg(test)]
@@ -36,6 +36,8 @@ pub mod trace;
 pub const PERIPHERY_POSEIDON2_WIDTH: usize = 16;
 pub const PERIPHERY_POSEIDON2_CHUNK_SIZE: usize = 8;
 
+#[derive(Chip)]
+#[chip(where = "F: PrimeField32")]
 pub enum Poseidon2PeripheryChip<F: PrimeField32> {
     Register0(Poseidon2PeripheryBaseChip<F, 0>),
     Register1(Poseidon2PeripheryBaseChip<F, 1>),
@@ -69,18 +71,6 @@ pub fn new_poseidon2_periphery_air<SC: StarkGenericConfig>(
             Arc::new(Poseidon2SubAir::new(poseidon2_config.constants.into())),
             direct_bus,
         ))
-    }
-}
-
-impl<RA, SC: StarkGenericConfig> Chip<RA, CpuBackend<SC>> for Poseidon2PeripheryChip<Val<SC>>
-where
-    Val<SC>: PrimeField32,
-{
-    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
-        match self {
-            Poseidon2PeripheryChip::Register0(chip) => chip.generate_air_proof_input(),
-            Poseidon2PeripheryChip::Register1(chip) => chip.generate_air_proof_input(),
-        }
     }
 }
 

--- a/crates/vm/src/system/poseidon2/trace.rs
+++ b/crates/vm/src/system/poseidon2/trace.rs
@@ -21,7 +21,7 @@ where
         self.air.clone()
     }
 
-    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
         let height = next_power_of_two_or_zero(self.current_trace_height());
         let width = self.trace_width();
 
@@ -55,7 +55,7 @@ where
                 cols.mult = Val::<SC>::from_canonical_u32(mult);
             });
 
-        AirProofInput::simple_no_pis(RowMajorMatrix::new(values, width))
+        AirProvingContext::simple_no_pis(RowMajorMatrix::new(values, width))
     }
 }
 

--- a/crates/vm/src/system/poseidon2/trace.rs
+++ b/crates/vm/src/system/poseidon2/trace.rs
@@ -7,7 +7,6 @@ use openvm_stark_backend::{
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     p3_maybe_rayon::prelude::*,
-    prover::types::AirProofInput,
     AirRef, Chip, ChipUsageGetter,
 };
 

--- a/crates/vm/src/system/poseidon2/trace.rs
+++ b/crates/vm/src/system/poseidon2/trace.rs
@@ -1,38 +1,41 @@
-use std::borrow::BorrowMut;
+use std::{borrow::BorrowMut, sync::Arc};
 
 use openvm_circuit_primitives::utils::next_power_of_two_or_zero;
+#[cfg(not(feature = "parallel"))]
+#[cfg(feature = "parallel")]
+use openvm_stark_backend::prover::types::AirProvingContext;
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     p3_air::BaseAir,
     p3_field::{FieldAlgebra, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     p3_maybe_rayon::prelude::*,
-    AirRef, Chip, ChipUsageGetter,
+    prover::{cpu::CpuBackend, types::AirProvingContext},
+    Chip, ChipUsageGetter,
 };
 
 use super::{columns::*, Poseidon2PeripheryBaseChip, PERIPHERY_POSEIDON2_WIDTH};
 
-impl<SC: StarkGenericConfig, const SBOX_REGISTERS: usize> Chip<SC>
+impl<RA, SC: StarkGenericConfig, const SBOX_REGISTERS: usize> Chip<RA, CpuBackend<SC>>
     for Poseidon2PeripheryBaseChip<Val<SC>, SBOX_REGISTERS>
 where
     Val<SC>: PrimeField32,
 {
-    fn air(&self) -> AirRef<SC> {
-        self.air.clone()
-    }
-
-    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
+    fn generate_proving_ctx(&self, _: RA) -> AirProvingContext<CpuBackend<SC>> {
         let height = next_power_of_two_or_zero(self.current_trace_height());
         let width = self.trace_width();
 
         let mut inputs = Vec::with_capacity(height);
         let mut multiplicities = Vec::with_capacity(height);
         #[cfg(feature = "parallel")]
-        let records_iter = self.records.into_par_iter();
+        let records_iter = self.records.par_iter();
         #[cfg(not(feature = "parallel"))]
-        let records_iter = self.records.into_iter();
+        let records_iter = self.records.iter();
         let (actual_inputs, actual_multiplicities): (Vec<_>, Vec<_>) = records_iter
-            .map(|(input, mult)| (input, mult.load(std::sync::atomic::Ordering::Relaxed)))
+            .map(|r| {
+                let (input, mult) = r.pair();
+                (*input, mult.load(std::sync::atomic::Ordering::Relaxed))
+            })
             .unzip();
         inputs.extend(actual_inputs);
         multiplicities.extend(actual_multiplicities);
@@ -55,7 +58,7 @@ where
                 cols.mult = Val::<SC>::from_canonical_u32(mult);
             });
 
-        AirProvingContext::simple_no_pis(RowMajorMatrix::new(values, width))
+        AirProvingContext::simple_no_pis(Arc::new(RowMajorMatrix::new(values, width)))
     }
 }
 

--- a/crates/vm/src/system/program/air.rs
+++ b/crates/vm/src/system/program/air.rs
@@ -32,7 +32,7 @@ pub struct ProgramExecutionCols<T> {
     pub g: T,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, derive_new::new)]
 pub struct ProgramAir {
     pub bus: ProgramBus,
 }

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -7,7 +7,6 @@ use openvm_stark_backend::{
     p3_field::PrimeField64,
     p3_maybe_rayon::prelude::*,
     prover::{cpu::CpuBackend, types::CommittedTraceData},
-    ChipUsageGetter,
 };
 
 use crate::{arch::ExecutionError, system::program::trace::padding_instruction};
@@ -102,28 +101,19 @@ impl<F: PrimeField64> ProgramHandler<F> {
     }
 }
 
-impl<F: PrimeField64> ChipUsageGetter for ProgramHandler<F> {
-    fn air_name(&self) -> String {
-        "ProgramChip".to_string()
-    }
-
-    fn constant_trace_height(&self) -> Option<usize> {
-        Some(self.true_program_length.next_power_of_two())
-    }
-
-    fn current_trace_height(&self) -> usize {
-        self.true_program_length
-    }
-
-    fn trace_width(&self) -> usize {
-        1
-    }
-}
-
 // For CPU backend only
 pub struct ProgramChip<SC: StarkGenericConfig> {
     /// `i` -> frequency of instruction in `i`th row of trace matrix. This requires filtering
     /// `program.instructions_and_debug_infos` to remove gaps.
-    pub filtered_exec_frequencies: Vec<u32>,
-    pub cached: CommittedTraceData<CpuBackend<SC>>,
+    filtered_exec_frequencies: Vec<u32>,
+    pub(super) cached: Option<CommittedTraceData<CpuBackend<SC>>>,
+}
+
+impl<SC: StarkGenericConfig> ProgramChip<SC> {
+    pub(super) fn unloaded() -> Self {
+        Self {
+            filtered_exec_frequencies: Vec::new(),
+            cached: None,
+        }
+    }
 }

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -12,7 +12,7 @@ use openvm_rv32im_transpiler::BranchEqualOpcode::*;
 use openvm_stark_backend::{
     p3_field::FieldAlgebra,
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
 };
 use openvm_stark_sdk::{
     any_rap_arc_vec,
@@ -81,7 +81,7 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
         any_rap_arc_vec!(program_air, counter_air),
         vec![
             program_proof_input,
-            AirProofInput::simple_no_pis(counter_trace),
+            AirProvingContext::simple_no_pis(counter_trace),
         ],
     )
     .expect("Verification failed");
@@ -209,7 +209,7 @@ fn test_program_negative() {
         any_rap_arc_vec!(program_air, counter_air),
         vec![
             program_proof_input,
-            AirProofInput::simple_no_pis(counter_trace),
+            AirProvingContext::simple_no_pis(counter_trace),
         ],
     )
     .expect("Verification failed");

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -29,7 +29,7 @@ use static_assertions::assert_impl_all;
 
 use crate::{
     arch::{instructions::SystemOpcode::*, testing::READ_INSTRUCTION_BUS},
-    system::program::{trace::VmCommittedExe, ProgramBus, ProgramChip},
+    system::program::{trace::VmCommittedExe, ProgramBus, ProgramHandler},
 };
 
 assert_impl_all!(VmCommittedExe<BabyBearPoseidon2Config>: Serialize, DeserializeOwned);
@@ -37,7 +37,7 @@ assert_impl_all!(VmCommittedExe<BabyBearPoseidon2RootConfig>: Serialize, Deseria
 
 fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
     let bus = ProgramBus::new(READ_INSTRUCTION_BUS);
-    let mut chip = ProgramChip::new_with_program(program.clone(), bus);
+    let mut chip = ProgramHandler::new_with_program(program.clone(), bus);
     let mut execution_frequencies = vec![0; program.len()];
     for pc_idx in execution {
         execution_frequencies[pc_idx as usize] += 1;
@@ -179,7 +179,7 @@ fn test_program_negative() {
     let bus = ProgramBus::new(READ_INSTRUCTION_BUS);
     let program = Program::from_instructions(&instructions);
 
-    let mut chip = ProgramChip::new_with_program(program, bus);
+    let mut chip = ProgramHandler::new_with_program(program, bus);
     let execution_frequencies = vec![1; instructions.len()];
     for pc_idx in 0..instructions.len() {
         chip.get_instruction(pc_idx as u32 * DEFAULT_PC_STEP)

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -83,7 +83,7 @@ where
     {
         let hasher = vm_poseidon2_hasher();
         let memory_dimensions = memory_config.memory_dimensions();
-        let app_program_commit: &[Val<SC>; CHUNK] = self.committed_program.commitment.as_ref();
+        let app_program_commit: &[Val<SC>; CHUNK] = self.commitment.as_ref();
         let mem_config = memory_config;
         let memory_image = AddressMap::from_sparse(
             mem_config.addr_space_sizes.clone(),

--- a/crates/vm/src/system/public_values/mod.rs
+++ b/crates/vm/src/system/public_values/mod.rs
@@ -1,11 +1,6 @@
-use core::PublicValuesCoreStep;
-
 use crate::{
-    arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper},
-    system::{
-        native_adapter::{NativeAdapterAir, NativeAdapterStep},
-        public_values::core::PublicValuesCoreAir,
-    },
+    arch::VmAirWrapper,
+    system::{native_adapter::NativeAdapterAir, public_values::core::PublicValuesCoreAir},
 };
 
 mod columns;
@@ -16,6 +11,3 @@ pub mod core;
 mod tests;
 
 pub type PublicValuesAir = VmAirWrapper<NativeAdapterAir<2, 0>, PublicValuesCoreAir>;
-pub type PublicValuesStepWithAdapter<F> = PublicValuesCoreStep<NativeAdapterStep<F, 2, 0>, F>;
-pub type PublicValuesChip<F> =
-    NewVmChipWrapper<F, PublicValuesAir, PublicValuesStepWithAdapter<F>, MatrixRecordArena<F>>;

--- a/crates/vm/src/system/public_values/mod.rs
+++ b/crates/vm/src/system/public_values/mod.rs
@@ -1,4 +1,7 @@
-use crate::{arch::VmAirWrapper, system::native_adapter::NativeAdapterAir};
+use crate::{
+    arch::{VmAirWrapper, VmChipWrapper},
+    system::native_adapter::NativeAdapterAir,
+};
 
 mod columns;
 /// Chip to publish custom public values from VM programs.
@@ -9,3 +12,4 @@ pub use core::*;
 mod tests;
 
 pub type PublicValuesAir = VmAirWrapper<NativeAdapterAir<2, 0>, PublicValuesCoreAir>;
+pub type PublicValuesChip<F> = VmChipWrapper<F, PublicValuesStep<F>>;

--- a/crates/vm/src/system/public_values/mod.rs
+++ b/crates/vm/src/system/public_values/mod.rs
@@ -1,11 +1,9 @@
-use crate::{
-    arch::VmAirWrapper,
-    system::{native_adapter::NativeAdapterAir, public_values::core::PublicValuesCoreAir},
-};
+use crate::{arch::VmAirWrapper, system::native_adapter::NativeAdapterAir};
 
 mod columns;
 /// Chip to publish custom public values from VM programs.
-pub mod core;
+mod core;
+pub use core::*;
 
 #[cfg(test)]
 mod tests;

--- a/crates/vm/src/system/public_values/tests.rs
+++ b/crates/vm/src/system/public_values/tests.rs
@@ -5,7 +5,7 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilderWithPublicValues},
     p3_field::{Field, FieldAlgebra},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     rap::PartitionedBaseAir,
     utils::disable_debug_builder,
     verifier::VerificationError,
@@ -51,7 +51,7 @@ fn public_values_happy_path_1() {
     let trace = RowMajorMatrix::new_row(cols.flatten());
     let pvs = to_field_vec(vec![0, 0, 12]);
 
-    BabyBearPoseidon2Engine::run_test_fast(vec![air], vec![AirProofInput::simple(trace, pvs)])
+    BabyBearPoseidon2Engine::run_test_fast(vec![air], vec![AirProvingContext::simple(trace, pvs)])
         .expect("Verification failed");
 }
 
@@ -70,8 +70,11 @@ fn public_values_neg_pv_not_match() {
 
     disable_debug_builder();
     assert_eq!(
-        BabyBearPoseidon2Engine::run_test_fast(vec![air], vec![AirProofInput::simple(trace, pvs)])
-            .err(),
+        BabyBearPoseidon2Engine::run_test_fast(
+            vec![air],
+            vec![AirProvingContext::simple(trace, pvs)]
+        )
+        .err(),
         Some(VerificationError::OodEvaluationMismatch)
     );
 }
@@ -91,8 +94,11 @@ fn public_values_neg_index_out_of_bound() {
 
     disable_debug_builder();
     assert_eq!(
-        BabyBearPoseidon2Engine::run_test_fast(vec![air], vec![AirProofInput::simple(trace, pvs)])
-            .err(),
+        BabyBearPoseidon2Engine::run_test_fast(
+            vec![air],
+            vec![AirProvingContext::simple(trace, pvs)]
+        )
+        .err(),
         Some(VerificationError::OodEvaluationMismatch)
     );
 }
@@ -129,8 +135,11 @@ fn public_values_neg_double_publish_impl(actual_pv: u32) {
 
     disable_debug_builder();
     assert_eq!(
-        BabyBearPoseidon2Engine::run_test_fast(vec![air], vec![AirProofInput::simple(trace, pvs)])
-            .err(),
+        BabyBearPoseidon2Engine::run_test_fast(
+            vec![air],
+            vec![AirProvingContext::simple(trace, pvs)]
+        )
+        .err(),
         Some(VerificationError::OodEvaluationMismatch)
     );
 }

--- a/extensions/algebra/circuit/src/fp2_extension.rs
+++ b/extensions/algebra/circuit/src/fp2_extension.rs
@@ -5,7 +5,7 @@ use openvm_circuit::{
     arch::{
         ExecutionBridge, SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor};
 use openvm_circuit_primitives::bitwise_op_lookup::{
@@ -76,7 +76,7 @@ pub enum Fp2ExtensionExecutor<F: PrimeField32> {
 pub enum Fp2ExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     // We put this only to get the <F> generic to work
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for Fp2Extension {

--- a/extensions/algebra/circuit/src/modular_extension.rs
+++ b/extensions/algebra/circuit/src/modular_extension.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     arch::{
         ExecutionBridge, SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor};
 use openvm_circuit_primitives::{
@@ -70,7 +70,7 @@ pub enum ModularExtensionExecutor<F: PrimeField32> {
 pub enum ModularExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     // We put this only to get the <F> generic to work
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for ModularExtension {

--- a/extensions/bigint/circuit/src/extension.rs
+++ b/extensions/bigint/circuit/src/extension.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
         ExecutionBridge, InitFileGenerator, SystemConfig, SystemPort, VmExtension, VmInventory,
         VmInventoryBuilder, VmInventoryError,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::{
@@ -90,7 +90,7 @@ pub enum Int256Periphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
     /// Only needed for multiplication extension
     RangeTupleChecker(SharedRangeTupleCheckerChip<2>),
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for Int256 {

--- a/extensions/ecc/circuit/src/weierstrass_extension.rs
+++ b/extensions/ecc/circuit/src/weierstrass_extension.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
     arch::{
         ExecutionBridge, SystemPort, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor};
 use openvm_circuit_primitives::bitwise_op_lookup::{
@@ -93,7 +93,7 @@ pub enum WeierstrassExtensionExecutor<F: PrimeField32> {
 #[derive(ChipUsageGetter, Chip, AnyEnum, From)]
 pub enum WeierstrassExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for WeierstrassExtension {

--- a/extensions/keccak256/circuit/src/extension.rs
+++ b/extensions/keccak256/circuit/src/extension.rs
@@ -6,7 +6,7 @@ use openvm_circuit::{
         InitFileGenerator, SystemConfig, SystemPort, VmExtension, VmInventory, VmInventoryBuilder,
         VmInventoryError,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
@@ -64,7 +64,7 @@ pub enum Keccak256Executor<F: PrimeField32> {
 #[derive(From, ChipUsageGetter, Chip, AnyEnum)]
 pub enum Keccak256Periphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for Keccak256 {

--- a/extensions/native/circuit/src/extension.rs
+++ b/extensions/native/circuit/src/extension.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
         ExecutionBridge, InitFileGenerator, MemoryConfig, SystemConfig, SystemPort, VmAirWrapper,
         VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives_derive::{Chip, ChipUsageGetter};
@@ -74,7 +74,7 @@ pub enum NativeExecutor<F: PrimeField32> {
 
 #[derive(From, ChipUsageGetter, Chip, AnyEnum)]
 pub enum NativePeriphery<F: PrimeField32> {
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for Native {

--- a/extensions/native/recursion/src/tests.rs
+++ b/extensions/native/recursion/src/tests.rs
@@ -7,7 +7,7 @@ use openvm_stark_backend::{
     interaction::BusIndex,
     p3_field::PrimeField32,
     p3_matrix::dense::RowMajorMatrix,
-    prover::types::AirProofInput,
+    prover::types::AirProvingContext,
     utils::disable_debug_builder,
     Chip,
 };
@@ -84,8 +84,8 @@ where
         receiver_air.field_width() + 1,
     );
 
-    let sender_air_proof_input = AirProofInput::simple_no_pis(sender_trace);
-    let receiver_air_proof_input = AirProofInput::simple_no_pis(receiver_trace);
+    let sender_air_proof_input = AirProvingContext::simple_no_pis(sender_trace);
+    let receiver_air_proof_input = AirProvingContext::simple_no_pis(receiver_trace);
 
     ProofInputForTest {
         airs: vec![Arc::new(sender_air), Arc::new(receiver_air)],

--- a/extensions/pairing/circuit/src/pairing_extension.rs
+++ b/extensions/pairing/circuit/src/pairing_extension.rs
@@ -3,7 +3,7 @@ use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Zero};
 use openvm_circuit::{
     arch::{VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError},
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor};
 use openvm_circuit_primitives::bitwise_op_lookup::SharedBitwiseOperationLookupChip;
@@ -64,13 +64,13 @@ pub struct PairingExtension {
 
 #[derive(Chip, ChipUsageGetter, InstructionExecutor, AnyEnum, InsExecutorE1)]
 pub enum PairingExtensionExecutor<F: PrimeField32> {
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 #[derive(ChipUsageGetter, Chip, AnyEnum, From)]
 pub enum PairingExtensionPeriphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for PairingExtension {

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -165,8 +165,10 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
     }
 }
 
+pub struct Rv32BaseAluAdapterStep<const LIMB_BITS: usize>;
+
 #[derive(derive_new::new)]
-pub struct Rv32BaseAluAdapterStep<const LIMB_BITS: usize> {
+pub struct Rv32BaseAluAdapterChip<const LIMB_BITS: usize> {
     // TODO(arayi): use reference to bitwise lookup chip with lifetimes instead
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
 }
@@ -270,7 +272,7 @@ impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceStep<F>
 }
 
 impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceFiller<F>
-    for Rv32BaseAluAdapterStep<LIMB_BITS>
+    for Rv32BaseAluAdapterChip<LIMB_BITS>
 {
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         // SAFETY: the following is highly unsafe. We are going to cast `adapter_row` to a record

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -169,8 +169,7 @@ pub struct Rv32BaseAluAdapterStep<const LIMB_BITS: usize>;
 
 #[derive(derive_new::new)]
 pub struct Rv32BaseAluAdapterChip<const LIMB_BITS: usize> {
-    // TODO(arayi): use reference to bitwise lookup chip with lifetimes instead
-    pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
+    bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
 }
 
 // Intermediate type that should not be copied or cloned and should be directly written to

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -118,7 +118,6 @@ pub struct Rv32BranchAdapterRecord {
 
 /// Reads instructions of the form OP a, b, c, d, e where if(\[a:4\]_d op \[b:4\]_e) pc += c.
 /// Operands d and e can only be 1.
-#[derive(derive_new::new)]
 pub struct Rv32BranchAdapterStep;
 
 impl<F> AdapterTraceStep<F> for Rv32BranchAdapterStep

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -119,6 +119,7 @@ pub struct Rv32BranchAdapterRecord {
 /// Reads instructions of the form OP a, b, c, d, e where if(\[a:4\]_d op \[b:4\]_e) pc += c.
 /// Operands d and e can only be 1.
 pub struct Rv32BranchAdapterStep;
+pub type Rv32BranchAdapterChip = Rv32BranchAdapterStep;
 
 impl<F> AdapterTraceStep<F> for Rv32BranchAdapterStep
 where
@@ -176,7 +177,7 @@ where
         // This function is intentionally left empty
     }
 }
-impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32BranchAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32BranchAdapterChip {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32BranchAdapterRecord =

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -160,6 +160,7 @@ pub struct Rv32JalrAdapterRecord {
 
 // This adapter reads from [b:4]_d (rs1) and writes to [a:4]_d (rd)
 pub struct Rv32JalrAdapterStep;
+pub type Rv32JalrAdapterChip = Rv32JalrAdapterStep;
 
 impl<F> AdapterTraceStep<F> for Rv32JalrAdapterStep
 where
@@ -227,7 +228,7 @@ where
         }
     }
 }
-impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32JalrAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32JalrAdapterChip {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32JalrAdapterRecord = unsafe { get_record_from_slice(&mut adapter_row, ()) };

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -159,7 +159,6 @@ pub struct Rv32JalrAdapterRecord {
 }
 
 // This adapter reads from [b:4]_d (rs1) and writes to [a:4]_d (rd)
-#[derive(derive_new::new)]
 pub struct Rv32JalrAdapterStep;
 
 impl<F> AdapterTraceStep<F> for Rv32JalrAdapterStep

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -324,6 +324,11 @@ pub struct Rv32LoadStoreAdapterRecord {
 #[derive(derive_new::new)]
 pub struct Rv32LoadStoreAdapterStep {
     pointer_max_bits: usize,
+}
+
+#[derive(derive_new::new)]
+pub struct Rv32LoadStoreAdapterChip {
+    pointer_max_bits: usize,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -200,7 +200,6 @@ pub struct Rv32RdWriteAdapterRecord {
     pub rd_aux_record: MemoryWriteBytesAuxRecord<RV32_REGISTER_NUM_LIMBS>,
 }
 
-#[derive(derive_new::new)]
 pub struct Rv32RdWriteAdapterStep;
 
 impl<F> AdapterTraceStep<F> for Rv32RdWriteAdapterStep

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -201,6 +201,7 @@ pub struct Rv32RdWriteAdapterRecord {
 }
 
 pub struct Rv32RdWriteAdapterStep;
+pub type Rv32RdWriteAdapterChip = Rv32RdWriteAdapterStep;
 
 impl<F> AdapterTraceStep<F> for Rv32RdWriteAdapterStep
 where
@@ -312,6 +313,7 @@ where
 pub struct Rv32CondRdWriteAdapterStep {
     inner: Rv32RdWriteAdapterStep,
 }
+pub type Rv32CondRdWriteAdapterChip = Rv32CondRdWriteAdapterStep;
 
 impl<F> AdapterTraceStep<F> for Rv32CondRdWriteAdapterStep
 where
@@ -368,7 +370,7 @@ where
     }
 }
 
-impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32CondRdWriteAdapterStep {
+impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32CondRdWriteAdapterChip {
     #[inline(always)]
     fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, mut adapter_row: &mut [F]) {
         let record: &Rv32RdWriteAdapterRecord =

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{
@@ -33,7 +33,9 @@ use openvm_stark_backend::{
     rap::BaseAirWithPublicValues,
 };
 
-use crate::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
+use crate::adapters::{
+    Rv32RdWriteAdapterChip, Rv32RdWriteAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+};
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow)]
@@ -203,14 +205,15 @@ pub struct Rv32AuipcCoreRecord {
 }
 
 #[derive(derive_new::new)]
-pub struct Rv32AuipcStep<A> {
+pub struct Rv32AuipcStep<A = Rv32RdWriteAdapterStep> {
     adapter: A,
 }
 
 #[derive(derive_new::new)]
-pub struct Rv32AuipcChip<A> {
+pub struct Rv32AuipcChip<F, A = Rv32RdWriteAdapterChip> {
     adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+    pub mem_helper: SharedMemoryHelper<F>,
 }
 
 impl<F, A> TraceStep<F> for Rv32AuipcStep<A>
@@ -252,14 +255,14 @@ where
     }
 }
 
-impl<F, A> TraceFiller<F> for Rv32AuipcStep<A>
+impl<F, A> TraceFiller<F> for Rv32AuipcChip<A>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
 
         let record: &Rv32AuipcCoreRecord = unsafe { get_record_from_slice(&mut core_row, ()) };
 

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -205,6 +205,11 @@ pub struct Rv32AuipcCoreRecord {
 #[derive(derive_new::new)]
 pub struct Rv32AuipcStep<A> {
     adapter: A,
+}
+
+#[derive(derive_new::new)]
+pub struct Rv32AuipcChip<A> {
+    adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 

--- a/extensions/rv32im/circuit/src/auipc/mod.rs
+++ b/extensions/rv32im/circuit/src/auipc/mod.rs
@@ -9,6 +9,3 @@ pub use core::*;
 mod tests;
 
 pub type Rv32AuipcAir = VmAirWrapper<Rv32RdWriteAdapterAir, Rv32AuipcCoreAir>;
-pub type Rv32AuipcStepWithAdapter = Rv32AuipcStep<Rv32RdWriteAdapterStep>;
-pub type Rv32AuipcChip<F> =
-    NewVmChipWrapper<F, Rv32AuipcAir, Rv32AuipcStepWithAdapter, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -185,6 +185,12 @@ pub struct BaseAluCoreRecord<const NUM_LIMBS: usize> {
 #[derive(derive_new::new)]
 pub struct BaseAluStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
+    pub offset: usize,
+}
+
+#[derive(derive_new::new)]
+pub struct BaseAluChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub offset: usize,
 }
@@ -242,7 +248,7 @@ where
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
-    for BaseAluStep<A, NUM_LIMBS, LIMB_BITS>
+    for BaseAluChip<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -13,7 +13,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{
@@ -189,10 +189,11 @@ pub struct BaseAluStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 #[derive(derive_new::new)]
-pub struct BaseAluChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct BaseAluChip<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub offset: usize,
+    pub mem_helper: SharedMemoryHelper<F>,
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
@@ -253,9 +254,9 @@ where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
 
         let record: &BaseAluCoreRecord<NUM_LIMBS> =
             unsafe { get_record_from_slice(&mut core_row, ()) };

--- a/extensions/rv32im/circuit/src/base_alu/mod.rs
+++ b/extensions/rv32im/circuit/src/base_alu/mod.rs
@@ -3,6 +3,7 @@ use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 use super::adapters::{
     Rv32BaseAluAdapterAir, Rv32BaseAluAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
+use crate::adapters::Rv32BaseAluAdapterChip;
 
 mod core;
 pub use core::*;
@@ -15,4 +16,4 @@ pub type Rv32BaseAluAir =
 pub type Rv32BaseAluStep =
     BaseAluStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32BaseAluChip<F> =
-    NewVmChipWrapper<F, Rv32BaseAluAir, Rv32BaseAluStep, MatrixRecordArena<F>>;
+    BaseAluChip<F, Rv32BaseAluAdapterChip<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{utils::not, AlignedBytesBorrow};
@@ -153,6 +153,14 @@ pub struct BranchEqualStep<A, const NUM_LIMBS: usize> {
     pub pc_step: u32,
 }
 
+#[derive(derive_new::new)]
+pub struct BranchEqualChip<F, A, const NUM_LIMBS: usize> {
+    adapter: A,
+    pub offset: usize,
+    pub pc_step: u32,
+    pub mem_helper: SharedMemoryHelper<F>,
+}
+
 impl<F, A, const NUM_LIMBS: usize> TraceStep<F> for BranchEqualStep<A, NUM_LIMBS>
 where
     F: PrimeField32,
@@ -201,14 +209,14 @@ where
     }
 }
 
-impl<F, A, const NUM_LIMBS: usize> TraceFiller<F> for BranchEqualStep<A, NUM_LIMBS>
+impl<F, A, const NUM_LIMBS: usize> TraceFiller<F> for BranchEqualChip<F, A, NUM_LIMBS>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
         let record: &BranchEqualCoreRecord<NUM_LIMBS> =
             unsafe { get_record_from_slice(&mut core_row, ()) };
         let core_row: &mut BranchEqualCoreCols<F, NUM_LIMBS> = core_row.borrow_mut();

--- a/extensions/rv32im/circuit/src/branch_eq/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/mod.rs
@@ -1,7 +1,7 @@
-use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{VmAirWrapper};
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
-use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep};
+use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep, Rv32BranchAdapterChip};
 
 mod core;
 pub use core::*;
@@ -12,5 +12,4 @@ mod tests;
 pub type Rv32BranchEqualAir =
     VmAirWrapper<Rv32BranchAdapterAir, BranchEqualCoreAir<RV32_REGISTER_NUM_LIMBS>>;
 pub type Rv32BranchEqualStep = BranchEqualStep<Rv32BranchAdapterStep, RV32_REGISTER_NUM_LIMBS>;
-pub type Rv32BranchEqualChip<F> =
-    NewVmChipWrapper<F, Rv32BranchEqualAir, Rv32BranchEqualStep, MatrixRecordArena<F>>;
+pub type Rv32BranchEqualChip<F> = BranchEqualChip<F, Rv32BranchAdapterChip, RV32_REGISTER_NUM_LIMBS>;

--- a/extensions/rv32im/circuit/src/branch_eq/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/mod.rs
@@ -1,7 +1,7 @@
-use openvm_circuit::arch::{VmAirWrapper};
+use openvm_circuit::arch::VmAirWrapper;
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
-use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep, Rv32BranchAdapterChip};
+use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterChip, Rv32BranchAdapterStep};
 
 mod core;
 pub use core::*;
@@ -12,4 +12,5 @@ mod tests;
 pub type Rv32BranchEqualAir =
     VmAirWrapper<Rv32BranchAdapterAir, BranchEqualCoreAir<RV32_REGISTER_NUM_LIMBS>>;
 pub type Rv32BranchEqualStep = BranchEqualStep<Rv32BranchAdapterStep, RV32_REGISTER_NUM_LIMBS>;
-pub type Rv32BranchEqualChip<F> = BranchEqualChip<F, Rv32BranchAdapterChip, RV32_REGISTER_NUM_LIMBS>;
+pub type Rv32BranchEqualChip<F> =
+    BranchEqualChip<F, Rv32BranchAdapterChip, RV32_REGISTER_NUM_LIMBS>;

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{
@@ -207,10 +207,11 @@ pub struct BranchLessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
 }
 
 #[derive(derive_new::new)]
-pub struct BranchLessChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct BranchLessThanChip<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub offset: usize,
+    pub mem_helper: SharedMemoryHelper<F>,
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
@@ -267,18 +268,18 @@ where
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
-    for BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
+    for BranchLessThanChip<F, A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
         let record: &BranchLessThanCoreRecord<NUM_LIMBS, LIMB_BITS> =
             unsafe { get_record_from_slice(&mut core_row, ()) };
 
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
         let core_row: &mut BranchLessThanCoreCols<F, NUM_LIMBS, LIMB_BITS> = core_row.borrow_mut();
 
         let signed = record.local_opcode == BranchLessThanOpcode::BLT as u8

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -203,6 +203,12 @@ pub struct BranchLessThanCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usi
 #[derive(derive_new::new)]
 pub struct BranchLessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
+    pub offset: usize,
+}
+
+#[derive(derive_new::new)]
+pub struct BranchLessChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub offset: usize,
 }

--- a/extensions/rv32im/circuit/src/branch_lt/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/mod.rs
@@ -1,7 +1,7 @@
-use openvm_circuit::arch::{VmAirWrapper};
+use openvm_circuit::arch::VmAirWrapper;
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep, Rv32BranchAdapterChip};
+use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterChip, Rv32BranchAdapterStep};
 
 mod core;
 pub use core::*;

--- a/extensions/rv32im/circuit/src/branch_lt/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/mod.rs
@@ -1,7 +1,7 @@
-use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::{VmAirWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep};
+use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterStep, Rv32BranchAdapterChip};
 
 mod core;
 pub use core::*;
@@ -16,4 +16,4 @@ pub type Rv32BranchLessThanAir = VmAirWrapper<
 pub type Rv32BranchLessThanStep =
     BranchLessThanStep<Rv32BranchAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32BranchLessThanChip<F> =
-    NewVmChipWrapper<F, Rv32BranchLessThanAir, Rv32BranchLessThanStep, MatrixRecordArena<F>>;
+    BranchLessThanChip<F, Rv32BranchAdapterChip, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -276,7 +276,8 @@ where
         inventory: &mut ChipInventory<SC, RA, CpuBackend<SC>>,
     ) -> Result<(), ChipInventoryError> {
         let range_checker = inventory.range_checker()?.clone();
-        let mem_helper = todo!();
+        let timestamp_max_bits = inventory.airs().config().memory_config.clk_max_bits;
+        let mem_helper = SharedMemoryHelper::new(range_checker.clone(), timestamp_max_bits);
 
         let bitwise_lu = if let Some(&chip) = inventory
             .find_chip::<SharedBitwiseOperationLookupChip<8>>()

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -275,15 +275,7 @@ where
         &self,
         inventory: &mut ChipInventory<SC, RA, CpuBackend<SC>>,
     ) -> Result<(), ChipInventoryError> {
-        let range_checker = inventory
-            .find_chip::<SharedVariableRangeCheckerChip>()
-            .next()
-            .ok_or_else(|_| {
-                Err(ChipInventoryError::ChipNotFound {
-                    name: "VariableRangeCheckerChip".to_string(),
-                })
-            })?
-            .clone();
+        let range_checker = inventory.range_checker()?.clone();
         let mem_helper = todo!();
 
         let bitwise_lu = if let Some(&chip) = inventory

--- a/extensions/rv32im/circuit/src/extension.rs
+++ b/extensions/rv32im/circuit/src/extension.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
         VmExecutionExtension, VmExtension, VmInventory, VmInventoryBuilder, VmInventoryError,
         VmProverExtension,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::{

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -158,6 +158,11 @@ pub struct Rv32JalLuiStepRecord {
 #[derive(derive_new::new)]
 pub struct Rv32JalLuiStep<A> {
     adapter: A,
+}
+
+#[derive(derive_new::new)]
+pub struct Rv32JalLuiChip<A> {
+    adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 

--- a/extensions/rv32im/circuit/src/jal_lui/mod.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/mod.rs
@@ -9,6 +9,3 @@ pub use core::*;
 mod tests;
 
 pub type Rv32JalLuiAir = VmAirWrapper<Rv32CondRdWriteAdapterAir, Rv32JalLuiCoreAir>;
-pub type Rv32JalLuiStepWithAdapter = Rv32JalLuiStep<Rv32CondRdWriteAdapterStep>;
-pub type Rv32JalLuiChip<F> =
-    NewVmChipWrapper<F, Rv32JalLuiAir, Rv32JalLuiStepWithAdapter, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{
@@ -34,7 +34,9 @@ use openvm_stark_backend::{
     rap::BaseAirWithPublicValues,
 };
 
-use crate::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
+use crate::adapters::{
+    Rv32JalrAdapterChip, Rv32JalrAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+};
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow)]
@@ -186,14 +188,15 @@ pub struct Rv32JalrCoreRecord {
 }
 
 #[derive_new::new]
-pub struct Rv32JalrStep<A> {
+pub struct Rv32JalrStep<A = Rv32JalrAdapterStep> {
     adapter: A,
 }
 
-pub struct Rv32JalrChip<A> {
+pub struct Rv32JalrChip<F, A = Rv32JalrAdapterChip> {
     adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
+    pub mem_helper: SharedMemoryHelper<F>,
 }
 
 impl<A> Rv32JalrChip<A> {
@@ -201,12 +204,14 @@ impl<A> Rv32JalrChip<A> {
         adapter: A,
         bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
         range_checker_chip: SharedVariableRangeCheckerChip,
+        mem_helper: SharedMemoryHelper<F>,
     ) -> Self {
         assert!(range_checker_chip.range_max_bits() >= 16);
         Self {
             adapter,
             bitwise_lookup_chip,
             range_checker_chip,
+            mem_helper,
         }
     }
 }
@@ -276,15 +281,15 @@ where
         Ok(())
     }
 }
-impl<F, A> TraceFiller<F> for Rv32JalrStep<A>
+impl<F, A> TraceFiller<F> for Rv32JalrChip<A>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
 
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
         let record: &Rv32JalrCoreRecord = unsafe { get_record_from_slice(&mut core_row, ()) };
 
         let core_row: &mut Rv32JalrCoreCols<F> = core_row.borrow_mut();

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -185,13 +185,18 @@ pub struct Rv32JalrCoreRecord {
     pub imm_sign: bool,
 }
 
+#[derive_new::new]
 pub struct Rv32JalrStep<A> {
+    adapter: A,
+}
+
+pub struct Rv32JalrChip<A> {
     adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<A> Rv32JalrStep<A> {
+impl<A> Rv32JalrChip<A> {
     pub fn new(
         adapter: A,
         bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,

--- a/extensions/rv32im/circuit/src/jalr/mod.rs
+++ b/extensions/rv32im/circuit/src/jalr/mod.rs
@@ -9,6 +9,3 @@ pub use core::*;
 mod tests;
 
 pub type Rv32JalrAir = VmAirWrapper<Rv32JalrAdapterAir, Rv32JalrCoreAir>;
-pub type Rv32JalrStepWithAdapter = Rv32JalrStep<Rv32JalrAdapterStep>;
-pub type Rv32JalrChip<F> =
-    NewVmChipWrapper<F, Rv32JalrAir, Rv32JalrStepWithAdapter, MatrixRecordArena<F>>;

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -181,6 +181,12 @@ pub struct LessThanCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 #[derive(derive_new::new)]
 pub struct LessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
+    pub offset: usize,
+}
+
+#[derive(derive_new::new)]
+pub struct LessThanChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub offset: usize,
 }
@@ -252,7 +258,7 @@ where
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
-    for LessThanStep<A, NUM_LIMBS, LIMB_BITS>
+    for LessThanChip<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{
@@ -185,7 +185,7 @@ pub struct LessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 #[derive(derive_new::new)]
-pub struct LessThanChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct LessThanChip<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub offset: usize,
@@ -259,14 +259,14 @@ where
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
-    for LessThanChip<A, NUM_LIMBS, LIMB_BITS>
+    for LessThanChip<F, A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
     fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
-        self.adapter.fill_trace_row(self.mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
         let record: &LessThanCoreRecord<NUM_LIMBS, LIMB_BITS> =
             unsafe { get_record_from_slice(&mut core_row, ()) };
 

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -189,6 +189,7 @@ pub struct LessThanChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub offset: usize,
+    pub mem_helper: SharedMemoryHelper<F>,
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceStep<F>
@@ -263,9 +264,9 @@ where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(self.mem_helper, adapter_row);
         let record: &LessThanCoreRecord<NUM_LIMBS, LIMB_BITS> =
             unsafe { get_record_from_slice(&mut core_row, ()) };
 

--- a/extensions/rv32im/circuit/src/less_than/mod.rs
+++ b/extensions/rv32im/circuit/src/less_than/mod.rs
@@ -3,6 +3,7 @@ use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
 use super::adapters::{
     Rv32BaseAluAdapterAir, Rv32BaseAluAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
+use crate::adapters::Rv32BaseAluAdapterChip;
 
 mod core;
 pub use core::*;
@@ -14,5 +15,9 @@ pub type Rv32LessThanAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, LessThanCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 pub type Rv32LessThanStep =
     LessThanStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32LessThanChip<F> =
-    NewVmChipWrapper<F, Rv32LessThanAir, Rv32LessThanStep, MatrixRecordArena<F>>;
+pub type Rv32LessThanChip<F> = LessThanChip<
+    F,
+    Rv32BaseAluAdapterChip<RV32_CELL_BITS>,
+    RV32_REGISTER_NUM_LIMBS,
+    RV32_CELL_BITS,
+>;

--- a/extensions/rv32im/circuit/src/lib.rs
+++ b/extensions/rv32im/circuit/src/lib.rs
@@ -28,6 +28,7 @@ pub use load_sign_extend::*;
 pub use loadstore::*;
 pub use mul::*;
 pub use mulh::*;
+use openvm_circuit::arch::{InitFileGenerator, SystemConfig};
 pub use shift::*;
 
 mod extension;
@@ -35,3 +36,81 @@ pub use extension::*;
 
 #[cfg(any(test, feature = "test-utils"))]
 mod test_utils;
+
+/// Config for a VM with base extension and IO extension
+#[derive(Clone, Debug, VmConfig, derive_new::new, Serialize, Deserialize)]
+pub struct Rv32IConfig {
+    #[system]
+    pub system: SystemConfig,
+    #[extension]
+    pub base: Rv32I,
+    #[extension]
+    pub io: Rv32Io,
+}
+
+// Default implementation uses no init file
+impl InitFileGenerator for Rv32IConfig {}
+
+/// Config for a VM with base extension, IO extension, and multiplication extension
+#[derive(Clone, Debug, Default, VmConfig, derive_new::new, Serialize, Deserialize)]
+pub struct Rv32ImConfig {
+    #[config]
+    pub rv32i: Rv32IConfig,
+    #[extension]
+    pub mul: Rv32M,
+}
+
+// Default implementation uses no init file
+impl InitFileGenerator for Rv32ImConfig {}
+
+impl Default for Rv32IConfig {
+    fn default() -> Self {
+        let system = SystemConfig::default().with_continuations();
+        Self {
+            system,
+            base: Default::default(),
+            io: Default::default(),
+        }
+    }
+}
+
+impl Rv32IConfig {
+    pub fn with_public_values(public_values: usize) -> Self {
+        let system = SystemConfig::default()
+            .with_continuations()
+            .with_public_values(public_values);
+        Self {
+            system,
+            base: Default::default(),
+            io: Default::default(),
+        }
+    }
+
+    pub fn with_public_values_and_segment_len(public_values: usize, segment_len: usize) -> Self {
+        let system = SystemConfig::default()
+            .with_continuations()
+            .with_public_values(public_values)
+            .with_max_segment_len(segment_len);
+        Self {
+            system,
+            base: Default::default(),
+            io: Default::default(),
+        }
+    }
+}
+
+impl Rv32ImConfig {
+    pub fn with_public_values(public_values: usize) -> Self {
+        Self {
+            rv32i: Rv32IConfig::with_public_values(public_values),
+            mul: Default::default(),
+        }
+    }
+
+    pub fn with_public_values_and_segment_len(public_values: usize, segment_len: usize) -> Self {
+        Self {
+            rv32i: Rv32IConfig::with_public_values_and_segment_len(public_values, segment_len),
+            mul: Default::default(),
+        }
+    }
+}

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -185,6 +185,11 @@ pub struct LoadSignExtendCoreRecord<const NUM_CELLS: usize> {
 #[derive(derive_new::new)]
 pub struct LoadSignExtendStep<A, const NUM_CELLS: usize, const LIMB_BITS: usize> {
     adapter: A,
+}
+
+#[derive(derive_new::new)]
+pub struct LoadSignExtendChip<A, const NUM_CELLS: usize, const LIMB_BITS: usize> {
+    adapter: A,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{
@@ -188,9 +188,10 @@ pub struct LoadSignExtendStep<A, const NUM_CELLS: usize, const LIMB_BITS: usize>
 }
 
 #[derive(derive_new::new)]
-pub struct LoadSignExtendChip<A, const NUM_CELLS: usize, const LIMB_BITS: usize> {
+pub struct LoadSignExtendChip<F, A, const NUM_CELLS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
+    pub mem_helper: SharedMemoryHelper<F>,
 }
 
 impl<F, A, const NUM_CELLS: usize, const LIMB_BITS: usize> TraceStep<F>
@@ -264,14 +265,14 @@ where
 }
 
 impl<F, A, const NUM_CELLS: usize, const LIMB_BITS: usize> TraceFiller<F>
-    for LoadSignExtendStep<A, NUM_CELLS, LIMB_BITS>
+    for LoadSignExtendChip<F, A, NUM_CELLS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
         let record: &LoadSignExtendCoreRecord<NUM_CELLS> =
             unsafe { get_record_from_slice(&mut core_row, ()) };
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
@@ -1,7 +1,7 @@
-use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::VmAirWrapper;
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterStep};
+use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterChip, Rv32LoadStoreAdapterStep};
 
 mod core;
 pub use core::*;
@@ -15,5 +15,9 @@ pub type Rv32LoadSignExtendAir = VmAirWrapper<
 >;
 pub type Rv32LoadSignExtendStep =
     LoadSignExtendStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32LoadSignExtendChip<F> =
-    NewVmChipWrapper<F, Rv32LoadSignExtendAir, Rv32LoadSignExtendStep, MatrixRecordArena<F>>;
+pub type Rv32LoadSignExtendChip<F> = LoadSignExtendChip<
+    F,
+    Rv32LoadStoreAdapterChip,
+    RV32_REGISTER_NUM_LIMBS,
+    RV32_CELL_BITS,
+>;

--- a/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
@@ -1,7 +1,9 @@
 use openvm_circuit::arch::VmAirWrapper;
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterChip, Rv32LoadStoreAdapterStep};
+use crate::adapters::{
+    Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterChip, Rv32LoadStoreAdapterStep,
+};
 
 mod core;
 pub use core::*;
@@ -15,9 +17,5 @@ pub type Rv32LoadSignExtendAir = VmAirWrapper<
 >;
 pub type Rv32LoadSignExtendStep =
     LoadSignExtendStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32LoadSignExtendChip<F> = LoadSignExtendChip<
-    F,
-    Rv32LoadStoreAdapterChip,
-    RV32_REGISTER_NUM_LIMBS,
-    RV32_CELL_BITS,
->;
+pub type Rv32LoadSignExtendChip<F> =
+    LoadSignExtendChip<F, Rv32LoadStoreAdapterChip, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;

--- a/extensions/rv32im/circuit/src/loadstore/mod.rs
+++ b/extensions/rv32im/circuit/src/loadstore/mod.rs
@@ -2,10 +2,10 @@ mod core;
 
 pub use core::*;
 
-use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::VmAirWrapper;
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
-use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterStep};
+use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterChip, Rv32LoadStoreAdapterStep};
 
 #[cfg(test)]
 mod tests;
@@ -14,4 +14,4 @@ pub type Rv32LoadStoreAir =
     VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<RV32_REGISTER_NUM_LIMBS>>;
 pub type Rv32LoadStoreStep = LoadStoreStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS>;
 pub type Rv32LoadStoreChip<F> =
-    NewVmChipWrapper<F, Rv32LoadStoreAir, Rv32LoadStoreStep, MatrixRecordArena<F>>;
+    LoadStoreChip<F, Rv32LoadStoreAdapterChip, RV32_REGISTER_NUM_LIMBS>;

--- a/extensions/rv32im/circuit/src/loadstore/mod.rs
+++ b/extensions/rv32im/circuit/src/loadstore/mod.rs
@@ -5,7 +5,9 @@ pub use core::*;
 use openvm_circuit::arch::VmAirWrapper;
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
-use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterChip, Rv32LoadStoreAdapterStep};
+use crate::adapters::{
+    Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterChip, Rv32LoadStoreAdapterStep,
+};
 
 #[cfg(test)]
 mod tests;
@@ -13,5 +15,4 @@ mod tests;
 pub type Rv32LoadStoreAir =
     VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<RV32_REGISTER_NUM_LIMBS>>;
 pub type Rv32LoadStoreStep = LoadStoreStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS>;
-pub type Rv32LoadStoreChip<F> =
-    LoadStoreChip<F, Rv32LoadStoreAdapterChip, RV32_REGISTER_NUM_LIMBS>;
+pub type Rv32LoadStoreChip<F> = LoadStoreChip<F, Rv32LoadStoreAdapterChip, RV32_REGISTER_NUM_LIMBS>;

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -255,11 +255,23 @@ pub struct ShiftCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 pub struct ShiftStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
+}
+
+pub struct ShiftChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+    adapter: A,
+    pub offset: usize,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
 impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, LIMB_BITS> {
+    pub fn new(adapter: A, offset: usize) -> Self {
+        assert_eq!(NUM_LIMBS % 2, 0, "Number of limbs must be divisible by 2");
+        Self { adapter, offset }
+    }
+}
+
+impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftChip<A, NUM_LIMBS, LIMB_BITS> {
     pub fn new(
         adapter: A,
         bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
     system::memory::{
         online::{GuestMemory, TracingMemory},
-        MemoryAuxColsFactory,
+        MemoryAuxColsFactory, SharedMemoryHelper,
     },
 };
 use openvm_circuit_primitives::{
@@ -257,11 +257,12 @@ pub struct ShiftStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub offset: usize,
 }
 
-pub struct ShiftChip<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct ShiftChip<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
+    pub mem_helper: SharedMemoryHelper<F>,
 }
 
 impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, LIMB_BITS> {
@@ -271,12 +272,13 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, 
     }
 }
 
-impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftChip<A, NUM_LIMBS, LIMB_BITS> {
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftChip<F, A, NUM_LIMBS, LIMB_BITS> {
     pub fn new(
         adapter: A,
         bitwise_lookup_chip: SharedBitwiseOperationLookupChip<LIMB_BITS>,
         range_checker_chip: SharedVariableRangeCheckerChip,
         offset: usize,
+        mem_helper: SharedMemoryHelper<F>,
     ) -> Self {
         assert_eq!(NUM_LIMBS % 2, 0, "Number of limbs must be divisible by 2");
         Self {
@@ -284,6 +286,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftChip<A, NUM_LIMBS, 
             offset,
             bitwise_lookup_chip,
             range_checker_chip,
+            mem_helper,
         }
     }
 }
@@ -349,14 +352,14 @@ where
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
-    for ShiftStep<A, NUM_LIMBS, LIMB_BITS>
+    for ShiftChip<F, A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
 {
-    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+    fn fill_trace_row(&self, row_slice: &mut [F]) {
         let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
-        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        self.adapter.fill_trace_row(&self.mem_helper, adapter_row);
 
         let record: &ShiftCoreRecord<NUM_LIMBS, LIMB_BITS> =
             unsafe { get_record_from_slice(&mut core_row, ()) };

--- a/extensions/rv32im/circuit/src/shift/mod.rs
+++ b/extensions/rv32im/circuit/src/shift/mod.rs
@@ -1,8 +1,9 @@
-use openvm_circuit::arch::{MatrixRecordArena, NewVmChipWrapper, VmAirWrapper};
+use openvm_circuit::arch::VmAirWrapper;
 
 use super::adapters::{
     Rv32BaseAluAdapterAir, Rv32BaseAluAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
+use crate::adapters::Rv32BaseAluAdapterChip;
 
 mod core;
 pub use core::*;
@@ -14,4 +15,9 @@ pub type Rv32ShiftAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 pub type Rv32ShiftStep =
     ShiftStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32ShiftChip<F> = NewVmChipWrapper<F, Rv32ShiftAir, Rv32ShiftStep, MatrixRecordArena<F>>;
+pub type Rv32ShiftChip<F> = ShiftChip<
+    F,
+    Rv32BaseAluAdapterChip<RV32_CELL_BITS>,
+    RV32_REGISTER_NUM_LIMBS,
+    RV32_CELL_BITS,
+>;

--- a/extensions/rv32im/circuit/src/shift/mod.rs
+++ b/extensions/rv32im/circuit/src/shift/mod.rs
@@ -15,9 +15,5 @@ pub type Rv32ShiftAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
 pub type Rv32ShiftStep =
     ShiftStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
-pub type Rv32ShiftChip<F> = ShiftChip<
-    F,
-    Rv32BaseAluAdapterChip<RV32_CELL_BITS>,
-    RV32_REGISTER_NUM_LIMBS,
-    RV32_CELL_BITS,
->;
+pub type Rv32ShiftChip<F> =
+    ShiftChip<F, Rv32BaseAluAdapterChip<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;

--- a/extensions/sha256/circuit/src/extension.rs
+++ b/extensions/sha256/circuit/src/extension.rs
@@ -4,7 +4,7 @@ use openvm_circuit::{
         InitFileGenerator, SystemConfig, VmExtension, VmInventory, VmInventoryBuilder,
         VmInventoryError,
     },
-    system::phantom::PhantomChip,
+    system::phantom::PhantomExecutor,
 };
 use openvm_circuit_derive::{AnyEnum, InsExecutorE1, InstructionExecutor, VmConfig};
 use openvm_circuit_primitives::bitwise_op_lookup::{
@@ -65,7 +65,7 @@ pub enum Sha256Executor<F: PrimeField32> {
 #[derive(From, ChipUsageGetter, Chip, AnyEnum)]
 pub enum Sha256Periphery<F: PrimeField32> {
     BitwiseOperationLookup(SharedBitwiseOperationLookupChip<8>),
-    Phantom(PhantomChip<F>),
+    Phantom(PhantomExecutor<F>),
 }
 
 impl<F: PrimeField32> VmExtension<F> for Sha256 {


### PR DESCRIPTION
Previously, `VmExtension` had only a single notion of chip, where some chips could be executors, and the notions of execution, circuit, tracegen were all deeply intertwined. With the new design, we have multiple modes of execution which are more disconnected from the circuit design, and we also want tracegen to support different device / prover backends.

The overall realization is that a true VM extension, meaning a modular way to extend the functionality of a working zkVM (including the prover) has three _separate_ components:
- extending the execution methods for custom opcodes (this includes different execution modes)
- extending the circuit itself at the level of AIRs
- extending how tracegen and ultimately proving of the circuit from execution traces is actually performed

In this PR, we aim to separate the notion of `VmExtension` into three separate traits `VmExecutionExtension, VmCircuitExtension, VmProverExtension` to better encapsulate this.
- The `VmExecutionExtension` is in principle separate from any circuit considerations: it is just a way to specify hooks to opcodes. Although practically, there is still some connection, and we still take an enum dispatch approach (for now) for storage purposes. This is intended to be compatible with the fn pointer changes being made in parallel.
- The `VmCircuitExtension` is the most security critical, and it should have **no** dependencies on the other two components. This will be made so that the verifying keys do not change even after this PR, and also this trait will not depend on any prover backend differences.
- `VmProverExtension` is the most customizable, and hence unfortunately will have a bunch of generics. We will allow even the system chips to be customized according to the prover backend.

Also
- Deleted `NewVmChipWrapper` because the wrapper pattern is not good. Now each chip owns `mem_helper` -- it is perhaps more correct if just the adapter chip owns `mem_helper`, but since we aren't so convinced about adapter chips existing in the future, I just did the more immediate refactor.
- Deleted the `Shared**Chip` wrapper structs because we don't need them anymore. I made them typedef to `Arc<..>`.

## Design Questions

I am still somewhat on the fence about `Chip` being generic in `RA` versus doing the old approach where the `**Chip` struct is generic in `RA` and starts off with empty records which get swapped out with the records from the `TracegenCtx` (see before this PR). However it feels weird when the clear use case is now that the "preflight trace" is recorded elsewhere and only fed into the chip at time of tracegen. 