### PR TITLE
refactor(static-verifier): migrate to v1 BabyBearChip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,7 +4217,9 @@ name = "openvm-static-verifier"
 version = "2.0.0-alpha"
 dependencies = [
  "halo2-base",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
+ "num-integer",
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "rand_chacha 0.3.1",

--- a/crates/static-verifier/Cargo.toml
+++ b/crates/static-verifier/Cargo.toml
@@ -8,10 +8,12 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-halo2-base = { workspace = true, features = ["halo2-axiom"] }
 openvm-stark-sdk = { workspace = true, features = ["baby-bear-bn254-poseidon2"] }
-num-bigint = { workspace = true }
 zkhash = { workspace = true }
+halo2-base = { workspace = true, features = ["halo2-axiom"] }
+itertools.workspace = true
+num-bigint = { workspace = true }
+num-integer.workspace = true
 
 [dev-dependencies]
 openvm-stark-backend = { workspace = true, features = ["test-utils"] }

--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -1,221 +1,440 @@
+use std::sync::Arc;
+
 use halo2_base::{
-    gates::{range::RangeChip, GateChip, GateInstructions, RangeInstructions},
-    utils::ScalarField,
-    AssignedValue, Context,
-    QuantumCell::Constant,
+    gates::{GateChip, GateInstructions, RangeChip, RangeInstructions},
+    halo2_proofs::{
+        arithmetic::Field as _,
+        halo2curves::{bn256::Fr, ff::PrimeField as _},
+    },
+    utils::{bigint_to_fe, biguint_to_fe, bit_length, fe_to_bigint, BigPrimeField},
+    AssignedValue, Context, QuantumCell,
 };
-use openvm_stark_sdk::openvm_stark_backend::p3_field::{PrimeCharacteristicRing, PrimeField64};
-
-use crate::{
-    utils::{bits_for_u64, usize_to_u64},
-    ChildF, Fr,
+use itertools::Itertools;
+use num_bigint::{BigInt, BigUint};
+use num_integer::Integer;
+use openvm_stark_sdk::{
+    openvm_stark_backend::p3_field::{Field, PrimeCharacteristicRing, PrimeField32, PrimeField64},
+    p3_baby_bear::BabyBear,
 };
 
-pub const BABY_BEAR_MODULUS_U64: u64 = 0x7800_0001;
-pub const BABY_BEAR_BITS: usize = 31;
-pub const BABY_BEAR_EXT_DEGREE: usize = 4;
-pub const BABY_BEAR_EXT_W_U64: u64 = 11;
+pub(crate) const BABYBEAR_MAX_BITS: usize = 31;
+// bits reserved so that if we do lazy range checking, we still have a valid result
+// the first reserved bit is so that we can represent negative numbers
+// the second is to accommodate lazy range checking
+const RESERVED_HIGH_BITS: usize = 2;
 
 #[derive(Copy, Clone, Debug)]
-pub struct BabyBearWire(pub AssignedValue<Fr>);
+pub struct BabyBearWire {
+    /// Logically `value` is a signed integer represented as `Bn254`.
+    /// Invariants:
+    /// - `|value|` never overflows `Bn254`
+    /// - `|value| < 2^max_bits` and `max_bits <= Fr::CAPACITY - RESERVED_HIGH_BITS`
+    ///
+    /// Basically `value` could do arithmetic operations without extra constraints as long as the
+    /// result doesn't overflow `Bn254`. And it's easy to track `max_bits` of the result.
+    pub value: AssignedValue<Fr>,
+    /// The value is guaranteed to be less than 2^max_bits.
+    pub max_bits: usize,
+}
 
 impl BabyBearWire {
-    pub fn as_u64(&self) -> u64 {
-        self.0.value().get_lower_64()
-    }
-
-    pub fn value(&self) -> ChildF {
-        ChildF::from_u64(self.0.value().get_lower_64())
+    pub fn to_baby_bear(&self) -> BabyBear {
+        let mut b_int = fe_to_bigint(self.value.value()) % BabyBear::ORDER_U32;
+        if b_int < BigInt::from(0) {
+            b_int += BabyBear::ORDER_U32;
+        }
+        BabyBear::from_u32(b_int.try_into().unwrap())
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct BabyBearChip<'a> {
-    range: &'a RangeChip<Fr>,
+pub struct BabyBearChip {
+    pub range: Arc<RangeChip<Fr>>,
 }
 
-impl<'a> BabyBearChip<'a> {
-    pub fn new(range: &'a RangeChip<Fr>) -> Self {
-        Self { range }
-    }
-
-    pub fn range(&self) -> &RangeChip<Fr> {
-        self.range
+impl BabyBearChip {
+    pub fn new(range_chip: Arc<RangeChip<Fr>>) -> Self {
+        BabyBearChip { range: range_chip }
     }
 
     pub fn gate(&self) -> &GateChip<Fr> {
         self.range.gate()
     }
 
-    fn modulus_fe() -> Fr {
-        Fr::from(BABY_BEAR_MODULUS_U64)
+    pub fn range(&self) -> &RangeChip<Fr> {
+        &self.range
     }
 
-    fn assert_canonical(value: u64) {
-        assert!(
-            value < BABY_BEAR_MODULUS_U64,
-            "BabyBear witness out of range: {value}"
-        );
+    pub fn load_witness(&self, ctx: &mut Context<Fr>, value: BabyBear) -> BabyBearWire {
+        let value = ctx.load_witness(Fr::from(PrimeField64::as_canonical_u64(&value)));
+        self.range.range_check(ctx, value, BABYBEAR_MAX_BITS);
+        BabyBearWire {
+            value,
+            max_bits: BABYBEAR_MAX_BITS,
+        }
     }
 
-    pub fn load_witness(&self, ctx: &mut Context<Fr>, value: ChildF) -> BabyBearWire {
-        let value_u64 = value.as_canonical_u64();
-        Self::assert_canonical(value_u64);
-        let cell = ctx.load_witness(Fr::from(value_u64));
-        self.range
-            .check_less_than_safe(ctx, cell, BABY_BEAR_MODULUS_U64);
-        BabyBearWire(cell)
+    pub fn load_constant(&self, ctx: &mut Context<Fr>, value: BabyBear) -> BabyBearWire {
+        let max_bits = bit_length(value.as_canonical_u64());
+        let value = ctx.load_constant(Fr::from(PrimeField64::as_canonical_u64(&value)));
+        BabyBearWire { value, max_bits }
     }
 
-    pub fn load_constant(&self, ctx: &mut Context<Fr>, value: ChildF) -> BabyBearWire {
-        let value_u64 = value.as_canonical_u64();
-        Self::assert_canonical(value_u64);
-        let cell = ctx.load_constant(Fr::from(value_u64));
-        BabyBearWire(cell)
-    }
-
-    pub fn zero(&self, ctx: &mut Context<Fr>) -> BabyBearWire {
-        self.load_constant(ctx, ChildF::ZERO)
-    }
-
-    pub fn one(&self, ctx: &mut Context<Fr>) -> BabyBearWire {
-        self.load_constant(ctx, ChildF::ONE)
-    }
-
-    pub fn add(&self, ctx: &mut Context<Fr>, a: &BabyBearWire, b: &BabyBearWire) -> BabyBearWire {
-        let sum = a.as_u64() + b.as_u64();
-        let q_u64 = sum / BABY_BEAR_MODULUS_U64;
-        let out_u64 = sum % BABY_BEAR_MODULUS_U64;
-
-        debug_assert!(q_u64 <= 1);
-        let out = self.load_witness(ctx, ChildF::from_u64(out_u64));
-        let q = ctx.load_witness(Fr::from(q_u64));
-        self.range.gate().assert_bit(ctx, q);
-
-        let gate = self.gate();
-        let lhs = gate.add(ctx, a.0, b.0);
-        let rhs = gate.mul_add(ctx, q, Constant(Self::modulus_fe()), out.0);
-        ctx.constrain_equal(&lhs, &rhs);
-
-        out
-    }
-
-    pub fn sub(&self, ctx: &mut Context<Fr>, a: &BabyBearWire, b: &BabyBearWire) -> BabyBearWire {
-        let (q_u64, out_u64) = if a.as_u64() >= b.as_u64() {
-            (0, a.as_u64() - b.as_u64())
-        } else {
-            (1, a.as_u64() + BABY_BEAR_MODULUS_U64 - b.as_u64())
+    pub fn reduce(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {
+        debug_assert!(fe_to_bigint(a.value.value()).bits() as usize <= a.max_bits);
+        let (_, r) = signed_div_mod(&self.range, ctx, a.value, a.max_bits);
+        let r = BabyBearWire {
+            value: r,
+            max_bits: BABYBEAR_MAX_BITS,
         };
-
-        let out = self.load_witness(ctx, ChildF::from_u64(out_u64));
-        let q = ctx.load_witness(Fr::from(q_u64));
-        self.range.gate().assert_bit(ctx, q);
-
-        let gate = self.gate();
-        let lhs = gate.mul_add(ctx, q, Constant(Self::modulus_fe()), a.0);
-        let rhs = gate.add(ctx, b.0, out.0);
-        ctx.constrain_equal(&lhs, &rhs);
-
-        out
+        debug_assert_eq!(a.to_baby_bear(), r.to_baby_bear());
+        r
     }
 
-    pub fn mul(&self, ctx: &mut Context<Fr>, a: &BabyBearWire, b: &BabyBearWire) -> BabyBearWire {
-        let prod = (a.as_u64() as u128) * (b.as_u64() as u128);
-        let modulus = BABY_BEAR_MODULUS_U64 as u128;
-        let q_u64 = (prod / modulus) as u64;
-        let out_u64 = (prod % modulus) as u64;
+    /// Reduce max_bits if possible. This function doesn't guarantee that the actual value is within
+    /// BabyBear.
+    pub fn reduce_max_bits(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {
+        if a.max_bits > BABYBEAR_MAX_BITS {
+            self.reduce(ctx, a)
+        } else {
+            a
+        }
+    }
 
-        let out = self.load_witness(ctx, ChildF::from_u64(out_u64));
-        let q = ctx.load_witness(Fr::from(q_u64));
+    pub fn add(
+        &self,
+        ctx: &mut Context<Fr>,
+        mut a: BabyBearWire,
+        mut b: BabyBearWire,
+    ) -> BabyBearWire {
+        if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            a = self.reduce(ctx, a);
+            if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+                b = self.reduce(ctx, b);
+            }
+        }
+        let value = self.gate().add(ctx, a.value, b.value);
+        let max_bits = a.max_bits.max(b.max_bits) + 1;
+        let mut c = BabyBearWire { value, max_bits };
+        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() + b.to_baby_bear());
+        if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            c = self.reduce(ctx, c);
+        }
+        c
+    }
+
+    pub fn neg(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {
+        let value = self.gate().neg(ctx, a.value);
+        let b = BabyBearWire {
+            value,
+            max_bits: a.max_bits,
+        };
+        debug_assert_eq!(b.to_baby_bear(), -a.to_baby_bear());
+        b
+    }
+
+    pub fn sub(
+        &self,
+        ctx: &mut Context<Fr>,
+        mut a: BabyBearWire,
+        mut b: BabyBearWire,
+    ) -> BabyBearWire {
+        if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            a = self.reduce(ctx, a);
+            if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+                b = self.reduce(ctx, b);
+            }
+        }
+        let value = self.gate().sub(ctx, a.value, b.value);
+        let max_bits = a.max_bits.max(b.max_bits) + 1;
+        let mut c = BabyBearWire { value, max_bits };
+        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() - b.to_baby_bear());
+        if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            c = self.reduce(ctx, c);
+        }
+        c
+    }
+
+    pub fn mul(
+        &self,
+        ctx: &mut Context<Fr>,
+        mut a: BabyBearWire,
+        mut b: BabyBearWire,
+    ) -> BabyBearWire {
+        if a.max_bits < b.max_bits {
+            std::mem::swap(&mut a, &mut b);
+        }
+        if a.max_bits + b.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            a = self.reduce(ctx, a);
+            if a.max_bits + b.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+                b = self.reduce(ctx, b);
+            }
+        }
+        let value = self.gate().mul(ctx, a.value, b.value);
+        let max_bits = a.max_bits + b.max_bits;
+
+        let mut c = BabyBearWire { value, max_bits };
+        if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            c = self.reduce(ctx, c);
+        }
+        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() * b.to_baby_bear());
+        c
+    }
+
+    pub fn mul_add(
+        &self,
+        ctx: &mut Context<Fr>,
+        mut a: BabyBearWire,
+        mut b: BabyBearWire,
+        mut c: BabyBearWire,
+    ) -> BabyBearWire {
+        if a.max_bits < b.max_bits {
+            std::mem::swap(&mut a, &mut b);
+        }
+        if a.max_bits + b.max_bits + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            a = self.reduce(ctx, a);
+            if a.max_bits + b.max_bits + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+                b = self.reduce(ctx, b);
+            }
+        }
+        if c.max_bits + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            c = self.reduce(ctx, c)
+        }
+        let value = self.gate().mul_add(ctx, a.value, b.value, c.value);
+        let max_bits = c.max_bits.max(a.max_bits + b.max_bits) + 1;
+
+        let mut d = BabyBearWire { value, max_bits };
+        if d.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            d = self.reduce(ctx, d);
+        }
+        debug_assert_eq!(
+            d.to_baby_bear(),
+            a.to_baby_bear() * b.to_baby_bear() + c.to_baby_bear()
+        );
+        d
+    }
+
+    pub fn div(
+        &self,
+        ctx: &mut Context<Fr>,
+        mut a: BabyBearWire,
+        mut b: BabyBearWire,
+    ) -> BabyBearWire {
+        let b_val = b.to_baby_bear();
+        let b_inv = b_val.try_inverse().unwrap();
+
+        let mut c = self.load_witness(ctx, a.to_baby_bear() * b_inv);
+        // constraint a = b * c (mod p)
+        if a.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            a = self.reduce(ctx, a);
+        }
+        if b.max_bits + c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            b = self.reduce(ctx, b);
+        }
+        if b.max_bits + c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            c = self.reduce(ctx, c);
+        }
+        let diff = self.gate().sub_mul(ctx, a.value, b.value, c.value);
+        let max_bits = a.max_bits.max(b.max_bits + c.max_bits) + 1;
+        self.assert_zero(
+            ctx,
+            BabyBearWire {
+                value: diff,
+                max_bits,
+            },
+        );
+        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() / b.to_baby_bear());
+        c
+    }
+
+    // This inner product function will be used exclusively for optimizing extension element
+    // multiplication.
+    pub(super) fn special_inner_product(
+        &self,
+        ctx: &mut Context<Fr>,
+        a: &mut [BabyBearWire],
+        b: &mut [BabyBearWire],
+        s: usize,
+    ) -> BabyBearWire {
+        assert!(a.len() == b.len());
+        assert!(a.len() == 4);
+        let mut max_bits = 0;
+        let lb = s.saturating_sub(3);
+        let ub = 4.min(s + 1);
+        let range = lb..ub;
+        let other_range = (s + 1 - ub)..(s + 1 - lb);
+        let len = if s < 3 { s + 1 } else { 7 - s };
+        for (i, (c, d)) in a[range.clone()]
+            .iter_mut()
+            .zip(b[other_range.clone()].iter_mut().rev())
+            .enumerate()
+        {
+            if c.max_bits + d.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS - len + i {
+                if c.max_bits >= d.max_bits {
+                    *c = self.reduce(ctx, *c);
+                    if c.max_bits + d.max_bits
+                        > Fr::CAPACITY as usize - RESERVED_HIGH_BITS - len + i
+                    {
+                        *d = self.reduce(ctx, *d);
+                    }
+                } else {
+                    *d = self.reduce(ctx, *d);
+                    if c.max_bits + d.max_bits
+                        > Fr::CAPACITY as usize - RESERVED_HIGH_BITS - len + i
+                    {
+                        *c = self.reduce(ctx, *c);
+                    }
+                }
+            }
+            if i == 0 {
+                max_bits = c.max_bits + d.max_bits;
+            } else {
+                max_bits = max_bits.max(c.max_bits + d.max_bits) + 1
+            }
+        }
+        let a_raw = a[range]
+            .iter()
+            .map(|a| QuantumCell::Existing(a.value))
+            .collect_vec();
+        let b_raw = b[other_range]
+            .iter()
+            .rev()
+            .map(|b| QuantumCell::Existing(b.value))
+            .collect_vec();
+        let prod = self.gate().inner_product(ctx, a_raw, b_raw);
+        BabyBearWire {
+            value: prod,
+            max_bits,
+        }
+    }
+
+    pub fn select(
+        &self,
+        ctx: &mut Context<Fr>,
+        cond: AssignedValue<Fr>,
+        a: BabyBearWire,
+        b: BabyBearWire,
+    ) -> BabyBearWire {
+        let value = self.gate().select(ctx, a.value, b.value, cond);
+        let max_bits = a.max_bits.max(b.max_bits);
+        BabyBearWire { value, max_bits }
+    }
+
+    pub fn assert_zero(&self, ctx: &mut Context<Fr>, a: BabyBearWire) {
+        // The proof of correctness of this function is listed in `signed_div_mod`.
+        debug_assert_eq!(a.to_baby_bear(), BabyBear::ZERO);
+        assert!(a.max_bits <= Fr::CAPACITY as usize - RESERVED_HIGH_BITS);
+        let a_num_bits = a.max_bits;
+        let b: BigUint = BabyBear::ORDER_U32.into();
+        let a_val = fe_to_bigint(a.value.value());
+        assert!(a_val.bits() <= a_num_bits as u64);
+        let (div, _) = a_val.div_mod_floor(&b.clone().into());
+        let div = bigint_to_fe(&div);
+        ctx.assign_region(
+            [
+                QuantumCell::Constant(Fr::ZERO),
+                QuantumCell::Constant(biguint_to_fe(&b)),
+                QuantumCell::Witness(div),
+                a.value.into(),
+            ],
+            [0],
+        );
+        let div = ctx.get(-2);
+        // Constrain that `abs(div) <= 2 ** (2 ** a_num_bits / b).bits()`.
+        let bound = (BigUint::from(1u32) << (a_num_bits as u32)) / &b;
+        let shifted_div =
+            self.range
+                .gate()
+                .add(ctx, div, QuantumCell::Constant(biguint_to_fe(&bound)));
+        debug_assert!(*shifted_div.value() < biguint_to_fe(&(&bound * 2u32 + 1u32)));
         self.range
-            .check_less_than_safe(ctx, q, BABY_BEAR_MODULUS_U64);
-
-        let gate = self.gate();
-        let lhs = gate.mul(ctx, a.0, b.0);
-        let rhs = gate.mul_add(ctx, q, Constant(Self::modulus_fe()), out.0);
-        ctx.constrain_equal(&lhs, &rhs);
-
-        out
+            .range_check(ctx, shifted_div, (bound * 2u32 + 1u32).bits() as usize);
     }
 
-    pub fn mul_const(
-        &self,
-        ctx: &mut Context<Fr>,
-        a: &BabyBearWire,
-        constant: ChildF,
-    ) -> BabyBearWire {
-        let constant_u64 = constant.as_canonical_u64() % BABY_BEAR_MODULUS_U64;
-        let prod = (a.as_u64() as u128) * (constant_u64 as u128);
-        let modulus = BABY_BEAR_MODULUS_U64 as u128;
-        let q_u64 = (prod / modulus) as u64;
-        let out_u64 = (prod % modulus) as u64;
-
-        let out = self.load_witness(ctx, ChildF::from_u64(out_u64));
-        let q = ctx.load_witness(Fr::from(q_u64));
-        self.range
-            .check_less_than_safe(ctx, q, BABY_BEAR_MODULUS_U64);
-
-        let gate = self.gate();
-        let lhs = gate.mul(ctx, a.0, Constant(Fr::from(constant_u64)));
-        let rhs = gate.mul_add(ctx, q, Constant(Self::modulus_fe()), out.0);
-        ctx.constrain_equal(&lhs, &rhs);
-
-        out
+    pub fn assert_equal(&self, ctx: &mut Context<Fr>, a: BabyBearWire, b: BabyBearWire) {
+        debug_assert_eq!(a.to_baby_bear(), b.to_baby_bear());
+        let diff = self.sub(ctx, a, b);
+        self.assert_zero(ctx, diff);
     }
+}
 
