### PR TITLE
ci(runs-on): use single label syntax

### DIFF
--- a/.github/merge-queue.yml
+++ b/.github/merge-queue.yml
@@ -1,6 +1,0 @@
-# .github/merge-queue.yml
-queue_rules:
-  - name: default
-    conditions:
-      # Require all status checks to pass
-      - status-success~=.*

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -13,7 +13,8 @@ runners:
     image: ubuntu24-gpu-x64
     cpu: [4, 8, 16, 32]
     disk: default
-    spot: capacity-optimized
+    spot: false
+    extras: s3-cache
     preinstall: |
       nvidia-smi
       nvidia-smi -L

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -123,12 +123,7 @@ jobs:
   bench-new:
     name: Run benchmark on workflow ref/branch
     runs-on:
-      - runs-on=${{ github.run_id }}-bench-${{ inputs.benchmark_id ||  github.event.inputs.benchmark_name || inputs.benchmark_name }}-${{ github.run_number }}-${{ github.run_attempt }}
-      - family=${{ github.event.inputs.instance_type || inputs.instance_type }}
-      - image=${{ startsWith(github.event.inputs.instance_type || inputs.instance_type, 'g') && 'ubuntu24-gpu-x64' || contains(github.event.inputs.instance_type || inputs.instance_type, 'g.') && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}
-      - spot=${{ startsWith(github.event.inputs.instance_type || inputs.instance_type, 'g') && 'false' || 'capacity-optimized' }}
-      - tag=bench-${{ inputs.benchmark_id || github.event.inputs.benchmark_name || inputs.benchmark_name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-bench-${{ inputs.benchmark_id ||  github.event.inputs.benchmark_name || inputs.benchmark_name }}-${{ github.run_number }}-${{ github.run_attempt }}/family=${{ github.event.inputs.instance_type || inputs.instance_type }}/image=${{ startsWith(github.event.inputs.instance_type || inputs.instance_type, 'g') && 'ubuntu24-gpu-x64' || contains(github.event.inputs.instance_type || inputs.instance_type, 'g.') && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/spot=${{ startsWith(github.event.inputs.instance_type || inputs.instance_type, 'g') && 'false' || 'capacity-optimized' }}/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       ##########################################################################

--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -75,10 +75,7 @@ jobs:
   codspeed-instrumentation-benchmarks:
     name: Run codspeed instrumentation benchmarks
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - family=m5a.xlarge
-      - image=ubuntu24-full-x64
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=m5a.xlarge/image=ubuntu24-full-x64/extras=s3-cache
     if: github.event_name != 'pull_request'
 
     env:

--- a/.github/workflows/benchmarks-upload-fixtures.yml
+++ b/.github/workflows/benchmarks-upload-fixtures.yml
@@ -11,10 +11,7 @@ jobs:
   generate-fixtures:
     name: Generate and upload benchmark fixtures
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=64cpu-linux-arm64
-      - family=m7
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/runner=64cpu-linux-arm64/family=m7/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       is_merge_queue:
-        description: 'Whether this is being called from merge queue'
+        description: "Whether this is being called from merge queue"
         required: false
         type: boolean
         default: false
@@ -64,8 +64,7 @@ permissions:
 jobs:
   create-matrix:
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=8cpu-linux-x64
+      - runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,7 @@ jobs:
   lint:
     name: Build
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=64cpu-linux-arm64
-      - image=ubuntu24-full-arm64
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/runner=64cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -34,11 +34,7 @@ env:
 jobs:
   app-level-cli:
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - disk=large
-      - runner=64cpu-linux-arm64
-      - image=ubuntu24-full-arm64
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/disk=large/runner=64cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=8cpu-linux-arm64
+      - runs-on=${{ github.run_id }}/runner=64cpu-linux-arm64
     steps:
       - uses: actions/checkout@v5
       - name: Set up Rust toolchain

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -28,13 +28,7 @@ jobs:
           - "rv32im native"
           - "keccak256 sha256 bigint algebra ecc pairing"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - runner=test-gpu-nvidia
-      - image=ubuntu24-gpu-x64
-      - cpu=8+32 # more cores for faster compilation
-      - spot=false
-      - tag=extension-tests-cuda-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=test-gpu-nvidia/cpu=8+32/spot=false/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -39,11 +39,7 @@ jobs:
       fail-fast: false
 
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - runner=${{ matrix.platform.runner }}
-      - image=${{ matrix.platform.image }}
-      - tag=extension-${{ matrix.extension.name }}-${{ matrix.platform.runner }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -31,13 +31,7 @@ jobs:
           - { names: "ff_derive k256 p256 ruint", family: "g6+g5+g6e" }
           - { names: "pairing", family: "g6e" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - family=${{ matrix.crates.family }}
-      - image=ubuntu24-gpu-x64
-      - cpu=8+32
-      - spot=false
-      - tag=guest-lib-cuda-${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.crates.family }}/image=ubuntu24-gpu-x64/cpu=8+32/spot=false/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -41,11 +41,7 @@ jobs:
       fail-fast: false
 
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-tests-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - runner=${{ matrix.platform.runner }}
-      - image=${{ matrix.platform.image }}
-      - tag=guest-lib-${{ matrix.crate.name }}-${{ matrix.platform.runner }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -13,9 +13,7 @@ jobs:
   lint:
     name: Lint
     runs-on:
-      - runs-on=${{ github.run_id }}-cpu
-      - runner=64cpu-linux-x64
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-cpu/runner=64cpu-linux-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5

--- a/.github/workflows/merge-queue-controller.yml
+++ b/.github/workflows/merge-queue-controller.yml
@@ -124,8 +124,7 @@ jobs:
   all-checks-pass:
     name: All Checks Pass
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=8cpu-linux-x64
+      - runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
     needs:
       - lints
       - build
@@ -157,7 +156,7 @@ jobs:
           else
             echo "All jobs passed successfully"
           fi
-      
+
       - name: PR status placeholder
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/native-compiler.yml
+++ b/.github/workflows/native-compiler.yml
@@ -22,10 +22,7 @@ env:
 jobs:
   tests:
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=64cpu-linux-arm64
-      - image=ubuntu24-full-arm64
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/runner=64cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,8 +17,7 @@ jobs:
   conventional-title:
     name: Validate PR title is Conventional Commit
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=8cpu-linux-x64
+      - runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -29,10 +29,7 @@ jobs:
           - { runner: "test-gpu-nvidia", image: "ubuntu24-gpu-x64" }
 
     runs-on:
-      - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - runner=${{ matrix.platform.runner }}
-      - image=${{ matrix.platform.image }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -23,10 +23,7 @@ env:
 jobs:
   tests:
     runs-on:
-      - runs-on=${{ github.run_id }}-cpu
-      - runner=64cpu-linux-arm64
-      - image=ubuntu24-full-arm64
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-cpu/runner=64cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -31,12 +31,7 @@ jobs:
           - { runner: "test-gpu-nvidia", image: "ubuntu24-gpu-x64" }
 
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=${{ matrix.platform.runner }}
-      - image=${{ matrix.platform.image }}
-      - tag=riscv-${{ matrix.platform.runner }}
-      - spot=${{ contains(matrix.platform.runner, 'gpu') && 'false' || 'capacity-optimized' }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/spot=${{ contains(matrix.platform.runner, 'gpu') && 'false' || 'capacity-optimized' }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -23,11 +23,7 @@ env:
 jobs:
   tests:
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - family=m7a.24xlarge
-      - image=ubuntu24-full-x64
-      - disk=large
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=m7a.24xlarge/image=ubuntu24-full-x64/disk=large/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -13,10 +13,7 @@ on:
 jobs:
   verify-versioning:
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=64cpu-linux-arm64
-      - extras=s3-cache
-      - disk=large
+      - runs-on=${{ github.run_id }}/runner=64cpu-linux-arm64/extras=s3-cache/disk=large
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -27,10 +27,7 @@ jobs:
           - { runner: "test-gpu-nvidia", image: "ubuntu24-gpu-x64" }
 
     runs-on:
-      - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}-${{ strategy.job-index }}
-      - runner=${{ matrix.platform.runner }}
-      - image=${{ matrix.platform.image }}
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2


### PR DESCRIPTION
RunsOn recommends single label syntax now. Attempting to address runner stealing.