### PR TITLE
fix: range check shifted top byte of deferral heap pointers + output_len

### DIFF
--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
     program::DEFAULT_PC_STEP,
-    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
     LocalOpcode, DEFERRAL_AS,
 };
 use openvm_stark_backend::{
@@ -76,7 +76,6 @@ pub struct DeferralCallCoreCols<T> {
 
     pub input_commit_lt_aux: [CanonicityAuxCols<T>; DIGEST_SIZE],
     pub output_commit_lt_aux: [CanonicityAuxCols<T>; DIGEST_SIZE],
-    pub output_len_lt_aux: CanonicityAuxCols<T>,
 }
 
 #[derive(Copy, Clone, Debug, derive_new::new)]
@@ -131,13 +130,6 @@ where
         })
         .collect_vec();
 
-        let output_len_rc = CanonicitySubAir.assert_canonicity(
-            builder,
-            &cols.writes.output_len,
-            &cols.output_len_lt_aux,
-            cols.is_valid.into(),
-        );
-
         for rc_pair in input_commit_rcs.chunks_exact(2) {
             self.bitwise_bus
                 .send_range(rc_pair[0].clone(), rc_pair[1].clone())
@@ -148,9 +140,6 @@ where
                 .send_range(rc_pair[0].clone(), rc_pair[1].clone())
                 .eval(builder, cols.is_valid);
         }
