### PR TITLE
feat: deferral extension CUDA tracegen

### DIFF
--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -55,4 +55,4 @@ jobs:
         working-directory: crates/continuations
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
-          cargo nextest run --cargo-profile=fast --features cuda --profile=heavy -E 'not test(e2e)'
+          cargo nextest run --cargo-profile=fast --features cuda,root-prover --profile=heavy -E 'not test(e2e)'

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -56,3 +56,7 @@ jobs:
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
           cargo nextest run --cargo-profile=fast --features cuda,root-prover --profile=heavy -E 'not test(e2e)'
+
+      - name: Run continuations CUDA e2e test
+        working-directory: crates/continuations
+        run: cargo nextest run --cargo-profile=fast --features cuda,root-prover --test-threads=1 -E 'test(e2e)'

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         extensions: # group extensions on the same runner based on test time
           - "rv32im"
-          - "keccak256 sha256 bigint algebra ecc pairing"
+          - "keccak256 sha256 bigint algebra ecc pairing deferral"
     runs-on:
       - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'test-gpu-nvidia/family=g6.*+g6e' }}
 
@@ -70,6 +70,8 @@ jobs:
               - "extensions/ecc/**"
             pairing:
               - "extensions/pairing/**"
+            deferral:
+              - "extensions/deferral/**"
 
       - name: Skip if no changes
         env:

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -54,4 +54,4 @@ jobs:
         working-directory: crates/sdk
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
-          cargo nextest run --cargo-profile=fast --features cuda --profile=heavy --test-threads=1
+          cargo nextest run --cargo-profile=fast --features cuda --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6625,6 +6625,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7102,6 +7112,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/crates/continuations/Cargo.toml
+++ b/crates/continuations/Cargo.toml
@@ -60,6 +60,7 @@ cuda = [
     "openvm-circuit-primitives/cuda",
     "openvm-circuit/cuda",
     "openvm-rv32im-circuit/cuda",
+    "openvm-deferral-circuit/cuda",
     "openvm-recursion-circuit/cuda",
 ]
 touchemall = [

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -64,7 +64,7 @@ use crate::{
 };
 
 type GpuEngine = BabyBearPoseidon2GpuEngine;
-type AppEngine = BabyBearPoseidon2CpuEngine<DuplexSponge>;
+type CpuEngine = BabyBearPoseidon2CpuEngine<DuplexSponge>;
 type RootEngine = BabyBearBn254Poseidon2CpuEngine;
 
 const NUM_DEF_CIRCUITS: usize = 3;
@@ -369,7 +369,7 @@ fn test_deferral_e2e() -> Result<()> {
     // =========================================================================
     // SECTION 2: Run the VM, capture merkle proofs before and after execution.
     // =========================================================================
-    let app_engine = AppEngine::new(app_system_params());
+    let app_engine = GpuEngine::new(app_system_params());
     let (vm, app_pk) = VirtualMachine::new_with_keygen(app_engine, Rv32DeferralBuilder, config)?;
     let cached_program_trace = vm.commit_program_on_device(&exe.program);
     let mut instance = VmInstance::new(vm, exe.into(), cached_program_trace)?;
@@ -382,7 +382,7 @@ fn test_deferral_e2e() -> Result<()> {
         &vm_poseidon2_hasher::<F>(),
     );
 
-    warn!("proving app proof (CPU)");
+    warn!("proving app proof");
     let app_proof = instance.prove(streams)?;
 
     let final_address_map = &instance.state().as_ref().unwrap().memory.memory;
@@ -399,7 +399,7 @@ fn test_deferral_e2e() -> Result<()> {
     // For each deferred_compute call, produce a proof whose DeferralCircuitPvs
     // carries the matching (input_commit, output_commit).
     // =========================================================================
-    let cpu_engine = AppEngine::new(app_system_params());
+    let cpu_engine = CpuEngine::new(app_system_params());
     let (def_pk, _) = cpu_engine
         .keygen(&[Arc::new(EmptyAirWithPvs(DeferralCircuitPvs::<u8>::width())) as AirRef<SC>]);
 

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -17,7 +17,7 @@ use openvm_circuit::{
 };
 use openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
 use openvm_deferral_circuit::{
-    DeferralCpuBuilder, DeferralExtension, DeferralFn, Rv32DeferralConfig,
+    DeferralExtension, DeferralFn, Rv32DeferralBuilder, Rv32DeferralConfig,
 };
 use openvm_deferral_transpiler::DeferralTranspilerExtension;
 use openvm_recursion_circuit::{
@@ -367,11 +367,10 @@ fn test_deferral_e2e() -> Result<()> {
     };
 
     // =========================================================================
-    // SECTION 2: Run the VM (CPU engine for DeferralCpuBuilder), capture merkle
-    // proofs before and after execution.
+    // SECTION 2: Run the VM, capture merkle proofs before and after execution.
     // =========================================================================
     let app_engine = AppEngine::new(app_system_params());
-    let (vm, app_pk) = VirtualMachine::new_with_keygen(app_engine, DeferralCpuBuilder, config)?;
+    let (vm, app_pk) = VirtualMachine::new_with_keygen(app_engine, Rv32DeferralBuilder, config)?;
     let cached_program_trace = vm.commit_program_on_device(&exe.program);
     let mut instance = VmInstance::new(vm, exe.into(), cached_program_trace)?;
 

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -18,7 +18,7 @@ use openvm_verify_stark_host::vk::NonRootStarkVerifyingKey;
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AppConfig, DEFAULT_APP_L_SKIP},
     prover::DeferralProver,
-    CpuSdk, DeferralInput, Sdk, StdIn,
+    DeferralInput, Sdk, StdIn,
 };
 
 cfg_if::cfg_if! {
@@ -141,9 +141,8 @@ fn test_verify_stark_deferral() -> Result<()> {
     vs_config.deferral = Some(deferral_ext);
     vs_config.system.config.memory_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 25;
 
-    // TODO[INT-6241]: Switch this to SDK once CUDA is implemented for deferrals
     let vs_app_config = AppConfig::new(vs_config, app_params);
-    let vs_sdk = CpuSdk::new(vs_app_config, agg_params)?.with_deferral_prover(deferral_prover);
+    let vs_sdk = Sdk::new(vs_app_config, agg_params)?.with_deferral_prover(deferral_prover);
 
     // ---- Step 7: Build the verify-stark ELF ----
     let vs_elf = Elf::decode(

--- a/extensions/deferral/circuit/Cargo.toml
+++ b/extensions/deferral/circuit/Cargo.toml
@@ -60,7 +60,8 @@ cuda = [
     "dep:openvm-cuda-common",
     "dep:openvm-cuda-builder",
     "openvm-circuit-primitives/cuda",
-    "openvm-circuit/cuda"
+    "openvm-circuit/cuda",
+    "openvm-rv32im-circuit/cuda",
 ]
 touchemall = [
     "cuda",

--- a/extensions/deferral/circuit/build.rs
+++ b/extensions/deferral/circuit/build.rs
@@ -1,24 +1,24 @@
-// #[cfg(feature = "cuda")]
-// use openvm_cuda_builder::{cuda_available, CudaBuilder};
+#[cfg(feature = "cuda")]
+use openvm_cuda_builder::{cuda_available, CudaBuilder};
 
 fn main() {
-    // #[cfg(feature = "cuda")]
-    // {
-    //     if !cuda_available() {
-    //         return; // Skip CUDA compilation
-    //     }
+    #[cfg(feature = "cuda")]
+    {
+        if !cuda_available() {
+            return; // Skip CUDA compilation
+        }
 
-    //     let builder = CudaBuilder::new()
-    //         .include_from_dep("DEP_CUDA_COMMON_INCLUDE")
-    //         .include("../../../crates/circuits/primitives/cuda/include")
-    //         .include("../../../crates/circuits/poseidon2-air/cuda/include")
-    //         .include("../../../crates/vm/cuda/include")
-    //         .include("cuda/include")
-    //         .watch("cuda/src")
-    //         .library_name("tracegen_gpu_deferral")
-    //         .files_from_glob("cuda/src/**/*.cu");
+        let builder = CudaBuilder::new()
+            .include_from_dep("DEP_CUDA_COMMON_INCLUDE")
+            .include("../../../crates/circuits/primitives/cuda/include")
+            .include("../../../crates/circuits/poseidon2-air/cuda/include")
+            .include("../../../crates/vm/cuda/include")
+            .include("cuda/include")
+            .watch("cuda/src")
+            .library_name("tracegen_gpu_deferral")
+            .files_from_glob("cuda/src/**/*.cu");
 
-    //     builder.emit_link_directives();
-    //     builder.build();
-    // }
+        builder.emit_link_directives();
+        builder.build();
+    }
 }

--- a/extensions/deferral/circuit/cuda/include/def_poseidon2_buffer.cuh
+++ b/extensions/deferral/circuit/cuda/include/def_poseidon2_buffer.cuh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <device_atomic_functions.h>
+
+#include "def_types.h"
+#include "primitives/fp_array.cuh"
+#include "primitives/trace_access.h"
+
+namespace deferral {
+
+struct DeferralPoseidon2Count {
+    uint32_t compress_mult;
+    uint32_t capacity_mult;
+};
+
+struct DeferralPoseidon2Buffer {
+    FpArray<16> *records;
+    DeferralPoseidon2Count *counts;
+    uint32_t *idx;
+    size_t capacity;
+
+    __device__ DeferralPoseidon2Buffer(
+        FpArray<16> *records,
+        DeferralPoseidon2Count *counts,
+        uint32_t *idx,
+        size_t capacity
+    )
+        : records(records), counts(counts), idx(idx), capacity(capacity) {}
+
+    __device__ void record(RowSlice left, RowSlice right, bool is_compress) {
+        FpArray<16> value;
+        FpArray<8> left_array = FpArray<8>::from_row(left, DIGEST_SIZE);
+        FpArray<8> right_array = FpArray<8>::from_row(right, DIGEST_SIZE);
+
+#pragma unroll
+        for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+            value.v[i] = left_array.v[i];
+            value.v[i + DIGEST_SIZE] = right_array.v[i];
+        }
+
+        const uint32_t record_idx = atomicAdd(idx, 1);
+        assert(record_idx < capacity && "DeferralPoseidon2Buffer overflow");
+        records[record_idx] = value;
+        counts[record_idx] = {
+            is_compress ? 1u : 0u,
+            is_compress ? 0u : 1u,
+        };
+    }
+};
+
+} // namespace deferral

--- a/extensions/deferral/circuit/cuda/include/def_types.h
+++ b/extensions/deferral/circuit/cuda/include/def_types.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "fp.h"
+
+namespace deferral {
+
+inline constexpr size_t DIGEST_SIZE = 8;
+inline constexpr size_t F_NUM_BYTES = 4;
+inline constexpr size_t COMMIT_NUM_BYTES = DIGEST_SIZE * F_NUM_BYTES;
+inline constexpr size_t OUTPUT_LEN_NUM_BYTES = 8;
+inline constexpr size_t OUTPUT_TOTAL_BYTES = COMMIT_NUM_BYTES + OUTPUT_LEN_NUM_BYTES;
+
+inline constexpr size_t MEMORY_OP_SIZE = 4;
+inline constexpr size_t DIGEST_MEMORY_OPS = DIGEST_SIZE / MEMORY_OP_SIZE;
+inline constexpr size_t COMMIT_MEMORY_OPS = COMMIT_NUM_BYTES / MEMORY_OP_SIZE;
+inline constexpr size_t OUTPUT_TOTAL_MEMORY_OPS = OUTPUT_TOTAL_BYTES / MEMORY_OP_SIZE;
+
+inline constexpr uint32_t BABY_BEAR_ORDER = Fp::P;
+inline constexpr uint8_t BABY_BEAR_ORDER_BE[F_NUM_BYTES] = {
+    static_cast<uint8_t>((BABY_BEAR_ORDER >> 24) & 0xff),
+    static_cast<uint8_t>((BABY_BEAR_ORDER >> 16) & 0xff),
+    static_cast<uint8_t>((BABY_BEAR_ORDER >> 8) & 0xff),
+    static_cast<uint8_t>(BABY_BEAR_ORDER & 0xff),
+};
+
+} // namespace deferral

--- a/extensions/deferral/circuit/cuda/src/call.cu
+++ b/extensions/deferral/circuit/cuda/src/call.cu
@@ -1,0 +1,410 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "canonicity.cuh"
+#include "def_poseidon2_buffer.cuh"
+#include "def_types.h"
+#include "fp.h"
+#include "launcher.cuh"
+#include "primitives/constants.h"
+#include "primitives/execution.h"
+#include "primitives/fp_array.cuh"
+#include "primitives/histogram.cuh"
+#include "primitives/trace_access.h"
+#include "system/memory/controller.cuh"
+#include "system/memory/offline_checker.cuh"
+
+using namespace deferral;
+using namespace canonicity;
+using namespace lookup;
+
+template <typename T> using MemoryWriteAuxCols4 = MemoryWriteAuxCols<T, MEMORY_OP_SIZE>;
+
+__device__ __forceinline__ Fp bytes4_to_fp(const uint8_t *bytes) {
+    const uint32_t value =
+        static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8) |
+        (static_cast<uint32_t>(bytes[2]) << 16) | (static_cast<uint32_t>(bytes[3]) << 24);
+    return Fp(value);
+}
+
+template <typename B, typename F> struct DeferralCallReads {
+    B input_commit[COMMIT_NUM_BYTES];
+    F old_input_acc[DIGEST_SIZE];
+    F old_output_acc[DIGEST_SIZE];
+};
+
+template <typename B, typename F> struct DeferralCallWrites {
+    B output_commit[COMMIT_NUM_BYTES];
+    B output_len[F_NUM_BYTES];
+    F new_input_acc[DIGEST_SIZE];
+    F new_output_acc[DIGEST_SIZE];
+};
+
+// =========================== CORE ===============================
+
+template <typename T> struct DeferralCallCoreRecord {
+    T deferral_idx;
+    DeferralCallReads<uint8_t, T> reads;
+    DeferralCallWrites<uint8_t, T> writes;
+};
+
+template <typename T> struct DeferralCallCoreCols {
+    T is_valid;
+    T deferral_idx;
+    DeferralCallReads<T, T> reads;
+    DeferralCallWrites<T, T> writes;
+
+    CanonicityAuxCols<T> input_commit_lt_aux[DIGEST_SIZE];
+    CanonicityAuxCols<T> output_commit_lt_aux[DIGEST_SIZE];
+};
+
+__device__ __forceinline__ void deferral_call_core_tracegen(
+    RowSlice row,
+    const DeferralCallCoreRecord<Fp> &record,
+    Histogram &count_buffer,
+    BitwiseOperationLookup &bitwise_buffer,
+    DeferralPoseidon2Buffer &poseidon2_buffer,
+    const size_t address_bits
+) {
+    COL_WRITE_VALUE(row, DeferralCallCoreCols, is_valid, Fp::one());
+    COL_WRITE_VALUE(row, DeferralCallCoreCols, deferral_idx, record.deferral_idx);
+
+    COL_WRITE_ARRAY(row, DeferralCallCoreCols, reads.input_commit, record.reads.input_commit);
+    COL_WRITE_ARRAY(row, DeferralCallCoreCols, reads.old_input_acc, record.reads.old_input_acc);
+    COL_WRITE_ARRAY(row, DeferralCallCoreCols, reads.old_output_acc, record.reads.old_output_acc);
+
+    COL_WRITE_ARRAY(row, DeferralCallCoreCols, writes.output_commit, record.writes.output_commit);
+    COL_WRITE_ARRAY(row, DeferralCallCoreCols, writes.output_len, record.writes.output_len);
+    COL_WRITE_ARRAY(row, DeferralCallCoreCols, writes.new_input_acc, record.writes.new_input_acc);
+    COL_WRITE_ARRAY(row, DeferralCallCoreCols, writes.new_output_acc, record.writes.new_output_acc);
+
+    count_buffer.add_count(record.deferral_idx.asUInt32());
+
+    Fp input_f_commit[DIGEST_SIZE];
+    Fp output_f_commit[DIGEST_SIZE];
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+        input_f_commit[i] = bytes4_to_fp(record.reads.input_commit + i * F_NUM_BYTES);
+        output_f_commit[i] = bytes4_to_fp(record.writes.output_commit + i * F_NUM_BYTES);
+    }
+    poseidon2_buffer.record(
+        row.slice_from(COL_INDEX(DeferralCallCoreCols, reads.old_input_acc)),
+        RowSlice(input_f_commit, 1),
+        true
+    );
+    poseidon2_buffer.record(
+        row.slice_from(COL_INDEX(DeferralCallCoreCols, reads.old_output_acc)),
+        RowSlice(output_f_commit, 1),
+        true
+    );
+
+#pragma unroll
+    for (size_t i = 0; i < COMMIT_NUM_BYTES; i += 2) {
+        bitwise_buffer.add_range(
+            record.writes.output_commit[i], record.writes.output_commit[i + 1]
+        );
+    }
+#pragma unroll
+    for (size_t i = 0; i < F_NUM_BYTES; i += 2) {
+        bitwise_buffer.add_range(record.writes.output_len[i], record.writes.output_len[i + 1]);
+    }
+
+    const uint32_t limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - address_bits;
+    bitwise_buffer.add_range(
+        static_cast<uint32_t>(record.writes.output_len[RV32_REGISTER_NUM_LIMBS - 1])
+            << limb_shift_bits,
+        0
+    );
+
+    constexpr size_t input_aux_offset = COL_INDEX(DeferralCallCoreCols, input_commit_lt_aux);
+    constexpr size_t output_aux_offset = COL_INDEX(DeferralCallCoreCols, output_commit_lt_aux);
+    constexpr size_t canonicity_aux_stride = sizeof(CanonicityAuxCols<uint8_t>);
+
+    uint32_t input_commit_rcs[DIGEST_SIZE];
+    uint32_t output_commit_rcs[DIGEST_SIZE];
+
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+        CanonicityAuxCols<Fp> aux;
+        Fp x_le[F_NUM_BYTES];
+#pragma unroll
+        for (size_t j = 0; j < F_NUM_BYTES; ++j) {
+            x_le[j] = Fp(record.reads.input_commit[i * F_NUM_BYTES + j]);
+        }
+        input_commit_rcs[i] = generate_subrow(x_le, aux);
+        RowSlice aux_row = row.slice_from(input_aux_offset + i * canonicity_aux_stride);
+        COL_WRITE_ARRAY(aux_row, CanonicityAuxCols, diff_marker, aux.diff_marker);
+        COL_WRITE_VALUE(aux_row, CanonicityAuxCols, diff_val, aux.diff_val);
+    }
+
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+        CanonicityAuxCols<Fp> aux;
+        Fp x_le[F_NUM_BYTES];
+#pragma unroll
+        for (size_t j = 0; j < F_NUM_BYTES; ++j) {
+            x_le[j] = Fp(record.writes.output_commit[i * F_NUM_BYTES + j]);
+        }
+        output_commit_rcs[i] = generate_subrow(x_le, aux);
+        RowSlice aux_row = row.slice_from(output_aux_offset + i * canonicity_aux_stride);
+        COL_WRITE_ARRAY(aux_row, CanonicityAuxCols, diff_marker, aux.diff_marker);
+        COL_WRITE_VALUE(aux_row, CanonicityAuxCols, diff_val, aux.diff_val);
+    }
+
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_SIZE; i += 2) {
+        bitwise_buffer.add_range(input_commit_rcs[i], input_commit_rcs[i + 1]);
+        bitwise_buffer.add_range(output_commit_rcs[i], output_commit_rcs[i + 1]);
+    }
+}
+
+// =========================== ADAPTER ============================
+
+template <typename T> struct DeferralCallAdapterRecord {
+    uint32_t from_pc;
+    uint32_t from_timestamp;
+    T rd_ptr;
+    T rs_ptr;
+
+    uint8_t rd_val[RV32_REGISTER_NUM_LIMBS];
+    uint8_t rs_val[RV32_REGISTER_NUM_LIMBS];
+    MemoryReadAuxRecord rd_aux;
+    MemoryReadAuxRecord rs_aux;
+
+    MemoryReadAuxRecord input_commit_aux[COMMIT_MEMORY_OPS];
+    MemoryReadAuxRecord old_input_acc_aux[DIGEST_MEMORY_OPS];
+    MemoryReadAuxRecord old_output_acc_aux[DIGEST_MEMORY_OPS];
+
+    MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE> output_commit_and_len_aux[OUTPUT_TOTAL_MEMORY_OPS];
+    MemoryWriteAuxRecord<T, MEMORY_OP_SIZE> new_input_acc_aux[DIGEST_MEMORY_OPS];
+    MemoryWriteAuxRecord<T, MEMORY_OP_SIZE> new_output_acc_aux[DIGEST_MEMORY_OPS];
+};
+
+template <typename T> struct DeferralCallAdapterCols {
+    ExecutionState<T> from_state;
+    T rd_ptr;
+    T rs_ptr;
+
+    T rd_val[RV32_REGISTER_NUM_LIMBS];
+    T rs_val[RV32_REGISTER_NUM_LIMBS];
+    MemoryReadAuxCols<T> rd_aux;
+    MemoryReadAuxCols<T> rs_aux;
+
+    MemoryReadAuxCols<T> input_commit_aux[COMMIT_MEMORY_OPS];
+    MemoryReadAuxCols<T> old_input_acc_aux[DIGEST_MEMORY_OPS];
+    MemoryReadAuxCols<T> old_output_acc_aux[DIGEST_MEMORY_OPS];
+
+    MemoryWriteAuxCols<T, MEMORY_OP_SIZE> output_commit_and_len_aux[OUTPUT_TOTAL_MEMORY_OPS];
+    MemoryWriteAuxCols<T, MEMORY_OP_SIZE> new_input_acc_aux[DIGEST_MEMORY_OPS];
+    MemoryWriteAuxCols<T, MEMORY_OP_SIZE> new_output_acc_aux[DIGEST_MEMORY_OPS];
+};
+
+__device__ __forceinline__ void deferral_call_adapter_tracegen(
+    RowSlice row,
+    const DeferralCallAdapterRecord<Fp> &record,
+    BitwiseOperationLookup &bitwise_buffer,
+    MemoryAuxColsFactory &mem_helper,
+    const size_t address_bits
+) {
+    const uint32_t limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - address_bits;
+    bitwise_buffer.add_range(
+        static_cast<uint32_t>(record.rd_val[RV32_REGISTER_NUM_LIMBS - 1]) << limb_shift_bits,
+        static_cast<uint32_t>(record.rs_val[RV32_REGISTER_NUM_LIMBS - 1]) << limb_shift_bits
+    );
+
+    COL_WRITE_VALUE(row, DeferralCallAdapterCols, from_state.pc, record.from_pc);
+    COL_WRITE_VALUE(row, DeferralCallAdapterCols, from_state.timestamp, record.from_timestamp);
+    COL_WRITE_VALUE(row, DeferralCallAdapterCols, rd_ptr, record.rd_ptr);
+    COL_WRITE_VALUE(row, DeferralCallAdapterCols, rs_ptr, record.rs_ptr);
+    COL_WRITE_ARRAY(row, DeferralCallAdapterCols, rd_val, record.rd_val);
+    COL_WRITE_ARRAY(row, DeferralCallAdapterCols, rs_val, record.rs_val);
+
+    uint32_t timestamp = record.from_timestamp;
+    constexpr size_t read_aux_stride = sizeof(MemoryReadAuxCols<uint8_t>);
+    constexpr size_t write_aux_stride = sizeof(MemoryWriteAuxCols4<uint8_t>);
+
+    mem_helper.fill(
+        row.slice_from(COL_INDEX(DeferralCallAdapterCols, rd_aux)),
+        record.rd_aux.prev_timestamp,
+        timestamp++
+    );
+    mem_helper.fill(
+        row.slice_from(COL_INDEX(DeferralCallAdapterCols, rs_aux)),
+        record.rs_aux.prev_timestamp,
+        timestamp++
+    );
+
+#pragma unroll
+    for (size_t i = 0; i < COMMIT_MEMORY_OPS; ++i) {
+        mem_helper.fill(
+            row.slice_from(
+                COL_INDEX(DeferralCallAdapterCols, input_commit_aux) + i * read_aux_stride
+            ),
+            record.input_commit_aux[i].prev_timestamp,
+            timestamp++
+        );
+    }
+
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_MEMORY_OPS; ++i) {
+        mem_helper.fill(
+            row.slice_from(
+                COL_INDEX(DeferralCallAdapterCols, old_input_acc_aux) + i * read_aux_stride
+            ),
+            record.old_input_acc_aux[i].prev_timestamp,
+            timestamp++
+        );
+    }
+
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_MEMORY_OPS; ++i) {
+        mem_helper.fill(
+            row.slice_from(
+                COL_INDEX(DeferralCallAdapterCols, old_output_acc_aux) + i * read_aux_stride
+            ),
+            record.old_output_acc_aux[i].prev_timestamp,
+            timestamp++
+        );
+    }
+
+#pragma unroll
+    for (size_t i = 0; i < OUTPUT_TOTAL_MEMORY_OPS; ++i) {
+        RowSlice aux_row = row.slice_from(
+            COL_INDEX(DeferralCallAdapterCols, output_commit_and_len_aux) + i * write_aux_stride
+        );
+        COL_WRITE_ARRAY(
+            aux_row, MemoryWriteAuxCols4, prev_data, record.output_commit_and_len_aux[i].prev_data
+        );
+        mem_helper.fill(aux_row, record.output_commit_and_len_aux[i].prev_timestamp, timestamp++);
+    }
+
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_MEMORY_OPS; ++i) {
+        RowSlice aux_row = row.slice_from(
+            COL_INDEX(DeferralCallAdapterCols, new_input_acc_aux) + i * write_aux_stride
+        );
+        COL_WRITE_ARRAY(
+            aux_row, MemoryWriteAuxCols4, prev_data, record.new_input_acc_aux[i].prev_data
+        );
+        mem_helper.fill(aux_row, record.new_input_acc_aux[i].prev_timestamp, timestamp++);
+    }
+
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_MEMORY_OPS; ++i) {
+        RowSlice aux_row = row.slice_from(
+            COL_INDEX(DeferralCallAdapterCols, new_output_acc_aux) + i * write_aux_stride
+        );
+        COL_WRITE_ARRAY(
+            aux_row, MemoryWriteAuxCols4, prev_data, record.new_output_acc_aux[i].prev_data
+        );
+        mem_helper.fill(aux_row, record.new_output_acc_aux[i].prev_timestamp, timestamp++);
+    }
+}
+
+// =========================== COMBINED ===========================
+
+template <typename T> struct DeferralCallRecord {
+    DeferralCallAdapterRecord<T> adapter;
+    DeferralCallCoreRecord<T> core;
+};
+
+template <typename T> struct DeferralCallCols {
+    DeferralCallAdapterCols<T> adapter;
+    DeferralCallCoreCols<T> core;
+};
+
+__global__ void deferral_call_tracegen(
+    Fp *trace,
+    const size_t height,
+    const DeferralCallRecord<Fp> *records,
+    const size_t num_records,
+    uint32_t *count_ptr,
+    const size_t num_def_circuits,
+    uint32_t *range_checker_ptr,
+    const uint32_t range_checker_num_bins,
+    const uint32_t timestamp_max_bits,
+    uint32_t *bitwise_ptr,
+    const size_t bitwise_num_bits,
+    FpArray<16> *poseidon2_records,
+    DeferralPoseidon2Count *poseidon2_counts,
+    uint32_t *poseidon2_idx,
+    const size_t poseidon2_capacity,
+    const size_t address_bits
+) {
+    const uint32_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + row_idx, height);
+
+    if (row_idx >= num_records) {
+        row.fill_zero(0, sizeof(DeferralCallCols<uint8_t>));
+        return;
+    }
+
+    DeferralCallRecord<Fp> record = records[row_idx];
+    Histogram count_buffer(count_ptr, num_def_circuits);
+    MemoryAuxColsFactory mem_helper(
+        VariableRangeChecker(range_checker_ptr, range_checker_num_bins), timestamp_max_bits
+    );
+    BitwiseOperationLookup bitwise_buffer(bitwise_ptr, bitwise_num_bits);
+    DeferralPoseidon2Buffer poseidon2_buffer(
+        poseidon2_records,
+        poseidon2_counts,
+        poseidon2_idx,
+        poseidon2_capacity
+    );
+
+    deferral_call_adapter_tracegen(row, record.adapter, bitwise_buffer, mem_helper, address_bits);
+    deferral_call_core_tracegen(
+        row.slice_from(COL_INDEX(DeferralCallCols, core)),
+        record.core,
+        count_buffer,
+        bitwise_buffer,
+        poseidon2_buffer,
+        address_bits
+    );
+}
+
+// =========================== LAUNCHER ===========================
+
+extern "C" int _deferral_call_tracegen(
+    Fp *d_trace,
+    size_t height,
+    size_t width,
+    const uint8_t *d_records,
+    size_t num_records,
+    uint32_t *d_count,
+    size_t num_def_circuits,
+    uint32_t *d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t timestamp_max_bits,
+    uint32_t *d_bitwise,
+    uint32_t bitwise_num_bits,
+    Fp *d_poseidon2_records,
+    DeferralPoseidon2Count *d_poseidon2_counts,
+    uint32_t *d_poseidon2_idx,
+    size_t poseidon2_capacity,
+    size_t address_bits
+) {
+    auto [grid, block] = kernel_launch_params(height);
+    assert(width == sizeof(DeferralCallCols<uint8_t>));
+
+    deferral_call_tracegen<<<grid, block>>>(
+        d_trace,
+        height,
+        reinterpret_cast<const DeferralCallRecord<Fp> *>(d_records),
+        num_records,
+        d_count,
+        num_def_circuits,
+        d_range_checker,
+        range_checker_num_bins,
+        timestamp_max_bits,
+        d_bitwise,
+        bitwise_num_bits,
+        reinterpret_cast<FpArray<16> *>(d_poseidon2_records),
+        d_poseidon2_counts,
+        d_poseidon2_idx,
+        poseidon2_capacity,
+        address_bits
+    );
+    return CHECK_KERNEL();
+}

