### PR TITLE
fix: constrain initial + final merkle proofs are equal up to address_height

### DIFF
--- a/crates/continuations/src/circuit/root/def_paths/air.rs
+++ b/crates/continuations/src/circuit/root/def_paths/air.rs
@@ -45,7 +45,7 @@ pub struct DeferralAccMerklePathsCols<F> {
 
     pub depth: F,
     pub is_skip: F,
-    pub is_untouched: F,
+    pub is_within_deferral_as: F,
     pub is_unset: F,
 }
 
@@ -154,29 +154,31 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
             .assert_eq(local.is_unset, next.is_unset);
 
         /*
-         * Constrain that then is_untouched is be set until address_height. We constrain
-         * the two paths to be equal as long as is_untouched is set, i.e. that the part
-         * of DEFERRAL_AS that is not included in the Merkle root is left untouched for
-         * the duration of the program execution.
+         * Constrain that then is_within_deferral_as is be set until address_height. We
+         * constrain the two paths to be equal as long as is_within_deferral_as is set,
+         * i.e. that the part of DEFERRAL_AS that is not included in the Merkle root is
+         * left untouched for the duration of the program execution.
          */
-        builder.assert_bool(local.is_untouched);
-        builder.when_first_row().assert_one(local.is_untouched);
+        builder.assert_bool(local.is_within_deferral_as);
+        builder
+            .when_first_row()
+            .assert_one(local.is_within_deferral_as);
         builder
             .when_transition()
-            .assert_bool(local.is_untouched - next.is_untouched);
+            .assert_bool(local.is_within_deferral_as - next.is_within_deferral_as);
         builder
             .when_transition()
-            .when(local.is_untouched - next.is_untouched)
+            .when(local.is_within_deferral_as - next.is_within_deferral_as)
             .assert_eq(local.depth, AB::Expr::from_usize(self.address_height));
 
         assert_array_eq(
-            &mut builder.when(local.is_untouched),
+            &mut builder.when(local.is_within_deferral_as),
             local.initial_sibling,
             local.final_sibling,
         );
 
         assert_array_eq(
-            &mut builder.when(and(local.is_untouched, local.is_unset)),
+            &mut builder.when(and(local.is_within_deferral_as, local.is_unset)),
             local.initial_node_commit,
             local.final_node_commit,
         );

--- a/crates/continuations/src/circuit/root/def_paths/air.rs
+++ b/crates/continuations/src/circuit/root/def_paths/air.rs
@@ -154,10 +154,10 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
             .assert_eq(local.is_unset, next.is_unset);
 
         /*
-         * Constrain that is_within_deferral_as is be set until address_height. We
-         * constrain the two paths to be equal as long as is_within_deferral_as is set,
-         * i.e. that the part of DEFERRAL_AS that is not included in the Merkle root is
-         * left untouched for the duration of the program execution.
+         * Constrain that is_within_deferral_as is set until address_height. We constrain
+         * the two paths to be equal as long as is_within_deferral_as is set, i.e. that the
+         * part of DEFERRAL_AS that is not included in the Merkle root is left untouched
+         * for the duration of the program execution.
          */
         builder.assert_bool(local.is_within_deferral_as);
         builder

