### PR TITLE
fix: Make Eq3bAir use the correct number of interactions per air

### DIFF
--- a/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
@@ -275,11 +275,12 @@ where
             builder,
             local.proof_idx,
             Eq3bShapeMessage {
-                sort_idx: local.sort_idx,
-                n_lift: local.n_lift,
-                n_logup: local.n_logup,
+                sort_idx: local.sort_idx.into(),
+                n_lift: local.n_lift.into(),
+                n_logup: local.n_logup.into(),
+                num_interactions: local.interaction_idx + not(local.has_no_interactions),
             },
-            local.is_first_in_air,
+            LoopSubAir::local_is_last(local.is_valid, next.is_valid, next.is_first_in_air),
         );
 
         self.eq_3b_bus.send(

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -655,6 +655,7 @@ pub struct Eq3bShapeMessage<T> {
     pub sort_idx: T,
     pub n_lift: T,
     pub n_logup: T,
+    pub num_interactions: T,
 }
 
 define_typed_per_proof_lookup_bus!(Eq3bShapeBus, Eq3bShapeMessage);

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -525,7 +525,7 @@ where
             AirShapeBusMessage {
                 sort_idx: local.sorted_idx.into(),
                 property_idx: AirShapeProperty::NumInteractions.to_field(),
-                value: num_interactions,
+                value: num_interactions.clone(),
             },
             local.is_present,
         );
@@ -982,6 +982,7 @@ where
                 sort_idx: local.sorted_idx.into(),
                 n_lift,
                 n_logup: local.n_logup.into(),
+                num_interactions,
             },
             local.is_present,
         );


### PR DESCRIPTION
This resolves INT-6828.

Now `Eq3bAir` propagates the `row_idx` by the correct amount for each AIR. Note that there is no need for this air to know `air_idx` or anything other than the number of interactions and the `n_lift` for this air, so no new columns are added (but we now do the interaction with proof shape air on the last row of the air instead of the first one).