### PR TITLE
fix(perf-metrics): perf instrumentation slow

### DIFF
--- a/ci/scripts/metric_unify/flamegraph.py
+++ b/ci/scripts/metric_unify/flamegraph.py
@@ -60,6 +60,9 @@ def get_stack_lines(metrics_dict, group_by_kvs, stack_keys, metric_name, sum_met
                     function_symbols = [get_function_symbol(string_table, offset) for offset in symbol_offsets]
                     stack_values.extend(function_symbols)
             else:
+                # don't make a stack frame for empty label
+                if labels[key] == '':
+                    continue
                 stack_values.append(labels[key])
         if filter:
             continue

--- a/crates/vm/src/arch/interpreter_preflight.rs
+++ b/crates/vm/src/arch/interpreter_preflight.rs
@@ -53,6 +53,7 @@ where
             self.execute_instruction(state)?;
             state.instret += 1;
         }
+
         Ok(())
     }
 
@@ -106,7 +107,7 @@ where
 
         #[cfg(feature = "metrics")]
         {
-            crate::metrics::update_instruction_metrics(state, executor, pc_entry);
+            crate::metrics::update_instruction_metrics(state, executor, pc, pc_entry);
         }
 
         Ok(())

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -451,7 +451,7 @@ where
             .memory
             .finalize::<Val<E::SC>>(system_config.continuation_enabled);
         #[cfg(feature = "perf-metrics")]
-        crate::metrics::update_memory_metrics(&mut exec_state);
+        crate::metrics::end_segment_metrics(&mut exec_state);
 
         let memory = exec_state.vm_state.memory;
         let to_state = ExecutionState::new(exec_state.vm_state.pc, memory.timestamp());
@@ -512,7 +512,12 @@ where
             state.metrics.debug_infos = exe.program.debug_infos();
         }
         #[cfg(feature = "perf-metrics")]
-        state.metrics.set_pk_info(&self.pk);
+        {
+            state.metrics.set_pk_info(&self.pk);
+            state.metrics.num_sys_airs = self.config().as_ref().num_airs();
+            state.metrics.access_adapter_offset =
+                self.config().as_ref().access_adapter_air_id_offset();
+        }
         state
     }
 

--- a/crates/vm/src/metrics/mod.rs
+++ b/crates/vm/src/metrics/mod.rs
@@ -11,14 +11,8 @@ use openvm_instructions::{
 use openvm_stark_backend::prover::{hal::ProverBackend, types::DeviceMultiStarkProvingKey};
 
 use crate::{
-    arch::{
-        execution_mode::tracegen::TracegenCtx, Arena, DenseRecordArena, PreflightExecutor,
-        VmExecState,
-    },
-    system::{
-        memory::{adapter::AccessAdapterInventory, online::TracingMemory},
-        program::PcEntry,
-    },
+    arch::{execution_mode::tracegen::TracegenCtx, Arena, PreflightExecutor, VmExecState},
+    system::{memory::online::TracingMemory, program::PcEntry},
 };
 
 pub mod cycle_tracker;
@@ -60,6 +54,7 @@ pub struct VmMetrics {
 pub fn update_instruction_metrics<F, RA, Executor>(
     state: &mut VmExecState<F, TracingMemory, TracegenCtx<RA>>,
     executor: &mut Executor,
+    prev_pc: u32, // the pc of the instruction executed, state.pc is next pc
     pc_entry: &PcEntry<F>,
 ) where
     F: Clone + Send + Sync,
@@ -80,59 +75,56 @@ pub fn update_instruction_metrics<F, RA, Executor>(
         let opcode = pc_entry.insn.opcode;
         let opcode_name = executor.get_opcode_name(opcode.as_usize());
 
-        let num_sys_airs = state.metrics.num_sys_airs;
-        let access_adapter_offset = state.metrics.access_adapter_offset;
-        let debug_info = state.metrics.debug_infos.get(pc);
+        let debug_info = state.metrics.debug_infos.get(prev_pc);
         let dsl_instr = debug_info.as_ref().map(|info| info.dsl_instruction.clone());
 
-        let now_trace_heights = get_dyn_trace_heights_from_arenas::<F, _>(
-            num_sys_airs,
-            access_adapter_offset,
-            &state.memory.access_adapter_records,
-            &state.ctx.arenas,
-        );
-        let mut now_trace_cells = now_trace_heights;
+        let now_trace_heights: Vec<usize> = state
+            .ctx
+            .arenas
+            .iter()
+            .map(|arena| arena.current_trace_height())
+            .collect();
+        let now_trace_cells = zip(&state.metrics.main_widths, &now_trace_heights)
+            .map(|(main_width, h)| main_width * h)
+            .collect_vec();
+        state
+            .metrics
+            .update_trace_cells(now_trace_cells, opcode_name, dsl_instr);
 
-        let metrics = &mut state.metrics;
-        for (main_width, cell_count) in zip(&metrics.main_widths, &mut now_trace_cells) {
-            *cell_count *= main_width;
-        }
-        metrics.update_trace_cells(now_trace_cells, opcode_name, dsl_instr);
-
-        metrics.update_current_fn(pc);
+        state.metrics.update_current_fn(pc);
     }
 }
 
-/// Assumed that `record_arenas` has length equal to number of AIRs.
-///
-/// Best effort calculation of the used trace heights per chip without padding to powers of
-/// two. This is best effort because some periphery chips may not have record arenas
-/// to instrument.
-///
-/// Does not include constant trace heights or the used program trace height.
-pub(crate) fn get_dyn_trace_heights_from_arenas<F, RA>(
-    num_sys_airs: usize,
-    access_adapter_offset: usize,
-    access_adapter_records: &DenseRecordArena,
-    record_arenas: &[RA],
-) -> Vec<usize>
+// Memory access adapter height calculation is slow, so only do it if this is the end of
+// execution:
+#[cfg(feature = "perf-metrics")]
+pub fn update_memory_metrics<F, RA>(state: &mut VmExecState<F, TracingMemory, TracegenCtx<RA>>)
 where
     F: Clone + Send + Sync,
     RA: Arena,
 {
-    // First, get used heights from record arenas
-    let mut heights: Vec<usize> = record_arenas
+    use std::iter::zip;
+
+    use crate::system::memory::adapter::AccessAdapterInventory;
+
+    let access_adapter_offset = state.metrics.access_adapter_offset;
+    let num_sys_airs = state.metrics.num_sys_airs;
+    let mut now_trace_heights: Vec<usize> = state
+        .ctx
+        .arenas
         .iter()
         .map(|arena| arena.current_trace_height())
         .collect();
-    // Memory is special case, so extract the memory AIR's trace heights from the special
-    // arena
     AccessAdapterInventory::<F>::compute_heights_from_arena(
-        access_adapter_records,
-        &mut heights[access_adapter_offset..num_sys_airs],
+        &state.memory.access_adapter_records,
+        &mut now_trace_heights[access_adapter_offset..num_sys_airs],
     );
-
-    heights
+    let now_trace_cells = zip(&state.metrics.main_widths, &now_trace_heights)
+        .map(|(main_width, h)| main_width * h)
+        .collect_vec();
+    state
+        .metrics
+        .update_trace_cells(now_trace_cells, "MEMORY_ACCESS_ADAPTERS".to_string(), None);
 }
 
 impl VmMetrics {

--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -50,6 +50,8 @@ pub struct AccessAdapterInventory<F> {
     chips: Vec<GenericAccessAdapterChip<F>>,
     #[getset(set = "pub")]
     arena: DenseRecordArena,
+    #[cfg(feature = "metrics")]
+    pub(crate) trace_heights: Vec<usize>,
 }
 
 impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
@@ -77,6 +79,8 @@ impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
             memory_config,
             chips,
             arena: DenseRecordArena::with_byte_capacity(0),
+            #[cfg(feature = "metrics")]
+            trace_heights: Vec::new(),
         }
     }
 