--- a/extensions/deferral/circuit/cuda/src/canonicity.cuh
+++ b/extensions/deferral/circuit/cuda/src/canonicity.cuh
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "def_types.h"
+#include "fp.h"
+
+namespace canonicity {
+
+using namespace deferral;
+
+template <typename T> struct CanonicityAuxCols {
+    T diff_marker[F_NUM_BYTES];
+    T diff_val;
+};
+
+__device__ __forceinline__ uint32_t
+generate_subrow(const Fp x_le[F_NUM_BYTES], CanonicityAuxCols<Fp> &aux) {
+#pragma unroll
+    for (size_t i = 0; i < F_NUM_BYTES; ++i) {
+        aux.diff_marker[i] = Fp::zero();
+    }
+    aux.diff_val = Fp::zero();
+
+    Fp x_be[F_NUM_BYTES];
+#pragma unroll
+    for (size_t i = 0; i < F_NUM_BYTES; ++i) {
+        x_be[i] = x_le[F_NUM_BYTES - 1 - i];
+    }
+
+    bool found = false;
+    uint32_t to_range_check = 0;
+
+#pragma unroll
+    for (size_t i = 0; i < F_NUM_BYTES; ++i) {
+        const uint32_t x_u32 = x_be[i].asUInt32();
+        const uint32_t y =
+            (BABY_BEAR_ORDER >> (8 * (F_NUM_BYTES - 1 - i))) & static_cast<uint32_t>(0xff);
+
+        if (!found && x_u32 != y) {
+#ifdef CUDA_DEBUG
+            assert(x_u32 < 256);
+            assert(y > x_u32);
+#endif
+            const uint32_t diff = y - x_u32;
+            aux.diff_marker[i] = Fp::one();
+            aux.diff_val = Fp(diff);
+            to_range_check = diff - 1;
+            found = true;
+        }
+    }
+
+#ifdef CUDA_DEBUG
+    assert(found);
+#endif
+
+    return to_range_check;
+}
+
+} // namespace canonicity

