### PR TITLE
fix(v2-rc.1): simplify memory subsystem after access adapter removal

### DIFF
--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -110,14 +110,9 @@ where
 
 pub const OPENVM_DEFAULT_INIT_FILE_BASENAME: &str = "openvm_init";
 pub const OPENVM_DEFAULT_INIT_FILE_NAME: &str = "openvm_init.rs";
-/// The minimum block size is 4, but RISC-V `lb` only requires alignment of 1 and `lh` only requires
-/// alignment of 2 because the instructions are implemented by doing an access of block size 4.
-const DEFAULT_U8_BLOCK_SIZE: usize = 4;
-const DEFAULT_NATIVE_BLOCK_SIZE: usize = 1;
-
-/// The constant block size used for all memory accesses.
-/// This is also the block size used by the Boundary AIR for memory bus interactions.
-pub const CONST_BLOCK_SIZE: usize = DEFAULT_U8_BLOCK_SIZE;
+/// Default block size for memory bus interactions. RISC-V byte/halfword loads (`lb`/`lh`) need
+/// fewer bytes, but the adapter always reads a full 4-byte block from memory.
+pub const DEFAULT_BLOCK_SIZE: usize = 4;
 
 /// Trait for generating a init.rs file that contains a call to moduli_init!,
 /// complex_init!, sw_init! with the supported moduli and curves.
@@ -193,25 +188,22 @@ impl Default for MemoryConfig {
 
 impl MemoryConfig {
     pub fn empty_address_space_configs(num_addr_spaces: usize) -> Vec<AddressSpaceHostConfig> {
-        // All except address spaces 0..4 default to native 32-bit field.
         // By default only address spaces 1..=4 have non-empty cell counts.
-        let mut addr_spaces = vec![
-            AddressSpaceHostConfig::new(
-                0,
-                DEFAULT_NATIVE_BLOCK_SIZE,
-                MemoryCellType::native32()
-            );
-            num_addr_spaces
-        ];
+        // Unassigned address spaces default to block_size=DEFAULT_BLOCK_SIZE with native32 cells.
+        let mut addr_spaces =
+            vec![
+                AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::native32());
+                num_addr_spaces
+            ];
         addr_spaces[RV32_IMM_AS as usize] = AddressSpaceHostConfig::new(0, 1, MemoryCellType::Null);
         addr_spaces[RV32_REGISTER_AS as usize] =
-            AddressSpaceHostConfig::new(0, DEFAULT_U8_BLOCK_SIZE, MemoryCellType::U8);
+            AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::U8);
 
         addr_spaces[RV32_MEMORY_AS as usize] =
-            AddressSpaceHostConfig::new(0, DEFAULT_U8_BLOCK_SIZE, MemoryCellType::U8);
+            AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::U8);
 
         addr_spaces[PUBLIC_VALUES_AS as usize] =
-            AddressSpaceHostConfig::new(0, DEFAULT_U8_BLOCK_SIZE, MemoryCellType::U8);
+            AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::U8);
 
         addr_spaces
     }
@@ -224,10 +216,10 @@ impl MemoryConfig {
         Self::new(3, addr_spaces, POINTER_MAX_BITS, 29, 17)
     }
 
-    pub fn min_block_size_bits(&self) -> Vec<u8> {
+    pub fn block_size_bits(&self) -> Vec<u8> {
         self.addr_spaces
             .iter()
-            .map(|addr_sp| log2_strict_usize(addr_sp.min_block_size) as u8)
+            .map(|addr_sp| log2_strict_usize(addr_sp.block_size) as u8)
             .collect()
     }
 }
@@ -329,10 +321,6 @@ impl SystemConfig {
     pub fn num_airs(&self) -> usize {
         self.memory_boundary_air_id() + num_memory_airs()
     }
-
-    pub fn initial_block_size(&self) -> usize {
-        CONST_BLOCK_SIZE
-    }
 }
 
 impl Default for SystemConfig {
@@ -361,11 +349,11 @@ pub struct AddressSpaceHostConfig {
     /// The number of memory cells in each address space, where a memory cell refers to a single
     /// addressable unit of memory as defined by the ISA.
     pub num_cells: usize,
-    /// Minimum block size for memory accesses supported. This is a property of the address space
-    /// that is determined by the ISA.
+    /// Block size for memory accesses. Each address space has a fixed block size that determines
+    /// the granularity of memory bus interactions.
     ///
     /// **Note**: Block size is in terms of memory cells.
-    pub min_block_size: usize,
+    pub block_size: usize,
     pub layout: MemoryCellType,
 }
 

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     arch::{
         execution_mode::{ExecutionCtxTrait, MeteredExecutionCtxTrait},
-        SystemConfig, VmExecState,
+        SystemConfig, VmExecState, BOUNDARY_AIR_ID, MERKLE_AIR_ID,
     },
     system::memory::online::GuestMemory,
 };
@@ -57,15 +57,14 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
         // Assert that the indices are correct
         debug_assert!(
-            segmentation_ctx.air_names[memory_ctx.boundary_idx].contains("Boundary"),
+            segmentation_ctx.air_names[BOUNDARY_AIR_ID].contains("Boundary"),
             "air_name={}",
-            segmentation_ctx.air_names[memory_ctx.boundary_idx]
+            segmentation_ctx.air_names[BOUNDARY_AIR_ID]
         );
