### PR TITLE
feat: `InterpretedInstance` holds pre-computed handlers

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -11,12 +11,7 @@ use openvm_benchmarks_utils::{get_elf_path, get_programs_dir, read_elf_file};
 use openvm_bigint_circuit::{Int256, Int256CpuProverExt, Int256Executor};
 use openvm_bigint_transpiler::Int256TranspilerExtension;
 use openvm_circuit::{
-    arch::{
-        execution_mode::{e1::E1Ctx, metered::MeteredCtx},
-        instructions::exe::VmExe,
-        interpreter::InterpretedInstance,
-        *,
-    },
+    arch::{execution_mode::metered::MeteredCtx, instructions::exe::VmExe, *},
     derive::VmConfig,
     system::*,
 };
@@ -224,12 +219,13 @@ fn benchmark_execute(bencher: Bencher, program: &str) {
         .with_inputs(|| {
             let vm_config = ExecuteConfig::default();
             let exe = load_program_executable(program).expect("Failed to load program executable");
-            let interpreter = InterpretedInstance::new(vm_config, exe).unwrap();
+            let executor = VmExecutor::<BabyBear, _>::new(vm_config).unwrap();
+            let interpreter = executor.instance(&exe).unwrap();
             (interpreter, vec![])
         })
         .bench_values(|(interpreter, input)| {
             interpreter
-                .execute(E1Ctx::new(None), input)
+                .execute(input, None)
                 .expect("Failed to execute program in interpreted mode");
         });
 }
@@ -242,13 +238,16 @@ fn benchmark_execute_metered(bencher: Bencher, program: &str) {
             let exe = load_program_executable(program).expect("Failed to load program executable");
 
             let (ctx, executor_idx_to_air_idx) = metering_setup();
-            let interpreter = InterpretedInstance::new(vm_config, exe).unwrap();
+            let executor = VmExecutor::<BabyBear, _>::new(vm_config).unwrap();
+            let interpreter = executor
+                .metered_instance(&exe, executor_idx_to_air_idx)
+                .unwrap();
 
-            (interpreter, vec![], ctx.clone(), executor_idx_to_air_idx)
+            (interpreter, vec![], ctx.clone())
         })
-        .bench_values(|(interpreter, input, ctx, executor_idx_to_air_idx)| {
+        .bench_values(|(interpreter, input, ctx)| {
             interpreter
-                .execute_e2(ctx, input, executor_idx_to_air_idx)
+                .execute_metered(input, ctx)
                 .expect("Failed to execute program");
         });
 }

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -68,9 +68,7 @@ pub(super) fn compute_root_proof_heights(
     // after tracegen:
     let mut trace_heights = NATIVE_MAX_TRACE_HEIGHTS.to_vec();
     trace_heights[PUBLIC_VALUES_AIR_ID] = num_public_values as u32;
-    let state = root_vm
-        .executor()
-        .create_initial_state(&root_committed_exe.exe, root_input.write());
+    let state = root_vm.create_initial_state(&root_committed_exe.exe, root_input.write());
     let cached_program_trace = root_vm.transport_committed_exe_to_device(root_committed_exe);
     root_vm.load_program(cached_program_trace);
     root_vm.transport_init_memory_to_device(&state.memory);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -185,10 +185,13 @@ where
         VC: VmExecutionConfig<F> + AsRef<SystemConfig> + Clone,
         VC::Executor: Clone + InsExecutorE1<F> + InsExecutorE2<F>,
     {
-        let vm = VmExecutor::new(vm_config)?;
-        let final_memory = vm.execute_e1(exe, inputs, None)?.memory;
-        let public_values =
-            extract_public_values(vm.config.as_ref().num_public_values, &final_memory.memory);
+        let executor = VmExecutor::new(vm_config)?;
+        let instance = executor.instance(&exe)?;
+        let final_memory = instance.execute(inputs, None)?.memory;
+        let public_values = extract_public_values(
+            executor.config.as_ref().num_public_values,
+            &final_memory.memory,
+        );
         Ok(public_values)
     }
 

--- a/crates/toolchain/tests/tests/riscv_test_vectors.rs
+++ b/crates/toolchain/tests/tests/riscv_test_vectors.rs
@@ -39,7 +39,8 @@ fn test_rv32im_riscv_vector_runtime() -> Result<()> {
                         .with_extension(Rv32MTranspilerExtension)
                         .with_extension(Rv32IoTranspilerExtension),
                 )?;
-                let interpreter = VmExecutor::new(config.clone())?.instance(&exe)?;
+                let executor = VmExecutor::new(config.clone())?;
+                let interpreter = executor.instance(&exe)?;
                 let _state = interpreter.execute(vec![], None)?;
                 Ok(())
             });

