### PR TITLE
DON'T MERGE: PoC of preflight execution using pre_compute

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -11,12 +11,7 @@ use openvm_benchmarks_utils::{get_elf_path, get_programs_dir, read_elf_file};
 use openvm_bigint_circuit::{Int256, Int256CpuProverExt, Int256Executor};
 use openvm_bigint_transpiler::Int256TranspilerExtension;
 use openvm_circuit::{
-    arch::{
-        execution_mode::{e1::E1Ctx, metered::MeteredCtx},
-        instructions::exe::VmExe,
-        interpreter::InterpretedInstance,
-        *,
-    },
+    arch::{execution_mode::metered::MeteredCtx, instructions::exe::VmExe, *},
     derive::VmConfig,
     system::*,
 };
@@ -224,12 +219,13 @@ fn benchmark_execute(bencher: Bencher, program: &str) {
         .with_inputs(|| {
             let vm_config = ExecuteConfig::default();
             let exe = load_program_executable(program).expect("Failed to load program executable");
-            let interpreter = InterpretedInstance::new(vm_config, exe).unwrap();
+            let executor = VmExecutor::<BabyBear, _>::new(vm_config).unwrap();
+            let interpreter = executor.instance(&exe).unwrap();
             (interpreter, vec![])
         })
         .bench_values(|(interpreter, input)| {
             interpreter
-                .execute(E1Ctx::new(None), input)
+                .execute(input, None)
                 .expect("Failed to execute program in interpreted mode");
         });
 }
@@ -242,13 +238,16 @@ fn benchmark_execute_metered(bencher: Bencher, program: &str) {
             let exe = load_program_executable(program).expect("Failed to load program executable");
 
             let (ctx, executor_idx_to_air_idx) = metering_setup();
-            let interpreter = InterpretedInstance::new(vm_config, exe).unwrap();
+            let executor = VmExecutor::<BabyBear, _>::new(vm_config).unwrap();
+            let interpreter = executor
+                .metered_instance(&exe, executor_idx_to_air_idx)
+                .unwrap();
 
-            (interpreter, vec![], ctx.clone(), executor_idx_to_air_idx)
+            (interpreter, vec![], ctx.clone())
         })
