### PR TITLE
chore(sdk): remove #[serde(flatten)]

### DIFF
--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -52,7 +52,6 @@ pub struct ProofData {
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EvmProof {
-    #[serde(flatten)]
     /// Bn254Fr public value app commits.
     pub app_commit: AppExecutionCommit,
     #[serde_as(as = "serde_with::hex::Hex")]
@@ -218,7 +217,6 @@ impl TryFrom<EvmProof> for RawEvmProof {
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VmStarkProofBytes {
-    #[serde(flatten)]
     pub app_commit: AppExecutionCommit,
     #[serde_as(as = "serde_with::hex::Hex")]
     pub user_public_values: Vec<u8>,


### PR DESCRIPTION
`bincode` does not support `#[serde(flatten)]` (see [this](https://github.com/bincode-org/bincode/issues/245)). 

I think this likely a strong enough reason to remove it from here as the benefit of having it seems minor.

Of course, it can be worked around on the client with wrapper type and/or custom serializer, so it's more like nice to have, not must have.