### PR TITLE
feat: add host configurable memory cell type to `MemoryConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project follows a versioning principles documented in [VERSIONING.md](.
 
 ## [Unreleased]
 
+### Added
+- (Config) Added `addr_spaces` vector of `AddressSpaceHostConfig` to `MemoryConfig`.
+
 ### Changed
 - (Toolchain) Removed `step` from `Program` struct because `DEFAULT_PC_STEP = 4` is always used.
+- (Config) The `clk_max_bits` field in `MemoryConfig` has been renamed to `timestamp_max_bits`.
+- (Prover) Guest memory is stored on host with address space-specified memory layouts. In particular address space `1` through `3` are now represented in bytes instead of field elements.
 
 ## v1.3.0 (2025-07-15)
 

--- a/crates/sdk/src/config/global.rs
+++ b/crates/sdk/src/config/global.rs
@@ -412,7 +412,7 @@ impl From<SdkVmConfigWithDefaultDeser> for SdkVmConfig {
         if config.native.is_none() && config.castf.is_none() {
             // There should be no need to write to native address space if Native extension and
             // CastF extension are not enabled.
-            system.config.memory_config.addr_space_sizes[NATIVE_AS as usize] = 0;
+            system.config.memory_config.addr_spaces[NATIVE_AS as usize].num_cells = 0;
         }
         Self {
             system,

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -383,6 +383,8 @@ pub struct AddressSpaceHostConfig {
     pub layout: MemoryCellType,
 }
 
+pub(crate) const MAX_CELL_BYTE_SIZE: usize = 8;
+
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryCellType {
     Null,
@@ -390,6 +392,7 @@ pub enum MemoryCellType {
     U16,
     /// Represented in little-endian format.
     U32,
+    /// `size` is the size in bytes of the native field type. This should not exceed 8.
     Native {
         size: u8,
     },

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -406,7 +406,7 @@ impl MemoryCellType {
 impl AddressSpaceHostLayout for MemoryCellType {
     fn size(&self) -> usize {
         match self {
-            Self::Null => 0,
+            Self::Null => 1, // to avoid divide by zero
             Self::U8 => size_of::<u8>(),
             Self::U16 => size_of::<u16>(),
             Self::U32 => size_of::<u32>(),

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -169,7 +169,7 @@ pub struct MemoryConfig {
     /// element is 0, which means no address space.
     pub addr_spaces: Vec<AddressSpaceHostConfig>,
     pub pointer_max_bits: usize,
-    /// All timestamps must be in the range `[0, 2^clk_max_bits)`. Maximum allowed: 29.
+    /// All timestamps must be in the range `[0, 2^timestamp_max_bits)`. Maximum allowed: 29.
     pub timestamp_max_bits: usize,
     /// Limb size used by the range checker
     pub decomp: usize,

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -165,7 +165,7 @@ pub struct MemoryConfig {
     /// for searching the address space. The allowed address spaces are those in the range `[1,
     /// 1 + 2^addr_space_height)` where it starts from 1 to not allow address space 0 in memory.
     pub addr_space_height: usize,
-    /// It is expected that the size of the list is `1 << addr_space_height + 1` and the first
+    /// It is expected that the size of the list is `(1 << addr_space_height) + 1` and the first
     /// element is 0, which means no address space.
     pub addr_spaces: Vec<AddressSpaceHostConfig>,
     pub pointer_max_bits: usize,

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -143,7 +143,7 @@ pub struct MemoryConfig {
     pub addr_space_sizes: Vec<usize>,
     pub pointer_max_bits: usize,
     /// All timestamps must be in the range `[0, 2^clk_max_bits)`. Maximum allowed: 29.
-    pub clk_max_bits: usize,
+    pub timestamp_max_bits: usize,
     /// Limb size used by the range checker
     pub decomp: usize,
     /// Maximum N AccessAdapter AIR to support.
@@ -209,7 +209,7 @@ impl SystemConfig {
         num_public_values: usize,
     ) -> Self {
         assert!(
-            memory_config.clk_max_bits <= 29,
+            memory_config.timestamp_max_bits <= 29,
             "Timestamp max bits must be <= 29 for LessThan to work in 31-bit field"
         );
         memory_config.addr_space_sizes[PUBLIC_VALUES_AS as usize] = num_public_values;

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -18,7 +18,9 @@ use crate::{
         Arena, ChipInventoryError, ExecutorInventory, ExecutorInventoryError,
     },
     system::{
-        memory::{merkle::public_values::PUBLIC_VALUES_AS, num_memory_airs, CHUNK},
+        memory::{
+            merkle::public_values::PUBLIC_VALUES_AS, num_memory_airs, CHUNK, POINTER_MAX_BITS,
+        },
         SystemChipComplex,
     },
 };
@@ -155,7 +157,7 @@ impl Default for MemoryConfig {
         let mut addr_space_sizes = vec![0; (1 << 3) + ADDR_SPACE_OFFSET as usize];
         addr_space_sizes[ADDR_SPACE_OFFSET as usize..=NATIVE_AS as usize].fill(1 << 29);
         addr_space_sizes[PUBLIC_VALUES_AS as usize] = DEFAULT_MAX_NUM_PUBLIC_VALUES;
-        Self::new(3, addr_space_sizes, 29, 29, 17, 32)
+        Self::new(3, addr_space_sizes, POINTER_MAX_BITS, 29, 17, 32)
     }
 }
 
@@ -164,7 +166,7 @@ impl MemoryConfig {
     pub fn aggregation() -> Self {
         let mut addr_space_sizes = vec![0; (1 << 3) + ADDR_SPACE_OFFSET as usize];
         addr_space_sizes[NATIVE_AS as usize] = 1 << 29;
-        Self::new(3, addr_space_sizes, 29, 29, 17, 8)
+        Self::new(3, addr_space_sizes, POINTER_MAX_BITS, 29, 17, 8)
     }
 }
 

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -144,7 +144,7 @@ pub trait InitFileGenerator {
 /// Each address space in guest memory may be configured with a different type `T` to represent a
 /// memory cell in the address space. On host, the address space will be mapped to linear host
 /// memory in bytes. The type `T` must be plain old data (POD) and be safely transmutable from a
-/// fixed size array of bytes. Moreover, each type `T` must be convertable to a field element `F`.
+/// fixed size array of bytes. Moreover, each type `T` must be convertible to a field element `F`.
 ///
 /// We currently implement this trait on the enum [MemoryCellType], which includes all cell types
 /// that we expect to be used in the VM context.

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -23,7 +23,6 @@ pub const DEFAULT_SEGMENT_CHECK_INSNS: u64 = 1000;
 #[derive(Clone, Debug, WithSetters)]
 pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
     pub trace_heights: Vec<u32>,
-    // TODO[jpw]: should this be in Ctrl?
     pub is_trace_height_constant: Vec<bool>,
 
     pub memory_ctx: MemoryCtx<PAGE_BITS>,

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -583,7 +583,7 @@ where
     }
 
     pub fn timestamp_max_bits(&self) -> usize {
-        self.airs.config().memory_config.clk_max_bits
+        self.airs.config().memory_config.timestamp_max_bits
     }
 }
 

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -35,11 +35,10 @@ impl<F: PrimeField32> MemoryTester<F> {
         }
     }
 
