### PR TITLE
chore(perf): use constant for address space in `tracing_read` when possible

### DIFF
--- a/crates/toolchain/instructions/src/lib.rs
+++ b/crates/toolchain/instructions/src/lib.rs
@@ -41,6 +41,7 @@ pub struct VmOpcode(usize);
 
 impl VmOpcode {
     /// Returns the corresponding `local_opcode_idx`
+    #[inline(always)]
     pub const fn local_opcode_idx(&self, offset: usize) -> usize {
         self.as_usize() - offset
     }

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -218,7 +218,7 @@ where
                 let addr_space = if i == 0 { e } else { f };
                 reads[i][0] = tracing_read_or_imm_native(
                     memory,
-                    addr_space.as_canonical_u32(),
+                    addr_space,
                     *ptr_or_imm,
                     &mut read_aux.prev_timestamp,
                 );

--- a/crates/vm/src/system/native_adapter/util.rs
+++ b/crates/vm/src/system/native_adapter/util.rs
@@ -121,6 +121,7 @@ where
 }
 
 /// Reads register value at `ptr` from memory and records the previous timestamp.
+/// Reads are only done from address space [NATIVE_AS].
 #[inline(always)]
 pub fn tracing_read_native<F, const BLOCK_SIZE: usize>(
     memory: &mut TracingMemory,
@@ -136,6 +137,7 @@ where
 }
 
 /// Writes `ptr, vals` into memory and records the previous timestamp and data.
+/// Writes are only done to address space [NATIVE_AS].
 #[inline(always)]
 pub fn tracing_write_native<F, const BLOCK_SIZE: usize>(
     memory: &mut TracingMemory,
@@ -171,7 +173,7 @@ pub fn tracing_write_native_inplace<F, const BLOCK_SIZE: usize>(
 #[inline(always)]
 pub fn tracing_read_or_imm_native<F>(
     memory: &mut TracingMemory,
-    addr_space: u32,
+    addr_space: F,
     ptr_or_imm: F,
     prev_timestamp: &mut u32,
 ) -> F
@@ -179,12 +181,12 @@ where
     F: PrimeField32,
 {
     debug_assert!(
-        addr_space == RV32_IMM_AS || addr_space == NATIVE_AS,
+        addr_space == F::ZERO || addr_space == F::from_canonical_u32(NATIVE_AS),
         "addr_space={} is not valid",
         addr_space
     );
 
-    if addr_space == RV32_IMM_AS {
+    if addr_space == F::ZERO {
         *prev_timestamp = u32::MAX;
         memory.increment_timestamp();
         ptr_or_imm

--- a/extensions/native/circuit/src/adapters/alu_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/alu_native_adapter.rs
@@ -170,19 +170,9 @@ impl<F: PrimeField32> AdapterTraceStep<F> for AluNativeAdapterStep {
         let &Instruction { b, c, e, f, .. } = instruction;
 
         record.b = b;
-        let rs1 = tracing_read_or_imm_native(
-            memory,
-            e.as_canonical_u32(),
-            b,
-            &mut record.reads_aux[0].prev_timestamp,
-        );
+        let rs1 = tracing_read_or_imm_native(memory, e, b, &mut record.reads_aux[0].prev_timestamp);
         record.c = c;
-        let rs2 = tracing_read_or_imm_native(
-            memory,
-            f.as_canonical_u32(),
-            c,
-            &mut record.reads_aux[1].prev_timestamp,
-        );
+        let rs2 = tracing_read_or_imm_native(memory, f, c, &mut record.reads_aux[1].prev_timestamp);
         [rs1, rs2]
     }
 

--- a/extensions/native/circuit/src/adapters/branch_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/branch_native_adapter.rs
@@ -165,19 +165,9 @@ where
         let &Instruction { a, b, d, e, .. } = instruction;
 
         record.ptrs[0] = a;
-        let rs1 = tracing_read_or_imm_native(
-            memory,
-            d.as_canonical_u32(),
-            a,
-            &mut record.reads_aux[0].prev_timestamp,
-        );
+        let rs1 = tracing_read_or_imm_native(memory, d, a, &mut record.reads_aux[0].prev_timestamp);
         record.ptrs[1] = b;
-        let rs2 = tracing_read_or_imm_native(
-            memory,
-            e.as_canonical_u32(),
-            b,
-            &mut record.reads_aux[1].prev_timestamp,
-        );
+        let rs2 = tracing_read_or_imm_native(memory, e, b, &mut record.reads_aux[1].prev_timestamp);
         [rs1, rs2]
     }
 

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -29,8 +29,8 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction,
     program::DEFAULT_PC_STEP,
-    riscv::{RV32_IMM_AS, RV32_REGISTER_AS},
-    LocalOpcode,
+    riscv::{RV32_IMM_AS, RV32_MEMORY_AS, RV32_REGISTER_AS},
+    LocalOpcode, NATIVE_AS,
 };
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
@@ -366,8 +366,6 @@ where
         } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
-        debug_assert!(e.as_canonical_u32() != RV32_IMM_AS);
-        debug_assert!(e.as_canonical_u32() != RV32_REGISTER_AS);
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),
@@ -381,7 +379,6 @@ where
             &mut record.rs1_aux_record.prev_timestamp,
         ));
 
