### PR TITLE
fix: constrain F values in rv32 memory are canonically decomposed

### DIFF
--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -198,6 +198,7 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
         memory_dimensions,
         num_user_pvs,
         None,
+        0,
     );
     let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
 

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -1,5 +1,6 @@
 use std::{array::from_fn, borrow::Borrow};
 
+use itertools::{izip, Itertools as _};
 use openvm_circuit::{
     arch::{
         AdapterAirContext, ExecutionBridge, ExecutionState, ImmInstruction, VmAdapterAir,
@@ -10,6 +11,7 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
+use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
@@ -24,8 +26,10 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
+use p3_field::PrimeField32;
 
 use crate::{
+    canonicity::{CanonicityAuxCols, CanonicitySubAir},
     count::DeferralCircuitCountBus,
     poseidon2::DeferralPoseidon2Bus,
     utils::{
@@ -69,12 +73,17 @@ pub struct DeferralCallCoreCols<T> {
     pub deferral_idx: T,
     pub reads: DeferralCallReads<T, T>,
     pub writes: DeferralCallWrites<T, T>,
+
+    pub input_commit_lt_aux: [CanonicityAuxCols<T>; DIGEST_SIZE],
+    pub output_commit_lt_aux: [CanonicityAuxCols<T>; DIGEST_SIZE],
+    pub output_len_lt_aux: CanonicityAuxCols<T>,
 }
 
 #[derive(Copy, Clone, Debug, derive_new::new)]
 pub struct DeferralCallCoreAir {
     pub count_bus: DeferralCircuitCountBus,
     pub poseidon2_bus: DeferralPoseidon2Bus,
+    pub bitwise_bus: BitwiseOperationLookupBus,
 }
 
 impl<F: Field> BaseAir<F> for DeferralCallCoreAir {
@@ -87,6 +96,7 @@ impl<F: Field> BaseAirWithPublicValues<F> for DeferralCallCoreAir {}
 impl<AB, I> VmCoreAir<AB, I> for DeferralCallCoreAir
 where
     AB: InteractionBuilder,
+    AB::F: PrimeField32,
     I: VmAdapterInterface<AB::Expr>,
     I::Reads: From<DeferralCallReads<AB::Expr, AB::Expr>>,
     I::Writes: From<DeferralCallWrites<AB::Expr, AB::Expr>>,
@@ -101,6 +111,61 @@ where
         let cols: &DeferralCallCoreCols<_> = local_core.borrow();
         builder.assert_bool(cols.is_valid);
 
+        // Constrain the canonicity of both commits and output_len, i.e. that every
+        // F_NUM_BYTES bytes uniquely represents an element of F.
+        let input_commit_rcs = izip!(
+            cols.reads.input_commit.chunks_exact(F_NUM_BYTES),
+            cols.input_commit_lt_aux
+        )
+        .map(|(bytes, aux)| {
+            CanonicitySubAir.assert_canonicity(builder, bytes, &aux, cols.is_valid.into())
+        })
+        .collect_vec();
+
+        let output_commit_rcs = izip!(
+            cols.writes.output_commit.chunks_exact(F_NUM_BYTES),
+            cols.output_commit_lt_aux
+        )
+        .map(|(bytes, aux)| {
+            CanonicitySubAir.assert_canonicity(builder, bytes, &aux, cols.is_valid.into())
+        })
+        .collect_vec();
+
+        let output_len_rc = CanonicitySubAir.assert_canonicity(
+            builder,
+            &cols.writes.output_len,
+            &cols.output_len_lt_aux,
+            cols.is_valid.into(),
+        );
+
+        for rc_pair in input_commit_rcs.chunks_exact(2) {
+            self.bitwise_bus
+                .send_range(rc_pair[0].clone(), rc_pair[1].clone())
+                .eval(builder, cols.is_valid);
+        }
+        for rc_pair in output_commit_rcs.chunks_exact(2) {
+            self.bitwise_bus
+                .send_range(rc_pair[0].clone(), rc_pair[1].clone())
+                .eval(builder, cols.is_valid);
+        }
+        self.bitwise_bus
+            .send_range(output_len_rc, AB::Expr::ZERO)
+            .eval(builder, cols.is_valid);
+
+        // Range check the bytes that we write to RV32 heap memory.
+        for bytes in cols.writes.output_commit.chunks_exact(2) {
+            self.bitwise_bus
+                .send_range(bytes[0], bytes[1])
+                .eval(builder, cols.is_valid);
+        }
+
+        for bytes in cols.writes.output_len.chunks_exact(2) {
+            self.bitwise_bus
+                .send_range(bytes[0], bytes[1])
+                .eval(builder, cols.is_valid);
+        }
+
+        // Constrain the updated accumulators.
         let input_f_commit = byte_commit_to_f(&cols.reads.input_commit);
         let output_f_commit = byte_commit_to_f(&cols.writes.output_commit);
 

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -12,12 +12,14 @@ use openvm_circuit::{
         MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::AlignedBytesBorrow;
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::SharedBitwiseOperationLookupChip, AlignedBytesBorrow,
+};
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
     instruction::Instruction,
     program::DEFAULT_PC_STEP,
-    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
 };
 use openvm_rv32im_circuit::adapters::{
     tracing_read, tracing_read_deferral, tracing_write, tracing_write_deferral,
@@ -27,6 +29,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 
 use crate::{
     call::{DeferralCallAdapterCols, DeferralCallCoreCols, DeferralCallReads, DeferralCallWrites},
+    canonicity::CanonicityTraceGen,
     count::DeferralCircuitCountChip,
     poseidon2::{deferral_poseidon2_chip, DeferralPoseidon2Chip},
     utils::{
@@ -52,11 +55,12 @@ pub struct DeferralCallCoreExecutor<A> {
     pub(in crate::call) deferral_fns: Vec<Arc<DeferralFn>>,
 }
 
-#[derive(Clone, Debug, derive_new::new)]
+#[derive(Clone, derive_new::new)]
 pub struct DeferralCallCoreFiller<A, F: VmField> {
     adapter: A,
     count_chip: Arc<DeferralCircuitCountChip>,
     poseidon2_chip: Arc<DeferralPoseidon2Chip<F>>,
+    bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
 impl<F, A, RA> PreflightExecutor<F, RA> for DeferralCallCoreExecutor<A>
@@ -142,13 +146,15 @@ where
             unsafe { get_record_from_slice(&mut core_row, ()) };
         let cols: &mut DeferralCallCoreCols<F> = core_row.borrow_mut();
 
+        let input_commit_f = record.read_data.input_commit.map(F::from_u8);
+        let output_commit_f = record.write_data.output_commit.map(F::from_u8);
+        let output_len_f = record.write_data.output_len.map(F::from_u8);
+
         self.count_chip
             .add_count(record.deferral_idx.as_canonical_u32());
 
-        let input_f_commit: [F; _] =
-            byte_commit_to_f(&record.read_data.input_commit.map(F::from_u8));
-        let output_f_commit: [F; _] =
-            byte_commit_to_f(&record.write_data.output_commit.map(F::from_u8));
+        let input_f_commit: [F; _] = byte_commit_to_f(&input_commit_f);
+        let output_f_commit: [F; _] = byte_commit_to_f(&output_commit_f);
         self.poseidon2_chip
             .perm_and_record(&record.read_data.old_input_acc, &input_f_commit, true);
         self.poseidon2_chip.perm_and_record(
@@ -157,14 +163,51 @@ where
             true,
         );
 
+        for bytes in record.write_data.output_commit.chunks_exact(2) {
+            self.bitwise_lookup_chip
+                .request_range(bytes[0] as u32, bytes[1] as u32);
+        }
+        for bytes in record.write_data.output_len.chunks_exact(2) {
+            self.bitwise_lookup_chip
+                .request_range(bytes[0] as u32, bytes[1] as u32);
+        }
+
         // Write columns in reverse order to avoid clobbering the record.
+        let input_commit_rcs = input_commit_f
+            .chunks_exact(F_NUM_BYTES)
+            .zip(cols.input_commit_lt_aux.iter_mut())
+            .map(|(bytes, aux)| {
+                let x_le = from_fn(|i| bytes[i]);
+                CanonicityTraceGen::generate_subrow(&x_le, aux)
+            })
+            .collect_vec();
+        for rc_pair in input_commit_rcs.chunks_exact(2) {
+            self.bitwise_lookup_chip
+                .request_range(rc_pair[0], rc_pair[1]);
+        }
+
+        let output_commit_rcs = output_commit_f
+            .chunks_exact(F_NUM_BYTES)
+            .zip(cols.output_commit_lt_aux.iter_mut())
+            .map(|(bytes, aux)| {
+                let x_le = from_fn(|i| bytes[i]);
+                CanonicityTraceGen::generate_subrow(&x_le, aux)
+            })
+            .collect_vec();
+        for rc_pair in output_commit_rcs.chunks_exact(2) {
+            self.bitwise_lookup_chip
+                .request_range(rc_pair[0], rc_pair[1]);
+        }
+        let rc = CanonicityTraceGen::generate_subrow(&output_len_f, &mut cols.output_len_lt_aux);
+        self.bitwise_lookup_chip.request_range(rc, 0);
+
         cols.writes.new_output_acc = record.write_data.new_output_acc;
         cols.writes.new_input_acc = record.write_data.new_input_acc;
-        cols.writes.output_len = record.write_data.output_len.map(F::from_u8);
-        cols.writes.output_commit = record.write_data.output_commit.map(F::from_u8);
+        cols.writes.output_len = output_len_f;
+        cols.writes.output_commit = output_commit_f;
         cols.reads.old_output_acc = record.read_data.old_output_acc;
         cols.reads.old_input_acc = record.read_data.old_input_acc;
-        cols.reads.input_commit = record.read_data.input_commit.map(F::from_u8);
+        cols.reads.input_commit = input_commit_f;
         cols.deferral_idx = record.deferral_idx;
         cols.is_valid = F::ONE;
     }

--- a/extensions/deferral/circuit/src/canonicity/air.rs
+++ b/extensions/deferral/circuit/src/canonicity/air.rs
@@ -1,0 +1,88 @@
+use itertools::{izip, Itertools};
+use openvm_circuit_primitives::{utils::not, SubAir};
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::AirBuilder,
+    p3_field::{PrimeCharacteristicRing, PrimeField32},
+};
+
+use super::{CanonicityAuxCols, CanonicityIo};
+
+/// Sub-AIR to constrain that a field byte decomposition is canonical. Note:
+/// - It is assumed that each value has been range checked
+/// - eval returns a value to be range check
+pub struct CanonicitySubAir;
+
+impl<AB: InteractionBuilder> SubAir<AB> for CanonicitySubAir
+where
+    AB::F: PrimeField32,
+{
+    type AirContext<'a>
+        = (
+        CanonicityIo<AB::Expr>,
+        &'a CanonicityAuxCols<AB::Var>,
+        &'a mut AB::Expr,
+    )
+    where
+        AB::Expr: 'a,
+        AB::Var: 'a,
+        AB: 'a;
+
+    fn eval<'a>(
+        &'a self,
+        builder: &'a mut AB,
+        (io, aux, to_range_check): (
+            CanonicityIo<AB::Expr>,
+            &'a CanonicityAuxCols<AB::Var>,
+            &'a mut AB::Expr,
+        ),
+    ) where
+        AB::Var: 'a,
+        AB::Expr: 'a,
+    {
+        let order_be = AB::F::ORDER_U32
+            .to_le_bytes()
+            .into_iter()
+            .rev()
+            .map(AB::Expr::from_u8);
+
+        let mut prefix_sum = AB::Expr::ZERO;
+
+        for (x, y, &marker) in izip!(io.x, order_be, aux.diff_marker.iter()) {
+            let diff = y - x;
+            prefix_sum += marker.into();
+            builder.assert_bool(marker);
+            builder.when(marker).assert_one(io.count.clone());
+            builder
+                .when(io.count.clone())
+                .assert_zero(not::<AB::Expr>(prefix_sum.clone()) * diff.clone());
+            builder.when(marker).assert_eq(aux.diff_val, diff);
+        }
+
+        builder.assert_bool(prefix_sum.clone());
+        builder.when(io.count.clone()).assert_one(prefix_sum);
+
+        *to_range_check = AB::Expr::from(aux.diff_val) - AB::Expr::ONE;
+    }
+}
+
+impl CanonicitySubAir {
+    pub fn assert_canonicity<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        x: &[AB::Var],
+        aux: &CanonicityAuxCols<AB::Var>,
+        enabled: AB::Expr,
+    ) -> AB::Expr
+    where
+        AB::F: PrimeField32,
+    {
+        let io = CanonicityIo {
+            x: x.iter().rev().map(|b| (*b).into()).collect_array().unwrap(),
+            count: enabled,
+        };
+        let mut ret = AB::Expr::ZERO;
+        self.eval(builder, (io, aux, &mut ret));
+        ret
+    }
+}

--- a/extensions/deferral/circuit/src/canonicity/mod.rs
+++ b/extensions/deferral/circuit/src/canonicity/mod.rs
@@ -1,0 +1,26 @@
+use openvm_circuit_primitives_derive::AlignedBorrow;
+
+use crate::utils::F_NUM_BYTES;
+
+mod air;
+mod trace;
+
+pub use air::*;
+pub use trace::*;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CanonicityIo<T> {
+    pub x: [T; F_NUM_BYTES],
+    /// Assumed boolean by caller.
+    pub count: T,
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow, Clone, Copy, Debug)]
+pub struct CanonicityAuxCols<T> {
+    /// Marker for the first index where x[i] != order[i] (big-endian).
+    pub diff_marker: [T; F_NUM_BYTES],
+    /// order[i] - x[i] at the first differing index, constrained to [1, 255].
+    pub diff_val: T,
+}

--- a/extensions/deferral/circuit/src/canonicity/trace.rs
+++ b/extensions/deferral/circuit/src/canonicity/trace.rs
@@ -1,0 +1,44 @@
+use std::array::from_fn;
+
+use openvm_stark_backend::p3_field::{PrimeCharacteristicRing, PrimeField32};
+
+use super::CanonicityAuxCols;
+use crate::utils::F_NUM_BYTES;
+
+/// Tracegen helper for canonicity sub-AIR auxiliary columns
+pub struct CanonicityTraceGen;
+
+impl CanonicityTraceGen {
+    pub fn generate_subrow<F: PrimeField32>(
+        x_le: &[F; F_NUM_BYTES],
+        aux: &mut CanonicityAuxCols<F>,
+    ) -> u32 {
+        aux.diff_marker.fill(F::ZERO);
+        aux.diff_val = F::ZERO;
+        let x_be: [F; F_NUM_BYTES] = from_fn(|i| x_le[F_NUM_BYTES - 1 - i]);
+        let order_be = F::ORDER_U32.to_le_bytes().into_iter().rev();
+
+        let mut found = false;
+        let mut to_range_check = 0u32;
+
+        for (i, (&x, y)) in x_be.iter().zip(order_be).enumerate() {
+            let x_u32 = x.as_canonical_u32();
+            if !found && x_u32 != y as u32 {
+                debug_assert!(x_u32 < 256);
+                debug_assert!(y as u32 > x_u32);
+                let diff = y as u32 - x_u32;
+                aux.diff_marker[i] = F::ONE;
+                aux.diff_val = F::from_u32(diff);
+                to_range_check = diff - 1;
+                found = true;
+            }
+        }
+        debug_assert!(found);
+        to_range_check
+    }
+
+    pub fn clear_aux<F: PrimeCharacteristicRing>(aux: &mut CanonicityAuxCols<F>) {
+        aux.diff_marker.fill(F::ZERO);
+        aux.diff_val = F::ZERO;
+    }
+}

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -11,6 +11,10 @@ use openvm_circuit::{
     system::{memory::SharedMemoryHelper, SystemChipInventory, SystemCpuBuilder, SystemExecutor},
 };
 use openvm_circuit_derive::{AnyEnum, Executor, MeteredExecutor, PreflightExecutor, VmConfig};
+use openvm_circuit_primitives::bitwise_op_lookup::{
+    BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+    SharedBitwiseOperationLookupChip,
+};
 use openvm_cpu_backend::{CpuBackend, CpuDevice};
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::LocalOpcode;
@@ -103,6 +107,17 @@ where
 
         let count_bus = DeferralCircuitCountBus::new(inventory.new_bus_idx());
         let poseidon2_bus = DeferralPoseidon2Bus::new(inventory.new_bus_idx());
+        let bitwise_bus = {
+            let existing_air = inventory.find_air::<BitwiseOperationLookupAir<8>>().next();
+            if let Some(air) = existing_air {
+                air.bus
+            } else {
+                let bus = BitwiseOperationLookupBus::new(inventory.new_bus_idx());
+                let air = BitwiseOperationLookupAir::<8>::new(bus);
+                inventory.add_air(air);
+                air.bus
+            }
+        };
         let base_num_airs = inventory.num_airs();
 
         inventory.add_air(DeferralCircuitCountAir::new(count_bus, self.fns.len()));
@@ -113,7 +128,7 @@ where
         assert_eq!(inventory.num_airs() - base_num_airs, CALL_AIR_REL_IDX);
         inventory.add_air(DeferralCallAir::new(
             DeferralCallAdapterAir::new(execution_bridge, memory_bridge),
-            DeferralCallCoreAir::new(count_bus, poseidon2_bus),
+            DeferralCallCoreAir::new(count_bus, poseidon2_bus, bitwise_bus),
         ));
 
         assert_eq!(inventory.num_airs() - base_num_airs, OUTPUT_AIR_REL_IDX);
@@ -122,6 +137,7 @@ where
             memory_bridge,
             count_bus,
             poseidon2_bus,
+            bitwise_bus,
         ));
 
         Ok(())
@@ -145,8 +161,20 @@ where
     ) -> Result<(), ChipInventoryError> {
         let range_checker = inventory.range_checker()?.clone();
         let timestamp_max_bits = inventory.timestamp_max_bits();
-        let mem_helper = SharedMemoryHelper::new(range_checker, timestamp_max_bits);
-
+        let mem_helper = SharedMemoryHelper::new(range_checker.clone(), timestamp_max_bits);
+        let bitwise_lu = {
+            let existing_chip = inventory
+                .find_chip::<SharedBitwiseOperationLookupChip<8>>()
+                .next();
+            if let Some(chip) = existing_chip {
+                chip.clone()
+            } else {
+                let air: &BitwiseOperationLookupAir<8> = inventory.next_air()?;
+                let chip = Arc::new(BitwiseOperationLookupChip::new(air.bus));
+                inventory.add_periphery_chip(chip.clone());
+                chip
+            }
+        };
         let count_chip = Arc::new(DeferralCircuitCountChip::new(extension.fns.len()));
         let poseidon2_chip = Arc::new(deferral_poseidon2_chip());
 
@@ -162,13 +190,14 @@ where
                 DeferralCallAdapterFiller::new(),
                 count_chip.clone(),
                 poseidon2_chip.clone(),
+                bitwise_lu.clone(),
             ),
             mem_helper.clone(),
         ));
 
         inventory.next_air::<DeferralOutputAir>()?;
         inventory.add_executor_chip(DeferralOutputChip::new(
-            DeferralOutputFiller::new(count_chip.clone(), poseidon2_chip.clone()),
+            DeferralOutputFiller::new(count_chip.clone(), poseidon2_chip.clone(), bitwise_lu),
             mem_helper,
         ));
 

