### PR TITLE
chore: make `SdkVmConfig::to_inner` pub

### DIFF
--- a/crates/sdk/src/config/global.rs
+++ b/crates/sdk/src/config/global.rs
@@ -156,7 +156,7 @@ impl AsMut<SystemConfig> for SdkVmConfig {
 }
 
 impl SdkVmConfig {
-    fn to_inner(&self) -> SdkVmConfigInner {
+    pub fn to_inner(&self) -> SdkVmConfigInner {
         let system = self.system.config.clone();
         let rv32i = self.rv32i.map(|_| Rv32I);
         let io = self.io.map(|_| Rv32Io);


### PR DESCRIPTION
`SdkVmConfigInner` is the more natural struct to work with, `SdkVmConfig` is just for serialization convenience.