### PR TITLE
fix: explicit panic on oob memory access

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -46,6 +46,7 @@ evm-prove = ["openvm-sdk/evm-prove"]
 evm-verify = ["evm-prove", "openvm-sdk/evm-verify"]
 metrics = ["openvm-sdk/metrics"]
 tco = ["openvm-sdk/tco"]
+unprotected = ["openvm-sdk/unprotected"]
 # for guest profiling:
 perf-metrics = ["openvm-sdk/perf-metrics", "metrics"]
 # performance features:

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -90,10 +90,14 @@ tco = [
     "openvm-bigint-circuit/tco",
     "openvm-algebra-circuit/tco",
     "openvm-ecc-circuit/tco",
-    "openvm-pairing-circuit/tco"
+    "openvm-pairing-circuit/tco",
 ]
+unprotected = ["openvm-circuit/unprotected"]
 # for guest profiling:
-perf-metrics = ["openvm-circuit/perf-metrics", "openvm-transpiler/function-span"]
+perf-metrics = [
+    "openvm-circuit/perf-metrics",
+    "openvm-transpiler/function-span",
+]
 # turns on stark-backend debugger in all proofs
 stark-debug = ["openvm-circuit/stark-debug"]
 test-utils = ["openvm-circuit/test-utils"]

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -80,6 +80,8 @@ test-utils = ["dep:openvm-stark-sdk"]
 # Tail call optimizations. This requires nightly for the `become` keyword (https://github.com/rust-lang/rust/pull/144232).
 # However tail call elimination is still an incomplete feature in Rust, so the `tco` feature remains experimental until then.
 tco = ["openvm-circuit-derive/tco"]
+# Disable bounds checking in memory operations for performance
+unprotected = []
 # performance features:
 mimalloc = ["openvm-stark-backend/mimalloc"]
 jemalloc = ["openvm-stark-backend/jemalloc"]
@@ -98,4 +100,3 @@ touchemall = [
     "openvm-cuda-backend/touchemall",
     "openvm-cuda-common/touchemall",
 ]
-unprotected = []

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -86,7 +86,7 @@ jemalloc = ["openvm-stark-backend/jemalloc"]
 jemalloc-prof = ["openvm-stark-backend/jemalloc-prof"]
 nightly-features = ["openvm-stark-sdk?/nightly-features"]
 cuda = [
-    "dep:openvm-stark-sdk", # for BabyBearPoseidon2Config
+    "dep:openvm-stark-sdk",           # for BabyBearPoseidon2Config
     "openvm-circuit-primitives/cuda",
     "dep:openvm-cuda-common",
     "dep:openvm-cuda-backend",
@@ -98,3 +98,4 @@ touchemall = [
     "openvm-cuda-backend/touchemall",
     "openvm-cuda-common/touchemall",
 ]
+unprotected = []

--- a/crates/vm/src/arch/execution_mode/metered_cost.rs
+++ b/crates/vm/src/arch/execution_mode/metered_cost.rs
@@ -85,14 +85,12 @@ impl MeteredCostCtx {
     }
 
     #[cold]
-    fn check_cost_limit(&self) {
-        if self.cost > 2 * std::cmp::max(self.max_execution_cost, DEFAULT_MAX_COST) {
-            panic!(
-                "Execution cost {} exceeded maximum allowed cost of {}",
-                self.cost,
-                2 * DEFAULT_MAX_COST
-            );
-        }
+    fn panic_cost_exceeded(&self) -> ! {
+        panic!(
+            "Execution cost {} exceeded maximum allowed cost of {}",
+            self.cost,
+            2 * DEFAULT_MAX_COST
+        );
     }
 }
 
@@ -110,7 +108,9 @@ impl ExecutionCtxTrait for MeteredCostCtx {
             size
         );
         // Prevent unbounded memory accesses per instruction
-        self.check_cost_limit();
+        if self.cost > 2 * std::cmp::max(self.max_execution_cost, DEFAULT_MAX_COST) {
+            self.panic_cost_exceeded();
+        }
 
         // Handle access adapter updates
         // SAFETY: size passed is always a non-zero power of 2


### PR DESCRIPTION
- add bounds checking for memory access in memmap unless `unprotected` feature is enabled (disabled by default)

[comparison benchmark](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17308694277)