### PR TITLE
perf(vm): avoid zeroed allocation in BasicMemory::clone

### DIFF
--- a/crates/vm/src/system/memory/online/basic.rs
+++ b/crates/vm/src/system/memory/online/basic.rs
@@ -1,5 +1,5 @@
 use std::{
-    alloc::{alloc_zeroed, dealloc, Layout},
+    alloc::{alloc, alloc_zeroed, dealloc, Layout},
     ptr::NonNull,
 };
 
@@ -55,11 +55,11 @@ impl Clone for BasicMemory {
 
         let layout = self.layout;
         // SAFETY:
-        // - alloc_zeroed creates a valid allocation for the layout
+        // - alloc creates a valid allocation for the layout
         // - copy_nonoverlapping copies exactly self.size bytes from valid source to valid dest
         // - new_ptr is guaranteed non-null after alloc check
         let ptr = unsafe {
-            let new_ptr = alloc_zeroed(layout);
+            let new_ptr = alloc(layout);
             if new_ptr.is_null() {
                 std::alloc::handle_alloc_error(layout);
             }


### PR DESCRIPTION
Replace `alloc_zeroed` with `alloc` in `BasicMemory::clone` to avoid unnecessary zero-initialization before copying the existing contents. The clone path always overwrites the entire allocated region with `copy_nonoverlapping`, so zeroing first provides no safety benefit but doubles the amount of memory work for large buffers. The constructor still uses `alloc_zeroed` to preserve the invariant that freshly created linear memory starts zeroed.