### PR TITLE
feat: E2 supports suspension & VmExecState supports clone

### DIFF
--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -285,7 +285,7 @@ fn test_metered_execution_suspension() -> eyre::Result<()> {
     let metered_ctx = vm.build_metered_ctx(&exe).with_segment_suspend(true);
     let vm_state = interpreter.create_initial_vm_state(vec![]);
     let mut vm_exec_state = VmExecState::new(vm_state, metered_ctx);
-    vm_exec_state = interpreter.execute_metered_from_state_until_suspension(vm_exec_state)?;
+    vm_exec_state = interpreter.execute_metered_until_suspension(vm_exec_state)?;
     assert!(
         vm_exec_state.exit_code.is_ok(),
         "Execution exits with an error: {:?}",

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -8,7 +8,10 @@ use eyre::Result;
 use openvm_build::GuestOptions;
 use openvm_circuit::{
     self,
-    arch::{instructions::exe::VmExe, ContinuationVmProof, ExecutionError, VirtualMachineError},
+    arch::{
+        instructions::exe::VmExe, ContinuationVmProof, ExecutionError, VirtualMachine,
+        VirtualMachineError, VmExecState,
+    },
     utils::test_system_config,
 };
 use openvm_continuations::verifier::{
@@ -19,15 +22,16 @@ use openvm_native_circuit::{execute_program_with_config, NativeConfig, NativeCpu
 use openvm_native_compiler::{conversion::CompilerOptions, prelude::*};
 use openvm_sdk::{
     codec::{Decode, Encode},
-    config::{AggregationConfig, AppConfig, SdkSystemConfig, SdkVmConfig},
+    config::{AggregationConfig, AppConfig, SdkSystemConfig, SdkVmBuilder, SdkVmConfig},
     prover::verify_app_proof,
-    Sdk, StdIn,
+    DefaultStarkEngine, Sdk, StdIn,
 };
 use openvm_stark_sdk::{
     config::{
         baby_bear_poseidon2::{BabyBearPoseidon2Config, BabyBearPoseidon2Engine},
         setup_tracing, FriParameters,
     },
+    engine::StarkFriEngine,
     openvm_stark_backend::p3_field::FieldAlgebra,
     p3_baby_bear::BabyBear,
 };
@@ -262,6 +266,35 @@ fn test_public_values_and_leaf_verification() -> eyre::Result<()> {
             execution_result
         );
     }
+    Ok(())
+}
+
+#[test]
+fn test_metered_execution_suspension() -> eyre::Result<()> {
+    setup_tracing();
+    let app_log_blowup = 1;
+    let app_config = small_test_app_config(app_log_blowup);
+    let exe = app_exe_for_test();
+
+    let engine = DefaultStarkEngine::new(app_config.app_fri_params.fri_params);
+    let (vm, _) = VirtualMachine::new_with_keygen(engine, SdkVmBuilder, app_config.app_vm_config)?;
+    let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
+    let interpreter = vm
+        .executor()
+        .metered_instance(&exe, &executor_idx_to_air_idx)?;
+    let metered_ctx = vm.build_metered_ctx(&exe).with_segment_suspend(true);
+    let vm_state = interpreter.create_initial_vm_state(vec![]);
+    let mut vm_exec_state = VmExecState::new(vm_state, metered_ctx);
+    vm_exec_state = interpreter.execute_metered_from_state_until_suspension(vm_exec_state)?;
+    assert!(
+        vm_exec_state.exit_code.is_ok(),
+        "Execution exits with an error: {:?}",
+        vm_exec_state.exit_code
+    );
+    assert!(
+        vm_exec_state.exit_code?.is_none(),
+        "Expect more than 1 segment but the execution terminates."
+    );
     Ok(())
 }
 

--- a/crates/sdk/tests/integration_test.rs
+++ b/crates/sdk/tests/integration_test.rs
@@ -282,7 +282,7 @@ fn test_metered_execution_suspension() -> eyre::Result<()> {
     let interpreter = vm
         .executor()
         .metered_instance(&exe, &executor_idx_to_air_idx)?;
-    let metered_ctx = vm.build_metered_ctx(&exe).with_segment_suspend(true);
+    let metered_ctx = vm.build_metered_ctx(&exe).with_suspend_on_segment(true);
     let vm_state = interpreter.create_initial_vm_state(vec![]);
     let mut vm_exec_state = VmExecState::new(vm_state, metered_ctx);
     vm_exec_state = interpreter.execute_metered_until_suspension(vm_exec_state)?;

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -23,7 +23,7 @@ pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
     pub is_trace_height_constant: Vec<bool>,
     pub memory_ctx: MemoryCtx<PAGE_BITS>,
     pub segmentation_ctx: SegmentationCtx,
-    pub segment_suspend: bool,
+    pub suspend_on_segment: bool,
 }
 
 impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
@@ -76,7 +76,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
             is_trace_height_constant,
             memory_ctx,
             segmentation_ctx,
-            segment_suspend: false,
+            suspend_on_segment: false,
         };
         if !config.continuation_enabled {
             // force single segment
@@ -109,7 +109,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
     }
 
     pub fn with_segment_suspend(mut self, segment_suspend: bool) -> Self {
-        self.segment_suspend = segment_suspend;
+        self.suspend_on_segment = segment_suspend;
         self
     }
 
@@ -212,7 +212,7 @@ impl<const PAGE_BITS: usize> ExecutionCtxTrait for MeteredCtx<PAGE_BITS> {
         exec_state
             .ctx
             .check_and_segment(instret, segment_check_insns)
-            && exec_state.ctx.segment_suspend
+            && exec_state.ctx.suspend_on_segment
     }
 
     #[inline(always)]

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -208,7 +208,9 @@ impl<const PAGE_BITS: usize> ExecutionCtxTrait for MeteredCtx<PAGE_BITS> {
         segment_check_insns: u64,
         exec_state: &mut VmExecState<F, GuestMemory, Self>,
     ) -> bool {
-        // If `segment_suspend` is set, suspend every segment. Otherwise, execute until termination.
+        // If `segment_suspend` is set, suspend when a segment is determined (but the VM state might
+        // be after the segment boundary because the segment happens in the previous checkpoint).
+        // Otherwise, execute until termination.
         exec_state
             .ctx
             .check_and_segment(instret, segment_check_insns)

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -1,5 +1,6 @@
 use std::num::NonZero;
 
+use getset::{Getters, Setters, WithSetters};
 use itertools::Itertools;
 use openvm_instructions::riscv::{RV32_IMM_AS, RV32_REGISTER_AS};
 
@@ -17,13 +18,14 @@ use crate::{
 
 pub const DEFAULT_PAGE_BITS: usize = 6;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Getters, Setters, WithSetters)]
 pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
     pub trace_heights: Vec<u32>,
     pub is_trace_height_constant: Vec<bool>,
     pub memory_ctx: MemoryCtx<PAGE_BITS>,
     pub segmentation_ctx: SegmentationCtx,
-    pub suspend_on_segment: bool,
+    #[getset(get = "pub", set = "pub", set_with = "pub")]
+    suspend_on_segment: bool,
 }
 
 impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
