### PR TITLE
feat: check for segmentation after each keccak/sha instruction

### DIFF
--- a/extensions/keccak256/circuit/src/execution.rs
+++ b/extensions/keccak256/circuit/src/execution.rs
@@ -200,4 +200,9 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: MeteredExecutionCtxTrait>(
     exec_state
         .ctx
         .on_height_change(pre_compute.chip_idx as usize, height);
+
+    // We don't use this result, so for most CTX implementations this does nothing.
+    // However, for MeteredCtx this forces a segment check since its implementation
+    // of should_suspend performs one as a side effect.
+    CTX::should_suspend(*instret, *pc, 0, exec_state);
 }

--- a/extensions/sha256/circuit/src/sha256_chip/execution.rs
+++ b/extensions/sha256/circuit/src/sha256_chip/execution.rs
@@ -170,6 +170,11 @@ unsafe fn execute_e2_impl<F: PrimeField32, CTX: MeteredExecutionCtxTrait>(
     exec_state
         .ctx
         .on_height_change(pre_compute.chip_idx as usize, height);
+
+    // We don't use this result, so for most CTX implementations this does nothing.
+    // However, for MeteredCtx this forces a segment check since its implementation
+    // of should_suspend performs one as a side effect.
+    CTX::should_suspend(*instret, *pc, 0, exec_state);
 }
 
 impl Sha256VmExecutor {


### PR DESCRIPTION
Resolves INT-5063. Benchmark run shows no difference https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17804008078