### PR TITLE
fix: MerkleVerifyAir constrains the Merkle path taken to merkle_idx

### DIFF
--- a/crates/recursion/cuda/src/primitives/exp_bits_len.cu
+++ b/crates/recursion/cuda/src/primitives/exp_bits_len.cu
@@ -16,10 +16,11 @@ struct ExpBitsLenRecord {
     Fp base;
     Fp bit_src;
     uint32_t row_offset;
+    uint8_t shift_bits;
+    uint32_t shift_mult;
 };
 
-template <typename T>
-struct ExpBitsLenCols {
+template <typename T> struct ExpBitsLenCols {
     T is_valid;
     T is_first;
     T bit_idx;
@@ -34,6 +35,8 @@ struct ExpBitsLenCols {
     T bit_src_mod_2;
     T low_bits_are_zero;
     T high_bits_all_one;
+    T bit_src_original;
+    T shift_mult;
 };
 
 __global__ void exp_bits_len_tracegen_kernel(
@@ -100,12 +103,7 @@ __global__ void exp_bits_len_tracegen_kernel(
         COL_WRITE_VALUE(row, ExpBitsLenCols, num_bits, Fp(num_bits));
         COL_WRITE_VALUE(row, ExpBitsLenCols, apply_bit, bool_to_fp(num_bits != 0));
         COL_WRITE_VALUE(row, ExpBitsLenCols, low_bits_left, Fp(low_bits_left));
-        COL_WRITE_VALUE(
-            row,
-            ExpBitsLenCols,
-            in_low_region,
-            bool_to_fp(low_bits_left != 0)
-        );
+        COL_WRITE_VALUE(row, ExpBitsLenCols, in_low_region, bool_to_fp(low_bits_left != 0));
         COL_WRITE_VALUE(row, ExpBitsLenCols, result, results[step]);
         COL_WRITE_VALUE(
             row,
@@ -114,17 +112,14 @@ __global__ void exp_bits_len_tracegen_kernel(
             num_bits != 0 && (shifted & 1) == 1 ? bases[step] : Fp::one()
         );
         COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src_mod_2, Fp(shifted & 1));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, low_bits_are_zero, bool_to_fp(low_bits_are_zero));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, high_bits_all_one, bool_to_fp(high_bits_all_one));
+        COL_WRITE_VALUE(row, ExpBitsLenCols, bit_src_original, Fp(bit_src_uint));
         COL_WRITE_VALUE(
             row,
             ExpBitsLenCols,
-            low_bits_are_zero,
-            bool_to_fp(low_bits_are_zero)
-        );
-        COL_WRITE_VALUE(
-            row,
-            ExpBitsLenCols,
-            high_bits_all_one,
-            bool_to_fp(high_bits_all_one)
+            shift_mult,
+            step == record.shift_bits ? Fp(record.shift_mult) : Fp::zero()
         );
 
         if (step < kExpBitsLenLowBitsCount) {
@@ -146,11 +141,7 @@ extern "C" int _exp_bits_len_tracegen(
     if (total_jobs > 0) {
         auto [grid, block] = kernel_launch_params(total_jobs);
         exp_bits_len_tracegen_kernel<<<grid, block>>>(
-            d_requests,
-            num_requests,
-            d_trace,
-            height,
-            num_valid_rows
+            d_requests, num_requests, d_trace, height, num_valid_rows
         );
         int err = CHECK_KERNEL();
         if (err != 0) {

--- a/crates/recursion/cuda/src/transcript/merkle_verify.cu
+++ b/crates/recursion/cuda/src/transcript/merkle_verify.cu
@@ -18,8 +18,8 @@ template <typename T> struct MerkleVerifyCols {
     T is_last_leaf;
     T leaf_sub_idx;
 
-    T idx;
-    T current_idx;
+    T merkle_idx_bit_src;
+    T current_idx_bit_src;
     T total_depth;
     T height;
 
@@ -161,10 +161,16 @@ __global__ void cukernel_merkle_verify_tracegen(
                 row, MerkleVerifyCols, leaf_sub_idx, Fp(static_cast<uint32_t>(indices.result_index))
             );
             COL_WRITE_VALUE(
-                row, MerkleVerifyCols, idx, Fp(static_cast<uint32_t>(record.merkle_idx))
+                row,
+                MerkleVerifyCols,
+                merkle_idx_bit_src,
+                Fp(static_cast<uint32_t>(record.merkle_idx))
             );
             COL_WRITE_VALUE(
-                row, MerkleVerifyCols, current_idx, Fp(static_cast<uint32_t>(record.merkle_idx))
+                row,
+                MerkleVerifyCols,
+                current_idx_bit_src,
+                Fp(static_cast<uint32_t>(record.merkle_idx))
             );
             COL_WRITE_VALUE(
                 row, MerkleVerifyCols, height, Fp(static_cast<uint32_t>(indices.source_layer))
@@ -202,13 +208,16 @@ __global__ void cukernel_merkle_verify_tracegen(
             COL_WRITE_VALUE(row, MerkleVerifyCols, is_combining_leaves, Fp::zero());
             COL_WRITE_VALUE(row, MerkleVerifyCols, leaf_sub_idx, Fp::zero());
             COL_WRITE_VALUE(
-                row, MerkleVerifyCols, idx, Fp(static_cast<uint32_t>(record.merkle_idx))
+                row,
+                MerkleVerifyCols,
+                merkle_idx_bit_src,
+                Fp(static_cast<uint32_t>(record.merkle_idx))
             );
 
             current_idx >>= 1;
 
             COL_WRITE_VALUE(
-                row, MerkleVerifyCols, current_idx, Fp(static_cast<uint32_t>(current_idx))
+                row, MerkleVerifyCols, current_idx_bit_src, Fp(static_cast<uint32_t>(current_idx))
             );
             COL_WRITE_VALUE(row, MerkleVerifyCols, height, Fp(static_cast<uint32_t>(pos + k)));
             COL_WRITE_VALUE(row, MerkleVerifyCols, is_last_leaf, Fp::zero());

--- a/crates/recursion/cuda/src/transcript/merkle_verify.cu
+++ b/crates/recursion/cuda/src/transcript/merkle_verify.cu
@@ -19,6 +19,7 @@ template <typename T> struct MerkleVerifyCols {
     T leaf_sub_idx;
 
     T idx;
+    T current_idx;
     T total_depth;
     T height;
 
@@ -163,6 +164,9 @@ __global__ void cukernel_merkle_verify_tracegen(
                 row, MerkleVerifyCols, idx, Fp(static_cast<uint32_t>(record.merkle_idx))
             );
             COL_WRITE_VALUE(
+                row, MerkleVerifyCols, current_idx, Fp(static_cast<uint32_t>(record.merkle_idx))
+            );
+            COL_WRITE_VALUE(
                 row, MerkleVerifyCols, height, Fp(static_cast<uint32_t>(indices.source_layer))
             );
             COL_WRITE_VALUE(
@@ -197,11 +201,18 @@ __global__ void cukernel_merkle_verify_tracegen(
             copy_digest(current_hash, poseidon_state);
             COL_WRITE_VALUE(row, MerkleVerifyCols, is_combining_leaves, Fp::zero());
             COL_WRITE_VALUE(row, MerkleVerifyCols, leaf_sub_idx, Fp::zero());
-            COL_WRITE_VALUE(row, MerkleVerifyCols, idx, record.merkle_idx);
+            COL_WRITE_VALUE(
+                row, MerkleVerifyCols, idx, Fp(static_cast<uint32_t>(record.merkle_idx))
+            );
+
+            current_idx >>= 1;
+
+            COL_WRITE_VALUE(
+                row, MerkleVerifyCols, current_idx, Fp(static_cast<uint32_t>(current_idx))
+            );
             COL_WRITE_VALUE(row, MerkleVerifyCols, height, Fp(static_cast<uint32_t>(pos + k)));
             COL_WRITE_VALUE(row, MerkleVerifyCols, is_last_leaf, Fp::zero());
             COL_WRITE_VALUE(row, MerkleVerifyCols, recv_flag, bool_to_fp(!left_is_cur));
-            current_idx >>= 1;
         }
         COL_WRITE_ARRAY(row, MerkleVerifyCols, output, poseidon_state);
     }

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -415,6 +415,8 @@ pub struct MerkleVerifyBusMessage<T> {
     /// The idx of the merkle proof in the proof, might have additional bits (so not 0 at the root)
     /// It will be the same for all the rows in the hashing leaves part.
     pub merkle_idx: T,
+    /// Merkle idx suffix after shifting right max(0, height - k) bits
+    pub current_idx: T,
     /// The total depth of the merkle proof including the leaves part, equal to merkle_proof.len()
     /// + 1 + k
     pub total_depth: T,

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -414,9 +414,9 @@ impl AirShapeProperty {
 pub struct MerkleVerifyBusMessage<T> {
     /// The idx of the merkle proof in the proof, might have additional bits (so not 0 at the root)
     /// It will be the same for all the rows in the hashing leaves part.
-    pub merkle_idx: T,
+    pub merkle_idx_bit_src: T,
     /// Merkle idx suffix after shifting right max(0, height - k) bits
-    pub current_idx: T,
+    pub current_idx_bit_src: T,
     /// The total depth of the merkle proof including the leaves part, equal to merkle_proof.len()
     /// + 1 + k
     pub total_depth: T,

--- a/crates/recursion/src/primitives/bus.rs
+++ b/crates/recursion/src/primitives/bus.rs
@@ -30,3 +30,13 @@ pub struct ExpBitsLenMessage<T> {
 }
 
 define_typed_lookup_bus!(ExpBitsLenBus, ExpBitsLenMessage);
+
+#[repr(C)]
+#[derive(AlignedBorrow, Debug, Clone)]
+pub struct BitShiftMessage<T> {
+    pub base: T,
+    pub num_bits: T,
+    pub result: T,
+}
+
+define_typed_lookup_bus!(BitShiftBus, BitShiftMessage);

--- a/crates/recursion/src/primitives/bus.rs
+++ b/crates/recursion/src/primitives/bus.rs
@@ -33,10 +33,10 @@ define_typed_lookup_bus!(ExpBitsLenBus, ExpBitsLenMessage);
 
 #[repr(C)]
 #[derive(AlignedBorrow, Debug, Clone)]
-pub struct BitShiftMessage<T> {
-    pub base: T,
-    pub num_bits: T,
+pub struct RightShiftMessage<T> {
+    pub input: T,
+    pub shift_bits: T,
     pub result: T,
 }
 
-define_typed_lookup_bus!(BitShiftBus, BitShiftMessage);
+define_typed_lookup_bus!(RightShiftBus, RightShiftMessage);

--- a/crates/recursion/src/primitives/exp_bits_len/air.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/air.rs
@@ -10,7 +10,7 @@ use p3_matrix::Matrix;
 use stark_recursion_circuit_derive::AlignedBorrow;
 
 use crate::primitives::{
-    bus::{ExpBitsLenBus, ExpBitsLenMessage},
+    bus::{BitShiftBus, BitShiftMessage, ExpBitsLenBus, ExpBitsLenMessage},
     exp_bits_len::trace::{LOW_BITS_COUNT, NUM_BITS_MAX_PLUS_ONE},
 };
 
@@ -45,17 +45,17 @@ pub struct ExpBitsLenCols<T> {
     pub low_bits_are_zero: T,
     /// Running flag: all high bits `b27..b30` seen so far are one.
     pub high_bits_all_one: T,
+
+    /// Original bit_src value
+    pub bit_src_original: T,
+    /// Indicator for if this show should send a shift message
+    pub shift_mult: T,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_new::new)]
 pub struct ExpBitsLenAir {
     pub exp_bits_len_bus: ExpBitsLenBus,
-}
-
-impl ExpBitsLenAir {
-    pub fn new(exp_bits_len_bus: ExpBitsLenBus) -> Self {
-        Self { exp_bits_len_bus }
-    }
+    pub bit_shift_bus: BitShiftBus,
 }
 
 fn assert_babybear_field<F: PrimeField32>() {
@@ -212,6 +212,25 @@ where
                 result: local.result,
             },
             local.is_first,
+        );
+
+        builder.when(local.shift_mult).assert_one(local.is_valid);
+
+        builder
+            .when(local.is_first)
+            .assert_eq(local.bit_src, local.bit_src_original);
+        builder
+            .when(is_transition)
+            .assert_eq(local.bit_src_original, next.bit_src_original);
+
+        self.bit_shift_bus.add_key_with_lookups(
+            builder,
+            BitShiftMessage {
+                base: local.bit_src_original,
+                num_bits: local.bit_idx,
+                result: local.bit_src,
+            },
+            local.shift_mult,
         );
     }
 }

--- a/crates/recursion/src/primitives/exp_bits_len/air.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/air.rs
@@ -10,7 +10,7 @@ use p3_matrix::Matrix;
 use stark_recursion_circuit_derive::AlignedBorrow;
 
 use crate::primitives::{
-    bus::{BitShiftBus, BitShiftMessage, ExpBitsLenBus, ExpBitsLenMessage},
+    bus::{ExpBitsLenBus, ExpBitsLenMessage, RightShiftBus, RightShiftMessage},
     exp_bits_len::trace::{LOW_BITS_COUNT, NUM_BITS_MAX_PLUS_ONE},
 };
 
@@ -55,7 +55,7 @@ pub struct ExpBitsLenCols<T> {
 #[derive(Debug, derive_new::new)]
 pub struct ExpBitsLenAir {
     pub exp_bits_len_bus: ExpBitsLenBus,
-    pub bit_shift_bus: BitShiftBus,
+    pub right_shift_bus: RightShiftBus,
 }
 
 fn assert_babybear_field<F: PrimeField32>() {
@@ -223,11 +223,11 @@ where
             .when(is_transition)
             .assert_eq(local.bit_src_original, next.bit_src_original);
 
-        self.bit_shift_bus.add_key_with_lookups(
+        self.right_shift_bus.add_key_with_lookups(
             builder,
-            BitShiftMessage {
-                base: local.bit_src_original,
-                num_bits: local.bit_idx,
+            RightShiftMessage {
+                input: local.bit_src_original,
+                shift_bits: local.bit_idx,
                 result: local.bit_src,
             },
             local.shift_mult,

--- a/crates/recursion/src/primitives/exp_bits_len/tests.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/tests.rs
@@ -29,7 +29,7 @@ use super::{
     },
 };
 use crate::{
-    primitives::bus::{BitShiftBus, ExpBitsLenBus, ExpBitsLenMessage},
+    primitives::bus::{ExpBitsLenBus, ExpBitsLenMessage, RightShiftBus},
     tests::test_engine_small,
 };
 
@@ -154,10 +154,10 @@ fn prove_and_verify_exp_bits(
     disable_debug_builder();
 
     let exp_bits_len_bus = ExpBitsLenBus::new(0);
-    let bit_shift_bus = BitShiftBus::new(1);
+    let right_shift_bus = RightShiftBus::new(1);
     let airs = any_air_arc_vec![
         ExpBitsLenLookupAir { exp_bits_len_bus },
-        ExpBitsLenAir::new(exp_bits_len_bus, bit_shift_bus)
+        ExpBitsLenAir::new(exp_bits_len_bus, right_shift_bus)
     ];
 
     let engine = test_engine_small();

--- a/crates/recursion/src/primitives/exp_bits_len/tests.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/tests.rs
@@ -29,7 +29,7 @@ use super::{
     },
 };
 use crate::{
-    primitives::bus::{ExpBitsLenBus, ExpBitsLenMessage},
+    primitives::bus::{BitShiftBus, ExpBitsLenBus, ExpBitsLenMessage},
     tests::test_engine_small,
 };
 
@@ -154,9 +154,10 @@ fn prove_and_verify_exp_bits(
     disable_debug_builder();
 
     let exp_bits_len_bus = ExpBitsLenBus::new(0);
+    let bit_shift_bus = BitShiftBus::new(1);
     let airs = any_air_arc_vec![
         ExpBitsLenLookupAir { exp_bits_len_bus },
-        ExpBitsLenAir::new(exp_bits_len_bus)
+        ExpBitsLenAir::new(exp_bits_len_bus, bit_shift_bus)
     ];
 
     let engine = test_engine_small();
@@ -232,6 +233,8 @@ fn test_exp_bits_len_cpu_trace_generation(num_requests: usize) {
             F::from_u32(req.base),
             req.bit_src,
             req.num_bits,
+            0,
+            0,
             &mut expected,
             width,
         );
@@ -283,6 +286,8 @@ fn test_exp_bits_len_rejects_noncanonical_31_bit_decomposition() {
         base,
         forged_decomp_src,
         num_bits as u8,
+        0,
+        0,
         &mut exp_bits_values,
         width,
     );

--- a/crates/recursion/src/primitives/exp_bits_len/trace.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/trace.rs
@@ -19,10 +19,19 @@ pub struct ExpBitsLenRecord {
     pub base: F,
     pub bit_src: F,
     pub row_offset: u32,
+    pub shift_bits: u8,
+    pub shift_mult: u32,
 }
 
 impl ExpBitsLenRecord {
-    pub(crate) fn new(base: F, bit_src: F, num_bits: usize, row_offset: u32) -> Self {
+    pub(crate) fn new(
+        base: F,
+        bit_src: F,
+        num_bits: usize,
+        row_offset: u32,
+        shift_bits: usize,
+        shift_mult: u32,
+    ) -> Self {
         debug_assert!(num_bits < NUM_BITS_MAX_PLUS_ONE);
         Self {
             base,
@@ -30,6 +39,9 @@ impl ExpBitsLenRecord {
             num_bits: u8::try_from(num_bits)
                 .expect("num_bits fits in NUM_BITS_MAX_PLUS_ONE (< 256)"),
             row_offset,
+            shift_bits: u8::try_from(shift_bits)
+                .expect("shift_bits fits in NUM_BITS_MAX_PLUS_ONE (< 256)"),
+            shift_mult,
         }
     }
 
@@ -56,11 +68,19 @@ impl ExpBitsLenCpuTraceGenerator {
     where
         I: IntoIterator<Item = (F, F, usize)>,
     {
+        self.add_requests_with_shift(batch.into_iter().map(|(x, y, z)| (x, y, z, 0, 0)));
+    }
+
+    pub fn add_requests_with_shift<I>(&self, batch: I)
+    where
+        I: IntoIterator<Item = (F, F, usize, usize, u32)>,
+    {
         let mut records = self.requests.lock().unwrap();
         let mut next_row_offset = records.last().map(|record| record.end_row()).unwrap_or(0);
-        for (base, bit_src, num_bits) in batch {
+        for (base, bit_src, num_bits, shift_bits, shift_mult) in batch {
             let row_offset = u32::try_from(next_row_offset).expect("row offset should fit in u32");
-            let record = ExpBitsLenRecord::new(base, bit_src, num_bits, row_offset);
+            let record =
+                ExpBitsLenRecord::new(base, bit_src, num_bits, row_offset, shift_bits, shift_mult);
             next_row_offset += record.num_rows();
             records.push(record);
         }
@@ -105,6 +125,8 @@ impl ExpBitsLenCpuTraceGenerator {
                         request.base,
                         request.bit_src.as_canonical_u32(),
                         request.num_bits,
+                        request.shift_bits,
+                        request.shift_mult,
                         trace_slice,
                         width,
                     );
@@ -123,14 +145,24 @@ impl ExpBitsLenCpuTraceGenerator {
     }
 }
 
-pub(crate) fn fill_valid_rows(base: F, bit_src: u32, n: u8, trace_slice: &mut [F], width: usize) {
-    fill_valid_rows_with_decomp_src(base, bit_src, n, trace_slice, width);
+pub(crate) fn fill_valid_rows(
+    base: F,
+    bit_src: u32,
+    n: u8,
+    shift_bits: u8,
+    shift_mult: u32,
+    trace_slice: &mut [F],
+    width: usize,
+) {
+    fill_valid_rows_with_decomp_src(base, bit_src, n, shift_bits, shift_mult, trace_slice, width);
 }
 
 pub(crate) fn fill_valid_rows_with_decomp_src(
     base: F,
     decomp_src: u32,
     n: u8,
+    shift_bits: u8,
+    shift_mult: u32,
     trace_slice: &mut [F],
     width: usize,
 ) {
@@ -180,6 +212,12 @@ pub(crate) fn fill_valid_rows_with_decomp_src(
         cols.bit_src_mod_2 = F::from_bool((shifted & 1) == 1);
         cols.low_bits_are_zero = F::from_bool(low_bits_are_zero);
         cols.high_bits_all_one = F::from_bool(high_bits_all_one);
+        cols.bit_src_original = F::from_u32(decomp_src);
+        cols.shift_mult = if shift_bits as usize == step {
+            F::from_u32(shift_mult)
+        } else {
+            F::ZERO
+        };
 
         if step < LOW_BITS_COUNT {
             low_bits_are_zero &= (shifted & 1) == 0;

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     },
     gkr::GkrModule,
     primitives::{
-        bus::{BitShiftBus, ExpBitsLenBus, PowerCheckerBus, RangeCheckerBus},
+        bus::{ExpBitsLenBus, PowerCheckerBus, RangeCheckerBus, RightShiftBus},
         exp_bits_len::{ExpBitsLenAir, ExpBitsLenTraceGenerator},
         pow::{PowerCheckerAir, PowerCheckerCpuTraceGenerator},
     },
@@ -252,7 +252,7 @@ pub struct BusInventory {
 
     // Compute buses
     pub exp_bits_len_bus: ExpBitsLenBus,
-    pub bit_shift_bus: BitShiftBus,
+    pub right_shift_bus: RightShiftBus,
     pub sel_uni_bus: SelUniBus,
     pub eq_neg_result_bus: EqNegResultBus,
     pub eq_neg_base_rand_bus: EqNegBaseRandBus,
@@ -389,7 +389,7 @@ impl BusInventory {
             column_claims_bus: ColumnClaimsBus::new(b.new_bus_idx()),
 
             exp_bits_len_bus: ExpBitsLenBus::new(b.new_bus_idx()),
-            bit_shift_bus: BitShiftBus::new(b.new_bus_idx()),
+            right_shift_bus: RightShiftBus::new(b.new_bus_idx()),
             eq_neg_base_rand_bus: EqNegBaseRandBus::new(b.new_bus_idx()),
             eq_neg_result_bus: EqNegResultBus::new(b.new_bus_idx()),
 
@@ -953,7 +953,7 @@ impl<const MAX_NUM_PROOFS: usize> AggregationSubCircuit for VerifierSubCircuit<M
     fn airs<SC: StarkProtocolConfig<F = F>>(&self) -> Vec<AirRef<SC>> {
         let exp_bits_len_air = ExpBitsLenAir::new(
             self.bus_inventory.exp_bits_len_bus,
-            self.bus_inventory.bit_shift_bus,
+            self.bus_inventory.right_shift_bus,
         );
         let power_checker_air = PowerCheckerAir::<2, POW_CHECKER_HEIGHT> {
             pow_bus: self.bus_inventory.power_checker_bus,

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     },
     gkr::GkrModule,
     primitives::{
-        bus::{ExpBitsLenBus, PowerCheckerBus, RangeCheckerBus},
+        bus::{BitShiftBus, ExpBitsLenBus, PowerCheckerBus, RangeCheckerBus},
         exp_bits_len::{ExpBitsLenAir, ExpBitsLenTraceGenerator},
         pow::{PowerCheckerAir, PowerCheckerCpuTraceGenerator},
     },
@@ -252,6 +252,7 @@ pub struct BusInventory {
 
     // Compute buses
     pub exp_bits_len_bus: ExpBitsLenBus,
+    pub bit_shift_bus: BitShiftBus,
     pub sel_uni_bus: SelUniBus,
     pub eq_neg_result_bus: EqNegResultBus,
     pub eq_neg_base_rand_bus: EqNegBaseRandBus,
@@ -388,6 +389,7 @@ impl BusInventory {
             column_claims_bus: ColumnClaimsBus::new(b.new_bus_idx()),
 
             exp_bits_len_bus: ExpBitsLenBus::new(b.new_bus_idx()),
+            bit_shift_bus: BitShiftBus::new(b.new_bus_idx()),
             eq_neg_base_rand_bus: EqNegBaseRandBus::new(b.new_bus_idx()),
             eq_neg_result_bus: EqNegResultBus::new(b.new_bus_idx()),
 
@@ -949,7 +951,10 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
 
 impl<const MAX_NUM_PROOFS: usize> AggregationSubCircuit for VerifierSubCircuit<MAX_NUM_PROOFS> {
     fn airs<SC: StarkProtocolConfig<F = F>>(&self) -> Vec<AirRef<SC>> {
-        let exp_bits_len_air = ExpBitsLenAir::new(self.bus_inventory.exp_bits_len_bus);
+        let exp_bits_len_air = ExpBitsLenAir::new(
+            self.bus_inventory.exp_bits_len_bus,
+            self.bus_inventory.bit_shift_bus,
+        );
         let power_checker_air = PowerCheckerAir::<2, POW_CHECKER_HEIGHT> {
             pow_bus: self.bus_inventory.power_checker_bus,
             range_bus: self.bus_inventory.range_checker_bus,

--- a/crates/recursion/src/transcript/merkle_verify/air.rs
+++ b/crates/recursion/src/transcript/merkle_verify/air.rs
@@ -15,7 +15,7 @@ use crate::{
         CommitmentsBus, CommitmentsBusMessage, MerkleVerifyBus, MerkleVerifyBusMessage,
         Poseidon2CompressBus, Poseidon2CompressMessage,
     },
-    primitives::bus::{BitShiftBus, BitShiftMessage},
+    primitives::bus::{RightShiftBus, RightShiftMessage},
 };
 
 /// There are two parts in the merkle proof: hashing leaves and the (standard) merkle proof.
@@ -55,9 +55,9 @@ pub struct MerkleVerifyCols<T> {
     pub leaf_sub_idx: T,
 
     /// The merkle idx of the leaf hash root
-    pub idx: T,
+    pub merkle_idx_bit_src: T,
     /// Merkle idx suffix after shifting right max(0, height - k) bits
-    pub current_idx: T,
+    pub current_idx_bit_src: T,
     /// Total depth of the merkle proof including the leaves part = merkle_proof.len() + 1 + k
     pub total_depth: T,
     /// 0 -> total_depth - 1, where leaves are at height 0, combined leaf hash is at height k
@@ -90,7 +90,7 @@ pub struct MerkleVerifyAir {
     pub poseidon2_compress_bus: Poseidon2CompressBus,
     pub merkle_verify_bus: MerkleVerifyBus,
     pub commitments_bus: CommitmentsBus,
-    pub bit_shift_bus: BitShiftBus,
+    pub right_shift_bus: RightShiftBus,
     pub k: usize,
 }
 
@@ -160,7 +160,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
         // Constrain current_idx == idx on leaf rows
         builder
             .when(local.is_combining_leaves)
-            .assert_eq(local.idx, local.current_idx);
+            .assert_eq(local.merkle_idx_bit_src, local.current_idx_bit_src);
 
         ///////////////////////////////////////////////////////////////////////
         // Interactions
@@ -176,7 +176,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             local.recv_flag * (AB::Expr::from_u8(3) - local.recv_flag) * AB::F::TWO.inverse();
 
         let left_child_current_idx =
-            local.current_idx * (AB::Expr::TWO - local.is_combining_leaves);
+            local.current_idx_bit_src * (AB::Expr::TWO - local.is_combining_leaves);
         let right_child_current_idx =
             left_child_current_idx.clone() + AB::Expr::ONE - local.is_combining_leaves;
 
@@ -185,8 +185,8 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             local.proof_idx,
             MerkleVerifyBusMessage {
                 value: local.left.map(Into::into),
-                merkle_idx: local.idx.into(),
-                current_idx: left_child_current_idx,
+                merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                current_idx_bit_src: left_child_current_idx,
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
                 is_leaf: local.is_combining_leaves.into(),
@@ -201,8 +201,8 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             local.proof_idx,
             MerkleVerifyBusMessage {
                 value: local.right.map(Into::into),
-                merkle_idx: local.idx.into(),
-                current_idx: right_child_current_idx,
+                merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                current_idx_bit_src: right_child_current_idx,
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
                 is_leaf: local.is_combining_leaves.into(),
@@ -218,8 +218,8 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             local.proof_idx,
             MerkleVerifyBusMessage {
                 value: local.compression_output.map(Into::into),
-                merkle_idx: local.idx.into(),
-                current_idx: local.current_idx.into(),
+                merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                current_idx_bit_src: local.current_idx_bit_src.into(),
                 total_depth: local.total_depth.into(),
                 height: local.height + AB::Expr::ONE,
                 is_leaf: local.is_combining_leaves - local.is_last_leaf,
@@ -241,12 +241,12 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             local.is_valid * local.is_last_merkle,
         );
 
-        self.bit_shift_bus.lookup_key(
+        self.right_shift_bus.lookup_key(
             builder,
-            BitShiftMessage {
-                base: local.idx.into(),
-                num_bits: local.total_depth - AB::Expr::from_usize(self.k),
-                result: local.current_idx.into(),
+            RightShiftMessage {
+                input: local.merkle_idx_bit_src.into(),
+                shift_bits: local.total_depth - AB::Expr::from_usize(self.k),
+                result: local.current_idx_bit_src.into(),
             },
             local.is_valid * local.is_last_merkle,
         );

--- a/crates/recursion/src/transcript/merkle_verify/air.rs
+++ b/crates/recursion/src/transcript/merkle_verify/air.rs
@@ -10,9 +10,12 @@ use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use stark_recursion_circuit_derive::AlignedBorrow;
 
-use crate::bus::{
-    CommitmentsBus, CommitmentsBusMessage, MerkleVerifyBus, MerkleVerifyBusMessage,
-    Poseidon2CompressBus, Poseidon2CompressMessage,
+use crate::{
+    bus::{
+        CommitmentsBus, CommitmentsBusMessage, MerkleVerifyBus, MerkleVerifyBusMessage,
+        Poseidon2CompressBus, Poseidon2CompressMessage,
+    },
+    primitives::bus::{BitShiftBus, BitShiftMessage},
 };
 
 /// There are two parts in the merkle proof: hashing leaves and the (standard) merkle proof.
@@ -53,6 +56,8 @@ pub struct MerkleVerifyCols<T> {
 
     /// The merkle idx of the leaf hash root
     pub idx: T,
+    /// Merkle idx suffix after shifting right max(0, height - k) bits
+    pub current_idx: T,
     /// Total depth of the merkle proof including the leaves part = merkle_proof.len() + 1 + k
     pub total_depth: T,
     /// 0 -> total_depth - 1, where leaves are at height 0, combined leaf hash is at height k
@@ -85,6 +90,7 @@ pub struct MerkleVerifyAir {
     pub poseidon2_compress_bus: Poseidon2CompressBus,
     pub merkle_verify_bus: MerkleVerifyBus,
     pub commitments_bus: CommitmentsBus,
+    pub bit_shift_bus: BitShiftBus,
     pub k: usize,
 }
 
@@ -151,6 +157,11 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             .when_ne(local.is_combining_leaves, AB::Expr::ONE)
             .assert_bool(local.recv_flag);
 
+        // Constrain current_idx == idx on leaf rows
+        builder
+            .when(local.is_combining_leaves)
+            .assert_eq(local.idx, local.current_idx);
+
         ///////////////////////////////////////////////////////////////////////
         // Interactions
         ///////////////////////////////////////////////////////////////////////
@@ -164,12 +175,18 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
         let recv_right =
             local.recv_flag * (AB::Expr::from_u8(3) - local.recv_flag) * AB::F::TWO.inverse();
 
+        let left_child_current_idx =
+            local.current_idx * (AB::Expr::TWO - local.is_combining_leaves);
+        let right_child_current_idx =
+            left_child_current_idx.clone() + AB::Expr::ONE - local.is_combining_leaves;
+
         self.merkle_verify_bus.receive(
             builder,
             local.proof_idx,
             MerkleVerifyBusMessage {
                 value: local.left.map(Into::into),
                 merkle_idx: local.idx.into(),
+                current_idx: left_child_current_idx,
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
                 is_leaf: local.is_combining_leaves.into(),
@@ -185,6 +202,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             MerkleVerifyBusMessage {
                 value: local.right.map(Into::into),
                 merkle_idx: local.idx.into(),
+                current_idx: right_child_current_idx,
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
                 is_leaf: local.is_combining_leaves.into(),
@@ -201,6 +219,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             MerkleVerifyBusMessage {
                 value: local.compression_output.map(Into::into),
                 merkle_idx: local.idx.into(),
+                current_idx: local.current_idx.into(),
                 total_depth: local.total_depth.into(),
                 height: local.height + AB::Expr::ONE,
                 is_leaf: local.is_combining_leaves - local.is_last_leaf,
@@ -218,6 +237,16 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
                 major_idx: local.commit_major,
                 minor_idx: local.commit_minor,
                 commitment: local.left, // left and right are both the commitment
+            },
+            local.is_valid * local.is_last_merkle,
+        );
+
+        self.bit_shift_bus.lookup_key(
+            builder,
+            BitShiftMessage {
+                base: local.idx.into(),
+                num_bits: local.total_depth - AB::Expr::from_usize(self.k),
+                result: local.current_idx.into(),
             },
             local.is_valid * local.is_last_merkle,
         );

--- a/crates/recursion/src/transcript/merkle_verify/trace.rs
+++ b/crates/recursion/src/transcript/merkle_verify/trace.rs
@@ -151,8 +151,8 @@ pub fn generate_trace(
             leaf_tree[combination_indices.result_layer][combination_indices.result_index] = output;
             cols.compression_output = output;
 
-            cols.idx = F::from_usize(merkle_idx); // const idx for leaves part
-            cols.current_idx = F::from_usize(merkle_idx);
+            cols.merkle_idx_bit_src = F::from_usize(merkle_idx); // const idx for leaves part
+            cols.current_idx_bit_src = F::from_usize(merkle_idx);
             cols.height = F::from_usize(combination_indices.source_layer);
             cols.is_last_leaf = F::from_bool(combination_indices.source_layer + 1 == k);
             cols.recv_flag = F::TWO;
@@ -202,8 +202,8 @@ pub fn generate_trace(
             cur_hash = output;
             cur_idx /= 2;
 
-            cols.idx = F::from_usize(merkle_idx);
-            cols.current_idx = F::from_usize(cur_idx);
+            cols.merkle_idx_bit_src = F::from_usize(merkle_idx);
+            cols.current_idx_bit_src = F::from_usize(cur_idx);
             cols.height = F::from_usize(i + 1 - num_leaves + k);
             cols.is_combining_leaves = F::ZERO;
         }

--- a/crates/recursion/src/transcript/merkle_verify/trace.rs
+++ b/crates/recursion/src/transcript/merkle_verify/trace.rs
@@ -152,6 +152,7 @@ pub fn generate_trace(
             cols.compression_output = output;
 
             cols.idx = F::from_usize(merkle_idx); // const idx for leaves part
+            cols.current_idx = F::from_usize(merkle_idx);
             cols.height = F::from_usize(combination_indices.source_layer);
             cols.is_last_leaf = F::from_bool(combination_indices.source_layer + 1 == k);
             cols.recv_flag = F::TWO;
@@ -198,12 +199,13 @@ pub fn generate_trace(
             input_state[DIGEST_SIZE..].copy_from_slice(&cols.right);
             poseidon2_compress_inputs.push(input_state);
 
-            cols.idx = F::from_usize(merkle_idx);
-            cols.height = F::from_usize(i + 1 - num_leaves + k);
-            cols.is_combining_leaves = F::ZERO;
-
             cur_hash = output;
             cur_idx /= 2;
+
+            cols.idx = F::from_usize(merkle_idx);
+            cols.current_idx = F::from_usize(cur_idx);
+            cols.height = F::from_usize(i + 1 - num_leaves + k);
+            cols.is_combining_leaves = F::ZERO;
         }
     }
 

--- a/crates/recursion/src/transcript/mod.rs
+++ b/crates/recursion/src/transcript/mod.rs
@@ -288,6 +288,7 @@ impl AirModule for TranscriptModule {
             poseidon2_compress_bus: self.bus_inventory.poseidon2_compress_bus,
             merkle_verify_bus: self.bus_inventory.merkle_verify_bus,
             commitments_bus: self.bus_inventory.commitments_bus,
+            bit_shift_bus: self.bus_inventory.bit_shift_bus,
             k: self.params.k_whir(),
         };
         vec![

--- a/crates/recursion/src/transcript/mod.rs
+++ b/crates/recursion/src/transcript/mod.rs
@@ -288,7 +288,7 @@ impl AirModule for TranscriptModule {
             poseidon2_compress_bus: self.bus_inventory.poseidon2_compress_bus,
             merkle_verify_bus: self.bus_inventory.merkle_verify_bus,
             commitments_bus: self.bus_inventory.commitments_bus,
-            bit_shift_bus: self.bus_inventory.bit_shift_bus,
+            right_shift_bus: self.bus_inventory.right_shift_bus,
             k: self.params.k_whir(),
         };
         vec![

--- a/crates/recursion/src/whir/initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/initial_opened_values/air.rs
@@ -303,6 +303,7 @@ where
             local.proof_idx,
             MerkleVerifyBusMessage {
                 merkle_idx: local.merkle_idx_bit_src.into(),
+                current_idx: local.merkle_idx_bit_src.into(),
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1),
                 height: AB::Expr::ZERO,
                 is_leaf: AB::Expr::ONE,

--- a/crates/recursion/src/whir/initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/initial_opened_values/air.rs
@@ -302,8 +302,8 @@ where
             builder,
             local.proof_idx,
             MerkleVerifyBusMessage {
-                merkle_idx: local.merkle_idx_bit_src.into(),
-                current_idx: local.merkle_idx_bit_src.into(),
+                merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                current_idx_bit_src: local.merkle_idx_bit_src.into(),
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1),
                 height: AB::Expr::ZERO,
                 is_leaf: AB::Expr::ONE,

--- a/crates/recursion/src/whir/mod.rs
+++ b/crates/recursion/src/whir/mod.rs
@@ -1024,12 +1024,21 @@ impl WhirModule {
             let round_queries = &preflight.whir.queries[query_range];
             let log_rs_domain_size = initial_log_rs_domain_size - i;
             let omega = F::two_adic_generator(log_rs_domain_size);
-            exp_bits_len_gen.add_requests(
-                round_queries
-                    .iter()
-                    .copied()
-                    .map(|sample| (omega, sample, log_rs_domain_size - k_whir)),
-            );
+            let shift_bits = initial_log_rs_domain_size - k_whir + 1 - i;
+            let per_query_lookups = if i == 0 {
+                preflight.initial_row_states.len() as u32
+            } else {
+                1
+            };
+            exp_bits_len_gen.add_requests_with_shift(round_queries.iter().copied().map(|sample| {
+                (
+                    omega,
+                    sample,
+                    log_rs_domain_size - k_whir,
+                    shift_bits,
+                    per_query_lookups,
+                )
+            }));
         }
     }
 

--- a/crates/recursion/src/whir/non_initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/non_initial_opened_values/air.rs
@@ -192,8 +192,8 @@ where
             local.proof_idx,
             MerkleVerifyBusMessage {
                 value: local.value_hash.map(Into::into),
-                merkle_idx: local.merkle_idx_bit_src.into(),
-                current_idx: local.merkle_idx_bit_src.into(),
+                merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                current_idx_bit_src: local.merkle_idx_bit_src.into(),
                 // There are two parts: hashing leaves (depth k) and merkle proof
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1)
                     - local.whir_round,

--- a/crates/recursion/src/whir/non_initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/non_initial_opened_values/air.rs
@@ -193,6 +193,7 @@ where
             MerkleVerifyBusMessage {
                 value: local.value_hash.map(Into::into),
                 merkle_idx: local.merkle_idx_bit_src.into(),
+                current_idx: local.merkle_idx_bit_src.into(),
                 // There are two parts: hashing leaves (depth k) and merkle proof
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1)
                     - local.whir_round,


### PR DESCRIPTION
Resolves INT-6728. 

- Modifies `ExpBitLenAir` to provide a right-shifted `bit_src` given its original value and a number of bits
- Each Merkle path `MerkleVerifyAir` consumes a bit of `merkle_idx` (remaining bits stored in `current_idx`)
- `current_idx` is compared against `merkle_idx` using `BitShiftBus`