### PR TITLE
chore: remove `openvm::entry!(main)` from examples

### DIFF
--- a/examples/algebra/src/main.rs
+++ b/examples/algebra/src/main.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
 
+use openvm;
 use openvm_algebra_guest::{moduli_macros::*, IntMod};
 
 // This macro will create two structs, `Mod1` and `Mod2`,

--- a/examples/ecc/src/main.rs
+++ b/examples/ecc/src/main.rs
@@ -1,5 +1,6 @@
 // [!region imports]
 use hex_literal::hex;
+use openvm;
 use openvm_algebra_guest::IntMod;
 use openvm_ecc_guest::weierstrass::WeierstrassPoint;
 use openvm_k256::{Secp256k1Coord, Secp256k1Point};

--- a/examples/i256/src/main.rs
+++ b/examples/i256/src/main.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::needless_range_loop)]
-openvm::entry!(main);
+
+use openvm;
 
 use core::array;
 
 use alloy_primitives::I256;
-
-openvm::entry!(main);
 
 const N: usize = 16;
 type Matrix = [[I256; N]; N];

--- a/examples/keccak/src/main.rs
+++ b/examples/keccak/src/main.rs
@@ -1,15 +1,12 @@
-openvm::entry!(main);
-
 // [!region imports]
 use core::hint::black_box;
+use openvm;
 
 use hex::FromHex;
 use openvm_keccak256::keccak256;
 // [!endregion imports]
 
 // [!region main]
-openvm::entry!(main);
-
 pub fn main() {
     let test_vectors = [
         (

--- a/examples/pairing/src/main.rs
+++ b/examples/pairing/src/main.rs
@@ -2,6 +2,7 @@
 use hex_literal::hex;
 // [!endregion pre]
 // [!region imports]
+use openvm;
 use openvm_algebra_guest::{field::FieldExtension, IntMod};
 use openvm_ecc_guest::AffinePoint;
 use openvm_pairing::{

--- a/examples/sha256/src/main.rs
+++ b/examples/sha256/src/main.rs
@@ -1,15 +1,12 @@
-openvm::entry!(main);
-
 // [!region imports]
 use core::hint::black_box;
 
 use hex::FromHex;
+use openvm;
 use openvm_sha2::sha256;
 // [!endregion imports]
 
 // [!region main]
-openvm::entry!(main);
-
 pub fn main() {
     let test_vectors = [(
         "",

--- a/examples/u256/src/main.rs
+++ b/examples/u256/src/main.rs
@@ -1,11 +1,9 @@
 #![allow(clippy::needless_range_loop)]
-openvm::entry!(main);
 
 use core::array;
 
+use openvm;
 use openvm_ruint::aliases::U256;
-
-openvm::entry!(main);
 
 const N: usize = 16;
 type Matrix = [[U256; N]; N];


### PR DESCRIPTION
Also I added `use openvm` just in case because we say:

> If you write a program that only imports openvm in Cargo.toml but does not import it anywhere in your crate, the Rust linker may optimize away the dependency, which will cause a compile error. To fix this, you may need to explicitly import the openvm crate in your code.