### PR TITLE
fix: change MerkleVerify to use interactions for inter-row constraints

### DIFF
--- a/crates/recursion/cuda/src/transcript/merkle_verify.cu
+++ b/crates/recursion/cuda/src/transcript/merkle_verify.cu
@@ -10,25 +10,21 @@
 
 template <typename T> struct MerkleVerifyCols {
     T proof_idx;
-    T is_proof_start;
-    T merkle_proof_idx;
     T is_valid;
-    T is_first_merkle;
     T is_last_merkle;
 
     T is_combining_leaves;
+    T is_last_leaf;
     T leaf_sub_idx;
 
     T idx;
-    T idx_parity;
     T total_depth;
     T height;
 
     T left[DIGEST_SIZE];
     T right[DIGEST_SIZE];
 
-    T recv_left;
-    T recv_right;
+    T recv_flag;
 
     T commit_major;
     T commit_minor;
@@ -125,15 +121,7 @@ __global__ void cukernel_merkle_verify_tracegen(
         );
         bool proof_start =
             record.proof_idx < num_proofs && global_row == proof_row_starts[record.proof_idx];
-        COL_WRITE_VALUE(row, MerkleVerifyCols, is_proof_start, bool_to_fp(proof_start));
-        COL_WRITE_VALUE(
-            row,
-            MerkleVerifyCols,
-            merkle_proof_idx,
-            Fp(static_cast<uint32_t>(record.merkle_proof_idx))
-        );
         COL_WRITE_VALUE(row, MerkleVerifyCols, is_valid, Fp::one());
-        COL_WRITE_VALUE(row, MerkleVerifyCols, is_first_merkle, bool_to_fp(local_row == 0));
         COL_WRITE_VALUE(
             row, MerkleVerifyCols, is_last_merkle, bool_to_fp(local_row + 1 == record.num_rows)
         );
@@ -176,13 +164,12 @@ __global__ void cukernel_merkle_verify_tracegen(
                 row, MerkleVerifyCols, idx, Fp(static_cast<uint32_t>(record.merkle_idx))
             );
             COL_WRITE_VALUE(
-                row, MerkleVerifyCols, idx_parity, Fp(static_cast<uint32_t>(record.merkle_idx & 1))
-            );
-            COL_WRITE_VALUE(
                 row, MerkleVerifyCols, height, Fp(static_cast<uint32_t>(indices.source_layer))
             );
-            COL_WRITE_VALUE(row, MerkleVerifyCols, recv_left, Fp::one());
-            COL_WRITE_VALUE(row, MerkleVerifyCols, recv_right, Fp::one());
+            COL_WRITE_VALUE(
+                row, MerkleVerifyCols, is_last_leaf, bool_to_fp(indices.source_layer + 1 == k)
+            );
+            COL_WRITE_VALUE(row, MerkleVerifyCols, recv_flag, Fp(2));
         } else {
             size_t pos = local_row + 1 - num_leaves;
             const Fp *sibling = siblings + record.siblings_offset + pos * DIGEST_SIZE;
@@ -211,13 +198,10 @@ __global__ void cukernel_merkle_verify_tracegen(
             copy_digest(current_hash, poseidon_state);
             COL_WRITE_VALUE(row, MerkleVerifyCols, is_combining_leaves, Fp::zero());
             COL_WRITE_VALUE(row, MerkleVerifyCols, leaf_sub_idx, Fp::zero());
-            COL_WRITE_VALUE(row, MerkleVerifyCols, idx, Fp(static_cast<uint32_t>(current_idx)));
-            COL_WRITE_VALUE(
-                row, MerkleVerifyCols, idx_parity, Fp(static_cast<uint32_t>(current_idx & 1))
-            );
+            COL_WRITE_VALUE(row, MerkleVerifyCols, idx, record.merkle_idx);
             COL_WRITE_VALUE(row, MerkleVerifyCols, height, Fp(static_cast<uint32_t>(pos + k)));
-            COL_WRITE_VALUE(row, MerkleVerifyCols, recv_left, bool_to_fp(left_is_cur));
-            COL_WRITE_VALUE(row, MerkleVerifyCols, recv_right, bool_to_fp(!left_is_cur));
+            COL_WRITE_VALUE(row, MerkleVerifyCols, is_last_leaf, Fp::zero());
+            COL_WRITE_VALUE(row, MerkleVerifyCols, recv_flag, bool_to_fp(!left_is_cur));
             current_idx >>= 1;
         }
         COL_WRITE_ARRAY(row, MerkleVerifyCols, output, poseidon_state);

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -421,6 +421,8 @@ pub struct MerkleVerifyBusMessage<T> {
     /// The height of this value, [0, k) are for the hashing leaves part, [k, total_depth) are for
     /// the merkle proof part.
     pub height: T,
+    /// Boolean value that indicates if this message is for the hashing leaves or Merkle proof part
+    pub is_leaf: T,
     /// For the leaves, it will be 0 ~ 2^k - 1, for the next intermediate values, it will be 0 ~
     /// 2^{k-1} - 1 0 for merkle proof part.
     pub leaf_sub_idx: T,

--- a/crates/recursion/src/transcript/merkle_verify/air.rs
+++ b/crates/recursion/src/transcript/merkle_verify/air.rs
@@ -37,21 +37,22 @@ use crate::bus::{
 #[repr(C)]
 #[derive(AlignedBorrow)]
 pub struct MerkleVerifyCols<T> {
+    /// Index of the proof this row is for
     pub proof_idx: T,
-    pub is_proof_start: T,
-    pub merkle_proof_idx: T,
+    /// Indicator: whether this row is valid
     pub is_valid: T,
-    /// Indicator: whether this is the first row of a merkle proof
-    pub is_first_merkle: T,
     /// Indicator: whether this is the last row of a merkle proof
     pub is_last_merkle: T,
 
+    /// Indicator: whether this row hashes two leaves or is part of the Merkle path proof
     pub is_combining_leaves: T,
+    /// Indicator: whether this row is the root of the hashed leaves
+    pub is_last_leaf: T,
+    /// Row node index of this node in the leaf hash tree, 0 if is_combining_leaves is false
     pub leaf_sub_idx: T,
 
-    /// The merkle idx, of the current level
+    /// The merkle idx of the leaf hash root
     pub idx: T,
-    pub idx_parity: T, // 0 for even, 1 for odd, of the merkle idx
     /// Total depth of the merkle proof including the leaves part = merkle_proof.len() + 1 + k
     pub total_depth: T,
     /// 0 -> total_depth - 1, where leaves are at height 0, combined leaf hash is at height k
@@ -60,9 +61,8 @@ pub struct MerkleVerifyCols<T> {
     pub left: [T; DIGEST_SIZE],
     pub right: [T; DIGEST_SIZE],
 
-    /// Indicator: whether to receive the left/right value
-    pub recv_left: T,
-    pub recv_right: T,
+    /// Flag that indicates what to receive; 0 for left, 1 for right, 2 for both
+    pub recv_flag: T,
 
     pub commit_major: T,
     pub commit_minor: T,
@@ -85,6 +85,7 @@ pub struct MerkleVerifyAir {
     pub poseidon2_compress_bus: Poseidon2CompressBus,
     pub merkle_verify_bus: MerkleVerifyBus,
     pub commitments_bus: CommitmentsBus,
+    pub k: usize,
 }
 
 impl<F: Field> BaseAir<F> for MerkleVerifyAir {
@@ -99,23 +100,17 @@ impl<F: Field> PartitionedBaseAir<F> for MerkleVerifyAir {}
 impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let (local, next) = (
-            main.row_slice(0).expect("window should have two elements"),
-            main.row_slice(1).expect("window should have two elements"),
-        );
+        let local = main.row_slice(0).expect("window should have two elements");
         let local: &MerkleVerifyCols<AB::Var> = (*local).borrow();
-        let next: &MerkleVerifyCols<AB::Var> = (*next).borrow();
 
         ///////////////////////////////////////////////////////////////////////
         // Constraints
         ///////////////////////////////////////////////////////////////////////
         builder.assert_bool(local.is_valid);
-        builder.assert_bool(local.is_proof_start);
-        builder.assert_bool(local.is_first_merkle);
         builder.assert_bool(local.is_last_merkle);
         builder.assert_bool(local.is_combining_leaves);
-        builder.assert_bool(local.recv_left);
-        builder.assert_bool(local.recv_right);
+        builder.assert_bool(local.is_last_leaf);
+        builder.assert_tern(local.recv_flag);
 
         // At the last row, the cur hash should be consistent with the commit
         for i in 0..DIGEST_SIZE {
@@ -124,48 +119,51 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
                 .assert_eq(local.left[i], local.right[i]);
         }
 
-        // Boundary constraints
-        builder
-            .when(local.is_first_merkle)
-            .assert_zero(local.height);
+        // Last row for a Merkle tree should have height + 1 == total_depth
         builder
             .when(local.is_last_merkle)
-            .assert_eq(local.total_depth, local.height + AB::Expr::ONE);
+            .assert_eq(local.height + AB::Expr::ONE, local.total_depth);
 
-        // transition of idx and depth, during merkle proof part
-        let is_merkle_transition = (AB::Expr::ONE - local.is_last_merkle)
-            * local.is_valid
-            * (AB::Expr::ONE - local.is_combining_leaves);
+        // When is_combining_leaves is false, leaf_sub_idx must be 0
         builder
-            .when(is_merkle_transition.clone())
-            .assert_eq(local.height + AB::Expr::ONE, next.height);
-        builder.assert_bool(local.idx_parity);
-        builder.when(is_merkle_transition.clone()).assert_eq(
-            local.idx,
-            next.idx * AB::Expr::from_usize(2) + local.idx_parity,
-        );
+            .when(AB::Expr::ONE - local.is_combining_leaves)
+            .assert_zero(local.leaf_sub_idx);
 
-        // Always receive both left and right for combining leaves part, otherwise receive only one
-        // of them
+        // On the last leaf, leaf_sub_idx must be 0 and height + 1 must be k
+        builder
+            .when(local.is_last_leaf)
+            .assert_one(local.is_combining_leaves);
+        builder
+            .when(local.is_last_leaf)
+            .assert_zero(local.leaf_sub_idx);
+        builder
+            .when(local.is_last_leaf)
+            .assert_eq(local.height + AB::Expr::ONE, AB::Expr::from_usize(self.k));
+
+        // Receive both left and right for combining leaves part, otherwise receive only one
         builder
             .when(local.is_combining_leaves)
-            .assert_one(local.recv_left);
+            .assert_one(local.is_valid);
         builder
             .when(local.is_combining_leaves)
-            .assert_one(local.recv_right);
+            .assert_eq(local.recv_flag, AB::Expr::TWO);
         builder
-            .when((AB::Expr::ONE - local.is_combining_leaves) * local.is_valid)
-            .assert_one(local.recv_right + local.recv_left);
+            .when_ne(local.is_combining_leaves, AB::Expr::ONE)
+            .assert_bool(local.recv_flag);
 
         ///////////////////////////////////////////////////////////////////////
         // Interactions
         ///////////////////////////////////////////////////////////////////////
 
         // This is 2x / 2x + 1 if it's a combining leaves part, otherwise it's 0.
-        let left_leaf_sub_idx =
-            local.is_combining_leaves * local.leaf_sub_idx * AB::Expr::from_usize(2);
-        let right_leaf_sub_idx = local.is_combining_leaves
-            * (local.leaf_sub_idx * AB::Expr::from_usize(2) + AB::Expr::ONE);
+        let left_leaf_sub_idx = local.is_combining_leaves * local.leaf_sub_idx * AB::Expr::TWO;
+        let right_leaf_sub_idx =
+            local.is_combining_leaves * (local.leaf_sub_idx * AB::Expr::TWO + AB::Expr::ONE);
+
+        let recv_left = (local.recv_flag - AB::Expr::ONE).square();
+        let recv_right =
+            local.recv_flag * (AB::Expr::from_u8(3) - local.recv_flag) * AB::F::TWO.inverse();
+
         self.merkle_verify_bus.receive(
             builder,
             local.proof_idx,
@@ -174,11 +172,12 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
                 merkle_idx: local.idx.into(),
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
+                is_leaf: local.is_combining_leaves.into(),
                 leaf_sub_idx: left_leaf_sub_idx,
                 commit_major: local.commit_major.into(),
                 commit_minor: local.commit_minor.into(),
             },
-            local.is_valid * local.recv_left,
+            local.is_valid * recv_left,
         );
         self.merkle_verify_bus.receive(
             builder,
@@ -188,24 +187,23 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
                 merkle_idx: local.idx.into(),
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
+                is_leaf: local.is_combining_leaves.into(),
                 leaf_sub_idx: right_leaf_sub_idx,
                 commit_major: local.commit_major.into(),
                 commit_minor: local.commit_minor.into(),
             },
-            local.is_valid * local.recv_right,
+            local.is_valid * recv_right,
         );
-        // At "combining leaves" part, the idx is the same for all the rows.
-        // Otherwise the idx should be half of the previous idx, which is just next.idx.
-        let send_merkle_idx = local.idx * local.is_combining_leaves
-            + (AB::Expr::ONE - local.is_combining_leaves) * next.idx;
+
         self.merkle_verify_bus.send(
             builder,
             local.proof_idx,
             MerkleVerifyBusMessage {
                 value: local.compression_output.map(Into::into),
-                merkle_idx: send_merkle_idx,
+                merkle_idx: local.idx.into(),
                 total_depth: local.total_depth.into(),
                 height: local.height + AB::Expr::ONE,
+                is_leaf: local.is_combining_leaves - local.is_last_leaf,
                 leaf_sub_idx: local.leaf_sub_idx.into(),
                 commit_major: local.commit_major.into(),
                 commit_minor: local.commit_minor.into(),

--- a/crates/recursion/src/transcript/merkle_verify/trace.rs
+++ b/crates/recursion/src/transcript/merkle_verify/trace.rs
@@ -125,9 +125,6 @@ pub fn generate_trace(
         }
 
         let cols: &mut MerkleVerifyCols<F> = row.borrow_mut();
-        if idx_in_proof == 0 {
-            cols.is_proof_start = F::ONE;
-        }
         // determine the layer and offset in the leaf_tree
         // 0th layer: [0, num_leaves / 2)
         // 1st layer: [num_leaves / 2, num_leaves / 2 + num_leaves / 4)
@@ -136,16 +133,12 @@ pub fn generate_trace(
 
         cols.is_valid = F::ONE;
         cols.proof_idx = F::from_usize(proof_idx);
-        cols.merkle_proof_idx = F::from_usize(merkle_proof_idx);
         cols.commit_major = F::from_usize(commit_major);
         cols.commit_minor = F::from_usize(commit_minor);
         cols.total_depth = F::from_usize(depth + k + 1);
 
         if i == depth + num_leaves - 1 {
             cols.is_last_merkle = F::ONE;
-        }
-        if i == 0 {
-            cols.is_first_merkle = F::ONE;
         }
 
         if let Some(combination_indices) = combination_indices {
@@ -159,10 +152,9 @@ pub fn generate_trace(
             cols.compression_output = output;
 
             cols.idx = F::from_usize(merkle_idx); // const idx for leaves part
-            cols.idx_parity = F::from_usize(merkle_idx % 2);
             cols.height = F::from_usize(combination_indices.source_layer);
-            cols.recv_left = F::ONE;
-            cols.recv_right = F::ONE;
+            cols.is_last_leaf = F::from_bool(combination_indices.source_layer + 1 == k);
+            cols.recv_flag = F::TWO;
 
             let mut input_state = [F::ZERO; POSEIDON2_WIDTH];
             input_state[..DIGEST_SIZE].copy_from_slice(&cols.left);
@@ -192,11 +184,11 @@ pub fn generate_trace(
             if cur_idx % 2 == 0 {
                 cols.left = cur_hash;
                 cols.right = sibling;
-                cols.recv_left = F::ONE;
+                cols.recv_flag = F::ZERO;
             } else {
                 cols.left = sibling;
                 cols.right = cur_hash;
-                cols.recv_right = F::ONE;
+                cols.recv_flag = F::ONE;
             }
 
             let output = poseidon2_compress_with_capacity(cols.left, cols.right).0;
@@ -206,8 +198,7 @@ pub fn generate_trace(
             input_state[DIGEST_SIZE..].copy_from_slice(&cols.right);
             poseidon2_compress_inputs.push(input_state);
 
-            cols.idx = F::from_usize(cur_idx);
-            cols.idx_parity = F::from_usize(cur_idx % 2);
+            cols.idx = F::from_usize(merkle_idx);
             cols.height = F::from_usize(i + 1 - num_leaves + k);
             cols.is_combining_leaves = F::ZERO;
 

--- a/crates/recursion/src/transcript/mod.rs
+++ b/crates/recursion/src/transcript/mod.rs
@@ -288,6 +288,7 @@ impl AirModule for TranscriptModule {
             poseidon2_compress_bus: self.bus_inventory.poseidon2_compress_bus,
             merkle_verify_bus: self.bus_inventory.merkle_verify_bus,
             commitments_bus: self.bus_inventory.commitments_bus,
+            k: self.params.k_whir(),
         };
         vec![
             Arc::new(transcript_air),

--- a/crates/recursion/src/whir/initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/initial_opened_values/air.rs
@@ -302,6 +302,7 @@ where
                 merkle_idx: local.merkle_idx_bit_src.into(),
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1),
                 height: AB::Expr::ZERO,
+                is_leaf: AB::Expr::ONE,
                 leaf_sub_idx: local.coset_idx.into(),
                 value: array::from_fn(|i| local.post_state[i].into()),
                 commit_major: AB::Expr::ZERO,

--- a/crates/recursion/src/whir/non_initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/non_initial_opened_values/air.rs
@@ -197,6 +197,7 @@ where
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1)
                     - local.whir_round,
                 height: AB::Expr::ZERO,
+                is_leaf: AB::Expr::ONE,
                 leaf_sub_idx: local.coset_idx.into(),
                 commit_major: local.whir_round.into(),
                 commit_minor: AB::Expr::ZERO,


### PR DESCRIPTION
Resolves INT-6587, INT-6329, INT-6451, INT-6452, INT-6453, INT-6454, INT-6455, INT-6456.

In addition to the fixes specified below, this PR also does the following (as this AIR will probably require a re-audit):

- Adds `is_last_leaf` to `MerkleVerifyCols` and `is_leaf` to `MerkleVerifyBusMessage` to constrain that the leaf Merkle tree has height `k`
- Collapses `recv_left` and `recv_right` into `recv_flag`

Note that this AIR currently constrains that there **exists** a Merkle path between the leaf root and the final commit, and not the path topology.

### INT-6329: `idx_parity` not bound to `recv` side in Merkle-proof rows

Removed `idx_parity` field, leaving `recv_flag` to determine the path topology.

### INT-6451: `is_valid` row-shape is underconstrained
### INT-6452: `is_first_merkle` not anchored to segment starts
### INT-6453: `is_last_merkle` not anchored to segment ends
### INT-6456: `proof_idx` not transition-constrained while next-row semantics assume same-proof continuity

Removed `next` constraints, constraining inter-row statements using interactions only. As a result, `is_first_merkle` was removed and `is_last_merkle` only needs to do a `height` check.

### INT-6454: `is_proof_start` is unconstrained structural selector
### INT-6455: `merkle_proof_idx` is unconstrained and unused

Removed both `is_proof_start` and `merkle_proof_idx`.