### PR TITLE
perf: `AddressMap` with `memmap` use madvise for zeroing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,7 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2851,7 +2851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4159,7 +4159,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4365,9 +4365,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libgit2-sys"
@@ -4388,7 +4388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5252,6 +5252,7 @@ dependencies = [
  "eyre",
  "getset",
  "itertools 0.14.0",
+ "libc",
  "memmap2",
  "metrics",
  "openvm-circuit",
@@ -7832,7 +7833,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7845,7 +7846,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8757,7 +8758,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9621,7 +9622,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ hex = { version = "0.4.3", default-features = false }
 serde-big-array = "0.5.1"
 dashmap = "6.1.0"
 memmap2 = "0.9.5"
+libc = "0.2.175"
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 
 # default-features = false for no_std for use in guest programs

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -38,6 +38,8 @@ dashmap.workspace = true
 
 [target.'cfg(any(unix, windows))'.dependencies]
 memmap2.workspace = true
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -188,7 +188,7 @@ where
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
         let vm_state = VmState::initial(
             &self.system_config,
-            self.init_memory.clone(),
+            &self.init_memory,
             self.pc_start,
             inputs,
         );
@@ -238,7 +238,7 @@ where
     ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
         let vm_state = VmState::initial(
             &self.system_config,
-            self.init_memory.clone(),
+            &self.init_memory,
             self.pc_start,
             inputs,
         );
@@ -287,7 +287,7 @@ where
     ) -> Result<u64, ExecutionError> {
         let vm_state = VmState::initial(
             &self.system_config,
-            self.init_memory.clone(),
+            &self.init_memory,
             self.pc_start,
             inputs,
         );

--- a/crates/vm/src/arch/state.rs
+++ b/crates/vm/src/arch/state.rs
@@ -55,7 +55,7 @@ impl<F: Clone, MEM> VmState<F, MEM> {
 impl<F: Clone> VmState<F, GuestMemory> {
     pub fn initial(
         system_config: &SystemConfig,
-        init_memory: SparseMemoryImage,
+        init_memory: &SparseMemoryImage,
         pc_start: u32,
         inputs: impl Into<Streams<F>>,
     ) -> Self {
@@ -77,7 +77,7 @@ impl<F: Clone> VmState<F, GuestMemory> {
 
     pub fn reset(
         &mut self,
-        init_memory: SparseMemoryImage,
+        init_memory: &SparseMemoryImage,
         pc_start: u32,
         streams: impl Into<Streams<F>>,
     ) {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -556,7 +556,7 @@ where
         #[allow(unused_mut)]
         let mut state = VmState::initial(
             self.config().as_ref(),
-            exe.init_memory.clone(),
+            &exe.init_memory,
             exe.pc_start,
             inputs,
         );
@@ -907,7 +907,7 @@ where
         self.state
             .as_mut()
             .unwrap()
-            .reset(self.exe.init_memory.clone(), self.exe.pc_start, inputs);
+            .reset(&self.exe.init_memory, self.exe.pc_start, inputs);
     }
 }
 
@@ -1230,7 +1230,7 @@ where
 
 pub(super) fn create_memory_image(
     memory_config: &MemoryConfig,
-    init_memory: SparseMemoryImage,
+    init_memory: &SparseMemoryImage,
 ) -> GuestMemory {
     let mut inner = AddressMap::new(memory_config.addr_spaces.clone());
     inner.set_from_sparse(init_memory);

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -270,14 +270,14 @@ impl<M: LinearMemory> AddressMap<M> {
     /// # Safety
     /// - `T` **must** be the correct type for a single memory cell for `addr_space`
     /// - Assumes `addr_space` is within the configured memory and not out of bounds
-    pub fn set_from_sparse(&mut self, sparse_map: SparseMemoryImage) {
-        for ((addr_space, index), data_byte) in sparse_map.into_iter() {
+    pub fn set_from_sparse(&mut self, sparse_map: &SparseMemoryImage) {
+        for ((addr_space, index), data_byte) in sparse_map.iter() {
             // SAFETY:
             // - safety assumptions in function doc comments
             unsafe {
                 self.mem
-                    .get_unchecked_mut(addr_space as usize)
-                    .write_unaligned(index as usize, data_byte);
+                    .get_unchecked_mut(*addr_space as usize)
+                    .write_unaligned(*index as usize, data_byte);
             }
         }
     }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -271,13 +271,13 @@ impl<M: LinearMemory> AddressMap<M> {
     /// - `T` **must** be the correct type for a single memory cell for `addr_space`
     /// - Assumes `addr_space` is within the configured memory and not out of bounds
     pub fn set_from_sparse(&mut self, sparse_map: &SparseMemoryImage) {
-        for ((addr_space, index), data_byte) in sparse_map.iter() {
+        for (&(addr_space, index), &data_byte) in sparse_map.iter() {
             // SAFETY:
             // - safety assumptions in function doc comments
             unsafe {
                 self.mem
-                    .get_unchecked_mut(*addr_space as usize)
-                    .write_unaligned(*index as usize, data_byte);
+                    .get_unchecked_mut(addr_space as usize)
+                    .write_unaligned(index as usize, data_byte);
             }
         }
     }

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -104,7 +104,7 @@ impl<SC: StarkGenericConfig> VmCommittedExe<SC> {
         let app_program_commit: &[Val<SC>; CHUNK] = self.commitment.as_ref();
         let mem_config = memory_config;
         let mut memory_image = AddressMap::new(mem_config.addr_spaces.clone());
-        memory_image.set_from_sparse(self.exe.init_memory.clone());
+        memory_image.set_from_sparse(&self.exe.init_memory);
         let init_memory_commit =
             MerkleTree::from_memory(&memory_image, &memory_dimensions, &hasher).root();
         Com::<SC>::from(compute_exe_commit(


### PR DESCRIPTION
Commit 61ba7ae5b8f68cc18dcf53e91fff7fec65cc6367 seemed to introduce a perf degradation because `fill_zero` is slower than the previous creation of a new memmap region. I think this is because memmap will just tell OS to give it new pages that are zero'd on-demand. I do this now for memmap memory by using `madvise` directly.

Comparison run between 61ba7ae5b8f68cc18dcf53e91fff7fec65cc6367 and this PR:  https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16925643699
- benchmark itself had a lot of noise, but if you search `vm.reset_state` in detailed metrics
- before: https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/new-execution/reth-30741fbba178d13d7a082dbe9668711e5aa37816-c4f412ba8d28ece7c9e686eb02c6ad77bd15fb42a3240326a379c445d4ece79c.md
- after: https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/new-execution/reth-3a634d4e5294b7ca678af31906ee85ce737b4c89-06e86df9e677f46a75d377f176a161d3dbe2ceef393bfa0515555dbe5a268c11.md 
- the max reset time goes from 400ms to 4ms