### PR TITLE
ci: remove merge-queue and consolidate CUDA base tests

### DIFF
--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -1,4 +1,5 @@
-name: VM STARK and Compiler Tests
+name: Base Tests (CUDA)
+# Consolidate non-extension tests to use fewer CUDA runners
 
 on:
   workflow_call:
@@ -9,11 +10,14 @@ on:
     paths:
       - "crates/circuits/**"
       - "crates/vm/**"
+      - "extensions/native/compiler/**"
+      - "extensions/native/recursion/**"
       - "Cargo.toml"
+      - ".github/workflows/recursion.yml"
       - ".github/workflows/vm.yml"
 
 concurrency:
-  group: ${{ github.workflow_ref }}-vm-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow_ref }}-base-tests-cuda-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -21,14 +25,9 @@ env:
   OPENVM_FAST_TEST: "1"
 
 jobs:
-  tests:
-    strategy:
-      matrix:
-        platform:
-          - { runner: "64cpu-linux-arm64", image: "ubuntu24-full-arm64" }
-
+  tests-cuda:
     runs-on:
-      - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/runner=test-gpu-nvidia
 
     steps:
       - uses: runs-on/action@v2
@@ -42,24 +41,27 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
 
-      - name: Set CPU tests environment variables
-        if: ${{ !contains(matrix.platform.runner, 'gpu') }}
-        run: |
-          echo "NEXTEST_ARGS=--cargo-profile fast --features parallel" >> $GITHUB_ENV
-
       - name: Check CUDA status and set environment variables
-        if: contains(matrix.platform.runner, 'gpu')
         run: |
           nvcc --version
           echo "NEXTEST_ARGS=cuda --features parallel,cuda,touchemall" >> $GITHUB_ENV
+
+      - name: Run tests for primitives
+        working-directory: crates/circuits/primitives
+        run: |
+          cargo nextest run ${{ env.NEXTEST_ARGS }}
+
+      - name: Run tests for poseidon2-air
+        working-directory: crates/circuits/poseidon2-air
+        run: |
+          cargo nextest run ${{ env.NEXTEST_ARGS }}
 
       - name: Run vm crate tests
         working-directory: crates/vm
         run: |
           cargo nextest run ${{ env.NEXTEST_ARGS }}
 
-      - name: Run vm crate tests with basic memory
-        if: ${{ !contains(matrix.platform.runner, 'gpu') }}
-        working-directory: crates/vm
+      - name: Run recursion crate tests
+        working-directory: extensions/native/recursion
         run: |
-          cargo nextest run --cargo-profile=fast --features parallel,basic-memory
+          cargo nextest run --features cuda

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -13,8 +13,7 @@ on:
       - "extensions/native/compiler/**"
       - "extensions/native/recursion/**"
       - "Cargo.toml"
-      - ".github/workflows/recursion.yml"
-      - ".github/workflows/vm.yml"
+      - ".github/workflows/base-tests.cuda.yml"
 
 concurrency:
   group: ${{ github.workflow_ref }}-base-tests-cuda-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -2,6 +2,8 @@ name: "Execution benchmarks"
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches: ["**"]

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,17 +9,22 @@ on:
         type: boolean
         default: false
   push:
-    branches: ["feat/new-execution"]
+    branches: ["main"]
+    paths:
+      - "benchmarks/prove/**"
+      - "benchmarks/guest/**"
+      - "crates/**"
+      - "extensions/**"
+      - ".github/workflows/benchmark-call.yml"
+      - ".github/workflows/benchmarks.yml"
+      - "Cargo.toml"
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches: ["**"]
     paths:
       - "benchmarks/prove/**"
-      - "crates/circuits/**"
-      - "crates/toolchain/**"
-      - "crates/prof/**"
-      - "crates/sdk/**"
-      - "crates/vm/**"
+      - "benchmarks/guest/**"
+      - "crates/**"
       - "extensions/**"
       - ".github/workflows/benchmark-call.yml"
       - ".github/workflows/benchmarks.yml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build Workspace
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
   workflow_call:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -2,6 +2,7 @@ name: OpenVM CLI Tests
 
 on:
   push:
+    branches: ["main"]
     tags: ["v*"]
   pull_request:
     branches: ["**"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Build and Serve Crate Docs
 on:
   workflow_call:
   push:
+    branches: ["main"]
     tags:
       - v*.*.*
   pull_request:

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -2,6 +2,8 @@ name: Extension Tests (CUDA)
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -2,6 +2,8 @@ name: Extension Tests
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -2,6 +2,8 @@ name: Guest Library Tests (CUDA)
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -2,6 +2,8 @@ name: Guest Library Tests
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,6 +1,8 @@
 name: Lint Workspace
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
   workflow_call:

--- a/.github/workflows/merge-queue-controller.yml
+++ b/.github/workflows/merge-queue-controller.yml
@@ -2,7 +2,7 @@ name: Merge Queue Controller
 
 on:
   # NOTE[jpw]: this workflow is currently disabled and not meant to be used
-  workflow_dispatch
+  workflow_dispatch:
   # merge_group:
   # pull_request:
   #   types: [opened, synchronize, reopened]

--- a/.github/workflows/merge-queue-controller.yml
+++ b/.github/workflows/merge-queue-controller.yml
@@ -1,9 +1,11 @@
 name: Merge Queue Controller
 
 on:
-  merge_group:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # NOTE[jpw]: this workflow is currently disabled and not meant to be used
+  workflow_dispatch
+  # merge_group:
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 permissions:
   contents: write

--- a/.github/workflows/native-compiler.yml
+++ b/.github/workflows/native-compiler.yml
@@ -2,6 +2,8 @@ name: Native Compiler Tests
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -2,6 +2,8 @@ name: Primitives Tests
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:
@@ -26,7 +28,6 @@ jobs:
       matrix:
         platform:
           - { runner: "64cpu-linux-arm64", image: "ubuntu24-full-arm64" }
-          - { runner: "test-gpu-nvidia", image: "ubuntu24-gpu-x64" }
 
     runs-on:
       - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -2,6 +2,8 @@ name: STARK Recursion Tests
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:
@@ -45,27 +47,3 @@ jobs:
         working-directory: crates/continuations
         run: |
           cargo nextest run --no-tests=pass
-
-  tests-cuda:
-    runs-on:
-      - runs-on=${{ github.run_id }}-cuda
-      - runner=test-gpu-nvidia
-      - image=ubuntu24-gpu-x64
-      - extras=s3-cache
-
-    steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
-      - run: | # avoid cross-device link error
-          rustup component remove clippy || true
-          rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - uses: taiki-e/install-action@nextest
-
-      - name: Run recursion crate tests
-        working-directory: extensions/native/recursion
-        run: |
-          cargo nextest run --features cuda

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -2,6 +2,8 @@ name: RISC-V Test Vectors
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -2,6 +2,8 @@ name: OpenVM SDK Tests
 
 on:
   workflow_call:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:


### PR DESCRIPTION
The merge queue is unstable and blocking PR merges due to not all jobs completing from workflow API flakiness or runner flakiness.

We will go back to merging to main and running workflows on push to main for now.

Additionally, I consolidated the primitives, vm, recursion CUDA tests to one runner to save some runners (and possibly compile time).