### PR TITLE
fix: sha2 primitive test

### DIFF
--- a/crates/circuits/sha256-air/src/tests.rs
+++ b/crates/circuits/sha256-air/src/tests.rs
@@ -1,4 +1,4 @@
-use std::{array, borrow::BorrowMut, cmp::max, sync::Arc};
+use std::{array, borrow::BorrowMut, sync::Arc};
 
 use openvm_circuit::arch::{
     instructions::riscv::RV32_CELL_BITS,
@@ -6,7 +6,8 @@ use openvm_circuit::arch::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{
-        BitwiseOperationLookupBus, BitwiseOperationLookupChip, SharedBitwiseOperationLookupChip,
+        BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+        SharedBitwiseOperationLookupChip,
     },
     SubAir,
 };
@@ -16,18 +17,18 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::{Field, FieldAlgebra, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    prover::types::AirProvingContext,
-    rap::{get_air_name, BaseAirWithPublicValues, PartitionedBaseAir},
+    prover::{cpu::CpuBackend, types::AirProvingContext},
+    rap::{BaseAirWithPublicValues, PartitionedBaseAir},
     utils::disable_debug_builder,
     verifier::VerificationError,
-    AirRef, Chip, ChipUsageGetter,
+    AirRef, Chip,
 };
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::Rng;
 
 use crate::{
-    Sha256Air, Sha256DigestCols, Sha256StepHelper, SHA256_BLOCK_U8S, SHA256_DIGEST_WIDTH,
-    SHA256_HASH_WORDS, SHA256_ROUND_WIDTH, SHA256_ROWS_PER_BLOCK, SHA256_WORD_U8S,
+    Sha256Air, Sha256DigestCols, Sha256FillerHelper, SHA256_BLOCK_U8S, SHA256_DIGEST_WIDTH,
+    SHA256_HASH_WORDS, SHA256_WIDTH, SHA256_WORD_U8S,
 };
 
 // A wrapper AIR purely for testing purposes
@@ -50,50 +51,41 @@ impl<AB: InteractionBuilder> Air<AB> for Sha256TestAir {
     }
 }
 
+const SELF_BUS_IDX: BusIndex = 28;
+type F = BabyBear;
+type RecordType = Vec<([u8; SHA256_BLOCK_U8S], bool)>;
+
 // A wrapper Chip purely for testing purposes
 pub struct Sha256TestChip {
-    pub air: Sha256TestAir,
-    pub step: Sha256StepHelper,
+    pub step: Sha256FillerHelper,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<8>,
-    pub records: Vec<([u8; SHA256_BLOCK_U8S], bool)>,
 }
 
