### PR TITLE
fix: add num_def_circuit_proofs to DeferralAggregationPvs

### DIFF
--- a/crates/continuations/src/circuit/deferral/hook/bus.rs
+++ b/crates/continuations/src/circuit/deferral/hook/bus.rs
@@ -17,6 +17,7 @@ define_typed_permutation_bus!(IoCommitBus, IoCommitMessage);
 pub struct OnionResultMessage<T> {
     pub input_onion: [T; DIGEST_SIZE],
     pub output_onion: [T; DIGEST_SIZE],
+    pub num_elements: T,
 }
 
 define_typed_permutation_bus!(OnionResultBus, OnionResultMessage);

--- a/crates/continuations/src/circuit/deferral/hook/onion/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/onion/air.rs
@@ -131,6 +131,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             OnionResultMessage {
                 input_onion: next.input_onion,
                 output_onion: next.output_onion,
+                num_elements: next.row_idx,
             },
             local.is_valid * not(next.is_valid),
         );

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -256,6 +256,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             OnionResultMessage {
                 input_onion: local.input_onion,
                 output_onion: local.output_onion,
+                num_elements: local.def_pvs.num_def_circuit_proofs,
             },
             AB::F::ONE,
         );

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -21,7 +21,7 @@ use crate::{
             DefPvsConsistencyBus, DefPvsConsistencyMessage, InputOrMerkleCommitBus,
             InputOrMerkleCommitMessage,
         },
-        DeferralAggregationPvs, DeferralCircuitPvs, DEF_CIRCUIT_PVS_AIR_ID,
+        DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
     },
     utils::digests_to_poseidon2_input,
 };
@@ -137,7 +137,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                 ),
                 output: local.merkle_commit,
             },
-            is_leaf * local.is_present,
+            is_leaf.clone() * local.is_present,
         );
 
         /*
@@ -154,20 +154,53 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         /*
+         * On internal layers we receive num_def_circuit_proofs from PublicValuesBus. To save
+         * columns, we repurpose the unused local.child_pvs.input_commit[0].
+         */
+        let local_num_def_circuit_proofs = local.child_pvs.input_commit[0];
+
+        builder
+            .when(not(local.is_present))
+            .when(is_internal)
+            .assert_zero(local_num_def_circuit_proofs);
+
+        self.public_values_bus.receive(
+            builder,
+            local.proof_idx,
+            PublicValuesBusMessage {
+                air_idx: AB::Expr::from_usize(DEF_AGG_PVS_AIR_ID),
+                pv_idx: AB::Expr::from_usize(DIGEST_SIZE),
+                value: local_num_def_circuit_proofs.into(),
+            },
+            is_internal * local.is_present,
+        );
+
+        /*
          * If there is only one row, then this proof is a wrapper and its public values should
          * match those of its child's. Otherwise, constrain that merkle_commit is the hash of
-         * the child proofs'.
+         * the child proofs'. We also constrain that num_def_circuit_proofs is the sum of the
+         * present children's.
          */
-        let &DeferralAggregationPvs::<_> { merkle_commit } = builder.public_values().borrow();
+        let &DeferralAggregationPvs::<_> {
+            merkle_commit,
+            num_def_circuit_proofs,
+        } = builder.public_values().borrow();
 
         let is_first = not(local.proof_idx);
         let is_first_of_two_rows = is_first.clone() * next.proof_idx;
 
