### PR TITLE
ci: use spot gpu runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -13,7 +13,7 @@ runners:
     image: ubuntu24-gpu-x64
     cpu: [4, 8, 16, 32]
     disk: default
-    spot: false
+    spot: capacity-optimized
     extras: s3-cache
     preinstall: |
       nvidia-smi

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -128,7 +128,7 @@ jobs:
   bench-new:
     name: Run benchmark on workflow ref/branch
     runs-on:
-      - runs-on=${{ github.run_id }}-benchcall-${{ github.run_attempt }}-${{ inputs.job_index || inputs.benchmark_id || inputs.benchmark_name || github.event.inputs.benchmark_name }}/family=${{ inputs.instance_type || github.event.inputs.instance_type }}/image=${{ startsWith(inputs.instance_type || github.event.inputs.instance_type, 'g') && 'ubuntu24-gpu-x64' || contains(inputs.instance_type || github.event.inputs.instance_type, 'g.') && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/spot=false/extras=s3-cache
+      - runs-on=${{ github.run_id }}-benchcall-${{ github.run_attempt }}-${{ inputs.job_index || inputs.benchmark_id || inputs.benchmark_name || github.event.inputs.benchmark_name }}/family=${{ inputs.instance_type || github.event.inputs.instance_type }}/image=${{ startsWith(inputs.instance_type || github.event.inputs.instance_type, 'g') && 'ubuntu24-gpu-x64' || contains(inputs.instance_type || github.event.inputs.instance_type, 'g.') && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       ##########################################################################

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -30,7 +30,7 @@ jobs:
           - "rv32im native"
           - "keccak256 sha256 bigint algebra ecc pairing"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=test-gpu-nvidia/cpu=8+32/spot=false/extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=test-gpu-nvidia/cpu=8+32
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -33,7 +33,7 @@ jobs:
           - { names: "ff_derive k256 p256 ruint", family: "g6+g5+g6e" }
           - { names: "pairing", family: "g6e" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.crates.family }}/image=ubuntu24-gpu-x64/cpu=8+32/spot=false/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.crates.family }}/image=ubuntu24-gpu-x64/cpu=8+32/spot=capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -89,12 +89,7 @@ jobs:
   lint-cuda:
     name: Lint CUDA
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda
-      - runner=test-gpu-nvidia
-      - image=ubuntu24-gpu-x64
-      - spot=false
-      - extras=s3-cache
-
+      - runs-on=${{ github.run_id }}-cuda/runner=test-gpu-nvidia
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5


### PR DESCRIPTION
switching back to spot runners because our vCPU quota is higher for spot than on-demand