--- a/extensions/deferral/circuit/cuda/src/count.cu
+++ b/extensions/deferral/circuit/cuda/src/count.cu
@@ -18,13 +18,11 @@ __global__ void deferral_count_tracegen(
     const size_t num_def_circuits
 ) {
     const uint32_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (row_idx >= height) {
-        return;
-    }
     RowSlice row(trace + row_idx, height);
 
     if (row_idx >= num_def_circuits) {
         row.fill_zero(0, sizeof(DeferralCircuitCountCols<uint8_t>));
+        COL_WRITE_VALUE(row, DeferralCircuitCountCols, row_idx, row_idx);
         return;
     }
 

--- a/extensions/deferral/circuit/cuda/src/count.cu
+++ b/extensions/deferral/circuit/cuda/src/count.cu
@@ -1,0 +1,45 @@
+#include <cstddef>
+#include <cstdint>
+
+#include "fp.h"
+#include "launcher.cuh"
+#include "primitives/trace_access.h"
+
+template <typename T> struct DeferralCircuitCountCols {
+    T is_valid;
+    T row_idx;
+    T mult;
+};
+
+__global__ void deferral_count_tracegen(
+    Fp *trace,
+    const size_t height,
+    const uint32_t *count,
+    const size_t num_def_circuits
+) {
+    const uint32_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row_idx >= height) {
+        return;
+    }
+    RowSlice row(trace + row_idx, height);
+
+    if (row_idx >= num_def_circuits) {
+        row.fill_zero(0, sizeof(DeferralCircuitCountCols<uint8_t>));
+        return;
+    }
+
+    COL_WRITE_VALUE(row, DeferralCircuitCountCols, is_valid, Fp::one());
+    COL_WRITE_VALUE(row, DeferralCircuitCountCols, row_idx, row_idx);
+    COL_WRITE_VALUE(row, DeferralCircuitCountCols, mult, count[row_idx]);
+}
+
+extern "C" int _deferral_count_tracegen(
+    Fp *d_trace,
+    const size_t height,
+    const uint32_t *d_count,
+    const size_t num_def_circuits
+) {
+    auto [grid, block] = kernel_launch_params(height);
+    deferral_count_tracegen<<<grid, block>>>(d_trace, height, d_count, num_def_circuits);
+    return CHECK_KERNEL();
+}

--- a/extensions/deferral/circuit/cuda/src/output.cu
+++ b/extensions/deferral/circuit/cuda/src/output.cu
@@ -1,0 +1,352 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "canonicity.cuh"
+#include "def_poseidon2_buffer.cuh"
+#include "def_types.h"
+#include "fp.h"
+#include "launcher.cuh"
+#include "primitives/constants.h"
+#include "primitives/execution.h"
+#include "primitives/fp_array.cuh"
+#include "primitives/histogram.cuh"
+#include "primitives/trace_access.h"
+#include "system/memory/controller.cuh"
+#include "system/memory/offline_checker.cuh"
+
+using namespace deferral;
+using namespace canonicity;
+using namespace lookup;
+
+struct DeferralOutputRecordHeader {
+    uint32_t from_pc;
+    uint32_t from_timestamp;
+    uint32_t rd_ptr;
+    uint32_t rs_ptr;
+    uint32_t deferral_idx;
+    uint32_t num_rows;
+
+    uint8_t rd_val[RV32_REGISTER_NUM_LIMBS];
+    uint8_t rs_val[RV32_REGISTER_NUM_LIMBS];
+    MemoryReadAuxRecord rd_aux;
+    MemoryReadAuxRecord rs_aux;
+
+    MemoryReadAuxRecord output_commit_and_len_aux[OUTPUT_TOTAL_MEMORY_OPS];
+};
+
+struct DeferralOutputPerCall {
+    uint8_t output_commit[COMMIT_NUM_BYTES];
+};
+
+struct DeferralOutputPerRow {
+    uint32_t header_offset;
+    uint32_t section_idx;
+    uint32_t call_idx;
+    Fp poseidon2_res[DIGEST_SIZE];
+};
+
+template <typename T> using MemoryWriteAuxCols4 = MemoryWriteAuxCols<T, MEMORY_OP_SIZE>;
+
+__device__ __forceinline__ size_t align_up(size_t value, size_t alignment) {
+    return ((value + alignment - 1) / alignment) * alignment;
+}
+
+__device__ __forceinline__ void write_canonicity_aux(
+    RowSlice row,
+    size_t base_offset,
+    size_t aux_idx,
+    const CanonicityAuxCols<Fp> &aux
+) {
+    constexpr size_t aux_stride = sizeof(CanonicityAuxCols<uint8_t>);
+    RowSlice aux_row = row.slice_from(base_offset + aux_idx * aux_stride);
+    COL_WRITE_ARRAY(aux_row, CanonicityAuxCols, diff_marker, aux.diff_marker);
+    COL_WRITE_VALUE(aux_row, CanonicityAuxCols, diff_val, aux.diff_val);
+}
+
+template <typename T> struct DeferralOutputCols {
+    // Indicates the status of this row, i.e. if it is valid and where it is in a
+    // section of rows that correspond to a single opcode invocation
+    T is_valid;
+    T is_first;
+    T is_last;
+    T section_idx;
+
+    // Initial execution state + instruction operands
+    ExecutionState<T> from_state;
+    T rd_ptr;
+    T rs_ptr;
+    T deferral_idx;
+
+    // Heap pointers + auxiliary read columns
+    T rd_val[RV32_REGISTER_NUM_LIMBS];
+    T rs_val[RV32_REGISTER_NUM_LIMBS];
+    MemoryReadAuxCols<T> rd_aux;
+    MemoryReadAuxCols<T> rs_aux;
+
+    // Read data and auxiliary columns. output_commit and output_len are read
+    // contiguously from heap with layout [output_commit || output_len]. The
+    // onion hash of all bytes written by this opcode invocation is constrained
+    // to output_commit.
+    T output_commit[COMMIT_NUM_BYTES];
+    T output_len[F_NUM_BYTES];
+    MemoryReadAuxCols<T> output_commit_and_len_aux[OUTPUT_TOTAL_MEMORY_OPS];
+
+    // Auxiliary columns to ensure the canonicity of each F byte decomposition in
+    // output_commit.
+    CanonicityAuxCols<T> output_commit_lt_aux[DIGEST_SIZE];
+
+    // Initial [def_idx, output_len, 0, ...] digest on the first row; on non-first
+    // rows bytes raw_output[local_idx * DIGEST_SIZE..(local_idx + 1) * DIGEST_SIZE]
+    // written to memory and auxiliary columns.
+    T sponge_inputs[DIGEST_SIZE];
+    MemoryWriteAuxCols<T, MEMORY_OP_SIZE> write_bytes_aux[DIGEST_MEMORY_OPS];
+
+    // Capacity of the permutation of write_bytes and the previous row's capacity on
+    // non-last rows, compression on the last row.
+    T poseidon2_res[DIGEST_SIZE];
+};
+
+__global__ void deferral_output_tracegen(
+    Fp *trace,
+    size_t height,
+    const uint8_t *raw_records,
+    const DeferralOutputPerCall *per_call,
+    const DeferralOutputPerRow *per_row,
+    const size_t num_valid,
+    uint32_t *count_ptr,
+    const size_t num_def_circuits,
+    uint32_t *range_checker_ptr,
+    const uint32_t range_checker_num_bins,
+    const uint32_t timestamp_max_bits,
+    uint32_t *bitwise_ptr,
+    const size_t bitwise_num_bits,
+    const size_t address_bits,
+    FpArray<16> *poseidon2_records,
+    DeferralPoseidon2Count *poseidon2_counts,
+    uint32_t *poseidon2_idx,
+    const size_t poseidon2_capacity
+) {
+    const uint32_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + row_idx, height);
+
+    if (row_idx >= num_valid) {
+        row.fill_zero(0, sizeof(DeferralOutputCols<uint8_t>));
+        return;
+    }
+
+    const DeferralOutputPerRow row_data = per_row[row_idx];
+    const uint32_t section_idx = row_data.section_idx;
+    const DeferralOutputPerCall call_data = per_call[row_data.call_idx];
+
+    const uint8_t *record_start = raw_records + row_data.header_offset;
+    const DeferralOutputRecordHeader header =
+        *reinterpret_cast<const DeferralOutputRecordHeader *>(record_start);
+
+    const uint32_t output_len = (header.num_rows - 1) * DIGEST_SIZE;
+    const bool is_first = section_idx == 0;
+    const bool is_last = section_idx + 1 == header.num_rows;
+
+    Histogram count_buffer(count_ptr, num_def_circuits);
+    MemoryAuxColsFactory mem_helper(
+        VariableRangeChecker(range_checker_ptr, range_checker_num_bins), timestamp_max_bits
+    );
+    BitwiseOperationLookup bitwise_buffer(bitwise_ptr, bitwise_num_bits);
+    DeferralPoseidon2Buffer poseidon2_buffer(
+        poseidon2_records, poseidon2_counts, poseidon2_idx, poseidon2_capacity
+    );
+
+    COL_WRITE_VALUE(row, DeferralOutputCols, is_valid, Fp::one());
+    COL_WRITE_VALUE(row, DeferralOutputCols, is_first, is_first ? Fp::one() : Fp::zero());
+    COL_WRITE_VALUE(row, DeferralOutputCols, is_last, is_last ? Fp::one() : Fp::zero());
+    COL_WRITE_VALUE(row, DeferralOutputCols, section_idx, section_idx);
+
+    COL_WRITE_VALUE(row, DeferralOutputCols, from_state.pc, header.from_pc);
+    COL_WRITE_VALUE(row, DeferralOutputCols, from_state.timestamp, header.from_timestamp);
+    COL_WRITE_VALUE(row, DeferralOutputCols, rd_ptr, header.rd_ptr);
+    COL_WRITE_VALUE(row, DeferralOutputCols, rs_ptr, header.rs_ptr);
+    COL_WRITE_VALUE(row, DeferralOutputCols, deferral_idx, header.deferral_idx);
+
+    COL_WRITE_ARRAY(row, DeferralOutputCols, rd_val, header.rd_val);
+    COL_WRITE_ARRAY(row, DeferralOutputCols, rs_val, header.rs_val);
+
+    COL_WRITE_ARRAY(row, DeferralOutputCols, output_commit, call_data.output_commit);
+    const uint8_t output_len_bytes[F_NUM_BYTES] = {
+        static_cast<uint8_t>(output_len & 0xffu),
+        static_cast<uint8_t>((output_len >> 8) & 0xffu),
+        static_cast<uint8_t>((output_len >> 16) & 0xffu),
+        static_cast<uint8_t>((output_len >> 24) & 0xffu),
+    };
+    COL_WRITE_ARRAY(row, DeferralOutputCols, output_len, output_len_bytes);
+
+    if (is_first) {
+        count_buffer.add_count(header.deferral_idx);
+
+        const uint32_t limb_shift_bits = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS - address_bits;
+        bitwise_buffer.add_range(
+            static_cast<uint32_t>(header.rd_val[RV32_REGISTER_NUM_LIMBS - 1]) << limb_shift_bits,
+            static_cast<uint32_t>(header.rs_val[RV32_REGISTER_NUM_LIMBS - 1]) << limb_shift_bits
+        );
+        bitwise_buffer.add_range(
+            static_cast<uint32_t>(output_len_bytes[RV32_REGISTER_NUM_LIMBS - 1]) << limb_shift_bits,
+            0
+        );
+
+        mem_helper.fill(
+            row.slice_from(COL_INDEX(DeferralOutputCols, rd_aux)),
+            header.rd_aux.prev_timestamp,
+            header.from_timestamp
+        );
+        mem_helper.fill(
+            row.slice_from(COL_INDEX(DeferralOutputCols, rs_aux)),
+            header.rs_aux.prev_timestamp,
+            header.from_timestamp + 1
+        );
+        constexpr size_t read_aux_stride = sizeof(MemoryReadAuxCols<uint8_t>);
+#pragma unroll
+        for (size_t chunk_idx = 0; chunk_idx < OUTPUT_TOTAL_MEMORY_OPS; ++chunk_idx) {
+            mem_helper.fill(
+                row.slice_from(
+                    COL_INDEX(DeferralOutputCols, output_commit_and_len_aux) +
+                    chunk_idx * read_aux_stride
+                ),
+                header.output_commit_and_len_aux[chunk_idx].prev_timestamp,
+                header.from_timestamp + 2 + static_cast<uint32_t>(chunk_idx)
+            );
+        }
+
+        uint32_t output_commit_rcs[DIGEST_SIZE];
+#pragma unroll
+        for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+            CanonicityAuxCols<Fp> aux;
+            Fp x_le[F_NUM_BYTES];
+#pragma unroll
+            for (size_t j = 0; j < F_NUM_BYTES; ++j) {
+                x_le[j] = Fp(call_data.output_commit[i * F_NUM_BYTES + j]);
+            }
+            output_commit_rcs[i] = generate_subrow(x_le, aux);
+            write_canonicity_aux(row, COL_INDEX(DeferralOutputCols, output_commit_lt_aux), i, aux);
+        }
+#pragma unroll
+        for (size_t i = 0; i < DIGEST_SIZE; i += 2) {
+            bitwise_buffer.add_range(output_commit_rcs[i], output_commit_rcs[i + 1]);
+        }
+
+        Fp sponge_inputs[DIGEST_SIZE];
+#pragma unroll
+        for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+            sponge_inputs[i] = Fp::zero();
+        }
+        sponge_inputs[0] = Fp(header.deferral_idx);
+        sponge_inputs[1] = Fp(output_len);
+        COL_WRITE_ARRAY(row, DeferralOutputCols, sponge_inputs, sponge_inputs);
+
+        COL_FILL_ZERO(row, DeferralOutputCols, write_bytes_aux);
+    } else {
+        const uint8_t *header_end = record_start + sizeof(DeferralOutputRecordHeader);
+        const uint8_t *write_bytes_start = header_end + (section_idx - 1) * DIGEST_SIZE;
+        const size_t write_aux_offset = align_up(
+            sizeof(DeferralOutputRecordHeader) + output_len,
+            alignof(MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE>)
+        );
+        const auto *write_aux = reinterpret_cast<const MemoryWriteBytesAuxRecord<MEMORY_OP_SIZE> *>(
+            record_start + write_aux_offset
+        );
+
+        COL_FILL_ZERO(row, DeferralOutputCols, rd_aux);
+        COL_FILL_ZERO(row, DeferralOutputCols, rs_aux);
+        COL_FILL_ZERO(row, DeferralOutputCols, output_commit_and_len_aux);
+        COL_FILL_ZERO(row, DeferralOutputCols, output_commit_lt_aux);
+
+        COL_WRITE_ARRAY(row, DeferralOutputCols, sponge_inputs, write_bytes_start);
+
+#pragma unroll
+        for (size_t i = 0; i < DIGEST_SIZE; i += 2) {
+            bitwise_buffer.add_range(write_bytes_start[i], write_bytes_start[i + 1]);
+        }
+
+        constexpr size_t write_aux_stride = sizeof(MemoryWriteAuxCols4<uint8_t>);
+#pragma unroll
+        for (size_t chunk_idx = 0; chunk_idx < DIGEST_MEMORY_OPS; ++chunk_idx) {
+            const size_t aux_idx = (section_idx - 1) * DIGEST_MEMORY_OPS + chunk_idx;
+            RowSlice aux_row = row.slice_from(
+                COL_INDEX(DeferralOutputCols, write_bytes_aux) + chunk_idx * write_aux_stride
+            );
+            COL_WRITE_ARRAY(aux_row, MemoryWriteAuxCols4, prev_data, write_aux[aux_idx].prev_data);
+            mem_helper.fill(
+                aux_row,
+                write_aux[aux_idx].prev_timestamp,
+                header.from_timestamp + 2 + static_cast<uint32_t>(OUTPUT_TOTAL_MEMORY_OPS) +
+                    static_cast<uint32_t>(aux_idx)
+            );
+        }
+    }
+
+    Fp prev_capacity[DIGEST_SIZE];
+    if (is_first) {
+#pragma unroll
+        for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+            prev_capacity[i] = Fp::zero();
+        }
+    } else {
+#pragma unroll
+        for (size_t i = 0; i < DIGEST_SIZE; ++i) {
+            prev_capacity[i] = per_row[row_idx - 1].poseidon2_res[i];
+        }
+    }
+
+    poseidon2_buffer.record(
+        row.slice_from(COL_INDEX(DeferralOutputCols, sponge_inputs)),
+        RowSlice(prev_capacity, 1),
+        is_last
+    );
+
+    COL_WRITE_ARRAY(row, DeferralOutputCols, poseidon2_res, row_data.poseidon2_res);
+}
+
+extern "C" int _deferral_output_tracegen(
+    Fp *d_trace,
+    size_t height,
+    size_t width,
+    const uint8_t *d_raw_records,
+    const DeferralOutputPerCall *d_per_call,
+    const DeferralOutputPerRow *d_per_row,
+    size_t num_valid,
+    uint32_t *d_count,
+    size_t num_def_circuits,
+    uint32_t *d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t timestamp_max_bits,
+    uint32_t *d_bitwise,
+    uint32_t bitwise_num_bits,
+    size_t address_bits,
+    Fp *d_poseidon2_records,
+    DeferralPoseidon2Count *d_poseidon2_counts,
+    uint32_t *d_poseidon2_idx,
+    size_t poseidon2_capacity
+) {
+    auto [grid, block] = kernel_launch_params(height);
+    assert(width == sizeof(DeferralOutputCols<uint8_t>));
+
+    deferral_output_tracegen<<<grid, block>>>(
+        d_trace,
+        height,
+        d_raw_records,
+        d_per_call,
+        d_per_row,
+        num_valid,
+        d_count,
+        num_def_circuits,
+        d_range_checker,
+        range_checker_num_bins,
+        timestamp_max_bits,
+        d_bitwise,
+        bitwise_num_bits,
+        address_bits,
+        reinterpret_cast<FpArray<16> *>(d_poseidon2_records),
+        d_poseidon2_counts,
+        d_poseidon2_idx,
+        poseidon2_capacity
+    );
+    return CHECK_KERNEL();
+}