-        assert_array_eq(
-            &mut builder.when(is_first * not(next.proof_idx)),
-            local.merkle_commit,
-            merkle_commit,
-        );
+        let local_num_proofs =
+            local.is_present * is_leaf.clone() + is_internal * local_num_def_circuit_proofs;
+        let next_num_proofs =
+            next.is_present * is_leaf + is_internal * next.child_pvs.input_commit[0];
+
+        let mut when_one_row = builder.when(is_first * not(next.proof_idx));
+        when_one_row.assert_eq(local_num_proofs.clone(), num_def_circuit_proofs);
+        assert_array_eq(&mut when_one_row, local.merkle_commit, merkle_commit);
+
+        builder
+            .when_transition()
+            .assert_eq(local_num_proofs + next_num_proofs, num_def_circuit_proofs);
 
         self.poseidon2_bus.lookup_key(
             builder,

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -83,6 +83,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .assert_one(next.proof_idx - local.proof_idx);
 
         builder.assert_bool(local.has_verifier_pvs);
+        builder.assert_eq(local.has_verifier_pvs, next.has_verifier_pvs);
 
         /*
          * We need to receive public values here to ensure the values read are correct.

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
@@ -31,6 +31,8 @@ pub fn generate_proving_ctx(
     debug_assert!((1..=2).contains(&num_proofs));
 
     let mut trace = vec![F::ZERO; num_rows * width];
+    let mut num_def_circuit_proofs = F::ZERO;
+
     for (proof_idx, (proof, chunk)) in proofs.iter().zip(trace.chunks_exact_mut(width)).enumerate()
     {
         let cols: &mut DeferralAggPvsCols<F> = chunk.borrow_mut();
@@ -42,6 +44,8 @@ pub fn generate_proving_ctx(
             let child_pvs: &DeferralAggregationPvs<F> =
                 proof.public_values[DEF_AGG_PVS_AIR_ID].as_slice().borrow();
             cols.merkle_commit = child_pvs.merkle_commit;
+            cols.child_pvs.input_commit[0] = child_pvs.num_def_circuit_proofs;
+            num_def_circuit_proofs += child_pvs.num_def_circuit_proofs;
         } else {
             let child_pvs: &DeferralCircuitPvs<F> = proof.public_values[DEF_CIRCUIT_PVS_AIR_ID]
                 .as_slice()
@@ -60,6 +64,7 @@ pub fn generate_proving_ctx(
             };
             cols.merkle_commit =
                 poseidon2_compress_with_capacity(folded_input_commit, child_pvs.output_commit).0;
+            num_def_circuit_proofs += F::ONE;
         }
     }
 
@@ -81,6 +86,7 @@ pub fn generate_proving_ctx(
         pvs.merkle_commit =
             poseidon2_compress_with_capacity(first_row.merkle_commit, second_row.merkle_commit).0;
     }
+    pvs.num_def_circuit_proofs = num_def_circuit_proofs;
 
     AirProvingContext {
         cached_mains: vec![],

--- a/crates/continuations/src/circuit/deferral/mod.rs
+++ b/crates/continuations/src/circuit/deferral/mod.rs
@@ -28,4 +28,6 @@ pub struct DeferralAggregationPvs<F> {
     /// the Merkle root of the aggregation subtree this proof is the root of
     /// at internal layers
     pub merkle_commit: [F; DIGEST_SIZE],
+    /// Number of present deferral circuit proofs that we've seen so far
+    pub num_def_circuit_proofs: F,
 }

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -62,6 +62,7 @@ cfg_if::cfg_if! {
             baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine,
         };
         use openvm_verify_stark_host::pvs::{VERIFIER_PVS_AIR_ID, DeferralPvs, VerifierBasePvs};
+        use p3_field::PrimeField32;
         use crate::prover::DeferralChildVkKind;
         use crate::utils::zero_hash;
         type RootEngine = BabyBearBn254Poseidon2CpuEngine;
@@ -523,6 +524,10 @@ fn test_deferral_leaf_prover(num_children: usize) -> Result<()> {
         .as_slice()
         .borrow();
     assert_eq!(expected_merkle_commit, wrapped_pvs.merkle_commit);
+    assert_eq!(
+        num_children as u32,
+        wrapped_pvs.num_def_circuit_proofs.as_canonical_u32()
+    );
 
     Ok(())
 }
@@ -551,6 +556,10 @@ fn test_deferral_aggregation(num_children: usize) -> Result<()> {
         .as_slice()
         .borrow();
     assert_eq!(expected_root_merkle, wrapped_pvs.merkle_commit);
+    assert_eq!(
+        num_children as u32,
+        wrapped_pvs.num_def_circuit_proofs.as_canonical_u32()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Resolves INT-6613 and INT-6782.

#### INT-6613: `DeferralAggPvsAir`: absent child `merkle_commit` unconstrained in two-child mode

The deferral hook circuit now receives `num_def_circuit_proofs`, and constrains that there are exactly onion hash elements. This implies that there are `num_def_circuit_proofs` set Merkle tree leaves, and the remainder are constrained to be 0. Should some child `merkle_commit` not be the correct `zero_hash` value the Merkle tree root will not equal the final `merkle_commit`.

#### INT-6782: Constrain number of deferral circuit inputs in deferral hook

`num_def_circuit_proofs` is now propagated and updated throughout the deferral aggregation tree. The final onion hash must consist of exactly `num_def_circuit_proofs` elements.