### PR TITLE
feat: change new SHA2 AIRs to have v2 max constraint degree <= 3

### DIFF
--- a/crates/circuits/sha2-air/src/air.rs
+++ b/crates/circuits/sha2-air/src/air.rs
@@ -255,10 +255,6 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherSubAir<C> {
             .assert_eq(local_row_idx.clone() + delta, next_row_idx.clone());
         builder.when_first_row().assert_zero(local_row_idx);
 
-        // Constrain the global block index starting with 1 so it is not the same as the padding
-        // rows.
-        // We set the global block index to 0 for padding rows
-
         // Global block index is 1 on first row
         builder
             .when_first_row()
@@ -273,15 +269,18 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherSubAir<C> {
         builder
             .when_transition()
             .when(*local_cols.flags.is_digest_row)
-            .when(*next_cols.flags.is_round_row)
             .assert_eq(
                 *local_cols.flags.global_block_idx + AB::Expr::ONE,
                 *next_cols.flags.global_block_idx,
             );
-        // Global block index is 0 on padding rows
+        // Global block index is constant on padding rows
         builder
+            .when_transition()
             .when(local_is_padding_row.clone())
-            .assert_zero(*local_cols.flags.global_block_idx);
+            .assert_eq(
+                *local_cols.flags.global_block_idx,
+                *next_cols.flags.global_block_idx,
+            );
 
         // Constrain that all the padding rows have the same work vars as the last block's digest
         // row. We constrain elsewhere that the last block's digest row is equal to the first
@@ -431,7 +430,7 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherSubAir<C> {
                 // check because the degree is already 3. So we must fill in `intermed_4` with dummy
                 // values on the first round row and the digest row (rows 0 and 16 for SHA-256) to
                 // ensure the constraint holds on these rows.
-                builder.when_transition().assert_eq(
+                builder.assert_eq(
                     next.schedule_helper.intermed_4[[i, j]],
                     w_idx_limb + sig_w_limb,
                 );
@@ -471,15 +470,12 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherSubAir<C> {
                 .collect::<Vec<_>>();
 
             // Constrain `W_{idx} = sig_1(W_{idx-2}) + W_{idx-7} + sig_0(W_{idx-15}) + W_{idx-16}`
-            // We would like to constrain this only on rows 4..C::ROUND_ROWS, but we can't do a
-            // conditional check because the degree of sum is already 3 So we must fill
-            // in `intermed_12` with dummy values on rows 0..3 and C::ROUND_ROWS-1 and C::ROUND_ROWS
-            // to ensure the constraint holds on rows 0..4 and C::ROUND_ROWS. Note that
-            // the dummy value goes in the previous row to make the current row's constraint hold.
+            // We can't do a conditional check because the degree of the sum is already 3.
+            // Instead, we fill in dummy values on non-applicable rows:
+            //   - `intermed_12` with dummy values on rows 0..3, C::ROUND_ROWS-1, and C::ROUND_ROWS
+            //   - `carry_or_buffer` with dummy values on the first block's row 0 (wrap-around)
             constraint_word_addition::<_, C>(
-                // Note: here we can't do a conditional check because the degree of sum is already
-                // 3
-                &mut builder.when_transition(),
+                builder,
                 &[&small_sig1_field::<AB::Expr, C>(
                     w.row(i + 2).as_slice().unwrap(),
                 )],

--- a/crates/circuits/sha2-air/src/columns.rs
+++ b/crates/circuits/sha2-air/src/columns.rs
@@ -143,7 +143,8 @@ pub struct Sha2FlagsCols<T, const ROW_VAR_CNT: usize> {
     /// We will encode the row index [0..C::ROWS_PER_BLOCK] using ROW_VAR_CNT cells
     pub row_idx: [T; ROW_VAR_CNT],
     /// The global index of the current block, starts at 1 for the first block
-    /// and increments by 1 for each block. Set to 0 for padding rows.
+    /// and increments by 1 for each block. Padding rows use one more than the
+    /// last real block's index and remain constant across all padding rows.
     pub global_block_idx: T,
 }
 

--- a/crates/circuits/sha2-air/src/trace.rs
+++ b/crates/circuits/sha2-air/src/trace.rs
@@ -662,5 +662,4 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherFillerHelper<C> {
             }
         }
     }
-
 }

--- a/crates/circuits/sha2-air/src/trace.rs
+++ b/crates/circuits/sha2-air/src/trace.rs
@@ -429,6 +429,7 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherFillerHelper<C> {
         first_block_prev_hash: &[C::Word],
         carry_a: Option<&[F]>,
         carry_e: Option<&[F]>,
+        global_block_idx: u32,
     ) {
         debug_assert!(first_block_prev_hash.len() == C::HASH_WORDS);
         debug_assert!(carry_a.is_some() == carry_e.is_some());
@@ -443,6 +444,7 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherFillerHelper<C> {
             &mut cols.flags.row_idx,
             get_flag_pt_array(&self.row_idx_encoder, C::ROWS_PER_BLOCK),
         );
+        *cols.flags.global_block_idx = F::from_u32(global_block_idx);
 
         for i in 0..C::ROUNDS_PER_ROW {
             // The padding rows need to have the first block's prev_hash here, to satisfy the air
@@ -660,4 +662,5 @@ impl<C: Sha2BlockHasherSubairConfig> Sha2BlockHasherFillerHelper<C> {
             }
         }
     }
+
 }

--- a/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
+++ b/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
@@ -1031,8 +1031,8 @@ int launch_sha2_second_pass_dependencies(Fp *d_trace, size_t trace_height, size_
     auto [grid_size, block_size] = kernel_launch_params(total_blocks, 256);
     sha2_second_pass_dependencies<V>
         <<<grid_size, block_size>>>(d_trace, trace_height, total_blocks);
-    if (CHECK_KERNEL() != 0) {
-        return -1;
+    if (auto err = CHECK_KERNEL(); != 0) {
+        return err;
     }
 
     sha2_fill_wraparound<V><<<1, 1>>>(d_trace, trace_height);

--- a/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
+++ b/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
@@ -1031,8 +1031,8 @@ int launch_sha2_second_pass_dependencies(Fp *d_trace, size_t trace_height, size_
     auto [grid_size, block_size] = kernel_launch_params(total_blocks, 256);
     sha2_second_pass_dependencies<V>
         <<<grid_size, block_size>>>(d_trace, trace_height, total_blocks);
-    if (CHECK_KERNEL() != 0) {
-        return -1;
+    if (auto err = CHECK_KERNEL() != 0) {
+        return err;
     }
 
     sha2_fill_wraparound<V><<<1, 1>>>(d_trace, trace_height);

--- a/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
+++ b/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
@@ -880,7 +880,12 @@ __global__ void sha2_fill_first_dummy_row(Fp *trace, size_t trace_height, size_t
     }
 
     RowSlice row(trace + row_idx, trace_height);
-    row.fill_zero(0, Sha2Layout<V>::WIDTH);
+    uint32_t intermed_4_offset =
+        SHA2_COL_INDEX(V, Sha2BlockHasherRoundCols, inner.schedule_helper.intermed_4);
+    uint32_t intermed_8_offset =
+        SHA2_COL_INDEX(V, Sha2BlockHasherRoundCols, inner.schedule_helper.intermed_8);
+    row.fill_zero(0, intermed_4_offset);
+    row.fill_zero(intermed_8_offset, Sha2Layout<V>::WIDTH - intermed_8_offset);
     SHA2_WRITE_ROUND(V, row, request_id, Fp::zero());
     RowSlice inner_row = row.slice_from(Sha2Layout<V>::INNER_COLUMN_OFFSET);
 

--- a/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
+++ b/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
@@ -1031,8 +1031,8 @@ int launch_sha2_second_pass_dependencies(Fp *d_trace, size_t trace_height, size_
     auto [grid_size, block_size] = kernel_launch_params(total_blocks, 256);
     sha2_second_pass_dependencies<V>
         <<<grid_size, block_size>>>(d_trace, trace_height, total_blocks);
-    if (auto err = CHECK_KERNEL(); != 0) {
-        return err;
+    if (CHECK_KERNEL() != 0) {
+        return -1;
     }
 
     sha2_fill_wraparound<V><<<1, 1>>>(d_trace, trace_height);

--- a/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
+++ b/extensions/sha2/circuit/cuda/src/sha2_hasher.cu
@@ -450,11 +450,13 @@ template <typename V> struct Sha2TraceHelper {
         const typename V::Word *first_block_prev_hash,
         Fp *carry_a,
         Fp *carry_e,
+        uint32_t global_block_idx,
         size_t trace_height
     ) const {
         RowSlice row_idx_flags =
             inner_row.slice_from(SHA2_COL_INDEX(V, Sha2RoundCols, flags.row_idx));
         row_idx_encoder.write_flag_pt(row_idx_flags, V::ROWS_PER_BLOCK);
+        SHA2INNER_WRITE_ROUND(V, inner_row, flags.global_block_idx, Fp(global_block_idx));
 
         for (uint32_t i = 0; i < V::ROUNDS_PER_ROW; i++) {
             uint32_t a_idx = V::ROUNDS_PER_ROW - i - 1;
@@ -855,6 +857,8 @@ __global__ void sha2_first_pass_tracegen(
 template <typename V>
 __global__ void sha2_fill_first_dummy_row(Fp *trace, size_t trace_height, size_t rows_used) {
     uint32_t row_idx = rows_used;
+    uint32_t total_blocks = rows_used / V::ROWS_PER_BLOCK;
+    uint32_t padding_global_block_idx = total_blocks + 1;
 
     uint32_t digest_row = V::ROUND_ROWS;
     if (digest_row >= trace_height) {
@@ -876,17 +880,19 @@ __global__ void sha2_fill_first_dummy_row(Fp *trace, size_t trace_height, size_t
     }
 
     RowSlice row(trace + row_idx, trace_height);
-    uint32_t intermed_4_offset =
-        SHA2_COL_INDEX(V, Sha2BlockHasherRoundCols, inner.schedule_helper.intermed_4);
-    uint32_t intermed_8_offset =
-        SHA2_COL_INDEX(V, Sha2BlockHasherRoundCols, inner.schedule_helper.intermed_8);
-    row.fill_zero(0, intermed_4_offset);
-    row.fill_zero(intermed_8_offset, Sha2Layout<V>::WIDTH - intermed_8_offset);
+    row.fill_zero(0, Sha2Layout<V>::WIDTH);
     SHA2_WRITE_ROUND(V, row, request_id, Fp::zero());
     RowSlice inner_row = row.slice_from(Sha2Layout<V>::INNER_COLUMN_OFFSET);
 
     Sha2TraceHelper<V> helper;
-    helper.generate_default_row(inner_row, prev_hash, nullptr, nullptr, trace_height);
+    helper.generate_default_row(
+        inner_row,
+        prev_hash,
+        nullptr,
+        nullptr,
+        padding_global_block_idx,
+        trace_height
+    );
 
     helper.generate_carry_ae(inner_row, inner_row);
 }
@@ -911,6 +917,8 @@ __global__ void sha2_fill_invalid_rows(
 ) {
     uint32_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
     uint32_t first_dummy_row_idx = rows_used;
+    uint32_t total_blocks = rows_used / V::ROWS_PER_BLOCK;
+    uint32_t padding_global_block_idx = total_blocks + 1;
     // skip the first dummy row, since it is already filled
     uint32_t row_idx = first_dummy_row_idx + thread_idx + 1;
     if (row_idx >= trace_height) {
@@ -931,8 +939,29 @@ __global__ void sha2_fill_invalid_rows(
 
     Sha2TraceHelper<V> helper;
     helper.generate_default_row(
-        dst_inner, &d_prev_hashes[0], first_dummy_row_carry_a, first_dummy_row_carry_e, trace_height
+        dst_inner,
+        &d_prev_hashes[0],
+        first_dummy_row_carry_a,
+        first_dummy_row_carry_e,
+        padding_global_block_idx,
+        trace_height
     );
+}
+
+template <typename V>
+__global__ void sha2_fill_wraparound(Fp *trace, size_t trace_height) {
+    if (trace_height < 2) {
+        return;
+    }
+
+    Sha2TraceHelper<V> helper;
+    RowSlice first_row(trace, trace_height);
+    RowSlice first_inner = first_row.slice_from(Sha2Layout<V>::INNER_COLUMN_OFFSET);
+    RowSlice last_row(trace + (trace_height - 1), trace_height);
+    RowSlice last_inner = last_row.slice_from(Sha2Layout<V>::INNER_COLUMN_OFFSET);
+
+    helper.generate_intermed_4(last_inner, first_inner);
+    helper.generate_intermed_12(last_inner, first_inner);
 }
 
 // ===== HOST LAUNCHER FUNCTIONS =====
@@ -997,6 +1026,11 @@ int launch_sha2_second_pass_dependencies(Fp *d_trace, size_t trace_height, size_
     auto [grid_size, block_size] = kernel_launch_params(total_blocks, 256);
     sha2_second_pass_dependencies<V>
         <<<grid_size, block_size>>>(d_trace, trace_height, total_blocks);
+    if (CHECK_KERNEL() != 0) {
+        return -1;
+    }
+
+    sha2_fill_wraparound<V><<<1, 1>>>(d_trace, trace_height);
     return CHECK_KERNEL();
 }
 

--- a/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/trace.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/trace.rs
@@ -133,12 +133,15 @@ where
         // we need to do this first, so we can compute the carries that make the
         // constraint_word_addition constraints hold on dummy rows (or more precisely, on rows such
         // that the next row is a dummy row).
+        let num_blocks = rows_used / C::ROWS_PER_BLOCK;
         let first_dummy_row_cols_const = self.fill_first_dummy_row(
             &mut trace[rows_used * C::BLOCK_HASHER_WIDTH..(rows_used + 1) * C::BLOCK_HASHER_WIDTH],
             &prev_hashes[0],
+            num_blocks,
         );
 
         // fill in the rest of the dummy rows
+        let padding_global_block_idx = (num_blocks + 1) as u32;
         trace[(rows_used + 1) * C::BLOCK_HASHER_WIDTH..]
             .par_chunks_exact_mut(C::BLOCK_HASHER_WIDTH)
             .for_each(|row| {
@@ -162,6 +165,7 @@ where
                             .as_slice()
                             .unwrap(),
                     ),
+                    padding_global_block_idx,
                 );
             });
 
@@ -174,12 +178,51 @@ where
                 self.inner
                     .generate_missing_cells(chunk, C::BLOCK_HASHER_WIDTH, INNER_OFFSET);
             });
+
+        self.fill_wraparound(trace);
+    }
+
+    /// Fill in dummy values for the wrap-around (last row → first row) so that
+    /// unconditional constraints hold:
+    /// - `intermed_4` on row 0 for the message schedule sigma constraint
+    /// - `intermed_12` on the last row for the message schedule addition constraint
+    fn fill_wraparound(&self, trace: &mut [F]) {
+        let height = trace.len() / C::BLOCK_HASHER_WIDTH;
+        let last_row_start = (height - 1) * C::BLOCK_HASHER_WIDTH;
+
+        // Fill intermed_4 on the first row (needs first_row mut, last_row immut)
+        {
+            let (first_row, rest) = trace.split_at_mut(C::BLOCK_HASHER_WIDTH);
+            let last_row = &rest[(height - 2) * C::BLOCK_HASHER_WIDTH..];
+            let local = Sha2RoundColsRef::from::<C>(
+                &last_row[INNER_OFFSET..INNER_OFFSET + C::SUBAIR_ROUND_WIDTH],
+            );
+            let mut next = Sha2RoundColsRefMut::from::<C>(
+                &mut first_row[INNER_OFFSET..INNER_OFFSET + C::SUBAIR_ROUND_WIDTH],
+            );
+            Sha2BlockHasherFillerHelper::<C>::generate_intermed_4(local, &mut next);
+        }
+
+        // Fill intermed_12 on the last row (needs last_row mut, first_row immut)
+        {
+            let (first_row, rest) = trace.split_at_mut(C::BLOCK_HASHER_WIDTH);
+            let next = Sha2RoundColsRef::from::<C>(
+                &first_row[INNER_OFFSET..INNER_OFFSET + C::SUBAIR_ROUND_WIDTH],
+            );
+            let last_row =
+                &mut rest[last_row_start - C::BLOCK_HASHER_WIDTH..last_row_start];
+            let mut local = Sha2RoundColsRefMut::from::<C>(
+                &mut last_row[INNER_OFFSET..INNER_OFFSET + C::SUBAIR_ROUND_WIDTH],
+            );
+            Sha2BlockHasherFillerHelper::<C>::generate_intermed_12(&mut local, next);
+        }
     }
 
     fn fill_first_dummy_row(
         &self,
         first_dummy_row_mut: &mut [F],
         first_block_prev_hash: &[C::Word],
+        num_blocks: usize,
     ) -> Sha2RoundColsRef<'_, F> {
         let first_dummy_row_const =
             unsafe { slice::from_raw_parts(first_dummy_row_mut.as_ptr(), C::BLOCK_HASHER_WIDTH) };
@@ -195,12 +238,13 @@ where
         );
 
         // first, fill in everything but the carries into the first dummy row (i.e. fill in the
-        // work vars and row_idx)
+        // work vars, row_idx, and global_block_idx)
         self.inner.generate_default_row(
             &mut first_dummy_row_cols_mut,
             first_block_prev_hash,
             None,
             None,
+            (num_blocks + 1) as u32,
         );
 
         // Now, this will fill in the first dummy row with the correct carries.

--- a/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/trace.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/trace.rs
@@ -209,8 +209,7 @@ where
             let next = Sha2RoundColsRef::from::<C>(
                 &first_row[INNER_OFFSET..INNER_OFFSET + C::SUBAIR_ROUND_WIDTH],
             );
-            let last_row =
-                &mut rest[last_row_start - C::BLOCK_HASHER_WIDTH..last_row_start];
+            let last_row = &mut rest[last_row_start - C::BLOCK_HASHER_WIDTH..last_row_start];
             let mut local = Sha2RoundColsRefMut::from::<C>(
                 &mut last_row[INNER_OFFSET..INNER_OFFSET + C::SUBAIR_ROUND_WIDTH],
             );

--- a/extensions/sha2/circuit/src/sha2_chips/tests.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/tests.rs
@@ -25,6 +25,7 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     utils::disable_debug_builder,
+    SystemParams,
 };
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
@@ -47,6 +48,12 @@ const SHA2_BUS_IDX: BusIndex = 28;
 const SUBAIR_BUS_IDX: BusIndex = 29;
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 4096;
+
+fn sha2_test_params() -> SystemParams {
+    let mut params = SystemParams::new_for_testing(21);
+    params.max_constraint_degree = 3;
+    params
+}
 type Harness<RA, C> = TestChipHarness<F, Sha2VmExecutor<C>, Sha2MainAir<C>, Sha2MainChip<F, C>, RA>;
 
 fn create_harness_fields<C: Sha2Config>(
@@ -200,7 +207,9 @@ fn rand_sha2_single_block_test<C: Sha2Config + 'static>() {
         .load_periphery(block_hasher)
         .load_periphery(bitwise)
         .finalize();
-    tester.simple_test().expect("Verification failed");
+    tester
+        .simple_test_with_params(sha2_test_params())
+        .expect("Verification failed");
 }
 
 #[test]
@@ -319,7 +328,9 @@ fn rand_sha2_multi_block_test<C: Sha2Config + 'static>() {
         .load_periphery(block_hasher)
         .load_periphery(bitwise)
         .finalize();
-    tester.simple_test().expect("Verification failed");
+    tester
+        .simple_test_with_params(sha2_test_params())
+        .expect("Verification failed");
 }
 
 #[test]
@@ -394,7 +405,9 @@ fn sha2_edge_test_lengths<C: Sha2Config + 'static>() {
         .load_periphery(block_hasher)
         .load_periphery(bitwise)
         .finalize();
-    tester.simple_test().expect("Verification failed");
+    tester
+        .simple_test_with_params(sha2_test_params())
+        .expect("Verification failed");
 }
 
 #[test]
@@ -542,7 +555,7 @@ fn negative_sha2_test_bad_final_hash<C: Sha2Config + 'static>() {
         .load_periphery(bitwise)
         .finalize();
     tester
-        .simple_test()
+        .simple_test_with_params(sha2_test_params())
         .expect_err("Expected verification to fail, but it passed");
 }
 
@@ -682,7 +695,7 @@ fn test_cuda_rand_sha2_multi_block<C: Sha2Config + 'static>() {
         (),
     );
     tester = tester.load_periphery(harness.bitwise_air, harness.bitwise_gpu);
-    tester.finalize().simple_test().unwrap();
+    tester.finalize().simple_test_with_params(sha2_test_params()).unwrap();
 }
 
 #[cfg(feature = "cuda")]
@@ -743,7 +756,7 @@ fn test_cuda_sha2_known_vectors<C: Sha2Config + 'static>(test_vectors: &[(&str, 
         (),
     );
     tester = tester.load_periphery(harness.bitwise_air, harness.bitwise_gpu);
-    tester.finalize().simple_test().unwrap();
+    tester.finalize().simple_test_with_params(sha2_test_params()).unwrap();
 }
 
 #[cfg(feature = "cuda")]