--- a/crates/toolchain/tests/tests/riscv_test_vectors.rs
+++ b/crates/toolchain/tests/tests/riscv_test_vectors.rs
@@ -2,7 +2,7 @@ use std::{fs::read_dir, path::PathBuf};
 
 use eyre::Result;
 use openvm_circuit::{
-    arch::{execution_mode::e1::E1Ctx, instructions::exe::VmExe, interpreter::InterpretedInstance},
+    arch::{instructions::exe::VmExe, VmExecutor},
     utils::air_test,
 };
 use openvm_rv32im_circuit::{Rv32ImConfig, Rv32ImCpuBuilder};
@@ -39,9 +39,8 @@ fn test_rv32im_riscv_vector_runtime() -> Result<()> {
                         .with_extension(Rv32MTranspilerExtension)
                         .with_extension(Rv32IoTranspilerExtension),
                 )?;
-                let interpreter = InterpretedInstance::new(config.clone(), exe)?;
-                let state = interpreter.execute(E1Ctx::new(None), vec![])?;
-                state.exit_code?;
+                let interpreter = VmExecutor::new(config.clone())?.instance(&exe)?;
+                let _state = interpreter.execute(vec![], None)?;
                 Ok(())
             });
 

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -9,10 +9,7 @@ use openvm_algebra_circuit::*;
 use openvm_algebra_transpiler::{Fp2TranspilerExtension, ModularTranspilerExtension};
 use openvm_bigint_circuit::*;
 use openvm_circuit::{
-    arch::{
-        execution_mode::e1::E1Ctx, interpreter::InterpretedInstance, InitFileGenerator,
-        SystemConfig,
-    },
+    arch::{InitFileGenerator, SystemConfig, VmExecutor},
     derive::VmConfig,
     system::SystemExecutor,
     utils::air_test,
@@ -77,8 +74,8 @@ fn test_rv32im_runtime(elf_path: &str) -> Result<()> {
             .with_extension(Rv32IoTranspilerExtension),
     )?;
     let config = Rv32ImConfig::default();
-    let interpreter = InterpretedInstance::new(config, exe)?;
-    interpreter.execute(E1Ctx::new(None), vec![])?;
+    let interpreter = VmExecutor::new(config)?.instance(&exe)?;
+    interpreter.execute(vec![], None)?;
     Ok(())
 }
 
@@ -140,8 +137,8 @@ fn test_intrinsic_runtime(elf_path: &str) -> Result<()> {
             .with_extension(ModularTranspilerExtension)
             .with_extension(Fp2TranspilerExtension),
     )?;
-    let interpreter = InterpretedInstance::new(config, openvm_exe)?;
-    interpreter.execute(E1Ctx::new(None), vec![])?;
+    let interpreter = VmExecutor::new(config)?.instance(&openvm_exe)?;
+    interpreter.execute(vec![], None)?;
     Ok(())
 }
 

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -74,7 +74,8 @@ fn test_rv32im_runtime(elf_path: &str) -> Result<()> {
             .with_extension(Rv32IoTranspilerExtension),
     )?;
     let config = Rv32ImConfig::default();
-    let interpreter = VmExecutor::new(config)?.instance(&exe)?;
+    let executor = VmExecutor::new(config)?;
+    let interpreter = executor.instance(&exe)?;
     interpreter.execute(vec![], None)?;
     Ok(())
 }
@@ -137,7 +138,8 @@ fn test_intrinsic_runtime(elf_path: &str) -> Result<()> {
             .with_extension(ModularTranspilerExtension)
             .with_extension(Fp2TranspilerExtension),
     )?;
