### PR TITLE
perf(sdk): avoid allocation in info_span group for AppProver

### DIFF
--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -56,8 +56,8 @@ impl<VC, E: StarkFriEngine<SC>> AppProver<VC, E> {
             "app proof",
             group = self
                 .program_name
-                .as_ref()
-                .unwrap_or(&"app_proof".to_string())
+                .as_deref()
+                .unwrap_or("app_proof")
         )
         .in_scope(|| {
             #[cfg(feature = "bench-metrics")]
@@ -81,8 +81,8 @@ impl<VC, E: StarkFriEngine<SC>> AppProver<VC, E> {
             "app proof",
             group = self
                 .program_name
-                .as_ref()
-                .unwrap_or(&"app_proof".to_string())
+                .as_deref()
+                .unwrap_or("app_proof")
         )
         .in_scope(|| {
             #[cfg(feature = "bench-metrics")]


### PR DESCRIPTION
Replace unwrap_or(&"app_proof".to_string()) with as_deref().unwrap_or("app_proof") to avoid unnecessary String allocation.