### PR TITLE
fix: host verify checks Proof cached commit

### DIFF
--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -12,7 +12,8 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
-    DagCommit, DeferralPvs, VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, VERIFIER_PVS_AIR_ID,
+    DagCommit, DeferralPvs, VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX,
+    VERIFIER_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -27,7 +28,6 @@ use crate::{
         root::NUM_DIGESTS_IN_VK_COMMIT,
         subair::{HashSliceCtx, HashSliceSubAir, MerkleRootBus, MerkleRootMessage},
         utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
-        CONSTRAINT_EVAL_CACHED_INDEX,
     },
     utils::{digests_to_poseidon2_input, pad_slice_to_poseidon2_input, zero_hash},
     CommitBytes, DagCommitBytes,

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -9,7 +9,9 @@ use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
-use openvm_verify_stark_host::pvs::{VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, VERIFIER_PVS_AIR_ID};
+use openvm_verify_stark_host::pvs::{
+    VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX, VERIFIER_PVS_AIR_ID,
+};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
@@ -17,7 +19,6 @@ use p3_matrix::Matrix;
 use crate::circuit::{
     deferral::inner::bus::{DefPvsConsistencyBus, DefPvsConsistencyMessage},
     utils::{assert_dag_commit_eq, assert_dag_commit_unset},
-    CONSTRAINT_EVAL_CACHED_INDEX,
 };
 
 #[repr(C)]

