### PR TITLE
feat: allow to override compiler's Rust toolchain

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6,8 +6,7 @@ pub mod util;
 use std::process::{Command, Stdio};
 
 use eyre::{Context, Result};
-
-pub const RUSTUP_TOOLCHAIN_NAME: &str = "nightly-2025-02-14";
+pub use openvm_build::{get_rustup_toolchain_name, DEFAULT_RUSTUP_TOOLCHAIN_NAME};
 
 pub const OPENVM_VERSION_MESSAGE: &str = concat!(
     "v",


### PR DESCRIPTION
Previously toolchain version was hardcoded to some version of rust 1.86 nightly.

Sometimes users may want to use custom version, e.g. for some newest nightly Rust feature. In my case, I needed this to compile guest program that depends on main branch of revm as it has 1.88 MSRV.