@@ -839,7 +852,7 @@ fn cuda_sha2_edge_test_lengths<C: Sha2Config + 'static>() {
         (),
     );
     tester = tester.load_periphery(harness.bitwise_air, harness.bitwise_gpu);
-    tester.finalize().simple_test().unwrap();
+    tester.finalize().simple_test_with_params(sha2_test_params()).unwrap();
 }
 
 #[cfg(feature = "cuda")]

--- a/extensions/sha2/circuit/src/sha2_chips/tests.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/tests.rs
@@ -25,7 +25,6 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     utils::disable_debug_builder,
-    SystemParams,
 };
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
@@ -48,12 +47,6 @@ const SHA2_BUS_IDX: BusIndex = 28;
 const SUBAIR_BUS_IDX: BusIndex = 29;
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 4096;
-
-fn sha2_test_params() -> SystemParams {
-    let mut params = SystemParams::new_for_testing(21);
-    params.max_constraint_degree = 3;
-    params
-}
 type Harness<RA, C> = TestChipHarness<F, Sha2VmExecutor<C>, Sha2MainAir<C>, Sha2MainChip<F, C>, RA>;
 
 fn create_harness_fields<C: Sha2Config>(
@@ -207,9 +200,7 @@ fn rand_sha2_single_block_test<C: Sha2Config + 'static>() {
         .load_periphery(block_hasher)
         .load_periphery(bitwise)
         .finalize();
-    tester
-        .simple_test_with_params(sha2_test_params())
-        .expect("Verification failed");
+    tester.simple_test().expect("Verification failed");
 }
 
 #[test]
