### PR TITLE
feat: make air_test generalized over engine

### DIFF
--- a/crates/toolchain/tests/tests/riscv_test_vectors.rs
+++ b/crates/toolchain/tests/tests/riscv_test_vectors.rs
@@ -9,7 +9,9 @@ use openvm_rv32im_circuit::{Rv32ImConfig, Rv32ImCpuBuilder};
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
-use openvm_stark_sdk::p3_baby_bear::BabyBear;
+use openvm_stark_sdk::{
+    config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+};
 use openvm_toolchain_tests::decode_elf;
 use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -81,7 +83,7 @@ fn test_rv32im_riscv_vector_prove() -> Result<()> {
             )?;
 
             let result = std::panic::catch_unwind(|| {
-                air_test(Rv32ImCpuBuilder, config.clone(), exe);
+                air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ImCpuBuilder, config.clone(), exe);
             });
 
             match result {

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -21,7 +21,9 @@ use openvm_rv32im_circuit::*;
 use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
-use openvm_stark_sdk::p3_baby_bear::BabyBear;
+use openvm_stark_sdk::{
+    config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+};
 use openvm_transpiler::{elf::Elf, transpiler::Transpiler, FromElf};
 use serde::{Deserialize, Serialize};
 use test_case::test_case;
@@ -156,6 +158,6 @@ fn test_terminate_prove() -> Result<()> {
             .with_extension(Rv32IoTranspilerExtension)
             .with_extension(ModularTranspilerExtension),
     )?;
-    air_test(Rv32ImCpuBuilder, config, openvm_exe);
+    air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ImCpuBuilder, config, openvm_exe);
     Ok(())
 }

