### PR TITLE
fix: E2 Check Frquency

### DIFF
--- a/crates/sdk/guest/fib/src/main.rs
+++ b/crates/sdk/guest/fib/src/main.rs
@@ -4,7 +4,7 @@
 openvm::entry!(main);
 
 pub fn main() {
-    let n = core::hint::black_box(1 << 10);
+    let n = core::hint::black_box(1 << 8);
     let mut a: u32 = 0;
     let mut b: u32 = 1;
     for _ in 1..n {

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -112,6 +112,10 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     pub fn with_max_trace_height(mut self, max_trace_height: u32) -> Self {
         self.segmentation_ctx.set_max_trace_height(max_trace_height);
+        let max_check_freq = (max_trace_height / 2) as u64;
+        if max_check_freq < self.segment_check_insns {
+            self.segment_check_insns = max_check_freq;
+        }
         self
     }
 


### PR DESCRIPTION
Segment check frequency shouldn't be larger than the height limit.