### PR TITLE
fix: make Eq3bAir receive `n_logup` and `n_lift`

### DIFF
--- a/crates/recursion/cuda/src/batch_constraint/eq_airs/eq_3b.cu
+++ b/crates/recursion/cuda/src/batch_constraint/eq_airs/eq_3b.cu
@@ -18,6 +18,7 @@ template <typename T> struct Eq3bColumns {
     T interaction_idx;
 
     T n_lift;
+    T n_logup;
     T two_to_the_n_lift;
     T n;
     T hypercube_volume;
@@ -140,6 +141,7 @@ __global__ void eq_3b_tracegen(
     COL_WRITE_VALUE(row, Eq3bColumns, sort_idx, record.sort_idx);
     COL_WRITE_VALUE(row, Eq3bColumns, interaction_idx, record.interaction_idx);
     COL_WRITE_VALUE(row, Eq3bColumns, n_lift, record.n_lift);
+    COL_WRITE_VALUE(row, Eq3bColumns, n_logup, n_logup);
     COL_WRITE_VALUE(row, Eq3bColumns, two_to_the_n_lift, 1u << record.n_lift);
     COL_WRITE_VALUE(row, Eq3bColumns, n, local_n);
     COL_WRITE_VALUE(row, Eq3bColumns, hypercube_volume, 1u << local_n);

--- a/crates/recursion/cuda/src/proof_shape/air.cu
+++ b/crates/recursion/cuda/src/proof_shape/air.cu
@@ -60,6 +60,7 @@ template <typename T, size_t MAX_CACHED> struct ProofShapeCols {
 
     T n_max;
     T is_n_max_greater;
+    T n_logup;
 
     T num_air_id_lookups;
 
@@ -345,6 +346,7 @@ __global__ void proof_shape_tracegen(
         COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, proof_idx, proof_idx);
         COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, is_first, record_idx == 0);
         COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, n_max, proof_data.n_max);
+        COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, n_logup, proof_data.n_logup);
 
         Encoder encoder(inputs.num_airs, 2, true);
         size_t encoder_flags_idx =

--- a/crates/recursion/cuda/src/proof_shape/air.cu
+++ b/crates/recursion/cuda/src/proof_shape/air.cu
@@ -308,9 +308,6 @@ __device__ __forceinline__ void fill_summary_row(
         row, typename Cols<MAX_CACHED>::template Type, is_n_max_greater, n_max > n_logup
     );
 
-    // n_logup
-    COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, starting_cidx, n_logup);
-
     size_t shifted_msb_limb = interaction_decomp[nonzero_idx] * (1 << msb_limb_zero_bits);
     range_checker.add_count(shifted_msb_limb);
     if (shifted_msb_limb != 0) {

--- a/crates/recursion/cuda/src/proof_shape/air.cu
+++ b/crates/recursion/cuda/src/proof_shape/air.cu
@@ -248,6 +248,7 @@ __device__ __forceinline__ void fill_summary_row(
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, is_last, Fp::one());
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, sorted_idx, Fp::zero());
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, is_present, Fp::zero());
+    COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, starting_cidx, Fp::zero());
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, num_air_id_lookups, Fp::zero());
     row.fill_zero(cached_commits_idx, MAX_CACHED * DIGEST_SIZE);
 

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
@@ -140,7 +140,10 @@ where
             .when(within_one_air.clone())
             .assert_eq(next.n_lift, local.n_lift);
         builder
-            .when(within_one_air.clone())
+            .when(LoopSubAir::local_is_transition(
+                next.is_valid,
+                next.is_first,
+            ))
             .assert_eq(next.n_logup, local.n_logup);
         builder
             .when(within_one_interaction.clone())

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
@@ -18,6 +18,7 @@ use crate::{
         BatchConstraintConductorBus, BatchConstraintConductorMessage,
         BatchConstraintInnerMessageType, Eq3bBus, Eq3bMessage,
     },
