### PR TITLE
fix(ci): rust cache needs to be cuda architecture specific

### DIFF
--- a/.github/actions/rust-cache-cuda/action.yml
+++ b/.github/actions/rust-cache-cuda/action.yml
@@ -1,0 +1,35 @@
+name: "Rust Cache with CUDA Architecture"
+description: "Wraps Swatinem/rust-cache with GPU architecture in cache key to avoid CUDA library conflicts"
+
+inputs:
+  cache-on-failure:
+    description: "Cache even if the build fails"
+    required: false
+    default: "true"
+  key:
+    description: "Additional cache key suffix"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect GPU architecture
+      id: gpu-arch
+      shell: bash
+      run: |
+        if command -v nvidia-smi &> /dev/null; then
+          # Get compute capability (e.g., "8.9" -> "89")
+          CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.' || echo "unknown")
+          echo "cuda_arch=$CUDA_ARCH" >> $GITHUB_OUTPUT
+          echo "Detected CUDA architecture: $CUDA_ARCH"
+        else
+          echo "cuda_arch=no-gpu" >> $GITHUB_OUTPUT
+          echo "No GPU detected"
+        fi
+
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: ${{ inputs.cache-on-failure }}
+        key: ${{ inputs.key }}${{ inputs.key && '-' || '' }}cuda-${{ steps.gpu-arch.outputs.cuda_arch }}

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -36,7 +36,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -142,7 +142,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
 

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -89,7 +89,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -107,7 +107,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -86,7 +86,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
       - name: Verify CUDA setup


### PR DESCRIPTION
CUDA workflows use rust cache but stark-backend's rust cache contains cuda architecture specific machine code.
We make a composite github action that wraps Swatinem/rust-cache and adds the cuda arch as a cache key.