### PR TITLE
feat: add parameter for interaction contribution to cell count

### DIFF
--- a/benchmarks/prove/src/bin/async_regex.rs
+++ b/benchmarks/prove/src/bin/async_regex.rs
@@ -19,11 +19,17 @@ async fn main() -> eyre::Result<()> {
         config
             .app_vm_config
             .as_mut()
-            .segmentation_limits
-            .max_trace_height = max_height;
+            .segmentation_config
+            .limits
+            .set_max_trace_height(max_height);
     }
     if let Some(max_cells) = args.segment_max_cells {
-        config.app_vm_config.as_mut().segmentation_limits.max_cells = max_cells;
+        config
+            .app_vm_config
+            .as_mut()
+            .segmentation_config
+            .limits
+            .set_max_cells(max_cells);
     }
 
     let sdk = Sdk::new(config)?;

--- a/benchmarks/prove/src/bin/fib_e2e.rs
+++ b/benchmarks/prove/src/bin/fib_e2e.rs
@@ -18,7 +18,8 @@ async fn main() -> Result<()> {
         SdkVmConfig::from_toml(include_str!("../../../guest/fibonacci/openvm.toml"))?.app_vm_config;
     config
         .as_mut()
-        .segmentation_limits
+        .segmentation_config
+        .limits
         .set_max_trace_height(max_segment_length);
     config.as_mut().num_public_values = NUM_PUBLIC_VALUES;
 

--- a/benchmarks/prove/src/util.rs
+++ b/benchmarks/prove/src/util.rs
@@ -92,11 +92,16 @@ impl BenchmarkCli {
         if let Some(max_height) = self.max_segment_length {
             app_vm_config
                 .as_mut()
-                .segmentation_limits
+                .segmentation_config
+                .limits
                 .set_max_trace_height(max_height);
         }
         if let Some(max_cells) = self.segment_max_cells {
-            app_vm_config.as_mut().segmentation_limits.max_cells = max_cells;
+            app_vm_config
+                .as_mut()
+                .segmentation_config
+                .limits
+                .set_max_cells(max_cells);
         }
         AppConfig {
             app_fri_params: FriParameters::standard_with_100_bits_conjectured_security(

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use eyre::Result;
 use openvm_circuit::arch::{
     execution_mode::metered::segment_ctx::{
-        SegmentationLimits, DEFAULT_MAX_CELLS, DEFAULT_MAX_TRACE_HEIGHT_BITS,
+        SegmentationConfig, SegmentationLimits, DEFAULT_MAX_CELLS, DEFAULT_MAX_TRACE_HEIGHT_BITS,
     },
     instructions::exe::VmExe,
 };
@@ -306,17 +306,19 @@ fn get_app_config(
         .vm_config
         .system
         .config
-        .set_segmentation_limits((*segmentation_args).into());
+        .set_segmentation_config((*segmentation_args).into());
     app_pk.app_config()
 }
 
-impl From<SegmentationArgs> for SegmentationLimits {
+impl From<SegmentationArgs> for SegmentationConfig {
     fn from(args: SegmentationArgs) -> Self {
-        SegmentationLimits {
-            max_trace_height: 1u32
-                .checked_shl(args.segment_max_height_bits as u32)
-                .expect("segment_max_height_bits too large"),
-            max_cells: args.segment_max_cells,
+        SegmentationConfig {
+            limits: SegmentationLimits::default()
+                .with_max_trace_height(
+                    1u32.checked_shl(args.segment_max_height_bits as u32)
+                        .expect("segment_max_height_bits too large"),
+                )
+                .with_max_cells(args.segment_max_cells),
             ..Default::default()
         }
     }

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -22,7 +22,7 @@ use stark_backend_v2::StarkEngineV2 as StarkEngine;
 use super::{AnyEnum, VmChipComplex, PUBLIC_VALUES_AIR_ID};
 use crate::{
     arch::{
-        execution_mode::metered::segment_ctx::SegmentationLimits, AirInventory, AirInventoryError,
+        execution_mode::metered::segment_ctx::SegmentationConfig, AirInventory, AirInventoryError,
         Arena, ChipInventoryError, ExecutorInventory, ExecutorInventoryError,
     },
     system::{
@@ -273,12 +273,12 @@ pub struct SystemConfig {
     /// Whether to collect detailed profiling metrics.
     /// **Warning**: this slows down the runtime.
     pub profiling: bool,
-    /// Segmentation limits
+    /// Segmentation configuration
     /// This field is skipped in serde as it's only used in execution and
     /// not needed after any serialize/deserialize.
-    #[serde(skip, default = "SegmentationLimits::default")]
+    #[serde(skip, default)]
     #[getset(set = "pub")]
-    pub segmentation_limits: SegmentationLimits,
+    pub segmentation_config: SegmentationConfig,
 }
 
 impl SystemConfig {
@@ -298,7 +298,7 @@ impl SystemConfig {
             memory_config,
             num_public_values,
             profiling: false,
-            segmentation_limits: SegmentationLimits::default(),
+            segmentation_config: SegmentationConfig::default(),
         }
     }
 
@@ -327,7 +327,8 @@ impl SystemConfig {
     }
 
     pub fn with_max_segment_len(mut self, max_segment_len: usize) -> Self {
-        self.segmentation_limits
+        self.segmentation_config
+            .limits
             .set_max_trace_height(max_segment_len as u32);
         self
     }

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -71,7 +71,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         );
 
         let segmentation_ctx =
-            SegmentationCtx::new(air_names, widths, interactions, config.segmentation_limits);
+            SegmentationCtx::new(air_names, widths, interactions, config.segmentation_config);
 
         let mut ctx = Self {
             trace_heights,
@@ -111,6 +111,11 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     pub fn with_max_interactions(mut self, max_interactions: usize) -> Self {
         self.segmentation_ctx.set_max_interactions(max_interactions);
+        self
+    }
+
+    pub fn with_interaction_cell_weight(mut self, weight: usize) -> Self {
+        self.segmentation_ctx.set_interaction_cell_weight(weight);
         self
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -1,4 +1,4 @@
-use getset::WithSetters;
+use getset::{Setters, WithSetters};
 use openvm_stark_backend::p3_field::PrimeField32;
 use p3_baby_bear::BabyBear;
 use serde::{Deserialize, Serialize};
@@ -17,11 +17,18 @@ pub struct Segment {
     pub trace_heights: Vec<u32>,
 }
 
-#[derive(Clone, Copy, Debug, WithSetters)]
+#[derive(Clone, Copy, Debug, Default, WithSetters)]
+pub struct SegmentationConfig {
+    pub limits: SegmentationLimits,
+    /// Cells per row contributed by each interaction in cell count.
+    #[getset(set_with = "pub")]
+    pub interaction_cell_weight: usize,
+}
+
+#[derive(Clone, Copy, Debug, WithSetters, Setters)]
 pub struct SegmentationLimits {
-    #[getset(set_with = "pub")]
     pub max_trace_height: u32,
-    #[getset(set_with = "pub")]
+    #[getset(set = "pub", set_with = "pub")]
     pub max_cells: usize,
     #[getset(set_with = "pub")]
     pub max_interactions: usize,
@@ -50,6 +57,15 @@ impl SegmentationLimits {
         }
     }
 
+    pub fn with_max_trace_height(mut self, max_trace_height: u32) -> Self {
+        debug_assert!(
+            max_trace_height.is_power_of_two(),
+            "max_trace_height should be a power of two"
+        );
+        self.max_trace_height = max_trace_height;
+        self
+    }
+
     pub fn set_max_trace_height(&mut self, max_trace_height: u32) {
         debug_assert!(
             max_trace_height.is_power_of_two(),
@@ -65,7 +81,7 @@ pub struct SegmentationCtx {
     pub(crate) air_names: Vec<String>,
     pub(crate) widths: Vec<usize>,
     interactions: Vec<usize>,
-    pub(crate) segmentation_limits: SegmentationLimits,
+    pub(crate) config: SegmentationConfig,
     pub instret: u64,
     pub instrets_until_check: u64,
     #[getset(set_with = "pub")]
@@ -81,7 +97,7 @@ impl SegmentationCtx {
         air_names: Vec<String>,
         widths: Vec<usize>,
         interactions: Vec<usize>,
-        segmentation_limits: SegmentationLimits,
+        config: SegmentationConfig,
     ) -> Self {
         assert_eq!(air_names.len(), widths.len());
         assert_eq!(air_names.len(), interactions.len());
@@ -92,30 +108,7 @@ impl SegmentationCtx {
             air_names,
             widths,
             interactions,
-            segmentation_limits,
-            instret: 0,
-            instrets_until_check: DEFAULT_SEGMENT_CHECK_INSNS,
-            segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
-            checkpoint_trace_heights: vec![0; num_airs],
-            checkpoint_instret: 0,
-        }
-    }
-
-    pub fn new_with_default_segmentation_limits(
-        air_names: Vec<String>,
-        widths: Vec<usize>,
-        interactions: Vec<usize>,
-    ) -> Self {
-        assert_eq!(air_names.len(), widths.len());
-        assert_eq!(air_names.len(), interactions.len());
-
-        let num_airs = air_names.len();
-        Self {
-            segments: Vec::new(),
-            air_names,
-            widths,
-            interactions,
-            segmentation_limits: SegmentationLimits::default(),
+            config,
             instret: 0,
             instrets_until_check: DEFAULT_SEGMENT_CHECK_INSNS,
             segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
@@ -125,16 +118,19 @@ impl SegmentationCtx {
     }
 
     pub fn set_max_trace_height(&mut self, max_trace_height: u32) {
-        self.segmentation_limits
-            .set_max_trace_height(max_trace_height);
+        self.config.limits.set_max_trace_height(max_trace_height);
     }
 
     pub fn set_max_cells(&mut self, max_cells: usize) {
-        self.segmentation_limits.max_cells = max_cells;
+        self.config.limits.max_cells = max_cells;
     }
 
     pub fn set_max_interactions(&mut self, max_interactions: usize) {
-        self.segmentation_limits.max_interactions = max_interactions;
+        self.config.limits.max_interactions = max_interactions;
+    }
+
+    pub fn set_interaction_cell_weight(&mut self, weight: usize) {
+        self.config.interaction_cell_weight = weight;
     }
 
     /// Calculate the maximum trace height and corresponding air name
@@ -149,15 +145,21 @@ impl SegmentationCtx {
             .unwrap_or((0, "unknown"))
     }
 
-    /// Calculate the total cells used based on trace heights and widths
+    /// Calculate the total cells used based on trace heights and widths,
+    /// including weighted contribution from interactions if `interaction_cell_weight > 0`.
     #[inline(always)]
     fn calculate_total_cells(&self, trace_heights: &[u32]) -> usize {
         debug_assert_eq!(trace_heights.len(), self.widths.len());
 
+        let interaction_weight = self.config.interaction_cell_weight;
         trace_heights
             .iter()
             .zip(self.widths.iter())
-            .map(|(&height, &width)| height.next_power_of_two() as usize * width)
+            .zip(self.interactions.iter())
+            .map(|((&height, &width), &interactions)| {
+                let padded_height = height.next_power_of_two() as usize;
+                padded_height * (width + interactions * interaction_weight)
+            })
             .sum()
     }
 
@@ -208,13 +210,13 @@ impl SegmentationCtx {
         {
             // Only segment if the height is not constant and exceeds the maximum height after
             // padding
-            if !is_constant && padded_height > self.segmentation_limits.max_trace_height {
+            if !is_constant && padded_height > self.config.limits.max_trace_height {
                 let air_name = unsafe { self.air_names.get_unchecked(i) };
                 tracing::info!(
                     "instret {:10} | height ({:8}) > max ({:8}) | chip {:3} ({}) ",
                     instret,
                     padded_height,
-                    self.segmentation_limits.max_trace_height,
+                    self.config.limits.max_trace_height,
                     i,
                     air_name,
                 );
@@ -223,23 +225,23 @@ impl SegmentationCtx {
             total_cells += padded_height as usize * width;
         }
 
-        if total_cells > self.segmentation_limits.max_cells {
+        if total_cells > self.config.limits.max_cells {
             tracing::info!(
                 "instret {:10} | total cells ({:10}) > max ({:10})",
                 instret,
                 total_cells,
-                self.segmentation_limits.max_cells
+                self.config.limits.max_cells
             );
             return true;
         }
 
         let total_interactions = self.calculate_total_interactions(trace_heights);
-        if total_interactions > self.segmentation_limits.max_interactions {
+        if total_interactions > self.config.limits.max_interactions {
             tracing::info!(
                 "instret {:10} | total interactions ({:10}) > max ({:10})",
                 instret,
                 total_interactions,
-                self.segmentation_limits.max_interactions
+                self.config.limits.max_interactions
             );
             return true;
         }

--- a/crates/vm/src/system/cuda/extensions.rs
+++ b/crates/vm/src/system/cuda/extensions.rs
@@ -112,7 +112,7 @@ impl VmBuilder<BabyBearPoseidon2GpuEngine> for SystemGpuBuilder {
         inventory.add_periphery_chip(range_checker.clone());
 
         let hasher_chip = if config.continuation_enabled {
-            let max_buffer_size = (config.segmentation_limits.max_trace_height as usize)
+            let max_buffer_size = (config.segmentation_config.limits.max_trace_height as usize)
                 .next_power_of_two() * 2 // seems like a reliable estimate
                 * (DIGEST_WIDTH * 2); // size of one record
             assert_eq!(inventory.chips().len(), POSEIDON2_INSERTION_IDX);

--- a/extensions/native/circuit/tests/integration_test.rs
+++ b/extensions/native/circuit/tests/integration_test.rs
@@ -949,9 +949,8 @@ fn test_single_segment_executor_no_segmentation() {
     setup_tracing();
 
     let mut config = test_native_config();
-    config
-        .system
-        .set_segmentation_limits(SegmentationLimits::default().with_max_trace_height(1));
+    config.system.segmentation_config.limits =
+        SegmentationLimits::default().with_max_trace_height(1);
 
     let engine = TestEngine::<DuplexSponge>::new(SystemParams::new_for_testing(20));
     let (vm, _) =


### PR DESCRIPTION
- replace `SegmentationLimits` with `SegmentationConfig` in `SystemConfig`
- add a `interaction_cell_weight` parameter to `SegmentationConfig` that specifies how much cells does an interaction contribute at each row