+    bus::{Eq3bShapeBus, Eq3bShapeMessage},
     subairs::nested_for_loop::{NestedForLoopIoCols, NestedForLoopSubAir},
     utils::{
         base_to_ext, ext_field_add, ext_field_multiply, ext_field_multiply_scalar,
@@ -36,6 +37,7 @@ pub struct Eq3bColumns<T> {
     pub interaction_idx: T,
 
     pub n_lift: T,
+    pub n_logup: T,
     pub two_to_the_n_lift: T,
     pub n: T,
     pub hypercube_volume: T, // 2^n
@@ -56,6 +58,7 @@ pub struct Eq3bColumns<T> {
 
 pub struct Eq3bAir {
     pub eq_3b_bus: Eq3bBus,
+    pub eq_3b_shape_bus: Eq3bShapeBus,
     pub batch_constraint_conductor_bus: BatchConstraintConductorBus,
 
     pub l_skip: usize,
@@ -137,6 +140,12 @@ where
             .when(within_one_interaction.clone())
             .assert_eq(next.n_lift, local.n_lift);
         builder
+            .when(within_one_air.clone())
+            .assert_eq(next.n_lift, local.n_lift);
+        builder
+            .when(within_one_air.clone())
+            .assert_eq(next.n_logup, local.n_logup);
+        builder
             .when(within_one_interaction.clone())
             .assert_eq(next.two_to_the_n_lift, local.two_to_the_n_lift);
         builder
@@ -176,6 +185,10 @@ where
             .when(local.is_first_in_interaction)
             .when(local.n_at_least_n_lift)
             .assert_one(local.two_to_the_n_lift);
+        builder
+            .when(is_last_in_interaction.clone())
+            .when(not(local.has_no_interactions))
+            .assert_eq(local.n + AB::Expr::ONE, local.n_logup);
 
         builder.when(next.is_valid - next.is_first).assert_eq(
             next.running_idx,
@@ -258,10 +271,16 @@ where
             local.n_at_least_n_lift * within_one_interaction,
         );
 
-        // The air with this sort_idx has that n_lift, because it's constrained by some
-        // HyperdimBusMessages between some other AIRs
-
-        // This pidx has that n_logup because of some GkrModuleMessage between some other AIRs
+        self.eq_3b_shape_bus.lookup_key(
+            builder,
+            local.proof_idx,
+            Eq3bShapeMessage {
+                sort_idx: local.sort_idx,
+                n_lift: local.n_lift,
+                n_logup: local.n_logup,
+            },
+            local.is_first_in_air,
+        );
 
         self.eq_3b_bus.send(
             builder,

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
@@ -137,9 +137,6 @@ where
             .when(local.is_valid)
             .assert_one(local.hypercube_volume);
         builder
-            .when(within_one_interaction.clone())
-            .assert_eq(next.n_lift, local.n_lift);
-        builder
             .when(within_one_air.clone())
             .assert_eq(next.n_lift, local.n_lift);
         builder
@@ -188,7 +185,7 @@ where
         builder
             .when(is_last_in_interaction.clone())
             .when(not(local.has_no_interactions))
-            .assert_eq(local.n + AB::Expr::ONE, local.n_logup);
+            .assert_eq(local.n, local.n_logup);
 
         builder.when(next.is_valid - next.is_first).assert_eq(
             next.running_idx,

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_3b/trace.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_3b/trace.rs
@@ -197,6 +197,7 @@ impl RowMajorChip<F> for Eq3bTraceGenerator {
                         cols.sort_idx = F::from_u32(record.sort_idx);
                         cols.interaction_idx = F::from_u32(record.interaction_idx);
                         cols.n_lift = F::from_u32(record.n_lift);
+                        cols.n_logup = F::from_usize(n_logup);
                         cols.two_to_the_n_lift = F::from_usize(1 << record.n_lift);
                         cols.n = F::from_usize(n);
                         cols.n_at_least_n_lift = F::from_bool(n >= record.n_lift as usize);

--- a/crates/recursion/src/batch_constraint/mod.rs
+++ b/crates/recursion/src/batch_constraint/mod.rs
@@ -47,10 +47,11 @@ use crate::{
     },
     bus::{
         AirPresenceBus, AirShapeBus, BatchConstraintModuleBus, ColumnClaimsBus,
-        ConstraintSumcheckRandomnessBus, ConstraintsFoldingInputBus, EqNegBaseRandBus,
-        EqNegResultBus, EqNsNLogupMaxBus, ExpressionClaimNMaxBus, FractionFolderInputBus,
-        HyperdimBus, InteractionsFoldingInputBus, NLiftBus, PublicValuesBus, SelHypercubeBus,
-        SelUniBus, StackingModuleBus, TranscriptBus, XiRandomnessBus,
+        ConstraintSumcheckRandomnessBus, ConstraintsFoldingInputBus, Eq3bShapeBus,
+        EqNegBaseRandBus, EqNegResultBus, EqNsNLogupMaxBus, ExpressionClaimNMaxBus,
+        FractionFolderInputBus, HyperdimBus, InteractionsFoldingInputBus, NLiftBus,
+        PublicValuesBus, SelHypercubeBus, SelUniBus, StackingModuleBus, TranscriptBus,
+        XiRandomnessBus,
     },
     primitives::{bus::PowerCheckerBus, pow::PowerCheckerCpuTraceGenerator},
     system::{
@@ -99,6 +100,7 @@ pub struct BatchConstraintModule {
     expression_claim_n_max_bus: ExpressionClaimNMaxBus,
     n_lift_bus: NLiftBus,
     eq_n_logup_n_max_bus: EqNsNLogupMaxBus,
+    eq_3b_shape_bus: Eq3bShapeBus,
 
     zero_n_bus: EqZeroNBus,
     eq_sharp_uni_bus: EqSharpUniBus,
@@ -149,6 +151,7 @@ impl BatchConstraintModule {
             expression_claim_n_max_bus: bus_inventory.expression_claim_n_max_bus,
             n_lift_bus: bus_inventory.n_lift_bus,
             eq_n_logup_n_max_bus: bus_inventory.eq_n_logup_n_max_bus,
+            eq_3b_shape_bus: bus_inventory.eq_3b_shape_bus,
             batch_constraint_conductor_bus: BatchConstraintConductorBus::new(b.new_bus_idx()),
             univariate_sumcheck_input_bus: UnivariateSumcheckInputBus::new(b.new_bus_idx()),
             sumcheck_bus: SumcheckClaimBus::new(b.new_bus_idx()),
@@ -359,6 +362,7 @@ impl AirModule for BatchConstraintModule {
         };
         let eq_3b_air = Eq3bAir {
             eq_3b_bus: self.eq_3b_bus,
+            eq_3b_shape_bus: self.eq_3b_shape_bus,
             batch_constraint_conductor_bus: self.batch_constraint_conductor_bus,
             l_skip,
         };

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -660,6 +660,16 @@ define_typed_per_proof_lookup_bus!(EqNsNLogupMaxBus, EqNsNLogupMaxMessage);
 
 #[repr(C)]
 #[derive(AlignedBorrow, Debug, Clone)]
+pub struct Eq3bShapeMessage<T> {
+    pub sort_idx: T,
+    pub n_lift: T,
+    pub n_logup: T,
+}
+
+define_typed_per_proof_lookup_bus!(Eq3bShapeBus, Eq3bShapeMessage);
+
+#[repr(C)]
+#[derive(AlignedBorrow, Debug, Clone)]
 pub struct ConstraintsFoldingInputMessage<T> {
     pub tidx: T,
 }

--- a/crates/recursion/src/proof_shape/mod.rs
+++ b/crates/recursion/src/proof_shape/mod.rs
@@ -254,6 +254,7 @@ impl AirModule for ProofShapeModule {
             transcript_bus: self.bus_inventory.transcript_bus,
             n_lift_bus: self.bus_inventory.n_lift_bus,
             eq_n_logup_n_max_bus: self.bus_inventory.eq_n_logup_n_max_bus,
+            eq_3b_shape_bus: self.bus_inventory.eq_3b_shape_bus,
             cached_commit_bus: self.bus_inventory.cached_commit_bus,
             pre_hash_bus: self.bus_inventory.pre_hash_bus,
             continuations_enabled: self.continuations_enabled,

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -876,7 +876,7 @@ where
             .when(not::<AB::Expr>(limb_times_inv.clone()))
             .assert_zero(n_logup);
         when_last.assert_eq(limb_to_range_check, expected_limb_to_range_check);
-        when_last.assert_eq(local.starting_cidx, n_logup.clone());
+        when_last.assert_eq(local.starting_cidx, n_logup);
         msb_limb_zero_bits -= n_logup + prefix * AB::F::from_usize(self.l_skip);
 
         self.pow_bus.lookup_key(
@@ -948,7 +948,7 @@ where
             builder,
             local.proof_idx,
             EqNsNLogupMaxMessage {
-                n_logup: n_logup.clone(),
+                n_logup,
                 n_max: local.n_max,
             },
             local.is_last,

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -876,7 +876,6 @@ where
             .when(not::<AB::Expr>(limb_times_inv.clone()))
             .assert_zero(n_logup);
         when_last.assert_eq(limb_to_range_check, expected_limb_to_range_check);
-        when_last.assert_eq(local.starting_cidx, n_logup);
         msb_limb_zero_bits -= n_logup + prefix * AB::F::from_usize(self.l_skip);
 
         self.pow_bus.lookup_key(
@@ -965,13 +964,14 @@ where
         );
 
         // Send n_lift to constraint folding air
+        let n_lift = (local.log_height - AB::Expr::from_usize(self.l_skip))
+            * (AB::Expr::ONE - local.n_sign_bit);
         self.n_lift_bus.send(
             builder,
             local.proof_idx,
             NLiftMessage {
                 air_idx,
-                n_lift: (local.log_height - AB::Expr::from_usize(self.l_skip))
-                    * (AB::Expr::ONE - local.n_sign_bit),
+                n_lift: n_lift.clone(),
             },
             local.is_present,
         );
@@ -980,8 +980,7 @@ where
             local.proof_idx,
             Eq3bShapeMessage {
                 sort_idx: local.sorted_idx.into(),
-                n_lift: (local.log_height - AB::Expr::from_usize(self.l_skip))
-                    * (AB::Expr::ONE - local.n_sign_bit),
+                n_lift,
                 n_logup: local.n_logup.into(),
             },
             local.is_present,

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -19,10 +19,11 @@ use crate::{
     bus::{
         AirPresenceBus, AirPresenceBusMessage, AirShapeBus, AirShapeBusMessage, AirShapeProperty,
         CachedCommitBus, CachedCommitBusMessage, CommitmentsBus, CommitmentsBusMessage,
-        EqNsNLogupMaxBus, EqNsNLogupMaxMessage, ExpressionClaimNMaxBus, ExpressionClaimNMaxMessage,
-        FractionFolderInputBus, FractionFolderInputMessage, GkrModuleBus, GkrModuleMessage,
-        HyperdimBus, HyperdimBusMessage, LiftedHeightsBus, LiftedHeightsBusMessage, NLiftBus,
-        NLiftMessage, PreHashBus, PreHashMessage, TranscriptBus, TranscriptBusMessage,
+        Eq3bShapeBus, Eq3bShapeMessage, EqNsNLogupMaxBus, EqNsNLogupMaxMessage,
+        ExpressionClaimNMaxBus, ExpressionClaimNMaxMessage, FractionFolderInputBus,
+        FractionFolderInputMessage, GkrModuleBus, GkrModuleMessage, HyperdimBus,
+        HyperdimBusMessage, LiftedHeightsBus, LiftedHeightsBusMessage, NLiftBus, NLiftMessage,
+        PreHashBus, PreHashMessage, TranscriptBus, TranscriptBusMessage,
     },
     primitives::bus::{
         PowerCheckerBus, PowerCheckerBusMessage, RangeCheckerBus, RangeCheckerBusMessage,
@@ -90,6 +91,7 @@ pub struct ProofShapeCols<F, const NUM_LIMBS: usize> {
     /// Computed as max(0, n0, n1, ...) where ni = log_height_i - l_skip for each present trace.
     pub n_max: F,
     pub is_n_max_greater: F,
+    pub n_logup: F,
 
     pub num_air_id_lookups: F,
 }
@@ -163,6 +165,7 @@ pub struct ProofShapeAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub transcript_bus: TranscriptBus,
     pub n_lift_bus: NLiftBus,
     pub eq_n_logup_n_max_bus: EqNsNLogupMaxBus,
+    pub eq_3b_shape_bus: Eq3bShapeBus,
 
     // For continuations
     pub cached_commit_bus: CachedCommitBus,
@@ -236,6 +239,9 @@ where
 
         builder.assert_bool(local.is_present);
         builder.when(local.is_present).assert_one(local.is_valid);
+        builder
+            .when(local.is_valid)
+            .assert_eq(local.n_logup, next.n_logup);
 
         builder
             .when(local.is_first)
@@ -844,7 +850,7 @@ where
         let limb_to_range_check_inv = local.n_sign_bit;
         let limb_times_inv = limb_to_range_check * limb_to_range_check_inv;
         let msb_limb_zero_bits_exp = local.log_height;
-        let n_logup = local.starting_cidx;
+        let n_logup = local.n_logup;
 
         let mut prefix = AB::Expr::ZERO;
         let mut expected_limb_to_range_check = AB::Expr::ZERO;
@@ -870,6 +876,7 @@ where
             .when(not::<AB::Expr>(limb_times_inv.clone()))
             .assert_zero(n_logup);
         when_last.assert_eq(limb_to_range_check, expected_limb_to_range_check);
+        when_last.assert_eq(local.starting_cidx, n_logup.clone());
         msb_limb_zero_bits -= n_logup + prefix * AB::F::from_usize(self.l_skip);
 
         self.pow_bus.lookup_key(
@@ -941,7 +948,7 @@ where
             builder,
             local.proof_idx,
             EqNsNLogupMaxMessage {
-                n_logup,
+                n_logup: n_logup.clone(),
                 n_max: local.n_max,
             },
             local.is_last,
@@ -965,6 +972,17 @@ where
                 air_idx,
                 n_lift: (local.log_height - AB::Expr::from_usize(self.l_skip))
                     * (AB::Expr::ONE - local.n_sign_bit),
+            },
+            local.is_present,
+        );
+        self.eq_3b_shape_bus.add_key_with_lookups(
+            builder,
+            local.proof_idx,
+            Eq3bShapeMessage {
+                sort_idx: local.sorted_idx.into(),
+                n_lift: (local.log_height - AB::Expr::from_usize(self.l_skip))
+                    * (AB::Expr::ONE - local.n_sign_bit),
+                n_logup: local.n_logup.into(),
             },
             local.is_present,
         );

--- a/crates/recursion/src/proof_shape/proof_shape/trace.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/trace.rs
@@ -114,6 +114,7 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 cols.starting_cidx = F::from_usize(cidx);
                 let has_preprocessed = child_vk.inner.per_air[*idx].preprocessed_data.is_some();
                 cidx += has_preprocessed as usize;
+                cols.n_logup = F::from_usize(preflight.proof_shape.n_logup);
 
                 cols.is_present = F::ONE;
                 cols.height = F::from_usize(height);
@@ -217,6 +218,7 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
 
                 cols.starting_tidx = F::from_usize(preflight.proof_shape.starting_tidx[idx]);
                 cols.starting_cidx = F::from_usize(cidx);
+                cols.n_logup = F::from_usize(preflight.proof_shape.n_logup);
 
                 cols.total_interactions_limbs = total_interactions_f;
                 cols.n_max = F::from_usize(preflight.proof_shape.n_max);
@@ -320,6 +322,7 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 cols.total_interactions_limbs = total_interactions_f;
                 cols.n_max = F::from_usize(preflight.proof_shape.n_max);
                 cols.is_n_max_greater = F::from_bool(preflight.proof_shape.n_max > n_logup);
+                cols.n_logup = F::from_usize(n_logup);
 
                 // n_logup
                 cols.starting_cidx = F::from_usize(n_logup);

--- a/crates/recursion/src/proof_shape/proof_shape/trace.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/trace.rs
@@ -324,9 +324,6 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 cols.is_n_max_greater = F::from_bool(preflight.proof_shape.n_max > n_logup);
                 cols.n_logup = F::from_usize(n_logup);
 
-                // n_logup
-                cols.starting_cidx = F::from_usize(n_logup);
-
                 let shifted_msb_limb =
                     msb_limb.as_canonical_u32() as usize * (1 << msb_limb_zero_bits);
                 range_checker.add_count(shifted_msb_limb);

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     bus::{
         AirPresenceBus, AirShapeBus, BatchConstraintModuleBus, CachedCommitBus, ColumnClaimsBus,
         CommitmentsBus, ConstraintSumcheckRandomnessBus, ConstraintsFoldingInputBus, DagCommitBus,
-        EqNegBaseRandBus, EqNegResultBus, EqNsNLogupMaxBus, ExpressionClaimNMaxBus,
+        Eq3bShapeBus, EqNegBaseRandBus, EqNegResultBus, EqNsNLogupMaxBus, ExpressionClaimNMaxBus,
         FinalTranscriptStateBus, FractionFolderInputBus, GkrModuleBus, HyperdimBus,
         InteractionsFoldingInputBus, LiftedHeightsBus, MerkleVerifyBus, NLiftBus,
         Poseidon2CompressBus, Poseidon2PermuteBus, PreHashBus, PublicValuesBus, SelUniBus,
@@ -230,6 +230,7 @@ pub struct BusInventory {
     pub fraction_folder_input_bus: FractionFolderInputBus,
     pub n_lift_bus: NLiftBus,
     pub eq_n_logup_n_max_bus: EqNsNLogupMaxBus,
+    pub eq_3b_shape_bus: Eq3bShapeBus,
 
     // Randomness buses
     pub xi_randomness_bus: XiRandomnessBus,
@@ -366,6 +367,7 @@ impl BusInventory {
             fraction_folder_input_bus: FractionFolderInputBus::new(b.new_bus_idx()),
             n_lift_bus: NLiftBus::new(b.new_bus_idx()),
             eq_n_logup_n_max_bus: EqNsNLogupMaxBus::new(b.new_bus_idx()),
+            eq_3b_shape_bus: Eq3bShapeBus::new(b.new_bus_idx()),
 
             // Randomness buses
             xi_randomness_bus: XiRandomnessBus::new(b.new_bus_idx()),


### PR DESCRIPTION
This resolves INT-6774.

Eq3bAir now maintains `n_logup` as well, constrains that it's constant across the AIR as well as `n_lift` and receives them one per AIR.