### PR TITLE
chore: Add phantom instructions to algebra specs

### DIFF
--- a/docs/vocs/docs/pages/specs/reference/instruction-reference.mdx
+++ b/docs/vocs/docs/pages/specs/reference/instruction-reference.mdx
@@ -184,6 +184,14 @@ In the tables below, we provide the mapping between the `LocalOpcode` and `Phant
 | Algebra | `Fp2Opcode::DIV` | DIV\<Fp2\> |
 | Algebra | `Fp2Opcode::SETUP_MULDIV` | SETUP_MULDIV\<Fp2\> |
 
+#### Phantom Sub-Instructions
+
+| VM Extension | `PhantomDiscriminant` | ISA Phantom Sub-Instruction |
+| ------------- | ---------- | ------------- |
+| Algebra | `ModularPhantom::HintNonQr` | HintNonQr\<N\> |
+| Algebra | `ModularPhantom::HintSqrt` | HintSqrt\<N\> |
+
+
 ## Elliptic Curve Extension
 
 #### Instructions
@@ -194,19 +202,3 @@ In the tables below, we provide the mapping between the `LocalOpcode` and `Phant
 | Elliptic Curve | `Rv32WeierstrassOpcode::SETUP_EC_ADD_NE` | SETUP_EC_ADD_NE\<C\> |
 | Elliptic Curve | `Rv32WeierstrassOpcode::EC_DOUBLE` | EC_DOUBLE\<C\> |
 | Elliptic Curve | `Rv32WeierstrassOpcode::SETUP_EC_DOUBLE` | SETUP_EC_DOUBLE\<C\> |
-
-#### Phantom Sub-Instructions
-
-| VM Extension | `PhantomDiscriminant` | ISA Phantom Sub-Instruction |
-| ------------- | ---------- | ------------- |
-| Elliptic Curve | `EccPhantom::HintDecompress` | HintDecompress |
-
-## Pairing Extension
-
-#### Instructions
-
-#### Phantom Sub-Instructions
-
-| VM Extension | `PhantomDiscriminant` | ISA Phantom Sub-Instruction |
-| ------------- | ---------- | ------------- |
-| Pairing | `PairingPhantom::HintDecompress` | HintDecompress |


### PR DESCRIPTION
A description of the `HintNonQr` and `HintSqrt` phantom instructions in the algebra extension was missing from instruction reference. This PR adds it.