-    let interpreter = VmExecutor::new(config)?.instance(&openvm_exe)?;
+    let executor = VmExecutor::new(config)?;
+    let interpreter = executor.instance(&openvm_exe)?;
     interpreter.execute(vec![], None)?;
     Ok(())
 }

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -24,8 +24,8 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum ExecutionError {
-    #[error("execution failed at pc {pc}")]
-    Fail { pc: u32 },
+    #[error("execution failed at pc {pc}, err: {msg}")]
+    Fail { pc: u32, msg: &'static str },
     #[error("pc {pc} out of bounds for program of length {program_len}, with pc_base {pc_base}")]
     PcOutOfBounds {
         pc: u32,

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -32,6 +32,8 @@ pub enum ExecutionError {
         pc_base: u32,
         program_len: usize,
     },
+    #[error("unreachable instruction at pc {0}")]
+    Unreachable(u32),
     #[error("at pc {pc}, opcode {opcode} was not enabled")]
     DisabledOperation { pc: u32, opcode: VmOpcode },
     #[error("at pc = {pc}")]
@@ -79,6 +81,8 @@ pub enum StaticProgramError {
     InvalidInstruction(u32),
     #[error("Too many executors")]
     TooManyExecutors,
+    #[error("at pc {pc}, opcode {opcode} was not enabled")]
+    DisabledOperation { pc: u32, opcode: VmOpcode },
     #[error("Executor not found for opcode {opcode}")]
     ExecutorNotFound { opcode: VmOpcode },
 }
@@ -113,11 +117,6 @@ pub trait InstructionExecutor<F, RA = MatrixRecordArena<F>>: Clone {
 }
 
 pub type ExecuteFunc<F, CTX> = unsafe fn(&[u8], &mut VmSegmentState<F, GuestMemory, CTX>);
-
-pub struct PreComputeInstruction<'a, F, CTX> {
-    pub handler: ExecuteFunc<F, CTX>,
-    pub pre_compute: &'a [u8],
-}
 
 #[derive(Clone, AlignedBytesBorrow)]
 #[repr(C)]

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -576,8 +576,10 @@ fn check_exit_code(exit_code: Result<Option<u32>, ExecutionError>) -> Result<(),
 
 /// Same as [check_exit_code] but errors if program did not terminate.
 fn check_termination(exit_code: Result<Option<u32>, ExecutionError>) -> Result<(), ExecutionError> {
-    if !matches!(exit_code.as_ref(), Ok(Some(_))) {
-        return Err(ExecutionError::DidNotTerminate);
+    let did_terminate = matches!(exit_code.as_ref(), Ok(Some(_)));
+    check_exit_code(exit_code)?;
+    match did_terminate {
+        true => Ok(()),
+        false => Err(ExecutionError::DidNotTerminate),
     }
-    check_exit_code(exit_code)
 }

--- a/crates/vm/src/system/phantom/execution.rs
+++ b/crates/vm/src/system/phantom/execution.rs
@@ -119,7 +119,10 @@ fn execute_impl<F>(
     // to handle here is DebugPanic.
     if let Some(discr) = SysPhantom::from_repr(discriminant.0) {
         if discr == SysPhantom::DebugPanic {
-            return Err(ExecutionError::Fail { pc: *state.pc });
+            return Err(ExecutionError::Fail {
+                pc: *state.pc,
+                msg: "DebugPanic",
+            });
         }
     }
     sub_executor

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -148,7 +148,10 @@ where
                             eprintln!("openvm program failure; no backtrace");
                         }
                     }
-                    return Err(ExecutionError::Fail { pc });
+                    return Err(ExecutionError::Fail {
+                        pc,
+                        msg: "DebugPanic",
+                    });
                 }
                 #[cfg(feature = "perf-metrics")]
                 SysPhantom::CtStart => {

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -115,12 +115,10 @@ where
     let input = input.into();
     let metered_ctx = vm.build_metered_ctx();
     let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
-    let (segments, _) = vm.executor().execute_metered(
-        exe.clone(),
-        input.clone(),
-        &executor_idx_to_air_idx,
-        metered_ctx,
-    )?;
+    let interpreter = vm
+        .executor()
+        .metered_instance(&exe, &executor_idx_to_air_idx)?;
+    let (segments, _) = interpreter.execute_metered(input.clone(), metered_ctx)?;
     let committed_exe = vm.commit_exe(exe);
     let cached_program_trace = vm.transport_committed_exe_to_device(&committed_exe);
     vm.load_program(cached_program_trace);

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -738,11 +738,8 @@ fn test_vm_pure_execution_non_continuation() {
     ];
 
     let exe = VmExe::new(Program::from_instructions(&instructions));
-
-    let instance = VmExecutor::new(test_native_config())
-        .unwrap()
-        .instance(&exe)
-        .unwrap();
+    let executor = VmExecutor::new(test_native_config()).unwrap();
+    let instance = executor.instance(&exe).unwrap();
     instance.execute(vec![], None).expect("Failed to execute");
 }
 
@@ -767,10 +764,8 @@ fn test_vm_pure_execution_continuation() {
     ];
 
     let exe = VmExe::new(Program::from_instructions(&instructions));
-    let instance = VmExecutor::new(test_native_continuations_config())
-        .unwrap()
-        .instance(&exe)
-        .unwrap();
+    let executor = VmExecutor::new(test_native_continuations_config()).unwrap();
+    let instance = executor.instance(&exe).unwrap();
     instance.execute(vec![], None).expect("Failed to execute");
 }
 
