### PR TITLE
fix: reject size=1 in RangeTupleCheckerChip constructor

### DIFF
--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -164,6 +164,12 @@ pub type SharedRangeTupleCheckerChip<const N: usize> = Arc<RangeTupleCheckerChip
 impl<const N: usize> RangeTupleCheckerChip<N> {
     pub fn new(bus: RangeTupleCheckerBus<N>) -> Self {
         assert!(N > 1, "RangeTupleChecker requires at least 2 dimensions");
+        // size = 1 is not useful, and breaks the completeness guarantee of this chip
+        assert!(
+            bus.sizes.iter().all(|&s| s > 1),
+            "RangeTupleChecker requires all sizes to be > 1 (size=1 dimensions break \
+             the carry coupling constraint)"
+        );
         let range_max = bus.sizes.iter().product();
         assert!(
             range_max > 0 && (range_max & (range_max - 1)) == 0,

--- a/crates/circuits/primitives/src/range_tuple/tests/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/tests/mod.rs
@@ -177,6 +177,21 @@ fn negative_test_range_tuple_chip_size_overflow() {
     );
 }
 
+#[test]
+fn negative_test_range_tuple_chip_size_one() {
+    let bus_index = 0;
+    let sizes = [2, 1, 2];
+
+    let result = std::panic::catch_unwind(|| {
+        let bus = RangeTupleCheckerBus::new(bus_index, sizes);
+        RangeTupleCheckerChip::new(bus)
+    });
+    assert!(
+        result.is_err(),
+        "Expected RangeTupleCheckerChip::new to panic when a size is 1"
+    );
+}
+
 #[cfg(feature = "cuda")]
 #[test]
 fn test_cuda_range_tuple() {


### PR DESCRIPTION
Resolves INT-6673.

When any dimension has size of 1, the T6 odometer carry constraint degenerates because "wrap" and "stay" produce the same diff (0), breaking the completeness guarantee of lexicographic enumeration.

Add an assert in the Chip constructor to reject this configuration, and a test to verify it panics.