@@ -328,9 +319,7 @@ fn rand_sha2_multi_block_test<C: Sha2Config + 'static>() {
         .load_periphery(block_hasher)
         .load_periphery(bitwise)
         .finalize();
-    tester
-        .simple_test_with_params(sha2_test_params())
-        .expect("Verification failed");
+    tester.simple_test().expect("Verification failed");
 }
 
 #[test]
@@ -405,9 +394,7 @@ fn sha2_edge_test_lengths<C: Sha2Config + 'static>() {
         .load_periphery(block_hasher)
         .load_periphery(bitwise)
         .finalize();
-    tester
-        .simple_test_with_params(sha2_test_params())
-        .expect("Verification failed");
+    tester.simple_test().expect("Verification failed");
 }
 
 #[test]
@@ -555,7 +542,7 @@ fn negative_sha2_test_bad_final_hash<C: Sha2Config + 'static>() {
         .load_periphery(bitwise)
         .finalize();
     tester
-        .simple_test_with_params(sha2_test_params())
+        .simple_test()
         .expect_err("Expected verification to fail, but it passed");
 }
 
@@ -695,7 +682,7 @@ fn test_cuda_rand_sha2_multi_block<C: Sha2Config + 'static>() {
         (),
     );
     tester = tester.load_periphery(harness.bitwise_air, harness.bitwise_gpu);