-        record.mem_as = e.as_canonical_u32() as u8;
         record.imm = c.as_canonical_u32() as u16;
         record.imm_sign = g.is_one();
         let imm_extended = record.imm as u32 + record.imm_sign as u32 * 0xffff0000;
@@ -397,33 +394,39 @@ where
             self.pointer_max_bits
         );
 
-        let read_data = match local_opcode {
-            LOADW | LOADB | LOADH | LOADBU | LOADHU => tracing_read(
-                memory,
-                e.as_canonical_u32(),
-                ptr_val,
-                &mut record.read_data_aux.prev_timestamp,
-            ),
-            STOREW | STOREH | STOREB => tracing_read(
-                memory,
-                RV32_REGISTER_AS,
-                a.as_canonical_u32(),
-                &mut record.read_data_aux.prev_timestamp,
-            ),
-        };
-
-        // We need to keep values of some cells to keep them unchanged when writing to those cells
-        let prev_data = match local_opcode {
+        // prev_data: We need to keep values of some cells to keep them unchanged when writing to
+        // those cells
+        let (read_data, prev_data) = match local_opcode {
+            LOADW | LOADB | LOADH | LOADBU | LOADHU => {
+                debug_assert_eq!(e, F::from_canonical_u32(RV32_MEMORY_AS));
+                record.mem_as = RV32_MEMORY_AS as u8;
+                let read_data = tracing_read(
+                    memory,
+                    RV32_MEMORY_AS,
+                    ptr_val,
+                    &mut record.read_data_aux.prev_timestamp,
+                );
+                let prev_data = memory_read(memory.data(), RV32_REGISTER_AS, a.as_canonical_u32())
+                    .map(u32::from);
+                (read_data, prev_data)
+            }
             STOREW | STOREH | STOREB => {
-                if e.as_canonical_u32() == 4 {
+                let e = e.as_canonical_u32();
+                debug_assert_ne!(e, RV32_IMM_AS);
+                debug_assert_ne!(e, RV32_REGISTER_AS);
+                record.mem_as = e as u8;
+                let read_data = tracing_read(
+                    memory,
+                    RV32_REGISTER_AS,
+                    a.as_canonical_u32(),
+                    &mut record.read_data_aux.prev_timestamp,
+                );
+                let prev_data = if e == NATIVE_AS {
                     memory_read_native(memory.data(), ptr_val).map(|x: F| x.as_canonical_u32())
                 } else {
-                    memory_read(memory.data(), e.as_canonical_u32(), ptr_val).map(u32::from)
-                }
-            }
-            LOADW | LOADB | LOADH | LOADBU | LOADHU => {
-                memory_read(memory.data(), d.as_canonical_u32(), a.as_canonical_u32())
-                    .map(u32::from)
+                    memory_read(memory.data(), e, ptr_val).map(u32::from)
+                };
+                (read_data, prev_data)
             }
         };
 
@@ -448,8 +451,8 @@ where
         } = instruction;
 
         debug_assert_eq!(d.as_canonical_u32(), RV32_REGISTER_AS);
-        debug_assert!(e.as_canonical_u32() != RV32_IMM_AS);
-        debug_assert!(e.as_canonical_u32() != RV32_REGISTER_AS);
+        debug_assert_ne!(e.as_canonical_u32(), RV32_IMM_AS);
+        debug_assert_ne!(e.as_canonical_u32(), RV32_REGISTER_AS);
 
         let local_opcode = Rv32LoadStoreOpcode::from_usize(
             opcode.local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),


### PR DESCRIPTION
I went through the uses of `tracing_read` and switched to using constants for better compilation optimization whenever possible, where the requirements on the address space were determined according to ISA.md

I don't think there was really a performance diff: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16513213487