### PR TITLE
fix: MultiLinearSumcheckAir findings

### DIFF
--- a/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
+++ b/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
@@ -125,6 +125,8 @@ where
         let is_last_eval =
             LoopSubAir::local_is_last(local.is_valid, next.is_valid, next.is_first_eval);
 
+        let is_proof_transition =
+            LoopSubAir::local_is_transition(next.is_valid, next.is_proof_start);
         let is_proof_end =
             LoopSubAir::local_is_last(local.is_valid, next.is_valid, next.is_proof_start);
 
@@ -241,7 +243,7 @@ where
         ///////////////////////////////////////////////////////////////////////
 
         builder
-            .when(is_transition_eval.clone())
+            .when(is_proof_transition)
             .assert_eq(next.tidx, local.tidx + AB::Expr::from_usize(D_EF));
 
         ///////////////////////////////////////////////////////////////////////

--- a/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
+++ b/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
@@ -119,8 +119,7 @@ where
         let is_last_eval =
             LoopSubAir::local_is_last(local.is_valid, next.is_valid, next.is_first_eval);
 
-        let is_proof_transition =
-            LoopSubAir::local_is_transition(next.is_valid, next.is_proof_start);
+        let is_same_proof = LoopSubAir::local_is_transition(next.is_valid, next.is_proof_start);
         let is_proof_end =
             LoopSubAir::local_is_last(local.is_valid, next.is_valid, next.is_proof_start);
 
@@ -247,7 +246,7 @@ where
         ///////////////////////////////////////////////////////////////////////
 
         builder
-            .when(is_proof_transition)
+            .when(is_same_proof)
             .assert_eq(next.tidx, local.tidx + AB::Expr::from_usize(D_EF));
 
         ///////////////////////////////////////////////////////////////////////

--- a/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
+++ b/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
@@ -93,12 +93,6 @@ where
         let s_deg = self.max_constraint_degree + 1;
 
         ///////////////////////////////////////////////////////////////////////
-        // Boolean Constraints
-        ///////////////////////////////////////////////////////////////////////
-
-        builder.assert_bool(local.is_dummy);
-
-        ///////////////////////////////////////////////////////////////////////
         // Loop Constraints
         ///////////////////////////////////////////////////////////////////////
 
@@ -129,6 +123,16 @@ where
             LoopSubAir::local_is_transition(next.is_valid, next.is_proof_start);
         let is_proof_end =
             LoopSubAir::local_is_last(local.is_valid, next.is_valid, next.is_proof_start);
+
+        // is_dummy forces a proof to be a single row
+        builder.assert_bool(local.is_dummy);
+        builder.when(local.is_dummy).assert_one(local.is_valid);
+        builder
+            .when(local.is_dummy)
+            .assert_one(local.is_proof_start);
+        builder
+            .when(local.is_dummy)
+            .assert_one(is_proof_end.clone());
 
         let is_not_dummy = AB::Expr::ONE - local.is_dummy;
 


### PR DESCRIPTION
Resolves INT-6596, INT-6388, INT-6389.

### INT-6388: lacks same-proof cross-round `tidx` continuity

Now constrains `tidx` increment over all rows in a Proof, not just a round

```rust
let is_proof_transition =
    LoopSubAir::local_is_transition(next.is_valid, next.is_proof_start);
...
builder
    .when(is_proof_transition)
    .assert_eq(next.tidx, local.tidx + AB::Expr::from_usize(D_EF));
```

### INT-6389: `is_dummy` can suppress required interactions

`is_dummy` now forces a proof to be a single row, effectively forcing no multilinear sumcheck rounds to occur.

```rust
builder.when(local.is_dummy).assert_one(local.is_valid);
builder
    .when(local.is_dummy)
    .assert_one(local.is_proof_start);
builder
    .when(local.is_dummy)
    .assert_one(is_proof_end.clone());
```