### PR TITLE
fix(v2-rc1): remove `block_size` from config

### DIFF
--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -8,9 +8,7 @@ use derive_new::new;
 use getset::{Setters, WithSetters};
 use openvm_instructions::riscv::{RV32_IMM_AS, RV32_MEMORY_AS, RV32_REGISTER_AS};
 use openvm_poseidon2_air::Poseidon2Config;
-use openvm_stark_backend::{
-    p3_field::Field, p3_util::log2_strict_usize, StarkEngine, StarkProtocolConfig, Val,
-};
+use openvm_stark_backend::{p3_field::Field, StarkEngine, StarkProtocolConfig, Val};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::{AnyEnum, VmChipComplex, BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, PROGRAM_AIR_ID};
@@ -189,21 +187,14 @@ impl Default for MemoryConfig {
 impl MemoryConfig {
     pub fn empty_address_space_configs(num_addr_spaces: usize) -> Vec<AddressSpaceHostConfig> {
         // By default only address spaces 1..=4 have non-empty cell counts.
-        // Unassigned address spaces default to block_size=DEFAULT_BLOCK_SIZE with native32 cells.
         let mut addr_spaces =
-            vec![
-                AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::native32());
-                num_addr_spaces
-            ];
-        addr_spaces[RV32_IMM_AS as usize] = AddressSpaceHostConfig::new(0, 1, MemoryCellType::Null);
-        addr_spaces[RV32_REGISTER_AS as usize] =
-            AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::U8);
+            vec![AddressSpaceHostConfig::new(0, MemoryCellType::native32()); num_addr_spaces];
+        addr_spaces[RV32_IMM_AS as usize] = AddressSpaceHostConfig::new(0, MemoryCellType::Null);
+        addr_spaces[RV32_REGISTER_AS as usize] = AddressSpaceHostConfig::new(0, MemoryCellType::U8);
 
-        addr_spaces[RV32_MEMORY_AS as usize] =
-            AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::U8);
+        addr_spaces[RV32_MEMORY_AS as usize] = AddressSpaceHostConfig::new(0, MemoryCellType::U8);
 
-        addr_spaces[PUBLIC_VALUES_AS as usize] =
-            AddressSpaceHostConfig::new(0, DEFAULT_BLOCK_SIZE, MemoryCellType::U8);
+        addr_spaces[PUBLIC_VALUES_AS as usize] = AddressSpaceHostConfig::new(0, MemoryCellType::U8);
 
         addr_spaces
     }
@@ -214,13 +205,6 @@ impl MemoryConfig {
             Self::empty_address_space_configs((1 << 3) + ADDR_SPACE_OFFSET as usize);
         addr_spaces[openvm_instructions::DEFERRAL_AS as usize].num_cells = 1 << 29;
         Self::new(3, addr_spaces, POINTER_MAX_BITS, 29, 17)
-    }
-
-    pub fn block_size_bits(&self) -> Vec<u8> {
-        self.addr_spaces
-            .iter()
-            .map(|addr_sp| log2_strict_usize(addr_sp.block_size) as u8)
-            .collect()
     }
 }
 
@@ -349,11 +333,6 @@ pub struct AddressSpaceHostConfig {
     /// The number of memory cells in each address space, where a memory cell refers to a single
     /// addressable unit of memory as defined by the ISA.
     pub num_cells: usize,
-    /// Block size for memory accesses. Each address space has a fixed block size that determines
-    /// the granularity of memory bus interactions.
-    ///
-    /// **Note**: Block size is in terms of memory cells.
-    pub block_size: usize,
     pub layout: MemoryCellType,
 }
 
@@ -363,8 +342,6 @@ impl AddressSpaceHostConfig {
         self.num_cells * self.layout.size()
     }
 }
-
-pub(crate) const MAX_CELL_BYTE_SIZE: usize = 8;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryCellType {

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -2,12 +2,14 @@ use abi_stable::std_types::RVec;
 use openvm_instructions::riscv::{RV32_NUM_REGISTERS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS};
 
 use crate::{
-    arch::{SystemConfig, BOUNDARY_AIR_ID, DEFAULT_BLOCK_SIZE, MERKLE_AIR_ID},
-    system::memory::dimensions::MemoryDimensions,
+    arch::{SystemConfig, BOUNDARY_AIR_ID, MERKLE_AIR_ID},
+    system::memory::{dimensions::MemoryDimensions, CHUNK},
 };
 
-const CHUNK: u32 = DEFAULT_BLOCK_SIZE as u32;
-const CHUNK_BITS: u32 = CHUNK.ilog2();
+/// CHUNK granularity (merkle leaf size) for page fault tracking.
+/// Must match the CHUNK used to compute `MemoryDimensions::address_height`.
+const CHUNK_U32: u32 = CHUNK as u32;
+const CHUNK_BITS: u32 = CHUNK_U32.ilog2();
 
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
@@ -161,11 +163,12 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
     ) {
         debug_assert!((address_space as usize) < self.addr_space_access_count.len());
 
-        let num_blocks = (size + CHUNK - 1) >> CHUNK_BITS;
-        let start_chunk_id = ptr >> CHUNK_BITS;
+        let chunk_idx = ptr >> CHUNK_BITS;
+        let end_chunk_idx = (ptr + size - 1) >> CHUNK_BITS;
+        let num_blocks = end_chunk_idx - chunk_idx + 1;
         let start_block_id = self
             .memory_dimensions
-            .label_to_index((address_space, start_chunk_id)) as u32;
+            .label_to_index((address_space, chunk_idx)) as u32;
         let end_block_id = start_block_id + num_blocks;
         let start_page_id = start_block_id >> PAGE_BITS;
         let end_page_id = ((end_block_id - 1) >> PAGE_BITS) + 1;
@@ -248,25 +251,48 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         self.page_indices_since_checkpoint_len = 0;
     }
 
-    /// Apply height updates given page counts
+    /// Overestimates trace heights from page faults.
+    ///
+    /// Memory leaves (CHUNK-sized) form a sparse merkle tree of height `h`. Each segment
+    /// maintains an initial and final tree, so all counts are doubled.
+    ///
+    /// On each page fault, we conservatively assume all `2^PAGE_BITS` leaves in the page
+    /// are touched and no merkle nodes are shared across pages:
+    ///
+    /// ```text
+    ///        [root]              height h
+    ///        /    \
+    ///      ...    ...
+    ///      /        \
+    ///   [page]    [page]         (h - PAGE_BITS) nodes above each page
+    ///   / .. \
+    ///  L  ..  L                  2^PAGE_BITS leaves, (2^PAGE_BITS - 1) internal nodes
+    /// ```
+    ///
+    /// Per page fault:
+    /// - BOUNDARY_AIR: `2 * 2^PAGE_BITS` rows (one init + one final row per leaf)
+    /// - MERKLE_AIR:   `2 * nodes_per_page` rows
+    /// - Poseidon2:    `2 * 2^PAGE_BITS` (leaf compression) + `2 * nodes_per_page` (tree hashes)
     #[inline(always)]
     fn apply_height_updates(&self, trace_heights: &mut [u32], addr_space_access_count: &[u32]) {
         let page_access_count: u32 = addr_space_access_count.iter().sum();
 
-        // On page fault, assume we add all leaves in a page
+        // Leaves touched: conservatively assume every leaf in each faulted page is touched.
         let leaves = page_access_count << PAGE_BITS;
-
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
 
         let merkle_height = self.memory_dimensions.overall_height();
-        let nodes = (((1 << PAGE_BITS) - 1) + (merkle_height - PAGE_BITS)) as u32;
+        let nodes_per_page = (((1 << PAGE_BITS) - 1) + (merkle_height - PAGE_BITS)) as u32;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
         unsafe {
-            *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves;
+            *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves * 2;
+            // Poseidon2: 2 hashes per leaf (compression) + 2 per internal node (init + final tree)
             *trace_heights.get_unchecked_mut(poseidon2_idx) +=
-                leaves * 2 + nodes * page_access_count * 2;
-            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += nodes * page_access_count * 2;
+                leaves * 2 + nodes_per_page * page_access_count * 2;
+            // Merkle AIR: 2 rows per internal node (init + final tree)
+            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) +=
+                nodes_per_page * page_access_count * 2;
         }
     }
 
