### PR TITLE
chore: remove an old `assert!(address_space < NATIVE_AS)`

### DIFF
--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -650,12 +650,13 @@ impl TracingMemory {
     }
 
     #[inline(always)]
-    fn split_by_meta<T: Copy, const MIN_BLOCK_SIZE: usize>(
+    fn split_by_meta<const MIN_BLOCK_SIZE: usize>(
         &mut self,
         start_ptr: u32,
         timestamp: u32,
         block_size: u8,
         address_space: usize,
+        cell_size: usize,
     ) {
         if block_size == MIN_BLOCK_SIZE as u8 {
             return;
@@ -676,7 +677,7 @@ impl TracingMemory {
             pointer: start_ptr,
             block_size: block_size as u32,
             lowest_block_size: MIN_BLOCK_SIZE as u32,
-            type_size: size_of::<T>() as u32,
+            type_size: cell_size as u32,
         });
     }
 
@@ -691,6 +692,14 @@ impl TracingMemory {
         prev_values: &[T; BLOCK_SIZE],
     ) -> u32 {
         debug_assert_eq!(ALIGN, self.data.memory.config[address_space].min_block_size);
+        let cell_size = unsafe {
+            self.data
+                .memory
+                .config
+                .get_unchecked(address_space)
+                .layout
+                .size()
+        };
         // Calculate what splits and merges are needed for this memory access
         let result = if let Some((splits, (merge_ptr, merge_size))) =
             self.calculate_splits_and_merges::<BLOCK_SIZE, ALIGN>(address_space, pointer)
@@ -700,11 +709,12 @@ impl TracingMemory {
                 let (_, block_metadata) =
                     self.get_block_metadata::<ALIGN>(address_space, split_ptr);
                 let timestamp = block_metadata.timestamp();
-                self.split_by_meta::<T, ALIGN>(
+                self.split_by_meta::<ALIGN>(
                     split_ptr as u32,
                     timestamp,
                     split_size as u8,
                     address_space,
+                    cell_size,
                 );
             }
 
@@ -722,7 +732,7 @@ impl TracingMemory {
                 let timestamp = if block_metadata.block_size() > 0 {
                     block_metadata.timestamp()
                 } else {
-                    self.handle_uninitialized_memory::<T, ALIGN>(address_space, ptr);
+                    self.handle_uninitialized_memory::<ALIGN>(address_space, ptr, cell_size);
                     INITIAL_TIMESTAMP
                 };
 
@@ -744,7 +754,7 @@ impl TracingMemory {
                     pointer: merge_ptr as u32,
                     block_size: merge_size as u32,
                     lowest_block_size: ALIGN as u32,
-                    type_size: size_of::<T>() as u32,
+                    type_size: cell_size as u32,
                 },
                 // SAFETY: T is plain old data
                 unsafe { slice_as_bytes(prev_values) },
@@ -763,21 +773,23 @@ impl TracingMemory {
 
     /// Handle uninitialized memory by creating appropriate split or merge records.
     #[inline(always)]
-    fn handle_uninitialized_memory<T: Copy, const ALIGN: usize>(
+    fn handle_uninitialized_memory<const ALIGN: usize>(
         &mut self,
         address_space: usize,
         pointer: usize,
+        cell_size: usize,
     ) {
         if self.initial_block_size >= ALIGN {
             // Split the initial block into chunks
             let segment_index = pointer / ALIGN;
             let block_start = segment_index & !(self.initial_block_size / ALIGN - 1);
             let start_ptr = (block_start * ALIGN) as u32;
-            self.split_by_meta::<T, ALIGN>(
+            self.split_by_meta::<ALIGN>(
                 start_ptr,
                 INITIAL_TIMESTAMP,
                 self.initial_block_size as u8,
                 address_space,
+                cell_size,
             );
         } else {
             // Create a merge record for single-byte initialization
@@ -789,7 +801,7 @@ impl TracingMemory {
                     pointer: pointer as u32,
                     block_size: ALIGN as u32,
                     lowest_block_size: self.initial_block_size as u32,
-                    type_size: 1,
+                    type_size: cell_size as u32,
                 },
                 &INITIAL_CELL_BUFFER[..ALIGN],
                 &INITIAL_TIMESTAMP_BUFFER[..ALIGN],

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -2,7 +2,7 @@ use std::{array::from_fn, fmt::Debug, num::NonZero};
 
 use getset::Getters;
 use itertools::zip_eq;
-use openvm_instructions::{exe::SparseMemoryImage, NATIVE_AS};
+use openvm_instructions::exe::SparseMemoryImage;
 use openvm_stark_backend::{
     p3_field::{Field, PrimeField32},
     p3_maybe_rayon::prelude::*,
@@ -690,6 +690,7 @@ impl TracingMemory {
         pointer: usize,
         prev_values: &[T; BLOCK_SIZE],
     ) -> u32 {
+        debug_assert_eq!(ALIGN, self.data.memory.config[address_space].min_block_size);
         // Calculate what splits and merges are needed for this memory access
         let result = if let Some((splits, (merge_ptr, merge_size))) =
             self.calculate_splits_and_merges::<BLOCK_SIZE, ALIGN>(address_space, pointer)
@@ -781,7 +782,6 @@ impl TracingMemory {
         } else {
             // Create a merge record for single-byte initialization
             debug_assert_eq!(self.initial_block_size, 1);
-            debug_assert!((address_space as u32) < NATIVE_AS);
             self.add_merge_record(
                 AccessRecordHeader {
                     timestamp_and_mask: INITIAL_TIMESTAMP,


### PR DESCRIPTION
This resolves INT-4549.

The assertion was a sanity check and it essentially checked that the "type size" should be greater than one. I replaced it with an `debug_assert_eq!(align, min block size from config)`.

While we are there, I also replaced some `cell_size` being `size_of::<T>()` or 1 with another value from config.