### PR TITLE
chore: removed needless mut references (clippy::needless_pass_by_ref_mut).

### DIFF
--- a/crates/vm/src/system/memory/adapter/mod.rs
+++ b/crates/vm/src/system/memory/adapter/mod.rs
@@ -146,7 +146,7 @@ impl<F: Clone + Send + Sync> AccessAdapterInventory<F> {
         tracing::debug!("Computed heights from memory adapters arena: {:?}", heights);
     }
 
-    fn apply_overridden_heights(&mut self, heights: &mut [usize]) {
+    fn apply_overridden_heights(&self, heights: &mut [usize]) {
         for (i, h) in heights.iter_mut().enumerate() {
             if let Some(oh) = self.chips[i].overridden_trace_height() {
                 assert!(

--- a/crates/vm/src/system/memory/online/basic.rs
+++ b/crates/vm/src/system/memory/online/basic.rs
@@ -18,7 +18,7 @@ impl BasicMemory {
     }
 
     #[inline(always)]
-    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+    pub fn as_mut_ptr(&self) -> *mut u8 {
         self.ptr.as_ptr()
     }
 }

--- a/extensions/native/compiler/src/asm/compiler.rs
+++ b/extensions/native/compiler/src/asm/compiler.rs
@@ -717,7 +717,7 @@ impl<F: PrimeField32 + TwoAdicField, EF: ExtensionField<F> + TwoAdicField> AsmCo
         self.basic_blocks.push(BasicBlock::new());
     }
 
-    fn block_label(&mut self) -> F {
+    fn block_label(&self) -> F {
         F::from_canonical_usize(self.basic_blocks.len() - 1)
     }
 

--- a/extensions/native/compiler/src/ir/collections.rs
+++ b/extensions/native/compiler/src/ir/collections.rs
@@ -125,7 +125,7 @@ impl<C: Config> Builder<C> {
     }
 
     /// Creates an array from a vector.
-    pub fn vec<V: MemVariable<C>>(&mut self, v: Vec<V>) -> Array<C, V> {
+    pub fn vec<V: MemVariable<C>>(&self, v: Vec<V>) -> Array<C, V> {
         Array::Fixed(Rc::new(RefCell::new(
             v.into_iter().map(|x| Some(x)).collect(),
         )))


### PR DESCRIPTION
I've first noticed this in the DSL `Builder` struct, where the `vec` function takes a `&mut self`, while not even using `self`.
This prompted me to run `cargo clippy -- -W clippy::needless_pass_by_ref_mut`, and fix everything I could find.