### PR TITLE
fix(sdk): `aggregate_leaf_proofs` should always generate an internal proof

### DIFF
--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -108,7 +108,9 @@ impl<E: StarkFriEngine<SC>> AggStarkProver<E> {
         let mut internal_node_idx = -1;
         let mut internal_node_height = 0;
         let mut proofs = leaf_proofs;
-        while proofs.len() > 1 {
+        // We will always generate at least one internal proof, even if there is only one leaf
+        // proof, in order to shrink the proof size
+        while proofs.len() > 1 || internal_node_height == 0 {
             let internal_inputs = InternalVmVerifierInput::chunk_leaf_or_internal_proofs(
                 self.internal_prover
                     .committed_exe


### PR DESCRIPTION
The `verify_e2e_stark_proof` exists a fixed log blowup factor set by the internal proof. Therefore we must always generate an internal proof even if there is only 1 leaf proof.

Test run on a 1 segment proof: https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/main/reth-c299bb2012ed6bf2aa289ee3decd45897c9ce574-59a742f87fe66d079554e6646f2a0fdabb1dc4d2e6afbf0f0b4f09376b854357.md