### PR TITLE
chore: use explicit `Result<_, ExecutionError>` and `pre_compute*` returns `StaticProgramError`

### DIFF
--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -8,12 +8,7 @@ use itertools::Itertools;
 use num_bigint::BigUint;
 use num_traits::Zero;
 use openvm_circuit::{
-    arch::{
-        get_record_from_slice, AdapterAirContext, AdapterCoreLayout, AdapterCoreMetadata,
-        AdapterTraceFiller, AdapterTraceStep, CustomBorrow, DynAdapterInterface, DynArray,
-        InstructionExecutor, MinimalInstruction, RecordArena, Result, SizedRecord, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmStateMut,
-    },
+    arch::*,
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::{
@@ -395,7 +390,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let (mut adapter_record, mut core_record) = state.ctx.alloc(self.get_record_layout());
 
         A::start(*state.pc, state.memory, &mut adapter_record);

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -167,7 +167,7 @@ pub fn ins_executor_e1_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         inst: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::StaticProgramError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E1ExecutionCtx, {
                         self.0.pre_compute_e1(pc, inst, data)
@@ -240,7 +240,7 @@ pub fn ins_executor_e1_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::StaticProgramError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E1ExecutionCtx, {
                         match self {
@@ -295,7 +295,7 @@ pub fn ins_executor_e2_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         inst: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::StaticProgramError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E2ExecutionCtx, {
                         self.0.pre_compute_e2(chip_idx, pc, inst, data)
@@ -369,7 +369,7 @@ pub fn ins_executor_e2_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::StaticProgramError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E2ExecutionCtx, {
                         match self {

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -57,7 +57,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                         &mut self,
                         state: ::openvm_circuit::arch::VmStateMut<#field_ty_generic, ::openvm_circuit::system::memory::online::TracingMemory, RA>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<#field_ty_generic>,
-                    ) -> ::openvm_circuit::arch::Result<()> {
+                    ) -> Result<(), ::openvm_circuit::arch::ExecutionError> {
                         self.0.execute(state, instruction)
                     }
 
@@ -109,7 +109,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                         &mut self,
                         state: ::openvm_circuit::arch::VmStateMut<#field_ty_generic, ::openvm_circuit::system::memory::online::TracingMemory, RA>,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<#field_ty_generic>,
-                    ) -> ::openvm_circuit::arch::Result<()> {
+                    ) -> Result<(), ::openvm_circuit::arch::ExecutionError> {
                         match self {
                             #(#execute_arms,)*
                         }
@@ -167,7 +167,7 @@ pub fn ins_executor_e1_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         inst: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> ::openvm_circuit::arch::execution::Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E1ExecutionCtx, {
                         self.0.pre_compute_e1(pc, inst, data)
@@ -240,7 +240,7 @@ pub fn ins_executor_e1_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> ::openvm_circuit::arch::execution::Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E1ExecutionCtx, {
                         match self {
@@ -295,7 +295,7 @@ pub fn ins_executor_e2_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         inst: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> ::openvm_circuit::arch::execution::Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E2ExecutionCtx, {
                         self.0.pre_compute_e2(chip_idx, pc, inst, data)
@@ -369,7 +369,7 @@ pub fn ins_executor_e2_derive(input: TokenStream) -> TokenStream {
                         pc: u32,
                         instruction: &::openvm_circuit::arch::instructions::instruction::Instruction<F>,
                         data: &mut [u8],
-                    ) -> ::openvm_circuit::arch::execution::Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>>
+                    ) -> Result<::openvm_circuit::arch::ExecuteFunc<F, Ctx>, ::openvm_circuit::arch::ExecutionError>
                     where
                         Ctx: ::openvm_circuit::arch::execution_mode::E2ExecutionCtx, {
                         match self {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -22,8 +22,6 @@ use crate::{
     },
 };
 
-pub type Result<T> = std::result::Result<T, ExecutionError>;
-
 #[derive(Error, Debug)]
 pub enum ExecutionError {
     #[error("execution failed at pc {pc}")]
@@ -100,7 +98,7 @@ pub trait InstructionExecutor<F, RA = MatrixRecordArena<F>>: Clone {
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()>;
+    ) -> Result<(), ExecutionError>;
 
     /// For display purposes. From absolute opcode as `usize`, return the string name of the opcode
     /// if it is a supported opcode by the present executor.
@@ -130,7 +128,7 @@ pub trait InsExecutorE1<F> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx;
 }
@@ -144,7 +142,7 @@ pub trait InsExecutorE2<F> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx;
 }

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -18,8 +18,8 @@ use crate::{
         create_memory_image,
         execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
         ExecuteFunc, ExecutionError, ExecutorInventory, ExecutorInventoryError, ExitCode,
-        InsExecutorE1, InsExecutorE2, PreComputeInstruction, Streams, SystemConfig,
-        VmExecutionConfig, VmSegmentState,
+        InsExecutorE1, InsExecutorE2, PreComputeInstruction, StaticProgramError, Streams,
+        SystemConfig, VmExecutionConfig, VmSegmentState,
     },
     system::memory::online::GuestMemory,
 };
@@ -385,7 +385,8 @@ fn get_pre_compute_instructions<'a, F: PrimeField32, E: InsExecutorE1<F>, Ctx: E
             } else {
                 PreComputeInstruction {
                     handler: |_, vm_state| {
-                        vm_state.exit_code = Err(ExecutionError::InvalidInstruction(vm_state.pc));
+                        vm_state.exit_code =
+                            Err(StaticProgramError::InvalidInstruction(vm_state.pc).into());
                     },
                     pre_compute: buf,
                 }
@@ -441,7 +442,8 @@ fn get_e2_pre_compute_instructions<
             } else {
                 PreComputeInstruction {
                     handler: |_, vm_state| {
-                        vm_state.exit_code = Err(ExecutionError::InvalidInstruction(vm_state.pc));
+                        vm_state.exit_code =
+                            Err(StaticProgramError::InvalidInstruction(vm_state.pc).into());
                     },
                     pre_compute: buf,
                 }

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -2,6 +2,7 @@ mod config;
 /// Instruction execution traits and types.
 /// Execution bus and interface.
 pub mod execution;
+/// Execution context types for different execution modes.
 pub mod execution_mode;
 /// Traits and builders to compose collections of chips into a virtual machine.
 mod extensions;
@@ -27,6 +28,7 @@ pub mod testing;
 
 pub use config::*;
 pub use execution::*;
+pub use execution_mode::{E1ExecutionCtx, E2ExecutionCtx};
 pub use extensions::*;
 pub use integration_api::*;
 pub use openvm_instructions as instructions;

--- a/crates/vm/src/system/phantom/execution.rs
+++ b/crates/vm/src/system/phantom/execution.rs
@@ -11,7 +11,7 @@ use crate::{
     arch::{
         execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
         E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2,
-        PhantomSubExecutor, Streams, VmSegmentState,
+        PhantomSubExecutor, StaticProgramError, Streams, VmSegmentState,
     },
     system::{memory::online::GuestMemory, phantom::PhantomExecutor},
 };
@@ -45,7 +45,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -177,7 +177,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -1,15 +1,12 @@
-use openvm_instructions::{
-    instruction::Instruction, program::Program, LocalOpcode, SystemOpcode, VmOpcode,
-};
+use openvm_instructions::{instruction::Instruction, program::Program, LocalOpcode, SystemOpcode};
 use openvm_stark_backend::{
     config::StarkGenericConfig,
     p3_field::Field,
     p3_maybe_rayon::prelude::*,
     prover::{cpu::CpuBackend, types::CommittedTraceData},
 };
-use thiserror::Error;
 
-use crate::arch::{ExecutionError, ExecutorId, ExecutorInventory};
+use crate::arch::{ExecutionError, ExecutorId, ExecutorInventory, StaticProgramError};
 
 #[cfg(test)]
 pub mod tests;
@@ -159,15 +156,6 @@ impl<F: Field, E> ProgramHandler<F, E> {
             .filter_map(|(i, entry)| entry.is_some().then(|| self.execution_frequencies[i]))
             .collect()
     }
-}
-
-/// Errors in the program that can be statically analyzed before runtime.
-#[derive(Error, Debug)]
-pub enum StaticProgramError {
-    #[error("Too many executors")]
-    TooManyExecutors,
-    #[error("Executor not found for opcode {opcode}")]
-    ExecutorNotFound { opcode: VmOpcode },
 }
 
 // For CPU backend only

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -25,7 +25,7 @@ use crate::{
         get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
         BasicAdapterInterface, E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError,
         InsExecutorE1, InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena,
-        TraceFiller, VmCoreAir, VmSegmentState, VmStateMut,
+        StaticProgramError, TraceFiller, VmCoreAir, VmSegmentState, VmStateMut,
     },
     system::{
         memory::{
@@ -267,7 +267,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -298,7 +298,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/extensions/algebra/circuit/src/lib.rs
+++ b/extensions/algebra/circuit/src/lib.rs
@@ -7,18 +7,16 @@ use derive_more::derive::{Deref, DerefMut};
 use num_bigint::BigUint;
 use openvm_algebra_transpiler::{Fp2Opcode, Rv32ModularArithmeticOpcode};
 use openvm_circuit::{
-    arch::{
-        execution::ExecuteFunc,
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
-        DynArray, E2PreCompute, ExecutionError, InsExecutorE1, InsExecutorE2, Result,
-        VmSegmentState,
-    },
+    arch::*,
     system::memory::{online::GuestMemory, POINTER_MAX_BITS},
 };
 use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives::AlignedBytesBorrow;
-use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
+use openvm_instructions::{
+    instruction::Instruction,
+    program::DEFAULT_PC_STEP,
+    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
+};
 use openvm_mod_circuit_builder::{
     run_field_expression_precomputed, FieldExpr, FieldExpressionStep,
 };
@@ -117,7 +115,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool>
         pc: u32,
         inst: &Instruction<F>,
         data: &mut FieldExpressionPreCompute<'a>,
-    ) -> Result<Option<Operation>> {
+    ) -> Result<Option<Operation>, ExecutionError> {
         let Instruction {
             opcode,
             a,
@@ -213,7 +211,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -310,7 +308,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/extensions/algebra/circuit/src/lib.rs
+++ b/extensions/algebra/circuit/src/lib.rs
@@ -115,7 +115,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool>
         pc: u32,
         inst: &Instruction<F>,
         data: &mut FieldExpressionPreCompute<'a>,
-    ) -> Result<Option<Operation>, ExecutionError> {
+    ) -> Result<Option<Operation>, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -132,7 +132,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool>
         let d = d.as_canonical_u32();
         let e = e.as_canonical_u32();
         if d != RV32_REGISTER_AS || e != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let local_opcode = opcode.local_opcode_idx(self.0.offset);
@@ -211,7 +211,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -308,7 +308,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -479,7 +479,7 @@ impl<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_READ_SIZE: usiz
         pc: u32,
         inst: &Instruction<F>,
         data: &mut ModularIsEqualPreCompute<TOTAL_READ_SIZE>,
-    ) -> Result<bool, ExecutionError> {
+    ) -> Result<bool, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -500,14 +500,14 @@ impl<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_READ_SIZE: usiz
         let d = d.as_canonical_u32();
         let e = e.as_canonical_u32();
         if d != RV32_REGISTER_AS || e != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         if !matches!(
             local_opcode,
             Rv32ModularArithmeticOpcode::IS_EQ | Rv32ModularArithmeticOpcode::SETUP_ISEQ
         ) {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let rs_addrs = from_fn(|i| if i == 0 { b } else { c } as u8);
@@ -538,7 +538,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut ModularIsEqualPreCompute<TOTAL_READ_SIZE> = data.borrow_mut();
 
         let is_setup = self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -568,7 +568,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut E2PreCompute<ModularIsEqualPreCompute<TOTAL_READ_SIZE>> =
             data.borrow_mut();
         pre_compute.chip_idx = chip_idx as u32;

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -6,13 +6,7 @@ use std::{
 use num_bigint::BigUint;
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory, POINTER_MAX_BITS,
@@ -348,7 +342,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode =
@@ -485,7 +479,7 @@ impl<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_READ_SIZE: usiz
         pc: u32,
         inst: &Instruction<F>,
         data: &mut ModularIsEqualPreCompute<TOTAL_READ_SIZE>,
-    ) -> Result<bool> {
+    ) -> Result<bool, ExecutionError> {
         let Instruction {
             opcode,
             a,
@@ -544,7 +538,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let pre_compute: &mut ModularIsEqualPreCompute<TOTAL_READ_SIZE> = data.borrow_mut();
 
         let is_setup = self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -574,7 +568,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let pre_compute: &mut E2PreCompute<ModularIsEqualPreCompute<TOTAL_READ_SIZE>> =
             data.borrow_mut();
         pre_compute.chip_idx = chip_idx as u32;

--- a/extensions/bigint/circuit/src/base_alu.rs
+++ b/extensions/bigint/circuit/src/base_alu.rs
@@ -44,7 +44,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32BaseAlu256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -72,7 +72,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32BaseAlu256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -131,7 +131,7 @@ impl Rv32BaseAlu256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BaseAluPreCompute,
-    ) -> Result<BaseAluOpcode, ExecutionError> {
+    ) -> Result<BaseAluOpcode, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -143,7 +143,7 @@ impl Rv32BaseAlu256Step {
         } = inst;
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = BaseAluPreCompute {
             a: a.as_canonical_u32() as u8,

--- a/extensions/bigint/circuit/src/base_alu.rs
+++ b/extensions/bigint/circuit/src/base_alu.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_bigint_transpiler::Rv32BaseAlu256Opcode;
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2, VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -50,7 +44,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32BaseAlu256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -78,7 +72,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32BaseAlu256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -137,7 +131,7 @@ impl Rv32BaseAlu256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BaseAluPreCompute,
-    ) -> openvm_circuit::arch::Result<BaseAluOpcode> {
+    ) -> Result<BaseAluOpcode, ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/bigint/circuit/src/branch_eq.rs
+++ b/extensions/bigint/circuit/src/branch_eq.rs
@@ -42,7 +42,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32BranchEqual256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -67,7 +67,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32BranchEqual256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -126,7 +126,7 @@ impl Rv32BranchEqual256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchEqPreCompute,
-    ) -> Result<BranchEqualOpcode, ExecutionError> {
+    ) -> Result<BranchEqualOpcode, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -144,7 +144,7 @@ impl Rv32BranchEqual256Step {
         };
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = BranchEqPreCompute {
             imm,

--- a/extensions/bigint/circuit/src/branch_eq.rs
+++ b/extensions/bigint/circuit/src/branch_eq.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_bigint_transpiler::Rv32BranchEqual256Opcode;
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2, VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -48,7 +42,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32BranchEqual256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -73,7 +67,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32BranchEqual256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -132,7 +126,7 @@ impl Rv32BranchEqual256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchEqPreCompute,
-    ) -> openvm_circuit::arch::Result<BranchEqualOpcode> {
+    ) -> Result<BranchEqualOpcode, ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/bigint/circuit/src/branch_lt.rs
+++ b/extensions/bigint/circuit/src/branch_lt.rs
@@ -45,7 +45,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32BranchLessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -72,7 +72,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32BranchLessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -132,7 +132,7 @@ impl Rv32BranchLessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchLtPreCompute,
-    ) -> Result<BranchLessThanOpcode, ExecutionError> {
+    ) -> Result<BranchLessThanOpcode, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -150,7 +150,7 @@ impl Rv32BranchLessThan256Step {
         };
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = BranchLtPreCompute {
             imm,

--- a/extensions/bigint/circuit/src/branch_lt.rs
+++ b/extensions/bigint/circuit/src/branch_lt.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_bigint_transpiler::Rv32BranchLessThan256Opcode;
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2, VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -51,7 +45,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32BranchLessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -78,7 +72,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32BranchLessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -138,7 +132,7 @@ impl Rv32BranchLessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchLtPreCompute,
-    ) -> openvm_circuit::arch::Result<BranchLessThanOpcode> {
+    ) -> Result<BranchLessThanOpcode, ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/bigint/circuit/src/less_than.rs
+++ b/extensions/bigint/circuit/src/less_than.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_bigint_transpiler::Rv32LessThan256Opcode;
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2, VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -48,7 +42,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32LessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -73,7 +67,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32LessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -136,7 +130,7 @@ impl Rv32LessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LessThanPreCompute,
-    ) -> Result<LessThanOpcode, ExecutionError> {
+    ) -> Result<LessThanOpcode, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -148,7 +142,7 @@ impl Rv32LessThan256Step {
         } = inst;
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = LessThanPreCompute {
             a: a.as_canonical_u32() as u8,

--- a/extensions/bigint/circuit/src/less_than.rs
+++ b/extensions/bigint/circuit/src/less_than.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32LessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -73,7 +73,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32LessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -136,7 +136,7 @@ impl Rv32LessThan256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LessThanPreCompute,
-    ) -> openvm_circuit::arch::Result<LessThanOpcode> {
+    ) -> Result<LessThanOpcode, ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/bigint/circuit/src/mult.rs
+++ b/extensions/bigint/circuit/src/mult.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_bigint_transpiler::Rv32Mul256Opcode;
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2, VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -48,7 +42,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32Multiplication256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -69,7 +63,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32Multiplication256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -122,7 +116,7 @@ impl Rv32Multiplication256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut MultPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -134,7 +128,7 @@ impl Rv32Multiplication256Step {
         } = inst;
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         let local_opcode =
             MulOpcode::from_usize(opcode.local_opcode_idx(Rv32Mul256Opcode::CLASS_OFFSET));

--- a/extensions/bigint/circuit/src/mult.rs
+++ b/extensions/bigint/circuit/src/mult.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32Multiplication256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -69,7 +69,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32Multiplication256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -122,7 +122,7 @@ impl Rv32Multiplication256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut MultPreCompute,
-    ) -> openvm_circuit::arch::Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/bigint/circuit/src/shift.rs
+++ b/extensions/bigint/circuit/src/shift.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_bigint_transpiler::Rv32Shift256Opcode;
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2, VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -48,7 +42,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32Shift256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -74,7 +68,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32Shift256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -130,7 +124,7 @@ impl Rv32Shift256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut ShiftPreCompute,
-    ) -> Result<ShiftOpcode, ExecutionError> {
+    ) -> Result<ShiftOpcode, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -142,7 +136,7 @@ impl Rv32Shift256Step {
         } = inst;
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = ShiftPreCompute {
             a: a.as_canonical_u32() as u8,

--- a/extensions/bigint/circuit/src/shift.rs
+++ b/extensions/bigint/circuit/src/shift.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Rv32Shift256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -74,7 +74,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Rv32Shift256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> openvm_circuit::arch::Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -130,7 +130,7 @@ impl Rv32Shift256Step {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut ShiftPreCompute,
-    ) -> openvm_circuit::arch::Result<ShiftOpcode> {
+    ) -> Result<ShiftOpcode, ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/ecc/circuit/src/weierstrass_chip/add_ne.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/add_ne.rs
@@ -159,7 +159,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize> EcAddNeStep<BLOCKS, BLOCK
         pc: u32,
         inst: &Instruction<F>,
         data: &mut EcAddNePreCompute<'a>,
-    ) -> Result<bool, ExecutionError> {
+    ) -> Result<bool, StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -177,7 +177,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize> EcAddNeStep<BLOCKS, BLOCK
         let d = d.as_canonical_u32();
         let e = e.as_canonical_u32();
         if d != RV32_REGISTER_AS || e != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let local_opcode = opcode.local_opcode_idx(self.offset);
@@ -227,7 +227,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -292,7 +292,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/extensions/ecc/circuit/src/weierstrass_chip/add_ne.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/add_ne.rs
@@ -9,14 +9,7 @@ use derive_more::derive::{Deref, DerefMut};
 use num_bigint::BigUint;
 use openvm_algebra_circuit::fields::{get_field_type, FieldType};
 use openvm_circuit::{
-    arch::{
-        execution::ExecuteFunc,
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
-        DynArray, E2PreCompute, ExecutionBridge,
-        ExecutionError::{self, InvalidInstruction},
-        InsExecutorE1, InsExecutorE2, Result, VmSegmentState,
-    },
+    arch::*,
     system::memory::{
         offline_checker::MemoryBridge, online::GuestMemory, SharedMemoryHelper, POINTER_MAX_BITS,
     },
@@ -29,7 +22,9 @@ use openvm_circuit_primitives::{
 };
 use openvm_ecc_transpiler::Rv32WeierstrassOpcode;
 use openvm_instructions::{
-    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_CELL_BITS,
+    instruction::Instruction,
+    program::DEFAULT_PC_STEP,
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS},
 };
 use openvm_mod_circuit_builder::{
     run_field_expression_precomputed, ExprBuilder, ExprBuilderConfig, FieldExpr,
@@ -164,7 +159,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize> EcAddNeStep<BLOCKS, BLOCK
         pc: u32,
         inst: &Instruction<F>,
         data: &mut EcAddNePreCompute<'a>,
-    ) -> Result<bool> {
+    ) -> Result<bool, ExecutionError> {
         let Instruction {
             opcode,
             a,
@@ -182,7 +177,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize> EcAddNeStep<BLOCKS, BLOCK
         let d = d.as_canonical_u32();
         let e = e.as_canonical_u32();
         if d != RV32_REGISTER_AS || e != RV32_MEMORY_AS {
-            return Err(InvalidInstruction(pc));
+            return Err(ExecutionError::InvalidInstruction(pc));
         }
 
         let local_opcode = opcode.local_opcode_idx(self.offset);
@@ -232,7 +227,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -297,7 +292,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -15,7 +15,7 @@ use openvm_circuit::{
         instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
         DynArray, E2PreCompute, ExecutionBridge,
         ExecutionError::{self, InvalidInstruction},
-        InsExecutorE1, InsExecutorE2, Result, VmSegmentState,
+        InsExecutorE1, InsExecutorE2, VmSegmentState,
     },
     system::memory::{
         offline_checker::MemoryBridge, online::GuestMemory, SharedMemoryHelper, POINTER_MAX_BITS,
@@ -175,7 +175,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize> EcDoubleStep<BLOCKS, BLOC
         pc: u32,
         inst: &Instruction<F>,
         data: &mut EcDoublePreCompute<'a>,
-    ) -> Result<bool> {
+    ) -> Result<bool, ExecutionError> {
         let Instruction {
             opcode, a, b, d, e, ..
         } = inst;
@@ -236,7 +236,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -285,7 +285,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -9,14 +9,7 @@ use derive_more::derive::{Deref, DerefMut};
 use num_bigint::BigUint;
 use num_traits::One;
 use openvm_circuit::{
-    arch::{
-        execution::ExecuteFunc,
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
-        DynArray, E2PreCompute, ExecutionBridge,
-        ExecutionError::{self, InvalidInstruction},
-        InsExecutorE1, InsExecutorE2, VmSegmentState,
-    },
+    arch::*,
     system::memory::{
         offline_checker::MemoryBridge, online::GuestMemory, SharedMemoryHelper, POINTER_MAX_BITS,
     },
@@ -29,7 +22,9 @@ use openvm_circuit_primitives::{
 };
 use openvm_ecc_transpiler::Rv32WeierstrassOpcode;
 use openvm_instructions::{
-    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_CELL_BITS,
+    instruction::Instruction,
+    program::DEFAULT_PC_STEP,
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS},
 };
 use openvm_mod_circuit_builder::{
     run_field_expression_precomputed, ExprBuilder, ExprBuilderConfig, FieldExpr,
@@ -175,7 +170,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize> EcDoubleStep<BLOCKS, BLOC
         pc: u32,
         inst: &Instruction<F>,
         data: &mut EcDoublePreCompute<'a>,
-    ) -> Result<bool, ExecutionError> {
+    ) -> Result<bool, StaticProgramError> {
         let Instruction {
             opcode, a, b, d, e, ..
         } = inst;
@@ -186,7 +181,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize> EcDoubleStep<BLOCKS, BLOC
         let d = d.as_canonical_u32();
         let e = e.as_canonical_u32();
         if d != RV32_REGISTER_AS || e != RV32_MEMORY_AS {
-            return Err(InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let local_opcode = opcode.local_opcode_idx(self.offset);
@@ -236,7 +231,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -285,7 +280,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize> InsExecutorE
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {

--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -17,14 +17,7 @@ mod extension;
 mod tests;
 pub use air::KeccakVmAir;
 pub use extension::*;
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionBridge, ExecutionError, InsExecutorE1, InsExecutorE2,
-        Result, VmChipWrapper, VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
@@ -99,7 +92,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for KeccakVmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -120,7 +113,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for KeccakVmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -195,7 +188,7 @@ impl KeccakVmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut KeccakPreCompute,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -92,7 +92,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for KeccakVmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -113,7 +113,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for KeccakVmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -188,7 +188,7 @@ impl KeccakVmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut KeccakPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -200,7 +200,7 @@ impl KeccakVmStep {
         } = inst;
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = KeccakPreCompute {
             a: a.as_canonical_u32() as u8,

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -5,10 +5,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        get_record_from_slice, CustomBorrow, InstructionExecutor, MultiRowLayout, MultiRowMetadata,
-        RecordArena, Result, SizedRecord, TraceFiller, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         offline_checker::{MemoryReadAuxRecord, MemoryWriteBytesAuxRecord},
         online::TracingMemory,
@@ -141,7 +138,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let &Instruction {
             opcode,
             a,

--- a/extensions/native/circuit/src/branch_eq/core.rs
+++ b/extensions/native/circuit/src/branch_eq/core.rs
@@ -1,12 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterTraceFiller, AdapterTraceStep, E2PreCompute,
-        EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2,
-        InstructionExecutor, RecordArena, TraceFiller, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -133,7 +128,7 @@ impl<A> NativeBranchEqualStep<A> {
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut NativeBranchEqualPreCompute,
-    ) -> Result<(bool, bool, bool), ExecutionError> {
+    ) -> Result<(bool, bool, bool), StaticProgramError> {
         let &Instruction {
             opcode,
             a,
@@ -194,7 +189,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut NativeBranchEqualPreCompute = data.borrow_mut();
 
         let (a_is_imm, b_is_imm, is_bne) = self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -230,7 +225,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut E2PreCompute<NativeBranchEqualPreCompute> = data.borrow_mut();
         pre_compute.chip_idx = chip_idx as u32;
 

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -215,19 +209,19 @@ impl<A> CastFCoreStep<A> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut CastFPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let Instruction {
             a, b, d, e, opcode, ..
         } = inst;
 
         if opcode.local_opcode_idx(CastfOpcode::CLASS_OFFSET) != CastfOpcode::CASTF as usize {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         if d.as_canonical_u32() != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         if e.as_canonical_u32() != AS::Native as u32 {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let a = a.as_canonical_u32();
@@ -253,7 +247,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut CastFPreCompute = data.borrow_mut();
 
         self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -280,7 +274,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut E2PreCompute<CastFPreCompute> = data.borrow_mut();
         pre_compute.chip_idx = chip_idx as u32;
 

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -2,13 +2,7 @@ use std::borrow::{Borrow, BorrowMut};
 
 use itertools::izip;
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -233,7 +227,7 @@ impl<A> FieldArithmeticCoreStep<A> {
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut FieldArithmeticPreCompute,
-    ) -> Result<(bool, bool, FieldArithmeticOpcode), ExecutionError> {
+    ) -> Result<(bool, bool, FieldArithmeticOpcode), StaticProgramError> {
         let &Instruction {
             opcode,
             a,
@@ -293,7 +287,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut FieldArithmeticPreCompute = data.borrow_mut();
 
         let (a_is_imm, b_is_imm, local_opcode) = self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -369,7 +363,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut E2PreCompute<FieldArithmeticPreCompute> = data.borrow_mut();
         pre_compute.chip_idx = chip_idx as u32;
 

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -6,13 +6,7 @@ use std::{
 
 use itertools::izip;
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -258,7 +252,7 @@ impl<A> FieldExtensionCoreStep<A> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut FieldExtensionPreCompute,
-    ) -> Result<u8, ExecutionError> {
+    ) -> Result<u8, StaticProgramError> {
         let &Instruction {
             opcode,
             a,
@@ -280,10 +274,10 @@ impl<A> FieldExtensionCoreStep<A> {
         let e = e.as_canonical_u32();
 
         if d != AS::Native as u32 {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         if e != AS::Native as u32 {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         *data = FieldExtensionPreCompute { a, b, c };
@@ -307,7 +301,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut FieldExtensionPreCompute = data.borrow_mut();
 
         let opcode = self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -340,7 +334,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut E2PreCompute<FieldExtensionPreCompute> = data.borrow_mut();
         pre_compute.chip_idx = chip_idx as u32;
 

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -6,13 +6,7 @@ use std::{
 
 use itertools::zip_eq;
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, CustomBorrow, E2PreCompute, ExecuteFunc, ExecutionBridge,
-        ExecutionError, ExecutionState, InsExecutorE1, InsExecutorE2, InstructionExecutor,
-        MultiRowLayout, MultiRowMetadata, RecordArena, SizedRecord, TraceFiller, VmChipWrapper,
-        VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::{
         memory::{
             offline_checker::{
@@ -1107,7 +1101,7 @@ impl FriReducedOpeningStep {
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut FriReducedOpeningPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let &Instruction {
             a,
             b,
@@ -1156,7 +1150,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut FriReducedOpeningPreCompute = data.borrow_mut();
 
         self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -1182,7 +1176,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut E2PreCompute<FriReducedOpeningPreCompute> = data.borrow_mut();
         pre_compute.chip_idx = chip_idx as u32;
 

--- a/extensions/native/circuit/src/jal_rangecheck/mod.rs
+++ b/extensions/native/circuit/src/jal_rangecheck/mod.rs
@@ -4,12 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, E2PreCompute, EmptyMultiRowLayout, ExecuteFunc, ExecutionBridge,
-        ExecutionError, ExecutionState, InsExecutorE1, InsExecutorE2, InstructionExecutor,
-        PcIncOrSet, RecordArena, TraceFiller, VmChipWrapper, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::{
         memory::{
             offline_checker::{MemoryBridge, MemoryWriteAuxCols, MemoryWriteAuxRecord},
@@ -315,11 +310,11 @@ impl JalRangeCheckStep {
         pc: u32,
         inst: &Instruction<F>,
         jal_data: &mut JalPreCompute<F>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let &Instruction { opcode, a, b, .. } = inst;
 
         if opcode != NativeJalOpcode::JAL.global_opcode() {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let a = a.as_canonical_u32();
@@ -335,20 +330,20 @@ impl JalRangeCheckStep {
         pc: u32,
         inst: &Instruction<F>,
         range_check_data: &mut RangeCheckPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let &Instruction {
             opcode, a, b, c, ..
         } = inst;
 
         if opcode != NativeRangeCheckOpcode::RANGE_CHECK.global_opcode() {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let a = a.as_canonical_u32();
         let b = b.as_canonical_u32();
         let c = c.as_canonical_u32();
         if b > 16 || c > 14 {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         *range_check_data = RangeCheckPreCompute {
@@ -378,7 +373,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let &Instruction { opcode, .. } = inst;
 
         let is_jal = opcode == NativeJalOpcode::JAL.global_opcode();
@@ -414,7 +409,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let &Instruction { opcode, .. } = inst;
 
         let is_jal = opcode == NativeJalOpcode::JAL.global_opcode();

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -1,12 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        CustomBorrow, E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2,
-        InstructionExecutor, MultiRowLayout, MultiRowMetadata, RecordArena, SizedRecord,
-        TraceFiller, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::{
         memory::{
             offline_checker::MemoryBaseAuxCols,
@@ -855,7 +850,7 @@ impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SB
         pc: u32,
         inst: &Instruction<F>,
         pos2_data: &mut Pos2PreCompute<'a, F, SBOX_REGISTERS>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let &Instruction {
             opcode,
             a,
@@ -867,7 +862,7 @@ impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SB
         } = inst;
 
         if opcode != PERM_POS2.global_opcode() && opcode != COMP_POS2.global_opcode() {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let a = a.as_canonical_u32();
@@ -877,10 +872,10 @@ impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SB
         let e = e.as_canonical_u32();
 
         if d != AS::Native as u32 {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         if e != AS::Native as u32 {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         *pos2_data = Pos2PreCompute {
@@ -899,7 +894,7 @@ impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SB
         pc: u32,
         inst: &Instruction<F>,
         verify_batch_data: &mut VerifyBatchPreCompute<'a, F, SBOX_REGISTERS>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let &Instruction {
             opcode,
             a,
@@ -913,7 +908,7 @@ impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SB
         } = inst;
 
         if opcode != VERIFY_BATCH.global_opcode() {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let a = a.as_canonical_u32();
@@ -962,7 +957,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> InsExecutorE1<F>
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let &Instruction { opcode, .. } = inst;
 
         let is_pos2 = opcode == PERM_POS2.global_opcode() || opcode == COMP_POS2.global_opcode();
@@ -1002,7 +997,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> InsExecutorE2<F>
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let &Instruction { opcode, .. } = inst;
 
         let is_pos2 = opcode == PERM_POS2.global_opcode() || opcode == COMP_POS2.global_opcode();

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -152,7 +152,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> openvm_circuit::arch::Result<()> {
+    ) -> Result<(), ExecutionError> {
         let arena = state.ctx;
         let init_timestamp_u32 = state.memory.timestamp;
         if instruction.opcode == PERM_POS2.global_opcode()

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, ImmInstruction,
-        InsExecutorE1, InsExecutorE2, InstructionExecutor, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -235,7 +229,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);
@@ -318,7 +312,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut AuiPcPreCompute = data.borrow_mut();
         self.pre_compute_impl(pc, inst, data)?;
         Ok(|pre_compute, vm_state| {
@@ -356,7 +350,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -381,7 +375,7 @@ impl<A> Rv32AuipcStep<A> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut AuiPcPreCompute,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { a, c: imm, d, .. } = inst;
         if d.as_canonical_u32() != RV32_REGISTER_AS {
             return Err(ExecutionError::InvalidInstruction(pc));

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -312,7 +312,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut AuiPcPreCompute = data.borrow_mut();
         self.pre_compute_impl(pc, inst, data)?;
         Ok(|pre_compute, vm_state| {
@@ -350,7 +350,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -375,10 +375,10 @@ impl<A> Rv32AuipcStep<A> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut AuiPcPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let Instruction { a, c: imm, d, .. } = inst;
         if d.as_canonical_u32() != RV32_REGISTER_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         let imm = imm.as_canonical_u32();
         let data: &mut AuiPcPreCompute = data.borrow_mut();

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -319,7 +319,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -404,7 +404,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -440,13 +440,13 @@ impl<A, const LIMB_BITS: usize> BaseAluStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BaseAluPreCompute,
-    ) -> Result<bool, ExecutionError> {
+    ) -> Result<bool, StaticProgramError> {
         let Instruction { a, b, c, d, e, .. } = inst;
         let e_u32 = e.as_canonical_u32();
         if (d.as_canonical_u32() != RV32_REGISTER_AS)
             || !(e_u32 == RV32_IMM_AS || e_u32 == RV32_REGISTER_AS)
         {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         let is_imm = e_u32 == RV32_IMM_AS;
         let c_u32 = c.as_canonical_u32();

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -5,13 +5,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -227,7 +221,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = BaseAluOpcode::from_usize(opcode.local_opcode_idx(self.offset));
@@ -325,7 +319,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -410,7 +404,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -446,7 +440,7 @@ impl<A, const LIMB_BITS: usize> BaseAluStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BaseAluPreCompute,
-    ) -> Result<bool> {
+    ) -> Result<bool, ExecutionError> {
         let Instruction { a, b, c, d, e, .. } = inst;
         let e_u32 = e.as_canonical_u32();
         if (d.as_canonical_u32() != RV32_REGISTER_AS)

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -263,7 +263,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut BranchEqualPreCompute = data.borrow_mut();
         let is_bne = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = if is_bne {
@@ -289,7 +289,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -346,7 +346,7 @@ impl<A, const NUM_LIMBS: usize> BranchEqualStep<A, NUM_LIMBS> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchEqualPreCompute,
-    ) -> Result<bool, ExecutionError> {
+    ) -> Result<bool, StaticProgramError> {
         let data: &mut BranchEqualPreCompute = data.borrow_mut();
         let &Instruction {
             opcode, a, b, c, d, ..
@@ -359,7 +359,7 @@ impl<A, const NUM_LIMBS: usize> BranchEqualStep<A, NUM_LIMBS> {
             c as isize
         };
         if d.as_canonical_u32() != RV32_REGISTER_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = BranchEqualPreCompute {
             imm,

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, ImmInstruction,
-        InsExecutorE1, InsExecutorE2, InstructionExecutor, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -184,7 +178,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let branch_eq_opcode = BranchEqualOpcode::from_usize(opcode.local_opcode_idx(self.offset));
@@ -269,7 +263,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut BranchEqualPreCompute = data.borrow_mut();
         let is_bne = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = if is_bne {
@@ -295,7 +289,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -352,7 +346,7 @@ impl<A, const NUM_LIMBS: usize> BranchEqualStep<A, NUM_LIMBS> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchEqualPreCompute,
-    ) -> Result<bool> {
+    ) -> Result<bool, ExecutionError> {
         let data: &mut BranchEqualPreCompute = data.borrow_mut();
         let &Instruction {
             opcode, a, b, c, d, ..

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -380,7 +380,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut BranchLePreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = match local_opcode {
@@ -407,7 +407,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -468,7 +468,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchLePreCompute,
-    ) -> Result<BranchLessThanOpcode, ExecutionError> {
+    ) -> Result<BranchLessThanOpcode, StaticProgramError> {
         let &Instruction {
             opcode, a, b, c, d, ..
         } = inst;
@@ -480,7 +480,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
             c as isize
         };
         if d.as_canonical_u32() != RV32_REGISTER_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = BranchLePreCompute {
             imm,

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, ImmInstruction,
-        InsExecutorE1, InsExecutorE2, InstructionExecutor, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -241,7 +235,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
@@ -386,7 +380,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut BranchLePreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = match local_opcode {
@@ -413,7 +407,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -474,7 +468,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
         pc: u32,
         inst: &Instruction<F>,
         data: &mut BranchLePreCompute,
-    ) -> Result<BranchLessThanOpcode> {
+    ) -> Result<BranchLessThanOpcode, ExecutionError> {
         let &Instruction {
             opcode, a, b, c, d, ..
         } = inst;

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -593,7 +593,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut DivRemPreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = match local_opcode {
@@ -621,7 +621,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -676,13 +676,13 @@ impl<A, const LIMB_BITS: usize> DivRemStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_
         pc: u32,
         inst: &Instruction<F>,
         data: &mut DivRemPreCompute,
-    ) -> Result<DivRemOpcode, ExecutionError> {
+    ) -> Result<DivRemOpcode, StaticProgramError> {
         let &Instruction {
             opcode, a, b, c, d, ..
         } = inst;
         let local_opcode = DivRemOpcode::from_usize(opcode.local_opcode_idx(self.offset));
         if d.as_canonical_u32() != RV32_REGISTER_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         let pre_compute: &mut DivRemPreCompute = data.borrow_mut();
         *pre_compute = DivRemPreCompute {

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -6,13 +6,7 @@ use std::{
 use num_bigint::BigUint;
 use num_integer::Integer;
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -438,7 +432,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
@@ -599,7 +593,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut DivRemPreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = match local_opcode {
@@ -627,7 +621,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -682,7 +676,7 @@ impl<A, const LIMB_BITS: usize> DivRemStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_
         pc: u32,
         inst: &Instruction<F>,
         data: &mut DivRemPreCompute,
-    ) -> Result<DivRemOpcode> {
+    ) -> Result<DivRemOpcode, ExecutionError> {
         let &Instruction {
             opcode, a, b, c, d, ..
         } = inst;

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -602,7 +602,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut HintStorePreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_impl(pc, inst, pre_compute)?;
         let fn_ptr = match local_opcode {
@@ -627,7 +627,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -711,7 +711,7 @@ impl Rv32HintStoreStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut HintStorePreCompute,
-    ) -> Result<Rv32HintStoreOpcode, ExecutionError> {
+    ) -> Result<Rv32HintStoreOpcode, StaticProgramError> {
         let &Instruction {
             opcode,
             a,
@@ -722,7 +722,7 @@ impl Rv32HintStoreStep {
             ..
         } = inst;
         if d.as_canonical_u32() != RV32_REGISTER_AS || e.as_canonical_u32() != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = {
             HintStorePreCompute {

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, CustomBorrow, E2PreCompute, ExecuteFunc, ExecutionBridge,
-        ExecutionError, ExecutionState, InsExecutorE1, InsExecutorE2, InstructionExecutor,
-        MultiRowLayout, MultiRowMetadata, RecordArena, Result, SizedRecord, TraceFiller,
-        VmChipWrapper, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         offline_checker::{
             MemoryBridge, MemoryReadAuxCols, MemoryReadAuxRecord, MemoryWriteAuxCols,
@@ -381,7 +375,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let &Instruction {
             opcode, a, b, d, e, ..
         } = instruction;
@@ -608,7 +602,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let pre_compute: &mut HintStorePreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_impl(pc, inst, pre_compute)?;
         let fn_ptr = match local_opcode {
@@ -633,7 +627,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -717,7 +711,7 @@ impl Rv32HintStoreStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut HintStorePreCompute,
-    ) -> Result<Rv32HintStoreOpcode> {
+    ) -> Result<Rv32HintStoreOpcode, ExecutionError> {
         let &Instruction {
             opcode,
             a,

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -261,7 +261,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut JalLuiPreCompute = data.borrow_mut();
         let (is_jal, enabled) = self.pre_compute_impl(inst, data)?;
         let fn_ptr = match (is_jal, enabled) {
@@ -288,7 +288,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -372,7 +372,7 @@ impl<A> Rv32JalLuiStep<A> {
         &self,
         inst: &Instruction<F>,
         data: &mut JalLuiPreCompute,
-    ) -> Result<(bool, bool), ExecutionError> {
+    ) -> Result<(bool, bool), StaticProgramError> {
         let local_opcode = Rv32JalLuiOpcode::from_usize(
             inst.opcode.local_opcode_idx(Rv32JalLuiOpcode::CLASS_OFFSET),
         );

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -1,13 +1,7 @@
 use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ImmInstruction, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, RecordArena, Result, TraceFiller, VmAdapterInterface,
-        VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -193,7 +187,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let &Instruction { opcode, c: imm, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
@@ -267,7 +261,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut JalLuiPreCompute = data.borrow_mut();
         let (is_jal, enabled) = self.pre_compute_impl(inst, data)?;
         let fn_ptr = match (is_jal, enabled) {
@@ -294,7 +288,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -378,7 +372,7 @@ impl<A> Rv32JalLuiStep<A> {
         &self,
         inst: &Instruction<F>,
         data: &mut JalLuiPreCompute,
-    ) -> Result<(bool, bool)> {
+    ) -> Result<(bool, bool), ExecutionError> {
         let local_opcode = Rv32JalLuiOpcode::from_usize(
             inst.opcode.local_opcode_idx(Rv32JalLuiOpcode::CLASS_OFFSET),
         );

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, RecordArena, Result, SignedImmInstruction, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -242,7 +236,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, c, g, .. } = *instruction;
 
         debug_assert_eq!(
@@ -348,7 +342,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut JalrPreCompute = data.borrow_mut();
         let enabled = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = if enabled {
@@ -374,7 +368,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -436,7 +430,7 @@ impl<A> Rv32JalrStep<A> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut JalrPreCompute,
-    ) -> Result<bool> {
+    ) -> Result<bool, ExecutionError> {
         let imm_extended = inst.c.as_canonical_u32() + inst.g.as_canonical_u32() * 0xffff0000;
         if inst.d.as_canonical_u32() != RV32_REGISTER_AS {
             return Err(ExecutionError::InvalidInstruction(pc));

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -342,7 +342,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut JalrPreCompute = data.borrow_mut();
         let enabled = self.pre_compute_impl(pc, inst, data)?;
         let fn_ptr = if enabled {
@@ -368,7 +368,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -430,10 +430,10 @@ impl<A> Rv32JalrStep<A> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut JalrPreCompute,
-    ) -> Result<bool, ExecutionError> {
+    ) -> Result<bool, StaticProgramError> {
         let imm_extended = inst.c.as_canonical_u32() + inst.g.as_canonical_u32() * 0xffff0000;
         if inst.d.as_canonical_u32() != RV32_REGISTER_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = JalrPreCompute {
             imm_extended,

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -359,7 +359,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut LessThanPreCompute = data.borrow_mut();
         let (is_imm, is_sltu) = self.pre_compute_impl(pc, inst, pre_compute)?;
         let fn_ptr = match (is_imm, is_sltu) {
@@ -387,7 +387,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -467,7 +467,7 @@ impl<A, const LIMB_BITS: usize> LessThanStep<A, { RV32_REGISTER_NUM_LIMBS }, LIM
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LessThanPreCompute,
-    ) -> Result<(bool, bool), ExecutionError> {
+    ) -> Result<(bool, bool), StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -481,7 +481,7 @@ impl<A, const LIMB_BITS: usize> LessThanStep<A, { RV32_REGISTER_NUM_LIMBS }, LIM
         if d.as_canonical_u32() != RV32_REGISTER_AS
             || !(e_u32 == RV32_IMM_AS || e_u32 == RV32_REGISTER_AS)
         {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         let local_opcode = LessThanOpcode::from_usize(opcode.local_opcode_idx(self.offset));
         let is_imm = e_u32 == RV32_IMM_AS;

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -226,7 +220,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         debug_assert!(LIMB_BITS <= 8);
         let Instruction { opcode, .. } = instruction;
 
@@ -365,7 +359,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let pre_compute: &mut LessThanPreCompute = data.borrow_mut();
         let (is_imm, is_sltu) = self.pre_compute_impl(pc, inst, pre_compute)?;
         let fn_ptr = match (is_imm, is_sltu) {
@@ -393,7 +387,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -473,7 +467,7 @@ impl<A, const LIMB_BITS: usize> LessThanStep<A, { RV32_REGISTER_NUM_LIMBS }, LIM
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LessThanPreCompute,
-    ) -> Result<(bool, bool)> {
+    ) -> Result<(bool, bool), ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -327,7 +327,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut LoadSignExtendPreCompute = data.borrow_mut();
         let (is_loadb, enabled) = self.pre_compute_impl(pc, inst, pre_compute)?;
         let fn_ptr = match (is_loadb, enabled) {
@@ -355,7 +355,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -450,7 +450,7 @@ impl<A, const LIMB_BITS: usize> LoadSignExtendStep<A, { RV32_REGISTER_NUM_LIMBS 
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LoadSignExtendPreCompute,
-    ) -> Result<(bool, bool), ExecutionError> {
+    ) -> Result<(bool, bool), StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -465,7 +465,7 @@ impl<A, const LIMB_BITS: usize> LoadSignExtendStep<A, { RV32_REGISTER_NUM_LIMBS 
 
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 == RV32_IMM_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, RecordArena, Result, TraceFiller, VmAdapterInterface,
-        VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory, POINTER_MAX_BITS,
@@ -233,7 +227,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
@@ -333,7 +327,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let pre_compute: &mut LoadSignExtendPreCompute = data.borrow_mut();
         let (is_loadb, enabled) = self.pre_compute_impl(pc, inst, pre_compute)?;
         let fn_ptr = match (is_loadb, enabled) {
@@ -361,7 +355,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -456,7 +450,7 @@ impl<A, const LIMB_BITS: usize> LoadSignExtendStep<A, { RV32_REGISTER_NUM_LIMBS 
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LoadSignExtendPreCompute,
-    ) -> Result<(bool, bool)> {
+    ) -> Result<(bool, bool), ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -5,13 +5,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, RecordArena, Result, TraceFiller, VmAdapterInterface,
-        VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory, POINTER_MAX_BITS,
@@ -300,7 +294,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
@@ -403,7 +397,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let pre_compute: &mut LoadStorePreCompute = data.borrow_mut();
         let (local_opcode, enabled, is_native_store) =
             self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -446,7 +440,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -567,7 +561,7 @@ impl<A, const NUM_CELLS: usize> LoadStoreStep<A, NUM_CELLS> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LoadStorePreCompute,
-    ) -> Result<(Rv32LoadStoreOpcode, bool, bool)> {
+    ) -> Result<(Rv32LoadStoreOpcode, bool, bool), ExecutionError> {
         let Instruction {
             opcode,
             a,

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -397,7 +397,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut LoadStorePreCompute = data.borrow_mut();
         let (local_opcode, enabled, is_native_store) =
             self.pre_compute_impl(pc, inst, pre_compute)?;
@@ -440,7 +440,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -561,7 +561,7 @@ impl<A, const NUM_CELLS: usize> LoadStoreStep<A, NUM_CELLS> {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut LoadStorePreCompute,
-    ) -> Result<(Rv32LoadStoreOpcode, bool, bool), ExecutionError> {
+    ) -> Result<(Rv32LoadStoreOpcode, bool, bool), StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -577,7 +577,7 @@ impl<A, const NUM_CELLS: usize> LoadStoreStep<A, NUM_CELLS> {
 
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 == RV32_IMM_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
@@ -587,7 +587,7 @@ impl<A, const NUM_CELLS: usize> LoadStoreStep<A, NUM_CELLS> {
             LOADW | LOADBU | LOADHU => {}
             STOREW | STOREH | STOREB => {
                 if !enabled {
-                    return Err(ExecutionError::InvalidInstruction(pc));
+                    return Err(StaticProgramError::InvalidInstruction(pc));
                 }
             }
             _ => unreachable!("LoadStoreStep should not handle LOADB/LOADH opcodes"),

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -201,7 +195,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         debug_assert_eq!(
@@ -279,7 +273,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -304,7 +298,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -358,7 +352,7 @@ impl<A, const LIMB_BITS: usize> MultiplicationStep<A, { RV32_REGISTER_NUM_LIMBS 
         pc: u32,
         inst: &Instruction<F>,
         data: &mut MultiPreCompute,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         assert_eq!(
             MulOpcode::from_usize(inst.opcode.local_opcode_idx(self.offset)),
             MulOpcode::MUL

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -273,7 +273,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -298,7 +298,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -352,13 +352,13 @@ impl<A, const LIMB_BITS: usize> MultiplicationStep<A, { RV32_REGISTER_NUM_LIMBS 
         pc: u32,
         inst: &Instruction<F>,
         data: &mut MultiPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         assert_eq!(
             MulOpcode::from_usize(inst.opcode.local_opcode_idx(self.offset)),
             MulOpcode::MUL
         );
         if inst.d.as_canonical_u32() != RV32_REGISTER_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
 
         *data = MultiPreCompute {

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, InsExecutorE1, InsExecutorE2,
-        InstructionExecutor, MinimalInstruction, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -274,7 +268,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
@@ -378,7 +372,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let pre_compute: &mut MulHPreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_e1(inst, pre_compute)?;
         let fn_ptr = match local_opcode {
@@ -405,7 +399,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>>
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -462,7 +456,7 @@ impl<A, const LIMB_BITS: usize> MulHStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BI
         &self,
         inst: &Instruction<F>,
         data: &mut MulHPreCompute,
-    ) -> Result<MulHOpcode> {
+    ) -> Result<MulHOpcode, ExecutionError> {
         *data = MulHPreCompute {
             a: inst.a.as_canonical_u32() as u8,
             b: inst.b.as_canonical_u32() as u8,

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -372,7 +372,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let pre_compute: &mut MulHPreCompute = data.borrow_mut();
         let local_opcode = self.pre_compute_e1(inst, pre_compute)?;
         let fn_ptr = match local_opcode {
@@ -399,7 +399,7 @@ where
         _pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -456,7 +456,7 @@ impl<A, const LIMB_BITS: usize> MulHStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BI
         &self,
         inst: &Instruction<F>,
         data: &mut MulHPreCompute,
-    ) -> Result<MulHOpcode, ExecutionError> {
+    ) -> Result<MulHOpcode, StaticProgramError> {
         *data = MulHPreCompute {
             a: inst.a.as_canonical_u32() as u8,
             b: inst.b.as_canonical_u32() as u8,

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -4,13 +4,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
-        E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MinimalInstruction, RecordArena, Result, TraceFiller,
-        VmAdapterInterface, VmCoreAir, VmSegmentState, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         online::{GuestMemory, TracingMemory},
         MemoryAuxColsFactory,
@@ -327,7 +321,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction { opcode, .. } = instruction;
 
         let local_opcode = ShiftOpcode::from_usize(opcode.local_opcode_idx(self.offset));
@@ -459,7 +453,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut ShiftPreCompute = data.borrow_mut();
         let (is_imm, shift_opcode) = self.pre_compute_impl(pc, inst, data)?;
         // `d` is always expected to be RV32_REGISTER_AS.
@@ -491,7 +485,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>> {
+    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
         let data: &mut E2PreCompute<ShiftPreCompute> = data.borrow_mut();
         data.chip_idx = chip_idx as u32;
         let (is_imm, shift_opcode) = self.pre_compute_impl(pc, inst, &mut data.data)?;
@@ -558,7 +552,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, 
         pc: u32,
         inst: &Instruction<F>,
         data: &mut ShiftPreCompute,
-    ) -> Result<(bool, ShiftOpcode)> {
+    ) -> Result<(bool, ShiftOpcode), ExecutionError> {
         let Instruction {
             opcode, a, b, c, e, ..
         } = inst;

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -453,7 +453,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut ShiftPreCompute = data.borrow_mut();
         let (is_imm, shift_opcode) = self.pre_compute_impl(pc, inst, data)?;
         // `d` is always expected to be RV32_REGISTER_AS.
@@ -485,7 +485,7 @@ where
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError> {
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError> {
         let data: &mut E2PreCompute<ShiftPreCompute> = data.borrow_mut();
         data.chip_idx = chip_idx as u32;
         let (is_imm, shift_opcode) = self.pre_compute_impl(pc, inst, &mut data.data)?;
@@ -552,7 +552,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, 
         pc: u32,
         inst: &Instruction<F>,
         data: &mut ShiftPreCompute,
-    ) -> Result<(bool, ShiftOpcode), ExecutionError> {
+    ) -> Result<(bool, ShiftOpcode), StaticProgramError> {
         let Instruction {
             opcode, a, b, c, e, ..
         } = inst;
@@ -561,7 +561,7 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, 
         if inst.d.as_canonical_u32() != RV32_REGISTER_AS
             || !(e_u32 == RV32_IMM_AS || e_u32 == RV32_REGISTER_AS)
         {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         let is_imm = e_u32 == RV32_IMM_AS;
         let c_u32 = c.as_canonical_u32();

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -3,14 +3,7 @@
 
 use std::borrow::{Borrow, BorrowMut};
 
-use openvm_circuit::{
-    arch::{
-        execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        E2PreCompute, ExecuteFunc, ExecutionError, InsExecutorE1, InsExecutorE2, VmChipWrapper,
-        VmSegmentState,
-    },
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives::{
     bitwise_op_lookup::SharedBitwiseOperationLookupChip, encoder::Encoder, AlignedBytesBorrow,
 };
@@ -99,7 +92,7 @@ impl<F: PrimeField32> InsExecutorE1<F> for Sha256VmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E1ExecutionCtx,
     {
@@ -119,7 +112,7 @@ impl<F: PrimeField32> InsExecutorE2<F> for Sha256VmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut [u8],
-    ) -> Result<ExecuteFunc<F, Ctx>, ExecutionError>
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
     where
         Ctx: E2ExecutionCtx,
     {
@@ -196,7 +189,7 @@ impl Sha256VmStep {
         pc: u32,
         inst: &Instruction<F>,
         data: &mut ShaPreCompute,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), StaticProgramError> {
         let Instruction {
             opcode,
             a,
@@ -208,7 +201,7 @@ impl Sha256VmStep {
         } = inst;
         let e_u32 = e.as_canonical_u32();
         if d.as_canonical_u32() != RV32_REGISTER_AS || e_u32 != RV32_MEMORY_AS {
-            return Err(ExecutionError::InvalidInstruction(pc));
+            return Err(StaticProgramError::InvalidInstruction(pc));
         }
         *data = ShaPreCompute {
             a: a.as_canonical_u32() as u8,

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -5,10 +5,7 @@ use std::{
 };
 
 use openvm_circuit::{
-    arch::{
-        get_record_from_slice, CustomBorrow, InstructionExecutor, MultiRowLayout, MultiRowMetadata,
-        RecordArena, Result, SizedRecord, TraceFiller, VmStateMut,
-    },
+    arch::*,
     system::memory::{
         offline_checker::{MemoryReadAuxRecord, MemoryWriteBytesAuxRecord},
         online::TracingMemory,
@@ -151,7 +148,7 @@ where
         &mut self,
         state: VmStateMut<F, TracingMemory, RA>,
         instruction: &Instruction<F>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecutionError> {
         let Instruction {
             opcode,
             a,


### PR DESCRIPTION
Remove `arch::execution::Result = Result<_, ExecutionError>` because our `use execution::*` makes it a confusing `arch::Result` typedef.

Moreover all `pre_compute` functions should return `StaticProgramError` to distinguish from `ExecutionError` which is for runtime errors.