### PR TITLE
fix: take program air height into account in metered execution

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -16,9 +16,7 @@ use openvm_bigint_circuit::{Int256, Int256CpuProverExt, Int256Executor};
 use openvm_bigint_transpiler::Int256TranspilerExtension;
 use openvm_circuit::{
     arch::{
-        execution_mode::{MeteredCostCtx, MeteredCtx},
-        instructions::exe::VmExe,
-        interpreter::InterpretedInstance,
+        execution_mode::MeteredCostCtx, instructions::exe::VmExe, interpreter::InterpretedInstance,
         ContinuationVmProof, *,
     },
     derive::VmConfig,
@@ -86,7 +84,6 @@ const APP_PROGRAMS: &[&str] = &[
 const LEAF_VERIFIER_PROGRAMS: &[&str] = &["kitchen-sink"];
 const INTERNAL_VERIFIER_PROGRAMS: &[&str] = &["fibonacci"];
 
-static METERED_CTX: OnceLock<(MeteredCtx, Vec<usize>)> = OnceLock::new();
 static METERED_COST_CTX: OnceLock<(MeteredCostCtx, Vec<usize>)> = OnceLock::new();
 static EXECUTOR: OnceLock<VmExecutor<BabyBear, ExecuteConfig>> = OnceLock::new();
 
@@ -231,17 +228,6 @@ fn load_program_executable(program: &str) -> Result<VmExe<BabyBear>> {
     Ok(VmExe::from_elf(elf, transpiler)?)
 }
 
-fn metering_setup() -> &'static (MeteredCtx, Vec<usize>) {
-    METERED_CTX.get_or_init(|| {
-        let config = ExecuteConfig::default();
-        let engine = BabyBearPoseidon2Engine::new(FriParameters::standard_fast());
-        let (vm, _) = VirtualMachine::new_with_keygen(engine, ExecuteBuilder, config).unwrap();
-        let ctx = vm.build_metered_ctx();
-        let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
-        (ctx, executor_idx_to_air_idx)
-    })
-}
-
 fn metered_cost_setup() -> &'static (MeteredCostCtx, Vec<usize>) {
     METERED_COST_CTX.get_or_init(|| {
         let config = ExecuteConfig::default();
@@ -280,9 +266,14 @@ fn benchmark_execute_metered(bencher: Bencher, program: &str) {
     bencher
         .with_inputs(|| {
             let exe = load_program_executable(program).expect("Failed to load program executable");
-            let (ctx, executor_idx_to_air_idx) = metering_setup();
+            let config = ExecuteConfig::default();
+            let engine = BabyBearPoseidon2Engine::new(FriParameters::standard_fast());
+            let (vm, _) = VirtualMachine::new_with_keygen(engine, ExecuteBuilder, config).unwrap();
+            let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
+
+            let ctx = vm.build_metered_ctx(&exe);
             let interpreter = executor()
-                .metered_instance(&exe, executor_idx_to_air_idx)
+                .metered_instance(&exe, &executor_idx_to_air_idx)
                 .unwrap();
             (interpreter, vec![], ctx.clone())
         })
@@ -403,7 +394,7 @@ fn benchmark_leaf_verifier_execute_metered(bencher: Bencher, program: &str) {
     bencher
         .with_inputs(|| {
             let (vm, leaf_exe, input_stream) = setup_leaf_verifier(program);
-            let ctx = vm.build_metered_ctx();
+            let ctx = vm.build_metered_ctx(&leaf_exe);
             let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
             let interpreter = vm
                 .executor()
@@ -459,7 +450,7 @@ fn benchmark_internal_verifier_execute_metered(bencher: Bencher, program: &str) 
     bencher
         .with_inputs(|| {
             let (vm, internal_exe, input_stream) = setup_internal_verifier(program);
-            let ctx = vm.build_metered_ctx();
+            let ctx = vm.build_metered_ctx(&internal_exe);
             let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
             let interpreter = vm
                 .executor()

--- a/benchmarks/execute/src/execute-verifier.rs
+++ b/benchmarks/execute/src/execute-verifier.rs
@@ -332,7 +332,7 @@ fn execute_verifier(
         }
         ExecutionMode::Metered => {
             tracing::info!("Running metered execute...");
-            let ctx = vm.build_metered_ctx();
+            let ctx = vm.build_metered_ctx(exe);
             let interpreter = vm.metered_interpreter(exe)?;
             interpreter.execute_metered(input_stream, ctx)?;
         }

--- a/benchmarks/prove/src/bin/kitchen_sink.rs
+++ b/benchmarks/prove/src/bin/kitchen_sink.rs
@@ -31,7 +31,7 @@ fn verify_native_max_trace_heights(
     for leaf_input in leaf_inputs {
         let exe = leaf_prover.exe().clone();
         let vm = &mut leaf_prover.vm;
-        let metered_ctx = vm.build_metered_ctx();
+        let metered_ctx = vm.build_metered_ctx(&exe);
         let (segments, _) = vm
             .metered_interpreter(&exe)?
             .execute_metered(leaf_input.write_to_stream(), metered_ctx)?;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -375,7 +375,7 @@ where
         let vm = app_prover.vm();
         let exe = app_prover.exe();
 
-        let ctx = vm.build_metered_ctx();
+        let ctx = vm.build_metered_ctx(&exe);
         let interpreter = vm
             .metered_interpreter(&exe)
             .map_err(VirtualMachineError::from)?;

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -1,5 +1,6 @@
 use std::num::NonZero;
 
+use itertools::Itertools;
 use openvm_instructions::riscv::{RV32_IMM_AS, RV32_REGISTER_AS};
 
 use super::{
@@ -152,17 +153,20 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
     }
 
     #[allow(dead_code)]
-    pub fn print_heights(&self) {
-        println!("{:>10} {:<30}", "Height", "Air Name");
-        println!("{}", "-".repeat(42));
-        for (i, height) in self.trace_heights.iter().enumerate() {
-            let air_name = self
-                .segmentation_ctx
-                .air_names
-                .get(i)
-                .map(|s| s.as_str())
-                .unwrap_or("Unknown");
-            println!("{:>10} {:<30}", height, air_name);
+    pub fn print_segment(&self) {
+        println!("{}", "-".repeat(80));
+        println!("Segment {}", self.segmentation_ctx.segments.len() - 1);
+        println!("{}", "-".repeat(80));
+        println!("{:>10} {:>10} {:<30}", "Width", "Height", "Air Name");
+        println!("{}", "-".repeat(80));
+        for ((&width, &height), air_name) in self
+            .segmentation_ctx
+            .widths
+            .iter()
+            .zip_eq(self.trace_heights.iter())
+            .zip_eq(self.segmentation_ctx.air_names.iter())
+        {
+            println!("{:>10} {:>10} {:<30}", width, height, air_name.as_str());
         }
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -40,7 +40,7 @@ impl Default for SegmentationLimits {
 pub struct SegmentationCtx {
     pub segments: Vec<Segment>,
     pub(crate) air_names: Vec<String>,
-    widths: Vec<usize>,
+    pub(crate) widths: Vec<usize>,
     interactions: Vec<usize>,
     pub(crate) segmentation_limits: SegmentationLimits,
     pub instret_last_segment_check: u64,
@@ -152,13 +152,13 @@ impl SegmentationCtx {
             return false;
         }
 
-        for (i, (height, is_constant)) in trace_heights
+        for (i, (&height, is_constant)) in trace_heights
             .iter()
             .zip(is_trace_height_constant.iter())
             .enumerate()
         {
             // Only segment if the height is not constant and exceeds the maximum height
-            if !is_constant && *height > self.segmentation_limits.max_trace_height {
+            if !is_constant && height > self.segmentation_limits.max_trace_height {
                 let air_name = &self.air_names[i];
                 tracing::info!(
                     "Segment {:2} | instret {:9} | chip {} ({}) height ({:8}) > max ({:8})",

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -114,7 +114,7 @@ where
     let vk = pk.get_vk();
     let exe = exe.into();
     let input = input.into();
-    let metered_ctx = vm.build_metered_ctx();
+    let metered_ctx = vm.build_metered_ctx(&exe);
     let (segments, _) = vm
         .metered_interpreter(&exe)?
         .execute_metered(input.clone(), metered_ctx)?;

--- a/extensions/native/circuit/src/utils.rs
+++ b/extensions/native/circuit/src/utils.rs
@@ -97,9 +97,9 @@ pub mod test_utils {
         let input = input_stream.into();
 
         let engine = E::new(FriParameters::new_for_testing(1));
-        let (vm, _) = VirtualMachine::new_with_keygen(engine, builder, config)?;
-        let ctx = vm.build_metered_ctx();
         let exe = VmExe::new(program);
+        let (vm, _) = VirtualMachine::new_with_keygen(engine, builder, config)?;
+        let ctx = vm.build_metered_ctx(&exe);
         let (mut segments, _) = vm
             .metered_interpreter(&exe)?
             .execute_metered(input.clone(), ctx)?;

--- a/extensions/native/circuit/tests/integration_test.rs
+++ b/extensions/native/circuit/tests/integration_test.rs
@@ -919,7 +919,7 @@ fn test_single_segment_executor_no_segmentation() {
 
     let exe = VmExe::new(Program::from_instructions(&instructions));
     let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
-    let metered_ctx = vm.build_metered_ctx();
+    let metered_ctx = vm.build_metered_ctx(&exe);
     vm.executor()
         .metered_instance(&exe, &executor_idx_to_air_idx)
         .unwrap()


### PR DESCRIPTION
- add `ProgramAir` height as a constant trace height in metered execution