### PR TITLE
chore(cuda): use new backend with bn254 engine

### DIFF
--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -20,7 +20,7 @@ jobs:
   cuda-backend:
     name: recursion cuda tracegen tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6+g5+g6e
+      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6.*+g5+g6e
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e839523331ce32267c6e8600c4322fdfd7abac39"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -3200,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e839523331ce32267c6e8600c4322fdfd7abac39"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -3216,6 +3216,7 @@ dependencies = [
  "p3-util",
  "rand 0.9.2",
  "rustc-hash",
+ "serde",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -3223,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e839523331ce32267c6e8600c4322fdfd7abac39"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
 dependencies = [
  "cc",
  "glob",
@@ -3232,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e839523331ce32267c6e8600c4322fdfd7abac39"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
 dependencies = [
  "bytesize",
  "ctor",
@@ -3926,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e839523331ce32267c6e8600c4322fdfd7abac39"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -3960,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e839523331ce32267c6e8600c4322fdfd7abac39"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -3200,16 +3200,18 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
+ "glob",
  "itertools 0.14.0",
  "openvm-cuda-builder",
  "openvm-cuda-common",
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "p3-baby-bear",
+ "p3-bn254",
  "p3-dft",
  "p3-field",
  "p3-symmetric",
@@ -3219,12 +3221,13 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tracing",
+ "zkhash",
 ]
 
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
 dependencies = [
  "cc",
  "glob",
@@ -3233,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
 dependencies = [
  "bytesize",
  "ctor",
@@ -3927,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -3961,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fgeneric-gpuengine#c6baf814bd2c4ebdfd4346122718cf7975f547bc"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,22 +624,8 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648bd963d2e5d465377acecfb4b827f9f553b6bc97a8f61715779e9ed9e52b74"
 dependencies = [
- "arrayvec",
- "bitcode_derive",
  "bytemuck",
- "glam",
  "serde",
-]
-
-[[package]]
-name = "bitcode_derive"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffebfc2d28a12b262c303cb3860ee77b91bd83b1f20f0bd2a9693008e2f55a9e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -969,6 +955,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.15",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1619,6 +1614,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,12 +1995,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glam"
-version = "0.30.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d1aab06663bdce00d6ca5e5ed586ec8d18033a771906c993a1e3755b368d85"
 
 [[package]]
 name = "glob"
@@ -3189,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#b140f48021c04410d54696640a9a366b84d09188"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -3200,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#b140f48021c04410d54696640a9a366b84d09188"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -3227,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#b140f48021c04410d54696640a9a366b84d09188"
 dependencies = [
  "cc",
  "glob",
@@ -3236,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#b140f48021c04410d54696640a9a366b84d09188"
 dependencies = [
  "bytesize",
  "ctor",
@@ -3930,9 +3931,8 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#b140f48021c04410d54696640a9a366b84d09188"
 dependencies = [
- "bitcode",
  "cfg-if",
  "derivative",
  "derive-new 0.7.0",
@@ -3952,6 +3952,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
+ "postcard",
  "rayon",
  "rustc-hash",
  "serde",
@@ -3964,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=chore%2Fbn254#bc8c1b0d9572ee5f5281b6f1e9662af49db18f71"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#b140f48021c04410d54696640a9a366b84d09188"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",
@@ -4509,6 +4510,18 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "postgres"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,12 +116,12 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
-openvm-codec-derive = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
-openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
-openvm-cuda-builder = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
-openvm-cuda-common = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
+openvm-codec-derive = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
+openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
+openvm-cuda-builder = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
+openvm-cuda-common = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,12 +116,12 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
-openvm-codec-derive = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
-openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
-openvm-cuda-builder = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
-openvm-cuda-common = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
+openvm-codec-derive = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
+openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
+openvm-cuda-builder = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
+openvm-cuda-common = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,12 +116,12 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
-openvm-codec-derive = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
-openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
-openvm-cuda-builder = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
-openvm-cuda-common = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/generic-gpuengine", default-features = false }
+openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
+openvm-codec-derive = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
+openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
+openvm-cuda-builder = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
+openvm-cuda-common = { git = "https://github.com/openvm-org/stark-backend.git", branch = "chore/bn254", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }
@@ -269,3 +269,4 @@ cuda-runtime-sys = "0.3.0-alpha.1"
 
 [workspace.metadata.cargo-shear]
 ignored = ["cargo-openvm"]
+

--- a/crates/continuations-v2/Cargo.toml
+++ b/crates/continuations-v2/Cargo.toml
@@ -55,6 +55,7 @@ cuda = [
     "openvm-circuit/cuda",
     "openvm-rv32im-circuit/cuda",
     "recursion-circuit/cuda",
+    "openvm-cuda-backend/baby-bear-bn254-poseidon2",
 ]
 touchemall = [
     "cuda",

--- a/crates/continuations-v2/Cargo.toml
+++ b/crates/continuations-v2/Cargo.toml
@@ -27,7 +27,7 @@ cfg-if.workspace = true
 num-bigint.workspace = true
 
 openvm-cuda-common = { workspace = true, optional = true }
-openvm-cuda-backend = { workspace = true, optional = true }
+openvm-cuda-backend = { workspace = true, optional = true, features = ["baby-bear-bn254-poseidon2"] }
 
 [dev-dependencies]
 openvm-rv32im-circuit = { workspace = true, features = ["test-utils"] }

--- a/crates/continuations-v2/src/circuit/root/trace.rs
+++ b/crates/continuations-v2/src/circuit/root/trace.rs
@@ -6,7 +6,10 @@ use openvm_circuit::{
     system::memory::{dimensions::MemoryDimensions, merkle::public_values::UserPublicValuesProof},
 };
 #[cfg(feature = "cuda")]
-use openvm_cuda_backend::{data_transporter::transport_air_proving_ctx_to_device, GpuBackend};
+use openvm_cuda_backend::{
+    data_transporter::transport_air_proving_ctx_to_device, BabyBearBn254Poseidon2HashScheme,
+    GenericGpuBackend, GpuBackend,
+};
 use openvm_stark_backend::{
     proof::Proof,
     prover::{AirProvingContext, CpuBackend, ProverBackend},
@@ -106,6 +109,65 @@ impl<SC: StarkProtocolConfig<F = F>> RootTraceGen<CpuBackend<SC>> for RootTraceG
             (None, vec![])
         };
         (paths_ctx.into_iter().collect_vec(), paths_inputs)
+    }
+}
+
+/// Coerces `AirProvingContext<GpuBackend>` into the Bn254 backend context.
+///
+/// Safe because both backends share `Val = BabyBear` and `Matrix = DeviceMatrix<F>`.
+/// Panics in debug builds if `cached_mains` is non-empty (commitment types differ).
+#[cfg(feature = "cuda")]
+fn coerce_gpu_to_bn254_ctx(
+    ctx: AirProvingContext<GpuBackend>,
+) -> AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> {
+    debug_assert!(ctx.cached_mains.is_empty());
+    AirProvingContext {
+        cached_mains: vec![],
+        common_main: ctx.common_main,
+        public_values: ctx.public_values,
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootTraceGenImpl {
+    fn new(deferral_enabled: bool) -> Self {
+        Self { deferral_enabled }
+    }
+
+    fn generate_pre_verifier_subcircuit_ctx(
+        &self,
+        proof: &Proof<BabyBearPoseidon2Config>,
+        user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, F>,
+        memory_dimensions: MemoryDimensions,
+    ) -> (
+        Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
+        Vec<[F; POSEIDON2_WIDTH]>,
+    ) {
+        let (cpu_ctxs, inputs) =
+            self.generate_pre_verifier_subcircuit_ctx(proof, user_pvs_proof, memory_dimensions);
+        let gpu_ctxs = cpu_ctxs
+            .into_iter()
+            .map(|ctx| coerce_gpu_to_bn254_ctx(transport_air_proving_ctx_to_device(ctx)))
+            .collect_vec();
+        (gpu_ctxs, inputs)
+    }
+
+    fn generate_other_proving_ctxs(
+        &self,
+        proof: &Proof<BabyBearPoseidon2Config>,
+        memory_dimensions: MemoryDimensions,
+        deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
+    ) -> (
+        Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
+        Vec<[F; POSEIDON2_WIDTH]>,
+    ) {
+        let (cpu_ctxs, inputs) =
+            self.generate_other_proving_ctxs(proof, memory_dimensions, deferral_merkle_proofs);
+        let gpu_ctxs = cpu_ctxs
+            .into_iter()
+            .map(|ctx| coerce_gpu_to_bn254_ctx(transport_air_proving_ctx_to_device(ctx)))
+            .collect_vec();
+        (gpu_ctxs, inputs)
     }
 }
 

--- a/crates/continuations-v2/src/circuit/root/trace.rs
+++ b/crates/continuations-v2/src/circuit/root/trace.rs
@@ -7,8 +7,8 @@ use openvm_circuit::{
 };
 #[cfg(feature = "cuda")]
 use openvm_cuda_backend::{
-    data_transporter::transport_air_proving_ctx_to_device, BabyBearBn254Poseidon2HashScheme,
-    GenericGpuBackend,
+    data_transporter::transport_air_proving_ctx_to_device, BabyBearBn254Poseidon2GpuEngine,
+    BabyBearBn254Poseidon2HashScheme,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -113,7 +113,7 @@ impl<SC: StarkProtocolConfig<F = F>> RootTraceGen<CpuBackend<SC>> for RootTraceG
 }
 
 #[cfg(feature = "cuda")]
-impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootTraceGenImpl {
+impl RootTraceGen<BabyBearBn254Poseidon2GpuEngine> for RootTraceGenImpl {
     fn new(deferral_enabled: bool) -> Self {
         Self { deferral_enabled }
     }
@@ -124,7 +124,7 @@ impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootT
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, F>,
         memory_dimensions: MemoryDimensions,
     ) -> (
-        Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
+        Vec<AirProvingContext<BabyBearBn254Poseidon2GpuEngine>>,
         Vec<[F; POSEIDON2_WIDTH]>,
     ) {
         let (cpu_ctxs, inputs) =
@@ -142,7 +142,7 @@ impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootT
         memory_dimensions: MemoryDimensions,
         deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
     ) -> (
-        Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
+        Vec<AirProvingContext<BabyBearBn254Poseidon2GpuEngine>>,
         Vec<[F; POSEIDON2_WIDTH]>,
     ) {
         let (cpu_ctxs, inputs) =

--- a/crates/continuations-v2/src/circuit/root/trace.rs
+++ b/crates/continuations-v2/src/circuit/root/trace.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
 #[cfg(feature = "cuda")]
 use openvm_cuda_backend::{
     data_transporter::transport_air_proving_ctx_to_device, BabyBearBn254Poseidon2HashScheme,
-    GenericGpuBackend, GpuBackend,
+    GenericGpuBackend,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -112,22 +112,6 @@ impl<SC: StarkProtocolConfig<F = F>> RootTraceGen<CpuBackend<SC>> for RootTraceG
     }
 }
 
-/// Coerces `AirProvingContext<GpuBackend>` into the Bn254 backend context.
-///
-/// Safe because both backends share `Val = BabyBear` and `Matrix = DeviceMatrix<F>`.
-/// Panics in debug builds if `cached_mains` is non-empty (commitment types differ).
-#[cfg(feature = "cuda")]
-fn coerce_gpu_to_bn254_ctx(
-    ctx: AirProvingContext<GpuBackend>,
-) -> AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> {
-    debug_assert!(ctx.cached_mains.is_empty());
-    AirProvingContext {
-        cached_mains: vec![],
-        common_main: ctx.common_main,
-        public_values: ctx.public_values,
-    }
-}
-
 #[cfg(feature = "cuda")]
 impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootTraceGenImpl {
     fn new(deferral_enabled: bool) -> Self {
@@ -147,7 +131,7 @@ impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootT
             self.generate_pre_verifier_subcircuit_ctx(proof, user_pvs_proof, memory_dimensions);
         let gpu_ctxs = cpu_ctxs
             .into_iter()
-            .map(|ctx| coerce_gpu_to_bn254_ctx(transport_air_proving_ctx_to_device(ctx)))
+            .map(transport_air_proving_ctx_to_device::<BabyBearBn254Poseidon2HashScheme>)
             .collect_vec();
         (gpu_ctxs, inputs)
     }
@@ -165,50 +149,7 @@ impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootT
             self.generate_other_proving_ctxs(proof, memory_dimensions, deferral_merkle_proofs);
         let gpu_ctxs = cpu_ctxs
             .into_iter()
-            .map(|ctx| coerce_gpu_to_bn254_ctx(transport_air_proving_ctx_to_device(ctx)))
-            .collect_vec();
-        (gpu_ctxs, inputs)
-    }
-}
-
-#[cfg(feature = "cuda")]
-impl RootTraceGen<GpuBackend> for RootTraceGenImpl {
-    fn new(deferral_enabled: bool) -> Self {
-        Self { deferral_enabled }
-    }
-
-    fn generate_pre_verifier_subcircuit_ctx(
-        &self,
-        proof: &Proof<BabyBearPoseidon2Config>,
-        user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, F>,
-        memory_dimensions: MemoryDimensions,
-    ) -> (
-        Vec<AirProvingContext<GpuBackend>>,
-        Vec<[F; POSEIDON2_WIDTH]>,
-    ) {
-        let (cpu_ctxs, inputs) =
-            self.generate_pre_verifier_subcircuit_ctx(proof, user_pvs_proof, memory_dimensions);
-        let gpu_ctxs = cpu_ctxs
-            .into_iter()
-            .map(transport_air_proving_ctx_to_device)
-            .collect_vec();
-        (gpu_ctxs, inputs)
-    }
-
-    fn generate_other_proving_ctxs(
-        &self,
-        proof: &Proof<BabyBearPoseidon2Config>,
-        memory_dimensions: MemoryDimensions,
-        deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
-    ) -> (
-        Vec<AirProvingContext<GpuBackend>>,
-        Vec<[F; POSEIDON2_WIDTH]>,
-    ) {
-        let (cpu_ctxs, inputs) =
-            self.generate_other_proving_ctxs(proof, memory_dimensions, deferral_merkle_proofs);
-        let gpu_ctxs = cpu_ctxs
-            .into_iter()
-            .map(transport_air_proving_ctx_to_device)
+            .map(transport_air_proving_ctx_to_device::<BabyBearBn254Poseidon2HashScheme>)
             .collect_vec();
         (gpu_ctxs, inputs)
     }

--- a/crates/continuations-v2/src/circuit/root/trace.rs
+++ b/crates/continuations-v2/src/circuit/root/trace.rs
@@ -7,8 +7,8 @@ use openvm_circuit::{
 };
 #[cfg(feature = "cuda")]
 use openvm_cuda_backend::{
-    data_transporter::transport_air_proving_ctx_to_device, BabyBearBn254Poseidon2GpuEngine,
-    BabyBearBn254Poseidon2HashScheme,
+    data_transporter::transport_air_proving_ctx_to_device, BabyBearBn254Poseidon2HashScheme,
+    GenericGpuBackend,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -113,7 +113,7 @@ impl<SC: StarkProtocolConfig<F = F>> RootTraceGen<CpuBackend<SC>> for RootTraceG
 }
 
 #[cfg(feature = "cuda")]
-impl RootTraceGen<BabyBearBn254Poseidon2GpuEngine> for RootTraceGenImpl {
+impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> for RootTraceGenImpl {
     fn new(deferral_enabled: bool) -> Self {
         Self { deferral_enabled }
     }
@@ -124,7 +124,7 @@ impl RootTraceGen<BabyBearBn254Poseidon2GpuEngine> for RootTraceGenImpl {
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, F>,
         memory_dimensions: MemoryDimensions,
     ) -> (
-        Vec<AirProvingContext<BabyBearBn254Poseidon2GpuEngine>>,
+        Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
         Vec<[F; POSEIDON2_WIDTH]>,
     ) {
         let (cpu_ctxs, inputs) =
@@ -142,7 +142,7 @@ impl RootTraceGen<BabyBearBn254Poseidon2GpuEngine> for RootTraceGenImpl {
         memory_dimensions: MemoryDimensions,
         deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
     ) -> (
-        Vec<AirProvingContext<BabyBearBn254Poseidon2GpuEngine>>,
+        Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
         Vec<[F; POSEIDON2_WIDTH]>,
     ) {
         let (cpu_ctxs, inputs) =

--- a/crates/continuations-v2/src/prover/mod.rs
+++ b/crates/continuations-v2/src/prover/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "cuda")]
-use openvm_cuda_backend::GpuBackend;
+use openvm_cuda_backend::{BabyBearBn254Poseidon2GpuEngine, GpuBackend};
 use openvm_stark_backend::prover::CpuBackend;
 use recursion_circuit::system::VerifierSubCircuit;
 
@@ -48,8 +48,12 @@ pub type InnerGpuProver<const MAX_NUM_PROOFS: usize> =
 #[cfg(feature = "cuda")]
 pub type CompressionGpuProver =
     CompressionProver<GpuBackend, VerifierSubCircuit<1>, InnerTraceGenImpl>;
-// #[cfg(feature = "cuda")]
-// pub type RootGpuProver = RootProver<GpuBackend, VerifierSubCircuit<1>, RootTraceGenImpl>;
+#[cfg(feature = "cuda")]
+pub type RootGpuProver = RootProver<
+    <BabyBearBn254Poseidon2GpuEngine as openvm_stark_backend::StarkEngine>::PB,
+    VerifierSubCircuit<1>,
+    RootTraceGenImpl,
+>;
 #[cfg(feature = "cuda")]
 pub type DeferralVerifyGpuProver =
     DeferredVerifyProver<GpuBackend, VerifierSubCircuit<1>, DeferredVerifyTraceGenImpl>;

--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -46,8 +46,6 @@ cuda = [
     "dep:openvm-cuda-backend",
     "openvm-circuit-primitives/cuda",
     "openvm-circuit/cuda",
-    "openvm-cuda-backend/baby-bear-bn254-poseidon2",
-    "openvm-stark-sdk/baby-bear-bn254-poseidon2",
 ]
 touchemall = [
     "cuda",

--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -46,6 +46,8 @@ cuda = [
     "dep:openvm-cuda-backend",
     "openvm-circuit-primitives/cuda",
     "openvm-circuit/cuda",
+    "openvm-cuda-backend/baby-bear-bn254-poseidon2",
+    "openvm-stark-sdk/baby-bear-bn254-poseidon2",
 ]
 touchemall = [
     "cuda",

--- a/crates/recursion/src/batch_constraint/mod.rs
+++ b/crates/recursion/src/batch_constraint/mod.rs
@@ -1091,14 +1091,19 @@ pub mod cuda_tracegen {
 
     impl BatchConstraintModule {
         /// Generates and then commits to the cache trace for `SymbolicExpressionAir`. Returns the
-        /// committed PCS data.
+        /// committed PCS data. The engine may use any GPU backend (e.g. BabyBear Poseidon2 or
+        /// BabyBear Bn254 Poseidon2) — only its `device().commit()` method is called.
         pub fn commit_child_vk_gpu<E>(
             &self,
             engine: &E,
             child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-        ) -> CommittedTraceData<GpuBackend>
+        ) -> CommittedTraceData<E::PB>
         where
-            E: StarkEngine<SC = BabyBearPoseidon2Config, PB = GpuBackend>,
+            E: StarkEngine,
+            E::PB: openvm_stark_backend::prover::ProverBackend<
+                Val = F,
+                Matrix = openvm_cuda_backend::base::DeviceMatrix<F>,
+            >,
         {
             let cached_trace_record = build_cached_trace_record(child_vk, true);
             let cached_trace = expr_eval::generate_symbolic_expr_cached_trace(&cached_trace_record);

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -1133,7 +1133,10 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
 pub mod cuda_tracegen {
     use std::iter::zip;
 
-    use openvm_cuda_backend::{prelude::SC, GpuBackend};
+    use openvm_cuda_backend::{
+        prelude::SC, BabyBearBn254Poseidon2HashScheme, GenericGpuBackend, GpuBackend,
+    };
+    use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config;
 
     use super::*;
     use crate::{
@@ -1346,6 +1349,205 @@ pub mod cuda_tracegen {
                 return None;
             }
             // Caution: this must be done after GKR and WHIR tracegen
+            tracing::trace_span!("wrapper.generate_proving_ctxs", air_module = "Primitives",)
+                .in_scope(|| {
+                    tracing::trace_span!("wrapper.generate_trace", air = "PowerChecker").in_scope(
+                        || {
+                            let pow_bits_trace = power_checker_gen.generate_trace();
+                            ctx_per_trace.push(AirProvingContext::simple_no_pis(pow_bits_trace));
+                        },
+                    );
+                });
+            let exp_bits_trace = tracing::trace_span!("wrapper.generate_trace", air = "ExpBitsLen")
+                .in_scope(|| exp_bits_len_gen.generate_trace_device(exp_bits_len_required))?;
+            ctx_per_trace.push(AirProvingContext::simple_no_pis(exp_bits_trace));
+            Some(ctx_per_trace)
+        }
+    }
+
+    /// Converts an `AirProvingContext<GpuBackend>` into an
+    /// `AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>`.
+    ///
+    /// This is safe because both backends share `Val = BabyBear` and `Matrix = DeviceMatrix<F>`.
+    /// The only field that differs is `Commitment` (inside `cached_mains`), so this function
+    /// panics if `cached_mains` is non-empty.
+    fn coerce_gpu_ctx_to_bn254(
+        ctx: AirProvingContext<GpuBackend>,
+    ) -> AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> {
+        debug_assert!(
+            ctx.cached_mains.is_empty(),
+            "cannot coerce context with cached_mains: commitment types differ between GpuBackend and Bn254 backend"
+        );
+        AirProvingContext {
+            cached_mains: vec![],
+            common_main: ctx.common_main,
+            public_values: ctx.public_values,
+        }
+    }
+
+    impl<const MAX_NUM_PROOFS: usize>
+        VerifierTraceGen<
+            GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>,
+            BabyBearBn254Poseidon2Config,
+        > for VerifierSubCircuit<MAX_NUM_PROOFS>
+    {
+        fn new(
+            child_mvk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
+            config: VerifierConfig,
+        ) -> Self {
+            Self::new_with_options(child_mvk, config)
+        }
+
+        fn commit_child_vk<
+            E: StarkEngine<
+                SC = BabyBearBn254Poseidon2Config,
+                PB = GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>,
+            >,
+        >(
+            &self,
+            engine: &E,
+            child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
+        ) -> CommittedTraceData<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> {
+            self.batch_constraint.commit_child_vk_gpu(engine, child_vk)
+        }
+
+        fn cached_trace_record(
+            &self,
+            child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
+        ) -> CachedTraceRecord {
+            self.batch_constraint.cached_trace_record(child_vk)
+        }
+
+        #[tracing::instrument(name = "subcircuit_generate_proving_ctxs_bn254", skip_all)]
+        fn generate_proving_ctxs<
+            TS: FiatShamirTranscript<BabyBearPoseidon2Config>
+                + TranscriptHistory<F = F, State = [F; POSEIDON2_WIDTH]>,
+        >(
+            &self,
+            child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
+            cached_trace_ctx: CachedTraceCtx<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>,
+            proofs: &[Proof<BabyBearPoseidon2Config>],
+            external_data: &mut VerifierExternalData<
+                GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>,
+            >,
+            initial_transcript: TS,
+        ) -> Option<Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>>
+        {
+            debug_assert!(proofs.len() <= MAX_NUM_PROOFS);
+            let child_vk_gpu = VerifyingKeyGpu::new(child_vk);
+            let proofs_gpu = proofs
+                .iter()
+                .map(|proof_cpu| ProofGpu::new(child_vk, proof_cpu))
+                .collect::<Vec<_>>();
+            let span = tracing::Span::current();
+            let mut preflights_cpu = std::thread::scope(|s| {
+                let handles: Vec<_> = proofs
+                    .iter()
+                    .map(|proof| {
+                        let sponge = initial_transcript.clone();
+                        let span = span.clone();
+                        s.spawn(move || {
+                            let _guard = span.enter();
+                            self.run_preflight(sponge, child_vk, proof)
+                        })
+                    })
+                    .collect();
+                handles
+                    .into_iter()
+                    .map(|h| h.join().unwrap())
+                    .collect::<Vec<_>>()
+            });
+
+            // Construct a GpuBackend-typed external_data view.
+            // This is safe because GpuBackend and GenericGpuBackend<Bn254HS> share the same
+            // Val = BabyBear, so all field types are identical.
+            let mut gpu_external_data = VerifierExternalData::<GpuBackend> {
+                poseidon2_compress_inputs: external_data.poseidon2_compress_inputs,
+                range_check_inputs: external_data.range_check_inputs,
+                required_heights: external_data.required_heights,
+                // Move the &mut pointer out so writes propagate back to the caller's variable.
+                final_transcript_state: external_data.final_transcript_state.take(),
+            };
+
+            if let Some(final_transcript_state) = &mut gpu_external_data.final_transcript_state {
+                debug_assert_eq!(preflights_cpu.len(), 1);
+                debug_assert!(preflights_cpu[0].transcript.samples().last().unwrap());
+                let state = *preflights_cpu[0].transcript.perm_results().last().unwrap();
+                *(*final_transcript_state) = state;
+                preflights_cpu[0].poseidon2_compress_inputs.push(state);
+            }
+
+            let power_checker_gen =
+                Arc::new(PowerCheckerGpuTraceGenerator::<2, POW_CHECKER_HEIGHT>::hybrid());
+            let exp_bits_len_gen = ExpBitsLenTraceGenerator::default();
+
+            let (module_required, power_checker_required, exp_bits_len_required) =
+                self.split_required_heights(gpu_external_data.required_heights);
+
+            let preflights_gpu = zip(proofs, preflights_cpu)
+                .map(|(proof, preflight_cpu)| PreflightGpu::new(child_vk, proof, &preflight_cpu))
+                .collect::<Vec<_>>();
+            let modules = vec![
+                TraceModuleRef::BatchConstraint(&self.batch_constraint),
+                TraceModuleRef::Transcript(&self.transcript),
+                TraceModuleRef::ProofShape(&self.proof_shape),
+                TraceModuleRef::Gkr(&self.gkr),
+                TraceModuleRef::Stacking(&self.stacking),
+                TraceModuleRef::Whir(&self.whir),
+            ];
+
+            // Borrow cached_trace_ctx for passing to modules, then consume it in the match below.
+            let cached_trace_record_for_modules = match &cached_trace_ctx {
+                CachedTraceCtx::Records(cached_trace_record) => Some(cached_trace_record),
+                CachedTraceCtx::PcsData(_) => None,
+            };
+
+            let mut ctxs_by_module_gpu = Vec::with_capacity(modules.len());
+            for (module, required_heights) in modules.into_iter().zip(module_required) {
+                ctxs_by_module_gpu.push(module.generate_gpu_ctxs(
+                    &child_vk_gpu,
+                    &proofs_gpu,
+                    &preflights_gpu,
+                    &power_checker_gen,
+                    &exp_bits_len_gen,
+                    &cached_trace_record_for_modules,
+                    &gpu_external_data,
+                    required_heights,
+                )?);
+            }
+            // The borrow of cached_trace_ctx via cached_trace_record_for_modules ends here.
+
+            // Convert GpuBackend contexts to Bn254 backend contexts.
+            // All cached_mains are empty at this point; they will be set below if needed.
+            let mut ctxs_by_module: Vec<
+                Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
+            > = ctxs_by_module_gpu
+                .into_iter()
+                .map(|module_ctxs| {
+                    module_ctxs
+                        .into_iter()
+                        .map(coerce_gpu_ctx_to_bn254)
+                        .collect()
+                })
+                .collect();
+
+            match cached_trace_ctx {
+                CachedTraceCtx::PcsData(child_vk_pcs_data) => {
+                    assert!(self.batch_constraint.has_cached);
+                    ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
+                        .cached_mains = vec![child_vk_pcs_data];
+                }
+                CachedTraceCtx::Records(cached_trace_record) => {
+                    assert!(!self.batch_constraint.has_cached);
+                    ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
+                        .public_values =
+                        cached_trace_record.dag_commit_info.unwrap().commit.to_vec();
+                }
+            };
+            let mut ctx_per_trace = ctxs_by_module.into_iter().flatten().collect::<Vec<_>>();
+            if power_checker_required.is_some_and(|h| h != POW_CHECKER_HEIGHT) {
+                return None;
+            }
             tracing::trace_span!("wrapper.generate_proving_ctxs", air_module = "Primitives",)
                 .in_scope(|| {
                     tracing::trace_span!("wrapper.generate_trace", air = "PowerChecker").in_scope(

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -72,11 +72,11 @@ impl Default for VerifierConfig {
 }
 
 #[derive(Debug)]
-pub struct VerifierExternalData<'a, PB: ProverBackend> {
-    pub poseidon2_compress_inputs: &'a Vec<[PB::Val; POSEIDON2_WIDTH]>,
+pub struct VerifierExternalData<'a> {
+    pub poseidon2_compress_inputs: &'a Vec<[F; POSEIDON2_WIDTH]>,
     pub range_check_inputs: &'a Vec<usize>,
     pub required_heights: Option<&'a [usize]>,
-    pub final_transcript_state: Option<&'a mut [PB::Val; POSEIDON2_WIDTH]>,
+    pub final_transcript_state: Option<&'a mut [F; POSEIDON2_WIDTH]>,
 }
 
 // Trait to make tracegen functions generic on ProverBackend
@@ -108,7 +108,7 @@ pub trait VerifierTraceGen<PB: ProverBackend, SC: StarkProtocolConfig<F = F>> {
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
         cached_trace_ctx: CachedTraceCtx<PB>,
         proofs: &[Proof<BabyBearPoseidon2Config>],
-        external_data: &mut VerifierExternalData<PB>,
+        external_data: &mut VerifierExternalData,
         initial_transcript: TS,
     ) -> Option<Vec<AirProvingContext<PB>>>;
 
@@ -463,7 +463,7 @@ impl<'a> TraceModuleRef<'a> {
         pow_checker_gen: &Arc<PowerCheckerCpuTraceGenerator<2, POW_CHECKER_HEIGHT>>,
         exp_bits_len_gen: &ExpBitsLenTraceGenerator,
         cached_trace_record: &Option<&CachedTraceRecord>,
-        external_data: &VerifierExternalData<CpuBackend<SC>>,
+        external_data: &VerifierExternalData,
         required_heights: Option<&[usize]>,
     ) -> Option<Vec<AirProvingContext<CpuBackend<SC>>>> {
         match self {
@@ -1010,7 +1010,7 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
         cached_trace_ctx: CachedTraceCtx<CpuBackend<SC>>,
         proofs: &[Proof<BabyBearPoseidon2Config>],
-        external_data: &mut VerifierExternalData<CpuBackend<SC>>,
+        external_data: &mut VerifierExternalData,
         initial_transcript: TS,
     ) -> Option<Vec<AirProvingContext<CpuBackend<SC>>>> {
         debug_assert!(proofs.len() <= MAX_NUM_PROOFS);
@@ -1157,7 +1157,7 @@ pub mod cuda_tracegen {
             pow_checker_gen: &Arc<PowerCheckerGpuTraceGenerator<2, POW_CHECKER_HEIGHT>>,
             exp_bits_len_gen: &ExpBitsLenTraceGenerator,
             cached_trace_record: &Option<&CachedTraceRecord>,
-            external_data: &VerifierExternalData<GpuBackend>,
+            external_data: &VerifierExternalData,
             required_heights: Option<&[usize]>,
         ) -> Option<Vec<AirProvingContext<GpuBackend>>> {
             match self {
@@ -1259,7 +1259,7 @@ pub mod cuda_tracegen {
             child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
             cached_trace_ctx: CachedTraceCtx<GenericGpuBackend<HS>>,
             proofs: &[Proof<BabyBearPoseidon2Config>],
-            external_data: &mut VerifierExternalData<GenericGpuBackend<HS>>,
+            external_data: &mut VerifierExternalData,
             initial_transcript: TS,
         ) -> Option<Vec<AirProvingContext<GenericGpuBackend<HS>>>> {
             debug_assert!(proofs.len() <= MAX_NUM_PROOFS);
@@ -1326,13 +1326,6 @@ pub mod cuda_tracegen {
                 _ => None,
             };
 
-            let external_data_gpu = VerifierExternalData::<GpuBackend> {
-                poseidon2_compress_inputs: external_data.poseidon2_compress_inputs,
-                range_check_inputs: external_data.range_check_inputs,
-                required_heights: external_data.required_heights,
-                final_transcript_state: None,
-            };
-
             // PERF[jpw]: we avoid par_iter so that kernel launches occur on the same stream.
             // This can be parallelized to separate streams for more CUDA stream parallelism, but it
             // will require recording events so streams properly sync for cudaMemcpyAsync and kernel
@@ -1346,7 +1339,7 @@ pub mod cuda_tracegen {
                     &power_checker_gen,
                     &exp_bits_len_gen,
                     &cached_trace_record,
-                    &external_data_gpu,
+                    external_data,
                     required_heights,
                 )?);
             }

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -1133,10 +1133,7 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
 pub mod cuda_tracegen {
     use std::iter::zip;
 
-    use openvm_cuda_backend::{
-        prelude::SC, BabyBearBn254Poseidon2HashScheme, GenericGpuBackend, GpuBackend,
-    };
-    use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config;
+    use openvm_cuda_backend::{hash_scheme::GpuHashScheme, GenericGpuBackend, GpuBackend};
 
     use super::*;
     use crate::{
@@ -1213,8 +1210,23 @@ pub mod cuda_tracegen {
         }
     }
 
-    impl<const MAX_NUM_PROOFS: usize> VerifierTraceGen<GpuBackend, SC>
-        for VerifierSubCircuit<MAX_NUM_PROOFS>
+    /// Coerces an `AirProvingContext<GpuBackend>` to `AirProvingContext<GenericGpuBackend<HS>>`.
+    ///
+    /// Safe because all GPU backends share `Val = BabyBear` and `Matrix = DeviceMatrix<F>`.
+    /// Panics in debug builds if `cached_mains` is non-empty (commitments differ by hash scheme).
+    fn coerce_gpu_ctx<HS: GpuHashScheme>(
+        ctx: AirProvingContext<GpuBackend>,
+    ) -> AirProvingContext<GenericGpuBackend<HS>> {
+        debug_assert!(ctx.cached_mains.is_empty());
+        AirProvingContext {
+            cached_mains: vec![],
+            common_main: ctx.common_main,
+            public_values: ctx.public_values,
+        }
+    }
+
+    impl<HS: GpuHashScheme, const MAX_NUM_PROOFS: usize>
+        VerifierTraceGen<GenericGpuBackend<HS>, HS::SC> for VerifierSubCircuit<MAX_NUM_PROOFS>
     {
         fn new(
             child_mvk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
@@ -1223,11 +1235,11 @@ pub mod cuda_tracegen {
             Self::new_with_options(child_mvk, config)
         }
 
-        fn commit_child_vk<E: StarkEngine<SC = BabyBearPoseidon2Config, PB = GpuBackend>>(
+        fn commit_child_vk<E: StarkEngine<SC = HS::SC, PB = GenericGpuBackend<HS>>>(
             &self,
             engine: &E,
             child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-        ) -> CommittedTraceData<GpuBackend> {
+        ) -> CommittedTraceData<GenericGpuBackend<HS>> {
             self.batch_constraint.commit_child_vk_gpu(engine, child_vk)
         }
 
@@ -1245,11 +1257,11 @@ pub mod cuda_tracegen {
         >(
             &self,
             child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-            cached_trace_ctx: CachedTraceCtx<GpuBackend>,
+            cached_trace_ctx: CachedTraceCtx<GenericGpuBackend<HS>>,
             proofs: &[Proof<BabyBearPoseidon2Config>],
-            external_data: &mut VerifierExternalData<GpuBackend>,
+            external_data: &mut VerifierExternalData<GenericGpuBackend<HS>>,
             initial_transcript: TS,
-        ) -> Option<Vec<AirProvingContext<GpuBackend>>> {
+        ) -> Option<Vec<AirProvingContext<GenericGpuBackend<HS>>>> {
             debug_assert!(proofs.len() <= MAX_NUM_PROOFS);
             let child_vk_gpu = VerifyingKeyGpu::new(child_vk);
             let proofs_gpu = proofs
@@ -1309,28 +1321,40 @@ pub mod cuda_tracegen {
                 TraceModuleRef::Whir(&self.whir),
             ];
 
-            let cached_trace_record = match &cached_trace_ctx {
-                CachedTraceCtx::Records(cached_trace_record) => Some(cached_trace_record),
+            let cached_trace_record: Option<&CachedTraceRecord> = match &cached_trace_ctx {
+                CachedTraceCtx::Records(ref cached_trace_record) => Some(cached_trace_record),
                 _ => None,
+            };
+
+            let external_data_gpu = VerifierExternalData::<GpuBackend> {
+                poseidon2_compress_inputs: external_data.poseidon2_compress_inputs,
+                range_check_inputs: external_data.range_check_inputs,
+                required_heights: external_data.required_heights,
+                final_transcript_state: None,
             };
 
             // PERF[jpw]: we avoid par_iter so that kernel launches occur on the same stream.
             // This can be parallelized to separate streams for more CUDA stream parallelism, but it
             // will require recording events so streams properly sync for cudaMemcpyAsync and kernel
             // launches
-            let mut ctxs_by_module = Vec::with_capacity(modules.len());
+            let mut ctxs_by_module_gpu = Vec::with_capacity(modules.len());
             for (module, required_heights) in modules.into_iter().zip(module_required) {
-                ctxs_by_module.push(module.generate_gpu_ctxs(
+                ctxs_by_module_gpu.push(module.generate_gpu_ctxs(
                     &child_vk_gpu,
                     &proofs_gpu,
                     &preflights_gpu,
                     &power_checker_gen,
                     &exp_bits_len_gen,
                     &cached_trace_record,
-                    external_data,
+                    &external_data_gpu,
                     required_heights,
                 )?);
             }
+            let mut ctxs_by_module: Vec<Vec<AirProvingContext<GenericGpuBackend<HS>>>> =
+                ctxs_by_module_gpu
+                    .into_iter()
+                    .map(|module_ctxs| module_ctxs.into_iter().map(coerce_gpu_ctx::<HS>).collect())
+                    .collect();
             match cached_trace_ctx {
                 CachedTraceCtx::PcsData(child_vk_pcs_data) => {
                     assert!(self.batch_constraint.has_cached);
@@ -1349,205 +1373,6 @@ pub mod cuda_tracegen {
                 return None;
             }
             // Caution: this must be done after GKR and WHIR tracegen
-            tracing::trace_span!("wrapper.generate_proving_ctxs", air_module = "Primitives",)
-                .in_scope(|| {
-                    tracing::trace_span!("wrapper.generate_trace", air = "PowerChecker").in_scope(
-                        || {
-                            let pow_bits_trace = power_checker_gen.generate_trace();
-                            ctx_per_trace.push(AirProvingContext::simple_no_pis(pow_bits_trace));
-                        },
-                    );
-                });
-            let exp_bits_trace = tracing::trace_span!("wrapper.generate_trace", air = "ExpBitsLen")
-                .in_scope(|| exp_bits_len_gen.generate_trace_device(exp_bits_len_required))?;
-            ctx_per_trace.push(AirProvingContext::simple_no_pis(exp_bits_trace));
-            Some(ctx_per_trace)
-        }
-    }
-
-    /// Converts an `AirProvingContext<GpuBackend>` into an
-    /// `AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>`.
-    ///
-    /// This is safe because both backends share `Val = BabyBear` and `Matrix = DeviceMatrix<F>`.
-    /// The only field that differs is `Commitment` (inside `cached_mains`), so this function
-    /// panics if `cached_mains` is non-empty.
-    fn coerce_gpu_ctx_to_bn254(
-        ctx: AirProvingContext<GpuBackend>,
-    ) -> AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> {
-        debug_assert!(
-            ctx.cached_mains.is_empty(),
-            "cannot coerce context with cached_mains: commitment types differ between GpuBackend and Bn254 backend"
-        );
-        AirProvingContext {
-            cached_mains: vec![],
-            common_main: ctx.common_main,
-            public_values: ctx.public_values,
-        }
-    }
-
-    impl<const MAX_NUM_PROOFS: usize>
-        VerifierTraceGen<
-            GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>,
-            BabyBearBn254Poseidon2Config,
-        > for VerifierSubCircuit<MAX_NUM_PROOFS>
-    {
-        fn new(
-            child_mvk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
-            config: VerifierConfig,
-        ) -> Self {
-            Self::new_with_options(child_mvk, config)
-        }
-
-        fn commit_child_vk<
-            E: StarkEngine<
-                SC = BabyBearBn254Poseidon2Config,
-                PB = GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>,
-            >,
-        >(
-            &self,
-            engine: &E,
-            child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-        ) -> CommittedTraceData<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>> {
-            self.batch_constraint.commit_child_vk_gpu(engine, child_vk)
-        }
-
-        fn cached_trace_record(
-            &self,
-            child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-        ) -> CachedTraceRecord {
-            self.batch_constraint.cached_trace_record(child_vk)
-        }
-
-        #[tracing::instrument(name = "subcircuit_generate_proving_ctxs_bn254", skip_all)]
-        fn generate_proving_ctxs<
-            TS: FiatShamirTranscript<BabyBearPoseidon2Config>
-                + TranscriptHistory<F = F, State = [F; POSEIDON2_WIDTH]>,
-        >(
-            &self,
-            child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-            cached_trace_ctx: CachedTraceCtx<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>,
-            proofs: &[Proof<BabyBearPoseidon2Config>],
-            external_data: &mut VerifierExternalData<
-                GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>,
-            >,
-            initial_transcript: TS,
-        ) -> Option<Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>>
-        {
-            debug_assert!(proofs.len() <= MAX_NUM_PROOFS);
-            let child_vk_gpu = VerifyingKeyGpu::new(child_vk);
-            let proofs_gpu = proofs
-                .iter()
-                .map(|proof_cpu| ProofGpu::new(child_vk, proof_cpu))
-                .collect::<Vec<_>>();
-            let span = tracing::Span::current();
-            let mut preflights_cpu = std::thread::scope(|s| {
-                let handles: Vec<_> = proofs
-                    .iter()
-                    .map(|proof| {
-                        let sponge = initial_transcript.clone();
-                        let span = span.clone();
-                        s.spawn(move || {
-                            let _guard = span.enter();
-                            self.run_preflight(sponge, child_vk, proof)
-                        })
-                    })
-                    .collect();
-                handles
-                    .into_iter()
-                    .map(|h| h.join().unwrap())
-                    .collect::<Vec<_>>()
-            });
-
-            // Construct a GpuBackend-typed external_data view.
-            // This is safe because GpuBackend and GenericGpuBackend<Bn254HS> share the same
-            // Val = BabyBear, so all field types are identical.
-            let mut gpu_external_data = VerifierExternalData::<GpuBackend> {
-                poseidon2_compress_inputs: external_data.poseidon2_compress_inputs,
-                range_check_inputs: external_data.range_check_inputs,
-                required_heights: external_data.required_heights,
-                // Move the &mut pointer out so writes propagate back to the caller's variable.
-                final_transcript_state: external_data.final_transcript_state.take(),
-            };
-
-            if let Some(final_transcript_state) = &mut gpu_external_data.final_transcript_state {
-                debug_assert_eq!(preflights_cpu.len(), 1);
-                debug_assert!(preflights_cpu[0].transcript.samples().last().unwrap());
-                let state = *preflights_cpu[0].transcript.perm_results().last().unwrap();
-                *(*final_transcript_state) = state;
-                preflights_cpu[0].poseidon2_compress_inputs.push(state);
-            }
-
-            let power_checker_gen =
-                Arc::new(PowerCheckerGpuTraceGenerator::<2, POW_CHECKER_HEIGHT>::hybrid());
-            let exp_bits_len_gen = ExpBitsLenTraceGenerator::default();
-
-            let (module_required, power_checker_required, exp_bits_len_required) =
-                self.split_required_heights(gpu_external_data.required_heights);
-
-            let preflights_gpu = zip(proofs, preflights_cpu)
-                .map(|(proof, preflight_cpu)| PreflightGpu::new(child_vk, proof, &preflight_cpu))
-                .collect::<Vec<_>>();
-            let modules = vec![
-                TraceModuleRef::BatchConstraint(&self.batch_constraint),
-                TraceModuleRef::Transcript(&self.transcript),
-                TraceModuleRef::ProofShape(&self.proof_shape),
-                TraceModuleRef::Gkr(&self.gkr),
-                TraceModuleRef::Stacking(&self.stacking),
-                TraceModuleRef::Whir(&self.whir),
-            ];
-
-            // Borrow cached_trace_ctx for passing to modules, then consume it in the match below.
-            let cached_trace_record_for_modules = match &cached_trace_ctx {
-                CachedTraceCtx::Records(cached_trace_record) => Some(cached_trace_record),
-                CachedTraceCtx::PcsData(_) => None,
-            };
-
-            let mut ctxs_by_module_gpu = Vec::with_capacity(modules.len());
-            for (module, required_heights) in modules.into_iter().zip(module_required) {
-                ctxs_by_module_gpu.push(module.generate_gpu_ctxs(
-                    &child_vk_gpu,
-                    &proofs_gpu,
-                    &preflights_gpu,
-                    &power_checker_gen,
-                    &exp_bits_len_gen,
-                    &cached_trace_record_for_modules,
-                    &gpu_external_data,
-                    required_heights,
-                )?);
-            }
-            // The borrow of cached_trace_ctx via cached_trace_record_for_modules ends here.
-
-            // Convert GpuBackend contexts to Bn254 backend contexts.
-            // All cached_mains are empty at this point; they will be set below if needed.
-            let mut ctxs_by_module: Vec<
-                Vec<AirProvingContext<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>>,
-            > = ctxs_by_module_gpu
-                .into_iter()
-                .map(|module_ctxs| {
-                    module_ctxs
-                        .into_iter()
-                        .map(coerce_gpu_ctx_to_bn254)
-                        .collect()
-                })
-                .collect();
-
-            match cached_trace_ctx {
-                CachedTraceCtx::PcsData(child_vk_pcs_data) => {
-                    assert!(self.batch_constraint.has_cached);
-                    ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
-                        .cached_mains = vec![child_vk_pcs_data];
-                }
-                CachedTraceCtx::Records(cached_trace_record) => {
-                    assert!(!self.batch_constraint.has_cached);
-                    ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
-                        .public_values =
-                        cached_trace_record.dag_commit_info.unwrap().commit.to_vec();
-                }
-            };
-            let mut ctx_per_trace = ctxs_by_module.into_iter().flatten().collect::<Vec<_>>();
-            if power_checker_required.is_some_and(|h| h != POW_CHECKER_HEIGHT) {
-                return None;
-            }
             tracing::trace_span!("wrapper.generate_proving_ctxs", air_module = "Primitives",)
                 .in_scope(|| {
                     tracing::trace_span!("wrapper.generate_trace", air = "PowerChecker").in_scope(

--- a/crates/sdk-v2/Cargo.toml
+++ b/crates/sdk-v2/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 openvm-stark-backend = { workspace = true }
 openvm-stark-sdk = { workspace = true, features = ["baby-bear-bn254-poseidon2"] }
-openvm-cuda-backend = { workspace = true, optional = true }
+openvm-cuda-backend = { workspace = true, optional = true, features = ["baby-bear-bn254-poseidon2"] }
 
 openvm-build = { workspace = true }
 openvm-circuit = { workspace = true }

--- a/crates/sdk-v2/Cargo.toml
+++ b/crates/sdk-v2/Cargo.toml
@@ -77,4 +77,5 @@ cuda = [
     "openvm-circuit/cuda",
     "openvm-sdk-config/cuda",
     "continuations-v2/cuda",
+    "openvm-cuda-backend/baby-bear-bn254-poseidon2",
 ]

--- a/crates/sdk-v2/src/prover/root.rs
+++ b/crates/sdk-v2/src/prover/root.rs
@@ -34,8 +34,8 @@ use crate::{
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
-        use continuations_v2::prover::RootCpuProver as RootInnerProver;
-        type E = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
+        use continuations_v2::prover::RootGpuProver as RootInnerProver;
+        type E = openvm_cuda_backend::BabyBearBn254Poseidon2GpuEngine;
         type ChildE = openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
     } else {
         use continuations_v2::prover::RootCpuProver as RootInnerProver;

--- a/crates/vm/src/system/cuda/program.rs
+++ b/crates/vm/src/system/cuda/program.rs
@@ -73,7 +73,7 @@ impl ProgramChipGPU {
         trace: DeviceMatrix<F>,
         device: &GpuDevice,
     ) -> CommittedTraceData<GpuBackend> {
-        let (commitment, data) = device.commit(&[&trace]).unwrap();
+        let (commitment, data) = TraceCommitter::<GpuBackend>::commit(device, &[&trace]).unwrap();
         CommittedTraceData {
             commitment,
             data: Arc::new(data),


### PR DESCRIPTION
Closes INT-6475
Relies on https://github.com/openvm-org/stark-backend/pull/288 

Wire `BabyBearBn254Poseidon2GpuEngine` as the root prover engine for CUDA builds

Previously the root proving step used `BabyBearPoseidon2GpuEngine` (BabyBear Poseidon2 hash) even in GPU builds. This PR switches the root prover to `BabyBearBn254Poseidon2GpuEngine` (BN254 Poseidon2 hash) when the cuda feature is enabled, enabling native BN254 merkle hashing in the root circuit.

Changes:

- `Cargo.toml`: Updated all stark-backend git dependency branches from chore/generic-gpuengine → chore/bn254, which provides BabyBearBn254Poseidon2GpuEngine, GenericGpuBackend<HS>, and related types.
- `crates/recursion`: Added `baby-bear-bn254-poseidon2` sub-features to the cuda feature flag. Added a new `VerifierTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>, BabyBearBn254Poseidon2Config>` impl for `VerifierSubCircuit<N>` — it runs the GPU preflight on the BabyBear backend then coerces contexts to the BN254 backend (safe: both share Val = BabyBear, Matrix = DeviceMatrix<F>; cached_mains are always empty at this point). Fixed `commit_child_vk_gpu` where clause to use `openvm_stark_backend::prover::ProverBackend`.
- `crates/continuations-v2`: Added `RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>>` impl using the same coercion pattern. Switched `RootGpuProver` type alias to use `BabyBearBn254Poseidon2GpuEngine::PB`.
- `crates/sdk-v2`: `cfg_if` selects `BabyBearBn254Poseidon2GpuEngine` for CUDA root proving, CPU engine otherwise.