### PR TITLE
fix(recursion): fully constrain exp_bits_len in BabyBear

### DIFF
--- a/crates/recursion/cuda/include/util.cuh
+++ b/crates/recursion/cuda/include/util.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "fp.h"
 #include <cstddef>
 
 // Returns the first index i in [0, len] such that arr[i] > value.
@@ -23,3 +24,7 @@ __device__ __forceinline__ size_t partition_point_leq(
     return lo;
 }
 
+/// Convert a boolean to Fp(1) or Fp(0).
+static __device__ __forceinline__ Fp bool_to_fp(bool value) {
+    return value ? Fp::one() : Fp::zero();
+}

--- a/crates/recursion/cuda/src/primitives/exp_bits_len.cu
+++ b/crates/recursion/cuda/src/primitives/exp_bits_len.cu
@@ -1,48 +1,15 @@
 #include "fp.h"
 #include "launcher.cuh"
 #include "primitives/trace_access.h"
+#include "util.cuh"
 
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 
 constexpr uint8_t kExpBitsLenNumBitsMax = 31;
-
-// Lookup table for inverses of all num_bits in [0, kExpBitsLenNumBitsMax]
-__device__ __constant__ Fp kExpBitsLenNumBitsInv[kExpBitsLenNumBitsMax + 1] = {
-    Fp(0x00000000),
-    Fp(0x00000001),
-    Fp(0x3c000001),
-    Fp(0x50000001),
-    Fp(0x5a000001),
-    Fp(0x60000001),
-    Fp(0x64000001),
-    Fp(0x336db6dc),
-    Fp(0x69000001),
-    Fp(0x1aaaaaab),
-    Fp(0x6c000001),
-    Fp(0x20ba2e8c),
-    Fp(0x6e000001),
-    Fp(0x1bb13b14),
-    Fp(0x19b6db6e),
-    Fp(0x70000001),
-    Fp(0x70800001),
-    Fp(0x38787879),
-    Fp(0x49555556),
-    Fp(0x5ebca1b0),
-    Fp(0x72000001),
-    Fp(0x6124924a),
-    Fp(0x105d1746),
-    Fp(0x3e9bd37b),
-    Fp(0x73000001),
-    Fp(0x5b333334),
-    Fp(0x0dd89d8a),
-    Fp(0x08e38e39),
-    Fp(0x0cdb6db7),
-    Fp(0x14b08d3e),
-    Fp(0x74000001),
-    Fp(0x03def7be),
-};
+constexpr uint8_t kExpBitsLenNumRows = kExpBitsLenNumBitsMax + 1;
+constexpr uint8_t kExpBitsLenLowBitsCount = 27;
 
 struct ExpBitsLenRecord {
     uint8_t num_bits;
@@ -54,14 +21,19 @@ struct ExpBitsLenRecord {
 template <typename T>
 struct ExpBitsLenCols {
     T is_valid;
+    T is_first;
+    T bit_idx;
     T base;
     T bit_src;
     T num_bits;
-    T num_bits_inv;
+    T apply_bit;
+    T low_bits_left;
+    T in_low_region;
     T result;
-    T sub_result;
-    T bit_src_div2;
-    T bit_src_mod2;
+    T result_multiplier;
+    T bit_src_mod_2;
+    T low_bits_are_zero;
+    T high_bits_all_one;
 };
 
 __global__ void exp_bits_len_tracegen_kernel(
@@ -79,48 +51,87 @@ __global__ void exp_bits_len_tracegen_kernel(
     if (idx >= num_requests) {
         RowSlice dummy_row(trace + num_valid_rows + (idx - num_requests), height);
         COL_WRITE_VALUE(dummy_row, ExpBitsLenCols, result, Fp::one());
+        COL_WRITE_VALUE(dummy_row, ExpBitsLenCols, result_multiplier, Fp::one());
         return;
     }
 
     const ExpBitsLenRecord record = records[idx];
     assert(record.num_bits <= kExpBitsLenNumBitsMax);
 
-    Fp base_pow = record.base;
-    for (uint8_t i = 0; i <= record.num_bits; i++) {
-        RowSlice base_row(trace + record.row_offset + (record.num_bits - i), height);
-        COL_WRITE_VALUE(base_row, ExpBitsLenCols, base, base_pow);
-        base_pow = base_pow * base_pow;
+    Fp bases[kExpBitsLenNumRows];
+    Fp results[kExpBitsLenNumRows];
+
+    bases[0] = record.base;
+    for (uint8_t step = 1; step < kExpBitsLenNumRows; ++step) {
+        bases[step] = bases[step - 1] * bases[step - 1];
     }
 
-    uint32_t bit_src_uint = record.bit_src.asUInt32();
+    for (uint8_t step = 0; step < kExpBitsLenNumRows; ++step) {
+        results[step] = Fp::one();
+    }
 
-    // First iteration j = 0
-    uint32_t shifted = bit_src_uint >> record.num_bits;
-    RowSlice row(trace + record.row_offset, height);
-    COL_WRITE_VALUE(row, ExpBitsLenCols, is_valid, Fp::one());
-    COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src, Fp(shifted));
-    COL_WRITE_VALUE(row, ExpBitsLenCols, num_bits, Fp::zero());
-    COL_WRITE_VALUE(row, ExpBitsLenCols, num_bits_inv, Fp::zero());
-    COL_WRITE_VALUE(row, ExpBitsLenCols, result, Fp::one());
-    COL_WRITE_VALUE(row, ExpBitsLenCols, sub_result, Fp::one());
-    COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src_div2, Fp(shifted >> 1));
-    COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src_mod2, Fp(shifted & 1));
-
+    const uint32_t bit_src_uint = record.bit_src.asUInt32();
     Fp acc = Fp::one();
-    for (uint8_t j = 1; j <= record.num_bits; j++) {
-        shifted = bit_src_uint >> (record.num_bits - j);
+    for (int step = kExpBitsLenNumBitsMax - 1; step >= 0; --step) {
+        if (step < record.num_bits && ((bit_src_uint >> step) & 1) == 1) {
+            acc = acc * bases[step];
+        }
+        results[step] = acc;
+    }
 
-        row = RowSlice(trace + record.row_offset + j, height);
+    bool low_bits_are_zero = true;
+    bool high_bits_all_one = false;
+    for (uint8_t step = 0; step < kExpBitsLenNumRows; ++step) {
+        if (step == kExpBitsLenLowBitsCount) {
+            high_bits_all_one = true;
+        }
+
+        const uint32_t shifted = bit_src_uint >> step;
+        const uint8_t num_bits = step < record.num_bits ? record.num_bits - step : 0;
+        const uint8_t low_bits_left =
+            step < kExpBitsLenLowBitsCount ? kExpBitsLenLowBitsCount - step : 0;
+        RowSlice row(trace + record.row_offset + step, height);
+
         COL_WRITE_VALUE(row, ExpBitsLenCols, is_valid, Fp::one());
+        COL_WRITE_VALUE(row, ExpBitsLenCols, is_first, bool_to_fp(step == 0));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, bit_idx, Fp(step));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, base, bases[step]);
         COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src, Fp(shifted));
-        COL_WRITE_VALUE(row, ExpBitsLenCols, num_bits, Fp(j));
-        COL_WRITE_VALUE(row, ExpBitsLenCols, num_bits_inv, kExpBitsLenNumBitsInv[j]);
-        COL_WRITE_VALUE(row, ExpBitsLenCols, sub_result, acc);
-        COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src_div2, Fp(shifted >> 1));
-        COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src_mod2, Fp(shifted & 1));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, num_bits, Fp(num_bits));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, apply_bit, bool_to_fp(num_bits != 0));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, low_bits_left, Fp(low_bits_left));
+        COL_WRITE_VALUE(
+            row,
+            ExpBitsLenCols,
+            in_low_region,
+            bool_to_fp(low_bits_left != 0)
+        );
+        COL_WRITE_VALUE(row, ExpBitsLenCols, result, results[step]);
+        COL_WRITE_VALUE(
+            row,
+            ExpBitsLenCols,
+            result_multiplier,
+            num_bits != 0 && (shifted & 1) == 1 ? bases[step] : Fp::one()
+        );
+        COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src_mod_2, Fp(shifted & 1));
+        COL_WRITE_VALUE(
+            row,
+            ExpBitsLenCols,
+            low_bits_are_zero,
+            bool_to_fp(low_bits_are_zero)
+        );
+        COL_WRITE_VALUE(
+            row,
+            ExpBitsLenCols,
+            high_bits_all_one,
+            bool_to_fp(high_bits_all_one)
+        );
 
