### PR TITLE
feat(e12-fn-dispatch): make vm e2 use interpreter

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -3,10 +3,14 @@ use std::{path::Path, sync::OnceLock};
 use divan::Bencher;
 use eyre::Result;
 use openvm_benchmarks_utils::{get_elf_path, get_programs_dir, read_elf_file};
-use openvm_circuit::arch::execution_mode::metered::ctx::DEFAULT_PAGE_BITS;
-use openvm_circuit::arch::execution_mode::metered::MeteredCtx;
-use openvm_circuit::arch::{execution_mode::e1::E1Ctx, interpreter::InterpretedInstance};
-use openvm_circuit::arch::{VmChipComplex, VmConfig};
+use openvm_circuit::arch::{
+    execution_mode::{
+        e1::E1Ctx,
+        metered::{ctx::DEFAULT_PAGE_BITS, MeteredCtx},
+    },
+    interpreter::InterpretedInstance,
+    VmChipComplex, VmConfig,
+};
 // use openvm_bigint_circuit::{Int256, Int256Executor, Int256Periphery};
 // use openvm_bigint_transpiler::Int256TranspilerExtension;
 use openvm_circuit::{
@@ -187,7 +191,7 @@ fn benchmark_execute_metered(bencher: Bencher, program: &str) {
 //             let (widths, interactions) = shared_widths_and_interactions();
 //             let segments = vm
 //                 .executor
-//                 .execute_metered(exe.clone(), vec![], widths, interactions)
+//                 .execute_metered(exe.clone(), vec![], interactions)
 //                 .expect("Failed to execute program");
 
 //             (vm.executor, exe, state, segments)

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -59,7 +59,7 @@ pub(super) fn compute_root_proof_heights(
     };
     let vm = SingleSegmentVmExecutor::new(root_vm_config);
     let max_trace_heights = vm
-        .execute_metered(root_exe.clone(), root_input.write(), widths, interactions)
+        .execute_metered(root_exe.clone(), root_input.write(), interactions)
         .unwrap();
     let res = vm
         .execute_and_compute_heights(root_exe, root_input.write(), &max_trace_heights)

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -38,7 +38,6 @@ impl RootVerifierLocalProver {
             .execute_metered(
                 self.root_verifier_pk.root_committed_exe.exe.clone(),
                 input.write(),
-                &vm_vk.total_widths(),
                 &vm_vk.num_interactions(),
             )
             .unwrap();

--- a/crates/sdk/src/prover/vm/local.rs
+++ b/crates/sdk/src/prover/vm/local.rs
@@ -178,7 +178,6 @@ where
             .execute_metered(
                 self.committed_exe.exe.clone(),
                 input.clone(),
-                &vm_vk.total_widths(),
                 &vm_vk.num_interactions(),
             )
             .expect("execute_metered failed");

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -105,7 +105,6 @@ fn run_leaf_verifier(
     let max_trace_heights = executor.execute_metered(
         leaf_committed_exe.exe.clone(),
         verifier_input.write_to_stream(),
-        &leaf_vm_vk.total_widths(),
         &leaf_vm_vk.num_interactions(),
     )?;
 

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -15,8 +15,10 @@ use crate::{
     system::memory::dimensions::MemoryDimensions,
 };
 
+pub const DEFAULT_PAGE_BITS: usize = 6;
+
 #[derive(Debug)]
-pub struct MeteredCtx<const PAGE_BITS: usize = 6> {
+pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
     pub trace_heights: Vec<u32>,
     pub is_trace_height_constant: Vec<bool>,
 

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -333,6 +333,17 @@ impl<E, P> VmInventory<E, P> {
         self.executors.get_mut(*id)
     }
 
+    pub fn get_executor_idx_in_vkey(&self, opcode: &VmOpcode) -> Option<usize> {
+        let id = *self.instruction_lookup.get(opcode)?;
+        self.insertion_order
+            .iter()
+            .rev()
+            .position(|chip_id| match chip_id {
+                ChipId::Executor(exec_id) => *exec_id == id,
+                _ => false,
+            })
+    }
+
     pub fn get_mut_executor_with_index(&mut self, opcode: &VmOpcode) -> Option<(&mut E, usize)> {
         let id = *self.instruction_lookup.get(opcode)?;
 

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -845,6 +845,15 @@ impl<F: PrimeField32, E, P> VmChipComplex<F, E, P> {
             .then(|| &self.inventory.executors[Self::PV_EXECUTOR_IDX])
     }
 
+    // The index at which the executor chips start in vkey.
+    pub(crate) fn get_executor_offset_in_vkey(&self) -> usize {
+        if self.config.has_public_values_chip() {
+            PUBLIC_VALUES_AIR_ID + 1 + self.memory_controller().num_airs()
+        } else {
+            PUBLIC_VALUES_AIR_ID + self.memory_controller().num_airs()
+        }
+    }
+
     // All inventory chips except public values chip, in reverse order they were added.
     pub(crate) fn chips_excluding_pv_chip(&self) -> impl Iterator<Item = Either<&'_ E, &'_ P>> {
         let public_values_chip_idx = self.public_values_chip_idx();

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -26,7 +26,7 @@ use crate::{
         ExecuteFunc,
         ExecutionError::{self, InvalidInstruction},
         InsExecutorE1, InsExecutorE2, PreComputeInstruction, Streams, VmChipComplex, VmConfig,
-        VmSegmentState, PUBLIC_VALUES_AIR_ID,
+        VmSegmentState,
     },
     system::memory::{online::GuestMemory, AddressMap},
 };
@@ -435,11 +435,7 @@ fn get_e2_pre_compute_instructions<
     chip_complex: &'a VmChipComplex<F, E, P>,
     pre_compute: &'a mut [&mut [u8]],
 ) -> Result<Vec<PreComputeInstruction<'a, F, Ctx>>, ExecutionError> {
-    let executor_idx_offset = if chip_complex.config().has_public_values_chip() {
-        PUBLIC_VALUES_AIR_ID + 1 + chip_complex.memory_controller().num_airs()
-    } else {
-        PUBLIC_VALUES_AIR_ID + chip_complex.memory_controller().num_airs()
-    };
+    let executor_idx_offset = chip_complex.get_executor_offset_in_vkey();
     program
         .instructions_and_debug_infos
         .iter()

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -237,55 +237,6 @@ where
         })
     }
 
-    /// Base metered execution function that operates from a given state
-    pub fn execute_metered_from_state(
-        &self,
-        exe: VmExe<F>,
-        state: VmState<F>,
-        interactions: &[usize],
-    ) -> Result<Vec<Segment>, ExecutionError> {
-        let _span = info_span!("execute_metered").entered();
-
-        let chip_complex =
-            create_and_initialize_chip_complex(&self.config, exe.program.clone(), None, None)
-                .unwrap();
-
-        let ctx = MeteredCtx::new(&chip_complex, interactions.to_vec())
-            // TODO(ayush): get rid of segmentation_strategy altogether
-            .with_max_trace_height(
-                self.config
-                    .system()
-                    .segmentation_strategy
-                    .max_trace_height() as u32,
-            )
-            .with_max_cells(self.config.system().segmentation_strategy.max_cells());
-
-        let mut executor = VmSegmentExecutor::<F, VC, _>::new(
-            chip_complex,
-            self.trace_height_constraints.clone(),
-            exe.fn_bounds.clone(),
-            MeteredExecutionControl,
-        );
-        #[cfg(feature = "bench-metrics")]
-        {
-            executor.metrics = state.metrics;
-        }
-
-        let mut exec_state = VmSegmentState::new(
-            state.instret,
-            state.pc,
-            Some(GuestMemory::new(state.memory)),
-            state.input,
-            state.rng,
-            ctx,
-        );
-        execute_spanned!("execute_metered", executor, &mut exec_state)?;
-
-        check_termination(exec_state.exit_code)?;
-
-        Ok(exec_state.ctx.into_segments())
-    }
-
     pub fn execute_metered(
         &self,
         exe: impl Into<VmExe<F>>,
@@ -598,37 +549,21 @@ where
         &self,
         exe: VmExe<F>,
         input: impl Into<Streams<F>>,
-        widths: &[usize],
         interactions: &[usize],
     ) -> Result<Vec<u32>, ExecutionError> {
-        let memory =
-            create_memory_image(&self.config.system().memory_config, exe.init_memory.clone());
-        let rng = StdRng::seed_from_u64(0);
-        let chip_complex =
-            create_and_initialize_chip_complex(&self.config, exe.program.clone(), None, None)
-                .unwrap();
-        let ctx = MeteredCtx::new(&chip_complex, interactions.to_vec())
-            .with_segment_check_insns(u64::MAX);
-        let mut executor = VmSegmentExecutor::<F, VC, _>::new(
-            chip_complex,
-            self.trace_height_constraints.clone(),
-            exe.fn_bounds.clone(),
-            MeteredExecutionControl,
-        );
-        let mut exec_state = VmSegmentState::new(
-            0,
-            exe.pc_start,
-            Some(GuestMemory::new(memory)),
-            input.into(),
-            rng,
-            ctx,
-        );
-        execute_spanned!("execute_metered", executor, &mut exec_state)?;
+        let interpreter = InterpretedInstance::new(self.config.clone(), exe);
 
-        check_termination(exec_state.exit_code)?;
+        let chip_complex = self.config.create_chip_complex().unwrap();
+
+        let ctx: MeteredCtx<DEFAULT_PAGE_BITS> =
+            MeteredCtx::new(&chip_complex, interactions.to_vec())
+                .with_segment_check_insns(u64::MAX);
+
+        let state = interpreter.execute_e2(ctx, input)?;
+        check_termination(state.exit_code)?;
 
         // Check segment count
-        let segments = exec_state.ctx.into_segments();
+        let segments = state.ctx.into_segments();
         assert_eq!(
             segments.len(),
             1,

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -222,7 +222,7 @@ where
 //     let (widths, interactions) = get_widths_and_interactions_from_vkey(pk.get_vk());
 //     let segments = vm
 //         .executor
-//         .execute_metered(program_exe.clone(), input.clone(), widths, interactions)
+//         .execute_metered(program_exe.clone(), input.clone(), interactions)
 //         .unwrap();
 //
 //     cfg_if::cfg_if! {

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -89,8 +89,9 @@ where
         let ctx = MeteredCtx::<6>::new(&chip_complex, vk.num_interactions())
             .with_max_trace_height(config.system().segmentation_strategy.max_trace_height() as u32)
             .with_max_cells(config.system().segmentation_strategy.max_cells());
-        let vm_state = executor.init_vm_state(ctx, input.clone());
-        let final_state = executor.execute_e2(vm_state).expect("Failed to execute");
+        let final_state = executor
+            .execute_e2(ctx, input.clone())
+            .expect("Failed to execute");
         assert!(final_state.ctx.segments().len() >= min_segments);
     }
 

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -135,12 +135,7 @@ fn test_vm_override_executor_height() {
     let executor = SingleSegmentVmExecutor::new(vm_config.clone());
 
     let max_trace_heights = executor
-        .execute_metered(
-            committed_exe.exe.clone(),
-            vec![],
-            &vk.total_widths(),
-            &vk.num_interactions(),
-        )
+        .execute_metered(committed_exe.exe.clone(), vec![], &vk.num_interactions())
         .unwrap();
 
     let res = executor
@@ -300,12 +295,7 @@ fn test_vm_public_values() {
         let single_vm = SingleSegmentVmExecutor::new(config);
 
         let max_trace_heights = single_vm
-            .execute_metered(
-                program.clone().into(),
-                vec![],
-                &vk.total_widths(),
-                &vk.num_interactions(),
-            )
+            .execute_metered(program.clone().into(), vec![], &vk.num_interactions())
             .unwrap();
 
         let exe_result = single_vm
@@ -1080,11 +1070,6 @@ fn test_single_segment_executor_no_segmentation() {
     let single_vm = SingleSegmentVmExecutor::<F, _>::new(config);
 
     let _ = single_vm
-        .execute_metered(
-            program.clone().into(),
-            vec![],
-            &vk.total_widths(),
-            &vk.num_interactions(),
-        )
+        .execute_metered(program.clone().into(), vec![], &vk.num_interactions())
         .unwrap();
 }

--- a/extensions/native/compiler/tests/public_values.rs
+++ b/extensions/native/compiler/tests/public_values.rs
@@ -37,12 +37,7 @@ fn test_compiler_public_values() {
     let executor = SingleSegmentVmExecutor::new(config);
 
     let max_trace_heights = executor
-        .execute_metered(
-            program.clone().into(),
-            vec![],
-            &vm_vk.total_widths(),
-            &vm_vk.num_interactions(),
-        )
+        .execute_metered(program.clone().into(), vec![], &vm_vk.num_interactions())
         .unwrap();
 
     let exe_result = executor

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -196,7 +196,6 @@ mod tests {
     //         .execute_metered(
     //             exe.clone(),
     //             vec![],
-    //             &vk.total_widths(),
     //             &vk.num_interactions(),
     //         )
     //         .unwrap();


### PR DESCRIPTION
- make `execute_with_metrics` a macro
- update `VmSegmentExecutor` `execute_metered` to use `InterpreterInstance`
- update `execute_metered` benchmarks