-    tester.finalize().simple_test_with_params(sha2_test_params()).unwrap();
+    tester.finalize().simple_test().unwrap();
 }
 
 #[cfg(feature = "cuda")]
@@ -756,7 +743,7 @@ fn test_cuda_sha2_known_vectors<C: Sha2Config + 'static>(test_vectors: &[(&str, 
         (),
     );
     tester = tester.load_periphery(harness.bitwise_air, harness.bitwise_gpu);
-    tester.finalize().simple_test_with_params(sha2_test_params()).unwrap();
+    tester.finalize().simple_test().unwrap();
 }
 
 #[cfg(feature = "cuda")]
@@ -852,7 +839,7 @@ fn cuda_sha2_edge_test_lengths<C: Sha2Config + 'static>() {
         (),
     );
     tester = tester.load_periphery(harness.bitwise_air, harness.bitwise_gpu);
-    tester.finalize().simple_test_with_params(sha2_test_params()).unwrap();
+    tester.finalize().simple_test().unwrap();
 }
 
 #[cfg(feature = "cuda")]


### PR DESCRIPTION
Resolves INT-6189.

### Summary

Reduces the maximum v2 constraint degree of the SHA2 block hasher AIR from 4 to 3 by converting two degree-4 `when_transition()` constraints into unconditional (degree-3) constraints, and fixing the `global_block_idx` padding row constraint to be wrap-around safe.

### AIR Changes

**1. Message schedule `intermed_4` constraint (line ~433):** Changed from `builder.when_transition().assert_eq(...)` to `builder.assert_eq(...)`. This removes one degree of multiplication (the transition selector), keeping the constraint at degree 3. The trace now fills dummy `intermed_4` values on the wrap-around edge (last row → first row) to satisfy the unconditional constraint.

**2. Message schedule addition (`intermed_12`) constraint (line ~477):** Similarly changed `constraint_word_addition` from being called on `builder.when_transition()` to being called on `builder` directly. Dummy `intermed_12` and `carry_or_buffer` values are filled on wrap-around rows to compensate.

**3. Global block index on padding rows (line ~276-283):** Previously constrained `global_block_idx == 0` on padding rows. Now constrains `global_block_idx` to be constant across padding rows (via a transition constraint). This removes the `when(is_digest_row) * when(is_round_row)` degree-4 interaction on the block boundary transition, since padding rows no longer need a different value from the last real block.

**4. Global block index increment (line ~269-275):** Removed the extra `.when(*next_cols.flags.is_round_row)` condition from the block-boundary increment constraint, reducing its degree by 1. The padding row constancy constraint now handles the case where the next row after a digest row is a padding row (rather than needing to exclude it).

