### PR TITLE
feat(new-execution): store precomputed instructions in mmapped memory 

### DIFF
--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -253,7 +253,7 @@ unsafe fn execute_impl<F: PrimeField32, Ctx: E1ExecutionCtx>(
 
         // The mmap will segfault if pc_index is out of bounds
         let pc_index = ((vm_state.pc - program.pc_base) / DEFAULT_PC_STEP) as usize;
-        let inst = unsafe { &*fn_ptrs_base.add(pc_index) };
+        let inst = unsafe { core::ptr::read(fn_ptrs_base.add(pc_index)) };
         unsafe { (inst.handler)(inst.pre_compute, vm_state) };
     }
     if vm_state


### PR DESCRIPTION
- [benchmark 1](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16652464904)
- [benchmark 2](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16653295217)