### PR TITLE
docs: update verify-stark docs + rename verify_proof_output

### DIFF
--- a/crates/sdk/programs/examples/verify-stark.rs
+++ b/crates/sdk/programs/examples/verify-stark.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 use openvm::io::read;
 use openvm_deferral_guest::Commit;
-use openvm_verify_stark_guest::{verify_proof_output, ProofOutput};
+use openvm_verify_stark_guest::{verify_stark, ProofOutput};
 
 openvm::entry!(main);
 
@@ -23,5 +23,5 @@ pub fn main() {
     };
 
     let input_commit: Commit = read();
-    verify_proof_output::<0>(&input_commit, &expected);
+    verify_stark::<0>(&input_commit, &expected);
 }

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -27,7 +27,7 @@ Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit
 pub fn verify_stark<const DEF_IDX: u16>(input_commit: &Commit, expected: &ProofOutput)
 ```
 
-Cals `get_proof_output` and panics if the result does not match `expected`.
+Calls `get_proof_output` and panics if the result does not match `expected`.
 
 ## Circuit
 

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -19,7 +19,7 @@ Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit
 - `app_vk_commit: Commit` — commitment to the app VM configuration
 - `user_public_values: Vec<u8>` — public values revealed by the verified app
 
-`DEF_IDX` must match the index of the corresponding `DeferralFn` in `DeferralExtension.fns`, as configured when building the VM extension.
+`DEF_IDX` must match the index of the corresponding `DeferralFn` in `DeferralExtension.fns`, as configured when [building the VM extension](#using-deferralextension). Each STARK verifying key will correspond to a different deferral circuit, and thus a different `DEF_IDX`.
 
 ### `verify_proof_output`
 
@@ -36,3 +36,48 @@ The circuit crate (`openvm-verify-stark-circuit`) provides the `DeferredVerifyCi
 1. Verifies the child STARK proof using the recursion verifier sub-circuit
 2. Constrains that the user public values are present in the final memory state
 3. Produces the output commitment containing `app_exe_commit`, `app_vk_commit`, and `user_public_values`