@@ -877,10 +872,8 @@ fn test_vm_e1_native_chips() {
     let exe = VmExe::new(Program::from_instructions(&instructions));
     let input_stream: Vec<Vec<F>> = vec![vec![]];
 
-    let instance = VmExecutor::new(test_rv32_with_kernels_config())
-        .unwrap()
-        .instance(&exe)
-        .unwrap();
+    let executor = VmExecutor::new(test_rv32_with_kernels_config()).unwrap();
+    let instance = executor.instance(&exe).unwrap();
     instance
         .execute(input_stream, None)
         .expect("Failed to execute");

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -7,15 +7,13 @@ use std::{
 use itertools::Itertools;
 use openvm_circuit::{
     arch::{
-        execution_mode::{
-            e1::E1Ctx,
-            metered::{ctx::DEFAULT_SEGMENT_CHECK_INSNS, segment_ctx::SegmentationLimits},
+        execution_mode::metered::{
+            ctx::DEFAULT_SEGMENT_CHECK_INSNS, segment_ctx::SegmentationLimits,
         },
         hasher::{poseidon2::vm_poseidon2_hasher, Hasher},
-        interpreter::InterpretedInstance,
         verify_segments, verify_single, AirInventory, ContinuationVmProver,
         PreflightExecutionOutput, RowMajorMatrixArena, SingleSegmentVmProver, VirtualMachine,
-        VmCircuitConfig, VmLocalProver, PUBLIC_VALUES_AIR_ID,
+        VmCircuitConfig, VmExecutor, VmLocalProver, PUBLIC_VALUES_AIR_ID,
     },
     system::{memory::CHUNK, program::trace::VmCommittedExe, SystemCpuBuilder},
     utils::{air_test, air_test_with_min_segments, test_system_config},
@@ -132,9 +130,7 @@ fn test_vm_override_trace_heights() -> eyre::Result<()> {
     let (mut vm, pk) = VirtualMachine::new_with_keygen(e, NativeCpuBuilder, vm_config)?;
     let vk = pk.get_vk();
 
-    let state = vm
-        .executor()
-        .create_initial_state(&committed_exe.exe, vec![]);
+    let state = vm.create_initial_state(&committed_exe.exe, vec![]);
     vm.transport_init_memory_to_device(&state.memory);
     let cached_program_trace = vm.transport_committed_exe_to_device(&committed_exe);
     vm.load_program(cached_program_trace);
@@ -714,7 +710,7 @@ fn test_vm_pure_execution_non_continuation() {
     Instruction 2 decrements word[0]_4 (using word[1]_4)
     Instruction 3 uses JAL as a simple jump to go back to instruction 1 (repeating the loop).
      */
-    let instructions = vec![
+    let instructions: Vec<Instruction<F>> = vec![
         // word[0]_4 <- word[n]_0
         Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 4, 0, 0, 0),
         // if word[0]_4 == 0 then pc += 3 * DEFAULT_PC_STEP
@@ -741,18 +737,19 @@ fn test_vm_pure_execution_non_continuation() {
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
-    let program = Program::from_instructions(&instructions);
+    let exe = VmExe::new(Program::from_instructions(&instructions));
 
-    let executor = InterpretedInstance::<F, _>::new(test_native_config(), program).unwrap();
-    executor
-        .execute(E1Ctx::default(), vec![])
-        .expect("Failed to execute");
+    let instance = VmExecutor::new(test_native_config())
+        .unwrap()
+        .instance(&exe)
+        .unwrap();
+    instance.execute(vec![], None).expect("Failed to execute");
 }
 
 #[test]
 fn test_vm_pure_execution_continuation() {
     type F = BabyBear;
-    let instructions = vec![
+    let instructions: Vec<Instruction<F>> = vec![
         Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 0, 0, 0),
         Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 4, 0, 0, 0),
         Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 4, 0, 0, 0),
@@ -769,12 +766,12 @@ fn test_vm_pure_execution_continuation() {
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
-    let program = Program::from_instructions(&instructions);
-    let executor =
-        InterpretedInstance::<F, _>::new(test_native_continuations_config(), program).unwrap();
-    executor
-        .execute(E1Ctx::default(), vec![])
-        .expect("Failed to execute");
+    let exe = VmExe::new(Program::from_instructions(&instructions));
+    let instance = VmExecutor::new(test_native_continuations_config())
+        .unwrap()
+        .instance(&exe)
+        .unwrap();
+    instance.execute(vec![], None).expect("Failed to execute");
 }
 
 #[test]
@@ -877,13 +874,15 @@ fn test_vm_e1_native_chips() {
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
-    let program = Program::from_instructions(&instructions);
+    let exe = VmExe::new(Program::from_instructions(&instructions));
     let input_stream: Vec<Vec<F>> = vec![vec![]];
 
-    let executor =
-        InterpretedInstance::<F, _>::new(test_rv32_with_kernels_config(), program).unwrap();
-    executor
-        .execute(E1Ctx::new(None), input_stream)
+    let instance = VmExecutor::new(test_rv32_with_kernels_config())
+        .unwrap()
+        .instance(&exe)
+        .unwrap();
+    instance
+        .execute(input_stream, None)
         .expect("Failed to execute");
 }
 
@@ -911,10 +910,12 @@ fn test_single_segment_executor_no_segmentation() {
         )))
         .collect();
 
-    let program = Program::from_instructions(&instructions);
+    let exe = VmExe::new(Program::from_instructions(&instructions));
     let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
     let metered_ctx = vm.build_metered_ctx();
     vm.executor()
-        .execute_metered(program, vec![], &executor_idx_to_air_idx, metered_ctx)
+        .metered_instance(&exe, &executor_idx_to_air_idx)
+        .unwrap()
+        .execute_metered(vec![], metered_ctx)
         .unwrap();
 }

--- a/extensions/algebra/circuit/src/lib.rs
+++ b/extensions/algebra/circuit/src/lib.rs
@@ -595,7 +595,10 @@ unsafe fn execute_e12_setup_impl<
     };
 
     if input_prime != pre_compute.expr.prime {
-        vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+        vm_state.exit_code = Err(ExecutionError::Fail {
+            pc: vm_state.pc,
+            msg: "ModularSetup: mismatched prime",
+        });
         return;
     }
 

--- a/extensions/ecc/circuit/src/weierstrass_chip/add_ne.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/add_ne.rs
@@ -474,7 +474,10 @@ unsafe fn execute_e12_setup_impl<
     let input_prime = BigUint::from_bytes_le(setup_input_data[..BLOCKS / 2].as_flattened());
 
     if input_prime != pre_compute.expr.prime {
-        vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+        vm_state.exit_code = Err(ExecutionError::Fail {
+            pc: vm_state.pc,
+            msg: "EcAddNe: mismatched prime",
+        });
         return;
     }
 

--- a/extensions/ecc/circuit/src/weierstrass_chip/double.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double.rs
@@ -446,7 +446,10 @@ unsafe fn execute_e12_setup_impl<
     let input_prime = BigUint::from_bytes_le(setup_input_data[..BLOCKS / 2].as_flattened());
 
     if input_prime != pre_compute.expr.builder.prime {
-        vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+        vm_state.exit_code = Err(ExecutionError::Fail {
+            pc: vm_state.pc,
+            msg: "EcDouble: mismatched prime",
+        });
         return;
     }
 
@@ -454,7 +457,10 @@ unsafe fn execute_e12_setup_impl<
     let input_a = BigUint::from_bytes_le(setup_input_data[BLOCKS / 2..].as_flattened());
     let coeff_a = &pre_compute.expr.setup_values[0];
     if input_a != *coeff_a {
-        vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+        vm_state.exit_code = Err(ExecutionError::Fail {
+            pc: vm_state.pc,
+            msg: "EcDouble: mismatched coeff_a",
+        });
         return;
     }
 

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -486,7 +486,10 @@ unsafe fn execute_e12_impl<
         3 => {
             // DIV
             if c_val.is_zero() {
-                vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+                vm_state.exit_code = Err(ExecutionError::Fail {
+                    pc: vm_state.pc,
+                    msg: "DivF divide by zero",
+                });
                 return;
             }
             b_val * c_val.inverse()

--- a/extensions/native/circuit/src/jal_rangecheck/mod.rs
+++ b/extensions/native/circuit/src/jal_rangecheck/mod.rs
@@ -496,7 +496,10 @@ unsafe fn execute_range_check_e12_impl<F: PrimeField32, CTX: E1ExecutionCtx>(
 
         // The range of `b`,`c` had already been checked in `pre_compute_e1`.
         if !(x < (1 << b) && y < (1 << c)) {
-            vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+            vm_state.exit_code = Err(ExecutionError::Fail {
+                pc: vm_state.pc,
+                msg: "NativeRangeCheck",
+            });
             return;
         }
     }

--- a/extensions/native/compiler/tests/arithmetic.rs
+++ b/extensions/native/compiler/tests/arithmetic.rs
@@ -1,4 +1,5 @@
 use openvm_circuit::arch::{ExecutionError, VmExecutor};
+use openvm_instructions::exe::VmExe;
 use openvm_native_circuit::{execute_program, NativeConfig};
 use openvm_native_compiler::{
     asm::{AsmBuilder, AsmCompiler, AsmConfig},
@@ -391,9 +392,10 @@ fn assert_failed_assertion(
     builder: Builder<AsmConfig<BabyBear, BinomialExtensionField<BabyBear, 4>>>,
 ) {
     let program = builder.compile_isa();
+    let exe = VmExe::new(program);
 
     let config = NativeConfig::aggregation(4, 3);
-    let executor = VmExecutor::new(config).unwrap();
-    let result = executor.execute_e1(program, vec![], None);
+    let instance = VmExecutor::new(config).unwrap().instance(&exe).unwrap();
+    let result = instance.execute(vec![], None);
     assert!(matches!(result, Err(ExecutionError::Fail { .. })));
 }

--- a/extensions/native/compiler/tests/arithmetic.rs
+++ b/extensions/native/compiler/tests/arithmetic.rs
@@ -397,5 +397,9 @@ fn assert_failed_assertion(
     let config = NativeConfig::aggregation(4, 3);
     let instance = VmExecutor::new(config).unwrap().instance(&exe).unwrap();
     let result = instance.execute(vec![], None);
-    assert!(matches!(result, Err(ExecutionError::Fail { .. })));
+    assert!(
+        matches!(result, Err(ExecutionError::Fail { .. })),
+        "Unexpected result: {:?}",
+        result.err()
+    );
 }

--- a/extensions/native/compiler/tests/arithmetic.rs
+++ b/extensions/native/compiler/tests/arithmetic.rs
@@ -395,7 +395,8 @@ fn assert_failed_assertion(
     let exe = VmExe::new(program);
 
     let config = NativeConfig::aggregation(4, 3);
-    let instance = VmExecutor::new(config).unwrap().instance(&exe).unwrap();
+    let executor = VmExecutor::new(config).unwrap();
+    let instance = executor.instance(&exe).unwrap();
     let result = instance.execute(vec![], None);
     assert!(
         matches!(result, Err(ExecutionError::Fail { .. })),

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -399,7 +399,10 @@ unsafe fn execute_e12_impl<
         sign_extended.to_le_bytes()
     } else {
         if shift_amount != 0 && shift_amount != 2 {
-            vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+            vm_state.exit_code = Err(ExecutionError::Fail {
+                pc: vm_state.pc,
+                msg: "LoadSignExtend invalid shift amount",
+            });
             return;
         }
         let half: [u8; 2] = array::from_fn(|i| read_data[shift_amount as usize + i]);

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -507,7 +507,10 @@ unsafe fn execute_e12_impl<
     };
 
     if !OP::compute_write_data(&mut write_data, read_data, shift_amount as usize) {
-        vm_state.exit_code = Err(ExecutionError::Fail { pc: vm_state.pc });
+        vm_state.exit_code = Err(ExecutionError::Fail {
+            pc: vm_state.pc,
+            msg: "Invalid LoadStoreOp",
+        });
         return;
     }
 

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -174,8 +174,8 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
 
-        let executor = VmExecutor::new(config.clone())?;
-        let state = executor.execute_e1(exe, vec![], None)?;
+        let instance = VmExecutor::new(config.clone())?.instance(&exe)?;
+        let state = instance.execute(vec![], None)?;
         let final_memory = state.memory.memory;
         let hasher = vm_poseidon2_hasher::<F>();
         let pv_proof = UserPublicValuesProof::compute(
@@ -230,9 +230,9 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
 
-        let executor = VmExecutor::new(config)?;
+        let instance = VmExecutor::new(config)?.instance(&exe)?;
         let input = vec![[0, 0, 0, 1].map(F::from_canonical_u8).to_vec()];
-        match executor.execute_e1(exe.clone(), input.clone(), None) {
+        match instance.execute(input.clone(), None) {
             Err(ExecutionError::FailedWithExitCode(_)) => Ok(()),
             Err(_) => panic!("should fail with `FailedWithExitCode`"),
             Ok(_) => panic!("should fail"),
@@ -292,8 +292,11 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )
         .unwrap();
-        let executor = VmExecutor::<F, _>::new(config.clone()).unwrap();
-        executor.execute_e1(exe, vec![], None).unwrap();
+        let instance = VmExecutor::<F, _>::new(config.clone())
+            .unwrap()
+            .instance(&exe)
+            .unwrap();
+        instance.execute(vec![], None).unwrap();
     }
 
     #[test_case("getrandom", vec!["getrandom", "getrandom-unsupported"])]

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -174,7 +174,8 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
 
-        let instance = VmExecutor::new(config.clone())?.instance(&exe)?;
+        let executor = VmExecutor::new(config.clone())?;
+        let instance = executor.instance(&exe)?;
         let state = instance.execute(vec![], None)?;
         let final_memory = state.memory.memory;
         let hasher = vm_poseidon2_hasher::<F>();
@@ -230,7 +231,8 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
 
-        let instance = VmExecutor::new(config)?.instance(&exe)?;
+        let executor = VmExecutor::new(config)?;
+        let instance = executor.instance(&exe)?;
         let input = vec![[0, 0, 0, 1].map(F::from_canonical_u8).to_vec()];
         match instance.execute(input.clone(), None) {
             Err(ExecutionError::FailedWithExitCode(_)) => Ok(()),
@@ -292,10 +294,8 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )
         .unwrap();
-        let instance = VmExecutor::<F, _>::new(config.clone())
-            .unwrap()
-            .instance(&exe)
-            .unwrap();
+        let executor = VmExecutor::new(config).unwrap();
+        let instance = executor.instance(&exe).unwrap();
         instance.execute(vec![], None).unwrap();
     }
 


### PR DESCRIPTION
For ultra-low latency, all data that can be pre-computed once the program binary is known should be held in `InterpretedInstance` and not re-computed on the fly. This PR does this and closes INT-4470

- `VmExecutor` is constructed once the VM config is known and holds all data that can be determined before given a program binary. (For execution this is only the executors)
- `InterpretedInstance` should be created once the program binary is known and holds all pre-computed buffers and function pointers, so that `execute` can focus on only runtime specific computations.
- Refactored so that the `InterpretedInstance` now provides the only `execute` and `execute_metered` functions, and `VmExecutor` only provides constructors for the `InterpretedInstance`, which is separated between pure (E1) and metered (E2) via the `Ctx` generic.
- Also added the ability to `execute_from_state` for future E1 purposes.
- (Out of scope here) Note that E2 always executes until completion -- the current API seems not designed for any kind of async execution of segments. I think to do this perhaps the easiest is if a separate thread is created with view access to the `SegmentationCtx` which can poll for new `Segment` creation and start off other processes.
- (Out of scope) I want to do a similar refactor for `VirtualMachine` vs a new `VmInstance` type, but going to hold off and try to switch E3 to use `InterpretedInstance` first

The codspeed benchmarks should be largely ignored since any perf improvements are mostly from decreasing the pre-computation time.