### PR TITLE
chore: fix doc comment for custom_insn_i

### DIFF
--- a/crates/toolchain/custom_insn/src/lib.rs
+++ b/crates/toolchain/custom_insn/src/lib.rs
@@ -340,7 +340,7 @@ pub fn custom_insn_r(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 /// This macro is used to define custom I-type RISC-V instructions for the zkVM.
 /// Usage:
 /// ```rust
-/// custom_insn_r!(
+/// custom_insn_i!(
 ///     opcode = OPCODE,
 ///     funct3 = FUNCT3,
 ///     rd = InOut x0,


### PR DESCRIPTION
# What
- Fixes doc comment so the popup on hover of `custom_insn_i` is correct