### PR TITLE
fix: E2 Instret Computation

### DIFF
--- a/crates/vm/src/arch/aot/metered_execute.rs
+++ b/crates/vm/src/arch/aot/metered_execute.rs
@@ -221,8 +221,8 @@ asm_execute:
     mov rax, {metered_extern_handler_ptr}
     call rax
     cmp rax, 1          
-    mov r13, rax        
     je asm_run_end      
+    mov r13, rax        
     jmp asm_execute     
 
 asm_run_end:

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -68,8 +68,10 @@ mod tests {
         let executor = VmExecutor::new(config)?;
         let instance = executor.instance(&exe)?;
         let state = instance.execute(vec![], Some(10))?;
+        let state = instance.execute_from_state(state, Some(10))?;
         let end_state1 = instance.execute_from_state(state, None)?;
         let end_state2 = instance.execute(vec![], None)?;
+        assert_eq!(end_state1.pc(), end_state2.pc());
         for addr_space in 1..end_state1.memory.memory.mem.len() {
             assert_eq!(
                 end_state1.memory.memory.mem[addr_space].size(),


### PR DESCRIPTION
Previous E2 instret offsets by 1 every time we call `execute_from_state`. 