### PR TITLE
fix: deferral output_commit should be a true hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,6 +3293,7 @@ name = "openvm-deferral-circuit"
 version = "2.0.0-alpha"
 dependencies = [
  "cfg-if",
+ "dashmap",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
@@ -3315,6 +3316,7 @@ dependencies = [
  "p3-field",
  "p3-symmetric",
  "rand 0.9.2",
+ "rustc-hash",
  "serde",
  "static_assertions",
  "strum",

--- a/crates/continuations/src/prover/deferral/mod.rs
+++ b/crates/continuations/src/prover/deferral/mod.rs
@@ -12,4 +12,5 @@ pub use inner::*;
 pub trait DeferralCircuitProver<SC: StarkProtocolConfig> {
     fn get_vk(&self) -> Arc<MultiStarkVerifyingKey<SC>>;
     fn prove(&self, input_bytes: &[u8]) -> Proof<SC>;
+    fn get_def_idx(&self) -> usize;
 }

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -57,6 +57,7 @@ impl DeferralProver {
         agg_config: AggregationConfig,
         hook_params: SystemParams,
     ) -> Self {
+        assert_eq!(def_circuit_prover.get_def_idx(), 0);
         let single_circuit_prover = SingleDefCircuitProver::new(
             def_circuit_prover,
             agg_config.params.leaf,
@@ -82,6 +83,7 @@ impl DeferralProver {
         def_hook_pk: Arc<MultiStarkProvingKey<SC>>,
         internal_recursive_cached_commit: CommitBytes,
     ) -> Self {
+        assert_eq!(def_circuit_prover.get_def_idx(), 0);
         let single_circuit_prover = SingleDefCircuitProver::from_pks(
             def_circuit_prover,
             def_agg_pk.leaf_pk,
@@ -108,6 +110,10 @@ impl DeferralProver {
         mut self,
         def_circuit_prover: DP,
     ) -> Self {
+        assert_eq!(
+            def_circuit_prover.get_def_idx(),
+            self.single_circuit_provers.len()
+        );
         let leaf_params = self.single_circuit_provers[0]
             .leaf_prover
             .get_vk()

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use eyre::Result;
+use itertools::Itertools;
 use openvm_continuations::{
     bn254::CommitBytes,
     prover::{DeferralChildVkKind, DeferralCircuitProver},
@@ -132,7 +133,7 @@ impl DeferralProver {
         let per_circuit = self
             .single_circuit_provers
             .iter()
-            .zip(inputs)
+            .zip_eq(inputs)
             .map(|(prover, inputs)| prover.prove(inputs))
             .collect::<Result<Vec<_>>>()?;
 

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -103,6 +103,7 @@ fn test_verify_stark_deferral() -> Result<()> {
         memory_dimensions,
         num_user_pvs,
         None,
+        0,
     );
     let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
 

--- a/extensions/deferral/circuit/Cargo.toml
+++ b/extensions/deferral/circuit/Cargo.toml
@@ -35,6 +35,8 @@ eyre.workspace = true
 serde.workspace = true
 static_assertions.workspace = true
 cfg-if.workspace = true
+dashmap.workspace = true
+rustc-hash.workspace = true
 
 [build-dependencies]
 openvm-cuda-builder = { workspace = true, optional = true }

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -105,18 +105,20 @@ where
         let output_f_commit = byte_commit_to_f(&cols.writes.output_commit);
 
         self.poseidon2_bus
-            .compress(
+            .lookup(
                 cols.reads.old_input_acc,
                 input_f_commit,
                 cols.writes.new_input_acc,
+                AB::Expr::ONE,
             )
             .eval(builder, cols.is_valid);
 
         self.poseidon2_bus
-            .compress(
+            .lookup(
                 cols.reads.old_output_acc,
                 output_f_commit,
                 cols.writes.new_output_acc,
+                AB::Expr::ONE,
             )
             .eval(builder, cols.is_valid);
 

--- a/extensions/deferral/circuit/src/call/execution.rs
+++ b/extensions/deferral/circuit/src/call/execution.rs
@@ -5,10 +5,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use openvm_circuit::{
-    arch::{hasher::Hasher, *},
-    system::memory::online::GuestMemory,
-};
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives::AlignedBytesBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
@@ -208,8 +205,8 @@ unsafe fn execute_e12_impl<F: VmField, CTX: ExecutionCtxTrait>(
     // (output_commit, output_len) pair, corresponds to guest struct OutputKey
     let output_key = combine_output(output_commit, output_len.to_le_bytes());
 
-    let new_input_acc = poseidon2_chip.compress(&old_input_acc, &input_commit);
-    let new_output_acc = poseidon2_chip.compress(&old_output_acc, &output_f_commit);
+    let new_input_acc = poseidon2_chip.perm(&old_input_acc, &input_commit, true);
+    let new_output_acc = poseidon2_chip.perm(&old_output_acc, &output_f_commit, true);
 
     for chunk_idx in 0..OUTPUT_TOTAL_MEMORY_OPS {
         exec_state.vm_write::<u8, MEMORY_OP_SIZE>(

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -3,10 +3,8 @@ use std::{array::from_fn, borrow::BorrowMut, sync::Arc};
 use itertools::Itertools;
 use openvm_circuit::{
     arch::{
-        get_record_from_slice,
-        hasher::{Hasher, HasherChip},
-        AdapterTraceExecutor, AdapterTraceFiller, EmptyAdapterCoreLayout, ExecutionError,
-        PreflightExecutor, RecordArena, TraceFiller, VmField, VmStateMut,
+        get_record_from_slice, AdapterTraceExecutor, AdapterTraceFiller, EmptyAdapterCoreLayout,
+        ExecutionError, PreflightExecutor, RecordArena, TraceFiller, VmField, VmStateMut,
     },
     system::memory::{
         offline_checker::{MemoryReadAuxRecord, MemoryWriteAuxRecord, MemoryWriteBytesAuxRecord},
@@ -107,8 +105,8 @@ where
 
         let output_f_commit =
             byte_commit_to_f(&output_commit.iter().map(|v| F::from_u8(*v)).collect_vec());
-        let new_input_acc = poseidon2_chip.compress(&read_data.old_input_acc, &input_commit);
-        let new_output_acc = poseidon2_chip.compress(&read_data.old_output_acc, &output_f_commit);
+        let new_input_acc = poseidon2_chip.perm(&read_data.old_input_acc, &input_commit, true);
+        let new_output_acc = poseidon2_chip.perm(&read_data.old_output_acc, &output_f_commit, true);
 
         let output_len_u32 =
             u32::try_from(output_len).expect("deferral output length should fit in a u32");
@@ -152,9 +150,12 @@ where
         let output_f_commit: [F; _] =
             byte_commit_to_f(&record.write_data.output_commit.map(F::from_u8));
         self.poseidon2_chip
-            .compress_and_record(&record.read_data.old_input_acc, &input_f_commit);
-        self.poseidon2_chip
-            .compress_and_record(&record.read_data.old_output_acc, &output_f_commit);
+            .perm_and_record(&record.read_data.old_input_acc, &input_f_commit, true);
+        self.poseidon2_chip.perm_and_record(
+            &record.read_data.old_output_acc,
+            &output_f_commit,
+            true,
+        );
 
         // Write columns in reverse order to avoid clobbering the record.
         cols.writes.new_output_acc = record.write_data.new_output_acc;

--- a/extensions/deferral/circuit/src/def_fn.rs
+++ b/extensions/deferral/circuit/src/def_fn.rs
@@ -85,7 +85,7 @@ fn hash_output_raw<F: VmField>(
     state[1] = F::from_usize(output_ref.len());
 
     let (lhs, rhs) = state_to_chunks(&state);
-    if output_ref.len() == 0 {
+    if output_ref.is_empty() {
         let res = hasher.perm(&lhs, &rhs, true);
         return f_commit_to_bytes(&res).to_vec();
     }

--- a/extensions/deferral/circuit/src/def_fn.rs
+++ b/extensions/deferral/circuit/src/def_fn.rs
@@ -2,9 +2,9 @@ use std::{array::from_fn, fmt::Debug};
 
 use openvm_circuit::arch::{
     deferral::{DeferralResult, DeferralState, InputCommit, InputMapVal, OutputCommit, OutputRaw},
-    hasher::Hasher,
     VmField,
 };
+use openvm_poseidon2_air::POSEIDON2_WIDTH;
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 
 use crate::{poseidon2::DeferralPoseidon2Chip, utils::f_commit_to_bytes};
@@ -79,11 +79,51 @@ fn hash_output_raw<F: VmField>(
     output_ref: &[u8],
 ) -> OutputCommit {
     assert!(output_ref.len().is_multiple_of(DIGEST_SIZE));
-    let mut state = [F::ZERO; DIGEST_SIZE];
+
+    let mut state = [F::ZERO; POSEIDON2_WIDTH];
     state[0] = F::from_u32(deferral_idx);
-    for chunk in output_ref.chunks_exact(DIGEST_SIZE) {
-        let bytes = from_fn(|i| F::from_u8(chunk[i]));
-        state = hasher.compress(&state, &bytes);
+    state[1] = F::from_usize(output_ref.len());
+
+    let (lhs, rhs) = state_to_chunks(&state);
+    if output_ref.len() == 0 {
+        let res = hasher.perm(&lhs, &rhs, true);
+        return f_commit_to_bytes(&res).to_vec();
     }
-    f_commit_to_bytes(&state).to_vec()
+
+    state[DIGEST_SIZE..].copy_from_slice(&hasher.perm(&lhs, &rhs, false));
+
+    let mut output_chunks = output_ref.chunks_exact(DIGEST_SIZE);
+    let last_chunk = output_chunks.next_back().unwrap();
+
+    for chunk in output_chunks {
+        let f_chunk = chunk.iter().map(|b| F::from_u8(*b)).collect::<Vec<_>>();
+        state[..DIGEST_SIZE].copy_from_slice(&f_chunk);
+        let (lhs, rhs) = state_to_chunks(&state);
+        let capacity = hasher.perm(&lhs, &rhs, false);
+        state[DIGEST_SIZE..].copy_from_slice(&capacity);
+    }
+
+    let (_, rhs) = state_to_chunks(&state);
+    let last_chunk_f = from_fn(|i| F::from_u8(last_chunk[i]));
+    let res = hasher.perm(&last_chunk_f, &rhs, true);
+    f_commit_to_bytes(&res).to_vec()
+}
+
+pub(crate) fn chunks_to_state<F: Copy>(
+    lhs: &[F; DIGEST_SIZE],
+    rhs: &[F; DIGEST_SIZE],
+) -> [F; POSEIDON2_WIDTH] {
+    from_fn(|i| {
+        if i < DIGEST_SIZE {
+            lhs[i]
+        } else {
+            rhs[i - DIGEST_SIZE]
+        }
+    })
+}
+
+pub(crate) fn state_to_chunks<F: Copy>(
+    state: &[F; POSEIDON2_WIDTH],
+) -> ([F; DIGEST_SIZE], [F; DIGEST_SIZE]) {
+    (from_fn(|i| state[i]), from_fn(|i| state[i + DIGEST_SIZE]))
 }

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::utils::{and, assert_array_eq, not, or};
+use openvm_circuit_primitives::utils::{assert_array_eq, not};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
@@ -41,6 +41,7 @@ pub struct DeferralOutputCols<T> {
     // section of rows that correspond to a single opcode invocation
     pub is_valid: T,
     pub is_first: T,
+    pub is_last: T,
     pub section_idx: T,
 
     // Initial execution state + instruction operands
@@ -63,18 +64,17 @@ pub struct DeferralOutputCols<T> {
     pub output_len: [T; F_NUM_BYTES],
     pub output_commit_and_len_aux: [MemoryReadAuxCols<T>; OUTPUT_TOTAL_MEMORY_OPS],
 
-    // Bytes raw_output[local_idx * DIGEST_SIZE..(local_idx + 1) * DIGEST_SIZE]
-    // written to memory and auxiliary columns
-    pub write_bytes: [T; DIGEST_SIZE],
+    // Initial [def_idx, output_len, 0, ...] digest on the first row; on non-first
+    // rows bytes raw_output[local_idx * DIGEST_SIZE..(local_idx + 1) * DIGEST_SIZE]
+    // written to memory and auxiliary columns.
+    pub sponge_inputs: [T; DIGEST_SIZE],
     pub write_bytes_aux: [MemoryWriteAuxCols<T, MEMORY_OP_SIZE>; DIGEST_MEMORY_OPS],
 
-    // Running hash of this section's write_bytes, constrained to be output_commit;
-    // note the initial state should be [deferral_idx, 0, ..., 0]
-    pub current_commit_state: [T; DIGEST_SIZE],
+    // Capacity of the permutation of write_bytes and the previous row's capacity on
+    // non-last rows, compression on the last row.
+    pub poseidon2_res: [T; DIGEST_SIZE],
 }
 
-// TODO: This should probably be split into two AIRs, one for the read + execution
-// state and one for the reads. This is quite difficult to do currently, though.
 #[derive(Clone, Copy, Debug, derive_new::new)]
 pub struct DeferralOutputAir {
     pub execution_bridge: ExecutionBridge,
@@ -102,6 +102,9 @@ where
         let local: &DeferralOutputCols<AB::Var> = (*local).borrow();
         let next: &DeferralOutputCols<AB::Var> = (*next).borrow();
 
+        let is_transition = next.is_valid - next.is_first;
+        let is_last = local.is_valid - is_transition.clone();
+
         // Constrain the status flags. Particularly, section_idx must (a) always
         // reset to 0 upon reaching a new section, and (b) otherwise increment by
         // one each valid row. Additionally, for convenience we constrain that
@@ -117,6 +120,8 @@ where
             .when(local.is_valid)
             .assert_one(local.is_first);
 
+        builder.assert_eq(local.is_last, is_last);
+
         builder
             .when(not(local.is_valid))
             .assert_zero(local.is_first);
@@ -126,11 +131,8 @@ where
 
         builder.when(local.is_first).assert_zero(local.section_idx);
         builder
-            .when(next.section_idx)
-            .assert_eq(next.section_idx, local.section_idx + AB::Expr::ONE);
-        builder
-            .when(and(next.is_valid, not(next.is_first)))
-            .assert_eq(next.section_idx, local.section_idx + AB::Expr::ONE);
+            .when(is_transition.clone())
+            .assert_one(next.section_idx - local.section_idx);
 
         // Constrain that the read columns and other operands stay the same within a
         // section, i.e. when section_idx is non-zero. Note that the read auxiliary
@@ -159,45 +161,45 @@ where
         );
 
         // Constrain the consistency of current_commit_state at each point in this
-        // section's rows. The initial state should be [deferral_idx, 0, ..., 0]
-        // and the final state should be output_commit. Note that output_len must
-        // be divisible by DIGEST_SIZE.
-        let is_last_or_invalid = or(next.is_first, not(next.is_valid));
-        let mut when_last_or_invalid = builder.when(is_last_or_invalid.clone());
+        // section's rows. The initial state should be [deferral_idx, output_len,
+        // ..., 0].
+        let output_len = bytes_to_f(&local.output_len);
+        let mut initial_state = [AB::Expr::ZERO; DIGEST_SIZE];
+        initial_state[0] = local.deferral_idx.into();
+        initial_state[1] = output_len.clone();
 
-        when_last_or_invalid.assert_eq(
-            bytes_to_f(&local.output_len),
-            (local.section_idx + local.is_valid) * AB::Expr::from_usize(DIGEST_SIZE),
-        );
         assert_array_eq(
-            &mut when_last_or_invalid,
-            byte_commit_to_f(&local.output_commit),
-            local.current_commit_state,
+            &mut builder.when(local.is_first),
+            initial_state,
+            local.sponge_inputs,
         );
 
         self.count_bus
             .send(local.deferral_idx)
             .eval(builder, local.is_first);
 
-        let mut initial_state = [AB::Expr::ZERO; DIGEST_SIZE];
-        initial_state[0] = local.deferral_idx.into();
+        // The final state should be output_commit, and output_len must be the final
+        // section_idx * DIGEST_SIZE.
+        let mut when_last = builder.when(local.is_last);
 
+        when_last.assert_eq(
+            output_len,
+            local.section_idx * AB::Expr::from_usize(DIGEST_SIZE),
+        );
+        assert_array_eq(
+            &mut when_last,
+            byte_commit_to_f(&local.output_commit),
+            local.poseidon2_res,
+        );
+
+        // Constrain poseidon2_res is the running permute capacity on all non-last rows,
+        // and the compression on the last row.
+        let rhs = from_fn(|i| is_transition.clone() * local.poseidon2_res[i]);
         self.poseidon2_bus
-            .compress(initial_state, local.write_bytes, local.current_commit_state)
-            .eval(builder, local.is_first);
+            .lookup(next.sponge_inputs, rhs, next.poseidon2_res, next.is_last)
+            .eval(builder, next.is_valid);
 
-        self.poseidon2_bus
-            .compress(
-                local.current_commit_state,
-                next.write_bytes,
-                next.current_commit_state,
-            )
-            .eval(
-                builder,
-                local.is_valid * and(next.is_valid, not(next.is_first)),
-            );
-
-        // Constrain the heap pointer memory reads first.
+        // Constrain the heap pointer memory reads.
         let d = AB::Expr::from_u32(RV32_REGISTER_AS);
         let e = AB::Expr::from_u32(RV32_MEMORY_AS);
 
@@ -233,7 +235,7 @@ where
         });
         let output_commit_and_len =
             combine_output(local.output_commit.map(Into::into), output_len_full);
-        let output_commit_and_len_chunks =
+        let output_commit_and_len_chunks: [[<AB as AirBuilder>::Expr; 4]; 10] =
             split_memory_ops::<_, OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS>(
                 output_commit_and_len,
             );
@@ -257,7 +259,8 @@ where
         }
 
         let write_bytes_chunks =
-            split_memory_ops::<_, DIGEST_SIZE, DIGEST_MEMORY_OPS>(local.write_bytes);
+            split_memory_ops::<_, DIGEST_SIZE, DIGEST_MEMORY_OPS>(local.sponge_inputs);
+        let section_idx_minus_one = local.section_idx - AB::Expr::ONE;
 
         for (chunk_idx, (data, aux)) in write_bytes_chunks
             .into_iter()
@@ -269,16 +272,16 @@ where
                     MemoryAddress::new(
                         e.clone(),
                         output_ptr.clone()
-                            + (local.section_idx.into() * AB::Expr::from_usize(DIGEST_SIZE))
+                            + (section_idx_minus_one.clone() * AB::Expr::from_usize(DIGEST_SIZE))
                             + AB::Expr::from_usize(chunk_idx * MEMORY_OP_SIZE),
                     ),
                     data,
                     local.from_state.timestamp
                         + AB::Expr::from_usize(2 + OUTPUT_TOTAL_MEMORY_OPS + chunk_idx)
-                        + (local.section_idx.into() * AB::Expr::from_usize(DIGEST_MEMORY_OPS)),
+                        + (section_idx_minus_one.clone() * AB::Expr::from_usize(DIGEST_MEMORY_OPS)),
                     aux,
                 )
-                .eval(builder, local.is_valid);
+                .eval(builder, local.is_valid - local.is_first);
         }
 
         // Evaluate the execution interaction. Because a single opcode spans many
@@ -294,10 +297,10 @@ where
                     e,
                 ],
                 local.from_state,
-                (local.section_idx.into() * AB::Expr::from_usize(DIGEST_MEMORY_OPS))
-                    + AB::Expr::from_usize(OUTPUT_TOTAL_MEMORY_OPS + DIGEST_MEMORY_OPS + 2),
+                (local.section_idx * AB::Expr::from_usize(DIGEST_MEMORY_OPS))
+                    + AB::Expr::from_usize(OUTPUT_TOTAL_MEMORY_OPS + 2),
                 (DEFAULT_PC_STEP, None),
             )
-            .eval(builder, local.is_valid * is_last_or_invalid);
+            .eval(builder, local.is_last);
     }
 }

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -235,7 +235,7 @@ where
         });
         let output_commit_and_len =
             combine_output(local.output_commit.map(Into::into), output_len_full);
-        let output_commit_and_len_chunks: [[<AB as AirBuilder>::Expr; 4]; 10] =
+        let output_commit_and_len_chunks =
             split_memory_ops::<_, OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS>(
                 output_commit_and_len,
             );

--- a/extensions/deferral/circuit/src/output/execution.rs
+++ b/extensions/deferral/circuit/src/output/execution.rs
@@ -163,7 +163,7 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
 
     let output_len_val = u64::from_le_bytes(output_len) as usize;
 
-    // Bytes are sponge-hashed and constrained against output_commit. Thhe
+    // Bytes are sponge-hashed and constrained against output_commit. The
     // sponge rate is DIGEST_SIZE.
     let num_rows = output_len_val / DIGEST_SIZE + 1;
     debug_assert!(output_len_val.is_multiple_of(DIGEST_SIZE));

--- a/extensions/deferral/circuit/src/output/execution.rs
+++ b/extensions/deferral/circuit/src/output/execution.rs
@@ -165,7 +165,7 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
 
     // Bytes are sponge-hashed and constrained against output_commit. Thhe
     // sponge rate is DIGEST_SIZE.
-    let num_rows = output_len_val / DIGEST_SIZE;
+    let num_rows = output_len_val / DIGEST_SIZE + 1;
     debug_assert!(output_len_val.is_multiple_of(DIGEST_SIZE));
 
     let output_raw = exec_state.streams.deferrals[pre_compute.deferral_idx as usize]

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -7,9 +7,8 @@ use std::{
 
 use openvm_circuit::{
     arch::{
-        get_record_from_slice, hasher::HasherChip, CustomBorrow, ExecutionError, MultiRowLayout,
-        MultiRowMetadata, PreflightExecutor, RecordArena, SizedRecord, TraceFiller, VmField,
-        VmStateMut,
+        get_record_from_slice, CustomBorrow, ExecutionError, MultiRowLayout, MultiRowMetadata,
+        PreflightExecutor, RecordArena, SizedRecord, TraceFiller, VmField, VmStateMut,
     },
     system::memory::{
         offline_checker::{MemoryReadAuxRecord, MemoryWriteBytesAuxRecord},
@@ -90,8 +89,9 @@ impl<'a> CustomBorrow<'a, DeferralOutputRecordMut<'a>, DeferralOutputLayout> for
         // SAFETY:
         // - The layout guarantees rest has sufficient length for write data
         // - There are DIGEST_SIZE bytes written per row
+        let num_write_rows = layout.metadata.num_rows.saturating_sub(1);
         let (write_bytes, rest) =
-            unsafe { rest.split_at_mut_unchecked(layout.metadata.num_rows * DIGEST_SIZE) };
+            unsafe { rest.split_at_mut_unchecked(num_write_rows * DIGEST_SIZE) };
 
         // SAFETY:
         // - Valid mutable slice from the previous split
@@ -104,7 +104,7 @@ impl<'a> CustomBorrow<'a, DeferralOutputRecordMut<'a>, DeferralOutputLayout> for
         DeferralOutputRecordMut {
             header: header_buf.borrow_mut(),
             write_bytes,
-            write_aux: &mut write_aux_buf[..layout.metadata.num_rows * DIGEST_MEMORY_OPS],
+            write_aux: &mut write_aux_buf[..num_write_rows * DIGEST_MEMORY_OPS],
         }
     }
 
@@ -121,10 +121,11 @@ impl<'a> CustomBorrow<'a, DeferralOutputRecordMut<'a>, DeferralOutputLayout> for
 impl<'a> SizedRecord<DeferralOutputLayout> for DeferralOutputRecordMut<'a> {
     fn size(layout: &DeferralOutputLayout) -> usize {
         let mut total_len = size_of::<DeferralOutputRecordHeader>();
-        total_len += layout.metadata.num_rows * DIGEST_SIZE;
+        let num_write_rows = layout.metadata.num_rows.saturating_sub(1);
+        total_len += num_write_rows * DIGEST_SIZE;
         total_len =
             total_len.next_multiple_of(align_of::<MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>>());
-        total_len += layout.metadata.num_rows
+        total_len += num_write_rows
             * DIGEST_MEMORY_OPS
             * size_of::<MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>>();
         total_len
@@ -179,7 +180,7 @@ where
         let (output_commit, output_len) = split_output(output_key);
 
         let output_len_val = u64::from_le_bytes(output_len) as usize;
-        let num_rows = output_len_val / DIGEST_SIZE;
+        let num_rows = output_len_val / DIGEST_SIZE + 1;
         debug_assert!(output_len_val.is_multiple_of(DIGEST_SIZE));
 
         // We now have the layout and can write the record
@@ -272,6 +273,7 @@ where
             let header: &DeferralOutputRecordHeader =
                 unsafe { get_record_from_slice(&mut trace, ()) };
             let num_rows = header.num_rows as usize;
+            let output_len = (num_rows - 1) * DIGEST_SIZE;
             let (mut section_chunk, rest) = trace.split_at_mut(width * num_rows);
 
             // Copy write data out first; row filling overwrites the record bytes in-place.
@@ -292,12 +294,15 @@ where
                 )
             };
 
-            // Starting commit state should be [deferral_idx, 0, ..., 0]
-            let mut current_commit_state = [F::ZERO; DIGEST_SIZE];
-            current_commit_state[0] = F::from_u32(header.deferral_idx);
+            // Initial sponge input is [deferral_idx, output_len, 0, ...].
+            let mut initial_sponge_input = [F::ZERO; DIGEST_SIZE];
+            initial_sponge_input[0] = F::from_u32(header.deferral_idx);
+            initial_sponge_input[1] = F::from_usize(output_len);
+
+            let mut current_poseidon2_res = [F::ZERO; DIGEST_SIZE];
             self.count_chip.add_count(header.deferral_idx);
 
-            let output_len_bytes = u32::try_from(num_rows * DIGEST_SIZE)
+            let output_len_bytes = u32::try_from(output_len)
                 .expect("deferral output length should fit a u32")
                 .to_le_bytes()
                 .map(F::from_u8);
@@ -307,6 +312,7 @@ where
 
                 cols.is_valid = F::ONE;
                 cols.is_first = F::from_bool(row_idx == 0);
+                cols.is_last = F::from_bool(row_idx + 1 == num_rows);
                 cols.section_idx = F::from_usize(row_idx);
 
                 cols.from_state.pc = F::from_u32(header.from_pc);
@@ -345,26 +351,42 @@ where
                 }
 
                 cols.output_len.copy_from_slice(&output_len_bytes);
-                cols.write_bytes = from_fn(|i| F::from_u8(write_bytes[row_idx * DIGEST_SIZE + i]));
-
-                current_commit_state = self
-                    .poseidon2_chip
-                    .compress_and_record(&current_commit_state, &cols.write_bytes);
-                cols.current_commit_state = current_commit_state;
-
-                for chunk_idx in 0..DIGEST_MEMORY_OPS {
-                    let aux_idx = row_idx * DIGEST_MEMORY_OPS + chunk_idx;
-                    cols.write_bytes_aux[chunk_idx]
-                        .set_prev_data(write_aux[aux_idx].prev_data.map(F::from_u8));
-                    mem_helper.fill(
-                        write_aux[aux_idx].prev_timestamp,
-                        header.from_timestamp + 2 + OUTPUT_TOTAL_MEMORY_OPS as u32 + aux_idx as u32,
-                        cols.write_bytes_aux[chunk_idx].as_mut(),
+                if row_idx == 0 {
+                    cols.sponge_inputs = initial_sponge_input;
+                    current_poseidon2_res = self.poseidon2_chip.perm_and_record(
+                        &cols.sponge_inputs,
+                        &[F::ZERO; DIGEST_SIZE],
+                        row_idx + 1 == num_rows,
                     );
+                    for chunk_aux in &mut cols.write_bytes_aux {
+                        mem_helper.fill_zero(chunk_aux.as_mut());
+                    }
+                } else {
+                    cols.sponge_inputs =
+                        from_fn(|i| F::from_u8(write_bytes[(row_idx - 1) * DIGEST_SIZE + i]));
+                    current_poseidon2_res = self.poseidon2_chip.perm_and_record(
+                        &cols.sponge_inputs,
+                        &current_poseidon2_res,
+                        row_idx + 1 == num_rows,
+                    );
+                    for chunk_idx in 0..DIGEST_MEMORY_OPS {
+                        let aux_idx = (row_idx - 1) * DIGEST_MEMORY_OPS + chunk_idx;
+                        cols.write_bytes_aux[chunk_idx]
+                            .set_prev_data(write_aux[aux_idx].prev_data.map(F::from_u8));
+                        mem_helper.fill(
+                            write_aux[aux_idx].prev_timestamp,
+                            header.from_timestamp
+                                + 2
+                                + OUTPUT_TOTAL_MEMORY_OPS as u32
+                                + aux_idx as u32,
+                            cols.write_bytes_aux[chunk_idx].as_mut(),
+                        );
+                    }
                 }
+                cols.poseidon2_res = current_poseidon2_res;
             }
 
-            let output_commit = f_commit_to_bytes(&current_commit_state).map(F::from_u8);
+            let output_commit = f_commit_to_bytes(&current_poseidon2_res).map(F::from_u8);
             for row in section_chunk.chunks_exact_mut(width) {
                 let cols: &mut DeferralOutputCols<F> = row.borrow_mut();
                 cols.output_commit = output_commit;

--- a/extensions/deferral/circuit/src/poseidon2/air.rs
+++ b/extensions/deferral/circuit/src/poseidon2/air.rs
@@ -71,17 +71,21 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralPoseidon2Air<AB::F
 
         self.bus.add_key_with_lookups(
             builder,
-            once(AB::Expr::ONE)
-                .chain(inputs.into_iter().map(Into::into))
-                .chain(compress_res.iter().copied().map(Into::into)),
+            inputs
+                .into_iter()
+                .map(Into::into)
+                .chain(compress_res.iter().copied().map(Into::into))
+                .chain(once(AB::Expr::ONE)),
             local.compress_mult,
         );
 
         self.bus.add_key_with_lookups(
             builder,
-            once(AB::Expr::ZERO)
-                .chain(inputs.into_iter().map(Into::into))
-                .chain(capacity_res.iter().copied().map(Into::into)),
+            inputs
+                .into_iter()
+                .map(Into::into)
+                .chain(capacity_res.iter().copied().map(Into::into))
+                .chain(once(AB::Expr::ZERO)),
             local.capacity_mult,
         );
     }

--- a/extensions/deferral/circuit/src/poseidon2/air.rs
+++ b/extensions/deferral/circuit/src/poseidon2/air.rs
@@ -73,7 +73,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralPoseidon2Air<AB::F
             builder,
             once(AB::Expr::ONE)
                 .chain(inputs.into_iter().map(Into::into))
-                .chain(compress_res.into_iter().copied().map(Into::into)),
+                .chain(compress_res.iter().copied().map(Into::into)),
             local.compress_mult,
         );
 
@@ -81,7 +81,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralPoseidon2Air<AB::F
             builder,
             once(AB::Expr::ZERO)
                 .chain(inputs.into_iter().map(Into::into))
-                .chain(capacity_res.into_iter().copied().map(Into::into)),
+                .chain(capacity_res.iter().copied().map(Into::into)),
             local.capacity_mult,
         );
     }

--- a/extensions/deferral/circuit/src/poseidon2/air.rs
+++ b/extensions/deferral/circuit/src/poseidon2/air.rs
@@ -1,15 +1,88 @@
-use std::sync::Arc;
+use std::{borrow::Borrow, iter::once, sync::Arc};
 
-use openvm_circuit::{arch::VmField, system::poseidon2::air::Poseidon2PeripheryAir};
-use openvm_poseidon2_air::{Poseidon2Config, Poseidon2SubAir};
-use openvm_stark_backend::interaction::LookupBus;
+use openvm_circuit_primitives::AlignedBorrow;
+use openvm_poseidon2_air::{
+    Poseidon2Config, Poseidon2SubAir, Poseidon2SubCols, BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS,
+};
+use openvm_stark_backend::{
+    air_builders::sub::SubAirBuilder,
+    interaction::{InteractionBuilder, LookupBus},
+    p3_air::{Air, AirBuilder, BaseAir},
+    p3_matrix::Matrix,
+    BaseAirWithPublicValues, PartitionedBaseAir,
+};
+use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
+use p3_field::{Field, PrimeCharacteristicRing};
 
 use super::SBOX_REGISTERS;
 
-pub type DeferralPoseidon2Air<F> = Poseidon2PeripheryAir<F, SBOX_REGISTERS>;
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct DeferralPoseidon2Cols<T> {
+    pub inner: Poseidon2SubCols<T, SBOX_REGISTERS>,
+    pub compress_mult: T,
+    pub capacity_mult: T,
+}
 
-pub fn deferral_poseidon2_air<F: VmField>(bus: LookupBus) -> DeferralPoseidon2Air<F> {
-    let constants = Poseidon2Config::default().constants;
-    let subair = Arc::new(Poseidon2SubAir::new(constants.into()));
-    DeferralPoseidon2Air::new(subair, bus)
+pub struct DeferralPoseidon2Air<F: Field> {
+    pub subair: Arc<Poseidon2SubAir<F, SBOX_REGISTERS>>,
+    pub bus: LookupBus,
+}
+
+impl<F: Field> DeferralPoseidon2Air<F> {
+    pub fn new(config: Poseidon2Config<F>, bus: LookupBus) -> Self {
+        Self {
+            subair: Arc::new(Poseidon2SubAir::new(config.constants.into())),
+            bus,
+        }
+    }
+}
+
+impl<F: Field> BaseAir<F> for DeferralPoseidon2Air<F> {
+    fn width(&self) -> usize {
+        DeferralPoseidon2Cols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for DeferralPoseidon2Air<F> {}
+impl<F: Field> PartitionedBaseAir<F> for DeferralPoseidon2Air<F> {}
+
+impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralPoseidon2Air<AB::F> {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main
+            .row_slice(0)
+            .expect("window should have at least one row");
+        let local: &DeferralPoseidon2Cols<AB::Var> = (*local).borrow();
+
+        let mut sub_builder =
+            SubAirBuilder::<AB, Poseidon2SubAir<AB::F, SBOX_REGISTERS>, AB::F>::new(
+                builder,
+                0..self.subair.width(),
+            );
+        self.subair.eval(&mut sub_builder);
+
+        let inputs = local.inner.inputs;
+        let compress_res = &local.inner.ending_full_rounds
+            [BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS - 1]
+            .post[..DIGEST_SIZE];
+        let capacity_res = &local.inner.ending_full_rounds
+            [BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS - 1]
+            .post[DIGEST_SIZE..];
+
+        self.bus.add_key_with_lookups(
+            builder,
+            once(AB::Expr::ONE)
+                .chain(inputs.into_iter().map(Into::into))
+                .chain(compress_res.into_iter().copied().map(Into::into)),
+            local.compress_mult,
+        );
+
+        self.bus.add_key_with_lookups(
+            builder,
+            once(AB::Expr::ZERO)
+                .chain(inputs.into_iter().map(Into::into))
+                .chain(capacity_res.into_iter().copied().map(Into::into)),
+            local.capacity_mult,
+        );
+    }
 }

--- a/extensions/deferral/circuit/src/poseidon2/bus.rs
+++ b/extensions/deferral/circuit/src/poseidon2/bus.rs
@@ -52,10 +52,12 @@ impl<T: PrimeCharacteristicRing> DeferralPoseidon2Interaction<T> {
     where
         AB: InteractionBuilder<Expr = T>,
     {
-        let key: [_; 3 * PERIPHERY_POSEIDON2_CHUNK_SIZE + 1] = once(self.is_compress)
-            .chain(self.left)
+        let key: [_; 3 * PERIPHERY_POSEIDON2_CHUNK_SIZE + 1] = self
+            .left
+            .into_iter()
             .chain(self.right)
             .chain(self.output)
+            .chain(once(self.is_compress))
             .collect_array()
             .unwrap();
         self.bus.lookup_key(builder, key, count);

--- a/extensions/deferral/circuit/src/poseidon2/bus.rs
+++ b/extensions/deferral/circuit/src/poseidon2/bus.rs
@@ -1,3 +1,5 @@
+use std::iter::once;
+
 use itertools::Itertools;
 use openvm_circuit::system::poseidon2::PERIPHERY_POSEIDON2_CHUNK_SIZE;
 use openvm_stark_backend::{
@@ -19,16 +21,18 @@ impl DeferralPoseidon2Bus {
     }
 
     #[must_use]
-    pub fn compress<T>(
+    pub fn lookup<T>(
         &self,
         left: [impl Into<T>; PERIPHERY_POSEIDON2_CHUNK_SIZE],
         right: [impl Into<T>; PERIPHERY_POSEIDON2_CHUNK_SIZE],
         output: [impl Into<T>; PERIPHERY_POSEIDON2_CHUNK_SIZE],
+        is_compress: impl Into<T>,
     ) -> DeferralPoseidon2Interaction<T> {
         DeferralPoseidon2Interaction {
             left: left.map(Into::into),
             right: right.map(Into::into),
             output: output.map(Into::into),
+            is_compress: is_compress.into(),
             bus: self.0,
         }
     }
@@ -39,6 +43,7 @@ pub struct DeferralPoseidon2Interaction<T> {
     pub left: [T; PERIPHERY_POSEIDON2_CHUNK_SIZE],
     pub right: [T; PERIPHERY_POSEIDON2_CHUNK_SIZE],
     pub output: [T; PERIPHERY_POSEIDON2_CHUNK_SIZE],
+    pub is_compress: T,
     pub bus: LookupBus,
 }
 
@@ -47,9 +52,9 @@ impl<T: PrimeCharacteristicRing> DeferralPoseidon2Interaction<T> {
     where
         AB: InteractionBuilder<Expr = T>,
     {
-        let key: [_; 3 * PERIPHERY_POSEIDON2_CHUNK_SIZE] = self
-            .left
+        let key: [_; 3 * PERIPHERY_POSEIDON2_CHUNK_SIZE + 1] = once(self.is_compress)
             .into_iter()
+            .chain(self.left)
             .chain(self.right)
             .chain(self.output)
             .collect_array()

--- a/extensions/deferral/circuit/src/poseidon2/bus.rs
+++ b/extensions/deferral/circuit/src/poseidon2/bus.rs
@@ -53,7 +53,6 @@ impl<T: PrimeCharacteristicRing> DeferralPoseidon2Interaction<T> {
         AB: InteractionBuilder<Expr = T>,
     {
         let key: [_; 3 * PERIPHERY_POSEIDON2_CHUNK_SIZE + 1] = once(self.is_compress)
-            .into_iter()
             .chain(self.left)
             .chain(self.right)
             .chain(self.output)

--- a/extensions/deferral/circuit/src/poseidon2/mod.rs
+++ b/extensions/deferral/circuit/src/poseidon2/mod.rs
@@ -1,3 +1,7 @@
+use openvm_circuit::arch::VmField;
+use openvm_poseidon2_air::Poseidon2Config;
+use openvm_stark_backend::interaction::LookupBus;
+
 mod air;
 mod bus;
 mod trace;
@@ -7,3 +11,13 @@ pub use bus::*;
 pub use trace::*;
 
 const SBOX_REGISTERS: usize = 1;
+
+pub fn deferral_poseidon2_air<F: VmField>(bus: LookupBus) -> DeferralPoseidon2Air<F> {
+    let config = Poseidon2Config::default();
+    DeferralPoseidon2Air::new(config, bus)
+}
+
+pub fn deferral_poseidon2_chip<F: VmField>() -> DeferralPoseidon2Chip<F> {
+    let config = Poseidon2Config::default();
+    DeferralPoseidon2Chip::new(config)
+}

--- a/extensions/deferral/circuit/src/poseidon2/trace.rs
+++ b/extensions/deferral/circuit/src/poseidon2/trace.rs
@@ -1,48 +1,87 @@
-use openvm_circuit::{
-    arch::{
-        hasher::{Hasher, HasherChip},
-        VmField,
-    },
-    system::poseidon2::{Poseidon2PeripheryBaseChip, PERIPHERY_POSEIDON2_CHUNK_SIZE},
+use std::{
+    array::from_fn,
+    borrow::BorrowMut,
+    sync::atomic::{AtomicBool, AtomicU32},
 };
-use openvm_circuit_primitives::Chip;
-use openvm_cpu_backend::CpuBackend;
-use openvm_poseidon2_air::Poseidon2Config;
-use openvm_stark_backend::{prover::AirProvingContext, StarkProtocolConfig, Val};
 
-use super::SBOX_REGISTERS;
+use dashmap::DashMap;
+use openvm_circuit::arch::VmField;
+use openvm_circuit_primitives::{utils::next_power_of_two_or_zero, Chip};
+use openvm_cpu_backend::CpuBackend;
+use openvm_poseidon2_air::{Poseidon2Config, Poseidon2SubChip, POSEIDON2_WIDTH};
+use openvm_stark_backend::{
+    p3_air::BaseAir, p3_field::PrimeCharacteristicRing, p3_matrix::dense::RowMajorMatrix,
+    p3_maybe_rayon::prelude::*, prover::AirProvingContext, StarkProtocolConfig, Val,
+};
+use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
+use rustc_hash::FxBuildHasher;
+
+use super::{DeferralPoseidon2Cols, SBOX_REGISTERS};
+use crate::chunks_to_state;
 
 #[derive(Debug)]
-pub struct DeferralPoseidon2Chip<F: VmField>(Poseidon2PeripheryBaseChip<F, SBOX_REGISTERS>);
+pub struct DeferralPoseidon2Chip<F: VmField> {
+    pub subchip: Poseidon2SubChip<F, SBOX_REGISTERS>,
+    pub records: DashMap<[F; POSEIDON2_WIDTH], (AtomicU32, AtomicU32), FxBuildHasher>,
+    pub nonempty: AtomicBool,
+}
 
 impl<F: VmField> DeferralPoseidon2Chip<F> {
     pub fn new(poseidon2_config: Poseidon2Config<F>) -> Self {
-        Self(Poseidon2PeripheryBaseChip::new(poseidon2_config))
+        let subchip = Poseidon2SubChip::new(poseidon2_config.constants);
+        Self {
+            subchip,
+            records: DashMap::default(),
+            nonempty: AtomicBool::new(false),
+        }
     }
-}
 
-pub fn deferral_poseidon2_chip<F: VmField>() -> DeferralPoseidon2Chip<F> {
-    let config = Poseidon2Config::default();
-    DeferralPoseidon2Chip::new(config)
-}
-
-impl<F: VmField> Hasher<PERIPHERY_POSEIDON2_CHUNK_SIZE, F> for DeferralPoseidon2Chip<F> {
-    fn compress(
+    pub fn perm(
         &self,
-        lhs: &[F; PERIPHERY_POSEIDON2_CHUNK_SIZE],
-        rhs: &[F; PERIPHERY_POSEIDON2_CHUNK_SIZE],
-    ) -> [F; PERIPHERY_POSEIDON2_CHUNK_SIZE] {
-        self.0.compress(lhs, rhs)
+        lhs: &[F; DIGEST_SIZE],
+        rhs: &[F; DIGEST_SIZE],
+        is_compress: bool,
+    ) -> [F; DIGEST_SIZE] {
+        let output = self.perm_state(lhs, rhs);
+        self.select_output_chunk(output, is_compress)
     }
-}
 
-impl<F: VmField> HasherChip<PERIPHERY_POSEIDON2_CHUNK_SIZE, F> for DeferralPoseidon2Chip<F> {
-    fn compress_and_record(
+    pub fn perm_state(
         &self,
-        lhs: &[F; PERIPHERY_POSEIDON2_CHUNK_SIZE],
-        rhs: &[F; PERIPHERY_POSEIDON2_CHUNK_SIZE],
-    ) -> [F; PERIPHERY_POSEIDON2_CHUNK_SIZE] {
-        self.0.compress_and_record(lhs, rhs)
+        lhs: &[F; DIGEST_SIZE],
+        rhs: &[F; DIGEST_SIZE],
+    ) -> [F; POSEIDON2_WIDTH] {
+        let input = chunks_to_state(lhs, rhs);
+        self.subchip.permute(input)
+    }
+
+    pub fn perm_and_record(
+        &self,
+        lhs: &[F; DIGEST_SIZE],
+        rhs: &[F; DIGEST_SIZE],
+        is_compress: bool,
+    ) -> [F; DIGEST_SIZE] {
+        let input = chunks_to_state(lhs, rhs);
+        let output = self.subchip.permute(input);
+        let ret = self.select_output_chunk(output, is_compress);
+        let count = self
+            .records
+            .entry(input)
+            .or_insert((AtomicU32::new(0), AtomicU32::new(0)));
+        let mult = if is_compress { &count.0 } else { &count.1 };
+        mult.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.nonempty
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        ret
+    }
+
+    fn select_output_chunk(
+        &self,
+        output: [F; POSEIDON2_WIDTH],
+        is_compress: bool,
+    ) -> [F; DIGEST_SIZE] {
+        let offset = if is_compress { 0 } else { DIGEST_SIZE };
+        from_fn(|i| output[i + offset])
     }
 }
 
@@ -50,7 +89,56 @@ impl<RA, SC: StarkProtocolConfig> Chip<RA, CpuBackend<SC>> for DeferralPoseidon2
 where
     Val<SC>: VmField,
 {
-    fn generate_proving_ctx(&self, records: RA) -> AirProvingContext<CpuBackend<SC>> {
-        self.0.generate_proving_ctx(records)
+    fn generate_proving_ctx(&self, _: RA) -> AirProvingContext<CpuBackend<SC>> {
+        let current_height = if self.nonempty.load(std::sync::atomic::Ordering::Relaxed) {
+            self.records.len()
+        } else {
+            0
+        };
+        let height = next_power_of_two_or_zero(current_height);
+        let width = DeferralPoseidon2Cols::<Val<SC>>::width();
+
+        let mut inputs = Vec::with_capacity(height);
+        let mut multiplicities = Vec::with_capacity(height);
+        #[cfg(feature = "parallel")]
+        let records_iter = self.records.par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let records_iter = self.records.iter();
+        let (actual_inputs, actual_multiplicities): (Vec<_>, Vec<_>) = records_iter
+            .map(|record| {
+                let (input, (compress_mult, capacity_mult)) = record.pair();
+                (
+                    *input,
+                    (
+                        compress_mult.load(std::sync::atomic::Ordering::Relaxed),
+                        capacity_mult.load(std::sync::atomic::Ordering::Relaxed),
+                    ),
+                )
+            })
+            .unzip();
+        inputs.extend(actual_inputs);
+        multiplicities.extend(actual_multiplicities);
+        inputs.resize(height, [Val::<SC>::ZERO; POSEIDON2_WIDTH]);
+        multiplicities.resize(height, (0, 0));
+
+        let inner_trace = self.subchip.generate_trace(inputs);
+        let inner_width = self.subchip.air.width();
+
+        let mut values = Val::<SC>::zero_vec(height * width);
+        values
+            .par_chunks_mut(width)
+            .zip(inner_trace.values.par_chunks(inner_width))
+            .zip(multiplicities)
+            .for_each(|((row, inner_row), (compress_mult, capacity_mult))| {
+                // WARNING: Poseidon2SubCols must be the first field in DeferralPoseidon2Cols.
+                row[..inner_width].copy_from_slice(inner_row);
+                let cols: &mut DeferralPoseidon2Cols<Val<SC>> = row.borrow_mut();
+                cols.compress_mult = Val::<SC>::from_u32(compress_mult);
+                cols.capacity_mult = Val::<SC>::from_u32(capacity_mult);
+            });
+        self.records.clear();
+
+        let trace = RowMajorMatrix::new(values, width);
+        AirProvingContext::simple_no_pis(trace)
     }
 }

--- a/guest-libs/verify-stark/circuit/src/lib.rs
+++ b/guest-libs/verify-stark/circuit/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prover;
 mod trace;
 pub use trace::*;
 
-#[cfg(all(test, feature = "cuda"))]
+#[cfg(test)]
 mod tests;
 
 #[derive(derive_new::new, Clone)]
@@ -46,6 +46,7 @@ pub struct DeferredVerifyCircuit<S: AggregationSubCircuit> {
     def_hook_commit: Option<CommitBytes>,
     pub(crate) memory_dimensions: MemoryDimensions,
     pub(crate) num_user_pvs: usize,
+    pub(crate) def_idx: usize,
 }
 
 impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
@@ -96,10 +97,11 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             self.num_user_pvs,
         );
         let output_commit_air = DeferralOutputCommitAir {
-            poseidon2_bus: bus_inventory.poseidon2_compress_bus,
+            poseidon2_bus: bus_inventory.poseidon2_permute_bus,
             range_bus: bus_inventory.range_checker_bus,
             output_val_bus,
             output_commit_bus,
+            def_idx: self.def_idx,
         };
 
         let acc_paths_air = self.def_hook_commit.map(|_| {

--- a/guest-libs/verify-stark/circuit/src/output/air.rs
+++ b/guest-libs/verify-stark/circuit/src/output/air.rs
@@ -1,13 +1,13 @@
-use std::borrow::Borrow;
+use std::{array::from_fn, borrow::Borrow};
 
-use itertools::{fold, izip};
+use itertools::{fold, Itertools};
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
     AlignedBorrow,
 };
 use openvm_continuations::utils::digests_to_poseidon2_input;
 use openvm_recursion_circuit::{
-    bus::{Poseidon2CompressBus, Poseidon2CompressMessage},
+    bus::{Poseidon2PermuteBus, Poseidon2PermuteMessage},
     prelude::DIGEST_SIZE,
     primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
 };
@@ -31,20 +31,22 @@ const fn exact_div_or_panic(a: usize, b: usize) -> usize {
 pub struct DeferralOutputCommitCols<F> {
     pub is_valid: F,
     pub is_first: F,
+    pub row_idx: F,
+    pub output_len: F,
 
-    pub state: [F; DIGEST_SIZE],
-    pub next_bytes: [F; DIGEST_SIZE],
-
-    pub next_f: [F; VALS_IN_DIGEST],
-    pub next_f_idx: F,
+    pub input_vals: [F; DIGEST_SIZE],
+    pub res_left: [F; DIGEST_SIZE],
+    pub res_right: [F; DIGEST_SIZE],
 }
 
 #[derive(Debug)]
 pub struct DeferralOutputCommitAir {
-    pub poseidon2_bus: Poseidon2CompressBus,
+    pub poseidon2_bus: Poseidon2PermuteBus,
     pub range_bus: RangeCheckerBus,
     pub output_val_bus: OutputValBus,
     pub output_commit_bus: OutputCommitBus,
+
+    pub def_idx: usize,
 }
 
 impl<F> BaseAir<F> for DeferralOutputCommitAir {
@@ -64,83 +66,107 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralOutputCommitAir {
         let local: &DeferralOutputCommitCols<AB::Var> = (*local).borrow();
         let next: &DeferralOutputCommitCols<AB::Var> = (*next).borrow();
 
+        let is_transition = next.is_valid - next.is_first;
+        let is_last = local.is_valid - is_transition.clone();
+
         /*
          * Base constraints to ensure that all the valid rows are at the beginning,
-         * and that there is at least one valid and one invalid row. The latter is
-         * important because we send the output commit on the first invalid row.
+         * and that there is at least one valid row. Additionally, row_idx starts at
+         * 0 and increments.
          */
         builder.assert_bool(local.is_valid);
         builder.when_first_row().assert_one(local.is_valid);
         builder
             .when_transition()
             .assert_bool(local.is_valid - next.is_valid);
-        builder.when_last_row().assert_zero(local.is_valid);
 
         builder.when_first_row().assert_one(local.is_first);
         builder.when_transition().assert_zero(next.is_first);
 
-        /*
-         * On valid rows we want to receive the next VALS_IN_DIGEST output values
-         * and constrain that next_bytes is their byte decomposition. To this end
-         * we also constrain that next_f_idx increments.
-         */
-        for (byte_decomp, next_f) in izip!(local.next_bytes.chunks(F_NUM_BYTES), local.next_f) {
-            let composed_f = fold(
-                byte_decomp.iter().enumerate(),
-                AB::Expr::ZERO,
-                |acc, (i, byte)| acc + (AB::Expr::from_usize(1 << (i * 8)) * (*byte).into()),
-            );
-            builder.when(local.is_valid).assert_eq(composed_f, next_f);
-        }
-
-        builder.when_first_row().assert_zero(local.next_f_idx);
+        builder.when_first_row().assert_zero(local.row_idx);
         builder
             .when_transition()
-            .assert_eq(local.next_f_idx + AB::Expr::ONE, next.next_f_idx);
+            .assert_eq(local.row_idx + AB::Expr::ONE, next.row_idx);
 
-        for byte in local.next_bytes {
+        /*
+         * On the first row, input_vals should be [def_idx, output_len, 0, ...].
+         * We constrain def_idx against a constant, and output_len against the
+         * last valid row_idx.
+         */
+        let mut initial_state = [AB::Expr::ZERO; DIGEST_SIZE];
+        initial_state[0] = AB::Expr::from_usize(self.def_idx);
+        initial_state[1] = local.output_len.into();
+
+        assert_array_eq(
+            &mut builder.when_first_row(),
+            local.input_vals,
+            initial_state,
+        );
+
+        builder
+            .when(is_transition)
+            .assert_eq(local.output_len, next.output_len);
+        builder.when(is_last.clone()).assert_eq(
+            local.output_len,
+            local.row_idx * AB::Expr::from_usize(DIGEST_SIZE),
+        );
+
+        /*
+         * On valid rows non-first we want to receive the next VALS_IN_DIGEST values
+         * and constrain that input_vals is their byte decomposition.
+         */
+        let next_f: [_; VALS_IN_DIGEST] = local
+            .input_vals
+            .chunks(F_NUM_BYTES)
+            .map(|c| {
+                fold(c.iter().enumerate(), AB::Expr::ZERO, |acc, (i, byte)| {
+                    acc + (AB::Expr::from_usize(1 << (i * 8)) * (*byte).into())
+                })
+            })
+            .collect_array()
+            .unwrap();
+
+        for byte in local.input_vals {
             self.range_bus.lookup_key(
                 builder,
                 RangeCheckerBusMessage {
                     value: byte.into(),
                     max_bits: AB::Expr::from_u8(8),
                 },
-                local.is_valid,
+                local.is_valid - local.is_first,
             );
         }
 
         self.output_val_bus.receive(
             builder,
             OutputValMessage {
-                values: local.next_f,
-                idx: local.next_f_idx,
+                values: next_f,
+                idx: local.row_idx - AB::Expr::ONE,
             },
-            local.is_valid,
+            local.is_valid - local.is_first,
         );
 
         /*
-         * Compute the output commit and send it on the first invalid row. The first
-         * row starts from zero state, and a compression is done on each row.
+         * Compute the output commit and send it on the last row. We sponge hash each
+         * valid input_vals and take the left child of the last row.
          */
-        assert_array_eq(
-            &mut builder.when_first_row(),
-            local.state,
-            [AB::Expr::ZERO; DIGEST_SIZE],
-        );
-
+        let next_not_first = not(next.is_first);
+        let next_capacity = from_fn(|i| next_not_first.clone() * local.res_right[i]);
         self.poseidon2_bus.lookup_key(
             builder,
-            Poseidon2CompressMessage {
-                input: digests_to_poseidon2_input(local.state, local.next_bytes),
-                output: next.state,
+            Poseidon2PermuteMessage {
+                input: digests_to_poseidon2_input(next.input_vals.map(Into::into), next_capacity),
+                output: digests_to_poseidon2_input(next.res_left, next.res_right).map(Into::into),
             },
-            local.is_valid,
+            next.is_valid,
         );
 
         self.output_commit_bus.send(
             builder,
-            OutputCommitMessage { commit: next.state },
-            local.is_valid * not(next.is_valid),
+            OutputCommitMessage {
+                commit: local.res_left,
+            },
+            is_last,
         );
     }
 }

--- a/guest-libs/verify-stark/circuit/src/output/air.rs
+++ b/guest-libs/verify-stark/circuit/src/output/air.rs
@@ -1,10 +1,7 @@
 use std::{array::from_fn, borrow::Borrow};
 
 use itertools::{fold, Itertools};
-use openvm_circuit_primitives::{
-    utils::{assert_array_eq, not},
-    AlignedBorrow,
-};
+use openvm_circuit_primitives::{utils::assert_array_eq, AlignedBorrow};
 use openvm_continuations::utils::digests_to_poseidon2_input;
 use openvm_recursion_circuit::{
     bus::{Poseidon2PermuteBus, Poseidon2PermuteMessage},
@@ -104,7 +101,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralOutputCommitAir {
         );
 
         builder
-            .when(is_transition)
+            .when(is_transition.clone())
             .assert_eq(local.output_len, next.output_len);
         builder.when(is_last.clone()).assert_eq(
             local.output_len,
@@ -150,8 +147,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralOutputCommitAir {
          * Compute the output commit and send it on the last row. We sponge hash each
          * valid input_vals and take the left child of the last row.
          */
-        let next_not_first = not(next.is_first);
-        let next_capacity = from_fn(|i| next_not_first.clone() * local.res_right[i]);
+        let next_capacity = from_fn(|i| is_transition.clone() * local.res_right[i]);
         self.poseidon2_bus.lookup_key(
             builder,
             Poseidon2PermuteMessage {

--- a/guest-libs/verify-stark/circuit/src/output/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/output/trace.rs
@@ -3,9 +3,10 @@ use std::{array::from_fn, borrow::BorrowMut};
 use openvm_circuit::arch::POSEIDON2_WIDTH;
 use openvm_continuations::utils::digests_to_poseidon2_input;
 use openvm_cpu_backend::CpuBackend;
+use openvm_poseidon2_air::Permutation;
 use openvm_stark_backend::prover::{AirProvingContext, ProverBackend};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
-    poseidon2_compress_with_capacity, BabyBearPoseidon2Config, DIGEST_SIZE, F,
+    poseidon2_perm, BabyBearPoseidon2Config, DIGEST_SIZE, F,
 };
 use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
@@ -23,56 +24,67 @@ pub fn generate_proving_ctx(
     app_exe_commit: [F; DIGEST_SIZE],
     app_vk_commit: [F; DIGEST_SIZE],
     user_pvs: Vec<F>,
+    def_idx: usize,
 ) -> DeferralOutputCtx<CpuBackend<BabyBearPoseidon2Config>> {
     debug_assert!(DIGEST_SIZE.is_multiple_of(F_NUM_BYTES));
     debug_assert!(DIGEST_SIZE.is_multiple_of(VALS_IN_DIGEST));
     debug_assert!(user_pvs.len().is_multiple_of(VALS_IN_DIGEST));
 
-    let mut next_f_rows = values_to_rows(&app_exe_commit);
-    next_f_rows.extend(values_to_rows(&app_vk_commit));
-    next_f_rows.extend(values_to_rows(&user_pvs));
-    debug_assert!(!next_f_rows.is_empty());
+    let mut input_val_rows = values_to_rows(&app_exe_commit);
+    input_val_rows.extend(values_to_rows(&app_vk_commit));
+    input_val_rows.extend(values_to_rows(&user_pvs));
 
-    // One trailing invalid row is required so OutputCommitBus can receive the final state
-    let min_height = next_f_rows.len() + 1;
-    let height = min_height.next_power_of_two();
+    let num_rows = input_val_rows.len() + 1;
+    let height = num_rows.next_power_of_two();
     let width = DeferralOutputCommitCols::<u8>::width();
     let mut trace = vec![F::ZERO; height * width];
     let mut chunks = trace.chunks_exact_mut(width);
 
-    let mut poseidon2_compress_inputs = Vec::with_capacity(next_f_rows.len().saturating_sub(1));
-    let mut range_inputs = Vec::with_capacity(next_f_rows.len() * DIGEST_SIZE);
-    let mut state = [F::ZERO; DIGEST_SIZE];
+    let mut poseidon2_permute_inputs = Vec::with_capacity(num_rows);
+    let mut range_inputs = Vec::with_capacity(input_val_rows.len() * DIGEST_SIZE);
+    let output_len = input_val_rows.len() * DIGEST_SIZE;
+    let mut input_capacity = [F::ZERO; DIGEST_SIZE];
+    let mut output_commit = [F::ZERO; DIGEST_SIZE];
+    let perm = poseidon2_perm();
 
-    for (row_idx, next_f) in next_f_rows.iter().copied().enumerate() {
+    for row_idx in 0..height {
         let row = chunks.next().unwrap();
         let cols: &mut DeferralOutputCommitCols<F> = row.borrow_mut();
-        cols.is_valid = F::ONE;
-        cols.is_first = F::from_bool(row_idx == 0);
-        cols.next_f = next_f;
-        cols.next_f_idx = F::from_usize(row_idx);
-        cols.next_bytes = next_f_to_digest(next_f);
-        range_inputs.extend_from_slice(&cols.next_bytes.map(|b| b.as_canonical_u32() as usize));
+        cols.row_idx = F::from_usize(row_idx);
+        if row_idx < num_rows {
+            cols.is_valid = F::ONE;
+            cols.is_first = F::from_bool(row_idx == 0);
+            cols.output_len = F::from_usize(output_len);
 
-        cols.state = state;
-        poseidon2_compress_inputs.push(digests_to_poseidon2_input(state, cols.next_bytes));
-        state = poseidon2_compress_with_capacity(state, cols.next_bytes).0;
-    }
+            cols.input_vals = if row_idx == 0 {
+                let mut input = [F::ZERO; DIGEST_SIZE];
+                input[0] = F::from_usize(def_idx);
+                input[1] = F::from_usize(output_len);
+                input
+            } else {
+                let next_f = input_val_rows[row_idx - 1];
+                let input_vals = next_f_to_digest(next_f);
+                range_inputs.extend(input_vals.map(|b| b.as_canonical_u32() as usize));
+                input_vals
+            };
 
-    for row_idx in next_f_rows.len()..height {
-        let row = chunks.next().unwrap();
-        let cols: &mut DeferralOutputCommitCols<F> = row.borrow_mut();
-        cols.next_f_idx = F::from_usize(row_idx);
-        if row_idx == next_f_rows.len() {
-            cols.state = state;
+            let perm_input = digests_to_poseidon2_input(cols.input_vals, input_capacity);
+            poseidon2_permute_inputs.push(perm_input);
+
+            let perm_output = perm.permute(perm_input);
+            cols.res_left = perm_output[..DIGEST_SIZE].try_into().unwrap();
+            cols.res_right = perm_output[DIGEST_SIZE..].try_into().unwrap();
+
+            input_capacity = cols.res_right;
+            output_commit = cols.res_left;
         }
     }
 
     DeferralOutputCtx {
         proving_ctx: AirProvingContext::simple_no_pis(RowMajorMatrix::new(trace, width)),
-        poseidon2_inputs: poseidon2_compress_inputs,
+        poseidon2_inputs: poseidon2_permute_inputs,
         range_inputs,
-        output_commit: state,
+        output_commit,
     }
 }
 

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -116,6 +116,7 @@ impl<
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
         def_hook_commit: Option<PB::Commitment>,
+        def_idx: usize,
     ) -> Self
     where
         E::PD: DeviceDataTransporter<SC, PB> + Clone,
@@ -142,6 +143,7 @@ impl<
             def_hook_commit,
             memory_dimensions,
             num_user_pvs,
+            def_idx,
         ));
         let (pk, vk) = engine.keygen(&circuit.airs());
         Self {
@@ -162,6 +164,7 @@ impl<
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
         def_hook_commit: Option<PB::Commitment>,
+        def_idx: usize,
     ) -> Self
     where
         PB::Val: Field + PrimeField32,
@@ -180,12 +183,15 @@ impl<
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
         };
+        // WARNING: def_idx must match the original def_idx used when generating the pk,
+        // or else the generated proof will be incorrect.
         let circuit = Arc::new(DeferredVerifyCircuit::new(
             Arc::new(verifier_circuit),
             internal_recursive_dag_commit,
             def_hook_commit,
             memory_dimensions,
             num_user_pvs,
+            def_idx,
         ));
         let vk = Arc::new(pk.get_vk());
         Self {
@@ -256,5 +262,9 @@ where
         self.prover
             .prove_no_def::<E>(non_root_proof.inner, &non_root_proof.user_pvs_proof)
             .expect("DeferredVerifyProver::prove_no_def failed")
+    }
+
+    fn get_def_idx(&self) -> usize {
+        self.prover.circuit.def_idx
     }
 }

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -156,6 +156,7 @@ impl<
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn from_pk(
         child_vk: Arc<MultiStarkVerifyingKey<SC>>,
         child_vk_pcs_data: CommittedTraceData<PB>,

--- a/guest-libs/verify-stark/circuit/src/prover/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/trace.rs
@@ -52,6 +52,7 @@ where
             &proof,
             user_pvs_proof,
             self.circuit.memory_dimensions,
+            self.circuit.def_idx,
             deferral_merkle_proofs,
         );
 

--- a/guest-libs/verify-stark/circuit/src/tests.rs
+++ b/guest-libs/verify-stark/circuit/src/tests.rs
@@ -13,11 +13,10 @@ use openvm_circuit::{
 };
 use openvm_continuations::{
     circuit::{deferral::DeferralCircuitPvs, utils::vk_commit_components},
-    prover::{ChildVkKind, InnerGpuProver as InnerProver},
+    prover::ChildVkKind,
     utils::poseidon2_input_to_digests,
     SC,
 };
-use openvm_cuda_backend::{BabyBearPoseidon2GpuEngine, GpuBackend};
 use openvm_recursion_circuit::utils::poseidon2_hash_slice;
 use openvm_rv32im_circuit::{Rv32IConfig, Rv32ImBuilder, Rv32ImConfig};
 use openvm_rv32im_transpiler::{
@@ -25,7 +24,7 @@ use openvm_rv32im_transpiler::{
 };
 use openvm_stark_backend::{
     keygen::types::MultiStarkVerifyingKey, proof::Proof, prover::CommittedTraceData,
-    verifier::verify, StarkEngine, SystemParams, TranscriptHistory,
+    verifier::verify, StarkEngine, TranscriptHistory,
 };
 use openvm_stark_sdk::{
     config::{
@@ -46,29 +45,25 @@ use p3_field::PrimeCharacteristicRing;
 use test_case::test_case;
 use tracing::Level;
 
-use crate::prover::DeferredVerifyGpuProver;
-
-type Engine = BabyBearPoseidon2GpuEngine;
-type PB = GpuBackend;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "cuda")] {
+        use openvm_continuations::prover::InnerGpuProver as InnerProver;
+        use openvm_cuda_backend::{BabyBearPoseidon2GpuEngine, GpuBackend};
+        use crate::prover::DeferredVerifyGpuProver as DeferredVerifyProver;
+        type Engine = BabyBearPoseidon2GpuEngine;
+        type PB = GpuBackend;
+    } else {
+        use openvm_continuations::prover::InnerCpuProver as InnerProver;
+        use openvm_cpu_backend::CpuBackend;
+        use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2CpuEngine, DuplexSponge};
+        use crate::prover::DeferredVerifyCpuProver as DeferredVerifyProver;
+        type Engine = BabyBearPoseidon2CpuEngine<DuplexSponge>;
+        type PB = CpuBackend<SC>;
+    }
+}
 
 const LOG_MAX_TRACE_HEIGHT: usize = 20;
 const DEFAULT_MAX_NUM_PROOFS: usize = 4;
-
-fn app_system_params() -> SystemParams {
-    app_params_with_100_bits_security(21)
-}
-
-fn leaf_system_params() -> SystemParams {
-    leaf_params_with_100_bits_security()
-}
-
-fn internal_system_params() -> SystemParams {
-    internal_params_with_100_bits_security()
-}
-
-fn root_system_params() -> SystemParams {
-    root_params_with_100_bits_security()
-}
 
 fn test_rv32im_config() -> Rv32ImConfig {
     Rv32ImConfig {
@@ -105,7 +100,7 @@ fn run_leaf_aggregation(
         .map(F::from_u8)
         .to_vec();
 
-    let engine = Engine::new(app_system_params());
+    let engine = Engine::new(app_params_with_100_bits_security(21));
     let (vm, app_pk) = VirtualMachine::new_with_keygen(engine, Rv32ImBuilder, config)?;
     let cached_program_trace = vm.commit_program_on_device(&exe.program);
     let mut instance = VmInstance::new(vm, exe.into(), cached_program_trace)?;
@@ -113,7 +108,7 @@ fn run_leaf_aggregation(
 
     let leaf_prover = InnerProver::<DEFAULT_MAX_NUM_PROOFS>::new::<Engine>(
         Arc::new(app_pk.get_vk()),
-        leaf_system_params(),
+        leaf_params_with_100_bits_security(),
         false,
         None,
     );
@@ -140,7 +135,7 @@ fn run_full_aggregation(
 
     let internal_for_leaf_prover = InnerProver::<DEFAULT_MAX_NUM_PROOFS>::new::<Engine>(
         leaf_vk,
-        internal_system_params(),
+        internal_params_with_100_bits_security(),
         false,
         None,
     );
@@ -149,7 +144,7 @@ fn run_full_aggregation(
 
     let internal_recursive_prover = InnerProver::<DEFAULT_MAX_NUM_PROOFS>::new::<Engine>(
         internal_for_leaf_prover.get_vk(),
-        internal_system_params(),
+        internal_params_with_100_bits_security(),
         true,
         None,
     );
@@ -181,13 +176,14 @@ fn test_deferral_verify_prover(child_extra_recursive_layers: usize) -> Result<()
     ) = run_full_aggregation(10, child_extra_recursive_layers)?;
 
     let system_config = test_rv32im_config().rv32i.system;
-    let deferred_verify_prover = DeferredVerifyGpuProver::new::<Engine>(
+    let deferred_verify_prover = DeferredVerifyProver::new::<Engine>(
         internal_recursive_vk.clone(),
         internal_recursive_pcs_data,
-        root_system_params(),
+        root_params_with_100_bits_security(),
         system_config.memory_config.memory_dimensions(),
         system_config.num_public_values,
         None,
+        0,
     );
     let def_proof = deferred_verify_prover
         .prove_no_def::<Engine>(internal_recursive_proof.clone(), &user_pvs_proof)?;
@@ -228,6 +224,7 @@ fn test_deferral_verify_prover(child_extra_recursive_layers: usize) -> Result<()
         app_exe_commit,
         app_vk_commit,
         user_pvs_proof.public_values,
+        0,
     )
     .output_commit;
 

--- a/guest-libs/verify-stark/circuit/src/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/trace.rs
@@ -48,6 +48,7 @@ pub trait DeferredVerifyTraceGen<PB: ProverBackend> {
         proof: &Proof<SC>,
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, PB::Val>,
         memory_dimensions: MemoryDimensions,
+        def_idx: usize,
         deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
     ) -> PreVerifierData<PB>;
 
@@ -74,6 +75,7 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>> for DeferredVerifyTraceGenImpl {
         proof: &Proof<SC>,
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, F>,
         memory_dimensions: MemoryDimensions,
+        def_idx: usize,
         deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
     ) -> PreVerifierData<CpuBackend<SC>> {
         let (verifier_pvs_record, verifier_p2_compress_inputs, verifier_p2_permute_inputs) =
@@ -95,6 +97,7 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>> for DeferredVerifyTraceGenImpl {
             verifier_pvs_record.app_exe_commit,
             verifier_pvs_record.app_vk_commit,
             user_pvs_proof.public_values.clone(),
+            def_idx,
         );
 
         let (paths_ctx, paths_p2_inputs) = if let Some(deferral_merkle_proofs) =
@@ -126,10 +129,12 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>> for DeferredVerifyTraceGenImpl {
                 .into_iter()
                 .chain(commit_p2_inputs)
                 .chain(memory_p2_inputs)
-                .chain(output_p2_inputs)
                 .chain(paths_p2_inputs)
                 .collect_vec(),
-            poseidon2_permute_inputs: verifier_p2_permute_inputs,
+            poseidon2_permute_inputs: verifier_p2_permute_inputs
+                .into_iter()
+                .chain(output_p2_inputs)
+                .collect_vec(),
             range_inputs,
             verifier_pvs_record,
             output_commit,
@@ -164,6 +169,7 @@ impl DeferredVerifyTraceGen<GpuBackend> for DeferredVerifyTraceGenImpl {
         proof: &Proof<SC>,
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, F>,
         memory_dimensions: MemoryDimensions,
+        def_idx: usize,
         deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
     ) -> PreVerifierData<GpuBackend> {
         let PreVerifierData {
@@ -179,6 +185,7 @@ impl DeferredVerifyTraceGen<GpuBackend> for DeferredVerifyTraceGenImpl {
             proof,
             user_pvs_proof,
             memory_dimensions,
+            def_idx,
             deferral_merkle_proofs,
         );
 


### PR DESCRIPTION
Resolves INT-6725, INT-6727, INT-6709, INT-6784, INT-6723, INT-6724

#### INT-6725: Output commit must be a true sponge hash
#### INT-6709: `output_len` is not bound in `DEFER_CALL`
#### INT-6784: Zero-length outputs bypass the output AIR

Output commit is now the `hash_slice` of `[def_idx, output_len, 0, ...]` and`output_raw`. The first row in `DeferralOutputAir` is for the `[def_idx, output_len, 0, ...]` (i.e. skips a write), and `DeferralOutputCommitAir` does the same.

#### INT-6727: `DeferralOutputCommitAir` doesn't handle initial `def_idx` state

Updated `DeferralOutputCommitAir` to constrain the `def_idx` and `output_len` present on the first row. The former is compared against a constant, while `output_len` is constrained to be consistent with the number of valid rows.

#### INT-6723: `DeferralOutputAir` cleanup and degree reduction

Replaced the redundant constraints with `is_transition`, which is used throughout the AIR now.

#### INT-6724: `DeferralOutputCommitAir` cleanup

Removed `next_f` and the final invalid row by calling permute on the `next` row.