### PR TITLE
fix(new-execution): always inline `execute_impl`

### DIFF
--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -206,7 +206,7 @@ where
     }
 }
 
-#[inline(never)]
+#[inline(always)]
 unsafe fn execute_impl<F: PrimeField32, Ctx: E1ExecutionCtx>(
     program: &Program<F>,
     vm_state: &mut VmSegmentState<F, GuestMemory, Ctx>,


### PR DESCRIPTION
- use `#[inline(always)]` to be consistent
- no significant perf difference ([benchmark](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16653883404))