+
+There should be a unique `DeferredVerifyCircuit` for each STARK verifying key you want to support.
+
+### Using `DeferralExtension`
+
+To use `DeferredVerifyCircuit` in an app, you must wire it into your VM config via `DeferralExtension`. A VM config can support up to 1024 different deferral circuits at one time. `DeferralExtension` stores:
+
+- `fns: Vec<Arc<DeferralFn>>` - one function per deferral circuit
+- `def_vk_commits: Vec<[u8; 32]>` - the corresponding deferral-circuit VK commitments
+
+These vectors are aligned by index.
+
+It is **highly** recommended that guest programs that use deferrals are proved using the SDK. The flow for this is:
+
+1. Build a `DeferralProver` whose single-circuit prover is `VerifyCircuitProver`.
+2. Create the extension with `make_extension`, passing the deferral function(s).
+3. Set `SdkVmConfig.deferral = Some(deferral_ext)`.
+4. Build your SDK with `.with_deferral_prover(deferral_prover)`.
+
+For example, to initialize the SDK with the `verify-stark` deferral circuit:
+
+```rust
+let deferred_verify_prover = VerifyProver::new::<E>(
+    ir_vk,
+    ir_pcs_data,
+    def_circuit_params,
+    memory_dimensions,
+    num_user_pvs,
+    None,
+    0,
+);
+let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
+
+let deferral_prover = DeferralProver::new(verify_stark_prover, agg_config, hook_params);
+let deferral_ext =
+    deferral_prover.make_extension(vec![Arc::new(DeferralFn::new(verify_stark_deferral_fn))]);
+
+let mut vm_config = SdkVmConfig::riscv32();
+vm_config.deferral = Some(deferral_ext);
+
+let sdk = CpuSdk::new(AppConfig::new(vm_config, app_params), agg_params)?
+    .with_deferral_prover(deferral_prover);
+```
+
+Each guest call `DEF_IDX` corresponds to the deferral circuit inserted at `DEF_IDX`. If there is exactly one deferral function registered (as above), `DEF_IDX = 0`.

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -8,13 +8,14 @@ You can find the library source code [here](https://github.com/openvm-org/openvm
 
 The guest library (`openvm-verify-stark-guest`) provides functions to request and consume deferred STARK proof verification.
 
-### `get_proof_output`
+### `verify_stark_unchecked`
 
 ```rust
-pub fn get_proof_output<const DEF_IDX: u16>(input_commit: &Commit) -> ProofOutput
+pub fn verify_stark_unchecked<const DEF_IDX: u16>(input_commit: &Commit) -> ProofOutput
 ```
 
-Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit` (a 32-byte commitment identifying the proof). Returns a `ProofOutput` containing:
+Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit` (a 32-byte commitment identifying the proof). When correctly configured with the [`DeferredVerifyCircuit`](#circuit), the proof is verified outside the VM circuit as part of the [deferral flow](/specs/architecture/deferral). Returns a `ProofOutput` containing:
+
 - `app_exe_commit: Commit` — commitment to the app executable whose execution is being verified
 - `app_vk_commit: Commit` — commitment to the app VM configuration
 - `user_public_values: Vec<u8>` — public values revealed by the verified app
@@ -27,7 +28,7 @@ Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit
 pub fn verify_stark<const DEF_IDX: u16>(input_commit: &Commit, expected: &ProofOutput)
 ```
 
-Calls `get_proof_output` and panics if the result does not match `expected`.
+Calls `verify_stark_unchecked` and panics if the result does not match `expected`.
 
 ## Circuit
 
@@ -48,7 +49,7 @@ To use `DeferredVerifyCircuit` in an app, you must wire it into your VM config v
 
 These vectors are aligned by index.
 
-It is **highly** recommended that guest programs that use deferrals are proved using the SDK. The flow for this is:
+It is **highly** recommended that guest programs that use deferrals are proved using the SDK. The flow is:
 
 1. Build a `DeferralProver` whose single-circuit prover is `VerifyCircuitProver`.
 2. Create the extension with `make_extension`, passing the deferral function(s).
@@ -58,16 +59,17 @@ It is **highly** recommended that guest programs that use deferrals are proved u
 For example, to initialize the SDK with the `verify-stark` deferral circuit:
 
 ```rust
-let deferred_verify_prover = VerifyProver::new::<E>(
+let def_idx = 0;
+let deferred_verify_prover = DeferredVerifyCpuProver::new::<E>(
     ir_vk,
     ir_pcs_data,
     def_circuit_params,
     memory_dimensions,
     num_user_pvs,
     None,
-    0,
+    def_idx,
 );
-let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
+let verify_stark_prover = DeferredVerifyCpuCircuitProver::new(deferred_verify_prover);
 
 let deferral_prover = DeferralProver::new(verify_stark_prover, agg_config, hook_params);
 let deferral_ext =
@@ -80,4 +82,4 @@ let sdk = CpuSdk::new(AppConfig::new(vm_config, app_params), agg_params)?
     .with_deferral_prover(deferral_prover);
 ```
 
-Each guest call `DEF_IDX` corresponds to the deferral circuit inserted at `DEF_IDX`. If there is exactly one deferral function registered (as above), `DEF_IDX = 0`.
+Each guest call using `DEF_IDX` corresponds to the deferral circuit inserted at `DEF_IDX`. If there is exactly one deferral function registered (as above), `DEF_IDX = 0`.

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -14,11 +14,13 @@ The guest library (`openvm-verify-stark-guest`) provides functions to request an
 pub fn verify_stark_unchecked<const DEF_IDX: u16>(input_commit: &Commit) -> ProofOutput
 ```
 
-Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit` (a 32-byte commitment identifying the proof). When correctly configured with the [`DeferredVerifyCircuit`](#circuit), the proof is verified outside the VM circuit as part of the [deferral flow](/specs/architecture/deferral). Returns a `ProofOutput` containing:
+Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit` (a 32-byte commitment identifying the proof). Returns a `ProofOutput` containing:
 
 - `app_exe_commit: Commit` — commitment to the app executable whose execution is being verified
 - `app_vk_commit: Commit` — commitment to the app VM configuration
 - `user_public_values: Vec<u8>` — public values revealed by the verified app
+
+When correctly configured with the [`DeferredVerifyCircuit`](#circuit), verification is performed outside the VM circuit as part of the [deferral flow](/specs/architecture/deferral). From the guest perspective, this establishes that **there exists a proof** matching `input_commit` that verifies and yields the returned `ProofOutput`; the proof itself is never accessible from the guest program.
 
 `DEF_IDX` must match the index of the corresponding `DeferralFn` in `DeferralExtension.fns`, as configured when [building the VM extension](#using-deferralextension). Each STARK verifying key will correspond to a different deferral circuit, and thus a different `DEF_IDX`.
 

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -21,13 +21,13 @@ Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit
 
 `DEF_IDX` must match the index of the corresponding `DeferralFn` in `DeferralExtension.fns`, as configured when [building the VM extension](#using-deferralextension). Each STARK verifying key will correspond to a different deferral circuit, and thus a different `DEF_IDX`.
 
-### `verify_proof_output`
+### `verify_stark`
 
 ```rust
-pub fn verify_proof_output<const DEF_IDX: u16>(input_commit: &Commit, expected: &ProofOutput)
+pub fn verify_stark<const DEF_IDX: u16>(input_commit: &Commit, expected: &ProofOutput)
 ```
 
-Convenience wrapper that calls `get_proof_output` and panics if the result does not match `expected`.
+Cals `get_proof_output` and panics if the result does not match `expected`.
 
 ## Circuit
 

--- a/guest-libs/verify-stark/guest/src/lib.rs
+++ b/guest-libs/verify-stark/guest/src/lib.rs
@@ -38,7 +38,7 @@ pub fn get_proof_output<const DEF_IDX: u16>(input_commit: &Commit) -> ProofOutpu
     }
 }
 
-pub fn verify_proof_output<const DEF_IDX: u16>(input_commit: &Commit, expected: &ProofOutput) {
+pub fn verify_stark<const DEF_IDX: u16>(input_commit: &Commit, expected: &ProofOutput) {
     let actual = get_proof_output::<DEF_IDX>(input_commit);
     if actual != *expected {
         panic!("Proof verification failed for commit {:?}", input_commit);

--- a/guest-libs/verify-stark/guest/src/lib.rs
+++ b/guest-libs/verify-stark/guest/src/lib.rs
@@ -13,7 +13,7 @@ pub struct ProofOutput {
     pub user_public_values: Vec<u8>,
 }
 
-pub fn get_proof_output<const DEF_IDX: u16>(input_commit: &Commit) -> ProofOutput {
+pub fn verify_stark_unchecked<const DEF_IDX: u16>(input_commit: &Commit) -> ProofOutput {
     let output_key = deferred_compute::<DEF_IDX>(input_commit);
     let output_len = output_key.output_len as usize;
 
@@ -39,7 +39,7 @@ pub fn get_proof_output<const DEF_IDX: u16>(input_commit: &Commit) -> ProofOutpu
 }
 
 pub fn verify_stark<const DEF_IDX: u16>(input_commit: &Commit, expected: &ProofOutput) {
-    let actual = get_proof_output::<DEF_IDX>(input_commit);
+    let actual = verify_stark_unchecked::<DEF_IDX>(input_commit);
     if actual != *expected {
         panic!("Proof verification failed for commit {:?}", input_commit);
     }


### PR DESCRIPTION
Updates `verify-stark` guest library docs do explain `DEF_IDX` more. Also renames `verify_proof_output` to `verify_stark`