### PR TITLE
chore: remove incorrect metrics when `cuda` enabled

### DIFF
--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -745,7 +745,7 @@ where
         system_records: SystemRecords<Val<E::SC>>,
         record_arenas: Vec<VB::RecordArena>,
     ) -> Result<ProvingContext<E::PB>, GenerationError> {
-        #[cfg(feature = "metrics")]
+        #[cfg(all(feature = "metrics", not(feature = "cuda")))]
         let mut current_trace_heights =
             self.get_trace_heights_from_arenas(&system_records, &record_arenas);
         // main tracegen call:
@@ -805,7 +805,7 @@ where
                 });
             }
         }
-        #[cfg(feature = "metrics")]
+        #[cfg(all(feature = "metrics", not(feature = "cuda")))]
         self.finalize_metrics(&mut current_trace_heights);
         #[cfg(feature = "stark-debug")]
         self.debug_proving_ctx(&ctx);


### PR DESCRIPTION
`main_cells_used` is inaccurate because trace height calculations are not accurate when cuda tracegen is enabled. to avoid confusion, don't emit these metrics