### PR TITLE
perf: remove `step` from `Program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to OpenVM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project follows a versioning principles documented in [VERSIONING.md](./VERSIONING.md).
 
+## [Unreleased]
+
+### Changed
+- (Toolchain) Removed `step` from `Program` struct because `DEFAULT_PC_STEP = 4` is always used.
+
 ## v1.3.0 (2025-07-15)
 
 No circuit constraints or verifying keys were changed in this release.

--- a/crates/toolchain/transpiler/src/lib.rs
+++ b/crates/toolchain/transpiler/src/lib.rs
@@ -1,10 +1,7 @@
 //! A transpiler from custom RISC-V ELFs to OpenVM executable binaries.
 
 use elf::Elf;
-use openvm_instructions::{
-    exe::VmExe,
-    program::{Program, DEFAULT_PC_STEP},
-};
+use openvm_instructions::{exe::VmExe, program::Program};
 pub use openvm_platform;
 use openvm_stark_backend::p3_field::PrimeField32;
 use transpiler::{Transpiler, TranspilerError};
@@ -29,11 +26,7 @@ impl<F: PrimeField32> FromElf for VmExe<F> {
     type ElfContext = Transpiler<F>;
     fn from_elf(elf: Elf, transpiler: Self::ElfContext) -> Result<Self, TranspilerError> {
         let instructions = transpiler.transpile(&elf.instructions)?;
-        let program = Program::new_without_debug_infos_with_option(
-            &instructions,
-            DEFAULT_PC_STEP,
-            elf.pc_base,
-        );
+        let program = Program::new_without_debug_infos_with_option(&instructions, elf.pc_base);
         let init_memory = elf_memory_image_to_openvm_memory_image(elf.memory_image);
 
         Ok(VmExe {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -28,10 +28,9 @@ pub type Result<T> = std::result::Result<T, ExecutionError>;
 pub enum ExecutionError {
     #[error("execution failed at pc {pc}")]
     Fail { pc: u32 },
-    #[error("pc {pc} out of bounds for program of length {program_len}, with pc_base {pc_base} and step = {step}")]
+    #[error("pc {pc} out of bounds for program of length {program_len}, with pc_base {pc_base}")]
     PcOutOfBounds {
         pc: u32,
-        step: u32,
         pc_base: u32,
         program_len: usize,
     },

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -1,5 +1,7 @@
 use openvm_instructions::{
-    instruction::Instruction, program::Program, LocalOpcode, SystemOpcode, VmOpcode,
+    instruction::Instruction,
+    program::{Program, DEFAULT_PC_STEP},
+    LocalOpcode, SystemOpcode, VmOpcode,
 };
 use openvm_stark_backend::{
     config::StarkGenericConfig,
@@ -58,7 +60,6 @@ pub struct ProgramHandler<F, E> {
     pc_handler: Vec<PcEntry<F>>,
     execution_frequencies: Vec<u32>,
     pc_base: u32,
-    step: u32,
 }
 
 impl<F: Field, E> ProgramHandler<F, E> {
@@ -110,15 +111,13 @@ impl<F: Field, E> ProgramHandler<F, E> {
             executors,
             pc_handler,
             pc_base: program.pc_base,
-            step: program.step,
         })
     }
 
     #[inline(always)]
     fn get_pc_index(&self, pc: u32) -> usize {
-        let step = self.step;
         let pc_base = self.pc_base;
-        ((pc - pc_base) / step) as usize
+        ((pc - pc_base) / DEFAULT_PC_STEP) as usize
     }
 
     /// Returns `(executor, pc_entry, pc_idx)`.
@@ -130,7 +129,6 @@ impl<F: Field, E> ProgramHandler<F, E> {
             .get(pc_idx)
             .ok_or_else(|| ExecutionError::PcOutOfBounds {
                 pc,
-                step: self.step,
                 pc_base: self.pc_base,
                 program_len: self.pc_handler.len(),
             })?;

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -288,7 +288,7 @@ fn test_program_with_undefined_instructions() {
         )),
     ];
 
-    let program = Program::new_without_debug_infos_with_option(&instructions, DEFAULT_PC_STEP, 0);
+    let program = Program::new_without_debug_infos_with_option(&instructions, 0);
 
     interaction_test(program, vec![0, 2, 5]);
 }

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -3,7 +3,11 @@ use std::{borrow::BorrowMut, sync::Arc};
 use derivative::Derivative;
 use itertools::Itertools;
 use openvm_circuit::arch::hasher::poseidon2::Poseidon2Hasher;
-use openvm_instructions::{exe::VmExe, program::Program, LocalOpcode, SystemOpcode};
+use openvm_instructions::{
+    exe::VmExe,
+    program::{Program, DEFAULT_PC_STEP},
+    LocalOpcode, SystemOpcode,
+};
 use openvm_stark_backend::{
     config::{Com, PcsProverData, StarkGenericConfig, Val},
     p3_commit::Pcs,
@@ -169,7 +173,7 @@ pub(crate) fn generate_cached_trace<F: Field>(program: &Program<F>) -> RowMajorM
     let padding = padding_instruction();
     while !instructions.len().is_power_of_two() {
         instructions.push((
-            program.pc_base + instructions.len() as u32 * program.step,
+            program.pc_base + instructions.len() as u32 * DEFAULT_PC_STEP,
             padding.clone(),
         ));
     }

--- a/extensions/native/compiler/src/conversion/mod.rs
+++ b/extensions/native/compiler/src/conversion/mod.rs
@@ -565,7 +565,7 @@ pub fn convert_program<F: PrimeField32, EF: ExtensionField<F>>(
         }
     }
 
-    let mut result = Program::new_empty(DEFAULT_PC_STEP, 0);
+    let mut result = Program::new_empty(0);
     result.push_instruction_and_debug_info(init_register_0, init_debug_info);
     for block in program.blocks.iter() {
         for (instruction, debug_info) in block.0.iter().zip(block.1.iter()) {


### PR DESCRIPTION
We always use `DEFAULT_PC_STEP = 4` and this can lead to slightly better compiler optimizations.

closes INT-4385