### PR TITLE
fix(cuda): sync memory subtree streams before drop

### DIFF
--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -231,3 +231,12 @@ impl MemoryInventoryGPU {
         ret
     }
 }
+
+impl Drop for PersistentMemoryInventoryGPU {
+    fn drop(&mut self) {
+        // Drop merkle subtrees first so their individual streams synchronize before dropping the
+        // initial memory buffers. This prevents buffers from dropping before build_async completes.
+        self.merkle_tree.drop_subtrees();
+        self.initial_memory.clear();
+    }
+}


### PR DESCRIPTION
In some edge case where right after we start `build_async` on the memory merkle subtrees, if the program panics, then the order of drop could be that we drop the `initial_memory` buffers on the default stream first, while the `build_async` kernels are still running and using those buffers. This leads to a deadloop. I fixed it by just forcing the drop to drop subtrees first (which should sync their special streams) before dropping `initial_memory`.

compare: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/18733111153
