### PR TITLE
feat: deferral support for SDK root prover

### DIFF
--- a/crates/continuations/src/circuit/root/def_paths/air.rs
+++ b/crates/continuations/src/circuit/root/def_paths/air.rs
@@ -169,7 +169,10 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
         builder
             .when_transition()
             .when(local.is_within_deferral_as - next.is_within_deferral_as)
-            .assert_eq(local.depth, AB::Expr::from_usize(self.address_height));
+            .assert_eq(next.depth, AB::Expr::from_usize(self.address_height));
+        builder
+            .when_last_row()
+            .assert_zero(local.is_within_deferral_as);
 
         assert_array_eq(
             &mut builder.when(local.is_within_deferral_as),

--- a/crates/continuations/src/circuit/root/def_paths/trace.rs
+++ b/crates/continuations/src/circuit/root/def_paths/trace.rs
@@ -144,7 +144,7 @@ pub fn generate_proving_input<SC: StarkProtocolConfig<F = F>>(
         cols.is_valid = if row_idx == 0 { F::TWO } else { F::ONE };
         cols.depth = F::from_usize(row_idx);
         cols.is_skip = F::from_bool(row_idx < skip_depth);
-        cols.is_within_deferral_as = F::from_bool(row_idx <= untouched_cut);
+        cols.is_within_deferral_as = F::from_bool(row_idx < untouched_cut);
         cols.is_unset = F::from_bool(is_unset);
 
         cols.is_right_child = F::from_bool(is_right_child_bits[row_idx]);

--- a/crates/continuations/src/prover/root/trace.rs
+++ b/crates/continuations/src/prover/root/trace.rs
@@ -53,6 +53,8 @@ where
             .poseidon2_compress_inputs
             .extend(other_compress_inputs);
 
+        // Get the verifier sub-circuit trace heights. If deferrals are enabled, there is
+        // an additional AIR at the end.
         let verifier_trace_heights = self.trace_heights.as_ref().map(|v| {
             let num_airs = v.len() - deferral_merkle_proofs.is_some() as usize;
             &v[3..num_airs]

--- a/crates/continuations/src/prover/root/trace.rs
+++ b/crates/continuations/src/prover/root/trace.rs
@@ -26,7 +26,7 @@ impl<
 where
     PB::Matrix: Clone,
 {
-    fn generate_proving_ctx_internal(
+    pub fn generate_proving_ctx(
         &self,
         proof: Proof<SC>,
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, PB::Val>,
@@ -54,7 +54,7 @@ where
             .extend(other_compress_inputs);
 
         let verifier_trace_heights = self.trace_heights.as_ref().map(|v| {
-            let num_airs = v.len();
+            let num_airs = v.len() - deferral_merkle_proofs.is_some() as usize;
             &v[3..num_airs]
         });
 
@@ -87,7 +87,7 @@ where
     }
 
     #[instrument(name = "trace_gen", skip_all)]
-    pub fn generate_proving_ctx(
+    pub fn generate_proving_ctx_no_def(
         &self,
         proof: Proof<SC>,
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, PB::Val>,
@@ -96,16 +96,6 @@ where
             self.circuit.def_hook_commit.is_none(),
             "deferral-enabled root prover requires generate_proving_ctx_with_deferrals"
         );
-        self.generate_proving_ctx_internal(proof, user_pvs_proof, None)
-    }
-
-    #[instrument(name = "trace_gen", skip_all)]
-    pub fn generate_proving_ctx_with_deferrals(
-        &self,
-        proof: Proof<SC>,
-        user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, PB::Val>,
-        deferral_merkle_proofs: &DeferralMerkleProofs<PB::Val>,
-    ) -> Option<ProvingContext<PB>> {
-        self.generate_proving_ctx_internal(proof, user_pvs_proof, Some(deferral_merkle_proofs))
+        self.generate_proving_ctx(proof, user_pvs_proof, None)
     }
 }

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -726,11 +726,8 @@ fn test_deferral_e2e() -> Result<()> {
         Some(def_hook_vk_commit.into()),
         None,
     );
-    let ctx = root_prover.generate_proving_ctx_with_deferrals(
-        combined_proof,
-        &user_pvs_proof,
-        &merkle_proofs,
-    );
+    let ctx =
+        root_prover.generate_proving_ctx(combined_proof, &user_pvs_proof, Some(&merkle_proofs));
     warn!("proving root (CPU)");
     let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx.unwrap())?;
 

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -290,7 +290,7 @@ fn test_root_prover(extra_recursive_layers: usize) -> Result<()> {
         None,
         None,
     );
-    let ctx = root_prover.generate_proving_ctx(internal_recursive_proof, &user_pvs_proof);
+    let ctx = root_prover.generate_proving_ctx_no_def(internal_recursive_proof, &user_pvs_proof);
     let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx.unwrap())?;
 
     let vk = root_prover.get_vk();
@@ -322,7 +322,7 @@ fn test_root_prover_trace_heights() -> Result<()> {
         None,
     );
     let ctx = root_base_prover
-        .generate_proving_ctx(internal_recursive_proof.clone(), &user_pvs_proof)
+        .generate_proving_ctx_no_def(internal_recursive_proof.clone(), &user_pvs_proof)
         .unwrap();
     let mut trace_heights = ctx
         .per_trace
@@ -343,7 +343,7 @@ fn test_root_prover_trace_heights() -> Result<()> {
         Some(trace_heights.clone()),
     );
     let ctx = root_prover
-        .generate_proving_ctx(internal_recursive_proof, &user_pvs_proof)
+        .generate_proving_ctx_no_def(internal_recursive_proof, &user_pvs_proof)
         .unwrap();
 
     for ((air_idx, air_ctx), expected_height) in ctx.per_trace.iter().zip(trace_heights) {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -28,7 +28,7 @@ use openvm_circuit::{
 use openvm_sdk_config::{SdkVmConfig, SdkVmCpuBuilder, TranspilerConfig};
 use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, StarkEngine, SystemParams};
 use openvm_stark_sdk::config::{
-    baby_bear_poseidon2::BabyBearPoseidon2CpuEngine as BabyBearPoseidon2Engine,
+    baby_bear_poseidon2::{BabyBearPoseidon2CpuEngine as BabyBearPoseidon2Engine, Digest},
     root_params_with_100_bits_security,
 };
 use openvm_transpiler::{
@@ -229,6 +229,10 @@ where
             self.def_path_prover.is_none(),
             "Deferral prover already defined"
         );
+        assert!(
+            self.agg_prover.get().is_none(),
+            "Agg prover has already been initialized without deferrals"
+        );
 
         let deferral_tree_config = AggregationTreeConfig {
             num_children_leaf: 2,
@@ -247,6 +251,20 @@ where
 
         self.def_path_prover = Some(Arc::new(def_path_prover));
         self
+    }
+
+    /// Returns the def_hook_prover cached commit.
+    pub fn def_hook_cached_commit(&self) -> Option<Digest> {
+        self.def_path_prover
+            .as_ref()
+            .map(|p| p.def_hook_cached_commit())
+    }
+
+    /// Returns the def_hook_prover vk commit.
+    pub fn def_hook_vk_commit(&self) -> Option<Digest> {
+        self.def_path_prover
+            .as_ref()
+            .map(|p| p.def_hook_vk_commit())
     }
 
     /// Builds the guest package located at `pkg_dir`. This function requires that the build target
@@ -420,7 +438,7 @@ where
         def_inputs: &[DeferralInput],
     ) -> Result<(NonRootStarkProof, VerificationBaseline), SdkError> {
         let mut prover = self.prover(app_exe)?;
-        let proof = prover.prove(inputs, def_inputs)?;
+        let proof = prover.prove(inputs, def_inputs)?.0;
         let baseline = prover.generate_baseline();
         Ok((proof, baseline))
     }
@@ -487,6 +505,7 @@ where
             &app_pk.app_vm_pk,
             app_exe,
             self.agg_prover(),
+            self.def_path_prover.clone(),
             self.root_prover(),
         )?;
         Ok(evm_prover)
@@ -498,15 +517,11 @@ where
         let app_pk = self.app_pk();
         self.agg_prover
             .get_or_init(|| {
-                let def_hook_commit = self
-                    .def_path_prover
-                    .as_ref()
-                    .map(|p| p.deferral_prover.def_hook_prover.get_cached_commit());
                 Arc::new(AggProver::new(
                     Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()),
                     self.agg_config.clone(),
                     self.agg_tree_config,
-                    def_hook_commit,
+                    self.def_hook_cached_commit(),
                 ))
             })
             .clone()
@@ -524,6 +539,7 @@ where
                     self.agg_config.params.clone(),
                     self.agg_tree_config,
                     root_params.clone(),
+                    self.def_path_prover.clone(),
                 )
                 .expect("Trace heights did not generate properly");
 
