### PR TITLE
chore: Optimize E2 Height Meter

### DIFF
--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -174,7 +174,9 @@ fn small_test_app_config(app_log_blowup: usize) -> AppConfig<SdkVmConfig> {
 #[test]
 fn test_public_values_and_leaf_verification() -> eyre::Result<()> {
     let app_log_blowup = 1;
-    let app_config = small_test_app_config(app_log_blowup);
+    let mut app_config = small_test_app_config(app_log_blowup);
+    app_config.app_vm_config.system.config.segmentation_strategy =
+        Arc::new(DefaultSegmentationStrategy::new_with_max_segment_len(256));
     let app_pk = Arc::new(AppProvingKey::keygen(app_config)?);
     let app_committed_exe = app_committed_exe_for_test(app_log_blowup);
     let pc_start = app_committed_exe.exe.pc_start;

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -155,7 +155,8 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         if instret < self.instret_last_segment_check + self.segment_check_insns {
             return;
         }
-        self.memory_ctx.lazy_update_heights(&mut self.trace_heights);
+        self.memory_ctx
+            .lazy_update_boundary_heights(&mut self.trace_heights);
         let did_segment = self.segmentation_ctx.check_and_segment(
             instret,
             &self.trace_heights,
@@ -222,7 +223,7 @@ impl<const PAGE_BITS: usize> E1ExecutionCtx for MeteredCtx<PAGE_BITS> {
         vm_state
             .ctx
             .memory_ctx
-            .lazy_update_heights(&mut vm_state.ctx.trace_heights);
+            .lazy_update_boundary_heights(&mut vm_state.ctx.trace_heights);
         vm_state
             .ctx
             .segmentation_ctx

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -9,13 +9,13 @@ pub struct BitSet {
 }
 
 impl BitSet {
-    pub fn new(size_bits: usize) -> Self {
-        let num_words = 1 << size_bits.saturating_sub(6);
+    pub fn new(num_bits: usize) -> Self {
         Self {
-            words: vec![0; num_words].into_boxed_slice(),
+            words: vec![0; num_bits.div_ceil(u64::BITS as usize)].into_boxed_slice(),
         }
     }
 
+    #[inline(always)]
     pub fn insert(&mut self, index: usize) -> bool {
         let word_index = index / 64;
         let bit_index = index % 64;
@@ -24,6 +24,39 @@ impl BitSet {
         let was_set = (self.words[word_index] & mask) != 0;
         self.words[word_index] |= mask;
         !was_set
+    }
+
+    /// Set all bits within [start, end) to 1, return the number of flipped bits.
+    #[inline(always)]
+    pub fn insert_range(&mut self, start: usize, end: usize) -> usize {
+        let mut ret = 0;
+        let start_word_index = start / u64::BITS as usize;
+        let end_word_index = (end - 1) / u64::BITS as usize;
+        let start_bit = start as u32 % u64::BITS;
+        if start_word_index == end_word_index {
+            let end_bit = (end - 1) as u32 % u64::BITS + 1;
+            let mask_bits = end_bit - start_bit;
+            let mask = (u64::MAX >> (u64::BITS - mask_bits)) << start_bit;
+            ret += mask_bits - (self.words[start_word_index] & mask).count_ones();
+            self.words[start_word_index] |= mask;
+        } else {
+            let end_bit = end as u32 % u64::BITS;
+            let mask_bits = u64::BITS - start_bit;
+            let mask = u64::MAX << start_bit;
+            ret += mask_bits - (self.words[start_word_index] & mask).count_ones();
+            self.words[start_word_index] |= mask;
+            let mask_bits = end_bit;
+            let (mask, _) = u64::MAX.overflowing_shr(u64::BITS - end_bit);
+            ret += mask_bits - (self.words[end_word_index] & mask).count_ones();
+            self.words[end_word_index] |= mask;
+        }
+        if start_word_index + 1 < end_word_index {
+            for i in (start_word_index + 1)..end_word_index {
+                ret += self.words[i].count_zeros();
+                self.words[i] = u64::MAX;
+            }
+        }
+        ret as usize
     }
 
     pub fn clear(&mut self) {
@@ -43,6 +76,9 @@ pub struct MemoryCtx<const PAGE_BITS: usize> {
     pub adapter_offset: usize,
     chunk: u32,
     chunk_bits: u32,
+    page_access_count: usize,
+    // Note: 32 is the maximum access adapter size.
+    addr_space_access_count: Vec<usize>,
 }
 
 impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
@@ -82,7 +118,8 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         let merkle_height = memory_dimensions.overall_height();
 
         Self {
-            page_indices: BitSet::new(merkle_height.saturating_sub(PAGE_BITS)),
+            // Address height already considers `chunk_bits`.
+            page_indices: BitSet::new(1 << (merkle_height.saturating_sub(PAGE_BITS))),
             as_byte_alignment_bits,
             boundary_idx,
             merkle_tree_index,
@@ -90,60 +127,38 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
             chunk,
             chunk_bits,
             memory_dimensions,
+            page_access_count: 0,
+            addr_space_access_count: vec![0; (1 << memory_dimensions.addr_space_height) + 1],
         }
     }
-
+    #[inline(always)]
     pub fn clear(&mut self) {
         self.page_indices.clear();
     }
 
-    pub fn update_boundary_merkle_heights(
-        &mut self,
-        trace_heights: &mut [u32],
-        address_space: u32,
-        ptr: u32,
-        size: u32,
-    ) {
+    #[inline(always)]
+    pub fn update_boundary_merkle_heights(&mut self, address_space: u32, ptr: u32, size: u32) {
         let num_blocks = (size + self.chunk - 1) >> self.chunk_bits;
-        let mut addr = ptr;
-        for _ in 0..num_blocks {
-            let block_id = addr >> self.chunk_bits;
-            let index = if self.chunk == 1 {
-                // Volatile
-                block_id
-            } else {
-                self.memory_dimensions
-                    .label_to_index((address_space, block_id)) as u32
-            } as usize;
-
-            if self.page_indices.insert(index >> PAGE_BITS) {
-                // On page fault, assume we add all leaves in a page
-                let leaves = 1 << PAGE_BITS;
-                trace_heights[self.boundary_idx] += leaves;
-
-                if let Some(merkle_tree_idx) = self.merkle_tree_index {
-                    let poseidon2_idx = trace_heights.len() - 2;
-                    trace_heights[poseidon2_idx] += leaves * 2;
-
-                    let merkle_height = self.memory_dimensions.overall_height();
-                    let nodes = (((1 << PAGE_BITS) - 1) + (merkle_height - PAGE_BITS)) as u32;
-                    trace_heights[poseidon2_idx] += nodes * 2;
-                    trace_heights[merkle_tree_idx] += nodes * 2;
-                }
-
-                // At finalize, we'll need to read it in chunk-sized units for the merkle chip
-                self.update_adapter_heights_batch(
-                    trace_heights,
-                    address_space,
-                    self.chunk_bits,
-                    leaves,
-                );
+        let start_chunk_id = ptr >> self.chunk_bits;
+        let star_block_id = if self.chunk == 1 {
+            start_chunk_id
+        } else {
+            self.memory_dimensions
+                .label_to_index((address_space, start_chunk_id)) as u32
+        };
+        // Because `self.chunk == 1 << self.chunk_bits`
+        let end_block_id = star_block_id + num_blocks;
+        let start_page_id = star_block_id >> PAGE_BITS;
+        let end_page_id = ((end_block_id - 1) >> PAGE_BITS) + 1;
+        for page_id in start_page_id..end_page_id {
+            if self.page_indices.insert(page_id as usize) {
+                self.page_access_count += 1;
+                self.addr_space_access_count[address_space as usize] += 1;
             }
-
-            addr = addr.wrapping_add(self.chunk);
         }
     }
 
+    #[inline(always)]
     pub fn update_adapter_heights(
         &mut self,
         trace_heights: &mut [u32],
@@ -153,8 +168,9 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         self.update_adapter_heights_batch(trace_heights, address_space, size_bits, 1);
     }
 
+    #[inline(always)]
     pub fn update_adapter_heights_batch(
-        &mut self,
+        &self,
         trace_heights: &mut [u32],
         address_space: u32,
         size_bits: u32,
@@ -171,5 +187,64 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
             let adapter_idx = self.adapter_offset + adapter_bits as usize - 1;
             trace_heights[adapter_idx] += num << (size_bits - adapter_bits + 1);
         }
+    }
+
+    #[inline(always)]
+    pub(crate) fn lazy_update_heights(&mut self, trace_heights: &mut [u32]) {
+        // On page fault, assume we add all leaves in a page
+        let leaves = (self.page_access_count << PAGE_BITS) as u32;
+        trace_heights[self.boundary_idx] += leaves;
+
+        if let Some(merkle_tree_idx) = self.merkle_tree_index {
+            let poseidon2_idx = trace_heights.len() - 2;
+            trace_heights[poseidon2_idx] += leaves * 2;
+
+            let merkle_height = self.memory_dimensions.overall_height();
+            let nodes = (((1 << PAGE_BITS) - 1) + (merkle_height - PAGE_BITS)) as u32;
+            trace_heights[poseidon2_idx] += nodes * 2;
+            trace_heights[merkle_tree_idx] += nodes * 2;
+        }
+        self.page_access_count = 0;
+        for address_space in 0..self.addr_space_access_count.len() {
+            let x = self.addr_space_access_count[address_space];
+            if x > 0 {
+                // After finalize, we'll need to read it in chunk-sized units for the merkle chip
+                self.update_adapter_heights_batch(
+                    trace_heights,
+                    address_space as u32,
+                    self.chunk_bits,
+                    (x << PAGE_BITS) as u32,
+                );
+                self.addr_space_access_count[address_space] = 0;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_bitset_insert_range() {
+        // 513 bits
+        let mut bit_set = BitSet::new(8 * 64 + 1);
+        let num_flips = bit_set.insert_range(2, 29);
+        assert_eq!(num_flips, 27);
+        let num_flips = bit_set.insert_range(1, 31);
+        assert_eq!(num_flips, 3);
+
+        let num_flips = bit_set.insert_range(32, 65);
+        assert_eq!(num_flips, 33);
+        let num_flips = bit_set.insert_range(0, 66);
+        assert_eq!(num_flips, 3);
+        let num_flips = bit_set.insert_range(0, 66);
+        assert_eq!(num_flips, 0);
+
+        let num_flips = bit_set.insert_range(256, 320);
+        assert_eq!(num_flips, 64);
+        let num_flips = bit_set.insert_range(256, 377);
+        assert_eq!(num_flips, 57);
+        let num_flips = bit_set.insert_range(100, 513);
+        assert_eq!(num_flips, 413 - 121);
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -2,10 +2,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use p3_baby_bear::BabyBear;
 use serde::{Deserialize, Serialize};
 
-/// Check segment every 100 instructions.
-const DEFAULT_SEGMENT_CHECK_INSNS: u64 = 100;
-
-const DEFAULT_MAX_TRACE_HEIGHT: u32 = (1 << 23) - 100;
+const DEFAULT_MAX_TRACE_HEIGHT: u32 = (1 << 23) - 10000;
 const DEFAULT_MAX_CELLS: usize = 2_000_000_000; // 2B
 const DEFAULT_MAX_INTERACTIONS: usize = BabyBear::ORDER_U32 as usize;
 
@@ -36,12 +33,10 @@ impl Default for SegmentationLimits {
 #[derive(Clone, Debug)]
 pub struct SegmentationCtx {
     pub segments: Vec<Segment>,
-    instret_last_segment_check: u64,
     pub(crate) air_names: Vec<String>,
     widths: Vec<usize>,
     interactions: Vec<usize>,
-    segment_check_insns: u64,
-    segmentation_limits: SegmentationLimits,
+    pub(crate) segmentation_limits: SegmentationLimits,
 }
 
 impl SegmentationCtx {
@@ -51,9 +46,7 @@ impl SegmentationCtx {
             air_names,
             widths,
             interactions,
-            segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
             segmentation_limits: SegmentationLimits::default(),
-            instret_last_segment_check: 0,
         }
     }
 
@@ -69,11 +62,8 @@ impl SegmentationCtx {
         self.segmentation_limits.max_interactions = max_interactions;
     }
 
-    pub fn set_segment_check_insns(&mut self, segment_check_insns: u64) {
-        self.segment_check_insns = segment_check_insns;
-    }
-
     /// Calculate the total cells used based on trace heights and widths
+    #[inline(always)]
     fn calculate_total_cells(&self, trace_heights: &[u32]) -> usize {
         trace_heights
             .iter()
@@ -83,6 +73,7 @@ impl SegmentationCtx {
     }
 
     /// Calculate the total interactions based on trace heights and interaction counts
+    #[inline(always)]
     fn calculate_total_interactions(&self, trace_heights: &[u32]) -> usize {
         trace_heights
             .iter()
@@ -92,6 +83,7 @@ impl SegmentationCtx {
             .sum()
     }
 
+    #[inline(always)]
     fn should_segment(
         &self,
         instret: u64,
@@ -150,6 +142,7 @@ impl SegmentationCtx {
         false
     }
 
+    #[inline(always)]
     pub fn check_and_segment(
         &mut self,
         instret: u64,
@@ -157,23 +150,15 @@ impl SegmentationCtx {
         is_trace_height_constant: &[bool],
     ) -> bool {
         // Avoid checking segment too often.
-        if instret
-            < self
-                .instret_last_segment_check
-                .saturating_add(self.segment_check_insns)
-        {
-            return false;
-        }
-
         let ret = self.should_segment(instret, trace_heights, is_trace_height_constant);
         if ret {
             self.segment(instret, trace_heights);
         }
-        self.instret_last_segment_check = instret;
         ret
     }
 
     /// Try segment if there is at least one cycle
+    #[inline(always)]
     pub fn segment(&mut self, instret: u64, trace_heights: &[u32]) {
         let instret_start = self
             .segments
@@ -185,24 +170,5 @@ impl SegmentationCtx {
             num_insns,
             trace_heights: trace_heights.to_vec(),
         });
-    }
-
-    pub fn add_final_segment(&mut self, instret: u64, trace_heights: &[u32]) {
-        tracing::info!(
-            "Segment {:2} | instret {:9} | terminated",
-            self.segments.len(),
-            instret,
-        );
-        // Add the last segment
-        let instret_start = self
-            .segments
-            .last()
-            .map_or(0, |s| s.instret_start + s.num_insns);
-        let segment = Segment {
-            instret_start,
-            num_insns: instret - instret_start,
-            trace_heights: trace_heights.to_vec(),
-        };
-        self.segments.push(segment);
     }
 }

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -209,7 +209,7 @@ unsafe fn execute_impl<F: PrimeField32, Ctx: E1ExecutionCtx>(
     vm_state: &mut VmSegmentState<F, GuestMemory, Ctx>,
     fn_ptrs: &[PreComputeInstruction<F, Ctx>],
 ) {
-    // let start = Instant::now();
+    // let start = std::time::Instant::now();
     while vm_state
         .exit_code
         .as_ref()

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -264,7 +264,7 @@ where
         .with_max_cells(seg_strategy.max_cells());
         if !system_config.continuation_enabled {
             // force single segment
-            ctx.segmentation_ctx.set_segment_check_insns(u64::MAX);
+            ctx = ctx.with_segment_check_insns(u64::MAX);
         }
         ctx
     }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -283,6 +283,7 @@ impl GuestMemory {
     /// and it must be the exact type used to represent a single memory cell in
     /// address space `address_space`. For standard usage,
     /// `T` is either `u8` or `F` where `F` is the base field of the ZK backend.
+    #[inline(always)]
     pub unsafe fn read<T, const BLOCK_SIZE: usize>(
         &self,
         addr_space: u32,
@@ -305,6 +306,7 @@ impl GuestMemory {
     ///
     /// # Safety
     /// See [`GuestMemory::read`].
+    #[inline(always)]
     pub unsafe fn write<T, const BLOCK_SIZE: usize>(
         &mut self,
         addr_space: u32,


### PR DESCRIPTION
Changes:
- Increase the default segment check frequency from 100 to 1000.
- Postpone adapter height change to segment check instead of every memory access. There is still 1 adapter height update in `on_memory_operation` but postponing it will make benchmark slower.

Benchmarks: 
Codespeed and my local show significant performance gain. However, [reth-benchmark](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16380276462) doesn't have any change. I don't have a good explanation yet.