--- a/crates/continuations/src/circuit/root/def_paths/air.rs
+++ b/crates/continuations/src/circuit/root/def_paths/air.rs
@@ -154,7 +154,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
             .assert_eq(local.is_unset, next.is_unset);
 
         /*
-         * Constrain that then is_within_deferral_as is be set until address_height. We
+         * Constrain that is_within_deferral_as is be set until address_height. We
          * constrain the two paths to be equal as long as is_within_deferral_as is set,
          * i.e. that the part of DEFERRAL_AS that is not included in the Merkle root is
          * left untouched for the duration of the program execution.

--- a/crates/continuations/src/circuit/root/def_paths/air.rs
+++ b/crates/continuations/src/circuit/root/def_paths/air.rs
@@ -46,7 +46,7 @@ pub struct DeferralAccMerklePathsCols<F> {
     pub depth: F,
     pub is_skip: F,
     pub is_untouched: F,
-    pub expected_branch_bits_offset: F,
+    pub is_unset: F,
 }
 
 pub struct DeferralAccMerklePathsAir {
@@ -115,17 +115,17 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
             .when(local.is_valid * next.is_valid)
             .assert_one(next.depth - local.depth);
 
-        let is_set = not(next.expected_branch_bits_offset);
+        let is_set = not(next.is_unset);
         self.def_acc_paths_bus.receive(
             builder,
             DeferralAccPathMessage {
                 initial_acc_hash: next.initial_node_commit.map(|v| v * is_set.clone()),
                 final_acc_hash: next.final_node_commit.map(|v| v * is_set.clone()),
                 depth: next.depth * is_set,
-                is_unset: next.expected_branch_bits_offset.into(),
+                is_unset: next.is_unset.into(),
             },
             (local.is_skip - next.is_skip) * (AB::Expr::TWO - next.is_valid)
-                + local.is_untouched
+                + local.is_unset
                     * local.is_valid
                     * (local.is_valid - AB::Expr::ONE)
                     * AB::F::TWO.inverse(),
@@ -133,7 +133,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
 
         assert_array_eq::<_, _, AB::Expr, _>(
             &mut builder
-                .when(local.is_untouched)
+                .when(local.is_unset)
                 .when(local.is_valid)
                 .when_ne(local.is_valid, AB::F::ONE),
             local.initial_node_commit,
@@ -141,36 +141,42 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
         );
 
         /*
-         * Constrain that if no rows are skipped, then is_untouched is be set until
-         * address_height. In this case we constrain the two paths to be equal as long
-         * as is_untouched is set. The path should start with a right sibling in that
-         * case.
+         * Constrain that is_unset, the flag that determines if deferrals are present, is
+         * consistent over all rows.
+         */
+        builder.assert_bool(local.is_unset);
+        builder
+            .when_first_row()
+            .when(local.is_unset)
+            .assert_one(local.is_right_child);
+        builder
+            .when(and(local.is_valid, next.is_valid))
+            .assert_eq(local.is_unset, next.is_unset);
+
+        /*
+         * Constrain that then is_untouched is be set until address_height. We constrain
+         * the two paths to be equal as long as is_untouched is set, i.e. that the part
+         * of DEFERRAL_AS that is not included in the Merkle root is left untouched for
+         * the duration of the program execution.
          */
         builder.assert_bool(local.is_untouched);
+        builder.when_first_row().assert_one(local.is_untouched);
         builder
             .when_transition()
             .assert_bool(local.is_untouched - next.is_untouched);
-        builder.when(local.is_untouched).assert_zero(local.is_skip);
-
         builder
             .when_transition()
             .when(local.is_untouched - next.is_untouched)
             .assert_eq(local.depth, AB::Expr::from_usize(self.address_height));
-        builder
-            .when_first_row()
-            .when(local.is_untouched)
-            .assert_one(local.is_right_child);
-
-        builder
-            .when_first_row()
-            .assert_eq(local.is_untouched, local.expected_branch_bits_offset);
-        builder.when(and(local.is_valid, next.is_valid)).assert_eq(
-            local.expected_branch_bits_offset,
-            next.expected_branch_bits_offset,
-        );
 
         assert_array_eq(
             &mut builder.when(local.is_untouched),
+            local.initial_sibling,
+            local.final_sibling,
+        );
+
+        assert_array_eq(
+            &mut builder.when(and(local.is_untouched, local.is_unset)),
             local.initial_node_commit,
             local.final_node_commit,
         );
@@ -201,7 +207,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
                 },
                 local.is_skip.into(),
                 next.is_skip.into(),
-                local.expected_branch_bits_offset.into(),
+                local.is_unset.into(),
             ),
         );
 
@@ -228,7 +234,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
                 },
                 local.is_skip.into(),
                 next.is_skip.into(),
-                local.expected_branch_bits_offset.into(),
+                local.is_unset.into(),
             ),
         );
 

--- a/crates/continuations/src/circuit/root/def_paths/trace.rs
+++ b/crates/continuations/src/circuit/root/def_paths/trace.rs
@@ -88,7 +88,7 @@ pub fn generate_proving_input<SC: StarkProtocolConfig<F = F>>(
         depth
     };
 
-    // `is_untouched` tracks the DEFERRAL_AS prefix outside the Merkle-rooted part.
+    // is_within_deferral_as tracks the DEFERRAL_AS prefix outside the Merkle-rooted part
     let untouched_cut = address_height.min(proof_len.saturating_sub(1));
 
     let mut is_right_child_bits = vec![false; num_layers];