@@ -542,6 +558,7 @@ where
                     root_params,
                     memory_dimensions,
                     num_user_pvs,
+                    self.def_hook_vk_commit(),
                     Some(trace_heights),
                 ))
             })

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -40,6 +40,7 @@ pub struct AggProver {
 pub struct InternalLayerMetadata {
     pub internal_recursive_layer: u32,
     pub internal_node_idx: u32,
+    pub proofs_type: ProofsType,
 }
 
 impl AggProver {
@@ -190,6 +191,7 @@ impl AggProver {
             InternalLayerMetadata {
                 internal_recursive_layer: internal_recursive_layer as u32,
                 internal_node_idx: internal_node_idx as u32,
+                proofs_type: ProofsType::Vm,
             },
         ))
     }
@@ -266,6 +268,7 @@ impl AggProver {
             })
         })?;
 
+        metadata.proofs_type = ProofsType::Combined;
         Ok(vm_proof)
     }
 
@@ -273,7 +276,6 @@ impl AggProver {
         &self,
         mut proof: NonRootStarkProof,
         metadata: &mut InternalLayerMetadata,
-        proofs_type: ProofsType,
     ) -> Result<NonRootStarkProof> {
         proof.inner = info_span!(
             "agg_layer",
@@ -286,7 +288,7 @@ impl AggProver {
                 self.internal_recursive_prover.agg_prove::<E>(
                     &[proof.inner],
                     ChildVkKind::RecursiveSelf,
-                    proofs_type,
+                    metadata.proofs_type,
                     None,
                 )
             })

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -9,8 +9,8 @@ use openvm_continuations::{circuit::inner::ProofsType, RootSC};
 use openvm_stark_backend::{p3_field::PrimeField32, proof::Proof, StarkEngine, Val};
 
 use crate::{
-    prover::{vm::types::VmProvingKey, AggProver, AppProver, RootProver},
-    StdIn, SC,
+    prover::{vm::types::VmProvingKey, AggProver, DeferralPathProver, RootProver, StarkProver},
+    DeferralInput, StdIn, SC,
 };
 
 pub struct EvmProver<E, VB>
@@ -18,15 +18,14 @@ where
     E: StarkEngine,
     VB: VmBuilder<E>,
 {
-    pub app_prover: AppProver<E, VB>,
-    pub agg_prover: Arc<AggProver>,
+    pub stark_prover: StarkProver<E, VB>,
     pub root_prover: Arc<RootProver>,
 }
 
 impl<E, VB> EvmProver<E, VB>
 where
     E: StarkEngine<SC = SC>,
-    VB: VmBuilder<E>,
+    VB: VmBuilder<E> + Clone,
     Val<SC>: PrimeField32,
 {
     pub fn new(
@@ -34,32 +33,28 @@ where
         app_vm_pk: &VmProvingKey<VB::VmConfig>,
         app_exe: Arc<VmExe<Val<SC>>>,
         agg_prover: Arc<AggProver>,
+        def_prover: Option<Arc<DeferralPathProver>>,
         root_prover: Arc<RootProver>,
     ) -> Result<Self> {
         Ok(Self {
-            app_prover: AppProver::new(vm_builder, app_vm_pk, app_exe)?,
-            agg_prover,
+            stark_prover: StarkProver::new(vm_builder, app_vm_pk, app_exe, agg_prover, def_prover)?,
             root_prover,
         })
     }
 
     // TODO[INT-5581]: should output an EvmProof
-    pub fn prove(&mut self, input: StdIn<Val<SC>>) -> Result<Proof<RootSC>>
+    pub fn prove(
+        &mut self,
+        input: StdIn<Val<SC>>,
+        def_inputs: &[DeferralInput],
+    ) -> Result<Proof<RootSC>>
     where
         <VB::VmConfig as VmExecutionConfig<Val<SC>>>::Executor: Executor<Val<SC>>
             + MeteredExecutor<Val<SC>>
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
-        let continuation_proof = self.app_prover.prove(input)?;
         let (mut stark_proof, mut internal_metadata) =
-            self.agg_prover.prove_vm(continuation_proof)?;
-
-        const ADDITIONAL_INTERNAL_RECURSIVE_LAYERS: usize = 2;
-        for _ in 0..ADDITIONAL_INTERNAL_RECURSIVE_LAYERS {
-            stark_proof =
-                self.agg_prover
-                    .wrap_proof(stark_proof, &mut internal_metadata, ProofsType::Vm)?;
-        }
+            self.stark_prover.prove(input, def_inputs)?;
 
         let root_ctx = {
             const MAX_ROOT_TRACEGEN_RETRIES: usize = 8;
@@ -73,7 +68,7 @@ where
                         "root tracegen returned None after {MAX_ROOT_TRACEGEN_RETRIES} retries"
                     ));
                 }
