### PR TITLE
ci: fix merge queue concurrency

### DIFF
--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-benchmarks-execute-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-benchmarks-execute-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-benchmarks-execute-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       is_merge_queue:
-        description: 'Whether this is being called from merge queue'
+        description: "Whether this is being called from merge queue"
         required: false
         type: boolean
         default: false
@@ -43,7 +43,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-benchmarks-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-benchmarks-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,7 +43,7 @@ on:
         default: false
 
 concurrency:
-  group: benchmark-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-benchmarks-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-build-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-build-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-build-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-cli-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-cli-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-cli-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       packages: read
     concurrency:
-      group: ${{ github.workflow_ref }}-${{ github.ref }}
+      group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
       - runs-on=${{ github.run_id }}
       - runner=8cpu-linux-arm64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       packages: read
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow_ref }}-${{ github.ref }}
     runs-on:
       - runs-on=${{ github.run_id }}
       - runner=8cpu-linux-arm64

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/extension-tests.cuda.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/extension-tests.cuda.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/extension-tests.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-extension-tests-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-extension-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/extension-tests.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-extension-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -15,7 +15,7 @@ on:
       - "crates/sdk/guest/fib/**"
 
 concurrency:
-  group: ${{ github.workflow }}-guest-lib-tests-cuda-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-guest-lib-tests-cuda-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -15,7 +15,7 @@ on:
       - "crates/sdk/guest/fib/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-guest-lib-tests-cuda-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -15,7 +15,7 @@ on:
       - "crates/sdk/guest/fib/**"
 
 concurrency:
-  group: ${{ github.workflow }}-guest-lib-tests-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-guest-lib-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -15,7 +15,7 @@ on:
       - "crates/sdk/guest/fib/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-guest-lib-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-lints-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-lints-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-lints-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/merge-queue-controller.yml
+++ b/.github/workflows/merge-queue-controller.yml
@@ -114,12 +114,6 @@ jobs:
       is_merge_queue: true
     secrets: inherit
 
-  benchmarks-execute:
-    name: Benchmarks Execute
-    if: github.event_name == 'merge_group'
-    uses: ./.github/workflows/benchmarks-execute.yml
-    secrets: inherit
-
   # Final job that depends on all others - this is what GitHub will track
   all-checks-pass:
     name: All Checks Pass
@@ -142,7 +136,6 @@ jobs:
       - guest-lib-tests
       - guest-lib-tests-cuda
       - benchmarks
-      - benchmarks-execute
     if: always()
     steps:
       - name: Check job results for merge queue
@@ -157,7 +150,7 @@ jobs:
           else
             echo "All jobs passed successfully"
           fi
-      
+
       - name: PR status placeholder
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/native-compiler.yml
+++ b/.github/workflows/native-compiler.yml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/native-compiler.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-native-compiler-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-native-compiler-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/native-compiler.yml
+++ b/.github/workflows/native-compiler.yml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/native-compiler.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-native-compiler-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/primitives.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-primitives-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-primitives-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/primitives.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-primitives-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/recursion.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-recursion-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/recursion.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-recursion-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-recursion-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -15,7 +15,7 @@ on:
       - ".github/workflows/riscv.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-riscv-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -15,7 +15,7 @@ on:
       - ".github/workflows/riscv.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-riscv-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-riscv-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/sdk.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-sdk-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/sdk.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-sdk-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-sdk-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/vm.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-vm-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-vm-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/vm.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-vm-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
`github.workflow` refers to the caller's workflow name, so merge queue controller messes up all the concurrency of callee jobs.

context: https://stackoverflow.com/questions/79511940/using-workflow-filename-in-concurrency-group-for-workflows-started-by-workflow-c

if reviewers have better ideas how to handle merge queue with required status checks, I'm all ears