-        let merkle_tree_index = memory_ctx.merkle_tree_index;
         debug_assert!(
-            segmentation_ctx.air_names[merkle_tree_index].contains("Merkle"),
+            segmentation_ctx.air_names[MERKLE_AIR_ID].contains("Merkle"),
             "air_name={}",
-            segmentation_ctx.air_names[merkle_tree_index]
+            segmentation_ctx.air_names[MERKLE_AIR_ID]
         );
         let mut ctx = Self {
             trace_heights,

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -1,7 +1,13 @@
 use abi_stable::std_types::RVec;
 use openvm_instructions::riscv::{RV32_NUM_REGISTERS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS};
 
-use crate::{arch::SystemConfig, system::memory::dimensions::MemoryDimensions};
+use crate::{
+    arch::{SystemConfig, BOUNDARY_AIR_ID, DEFAULT_BLOCK_SIZE, MERKLE_AIR_ID},
+    system::memory::dimensions::MemoryDimensions,
+};
+
+const CHUNK: u32 = DEFAULT_BLOCK_SIZE as u32;
+const CHUNK_BITS: u32 = CHUNK.ilog2();
 
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
@@ -103,10 +109,6 @@ impl BitSet {
 #[derive(Clone, Debug)]
 pub struct MemoryCtx<const PAGE_BITS: usize> {
     memory_dimensions: MemoryDimensions,
-    pub boundary_idx: usize,
-    pub merkle_tree_index: usize,
-    chunk: u32,
-    chunk_bits: u32,
     pub page_indices: BitSet,
     pub addr_space_access_count: RVec<u32>,
     pub page_indices_since_checkpoint: Box<[u32]>,
@@ -115,9 +117,6 @@ pub struct MemoryCtx<const PAGE_BITS: usize> {
 
 impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
     pub fn new(config: &SystemConfig, segment_check_insns: u64) -> Self {
-        let chunk = config.initial_block_size() as u32;
-        let chunk_bits = chunk.ilog2();
-
         let memory_dimensions = config.memory_config.memory_dimensions();
         let merkle_height = memory_dimensions.overall_height();
 
@@ -127,10 +126,6 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
             Self::calculate_checkpoint_capacity(segment_check_insns);
 
         Self {
-            boundary_idx: config.memory_boundary_air_id(),
-            merkle_tree_index: config.memory_merkle_air_id(),
-            chunk,
-            chunk_bits,
             memory_dimensions,
             page_indices: BitSet::new(bitset_size),
             addr_space_access_count: vec![0; addr_space_size].into(),
@@ -166,15 +161,11 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
     ) {
         debug_assert!((address_space as usize) < self.addr_space_access_count.len());
 
-        let num_blocks = (size + self.chunk - 1) >> self.chunk_bits;
-        let start_chunk_id = ptr >> self.chunk_bits;
-        let start_block_id = if self.chunk == 1 {
-            start_chunk_id
-        } else {
-            self.memory_dimensions
-                .label_to_index((address_space, start_chunk_id)) as u32
-        };
-        // Because `self.chunk == 1 << self.chunk_bits`
+        let num_blocks = (size + CHUNK - 1) >> CHUNK_BITS;
+        let start_chunk_id = ptr >> CHUNK_BITS;
+        let start_block_id = self
+            .memory_dimensions
+            .label_to_index((address_space, start_chunk_id)) as u32;
         let end_block_id = start_block_id + num_blocks;
         let start_page_id = start_block_id >> PAGE_BITS;
         let end_page_id = ((end_block_id - 1) >> PAGE_BITS) + 1;
@@ -213,13 +204,10 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         self.page_indices.clear();
 
         // Reset trace heights for memory chips as 0
-        // SAFETY: boundary_idx is a compile time constant within bounds
+        // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
         unsafe {
-            *trace_heights.get_unchecked_mut(self.boundary_idx) = 0;
-        }
-        // SAFETY: merkle_tree_index is guaranteed to be in bounds
-        unsafe {
-            *trace_heights.get_unchecked_mut(self.merkle_tree_index) = 0;
+            *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) = 0;
+            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) = 0;
         }
         let poseidon2_idx = trace_heights.len() - 2;
         // SAFETY: poseidon2_idx is trace_heights.len() - 2, guaranteed to be in bounds
@@ -267,27 +255,18 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
 
         // On page fault, assume we add all leaves in a page
         let leaves = page_access_count << PAGE_BITS;
-        // SAFETY: boundary_idx is a compile time constant within bounds
-        unsafe {
-            *trace_heights.get_unchecked_mut(self.boundary_idx) += leaves;
-        }
 
-        debug_assert!(self.merkle_tree_index < trace_heights.len());
         debug_assert!(trace_heights.len() >= 2);
-
         let poseidon2_idx = trace_heights.len() - 2;
-        // SAFETY: poseidon2_idx is trace_heights.len() - 2, guaranteed to be in bounds
-        unsafe {
-            *trace_heights.get_unchecked_mut(poseidon2_idx) += leaves * 2;
-        }
 
         let merkle_height = self.memory_dimensions.overall_height();
         let nodes = (((1 << PAGE_BITS) - 1) + (merkle_height - PAGE_BITS)) as u32;
-        // SAFETY: merkle_tree_index is guaranteed to be in bounds
+        // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
         unsafe {
-            *trace_heights.get_unchecked_mut(poseidon2_idx) += nodes * page_access_count * 2;
-            *trace_heights.get_unchecked_mut(self.merkle_tree_index) +=
-                nodes * page_access_count * 2;
+            *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves;
+            *trace_heights.get_unchecked_mut(poseidon2_idx) +=
+                leaves * 2 + nodes * page_access_count * 2;
+            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += nodes * page_access_count * 2;
         }
     }
 

--- a/crates/vm/src/arch/testing/cpu.rs
+++ b/crates/vm/src/arch/testing/cpu.rs
@@ -39,7 +39,7 @@ use crate::{
         },
         vm_poseidon2_config, Arena, ExecutionBridge, ExecutionBus, ExecutionState,
         MatrixRecordArena, MemoryConfig, PreflightExecutor, Streams, VmField, VmStateMut,
-        CONST_BLOCK_SIZE,
+        DEFAULT_BLOCK_SIZE,
     },
     system::{
         memory::{
@@ -179,13 +179,13 @@ where
     ) -> (usize, usize) {
         let register = self.get_default_register(reg_increment);
         let pointer = self.get_default_pointer(pointer_increment);
-        // Write pointer in CONST_BLOCK_SIZE-byte chunks to match the fixed block size.
+        // Write pointer in DEFAULT_BLOCK_SIZE-byte chunks to match the fixed block size.
         // The pointer is RV32_REGISTER_NUM_LIMBS bytes (32-bit for RV32).
         let ptr_bytes = (pointer as u32).to_le_bytes();
-        for i in (0..RV32_REGISTER_NUM_LIMBS).step_by(CONST_BLOCK_SIZE) {
-            let chunk: [u8; CONST_BLOCK_SIZE] =
-                ptr_bytes[i..i + CONST_BLOCK_SIZE].try_into().unwrap();
-            self.write::<CONST_BLOCK_SIZE>(1, register + i, chunk.map(F::from_u8));
+        for i in (0..RV32_REGISTER_NUM_LIMBS).step_by(DEFAULT_BLOCK_SIZE) {
+            let chunk: [u8; DEFAULT_BLOCK_SIZE] =
+                ptr_bytes[i..i + DEFAULT_BLOCK_SIZE].try_into().unwrap();
+            self.write::<DEFAULT_BLOCK_SIZE>(1, register + i, chunk.map(F::from_u8));
         }
         (register, pointer)
     }
@@ -236,22 +236,22 @@ impl<F: VmField> VmChipTestBuilder<F> {
         pointer: usize,
         writes: Vec<[F; NUM_LIMBS]>,
     ) {
-        // Write pointer in CONST_BLOCK_SIZE-byte chunks to match the fixed block size.
+        // Write pointer in DEFAULT_BLOCK_SIZE-byte chunks to match the fixed block size.
         // The pointer is RV32_REGISTER_NUM_LIMBS bytes (32-bit for RV32).
         let ptr_bytes = (pointer as u32).to_le_bytes();
-        for i in (0..RV32_REGISTER_NUM_LIMBS).step_by(CONST_BLOCK_SIZE) {
-            let chunk: [u8; CONST_BLOCK_SIZE] =
-                ptr_bytes[i..i + CONST_BLOCK_SIZE].try_into().unwrap();
-            self.write::<CONST_BLOCK_SIZE>(1usize, register + i, chunk.map(F::from_u8));
+        for i in (0..RV32_REGISTER_NUM_LIMBS).step_by(DEFAULT_BLOCK_SIZE) {
+            let chunk: [u8; DEFAULT_BLOCK_SIZE] =
+                ptr_bytes[i..i + DEFAULT_BLOCK_SIZE].try_into().unwrap();
+            self.write::<DEFAULT_BLOCK_SIZE>(1usize, register + i, chunk.map(F::from_u8));
         }
-        // Always write in CONST_BLOCK_SIZE-byte chunks to match the fixed block size.
+        // Always write in DEFAULT_BLOCK_SIZE-byte chunks to match the fixed block size.
         for (i, &write) in writes.iter().enumerate() {
             let ptr = pointer + i * NUM_LIMBS;
-            for j in (0..NUM_LIMBS).step_by(CONST_BLOCK_SIZE) {
-                self.write::<CONST_BLOCK_SIZE>(
+            for j in (0..NUM_LIMBS).step_by(DEFAULT_BLOCK_SIZE) {
+                self.write::<DEFAULT_BLOCK_SIZE>(
                     2usize,
                     ptr + j,
-                    write[j..j + CONST_BLOCK_SIZE].try_into().unwrap(),
+                    write[j..j + DEFAULT_BLOCK_SIZE].try_into().unwrap(),
                 );
             }
         }
@@ -320,20 +320,19 @@ impl VmChipTestBuilder<BabyBear> {
 impl<F: VmField> VmChipTestBuilder<F> {
     fn range_checker_and_memory(
         mem_config: &MemoryConfig,
-        init_block_size: usize,
     ) -> (SharedVariableRangeCheckerChip, TracingMemory) {
         let range_checker = Arc::new(VariableRangeCheckerChip::new(VariableRangeCheckerBus::new(
             RANGE_CHECKER_BUS,
             mem_config.decomp,
         )));
-        let memory = TracingMemory::new(mem_config, init_block_size);
+        let memory = TracingMemory::new(mem_config);
 
         (range_checker, memory)
     }
 
     pub fn from_config(mem_config: MemoryConfig) -> Self {
         setup_tracing_with_log_level(Level::INFO);
-        let (range_checker, memory) = Self::range_checker_and_memory(&mem_config, CONST_BLOCK_SIZE);
+        let (range_checker, memory) = Self::range_checker_and_memory(&mem_config);
         let hasher_chip = Arc::new(Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3));
         let memory_controller = MemoryController::with_persistent_memory(
             MemoryBus::new(MEMORY_BUS),

--- a/crates/vm/src/arch/testing/cuda.rs
+++ b/crates/vm/src/arch/testing/cuda.rs
@@ -48,7 +48,7 @@ use crate::{
             POSEIDON2_DIRECT_BUS, READ_INSTRUCTION_BUS,
         },
         Arena, DenseRecordArena, ExecutionBridge, ExecutionBus, ExecutionState, MatrixRecordArena,
-        MemoryConfig, PreflightExecutor, Streams, VmStateMut, CONST_BLOCK_SIZE,
+        MemoryConfig, PreflightExecutor, Streams, VmStateMut, DEFAULT_BLOCK_SIZE,
     },
     system::{
         cuda::poseidon2::Poseidon2PeripheryChipGPU,
@@ -263,7 +263,7 @@ impl GpuChipTestBuilder {
         )));
         Self {
             memory: DeviceMemoryTester::new(
-                default_tracing_memory(&mem_config, CONST_BLOCK_SIZE),
+                default_tracing_memory(&mem_config),
                 mem_bus,
                 mem_config,
                 range_checker.clone(),
@@ -334,14 +334,14 @@ impl GpuChipTestBuilder {
             register,
             (pointer as u32).to_le_bytes().map(F::from_u8),
         );
-        // Always write in CONST_BLOCK_SIZE-byte chunks to match the fixed block size.
+        // Always write in DEFAULT_BLOCK_SIZE-byte chunks to match the fixed block size.
         for (i, &write) in writes.iter().enumerate() {
             let ptr = pointer + i * NUM_LIMBS;
-            for j in (0..NUM_LIMBS).step_by(CONST_BLOCK_SIZE) {
-                self.write::<CONST_BLOCK_SIZE>(
+            for j in (0..NUM_LIMBS).step_by(DEFAULT_BLOCK_SIZE) {
+                self.write::<DEFAULT_BLOCK_SIZE>(
                     2usize,
                     ptr + j,
-                    write[j..j + CONST_BLOCK_SIZE].try_into().unwrap(),
+                    write[j..j + DEFAULT_BLOCK_SIZE].try_into().unwrap(),
                 );
             }
         }

--- a/crates/vm/src/arch/testing/memory/cuda.rs
+++ b/crates/vm/src/arch/testing/memory/cuda.rs
@@ -77,7 +77,7 @@ impl DeviceMemoryTester {
 
     pub fn read<const N: usize>(&mut self, addr_space: usize, ptr: usize) -> [F; N] {
         let t = self.memory.timestamp();
-        let (t_prev, data) = unsafe { self.memory.read::<u8, N, 4>(addr_space as u32, ptr as u32) };
+        let (t_prev, data) = unsafe { self.memory.read::<u8, N>(addr_space as u32, ptr as u32) };
         let data = data.map(F::from_u8);
         self.chip_for_block.get_mut(&N).unwrap().receive(
             addr_space as u32,
@@ -95,7 +95,7 @@ impl DeviceMemoryTester {
     pub fn write<const N: usize>(&mut self, addr_space: usize, ptr: usize, data: [F; N]) {
         let t = self.memory.timestamp();
         let (t_prev, data_prev) = unsafe {
-            self.memory.write::<u8, N, 4>(
+            self.memory.write::<u8, N>(
                 addr_space as u32,
                 ptr as u32,
                 data.map(|x| x.as_canonical_u32() as u8),

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -46,7 +46,7 @@ impl<F: VmField> MemoryTester<F> {
         let memory = &mut self.memory;
         let t = memory.timestamp();
         // TODO: this could be improved if we added a TracingMemory::get_f function
-        let (t_prev, data) = unsafe { memory.read::<u8, N, 4>(addr_space as u32, ptr as u32) };
+        let (t_prev, data) = unsafe { memory.read::<u8, N>(addr_space as u32, ptr as u32) };
         let data = data.map(F::from_u8);
         self.chip_for_block.get_mut(&N).unwrap().receive(
             addr_space as u32,
@@ -67,7 +67,7 @@ impl<F: VmField> MemoryTester<F> {
         let t = memory.timestamp();
         // TODO: this could be improved if we added a TracingMemory::write_f function
         let (t_prev, data_prev) = unsafe {
-            memory.write::<u8, N, 4>(
+            memory.write::<u8, N>(
                 addr_space as u32,
                 ptr as u32,
                 data.map(|x| x.as_canonical_u32() as u8),

--- a/crates/vm/src/arch/testing/utils.rs
+++ b/crates/vm/src/arch/testing/utils.rs
@@ -45,6 +45,6 @@ pub fn dummy_memory_helper<F: Field>(
     SharedMemoryHelper::new(dummy_range_checker(bus), timestamp_max_bits)
 }
 
-pub fn default_tracing_memory(mem_config: &MemoryConfig, init_block_size: usize) -> TracingMemory {
-    TracingMemory::new(mem_config, init_block_size)
+pub fn default_tracing_memory(mem_config: &MemoryConfig) -> TracingMemory {
+    TracingMemory::new(mem_config)
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -636,9 +636,8 @@ where
             .collect::<Vec<_>>();
         let ctx = PreflightCtx::new_with_capacity(&capacities, num_insns);
 
-        let system_config: &SystemConfig = self.config().as_ref();
         let pc = state.pc();
-        let memory = TracingMemory::from_image(state.memory, system_config.initial_block_size());
+        let memory = TracingMemory::from_image(state.memory);
         let from_state = ExecutionState::new(pc, memory.timestamp());
         let vm_state = VmState::new(
             pc,

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -1,5 +1,5 @@
 use openvm_circuit::{
-    arch::CONST_BLOCK_SIZE, system::memory::persistent::PersistentBoundaryCols,
+    arch::DEFAULT_BLOCK_SIZE, system::memory::persistent::PersistentBoundaryCols,
     utils::next_power_of_two_or_zero,
 };
 use openvm_circuit_primitives::Chip;
@@ -21,7 +21,7 @@ pub struct BoundaryChipGPU {
     pub trace_width: Option<usize>,
 }
 
-const BLOCKS_PER_CHUNK: usize = DIGEST_WIDTH / CONST_BLOCK_SIZE;
+const BLOCKS_PER_CHUNK: usize = DIGEST_WIDTH / DEFAULT_BLOCK_SIZE;
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -363,14 +363,14 @@ mod tests {
         let touched_bytes = [101u8, 102, 103, 104];
         let touched_bytes_late = [111u8, 112, 113, 114];
         unsafe {
-            final_memory.write::<u8, { crate::arch::CONST_BLOCK_SIZE }>(
+            final_memory.write::<u8, { crate::arch::DEFAULT_BLOCK_SIZE }>(
                 RV32_MEMORY_AS,
                 0,
                 touched_bytes,
             );
-            final_memory.write::<u8, { crate::arch::CONST_BLOCK_SIZE }>(
+            final_memory.write::<u8, { crate::arch::DEFAULT_BLOCK_SIZE }>(
                 RV32_MEMORY_AS,
-                crate::arch::CONST_BLOCK_SIZE as u32,
+                crate::arch::DEFAULT_BLOCK_SIZE as u32,
                 touched_bytes_late,
             );
         }
@@ -405,7 +405,7 @@ mod tests {
                 },
             ),
             (
-                (RV32_MEMORY_AS, crate::arch::CONST_BLOCK_SIZE as u32),
+                (RV32_MEMORY_AS, crate::arch::DEFAULT_BLOCK_SIZE as u32),
                 TimestampedValues {
                     timestamp: 3,
                     values: touched_bytes_late.map(F::from_u8),

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -1,7 +1,7 @@
 use std::{ffi::c_void, sync::Arc};
 
 use openvm_circuit::{
-    arch::{MemoryConfig, ADDR_SPACE_OFFSET, CONST_BLOCK_SIZE},
+    arch::{MemoryConfig, ADDR_SPACE_OFFSET, DEFAULT_BLOCK_SIZE},
     system::memory::{merkle::MemoryMerkleCols, TimestampedEquipartition},
     utils::next_power_of_two_or_zero,
 };
@@ -26,9 +26,9 @@ pub mod cuda;
 use cuda::merkle_tree::*;
 
 type H = [F; DIGEST_WIDTH];
-/// Width of `((u32, u32), TimestampedValues<F, CONST_BLOCK_SIZE>)` in u32 units.
-/// = 2 (key) + 1 (timestamp) + CONST_BLOCK_SIZE (values)
-pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + CONST_BLOCK_SIZE;
+/// Width of `((u32, u32), TimestampedValues<F, DEFAULT_BLOCK_SIZE>)` in u32 units.
+/// = 2 (key) + 1 (timestamp) + DEFAULT_BLOCK_SIZE (values)
+pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + DEFAULT_BLOCK_SIZE;
 /// Width of `((u32, u32), TimestampedValues<F, DIGEST_WIDTH>)` in u32 units.
 /// = 2 (key) + 1 (timestamp) + DIGEST_WIDTH (values)
 pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + DIGEST_WIDTH;

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use self::interface::MemoryInterface;
 use super::AddressMap;
 use crate::{
-    arch::{MemoryConfig, VmField, CONST_BLOCK_SIZE},
+    arch::{MemoryConfig, VmField, DEFAULT_BLOCK_SIZE},
     system::{
         memory::{
             dimensions::MemoryDimensions,
@@ -186,7 +186,7 @@ impl<F: VmField> MemoryController<F> {
         let hasher = self.hasher_chip.as_ref().unwrap();
         boundary_chip.finalize(initial_memory, &final_memory, hasher.as_ref());
 
-        // Rechunk CONST_BLOCK_SIZE blocks into CHUNK-sized blocks for merkle_chip
+        // Rechunk DEFAULT_BLOCK_SIZE blocks into CHUNK-sized blocks for merkle_chip
         // Note: Equipartition key is (addr_space, ptr) where ptr is the starting pointer
         let final_memory_values: Equipartition<F, CHUNK> = {
             use std::collections::BTreeMap;
@@ -194,7 +194,8 @@ impl<F: VmField> MemoryController<F> {
             for ((addr_space, ptr), ts_values) in final_memory {
                 // Align to CHUNK boundary to get the chunk's starting pointer
                 let chunk_ptr = (ptr / CHUNK as u32) * CHUNK as u32;
-                let block_idx_in_chunk = ((ptr % CHUNK as u32) / CONST_BLOCK_SIZE as u32) as usize;
+                let block_idx_in_chunk =
+                    ((ptr % CHUNK as u32) / DEFAULT_BLOCK_SIZE as u32) as usize;
                 let entry = chunk_map.entry((addr_space, chunk_ptr)).or_insert_with(|| {
                     // Initialize with values from initial memory
                     std::array::from_fn(|i| unsafe {
@@ -203,7 +204,7 @@ impl<F: VmField> MemoryController<F> {
                 });
                 // Copy values for this block
                 for (i, val) in ts_values.values.into_iter().enumerate() {
-                    entry[block_idx_in_chunk * CONST_BLOCK_SIZE + i] = val;
+                    entry[block_idx_in_chunk * DEFAULT_BLOCK_SIZE + i] = val;
                 }
             }
             chunk_map

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -191,17 +191,17 @@ fn random_test(
         vec![
             AddressSpaceHostConfig {
                 num_cells: 0,
-                min_block_size: 0,
+                block_size: 0,
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                min_block_size: 1,
+                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                min_block_size: 1,
+                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
         ],
@@ -283,17 +283,17 @@ fn expand_test_no_accesses() {
         vec![
             AddressSpaceHostConfig {
                 num_cells: 0,
-                min_block_size: 0,
+                block_size: 0,
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                min_block_size: 1,
+                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                min_block_size: 1,
+                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
         ],
@@ -331,17 +331,17 @@ fn expand_test_negative() {
         vec![
             AddressSpaceHostConfig {
                 num_cells: 0,
-                min_block_size: 0,
+                block_size: 0,
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                min_block_size: 1,
+                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                min_block_size: 1,
+                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
         ],

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -1,4 +1,4 @@
-use std::{array::from_fn, fmt::Debug, num::NonZero};
+use std::{array::from_fn, fmt::Debug};
 
 use getset::Getters;
 use itertools::zip_eq;
@@ -12,7 +12,7 @@ use tracing::instrument;
 
 use crate::{
     arch::{
-        AddressSpaceHostConfig, AddressSpaceHostLayout, MemoryConfig, CONST_BLOCK_SIZE,
+        AddressSpaceHostConfig, AddressSpaceHostLayout, MemoryConfig, DEFAULT_BLOCK_SIZE,
         MAX_CELL_BYTE_SIZE,
     },
     system::{
@@ -40,11 +40,6 @@ pub type MemoryBackend = basic::BasicMemory;
 pub const INITIAL_TIMESTAMP: u32 = 0;
 /// Default mmap page size. Change this if using THB.
 pub const PAGE_SIZE: usize = 4096;
-
-// Memory access constraints
-const MAX_BLOCK_SIZE: usize = 32;
-const MIN_ALIGN: usize = 1;
-const MAX_SEGMENTS: usize = MAX_BLOCK_SIZE / MIN_ALIGN;
 
 /// (address_space, pointer)
 pub type Address = (u32, u32);
@@ -379,378 +374,82 @@ impl GuestMemory {
     }
 }
 
-#[repr(C)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
-pub struct AccessMetadata {
-    /// Packed timestamp (29 bits) and log2(block_size) (3 bits)
-    pub timestamp_and_log_block_size: u32,
-    /// Offset to block start (in ALIGN units).
-    pub offset_to_start: u8,
-}
-
-impl AccessMetadata {
-    const TIMESTAMP_MASK: u32 = (1 << 29) - 1;
-    const LOG_BLOCK_SIZE_SHIFT: u32 = 29;
-
-    pub fn new(timestamp: u32, block_size: u8, offset_to_start: u8) -> Self {
-        debug_assert!(timestamp < (1 << 29), "Timestamp must be less than 2^29");
-        debug_assert!(
-            block_size == 0 || (block_size.is_power_of_two() && block_size <= MAX_BLOCK_SIZE as u8),
-            "Block size must be 0 or power of 2 and <= {MAX_BLOCK_SIZE}"
-        );
-
-        let encoded_block_size = if block_size == 0 {
-            0
-        } else {
-            // SAFETY: We already asserted that block_size is non-zero in this branch
-            unsafe { NonZero::new_unchecked(block_size) }.ilog2() + 1
-        };
-        let packed = timestamp | (encoded_block_size << Self::LOG_BLOCK_SIZE_SHIFT);
-
-        Self {
-            timestamp_and_log_block_size: packed,
-            offset_to_start,
-        }
-    }
-
-    pub fn timestamp(&self) -> u32 {
-        self.timestamp_and_log_block_size & Self::TIMESTAMP_MASK
-    }
-
-    pub fn block_size(&self) -> u8 {
-        let encoded = self.timestamp_and_log_block_size >> Self::LOG_BLOCK_SIZE_SHIFT;
-        if encoded == 0 {
-            0
-        } else {
-            1 << (encoded - 1)
-        }
-    }
-}
-
 /// Online memory that stores additional information for trace generation purposes.
 /// In particular, keeps track of timestamp.
 #[derive(Getters)]
 pub struct TracingMemory {
     pub timestamp: u32,
-    /// The initial block size -- this depends on the type of boundary chip.
-    initial_block_size: usize,
     /// The underlying data memory, with memory cells typed by address space: see [AddressMap].
     #[getset(get = "pub")]
     pub data: GuestMemory,
-    /// Maps addr_space to (ptr / min_block_size[addr_space] -> AccessMetadata) for latest access
-    /// metadata. Uses paged storage for memory efficiency. AccessMetadata stores offset_to_start
-    /// (in ALIGN units), block_size, and timestamp (latter two only valid at offset_to_start ==
-    /// 0).
-    pub(super) meta: Vec<PagedVec<AccessMetadata, PAGE_SIZE>>,
-    /// For each `addr_space`, the minimum block size allowed for memory accesses. In other words,
-    /// all memory accesses in `addr_space` must be aligned to this block size.
-    pub min_block_size: Vec<u32>,
+    /// Maps (addr_space, ptr / block_size[addr_space]) → timestamp of last access.
+    /// A value of 0 means the slot has never been accessed.
+    pub(super) meta: Vec<PagedVec<u32, PAGE_SIZE>>,
+    /// For each `addr_space`, the block size for memory accesses. All memory accesses in
+    /// `addr_space` must be aligned to this block size.
+    pub block_size: Vec<u32>,
 }
 
 impl TracingMemory {
-    pub fn new(mem_config: &MemoryConfig, initial_block_size: usize) -> Self {
+    pub fn new(mem_config: &MemoryConfig) -> Self {
         let image = GuestMemory::new(AddressMap::from_mem_config(mem_config));
-        Self::from_image(image, initial_block_size)
+        Self::from_image(image)
     }
 
     /// Constructor from pre-existing memory image.
-    pub fn from_image(image: GuestMemory, initial_block_size: usize) -> Self {
-        let (meta, min_block_size): (Vec<_>, Vec<_>) =
+    pub fn from_image(image: GuestMemory) -> Self {
+        let (meta, block_size): (Vec<_>, Vec<_>) =
             zip_eq(image.memory.get_memory(), &image.memory.config)
                 .map(|(mem, addr_sp)| {
                     let num_cells = mem.size() / addr_sp.layout.size();
-                    let min_block_size = addr_sp.min_block_size;
-                    let total_metadata_len = num_cells.div_ceil(min_block_size);
-                    (PagedVec::new(total_metadata_len), min_block_size as u32)
+                    let block_size = addr_sp.block_size;
+                    let total_metadata_len = num_cells.div_ceil(block_size);
+                    (PagedVec::new(total_metadata_len), block_size as u32)
                 })
                 .unzip();
         Self {
             data: image,
             meta,
-            min_block_size,
+            block_size,
             timestamp: INITIAL_TIMESTAMP + 1,
-            initial_block_size,
         }
     }
 
     #[inline(always)]
-    fn assert_alignment(&self, block_size: usize, align: usize, addr_space: u32, ptr: u32) {
-        debug_assert!(block_size.is_power_of_two());
-        debug_assert_eq!(block_size % align, 0);
+    fn assert_valid_access(&self, block_size: usize, addr_space: u32, ptr: u32) {
         debug_assert_ne!(addr_space, 0);
-        debug_assert_eq!(align as u32, self.min_block_size[addr_space as usize]);
+        debug_assert!(block_size.is_power_of_two());
+        debug_assert_eq!(block_size, self.block_size[addr_space as usize] as usize);
         assert_eq!(
-            ptr % (align as u32),
+            ptr % block_size as u32,
             0,
-            "pointer={ptr} not aligned to {align}"
+            "pointer={ptr} not aligned to block_size {block_size}"
         );
     }
 
-    /// Get block metadata by jumping to the start of the block.
-    /// Returns (block_start_pointer, block_metadata).
+    /// Returns the previous access timestamp and updates metadata for this access.
+    /// Each read/write accesses exactly one metadata slot since callers always use
+    /// BLOCK_SIZE == block_size[addr_space].
     #[inline(always)]
-    fn get_block_metadata<const ALIGN: usize>(
-        &mut self,
-        address_space: usize,
-        pointer: usize,
-    ) -> (u32, AccessMetadata) {
-        let ptr_index = pointer / ALIGN;
-        // SAFETY:
-        // - address_space is validated during instruction decoding and guaranteed to be within
-        //   bounds
+    fn prev_access_time(&mut self, address_space: usize, pointer: usize) -> u32 {
+        let bs = self.block_size[address_space] as usize;
+        let idx = pointer / bs;
+        // SAFETY: address_space is validated during instruction decoding
         let meta_page = unsafe { self.meta.get_unchecked_mut(address_space) };
-        let current_meta = meta_page.get(ptr_index);
-
-        let (block_start_index, block_metadata) = if current_meta.offset_to_start == 0 {
-            (ptr_index, current_meta)
-        } else {
-            let offset = current_meta.offset_to_start;
-            let start_idx = ptr_index - offset as usize;
-            let start_meta = meta_page.get(start_idx);
-            (start_idx, start_meta)
-        };
-
-        let block_start_pointer = (block_start_index * ALIGN) as u32;
-
-        (block_start_pointer, block_metadata)
-    }
-
-    #[inline(always)]
-    fn get_timestamp<const ALIGN: usize>(&mut self, address_space: usize, pointer: usize) -> u32 {
-        let ptr_index = pointer / ALIGN;
-        // SAFETY:
-        // - address_space is validated during instruction decoding and guaranteed to be within
-        //   bounds
-        let meta_page = unsafe { self.meta.get_unchecked_mut(address_space) };
-        let current_meta = meta_page.get(ptr_index);
-
-        if current_meta.offset_to_start == 0 {
-            current_meta.timestamp()
-        } else {
-            let offset = current_meta.offset_to_start;
-            let block_start_index = ptr_index - offset as usize;
-            meta_page.get(block_start_index).timestamp()
-        }
-    }
-
-    /// Updates the metadata with the given block.
-    /// Stores timestamp and block_size only at block start, offsets elsewhere.
-    #[inline(always)]
-    fn set_meta_block<const BLOCK_SIZE: usize, const ALIGN: usize>(
-        &mut self,
-        address_space: usize,
-        pointer: usize,
-        timestamp: u32,
-    ) {
-        let ptr = pointer / ALIGN;
-        // SAFETY: address_space is assumed to be valid and within bounds
-        let meta_page = unsafe { self.meta.get_unchecked_mut(address_space) };
-
-        // Store full metadata at the block start
-        meta_page.set(ptr, AccessMetadata::new(timestamp, BLOCK_SIZE as u8, 0));
-
-        // Store offsets for other positions in the block
-        for i in 1..(BLOCK_SIZE / ALIGN) {
-            meta_page.set(ptr + i, AccessMetadata::new(0, 0, i as u8));
-        }
-    }
-
-    /// Calculate splits and merges needed for a memory access.
-    /// Returns Some((splits, merge)) or None if no operations needed.
-    #[inline(always)]
-    #[allow(clippy::type_complexity)]
-    fn calculate_splits_and_merges<const BLOCK_SIZE: usize, const ALIGN: usize>(
-        &mut self,
-        address_space: usize,
-        pointer: usize,
-    ) -> Option<(Vec<(usize, usize)>, (usize, usize))> {
-        // Skip metadata update if this is a repeated access to the same location with same size
-        let (start_ptr, block_meta) = self.get_block_metadata::<ALIGN>(address_space, pointer);
-        if block_meta.block_size() == BLOCK_SIZE as u8 && start_ptr == pointer as u32 {
-            return None;
-        }
-
-        // Split intersecting blocks to align bytes
-        let mut splits_buf = [(0usize, 0usize); MAX_SEGMENTS];
-        let mut splits_count = 0;
-        let mut current_ptr = pointer;
-        let end_ptr = pointer + BLOCK_SIZE;
-
-        while current_ptr < end_ptr {
-            let (start_ptr, block_metadata) =
-                self.get_block_metadata::<ALIGN>(address_space, current_ptr);
-
-            if block_metadata.block_size() == 0 {
-                current_ptr += ALIGN;
-                continue;
-            }
-
-            if block_metadata.block_size() > ALIGN as u8 {
-                // SAFETY: splits_count < MAX_SEGMENTS by construction since we iterate over
-                // at most BLOCK_SIZE/ALIGN segments and BLOCK_SIZE <= MAX_BLOCK_SIZE
-                unsafe {
-                    *splits_buf.get_unchecked_mut(splits_count) =
-                        (start_ptr as usize, block_metadata.block_size() as usize);
-                }
-                splits_count += 1;
-            }
-
-            // Skip to the next segment after this block ends
-            current_ptr = start_ptr as usize + block_metadata.block_size() as usize;
-        }
-
-        let merge = (pointer, BLOCK_SIZE);
-
-        Some((splits_buf[..splits_count].to_vec(), merge))
-    }
-
-    #[inline(always)]
-    fn split_by_meta<const MIN_BLOCK_SIZE: usize>(
-        &mut self,
-        start_ptr: u32,
-        timestamp: u32,
-        block_size: u8,
-        address_space: usize,
-    ) {
-        if block_size == MIN_BLOCK_SIZE as u8 {
-            return;
-        }
-        let begin = start_ptr as usize / MIN_BLOCK_SIZE;
-        // SAFETY:
-        // - address_space is validated during instruction decoding and guaranteed to be within
-        //   bounds
-        let meta_page = unsafe { self.meta.get_unchecked_mut(address_space) };
-
-        for i in 0..(block_size as usize / MIN_BLOCK_SIZE) {
-            // Each split piece becomes its own block start
-            meta_page.set(
-                begin + i,
-                AccessMetadata::new(timestamp, MIN_BLOCK_SIZE as u8, 0),
-            );
-        }
-    }
-
-    /// Returns the timestamp of the previous access to `[pointer:BLOCK_SIZE]_{address_space}`.
-    ///
-    /// Caller must ensure alignment (e.g. via `assert_alignment`) prior to calling this function.
-    #[inline(always)]
-    fn prev_access_time<T: Copy, const BLOCK_SIZE: usize, const ALIGN: usize>(
-        &mut self,
-        address_space: usize,
-        pointer: usize,
-    ) -> u32 {
-        debug_assert_eq!(ALIGN, self.data.memory.config[address_space].min_block_size);
-        // SAFETY:
-        // - address_space is validated during instruction decoding and guaranteed to be within
-        //   bounds
-        debug_assert_eq!(
-            unsafe {
-                self.data
-                    .memory
-                    .config
-                    .get_unchecked(address_space)
-                    .layout
-                    .size()
-            },
-            size_of::<T>()
-        );
-        // Calculate what splits and merges are needed for this memory access
-        let result = if let Some((splits, (merge_ptr, merge_size))) =
-            self.calculate_splits_and_merges::<BLOCK_SIZE, ALIGN>(address_space, pointer)
-        {
-            // Process all splits first
-            for (split_ptr, split_size) in splits {
-                let (_, block_metadata) =
-                    self.get_block_metadata::<ALIGN>(address_space, split_ptr);
-                let timestamp = block_metadata.timestamp();
-                self.split_by_meta::<ALIGN>(
-                    split_ptr as u32,
-                    timestamp,
-                    split_size as u8,
-                    address_space,
-                );
-            }
-
-            // Process merge
-            let mut prev_ts_buf = [0u32; MAX_SEGMENTS];
-
-            let mut max_timestamp = INITIAL_TIMESTAMP;
-
-            let mut ptr = merge_ptr;
-            let end_ptr = merge_ptr + merge_size;
-            let mut seg_idx = 0;
-            while ptr < end_ptr {
-                let (_, block_metadata) = self.get_block_metadata::<ALIGN>(address_space, ptr);
-
-                let timestamp = if block_metadata.block_size() > 0 {
-                    block_metadata.timestamp()
-                } else {
-                    self.handle_uninitialized_memory::<ALIGN>(address_space, ptr);
-                    INITIAL_TIMESTAMP
-                };
-
-                // SAFETY: seg_idx < MAX_SEGMENTS since we iterate at most merge_size/ALIGN times
-                // and merge_size <= BLOCK_SIZE <= MAX_BLOCK_SIZE
-                unsafe {
-                    *prev_ts_buf.get_unchecked_mut(seg_idx) = timestamp;
-                }
-                max_timestamp = max_timestamp.max(timestamp);
-                ptr += ALIGN;
-                seg_idx += 1;
-            }
-
-            max_timestamp
-        } else {
-            self.get_timestamp::<ALIGN>(address_space, pointer)
-        };
-
-        // Update the metadata for this access
-        self.set_meta_block::<BLOCK_SIZE, ALIGN>(address_space, pointer, self.timestamp);
-        result
-    }
-
-    /// Handle uninitialized memory by creating appropriate split or merge records.
-    #[inline(always)]
-    fn handle_uninitialized_memory<const ALIGN: usize>(
-        &mut self,
-        address_space: usize,
-        pointer: usize,
-    ) {
-        if self.initial_block_size >= ALIGN {
-            // Split the initial block into chunks
-            let segment_index = pointer / ALIGN;
-            let block_start = segment_index & !(self.initial_block_size / ALIGN - 1);
-            let start_ptr = (block_start * ALIGN) as u32;
-            self.split_by_meta::<ALIGN>(
-                start_ptr,
-                INITIAL_TIMESTAMP,
-                self.initial_block_size as u8,
-                address_space,
-            );
-        } else {
-            debug_assert_eq!(self.initial_block_size, 1);
-        }
+        let prev = meta_page.get(idx);
+        meta_page.set(idx, self.timestamp);
+        prev
     }
 
     /// Atomic read operation which increments the timestamp by 1.
-    /// Returns `(t_prev, [pointer:BLOCK_SIZE]_{address_space})` where `t_prev` is the
-    /// timestamp of the last memory access.
-    ///
-    ///
-    /// # Assumptions
-    /// The `BLOCK_SIZE` is a multiple of `ALIGN`, which must equal the minimum block size
-    /// of `address_space`.
+    /// Returns `(t_prev, [pointer:BLOCK_SIZE]_{address_space})`.
     ///
     /// # Safety
-    /// The type `T` must be stack-allocated `repr(C)` or `repr(transparent)`,
-    /// plain old data, and it must be the exact type used to represent a single memory cell in
-    /// address space `address_space`. For standard usage,
-    /// `T` is either `u8` or `F` where `F` is the base field of the ZK backend.
-    ///
-    /// In addition:
+    /// - `T` must be `repr(C)` or `repr(transparent)` and match the cell type for `address_space`.
     /// - `address_space` must be valid.
+    /// - `BLOCK_SIZE` must equal the address space's block size.
     #[inline(always)]
-    pub unsafe fn read<T, const BLOCK_SIZE: usize, const ALIGN: usize>(
+    pub unsafe fn read<T, const BLOCK_SIZE: usize>(
         &mut self,
         address_space: u32,
         pointer: u32,
@@ -758,34 +457,22 @@ impl TracingMemory {
     where
         T: Copy + Debug,
     {
-        self.assert_alignment(BLOCK_SIZE, ALIGN, address_space, pointer);
+        self.assert_valid_access(BLOCK_SIZE, address_space, pointer);
         let values = self.data.read(address_space, pointer);
-        let t_prev =
-            self.prev_access_time::<T, BLOCK_SIZE, ALIGN>(address_space as usize, pointer as usize);
+        let t_prev = self.prev_access_time(address_space as usize, pointer as usize);
         self.timestamp += 1;
 
         (t_prev, values)
     }
 
-    /// Atomic write operation that writes `values` into `[pointer:BLOCK_SIZE]_{address_space}` and
-    /// then increments the timestamp by 1. Returns `(t_prev, values_prev)` which equal the
-    /// timestamp and value `[pointer:BLOCK_SIZE]_{address_space}` of the last memory access.
-    ///
-    ///
-    /// # Assumptions
-    /// The `BLOCK_SIZE` is a multiple of `ALIGN`, which must equal the minimum block size
-    /// of `address_space`.
+    /// Atomic write operation. Returns `(t_prev, values_prev)`.
     ///
     /// # Safety
-    /// The type `T` must be stack-allocated `repr(C)` or `repr(transparent)`,
-    /// and it must be the exact type used to represent a single memory cell in
-    /// address space `address_space`. For standard usage,
-    /// `T` is either `u8` or `F` where `F` is the base field of the ZK backend.
-    ///
-    /// In addition:
+    /// - `T` must be `repr(C)` or `repr(transparent)` and match the cell type for `address_space`.
     /// - `address_space` must be valid.
+    /// - `BLOCK_SIZE` must equal the address space's block size.
     #[inline(always)]
-    pub unsafe fn write<T, const BLOCK_SIZE: usize, const ALIGN: usize>(
+    pub unsafe fn write<T, const BLOCK_SIZE: usize>(
         &mut self,
         address_space: u32,
         pointer: u32,
@@ -794,10 +481,9 @@ impl TracingMemory {
     where
         T: Copy + Debug,
     {
-        self.assert_alignment(BLOCK_SIZE, ALIGN, address_space, pointer);
+        self.assert_valid_access(BLOCK_SIZE, address_space, pointer);
         let values_prev = self.data.read(address_space, pointer);
-        let t_prev =
-            self.prev_access_time::<T, BLOCK_SIZE, ALIGN>(address_space as usize, pointer as usize);
+        let t_prev = self.prev_access_time(address_space as usize, pointer as usize);
         self.data.write(address_space, pointer, values);
         self.timestamp += 1;
 
@@ -820,23 +506,23 @@ impl TracingMemory {
     #[instrument(name = "memory_finalize", skip_all)]
     pub fn finalize<F: Field>(&mut self) -> TouchedMemory<F> {
         let touched_blocks = self.touched_blocks();
-        self.touched_blocks_to_equipartition::<F, CONST_BLOCK_SIZE>(touched_blocks)
+        self.touched_blocks_to_equipartition::<F, DEFAULT_BLOCK_SIZE>(touched_blocks)
     }
 
-    /// Returns the list of all touched blocks. The list is sorted by address.
-    fn touched_blocks(&self) -> Vec<(Address, AccessMetadata)> {
-        assert_eq!(self.meta.len(), self.min_block_size.len());
+    /// Returns the list of all touched blocks (address, timestamp). Sorted by address.
+    fn touched_blocks(&self) -> Vec<(Address, u32)> {
+        assert_eq!(self.meta.len(), self.block_size.len());
         self.meta
             .par_iter()
-            .zip(self.min_block_size.par_iter())
+            .zip(self.block_size.par_iter())
             .enumerate()
-            .flat_map(|(addr_space, (meta_page, &align))| {
+            .flat_map(|(addr_space, (meta_page, &bs))| {
                 meta_page
                     .par_iter()
-                    .filter_map(move |(idx, metadata)| {
-                        let ptr = idx as u32 * align;
-                        if metadata.offset_to_start == 0 && metadata.block_size() != 0 {
-                            Some(((addr_space as u32, ptr), metadata))
+                    .filter_map(move |(idx, timestamp)| {
+                        if timestamp > INITIAL_TIMESTAMP {
+                            let ptr = idx as u32 * bs;
+                            Some(((addr_space as u32, ptr), timestamp))
                         } else {
                             None
                         }
@@ -847,12 +533,10 @@ impl TracingMemory {
     }
 
     /// Returns the equipartition of the touched blocks.
-    /// Modifies records and adds new to account for the initial/final segments.
     fn touched_blocks_to_equipartition<F: Field, const CHUNK: usize>(
         &mut self,
-        touched_blocks: Vec<((u32, u32), AccessMetadata)>,
+        touched_blocks: Vec<((u32, u32), u32)>,
     ) -> TimestampedEquipartition<F, CHUNK> {
-        // [perf] We can `.with_capacity()` if we keep track of the number of segments we initialize
         let mut final_memory = Vec::new();
 
         debug_assert!(touched_blocks.is_sorted_by_key(|(addr, _)| addr));
@@ -865,28 +549,26 @@ impl TracingMemory {
     fn handle_touched_blocks<F: Field, const CHUNK: usize>(
         &mut self,
         final_memory: &mut Vec<((u32, u32), TimestampedValues<F, CHUNK>)>,
-        touched_blocks: Vec<((u32, u32), AccessMetadata)>,
+        touched_blocks: Vec<((u32, u32), u32)>,
     ) {
         let mut current_values = vec![0u8; MAX_CELL_BYTE_SIZE * CHUNK];
         let mut current_cnt = 0;
         let mut current_address = MemoryAddress::new(0, 0);
-        let mut current_timestamps = vec![0; CHUNK];
-        for ((addr_space, ptr), access_metadata) in touched_blocks {
+        let mut current_timestamps = vec![0u32; CHUNK];
+        for ((addr_space, ptr), timestamp) in touched_blocks {
             // SAFETY: addr_space of touched blocks are all in bounds
             let addr_space_config =
                 unsafe { *self.data.memory.config.get_unchecked(addr_space as usize) };
-            let min_block_size = addr_space_config.min_block_size;
+            let block_size = addr_space_config.block_size;
             let cell_size = addr_space_config.layout.size();
-            let timestamp = access_metadata.timestamp();
-            let block_size = access_metadata.block_size();
+            debug_assert!(ptr % block_size as u32 == 0);
+
             assert!(
                 current_cnt == 0
                     || (current_address.address_space == addr_space
                         && current_address.pointer + current_cnt as u32 == ptr),
                 "The union of all touched blocks must consist of blocks with sizes divisible by `CHUNK`"
             );
-            debug_assert!(block_size >= min_block_size as u8);
-            debug_assert!(ptr % min_block_size as u32 == 0);
 
             if current_cnt == 0 {
                 assert_eq!(
@@ -897,82 +579,48 @@ impl TracingMemory {
                 current_address = MemoryAddress::new(addr_space, ptr);
             }
 
-            if min_block_size > CHUNK {
-                assert_eq!(current_cnt, 0);
-                // SAFETY: touched blocks are in bounds
-                let values = unsafe {
+            // SAFETY: current_cnt / block_size < CHUNK / block_size <= CHUNK
+            unsafe {
+                *current_timestamps.get_unchecked_mut(current_cnt / block_size) = timestamp;
+            }
+
+            for i in 0..block_size as u32 {
+                let cell_data = unsafe {
                     self.data.memory.get_u8_slice(
                         addr_space,
-                        ptr as usize * cell_size,
-                        block_size as usize * cell_size,
+                        (ptr + i) as usize * cell_size,
+                        cell_size,
                     )
                 };
-                for i in (0..block_size as u32).step_by(CHUNK) {
+                current_values[current_cnt * cell_size..current_cnt * cell_size + cell_size]
+                    .copy_from_slice(cell_data);
+                current_cnt += 1;
+                if current_cnt == CHUNK {
+                    let timestamp = *current_timestamps[..CHUNK / block_size]
+                        .iter()
+                        .max()
+                        .unwrap();
                     final_memory.push((
-                        (addr_space, ptr + i),
+                        (current_address.address_space, current_address.pointer),
                         TimestampedValues {
                             timestamp,
-                            values: from_fn(|j| {
-                                let byte_idx = (i as usize + j) * cell_size;
-                                // SAFETY: block_size is multiple of CHUNK and we are reading chunks
-                                // of cells within bounds
-                                unsafe {
-                                    addr_space_config
-                                        .layout
-                                        .to_field(&values[byte_idx..byte_idx + cell_size])
-                                }
+                            values: from_fn(|i| unsafe {
+                                addr_space_config.layout.to_field(
+                                    &current_values[i * cell_size..i * cell_size + cell_size],
+                                )
                             }),
                         },
                     ));
-                }
-            } else {
-                for i in 0..block_size as u32 {
-                    // SAFETY: getting cell data
-                    let cell_data = unsafe {
-                        self.data.memory.get_u8_slice(
-                            addr_space,
-                            (ptr + i) as usize * cell_size,
-                            cell_size,
-                        )
-                    };
-                    current_values[current_cnt * cell_size..current_cnt * cell_size + cell_size]
-                        .copy_from_slice(cell_data);
-                    if current_cnt & (min_block_size - 1) == 0 {
-                        // SAFETY: current_cnt / min_block_size < CHUNK / min_block_size <= CHUNK
-                        unsafe {
-                            *current_timestamps.get_unchecked_mut(current_cnt / min_block_size) =
-                                timestamp;
-                        }
-                    }
-                    current_cnt += 1;
-                    if current_cnt == CHUNK {
-                        let timestamp = *current_timestamps[..CHUNK / min_block_size]
-                            .iter()
-                            .max()
-                            .unwrap();
-                        final_memory.push((
-                            (current_address.address_space, current_address.pointer),
-                            TimestampedValues {
-                                timestamp,
-                                values: from_fn(|i| unsafe {
-                                    // SAFETY: cell_size is correct, and alignment is guaranteed
-                                    addr_space_config.layout.to_field(
-                                        &current_values[i * cell_size..i * cell_size + cell_size],
-                                    )
-                                }),
-                            },
-                        ));
-                        current_address.pointer += current_cnt as u32;
-                        current_cnt = 0;
-                    }
+                    current_address.pointer += current_cnt as u32;
+                    current_cnt = 0;
                 }
             }
         }
         assert_eq!(current_cnt, 0, "The union of all touched blocks must consist of blocks with sizes divisible by `CHUNK`");
     }
 
-    pub fn address_space_alignment(&self) -> Vec<u8> {
-        self.min_block_size
+    pub fn block_size_bits(&self) -> Vec<u8> {
+        self.block_size
             .iter()
             .map(|&x| log2_strict_usize(x as usize) as u8)
             .collect()

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -20,7 +20,7 @@ use tracing::instrument;
 
 use super::{merkle::SerialReceiver, online::INITIAL_TIMESTAMP};
 use crate::{
-    arch::{hasher::Hasher, ADDR_SPACE_OFFSET, CONST_BLOCK_SIZE},
+    arch::{hasher::Hasher, ADDR_SPACE_OFFSET, DEFAULT_BLOCK_SIZE},
     primitives::Chip,
     system::memory::{
         controller::CHUNK, dimensions::MemoryDimensions, offline_checker::MemoryBus, MemoryAddress,
@@ -28,10 +28,10 @@ use crate::{
     },
 };
 
-/// Number of CONST_BLOCK_SIZE blocks per CHUNK (e.g., 2 for 8/4).
+/// Number of DEFAULT_BLOCK_SIZE blocks per CHUNK (e.g., 2 for 8/4).
 /// Blocks are on the same row only for Merkle tree hashing (8 bytes at a time).
 /// Memory bus interactions use per-block timestamps.
-pub const BLOCKS_PER_CHUNK: usize = CHUNK / CONST_BLOCK_SIZE;
+pub const BLOCKS_PER_CHUNK: usize = CHUNK / DEFAULT_BLOCK_SIZE;
 
 /// The values describe aligned chunk of memory of size `CHUNK`---the data together with the last
 /// accessed timestamp---in either the initial or final memory state.
@@ -46,7 +46,7 @@ pub struct PersistentBoundaryCols<T, const CHUNK: usize> {
     pub leaf_label: T,
     pub values: [T; CHUNK],
     pub hash: [T; CHUNK],
-    /// Per-block timestamps. Each CONST_BLOCK_SIZE block within the chunk has its own timestamp.
+    /// Per-block timestamps. Each DEFAULT_BLOCK_SIZE block within the chunk has its own timestamp.
     /// For untouched blocks, timestamp stays at 0 (balances: boundary sends at t=0 init, receives
     /// at t=0 final).
     pub timestamps: [T; BLOCKS_PER_CHUNK],
@@ -120,8 +120,8 @@ impl<const CHUNK: usize, AB: InteractionBuilder> Air<AB> for PersistentBoundaryA
 
         let chunk_size_f = AB::F::from_usize(CHUNK);
         for block_idx in 0..BLOCKS_PER_CHUNK {
-            let offset = AB::F::from_usize(block_idx * CONST_BLOCK_SIZE);
-            // Split the 1xCHUNK leaf into CONST_BLOCK_SIZE-sized bus messages.
+            let offset = AB::F::from_usize(block_idx * DEFAULT_BLOCK_SIZE);
+            // Split the 1xCHUNK leaf into DEFAULT_BLOCK_SIZE-sized bus messages.
             // Each block uses its own timestamp - untouched blocks stay at t=0.
             self.memory_bus
                 .send(
@@ -129,7 +129,8 @@ impl<const CHUNK: usize, AB: InteractionBuilder> Air<AB> for PersistentBoundaryA
                         local.address_space,
                         local.leaf_label * chunk_size_f + offset,
                     ),
-                    local.values[block_idx * CONST_BLOCK_SIZE..(block_idx + 1) * CONST_BLOCK_SIZE]
+                    local.values
+                        [block_idx * DEFAULT_BLOCK_SIZE..(block_idx + 1) * DEFAULT_BLOCK_SIZE]
                         .to_vec(),
                     local.timestamps[block_idx],
                 )
@@ -158,7 +159,7 @@ pub struct FinalTouchedLabel<F, const CHUNK: usize> {
     final_values: [F; CHUNK],
     init_hash: [F; CHUNK],
     final_hash: [F; CHUNK],
-    /// Per-block timestamps. Each CONST_BLOCK_SIZE block has its own timestamp.
+    /// Per-block timestamps. Each DEFAULT_BLOCK_SIZE block has its own timestamp.
     final_timestamps: [u32; BLOCKS_PER_CHUNK],
 }
 
@@ -226,7 +227,7 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
 
     /// Finalize the boundary chip with per-block timestamped memory.
     ///
-    /// `final_memory` is at CONST_BLOCK_SIZE granularity (4 bytes per entry, single timestamp
+    /// `final_memory` is at DEFAULT_BLOCK_SIZE granularity (4 bytes per entry, single timestamp
     /// each). This function rechunks into CHUNK-sized (8 bytes) groups with per-block
     /// timestamps. Untouched blocks within a touched chunk get values from initial_memory and
     /// timestamp 0.
@@ -234,20 +235,20 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
     pub(crate) fn finalize<H>(
         &mut self,
         initial_memory: &MemoryImage,
-        // Touched stuff at CONST_BLOCK_SIZE granularity
-        final_memory: &TimestampedEquipartition<F, CONST_BLOCK_SIZE>,
+        // Touched stuff at DEFAULT_BLOCK_SIZE granularity
+        final_memory: &TimestampedEquipartition<F, DEFAULT_BLOCK_SIZE>,
         hasher: &H,
     ) where
         H: Hasher<CHUNK, F> + Sync + for<'a> SerialReceiver<&'a [F]>,
     {
-        type BlockInfo<F> = (usize, u32, [F; CONST_BLOCK_SIZE]); // (block_idx, timestamp, values)
+        type BlockInfo<F> = (usize, u32, [F; DEFAULT_BLOCK_SIZE]); // (block_idx, timestamp, values)
         type EnrichedEntry<F> = ((u32, u32), BlockInfo<F>); // (chunk_key, block_info)
 
         let enriched: Vec<EnrichedEntry<F>> = final_memory
             .par_iter()
             .map(|&((addr_space, ptr), ts_values)| {
                 let chunk_label = ptr / CHUNK as u32;
-                let block_idx = ((ptr % CHUNK as u32) / CONST_BLOCK_SIZE as u32) as usize;
+                let block_idx = ((ptr % CHUNK as u32) / DEFAULT_BLOCK_SIZE as u32) as usize;
                 let key = (addr_space, chunk_label);
                 let block_info = (block_idx, ts_values.timestamp, ts_values.values);
                 (key, block_info)
@@ -278,7 +279,7 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
                 for (block_idx, ts, values) in blocks {
                     timestamps[block_idx] = ts;
                     for (i, &val) in values.iter().enumerate() {
-                        final_values[block_idx * CONST_BLOCK_SIZE + i] = val;
+                        final_values[block_idx * DEFAULT_BLOCK_SIZE + i] = val;
                     }
                 }
 

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -28,7 +28,7 @@ use crate::{
         ChipInventoryError, ExecutionBridge, ExecutionBus, ExecutionState, ExecutorInventory,
         ExecutorInventoryError, MatrixRecordArena, PhantomSubExecutor, RowMajorMatrixArena,
         SystemConfig, VmBuilder, VmChipComplex, VmCircuitConfig, VmExecutionConfig, VmField,
-        BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, CONST_BLOCK_SIZE, PROGRAM_AIR_ID,
+        BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, DEFAULT_BLOCK_SIZE, PROGRAM_AIR_ID,
     },
     system::{
         connector::VmConnectorChip,
@@ -111,7 +111,7 @@ pub struct SystemRecords<F> {
     pub touched_memory: TouchedMemory<F>,
 }
 
-pub type TouchedMemory<F> = TimestampedEquipartition<F, CONST_BLOCK_SIZE>;
+pub type TouchedMemory<F> = TimestampedEquipartition<F, DEFAULT_BLOCK_SIZE>;
 
 #[derive(Clone, AnyEnum, Executor, MeteredExecutor, PreflightExecutor, From)]
 #[cfg_attr(feature = "aot", derive(AotExecutor, AotMeteredExecutor))]

--- a/extensions/algebra/circuit/src/extension/fp2.rs
+++ b/extensions/algebra/circuit/src/extension/fp2.rs
@@ -6,7 +6,7 @@ use openvm_circuit::{
     arch::{
         AirInventory, AirInventoryError, ChipInventory, ChipInventoryError, ExecutionBridge,
         ExecutorInventoryBuilder, ExecutorInventoryError, RowMajorMatrixArena, VmCircuitExtension,
-        VmExecutionExtension, VmProverExtension, CONST_BLOCK_SIZE,
+        VmExecutionExtension, VmProverExtension, DEFAULT_BLOCK_SIZE,
     },
     system::{memory::SharedMemoryHelper, SystemPort},
 };
@@ -81,11 +81,11 @@ impl Fp2Extension {
 )]
 pub enum Fp2ExtensionExecutor {
     // 32 limbs prime
-    Fp2AddSubRv32_32(Fp2Executor<FP2_BLOCKS_32, CONST_BLOCK_SIZE>), // Fp2AddSub
-    Fp2MulDivRv32_32(Fp2Executor<FP2_BLOCKS_32, CONST_BLOCK_SIZE>), // Fp2MulDiv
+    Fp2AddSubRv32_32(Fp2Executor<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>), // Fp2AddSub
+    Fp2MulDivRv32_32(Fp2Executor<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>), // Fp2MulDiv
     // 48 limbs prime
-    Fp2AddSubRv32_48(Fp2Executor<FP2_BLOCKS_48, CONST_BLOCK_SIZE>), // Fp2AddSub
-    Fp2MulDivRv32_48(Fp2Executor<FP2_BLOCKS_48, CONST_BLOCK_SIZE>), // Fp2MulDiv
+    Fp2AddSubRv32_48(Fp2Executor<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>), // Fp2AddSub
+    Fp2MulDivRv32_48(Fp2Executor<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>), // Fp2MulDiv
 }
 
 impl<F: PrimeField32> VmExecutionExtension<F> for Fp2Extension {
@@ -209,7 +209,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Fp2Extension {
                     limb_bits: 8,
                 };
 
-                let addsub = get_fp2_addsub_air::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let addsub = get_fp2_addsub_air::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config.clone(),
@@ -220,7 +220,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Fp2Extension {
                 );
                 inventory.add_air(addsub);
 
-                let muldiv = get_fp2_muldiv_air::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let muldiv = get_fp2_muldiv_air::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config,
@@ -237,7 +237,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Fp2Extension {
                     limb_bits: 8,
                 };
 
-                let addsub = get_fp2_addsub_air::<FP2_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let addsub = get_fp2_addsub_air::<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config.clone(),
@@ -248,7 +248,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Fp2Extension {
                 );
                 inventory.add_air(addsub);
 
-                let muldiv = get_fp2_muldiv_air::<FP2_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let muldiv = get_fp2_muldiv_air::<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config,
@@ -310,8 +310,8 @@ where
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_fp2_addsub_chip::<Val<SC>, FP2_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub = get_fp2_addsub_chip::<Val<SC>, FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -320,8 +320,8 @@ where
                 );
                 inventory.add_executor_chip(addsub);
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_fp2_muldiv_chip::<Val<SC>, FP2_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv = get_fp2_muldiv_chip::<Val<SC>, FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -336,8 +336,8 @@ where
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_fp2_addsub_chip::<Val<SC>, FP2_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub = get_fp2_addsub_chip::<Val<SC>, FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -346,8 +346,8 @@ where
                 );
                 inventory.add_executor_chip(addsub);
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_fp2_muldiv_chip::<Val<SC>, FP2_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv = get_fp2_muldiv_chip::<Val<SC>, FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),

--- a/extensions/algebra/circuit/src/extension/hybrid.rs
+++ b/extensions/algebra/circuit/src/extension/hybrid.rs
@@ -2,7 +2,7 @@
 
 use openvm_algebra_transpiler::Rv32ModularArithmeticOpcode;
 use openvm_circuit::{
-    arch::{CONST_BLOCK_SIZE, *},
+    arch::{DEFAULT_BLOCK_SIZE, *},
     system::{
         cuda::{
             extensions::{
@@ -166,8 +166,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, ModularExte
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_modular_addsub_chip::<F, MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub = get_modular_addsub_chip::<F, MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -176,8 +176,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, ModularExte
                 );
                 inventory.add_executor_chip(HybridModularChip::new(addsub));
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_modular_muldiv_chip::<F, MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv = get_modular_muldiv_chip::<F, MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -193,11 +193,11 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, ModularExte
                         0
                     }
                 });
-                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>>()?;
+                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>>()?;
                 let is_eq = ModularIsEqualChip::<
                     F,
                     MODULAR_BLOCKS_32,
-                    CONST_BLOCK_SIZE,
+                    DEFAULT_BLOCK_SIZE,
                     NUM_LIMBS_32,
                 >::new(
                     ModularIsEqualFiller::new(
@@ -216,8 +216,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, ModularExte
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_modular_addsub_chip::<F, MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub = get_modular_addsub_chip::<F, MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -226,8 +226,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, ModularExte
                 );
                 inventory.add_executor_chip(HybridModularChip::new(addsub));
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_modular_muldiv_chip::<F, MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv = get_modular_muldiv_chip::<F, MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -243,11 +243,11 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, ModularExte
                         0
                     }
                 });
-                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>>()?;
+                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>>()?;
                 let is_eq = ModularIsEqualChip::<
                     F,
                     MODULAR_BLOCKS_48,
-                    CONST_BLOCK_SIZE,
+                    DEFAULT_BLOCK_SIZE,
                     NUM_LIMBS_48,
                 >::new(
                     ModularIsEqualFiller::new(
@@ -342,8 +342,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Fp2Extensio
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_fp2_addsub_chip::<F, FP2_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub = get_fp2_addsub_chip::<F, FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -352,8 +352,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Fp2Extensio
                 );
                 inventory.add_executor_chip(HybridFp2Chip::new(addsub));
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_fp2_muldiv_chip::<F, FP2_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv = get_fp2_muldiv_chip::<F, FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -368,8 +368,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Fp2Extensio
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_fp2_addsub_chip::<F, FP2_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub = get_fp2_addsub_chip::<F, FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -378,8 +378,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Fp2Extensio
                 );
                 inventory.add_executor_chip(HybridFp2Chip::new(addsub));
 
-                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_fp2_muldiv_chip::<F, FP2_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<Fp2Air<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv = get_fp2_muldiv_chip::<F, FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),

--- a/extensions/algebra/circuit/src/extension/modular.rs
+++ b/extensions/algebra/circuit/src/extension/modular.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
     arch::{
         AirInventory, AirInventoryError, ChipInventory, ChipInventoryError, ExecutionBridge,
         ExecutorInventoryBuilder, ExecutorInventoryError, RowMajorMatrixArena, VmCircuitExtension,
-        VmExecutionExtension, VmProverExtension, CONST_BLOCK_SIZE,
+        VmExecutionExtension, VmProverExtension, DEFAULT_BLOCK_SIZE,
     },
     system::{memory::SharedMemoryHelper, SystemPort},
 };
@@ -74,17 +74,17 @@ impl ModularExtension {
 )]
 pub enum ModularExtensionExecutor {
     // 32 limbs prime
-    ModularAddSubRv32_32(ModularExecutor<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>), // ModularAddSub
-    ModularMulDivRv32_32(ModularExecutor<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>), // ModularMulDiv
+    ModularAddSubRv32_32(ModularExecutor<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>), // ModularAddSub
+    ModularMulDivRv32_32(ModularExecutor<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>), // ModularMulDiv
     ModularIsEqualRv32_32(
-        VmModularIsEqualExecutor<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>,
-    ), // ModularIsEqual
+        VmModularIsEqualExecutor<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>,
+    ), /* ModularIsEqual */
     // 48 limbs prime
-    ModularAddSubRv32_48(ModularExecutor<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>), // ModularAddSub
-    ModularMulDivRv32_48(ModularExecutor<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>), // ModularMulDiv
+    ModularAddSubRv32_48(ModularExecutor<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>), // ModularAddSub
+    ModularMulDivRv32_48(ModularExecutor<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>), // ModularMulDiv
     ModularIsEqualRv32_48(
-        VmModularIsEqualExecutor<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>,
-    ), // ModularIsEqual
+        VmModularIsEqualExecutor<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>,
+    ), /* ModularIsEqual */
 }
 
 impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
@@ -109,7 +109,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
                     num_limbs: NUM_LIMBS_32,
                     limb_bits: 8,
                 };
-                let addsub = get_modular_addsub_step::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let addsub = get_modular_addsub_step::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     dummy_range_checker_bus,
                     pointer_max_bits,
@@ -123,7 +123,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
                         .map(|x| VmOpcode::from_usize(x + start_offset)),
                 )?;
 
-                let muldiv = get_modular_muldiv_step::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let muldiv = get_modular_muldiv_step::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config,
                     dummy_range_checker_bus,
                     pointer_max_bits,
@@ -163,7 +163,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
                     num_limbs: NUM_LIMBS_48,
                     limb_bits: 8,
                 };
-                let addsub = get_modular_addsub_step::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let addsub = get_modular_addsub_step::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     dummy_range_checker_bus,
                     pointer_max_bits,
@@ -177,7 +177,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for ModularExtension {
                         .map(|x| VmOpcode::from_usize(x + start_offset)),
                 )?;
 
-                let muldiv = get_modular_muldiv_step::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let muldiv = get_modular_muldiv_step::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config,
                     dummy_range_checker_bus,
                     pointer_max_bits,
@@ -269,7 +269,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for ModularExtension {
                     limb_bits: 8,
                 };
 
-                let addsub = get_modular_addsub_air::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let addsub = get_modular_addsub_air::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config.clone(),
@@ -280,7 +280,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for ModularExtension {
                 );
                 inventory.add_air(addsub);
 
-                let muldiv = get_modular_muldiv_air::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let muldiv = get_modular_muldiv_air::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config,
@@ -292,7 +292,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for ModularExtension {
                 inventory.add_air(muldiv);
 
                 let is_eq =
-                    ModularIsEqualAir::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>::new(
+                    ModularIsEqualAir::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>::new(
                         Rv32IsEqualModAdapterAir::new(
                             exec_bridge,
                             memory_bridge,
@@ -309,7 +309,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for ModularExtension {
                     limb_bits: 8,
                 };
 
-                let addsub = get_modular_addsub_air::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let addsub = get_modular_addsub_air::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config.clone(),
@@ -320,7 +320,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for ModularExtension {
                 );
                 inventory.add_air(addsub);
 
-                let muldiv = get_modular_muldiv_air::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let muldiv = get_modular_muldiv_air::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config,
@@ -332,7 +332,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for ModularExtension {
                 inventory.add_air(muldiv);
 
                 let is_eq =
-                    ModularIsEqualAir::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>::new(
+                    ModularIsEqualAir::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>::new(
                         Rv32IsEqualModAdapterAir::new(
                             exec_bridge,
                             memory_bridge,
@@ -398,24 +398,26 @@ where
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_modular_addsub_chip::<Val<SC>, MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
-                    config.clone(),
-                    mem_helper.clone(),
-                    range_checker.clone(),
-                    bitwise_lu.clone(),
-                    pointer_max_bits,
-                );
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub =
+                    get_modular_addsub_chip::<Val<SC>, MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
+                        config.clone(),
+                        mem_helper.clone(),
+                        range_checker.clone(),
+                        bitwise_lu.clone(),
+                        pointer_max_bits,
+                    );
                 inventory.add_executor_chip(addsub);
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_modular_muldiv_chip::<Val<SC>, MODULAR_BLOCKS_32, CONST_BLOCK_SIZE>(
-                    config,
-                    mem_helper.clone(),
-                    range_checker.clone(),
-                    bitwise_lu.clone(),
-                    pointer_max_bits,
-                );
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv =
+                    get_modular_muldiv_chip::<Val<SC>, MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
+                        config,
+                        mem_helper.clone(),
+                        range_checker.clone(),
+                        bitwise_lu.clone(),
+                        pointer_max_bits,
+                    );
                 inventory.add_executor_chip(muldiv);
 
                 let modulus_limbs = array::from_fn(|i| {
@@ -425,11 +427,11 @@ where
                         0
                     }
                 });
-                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>>()?;
+                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>>()?;
                 let is_eq = ModularIsEqualChip::<
                     Val<SC>,
                     MODULAR_BLOCKS_32,
-                    CONST_BLOCK_SIZE,
+                    DEFAULT_BLOCK_SIZE,
                     NUM_LIMBS_32,
                 >::new(
                     ModularIsEqualFiller::new(
@@ -448,24 +450,26 @@ where
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let addsub = get_modular_addsub_chip::<Val<SC>, MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
-                    config.clone(),
-                    mem_helper.clone(),
-                    range_checker.clone(),
-                    bitwise_lu.clone(),
-                    pointer_max_bits,
-                );
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let addsub =
+                    get_modular_addsub_chip::<Val<SC>, MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
+                        config.clone(),
+                        mem_helper.clone(),
+                        range_checker.clone(),
+                        bitwise_lu.clone(),
+                        pointer_max_bits,
+                    );
                 inventory.add_executor_chip(addsub);
 
-                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let muldiv = get_modular_muldiv_chip::<Val<SC>, MODULAR_BLOCKS_48, CONST_BLOCK_SIZE>(
-                    config,
-                    mem_helper.clone(),
-                    range_checker.clone(),
-                    bitwise_lu.clone(),
-                    pointer_max_bits,
-                );
+                inventory.next_air::<ModularAir<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let muldiv =
+                    get_modular_muldiv_chip::<Val<SC>, MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
+                        config,
+                        mem_helper.clone(),
+                        range_checker.clone(),
+                        bitwise_lu.clone(),
+                        pointer_max_bits,
+                    );
                 inventory.add_executor_chip(muldiv);
 
                 let modulus_limbs = array::from_fn(|i| {
@@ -475,11 +479,11 @@ where
                         0
                     }
                 });
-                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>>()?;
+                inventory.next_air::<ModularIsEqualAir<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>>()?;
                 let is_eq = ModularIsEqualChip::<
                     Val<SC>,
                     MODULAR_BLOCKS_48,
-                    CONST_BLOCK_SIZE,
+                    DEFAULT_BLOCK_SIZE,
                     NUM_LIMBS_48,
                 >::new(
                     ModularIsEqualFiller::new(

--- a/extensions/algebra/circuit/src/fp2_chip/tests.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/tests.rs
@@ -8,7 +8,7 @@ use openvm_circuit::arch::{
     testing::{
         memory::gen_pointer, TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
     },
-    Arena, PreflightExecutor, CONST_BLOCK_SIZE,
+    Arena, PreflightExecutor, DEFAULT_BLOCK_SIZE,
 };
 use openvm_circuit_primitives::{
     bigint::utils::secp256k1_coord_prime,
@@ -273,42 +273,42 @@ struct TestConfig<const BLOCKS: usize, const BLOCK_SIZE: usize, const NUM_LIMBS:
     pub num_ops: usize,
 }
 
-#[test_case(TestConfig::<{FP2_BLOCKS_32}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_32}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
     BigUint::from_str("357686312646216567629137").unwrap(),
     true,
     50,
 ))]
-#[test_case(TestConfig::<{FP2_BLOCKS_32}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_32}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
     secp256k1_coord_prime(),
     true,
     50,
 ))]
-#[test_case(TestConfig::<{FP2_BLOCKS_32}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_32}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
     BN254_MODULUS.clone(),
     true,
     50,
 ))]
-#[test_case(TestConfig::<{FP2_BLOCKS_48}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_48}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_48}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_48}>::new(
     BLS12_381_MODULUS.clone(),
     true,
     50,
 ))]
-#[test_case(TestConfig::<{FP2_BLOCKS_32}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_32}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
     BigUint::from_str("357686312646216567629137").unwrap(),
     false,
     50,
 ))]
-#[test_case(TestConfig::<{FP2_BLOCKS_32}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_32}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
     secp256k1_coord_prime(),
     false,
     50,
 ))]
-#[test_case(TestConfig::<{FP2_BLOCKS_32}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_32}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_32}>::new(
     BN254_MODULUS.clone(),
     false,
     50,
 ))]
-#[test_case(TestConfig::<{FP2_BLOCKS_48}, {CONST_BLOCK_SIZE}, {NUM_LIMBS_48}>::new(
+#[test_case(TestConfig::<{FP2_BLOCKS_48}, {DEFAULT_BLOCK_SIZE}, {NUM_LIMBS_48}>::new(
     BLS12_381_MODULUS.clone(),
     false,
     50,
@@ -466,53 +466,53 @@ mod cuda_tests {
         GpuTestChipHarness::with_capacity(executor, air, hybrid_chip, cpu_chip, MAX_INS_CAPACITY)
     }
 
-    #[test_case(TestConfig::<FP2_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>::new(
     BigUint::from_str("357686312646216567629137").unwrap(),
     true,
     50),
-    create_addsub_cuda_test_harness::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>
+    create_addsub_cuda_test_harness::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>
 )]
-    #[test_case(TestConfig::<FP2_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>::new(
     secp256k1_coord_prime(),
     true,
     50),
-    create_addsub_cuda_test_harness::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>
+    create_addsub_cuda_test_harness::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>
 )]
-    #[test_case(TestConfig::<FP2_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>::new(
     BN254_MODULUS.clone(),
     true,
     50),
-    create_addsub_cuda_test_harness::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>
+    create_addsub_cuda_test_harness::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>
 )]
-    #[test_case(TestConfig::<FP2_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>::new(
     BLS12_381_MODULUS.clone(),
     true,
     50),
-    create_addsub_cuda_test_harness::<FP2_BLOCKS_48, CONST_BLOCK_SIZE>
+    create_addsub_cuda_test_harness::<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>
 )]
-    #[test_case(TestConfig::<FP2_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>::new(
     BigUint::from_str("357686312646216567629137").unwrap(),
     false,
     50),
-    create_muldiv_cuda_test_harness::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>
+    create_muldiv_cuda_test_harness::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>
 )]
-    #[test_case(TestConfig::<FP2_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>::new(
     secp256k1_coord_prime(),
     false,
     50),
-    create_muldiv_cuda_test_harness::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>
+    create_muldiv_cuda_test_harness::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>
 )]
-    #[test_case(TestConfig::<FP2_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>::new(
     BN254_MODULUS.clone(),
     false,
     50),
-    create_muldiv_cuda_test_harness::<FP2_BLOCKS_32, CONST_BLOCK_SIZE>
+    create_muldiv_cuda_test_harness::<FP2_BLOCKS_32, DEFAULT_BLOCK_SIZE>
 )]
-    #[test_case(TestConfig::<FP2_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>::new(
+    #[test_case(TestConfig::<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>::new(
     BLS12_381_MODULUS.clone(),
     false,
     50),
-    create_muldiv_cuda_test_harness::<FP2_BLOCKS_48, CONST_BLOCK_SIZE>
+    create_muldiv_cuda_test_harness::<FP2_BLOCKS_48, DEFAULT_BLOCK_SIZE>
 )]
     fn run_cuda_test_with_config<
         const BLOCKS: usize,

--- a/extensions/algebra/circuit/src/lib.rs
+++ b/extensions/algebra/circuit/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use openvm_circuit::arch::CONST_BLOCK_SIZE;
+use openvm_circuit::arch::DEFAULT_BLOCK_SIZE;
 use openvm_mod_circuit_builder::FieldExpressionExecutor;
 use openvm_rv32_adapters::Rv32VecHeapAdapterExecutor;
 #[cfg(feature = "cuda")]
@@ -22,9 +22,9 @@ pub const NUM_LIMBS_48: usize = 48;
 
 // Blocks per operation for modular arithmetic (single field element)
 /// Blocks for 32-limb modular operations: 32 / 4 = 8 blocks
-pub const MODULAR_BLOCKS_32: usize = NUM_LIMBS_32 / CONST_BLOCK_SIZE;
+pub const MODULAR_BLOCKS_32: usize = NUM_LIMBS_32 / DEFAULT_BLOCK_SIZE;
 /// Blocks for 48-limb modular operations: 48 / 4 = 12 blocks
-pub const MODULAR_BLOCKS_48: usize = NUM_LIMBS_48 / CONST_BLOCK_SIZE;
+pub const MODULAR_BLOCKS_48: usize = NUM_LIMBS_48 / DEFAULT_BLOCK_SIZE;
 
 // Blocks per operation for Fp2 (two field elements)
 /// Blocks for Fp2 with 32-limb base field: 2 * 8 = 16 blocks

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -8,7 +8,7 @@ use openvm_circuit::arch::{
     testing::{
         memory::gen_pointer, TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
     },
-    Arena, PreflightExecutor, CONST_BLOCK_SIZE,
+    Arena, PreflightExecutor, DEFAULT_BLOCK_SIZE,
 };
 use openvm_circuit_primitives::{
     bigint::utils::{secp256k1_coord_prime, secp256k1_scalar_prime},
@@ -304,7 +304,7 @@ mod addsub_tests {
 
     #[test]
     fn test_modular_addsub_32limb_small() {
-        run_addsub_test::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_addsub_test::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BigUint::from_str("357686312646216567629137").unwrap(),
             50,
@@ -313,12 +313,12 @@ mod addsub_tests {
 
     #[test]
     fn test_modular_addsub_32limb_secp256k1() {
-        run_addsub_test::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_addsub_test::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             secp256k1_coord_prime(),
             50,
         );
-        run_addsub_test::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_addsub_test::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             4,
             secp256k1_scalar_prime(),
             50,
@@ -327,7 +327,7 @@ mod addsub_tests {
 
     #[test]
     fn test_modular_addsub_32limb_bn254() {
-        run_addsub_test::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_addsub_test::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BN254_MODULUS.clone(),
             50,
@@ -336,7 +336,7 @@ mod addsub_tests {
 
     #[test]
     fn test_modular_addsub_48limb_bls12_381() {
-        run_addsub_test::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_addsub_test::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             0,
             BLS12_381_MODULUS.clone(),
             50,
@@ -400,27 +400,27 @@ mod addsub_tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn cuda_test_modular_addsub() {
-        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BigUint::from_str("357686312646216567629137").unwrap(),
             50,
         );
-        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             secp256k1_coord_prime(),
             50,
         );
-        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             4,
             secp256k1_scalar_prime(),
             50,
         );
-        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BN254_MODULUS.clone(),
             50,
         );
-        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_cuda_addsub_test_with_config::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             0,
             BLS12_381_MODULUS.clone(),
             50,
@@ -677,7 +677,7 @@ mod muldiv_tests {
 
     #[test]
     fn test_modular_muldiv_32limb_small() {
-        run_test_muldiv::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_test_muldiv::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BigUint::from_str("357686312646216567629137").unwrap(),
             50,
@@ -686,12 +686,12 @@ mod muldiv_tests {
 
     #[test]
     fn test_modular_muldiv_32limb_secp256k1() {
-        run_test_muldiv::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_test_muldiv::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             secp256k1_coord_prime(),
             50,
         );
-        run_test_muldiv::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_test_muldiv::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             4,
             secp256k1_scalar_prime(),
             50,
@@ -700,7 +700,7 @@ mod muldiv_tests {
 
     #[test]
     fn test_modular_muldiv_32limb_bn254() {
-        run_test_muldiv::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_test_muldiv::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BN254_MODULUS.clone(),
             50,
@@ -709,7 +709,7 @@ mod muldiv_tests {
 
     #[test]
     fn test_modular_muldiv_48limb_bls12_381() {
-        run_test_muldiv::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_test_muldiv::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             0,
             BLS12_381_MODULUS.clone(),
             50,
@@ -773,27 +773,27 @@ mod muldiv_tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn cuda_test_modular_muldiv() {
-        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BigUint::from_str("357686312646216567629137").unwrap(),
             50,
         );
-        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             secp256k1_coord_prime(),
             50,
         );
-        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             4,
             secp256k1_scalar_prime(),
             50,
         );
-        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             0,
             BN254_MODULUS.clone(),
             50,
         );
-        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_cuda_muldiv_test_with_config::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             0,
             BLS12_381_MODULUS.clone(),
             50,
@@ -981,7 +981,7 @@ mod is_equal_tests {
 
     #[test]
     fn test_modular_is_equal_32limb() {
-        test_is_equal::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        test_is_equal::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             17,
             secp256k1_coord_prime(),
             100,
@@ -990,7 +990,7 @@ mod is_equal_tests {
 
     #[test]
     fn test_modular_is_equal_48limb() {
-        test_is_equal::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        test_is_equal::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             17,
             BLS12_381_MODULUS.clone(),
             100,
@@ -1142,17 +1142,17 @@ mod is_equal_tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn cuda_test_modular_is_equal() {
-        run_cuda_is_equal_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_is_equal_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             17,
             secp256k1_coord_prime(),
             50,
         );
-        run_cuda_is_equal_test_with_config::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_is_equal_test_with_config::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             17,
             secp256k1_scalar_prime(),
             50,
         );
-        run_cuda_is_equal_test_with_config::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_cuda_is_equal_test_with_config::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             17,
             BLS12_381_MODULUS.clone(),
             50,
@@ -1255,19 +1255,19 @@ mod is_equal_tests {
 
     #[test]
     fn negative_test_modular_is_equal_32limb() {
-        run_negative_is_equal_test::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_negative_is_equal_test::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             secp256k1_coord_prime(),
             17,
             1,
         );
 
-        run_negative_is_equal_test::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_negative_is_equal_test::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             secp256k1_coord_prime(),
             17,
             2,
         );
 
-        run_negative_is_equal_test::<MODULAR_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_negative_is_equal_test::<MODULAR_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             secp256k1_coord_prime(),
             17,
             3,
@@ -1276,19 +1276,19 @@ mod is_equal_tests {
 
     #[test]
     fn negative_test_modular_is_equal_48limb() {
-        run_negative_is_equal_test::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_negative_is_equal_test::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             BLS12_381_MODULUS.clone(),
             17,
             1,
         );
 
-        run_negative_is_equal_test::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_negative_is_equal_test::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             BLS12_381_MODULUS.clone(),
             17,
             2,
         );
 
-        run_negative_is_equal_test::<MODULAR_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_negative_is_equal_test::<MODULAR_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             BLS12_381_MODULUS.clone(),
             17,
             3,

--- a/extensions/bigint/circuit/src/common.rs
+++ b/extensions/bigint/circuit/src/common.rs
@@ -1,5 +1,5 @@
 use openvm_circuit::{
-    arch::{ExecutionCtxTrait, VmExecState, CONST_BLOCK_SIZE},
+    arch::{ExecutionCtxTrait, VmExecState, DEFAULT_BLOCK_SIZE},
     system::memory::online::GuestMemory,
 };
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -15,9 +15,9 @@ pub fn read_int256<F: PrimeField32, CTX: ExecutionCtxTrait>(
 ) -> [u8; INT256_NUM_LIMBS] {
     let mut result = [0u8; INT256_NUM_LIMBS];
     for i in 0..INT256_NUM_BLOCKS {
-        let block: [u8; CONST_BLOCK_SIZE] =
-            exec_state.vm_read(addr_space, ptr + (i * CONST_BLOCK_SIZE) as u32);
-        result[i * CONST_BLOCK_SIZE..(i + 1) * CONST_BLOCK_SIZE].copy_from_slice(&block);
+        let block: [u8; DEFAULT_BLOCK_SIZE] =
+            exec_state.vm_read(addr_space, ptr + (i * DEFAULT_BLOCK_SIZE) as u32);
+        result[i * DEFAULT_BLOCK_SIZE..(i + 1) * DEFAULT_BLOCK_SIZE].copy_from_slice(&block);
     }
     result
 }
@@ -31,10 +31,11 @@ pub fn write_int256<F: PrimeField32, CTX: ExecutionCtxTrait>(
     data: &[u8; INT256_NUM_LIMBS],
 ) {
     for i in 0..INT256_NUM_BLOCKS {
-        let block: [u8; CONST_BLOCK_SIZE] = data[i * CONST_BLOCK_SIZE..(i + 1) * CONST_BLOCK_SIZE]
+        let block: [u8; DEFAULT_BLOCK_SIZE] = data
+            [i * DEFAULT_BLOCK_SIZE..(i + 1) * DEFAULT_BLOCK_SIZE]
             .try_into()
             .unwrap();
-        exec_state.vm_write(addr_space, ptr + (i * CONST_BLOCK_SIZE) as u32, &block);
+        exec_state.vm_write(addr_space, ptr + (i * DEFAULT_BLOCK_SIZE) as u32, &block);
     }
 }
 

--- a/extensions/bigint/circuit/src/cuda/mod.rs
+++ b/extensions/bigint/circuit/src/cuda/mod.rs
@@ -2,7 +2,7 @@ use std::{mem::size_of, sync::Arc};
 
 use derive_new::new;
 use openvm_circuit::{
-    arch::{DenseRecordArena, CONST_BLOCK_SIZE},
+    arch::{DenseRecordArena, DEFAULT_BLOCK_SIZE},
     utils::next_power_of_two_or_zero,
 };
 use openvm_circuit_primitives::{
@@ -34,8 +34,8 @@ pub type BaseAlu256AdapterRecord = Rv32VecHeapAdapterRecord<
     2,
     INT256_NUM_BLOCKS,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
 >;
 pub type BaseAlu256CoreRecord = BaseAluCoreRecord<INT256_NUM_LIMBS>;
 
@@ -62,8 +62,8 @@ impl Chip<DenseRecordArena, GpuBackend> for BaseAlu256ChipGpu {
                 2,
                 INT256_NUM_BLOCKS,
                 INT256_NUM_BLOCKS,
-                CONST_BLOCK_SIZE,
-                CONST_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
             >::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
@@ -92,7 +92,7 @@ impl Chip<DenseRecordArena, GpuBackend> for BaseAlu256ChipGpu {
 /// Branch Equal
 //////////////////////////////////////////////////////////////////////////////////////
 pub type BranchEqual256AdapterRecord =
-    Rv32VecHeapBranchAdapterRecord<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>;
+    Rv32VecHeapBranchAdapterRecord<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>;
 pub type BranchEqual256CoreRecord = BranchEqualCoreRecord<INT256_NUM_LIMBS>;
 
 #[derive(new)]
@@ -114,7 +114,7 @@ impl Chip<DenseRecordArena, GpuBackend> for BranchEqual256ChipGpu {
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
         let trace_width = BranchEqualCoreCols::<F, INT256_NUM_LIMBS>::width()
-            + Rv32VecHeapBranchAdapterCols::<F, 2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>::width();
+            + Rv32VecHeapBranchAdapterCols::<F, 2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
         let d_records = records.to_device().unwrap();
@@ -145,8 +145,8 @@ pub type LessThan256AdapterRecord = Rv32VecHeapAdapterRecord<
     2,
     INT256_NUM_BLOCKS,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
 >;
 pub type LessThan256CoreRecord = LessThanCoreRecord<INT256_NUM_LIMBS, RV32_CELL_BITS>;
 
@@ -173,8 +173,8 @@ impl Chip<DenseRecordArena, GpuBackend> for LessThan256ChipGpu {
                 2,
                 INT256_NUM_BLOCKS,
                 INT256_NUM_BLOCKS,
-                CONST_BLOCK_SIZE,
-                CONST_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
             >::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
@@ -203,7 +203,7 @@ impl Chip<DenseRecordArena, GpuBackend> for LessThan256ChipGpu {
 /// Branch Less Than
 //////////////////////////////////////////////////////////////////////////////////////
 pub type BranchLessThan256AdapterRecord =
-    Rv32VecHeapBranchAdapterRecord<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>;
+    Rv32VecHeapBranchAdapterRecord<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>;
 pub type BranchLessThan256CoreRecord = BranchLessThanCoreRecord<INT256_NUM_LIMBS, RV32_CELL_BITS>;
 
 #[derive(new)]
@@ -225,7 +225,7 @@ impl Chip<DenseRecordArena, GpuBackend> for BranchLessThan256ChipGpu {
         debug_assert_eq!(records.len() % RECORD_SIZE, 0);
 
         let trace_width = BranchLessThanCoreCols::<F, INT256_NUM_LIMBS, RV32_CELL_BITS>::width()
-            + Rv32VecHeapBranchAdapterCols::<F, 2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>::width();
+            + Rv32VecHeapBranchAdapterCols::<F, 2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
         let d_records = records.to_device().unwrap();
@@ -256,8 +256,8 @@ pub type Shift256AdapterRecord = Rv32VecHeapAdapterRecord<
     2,
     INT256_NUM_BLOCKS,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
 >;
 pub type Shift256CoreRecord = ShiftCoreRecord<INT256_NUM_LIMBS, RV32_CELL_BITS>;
 
@@ -284,8 +284,8 @@ impl Chip<DenseRecordArena, GpuBackend> for Shift256ChipGpu {
                 2,
                 INT256_NUM_BLOCKS,
                 INT256_NUM_BLOCKS,
-                CONST_BLOCK_SIZE,
-                CONST_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
             >::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 
@@ -317,8 +317,8 @@ pub type Multiplication256AdapterRecord = Rv32VecHeapAdapterRecord<
     2,
     INT256_NUM_BLOCKS,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
 >;
 pub type Multiplication256CoreRecord = MultiplicationCoreRecord<INT256_NUM_LIMBS, RV32_CELL_BITS>;
 
@@ -347,8 +347,8 @@ impl Chip<DenseRecordArena, GpuBackend> for Multiplication256ChipGpu {
                 2,
                 INT256_NUM_BLOCKS,
                 INT256_NUM_BLOCKS,
-                CONST_BLOCK_SIZE,
-                CONST_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
+                DEFAULT_BLOCK_SIZE,
             >::width();
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
 

--- a/extensions/bigint/circuit/src/lib.rs
+++ b/extensions/bigint/circuit/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(feature = "tco", feature(core_intrinsics))]
 use openvm_circuit::{
     self,
-    arch::{InitFileGenerator, SystemConfig, VmAirWrapper, VmChipWrapper, CONST_BLOCK_SIZE},
+    arch::{InitFileGenerator, SystemConfig, VmAirWrapper, VmChipWrapper, DEFAULT_BLOCK_SIZE},
     system::SystemExecutor,
 };
 use openvm_circuit_derive::{PreflightExecutor, VmConfig};
@@ -43,8 +43,8 @@ pub use cuda::*;
 #[cfg(test)]
 mod tests;
 
-/// Number of blocks for INT256 operations (INT256_NUM_LIMBS / CONST_BLOCK_SIZE)
-pub const INT256_NUM_BLOCKS: usize = INT256_NUM_LIMBS / CONST_BLOCK_SIZE;
+/// Number of blocks for INT256 operations (INT256_NUM_LIMBS / DEFAULT_BLOCK_SIZE)
+pub const INT256_NUM_BLOCKS: usize = INT256_NUM_LIMBS / DEFAULT_BLOCK_SIZE;
 
 /// Type alias for the ALU adapter AIR wrapper
 type AluAdapterAir = VecToFlatAluAdapterAir<
@@ -52,13 +52,13 @@ type AluAdapterAir = VecToFlatAluAdapterAir<
         2,
         INT256_NUM_BLOCKS,
         INT256_NUM_BLOCKS,
-        CONST_BLOCK_SIZE,
-        CONST_BLOCK_SIZE,
+        DEFAULT_BLOCK_SIZE,
+        DEFAULT_BLOCK_SIZE,
     >,
     2,
     INT256_NUM_BLOCKS,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
     INT256_NUM_LIMBS,
     INT256_NUM_LIMBS,
 >;
@@ -69,32 +69,32 @@ type AluAdapterExecutor = VecToFlatAluAdapterExecutor<
         2,
         INT256_NUM_BLOCKS,
         INT256_NUM_BLOCKS,
-        CONST_BLOCK_SIZE,
-        CONST_BLOCK_SIZE,
+        DEFAULT_BLOCK_SIZE,
+        DEFAULT_BLOCK_SIZE,
     >,
     2,
     INT256_NUM_BLOCKS,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
     INT256_NUM_LIMBS,
     INT256_NUM_LIMBS,
 >;
 
 /// Type alias for the Branch adapter AIR wrapper
 type BranchAdapterAir = VecToFlatBranchAdapterAir<
-    Rv32VecHeapBranchAdapterAir<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>,
+    Rv32VecHeapBranchAdapterAir<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>,
     2,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
     INT256_NUM_LIMBS,
 >;
 
 /// Type alias for the Branch adapter executor wrapper
 type BranchAdapterExecutor = VecToFlatBranchAdapterExecutor<
-    Rv32VecHeapBranchAdapterExecutor<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>,
+    Rv32VecHeapBranchAdapterExecutor<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>,
     2,
     INT256_NUM_BLOCKS,
-    CONST_BLOCK_SIZE,
+    DEFAULT_BLOCK_SIZE,
     INT256_NUM_LIMBS,
 >;
 
@@ -112,8 +112,8 @@ pub type Rv32BaseAlu256Chip<F> = VmChipWrapper<
             2,
             INT256_NUM_BLOCKS,
             INT256_NUM_BLOCKS,
-            CONST_BLOCK_SIZE,
-            CONST_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
         >,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
@@ -134,8 +134,8 @@ pub type Rv32LessThan256Chip<F> = VmChipWrapper<
             2,
             INT256_NUM_BLOCKS,
             INT256_NUM_BLOCKS,
-            CONST_BLOCK_SIZE,
-            CONST_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
         >,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
@@ -156,8 +156,8 @@ pub type Rv32Multiplication256Chip<F> = VmChipWrapper<
             2,
             INT256_NUM_BLOCKS,
             INT256_NUM_BLOCKS,
-            CONST_BLOCK_SIZE,
-            CONST_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
         >,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
@@ -178,8 +178,8 @@ pub type Rv32Shift256Chip<F> = VmChipWrapper<
             2,
             INT256_NUM_BLOCKS,
             INT256_NUM_BLOCKS,
-            CONST_BLOCK_SIZE,
-            CONST_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
+            DEFAULT_BLOCK_SIZE,
         >,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
@@ -194,7 +194,7 @@ pub struct Rv32BranchEqual256Executor(BranchEqualExecutor<BranchAdapterExecutor,
 pub type Rv32BranchEqual256Chip<F> = VmChipWrapper<
     F,
     BranchEqualFiller<
-        Rv32VecHeapBranchAdapterFiller<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>,
+        Rv32VecHeapBranchAdapterFiller<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>,
         INT256_NUM_LIMBS,
     >,
 >;
@@ -209,7 +209,7 @@ pub struct Rv32BranchLessThan256Executor(
 pub type Rv32BranchLessThan256Chip<F> = VmChipWrapper<
     F,
     BranchLessThanFiller<
-        Rv32VecHeapBranchAdapterFiller<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>,
+        Rv32VecHeapBranchAdapterFiller<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>,
         INT256_NUM_LIMBS,
         RV32_CELL_BITS,
     >,

--- a/extensions/bigint/circuit/src/tests.rs
+++ b/extensions/bigint/circuit/src/tests.rs
@@ -58,7 +58,7 @@ use {
             default_bitwise_lookup_bus, default_var_range_checker_bus, GpuChipTestBuilder,
             GpuTestChipHarness,
         },
-        EmptyAdapterCoreLayout, CONST_BLOCK_SIZE,
+        EmptyAdapterCoreLayout, DEFAULT_BLOCK_SIZE,
     },
 };
 
@@ -919,7 +919,7 @@ fn run_beq_256_rand_test_cuda(opcode: BranchEqualOpcode, num_ops: usize) {
             &mut harness.matrix_arena,
             EmptyAdapterCoreLayout::<
                 F,
-                Rv32VecHeapBranchAdapterExecutor<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>,
+                Rv32VecHeapBranchAdapterExecutor<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>,
             >::new(),
         );
 
@@ -985,7 +985,7 @@ fn run_blt_256_rand_test_cuda(opcode: BranchLessThanOpcode, num_ops: usize) {
             &mut harness.matrix_arena,
             EmptyAdapterCoreLayout::<
                 F,
-                Rv32VecHeapBranchAdapterExecutor<2, INT256_NUM_BLOCKS, CONST_BLOCK_SIZE>,
+                Rv32VecHeapBranchAdapterExecutor<2, INT256_NUM_BLOCKS, DEFAULT_BLOCK_SIZE>,
             >::new(),
         );
 

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -3,7 +3,7 @@ use std::{array::from_fn, borrow::Borrow};
 use openvm_circuit::{
     arch::{
         AdapterAirContext, ExecutionBridge, ExecutionState, ImmInstruction, VmAdapterAir,
-        VmAdapterInterface, VmCoreAir,
+        VmAdapterInterface, VmCoreAir, DEFAULT_BLOCK_SIZE,
     },
     system::memory::{
         offline_checker::{MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxCols},
@@ -30,7 +30,7 @@ use crate::{
     poseidon2::DeferralPoseidon2Bus,
     utils::{
         byte_commit_to_f, bytes_to_f, combine_output, split_memory_ops, COMMIT_MEMORY_OPS,
-        COMMIT_NUM_BYTES, DIGEST_MEMORY_OPS, F_NUM_BYTES, MEMORY_OP_SIZE, OUTPUT_TOTAL_BYTES,
+        COMMIT_NUM_BYTES, DIGEST_MEMORY_OPS, F_NUM_BYTES, OUTPUT_TOTAL_BYTES,
         OUTPUT_TOTAL_MEMORY_OPS,
     },
 };
@@ -182,9 +182,10 @@ pub struct DeferralCallAdapterCols<T> {
     pub old_output_acc_aux: [MemoryReadAuxCols<T>; DIGEST_MEMORY_OPS],
 
     // Write auxiliary columns
-    pub output_commit_and_len_aux: [MemoryWriteAuxCols<T, MEMORY_OP_SIZE>; OUTPUT_TOTAL_MEMORY_OPS],
-    pub new_input_acc_aux: [MemoryWriteAuxCols<T, MEMORY_OP_SIZE>; DIGEST_MEMORY_OPS],
-    pub new_output_acc_aux: [MemoryWriteAuxCols<T, MEMORY_OP_SIZE>; DIGEST_MEMORY_OPS],
+    pub output_commit_and_len_aux:
+        [MemoryWriteAuxCols<T, DEFAULT_BLOCK_SIZE>; OUTPUT_TOTAL_MEMORY_OPS],
+    pub new_input_acc_aux: [MemoryWriteAuxCols<T, DEFAULT_BLOCK_SIZE>; DIGEST_MEMORY_OPS],
+    pub new_output_acc_aux: [MemoryWriteAuxCols<T, DEFAULT_BLOCK_SIZE>; DIGEST_MEMORY_OPS],
 }
 
 #[derive(Clone, Copy, Debug, derive_new::new)]
@@ -284,7 +285,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 .read(
                     MemoryAddress::new(
                         e.clone(),
-                        input_ptr.clone() + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                        input_ptr.clone() + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     timestamp_pp(),
@@ -304,7 +305,8 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 .read(
                     MemoryAddress::new(
                         deferral_as.clone(),
-                        input_acc_ptr.clone() + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                        input_acc_ptr.clone()
+                            + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     timestamp_pp(),
@@ -324,7 +326,8 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 .read(
                     MemoryAddress::new(
                         deferral_as.clone(),
-                        output_acc_ptr.clone() + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                        output_acc_ptr.clone()
+                            + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     timestamp_pp(),
@@ -347,7 +350,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 .write(
                     MemoryAddress::new(
                         e.clone(),
-                        output_ptr.clone() + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                        output_ptr.clone() + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     timestamp_pp(),
@@ -367,7 +370,8 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 .write(
                     MemoryAddress::new(
                         deferral_as.clone(),
-                        input_acc_ptr.clone() + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                        input_acc_ptr.clone()
+                            + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     timestamp_pp(),
@@ -387,7 +391,8 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 .write(
                     MemoryAddress::new(
                         deferral_as.clone(),
-                        output_acc_ptr.clone() + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                        output_acc_ptr.clone()
+                            + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     timestamp_pp(),

--- a/extensions/deferral/circuit/src/call/execution.rs
+++ b/extensions/deferral/circuit/src/call/execution.rs
@@ -24,7 +24,7 @@ use crate::{
     poseidon2::deferral_poseidon2_chip,
     utils::{
         byte_commit_to_f, combine_output, join_memory_ops, memory_op_chunk, COMMIT_MEMORY_OPS,
-        COMMIT_NUM_BYTES, DIGEST_MEMORY_OPS, MEMORY_OP_SIZE, OUTPUT_TOTAL_MEMORY_OPS,
+        COMMIT_NUM_BYTES, DIGEST_MEMORY_OPS, OUTPUT_TOTAL_MEMORY_OPS,
     },
     DeferralFn, CALL_AIR_REL_IDX, POSEIDON2_AIR_REL_IDX,
 };
@@ -176,20 +176,21 @@ unsafe fn execute_e12_impl<F: VmField, CTX: ExecutionCtxTrait>(
     let output_ptr = u32::from_le_bytes(exec_state.vm_read(RV32_REGISTER_AS, pre_compute.rd_ptr));
     let input_ptr = u32::from_le_bytes(exec_state.vm_read(RV32_REGISTER_AS, pre_compute.rs_ptr));
 
-    let input_commit_chunks: [[u8; MEMORY_OP_SIZE]; COMMIT_MEMORY_OPS] =
-        from_fn(|i| exec_state.vm_read(RV32_MEMORY_AS, input_ptr + (i * MEMORY_OP_SIZE) as u32));
+    let input_commit_chunks: [[u8; DEFAULT_BLOCK_SIZE]; COMMIT_MEMORY_OPS] = from_fn(|i| {
+        exec_state.vm_read(RV32_MEMORY_AS, input_ptr + (i * DEFAULT_BLOCK_SIZE) as u32)
+    });
     let input_commit_bytes: [_; COMMIT_NUM_BYTES] = join_memory_ops(input_commit_chunks);
     let input_commit: [F; _] = byte_commit_to_f(&input_commit_bytes.map(F::from_u8));
-    let old_input_acc_chunks: [[F; MEMORY_OP_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
+    let old_input_acc_chunks: [[F; DEFAULT_BLOCK_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
         exec_state.vm_read(
             DEFERRAL_AS,
-            pre_compute.input_acc_ptr + (i * MEMORY_OP_SIZE) as u32,
+            pre_compute.input_acc_ptr + (i * DEFAULT_BLOCK_SIZE) as u32,
         )
     });
-    let old_output_acc_chunks: [[F; MEMORY_OP_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
+    let old_output_acc_chunks: [[F; DEFAULT_BLOCK_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
         exec_state.vm_read(
             DEFERRAL_AS,
-            pre_compute.output_acc_ptr + (i * MEMORY_OP_SIZE) as u32,
+            pre_compute.output_acc_ptr + (i * DEFAULT_BLOCK_SIZE) as u32,
         )
     });
     let old_input_acc = join_memory_ops(old_input_acc_chunks);
@@ -212,23 +213,23 @@ unsafe fn execute_e12_impl<F: VmField, CTX: ExecutionCtxTrait>(
     let new_output_acc = poseidon2_chip.compress(&old_output_acc, &output_f_commit);
 
     for chunk_idx in 0..OUTPUT_TOTAL_MEMORY_OPS {
-        exec_state.vm_write::<u8, MEMORY_OP_SIZE>(
+        exec_state.vm_write::<u8, DEFAULT_BLOCK_SIZE>(
             RV32_MEMORY_AS,
-            output_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+            output_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
             &memory_op_chunk(&output_key, chunk_idx),
         );
     }
     for chunk_idx in 0..DIGEST_MEMORY_OPS {
-        exec_state.vm_write::<F, MEMORY_OP_SIZE>(
+        exec_state.vm_write::<F, DEFAULT_BLOCK_SIZE>(
             DEFERRAL_AS,
-            pre_compute.input_acc_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+            pre_compute.input_acc_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
             &memory_op_chunk(&new_input_acc, chunk_idx),
         );
     }
     for chunk_idx in 0..DIGEST_MEMORY_OPS {
-        exec_state.vm_write::<F, MEMORY_OP_SIZE>(
+        exec_state.vm_write::<F, DEFAULT_BLOCK_SIZE>(
             DEFERRAL_AS,
-            pre_compute.output_acc_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+            pre_compute.output_acc_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
             &memory_op_chunk(&new_output_acc, chunk_idx),
         );
     }

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -6,7 +6,7 @@ use openvm_circuit::{
         get_record_from_slice,
         hasher::{Hasher, HasherChip},
         AdapterTraceExecutor, AdapterTraceFiller, EmptyAdapterCoreLayout, ExecutionError,
-        PreflightExecutor, RecordArena, TraceFiller, VmField, VmStateMut,
+        PreflightExecutor, RecordArena, TraceFiller, VmField, VmStateMut, DEFAULT_BLOCK_SIZE,
     },
     system::memory::{
         offline_checker::{MemoryReadAuxRecord, MemoryWriteAuxRecord, MemoryWriteBytesAuxRecord},
@@ -33,7 +33,7 @@ use crate::{
     poseidon2::{deferral_poseidon2_chip, DeferralPoseidon2Chip},
     utils::{
         byte_commit_to_f, combine_output, join_memory_ops, memory_op_chunk, COMMIT_MEMORY_OPS,
-        DIGEST_MEMORY_OPS, F_NUM_BYTES, MEMORY_OP_SIZE, OUTPUT_TOTAL_MEMORY_OPS,
+        DIGEST_MEMORY_OPS, F_NUM_BYTES, OUTPUT_TOTAL_MEMORY_OPS,
     },
     DeferralFn,
 };
@@ -192,9 +192,9 @@ pub struct DeferralCallAdapterRecord<F> {
 
     // Write auxiliary records
     pub output_commit_and_len_aux:
-        [MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>; OUTPUT_TOTAL_MEMORY_OPS],
-    pub new_input_acc_aux: [MemoryWriteAuxRecord<F, MEMORY_OP_SIZE>; DIGEST_MEMORY_OPS],
-    pub new_output_acc_aux: [MemoryWriteAuxRecord<F, MEMORY_OP_SIZE>; DIGEST_MEMORY_OPS],
+        [MemoryWriteBytesAuxRecord<DEFAULT_BLOCK_SIZE>; OUTPUT_TOTAL_MEMORY_OPS],
+    pub new_input_acc_aux: [MemoryWriteAuxRecord<F, DEFAULT_BLOCK_SIZE>; DIGEST_MEMORY_OPS],
+    pub new_output_acc_aux: [MemoryWriteAuxRecord<F, DEFAULT_BLOCK_SIZE>; DIGEST_MEMORY_OPS],
 }
 
 #[derive(Clone, Copy)]
@@ -239,11 +239,11 @@ impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
             &mut record.rs_aux.prev_timestamp,
         );
 
-        let input_commit_chunks: [[u8; MEMORY_OP_SIZE]; COMMIT_MEMORY_OPS] = from_fn(|i| {
+        let input_commit_chunks: [[u8; DEFAULT_BLOCK_SIZE]; COMMIT_MEMORY_OPS] = from_fn(|i| {
             tracing_read(
                 memory,
                 e.as_canonical_u32(),
-                u32::from_le_bytes(record.rs_val) + (i * MEMORY_OP_SIZE) as u32,
+                u32::from_le_bytes(record.rs_val) + (i * DEFAULT_BLOCK_SIZE) as u32,
                 &mut record.input_commit_aux[i].prev_timestamp,
             )
         });
@@ -255,17 +255,17 @@ impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
         let input_acc_ptr = 2 * deferral_idx * DIGEST_SIZE_U32;
         let output_acc_ptr = input_acc_ptr + DIGEST_SIZE_U32;
 
-        let old_input_acc_chunks: [[F; MEMORY_OP_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
+        let old_input_acc_chunks: [[F; DEFAULT_BLOCK_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
             tracing_read_deferral(
                 memory,
-                input_acc_ptr + (i * MEMORY_OP_SIZE) as u32,
+                input_acc_ptr + (i * DEFAULT_BLOCK_SIZE) as u32,
                 &mut record.old_input_acc_aux[i].prev_timestamp,
             )
         });
-        let old_output_acc_chunks: [[F; MEMORY_OP_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
+        let old_output_acc_chunks: [[F; DEFAULT_BLOCK_SIZE]; DIGEST_MEMORY_OPS] = from_fn(|i| {
             tracing_read_deferral(
                 memory,
-                output_acc_ptr + (i * MEMORY_OP_SIZE) as u32,
+                output_acc_ptr + (i * DEFAULT_BLOCK_SIZE) as u32,
                 &mut record.old_output_acc_aux[i].prev_timestamp,
             )
         });
@@ -302,7 +302,7 @@ impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
             tracing_write(
                 memory,
                 e.as_canonical_u32(),
-                u32::from_le_bytes(record.rd_val) + (chunk_idx * MEMORY_OP_SIZE) as u32,
+                u32::from_le_bytes(record.rd_val) + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
                 memory_op_chunk(&output_commit_and_len, chunk_idx),
                 &mut record.output_commit_and_len_aux[chunk_idx].prev_timestamp,
                 &mut record.output_commit_and_len_aux[chunk_idx].prev_data,
@@ -318,7 +318,7 @@ impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
         for chunk_idx in 0..DIGEST_MEMORY_OPS {
             tracing_write_deferral(
                 memory,
-                input_acc_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+                input_acc_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
                 memory_op_chunk(&data.new_input_acc, chunk_idx),
                 &mut record.new_input_acc_aux[chunk_idx].prev_timestamp,
                 &mut record.new_input_acc_aux[chunk_idx].prev_data,
@@ -328,7 +328,7 @@ impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
         for chunk_idx in 0..DIGEST_MEMORY_OPS {
             tracing_write_deferral(
                 memory,
-                output_acc_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+                output_acc_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
                 memory_op_chunk(&data.new_output_acc, chunk_idx),
                 &mut record.new_output_acc_aux[chunk_idx].prev_timestamp,
                 &mut record.new_output_acc_aux[chunk_idx].prev_data,

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, borrow::Borrow};
 
 use openvm_circuit::{
-    arch::{ExecutionBridge, ExecutionState},
+    arch::{ExecutionBridge, ExecutionState, DEFAULT_BLOCK_SIZE},
     system::memory::{
         offline_checker::{MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxCols},
         MemoryAddress,
@@ -29,8 +29,7 @@ use crate::{
     poseidon2::DeferralPoseidon2Bus,
     utils::{
         byte_commit_to_f, bytes_to_f, combine_output, split_memory_ops, COMMIT_NUM_BYTES,
-        DIGEST_MEMORY_OPS, F_NUM_BYTES, MEMORY_OP_SIZE, OUTPUT_TOTAL_BYTES,
-        OUTPUT_TOTAL_MEMORY_OPS,
+        DIGEST_MEMORY_OPS, F_NUM_BYTES, OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS,
     },
 };
 
@@ -66,7 +65,7 @@ pub struct DeferralOutputCols<T> {
     // Bytes raw_output[local_idx * DIGEST_SIZE..(local_idx + 1) * DIGEST_SIZE]
     // written to memory and auxiliary columns
     pub write_bytes: [T; DIGEST_SIZE],
-    pub write_bytes_aux: [MemoryWriteAuxCols<T, MEMORY_OP_SIZE>; DIGEST_MEMORY_OPS],
+    pub write_bytes_aux: [MemoryWriteAuxCols<T, DEFAULT_BLOCK_SIZE>; DIGEST_MEMORY_OPS],
 
     // Running hash of this section's write_bytes, constrained to be output_commit;
     // note the initial state should be [deferral_idx, 0, ..., 0]
@@ -247,7 +246,7 @@ where
                 .read(
                     MemoryAddress::new(
                         e.clone(),
-                        input_ptr.clone() + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                        input_ptr.clone() + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     local.from_state.timestamp + AB::Expr::from_usize(2 + chunk_idx),
@@ -270,7 +269,7 @@ where
                         e.clone(),
                         output_ptr.clone()
                             + (local.section_idx.into() * AB::Expr::from_usize(DIGEST_SIZE))
-                            + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
+                            + AB::Expr::from_usize(chunk_idx * DEFAULT_BLOCK_SIZE),
                     ),
                     data,
                     local.from_state.timestamp

--- a/extensions/deferral/circuit/src/output/execution.rs
+++ b/extensions/deferral/circuit/src/output/execution.rs
@@ -19,8 +19,8 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use super::DeferralOutputExecutor;
 use crate::{
     utils::{
-        join_memory_ops, memory_op_chunk, split_output, DIGEST_MEMORY_OPS, MEMORY_OP_SIZE,
-        OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS,
+        join_memory_ops, memory_op_chunk, split_output, DIGEST_MEMORY_OPS, OUTPUT_TOTAL_BYTES,
+        OUTPUT_TOTAL_MEMORY_OPS,
     },
     OUTPUT_AIR_REL_IDX, POSEIDON2_AIR_REL_IDX,
 };
@@ -156,8 +156,9 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
 ) -> u32 {
     let output_ptr = u32::from_le_bytes(exec_state.vm_read(RV32_REGISTER_AS, pre_compute.rd_ptr));
     let input_ptr = u32::from_le_bytes(exec_state.vm_read(RV32_REGISTER_AS, pre_compute.rs_ptr));
-    let output_key_chunks: [[u8; MEMORY_OP_SIZE]; OUTPUT_TOTAL_MEMORY_OPS] =
-        from_fn(|i| exec_state.vm_read(RV32_MEMORY_AS, input_ptr + (i * MEMORY_OP_SIZE) as u32));
+    let output_key_chunks: [[u8; DEFAULT_BLOCK_SIZE]; OUTPUT_TOTAL_MEMORY_OPS] = from_fn(|i| {
+        exec_state.vm_read(RV32_MEMORY_AS, input_ptr + (i * DEFAULT_BLOCK_SIZE) as u32)
+    });
     let output_key: [u8; OUTPUT_TOTAL_BYTES] = join_memory_ops(output_key_chunks);
     let (output_commit, output_len) = split_output(output_key);
 
@@ -176,9 +177,9 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
     for (row_idx, output_chunk) in output_raw.chunks_exact(DIGEST_SIZE).enumerate() {
         let row_output_ptr = output_ptr + (row_idx * DIGEST_SIZE) as u32;
         for chunk_idx in 0..DIGEST_MEMORY_OPS {
-            exec_state.vm_write::<u8, MEMORY_OP_SIZE>(
+            exec_state.vm_write::<u8, DEFAULT_BLOCK_SIZE>(
                 RV32_MEMORY_AS,
-                row_output_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+                row_output_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
                 &memory_op_chunk(output_chunk, chunk_idx),
             );
         }

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     arch::{
         get_record_from_slice, hasher::HasherChip, CustomBorrow, ExecutionError, MultiRowLayout,
         MultiRowMetadata, PreflightExecutor, RecordArena, SizedRecord, TraceFiller, VmField,
-        VmStateMut,
+        VmStateMut, DEFAULT_BLOCK_SIZE,
     },
     system::memory::{
         offline_checker::{MemoryReadAuxRecord, MemoryWriteBytesAuxRecord},
@@ -36,7 +36,7 @@ use crate::{
     poseidon2::DeferralPoseidon2Chip,
     utils::{
         f_commit_to_bytes, join_memory_ops, memory_op_chunk, split_output, DIGEST_MEMORY_OPS,
-        MEMORY_OP_SIZE, OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS,
+        OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS,
     },
 };
 
@@ -77,7 +77,7 @@ pub struct DeferralOutputRecordHeader {
 pub struct DeferralOutputRecordMut<'a> {
     pub header: &'a mut DeferralOutputRecordHeader,
     pub write_bytes: &'a mut [u8],
-    pub write_aux: &'a mut [MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>],
+    pub write_aux: &'a mut [MemoryWriteBytesAuxRecord<DEFAULT_BLOCK_SIZE>],
 }
 
 impl<'a> CustomBorrow<'a, DeferralOutputRecordMut<'a>, DeferralOutputLayout> for [u8] {
@@ -99,7 +99,7 @@ impl<'a> CustomBorrow<'a, DeferralOutputRecordMut<'a>, DeferralOutputLayout> for
         // - Subslice operation [..layout.metadata.num_rows] validates sufficient capacity
         // - Layout calculation ensures space for alignment padding plus required aux records
         let (_, write_aux_buf, _) =
-            unsafe { rest.align_to_mut::<MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>>() };
+            unsafe { rest.align_to_mut::<MemoryWriteBytesAuxRecord<DEFAULT_BLOCK_SIZE>>() };
 
         DeferralOutputRecordMut {
             header: header_buf.borrow_mut(),
@@ -123,10 +123,10 @@ impl<'a> SizedRecord<DeferralOutputLayout> for DeferralOutputRecordMut<'a> {
         let mut total_len = size_of::<DeferralOutputRecordHeader>();
         total_len += layout.metadata.num_rows * DIGEST_SIZE;
         total_len =
-            total_len.next_multiple_of(align_of::<MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>>());
+            total_len.next_multiple_of(align_of::<MemoryWriteBytesAuxRecord<DEFAULT_BLOCK_SIZE>>());
         total_len += layout.metadata.num_rows
             * DIGEST_MEMORY_OPS
-            * size_of::<MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>>();
+            * size_of::<MemoryWriteBytesAuxRecord<DEFAULT_BLOCK_SIZE>>();
         total_len
     }
 
@@ -168,11 +168,11 @@ where
 
         // Do a non-tracing read to get the output_len and compute num_rows
         let read_ptr = read_rv32_register(state.memory.data(), rs_ptr);
-        let output_key_chunks: [[u8; MEMORY_OP_SIZE]; OUTPUT_TOTAL_MEMORY_OPS] = from_fn(|i| {
+        let output_key_chunks: [[u8; DEFAULT_BLOCK_SIZE]; OUTPUT_TOTAL_MEMORY_OPS] = from_fn(|i| {
             memory_read(
                 state.memory.data(),
                 RV32_MEMORY_AS,
-                read_ptr + (i * MEMORY_OP_SIZE) as u32,
+                read_ptr + (i * DEFAULT_BLOCK_SIZE) as u32,
             )
         });
         let output_key: [u8; OUTPUT_TOTAL_BYTES] = join_memory_ops(output_key_chunks);
@@ -212,10 +212,10 @@ where
         let input_ptr = u32::from_le_bytes(record.header.rs_val);
         let output_ptr = u32::from_le_bytes(record.header.rd_val);
         for chunk_idx in 0..OUTPUT_TOTAL_MEMORY_OPS {
-            tracing_read::<MEMORY_OP_SIZE>(
+            tracing_read::<DEFAULT_BLOCK_SIZE>(
                 state.memory,
                 RV32_MEMORY_AS,
-                input_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+                input_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
                 &mut record.header.output_commit_and_len_aux[chunk_idx].prev_timestamp,
             );
         }
@@ -231,7 +231,7 @@ where
                 tracing_write(
                     state.memory,
                     RV32_MEMORY_AS,
-                    row_output_ptr + (chunk_idx * MEMORY_OP_SIZE) as u32,
+                    row_output_ptr + (chunk_idx * DEFAULT_BLOCK_SIZE) as u32,
                     memory_op_chunk(output_chunk, chunk_idx),
                     &mut record.write_aux[aux_idx].prev_timestamp,
                     &mut record.write_aux[aux_idx].prev_data,

--- a/extensions/deferral/circuit/src/utils.rs
+++ b/extensions/deferral/circuit/src/utils.rs
@@ -1,6 +1,7 @@
 use std::array::from_fn;
 
 use itertools::Itertools;
+use openvm_circuit::arch::DEFAULT_BLOCK_SIZE;
 use openvm_instructions::riscv::RV32_CELL_BITS;
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_field::{PrimeCharacteristicRing, PrimeField32};
@@ -9,38 +10,35 @@ pub const F_NUM_BYTES: usize = 4;
 pub const COMMIT_NUM_BYTES: usize = DIGEST_SIZE * F_NUM_BYTES;
 pub const OUTPUT_LEN_NUM_BYTES: usize = 8;
 pub const OUTPUT_TOTAL_BYTES: usize = OUTPUT_LEN_NUM_BYTES + COMMIT_NUM_BYTES;
-
-// TODO: replace MEMORY_OP_SIZE with CONST_BLOCK_SIZE
-pub const MEMORY_OP_SIZE: usize = 4;
 pub const DIGEST_MEMORY_OPS: usize = num_memory_ops(DIGEST_SIZE);
 pub const COMMIT_MEMORY_OPS: usize = num_memory_ops(COMMIT_NUM_BYTES);
 pub const OUTPUT_TOTAL_MEMORY_OPS: usize = num_memory_ops(OUTPUT_TOTAL_BYTES);
 
 #[inline(always)]
 pub const fn num_memory_ops(total_cells: usize) -> usize {
-    assert!(total_cells.is_multiple_of(MEMORY_OP_SIZE));
-    total_cells / MEMORY_OP_SIZE
+    assert!(total_cells.is_multiple_of(DEFAULT_BLOCK_SIZE));
+    total_cells / DEFAULT_BLOCK_SIZE
 }
 
 pub fn split_memory_ops<T, const TOTAL_CELLS: usize, const NUM_OPS: usize>(
     data: [T; TOTAL_CELLS],
-) -> [[T; MEMORY_OP_SIZE]; NUM_OPS] {
-    assert_eq!(TOTAL_CELLS, NUM_OPS * MEMORY_OP_SIZE);
+) -> [[T; DEFAULT_BLOCK_SIZE]; NUM_OPS] {
+    assert_eq!(TOTAL_CELLS, NUM_OPS * DEFAULT_BLOCK_SIZE);
     let mut it = data.into_iter();
     from_fn(|_| from_fn(|_| it.next().unwrap()))
 }
 
 pub fn join_memory_ops<T, const TOTAL_CELLS: usize, const NUM_OPS: usize>(
-    chunks: [[T; MEMORY_OP_SIZE]; NUM_OPS],
+    chunks: [[T; DEFAULT_BLOCK_SIZE]; NUM_OPS],
 ) -> [T; TOTAL_CELLS] {
-    assert_eq!(TOTAL_CELLS, NUM_OPS * MEMORY_OP_SIZE);
+    assert_eq!(TOTAL_CELLS, NUM_OPS * DEFAULT_BLOCK_SIZE);
     chunks.into_iter().flatten().collect_array().unwrap()
 }
 
-pub fn memory_op_chunk<T: Clone>(data: &[T], chunk_idx: usize) -> [T; MEMORY_OP_SIZE] {
-    debug_assert!(data.len().is_multiple_of(MEMORY_OP_SIZE));
-    let start = chunk_idx * MEMORY_OP_SIZE;
-    debug_assert!(start + MEMORY_OP_SIZE <= data.len());
+pub fn memory_op_chunk<T: Clone>(data: &[T], chunk_idx: usize) -> [T; DEFAULT_BLOCK_SIZE] {
+    debug_assert!(data.len().is_multiple_of(DEFAULT_BLOCK_SIZE));
+    let start = chunk_idx * DEFAULT_BLOCK_SIZE;
+    debug_assert!(start + DEFAULT_BLOCK_SIZE <= data.len());
     from_fn(|i| data[start + i].clone())
 }
 

--- a/extensions/ecc/circuit/src/extension/hybrid.rs
+++ b/extensions/ecc/circuit/src/extension/hybrid.rs
@@ -2,7 +2,7 @@
 
 use openvm_algebra_circuit::Rv32ModularHybridBuilder;
 use openvm_circuit::{
-    arch::{CONST_BLOCK_SIZE, *},
+    arch::{DEFAULT_BLOCK_SIZE, *},
     system::{
         cuda::{
             extensions::{get_inventory_range_checker, get_or_create_bitwise_op_lookup},
@@ -112,8 +112,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Weierstrass
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let addne = get_ec_addne_chip::<F, ECC_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let addne = get_ec_addne_chip::<F, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -122,8 +122,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Weierstrass
                 );
                 inventory.add_executor_chip(HybridWeierstrassChip::new(addne));
 
-                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let double = get_ec_double_chip::<F, ECC_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let double = get_ec_double_chip::<F, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -139,8 +139,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Weierstrass
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let addne = get_ec_addne_chip::<F, ECC_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let addne = get_ec_addne_chip::<F, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -149,8 +149,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Weierstrass
                 );
                 inventory.add_executor_chip(HybridWeierstrassChip::new(addne));
 
-                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let double = get_ec_double_chip::<F, ECC_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let double = get_ec_double_chip::<F, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),

--- a/extensions/ecc/circuit/src/extension/weierstrass.rs
+++ b/extensions/ecc/circuit/src/extension/weierstrass.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     arch::{
         AirInventory, AirInventoryError, ChipInventory, ChipInventoryError, ExecutionBridge,
         ExecutorInventoryBuilder, ExecutorInventoryError, RowMajorMatrixArena, VmCircuitExtension,
-        VmExecutionExtension, VmProverExtension, CONST_BLOCK_SIZE,
+        VmExecutionExtension, VmProverExtension, DEFAULT_BLOCK_SIZE,
     },
     system::{memory::SharedMemoryHelper, SystemPort},
 };
@@ -99,11 +99,11 @@ impl WeierstrassExtension {
 )]
 pub enum WeierstrassExtensionExecutor {
     // 32 limbs prime
-    EcAddNeRv32_32(EcAddNeExecutor<ECC_BLOCKS_32, CONST_BLOCK_SIZE>),
-    EcDoubleRv32_32(EcDoubleExecutor<ECC_BLOCKS_32, CONST_BLOCK_SIZE>),
+    EcAddNeRv32_32(EcAddNeExecutor<ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>),
+    EcDoubleRv32_32(EcDoubleExecutor<ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>),
     // 48 limbs prime
-    EcAddNeRv32_48(EcAddNeExecutor<ECC_BLOCKS_48, CONST_BLOCK_SIZE>),
-    EcDoubleRv32_48(EcDoubleExecutor<ECC_BLOCKS_48, CONST_BLOCK_SIZE>),
+    EcAddNeRv32_48(EcAddNeExecutor<ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>),
+    EcDoubleRv32_48(EcDoubleExecutor<ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>),
 }
 
 impl<F: PrimeField32> VmExecutionExtension<F> for WeierstrassExtension {
@@ -234,7 +234,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for WeierstrassExtension {
                     limb_bits: 8,
                 };
 
-                let addne = get_ec_addne_air::<ECC_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let addne = get_ec_addne_air::<ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config.clone(),
@@ -245,7 +245,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for WeierstrassExtension {
                 );
                 inventory.add_air(addne);
 
-                let double = get_ec_double_air::<ECC_BLOCKS_32, CONST_BLOCK_SIZE>(
+                let double = get_ec_double_air::<ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config,
@@ -263,7 +263,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for WeierstrassExtension {
                     limb_bits: 8,
                 };
 
-                let addne = get_ec_addne_air::<ECC_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let addne = get_ec_addne_air::<ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config.clone(),
@@ -274,7 +274,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for WeierstrassExtension {
                 );
                 inventory.add_air(addne);
 
-                let double = get_ec_double_air::<ECC_BLOCKS_48, CONST_BLOCK_SIZE>(
+                let double = get_ec_double_air::<ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     exec_bridge,
                     memory_bridge,
                     config,
@@ -336,8 +336,8 @@ where
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let addne = get_ec_addne_chip::<Val<SC>, ECC_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let addne = get_ec_addne_chip::<Val<SC>, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -346,8 +346,8 @@ where
                 );
                 inventory.add_executor_chip(addne);
 
-                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_32, CONST_BLOCK_SIZE>>()?;
-                let double = get_ec_double_chip::<Val<SC>, ECC_BLOCKS_32, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>>()?;
+                let double = get_ec_double_chip::<Val<SC>, ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -363,8 +363,8 @@ where
                     limb_bits: 8,
                 };
 
-                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let addne = get_ec_addne_chip::<Val<SC>, ECC_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<2, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let addne = get_ec_addne_chip::<Val<SC>, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config.clone(),
                     mem_helper.clone(),
                     range_checker.clone(),
@@ -373,8 +373,8 @@ where
                 );
                 inventory.add_executor_chip(addne);
 
-                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_48, CONST_BLOCK_SIZE>>()?;
-                let double = get_ec_double_chip::<Val<SC>, ECC_BLOCKS_48, CONST_BLOCK_SIZE>(
+                inventory.next_air::<WeierstrassAir<1, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>>()?;
+                let double = get_ec_double_chip::<Val<SC>, ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE>(
                     config,
                     mem_helper.clone(),
                     range_checker.clone(),

--- a/extensions/ecc/circuit/src/lib.rs
+++ b/extensions/ecc/circuit/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "tco", feature(explicit_tail_calls))]
 #![cfg_attr(feature = "tco", allow(internal_features))]
 #![cfg_attr(feature = "tco", feature(core_intrinsics))]
-use openvm_circuit::arch::CONST_BLOCK_SIZE;
+use openvm_circuit::arch::DEFAULT_BLOCK_SIZE;
 #[cfg(feature = "cuda")]
 use {
     openvm_mod_circuit_builder::FieldExpressionCoreRecordMut,
@@ -19,9 +19,9 @@ pub use weierstrass_chip::*;
 
 // Blocks per ECC operation (2 coordinates per point)
 /// Blocks for ECC with 32-limb coordinates: 2 * (32 / 4) = 16 blocks
-pub const ECC_BLOCKS_32: usize = 2 * (NUM_LIMBS_32 / CONST_BLOCK_SIZE);
+pub const ECC_BLOCKS_32: usize = 2 * (NUM_LIMBS_32 / DEFAULT_BLOCK_SIZE);
 /// Blocks for ECC with 48-limb coordinates: 2 * (48 / 4) = 24 blocks
-pub const ECC_BLOCKS_48: usize = 2 * (NUM_LIMBS_48 / CONST_BLOCK_SIZE);
+pub const ECC_BLOCKS_48: usize = 2 * (NUM_LIMBS_48 / DEFAULT_BLOCK_SIZE);
 
 #[cfg(feature = "cuda")]
 pub(crate) type EccRecord<

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -7,7 +7,7 @@ use openvm_circuit::arch::{
     testing::{
         memory::gen_pointer, TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
     },
-    Arena, MatrixRecordArena, PreflightExecutor, CONST_BLOCK_SIZE,
+    Arena, MatrixRecordArena, PreflightExecutor, DEFAULT_BLOCK_SIZE,
 };
 use openvm_circuit_primitives::{
     bigint::utils::{secp256k1_coord_prime, secp256r1_coord_prime},
@@ -398,7 +398,7 @@ mod ec_addne_tests {
 
     #[test]
     fn test_ec_addne_32limb() {
-        run_ec_addne_test::<{ ECC_BLOCKS_32 }, { CONST_BLOCK_SIZE }, { NUM_LIMBS_32 }>(
+        run_ec_addne_test::<{ ECC_BLOCKS_32 }, { DEFAULT_BLOCK_SIZE }, { NUM_LIMBS_32 }>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             secp256k1_coord_prime(),
         );
@@ -406,7 +406,7 @@ mod ec_addne_tests {
 
     #[test]
     fn test_ec_addne_48limb() {
-        run_ec_addne_test::<{ ECC_BLOCKS_48 }, { CONST_BLOCK_SIZE }, { NUM_LIMBS_48 }>(
+        run_ec_addne_test::<{ ECC_BLOCKS_48 }, { DEFAULT_BLOCK_SIZE }, { NUM_LIMBS_48 }>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             BLS12_381_MODULUS.clone(),
         );
@@ -487,7 +487,7 @@ mod ec_addne_tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn test_weierstrass_addne_cuda_2x32() {
-        run_cuda_ec_addne::<ECC_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_cuda_ec_addne::<ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             secp256k1_coord_prime(),
         );
@@ -496,7 +496,7 @@ mod ec_addne_tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn test_weierstrass_addne_cuda_6x16() {
-        run_cuda_ec_addne::<ECC_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_cuda_ec_addne::<ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             BLS12_381_MODULUS.clone(),
         );
@@ -516,7 +516,7 @@ mod ec_addne_tests {
             limb_bits: LIMB_BITS,
         };
 
-        let executor = get_ec_addne_step::<{ ECC_BLOCKS_32 }, { CONST_BLOCK_SIZE }>(
+        let executor = get_ec_addne_step::<{ ECC_BLOCKS_32 }, { DEFAULT_BLOCK_SIZE }>(
             config,
             tester.range_checker().bus(),
             tester.address_bits(),
@@ -850,7 +850,7 @@ mod ec_double_tests {
 
     #[test]
     fn test_ec_double_32limb() {
-        run_ec_double_test::<{ ECC_BLOCKS_32 }, { CONST_BLOCK_SIZE }, { NUM_LIMBS_32 }>(
+        run_ec_double_test::<{ ECC_BLOCKS_32 }, { DEFAULT_BLOCK_SIZE }, { NUM_LIMBS_32 }>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             secp256k1_coord_prime(),
             50,
@@ -863,7 +863,7 @@ mod ec_double_tests {
         let coeff_a = (-secp256r1::Fp::from(3)).to_bytes();
         let a = BigUint::from_bytes_le(&coeff_a);
 
-        run_ec_double_test::<{ ECC_BLOCKS_32 }, { CONST_BLOCK_SIZE }, { NUM_LIMBS_32 }>(
+        run_ec_double_test::<{ ECC_BLOCKS_32 }, { DEFAULT_BLOCK_SIZE }, { NUM_LIMBS_32 }>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             secp256r1_coord_prime(),
             50,
@@ -873,7 +873,7 @@ mod ec_double_tests {
 
     #[test]
     fn test_ec_double_48limb() {
-        run_ec_double_test::<{ ECC_BLOCKS_48 }, { CONST_BLOCK_SIZE }, { NUM_LIMBS_48 }>(
+        run_ec_double_test::<{ ECC_BLOCKS_48 }, { DEFAULT_BLOCK_SIZE }, { NUM_LIMBS_48 }>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             BLS12_381_MODULUS.clone(),
             50,
@@ -994,7 +994,7 @@ mod ec_double_tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn test_ec_double_cuda_2x32() {
-        run_ec_double_cuda_test::<ECC_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_ec_double_cuda_test::<ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             secp256k1_coord_prime(),
             50,
@@ -1008,7 +1008,7 @@ mod ec_double_tests {
         let coeff_a = (-secp256r1::Fp::from(3)).to_bytes();
         let a = BigUint::from_bytes_le(&coeff_a);
 
-        run_ec_double_cuda_test::<ECC_BLOCKS_32, CONST_BLOCK_SIZE, NUM_LIMBS_32>(
+        run_ec_double_cuda_test::<ECC_BLOCKS_32, DEFAULT_BLOCK_SIZE, NUM_LIMBS_32>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             secp256r1_coord_prime(),
             50,
@@ -1019,7 +1019,7 @@ mod ec_double_tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn test_ec_double_cuda_6x16() {
-        run_ec_double_cuda_test::<ECC_BLOCKS_48, CONST_BLOCK_SIZE, NUM_LIMBS_48>(
+        run_ec_double_cuda_test::<ECC_BLOCKS_48, DEFAULT_BLOCK_SIZE, NUM_LIMBS_48>(
             Rv32WeierstrassOpcode::CLASS_OFFSET,
             BLS12_381_MODULUS.clone(),
             50,
@@ -1041,7 +1041,7 @@ mod ec_double_tests {
             limb_bits: LIMB_BITS,
         };
 
-        let executor = get_ec_double_step::<{ ECC_BLOCKS_32 }, { CONST_BLOCK_SIZE }>(
+        let executor = get_ec_double_step::<{ ECC_BLOCKS_32 }, { DEFAULT_BLOCK_SIZE }>(
             config,
             tester.range_checker().bus(),
             tester.address_bits(),
@@ -1073,7 +1073,7 @@ mod ec_double_tests {
         )
         .unwrap();
 
-        let executor = get_ec_double_step::<{ ECC_BLOCKS_32 }, { CONST_BLOCK_SIZE }>(
+        let executor = get_ec_double_step::<{ ECC_BLOCKS_32 }, { DEFAULT_BLOCK_SIZE }>(
             config.clone(),
             tester.range_checker().bus(),
             tester.address_bits(),

--- a/extensions/rv32im/circuit/src/adapters/deferral.rs
+++ b/extensions/rv32im/circuit/src/adapters/deferral.rs
@@ -104,8 +104,8 @@ where
     F: PrimeField32,
 {
     // SAFETY:
-    // - address space `Native` will always have cell type `F` and minimum alignment of `1`
-    unsafe { memory.read::<F, BLOCK_SIZE, 1>(DEFERRAL_AS, ptr) }
+    // - address space `DEFERRAL_AS` has cell type `F` and block_size of `DEFAULT_BLOCK_SIZE`
+    unsafe { memory.read::<F, BLOCK_SIZE>(DEFERRAL_AS, ptr) }
 }
 
 #[inline(always)]
@@ -118,8 +118,8 @@ where
     F: PrimeField32,
 {
     // SAFETY:
-    // - address space `Native` will always have cell type `F` and minimum alignment of `1`
-    unsafe { memory.write::<F, BLOCK_SIZE, 1>(DEFERRAL_AS, ptr, vals) }
+    // - address space `DEFERRAL_AS` has cell type `F` and block_size of `DEFAULT_BLOCK_SIZE`
+    unsafe { memory.write::<F, BLOCK_SIZE>(DEFERRAL_AS, ptr, vals) }
 }
 
 /// Reads register value at `ptr` from memory and records the previous timestamp.

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -72,8 +72,8 @@ pub fn memory_read<const N: usize>(memory: &GuestMemory, address_space: u32, ptr
     );
 
     // SAFETY:
-    // - address space `RV32_REGISTER_AS` and `RV32_MEMORY_AS` will always have cell type `u8` and
-    //   minimum alignment of `RV32_REGISTER_NUM_LIMBS`
+    // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
+    //   and block_size of `DEFAULT_BLOCK_SIZE`
     unsafe { memory.read::<u8, N>(address_space, ptr) }
 }
 
@@ -91,8 +91,8 @@ pub fn memory_write<const N: usize>(
     );
 
     // SAFETY:
-    // - address space `RV32_REGISTER_AS` and `RV32_MEMORY_AS` will always have cell type `u8` and
-    //   minimum alignment of `RV32_REGISTER_NUM_LIMBS`
+    // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
+    //   and block_size of `DEFAULT_BLOCK_SIZE`
     unsafe { memory.write::<u8, N>(address_space, ptr, data) }
 }
 
@@ -112,9 +112,9 @@ pub fn timed_read<const N: usize>(
     );
 
     // SAFETY:
-    // - address space `RV32_REGISTER_AS` and `RV32_MEMORY_AS` will always have cell type `u8` and
-    //   minimum alignment of `RV32_REGISTER_NUM_LIMBS`
-    unsafe { memory.read::<u8, N, RV32_REGISTER_NUM_LIMBS>(address_space, ptr) }
+    // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
+    //   and block_size of `DEFAULT_BLOCK_SIZE`
+    unsafe { memory.read::<u8, N>(address_space, ptr) }
 }
 
 #[inline(always)]
@@ -131,9 +131,9 @@ pub fn timed_write<const N: usize>(
     );
 
     // SAFETY:
-    // - address space `RV32_REGISTER_AS` and `RV32_MEMORY_AS` will always have cell type `u8` and
-    //   minimum alignment of `RV32_REGISTER_NUM_LIMBS`
-    unsafe { memory.write::<u8, N, RV32_REGISTER_NUM_LIMBS>(address_space, ptr, data) }
+    // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
+    //   and block_size of `DEFAULT_BLOCK_SIZE`
+    unsafe { memory.write::<u8, N>(address_space, ptr, data) }
 }
 
 /// Reads register value at `reg_ptr` from memory and records the memory access in mutable buffer.

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -160,7 +160,7 @@ fn rand_rv32_alu_test(opcode: BaseAluOpcode, num_ops: usize) {
     // TODO(AG): make a more meaningful test for memory accesses
     tester.write(2, 1024, [F::ONE; 4]);
     tester.write(2, 1028, [F::ONE; 4]);
-    // Use CONST_BLOCK_SIZE-aligned accesses matching the minimum block size
+    // Use DEFAULT_BLOCK_SIZE-aligned accesses matching the minimum block size
     let sm1 = tester.read(2, 1024);
     let sm2 = tester.read(2, 1028);
     assert_eq!(sm1, [F::ONE; 4]);

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -9,7 +9,7 @@ mod aot {
     use openvm_circuit::{
         arch::{
             execution_mode::{metered::memory_ctx::MemoryCtx, MeteredCtx},
-            AotError, SystemConfig, VmExecState, ADDR_SPACE_OFFSET, CONST_BLOCK_SIZE,
+            AotError, SystemConfig, VmExecState, ADDR_SPACE_OFFSET, DEFAULT_BLOCK_SIZE,
         },
         system::memory::online::GuestMemory,
     };
@@ -181,13 +181,7 @@ mod aot {
         //
         // Therefore the loop only iterates once for `page_id = start_page_id`.
 
-        let initial_block_size: usize = config.initial_block_size();
-        if initial_block_size != CONST_BLOCK_SIZE {
-            return Err(AotError::Other(format!(
-                "initial_block_size must be {CONST_BLOCK_SIZE}, got {initial_block_size}"
-            )));
-        }
-        let chunk_bits = CONST_BLOCK_SIZE.ilog2();
+        let chunk_bits = DEFAULT_BLOCK_SIZE.ilog2();
         let as_offset = ((address_space - ADDR_SPACE_OFFSET) as u64)
             << (config.memory_config.memory_dimensions().address_height);
 


### PR DESCRIPTION
# Simplify memory subsystem after access adapter removal

## Overview

This PR simplifies the memory subsystem now that access adapters (split/merge logic) have been removed. The key changes are:

1. **Remove `AccessMetadata` and all split/merge machinery** from `TracingMemory` — metadata is now a plain `u32` timestamp per block slot instead of a packed struct with block size and offset fields.
2. **Rename `min_block_size` → `block_size`** — without access adapters there is no "minimum" concept; each address space has a single fixed block size.
3. **Remove the `ALIGN` const generic** from `TracingMemory::read/write` — alignment is now looked up at runtime from `self.block_size[addr_space]`, eliminating a redundant generic parameter.
4. **Consolidate block size constants** — `DEFAULT_U8_BLOCK_SIZE`, `DEFAULT_NATIVE_BLOCK_SIZE`, `CONST_BLOCK_SIZE`, and `MEMORY_OP_SIZE` are all replaced by a single `DEFAULT_BLOCK_SIZE = 4`.
5. **Replace runtime state with compile-time constants** in `MemoryCtx` — `chunk`, `chunk_bits`, `boundary_idx`, `merkle_tree_index` fields are removed in favor of `CHUNK`, `CHUNK_BITS`, `BOUNDARY_AIR_ID`, `MERKLE_AIR_ID` constants.

**No AIR changes.** This is purely a host-side simplification of execution and trace generation code.

---

## Detailed Changes

### `crates/vm` (`openvm-circuit`)

#### `system/memory/online.rs` (largest change, −350 lines net)

- **Removed**: `AccessMetadata` struct (packed timestamp + log2(block_size) + offset_to_start), along with all methods: `get_block_metadata`, `get_timestamp`, `set_meta_block`, `calculate_splits_and_merges`, `split_by_meta`, `handle_uninitialized_memory`.
- **Removed**: Constants `MAX_BLOCK_SIZE`, `MIN_ALIGN`, `MAX_SEGMENTS`.
- **Simplified `TracingMemory`**:
  - `meta` field: `Vec<PagedVec<AccessMetadata, PAGE_SIZE>>` → `Vec<PagedVec<u32, PAGE_SIZE>>` (just timestamps).
  - `min_block_size` → `block_size` (renamed).
  - Removed `initial_block_size` field and constructor parameter.
  - `read`/`write` signatures: `<T, const BLOCK_SIZE: usize, const ALIGN: usize>` → `<T, const BLOCK_SIZE: usize>`. The alignment is now derived at runtime from `self.block_size[addr_space]`.
  - `prev_access_time`: iterates over `BLOCK_SIZE / block_size` metadata slots, takes max timestamp, and updates all slots to current timestamp.
  - `assert_alignment` → `assert_block_aligned` (renamed, simplified).
  - `address_space_alignment()` → `block_size_bits()` (renamed).
  - `touched_blocks` / `touched_blocks_to_equipartition`: simplified to use plain `u32` timestamps instead of `AccessMetadata`.

#### `arch/config.rs`

- **Removed**: `DEFAULT_U8_BLOCK_SIZE`, `DEFAULT_NATIVE_BLOCK_SIZE`, `CONST_BLOCK_SIZE` constants.
- **Added**: Single `pub const DEFAULT_BLOCK_SIZE: usize = 4`.
- **Renamed**: `AddressSpaceHostConfig::min_block_size` → `block_size`.
- **Renamed**: `MemoryConfig::min_block_size_bits()` → `block_size_bits()`.
- **Removed**: `SystemConfig::initial_block_size()` method.
- Default address space configs now all use `DEFAULT_BLOCK_SIZE` (including the fallback for unassigned address spaces, which previously used `DEFAULT_NATIVE_BLOCK_SIZE = 1`).

#### `arch/execution_mode/metered/memory_ctx.rs`

- **Removed fields** from `MemoryCtx`: `chunk`, `chunk_bits`, `boundary_idx`, `merkle_tree_index`.
- **Added module-level constants**: `CHUNK = DEFAULT_BLOCK_SIZE as u32`, `CHUNK_BITS = CHUNK.ilog2()`.
- Uses `BOUNDARY_AIR_ID` and `MERKLE_AIR_ID` constants directly instead of storing copies.
- Removed dead `if self.chunk == 1` branch in `update_boundary_merkle_heights`.

#### `arch/execution_mode/metered/ctx.rs`

- Debug assertions now use `BOUNDARY_AIR_ID` / `MERKLE_AIR_ID` constants directly.

#### `arch/testing/` (cpu.rs, cuda.rs, memory/mod.rs, memory/cuda.rs, utils.rs)

- `TracingMemory::new` / `from_image` no longer takes `initial_block_size` parameter.
- `read`/`write` calls updated from 3 type params to 2 (dropped `ALIGN`).

#### `arch/vm.rs`

- `TracingMemory::from_image` call simplified (no block size arg).
- Removed unused `system_config` variable.

#### `system/memory/merkle/tests/mod.rs`

- Renamed `min_block_size` → `block_size` in `AddressSpaceHostConfig` construction.

#### `system/memory/persistent.rs`, `system/memory/controller/mod.rs`, `system/mod.rs`, `system/cuda/`

- `CONST_BLOCK_SIZE` → `DEFAULT_BLOCK_SIZE` rename only.

---

### `extensions/rv32im/circuit`

#### `adapters/mod.rs`

- `timed_read` / `timed_write`: dropped `ALIGN` type parameter from `TracingMemory` calls.
- Updated safety comments to reference `block_size` instead of "minimum alignment".

#### `adapters/deferral.rs`

- Same `ALIGN` removal for `timed_read_deferral` / `timed_write_deferral`.
- Updated safety comments.

#### `common/mod.rs`

- Removed dead `initial_block_size` validation check (the method no longer exists).
- `CONST_BLOCK_SIZE` → `DEFAULT_BLOCK_SIZE`.

#### `base_alu/tests.rs`

- `CONST_BLOCK_SIZE` → `DEFAULT_BLOCK_SIZE` rename only.

---

### `extensions/deferral/circuit`

#### `utils.rs`

- **Removed**: `MEMORY_OP_SIZE` constant and its TODO comment.
- Functions (`split_memory_ops`, `join_memory_ops`, `memory_op_chunk`, `num_memory_ops`) now use `DEFAULT_BLOCK_SIZE` imported from `openvm_circuit::arch`.

#### `call/air.rs`, `call/trace.rs`, `call/execution.rs`, `output/air.rs`, `output/trace.rs`, `output/execution.rs`

- Import `DEFAULT_BLOCK_SIZE` from `openvm_circuit::arch` instead of from `crate::utils`.
- All `MEMORY_OP_SIZE` usages replaced with `DEFAULT_BLOCK_SIZE`.

---

### `extensions/algebra/circuit`, `extensions/ecc/circuit`, `extensions/bigint/circuit`

- Pure `CONST_BLOCK_SIZE` → `DEFAULT_BLOCK_SIZE` rename across all files (extension definitions, executor/filler enums, test files). No behavioral changes.

---

## Possible follow-ups

<!-- These are not blocking for this PR but are worth considering in future work. -->

- **If all address spaces converge to the same block size**, the per-AS `block_size` field in `AddressSpaceHostConfig` and `TracingMemory` can be removed entirely, replaced by the single `DEFAULT_BLOCK_SIZE` constant everywhere.
- **Several const generics (e.g., `BLOCK_SIZE` on `timed_read`/`timed_write`, adapter helpers) are always instantiated with `DEFAULT_BLOCK_SIZE` (= 4).** If no extension ever needs a different value, these can be collapsed to non-generic functions, reducing monomorphization bloat and simplifying call sites.
- **`touched_blocks_to_equipartition` and `handle_touched_blocks` take a `CHUNK` const generic** but it's always `DEFAULT_BLOCK_SIZE`. Can remove the generic and use the constant directly.
- **`handle_touched_blocks` is over-complicated when `block_size == CHUNK`** (which is always true now). The accumulation loop, `current_timestamps` vec, and max logic all collapse to a single entry per touched block.

Towards INT-6630