@@ -105,11 +107,6 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     pub fn with_max_interactions(mut self, max_interactions: usize) -> Self {
         self.segmentation_ctx.set_max_interactions(max_interactions);
-        self
-    }
-
-    pub fn with_segment_suspend(mut self, segment_suspend: bool) -> Self {
-        self.suspend_on_segment = segment_suspend;
         self
     }
 

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -425,11 +425,11 @@ where
     }
     pub fn execute_metered_from_state_until_suspension(
         &self,
-        mut from_state: VmExecState<F, GuestMemory, MeteredCtx>,
+        mut exec_state: VmExecState<F, GuestMemory, MeteredCtx>,
     ) -> Result<VmExecState<F, GuestMemory, MeteredCtx>, ExecutionError> {
-        let instret = from_state.instret();
-        let pc = from_state.pc();
-        let segmentation_check_insns = from_state.ctx.segmentation_ctx.segment_check_insns;
+        let instret = exec_state.instret();
+        let pc = exec_state.pc();
+        let segmentation_check_insns = exec_state.ctx.segmentation_ctx.segment_check_insns;
         // Start execution
         run!(
             "execute_metered",
@@ -437,10 +437,10 @@ where
             instret,
             pc,
             segmentation_check_insns,
-            from_state,
+            exec_state,
             MeteredCtx
         );
-        Ok(from_state)
+        Ok(exec_state)
     }
 }
 

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -201,6 +201,15 @@ where
         })
     }
 
