### PR TITLE
feat: Field zero initialization

### DIFF
--- a/crates/vm/src/system/memory/online/paged_vec.rs
+++ b/crates/vm/src/system/memory/online/paged_vec.rs
@@ -2,6 +2,8 @@ use std::fmt::Debug;
 
 use openvm_stark_backend::p3_maybe_rayon::prelude::*;
 
+use crate::utils::get_zeroed_array;
+
 #[derive(Debug, Clone)]
 pub struct PagedVec<T> {
     pages: Vec<Option<Box<[T]>>>,
@@ -37,8 +39,8 @@ impl<T: Copy + Default> PagedVec<T> {
         );
 
         if self.pages[page_idx].is_none() {
-            let page = vec![T::default(); self.page_size];
-            self.pages[page_idx] = Some(page.into_boxed_slice());
+            let page = get_zeroed_array(self.page_size);
+            self.pages[page_idx] = Some(page);
         }
 
         unsafe {
@@ -73,9 +75,9 @@ impl<T: Copy + Default> PagedVec<T> {
                 *page.get_unchecked_mut(offset) = value;
             }
         } else {
-            let mut page = vec![T::default(); self.page_size];
+            let mut page = get_zeroed_array(self.page_size);
             page[offset] = value;
-            self.pages[page_idx] = Some(page.into_boxed_slice());
+            self.pages[page_idx] = Some(page);
         }
     }
 

--- a/crates/vm/src/utils/mod.rs
+++ b/crates/vm/src/utils/mod.rs
@@ -3,6 +3,8 @@ mod stark_utils;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
+use std::mem::size_of_val;
+
 pub use openvm_circuit_primitives::utils::next_power_of_two_or_zero;
 use openvm_stark_backend::p3_field::PrimeField32;
 #[cfg(any(test, feature = "test-utils"))]
@@ -54,4 +56,29 @@ pub unsafe fn slice_as_bytes<T>(slice: &[T]) -> &[u8] {
     let len = size_of_val(slice);
     // SAFETY: length and alignment are correct.
     unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, len) }
+}
+
+/// Allocates a boxed slice of `T` with all bytes zeroed.
+/// SAFETY: The caller must ensure that zero representation is valid for `T`.
+pub fn get_zeroed_array<T: Sized>(len: usize) -> Box<[T]> {
+    if len == 0 {
+        return Box::new([]);
+    }
+
+    let layout = std::alloc::Layout::array::<T>(len).expect("Layout calculation failed");
+
+    // SAFETY: We're allocating memory and zero-initializing it directly.
+    // This is safe because:
+    // 1. T is Sized, so we know its exact size and alignment
+    // 2. The caller guarantees that zero representation is valid for T
+    // 3. We use the global allocator with the correct layout
+    // 4. We only create the Box after successful allocation and initialization
+    unsafe {
+        let ptr = std::alloc::alloc_zeroed(layout) as *mut T;
+        if ptr.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+        let slice = std::slice::from_raw_parts_mut(ptr, len);
+        Box::from_raw(slice)
+    }
 }


### PR DESCRIPTION
Made a utility function that allocates and initializes a slice of memory with Rust's `alloc_zeroed`. Let me know if there are other places that could use this utility function