@@ -177,6 +181,10 @@ impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
             .zip(heights.iter())
             .map(|(&width, &height)| RowMajorMatrix::new(vec![F::ZERO; width * height], width))
             .collect::<Vec<_>>();
+        #[cfg(feature = "metrics")]
+        {
+            self.trace_heights = heights;
+        }
 
         let mut trace_ptrs = vec![0; num_adapters];
 

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -78,7 +78,7 @@ pub struct MemoryController<F: Field> {
     pub range_checker: SharedVariableRangeCheckerChip,
     // Store separately to avoid smart pointer reference each time
     range_checker_bus: VariableRangeCheckerBus,
-    access_adapter_inventory: AccessAdapterInventory<F>,
+    pub(crate) access_adapter_inventory: AccessAdapterInventory<F>,
     pub(crate) hasher_chip: Option<Arc<Poseidon2PeripheryChip<F>>>,
 }
 

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -477,6 +477,7 @@ where
         use crate::system::memory::interface::MemoryInterface;
 
         let boundary_idx = PUBLIC_VALUES_AIR_ID + usize::from(self.public_values_chip.is_some());
+        let mut access_adapter_offset = boundary_idx + 1;
         match &self.memory_controller.interface_chip {
             MemoryInterface::Volatile { boundary_chip } => {
                 let boundary_height = boundary_chip
@@ -494,6 +495,7 @@ where
                 let boundary_height = 2 * boundary_chip.touched_labels.len();
                 heights[boundary_idx] = boundary_height;
                 heights[boundary_idx + 1] = merkle_chip.current_height;
+                access_adapter_offset += 1;
 
                 // Poseidon2Periphery height also varies based on memory, so set it now even though
                 // it's not a system chip:
@@ -505,6 +507,12 @@ where
                 heights[poseidon_idx] = poseidon_height;
             }
         }
+        let access_heights = &self
+            .memory_controller
+            .access_adapter_inventory
+            .trace_heights;
+        heights[access_adapter_offset..access_adapter_offset + access_heights.len()]
+            .copy_from_slice(access_heights);
     }
 }
 


### PR DESCRIPTION
The per-instruction call to calculate memory access adapter heights is very slow because it iterates linearly through the entire adapter record. I changed it now to only do this at the end. The downside is that we won't be able to see the contribution to access adapters on a per-instruction basis, but this could be extracted more efficiently in a different way.

Proof it works: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16767319820