-        self.bitwise_bus
-            .send_range(output_len_rc, AB::Expr::ZERO)
-            .eval(builder, cols.is_valid);
 
         // Range check the bytes that we write to RV32 heap memory.
         for bytes in cols.writes.output_commit.chunks_exact(2) {
@@ -258,6 +247,8 @@ pub struct DeferralCallAdapterCols<T> {
 pub struct DeferralCallAdapterAir {
     pub execution_bridge: ExecutionBridge,
     pub memory_bridge: MemoryBridge,
+    pub bitwise_bus: BitwiseOperationLookupBus,
+    pub address_bits: usize,
 }
 
 impl<F: Field> BaseAir<F> for DeferralCallAdapterAir {
@@ -307,6 +298,19 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
             )
             .eval(builder, ctx.instruction.is_valid.clone());
 
+        // We range check the top byte of both heap pointers to ensure that each
+        // access is in [0, 2^address_bits). The memory merkle argument ensures
+        // that each read/write pointer is less than 2^addr_bits, and this range
+        // check ensures the accesses don't wrap around P.
+        let limb_shift =
+            AB::F::from_usize(1 << (RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits));
+        self.bitwise_bus
+            .send_range(
+                cols.rd_val[RV32_REGISTER_NUM_LIMBS - 1] * limb_shift,
+                cols.rs_val[RV32_REGISTER_NUM_LIMBS - 1] * limb_shift,
+            )
+            .eval(builder, ctx.instruction.is_valid.clone());
+
         // Accumulators are read then updated in the native address space, using
         // deferral_idx (instruction immediate / operand c) to determine the
         // accumulator memory address.
@@ -331,6 +335,14 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
             new_input_acc,
             new_output_acc,
         } = ctx.writes;
+
+        // Constrain output_len to be under 2^address_bits also.
+        self.bitwise_bus
+            .send_range(
+                output_len[RV32_REGISTER_NUM_LIMBS - 1].clone() * limb_shift,
+                AB::Expr::ZERO,
+            )
+            .eval(builder, ctx.instruction.is_valid.clone());
 
         let output_len_full = from_fn(|i| {
             if i < F_NUM_BYTES {

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -302,8 +302,10 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
         // access is in [0, 2^address_bits). The memory merkle argument ensures
         // that each read/write pointer is less than 2^addr_bits, and this range
         // check ensures the accesses don't wrap around P.
+        debug_assert!(RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS >= self.address_bits);
         let limb_shift =
             AB::F::from_usize(1 << (RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits));
+
         self.bitwise_bus
             .send_range(
                 cols.rd_val[RV32_REGISTER_NUM_LIMBS - 1] * limb_shift,

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -174,6 +174,7 @@ where
         }
 
         // NOTE: this range check is done in the adapter AIR
+        debug_assert!(RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS >= self.address_bits);
         let limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits;
         self.bitwise_lookup_chip.request_range(
             (record.write_data.output_len[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
@@ -403,7 +404,9 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for DeferralCallAdapterFiller {
 
         // Range checks must happen before we start writing adapter columns,
         // since the record and columns share the same backing buffer.
+        debug_assert!(RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS >= self.address_bits);
         let limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits;
+
         self.bitwise_lookup_chip.request_range(
             (record.rd_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
             (record.rs_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -61,6 +61,7 @@ pub struct DeferralCallCoreFiller<A, F: VmField> {
     count_chip: Arc<DeferralCircuitCountChip>,
     poseidon2_chip: Arc<DeferralPoseidon2Chip<F>>,
     bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+    address_bits: usize,
 }
 
 impl<F, A, RA> PreflightExecutor<F, RA> for DeferralCallCoreExecutor<A>
@@ -172,6 +173,13 @@ where
                 .request_range(bytes[0] as u32, bytes[1] as u32);
         }
 
+        // NOTE: this range check is done in the adapter AIR
+        let limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits;
+        self.bitwise_lookup_chip.request_range(
+            (record.write_data.output_len[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
+            0,
+        );
+
         // Write columns in reverse order to avoid clobbering the record.
         let input_commit_rcs = input_commit_f
             .chunks_exact(F_NUM_BYTES)
@@ -198,8 +206,6 @@ where
             self.bitwise_lookup_chip
                 .request_range(rc_pair[0], rc_pair[1]);
         }
-        let rc = CanonicityTraceGen::generate_subrow(&output_len_f, &mut cols.output_len_lt_aux);
-        self.bitwise_lookup_chip.request_range(rc, 0);
 
         cols.writes.new_output_acc = record.write_data.new_output_acc;
         cols.writes.new_input_acc = record.write_data.new_input_acc;
@@ -244,8 +250,11 @@ pub struct DeferralCallAdapterRecord<F> {
 #[derive(Clone, Copy)]
 pub struct DeferralCallAdapterExecutor;
 
-#[derive(derive_new::new)]
-pub struct DeferralCallAdapterFiller;
+#[derive(Clone, derive_new::new)]
+pub struct DeferralCallAdapterFiller {
+    bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+    address_bits: usize,
+}
 
 impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
     const WIDTH: usize = DeferralCallAdapterCols::<u8>::width();
@@ -391,6 +400,14 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for DeferralCallAdapterFiller {
         let record: &DeferralCallAdapterRecord<F> =
             unsafe { get_record_from_slice(&mut adapter_row, ()) };
         let adapter_row: &mut DeferralCallAdapterCols<F> = adapter_row.borrow_mut();
+
+        // Range checks must happen before we start writing adapter columns,
+        // since the record and columns share the same backing buffer.
+        let limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits;
+        self.bitwise_lookup_chip.request_range(
+            (record.rd_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
+            (record.rs_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
+        );
 
         // Timestamps in AIR are assigned in strict sequence starting from
         // `from_state.timestamp`; mirror that exact sequence in reverse here.

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -118,7 +118,9 @@ where
                 air.bus
             }
         };
+
         let base_num_airs = inventory.num_airs();
+        let address_bits = inventory.pointer_max_bits();
 
         inventory.add_air(DeferralCircuitCountAir::new(count_bus, self.fns.len()));
 
@@ -127,7 +129,7 @@ where
 
         assert_eq!(inventory.num_airs() - base_num_airs, CALL_AIR_REL_IDX);
         inventory.add_air(DeferralCallAir::new(
-            DeferralCallAdapterAir::new(execution_bridge, memory_bridge),
+            DeferralCallAdapterAir::new(execution_bridge, memory_bridge, bitwise_bus, address_bits),
             DeferralCallCoreAir::new(count_bus, poseidon2_bus, bitwise_bus),
         ));
 
@@ -138,6 +140,7 @@ where
             count_bus,
             poseidon2_bus,
             bitwise_bus,
+            address_bits,
         ));
 
         Ok(())
@@ -161,6 +164,7 @@ where
     ) -> Result<(), ChipInventoryError> {
         let range_checker = inventory.range_checker()?.clone();
         let timestamp_max_bits = inventory.timestamp_max_bits();
+        let address_bits = inventory.airs().pointer_max_bits();
         let mem_helper = SharedMemoryHelper::new(range_checker.clone(), timestamp_max_bits);
         let bitwise_lu = {
             let existing_chip = inventory
@@ -187,17 +191,23 @@ where
         inventory.next_air::<DeferralCallAir>()?;
         inventory.add_executor_chip(DeferralCallChip::new(
             DeferralCallCoreFiller::new(
-                DeferralCallAdapterFiller::new(),
+                DeferralCallAdapterFiller::new(bitwise_lu.clone(), address_bits),
                 count_chip.clone(),
                 poseidon2_chip.clone(),
                 bitwise_lu.clone(),
+                address_bits,
             ),
             mem_helper.clone(),
         ));
 
         inventory.next_air::<DeferralOutputAir>()?;
         inventory.add_executor_chip(DeferralOutputChip::new(
-            DeferralOutputFiller::new(count_chip.clone(), poseidon2_chip.clone(), bitwise_lu),
+            DeferralOutputFiller::new(
+                count_chip.clone(),
+                poseidon2_chip.clone(),
+                bitwise_lu,
+                address_bits,
+            ),
             mem_helper,
         ));
 

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -235,8 +235,10 @@ where
         // canonical. Note that constraining the starting output pointer is sufficient
         // to constrain the entire write is in range - even if output_ptr + output_len
         // wraps, there will be several written values in the middle that do not.
+        debug_assert!(RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS >= self.address_bits);
         let limb_shift =
             AB::F::from_usize(1 << (RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits));
+
         self.bitwise_bus
             .send_range(
                 local.rd_val[RV32_REGISTER_NUM_LIMBS - 1] * limb_shift,

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
     program::DEFAULT_PC_STEP,
-    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS},
     LocalOpcode,
 };
 use openvm_stark_backend::{
@@ -70,10 +70,9 @@ pub struct DeferralOutputCols<T> {
     pub output_len: [T; F_NUM_BYTES],
     pub output_commit_and_len_aux: [MemoryReadAuxCols<T>; OUTPUT_TOTAL_MEMORY_OPS],
 
-    // Auxiliary columns to ensure the canonicity of each F byte decomposition. Both
-    // output_commit and output_len are checked.
+    // Auxiliary columns to ensure the canonicity of each F byte decomposition in
+    // output_commit.
     pub output_commit_lt_aux: [CanonicityAuxCols<T>; DIGEST_SIZE],
-    pub output_len_lt_aux: CanonicityAuxCols<T>,
 
     // Initial [def_idx, output_len, 0, ...] digest on the first row; on non-first
     // rows bytes raw_output[local_idx * DIGEST_SIZE..(local_idx + 1) * DIGEST_SIZE]
@@ -93,6 +92,7 @@ pub struct DeferralOutputAir {
     pub count_bus: DeferralCircuitCountBus,
     pub poseidon2_bus: DeferralPoseidon2Bus,
     pub bitwise_bus: BitwiseOperationLookupBus,
+    pub address_bits: usize,
 }
 
 impl<F> BaseAir<F> for DeferralOutputAir {
@@ -184,21 +184,11 @@ where
         })
         .collect_vec();
 
-        let output_len_rc = CanonicitySubAir.assert_canonicity(
-            builder,
-            &local.output_len,
-            &local.output_len_lt_aux,
-            local.is_first.into(),
-        );
-
         for rc_pair in output_commit_rcs.chunks_exact(2) {
             self.bitwise_bus
                 .send_range(rc_pair[0].clone(), rc_pair[1].clone())
                 .eval(builder, local.is_first);
         }
-        self.bitwise_bus
-            .send_range(output_len_rc, AB::Expr::ZERO)
-            .eval(builder, local.is_first);
 
         // Constrain the consistency of current_commit_state at each point in this
         // section's rows. The initial state should be [deferral_idx, output_len,
@@ -238,6 +228,29 @@ where
         self.poseidon2_bus
             .lookup(next.sponge_inputs, rhs, next.poseidon2_res, next.is_last)
             .eval(builder, next.is_valid);
+
+        // We range check the top byte of both heap pointers to ensure that each access
+        // is in [0, 2^address_bits). The memory merkle argument ensures each pointer
+        // is less than 2^addr_bits, and this range check ensures the decomposition is
+        // canonical. Note that constraining the starting output pointer is sufficient
+        // to constrain the entire write is in range - even if output_ptr + output_len
+        // wraps, there will be several written values in the middle that do not.
+        let limb_shift =
+            AB::F::from_usize(1 << (RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits));
+        self.bitwise_bus
+            .send_range(
+                local.rd_val[RV32_REGISTER_NUM_LIMBS - 1] * limb_shift,
+                local.rs_val[RV32_REGISTER_NUM_LIMBS - 1] * limb_shift,
+            )
+            .eval(builder, local.is_first);
+
+        // We also constrain output_len to be under 2^address_bits.
+        self.bitwise_bus
+            .send_range(
+                local.output_len[RV32_REGISTER_NUM_LIMBS - 1] * limb_shift,
+                AB::Expr::ZERO,
+            )
+            .eval(builder, local.is_first);
 
         // Constrain the heap pointer memory reads.
         let d = AB::Expr::from_u32(RV32_REGISTER_AS);

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -331,8 +331,10 @@ where
                 cols.rs_val = header.rs_val.map(F::from_u8);
 
                 if row_idx == 0 {
+                    debug_assert!(RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS >= self.address_bits);
                     let limb_shift_bits =
                         RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits;
+
                     self.bitwise_lookup_chip.request_range(
                         (header.rd_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
                         (header.rs_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -148,6 +148,7 @@ pub struct DeferralOutputFiller<F: VmField> {
     count_chip: Arc<DeferralCircuitCountChip>,
     poseidon2_chip: Arc<DeferralPoseidon2Chip<F>>,
     bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+    address_bits: usize,
 }
 
 impl<F, RA> PreflightExecutor<F, RA> for DeferralOutputExecutor
@@ -330,6 +331,17 @@ where
                 cols.rs_val = header.rs_val.map(F::from_u8);
 
                 if row_idx == 0 {
+                    let limb_shift_bits =
+                        RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - self.address_bits;
+                    self.bitwise_lookup_chip.request_range(
+                        (header.rd_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
+                        (header.rs_val[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
+                    );
+                    self.bitwise_lookup_chip.request_range(
+                        (output_len_bytes[RV32_REGISTER_NUM_LIMBS - 1] as u32) << limb_shift_bits,
+                        0,
+                    );
+
                     mem_helper.fill(
                         header.rd_aux.prev_timestamp,
                         header.from_timestamp,
@@ -402,9 +414,6 @@ where
                 cols.output_commit = output_commit;
             }
             let cols: &mut DeferralOutputCols<F> = section_chunk[..width].borrow_mut();
-            let rc =
-                CanonicityTraceGen::generate_subrow(&output_len_f, &mut cols.output_len_lt_aux);
-            self.bitwise_lookup_chip.request_range(rc, 0);
             let output_commit_rcs = output_commit
                 .chunks_exact(F_NUM_BYTES)
                 .zip(cols.output_commit_lt_aux.iter_mut())


### PR DESCRIPTION
Resolves INT-6785. Also replaces `output_len` canonicity check with a stricter range check