### PR TITLE
refactor(static-verifier): extract witness loading into ProofWire

### DIFF
--- a/crates/static-verifier/src/prover.rs
+++ b/crates/static-verifier/src/prover.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     config::StaticVerifierShape,
-    stages::full_pipeline::{constrained_verify, digest_scalar_to_fr},
+    stages::full_pipeline::{constrained_verify, load_proof_wire},
 };
 
 /// KZG parameters for the Halo2 BN256 proving system.
@@ -100,11 +100,9 @@ impl StaticVerifierCircuit {
     ) -> Vec<Fr> {
         let range = builder.range_chip();
         let ctx = builder.main(0);
-        let statement_public_inputs = [
-            ctx.load_witness(digest_scalar_to_fr(input.mvk.pre_hash[0])),
-            ctx.load_witness(digest_scalar_to_fr(input.proof.common_main_commit[0])),
-        ];
-        constrained_verify(ctx, &range, input.mvk, input.proof, statement_public_inputs);
+        let proof_wire = load_proof_wire(ctx, &range, input.proof);
+        let statement_public_inputs =
+            constrained_verify(ctx, &range, input.mvk, input.proof, proof_wire);
         let pis = statement_public_inputs
             .iter()
             .map(|c| *c.value())

--- a/crates/static-verifier/src/prover.rs
+++ b/crates/static-verifier/src/prover.rs
@@ -104,8 +104,7 @@ impl StaticVerifierCircuit {
             ctx.load_witness(digest_scalar_to_fr(input.mvk.pre_hash[0])),
             ctx.load_witness(digest_scalar_to_fr(input.proof.common_main_commit[0])),
         ];
-        constrained_verify(ctx, &range, input.mvk, input.proof, statement_public_inputs)
-            .expect("pipeline constrained verify should succeed");
+        constrained_verify(ctx, &range, input.mvk, input.proof, statement_public_inputs);
         let pis = statement_public_inputs
             .iter()
             .map(|c| *c.value())

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -11,11 +11,6 @@ use openvm_stark_sdk::{
         calculate_n_logup,
         keygen::types::MultiStarkVerifyingKey0,
         p3_field::{Field, PrimeCharacteristicRing, TwoAdicField},
-        proof::Proof,
-        verifier::{
-            batch_constraints::BatchConstraintError as NativeBatchConstraintError,
-            proof_shape::ProofShapeError,
-        },
     },
 };
 
@@ -23,49 +18,123 @@ use crate::{
     field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearExtWire, BabyBearWire},
     stages::shared_math,
     transcript::TranscriptGadget,
