### PR TITLE
chore: `PairingProverExt` is vacuous

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -25,7 +25,7 @@ use openvm_ecc_transpiler::EccTranspilerExtension;
 use openvm_keccak256_circuit::{Keccak256, Keccak256CpuProverExt, Keccak256Executor};
 use openvm_keccak256_transpiler::Keccak256TranspilerExtension;
 use openvm_pairing_circuit::{
-    PairingCpuProverExt, PairingCurve, PairingExtension, PairingExtensionExecutor,
+    PairingCurve, PairingExtension, PairingExtensionExecutor, PairingProverExt,
 };
 use openvm_pairing_guest::bn254::BN254_COMPLEX_STRUCT_NAME;
 use openvm_pairing_transpiler::PairingTranspilerExtension;
@@ -176,11 +176,7 @@ where
             &config.weierstrass,
             inventory,
         )?;
-        VmProverExtension::<E, _, _>::extend_prover(
-            &PairingCpuProverExt,
-            &config.pairing,
-            inventory,
-        )?;
+        VmProverExtension::<E, _, _>::extend_prover(&PairingProverExt, &config.pairing, inventory)?;
         Ok(chip_complex)
     }
 }

--- a/crates/sdk/src/config/global.rs
+++ b/crates/sdk/src/config/global.rs
@@ -24,7 +24,7 @@ use openvm_native_circuit::{
     CastFExtension, CastFExtensionExecutor, Native, NativeCpuProverExt, NativeExecutor,
 };
 use openvm_native_transpiler::LongFormTranspilerExtension;
-use openvm_pairing_circuit::{PairingCpuProverExt, PairingExtension, PairingExtensionExecutor};
+use openvm_pairing_circuit::{PairingExtension, PairingExtensionExecutor, PairingProverExt};
 use openvm_pairing_transpiler::PairingTranspilerExtension;
 use openvm_rv32im_circuit::{
     Rv32I, Rv32IExecutor, Rv32ImCpuProverExt, Rv32Io, Rv32IoExecutor, Rv32M, Rv32MExecutor,
@@ -274,7 +274,7 @@ where
             VmProverExtension::<E, _, _>::extend_prover(&AlgebraCpuProverExt, fp2, inventory)?;
         }
         if let Some(pairing) = &config.pairing {
-            VmProverExtension::<E, _, _>::extend_prover(&PairingCpuProverExt, pairing, inventory)?;
+            VmProverExtension::<E, _, _>::extend_prover(&PairingProverExt, pairing, inventory)?;
         }
         if let Some(ecc) = &config.ecc {
             VmProverExtension::<E, _, _>::extend_prover(&EccCpuProverExt, ecc, inventory)?;

--- a/extensions/pairing/circuit/src/config.rs
+++ b/extensions/pairing/circuit/src/config.rs
@@ -100,11 +100,7 @@ where
             &config.weierstrass,
             inventory,
         )?;
-        VmProverExtension::<E, _, _>::extend_prover(
-            &PairingCpuProverExt,
-            &config.pairing,
-            inventory,
-        )?;
+        VmProverExtension::<E, _, _>::extend_prover(&PairingProverExt, &config.pairing, inventory)?;
         Ok(chip_complex)
     }
 }


### PR DESCRIPTION
`PairingProverExt` is backend agnostic because it is vacuous and the pairing extension only consists of phantom sub-executors.

Also changed a trait bound from `PrimeField32` to just `Field`