--- a/extensions/algebra/tests/src/lib.rs
+++ b/extensions/algebra/tests/src/lib.rs
@@ -15,7 +15,9 @@ mod tests {
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{build_example_program_at_path, get_programs_dir, NoInitFile};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -52,7 +54,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -68,7 +70,7 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -95,7 +97,7 @@ mod tests {
                 .with_extension(Fp2TranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32ModularWithFp2CpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularWithFp2CpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -127,7 +129,7 @@ mod tests {
                 .with_extension(Fp2TranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32ModularWithFp2CpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularWithFp2CpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -147,7 +149,7 @@ mod tests {
                 .with_extension(Fp2TranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32ModularWithFp2CpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularWithFp2CpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -176,7 +178,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )
         .unwrap();
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
     }
 
     #[test]
@@ -191,7 +193,7 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/extensions/ecc/tests/src/lib.rs
+++ b/extensions/ecc/tests/src/lib.rs
@@ -26,7 +26,10 @@ mod tests {
         StdIn,
     };
     use openvm_stark_backend::p3_field::FieldAlgebra;
-    use openvm_stark_sdk::{openvm_stark_backend, p3_baby_bear::BabyBear};
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, openvm_stark_backend,
+        p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{
         build_example_program_at_path_with_features, get_programs_dir, NoInitFile,
     };
@@ -63,7 +66,7 @@ mod tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -85,7 +88,7 @@ mod tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -108,7 +111,7 @@ mod tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -174,7 +177,7 @@ mod tests {
             .into_iter()
             .map(FieldAlgebra::from_canonical_u8)
             .collect();
-        air_test_with_min_segments(
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
             Rv32WeierstrassCpuBuilder,
             config,
             openvm_exe,
@@ -197,7 +200,7 @@ mod tests {
             &config,
         )?;
         let openvm_exe = VmExe::from_elf(elf, config.transpiler())?;
-        air_test(SdkVmCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(SdkVmCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -215,7 +218,13 @@ mod tests {
         let openvm_exe = VmExe::from_elf(elf, config.transpiler())?;
         let mut input = StdIn::default();
         input.write(&P256_RECOVERY_TEST_VECTORS.to_vec());
-        air_test_with_min_segments(SdkVmCpuBuilder, config, openvm_exe, input, 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            SdkVmCpuBuilder,
+            config,
+            openvm_exe,
+            input,
+            1,
+        );
         Ok(())
     }
 
@@ -233,7 +242,13 @@ mod tests {
         let openvm_exe = VmExe::from_elf(elf, config.transpiler())?;
         let mut input = StdIn::default();
         input.write(&K256_RECOVERY_TEST_VECTORS.to_vec());
-        air_test_with_min_segments(SdkVmCpuBuilder, config, openvm_exe, input, 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            SdkVmCpuBuilder,
+            config,
+            openvm_exe,
+            input,
+            1,
+        );
         Ok(())
     }
 
@@ -251,7 +266,13 @@ mod tests {
         let openvm_exe = VmExe::from_elf(elf, config.transpiler())?;
         let mut input = StdIn::default();
         input.write(&k256_sec1_decoding_test_vectors());
-        air_test_with_min_segments(SdkVmCpuBuilder, config, openvm_exe, input, 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            SdkVmCpuBuilder,
+            config,
+            openvm_exe,
+            input,
+            1,
+        );
         Ok(())
     }
 
@@ -277,6 +298,6 @@ mod tests {
         .unwrap();
         let config =
             test_rv32weierstrass_config(vec![SECP256K1_CONFIG.clone(), P256_CONFIG.clone()]);
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
     }
 }

--- a/extensions/native/circuit/src/poseidon2/tests.rs
+++ b/extensions/native/circuit/src/poseidon2/tests.rs
@@ -23,6 +23,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::{
     config::{
         baby_bear_blake3::{BabyBearBlake3Config, BabyBearBlake3Engine},
+        baby_bear_poseidon2::BabyBearPoseidon2Engine,
         FriParameters,
     },
     engine::StarkFriEngine,
@@ -591,12 +592,12 @@ fn test_vm_compress_poseidon2_as4() {
 
     let program = Program::from_instructions(&instructions);
 
-    air_test(
+    air_test::<BabyBearPoseidon2Engine, _, _>(
         NativeCpuBuilder,
         NativeConfig::aggregation(0, 3),
         program.clone(),
     );
-    air_test(
+    air_test::<BabyBearPoseidon2Engine, _, _>(
         NativeCpuBuilder,
         NativeConfig::aggregation(0, 7),
         program.clone(),

--- a/extensions/native/circuit/tests/integration_test.rs
+++ b/extensions/native/circuit/tests/integration_test.rs
@@ -102,7 +102,7 @@ fn test_vm_1() {
 
     let program = Program::from_instructions(&instructions);
 
-    air_test(NativeCpuBuilder, test_native_config(), program);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, test_native_config(), program);
 }
 
 // See crates/sdk/src/prover/root.rs for intended usage
@@ -271,7 +271,7 @@ fn test_vm_initial_memory() {
         init_memory,
         fn_bounds: Default::default(),
     };
-    air_test(NativeCpuBuilder, config, exe);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, config, exe);
 }
 
 #[test]
@@ -375,7 +375,7 @@ fn test_vm_without_field_arithmetic() {
 
     let program = Program::from_instructions(&instructions);
 
-    air_test(NativeCpuBuilder, test_native_config(), program);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, test_native_config(), program);
 }
 
 #[test]
@@ -422,7 +422,7 @@ fn test_vm_fibonacci_old() {
 
     let program = Program::from_instructions(&instructions);
 
-    air_test(NativeCpuBuilder, test_native_config(), program);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, test_native_config(), program);
 }
 
 #[test]
@@ -481,7 +481,7 @@ fn test_vm_fibonacci_old_cycle_tracker() {
 
     let program = Program::from_instructions(&instructions);
 
-    air_test(NativeCpuBuilder, test_native_config(), program);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, test_native_config(), program);
 }
 
 #[test]
@@ -505,7 +505,7 @@ fn test_vm_field_extension_arithmetic() {
 
     let program = Program::from_instructions(&instructions);
 
-    air_test(NativeCpuBuilder, test_native_config(), program);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, test_native_config(), program);
 }
 
 #[test]
@@ -554,7 +554,7 @@ fn test_vm_max_access_adapter_8() {
             num_sys_airs2 + num_ext_airs
         );
     }
-    air_test(NativeCpuBuilder, test_native_config(), program);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, test_native_config(), program);
 }
 
 #[test]
@@ -578,7 +578,7 @@ fn test_vm_field_extension_arithmetic_persistent() {
 
     let program = Program::from_instructions(&instructions);
     let config = test_native_continuations_config();
-    air_test(NativeCpuBuilder, config, program);
+    air_test::<BabyBearPoseidon2Engine, _, _>(NativeCpuBuilder, config, program);
 }
 
 #[test]
@@ -639,7 +639,13 @@ fn test_vm_hint() {
 
     let input_stream: Vec<Vec<F>> = vec![vec![F::TWO]];
     let config = test_native_config();
-    air_test_with_min_segments(NativeCpuBuilder, config, program, input_stream, 1);
+    air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+        NativeCpuBuilder,
+        config,
+        program,
+        input_stream,
+        1,
+    );
 }
 
 #[test]

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -17,7 +17,10 @@ mod tests {
         DivRemOpcode, MulHOpcode, MulOpcode, Rv32ITranspilerExtension, Rv32IoTranspilerExtension,
         Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::{openvm_stark_backend::p3_field::FieldAlgebra, p3_baby_bear::BabyBear};
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine,
+        openvm_stark_backend::p3_field::FieldAlgebra, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{
         build_example_program_at_path, build_example_program_at_path_with_features,
         get_programs_dir,
@@ -51,7 +54,13 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
         change_rv32m_insn_to_nop(&mut exe);
-        air_test_with_min_segments(Rv32ICpuBuilder, config, exe, vec![], min_segments);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32ICpuBuilder,
+            config,
+            exe,
+            vec![],
+            min_segments,
+        );
         Ok(())
     }
 
@@ -67,7 +76,13 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension)
                 .with_extension(Rv32MTranspilerExtension),
         )?;
