### PR TITLE
fix: TranscriptAir findings

### DIFF
--- a/crates/recursion/cuda/src/transcript/transcript.cu
+++ b/crates/recursion/cuda/src/transcript/transcript.cu
@@ -17,7 +17,6 @@ template <typename T> struct TranscriptCols {
     T is_sample;
     T mask[CHUNK];
 
-    T permuted;
     T prev_state[WIDTH];
     T post_state[WIDTH];
 };
@@ -69,7 +68,6 @@ __global__ void transcript_air_tracegen_kernel(
     COL_WRITE_VALUE(row, TranscriptCols, is_proof_start, row_idx == 0);
     COL_WRITE_VALUE(row, TranscriptCols, is_sample, is_sample);
     COL_WRITE_VALUE(row, TranscriptCols, tidx, tidx);
-    COL_WRITE_VALUE(row, TranscriptCols, permuted, permuted);
 
 #pragma unroll
     for (uint8_t i = 0; i < CHUNK; i++) {

--- a/crates/recursion/src/transcript/mod.rs
+++ b/crates/recursion/src/transcript/mod.rs
@@ -199,7 +199,6 @@ impl TranscriptModule {
                         break;
                     }
                 }
-                cols.permuted = F::from_bool(permuted);
 
                 prev_poseidon_state = cols.prev_state;
                 if permuted {

--- a/crates/recursion/src/transcript/transcript/air.rs
+++ b/crates/recursion/src/transcript/transcript/air.rs
@@ -35,8 +35,6 @@ pub struct TranscriptCols<T> {
     /// are sent with multiplicity 0 or 1, this also functions as the lookup count.
     pub mask: [T; CHUNK],
 
-    /// indicator, whether the state is permutation from previous row's state
-    pub permuted: T,
     /// The poseidon2 state.
     pub prev_state: [T; POSEIDON2_WIDTH],
     pub post_state: [T; POSEIDON2_WIDTH],
@@ -143,19 +141,6 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
             .when_ne(local.is_sample, not(next.is_sample))
             .assert_eq(count, AB::Expr::from_usize(CHUNK));
 
-        // Permute on all non-final rows except when going from sample to observe
-        when_same_proof
-            .when(not(local.is_sample))
-            .assert_one(local.permuted);
-        when_same_proof
-            .when(local.is_sample)
-            .assert_eq(local.permuted, next.is_sample);
-
-        // We never permute on the final row
-        builder
-            .when(not::<AB::Expr>(local_next_same_proof))
-            .assert_zero(local.permuted);
-
         ///////////////////////////////////////////////////////////////////////
         // Interactions
         ///////////////////////////////////////////////////////////////////////
@@ -186,14 +171,17 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
             );
         }
 
-        builder.assert_bool(local.permuted);
+        // Permute on all non-final rows except when going from sample to observe,
+        // and never on the final row.
+        let permuted =
+            local_next_same_proof * not::<AB::Expr>(and(local.is_sample, not(next.is_sample)));
         self.poseidon2_permute_bus.lookup_key(
             builder,
             Poseidon2PermuteMessage {
                 input: local.prev_state,
                 output: local.post_state,
             },
-            local.permuted,
+            permuted,
         );
 
         if let Some(final_state_bus) = self.final_state_bus {

--- a/crates/recursion/src/transcript/transcript/air.rs
+++ b/crates/recursion/src/transcript/transcript/air.rs
@@ -1,6 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::utils::{and, not, or};
+use openvm_circuit_primitives::{
+    utils::{and, not, or},
+    SubAir,
+};
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
@@ -14,6 +17,7 @@ use crate::{
         FinalTranscriptStateBus, FinalTranscriptStateMessage, Poseidon2PermuteBus,
         Poseidon2PermuteMessage, TranscriptBus, TranscriptBusMessage,
     },
+    subairs::nested_for_loop::{NestedForLoopIoCols, NestedForLoopSubAir},
     transcript::poseidon2::{CHUNK, POSEIDON2_WIDTH},
 };
 
@@ -67,6 +71,25 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
         // Constraints
         ///////////////////////////////////////////////////////////////////////
         let is_valid = local.mask[0];
+        let next_valid = next.mask[0];
+
+        NestedForLoopSubAir::<1> {}.eval(
+            builder,
+            (
+                NestedForLoopIoCols {
+                    is_enabled: is_valid,
+                    counter: [local.proof_idx],
+                    is_first: [local.is_proof_start],
+                }
+                .map_into(),
+                NestedForLoopIoCols {
+                    is_enabled: next_valid,
+                    counter: [next.proof_idx],
+                    is_first: [next.is_proof_start],
+                }
+                .map_into(),
+            ),
+        );
 
         builder.when(local.is_proof_start).assert_zero(local.tidx);
         builder.when(local.is_proof_start).assert_one(is_valid);
@@ -84,7 +107,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
         }
 
         let mut count = AB::Expr::ZERO;
