### PR TITLE
feat: extract_layout implementation for native Poseidon2

### DIFF
--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -100,7 +100,14 @@ impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize>
     }
 
     unsafe fn extract_layout(&self) -> NativePoseidon2RecordLayout {
-        todo!()
+        // Each instruction record consists solely of some number of contiguously
+        // stored NativePoseidon2Cols<...> structs, each of which corresponds to a
+        // single trace row. Trace fillers don't actually need to know how many rows
+        // each instruction uses, and can thus treat each NativePoseidon2Cols<...>
+        // as a single record.
+        NativePoseidon2RecordLayout {
+            metadata: NativePoseidon2Metadata { num_rows: 1 },
+        }
     }
 }
 


### PR DESCRIPTION
Resolves INT-4288.

Discussed with @arayikhalatyan, for trace generation purposes we can actually treat native Poseidon2 as if it uses fixed-size records. This simplifies the GPU tracegen and allows us to not send any auxiliary information to the GPU device.