### PR TITLE
chore: rename segment.rs to state.rs

### DIFF
--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -513,7 +513,7 @@ where
         .map(|(i, (inst_opt, buf))| {
             let buf: &mut [u8] = buf;
             let pre_inst = if let Some((inst, _)) = inst_opt {
-                tracing::trace!("get_e2_pre_compute_instruction {inst:?}");
+                tracing::trace!("get_metered_pre_compute_instruction {inst:?}");
                 let pc = program.pc_base + i as u32 * DEFAULT_PC_STEP;
                 if let Some(handler) = get_system_opcode_handler(inst, buf) {
                     PreComputeInstruction {

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -11,9 +11,8 @@ mod integration_api;
 /// [RecordArena] trait definitions and implementations. Currently there are two concrete
 /// implementations: [MatrixRecordArena] and [DenseRecordArena].
 mod record_arena;
-/// Runtime execution and segmentation
-// TODO: rename this module
-pub mod segment;
+/// VM state definitions
+mod state;
 /// Top level [VmExecutor] and [VirtualMachine] constructor and API.
 pub mod vm;
 
@@ -31,5 +30,5 @@ pub use extensions::*;
 pub use integration_api::*;
 pub use openvm_instructions as instructions;
 pub use record_arena::*;
-pub use segment::*;
+pub use state::*;
 pub use vm::*;


### PR DESCRIPTION
Targeting (merge after): https://github.com/openvm-org/openvm/pull/1924

Some code cleanups: segment.rs doesn't really make sense anymore, and I renamed to state.rs and moved `VmState` into that file. 

Will move `VmSegmentExecutor` out into a separate file in another PR.