### PR TITLE
chore: remove `DenseRecordArena::current_size`

### DIFF
--- a/crates/vm/src/arch/record_arena.rs
+++ b/crates/vm/src/arch/record_arena.rs
@@ -182,12 +182,9 @@ impl DenseRecordArena {
         self.records_buffer = cursor;
     }
 
-    /// Returns the current size of the allocated buffer so far.
-    pub fn current_size(&self) -> usize {
-        self.records_buffer.position() as usize
-    }
-
     /// Returns the allocated size of the arena in bytes.
+    ///
+    /// **Note**: This may include additional bytes for alignment.
     pub fn capacity(&self) -> usize {
         self.records_buffer.get_ref().len()
     }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -1051,6 +1051,6 @@ mod tests {
                 }
             }
         }
-        assert_eq!(memory.access_adapter_records.current_size(), 0);
+        assert!(memory.access_adapter_records.allocated().is_empty());
     }
 }


### PR DESCRIPTION
The function is confusing and easy to misuse because it includes the initial offset bytes which are only for alignment correct purposes.