### PR TITLE
fix(new-execution): warn if `max_constraint_degree` differ

### DIFF
--- a/benchmarks/prove/src/bin/verify_fibair.rs
+++ b/benchmarks/prove/src/bin/verify_fibair.rs
@@ -54,6 +54,7 @@ fn main() -> Result<()> {
             app_fri_params.max_constraint_degree().min(7),
         );
         app_vm_config.system.profiling = args.profiling;
+        app_vm_config.system.max_constraint_degree = (1 << app_log_blowup) + 1;
 
         let compiler_options = CompilerOptions::default();
         let app_config = AppConfig {

--- a/benchmarks/prove/src/util.rs
+++ b/benchmarks/prove/src/util.rs
@@ -88,6 +88,7 @@ impl BenchmarkCli {
         let leaf_log_blowup = self.leaf_log_blowup.unwrap_or(DEFAULT_LEAF_LOG_BLOWUP);
 
         app_vm_config.as_mut().profiling = self.profiling;
+        app_vm_config.as_mut().max_constraint_degree = (1 << app_log_blowup) + 1;
         if let Some(max_height) = self.max_segment_length {
             app_vm_config.as_mut().segmentation_limits.max_trace_height = max_height;
         }

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -49,7 +49,7 @@ use crate::{
         perm::AirIdPermutation,
     },
     prover::vm::types::VmProvingKey,
-    util::warn_if_constraint_degree_mismatch,
+    util::check_max_constraint_degrees,
     RootSC, SC,
 };
 
@@ -127,7 +127,7 @@ where
                 vm_pk.max_constraint_degree
                     <= config.app_fri_params.fri_params.max_constraint_degree()
             );
