### PR TITLE
docs(book): clarify read-only reflection

### DIFF
--- a/book/src/writing-apps/write-program.md
+++ b/book/src/writing-apps/write-program.md
@@ -136,4 +136,4 @@ To override the default behavior and provide a custom implementation, turn off t
 
 OpenVM partially supports [reflective programming](https://en.wikipedia.org/wiki/Reflective_programming) by allowing **read-only** access to the program code itself during runtime execution. Program code that is modified during runtime will **not** be executed.
 
-More specifically, data and executable code from the RISC-V ELF are loaded into the initial memory image at the start of runtime execution, and this memory may be freely accessed during execution. However execution will always run with respect to the initial executable code from the ELF and all runtime modifications will be ignored.
+More specifically, data and executable code from the RISC-V ELF are loaded into the initial memory image at the start of runtime execution, and this memory may be freely accessed during execution. However, execution will always run with respect to the initial executable code from the ELF, and all runtime modifications will be ignored.

--- a/book/src/writing-apps/write-program.md
+++ b/book/src/writing-apps/write-program.md
@@ -131,3 +131,9 @@ OpenVM is compatible with [getrandom](https://crates.io/crates/getrandom) `v0.2`
 By default the `openvm` crate has a default feature `"getrandom-unsupported"` which exports a `__getrandom_v03_custom` function that always returns `Err(Error::UNSUPPORTED)`. This is enabled by default to allow compilation of guest programs that pull in dependencies which require `getrandom` but where the executed code does not actually use `getrandom` functions.
 
 To override the default behavior and provide a custom implementation, turn off the `"getrandom-unsupported"` feature in the `openvm` crate and supply your own `__getrandom_v03_custom` function as specified in the [getrandom docs](https://docs.rs/getrandom/0.3.3/getrandom/#custom-backend). Similar customization options are available for `getrandom` `v0.2`.
+
+## Read-only reflection
+
+OpenVM partially supports [reflective programming](https://en.wikipedia.org/wiki/Reflective_programming) by allowing **read-only** access to the program code itself during runtime execution. Program code that is modified during runtime will **not** be executed.
+
+More specifically, data and executable code from the RISC-V ELF are loaded into the initial memory image at the start of runtime execution, and this memory may be freely accessed during execution. However execution will always run with respect to the initial executable code from the ELF and all runtime modifications will be ignored.


### PR DESCRIPTION
Clarify that OpenVM's use of the Harvard architecture and how it relates to reflective programming.

Closes INT-4352