### PR TITLE
chore(docs): update link to example repo

### DIFF
--- a/docs/vocs/docs/pages/book/writing-apps/overview.mdx
+++ b/docs/vocs/docs/pages/book/writing-apps/overview.mdx
@@ -62,7 +62,7 @@ where
 }
 ```
 
-For more details on how to serialize complex types into a VM-readable format, see the input utilities in the [OpenVM example program](https://github.com/openvm-org/openvm-example-fibonacci/).
+For more details on how to serialize complex types into a VM-readable format, see the input utilities in the [OpenVM examples](https://github.com/openvm-org/openvm-examples/) repository.
 
 ## Generating Application Proofs
 

--- a/docs/vocs/docs/pages/book/writing-apps/writing-a-program.mdx
+++ b/docs/vocs/docs/pages/book/writing-apps/writing-a-program.mdx
@@ -7,7 +7,7 @@ cargo openvm init
 ```
 
 This will initialize a new Rust project, and you can start writing your program in `src/main.rs`.
-For a guest program example, see this [Fibonacci program](https://github.com/openvm-org/openvm-example-fibonacci). More examples can be found in the [benchmarks/guest](https://github.com/openvm-org/openvm/tree/main/benchmarks/guest) directory.
+For a guest program example, see this [Fibonacci program](https://github.com/openvm-org/openvm-examples). More examples can be found in the [benchmarks/guest](https://github.com/openvm-org/openvm/tree/main/benchmarks/guest) directory.
 
 ## Handling I/O
 


### PR DESCRIPTION
Renamed `openvm-examples` since it has more than one example.