### PR TITLE
fix(new-execution): use smaller fib number in `verify_stark` test

### DIFF
--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -13,6 +13,7 @@ on:
       - "guest-libs/**"
       - "Cargo.toml"
       - ".github/workflows/guest-lib-tests.yml"
+      - "crates/sdk/guest/fib/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/crates/sdk/guest/fib/src/main.rs
+++ b/crates/sdk/guest/fib/src/main.rs
@@ -4,7 +4,7 @@
 openvm::entry!(main);
 
 pub fn main() {
-    let n = core::hint::black_box(1 << 8);
+    let n = core::hint::black_box(1 << 3);
     let mut a: u32 = 0;
     let mut b: u32 = 1;
     for _ in 1..n {

--- a/crates/sdk/guest/fib/src/main.rs
+++ b/crates/sdk/guest/fib/src/main.rs
@@ -4,7 +4,8 @@
 openvm::entry!(main);
 
 pub fn main() {
-    let n = core::hint::black_box(1 << 3);
+    // arbitrary n that results in more than 1 segment
+    let n = core::hint::black_box((1 << 5) + 4);
     let mut a: u32 = 0;
     let mut b: u32 = 1;
     for _ in 1..n {

--- a/guest-libs/verify_stark/tests/integration_test.rs
+++ b/guest-libs/verify_stark/tests/integration_test.rs
@@ -101,8 +101,8 @@ mod tests {
             sdk.transpile(elf, vm_config.transpiler())?
         };
 
-        // app_exe publishes 7th and 8th fibonacci numbers.
-        let pvs: Vec<u8> = [13u32, 21, 0, 0, 0, 0, 0, 0]
+        // app_exe publishes 35th and 36th fibonacci numbers.
+        let pvs: Vec<u8> = [9227465, 14930352, 0, 0, 0, 0, 0, 0u32]
             .iter()
             .flat_map(|x| x.to_le_bytes())
             .collect();


### PR DESCRIPTION
We hardcode these values in the `verify_stark` test
https://github.com/openvm-org/openvm/blob/af8f6c9037ac090d7148c3ba7056d7c9ef7d5f96/guest-libs/verify_stark/tests/integration_test.rs#L104-L108

Resolves INT-4429