-impl<SC: StarkGenericConfig> Chip<SC> for Sha256TestChip
+impl<SC: StarkGenericConfig> Chip<RecordType, CpuBackend<SC>> for Sha256TestChip
 where
     Val<SC>: PrimeField32,
 {
-    fn air(&self) -> AirRef<SC> {
-        Arc::new(self.air.clone())
-    }
-
-    fn generate_air_proof_input(self) -> AirProvingContext<SC> {
+    fn generate_proving_ctx(&self, records: RecordType) -> AirProvingContext<CpuBackend<SC>> {
         let trace = crate::generate_trace::<Val<SC>>(
             &self.step,
             self.bitwise_lookup_chip.as_ref(),
-            <Sha256Air as BaseAir<Val<SC>>>::width(&self.air.sub_air),
-            self.records,
+            SHA256_WIDTH,
+            records,
         );
-        AirProvingContext::simple_no_pis(trace)
+        AirProvingContext::simple(Arc::new(trace), vec![])
     }
 }
 
-impl ChipUsageGetter for Sha256TestChip {
-    fn air_name(&self) -> String {
-        get_air_name(&self.air)
-    }
-    fn current_trace_height(&self) -> usize {
-        self.records.len() * SHA256_ROWS_PER_BLOCK
-    }
-
-    fn trace_width(&self) -> usize {
-        max(SHA256_ROUND_WIDTH, SHA256_DIGEST_WIDTH)
-    }
-}
-
-const SELF_BUS_IDX: BusIndex = 28;
-type F = BabyBear;
-
-fn create_chip_with_rand_records() -> (Sha256TestChip, SharedBitwiseOperationLookupChip<8>) {
+fn create_air_with_air_ctx<SC: StarkGenericConfig>() -> (
+    (AirRef<SC>, AirProvingContext<CpuBackend<SC>>),
+    (
+        BitwiseOperationLookupAir<RV32_CELL_BITS>,
+        SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+    ),
+)
+where
+    Val<SC>: PrimeField32,
+{
     let mut rng = create_seeded_rng();
     let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
     let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV32_CELL_BITS>::new(
@@ -108,29 +100,35 @@ fn create_chip_with_rand_records() -> (Sha256TestChip, SharedBitwiseOperationLoo
             )
         })
         .collect();
-    let chip = Sha256TestChip {
-        air: Sha256TestAir {
-            sub_air: Sha256Air::new(bitwise_bus, SELF_BUS_IDX),
-        },
-        step: Sha256StepHelper::new(),
-        bitwise_lookup_chip: bitwise_chip.clone(),
-        records: random_records,
+
+    let air = Sha256TestAir {
+        sub_air: Sha256Air::new(bitwise_bus, SELF_BUS_IDX),
     };
-    (chip, bitwise_chip)
+    let chip = Sha256TestChip {
+        step: Sha256FillerHelper::new(),
+        bitwise_lookup_chip: bitwise_chip.clone(),
+    };
+    let air_ctx = chip.generate_proving_ctx(random_records);
+
+    ((Arc::new(air), air_ctx), (bitwise_chip.air, bitwise_chip))
 }
 
 #[test]
 fn rand_sha256_test() {
     let tester = VmChipTestBuilder::default();
-    let (chip, bitwise_chip) = create_chip_with_rand_records();
-    let tester = tester.build().load(chip).load(bitwise_chip).finalize();
+    let (air_ctx, bitwise) = create_air_with_air_ctx();
+    let tester = tester
+        .build()
+        .load_air_proving_ctx(air_ctx)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
 #[test]
 fn negative_sha256_test_bad_final_hash() {
     let tester = VmChipTestBuilder::default();
-    let (chip, bitwise_chip) = create_chip_with_rand_records();
+    let ((air, mut air_ctx), bitwise) = create_air_with_air_ctx();
 
     // Set the final_hash to all zeros
     let modify_trace = |trace: &mut RowMajorMatrix<F>| {
@@ -148,11 +146,17 @@ fn negative_sha256_test_bad_final_hash() {
         });
     };
 
+    // Modify the air_ctx
+    let trace = Option::take(&mut air_ctx.common_main).unwrap();
+    let mut trace = Arc::into_inner(trace).unwrap();
+    modify_trace(&mut trace);
+    air_ctx.common_main = Some(Arc::new(trace));
+
     disable_debug_builder();
     let tester = tester
         .build()
-        .load_and_prank_trace(chip, modify_trace)
-        .load(bitwise_chip)
+        .load_air_proving_ctx((air, air_ctx))
+        .load_periphery(bitwise)
         .finalize();
     tester.simple_test_with_expected_error(VerificationError::OodEvaluationMismatch);
 }

--- a/crates/circuits/sha256-air/src/tests.rs
+++ b/crates/circuits/sha256-air/src/tests.rs
@@ -72,7 +72,7 @@ where
             SHA256_WIDTH,
             records,
         );
-        AirProvingContext::simple(Arc::new(trace), vec![])
+        AirProvingContext::simple_no_pis(Arc::new(trace))
     }
 }
 