-            warn_if_constraint_degree_mismatch(
+            check_max_constraint_degrees(
                 config.app_vm_config.as_ref(),
                 config.app_fri_params.fri_params,
             );
@@ -311,7 +311,7 @@ impl AggProvingKey {
                 leaf_vm_config.clone(),
             )?;
             assert!(vm_pk.max_constraint_degree <= config.leaf_fri_params.max_constraint_degree());
-            warn_if_constraint_degree_mismatch(&leaf_vm_config.system, config.leaf_fri_params);
+            check_max_constraint_degrees(&leaf_vm_config.system, config.leaf_fri_params);
             Arc::new(VmProvingKey {
                 fri_params: config.leaf_fri_params,
                 vm_config: leaf_vm_config,
@@ -331,7 +331,7 @@ impl AggProvingKey {
             NativeCpuBuilder,
             internal_vm_config.clone(),
         )?;
-        warn_if_constraint_degree_mismatch(&internal_vm_config.system, config.internal_fri_params);
+        check_max_constraint_degrees(&internal_vm_config.system, config.internal_fri_params);
         assert!(vm_pk.max_constraint_degree <= config.internal_fri_params.max_constraint_degree());
         let internal_vm_pk = Arc::new(VmProvingKey {
             fri_params: config.internal_fri_params,

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -129,7 +129,7 @@ where
             );
             check_max_constraint_degrees(
                 config.app_vm_config.as_ref(),
-                config.app_fri_params.fri_params,
+                &config.app_fri_params.fri_params,
             );
             VmProvingKey {
                 fri_params: config.app_fri_params.fri_params,
@@ -311,7 +311,7 @@ impl AggProvingKey {
                 leaf_vm_config.clone(),
             )?;
             assert!(vm_pk.max_constraint_degree <= config.leaf_fri_params.max_constraint_degree());
-            check_max_constraint_degrees(&leaf_vm_config.system, config.leaf_fri_params);
+            check_max_constraint_degrees(&leaf_vm_config.system, &config.leaf_fri_params);
             Arc::new(VmProvingKey {
                 fri_params: config.leaf_fri_params,
                 vm_config: leaf_vm_config,
@@ -331,7 +331,7 @@ impl AggProvingKey {
             NativeCpuBuilder,
             internal_vm_config.clone(),
         )?;
-        check_max_constraint_degrees(&internal_vm_config.system, config.internal_fri_params);
+        check_max_constraint_degrees(&internal_vm_config.system, &config.internal_fri_params);
         assert!(vm_pk.max_constraint_degree <= config.internal_fri_params.max_constraint_degree());
         let internal_vm_pk = Arc::new(VmProvingKey {
             fri_params: config.internal_fri_params,

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -49,7 +49,7 @@ use crate::{
         perm::AirIdPermutation,
     },
     prover::vm::types::VmProvingKey,
-    util::warn_constraint_degree_mismatch,
+    util::warn_if_constraint_degree_mismatch,
     RootSC, SC,
 };
 
@@ -127,7 +127,7 @@ where
                 vm_pk.max_constraint_degree
                     <= config.app_fri_params.fri_params.max_constraint_degree()
             );
-            warn_constraint_degree_mismatch(
+            warn_if_constraint_degree_mismatch(
                 config.app_vm_config.as_ref(),
                 config.app_fri_params.fri_params,
             );
@@ -311,7 +311,7 @@ impl AggProvingKey {
                 leaf_vm_config.clone(),
             )?;
             assert!(vm_pk.max_constraint_degree <= config.leaf_fri_params.max_constraint_degree());
-            warn_constraint_degree_mismatch(&leaf_vm_config.system, config.leaf_fri_params);
+            warn_if_constraint_degree_mismatch(&leaf_vm_config.system, config.leaf_fri_params);
             Arc::new(VmProvingKey {
                 fri_params: config.leaf_fri_params,
                 vm_config: leaf_vm_config,
@@ -331,7 +331,7 @@ impl AggProvingKey {
             NativeCpuBuilder,
             internal_vm_config.clone(),
         )?;
-        warn_constraint_degree_mismatch(&internal_vm_config.system, config.internal_fri_params);
+        warn_if_constraint_degree_mismatch(&internal_vm_config.system, config.internal_fri_params);
         assert!(vm_pk.max_constraint_degree <= config.internal_fri_params.max_constraint_degree());
         let internal_vm_pk = Arc::new(VmProvingKey {
             fri_params: config.internal_fri_params,

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -126,6 +126,15 @@ where
                 vm_pk.max_constraint_degree
                     <= config.app_fri_params.fri_params.max_constraint_degree()
             );
+            if vm_pk.max_constraint_degree
+                != config.app_fri_params.fri_params.max_constraint_degree()
+            {
+                tracing::warn!(
+                    "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
+                    vm_pk.max_constraint_degree,
+                    config.app_fri_params.fri_params.max_constraint_degree()
+                );
+            }
             VmProvingKey {
                 fri_params: config.app_fri_params.fri_params,
                 vm_config: config.app_vm_config.clone(),
@@ -306,6 +315,13 @@ impl AggProvingKey {
                 leaf_vm_config.clone(),
             )?;
             assert!(vm_pk.max_constraint_degree <= config.leaf_fri_params.max_constraint_degree());
+            if vm_pk.max_constraint_degree != config.leaf_fri_params.max_constraint_degree() {
+                tracing::warn!(
+                    "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
+                    vm_pk.max_constraint_degree,
+                    config.leaf_fri_params.max_constraint_degree()
+                );
+            }
             Arc::new(VmProvingKey {
                 fri_params: config.leaf_fri_params,
                 vm_config: leaf_vm_config,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -73,6 +73,7 @@ pub mod fs;
 pub mod keygen;
 pub mod prover;
 pub mod types;
+pub mod util;
 
 mod error;
 mod stdin;

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -127,7 +127,7 @@ where
     ) -> Result<Vec<Proof<SC>>, VirtualMachineError> {
         check_max_constraint_degrees(
             self.leaf_prover.vm.config().as_ref(),
-            self.leaf_prover.vm.engine.fri_params(),
+            &self.leaf_prover.vm.engine.fri_params(),
         );
         self.leaf_controller
             .generate_proof(&mut self.leaf_prover, app_proofs)
@@ -152,8 +152,8 @@ where
         public_values: Vec<F>,
     ) -> Result<VmStarkProof<SC>, VirtualMachineError> {
         check_max_constraint_degrees(
-            self.leaf_prover.vm.config().as_ref(),
-            self.leaf_prover.vm.engine.fri_params(),
+            self.internal_prover.vm.config().as_ref(),
+            &self.internal_prover.vm.engine.fri_params(),
         );
 
         let mut internal_node_idx = -1;
@@ -268,6 +268,10 @@ where
         &mut self,
         root_input: RootVmVerifierInput<SC>,
     ) -> Result<Proof<RootSC>, VirtualMachineError> {
+        check_max_constraint_degrees(
+            self.root_prover.vm_config().as_ref(),
+            self.root_prover.fri_params(),
+        );
         let input = root_input.write();
         #[cfg(feature = "metrics")]
         metrics::counter!("fri.log_blowup")

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -17,7 +17,7 @@ use tracing::{info_span, instrument};
 
 use crate::{
     config::AggregationTreeConfig, keygen::AggProvingKey, prover::vm::new_local_prover,
-    util::warn_constraint_degree_mismatch, F, SC,
+    util::warn_if_constraint_degree_mismatch, F, SC,
 };
 #[cfg(feature = "evm-prove")]
 use crate::{prover::RootVerifierLocalProver, RootSC};
@@ -125,7 +125,7 @@ where
         &mut self,
         app_proofs: &ContinuationVmProof<SC>,
     ) -> Result<Vec<Proof<SC>>, VirtualMachineError> {
-        warn_constraint_degree_mismatch(
+        warn_if_constraint_degree_mismatch(
             self.leaf_prover.vm.config().as_ref(),
             self.leaf_prover.vm.engine.fri_params(),
         );
@@ -151,7 +151,7 @@ where
         leaf_proofs: Vec<Proof<SC>>,
         public_values: Vec<F>,
     ) -> Result<VmStarkProof<SC>, VirtualMachineError> {
-        warn_constraint_degree_mismatch(
+        warn_if_constraint_degree_mismatch(
             self.leaf_prover.vm.config().as_ref(),
             self.leaf_prover.vm.engine.fri_params(),
         );

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -124,6 +124,20 @@ where
         &mut self,
         app_proofs: &ContinuationVmProof<SC>,
     ) -> Result<Vec<Proof<SC>>, VirtualMachineError> {
+        if self.leaf_prover.vm.config().as_ref().max_constraint_degree
+            != self
+                .leaf_prover
+                .vm
+                .engine
+                .fri_params()
+                .max_constraint_degree()
+        {
+            tracing::warn!(
+                "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
+                self.leaf_prover.vm.config().as_ref().max_constraint_degree,
+                self.leaf_prover.vm.engine.fri_params().max_constraint_degree()
+            );
+        }
         self.leaf_controller
             .generate_proof(&mut self.leaf_prover, app_proofs)
     }
@@ -146,6 +160,21 @@ where
         leaf_proofs: Vec<Proof<SC>>,
         public_values: Vec<F>,
     ) -> Result<VmStarkProof<SC>, VirtualMachineError> {
+        if self.leaf_prover.vm.config().as_ref().max_constraint_degree
+            != self
+                .leaf_prover
+                .vm
+                .engine
+                .fri_params()
+                .max_constraint_degree()
+        {
+            tracing::warn!(
+                "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
+                self.leaf_prover.vm.config().as_ref().max_constraint_degree,
+                self.leaf_prover.vm.engine.fri_params().max_constraint_degree()
+            );
+        }
+
         let mut internal_node_idx = -1;
         let mut internal_node_height = 0;
         let mut proofs = leaf_proofs;

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -17,7 +17,7 @@ use tracing::{info_span, instrument};
 
 use crate::{
     config::AggregationTreeConfig, keygen::AggProvingKey, prover::vm::new_local_prover,
-    util::warn_if_constraint_degree_mismatch, F, SC,
+    util::check_max_constraint_degrees, F, SC,
 };
 #[cfg(feature = "evm-prove")]
 use crate::{prover::RootVerifierLocalProver, RootSC};
@@ -125,7 +125,7 @@ where
         &mut self,
         app_proofs: &ContinuationVmProof<SC>,
     ) -> Result<Vec<Proof<SC>>, VirtualMachineError> {
-        warn_if_constraint_degree_mismatch(
+        check_max_constraint_degrees(
             self.leaf_prover.vm.config().as_ref(),
             self.leaf_prover.vm.engine.fri_params(),
         );
@@ -151,7 +151,7 @@ where
         leaf_proofs: Vec<Proof<SC>>,
         public_values: Vec<F>,
     ) -> Result<VmStarkProof<SC>, VirtualMachineError> {
-        warn_if_constraint_degree_mismatch(
+        check_max_constraint_degrees(
             self.leaf_prover.vm.config().as_ref(),
             self.leaf_prover.vm.engine.fri_params(),
         );

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -16,7 +16,8 @@ use openvm_stark_sdk::{engine::StarkFriEngine, openvm_stark_backend::proof::Proo
 use tracing::{info_span, instrument};
 
 use crate::{
-    config::AggregationTreeConfig, keygen::AggProvingKey, prover::vm::new_local_prover, F, SC,
+    config::AggregationTreeConfig, keygen::AggProvingKey, prover::vm::new_local_prover,
+    util::warn_constraint_degree_mismatch, F, SC,
 };
 #[cfg(feature = "evm-prove")]
 use crate::{prover::RootVerifierLocalProver, RootSC};
@@ -124,20 +125,10 @@ where
         &mut self,
         app_proofs: &ContinuationVmProof<SC>,
     ) -> Result<Vec<Proof<SC>>, VirtualMachineError> {
-        if self.leaf_prover.vm.config().as_ref().max_constraint_degree
-            != self
-                .leaf_prover
-                .vm
-                .engine
-                .fri_params()
-                .max_constraint_degree()
-        {
-            tracing::warn!(
-                "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
-                self.leaf_prover.vm.config().as_ref().max_constraint_degree,
-                self.leaf_prover.vm.engine.fri_params().max_constraint_degree()
-            );
-        }
+        warn_constraint_degree_mismatch(
+            self.leaf_prover.vm.config().as_ref(),
+            self.leaf_prover.vm.engine.fri_params(),
+        );
         self.leaf_controller
             .generate_proof(&mut self.leaf_prover, app_proofs)
     }
@@ -160,20 +151,10 @@ where
         leaf_proofs: Vec<Proof<SC>>,
         public_values: Vec<F>,
     ) -> Result<VmStarkProof<SC>, VirtualMachineError> {
-        if self.leaf_prover.vm.config().as_ref().max_constraint_degree
-            != self
-                .leaf_prover
-                .vm
-                .engine
-                .fri_params()
-                .max_constraint_degree()
-        {
-            tracing::warn!(
-                "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
-                self.leaf_prover.vm.config().as_ref().max_constraint_degree,
-                self.leaf_prover.vm.engine.fri_params().max_constraint_degree()
-            );
-        }
+        warn_constraint_degree_mismatch(
+            self.leaf_prover.vm.config().as_ref(),
+            self.leaf_prover.vm.engine.fri_params(),
+        );
 
         let mut internal_node_idx = -1;
         let mut internal_node_height = 0;

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -136,7 +136,7 @@ where
         );
         check_max_constraint_degrees(
             self.vm_config().as_ref(),
-            self.instance.vm.engine.fri_params(),
+            &self.instance.vm.engine.fri_params(),
         );
         let proofs = info_span!(
             "app proof",

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -27,7 +27,7 @@ use crate::{
     commit::{AppExecutionCommit, CommitBytes},
     keygen::AppVerifyingKey,
     prover::vm::{new_local_prover, types::VmProvingKey},
-    util::warn_constraint_degree_mismatch,
+    util::warn_if_constraint_degree_mismatch,
     StdIn, F, SC,
 };
 
@@ -134,7 +134,7 @@ where
             self.vm_config().as_ref().continuation_enabled,
             "Use generate_app_proof_without_continuations instead."
         );
-        warn_constraint_degree_mismatch(
+        warn_if_constraint_degree_mismatch(
             self.vm_config().as_ref(),
             self.instance.vm.engine.fri_params(),
         );

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -27,6 +27,7 @@ use crate::{
     commit::{AppExecutionCommit, CommitBytes},
     keygen::AppVerifyingKey,
     prover::vm::{new_local_prover, types::VmProvingKey},
+    util::warn_constraint_degree_mismatch,
     StdIn, F, SC,
 };
 
@@ -133,15 +134,10 @@ where
             self.vm_config().as_ref().continuation_enabled,
             "Use generate_app_proof_without_continuations instead."
         );
-        if self.vm_config().as_ref().max_constraint_degree
-            != self.instance.vm.engine.fri_params().max_constraint_degree()
-        {
-            tracing::warn!(
-                "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
-                self.vm_config().as_ref().max_constraint_degree,
-                self.instance.vm.engine.fri_params().max_constraint_degree()
-            );
-        }
+        warn_constraint_degree_mismatch(
+            self.vm_config().as_ref(),
+            self.instance.vm.engine.fri_params(),
+        );
         let proofs = info_span!(
             "app proof",
             group = self

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -27,7 +27,7 @@ use crate::{
     commit::{AppExecutionCommit, CommitBytes},
     keygen::AppVerifyingKey,
     prover::vm::{new_local_prover, types::VmProvingKey},
-    util::warn_if_constraint_degree_mismatch,
+    util::check_max_constraint_degrees,
     StdIn, F, SC,
 };
 
@@ -134,7 +134,7 @@ where
             self.vm_config().as_ref().continuation_enabled,
             "Use generate_app_proof_without_continuations instead."
         );
-        warn_if_constraint_degree_mismatch(
+        check_max_constraint_degrees(
             self.vm_config().as_ref(),
             self.instance.vm.engine.fri_params(),
         );

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -133,6 +133,15 @@ where
             self.vm_config().as_ref().continuation_enabled,
             "Use generate_app_proof_without_continuations instead."
         );
+        if self.vm_config().as_ref().max_constraint_degree
+            != self.instance.vm.engine.fri_params().max_constraint_degree()
+        {
+            tracing::warn!(
+                "config.max_constraint_degree ({}) != engine.fri_params().max_constraint_degree() ({})",
+                self.vm_config().as_ref().max_constraint_degree,
+                self.instance.vm.engine.fri_params().max_constraint_degree()
+            );
+        }
         let proofs = info_span!(
             "app proof",
             group = self

--- a/crates/sdk/src/util.rs
+++ b/crates/sdk/src/util.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::SystemConfig;
 use openvm_stark_sdk::config::FriParameters;
 
-pub fn check_max_constraint_degrees(config: &SystemConfig, fri_params: FriParameters) {
+pub fn check_max_constraint_degrees(config: &SystemConfig, fri_params: &FriParameters) {
     if config.max_constraint_degree != fri_params.max_constraint_degree() {
         tracing::warn!(
             "config.max_constraint_degree ({}) != fri_params.max_constraint_degree() ({})",

--- a/crates/sdk/src/util.rs
+++ b/crates/sdk/src/util.rs
@@ -1,0 +1,12 @@
+use openvm_circuit::arch::SystemConfig;
+use openvm_stark_sdk::config::FriParameters;
+
+pub fn warn_constraint_degree_mismatch(config: &SystemConfig, fri_params: FriParameters) {
+    if config.max_constraint_degree != fri_params.max_constraint_degree() {
+        tracing::warn!(
+            "config.max_constraint_degree ({}) != fri_params.max_constraint_degree() ({})",
+            config.max_constraint_degree,
+            fri_params.max_constraint_degree()
+        );
+    }
+}

--- a/crates/sdk/src/util.rs
+++ b/crates/sdk/src/util.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::SystemConfig;
 use openvm_stark_sdk::config::FriParameters;
 
-pub fn warn_if_constraint_degree_mismatch(config: &SystemConfig, fri_params: FriParameters) {
+pub fn check_max_constraint_degrees(config: &SystemConfig, fri_params: FriParameters) {
     if config.max_constraint_degree != fri_params.max_constraint_degree() {
         tracing::warn!(
             "config.max_constraint_degree ({}) != fri_params.max_constraint_degree() ({})",

--- a/crates/sdk/src/util.rs
+++ b/crates/sdk/src/util.rs
@@ -1,7 +1,7 @@
 use openvm_circuit::arch::SystemConfig;
 use openvm_stark_sdk::config::FriParameters;
 
-pub fn warn_constraint_degree_mismatch(config: &SystemConfig, fri_params: FriParameters) {
+pub fn warn_if_constraint_degree_mismatch(config: &SystemConfig, fri_params: FriParameters) {
     if config.max_constraint_degree != fri_params.max_constraint_degree() {
         tracing::warn!(
             "config.max_constraint_degree ({}) != fri_params.max_constraint_degree() ({})",

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -667,16 +667,6 @@ where
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor:
             PreflightExecutor<Val<E::SC>, VB::RecordArena>,
     {
-        // TODO(ayush): why does engine return an Option?
-        if self.config().as_ref().max_constraint_degree
-            != self.engine.max_constraint_degree().unwrap()
-        {
-            tracing::warn!(
-                "config.max_constraint_degree ({}) != engine.max_constraint_degree() ({})",
-                self.config().as_ref().max_constraint_degree,
-                self.engine.max_constraint_degree().unwrap()
-            );
-        }
         self.transport_init_memory_to_device(&state.memory);
 
         let PreflightExecutionOutput {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -667,6 +667,16 @@ where
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor:
             PreflightExecutor<Val<E::SC>, VB::RecordArena>,
     {
+        // TODO(ayush): why does engine return an Option?
+        if self.config().as_ref().max_constraint_degree
+            != self.engine.max_constraint_degree().unwrap()
+        {
+            tracing::warn!(
+                "config.max_constraint_degree ({}) != engine.max_constraint_degree() ({})",
+                self.config().as_ref().max_constraint_degree,
+                self.engine.max_constraint_degree().unwrap()
+            );
+        }
         self.transport_init_memory_to_device(&state.memory);
 
         let PreflightExecutionOutput {


### PR DESCRIPTION
- emit a warning if `max_constraint_degree` don't matching between `VmConfig` and `StarkFriConfig`