@@ -288,6 +314,7 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_bitset_insert_range() {
         // 513 bits

--- a/crates/vm/src/arch/testing/cpu.rs
+++ b/crates/vm/src/arch/testing/cpu.rs
@@ -134,14 +134,6 @@ where
             .write(address_space, pointer, value.map(F::from_usize));
     }
 
-    fn write_cell(&mut self, address_space: usize, pointer: usize, value: F) {
-        self.write(address_space, pointer, [value]);
-    }
-
-    fn read_cell(&mut self, address_space: usize, pointer: usize) -> F {
-        self.read::<1>(address_space, pointer)[0]
-    }
-
     fn address_bits(&self) -> usize {
         self.memory.controller.memory_config().pointer_max_bits
     }
@@ -434,14 +426,15 @@ where
 
     pub fn finalize(mut self) -> Self {
         if let Some(memory_tester) = self.memory.take() {
-            let mut memory_controller = memory_tester.controller;
-            let mut memory = memory_tester.memory;
+            let MemoryTester {
+                chip: mem_chip,
+                mut memory,
+                controller: mut memory_controller,
+            } = memory_tester;
             let touched_memory = memory.finalize::<Val<SC>>();
             // Balance memory boundaries
             let range_checker = memory_controller.range_checker.clone();
-            for mem_chip in memory_tester.chip_for_block.into_values() {
-                self = self.load_periphery((mem_chip.air, mem_chip));
-            }
+            self = self.load_periphery((mem_chip.air, mem_chip));
             let mem_inventory = MemoryAirInventory::new(
                 memory_controller.memory_bridge(),
                 memory_controller.memory_config(),

--- a/crates/vm/src/arch/testing/cuda.rs
+++ b/crates/vm/src/arch/testing/cuda.rs
@@ -148,14 +148,6 @@ impl TestBuilder<F> for GpuChipTestBuilder {
         self.execution.execute(initial_state, final_state);
     }
 
-    fn read_cell(&mut self, address_space: usize, pointer: usize) -> F {
-        self.read::<1>(address_space, pointer)[0]
-    }
-
-    fn write_cell(&mut self, address_space: usize, pointer: usize, value: F) {
-        self.write(address_space, pointer, [value]);
-    }
-
     fn read<const N: usize>(&mut self, address_space: usize, pointer: usize) -> [F; N] {
         self.memory.read(address_space, pointer)
     }
@@ -565,24 +557,28 @@ impl GpuChipTester {
     }
 
     pub fn finalize(mut self) -> Self {
-        if let Some(mut memory_tester) = self.memory.take() {
-            let touched_memory = memory_tester.memory.finalize::<F>();
-            let memory_bridge = memory_tester.memory_bridge();
-
-            for chip in memory_tester.chip_for_block.into_values() {
-                self = self.load_periphery(chip.0.air, chip);
-            }
+        if let Some(memory_tester) = self.memory.take() {
+            let DeviceMemoryTester {
+                chip,
+                mut memory,
+                mut inventory,
+                hasher_chip,
+                config,
+                mem_bus,
+                range_bus,
+            } = memory_tester;
+            let touched_memory = memory.finalize::<F>();
+            let memory_bridge = MemoryBridge::new(mem_bus, config.timestamp_max_bits, range_bus);
+            self = self.load_periphery(chip.0.air, chip);
 
             let airs = MemoryAirInventory::new(
                 memory_bridge,
-                &memory_tester.config,
+                &config,
                 PermutationCheckBus::new(MEMORY_MERKLE_BUS),
                 PermutationCheckBus::new(POSEIDON2_DIRECT_BUS),
             )
             .into_airs();
-            let ctxs = memory_tester
-                .inventory
-                .generate_proving_ctxs(touched_memory);
+            let ctxs = inventory.generate_proving_ctxs(touched_memory);
             for (air, ctx) in airs
                 .into_iter()
                 .zip(ctxs)
@@ -591,7 +587,7 @@ impl GpuChipTester {
                 self = self.load_air_proving_ctx(air, ctx);
             }
 
-            if let Some(hasher_chip) = memory_tester.hasher_chip {
+            if let Some(hasher_chip) = hasher_chip {
                 let air: AirRef<SC> = match hasher_chip.as_ref() {
                     Poseidon2PeripheryChipGPU::Register0(_) => {
                         let config = Poseidon2Config::default();

--- a/crates/vm/src/arch/testing/memory/air.rs
+++ b/crates/vm/src/arch/testing/memory/air.rs
@@ -11,7 +11,10 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 
-use crate::system::memory::{offline_checker::MemoryBus, MemoryAddress};
+use crate::{
+    arch::DEFAULT_BLOCK_SIZE,
+    system::memory::{offline_checker::MemoryBus, MemoryAddress},
+};
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -61,17 +64,17 @@ impl<'a, T> DummyMemoryInteractionColsMut<'a, T> {
     }
 }
 
+/// AIR width = DEFAULT_BLOCK_SIZE + 4 (addr_space, ptr, data[DEFAULT_BLOCK_SIZE], timestamp, count)
 #[derive(Clone, Copy, Debug, derive_new::new)]
 pub struct MemoryDummyAir {
     pub bus: MemoryBus,
-    pub block_size: usize,
 }
 
 impl<F> BaseAirWithPublicValues<F> for MemoryDummyAir {}
 impl<F> PartitionedBaseAir<F> for MemoryDummyAir {}
 impl<F> BaseAir<F> for MemoryDummyAir {
     fn width(&self) -> usize {
-        self.block_size + 4
+        DEFAULT_BLOCK_SIZE + 4
     }
 }
 
@@ -116,7 +119,7 @@ impl<F: PrimeField32> MemoryDummyChip<F> {
     }
 
     pub fn push(&mut self, addr_space: u32, ptr: u32, data: &[F], timestamp: u32, count: F) {
-        assert_eq!(data.len(), self.air.block_size);
+        assert_eq!(data.len(), DEFAULT_BLOCK_SIZE);
         self.trace.push(F::from_u32(addr_space));
         self.trace.push(F::from_u32(ptr));
         self.trace.extend_from_slice(data);

--- a/crates/vm/src/arch/testing/memory/cuda.rs
+++ b/crates/vm/src/arch/testing/memory/cuda.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use openvm_circuit::{
     arch::{
         testing::memory::air::{MemoryDummyAir, MemoryDummyChip},
-        MemoryConfig,
+        MemoryConfig, DEFAULT_BLOCK_SIZE,
     },
     system::memory::{
         offline_checker::{MemoryBridge, MemoryBus},
@@ -28,7 +28,7 @@ use crate::{
 };
 
 pub struct DeviceMemoryTester {
-    pub chip_for_block: HashMap<usize, FixedSizeMemoryTester>,
+    pub(crate) chip: FixedSizeMemoryTester,
     pub memory: TracingMemory,
     pub inventory: MemoryInventoryGPU,
     pub hasher_chip: Option<Arc<Poseidon2PeripheryChipGPU>>,
@@ -46,11 +46,6 @@ impl DeviceMemoryTester {
         mem_config: MemoryConfig,
         range_checker: Arc<VariableRangeCheckerChipGPU>,
     ) -> Self {
-        let mut chip_for_block = HashMap::new();
-        for log_block_size in 0..6 {
-            let block_size = 1 << log_block_size;
-            chip_for_block.insert(block_size, FixedSizeMemoryTester::new(mem_bus, block_size));
-        }
         let range_bus = range_checker.cpu_chip.as_ref().unwrap().bus();
         let sbox_regs = 1;
         let poseidon2_periphery = Arc::new(Poseidon2PeripheryChipGPU::new(
@@ -61,7 +56,7 @@ impl DeviceMemoryTester {
             MemoryInventoryGPU::new(mem_config.clone(), poseidon2_periphery.clone());
         inventory.set_initial_memory(&memory.data.memory);
         Self {
-            chip_for_block,
+            chip: FixedSizeMemoryTester::new(mem_bus),
             memory,
             inventory,
             hasher_chip: Some(poseidon2_periphery),
@@ -76,23 +71,18 @@ impl DeviceMemoryTester {
     }
 
     pub fn read<const N: usize>(&mut self, addr_space: usize, ptr: usize) -> [F; N] {
+        const { assert!(N == DEFAULT_BLOCK_SIZE) };
         let t = self.memory.timestamp();
         let (t_prev, data) = unsafe { self.memory.read::<u8, N>(addr_space as u32, ptr as u32) };
         let data = data.map(F::from_u8);
-        self.chip_for_block.get_mut(&N).unwrap().receive(
-            addr_space as u32,
-            ptr as u32,
-            &data,
-            t_prev,
-        );
-        self.chip_for_block
-            .get_mut(&N)
-            .unwrap()
-            .send(addr_space as u32, ptr as u32, &data, t);
+        self.chip
+            .receive(addr_space as u32, ptr as u32, &data, t_prev);
+        self.chip.send(addr_space as u32, ptr as u32, &data, t);
         data
     }
 
     pub fn write<const N: usize>(&mut self, addr_space: usize, ptr: usize, data: [F; N]) {
+        const { assert!(N == DEFAULT_BLOCK_SIZE) };
         let t = self.memory.timestamp();
         let (t_prev, data_prev) = unsafe {
             self.memory.write::<u8, N>(
@@ -102,24 +92,17 @@ impl DeviceMemoryTester {
             )
         };
         let data_prev = data_prev.map(F::from_u8);
-        self.chip_for_block.get_mut(&N).unwrap().receive(
-            addr_space as u32,
-            ptr as u32,
-            &data_prev,
-            t_prev,
-        );
-        self.chip_for_block
-            .get_mut(&N)
-            .unwrap()
-            .send(addr_space as u32, ptr as u32, &data, t);
+        self.chip
+            .receive(addr_space as u32, ptr as u32, &data_prev, t_prev);
+        self.chip.send(addr_space as u32, ptr as u32, &data, t);
     }
 }
 
 pub struct FixedSizeMemoryTester(pub(crate) MemoryDummyChip<F>);
 
 impl FixedSizeMemoryTester {
-    pub fn new(bus: MemoryBus, block_size: usize) -> Self {
-        Self(MemoryDummyChip::new(MemoryDummyAir::new(bus, block_size)))
+    pub fn new(bus: MemoryBus) -> Self {
+        Self(MemoryDummyChip::new(MemoryDummyAir::new(bus)))
     }
 
     pub fn send(&mut self, addr_space: u32, ptr: u32, data: &[F], timestamp: u32) {
@@ -152,7 +135,7 @@ impl<RA> Chip<RA, GpuBackend> for FixedSizeMemoryTester {
                 width,
                 &records.to_device().unwrap(),
                 num_records,
-                self.0.air.block_size,
+                DEFAULT_BLOCK_SIZE,
             )
             .unwrap();
         }

--- a/crates/vm/src/arch/testing/memory/mod.rs
+++ b/crates/vm/src/arch/testing/memory/mod.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-
 use air::{MemoryDummyAir, MemoryDummyChip};
 use rand::Rng;
 
 use crate::{
-    arch::VmField,
+    arch::{VmField, DEFAULT_BLOCK_SIZE},
     system::memory::{online::TracingMemory, MemoryController},
 };
 
@@ -15,57 +13,41 @@ mod cuda;
 #[cfg(feature = "cuda")]
 pub use cuda::*;
 
-/// A dummy testing chip that will add unconstrained messages into the [MemoryBus].
-/// Stores a log of raw messages to send/receive to the [MemoryBus].
-///
-/// It will create a [air::MemoryDummyAir] to add messages to MemoryBus.
+/// A dummy testing chip that sends/receives unconstrained messages on the [MemoryBus].
+/// All memory accesses use `DEFAULT_BLOCK_SIZE`.
 pub struct MemoryTester<F: VmField> {
-    /// Map from `block_size` to [MemoryDummyChip] of that block size
-    pub chip_for_block: HashMap<usize, MemoryDummyChip<F>>,
+    pub(crate) chip: MemoryDummyChip<F>,
     pub memory: TracingMemory,
     pub(super) controller: MemoryController<F>,
 }
 
 impl<F: VmField> MemoryTester<F> {
     pub fn new(controller: MemoryController<F>, memory: TracingMemory) -> Self {
-        let bus = controller.memory_bus;
-        let mut chip_for_block = HashMap::new();
-        for log_block_size in 0..6 {
-            let block_size = 1 << log_block_size;
-            let chip = MemoryDummyChip::new(MemoryDummyAir::new(bus, block_size));
-            chip_for_block.insert(block_size, chip);
-        }
+        let chip = MemoryDummyChip::new(MemoryDummyAir::new(controller.memory_bus));
         Self {
-            chip_for_block,
+            chip,
             memory,
             controller,
         }
     }
 
     pub fn read<const N: usize>(&mut self, addr_space: usize, ptr: usize) -> [F; N] {
+        const { assert!(N == DEFAULT_BLOCK_SIZE) };
         let memory = &mut self.memory;
         let t = memory.timestamp();
-        // TODO: this could be improved if we added a TracingMemory::get_f function
         let (t_prev, data) = unsafe { memory.read::<u8, N>(addr_space as u32, ptr as u32) };
         let data = data.map(F::from_u8);
-        self.chip_for_block.get_mut(&N).unwrap().receive(
-            addr_space as u32,
-            ptr as u32,
-            &data,
-            t_prev,
-        );
-        self.chip_for_block
-            .get_mut(&N)
-            .unwrap()
-            .send(addr_space as u32, ptr as u32, &data, t);
+        self.chip
+            .receive(addr_space as u32, ptr as u32, &data, t_prev);
+        self.chip.send(addr_space as u32, ptr as u32, &data, t);
 
         data
     }
 
     pub fn write<const N: usize>(&mut self, addr_space: usize, ptr: usize, data: [F; N]) {
+        const { assert!(N == DEFAULT_BLOCK_SIZE) };
         let memory = &mut self.memory;
         let t = memory.timestamp();
-        // TODO: this could be improved if we added a TracingMemory::write_f function
         let (t_prev, data_prev) = unsafe {
             memory.write::<u8, N>(
                 addr_space as u32,
@@ -74,16 +56,9 @@ impl<F: VmField> MemoryTester<F> {
             )
         };
         let data_prev = data_prev.map(F::from_u8);
-        self.chip_for_block.get_mut(&N).unwrap().receive(
-            addr_space as u32,
-            ptr as u32,
-            &data_prev,
-            t_prev,
-        );
-        self.chip_for_block
-            .get_mut(&N)
-            .unwrap()
-            .send(addr_space as u32, ptr as u32, &data, t);
+        self.chip
+            .receive(addr_space as u32, ptr as u32, &data_prev, t_prev);
+        self.chip.send(addr_space as u32, ptr as u32, &data, t);
     }
 }
 

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -78,9 +78,6 @@ pub trait TestBuilder<F> {
         initial_pc: u32,
     );
 
-    fn write_cell(&mut self, address_space: usize, pointer: usize, value: F);
-    fn read_cell(&mut self, address_space: usize, pointer: usize) -> F;
-
     fn write<const N: usize>(&mut self, address_space: usize, pointer: usize, value: [F; N]);
     fn read<const N: usize>(&mut self, address_space: usize, pointer: usize) -> [F; N];
 

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -25,7 +25,7 @@ use crate::{
             dimensions::MemoryDimensions,
             merkle::MemoryMerkleChip,
             offline_checker::{MemoryBaseAuxCols, MemoryBridge, MemoryBus, AUX_LEN},
-            persistent::PersistentBoundaryChip,
+            persistent::{group_touched_memory_by_chunk, PersistentBoundaryChip},
         },
         poseidon2::Poseidon2PeripheryChip,
         TouchedMemory,
@@ -188,27 +188,22 @@ impl<F: VmField> MemoryController<F> {
 
         // Rechunk DEFAULT_BLOCK_SIZE blocks into CHUNK-sized blocks for merkle_chip
         // Note: Equipartition key is (addr_space, ptr) where ptr is the starting pointer
-        let final_memory_values: Equipartition<F, CHUNK> = {
-            use std::collections::BTreeMap;
-            let mut chunk_map: BTreeMap<(u32, u32), [F; CHUNK]> = BTreeMap::new();
-            for ((addr_space, ptr), ts_values) in final_memory {
-                // Align to CHUNK boundary to get the chunk's starting pointer
-                let chunk_ptr = (ptr / CHUNK as u32) * CHUNK as u32;
-                let block_idx_in_chunk =
-                    ((ptr % CHUNK as u32) / DEFAULT_BLOCK_SIZE as u32) as usize;
-                let entry = chunk_map.entry((addr_space, chunk_ptr)).or_insert_with(|| {
-                    // Initialize with values from initial memory
-                    std::array::from_fn(|i| unsafe {
+        let final_memory_values: Equipartition<F, CHUNK> =
+            group_touched_memory_by_chunk(&final_memory)
+                .into_iter()
+                .map(|((addr_space, chunk_label), blocks)| {
+                    let chunk_ptr = chunk_label * CHUNK as u32;
+                    let mut values = std::array::from_fn(|i| unsafe {
                         initial_memory.get_f::<F>(addr_space, chunk_ptr + i as u32)
-                    })
-                });
-                // Copy values for this block
-                for (i, val) in ts_values.values.into_iter().enumerate() {
-                    entry[block_idx_in_chunk * DEFAULT_BLOCK_SIZE + i] = val;
-                }
-            }
-            chunk_map
-        };
+                    });
+                    for (block_idx, _, block_values) in blocks {
+                        for (i, val) in block_values.into_iter().enumerate() {
+                            values[block_idx * DEFAULT_BLOCK_SIZE + i] = val;
+                        }
+                    }
+                    ((addr_space, chunk_ptr), values)
+                })
+                .collect();
         merkle_chip.finalize(initial_memory, &final_memory_values, hasher.as_ref());
 
         vec![

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -191,17 +191,14 @@ fn random_test(
         vec![
             AddressSpaceHostConfig {
                 num_cells: 0,
-                block_size: 0,
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
         ],
@@ -283,17 +280,14 @@ fn expand_test_no_accesses() {
         vec![
             AddressSpaceHostConfig {
                 num_cells: 0,
-                block_size: 0,
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
         ],
@@ -331,17 +325,14 @@ fn expand_test_negative() {
         vec![
             AddressSpaceHostConfig {
                 num_cells: 0,
-                block_size: 0,
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
             AddressSpaceHostConfig {
                 num_cells: CHUNK << height,
-                block_size: 1,
                 layout: MemoryCellType::Native { size: 4 },
             },
         ],

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -1,24 +1,16 @@
 use std::{array::from_fn, fmt::Debug};
 
 use getset::Getters;
-use itertools::zip_eq;
 use openvm_instructions::exe::SparseMemoryImage;
 use openvm_stark_backend::{
     p3_field::{Field, PrimeField32},
     p3_maybe_rayon::prelude::*,
-    p3_util::log2_strict_usize,
 };
 use tracing::instrument;
 
 use crate::{
-    arch::{
-        AddressSpaceHostConfig, AddressSpaceHostLayout, MemoryConfig, DEFAULT_BLOCK_SIZE,
-        MAX_CELL_BYTE_SIZE,
-    },
-    system::{
-        memory::{MemoryAddress, TimestampedEquipartition, TimestampedValues},
-        TouchedMemory,
-    },
+    arch::{AddressSpaceHostConfig, AddressSpaceHostLayout, MemoryConfig, DEFAULT_BLOCK_SIZE},
+    system::{memory::TimestampedValues, TouchedMemory},
 };
 
 mod basic;
@@ -382,12 +374,9 @@ pub struct TracingMemory {
     /// The underlying data memory, with memory cells typed by address space: see [AddressMap].
     #[getset(get = "pub")]
     pub data: GuestMemory,
-    /// Maps (addr_space, ptr / block_size[addr_space]) → timestamp of last access.
-    /// A value of 0 means the slot has never been accessed.
+    /// Maps `(addr_space, ptr / DEFAULT_BLOCK_SIZE)` to the latest access timestamp.
+    /// A value of 0 means the 4-cell touched-memory slot has never been accessed.
     pub(super) meta: Vec<PagedVec<u32, PAGE_SIZE>>,
-    /// For each `addr_space`, the block size for memory accesses. All memory accesses in
-    /// `addr_space` must be aligned to this block size.
-    pub block_size: Vec<u32>,
 }
 
 impl TracingMemory {
@@ -398,19 +387,15 @@ impl TracingMemory {
 
     /// Constructor from pre-existing memory image.
     pub fn from_image(image: GuestMemory) -> Self {
-        let (meta, block_size): (Vec<_>, Vec<_>) =
-            zip_eq(image.memory.get_memory(), &image.memory.config)
-                .map(|(mem, addr_sp)| {
-                    let num_cells = mem.size() / addr_sp.layout.size();
-                    let block_size = addr_sp.block_size;
-                    let total_metadata_len = num_cells.div_ceil(block_size);
-                    (PagedVec::new(total_metadata_len), block_size as u32)
-                })
-                .unzip();
+        let meta = image
+            .memory
+            .config
+            .iter()
+            .map(|config| PagedVec::new(config.num_cells.div_ceil(DEFAULT_BLOCK_SIZE)))
+            .collect();
         Self {
             data: image,
             meta,
-            block_size,
             timestamp: INITIAL_TIMESTAMP + 1,
         }
     }
@@ -419,7 +404,10 @@ impl TracingMemory {
     fn assert_valid_access(&self, block_size: usize, addr_space: u32, ptr: u32) {
         debug_assert_ne!(addr_space, 0);
         debug_assert!(block_size.is_power_of_two());
-        debug_assert_eq!(block_size, self.block_size[addr_space as usize] as usize);
+        debug_assert_eq!(
+            block_size, DEFAULT_BLOCK_SIZE,
+            "TracingMemory only supports {DEFAULT_BLOCK_SIZE}-cell accesses; got {block_size}"
+        );
         assert_eq!(
             ptr % block_size as u32,
             0,
@@ -427,13 +415,11 @@ impl TracingMemory {
         );
     }
 
-    /// Returns the previous access timestamp and updates metadata for this access.
-    /// Each read/write accesses exactly one metadata slot since callers always use
-    /// BLOCK_SIZE == block_size[addr_space].
+    /// Returns the previous access timestamp and updates the metadata slot.
+    /// Block size is always `DEFAULT_BLOCK_SIZE`, so this is a single-slot read/write.
     #[inline(always)]
     fn prev_access_time(&mut self, address_space: usize, pointer: usize) -> u32 {
-        let bs = self.block_size[address_space] as usize;
-        let idx = pointer / bs;
+        let idx = pointer / DEFAULT_BLOCK_SIZE;
         // SAFETY: address_space is validated during instruction decoding
         let meta_page = unsafe { self.meta.get_unchecked_mut(address_space) };
         let prev = meta_page.get(idx);
@@ -447,7 +433,8 @@ impl TracingMemory {
     /// # Safety
     /// - `T` must be `repr(C)` or `repr(transparent)` and match the cell type for `address_space`.
     /// - `address_space` must be valid.
-    /// - `BLOCK_SIZE` must equal the address space's block size.
+    /// - `BLOCK_SIZE` is measured in memory cells and is tracked in fixed `DEFAULT_BLOCK_SIZE`
+    ///   touched-memory slots.
     #[inline(always)]
     pub unsafe fn read<T, const BLOCK_SIZE: usize>(
         &mut self,
@@ -470,7 +457,8 @@ impl TracingMemory {
     /// # Safety
     /// - `T` must be `repr(C)` or `repr(transparent)` and match the cell type for `address_space`.
     /// - `address_space` must be valid.
-    /// - `BLOCK_SIZE` must equal the address space's block size.
+    /// - `BLOCK_SIZE` is measured in memory cells and is tracked in fixed `DEFAULT_BLOCK_SIZE`
+    ///   touched-memory slots.
     #[inline(always)]
     pub unsafe fn write<T, const BLOCK_SIZE: usize>(
         &mut self,
@@ -505,23 +493,22 @@ impl TracingMemory {
     /// Finalize the boundary and merkle chips.
     #[instrument(name = "memory_finalize", skip_all)]
     pub fn finalize<F: Field>(&mut self) -> TouchedMemory<F> {
-        let touched_blocks = self.touched_blocks();
-        self.touched_blocks_to_equipartition::<F, DEFAULT_BLOCK_SIZE>(touched_blocks)
+        self.touched_blocks_to_equipartition::<F>(self.touched_blocks())
     }
 
-    /// Returns the list of all touched blocks (address, timestamp). Sorted by address.
+    /// Returns the list of all touched blocks (address, timestamp), sorted by address.
     fn touched_blocks(&self) -> Vec<(Address, u32)> {
-        assert_eq!(self.meta.len(), self.block_size.len());
-        self.meta
+        assert_eq!(self.meta.len(), self.data.memory.config.len());
+        let mut touched_blocks: Vec<_> = self
+            .meta
             .par_iter()
-            .zip(self.block_size.par_iter())
             .enumerate()
-            .flat_map(|(addr_space, (meta_page, &bs))| {
+            .flat_map_iter(|(addr_space, meta_page)| {
                 meta_page
                     .par_iter()
                     .filter_map(move |(idx, timestamp)| {
                         if timestamp > INITIAL_TIMESTAMP {
-                            let ptr = idx as u32 * bs;
+                            let ptr = idx as u32 * DEFAULT_BLOCK_SIZE as u32;
                             Some(((addr_space as u32, ptr), timestamp))
                         } else {
                             None
@@ -529,100 +516,35 @@ impl TracingMemory {
                     })
                     .collect::<Vec<_>>()
             })
-            .collect()
+            .collect();
+        // This sort may not be strictly necessary, but it makes the finalize path independent of
+        // Rayon ordering.
+        touched_blocks.sort_unstable_by_key(|(addr, _)| *addr);
+        touched_blocks
     }
 
-    /// Returns the equipartition of the touched blocks.
-    fn touched_blocks_to_equipartition<F: Field, const CHUNK: usize>(
-        &mut self,
+    /// Returns the fixed 4-byte touched memory equipartition.
+    fn touched_blocks_to_equipartition<F: Field>(
+        &self,
         touched_blocks: Vec<((u32, u32), u32)>,
-    ) -> TimestampedEquipartition<F, CHUNK> {
-        let mut final_memory = Vec::new();
-
+    ) -> TouchedMemory<F> {
         debug_assert!(touched_blocks.is_sorted_by_key(|(addr, _)| addr));
-        self.handle_touched_blocks::<F, CHUNK>(&mut final_memory, touched_blocks);
-
-        debug_assert!(final_memory.is_sorted_by_key(|(key, _)| *key));
-        final_memory
-    }
-
-    fn handle_touched_blocks<F: Field, const CHUNK: usize>(
-        &mut self,
-        final_memory: &mut Vec<((u32, u32), TimestampedValues<F, CHUNK>)>,
-        touched_blocks: Vec<((u32, u32), u32)>,
-    ) {
-        let mut current_values = vec![0u8; MAX_CELL_BYTE_SIZE * CHUNK];
-        let mut current_cnt = 0;
-        let mut current_address = MemoryAddress::new(0, 0);
-        let mut current_timestamps = vec![0u32; CHUNK];
-        for ((addr_space, ptr), timestamp) in touched_blocks {
-            // SAFETY: addr_space of touched blocks are all in bounds
-            let addr_space_config =
-                unsafe { *self.data.memory.config.get_unchecked(addr_space as usize) };
-            let block_size = addr_space_config.block_size;
-            let cell_size = addr_space_config.layout.size();
-            debug_assert!(ptr % block_size as u32 == 0);
-
-            assert!(
-                current_cnt == 0
-                    || (current_address.address_space == addr_space
-                        && current_address.pointer + current_cnt as u32 == ptr),
-                "The union of all touched blocks must consist of blocks with sizes divisible by `CHUNK`"
-            );
-
-            if current_cnt == 0 {
-                assert_eq!(
-                    ptr & (CHUNK as u32 - 1),
-                    0,
-                    "The union of all touched blocks must consist of `CHUNK`-aligned blocks"
-                );
-                current_address = MemoryAddress::new(addr_space, ptr);
-            }
-
-            // SAFETY: current_cnt / block_size < CHUNK / block_size <= CHUNK
-            unsafe {
-                *current_timestamps.get_unchecked_mut(current_cnt / block_size) = timestamp;
-            }
-
-            for i in 0..block_size as u32 {
-                let cell_data = unsafe {
-                    self.data.memory.get_u8_slice(
-                        addr_space,
-                        (ptr + i) as usize * cell_size,
-                        cell_size,
-                    )
-                };
-                current_values[current_cnt * cell_size..current_cnt * cell_size + cell_size]
-                    .copy_from_slice(cell_data);
-                current_cnt += 1;
-                if current_cnt == CHUNK {
-                    let timestamp = *current_timestamps[..CHUNK / block_size]
-                        .iter()
-                        .max()
-                        .unwrap();
-                    final_memory.push((
-                        (current_address.address_space, current_address.pointer),
-                        TimestampedValues {
-                            timestamp,
-                            values: from_fn(|i| unsafe {
-                                addr_space_config.layout.to_field(
-                                    &current_values[i * cell_size..i * cell_size + cell_size],
-                                )
-                            }),
-                        },
-                    ));
-                    current_address.pointer += current_cnt as u32;
-                    current_cnt = 0;
-                }
-            }
-        }
-        assert_eq!(current_cnt, 0, "The union of all touched blocks must consist of blocks with sizes divisible by `CHUNK`");
-    }
-
-    pub fn block_size_bits(&self) -> Vec<u8> {
-        self.block_size
-            .iter()
-            .map(|&x| log2_strict_usize(x as usize) as u8)
+        touched_blocks
+            .into_par_iter()
+            .map(|((addr_space, ptr), timestamp)| {
+                let addr_space_config = &self.data.memory.config[addr_space as usize];
+                let cell_size = addr_space_config.layout.size();
+                let values = from_fn(|i| unsafe {
+                    addr_space_config
+                        .layout
+                        .to_field(self.data.memory.get_u8_slice(
+                            addr_space,
+                            (ptr as usize + i) * cell_size,
+                            cell_size,
+                        ))
+                });
+                ((addr_space, ptr), TimestampedValues { timestamp, values })
+            })
             .collect()
     }
 }

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -163,6 +163,35 @@ pub struct FinalTouchedLabel<F, const CHUNK: usize> {
     final_timestamps: [u32; BLOCKS_PER_CHUNK],
 }
 
+type BlockInfo<F> = (usize, u32, [F; DEFAULT_BLOCK_SIZE]); // (block_idx, timestamp, values)
+type EnrichedEntry<F> = ((u32, u32), BlockInfo<F>); // (chunk_key, block_info)
+pub(crate) type ChunkedTouchedMemory<F> = Vec<((u32, u32), Vec<BlockInfo<F>>)>;
+
+pub(crate) fn group_touched_memory_by_chunk<F: Copy + Send + Sync>(
+    final_memory: &TimestampedEquipartition<F, DEFAULT_BLOCK_SIZE>,
+) -> ChunkedTouchedMemory<F> {
+    let mut enriched: Vec<EnrichedEntry<F>> = final_memory
+        .par_iter()
+        .map(|&((addr_space, ptr), ts_values)| {
+            let chunk_label = ptr / CHUNK as u32;
+            let block_idx = ((ptr % CHUNK as u32) / DEFAULT_BLOCK_SIZE as u32) as usize;
+            let key = (addr_space, chunk_label);
+            let block_info = (block_idx, ts_values.timestamp, ts_values.values);
+            (key, block_info)
+        })
+        .collect();
+    enriched.sort_unstable_by_key(|(key, _)| *key);
+
+    enriched
+        .chunk_by(|a, b| a.0 == b.0)
+        .map(|group| {
+            let key = group[0].0;
+            let blocks = group.iter().map(|&(_, info)| info).collect();
+            (key, blocks)
+        })
+        .collect()
+}
+
 impl<F: PrimeField32, const CHUNK: usize> Default for TouchedLabels<F, CHUNK> {
     fn default() -> Self {
         Self::Running(FxHashSet::default())
@@ -218,6 +247,9 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
     }
 
     pub fn touch_range(&mut self, address_space: u32, pointer: u32, len: u32) {
+        if len == 0 {
+            return;
+        }
         let start_label = pointer / CHUNK as u32;
         let end_label = (pointer + len - 1) / CHUNK as u32;
         for label in start_label..=end_label {
@@ -241,30 +273,7 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
     ) where
         H: Hasher<CHUNK, F> + Sync + for<'a> SerialReceiver<&'a [F]>,
     {
-        type BlockInfo<F> = (usize, u32, [F; DEFAULT_BLOCK_SIZE]); // (block_idx, timestamp, values)
-        type EnrichedEntry<F> = ((u32, u32), BlockInfo<F>); // (chunk_key, block_info)
-
-        let enriched: Vec<EnrichedEntry<F>> = final_memory
-            .par_iter()
-            .map(|&((addr_space, ptr), ts_values)| {
-                let chunk_label = ptr / CHUNK as u32;
-                let block_idx = ((ptr % CHUNK as u32) / DEFAULT_BLOCK_SIZE as u32) as usize;
-                let key = (addr_space, chunk_label);
-                let block_info = (block_idx, ts_values.timestamp, ts_values.values);
-                (key, block_info)
-            })
-            .collect();
-
-        let chunk_groups: Vec<_> = enriched
-            .chunk_by(|a, b| a.0 == b.0)
-            .map(|group| {
-                let key = group[0].0;
-                let blocks: Vec<BlockInfo<F>> = group.iter().map(|&(_, info)| info).collect();
-                (key, blocks)
-            })
-            .collect();
-
-        let final_touched_labels: Vec<_> = chunk_groups
+        let final_touched_labels: Vec<_> = group_touched_memory_by_chunk(final_memory)
             .into_par_iter()
             .map(|((addr_space, chunk_label), blocks)| {
                 let chunk_ptr = chunk_label * CHUNK as u32;

--- a/crates/vm/src/system/memory/tests.rs
+++ b/crates/vm/src/system/memory/tests.rs
@@ -7,7 +7,7 @@ use test_case::test_case;
 
 use crate::arch::{
     testing::{TestBuilder, VmChipTestBuilder},
-    MemoryConfig,
+    MemoryConfig, DEFAULT_BLOCK_SIZE,
 };
 
 type F = BabyBear;
@@ -19,43 +19,16 @@ fn test_memory_write_by_tester(tester: &mut impl TestBuilder<F>, its: usize) {
     // and intersecting/overlapping blocks,
     // by limiting the space of valid pointers.
     let max_ptr = 20;
-    let aligns = [4, 4, 4];
     let value_bounds = [256, 256, 256];
     for _ in 0..its {
-        let addr_sp = rng.random_range(1..=aligns.len());
-        let align: usize = aligns[addr_sp - 1];
+        let addr_sp = rng.random_range(1..=value_bounds.len());
         let value_bound: u32 = value_bounds[addr_sp - 1];
-        let ptr = rng.random_range(0..max_ptr / align) * align;
-        // Accesses use the address space minimum block size.
-        let log_len = align.trailing_zeros();
-        match log_len {
-            0 => tester.write::<1>(
-                addr_sp,
-                ptr,
-                array::from_fn(|_| F::from_u32(rng.random_range(0..value_bound))),
-            ),
-            1 => tester.write::<2>(
-                addr_sp,
-                ptr,
-                array::from_fn(|_| F::from_u32(rng.random_range(0..value_bound))),
-            ),
-            2 => tester.write::<4>(
-                addr_sp,
-                ptr,
-                array::from_fn(|_| F::from_u32(rng.random_range(0..value_bound))),
-            ),
-            3 => tester.write::<8>(
-                addr_sp,
-                ptr,
-                array::from_fn(|_| F::from_u32(rng.random_range(0..value_bound))),
-            ),
-            4 => tester.write::<16>(
-                addr_sp,
-                ptr,
-                array::from_fn(|_| F::from_u32(rng.random_range(0..value_bound))),
-            ),
-            _ => unreachable!(),
-        }
+        let ptr = rng.random_range(0..max_ptr / DEFAULT_BLOCK_SIZE) * DEFAULT_BLOCK_SIZE;
+        tester.write::<DEFAULT_BLOCK_SIZE>(
+            addr_sp,
+            ptr,
+            array::from_fn(|_| F::from_u32(rng.random_range(0..value_bound))),
+        );
     }
 }
 

--- a/extensions/rv32im/circuit/src/adapters/deferral.rs
+++ b/extensions/rv32im/circuit/src/adapters/deferral.rs
@@ -14,7 +14,7 @@ where
     F: PrimeField32,
 {
     // SAFETY:
-    // - address space `DEFERRAL_AS` will always have cell type `F` and minimum alignment of `1`
+    // - address space `DEFERRAL_AS` has cell type `F` with `DEFAULT_BLOCK_SIZE`-aligned accesses
     unsafe { memory.read::<F, N>(DEFERRAL_AS, ptr) }
 }
 
@@ -39,7 +39,7 @@ where
     F: PrimeField32,
 {
     // SAFETY:
-    // - address space `DEFERRAL_AS` will always have cell type `F` and minimum alignment of `1`
+    // - address space `DEFERRAL_AS` has cell type `F` with `DEFAULT_BLOCK_SIZE`-aligned accesses
     unsafe { memory.write::<F, N>(DEFERRAL_AS, ptr, data) }
 }
 
@@ -104,7 +104,7 @@ where
     F: PrimeField32,
 {
     // SAFETY:
-    // - address space `DEFERRAL_AS` has cell type `F` and block_size of `DEFAULT_BLOCK_SIZE`
+    // - address space `DEFERRAL_AS` has cell type `F` with `DEFAULT_BLOCK_SIZE`-aligned accesses
     unsafe { memory.read::<F, BLOCK_SIZE>(DEFERRAL_AS, ptr) }
 }
 
@@ -118,7 +118,7 @@ where
     F: PrimeField32,
 {
     // SAFETY:
-    // - address space `DEFERRAL_AS` has cell type `F` and block_size of `DEFAULT_BLOCK_SIZE`
+    // - address space `DEFERRAL_AS` has cell type `F` with `DEFAULT_BLOCK_SIZE`-aligned accesses
     unsafe { memory.write::<F, BLOCK_SIZE>(DEFERRAL_AS, ptr, vals) }
 }
 

--- a/extensions/rv32im/circuit/src/adapters/mod.rs
+++ b/extensions/rv32im/circuit/src/adapters/mod.rs
@@ -73,7 +73,7 @@ pub fn memory_read<const N: usize>(memory: &GuestMemory, address_space: u32, ptr
 
     // SAFETY:
     // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
-    //   and block_size of `DEFAULT_BLOCK_SIZE`
+    //   and use the fixed 4-byte VM memory access granularity
     unsafe { memory.read::<u8, N>(address_space, ptr) }
 }
 
@@ -92,7 +92,7 @@ pub fn memory_write<const N: usize>(
 
     // SAFETY:
     // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
-    //   and block_size of `DEFAULT_BLOCK_SIZE`
+    //   and use the fixed 4-byte VM memory access granularity
     unsafe { memory.write::<u8, N>(address_space, ptr, data) }
 }
 
@@ -113,7 +113,7 @@ pub fn timed_read<const N: usize>(
 
     // SAFETY:
     // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
-    //   and block_size of `DEFAULT_BLOCK_SIZE`
+    //   and use the fixed 4-byte VM memory access granularity
     unsafe { memory.read::<u8, N>(address_space, ptr) }
 }
 
@@ -132,7 +132,7 @@ pub fn timed_write<const N: usize>(
 
     // SAFETY:
     // - address spaces `RV32_REGISTER_AS`, `RV32_MEMORY_AS`, `PUBLIC_VALUES_AS` have cell type `u8`
-    //   and block_size of `DEFAULT_BLOCK_SIZE`
+    //   and use the fixed 4-byte VM memory access granularity
     unsafe { memory.write::<u8, N>(address_space, ptr, data) }
 }
 

--- a/extensions/rv32im/circuit/src/base_alu/tests.rs
+++ b/extensions/rv32im/circuit/src/base_alu/tests.rs
@@ -160,7 +160,7 @@ fn rand_rv32_alu_test(opcode: BaseAluOpcode, num_ops: usize) {
     // TODO(AG): make a more meaningful test for memory accesses
     tester.write(2, 1024, [F::ONE; 4]);
     tester.write(2, 1028, [F::ONE; 4]);
-    // Use DEFAULT_BLOCK_SIZE-aligned accesses matching the minimum block size
+    // Use fixed DEFAULT_BLOCK_SIZE-aligned accesses.
     let sm1 = tester.read(2, 1024);
     let sm2 = tester.read(2, 1028);
     assert_eq!(sm1, [F::ONE; 4]);

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -9,9 +9,9 @@ mod aot {
     use openvm_circuit::{
         arch::{
             execution_mode::{metered::memory_ctx::MemoryCtx, MeteredCtx},
-            AotError, SystemConfig, VmExecState, ADDR_SPACE_OFFSET, DEFAULT_BLOCK_SIZE,
+            AotError, SystemConfig, VmExecState, ADDR_SPACE_OFFSET,
         },
-        system::memory::online::GuestMemory,
+        system::memory::{online::GuestMemory, CHUNK},
     };
     /// This is DIRTY because PAGE_BITS is a generic parameter of E2 context.
     const DEFAULT_PAGE_BITS: usize = 6;
@@ -166,29 +166,29 @@ mod aot {
         // 
         // For a specific RV32 instruction, the variables can be treated as constants at AOT compilation time:
         // Inputs:
-        // - `chunk`: always 8(CHUNK) because we only support when continuation is enabled.
+        // - `chunk`: always CHUNK (8), the merkle leaf size.
         // - `address_space`: always a constant because it is derived from an Instruction
         // - `size`: RV32 instruction always read 4 bytes(in the AIR level).
         // - `self.memory_dimensions.address_height`: known at AOT compilation time because it is derived from the memory configuration.
         // Inside the function body:
-        // - `num_blocks`: `(size + self.chunk - 1) >> self.chunk_bits = (4 + 8 - 1) >> 3 = 1`
+        // - `num_blocks`: `(size + chunk - 1) >> chunk_bits = (4 + 8 - 1) >> 3 = 1`
         // - `as_offset = (addr_space - ADDR_SPACE_OFFSET) as u64) << self.address_height)`: constant because `address_space` and `address_height` constant
-        // - `start_chunk_id`: `ptr >> self.chunk_bits`
-        // - `start_block_id`: `start_chunk_id + as_offset`
+        // - `chunk_idx`: `ptr >> chunk_bits`
+        // - `start_block_id`: `chunk_idx + as_offset`
         // - `end_block_id`: `start_block_id + num_blocks = start_block_id +1`
         // - `start_page_id`: `start_block_id >> PAGE_BITS`
         // - `end_page_id`: ((end_block_id - 1) >> PAGE_BITS) + 1 = start_block_id >> PAGE_BITS + 1;
         //
         // Therefore the loop only iterates once for `page_id = start_page_id`.
 
-        let chunk_bits = DEFAULT_BLOCK_SIZE.ilog2();
+        let chunk_bits = CHUNK.ilog2();
         let as_offset = ((address_space - ADDR_SPACE_OFFSET) as u64)
             << (config.memory_config.memory_dimensions().address_height);
 
         let mut asm_str = String::new();
-        // `start_chunk_id`: `ptr >> self.chunk_bits`
+        // `chunk_idx`: `ptr >> chunk_bits`
         asm_str += &format!("    shr {ptr_reg}, {chunk_bits}\n");
-        // `start_block_id`: `start_chunk_id + as_offset`
+        // `start_block_id`: `chunk_idx + as_offset`
         asm_str += &format!("    add {ptr_reg}, {as_offset}\n");
         // `start_page_id`: `start_block_id >> PAGE_BITS`
         // NOTE: This is DIRTY because PAGE_BITS is a generic parameter of E2 context.

--- a/extensions/rv32im/circuit/src/loadstore/tests.rs
+++ b/extensions/rv32im/circuit/src/loadstore/tests.rs
@@ -216,7 +216,7 @@ fn rand_loadstore_test(opcode: Rv32LoadStoreOpcode, num_ops: usize) {
     if [STOREW, STOREB, STOREH].contains(&opcode) {
         mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     }
-    // Use custom memory config so initial block size matches the 4-byte alignment.
+    // Use a large register/public-values space for random access coverage.
     let mut tester = VmChipTestBuilder::from_config(mem_config);
     let mut harness = create_harness(&mut tester);
 
@@ -268,7 +268,7 @@ fn run_negative_loadstore_test(
     if [STOREW, STOREB, STOREH].contains(&opcode) {
         mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     }
-    // Use custom memory config so the min block size matches alignment without needing adapters.
+    // Use a large register/public-values space for random access coverage.
     let mut tester = VmChipTestBuilder::from_config(mem_config);
     let mut harness = create_harness(&mut tester);
 


### PR DESCRIPTION
## Overview

With access adapters removed, every address space now uses a single fixed block size (`DEFAULT_BLOCK_SIZE = 4`). This PR removes the per-address-space `block_size` field and the associated dynamic block-size machinery, making the memory subsystem simpler and faster.

**No AIR changes.** This is purely host-side (execution, trace generation, testing).

**Bug fixes included:**

1. The metered execution path and AOT code path were using `DEFAULT_BLOCK_SIZE` (4) to compute merkle tree leaf indices, but `MemoryDimensions::address_height` is sized for `CHUNK` (8) leaves. This was introduced when `initial_block_size()` (which returned `CHUNK = 8` on `main`) was replaced with `CONST_BLOCK_SIZE = 4`. Both paths now correctly use `controller::CHUNK`.

2. The boundary AIR height estimate was `leaves` but the actual trace uses `2 * leaves` (one init + one final row per leaf). This caused segmentation underestimates that surfaced in ECC integration tests.

Resolves int-6630.

---

## `crates/vm` (`openvm-circuit`)

### `arch/config.rs`

- Removed `AddressSpaceHostConfig::block_size` field. Constructor no longer takes a block size.
- Removed `MemoryConfig::block_size_bits()`.
- Removed `MAX_CELL_BYTE_SIZE` (unused after `handle_touched_blocks` simplification).

### `system/memory/online.rs` (core simplification)

- **Removed `TracingMemory::block_size`** field (per-AS `Vec<u32>`). Metadata slots are now always `DEFAULT_BLOCK_SIZE`-sized.
- **Simplified `prev_access_time`**: no const generic, no loop. Single-slot get/set using `pointer / DEFAULT_BLOCK_SIZE`.
- **Simplified `touched_blocks`**: uses `DEFAULT_BLOCK_SIZE` directly instead of zipping with per-AS block sizes.
- **Replaced `handle_touched_blocks`** (accumulation loop with `current_timestamps`, `current_values` buffer, max-timestamp logic) with a direct parallel `.map()` in `touched_blocks_to_equipartition` — each touched block maps 1:1 to a `TimestampedValues` entry.

### `system/memory/persistent.rs`

- Extracted `group_touched_memory_by_chunk` as a `pub(crate)` function so the rechunking logic (grouping `DEFAULT_BLOCK_SIZE` blocks into `CHUNK`-sized merkle leaves) is shared between `PersistentBoundaryChip::finalize` and `MemoryController::generate_proving_ctx`.
- Added early return in `touch_range` for `len == 0`.

### `system/memory/controller/mod.rs`

- Rechunking in `generate_proving_ctx` now uses `group_touched_memory_by_chunk` instead of inline `BTreeMap` logic.

### `arch/execution_mode/metered/memory_ctx.rs` (bug fixes)

- **Fixed CHUNK mismatch**: `CHUNK` was aliased to `DEFAULT_BLOCK_SIZE` (4), but merkle tree addressing uses `controller::CHUNK` (8). Now imports and uses `controller::CHUNK` directly.
- **Fixed boundary height underestimate**: `BOUNDARY_AIR_ID += leaves` → `leaves * 2` (init + final row per leaf).
- **Fixed `num_blocks` for unaligned accesses**: uses `(ptr + size - 1) >> CHUNK_BITS - ptr >> CHUNK_BITS + 1` instead of `(size + CHUNK - 1) >> CHUNK_BITS`, which was incorrect when `ptr` is not chunk-aligned.
- Removed `chunk`, `chunk_bits`, `boundary_idx`, `merkle_tree_index` struct fields — replaced with module-level constants and `BOUNDARY_AIR_ID` / `MERKLE_AIR_ID`.
- Added doc comment on `apply_height_updates` explaining the paged overestimate strategy.

### `arch/testing/memory/` (tester simplification)

- **`MemoryTester`**: Replaced `HashMap<usize, MemoryDummyChip>` with a single `chip` field. Added `into_parts()`. `read`/`write` assert `N == DEFAULT_BLOCK_SIZE`.
- **`MemoryDummyAir`**: Removed runtime `block_size` field. Width hardcoded to `DEFAULT_BLOCK_SIZE + 4`.
- **`DeviceMemoryTester`** (CUDA): Same pattern — single `chip`, `take_chip()`, assertions on `N`.

### `system/memory/tests.rs`

- Simplified to use only `DEFAULT_BLOCK_SIZE`-aligned accesses (was exercising 1/2/4/8/16-byte widths that no longer exist).

---

## `extensions/rv32im/circuit`

### `adapters/deferral.rs`

- Updated safety comments: "minimum alignment of 1" → "block_size of DEFAULT_BLOCK_SIZE".

### `adapters/mod.rs`

- Updated safety comments to reference the fixed 4-byte memory access granularity.

### `common/mod.rs` (bug fix)

- AOT code path: `chunk_bits` now uses `CHUNK.ilog2()` (= 3) instead of `DEFAULT_BLOCK_SIZE.ilog2()` (= 2), matching the merkle tree leaf size.
- Comments updated to reflect `CHUNK = 8`.

### `base_alu/tests.rs`, `loadstore/tests.rs`

- Cleaned up stale comments referencing "min block size" and "alignment".
