### PR TITLE
fix: allow cli prove without source code

### DIFF
--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -259,7 +259,6 @@ pub(crate) fn load_app_pk(
     app_pk: &Option<PathBuf>,
     cargo_args: &RunCargoArgs,
 ) -> Result<AppProvingKey<SdkVmConfig>> {
-
     let app_pk_path = if let Some(app_pk) = app_pk {
         app_pk.to_path_buf()
     } else {


### PR DESCRIPTION
When passing in pk path, it shouldn't try to read local repo