### PR TITLE
fix: 404 links in docs

### DIFF
--- a/crates/circuits/mod-builder/src/README.md
+++ b/crates/circuits/mod-builder/src/README.md
@@ -179,6 +179,6 @@ See the [examples section](#examples) for code examples to follow along with.
 
 See these examples in the elliptic curve extension code:
 
-- [Short Weierstrass Addition Chip](https://github.com/openvm-org/openvm/blob/main/extensions/ecc/circuit/src/weierstrass_chip/add_ne.rs)
-- [Short Weierstrass Double Chip](https://github.com/openvm-org/openvm/blob/main/extensions/ecc/circuit/src/weierstrass_chip/double.rs)
+- [Short Weierstrass Addition Chip](https://github.com/openvm-org/openvm/blob/main/extensions/ecc/circuit/src/weierstrass_chip/add_ne/mod.rs)
+- [Short Weierstrass Double Chip](https://github.com/openvm-org/openvm/blob/main/extensions/ecc/circuit/src/weierstrass_chip/double/mod.rs)
 

--- a/docs/vocs/docs/pages/specs/security/audits.mdx
+++ b/docs/vocs/docs/pages/specs/security/audits.mdx
@@ -8,7 +8,7 @@ as outlined below.
 |---------------|------------|---------------|--------|
 | v1.0.0 | Internal | [Axiom](https://axiom.xyz) | [v1-internal](https://github.com/openvm-org/openvm/tree/main/audits/v1-internal) |
 | v1.0.0 | External | [Cantina](https://cantina.xyz) | [v1-cantina](https://github.com/openvm-org/openvm/blob/main/audits/v1-cantina-report.pdf) |
-| v1.1.0 | External | [Cantina](https://cantina.xyz) | [v1.1.0-cantina](https://github.com/openvm-org/openvm/blob/main/audits/v1.1.0-cantina-fix-report.pdf) |
+| v1.1.0 | External | [Cantina](https://cantina.xyz) | [v1.1.0-cantina](https://github.com/openvm-org/openvm/blob/main/audits/v1.1.0-cantina-fix-review.pdf) |
 | v1.1.1 | External | [Cantina](https://cantina.xyz) | [v1.1.1-cantina](https://github.com/openvm-org/openvm/blob/main/audits/v1.1.1-cantina-report.pdf) |
 | v1.3.0 | External | [Cantina](https://cantina.xyz) | [v1.3.0-cantina](https://github.com/openvm-org/openvm/blob/main/audits/v1.3.0-cantina-report.pdf) |
 | v1.4.0 | External | [Cantina](https://cantina.xyz) | [v1.4.0-cantina](https://github.com/openvm-org/openvm/blob/main/audits/v1.4.0-cantina-report.pdf) |


### PR DESCRIPTION
Hi! Fixed a couple of broken links in the docs — one in the audits section and another in the mod-builder README.