### PR TITLE
chore: Optimistic E3 Execution for Poseidon2 Chip

### DIFF
--- a/extensions/native/circuit/src/lib.rs
+++ b/extensions/native/circuit/src/lib.rs
@@ -43,7 +43,7 @@ pub use extension::*;
 mod utils;
 #[cfg(any(test, feature = "test-utils"))]
 pub use utils::test_utils::*;
-pub use utils::*;
+pub(crate) use utils::*;
 
 #[derive(Clone, Debug, derive_new::new, VmConfig, Serialize, Deserialize)]
 pub struct NativeConfig {


### PR DESCRIPTION
Add a flag to execute E3 optimistically. When the flag is enabled, `verify_batch` skips all verification logic and postpone all poseidon2 hash computation to the tracegen phase.

[Reth-benchmark](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16510370163) shows 20% execution time reduction. Tracegen time slightly increases but the increment is less than the saving.

Close INT-4374

Per opcode stats on my laptop(variance is large but we could see a significant difference):

Before:
GROUP | FREQUENCY | TOTAL EXEC TIME | AVG TIME | Percentage
-- | -- | -- | -- | --
ADD | 599175 | 46411254 | 77.46 | 9.30%
BBE4DIV | 19534 | 7959238 | 407.46 | 1.60%
BBE4MUL | 52005 | 9243036 | 177.73 | 1.85%
COMP_POS2 | 27 | 53917 | 1,996.93 | 0.01%
DIV | 2184 | 390832 | 178.95 | 0.08%
FE4ADD | 27755 | 3580894 | 129.02 | 0.72%
FE4SUB | 6709 | 1523758 | 227.12 | 0.31%
FRI_REDUCED_OPENING | 17500 | 47049340 | 2,688.53 | 9.43%
HINT_STOREW | 54961 | 6639322 | 120.80 | 1.33%
JAL | 20264 | 1670740 | 82.45 | 0.33%
LOADW | 332530 | 56095576 | 168.69 | 11.25%
MUL | 146789 | 11367159 | 77.44 | 2.28%
NativeBranchEqualOpcode(BEQ) | 8951 | 570160 | 63.70 | 0.11%
NativeBranchEqualOpcode(BNE) | 151700 | 10170358 | 67.04 | 2.04%
PERM_POS2 | 1968 | 3516015 | 1,786.59 | 0.70%
PHANTOM | 16541 | 1531674 | 92.60 | 0.31%
PUBLISH | 36 | 16165 | 449.03 | 0.00%
RANGE_CHECK | 26909 | 1374440 | 51.08 | 0.28%
STOREW | 72946 | 10643024 | 145.90 | 2.13%
SUB | 61182 | 7812138 | 127.69 | 1.57%
VERIFY_BATCH | 2700 | 271206706 | 100,446.93 | 54.37%
  |   | 498825746 |   | 100.00%



After:
GROUP | FREQUENCY | TOTAL EXEC TIME | AVG TIME | Percentage
-- | -- | -- | -- | --
ADD | 599175 | 50,137,976 | 83.68 | 11.65%
BBE4DIV | 19534 | 10,487,243 | 536.87 | 2.44%
BBE4MUL | 52005 | 11,279,418 | 216.89 | 2.62%
COMP_POS2 | 27 | 109,915 | 4,070.93 | 0.03%
DIV | 2184 | 502,509 | 230.09 | 0.12%
FE4ADD | 27755 | 4,140,336 | 149.17 | 0.96%
FE4SUB | 6709 | 1,979,492 | 295.05 | 0.46%
FRI_REDUCED_OPENING | 17500 | 57,441,000 | 3,282.34 | 13.34%
HINT_STOREW | 54961 | 9,498,320 | 172.82 | 2.21%
JAL | 20193 | 1,504,236 | 74.49 | 0.35%
LOADW | 332530 | 60,762,686 | 182.73 | 14.12%
MUL | 146789 | 12,791,836 | 87.14 | 2.97%
NativeBranchEqualOpcode(BEQ) | 8951 | 662,178 | 73.98 | 0.15%
NativeBranchEqualOpcode(BNE) | 151700 | 10,591,935 | 69.82 | 2.46%
PERM_POS2 | 1968 | 4,060,309 | 2,063.17 | 0.94%
PHANTOM | 16541 | 2,082,586 | 125.90 | 0.48%
PUBLISH | 36 | 233,085 | 6,474.58 | 0.05%
RANGE_CHECK | 26909 | 1,326,437 | 49.29 | 0.31%
STOREW | 72946 | 10,698,539 | 146.66 | 2.49%
SUB | 61182 | 9,573,439 | 156.47 | 2.22%
VERIFY_BATCH | 2700 | 170,589,925 | 63,181.45 | 39.63%
  |   | 430,453,400 |   | 100.00%