-                stark_proof = self.agg_prover.wrap_proof(
+                stark_proof = self.stark_prover.agg_prover.wrap_proof(
                     stark_proof,
                     &mut internal_metadata,
                     ProofsType::Vm,
@@ -83,16 +78,27 @@ where
         };
 
         #[cfg(test)]
-        for ((air_idx, air_ctx), expected_height) in root_ctx
-            .per_trace
-            .iter()
-            .zip(self.root_prover.0.get_trace_heights().unwrap())
         {
-            assert_eq!(
-                air_ctx.height(),
-                expected_height,
-                "height mismatch at {air_idx}"
-            )
+            for ((air_idx, air_ctx), expected_height) in root_ctx
+                .per_trace
+                .iter()
+                .zip(self.root_prover.0.get_trace_heights().unwrap())
+            {
+                assert_eq!(
+                    air_ctx.height(),
+                    expected_height,
+                    "height mismatch at {air_idx}"
+                )
+            }
+            let agg_vk = self
+                .stark_prover
+                .agg_prover
+                .internal_recursive_prover
+                .get_vk()
+                .as_ref()
+                .clone();
+            let baseline = self.stark_prover.generate_baseline();
+            crate::GenericSdk::<E, VB>::verify_proof(agg_vk, baseline, &stark_proof)?;
         }
 
         let root_proof = self.root_prover.prove_from_ctx(root_ctx)?;

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -5,7 +5,7 @@ use openvm_circuit::arch::{
     instructions::exe::VmExe, Executor, MeteredExecutor, PreflightExecutor, VmBuilder,
     VmExecutionConfig,
 };
-use openvm_continuations::{circuit::inner::ProofsType, RootSC};
+use openvm_continuations::RootSC;
 use openvm_stark_backend::{p3_field::PrimeField32, proof::Proof, StarkEngine, Val};
 
 use crate::{
@@ -68,11 +68,10 @@ where
                         "root tracegen returned None after {MAX_ROOT_TRACEGEN_RETRIES} retries"
                     ));
                 }
