### PR TITLE
feat(new-execution): halt on cost going above threshold

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -280,7 +280,7 @@ fn benchmark_execute_metered(bencher: Bencher, program: &str) {
         });
 }
 
-#[divan::bench(ignore, args = AVAILABLE_PROGRAMS, sample_count=5)]
+#[divan::bench(ignore = true, args = AVAILABLE_PROGRAMS, sample_count=5)]
 fn benchmark_execute_metered_cost(bencher: Bencher, program: &str) {
     bencher
         .with_inputs(|| {

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -17,8 +17,11 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use super::{AnyEnum, VmChipComplex, PUBLIC_VALUES_AIR_ID};
 use crate::{
     arch::{
-        execution_mode::metered::segment_ctx::SegmentationLimits, AirInventory, AirInventoryError,
-        Arena, ChipInventoryError, ExecutorInventory, ExecutorInventoryError,
+        execution_mode::{
+            metered::segment_ctx::SegmentationLimits, metered_cost::DEFAULT_MAX_COST,
+        },
+        AirInventory, AirInventoryError, Arena, ChipInventoryError, ExecutorInventory,
+        ExecutorInventoryError,
     },
     system::{
         memory::{
@@ -254,6 +257,11 @@ pub struct SystemConfig {
     #[serde(skip, default = "SegmentationLimits::default")]
     #[getset(set = "pub")]
     pub segmentation_limits: SegmentationLimits,
+    /// This field is skipped in serde as it's only used in execution and
+    /// not needed after any serialize/deserialize.
+    #[serde(skip, default)]
+    #[getset(set = "pub")]
+    pub max_execution_cost: u64,
 }
 
 impl SystemConfig {
@@ -274,6 +282,7 @@ impl SystemConfig {
             num_public_values,
             profiling: false,
             segmentation_limits: SegmentationLimits::default(),
+            max_execution_cost: DEFAULT_MAX_COST,
         }
     }
 

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -17,11 +17,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use super::{AnyEnum, VmChipComplex, PUBLIC_VALUES_AIR_ID};
 use crate::{
     arch::{
-        execution_mode::{
-            metered::segment_ctx::SegmentationLimits, metered_cost::DEFAULT_MAX_COST,
-        },
-        AirInventory, AirInventoryError, Arena, ChipInventoryError, ExecutorInventory,
-        ExecutorInventoryError,
+        execution_mode::metered::segment_ctx::SegmentationLimits, AirInventory, AirInventoryError,
+        Arena, ChipInventoryError, ExecutorInventory, ExecutorInventoryError,
     },
     system::{
         memory::{
@@ -257,11 +254,6 @@ pub struct SystemConfig {
     #[serde(skip, default = "SegmentationLimits::default")]
     #[getset(set = "pub")]
     pub segmentation_limits: SegmentationLimits,
-    /// This field is skipped in serde as it's only used in execution and
-    /// not needed after any serialize/deserialize.
-    #[serde(skip, default)]
-    #[getset(set = "pub")]
-    pub max_execution_cost: u64,
 }
 
 impl SystemConfig {
@@ -282,7 +274,6 @@ impl SystemConfig {
             num_public_values,
             profiling: false,
             segmentation_limits: SegmentationLimits::default(),
-            max_execution_cost: DEFAULT_MAX_COST,
         }
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_SEGMENT_CHECK_INSNS: u64 = 1000;
 
 const DEFAULT_MAX_TRACE_HEIGHT: u32 = (1 << 23) - 10000;
-const DEFAULT_MAX_CELLS: usize = 2_000_000_000; // 2B
+pub const DEFAULT_MAX_CELLS: usize = 2_000_000_000; // 2B
 const DEFAULT_MAX_INTERACTIONS: usize = BabyBear::ORDER_U32 as usize;
 
 #[derive(derive_new::new, Clone, Debug, Serialize, Deserialize)]

--- a/crates/vm/src/arch/execution_mode/metered_cost.rs
+++ b/crates/vm/src/arch/execution_mode/metered_cost.rs
@@ -109,6 +109,17 @@ impl MeteredCostCtx {
             cost: 0,
         }
     }
+
+    #[cold]
+    fn check_cost_limit(&self) {
+        if self.cost > 2 * DEFAULT_MAX_COST {
+            panic!(
+                "Execution cost {} exceeded maximum allowed cost of {}",
+                self.cost,
+                2 * DEFAULT_MAX_COST
+            );
+        }
+    }
 }
 
 impl ExecutionCtxTrait for MeteredCostCtx {
@@ -125,13 +136,7 @@ impl ExecutionCtxTrait for MeteredCostCtx {
             size
         );
         // Prevent unbounded memory accesses per instruction
-        if self.cost > 2 * DEFAULT_MAX_COST {
-            panic!(
-                "Execution cost {} exceeded maximum allowed cost of {}",
-                self.cost,
-                2 * DEFAULT_MAX_COST
-            );
-        }
+        self.check_cost_limit();
 
         // Handle access adapter updates
         // SAFETY: size passed is always a non-zero power of 2

--- a/crates/vm/src/arch/execution_mode/metered_cost.rs
+++ b/crates/vm/src/arch/execution_mode/metered_cost.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 const DEFAULT_MAX_SEGMENTS: u64 = 100;
-const DEFAULT_MAX_COST: u64 = DEFAULT_MAX_SEGMENTS * DEFAULT_SEGMENT_MAX_CELLS as u64;
+pub const DEFAULT_MAX_COST: u64 = DEFAULT_MAX_SEGMENTS * DEFAULT_SEGMENT_MAX_CELLS as u64;
 
 #[derive(Debug, Copy, Clone, derive_new::new)]
 pub struct MeteredCostExecutionOutput {
@@ -85,6 +85,7 @@ impl AccessAdapterCtx {
 
 #[derive(Clone, Debug)]
 pub struct MeteredCostCtx {
+    pub max_execution_cost: u64,
     pub widths: Vec<usize>,
     pub access_adapter_ctx: AccessAdapterCtx,
     // Cost is number of trace cells (height * width)
@@ -93,6 +94,7 @@ pub struct MeteredCostCtx {
 
 impl MeteredCostCtx {
     pub fn new(
+        max_execution_cost: u64,
         widths: Vec<usize>,
         as_byte_alignment_bits: Vec<u8>,
         has_public_values_chip: bool,
@@ -104,6 +106,7 @@ impl MeteredCostCtx {
             continuations_enabled,
         );
         Self {
+            max_execution_cost,
             widths,
             access_adapter_ctx,
             cost: 0,
@@ -150,7 +153,7 @@ impl ExecutionCtxTrait for MeteredCostCtx {
     }
 
     fn should_suspend<F>(vm_state: &mut VmExecState<F, GuestMemory, Self>) -> bool {
-        vm_state.ctx.cost > DEFAULT_MAX_COST
+        vm_state.ctx.cost > vm_state.ctx.max_execution_cost
     }
 }
 

--- a/crates/vm/src/arch/execution_mode/metered_cost.rs
+++ b/crates/vm/src/arch/execution_mode/metered_cost.rs
@@ -1,6 +1,6 @@
 use std::num::NonZero;
 
-use getset::Setters;
+use getset::WithSetters;
 use openvm_instructions::riscv::RV32_IMM_AS;
 
 use crate::{
@@ -69,11 +69,11 @@ impl AccessAdapterCtx {
     }
 }
 
-#[derive(Clone, Debug, Setters)]
+#[derive(Clone, Debug, WithSetters)]
 pub struct MeteredCostCtx {
     pub widths: Vec<usize>,
     pub access_adapter_ctx: AccessAdapterCtx,
-    #[getset(set = "pub")]
+    #[getset(set_with = "pub")]
     pub max_execution_cost: u64,
     // Cost is number of trace cells (height * width)
     pub cost: u64,

--- a/crates/vm/src/arch/execution_mode/metered_cost.rs
+++ b/crates/vm/src/arch/execution_mode/metered_cost.rs
@@ -1,5 +1,6 @@
 use std::num::NonZero;
 
+use getset::Setters;
 use openvm_instructions::riscv::RV32_IMM_AS;
 
 use crate::{
@@ -83,18 +84,18 @@ impl AccessAdapterCtx {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Setters)]
 pub struct MeteredCostCtx {
-    pub max_execution_cost: u64,
     pub widths: Vec<usize>,
     pub access_adapter_ctx: AccessAdapterCtx,
+    #[getset(set = "pub")]
+    pub max_execution_cost: u64,
     // Cost is number of trace cells (height * width)
     pub cost: u64,
 }
 
 impl MeteredCostCtx {
     pub fn new(
-        max_execution_cost: u64,
         widths: Vec<usize>,
         as_byte_alignment_bits: Vec<u8>,
         has_public_values_chip: bool,
@@ -106,9 +107,9 @@ impl MeteredCostCtx {
             continuations_enabled,
         );
         Self {
-            max_execution_cost,
             widths,
             access_adapter_ctx,
+            max_execution_cost: DEFAULT_MAX_COST,
             cost: 0,
         }
     }

--- a/crates/vm/src/arch/execution_mode/metered_cost.rs
+++ b/crates/vm/src/arch/execution_mode/metered_cost.rs
@@ -115,7 +115,7 @@ impl MeteredCostCtx {
 
     #[cold]
     fn check_cost_limit(&self) {
-        if self.cost > 2 * DEFAULT_MAX_COST {
+        if self.cost > 2 * std::cmp::max(self.max_execution_cost, DEFAULT_MAX_COST) {
             panic!(
                 "Execution cost {} exceeded maximum allowed cost of {}",
                 self.cost,

--- a/crates/vm/src/arch/execution_mode/mod.rs
+++ b/crates/vm/src/arch/execution_mode/mod.rs
@@ -1,7 +1,7 @@
 use crate::{arch::VmExecState, system::memory::online::GuestMemory};
 
 pub mod metered;
-mod metered_cost;
+pub mod metered_cost;
 mod preflight;
 mod pure;
 

--- a/crates/vm/src/arch/execution_mode/mod.rs
+++ b/crates/vm/src/arch/execution_mode/mod.rs
@@ -6,7 +6,7 @@ mod preflight;
 mod pure;
 
 pub use metered::{ctx::MeteredCtx, segment_ctx::Segment};
-pub use metered_cost::MeteredCostCtx;
+pub use metered_cost::{MeteredCostCtx, MeteredCostExecutionOutput};
 pub use preflight::PreflightCtx;
 pub use pure::ExecutionCtx;
 

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -18,8 +18,8 @@ use tracing::info_span;
 use crate::{
     arch::{
         execution_mode::{
-            ExecutionCtx, ExecutionCtxTrait, MeteredCostCtx, MeteredCtx, MeteredExecutionCtxTrait,
-            Segment,
+            ExecutionCtx, ExecutionCtxTrait, MeteredCostCtx, MeteredCostExecutionOutput,
+            MeteredCtx, MeteredExecutionCtxTrait, Segment,
         },
         ExecuteFunc, ExecutionError, Executor, ExecutorInventory, ExitCode, MeteredExecutor,
         StaticProgramError, Streams, SystemConfig, VmExecState, VmState,
@@ -284,7 +284,7 @@ where
         &self,
         inputs: impl Into<Streams<F>>,
         ctx: MeteredCostCtx,
-    ) -> Result<u64, ExecutionError> {
+    ) -> Result<MeteredCostExecutionOutput, ExecutionError> {
         let vm_state = VmState::initial(
             &self.system_config,
             &self.init_memory,
@@ -302,7 +302,7 @@ where
         &self,
         from_state: VmState<F, GuestMemory>,
         ctx: MeteredCostCtx,
-    ) -> Result<u64, ExecutionError> {
+    ) -> Result<MeteredCostExecutionOutput, ExecutionError> {
         let mut exec_state = VmExecState::new(from_state, ctx);
         // Start execution
         execute_with_metrics!(
@@ -312,8 +312,9 @@ where
             &self.pre_compute_insns
         );
         check_termination(exec_state.exit_code)?;
-        let VmExecState { ctx, .. } = exec_state;
-        Ok(ctx.cost)
+        let VmExecState { ctx, vm_state, .. } = exec_state;
+        let output = MeteredCostExecutionOutput::new(vm_state.instret, ctx.cost);
+        Ok(output)
     }
 }
 

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -311,7 +311,7 @@ where
             &mut exec_state,
             &self.pre_compute_insns
         );
-        check_termination(exec_state.exit_code)?;
+        check_exit_code(exec_state.exit_code)?;
         let VmExecState { ctx, vm_state, .. } = exec_state;
         let output = MeteredCostExecutionOutput::new(vm_state.instret, ctx.cost);
         Ok(output)

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -199,42 +199,17 @@ where
         widths: &[usize],
         interactions: &[usize],
     ) -> MeteredCtx {
-        let system_config = self.config.as_ref();
-        let as_byte_alignment_bits = system_config
-            .memory_config
-            .addr_spaces
-            .iter()
-            .map(|addr_sp| log2_strict_usize(addr_sp.min_block_size) as u8)
-            .collect();
-
         MeteredCtx::new(
             constant_trace_heights.to_vec(),
-            system_config.has_public_values_chip(),
-            system_config.continuation_enabled,
-            as_byte_alignment_bits,
-            system_config.memory_config.memory_dimensions(),
             air_names.to_vec(),
             widths.to_vec(),
             interactions.to_vec(),
-            system_config.segmentation_limits,
+            self.config.as_ref(),
         )
     }
 
     pub fn build_metered_cost_ctx(&self, widths: &[usize]) -> MeteredCostCtx {
-        let system_config = self.config.as_ref();
-        let as_byte_alignment_bits = system_config
-            .memory_config
-            .addr_spaces
-            .iter()
-            .map(|addr_sp| log2_strict_usize(addr_sp.min_block_size) as u8)
-            .collect();
-
-        MeteredCostCtx::new(
-            widths.to_vec(),
-            as_byte_alignment_bits,
-            system_config.has_public_values_chip(),
-            system_config.continuation_enabled,
-        )
+        MeteredCostCtx::new(widths.to_vec(), self.config.as_ref())
     }
 }
 

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -230,6 +230,7 @@ where
             .collect();
 
         MeteredCostCtx::new(
+            system_config.max_execution_cost,
             widths.to_vec(),
             as_byte_alignment_bits,
             system_config.has_public_values_chip(),

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -230,7 +230,6 @@ where
             .collect();
 
         MeteredCostCtx::new(
-            system_config.max_execution_cost,
             widths.to_vec(),
             as_byte_alignment_bits,
             system_config.has_public_values_chip(),

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -953,7 +953,7 @@ fn test_vm_execute_metered_cost_halt() {
     type F = BabyBear;
 
     setup_tracing();
-    let mut config = test_native_config();
+    let config = test_native_config();
 
     let engine = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));
     let (vm, _) =
@@ -983,17 +983,13 @@ fn test_vm_execute_metered_cost_halt() {
 
     assert_eq!(output1.instret, instructions.len() as u64);
 
-    // Create a new VM with limited execution cost
-    config.system.set_max_execution_cost(1);
-    let engine2 = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));
-    let (vm2, _) = VirtualMachine::new_with_keygen(engine2, NativeCpuBuilder, config).unwrap();
-
-    let executor_idx_to_air_idx2 = vm2.executor_idx_to_air_idx();
-    let instance2 = vm2
+    let executor_idx_to_air_idx2 = vm.executor_idx_to_air_idx();
+    let instance2 = vm
         .executor()
         .metered_cost_instance(&exe, &executor_idx_to_air_idx2)
         .unwrap();
-    let ctx2 = vm2.build_metered_cost_ctx();
+    let mut ctx2 = vm.build_metered_cost_ctx();
+    ctx2.set_max_execution_cost(0);
     let output2 = instance2
         .execute_metered_cost(vec![], ctx2)
         .expect("Failed to execute");

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -944,6 +944,61 @@ fn test_vm_execute_metered_cost_native_chips() {
         .execute_metered_cost(vec![], ctx)
         .expect("Failed to execute");
 
-    assert_eq!(output.instret, 5);
+    assert_eq!(output.instret, instructions.len() as u64);
     assert!(output.cost > 0);
+}
+
+#[test]
+fn test_vm_execute_metered_cost_halt() {
+    type F = BabyBear;
+
+    setup_tracing();
+    let mut config = test_native_config();
+
+    let engine = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));
+    let (vm, _) =
+        VirtualMachine::new_with_keygen(engine, NativeCpuBuilder, config.clone()).unwrap();
+
+    let instructions = vec![
+        // Field Arithmetic operations (FieldArithmeticChip)
+        Instruction::large_from_isize(ADD.global_opcode(), 0, 0, 1, 4, 0, 0, 0),
+        Instruction::large_from_isize(SUB.global_opcode(), 1, 10, 2, 4, 0, 0, 0),
+        Instruction::large_from_isize(MUL.global_opcode(), 2, 3, 4, 4, 0, 0, 0),
+        Instruction::large_from_isize(DIV.global_opcode(), 3, 20, 5, 4, 0, 0, 0),
+        // Terminate
+        Instruction::from_isize(TERMINATE.global_opcode(), 0, 0, 0, 0, 0),
+    ];
+
+    let exe = VmExe::new(Program::<F>::from_instructions(&instructions));
+
+    let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
+    let instance = vm
+        .executor()
+        .metered_cost_instance(&exe, &executor_idx_to_air_idx)
+        .unwrap();
+    let ctx = vm.build_metered_cost_ctx();
+    let output1 = instance
+        .execute_metered_cost(vec![], ctx)
+        .expect("Failed to execute");
+
+    assert_eq!(output1.instret, instructions.len() as u64);
+
+    // Create a new VM with limited execution cost
+    config.system.set_max_execution_cost(1);
+    let engine2 = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));
+    let (vm2, _) = VirtualMachine::new_with_keygen(engine2, NativeCpuBuilder, config).unwrap();
+
+    let executor_idx_to_air_idx2 = vm2.executor_idx_to_air_idx();
+    let instance2 = vm2
+        .executor()
+        .metered_cost_instance(&exe, &executor_idx_to_air_idx2)
+        .unwrap();
+    let ctx2 = vm2.build_metered_cost_ctx();
+    let output2 = instance2
+        .execute_metered_cost(vec![], ctx2)
+        .expect("Failed to execute");
+
+    assert_eq!(output2.instret, 1);
+
+    assert!(output2.cost < output1.cost);
 }

--- a/crates/vm/tests/integration_test.rs
+++ b/crates/vm/tests/integration_test.rs
@@ -988,8 +988,7 @@ fn test_vm_execute_metered_cost_halt() {
         .executor()
         .metered_cost_instance(&exe, &executor_idx_to_air_idx2)
         .unwrap();
-    let mut ctx2 = vm.build_metered_cost_ctx();
-    ctx2.set_max_execution_cost(0);
+    let ctx2 = vm.build_metered_cost_ctx().with_max_execution_cost(0);
     let output2 = instance2
         .execute_metered_cost(vec![], ctx2)
         .expect("Failed to execute");


### PR DESCRIPTION
- add a `max_execution_cost` config parameter that determines the threshold up to which `execute_metered_cost` will execute

Resolves INT-4727