--- a/extensions/deferral/circuit/cuda/src/poseidon2.cu
+++ b/extensions/deferral/circuit/cuda/src/poseidon2.cu
@@ -1,0 +1,198 @@
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cub/cub.cuh>
+#include <cub/device/device_merge_sort.cuh>
+#include <cub/device/device_reduce.cuh>
+#include <driver_types.h>
+
+#include "def_poseidon2_buffer.cuh"
+#include "fp.h"
+#include "launcher.cuh"
+#include "poseidon2-air/columns.cuh"
+#include "poseidon2-air/params.cuh"
+#include "poseidon2-air/tracegen.cuh"
+#include "primitives/fp_array.cuh"
+#include "primitives/trace_access.h"
+
+using namespace deferral;
+
+struct DeferralPoseidon2CountCompose {
+    __device__ __forceinline__ DeferralPoseidon2Count
+    operator()(const DeferralPoseidon2Count &a, const DeferralPoseidon2Count &b) const {
+        return {a.compress_mult + b.compress_mult, a.capacity_mult + b.capacity_mult};
+    }
+};
+
+template <typename T, typename PoseidonParams> struct DeferralPoseidon2Cols {
+    poseidon2::Poseidon2SubCols<
+        T,
+        16,
+        Poseidon2DefaultParams::SBOX_DEGREE,
+        PoseidonParams::SBOX_REGS,
+        Poseidon2DefaultParams::HALF_FULL_ROUNDS,
+        Poseidon2DefaultParams::PARTIAL_ROUNDS>
+        inner;
+    T compress_mult;
+    T capacity_mult;
+};
+
+template <size_t WIDTH, typename PoseidonParams>
+__global__ void cukernel_deferral_poseidon2_tracegen(
+    Fp *d_trace,
+    size_t trace_height,
+    size_t trace_width,
+    Fp *d_records,
+    DeferralPoseidon2Count *d_counts,
+    size_t num_records
+) {
+    const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    using Poseidon2Row = poseidon2::Poseidon2Row<
+        WIDTH,
+        PoseidonParams::SBOX_DEGREE,
+        PoseidonParams::SBOX_REGS,
+        PoseidonParams::HALF_FULL_ROUNDS,
+        PoseidonParams::PARTIAL_ROUNDS>;
+
+#ifdef CUDA_DEBUG
+    assert(sizeof(DeferralPoseidon2Cols<uint8_t, PoseidonParams>) == trace_width);
+    assert(Poseidon2Row::get_total_size() + 2 == trace_width);
+#endif
+
+    if (idx >= trace_height) {
+        return;
+    }
+
+    RowSlice row(d_trace + idx, trace_height);
+    Poseidon2Row poseidon2_row(row);
+    constexpr size_t compress_mult_idx = Poseidon2Row::get_total_size();
+    constexpr size_t capacity_mult_idx = compress_mult_idx + 1;
+
+    if (idx < num_records) {
+        RowSlice state(d_records + idx * WIDTH, 1);
+        poseidon2::generate_trace_row_for_perm(poseidon2_row, state);
+
+        const auto count = d_counts[idx];
+        row.write(compress_mult_idx, Fp(count.compress_mult));
+        row.write(capacity_mult_idx, Fp(count.capacity_mult));
+    } else {
+        Fp zero_state[WIDTH] = {0};
+        RowSlice zero_state_row(zero_state, 1);
+        poseidon2::generate_trace_row_for_perm(poseidon2_row, zero_state_row);
+
+        row.write(compress_mult_idx, Fp::zero());
+        row.write(capacity_mult_idx, Fp::zero());
+    }
+}
+
+extern "C" int _deferral_poseidon2_tracegen(
+    Fp *d_trace,
+    size_t height,
+    size_t width,
+    Fp *d_records,
+    DeferralPoseidon2Count *d_counts,
+    size_t num_records,
+    size_t sbox_regs
+) {
+    auto [grid, block] = kernel_launch_params(height);
+
+    switch (sbox_regs) {
+    case 1:
+        cukernel_deferral_poseidon2_tracegen<16, Poseidon2ParamsS1>
+            <<<grid, block, 0, cudaStreamPerThread>>>(
+                d_trace, height, width, d_records, d_counts, num_records
+            );
+        break;
+    case 0:
+        cukernel_deferral_poseidon2_tracegen<16, Poseidon2ParamsS0>
+            <<<grid, block, 0, cudaStreamPerThread>>>(
+                d_trace, height, width, d_records, d_counts, num_records
+            );
+        break;
+    default:
+        return cudaErrorInvalidConfiguration;
+    }
+
+    return CHECK_KERNEL();
+}
+
+// Prepares d_num_records for use with sort reduce and stores the temporary
+// buffer size necessary for both cub functions (i.e. sort and reduce).
+extern "C" int _deferral_poseidon2_deduplicate_records_get_temp_bytes(
+    Fp *d_records,
+    DeferralPoseidon2Count *d_counts,
+    size_t num_records,
+    size_t *d_num_records,
+    size_t *h_temp_bytes_out
+) {
+    FpArray<16> *d_records_fp16 = reinterpret_cast<FpArray<16> *>(d_records);
+
+    size_t sort_storage_bytes = 0;
+    cub::DeviceMergeSort::SortPairs(
+        nullptr,
+        sort_storage_bytes,
+        d_records_fp16,
+        d_counts,
+        num_records,
+        Fp16CompareOp(),
+        cudaStreamPerThread
+    );
+
+    size_t reduce_storage_bytes = 0;
+    cub::DeviceReduce::ReduceByKey(
+        nullptr,
+        reduce_storage_bytes,
+        d_records_fp16,
+        d_records_fp16,
+        d_counts,
+        d_counts,
+        d_num_records,
+        DeferralPoseidon2CountCompose{},
+        num_records,
+        cudaStreamPerThread
+    );
+
+    *h_temp_bytes_out = std::max(sort_storage_bytes, reduce_storage_bytes);
+    return CHECK_KERNEL();
+}
+
+// Reduces the records, removing duplicates and summing multiplicities into
+// d_counts. The number of records after reduction is stored into d_num_records.
+// The value of temp_storage_bytes should be computed using the _get_temp_bytes
+// function above.
+extern "C" int _deferral_poseidon2_deduplicate_records(
+    Fp *d_records,
+    DeferralPoseidon2Count *d_counts,
+    size_t num_records,
+    size_t *d_num_records,
+    void *d_temp_storage,
+    size_t temp_storage_bytes
+) {
+    FpArray<16> *d_records_fp16 = reinterpret_cast<FpArray<16> *>(d_records);
+
+    cub::DeviceMergeSort::SortPairs(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_records_fp16,
+        d_counts,
+        num_records,
+        Fp16CompareOp(),
+        cudaStreamPerThread
+    );
+
+    cub::DeviceReduce::ReduceByKey(
+        d_temp_storage,
+        temp_storage_bytes,
+        d_records_fp16,
+        d_records_fp16,
+        d_counts,
+        d_counts,
+        d_num_records,
+        DeferralPoseidon2CountCompose{},
+        num_records,
+        cudaStreamPerThread
+    );
+
+    return CHECK_KERNEL();
+}

--- a/extensions/deferral/circuit/src/call/cuda.rs
+++ b/extensions/deferral/circuit/src/call/cuda.rs
@@ -1,0 +1,73 @@
+use std::{mem::size_of, sync::Arc};
+
+use derive_new::new;
+use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
+};
+use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
+use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer};
+use openvm_instructions::riscv::RV32_CELL_BITS;
+use openvm_stark_backend::prover::AirProvingContext;
+
+use super::{
+    DeferralCallAdapterCols, DeferralCallAdapterRecord, DeferralCallCoreCols,
+    DeferralCallCoreRecord,
+};
+use crate::{cuda_abi::call, poseidon2::DeferralPoseidon2SharedBuffer};
+
+#[derive(new)]
+pub struct DeferralCallChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
+    pub address_bits: usize,
+    pub timestamp_max_bits: usize,
+    pub count: Arc<DeviceBuffer<u32>>,
+    pub num_deferral_circuits: usize,
+    pub poseidon2: DeferralPoseidon2SharedBuffer,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for DeferralCallChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        type Record = (DeferralCallAdapterRecord<F>, DeferralCallCoreRecord<F>);
+        const RECORD_SIZE: usize = size_of::<Record>();
+
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let num_records = records.len() / RECORD_SIZE;
+        let trace_height = next_power_of_two_or_zero(num_records);
+        let trace_width =
+            DeferralCallAdapterCols::<F>::width() + DeferralCallCoreCols::<F>::width();
+
+        let d_records = records.to_device().unwrap();
+        let trace = DeviceMatrix::<F>::with_capacity(trace_height, trace_width);
+
+        unsafe {
+            call::tracegen(
+                trace.buffer(),
+                trace_height,
+                trace_width,
+                &d_records,
+                num_records,
+                &self.count,
+                self.num_deferral_circuits,
+                &self.range_checker.count,
+                self.timestamp_max_bits as u32,
+                &self.bitwise_lookup.count,
+                RV32_CELL_BITS as u32,
+                &self.poseidon2.records,
+                &self.poseidon2.counts,
+                &self.poseidon2.idx,
+                self.poseidon2.records.len(),
+                self.address_bits,
+            )
+            .expect("Failed to generate deferral call trace");
+        }
+
+        AirProvingContext::simple_no_pis(trace)
+    }
+}

--- a/extensions/deferral/circuit/src/call/mod.rs
+++ b/extensions/deferral/circuit/src/call/mod.rs
@@ -6,6 +6,11 @@ mod trace;
 pub use trace::*;
 mod execution;
 
+#[cfg(feature = "cuda")]
+mod cuda;
+#[cfg(feature = "cuda")]
+pub use cuda::*;
+
 pub type DeferralCallAir = VmAirWrapper<DeferralCallAdapterAir, DeferralCallCoreAir>;
 pub type DeferralCallExecutor = DeferralCallCoreExecutor<DeferralCallAdapterExecutor>;
 pub type DeferralCallChip<F> =

--- a/extensions/deferral/circuit/src/call/mod.rs
+++ b/extensions/deferral/circuit/src/call/mod.rs
@@ -11,6 +11,9 @@ mod cuda;
 #[cfg(feature = "cuda")]
 pub use cuda::*;
 
+#[cfg(test)]
+mod tests;
+
 pub type DeferralCallAir = VmAirWrapper<DeferralCallAdapterAir, DeferralCallCoreAir>;
 pub type DeferralCallExecutor = DeferralCallCoreExecutor<DeferralCallAdapterExecutor>;
 pub type DeferralCallChip<F> =