-    // TODO: change interface by implementing GuestMemory trait after everything works
     pub fn read<const N: usize>(&mut self, addr_space: usize, ptr: usize) -> [F; N] {
         let memory = &mut self.memory;
         let t = memory.timestamp();
-        // TODO: hack
+        // TODO: this could be improved if we added a TracingMemory::get_f function
         let (t_prev, data) = if addr_space <= 3 {
             let (t_prev, data) = unsafe { memory.read::<u8, N, 4>(addr_space as u32, ptr as u32) };
             (t_prev, data.map(F::from_canonical_u8))
@@ -60,11 +59,10 @@ impl<F: PrimeField32> MemoryTester<F> {
         data
     }
 
-    // TODO: see read
     pub fn write<const N: usize>(&mut self, addr_space: usize, ptr: usize, data: [F; N]) {
         let memory = &mut self.memory;
         let t = memory.timestamp();
-        // TODO: hack
+        // TODO: this could be improved if we added a TracingMemory::write_f function
         let (t_prev, data_prev) = if addr_space <= 3 {
             let (t_prev, data_prev) = unsafe {
                 memory.write::<u8, N, 4>(

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -336,6 +336,7 @@ impl VmChipTestBuilder<BabyBear> {
 impl<F: PrimeField32> VmChipTestBuilder<F> {
     pub fn default_persistent() -> Self {
         let mut mem_config = MemoryConfig::default();
+        mem_config.addr_spaces[RV32_REGISTER_AS as usize].num_cells = 1 << 29;
         mem_config.addr_spaces[NATIVE_AS as usize].num_cells = 0;
         Self::persistent(mem_config)
     }

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -7,7 +7,7 @@ use openvm_circuit_primitives::{
         SharedVariableRangeCheckerChip, VariableRangeCheckerBus, VariableRangeCheckerChip,
     },
 };
-use openvm_instructions::{instruction::Instruction, NATIVE_AS};
+use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS, NATIVE_AS};
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
     engine::VerificationData,
@@ -411,6 +411,9 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
 impl<F: PrimeField32> Default for VmChipTestBuilder<F> {
     fn default() -> Self {
         let mut mem_config = MemoryConfig::default();
+        // TODO[jpw]: this is because old tests use `gen_pointer` on address space 1; this can be
+        // removed when tests are updated.
+        mem_config.addr_spaces[RV32_REGISTER_AS as usize].num_cells = 1 << 29;
         mem_config.addr_spaces[NATIVE_AS as usize].num_cells = 0;
         Self::volatile(mem_config)
     }

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -336,7 +336,7 @@ impl VmChipTestBuilder<BabyBear> {
 impl<F: PrimeField32> VmChipTestBuilder<F> {
     pub fn default_persistent() -> Self {
         let mut mem_config = MemoryConfig::default();
-        mem_config.addr_space_sizes[NATIVE_AS as usize] = 0;
+        mem_config.addr_spaces[NATIVE_AS as usize].num_cells = 0;
         Self::persistent(mem_config)
     }
 
@@ -411,7 +411,7 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
 impl<F: PrimeField32> Default for VmChipTestBuilder<F> {
     fn default() -> Self {
         let mut mem_config = MemoryConfig::default();
-        mem_config.addr_space_sizes[NATIVE_AS as usize] = 0;
+        mem_config.addr_spaces[NATIVE_AS as usize].num_cells = 0;
         Self::volatile(mem_config)
     }
 }

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -272,7 +272,7 @@ impl<F: PrimeField32> VmChipTestBuilder<F> {
     }
 
     pub fn address_bits(&self) -> usize {
-        self.memory.controller.mem_config.pointer_max_bits
+        self.memory.controller.memory_config().pointer_max_bits
     }
 
     pub fn get_default_register(&mut self, increment: usize) -> usize {
@@ -487,7 +487,7 @@ where
             }
             let mem_inventory = MemoryAirInventory::new(
                 memory_controller.memory_bridge(),
-                &memory_controller.mem_config,
+                memory_controller.memory_config(),
                 range_checker.bus(),
                 is_persistent.then_some((
                     PermutationCheckBus::new(MEMORY_MERKLE_BUS),

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -237,16 +237,11 @@ where
         interactions: &[usize],
     ) -> MeteredCtx {
         let system_config = self.config.as_ref();
-        let num_addr_sp = 1 + (1 << system_config.memory_config.addr_space_height);
-        let mut min_block_size = vec![1; num_addr_sp];
-        // TMP: hardcoding for now
-        // TODO[jpw]: move to mem_config
-        min_block_size[1] = 4;
-        min_block_size[2] = 4;
-        min_block_size[3] = 4;
-        let as_byte_alignment_bits = min_block_size
+        let as_byte_alignment_bits = system_config
+            .memory_config
+            .addr_spaces
             .iter()
-            .map(|&x| log2_strict_usize(x as usize) as u8)
+            .map(|addr_sp| log2_strict_usize(addr_sp.min_block_size) as u8)
             .collect();
 
         MeteredCtx::new(
@@ -543,7 +538,6 @@ where
         );
         let memory = TracingMemory::from_image(
             state.memory,
-            &system_config.memory_config,
             system_config.initial_block_size(),
             access_adapter_arena_size_bound,
         );
@@ -1201,7 +1195,7 @@ pub(super) fn create_memory_image(
     init_memory: SparseMemoryImage,
 ) -> GuestMemory {
     GuestMemory::new(AddressMap::from_sparse(
-        memory_config.addr_space_sizes.clone(),
+        memory_config.addr_spaces.clone(),
         init_memory,
     ))
 }

--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -53,20 +53,20 @@ impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
     pub fn new(
         range_checker: SharedVariableRangeCheckerChip,
         memory_bus: MemoryBus,
-        clk_max_bits: usize,
+        timestamp_max_bits: usize,
         max_access_adapter_n: usize,
     ) -> Self {
         let rc = range_checker;
         let mb = memory_bus;
-        let cmb = clk_max_bits;
+        let tmb = timestamp_max_bits;
         let maan = max_access_adapter_n;
         assert!(matches!(maan, 2 | 4 | 8 | 16 | 32));
         let chips: Vec<_> = [
-            Self::create_access_adapter_chip::<2>(rc.clone(), mb, cmb, maan),
-            Self::create_access_adapter_chip::<4>(rc.clone(), mb, cmb, maan),
-            Self::create_access_adapter_chip::<8>(rc.clone(), mb, cmb, maan),
-            Self::create_access_adapter_chip::<16>(rc.clone(), mb, cmb, maan),
-            Self::create_access_adapter_chip::<32>(rc.clone(), mb, cmb, maan),
+            Self::create_access_adapter_chip::<2>(rc.clone(), mb, tmb, maan),
+            Self::create_access_adapter_chip::<4>(rc.clone(), mb, tmb, maan),
+            Self::create_access_adapter_chip::<8>(rc.clone(), mb, tmb, maan),
+            Self::create_access_adapter_chip::<16>(rc.clone(), mb, tmb, maan),
+            Self::create_access_adapter_chip::<32>(rc.clone(), mb, tmb, maan),
         ]
         .into_iter()
         .flatten()
@@ -246,7 +246,7 @@ impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
     fn create_access_adapter_chip<const N: usize>(
         range_checker: SharedVariableRangeCheckerChip,
         memory_bus: MemoryBus,
-        clk_max_bits: usize,
+        timestamp_max_bits: usize,
         max_access_adapter_n: usize,
     ) -> Option<GenericAccessAdapterChip<F>>
     where
@@ -256,7 +256,7 @@ impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
             Some(GenericAccessAdapterChip::new::<N>(
                 range_checker,
                 memory_bus,
-                clk_max_bits,
+                timestamp_max_bits,
             ))
         } else {
             None

--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -373,7 +373,7 @@ impl<F, const N: usize> GenericAccessAdapterChipTrait<F> for AccessAdapterChip<F
             F::from_canonical_u32(address.pointer),
         );
         let addr_space_layout = addr_spaces[address.address_space as usize].layout;
-        // SAFETY: values will be a slice of of the cell type
+        // SAFETY: values will be a slice of the cell type
         unsafe {
             match addr_space_layout {
                 MemoryCellType::Native { .. } => {

--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -295,11 +295,11 @@ impl<F: Clone + Send + Sync> GenericAccessAdapterChip<F> {
     fn new<const N: usize>(
         range_checker: SharedVariableRangeCheckerChip,
         memory_bus: MemoryBus,
-        clk_max_bits: usize,
+        timestamp_max_bits: usize,
     ) -> Self {
         let rc = range_checker;
         let mb = memory_bus;
-        let cmb = clk_max_bits;
+        let cmb = timestamp_max_bits;
         match N {
             2 => GenericAccessAdapterChip::N2(AccessAdapterChip::new(rc, mb, cmb)),
             4 => GenericAccessAdapterChip::N4(AccessAdapterChip::new(rc, mb, cmb)),
@@ -322,9 +322,9 @@ impl<F: Clone + Send + Sync, const N: usize> AccessAdapterChip<F, N> {
     pub fn new(
         range_checker: SharedVariableRangeCheckerChip,
         memory_bus: MemoryBus,
-        clk_max_bits: usize,
+        timestamp_max_bits: usize,
     ) -> Self {
-        let lt_air = IsLtSubAir::new(range_checker.bus(), clk_max_bits);
+        let lt_air = IsLtSubAir::new(range_checker.bus(), timestamp_max_bits);
         Self {
             air: AccessAdapterAir::<N> { memory_bus, lt_air },
             range_checker,

--- a/crates/vm/src/system/memory/adapter/records.rs
+++ b/crates/vm/src/system/memory/adapter/records.rs
@@ -14,7 +14,7 @@ pub struct AccessRecordHeader {
     pub timestamp_and_mask: u32,
     pub address_space: u32,
     pub pointer: u32,
-    // TODO: these three are easily mergeable into a single u32
+    // PERF: these three are easily mergeable into a single u32
     pub block_size: u32,
     pub lowest_block_size: u32,
     pub type_size: u32,
@@ -24,7 +24,7 @@ pub struct AccessRecordHeader {
 #[derive(Debug)]
 pub struct AccessRecordMut<'a> {
     pub header: &'a mut AccessRecordHeader,
-    // TODO(AG): optimize with some `Option` serialization stuff
+    // PERF(AG): optimize with some `Option` serialization stuff
     pub timestamps: &'a mut [u32], // len is block_size / lowest_block_size
     pub data: &'a mut [u8],        // len is block_size * type_size
 }

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -75,8 +75,6 @@ pub type Equipartition<F, const N: usize> = BTreeMap<(u32, u32), [F; N]>;
 pub struct MemoryController<F: Field> {
     pub memory_bus: MemoryBus,
     pub interface_chip: MemoryInterface<F>,
-    #[getset(get = "pub")]
-    pub(crate) mem_config: MemoryConfig,
     pub range_checker: SharedVariableRangeCheckerChip,
     // Store separately to avoid smart pointer reference each time
     range_checker_bus: VariableRangeCheckerBus,
@@ -146,7 +144,6 @@ impl<F: PrimeField32> MemoryController<F> {
         );
         Self {
             memory_bus,
-            mem_config: mem_config.clone(),
             interface_chip: MemoryInterface::Volatile {
                 boundary_chip: VolatileBoundaryChip::new(
                     memory_bus,
@@ -158,8 +155,7 @@ impl<F: PrimeField32> MemoryController<F> {
             access_adapter_inventory: AccessAdapterInventory::new(
                 range_checker.clone(),
                 memory_bus,
-                mem_config.timestamp_max_bits,
-                mem_config.max_access_adapter_n,
+                mem_config,
             ),
             range_checker,
             range_checker_bus,
@@ -195,18 +191,20 @@ impl<F: PrimeField32> MemoryController<F> {
         };
         Self {
             memory_bus,
-            mem_config: mem_config.clone(),
             interface_chip,
             access_adapter_inventory: AccessAdapterInventory::new(
                 range_checker.clone(),
                 memory_bus,
-                mem_config.timestamp_max_bits,
-                mem_config.max_access_adapter_n,
+                mem_config,
             ),
             range_checker,
             range_checker_bus,
             hasher_chip: Some(hasher_chip),
         }
+    }
+
+    pub fn memory_config(&self) -> &MemoryConfig {
+        &self.access_adapter_inventory.memory_config
     }
 
     pub(crate) fn set_override_trace_heights(&mut self, overridden_heights: &[u32]) {
@@ -247,7 +245,7 @@ impl<F: PrimeField32> MemoryController<F> {
     pub fn memory_bridge(&self) -> MemoryBridge {
         MemoryBridge::new(
             self.memory_bus,
-            self.mem_config.timestamp_max_bits,
+            self.memory_config().timestamp_max_bits,
             self.range_checker_bus,
         )
     }
@@ -256,7 +254,10 @@ impl<F: PrimeField32> MemoryController<F> {
         let range_bus = self.range_checker.bus();
         SharedMemoryHelper {
             range_checker: self.range_checker.clone(),
-            timestamp_lt_air: AssertLtSubAir::new(range_bus, self.mem_config.timestamp_max_bits),
+            timestamp_lt_air: AssertLtSubAir::new(
+                range_bus,
+                self.memory_config().timestamp_max_bits,
+            ),
             _marker: Default::default(),
         }
     }

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -158,7 +158,7 @@ impl<F: PrimeField32> MemoryController<F> {
             access_adapter_inventory: AccessAdapterInventory::new(
                 range_checker.clone(),
                 memory_bus,
-                mem_config.clk_max_bits,
+                mem_config.timestamp_max_bits,
                 mem_config.max_access_adapter_n,
             ),
             range_checker,
@@ -200,7 +200,7 @@ impl<F: PrimeField32> MemoryController<F> {
             access_adapter_inventory: AccessAdapterInventory::new(
                 range_checker.clone(),
                 memory_bus,
-                mem_config.clk_max_bits,
+                mem_config.timestamp_max_bits,
                 mem_config.max_access_adapter_n,
             ),
             range_checker,
@@ -247,7 +247,7 @@ impl<F: PrimeField32> MemoryController<F> {
     pub fn memory_bridge(&self) -> MemoryBridge {
         MemoryBridge::new(
             self.memory_bus,
-            self.mem_config.clk_max_bits,
+            self.mem_config.timestamp_max_bits,
             self.range_checker_bus,
         )
     }
@@ -256,7 +256,7 @@ impl<F: PrimeField32> MemoryController<F> {
         let range_bus = self.range_checker.bus();
         SharedMemoryHelper {
             range_checker: self.range_checker.clone(),
-            timestamp_lt_air: AssertLtSubAir::new(range_bus, self.mem_config.clk_max_bits),
+            timestamp_lt_air: AssertLtSubAir::new(range_bus, self.mem_config.timestamp_max_bits),
             _marker: Default::default(),
         }
     }

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -137,9 +137,9 @@ impl<F: PrimeField32> MemoryController<F> {
         let range_checker_bus = range_checker.bus();
         assert!(mem_config.pointer_max_bits <= F::bits() - 2);
         assert!(mem_config
-            .addr_space_sizes
+            .addr_spaces
             .iter()
-            .all(|&x| x <= (1 << mem_config.pointer_max_bits)));
+            .all(|&space| space.num_cells <= (1 << mem_config.pointer_max_bits)));
         assert!(mem_config.addr_space_height < F::bits() - 2);
         let addr_space_max_bits = log2_ceil_usize(
             (ADDR_SPACE_OFFSET + 2u32.pow(mem_config.addr_space_height as u32)) as usize,

--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -5,7 +5,7 @@ use openvm_stark_backend::{
 };
 
 use super::{controller::dimensions::MemoryDimensions, online::LinearMemory, MemoryImage};
-use crate::system::memory::online::PAGE_SIZE;
+use crate::{arch::AddressSpaceHostLayout, system::memory::online::PAGE_SIZE};
 
 mod air;
 mod columns;
@@ -73,7 +73,7 @@ fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
         .into_par_iter()
         .map(move |as_idx| {
             let space_mem = memory.mem[as_idx].as_slice();
-            let cell_size = memory.cell_size[as_idx];
+            let cell_size = memory.config[as_idx].layout.size();
             debug_assert_eq!(PAGE_SIZE % (cell_size * N), 0);
 
             let num_nonzero_pages = space_mem

--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -4,8 +4,11 @@ use openvm_stark_backend::{
     interaction::PermutationCheckBus, p3_field::PrimeField32, p3_maybe_rayon::prelude::*,
 };
 
-use super::{controller::dimensions::MemoryDimensions, online::LinearMemory, MemoryImage};
-use crate::{arch::AddressSpaceHostLayout, system::memory::online::PAGE_SIZE};
+use super::{controller::dimensions::MemoryDimensions, online::LinearMemory};
+use crate::{
+    arch::AddressSpaceHostLayout,
+    system::memory::{online::PAGE_SIZE, AddressMap},
+};
 
 mod air;
 mod columns;
@@ -66,14 +69,15 @@ impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
 
 #[tracing::instrument(level = "info", skip_all)]
 fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
-    memory: &MemoryImage,
+    memory: &AddressMap,
     md: &MemoryDimensions,
 ) -> Vec<(u64, [F; N])> {
     (0..memory.mem.len())
         .into_par_iter()
         .map(move |as_idx| {
             let space_mem = memory.mem[as_idx].as_slice();
-            let cell_size = memory.config[as_idx].layout.size();
+            let addr_space_layout = memory.config[as_idx].layout;
+            let cell_size = addr_space_layout.size();
             debug_assert_eq!(PAGE_SIZE % (cell_size * N), 0);
 
             let num_nonzero_pages = space_mem
@@ -94,41 +98,23 @@ fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
             // virtual memory may be larger than dimensions due to rounding up to page size
             num_elements = num_elements.min(1 << md.address_height);
 
-            // TODO: handle different cell sizes better
-            if cell_size == 1 {
-                (0..num_elements)
-                    .into_par_iter()
-                    .map(move |idx| {
-                        let byte_index = idx * cell_size * N;
-                        unsafe {
-                            let ptr = space_mem.as_ptr();
-                            let src = ptr.add(byte_index);
-                            (
-                                md.label_to_index((as_idx as u32, idx as u32)),
-                                array::from_fn(|i| {
-                                    F::from_canonical_u8(core::ptr::read(src.add(i)))
-                                }),
-                            )
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            } else {
-                assert_eq!(cell_size, 4);
-                (0..num_elements)
-                    .into_par_iter()
-                    .map(move |idx| {
-                        let byte_index = idx * cell_size * N;
-                        unsafe {
-                            let ptr = space_mem.as_ptr();
-                            let src = ptr.add(byte_index) as *const F;
-                            (
-                                md.label_to_index((as_idx as u32, idx as u32)),
-                                array::from_fn(|i| core::ptr::read(src.add(i))),
-                            )
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            }
+            (0..num_elements)
+                .into_par_iter()
+                .map(move |idx| {
+                    (
+                        md.label_to_index((as_idx as u32, idx as u32)),
+                        array::from_fn(|i| unsafe {
+                            // SAFETY: idx < num_elements = space_mem.len() / (cell_size * N) so ptr
+                            // is within bounds. We are reading one cell at a time, so alignment is
+                            // guaranteed.
+                            let ptr: *const u8 =
+                                space_mem.as_ptr().add(idx * cell_size * N + i * cell_size);
+                            addr_space_layout
+                                .to_field(&*core::ptr::slice_from_raw_parts(ptr, cell_size))
+                        }),
+                    )
+                })
+                .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>()
         .into_iter()

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -44,7 +44,6 @@ impl<const CHUNK: usize, F> MemoryMerkleChip<CHUNK, F>
 where
     F: PrimeField32,
 {
-    // TODO: switch to using records
     pub fn generate_proving_ctx<SC>(&mut self) -> AirProvingContext<CpuBackend<SC>>
     where
         SC: StarkGenericConfig,
@@ -54,7 +53,6 @@ where
             self.final_state.is_some(),
             "Merkle chip must finalize before trace generation"
         );
-        // TODO[jpw]: figure this out later, probably memory just shouldn't use Chip trait
         let FinalState {
             mut rows,
             init_root,

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -120,7 +120,7 @@ impl<SC: StarkGenericConfig> MemoryAirInventory<SC> {
             MemoryInterfaceAirs::Volatile { boundary }
         };
         // Memory access adapters
-        let lt_air = IsLtSubAir::new(range_bus, mem_config.clk_max_bits);
+        let lt_air = IsLtSubAir::new(range_bus, mem_config.timestamp_max_bits);
         let maan = mem_config.max_access_adapter_n;
         assert!(matches!(maan, 2 | 4 | 8 | 16 | 32));
         let access_adapters: Vec<AirRef<SC>> = [

--- a/crates/vm/src/system/memory/offline_checker/bridge.rs
+++ b/crates/vm/src/system/memory/offline_checker/bridge.rs
@@ -20,7 +20,7 @@ use crate::system::memory::{
 
 /// AUX_LEN is the number of auxiliary columns (aka the number of limbs that the input numbers will
 /// be decomposed into) for the `AssertLtSubAir` in the `MemoryOfflineChecker`.
-/// Warning: This requires that (clk_max_bits + decomp - 1) / decomp = AUX_LEN
+/// Warning: This requires that (timestamp_max_bits + decomp - 1) / decomp = AUX_LEN
 ///         in MemoryOfflineChecker (or whenever AssertLtSubAir is used)
 pub const AUX_LEN: usize = 2;
 
@@ -35,11 +35,11 @@ impl MemoryBridge {
     /// Create a new [MemoryBridge] with the provided offline_checker.
     pub fn new(
         memory_bus: MemoryBus,
-        clk_max_bits: usize,
+        timestamp_max_bits: usize,
         range_bus: VariableRangeCheckerBus,
     ) -> Self {
         Self {
-            offline_checker: MemoryOfflineChecker::new(memory_bus, clk_max_bits, range_bus),
+            offline_checker: MemoryOfflineChecker::new(memory_bus, timestamp_max_bits, range_bus),
         }
     }
 
@@ -274,10 +274,14 @@ struct MemoryOfflineChecker {
 }
 
 impl MemoryOfflineChecker {
-    fn new(memory_bus: MemoryBus, clk_max_bits: usize, range_bus: VariableRangeCheckerBus) -> Self {
+    fn new(
+        memory_bus: MemoryBus,
+        timestamp_max_bits: usize,
+        range_bus: VariableRangeCheckerBus,
+    ) -> Self {
         Self {
             memory_bus,
-            timestamp_lt_air: AssertLtSubAir::new(range_bus, clk_max_bits),
+            timestamp_lt_air: AssertLtSubAir::new(range_bus, timestamp_max_bits),
         }
     }
 

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -218,7 +218,7 @@ impl<M: LinearMemory> AddressMap<M> {
         mem.get_aligned_slice(start, len)
     }
 
-    /// Reads the slice at **byte** adddresses `start..start + len` from address space `addr_space`
+    /// Reads the slice at **byte** addresses `start..start + len` from address space `addr_space`
     /// linear memory. Panics or segfaults if `start..start + len` is out of bounds
     ///
     /// # Safety

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -221,8 +221,10 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
             .par_iter()
             .map(|&((addr_space, ptr), ts_values)| {
                 let TimestampedValues { timestamp, values } = ts_values;
-                let init_values =
-                    array::from_fn(|i| initial_memory.get_f::<F>(addr_space, ptr + i as u32));
+                // SAFETY: addr_space from `final_memory` are all in bounds
+                let init_values = array::from_fn(|i| unsafe {
+                    initial_memory.get_f::<F>(addr_space, ptr + i as u32)
+                });
                 let initial_hash = hasher.hash(&init_values);
                 let final_hash = hasher.hash(&values);
                 FinalTouchedLabel {

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -174,7 +174,7 @@ impl<SC: StarkGenericConfig> SystemAirInventory<SC> {
             execution_bus,
             program_bus,
             range_bus,
-            config.memory_config.clk_max_bits,
+            config.memory_config.timestamp_max_bits,
         );
         assert_eq!(
             config.continuation_enabled,
@@ -299,7 +299,7 @@ impl<SC: StarkGenericConfig> VmCircuitConfig<SC> for SystemConfig {
             None
         };
         let memory_bridge =
-            MemoryBridge::new(memory_bus, self.memory_config.clk_max_bits, range_bus);
+            MemoryBridge::new(memory_bus, self.memory_config.timestamp_max_bits, range_bus);
         let system_port = SystemPort {
             execution_bus,
             program_bus,
@@ -367,7 +367,7 @@ where
         let program_chip = ProgramChip::unloaded();
         let connector_chip = VmConnectorChip::<Val<SC>>::new(
             range_checker.clone(),
-            config.memory_config.clk_max_bits,
+            config.memory_config.timestamp_max_bits,
         );
         let memory_bus = mem_inventory.bridge.memory_bus();
         let memory_controller = match &mem_inventory.interface {

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -103,10 +103,8 @@ impl<SC: StarkGenericConfig> VmCommittedExe<SC> {
         let memory_dimensions = memory_config.memory_dimensions();
         let app_program_commit: &[Val<SC>; CHUNK] = self.commitment.as_ref();
         let mem_config = memory_config;
-        let memory_image = AddressMap::from_sparse(
-            mem_config.addr_space_sizes.clone(),
-            self.exe.init_memory.clone(),
-        );
+        let memory_image =
+            AddressMap::from_sparse(mem_config.addr_spaces.clone(), self.exe.init_memory.clone());
         let init_memory_commit =
             MerkleTree::from_memory(&memory_image, &memory_dimensions, &hasher).root();
         Com::<SC>::from(compute_exe_commit(

--- a/crates/vm/src/utils/mod.rs
+++ b/crates/vm/src/utils/mod.rs
@@ -45,3 +45,13 @@ pub fn transmute_u32_to_field<F: PrimeField32>(value: &u32) -> F {
     // as a single u32 internally
     unsafe { *(value as *const u32 as *const F) }
 }
+
+/// # Safety
+/// The type `T` should be plain old data so there is no worry about [Drop] behavior in the
+/// transmutation.
+#[inline(always)]
+pub unsafe fn slice_as_bytes<T>(slice: &[T]) -> &[u8] {
+    let len = size_of_val(slice);
+    // SAFETY: length and alignment are correct.
+    unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, len) }
+}

--- a/crates/vm/src/utils/test_utils.rs
+++ b/crates/vm/src/utils/test_utils.rs
@@ -1,9 +1,14 @@
 use std::array;
 
 use openvm_circuit::arch::{MemoryConfig, SystemConfig};
-use openvm_instructions::NATIVE_AS;
+use openvm_instructions::{
+    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
+    NATIVE_AS,
+};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, Rng};
+
+use crate::system::memory::{merkle::public_values::PUBLIC_VALUES_AS, online::PAGE_SIZE};
 
 pub fn i32_to_f<F: PrimeField32>(val: i32) -> F {
     if val.signum() == -1 {
@@ -35,17 +40,18 @@ pub fn u32_sign_extend<const IMM_BITS: usize>(num: u32) -> u32 {
 }
 
 pub fn test_system_config() -> SystemConfig {
-    SystemConfig::new(
-        3,
-        MemoryConfig::new(2, vec![0, 4096, 1 << 22, 4096, 1 << 25], 29, 29, 17, 32),
-        32,
-    )
+    let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
+    addr_spaces[RV32_REGISTER_AS as usize].num_cells = PAGE_SIZE;
+    addr_spaces[RV32_MEMORY_AS as usize].num_cells = 1 << 22;
+    addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = PAGE_SIZE;
+    addr_spaces[NATIVE_AS as usize].num_cells = 1 << 25;
+    SystemConfig::new(3, MemoryConfig::new(2, addr_spaces, 29, 29, 17, 32), 32)
 }
 
 // Testing config when native address space is not needed
 pub fn test_system_config_with_continuations() -> SystemConfig {
     let mut config = test_system_config();
-    config.memory_config.addr_space_sizes[NATIVE_AS as usize] = 0;
+    config.memory_config.addr_spaces[NATIVE_AS as usize].num_cells = 0;
     config.with_continuations()
 }
 

--- a/extensions/native/circuit/src/utils.rs
+++ b/extensions/native/circuit/src/utils.rs
@@ -140,8 +140,8 @@ pub mod test_utils {
 
     pub fn test_native_config() -> NativeConfig {
         let mut system = test_system_config();
-        system.memory_config.addr_space_sizes[RV32_REGISTER_AS as usize] = 0;
-        system.memory_config.addr_space_sizes[RV32_MEMORY_AS as usize] = 0;
+        system.memory_config.addr_spaces[RV32_REGISTER_AS as usize].num_cells = 0;
+        system.memory_config.addr_spaces[RV32_MEMORY_AS as usize].num_cells = 0;
         NativeConfig {
             system,
             native: Default::default(),

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -287,7 +287,6 @@ impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceFiller<F>
         let adapter_row: &mut Rv32BaseAluAdapterCols<F> = adapter_row.borrow_mut();
 
         // We must assign in reverse
-        // TODO[jpw]: is there a way to not hardcode?
         const TIMESTAMP_DELTA: u32 = 2;
         let mut timestamp = record.from_timestamp + TIMESTAMP_DELTA;
 

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
     },
     system::memory::merkle::public_values::PUBLIC_VALUES_AS,
 };
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS, LocalOpcode};
 use openvm_rv32im_transpiler::Rv32LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
@@ -230,6 +230,7 @@ fn run_negative_loadstore_test(
 ) {
     let mut rng = create_seeded_rng();
     let mut mem_config = MemoryConfig::default();
+    mem_config.addr_spaces[RV32_REGISTER_AS as usize].num_cells = 1 << 29;
     if [STOREW, STOREB, STOREH].contains(&opcode) {
         mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     }

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -179,6 +179,7 @@ fn set_and_execute(
 fn rand_loadstore_test(opcode: Rv32LoadStoreOpcode, num_ops: usize) {
     let mut rng = create_seeded_rng();
     let mut mem_config = MemoryConfig::default();
+    mem_config.addr_spaces[RV32_REGISTER_AS as usize].num_cells = 1 << 29;
     if [STOREW, STOREB, STOREH].contains(&opcode) {
         mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     }

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -180,7 +180,7 @@ fn rand_loadstore_test(opcode: Rv32LoadStoreOpcode, num_ops: usize) {
     let mut rng = create_seeded_rng();
     let mut mem_config = MemoryConfig::default();
     if [STOREW, STOREB, STOREH].contains(&opcode) {
-        mem_config.addr_space_sizes[PUBLIC_VALUES_AS as usize] = 1 << 29;
+        mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     }
     let mut tester = VmChipTestBuilder::volatile(mem_config);
     let mut harness = create_test_chip(&mut tester);
@@ -231,7 +231,7 @@ fn run_negative_loadstore_test(
     let mut rng = create_seeded_rng();
     let mut mem_config = MemoryConfig::default();
     if [STOREW, STOREB, STOREH].contains(&opcode) {
-        mem_config.addr_space_sizes[PUBLIC_VALUES_AS as usize] = 1 << 29;
+        mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     }
     let mut tester = VmChipTestBuilder::volatile(mem_config);
     let mut harness = create_test_chip(&mut tester);


### PR DESCRIPTION
Add trait `AddressSpaceHostLayout` with concrete implementation as enum `MemoryCellType`.

Add `AddressSpaceHostConfig` struct and now `MemoryConfig` stores a vec of these, one per address space.
Now all handling of conversions from raw bytes to `F` is done through this config.

Comparison: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16532679208
Memory finalize time seems to have increased significantly percentage-wise, but it is still on the order of milliseconds so I think negligible?