### PR TITLE
ci(bench): tune jemalloc conf for execute benchmarks

### DIFF
--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -26,7 +26,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   S3_FIXTURES_PATH: s3://openvm-public-data-sandbox-us-east-1/benchmark/fixtures
-  JEMALLOC_SYS_WITH_MALLOC_CONF: "retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
+  JEMALLOC_SYS_WITH_MALLOC_CONF: "retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
 
 jobs:
   codspeed-walltime-benchmarks:


### PR DESCRIPTION
Reduces memory fragmentation by returning pages to OS with some delay