### PR TITLE
fix: change index of initial SumcheckClaimsBus send to -1

### DIFF
--- a/crates/recursion/src/batch_constraint/fractions_folder/air.rs
+++ b/crates/recursion/src/batch_constraint/fractions_folder/air.rs
@@ -220,7 +220,7 @@ where
             builder,
             local.proof_idx,
             SumcheckClaimMessage {
-                round: AB::Expr::ZERO,
+                round: AB::Expr::NEG_ONE,
                 value: local.cur_hash.map(Into::into),
             },
             is_last.clone(),

--- a/crates/recursion/src/batch_constraint/sumcheck/univariate/air.rs
+++ b/crates/recursion/src/batch_constraint/sumcheck/univariate/air.rs
@@ -260,7 +260,7 @@ where
             builder,
             local.proof_idx,
             SumcheckClaimMessage {
-                round: AB::Expr::ZERO,
+                round: AB::Expr::NEG_ONE,
                 value: local.sum_at_roots.map(Into::into),
             },
             is_last.clone(),


### PR DESCRIPTION
Resolves INT-6391. `SumcheckClaimsBus` message flow now goes like this:

- `FractionsFolderAir` sends initial round -1 value to `UnivariateSumcheckAir`
- `UnivariateSumcheckAir` sends round 0 value to `MultilinearSumcheckAir`
- `MultilinearSumcheckAir` sends round `n_max` value to `ExpressionClaimAir` (and sends/consumes rounds in between)