### PR TITLE
feat: add "stark-debug" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6000,7 +6000,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.2.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.0#9fd9157032c6f042a116c11d7117bf84ab059435"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.1#2bf6fd20e3c77cabe01f830d06e6439ea101f98e"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -6028,7 +6028,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.2.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.0#9fd9157032c6f042a116c11d7117bf84ab059435"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.1#2bf6fd20e3c77cabe01f830d06e6439ea101f98e"
 dependencies = [
  "dashmap",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0-rc.0", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0-rc.0", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0-rc.1", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0-rc.1", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/benchmarks/prove/Cargo.toml
+++ b/benchmarks/prove/Cargo.toml
@@ -35,7 +35,9 @@ tracing.workspace = true
 default = ["parallel", "jemalloc", "metrics"]
 metrics = ["openvm-sdk/metrics"]
 perf-metrics = ["openvm-sdk/perf-metrics", "metrics"]
-aggregation = []                                    # runs leaf aggregation benchmarks
+stark-debug = ["openvm-sdk/stark-debug"]
+# runs leaf aggregation benchmarks:
+aggregation = []
 evm = ["openvm-sdk/evm-verify"]
 parallel = ["openvm-sdk/parallel"]
 mimalloc = ["openvm-sdk/mimalloc"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -81,6 +81,8 @@ metrics = [
 ]
 # for guest profiling:
 perf-metrics = ["openvm-circuit/perf-metrics", "openvm-transpiler/function-span"]
+# turns on stark-backend debugger in all proofs
+stark-debug = ["openvm-circuit/stark-debug"]
 test-utils = ["openvm-circuit/test-utils"]
 # performance features:
 # (rayon is always imported because of halo2, so "parallel" feature is redundant)

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -55,7 +55,6 @@ parallel = [
     "dashmap/rayon",
     "openvm-stark-sdk?/parallel",
 ]
-test-utils = ["openvm-stark-sdk"]
 metrics = [
     "dep:metrics",
     "openvm-stark-backend/metrics",
@@ -65,6 +64,9 @@ metrics = [
 perf-metrics = ["metrics"]
 # use basic memory instead of mmap:
 basic-memory = []
+# turns on stark-backend debugger in all proofs
+stark-debug = []
+test-utils = ["openvm-stark-sdk"]
 # performance features:
 mimalloc = ["openvm-stark-backend/mimalloc"]
 jemalloc = ["openvm-stark-backend/jemalloc"]

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -1,10 +1,8 @@
-use itertools::{multiunzip, Itertools};
 use openvm_instructions::exe::VmExe;
 use openvm_stark_backend::{
     config::{Com, Val},
     engine::VerificationData,
     p3_field::PrimeField32,
-    prover::{hal::DeviceDataTransporter, types::AirProofRawInput},
 };
 use openvm_stark_sdk::{
     config::{
@@ -17,9 +15,9 @@ use openvm_stark_sdk::{
 
 use crate::{
     arch::{
-        execution_mode::metered::Segment, vm::VirtualMachine, ExitCode, InsExecutorE1,
-        InsExecutorE2, InstructionExecutor, MatrixRecordArena, PreflightExecutionOutput, Streams,
-        VmBuilder, VmCircuitConfig, VmConfig, VmExecutionConfig,
+        debug_proving_ctx, execution_mode::metered::Segment, vm::VirtualMachine, ExitCode,
+        InsExecutorE1, InsExecutorE2, InstructionExecutor, MatrixRecordArena,
+        PreflightExecutionOutput, Streams, VmBuilder, VmCircuitConfig, VmConfig, VmExecutionConfig,
     },
     system::memory::{MemoryImage, CHUNK},
 };
@@ -129,7 +127,6 @@ where
     let exe = committed_exe.exe;
 
     let mut state = Some(vm.create_initial_state(&exe, input));
-    let global_airs = vm.config().create_airs().unwrap().into_airs().collect_vec();
     let mut proofs = Vec::new();
     let mut exit_code = None;
     for segment in segments {
@@ -150,33 +147,8 @@ where
         exit_code = system_records.exit_code;
 
         let ctx = vm.generate_proving_ctx(system_records, record_arenas)?;
-        let device = vm.engine.device();
         if debug {
-            let (airs, pks, proof_inputs): (Vec<_>, Vec<_>, Vec<_>) =
-                multiunzip(ctx.per_air.iter().map(|(air_id, air_ctx)| {
-                    // Unfortunate H2D transfers
-                    let cached_mains = air_ctx
-                        .cached_mains
-                        .iter()
-                        .map(|pre| device.transport_matrix_from_device_to_host(&pre.trace))
-                        .collect_vec();
-                    let common_main = air_ctx
-                        .common_main
-                        .as_ref()
-                        .map(|m| device.transport_matrix_from_device_to_host(m));
-                    let public_values = air_ctx.public_values.clone();
-                    let raw = AirProofRawInput {
-                        cached_mains,
-                        common_main,
-                        public_values,
-                    };
-                    (
-                        global_airs[*air_id].clone(),
-                        pk.per_air[*air_id].clone(),
-                        raw,
-                    )
-                }));
-            vm.engine.debug(&airs, &pks, &proof_inputs);
+            debug_proving_ctx(&vm, &pk, &ctx);
         }
         let proof = vm.engine.prove(vm.pk(), ctx);
         proofs.push(proof);


### PR DESCRIPTION
Adds a new "stark-debug" feature to `openvm-circuit` and `openvm-sdk` for debugging purposes: when turned on, we pay a performance penalty to run the stark-backend debugger on all trace matrices before generating the proof. The debugger checks the constraints logically instead of cryptographically, which gives more information failure information.

Also updated stark-backend to tag `v1.2.0-rc.1` which updates to make logs at info level a little less verbose.