--- a/extensions/deferral/circuit/src/call/tests.rs
+++ b/extensions/deferral/circuit/src/call/tests.rs
@@ -1,0 +1,453 @@
+use std::{array::from_fn, sync::Arc};
+
+use openvm_circuit::arch::{
+    deferral::{DeferralState, InputMapVal},
+    testing::{
+        memory::gen_pointer, TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
+    },
+    Arena, MatrixRecordArena, MemoryConfig, PreflightExecutor,
+};
+use openvm_circuit_primitives::bitwise_op_lookup::{
+    BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+    SharedBitwiseOperationLookupChip,
+};
+use openvm_deferral_transpiler::DeferralOpcode;
+use openvm_instructions::{
+    instruction::Instruction,
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS},
+    LocalOpcode, DEFERRAL_AS,
+};
+use openvm_stark_backend::{
+    interaction::BusIndex,
+    p3_field::{PrimeCharacteristicRing, PrimeField32},
+};
+use openvm_stark_sdk::{
+    config::baby_bear_poseidon2::DIGEST_SIZE, p3_baby_bear::BabyBear, utils::create_seeded_rng,
+};
+use rand::{rngs::StdRng, Rng};
+#[cfg(feature = "cuda")]
+use {
+    super::{DeferralCallAdapterRecord, DeferralCallChipGpu, DeferralCallCoreRecord},
+    crate::{
+        count::DeferralCircuitCountChipGpu,
+        poseidon2::{poseidon2_buffer_capacity, DeferralPoseidon2ChipGpu},
+    },
+    openvm_circuit::arch::{
+        testing::{default_bitwise_lookup_bus, GpuChipTestBuilder, GpuTestChipHarness},
+        DenseRecordArena, EmptyAdapterCoreLayout,
+    },
+    openvm_cuda_common::d_buffer::DeviceBuffer,
+};
+
+use super::{
+    DeferralCallAdapterAir, DeferralCallAdapterExecutor, DeferralCallAdapterFiller,
+    DeferralCallAir, DeferralCallChip, DeferralCallCoreAir, DeferralCallCoreFiller,
+    DeferralCallExecutor,
+};
+use crate::{
+    count::{DeferralCircuitCountAir, DeferralCircuitCountBus, DeferralCircuitCountChip},
+    poseidon2::{
+        deferral_poseidon2_air, deferral_poseidon2_chip, DeferralPoseidon2Air,
+        DeferralPoseidon2Bus, DeferralPoseidon2Chip,
+    },
+    utils::{
+        byte_commit_to_f, COMMIT_NUM_BYTES, MEMORY_OP_SIZE, OUTPUT_TOTAL_BYTES,
+        OUTPUT_TOTAL_MEMORY_OPS,
+    },
+    DeferralFn,
+};
+
+type F = BabyBear;
+const MAX_INS_CAPACITY: usize = 1024;
+const NUM_DEFERRALS: usize = 4;
+const DEFERRAL_COUNT_BUS: BusIndex = 20;
+const DEFERRAL_POSEIDON2_BUS: BusIndex = 21;
+
+type Harness<RA> =
+    TestChipHarness<F, DeferralCallExecutor, DeferralCallAir, DeferralCallChip<F>, RA>;
+type BitwisePeriphery = (
+    BitwiseOperationLookupAir<RV32_CELL_BITS>,
+    SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+);
+type CountPeriphery = (DeferralCircuitCountAir, Arc<DeferralCircuitCountChip>);
+type Poseidon2Periphery = (DeferralPoseidon2Air<F>, Arc<DeferralPoseidon2Chip<F>>);
+
+#[cfg(feature = "cuda")]
+type GpuHarness = GpuTestChipHarness<
+    F,
+    DeferralCallExecutor,
+    DeferralCallAir,
+    DeferralCallChipGpu,
+    DeferralCallChip<F>,
+>;
+#[cfg(feature = "cuda")]
+type CudaCountPeriphery = (
+    DeferralCircuitCountAir,
+    DeferralCircuitCountChipGpu,
+    DenseRecordArena,
+);
+#[cfg(feature = "cuda")]
+type CudaPoseidon2Periphery = (
+    DeferralPoseidon2Air<F>,
+    DeferralPoseidon2ChipGpu,
+    DenseRecordArena,
+);
+
+struct CpuHarnessBundle {
+    harness: Harness<MatrixRecordArena<F>>,
+    bitwise: BitwisePeriphery,
+    count: CountPeriphery,
+    poseidon2: Poseidon2Periphery,
+}
+
+#[cfg(feature = "cuda")]
+struct CudaHarnessBundle {
+    harness: GpuHarness,
+    count: CudaCountPeriphery,
+    poseidon2: CudaPoseidon2Periphery,
+}
+
+fn test_memory_config() -> MemoryConfig {
+    let mut config = MemoryConfig::default();
+    config.addr_spaces[RV32_REGISTER_AS as usize].num_cells = 1 << 29;
+    config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 20;
+    config
+}
+
+fn deferral_fns(num_deferrals: usize) -> Vec<Arc<DeferralFn>> {
+    (0..num_deferrals)
+        .map(|idx| {
+            Arc::new(DeferralFn::new(move |input_raw| {
+                let seed = input_raw
+                    .iter()
+                    .fold(idx as u8, |acc, byte| acc.wrapping_add(*byte));
+                let num_chunks = (seed as usize % 4) + 1;
+                let len = num_chunks * DIGEST_SIZE;
+                (0..len)
+                    .map(|i| seed.wrapping_add(i as u8))
+                    .collect::<Vec<_>>()
+            }))
+        })
+        .collect()
+}
+
+fn init_streams(tester: &mut impl TestBuilder<F>, num_deferrals: usize) {
+    tester.streams_mut().deferrals = vec![DeferralState::new(vec![]); num_deferrals];
+}
+
+fn set_and_execute_call<RA, E>(
+    tester: &mut impl TestBuilder<F>,
+    executor: &mut E,
+    arena: &mut RA,
+    rng: &mut StdRng,
+    num_deferrals: usize,
+) where
+    RA: Arena,
+    E: PreflightExecutor<F, RA>,
+{
+    let rd = gen_pointer(rng, MEMORY_OP_SIZE);
+    let rs = gen_pointer(rng, MEMORY_OP_SIZE);
+    let output_ptr = gen_pointer(rng, MEMORY_OP_SIZE);
+    let input_ptr = gen_pointer(rng, MEMORY_OP_SIZE);
+    let deferral_idx = rng.random_range(0..num_deferrals);
+
+    let input_commit_f: [F; DIGEST_SIZE] =
+        from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32)));
+    let input_commit: [u8; COMMIT_NUM_BYTES] = input_commit_f
+        .iter()
+        .flat_map(|x| x.as_canonical_u32().to_le_bytes())
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    let input_raw_len = rng.random_range(1..=(3 * DIGEST_SIZE));
+    let input_raw = (0..input_raw_len)
+        .map(|_| rng.random())
+        .collect::<Vec<u8>>();
+    tester.streams_mut().deferrals[deferral_idx].store_input(input_commit.to_vec(), input_raw);
+
+    tester.write(
+        RV32_REGISTER_AS as usize,
+        rd,
+        output_ptr.to_le_bytes().map(F::from_u8),
+    );
+    tester.write(
+        RV32_REGISTER_AS as usize,
+        rs,
+        input_ptr.to_le_bytes().map(F::from_u8),
+    );
+    for (chunk_idx, chunk) in input_commit.chunks_exact(MEMORY_OP_SIZE).enumerate() {
+        let chunk: [u8; MEMORY_OP_SIZE] = chunk.try_into().unwrap();
+        tester.write(
+            RV32_MEMORY_AS as usize,
+            input_ptr + chunk_idx * MEMORY_OP_SIZE,
+            chunk.map(F::from_u8),
+        );
+    }
+
+    let input_acc_ptr = 2 * deferral_idx * DIGEST_SIZE;
+    let output_acc_ptr = input_acc_ptr + DIGEST_SIZE;
+    let old_input_acc: [F; DIGEST_SIZE] = tester.read(DEFERRAL_AS as usize, input_acc_ptr);
+    let old_output_acc: [F; DIGEST_SIZE] = tester.read(DEFERRAL_AS as usize, output_acc_ptr);
+
+    tester.execute(
+        executor,
+        arena,
+        &Instruction::from_usize(
+            DeferralOpcode::CALL.global_opcode(),
+            [
+                rd,
+                rs,
+                deferral_idx,
+                RV32_REGISTER_AS as usize,
+                RV32_MEMORY_AS as usize,
+            ],
+        ),
+    );
+
+    let (output_commit, output_raw) = {
+        let state = &tester.streams_mut().deferrals[deferral_idx];
+        let output_commit = match state.get_input(&input_commit.to_vec()) {
+            InputMapVal::Output(output_commit) => output_commit.clone(),
+            InputMapVal::Raw(_) => panic!("deferral CALL should cache the computed output"),
+        };
+        let output_raw = state.get_output(&output_commit).clone();
+        (output_commit, output_raw)
+    };
+
+    let mut output_key = [0u8; OUTPUT_TOTAL_BYTES];
+    for chunk_idx in 0..OUTPUT_TOTAL_MEMORY_OPS {
+        let chunk: [F; MEMORY_OP_SIZE] = tester.read(
+            RV32_MEMORY_AS as usize,
+            output_ptr + chunk_idx * MEMORY_OP_SIZE,
+        );
+        for i in 0..MEMORY_OP_SIZE {
+            output_key[chunk_idx * MEMORY_OP_SIZE + i] = chunk[i].as_canonical_u32() as u8;
+        }
+    }
+    let output_commit_expected: [u8; COMMIT_NUM_BYTES] = output_commit.clone().try_into().unwrap();
+    assert_eq!(
+        &output_key[..COMMIT_NUM_BYTES],
+        &output_commit_expected,
+        "output commit mismatch"
+    );
+    assert_eq!(
+        &output_key[COMMIT_NUM_BYTES..],
+        &(output_raw.len() as u64).to_le_bytes(),
+        "output length mismatch"
+    );
+
+    let poseidon2_chip = deferral_poseidon2_chip::<F>();
+    let input_f_commit = byte_commit_to_f(&input_commit.map(F::from_u8));
+    let output_f_commit = byte_commit_to_f(&output_commit_expected.map(F::from_u8));
+    let expected_new_input_acc = poseidon2_chip.perm(&old_input_acc, &input_f_commit, true);
+    let expected_new_output_acc = poseidon2_chip.perm(&old_output_acc, &output_f_commit, true);
+    let new_input_acc: [F; DIGEST_SIZE] = tester.read(DEFERRAL_AS as usize, input_acc_ptr);
+    let new_output_acc: [F; DIGEST_SIZE] = tester.read(DEFERRAL_AS as usize, output_acc_ptr);
+    assert_eq!(
+        new_input_acc, expected_new_input_acc,
+        "input accumulator mismatch"
+    );
+    assert_eq!(
+        new_output_acc, expected_new_output_acc,
+        "output accumulator mismatch"
+    );
+}
+
+fn create_cpu_harness(
+    tester: &VmChipTestBuilder<F>,
+    num_deferrals: usize,
+    fns: Vec<Arc<DeferralFn>>,
+) -> CpuHarnessBundle {
+    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
+    let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV32_CELL_BITS>::new(
+        bitwise_bus,
+    ));
+
+    let count_bus = DeferralCircuitCountBus::new(DEFERRAL_COUNT_BUS);
+    let poseidon2_bus = DeferralPoseidon2Bus::new(DEFERRAL_POSEIDON2_BUS);
+    let count_chip = Arc::new(DeferralCircuitCountChip::new(num_deferrals));
+    let poseidon2_chip = Arc::new(deferral_poseidon2_chip());
+
+    let air = DeferralCallAir::new(
+        DeferralCallAdapterAir::new(
+            tester.execution_bridge(),
+            tester.memory_bridge(),
+            bitwise_bus,
+            tester.address_bits(),
+        ),
+        DeferralCallCoreAir::new(count_bus, poseidon2_bus, bitwise_bus),
+    );
+    let executor = DeferralCallExecutor::new(DeferralCallAdapterExecutor, fns);
+    let chip = DeferralCallChip::new(
+        DeferralCallCoreFiller::new(
+            DeferralCallAdapterFiller::new(bitwise_chip.clone(), tester.address_bits()),
+            count_chip.clone(),
+            poseidon2_chip.clone(),
+            bitwise_chip.clone(),
+            tester.address_bits(),
+        ),
+        tester.memory_helper(),
+    );
+
+    let harness = Harness::with_capacity(executor, air, chip, MAX_INS_CAPACITY);
+    CpuHarnessBundle {
+        harness,
+        bitwise: (bitwise_chip.air, bitwise_chip),
+        count: (
+            DeferralCircuitCountAir::new(count_bus, num_deferrals),
+            count_chip,
+        ),
+        poseidon2: (deferral_poseidon2_air(poseidon2_bus.0), poseidon2_chip),
+    }
+}
+
+#[cfg(feature = "cuda")]
+#[allow(clippy::type_complexity)]
+fn create_cuda_harness(
+    tester: &GpuChipTestBuilder,
+    num_deferrals: usize,
+    fns: Vec<Arc<DeferralFn>>,
+) -> CudaHarnessBundle {
+    let bitwise_bus = default_bitwise_lookup_bus();
+    let dummy_bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV32_CELL_BITS>::new(
+        bitwise_bus,
+    ));
+
+    let count_bus = DeferralCircuitCountBus::new(DEFERRAL_COUNT_BUS);
+    let poseidon2_bus = DeferralPoseidon2Bus::new(DEFERRAL_POSEIDON2_BUS);
+    let count_chip_cpu = Arc::new(DeferralCircuitCountChip::new(num_deferrals));
+    let poseidon2_chip_cpu = Arc::new(deferral_poseidon2_chip());
+
+    let air = DeferralCallAir::new(
+        DeferralCallAdapterAir::new(
+            tester.execution_bridge(),
+            tester.memory_bridge(),
+            bitwise_bus,
+            tester.address_bits(),
+        ),
+        DeferralCallCoreAir::new(count_bus, poseidon2_bus, bitwise_bus),
+    );
+    let executor = DeferralCallExecutor::new(DeferralCallAdapterExecutor, fns);
+    let cpu_chip = DeferralCallChip::new(
+        DeferralCallCoreFiller::new(
+            DeferralCallAdapterFiller::new(dummy_bitwise_chip.clone(), tester.address_bits()),
+            count_chip_cpu,
+            poseidon2_chip_cpu,
+            dummy_bitwise_chip,
+            tester.address_bits(),
+        ),
+        tester.dummy_memory_helper(),
+    );
+
+    let count = Arc::new(DeviceBuffer::<u32>::with_capacity(num_deferrals));
+    count.fill_zero().unwrap();
+    let poseidon2_chip_gpu =
+        DeferralPoseidon2ChipGpu::new(poseidon2_buffer_capacity(MAX_INS_CAPACITY.max(1)), 1);
+    let gpu_chip = DeferralCallChipGpu::new(
+        tester.range_checker(),
+        tester.bitwise_op_lookup(),
+        tester.address_bits(),
+        tester.timestamp_max_bits(),
+        count.clone(),
+        num_deferrals,
+        poseidon2_chip_gpu.shared_buffer(),
+    );
+
+    let harness = GpuHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY);
+    CudaHarnessBundle {
+        harness,
+        count: (
+            DeferralCircuitCountAir::new(count_bus, num_deferrals),
+            DeferralCircuitCountChipGpu::new(count, num_deferrals),
+            DenseRecordArena::with_byte_capacity(0),
+        ),
+        poseidon2: (
+            deferral_poseidon2_air(poseidon2_bus.0),
+            poseidon2_chip_gpu,
+            DenseRecordArena::with_byte_capacity(0),
+        ),
+    }
+}
+
+#[test]
+fn rand_deferral_call_test() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::<F>::volatile(test_memory_config());
+    let CpuHarnessBundle {
+        mut harness,
+        bitwise,
+        count,
+        poseidon2,
+    } = create_cpu_harness(&tester, NUM_DEFERRALS, deferral_fns(NUM_DEFERRALS));
+
+    init_streams(&mut tester, NUM_DEFERRALS);
+    let num_ops = 25;
+    for _ in 0..num_ops {
+        set_and_execute_call(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            NUM_DEFERRALS,
+        );
+    }
+
+    tester
+        .build()
+        .load(harness)
+        .load_periphery(count)
+        .load_periphery(poseidon2)
+        .load_periphery(bitwise)
+        .finalize()
+        .simple_test()
+        .expect("Verification failed");
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_rand_deferral_call_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester = GpuChipTestBuilder::volatile(
+        test_memory_config(),
+        openvm_circuit::arch::testing::default_var_range_checker_bus(),
+    )
+    .with_bitwise_op_lookup(default_bitwise_lookup_bus());
+    let CudaHarnessBundle {
+        mut harness,
+        count,
+        poseidon2,
+    } = create_cuda_harness(&tester, NUM_DEFERRALS, deferral_fns(NUM_DEFERRALS));
+
+    init_streams(&mut tester, NUM_DEFERRALS);
+    let num_ops = 40;
+    for _ in 0..num_ops {
+        set_and_execute_call(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            NUM_DEFERRALS,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut DeferralCallAdapterRecord<F>,
+        &'a mut DeferralCallCoreRecord<F>,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record<'_>, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, DeferralCallAdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .load(count.0, count.1, count.2)
+        .load(poseidon2.0, poseidon2.1, poseidon2.2)
+        .finalize()
+        .simple_test()
+        .expect("Verification failed");
+}

--- a/extensions/deferral/circuit/src/count/cuda.rs
+++ b/extensions/deferral/circuit/src/count/cuda.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use derive_new::new;
+use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
+use openvm_circuit_primitives::Chip;
+use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
+use openvm_cuda_common::d_buffer::DeviceBuffer;
+use openvm_stark_backend::prover::AirProvingContext;
+
+use crate::{count::DeferralCircuitCountCols, cuda_abi::count};
+
+#[derive(new)]
+pub struct DeferralCircuitCountChipGpu {
+    pub count: Arc<DeviceBuffer<u32>>,
+    pub num_deferral_circuits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for DeferralCircuitCountChipGpu {
+    fn generate_proving_ctx(&self, _: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        if self.num_deferral_circuits == 0 {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+
+        let trace_width = DeferralCircuitCountCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(self.num_deferral_circuits);
+        let trace = DeviceMatrix::<F>::with_capacity(trace_height, trace_width);
+
+        unsafe {
+            count::tracegen(
+                trace.buffer(),
+                trace_height,
+                &self.count,
+                self.num_deferral_circuits,
+            )
+            .expect("Failed to generate deferral count trace");
+        }
+
+        self.count
+            .fill_zero()
+            .expect("Failed to reset deferral count");
+        AirProvingContext::simple_no_pis(trace)
+    }
+}

--- a/extensions/deferral/circuit/src/count/mod.rs
+++ b/extensions/deferral/circuit/src/count/mod.rs
@@ -9,3 +9,7 @@ pub use bus::*;
 #[cfg(feature = "cuda")]
 pub use cuda::*;
 pub use trace::*;
+
+#[cfg(feature = "cuda")]
+#[cfg(test)]
+mod tests;

--- a/extensions/deferral/circuit/src/count/mod.rs
+++ b/extensions/deferral/circuit/src/count/mod.rs
@@ -1,7 +1,11 @@
 mod air;
 mod bus;
+#[cfg(feature = "cuda")]
+mod cuda;
 mod trace;
 
 pub use air::*;
 pub use bus::*;
+#[cfg(feature = "cuda")]
+pub use cuda::*;
 pub use trace::*;

--- a/extensions/deferral/circuit/src/count/tests.rs
+++ b/extensions/deferral/circuit/src/count/tests.rs
@@ -1,0 +1,40 @@
+
+use std::sync::Arc;
+
+use openvm_circuit::{arch::DenseRecordArena, Arena};
+use openvm_circuit_primitives::Chip;
+use openvm_cuda_backend::data_transporter::assert_eq_host_and_device_matrix_col_maj;
+use openvm_cuda_common::copy::MemCopyH2D;
+use openvm_stark_backend::prover::ColMajorMatrix;
+use openvm_stark_sdk::utils::create_seeded_rng;
+use rand::Rng;
+
+use crate::count::{DeferralCircuitCountChip, DeferralCircuitCountChipGpu};
+
+#[test]
+fn test_cuda_deferral_count_tracegen_equivalence() {
+    const NUM_DEFERRAL_CIRCUITS: usize = 16;
+
+    let mut rng = create_seeded_rng();
+    let counts = (0..NUM_DEFERRAL_CIRCUITS)
+        .map(|_| rng.random_range(0..200))
+        .collect::<Vec<_>>();
+
+    let cpu_chip = DeferralCircuitCountChip::new(NUM_DEFERRAL_CIRCUITS);
+    for (idx, mult) in counts.iter().copied().enumerate() {
+        for _ in 0..mult {
+            cpu_chip.add_count(idx as u32);
+        }
+    }
+
+    let count = Arc::new(counts.to_device().unwrap());
+    let gpu_chip = DeferralCircuitCountChipGpu::new(count, NUM_DEFERRAL_CIRCUITS);
+
+    let cpu_trace = cpu_chip.generate_proving_ctx(()).common_main;
+    let gpu_trace = gpu_chip
+        .generate_proving_ctx(DenseRecordArena::with_capacity(1, 1))
+        .common_main;
+
+    let cpu_trace_cm = ColMajorMatrix::from_row_major(&cpu_trace);
+    assert_eq_host_and_device_matrix_col_maj(&cpu_trace_cm, &gpu_trace);
+}

--- a/extensions/deferral/circuit/src/count/tests.rs
+++ b/extensions/deferral/circuit/src/count/tests.rs
@@ -1,4 +1,3 @@
-
 use std::sync::Arc;
 
 use openvm_circuit::{arch::DenseRecordArena, Arena};

--- a/extensions/deferral/circuit/src/count/tests.rs
+++ b/extensions/deferral/circuit/src/count/tests.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
-use openvm_circuit::{arch::DenseRecordArena, Arena};
+use openvm_circuit::arch::{Arena, DenseRecordArena};
 use openvm_circuit_primitives::Chip;
-use openvm_cuda_backend::data_transporter::assert_eq_host_and_device_matrix_col_maj;
+use openvm_cpu_backend::CpuBackend;
+use openvm_cuda_backend::{
+    data_transporter::assert_eq_host_and_device_matrix_col_maj, prelude::BabyBearPoseidon2Config,
+};
 use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::ColMajorMatrix;
 use openvm_stark_sdk::utils::create_seeded_rng;
@@ -29,7 +32,11 @@ fn test_cuda_deferral_count_tracegen_equivalence() {
     let count = Arc::new(counts.to_device().unwrap());
     let gpu_chip = DeferralCircuitCountChipGpu::new(count, NUM_DEFERRAL_CIRCUITS);
 
-    let cpu_trace = cpu_chip.generate_proving_ctx(()).common_main;
+    let cpu_trace = <DeferralCircuitCountChip as Chip<
+        (),
+        CpuBackend<BabyBearPoseidon2Config>,
+    >>::generate_proving_ctx(&cpu_chip, ())
+    .common_main;
     let gpu_trace = gpu_chip
         .generate_proving_ctx(DenseRecordArena::with_capacity(1, 1))
         .common_main;

--- a/extensions/deferral/circuit/src/cuda_abi.rs
+++ b/extensions/deferral/circuit/src/cuda_abi.rs
@@ -1,0 +1,286 @@
+#![allow(clippy::missing_safety_doc)]
+
+use openvm_cuda_backend::prelude::F;
+use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+
+pub mod count {
+    use super::*;
+
+    extern "C" {
+        fn _deferral_count_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            d_count: *const u32,
+            num_def_circuits: usize,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_count: &DeviceBuffer<u32>,
+        num_def_circuits: usize,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_deferral_count_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_count.as_ptr(),
+            num_def_circuits,
+        ))
+    }
+}
+
+pub mod poseidon2 {
+    use super::*;
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct DeferralPoseidon2Count {
+        pub compress_mult: u32,
+        pub capacity_mult: u32,
+    }
+
+    extern "C" {
+        fn _deferral_poseidon2_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: *mut F,
+            d_counts: *mut DeferralPoseidon2Count,
+            num_records: usize,
+            sbox_regs: usize,
+        ) -> i32;
+
+        fn _deferral_poseidon2_deduplicate_records_get_temp_bytes(
+            d_records: *mut F,
+            d_counts: *mut DeferralPoseidon2Count,
+            num_records: usize,
+            d_num_records: *mut usize,
+            h_temp_bytes_out: *mut usize,
+        ) -> i32;
+
+        fn _deferral_poseidon2_deduplicate_records(
+            d_records: *mut F,
+            d_counts: *mut DeferralPoseidon2Count,
+            num_records: usize,
+            d_num_records: *mut usize,
+            d_temp_storage: *mut std::ffi::c_void,
+            temp_storage_bytes: usize,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        width: usize,
+        d_records: &DeviceBuffer<F>,
+        d_counts: &DeviceBuffer<DeferralPoseidon2Count>,
+        num_records: usize,
+        sbox_regs: usize,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_deferral_poseidon2_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            width,
+            d_records.as_mut_ptr(),
+            d_counts.as_mut_ptr(),
+            num_records,
+            sbox_regs,
+        ))
+    }
+
+    pub unsafe fn deduplicate_records_get_temp_bytes(
+        d_records: &DeviceBuffer<F>,
+        d_counts: &DeviceBuffer<DeferralPoseidon2Count>,
+        num_records: usize,
+        d_num_records: &DeviceBuffer<usize>,
+        h_temp_bytes_out: &mut usize,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_deferral_poseidon2_deduplicate_records_get_temp_bytes(
+            d_records.as_mut_ptr(),
+            d_counts.as_mut_ptr(),
+            num_records,
+            d_num_records.as_mut_ptr(),
+            h_temp_bytes_out,
+        ))
+    }
+
+    pub unsafe fn deduplicate_records(
+        d_records: &DeviceBuffer<F>,
+        d_counts: &DeviceBuffer<DeferralPoseidon2Count>,
+        num_records: usize,
+        d_num_records: &DeviceBuffer<usize>,
+        d_temp_storage: &DeviceBuffer<u8>,
+        temp_storage_bytes: usize,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_deferral_poseidon2_deduplicate_records(
+            d_records.as_mut_ptr(),
+            d_counts.as_mut_ptr(),
+            num_records,
+            d_num_records.as_mut_ptr(),
+            d_temp_storage.as_mut_raw_ptr(),
+            temp_storage_bytes,
+        ))
+    }
+}
+
+pub mod call {
+    use super::*;
+    use crate::cuda_abi::poseidon2::DeferralPoseidon2Count;
+
+    #[allow(clippy::too_many_arguments)]
+    extern "C" {
+        fn _deferral_call_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: *const u8,
+            num_records: usize,
+            d_count: *mut u32,
+            num_def_circuits: usize,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            timestamp_max_bits: u32,
+            d_bitwise: *mut u32,
+            bitwise_num_bits: u32,
+            d_poseidon2_records: *mut F,
+            d_poseidon2_counts: *mut DeferralPoseidon2Count,
+            d_poseidon2_idx: *mut u32,
+            poseidon2_capacity: usize,
+            address_bits: usize,
+        ) -> i32;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        width: usize,
+        d_records: &DeviceBuffer<u8>,
+        num_records: usize,
+        d_count: &DeviceBuffer<u32>,
+        num_def_circuits: usize,
+        d_range_checker: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        d_bitwise: &DeviceBuffer<F>,
+        bitwise_num_bits: u32,
+        d_poseidon2_records: &DeviceBuffer<F>,
+        d_poseidon2_counts: &DeviceBuffer<DeferralPoseidon2Count>,
+        d_poseidon2_idx: &DeviceBuffer<u32>,
+        poseidon2_capacity: usize,
+        address_bits: usize,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_deferral_call_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            width,
+            d_records.as_ptr(),
+            num_records,
+            d_count.as_mut_ptr(),
+            num_def_circuits,
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            timestamp_max_bits,
+            d_bitwise.as_mut_ptr() as *mut u32,
+            bitwise_num_bits,
+            d_poseidon2_records.as_mut_ptr(),
+            d_poseidon2_counts.as_mut_ptr(),
+            d_poseidon2_idx.as_mut_ptr(),
+            poseidon2_capacity,
+            address_bits,
+        ))
+    }
+}
+
+pub mod output {
+    use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
+
+    use super::*;
+    use crate::cuda_abi::poseidon2::DeferralPoseidon2Count;
+
+    pub const COMMIT_NUM_BYTES: usize = DIGEST_SIZE * 4;
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct DeferralOutputPerCall {
+        pub output_commit: [u8; COMMIT_NUM_BYTES],
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct DeferralOutputPerRow {
+        pub header_offset: u32,
+        pub section_idx: u32,
+        pub call_idx: u32,
+        pub poseidon2_res: [F; DIGEST_SIZE],
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    extern "C" {
+        fn _deferral_output_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_raw_records: *const u8,
+            d_per_call: *const DeferralOutputPerCall,
+            d_per_row: *const DeferralOutputPerRow,
+            num_valid: usize,
+            d_count: *mut u32,
+            num_def_circuits: usize,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            timestamp_max_bits: u32,
+            d_bitwise: *mut u32,
+            bitwise_num_bits: u32,
+            address_bits: usize,
+            d_poseidon2_records: *mut F,
+            d_poseidon2_counts: *mut DeferralPoseidon2Count,
+            d_poseidon2_idx: *mut u32,
+            poseidon2_capacity: usize,
+        ) -> i32;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        width: usize,
+        d_raw_records: &DeviceBuffer<u8>,
+        d_per_call: &DeviceBuffer<DeferralOutputPerCall>,
+        d_per_row: &DeviceBuffer<DeferralOutputPerRow>,
+        num_valid: usize,
+        d_count: &DeviceBuffer<u32>,
+        num_def_circuits: usize,
+        d_range_checker: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        d_bitwise: &DeviceBuffer<F>,
+        bitwise_num_bits: u32,
+        address_bits: usize,
+        d_poseidon2_records: &DeviceBuffer<F>,
+        d_poseidon2_counts: &DeviceBuffer<DeferralPoseidon2Count>,
+        d_poseidon2_idx: &DeviceBuffer<u32>,
+        poseidon2_capacity: usize,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_deferral_output_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            width,
+            d_raw_records.as_ptr(),
+            d_per_call.as_ptr(),
+            d_per_row.as_ptr(),
+            num_valid,
+            d_count.as_mut_ptr(),
+            num_def_circuits,
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            timestamp_max_bits,
+            d_bitwise.as_mut_ptr() as *mut u32,
+            bitwise_num_bits,
+            address_bits,
+            d_poseidon2_records.as_mut_ptr(),
+            d_poseidon2_counts.as_mut_ptr(),
+            d_poseidon2_idx.as_mut_ptr(),
+            poseidon2_capacity,
+        ))
+    }
+}

