### PR TITLE
fix(new-execution): fetch segments properly in kitchen_sink

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -263,7 +263,7 @@ fn benchmark_execute_metered(bencher: Bencher, program: &str) {
 // &exe, vec![], 0);
 
 //             let (widths, interactions) = shared_widths_and_interactions();
-//             let segments = vm
+//             let (segments, _) = vm
 //                 .executor
 //                 .execute_metered(exe.clone(), vec![], interactions)
 //                 .expect("Failed to execute program");

--- a/benchmarks/prove/src/bin/kitchen_sink.rs
+++ b/benchmarks/prove/src/bin/kitchen_sink.rs
@@ -48,7 +48,7 @@ fn verify_native_max_trace_heights(
         let exe = leaf_prover.exe().clone();
         let vm = &mut leaf_prover.vm;
         let metered_ctx = vm.build_metered_ctx();
-        let segments = vm.executor().execute_metered(
+        let (segments, _) = vm.executor().execute_metered(
             app_pk.leaf_committed_exe.exe.clone(),
             leaf_input.write_to_stream(),
             &executor_idx_to_air_idx,


### PR DESCRIPTION
should fix ci in `feat/new-execution`