-                stark_proof = self.stark_prover.agg_prover.wrap_proof(
-                    stark_proof,
-                    &mut internal_metadata,
-                    ProofsType::Vm,
-                )?;
+                stark_proof = self
+                    .stark_prover
+                    .agg_prover
+                    .wrap_proof(stark_proof, &mut internal_metadata)?;
                 attempt += 1;
             }
         };

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -19,7 +19,9 @@ use openvm_stark_backend::{
     StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security, baby_bear_poseidon2::F, MAX_APP_LOG_STACKED_HEIGHT,
+    app_params_with_100_bits_security,
+    baby_bear_poseidon2::{Digest, F},
+    MAX_APP_LOG_STACKED_HEIGHT,
 };
 use openvm_verify_stark_host::NonRootStarkProof;
 use tracing::info_span;
@@ -27,7 +29,7 @@ use tracing::info_span;
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig},
     keygen::AppProvingKey,
-    prover::{AggProver, AppProver},
+    prover::{AggProver, DeferralPathProver, StarkProver},
     StdIn,
 };
 
@@ -52,6 +54,7 @@ impl RootProver {
         system_params: SystemParams,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
+        def_hook_vk_commit: Option<Digest>,
         trace_heights: Option<Vec<usize>>,
     ) -> Self {
         let inner = RootInnerProver::new::<E>(
@@ -60,7 +63,7 @@ impl RootProver {
             system_params,
             memory_dimensions,
             num_user_pvs,
-            None,
+            def_hook_vk_commit.map(Into::into),
             trace_heights,
         );
         Self(inner)
@@ -72,6 +75,7 @@ impl RootProver {
         pk: Arc<MultiStarkProvingKey<RootSC>>,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
+        def_hook_vk_commit: Option<Digest>,
         trace_heights: Option<Vec<usize>>,
     ) -> Self {
         let inner = RootInnerProver::from_pk::<E>(
@@ -80,7 +84,7 @@ impl RootProver {
             pk,
             memory_dimensions,
             num_user_pvs,
-            None,
+            def_hook_vk_commit.map(Into::into),
             trace_heights,
         );
         Self(inner)
@@ -91,8 +95,11 @@ impl RootProver {
         input: NonRootStarkProof,
     ) -> Option<ProvingContext<<E as StarkEngine>::PB>> {
         let ctx = info_span!("tracegen_attempt", group = format!("root")).in_scope(|| {
-            self.0
-                .generate_proving_ctx(input.inner, &input.user_pvs_proof)
+            self.0.generate_proving_ctx(
+                input.inner,
+                &input.user_pvs_proof,
+                input.deferral_merkle_proofs.as_ref(),
+            )
         });
         ctx
     }
@@ -112,6 +119,7 @@ pub fn compute_root_proof_heights(
     agg_params: AggregationSystemParams,
     agg_tree_config: AggregationTreeConfig,
     root_params: SystemParams,
+    def_prover: Option<Arc<DeferralPathProver>>,
 ) -> Result<Vec<usize>> {
     let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
         SystemOpcode::TERMINATE.global_opcode(),
@@ -131,18 +139,25 @@ pub fn compute_root_proof_heights(
     ));
     app_config.app_vm_config.system.config = system_config;
 
-    let app_pk = AppProvingKey::keygen(app_config)?;
-    let mut app_prover =
-        AppProver::<ChildE, SdkVmBuilder>::new(Default::default(), &app_pk.app_vm_pk, dummy_exe)?;
-    let app_proof = app_prover.prove(StdIn::default())?;
+    let def_hook_cached_commit = def_prover.as_ref().map(|p| p.def_hook_cached_commit());
+    let def_hook_vk_commit = def_prover.as_ref().map(|p| p.def_hook_vk_commit().into());
 
-    let agg_prover = AggProver::new(
+    let app_pk = AppProvingKey::keygen(app_config)?;
+    let agg_prover = Arc::new(AggProver::new(
         Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()),
         AggregationConfig { params: agg_params },
         agg_tree_config,
-        None,
-    );
-    let (agg_proof, _) = agg_prover.prove_vm(app_proof)?;
+        def_hook_cached_commit,
+    ));
+
+    let mut stark_prover = StarkProver::<ChildE, SdkVmBuilder>::new(
+        Default::default(),
+        &app_pk.app_vm_pk,
+        dummy_exe,
+        agg_prover.clone(),
+        def_prover,
+    )?;
+    let (agg_proof, _) = stark_prover.prove(StdIn::default(), &[])?;
 
     let root_prover = RootInnerProver::new::<E>(
         agg_prover.internal_recursive_prover.get_vk(),
@@ -155,11 +170,16 @@ pub fn compute_root_proof_heights(
         root_params,
         memory_dimensions,
         num_user_pvs,
-        None,
+        def_hook_vk_commit,
         None,
     );
+
     let root_proving_ctx = root_prover
-        .generate_proving_ctx(agg_proof.inner, &agg_proof.user_pvs_proof)
+        .generate_proving_ctx(
+            agg_proof.inner,
+            &agg_proof.user_pvs_proof,
+            agg_proof.deferral_merkle_proofs.as_ref(),
+        )
         .unwrap();
 
     let ret = root_proving_ctx

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -8,7 +8,6 @@ use openvm_circuit::{
     },
     system::memory::merkle::MerkleTree,
 };
-use openvm_continuations::circuit::inner::ProofsType;
 use openvm_recursion_circuit::utils::poseidon2_hash_slice;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, Val};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, F};
@@ -99,24 +98,21 @@ where
         let (mut stark_proof, mut internal_metadata) =
             self.agg_prover.prove_vm(continuation_proof)?;
 
-        let wrap_proof_type = if def_inputs.is_empty() {
-            ProofsType::Vm
-        } else {
+        if !def_inputs.is_empty() {
             let def_prover = self.def_prover.as_ref().unwrap();
             let def_hook_proofs = def_prover.deferral_prover.prove(def_inputs)?;
             let def_proof = def_prover.agg_prover.prove_def(def_hook_proofs)?;
             stark_proof =
                 self.agg_prover
                     .prove_mixed(stark_proof, def_proof, &mut internal_metadata)?;
-            ProofsType::Combined
-        };
+        }
 
         // We add one additional internal_recursive layer to reduce the proof size.
         const ADDITIONAL_INTERNAL_RECURSIVE_LAYERS: usize = 1;
         for _ in 0..ADDITIONAL_INTERNAL_RECURSIVE_LAYERS {
-            stark_proof =
-                self.agg_prover
-                    .wrap_proof(stark_proof, &mut internal_metadata, wrap_proof_type)?;
+            stark_proof = self
+                .agg_prover
+                .wrap_proof(stark_proof, &mut internal_metadata)?;
         }
 
         // Generate deferral merkle proofs if deferrals are enabled.
@@ -166,26 +162,7 @@ where
                 .agg_prover
                 .internal_recursive_prover
                 .get_dag_commit(true),
-            expected_def_vk_commit: self.def_prover.as_ref().map(|dp| {
-                let hook_dag = dp.agg_prover.leaf_prover.get_dag_commit(false);
-                let leaf_dag = dp.agg_prover.internal_for_leaf_prover.get_dag_commit(false);
-                let i4l_dag = dp
-                    .agg_prover
-                    .internal_recursive_prover
-                    .get_dag_commit(false);
-                poseidon2_hash_slice(
-                    &vec![
-                        hook_dag.cached_commit,
-                        hook_dag.vk_pre_hash,
-                        leaf_dag.cached_commit,
-                        leaf_dag.vk_pre_hash,
-                        i4l_dag.cached_commit,
-                        i4l_dag.vk_pre_hash,
-                    ]
-                    .into_flattened(),
-                )
-                .0
-            }),
+            expected_def_vk_commit: self.def_prover.as_ref().map(|dp| dp.def_hook_vk_commit()),
         }
     }
 }

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
 use openvm_continuations::circuit::inner::ProofsType;
 use openvm_recursion_circuit::utils::poseidon2_hash_slice;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, Val};