-    pub fn neg(&self, ctx: &mut Context<Fr>, a: &BabyBearWire) -> BabyBearWire {
-        let zero = self.zero(ctx);
-        self.sub(ctx, &zero, a)
-    }
-
-    pub fn square(&self, ctx: &mut Context<Fr>, a: &BabyBearWire) -> BabyBearWire {
-        self.mul(ctx, a, a)
-    }
-
-    pub fn assert_equal(&self, ctx: &mut Context<Fr>, lhs: &BabyBearWire, rhs: &BabyBearWire) {
-        ctx.constrain_equal(&lhs.0, &rhs.0);
-    }
-
-    pub(super) fn add2(
-        &self,
-        ctx: &mut Context<Fr>,
-        a: BabyBearWire,
-        b: BabyBearWire,
-    ) -> BabyBearWire {
-        self.add(ctx, &a, &b)
-    }
-
-    pub(super) fn add3(
-        &self,
-        ctx: &mut Context<Fr>,
-        a: BabyBearWire,
-        b: BabyBearWire,
-        c: BabyBearWire,
-    ) -> BabyBearWire {
-        let ab = self.add2(ctx, a, b);
-        self.add2(ctx, ab, c)
-    }
-
-    pub(super) fn add4(
-        &self,
-        ctx: &mut Context<Fr>,
-        a: BabyBearWire,
-        b: BabyBearWire,
-        c: BabyBearWire,
-        d: BabyBearWire,
-    ) -> BabyBearWire {
-        let ab = self.add2(ctx, a, b);
-        let cd = self.add2(ctx, c, d);
-        self.add2(ctx, ab, cd)
-    }
-
-    pub fn assign_and_range_u64(&self, ctx: &mut Context<Fr>, value: u64) -> AssignedValue<Fr> {
-        let cell = ctx.load_witness(Fr::from(value));
-        self.range.range_check(ctx, cell, bits_for_u64(value));
-        cell
-    }
-
-    pub fn assign_and_range_usize(&self, ctx: &mut Context<Fr>, value: usize) -> AssignedValue<Fr> {
-        self.assign_and_range_u64(ctx, usize_to_u64(value))
-    }
+/// Constrains and returns `(c, r)` such that `a = BabyBear::ORDER_U32 * c + r`.
+///
+/// * a: [QuantumCell] value to divide
+/// * a_num_bits: number of bits needed to represent the absolute value of `a`
+///
+/// ## Assumptions
+/// * `a_max_bits < F::CAPACITY = F::NUM_BITS - RESERVED_HIGH_BITS`
+///   * Unsafe behavior if `a_max_bits >= F::CAPACITY`
+fn signed_div_mod<F>(
+    range: &RangeChip<F>,
+    ctx: &mut Context<F>,
+    a: impl Into<QuantumCell<F>>,
+    a_num_bits: usize,
+) -> (AssignedValue<F>, AssignedValue<F>)
+where
+    F: BigPrimeField,
+{
+    // Proof of correctness:
+    // Let `b` be the order of `BabyBear` and `p` be the order of `Fr`.
+    // First we introduce witness `div` and `rem`.
+    // We constraint:
+    // (1) `div * b + rem ≡ a (mod p)`
+    // (2) `0 <= rem < b`
+    // Logically we want `div = a // b`. Because (2) and `a` could be negative, `div` could
+    // be negative. Therefore, we have `|div| = |a // b| = |a| // b < 2^max_bits // b = bound` and
+    // we can say `shifted_div = div + bound` is in `[0, 2 * bound)`.
+    // In practice, it's expensive to assert `shifted_div` is less than `2 * bound` which is not a
+    // power of 2s. Instead, we add a looser constraint:
+    // (3) `shifted_div < 2^max_bits/2^(BABYBEAR_ORDER_BITS-1)=2^(max_bits-BABYBEAR_ORDER_BITS+1)`
+    //
+    // Let's check if |div * b + rem| can overflow:
+    // - `div` has at most `max_bits-BABYBEAR_ORDER_BITS` bits
+    // - `b` has `BABYBEAR_ORDER_BITS` bits.
+    // - `rem` has at most `BABYBEAR_ORDER_BITS` bits.
+    // When `max_bits > BABYBEAR_ORDER_BITS`, `|div * b + rem|` has at most `max_bits+1` bits.
+    // Because of the invariant `max_bits <= Fr::CAPACITY - RESERVED_HIGH_BITS`, `|div * b + rem|`
+    // cannot overflow.
+    //
+    // Let's check if the looser constraint will cause some problem:
+    // Assume there are other `div'` and `rem'` satisfying:
+    // `div * b + rem ≡ div' * b + rem' (mod p)`
+    // Then we have:
+    // `(div - div') * b ≡ rem' - rem (mod p)`
+    // (3) => `|(div - div') * b| < 2^(max_bits+1) < p`
+    // (2) => `|rem' - rem| < b`
+    // There could be 3 cases:
+    // a. `-b < (div - div') * b < b` or;
+    // b. `0 < (div - div') * b + p < b` or;
+    // c. `-b < (div - div') * b - p < 0`
+    // Case (a) is impossible because `div != div'`.
+    // Case (b) and (c) imply:
+    // |div - div'|  > (p-b) // b > 2^(Fr::CAPACITY - (BABYBEAR_ORDER_BITS - 1) - 1) = 2^(Fr::CAPACITY - BABYBEAR_ORDER_BITS)
+    // (3) also constrains that this is impossible.
+    let a = a.into();
+    let b = BigUint::from(BabyBear::ORDER_U32);
+    let a_val = fe_to_bigint(a.value());
+    assert!(a_val.bits() <= a_num_bits as u64);
+    let (div, rem) = a_val.div_mod_floor(&b.clone().into());
+    let [div, rem] = [div, rem].map(|v| bigint_to_fe(&v));
+    ctx.assign_region(
+        [
+            QuantumCell::Witness(rem),
+            QuantumCell::Constant(biguint_to_fe(&b)),
+            QuantumCell::Witness(div),
+            a,
+        ],
+        [0],
+    );
+    let rem = ctx.get(-4);
+    let div = ctx.get(-2);
+    // Constrain that `abs(div) <= 2 ** (2 ** a_num_bits / b).bits()`.
+    let bound = (BigUint::from(1u32) << (a_num_bits as u32)) / &b;
+    let shifted_div = range
+        .gate()
+        .add(ctx, div, QuantumCell::Constant(biguint_to_fe(&bound)));
+    debug_assert!(*shifted_div.value() < biguint_to_fe(&(&bound * 2u32 + 1u32)));
+    range.range_check(ctx, shifted_div, (bound * 2u32 + 1u32).bits() as usize);
+    debug_assert!(*rem.value() < biguint_to_fe(&b));
+    range.check_big_less_than_safe(ctx, rem, b);
+    (div, rem)
 }

--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -9,6 +9,7 @@ use halo2_base::{
     utils::{bigint_to_fe, biguint_to_fe, bit_length, fe_to_bigint, BigPrimeField},
     AssignedValue, Context, QuantumCell,
 };
+use crate::utils::{guarded_debug_assert, guarded_debug_assert_eq};
 use itertools::Itertools;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
@@ -45,6 +46,10 @@ impl BabyBearWire {
         }
         BabyBear::from_u32(b_int.try_into().unwrap())
     }
+
+    pub fn as_u64(&self) -> u64 {
+        PrimeField64::as_canonical_u64(&self.to_baby_bear())
+    }
 }
 
 pub struct BabyBearChip {
@@ -80,13 +85,13 @@ impl BabyBearChip {
     }
 
     pub fn reduce(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {
-        debug_assert!(fe_to_bigint(a.value.value()).bits() as usize <= a.max_bits);
+        guarded_debug_assert!(fe_to_bigint(a.value.value()).bits() as usize <= a.max_bits);
         let (_, r) = signed_div_mod(&self.range, ctx, a.value, a.max_bits);
         let r = BabyBearWire {
             value: r,
             max_bits: BABYBEAR_MAX_BITS,
         };
-        debug_assert_eq!(a.to_baby_bear(), r.to_baby_bear());
+        guarded_debug_assert_eq!(a.to_baby_bear(), r.to_baby_bear());
         r
     }
 
@@ -115,7 +120,7 @@ impl BabyBearChip {
         let value = self.gate().add(ctx, a.value, b.value);
         let max_bits = a.max_bits.max(b.max_bits) + 1;
         let mut c = BabyBearWire { value, max_bits };
-        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() + b.to_baby_bear());
+        guarded_debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() + b.to_baby_bear());
         if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             c = self.reduce(ctx, c);
         }
@@ -128,7 +133,7 @@ impl BabyBearChip {
             value,
             max_bits: a.max_bits,
         };
-        debug_assert_eq!(b.to_baby_bear(), -a.to_baby_bear());
+        guarded_debug_assert_eq!(b.to_baby_bear(), -a.to_baby_bear());
         b
     }
 
@@ -147,7 +152,7 @@ impl BabyBearChip {
         let value = self.gate().sub(ctx, a.value, b.value);
         let max_bits = a.max_bits.max(b.max_bits) + 1;
         let mut c = BabyBearWire { value, max_bits };
-        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() - b.to_baby_bear());
+        guarded_debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() - b.to_baby_bear());
         if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             c = self.reduce(ctx, c);
         }
@@ -176,7 +181,7 @@ impl BabyBearChip {
         if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             c = self.reduce(ctx, c);
         }
-        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() * b.to_baby_bear());
+        guarded_debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() * b.to_baby_bear());
         c
     }
 
@@ -206,7 +211,7 @@ impl BabyBearChip {
         if d.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             d = self.reduce(ctx, d);
         }
-        debug_assert_eq!(
+        guarded_debug_assert_eq!(
             d.to_baby_bear(),
             a.to_baby_bear() * b.to_baby_bear() + c.to_baby_bear()
         );
@@ -242,7 +247,7 @@ impl BabyBearChip {
                 max_bits,
             },
         );
-        debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() / b.to_baby_bear());
+        guarded_debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() / b.to_baby_bear());
         c
     }
 