-        if (shifted & 1) acc = acc * row[COL_INDEX(ExpBitsLenCols, base)];
-        COL_WRITE_VALUE(row, ExpBitsLenCols, result, acc);
+        if (step < kExpBitsLenLowBitsCount) {
+            low_bits_are_zero = low_bits_are_zero && ((shifted & 1) == 0);
+        } else if (step + 1 < kExpBitsLenNumRows) {
+            high_bits_all_one = high_bits_all_one && ((shifted & 1) == 1);
+        }
     }
 }
 

--- a/crates/recursion/cuda/src/transcript/merkle_verify.cu
+++ b/crates/recursion/cuda/src/transcript/merkle_verify.cu
@@ -3,6 +3,7 @@
 #include "poseidon2.cuh"
 #include "primitives/trace_access.h"
 #include "types.h"
+#include "util.cuh"
 
 #include <cstddef>
 #include <cstdint>
@@ -39,8 +40,6 @@ struct CombinationIndices {
     size_t result_layer;
     size_t result_index;
 };
-
-__device__ __forceinline__ Fp bool_to_fp(bool value) { return value ? Fp::one() : Fp::zero(); }
 
 __device__ bool compute_combination_indices(size_t k, size_t idx, CombinationIndices &out) {
     if (k == 0) {

--- a/crates/recursion/src/primitives/exp_bits_len/README.md
+++ b/crates/recursion/src/primitives/exp_bits_len/README.md
@@ -1,81 +1,95 @@
-# Recursion ExpBitsLen AIR 
+# Recursion ExpBitsLen AIR
 
-## 1. Executive summary
+## Summary
 
-The job of `ExpBitsLenAir` is to provide a lookup service for messages
-`(base, bit_src, num_bits, result)` where:
+`ExpBitsLenAir` serves lookups of the form
 
-`result` equals `base` raised to the value of the lowest `num_bits` bits of `bit_src`.
+`(base, bit_src, num_bits, result)`
 
-In formula form:
+where
 
-`result = base^(bit_src mod 2^num_bits)`.
+`result = base^(bit_src mod 2^num_bits)`
 
-Why we need it: many AIRs (PoW checks and query exponent checks) can reuse this one bus lookup instead of implementing exponent logic repeatedly.
+using the canonical BabyBear representative of `bit_src`.
 
-## 2. Public values
+This primitive is shared by the recursion PoW and query AIRs so they can reuse the same low-bit exponent logic.
 
-This AIR has no public values in its trace interface.
+This AIR is BabyBear-specific. Its canonicality check is hard-coded to the BabyBear modulus
+`p = 15 * 2^27 + 1`, and the implementation will panic if instantiated over a different
+`PrimeField32`.
 
-## 3. Example
+## Trace shape
 
-### 3.1 Row count per request
+Each request always occupies exactly `32` rows:
 
-Other AIRs can make a request: `add_request(&self, base: F, bit_src: F, num_bits: usize)`
-to lookup the exp result.
+- rows `0..30` are the 31 decomposition steps
+- row `31` is the terminal state after the final shift
 
-For one request with `num_bits = n`, tracegen creates exactly `n + 1` valid rows.
+The request row is row `0`. Only that row publishes the external lookup key on `ExpBitsLenBus`.
 
-- row `0` has `num_bits = 0` (base case, `result = 1`)
-- row `n` has `num_bits = n` (the requested top key)
+Across a block:
 
-### 3.2 Relation between adjacent rows
+- `base` squares each step
+- `bit_src` shifts right by one bit each step
+- `num_bits` decrements until it reaches `0`, then stays `0`
+- `result` updates only while `num_bits > 0`
+- decomposition continues all the way to the terminal row even after `num_bits == 0`
 
-- the next row tracks one more bit than the previous row (so `num_bits` increases by one)
-- the next row uses the previous row's base before squaring (equivalently, the next base is one square-root step of the previous base)
-- the next row's `sub_result` is exactly the previous row's `result`
-- the next row computes `result` from `sub_result` and the current least-significant bit:
-  - if the current low bit is `1`, multiply by `base`
-  - if the current low bit is `0`, keep `sub_result` unchanged
+So the external meaning stays the same, but the underlying bit decomposition is fully constrained.
 
-This is exactly the recursive lookup rule encoded in AIR.
+The AIR stores `is_first`, but does not store `is_last` as a column. Instead, on a local/next row
+pair it derives:
 
-### 3.3 Concrete example
+- `is_transition = next.is_valid - next.is_first`
+- `local_is_last = local.is_valid - next.is_valid + next.is_first`
 
-Example request: `base = g`, `bit_src = 45`, `num_bits = 4`.
+This gives a fixed 32-row block structure while still handling exact-height traces and a padding
+tail with the same formula.
 
-`101101b` means binary (`b` = binary), so `101101b = 45` in decimal.
+## Canonicality check
 
-Because `num_bits = 4`, we use only the lowest 4 bits of `bit_src`:  
-`45 = 101101b`, lowest 4 bits are `1101b = 13`, so exponent is `13`.
+Decomposing all 31 bits is not enough by itself in BabyBear, because
 
+`BabyBear::ORDER_U32 = 0x78000001 < 2^31`.
 
-| base | bit_src | num_bits | bit_src_mod_2 | sub_result | result |
-| --- | --- | --- | --- | --- | --- |
-| `g^16` | 2 | 0 | 0 | 1 | 1 |
-| `g^8` | 5 | 1 | 1 | 1 | `g^8` |
-| `g^4` | 11 | 2 | 1 | `g^8` | `g^12` |
-| `g^2` | 22 | 3 | 0 | `g^12` | `g^12` |
-| `g` | 45 | 4 | 1 | `g^12` | `g^13` |
+That means some field elements also admit a second 31-bit representative as `x + p`.
 
-Top requested key is `(g, 45, 4, g^13)`, matching `g^(45 mod 16) = g^13`.
+For BabyBear we can rule that out with a low-degree check because
 
-Note: there are additional auxiliary columns not shown in the table.
+`p = 15 * 2^27 + 1`.
 
-## 4. Proof
+A 31-bit integer is `>= p` iff:
 
-The statement is: for each valid row key `(base, bit_src, num_bits, result)`, `result` is the exponent over the low `num_bits` bits of `bit_src`.
+- its top four bits `b27..b30` are all `1`
+- and at least one of the low 27 bits `b0..b26` is `1`
 
-This is guaranteed by constraints:
+The AIR therefore carries two running booleans:
 
-1. `bit_src_mod_2` is boolean, and `bit_src = 2 * bit_src_div_2 + bit_src_mod_2`
-2. `num_bits = num_bits^2 * num_bits_inv`  
-   so `num_bits * num_bits_inv` is `0` when `num_bits=0`, else `1`
-3. For nonzero `num_bits`, lookup the subproblem at
-   `(base^2, bit_src_div_2, num_bits-1, sub_result)`
-4. For nonzero `num_bits`, enforce
-   `result = sub_result * (bit_src_mod_2 * base + 1 - bit_src_mod_2)`. That is, if `bit_src_mod_2` is 1 we multiply sub_result by base. Otherwise do nothing. 
-5. For zero `num_bits`, enforce `result = 1`
+- `low_bits_are_zero`: all bits `b0..b26` seen so far are zero
+- `high_bits_all_one`: all high bits `b27..b30` seen so far are one
 
-The constraints are all "local", and the relationship between adjacent rows is guaranteed by the self lookup: Every row `add_key_with_lookups`, and every row except first row `lookup_key` for the "previous row".
+On the terminal row it enforces:
 
+`high_bits_all_one * (1 - low_bits_are_zero) = 0`
+
+which excludes the non-canonical `x + p` decomposition while still allowing `p - 1`.
+
+## Main constraints
+
+The AIR enforces:
+
+1. `bit_src_mod_2` is boolean and adjacent rows satisfy `bit_src = 2 * next.bit_src + bit_src_mod_2`
+2. `num_bits` and `low_bits_left` imply their boolean “nonzero” flags via `when(counter).assert_one(selector)`, and the fixed decrement-to-zero transitions force those selectors back to `0` once the counters reach `0`
+3. `result_multiplier` is either `1` or `base`, depending on whether the current bit is active
+4. `is_first => is_valid`, and adjacent rows enforce the fixed 32-row block transition through the derived `is_transition` / `local_is_last` selectors above
+5. the terminal row enforces `bit_src = 0`, `num_bits = 0`, and `result = 1`
+6. the terminal row also enforces the canonical `< p` condition above
+
+These constraints ensure that:
+
+- the bit decomposition is fully constrained through the terminal row
+- `result` is computed from the requested low `num_bits` bits
+- `bit_src` is interpreted using the canonical BabyBear representative
+
+Padding rows do not publish interactions. The AIR does not require a unique padding-row encoding;
+it only constrains the selector structure needed to separate valid request blocks from padding.

--- a/crates/recursion/src/primitives/exp_bits_len/air.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/air.rs
@@ -3,27 +3,48 @@ use core::borrow::Borrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
-use openvm_stark_sdk::config::baby_bear_poseidon2::F;
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::PrimeCharacteristicRing;
+use p3_baby_bear::BabyBear;
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::Matrix;
 use stark_recursion_circuit_derive::AlignedBorrow;
 
-use crate::primitives::bus::{ExpBitsLenBus, ExpBitsLenMessage};
+use crate::primitives::{
+    bus::{ExpBitsLenBus, ExpBitsLenMessage},
+    exp_bits_len::trace::{LOW_BITS_COUNT, NUM_BITS_MAX_PLUS_ONE},
+};
 
 #[repr(C)]
 #[derive(AlignedBorrow)]
 pub struct ExpBitsLenCols<T> {
+    /// Marks rows that belong to an `ExpBitsLen` request rather than trailing padding.
     pub is_valid: T,
+    /// Marks the first row of a 32-row request block. Only these rows publish on the lookup bus.
+    pub is_first: T,
+    /// Bit position carried by this row. Rows `0..30` decompose bits, row `31` is terminal.
+    pub bit_idx: T,
+    /// `base^(2^bit_idx)`.
     pub base: T,
+    /// Remaining suffix of the canonical 31-bit decomposition after shifting by `bit_idx`.
     pub bit_src: T,
+    /// Remaining number of low bits that still affect `result`.
     pub num_bits: T,
-    pub num_bits_inv: T,
+    /// Boolean witness for `num_bits != 0`.
+    pub apply_bit: T,
+    /// Countdown for the low 27 bits used in the BabyBear `< p` canonicality check.
+    pub low_bits_left: T,
+    /// Boolean witness for `low_bits_left != 0`.
+    pub in_low_region: T,
+    /// Running product for the requested low-bit exponentiation.
     pub result: T,
-    pub sub_result: T,
-    // bit_src = 2 * q_mod_2 + r_mod_2
-    pub bit_src_div_2: T,
+    /// Multiplies `result` by either `1` or `base` on the next transition.
+    pub result_multiplier: T,
+    /// Current decomposition bit.
     pub bit_src_mod_2: T,
+    /// Running flag: all low bits `b0..b26` seen so far are zero.
+    pub low_bits_are_zero: T,
+    /// Running flag: all high bits `b27..b30` seen so far are one.
+    pub high_bits_all_one: T,
 }
 
 #[derive(Debug)]
@@ -37,38 +58,151 @@ impl ExpBitsLenAir {
     }
 }
 
-impl BaseAirWithPublicValues<F> for ExpBitsLenAir {}
-impl PartitionedBaseAir<F> for ExpBitsLenAir {}
+fn assert_babybear_field<F: PrimeField32>() {
+    assert_eq!(
+        F::ORDER_U32,
+        BabyBear::ORDER_U32,
+        "ExpBitsLenAir is hard-coded for the BabyBear modulus; canonicality constraints assume p = 15 * 2^27 + 1",
+    );
+}
 
-impl<F> BaseAir<F> for ExpBitsLenAir {
+impl<F: PrimeField32> BaseAirWithPublicValues<F> for ExpBitsLenAir {}
+impl<F: PrimeField32> PartitionedBaseAir<F> for ExpBitsLenAir {}
+
+impl<F: PrimeField32> BaseAir<F> for ExpBitsLenAir {
     fn width(&self) -> usize {
+        assert_babybear_field::<F>();
         ExpBitsLenCols::<F>::width()
     }
 }
 
-impl<AB: AirBuilder + InteractionBuilder> Air<AB> for ExpBitsLenAir {
+impl<AB: AirBuilder + InteractionBuilder> Air<AB> for ExpBitsLenAir
+where
+    AB::F: PrimeField32,
+{
     fn eval(&self, builder: &mut AB) {
+        assert_babybear_field::<AB::F>();
         let main = builder.main();
 
-        let local = main.row_slice(0).expect("window should have two elements");
+        let (local, next) = (
+            main.row_slice(0).expect("window should have two elements"),
+            main.row_slice(1).expect("window should have two elements"),
+        );
         let local: &ExpBitsLenCols<AB::Var> = (*local).borrow();
+        let next: &ExpBitsLenCols<AB::Var> = (*next).borrow();
 
+        let is_transition = next.is_valid.into() - next.is_first.into();
+        let local_is_last = local.is_valid.into() - is_transition.clone();
+        let local_in_high_region =
+            local.is_valid.into() - local.in_low_region.into() - local_is_last.clone();
+        let next_is_not_low_region = next.is_valid.into() - next.in_low_region.into();
+
+        builder.assert_bool(local.is_valid);
+        builder.assert_bool(local.is_first);
+        builder.assert_bool(is_transition.clone());
+        builder
+            .when(is_transition.clone())
+            .assert_one(local.is_valid);
+        builder.assert_bool(local.apply_bit);
+        builder.assert_bool(local.in_low_region);
         builder.assert_bool(local.bit_src_mod_2);
+        builder.assert_bool(local.low_bits_are_zero);
+        builder.assert_bool(local.high_bits_all_one);
+        builder.assert_bool(local_in_high_region.clone());
+        builder.when(local.is_first).assert_one(local.is_valid);
+        builder.when(local.num_bits).assert_one(local.apply_bit);
+        builder
+            .when(local.low_bits_left)
+            .assert_one(local.in_low_region);
+
         builder.assert_eq(
-            local.bit_src,
-            local.bit_src_div_2 * AB::Expr::TWO + local.bit_src_mod_2,
-        );
-        builder.assert_eq(
-            local.num_bits,
-            local.num_bits * local.num_bits * local.num_bits_inv,
-        );
-        builder.when(local.num_bits).assert_eq(
-            local.result,
-            local.sub_result
-                * (local.bit_src_mod_2 * local.base + AB::Expr::ONE - local.bit_src_mod_2),
+            local.result_multiplier - AB::Expr::ONE,
+            local.apply_bit * local.bit_src_mod_2 * (local.base - AB::Expr::ONE),
         );
 
-        let is_num_bits_nonzero = local.num_bits * local.num_bits_inv;
+        builder
+            .when_first_row()
+            .assert_eq(local.is_valid, local.is_first);
+        builder.when(local.is_first).assert_one(local.in_low_region);
+        builder
+            .when(local.is_first)
+            .assert_zero(local_is_last.clone());
+        builder.when(local.is_first).assert_zero(local.bit_idx);
+        builder
+            .when(local.is_first)
+            .assert_eq(local.low_bits_left, AB::Expr::from_usize(LOW_BITS_COUNT));
+        builder
+            .when(local.is_first)
+            .assert_one(local.low_bits_are_zero);
+        builder
+            .when(local.is_first)
+            .assert_zero(local.high_bits_all_one);
+
+        builder
+            .when(local_is_last.clone())
+            .assert_zero(local.in_low_region);
+        builder.when(local_is_last.clone()).assert_eq(
+            local.bit_idx,
+            AB::Expr::from_usize(NUM_BITS_MAX_PLUS_ONE - 1),
+        );
+        builder
+            .when(local_is_last.clone())
+            .assert_zero(local.bit_src);
+        builder
+            .when(local_is_last.clone())
+            .assert_zero(local.num_bits);
+        builder
+            .when(local_is_last.clone())
+            .assert_zero(local.apply_bit);
+        builder
+            .when(local_is_last.clone())
+            .assert_zero(local.low_bits_left);
+        builder.when(local_is_last.clone()).assert_one(local.result);
+        builder
+            .when(local_is_last.clone())
+            .assert_one(local.result_multiplier);
+        builder
+            .when(local_is_last.clone())
+            .assert_zero(local.high_bits_all_one * (AB::Expr::ONE - local.low_bits_are_zero));
+
+        builder
+            .when(is_transition.clone())
+            .assert_eq(next.bit_idx, local.bit_idx + AB::Expr::ONE);
+        builder
+            .when(is_transition.clone())
+            .assert_eq(next.base, local.base * local.base);
+        builder.when(is_transition.clone()).assert_eq(
+            local.bit_src,
+            next.bit_src * AB::Expr::TWO + local.bit_src_mod_2,
+        );
+        builder
+            .when(is_transition.clone())
+            .assert_eq(next.num_bits, local.num_bits - local.apply_bit);
+        builder.when(is_transition.clone()).assert_eq(
+            next.low_bits_left,
+            local.low_bits_left - local.in_low_region,
+        );
+        builder
+            .when(is_transition.clone())
+            .assert_eq(local.result, next.result * local.result_multiplier);
+        builder.when(local.in_low_region).assert_eq(
+            next.low_bits_are_zero,
+            local.low_bits_are_zero * (AB::Expr::ONE - local.bit_src_mod_2),
+        );
+        builder
+            .when(local_in_high_region.clone())
+            .assert_eq(next.low_bits_are_zero, local.low_bits_are_zero);
+        builder
+            .when(local.in_low_region * next.in_low_region)
+            .assert_zero(next.high_bits_all_one);
+        builder
+            .when(local.in_low_region * next_is_not_low_region.clone())
+            .assert_one(next.high_bits_all_one);
+        builder.when(local_in_high_region).assert_eq(
+            next.high_bits_all_one,
+            local.high_bits_all_one * local.bit_src_mod_2,
+        );
+
         self.exp_bits_len_bus.add_key_with_lookups(
             builder,
             ExpBitsLenMessage {
@@ -77,20 +211,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for ExpBitsLenAir {
                 num_bits: local.num_bits,
                 result: local.result,
             },
-            local.is_valid,
+            local.is_first,
         );
-        self.exp_bits_len_bus.lookup_key(
-            builder,
-            ExpBitsLenMessage {
-                base: local.base * local.base,
-                bit_src: local.bit_src_div_2.into(),
-                num_bits: local.num_bits - AB::Expr::ONE,
-                result: local.sub_result.into(),
-            },
-            is_num_bits_nonzero.clone(),
-        );
-        builder
-            .when(AB::Expr::ONE - is_num_bits_nonzero)
-            .assert_one(local.result);
     }
 }

--- a/crates/recursion/src/primitives/exp_bits_len/tests.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/tests.rs
@@ -1,13 +1,36 @@
 use core::borrow::Borrow;
+use std::borrow::BorrowMut;
 
-use openvm_stark_sdk::{config::baby_bear_poseidon2::F, utils::setup_tracing_with_log_level};
+use openvm_stark_backend::{
+    any_air_arc_vec,
+    interaction::InteractionBuilder,
+    prover::{
+        AirProvingContext, ColMajorMatrix, CpuBackend, DeviceDataTransporter, ProvingContext,
+    },
+    utils::disable_debug_builder,
+    verifier::VerifierError,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkProtocolConfig,
+};
+use openvm_stark_sdk::{
+    config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F},
+    utils::setup_tracing_with_log_level,
+};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField32};
-use p3_matrix::Matrix;
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use stark_recursion_circuit_derive::AlignedBorrow;
 use tracing::Level;
 
 use super::{
-    air::ExpBitsLenCols,
-    trace::{fill_valid_rows, ExpBitsLenCpuTraceGenerator, NUM_BITS_MAX_PLUS_ONE},
+    air::{ExpBitsLenAir, ExpBitsLenCols},
+    trace::{
+        fill_valid_rows, fill_valid_rows_with_decomp_src, ExpBitsLenCpuTraceGenerator,
+        NUM_BITS_MAX_PLUS_ONE,
+    },
+};
+use crate::{
+    primitives::bus::{ExpBitsLenBus, ExpBitsLenMessage},
+    tests::test_engine_small,
 };
 
 #[derive(Clone, Debug)]
@@ -41,6 +64,139 @@ pub(crate) fn sample_exp_bits_len_requests(num_requests: usize) -> Vec<ExpBitsLe
         .collect()
 }
 
+#[repr(C)]
+#[derive(AlignedBorrow)]
+struct ExpBitsLenLookupCols<T> {
+    enabled: T,
+    base: T,
+    bit_src: T,
+    num_bits: T,
+    result: T,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ExpBitsLenLookupAir {
+    exp_bits_len_bus: ExpBitsLenBus,
+}
+
+impl<F> BaseAir<F> for ExpBitsLenLookupAir {
+    fn width(&self) -> usize {
+        ExpBitsLenLookupCols::<F>::width()
+    }
+}
+
+impl<F> BaseAirWithPublicValues<F> for ExpBitsLenLookupAir {}
+impl<F> PartitionedBaseAir<F> for ExpBitsLenLookupAir {}
+
+impl<AB: AirBuilder + InteractionBuilder> Air<AB> for ExpBitsLenLookupAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main
+            .row_slice(0)
+            .expect("window should contain at least one row");
+        let local: &ExpBitsLenLookupCols<AB::Var> = (*local).borrow();
+
+        builder.assert_bool(local.enabled);
+        self.exp_bits_len_bus.lookup_key(
+            builder,
+            ExpBitsLenMessage {
+                base: local.base,
+                bit_src: local.bit_src,
+                num_bits: local.num_bits,
+                result: local.result,
+            },
+            local.enabled,
+        );
+    }
+}
+
+fn build_lookup_trace(base: F, bit_src: F, num_bits: usize, result: F) -> RowMajorMatrix<F> {
+    let width = ExpBitsLenLookupCols::<F>::width();
+    let mut values = vec![F::ZERO; 2 * width];
+    let row = &mut values[..width];
+    let cols: &mut ExpBitsLenLookupCols<F> = row.borrow_mut();
+    cols.enabled = F::ONE;
+    cols.base = base;
+    cols.bit_src = bit_src;
+    cols.num_bits = F::from_usize(num_bits);
+    cols.result = result;
+    RowMajorMatrix::new(values, width)
+}
+
+fn pow_by_low_bits(base: F, bit_src: u32, num_bits: usize) -> F {
+    let exponent = if num_bits == 0 {
+        0
+    } else {
+        bit_src & ((1u32 << num_bits) - 1)
+    };
+    let mut acc = F::ONE;
+    for _ in 0..exponent {
+        acc *= base;
+    }
+    acc
+}
+
+fn add_terminal_tail(exp_bits_trace: &mut RowMajorMatrix<F>, delta: F) {
+    let width = exp_bits_trace.width();
+    let mut tail = delta;
+    for step in (0..NUM_BITS_MAX_PLUS_ONE).rev() {
+        let row_slice = &mut exp_bits_trace.values[step * width..(step + 1) * width];
+        let cols: &mut ExpBitsLenCols<F> = row_slice.borrow_mut();
+        cols.bit_src += tail;
+        tail += tail;
+    }
+}
+
+fn prove_and_verify_exp_bits(
+    lookup_trace: RowMajorMatrix<F>,
+    exp_bits_trace: RowMajorMatrix<F>,
+) -> Result<(), VerifierError<<BabyBearPoseidon2Config as StarkProtocolConfig>::EF>> {
+    disable_debug_builder();
+
+    let exp_bits_len_bus = ExpBitsLenBus::new(0);
+    let airs = any_air_arc_vec![
+        ExpBitsLenLookupAir { exp_bits_len_bus },
+        ExpBitsLenAir::new(exp_bits_len_bus)
+    ];
+
+    let engine = test_engine_small();
+    let (pk, vk) = engine.keygen(&airs);
+    let ctx: ProvingContext<CpuBackend<BabyBearPoseidon2Config>> = ProvingContext::new(
+        [lookup_trace, exp_bits_trace]
+            .into_iter()
+            .enumerate()
+            .map(|(air_idx, trace)| {
+                (
+                    air_idx,
+                    AirProvingContext::<CpuBackend<BabyBearPoseidon2Config>>::simple_no_pis(
+                        ColMajorMatrix::from_row_major(&trace),
+                    ),
+                )
+            })
+            .collect(),
+    );
+
+    let device = engine.device();
+    let d_pk = device.transport_pk_to_device(&pk);
+    let d_ctx: ProvingContext<CpuBackend<BabyBearPoseidon2Config>> = ProvingContext::new(
+        ctx.into_iter()
+            .map(|(air_idx, air_ctx)| {
+                (
+                    air_idx,
+                    AirProvingContext::<CpuBackend<BabyBearPoseidon2Config>> {
+                        cached_mains: vec![],
+                        common_main: device.transport_matrix_to_device(&air_ctx.common_main),
+                        public_values: air_ctx.public_values,
+                    },
+                )
+            })
+            .collect(),
+    );
+
+    let proof = engine.prove(&d_pk, d_ctx).unwrap();
+    engine.verify(&vk, &proof)
+}
+
 #[test_case::test_case(1)]
 #[test_case::test_case(1_000)]
 #[test_case::test_case(1_000_000)]