-use openvm_stark_sdk::config::baby_bear_poseidon2::F;
+use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, F};
 use openvm_verify_stark_host::{
     pvs::{DeferralPvs, DEF_PVS_AIR_ID},
     vk::VerificationBaseline,
@@ -21,7 +21,7 @@ use openvm_verify_stark_host::{
 use crate::{
     prover::{
         deferral::compute_deferral_merkle_proofs, vm::types::VmProvingKey, AggProver, AppProver,
-        DeferralProver,
+        DeferralProver, InternalLayerMetadata,
     },
     DeferralInput, StdIn, SC,
 };
@@ -66,7 +66,7 @@ where
         &mut self,
         vm_input: StdIn<Val<SC>>,
         def_inputs: &[DeferralInput],
-    ) -> Result<NonRootStarkProof>
+    ) -> Result<(NonRootStarkProof, InternalLayerMetadata)>
     where
         <VB::VmConfig as VmExecutionConfig<Val<SC>>>::Executor: Executor<Val<SC>>
             + MeteredExecutor<Val<SC>>
@@ -99,16 +99,16 @@ where
         let (mut stark_proof, mut internal_metadata) =
             self.agg_prover.prove_vm(continuation_proof)?;
 
-        let wrap_proof_type = if let Some(def_prover) = self.def_prover.as_ref() {
+        let wrap_proof_type = if def_inputs.is_empty() {
+            ProofsType::Vm
+        } else {
+            let def_prover = self.def_prover.as_ref().unwrap();
             let def_hook_proofs = def_prover.deferral_prover.prove(def_inputs)?;
             let def_proof = def_prover.agg_prover.prove_def(def_hook_proofs)?;
             stark_proof =
                 self.agg_prover
                     .prove_mixed(stark_proof, def_proof, &mut internal_metadata)?;
             ProofsType::Combined
-        } else {
-            assert_eq!(def_inputs.len(), 0);
-            ProofsType::Vm
         };
 
         // We add one additional internal_recursive layer to reduce the proof size.
@@ -146,7 +146,7 @@ where
             ));
         }
 
-        Ok(stark_proof)
+        Ok((stark_proof, internal_metadata))
     }
 
     pub fn generate_baseline(&self) -> VerificationBaseline {
@@ -187,5 +187,33 @@ where
                 .0
             }),
         }