--- a/crates/circuits/sha256-air/src/trace.rs
+++ b/crates/circuits/sha256-air/src/trace.rs
@@ -23,11 +23,11 @@ use crate::{
 
 /// A helper struct for the SHA256 trace generation.
 /// Also, separates the inner AIR from the trace generation.
-pub struct Sha256StepHelper {
+pub struct Sha256FillerHelper {
     pub row_idx_encoder: Encoder,
 }
 
-impl Default for Sha256StepHelper {
+impl Default for Sha256FillerHelper {
     fn default() -> Self {
         Self::new()
     }
@@ -37,7 +37,7 @@ impl Default for Sha256StepHelper {
 /// The first pass should do `get_block_trace` for every block and generate the invalid rows through
 /// `get_default_row` The second pass should go through all the blocks and call
 /// `generate_missing_cells`
-impl Sha256StepHelper {
+impl Sha256FillerHelper {
     pub fn new() -> Self {
         Self {
             row_idx_encoder: Encoder::new(18, 2, false),
@@ -334,7 +334,7 @@ impl Sha256StepHelper {
     /// Fills the `cols` as a padding row
     /// Note: we still need to correctly fill in the hash values, carries and intermeds
     pub fn generate_default_row<F: PrimeField32>(
-        self: &Sha256StepHelper,
+        self: &Sha256FillerHelper,
         cols: &mut Sha256RoundCols<F>,
     ) {
         cols.flags.row_idx =
@@ -474,7 +474,7 @@ impl Sha256StepHelper {
 /// Generates a trace for a standalone SHA256 computation (currently only used for testing)
 /// `records` consists of pairs of `(input_block, is_last_block)`.
 pub fn generate_trace<F: PrimeField32>(
-    step: &Sha256StepHelper,
+    step: &Sha256FillerHelper,
     bitwise_lookup_chip: &BitwiseOperationLookupChip<8>,
     width: usize,
     records: Vec<([u8; SHA256_BLOCK_U8S], bool)>,
@@ -508,7 +508,7 @@ pub fn generate_trace<F: PrimeField32>(
             prev_hash = SHA256_H;
         } else {
             local_block_idx += 1;
-            prev_hash = Sha256StepHelper::get_block_hash(&prev_hash, input);
+            prev_hash = Sha256FillerHelper::get_block_hash(&prev_hash, input);
         }
     }
     // first pass

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -24,7 +24,7 @@ use openvm_rv32im_circuit::adapters::{
     read_rv32_register_from_state,
 };
 use openvm_sha256_air::{
-    get_sha256_num_blocks, Sha256StepHelper, SHA256_BLOCK_BITS, SHA256_ROWS_PER_BLOCK,
+    get_sha256_num_blocks, Sha256FillerHelper, SHA256_BLOCK_BITS, SHA256_ROWS_PER_BLOCK,
 };
 use openvm_sha256_transpiler::Rv32Sha256Opcode;
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -63,7 +63,7 @@ pub struct Sha256VmStep {
 }
 
 pub struct Sha256VmFiller {
-    pub inner: Sha256StepHelper,
+    pub inner: Sha256FillerHelper,
     pub padding_encoder: Encoder,
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
     pub pointer_max_bits: usize,
@@ -75,7 +75,7 @@ impl Sha256VmFiller {
         pointer_max_bits: usize,
     ) -> Self {
         Self {
-            inner: Sha256StepHelper::new(),
+            inner: Sha256FillerHelper::new(),
             padding_encoder: Encoder::new(PaddingFlags::COUNT, 2, false),
             bitwise_lookup_chip,
             pointer_max_bits,

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -24,7 +24,7 @@ use openvm_instructions::{
 };
 use openvm_rv32im_circuit::adapters::{read_rv32_register, tracing_read, tracing_write};
 use openvm_sha256_air::{
-    get_flag_pt_array, get_sha256_num_blocks, Sha256StepHelper, SHA256_BLOCK_BITS, SHA256_H,
+    get_flag_pt_array, get_sha256_num_blocks, Sha256FillerHelper, SHA256_BLOCK_BITS, SHA256_H,
     SHA256_ROWS_PER_BLOCK,
 };
 use openvm_sha256_transpiler::Rv32Sha256Opcode;
@@ -325,7 +325,7 @@ impl<F: PrimeField32> TraceFiller<F> for Sha256VmFiller {
                 let mut prev_hashes = Vec::with_capacity(*num_blocks);
                 prev_hashes.push(SHA256_H);
                 for i in 0..*num_blocks - 1 {
-                    prev_hashes.push(Sha256StepHelper::get_block_hash(
+                    prev_hashes.push(Sha256FillerHelper::get_block_hash(
                         &prev_hashes[i],
                         padded_input[i * SHA256_BLOCK_CELLS..(i + 1) * SHA256_BLOCK_CELLS]
                             .try_into()


### PR DESCRIPTION
port `sha2` primitive tests to the new testbuilder
Renamed `Sha256StepHelper->Sha256FillerHelper`