@@ -144,7 +144,7 @@ pub fn generate_proving_input<SC: StarkProtocolConfig<F = F>>(
         cols.is_valid = if row_idx == 0 { F::TWO } else { F::ONE };
         cols.depth = F::from_usize(row_idx);
         cols.is_skip = F::from_bool(row_idx < skip_depth);
-        cols.is_untouched = F::from_bool(row_idx <= untouched_cut);
+        cols.is_within_deferral_as = F::from_bool(row_idx <= untouched_cut);
         cols.is_unset = F::from_bool(is_unset);
 
         cols.is_right_child = F::from_bool(is_right_child_bits[row_idx]);

--- a/crates/continuations/src/circuit/root/def_paths/trace.rs
+++ b/crates/continuations/src/circuit/root/def_paths/trace.rs
@@ -88,12 +88,8 @@ pub fn generate_proving_input<SC: StarkProtocolConfig<F = F>>(
         depth
     };
 
-    // If is_unset, the trace keeps initial/final paths equal for an untouched prefix.
-    let untouched_cut = if is_unset {
-        address_height.min(proof_len.saturating_sub(1))
-    } else {
-        0
-    };
+    // `is_untouched` tracks the DEFERRAL_AS prefix outside the Merkle-rooted part.
+    let untouched_cut = address_height.min(proof_len.saturating_sub(1));
 
     let mut is_right_child_bits = vec![false; num_layers];
     let mut row_branch_bits = vec![0usize; num_layers];
@@ -130,35 +126,13 @@ pub fn generate_proving_input<SC: StarkProtocolConfig<F = F>>(
         &is_right_child_bits,
         skip_depth,
     );
-    let mut final_nodes = build_path_nodes(
+    let final_nodes = build_path_nodes(
         final_start_hash,
         final_merkle_proof,
         &is_right_child_bits,
         skip_depth,
     );
-    let mut final_siblings = final_merkle_proof.to_vec();
-
-    if is_unset {
-        final_nodes[..=untouched_cut].copy_from_slice(&initial_nodes[..=untouched_cut]);
-        final_siblings[..untouched_cut].copy_from_slice(&initial_merkle_proof[..untouched_cut]);
-        if untouched_cut < proof_len {
-            for row_idx in untouched_cut..proof_len {
-                let sibling = final_siblings[row_idx];
-                let is_right_child = is_right_child_bits[row_idx];
-                let left = if is_right_child {
-                    sibling
-                } else {
-                    final_nodes[row_idx]
-                };
-                let right = if is_right_child {
-                    final_nodes[row_idx]
-                } else {
-                    sibling
-                };
-                final_nodes[row_idx + 1] = poseidon2_compress_with_capacity(left, right).0;
-            }
-        }
-    }
+    let final_siblings = final_merkle_proof.to_vec();
 
     let mut trace = vec![F::ZERO; height * width];
     let mut poseidon2_inputs = Vec::with_capacity(proof_len * 2);
@@ -170,8 +144,8 @@ pub fn generate_proving_input<SC: StarkProtocolConfig<F = F>>(
         cols.is_valid = if row_idx == 0 { F::TWO } else { F::ONE };
         cols.depth = F::from_usize(row_idx);
         cols.is_skip = F::from_bool(row_idx < skip_depth);
-        cols.is_untouched = F::from_bool(is_unset && row_idx <= untouched_cut);
-        cols.expected_branch_bits_offset = F::from_bool(is_unset);
+        cols.is_untouched = F::from_bool(row_idx <= untouched_cut);
+        cols.is_unset = F::from_bool(is_unset);
 
         cols.is_right_child = F::from_bool(is_right_child_bits[row_idx]);
         cols.row_idx_exp_2 = F::from_usize(1usize << row_idx);


### PR DESCRIPTION
Resolves INT-6766, INT-6646. Changes the following columns:

- `expected_branch_bits_offset` renamed to `is_unset`, still 1 for the entire proof iff no deferral proof is present.
- `is_untouched` changed to be 1 iff `depth <= address_height` (i.e. no dependency on `is_unset`)

We now constrain that `initial_sibling == final_sibling` when `is_untouched`. This constrains that the rest of the `DEFERRAL_AS` is left untouched during program execution.