### PR TITLE
fix: ensure segments are below thresholds

### DIFF
--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -116,11 +116,6 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     fn reset_segment(&mut self) {
         self.memory_ctx.clear();
-        for (i, &is_constant) in self.is_trace_height_constant.iter().enumerate() {
-            if !is_constant {
-                self.trace_heights[i] = 0;
-            }
-        }
         // Add merkle height contributions for all registers
         self.memory_ctx.add_register_merkle_heights();
     }
@@ -143,7 +138,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
             .lazy_update_boundary_heights(&mut self.trace_heights);
         let did_segment = self.segmentation_ctx.check_and_segment(
             instret,
-            &self.trace_heights,
+            &mut self.trace_heights,
             &self.is_trace_height_constant,
         );
 

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -46,6 +46,10 @@ pub struct SegmentationCtx {
     pub instret_last_segment_check: u64,
     #[getset(set_with = "pub")]
     pub segment_check_insns: u64,
+    /// Checkpoint of trace heights at last known state where all thresholds satisfied
+    pub(crate) checkpoint_trace_heights: Vec<u32>,
+    /// Instruction count at the checkpoint
+    checkpoint_instret: u64,
 }
 
 impl SegmentationCtx {
@@ -58,6 +62,7 @@ impl SegmentationCtx {
         assert_eq!(air_names.len(), widths.len());
         assert_eq!(air_names.len(), interactions.len());
 
+        let num_airs = air_names.len();
         Self {
             segments: Vec::new(),
             air_names,
@@ -66,6 +71,8 @@ impl SegmentationCtx {
             segmentation_limits,
             segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
             instret_last_segment_check: 0,
+            checkpoint_trace_heights: vec![0; num_airs],
+            checkpoint_instret: 0,
         }
     }
 
@@ -77,6 +84,7 @@ impl SegmentationCtx {
         assert_eq!(air_names.len(), widths.len());
         assert_eq!(air_names.len(), interactions.len());
 
+        let num_airs = air_names.len();
         Self {
             segments: Vec::new(),
             air_names,
@@ -85,6 +93,8 @@ impl SegmentationCtx {
             segmentation_limits: SegmentationLimits::default(),
             segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
             instret_last_segment_check: 0,
+            checkpoint_trace_heights: vec![0; num_airs],
+            checkpoint_instret: 0,
         }
     }
 
@@ -159,7 +169,7 @@ impl SegmentationCtx {
         {
             // Only segment if the height is not constant and exceeds the maximum height
             if !is_constant && height > self.segmentation_limits.max_trace_height {
-                let air_name = &self.air_names[i];
+                let air_name = unsafe { self.air_names.get_unchecked(i) };
                 tracing::info!(
                     "Segment {:2} | instret {:9} | chip {} ({}) height ({:8}) > max ({:8})",
                     self.segments.len(),
@@ -204,16 +214,78 @@ impl SegmentationCtx {
     pub fn check_and_segment(
         &mut self,
         instret: u64,
-        trace_heights: &[u32],
+        trace_heights: &mut [u32],
         is_trace_height_constant: &[bool],
     ) -> bool {
-        let ret = self.should_segment(instret, trace_heights, is_trace_height_constant);
-        if ret {
-            self.segment(instret, trace_heights);
-        }
-        self.instret_last_segment_check = instret;
+        let should_seg = self.should_segment(instret, trace_heights, is_trace_height_constant);
 
-        ret
+        if should_seg {
+            self.create_segment_from_checkpoint(instret, trace_heights, is_trace_height_constant);
+        } else {
+            self.update_checkpoint(instret, trace_heights);
+        }
+
+        self.instret_last_segment_check = instret;
+        should_seg
+    }
+
+    #[inline(always)]
+    fn create_segment_from_checkpoint(
+        &mut self,
+        instret: u64,
+        trace_heights: &mut [u32],
+        is_trace_height_constant: &[bool],
+    ) {
+        let instret_start = self
+            .segments
+            .last()
+            .map_or(0, |s| s.instret_start + s.num_insns);
+
+        let (segment_instret, segment_heights) = if self.checkpoint_instret > instret_start {
+            (
+                self.checkpoint_instret,
+                self.checkpoint_trace_heights.clone(),
+            )
+        } else {
+            // No valid checkpoint, use current values
+            (instret, trace_heights.to_vec())
+        };
+
+        // Reset current trace heights and checkpoint
+        self.reset_trace_heights(trace_heights, &segment_heights, is_trace_height_constant);
+        self.checkpoint_instret = 0;
+
+        self.segments.push(Segment {
+            instret_start,
+            num_insns: segment_instret - instret_start,
+            trace_heights: segment_heights,
+        });
+    }
+
+    /// Resets trace heights by subtracting segment heights
+    #[inline(always)]
+    fn reset_trace_heights(
+        &self,
+        trace_heights: &mut [u32],
+        segment_heights: &[u32],
+        is_trace_height_constant: &[bool],
+    ) {
+        for ((trace_height, &segment_height), &is_trace_height_constant) in trace_heights
+            .iter_mut()
+            .zip(segment_heights.iter())
+            .zip(is_trace_height_constant.iter())
+        {
+            if !is_trace_height_constant {
+                *trace_height -= segment_height;
+            }
+        }
+    }
+
+    /// Updates the checkpoint with current safe state
+    #[inline(always)]
+    fn update_checkpoint(&mut self, instret: u64, trace_heights: &[u32]) {
+        self.checkpoint_trace_heights.copy_from_slice(trace_heights);
+        self.checkpoint_instret = instret;
     }
 
     /// Try segment if there is at least one cycle

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -260,7 +260,7 @@ impl SegmentationCtx {
             .zip(is_trace_height_constant.iter())
         {
             if !is_trace_height_constant {
-                *trace_height -= segment_height;
+                *trace_height = trace_height.checked_sub(segment_height).unwrap();
             }
         }
     }

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -162,7 +162,11 @@ impl SegmentationCtx {
             return false;
         }
 
-        for (i, (&height, is_constant)) in trace_heights
+        let padded_height = trace_heights
+            .iter()
+            .map(|&height| height.next_power_of_two())
+            .collect::<Vec<_>>();
+        for (i, (&height, is_constant)) in padded_height
             .iter()
             .zip(is_trace_height_constant.iter())
             .enumerate()
@@ -182,7 +186,7 @@ impl SegmentationCtx {
             }
         }
 
-        let total_cells = self.calculate_total_cells(trace_heights);
+        let total_cells = self.calculate_total_cells(&padded_height);
         if total_cells > self.segmentation_limits.max_cells {
             tracing::info!(
                 "instret {:9} | total cells ({:10}) > max ({:10})",
@@ -193,6 +197,7 @@ impl SegmentationCtx {
             return true;
         }
 
+        // We use unpadded height for interactions
         let total_interactions = self.calculate_total_interactions(trace_heights);
         if total_interactions > self.segmentation_limits.max_interactions {
             tracing::info!(


### PR DESCRIPTION
Replace the optimistic execution/segmentation with a checkpointing approach that checkpoints the last `trace_height`/`instret` value that is below the thresholds and use these values for the segments. This should make the segmentation more predictable for downstream usage since the segments should satisfy the thresholds (with the only caveat being if segmentation happens when there is no checkpoint to fall back to i.e. if we overshoot the threshold before the first segmentation check) 

This requires storing some extra state and results in a higher segment count compared to earlier for the same thresholds. Also makes execution slightly slower since we're doing some extra work now

[benchmark run](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17750607194) with 0.7B max cells
[benchmark run](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17771662984) with 1.2B max cells