+    pub fn create_initial_vm_state(&self, inputs: impl Into<Streams<F>>) -> VmState<F> {
+        VmState::initial(
+            &self.system_config,
+            &self.init_memory,
+            self.pc_start,
+            inputs,
+        )
+    }
+
     /// # Safety
     /// - This function assumes that the `pc` is within program bounds - this should be the case if
     ///   the pc is checked to be in bounds before jumping to it.
@@ -381,12 +390,7 @@ where
         inputs: impl Into<Streams<F>>,
         ctx: MeteredCtx,
     ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
-        let vm_state = VmState::initial(
-            &self.system_config,
-            &self.init_memory,
-            self.pc_start,
-            inputs,
-        );
+        let vm_state = self.create_initial_vm_state(inputs);
         self.execute_metered_from_state(vm_state, ctx)
     }
 
@@ -405,9 +409,27 @@ where
     ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
         let mut exec_state = VmExecState::new(from_state, ctx);
 
-        let instret = exec_state.instret();
-        let pc = exec_state.pc();
-        let segmentation_check_insns = exec_state.ctx.segmentation_ctx.segment_check_insns;
+        loop {
+            exec_state = self.execute_metered_from_state_until_suspension(exec_state)?;
+            // The execution has terminated.
+            if exec_state.exit_code.is_ok() && exec_state.exit_code.as_ref().unwrap().is_some() {
+                break;
+            }
+            if exec_state.exit_code.is_err() {
+                return Err(exec_state.exit_code.unwrap_err());
+            }
+        }
+        check_termination(exec_state.exit_code)?;
+        let VmExecState { vm_state, ctx, .. } = exec_state;
+        Ok((ctx.into_segments(), vm_state))
+    }
+    pub fn execute_metered_from_state_until_suspension(
+        &self,
+        mut from_state: VmExecState<F, GuestMemory, MeteredCtx>,
+    ) -> Result<VmExecState<F, GuestMemory, MeteredCtx>, ExecutionError> {
+        let instret = from_state.instret();
+        let pc = from_state.pc();
+        let segmentation_check_insns = from_state.ctx.segmentation_ctx.segment_check_insns;
         // Start execution
         run!(
             "execute_metered",
@@ -415,12 +437,10 @@ where
             instret,
             pc,
             segmentation_check_insns,
-            exec_state,
+            from_state,
             MeteredCtx
         );
-        check_termination(exec_state.exit_code)?;
-        let VmExecState { vm_state, ctx, .. } = exec_state;
-        Ok((ctx.into_segments(), vm_state))
+        Ok(from_state)
     }
 }
 
@@ -437,12 +457,7 @@ where
         inputs: impl Into<Streams<F>>,
         ctx: MeteredCostCtx,
     ) -> Result<(u64, VmState<F, GuestMemory>), ExecutionError> {
-        let vm_state = VmState::initial(
-            &self.system_config,
-            &self.init_memory,
-            self.pc_start,
-            inputs,
-        );
+        let vm_state = self.create_initial_vm_state(inputs);
         self.execute_metered_cost_from_state(vm_state, ctx)
     }
 

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -428,8 +428,8 @@ where
     ///
     /// This function resumes and continues execution of a guest virtual machine until either it:
     /// - Hits a suspension trigger (e.g. out of gas or a specific halt condition). ATTENTION: when
-    /// a suspension is triggered, the VM state is not at the boundary of the last segment. Instead,
-    /// the VM state is slightly after the segment boundary.
+    ///   a suspension is triggered, the VM state is not at the boundary of the last segment.
+    ///   Instead, the VM state is slightly after the segment boundary.
     /// - Completes its run based on the instructions or context provided.
     ///
     /// # Parameters


### PR DESCRIPTION
- E2 execution supports suspension every segment. [Reth-benchmark](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17782856127) doesn't show performance difference.
- `VmExecState`/`VmState` supports clone. Benchmark shows cloning a VM state which only uses address space 2 takes 0.3~0.6ms.

closes INT-5066
closes INT-5067