-        let local_next_same_proof = next.mask[0] * (AB::Expr::ONE - next.is_proof_start);
+        let local_next_same_proof = next_valid * (AB::Expr::ONE - next.is_proof_start);
         for i in 0..CHUNK {
             builder.assert_bool(local.mask[i]);
             count += local.mask[i].into();
@@ -157,7 +180,6 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
         );
 
         if let Some(final_state_bus) = self.final_state_bus {
-            let next_valid = next.mask[0];
             final_state_bus.send(
                 builder,
                 local.proof_idx,

--- a/crates/recursion/src/transcript/transcript/air.rs
+++ b/crates/recursion/src/transcript/transcript/air.rs
@@ -107,7 +107,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
         }
 
         let mut count = AB::Expr::ZERO;
-        let local_next_same_proof = next_valid * (AB::Expr::ONE - next.is_proof_start);
+        let local_next_same_proof = next_valid - next.is_proof_start;
         for i in 0..CHUNK {
             builder.assert_bool(local.mask[i]);
             count += local.mask[i].into();
@@ -135,9 +135,21 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
                 .assert_eq(local.post_state[i + CHUNK], next.prev_state[i + CHUNK]);
         }
 
+        let mut when_same_proof = builder.when(local_next_same_proof.clone());
+        when_same_proof.assert_eq(next.tidx, local.tidx + count);
+
+        // Permute on all non-final rows except when going from sample to observe
+        when_same_proof
+            .when(not(local.is_sample))
+            .assert_one(local.permuted);
+        when_same_proof
+            .when(local.is_sample)
+            .assert_eq(local.permuted, next.is_sample);
+
+        // We never permute on the final row
         builder
-            .when(local_next_same_proof) // if next is valid
-            .assert_eq(next.tidx, local.tidx + count);
+            .when(not::<AB::Expr>(local_next_same_proof))
+            .assert_zero(local.permuted);
 
         ///////////////////////////////////////////////////////////////////////
         // Interactions

--- a/crates/recursion/src/transcript/transcript/air.rs
+++ b/crates/recursion/src/transcript/transcript/air.rs
@@ -136,7 +136,12 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
         }
 
         let mut when_same_proof = builder.when(local_next_same_proof.clone());
-        when_same_proof.assert_eq(next.tidx, local.tidx + count);
+        when_same_proof.assert_eq(next.tidx, local.tidx + count.clone());
+
+        // If local.is_sample = next.is_sample, there have to be CHUNK operations
+        when_same_proof
+            .when_ne(local.is_sample, not(next.is_sample))
+            .assert_eq(count, AB::Expr::from_usize(CHUNK));
 
         // Permute on all non-final rows except when going from sample to observe
         when_same_proof


### PR DESCRIPTION
Resolves INT-6586, INT-6326, INT-6327, INT-6328, INT-6457, INT-6647.

### INT-6326: bridge rows bypass continuity via disabled row insertion
### INT-6328: `is_proof_start` missing booleanity constraint
### INT-6329: `local_next_same_proof` is not tied to `proof_idx`

Inserted `NestedForLoopSubAir` to constrain `proof_idx` semantics. All above tickets are resolved as a result.

### INT-6457: `permuted` flag not constrained to transcript semantics

Removed `permuted` column, replacing it with an algebraically derived value.

```rust
let permuted =
    local_next_same_proof * not::<AB::Expr>(and(local.is_sample, not(next.is_sample)));
```

### INT-6647: when `local.is_sample == next.is_sample` count must be `CHUNK`

Added check for the above