-    Fr, RootEF, RootF,
+    Fr, RootF,
 };
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum BatchConstraintError {
-    SystemParamsMismatch,
-    TraceHeightsTooLarge,
-    MissingTraceVData {
-        air_id: usize,
-    },
-    MissingPreprocessedView {
-        air_id: usize,
-    },
-    UnsupportedSymbolicVariableEntry {
-        air_id: usize,
-        entry: &'static str,
-    },
-    SymbolicVariableOutOfBounds {
-        air_id: usize,
-        entry: &'static str,
-        index: usize,
-    },
-    MissingStackedChallenges,
-    ProofShape(ProofShapeError),
-    BatchConstraint(NativeBatchConstraintError<RootEF>),
-}
-
-impl From<ProofShapeError> for BatchConstraintError {
-    fn from(value: ProofShapeError) -> Self {
-        Self::ProofShape(value)
-    }
-}
-
-impl From<NativeBatchConstraintError<RootEF>> for BatchConstraintError {
-    fn from(value: NativeBatchConstraintError<RootEF>) -> Self {
-        Self::BatchConstraint(value)
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct BatchConstraintWire {
     pub column_openings: Vec<Vec<Vec<BabyBearExtWire>>>,
     pub r: Vec<BabyBearExtWire>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct GkrProofWire {
+    pub logup_pow_witness: BabyBearWire,
+    pub q0_claim: BabyBearExtWire,
+    pub claims_per_layer: Vec<Vec<BabyBearExtWire>>,
+    pub sumcheck_polys: Vec<Vec<BabyBearExtWire>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BatchConstraintProofWire {
+    pub numerator_term_per_air: Vec<BabyBearExtWire>,
+    pub denominator_term_per_air: Vec<BabyBearExtWire>,
+    pub univariate_round_coeffs: Vec<BabyBearExtWire>,
+    pub sumcheck_round_polys: Vec<Vec<BabyBearExtWire>>,
+    pub column_openings: Vec<Vec<Vec<BabyBearExtWire>>>,
+}
+
+pub(crate) fn load_gkr_proof_wire(
+    ctx: &mut Context<Fr>,
+    base_chip: &BabyBearChip,
+    ext_chip: &BabyBearExtChip,
+    gkr_proof: &openvm_stark_sdk::openvm_stark_backend::proof::GkrProof<RootConfig>,
+) -> GkrProofWire {
+    let logup_pow_witness = base_chip.load_witness(ctx, gkr_proof.logup_pow_witness);
+    let q0_claim = ext_chip.load_witness(ctx, gkr_proof.q0_claim);
+    let claims_per_layer = gkr_proof
+        .claims_per_layer
+        .iter()
+        .map(|claims| {
+            vec![
+                ext_chip.load_witness(ctx, claims.p_xi_0),
+                ext_chip.load_witness(ctx, claims.q_xi_0),
+                ext_chip.load_witness(ctx, claims.p_xi_1),
+                ext_chip.load_witness(ctx, claims.q_xi_1),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let sumcheck_polys = gkr_proof
+        .sumcheck_polys
+        .iter()
+        .map(|poly| {
+            let mut assigned = Vec::with_capacity(poly.len() * 3);
+            for evals in poly {
+                for &value in evals {
+                    assigned.push(ext_chip.load_witness(ctx, value));
+                }
+            }
+            assigned
+        })
+        .collect::<Vec<_>>();
+    GkrProofWire {
+        logup_pow_witness,
+        q0_claim,
+        claims_per_layer,
+        sumcheck_polys,
+    }
+}
+
+pub(crate) fn load_batch_constraint_proof_wire(
+    ctx: &mut Context<Fr>,
+    ext_chip: &BabyBearExtChip,
+    batch_proof: &openvm_stark_sdk::openvm_stark_backend::proof::BatchConstraintProof<RootConfig>,
+) -> BatchConstraintProofWire {
+    let numerator_term_per_air = batch_proof
+        .numerator_term_per_air
+        .iter()
+        .map(|&value| ext_chip.load_witness(ctx, value))
+        .collect::<Vec<_>>();
+    let denominator_term_per_air = batch_proof
+        .denominator_term_per_air
+        .iter()
+        .map(|&value| ext_chip.load_witness(ctx, value))
+        .collect::<Vec<_>>();
+    let univariate_round_coeffs = batch_proof
+        .univariate_round_coeffs
+        .iter()
+        .map(|&value| ext_chip.load_witness(ctx, value))
+        .collect::<Vec<_>>();
+    let sumcheck_round_polys = batch_proof
+        .sumcheck_round_polys
+        .iter()
+        .map(|poly| {
+            poly.iter()
+                .map(|&value| ext_chip.load_witness(ctx, value))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let column_openings = batch_proof
+        .column_openings
+        .iter()
+        .map(|per_air| {
+            per_air
+                .iter()
+                .map(|part| {
+                    part.iter()
+                        .map(|&value| ext_chip.load_witness(ctx, value))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    BatchConstraintProofWire {
+        numerator_term_per_air,
+        denominator_term_per_air,
+        univariate_round_coeffs,
+        sumcheck_round_polys,
+        column_openings,
+    }
 }
 
 fn eval_ext_poly_horner(
@@ -487,28 +556,20 @@ pub(crate) fn constrain_batch_from_proof_inputs(
     range: &halo2_base::gates::range::RangeChip<Fr>,
     transcript: &mut TranscriptGadget,
     mvk0: &MultiStarkVerifyingKey0<RootConfig>,
-    proof: &Proof<RootConfig>,
+    gkr_wire: &GkrProofWire,
+    batch_wire: &BatchConstraintProofWire,
+    n_per_trace: &[isize],
     trace_id_to_air_id: &[usize],
     public_values: Vec<Vec<BabyBearWire>>,
-) -> Result<BatchConstraintWire, BatchConstraintError> {
+) -> BatchConstraintWire {
     let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
     let ext_chip = BabyBearExtChip::new(base_chip);
     let baby_bear = ext_chip.base();
 
     let l_skip = mvk0.params.l_skip;
-    let n_per_trace = trace_id_to_air_id
-        .iter()
-        .map(|&air_id| {
-            Ok(proof.trace_vdata[air_id]
-                .as_ref()
-                .ok_or(BatchConstraintError::MissingTraceVData { air_id })?
-                .log_height as isize
-                - l_skip as isize)
-        })
-        .collect::<Result<Vec<_>, BatchConstraintError>>()?;
 
     let trace_id_to_air_id_host = trace_id_to_air_id.to_vec();
-    let total_interactions_host = zip(trace_id_to_air_id, &n_per_trace)
+    let total_interactions_host = zip(trace_id_to_air_id, n_per_trace)
         .map(|(&air_idx, &n)| {
             let n_lift = n.max(0) as usize;
             let num_interactions = mvk0.per_air[air_idx]
@@ -566,55 +627,28 @@ pub(crate) fn constrain_batch_from_proof_inputs(
         .collect::<Vec<_>>();
 
     let logup_pow_bits = mvk0.params.logup.pow_bits;
-    let logup_pow_witness = baby_bear.load_witness(ctx, proof.gkr_proof.logup_pow_witness);
+    let logup_pow_witness = gkr_wire.logup_pow_witness;
     transcript.check_witness(ctx, baby_bear, logup_pow_bits, &logup_pow_witness);
 
     let alpha_logup = transcript.sample_ext(ctx, baby_bear);
     let beta_logup = transcript.sample_ext(ctx, baby_bear);
 
-    let gkr_q0_claim = (total_interactions_host != 0)
-        .then(|| ext_chip.load_witness(ctx, proof.gkr_proof.q0_claim));
-    let gkr_claims_per_layer = proof
-        .gkr_proof
-        .claims_per_layer
-        .iter()
-        .map(|claims| {
-            vec![
-                ext_chip.load_witness(ctx, claims.p_xi_0),
-                ext_chip.load_witness(ctx, claims.q_xi_0),
-                ext_chip.load_witness(ctx, claims.p_xi_1),
-                ext_chip.load_witness(ctx, claims.q_xi_1),
-            ]
-        })
-        .collect::<Vec<_>>();
-    let gkr_sumcheck_polys = proof
-        .gkr_proof
-        .sumcheck_polys
-        .iter()
-        .map(|poly| {
-            let mut assigned = Vec::with_capacity(poly.len() * 3);
-            for evals in poly {
-                for &value in evals {
-                    assigned.push(ext_chip.load_witness(ctx, value));
-                }
-            }
-            assigned
-        })
-        .collect::<Vec<_>>();
+    let gkr_q0_claim = (total_interactions_host != 0).then_some(gkr_wire.q0_claim);
+    let gkr_claims_per_layer = &gkr_wire.claims_per_layer;
+    let gkr_sumcheck_polys = &gkr_wire.sumcheck_polys;
 
     let zero = ext_chip.zero(ctx);
     let one = ext_chip.from_base_const(ctx, RootF::ONE);
     let total_gkr_rounds = l_skip + n_logup_host;
     let (mut gkr_p_xi_claim, mut gkr_q_xi_claim, gkr_xi_claims, _gkr_sample_stream) =
         if total_interactions_host == 0 {
-            let q0_claim = ext_chip.load_witness(ctx, proof.gkr_proof.q0_claim);
+            let q0_claim = gkr_wire.q0_claim;
             ext_chip.assert_equal(ctx, q0_claim, one);
             (zero, alpha_logup, Vec::new(), Vec::new())
         } else {
-            let q0_claim = gkr_q0_claim
-                .as_ref()
-                .expect("non-zero interaction branch must include q0 claim witness");
-            transcript.observe_ext(ctx, baby_bear, q0_claim);
+            let q0_claim =
+                gkr_q0_claim.expect("non-zero interaction branch must include q0 claim witness");
+            transcript.observe_ext(ctx, baby_bear, &q0_claim);
 
             let layer0 = &gkr_claims_per_layer[0];
             observe_layer_claims_assigned(ctx, transcript, baby_bear, layer0);
@@ -624,7 +658,7 @@ pub(crate) fn constrain_batch_from_proof_inputs(
             let p_cross = ext_chip.add(ctx, p0_q1, p1_q0);
             let q_cross = ext_chip.mul(ctx, layer0[1], layer0[3]);
             ext_chip.assert_equal(ctx, p_cross, zero);
-            ext_chip.assert_equal(ctx, q_cross, *q0_claim);
+            ext_chip.assert_equal(ctx, q_cross, q0_claim);
 
             let mu0 = transcript.sample_ext(ctx, baby_bear);
             let mut gkr_sample_stream = vec![mu0];
@@ -714,18 +748,8 @@ pub(crate) fn constrain_batch_from_proof_inputs(
 
     let lambda = transcript.sample_ext(ctx, baby_bear);
 
-    let numerator_term_per_air = proof
-        .batch_constraint_proof
-        .numerator_term_per_air
-        .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
-        .collect::<Vec<_>>();
-    let denominator_term_per_air = proof
-        .batch_constraint_proof
-        .denominator_term_per_air
-        .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
-        .collect::<Vec<_>>();
+    let numerator_term_per_air = &batch_wire.numerator_term_per_air;
+    let denominator_term_per_air = &batch_wire.denominator_term_per_air;
     for (num_term, den_term) in numerator_term_per_air
         .iter()
         .zip(denominator_term_per_air.iter())
@@ -758,13 +782,8 @@ pub(crate) fn constrain_batch_from_proof_inputs(
         cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
     }
 
-    let univariate_round_coeffs = proof
-        .batch_constraint_proof
-        .univariate_round_coeffs
-        .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
-        .collect::<Vec<_>>();
-    for coeff in &univariate_round_coeffs {
+    let univariate_round_coeffs = &batch_wire.univariate_round_coeffs;
+    for coeff in univariate_round_coeffs {
         transcript.observe_ext(ctx, baby_bear, coeff);
     }
     let mut r = vec![transcript.sample_ext(ctx, baby_bear)];
@@ -778,18 +797,9 @@ pub(crate) fn constrain_batch_from_proof_inputs(
         ext_chip.mul_base_const(ctx, sum_univ_domain_s_0, RootF::from_u64(stride as u64));
     ext_chip.assert_equal(ctx, sum_claim, sum_univ_domain_s_0);
 
-    let sumcheck_round_polys = proof
-        .batch_constraint_proof
-        .sumcheck_round_polys
-        .iter()
-        .map(|poly| {
-            poly.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-    let mut consistency_lhs = eval_ext_poly_horner(ctx, &ext_chip, &univariate_round_coeffs, &r[0]);
-    for round_evals in &sumcheck_round_polys {
+    let sumcheck_round_polys = &batch_wire.sumcheck_round_polys;
+    let mut consistency_lhs = eval_ext_poly_horner(ctx, &ext_chip, univariate_round_coeffs, &r[0]);
+    for round_evals in sumcheck_round_polys {
         for eval in round_evals {
             transcript.observe_ext(ctx, baby_bear, eval);
         }
@@ -805,21 +815,7 @@ pub(crate) fn constrain_batch_from_proof_inputs(
         r.push(next_r);
     }
 
-    let column_openings = proof
-        .batch_constraint_proof
-        .column_openings
-        .iter()
-        .map(|per_air| {
-            per_air
-                .iter()
-                .map(|part| {
-                    part.iter()
-                        .map(|&value| ext_chip.load_witness(ctx, value))
-                        .collect::<Vec<_>>()
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
+    let column_openings = &batch_wire.column_openings;
 
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
         let need_rot = column_openings_need_rot[trace_idx][0];
@@ -1015,5 +1011,8 @@ pub(crate) fn constrain_batch_from_proof_inputs(
     let consistency_residual = ext_chip.sub(ctx, consistency_lhs, consistency_rhs);
     ext_chip.assert_equal(ctx, consistency_residual, zero);
 
-    Ok(BatchConstraintWire { column_openings, r })
+    BatchConstraintWire {
+        column_openings: column_openings.clone(),
+        r,
+    }
 }

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -28,7 +28,7 @@ pub struct BatchConstraintWire {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct GkrProofWire {
+pub struct GkrProofWire {
     pub logup_pow_witness: BabyBearWire,
     pub q0_claim: BabyBearExtWire,
     pub claims_per_layer: Vec<Vec<BabyBearExtWire>>,
@@ -36,7 +36,7 @@ pub(crate) struct GkrProofWire {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct BatchConstraintProofWire {
+pub struct BatchConstraintProofWire {
     pub numerator_term_per_air: Vec<BabyBearExtWire>,
     pub denominator_term_per_air: Vec<BabyBearExtWire>,
     pub univariate_round_coeffs: Vec<BabyBearExtWire>,

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct BatchConstraintWire {
+pub struct BatchConstraintIntermediatesWire {
     pub column_openings: Vec<Vec<Vec<BabyBearExtWire>>>,
     pub r: Vec<BabyBearExtWire>,
 }
@@ -551,7 +551,7 @@ fn observe_layer_claims_assigned(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn constrain_batch_from_proof_inputs(
+pub(crate) fn constrain_batch_constraints_verification(
     ctx: &mut Context<Fr>,
     range: &halo2_base::gates::range::RangeChip<Fr>,
     transcript: &mut TranscriptGadget,
@@ -561,7 +561,7 @@ pub(crate) fn constrain_batch_from_proof_inputs(
     n_per_trace: &[isize],
     trace_id_to_air_id: &[usize],
     public_values: Vec<Vec<BabyBearWire>>,
-) -> BatchConstraintWire {
+) -> BatchConstraintIntermediatesWire {
     let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
     let ext_chip = BabyBearExtChip::new(base_chip);
     let baby_bear = ext_chip.base();
@@ -1011,7 +1011,7 @@ pub(crate) fn constrain_batch_from_proof_inputs(
     let consistency_residual = ext_chip.sub(ctx, consistency_lhs, consistency_rhs);
     ext_chip.assert_equal(ctx, consistency_residual, zero);
 
-    BatchConstraintWire {
+    BatchConstraintIntermediatesWire {
         column_openings: column_openings.clone(),
         r,
     }

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -13,12 +13,16 @@ use openvm_stark_sdk::{
 use crate::{
     field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearWire, BABY_BEAR_BITS},
     stages::{
-        batch_constraints::{constrain_batch_from_proof_inputs, BatchConstraintError},
+        batch_constraints::{
+            constrain_batch_from_proof_inputs, load_batch_constraint_proof_wire,
+            load_gkr_proof_wire, BatchConstraintProofWire, GkrProofWire,
+        },
         proof_shape::compute_trace_id_to_air_id,
         stacked_reduction::{
-            constrain_stacked_reduction, stacked_reduction_layouts, StackedReductionConstraintError,
+            constrain_stacked_reduction, load_stacking_proof_wire, stacked_reduction_layouts,
+            StackingProofWire,
         },
-        whir::{constrain_whir_verification, WhirError},
+        whir::{constrain_whir_verification, load_whir_proof_wire, WhirProofWire},
     },
     transcript::{digest_wire_from_root, TranscriptGadget},
     Fr,
@@ -27,54 +31,82 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum PipelineError {
-    Batch(BatchConstraintError),
-    StackedReduction(StackedReductionConstraintError),
-    Whir(WhirError),
-}
-
-impl From<BatchConstraintError> for PipelineError {
-    fn from(value: BatchConstraintError) -> Self {
-        Self::Batch(value)
-    }
-}
-
-impl From<StackedReductionConstraintError> for PipelineError {
-    fn from(value: StackedReductionConstraintError) -> Self {
-        Self::StackedReduction(value)
-    }
-}
-
-impl From<WhirError> for PipelineError {
-    fn from(value: WhirError) -> Self {
-        Self::Whir(value)
-    }
-}
-
 #[derive(Clone, Debug)]
-struct PreambleWire {
+struct ProofWire {
     public_values: Vec<Vec<BabyBearWire>>,
-    /// Per-air cached commitment roots loaded as witness cells during transcript observation.
-    /// Indexed by air_id (sparse: `None` for airs without cached commitments).
     cached_commitment_roots: Vec<Vec<AssignedValue<Fr>>>,
+    gkr: GkrProofWire,
+    batch: BatchConstraintProofWire,
+    stacking: StackingProofWire,
+    whir: WhirProofWire,
 }
 
 pub(crate) fn digest_scalar_to_fr(value: Bn254Scalar) -> Fr {
     biguint_to_fe(&value.as_canonical_biguint())
 }
 
+fn load_proof_wire(
+    ctx: &mut Context<Fr>,
+    range: &RangeChip<Fr>,
+    proof: &Proof<RootConfig>,
+) -> ProofWire {
+    let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
+    let ext_chip = BabyBearExtChip::new(base_chip.clone());
+
+    let public_values = proof
+        .public_values
+        .iter()
+        .map(|values| {
+            values
+                .iter()
+                .map(|&value| base_chip.load_witness(ctx, value))
+                .collect()
+        })
+        .collect();
+
+    let cached_commitment_roots = proof
+        .trace_vdata
+        .iter()
+        .map(|vdata| {
+            if let Some(vdata) = vdata {
+                vdata
+                    .cached_commitments
+                    .iter()
+                    .map(|commit| ctx.load_witness(digest_scalar_to_fr(commit[0])))
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        })
+        .collect();
+
+    let gkr = load_gkr_proof_wire(ctx, &base_chip, &ext_chip, &proof.gkr_proof);
+    let batch = load_batch_constraint_proof_wire(ctx, &ext_chip, &proof.batch_constraint_proof);
+    let stacking = load_stacking_proof_wire(ctx, &ext_chip, &proof.stacking_proof);
+    let whir = load_whir_proof_wire(ctx, &base_chip, &ext_chip, &proof.whir_proof);
+
+    ProofWire {
+        public_values,
+        cached_commitment_roots,
+        gkr,
+        batch,
+        stacking,
+        whir,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn observe_preamble(
     ctx: &mut Context<Fr>,
     range: &RangeChip<Fr>,
     transcript: &mut TranscriptGadget,
     mvk: &MultiStarkVerifyingKey<RootConfig>,
     proof: &Proof<RootConfig>,
+    public_values: &[Vec<BabyBearWire>],
+    cached_commitment_roots: &[Vec<AssignedValue<Fr>>],
     statement_public_inputs: [AssignedValue<Fr>; 2],
-) -> PreambleWire {
+) {
     let base_chip = BabyBearChip::new(Arc::new(range.clone()));
-    let num_airs = mvk.inner.per_air.len();
-    let mut cached_commitment_roots = Vec::with_capacity(num_airs);
 
     transcript.observe_commit(
         ctx,
@@ -87,79 +119,54 @@ fn observe_preamble(
         &digest_wire_from_root(statement_public_inputs[1]),
     );
 
-    let public_values = proof
-        .public_values
-        .iter()
-        .enumerate()
-        .map(|(air_idx, values)| {
-            if !mvk.inner.per_air[air_idx].is_required {
-                let presence_flag =
-                    ctx.load_constant(Fr::from(proof.trace_vdata[air_idx].is_some() as u64));
+    for air_idx in 0..mvk.inner.per_air.len() {
+        if !mvk.inner.per_air[air_idx].is_required {
+            let presence_flag =
+                ctx.load_constant(Fr::from(proof.trace_vdata[air_idx].is_some() as u64));
+            transcript.observe(
+                ctx,
+                &base_chip,
+                &BabyBearWire {
+                    value: presence_flag,
+                    max_bits: 1,
+                },
+            );
+        }
+
+        if proof.trace_vdata[air_idx].is_some() {
+            if let Some(preprocessed) = mvk.inner.per_air[air_idx].preprocessed_data.as_ref() {
+                let preprocessed_root =
+                    ctx.load_constant(digest_scalar_to_fr(preprocessed.commit[0]));
+                transcript.observe_commit(
+                    ctx,
+                    &base_chip,
+                    &digest_wire_from_root(preprocessed_root),
+                );
+            } else {
+                let log_height = ctx.load_constant(Fr::from(
+                    proof.trace_vdata[air_idx]
+                        .as_ref()
+                        .expect("present air must include trace vdata")
+                        .log_height as u64,
+                ));
                 transcript.observe(
                     ctx,
                     &base_chip,
                     &BabyBearWire {
-                        value: presence_flag,
-                        max_bits: 1,
+                        value: log_height,
+                        max_bits: BABY_BEAR_BITS,
                     },
                 );
             }
 
-            if proof.trace_vdata[air_idx].is_some() {
-                if let Some(preprocessed) = mvk.inner.per_air[air_idx].preprocessed_data.as_ref() {
-                    let preprocessed_root =
-                        ctx.load_constant(digest_scalar_to_fr(preprocessed.commit[0]));
-                    transcript.observe_commit(
-                        ctx,
-                        &base_chip,
-                        &digest_wire_from_root(preprocessed_root),
-                    );
-                } else {
-                    let log_height = ctx.load_constant(Fr::from(
-                        proof.trace_vdata[air_idx]
-                            .as_ref()
-                            .expect("present air must include trace vdata")
-                            .log_height as u64,
-                    ));
-                    transcript.observe(
-                        ctx,
-                        &base_chip,
-                        &BabyBearWire {
-                            value: log_height,
-                            max_bits: BABY_BEAR_BITS,
-                        },
-                    );
-                }
-
-                let mut air_cached_roots = Vec::new();
-                for commit in &proof.trace_vdata[air_idx]
-                    .as_ref()
-                    .expect("present air must include trace vdata")
-                    .cached_commitments
-                {
-                    let root = ctx.load_witness(digest_scalar_to_fr(commit[0]));
-                    transcript.observe_commit(ctx, &base_chip, &digest_wire_from_root(root));
-                    air_cached_roots.push(root);
-                }
-                cached_commitment_roots.push(air_cached_roots);
-            } else {
-                cached_commitment_roots.push(Vec::new());
+            for root in &cached_commitment_roots[air_idx] {
+                transcript.observe_commit(ctx, &base_chip, &digest_wire_from_root(*root));
             }
+        }
 
-            values
-                .iter()
-                .map(|&value| {
-                    let value = base_chip.load_witness(ctx, value);
-                    transcript.observe(ctx, &base_chip, &value);
-                    value
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-
-    PreambleWire {
-        public_values,
-        cached_commitment_roots,
+        for value in &public_values[air_idx] {
+            transcript.observe(ctx, &base_chip, value);
+        }
     }
 }
 
@@ -169,39 +176,58 @@ pub fn constrained_verify(
     mvk: &MultiStarkVerifyingKey<RootConfig>,
     proof: &Proof<RootConfig>,
     statement_public_inputs: [AssignedValue<Fr>; 2],
-) -> Result<(), PipelineError> {
+) {
     let l_skip = mvk.inner.params.l_skip;
-    let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
-    let ext_chip = BabyBearExtChip::new(base_chip);
     let trace_id_to_air_id = compute_trace_id_to_air_id(&mvk.inner, proof);
 
+    // Load ALL witness data upfront
+    let proof_wire = load_proof_wire(ctx, range, proof);
+
+    let n_per_trace: Vec<isize> = trace_id_to_air_id
+        .iter()
+        .map(|&air_id| {
+            proof.trace_vdata[air_id]
+                .as_ref()
+                .expect("present air must have trace vdata")
+                .log_height as isize
+                - l_skip as isize
+        })
+        .collect();
+
     let mut transcript = TranscriptGadget::new(ctx);
-    let preamble = observe_preamble(
+    observe_preamble(
         ctx,
         range,
         &mut transcript,
         mvk,
         proof,
+        &proof_wire.public_values,
+        &proof_wire.cached_commitment_roots,
         statement_public_inputs,
     );
+
+    let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
+    let ext_chip = BabyBearExtChip::new(base_chip);
 
     let batch = constrain_batch_from_proof_inputs(
         ctx,
         range,
         &mut transcript,
         &mvk.inner,
-        proof,
+        &proof_wire.gkr,
+        &proof_wire.batch,
+        &n_per_trace,
         &trace_id_to_air_id,
-        preamble.public_values,
-    )?;
+        proof_wire.public_values,
+    );
 
     let layouts = stacked_reduction_layouts(&mvk.inner, proof);
-    let need_rot_per_commit = get_need_rot_per_commit(&mvk.inner, proof, &trace_id_to_air_id)?;
+    let need_rot_per_commit = get_need_rot_per_commit(&mvk.inner, proof, &trace_id_to_air_id);
     let stacked_reduction = constrain_stacked_reduction(
         ctx,
         &ext_chip,
         &mut transcript,
-        &proof.stacking_proof,
+        &proof_wire.stacking,
         &layouts,
         &need_rot_per_commit,
         l_skip,
@@ -230,7 +256,7 @@ pub fn constrained_verify(
             if let Some(preprocessed) = &mvk.inner.per_air[air_id].preprocessed_data {
                 commits.push(ctx.load_constant(digest_scalar_to_fr(preprocessed.commit[0])));
             }
-            commits.extend(preamble.cached_commitment_roots[air_id].iter().copied());
+            commits.extend(proof_wire.cached_commitment_roots[air_id].iter().copied());
         }
         commits
     };
@@ -240,22 +266,19 @@ pub fn constrained_verify(
         &ext_chip,
         &mut transcript,
         &mvk.inner,
-        &proof.whir_proof,
+        &proof_wire.whir,
         &stacked_reduction.stacking_openings,
         &initial_commitment_roots,
         &u_cube,
     );
-
-    Ok(())
 }
 
-/// Helper function, purely on out-of-circuit values. `builder` is not involved and there are no
-/// cells.
+/// Helper function, purely on out-of-circuit values.
 fn get_need_rot_per_commit(
     mvk0: &MultiStarkVerifyingKey0<RootConfig>,
     proof: &Proof<RootConfig>,
     trace_id_to_air_id: &[usize],
-) -> Result<Vec<Vec<bool>>, BatchConstraintError> {
+) -> Vec<Vec<bool>> {
     let mut need_rot_per_commit = vec![trace_id_to_air_id
         .iter()
         .map(|&air_id| mvk0.per_air[air_id].params.need_rot)
@@ -267,12 +290,12 @@ fn get_need_rot_per_commit(
         }
         let cached_len = proof.trace_vdata[air_id]
             .as_ref()
-            .ok_or(BatchConstraintError::MissingTraceVData { air_id })?
+            .expect("present air must have trace vdata")
             .cached_commitments
             .len();
         for _ in 0..cached_len {
             need_rot_per_commit.push(vec![need_rot]);
         }
     }
-    Ok(need_rot_per_commit)
+    need_rot_per_commit
 }

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -32,26 +32,30 @@ use crate::{
 mod tests;
 
 #[derive(Clone, Debug)]
-struct ProofWire {
-    public_values: Vec<Vec<BabyBearWire>>,
-    cached_commitment_roots: Vec<Vec<AssignedValue<Fr>>>,
-    gkr: GkrProofWire,
-    batch: BatchConstraintProofWire,
-    stacking: StackingProofWire,
-    whir: WhirProofWire,
+pub struct ProofWire {
+    pub common_main_commit_root: AssignedValue<Fr>,
+    pub public_values: Vec<Vec<BabyBearWire>>,
+    pub cached_commitment_roots: Vec<Vec<AssignedValue<Fr>>>,
+    pub gkr: GkrProofWire,
+    pub batch: BatchConstraintProofWire,
+    pub stacking: StackingProofWire,
+    pub whir: WhirProofWire,
 }
 
 pub(crate) fn digest_scalar_to_fr(value: Bn254Scalar) -> Fr {
     biguint_to_fe(&value.as_canonical_biguint())
 }
 
-fn load_proof_wire(
+pub fn load_proof_wire(
     ctx: &mut Context<Fr>,
     range: &RangeChip<Fr>,
     proof: &Proof<RootConfig>,
 ) -> ProofWire {
     let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
     let ext_chip = BabyBearExtChip::new(base_chip.clone());
+
+    let common_main_commit_root =
+        ctx.load_witness(digest_scalar_to_fr(proof.common_main_commit[0]));
 
     let public_values = proof
         .public_values
@@ -86,6 +90,7 @@ fn load_proof_wire(
     let whir = load_whir_proof_wire(ctx, &base_chip, &ext_chip, &proof.whir_proof);
 
     ProofWire {
+        common_main_commit_root,
         public_values,
         cached_commitment_roots,
         gkr,
@@ -170,18 +175,22 @@ fn observe_preamble(
     }
 }
 
+/// Run the full static verifier pipeline on pre-loaded witness data.
+///
+/// Returns the two statement public inputs as assigned cells:
+/// `[mvk_pre_hash_root, common_main_commit_root]`.
 pub fn constrained_verify(
     ctx: &mut Context<Fr>,
     range: &RangeChip<Fr>,
     mvk: &MultiStarkVerifyingKey<RootConfig>,
     proof: &Proof<RootConfig>,
-    statement_public_inputs: [AssignedValue<Fr>; 2],
-) {
+    proof_wire: ProofWire,
+) -> [AssignedValue<Fr>; 2] {
     let l_skip = mvk.inner.params.l_skip;
     let trace_id_to_air_id = compute_trace_id_to_air_id(&mvk.inner, proof);
 
-    // Load ALL witness data upfront
-    let proof_wire = load_proof_wire(ctx, range, proof);
+    let mvk_pre_hash_root = ctx.load_constant(digest_scalar_to_fr(mvk.pre_hash[0]));
+    let statement_public_inputs = [mvk_pre_hash_root, proof_wire.common_main_commit_root];
 
     let n_per_trace: Vec<isize> = trace_id_to_air_id
         .iter()
@@ -271,6 +280,8 @@ pub fn constrained_verify(
         &initial_commitment_roots,
         &u_cube,
     );
+
+    statement_public_inputs
 }
 
 /// Helper function, purely on out-of-circuit values.

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearWire, BABY_BEAR_BITS},
     stages::{
         batch_constraints::{
-            constrain_batch_from_proof_inputs, load_batch_constraint_proof_wire,
+            constrain_batch_constraints_verification, load_batch_constraint_proof_wire,
             load_gkr_proof_wire, BatchConstraintProofWire, GkrProofWire,
         },
         proof_shape::compute_trace_id_to_air_id,
@@ -218,7 +218,7 @@ pub fn constrained_verify(
     let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
     let ext_chip = BabyBearExtChip::new(base_chip);
 
-    let batch = constrain_batch_from_proof_inputs(
+    let batch = constrain_batch_constraints_verification(
         ctx,
         range,
         &mut transcript,

--- a/crates/static-verifier/src/stages/full_pipeline/tests.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/tests.rs
@@ -191,12 +191,9 @@ fn pipeline_constraints_fail_when_ext_constant_families_are_pranked() {
     run_mock(false, &public_inputs, move |builder| {
         let range = builder.range_chip();
         let ctx = builder.main(0);
-        let statement_public_inputs = [
-            ctx.load_witness(digest_scalar_to_fr(vk.pre_hash[0])),
-            ctx.load_witness(digest_scalar_to_fr(proof.common_main_commit[0])),
-        ];
+        let proof_wire = load_proof_wire(ctx, &range, &proof);
         clear_recorded_ext_base_consts();
-        constrained_verify(ctx, &range, &vk, &proof, statement_public_inputs);
+        let statement_public_inputs = constrained_verify(ctx, &range, &vk, &proof, proof_wire);
         let records = take_recorded_ext_base_consts();
         for (family, constant) in base_families {
             prank_recorded_ext_constant(ctx, &records, family, constant);

--- a/crates/static-verifier/src/stages/full_pipeline/tests.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/tests.rs
@@ -196,8 +196,7 @@ fn pipeline_constraints_fail_when_ext_constant_families_are_pranked() {
             ctx.load_witness(digest_scalar_to_fr(proof.common_main_commit[0])),
         ];
         clear_recorded_ext_base_consts();
-        constrained_verify(ctx, &range, &vk, &proof, statement_public_inputs)
-            .expect("pipeline constrained verify should succeed before ext-constant prank");
+        constrained_verify(ctx, &range, &vk, &proof, statement_public_inputs);
         let records = take_recorded_ext_base_consts();
         for (family, constant) in base_families {
             prank_recorded_ext_constant(ctx, &records, family, constant);

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -4,14 +4,8 @@ use halo2_base::Context;
 use openvm_stark_sdk::{
     config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
     openvm_stark_backend::{
-        keygen::types::MultiStarkVerifyingKey0,
-        p3_field::PrimeCharacteristicRing,
-        proof::{Proof, StackingProof},
+        keygen::types::MultiStarkVerifyingKey0, p3_field::PrimeCharacteristicRing, proof::Proof,
         prover::stacked_pcs::StackedLayout,
-        verifier::{
-            batch_constraints::BatchConstraintError as NativeBatchConstraintError,
-            proof_shape::ProofShapeError, stacked_reduction::StackedReductionError,
-        },
     },
 };
 
@@ -20,7 +14,7 @@ use crate::{
     stages::{
         batch_constraints::{
             eval_eq_mle_binary_assigned, eval_eq_prism_assigned, eval_eq_uni_at_one_assigned,
-            eval_rot_kernel_prism_assigned, BatchConstraintError,
+            eval_rot_kernel_prism_assigned,
         },
         shared_math::{
             column_openings_by_rot_assigned, horner_eval_ext_poly_assigned,
@@ -28,7 +22,7 @@ use crate::{
         },
     },
     transcript::TranscriptGadget,
-    Fr, RootEF, RootF,
+    Fr, RootF,
 };
 
 /// Stacked PCS layouts for the trace commitments present in `proof`, derived from the VK widths
@@ -78,50 +72,52 @@ pub(crate) fn stacked_reduction_layouts(
         .collect::<Vec<_>>()
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum StackedReductionConstraintError {
-    SystemParamsMismatch,
-    TraceHeightsTooLarge,
-    ProofShape(ProofShapeError),
-    BatchConstraint(NativeBatchConstraintError<RootEF>),
-    StackedReduction(StackedReductionError<RootEF>),
-    BatchSetup(BatchConstraintError),
-}
-
-impl From<ProofShapeError> for StackedReductionConstraintError {
-    fn from(value: ProofShapeError) -> Self {
-        Self::ProofShape(value)
-    }
-}
-
-impl From<NativeBatchConstraintError<RootEF>> for StackedReductionConstraintError {
-    fn from(value: NativeBatchConstraintError<RootEF>) -> Self {
-        Self::BatchConstraint(value)
-    }
-}
-
-impl From<StackedReductionError<RootEF>> for StackedReductionConstraintError {
-    fn from(value: StackedReductionError<RootEF>) -> Self {
-        Self::StackedReduction(value)
-    }
-}
-
-impl From<BatchConstraintError> for StackedReductionConstraintError {
-    fn from(value: BatchConstraintError) -> Self {
-        match value {
-            BatchConstraintError::SystemParamsMismatch => Self::SystemParamsMismatch,
-            BatchConstraintError::TraceHeightsTooLarge => Self::TraceHeightsTooLarge,
-            BatchConstraintError::ProofShape(err) => Self::ProofShape(err),
-            BatchConstraintError::BatchConstraint(err) => Self::BatchConstraint(err),
-            _ => Self::BatchSetup(value),
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct StackedReductionWire {
     pub stacking_openings: Vec<Vec<BabyBearExtWire>>,
     pub u: Vec<BabyBearExtWire>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StackingProofWire {
+    pub univariate_round_coeffs: Vec<BabyBearExtWire>,
+    pub sumcheck_round_polys: Vec<Vec<BabyBearExtWire>>,
+    pub stacking_openings: Vec<Vec<BabyBearExtWire>>,
+}
+
+pub(crate) fn load_stacking_proof_wire(
+    ctx: &mut Context<Fr>,
+    ext_chip: &BabyBearExtChip,
+    stacking_proof: &openvm_stark_sdk::openvm_stark_backend::proof::StackingProof<RootConfig>,
+) -> StackingProofWire {
+    let univariate_round_coeffs = stacking_proof
+        .univariate_round_coeffs
+        .iter()
+        .map(|&value| ext_chip.load_witness(ctx, value))
+        .collect::<Vec<_>>();
+    let sumcheck_round_polys = stacking_proof
+        .sumcheck_round_polys
+        .iter()
+        .map(|poly| {
+            poly.iter()
+                .map(|&value| ext_chip.load_witness(ctx, value))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let stacking_openings = stacking_proof
+        .stacking_openings
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|&value| ext_chip.load_witness(ctx, value))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    StackingProofWire {
+        univariate_round_coeffs,
+        sumcheck_round_polys,
+        stacking_openings,
+    }
 }
 
 fn eval_in_uni_assigned(
@@ -144,7 +140,7 @@ pub(crate) fn constrain_stacked_reduction(
     ctx: &mut Context<Fr>,
     ext_chip: &BabyBearExtChip,
     transcript: &mut TranscriptGadget,
-    proof: &StackingProof<RootConfig>,
+    stacking_wire: &StackingProofWire,
     layouts: &[StackedLayout],
     need_rot_per_commit: &[Vec<bool>],
     l_skip: usize,
@@ -207,11 +203,7 @@ pub(crate) fn constrain_stacked_reduction(
         s_0 = ext_chip.add(ctx, s_0, term);
     }
 
-    let univariate_round_coeffs = proof
-        .univariate_round_coeffs
-        .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
-        .collect::<Vec<_>>();
+    let univariate_round_coeffs = &stacking_wire.univariate_round_coeffs;
     let mut s_0_sum_eval = ext_chip.zero(ctx);
     for coeff in univariate_round_coeffs.iter().step_by(omega_order) {
         s_0_sum_eval = ext_chip.add(ctx, s_0_sum_eval, *coeff);
@@ -222,26 +214,18 @@ pub(crate) fn constrain_stacked_reduction(
     let zero = ext_chip.zero(ctx);
     ext_chip.assert_equal(ctx, s_0_residual, zero);
 
-    for coeff in &univariate_round_coeffs {
+    for coeff in univariate_round_coeffs {
         transcript.observe_ext(ctx, ext_chip.base(), coeff);
     }
 
     let mut u = Vec::with_capacity(n_stack + 1);
     u.push(transcript.sample_ext(ctx, ext_chip.base()));
 
-    let sumcheck_round_polys = proof
-        .sumcheck_round_polys
-        .iter()
-        .map(|poly| {
-            poly.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
+    let sumcheck_round_polys = &stacking_wire.sumcheck_round_polys;
 
     let mut final_claim =
-        horner_eval_ext_poly_assigned(ctx, ext_chip, &univariate_round_coeffs, &u[0]);
-    for round_poly in &sumcheck_round_polys {
+        horner_eval_ext_poly_assigned(ctx, ext_chip, univariate_round_coeffs, &u[0]);
+    for round_poly in sumcheck_round_polys {
         let s_j_1 = round_poly[0];
         let s_j_2 = round_poly[1];
         transcript.observe_ext(ctx, ext_chip.base(), &s_j_1);
@@ -307,15 +291,7 @@ pub(crate) fn constrain_stacked_reduction(
         }
     }
 
-    let stacking_openings = proof
-        .stacking_openings
-        .iter()
-        .map(|row| {
-            row.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
+    let stacking_openings = &stacking_wire.stacking_openings;
     let mut final_sum = ext_chip.zero(ctx);
     for (coeff_row, opening_row) in derived_q_coeffs.iter().zip(stacking_openings.iter()) {
         for (coeff, opening) in coeff_row.iter().zip(opening_row.iter()) {
@@ -329,7 +305,7 @@ pub(crate) fn constrain_stacked_reduction(
     ext_chip.assert_equal(ctx, final_residual, zero);
 
     StackedReductionWire {
-        stacking_openings,
+        stacking_openings: stacking_openings.clone(),
         u,
     }
 }

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn stacked_reduction_layouts(
 }
 
 #[derive(Clone, Debug)]
-pub struct StackedReductionWire {
+pub struct StackedReductionIntermediatesWire {
     pub stacking_openings: Vec<Vec<BabyBearExtWire>>,
     pub u: Vec<BabyBearExtWire>,
 }
@@ -147,7 +147,7 @@ pub(crate) fn constrain_stacked_reduction(
     n_stack: usize,
     batch_column_openings: &[Vec<Vec<BabyBearExtWire>>],
     r: &[BabyBearExtWire],
-) -> StackedReductionWire {
+) -> StackedReductionIntermediatesWire {
     let omega_order = 1usize << l_skip;
     let one = ext_chip.from_base_const(ctx, RootF::ONE);
 
@@ -304,7 +304,7 @@ pub(crate) fn constrain_stacked_reduction(
     let final_residual = ext_chip.sub(ctx, final_claim, final_sum);
     ext_chip.assert_equal(ctx, final_residual, zero);
 
-    StackedReductionWire {
+    StackedReductionIntermediatesWire {
         stacking_openings: stacking_openings.clone(),
         u,
     }

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -79,7 +79,7 @@ pub struct StackedReductionWire {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct StackingProofWire {
+pub struct StackingProofWire {
     pub univariate_round_coeffs: Vec<BabyBearExtWire>,
     pub sumcheck_round_polys: Vec<Vec<BabyBearExtWire>>,
     pub stacking_openings: Vec<Vec<BabyBearExtWire>>,

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -31,13 +31,13 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub(crate) struct MerklePathWire {
+pub struct MerklePathWire {
     pub leaf_values: Vec<Vec<BabyBearWire>>,
     pub siblings: Vec<AssignedValue<Fr>>,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct WhirProofWire {
+pub struct WhirProofWire {
     pub mu_pow_witness: BabyBearWire,
     pub folding_pow_witnesses: Vec<BabyBearWire>,
     pub query_phase_pow_witnesses: Vec<BabyBearWire>,

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -14,11 +14,6 @@ use openvm_stark_sdk::{
             TwoAdicField,
         },
         proof::WhirProof,
-        verifier::{
-            batch_constraints::BatchConstraintError as NativeBatchConstraintError,
-            proof_shape::ProofShapeError, stacked_reduction::StackedReductionError,
-            whir::VerifyWhirError,
-        },
     },
 };
 
@@ -28,57 +23,145 @@ use crate::{
     },
     hash::poseidon2::{compress_bn254_digests, hash_babybear_slice_to_digest},
     stages::{
-        batch_constraints::{eval_eq_mle_assigned, BatchConstraintError},
+        batch_constraints::eval_eq_mle_assigned,
         shared_math::{horner_eval_ext_poly_assigned, interpolate_quadratic_at_012_assigned},
     },
     transcript::{digest_wire_from_root, TranscriptGadget},
     Fr, RootEF, RootF,
 };
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum WhirError {
-    SystemParamsMismatch,
-    TraceHeightsTooLarge,
-    ProofShape(ProofShapeError),
-    BatchConstraint(NativeBatchConstraintError<RootEF>),
-    StackedReduction(StackedReductionError<RootEF>),
-    Whir(VerifyWhirError),
-    BatchSetup(BatchConstraintError),
+#[derive(Clone, Debug)]
+pub(crate) struct MerklePathWire {
+    pub leaf_values: Vec<Vec<BabyBearWire>>,
+    pub siblings: Vec<AssignedValue<Fr>>,
 }
 
-impl From<ProofShapeError> for WhirError {
-    fn from(value: ProofShapeError) -> Self {
-        Self::ProofShape(value)
-    }
+#[derive(Clone, Debug)]
+pub(crate) struct WhirProofWire {
+    pub mu_pow_witness: BabyBearWire,
+    pub folding_pow_witnesses: Vec<BabyBearWire>,
+    pub query_phase_pow_witnesses: Vec<BabyBearWire>,
+    pub whir_sumcheck_polys: Vec<Vec<BabyBearExtWire>>,
+    pub ood_values: Vec<BabyBearExtWire>,
+    pub final_poly: Vec<BabyBearExtWire>,
+    pub codeword_commitment_roots: Vec<AssignedValue<Fr>>,
+    pub initial_round_merkle_paths: Vec<Vec<MerklePathWire>>,
+    pub codeword_merkle_paths: Vec<Vec<MerklePathWire>>,
 }
 
-impl From<NativeBatchConstraintError<RootEF>> for WhirError {
-    fn from(value: NativeBatchConstraintError<RootEF>) -> Self {
-        Self::BatchConstraint(value)
-    }
-}
+pub(crate) fn load_whir_proof_wire(
+    ctx: &mut Context<Fr>,
+    base_chip: &crate::field::baby_bear::BabyBearChip,
+    ext_chip: &BabyBearExtChip,
+    whir_proof: &WhirProof<RootConfig>,
+) -> WhirProofWire {
+    let mu_pow_witness = base_chip.load_witness(ctx, whir_proof.mu_pow_witness);
+    let folding_pow_witnesses = whir_proof
+        .folding_pow_witnesses
+        .iter()
+        .map(|&witness| base_chip.load_witness(ctx, RootF::from_u64(witness.as_canonical_u64())))
+        .collect::<Vec<_>>();
+    let query_phase_pow_witnesses = whir_proof
+        .query_phase_pow_witnesses
+        .iter()
+        .map(|&witness| base_chip.load_witness(ctx, RootF::from_u64(witness.as_canonical_u64())))
+        .collect::<Vec<_>>();
+    let whir_sumcheck_polys = whir_proof
+        .whir_sumcheck_polys
+        .iter()
+        .map(|poly| {
+            poly.iter()
+                .map(|&value| ext_chip.load_witness(ctx, value))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let ood_values = whir_proof
+        .ood_values
+        .iter()
+        .map(|&value| ext_chip.load_witness(ctx, value))
+        .collect::<Vec<_>>();
+    let final_poly = whir_proof
+        .final_poly
+        .iter()
+        .map(|&value| ext_chip.load_witness(ctx, value))
+        .collect::<Vec<_>>();
+    let codeword_commitment_roots = whir_proof
+        .codeword_commits
+        .iter()
+        .map(|&digest| ctx.load_witness(digest_to_fr(digest)))
+        .collect::<Vec<_>>();
 
-impl From<StackedReductionError<RootEF>> for WhirError {
-    fn from(value: StackedReductionError<RootEF>) -> Self {
-        Self::StackedReduction(value)
-    }
-}
+    let initial_round_merkle_paths = whir_proof
+        .initial_round_opened_rows
+        .iter()
+        .zip(whir_proof.initial_round_merkle_proofs.iter())
+        .map(|(rows_per_query, proofs_per_query)| {
+            rows_per_query
+                .iter()
+                .zip(proofs_per_query.iter())
+                .map(|(opened_rows, merkle_proof)| {
+                    let leaf_values = opened_rows
+                        .iter()
+                        .map(|row| {
+                            row.iter()
+                                .map(|&value| base_chip.load_witness(ctx, value))
+                                .collect::<Vec<BabyBearWire>>()
+                        })
+                        .collect::<Vec<_>>();
+                    let siblings = merkle_proof
+                        .iter()
+                        .map(|&digest| ctx.load_witness(digest_to_fr(digest)))
+                        .collect::<Vec<_>>();
+                    MerklePathWire {
+                        leaf_values,
+                        siblings,
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
 
-impl From<VerifyWhirError> for WhirError {
-    fn from(value: VerifyWhirError) -> Self {
-        Self::Whir(value)
-    }
-}
+    let codeword_merkle_paths = whir_proof
+        .codeword_opened_values
+        .iter()
+        .zip(whir_proof.codeword_merkle_proofs.iter())
+        .map(|(values_per_query, proofs_per_query)| {
+            values_per_query
+                .iter()
+                .zip(proofs_per_query.iter())
+                .map(|(opened_values, merkle_proof)| {
+                    let leaf_values = opened_values
+                        .iter()
+                        .map(|value| {
+                            ext_to_coeffs(*value)
+                                .iter()
+                                .map(|&coeff| base_chip.load_witness(ctx, RootF::from_u64(coeff)))
+                                .collect::<Vec<BabyBearWire>>()
+                        })
+                        .collect::<Vec<_>>();
+                    let siblings = merkle_proof
+                        .iter()
+                        .map(|&digest| ctx.load_witness(digest_to_fr(digest)))
+                        .collect::<Vec<_>>();
+                    MerklePathWire {
+                        leaf_values,
+                        siblings,
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
 
-impl From<BatchConstraintError> for WhirError {
-    fn from(value: BatchConstraintError) -> Self {
-        match value {
-            BatchConstraintError::SystemParamsMismatch => Self::SystemParamsMismatch,
-            BatchConstraintError::TraceHeightsTooLarge => Self::TraceHeightsTooLarge,
-            BatchConstraintError::ProofShape(err) => Self::ProofShape(err),
-            BatchConstraintError::BatchConstraint(err) => Self::BatchConstraint(err),
-            _ => Self::BatchSetup(value),
-        }
+    WhirProofWire {
+        mu_pow_witness,
+        folding_pow_witnesses,
+        query_phase_pow_witnesses,
+        whir_sumcheck_polys,
+        ood_values,
+        final_poly,
+        codeword_commitment_roots,
+        initial_round_merkle_paths,
+        codeword_merkle_paths,
     }
 }
 
@@ -91,17 +174,6 @@ pub(crate) fn ext_to_coeffs(value: RootEF) -> [u64; BABY_BEAR_EXT_DEGREE] {
 
 fn digest_to_fr(digest: RootDigest) -> Fr {
     biguint_to_fe(&digest[0].as_canonical_biguint())
-}
-
-fn base_slice_to_u64_vec(values: &[RootF]) -> Vec<u64> {
-    values
-        .iter()
-        .map(|value| value.as_canonical_u64())
-        .collect::<Vec<_>>()
-}
-
-fn ext_to_u64_vec(value: RootEF) -> Vec<u64> {
-    ext_to_coeffs(value).to_vec()
 }
 
 fn eval_mobius_eq_mle_assigned(
@@ -268,20 +340,15 @@ fn tree_compress_assigned_digests(
         .expect("tree_compress must output one digest for non-empty inputs")
 }
 
-struct MerkleWire {
-    leaf_values: Vec<Vec<BabyBearWire>>,
-}
-
 fn constrain_merkle_path(
     ctx: &mut Context<Fr>,
     ext_chip: &BabyBearExtChip,
     query_bits: &[AssignedValue<Fr>],
-    leaf_inputs: &[Vec<u64>],
-    siblings: &[Fr],
+    merkle_path: &MerklePathWire,
     root_digest: AssignedValue<Fr>,
-) -> MerkleWire {
+) {
     assert!(
-        leaf_inputs.len().is_power_of_two(),
+        merkle_path.leaf_values.len().is_power_of_two(),
         "leaf input count must be power of two"
     );
 
@@ -289,20 +356,13 @@ fn constrain_merkle_path(
     let one = ctx.load_constant(Fr::from(1u64));
 
     assert_eq!(
-        siblings.len(),
+        merkle_path.siblings.len(),
         query_bits.len(),
         "merkle path depth must match query bits",
     );
 
-    let leaf_values = leaf_inputs
-        .iter()
-        .map(|leaf| {
-            leaf.iter()
-                .map(|&value| ext_chip.base().load_witness(ctx, RootF::from_u64(value)))
-                .collect::<Vec<BabyBearWire>>()
-        })
-        .collect::<Vec<_>>();
-    let leaf_hashes = leaf_values
+    let leaf_hashes = merkle_path
+        .leaf_values
         .iter()
         .map(|leaf| hash_babybear_slice_to_digest(ctx, ext_chip.range(), leaf))
         .collect::<Vec<_>>();
@@ -310,8 +370,7 @@ fn constrain_merkle_path(
     let mut cur = tree_compress_assigned_digests(ctx, ext_chip, leaf_hashes);
     let query_bits = query_bits.to_vec();
 
-    for (bit, sibling_digest) in query_bits.iter().zip(siblings.iter()) {
-        let sibling = ctx.load_witness(*sibling_digest);
+    for (bit, &sibling) in query_bits.iter().zip(merkle_path.siblings.iter()) {
         let left_right = compress_bn254_digests(ctx, ext_chip.range(), cur, sibling);
         let right_left = compress_bn254_digests(ctx, ext_chip.range(), sibling, cur);
         let one_minus_bit = gate.sub(ctx, one, *bit);
@@ -321,7 +380,6 @@ fn constrain_merkle_path(
     }
 
     ctx.constrain_equal(&cur, &root_digest);
-    MerkleWire { leaf_values }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -330,7 +388,7 @@ pub(crate) fn constrain_whir_verification(
     ext_chip: &BabyBearExtChip,
     transcript: &mut TranscriptGadget,
     mvk0: &MultiStarkVerifyingKey0<RootConfig>,
-    whir_proof: &WhirProof<RootConfig>,
+    whir_wire: &WhirProofWire,
     stacking_openings: &[Vec<BabyBearExtWire>],
     initial_commitment_roots: &[AssignedValue<Fr>],
     u_cube: &[BabyBearExtWire],
@@ -341,52 +399,16 @@ pub(crate) fn constrain_whir_verification(
     let k_whir = params.k_whir();
     let num_whir_rounds = params.num_whir_rounds();
 
-    let mu_pow_witness = ext_chip.base().load_witness(ctx, whir_proof.mu_pow_witness);
+    let mu_pow_witness = whir_wire.mu_pow_witness;
     transcript.check_witness(ctx, base_chip, params.whir.mu_pow_bits, &mu_pow_witness);
     let mu_challenge = transcript.sample_ext(ctx, ext_chip.base());
 
-    let folding_pow_witnesses = whir_proof
-        .folding_pow_witnesses
-        .iter()
-        .map(|&witness| {
-            ext_chip
-                .base()
-                .load_witness(ctx, RootF::from_u64(witness.as_canonical_u64()))
-        })
-        .collect::<Vec<_>>();
-    let query_phase_pow_witnesses = whir_proof
-        .query_phase_pow_witnesses
-        .iter()
-        .map(|&witness| {
-            ext_chip
-                .base()
-                .load_witness(ctx, RootF::from_u64(witness.as_canonical_u64()))
-        })
-        .collect::<Vec<_>>();
-    let whir_sumcheck_polys = whir_proof
-        .whir_sumcheck_polys
-        .iter()
-        .map(|poly| {
-            poly.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-    let ood_values = whir_proof
-        .ood_values
-        .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
-        .collect::<Vec<_>>();
-    let final_poly = whir_proof
-        .final_poly
-        .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
-        .collect::<Vec<_>>();
-    let codeword_commitment_roots = whir_proof
-        .codeword_commits
-        .iter()
-        .map(|&digest| ctx.load_witness(digest_to_fr(digest)))
-        .collect::<Vec<_>>();
+    let folding_pow_witnesses = &whir_wire.folding_pow_witnesses;
+    let query_phase_pow_witnesses = &whir_wire.query_phase_pow_witnesses;
+    let whir_sumcheck_polys = &whir_wire.whir_sumcheck_polys;
+    let ood_values = &whir_wire.ood_values;
+    let final_poly = &whir_wire.final_poly;
+    let codeword_commitment_roots = &whir_wire.codeword_commitment_roots;
     let codeword_commitment_digests = codeword_commitment_roots
         .iter()
         .copied()
@@ -463,7 +485,7 @@ pub(crate) fn constrain_whir_verification(
         folding_counts_per_round.push(alphas_round.len());
 
         let y0 = if is_final_round {
-            for coeff in &final_poly {
+            for coeff in final_poly {
                 transcript.observe_ext(ctx, ext_chip.base(), coeff);
             }
             None
@@ -513,27 +535,17 @@ pub(crate) fn constrain_whir_verification(
                 let mut codeword_vals = vec![ext_chip.zero(ctx); 1usize << k_whir];
                 let mut mu_power_idx = 0usize;
                 for (commit_idx, commit_openings) in stacking_openings.iter().enumerate() {
-                    let opened_rows = &whir_proof.initial_round_opened_rows[commit_idx][query_idx];
-                    let siblings = whir_proof.initial_round_merkle_proofs[commit_idx][query_idx]
-                        .iter()
-                        .copied()
-                        .map(digest_to_fr)
-                        .collect::<Vec<_>>();
-                    let leaf_inputs = opened_rows
-                        .iter()
-                        .map(|row| base_slice_to_u64_vec(row))
-                        .collect::<Vec<_>>();
-                    let payload = constrain_merkle_path(
+                    let merkle_path = &whir_wire.initial_round_merkle_paths[commit_idx][query_idx];
+                    constrain_merkle_path(
                         ctx,
                         ext_chip,
                         &query_bits_vec,
-                        &leaf_inputs,
-                        &siblings,
+                        merkle_path,
                         initial_commitment_roots[commit_idx],
                     );
                     for col_idx in 0..commit_openings.len() {
                         let mu_pow = mu_pows[mu_power_idx];
-                        for (row_idx, row) in payload.leaf_values.iter().enumerate() {
+                        for (row_idx, row) in merkle_path.leaf_values.iter().enumerate() {
                             let opened_base = row[col_idx];
                             let opened_ext = ext_chip.from_base_var(ctx, opened_base);
                             let weighted = ext_chip.mul(ctx, opened_ext, mu_pow);
@@ -545,25 +557,15 @@ pub(crate) fn constrain_whir_verification(
                 }
                 binary_k_fold_assigned(ctx, ext_chip, codeword_vals, &alphas_round, zi_root_base)
             } else {
-                let opened_values = &whir_proof.codeword_opened_values[round_idx - 1][query_idx];
-                let siblings = whir_proof.codeword_merkle_proofs[round_idx - 1][query_idx]
-                    .iter()
-                    .copied()
-                    .map(digest_to_fr)
-                    .collect::<Vec<_>>();
-                let leaf_inputs = opened_values
-                    .iter()
-                    .map(|value| ext_to_u64_vec(*value))
-                    .collect::<Vec<_>>();
-                let payload = constrain_merkle_path(
+                let merkle_path = &whir_wire.codeword_merkle_paths[round_idx - 1][query_idx];
+                constrain_merkle_path(
                     ctx,
                     ext_chip,
                     &query_bits_vec,
-                    &leaf_inputs,
-                    &siblings,
+                    merkle_path,
                     codeword_commitment_roots[round_idx - 1],
                 );
-                let opened_values = payload
+                let opened_values = merkle_path
                     .leaf_values
                     .iter()
                     .map(|row| BabyBearExt4Wire(core::array::from_fn(|idx| row[idx])))
@@ -595,7 +597,7 @@ pub(crate) fn constrain_whir_verification(
     let rounds = query_counts_per_round.len();
     let t = k_whir * rounds;
     let prefix = eval_mobius_eq_mle_assigned(ctx, ext_chip, &u_cube[..t], &folding_alphas[..t]);
-    let suffix = eval_mle_evals_at_point_assigned(ctx, ext_chip, &final_poly, &u_cube[t..]);
+    let suffix = eval_mle_evals_at_point_assigned(ctx, ext_chip, final_poly, &u_cube[t..]);
     let mut final_acc = ext_chip.mul(ctx, prefix, suffix);
 
     let mut alpha_offset = k_whir;
@@ -623,7 +625,7 @@ pub(crate) fn constrain_whir_verification(
                 alpha_slc,
                 &z0_pows[..z0_pows.len().saturating_sub(1)],
             );
-            let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, &final_poly, &z0_max);
+            let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, final_poly, &z0_max);
             let term = ext_chip.mul(ctx, *gamma, eq);
             let term = ext_chip.mul(ctx, term, poly_eval);
             final_acc = ext_chip.add(ctx, final_acc, term);
@@ -648,7 +650,7 @@ pub(crate) fn constrain_whir_verification(
                 alpha_slc,
                 &zi_pows[..zi_pows.len().saturating_sub(1)],
             );
-            let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, &final_poly, &zi_max);
+            let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, final_poly, &zi_max);
             let term = ext_chip.mul(ctx, gamma_pow, eq);
             let term = ext_chip.mul(ctx, term, poly_eval);
             final_acc = ext_chip.add(ctx, final_acc, term);


### PR DESCRIPTION
## Summary
- Extract all `load_witness` calls into upfront `*Wire` structs and loader functions, separating witness loading from constraint logic across batch_constraints, stacked_reduction, whir, and full_pipeline stages
- Remove vestigial error enums (`BatchConstraintError`, `StackedReductionConstraintError`, `WhirError`, `PipelineError`) — all checks are host-only structural asserts, not circuit witness validations
- Fix soundness: `mvk.pre_hash` is now `load_constant` (verifying key data), `common_main_commit` is loaded as witness in `ProofWire`; `constrained_verify` takes `ProofWire` and returns the statement public inputs

## Test plan
- [x] `cargo nextest run --cargo-profile=fast -p openvm-static-verifier` — all 12 tests pass
- [x] `cargo clippy -p openvm-static-verifier --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean

closes INT-6942