### PR TITLE
fix: InitialOpenedValuesAir ensure no breaks between set flags

### DIFF
--- a/crates/recursion/src/whir/initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/initial_opened_values/air.rs
@@ -245,6 +245,9 @@ where
             builder
                 .when(is_same_commit.clone())
                 .assert_eq(next.pre_state[CHUNK + i], local.post_state[CHUNK + i]);
+            builder
+                .when(is_same_commit.clone())
+                .assert_one(local.flags[i]);
 
             let col_idx =
                 local.col_chunk_idx * AB::Expr::from_usize(CHUNK) + AB::Expr::from_usize(i);


### PR DESCRIPTION
Resolves INT-6701, INT-6607.

Constraints ensure all flags from 0 to some `max_col_idx` are set by ensuring all are set on each non-terminal row. Note `stacking_indices_bus` sends the same number of messages per valid `(commit_idx, col_idx)`, and thus:

- If an extra flag is set, there will be not be a corresponding key added on the stacking side
- If a flag is left unset, there will be no way one could ensure each `(commit_idx, col_idx)` is looked up the same number of times