--- a/crates/continuations/src/circuit/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/def_pvs/air.rs
@@ -9,7 +9,9 @@ use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
-use openvm_verify_stark_host::pvs::{DeferralPvs, CONSTRAINT_EVAL_AIR_ID, DEF_PVS_AIR_ID};
+use openvm_verify_stark_host::pvs::{
+    DeferralPvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID,
+};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
@@ -18,7 +20,6 @@ use crate::{
     circuit::{
         deferral::DEF_HOOK_PVS_AIR_ID,
         inner::bus::{PvsAirConsistencyBus, PvsAirConsistencyMessage},
-        CONSTRAINT_EVAL_CACHED_INDEX,
     },
     utils::digests_to_poseidon2_input,
     CommitBytes,

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -17,7 +17,8 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_verify_stark_host::pvs::{
-    VerifierBasePvs, VerifierDefPvs, CONSTRAINT_EVAL_AIR_ID, VERIFIER_PVS_AIR_ID,
+    VerifierBasePvs, VerifierDefPvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX,
+    VERIFIER_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -28,7 +29,6 @@ use crate::circuit::{
     root::NUM_DIGESTS_IN_VK_COMMIT,
     subair::{HashSliceCtx, HashSliceSubAir},
     utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
-    CONSTRAINT_EVAL_CACHED_INDEX,
 };
 
 #[repr(C)]

--- a/crates/continuations/src/circuit/mod.rs
+++ b/crates/continuations/src/circuit/mod.rs
@@ -12,8 +12,6 @@ pub mod inner;
 pub mod root;
 pub mod subair;
 
-pub const CONSTRAINT_EVAL_CACHED_INDEX: usize = 0;
-
 pub struct SubCircuitTraceData<PB: ProverBackend> {
     pub air_proving_ctxs: Vec<AirProvingContext<PB>>,
     pub poseidon2_compress_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -16,7 +16,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
     DagCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
-    DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
+    CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -33,7 +33,6 @@ use crate::{
         },
         subair::{HashSliceCtx, HashSliceSubAir},
         utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
-        CONSTRAINT_EVAL_CACHED_INDEX,
     },
     utils::{digests_to_poseidon2_input, pad_slice_to_poseidon2_input},
     CommitBytes, DagCommitBytes,

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -31,7 +31,7 @@ pub enum VerifyStarkError {
     InternalRecursiveDagCachedCommitSet { actual: Digest },
     #[error("Internal recursive vk pre-hash should be unset, actual {actual:?}")]
     InternalRecursiveDagPreHashSet { actual: Digest },
-    #[error("Proof cached commit should be internal recursive: expected {expected:?}, actual {actual:?}")]
+    #[error("Invalid proof cached commit: expected {expected:?}, actual {actual:?}")]
     ProofCachedCommitMismatch { expected: Digest, actual: Digest },
     #[error("Missing constraint-eval trace vdata, expected at AIR idx {air_idx}")]
     MissingConstraintEvalTraceVdata { air_idx: usize },

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -33,6 +33,10 @@ pub enum VerifyStarkError {
     InternalRecursiveDagPreHashSet { actual: Digest },
     #[error("Proof cached commit should be internal recursive: expected {expected:?}, actual {actual:?}")]
     ProofCachedCommitMismatch { expected: Digest, actual: Digest },
+    #[error("Missing constraint-eval trace vdata, expected at AIR idx {air_idx}")]
+    MissingConstraintEvalTraceVdata { air_idx: usize },
+    #[error("Missing constraint-eval cached trace at AIR idx {air_idx} cached idx {cached_idx}")]
+    MissingConstraintEvalCachedTrace { air_idx: usize, cached_idx: usize },
     #[error("Program execution did not terminate successfully, exit_code: {0}")]
     ExecutionUnsuccessful(F),
     #[error("Invalid internal flag {0}, should be 2")]

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -31,6 +31,8 @@ pub enum VerifyStarkError {
     InternalRecursiveDagCachedCommitSet { actual: Digest },
     #[error("Internal recursive vk pre-hash should be unset, actual {actual:?}")]
     InternalRecursiveDagPreHashSet { actual: Digest },
+    #[error("Proof cached commit should be internal recursive: expected {expected:?}, actual {actual:?}")]
+    ProofCachedCommitMismatch { expected: Digest, actual: Digest },
     #[error("Program execution did not terminate successfully, exit_code: {0}")]
     ExecutionUnsuccessful(F),
     #[error("Invalid internal flag {0}, should be 2")]

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -21,8 +21,8 @@ use crate::{
     deferral::DeferralMerkleProofs,
     error::VerifyStarkError,
     pvs::{
-        DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID,
-        VM_PVS_AIR_ID,
+        DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
+        CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
     },
     vk::NonRootStarkVerifyingKey,
 };
@@ -192,6 +192,19 @@ pub fn verify_vm_stark_proof_pvs(
         return Err(VerifyStarkError::InternalForLeafDagPreHashMismatch {
             expected: vk.baseline.internal_for_leaf_dag_commit.vk_pre_hash,
             actual: internal_for_leaf_dag_commit.vk_pre_hash,
+        });
+    }
+
+    // Check the proof's cached commit is the internal-recursive one.
+    let proof_cached_commit = proof.inner.trace_vdata[CONSTRAINT_EVAL_AIR_ID]
+        .as_ref()
+        .unwrap()
+        .cached_commitments[CONSTRAINT_EVAL_CACHED_INDEX];
+
+    if proof_cached_commit != vk.baseline.internal_recursive_dag_commit.cached_commit {
+        return Err(VerifyStarkError::ProofCachedCommitMismatch {
+            expected: vk.baseline.internal_recursive_dag_commit.cached_commit,
+            actual: proof_cached_commit,
         });
     }
 

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -196,15 +196,26 @@ pub fn verify_vm_stark_proof_pvs(
     }
 
     // Check the proof's cached commit is the internal-recursive one.
-    let proof_cached_commit = proof.inner.trace_vdata[CONSTRAINT_EVAL_AIR_ID]
-        .as_ref()
-        .unwrap()
-        .cached_commitments[CONSTRAINT_EVAL_CACHED_INDEX];
-
-    if proof_cached_commit != vk.baseline.internal_recursive_dag_commit.cached_commit {
-        return Err(VerifyStarkError::ProofCachedCommitMismatch {
-            expected: vk.baseline.internal_recursive_dag_commit.cached_commit,
-            actual: proof_cached_commit,
+    if let Some(trace_vdata) = proof.inner.trace_vdata[CONSTRAINT_EVAL_AIR_ID].as_ref() {
+        if let Some(proof_cached_commit) = trace_vdata
+            .cached_commitments
+            .get(CONSTRAINT_EVAL_CACHED_INDEX)
+        {
+            if *proof_cached_commit != vk.baseline.internal_recursive_dag_commit.cached_commit {
+                return Err(VerifyStarkError::ProofCachedCommitMismatch {
+                    expected: vk.baseline.internal_recursive_dag_commit.cached_commit,
+                    actual: *proof_cached_commit,
+                });
+            }
+        } else {
+            return Err(VerifyStarkError::MissingConstraintEvalCachedTrace {
+                air_idx: CONSTRAINT_EVAL_AIR_ID,
+                cached_idx: CONSTRAINT_EVAL_CACHED_INDEX,
+            });
+        }
+    } else {
+        return Err(VerifyStarkError::MissingConstraintEvalTraceVdata {
+            air_idx: CONSTRAINT_EVAL_AIR_ID,
         });
     }
 

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -195,29 +195,25 @@ pub fn verify_vm_stark_proof_pvs(
         });
     }
 
-    // Check the proof's cached commit is the internal-recursive one.
-    if let Some(trace_vdata) = proof.inner.trace_vdata[CONSTRAINT_EVAL_AIR_ID].as_ref() {
-        if let Some(proof_cached_commit) = trace_vdata
-            .cached_commitments
-            .get(CONSTRAINT_EVAL_CACHED_INDEX)
-        {
-            if *proof_cached_commit != vk.baseline.internal_recursive_dag_commit.cached_commit {
-                return Err(VerifyStarkError::ProofCachedCommitMismatch {
-                    expected: vk.baseline.internal_recursive_dag_commit.cached_commit,
-                    actual: *proof_cached_commit,
+    // Check that SymbolicExpressionAir's cached trace exists and extract it.
+    let proof_cached_commit =
+        if let Some(trace_vdata) = proof.inner.trace_vdata[CONSTRAINT_EVAL_AIR_ID].as_ref() {
+            if let Some(proof_cached_commit) = trace_vdata
+                .cached_commitments
+                .get(CONSTRAINT_EVAL_CACHED_INDEX)
+            {
+                *proof_cached_commit
+            } else {
+                return Err(VerifyStarkError::MissingConstraintEvalCachedTrace {
+                    air_idx: CONSTRAINT_EVAL_AIR_ID,
+                    cached_idx: CONSTRAINT_EVAL_CACHED_INDEX,
                 });
             }
         } else {
-            return Err(VerifyStarkError::MissingConstraintEvalCachedTrace {
+            return Err(VerifyStarkError::MissingConstraintEvalTraceVdata {
                 air_idx: CONSTRAINT_EVAL_AIR_ID,
-                cached_idx: CONSTRAINT_EVAL_CACHED_INDEX,
             });
-        }
-    } else {
-        return Err(VerifyStarkError::MissingConstraintEvalTraceVdata {
-            air_idx: CONSTRAINT_EVAL_AIR_ID,
-        });
-    }
+        };
 
     // Check that recursion_flag is 1 or 2, i.e. that the penultimate layer is
     // internal-for-leaf or internal-recursive.
@@ -244,6 +240,12 @@ pub fn verify_vm_stark_proof_pvs(
                 actual: internal_recursive_dag_commit.vk_pre_hash,
             });
         }
+        if proof_cached_commit != vk.baseline.internal_recursive_dag_commit.cached_commit {
+            return Err(VerifyStarkError::ProofCachedCommitMismatch {
+                expected: vk.baseline.internal_recursive_dag_commit.cached_commit,
+                actual: proof_cached_commit,
+            });
+        }
     } else {
         if !is_unset(&internal_recursive_dag_commit.cached_commit) {
             return Err(VerifyStarkError::InternalRecursiveDagCachedCommitSet {
@@ -253,6 +255,12 @@ pub fn verify_vm_stark_proof_pvs(
         if !is_unset(&internal_recursive_dag_commit.vk_pre_hash) {
             return Err(VerifyStarkError::InternalRecursiveDagPreHashSet {
                 actual: internal_recursive_dag_commit.vk_pre_hash,
+            });
+        }
+        if proof_cached_commit != vk.baseline.internal_for_leaf_dag_commit.cached_commit {
+            return Err(VerifyStarkError::ProofCachedCommitMismatch {
+                expected: vk.baseline.internal_for_leaf_dag_commit.cached_commit,
+                actual: proof_cached_commit,
             });
         }
     }

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -7,6 +7,8 @@ pub const VM_PVS_AIR_ID: usize = 1;
 pub const DEF_PVS_AIR_ID: usize = 2;
 pub const CONSTRAINT_EVAL_AIR_ID: usize = 3;
 
+pub const CONSTRAINT_EVAL_CACHED_INDEX: usize = 0;
+
 #[repr(C)]
 #[derive(AlignedBorrow, Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DagCommit<F> {

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -14,7 +14,6 @@ use openvm_continuations::{
         },
         subair::{HashSliceCtx, HashSliceSubAir},
         utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
-        CONSTRAINT_EVAL_CACHED_INDEX,
     },
     utils::{digests_to_poseidon2_input, pad_slice_to_poseidon2_input},
     CommitBytes, DagCommitBytes,
@@ -34,7 +33,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
     DagCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
-    DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
+    CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};


### PR DESCRIPTION
Resolves INT-6962.

- Adds a check to `crates/verify/src/lib.rs` to force the `Proof` cached commit to be the `internal-recursive` one
- Moves `CONSTRAINT_EVAL_CACHED_INDEX` from `crates/continuations` to `crates/verify`