### PR TITLE
fix: execution from non-zero `instret`

### DIFF
--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -66,6 +66,8 @@ pub enum ExecutionError {
     FailedWithExitCode(u32),
     #[error("trace buffer out of bounds: requested {requested} but capacity is {capacity}")]
     TraceBufferOutOfBounds { requested: usize, capacity: usize },
+    #[error("instruction counter overflow: {instret} + {num_insns} > u64::MAX")]
+    InstretOverflow { instret: u64, num_insns: u64 },
     #[error("inventory error: {0}")]
     Inventory(#[from] ExecutorInventoryError),
     #[error("static program error: {0}")]

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -353,10 +353,11 @@ where
         from_state: VmState<F, GuestMemory>,
         num_insns: Option<u64>,
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
-        let ctx = ExecutionCtx::new(num_insns);
+        let instret = from_state.instret();
+        let instret_end = num_insns.map(|n| instret.checked_add(n).unwrap());
+        let ctx = ExecutionCtx::new(instret_end);
         let mut exec_state = VmExecState::new(from_state, ctx);
 
-        let instret = exec_state.instret();
         let pc = exec_state.pc();
         let instret_end = exec_state.ctx.instret_end;
         run!(

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -354,7 +354,17 @@ where
         num_insns: Option<u64>,
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
         let instret = from_state.instret();
-        let instret_end = num_insns.map(|n| instret.checked_add(n).unwrap());
+        let instret_end = if let Some(n) = num_insns {
+            let end = instret
+                .checked_add(n)
+                .ok_or(ExecutionError::InstretOverflow {
+                    instret,
+                    num_insns: n,
+                })?;
+            Some(end)
+        } else {
+            None
+        };
         let ctx = ExecutionCtx::new(instret_end);
         let mut exec_state = VmExecState::new(from_state, ctx);
 


### PR DESCRIPTION
`InterpretedInstance::execute_from_state` for pure execution was using `num_insns` instead of `instret_end` in the `ExecutionCtx` constructor. This was not caught because we currently only ever execute from `instret=0`.