--- a/extensions/deferral/circuit/src/extension/cuda.rs
+++ b/extensions/deferral/circuit/src/extension/cuda.rs
@@ -1,10 +1,31 @@
-use openvm_circuit::arch::{
-    ChipInventory, ChipInventoryError, DenseRecordArena, VmProverExtension,
+use std::sync::Arc;
+
+use openvm_circuit::{
+    arch::{
+        AirInventory, ChipInventory, ChipInventoryError, DenseRecordArena, VmBuilder,
+        VmChipComplex, VmProverExtension,
+    },
+    system::cuda::{
+        extensions::{
+            get_inventory_range_checker, get_or_create_bitwise_op_lookup, SystemGpuBuilder,
+        },
+        SystemChipInventoryGPU,
+    },
 };
-use openvm_cuda_backend::{BabyBearPoseidon2GpuEngine as GpuBabyBearPoseidon2Engine, GpuBackend};
+use openvm_cuda_backend::{
+    prelude::F as CudaF, BabyBearPoseidon2GpuEngine as GpuBabyBearPoseidon2Engine, GpuBackend,
+};
+use openvm_cuda_common::d_buffer::DeviceBuffer;
+use openvm_rv32im_circuit::Rv32ImGpuProverExt;
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 
-use super::DeferralExtension;
+use crate::{
+    call::{DeferralCallAir, DeferralCallChipGpu},
+    count::{DeferralCircuitCountAir, DeferralCircuitCountChipGpu},
+    output::{DeferralOutputAir, DeferralOutputChipGpu},
+    poseidon2::{poseidon2_buffer_capacity, DeferralPoseidon2Air, DeferralPoseidon2ChipGpu},
+    DeferralExtension, Rv32DeferralConfig,
+};
 
 pub struct DeferralGpuProverExt;
 
@@ -13,9 +34,119 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, DeferralExt
 {
     fn extend_prover(
         &self,
-        _: &DeferralExtension,
-        _inventory: &mut ChipInventory<BabyBearPoseidon2Config, DenseRecordArena, GpuBackend>,
+        extension: &DeferralExtension,
+        inventory: &mut ChipInventory<BabyBearPoseidon2Config, DenseRecordArena, GpuBackend>,
     ) -> Result<(), ChipInventoryError> {
+        let num_deferral_circuits = extension.fns.len();
+        let address_bits = inventory.airs().pointer_max_bits();
+        let timestamp_max_bits = inventory.timestamp_max_bits();
+
+        let range_checker = get_inventory_range_checker(inventory);
+        let bitwise_lu = get_or_create_bitwise_op_lookup(inventory)?;
+
+        let count = Arc::new(if num_deferral_circuits == 0 {
+            DeviceBuffer::<u32>::new()
+        } else {
+            DeviceBuffer::<u32>::with_capacity(num_deferral_circuits)
+        });
+        if num_deferral_circuits > 0 {
+            count.fill_zero().unwrap();
+        }
+
+        let max_trace_height = inventory
+            .config()
+            .segmentation_config
+            .limits
+            .max_trace_height as usize;
+        let poseidon2_capacity = poseidon2_buffer_capacity(max_trace_height.max(1));
+
+        inventory.next_air::<DeferralCircuitCountAir>()?;
+        let count_chip = Arc::new(DeferralCircuitCountChipGpu::new(
+            count.clone(),
+            num_deferral_circuits,
+        ));
+        inventory.add_periphery_chip(count_chip);
+
+        inventory.next_air::<DeferralPoseidon2Air<CudaF>>()?;
+        let poseidon2_chip = Arc::new(DeferralPoseidon2ChipGpu::new(poseidon2_capacity, 1));
+        let poseidon2_shared = poseidon2_chip.shared_buffer();
+        inventory.add_periphery_chip(poseidon2_chip);
+
+        inventory.next_air::<DeferralCallAir>()?;
+        let call_chip = DeferralCallChipGpu::new(
+            range_checker.clone(),
+            bitwise_lu.clone(),
+            address_bits,
+            timestamp_max_bits,
+            count.clone(),
+            num_deferral_circuits,
+            poseidon2_shared.clone(),
+        );
+        inventory.add_executor_chip(call_chip);
+
+        inventory.next_air::<DeferralOutputAir>()?;
+        let output_chip = DeferralOutputChipGpu::new(
+            range_checker,
+            bitwise_lu,
+            address_bits,
+            timestamp_max_bits,
+            count,
+            num_deferral_circuits,
+            poseidon2_shared,
+        );
+        inventory.add_executor_chip(output_chip);
+
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct Rv32DeferralGpuBuilder;
+
+impl VmBuilder<GpuBabyBearPoseidon2Engine> for Rv32DeferralGpuBuilder {
+    type VmConfig = Rv32DeferralConfig;
+    type SystemChipInventory = SystemChipInventoryGPU;
+    type RecordArena = DenseRecordArena;
+
+    fn create_chip_complex(
+        &self,
+        config: &Self::VmConfig,
+        circuit: AirInventory<BabyBearPoseidon2Config>,
+    ) -> Result<
+        VmChipComplex<
+            BabyBearPoseidon2Config,
+            Self::RecordArena,
+            GpuBackend,
+            Self::SystemChipInventory,
+        >,
+        ChipInventoryError,
+    > {
+        let mut chip_complex = VmBuilder::<GpuBabyBearPoseidon2Engine>::create_chip_complex(
+            &SystemGpuBuilder,
+            &config.system,
+            circuit,
+        )?;
+        let inventory = &mut chip_complex.inventory;
+        VmProverExtension::<GpuBabyBearPoseidon2Engine, _, _>::extend_prover(
+            &Rv32ImGpuProverExt,
+            &config.rv32i,
+            inventory,
+        )?;
+        VmProverExtension::<GpuBabyBearPoseidon2Engine, _, _>::extend_prover(
+            &Rv32ImGpuProverExt,
+            &config.rv32m,
+            inventory,
+        )?;
+        VmProverExtension::<GpuBabyBearPoseidon2Engine, _, _>::extend_prover(
+            &Rv32ImGpuProverExt,
+            &config.io,
+            inventory,
+        )?;
+        VmProverExtension::<GpuBabyBearPoseidon2Engine, _, _>::extend_prover(
+            &DeferralGpuProverExt,
+            &config.deferral,
+            inventory,
+        )?;
+        Ok(chip_complex)
     }
 }

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -43,8 +43,11 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
         mod cuda;
         pub use self::cuda::DeferralGpuProverExt as DeferralProverExt;
+        pub use self::cuda::Rv32DeferralGpuBuilder as Rv32DeferralBuilder;
+
     } else {
         pub use self::DeferralCpuProverExt as DeferralProverExt;
+        pub use self::Rv32DeferralCpuBuilder as Rv32DeferralBuilder;
     }
 }
 
@@ -235,9 +238,9 @@ pub struct Rv32DeferralConfig {
 impl InitFileGenerator for Rv32DeferralConfig {}
 
 #[derive(Clone)]
-pub struct DeferralCpuBuilder;
+pub struct Rv32DeferralCpuBuilder;
 
-impl<SC, E> VmBuilder<E> for DeferralCpuBuilder
+impl<SC, E> VmBuilder<E> for Rv32DeferralCpuBuilder
 where
     SC: StarkProtocolConfig,
     E: StarkEngine<SC = SC, PB = CpuBackend<SC>, PD = CpuDevice<SC>>,

--- a/extensions/deferral/circuit/src/lib.rs
+++ b/extensions/deferral/circuit/src/lib.rs
@@ -9,6 +9,9 @@ pub mod canonicity;
 pub mod count;
 pub mod output;
 pub mod poseidon2;
+
+#[cfg(feature = "cuda")]
+pub(crate) mod cuda_abi;
 pub(crate) mod utils;
 
 mod def_fn;

--- a/extensions/deferral/circuit/src/output/cuda.rs
+++ b/extensions/deferral/circuit/src/output/cuda.rs
@@ -1,0 +1,147 @@
+use std::{array::from_fn, mem::size_of, sync::Arc};
+
+use derive_new::new;
+use openvm_circuit::{
+    arch::{DenseRecordArena, SizedRecord},
+    utils::next_power_of_two_or_zero,
+};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
+};
+use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
+use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer};
+use openvm_instructions::riscv::RV32_CELL_BITS;
+use openvm_stark_backend::{p3_field::PrimeCharacteristicRing, prover::AirProvingContext};
+use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
+
+use super::{
+    DeferralOutputCols, DeferralOutputLayout, DeferralOutputMetadata, DeferralOutputRecordHeader,
+    DeferralOutputRecordMut,
+};
+use crate::{
+    cuda_abi::output::{self, DeferralOutputPerCall, DeferralOutputPerRow},
+    poseidon2::{deferral_poseidon2_chip, DeferralPoseidon2SharedBuffer},
+    utils::f_commit_to_bytes,
+};
+
+#[derive(new)]
+pub struct DeferralOutputChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV32_CELL_BITS>>,
+    pub address_bits: usize,
+    pub timestamp_max_bits: usize,
+    pub count: Arc<DeviceBuffer<u32>>,
+    pub num_deferral_circuits: usize,
+    pub poseidon2: DeferralPoseidon2SharedBuffer,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for DeferralOutputChipGpu {
+    fn generate_proving_ctx(&self, mut arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        let records = arena.allocated_mut();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+
+        let poseidon2_chip = deferral_poseidon2_chip::<F>();
+        let mut per_call = Vec::<DeferralOutputPerCall>::new();
+        let mut per_row = Vec::<DeferralOutputPerRow>::new();
+
+        let mut offset = 0usize;
+        while offset < records.len() {
+            let header_offset = offset;
+            let header: &DeferralOutputRecordHeader = unsafe {
+                &*(records.as_ptr().add(header_offset) as *const DeferralOutputRecordHeader)
+            };
+
+            let num_rows = header.num_rows as usize;
+            let output_len = (num_rows - 1) * DIGEST_SIZE;
+            let write_bytes = unsafe {
+                std::slice::from_raw_parts(
+                    records
+                        .as_ptr()
+                        .add(header_offset + size_of::<DeferralOutputRecordHeader>()),
+                    output_len,
+                )
+            };
+
+            let mut current_poseidon2_res = [F::ZERO; DIGEST_SIZE];
+            let call_idx =
+                u32::try_from(per_call.len()).expect("deferral output call index should fit u32");
+            let header_offset_u32 =
+                u32::try_from(header_offset).expect("record byte offset should fit u32");
+
+            for section_idx in 0..num_rows {
+                let sponge_inputs = if section_idx == 0 {
+                    let mut input = [F::ZERO; DIGEST_SIZE];
+                    input[0] = F::from_u32(header.deferral_idx);
+                    input[1] = F::from_usize(output_len);
+                    input
+                } else {
+                    let base = (section_idx - 1) * DIGEST_SIZE;
+                    from_fn(|i| F::from_u8(write_bytes[base + i]))
+                };
+
+                current_poseidon2_res = poseidon2_chip.perm(
+                    &sponge_inputs,
+                    &current_poseidon2_res,
+                    section_idx + 1 == num_rows,
+                );
+
+                per_row.push(DeferralOutputPerRow {
+                    header_offset: header_offset_u32,
+                    section_idx: section_idx as u32,
+                    call_idx,
+                    poseidon2_res: current_poseidon2_res,
+                });
+            }
+
+            per_call.push(DeferralOutputPerCall {
+                output_commit: f_commit_to_bytes(&current_poseidon2_res),
+            });
+
+            let layout = DeferralOutputLayout::new(DeferralOutputMetadata { num_rows });
+            let record_size =
+                <DeferralOutputRecordMut<'_> as SizedRecord<DeferralOutputLayout>>::size(&layout);
+            let record_alignment = <DeferralOutputRecordMut<'_> as SizedRecord<
+                DeferralOutputLayout,
+            >>::alignment(&layout);
+            offset += record_size.next_multiple_of(record_alignment);
+        }
+        debug_assert_eq!(offset, records.len());
+
+        let rows_used = per_row.len();
+        let trace_height = next_power_of_two_or_zero(rows_used);
+        let trace_width = DeferralOutputCols::<F>::width();
+        let trace = DeviceMatrix::<F>::with_capacity(trace_height, trace_width);
+
+        let d_raw_records = records.to_device().unwrap();
+        let d_per_call = per_call.to_device().unwrap();
+        let d_per_row = per_row.to_device().unwrap();
+
+        unsafe {
+            output::tracegen(
+                trace.buffer(),
+                trace_height,
+                trace_width,
+                &d_raw_records,
+                &d_per_call,
+                &d_per_row,
+                rows_used,
+                &self.count,
+                self.num_deferral_circuits,
+                &self.range_checker.count,
+                self.timestamp_max_bits as u32,
+                &self.bitwise_lookup.count,
+                RV32_CELL_BITS as u32,
+                self.address_bits,
+                &self.poseidon2.records,
+                &self.poseidon2.counts,
+                &self.poseidon2.idx,
+                self.poseidon2.records.len(),
+            )
+            .expect("Failed to generate deferral output trace");
+        }
+
+        AirProvingContext::simple_no_pis(trace)
+    }
+}