@@ -321,7 +326,7 @@ impl BabyBearChip {
 
     pub fn assert_zero(&self, ctx: &mut Context<Fr>, a: BabyBearWire) {
         // The proof of correctness of this function is listed in `signed_div_mod`.
-        debug_assert_eq!(a.to_baby_bear(), BabyBear::ZERO);
+        guarded_debug_assert_eq!(a.to_baby_bear(), BabyBear::ZERO);
         assert!(a.max_bits <= Fr::CAPACITY as usize - RESERVED_HIGH_BITS);
         let a_num_bits = a.max_bits;
         let b: BigUint = BabyBear::ORDER_U32.into();
@@ -345,15 +350,59 @@ impl BabyBearChip {
             self.range
                 .gate()
                 .add(ctx, div, QuantumCell::Constant(biguint_to_fe(&bound)));
-        debug_assert!(*shifted_div.value() < biguint_to_fe(&(&bound * 2u32 + 1u32)));
+        guarded_debug_assert!(*shifted_div.value() < biguint_to_fe(&(&bound * 2u32 + 1u32)));
         self.range
             .range_check(ctx, shifted_div, (bound * 2u32 + 1u32).bits() as usize);
     }
 
     pub fn assert_equal(&self, ctx: &mut Context<Fr>, a: BabyBearWire, b: BabyBearWire) {
-        debug_assert_eq!(a.to_baby_bear(), b.to_baby_bear());
+        guarded_debug_assert_eq!(a.to_baby_bear(), b.to_baby_bear());
         let diff = self.sub(ctx, a, b);
         self.assert_zero(ctx, diff);
+    }
+
+    pub fn zero(&self, ctx: &mut Context<Fr>) -> BabyBearWire {
+        self.load_constant(ctx, BabyBear::ZERO)
+    }
+
+    pub fn one(&self, ctx: &mut Context<Fr>) -> BabyBearWire {
+        self.load_constant(ctx, BabyBear::ONE)
+    }
+
+    pub fn mul_const(
+        &self,
+        ctx: &mut Context<Fr>,
+        a: BabyBearWire,
+        c: BabyBear,
+    ) -> BabyBearWire {
+        let c_wire = self.load_constant(ctx, c);
+        self.mul(ctx, a, c_wire)
+    }
+
+    pub fn square(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {
+        self.mul(ctx, a, a)
+    }
+
+    pub fn assign_and_range_usize(
+        &self,
+        ctx: &mut Context<Fr>,
+        value: usize,
+    ) -> AssignedValue<Fr> {
+        let cell = ctx.load_witness(Fr::from(value as u64));
+        let bits = bit_length(value as u64).max(1);
+        self.range.range_check(ctx, cell, bits);
+        cell
+    }
+
+    pub fn assign_and_range_u64(
+        &self,
+        ctx: &mut Context<Fr>,
+        value: u64,
+    ) -> AssignedValue<Fr> {
+        let cell = ctx.load_witness(Fr::from(value));
+        let bits = bit_length(value).max(1);
+        self.range.range_check(ctx, cell, bits);
+        cell
     }
 }
 
@@ -432,9 +481,9 @@ where
     let shifted_div = range
         .gate()
         .add(ctx, div, QuantumCell::Constant(biguint_to_fe(&bound)));
-    debug_assert!(*shifted_div.value() < biguint_to_fe(&(&bound * 2u32 + 1u32)));
+    guarded_debug_assert!(*shifted_div.value() < biguint_to_fe(&(&bound * 2u32 + 1u32)));
     range.range_check(ctx, shifted_div, (bound * 2u32 + 1u32).bits() as usize);
-    debug_assert!(*rem.value() < biguint_to_fe(&b));
+    guarded_debug_assert!(*rem.value() < biguint_to_fe(&b));
     range.check_big_less_than_safe(ctx, rem, b);
     (div, rem)
 }

--- a/crates/static-verifier/src/field/baby_bear/extension.rs
+++ b/crates/static-verifier/src/field/baby_bear/extension.rs
@@ -1,16 +1,47 @@
 use std::sync::Arc;
+#[cfg(test)]
+use std::{cell::RefCell, vec::Vec};
 
-use halo2_base::{halo2_proofs::halo2curves::bn256::Fr, AssignedValue, Context};
+use halo2_base::{
+    gates::range::RangeChip, halo2_proofs::halo2curves::bn256::Fr, AssignedValue, Context,
+};
 use itertools::Itertools;
 use openvm_stark_sdk::{
     openvm_stark_backend::p3_field::{
         extension::{BinomialExtensionField, BinomiallyExtendable},
-        BasedVectorSpace, Field,
+        BasedVectorSpace, Field, PrimeCharacteristicRing,
     },
     p3_baby_bear::BabyBear,
 };
 
-use crate::field::baby_bear::{BabyBearChip, BabyBearWire};
+use crate::{
+    field::baby_bear::{BabyBearChip, BabyBearWire},
+    utils::guarded_debug_assert_eq,
+};
+
+#[cfg(test)]
+use openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField64;
+
+#[cfg(test)]
+pub(crate) struct RecordedExtBaseConst {
+    pub constant: u64,
+    pub cell: AssignedValue<Fr>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static RECORDED_EXT_BASE_CONSTS: RefCell<Vec<RecordedExtBaseConst>> = const { RefCell::new(Vec::new()) };
+}
+
+#[cfg(test)]
+pub(crate) fn clear_recorded_ext_base_consts() {
+    RECORDED_EXT_BASE_CONSTS.with(|records| records.borrow_mut().clear());
+}
+
+#[cfg(test)]
+pub(crate) fn take_recorded_ext_base_consts() -> Vec<RecordedExtBaseConst> {
+    RECORDED_EXT_BASE_CONSTS.with(|records| records.borrow_mut().drain(..).collect())
+}
 
 // irred poly is x^4 - 11
 pub struct BabyBearExt4Chip {
@@ -158,7 +189,7 @@ impl BabyBearExt4Chip {
         }
         coeffs.truncate(4);
         let c = BabyBearExt4Wire(coeffs.try_into().unwrap());
-        debug_assert_eq!(
+        guarded_debug_assert_eq!(
             c.to_extension_field(),
             a.to_extension_field() * b.to_extension_field()
         );
@@ -179,7 +210,7 @@ impl BabyBearExt4Chip {
         let prod = self.mul(ctx, b, c);
         self.assert_equal(ctx, a, prod);
 
-        debug_assert_eq!(
+        guarded_debug_assert_eq!(
             c.to_extension_field(),
             a.to_extension_field() / b.to_extension_field()
         );
@@ -194,5 +225,62 @@ impl BabyBearExt4Chip {
                 .try_into()
                 .unwrap(),
         )
+    }
+
+    pub fn base(&self) -> &BabyBearChip {
+        &self.base
+    }
+
+    pub fn range(&self) -> &RangeChip<Fr> {
+        self.base.range()
+    }
+
+    pub fn zero(&self, ctx: &mut Context<Fr>) -> BabyBearExt4Wire {
+        self.from_base_const(ctx, BabyBear::ZERO)
+    }
+
+    pub fn from_base_const(&self, ctx: &mut Context<Fr>, value: BabyBear) -> BabyBearExt4Wire {
+        let base_val = self.base.load_constant(ctx, value);
+        #[cfg(test)]
+        RECORDED_EXT_BASE_CONSTS.with(|records| {
+            records.borrow_mut().push(RecordedExtBaseConst {
+                constant: value.as_canonical_u64(),
+                cell: base_val.value,
+            });
+        });
+        let z = self.base.load_constant(ctx, BabyBear::ZERO);
+        BabyBearExt4Wire([base_val, z, z, z])
+    }
+
+    pub fn from_base_var(&self, ctx: &mut Context<Fr>, value: BabyBearWire) -> BabyBearExt4Wire {
+        let z = self.base.load_constant(ctx, BabyBear::ZERO);
+        BabyBearExt4Wire([value, z, z, z])
+    }
+
+    pub fn mul_base_const(
+        &self,
+        ctx: &mut Context<Fr>,
+        a: BabyBearExt4Wire,
+        c: BabyBear,
+    ) -> BabyBearExt4Wire {
+        let c_wire = self.base.load_constant(ctx, c);
+        self.scalar_mul(ctx, a, c_wire)
+    }
+
+    pub fn square(&self, ctx: &mut Context<Fr>, a: BabyBearExt4Wire) -> BabyBearExt4Wire {
+        self.mul(ctx, a, a)
+    }
+
+    pub fn pow_power_of_two(
+        &self,
+        ctx: &mut Context<Fr>,
+        a: BabyBearExt4Wire,
+        n: usize,
+    ) -> BabyBearExt4Wire {
+        let mut result = a;
+        for _ in 0..n {
+            result = self.square(ctx, result);
+        }
+        result
     }
 }

--- a/crates/static-verifier/src/field/baby_bear/extension.rs
+++ b/crates/static-verifier/src/field/baby_bear/extension.rs
@@ -1,241 +1,198 @@
-#[cfg(test)]
-use std::cell::RefCell;
+use std::sync::Arc;
 
-#[cfg(test)]
-use halo2_base::AssignedValue;
-use halo2_base::{gates::range::RangeChip, Context};
-#[cfg(test)]
-use openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField64;
-use openvm_stark_sdk::openvm_stark_backend::p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
+use halo2_base::{halo2_proofs::halo2curves::bn256::Fr, AssignedValue, Context};
+use itertools::Itertools;
+use openvm_stark_sdk::{
+    openvm_stark_backend::p3_field::{
+        extension::{BinomialExtensionField, BinomiallyExtendable},
+        BasedVectorSpace, Field,
+    },
+    p3_baby_bear::BabyBear,
+};
 
-use super::base::{BabyBearChip, BabyBearWire, BABY_BEAR_EXT_DEGREE, BABY_BEAR_EXT_W_U64};
-use crate::{ChildEF, ChildF, Fr};
+use crate::field::baby_bear::{BabyBearChip, BabyBearWire};
+
+// irred poly is x^4 - 11
+pub struct BabyBearExt4Chip {
+    pub base: Arc<BabyBearChip>,
+}
 
 #[derive(Copy, Clone, Debug)]
-pub struct BabyBearExtWire(pub [BabyBearWire; BABY_BEAR_EXT_DEGREE]);
+pub struct BabyBearExt4Wire(pub [BabyBearWire; 4]);
+pub type BabyBearExt4 = BinomialExtensionField<BabyBear, 4>;
 
-impl BabyBearExtWire {
-    pub fn as_u64(&self) -> [u64; BABY_BEAR_EXT_DEGREE] {
-        core::array::from_fn(|i| self.0[i].as_u64())
-    }
-
-    pub fn value(&self) -> ChildEF {
-        ChildEF::from_basis_coefficients_fn(|i| self.0[i].value())
+impl BabyBearExt4Wire {
+    pub fn to_extension_field(&self) -> BabyBearExt4 {
+        let b_val = (0..4).map(|i| self.0[i].to_baby_bear()).collect_vec();
+        BabyBearExt4::from_basis_coefficients_slice(&b_val).unwrap()
     }
 }
 
-#[cfg(test)]
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct RecordedExtBaseConst {
-    pub constant: u64,
-    pub cell: AssignedValue<Fr>,
-}
-
-#[cfg(test)]
-thread_local! {
-    static RECORDED_EXT_BASE_CONSTS: RefCell<Vec<RecordedExtBaseConst>> = const { RefCell::new(Vec::new()) };
-}
-
-#[cfg(test)]
-pub(crate) fn clear_recorded_ext_base_consts() {
-    RECORDED_EXT_BASE_CONSTS.with(|records| records.borrow_mut().clear());
-}
-
-#[cfg(test)]
-pub(crate) fn take_recorded_ext_base_consts() -> Vec<RecordedExtBaseConst> {
-    RECORDED_EXT_BASE_CONSTS.with(|records| records.borrow_mut().drain(..).collect())
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct BabyBearExtChip<'a> {
-    base: BabyBearChip<'a>,
-}
-
-impl<'a> BabyBearExtChip<'a> {
-    pub fn new(base: BabyBearChip<'a>) -> Self {
-        Self { base }
+impl BabyBearExt4Chip {
+    pub fn new(base_chip: Arc<BabyBearChip>) -> Self {
+        BabyBearExt4Chip { base: base_chip }
     }
-
-    pub fn base(&self) -> &BabyBearChip<'a> {
-        &self.base
+    pub fn load_witness(&self, ctx: &mut Context<Fr>, value: BabyBearExt4) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            value
+                .as_basis_coefficients_slice()
+                .iter()
+                .map(|x| self.base.load_witness(ctx, *x))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
     }
-
-    pub fn range(&self) -> &RangeChip<Fr> {
-        self.base.range()
+    pub fn load_constant(&self, ctx: &mut Context<Fr>, value: BabyBearExt4) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            value
+                .as_basis_coefficients_slice()
+                .iter()
+                .map(|x| self.base.load_constant(ctx, *x))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
     }
-
-    pub fn load_witness(&self, ctx: &mut Context<Fr>, value: ChildEF) -> BabyBearExtWire {
-        let coeffs = <ChildEF as BasedVectorSpace<ChildF>>::as_basis_coefficients_slice(&value);
-        BabyBearExtWire(core::array::from_fn(|i| {
-            self.base.load_witness(ctx, coeffs[i])
-        }))
-    }
-
-    pub fn load_constant(&self, ctx: &mut Context<Fr>, value: ChildEF) -> BabyBearExtWire {
-        let coeffs = <ChildEF as BasedVectorSpace<ChildF>>::as_basis_coefficients_slice(&value);
-        BabyBearExtWire(core::array::from_fn(|i| {
-            self.base.load_constant(ctx, coeffs[i])
-        }))
-    }
-
-    pub fn zero(&self, ctx: &mut Context<Fr>) -> BabyBearExtWire {
-        self.load_constant(ctx, ChildEF::ZERO)
-    }
-
-    pub fn one(&self, ctx: &mut Context<Fr>) -> BabyBearExtWire {
-        self.load_constant(ctx, ChildEF::ONE)
-    }
-
     pub fn add(
         &self,
         ctx: &mut Context<Fr>,
-        a: &BabyBearExtWire,
-        b: &BabyBearExtWire,
-    ) -> BabyBearExtWire {
-        BabyBearExtWire(core::array::from_fn(|i| {
-            self.base.add(ctx, &a.0[i], &b.0[i])
-        }))
+        a: BabyBearExt4Wire,
+        b: BabyBearExt4Wire,
+    ) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            a.0.iter()
+                .zip(b.0.iter())
+                .map(|(a, b)| self.base.add(ctx, *a, *b))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    pub fn neg(&self, ctx: &mut Context<Fr>, a: BabyBearExt4Wire) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            a.0.iter()
+                .map(|x| self.base.neg(ctx, *x))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
     }
 
     pub fn sub(
         &self,
         ctx: &mut Context<Fr>,
-        a: &BabyBearExtWire,
-        b: &BabyBearExtWire,
-    ) -> BabyBearExtWire {
-        BabyBearExtWire(core::array::from_fn(|i| {
-            self.base.sub(ctx, &a.0[i], &b.0[i])
-        }))
+        a: BabyBearExt4Wire,
+        b: BabyBearExt4Wire,
+    ) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            a.0.iter()
+                .zip(b.0.iter())
+                .map(|(a, b)| self.base.sub(ctx, *a, *b))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    pub fn scalar_mul(
+        &self,
+        ctx: &mut Context<Fr>,
+        a: BabyBearExt4Wire,
+        b: BabyBearWire,
+    ) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            a.0.iter()
+                .map(|x| self.base.mul(ctx, *x, b))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    pub fn select(
+        &self,
+        ctx: &mut Context<Fr>,
+        cond: AssignedValue<Fr>,
+        a: BabyBearExt4Wire,
+        b: BabyBearExt4Wire,
+    ) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            a.0.iter()
+                .zip(b.0.iter())
+                .map(|(a, b)| self.base.select(ctx, cond, *a, *b))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    pub fn assert_zero(&self, ctx: &mut Context<Fr>, a: BabyBearExt4Wire) {
+        for x in a.0.iter() {
+            self.base.assert_zero(ctx, *x);
+        }
+    }
+
+    pub fn assert_equal(&self, ctx: &mut Context<Fr>, a: BabyBearExt4Wire, b: BabyBearExt4Wire) {
+        for (a, b) in a.0.iter().zip(b.0.iter()) {
+            self.base.assert_equal(ctx, *a, *b);
+        }
     }
 
     pub fn mul(
         &self,
         ctx: &mut Context<Fr>,
-        a: &BabyBearExtWire,
-        b: &BabyBearExtWire,
-    ) -> BabyBearExtWire {
-        let a0 = a.0[0];
-        let a1 = a.0[1];
-        let a2 = a.0[2];
-        let a3 = a.0[3];
-        let b0 = b.0[0];
-        let b1 = b.0[1];
-        let b2 = b.0[2];
-        let b3 = b.0[3];
-
-        let t0 = self.base.mul(ctx, &a0, &b0);
-
-        let m01 = self.base.mul(ctx, &a0, &b1);
-        let m10 = self.base.mul(ctx, &a1, &b0);
-        let t1 = self.base.add2(ctx, m01, m10);
-
-        let m02 = self.base.mul(ctx, &a0, &b2);
-        let m11 = self.base.mul(ctx, &a1, &b1);
-        let m20 = self.base.mul(ctx, &a2, &b0);
-        let t2 = self.base.add3(ctx, m02, m11, m20);
-
-        let m03 = self.base.mul(ctx, &a0, &b3);
-        let m12 = self.base.mul(ctx, &a1, &b2);
-        let m21 = self.base.mul(ctx, &a2, &b1);
-        let m30 = self.base.mul(ctx, &a3, &b0);
-        let t3 = self.base.add4(ctx, m03, m12, m21, m30);
-
-        let m13 = self.base.mul(ctx, &a1, &b3);
-        let m22 = self.base.mul(ctx, &a2, &b2);
-        let m31 = self.base.mul(ctx, &a3, &b1);
-        let t4 = self.base.add3(ctx, m13, m22, m31);
-
-        let m23 = self.base.mul(ctx, &a2, &b3);
-        let m32 = self.base.mul(ctx, &a3, &b2);
-        let t5 = self.base.add2(ctx, m23, m32);
-
-        let t6 = self.base.mul(ctx, &a3, &b3);
-
-        let w = ChildF::from_u64(BABY_BEAR_EXT_W_U64);
-        let wt4 = self.base.mul_const(ctx, &t4, w);
-        let wt5 = self.base.mul_const(ctx, &t5, w);
-        let wt6 = self.base.mul_const(ctx, &t6, w);
-
-        BabyBearExtWire([
-            self.base.add2(ctx, t0, wt4),
-            self.base.add2(ctx, t1, wt5),
-            self.base.add2(ctx, t2, wt6),
-            t3,
-        ])
-    }
-
-    pub fn square(&self, ctx: &mut Context<Fr>, a: &BabyBearExtWire) -> BabyBearExtWire {
-        self.mul(ctx, a, a)
-    }
-
-    pub fn neg(&self, ctx: &mut Context<Fr>, a: &BabyBearExtWire) -> BabyBearExtWire {
-        let zero = self.zero(ctx);
-        self.sub(ctx, &zero, a)
-    }
-
-    pub fn assert_equal(
-        &self,
-        ctx: &mut Context<Fr>,
-        lhs: &BabyBearExtWire,
-        rhs: &BabyBearExtWire,
-    ) {
-        for i in 0..BABY_BEAR_EXT_DEGREE {
-            self.base.assert_equal(ctx, &lhs.0[i], &rhs.0[i]);
+        mut a: BabyBearExt4Wire,
+        mut b: BabyBearExt4Wire,
+    ) -> BabyBearExt4Wire {
+        let mut coeffs = Vec::with_capacity(7);
+        for s in 0..7 {
+            coeffs.push(self.base.special_inner_product(ctx, &mut a.0, &mut b.0, s));
         }
-    }
-
-    pub fn from_base_const(&self, ctx: &mut Context<Fr>, constant: ChildF) -> BabyBearExtWire {
-        let c0 = self.base.load_constant(ctx, constant);
-        #[cfg(test)]
-        RECORDED_EXT_BASE_CONSTS.with(|records| {
-            records.borrow_mut().push(RecordedExtBaseConst {
-                constant: constant.as_canonical_u64(),
-                cell: c0.0,
-            });
-        });
-        BabyBearExtWire(core::array::from_fn(|idx| {
-            if idx == 0 {
-                c0
-            } else {
-                self.base.zero(ctx)
-            }
-        }))
-    }
-
-    pub fn mul_base_const(
-        &self,
-        ctx: &mut Context<Fr>,
-        value: &BabyBearExtWire,
-        constant: ChildF,
-    ) -> BabyBearExtWire {
-        BabyBearExtWire(core::array::from_fn(|idx| {
-            self.base.mul_const(ctx, &value.0[idx], constant)
-        }))
-    }
-
-    pub fn pow_power_of_two(
-        &self,
-        ctx: &mut Context<Fr>,
-        value: &BabyBearExtWire,
-        exp_power: usize,
-    ) -> BabyBearExtWire {
-        let mut acc = *value;
-        for _ in 0..exp_power {
-            acc = self.mul(ctx, &acc, &acc);
+        let w = self
+            .base
+            .load_constant(ctx, <BabyBear as BinomiallyExtendable<4>>::W);
+        for i in 4..7 {
+            coeffs[i - 4] = self.base.mul_add(ctx, coeffs[i], w, coeffs[i - 4]);
         }
-        acc
+        coeffs.truncate(4);
+        let c = BabyBearExt4Wire(coeffs.try_into().unwrap());
+        debug_assert_eq!(
+            c.to_extension_field(),
+            a.to_extension_field() * b.to_extension_field()
+        );
+        c
     }
 
-    pub fn from_base_var(&self, ctx: &mut Context<Fr>, value: &BabyBearWire) -> BabyBearExtWire {
-        let zero = self.base.zero(ctx);
-        BabyBearExtWire(core::array::from_fn(
-            |idx| {
-                if idx == 0 {
-                    *value
-                } else {
-                    zero
-                }
-            },
-        ))
+    pub fn div(
+        &self,
+        ctx: &mut Context<Fr>,
+        a: BabyBearExt4Wire,
+        b: BabyBearExt4Wire,
+    ) -> BabyBearExt4Wire {
+        let b_val = b.to_extension_field();
+        let b_inv = b_val.try_inverse().unwrap();
+
+        let c = self.load_witness(ctx, a.to_extension_field() * b_inv);
+        // constraint a = b * c
+        let prod = self.mul(ctx, b, c);
+        self.assert_equal(ctx, a, prod);
+
+        debug_assert_eq!(
+            c.to_extension_field(),
+            a.to_extension_field() / b.to_extension_field()
+        );
+        c
+    }
+
+    pub fn reduce_max_bits(&self, ctx: &mut Context<Fr>, a: BabyBearExt4Wire) -> BabyBearExt4Wire {
+        BabyBearExt4Wire(
+            a.0.into_iter()
+                .map(|x| self.base.reduce_max_bits(ctx, x))
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        )
     }
 }

--- a/crates/static-verifier/src/field/baby_bear/mod.rs
+++ b/crates/static-verifier/src/field/baby_bear/mod.rs
@@ -4,5 +4,12 @@ mod extension;
 pub use base::*;
 pub use extension::*;
 
+pub(crate) const BABY_BEAR_MODULUS_U64: u64 = 0x78000001; // BabyBear prime: 2013265921
+pub(crate) const BABY_BEAR_EXT_DEGREE: usize = 4;
+pub(crate) const BABY_BEAR_BITS: usize = BABYBEAR_MAX_BITS;
+
+pub type BabyBearExtChip = BabyBearExt4Chip;
+pub type BabyBearExtWire = BabyBearExt4Wire;
+
 #[cfg(test)]
 mod tests;

--- a/crates/static-verifier/src/field/baby_bear/tests.rs
+++ b/crates/static-verifier/src/field/baby_bear/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use halo2_base::{
     gates::{
         circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
@@ -49,7 +51,7 @@ fn run_mock(build: impl FnOnce(&mut BaseCircuitBuilder<Fr>)) {
 fn baby_bear_base_ops_match_native_mod_arithmetic() {
     run_mock(|builder| {
         let range = builder.range_chip();
-        let chip = BabyBearChip::new(&range);
+        let chip = BabyBearChip::new(Arc::new(range.clone()));
         let ctx = builder.main(0);
         let gate = range.gate();
 
@@ -65,11 +67,18 @@ fn baby_bear_base_ops_match_native_mod_arithmetic() {
             let a = chip.load_witness(ctx, ChildF::from_u64(a_u64));
             let b = chip.load_witness(ctx, ChildF::from_u64(b_u64));
 
-            let sum = chip.add(ctx, &a, &b);
-            let diff = chip.sub(ctx, &a, &b);
-            let prod = chip.mul(ctx, &a, &b);
-            let neg = chip.neg(ctx, &a);
-            let by_const = chip.mul_const(ctx, &a, ChildF::from_u64(11));
+            // Reduce results to canonical form before comparing, since the new
+            // BabyBearChip uses lazy reduction and wire values may be unreduced.
+            let sum = chip.add(ctx, a, b);
+            let sum = chip.reduce(ctx, sum);
+            let diff = chip.sub(ctx, a, b);
+            let diff = chip.reduce(ctx, diff);
+            let prod = chip.mul(ctx, a, b);
+            let prod = chip.reduce(ctx, prod);
+            let neg = chip.neg(ctx, a);
+            let neg = chip.reduce(ctx, neg);
+            let by_const = chip.mul_const(ctx, a, ChildF::from_u64(11));
+            let by_const = chip.reduce(ctx, by_const);
 
             let expected_sum = (a_u64 + b_u64) % BABY_BEAR_MODULUS_U64;
             let expected_diff = (a_u64 + BABY_BEAR_MODULUS_U64 - b_u64) % BABY_BEAR_MODULUS_U64;
@@ -83,11 +92,11 @@ fn baby_bear_base_ops_match_native_mod_arithmetic() {
             let expected_by_const =
                 ((a_u64 as u128 * 11u128) % BABY_BEAR_MODULUS_U64 as u128) as u64;
 
-            gate.assert_is_const(ctx, &sum.0, &Fr::from(expected_sum));
-            gate.assert_is_const(ctx, &diff.0, &Fr::from(expected_diff));
-            gate.assert_is_const(ctx, &prod.0, &Fr::from(expected_prod));
-            gate.assert_is_const(ctx, &neg.0, &Fr::from(expected_neg));
-            gate.assert_is_const(ctx, &by_const.0, &Fr::from(expected_by_const));
+            gate.assert_is_const(ctx, &sum.value, &Fr::from(expected_sum));
+            gate.assert_is_const(ctx, &diff.value, &Fr::from(expected_diff));
+            gate.assert_is_const(ctx, &prod.value, &Fr::from(expected_prod));
+            gate.assert_is_const(ctx, &neg.value, &Fr::from(expected_neg));
+            gate.assert_is_const(ctx, &by_const.value, &Fr::from(expected_by_const));
         }
     });
 }
@@ -96,8 +105,8 @@ fn baby_bear_base_ops_match_native_mod_arithmetic() {
 fn baby_bear_ext_mul_matches_native_binomial_extension() {
     run_mock(|builder| {
         let range = builder.range_chip();
-        let base_chip = BabyBearChip::new(&range);
-        let ext_chip = BabyBearExtChip::new(base_chip);
+        let base_chip = BabyBearChip::new(Arc::new(range.clone()));
+        let ext_chip = BabyBearExt4Chip::new(Arc::new(base_chip));
         let ctx = builder.main(0);
         let gate = range.gate();
 
@@ -108,10 +117,14 @@ fn baby_bear_ext_mul_matches_native_binomial_extension() {
         let lhs = ext_chip.load_witness(ctx, lhs_native);
         let rhs = ext_chip.load_witness(ctx, rhs_native);
 
-        let sum = ext_chip.add(ctx, &lhs, &rhs);
-        let diff = ext_chip.sub(ctx, &lhs, &rhs);
-        let prod = ext_chip.mul(ctx, &lhs, &rhs);
-        let sqr = ext_chip.square(ctx, &lhs);
+        let sum = ext_chip.add(ctx, lhs, rhs);
+        let sum = ext_chip.reduce_max_bits(ctx, sum);
+        let diff = ext_chip.sub(ctx, lhs, rhs);
+        let diff = ext_chip.reduce_max_bits(ctx, diff);
+        let prod = ext_chip.mul(ctx, lhs, rhs);
+        let prod = ext_chip.reduce_max_bits(ctx, prod);
+        let sqr = ext_chip.square(ctx, lhs);
+        let sqr = ext_chip.reduce_max_bits(ctx, sqr);
 
         let sum_native = lhs_native + rhs_native;
         let diff_native = lhs_native - rhs_native;
@@ -136,10 +149,10 @@ fn baby_bear_ext_mul_matches_native_binomial_extension() {
         });
 
         for i in 0..BABY_BEAR_EXT_DEGREE {
-            gate.assert_is_const(ctx, &sum.0[i].0, &Fr::from(expected_sum[i]));
-            gate.assert_is_const(ctx, &diff.0[i].0, &Fr::from(expected_diff[i]));
-            gate.assert_is_const(ctx, &prod.0[i].0, &Fr::from(expected_prod[i]));
-            gate.assert_is_const(ctx, &sqr.0[i].0, &Fr::from(expected_sqr[i]));
+            gate.assert_is_const(ctx, &sum.0[i].value, &Fr::from(expected_sum[i]));
+            gate.assert_is_const(ctx, &diff.0[i].value, &Fr::from(expected_diff[i]));
+            gate.assert_is_const(ctx, &prod.0[i].value, &Fr::from(expected_prod[i]));
+            gate.assert_is_const(ctx, &sqr.0[i].value, &Fr::from(expected_sqr[i]));
         }
     });
 }

--- a/crates/static-verifier/src/hash/poseidon2.rs
+++ b/crates/static-verifier/src/hash/poseidon2.rs
@@ -171,7 +171,7 @@ pub(crate) fn hash_babybear_slice_to_digest(
     let mut state = core::array::from_fn(|_| ctx.load_constant(Fr::from(0u64)));
     for block_chunk in values.chunks(MULTI_FIELD32_RATE) {
         for (chunk_id, chunk) in block_chunk.chunks(MULTI_FIELD32_NUM_F_ELMS).enumerate() {
-            let cells = chunk.iter().map(|value| value.0).collect::<Vec<_>>();
+            let cells = chunk.iter().map(|value| value.value).collect::<Vec<_>>();
             state[chunk_id] = reduce_32_cells(ctx, range, &cells);
         }
         state = poseidon2_permute_bn254_state(ctx, range, state);

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -1,5 +1,5 @@
 use core::cmp::Reverse;
-use std::{iter::zip, slice};
+use std::{iter::zip, slice, sync::Arc};
 
 use halo2_base::{
     gates::{GateInstructions, RangeInstructions},
@@ -960,21 +960,21 @@ pub fn derive_batch_intermediates(
 
 fn eval_ext_poly_horner(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     coeffs: &[BabyBearExtWire],
     point: &BabyBearExtWire,
 ) -> BabyBearExtWire {
     let mut acc = ext_chip.zero(ctx);
     for coeff in coeffs.iter().rev() {
-        acc = ext_chip.mul(ctx, &acc, point);
-        acc = ext_chip.add(ctx, &acc, coeff);
+        acc = ext_chip.mul(ctx, acc, *point);
+        acc = ext_chip.add(ctx, acc, *coeff);
     }
     acc
 }
 
 fn eval_lagrange_on_integer_grid(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     point: &BabyBearExtWire,
     evals: &[BabyBearExtWire],
 ) -> BabyBearExtWire {
@@ -988,8 +988,8 @@ fn eval_lagrange_on_integer_grid(
                 continue;
             }
             let x_j = ext_chip.from_base_const(ctx, ChildF::from_u64(j as u64));
-            let x_minus_j = ext_chip.sub(ctx, point, &x_j);
-            basis = ext_chip.mul(ctx, &basis, &x_minus_j);
+            let x_minus_j = ext_chip.sub(ctx, *point, x_j);
+            basis = ext_chip.mul(ctx, basis, x_minus_j);
 
             let diff = if i >= j {
                 ChildF::from_usize(i - j)
@@ -999,16 +999,16 @@ fn eval_lagrange_on_integer_grid(
             denom *= diff;
         }
         let denom_inv = denom.inverse();
-        let basis = ext_chip.mul_base_const(ctx, &basis, denom_inv);
-        let term = ext_chip.mul(ctx, eval_i, &basis);
-        acc = ext_chip.add(ctx, &acc, &term);
+        let basis = ext_chip.mul_base_const(ctx, basis, denom_inv);
+        let term = ext_chip.mul(ctx, *eval_i, basis);
+        acc = ext_chip.add(ctx, acc, term);
     }
     acc
 }
 
 fn progression_exp_2_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     m: &BabyBearExtWire,
     l: usize,
 ) -> BabyBearExtWire {
@@ -1016,16 +1016,16 @@ fn progression_exp_2_assigned(
     let mut sum = ext_chip.from_base_const(ctx, ChildF::ONE);
     let one = ext_chip.from_base_const(ctx, ChildF::ONE);
     for _ in 0..l {
-        let one_plus_pow = ext_chip.add(ctx, &one, &pow);
-        sum = ext_chip.mul(ctx, &sum, &one_plus_pow);
-        pow = ext_chip.mul(ctx, &pow, &pow);
+        let one_plus_pow = ext_chip.add(ctx, one, pow);
+        sum = ext_chip.mul(ctx, sum, one_plus_pow);
+        pow = ext_chip.mul(ctx, pow, pow);
     }
     sum
 }
 
 pub(crate) fn eval_eq_mle_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     x: &[BabyBearExtWire],
     y: &[BabyBearExtWire],
 ) -> BabyBearExtWire {
@@ -1033,19 +1033,19 @@ pub(crate) fn eval_eq_mle_assigned(
     let one = ext_chip.from_base_const(ctx, ChildF::ONE);
     let mut acc = one;
     for (x_i, y_i) in x.iter().zip(y.iter()) {
-        let xy = ext_chip.mul(ctx, x_i, y_i);
-        let two_xy = ext_chip.mul_base_const(ctx, &xy, ChildF::TWO);
-        let one_minus_y = ext_chip.sub(ctx, &one, y_i);
-        let one_minus_y_minus_x = ext_chip.sub(ctx, &one_minus_y, x_i);
-        let factor = ext_chip.add(ctx, &one_minus_y_minus_x, &two_xy);
-        acc = ext_chip.mul(ctx, &acc, &factor);
+        let xy = ext_chip.mul(ctx, *x_i, *y_i);
+        let two_xy = ext_chip.mul_base_const(ctx, xy, ChildF::TWO);
+        let one_minus_y = ext_chip.sub(ctx, one, *y_i);
+        let one_minus_y_minus_x = ext_chip.sub(ctx, one_minus_y, *x_i);
+        let factor = ext_chip.add(ctx, one_minus_y_minus_x, two_xy);
+        acc = ext_chip.mul(ctx, acc, factor);
     }
     acc
 }
 
 pub(crate) fn eval_eq_mle_binary_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     x: &[BabyBearExtWire],
     y_bits: &[bool],
 ) -> BabyBearExtWire {
@@ -1060,16 +1060,16 @@ pub(crate) fn eval_eq_mle_binary_assigned(
         let factor = if bit {
             *x_i
         } else {
-            ext_chip.sub(ctx, &one, x_i)
+            ext_chip.sub(ctx, one, *x_i)
         };
-        acc = ext_chip.mul(ctx, &acc, &factor);
+        acc = ext_chip.mul(ctx, acc, factor);
     }
     acc
 }
 
 pub(crate) fn eval_eq_uni_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     l_skip: usize,
     x: &BabyBearExtWire,
     y: &BabyBearExtWire,
@@ -1079,22 +1079,22 @@ pub(crate) fn eval_eq_uni_assigned(
     let mut x_pow = *x;
     let mut y_pow = *y;
     for _ in 0..l_skip {
-        let x_plus_y = ext_chip.add(ctx, &x_pow, &y_pow);
-        let x_minus_one = ext_chip.sub(ctx, &x_pow, &one);
-        let y_minus_one = ext_chip.sub(ctx, &y_pow, &one);
-        let correction = ext_chip.mul(ctx, &x_minus_one, &y_minus_one);
-        let scaled_res = ext_chip.mul(ctx, &x_plus_y, &res);
-        res = ext_chip.add(ctx, &scaled_res, &correction);
-        x_pow = ext_chip.mul(ctx, &x_pow, &x_pow);
-        y_pow = ext_chip.mul(ctx, &y_pow, &y_pow);
+        let x_plus_y = ext_chip.add(ctx, x_pow, y_pow);
+        let x_minus_one = ext_chip.sub(ctx, x_pow, one);
+        let y_minus_one = ext_chip.sub(ctx, y_pow, one);
+        let correction = ext_chip.mul(ctx, x_minus_one, y_minus_one);
+        let scaled_res = ext_chip.mul(ctx, x_plus_y, res);
+        res = ext_chip.add(ctx, scaled_res, correction);
+        x_pow = ext_chip.mul(ctx, x_pow, x_pow);
+        y_pow = ext_chip.mul(ctx, y_pow, y_pow);
     }
     let half_pow_l = ChildF::ONE.halve().exp_u64(l_skip as u64);
-    ext_chip.mul_base_const(ctx, &res, half_pow_l)
+    ext_chip.mul_base_const(ctx, res, half_pow_l)
 }
 
 pub(crate) fn eval_eq_uni_at_one_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     l_skip: usize,
     x: &BabyBearExtWire,
 ) -> BabyBearExtWire {
@@ -1102,17 +1102,17 @@ pub(crate) fn eval_eq_uni_at_one_assigned(
     let mut res = one;
     let mut x_pow = *x;
     for _ in 0..l_skip {
-        let x_plus_one = ext_chip.add(ctx, &x_pow, &one);
-        res = ext_chip.mul(ctx, &res, &x_plus_one);
-        x_pow = ext_chip.mul(ctx, &x_pow, &x_pow);
+        let x_plus_one = ext_chip.add(ctx, x_pow, one);
+        res = ext_chip.mul(ctx, res, x_plus_one);
+        x_pow = ext_chip.mul(ctx, x_pow, x_pow);
     }
     let half_pow_l = ChildF::ONE.halve().exp_u64(l_skip as u64);
-    ext_chip.mul_base_const(ctx, &res, half_pow_l)
+    ext_chip.mul_base_const(ctx, res, half_pow_l)
 }
 
 fn eval_eq_sharp_uni_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     omega_skip_pows: &[ChildF],
     xi_1: &[BabyBearExtWire],
     z: &BabyBearExtWire,
@@ -1125,11 +1125,11 @@ fn eval_eq_sharp_uni_assigned(
     // mask bit `i` corresponds to `xi_1[i]`.
     for (i, xi) in xi_1.iter().enumerate() {
         let span = 1usize << i;
-        let one_minus_xi = ext_chip.sub(ctx, &one, xi);
+        let one_minus_xi = ext_chip.sub(ctx, one, *xi);
         for idx in 0..span {
             let prev = eq_xi_evals[idx];
-            let lo = ext_chip.mul(ctx, &prev, &one_minus_xi);
-            let hi = ext_chip.mul(ctx, &prev, xi);
+            let lo = ext_chip.mul(ctx, prev, one_minus_xi);
+            let hi = ext_chip.mul(ctx, prev, *xi);
             eq_xi_evals[idx] = lo;
             eq_xi_evals[span + idx] = hi;
         }
@@ -1146,15 +1146,15 @@ fn eval_eq_sharp_uni_assigned(
     for (omega_pow, eq_xi_eval) in omega_skip_pows.iter().zip(eq_xi_evals.iter()) {
         let omega_ext = ext_chip.from_base_const(ctx, *omega_pow);
         let eq_uni = eval_eq_uni_assigned(ctx, ext_chip, l_skip, z, &omega_ext);
-        let term = ext_chip.mul(ctx, &eq_uni, eq_xi_eval);
-        res = ext_chip.add(ctx, &res, &term);
+        let term = ext_chip.mul(ctx, eq_uni, *eq_xi_eval);
+        res = ext_chip.add(ctx, res, term);
     }
     res
 }
 
 pub(crate) fn eval_eq_prism_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     l_skip: usize,
     x: &[BabyBearExtWire],
     y: &[BabyBearExtWire],
@@ -1165,12 +1165,12 @@ pub(crate) fn eval_eq_prism_assigned(
     );
     let eq_uni = eval_eq_uni_assigned(ctx, ext_chip, l_skip, &x[0], &y[0]);
     let eq_mle = eval_eq_mle_assigned(ctx, ext_chip, &x[1..], &y[1..]);
-    ext_chip.mul(ctx, &eq_uni, &eq_mle)
+    ext_chip.mul(ctx, eq_uni, eq_mle)
 }
 
 fn eval_eq_rot_cube_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     x: &[BabyBearExtWire],
     y: &[BabyBearExtWire],
 ) -> (BabyBearExtWire, BabyBearExtWire) {
@@ -1179,25 +1179,25 @@ fn eval_eq_rot_cube_assigned(
     let mut rot = one;
     let mut eq = one;
     for i in (0..x.len()).rev() {
-        let one_minus_y = ext_chip.sub(ctx, &one, &y[i]);
-        let one_minus_x = ext_chip.sub(ctx, &one, &x[i]);
-        let x_times = ext_chip.mul(ctx, &x[i], &one_minus_y);
-        let term1 = ext_chip.mul(ctx, &x_times, &eq);
-        let y_times = ext_chip.mul(ctx, &one_minus_x, &y[i]);
-        let term2 = ext_chip.mul(ctx, &y_times, &rot);
-        rot = ext_chip.add(ctx, &term1, &term2);
+        let one_minus_y = ext_chip.sub(ctx, one, y[i]);
+        let one_minus_x = ext_chip.sub(ctx, one, x[i]);
+        let x_times = ext_chip.mul(ctx, x[i], one_minus_y);
+        let term1 = ext_chip.mul(ctx, x_times, eq);
+        let y_times = ext_chip.mul(ctx, one_minus_x, y[i]);
+        let term2 = ext_chip.mul(ctx, y_times, rot);
+        rot = ext_chip.add(ctx, term1, term2);
 
-        let xy = ext_chip.mul(ctx, &x[i], &y[i]);
-        let one_minus_xy = ext_chip.mul(ctx, &one_minus_x, &one_minus_y);
-        let eq_factor = ext_chip.add(ctx, &xy, &one_minus_xy);
-        eq = ext_chip.mul(ctx, &eq, &eq_factor);
+        let xy = ext_chip.mul(ctx, x[i], y[i]);
+        let one_minus_xy = ext_chip.mul(ctx, one_minus_x, one_minus_y);
+        let eq_factor = ext_chip.add(ctx, xy, one_minus_xy);
+        eq = ext_chip.mul(ctx, eq, eq_factor);
     }
     (eq, rot)
 }
 
 pub(crate) fn eval_rot_kernel_prism_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     l_skip: usize,
     x: &[BabyBearExtWire],
     y: &[BabyBearExtWire],
@@ -1207,60 +1207,60 @@ pub(crate) fn eval_rot_kernel_prism_assigned(
         "rot-kernel vectors must be non-empty",
     );
     let omega = ChildF::two_adic_generator(l_skip);
-    let y0_omega = ext_chip.mul_base_const(ctx, &y[0], omega);
+    let y0_omega = ext_chip.mul_base_const(ctx, y[0], omega);
     let eq_uni_rot = eval_eq_uni_assigned(ctx, ext_chip, l_skip, &x[0], &y0_omega);
     let (eq_cube, rot_cube) = eval_eq_rot_cube_assigned(ctx, ext_chip, &x[1..], &y[1..]);
-    let term_a = ext_chip.mul(ctx, &eq_uni_rot, &eq_cube);
+    let term_a = ext_chip.mul(ctx, eq_uni_rot, eq_cube);
 
     let eq_uni_x_one = eval_eq_uni_at_one_assigned(ctx, ext_chip, l_skip, &x[0]);
     let eq_uni_y_one = eval_eq_uni_at_one_assigned(ctx, ext_chip, l_skip, &y0_omega);
-    let rot_minus_eq = ext_chip.sub(ctx, &rot_cube, &eq_cube);
-    let eq_uni_product = ext_chip.mul(ctx, &eq_uni_x_one, &eq_uni_y_one);
-    let term_b = ext_chip.mul(ctx, &eq_uni_product, &rot_minus_eq);
-    ext_chip.add(ctx, &term_a, &term_b)
+    let rot_minus_eq = ext_chip.sub(ctx, rot_cube, eq_cube);
+    let eq_uni_product = ext_chip.mul(ctx, eq_uni_x_one, eq_uni_y_one);
+    let term_b = ext_chip.mul(ctx, eq_uni_product, rot_minus_eq);
+    ext_chip.add(ctx, term_a, term_b)
 }
 
 fn interpolate_linear_at_01_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     eval0: &BabyBearExtWire,
     eval1: &BabyBearExtWire,
     x: &BabyBearExtWire,
 ) -> BabyBearExtWire {
-    let delta = ext_chip.sub(ctx, eval1, eval0);
-    let scaled = ext_chip.mul(ctx, &delta, x);
-    ext_chip.add(ctx, &scaled, eval0)
+    let delta = ext_chip.sub(ctx, *eval1, *eval0);
+    let scaled = ext_chip.mul(ctx, delta, *x);
+    ext_chip.add(ctx, scaled, *eval0)
 }
 
 fn interpolate_cubic_at_0123_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     evals: [&BabyBearExtWire; 4],
     x: &BabyBearExtWire,
 ) -> BabyBearExtWire {
     let inv6 = ChildF::from_u64(6).inverse();
-    let s1 = ext_chip.sub(ctx, evals[1], evals[0]);
-    let s2 = ext_chip.sub(ctx, evals[2], evals[0]);
-    let s3 = ext_chip.sub(ctx, evals[3], evals[0]);
+    let s1 = ext_chip.sub(ctx, *evals[1], *evals[0]);
+    let s2 = ext_chip.sub(ctx, *evals[2], *evals[0]);
+    let s3 = ext_chip.sub(ctx, *evals[3], *evals[0]);
 
-    let s2_minus_s1 = ext_chip.sub(ctx, &s2, &s1);
-    let triple = ext_chip.mul_base_const(ctx, &s2_minus_s1, ChildF::from_u64(3));
-    let d3 = ext_chip.sub(ctx, &s3, &triple);
+    let s2_minus_s1 = ext_chip.sub(ctx, s2, s1);
+    let triple = ext_chip.mul_base_const(ctx, s2_minus_s1, ChildF::from_u64(3));
+    let d3 = ext_chip.sub(ctx, s3, triple);
 
-    let p = ext_chip.mul_base_const(ctx, &d3, inv6);
-    let s2_minus_d3 = ext_chip.sub(ctx, &s2, &d3);
+    let p = ext_chip.mul_base_const(ctx, d3, inv6);
+    let s2_minus_d3 = ext_chip.sub(ctx, s2, d3);
     let half = ChildF::ONE.halve();
-    let q_half = ext_chip.mul_base_const(ctx, &s2_minus_d3, half);
-    let q = ext_chip.sub(ctx, &q_half, &s1);
-    let p_plus_q = ext_chip.add(ctx, &p, &q);
-    let r = ext_chip.sub(ctx, &s1, &p_plus_q);
+    let q_half = ext_chip.mul_base_const(ctx, s2_minus_d3, half);
+    let q = ext_chip.sub(ctx, q_half, s1);
+    let p_plus_q = ext_chip.add(ctx, p, q);
+    let r = ext_chip.sub(ctx, s1, p_plus_q);
 
-    let p_mul_x = ext_chip.mul(ctx, &p, x);
-    let px_plus_q = ext_chip.add(ctx, &p_mul_x, &q);
-    let quad_mul_x = ext_chip.mul(ctx, &px_plus_q, x);
-    let quad = ext_chip.add(ctx, &quad_mul_x, &r);
-    let cubic = ext_chip.mul(ctx, &quad, x);
-    ext_chip.add(ctx, &cubic, evals[0])
+    let p_mul_x = ext_chip.mul(ctx, p, *x);
+    let px_plus_q = ext_chip.add(ctx, p_mul_x, q);
+    let quad_mul_x = ext_chip.mul(ctx, px_plus_q, *x);
+    let quad = ext_chip.add(ctx, quad_mul_x, r);
+    let cubic = ext_chip.mul(ctx, quad, *x);
+    ext_chip.add(ctx, cubic, *evals[0])
 }
 
 #[derive(Clone)]
@@ -1281,18 +1281,18 @@ impl AssignedConstraintEvaluator<'_> {
     fn reject_malformed_symbolic_var(
         &self,
         ctx: &mut Context<Fr>,
-        ext_chip: &BabyBearExtChip<'_>,
+        ext_chip: &BabyBearExtChip,
     ) -> BabyBearExtWire {
         let zero = ext_chip.zero(ctx);
         let one = ext_chip.from_base_const(ctx, ChildF::ONE);
-        ext_chip.assert_equal(ctx, &zero, &one);
+        ext_chip.assert_equal(ctx, zero, one);
         zero
     }
 
     fn eval_var(
         &self,
         ctx: &mut Context<Fr>,
-        ext_chip: &BabyBearExtChip<'_>,
+        ext_chip: &BabyBearExtChip,
         symbolic_var: SymbolicVariable<ChildF>,
     ) -> BabyBearExtWire {
         let index = symbolic_var.index;
@@ -1327,7 +1327,7 @@ impl AssignedConstraintEvaluator<'_> {
                 let Some(value) = self.public_values.get(index) else {
                     return self.reject_malformed_symbolic_var(ctx, ext_chip);
                 };
-                ext_chip.from_base_var(ctx, value)
+                ext_chip.from_base_var(ctx, *value)
             }
             _ => self.reject_malformed_symbolic_var(ctx, ext_chip),
         }
@@ -1336,7 +1336,7 @@ impl AssignedConstraintEvaluator<'_> {
 
 fn eval_symbolic_nodes_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     evaluator: &AssignedConstraintEvaluator<'_>,
     nodes: &[SymbolicExpressionNode<ChildF>],
 ) -> Vec<BabyBearExtWire> {
@@ -1350,21 +1350,21 @@ fn eval_symbolic_nodes_assigned(
                 left_idx,
                 right_idx,
                 ..
-            } => ext_chip.add(ctx, &exprs[*left_idx], &exprs[*right_idx]),
+            } => ext_chip.add(ctx, exprs[*left_idx], exprs[*right_idx]),
             SymbolicExpressionNode::Sub {
                 left_idx,
                 right_idx,
                 ..
-            } => ext_chip.sub(ctx, &exprs[*left_idx], &exprs[*right_idx]),
-            SymbolicExpressionNode::Neg { idx, .. } => ext_chip.neg(ctx, &exprs[*idx]),
+            } => ext_chip.sub(ctx, exprs[*left_idx], exprs[*right_idx]),
+            SymbolicExpressionNode::Neg { idx, .. } => ext_chip.neg(ctx, exprs[*idx]),
             SymbolicExpressionNode::Mul {
                 left_idx,
                 right_idx,
                 ..
-            } => ext_chip.mul(ctx, &exprs[*left_idx], &exprs[*right_idx]),
+            } => ext_chip.mul(ctx, exprs[*left_idx], exprs[*right_idx]),
             SymbolicExpressionNode::IsFirstRow => evaluator.is_first_row,
             SymbolicExpressionNode::IsLastRow => evaluator.is_last_row,
-            SymbolicExpressionNode::IsTransition => ext_chip.sub(ctx, &one, &evaluator.is_last_row),
+            SymbolicExpressionNode::IsTransition => ext_chip.sub(ctx, one, evaluator.is_last_row),
         };
         exprs.push(expr);
     }
@@ -1373,7 +1373,7 @@ fn eval_symbolic_nodes_assigned(
 
 fn column_openings_by_rot_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     openings: &[BabyBearExtWire],
     need_rot: bool,
 ) -> Vec<AssignedViewPair> {
@@ -1416,8 +1416,8 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
         "trace interaction sets must align with trace count",
     );
 
-    let base_chip = BabyBearChip::new(range);
-    let ext_chip = BabyBearExtChip::new(base_chip);
+    let base_chip = BabyBearChip::new(Arc::new(range.clone()));
+    let ext_chip = BabyBearExtChip::new(Arc::new(base_chip));
     let gate = ext_chip.range().gate();
 
     let trace_id_to_air_id = shared_trace_id_to_air_id.map_or_else(
@@ -1709,16 +1709,15 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
         let layer0_len = ext_chip.base().assign_and_range_usize(ctx, layer0.len());
         gate.assert_is_const(ctx, &layer0_len, &Fr::from(4u64));
 
-        let p0_q1 = ext_chip.mul(ctx, &layer0[0], &layer0[3]);
-        let p1_q0 = ext_chip.mul(ctx, &layer0[2], &layer0[1]);
-        let p_cross = ext_chip.add(ctx, &p0_q1, &p1_q0);
-        let q_cross = ext_chip.mul(ctx, &layer0[1], &layer0[3]);
-        ext_chip.assert_equal(ctx, &p_cross, &zero);
+        let p0_q1 = ext_chip.mul(ctx, layer0[0], layer0[3]);
+        let p1_q0 = ext_chip.mul(ctx, layer0[2], layer0[1]);
+        let p_cross = ext_chip.add(ctx, p0_q1, p1_q0);
+        let q_cross = ext_chip.mul(ctx, layer0[1], layer0[3]);
+        ext_chip.assert_equal(ctx, p_cross, zero);
         ext_chip.assert_equal(
             ctx,
-            &q_cross,
+            q_cross,
             gkr_q0_claim
-                .as_ref()
                 .expect("non-zero interaction branch must include GKR q0 claim witness"),
         );
 
@@ -1740,8 +1739,8 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
                 .unwrap_or(zero);
             gkr_sample_cursor += 1;
 
-            let lambda_denom = ext_chip.mul(ctx, &lambda_round, &denom_claim);
-            let mut claim = ext_chip.add(ctx, &numer_claim, &lambda_denom);
+            let lambda_denom = ext_chip.mul(ctx, lambda_round, denom_claim);
+            let mut claim = ext_chip.add(ctx, numer_claim, lambda_denom);
             let round_polys = gkr_sumcheck_polys
                 .get(round - 1)
                 .cloned()
@@ -1764,19 +1763,19 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
                 gkr_sample_cursor += 1;
                 gkr_r_prime.push(ri);
 
-                let ev0 = ext_chip.sub(ctx, &claim, &ev1);
+                let ev0 = ext_chip.sub(ctx, claim, ev1);
                 claim = interpolate_cubic_at_0123_assigned(
                     ctx,
                     &ext_chip,
                     [&ev0, &ev1, &ev2, &ev3],
                     &ri,
                 );
-                let xi_ri = ext_chip.mul(ctx, xi_prev, &ri);
-                let one_minus_xi = ext_chip.sub(ctx, &one, xi_prev);
-                let one_minus_ri = ext_chip.sub(ctx, &one, &ri);
-                let one_minus_term = ext_chip.mul(ctx, &one_minus_xi, &one_minus_ri);
-                let eq_factor = ext_chip.add(ctx, &xi_ri, &one_minus_term);
-                eq = ext_chip.mul(ctx, &eq, &eq_factor);
+                let xi_ri = ext_chip.mul(ctx, *xi_prev, ri);
+                let one_minus_xi = ext_chip.sub(ctx, one, *xi_prev);
+                let one_minus_ri = ext_chip.sub(ctx, one, ri);
+                let one_minus_term = ext_chip.mul(ctx, one_minus_xi, one_minus_ri);
+                let eq_factor = ext_chip.add(ctx, xi_ri, one_minus_term);
+                eq = ext_chip.mul(ctx, eq, eq_factor);
             }
 
             let layer_claims = gkr_claims_per_layer
@@ -1787,14 +1786,14 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
                 .base()
                 .assign_and_range_usize(ctx, layer_claims.len());
             gate.assert_is_const(ctx, &layer_claim_count, &Fr::from(4u64));
-            let p0_q1 = ext_chip.mul(ctx, &layer_claims[0], &layer_claims[3]);
-            let p1_q0 = ext_chip.mul(ctx, &layer_claims[2], &layer_claims[1]);
-            let p_cross = ext_chip.add(ctx, &p0_q1, &p1_q0);
-            let q_cross = ext_chip.mul(ctx, &layer_claims[1], &layer_claims[3]);
-            let lambda_q_cross = ext_chip.mul(ctx, &lambda_round, &q_cross);
-            let claim_sum = ext_chip.add(ctx, &p_cross, &lambda_q_cross);
-            let expected_claim = ext_chip.mul(ctx, &claim_sum, &eq);
-            ext_chip.assert_equal(ctx, &expected_claim, &claim);
+            let p0_q1 = ext_chip.mul(ctx, layer_claims[0], layer_claims[3]);
+            let p1_q0 = ext_chip.mul(ctx, layer_claims[2], layer_claims[1]);
+            let p_cross = ext_chip.add(ctx, p0_q1, p1_q0);
+            let q_cross = ext_chip.mul(ctx, layer_claims[1], layer_claims[3]);
+            let lambda_q_cross = ext_chip.mul(ctx, lambda_round, q_cross);
+            let claim_sum = ext_chip.add(ctx, p_cross, lambda_q_cross);
+            let expected_claim = ext_chip.mul(ctx, claim_sum, eq);
+            ext_chip.assert_equal(ctx, expected_claim, claim);
 
             let mu_round = gkr_sample_stream
                 .get(gkr_sample_cursor)
@@ -1840,33 +1839,33 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
         usize_to_u64(xi.len()).saturating_add(1),
     );
     for (expected_xi, assigned_xi) in gkr_xi_claims.iter().zip(xi.iter()) {
-        ext_chip.assert_equal(ctx, expected_xi, assigned_xi);
+        ext_chip.assert_equal(ctx, *expected_xi, *assigned_xi);
     }
 
     for (num_term, den_term) in numerator_term_per_air
         .iter()
         .zip(denominator_term_per_air.iter())
     {
-        gkr_p_xi_claim = ext_chip.sub(ctx, &gkr_p_xi_claim, num_term);
-        gkr_q_xi_claim = ext_chip.sub(ctx, &gkr_q_xi_claim, den_term);
+        gkr_p_xi_claim = ext_chip.sub(ctx, gkr_p_xi_claim, *num_term);
+        gkr_q_xi_claim = ext_chip.sub(ctx, gkr_q_xi_claim, *den_term);
     }
     let derived_gkr_numerator_residual = gkr_p_xi_claim;
     let derived_gkr_denominator_claim = gkr_q_xi_claim;
     let derived_gkr_denominator_residual =
-        ext_chip.sub(ctx, &derived_gkr_denominator_claim, &alpha_logup);
+        ext_chip.sub(ctx, derived_gkr_denominator_claim, alpha_logup);
     ext_chip.assert_equal(
         ctx,
-        &derived_gkr_numerator_residual,
-        &gkr_numerator_residual,
+        derived_gkr_numerator_residual,
+        gkr_numerator_residual,
     );
-    ext_chip.assert_equal(ctx, &derived_gkr_denominator_claim, &gkr_denominator_claim);
+    ext_chip.assert_equal(ctx, derived_gkr_denominator_claim, gkr_denominator_claim);
     ext_chip.assert_equal(
         ctx,
-        &derived_gkr_denominator_residual,
-        &gkr_denominator_residual,
+        derived_gkr_denominator_residual,
+        gkr_denominator_residual,
     );
-    ext_chip.assert_equal(ctx, &gkr_numerator_residual, &zero);
-    ext_chip.assert_equal(ctx, &gkr_denominator_residual, &zero);
+    ext_chip.assert_equal(ctx, gkr_numerator_residual, zero);
+    ext_chip.assert_equal(ctx, gkr_denominator_residual, zero);
 
     let sum_claim = ext_chip.load_witness(ctx, actual.sum_claim);
     let mut derived_sum_claim = ext_chip.zero(ctx);
@@ -1875,33 +1874,33 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
         .iter()
         .zip(denominator_term_per_air.iter())
     {
-        let num_weighted = ext_chip.mul(ctx, num_term, &cur_mu_pow);
-        derived_sum_claim = ext_chip.add(ctx, &derived_sum_claim, &num_weighted);
-        cur_mu_pow = ext_chip.mul(ctx, &cur_mu_pow, &mu);
+        let num_weighted = ext_chip.mul(ctx, *num_term, cur_mu_pow);
+        derived_sum_claim = ext_chip.add(ctx, derived_sum_claim, num_weighted);
+        cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
 
-        let den_weighted = ext_chip.mul(ctx, den_term, &cur_mu_pow);
-        derived_sum_claim = ext_chip.add(ctx, &derived_sum_claim, &den_weighted);
-        cur_mu_pow = ext_chip.mul(ctx, &cur_mu_pow, &mu);
+        let den_weighted = ext_chip.mul(ctx, *den_term, cur_mu_pow);
+        derived_sum_claim = ext_chip.add(ctx, derived_sum_claim, den_weighted);
+        cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
     }
-    ext_chip.assert_equal(ctx, &sum_claim, &derived_sum_claim);
+    ext_chip.assert_equal(ctx, sum_claim, derived_sum_claim);
 
     let sum_univ_domain_s_0 = ext_chip.load_witness(ctx, actual.sum_univ_domain_s_0);
     let stride = 1usize << actual.l_skip;
     let mut derived_univ_sum = ext_chip.zero(ctx);
     for coeff in univariate_round_coeffs.iter().step_by(stride) {
-        derived_univ_sum = ext_chip.add(ctx, &derived_univ_sum, coeff);
+        derived_univ_sum = ext_chip.add(ctx, derived_univ_sum, *coeff);
     }
     let derived_univ_sum =
-        ext_chip.mul_base_const(ctx, &derived_univ_sum, ChildF::from_u64(stride as u64));
-    ext_chip.assert_equal(ctx, &sum_univ_domain_s_0, &derived_univ_sum);
-    ext_chip.assert_equal(ctx, &sum_claim, &sum_univ_domain_s_0);
+        ext_chip.mul_base_const(ctx, derived_univ_sum, ChildF::from_u64(stride as u64));
+    ext_chip.assert_equal(ctx, sum_univ_domain_s_0, derived_univ_sum);
+    ext_chip.assert_equal(ctx, sum_claim, sum_univ_domain_s_0);
 
     let consistency_lhs = ext_chip.load_witness(ctx, actual.consistency_lhs);
     let mut derived_consistency_lhs =
         eval_ext_poly_horner(ctx, &ext_chip, &univariate_round_coeffs, &r[0]);
     for (round_idx, round_evals) in sumcheck_round_polys.iter().enumerate() {
         let s_1 = round_evals.first().copied().unwrap_or(zero);
-        let s_0 = ext_chip.sub(ctx, &derived_consistency_lhs, &s_1);
+        let s_0 = ext_chip.sub(ctx, derived_consistency_lhs, s_1);
         let mut interpolation_evals = Vec::with_capacity(round_evals.len() + 1);
         interpolation_evals.push(s_0);
         interpolation_evals.extend(round_evals.iter().copied());
@@ -1909,7 +1908,7 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
         derived_consistency_lhs =
             eval_lagrange_on_integer_grid(ctx, &ext_chip, &next_r, &interpolation_evals);
     }
-    ext_chip.assert_equal(ctx, &consistency_lhs, &derived_consistency_lhs);
+    ext_chip.assert_equal(ctx, consistency_lhs, derived_consistency_lhs);
 
     let required_xi_len = ext_chip
         .base()
@@ -1969,15 +1968,15 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
             &[xi[actual.l_skip + i - 1]],
             core::slice::from_ref(r_i),
         );
-        eq_ns[i] = ext_chip.mul(ctx, &eq_ns[i - 1], &eq_mle);
-        eq_sharp_ns[i] = ext_chip.mul(ctx, &eq_sharp_ns[i - 1], &eq_mle);
+        eq_ns[i] = ext_chip.mul(ctx, eq_ns[i - 1], eq_mle);
+        eq_sharp_ns[i] = ext_chip.mul(ctx, eq_sharp_ns[i - 1], eq_mle);
     }
     if actual.n_max > 0 {
         let mut r_rev_prod = r[actual.n_max];
         for i in (0..actual.n_max).rev() {
-            eq_ns[i] = ext_chip.mul(ctx, &eq_ns[i], &r_rev_prod);
-            eq_sharp_ns[i] = ext_chip.mul(ctx, &eq_sharp_ns[i], &r_rev_prod);
-            r_rev_prod = ext_chip.mul(ctx, &r_rev_prod, &r[i]);
+            eq_ns[i] = ext_chip.mul(ctx, eq_ns[i], r_rev_prod);
+            eq_sharp_ns[i] = ext_chip.mul(ctx, eq_sharp_ns[i], r_rev_prod);
+            r_rev_prod = ext_chip.mul(ctx, r_rev_prod, r[i]);
         }
     }
 
@@ -2026,7 +2025,7 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
         let (l, rs_n, norm_factor) = if n.is_negative() {
             (
                 actual.l_skip.wrapping_add_signed(n),
-                vec![ext_chip.pow_power_of_two(ctx, &r[0], n.unsigned_abs())],
+                vec![ext_chip.pow_power_of_two(ctx, r[0], n.unsigned_abs())],
                 ChildF::from_usize(1usize << n.unsigned_abs()).inverse(),
             )
         } else {
@@ -2035,18 +2034,18 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
 
         let inv_l = ChildF::from_usize(1usize << l).inverse();
         let mut is_first_row = progression_exp_2_assigned(ctx, &ext_chip, &rs_n[0], l);
-        is_first_row = ext_chip.mul_base_const(ctx, &is_first_row, inv_l);
+        is_first_row = ext_chip.mul_base_const(ctx, is_first_row, inv_l);
         for x in rs_n.iter().skip(1) {
-            let one_minus_x = ext_chip.sub(ctx, &one, x);
-            is_first_row = ext_chip.mul(ctx, &is_first_row, &one_minus_x);
+            let one_minus_x = ext_chip.sub(ctx, one, *x);
+            is_first_row = ext_chip.mul(ctx, is_first_row, one_minus_x);
         }
 
         let omega = ChildF::two_adic_generator(l);
-        let rs0_omega = ext_chip.mul_base_const(ctx, &rs_n[0], omega);
+        let rs0_omega = ext_chip.mul_base_const(ctx, rs_n[0], omega);
         let mut is_last_row = progression_exp_2_assigned(ctx, &ext_chip, &rs0_omega, l);
-        is_last_row = ext_chip.mul_base_const(ctx, &is_last_row, inv_l);
+        is_last_row = ext_chip.mul_base_const(ctx, is_last_row, inv_l);
         for x in rs_n.iter().skip(1) {
-            is_last_row = ext_chip.mul(ctx, &is_last_row, x);
+            is_last_row = ext_chip.mul(ctx, is_last_row, *x);
         }
 
         let evaluator = AssignedConstraintEvaluator {
@@ -2070,11 +2069,11 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
         let mut expr = ext_chip.zero(ctx);
         let mut lambda_pow = one;
         for &constraint_idx in &actual.trace_constraint_indices[trace_idx] {
-            let term = ext_chip.mul(ctx, &node_values[constraint_idx], &lambda_pow);
-            expr = ext_chip.add(ctx, &expr, &term);
-            lambda_pow = ext_chip.mul(ctx, &lambda_pow, &lambda);
+            let term = ext_chip.mul(ctx, node_values[constraint_idx], lambda_pow);
+            expr = ext_chip.add(ctx, expr, term);
+            lambda_pow = ext_chip.mul(ctx, lambda_pow, lambda);
         }
-        constraints_evals.push(ext_chip.mul(ctx, &eq_ns[n_lift], &expr));
+        constraints_evals.push(ext_chip.mul(ctx, eq_ns[n_lift], expr));
 
         let interactions = &actual.trace_interactions[trace_idx];
         let eq_3bs = &eq_3b_per_trace[trace_idx];
@@ -2090,25 +2089,25 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
             let mut denom_eval = ext_chip.zero(ctx);
             let mut beta_pow = one;
             for &msg_idx in &interaction.message {
-                let term = ext_chip.mul(ctx, &node_values[msg_idx], &beta_pow);
-                denom_eval = ext_chip.add(ctx, &denom_eval, &term);
-                beta_pow = ext_chip.mul(ctx, &beta_pow, &beta_logup);
+                let term = ext_chip.mul(ctx, node_values[msg_idx], beta_pow);
+                denom_eval = ext_chip.add(ctx, denom_eval, term);
+                beta_pow = ext_chip.mul(ctx, beta_pow, beta_logup);
             }
             let bus_const = ext_chip
                 .from_base_const(ctx, ChildF::from_u64(u64::from(interaction.bus_index) + 1));
-            let bus_term = ext_chip.mul(ctx, &bus_const, &beta_pow);
-            denom_eval = ext_chip.add(ctx, &denom_eval, &bus_term);
+            let bus_term = ext_chip.mul(ctx, bus_const, beta_pow);
+            denom_eval = ext_chip.add(ctx, denom_eval, bus_term);
 
-            let eq_times_count = ext_chip.mul(ctx, eq_3b, &count_eval);
-            num = ext_chip.add(ctx, &num, &eq_times_count);
-            let eq_times_denom = ext_chip.mul(ctx, eq_3b, &denom_eval);
-            denom = ext_chip.add(ctx, &denom, &eq_times_denom);
+            let eq_times_count = ext_chip.mul(ctx, *eq_3b, count_eval);
+            num = ext_chip.add(ctx, num, eq_times_count);
+            let eq_times_denom = ext_chip.mul(ctx, *eq_3b, denom_eval);
+            denom = ext_chip.add(ctx, denom, eq_times_denom);
         }
 
         let norm = ext_chip.from_base_const(ctx, norm_factor);
-        let num_norm = ext_chip.mul(ctx, &num, &norm);
-        let num_scaled = ext_chip.mul(ctx, &num_norm, &eq_sharp_ns[n_lift]);
-        let denom_scaled = ext_chip.mul(ctx, &denom, &eq_sharp_ns[n_lift]);
+        let num_norm = ext_chip.mul(ctx, num, norm);
+        let num_scaled = ext_chip.mul(ctx, num_norm, eq_sharp_ns[n_lift]);
+        let denom_scaled = ext_chip.mul(ctx, denom, eq_sharp_ns[n_lift]);
         interactions_evals.push(num_scaled);
         interactions_evals.push(denom_scaled);
     }
@@ -2117,16 +2116,16 @@ pub(crate) fn constrain_batch_intermediates_with_shared_trace_ids(
     let mut derived_consistency_rhs = ext_chip.zero(ctx);
     let mut cur_mu_pow = one;
     for term in interactions_evals.iter().chain(constraints_evals.iter()) {
-        let weighted_term = ext_chip.mul(ctx, term, &cur_mu_pow);
-        derived_consistency_rhs = ext_chip.add(ctx, &derived_consistency_rhs, &weighted_term);
-        cur_mu_pow = ext_chip.mul(ctx, &cur_mu_pow, &mu);
+        let weighted_term = ext_chip.mul(ctx, *term, cur_mu_pow);
+        derived_consistency_rhs = ext_chip.add(ctx, derived_consistency_rhs, weighted_term);
+        cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
     }
-    ext_chip.assert_equal(ctx, &consistency_rhs, &derived_consistency_rhs);
+    ext_chip.assert_equal(ctx, consistency_rhs, derived_consistency_rhs);
 
     let consistency_residual = ext_chip.load_witness(ctx, actual.consistency_residual);
-    let derived_consistency_residual = ext_chip.sub(ctx, &consistency_lhs, &consistency_rhs);
-    ext_chip.assert_equal(ctx, &derived_consistency_residual, &consistency_residual);
-    ext_chip.assert_equal(ctx, &consistency_residual, &zero);
+    let derived_consistency_residual = ext_chip.sub(ctx, consistency_lhs, consistency_rhs);
+    ext_chip.assert_equal(ctx, derived_consistency_residual, consistency_residual);
+    ext_chip.assert_equal(ctx, consistency_residual, zero);
 
     AssignedBatchIntermediates {
         trace_id_to_air_id,

--- a/crates/static-verifier/src/stages/batch_constraints/tests.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use halo2_base::{
     gates::{
         circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
@@ -73,7 +75,12 @@ fn run_mock(expect_satisfied: bool, build: impl FnOnce(&mut BaseCircuitBuilder<F
         .use_k(BATCH_K as usize)
         .use_lookup_bits(8)
         .use_instance_columns(1);
-    build(&mut builder);
+
+    if expect_satisfied {
+        build(&mut builder);
+    } else {
+        crate::utils::with_debug_asserts_disabled(|| build(&mut builder));
+    }
 
     let params = builder.calculate_params(Some(32768));
     // This scaffold intentionally checks for one phase-0 lookup column so tests
@@ -168,10 +175,10 @@ fn ext_from_base_const_rejects_constant_family_pranks() {
         run_mock(false, move |builder| {
             let range = builder.range_chip();
             let ctx = builder.main(0);
-            let ext_chip = BabyBearExtChip::new(BabyBearChip::new(&range));
+            let ext_chip = BabyBearExtChip::new(Arc::new(BabyBearChip::new(Arc::new(range.clone()))));
             let ext = ext_chip.from_base_const(ctx, ChildF::from_u64(constant));
             ext.0[0]
-                .0
+                .value
                 .debug_prank(ctx, Fr::from((constant + 1) % BABY_BEAR_MODULUS_U64));
             // `load_constant` no longer creates lookup rows; add a tiny lookup so
             // `run_mock` still validates the expected phase-0 lookup shape.

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod witness;
 
+use std::sync::Arc;
+
 use core::iter::{once, zip};
 
 use halo2_base::{
@@ -782,13 +784,13 @@ fn bind_sample_ext(ctx: &mut Context<Fr>, cursor: &mut SampleCursor<'_>, target:
             ctx.constrain_equal(&zero, &one);
             zero
         });
-        ctx.constrain_equal(&coeff.0, &sampled);
+        ctx.constrain_equal(&coeff.value, &sampled);
     }
 }
 
 fn derive_u_cube_from_stacked_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     l_skip: usize,
     stacked_u: &[BabyBearExtWire],
 ) -> Vec<BabyBearExtWire> {
@@ -799,7 +801,7 @@ fn derive_u_cube_from_stacked_assigned(
     let mut power = stacked_u.first().copied().unwrap_or(zero_ext);
     for _ in 0..l_skip {
         derived_u_cube.push(power);
-        power = ext_chip.square(ctx, &power);
+        power = ext_chip.square(ctx, power);
     }
     derived_u_cube.extend(stacked_u.iter().skip(1).copied());
     derived_u_cube
@@ -807,7 +809,7 @@ fn derive_u_cube_from_stacked_assigned(
 
 fn push_ext_observe_cells(observes: &mut Vec<AssignedValue<Fr>>, value: &BabyBearExtWire) {
     for coeff in &value.0 {
-        observes.push(coeff.0);
+        observes.push(coeff.value);
     }
 }
 
@@ -842,10 +844,10 @@ fn derive_stage_payload_observe_cells(
 ) -> Vec<AssignedValue<Fr>> {
     let mut observes = Vec::new();
     let zero = ctx.load_constant(Fr::from(0u64));
-    let ext_chip = BabyBearExtChip::new(BabyBearChip::new(range));
+    let ext_chip = BabyBearExtChip::new(Arc::new(BabyBearChip::new(Arc::new(range.clone()))));
     let zero_ext = ext_chip.zero(ctx);
     if schedule.logup_pow_bits > 0 {
-        observes.push(batch.logup_pow_witness.0);
+        observes.push(batch.logup_pow_witness.value);
     }
 
     if schedule.has_gkr_observe_payload {
@@ -958,7 +960,7 @@ fn derive_stage_payload_observe_cells(
     }
 
     if schedule.mu_pow_bits > 0 {
-        observes.push(whir.mu_pow_witness.0);
+        observes.push(whir.mu_pow_witness.value);
     }
     let mut sumcheck_cursor = 0usize;
     let mut folding_pow_cursor = 0usize;
@@ -984,7 +986,7 @@ fn derive_stage_payload_observe_cells(
                     .get(folding_pow_cursor)
                     .copied()
                     .unwrap_or(ext_chip.base().zero(ctx));
-                observes.push(pow_witness.0);
+                observes.push(pow_witness.value);
             }
             sumcheck_cursor += 1;
             folding_pow_cursor += 1;
@@ -1003,7 +1005,7 @@ fn derive_stage_payload_observe_cells(
                 .unwrap_or(zero);
             let root_limbs = split_assigned_bn254_to_babybear_limbs(ctx, range, codeword_root);
             for limb in root_limbs {
-                observes.push(limb.0);
+                observes.push(limb.value);
             }
             let ood = whir.ood_values.get(round_idx).unwrap_or(&zero_ext);
             push_ext_observe_cells(&mut observes, ood);
@@ -1015,7 +1017,7 @@ fn derive_stage_payload_observe_cells(
                 .get(round_idx)
                 .copied()
                 .unwrap_or(ext_chip.base().zero(ctx));
-            observes.push(pow_witness.0);
+            observes.push(pow_witness.value);
         }
     }
 
@@ -1398,10 +1400,10 @@ fn derive_preamble_observe_cells_from_stage(
     let common_main_commit_limbs =
         split_assigned_bn254_to_babybear_limbs(ctx, range, statement_public_inputs[1]);
     for limb in pre_hash_limbs {
-        observes.push(limb.0);
+        observes.push(limb.value);
     }
     for limb in common_main_commit_limbs {
-        observes.push(limb.0);
+        observes.push(limb.value);
     }
 
     let (preprocessed_roots_by_air, cached_roots_by_air) = map_initial_commitment_roots_by_air(
@@ -1429,7 +1431,7 @@ fn derive_preamble_observe_cells_from_stage(
 
                 let root_limbs = split_assigned_bn254_to_babybear_limbs(ctx, range, root);
                 for limb in root_limbs {
-                    observes.push(limb.0);
+                    observes.push(limb.value);
                 }
             } else {
                 observes.push(proof_shape.air_log_heights[air_idx]);
@@ -1438,13 +1440,13 @@ fn derive_preamble_observe_cells_from_stage(
             for &cached_root in &cached_roots_by_air[air_idx] {
                 let cached_limbs = split_assigned_bn254_to_babybear_limbs(ctx, range, cached_root);
                 for limb in cached_limbs {
-                    observes.push(limb.0);
+                    observes.push(limb.value);
                 }
             }
         }
 
         for pv in &batch.public_values[air_idx] {
-            observes.push(pv.0);
+            observes.push(pv.value);
         }
     }
 
@@ -1756,8 +1758,8 @@ pub(crate) fn constrain_pipeline_intermediates(
     // replay-owned, and schedule metadata is bound through a transcript-derived public
     // commitment.
     let gate = range.gate();
-    let base_chip = BabyBearChip::new(range);
-    let ext_chip = BabyBearExtChip::new(base_chip);
+    let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
+    let ext_chip = BabyBearExtChip::new(base_chip.clone());
     let zero_ext = ext_chip.zero(ctx);
     let zero_cell = ctx.load_constant(Fr::from(0u64));
 
@@ -2120,7 +2122,7 @@ pub(crate) fn constrain_pipeline_intermediates(
             .get(gkr_xi_len - 1)
             .copied()
             .unwrap_or(zero_ext);
-        ext_chip.assert_equal(ctx, &xi_0, &gkr_last);
+        ext_chip.assert_equal(ctx, xi_0, gkr_last);
         for idx in 1..gkr_xi_len {
             let xi_val = batch.xi.get(idx).copied().unwrap_or(zero_ext);
             let gkr_prev = batch
@@ -2128,7 +2130,7 @@ pub(crate) fn constrain_pipeline_intermediates(
                 .get(idx - 1)
                 .copied()
                 .unwrap_or(zero_ext);
-            ext_chip.assert_equal(ctx, &xi_val, &gkr_prev);
+            ext_chip.assert_equal(ctx, xi_val, gkr_prev);
         }
     }
     for xi_challenge in batch.xi.iter().skip(gkr_xi_len) {

--- a/crates/static-verifier/src/stages/full_pipeline/tests.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/tests.rs
@@ -62,20 +62,18 @@ fn run_mock(
         .use_lookup_bits(END_TO_END_LOOKUP_BITS)
         .use_instance_columns(1);
 
-    // Build-time assertions (e.g. deterministic metadata checks) may panic for
-    // tampered inputs.  When `expect_satisfied == false` a build-time panic is
-    // an acceptable rejection mechanism, equivalent to a circuit constraint
-    // violation.
-    let build_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    if expect_satisfied {
         build(&mut builder);
-    }));
-    if !expect_satisfied {
+    } else {
+        // Disable guarded debug assertions in BabyBearChip, and catch host-side
+        // panics (e.g. deterministic metadata shape checks) that fire before the
+        // MockProver can verify constraints.
+        let build_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            crate::utils::with_debug_asserts_disabled(|| build(&mut builder));
+        }));
         if build_result.is_err() {
-            // Build-time assertion caught the tampered input.
             return;
         }
-    } else {
-        build_result.expect("circuit build should not panic for valid inputs");
     }
 
     let params = builder.calculate_params(Some(END_TO_END_MIN_ROWS));

--- a/crates/static-verifier/src/stages/proof_shape/mod.rs
+++ b/crates/static-verifier/src/stages/proof_shape/mod.rs
@@ -903,7 +903,7 @@ pub fn derive_proof_shape_ownership_schedule(
 
 pub(crate) fn constrain_proof_shape_intermediates_with_ownership(
     ctx: &mut Context<Fr>,
-    base_chip: &BabyBearChip<'_>,
+    base_chip: &BabyBearChip,
     actual: &ProofShapeIntermediates,
     ownership_schedule: Option<&ProofShapeOwnershipSchedule>,
 ) -> AssignedProofShapeIntermediates {
@@ -1217,7 +1217,7 @@ pub(crate) fn constrain_proof_shape_intermediates_with_ownership(
 
 pub fn derive_and_constrain_proof_shape(
     ctx: &mut Context<Fr>,
-    base_chip: &BabyBearChip<'_>,
+    base_chip: &BabyBearChip,
     config: &NativeConfig,
     mvk: &MultiStarkVerifyingKey<NativeConfig>,
     proof: &Proof<NativeConfig>,
@@ -1245,7 +1245,7 @@ pub(crate) fn derive_raw_proof_shape_witness_state(
 
 pub(crate) fn constrain_checked_proof_shape_witness_state_with_ownership(
     ctx: &mut Context<Fr>,
-    base_chip: &BabyBearChip<'_>,
+    base_chip: &BabyBearChip,
     raw: &RawProofShapeWitnessState,
     ownership_schedule: Option<&ProofShapeOwnershipSchedule>,
 ) -> CheckedProofShapeWitnessState {

--- a/crates/static-verifier/src/stages/proof_shape/tests.rs
+++ b/crates/static-verifier/src/stages/proof_shape/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use halo2_base::{
     gates::{
         circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
@@ -32,7 +34,7 @@ fn constrain_proof_shape_intermediates(
     range: &RangeChip<Fr>,
     actual: &ProofShapeIntermediates,
 ) -> AssignedProofShapeIntermediates {
-    let base_chip = BabyBearChip::new(range);
+    let base_chip = BabyBearChip::new(Arc::new(range.clone()));
     constrain_proof_shape_intermediates_with_ownership(ctx, &base_chip, actual, None)
 }
 
@@ -88,7 +90,7 @@ where
     run_mock(true, move |builder| {
         let range = builder.range_chip();
         let ctx = builder.main(0);
-        let base_chip = BabyBearChip::new(&range);
+        let base_chip = BabyBearChip::new(Arc::new(range.clone()));
         let assigned =
             derive_and_constrain_proof_shape(ctx, &base_chip, engine.config(), &vk, &proof)
                 .expect("proof-shape derive+constrain should succeed");

--- a/crates/static-verifier/src/stages/shared_math.rs
+++ b/crates/static-verifier/src/stages/shared_math.rs
@@ -7,7 +7,7 @@ pub(crate) type BabyBearExtWire = crate::field::baby_bear::BabyBearExtWire;
 
 pub(crate) fn column_openings_by_rot_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     openings: &[BabyBearExtWire],
     need_rot: bool,
 ) -> Vec<(BabyBearExtWire, BabyBearExtWire)> {
@@ -31,21 +31,21 @@ pub(crate) fn column_openings_by_rot_assigned(
 
 pub(crate) fn horner_eval_ext_poly_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     coeffs: &[BabyBearExtWire],
     x: &BabyBearExtWire,
 ) -> BabyBearExtWire {
     let mut acc = ext_chip.zero(ctx);
     for coeff in coeffs.iter().rev() {
-        acc = ext_chip.mul(ctx, &acc, x);
-        acc = ext_chip.add(ctx, &acc, coeff);
+        acc = ext_chip.mul(ctx, acc, *x);
+        acc = ext_chip.add(ctx, acc, *coeff);
     }
     acc
 }
 
 pub(crate) fn interpolate_quadratic_at_012_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     evals: [&BabyBearExtWire; 3],
     x: &BabyBearExtWire,
 ) -> BabyBearExtWire {
@@ -53,19 +53,19 @@ pub(crate) fn interpolate_quadratic_at_012_assigned(
     let two = ext_chip.from_base_const(ctx, ChildF::TWO);
     let inv_two = ChildF::ONE.halve();
 
-    let x_minus_one = ext_chip.sub(ctx, x, &one);
-    let x_minus_two = ext_chip.sub(ctx, x, &two);
-    let x_times_x_minus_one = ext_chip.mul(ctx, x, &x_minus_one);
-    let x_times_x_minus_two = ext_chip.mul(ctx, x, &x_minus_two);
-    let x_minus_one_times_x_minus_two = ext_chip.mul(ctx, &x_minus_one, &x_minus_two);
+    let x_minus_one = ext_chip.sub(ctx, *x, one);
+    let x_minus_two = ext_chip.sub(ctx, *x, two);
+    let x_times_x_minus_one = ext_chip.mul(ctx, *x, x_minus_one);
+    let x_times_x_minus_two = ext_chip.mul(ctx, *x, x_minus_two);
+    let x_minus_one_times_x_minus_two = ext_chip.mul(ctx, x_minus_one, x_minus_two);
 
-    let l0 = ext_chip.mul_base_const(ctx, &x_minus_one_times_x_minus_two, inv_two);
-    let l1 = ext_chip.neg(ctx, &x_times_x_minus_two);
-    let l2 = ext_chip.mul_base_const(ctx, &x_times_x_minus_one, inv_two);
+    let l0 = ext_chip.mul_base_const(ctx, x_minus_one_times_x_minus_two, inv_two);
+    let l1 = ext_chip.neg(ctx, x_times_x_minus_two);
+    let l2 = ext_chip.mul_base_const(ctx, x_times_x_minus_one, inv_two);
 
-    let term0 = ext_chip.mul(ctx, evals[0], &l0);
-    let term1 = ext_chip.mul(ctx, evals[1], &l1);
-    let term2 = ext_chip.mul(ctx, evals[2], &l2);
-    let sum01 = ext_chip.add(ctx, &term0, &term1);
-    ext_chip.add(ctx, &sum01, &term2)
+    let term0 = ext_chip.mul(ctx, *evals[0], l0);
+    let term1 = ext_chip.mul(ctx, *evals[1], l1);
+    let term2 = ext_chip.mul(ctx, *evals[2], l2);
+    let sum01 = ext_chip.add(ctx, term0, term1);
+    ext_chip.add(ctx, sum01, term2)
 }

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -368,7 +368,7 @@ pub fn derive_stacked_reduction_intermediates(
 
 fn assign_ext(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     value: ChildEF,
 ) -> BabyBearExtWire {
     ext_chip.load_witness(ctx, value)
@@ -376,10 +376,10 @@ fn assign_ext(
 
 fn eval_in_uni_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     l_skip: usize,
     n: isize,
-    z: &BabyBearExtWire,
+    z: BabyBearExtWire,
 ) -> BabyBearExtWire {
     if n.is_negative() {
         let z_pow = ext_chip.pow_power_of_two(ctx, z, l_skip.wrapping_add_signed(n));
@@ -391,7 +391,7 @@ fn eval_in_uni_assigned(
 
 pub(crate) fn constrain_stacked_reduction_intermediates_with_shared_inputs(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     actual: &StackedReductionIntermediates,
     shared_batch_column_openings: Option<&[Vec<Vec<BabyBearExtWire>>]>,
     shared_r: Option<&[BabyBearExtWire]>,
@@ -553,36 +553,36 @@ pub(crate) fn constrain_stacked_reduction_intermediates_with_shared_inputs(
         "all non-common commitments must be consumed when deriving t-claims",
     );
 
-    let lambda_sqr = ext_chip.mul(ctx, &lambda, &lambda);
+    let lambda_sqr = ext_chip.mul(ctx, lambda, lambda);
     let mut lambda_sqr_powers = Vec::with_capacity(t_claims.len());
     let mut cur_lambda_sqr = ext_chip.from_base_const(ctx, ChildF::from_u64(1));
     for _ in 0..t_claims.len() {
         lambda_sqr_powers.push(cur_lambda_sqr);
-        cur_lambda_sqr = ext_chip.mul(ctx, &cur_lambda_sqr, &lambda_sqr);
+        cur_lambda_sqr = ext_chip.mul(ctx, cur_lambda_sqr, lambda_sqr);
     }
     let mut derived_s_0 = ext_chip.zero(ctx);
     for ((claim, claim_rot), lambda_pow) in t_claims.iter().zip(lambda_sqr_powers.iter()) {
-        let claim_rot_lambda = ext_chip.mul(ctx, claim_rot, &lambda);
-        let batched_claim = ext_chip.add(ctx, claim, &claim_rot_lambda);
-        let term = ext_chip.mul(ctx, &batched_claim, lambda_pow);
-        derived_s_0 = ext_chip.add(ctx, &derived_s_0, &term);
+        let claim_rot_lambda = ext_chip.mul(ctx, *claim_rot, lambda);
+        let batched_claim = ext_chip.add(ctx, *claim, claim_rot_lambda);
+        let term = ext_chip.mul(ctx, batched_claim, *lambda_pow);
+        derived_s_0 = ext_chip.add(ctx, derived_s_0, term);
     }
-    ext_chip.assert_equal(ctx, &derived_s_0, &s_0);
+    ext_chip.assert_equal(ctx, derived_s_0, s_0);
 
     let s_0_sum_eval = assign_ext(ctx, ext_chip, actual.s_0_sum_eval);
     let stride = 1usize << actual.l_skip;
     let mut derived_s_0_sum_eval = ext_chip.zero(ctx);
     for coeff in univariate_round_coeffs.iter().step_by(stride) {
-        derived_s_0_sum_eval = ext_chip.add(ctx, &derived_s_0_sum_eval, coeff);
+        derived_s_0_sum_eval = ext_chip.add(ctx, derived_s_0_sum_eval, *coeff);
     }
     let derived_s_0_sum_eval =
-        ext_chip.mul_base_const(ctx, &derived_s_0_sum_eval, ChildF::from_u64(stride as u64));
-    ext_chip.assert_equal(ctx, &derived_s_0_sum_eval, &s_0_sum_eval);
+        ext_chip.mul_base_const(ctx, derived_s_0_sum_eval, ChildF::from_u64(stride as u64));
+    ext_chip.assert_equal(ctx, derived_s_0_sum_eval, s_0_sum_eval);
 
     let s_0_residual = assign_ext(ctx, ext_chip, actual.s_0_residual);
     // Equation-first check: s_0_residual = s_0 - s_0_sum_eval.
-    let derived_s_0_residual = ext_chip.sub(ctx, &s_0, &s_0_sum_eval);
-    ext_chip.assert_equal(ctx, &derived_s_0_residual, &s_0_residual);
+    let derived_s_0_residual = ext_chip.sub(ctx, s_0, s_0_sum_eval);
+    ext_chip.assert_equal(ctx, derived_s_0_residual, s_0_residual);
 
     assert!(
         !univariate_round_coeffs.is_empty(),
@@ -605,7 +605,7 @@ pub(crate) fn constrain_stacked_reduction_intermediates_with_shared_inputs(
         );
         let s_j_1 = &round_poly[0];
         let s_j_2 = &round_poly[1];
-        let s_j_0 = ext_chip.sub(ctx, &derived_claim, s_j_1);
+        let s_j_0 = ext_chip.sub(ctx, derived_claim, *s_j_1);
         derived_claim = interpolate_quadratic_at_012_assigned(
             ctx,
             ext_chip,
@@ -613,7 +613,7 @@ pub(crate) fn constrain_stacked_reduction_intermediates_with_shared_inputs(
             &u[round_idx + 1],
         );
     }
-    ext_chip.assert_equal(ctx, &derived_claim, &final_claim);
+    ext_chip.assert_equal(ctx, derived_claim, final_claim);
 
     let final_sum = assign_ext(ctx, ext_chip, actual.final_sum);
     let mut derived_q_coeffs = actual
@@ -640,54 +640,54 @@ pub(crate) fn constrain_stacked_reduction_intermediates_with_shared_inputs(
             "q-coeff lambda index out of bounds",
         );
         let eq_mle = eval_eq_mle_binary_assigned(ctx, ext_chip, &u[n_lift + 1..], &term.b_bits);
-        let ind = eval_in_uni_assigned(ctx, ext_chip, actual.l_skip, term.n, &u[0]);
+        let ind = eval_in_uni_assigned(ctx, ext_chip, actual.l_skip, term.n, u[0]);
         let (l, rs_n) = if term.n.is_negative() {
             (
                 actual.l_skip.wrapping_add_signed(term.n),
-                vec![ext_chip.pow_power_of_two(ctx, &r[0], term.n.unsigned_abs())],
+                vec![ext_chip.pow_power_of_two(ctx, r[0], term.n.unsigned_abs())],
             )
         } else {
             (actual.l_skip, r[..=n_lift].to_vec())
         };
         let eq_prism = eval_eq_prism_assigned(ctx, ext_chip, l, &u[..=n_lift], &rs_n);
-        let mut batched = ext_chip.mul(ctx, &lambda_sqr_powers[term.lambda_idx], &eq_prism);
+        let mut batched = ext_chip.mul(ctx, lambda_sqr_powers[term.lambda_idx], eq_prism);
         if term.need_rot {
             let rot_kernel = eval_rot_kernel_prism_assigned(ctx, ext_chip, l, &u[..=n_lift], &rs_n);
-            let lambda_rot = ext_chip.mul(ctx, &lambda, &rot_kernel);
-            let rot_term = ext_chip.mul(ctx, &lambda_sqr_powers[term.lambda_idx], &lambda_rot);
-            batched = ext_chip.add(ctx, &batched, &rot_term);
+            let lambda_rot = ext_chip.mul(ctx, lambda, rot_kernel);
+            let rot_term = ext_chip.mul(ctx, lambda_sqr_powers[term.lambda_idx], lambda_rot);
+            batched = ext_chip.add(ctx, batched, rot_term);
         }
-        let batched_ind = ext_chip.mul(ctx, &batched, &ind);
-        let coeff = ext_chip.mul(ctx, &eq_mle, &batched_ind);
+        let batched_ind = ext_chip.mul(ctx, batched, ind);
+        let coeff = ext_chip.mul(ctx, eq_mle, batched_ind);
         let updated = ext_chip.add(
             ctx,
-            &derived_q_coeffs[term.commit_idx][term.target_col_idx],
-            &coeff,
+            derived_q_coeffs[term.commit_idx][term.target_col_idx],
+            coeff,
         );
         derived_q_coeffs[term.commit_idx][term.target_col_idx] = updated;
     }
     for (derived_row, assigned_row) in derived_q_coeffs.iter().zip(q_coeffs.iter()) {
         for (derived_coeff, assigned_coeff) in derived_row.iter().zip(assigned_row.iter()) {
-            ext_chip.assert_equal(ctx, derived_coeff, assigned_coeff);
+            ext_chip.assert_equal(ctx, *derived_coeff, *assigned_coeff);
         }
     }
     let mut derived_final_sum = ext_chip.zero(ctx);
     for (coeff_row, opening_row) in derived_q_coeffs.iter().zip(stacking_openings.iter()) {
         for (coeff, opening) in coeff_row.iter().zip(opening_row.iter()) {
-            let term = ext_chip.mul(ctx, coeff, opening);
-            derived_final_sum = ext_chip.add(ctx, &derived_final_sum, &term);
+            let term = ext_chip.mul(ctx, *coeff, *opening);
+            derived_final_sum = ext_chip.add(ctx, derived_final_sum, term);
         }
     }
-    ext_chip.assert_equal(ctx, &derived_final_sum, &final_sum);
+    ext_chip.assert_equal(ctx, derived_final_sum, final_sum);
 
     let final_residual = assign_ext(ctx, ext_chip, actual.final_residual);
     // Equation-first check: final_residual = final_claim - final_sum.
-    let derived_final_residual = ext_chip.sub(ctx, &final_claim, &final_sum);
-    ext_chip.assert_equal(ctx, &derived_final_residual, &final_residual);
+    let derived_final_residual = ext_chip.sub(ctx, final_claim, final_sum);
+    ext_chip.assert_equal(ctx, derived_final_residual, final_residual);
 
     let zero = ext_chip.zero(ctx);
-    ext_chip.assert_equal(ctx, &s_0_residual, &zero);
-    ext_chip.assert_equal(ctx, &final_residual, &zero);
+    ext_chip.assert_equal(ctx, s_0_residual, zero);
+    ext_chip.assert_equal(ctx, final_residual, zero);
 
     AssignedStackedReductionIntermediates {
         lambda,

--- a/crates/static-verifier/src/stages/stacked_reduction/tests.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use halo2_base::{
     gates::{
         circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
@@ -33,8 +35,8 @@ fn coeffs_to_ext(coeffs: [u64; BABY_BEAR_EXT_DEGREE]) -> ChildEF {
     ChildEF::from_basis_coefficients_fn(|i| ChildF::from_u64(coeffs[i]))
 }
 
-fn make_ext_chip(range: &RangeChip<Fr>) -> BabyBearExtChip<'_> {
-    BabyBearExtChip::new(BabyBearChip::new(range))
+fn make_ext_chip(range: &RangeChip<Fr>) -> BabyBearExtChip {
+    BabyBearExtChip::new(Arc::new(BabyBearChip::new(Arc::new(range.clone()))))
 }
 
 /// Standalone stacked-reduction derive+constrain wrapper is internal; external callers must use
@@ -63,7 +65,7 @@ fn derive_raw_stacked_witness_state(
 
 fn constrain_checked_stacked_witness_state(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     raw: &RawStackedWitnessState,
 ) -> CheckedStackedWitnessState {
     let assigned = constrain_stacked_reduction_intermediates_with_shared_inputs(
@@ -82,7 +84,7 @@ fn constrain_checked_stacked_witness_state(
 
 fn constrain_stacked_reduction_for_test(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     actual: &StackedReductionIntermediates,
 ) -> AssignedStackedReductionIntermediates {
     constrain_stacked_reduction_intermediates_with_shared_inputs(ctx, ext_chip, actual, None, None)
@@ -94,7 +96,12 @@ fn run_mock(expect_satisfied: bool, build: impl FnOnce(&mut BaseCircuitBuilder<F
         .use_k(MOCK_K as usize)
         .use_lookup_bits(8)
         .use_instance_columns(1);
-    build(&mut builder);
+
+    if expect_satisfied {
+        build(&mut builder);
+    } else {
+        crate::utils::with_debug_asserts_disabled(|| build(&mut builder));
+    }
 
     let params = builder.calculate_params(Some(32768));
     assert_eq!(

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -33,7 +33,9 @@ use openvm_stark_sdk::{
 };
 
 use crate::{
-    field::baby_bear::{BabyBearExtChip, BabyBearExtWire, BabyBearWire, BABY_BEAR_EXT_DEGREE},
+    field::baby_bear::{
+        BabyBearExt4Wire, BabyBearExtChip, BabyBearExtWire, BabyBearWire, BABY_BEAR_EXT_DEGREE,
+    },
     hash::poseidon2::{compress_bn254_digests, hash_babybear_slice_to_digest},
     stages::{
         batch_constraints::{eval_eq_mle_assigned, BatchConstraintError},
@@ -661,7 +663,7 @@ pub fn derive_whir_intermediates(
 
 fn assign_ext(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     value: ChildEF,
 ) -> BabyBearExtWire {
     ext_chip.load_witness(ctx, value)
@@ -669,7 +671,7 @@ fn assign_ext(
 
 fn eval_mobius_eq_mle_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     u: &[BabyBearExtWire],
     x: &[BabyBearExtWire],
 ) -> BabyBearExtWire {
@@ -677,20 +679,20 @@ fn eval_mobius_eq_mle_assigned(
     let one = ext_chip.from_base_const(ctx, ChildF::ONE);
     let mut acc = one;
     for (u_i, x_i) in u.iter().zip(x.iter()) {
-        let two_u = ext_chip.mul_base_const(ctx, u_i, ChildF::TWO);
-        let w0 = ext_chip.sub(ctx, &one, &two_u);
-        let one_minus_x = ext_chip.sub(ctx, &one, x_i);
-        let left = ext_chip.mul(ctx, &w0, &one_minus_x);
-        let right = ext_chip.mul(ctx, u_i, x_i);
-        let factor = ext_chip.add(ctx, &left, &right);
-        acc = ext_chip.mul(ctx, &acc, &factor);
+        let two_u = ext_chip.mul_base_const(ctx, *u_i, ChildF::TWO);
+        let w0 = ext_chip.sub(ctx, one, two_u);
+        let one_minus_x = ext_chip.sub(ctx, one, *x_i);
+        let left = ext_chip.mul(ctx, w0, one_minus_x);
+        let right = ext_chip.mul(ctx, *u_i, *x_i);
+        let factor = ext_chip.add(ctx, left, right);
+        acc = ext_chip.mul(ctx, acc, factor);
     }
     acc
 }
 
 fn eval_mle_evals_at_point_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     evals: &[BabyBearExtWire],
     x: &[BabyBearExtWire],
 ) -> BabyBearExtWire {
@@ -704,13 +706,13 @@ fn eval_mle_evals_at_point_assigned(
     let mut len = values.len();
     for xj in x.iter().rev() {
         len >>= 1;
-        let one_minus_xj = ext_chip.sub(ctx, &one, xj);
+        let one_minus_xj = ext_chip.sub(ctx, one, *xj);
         for i in 0..len {
             let lo = values[i];
             let hi = values[i + len];
-            let lo_term = ext_chip.mul(ctx, &lo, &one_minus_xj);
-            let hi_term = ext_chip.mul(ctx, &hi, xj);
-            values[i] = ext_chip.add(ctx, &lo_term, &hi_term);
+            let lo_term = ext_chip.mul(ctx, lo, one_minus_xj);
+            let hi_term = ext_chip.mul(ctx, hi, *xj);
+            values[i] = ext_chip.add(ctx, lo_term, hi_term);
         }
     }
     values
@@ -721,22 +723,22 @@ fn eval_mle_evals_at_point_assigned(
 
 fn invert_base_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
-    value: &BabyBearWire,
+    ext_chip: &BabyBearExtChip,
+    value: BabyBearWire,
 ) -> BabyBearWire {
     let value_u64 = value.as_u64();
     assert!(value_u64 != 0, "cannot invert zero BabyBear value");
     let inv_u64 = ChildF::from_u64(value_u64).inverse().as_canonical_u64();
     let inv = ext_chip.base().load_witness(ctx, ChildF::from_u64(inv_u64));
     let one = ext_chip.base().one(ctx);
-    let check = ext_chip.base().mul(ctx, value, &inv);
-    ext_chip.base().assert_equal(ctx, &check, &one);
+    let check = ext_chip.base().mul(ctx, value, inv);
+    ext_chip.base().assert_equal(ctx, check, one);
     inv
 }
 
 fn query_root_from_bits_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     query_bits: &[AssignedValue<Fr>],
     log_rs_domain_size: usize,
 ) -> BabyBearWire {
@@ -750,18 +752,18 @@ fn query_root_from_bits_assigned(
         let bit_times_pow = gate.mul(ctx, bit, omega_pow_const);
         let one_minus_bit = gate.sub(ctx, one, bit);
         let rhs = gate.add(ctx, bit_times_pow, one_minus_bit);
-        let selected = BabyBearWire(rhs);
-        root = ext_chip.base().mul(ctx, &root, &selected);
+        let selected = BabyBearWire { value: rhs, max_bits: crate::field::baby_bear::BABYBEAR_MAX_BITS };
+        root = ext_chip.base().mul(ctx, root, selected);
     }
     root
 }
 
 fn binary_k_fold_assigned(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     mut values: Vec<BabyBearExtWire>,
     alphas: &[BabyBearExtWire],
-    x: &BabyBearWire,
+    x: BabyBearWire,
 ) -> BabyBearExtWire {
     let n = values.len();
     assert_eq!(
@@ -780,36 +782,36 @@ fn binary_k_fold_assigned(
     let inv_tw = omega_k_inv.powers().take(1usize << (k - 1)).collect();
     let half = ChildF::ONE.halve();
 
-    let mut x_pow = *x;
+    let mut x_pow = x;
     let x_inv = invert_base_assigned(ctx, ext_chip, x);
     let mut x_inv_pow = x_inv;
 
     for (j, alpha) in alphas.iter().enumerate() {
         let m = n >> (j + 1);
         for i in 0..m {
-            let t = ext_chip.base().mul_const(ctx, &x_pow, tw[i << j]);
-            let t_inv = ext_chip.base().mul_const(ctx, &x_inv_pow, inv_tw[i << j]);
-            let t_inv_half = ext_chip.base().mul_const(ctx, &t_inv, half);
+            let t = ext_chip.base().mul_const(ctx, x_pow, tw[i << j]);
+            let t_inv = ext_chip.base().mul_const(ctx, x_inv_pow, inv_tw[i << j]);
+            let t_inv_half = ext_chip.base().mul_const(ctx, t_inv, half);
 
             let lo = values[i];
             let hi = values[i + m];
-            let lo_minus_hi = ext_chip.sub(ctx, &lo, &hi);
-            let t_ext = ext_chip.from_base_var(ctx, &t);
-            let alpha_minus_t = ext_chip.sub(ctx, alpha, &t_ext);
-            let fold = ext_chip.mul(ctx, &alpha_minus_t, &lo_minus_hi);
-            let t_inv_half_ext = ext_chip.from_base_var(ctx, &t_inv_half);
-            let fold = ext_chip.mul(ctx, &fold, &t_inv_half_ext);
-            values[i] = ext_chip.add(ctx, &lo, &fold);
+            let lo_minus_hi = ext_chip.sub(ctx, lo, hi);
+            let t_ext = ext_chip.from_base_var(ctx, t);
+            let alpha_minus_t = ext_chip.sub(ctx, *alpha, t_ext);
+            let fold = ext_chip.mul(ctx, alpha_minus_t, lo_minus_hi);
+            let t_inv_half_ext = ext_chip.from_base_var(ctx, t_inv_half);
+            let fold = ext_chip.mul(ctx, fold, t_inv_half_ext);
+            values[i] = ext_chip.add(ctx, lo, fold);
         }
-        x_pow = ext_chip.base().square(ctx, &x_pow);
-        x_inv_pow = ext_chip.base().square(ctx, &x_inv_pow);
+        x_pow = ext_chip.base().square(ctx, x_pow);
+        x_inv_pow = ext_chip.base().square(ctx, x_inv_pow);
     }
     values[0]
 }
 
 fn tree_compress_assigned_digests(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     digests: Vec<AssignedValue<Fr>>,
 ) -> AssignedValue<Fr> {
     assert!(
@@ -848,7 +850,7 @@ pub(crate) struct SharedWhirWitnessInputs<'a> {
 
 fn constrain_merkle_path(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     query_bits: &[AssignedValue<Fr>],
     leaf_inputs: &[Vec<u64>],
     siblings: &[Fr],
@@ -904,7 +906,7 @@ fn constrain_merkle_path(
 
 pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     actual: &WhirIntermediates,
     shared: SharedWhirWitnessInputs<'_>,
 ) -> AssignedWhirIntermediates {
@@ -1458,15 +1460,15 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
     let mut mu_pow = one;
     for _ in 0..total_width {
         mu_pows.push(mu_pow);
-        mu_pow = ext_chip.mul(ctx, &mu_pow, &mu_challenge);
+        mu_pow = ext_chip.mul(ctx, mu_pow, mu_challenge);
     }
 
     let mut derived_claim = ext_chip.zero(ctx);
     let mut mu_idx = 0usize;
     for commit_openings in &stacking_openings {
         for opening in commit_openings {
-            let weighted = ext_chip.mul(ctx, opening, &mu_pows[mu_idx]);
-            derived_claim = ext_chip.add(ctx, &derived_claim, &weighted);
+            let weighted = ext_chip.mul(ctx, *opening, mu_pows[mu_idx]);
+            derived_claim = ext_chip.add(ctx, derived_claim, weighted);
             mu_idx += 1;
         }
     }
@@ -1504,7 +1506,7 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
                 .and_then(|round| round.get(1))
                 .copied()
                 .unwrap_or(zero);
-            let ev0 = ext_chip.sub(ctx, &derived_claim, &ev1);
+            let ev0 = ext_chip.sub(ctx, derived_claim, ev1);
             derived_claim =
                 interpolate_quadratic_at_012_assigned(ctx, ext_chip, [&ev0, &ev1, &ev2], alpha);
             sumcheck_cursor += 1;
@@ -1540,8 +1542,8 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
                 &query_bit_source.query_bits,
                 log_rs_domain_size,
             );
-            let zi_root_ext = ext_chip.from_base_var(ctx, &zi_root_base);
-            let zi = ext_chip.pow_power_of_two(ctx, &zi_root_ext, actual.k_whir);
+            let zi_root_ext = ext_chip.from_base_var(ctx, zi_root_base);
+            let zi = ext_chip.pow_power_of_two(ctx, zi_root_ext, actual.k_whir);
             zs_round.push(zi);
 
             let yi = if round_idx == 0 {
@@ -1582,10 +1584,10 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
                         let mu_pow = &mu_pows[mu_power_idx];
                         for (row_idx, row) in payload.leaf_values.iter().enumerate() {
                             let opened_base = row.get(col_idx).copied().unwrap_or(zero_base);
-                            let opened_ext = ext_chip.from_base_var(ctx, &opened_base);
-                            let weighted = ext_chip.mul(ctx, &opened_ext, mu_pow);
+                            let opened_ext = ext_chip.from_base_var(ctx, opened_base);
+                            let weighted = ext_chip.mul(ctx, opened_ext, *mu_pow);
                             codeword_vals[row_idx] =
-                                ext_chip.add(ctx, &codeword_vals[row_idx], &weighted);
+                                ext_chip.add(ctx, codeword_vals[row_idx], weighted);
                         }
                         mu_power_idx += 1;
                     }
@@ -1598,7 +1600,7 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
                     &Fr::from(usize_to_u64(mu_pows.len())),
                 );
                 payload_cursor += stacking_openings.len();
-                binary_k_fold_assigned(ctx, ext_chip, codeword_vals, alphas_round, &zi_root_base)
+                binary_k_fold_assigned(ctx, ext_chip, codeword_vals, alphas_round, zi_root_base)
             } else {
                 let payload = merkle_payloads
                     .get(payload_cursor)
@@ -1622,12 +1624,12 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
                             &row_width,
                             &Fr::from(usize_to_u64(BABY_BEAR_EXT_DEGREE)),
                         );
-                        BabyBearExtWire(core::array::from_fn(|idx| {
+                        BabyBearExt4Wire(core::array::from_fn(|idx| {
                             row.get(idx).copied().unwrap_or(zero_base)
                         }))
                     })
                     .collect::<Vec<_>>();
-                binary_k_fold_assigned(ctx, ext_chip, opened_values, alphas_round, &zi_root_base)
+                binary_k_fold_assigned(ctx, ext_chip, opened_values, alphas_round, zi_root_base)
             };
             ys_round.push(yi);
             query_cursor += 1;
@@ -1635,14 +1637,14 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
 
         let gamma = &gammas[round_idx];
         if round_idx + 1 != actual.query_counts_per_round.len() {
-            let y0_term = ext_chip.mul(ctx, &ood_values[round_idx], gamma);
-            derived_claim = ext_chip.add(ctx, &derived_claim, &y0_term);
+            let y0_term = ext_chip.mul(ctx, ood_values[round_idx], *gamma);
+            derived_claim = ext_chip.add(ctx, derived_claim, y0_term);
         }
-        let mut gamma_pow = ext_chip.mul(ctx, gamma, gamma);
+        let mut gamma_pow = ext_chip.mul(ctx, *gamma, *gamma);
         for yi in &ys_round {
-            let term = ext_chip.mul(ctx, yi, &gamma_pow);
-            derived_claim = ext_chip.add(ctx, &derived_claim, &term);
-            gamma_pow = ext_chip.mul(ctx, &gamma_pow, gamma);
+            let term = ext_chip.mul(ctx, *yi, gamma_pow);
+            derived_claim = ext_chip.add(ctx, derived_claim, term);
+            gamma_pow = ext_chip.mul(ctx, gamma_pow, *gamma);
         }
 
         zs_per_round.push(zs_round);
@@ -1673,7 +1675,7 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
         &consumed_query_count,
         &Fr::from(usize_to_u64(query_indices.len())),
     );
-    ext_chip.assert_equal(ctx, &derived_claim, &final_claim);
+    ext_chip.assert_equal(ctx, derived_claim, final_claim);
 
     let rounds = actual.query_counts_per_round.len();
     let t = actual.k_whir * rounds;
@@ -1687,24 +1689,21 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
     );
     let prefix = eval_mobius_eq_mle_assigned(ctx, ext_chip, &u_cube[..t], &folding_alphas[..t]);
     let suffix = eval_mle_evals_at_point_assigned(ctx, ext_chip, &final_poly, &u_cube[t..]);
-    let mut derived_final_acc = ext_chip.mul(ctx, &prefix, &suffix);
+    let mut derived_final_acc = ext_chip.mul(ctx, prefix, suffix);
 
     let mut alpha_offset = actual.k_whir;
     for round_idx in 0..rounds {
-        let gamma = &gammas[round_idx];
+        let gamma = gammas[round_idx];
         let alpha_slc = &folding_alphas[alpha_offset..t];
         let slc_len = (t - alpha_offset) + 1;
 
         if round_idx + 1 != rounds {
-            let z0 = &z0_challenges[round_idx];
+            let z0 = z0_challenges[round_idx];
             let mut z0_pows = Vec::with_capacity(slc_len);
-            z0_pows.push(*z0);
+            z0_pows.push(z0);
             for _ in 1..slc_len {
-                let next = ext_chip.mul(
-                    ctx,
-                    z0_pows.last().expect("z0 power sequence is non-empty"),
-                    z0_pows.last().expect("z0 power sequence is non-empty"),
-                );
+                let prev = *z0_pows.last().expect("z0 power sequence is non-empty");
+                let next = ext_chip.mul(ctx, prev, prev);
                 z0_pows.push(next);
             }
             let z0_max = z0_pows
@@ -1718,9 +1717,9 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
                 &z0_pows[..z0_pows.len().saturating_sub(1)],
             );
             let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, &final_poly, &z0_max);
-            let term = ext_chip.mul(ctx, gamma, &eq);
-            let term = ext_chip.mul(ctx, &term, &poly_eval);
-            derived_final_acc = ext_chip.add(ctx, &derived_final_acc, &term);
+            let term = ext_chip.mul(ctx, gamma, eq);
+            let term = ext_chip.mul(ctx, term, poly_eval);
+            derived_final_acc = ext_chip.add(ctx, derived_final_acc, term);
         }
 
         let mut gamma_pow = ext_chip.mul(ctx, gamma, gamma);
@@ -1728,11 +1727,8 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
             let mut zi_pows = Vec::with_capacity(slc_len);
             zi_pows.push(*zi);
             for _ in 1..slc_len {
-                let next = ext_chip.mul(
-                    ctx,
-                    zi_pows.last().expect("zi power sequence is non-empty"),
-                    zi_pows.last().expect("zi power sequence is non-empty"),
-                );
+                let prev = *zi_pows.last().expect("zi power sequence is non-empty");
+                let next = ext_chip.mul(ctx, prev, prev);
                 zi_pows.push(next);
             }
             let zi_max = zi_pows
@@ -1746,21 +1742,21 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
                 &zi_pows[..zi_pows.len().saturating_sub(1)],
             );
             let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, &final_poly, &zi_max);
-            let term = ext_chip.mul(ctx, &gamma_pow, &eq);
-            let term = ext_chip.mul(ctx, &term, &poly_eval);
-            derived_final_acc = ext_chip.add(ctx, &derived_final_acc, &term);
-            gamma_pow = ext_chip.mul(ctx, &gamma_pow, gamma);
+            let term = ext_chip.mul(ctx, gamma_pow, eq);
+            let term = ext_chip.mul(ctx, term, poly_eval);
+            derived_final_acc = ext_chip.add(ctx, derived_final_acc, term);
+            gamma_pow = ext_chip.mul(ctx, gamma_pow, gamma);
         }
 
         alpha_offset += actual.k_whir;
     }
-    ext_chip.assert_equal(ctx, &derived_final_acc, &final_acc);
+    ext_chip.assert_equal(ctx, derived_final_acc, final_acc);
 
     let final_residual = assign_ext(ctx, ext_chip, actual.final_residual);
-    let derived_final_residual = ext_chip.sub(ctx, &final_acc, &final_claim);
-    ext_chip.assert_equal(ctx, &derived_final_residual, &final_residual);
+    let derived_final_residual = ext_chip.sub(ctx, final_acc, final_claim);
+    ext_chip.assert_equal(ctx, derived_final_residual, final_residual);
 
-    ext_chip.assert_equal(ctx, &final_residual, &zero);
+    ext_chip.assert_equal(ctx, final_residual, zero);
 
     AssignedWhirIntermediates {
         mu_pow_bits,
@@ -1796,7 +1792,7 @@ pub(crate) fn constrain_whir_intermediates_with_shared_inputs(
 
 pub(crate) fn constrain_checked_whir_witness_state_with_shared_inputs(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     raw: &RawWhirWitnessState,
     shared: SharedWhirWitnessInputs<'_>,
 ) -> CheckedWhirWitnessState {

--- a/crates/static-verifier/src/stages/whir/tests.rs
+++ b/crates/static-verifier/src/stages/whir/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use halo2_base::{
     gates::circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
     halo2_proofs::dev::MockProver,
@@ -35,7 +37,7 @@ struct WhirStrictOwnership {
 // Internal standalone whir wrapper for intra-crate composition/tests.
 fn derive_and_constrain_whir(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     config: &NativeConfig,
     mvk: &MultiStarkVerifyingKey<NativeConfig>,
     proof: &Proof<NativeConfig>,
@@ -76,7 +78,7 @@ fn derive_whir_strict_ownership(
 
 fn constrain_whir_strict_metadata(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     raw: &RawWhirWitnessState,
     assigned: &AssignedWhirIntermediates,
     ownership: &WhirStrictOwnership,
@@ -163,7 +165,7 @@ fn constrain_whir_strict_metadata(
 
 fn constrain_checked_whir_witness_state_strict(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     raw: &RawWhirWitnessState,
     ownership: &WhirStrictOwnership,
 ) -> CheckedWhirWitnessState {
@@ -179,7 +181,7 @@ fn constrain_checked_whir_witness_state_strict(
 
 fn constrain_whir_intermediates_for_test(
     ctx: &mut Context<Fr>,
-    ext_chip: &BabyBearExtChip<'_>,
+    ext_chip: &BabyBearExtChip,
     actual: &WhirIntermediates,
 ) -> AssignedWhirIntermediates {
     constrain_whir_intermediates_with_shared_inputs(
@@ -197,7 +199,12 @@ fn run_mock(expect_satisfied: bool, build: impl FnOnce(&mut BaseCircuitBuilder<F
         .use_k(MOCK_K as usize)
         .use_lookup_bits(8)
         .use_instance_columns(1);
-    build(&mut builder);
+
+    if expect_satisfied {
+        build(&mut builder);
+    } else {
+        crate::utils::with_debug_asserts_disabled(|| build(&mut builder));
+    }
 
     let params = builder.calculate_params(Some(MOCK_MIN_ROWS));
     assert_eq!(
@@ -233,8 +240,8 @@ fn test_engine() -> BabyBearBn254Poseidon2CpuEngine {
     BabyBearBn254Poseidon2CpuEngine::new(test_system_params_small(2, 8, 3))
 }
 
-fn make_ext_chip(range: &halo2_base::gates::range::RangeChip<Fr>) -> BabyBearExtChip<'_> {
-    BabyBearExtChip::new(BabyBearChip::new(range))
+fn make_ext_chip(range: &halo2_base::gates::range::RangeChip<Fr>) -> BabyBearExtChip {
+    BabyBearExtChip::new(Arc::new(BabyBearChip::new(Arc::new(range.clone()))))
 }
 
 #[test]

--- a/crates/static-verifier/src/transcript/mod.rs
+++ b/crates/static-verifier/src/transcript/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use halo2_base::{
     gates::{range::RangeChip, GateInstructions, RangeInstructions},
@@ -21,7 +21,8 @@ use openvm_stark_sdk::{
 
 use crate::{
     field::baby_bear::{
-        BabyBearChip, BabyBearExtWire, BabyBearWire, BABY_BEAR_BITS, BABY_BEAR_MODULUS_U64,
+        BabyBearChip, BabyBearExt4Wire, BabyBearExtWire, BabyBearWire, BABY_BEAR_BITS,
+        BABY_BEAR_MODULUS_U64,
     },
     hash::poseidon2::{
         poseidon2_permute_bn254_state, reduce_32_cells, DIGEST_WIDTH, POSEIDON2_RATE,
@@ -175,7 +176,7 @@ fn decompose_packed_bn254_to_split_limbs(
 fn reduce_assigned_limb_to_babybear(
     ctx: &mut Context<Fr>,
     range: &RangeChip<Fr>,
-    baby_bear: &BabyBearChip<'_>,
+    baby_bear: &BabyBearChip,
     limb: AssignedValue<Fr>,
 ) -> BabyBearWire {
     let limb_u64 = fe_to_biguint(limb.value())
@@ -195,7 +196,7 @@ fn reduce_assigned_limb_to_babybear(
         ctx,
         quotient_cell,
         Constant(Fr::from(BABY_BEAR_MODULUS_U64)),
-        remainder_var.0,
+        remainder_var.value,
     );
     ctx.constrain_equal(&limb, &recomposed);
 
@@ -207,7 +208,7 @@ pub fn split_assigned_bn254_to_babybear_limbs(
     range: &RangeChip<Fr>,
     packed: AssignedValue<Fr>,
 ) -> [BabyBearWire; NUM_SPLIT_LIMBS] {
-    let baby_bear = BabyBearChip::new(range);
+    let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
     let limbs = decompose_packed_bn254_to_split_limbs(ctx, range, packed);
     core::array::from_fn(|idx| reduce_assigned_limb_to_babybear(ctx, range, &baby_bear, limbs[idx]))
 }
@@ -238,7 +239,7 @@ impl TranscriptGadget {
         range: &RangeChip<Fr>,
         values: &[BabyBearWire],
     ) -> AssignedValue<Fr> {
-        let cells = values.iter().map(|value| value.0).collect::<Vec<_>>();
+        let cells = values.iter().map(|value| value.value).collect::<Vec<_>>();
         reduce_32_cells(ctx, range, &cells)
     }
 
@@ -246,7 +247,7 @@ impl TranscriptGadget {
         &self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
         packed: AssignedValue<Fr>,
     ) -> [BabyBearWire; NUM_SPLIT_LIMBS] {
         let limbs = decompose_packed_bn254_to_split_limbs(ctx, range, packed);
@@ -259,7 +260,7 @@ impl TranscriptGadget {
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
     ) {
         assert!(
             self.input_buffer.len() <= NUM_SPLIT_LIMBS * POSEIDON2_RATE,
@@ -284,7 +285,7 @@ impl TranscriptGadget {
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
         value: &BabyBearWire,
     ) {
         self.output_buffer.clear();
@@ -298,7 +299,7 @@ impl TranscriptGadget {
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
         value: &BabyBearExtWire,
     ) {
         for coeff in &value.0 {
@@ -310,7 +311,7 @@ impl TranscriptGadget {
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
         digest: &DigestWire,
     ) {
         for packed in &digest.elems {
@@ -325,7 +326,7 @@ impl TranscriptGadget {
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
     ) -> BabyBearWire {
         if !self.input_buffer.is_empty() || self.output_buffer.is_empty() {
             self.duplexing(ctx, range, baby_bear);
@@ -340,17 +341,17 @@ impl TranscriptGadget {
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
     ) -> BabyBearExtWire {
         let coeffs = core::array::from_fn(|_| self.sample(ctx, range, baby_bear));
-        BabyBearExtWire(coeffs)
+        BabyBearExt4Wire(coeffs)
     }
 
     pub fn sample_bits(
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
         bits: usize,
     ) -> AssignedValue<Fr> {
         assert!(
@@ -367,7 +368,7 @@ impl TranscriptGadget {
             return ctx.load_constant(Fr::from(0u64));
         }
 
-        let (_, rem) = range.div_mod(ctx, sampled.0, BigUint::from(1u64) << bits, BABY_BEAR_BITS);
+        let (_, rem) = range.div_mod(ctx, sampled.value, BigUint::from(1u64) << bits, BABY_BEAR_BITS);
         range.range_check(ctx, rem, bits);
         rem
     }
@@ -376,7 +377,7 @@ impl TranscriptGadget {
         &mut self,
         ctx: &mut Context<Fr>,
         range: &RangeChip<Fr>,
-        baby_bear: &BabyBearChip<'_>,
+        baby_bear: &BabyBearChip,
         bits: usize,
         witness: &BabyBearWire,
     ) -> AssignedValue<Fr> {
@@ -408,7 +409,7 @@ pub fn constrain_transcript_events(
     range: &RangeChip<Fr>,
     events: &[TranscriptEvent],
 ) -> TranscriptReplay {
-    let baby_bear = BabyBearChip::new(range);
+    let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
     let gate = range.gate();
     let mut transcript = TranscriptGadget::new(ctx);
     let mut replay = TranscriptReplay {
@@ -423,20 +424,20 @@ pub fn constrain_transcript_events(
                 let observed = baby_bear.load_witness(ctx, ChildF::from_u64(*value));
                 transcript.observe(ctx, range, &baby_bear, &observed);
                 let is_sample = ctx.load_zero();
-                replay.observes.push(observed.0);
+                replay.observes.push(observed.value);
                 replay.events.push(AssignedTranscriptEvent {
                     is_sample,
-                    value: observed.0,
+                    value: observed.value,
                 });
             }
             TranscriptEvent::Sample(expected) => {
                 let sampled = transcript.sample(ctx, range, &baby_bear);
-                gate.assert_is_const(ctx, &sampled.0, &Fr::from(*expected));
+                gate.assert_is_const(ctx, &sampled.value, &Fr::from(*expected));
                 let is_sample = ctx.load_constant(Fr::ONE);
-                replay.samples.push(sampled.0);
+                replay.samples.push(sampled.value);
                 replay.events.push(AssignedTranscriptEvent {
                     is_sample,
-                    value: sampled.0,
+                    value: sampled.value,
                 });
             }
         }

--- a/crates/static-verifier/src/transcript/tests.rs
+++ b/crates/static-verifier/src/transcript/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use halo2_base::{
     gates::{
         circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
@@ -19,7 +21,7 @@ use openvm_stark_sdk::{
 use super::*;
 use crate::{
     config::{STATIC_VERIFIER_LOOKUP_ADVICE_COLS_PHASE0, STATIC_VERIFIER_NUM_ADVICE_COLS_PHASE0},
-    field::baby_bear::BabyBearChip,
+    field::baby_bear::{BabyBearChip, BabyBearExt4Wire},
     ChildEF, ChildF,
 };
 
@@ -92,7 +94,7 @@ fn transcript_outputs_match_native_interleaved_flow() {
 
     run_mock(true, |builder| {
         let range = builder.range_chip();
-        let baby_bear = BabyBearChip::new(&range);
+        let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
 
         let ctx = builder.main(0);
         let gate = range.gate();
@@ -106,7 +108,7 @@ fn transcript_outputs_match_native_interleaved_flow() {
         transcript.observe(ctx, &range, &baby_bear, &two);
         transcript.observe(ctx, &range, &baby_bear, &three);
 
-        let observed_ext = BabyBearExtWire(core::array::from_fn(|i| {
+        let observed_ext = BabyBearExt4Wire(core::array::from_fn(|i| {
             baby_bear.load_witness(ctx, ChildF::from_u64(observed_ext_coeffs[i]))
         }));
         transcript.observe_ext(ctx, &range, &baby_bear, &observed_ext);
@@ -115,11 +117,11 @@ fn transcript_outputs_match_native_interleaved_flow() {
         transcript.observe_commit(ctx, &range, &baby_bear, &digest_wire);
 
         let sampled = transcript.sample(ctx, &range, &baby_bear);
-        gate.assert_is_const(ctx, &sampled.0, &Fr::from(expected_sample));
+        gate.assert_is_const(ctx, &sampled.value, &Fr::from(expected_sample));
 
         let sampled_ext = transcript.sample_ext(ctx, &range, &baby_bear);
         for (i, coeff) in sampled_ext.0.iter().enumerate() {
-            gate.assert_is_const(ctx, &coeff.0, &Fr::from(expected_ext[i]));
+            gate.assert_is_const(ctx, &coeff.value, &Fr::from(expected_ext[i]));
         }
 
         let sampled_bits = transcript.sample_bits(ctx, &range, &baby_bear, 17);
@@ -130,7 +132,7 @@ fn transcript_outputs_match_native_interleaved_flow() {
         gate.assert_is_const(ctx, &pow_ok, &Fr::from(expected_pow as u64));
 
         let followup = transcript.sample(ctx, &range, &baby_bear);
-        gate.assert_is_const(ctx, &followup.0, &Fr::from(expected_followup));
+        gate.assert_is_const(ctx, &followup.value, &Fr::from(expected_followup));
     });
 }
 
@@ -144,7 +146,7 @@ fn transcript_check_witness_zero_bits_matches_native() {
 
     run_mock(true, |builder| {
         let range = builder.range_chip();
-        let baby_bear = BabyBearChip::new(&range);
+        let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
 
         let ctx = builder.main(0);
         let gate = range.gate();
@@ -155,14 +157,14 @@ fn transcript_check_witness_zero_bits_matches_native() {
         transcript.observe(ctx, &range, &baby_bear, &obs);
 
         let first = transcript.sample(ctx, &range, &baby_bear);
-        gate.assert_is_const(ctx, &first.0, &Fr::from(expected_first));
+        gate.assert_is_const(ctx, &first.value, &Fr::from(expected_first));
 
         let witness = baby_bear.load_witness(ctx, ChildF::from_u64(7));
         let check = transcript.check_witness(ctx, &range, &baby_bear, 0, &witness);
         gate.assert_is_const(ctx, &check, &Fr::from(expected_check as u64));
 
         let second = transcript.sample(ctx, &range, &baby_bear);
-        gate.assert_is_const(ctx, &second.0, &Fr::from(expected_second));
+        gate.assert_is_const(ctx, &second.value, &Fr::from(expected_second));
     });
 }
 
@@ -171,7 +173,7 @@ fn transcript_sample_bits_rejects_bits_equal_31() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         run_mock(true, |builder| {
             let range = builder.range_chip();
-            let baby_bear = BabyBearChip::new(&range);
+            let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
             let ctx = builder.main(0);
             let mut transcript = TranscriptGadget::new(ctx);
             let _ = transcript.sample_bits(ctx, &range, &baby_bear, 31);

--- a/crates/static-verifier/src/utils.rs
+++ b/crates/static-verifier/src/utils.rs
@@ -7,3 +7,76 @@ pub(crate) fn bits_for_u64(value: u64) -> usize {
 pub(crate) fn usize_to_u64(value: usize) -> u64 {
     u64::try_from(value).expect("usize value does not fit in u64")
 }
+
+#[cfg(debug_assertions)]
+thread_local! {
+    pub(crate) static DEBUG_ASSERTS_ENABLED: std::cell::Cell<bool> = const { std::cell::Cell::new(true) };
+}
+
+/// Suppress debug assertions for the duration of `f`, then restore the previous state.
+#[cfg(all(test, debug_assertions))]
+pub(crate) fn with_debug_asserts_disabled<R>(f: impl FnOnce() -> R) -> R {
+    DEBUG_ASSERTS_ENABLED.with(|cell| {
+        let prev = cell.get();
+        cell.set(false);
+        let result = f();
+        cell.set(prev);
+        result
+    })
+}
+
+#[cfg(all(test, not(debug_assertions)))]
+pub(crate) fn with_debug_asserts_disabled<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}
+
+/// Like `debug_assert_eq!`, but respects the thread-local disable flag.
+#[cfg(debug_assertions)]
+macro_rules! guarded_debug_assert_eq {
+    ($left:expr, $right:expr $(,)?) => {
+        $crate::utils::DEBUG_ASSERTS_ENABLED.with(|cell| {
+            if cell.get() {
+                assert_eq!($left, $right);
+            }
+        });
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        $crate::utils::DEBUG_ASSERTS_ENABLED.with(|cell| {
+            if cell.get() {
+                assert_eq!($left, $right, $($arg)+);
+            }
+        });
+    };
+}
+
+#[cfg(not(debug_assertions))]
+macro_rules! guarded_debug_assert_eq {
+    ($($tt:tt)*) => {};
+}
+
+/// Like `debug_assert!`, but respects the thread-local disable flag.
+#[cfg(debug_assertions)]
+macro_rules! guarded_debug_assert {
+    ($cond:expr $(,)?) => {
+        $crate::utils::DEBUG_ASSERTS_ENABLED.with(|cell| {
+            if cell.get() {
+                assert!($cond);
+            }
+        });
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        $crate::utils::DEBUG_ASSERTS_ENABLED.with(|cell| {
+            if cell.get() {
+                assert!($cond, $($arg)+);
+            }
+        });
+    };
+}
+
+#[cfg(not(debug_assertions))]
+macro_rules! guarded_debug_assert {
+    ($($tt:tt)*) => {};
+}
+
+pub(crate) use guarded_debug_assert;
+pub(crate) use guarded_debug_assert_eq;


### PR DESCRIPTION
## Summary
- Copy over v1 BabyBear chips with lazy reduction and `max_bits` tracking
- Update all consumer interfaces: `Arc`-based constructors, named `.value` field, pass-by-value, `BabyBearExt4Wire` constructors
- Add guarded debug assert infrastructure (`utils.rs`) so negative tests disable BabyBearChip `debug_assert`s and verify constraint violations through MockProver

## Test plan
- [x] `cargo check -p openvm-static-verifier` — 0 errors, 0 warnings
- [x] `cargo nextest run --cargo-profile=fast -p openvm-static-verifier` — 110/110 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)