### PR TITLE
fix(test): use local `openvm` for testing `cargo openvm init`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,6 +3,7 @@ name: OpenVM CLI Tests
 on:
   push:
     branches: ["main"]
+    tags: ["v*"]
   pull_request:
     branches: ["**"]
     paths:
@@ -14,6 +15,13 @@ on:
       - "examples/**"
       - "Cargo.toml"
       - ".github/workflows/cli.yml"
+  workflow_dispatch:
+    inputs:
+      use_local_openvm:
+        description: "Test cargo openvm init using local patch"
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -74,6 +82,14 @@ jobs:
           export RUST_BACKTRACE=1
           cargo build
           cargo run --bin cargo-openvm -- openvm keygen --config ./example/app_config.toml --output-dir .
+
+      - name: Set USE_LOCAL_OPENVM environment variable
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.use_local_openvm }}" == "false" ]]; then
+            echo "USE_LOCAL_OPENVM=0" >> $GITHUB_ENV
+          else
+            echo "USE_LOCAL_OPENVM=1" >> $GITHUB_ENV
+          fi
 
       - name: Run CLI tests
         working-directory: crates/cli

--- a/crates/cli/tests/app_e2e.rs
+++ b/crates/cli/tests/app_e2e.rs
@@ -1,4 +1,4 @@
-use std::{env, process::Command};
+use std::{env, fs::OpenOptions, io::Write, path::Path, process::Command};
 
 use eyre::Result;
 use tempfile::tempdir;
@@ -134,6 +134,9 @@ fn test_cli_init_build() -> Result<()> {
             "cli-package",
         ],
     )?;
+    if matches!(env::var("USE_LOCAL_OPENVM"), Ok(x) if x == "1") {
+        append_patch_to_cargo_toml(&manifest_path)?;
+    }
 
     run_cmd(
         "cargo",
@@ -169,5 +172,31 @@ fn run_cmd(program: &str, args: &[&str]) -> Result<()> {
     if !output.status.success() {
         return Err(eyre::eyre!("Command failed with status: {}", output.status));
     }
+    Ok(())
+}
+
+fn append_patch_to_cargo_toml(file_path: impl AsRef<Path>) -> Result<()> {
+    const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
+    let openvm_path = Path::new(MANIFEST_DIR)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("crates")
+        .join("toolchain")
+        .join("openvm");
+    let mut file = OpenOptions::new()
+        .create(false)
+        .append(true)
+        .open(file_path)?;
+
+    // Add a newline first to ensure proper formatting
+    writeln!(file)?;
+    writeln!(
+        file,
+        r#"[patch."https://github.com/openvm-org/openvm.git"]"#
+    )?;
+    writeln!(file, r#"openvm = {{ path = "{}" }}"#, openvm_path.display())?;
+
     Ok(())
 }

--- a/crates/cli/tests/app_e2e.rs
+++ b/crates/cli/tests/app_e2e.rs
@@ -180,9 +180,6 @@ fn append_patch_to_cargo_toml(file_path: impl AsRef<Path>) -> Result<()> {
     let openvm_path = Path::new(MANIFEST_DIR)
         .parent()
         .unwrap()
-        .parent()
-        .unwrap()
-        .join("crates")
         .join("toolchain")
         .join("openvm");
     let mut file = OpenOptions::new()


### PR DESCRIPTION
Currently if we change the workspace version before tagging, the integration test for `cargo openvm init` will break because it creates a guest crate that references the tagged version. I updated the test so it patches to the local openvm if the environmental variable `USE_LOCAL_OPENVM=1` is set.