### PR TITLE
refactor(static-verifier): host-fixed StaticVerifierCircuit + stored stacked layouts

### DIFF
--- a/crates/static-verifier/src/circuit.rs
+++ b/crates/static-verifier/src/circuit.rs
@@ -1,0 +1,186 @@
+//! Host-fixed parameters for the static verifier Halo2 circuit (see crate `lib.rs`).
+
+use core::cmp::Reverse;
+use std::fmt;
+
+use halo2_base::{
+    gates::circuit::builder::BaseCircuitBuilder, halo2_proofs::halo2curves::bn256::Fr,
+};
+use itertools::Itertools;
+use openvm_stark_sdk::{
+    config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
+    openvm_stark_backend::{
+        keygen::types::{MultiStarkVerifyingKey, MultiStarkVerifyingKey0},
+        proof::Proof,
+        prover::stacked_pcs::StackedLayout,
+    },
+};
+
+use crate::stages::{
+    full_pipeline::{constrained_verify, load_proof_wire},
+    proof_shape::{compute_trace_id_to_air_id, trace_id_order_from_static_heights},
+};
+
+/// Builds stacked PCS layouts for the static verifier from VK widths and fixed per-air log heights.
+pub(crate) fn build_stacked_layouts_for_static_vk(
+    mvk0: &MultiStarkVerifyingKey0<RootConfig>,
+    log_heights_per_air: &[usize],
+) -> Vec<StackedLayout> {
+    let l_skip = mvk0.params.l_skip;
+    assert_eq!(
+        log_heights_per_air.len(),
+        mvk0.per_air.len(),
+        "log_heights_per_air length must match VK per_air count"
+    );
+    let mut per_trace = mvk0
+        .per_air
+        .iter()
+        .enumerate()
+        .map(|(air_idx, vk)| (air_idx, vk, log_heights_per_air[air_idx]))
+        .collect::<Vec<_>>();
+    per_trace.sort_by_key(|(_, _, log_height)| Reverse(*log_height));
+
+    let common_main_layout = StackedLayout::new(
+        l_skip,
+        mvk0.params.n_stack + l_skip,
+        per_trace
+            .iter()
+            .map(|(_, vk, log_height)| (vk.params.width.common_main, *log_height))
+            .collect::<Vec<_>>(),
+    )
+    .expect("stacked layout for common main");
+    let other_layouts = per_trace
+        .iter()
+        .flat_map(|(_, vk, log_height)| {
+            vk.params
+                .width
+                .preprocessed
+                .iter()
+                .chain(&vk.params.width.cached_mains)
+                .copied()
+                .map(|width| (width, *log_height))
+                .collect::<Vec<_>>()
+        })
+        .map(|sorted| {
+            StackedLayout::new(l_skip, mvk0.params.n_stack + l_skip, vec![sorted])
+                .expect("stacked layout for auxiliary column")
+        })
+        .collect::<Vec<_>>();
+    core::iter::once(common_main_layout)
+        .chain(other_layouts)
+        .collect::<Vec<_>>()
+}
+
+/// Error building [`StaticVerifierCircuit`] from a template child proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StaticCircuitParamsError {
+    TraceVdataLenMismatch {
+        expected: usize,
+        got: usize,
+    },
+    MissingTraceVData {
+        air_id: usize,
+    },
+    /// `compute_trace_id_to_air_id` disagrees with height-only ordering (should not happen for a
+    /// valid proof whose `trace_vdata` matches the extracted heights).
+    TraceOrderingMismatch,
+}
+
+impl fmt::Display for StaticCircuitParamsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TraceVdataLenMismatch { expected, got } => {
+                write!(
+                    f,
+                    "trace_vdata length {got} != VK per_air length {expected}"
+                )
+            }
+            Self::MissingTraceVData { air_id } => {
+                write!(f, "missing trace_vdata for air_id {air_id}")
+            }
+            Self::TraceOrderingMismatch => {
+                write!(
+                    f,
+                    "trace_id_to_air_id from proof does not match static height ordering"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for StaticCircuitParamsError {}
+
+/// Parameters fixed host-side for the static verifier (child VK, trace heights, AIR permutation).
+#[derive(Clone, Debug)]
+pub struct StaticVerifierCircuit {
+    pub child_vk: MultiStarkVerifyingKey<RootConfig>,
+    pub log_heights_per_air: Vec<usize>,
+    pub trace_id_to_air_id: Vec<usize>,
+    pub stacked_layouts: Vec<StackedLayout>,
+}
+
+impl StaticVerifierCircuit {
+    /// Build static parameters from a child VK and any valid root proof with the target shape.
+    ///
+    /// Every AIR must have `trace_vdata` present. The stored permutation matches
+    /// [`compute_trace_id_to_air_id`] on the template proof.
+    pub fn try_new(
+        child_vk: MultiStarkVerifyingKey<RootConfig>,
+        template_proof: &Proof<RootConfig>,
+    ) -> Result<Self, StaticCircuitParamsError> {
+        let n = child_vk.inner.per_air.len();
+        if template_proof.trace_vdata.len() != n {
+            return Err(StaticCircuitParamsError::TraceVdataLenMismatch {
+                expected: n,
+                got: template_proof.trace_vdata.len(),
+            });
+        }
+        let mut log_heights_per_air = Vec::with_capacity(n);
+        for (air_id, tv) in template_proof.trace_vdata.iter().enumerate() {
+            let Some(vd) = tv.as_ref() else {
+                return Err(StaticCircuitParamsError::MissingTraceVData { air_id });
+            };
+            log_heights_per_air.push(vd.log_height);
+        }
+        let from_proof = compute_trace_id_to_air_id(&child_vk.inner, template_proof);
+        let from_heights =
+            trace_id_order_from_static_heights(&child_vk.inner, &log_heights_per_air);
+        if from_proof != from_heights {
+            return Err(StaticCircuitParamsError::TraceOrderingMismatch);
+        }
+        let stacked_layouts =
+            build_stacked_layouts_for_static_vk(&child_vk.inner, &log_heights_per_air);
+        Ok(Self {
+            child_vk,
+            log_heights_per_air,
+            trace_id_to_air_id: from_heights,
+            stacked_layouts,
+        })
+    }
+
+    /// Populate a builder with the static verifier constraints and return the public inputs.
+    pub fn populate(
+        &self,
+        builder: &mut BaseCircuitBuilder<Fr>,
+        proof: &Proof<RootConfig>,
+    ) -> Vec<Fr> {
+        let range = builder.range_chip();
+        let ctx = builder.main(0);
+        let proof_wire = load_proof_wire(ctx, &range, proof, &self.log_heights_per_air);
+        let statement_public_inputs = constrained_verify(
+            ctx,
+            &range,
+            &self.child_vk,
+            proof_wire,
+            &self.trace_id_to_air_id,
+            &self.log_heights_per_air,
+            &self.stacked_layouts,
+        );
+        let pis = statement_public_inputs
+            .iter()
+            .map(|c| *c.value())
+            .collect_vec();
+        builder.assigned_instances[0].extend(statement_public_inputs);
+        pis
+    }
+}

--- a/crates/static-verifier/src/keygen.rs
+++ b/crates/static-verifier/src/keygen.rs
@@ -2,27 +2,30 @@ use halo2_base::{
     gates::circuit::CircuitBuilderStage,
     halo2_proofs::plonk::{keygen_pk, keygen_vk},
 };
+use openvm_stark_sdk::{
+    config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
+    openvm_stark_backend::proof::Proof,
+};
 
 use crate::{
+    circuit::StaticVerifierCircuit,
     config::StaticVerifierShape,
-    prover::{
-        Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning, StaticVerifierCircuit,
-        StaticVerifierInput, StaticVerifierProof,
-    },
+    prover::{Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning, StaticVerifierProof},
 };
 
 impl StaticVerifierCircuit {
     /// Run keygen to produce a [`Halo2ProvingPinning`].
     ///
-    /// The `input` is used as a representative witness for keygen; any valid
-    /// input for the target circuit shape will do.
+    /// The `representative_proof` is used as a witness for keygen; any valid proof for this static
+    /// circuit shape will do.
     pub fn keygen(
+        &self,
         params: &Halo2Params,
         shape: &StaticVerifierShape,
-        input: &StaticVerifierInput<'_>,
+        representative_proof: &Proof<RootConfig>,
     ) -> Halo2ProvingPinning {
         let mut builder = Self::builder(CircuitBuilderStage::Keygen, shape);
-        let public_inputs = Self::populate(&mut builder, input);
+        let public_inputs = self.populate(&mut builder, representative_proof);
 
         let config_params = builder.calculate_params(Some(shape.minimum_rows));
 
@@ -41,32 +44,34 @@ impl StaticVerifierCircuit {
     }
 }
 
-/// High-level proving key that owns a [`Halo2ProvingPinning`] together with
-/// the [`StaticVerifierShape`] needed to reconstruct prover builders.
+/// High-level proving key that owns a [`StaticVerifierCircuit`], [`Halo2ProvingPinning`], and
+/// [`StaticVerifierShape`].
 pub struct StaticVerifierProvingKey {
+    pub circuit: StaticVerifierCircuit,
     pub pinning: Halo2ProvingPinning,
     pub shape: StaticVerifierShape,
 }
 
 impl StaticVerifierProvingKey {
-    /// Run keygen and return a proving key that can be reused for multiple
-    /// proofs.
+    /// Run keygen and return a proving key that can be reused for multiple proofs.
     pub fn keygen(
         params: &Halo2Params,
         shape: StaticVerifierShape,
-        input: &StaticVerifierInput<'_>,
+        circuit: StaticVerifierCircuit,
+        representative_proof: &Proof<RootConfig>,
     ) -> Self {
-        let pinning = StaticVerifierCircuit::keygen(params, &shape, input);
-        Self { pinning, shape }
+        let pinning = circuit.keygen(params, &shape, representative_proof);
+        Self {
+            circuit,
+            pinning,
+            shape,
+        }
     }
 
     /// Generate a proof using the stored pinning and shape.
-    pub fn prove(
-        &self,
-        params: &Halo2Params,
-        input: &StaticVerifierInput<'_>,
-    ) -> StaticVerifierProof {
-        StaticVerifierCircuit::prove(params, &self.pinning, &self.shape, input)
+    pub fn prove(&self, params: &Halo2Params, proof: &Proof<RootConfig>) -> StaticVerifierProof {
+        self.circuit
+            .prove(params, &self.pinning, &self.shape, proof)
     }
 
     /// Verify a proof against this proving key's verifying key.
@@ -130,18 +135,14 @@ impl StaticVerifierProvingKey {
     }
 
     /// Generate an EVM-compatible proof.
-    pub fn prove_for_evm(
-        &self,
-        params: &Halo2Params,
-        input: &StaticVerifierInput<'_>,
-    ) -> RawEvmProof {
+    pub fn prove_for_evm(&self, params: &Halo2Params, proof: &Proof<RootConfig>) -> RawEvmProof {
         let mut builder = BaseCircuitBuilder::prover(
             self.pinning.metadata.config_params.clone(),
             self.pinning.metadata.break_points.clone(),
         )
         .use_instance_columns(self.shape.instance_columns);
 
-        let public_inputs = StaticVerifierCircuit::populate(&mut builder, input);
+        let public_inputs = self.circuit.populate(&mut builder, proof);
 
         let snark = gen_evm_proof_shplonk(
             params,

--- a/crates/static-verifier/src/lib.rs
+++ b/crates/static-verifier/src/lib.rs
@@ -11,6 +11,7 @@
 //!   verifying key is optional.
 #![forbid(unsafe_code)]
 
+mod circuit;
 pub mod config;
 pub mod field;
 pub mod hash;
@@ -20,13 +21,11 @@ pub mod stages;
 pub mod transcript;
 mod utils;
 
+pub use circuit::{StaticCircuitParamsError, StaticVerifierCircuit};
 pub use config::{
     StaticVerifierShape, STATIC_VERIFIER_LOOKUP_ADVICE_COLS, STATIC_VERIFIER_NUM_ADVICE_COLS,
 };
 pub use halo2_base::halo2_proofs::halo2curves::bn256::Fr;
 pub use keygen::StaticVerifierProvingKey;
 pub use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{EF as RootEF, F as RootF};
-pub use prover::{
-    Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning, StaticVerifierCircuit,
-    StaticVerifierInput, StaticVerifierProof,
-};
+pub use prover::{Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning, StaticVerifierProof};

--- a/crates/static-verifier/src/prover.rs
+++ b/crates/static-verifier/src/prover.rs
@@ -20,18 +20,14 @@ use halo2_base::{
         },
     },
 };
-use itertools::Itertools;
 use openvm_stark_sdk::{
     config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
-    openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, proof::Proof},
+    openvm_stark_backend::proof::Proof,
 };
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    config::StaticVerifierShape,
-    stages::full_pipeline::{constrained_verify, load_proof_wire},
-};
+use crate::{circuit::StaticVerifierCircuit, config::StaticVerifierShape};
 
 /// KZG parameters for the Halo2 BN256 proving system.
 pub type Halo2Params = ParamsKZG<Bn256>;
@@ -66,19 +62,6 @@ pub struct StaticVerifierProof {
     pub public_inputs: Vec<Fr>,
 }
 
-/// Bundles the three inputs that always travel together when interacting with
-/// the static verifier circuit.
-pub struct StaticVerifierInput<'a> {
-    pub mvk: &'a MultiStarkVerifyingKey<RootConfig>,
-    pub proof: &'a Proof<RootConfig>,
-}
-
-/// Stateless helper for the static verifier Halo2 circuit.
-///
-/// Provides circuit-building utilities (`builder`, `populate`), mock proving,
-/// real proving, and verification. Keygen is in [`crate::keygen`].
-pub struct StaticVerifierCircuit;
-
 impl StaticVerifierCircuit {
     /// Create a [`BaseCircuitBuilder`] configured for the given `stage` and
     /// `shape`.
@@ -92,30 +75,10 @@ impl StaticVerifierCircuit {
             .use_instance_columns(shape.instance_columns)
     }
 
-    /// Populate a builder with the static verifier constraints and return the
-    /// public inputs.
-    pub fn populate(
-        builder: &mut BaseCircuitBuilder<Fr>,
-        input: &StaticVerifierInput<'_>,
-    ) -> Vec<Fr> {
-        let range = builder.range_chip();
-        let ctx = builder.main(0);
-        let proof_wire = load_proof_wire(ctx, &range, input.proof);
-        let statement_public_inputs =
-            constrained_verify(ctx, &range, input.mvk, input.proof, proof_wire);
-        let pis = statement_public_inputs
-            .iter()
-            .map(|c| *c.value())
-            .collect_vec();
-        builder.assigned_instances[0].extend(statement_public_inputs);
-
-        pis
-    }
-
     /// Run the [`MockProver`] and panic if any constraint is unsatisfied.
-    pub fn mock(shape: &StaticVerifierShape, input: &StaticVerifierInput<'_>) {
+    pub fn mock(&self, shape: &StaticVerifierShape, proof: &Proof<RootConfig>) {
         let mut builder = Self::builder(CircuitBuilderStage::Mock, shape);
-        let public_inputs = Self::populate(&mut builder, input);
+        let public_inputs = self.populate(&mut builder, proof);
 
         let _ = builder.calculate_params(Some(shape.minimum_rows));
 
@@ -126,10 +89,11 @@ impl StaticVerifierCircuit {
 
     /// Generate a Halo2 proof using a previously computed [`Halo2ProvingPinning`].
     pub fn prove(
+        &self,
         params: &Halo2Params,
         pinning: &Halo2ProvingPinning,
         shape: &StaticVerifierShape,
-        input: &StaticVerifierInput<'_>,
+        proof: &Proof<RootConfig>,
     ) -> StaticVerifierProof {
         let mut builder = BaseCircuitBuilder::prover(
             pinning.metadata.config_params.clone(),
@@ -137,7 +101,7 @@ impl StaticVerifierCircuit {
         );
         builder = builder.use_instance_columns(shape.instance_columns);
 
-        let public_inputs = Self::populate(&mut builder, input);
+        let public_inputs = self.populate(&mut builder, proof);
 
         let rng = ChaCha20Rng::from_seed(Default::default());
         let instances: &[&[Fr]] = &[&public_inputs];

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -7,6 +7,7 @@ use openvm_stark_sdk::{
         keygen::types::{MultiStarkVerifyingKey, MultiStarkVerifyingKey0},
         p3_field::PrimeField,
         proof::Proof,
+        prover::stacked_pcs::StackedLayout,
     },
 };
 
@@ -17,10 +18,8 @@ use crate::{
             constrain_batch_constraints_verification, load_batch_constraint_proof_wire,
             load_gkr_proof_wire, BatchConstraintProofWire, GkrProofWire,
         },
-        proof_shape::compute_trace_id_to_air_id,
         stacked_reduction::{
-            constrain_stacked_reduction, load_stacking_proof_wire, stacked_reduction_layouts,
-            StackingProofWire,
+            constrain_stacked_reduction, load_stacking_proof_wire, StackingProofWire,
         },
         whir::{constrain_whir_verification, load_whir_proof_wire, WhirProofWire},
     },
@@ -46,11 +45,35 @@ pub(crate) fn digest_scalar_to_fr(value: Bn254Scalar) -> Fr {
     biguint_to_fe(&value.as_canonical_biguint())
 }
 
+/// Load proof data into Halo2 cells. `log_heights_per_air` must match this circuit's fixed heights;
+/// host-side asserts enforce that every `proof.trace_vdata[air_id].log_height` agrees.
 pub fn load_proof_wire(
     ctx: &mut Context<Fr>,
     range: &RangeChip<Fr>,
     proof: &Proof<RootConfig>,
+    log_heights_per_air: &[usize],
 ) -> ProofWire {
+    assert_eq!(
+        proof.trace_vdata.len(),
+        log_heights_per_air.len(),
+        "proof.trace_vdata length must match log_heights_per_air"
+    );
+    for (air_id, (tv, &expected_log_height)) in proof
+        .trace_vdata
+        .iter()
+        .zip(log_heights_per_air.iter())
+        .enumerate()
+    {
+        let Some(vd) = tv.as_ref() else {
+            panic!("static verifier proof must include trace_vdata for air_id {air_id}");
+        };
+        assert_eq!(
+            vd.log_height, expected_log_height,
+            "trace log_height mismatch for air_id {air_id}: proof has {}, circuit expects {}",
+            vd.log_height, expected_log_height
+        );
+    }
+
     let base_chip = Arc::new(BabyBearChip::new(Arc::new(range.clone())));
     let ext_chip = BabyBearExtChip::new(base_chip.clone());
 
@@ -106,7 +129,7 @@ fn observe_preamble(
     range: &RangeChip<Fr>,
     transcript: &mut TranscriptGadget,
     mvk: &MultiStarkVerifyingKey<RootConfig>,
-    proof: &Proof<RootConfig>,
+    log_heights_per_air: &[usize],
     public_values: &[Vec<BabyBearWire>],
     cached_commitment_roots: &[Vec<AssignedValue<Fr>>],
     statement_public_inputs: [AssignedValue<Fr>; 2],
@@ -126,8 +149,8 @@ fn observe_preamble(
 
     for air_idx in 0..mvk.inner.per_air.len() {
         if !mvk.inner.per_air[air_idx].is_required {
-            let presence_flag =
-                ctx.load_constant(Fr::from(proof.trace_vdata[air_idx].is_some() as u64));
+            // Static verifier: every AIR in the child VK has a trace (see crate `lib.rs`).
+            let presence_flag = ctx.load_constant(Fr::one());
             transcript.observe(
                 ctx,
                 &base_chip,
@@ -138,35 +161,24 @@ fn observe_preamble(
             );
         }
 
-        if proof.trace_vdata[air_idx].is_some() {
-            if let Some(preprocessed) = mvk.inner.per_air[air_idx].preprocessed_data.as_ref() {
-                let preprocessed_root =
-                    ctx.load_constant(digest_scalar_to_fr(preprocessed.commit[0]));
-                transcript.observe_commit(
-                    ctx,
-                    &base_chip,
-                    &digest_wire_from_root(preprocessed_root),
-                );
-            } else {
-                let log_height = ctx.load_constant(Fr::from(
-                    proof.trace_vdata[air_idx]
-                        .as_ref()
-                        .expect("present air must include trace vdata")
-                        .log_height as u64,
-                ));
-                transcript.observe(
-                    ctx,
-                    &base_chip,
-                    &BabyBearWire {
-                        value: log_height,
-                        max_bits: BABY_BEAR_BITS,
-                    },
-                );
-            }
+        if let Some(preprocessed) = mvk.inner.per_air[air_idx].preprocessed_data.as_ref() {
+            let preprocessed_root = ctx.load_constant(digest_scalar_to_fr(preprocessed.commit[0]));
+            transcript.observe_commit(ctx, &base_chip, &digest_wire_from_root(preprocessed_root));
+        } else {
+            // Fixed circuit parameter (not loaded from the proof witness).
+            let log_height = ctx.load_constant(Fr::from(log_heights_per_air[air_idx] as u64));
+            transcript.observe(
+                ctx,
+                &base_chip,
+                &BabyBearWire {
+                    value: log_height,
+                    max_bits: BABY_BEAR_BITS,
+                },
+            );
+        }
 
-            for root in &cached_commitment_roots[air_idx] {
-                transcript.observe_commit(ctx, &base_chip, &digest_wire_from_root(*root));
-            }
+        for root in &cached_commitment_roots[air_idx] {
+            transcript.observe_commit(ctx, &base_chip, &digest_wire_from_root(*root));
         }
 
         for value in &public_values[air_idx] {
@@ -177,30 +189,38 @@ fn observe_preamble(
 
 /// Run the full static verifier pipeline on pre-loaded witness data.
 ///
+/// `trace_id_to_air_id` and `log_heights_per_air` are fixed for this circuit (host-side). They must
+/// match the child proof shape: `log_heights_per_air.len() == mvk.inner.per_air.len()`, and
+/// `trace_id_to_air_id` must list every `air_id` exactly once in descending-`log_height` order
+/// (tie-break: ascending `air_id`).
+///
+/// `stacked_layouts` must be the layout vector fixed for this circuit (same as stored on
+/// [`crate::StaticVerifierCircuit`]).
+///
 /// Returns the two statement public inputs as assigned cells:
 /// `[mvk_pre_hash_root, common_main_commit_root]`.
 pub fn constrained_verify(
     ctx: &mut Context<Fr>,
     range: &RangeChip<Fr>,
     mvk: &MultiStarkVerifyingKey<RootConfig>,
-    proof: &Proof<RootConfig>,
     proof_wire: ProofWire,
+    trace_id_to_air_id: &[usize],
+    log_heights_per_air: &[usize],
+    stacked_layouts: &[StackedLayout],
 ) -> [AssignedValue<Fr>; 2] {
+    assert_eq!(
+        log_heights_per_air.len(),
+        mvk.inner.per_air.len(),
+        "log_heights_per_air must match VK per_air count"
+    );
     let l_skip = mvk.inner.params.l_skip;
-    let trace_id_to_air_id = compute_trace_id_to_air_id(&mvk.inner, proof);
 
     let mvk_pre_hash_root = ctx.load_constant(digest_scalar_to_fr(mvk.pre_hash[0]));
     let statement_public_inputs = [mvk_pre_hash_root, proof_wire.common_main_commit_root];
 
     let n_per_trace: Vec<isize> = trace_id_to_air_id
         .iter()
-        .map(|&air_id| {
-            proof.trace_vdata[air_id]
-                .as_ref()
-                .expect("present air must have trace vdata")
-                .log_height as isize
-                - l_skip as isize
-        })
+        .map(|&air_id| log_heights_per_air[air_id] as isize - l_skip as isize)
         .collect();
 
     let mut transcript = TranscriptGadget::new(ctx);
@@ -209,7 +229,7 @@ pub fn constrained_verify(
         range,
         &mut transcript,
         mvk,
-        proof,
+        log_heights_per_air,
         &proof_wire.public_values,
         &proof_wire.cached_commitment_roots,
         statement_public_inputs,
@@ -226,18 +246,17 @@ pub fn constrained_verify(
         &proof_wire.gkr,
         &proof_wire.batch,
         &n_per_trace,
-        &trace_id_to_air_id,
+        trace_id_to_air_id,
         proof_wire.public_values,
     );
 
-    let layouts = stacked_reduction_layouts(&mvk.inner, proof);
-    let need_rot_per_commit = get_need_rot_per_commit(&mvk.inner, proof, &trace_id_to_air_id);
+    let need_rot_per_commit = get_need_rot_per_commit(&mvk.inner, trace_id_to_air_id);
     let stacked_reduction = constrain_stacked_reduction(
         ctx,
         &ext_chip,
         &mut transcript,
         &proof_wire.stacking,
-        &layouts,
+        stacked_layouts,
         &need_rot_per_commit,
         l_skip,
         mvk.inner.params.n_stack,
@@ -261,7 +280,7 @@ pub fn constrained_verify(
     let initial_commitment_roots = {
         let common_main_root = statement_public_inputs[1];
         let mut commits = vec![common_main_root];
-        for &air_id in &trace_id_to_air_id {
+        for &air_id in trace_id_to_air_id {
             if let Some(preprocessed) = &mvk.inner.per_air[air_id].preprocessed_data {
                 commits.push(ctx.load_constant(digest_scalar_to_fr(preprocessed.commit[0])));
             }
@@ -287,7 +306,6 @@ pub fn constrained_verify(
 /// Helper function, purely on out-of-circuit values.
 fn get_need_rot_per_commit(
     mvk0: &MultiStarkVerifyingKey0<RootConfig>,
-    proof: &Proof<RootConfig>,
     trace_id_to_air_id: &[usize],
 ) -> Vec<Vec<bool>> {
     let mut need_rot_per_commit = vec![trace_id_to_air_id
@@ -299,11 +317,7 @@ fn get_need_rot_per_commit(
         if mvk0.per_air[air_id].preprocessed_data.is_some() {
             need_rot_per_commit.push(vec![need_rot]);
         }
-        let cached_len = proof.trace_vdata[air_id]
-            .as_ref()
-            .expect("present air must have trace vdata")
-            .cached_commitments
-            .len();
+        let cached_len = mvk0.per_air[air_id].params.width.cached_mains.len();
         for _ in 0..cached_len {
             need_rot_per_commit.push(vec![need_rot]);
         }

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -5,14 +5,15 @@ use openvm_stark_sdk::{
     config::baby_bear_bn254_poseidon2::{BabyBearBn254Poseidon2Config as RootConfig, Bn254Scalar},
     openvm_stark_backend::{
         keygen::types::{MultiStarkVerifyingKey, MultiStarkVerifyingKey0},
-        p3_field::PrimeField,
+        p3_field::{PrimeCharacteristicRing, PrimeField},
         proof::Proof,
         prover::stacked_pcs::StackedLayout,
     },
+    p3_baby_bear::BabyBear,
 };
 
 use crate::{
-    field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearWire, BABY_BEAR_BITS},
+    field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearWire},
     stages::{
         batch_constraints::{
             constrain_batch_constraints_verification, load_batch_constraint_proof_wire,
@@ -166,15 +167,10 @@ fn observe_preamble(
             transcript.observe_commit(ctx, &base_chip, &digest_wire_from_root(preprocessed_root));
         } else {
             // Fixed circuit parameter (not loaded from the proof witness).
-            let log_height = ctx.load_constant(Fr::from(log_heights_per_air[air_idx] as u64));
-            transcript.observe(
-                ctx,
-                &base_chip,
-                &BabyBearWire {
-                    value: log_height,
-                    max_bits: BABY_BEAR_BITS,
-                },
-            );
+            let lh = u32::try_from(log_heights_per_air[air_idx])
+                .expect("log_height must fit in u32 for BabyBear constant");
+            let log_height = base_chip.load_constant(ctx, BabyBear::from_u32(lh));
+            transcript.observe(ctx, &base_chip, &log_height);
         }
 
         for root in &cached_commitment_roots[air_idx] {

--- a/crates/static-verifier/src/stages/full_pipeline/tests.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/tests.rs
@@ -18,13 +18,14 @@ use openvm_stark_sdk::{
 
 use super::*;
 use crate::{
+    circuit::build_stacked_layouts_for_static_vk,
     config::{STATIC_VERIFIER_LOOKUP_ADVICE_COLS, STATIC_VERIFIER_NUM_ADVICE_COLS},
     field::baby_bear::{
         clear_recorded_ext_base_consts, take_recorded_ext_base_consts, RecordedExtBaseConst,
         BABY_BEAR_MODULUS_U64,
     },
-    prover::{StaticVerifierCircuit, StaticVerifierInput},
-    RootF,
+    stages::proof_shape::compute_trace_id_to_air_id,
+    RootF, StaticVerifierCircuit,
 };
 
 const END_TO_END_K: u32 = 22;
@@ -105,15 +106,10 @@ where
 {
     let (vk, proof) = fixture.keygen_and_prove(engine);
     let public_inputs = pipeline_public_inputs(&vk, &proof);
+    let circuit = StaticVerifierCircuit::try_new(vk, &proof).expect("static circuit params");
 
     run_mock(true, &public_inputs, |builder| {
-        StaticVerifierCircuit::populate(
-            builder,
-            &StaticVerifierInput {
-                mvk: &vk,
-                proof: &proof,
-            },
-        );
+        circuit.populate(builder, &proof);
     });
 }
 
@@ -188,12 +184,31 @@ fn pipeline_constraints_fail_when_ext_constant_families_are_pranked() {
     ];
 
     let public_inputs = pipeline_public_inputs(&vk, &proof);
+    let trace_id_to_air_id = compute_trace_id_to_air_id(&vk.inner, &proof);
+    let log_heights_per_air: Vec<usize> = proof
+        .trace_vdata
+        .iter()
+        .map(|v| {
+            v.as_ref()
+                .expect("fixture proof has full trace_vdata")
+                .log_height
+        })
+        .collect();
+    let stacked_layouts = build_stacked_layouts_for_static_vk(&vk.inner, &log_heights_per_air);
     run_mock(false, &public_inputs, move |builder| {
         let range = builder.range_chip();
         let ctx = builder.main(0);
-        let proof_wire = load_proof_wire(ctx, &range, &proof);
+        let proof_wire = load_proof_wire(ctx, &range, &proof, &log_heights_per_air);
         clear_recorded_ext_base_consts();
-        let statement_public_inputs = constrained_verify(ctx, &range, &vk, &proof, proof_wire);
+        let statement_public_inputs = constrained_verify(
+            ctx,
+            &range,
+            &vk,
+            proof_wire,
+            &trace_id_to_air_id,
+            &log_heights_per_air,
+            &stacked_layouts,
+        );
         let records = take_recorded_ext_base_consts();
         for (family, constant) in base_families {
             prank_recorded_ext_constant(ctx, &records, family, constant);
@@ -215,13 +230,8 @@ fn pipeline_constraints_fail_when_public_inputs_are_tampered() {
     let mut tampered_public_inputs = pipeline_public_inputs(&vk, &proof);
     tampered_public_inputs[0] += Fr::from(1u64);
 
+    let circuit = StaticVerifierCircuit::try_new(vk, &proof).expect("static circuit params");
     run_mock(false, &tampered_public_inputs, |builder| {
-        StaticVerifierCircuit::populate(
-            builder,
-            &StaticVerifierInput {
-                mvk: &vk,
-                proof: &proof,
-            },
-        );
+        circuit.populate(builder, &proof);
     });
 }

--- a/crates/static-verifier/src/stages/proof_shape/mod.rs
+++ b/crates/static-verifier/src/stages/proof_shape/mod.rs
@@ -25,3 +25,20 @@ pub(crate) fn compute_trace_id_to_air_id(
     trace_id_to_air_id.truncate(num_traces);
     trace_id_to_air_id
 }
+
+/// Permutation of AIR indices when every AIR has a trace, ordered by descending `log_height`
+/// (tie-break: lower `air_id` first). Must match [`compute_trace_id_to_air_id`] on such proofs.
+pub(crate) fn trace_id_order_from_static_heights(
+    mvk0: &MultiStarkVerifyingKey0<RootConfig>,
+    log_heights_per_air: &[usize],
+) -> Vec<usize> {
+    let num_airs = mvk0.per_air.len();
+    assert_eq!(
+        log_heights_per_air.len(),
+        num_airs,
+        "log_heights_per_air length must match VK per_air count"
+    );
+    let mut trace_id_to_air_id: Vec<usize> = (0..num_airs).collect();
+    trace_id_to_air_id.sort_by_key(|&air_id| (Reverse(log_heights_per_air[air_id]), air_id));
+    trace_id_to_air_id
+}

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -1,12 +1,7 @@
-use core::cmp::Reverse;
-
 use halo2_base::Context;
 use openvm_stark_sdk::{
     config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
-    openvm_stark_backend::{
-        keygen::types::MultiStarkVerifyingKey0, p3_field::PrimeCharacteristicRing, proof::Proof,
-        prover::stacked_pcs::StackedLayout,
-    },
+    openvm_stark_backend::{p3_field::PrimeCharacteristicRing, prover::stacked_pcs::StackedLayout},
 };
 
 use crate::{
@@ -24,53 +19,6 @@ use crate::{
     transcript::TranscriptGadget,
     Fr, RootF,
 };
-
-/// Stacked PCS layouts for the trace commitments present in `proof`, derived from the VK widths
-/// and per-air trace heights. Caller must ensure `proof` matches the static circuit shape.
-pub(crate) fn stacked_reduction_layouts(
-    mvk0: &MultiStarkVerifyingKey0<RootConfig>,
-    proof: &Proof<RootConfig>,
-) -> Vec<StackedLayout> {
-    let l_skip = mvk0.params.l_skip;
-    let mut per_trace = mvk0
-        .per_air
-        .iter()
-        .zip(&proof.trace_vdata)
-        .enumerate()
-        .filter_map(|(air_idx, (vk, vdata))| vdata.as_ref().map(|vdata| (air_idx, vk, vdata)))
-        .collect::<Vec<_>>();
-    per_trace.sort_by_key(|(_, _, vdata)| Reverse(vdata.log_height));
-
-    let common_main_layout = StackedLayout::new(
-        l_skip,
-        mvk0.params.n_stack + l_skip,
-        per_trace
-            .iter()
-            .map(|(_, vk, vdata)| (vk.params.width.common_main, vdata.log_height))
-            .collect::<Vec<_>>(),
-    )
-    .expect("stacked layout for common main");
-    let other_layouts = per_trace
-        .iter()
-        .flat_map(|(_, vk, vdata)| {
-            vk.params
-                .width
-                .preprocessed
-                .iter()
-                .chain(&vk.params.width.cached_mains)
-                .copied()
-                .map(|width| (width, vdata.log_height))
-                .collect::<Vec<_>>()
-        })
-        .map(|sorted| {
-            StackedLayout::new(l_skip, mvk0.params.n_stack + l_skip, vec![sorted])
-                .expect("stacked layout for auxiliary column")
-        })
-        .collect::<Vec<_>>();
-    core::iter::once(common_main_layout)
-        .chain(other_layouts)
-        .collect::<Vec<_>>()
-}
 
 #[derive(Clone, Debug)]
 pub struct StackedReductionIntermediatesWire {

--- a/crates/static-verifier/tests/real_prover_roundtrip.rs
+++ b/crates/static-verifier/tests/real_prover_roundtrip.rs
@@ -1,20 +1,23 @@
 use halo2_base::{gates::circuit::CircuitBuilderStage, utils::fs::gen_srs};
 use openvm_stark_sdk::{
-    config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine,
+    config::baby_bear_bn254_poseidon2::{
+        BabyBearBn254Poseidon2Config as RootConfig, BabyBearBn254Poseidon2CpuEngine,
+    },
     openvm_stark_backend::{
         p3_util::log2_ceil_usize,
+        proof::Proof,
         test_utils::{test_system_params_small, FibFixture, TestFixture},
         StarkEngine,
     },
     utils::setup_tracing,
 };
-use openvm_static_verifier::{StaticVerifierCircuit, StaticVerifierInput, StaticVerifierShape};
+use openvm_static_verifier::{StaticVerifierCircuit, StaticVerifierShape};
 
 const MIN_ROWS: usize = 20;
 
 /// Find the smallest k such that the static verifier circuit fits in a single advice column.
 /// Follows the pattern from the Halo2 wrapper `select_k`.
-fn select_k(input: &StaticVerifierInput<'_>) -> usize {
+fn select_k(circuit: &StaticVerifierCircuit, proof: &Proof<RootConfig>) -> usize {
     let mut k = 12;
     let mut first_run = true;
     loop {
@@ -25,7 +28,7 @@ fn select_k(input: &StaticVerifierInput<'_>) -> usize {
             instance_columns: 1,
         };
         let mut builder = StaticVerifierCircuit::builder(CircuitBuilderStage::Keygen, &shape);
-        StaticVerifierCircuit::populate(&mut builder, input);
+        circuit.populate(&mut builder, proof);
         let params = builder.calculate_params(Some(MIN_ROWS));
         if params.num_advice_per_phase[0] == 1 {
             builder.clear();
@@ -54,13 +57,10 @@ fn real_prover_keygen_prove_verify_roundtrip() {
     let (vk, proof_keygen) = FibFixture::new(0, 1, 1 << 5).keygen_and_prove(&engine);
     let (_vk_prove, proof_prove) = FibFixture::new(1, 1, 1 << 5).keygen_and_prove(&engine);
 
-    let keygen_input = StaticVerifierInput {
-        mvk: &vk,
-        proof: &proof_keygen,
-    };
+    let circuit = StaticVerifierCircuit::try_new(vk, &proof_keygen).expect("static circuit params");
 
     // Auto-tune k to the smallest value that fits in 1 advice column
-    let k = select_k(&keygen_input);
+    let k = select_k(&circuit, &proof_keygen);
     let shape = StaticVerifierShape {
         k,
         lookup_bits: k - 1,
@@ -70,14 +70,10 @@ fn real_prover_keygen_prove_verify_roundtrip() {
     let params = gen_srs(k as u32);
 
     // Keygen with first proof
-    let pinning = StaticVerifierCircuit::keygen(&params, &shape, &keygen_input);
+    let pinning = circuit.keygen(&params, &shape, &proof_keygen);
 
     // Prove with second (different) proof
-    let prove_input = StaticVerifierInput {
-        mvk: &vk,
-        proof: &proof_prove,
-    };
-    let halo2_proof = StaticVerifierCircuit::prove(&params, &pinning, &shape, &prove_input);
+    let halo2_proof = circuit.prove(&params, &pinning, &shape, &proof_prove);
 
     // Verify
     assert!(StaticVerifierCircuit::verify(


### PR DESCRIPTION
## Summary
- Introduce `StaticVerifierCircuit` as a non-ZST in `circuit.rs`: holds `child_vk`, `log_heights_per_air`, `trace_id_to_air_id`, and precomputed `stacked_layouts` (built in `try_new`).
- `try_new(vk, template_proof)` validates full `trace_vdata`, height ordering vs `compute_trace_id_to_air_id`, and constructs stacked PCS layouts once.
- `populate` uses `load_proof_wire` + `constrained_verify`; removed `StaticVerifierInput` (proof-only at API boundary).
- `constrained_verify` takes fixed `trace_id_to_air_id`, `log_heights_per_air`, and `stacked_layouts`; transcript log heights use `load_constant` (circuit-fixed, not witness).
- `load_proof_wire` asserts proof trace heights match the circuit’s stored heights.
- `StaticVerifierProvingKey` now owns `StaticVerifierCircuit`; `keygen` / `prove` / EVM path updated accordingly.
- Remove `stacked_reduction_layouts_from_heights` from `stacked_reduction` (logic lives in `circuit.rs` as `build_stacked_layouts_for_static_vk`).
- Add `trace_id_order_from_static_heights` and `StaticCircuitParamsError`.

## Testing
- `cargo nextest run --cargo-profile=fast -p openvm-static-verifier`

Made with [Cursor](https://cursor.com)

closes INT-6943