### PR TITLE
fix: native `FriReducedOpeningRecord` size calculation

### DIFF
--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -676,6 +676,9 @@ impl<F> SizedRecord<FriReducedOpeningLayout> for FriReducedOpeningRecordMut<'_, 
     fn size(layout: &FriReducedOpeningLayout) -> usize {
         let mut total_len = size_of::<FriReducedOpeningHeaderRecord>();
         total_len += layout.metadata.length * size_of::<FriReducedOpeningWorkloadRowRecord<F>>();
+        if !layout.metadata.is_init {
+            total_len += layout.metadata.length * size_of::<F>();
+        }
         total_len += size_of::<FriReducedOpeningCommonRecord<F>>();
         total_len
     }


### PR DESCRIPTION
The size of `a_prev_buf` (i.e. `a_prev_size`) was not being factored in the size calculation for `FriReducedOpeningRecordMut`, sometimes making the record too small.