### PR TITLE
fix: JSON I/O helpers to use explicit open/create and serde with proper error mapping

### DIFF
--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -122,9 +122,8 @@ fn write_to_file_bitcode<T: Serialize, P: AsRef<Path>>(path: P, data: T) -> Resu
 }
 
 pub fn read_from_file_json<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
-    let ret: T = File::open(&path)
-        .and_then(|file| serde_json::from_reader(file).map_err(|e| e.into()))
-        .map_err(|e| read_error(&path, e.into()))?;
+    let file = File::open(&path).map_err(|e| read_error(&path, e.into()))?;
+    let ret: T = serde_json::from_reader(file).map_err(|e| read_error(&path, e.into()))?;
     Ok(ret)
 }
 
@@ -132,9 +131,8 @@ pub fn write_to_file_json<T: Serialize, P: AsRef<Path>>(path: P, data: T) -> Res
     if let Some(parent) = path.as_ref().parent() {
         create_dir_all(parent).map_err(|e| write_error(&path, e.into()))?;
     }
-    File::create(&path)
-        .and_then(|file| serde_json::to_writer_pretty(file, &data).map_err(|e| e.into()))
-        .map_err(|e| write_error(&path, e.into()))?;
+    let file = File::create(&path).map_err(|e| write_error(&path, e.into()))?;
+    serde_json::to_writer_pretty(file, &data).map_err(|e| write_error(&path, e.into()))?;
     Ok(())
 }
 


### PR DESCRIPTION
Replace chaining with and_then in read_from_file_json/write_to_file_json by splitting into two steps: open/create the file and call serde_json::{from_reader,to_writer_pretty}.
Map both IO and serde_json errors through read_error/write_error for consistent eyre::Report messages.
This change is necessary because serde_json::Error does not convert into std::io::Error, making the previous and_then + map_err(|e| e.into()) approach incorrect and potentially non-compiling. It also aligns error handling style with the rest of the codebase.