### PR TITLE
CI: migrate workflows to checkout v6

### DIFF
--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: | # avoid cross-device link error
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -134,7 +134,7 @@ jobs:
       ##########################################################################
       # Environment setup                                                      #
       ##########################################################################
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/benchmarks-upload-fixtures.yml
+++ b/.github/workflows/benchmarks-upload-fixtures.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -73,7 +73,7 @@ jobs:
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.CURRENT_SHA }}
           repository: ${{ env.REPO }}
@@ -178,7 +178,7 @@ jobs:
       ##########################################################################
       # Download individual result .md files from S3 and combine them          #
       ##########################################################################
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.CURRENT_SHA }}
           repository: ${{ env.REPO }}
@@ -298,7 +298,7 @@ jobs:
       ##########################################################################
       # Update benchmark-results branch with summary                           #
       ##########################################################################
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: benchmark-results
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - runs-on=${{ github.run_id }}/runner=64cpu-linux-x64/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -38,7 +38,7 @@ jobs:
       - runs-on=${{ github.run_id }}/disk=large/runner=64cpu-linux-x64/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
       - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/cpu=32
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -15,7 +15,7 @@ jobs:
       - runs-on=${{ github.run_id }}-cpu/runner=64cpu-linux-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: codespell-project/actions-codespell@v2
         with:
           skip: Cargo.lock,./docs/vocs/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,./audits/*.pdf,./guest-libs/ruint/*
@@ -81,7 +81,7 @@ jobs:
       - runs-on=${{ github.run_id }}-cuda/runner=test-gpu-nvidia
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: | # avoid cross-device link error
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true

--- a/.github/workflows/native-compiler.yml
+++ b/.github/workflows/native-compiler.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/openvm-tags.yml
+++ b/.github/workflows/openvm-tags.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on:
       - runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check the tags
         working-directory: docs
         run: ../ci/scripts/check_openvm_tags.sh .

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: | # avoid cross-device link error
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true

--- a/.github/workflows/publish-vocs.yml
+++ b/.github/workflows/publish-vocs.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - runs-on=${{ github.run_id }}/runner=64cpu-linux-x64/extras=s3-cache/disk=large
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set version
         run: echo "version=${{ github.event.inputs.version || 'v1.4.1' }}" >> $GITHUB_ENV
@@ -37,7 +37,7 @@ jobs:
 
       # Checkout and test tagged version
       - name: Checkout tagged version
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.version }}
 

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -16,7 +16,7 @@ jobs:
       - runs-on=${{ github.run_id }}/runner=64cpu-linux-x64/extras=s3-cache/disk=large
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set version fallback
         run: echo "version=${{ github.event.inputs.version || 'v1.4.1' }}" >> $GITHUB_ENV
@@ -72,7 +72,7 @@ jobs:
 
       # Checkout and test tagged version
       - name: Checkout tagged version
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.version }}
           clean: false

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: runs-on/action@v2
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: | # avoid cross-device link error
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true


### PR DESCRIPTION
Bumps `actions/checkout` from v5 to v6. Workflow-only change, no impact on functionality.

https://github.com/actions/checkout/releases/tag/v6.0.0