-        air_test_with_min_segments(Rv32ImCpuBuilder, config, exe, vec![], min_segments);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32ImCpuBuilder,
+            config,
+            exe,
+            vec![],
+            min_segments,
+        );
         Ok(())
     }
 
@@ -88,7 +103,13 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension)
                 .with_extension(Rv32MTranspilerExtension),
         )?;
-        air_test_with_min_segments(Rv32ImCpuBuilder, config, exe, vec![], min_segments);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32ImCpuBuilder,
+            config,
+            exe,
+            vec![],
+            min_segments,
+        );
         Ok(())
     }
 
@@ -104,7 +125,13 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
         let input = vec![[0, 1, 2, 3].map(F::from_canonical_u8).to_vec()];
-        air_test_with_min_segments(Rv32ImCpuBuilder, config, exe, input, 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32ImCpuBuilder,
+            config,
+            exe,
+            input,
+            1,
+        );
         Ok(())
     }
 
@@ -127,7 +154,13 @@ mod tests {
             "key".as_bytes().to_vec(),
             hint_load_by_key_encode(&input),
         )]));
-        air_test_with_min_segments(Rv32ImCpuBuilder, config, exe, streams, 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32ImCpuBuilder,
+            config,
+            exe,
+            streams,
+            1,
+        );
         Ok(())
     }
 
@@ -158,7 +191,13 @@ mod tests {
             .flat_map(|w| w.to_le_bytes())
             .map(F::from_canonical_u8)
             .collect();
-        air_test_with_min_segments(Rv32ImCpuBuilder, config, exe, vec![input], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32ImCpuBuilder,
+            config,
+            exe,
+            vec![input],
+            1,
+        );
         Ok(())
     }
 
@@ -215,7 +254,7 @@ mod tests {
                 .with_extension(Rv32MTranspilerExtension)
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
-        air_test(Rv32ImCpuBuilder, config, exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ImCpuBuilder, config, exe);
         Ok(())
     }
 
@@ -257,7 +296,7 @@ mod tests {
                 .with_extension(Rv32MTranspilerExtension)
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
-        air_test(Rv32ImCpuBuilder, config, exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ImCpuBuilder, config, exe);
         Ok(())
     }
 
@@ -277,7 +316,7 @@ mod tests {
                 .with_extension(Rv32MTranspilerExtension)
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
-        air_test(Rv32ImCpuBuilder, config, exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ImCpuBuilder, config, exe);
         Ok(())
     }
 
@@ -320,7 +359,7 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension),
         )
         .unwrap();
-        air_test(Rv32ImCpuBuilder, config, exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ImCpuBuilder, config, exe);
     }
 
     // For testing programs that should only execute RV32I:

--- a/guest-libs/ff_derive/tests/lib.rs
+++ b/guest-libs/ff_derive/tests/lib.rs
@@ -11,7 +11,9 @@ mod tests {
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{
         build_example_program_at_path, build_example_program_at_path_with_features,
         get_programs_dir,
@@ -46,7 +48,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -65,7 +67,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -84,7 +86,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -108,7 +110,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -132,7 +134,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -157,7 +159,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -181,7 +183,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32ModularCpuBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/k256/tests/lib.rs
+++ b/guest-libs/k256/tests/lib.rs
@@ -14,7 +14,9 @@ mod guest_tests {
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
     use openvm_sha256_transpiler::Sha256TranspilerExtension;
-    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{build_example_program_at_path, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -43,7 +45,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -61,7 +63,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -82,7 +84,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -189,7 +191,7 @@ mod guest_tests {
                 .with_extension(ModularTranspilerExtension)
                 .with_extension(Sha256TranspilerExtension),
         )?;
-        air_test(EcdsaCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(EcdsaCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -210,7 +212,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/keccak256/tests/lib.rs
+++ b/guest-libs/keccak256/tests/lib.rs
@@ -8,7 +8,9 @@ mod tests {
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{build_example_program_at_path, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -27,7 +29,7 @@ mod tests {
                 .with_extension(Rv32MTranspilerExtension)
                 .with_extension(Rv32IoTranspilerExtension),
         )?;
-        air_test(Keccak256Rv32CpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Keccak256Rv32CpuBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/p256/tests/lib.rs
+++ b/guest-libs/p256/tests/lib.rs
@@ -14,7 +14,9 @@ mod guest_tests {
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
     use openvm_sha256_transpiler::Sha256TranspilerExtension;
-    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{build_example_program_at_path, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -43,7 +45,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -61,7 +63,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -82,7 +84,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -189,7 +191,7 @@ mod guest_tests {
                 .with_extension(ModularTranspilerExtension)
                 .with_extension(Sha256TranspilerExtension),
         )?;
-        air_test(EcdsaCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(EcdsaCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -210,7 +212,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/pairing/tests/lib.rs
+++ b/guest-libs/pairing/tests/lib.rs
@@ -88,7 +88,7 @@ mod bn254 {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -124,7 +124,13 @@ mod bn254 {
             .map(F::from_canonical_u8)
             .collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io],
+            1,
+        );
         Ok(())
     }
 
@@ -182,7 +188,13 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -231,7 +243,13 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -284,7 +302,13 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -341,7 +365,13 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -460,7 +490,13 @@ mod bn254 {
             .flat_map(|w| w.to_le_bytes())
             .map(F::from_canonical_u8)
             .collect();
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io],
+            1,
+        );
         Ok(())
     }
 }
@@ -562,7 +598,7 @@ mod bls12_381 {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassCpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Rv32WeierstrassCpuBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -598,7 +634,13 @@ mod bls12_381 {
             .map(F::from_canonical_u8)
             .collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io],
+            1,
+        );
         Ok(())
     }
 
@@ -657,7 +699,13 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -706,7 +754,13 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -765,7 +819,13 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -821,7 +881,13 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io_all],
+            1,
+        );
         Ok(())
     }
 
@@ -940,7 +1006,13 @@ mod bls12_381 {
             .flat_map(|w| w.to_le_bytes())
             .map(F::from_canonical_u8)
             .collect();
-        air_test_with_min_segments(Rv32PairingCpuBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments::<BabyBearPoseidon2Engine, _, _>(
+            Rv32PairingCpuBuilder,
+            config,
+            openvm_exe,
+            vec![io],
+            1,
+        );
         Ok(())
     }
 }

--- a/guest-libs/ruint/tests/lib.rs
+++ b/guest-libs/ruint/tests/lib.rs
@@ -8,7 +8,9 @@ mod tests {
     use openvm_rv32im_transpiler::{
         Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
     };
-    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{build_example_program_at_path, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -30,7 +32,7 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension)
                 .with_extension(Int256TranspilerExtension),
         )?;
-        air_test(Int256Rv32CpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Int256Rv32CpuBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/sha2/tests/lib.rs
+++ b/guest-libs/sha2/tests/lib.rs
@@ -8,7 +8,9 @@ mod tests {
     };
     use openvm_sha256_circuit::{Sha256Rv32Config, Sha256Rv32CpuBuilder};
     use openvm_sha256_transpiler::Sha256TranspilerExtension;
-    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+    use openvm_stark_sdk::{
+        config::baby_bear_poseidon2::BabyBearPoseidon2Engine, p3_baby_bear::BabyBear,
+    };
     use openvm_toolchain_tests::{build_example_program_at_path, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
 
@@ -27,7 +29,7 @@ mod tests {
                 .with_extension(Rv32IoTranspilerExtension)
                 .with_extension(Sha256TranspilerExtension),
         )?;
-        air_test(Sha256Rv32CpuBuilder, config, openvm_exe);
+        air_test::<BabyBearPoseidon2Engine, _, _>(Sha256Rv32CpuBuilder, config, openvm_exe);
         Ok(())
     }
 }


### PR DESCRIPTION
Makes `air_test` and `air_test_with_min_segments` generic over engine `E`. In preparation for CUDA integration migration.