--- a/extensions/deferral/circuit/src/output/mod.rs
+++ b/extensions/deferral/circuit/src/output/mod.rs
@@ -11,4 +11,7 @@ pub use air::*;
 pub use cuda::*;
 pub use trace::*;
 
+#[cfg(test)]
+mod tests;
+
 pub type DeferralOutputChip<F> = VmChipWrapper<F, DeferralOutputFiller<F>>;

--- a/extensions/deferral/circuit/src/output/mod.rs
+++ b/extensions/deferral/circuit/src/output/mod.rs
@@ -1,10 +1,14 @@
 use openvm_circuit::arch::VmChipWrapper;
 
 mod air;
+#[cfg(feature = "cuda")]
+mod cuda;
 mod execution;
 mod trace;
 
 pub use air::*;
+#[cfg(feature = "cuda")]
+pub use cuda::*;
 pub use trace::*;
 
 pub type DeferralOutputChip<F> = VmChipWrapper<F, DeferralOutputFiller<F>>;

--- a/extensions/deferral/circuit/src/output/tests.rs
+++ b/extensions/deferral/circuit/src/output/tests.rs
@@ -1,0 +1,384 @@
+use std::sync::Arc;
+
+use openvm_circuit::arch::{
+    deferral::{DeferralResult, DeferralState},
+    testing::{
+        memory::gen_pointer, TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS,
+    },
+    Arena, MatrixRecordArena, MemoryConfig, PreflightExecutor,
+};
+use openvm_circuit_primitives::bitwise_op_lookup::{
+    BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+    SharedBitwiseOperationLookupChip,
+};
+use openvm_deferral_transpiler::DeferralOpcode;
+use openvm_instructions::{
+    instruction::Instruction,
+    riscv::{RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS},
+    LocalOpcode, DEFERRAL_AS,
+};
+use openvm_stark_backend::{interaction::BusIndex, p3_field::PrimeCharacteristicRing};
+use openvm_stark_sdk::{
+    config::baby_bear_poseidon2::DIGEST_SIZE, p3_baby_bear::BabyBear, utils::create_seeded_rng,
+};
+use rand::{rngs::StdRng, Rng, RngCore};
+#[cfg(feature = "cuda")]
+use {
+    super::{DeferralOutputChipGpu, DeferralOutputRecordMut},
+    crate::{
+        count::DeferralCircuitCountChipGpu,
+        poseidon2::{poseidon2_buffer_capacity, DeferralPoseidon2ChipGpu},
+    },
+    openvm_circuit::arch::{
+        testing::{default_bitwise_lookup_bus, GpuChipTestBuilder, GpuTestChipHarness},
+        DenseRecordArena,
+    },
+    openvm_cuda_common::d_buffer::DeviceBuffer,
+};
+
+use super::{DeferralOutputAir, DeferralOutputChip, DeferralOutputExecutor, DeferralOutputFiller};
+use crate::{
+    count::{DeferralCircuitCountAir, DeferralCircuitCountBus, DeferralCircuitCountChip},
+    generate_deferral_results,
+    poseidon2::{
+        deferral_poseidon2_air, deferral_poseidon2_chip, DeferralPoseidon2Air,
+        DeferralPoseidon2Bus, DeferralPoseidon2Chip,
+    },
+    utils::{combine_output, COMMIT_NUM_BYTES, MEMORY_OP_SIZE, OUTPUT_TOTAL_BYTES},
+    RawDeferralResult,
+};
+
+type F = BabyBear;
+const MAX_INS_CAPACITY: usize = 1024;
+const NUM_DEFERRALS: usize = 4;
+const DEFERRAL_COUNT_BUS: BusIndex = 20;
+const DEFERRAL_POSEIDON2_BUS: BusIndex = 21;
+
+type Harness<RA> =
+    TestChipHarness<F, DeferralOutputExecutor, DeferralOutputAir, DeferralOutputChip<F>, RA>;
+type BitwisePeriphery = (
+    BitwiseOperationLookupAir<RV32_CELL_BITS>,
+    SharedBitwiseOperationLookupChip<RV32_CELL_BITS>,
+);
+type CountPeriphery = (DeferralCircuitCountAir, Arc<DeferralCircuitCountChip>);
+type Poseidon2Periphery = (DeferralPoseidon2Air<F>, Arc<DeferralPoseidon2Chip<F>>);
+
+#[cfg(feature = "cuda")]
+type GpuHarness = GpuTestChipHarness<
+    F,
+    DeferralOutputExecutor,
+    DeferralOutputAir,
+    DeferralOutputChipGpu,
+    DeferralOutputChip<F>,
+>;
+#[cfg(feature = "cuda")]
+type CudaCountPeriphery = (
+    DeferralCircuitCountAir,
+    DeferralCircuitCountChipGpu,
+    DenseRecordArena,
+);
+#[cfg(feature = "cuda")]
+type CudaPoseidon2Periphery = (
+    DeferralPoseidon2Air<F>,
+    DeferralPoseidon2ChipGpu,
+    DenseRecordArena,
+);
+
+struct CpuHarnessBundle {
+    harness: Harness<MatrixRecordArena<F>>,
+    bitwise: BitwisePeriphery,
+    count: CountPeriphery,
+    poseidon2: Poseidon2Periphery,
+}
+
+#[cfg(feature = "cuda")]
+struct CudaHarnessBundle {
+    harness: GpuHarness,
+    count: CudaCountPeriphery,
+    poseidon2: CudaPoseidon2Periphery,
+}
+
+fn test_memory_config() -> MemoryConfig {
+    let mut config = MemoryConfig::default();
+    config.addr_spaces[RV32_REGISTER_AS as usize].num_cells = 1 << 29;
+    config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 20;
+    config
+}
+
+fn init_streams(tester: &mut impl TestBuilder<F>, num_deferrals: usize) {
+    tester.streams_mut().deferrals = vec![DeferralState::new(vec![]); num_deferrals];
+}
+
+fn write_output_key(
+    tester: &mut impl TestBuilder<F>,
+    input_ptr: usize,
+    output_key: [u8; OUTPUT_TOTAL_BYTES],
+) {
+    for (chunk_idx, chunk) in output_key.chunks_exact(MEMORY_OP_SIZE).enumerate() {
+        let chunk: [u8; MEMORY_OP_SIZE] = chunk.try_into().unwrap();
+        tester.write(
+            RV32_MEMORY_AS as usize,
+            input_ptr + chunk_idx * MEMORY_OP_SIZE,
+            chunk.map(F::from_u8),
+        );
+    }
+}
+
+fn make_result(
+    deferral_idx: usize,
+    input_commit: [u8; COMMIT_NUM_BYTES],
+    output_raw: Vec<u8>,
+) -> DeferralResult {
+    let hasher = deferral_poseidon2_chip::<F>();
+    generate_deferral_results(
+        vec![RawDeferralResult::new(input_commit.to_vec(), output_raw)],
+        deferral_idx as u32,
+        &hasher,
+    )
+    .into_iter()
+    .next()
+    .unwrap()
+}
+
+fn set_and_execute_output<RA, E>(
+    tester: &mut impl TestBuilder<F>,
+    executor: &mut E,
+    arena: &mut RA,
+    rng: &mut StdRng,
+    num_deferrals: usize,
+) where
+    RA: Arena,
+    E: PreflightExecutor<F, RA>,
+{
+    let rd = gen_pointer(rng, MEMORY_OP_SIZE);
+    let rs = gen_pointer(rng, MEMORY_OP_SIZE);
+    let output_ptr = gen_pointer(rng, MEMORY_OP_SIZE);
+    let input_ptr = gen_pointer(rng, MEMORY_OP_SIZE);
+    let deferral_idx = rng.random_range(0..num_deferrals);
+
+    let mut input_commit = [0u8; COMMIT_NUM_BYTES];
+    rng.fill_bytes(&mut input_commit);
+    let output_len = rng.random_range(0..=4) * DIGEST_SIZE;
+    let mut output_raw = vec![0u8; output_len];
+    rng.fill_bytes(&mut output_raw);
+    let result = make_result(deferral_idx, input_commit, output_raw);
+
+    let state = &mut tester.streams_mut().deferrals[deferral_idx];
+    state.store_input(result.input.clone(), vec![]);
+    state.store_output(
+        &result.input,
+        result.output_commit.clone(),
+        result.output_raw.clone(),
+    );
+
+    tester.write(
+        RV32_REGISTER_AS as usize,
+        rd,
+        output_ptr.to_le_bytes().map(F::from_u8),
+    );
+    tester.write(
+        RV32_REGISTER_AS as usize,
+        rs,
+        input_ptr.to_le_bytes().map(F::from_u8),
+    );
+
+    let output_commit: [u8; COMMIT_NUM_BYTES] = result.output_commit.try_into().unwrap();
+    let output_key = combine_output(
+        output_commit,
+        (result.output_raw.len() as u64).to_le_bytes(),
+    );
+    write_output_key(tester, input_ptr, output_key);
+
+    tester.execute(
+        executor,
+        arena,
+        &Instruction::from_usize(
+            DeferralOpcode::OUTPUT.global_opcode(),
+            [
+                rd,
+                rs,
+                deferral_idx,
+                RV32_REGISTER_AS as usize,
+                RV32_MEMORY_AS as usize,
+            ],
+        ),
+    );
+}
+
+fn create_cpu_harness(tester: &VmChipTestBuilder<F>, num_deferrals: usize) -> CpuHarnessBundle {
+    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
+    let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV32_CELL_BITS>::new(
+        bitwise_bus,
+    ));
+    let count_bus = DeferralCircuitCountBus::new(DEFERRAL_COUNT_BUS);
+    let poseidon2_bus = DeferralPoseidon2Bus::new(DEFERRAL_POSEIDON2_BUS);
+    let count_chip = Arc::new(DeferralCircuitCountChip::new(num_deferrals));
+    let poseidon2_chip = Arc::new(deferral_poseidon2_chip());
+
+    let air = DeferralOutputAir::new(
+        tester.execution_bridge(),
+        tester.memory_bridge(),
+        count_bus,
+        poseidon2_bus,
+        bitwise_bus,
+        tester.address_bits(),
+    );
+    let executor = DeferralOutputExecutor::new();
+    let chip = DeferralOutputChip::new(
+        DeferralOutputFiller::new(
+            count_chip.clone(),
+            poseidon2_chip.clone(),
+            bitwise_chip.clone(),
+            tester.address_bits(),
+        ),
+        tester.memory_helper(),
+    );
+
+    let harness = Harness::with_capacity(executor, air, chip, MAX_INS_CAPACITY);
+    CpuHarnessBundle {
+        harness,
+        bitwise: (bitwise_chip.air, bitwise_chip),
+        count: (
+            DeferralCircuitCountAir::new(count_bus, num_deferrals),
+            count_chip,
+        ),
+        poseidon2: (deferral_poseidon2_air(poseidon2_bus.0), poseidon2_chip),
+    }
+}
+
+#[cfg(feature = "cuda")]
+#[allow(clippy::type_complexity)]
+fn create_cuda_harness(tester: &GpuChipTestBuilder, num_deferrals: usize) -> CudaHarnessBundle {
+    let bitwise_bus = default_bitwise_lookup_bus();
+    let dummy_bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV32_CELL_BITS>::new(
+        bitwise_bus,
+    ));
+    let count_bus = DeferralCircuitCountBus::new(DEFERRAL_COUNT_BUS);
+    let poseidon2_bus = DeferralPoseidon2Bus::new(DEFERRAL_POSEIDON2_BUS);
+    let count_chip_cpu = Arc::new(DeferralCircuitCountChip::new(num_deferrals));
+    let poseidon2_chip_cpu = Arc::new(deferral_poseidon2_chip());
+
+    let air = DeferralOutputAir::new(
+        tester.execution_bridge(),
+        tester.memory_bridge(),
+        count_bus,
+        poseidon2_bus,
+        bitwise_bus,
+        tester.address_bits(),
+    );
+    let executor = DeferralOutputExecutor::new();
+    let cpu_chip = DeferralOutputChip::new(
+        DeferralOutputFiller::new(
+            count_chip_cpu,
+            poseidon2_chip_cpu,
+            dummy_bitwise_chip,
+            tester.address_bits(),
+        ),
+        tester.dummy_memory_helper(),
+    );
+
+    let count = Arc::new(DeviceBuffer::<u32>::with_capacity(num_deferrals));
+    count.fill_zero().unwrap();
+    let poseidon2_chip_gpu =
+        DeferralPoseidon2ChipGpu::new(poseidon2_buffer_capacity(MAX_INS_CAPACITY.max(1)), 1);
+    let gpu_chip = DeferralOutputChipGpu::new(
+        tester.range_checker(),
+        tester.bitwise_op_lookup(),
+        tester.address_bits(),
+        tester.timestamp_max_bits(),
+        count.clone(),
+        num_deferrals,
+        poseidon2_chip_gpu.shared_buffer(),
+    );
+
+    let harness = GpuHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY);
+    CudaHarnessBundle {
+        harness,
+        count: (
+            DeferralCircuitCountAir::new(count_bus, num_deferrals),
+            DeferralCircuitCountChipGpu::new(count, num_deferrals),
+            DenseRecordArena::with_byte_capacity(0),
+        ),
+        poseidon2: (
+            deferral_poseidon2_air(poseidon2_bus.0),
+            poseidon2_chip_gpu,
+            DenseRecordArena::with_byte_capacity(0),
+        ),
+    }
+}
+
+#[test]
+fn rand_deferral_output_test() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::<F>::volatile(test_memory_config());
+    let CpuHarnessBundle {
+        mut harness,
+        bitwise,
+        count,
+        poseidon2,
+    } = create_cpu_harness(&tester, NUM_DEFERRALS);
+
+    init_streams(&mut tester, NUM_DEFERRALS);
+    let num_ops = 25;
+    for _ in 0..num_ops {
+        set_and_execute_output(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            NUM_DEFERRALS,
+        );
+    }
+
+    tester
+        .build()
+        .load(harness)
+        .load_periphery(count)
+        .load_periphery(poseidon2)
+        .load_periphery(bitwise)
+        .finalize()
+        .simple_test()
+        .expect("Verification failed");
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_rand_deferral_output_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester = GpuChipTestBuilder::volatile(
+        test_memory_config(),
+        openvm_circuit::arch::testing::default_var_range_checker_bus(),
+    )
+    .with_bitwise_op_lookup(default_bitwise_lookup_bus());
+    let CudaHarnessBundle {
+        mut harness,
+        count,
+        poseidon2,
+    } = create_cuda_harness(&tester, NUM_DEFERRALS);
+
+    init_streams(&mut tester, NUM_DEFERRALS);
+    let num_ops = 40;
+    for _ in 0..num_ops {
+        set_and_execute_output(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            NUM_DEFERRALS,
+        );
+    }
+
+    harness
+        .dense_arena
+        .get_record_seeker::<DeferralOutputRecordMut<'_>, _>()
+        .transfer_to_matrix_arena(&mut harness.matrix_arena);
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .load(count.0, count.1, count.2)
+        .load(poseidon2.0, poseidon2.1, poseidon2.2)
+        .finalize()
+        .simple_test()
+        .expect("Verification failed");
+}