--- a/extensions/deferral/circuit/src/lib.rs
+++ b/extensions/deferral/circuit/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "tco", feature(core_intrinsics))]
 
 pub mod call;
+pub mod canonicity;
 pub mod count;
 pub mod output;
 pub mod poseidon2;

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -1,5 +1,6 @@
 use std::{array::from_fn, borrow::Borrow};
 
+use itertools::{izip, Itertools};
 use openvm_circuit::{
     arch::{ExecutionBridge, ExecutionState},
     system::memory::{
@@ -7,7 +8,10 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::utils::{assert_array_eq, not};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupBus,
+    utils::{assert_array_eq, not},
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
@@ -23,8 +27,10 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
+use p3_field::PrimeField32;
 
 use crate::{
+    canonicity::{CanonicityAuxCols, CanonicitySubAir},
     count::DeferralCircuitCountBus,
     poseidon2::DeferralPoseidon2Bus,
     utils::{
@@ -64,6 +70,11 @@ pub struct DeferralOutputCols<T> {
     pub output_len: [T; F_NUM_BYTES],
     pub output_commit_and_len_aux: [MemoryReadAuxCols<T>; OUTPUT_TOTAL_MEMORY_OPS],
 
+    // Auxiliary columns to ensure the canonicity of each F byte decomposition. Both
+    // output_commit and output_len are checked.
+    pub output_commit_lt_aux: [CanonicityAuxCols<T>; DIGEST_SIZE],
+    pub output_len_lt_aux: CanonicityAuxCols<T>,
+
     // Initial [def_idx, output_len, 0, ...] digest on the first row; on non-first
     // rows bytes raw_output[local_idx * DIGEST_SIZE..(local_idx + 1) * DIGEST_SIZE]
     // written to memory and auxiliary columns.
@@ -81,6 +92,7 @@ pub struct DeferralOutputAir {
     pub memory_bridge: MemoryBridge,
     pub count_bus: DeferralCircuitCountBus,
     pub poseidon2_bus: DeferralPoseidon2Bus,
+    pub bitwise_bus: BitwiseOperationLookupBus,
 }
 
 impl<F> BaseAir<F> for DeferralOutputAir {
@@ -94,6 +106,7 @@ impl<F> PartitionedBaseAir<F> for DeferralOutputAir {}
 impl<AB> Air<AB> for DeferralOutputAir
 where
     AB: InteractionBuilder,
+    AB::F: PrimeField32,
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
@@ -159,6 +172,33 @@ where
             local.output_len,
             next.output_len,
         );
+
+        // Constrain the canonicity of output_commit and output_len, i.e. that every
+        // F_NUM_BYTES bytes uniquely represents an element of F.
+        let output_commit_rcs = izip!(
+            local.output_commit.chunks_exact(F_NUM_BYTES),
+            local.output_commit_lt_aux
+        )
+        .map(|(bytes, aux)| {
+            CanonicitySubAir.assert_canonicity(builder, bytes, &aux, local.is_first.into())
+        })
+        .collect_vec();
+
+        let output_len_rc = CanonicitySubAir.assert_canonicity(
+            builder,
+            &local.output_len,
+            &local.output_len_lt_aux,
+            local.is_first.into(),
+        );
+
+        for rc_pair in output_commit_rcs.chunks_exact(2) {
+            self.bitwise_bus
+                .send_range(rc_pair[0].clone(), rc_pair[1].clone())
+                .eval(builder, local.is_first);
+        }
+        self.bitwise_bus
+            .send_range(output_len_rc, AB::Expr::ZERO)
+            .eval(builder, local.is_first);
 
         // Constrain the consistency of current_commit_state at each point in this
         // section's rows. The initial state should be [deferral_idx, output_len,
@@ -267,6 +307,12 @@ where
             .zip(&local.write_bytes_aux)
             .enumerate()
         {
+            for bytes in data.chunks(2) {
+                self.bitwise_bus
+                    .send_range(bytes[0], bytes[1])
+                    .eval(builder, local.is_valid - local.is_first);
+            }
+
             self.memory_bridge
                 .write(
                     MemoryAddress::new(

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -5,6 +5,7 @@ use std::{
     sync::Arc,
 };
 
+use itertools::Itertools;
 use openvm_circuit::{
     arch::{
         get_record_from_slice, CustomBorrow, ExecutionError, MultiRowLayout, MultiRowMetadata,
@@ -16,12 +17,14 @@ use openvm_circuit::{
         MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::AlignedBytesBorrow;
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::SharedBitwiseOperationLookupChip, AlignedBytesBorrow,
+};
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
     instruction::Instruction,
     program::DEFAULT_PC_STEP,
-    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
 };
 use openvm_rv32im_circuit::adapters::{
     memory_read, read_rv32_register, tracing_read, tracing_write,
@@ -30,12 +33,13 @@ use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMat
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 
 use crate::{
+    canonicity::CanonicityTraceGen,
     count::DeferralCircuitCountChip,
     output::DeferralOutputCols,
     poseidon2::DeferralPoseidon2Chip,
     utils::{
         f_commit_to_bytes, join_memory_ops, memory_op_chunk, split_output, DIGEST_MEMORY_OPS,
-        MEMORY_OP_SIZE, OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS,
+        F_NUM_BYTES, MEMORY_OP_SIZE, OUTPUT_TOTAL_BYTES, OUTPUT_TOTAL_MEMORY_OPS,
     },
 };
 
@@ -139,10 +143,11 @@ impl<'a> SizedRecord<DeferralOutputLayout> for DeferralOutputRecordMut<'a> {
 #[derive(Clone, Copy, Debug, derive_new::new)]
 pub struct DeferralOutputExecutor;
 
-#[derive(Clone, Debug, derive_new::new)]
+#[derive(Clone, derive_new::new)]
 pub struct DeferralOutputFiller<F: VmField> {
     count_chip: Arc<DeferralCircuitCountChip>,
     poseidon2_chip: Arc<DeferralPoseidon2Chip<F>>,
+    bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
 }
 
 impl<F, RA> PreflightExecutor<F, RA> for DeferralOutputExecutor
@@ -304,8 +309,8 @@ where
 
             let output_len_bytes = u32::try_from(output_len)
                 .expect("deferral output length should fit a u32")
-                .to_le_bytes()
-                .map(F::from_u8);
+                .to_le_bytes();
+            let output_len_f = output_len_bytes.map(F::from_u8);
 
             for (row_idx, row) in section_chunk.chunks_exact_mut(width).enumerate() {
                 let cols: &mut DeferralOutputCols<F> = row.borrow_mut();
@@ -323,6 +328,10 @@ where
 
                 cols.rd_val = header.rd_val.map(F::from_u8);
                 cols.rs_val = header.rs_val.map(F::from_u8);
+                for aux in &mut cols.output_commit_lt_aux {
+                    CanonicityTraceGen::clear_aux(aux);
+                }
+                CanonicityTraceGen::clear_aux(&mut cols.output_len_lt_aux);
 
                 if row_idx == 0 {
                     mem_helper.fill(
@@ -350,7 +359,7 @@ where
                     }
                 }
 
-                cols.output_len.copy_from_slice(&output_len_bytes);
+                cols.output_len = output_len_f;
                 if row_idx == 0 {
                     cols.sponge_inputs = initial_sponge_input;
                     current_poseidon2_res = self.poseidon2_chip.perm_and_record(
@@ -362,8 +371,13 @@ where
                         mem_helper.fill_zero(chunk_aux.as_mut());
                     }
                 } else {
-                    cols.sponge_inputs =
-                        from_fn(|i| F::from_u8(write_bytes[(row_idx - 1) * DIGEST_SIZE + i]));
+                    let output_chunk =
+                        &write_bytes[(row_idx - 1) * DIGEST_SIZE..row_idx * DIGEST_SIZE];
+                    for bytes in output_chunk.chunks_exact(2) {
+                        self.bitwise_lookup_chip
+                            .request_range(bytes[0] as u32, bytes[1] as u32);
+                    }
+                    cols.sponge_inputs = from_fn(|i| F::from_u8(output_chunk[i]));
                     current_poseidon2_res = self.poseidon2_chip.perm_and_record(
                         &cols.sponge_inputs,
                         &current_poseidon2_res,
@@ -390,6 +404,22 @@ where
             for row in section_chunk.chunks_exact_mut(width) {
                 let cols: &mut DeferralOutputCols<F> = row.borrow_mut();
                 cols.output_commit = output_commit;
+            }
+            let cols: &mut DeferralOutputCols<F> = section_chunk[..width].borrow_mut();
+            let rc =
+                CanonicityTraceGen::generate_subrow(&output_len_f, &mut cols.output_len_lt_aux);
+            self.bitwise_lookup_chip.request_range(rc, 0);
+            let output_commit_rcs = output_commit
+                .chunks_exact(F_NUM_BYTES)
+                .zip(cols.output_commit_lt_aux.iter_mut())
+                .map(|(bytes, aux)| {
+                    let x_le = from_fn(|i| bytes[i]);
+                    CanonicityTraceGen::generate_subrow(&x_le, aux)
+                })
+                .collect_vec();
+            for rc_pair in output_commit_rcs.chunks_exact(2) {
+                self.bitwise_lookup_chip
+                    .request_range(rc_pair[0], rc_pair[1]);
             }
 
             trace = rest;

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -328,10 +328,6 @@ where
 
                 cols.rd_val = header.rd_val.map(F::from_u8);
                 cols.rs_val = header.rs_val.map(F::from_u8);
-                for aux in &mut cols.output_commit_lt_aux {
-                    CanonicityTraceGen::clear_aux(aux);
-                }
-                CanonicityTraceGen::clear_aux(&mut cols.output_len_lt_aux);
 
                 if row_idx == 0 {
                     mem_helper.fill(

--- a/guest-libs/verify-stark/circuit/src/output/air.rs
+++ b/guest-libs/verify-stark/circuit/src/output/air.rs
@@ -36,7 +36,7 @@ pub struct DeferralOutputCommitCols<F> {
     pub res_left: [F; DIGEST_SIZE],
     pub res_right: [F; DIGEST_SIZE],
 
-    pub canonicity_aux: [CanonicityAuxCols<F>; F_NUM_BYTES],
+    pub canonicity_aux: [CanonicityAuxCols<F>; VALS_IN_DIGEST],
 }
 
 #[derive(Debug)]

--- a/guest-libs/verify-stark/circuit/src/output/air.rs
+++ b/guest-libs/verify-stark/circuit/src/output/air.rs
@@ -3,6 +3,7 @@ use std::{array::from_fn, borrow::Borrow};
 use itertools::{fold, Itertools};
 use openvm_circuit_primitives::{utils::assert_array_eq, AlignedBorrow};
 use openvm_continuations::utils::digests_to_poseidon2_input;
+use openvm_deferral_circuit::canonicity::{CanonicityAuxCols, CanonicitySubAir};
 use openvm_recursion_circuit::{
     bus::{Poseidon2PermuteBus, Poseidon2PermuteMessage},
     prelude::DIGEST_SIZE,
@@ -10,7 +11,7 @@ use openvm_recursion_circuit::{
 };
 use openvm_stark_backend::{interaction::InteractionBuilder, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::Matrix;
 
 use crate::bus::{OutputCommitBus, OutputCommitMessage, OutputValBus, OutputValMessage};
@@ -34,6 +35,8 @@ pub struct DeferralOutputCommitCols<F> {
     pub input_vals: [F; DIGEST_SIZE],
     pub res_left: [F; DIGEST_SIZE],
     pub res_right: [F; DIGEST_SIZE],
+
+    pub canonicity_aux: [CanonicityAuxCols<F>; F_NUM_BYTES],
 }
 
 #[derive(Debug)]
@@ -54,7 +57,10 @@ impl<F> BaseAir<F> for DeferralOutputCommitAir {
 impl<F> BaseAirWithPublicValues<F> for DeferralOutputCommitAir {}
 impl<F> PartitionedBaseAir<F> for DeferralOutputCommitAir {}
 
-impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralOutputCommitAir {
+impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralOutputCommitAir
+where
+    AB::F: PrimeField32,
+{
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
         let local = main.row_slice(0).expect("row 0 present");
@@ -142,6 +148,35 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralOutputCommitAir {
             },
             local.is_valid - local.is_first,
         );
+
+        /*
+         * For each output value we need to constraint the canonicity of the byte
+         * decomposition.
+         */
+        let rcs = local
+            .input_vals
+            .chunks(F_NUM_BYTES)
+            .zip(local.canonicity_aux)
+            .map(|(x, aux)| {
+                CanonicitySubAir.assert_canonicity(
+                    builder,
+                    x,
+                    &aux,
+                    local.is_valid - local.is_first,
+                )
+            })
+            .collect_vec();
+
+        for rc in rcs {
+            self.range_bus.lookup_key(
+                builder,
+                RangeCheckerBusMessage {
+                    value: rc,
+                    max_bits: AB::Expr::from_u8(8),
+                },
+                local.is_valid - local.is_first,
+            );
+        }
 
         /*
          * Compute the output commit and send it on the last row. We sponge hash each

--- a/guest-libs/verify-stark/circuit/src/output/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/output/trace.rs
@@ -57,9 +57,6 @@ pub fn generate_proving_ctx(
             cols.is_valid = F::ONE;
             cols.is_first = F::from_bool(row_idx == 0);
             cols.output_len = F::from_usize(output_len);
-            for aux in &mut cols.canonicity_aux {
-                CanonicityTraceGen::clear_aux(aux);
-            }
 
             cols.input_vals = if row_idx == 0 {
                 let mut input = [F::ZERO; DIGEST_SIZE];

--- a/guest-libs/verify-stark/circuit/src/output/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/output/trace.rs
@@ -3,6 +3,7 @@ use std::{array::from_fn, borrow::BorrowMut};
 use openvm_circuit::arch::POSEIDON2_WIDTH;
 use openvm_continuations::utils::digests_to_poseidon2_input;
 use openvm_cpu_backend::CpuBackend;
+use openvm_deferral_circuit::canonicity::CanonicityTraceGen;
 use openvm_poseidon2_air::Permutation;
 use openvm_stark_backend::prover::{AirProvingContext, ProverBackend};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
@@ -41,7 +42,8 @@ pub fn generate_proving_ctx(
     let mut chunks = trace.chunks_exact_mut(width);
 
     let mut poseidon2_permute_inputs = Vec::with_capacity(num_rows);
-    let mut range_inputs = Vec::with_capacity(input_val_rows.len() * DIGEST_SIZE);
+    let mut range_inputs =
+        Vec::with_capacity(input_val_rows.len() * (DIGEST_SIZE + VALS_IN_DIGEST));
     let output_len = input_val_rows.len() * DIGEST_SIZE;
     let mut input_capacity = [F::ZERO; DIGEST_SIZE];
     let mut output_commit = [F::ZERO; DIGEST_SIZE];
@@ -55,6 +57,9 @@ pub fn generate_proving_ctx(
             cols.is_valid = F::ONE;
             cols.is_first = F::from_bool(row_idx == 0);
             cols.output_len = F::from_usize(output_len);
+            for aux in &mut cols.canonicity_aux {
+                CanonicityTraceGen::clear_aux(aux);
+            }
 
             cols.input_vals = if row_idx == 0 {
                 let mut input = [F::ZERO; DIGEST_SIZE];
@@ -65,6 +70,14 @@ pub fn generate_proving_ctx(
                 let next_f = input_val_rows[row_idx - 1];
                 let input_vals = next_f_to_digest(next_f);
                 range_inputs.extend(input_vals.map(|b| b.as_canonical_u32() as usize));
+                for (bytes, aux) in input_vals
+                    .chunks_exact(F_NUM_BYTES)
+                    .zip(cols.canonicity_aux.iter_mut())
+                {
+                    let x_le = from_fn(|i| bytes[i]);
+                    let rc = CanonicityTraceGen::generate_subrow(&x_le, aux);
+                    range_inputs.push(rc as usize);
+                }
                 input_vals
             };
 


### PR DESCRIPTION
Resolves INT-6643 and INT-6708.

## Overview
This PR adds a reusable **field canonicity sub-AIR** and applies it to deferral + verify-stark output paths to ensure that 4-byte decompositions interpreted as field elements are **canonical** (strictly `< F::ORDER_U32`).

In scope (base: `fix/deferral-output-hash`):
- 1 new reusable sub-AIR module: `extensions/deferral/circuit/src/canonicity/*`
- Deferral CALL/OUTPUT AIR + tracegen updates to enforce canonicity and wire required range interactions
- Verify-stark output AIR + tracegen updates to reuse the same canonicity logic
- Deferral extension wiring to ensure a shared 8-bit bitwise/range lookup chip is available

## Suggested Review Order
1. `extensions/deferral/circuit/src/canonicity/{mod.rs,air.rs,trace.rs}`
2. Deferral integration:
   - `extensions/deferral/circuit/src/call/{air.rs,trace.rs}`
   - `extensions/deferral/circuit/src/output/{air.rs,trace.rs}`
   - `extensions/deferral/circuit/src/extension/mod.rs`
3. Verify-stark integration:
   - `guest-libs/verify-stark/circuit/src/output/{air.rs,trace.rs}`

---

## 1) New `CanonicitySubAir` (Reusable Primitive in Deferral Crate)

### What it constrains
`CanonicitySubAir` constrains that a 4-byte decomposition `x` (little-endian input) is a canonical encoding of a `PrimeField32` element:
- Converts `x_le` to `x_be`
- Compares lexicographically against `order_be = F::ORDER_U32.to_be_bytes()`
- Enforces exactly one first-difference marker when enabled
- Returns `to_range_check = diff_val - 1` (caller must range-check this)

### Why it is correct
When enabled:
- Before first marker: bytes must match field order prefix.
- At marker index `i`: `diff_val = order_be[i] - x_be[i]`.
- `diff_val - 1` range-checked to 8 bits implies `diff_val ∈ [1, 255]`, so `x_be[i] < order_be[i]`.
- Exactly one marker implies a strict lexicographic inequality at first difference.

Therefore `x < F::ORDER_U32`, i.e. canonical representation.

Assumption (explicit in code comments): each byte value is already range-checked as a byte.

### Columns added (new sub-AIR aux)
`CanonicityAuxCols<T>`:
- `diff_marker: [T; 4]` (one-hot first-difference marker)
- `diff_val: T` (byte difference at first differing index)

### Example aux row (enabled)
For BabyBear `ORDER_U32 = 0x78000001` and `x = 0x77000001`:

| `x_le` | `x_be` | `order_be` | `diff_marker` | `diff_val` | returned `to_range_check` |
|---|---|---|---|---|---|
| `[01,00,00,77]` | `[77,00,00,01]` | `[78,00,00,01]` | `[1,0,0,0]` | `1` | `0` |

---

## 2) Deferral Circuit Integration

## 2.1 Bus Wiring Change (shared bitwise/range lookup)
`extensions/deferral/circuit/src/extension/mod.rs` now ensures a shared `BitwiseOperationLookupAir<8>` / chip exists and passes its bus/chip into:
- `DeferralCallCoreAir` + `DeferralCallCoreFiller`
- `DeferralOutputAir` + `DeferralOutputFiller`

Text diagram:

```text
DeferralCallCoreAir  -- send_range(x,y) --> BitwiseOperationLookupAir<8>
DeferralOutputAir    -- send_range(x,y) --> BitwiseOperationLookupAir<8>

DeferralCallCoreFiller / DeferralOutputFiller
  -- request_range(x,y) --> BitwiseOperationLookupChip<8>
```

## 2.2 `DeferralCallCoreAir` / `call/trace.rs`

### AIR changes
Added core columns:
- `input_commit_lt_aux: [CanonicityAuxCols; DIGEST_SIZE]`
- `output_commit_lt_aux: [CanonicityAuxCols; DIGEST_SIZE]`
- `output_len_lt_aux: CanonicityAuxCols`

New constraints on valid rows:
- Canonicality checks for:
  - `reads.input_commit` (each 4-byte chunk)
  - `writes.output_commit` (each 4-byte chunk)
  - `writes.output_len` (single 4-byte value)
- Emits range interactions for each returned `to_range_check`.
- Also emits explicit byte range interactions for written `output_commit` and `output_len` bytes.

### Tracegen changes
- Fills new canonicity aux columns via `CanonicityTraceGen::generate_subrow`.
- Requests corresponding bitwise/range lookups for:
  - canonicality return values
  - output write bytes

### Example row shape
| row type | `is_valid` | `*_lt_aux` | byte range sends |
|---|---:|---|---|
| active CALL row | `1` | populated (one marker per 4-byte chunk) | yes (`output_commit`, `output_len`) |
| padding row | `0` | unconstrained/zeroed by trace filler conventions | no |

## 2.3 `DeferralOutputAir` / `output/trace.rs`

### AIR changes
Added columns:
- `output_commit_lt_aux: [CanonicityAuxCols; DIGEST_SIZE]`
- `output_len_lt_aux: CanonicityAuxCols`

New constraints:
- On `is_first` row of each OUTPUT section:
  - canonicality for `output_commit` and `output_len`
  - range sends for returned canonicality values
- On non-first valid rows (raw output writes):
  - range sends for each written byte pair in `sponge_inputs`

### Tracegen changes
- Clears canonicity aux on all section rows, populates first-row aux.
- Requests range lookups for:
  - first-row canonicality return values
  - non-first-row written output bytes

### Example section rows
| row kind | `is_first` | `is_valid` | canonicity aux usage | byte range sends |
|---|---:|---:|---|---|
| first row of section | `1` | `1` | populated + constrained | no write-byte sends |
| middle/last valid row | `0` | `1` | aux cleared / not checked | yes (written bytes) |
| padding row | `0` | `0` | zero | no |

---

## 3) Verify-Stark Output Integration

Files:
- `guest-libs/verify-stark/circuit/src/output/air.rs`
- `guest-libs/verify-stark/circuit/src/output/trace.rs`

### AIR changes
`DeferralOutputCommitCols` now includes:
- `canonicity_aux: [CanonicityAuxCols; F_NUM_BYTES]`

For non-first valid rows (`is_valid - is_first`):
- Existing byte range checks remain.
- New canonicality checks run per 4-byte chunk of `input_vals`.
- Returned `to_range_check` values are range-checked through existing `RangeCheckerBus`.

### Tracegen changes
- Generates/clears `canonicity_aux` per active row.
- Appends canonicality return values into `range_inputs` so AIR lookups balance.

### Bus interaction view

```text
OutputValBus --(values)--> DeferralOutputCommitAir
DeferralOutputCommitAir --(byte range + canonicity-return range)--> RangeCheckerBus
DeferralOutputCommitAir --(permute message)--> Poseidon2PermuteBus
DeferralOutputCommitAir --(final commit)--> OutputCommitBus
```

### Example row types
| row kind | `is_first` | `is_valid` | `canonicity_aux` | range inputs emitted |
|---|---:|---:|---|---|
| first row (header) | `1` | `1` | cleared | none for canonicity |
| non-first valid row | `0` | `1` | populated (per 4-byte chunk) | byte ranges + canonicity return ranges |
| padding row | `0` | `0` | zero | none |

---

## Net Effect
This PR closes a representation soundness gap by ensuring field values reconstructed from rv32 memory bytes are canonical where required:
- Deferral CALL: `input_commit`, `output_commit`, `output_len`
- Deferral OUTPUT: `output_commit`, `output_len`
- Verify-stark OUTPUT: each decoded output field element

Non-canonical byte encodings that previously could alias the same field element are now rejected by AIR constraints.
