### PR TITLE
feat: FriReducedOpening with `batch_prev_access_times`

### DIFF
--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -117,8 +117,8 @@ pub const OPENVM_DEFAULT_INIT_FILE_BASENAME: &str = "openvm_init";
 pub const OPENVM_DEFAULT_INIT_FILE_NAME: &str = "openvm_init.rs";
 /// The minimum block size is 4, but RISC-V `lb` only requires alignment of 1 and `lh` only requires
 /// alignment of 2 because the instructions are implemented by doing an access of block size 4.
-const DEFAULT_U8_BLOCK_SIZE: usize = 4;
-const DEFAULT_NATIVE_BLOCK_SIZE: usize = 1;
+pub const DEFAULT_U8_BLOCK_SIZE: usize = 4;
+pub const DEFAULT_NATIVE_BLOCK_SIZE: usize = 1;
 
 /// Trait for generating a init.rs file that contains a call to moduli_init!,
 /// complex_init!, sw_init! with the supported moduli and curves.

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -894,6 +894,11 @@ impl TracingMemory {
         unsafe { ret.assume_init() }
     }
 
+    /// Performs batch read of a slice in address space `address_space` starting at `pointer` of
+    /// length `access_timestamp.len()` elements of type `T`.
+    ///
+    /// **Note**: Unlike `read`, this function does not mutate the internal timestamp. Instead it
+    /// takes in the `access_timestamp`s to update this slice's metadata to as a separate argument.
     #[inline(always)]
     pub fn batch_read<T: Copy + Send + Sync, const BLOCK_SIZE: usize, const ALIGN: usize>(
         &mut self,

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -1040,7 +1040,7 @@ impl TracingMemory {
                             lowest_block_size: ALIGN as u32,
                             type_size: size_of::<T>() as u32,
                         },
-                        &prev_ts_buf,
+                        &prev_ts_buf[..seg_idx],
                     );
                     batch_processor.set_meta_block::<BLOCK_SIZE, ALIGN>(
                         block_start_ptr as usize,

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -926,7 +926,6 @@ impl TracingMemory {
         // accesses.
         access_timestamp: FN,
     ) -> Vec<u32> {
-        // dbg!(BLOCK_SIZE, ALIGN, address_space, pointer, len);
         // Goal: read a batch of memory with the same `BLOCK_SIZE` at given the timestamps.
         // High-level overview:
         // The batch read splits memory into the following segments:
@@ -1065,7 +1064,7 @@ impl TracingMemory {
                         AccessRecordHeader {
                             timestamp_and_mask: max_timestamp,
                             address_space,
-                            pointer,
+                            pointer: block_start_ptr,
                             block_size: BLOCK_SIZE as u32,
                             lowest_block_size: ALIGN as u32,
                             type_size: size_of::<T>() as u32,

--- a/extensions/native/circuit/src/fri/mod.rs
+++ b/extensions/native/circuit/src/fri/mod.rs
@@ -834,13 +834,14 @@ where
                 .get_slice(NATIVE_AS, record.common.b_ptr, length * EXT_DEG)
         };
 
+        let start_t = state.memory.timestamp();
         let a_prev_ts = state
             .memory
             .batch_prev_access_times::<F, 1, DEFAULT_NATIVE_BLOCK_SIZE, _>(
                 NATIVE_AS,
                 a_ptr,
                 length,
-                |i| 2 * i as u32,
+                |i| start_t + 2 * i as u32,
             );
         let b_prev_ts = state
             .memory
@@ -848,7 +849,7 @@ where
                 NATIVE_AS,
                 b_ptr,
                 length,
-                |i| (2 * i + 1) as u32,
+                |i| start_t + (2 * i + 1) as u32,
             );
         state.memory.increment_timestamp_by(2 * length as u32);
 

--- a/extensions/native/circuit/src/fri/tests.rs
+++ b/extensions/native/circuit/src/fri/tests.rs
@@ -123,7 +123,7 @@ fn fri_mat_opening_air_test() {
     let mut tester = VmChipTestBuilder::default_native();
     let mut harness = create_test_chip(&tester);
 
-    let num_ops = 28; // non-power-of-2 to also test padding
+    let num_ops = 1; // 28; // non-power-of-2 to also test padding
     for _ in 0..num_ops {
         set_and_execute(&mut tester, &mut harness, &mut rng);
     }


### PR DESCRIPTION
- Fixes various bugs in `batch_prev_access_times`.
- switched FriReducedOpening execute to use `batch_prev_access_times` which parallelizes some tracing memory operations.

On a 8 vCPU machine it doesn't make a difference / might be slightly worse.
Comparison benchmark (in progress): https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17028396319 

~~The next optimization is to do the actual reduced opening RLC using a parallel scan algorithm.~~ this was worse due to the thread switching overhead: https://github.com/openvm-org/openvm/pull/1992