### PR TITLE
perf!(HOLD): change keccak AIR's block size to `8`

### DIFF
--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -33,7 +33,7 @@ use crate::utils::{keccak256, num_keccak_f};
 /// Register reads to get dst, src, len
 const KECCAK_REGISTER_READS: usize = 3;
 /// Number of cells to read/write in a single memory access
-const KECCAK_WORD_SIZE: usize = 4;
+const KECCAK_WORD_SIZE: usize = 8;
 /// Memory reads for absorb per row
 const KECCAK_ABSORB_READS: usize = KECCAK_RATE_BYTES / KECCAK_WORD_SIZE;
 /// Memory writes for digest per row


### PR DESCRIPTION
This makes the keccak AIR use less interactions because it does less memory read/writes with each memory read/write of more bytes. In some sense this is like SIMD.

Note that `8` is the maximum block size because the keccakf must read in `136 = 17 * 8` bytes at a time, and the current design requires the block size to be divisible by `136`.

Reth benchmark comparison: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16513569939