@@ -63,12 +219,12 @@ fn test_exp_bits_len_cpu_trace_generation(num_requests: usize) {
     let width = ExpBitsLenCols::<F>::width();
     assert_eq!(trace.width(), width);
 
-    let total_valid_rows: usize = requests.iter().map(|req| req.num_bits as usize + 1).sum();
+    let total_valid_rows = requests.len() * NUM_BITS_MAX_PLUS_ONE;
     assert_eq!(trace.height(), total_valid_rows.next_power_of_two());
 
     let mut cursor = 0;
     for req in &requests {
-        let row_count = req.num_bits as usize + 1;
+        let row_count = NUM_BITS_MAX_PLUS_ONE;
         let start = cursor * width;
         let end = start + row_count * width;
         let mut expected = vec![F::ZERO; row_count * width];
@@ -91,6 +247,77 @@ fn test_exp_bits_len_cpu_trace_generation(num_requests: usize) {
         assert_eq!(cols.is_valid, F::ZERO);
         assert_eq!(cols.result, F::ONE);
     }
+}
+
+#[test]
+fn test_exp_bits_len_proves_honest_trace() {
+    let base = F::from_u32(3);
+    let bit_src = F::from_u32(45);
+    let num_bits = 4usize;
+    let result = pow_by_low_bits(base, bit_src.as_canonical_u32(), num_bits);
+
+    let exp_bits_gen = ExpBitsLenCpuTraceGenerator::default();
+    exp_bits_gen.add_request(base, bit_src, num_bits);
+
+    let lookup_trace = build_lookup_trace(base, bit_src, num_bits, result);
+    let exp_bits_trace = exp_bits_gen
+        .generate_trace_row_major(None)
+        .expect("exp_bits_len trace should fit");
+
+    prove_and_verify_exp_bits(lookup_trace, exp_bits_trace).unwrap();
+}
+
+#[test]
+fn test_exp_bits_len_rejects_noncanonical_31_bit_decomposition() {
+    let base = F::from_u32(3);
+    let bit_src = F::from_u32(2);
+    let num_bits = 2usize;
+    let forged_decomp_src = F::ORDER_U32 + 2;
+    let forged_result = pow_by_low_bits(base, forged_decomp_src, num_bits);
+
+    let lookup_trace = build_lookup_trace(base, bit_src, num_bits, forged_result);
+
+    let width = ExpBitsLenCols::<F>::width();
+    let mut exp_bits_values = vec![F::ZERO; NUM_BITS_MAX_PLUS_ONE * width];
+    fill_valid_rows_with_decomp_src(
+        base,
+        forged_decomp_src,
+        num_bits as u8,
+        &mut exp_bits_values,
+        width,
+    );
+    let exp_bits_trace = RowMajorMatrix::new(exp_bits_values, width);
+
+    let result = prove_and_verify_exp_bits(lookup_trace, exp_bits_trace);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_exp_bits_len_rejects_nonzero_terminal_tail_on_last_row() {
+    let base = F::from_u32(3);
+    let bit_src = F::from_u32(45);
+    let num_bits = 4usize;
+    let honest_result = pow_by_low_bits(base, bit_src.as_canonical_u32(), num_bits);
+
+    let exp_bits_gen = ExpBitsLenCpuTraceGenerator::default();
+    exp_bits_gen.add_request(base, bit_src, num_bits);
+    let mut exp_bits_trace = exp_bits_gen
+        .generate_trace_row_major(Some(NUM_BITS_MAX_PLUS_ONE))
+        .expect("single request should fit exactly");
+
+    add_terminal_tail(&mut exp_bits_trace, F::ONE);
+
+    let first_row = &exp_bits_trace.values[..exp_bits_trace.width()];
+    let first_cols: &ExpBitsLenCols<F> = first_row.borrow();
+    let forged_bit_src = first_cols.bit_src;
+    assert_ne!(
+        pow_by_low_bits(base, forged_bit_src.as_canonical_u32(), num_bits),
+        honest_result
+    );
+
+    let lookup_trace = build_lookup_trace(base, forged_bit_src, num_bits, honest_result);
+    let result = prove_and_verify_exp_bits(lookup_trace, exp_bits_trace);
+    assert!(result.is_err());
 }
 
 #[cfg(feature = "cuda")]

--- a/crates/recursion/src/primitives/exp_bits_len/trace.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/trace.rs
@@ -1,30 +1,16 @@
 use core::borrow::BorrowMut;
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 use openvm_stark_backend::poly_common::Squarable;
 use openvm_stark_sdk::config::baby_bear_poseidon2::F;
-use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 
 use super::air::ExpBitsLenCols;
 
 pub(crate) const NUM_BITS_MAX_PLUS_ONE: usize = 32;
-
-/// Lookup table for inverses of all num_bits in [0, NUM_BITS_MAX_PLUS_ONE]
-/// Note: 0^(-1) is stored as 0
-static NUM_BITS_INV_TABLE: LazyLock<[F; NUM_BITS_MAX_PLUS_ONE]> = LazyLock::new(|| {
-    std::array::from_fn(|idx| {
-        if idx == 0 {
-            F::ZERO
-        } else {
-            let value = F::from_u32(idx as u32);
-            value
-                .try_inverse()
-                .expect("non-zero num_bits value should always be invertible")
-        }
-    })
-});
+pub(crate) const LOW_BITS_COUNT: usize = 27;
 
 #[repr(C)]
 #[derive(Clone, Debug)]
@@ -48,7 +34,7 @@ impl ExpBitsLenRecord {
     }
 
     pub(crate) fn num_rows(&self) -> usize {
-        self.num_bits as usize + 1
+        NUM_BITS_MAX_PLUS_ONE
     }
 
     pub(crate) fn end_row(&self) -> usize {
@@ -99,7 +85,6 @@ impl ExpBitsLenCpuTraceGenerator {
         };
         let mut trace = vec![F::ZERO; padded_rows * width];
 
-        // Split trace into chunks for each request
         let (data_slice, padding_slice) = trace.split_at_mut(num_valid_rows * width);
         let mut trace_slices: Vec<&mut [F]> = Vec::with_capacity(records.len());
         let mut remaining = data_slice;
@@ -111,7 +96,6 @@ impl ExpBitsLenCpuTraceGenerator {
             remaining = rest;
         }
 
-        // Fill valid rows in parallel across requests (serial within each request)
         tracing::info_span!("fill_valid_rows").in_scope(|| {
             trace_slices
                 .par_iter_mut()
@@ -127,11 +111,11 @@ impl ExpBitsLenCpuTraceGenerator {
                 });
         });
 
-        // Fill padding rows: 0^0 = 1
         tracing::info_span!("fill_padding_rows").in_scope(|| {
             padding_slice.par_chunks_exact_mut(width).for_each(|row| {
                 let cols: &mut ExpBitsLenCols<F> = row.borrow_mut();
                 cols.result = F::ONE;
+                cols.result_multiplier = F::ONE;
             });
         });
 
@@ -140,34 +124,67 @@ impl ExpBitsLenCpuTraceGenerator {
 }
 
 pub(crate) fn fill_valid_rows(base: F, bit_src: u32, n: u8, trace_slice: &mut [F], width: usize) {
-    let bases: Vec<_> = base.exp_powers_of_2().take(n as usize + 1).collect();
+    fill_valid_rows_with_decomp_src(base, bit_src, n, trace_slice, width);
+}
+
+pub(crate) fn fill_valid_rows_with_decomp_src(
+    base: F,
+    decomp_src: u32,
+    n: u8,
+    trace_slice: &mut [F],
+    width: usize,
+) {
+    debug_assert!(n < NUM_BITS_MAX_PLUS_ONE as u8);
+    debug_assert_eq!(trace_slice.len(), NUM_BITS_MAX_PLUS_ONE * width);
+    debug_assert!(decomp_src < (1u32 << (NUM_BITS_MAX_PLUS_ONE - 1)));
+
+    let bases: Vec<_> = base.exp_powers_of_2().take(NUM_BITS_MAX_PLUS_ONE).collect();
+    let mut results = [F::ONE; NUM_BITS_MAX_PLUS_ONE];
     let mut acc = F::ONE;
+    for step in (0..NUM_BITS_MAX_PLUS_ONE - 1).rev() {
+        if step < n as usize && ((decomp_src >> step) & 1) == 1 {
+            acc *= bases[step];
+        }
+        results[step] = acc;
+    }
 
-    for i in (0..=n).rev() {
-        let remaining = n - i;
-        let shifted = bit_src >> i;
+    let mut low_bits_are_zero = true;
+    let mut high_bits_all_one = false;
+    for step in 0..NUM_BITS_MAX_PLUS_ONE {
+        if step == LOW_BITS_COUNT {
+            high_bits_all_one = true;
+        }
 
-        let (result, sub_result) = if i == n {
-            (F::ONE, F::ONE)
-        } else {
-            let sub = acc;
-            if (bit_src >> i) & 1 == 1 {
-                acc *= bases[i as usize];
-            }
-            (acc, sub)
-        };
+        let shifted = decomp_src >> step;
+        let num_bits = (n as usize).saturating_sub(step);
+        let low_bits_left = LOW_BITS_COUNT.saturating_sub(step);
 
-        let row_offset = remaining as usize * width;
+        let row_offset = step * width;
         let row = &mut trace_slice[row_offset..row_offset + width];
         let cols: &mut ExpBitsLenCols<F> = row.borrow_mut();
-        cols.base = bases[i as usize];
-        cols.bit_src = F::from_u32(shifted);
-        cols.result = result;
-        cols.sub_result = sub_result;
-        cols.num_bits = F::from_u8(remaining);
         cols.is_valid = F::ONE;
-        cols.bit_src_div_2 = F::from_u32(shifted / 2);
-        cols.bit_src_mod_2 = F::from_u32(shifted % 2);
-        cols.num_bits_inv = NUM_BITS_INV_TABLE[remaining as usize];
+        cols.is_first = F::from_bool(step == 0);
+        cols.bit_idx = F::from_usize(step);
+        cols.base = bases[step];
+        cols.bit_src = F::from_u32(shifted);
+        cols.num_bits = F::from_usize(num_bits);
+        cols.apply_bit = F::from_bool(num_bits != 0);
+        cols.low_bits_left = F::from_usize(low_bits_left);
+        cols.in_low_region = F::from_bool(low_bits_left != 0);
+        cols.result = results[step];
+        cols.result_multiplier = if num_bits != 0 && (shifted & 1) == 1 {
+            bases[step]
+        } else {
+            F::ONE
+        };
+        cols.bit_src_mod_2 = F::from_bool((shifted & 1) == 1);
+        cols.low_bits_are_zero = F::from_bool(low_bits_are_zero);
+        cols.high_bits_all_one = F::from_bool(high_bits_all_one);
+
+        if step < LOW_BITS_COUNT {
+            low_bits_are_zero &= (shifted & 1) == 0;
+        } else if step + 1 < NUM_BITS_MAX_PLUS_ONE {
+            high_bits_all_one &= (shifted & 1) == 1;
+        }
     }
 }


### PR DESCRIPTION
Use fixed 32-row blocks with a full 31-bit decomposition and terminal row. Enforce canonical BabyBear representatives for bit_src.