### PR TITLE
fix: various proof shape + stacking + transcript fixes

### DIFF
--- a/crates/recursion/cuda/src/proof_shape/air.cu
+++ b/crates/recursion/cuda/src/proof_shape/air.cu
@@ -310,7 +310,11 @@ __device__ __forceinline__ void fill_summary_row(
     // n_logup
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, starting_cidx, n_logup);
 
-    range_checker.add_count(interaction_decomp[nonzero_idx] * (1 << msb_limb_zero_bits));
+    size_t shifted_msb_limb = interaction_decomp[nonzero_idx] * (1 << msb_limb_zero_bits);
+    range_checker.add_count(shifted_msb_limb);
+    if (shifted_msb_limb != 0) {
+        range_checker.add_count(shifted_msb_limb - (1 << (LIMB_BITS - 1)));
+    }
     range_checker.add_count(max_interaction_decomp[diff_idx] - interaction_decomp[diff_idx] - 1);
     pow_checker.add_pow_count(msb_limb_zero_bits);
     pow_checker.add_range_count(n_max > n_logup ? n_max - n_logup : n_logup - n_max);

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -867,7 +867,7 @@ where
 
         when_last.assert_bool(prefix.clone());
         when_last
-            .when(not::<AB::Expr>(limb_times_inv))
+            .when(not::<AB::Expr>(limb_times_inv.clone()))
             .assert_zero(n_logup);
         when_last.assert_eq(limb_to_range_check, expected_limb_to_range_check);
         msb_limb_zero_bits -= n_logup + prefix * AB::F::from_usize(self.l_skip);
@@ -881,13 +881,25 @@ where
             local.is_last,
         );
 
+        // When limb_to_range_check is non-zero we range check x and x - 128 to be in [0, 256).
+        // This ensures x in [128, 256), which implies that n_logup is exact.
+        let shifted_msb_limb = limb_to_range_check * msb_limb_zero_bits_exp;
         self.range_bus.lookup_key(
             builder,
             RangeCheckerBusMessage {
-                value: limb_to_range_check * msb_limb_zero_bits_exp,
+                value: shifted_msb_limb.clone(),
                 max_bits: AB::Expr::from_usize(LIMB_BITS),
             },
             local.is_last,
+        );
+
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: shifted_msb_limb - AB::Expr::from_usize(1 << (LIMB_BITS - 1)),
+                max_bits: AB::Expr::from_usize(LIMB_BITS),
+            },
+            local.is_last * limb_times_inv,
         );
 
         // Constrain n_max on each row. Also constrain that local.is_n_max_greater is one when

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -674,7 +674,7 @@ where
                     cached_commit: localv.cached_commits[cached_idx].map(Into::into),
                 },
                 cached_present[cached_idx].clone()
-                    * local.is_valid
+                    * local.is_present
                     * AB::Expr::from_bool(self.continuations_enabled),
             );
         });

--- a/crates/recursion/src/proof_shape/proof_shape/trace.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/trace.rs
@@ -324,8 +324,13 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 // n_logup
                 cols.starting_cidx = F::from_usize(n_logup);
 
