### PR TITLE
fix(ci): remove `nvcc` from preinstall

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -17,4 +17,3 @@ runners:
     preinstall: |
       nvidia-smi
       nvidia-smi -L
-      nvcc --version


### PR DESCRIPTION
PATH var aren't set until runner is set up.