--- a/extensions/deferral/circuit/src/poseidon2/cuda.rs
+++ b/extensions/deferral/circuit/src/poseidon2/cuda.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
+use openvm_circuit_primitives::Chip;
+use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
+use openvm_cuda_common::{
+    copy::{MemCopyD2H, MemCopyH2D},
+    d_buffer::DeviceBuffer,
+};
+use openvm_stark_backend::prover::{AirProvingContext, MatrixDimensions};
+use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
+
+use crate::{
+    cuda_abi::poseidon2::{self, DeferralPoseidon2Count},
+    poseidon2::DeferralPoseidon2Cols,
+};
+
+#[derive(Clone)]
+pub struct DeferralPoseidon2SharedBuffer {
+    pub records: Arc<DeviceBuffer<F>>,
+    pub counts: Arc<DeviceBuffer<DeferralPoseidon2Count>>,
+    pub idx: Arc<DeviceBuffer<u32>>,
+}
+
+pub struct DeferralPoseidon2ChipGpu {
+    pub records: Arc<DeviceBuffer<F>>,
+    pub counts: Arc<DeviceBuffer<DeferralPoseidon2Count>>,
+    pub idx: Arc<DeviceBuffer<u32>>,
+    pub sbox_registers: usize,
+}
+
+impl DeferralPoseidon2ChipGpu {
+    pub fn new(max_buffer_size: usize, sbox_registers: usize) -> Self {
+        let idx = Arc::new(DeviceBuffer::<u32>::with_capacity(1));
+        idx.fill_zero().unwrap();
+
+        Self {
+            records: Arc::new(DeviceBuffer::<F>::with_capacity(max_buffer_size)),
+            counts: Arc::new(DeviceBuffer::<DeferralPoseidon2Count>::with_capacity(
+                max_buffer_size,
+            )),
+            idx,
+            sbox_registers,
+        }
+    }
+
+    pub fn shared_buffer(&self) -> DeferralPoseidon2SharedBuffer {
+        DeferralPoseidon2SharedBuffer {
+            records: self.records.clone(),
+            counts: self.counts.clone(),
+            idx: self.idx.clone(),
+        }
+    }
+
+    pub fn trace_width() -> usize {
+        DeferralPoseidon2Cols::<F>::width()
+    }
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for DeferralPoseidon2ChipGpu {
+    fn generate_proving_ctx(&self, _: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        let mut num_records = self.idx.to_host().unwrap()[0] as usize;
+
+        if num_records > 0 {
+            unsafe {
+                let d_num_records = [num_records].to_device().unwrap();
+                let mut temp_bytes = 0;
+                poseidon2::deduplicate_records_get_temp_bytes(
+                    &self.records,
+                    &self.counts,
+                    num_records,
+                    &d_num_records,
+                    &mut temp_bytes,
+                )
+                .expect("Failed to get deferral poseidon2 temp bytes");
+
+                let d_temp_storage = if temp_bytes == 0 {
+                    DeviceBuffer::<u8>::new()
+                } else {
+                    DeviceBuffer::<u8>::with_capacity(temp_bytes)
+                };
+
+                poseidon2::deduplicate_records(
+                    &self.records,
+                    &self.counts,
+                    num_records,
+                    &d_num_records,
+                    &d_temp_storage,
+                    temp_bytes,
+                )
+                .expect("Failed to deduplicate deferral poseidon2 records");
+
+                num_records = *d_num_records.to_host().unwrap().first().unwrap();
+            }
+        }
+
+        let trace_height = next_power_of_two_or_zero(num_records);
+        let trace = DeviceMatrix::<F>::with_capacity(trace_height, Self::trace_width());
+
+        unsafe {
+            poseidon2::tracegen(
+                trace.buffer(),
+                trace.height(),
+                trace.width(),
+                &self.records,
+                &self.counts,
+                num_records,
+                self.sbox_registers,
+            )
+            .expect("Failed to generate deferral poseidon2 trace");
+        }
+
+        self.idx
+            .fill_zero()
+            .expect("Failed to reset deferral poseidon2 record index");
+
+        AirProvingContext::simple_no_pis(trace)
+    }
+}
+
+pub fn poseidon2_buffer_capacity(max_trace_height: usize) -> usize {
+    max_trace_height.next_power_of_two() * 2 * (DIGEST_SIZE * 2)
+}

--- a/extensions/deferral/circuit/src/poseidon2/mod.rs
+++ b/extensions/deferral/circuit/src/poseidon2/mod.rs
@@ -4,10 +4,14 @@ use openvm_stark_backend::interaction::LookupBus;
 
 mod air;
 mod bus;
+#[cfg(feature = "cuda")]
+mod cuda;
 mod trace;
 
 pub use air::*;
 pub use bus::*;
+#[cfg(feature = "cuda")]
+pub use cuda::*;
 pub use trace::*;
 
 const SBOX_REGISTERS: usize = 1;

--- a/extensions/deferral/tests/src/lib.rs
+++ b/extensions/deferral/tests/src/lib.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-#[cfg(not(feature = "cuda"))]
 mod tests {
     use std::sync::Arc;
 
@@ -13,7 +12,7 @@ mod tests {
         utils::{air_test_with_min_segments, test_system_config},
     };
     use openvm_deferral_circuit::{
-        DeferralCpuBuilder, DeferralExtension, DeferralFn, Rv32DeferralConfig,
+        DeferralExtension, DeferralFn, Rv32DeferralBuilder, Rv32DeferralConfig,
     };
     use openvm_deferral_transpiler::DeferralTranspilerExtension;
     use openvm_instructions::{exe::VmExe, DEFERRAL_AS};
@@ -96,7 +95,7 @@ mod tests {
                     config.deferral.def_vk_commits.clone(),
                 )),
         )?;
-        air_test_with_min_segments(DeferralCpuBuilder, config, exe, streams, 1).unwrap();
+        air_test_with_min_segments(Rv32DeferralBuilder, config, exe, streams, 1).unwrap();
         Ok(())
     }
 


### PR DESCRIPTION
Resolves INT-6241 and INT-6976.

## Overview

This PR adds CUDA trace generation support for the deferral extension and wires it into the deferral GPU prover path. It also updates test call sites and CUDA workflows so the new path is exercised in CI.

## 1) Deferral Extension: CUDA Tracegen Implementation
### Files
- `extensions/deferral/circuit/build.rs`
- `extensions/deferral/circuit/Cargo.toml`
- `extensions/deferral/circuit/src/lib.rs`
- `extensions/deferral/circuit/src/cuda_abi.rs`
- `extensions/deferral/circuit/src/extension/mod.rs`
- `extensions/deferral/circuit/src/extension/cuda.rs`
- `extensions/deferral/circuit/src/call/mod.rs`
- `extensions/deferral/circuit/src/call/cuda.rs`
- `extensions/deferral/circuit/src/call/tests.rs`
- `extensions/deferral/circuit/src/count/mod.rs`
- `extensions/deferral/circuit/src/count/cuda.rs`
- `extensions/deferral/circuit/src/count/tests.rs`
- `extensions/deferral/circuit/src/output/mod.rs`
- `extensions/deferral/circuit/src/output/cuda.rs`
- `extensions/deferral/circuit/src/output/tests.rs`
- `extensions/deferral/circuit/src/poseidon2/mod.rs`
- `extensions/deferral/circuit/src/poseidon2/cuda.rs`
- `extensions/deferral/circuit/cuda/include/def_types.h`
- `extensions/deferral/circuit/cuda/include/def_poseidon2_buffer.cuh`
- `extensions/deferral/circuit/cuda/src/call.cu`
- `extensions/deferral/circuit/cuda/src/count.cu`
- `extensions/deferral/circuit/cuda/src/output.cu`
- `extensions/deferral/circuit/cuda/src/poseidon2.cu`
- `extensions/deferral/circuit/cuda/src/canonicity.cuh`

### What changed
- Re-enabled and completed CUDA build integration for the deferral circuit crate.
- Added CUDA feature dependency on `openvm-rv32im-circuit/cuda` for GPU builder/prover compatibility.
- Added Rust CUDA ABI bindings for deferral `count`, `call`, `output`, and `poseidon2`.
- Added GPU chip implementations for deferral call/count/output/poseidon2 trace generation.
- Added CUDA kernels for call, output, count, and poseidon2 trace rows.
- Added shared deferral Poseidon2 record buffer with atomic append and multiplicity tracking.
- Added GPU-side deduplication of poseidon2 records (sort + reduce-by-key) before final poseidon2 tracegen.
- Added canonicity helper logic for BabyBear byte decomposition checks used by deferral call/output tracegen.
- Completed GPU prover extension wiring in `DeferralGpuProverExt` so the deferral extension now installs all required GPU chips.
- Added circuit and CUDA tracegen tests for the deferral extension.

### Reviewer focus
- Check the buffer lifecycle/reset behavior for shared GPU state (`count`, poseidon2 record index/counters).
- Check call/output kernels for consistency with existing CPU trace semantics (memory aux timestamps, bitwise/range checker interactions, poseidon2 recording, canonicity aux columns).
- Check poseidon2 dedup+multiplicity logic for correctness and alignment with AIR expectations.

## 2) Builder API and Call-Site Updates
### Files
- `extensions/deferral/circuit/src/extension/mod.rs`
- `crates/continuations/src/tests/e2e.rs`
- `extensions/deferral/tests/src/lib.rs`
- `crates/sdk/src/tests.rs`

### What changed
- Renamed the CPU-only builder type to `Rv32DeferralCpuBuilder`.
- Added a feature-dependent public alias `Rv32DeferralBuilder` that resolves to `Rv32DeferralGpuBuilder` with CUDA and `Rv32DeferralCpuBuilder` without CUDA.
- Updated tests to use `Rv32DeferralBuilder` instead of a CPU-only builder.
- Removed the `#[cfg(not(feature = "cuda"))]` gate from deferral integration tests so they can run in CUDA builds.
- Updated SDK deferral test to use `Sdk::new(...)` instead of `CpuSdk::new(...)`, removing a CUDA-related TODO.

### Reviewer focus
- Confirm API rename/aliasing is intentional and does not break expected external usage patterns.
- Confirm updated tests now exercise the CUDA path where intended.

## 3) CUDA Workflow Updates
### Files
- `.github/workflows/extension-tests.cuda.yml`
- `.github/workflows/continuations.cuda.yml`
- `.github/workflows/sdk.cuda.yml`

### What changed
- Added `deferral` to CUDA extension test matrix and `paths-filter` in `extension-tests.cuda.yml`.
- Enabled `root-prover` alongside `cuda` in continuations CUDA workflow.
- Removed `--profile=heavy` from SDK CUDA workflow nextest invocation (kept `--test-threads=1`).

### Reviewer focus
- Confirm CI trigger/filter behavior now includes deferral extension CUDA changes.
- Confirm continuations CUDA workflow feature set (`cuda,root-prover`) matches intended test surface.

## 4) Deferral Extension tests
### Files
- `extensions/deferral/circuit/src/call/tests.rs`
- `extensions/deferral/circuit/src/count/tests.rs`
- `extensions/deferral/circuit/src/output/tests.rs`

### What changed
- Added positive tests for executor chips `call` and `output`
- Added CUDA tracegen tests for `call`, `count`, and `output`