+    }
+}
+
+impl DeferralPathProver {
+    pub fn def_hook_cached_commit(&self) -> Digest {
+        self.deferral_prover.def_hook_prover.get_cached_commit()
+    }
+
+    pub fn def_hook_vk_commit(&self) -> Digest {
+        let def_dag_commit = self.agg_prover.leaf_prover.get_dag_commit(false);
+        let leaf_dag_commit = self
+            .agg_prover
+            .internal_for_leaf_prover
+            .get_dag_commit(false);
+        let internal_for_leaf_dag_commit = self
+            .agg_prover
+            .internal_recursive_prover
+            .get_dag_commit(false);
+        let components = vec![
+            def_dag_commit.cached_commit,
+            def_dag_commit.vk_pre_hash,
+            leaf_dag_commit.cached_commit,
+            leaf_dag_commit.vk_pre_hash,
+            internal_for_leaf_dag_commit.cached_commit,
+            internal_for_leaf_dag_commit.vk_pre_hash,
+        ]
+        .into_flattened();
+        poseidon2_hash_slice(&components).0
     }
 }

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -54,7 +54,7 @@ fn test_root_prover_trace_heights() -> Result<()> {
     let mut stdin = StdIn::default();
     stdin.write(&n);
 
-    let proof = evm_prover.prove(stdin)?;
+    let proof = evm_prover.prove(stdin, &[])?;
     let vk = evm_prover.root_prover.0.get_vk();
     let engine = RootE::new(vk.inner.params.clone());
     engine.verify(&vk, &proof)?;
@@ -163,10 +163,69 @@ fn test_verify_stark_deferral() -> Result<()> {
     let def_input = DeferralInput::from_inputs(&[fib_proof]);
 
     // ---- Step 10: Prove and verify ----
-    let (vs_proof, vs_baseline) = vs_sdk.prove(vs_exe, vs_stdin, &[def_input])?;
+    let mut evm_prover = vs_sdk.evm_prover(vs_exe)?;
+    let vs_proof = evm_prover.prove(vs_stdin, &[def_input])?;
 
-    let vs_agg_vk = vs_sdk.agg_vk();
-    Sdk::verify_proof(vs_agg_vk.as_ref().clone(), vs_baseline, &vs_proof)?;
+    let vk = evm_prover.root_prover.0.get_vk();
+    let engine = RootE::new(vk.inner.params.clone());
+    engine.verify(&vk, &vs_proof)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_deferrals_enabled_without_usage() -> Result<()> {
+    let n_stack = 19;
+    let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
+    let agg_params = AggregationSystemParams::default();
+
+    // ---- Step 1: Create dummy DeferralProver ----
+    let rv32_sdk = Sdk::riscv32(app_params.clone(), agg_params.clone());
+    let ir_prover = &rv32_sdk.agg_prover().internal_recursive_prover;
+    let ir_vk = ir_prover.get_vk();
+    let ir_pcs_data = ir_prover.get_self_vk_pcs_data().unwrap();
+
+    let system_config = rv32_sdk.app_config().app_vm_config.as_ref().clone();
+    let memory_dimensions = system_config.memory_config.memory_dimensions();
+    let num_user_pvs = system_config.num_public_values;
+
+    let def_circuit_params = internal_params_with_100_bits_security();
+    let deferred_verify_prover = VerifyProver::new::<E>(
+        ir_vk,
+        ir_pcs_data,
+        def_circuit_params,
+        memory_dimensions,
+        num_user_pvs,
+        None,
+    );
+    let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
+
+    let hook_params = root_params_with_100_bits_security();
+    let agg_config = AggregationConfig {
+        params: agg_params.clone(),
+    };
+    let deferral_prover = DeferralProver::new(verify_stark_prover, agg_config, hook_params);
+
+    // ---- Step 2: Enable deferrals in SDK and prove ----
+    let sdk = Sdk::riscv32(app_params, agg_params.clone()).with_deferral_prover(deferral_prover);
+
+    let elf = Elf::decode(
+        include_bytes!("../programs/examples/fibonacci.elf"),
+        MEM_SIZE as u32,
+    )?;
+    let app_exe = sdk.convert_to_exe(elf)?;
+
+    let n = 1000u64;
+    let mut stdin = StdIn::default();
+    stdin.write(&n);
+
+    let mut evm_prover = sdk.evm_prover(app_exe)?;
+    let proof = evm_prover.prove(stdin, &[])?;
+
+    // ---- Step 3: Verify the final result ----
+    let vk = evm_prover.root_prover.0.get_vk();
+    let engine = RootE::new(vk.inner.params.clone());
+    engine.verify(&vk, &proof)?;
 
     Ok(())
 }

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -48,9 +48,15 @@ pub enum VerifyStarkError {
     #[error("Deferral hook VK commit mismatch: expected {expected:?}, actual {actual:?}")]
     DefHookVkCommitMismatch { expected: Digest, actual: Digest },
     #[error("Proof has deferrals but baseline has no expected_def_hook_vk_commit")]
-    UnexpectedDeferral,
+    UnexpectedDeferralDisabled,
     #[error("Baseline expects deferrals but proof has no deferral Merkle proofs")]
     MissingDeferralMerkleProofs,
-    #[error("Proof has deferral_flag=0 but baseline expects deferrals")]
-    DeferralFlagNotSet,
+    #[error("Proof has deferral_flag=0 but def_hook_vk_commit is set, actual {actual:?}")]
+    DefHookVkCommitSet { actual: Digest },
+    #[error("Proof has deferral_flag=0 but initial_acc_hash is set, actual {actual:?}")]
+    DefInitialAccHashCommitSet { actual: Digest },
+    #[error("Proof has deferral_flag=0 but final_acc_hash is set, actual {actual:?}")]
+    DefFinalAccHashCommitSet { actual: Digest },
+    #[error("Proof has deferral_flag=0 but depth is set, actual {actual:?}")]
+    DefDepthSet { actual: F },
 }

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -283,5 +283,5 @@ pub fn verify_vm_stark_proof_pvs(
 }
 
 fn is_unset(slice: &[F]) -> bool {
-    slice.iter().fold(true, |acc, &f| acc && (f == F::ZERO))
+    slice.iter().all(|&f| f == F::ZERO)
 }

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -226,26 +226,6 @@ pub fn verify_vm_stark_proof_pvs(
             def_hook_vk_commit,
         } = verifier_def_pvs_slice.borrow();
 
-        let flag = deferral_flag.as_canonical_u32();
-        if flag != 0 && flag != 2 {
-            return Err(VerifyStarkError::InvalidDeferralFlag(deferral_flag));
-        }
-        if flag == 0 {
-            return Err(VerifyStarkError::DeferralFlagNotSet);
-        }
-
-        if def_hook_vk_commit != expected_def_vk_commit {
-            return Err(VerifyStarkError::DefHookVkCommitMismatch {
-                expected: expected_def_vk_commit,
-                actual: def_hook_vk_commit,
-            });
-        }
-
-        let deferral_merkle_proofs = proof
-            .deferral_merkle_proofs
-            .as_ref()
-            .ok_or(VerifyStarkError::MissingDeferralMerkleProofs)?;
-
         let &DeferralPvs {
             initial_acc_hash,
             final_acc_hash,
@@ -254,20 +234,54 @@ pub fn verify_vm_stark_proof_pvs(
             .as_slice()
             .borrow();
 
-        deferral_merkle_proofs.verify(
-            vk.baseline.memory_dimensions,
-            initial_root,
-            final_root,
-            initial_acc_hash,
-            final_acc_hash,
-            depth.as_canonical_u32() as usize,
-        )?;
+        if deferral_flag == F::ZERO {
+            if !is_unset(&def_hook_vk_commit) {
+                return Err(VerifyStarkError::DefHookVkCommitSet {
+                    actual: def_hook_vk_commit,
+                });
+            } else if !is_unset(&initial_acc_hash) {
+                return Err(VerifyStarkError::DefInitialAccHashCommitSet {
+                    actual: initial_acc_hash,
+                });
+            } else if !is_unset(&final_acc_hash) {
+                return Err(VerifyStarkError::DefFinalAccHashCommitSet {
+                    actual: final_acc_hash,
+                });
+            } else if depth != F::ZERO {
+                return Err(VerifyStarkError::DefDepthSet { actual: depth });
+            }
+        } else if deferral_flag == F::TWO {
+            if def_hook_vk_commit != expected_def_vk_commit {
+                return Err(VerifyStarkError::DefHookVkCommitMismatch {
+                    expected: expected_def_vk_commit,
+                    actual: def_hook_vk_commit,
+                });
+            }
+            let deferral_merkle_proofs = proof
+                .deferral_merkle_proofs
+                .as_ref()
+                .ok_or(VerifyStarkError::MissingDeferralMerkleProofs)?;
+            deferral_merkle_proofs.verify(
+                vk.baseline.memory_dimensions,
+                initial_root,
+                final_root,
+                initial_acc_hash,
+                final_acc_hash,
+                depth.as_canonical_u32() as usize,
+            )?;
+        } else {
+            return Err(VerifyStarkError::InvalidDeferralFlag(deferral_flag));
+        }
     } else if !verifier_def_pvs_slice.is_empty()
         || !proof.inner.public_values[DEF_PVS_AIR_ID].is_empty()
         || proof.deferral_merkle_proofs.is_some()
     {
-        return Err(VerifyStarkError::UnexpectedDeferral);
+        return Err(VerifyStarkError::UnexpectedDeferralDisabled);
     }
 
     Ok(())
+}
+
+fn is_unset(slice: &[F]) -> bool {
+    slice.iter().fold(true, |acc, &f| acc && (f == F::ZERO))
 }


### PR DESCRIPTION
Resolves INT-6843, INT-6844.

## High-Level Overview

This branch adds end-to-end support for **deferral-enabled SDK proving when no deferrals are actually used**, while tightening deferral-path AIR boundary constraints and aligning verifier semantics with that behavior.

In practice, this PR:
- fixes the deferral-path boundary condition in root trace generation/AIR,
- unifies root tracegen APIs around optional deferral Merkle proofs,
- plumbs deferral commit metadata through SDK prover construction and root height computation,
- updates host verification to accept `deferral_flag = 0` (with strict zero/unset checks) when deferrals are enabled but unused,
- adds/updates tests for both used and unused deferral paths.

---

## Review Map

### 1) `crates/continuations`: Root Deferral Path AIR + Root Tracegen API

**Primary files**
- `crates/continuations/src/circuit/root/def_paths/air.rs`
- `crates/continuations/src/circuit/root/def_paths/trace.rs`
- `crates/continuations/src/prover/root/trace.rs`
- `crates/continuations/src/tests/mod.rs`
- `crates/continuations/src/tests/e2e.rs`

**What changed**
- `is_within_deferral_as` trace generation changed from `row_idx <= untouched_cut` to `row_idx < untouched_cut`.
- AIR transition constraint now pins the drop point using `next.depth == address_height` (instead of `local.depth`).
- AIR now enforces `is_within_deferral_as == 0` on the last row.
- Root prover API is consolidated:
  - `generate_proving_ctx(...)` now takes optional deferral Merkle proofs.
  - no-def path is now explicit via `generate_proving_ctx_no_def(...)`.
- Trace height slicing now accounts for optional deferral-path AIR presence.

**AIR behavior summary (DeferralAccMerklePathsAir)**
- `depth` starts at 0 and increments by 1 on valid transitions.
- `is_within_deferral_as`:
  - starts at 1 on the first row,
  - can only transition once from 1 to 0,
  - must drop exactly when the **next** row depth reaches `address_height`,
  - must be 0 on the last row.
- While `is_within_deferral_as = 1`, initial/final sibling commits are constrained equal (and for unset deferrals, initial/final node commits are also equal).

**Example trace (changed columns)**

Example: `address_height = 3`, `proof_len = 5`, so `untouched_cut = min(3, 4) = 3`.

| row_idx | depth | is_within_deferral_as | Notes |
|---|---:|---:|---|
| 0 | 0 | 1 | first row, flag must be 1 |
| 1 | 1 | 1 | still within untouched DEFERRAL_AS prefix |
| 2 | 2 | 1 | last row with flag = 1 |
| 3 | 3 | 0 | drop occurs on transition `2 -> 3`; constrained by `next.depth == address_height` |
| 4 | 4 | 0 | outside untouched prefix |
| 5 | 5 | 0 | last row must be 0 |

**Bus interaction diagram**

No new buses were introduced; the interface is unchanged. The semantic change is the row range over which equality constraints are active.

```text
RootVerifierAir
  ├─ send DeferralAccPathMessage(initial_acc_hash, final_acc_hash, depth, is_unset)
  │    └──> DeferralAccMerklePathsAir (receive)
  └─ send DeferralMerkleRootsMessage(initial_root, final_root)
       └──> DeferralAccMerklePathsAir (receive)

DeferralAccMerklePathsAir
  └─ uses MerklePathSubAir (initial path + final path), backed by Poseidon2 compress interactions
```

---

### 2) `crates/sdk`: Deferral-Aware Prover Wiring and API Alignment

**Primary files**
- `crates/sdk/src/lib.rs`
- `crates/sdk/src/prover/stark.rs`
- `crates/sdk/src/prover/root.rs`
- `crates/sdk/src/prover/evm.rs`
- `crates/sdk/src/tests.rs`

**What changed**
- `with_deferral_prover(...)` now asserts aggregation prover has not already been initialized without deferrals.
- New helper accessors:
  - `def_hook_cached_commit()`
  - `def_hook_vk_commit()`
- `agg_prover()` now consistently uses deferral cached commit when deferrals are enabled.
- Root prover construction and root trace-height precomputation now receive deferral context (`DeferralPathProver` and optional `def_hook_vk_commit`) so sizing/config matches runtime mode.
- `StarkProver::prove(...)` now returns `(NonRootStarkProof, InternalLayerMetadata)` (metadata reused by EVM/root wrapping flow).
- Deferral aggregation path now keys off `def_inputs`:
  - empty `def_inputs` => VM-only path,
  - non-empty `def_inputs` => mixed aggregation path.
- `EvmProver` now wraps `StarkProver`; `EvmProver::prove(...)` accepts `def_inputs`.
- Test-only assertion in EVM prover now also verifies the non-root proof against baseline.

**Why this matters for review**
- The main risk area is consistency of deferral commit derivation and propagation across:
  - aggregation prover initialization,
  - root prover initialization,
  - baseline verification expectations.

---

### 3) `crates/verify`: Deferral Verification Semantics for `flag = 0`

**Primary files**
- `crates/verify/src/lib.rs`
- `crates/verify/src/error.rs`

**What changed**
- For baselines that expect deferrals:
  - `deferral_flag = 0` is now valid **if and only if** all deferral-specific fields are unset/zero:
    - `def_hook_vk_commit == 0`
    - `initial_acc_hash == 0`
    - `final_acc_hash == 0`
    - `depth == 0`
  - `deferral_flag = 2` keeps existing behavior (commit check + required Merkle proofs).
  - other values remain invalid.
- Error taxonomy updated with specific failures for each non-zero field under `flag = 0`.
- `UnexpectedDeferral` renamed to `UnexpectedDeferralDisabled` for clarity when baseline does not expect deferrals.

**Why this matters for review**
- This is the host-side semantic counterpart to SDK/root changes: it enables deferral-ready configurations to produce proofs with no actual deferral usage while still enforcing strict zeroization of deferral data.

---

### 4) Tests

**Updated coverage**
- Continuations tests switched to the new root tracegen API (`generate_proving_ctx_no_def` vs optional-deferral path).
- SDK tests updated for new `evm_prover.prove(stdin, def_inputs)` signature.
- New SDK test: `test_deferrals_enabled_without_usage` validates prove+verify when deferrals are enabled but `def_inputs` is empty.
- Existing deferral integration test now exercises the EVM prover path with explicit deferral inputs.

