### PR TITLE
fix: make with_halo2_pk panic on duplicate key

### DIFF
--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -668,7 +668,7 @@ where
     pub fn with_halo2_pk(self, halo2_pk: Halo2ProvingKey) -> Self {
         let _ = self
             .set_halo2_pk(halo2_pk)
-            .map_err(|_| "halo2_pk already set");
+            .map_err(|_| panic!("halo2_pk already set"));
         self
     }
 


### PR DESCRIPTION
with_halo2_pk silently ignored errors from set_halo2_pk, even though the docstring explicitly says it should panic if Halo2 keygen has already been called. This also diverged from the pattern used by with_app_pk and with_agg_pk, both of which panic when their respective keys are already set.

Update with_halo2_pk to panic on a failed set_halo2_pk call, restoring the documented behavior and making the builder-style API consistent.