-                range_checker
-                    .add_count(msb_limb.as_canonical_u32() as usize * (1 << msb_limb_zero_bits));
+                let shifted_msb_limb =
+                    msb_limb.as_canonical_u32() as usize * (1 << msb_limb_zero_bits);
+                range_checker.add_count(shifted_msb_limb);
+                if shifted_msb_limb != 0 {
+                    range_checker.add_count(shifted_msb_limb - (1 << (LIMB_BITS - 1)));
+                }
+
                 range_checker.add_count(
                     (max_interactions[diff_idx] - total_interactions_f[diff_idx]).as_canonical_u32()
                         as usize

--- a/crates/recursion/src/stacking/opening/air.rs
+++ b/crates/recursion/src/stacking/opening/air.rs
@@ -341,10 +341,8 @@ where
             .assert_zero(next.stacked_col_idx);
 
         builder
-            .when(and::<AB::Expr>(
-                not(local.is_last),
-                not::<AB::Expr>(next.commit_idx - local.commit_idx),
-            ))
+            .when(not(local.is_last))
+            .when_ne(local.commit_idx, next.commit_idx)
             .assert_bool(next.stacked_col_idx - local.stacked_col_idx);
         builder
             .when(and(local.is_last_for_claim, not(local.is_last)))

--- a/crates/recursion/src/stacking/opening/air.rs
+++ b/crates/recursion/src/stacking/opening/air.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
-    utils::{and, assert_array_eq, not},
+    utils::{and, assert_array_eq, not, or},
     SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
@@ -339,6 +339,19 @@ where
         builder
             .when(next.commit_idx - local.commit_idx)
             .assert_zero(next.stacked_col_idx);
+
+        builder
+            .when(and::<AB::Expr>(
+                not(local.is_last),
+                not::<AB::Expr>(next.commit_idx - local.commit_idx),
+            ))
+            .assert_bool(next.stacked_col_idx - local.stacked_col_idx);
+        builder
+            .when(and(local.is_last_for_claim, not(local.is_last)))
+            .assert_one(or::<AB::Expr>(
+                next.commit_idx - local.commit_idx,
+                next.stacked_col_idx - local.stacked_col_idx,
+            ));
 
         builder.assert_bool(local.is_last_for_claim);
         builder

--- a/crates/recursion/src/stacking/opening/air.rs
+++ b/crates/recursion/src/stacking/opening/air.rs
@@ -341,8 +341,10 @@ where
             .assert_zero(next.stacked_col_idx);
 
         builder
-            .when(not(local.is_last))
-            .when_ne(local.commit_idx, next.commit_idx)
+            .when(and::<AB::Expr>(
+                not(local.is_last),
+                not::<AB::Expr>(next.commit_idx - local.commit_idx),
+            ))
             .assert_bool(next.stacked_col_idx - local.stacked_col_idx);
         builder
             .when(and(local.is_last_for_claim, not(local.is_last)))

--- a/crates/recursion/src/stacking/univariate/air.rs
+++ b/crates/recursion/src/stacking/univariate/air.rs
@@ -154,6 +154,12 @@ where
             next.s_0_sum_over_d,
         );
 
+        assert_array_eq(
+            &mut builder.when(and::<AB::Expr>(not(next.coeff_is_d), not(local.is_last))),
+            local.s_0_sum_over_d,
+            next.s_0_sum_over_d,
+        );
+
         self.sumcheck_claims_bus.receive(
             builder,
             next.proof_idx,

--- a/crates/recursion/src/transcript/transcript/air.rs
+++ b/crates/recursion/src/transcript/transcript/air.rs
@@ -1,7 +1,7 @@
 use core::borrow::Borrow;
 
 use openvm_circuit_primitives::{
-    utils::{and, not, or},
+    utils::{and, assert_array_eq, not, or},
     SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
@@ -181,7 +181,13 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TranscriptAir {
                 input: local.prev_state,
                 output: local.post_state,
             },
-            permuted,
+            permuted.clone(),
+        );
+
+        assert_array_eq(
+            &mut builder.when(not::<AB::Expr>(permuted)),
+            local.prev_state,
+            local.post_state,
         );
 
         if let Some(final_state_bus) = self.final_state_bus {


### PR DESCRIPTION
Resolves INT-6749, INT-6753, INT-6757, INT-6761, INT-6764, INT-6765. In order of commit:

#### INT-6764: TranscriptAir: Non-permuted transcript rows leave the sponge state prover-controlled
#### INT-6765: TranscriptAir: Terminal FinalTranscriptStateBus export is not bound to the actual final transcript state

Asserts `pre_state` and `post_state` are equal on rows we do not permute.

#### INT-6749: ProofShapeAir: Absent AIR rows can export arbitrary cached commitments

Replace the `local.is_valid` gate in the `CachedTraceCommitBus` message mult to `local.is_present`.

#### INT-6761: UnivariateRoundAir: Univariate AIR does not carry the |D| * a_0 term forward to the a_|D| row

Constrain `local.s_0_sum_over_d == next.s_0_sum_over_d` on all rows we don't change it.

#### INT-6757: OpeningClaimsAir: Opening coefficients can be permuted across stacked columns within a commitment

Constrain that `stacked_col_idx` increments by at most 1 each row, and that for each `is_last_claim` either `commit_idx` or `stacked_col_idx` increments by 1.

#### INT-6753: ProofShapeAir: Summary row exports a forgeable n_logup

Issue was that the prover could increase `n_logup` in order to decrease `limb_to_range_check * msb_limb_zero_bits_exp`, making it easier to pass the range check. Added a range check to ensure that the MSB of the product above is 1.