### PR TITLE
chore: rename `**Step` to `**Executor`

### DIFF
--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -203,7 +203,7 @@ impl<F, A> FieldExpressionMetadata<F, A> {
 
 impl<F, A> AdapterCoreMetadata for FieldExpressionMetadata<F, A>
 where
-    A: AdapterTraceStep<F>,
+    A: AdapterTraceExecutor<F>,
 {
     #[inline(always)]
     fn get_adapter_width() -> usize {
@@ -234,7 +234,7 @@ impl<'a, F, A> CustomBorrow<'a, FieldExpressionCoreRecordMut<'a>, FieldExpressio
     }
 
     unsafe fn extract_layout(&self) -> FieldExpressionRecordLayout<F, A> {
-        panic!("Should get the Layout information from FieldExpressionStep");
+        panic!("Should get the Layout information from FieldExpressionExecutor");
     }
 }
 
@@ -273,7 +273,7 @@ impl<'a> FieldExpressionCoreRecordMut<'a> {
 }
 
 #[derive(Clone)]
-pub struct FieldExpressionStep<A> {
+pub struct FieldExpressionExecutor<A> {
     adapter: A,
     pub expr: FieldExpr,
     pub offset: usize,
@@ -282,7 +282,7 @@ pub struct FieldExpressionStep<A> {
     pub name: String,
 }
 
-impl<A> FieldExpressionStep<A> {
+impl<A> FieldExpressionExecutor<A> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         adapter: A,
@@ -301,7 +301,7 @@ impl<A> FieldExpressionStep<A> {
         };
         assert_eq!(opcode_flag_idx.len(), local_opcode_idx.len() - 1);
         tracing::info!(
-            "FieldExpressionCoreStep: opcode={name}, main_width={}",
+            "FieldExpressionCoreExecutor: opcode={name}, main_width={}",
             BaseAir::<BabyBear>::width(&expr)
         );
         Self {
@@ -376,10 +376,11 @@ impl<A> FieldExpressionFiller<A> {
     }
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for FieldExpressionStep<A>
+impl<F, A, RA> PreflightExecutor<F, RA> for FieldExpressionExecutor<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData: Into<DynArray<u8>>, WriteData: From<DynArray<u8>>>,
+    A: 'static
+        + AdapterTraceExecutor<F, ReadData: Into<DynArray<u8>>, WriteData: From<DynArray<u8>>>,
     for<'buf> RA: RecordArena<
         'buf,
         FieldExpressionRecordLayout<F, A>,

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -94,8 +94,8 @@ pub struct AdapterAirContext<T, I: VmAdapterInterface<T>> {
 /// Helper trait for CPU tracegen.
 pub trait TraceFiller<F>: Send + Sync {
     /// Populates `trace`. This function will always be called after
-    /// [`TraceStep::execute`], so the `trace` should already contain the records necessary to fill
-    /// in the rest of it.
+    /// [`TraceExecutor::execute`], so the `trace` should already contain the records necessary to
+    /// fill in the rest of it.
     fn fill_trace(
         &self,
         mem_helper: &MemoryAuxColsFactory<F>,
@@ -118,7 +118,7 @@ pub trait TraceFiller<F>: Send + Sync {
     }
 
     /// Populates `row_slice`. This function will always be called after
-    /// [`TraceStep::execute`], so the `row_slice` should already contain context necessary to
+    /// [`TraceExecutor::execute`], so the `row_slice` should already contain context necessary to
     /// fill in the rest of the row. This function will be called for each row in the trace which
     /// is being used, and for all other rows in the trace see `fill_dummy_trace_row`.
     ///
@@ -167,10 +167,10 @@ where
 }
 
 /// A helper trait for expressing generic state accesses within the implementation of
-/// [TraceStep]. Note that this is only a helper trait when the same interface of state access
+/// [TraceExecutor]. Note that this is only a helper trait when the same interface of state access
 /// is reused or shared by multiple implementations. It is not required to implement this trait if
-/// it is easier to implement the [TraceStep] trait directly without this trait.
-pub trait AdapterTraceStep<F>: Clone {
+/// it is easier to implement the [TraceExecutor] trait directly without this trait.
+pub trait AdapterTraceExecutor<F>: Clone {
     const WIDTH: usize;
     type ReadData;
     type WriteData;

--- a/crates/vm/src/arch/record_arena.rs
+++ b/crates/vm/src/arch/record_arena.rs
@@ -569,7 +569,7 @@ impl<M> AdapterCoreLayout<M> {
 }
 
 /// Empty metadata that implements `AdapterCoreMetadata`
-/// **NOTE**: `AS` is the adapter type that implements `AdapterTraceStep`
+/// **NOTE**: `AS` is the adapter type that implements `AdapterTraceExecutor`
 /// **WARNING**: `AS::WIDTH` is the number of field elements, not the size in bytes
 pub struct AdapterCoreEmptyMetadata<F, AS> {
     _phantom: PhantomData<(F, AS)>,
@@ -601,7 +601,7 @@ impl<F, AS> Default for AdapterCoreEmptyMetadata<F, AS> {
 
 impl<F, AS> AdapterCoreMetadata for AdapterCoreEmptyMetadata<F, AS>
 where
-    AS: super::AdapterTraceStep<F>,
+    AS: super::AdapterTraceExecutor<F>,
 {
     #[inline(always)]
     fn get_adapter_width() -> usize {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -67,7 +67,7 @@ use crate::{
             AddressMap, CHUNK,
         },
         program::{trace::VmCommittedExe, ProgramHandler},
-        public_values::PublicValuesStep,
+        public_values::PublicValuesExecutor,
         SystemChipComplex, SystemRecords, SystemWithFixedTraceHeights, PV_EXECUTOR_IDX,
     },
 };
@@ -461,7 +461,7 @@ where
             .then(|| {
                 instance.handler.executors[PV_EXECUTOR_IDX]
                     .as_any_kind()
-                    .downcast_ref::<PublicValuesStep<Val<E::SC>>>()
+                    .downcast_ref::<PublicValuesExecutor<Val<E::SC>>>()
                     .unwrap()
                     .generate_public_values()
             })

--- a/crates/vm/src/system/native_adapter/mod.rs
+++ b/crates/vm/src/system/native_adapter/mod.rs
@@ -29,7 +29,7 @@ use util::{tracing_read_or_imm_native, tracing_write_native};
 
 use super::memory::{online::TracingMemory, MemoryAuxColsFactory};
 use crate::{
-    arch::{get_record_from_slice, AdapterTraceFiller, AdapterTraceStep},
+    arch::{get_record_from_slice, AdapterTraceExecutor, AdapterTraceFiller},
     system::memory::offline_checker::{MemoryReadAuxRecord, MemoryWriteAuxRecord},
 };
 
@@ -170,11 +170,11 @@ pub struct NativeAdapterRecord<F, const R: usize, const W: usize> {
 /// Operands: b for the first read, c for the second read, a for the first write.
 /// If an operand is not used, its address space and pointer should be all 0.
 #[derive(Clone, Debug)]
-pub struct NativeAdapterStep<F, const R: usize, const W: usize> {
+pub struct NativeAdapterExecutor<F, const R: usize, const W: usize> {
     _phantom: PhantomData<F>,
 }
 
-impl<F, const R: usize, const W: usize> Default for NativeAdapterStep<F, R, W> {
+impl<F, const R: usize, const W: usize> Default for NativeAdapterExecutor<F, R, W> {
     fn default() -> Self {
         Self {
             _phantom: PhantomData,
@@ -182,7 +182,7 @@ impl<F, const R: usize, const W: usize> Default for NativeAdapterStep<F, R, W> {
     }
 }
 
-impl<F, const R: usize, const W: usize> AdapterTraceStep<F> for NativeAdapterStep<F, R, W>
+impl<F, const R: usize, const W: usize> AdapterTraceExecutor<F> for NativeAdapterExecutor<F, R, W>
 where
     F: PrimeField32,
 {
@@ -252,7 +252,7 @@ where
 }
 
 impl<F: PrimeField32, const R: usize, const W: usize> AdapterTraceFiller<F>
-    for NativeAdapterStep<F, R, W>
+    for NativeAdapterExecutor<F, R, W>
 {
     const WIDTH: usize = size_of::<NativeAdapterCols<u8, R, W>>();
 

--- a/crates/vm/src/system/public_values/core.rs
+++ b/crates/vm/src/system/public_values/core.rs
@@ -22,7 +22,7 @@ use openvm_stark_backend::{
 use crate::{
     arch::{
         execution_mode::{E1ExecutionCtx, E2ExecutionCtx},
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, E2PreCompute, EmptyAdapterCoreLayout, ExecuteFunc, ExecutionError,
         Executor, MeteredExecutor, MinimalInstruction, PreflightExecutor, RecordArena,
         StaticProgramError, TraceFiller, VmCoreAir, VmExecState, VmStateMut,
@@ -32,7 +32,7 @@ use crate::{
             online::{GuestMemory, TracingMemory},
             MemoryAuxColsFactory,
         },
-        native_adapter::NativeAdapterStep,
+        native_adapter::NativeAdapterExecutor,
         public_values::columns::PublicValuesCoreColsView,
     },
     utils::{transmute_field_to_u32, transmute_u32_to_field},
@@ -125,14 +125,14 @@ pub struct PublicValuesRecord<F> {
 
 /// ATTENTION: If a specific public value is not provided, a default 0 will be used when generating
 /// the proof but in the perspective of constraints, it could be any value.
-pub struct PublicValuesStep<F, A = NativeAdapterStep<F, 2, 0>> {
+pub struct PublicValuesExecutor<F, A = NativeAdapterExecutor<F, 2, 0>> {
     adapter: A,
     encoder: Encoder,
     // Mutex is to make the struct Sync. But it actually won't be accessed by multiple threads.
     pub(crate) custom_pvs: Mutex<Vec<Option<F>>>,
 }
 
-impl<F: Clone, A> PublicValuesStep<F, A> {
+impl<F: Clone, A> PublicValuesExecutor<F, A> {
     /// **Note:** `max_degree` is the maximum degree of the constraint polynomials to represent the
     /// flags. If you want the overall AIR's constraint degree to be `<= max_constraint_degree`,
     /// then typically you should set `max_degree` to `max_constraint_degree - 1`.
@@ -154,7 +154,7 @@ impl<F: Clone, A> PublicValuesStep<F, A> {
 }
 
 // We clone when we want to run a new instance of the program, so we reset the custom public values.
-impl<F: Clone, A: Clone> Clone for PublicValuesStep<F, A> {
+impl<F: Clone, A: Clone> Clone for PublicValuesExecutor<F, A> {
     fn clone(&self) -> Self {
         Self {
             adapter: self.adapter.clone(),
@@ -164,10 +164,10 @@ impl<F: Clone, A: Clone> Clone for PublicValuesStep<F, A> {
     }
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for PublicValuesStep<F, A>
+impl<F, A, RA> PreflightExecutor<F, RA> for PublicValuesExecutor<F, A>
 where
     F: PrimeField32,
-    A: 'static + Clone + AdapterTraceStep<F, ReadData = [[F; 1]; 2], WriteData = [[F; 1]; 0]>,
+    A: 'static + Clone + AdapterTraceExecutor<F, ReadData = [[F; 1]; 2], WriteData = [[F; 1]; 0]>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -212,7 +212,7 @@ where
     }
 }
 
-impl<F, A> TraceFiller<F> for PublicValuesStep<F, A>
+impl<F, A> TraceFiller<F> for PublicValuesExecutor<F, A>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
@@ -252,7 +252,7 @@ struct PublicValuesPreCompute<F> {
     pvs: *const Mutex<Vec<Option<F>>>,
 }
 
-impl<F, A> Executor<F> for PublicValuesStep<F, A>
+impl<F, A> Executor<F> for PublicValuesExecutor<F, A>
 where
     F: PrimeField32,
 {
@@ -284,7 +284,7 @@ where
     }
 }
 
-impl<F, A> MeteredExecutor<F> for PublicValuesStep<F, A>
+impl<F, A> MeteredExecutor<F> for PublicValuesExecutor<F, A>
 where
     F: PrimeField32,
 {
@@ -374,7 +374,7 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX, const B_IS_IMM: bool, const C_I
     state.instret += 1;
 }
 
-impl<F, A> PublicValuesStep<F, A>
+impl<F, A> PublicValuesExecutor<F, A>
 where
     F: PrimeField32,
 {

--- a/crates/vm/src/system/public_values/mod.rs
+++ b/crates/vm/src/system/public_values/mod.rs
@@ -12,4 +12,4 @@ pub use core::*;
 mod tests;
 
 pub type PublicValuesAir = VmAirWrapper<NativeAdapterAir<2, 0>, PublicValuesCoreAir>;
-pub type PublicValuesChip<F> = VmChipWrapper<F, PublicValuesStep<F>>;
+pub type PublicValuesChip<F> = VmChipWrapper<F, PublicValuesExecutor<F>>;

--- a/extensions/algebra/circuit/src/fp2_chip/mod.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/mod.rs
@@ -2,7 +2,7 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 use openvm_mod_circuit_builder::{FieldExpressionCoreAir, FieldExpressionFiller};
 use openvm_rv32_adapters::{Rv32VecHeapAdapterAir, Rv32VecHeapAdapterFiller};
 
-use crate::FieldExprVecHeapStep;
+use crate::FieldExprVecHeapExecutor;
 
 mod addsub;
 pub use addsub::*;
@@ -15,8 +15,8 @@ pub type Fp2Air<const BLOCKS: usize, const BLOCK_SIZE: usize> = VmAirWrapper<
     FieldExpressionCoreAir,
 >;
 
-pub type Fp2Step<const BLOCKS: usize, const BLOCK_SIZE: usize> =
-    FieldExprVecHeapStep<BLOCKS, BLOCK_SIZE, true>;
+pub type Fp2Executor<const BLOCKS: usize, const BLOCK_SIZE: usize> =
+    FieldExprVecHeapExecutor<BLOCKS, BLOCK_SIZE, true>;
 
 pub type Fp2Chip<F, const BLOCKS: usize, const BLOCK_SIZE: usize> = VmChipWrapper<
     F,

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -11,15 +11,15 @@ use openvm_circuit_primitives::{
 };
 use openvm_instructions::riscv::RV32_CELL_BITS;
 use openvm_mod_circuit_builder::{
-    ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionFiller,
-    FieldExpressionStep, SymbolicExpr,
+    ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
+    FieldExpressionFiller, SymbolicExpr,
 };
 use openvm_rv32_adapters::{
-    Rv32VecHeapAdapterAir, Rv32VecHeapAdapterFiller, Rv32VecHeapAdapterStep,
+    Rv32VecHeapAdapterAir, Rv32VecHeapAdapterExecutor, Rv32VecHeapAdapterFiller,
 };
 
-use super::{Fp2Air, Fp2Chip, Fp2Step};
-use crate::{FieldExprVecHeapStep, Fp2};
+use super::{Fp2Air, Fp2Chip, Fp2Executor};
+use crate::{FieldExprVecHeapExecutor, Fp2};
 
 pub fn fp2_muldiv_expr(
     config: ExprBuilderConfig,
@@ -132,11 +132,11 @@ pub fn get_fp2_muldiv_step<const BLOCKS: usize, const BLOCK_SIZE: usize>(
     range_checker_bus: VariableRangeCheckerBus,
     pointer_max_bits: usize,
     offset: usize,
-) -> Fp2Step<BLOCKS, BLOCK_SIZE> {
+) -> Fp2Executor<BLOCKS, BLOCK_SIZE> {
     let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
 
-    FieldExprVecHeapStep(FieldExpressionStep::new(
-        Rv32VecHeapAdapterStep::new(pointer_max_bits),
+    FieldExprVecHeapExecutor(FieldExpressionExecutor::new(
+        Rv32VecHeapAdapterExecutor::new(pointer_max_bits),
         expr,
         offset,
         local_opcode_idx,
@@ -192,7 +192,7 @@ mod tests {
     use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 
     use crate::fp2_chip::{
-        get_fp2_muldiv_air, get_fp2_muldiv_chip, get_fp2_muldiv_step, Fp2Air, Fp2Chip, Fp2Step,
+        get_fp2_muldiv_air, get_fp2_muldiv_chip, get_fp2_muldiv_step, Fp2Air, Fp2Chip, Fp2Executor,
     };
 
     const NUM_LIMBS: usize = 32;
@@ -200,8 +200,12 @@ mod tests {
     const OFFSET: usize = Fp2Opcode::CLASS_OFFSET;
     const MAX_INS_CAPACITY: usize = 128;
     type F = BabyBear;
-    type Harness =
-        TestChipHarness<F, Fp2Step<2, NUM_LIMBS>, Fp2Air<2, NUM_LIMBS>, Fp2Chip<F, 2, NUM_LIMBS>>;
+    type Harness = TestChipHarness<
+        F,
+        Fp2Executor<2, NUM_LIMBS>,
+        Fp2Air<2, NUM_LIMBS>,
+        Fp2Chip<F, 2, NUM_LIMBS>,
+    >;
 
     fn set_and_execute_rand(
         tester: &mut VmChipTestBuilder<F>,

--- a/extensions/algebra/circuit/src/fp2_extension.rs
+++ b/extensions/algebra/circuit/src/fp2_extension.rs
@@ -33,7 +33,7 @@ use strum::EnumCount;
 use crate::{
     fp2_chip::{
         get_fp2_addsub_air, get_fp2_addsub_chip, get_fp2_addsub_step, get_fp2_muldiv_air,
-        get_fp2_muldiv_chip, get_fp2_muldiv_step, Fp2Air, Fp2Step,
+        get_fp2_muldiv_chip, get_fp2_muldiv_step, Fp2Air, Fp2Executor,
     },
     AlgebraCpuProverExt, ModularExtension,
 };
@@ -77,11 +77,11 @@ impl Fp2Extension {
 #[derive(Clone, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 pub enum Fp2ExtensionExecutor {
     // 32 limbs prime
-    Fp2AddSubRv32_32(Fp2Step<2, 32>), // Fp2AddSub
-    Fp2MulDivRv32_32(Fp2Step<2, 32>), // Fp2MulDiv
+    Fp2AddSubRv32_32(Fp2Executor<2, 32>), // Fp2AddSub
+    Fp2MulDivRv32_32(Fp2Executor<2, 32>), // Fp2MulDiv
     // 48 limbs prime
-    Fp2AddSubRv32_48(Fp2Step<6, 16>), // Fp2AddSub
-    Fp2MulDivRv32_48(Fp2Step<6, 16>), // Fp2MulDiv
+    Fp2AddSubRv32_48(Fp2Executor<6, 16>), // Fp2AddSub
+    Fp2MulDivRv32_48(Fp2Executor<6, 16>), // Fp2MulDiv
 }
 
 impl<F: PrimeField32> VmExecutionExtension<F> for Fp2Extension {

--- a/extensions/algebra/circuit/src/lib.rs
+++ b/extensions/algebra/circuit/src/lib.rs
@@ -18,9 +18,9 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
 };
 use openvm_mod_circuit_builder::{
-    run_field_expression_precomputed, FieldExpr, FieldExpressionStep,
+    run_field_expression_precomputed, FieldExpr, FieldExpressionExecutor,
 };
-use openvm_rv32_adapters::Rv32VecHeapAdapterStep;
+use openvm_rv32_adapters::Rv32VecHeapAdapterExecutor;
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use self::fields::{
@@ -94,9 +94,11 @@ pub mod fields;
 pub struct AlgebraCpuProverExt;
 
 #[derive(Clone, PreflightExecutor, Deref, DerefMut)]
-pub struct FieldExprVecHeapStep<const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool>(
-    FieldExpressionStep<Rv32VecHeapAdapterStep<2, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>>,
-);
+pub struct FieldExprVecHeapExecutor<
+    const BLOCKS: usize,
+    const BLOCK_SIZE: usize,
+    const IS_FP2: bool,
+>(FieldExpressionExecutor<Rv32VecHeapAdapterExecutor<2, BLOCKS, BLOCKS, BLOCK_SIZE, BLOCK_SIZE>>);
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
@@ -108,7 +110,7 @@ struct FieldExpressionPreCompute<'a> {
 }
 
 impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool>
-    FieldExprVecHeapStep<BLOCKS, BLOCK_SIZE, IS_FP2>
+    FieldExprVecHeapExecutor<BLOCKS, BLOCK_SIZE, IS_FP2>
 {
     fn pre_compute_impl<F: PrimeField32>(
         &'a self,
@@ -199,7 +201,7 @@ impl<'a, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool>
 }
 
 impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool> Executor<F>
-    for FieldExprVecHeapStep<BLOCKS, BLOCK_SIZE, IS_FP2>
+    for FieldExprVecHeapExecutor<BLOCKS, BLOCK_SIZE, IS_FP2>
 {
     #[inline(always)]
     fn pre_compute_size(&self) -> usize {
@@ -295,7 +297,7 @@ impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2
 }
 
 impl<F: PrimeField32, const BLOCKS: usize, const BLOCK_SIZE: usize, const IS_FP2: bool>
-    MeteredExecutor<F> for FieldExprVecHeapStep<BLOCKS, BLOCK_SIZE, IS_FP2>
+    MeteredExecutor<F> for FieldExprVecHeapExecutor<BLOCKS, BLOCK_SIZE, IS_FP2>
 {
     #[inline(always)]
     fn metered_pre_compute_size(&self) -> usize {

--- a/extensions/algebra/circuit/src/modular_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/modular_chip/addsub.rs
@@ -11,15 +11,15 @@ use openvm_circuit_primitives::{
 };
 use openvm_instructions::riscv::RV32_CELL_BITS;
 use openvm_mod_circuit_builder::{
-    ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionFiller,
-    FieldExpressionStep, FieldVariable,
+    ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
+    FieldExpressionFiller, FieldVariable,
 };
 use openvm_rv32_adapters::{
-    Rv32VecHeapAdapterAir, Rv32VecHeapAdapterFiller, Rv32VecHeapAdapterStep,
+    Rv32VecHeapAdapterAir, Rv32VecHeapAdapterExecutor, Rv32VecHeapAdapterFiller,
 };
 
-use super::{ModularAir, ModularChip, ModularStep};
-use crate::FieldExprVecHeapStep;
+use super::{ModularAir, ModularChip, ModularExecutor};
+use crate::FieldExprVecHeapExecutor;
 
 pub fn addsub_expr(
     config: ExprBuilderConfig,
@@ -89,11 +89,11 @@ pub fn get_modular_addsub_step<const BLOCKS: usize, const BLOCK_SIZE: usize>(
     range_checker_bus: VariableRangeCheckerBus,
     pointer_max_bits: usize,
     offset: usize,
-) -> ModularStep<BLOCKS, BLOCK_SIZE> {
+) -> ModularExecutor<BLOCKS, BLOCK_SIZE> {
     let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
 
-    FieldExprVecHeapStep(FieldExpressionStep::new(
-        Rv32VecHeapAdapterStep::new(pointer_max_bits),
+    FieldExprVecHeapExecutor(FieldExpressionExecutor::new(
+        Rv32VecHeapAdapterExecutor::new(pointer_max_bits),
         expr,
         offset,
         local_opcode_idx,

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -25,7 +25,7 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
     LocalOpcode,
 };
-use openvm_rv32_adapters::Rv32IsEqualModAdapterStep;
+use openvm_rv32_adapters::Rv32IsEqualModAdapterExecutor;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
@@ -33,7 +33,7 @@ use openvm_stark_backend::{
     rap::BaseAirWithPublicValues,
 };
 
-use crate::modular_chip::VmModularIsEqualStep;
+use crate::modular_chip::VmModularIsEqualExecutor;
 // Given two numbers b and c, we want to prove that a) b == c or b != c, depending on
 // result of cmp_result and b) b, c < N for some modulus N that is passed into the AIR
 // at runtime (i.e. when chip is instantiated).
@@ -295,7 +295,7 @@ pub struct ModularIsEqualRecord<const READ_LIMBS: usize> {
 }
 
 #[derive(derive_new::new, Clone)]
-pub struct ModularIsEqualStep<
+pub struct ModularIsEqualExecutor<
     A,
     const READ_LIMBS: usize,
     const WRITE_LIMBS: usize,
@@ -320,11 +320,11 @@ pub struct ModularIsEqualFiller<
 }
 
 impl<F, A, RA, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
-    PreflightExecutor<F, RA> for ModularIsEqualStep<A, READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
+    PreflightExecutor<F, RA> for ModularIsEqualExecutor<A, READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData: Into<[[u8; READ_LIMBS]; 2]>,
             WriteData: From<[u8; WRITE_LIMBS]>,
@@ -452,14 +452,14 @@ where
 }
 
 impl<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_LIMBS: usize>
-    VmModularIsEqualStep<NUM_LANES, LANE_SIZE, TOTAL_LIMBS>
+    VmModularIsEqualExecutor<NUM_LANES, LANE_SIZE, TOTAL_LIMBS>
 {
     pub fn new(
-        adapter: Rv32IsEqualModAdapterStep<2, NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
+        adapter: Rv32IsEqualModAdapterExecutor<2, NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
         offset: usize,
         modulus_limbs: [u8; TOTAL_LIMBS],
     ) -> Self {
-        Self(ModularIsEqualStep::new(adapter, offset, modulus_limbs))
+        Self(ModularIsEqualExecutor::new(adapter, offset, modulus_limbs))
     }
 }
 
@@ -472,7 +472,7 @@ struct ModularIsEqualPreCompute<const READ_LIMBS: usize> {
 }
 
 impl<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_READ_SIZE: usize>
-    VmModularIsEqualStep<NUM_LANES, LANE_SIZE, TOTAL_READ_SIZE>
+    VmModularIsEqualExecutor<NUM_LANES, LANE_SIZE, TOTAL_READ_SIZE>
 {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -524,7 +524,7 @@ impl<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_READ_SIZE: usiz
 }
 
 impl<F, const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_READ_SIZE: usize> Executor<F>
-    for VmModularIsEqualStep<NUM_LANES, LANE_SIZE, TOTAL_READ_SIZE>
+    for VmModularIsEqualExecutor<NUM_LANES, LANE_SIZE, TOTAL_READ_SIZE>
 where
     F: PrimeField32,
 {
@@ -553,7 +553,7 @@ where
 }
 
 impl<F, const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_READ_SIZE: usize>
-    MeteredExecutor<F> for VmModularIsEqualStep<NUM_LANES, LANE_SIZE, TOTAL_READ_SIZE>
+    MeteredExecutor<F> for VmModularIsEqualExecutor<NUM_LANES, LANE_SIZE, TOTAL_READ_SIZE>
 where
     F: PrimeField32,
 {

--- a/extensions/algebra/circuit/src/modular_chip/mod.rs
+++ b/extensions/algebra/circuit/src/modular_chip/mod.rs
@@ -3,11 +3,11 @@ use openvm_circuit_derive::PreflightExecutor;
 use openvm_instructions::riscv::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use openvm_mod_circuit_builder::{FieldExpressionCoreAir, FieldExpressionFiller};
 use openvm_rv32_adapters::{
-    Rv32IsEqualModAdapterAir, Rv32IsEqualModAdapterFiller, Rv32IsEqualModAdapterStep,
+    Rv32IsEqualModAdapterAir, Rv32IsEqualModAdapterExecutor, Rv32IsEqualModAdapterFiller,
     Rv32VecHeapAdapterAir, Rv32VecHeapAdapterFiller,
 };
 
-use crate::FieldExprVecHeapStep;
+use crate::FieldExprVecHeapExecutor;
 
 mod is_eq;
 pub use is_eq::*;
@@ -24,8 +24,8 @@ pub type ModularAir<const BLOCKS: usize, const BLOCK_SIZE: usize> = VmAirWrapper
     FieldExpressionCoreAir,
 >;
 
-pub type ModularStep<const BLOCKS: usize, const BLOCK_SIZE: usize> =
-    FieldExprVecHeapStep<BLOCKS, BLOCK_SIZE, false>;
+pub type ModularExecutor<const BLOCKS: usize, const BLOCK_SIZE: usize> =
+    FieldExprVecHeapExecutor<BLOCKS, BLOCK_SIZE, false>;
 
 pub type ModularChip<F, const BLOCKS: usize, const BLOCK_SIZE: usize> = VmChipWrapper<
     F,
@@ -43,13 +43,13 @@ pub type ModularIsEqualAir<
 >;
 
 #[derive(Clone, PreflightExecutor)]
-pub struct VmModularIsEqualStep<
+pub struct VmModularIsEqualExecutor<
     const NUM_LANES: usize,
     const LANE_SIZE: usize,
     const TOTAL_LIMBS: usize,
 >(
-    ModularIsEqualStep<
-        Rv32IsEqualModAdapterStep<2, NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
+    ModularIsEqualExecutor<
+        Rv32IsEqualModAdapterExecutor<2, NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
         TOTAL_LIMBS,
         RV32_REGISTER_NUM_LIMBS,
         RV32_CELL_BITS,

--- a/extensions/algebra/circuit/src/modular_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/modular_chip/muldiv.rs
@@ -11,15 +11,15 @@ use openvm_circuit_primitives::{
 };
 use openvm_instructions::riscv::RV32_CELL_BITS;
 use openvm_mod_circuit_builder::{
-    ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionFiller,
-    FieldExpressionStep, FieldVariable, SymbolicExpr,
+    ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
+    FieldExpressionFiller, FieldVariable, SymbolicExpr,
 };
 use openvm_rv32_adapters::{
-    Rv32VecHeapAdapterAir, Rv32VecHeapAdapterFiller, Rv32VecHeapAdapterStep,
+    Rv32VecHeapAdapterAir, Rv32VecHeapAdapterExecutor, Rv32VecHeapAdapterFiller,
 };
 
-use super::{ModularAir, ModularChip, ModularStep};
-use crate::FieldExprVecHeapStep;
+use super::{ModularAir, ModularChip, ModularExecutor};
+use crate::FieldExprVecHeapExecutor;
 
 pub fn muldiv_expr(
     config: ExprBuilderConfig,
@@ -106,11 +106,11 @@ pub fn get_modular_muldiv_step<const BLOCKS: usize, const BLOCK_SIZE: usize>(
     range_checker_bus: VariableRangeCheckerBus,
     pointer_max_bits: usize,
     offset: usize,
-) -> ModularStep<BLOCKS, BLOCK_SIZE> {
+) -> ModularExecutor<BLOCKS, BLOCK_SIZE> {
     let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
 
-    FieldExprVecHeapStep(FieldExpressionStep::new(
-        Rv32VecHeapAdapterStep::new(pointer_max_bits),
+    FieldExprVecHeapExecutor(FieldExpressionExecutor::new(
+        Rv32VecHeapAdapterExecutor::new(pointer_max_bits),
         expr,
         offset,
         local_opcode_idx,

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -30,8 +30,8 @@ use rand::{rngs::StdRng, Rng};
 use crate::modular_chip::{
     get_modular_addsub_air, get_modular_addsub_chip, get_modular_addsub_step,
     get_modular_muldiv_air, get_modular_muldiv_chip, get_modular_muldiv_step, ModularAir,
-    ModularChip, ModularIsEqualAir, ModularIsEqualChip, ModularIsEqualCoreAir,
-    ModularIsEqualCoreCols, ModularIsEqualFiller, ModularStep, VmModularIsEqualStep,
+    ModularChip, ModularExecutor, ModularIsEqualAir, ModularIsEqualChip, ModularIsEqualCoreAir,
+    ModularIsEqualCoreCols, ModularIsEqualFiller, VmModularIsEqualExecutor,
 };
 
 const NUM_LIMBS: usize = 32;
@@ -48,7 +48,7 @@ mod addsubtests {
 
     type Harness<RA> = TestChipHarness<
         F,
-        ModularStep<1, NUM_LIMBS>,
+        ModularExecutor<1, NUM_LIMBS>,
         ModularAir<1, NUM_LIMBS>,
         ModularChip<F, 1, NUM_LIMBS>,
         RA,
@@ -104,7 +104,7 @@ mod addsubtests {
         is_setup: bool,
         offset: usize,
     ) where
-        ModularStep<1, NUM_LIMBS>: PreflightExecutor<F, RA>,
+        ModularExecutor<1, NUM_LIMBS>: PreflightExecutor<F, RA>,
     {
         let mut rng = create_seeded_rng();
 
@@ -252,7 +252,7 @@ mod muldivtests {
     const MUL_LOCAL: usize = Rv32ModularArithmeticOpcode::MUL as usize;
     type Harness = TestChipHarness<
         F,
-        ModularStep<1, NUM_LIMBS>,
+        ModularExecutor<1, NUM_LIMBS>,
         ModularAir<1, NUM_LIMBS>,
         ModularChip<F, 1, NUM_LIMBS>,
     >;
@@ -387,7 +387,7 @@ mod muldivtests {
 #[cfg(test)]
 mod is_equal_tests {
     use openvm_rv32_adapters::{
-        Rv32IsEqualModAdapterAir, Rv32IsEqualModAdapterFiller, Rv32IsEqualModAdapterStep,
+        Rv32IsEqualModAdapterAir, Rv32IsEqualModAdapterExecutor, Rv32IsEqualModAdapterFiller,
     };
     use openvm_stark_backend::{
         p3_air::BaseAir,
@@ -404,7 +404,7 @@ mod is_equal_tests {
     type Harness<const NUM_LANES: usize, const LANE_SIZE: usize, const TOTAL_LIMBS: usize> =
         TestChipHarness<
             F,
-            VmModularIsEqualStep<NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
+            VmModularIsEqualExecutor<NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
             ModularIsEqualAir<NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
             ModularIsEqualChip<F, NUM_LANES, LANE_SIZE, TOTAL_LIMBS>,
         >;
@@ -437,8 +437,8 @@ mod is_equal_tests {
             ),
             ModularIsEqualCoreAir::new(modulus.clone(), bitwise_bus, offset),
         );
-        let executor = VmModularIsEqualStep::new(
-            Rv32IsEqualModAdapterStep::new(tester.address_bits()),
+        let executor = VmModularIsEqualExecutor::new(
+            Rv32IsEqualModAdapterExecutor::new(tester.address_bits()),
             offset,
             modulus_limbs,
         );

--- a/extensions/algebra/circuit/src/modular_extension.rs
+++ b/extensions/algebra/circuit/src/modular_extension.rs
@@ -24,7 +24,7 @@ use openvm_circuit_primitives::{
 use openvm_instructions::{LocalOpcode, PhantomDiscriminant, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
 use openvm_rv32_adapters::{
-    Rv32IsEqualModAdapterAir, Rv32IsEqualModAdapterFiller, Rv32IsEqualModAdapterStep,
+    Rv32IsEqualModAdapterAir, Rv32IsEqualModAdapterExecutor, Rv32IsEqualModAdapterFiller,
 };
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
@@ -41,8 +41,8 @@ use crate::{
     modular_chip::{
         get_modular_addsub_air, get_modular_addsub_chip, get_modular_addsub_step,
         get_modular_muldiv_air, get_modular_muldiv_chip, get_modular_muldiv_step, ModularAir,
-        ModularIsEqualAir, ModularIsEqualChip, ModularIsEqualCoreAir, ModularIsEqualFiller,
-        ModularStep, VmModularIsEqualStep,
+        ModularExecutor, ModularIsEqualAir, ModularIsEqualChip, ModularIsEqualCoreAir,
+        ModularIsEqualFiller, VmModularIsEqualExecutor,
     },
     AlgebraCpuProverExt,
 };
@@ -71,13 +71,13 @@ impl ModularExtension {
 #[derive(Clone, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 pub enum ModularExtensionExecutor {
     // 32 limbs prime
-    ModularAddSubRv32_32(ModularStep<1, 32>), // ModularAddSub
-    ModularMulDivRv32_32(ModularStep<1, 32>), // ModularMulDiv
-    ModularIsEqualRv32_32(VmModularIsEqualStep<1, 32, 32>), // ModularIsEqual
+    ModularAddSubRv32_32(ModularExecutor<1, 32>), // ModularAddSub
+    ModularMulDivRv32_32(ModularExecutor<1, 32>), // ModularMulDiv
+    ModularIsEqualRv32_32(VmModularIsEqualExecutor<1, 32, 32>), // ModularIsEqual
     // 48 limbs prime
-    ModularAddSubRv32_48(ModularStep<3, 16>), // ModularAddSub
-    ModularMulDivRv32_48(ModularStep<3, 16>), // ModularMulDiv
-    ModularIsEqualRv32_48(VmModularIsEqualStep<3, 16, 48>), // ModularIsEqual
+    ModularAddSubRv32_48(ModularExecutor<3, 16>), // ModularAddSub
+    ModularMulDivRv32_48(ModularExecutor<3, 16>), // ModularMulDiv
+    ModularIsEqualRv32_48(VmModularIsEqualExecutor<3, 16, 48>), // ModularIsEqual
 }
 
 impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
@@ -138,8 +138,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
                     }
                 });
 
-                let is_eq = VmModularIsEqualStep::new(
-                    Rv32IsEqualModAdapterStep::new(pointer_max_bits),
+                let is_eq = VmModularIsEqualExecutor::new(
+                    Rv32IsEqualModAdapterExecutor::new(pointer_max_bits),
                     start_offset,
                     modulus_limbs,
                 );
@@ -192,8 +192,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
                     }
                 });
 
-                let is_eq = VmModularIsEqualStep::new(
-                    Rv32IsEqualModAdapterStep::new(pointer_max_bits),
+                let is_eq = VmModularIsEqualExecutor::new(
+                    Rv32IsEqualModAdapterExecutor::new(pointer_max_bits),
                     start_offset,
                     modulus_limbs,
                 );

--- a/extensions/bigint/circuit/src/base_alu.rs
+++ b/extensions/bigint/circuit/src/base_alu.rs
@@ -12,18 +12,18 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
     LocalOpcode,
 };
-use openvm_rv32_adapters::Rv32HeapAdapterStep;
-use openvm_rv32im_circuit::BaseAluStep;
+use openvm_rv32_adapters::Rv32HeapAdapterExecutor;
+use openvm_rv32im_circuit::BaseAluExecutor;
 use openvm_rv32im_transpiler::BaseAluOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::{Rv32BaseAlu256Step, INT256_NUM_LIMBS};
+use crate::{Rv32BaseAlu256Executor, INT256_NUM_LIMBS};
 
-type AdapterStep = Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
+type AdapterExecutor = Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
 
-impl Rv32BaseAlu256Step {
-    pub fn new(adapter: AdapterStep, offset: usize) -> Self {
-        Self(BaseAluStep::new(adapter, offset))
+impl Rv32BaseAlu256Executor {
+    pub fn new(adapter: AdapterExecutor, offset: usize) -> Self {
+        Self(BaseAluExecutor::new(adapter, offset))
     }
 }
 
@@ -34,7 +34,7 @@ struct BaseAluPreCompute {
     c: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for Rv32BaseAlu256Step {
+impl<F: PrimeField32> Executor<F> for Rv32BaseAlu256Executor {
     fn pre_compute_size(&self) -> usize {
         size_of::<BaseAluPreCompute>()
     }
@@ -61,7 +61,7 @@ impl<F: PrimeField32> Executor<F> for Rv32BaseAlu256Step {
     }
 }
 
-impl<F: PrimeField32> MeteredExecutor<F> for Rv32BaseAlu256Step {
+impl<F: PrimeField32> MeteredExecutor<F> for Rv32BaseAlu256Executor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<BaseAluPreCompute>>()
     }
@@ -125,7 +125,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, OP: AluOp>(
     execute_e12_impl::<F, CTX, OP>(&pre_compute.data, vm_state);
 }
 
-impl Rv32BaseAlu256Step {
+impl Rv32BaseAlu256Executor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/bigint/circuit/src/branch_eq.rs
+++ b/extensions/bigint/circuit/src/branch_eq.rs
@@ -9,18 +9,18 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
     LocalOpcode,
 };
-use openvm_rv32_adapters::Rv32HeapBranchAdapterStep;
-use openvm_rv32im_circuit::BranchEqualStep;
+use openvm_rv32_adapters::Rv32HeapBranchAdapterExecutor;
+use openvm_rv32im_circuit::BranchEqualExecutor;
 use openvm_rv32im_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::{Rv32BranchEqual256Step, INT256_NUM_LIMBS};
+use crate::{Rv32BranchEqual256Executor, INT256_NUM_LIMBS};
 
-type AdapterStep = Rv32HeapBranchAdapterStep<2, INT256_NUM_LIMBS>;
+type AdapterExecutor = Rv32HeapBranchAdapterExecutor<2, INT256_NUM_LIMBS>;
 
-impl Rv32BranchEqual256Step {
-    pub fn new(adapter_step: AdapterStep, offset: usize, pc_step: u32) -> Self {
-        Self(BranchEqualStep::new(adapter_step, offset, pc_step))
+impl Rv32BranchEqual256Executor {
+    pub fn new(adapter_step: AdapterExecutor, offset: usize, pc_step: u32) -> Self {
+        Self(BranchEqualExecutor::new(adapter_step, offset, pc_step))
     }
 }
 
@@ -32,7 +32,7 @@ struct BranchEqPreCompute {
     b: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for Rv32BranchEqual256Step {
+impl<F: PrimeField32> Executor<F> for Rv32BranchEqual256Executor {
     fn pre_compute_size(&self) -> usize {
         size_of::<BranchEqPreCompute>()
     }
@@ -56,7 +56,7 @@ impl<F: PrimeField32> Executor<F> for Rv32BranchEqual256Step {
     }
 }
 
-impl<F: PrimeField32> MeteredExecutor<F> for Rv32BranchEqual256Step {
+impl<F: PrimeField32> MeteredExecutor<F> for Rv32BranchEqual256Executor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<BranchEqPreCompute>>()
     }
@@ -120,7 +120,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, const IS_NE: boo
     execute_e12_impl::<F, CTX, IS_NE>(&pre_compute.data, vm_state);
 }
 
-impl Rv32BranchEqual256Step {
+impl Rv32BranchEqual256Executor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/bigint/circuit/src/branch_lt.rs
+++ b/extensions/bigint/circuit/src/branch_lt.rs
@@ -9,21 +9,21 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
     LocalOpcode,
 };
-use openvm_rv32_adapters::Rv32HeapBranchAdapterStep;
-use openvm_rv32im_circuit::BranchLessThanStep;
+use openvm_rv32_adapters::Rv32HeapBranchAdapterExecutor;
+use openvm_rv32im_circuit::BranchLessThanExecutor;
 use openvm_rv32im_transpiler::BranchLessThanOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use crate::{
     common::{i256_lt, u256_lt},
-    Rv32BranchLessThan256Step, INT256_NUM_LIMBS,
+    Rv32BranchLessThan256Executor, INT256_NUM_LIMBS,
 };
 
-type AdapterStep = Rv32HeapBranchAdapterStep<2, INT256_NUM_LIMBS>;
+type AdapterExecutor = Rv32HeapBranchAdapterExecutor<2, INT256_NUM_LIMBS>;
 
-impl Rv32BranchLessThan256Step {
-    pub fn new(adapter: AdapterStep, offset: usize) -> Self {
-        Self(BranchLessThanStep::new(adapter, offset))
+impl Rv32BranchLessThan256Executor {
+    pub fn new(adapter: AdapterExecutor, offset: usize) -> Self {
+        Self(BranchLessThanExecutor::new(adapter, offset))
     }
 }
 
@@ -35,7 +35,7 @@ struct BranchLtPreCompute {
     b: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for Rv32BranchLessThan256Step {
+impl<F: PrimeField32> Executor<F> for Rv32BranchLessThan256Executor {
     fn pre_compute_size(&self) -> usize {
         size_of::<BranchLtPreCompute>()
     }
@@ -61,7 +61,7 @@ impl<F: PrimeField32> Executor<F> for Rv32BranchLessThan256Step {
     }
 }
 
-impl<F: PrimeField32> MeteredExecutor<F> for Rv32BranchLessThan256Step {
+impl<F: PrimeField32> MeteredExecutor<F> for Rv32BranchLessThan256Executor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<BranchLtPreCompute>>()
     }
@@ -126,7 +126,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, OP: BranchLessTh
     execute_e12_impl::<F, CTX, OP>(&pre_compute.data, vm_state);
 }
 
-impl Rv32BranchLessThan256Step {
+impl Rv32BranchLessThan256Executor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/bigint/circuit/src/extension.rs
+++ b/extensions/bigint/circuit/src/extension.rs
@@ -56,12 +56,12 @@ fn default_range_tuple_checker_sizes() -> [u32; 2] {
 
 #[derive(Clone, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 pub enum Int256Executor {
-    BaseAlu256(Rv32BaseAlu256Step),
-    LessThan256(Rv32LessThan256Step),
-    BranchEqual256(Rv32BranchEqual256Step),
-    BranchLessThan256(Rv32BranchLessThan256Step),
-    Multiplication256(Rv32Multiplication256Step),
-    Shift256(Rv32Shift256Step),
+    BaseAlu256(Rv32BaseAlu256Executor),
+    LessThan256(Rv32LessThan256Executor),
+    BranchEqual256(Rv32BranchEqual256Executor),
+    BranchLessThan256(Rv32BranchLessThan256Executor),
+    Multiplication256(Rv32Multiplication256Executor),
+    Shift256(Rv32Shift256Executor),
 }
 
 impl<F: PrimeField32> VmExecutionExtension<F> for Int256 {
@@ -73,20 +73,20 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Int256 {
     ) -> Result<(), ExecutorInventoryError> {
         let pointer_max_bits = inventory.pointer_max_bits();
 
-        let alu = Rv32BaseAlu256Step::new(
-            Rv32HeapAdapterStep::new(pointer_max_bits),
+        let alu = Rv32BaseAlu256Executor::new(
+            Rv32HeapAdapterExecutor::new(pointer_max_bits),
             Rv32BaseAlu256Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(alu, Rv32BaseAlu256Opcode::iter().map(|x| x.global_opcode()))?;
 
-        let lt = Rv32LessThan256Step::new(
-            Rv32HeapAdapterStep::new(pointer_max_bits),
+        let lt = Rv32LessThan256Executor::new(
+            Rv32HeapAdapterExecutor::new(pointer_max_bits),
             Rv32LessThan256Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(lt, Rv32LessThan256Opcode::iter().map(|x| x.global_opcode()))?;
 
-        let beq = Rv32BranchEqual256Step::new(
-            Rv32HeapBranchAdapterStep::new(pointer_max_bits),
+        let beq = Rv32BranchEqual256Executor::new(
+            Rv32HeapBranchAdapterExecutor::new(pointer_max_bits),
             Rv32BranchEqual256Opcode::CLASS_OFFSET,
             DEFAULT_PC_STEP,
         );
@@ -95,8 +95,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Int256 {
             Rv32BranchEqual256Opcode::iter().map(|x| x.global_opcode()),
         )?;
 
-        let blt = Rv32BranchLessThan256Step::new(
-            Rv32HeapBranchAdapterStep::new(pointer_max_bits),
+        let blt = Rv32BranchLessThan256Executor::new(
+            Rv32HeapBranchAdapterExecutor::new(pointer_max_bits),
             Rv32BranchLessThan256Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(
@@ -104,14 +104,14 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Int256 {
             Rv32BranchLessThan256Opcode::iter().map(|x| x.global_opcode()),
         )?;
 
-        let mult = Rv32Multiplication256Step::new(
-            Rv32HeapAdapterStep::new(pointer_max_bits),
+        let mult = Rv32Multiplication256Executor::new(
+            Rv32HeapAdapterExecutor::new(pointer_max_bits),
             Rv32Mul256Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(mult, Rv32Mul256Opcode::iter().map(|x| x.global_opcode()))?;
 
-        let shift = Rv32Shift256Step::new(
-            Rv32HeapAdapterStep::new(pointer_max_bits),
+        let shift = Rv32Shift256Executor::new(
+            Rv32HeapAdapterExecutor::new(pointer_max_bits),
             Rv32Shift256Opcode::CLASS_OFFSET,
         );
         inventory.add_executor(shift, Rv32Shift256Opcode::iter().map(|x| x.global_opcode()))?;

--- a/extensions/bigint/circuit/src/less_than.rs
+++ b/extensions/bigint/circuit/src/less_than.rs
@@ -9,18 +9,18 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
     LocalOpcode,
 };
-use openvm_rv32_adapters::Rv32HeapAdapterStep;
-use openvm_rv32im_circuit::LessThanStep;
+use openvm_rv32_adapters::Rv32HeapAdapterExecutor;
+use openvm_rv32im_circuit::LessThanExecutor;
 use openvm_rv32im_transpiler::LessThanOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::{common, Rv32LessThan256Step, INT256_NUM_LIMBS};
+use crate::{common, Rv32LessThan256Executor, INT256_NUM_LIMBS};
 
-type AdapterStep = Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
+type AdapterExecutor = Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
 
-impl Rv32LessThan256Step {
-    pub fn new(adapter: AdapterStep, offset: usize) -> Self {
-        Self(LessThanStep::new(adapter, offset))
+impl Rv32LessThan256Executor {
+    pub fn new(adapter: AdapterExecutor, offset: usize) -> Self {
+        Self(LessThanExecutor::new(adapter, offset))
     }
 }
 
@@ -32,7 +32,7 @@ struct LessThanPreCompute {
     c: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for Rv32LessThan256Step {
+impl<F: PrimeField32> Executor<F> for Rv32LessThan256Executor {
     fn pre_compute_size(&self) -> usize {
         size_of::<LessThanPreCompute>()
     }
@@ -56,7 +56,7 @@ impl<F: PrimeField32> Executor<F> for Rv32LessThan256Step {
     }
 }
 
-impl<F: PrimeField32> MeteredExecutor<F> for Rv32LessThan256Step {
+impl<F: PrimeField32> MeteredExecutor<F> for Rv32LessThan256Executor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<LessThanPreCompute>>()
     }
@@ -124,7 +124,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, const IS_U256: b
     execute_e12_impl::<F, CTX, IS_U256>(&pre_compute.data, vm_state);
 }
 
-impl Rv32LessThan256Step {
+impl Rv32LessThan256Executor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/bigint/circuit/src/lib.rs
+++ b/extensions/bigint/circuit/src/lib.rs
@@ -8,16 +8,16 @@ use openvm_circuit::{
 };
 use openvm_circuit_derive::{PreflightExecutor, VmConfig};
 use openvm_rv32_adapters::{
-    Rv32HeapAdapterAir, Rv32HeapAdapterFiller, Rv32HeapAdapterStep, Rv32HeapBranchAdapterAir,
-    Rv32HeapBranchAdapterFiller, Rv32HeapBranchAdapterStep,
+    Rv32HeapAdapterAir, Rv32HeapAdapterExecutor, Rv32HeapAdapterFiller, Rv32HeapBranchAdapterAir,
+    Rv32HeapBranchAdapterExecutor, Rv32HeapBranchAdapterFiller,
 };
 use openvm_rv32im_circuit::{
     adapters::{INT256_NUM_LIMBS, RV32_CELL_BITS},
-    BaseAluCoreAir, BaseAluFiller, BaseAluStep, BranchEqualCoreAir, BranchEqualFiller,
-    BranchEqualStep, BranchLessThanCoreAir, BranchLessThanFiller, BranchLessThanStep,
-    LessThanCoreAir, LessThanFiller, LessThanStep, MultiplicationCoreAir, MultiplicationFiller,
-    MultiplicationStep, Rv32I, Rv32IExecutor, Rv32ImCpuProverExt, Rv32Io, Rv32IoExecutor, Rv32M,
-    Rv32MExecutor, ShiftCoreAir, ShiftFiller, ShiftStep,
+    BaseAluCoreAir, BaseAluExecutor, BaseAluFiller, BranchEqualCoreAir, BranchEqualExecutor,
+    BranchEqualFiller, BranchLessThanCoreAir, BranchLessThanExecutor, BranchLessThanFiller,
+    LessThanCoreAir, LessThanExecutor, LessThanFiller, MultiplicationCoreAir,
+    MultiplicationExecutor, MultiplicationFiller, Rv32I, Rv32IExecutor, Rv32ImCpuProverExt, Rv32Io,
+    Rv32IoExecutor, Rv32M, Rv32MExecutor, ShiftCoreAir, ShiftExecutor, ShiftFiller,
 };
 use openvm_stark_backend::{
     config::{StarkGenericConfig, Val},
@@ -46,9 +46,9 @@ pub type Rv32BaseAlu256Air = VmAirWrapper<
     BaseAluCoreAir<INT256_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 #[derive(Clone, PreflightExecutor)]
-pub struct Rv32BaseAlu256Step(
-    BaseAluStep<
-        Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
+pub struct Rv32BaseAlu256Executor(
+    BaseAluExecutor<
+        Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
     >,
@@ -68,9 +68,9 @@ pub type Rv32LessThan256Air = VmAirWrapper<
     LessThanCoreAir<INT256_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 #[derive(Clone, PreflightExecutor)]
-pub struct Rv32LessThan256Step(
-    LessThanStep<
-        Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
+pub struct Rv32LessThan256Executor(
+    LessThanExecutor<
+        Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
     >,
@@ -90,9 +90,9 @@ pub type Rv32Multiplication256Air = VmAirWrapper<
     MultiplicationCoreAir<INT256_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 #[derive(Clone, PreflightExecutor)]
-pub struct Rv32Multiplication256Step(
-    MultiplicationStep<
-        Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
+pub struct Rv32Multiplication256Executor(
+    MultiplicationExecutor<
+        Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
     >,
@@ -112,9 +112,9 @@ pub type Rv32Shift256Air = VmAirWrapper<
     ShiftCoreAir<INT256_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 #[derive(Clone, PreflightExecutor)]
-pub struct Rv32Shift256Step(
-    ShiftStep<
-        Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
+pub struct Rv32Shift256Executor(
+    ShiftExecutor<
+        Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
     >,
@@ -134,8 +134,8 @@ pub type Rv32BranchEqual256Air = VmAirWrapper<
     BranchEqualCoreAir<INT256_NUM_LIMBS>,
 >;
 #[derive(Clone, PreflightExecutor)]
-pub struct Rv32BranchEqual256Step(
-    BranchEqualStep<Rv32HeapBranchAdapterStep<2, INT256_NUM_LIMBS>, INT256_NUM_LIMBS>,
+pub struct Rv32BranchEqual256Executor(
+    BranchEqualExecutor<Rv32HeapBranchAdapterExecutor<2, INT256_NUM_LIMBS>, INT256_NUM_LIMBS>,
 );
 pub type Rv32BranchEqual256Chip<F> = VmChipWrapper<
     F,
@@ -148,9 +148,9 @@ pub type Rv32BranchLessThan256Air = VmAirWrapper<
     BranchLessThanCoreAir<INT256_NUM_LIMBS, RV32_CELL_BITS>,
 >;
 #[derive(Clone, PreflightExecutor)]
-pub struct Rv32BranchLessThan256Step(
-    BranchLessThanStep<
-        Rv32HeapBranchAdapterStep<2, INT256_NUM_LIMBS>,
+pub struct Rv32BranchLessThan256Executor(
+    BranchLessThanExecutor<
+        Rv32HeapBranchAdapterExecutor<2, INT256_NUM_LIMBS>,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
     >,

--- a/extensions/bigint/circuit/src/mult.rs
+++ b/extensions/bigint/circuit/src/mult.rs
@@ -9,18 +9,18 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
     LocalOpcode,
 };
-use openvm_rv32_adapters::Rv32HeapAdapterStep;
-use openvm_rv32im_circuit::MultiplicationStep;
+use openvm_rv32_adapters::Rv32HeapAdapterExecutor;
+use openvm_rv32im_circuit::MultiplicationExecutor;
 use openvm_rv32im_transpiler::MulOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::{Rv32Multiplication256Step, INT256_NUM_LIMBS};
+use crate::{Rv32Multiplication256Executor, INT256_NUM_LIMBS};
 
-type AdapterStep = Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
+type AdapterExecutor = Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
 
-impl Rv32Multiplication256Step {
-    pub fn new(adapter: AdapterStep, offset: usize) -> Self {
-        Self(MultiplicationStep::new(adapter, offset))
+impl Rv32Multiplication256Executor {
+    pub fn new(adapter: AdapterExecutor, offset: usize) -> Self {
+        Self(MultiplicationExecutor::new(adapter, offset))
     }
 }
 
@@ -32,7 +32,7 @@ struct MultPreCompute {
     c: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for Rv32Multiplication256Step {
+impl<F: PrimeField32> Executor<F> for Rv32Multiplication256Executor {
     fn pre_compute_size(&self) -> usize {
         size_of::<MultPreCompute>()
     }
@@ -52,7 +52,7 @@ impl<F: PrimeField32> Executor<F> for Rv32Multiplication256Step {
     }
 }
 
-impl<F: PrimeField32> MeteredExecutor<F> for Rv32Multiplication256Step {
+impl<F: PrimeField32> MeteredExecutor<F> for Rv32Multiplication256Executor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<MultPreCompute>>()
     }
@@ -110,7 +110,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx>(
     execute_e12_impl(&pre_compute.data, vm_state);
 }
 
-impl Rv32Multiplication256Step {
+impl Rv32Multiplication256Executor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/bigint/circuit/src/shift.rs
+++ b/extensions/bigint/circuit/src/shift.rs
@@ -9,18 +9,18 @@ use openvm_instructions::{
     riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
     LocalOpcode,
 };
-use openvm_rv32_adapters::Rv32HeapAdapterStep;
-use openvm_rv32im_circuit::ShiftStep;
+use openvm_rv32_adapters::Rv32HeapAdapterExecutor;
+use openvm_rv32im_circuit::ShiftExecutor;
 use openvm_rv32im_transpiler::ShiftOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use crate::{Rv32Shift256Step, INT256_NUM_LIMBS};
+use crate::{Rv32Shift256Executor, INT256_NUM_LIMBS};
 
-type AdapterStep = Rv32HeapAdapterStep<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
+type AdapterExecutor = Rv32HeapAdapterExecutor<2, INT256_NUM_LIMBS, INT256_NUM_LIMBS>;
 
-impl Rv32Shift256Step {
-    pub fn new(adapter: AdapterStep, offset: usize) -> Self {
-        Self(ShiftStep::new(adapter, offset))
+impl Rv32Shift256Executor {
+    pub fn new(adapter: AdapterExecutor, offset: usize) -> Self {
+        Self(ShiftExecutor::new(adapter, offset))
     }
 }
 
@@ -32,7 +32,7 @@ struct ShiftPreCompute {
     c: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for Rv32Shift256Step {
+impl<F: PrimeField32> Executor<F> for Rv32Shift256Executor {
     fn pre_compute_size(&self) -> usize {
         size_of::<ShiftPreCompute>()
     }
@@ -57,7 +57,7 @@ impl<F: PrimeField32> Executor<F> for Rv32Shift256Step {
     }
 }
 
-impl<F: PrimeField32> MeteredExecutor<F> for Rv32Shift256Step {
+impl<F: PrimeField32> MeteredExecutor<F> for Rv32Shift256Executor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<ShiftPreCompute>>()
     }
@@ -118,7 +118,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, OP: ShiftOp>(
     execute_e12_impl::<F, CTX, OP>(&pre_compute.data, vm_state);
 }
 
-impl Rv32Shift256Step {
+impl Rv32Shift256Executor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -22,7 +22,7 @@ use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 use crate::{
     get_ec_addne_air, get_ec_addne_chip, get_ec_addne_step, get_ec_double_air, get_ec_double_chip,
-    get_ec_double_step, EcDoubleStep, WeierstrassAir, WeierstrassChip,
+    get_ec_double_step, EcDoubleExecutor, WeierstrassAir, WeierstrassChip,
 };
 
 const NUM_LIMBS: usize = 32;
@@ -89,7 +89,7 @@ fn prime_limbs(expr: &FieldExpr) -> Vec<BabyBear> {
 
 type WeierstrassHarness = TestChipHarness<
     F,
-    EcDoubleStep<2, BLOCK_SIZE>,
+    EcDoubleExecutor<2, BLOCK_SIZE>,
     WeierstrassAir<1, 2, BLOCK_SIZE>,
     WeierstrassChip<F, 1, 2, BLOCK_SIZE>,
     MatrixRecordArena<F>,

--- a/extensions/ecc/circuit/src/weierstrass_extension.rs
+++ b/extensions/ecc/circuit/src/weierstrass_extension.rs
@@ -36,7 +36,7 @@ use strum::EnumCount;
 
 use crate::{
     get_ec_addne_air, get_ec_addne_chip, get_ec_addne_step, get_ec_double_air, get_ec_double_chip,
-    get_ec_double_step, EcAddNeStep, EcDoubleStep, EccCpuProverExt, WeierstrassAir,
+    get_ec_double_step, EcAddNeExecutor, EcDoubleExecutor, EccCpuProverExt, WeierstrassAir,
 };
 
 #[serde_as]
@@ -95,11 +95,11 @@ impl WeierstrassExtension {
 #[derive(Clone, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 pub enum WeierstrassExtensionExecutor {
     // 32 limbs prime
-    EcAddNeRv32_32(EcAddNeStep<2, 32>),
-    EcDoubleRv32_32(EcDoubleStep<2, 32>),
+    EcAddNeRv32_32(EcAddNeExecutor<2, 32>),
+    EcDoubleRv32_32(EcDoubleExecutor<2, 32>),
     // 48 limbs prime
-    EcAddNeRv32_48(EcAddNeStep<6, 16>),
-    EcDoubleRv32_48(EcDoubleStep<6, 16>),
+    EcAddNeRv32_48(EcAddNeExecutor<6, 16>),
+    EcDoubleRv32_48(EcDoubleExecutor<6, 16>),
 }
 
 impl<F: PrimeField32> VmExecutionExtension<F> for WeierstrassExtension {

--- a/extensions/keccak256/circuit/src/extension.rs
+++ b/extensions/keccak256/circuit/src/extension.rs
@@ -103,7 +103,7 @@ pub struct Keccak256;
 
 #[derive(Clone, Copy, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 pub enum Keccak256Executor {
-    Keccak256(KeccakVmStep),
+    Keccak256(KeccakVmExecutor),
 }
 
 impl<F> VmExecutionExtension<F> for Keccak256 {
@@ -114,7 +114,7 @@ impl<F> VmExecutionExtension<F> for Keccak256 {
         inventory: &mut ExecutorInventoryBuilder<F, Keccak256Executor>,
     ) -> Result<(), ExecutorInventoryError> {
         let pointer_max_bits = inventory.pointer_max_bits();
-        let keccak_step = KeccakVmStep::new(Rv32KeccakOpcode::CLASS_OFFSET, pointer_max_bits);
+        let keccak_step = KeccakVmExecutor::new(Rv32KeccakOpcode::CLASS_OFFSET, pointer_max_bits);
         inventory.add_executor(
             keccak_step,
             Rv32KeccakOpcode::iter().map(|x| x.global_opcode()),

--- a/extensions/keccak256/circuit/src/lib.rs
+++ b/extensions/keccak256/circuit/src/lib.rs
@@ -63,7 +63,7 @@ pub const KECCAK_DIGEST_U64S: usize = KECCAK_DIGEST_BYTES / 8;
 pub type KeccakVmChip<F> = VmChipWrapper<F, KeccakVmFiller>;
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct KeccakVmStep {
+pub struct KeccakVmExecutor {
     pub offset: usize,
     pub pointer_max_bits: usize,
 }
@@ -82,7 +82,7 @@ struct KeccakPreCompute {
     c: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for KeccakVmStep {
+impl<F: PrimeField32> Executor<F> for KeccakVmExecutor {
     fn pre_compute_size(&self) -> usize {
         size_of::<KeccakPreCompute>()
     }
@@ -102,7 +102,7 @@ impl<F: PrimeField32> Executor<F> for KeccakVmStep {
     }
 }
 
-impl<F: PrimeField32> MeteredExecutor<F> for KeccakVmStep {
+impl<F: PrimeField32> MeteredExecutor<F> for KeccakVmExecutor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<KeccakPreCompute>>()
     }
@@ -182,7 +182,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx>(
         .on_height_change(pre_compute.chip_idx as usize, height);
 }
 
-impl KeccakVmStep {
+impl KeccakVmExecutor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/keccak256/circuit/src/tests.rs
+++ b/extensions/keccak256/circuit/src/tests.rs
@@ -29,12 +29,12 @@ use tiny_keccak::Hasher;
 
 use super::{columns::KeccakVmCols, KeccakVmChip};
 use crate::{
-    trace::KeccakVmRecordLayout, utils::keccak256, KeccakVmAir, KeccakVmFiller, KeccakVmStep,
+    trace::KeccakVmRecordLayout, utils::keccak256, KeccakVmAir, KeccakVmExecutor, KeccakVmFiller,
 };
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 8192;
-type Harness<RA> = TestChipHarness<F, KeccakVmStep, KeccakVmAir, KeccakVmChip<F>, RA>;
+type Harness<RA> = TestChipHarness<F, KeccakVmExecutor, KeccakVmAir, KeccakVmChip<F>, RA>;
 
 fn create_test_chips<RA: Arena>(
     tester: &mut VmChipTestBuilder<F>,
@@ -58,7 +58,7 @@ fn create_test_chips<RA: Arena>(
         Rv32KeccakOpcode::CLASS_OFFSET,
     );
 
-    let executor = KeccakVmStep::new(Rv32KeccakOpcode::CLASS_OFFSET, tester.address_bits());
+    let executor = KeccakVmExecutor::new(Rv32KeccakOpcode::CLASS_OFFSET, tester.address_bits());
     let chip = KeccakVmChip::new(
         KeccakVmFiller::new(bitwise_chip.clone(), tester.address_bits()),
         tester.memory_helper(),
@@ -78,7 +78,7 @@ fn set_and_execute<RA: Arena>(
     len: Option<usize>,
     expected_output: Option<[u8; 32]>,
 ) where
-    KeccakVmStep: PreflightExecutor<F, RA>,
+    KeccakVmExecutor: PreflightExecutor<F, RA>,
 {
     let len = len.unwrap_or(rng.gen_range(1..3000));
     let tmp = get_random_message(rng, len);

--- a/extensions/keccak256/circuit/src/trace.rs
+++ b/extensions/keccak256/circuit/src/trace.rs
@@ -38,7 +38,7 @@ use super::{
 use crate::{
     columns::NUM_KECCAK_VM_COLS,
     utils::{keccak256, keccak_f, num_keccak_f},
-    KeccakVmFiller, KeccakVmStep, KECCAK_DIGEST_BYTES, KECCAK_RATE_U16S, KECCAK_WORD_SIZE,
+    KeccakVmExecutor, KeccakVmFiller, KECCAK_DIGEST_BYTES, KECCAK_RATE_U16S, KECCAK_WORD_SIZE,
 };
 
 #[derive(Clone, Copy)]
@@ -125,7 +125,7 @@ impl SizedRecord<KeccakVmRecordLayout> for KeccakVmRecordMut<'_> {
     }
 }
 
-impl<F, RA> PreflightExecutor<F, RA> for KeccakVmStep
+impl<F, RA> PreflightExecutor<F, RA> for KeccakVmExecutor
 where
     F: PrimeField32,
     for<'buf> RA: RecordArena<'buf, KeccakVmRecordLayout, KeccakVmRecordMut<'buf>>,

--- a/extensions/native/circuit/src/adapters/alu_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/alu_native_adapter.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, MinimalInstruction, VmAdapterAir,
     },
     system::{
@@ -143,12 +143,12 @@ pub struct AluNativeAdapterRecord<F> {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct AluNativeAdapterStep;
+pub struct AluNativeAdapterExecutor;
 
 #[derive(derive_new::new)]
 pub struct AluNativeAdapterFiller;
 
-impl<F: PrimeField32> AdapterTraceStep<F> for AluNativeAdapterStep {
+impl<F: PrimeField32> AdapterTraceExecutor<F> for AluNativeAdapterExecutor {
     const WIDTH: usize = size_of::<AluNativeAdapterCols<u8>>();
     type ReadData = [F; 2];
     type WriteData = [F; 1];

--- a/extensions/native/circuit/src/adapters/branch_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/branch_native_adapter.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, ImmInstruction, VmAdapterAir,
     },
     system::{
@@ -135,12 +135,12 @@ pub struct BranchNativeAdapterRecord<F> {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct BranchNativeAdapterStep;
+pub struct BranchNativeAdapterExecutor;
 
 #[derive(derive_new::new)]
 pub struct BranchNativeAdapterFiller;
 
-impl<F> AdapterTraceStep<F> for BranchNativeAdapterStep
+impl<F> AdapterTraceExecutor<F> for BranchNativeAdapterExecutor
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/adapters/convert_adapter.rs
+++ b/extensions/native/circuit/src/adapters/convert_adapter.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, MinimalInstruction, VmAdapterAir,
     },
     system::{
@@ -135,13 +135,13 @@ pub struct ConvertAdapterRecord<F, const READ_SIZE: usize, const WRITE_SIZE: usi
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct ConvertAdapterStep<const READ_SIZE: usize, const WRITE_SIZE: usize>;
+pub struct ConvertAdapterExecutor<const READ_SIZE: usize, const WRITE_SIZE: usize>;
 
 #[derive(derive_new::new)]
 pub struct ConvertAdapterFiller<const READ_SIZE: usize, const WRITE_SIZE: usize>;
 
-impl<F: PrimeField32, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterTraceStep<F>
-    for ConvertAdapterStep<READ_SIZE, WRITE_SIZE>
+impl<F: PrimeField32, const READ_SIZE: usize, const WRITE_SIZE: usize> AdapterTraceExecutor<F>
+    for ConvertAdapterExecutor<READ_SIZE, WRITE_SIZE>
 {
     const WIDTH: usize = size_of::<ConvertAdapterCols<u8, READ_SIZE, WRITE_SIZE>>();
     type ReadData = [F; READ_SIZE];

--- a/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
+++ b/extensions/native/circuit/src/adapters/loadstore_native_adapter.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         ExecutionBridge, ExecutionState, VmAdapterAir, VmAdapterInterface,
     },
     system::{
@@ -186,15 +186,15 @@ pub struct NativeLoadStoreAdapterRecord<F, const NUM_CELLS: usize> {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct NativeLoadStoreAdapterStep<const NUM_CELLS: usize> {
+pub struct NativeLoadStoreAdapterExecutor<const NUM_CELLS: usize> {
     offset: usize,
 }
 
 #[derive(derive_new::new)]
 pub struct NativeLoadStoreAdapterFiller<const NUM_CELLS: usize>;
 
-impl<F: PrimeField32, const NUM_CELLS: usize> AdapterTraceStep<F>
-    for NativeLoadStoreAdapterStep<NUM_CELLS>
+impl<F: PrimeField32, const NUM_CELLS: usize> AdapterTraceExecutor<F>
+    for NativeLoadStoreAdapterExecutor<NUM_CELLS>
 {
     const WIDTH: usize = std::mem::size_of::<NativeLoadStoreAdapterCols<u8, NUM_CELLS>>();
     type ReadData = (F, [F; NUM_CELLS]);

--- a/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
+++ b/extensions/native/circuit/src/adapters/native_vectorized_adapter.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, MinimalInstruction, VmAdapterAir,
     },
     system::{
@@ -135,12 +135,14 @@ pub struct NativeVectorizedAdapterRecord<F, const N: usize> {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct NativeVectorizedAdapterStep<const N: usize>;
+pub struct NativeVectorizedAdapterExecutor<const N: usize>;
 
 #[derive(derive_new::new)]
 pub struct NativeVectorizedAdapterFiller<const N: usize>;
 
-impl<F: PrimeField32, const N: usize> AdapterTraceStep<F> for NativeVectorizedAdapterStep<N> {
+impl<F: PrimeField32, const N: usize> AdapterTraceExecutor<F>
+    for NativeVectorizedAdapterExecutor<N>
+{
     const WIDTH: usize = size_of::<NativeVectorizedAdapterCols<u8, N>>();
     type ReadData = [[F; N]; 2];
     type WriteData = [F; N];

--- a/extensions/native/circuit/src/branch_eq/core.rs
+++ b/extensions/native/circuit/src/branch_eq/core.rs
@@ -27,7 +27,7 @@ pub struct NativeBranchEqualCoreRecord<F> {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct NativeBranchEqualStep<A> {
+pub struct NativeBranchEqualExecutor<A> {
     adapter: A,
     pub offset: usize,
     pub pc_step: u32,
@@ -38,10 +38,10 @@ pub struct NativeBranchEqualFiller<A> {
     adapter: A,
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for NativeBranchEqualStep<A>
+impl<F, A, RA> PreflightExecutor<F, RA> for NativeBranchEqualExecutor<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData: Into<[F; 2]>, WriteData = ()>,
+    A: 'static + AdapterTraceExecutor<F, ReadData: Into<[F; 2]>, WriteData = ()>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -121,7 +121,7 @@ struct NativeBranchEqualPreCompute {
     b_or_imm: u32,
 }
 
-impl<A> NativeBranchEqualStep<A> {
+impl<A> NativeBranchEqualExecutor<A> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -174,7 +174,7 @@ impl<A> NativeBranchEqualStep<A> {
     }
 }
 
-impl<F, A> Executor<F> for NativeBranchEqualStep<A>
+impl<F, A> Executor<F> for NativeBranchEqualExecutor<A>
 where
     F: PrimeField32,
 {
@@ -209,7 +209,7 @@ where
     }
 }
 
-impl<F, A> MeteredExecutor<F> for NativeBranchEqualStep<A>
+impl<F, A> MeteredExecutor<F> for NativeBranchEqualExecutor<A>
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/branch_eq/mod.rs
+++ b/extensions/native/circuit/src/branch_eq/mod.rs
@@ -4,12 +4,14 @@ use openvm_rv32im_circuit::BranchEqualCoreAir;
 mod core;
 pub use core::*;
 
-use crate::adapters::{BranchNativeAdapterAir, BranchNativeAdapterFiller, BranchNativeAdapterStep};
+use crate::adapters::{
+    BranchNativeAdapterAir, BranchNativeAdapterExecutor, BranchNativeAdapterFiller,
+};
 
 #[cfg(test)]
 mod tests;
 
 pub type NativeBranchEqAir = VmAirWrapper<BranchNativeAdapterAir, BranchEqualCoreAir<1>>;
-pub type NativeBranchEqStep = NativeBranchEqualStep<BranchNativeAdapterStep>;
+pub type NativeBranchEqExecutor = NativeBranchEqualExecutor<BranchNativeAdapterExecutor>;
 pub type NativeBranchEqChip<F> =
     VmChipWrapper<F, NativeBranchEqualFiller<BranchNativeAdapterFiller>>;

--- a/extensions/native/circuit/src/branch_eq/tests.rs
+++ b/extensions/native/circuit/src/branch_eq/tests.rs
@@ -27,8 +27,8 @@ use rand::{rngs::StdRng, Rng};
 use test_case::test_case;
 
 use crate::{
-    adapters::{BranchNativeAdapterAir, BranchNativeAdapterFiller, BranchNativeAdapterStep},
-    branch_eq::{run_eq, NativeBranchEqAir, NativeBranchEqChip, NativeBranchEqStep},
+    adapters::{BranchNativeAdapterAir, BranchNativeAdapterExecutor, BranchNativeAdapterFiller},
+    branch_eq::{run_eq, NativeBranchEqAir, NativeBranchEqChip, NativeBranchEqExecutor},
     test_utils::write_native_or_imm,
     NativeBranchEqualFiller,
 };
@@ -36,15 +36,15 @@ use crate::{
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
 const ABS_MAX_IMM: i32 = 1 << (RV_B_TYPE_IMM_BITS - 1);
-type Harness = TestChipHarness<F, NativeBranchEqStep, NativeBranchEqAir, NativeBranchEqChip<F>>;
+type Harness = TestChipHarness<F, NativeBranchEqExecutor, NativeBranchEqAir, NativeBranchEqChip<F>>;
 
 fn create_test_chip(tester: &mut VmChipTestBuilder<F>) -> Harness {
     let air = NativeBranchEqAir::new(
         BranchNativeAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         BranchEqualCoreAir::new(NativeBranchEqualOpcode::CLASS_OFFSET, DEFAULT_PC_STEP),
     );
-    let executor = NativeBranchEqStep::new(
-        BranchNativeAdapterStep,
+    let executor = NativeBranchEqExecutor::new(
+        BranchNativeAdapterExecutor,
         NativeBranchEqualOpcode::CLASS_OFFSET,
         DEFAULT_PC_STEP,
     );

--- a/extensions/native/circuit/src/castf/core.rs
+++ b/extensions/native/circuit/src/castf/core.rs
@@ -118,7 +118,7 @@ pub struct CastFCoreRecord {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct CastFCoreStep<A> {
+pub struct CastFCoreExecutor<A> {
     adapter: A,
 }
 
@@ -128,10 +128,11 @@ pub struct CastFCoreFiller<A> {
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for CastFCoreStep<A>
+impl<F, A, RA> PreflightExecutor<F, RA> for CastFCoreExecutor<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData = [F; 1], WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
+    A: 'static
+        + AdapterTraceExecutor<F, ReadData = [F; 1], WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -202,7 +203,7 @@ struct CastFPreCompute {
     b: u32,
 }
 
-impl<A> CastFCoreStep<A> {
+impl<A> CastFCoreExecutor<A> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -232,7 +233,7 @@ impl<A> CastFCoreStep<A> {
     }
 }
 
-impl<F, A> Executor<F> for CastFCoreStep<A>
+impl<F, A> Executor<F> for CastFCoreExecutor<A>
 where
     F: PrimeField32,
 {
@@ -258,7 +259,7 @@ where
     }
 }
 
-impl<F, A> MeteredExecutor<F> for CastFCoreStep<A>
+impl<F, A> MeteredExecutor<F> for CastFCoreExecutor<A>
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/castf/mod.rs
+++ b/extensions/native/circuit/src/castf/mod.rs
@@ -1,6 +1,6 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
-use crate::adapters::{ConvertAdapterAir, ConvertAdapterFiller, ConvertAdapterStep};
+use crate::adapters::{ConvertAdapterAir, ConvertAdapterExecutor, ConvertAdapterFiller};
 
 mod core;
 pub use core::*;
@@ -9,5 +9,5 @@ pub use core::*;
 mod tests;
 
 pub type CastFAir = VmAirWrapper<ConvertAdapterAir<1, 4>, CastFCoreAir>;
-pub type CastFStep = CastFCoreStep<ConvertAdapterStep<1, 4>>;
+pub type CastFExecutor = CastFCoreExecutor<ConvertAdapterExecutor<1, 4>>;
 pub type CastFChip<F> = VmChipWrapper<F, CastFCoreFiller<ConvertAdapterFiller<1, 4>>>;

--- a/extensions/native/circuit/src/castf/tests.rs
+++ b/extensions/native/circuit/src/castf/tests.rs
@@ -23,9 +23,11 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 
-use super::{CastFChip, CastFCoreAir, CastFCoreCols, CastFStep, LIMB_BITS};
+use super::{CastFChip, CastFCoreAir, CastFCoreCols, CastFExecutor, LIMB_BITS};
 use crate::{
-    adapters::{ConvertAdapterAir, ConvertAdapterCols, ConvertAdapterFiller, ConvertAdapterStep},
+    adapters::{
+        ConvertAdapterAir, ConvertAdapterCols, ConvertAdapterExecutor, ConvertAdapterFiller,
+    },
     castf::run_castf,
     test_utils::write_native_array,
     CastFAir, CastFCoreFiller, CASTF_MAX_BITS,
@@ -35,7 +37,7 @@ const MAX_INS_CAPACITY: usize = 128;
 const READ_SIZE: usize = 1;
 const WRITE_SIZE: usize = 4;
 type F = BabyBear;
-type Harness = TestChipHarness<F, CastFStep, CastFAir, CastFChip<F>>;
+type Harness = TestChipHarness<F, CastFExecutor, CastFAir, CastFChip<F>>;
 
 fn create_test_chip(tester: &VmChipTestBuilder<F>) -> Harness {
     let range_checker = tester.range_checker().clone();
@@ -43,7 +45,7 @@ fn create_test_chip(tester: &VmChipTestBuilder<F>) -> Harness {
         ConvertAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         CastFCoreAir::new(range_checker.bus()),
     );
-    let executor = CastFStep::new(ConvertAdapterStep::<READ_SIZE, WRITE_SIZE>::new());
+    let executor = CastFExecutor::new(ConvertAdapterExecutor::<READ_SIZE, WRITE_SIZE>::new());
     let chip = CastFChip::<F>::new(
         CastFCoreFiller::new(ConvertAdapterFiller, range_checker),
         tester.memory_helper(),

--- a/extensions/native/circuit/src/field_arithmetic/core.rs
+++ b/extensions/native/circuit/src/field_arithmetic/core.rs
@@ -123,7 +123,7 @@ pub struct FieldArithmeticRecord<F> {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct FieldArithmeticCoreStep<A> {
+pub struct FieldArithmeticCoreExecutor<A> {
     adapter: A,
 }
 
@@ -132,10 +132,10 @@ pub struct FieldArithmeticCoreFiller<A> {
     adapter: A,
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for FieldArithmeticCoreStep<A>
+impl<F, A, RA> PreflightExecutor<F, RA> for FieldArithmeticCoreExecutor<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData = [F; 2], WriteData = [F; 1]>,
+    A: 'static + AdapterTraceExecutor<F, ReadData = [F; 2], WriteData = [F; 1]>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -220,7 +220,7 @@ struct FieldArithmeticPreCompute {
     f: u32,
 }
 
-impl<A> FieldArithmeticCoreStep<A> {
+impl<A> FieldArithmeticCoreExecutor<A> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -272,7 +272,7 @@ impl<A> FieldArithmeticCoreStep<A> {
     }
 }
 
-impl<F, A> Executor<F> for FieldArithmeticCoreStep<A>
+impl<F, A> Executor<F> for FieldArithmeticCoreExecutor<A>
 where
     F: PrimeField32,
 {
@@ -347,7 +347,7 @@ where
     }
 }
 
-impl<F, A> MeteredExecutor<F> for FieldArithmeticCoreStep<A>
+impl<F, A> MeteredExecutor<F> for FieldArithmeticCoreExecutor<A>
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/field_arithmetic/mod.rs
+++ b/extensions/native/circuit/src/field_arithmetic/mod.rs
@@ -1,6 +1,6 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
-use crate::adapters::{AluNativeAdapterAir, AluNativeAdapterFiller, AluNativeAdapterStep};
+use crate::adapters::{AluNativeAdapterAir, AluNativeAdapterExecutor, AluNativeAdapterFiller};
 
 #[cfg(test)]
 mod tests;
@@ -9,6 +9,6 @@ mod core;
 pub use core::*;
 
 pub type FieldArithmeticAir = VmAirWrapper<AluNativeAdapterAir, FieldArithmeticCoreAir>;
-pub type FieldArithmeticStep = FieldArithmeticCoreStep<AluNativeAdapterStep>;
+pub type FieldArithmeticExecutor = FieldArithmeticCoreExecutor<AluNativeAdapterExecutor>;
 pub type FieldArithmeticChip<F> =
     VmChipWrapper<F, FieldArithmeticCoreFiller<AluNativeAdapterFiller>>;

--- a/extensions/native/circuit/src/field_arithmetic/tests.rs
+++ b/extensions/native/circuit/src/field_arithmetic/tests.rs
@@ -18,10 +18,10 @@ use rand::{rngs::StdRng, Rng};
 use test_case::test_case;
 
 use super::{
-    FieldArithmeticChip, FieldArithmeticCoreAir, FieldArithmeticCoreCols, FieldArithmeticStep,
+    FieldArithmeticChip, FieldArithmeticCoreAir, FieldArithmeticCoreCols, FieldArithmeticExecutor,
 };
 use crate::{
-    adapters::{AluNativeAdapterAir, AluNativeAdapterFiller, AluNativeAdapterStep},
+    adapters::{AluNativeAdapterAir, AluNativeAdapterExecutor, AluNativeAdapterFiller},
     field_arithmetic::{run_field_arithmetic, FieldArithmeticAir},
     test_utils::write_native_or_imm,
     FieldArithmeticCoreFiller,
@@ -29,14 +29,15 @@ use crate::{
 
 const MAX_INS_CAPACITY: usize = 128;
 type F = BabyBear;
-type Harness = TestChipHarness<F, FieldArithmeticStep, FieldArithmeticAir, FieldArithmeticChip<F>>;
+type Harness =
+    TestChipHarness<F, FieldArithmeticExecutor, FieldArithmeticAir, FieldArithmeticChip<F>>;
 
 fn create_test_chip(tester: &VmChipTestBuilder<F>) -> Harness {
     let air = FieldArithmeticAir::new(
         AluNativeAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         FieldArithmeticCoreAir::new(),
     );
-    let executor = FieldArithmeticStep::new(AluNativeAdapterStep::new());
+    let executor = FieldArithmeticExecutor::new(AluNativeAdapterExecutor::new());
     let chip = FieldArithmeticChip::<F>::new(
         FieldArithmeticCoreFiller::new(AluNativeAdapterFiller),
         tester.memory_helper(),

--- a/extensions/native/circuit/src/field_extension/core.rs
+++ b/extensions/native/circuit/src/field_extension/core.rs
@@ -147,7 +147,7 @@ pub struct FieldExtensionRecord<F> {
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct FieldExtensionCoreStep<A> {
+pub struct FieldExtensionCoreExecutor<A> {
     adapter: A,
 }
 
@@ -156,10 +156,10 @@ pub struct FieldExtensionCoreFiller<A> {
     adapter: A,
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for FieldExtensionCoreStep<A>
+impl<F, A, RA> PreflightExecutor<F, RA> for FieldExtensionCoreExecutor<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData = [[F; EXT_DEG]; 2], WriteData = [F; EXT_DEG]>,
+    A: 'static + AdapterTraceExecutor<F, ReadData = [[F; EXT_DEG]; 2], WriteData = [F; EXT_DEG]>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -245,7 +245,7 @@ struct FieldExtensionPreCompute {
     c: u32,
 }
 
-impl<A> FieldExtensionCoreStep<A> {
+impl<A> FieldExtensionCoreExecutor<A> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -286,7 +286,7 @@ impl<A> FieldExtensionCoreStep<A> {
     }
 }
 
-impl<F, A> Executor<F> for FieldExtensionCoreStep<A>
+impl<F, A> Executor<F> for FieldExtensionCoreExecutor<A>
 where
     F: PrimeField32,
 {
@@ -318,7 +318,7 @@ where
     }
 }
 
-impl<F, A> MeteredExecutor<F> for FieldExtensionCoreStep<A>
+impl<F, A> MeteredExecutor<F> for FieldExtensionCoreExecutor<A>
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/field_extension/mod.rs
+++ b/extensions/native/circuit/src/field_extension/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use crate::adapters::{
-    NativeVectorizedAdapterAir, NativeVectorizedAdapterFiller, NativeVectorizedAdapterStep,
+    NativeVectorizedAdapterAir, NativeVectorizedAdapterExecutor, NativeVectorizedAdapterFiller,
 };
 
 mod core;
@@ -12,6 +12,7 @@ mod tests;
 
 pub type FieldExtensionAir =
     VmAirWrapper<NativeVectorizedAdapterAir<EXT_DEG>, FieldExtensionCoreAir>;
-pub type FieldExtensionStep = FieldExtensionCoreStep<NativeVectorizedAdapterStep<EXT_DEG>>;
+pub type FieldExtensionExecutor =
+    FieldExtensionCoreExecutor<NativeVectorizedAdapterExecutor<EXT_DEG>>;
 pub type FieldExtensionChip<F> =
     VmChipWrapper<F, FieldExtensionCoreFiller<NativeVectorizedAdapterFiller<EXT_DEG>>>;

--- a/extensions/native/circuit/src/field_extension/tests.rs
+++ b/extensions/native/circuit/src/field_extension/tests.rs
@@ -23,24 +23,24 @@ use test_case::test_case;
 
 use crate::{
     adapters::{
-        NativeVectorizedAdapterAir, NativeVectorizedAdapterFiller, NativeVectorizedAdapterStep,
+        NativeVectorizedAdapterAir, NativeVectorizedAdapterExecutor, NativeVectorizedAdapterFiller,
     },
     field_extension::run_field_extension,
     test_utils::write_native_array,
     FieldExtension, FieldExtensionAir, FieldExtensionChip, FieldExtensionCoreAir,
-    FieldExtensionCoreCols, FieldExtensionCoreFiller, FieldExtensionStep, EXT_DEG,
+    FieldExtensionCoreCols, FieldExtensionCoreFiller, FieldExtensionExecutor, EXT_DEG,
 };
 
 const MAX_INS_CAPACITY: usize = 128;
 type F = BabyBear;
-type Harness = TestChipHarness<F, FieldExtensionStep, FieldExtensionAir, FieldExtensionChip<F>>;
+type Harness = TestChipHarness<F, FieldExtensionExecutor, FieldExtensionAir, FieldExtensionChip<F>>;
 
 fn create_test_chip(tester: &VmChipTestBuilder<F>) -> Harness {
     let air = FieldExtensionAir::new(
         NativeVectorizedAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         FieldExtensionCoreAir::new(),
     );
-    let executor = FieldExtensionStep::new(NativeVectorizedAdapterStep::new());
+    let executor = FieldExtensionExecutor::new(NativeVectorizedAdapterExecutor::new());
     let chip = FieldExtensionChip::<F>::new(
         FieldExtensionCoreFiller::new(NativeVectorizedAdapterFiller),
         tester.memory_helper(),

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -689,20 +689,20 @@ impl<F> SizedRecord<FriReducedOpeningLayout> for FriReducedOpeningRecordMut<'_, 
 }
 
 #[derive(derive_new::new, Copy, Clone)]
-pub struct FriReducedOpeningStep;
+pub struct FriReducedOpeningExecutor;
 
 #[derive(derive_new::new)]
 pub struct FriReducedOpeningFiller;
 
 pub type FriReducedOpeningChip<F> = VmChipWrapper<F, FriReducedOpeningFiller>;
 
-impl Default for FriReducedOpeningStep {
+impl Default for FriReducedOpeningExecutor {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<F, RA> PreflightExecutor<F, RA> for FriReducedOpeningStep
+impl<F, RA> PreflightExecutor<F, RA> for FriReducedOpeningExecutor
 where
     F: PrimeField32,
     for<'buf> RA: RecordArena<'buf, FriReducedOpeningLayout, FriReducedOpeningRecordMut<'buf, F>>,
@@ -1097,7 +1097,7 @@ struct FriReducedOpeningPreCompute {
     is_init_ptr: u32,
 }
 
-impl FriReducedOpeningStep {
+impl FriReducedOpeningExecutor {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -1138,7 +1138,7 @@ impl FriReducedOpeningStep {
     }
 }
 
-impl<F> Executor<F> for FriReducedOpeningStep
+impl<F> Executor<F> for FriReducedOpeningExecutor
 where
     F: PrimeField32,
 {
@@ -1163,7 +1163,7 @@ where
     }
 }
 
-impl<F> MeteredExecutor<F> for FriReducedOpeningStep
+impl<F> MeteredExecutor<F> for FriReducedOpeningExecutor
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/fri/tests.rs
+++ b/extensions/native/circuit/src/fri/tests.rs
@@ -18,7 +18,7 @@ use rand::{rngs::StdRng, Rng};
 
 use super::{
     super::field_extension::FieldExtension, elem_to_ext, FriReducedOpeningAir,
-    FriReducedOpeningChip, FriReducedOpeningStep, EXT_DEG,
+    FriReducedOpeningChip, FriReducedOpeningExecutor, EXT_DEG,
 };
 use crate::{
     fri::{WorkloadCols, OVERALL_WIDTH, WL_WIDTH},
@@ -28,11 +28,11 @@ use crate::{
 const MAX_INS_CAPACITY: usize = 1024;
 type F = BabyBear;
 type Harness =
-    TestChipHarness<F, FriReducedOpeningStep, FriReducedOpeningAir, FriReducedOpeningChip<F>>;
+    TestChipHarness<F, FriReducedOpeningExecutor, FriReducedOpeningAir, FriReducedOpeningChip<F>>;
 
 fn create_test_chip(tester: &VmChipTestBuilder<F>) -> Harness {
     let air = FriReducedOpeningAir::new(tester.execution_bridge(), tester.memory_bridge());
-    let step = FriReducedOpeningStep::new();
+    let step = FriReducedOpeningExecutor::new();
     let chip = FriReducedOpeningChip::new(FriReducedOpeningFiller, tester.memory_helper());
 
     Harness::with_capacity(step, air, chip, MAX_INS_CAPACITY)

--- a/extensions/native/circuit/src/jal_rangecheck/mod.rs
+++ b/extensions/native/circuit/src/jal_rangecheck/mod.rs
@@ -147,7 +147,7 @@ pub struct JalRangeCheckRecord<F> {
 /// Chip for JAL and RANGE_CHECK. These opcodes are logically irrelevant. Putting these opcodes into
 /// the same chip is just to save columns.
 #[derive(derive_new::new, Clone, Copy)]
-pub struct JalRangeCheckStep;
+pub struct JalRangeCheckExecutor;
 
 #[derive(derive_new::new)]
 pub struct JalRangeCheckFiller {
@@ -155,7 +155,7 @@ pub struct JalRangeCheckFiller {
 }
 pub type NativeJalRangeCheckChip<F> = VmChipWrapper<F, JalRangeCheckFiller>;
 
-impl<F, RA> PreflightExecutor<F, RA> for JalRangeCheckStep
+impl<F, RA> PreflightExecutor<F, RA> for JalRangeCheckExecutor
 where
     F: PrimeField32,
     for<'buf> RA: RecordArena<'buf, EmptyMultiRowLayout, &'buf mut JalRangeCheckRecord<F>>,
@@ -303,7 +303,7 @@ struct RangeCheckPreCompute {
     c: u8,
 }
 
-impl JalRangeCheckStep {
+impl JalRangeCheckExecutor {
     #[inline(always)]
     fn pre_compute_jal_impl<F: PrimeField32>(
         &self,
@@ -355,7 +355,7 @@ impl JalRangeCheckStep {
     }
 }
 
-impl<F> Executor<F> for JalRangeCheckStep
+impl<F> Executor<F> for JalRangeCheckExecutor
 where
     F: PrimeField32,
 {
@@ -390,7 +390,7 @@ where
     }
 }
 
-impl<F> MeteredExecutor<F> for JalRangeCheckStep
+impl<F> MeteredExecutor<F> for JalRangeCheckExecutor
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/jal_rangecheck/tests.rs
+++ b/extensions/native/circuit/src/jal_rangecheck/tests.rs
@@ -22,7 +22,7 @@ use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 use test_case::test_case;
 
-use super::{JalRangeCheckAir, JalRangeCheckStep};
+use super::{JalRangeCheckAir, JalRangeCheckExecutor};
 use crate::{
     jal_rangecheck::{JalRangeCheckCols, NativeJalRangeCheckChip},
     test_utils::write_native_array,
@@ -31,7 +31,8 @@ use crate::{
 
 const MAX_INS_CAPACITY: usize = 128;
 type F = BabyBear;
-type Harness = TestChipHarness<F, JalRangeCheckStep, JalRangeCheckAir, NativeJalRangeCheckChip<F>>;
+type Harness =
+    TestChipHarness<F, JalRangeCheckExecutor, JalRangeCheckAir, NativeJalRangeCheckChip<F>>;
 
 fn create_test_chip(tester: &VmChipTestBuilder<F>) -> Harness {
     let range_checker = tester.range_checker().clone();
@@ -40,7 +41,7 @@ fn create_test_chip(tester: &VmChipTestBuilder<F>) -> Harness {
         tester.memory_bridge(),
         range_checker.bus(),
     );
-    let executor = JalRangeCheckStep::new();
+    let executor = JalRangeCheckExecutor::new();
     let chip = NativeJalRangeCheckChip::<F>::new(
         JalRangeCheckFiller::new(range_checker),
         tester.memory_helper(),

--- a/extensions/native/circuit/src/loadstore/core.rs
+++ b/extensions/native/circuit/src/loadstore/core.rs
@@ -113,7 +113,7 @@ pub struct NativeLoadStoreCoreRecord<F, const NUM_CELLS: usize> {
 }
 
 #[derive(derive_new::new, Debug, Clone, Copy)]
-pub struct NativeLoadStoreCoreStep<A, const NUM_CELLS: usize> {
+pub struct NativeLoadStoreCoreExecutor<A, const NUM_CELLS: usize> {
     adapter: A,
     offset: usize,
 }
@@ -124,10 +124,11 @@ pub struct NativeLoadStoreCoreFiller<A, const NUM_CELLS: usize> {
 }
 
 impl<F, A, RA, const NUM_CELLS: usize> PreflightExecutor<F, RA>
-    for NativeLoadStoreCoreStep<A, NUM_CELLS>
+    for NativeLoadStoreCoreExecutor<A, NUM_CELLS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData = (F, [F; NUM_CELLS]), WriteData = [F; NUM_CELLS]>,
+    A: 'static
+        + AdapterTraceExecutor<F, ReadData = (F, [F; NUM_CELLS]), WriteData = [F; NUM_CELLS]>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -215,7 +216,7 @@ struct NativeLoadStorePreCompute<F> {
     c: u32,
 }
 
-impl<A, const NUM_CELLS: usize> NativeLoadStoreCoreStep<A, NUM_CELLS> {
+impl<A, const NUM_CELLS: usize> NativeLoadStoreCoreExecutor<A, NUM_CELLS> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -250,7 +251,7 @@ impl<A, const NUM_CELLS: usize> NativeLoadStoreCoreStep<A, NUM_CELLS> {
     }
 }
 
-impl<F, A, const NUM_CELLS: usize> Executor<F> for NativeLoadStoreCoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> Executor<F> for NativeLoadStoreCoreExecutor<A, NUM_CELLS>
 where
     F: PrimeField32,
 {
@@ -280,7 +281,7 @@ where
     }
 }
 
-impl<F, A, const NUM_CELLS: usize> MeteredExecutor<F> for NativeLoadStoreCoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> MeteredExecutor<F> for NativeLoadStoreCoreExecutor<A, NUM_CELLS>
 where
     F: PrimeField32,
 {

--- a/extensions/native/circuit/src/loadstore/mod.rs
+++ b/extensions/native/circuit/src/loadstore/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use crate::adapters::{
-    NativeLoadStoreAdapterAir, NativeLoadStoreAdapterFiller, NativeLoadStoreAdapterStep,
+    NativeLoadStoreAdapterAir, NativeLoadStoreAdapterExecutor, NativeLoadStoreAdapterFiller,
 };
 
 mod core;
@@ -12,7 +12,7 @@ mod tests;
 
 pub type NativeLoadStoreAir<const NUM_CELLS: usize> =
     VmAirWrapper<NativeLoadStoreAdapterAir<NUM_CELLS>, NativeLoadStoreCoreAir<NUM_CELLS>>;
-pub type NativeLoadStoreStep<const NUM_CELLS: usize> =
-    NativeLoadStoreCoreStep<NativeLoadStoreAdapterStep<NUM_CELLS>, NUM_CELLS>;
+pub type NativeLoadStoreExecutor<const NUM_CELLS: usize> =
+    NativeLoadStoreCoreExecutor<NativeLoadStoreAdapterExecutor<NUM_CELLS>, NUM_CELLS>;
 pub type NativeLoadStoreChip<F, const NUM_CELLS: usize> =
     VmChipWrapper<F, NativeLoadStoreCoreFiller<NativeLoadStoreAdapterFiller<NUM_CELLS>, NUM_CELLS>>;

--- a/extensions/native/circuit/src/loadstore/tests.rs
+++ b/extensions/native/circuit/src/loadstore/tests.rs
@@ -23,18 +23,19 @@ use test_case::test_case;
 use super::{NativeLoadStoreChip, NativeLoadStoreCoreAir};
 use crate::{
     adapters::{
-        NativeLoadStoreAdapterAir, NativeLoadStoreAdapterCols, NativeLoadStoreAdapterFiller,
-        NativeLoadStoreAdapterStep,
+        NativeLoadStoreAdapterAir, NativeLoadStoreAdapterCols, NativeLoadStoreAdapterExecutor,
+        NativeLoadStoreAdapterFiller,
     },
     test_utils::write_native_array,
-    NativeLoadStoreAir, NativeLoadStoreCoreCols, NativeLoadStoreCoreFiller, NativeLoadStoreStep,
+    NativeLoadStoreAir, NativeLoadStoreCoreCols, NativeLoadStoreCoreFiller,
+    NativeLoadStoreExecutor,
 };
 
 const MAX_INS_CAPACITY: usize = 128;
 type F = BabyBear;
 type Harness<const NUM_CELLS: usize> = TestChipHarness<
     F,
-    NativeLoadStoreStep<NUM_CELLS>,
+    NativeLoadStoreExecutor<NUM_CELLS>,
     NativeLoadStoreAir<NUM_CELLS>,
     NativeLoadStoreChip<F, NUM_CELLS>,
 >;
@@ -44,8 +45,8 @@ fn create_test_chip<const NUM_CELLS: usize>(tester: &VmChipTestBuilder<F>) -> Ha
         NativeLoadStoreAdapterAir::new(tester.memory_bridge(), tester.execution_bridge()),
         NativeLoadStoreCoreAir::new(NativeLoadStoreOpcode::CLASS_OFFSET),
     );
-    let executor = NativeLoadStoreStep::new(
-        NativeLoadStoreAdapterStep::new(NativeLoadStoreOpcode::CLASS_OFFSET),
+    let executor = NativeLoadStoreExecutor::new(
+        NativeLoadStoreAdapterExecutor::new(NativeLoadStoreOpcode::CLASS_OFFSET),
         NativeLoadStoreOpcode::CLASS_OFFSET,
     );
     let chip = NativeLoadStoreChip::<F, NUM_CELLS>::new(

--- a/extensions/native/circuit/src/poseidon2/chip.rs
+++ b/extensions/native/circuit/src/poseidon2/chip.rs
@@ -37,7 +37,7 @@ use crate::poseidon2::{
 };
 
 #[derive(Clone)]
-pub struct NativePoseidon2Step<F: Field, const SBOX_REGISTERS: usize> {
+pub struct NativePoseidon2Executor<F: Field, const SBOX_REGISTERS: usize> {
     pub(super) subchip: Poseidon2SubChip<F, SBOX_REGISTERS>,
     /// If true, `verify_batch` assumes the verification is always passed and skips poseidon2
     /// computation during execution for performance.
@@ -50,7 +50,7 @@ pub struct NativePoseidon2Filler<F: Field, const SBOX_REGISTERS: usize> {
     pub(super) subchip: Poseidon2SubChip<F, SBOX_REGISTERS>,
 }
 
-impl<F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SBOX_REGISTERS> {
+impl<F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Executor<F, SBOX_REGISTERS> {
     pub fn new(poseidon2_config: Poseidon2Config<F>) -> Self {
         let subchip = Poseidon2SubChip::new(poseidon2_config.constants);
         Self {
@@ -145,7 +145,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> SizedRecord<NativePoseidon2Re
 }
 
 impl<F: PrimeField32, RA, const SBOX_REGISTERS: usize> PreflightExecutor<F, RA>
-    for NativePoseidon2Step<F, SBOX_REGISTERS>
+    for NativePoseidon2Executor<F, SBOX_REGISTERS>
 where
     for<'buf> RA: RecordArena<
         'buf,
@@ -1009,7 +1009,7 @@ struct VerifyBatchPreCompute<'a, F: Field, const SBOX_REGISTERS: usize> {
     opened_element_size: F,
 }
 
-impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SBOX_REGISTERS> {
+impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Executor<F, SBOX_REGISTERS> {
     #[inline(always)]
     fn pre_compute_pos2_impl(
         &'a self,
@@ -1107,7 +1107,7 @@ impl<'a, F: PrimeField32, const SBOX_REGISTERS: usize> NativePoseidon2Step<F, SB
 }
 
 impl<F: PrimeField32, const SBOX_REGISTERS: usize> Executor<F>
-    for NativePoseidon2Step<F, SBOX_REGISTERS>
+    for NativePoseidon2Executor<F, SBOX_REGISTERS>
 {
     #[inline(always)]
     fn pre_compute_size(&self) -> usize {
@@ -1146,7 +1146,7 @@ impl<F: PrimeField32, const SBOX_REGISTERS: usize> Executor<F>
 }
 
 impl<F: PrimeField32, const SBOX_REGISTERS: usize> MeteredExecutor<F>
-    for NativePoseidon2Step<F, SBOX_REGISTERS>
+    for NativePoseidon2Executor<F, SBOX_REGISTERS>
 {
     #[inline(always)]
     fn metered_pre_compute_size(&self) -> usize {

--- a/extensions/native/circuit/src/poseidon2/tests.rs
+++ b/extensions/native/circuit/src/poseidon2/tests.rs
@@ -34,7 +34,7 @@ use rand::{rngs::StdRng, Rng};
 use super::air::VerifyBatchBus;
 use crate::{
     air::NativePoseidon2Air,
-    chip::NativePoseidon2Step,
+    chip::NativePoseidon2Executor,
     poseidon2::{chip::NativePoseidon2Filler, CHUNK},
     NativeConfig, NativeCpuBuilder, NativePoseidon2Chip,
 };
@@ -43,7 +43,7 @@ const VERIFY_BATCH_BUS: VerifyBatchBus = VerifyBatchBus::new(7);
 const MAX_INS_CAPACITY: usize = 1 << 15;
 type Harness<F, const SBOX_REGISTERS: usize> = TestChipHarness<
     F,
-    NativePoseidon2Step<F, SBOX_REGISTERS>,
+    NativePoseidon2Executor<F, SBOX_REGISTERS>,
     NativePoseidon2Air<F, SBOX_REGISTERS>,
     NativePoseidon2Chip<F, SBOX_REGISTERS>,
 >;
@@ -57,7 +57,7 @@ fn create_test_chip<F: PrimeField32, const SBOX_REGISTERS: usize>(
         VERIFY_BATCH_BUS,
         Poseidon2Config::default(),
     );
-    let step = NativePoseidon2Step::new(Poseidon2Config::default());
+    let step = NativePoseidon2Executor::new(Poseidon2Config::default());
     let chip = NativePoseidon2Chip::new(
         NativePoseidon2Filler::new(Poseidon2Config::default()),
         tester.memory_helper(),

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -6,7 +6,7 @@ use std::{
 use itertools::izip;
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, MinimalInstruction, VmAdapterAir,
     },
     system::memory::{
@@ -245,7 +245,7 @@ pub struct Rv32IsEqualModAdapterRecord<
 }
 
 #[derive(Clone, Copy)]
-pub struct Rv32IsEqualModAdapterStep<
+pub struct Rv32IsEqualModAdapterExecutor<
     const NUM_READS: usize,
     const BLOCKS_PER_READ: usize,
     const BLOCK_SIZE: usize,
@@ -270,7 +270,7 @@ impl<
         const BLOCKS_PER_READ: usize,
         const BLOCK_SIZE: usize,
         const TOTAL_READ_SIZE: usize,
-    > Rv32IsEqualModAdapterStep<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
+    > Rv32IsEqualModAdapterExecutor<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
 {
     pub fn new(pointer_max_bits: usize) -> Self {
         assert!(NUM_READS <= 2);
@@ -289,8 +289,8 @@ impl<
         const BLOCKS_PER_READ: usize,
         const BLOCK_SIZE: usize,
         const TOTAL_READ_SIZE: usize,
-    > AdapterTraceStep<F>
-    for Rv32IsEqualModAdapterStep<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
+    > AdapterTraceExecutor<F>
+    for Rv32IsEqualModAdapterExecutor<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
 where
     F: PrimeField32,
 {

--- a/extensions/rv32-adapters/src/heap_branch.rs
+++ b/extensions/rv32-adapters/src/heap_branch.rs
@@ -6,7 +6,7 @@ use std::{
 use itertools::izip;
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, ImmInstruction, VmAdapterAir,
     },
     system::memory::{
@@ -176,7 +176,7 @@ pub struct Rv32HeapBranchAdapterRecord<const NUM_READS: usize> {
 }
 
 #[derive(Clone, Copy)]
-pub struct Rv32HeapBranchAdapterStep<const NUM_READS: usize, const READ_SIZE: usize> {
+pub struct Rv32HeapBranchAdapterExecutor<const NUM_READS: usize, const READ_SIZE: usize> {
     pub pointer_max_bits: usize,
 }
 
@@ -187,7 +187,7 @@ pub struct Rv32HeapBranchAdapterFiller<const NUM_READS: usize, const READ_SIZE: 
 }
 
 impl<const NUM_READS: usize, const READ_SIZE: usize>
-    Rv32HeapBranchAdapterStep<NUM_READS, READ_SIZE>
+    Rv32HeapBranchAdapterExecutor<NUM_READS, READ_SIZE>
 {
     pub fn new(pointer_max_bits: usize) -> Self {
         assert!(NUM_READS <= 2);
@@ -199,8 +199,8 @@ impl<const NUM_READS: usize, const READ_SIZE: usize>
     }
 }
 
-impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterTraceStep<F>
-    for Rv32HeapBranchAdapterStep<NUM_READS, READ_SIZE>
+impl<F: PrimeField32, const NUM_READS: usize, const READ_SIZE: usize> AdapterTraceExecutor<F>
+    for Rv32HeapBranchAdapterExecutor<NUM_READS, READ_SIZE>
 {
     const WIDTH: usize = Rv32HeapBranchAdapterCols::<F, NUM_READS, READ_SIZE>::width();
     type ReadData = [[u8; READ_SIZE]; NUM_READS];

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -7,7 +7,7 @@ use std::{
 use itertools::izip;
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         ExecutionBridge, ExecutionState, VecHeapAdapterInterface, VmAdapterAir,
     },
     system::memory::{
@@ -291,7 +291,7 @@ pub struct Rv32VecHeapAdapterRecord<
 }
 
 #[derive(derive_new::new, Clone, Copy)]
-pub struct Rv32VecHeapAdapterStep<
+pub struct Rv32VecHeapAdapterExecutor<
     const NUM_READS: usize,
     const BLOCKS_PER_READ: usize,
     const BLOCKS_PER_WRITE: usize,
@@ -320,8 +320,14 @@ impl<
         const BLOCKS_PER_WRITE: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > AdapterTraceStep<F>
-    for Rv32VecHeapAdapterStep<NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>
+    > AdapterTraceExecutor<F>
+    for Rv32VecHeapAdapterExecutor<
+        NUM_READS,
+        BLOCKS_PER_READ,
+        BLOCKS_PER_WRITE,
+        READ_SIZE,
+        WRITE_SIZE,
+    >
 {
     const WIDTH: usize = Rv32VecHeapAdapterCols::<
         F,

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -2,7 +2,7 @@ use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, MinimalInstruction, VmAdapterAir,
     },
     system::memory::{
@@ -164,7 +164,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
 }
 
 #[derive(Clone, derive_new::new)]
-pub struct Rv32BaseAluAdapterStep<const LIMB_BITS: usize>;
+pub struct Rv32BaseAluAdapterExecutor<const LIMB_BITS: usize>;
 
 #[derive(derive_new::new)]
 pub struct Rv32BaseAluAdapterFiller<const LIMB_BITS: usize> {
@@ -189,8 +189,8 @@ pub struct Rv32BaseAluAdapterRecord {
     pub writes_aux: MemoryWriteBytesAuxRecord<RV32_REGISTER_NUM_LIMBS>,
 }
 
-impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceStep<F>
-    for Rv32BaseAluAdapterStep<LIMB_BITS>
+impl<F: PrimeField32, const LIMB_BITS: usize> AdapterTraceExecutor<F>
+    for Rv32BaseAluAdapterExecutor<LIMB_BITS>
 {
     const WIDTH: usize = size_of::<Rv32BaseAluAdapterCols<u8>>();
     type ReadData = [[u8; RV32_REGISTER_NUM_LIMBS]; 2];

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -2,7 +2,7 @@ use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, ImmInstruction, VmAdapterAir,
     },
     system::memory::{
@@ -118,12 +118,12 @@ pub struct Rv32BranchAdapterRecord {
 /// Reads instructions of the form OP a, b, c, d, e where if(\[a:4\]_d op \[b:4\]_e) pc += c.
 /// Operands d and e can only be 1.
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32BranchAdapterStep;
+pub struct Rv32BranchAdapterExecutor;
 
 #[derive(derive_new::new)]
 pub struct Rv32BranchAdapterFiller;
 
-impl<F> AdapterTraceStep<F> for Rv32BranchAdapterStep
+impl<F> AdapterTraceExecutor<F> for Rv32BranchAdapterExecutor
 where
     F: PrimeField32,
 {

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -2,7 +2,7 @@ use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, SignedImmInstruction, VmAdapterAir,
     },
     system::memory::{
@@ -157,12 +157,12 @@ pub struct Rv32JalrAdapterRecord {
 
 // This adapter reads from [b:4]_d (rs1) and writes to [a:4]_d (rd)
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32JalrAdapterStep;
+pub struct Rv32JalrAdapterExecutor;
 
 #[derive(Clone, Copy, derive_new::new)]
 pub struct Rv32JalrAdapterFiller;
 
-impl<F> AdapterTraceStep<F> for Rv32JalrAdapterStep
+impl<F> AdapterTraceExecutor<F> for Rv32JalrAdapterExecutor
 where
     F: PrimeField32,
 {

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         ExecutionBridge, ExecutionState, VmAdapterAir, VmAdapterInterface,
     },
     system::{
@@ -316,7 +316,7 @@ pub struct Rv32LoadStoreAdapterRecord {
 /// In case of Loads, reads from the shifted intermediate pointer and writes to rd.
 /// In case of Stores, reads from rs2 and writes to the shifted intermediate pointer.
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32LoadStoreAdapterStep {
+pub struct Rv32LoadStoreAdapterExecutor {
     pointer_max_bits: usize,
 }
 
@@ -326,7 +326,7 @@ pub struct Rv32LoadStoreAdapterFiller {
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<F> AdapterTraceStep<F> for Rv32LoadStoreAdapterStep
+impl<F> AdapterTraceExecutor<F> for Rv32LoadStoreAdapterExecutor
 where
     F: PrimeField32,
 {

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -2,7 +2,7 @@ use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, MinimalInstruction, VmAdapterAir,
     },
     system::memory::{
@@ -142,12 +142,12 @@ pub struct Rv32MultAdapterRecord {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32MultAdapterStep;
+pub struct Rv32MultAdapterExecutor;
 
 #[derive(Clone, Copy, derive_new::new)]
 pub struct Rv32MultAdapterFiller;
 
-impl<F> AdapterTraceStep<F> for Rv32MultAdapterStep
+impl<F> AdapterTraceExecutor<F> for Rv32MultAdapterExecutor
 where
     F: PrimeField32,
 {

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -2,7 +2,7 @@ use std::borrow::{Borrow, BorrowMut};
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, AdapterAirContext, AdapterTraceFiller, AdapterTraceStep,
+        get_record_from_slice, AdapterAirContext, AdapterTraceExecutor, AdapterTraceFiller,
         BasicAdapterInterface, ExecutionBridge, ExecutionState, ImmInstruction, VmAdapterAir,
     },
     system::memory::{
@@ -200,12 +200,12 @@ pub struct Rv32RdWriteAdapterRecord {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32RdWriteAdapterStep;
+pub struct Rv32RdWriteAdapterExecutor;
 
 #[derive(Clone, Copy, derive_new::new)]
 pub struct Rv32RdWriteAdapterFiller;
 
-impl<F> AdapterTraceStep<F> for Rv32RdWriteAdapterStep
+impl<F> AdapterTraceExecutor<F> for Rv32RdWriteAdapterExecutor
 where
     F: PrimeField32,
 {
@@ -279,8 +279,8 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv32RdWriteAdapterFiller {
 
 /// This adapter doesn't read anything, and **maybe** writes to \[a:4\]_d, where d == 1
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32CondRdWriteAdapterStep {
-    inner: Rv32RdWriteAdapterStep,
+pub struct Rv32CondRdWriteAdapterExecutor {
+    inner: Rv32RdWriteAdapterExecutor,
 }
 
 #[derive(Clone, Copy, derive_new::new)]
@@ -288,7 +288,7 @@ pub struct Rv32CondRdWriteAdapterFiller {
     inner: Rv32RdWriteAdapterFiller,
 }
 
-impl<F> AdapterTraceStep<F> for Rv32CondRdWriteAdapterStep
+impl<F> AdapterTraceExecutor<F> for Rv32CondRdWriteAdapterExecutor
 where
     F: PrimeField32,
 {
@@ -310,7 +310,7 @@ where
         instruction: &Instruction<F>,
         record: &mut Self::RecordMut<'_>,
     ) -> Self::ReadData {
-        <Rv32RdWriteAdapterStep as AdapterTraceStep<F>>::read(
+        <Rv32RdWriteAdapterExecutor as AdapterTraceExecutor<F>>::read(
             &self.inner,
             memory,
             instruction,
@@ -329,7 +329,7 @@ where
         let Instruction { f: enabled, .. } = instruction;
 
         if enabled.is_one() {
-            <Rv32RdWriteAdapterStep as AdapterTraceStep<F>>::write(
+            <Rv32RdWriteAdapterExecutor as AdapterTraceExecutor<F>>::write(
                 &self.inner,
                 memory,
                 instruction,

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -30,7 +30,7 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    Rv32RdWriteAdapterFiller, Rv32RdWriteAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+    Rv32RdWriteAdapterExecutor, Rv32RdWriteAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
 
 #[repr(C)]
@@ -201,7 +201,7 @@ pub struct Rv32AuipcCoreRecord {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32AuipcStep<A = Rv32RdWriteAdapterStep> {
+pub struct Rv32AuipcExecutor<A = Rv32RdWriteAdapterExecutor> {
     adapter: A,
 }
 
@@ -211,10 +211,10 @@ pub struct Rv32AuipcFiller<A = Rv32RdWriteAdapterFiller> {
     pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for Rv32AuipcStep<A>
+impl<F, A, RA> PreflightExecutor<F, RA> for Rv32AuipcExecutor<A>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
+    A: 'static + AdapterTraceExecutor<F, ReadData = (), WriteData = [u8; RV32_REGISTER_NUM_LIMBS]>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -297,7 +297,7 @@ struct AuiPcPreCompute {
     a: u8,
 }
 
-impl<F, A> Executor<F> for Rv32AuipcStep<A>
+impl<F, A> Executor<F> for Rv32AuipcExecutor<A>
 where
     F: PrimeField32,
 {
@@ -336,7 +336,7 @@ unsafe fn execute_e1_impl<F: PrimeField32, CTX: E1ExecutionCtx>(
     vm_state.instret += 1;
 }
 
-impl<F, A> MeteredExecutor<F> for Rv32AuipcStep<A>
+impl<F, A> MeteredExecutor<F> for Rv32AuipcExecutor<A>
 where
     F: PrimeField32,
 {
@@ -369,7 +369,7 @@ where
     }
 }
 
-impl<A> Rv32AuipcStep<A> {
+impl<A> Rv32AuipcExecutor<A> {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -185,7 +185,7 @@ pub struct BaseAluCoreRecord<const NUM_LIMBS: usize> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct BaseAluStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct BaseAluExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -198,11 +198,11 @@ pub struct BaseAluFiller<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 impl<F, A, RA, const NUM_LIMBS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for BaseAluStep<A, NUM_LIMBS, LIMB_BITS>
+    for BaseAluExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
@@ -304,7 +304,7 @@ struct BaseAluPreCompute {
 }
 
 impl<F, A, const LIMB_BITS: usize> Executor<F>
-    for BaseAluStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for BaseAluExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -388,7 +388,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, const IS_IMM: bo
 }
 
 impl<F, A, const LIMB_BITS: usize> MeteredExecutor<F>
-    for BaseAluStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for BaseAluExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -432,7 +432,7 @@ where
     }
 }
 
-impl<A, const LIMB_BITS: usize> BaseAluStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
+impl<A, const LIMB_BITS: usize> BaseAluExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
     /// Return `is_imm`, true if `e` is RV32_IMM_AS.
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(

--- a/extensions/rv32im/circuit/src/base_alu/mod.rs
+++ b/extensions/rv32im/circuit/src/base_alu/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{
-    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, Rv32BaseAluAdapterStep, RV32_CELL_BITS,
+    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterExecutor, Rv32BaseAluAdapterFiller, RV32_CELL_BITS,
     RV32_REGISTER_NUM_LIMBS,
 };
 
@@ -13,8 +13,11 @@ mod tests;
 
 pub type Rv32BaseAluAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32BaseAluStep =
-    BaseAluStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32BaseAluExecutor = BaseAluExecutor<
+    Rv32BaseAluAdapterExecutor<RV32_CELL_BITS>,
+    RV32_REGISTER_NUM_LIMBS,
+    RV32_CELL_BITS,
+>;
 pub type Rv32BaseAluChip<F> = VmChipWrapper<
     F,
     BaseAluFiller<

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -20,11 +20,11 @@ use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 use test_case::test_case;
 
-use super::{core::run_alu, BaseAluCoreAir, Rv32BaseAluChip, Rv32BaseAluStep};
+use super::{core::run_alu, BaseAluCoreAir, Rv32BaseAluChip, Rv32BaseAluExecutor};
 use crate::{
     adapters::{
-        Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, Rv32BaseAluAdapterStep, RV32_CELL_BITS,
-        RV32_REGISTER_NUM_LIMBS,
+        Rv32BaseAluAdapterAir, Rv32BaseAluAdapterExecutor, Rv32BaseAluAdapterFiller,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
     },
     base_alu::BaseAluCoreCols,
     test_utils::{
@@ -35,7 +35,7 @@ use crate::{
 
 const MAX_INS_CAPACITY: usize = 128;
 type F = BabyBear;
-type Harness = TestChipHarness<F, Rv32BaseAluStep, Rv32BaseAluAir, Rv32BaseAluChip<F>>;
+type Harness = TestChipHarness<F, Rv32BaseAluExecutor, Rv32BaseAluAir, Rv32BaseAluChip<F>>;
 
 fn create_test_chip(
     tester: &VmChipTestBuilder<F>,
@@ -59,7 +59,10 @@ fn create_test_chip(
         ),
         BaseAluCoreAir::new(bitwise_bus, BaseAluOpcode::CLASS_OFFSET),
     );
-    let executor = Rv32BaseAluStep::new(Rv32BaseAluAdapterStep::new(), BaseAluOpcode::CLASS_OFFSET);
+    let executor = Rv32BaseAluExecutor::new(
+        Rv32BaseAluAdapterExecutor::new(),
+        BaseAluOpcode::CLASS_OFFSET,
+    );
     let chip = Rv32BaseAluChip::new(
         BaseAluFiller::new(
             Rv32BaseAluAdapterFiller::new(bitwise_chip.clone()),

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -144,7 +144,7 @@ pub struct BranchEqualCoreRecord<const NUM_LIMBS: usize> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct BranchEqualStep<A, const NUM_LIMBS: usize> {
+pub struct BranchEqualExecutor<A, const NUM_LIMBS: usize> {
     adapter: A,
     pub offset: usize,
     pub pc_step: u32,
@@ -157,10 +157,11 @@ pub struct BranchEqualFiller<A, const NUM_LIMBS: usize> {
     pub pc_step: u32,
 }
 
-impl<F, A, RA, const NUM_LIMBS: usize> PreflightExecutor<F, RA> for BranchEqualStep<A, NUM_LIMBS>
+impl<F, A, RA, const NUM_LIMBS: usize> PreflightExecutor<F, RA>
+    for BranchEqualExecutor<A, NUM_LIMBS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
+    A: 'static + AdapterTraceExecutor<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -248,7 +249,7 @@ struct BranchEqualPreCompute {
     b: u8,
 }
 
-impl<F, A, const NUM_LIMBS: usize> Executor<F> for BranchEqualStep<A, NUM_LIMBS>
+impl<F, A, const NUM_LIMBS: usize> Executor<F> for BranchEqualExecutor<A, NUM_LIMBS>
 where
     F: PrimeField32,
 {
@@ -275,7 +276,7 @@ where
     }
 }
 
-impl<F, A, const NUM_LIMBS: usize> MeteredExecutor<F> for BranchEqualStep<A, NUM_LIMBS>
+impl<F, A, const NUM_LIMBS: usize> MeteredExecutor<F> for BranchEqualExecutor<A, NUM_LIMBS>
 where
     F: PrimeField32,
 {
@@ -338,7 +339,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, const IS_NE: boo
     execute_e12_impl::<F, CTX, IS_NE>(&pre_compute.data, vm_state);
 }
 
-impl<A, const NUM_LIMBS: usize> BranchEqualStep<A, NUM_LIMBS> {
+impl<A, const NUM_LIMBS: usize> BranchEqualExecutor<A, NUM_LIMBS> {
     /// Return `is_bne`, true if the local opcode is BNE.
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(

--- a/extensions/rv32im/circuit/src/branch_eq/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
-use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterFiller, Rv32BranchAdapterStep};
+use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterExecutor, Rv32BranchAdapterFiller};
 
 mod core;
 pub use core::*;
@@ -11,6 +11,7 @@ mod tests;
 
 pub type Rv32BranchEqualAir =
     VmAirWrapper<Rv32BranchAdapterAir, BranchEqualCoreAir<RV32_REGISTER_NUM_LIMBS>>;
-pub type Rv32BranchEqualStep = BranchEqualStep<Rv32BranchAdapterStep, RV32_REGISTER_NUM_LIMBS>;
+pub type Rv32BranchEqualExecutor =
+    BranchEqualExecutor<Rv32BranchAdapterExecutor, RV32_REGISTER_NUM_LIMBS>;
 pub type Rv32BranchEqualChip<F> =
     VmChipWrapper<F, BranchEqualFiller<Rv32BranchAdapterFiller, RV32_REGISTER_NUM_LIMBS>>;

--- a/extensions/rv32im/circuit/src/branch_eq/tests.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/tests.rs
@@ -23,26 +23,27 @@ use test_case::test_case;
 use super::{core::run_eq, BranchEqualCoreCols, Rv32BranchEqualChip};
 use crate::{
     adapters::{
-        Rv32BranchAdapterAir, Rv32BranchAdapterFiller, Rv32BranchAdapterStep,
+        Rv32BranchAdapterAir, Rv32BranchAdapterExecutor, Rv32BranchAdapterFiller,
         RV32_REGISTER_NUM_LIMBS, RV_B_TYPE_IMM_BITS,
     },
     branch_eq::fast_run_eq,
     test_utils::get_verification_error,
-    BranchEqualCoreAir, BranchEqualFiller, Rv32BranchEqualAir, Rv32BranchEqualStep,
+    BranchEqualCoreAir, BranchEqualFiller, Rv32BranchEqualAir, Rv32BranchEqualExecutor,
 };
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
 const ABS_MAX_IMM: i32 = 1 << (RV_B_TYPE_IMM_BITS - 1);
-type Harness = TestChipHarness<F, Rv32BranchEqualStep, Rv32BranchEqualAir, Rv32BranchEqualChip<F>>;
+type Harness =
+    TestChipHarness<F, Rv32BranchEqualExecutor, Rv32BranchEqualAir, Rv32BranchEqualChip<F>>;
 
 fn create_test_chip(tester: &mut VmChipTestBuilder<F>) -> Harness {
     let air = Rv32BranchEqualAir::new(
         Rv32BranchAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         BranchEqualCoreAir::new(BranchEqualOpcode::CLASS_OFFSET, DEFAULT_PC_STEP),
     );
-    let executor = Rv32BranchEqualStep::new(
-        Rv32BranchAdapterStep,
+    let executor = Rv32BranchEqualExecutor::new(
+        Rv32BranchAdapterExecutor,
         BranchEqualOpcode::CLASS_OFFSET,
         DEFAULT_PC_STEP,
     );

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -198,7 +198,7 @@ pub struct BranchLessThanCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usi
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct BranchLessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct BranchLessThanExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -211,10 +211,10 @@ pub struct BranchLessThanFiller<A, const NUM_LIMBS: usize, const LIMB_BITS: usiz
 }
 
 impl<F, A, RA, const NUM_LIMBS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
+    for BranchLessThanExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
-    A: 'static + AdapterTraceStep<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
+    A: 'static + AdapterTraceExecutor<F, ReadData: Into<[[u8; NUM_LIMBS]; 2]>, WriteData = ()>,
     for<'buf> RA: RecordArena<
         'buf,
         EmptyAdapterCoreLayout<F, A>,
@@ -365,7 +365,7 @@ struct BranchLePreCompute {
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> Executor<F>
-    for BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
+    for BranchLessThanExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -393,7 +393,7 @@ where
     }
 }
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> MeteredExecutor<F>
-    for BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
+    for BranchLessThanExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -460,7 +460,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, OP: BranchLessTh
 }
 
 impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
-    BranchLessThanStep<A, NUM_LIMBS, LIMB_BITS>
+    BranchLessThanExecutor<A, NUM_LIMBS, LIMB_BITS>
 {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(

--- a/extensions/rv32im/circuit/src/branch_lt/mod.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterFiller, Rv32BranchAdapterStep};
+use crate::adapters::{Rv32BranchAdapterAir, Rv32BranchAdapterExecutor, Rv32BranchAdapterFiller};
 
 mod core;
 pub use core::*;
@@ -13,8 +13,8 @@ pub type Rv32BranchLessThanAir = VmAirWrapper<
     Rv32BranchAdapterAir,
     BranchLessThanCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
-pub type Rv32BranchLessThanStep =
-    BranchLessThanStep<Rv32BranchAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32BranchLessThanExecutor =
+    BranchLessThanExecutor<Rv32BranchAdapterExecutor, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32BranchLessThanChip<F> = VmChipWrapper<
     F,
     BranchLessThanFiller<Rv32BranchAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,

--- a/extensions/rv32im/circuit/src/branch_lt/tests.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/tests.rs
@@ -28,19 +28,23 @@ use test_case::test_case;
 use super::{core::run_cmp, Rv32BranchLessThanChip};
 use crate::{
     adapters::{
-        Rv32BranchAdapterAir, Rv32BranchAdapterFiller, Rv32BranchAdapterStep, RV32_CELL_BITS,
+        Rv32BranchAdapterAir, Rv32BranchAdapterExecutor, Rv32BranchAdapterFiller, RV32_CELL_BITS,
         RV32_REGISTER_NUM_LIMBS, RV_B_TYPE_IMM_BITS,
     },
     branch_lt::BranchLessThanCoreCols,
     test_utils::get_verification_error,
-    BranchLessThanCoreAir, BranchLessThanFiller, Rv32BranchLessThanAir, Rv32BranchLessThanStep,
+    BranchLessThanCoreAir, BranchLessThanFiller, Rv32BranchLessThanAir, Rv32BranchLessThanExecutor,
 };
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
 const ABS_MAX_IMM: i32 = 1 << (RV_B_TYPE_IMM_BITS - 1);
-type Harness =
-    TestChipHarness<F, Rv32BranchLessThanStep, Rv32BranchLessThanAir, Rv32BranchLessThanChip<F>>;
+type Harness = TestChipHarness<
+    F,
+    Rv32BranchLessThanExecutor,
+    Rv32BranchLessThanAir,
+    Rv32BranchLessThanChip<F>,
+>;
 
 fn create_test_chip(
     tester: &mut VmChipTestBuilder<F>,
@@ -60,8 +64,8 @@ fn create_test_chip(
         Rv32BranchAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         BranchLessThanCoreAir::new(bitwise_bus, BranchLessThanOpcode::CLASS_OFFSET),
     );
-    let executor = Rv32BranchLessThanStep::new(
-        Rv32BranchAdapterStep::new(),
+    let executor = Rv32BranchLessThanExecutor::new(
+        Rv32BranchAdapterExecutor::new(),
         BranchLessThanOpcode::CLASS_OFFSET,
     );
     let chip = Rv32BranchLessThanChip::new(

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -366,7 +366,7 @@ pub struct DivRemCoreRecord<const NUM_LIMBS: usize> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct DivRemStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct DivRemExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -409,11 +409,11 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> DivRemFiller<A, NUM_LIMB
 }
 
 impl<F, A, RA, const NUM_LIMBS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for DivRemStep<A, NUM_LIMBS, LIMB_BITS>
+    for DivRemExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
@@ -578,7 +578,7 @@ struct DivRemPreCompute {
 }
 
 impl<F, A, const LIMB_BITS: usize> Executor<F>
-    for DivRemStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for DivRemExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -607,7 +607,7 @@ where
 }
 
 impl<F, A, const LIMB_BITS: usize> MeteredExecutor<F>
-    for DivRemStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for DivRemExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -669,7 +669,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, OP: DivRemOp>(
     execute_e12_impl::<F, CTX, OP>(&pre_compute.data, vm_state);
 }
 
-impl<A, const LIMB_BITS: usize> DivRemStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
+impl<A, const LIMB_BITS: usize> DivRemExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,

--- a/extensions/rv32im/circuit/src/divrem/mod.rs
+++ b/extensions/rv32im/circuit/src/divrem/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterFiller, Rv32MultAdapterStep};
+use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterExecutor, Rv32MultAdapterFiller};
 
 mod core;
 pub use core::*;
@@ -11,6 +11,7 @@ mod tests;
 
 pub type Rv32DivRemAir =
     VmAirWrapper<Rv32MultAdapterAir, DivRemCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32DivRemStep = DivRemStep<Rv32MultAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32DivRemExecutor =
+    DivRemExecutor<Rv32MultAdapterExecutor, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32DivRemChip<F> =
     VmChipWrapper<F, DivRemFiller<Rv32MultAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;

--- a/extensions/rv32im/circuit/src/divrem/tests.rs
+++ b/extensions/rv32im/circuit/src/divrem/tests.rs
@@ -35,21 +35,21 @@ use test_case::test_case;
 use super::core::run_divrem;
 use crate::{
     adapters::{
-        Rv32MultAdapterAir, Rv32MultAdapterFiller, Rv32MultAdapterStep, RV32_CELL_BITS,
+        Rv32MultAdapterAir, Rv32MultAdapterExecutor, Rv32MultAdapterFiller, RV32_CELL_BITS,
         RV32_REGISTER_NUM_LIMBS,
     },
     divrem::{
         run_mul_carries, run_sltu_diff_idx, DivRemCoreCols, DivRemCoreSpecialCase, Rv32DivRemChip,
     },
     test_utils::get_verification_error,
-    DivRemCoreAir, DivRemFiller, Rv32DivRemAir, Rv32DivRemStep,
+    DivRemCoreAir, DivRemFiller, Rv32DivRemAir, Rv32DivRemExecutor,
 };
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
 // the max number of limbs we currently support MUL for is 32 (i.e. for U256s)
 const MAX_NUM_LIMBS: u32 = 32;
-type Harness = TestChipHarness<F, Rv32DivRemStep, Rv32DivRemAir, Rv32DivRemChip<F>>;
+type Harness = TestChipHarness<F, Rv32DivRemExecutor, Rv32DivRemAir, Rv32DivRemChip<F>>;
 
 fn limb_sra<const NUM_LIMBS: usize, const LIMB_BITS: usize>(
     x: [u32; NUM_LIMBS],
@@ -86,7 +86,7 @@ fn create_test_chip(
         Rv32MultAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         DivRemCoreAir::new(bitwise_bus, range_tuple_bus, DivRemOpcode::CLASS_OFFSET),
     );
-    let executor = Rv32DivRemStep::new(Rv32MultAdapterStep, DivRemOpcode::CLASS_OFFSET);
+    let executor = Rv32DivRemExecutor::new(Rv32MultAdapterExecutor, DivRemOpcode::CLASS_OFFSET);
     let chip = Rv32DivRemChip::<F>::new(
         DivRemFiller::new(
             Rv32MultAdapterFiller,

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -344,7 +344,7 @@ impl SizedRecord<Rv32HintStoreLayout> for Rv32HintStoreRecordMut<'_> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32HintStoreStep {
+pub struct Rv32HintStoreExecutor {
     pub pointer_max_bits: usize,
     pub offset: usize,
 }
@@ -355,7 +355,7 @@ pub struct Rv32HintStoreFiller {
     bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
-impl<F, RA> PreflightExecutor<F, RA> for Rv32HintStoreStep
+impl<F, RA> PreflightExecutor<F, RA> for Rv32HintStoreExecutor
 where
     F: PrimeField32,
     for<'buf> RA:
@@ -588,7 +588,7 @@ struct HintStorePreCompute {
     b: u8,
 }
 
-impl<F> Executor<F> for Rv32HintStoreStep
+impl<F> Executor<F> for Rv32HintStoreExecutor
 where
     F: PrimeField32,
 {
@@ -613,7 +613,7 @@ where
     }
 }
 
-impl<F> MeteredExecutor<F> for Rv32HintStoreStep
+impl<F> MeteredExecutor<F> for Rv32HintStoreExecutor
 where
     F: PrimeField32,
 {
@@ -704,7 +704,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, const IS_HINT_ST
         .on_height_change(pre_compute.chip_idx as usize, height_delta);
 }
 
-impl Rv32HintStoreStep {
+impl Rv32HintStoreExecutor {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,

--- a/extensions/rv32im/circuit/src/hintstore/tests.rs
+++ b/extensions/rv32im/circuit/src/hintstore/tests.rs
@@ -25,13 +25,13 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng, RngCore};
 
-use super::{Rv32HintStoreAir, Rv32HintStoreChip, Rv32HintStoreCols, Rv32HintStoreStep};
+use super::{Rv32HintStoreAir, Rv32HintStoreChip, Rv32HintStoreCols, Rv32HintStoreExecutor};
 use crate::{test_utils::get_verification_error, Rv32HintStoreFiller, Rv32HintStoreLayout};
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 4096;
 type Harness<RA> =
-    TestChipHarness<F, Rv32HintStoreStep, Rv32HintStoreAir, Rv32HintStoreChip<F>, RA>;
+    TestChipHarness<F, Rv32HintStoreExecutor, Rv32HintStoreAir, Rv32HintStoreChip<F>, RA>;
 
 fn create_test_chip<RA: Arena>(
     tester: &mut VmChipTestBuilder<F>,
@@ -54,7 +54,8 @@ fn create_test_chip<RA: Arena>(
         Rv32HintStoreOpcode::CLASS_OFFSET,
         tester.address_bits(),
     );
-    let executor = Rv32HintStoreStep::new(tester.address_bits(), Rv32HintStoreOpcode::CLASS_OFFSET);
+    let executor =
+        Rv32HintStoreExecutor::new(tester.address_bits(), Rv32HintStoreOpcode::CLASS_OFFSET);
     let chip = Rv32HintStoreChip::<F>::new(
         Rv32HintStoreFiller::new(tester.address_bits(), bitwise_chip.clone()),
         tester.memory_helper(),
@@ -71,7 +72,7 @@ fn set_and_execute<RA: Arena>(
     rng: &mut StdRng,
     opcode: Rv32HintStoreOpcode,
 ) where
-    Rv32HintStoreStep: PreflightExecutor<F, RA>,
+    Rv32HintStoreExecutor: PreflightExecutor<F, RA>,
 {
     let num_words = match opcode {
         HINT_STOREW => 1,

--- a/extensions/rv32im/circuit/src/jal_lui/tests.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/tests.rs
@@ -20,12 +20,12 @@ use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 use test_case::test_case;
 
-use super::{run_jal_lui, Rv32JalLuiChip, Rv32JalLuiCoreAir, Rv32JalLuiStep};
+use super::{run_jal_lui, Rv32JalLuiChip, Rv32JalLuiCoreAir, Rv32JalLuiExecutor};
 use crate::{
     adapters::{
-        Rv32CondRdWriteAdapterAir, Rv32CondRdWriteAdapterCols, Rv32CondRdWriteAdapterFiller,
-        Rv32CondRdWriteAdapterStep, Rv32RdWriteAdapterAir, Rv32RdWriteAdapterFiller,
-        Rv32RdWriteAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, RV_IS_TYPE_IMM_BITS,
+        Rv32CondRdWriteAdapterAir, Rv32CondRdWriteAdapterCols, Rv32CondRdWriteAdapterExecutor,
+        Rv32CondRdWriteAdapterFiller, Rv32RdWriteAdapterAir, Rv32RdWriteAdapterExecutor,
+        Rv32RdWriteAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS, RV_IS_TYPE_IMM_BITS,
     },
     jal_lui::{Rv32JalLuiCoreCols, ADDITIONAL_BITS},
     test_utils::get_verification_error,
@@ -35,7 +35,7 @@ use crate::{
 const IMM_BITS: usize = 20;
 const LIMB_MAX: u32 = (1 << RV32_CELL_BITS) - 1;
 const MAX_INS_CAPACITY: usize = 128;
-type Harness = TestChipHarness<F, Rv32JalLuiStep, Rv32JalLuiAir, Rv32JalLuiChip<F>>;
+type Harness = TestChipHarness<F, Rv32JalLuiExecutor, Rv32JalLuiAir, Rv32JalLuiChip<F>>;
 
 type F = BabyBear;
 
@@ -61,7 +61,9 @@ fn create_test_chip(
         )),
         Rv32JalLuiCoreAir::new(bitwise_bus),
     );
-    let executor = Rv32JalLuiStep::new(Rv32CondRdWriteAdapterStep::new(Rv32RdWriteAdapterStep));
+    let executor = Rv32JalLuiExecutor::new(Rv32CondRdWriteAdapterExecutor::new(
+        Rv32RdWriteAdapterExecutor,
+    ));
     let chip = Rv32JalLuiChip::<F>::new(
         Rv32JalLuiFiller::new(
             Rv32CondRdWriteAdapterFiller::new(Rv32RdWriteAdapterFiller),

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -31,7 +31,7 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    Rv32JalrAdapterFiller, Rv32JalrAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+    Rv32JalrAdapterExecutor, Rv32JalrAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
 };
 
 #[repr(C)]
@@ -184,7 +184,7 @@ pub struct Rv32JalrCoreRecord {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct Rv32JalrStep<A = Rv32JalrAdapterStep> {
+pub struct Rv32JalrExecutor<A = Rv32JalrAdapterExecutor> {
     adapter: A,
 }
 
@@ -210,11 +210,11 @@ impl<A> Rv32JalrFiller<A> {
     }
 }
 
-impl<F, A, RA> PreflightExecutor<F, RA> for Rv32JalrStep<A>
+impl<F, A, RA> PreflightExecutor<F, RA> for Rv32JalrExecutor<A>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData = [u8; RV32_REGISTER_NUM_LIMBS],
             WriteData = [u8; RV32_REGISTER_NUM_LIMBS],
@@ -328,7 +328,7 @@ struct JalrPreCompute {
     b: u8,
 }
 
-impl<F, A> Executor<F> for Rv32JalrStep<A>
+impl<F, A> Executor<F> for Rv32JalrExecutor<A>
 where
     F: PrimeField32,
 {
@@ -354,7 +354,7 @@ where
     }
 }
 
-impl<F, A> MeteredExecutor<F> for Rv32JalrStep<A>
+impl<F, A> MeteredExecutor<F> for Rv32JalrExecutor<A>
 where
     F: PrimeField32,
 {
@@ -423,7 +423,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, const ENABLED: b
     execute_e12_impl::<F, CTX, ENABLED>(&pre_compute.data, vm_state);
 }
 
-impl<A> Rv32JalrStep<A> {
+impl<A> Rv32JalrExecutor<A> {
     /// Return true if enabled.
     fn pre_compute_impl<F: PrimeField32>(
         &self,

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -22,10 +22,10 @@ use rand::{rngs::StdRng, Rng};
 use super::Rv32JalrCoreAir;
 use crate::{
     adapters::{
-        compose, Rv32JalrAdapterAir, Rv32JalrAdapterFiller, Rv32JalrAdapterStep, RV32_CELL_BITS,
-        RV32_REGISTER_NUM_LIMBS,
+        compose, Rv32JalrAdapterAir, Rv32JalrAdapterExecutor, Rv32JalrAdapterFiller,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
     },
-    jalr::{run_jalr, Rv32JalrChip, Rv32JalrCoreCols, Rv32JalrStep},
+    jalr::{run_jalr, Rv32JalrChip, Rv32JalrCoreCols, Rv32JalrExecutor},
     test_utils::get_verification_error,
     Rv32JalrAir, Rv32JalrFiller,
 };
@@ -33,7 +33,7 @@ use crate::{
 const IMM_BITS: usize = 16;
 const MAX_INS_CAPACITY: usize = 128;
 type F = BabyBear;
-type Harness = TestChipHarness<F, Rv32JalrStep, Rv32JalrAir, Rv32JalrChip<F>>;
+type Harness = TestChipHarness<F, Rv32JalrExecutor, Rv32JalrAir, Rv32JalrChip<F>>;
 
 fn into_limbs(num: u32) -> [u32; 4] {
     array::from_fn(|i| (num >> (8 * i)) & 255)
@@ -59,7 +59,7 @@ fn create_test_chip(
         Rv32JalrAdapterAir::new(tester.memory_bridge(), tester.execution_bridge()),
         Rv32JalrCoreAir::new(bitwise_bus, range_checker_chip.bus()),
     );
-    let executor = Rv32JalrStep::new(Rv32JalrAdapterStep);
+    let executor = Rv32JalrExecutor::new(Rv32JalrAdapterExecutor);
     let chip = Rv32JalrChip::<F>::new(
         Rv32JalrFiller::new(
             Rv32JalrAdapterFiller::new(),

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -181,7 +181,7 @@ pub struct LessThanCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct LessThanStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct LessThanExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -194,11 +194,11 @@ pub struct LessThanFiller<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 impl<F, A, RA, const NUM_LIMBS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for LessThanStep<A, NUM_LIMBS, LIMB_BITS>
+    for LessThanExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
@@ -344,7 +344,7 @@ struct LessThanPreCompute {
 }
 
 impl<F, A, const LIMB_BITS: usize> Executor<F>
-    for LessThanStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for LessThanExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -373,7 +373,7 @@ where
 }
 
 impl<F, A, const LIMB_BITS: usize> MeteredExecutor<F>
-    for LessThanStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for LessThanExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -460,7 +460,7 @@ unsafe fn execute_e2_impl<
     execute_e12_impl::<F, CTX, E_IS_IMM, IS_U32>(&pre_compute.data, vm_state);
 }
 
-impl<A, const LIMB_BITS: usize> LessThanStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
+impl<A, const LIMB_BITS: usize> LessThanExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,

--- a/extensions/rv32im/circuit/src/less_than/mod.rs
+++ b/extensions/rv32im/circuit/src/less_than/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{
-    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, Rv32BaseAluAdapterStep, RV32_CELL_BITS,
+    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterExecutor, Rv32BaseAluAdapterFiller, RV32_CELL_BITS,
     RV32_REGISTER_NUM_LIMBS,
 };
 
@@ -13,8 +13,11 @@ mod tests;
 
 pub type Rv32LessThanAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, LessThanCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32LessThanStep =
-    LessThanStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32LessThanExecutor = LessThanExecutor<
+    Rv32BaseAluAdapterExecutor<RV32_CELL_BITS>,
+    RV32_REGISTER_NUM_LIMBS,
+    RV32_CELL_BITS,
+>;
 pub type Rv32LessThanChip<F> = VmChipWrapper<
     F,
     LessThanFiller<

--- a/extensions/rv32im/circuit/src/less_than/tests.rs
+++ b/extensions/rv32im/circuit/src/less_than/tests.rs
@@ -26,19 +26,19 @@ use test_case::test_case;
 use super::{core::run_less_than, LessThanCoreAir, Rv32LessThanChip};
 use crate::{
     adapters::{
-        Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, Rv32BaseAluAdapterStep, RV32_CELL_BITS,
-        RV32_REGISTER_NUM_LIMBS,
+        Rv32BaseAluAdapterAir, Rv32BaseAluAdapterExecutor, Rv32BaseAluAdapterFiller,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
     },
     less_than::LessThanCoreCols,
     test_utils::{
         generate_rv32_is_type_immediate, get_verification_error, rv32_rand_write_register_or_imm,
     },
-    LessThanFiller, Rv32LessThanAir, Rv32LessThanStep,
+    LessThanFiller, Rv32LessThanAir, Rv32LessThanExecutor,
 };
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
-type Harness = TestChipHarness<F, Rv32LessThanStep, Rv32LessThanAir, Rv32LessThanChip<F>>;
+type Harness = TestChipHarness<F, Rv32LessThanExecutor, Rv32LessThanAir, Rv32LessThanChip<F>>;
 
 fn create_test_chip(
     tester: &VmChipTestBuilder<F>,
@@ -61,7 +61,8 @@ fn create_test_chip(
         ),
         LessThanCoreAir::new(bitwise_bus, LessThanOpcode::CLASS_OFFSET),
     );
-    let executor = Rv32LessThanStep::new(Rv32BaseAluAdapterStep, LessThanOpcode::CLASS_OFFSET);
+    let executor =
+        Rv32LessThanExecutor::new(Rv32BaseAluAdapterExecutor, LessThanOpcode::CLASS_OFFSET);
     let chip = Rv32LessThanChip::<F>::new(
         LessThanFiller::new(
             Rv32BaseAluAdapterFiller::new(bitwise_chip.clone()),

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -183,7 +183,7 @@ pub struct LoadSignExtendCoreRecord<const NUM_CELLS: usize> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct LoadSignExtendStep<A, const NUM_CELLS: usize, const LIMB_BITS: usize> {
+pub struct LoadSignExtendExecutor<A, const NUM_CELLS: usize, const LIMB_BITS: usize> {
     adapter: A,
 }
 
@@ -198,11 +198,11 @@ pub struct LoadSignExtendFiller<
 }
 
 impl<F, A, RA, const NUM_CELLS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for LoadSignExtendStep<A, NUM_CELLS, LIMB_BITS>
+    for LoadSignExtendExecutor<A, NUM_CELLS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData = (([u32; NUM_CELLS], [u8; NUM_CELLS]), u8),
             WriteData = [u32; NUM_CELLS],
@@ -313,7 +313,7 @@ struct LoadSignExtendPreCompute {
 }
 
 impl<F, A, const LIMB_BITS: usize> Executor<F>
-    for LoadSignExtendStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for LoadSignExtendExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -341,7 +341,7 @@ where
 }
 
 impl<F, A, const LIMB_BITS: usize> MeteredExecutor<F>
-    for LoadSignExtendStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for LoadSignExtendExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -446,7 +446,7 @@ unsafe fn execute_e2_impl<
     execute_e12_impl::<F, CTX, IS_LOADB, ENABLED>(&pre_compute.data, vm_state);
 }
 
-impl<A, const LIMB_BITS: usize> LoadSignExtendStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
+impl<A, const LIMB_BITS: usize> LoadSignExtendExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
     /// Return (is_loadb, enabled)
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -476,7 +476,7 @@ impl<A, const LIMB_BITS: usize> LoadSignExtendStep<A, { RV32_REGISTER_NUM_LIMBS 
         );
         match local_opcode {
             LOADB | LOADH => {}
-            _ => unreachable!("LoadSignExtendStep should only handle LOADB/LOADH opcodes"),
+            _ => unreachable!("LoadSignExtendExecutor should only handle LOADB/LOADH opcodes"),
         }
 
         let imm = c.as_canonical_u32();

--- a/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterStep};
+use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterExecutor};
 
 mod core;
 pub use core::*;
@@ -13,6 +13,6 @@ pub type Rv32LoadSignExtendAir = VmAirWrapper<
     Rv32LoadStoreAdapterAir,
     LoadSignExtendCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
-pub type Rv32LoadSignExtendStep =
-    LoadSignExtendStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32LoadSignExtendExecutor =
+    LoadSignExtendExecutor<Rv32LoadStoreAdapterExecutor, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32LoadSignExtendChip<F> = VmChipWrapper<F, LoadSignExtendFiller>;

--- a/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/tests.rs
@@ -19,18 +19,23 @@ use test_case::test_case;
 use super::{run_write_data_sign_extend, LoadSignExtendCoreAir};
 use crate::{
     adapters::{
-        Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterFiller, Rv32LoadStoreAdapterStep,
+        Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterExecutor, Rv32LoadStoreAdapterFiller,
         RV32_REGISTER_NUM_LIMBS,
     },
     load_sign_extend::LoadSignExtendCoreCols,
     test_utils::get_verification_error,
-    LoadSignExtendFiller, Rv32LoadSignExtendAir, Rv32LoadSignExtendChip, Rv32LoadSignExtendStep,
+    LoadSignExtendFiller, Rv32LoadSignExtendAir, Rv32LoadSignExtendChip,
+    Rv32LoadSignExtendExecutor,
 };
 
 const IMM_BITS: usize = 16;
 const MAX_INS_CAPACITY: usize = 128;
-type Harness =
-    TestChipHarness<F, Rv32LoadSignExtendStep, Rv32LoadSignExtendAir, Rv32LoadSignExtendChip<F>>;
+type Harness = TestChipHarness<
+    F,
+    Rv32LoadSignExtendExecutor,
+    Rv32LoadSignExtendAir,
+    Rv32LoadSignExtendChip<F>,
+>;
 type F = BabyBear;
 
 fn create_test_chip(tester: &mut VmChipTestBuilder<F>) -> Harness {
@@ -45,7 +50,7 @@ fn create_test_chip(tester: &mut VmChipTestBuilder<F>) -> Harness {
         LoadSignExtendCoreAir::new(range_checker_chip.bus()),
     );
     let executor =
-        Rv32LoadSignExtendStep::new(Rv32LoadStoreAdapterStep::new(tester.address_bits()));
+        Rv32LoadSignExtendExecutor::new(Rv32LoadStoreAdapterExecutor::new(tester.address_bits()));
     let chip = Rv32LoadSignExtendChip::<F>::new(
         LoadSignExtendFiller::new(
             Rv32LoadStoreAdapterFiller::new(tester.address_bits(), range_checker_chip.clone()),

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -254,7 +254,7 @@ pub struct LoadStoreCoreRecord<const NUM_CELLS: usize> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct LoadStoreStep<A, const NUM_CELLS: usize> {
+pub struct LoadStoreExecutor<A, const NUM_CELLS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -268,11 +268,11 @@ pub struct LoadStoreFiller<
     pub offset: usize,
 }
 
-impl<F, A, RA, const NUM_CELLS: usize> PreflightExecutor<F, RA> for LoadStoreStep<A, NUM_CELLS>
+impl<F, A, RA, const NUM_CELLS: usize> PreflightExecutor<F, RA> for LoadStoreExecutor<A, NUM_CELLS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData = (([u32; NUM_CELLS], [u8; NUM_CELLS]), u8),
             WriteData = [u32; NUM_CELLS],
@@ -382,7 +382,7 @@ struct LoadStorePreCompute {
     e: u8,
 }
 
-impl<F, A, const NUM_CELLS: usize> Executor<F> for LoadStoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> Executor<F> for LoadStoreExecutor<A, NUM_CELLS>
 where
     F: PrimeField32,
 {
@@ -426,7 +426,7 @@ where
     }
 }
 
-impl<F, A, const NUM_CELLS: usize> MeteredExecutor<F> for LoadStoreStep<A, NUM_CELLS>
+impl<F, A, const NUM_CELLS: usize> MeteredExecutor<F> for LoadStoreExecutor<A, NUM_CELLS>
 where
     F: PrimeField32,
 {
@@ -557,7 +557,7 @@ unsafe fn execute_e2_impl<
     execute_e12_impl::<F, CTX, T, OP, ENABLED>(&pre_compute.data, vm_state);
 }
 
-impl<A, const NUM_CELLS: usize> LoadStoreStep<A, NUM_CELLS> {
+impl<A, const NUM_CELLS: usize> LoadStoreExecutor<A, NUM_CELLS> {
     /// Return (local_opcode, enabled, is_native_store)
     fn pre_compute_impl<F: PrimeField32>(
         &self,
@@ -593,7 +593,7 @@ impl<A, const NUM_CELLS: usize> LoadStoreStep<A, NUM_CELLS> {
                     return Err(StaticProgramError::InvalidInstruction(pc));
                 }
             }
-            _ => unreachable!("LoadStoreStep should not handle LOADB/LOADH opcodes"),
+            _ => unreachable!("LoadStoreExecutor should not handle LOADB/LOADH opcodes"),
         }
 
         let imm = c.as_canonical_u32();

--- a/extensions/rv32im/circuit/src/loadstore/mod.rs
+++ b/extensions/rv32im/circuit/src/loadstore/mod.rs
@@ -5,12 +5,13 @@ pub use core::*;
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::RV32_REGISTER_NUM_LIMBS;
-use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterStep};
+use crate::adapters::{Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterExecutor};
 
 #[cfg(test)]
 mod tests;
 
 pub type Rv32LoadStoreAir =
     VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<RV32_REGISTER_NUM_LIMBS>>;
-pub type Rv32LoadStoreStep = LoadStoreStep<Rv32LoadStoreAdapterStep, RV32_REGISTER_NUM_LIMBS>;
+pub type Rv32LoadStoreExecutor =
+    LoadStoreExecutor<Rv32LoadStoreAdapterExecutor, RV32_REGISTER_NUM_LIMBS>;
 pub type Rv32LoadStoreChip<F> = VmChipWrapper<F, LoadStoreFiller>;

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -25,19 +25,19 @@ use test_case::test_case;
 use super::{run_write_data, LoadStoreCoreAir, Rv32LoadStoreChip};
 use crate::{
     adapters::{
-        Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterCols, Rv32LoadStoreAdapterFiller,
-        Rv32LoadStoreAdapterStep, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
+        Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterCols, Rv32LoadStoreAdapterExecutor,
+        Rv32LoadStoreAdapterFiller, RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
     },
     loadstore::LoadStoreCoreCols,
     test_utils::get_verification_error,
-    LoadStoreFiller, Rv32LoadStoreAir, Rv32LoadStoreStep,
+    LoadStoreFiller, Rv32LoadStoreAir, Rv32LoadStoreExecutor,
 };
 
 const IMM_BITS: usize = 16;
 const MAX_INS_CAPACITY: usize = 128;
 
 type F = BabyBear;
-type Harness = TestChipHarness<F, Rv32LoadStoreStep, Rv32LoadStoreAir, Rv32LoadStoreChip<F>>;
+type Harness = TestChipHarness<F, Rv32LoadStoreExecutor, Rv32LoadStoreAir, Rv32LoadStoreChip<F>>;
 
 fn create_test_chip(tester: &mut VmChipTestBuilder<F>) -> Harness {
     let range_checker_chip = tester.range_checker();
@@ -51,8 +51,8 @@ fn create_test_chip(tester: &mut VmChipTestBuilder<F>) -> Harness {
         ),
         LoadStoreCoreAir::new(Rv32LoadStoreOpcode::CLASS_OFFSET),
     );
-    let executor = Rv32LoadStoreStep::new(
-        Rv32LoadStoreAdapterStep::new(tester.address_bits()),
+    let executor = Rv32LoadStoreExecutor::new(
+        Rv32LoadStoreAdapterExecutor::new(tester.address_bits()),
         Rv32LoadStoreOpcode::CLASS_OFFSET,
     );
     let chip = Rv32LoadStoreChip::<F>::new(

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -126,7 +126,7 @@ pub struct MultiplicationCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usi
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct MultiplicationStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct MultiplicationExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -169,11 +169,11 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize>
 }
 
 impl<F, A, RA, const NUM_LIMBS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for MultiplicationStep<A, NUM_LIMBS, LIMB_BITS>
+    for MultiplicationExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
@@ -261,7 +261,7 @@ struct MultiPreCompute {
 }
 
 impl<F, A, const LIMB_BITS: usize> Executor<F>
-    for MultiplicationStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for MultiplicationExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -284,7 +284,7 @@ where
 }
 
 impl<F, A, const LIMB_BITS: usize> MeteredExecutor<F>
-    for MultiplicationStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for MultiplicationExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -346,7 +346,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx>(
     execute_e12_impl(&pre_compute.data, vm_state);
 }
 
-impl<A, const LIMB_BITS: usize> MultiplicationStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
+impl<A, const LIMB_BITS: usize> MultiplicationExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/rv32im/circuit/src/mul/mod.rs
+++ b/extensions/rv32im/circuit/src/mul/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterFiller, Rv32MultAdapterStep};
+use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterExecutor, Rv32MultAdapterFiller};
 
 mod core;
 pub use core::*;
@@ -13,8 +13,8 @@ pub type Rv32MultiplicationAir = VmAirWrapper<
     Rv32MultAdapterAir,
     MultiplicationCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,
 >;
-pub type Rv32MultiplicationStep =
-    MultiplicationStep<Rv32MultAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32MultiplicationExecutor =
+    MultiplicationExecutor<Rv32MultAdapterExecutor, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32MultiplicationChip<F> = VmChipWrapper<
     F,
     MultiplicationFiller<Rv32MultAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,

--- a/extensions/rv32im/circuit/src/mul/tests.rs
+++ b/extensions/rv32im/circuit/src/mul/tests.rs
@@ -21,20 +21,24 @@ use rand::{rngs::StdRng, Rng};
 use super::core::run_mul;
 use crate::{
     adapters::{
-        Rv32MultAdapterAir, Rv32MultAdapterFiller, Rv32MultAdapterStep, RV32_CELL_BITS,
+        Rv32MultAdapterAir, Rv32MultAdapterExecutor, Rv32MultAdapterFiller, RV32_CELL_BITS,
         RV32_REGISTER_NUM_LIMBS,
     },
     mul::{MultiplicationCoreCols, Rv32MultiplicationChip},
     test_utils::{get_verification_error, rv32_rand_write_register_or_imm},
-    MultiplicationCoreAir, MultiplicationFiller, Rv32MultiplicationAir, Rv32MultiplicationStep,
+    MultiplicationCoreAir, MultiplicationFiller, Rv32MultiplicationAir, Rv32MultiplicationExecutor,
 };
 
 const MAX_INS_CAPACITY: usize = 128;
 // the max number of limbs we currently support MUL for is 32 (i.e. for U256s)
 const MAX_NUM_LIMBS: u32 = 32;
 type F = BabyBear;
-type Harness =
-    TestChipHarness<F, Rv32MultiplicationStep, Rv32MultiplicationAir, Rv32MultiplicationChip<F>>;
+type Harness = TestChipHarness<
+    F,
+    Rv32MultiplicationExecutor,
+    Rv32MultiplicationAir,
+    Rv32MultiplicationChip<F>,
+>;
 
 fn create_test_chip(
     tester: &mut VmChipTestBuilder<F>,
@@ -53,7 +57,8 @@ fn create_test_chip(
         Rv32MultAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         MultiplicationCoreAir::new(range_tuple_bus, MulOpcode::CLASS_OFFSET),
     );
-    let executor = Rv32MultiplicationStep::new(Rv32MultAdapterStep, MulOpcode::CLASS_OFFSET);
+    let executor =
+        Rv32MultiplicationExecutor::new(Rv32MultAdapterExecutor, MulOpcode::CLASS_OFFSET);
     let chip = Rv32MultiplicationChip::<F>::new(
         MultiplicationFiller::new(
             Rv32MultAdapterFiller,

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -199,7 +199,7 @@ pub struct MulHCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 #[derive(Clone, Copy, derive_new::new)]
-pub struct MulHStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct MulHExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -239,11 +239,11 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> MulHFiller<A, NUM_LIMBS,
 }
 
 impl<F, A, RA, const NUM_LIMBS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for MulHStep<A, NUM_LIMBS, LIMB_BITS>
+    for MulHExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
@@ -357,7 +357,7 @@ struct MulHPreCompute {
 }
 
 impl<F, A, const LIMB_BITS: usize> Executor<F>
-    for MulHStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for MulHExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -385,7 +385,7 @@ where
 }
 
 impl<F, A, const LIMB_BITS: usize> MeteredExecutor<F>
-    for MulHStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
+    for MulHExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -450,7 +450,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, OP: MulHOperatio
     execute_e12_impl::<F, CTX, OP>(&pre_compute.data, vm_state);
 }
 
-impl<A, const LIMB_BITS: usize> MulHStep<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
+impl<A, const LIMB_BITS: usize> MulHExecutor<A, { RV32_REGISTER_NUM_LIMBS }, LIMB_BITS> {
     #[inline(always)]
     fn pre_compute_e1<F: PrimeField32>(
         &self,

--- a/extensions/rv32im/circuit/src/mulh/mod.rs
+++ b/extensions/rv32im/circuit/src/mulh/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
-use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterFiller, Rv32MultAdapterStep};
+use crate::adapters::{Rv32MultAdapterAir, Rv32MultAdapterExecutor, Rv32MultAdapterFiller};
 
 mod core;
 pub use core::*;
@@ -11,6 +11,7 @@ mod tests;
 
 pub type Rv32MulHAir =
     VmAirWrapper<Rv32MultAdapterAir, MulHCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32MulHStep = MulHStep<Rv32MultAdapterStep, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32MulHExecutor =
+    MulHExecutor<Rv32MultAdapterExecutor, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
 pub type Rv32MulHChip<F> =
     VmChipWrapper<F, MulHFiller<Rv32MultAdapterFiller, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;

--- a/extensions/rv32im/circuit/src/mulh/tests.rs
+++ b/extensions/rv32im/circuit/src/mulh/tests.rs
@@ -35,19 +35,19 @@ use test_case::test_case;
 use super::core::run_mulh;
 use crate::{
     adapters::{
-        Rv32MultAdapterAir, Rv32MultAdapterFiller, Rv32MultAdapterStep, RV32_CELL_BITS,
+        Rv32MultAdapterAir, Rv32MultAdapterExecutor, Rv32MultAdapterFiller, RV32_CELL_BITS,
         RV32_REGISTER_NUM_LIMBS,
     },
     mulh::{MulHCoreCols, Rv32MulHChip},
     test_utils::get_verification_error,
-    MulHCoreAir, MulHFiller, Rv32MulHAir, Rv32MulHStep,
+    MulHCoreAir, MulHFiller, Rv32MulHAir, Rv32MulHExecutor,
 };
 
 const MAX_INS_CAPACITY: usize = 128;
 // the max number of limbs we currently support MUL for is 32 (i.e. for U256s)
 const MAX_NUM_LIMBS: u32 = 32;
 type F = BabyBear;
-type Harness = TestChipHarness<F, Rv32MulHStep, Rv32MulHAir, Rv32MulHChip<F>>;
+type Harness = TestChipHarness<F, Rv32MulHExecutor, Rv32MulHAir, Rv32MulHChip<F>>;
 
 fn create_test_chip(
     tester: &mut VmChipTestBuilder<F>,
@@ -75,7 +75,7 @@ fn create_test_chip(
         Rv32MultAdapterAir::new(tester.execution_bridge(), tester.memory_bridge()),
         MulHCoreAir::new(bitwise_bus, range_tuple_bus),
     );
-    let executor = Rv32MulHStep::new(Rv32MultAdapterStep, MulHOpcode::CLASS_OFFSET);
+    let executor = Rv32MulHExecutor::new(Rv32MultAdapterExecutor, MulHOpcode::CLASS_OFFSET);
     let chip = Rv32MulHChip::<F>::new(
         MulHFiller::new(
             Rv32MultAdapterFiller,

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -258,7 +258,7 @@ pub struct ShiftCoreRecord<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 #[derive(Clone, Copy)]
-pub struct ShiftStep<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct ShiftExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     adapter: A,
     pub offset: usize,
 }
@@ -270,7 +270,7 @@ pub struct ShiftFiller<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
 
-impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, LIMB_BITS> {
+impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftExecutor<A, NUM_LIMBS, LIMB_BITS> {
     pub fn new(adapter: A, offset: usize) -> Self {
         assert_eq!(NUM_LIMBS % 2, 0, "Number of limbs must be divisible by 2");
         Self { adapter, offset }
@@ -295,11 +295,11 @@ impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftFiller<A, NUM_LIMBS
 }
 
 impl<F, A, RA, const NUM_LIMBS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
-    for ShiftStep<A, NUM_LIMBS, LIMB_BITS>
+    for ShiftExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
     A: 'static
-        + AdapterTraceStep<
+        + AdapterTraceExecutor<
             F,
             ReadData: Into<[[u8; NUM_LIMBS]; 2]>,
             WriteData: From<[[u8; NUM_LIMBS]; 1]>,
@@ -439,7 +439,7 @@ struct ShiftPreCompute {
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> Executor<F>
-    for ShiftStep<A, NUM_LIMBS, LIMB_BITS>
+    for ShiftExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -470,7 +470,7 @@ where
 }
 
 impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> MeteredExecutor<F>
-    for ShiftStep<A, NUM_LIMBS, LIMB_BITS>
+    for ShiftExecutor<A, NUM_LIMBS, LIMB_BITS>
 where
     F: PrimeField32,
 {
@@ -545,7 +545,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx, const IS_IMM: bo
     execute_e12_impl::<F, CTX, IS_IMM, OP>(&pre_compute.data, state);
 }
 
-impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftStep<A, NUM_LIMBS, LIMB_BITS> {
+impl<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> ShiftExecutor<A, NUM_LIMBS, LIMB_BITS> {
     #[inline(always)]
     fn pre_compute_impl<F: PrimeField32>(
         &self,

--- a/extensions/rv32im/circuit/src/shift/mod.rs
+++ b/extensions/rv32im/circuit/src/shift/mod.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper};
 
 use super::adapters::{
-    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, Rv32BaseAluAdapterStep, RV32_CELL_BITS,
+    Rv32BaseAluAdapterAir, Rv32BaseAluAdapterExecutor, Rv32BaseAluAdapterFiller, RV32_CELL_BITS,
     RV32_REGISTER_NUM_LIMBS,
 };
 
@@ -13,8 +13,11 @@ mod tests;
 
 pub type Rv32ShiftAir =
     VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>>;
-pub type Rv32ShiftStep =
-    ShiftStep<Rv32BaseAluAdapterStep<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>;
+pub type Rv32ShiftExecutor = ShiftExecutor<
+    Rv32BaseAluAdapterExecutor<RV32_CELL_BITS>,
+    RV32_REGISTER_NUM_LIMBS,
+    RV32_CELL_BITS,
+>;
 pub type Rv32ShiftChip<F> = VmChipWrapper<
     F,
     ShiftFiller<Rv32BaseAluAdapterFiller<RV32_CELL_BITS>, RV32_REGISTER_NUM_LIMBS, RV32_CELL_BITS>,

--- a/extensions/rv32im/circuit/src/shift/tests.rs
+++ b/extensions/rv32im/circuit/src/shift/tests.rs
@@ -23,18 +23,18 @@ use test_case::test_case;
 use super::{core::run_shift, Rv32ShiftChip, ShiftCoreAir, ShiftCoreCols};
 use crate::{
     adapters::{
-        Rv32BaseAluAdapterAir, Rv32BaseAluAdapterFiller, Rv32BaseAluAdapterStep, RV32_CELL_BITS,
-        RV32_REGISTER_NUM_LIMBS,
+        Rv32BaseAluAdapterAir, Rv32BaseAluAdapterExecutor, Rv32BaseAluAdapterFiller,
+        RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS,
     },
     test_utils::{
         generate_rv32_is_type_immediate, get_verification_error, rv32_rand_write_register_or_imm,
     },
-    Rv32ShiftAir, Rv32ShiftStep, ShiftFiller,
+    Rv32ShiftAir, Rv32ShiftExecutor, ShiftFiller,
 };
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
-type Harness = TestChipHarness<F, Rv32ShiftStep, Rv32ShiftAir, Rv32ShiftChip<F>>;
+type Harness = TestChipHarness<F, Rv32ShiftExecutor, Rv32ShiftAir, Rv32ShiftChip<F>>;
 
 fn create_test_chip(
     tester: &VmChipTestBuilder<F>,
@@ -59,7 +59,7 @@ fn create_test_chip(
         ),
         ShiftCoreAir::new(bitwise_bus, range_checker.bus(), ShiftOpcode::CLASS_OFFSET),
     );
-    let executor = Rv32ShiftStep::new(Rv32BaseAluAdapterStep, ShiftOpcode::CLASS_OFFSET);
+    let executor = Rv32ShiftExecutor::new(Rv32BaseAluAdapterExecutor, ShiftOpcode::CLASS_OFFSET);
     let chip = Rv32ShiftChip::<F>::new(
         ShiftFiller::new(
             Rv32BaseAluAdapterFiller::new(bitwise_chip.clone()),

--- a/extensions/sha256/circuit/src/extension.rs
+++ b/extensions/sha256/circuit/src/extension.rs
@@ -33,7 +33,7 @@ pub struct Sha256;
 
 #[derive(Clone, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 pub enum Sha256Executor {
-    Sha256(Sha256VmStep),
+    Sha256(Sha256VmExecutor),
 }
 
 impl<F> VmExecutionExtension<F> for Sha256 {
@@ -44,7 +44,7 @@ impl<F> VmExecutionExtension<F> for Sha256 {
         inventory: &mut ExecutorInventoryBuilder<F, Sha256Executor>,
     ) -> Result<(), ExecutorInventoryError> {
         let pointer_max_bits = inventory.pointer_max_bits();
-        let sha256_step = Sha256VmStep::new(Rv32Sha256Opcode::CLASS_OFFSET, pointer_max_bits);
+        let sha256_step = Sha256VmExecutor::new(Rv32Sha256Opcode::CLASS_OFFSET, pointer_max_bits);
         inventory.add_executor(
             sha256_step,
             Rv32Sha256Opcode::iter().map(|x| x.global_opcode()),

--- a/extensions/sha256/circuit/src/sha256_chip/mod.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/mod.rs
@@ -48,7 +48,7 @@ pub const SHA256_MAX_MESSAGE_LEN: usize = 1 << 29;
 pub type Sha256VmChip<F> = VmChipWrapper<F, Sha256VmFiller>;
 
 #[derive(derive_new::new, Clone)]
-pub struct Sha256VmStep {
+pub struct Sha256VmExecutor {
     pub offset: usize,
     pub pointer_max_bits: usize,
 }
@@ -82,7 +82,7 @@ struct ShaPreCompute {
     c: u8,
 }
 
-impl<F: PrimeField32> Executor<F> for Sha256VmStep {
+impl<F: PrimeField32> Executor<F> for Sha256VmExecutor {
     fn pre_compute_size(&self) -> usize {
         size_of::<ShaPreCompute>()
     }
@@ -101,7 +101,7 @@ impl<F: PrimeField32> Executor<F> for Sha256VmStep {
         Ok(execute_e1_impl::<_, _>)
     }
 }
-impl<F: PrimeField32> MeteredExecutor<F> for Sha256VmStep {
+impl<F: PrimeField32> MeteredExecutor<F> for Sha256VmExecutor {
     fn metered_pre_compute_size(&self) -> usize {
         size_of::<E2PreCompute<ShaPreCompute>>()
     }
@@ -183,7 +183,7 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: E2ExecutionCtx>(
         .on_height_change(pre_compute.chip_idx as usize, height);
 }
 
-impl Sha256VmStep {
+impl Sha256VmExecutor {
     fn pre_compute_impl<F: PrimeField32>(
         &self,
         pc: u32,

--- a/extensions/sha256/circuit/src/sha256_chip/tests.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/tests.rs
@@ -17,7 +17,7 @@ use openvm_stark_backend::{interaction::BusIndex, p3_field::FieldAlgebra};
 use openvm_stark_sdk::{config::setup_tracing, p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 
-use super::{Sha256VmAir, Sha256VmChip, Sha256VmStep};
+use super::{Sha256VmAir, Sha256VmChip, Sha256VmExecutor};
 use crate::{
     sha256_chip::trace::Sha256VmRecordLayout, sha256_solve, Sha256VmDigestCols, Sha256VmFiller,
     Sha256VmRoundCols,
@@ -26,7 +26,7 @@ use crate::{
 type F = BabyBear;
 const SELF_BUS_IDX: BusIndex = 28;
 const MAX_INS_CAPACITY: usize = 4096;
-type Harness<RA> = TestChipHarness<F, Sha256VmStep, Sha256VmAir, Sha256VmChip<F>, RA>;
+type Harness<RA> = TestChipHarness<F, Sha256VmExecutor, Sha256VmAir, Sha256VmChip<F>, RA>;
 
 fn create_test_chips<RA: Arena>(
     tester: &mut VmChipTestBuilder<F>,
@@ -48,7 +48,7 @@ fn create_test_chips<RA: Arena>(
         tester.address_bits(),
         SELF_BUS_IDX,
     );
-    let executor = Sha256VmStep::new(Rv32Sha256Opcode::CLASS_OFFSET, tester.address_bits());
+    let executor = Sha256VmExecutor::new(Rv32Sha256Opcode::CLASS_OFFSET, tester.address_bits());
     let chip = Sha256VmChip::new(
         Sha256VmFiller::new(bitwise_chip.clone(), tester.address_bits()),
         tester.memory_helper(),
@@ -66,7 +66,7 @@ fn set_and_execute<RA: Arena>(
     message: Option<&[u8]>,
     len: Option<usize>,
 ) where
-    Sha256VmStep: PreflightExecutor<F, RA>,
+    Sha256VmExecutor: PreflightExecutor<F, RA>,
 {
     let len = len.unwrap_or(rng.gen_range(1..3000));
     let tmp = get_random_message(rng, len);

--- a/extensions/sha256/circuit/src/sha256_chip/trace.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/trace.rs
@@ -32,7 +32,7 @@ use openvm_stark_backend::{
 };
 
 use super::{
-    Sha256VmDigestCols, Sha256VmRoundCols, Sha256VmStep, SHA256VM_CONTROL_WIDTH,
+    Sha256VmDigestCols, Sha256VmExecutor, Sha256VmRoundCols, SHA256VM_CONTROL_WIDTH,
     SHA256VM_DIGEST_WIDTH,
 };
 use crate::{
@@ -135,7 +135,7 @@ impl SizedRecord<Sha256VmRecordLayout> for Sha256VmRecordMut<'_> {
     }
 }
 
-impl<F, RA> PreflightExecutor<F, RA> for Sha256VmStep
+impl<F, RA> PreflightExecutor<F, RA> for Sha256VmExecutor
 where
     F: PrimeField32,
     for<'buf> RA: RecordArena<'buf, Sha256VmRecordLayout, Sha256VmRecordMut<'buf>>,


### PR DESCRIPTION
Now that our traits are unified around Executor

This was a find/replace excluding the following: codec.rs,memcpy.s,memset.s,ECDSA.md,**/recursion/**,**/pairing/**,**/ff_derive/**

closes INT-4350