-        .bench_values(|(interpreter, input, ctx, executor_idx_to_air_idx)| {
+        .bench_values(|(interpreter, input, ctx)| {
             interpreter
-                .execute_e2(ctx, input, executor_idx_to_air_idx)
+                .execute_metered(input, ctx)
                 .expect("Failed to execute program");
         });
 }

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -68,9 +68,7 @@ pub(super) fn compute_root_proof_heights(
     // after tracegen:
     let mut trace_heights = NATIVE_MAX_TRACE_HEIGHTS.to_vec();
     trace_heights[PUBLIC_VALUES_AIR_ID] = num_public_values as u32;
-    let state = root_vm
-        .executor()
-        .create_initial_state(&root_committed_exe.exe, root_input.write());
+    let state = root_vm.create_initial_state(&root_committed_exe.exe, root_input.write());
     let cached_program_trace = root_vm.transport_committed_exe_to_device(root_committed_exe);
     root_vm.load_program(cached_program_trace);
     root_vm.transport_init_memory_to_device(&state.memory);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -185,10 +185,13 @@ where
         VC: VmExecutionConfig<F> + AsRef<SystemConfig> + Clone,
         VC::Executor: Clone + InsExecutorE1<F> + InsExecutorE2<F>,
     {
-        let vm = VmExecutor::new(vm_config)?;
-        let final_memory = vm.execute_e1(exe, inputs, None)?.memory;
-        let public_values =
-            extract_public_values(vm.config.as_ref().num_public_values, &final_memory.memory);
+        let executor = VmExecutor::new(vm_config)?;
+        let instance = executor.instance(&exe)?;
+        let final_memory = instance.execute(inputs, None)?.memory;
+        let public_values = extract_public_values(
+            executor.config.as_ref().num_public_values,
+            &final_memory.memory,
+        );
         Ok(public_values)
     }
 

--- a/crates/toolchain/tests/tests/riscv_test_vectors.rs
+++ b/crates/toolchain/tests/tests/riscv_test_vectors.rs
@@ -2,7 +2,7 @@ use std::{fs::read_dir, path::PathBuf};
 
 use eyre::Result;
 use openvm_circuit::{
-    arch::{execution_mode::e1::E1Ctx, instructions::exe::VmExe, interpreter::InterpretedInstance},
+    arch::{instructions::exe::VmExe, VmExecutor},
     utils::air_test,
 };
 use openvm_rv32im_circuit::{Rv32ImConfig, Rv32ImCpuBuilder};
@@ -39,9 +39,8 @@ fn test_rv32im_riscv_vector_runtime() -> Result<()> {
                         .with_extension(Rv32MTranspilerExtension)
                         .with_extension(Rv32IoTranspilerExtension),
                 )?;
-                let interpreter = InterpretedInstance::new(config.clone(), exe)?;
-                let state = interpreter.execute(E1Ctx::new(None), vec![])?;
-                state.exit_code?;
+                let interpreter = VmExecutor::new(config.clone())?.instance(&exe)?;
+                let _state = interpreter.execute(vec![], None)?;
                 Ok(())
             });
 

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -9,10 +9,7 @@ use openvm_algebra_circuit::*;
 use openvm_algebra_transpiler::{Fp2TranspilerExtension, ModularTranspilerExtension};
 use openvm_bigint_circuit::*;
 use openvm_circuit::{
-    arch::{
-        execution_mode::e1::E1Ctx, interpreter::InterpretedInstance, InitFileGenerator,
-        SystemConfig,
-    },
+    arch::{InitFileGenerator, SystemConfig, VmExecutor},
     derive::VmConfig,
     system::SystemExecutor,
     utils::air_test,
@@ -77,8 +74,8 @@ fn test_rv32im_runtime(elf_path: &str) -> Result<()> {
             .with_extension(Rv32IoTranspilerExtension),
     )?;
     let config = Rv32ImConfig::default();
-    let interpreter = InterpretedInstance::new(config, exe)?;
-    interpreter.execute(E1Ctx::new(None), vec![])?;
+    let interpreter = VmExecutor::new(config)?.instance(&exe)?;
+    interpreter.execute(vec![], None)?;
     Ok(())
 }
 
@@ -140,8 +137,8 @@ fn test_intrinsic_runtime(elf_path: &str) -> Result<()> {
             .with_extension(ModularTranspilerExtension)
             .with_extension(Fp2TranspilerExtension),
     )?;
