### PR TITLE
fix: always constrain sum_at_roots's initial value in UnivariateSumcheckAir

### DIFF
--- a/crates/recursion/src/batch_constraint/sumcheck/univariate/air.rs
+++ b/crates/recursion/src/batch_constraint/sumcheck/univariate/air.rs
@@ -25,7 +25,7 @@ use crate::{
         StackingModuleMessage, TranscriptBus,
     },
     subairs::nested_for_loop::{NestedForLoopIoCols, NestedForLoopSubAir},
-    utils::{ext_field_add, ext_field_multiply, ext_field_multiply_scalar},
+    utils::{assert_zeros, ext_field_add, ext_field_multiply, ext_field_multiply_scalar},
 };
 
 #[derive(AlignedBorrow, Clone, Copy, Debug)]
@@ -168,6 +168,12 @@ where
                 .when(local.is_omega_skip_power_equal_to_one),
             local.sum_at_roots,
             ext_field_multiply_scalar(local.coeff, domain_size.clone()),
+        );
+        assert_zeros(
+            &mut builder
+                .when(local.is_first)
+                .when(not(local.is_omega_skip_power_equal_to_one)),
+            local.sum_at_roots,
         );
         // Add c * 2^{l_skip} at every 2^{l_skip} coefficient
         assert_array_eq(


### PR DESCRIPTION
Resolves INT-6390, INT-6597.