### PR TITLE
perf: implement register mapping design for divrem 

### DIFF
--- a/extensions/rv32im/circuit/src/divrem/execution.rs
+++ b/extensions/rv32im/circuit/src/divrem/execution.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 #[cfg(feature = "aot")]
-use openvm_circuit::arch::aot::common::REG_A;
+use openvm_circuit::arch::aot::common::REG_A_W;
 use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{


### PR DESCRIPTION
Closes INT-5423
* Implements the new register mapping design for divrem
* Important safety note: divrem requires the usage of `eax` and `edx` for its division opcode. This is fixed and cannot be moved into another opcode and hence this opcode remains hardcoded and will not use the constants from common.rs.