-    let interpreter = InterpretedInstance::new(config, openvm_exe)?;
-    interpreter.execute(E1Ctx::new(None), vec![])?;
+    let interpreter = VmExecutor::new(config)?.instance(&openvm_exe)?;
+    interpreter.execute(vec![], None)?;
     Ok(())
 }
 

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -125,10 +125,18 @@ pub trait InsExecutorE2<F> {
 pub trait InstructionExecutor<F, RA = MatrixRecordArena<F>>: Clone {
     /// Runtime execution of the instruction, if the instruction is owned by the
     /// current instance. May internally store records of this call for later trace generation.
+    ///
+    /// The `pre_compute` buffer is guaranteed to be populated according to
+    /// [InsExecutorE1::pre_compute_e1] for the given instruction.
+    ///
+    /// The `state` has context `ctx` set to the **single** record arena for this executor.
+    // @dev This is essentially an enum-dispatched version of `ExecuteFunc`. We may consider
+    // switching fully to a function pointer based approach depending on the performance.
+    // @dev Note that `state` has `TracingMemory`
     fn execute(
-        &mut self,
+        &self,
+        pre_compute: &[u8],
         state: VmStateMut<F, TracingMemory, RA>,
-        instruction: &Instruction<F>,
     ) -> Result<(), ExecutionError>;
 
     /// For display purposes. From absolute opcode as `usize`, return the string name of the opcode

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -32,6 +32,8 @@ pub enum ExecutionError {
         pc_base: u32,
         program_len: usize,
     },
+    #[error("unreachable instruction at pc {0}")]
+    Unreachable(u32),
     #[error("at pc {pc}, opcode {opcode} was not enabled")]
     DisabledOperation { pc: u32, opcode: VmOpcode },
     #[error("at pc = {pc}")]
@@ -79,6 +81,8 @@ pub enum StaticProgramError {
     InvalidInstruction(u32),
     #[error("Too many executors")]
     TooManyExecutors,
+    #[error("at pc {pc}, opcode {opcode} was not enabled")]
+    DisabledOperation { pc: u32, opcode: VmOpcode },
     #[error("Executor not found for opcode {opcode}")]
     ExecutorNotFound { opcode: VmOpcode },
 }
@@ -113,11 +117,6 @@ pub trait InstructionExecutor<F, RA = MatrixRecordArena<F>>: Clone {
 }
 
 pub type ExecuteFunc<F, CTX> = unsafe fn(&[u8], &mut VmSegmentState<F, GuestMemory, CTX>);
-
-pub struct PreComputeInstruction<'a, F, CTX> {
-    pub handler: ExecuteFunc<F, CTX>,
-    pub pre_compute: &'a [u8],
-}
 
 #[derive(Clone, AlignedBytesBorrow)]
 #[repr(C)]

--- a/crates/vm/src/arch/execution_mode/tracegen.rs
+++ b/crates/vm/src/arch/execution_mode/tracegen.rs
@@ -1,9 +1,4 @@
-use std::marker::PhantomData;
-
-use crate::{
-    arch::{Arena, ExecutionError, InstructionExecutor, VmSegmentState, VmStateMut},
-    system::{memory::online::TracingMemory, program::PcEntry},
-};
+use crate::arch::Arena;
 
 pub struct TracegenCtx<RA> {
     pub arenas: Vec<RA>,
@@ -25,93 +20,5 @@ impl<RA: Arena> TracegenCtx<RA> {
             arenas,
             instret_end,
         }
-    }
-}
-
-pub struct TracegenExecutionControl<F> {
-    executor_idx_to_air_idx: Vec<usize>,
-    phantom: PhantomData<F>,
-}
-
-impl<F> TracegenExecutionControl<F> {
-    pub fn new(executor_idx_to_air_idx: Vec<usize>) -> Self {
-        Self {
-            executor_idx_to_air_idx,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<F> TracegenExecutionControl<F> {
-    #[inline(always)]
-    pub fn should_suspend<RA>(
-        &self,
-        state: &mut VmSegmentState<F, TracingMemory, TracegenCtx<RA>>,
-    ) -> bool {
-        state
-            .ctx
-            .instret_end
-            .is_some_and(|instret_end| state.instret >= instret_end)
-    }
-
-    #[inline(always)]
-    pub fn on_suspend_or_terminate<RA>(
-        &self,
-        _state: &mut VmSegmentState<F, TracingMemory, TracegenCtx<RA>>,
-        _exit_code: Option<u32>,
-    ) {
-    }
-
-    #[inline(always)]
-    pub fn on_suspend<RA>(&self, state: &mut VmSegmentState<F, TracingMemory, TracegenCtx<RA>>) {
-        self.on_suspend_or_terminate(state, None);
-    }
-
-    #[inline(always)]
-    pub fn on_terminate<RA>(
-        &self,
-        state: &mut VmSegmentState<F, TracingMemory, TracegenCtx<RA>>,
-        exit_code: u32,
-    ) {
-        self.on_suspend_or_terminate(state, Some(exit_code));
-    }
-
-    /// Execute a single instruction
-    #[inline(always)]
-    pub fn execute_instruction<RA, Executor>(
-        &self,
-        state: &mut VmSegmentState<F, TracingMemory, TracegenCtx<RA>>,
-        executor: &mut Executor,
-        pc_entry: &PcEntry<F>,
-    ) -> Result<(), ExecutionError>
-    where
-        Executor: InstructionExecutor<F, RA>,
-    {
-        tracing::trace!(
-            "opcode: {} | timestamp: {}",
-            executor.get_opcode_name(pc_entry.insn.opcode.as_usize()),
-            state.memory.timestamp()
-        );
-        let arena = unsafe {
-            // SAFETY: executor_idx is guarantee to be within bounds by ProgramHandler constructor
-            let air_idx = *self
-                .executor_idx_to_air_idx
-                .get_unchecked(pc_entry.executor_idx as usize);
-            // SAFETY: air_idx is a valid AIR index in the vkey, and always construct arenas with
-            // length equal to num_airs
-            state.ctx.arenas.get_unchecked_mut(air_idx)
-        };
-        let state_mut = VmStateMut {
-            pc: &mut state.vm_state.pc,
-            memory: &mut state.vm_state.memory,
-            streams: &mut state.vm_state.streams,
-            rng: &mut state.vm_state.rng,
-            ctx: arena,
-            #[cfg(feature = "metrics")]
-            metrics: &mut state.vm_state.metrics,
-        };
-        executor.execute(state_mut, &pc_entry.insn)?;
-
-        Ok(())
     }
 }

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -576,8 +576,10 @@ fn check_exit_code(exit_code: Result<Option<u32>, ExecutionError>) -> Result<(),
 
 /// Same as [check_exit_code] but errors if program did not terminate.
 fn check_termination(exit_code: Result<Option<u32>, ExecutionError>) -> Result<(), ExecutionError> {
-    if !matches!(exit_code.as_ref(), Ok(Some(_))) {
-        return Err(ExecutionError::DidNotTerminate);
+    let did_terminate = matches!(exit_code.as_ref(), Ok(Some(_)));
+    check_exit_code(exit_code)?;
+    match did_terminate {
+        true => Ok(()),
+        false => Err(ExecutionError::DidNotTerminate),
     }
-    check_exit_code(exit_code)
 }

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -513,7 +513,7 @@ where
         .map(|(i, (inst_opt, buf))| {
             let buf: &mut [u8] = buf;
             let pre_inst = if let Some((inst, _)) = inst_opt {
-                tracing::trace!("get_e2_pre_compute_instruction {inst:?}");
+                tracing::trace!("get_metered_pre_compute_instruction {inst:?}");
                 let pc = program.pc_base + i as u32 * DEFAULT_PC_STEP;
                 if let Some(handler) = get_system_opcode_handler(inst, buf) {
                     PreComputeInstruction {

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -11,9 +11,8 @@ mod integration_api;
 /// [RecordArena] trait definitions and implementations. Currently there are two concrete
 /// implementations: [MatrixRecordArena] and [DenseRecordArena].
 mod record_arena;
-/// Runtime execution and segmentation
-// TODO: rename this module
-pub mod segment;
+/// VM state definitions
+mod state;
 /// Top level [VmExecutor] and [VirtualMachine] constructor and API.
 pub mod vm;
 
@@ -31,5 +30,5 @@ pub use extensions::*;
 pub use integration_api::*;
 pub use openvm_instructions as instructions;
 pub use record_arena::*;
-pub use segment::*;
+pub use state::*;
 pub use vm::*;

--- a/crates/vm/src/system/phantom/execution.rs
+++ b/crates/vm/src/system/phantom/execution.rs
@@ -16,7 +16,7 @@ use crate::{
     system::{memory::online::GuestMemory, phantom::PhantomExecutor},
 };
 
-#[derive(Clone, AlignedBytesBorrow)]
+#[derive(Clone, Copy, AlignedBytesBorrow)]
 #[repr(C)]
 pub(super) struct PhantomOperands {
     pub(super) a: u32,
@@ -26,9 +26,9 @@ pub(super) struct PhantomOperands {
 
 #[derive(Clone, AlignedBytesBorrow)]
 #[repr(C)]
-struct PhantomPreCompute<F> {
-    operands: PhantomOperands,
-    sub_executor: *const dyn PhantomSubExecutor<F>,
+pub(super) struct PhantomPreCompute<F> {
+    pub operands: PhantomOperands,
+    pub sub_executor: *const dyn PhantomSubExecutor<F>,
 }
 
 impl<F> InsExecutorE1<F> for PhantomExecutor<F>

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -182,10 +182,11 @@ where
     }
 
     fn execute(
-        &mut self,
+        &self,
+        pre_compute: &[u8],
         state: VmStateMut<F, TracingMemory, RA>,
-        instruction: &Instruction<F>,
     ) -> Result<(), ExecutionError> {
+        let pre_compute: &PublicValuesPreCompute<F> = pre_compute.borrow();
         let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
 
         A::start(*state.pc, state.memory, &mut adapter_record);

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -115,12 +115,10 @@ where
     let input = input.into();
     let metered_ctx = vm.build_metered_ctx();
     let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
-    let (segments, _) = vm.executor().execute_metered(
-        exe.clone(),
-        input.clone(),
-        &executor_idx_to_air_idx,
-        metered_ctx,
-    )?;
+    let interpreter = vm
+        .executor()
+        .metered_instance(&exe, &executor_idx_to_air_idx)?;
+    let (segments, _) = interpreter.execute_metered(input.clone(), metered_ctx)?;
     let committed_exe = vm.commit_exe(exe);
     let cached_program_trace = vm.transport_committed_exe_to_device(&committed_exe);
     vm.load_program(cached_program_trace);

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -7,15 +7,13 @@ use std::{
 use itertools::Itertools;
 use openvm_circuit::{
     arch::{
-        execution_mode::{
-            e1::E1Ctx,
-            metered::{ctx::DEFAULT_SEGMENT_CHECK_INSNS, segment_ctx::SegmentationLimits},
+        execution_mode::metered::{
+            ctx::DEFAULT_SEGMENT_CHECK_INSNS, segment_ctx::SegmentationLimits,
         },
         hasher::{poseidon2::vm_poseidon2_hasher, Hasher},
-        interpreter::InterpretedInstance,
         verify_segments, verify_single, AirInventory, ContinuationVmProver,
         PreflightExecutionOutput, RowMajorMatrixArena, SingleSegmentVmProver, VirtualMachine,
-        VmCircuitConfig, VmLocalProver, PUBLIC_VALUES_AIR_ID,
+        VmCircuitConfig, VmExecutor, VmLocalProver, PUBLIC_VALUES_AIR_ID,
     },
     system::{memory::CHUNK, program::trace::VmCommittedExe, SystemCpuBuilder},
     utils::{air_test, air_test_with_min_segments, test_system_config},
@@ -132,9 +130,7 @@ fn test_vm_override_trace_heights() -> eyre::Result<()> {
     let (mut vm, pk) = VirtualMachine::new_with_keygen(e, NativeCpuBuilder, vm_config)?;
     let vk = pk.get_vk();
 
-    let state = vm
-        .executor()
-        .create_initial_state(&committed_exe.exe, vec![]);
+    let state = vm.create_initial_state(&committed_exe.exe, vec![]);
     vm.transport_init_memory_to_device(&state.memory);
     let cached_program_trace = vm.transport_committed_exe_to_device(&committed_exe);
     vm.load_program(cached_program_trace);
@@ -714,7 +710,7 @@ fn test_vm_pure_execution_non_continuation() {
     Instruction 2 decrements word[0]_4 (using word[1]_4)
     Instruction 3 uses JAL as a simple jump to go back to instruction 1 (repeating the loop).
      */
-    let instructions = vec![
+    let instructions: Vec<Instruction<F>> = vec![
         // word[0]_4 <- word[n]_0
         Instruction::large_from_isize(ADD.global_opcode(), 0, n, 0, 4, 0, 0, 0),
         // if word[0]_4 == 0 then pc += 3 * DEFAULT_PC_STEP
@@ -741,18 +737,19 @@ fn test_vm_pure_execution_non_continuation() {
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
-    let program = Program::from_instructions(&instructions);
+    let exe = VmExe::new(Program::from_instructions(&instructions));
 
-    let executor = InterpretedInstance::<F, _>::new(test_native_config(), program).unwrap();
-    executor
-        .execute(E1Ctx::default(), vec![])
-        .expect("Failed to execute");
+    let instance = VmExecutor::new(test_native_config())
+        .unwrap()
+        .instance(&exe)
+        .unwrap();
+    instance.execute(vec![], None).expect("Failed to execute");
 }
 
 #[test]
 fn test_vm_pure_execution_continuation() {
     type F = BabyBear;
-    let instructions = vec![
+    let instructions: Vec<Instruction<F>> = vec![
         Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 0, 0, 0),
         Instruction::large_from_isize(ADD.global_opcode(), 1, 0, 2, 4, 0, 0, 0),
         Instruction::large_from_isize(ADD.global_opcode(), 2, 0, 1, 4, 0, 0, 0),
@@ -769,12 +766,12 @@ fn test_vm_pure_execution_continuation() {
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
-    let program = Program::from_instructions(&instructions);
-    let executor =
-        InterpretedInstance::<F, _>::new(test_native_continuations_config(), program).unwrap();
-    executor
-        .execute(E1Ctx::default(), vec![])
-        .expect("Failed to execute");
+    let exe = VmExe::new(Program::from_instructions(&instructions));
+    let instance = VmExecutor::new(test_native_continuations_config())
+        .unwrap()
+        .instance(&exe)
+        .unwrap();
+    instance.execute(vec![], None).expect("Failed to execute");
 }
 
 #[test]
@@ -877,13 +874,15 @@ fn test_vm_e1_native_chips() {
         Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
     ];
 
-    let program = Program::from_instructions(&instructions);
+    let exe = VmExe::new(Program::from_instructions(&instructions));
     let input_stream: Vec<Vec<F>> = vec![vec![]];
 
-    let executor =
-        InterpretedInstance::<F, _>::new(test_rv32_with_kernels_config(), program).unwrap();
-    executor
-        .execute(E1Ctx::new(None), input_stream)
+    let instance = VmExecutor::new(test_rv32_with_kernels_config())
+        .unwrap()
+        .instance(&exe)
+        .unwrap();
+    instance
+        .execute(input_stream, None)
         .expect("Failed to execute");
 }
 
@@ -911,10 +910,12 @@ fn test_single_segment_executor_no_segmentation() {
         )))
         .collect();
 
-    let program = Program::from_instructions(&instructions);
+    let exe = VmExe::new(Program::from_instructions(&instructions));
     let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
     let metered_ctx = vm.build_metered_ctx();
     vm.executor()
-        .execute_metered(program, vec![], &executor_idx_to_air_idx, metered_ctx)
+        .metered_instance(&exe, &executor_idx_to_air_idx)
+        .unwrap()
+        .execute_metered(vec![], metered_ctx)
         .unwrap();
 }

--- a/extensions/native/compiler/tests/arithmetic.rs
+++ b/extensions/native/compiler/tests/arithmetic.rs
@@ -1,4 +1,5 @@
 use openvm_circuit::arch::{ExecutionError, VmExecutor};
+use openvm_instructions::exe::VmExe;
 use openvm_native_circuit::{execute_program, NativeConfig};
 use openvm_native_compiler::{
     asm::{AsmBuilder, AsmCompiler, AsmConfig},
@@ -391,9 +392,10 @@ fn assert_failed_assertion(
     builder: Builder<AsmConfig<BabyBear, BinomialExtensionField<BabyBear, 4>>>,
 ) {
     let program = builder.compile_isa();
+    let exe = VmExe::new(program);
 
     let config = NativeConfig::aggregation(4, 3);
-    let executor = VmExecutor::new(config).unwrap();
-    let result = executor.execute_e1(program, vec![], None);
+    let instance = VmExecutor::new(config).unwrap().instance(&exe).unwrap();
+    let result = instance.execute(vec![], None);
     assert!(matches!(result, Err(ExecutionError::Fail { .. })));
 }

--- a/extensions/native/compiler/tests/arithmetic.rs
+++ b/extensions/native/compiler/tests/arithmetic.rs
@@ -397,5 +397,9 @@ fn assert_failed_assertion(
     let config = NativeConfig::aggregation(4, 3);
     let instance = VmExecutor::new(config).unwrap().instance(&exe).unwrap();
     let result = instance.execute(vec![], None);
-    assert!(matches!(result, Err(ExecutionError::Fail { .. })));
+    assert!(
+        matches!(result, Err(ExecutionError::Fail { .. })),
+        "Unexpected result: {:?}",
+        result.err()
+    );
 }

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -174,8 +174,8 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
 
-        let executor = VmExecutor::new(config.clone())?;
-        let state = executor.execute_e1(exe, vec![], None)?;
+        let instance = VmExecutor::new(config.clone())?.instance(&exe)?;
+        let state = instance.execute(vec![], None)?;
         let final_memory = state.memory.memory;
         let hasher = vm_poseidon2_hasher::<F>();
         let pv_proof = UserPublicValuesProof::compute(
@@ -230,9 +230,9 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
 
-        let executor = VmExecutor::new(config)?;
+        let instance = VmExecutor::new(config)?.instance(&exe)?;
         let input = vec![[0, 0, 0, 1].map(F::from_canonical_u8).to_vec()];
-        match executor.execute_e1(exe.clone(), input.clone(), None) {
+        match instance.execute(input.clone(), None) {
             Err(ExecutionError::FailedWithExitCode(_)) => Ok(()),
             Err(_) => panic!("should fail with `FailedWithExitCode`"),
             Ok(_) => panic!("should fail"),
@@ -292,8 +292,11 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )
         .unwrap();
-        let executor = VmExecutor::<F, _>::new(config.clone()).unwrap();
-        executor.execute_e1(exe, vec![], None).unwrap();
+        let instance = VmExecutor::<F, _>::new(config.clone())
+            .unwrap()
+            .instance(&exe)
+            .unwrap();
+        instance.execute(vec![], None).unwrap();
     }
 
     #[test_case("getrandom", vec!["getrandom", "getrandom-unsupported"])]


### PR DESCRIPTION
This is for reference and PR should be closed after reviewers have taken a look.

I attempted to try switching E3 `InstructionExecutor` to also use the `pre_compute: &[u8]` pattern from E1 and was able to make a `PreflightInterpretedInstance` struct that replaces the old `VmSegmentExecutor`. The benefit of using `pre_compute` is:
- the `pre_compute` per instruction is much smaller in memory layout than `Instruction<F>`, for better cache locality
- the `pre_compute` allows pre-computations such as Montgomery reduction of `F` to `u32` etc, which speeds up execution

_In principle_ E3 should be able to use the same `pre_compute` as E1 since they are the same form of execution.
In practice, the blocker I ran into is that the `AdapterTraceStep` trait relies on `Instruction<F>` as a common way to pass operands around. It would take a lot of work (I think) to update all `AdapterTraceStep` implementations to not use `Instruction<F>` (and the easiest way is just to delete as many adapters and inline them as possible).
I doubt that cache locality and Monty reduction are the main bottlenecks at the moment, so this doesn't seem like the most fruitful area of optimization.