### PR TITLE
ci: only run CUDA lint when CUDA files change and use 8-cpu runner

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -26,6 +26,7 @@ jobs:
               - '**/cuda/**'
               - '**/cuda*.rs'
               - '**/cuda_abi.rs'
+              - '**/build.rs'
               - '.github/workflows/lints.yml'
               - '.github/actions/rust-cache-cuda/**'
   lint:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -9,6 +9,25 @@ concurrency:
   group: ${{ github.workflow_ref }}-lints-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      cuda: ${{ steps.filter.outputs.cuda }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            cuda:
+              - '**/*.cu'
+              - '**/*.cuh'
+              - '**/cuda/**'
+              - '**/cuda*.rs'
+              - '**/cuda_abi.rs'
+              - '.github/workflows/lints.yml'
+              - '.github/actions/rust-cache-cuda/**'
   lint:
     name: Lint
     runs-on:
@@ -85,8 +104,10 @@ jobs:
           cargo audit
   lint-cuda:
     name: Lint CUDA
+    needs: changes
+    if: ${{ needs.changes.outputs.cuda == 'true' }}
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda/runner=test-gpu-nvidia
+      - runs-on=${{ github.run_id }}-cuda/runner=test-gpu-nvidia/cpu=8
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Add a `changes` detection job using `dorny/paths-filter@v3` to skip the `lint-cuda` job when no CUDA-related files (`*.cu`, `*.cuh`, `**/cuda/**`, `**/cuda*.rs`, etc.) are modified
- Request at least 8 CPUs on the GPU runner (`/cpu=8`) for faster builds
- The workflow file and CUDA cache action are also included as triggers so changes to CI itself still run the CUDA lint

## Test plan
- [ ] Open a PR that doesn't touch any CUDA files and verify `lint-cuda` is skipped
- [ ] Open a PR that touches a `.cu` or `.cuh` file and verify `lint-cuda` runs
