### PR TITLE
feat: root circuit uses re-introduced DagCommitSubAir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -3025,7 +3025,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -6384,7 +6384,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -6422,9 +6422,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/continuations/src/prover/deferral/hook/trace.rs
+++ b/crates/continuations/src/prover/deferral/hook/trace.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use itertools::Itertools;
 use openvm_recursion_circuit::system::{
-    AggregationSubCircuit, VerifierExternalData, VerifierTraceGen,
+    AggregationSubCircuit, CachedTraceCtx, VerifierExternalData, VerifierTraceGen,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -58,7 +58,7 @@ where
             .verifier_circuit
             .generate_proving_ctxs(
                 &self.child_vk,
-                self.child_vk_pcs_data.clone(),
+                CachedTraceCtx::PcsData(self.child_vk_pcs_data.clone()),
                 proof_slice,
                 &mut external_data,
                 default_duplex_sponge_recorder(),

--- a/crates/continuations/src/prover/deferral/inner/trace.rs
+++ b/crates/continuations/src/prover/deferral/inner/trace.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use itertools::Itertools;
 use openvm_recursion_circuit::system::{
-    AggregationSubCircuit, VerifierExternalData, VerifierTraceGen,
+    AggregationSubCircuit, CachedTraceCtx, VerifierExternalData, VerifierTraceGen,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -85,7 +85,7 @@ where
             .verifier_circuit
             .generate_proving_ctxs(
                 child_vk,
-                child_vk_pcs_data,
+                CachedTraceCtx::PcsData(child_vk_pcs_data),
                 proofs,
                 &mut external_data,
                 default_duplex_sponge_recorder(),

--- a/crates/continuations/src/prover/inner/trace.rs
+++ b/crates/continuations/src/prover/inner/trace.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use openvm_recursion_circuit::system::{
-    AggregationSubCircuit, VerifierExternalData, VerifierTraceGen,
+    AggregationSubCircuit, CachedTraceCtx, VerifierExternalData, VerifierTraceGen,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -70,7 +70,7 @@ where
             .verifier_circuit
             .generate_proving_ctxs(
                 child_vk,
-                child_vk_pcs_data,
+                CachedTraceCtx::PcsData(child_vk_pcs_data),
                 proofs,
                 &mut external_data,
                 default_duplex_sponge_recorder(),

--- a/crates/continuations/src/prover/mod.rs
+++ b/crates/continuations/src/prover/mod.rs
@@ -4,7 +4,7 @@ use openvm_cuda_backend::GpuBackend;
 use openvm_recursion_circuit::system::VerifierSubCircuit;
 
 #[cfg(feature = "root-prover")]
-use crate::{circuit::root::RootTraceGenImpl, RootSC};
+use crate::circuit::root::RootTraceGenImpl;
 use crate::{
     circuit::{
         deferral::{hook::DeferralHookTraceGenImpl, inner::DeferralInnerTraceGenImpl},
@@ -33,13 +33,9 @@ pub type InnerGpuProver<const MAX_NUM_PROOFS: usize> =
     InnerAggregationProver<GpuBackend, VerifierSubCircuit<MAX_NUM_PROOFS>, InnerTraceGenImpl>;
 
 #[cfg(feature = "root-prover")]
-pub type RootCpuProver = RootProver<CpuBackend<RootSC>, VerifierSubCircuit<1>, RootTraceGenImpl>;
+pub type RootCpuProver = RootProver<VerifierSubCircuit<1>, RootTraceGenImpl>;
 #[cfg(all(feature = "cuda", feature = "root-prover"))]
-pub type RootGpuProver = RootProver<
-    <openvm_cuda_backend::BabyBearBn254Poseidon2GpuEngine as openvm_stark_backend::StarkEngine>::PB,
-    VerifierSubCircuit<1>,
-    RootTraceGenImpl,
->;
+pub type RootGpuProver = RootProver<VerifierSubCircuit<1>, RootTraceGenImpl>;
 
 pub type DeferralInnerCpuProver =
     DeferralInnerProver<CpuBackend<SC>, VerifierSubCircuit<2>, DeferralInnerTraceGenImpl>;

--- a/crates/continuations/src/prover/root/mod.rs
+++ b/crates/continuations/src/prover/root/mod.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use eyre::Result;
 use openvm_circuit::system::memory::dimensions::MemoryDimensions;
-use openvm_recursion_circuit::system::{AggregationSubCircuit, VerifierConfig, VerifierTraceGen};
+use openvm_recursion_circuit::{
+    batch_constraint::expr_eval::CachedTraceRecord,
+    system::{AggregationSubCircuit, VerifierConfig, VerifierTraceGen},
+};
 use openvm_stark_backend::{
     keygen::types::{MultiStarkProvingKey, MultiStarkVerifyingKey},
     proof::Proof,
-    prover::{CommittedTraceData, DeviceDataTransporter, ProverBackend, ProvingContext},
+    prover::{DeviceDataTransporter, ProverBackend, ProvingContext},
     StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{EF, F};
@@ -25,35 +28,28 @@ use crate::{
 
 mod trace;
 
-pub struct RootProver<
-    PB: ProverBackend<Val = F, Challenge = EF>,
-    S: AggregationSubCircuit,
-    T: RootTraceGen<PB>,
-> {
+pub struct RootProver<S: AggregationSubCircuit, T> {
     pk: Arc<MultiStarkProvingKey<RootSC>>,
     vk: Arc<MultiStarkVerifyingKey<RootSC>>,
 
     agg_node_tracegen: T,
 
     child_vk: Arc<MultiStarkVerifyingKey<SC>>,
-    child_vk_pcs_data: CommittedTraceData<PB>,
+    cached_trace_record: CachedTraceRecord,
     circuit: Arc<RootCircuit<S>>,
     trace_heights: Option<Vec<usize>>,
 }
 
-impl<
-        PB: ProverBackend<Val = F, Challenge = EF, Commitment = [Bn254; 1]>,
-        S: AggregationSubCircuit + VerifierTraceGen<PB, RootSC>,
-        T: RootTraceGen<PB>,
-    > RootProver<PB, S, T>
-where
-    PB::Matrix: Clone,
-{
+impl<S: AggregationSubCircuit, T> RootProver<S, T> {
     #[instrument(name = "total_proof", skip_all)]
-    pub fn root_prove_from_ctx<E: StarkEngine<SC = RootSC, PB = PB>>(
-        &self,
-        ctx: ProvingContext<PB>,
-    ) -> Result<Proof<RootSC>> {
+    pub fn root_prove_from_ctx<E>(&self, ctx: ProvingContext<E::PB>) -> Result<Proof<RootSC>>
+    where
+        E: StarkEngine<SC = RootSC>,
+        E::PB: ProverBackend<Val = F, Challenge = EF, Commitment = [Bn254; 1]>,
+        <E::PB as ProverBackend>::Matrix: Clone,
+        S: VerifierTraceGen<E::PB, RootSC>,
+        T: RootTraceGen<E::PB>,
+    {
         if tracing::enabled!(tracing::Level::DEBUG) {
             trace_heights_tracing_info::<_, RootSC>(&ctx.per_trace, &self.circuit.airs());
         }
@@ -68,13 +64,8 @@ where
     }
 }
 
-impl<
-        PB: ProverBackend<Val = F, Challenge = EF, Commitment = [Bn254; 1]>,
-        S: AggregationSubCircuit + VerifierTraceGen<PB, RootSC>,
-        T: RootTraceGen<PB>,
-    > RootProver<PB, S, T>
-{
-    pub fn new<E: StarkEngine<SC = RootSC, PB = PB>>(
+impl<S: AggregationSubCircuit, T> RootProver<S, T> {
+    pub fn new<E>(
         child_vk: Arc<MultiStarkVerifyingKey<SC>>,
         internal_recursive_cached_commit: CommitBytes,
         system_params: SystemParams,
@@ -84,20 +75,24 @@ impl<
         trace_heights: Option<Vec<usize>>,
     ) -> Self
     where
-        E::PD: DeviceDataTransporter<RootSC, PB> + Clone,
-        PB::Val: Field + PrimeField32,
-        PB::Matrix: Clone,
-        PB::Commitment: Into<CommitBytes>,
+        E: StarkEngine<SC = RootSC>,
+        E::PB: ProverBackend<Val = F, Challenge = EF, Commitment = [Bn254; 1]>,
+        S: VerifierTraceGen<E::PB, RootSC>,
+        T: RootTraceGen<E::PB>,
+        E::PD: DeviceDataTransporter<RootSC, E::PB> + Clone,
+        <E::PB as ProverBackend>::Val: Field + PrimeField32,
+        <E::PB as ProverBackend>::Matrix: Clone,
     {
         let verifier_circuit = S::new(
             child_vk.clone(),
             VerifierConfig {
                 continuations_enabled: true,
+                has_cached: false,
                 ..Default::default()
             },
         );
+        let cached_trace_record = verifier_circuit.cached_trace_record(&child_vk);
         let engine = E::new(system_params);
-        let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
         let internal_recursive_dag_commit = DagCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
@@ -115,13 +110,13 @@ impl<
             vk: Arc::new(vk),
             agg_node_tracegen: T::new(def_hook_vk_commit.is_some()),
             child_vk,
-            child_vk_pcs_data,
+            cached_trace_record,
             circuit,
             trace_heights,
         }
     }
 
-    pub fn from_pk<E: StarkEngine<SC = RootSC, PB = PB>>(
+    pub fn from_pk<E>(
         child_vk: Arc<MultiStarkVerifyingKey<SC>>,
         internal_recursive_cached_commit: CommitBytes,
         pk: Arc<MultiStarkProvingKey<RootSC>>,
@@ -131,19 +126,22 @@ impl<
         trace_heights: Option<Vec<usize>>,
     ) -> Self
     where
-        PB::Val: Field + PrimeField32,
-        PB::Matrix: Clone,
-        PB::Commitment: Into<CommitBytes>,
+        E: StarkEngine<SC = RootSC>,
+        E::PB: ProverBackend<Val = F, Challenge = EF, Commitment = [Bn254; 1]>,
+        S: VerifierTraceGen<E::PB, RootSC>,
+        T: RootTraceGen<E::PB>,
+        <E::PB as ProverBackend>::Val: Field + PrimeField32,
+        <E::PB as ProverBackend>::Matrix: Clone,
     {
         let verifier_circuit = S::new(
             child_vk.clone(),
             VerifierConfig {
                 continuations_enabled: true,
+                has_cached: false,
                 ..Default::default()
             },
         );
-        let engine = E::new(pk.params.clone());
-        let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
+        let cached_trace_record = verifier_circuit.cached_trace_record(&child_vk);
         let internal_recursive_dag_commit = DagCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
@@ -161,7 +159,7 @@ impl<
             vk,
             agg_node_tracegen: T::new(def_hook_vk_commit.is_some()),
             child_vk,
-            child_vk_pcs_data,
+            cached_trace_record,
             circuit,
             trace_heights,
         }
@@ -177,10 +175,6 @@ impl<
 
     pub fn get_vk(&self) -> Arc<MultiStarkVerifyingKey<RootSC>> {
         self.vk.clone()
-    }
-
-    pub fn get_cached_commit(&self) -> <PB as ProverBackend>::Commitment {
-        self.child_vk_pcs_data.commitment
     }
 
     pub fn get_trace_heights(&self) -> Option<Vec<usize>> {

--- a/crates/continuations/src/prover/root/trace.rs
+++ b/crates/continuations/src/prover/root/trace.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use openvm_circuit::system::memory::merkle::public_values::UserPublicValuesProof;
 use openvm_recursion_circuit::system::{
-    AggregationSubCircuit, VerifierExternalData, VerifierTraceGen,
+    AggregationSubCircuit, CachedTraceCtx, VerifierExternalData, VerifierTraceGen,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -71,7 +71,7 @@ where
 
         let subcircuit_ctxs = self.circuit.verifier_circuit.generate_proving_ctxs(
             &self.child_vk,
-            self.child_vk_pcs_data.clone(),
+            CachedTraceCtx::PcsData(self.child_vk_pcs_data.clone()),
             &[proof],
             &mut external_data,
             default_duplex_sponge_recorder(),

--- a/crates/continuations/src/prover/root/trace.rs
+++ b/crates/continuations/src/prover/root/trace.rs
@@ -18,20 +18,19 @@ use crate::{
     RootSC, SC,
 };
 
-impl<
-        PB: ProverBackend<Val = F, Challenge = EF>,
-        S: AggregationSubCircuit + VerifierTraceGen<PB, RootSC>,
-        T: RootTraceGen<PB>,
-    > RootProver<PB, S, T>
-where
-    PB::Matrix: Clone,
-{
-    pub fn generate_proving_ctx(
+impl<S: AggregationSubCircuit, T> RootProver<S, T> {
+    pub fn generate_proving_ctx<PB>(
         &self,
         proof: Proof<SC>,
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, PB::Val>,
         deferral_merkle_proofs: Option<&DeferralMerkleProofs<PB::Val>>,
-    ) -> Option<ProvingContext<PB>> {
+    ) -> Option<ProvingContext<PB>>
+    where
+        PB: ProverBackend<Val = F, Challenge = EF>,
+        PB::Matrix: Clone,
+        S: VerifierTraceGen<PB, RootSC>,
+        T: RootTraceGen<PB>,
+    {
         assert_eq!(
             user_pvs_proof.public_values.len(),
             self.circuit.num_user_pvs
@@ -71,7 +70,7 @@ where
 
         let subcircuit_ctxs = self.circuit.verifier_circuit.generate_proving_ctxs(
             &self.child_vk,
-            CachedTraceCtx::PcsData(self.child_vk_pcs_data.clone()),
+            CachedTraceCtx::Records(self.cached_trace_record.clone()),
             &[proof],
             &mut external_data,
             default_duplex_sponge_recorder(),
@@ -89,11 +88,17 @@ where
     }
 
     #[instrument(name = "trace_gen", skip_all)]
-    pub fn generate_proving_ctx_no_def(
+    pub fn generate_proving_ctx_no_def<PB>(
         &self,
         proof: Proof<SC>,
         user_pvs_proof: &UserPublicValuesProof<DIGEST_SIZE, PB::Val>,
-    ) -> Option<ProvingContext<PB>> {
+    ) -> Option<ProvingContext<PB>>
+    where
+        PB: ProverBackend<Val = F, Challenge = EF>,
+        PB::Matrix: Clone,
+        S: VerifierTraceGen<PB, RootSC>,
+        T: RootTraceGen<PB>,
+    {
         assert!(
             self.circuit.def_hook_vk_commit.is_none(),
             "deferral-enabled root prover requires generate_proving_ctx_with_deferrals"

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -739,8 +739,11 @@ fn test_deferral_e2e() -> Result<()> {
         Some(def_hook_vk_commit.into()),
         None,
     );
-    let ctx =
-        root_prover.generate_proving_ctx(combined_proof, &user_pvs_proof, Some(&merkle_proofs));
+    let ctx = root_prover.generate_proving_ctx::<<RootEngine as StarkEngine>::PB>(
+        combined_proof,
+        &user_pvs_proof,
+        Some(&merkle_proofs),
+    );
     warn!("proving root (CPU)");
     let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx.unwrap())?;
 

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -290,7 +290,10 @@ fn test_root_prover(extra_recursive_layers: usize) -> Result<()> {
         None,
         None,
     );
-    let ctx = root_prover.generate_proving_ctx_no_def(internal_recursive_proof, &user_pvs_proof);
+    let ctx = root_prover.generate_proving_ctx_no_def::<<RootEngine as StarkEngine>::PB>(
+        internal_recursive_proof,
+        &user_pvs_proof,
+    );
     let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx.unwrap())?;
 
     let vk = root_prover.get_vk();
@@ -322,7 +325,10 @@ fn test_root_prover_trace_heights() -> Result<()> {
         None,
     );
     let ctx = root_base_prover
-        .generate_proving_ctx_no_def(internal_recursive_proof.clone(), &user_pvs_proof)
+        .generate_proving_ctx_no_def::<<RootEngine as StarkEngine>::PB>(
+            internal_recursive_proof.clone(),
+            &user_pvs_proof,
+        )
         .unwrap();
     let mut trace_heights = ctx
         .per_trace
@@ -343,7 +349,10 @@ fn test_root_prover_trace_heights() -> Result<()> {
         Some(trace_heights.clone()),
     );
     let ctx = root_prover
-        .generate_proving_ctx_no_def(internal_recursive_proof, &user_pvs_proof)
+        .generate_proving_ctx_no_def::<<RootEngine as StarkEngine>::PB>(
+            internal_recursive_proof,
+            &user_pvs_proof,
+        )
         .unwrap();
 
     for ((air_idx, air_ctx), expected_height) in ctx.per_trace.iter().zip(trace_heights) {

--- a/crates/recursion/cuda/src/batch_constraint/expr_eval/dag_commit.cuh
+++ b/crates/recursion/cuda/src/batch_constraint/expr_eval/dag_commit.cuh
@@ -1,0 +1,49 @@
+#include "fp.h"
+#include "poseidon2-air/columns.cuh"
+#include "poseidon2-air/params.cuh"
+#include "poseidon2-air/tracegen.cuh"
+#include "primitives/encoder.cuh"
+#include "primitives/trace_access.h"
+#include "types.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+inline constexpr size_t SBOX_REGS = Poseidon2ParamsS1::SBOX_REGS;
+inline constexpr size_t SBOX_DEGREE = Poseidon2DefaultParams::SBOX_DEGREE;
+inline constexpr size_t HALF_FULL_ROUNDS = Poseidon2DefaultParams::HALF_FULL_ROUNDS;
+inline constexpr size_t PARTIAL_ROUNDS = Poseidon2DefaultParams::PARTIAL_ROUNDS;
+inline constexpr size_t NUM_FLAGS = 4;
+
+template <typename T> struct DagCommitCols {
+    poseidon2::Poseidon2SubCols<T, WIDTH, SBOX_DEGREE, SBOX_REGS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+        inner;
+    T flags[NUM_FLAGS];
+    T is_constraint;
+};
+
+__device__ __forceinline__ void write_dag_commit_poseidon2(
+    RowSlice row,
+    Fp *poseidon2_input,
+    bool is_constraint
+) {
+    using Poseidon2Row =
+        poseidon2::Poseidon2Row<WIDTH, SBOX_DEGREE, SBOX_REGS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>;
+
+    Poseidon2Row perm(row);
+    RowSlice state(poseidon2_input, 1);
+    poseidon2::generate_trace_row_for_perm(perm, state);
+
+    row.fill_zero(COL_INDEX(DagCommitCols, flags), NUM_FLAGS);
+    COL_WRITE_VALUE(row, DagCommitCols, is_constraint, is_constraint ? Fp::one() : Fp::zero());
+}
+
+__device__ __forceinline__ void write_dag_commit_flags(
+    RowSlice row,
+    Encoder &encoder,
+    uint32_t node_kind
+) {
+    assert(encoder.k == NUM_FLAGS);
+    encoder.write_flag_pt(row.slice_from(COL_INDEX(DagCommitCols, flags)), node_kind);
+}

--- a/crates/recursion/cuda/src/batch_constraint/expr_eval/symbolic_expression.cu
+++ b/crates/recursion/cuda/src/batch_constraint/expr_eval/symbolic_expression.cu
@@ -1,3 +1,4 @@
+#include "dag_commit.cuh"
 #include "fp.h"
 #include "fpext.h"
 #include "launcher.cuh"
@@ -51,6 +52,7 @@ struct FlatSymbolicVariable {
 };
 
 struct CachedRecord {
+    Fp poseidon2_input[WIDTH];
     bool is_constraint;
 };
 
@@ -135,7 +137,8 @@ __global__ void symbolic_expression_tracegen(
     const uint32_t *air_ids_per_record,
     size_t num_records_per_proof,
     const FpExt *sumcheck_rnds,
-    const size_t *sumcheck_bounds
+    const size_t *sumcheck_bounds,
+    const CachedRecord *cached_records
 ) {
     // Unused because expr_evals[i].len() is aleways the number of all airs,
     // plus 1 for unused variables
@@ -150,10 +153,17 @@ __global__ void symbolic_expression_tracegen(
     uint32_t row_idx = thread_idx / max_num_proofs;
     uint32_t proof_idx = thread_idx % max_num_proofs;
 
-    constexpr uint32_t SINGLE_WIDTH = sizeof(SymbolicExpressionCols<uint8_t>);
-
     RowSlice row(trace + row_idx, height);
-    RowSlice proof_row = row.slice_from(proof_idx * SINGLE_WIDTH);
+    constexpr uint32_t SINGLE_WIDTH = sizeof(SymbolicExpressionCols<uint8_t>);
+    constexpr uint32_t COMMIT_WIDTH = sizeof(DagCommitCols<uint8_t>);
+
+    if (cached_records && proof_idx == 0) {
+        CachedRecord record = cached_records[row_idx];
+        write_dag_commit_poseidon2(row, record.poseidon2_input, record.is_constraint);
+    }
+
+    RowSlice proof_row =
+        row.slice_from((cached_records ? COMMIT_WIDTH : 0) + proof_idx * SINGLE_WIDTH);
     proof_row.fill_zero(0, SINGLE_WIDTH);
 
     if (proof_idx >= num_proofs) {
@@ -202,6 +212,7 @@ __global__ void symbolic_expression_tracegen(
 
     uint32_t unused_start = unused_variables_bounds[air_idx];
     uint32_t unused_len = unused_variables_bounds[air_idx + 1] - unused_start;
+    const FlatSymbolicVariable *unused_variables_per_air = unused_variables + unused_start;
 
     Fp sort_idx_fp = Fp(static_cast<uint32_t>(sort_idx));
     uint32_t n_abs = log_height < l_skip ? l_skip - log_height : log_height - l_skip;
@@ -268,6 +279,9 @@ __global__ void symbolic_expression_tracegen(
         default:
             break;
         }
+        if (cached_records && proof_idx == 0) {
+            write_dag_commit_flags(row, encoder, node.kind);
+        }
         return;
     }
 
@@ -286,6 +300,17 @@ __global__ void symbolic_expression_tracegen(
                 uint32_t node_idx = interaction_messages[interaction.message_start + msg_offset];
                 write_arg_first(proof_row, expr_per_air[node_idx]);
             }
+            if (cached_records && proof_idx == 0) {
+                write_dag_commit_flags(
+                    row,
+                    encoder,
+                    local_idx == 0
+                        ? NODE_KIND_INTERACTION_MULT
+                        : (local_idx == interaction.message_len + 1
+                               ? NODE_KIND_INTERACTION_BUS_INDEX
+                               : NODE_KIND_INTERACTION_MSG_COMP)
+                );
+            }
             return;
         }
         local_idx -= block;
@@ -296,6 +321,10 @@ __global__ void symbolic_expression_tracegen(
         uint32_t eval_idx = nodes_len + local_idx;
         if (expr_start + eval_idx < expr_end) {
             write_arg_first(proof_row, expr_per_air[eval_idx]);
+            if (cached_records && proof_idx == 0) {
+                FlatSymbolicVariable unused = unused_variables_per_air[local_idx];
+                write_dag_commit_flags(row, encoder, unused.entry_kind);
+            }
         }
     }
 }
@@ -323,7 +352,8 @@ extern "C" int _sym_expr_common_tracegen(
     const uint32_t *d_air_ids_per_record,
     size_t num_records_per_proof,
     const FpExt *d_sumcheck_rnds,
-    const size_t *d_sumcheck_bounds
+    const size_t *d_sumcheck_bounds,
+    const CachedRecord *d_cached_records
 ) {
     // Unused because expr_evals[i].len() is always the number of all airs,
     // plus 1 for unused variables.
@@ -356,7 +386,8 @@ extern "C" int _sym_expr_common_tracegen(
         d_air_ids_per_record,
         num_records_per_proof,
         d_sumcheck_rnds,
-        d_sumcheck_bounds
+        d_sumcheck_bounds,
+        d_cached_records
     );
     return CHECK_KERNEL();
 }

--- a/crates/recursion/src/batch_constraint/cuda_abi.rs
+++ b/crates/recursion/src/batch_constraint/cuda_abi.rs
@@ -56,6 +56,7 @@ extern "C" {
         num_records_per_proof: usize,
         d_sumcheck_rnds: *const EF,
         d_sumcheck_bounds: *const usize,
+        d_cached_records: *const CachedGpuRecord,
     ) -> i32;
 
     fn _eq_3b_tracegen(
@@ -159,7 +160,9 @@ pub unsafe fn sym_expr_common_tracegen(
     num_records_per_proof: usize,
     d_sumcheck_rnds: &DeviceBuffer<EF>,
     d_sumcheck_bounds: &DeviceBuffer<usize>,
+    d_cached_records: Option<&DeviceBuffer<CachedGpuRecord>>,
 ) -> Result<(), CudaError> {
+    let cached_records_ptr = d_cached_records.map_or(::core::ptr::null(), |b| b.as_ptr());
     CudaError::from_result(_sym_expr_common_tracegen(
         d_trace.as_mut_ptr(),
         height,
@@ -184,6 +187,7 @@ pub unsafe fn sym_expr_common_tracegen(
         num_records_per_proof,
         d_sumcheck_rnds.as_ptr(),
         d_sumcheck_bounds.as_ptr(),
+        cached_records_ptr,
     ))
 }
 

--- a/crates/recursion/src/batch_constraint/cuda_utils.rs
+++ b/crates/recursion/src/batch_constraint/cuda_utils.rs
@@ -1,4 +1,5 @@
 use openvm_cuda_backend::prelude::{Digest, F};
+use openvm_poseidon2_air::POSEIDON2_WIDTH;
 use openvm_stark_backend::{
     air_builders::symbolic::{
         symbolic_variable::{Entry, SymbolicVariable},
@@ -8,7 +9,7 @@ use openvm_stark_backend::{
 };
 use p3_field::PrimeCharacteristicRing;
 
-use crate::batch_constraint::expr_eval::NodeKind;
+use crate::batch_constraint::expr_eval::{CachedTraceRecord, NodeKind};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -37,6 +38,40 @@ pub struct FlatSymbolicVariable {
     pub index: u32,
     pub part_index: u32,
     pub offset: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CachedGpuRecord {
+    pub poseidon2_start: [F; POSEIDON2_WIDTH],
+    pub is_constraint: bool,
+}
+
+pub(crate) fn build_cached_gpu_records(
+    cached_trace_record: &CachedTraceRecord,
+) -> Option<Vec<CachedGpuRecord>> {
+    cached_trace_record
+        .dag_commit_info
+        .as_ref()
+        .map(|dag_commit_info| {
+            // We need one Poseidon2 start-state per row of the (power-of-two) trace height,
+            // including padding rows. Padding rows have `is_constraint = false`.
+            let height = dag_commit_info.poseidon2_inputs.len();
+            debug_assert_eq!(
+                height,
+                cached_trace_record.records.len().next_power_of_two()
+            );
+
+            (0..height)
+                .map(|row_idx| CachedGpuRecord {
+                    poseidon2_start: *dag_commit_info.poseidon2_inputs.get(row_idx).unwrap(),
+                    is_constraint: cached_trace_record
+                        .records
+                        .get(row_idx)
+                        .is_some_and(|r| r.is_constraint),
+                })
+                .collect()
+        })
 }
 
 pub(super) fn flatten_constraint_node(

--- a/crates/recursion/src/batch_constraint/expr_eval/dag_commit.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/dag_commit.rs
@@ -1,0 +1,231 @@
+use core::borrow::Borrow;
+use std::{array::from_fn, sync::Arc};
+
+use itertools::{fold, Itertools};
+use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, SubAir};
+use openvm_poseidon2_air::{
+    Poseidon2Config, Poseidon2SubAir, Poseidon2SubChip, Poseidon2SubCols,
+    BABY_BEAR_POSEIDON2_SBOX_DEGREE, POSEIDON2_WIDTH,
+};
+use openvm_recursion_circuit_derive::AlignedBorrow;
+use openvm_stark_backend::{air_builders::sub::SubAirBuilder, interaction::InteractionBuilder};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{DIGEST_SIZE, F};
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
+use p3_field::{Field, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
+
+use crate::{
+    batch_constraint::expr_eval::{
+        CachedRecord, CachedSymbolicExpressionColumns, FLAG_MODULUS, NUM_FLAGS,
+    },
+    utils::assert_zeros,
+};
+
+pub(in crate::batch_constraint) const SBOX_REGISTERS: usize = 1;
+
+pub fn default_poseidon2_sub_chip<
+    F: PrimeField + InjectiveMonomial<BABY_BEAR_POSEIDON2_SBOX_DEGREE>,
+>() -> Poseidon2SubChip<F, SBOX_REGISTERS> {
+    Poseidon2SubChip::<F, SBOX_REGISTERS>::new(Poseidon2Config::default().constants)
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct DagCommitCols<T> {
+    pub inner: Poseidon2SubCols<T, SBOX_REGISTERS>,
+    pub flags: [T; NUM_FLAGS],
+    pub is_constraint: T,
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow)]
+pub struct DagCommitPvs<T> {
+    pub commit: [T; DIGEST_SIZE],
+}
+
+/// Sub-AIR to compute the onion hash of one digest per row. Expects each AIR
+/// that uses it to have DagCommitPvs as its public value representation.
+pub struct DagCommitSubAir<F: Field> {
+    pub subair: Arc<Poseidon2SubAir<F, SBOX_REGISTERS>>,
+}
+
+impl<F: PrimeField + InjectiveMonomial<BABY_BEAR_POSEIDON2_SBOX_DEGREE>> DagCommitSubAir<F> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<F: PrimeField + InjectiveMonomial<BABY_BEAR_POSEIDON2_SBOX_DEGREE>> Default
+    for DagCommitSubAir<F>
+{
+    fn default() -> Self {
+        Self {
+            subair: default_poseidon2_sub_chip().air,
+        }
+    }
+}
+
+impl<F: Field> BaseAir<F> for DagCommitSubAir<F> {
+    fn width(&self) -> usize {
+        DagCommitCols::<u8>::width()
+    }
+}
+
+impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> SubAir<AB>
+    for DagCommitSubAir<AB::F>
+{
+    type AirContext<'a>
+        = (&'a [AB::Var], &'a [AB::Var])
+    where
+        AB::Expr: 'a,
+        AB::Var: 'a,
+        AB: 'a;
+
+    fn eval<'a>(&'a self, builder: &'a mut AB, (local, next): (&'a [AB::Var], &'a [AB::Var]))
+    where
+        AB::Var: 'a,
+        AB::Expr: 'a,
+    {
+        let local: &DagCommitCols<AB::Var> = (*local).borrow();
+        let next: &DagCommitCols<AB::Var> = (*next).borrow();
+
+        let mut sub_builder =
+            SubAirBuilder::<AB, Poseidon2SubAir<AB::F, SBOX_REGISTERS>, AB::F>::new(
+                builder,
+                0..self.subair.width(),
+            );
+        self.subair.eval(&mut sub_builder);
+
+        debug_assert_eq!(FLAG_MODULUS, 3);
+        builder.assert_bool(local.is_constraint);
+        for flag in local.flags {
+            builder.assert_tern(flag);
+        }
+
+        let first_digest_element =
+            collapse_flags(local.flags.map(Into::into), local.is_constraint.into());
+        builder.assert_eq(local.inner.inputs[0], first_digest_element);
+
+        assert_zeros::<_, DIGEST_SIZE>(
+            &mut builder.when_first_row(),
+            from_fn(|i| local.inner.inputs[i + DIGEST_SIZE]),
+        );
+        assert_array_eq::<_, _, _, DIGEST_SIZE>(
+            &mut builder.when_transition(),
+            from_fn(|i| local.inner.ending_full_rounds.last().unwrap().post[i + DIGEST_SIZE]),
+            from_fn(|i| next.inner.inputs[i + DIGEST_SIZE]),
+        );
+
+        let &DagCommitPvs::<_> { commit: pvs_commit } = builder.public_values().borrow();
+
+        assert_array_eq::<_, _, _, DIGEST_SIZE>(
+            &mut builder.when_last_row(),
+            from_fn(|i| local.inner.ending_full_rounds.last().unwrap().post[i]),
+            pvs_commit,
+        );
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DagCommitInfo<F: Clone> {
+    pub commit: [F; DIGEST_SIZE],
+    pub poseidon2_inputs: Vec<[F; POSEIDON2_WIDTH]>,
+}
+
+/// Collapse flags and is_constraint into a single field element, which should be the
+/// first element of a row's input digest.
+///
+/// WARNING: To use this in an AIR you MUST constrain that is_constraint is boolean
+/// and that each flag is in [0, FLAG_MODULUS). This ensures that the element doesn't
+/// overflow for any 13-bit field or higher.
+pub fn collapse_flags<F: PrimeCharacteristicRing>(flags: [F; NUM_FLAGS], is_constraint: F) -> F {
+    fold(
+        flags.iter().enumerate(),
+        is_constraint.clone(),
+        |acc, (pow_exp, flag)| {
+            acc + (flag.clone() * F::from_u32(FLAG_MODULUS.pow(pow_exp as u32) << 1))
+        },
+    )
+}
+
+/// Compresses a CachedSymbolicExpressionColumns row into a digest. Uses collapse_flags for
+/// the first element.
+pub fn cached_symbolic_expr_cols_to_digest<F: PrimeCharacteristicRing>(
+    cached_cols: &[F],
+) -> [F; DIGEST_SIZE] {
+    let cached_cols: &CachedSymbolicExpressionColumns<_> = cached_cols.borrow();
+    let mut ret = [F::ZERO; DIGEST_SIZE];
+    ret[0] = collapse_flags(cached_cols.flags.clone(), cached_cols.is_constraint.clone());
+    ret[1] = cached_cols.air_idx.clone();
+    ret[2] = cached_cols.node_or_interaction_idx.clone();
+    ret[3] = cached_cols.attrs[0].clone();
+    ret[4] = cached_cols.attrs[1].clone();
+    ret[5] = cached_cols.attrs[2].clone();
+    ret[6] = cached_cols.fanout.clone();
+    ret[7] = cached_cols.constraint_idx.clone();
+    ret
+}
+
+/// Converts an input digest (+ flags and is_constraint) into cached columns.
+pub fn digest_to_cached_symbolic_expr_cols<F: Copy>(
+    digest: [F; DIGEST_SIZE],
+    flags: [F; NUM_FLAGS],
+    is_constraint: F,
+) -> CachedSymbolicExpressionColumns<F> {
+    CachedSymbolicExpressionColumns {
+        flags,
+        air_idx: digest[1],
+        node_or_interaction_idx: digest[2],
+        attrs: from_fn(|i| digest[3..][i]),
+        fanout: digest[6],
+        is_constraint,
+        constraint_idx: digest[7],
+    }
+}
+
+pub fn dag_commit_cols_to_cached_cols<F: Copy>(
+    dag_commit_cols: &[F],
+) -> CachedSymbolicExpressionColumns<F> {
+    let cols: &DagCommitCols<_> = dag_commit_cols.borrow();
+    let digest = from_fn(|i| cols.inner.inputs[i]);
+    digest_to_cached_symbolic_expr_cols(digest, cols.flags, cols.is_constraint)
+}
+
+pub(crate) fn generate_dag_commit_info(
+    cached_records: &[CachedRecord],
+    encoder: Encoder,
+) -> DagCommitInfo<F> {
+    let sub_chip = Poseidon2SubChip::<F, SBOX_REGISTERS>::new(Poseidon2Config::default().constants);
+    let mut state = [F::ZERO; POSEIDON2_WIDTH];
+
+    let height = cached_records.len().next_power_of_two();
+    let poseidon2_inputs = (0..height)
+        .map(|row_idx| {
+            let digest: [F; DIGEST_SIZE] = if row_idx < cached_records.len() {
+                let r = &cached_records[row_idx];
+                let encoder_flag = encoder.get_flag_pt(r.kind as usize);
+                let columns = CachedSymbolicExpressionColumns {
+                    flags: from_fn(|i| F::from_u32(encoder_flag[i])),
+                    air_idx: F::from_usize(r.air_idx),
+                    node_or_interaction_idx: F::from_usize(r.node_idx),
+                    attrs: r.attrs.map(F::from_usize),
+                    fanout: F::from_usize(r.fanout),
+                    is_constraint: F::from_bool(r.is_constraint),
+                    constraint_idx: F::from_usize(r.constraint_idx),
+                };
+                cached_symbolic_expr_cols_to_digest(&columns.to_vec())
+            } else {
+                [F::ZERO; DIGEST_SIZE]
+            };
+
+            state[..DIGEST_SIZE].copy_from_slice(&digest);
+            let input = state;
+            sub_chip.permute_mut(&mut state);
+            input
+        })
+        .collect_vec();
+
+    DagCommitInfo {
+        commit: from_fn(|i| state[i]),
+        poseidon2_inputs,
+    }
+}

--- a/crates/recursion/src/batch_constraint/expr_eval/mod.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/mod.rs
@@ -1,7 +1,9 @@
 pub mod constraints_folding;
+mod dag_commit;
 pub mod interactions_folding;
 pub mod symbolic_expression;
 
 pub use constraints_folding::*;
+pub use dag_commit::*;
 pub use interactions_folding::*;
 pub use symbolic_expression::*;

--- a/crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/air.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/air.rs
@@ -1,7 +1,7 @@
 use core::array;
-use std::borrow::Borrow;
+use std::{borrow::Borrow, sync::Arc};
 
-use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq};
+use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     air_builders::PartitionedAirBuilder, interaction::InteractionBuilder, BaseAirWithPublicValues,
@@ -15,9 +15,12 @@ use strum::{EnumCount, IntoEnumIterator};
 use strum_macros::EnumIter;
 
 use crate::{
-    batch_constraint::bus::{
-        ConstraintsFoldingBus, ConstraintsFoldingMessage, InteractionsFoldingBus,
-        InteractionsFoldingMessage, SymbolicExpressionBus, SymbolicExpressionMessage,
+    batch_constraint::{
+        bus::{
+            ConstraintsFoldingBus, ConstraintsFoldingMessage, InteractionsFoldingBus,
+            InteractionsFoldingMessage, SymbolicExpressionBus, SymbolicExpressionMessage,
+        },
+        expr_eval::{dag_commit_cols_to_cached_cols, DagCommitCols, DagCommitPvs, DagCommitSubAir},
     },
     bus::{
         AirPresenceBus, AirPresenceBusMessage, AirShapeBus, AirShapeBusMessage, AirShapeProperty,
@@ -33,6 +36,7 @@ use crate::{
 
 pub(in crate::batch_constraint) const NUM_FLAGS: usize = 4;
 pub(in crate::batch_constraint) const ENCODER_MAX_DEGREE: u32 = 2;
+pub(in crate::batch_constraint) const FLAG_MODULUS: u32 = ENCODER_MAX_DEGREE + 1;
 
 #[derive(Debug, Clone, Copy, EnumIter, EnumCount)]
 pub(crate) enum NodeKind {
@@ -99,7 +103,7 @@ pub struct SingleMainSymbolicExpressionColumns<T> {
     pub(in crate::batch_constraint) is_n_neg: T,
 }
 
-pub struct SymbolicExpressionAir {
+pub struct SymbolicExpressionAir<F: Field> {
     pub expr_bus: SymbolicExpressionBus,
     pub hyperdim_bus: HyperdimBus,
     pub air_shape_bus: AirShapeBus,
@@ -112,38 +116,61 @@ pub struct SymbolicExpressionAir {
     pub sel_uni_bus: SelUniBus,
 
     pub cnt_proofs: usize,
+    pub dag_commit_subair: Option<Arc<DagCommitSubAir<F>>>,
 }
 
-impl<F: Field> BaseAirWithPublicValues<F> for SymbolicExpressionAir {}
+impl<F: Field> SymbolicExpressionAir<F> {
+    fn has_cached(&self) -> bool {
+        self.dag_commit_subair.is_none()
+    }
+}
 
-impl<F: Field> PartitionedBaseAir<F> for SymbolicExpressionAir {
+impl<F: Field> BaseAirWithPublicValues<F> for SymbolicExpressionAir<F> {
+    fn num_public_values(&self) -> usize {
+        if self.has_cached() {
+            0
+        } else {
+            DagCommitPvs::<F>::width()
+        }
+    }
+}
+
+impl<F: Field> PartitionedBaseAir<F> for SymbolicExpressionAir<F> {
     fn cached_main_widths(&self) -> Vec<usize> {
-        vec![CachedSymbolicExpressionColumns::<F>::width()]
+        if self.has_cached() {
+            vec![CachedSymbolicExpressionColumns::<F>::width()]
+        } else {
+            vec![]
+        }
     }
 
     fn common_main_width(&self) -> usize {
         SingleMainSymbolicExpressionColumns::<F>::width() * self.cnt_proofs
+            + if self.has_cached() {
+                0
+            } else {
+                DagCommitCols::<F>::width()
+            }
     }
 }
 
-impl<F: Field> BaseAir<F> for SymbolicExpressionAir {
+impl<F: Field> BaseAir<F> for SymbolicExpressionAir<F> {
     fn width(&self) -> usize {
-        let cached_width = CachedSymbolicExpressionColumns::<F>::width();
         let single_main_width = SingleMainSymbolicExpressionColumns::<F>::width();
-        cached_width + single_main_width * self.cnt_proofs
+        if self.has_cached() {
+            CachedSymbolicExpressionColumns::<F>::width() + single_main_width * self.cnt_proofs
+        } else {
+            DagCommitCols::<F>::width() + single_main_width * self.cnt_proofs
+        }
     }
 }
 
 impl<AB: PartitionedAirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
-    for SymbolicExpressionAir
+    for SymbolicExpressionAir<AB::F>
 where
     <AB::Expr as PrimeCharacteristicRing>::PrimeSubfield: BinomiallyExtendable<{ D_EF }>,
 {
     fn eval(&self, builder: &mut AB) {
-        let cached_local = builder.cached_mains()[0]
-            .row_slice(0)
-            .expect("window should have at least one row")
-            .to_vec();
         let main_local = builder
             .common_main()
             .row_slice(0)
@@ -155,13 +182,37 @@ where
             .expect("window should have at least two rows")
             .to_vec();
 
+        let (cached_local_vec, main_local_slice, main_next_slice) =
+            if let Some(subair) = self.dag_commit_subair.as_ref() {
+                // No cached trace: DagCommitCols come before the regular columns
+                debug_assert!(!self.has_cached());
+                let commit_width = DagCommitCols::<AB::Var>::width();
+                let (commit_local, rest_local) = main_local.as_slice().split_at(commit_width);
+                let (commit_next, rest_next) = main_next.as_slice().split_at(commit_width);
+                subair.eval(builder, (commit_local, commit_next));
+
+                let cached_local_vec = dag_commit_cols_to_cached_cols(commit_local).to_vec();
+                (cached_local_vec, rest_local, rest_next)
+            } else {
+                debug_assert!(self.has_cached());
+                let cached_local_vec = builder.cached_mains()[0]
+                    .row_slice(0)
+                    .expect("window should have at least one row")
+                    .to_vec();
+                (
+                    cached_local_vec,
+                    main_local.as_slice(),
+                    main_next.as_slice(),
+                )
+            };
+
         let cached_cols: &CachedSymbolicExpressionColumns<AB::Var> =
-            cached_local.as_slice().borrow();
-        let main_cols: Vec<&SingleMainSymbolicExpressionColumns<AB::Var>> = main_local
+            cached_local_vec.as_slice().borrow();
+        let main_cols: Vec<&SingleMainSymbolicExpressionColumns<AB::Var>> = main_local_slice
             .chunks(SingleMainSymbolicExpressionColumns::<AB::Var>::width())
             .map(|chunk| chunk.borrow())
             .collect();
-        let next_main_cols: Vec<&SingleMainSymbolicExpressionColumns<AB::Var>> = main_next
+        let next_main_cols: Vec<&SingleMainSymbolicExpressionColumns<AB::Var>> = main_next_slice
             .chunks(SingleMainSymbolicExpressionColumns::<AB::Var>::width())
             .map(|chunk| chunk.borrow())
             .collect();

--- a/crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/trace.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/trace.rs
@@ -1,6 +1,7 @@
 use core::{cmp::min, iter::zip};
 use std::borrow::BorrowMut;
 
+use itertools::Itertools;
 use openvm_circuit_primitives::encoder::Encoder;
 use openvm_stark_backend::{
     air_builders::symbolic::{symbolic_variable::Entry, SymbolicExpressionNode},
@@ -9,14 +10,18 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, D_EF, EF, F};
 use p3_field::{BasedVectorSpace, PrimeCharacteristicRing, PrimeField32, TwoAdicField};
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_maybe_rayon::prelude::*;
 use strum::EnumCount;
 
 use crate::{
-    batch_constraint::expr_eval::symbolic_expression::air::{
-        CachedSymbolicExpressionColumns, NodeKind, SingleMainSymbolicExpressionColumns,
-        ENCODER_MAX_DEGREE, NUM_FLAGS,
+    batch_constraint::expr_eval::{
+        default_poseidon2_sub_chip, generate_dag_commit_info,
+        symbolic_expression::air::{
+            CachedSymbolicExpressionColumns, NodeKind, SingleMainSymbolicExpressionColumns,
+            ENCODER_MAX_DEGREE, NUM_FLAGS,
+        },
+        DagCommitCols, DagCommitInfo,
     },
     system::Preflight,
     tracegen::RowMajorChip,
@@ -25,12 +30,14 @@ use crate::{
 
 pub struct SymbolicExpressionTraceGenerator {
     pub max_num_proofs: usize,
+    pub has_cached: bool,
 }
 
 pub(crate) struct SymbolicExpressionCtx<'a> {
     pub vk: &'a MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
     pub preflights: &'a [&'a Preflight],
     pub expr_evals: &'a MultiVecWithBounds<EF, 2>,
+    pub cached_trace_record: &'a Option<&'a CachedTraceRecord>,
 }
 
 impl RowMajorChip<F> for SymbolicExpressionTraceGenerator {
@@ -45,12 +52,15 @@ impl RowMajorChip<F> for SymbolicExpressionTraceGenerator {
         let child_vk = ctx.vk;
         let preflights = ctx.preflights;
         let max_num_proofs = self.max_num_proofs;
+        let has_cached = self.has_cached;
         let expr_evals = ctx.expr_evals;
         let trace_height = required_height;
         let l_skip = child_vk.inner.params.l_skip;
 
         let single_main_width = SingleMainSymbolicExpressionColumns::<F>::width();
-        let main_width = single_main_width * max_num_proofs;
+        let dag_commit_width = DagCommitCols::<F>::width();
+        let main_width =
+            single_main_width * max_num_proofs + if has_cached { 0 } else { dag_commit_width };
 
         struct Record {
             args: [F; 2 * D_EF],
@@ -301,16 +311,71 @@ impl RowMajorChip<F> for SymbolicExpressionTraceGenerator {
         };
         let mut main_trace = F::zero_vec(main_width * height);
 
+        let (encoder, cached_records, poseidon2_rows) = if has_cached {
+            (None, None, None)
+        } else {
+            let encoder = Encoder::new(NodeKind::COUNT, ENCODER_MAX_DEGREE, true);
+            assert_eq!(encoder.width(), NUM_FLAGS);
+
+            let cached_trace_record = ctx.cached_trace_record.unwrap();
+            debug_assert_eq!(cached_trace_record.records.len(), num_valid_rows);
+
+            let poseidon2_subchip = default_poseidon2_sub_chip();
+            let poseidon2_trace = poseidon2_subchip.generate_trace(
+                cached_trace_record
+                    .dag_commit_info
+                    .as_ref()
+                    .unwrap()
+                    .poseidon2_inputs
+                    .clone(),
+            );
+            let poseidon2_rows = poseidon2_trace
+                .rows()
+                .map(|row| row.collect_vec())
+                .collect_vec();
+
+            (
+                Some(encoder),
+                Some(&cached_trace_record.records),
+                Some(poseidon2_rows),
+            )
+        };
+
         main_trace
             .par_chunks_exact_mut(main_width)
             .enumerate()
             .for_each(|(row_idx, row)| {
+                let main_offset = if has_cached {
+                    0
+                } else {
+                    // Poseidon2 data must be written for ALL rows (including padding) to
+                    // keep the onion hash chain valid.
+                    let poseidon2_row = &poseidon2_rows.as_ref().unwrap()[row_idx];
+                    row[..poseidon2_row.len()].copy_from_slice(poseidon2_row);
+
+                    if row_idx < num_valid_rows {
+                        let record = &cached_records.as_ref().unwrap()[row_idx];
+                        let encoder = encoder.as_ref().unwrap();
+                        let cols: &mut DagCommitCols<_> = row[..dag_commit_width].borrow_mut();
+                        for (i, x) in encoder
+                            .get_flag_pt(record.kind as usize)
+                            .into_iter()
+                            .enumerate()
+                        {
+                            cols.flags[i] = F::from_u32(x);
+                        }
+                        cols.is_constraint = F::from_bool(record.is_constraint);
+                    }
+
+                    dag_commit_width
+                };
+
                 for proof_idx in 0..max_num_proofs {
                     if proof_idx >= preflights.len() {
                         continue;
                     }
 
-                    let start = proof_idx * single_main_width;
+                    let start = main_offset + proof_idx * single_main_width;
                     let end = start + single_main_width;
                     let cols: &mut SingleMainSymbolicExpressionColumns<_> =
                         row[start..end].borrow_mut();
@@ -355,10 +420,12 @@ pub(crate) struct CachedRecord {
 #[derive(Debug, Clone)]
 pub struct CachedTraceRecord {
     pub(crate) records: Vec<CachedRecord>,
+    pub dag_commit_info: Option<DagCommitInfo<F>>,
 }
 
 pub(crate) fn build_cached_trace_record(
     child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
+    has_cached: bool,
 ) -> CachedTraceRecord {
     let mut fanout_per_air = Vec::with_capacity(child_vk.inner.per_air.len());
     for vk in &child_vk.inner.per_air {
@@ -572,7 +639,15 @@ pub(crate) fn build_cached_trace_record(
         }
     }
 
-    CachedTraceRecord { records }
+    let dag_commit_info = (!has_cached).then(|| {
+        let encoder = Encoder::new(NodeKind::COUNT, ENCODER_MAX_DEGREE, true);
+        generate_dag_commit_info(&records, encoder)
+    });
+
+    CachedTraceRecord {
+        records,
+        dag_commit_info,
+    }
 }
 
 /// Returns the cached trace
@@ -639,6 +714,7 @@ pub(in crate::batch_constraint) mod cuda {
         pub proofs: &'a [ProofGpu],
         pub preflights: &'a [PreflightGpu],
         pub expr_evals: &'a MultiVecWithBounds<openvm_cuda_backend::prelude::EF, 2>,
+        pub cached_trace_record: &'a Option<&'a CachedTraceRecord>,
     }
 
     impl ModuleChip<GpuBackend> for SymbolicExpressionTraceGenerator {
@@ -654,6 +730,7 @@ pub(in crate::batch_constraint) mod cuda {
             let proofs = ctx.proofs;
             let preflights = ctx.preflights;
             let max_num_proofs = self.max_num_proofs;
+            let has_cached = self.has_cached;
             let expr_evals = ctx.expr_evals;
 
             debug_assert_eq!(proofs.len(), preflights.len());
@@ -726,7 +803,9 @@ pub(in crate::batch_constraint) mod cuda {
             } else {
                 total_rows.max(1).next_power_of_two()
             };
-            let width = SingleMainSymbolicExpressionColumns::<F>::width() * max_num_proofs;
+            let commit_width = DagCommitCols::<F>::width();
+            let width = SingleMainSymbolicExpressionColumns::<F>::width() * max_num_proofs
+                + if has_cached { 0 } else { commit_width };
             let trace = DeviceMatrix::with_capacity(height, width);
 
             let d_log_heights = proofs
@@ -786,6 +865,9 @@ pub(in crate::batch_constraint) mod cuda {
                 sumcheck_data.to_device().unwrap()
             };
             let d_sumcheck_bounds = sumcheck_bounds.to_device().unwrap();
+            let d_cached_records = ctx
+                .cached_trace_record
+                .map(|data| build_cached_gpu_records(data).unwrap().to_device().unwrap());
 
             unsafe {
                 sym_expr_common_tracegen(
@@ -812,6 +894,7 @@ pub(in crate::batch_constraint) mod cuda {
                     total_rows,
                     &d_sumcheck_rnds,
                     &d_sumcheck_bounds,
+                    d_cached_records.as_ref(),
                 )
                 .unwrap();
             }

--- a/crates/recursion/src/batch_constraint/mod.rs
+++ b/crates/recursion/src/batch_constraint/mod.rs
@@ -31,7 +31,7 @@ use crate::{
             EqSharpUniAir, EqSharpUniBlob, EqSharpUniReceiverAir, EqUniAir,
         },
         expr_eval::{
-            CachedTraceRecord, ConstraintsFoldingAir, ConstraintsFoldingBlob,
+            CachedTraceRecord, ConstraintsFoldingAir, ConstraintsFoldingBlob, DagCommitSubAir,
             InteractionsFoldingAir, InteractionsFoldingBlob, SymbolicExpressionAir,
         },
         expression_claim::{
@@ -120,6 +120,7 @@ pub struct BatchConstraintModule {
     max_constraint_degree: usize,
 
     max_num_proofs: usize,
+    pub(crate) has_cached: bool,
 }
 
 impl BatchConstraintModule {
@@ -128,6 +129,7 @@ impl BatchConstraintModule {
         b: &mut BusIndexManager,
         bus_inventory: BusInventory,
         max_num_proofs: usize,
+        has_cached: bool,
     ) -> Self {
         let l_skip = child_vk.inner.params.l_skip;
         let max_constraint_degree = child_vk.max_constraint_degree();
@@ -171,6 +173,7 @@ impl BatchConstraintModule {
             l_skip,
             max_constraint_degree,
             max_num_proofs,
+            has_cached,
         }
     }
 
@@ -312,7 +315,7 @@ impl AirModule for BatchConstraintModule {
     fn airs<SC: StarkProtocolConfig<F = BabyBear>>(&self) -> Vec<AirRef<SC>> {
         let l_skip = self.l_skip;
 
-        let symbolic_expression_air = SymbolicExpressionAir {
+        let symbolic_expression_air = SymbolicExpressionAir::<BabyBear> {
             expr_bus: self.symbolic_expression_bus,
             air_shape_bus: self.air_shape_bus,
             air_presence_bus: self.air_presence_bus,
@@ -324,6 +327,7 @@ impl AirModule for BatchConstraintModule {
             sel_hypercube_bus: self.sel_hypercube_bus,
             sel_uni_bus: self.sel_uni_bus,
             cnt_proofs: self.max_num_proofs,
+            dag_commit_subair: (!self.has_cached).then_some(Arc::new(DagCommitSubAir::new())),
         };
         let fraction_folder_air = FractionsFolderAir {
             transcript_bus: self.transcript_bus,
@@ -678,7 +682,10 @@ impl BatchConstraintBlobCpu {
 impl<SC: StarkProtocolConfig<F = F>> TraceGenModule<GlobalCtxCpu, CpuBackend<SC>>
     for BatchConstraintModule
 {
-    type ModuleSpecificCtx<'a> = Arc<PowerCheckerCpuTraceGenerator<2, POW_CHECKER_HEIGHT>>;
+    type ModuleSpecificCtx<'a> = (
+        Option<&'a CachedTraceRecord>,
+        Arc<PowerCheckerCpuTraceGenerator<2, POW_CHECKER_HEIGHT>>,
+    );
 
     /// **Note**: This generates all common main traces but leaves the cached trace for
     /// `SymbolicExpressionAir` unset. The cached trace must be loaded **after** calling this
@@ -689,10 +696,11 @@ impl<SC: StarkProtocolConfig<F = F>> TraceGenModule<GlobalCtxCpu, CpuBackend<SC>
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         preflights: &[Preflight],
-        pow_checker: &Self::ModuleSpecificCtx<'_>,
+        ctx: &Self::ModuleSpecificCtx<'_>,
         required_heights: Option<&[usize]>,
     ) -> Option<Vec<AirProvingContext<CpuBackend<SC>>>> {
         let blob = BatchConstraintBlobCpu::new(child_vk, proofs, preflights);
+        let pow_checker = ctx.1.clone();
         let ctx = (
             StandardTracegenCtx {
                 vk: child_vk,
@@ -700,11 +708,13 @@ impl<SC: StarkProtocolConfig<F = F>> TraceGenModule<GlobalCtxCpu, CpuBackend<SC>
                 preflights: &preflights.iter().collect_vec(),
             },
             blob,
+            ctx.0,
         );
 
         let chips = [
             BatchConstraintModuleChip::SymbolicExpression {
                 max_num_proofs: self.max_num_proofs,
+                has_cached: self.has_cached,
             },
             BatchConstraintModuleChip::FractionsFolder,
             BatchConstraintModuleChip::SumcheckUni,
@@ -714,9 +724,7 @@ impl<SC: StarkProtocolConfig<F = F>> TraceGenModule<GlobalCtxCpu, CpuBackend<SC>
             BatchConstraintModuleChip::EqSharpUni,
             BatchConstraintModuleChip::EqSharpUniReceiver,
             BatchConstraintModuleChip::EqUni,
-            BatchConstraintModuleChip::ExpressionClaim {
-                pow_checker: pow_checker.clone(),
-            },
+            BatchConstraintModuleChip::ExpressionClaim { pow_checker },
             BatchConstraintModuleChip::InteractionsFolding,
             BatchConstraintModuleChip::ConstraintsFolding,
             BatchConstraintModuleChip::EqNeg,
@@ -743,7 +751,7 @@ impl BatchConstraintModule {
         &self,
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
     ) -> CachedTraceRecord {
-        expr_eval::build_cached_trace_record(child_vk)
+        expr_eval::build_cached_trace_record(child_vk, self.has_cached)
     }
 
     /// Generates and then commits to the cache trace for `SymbolicExpressionAir`. Returns the
@@ -774,6 +782,7 @@ impl BatchConstraintModule {
 enum BatchConstraintModuleChip {
     SymbolicExpression {
         max_num_proofs: usize,
+        has_cached: bool,
     },
     FractionsFolder,
     SumcheckUni,
@@ -798,7 +807,11 @@ impl BatchConstraintModuleChip {
 }
 
 impl RowMajorChip<F> for BatchConstraintModuleChip {
-    type Ctx<'a> = (StandardTracegenCtx<'a>, BatchConstraintBlobCpu);
+    type Ctx<'a> = (
+        StandardTracegenCtx<'a>,
+        BatchConstraintBlobCpu,
+        Option<&'a CachedTraceRecord>,
+    );
 
     #[tracing::instrument(
         name = "wrapper.generate_trace",
@@ -816,6 +829,7 @@ impl RowMajorChip<F> for BatchConstraintModuleChip {
         let proofs = ctx.0.proofs;
         let preflights = ctx.0.preflights;
         let blob = &ctx.1;
+        let cached_trace_record = ctx.2;
         match self {
             FractionsFolder => {
                 FractionsFolderTraceGenerator.generate_trace(&ctx.0, required_height)
@@ -841,14 +855,19 @@ impl RowMajorChip<F> for BatchConstraintModuleChip {
                 required_height,
             ),
             EqUni => eq_airs::EqUniTraceGenerator.generate_trace(&ctx.0, required_height),
-            SymbolicExpression { max_num_proofs } => expr_eval::SymbolicExpressionTraceGenerator {
+            SymbolicExpression {
+                max_num_proofs,
+                has_cached,
+            } => expr_eval::SymbolicExpressionTraceGenerator {
                 max_num_proofs: *max_num_proofs,
+                has_cached: *has_cached,
             }
             .generate_trace(
                 &expr_eval::SymbolicExpressionCtx {
                     vk: child_vk,
                     preflights,
                     expr_evals: &blob.common_blob.expr_evals,
+                    cached_trace_record: &cached_trace_record,
                 },
                 required_height,
             ),
@@ -890,7 +909,11 @@ pub mod cuda_tracegen {
     };
 
     impl ModuleChip<GpuBackend> for BatchConstraintModuleChip {
-        type Ctx<'a> = (StandardTracegenGpuCtx<'a>, &'a BatchConstraintBlobGpu);
+        type Ctx<'a> = (
+            StandardTracegenGpuCtx<'a>,
+            &'a BatchConstraintBlobGpu,
+            Option<&'a CachedTraceRecord>,
+        );
 
         fn generate_proving_ctx(
             &self,
@@ -902,25 +925,29 @@ pub mod cuda_tracegen {
             let proofs = ctx.0.proofs;
             let preflights = ctx.0.preflights;
             let blob = ctx.1;
+            let cached_trace_record = ctx.2;
             match self {
                 Eq3b => eq_airs::Eq3bTraceGenerator.generate_proving_ctx(
                     &(&child_vk.cpu, &blob.common_blob.eq_3b_blob, preflights),
                     required_height,
                 ),
-                SymbolicExpression { max_num_proofs } => {
-                    expr_eval::SymbolicExpressionTraceGenerator {
-                        max_num_proofs: *max_num_proofs,
-                    }
-                    .generate_proving_ctx(
-                        &expr_eval::symbolic_expression::cuda::SymbolicExpressionGpuCtx {
-                            vk: &child_vk.cpu,
-                            proofs,
-                            preflights,
-                            expr_evals: &blob.common_blob.expr_evals,
-                        },
-                        required_height,
-                    )
+                SymbolicExpression {
+                    max_num_proofs,
+                    has_cached,
+                } => expr_eval::SymbolicExpressionTraceGenerator {
+                    max_num_proofs: *max_num_proofs,
+                    has_cached: *has_cached,
                 }
+                .generate_proving_ctx(
+                    &expr_eval::symbolic_expression::cuda::SymbolicExpressionGpuCtx {
+                        vk: &child_vk.cpu,
+                        proofs,
+                        preflights,
+                        expr_evals: &blob.common_blob.expr_evals,
+                        cached_trace_record: &cached_trace_record,
+                    },
+                    required_height,
+                ),
                 InteractionsFolding => expr_eval::InteractionsFoldingTraceGenerator
                     .generate_proving_ctx(&(child_vk, preflights, &blob.if_blob), required_height),
                 ConstraintsFolding => expr_eval::ConstraintsFoldingTraceGenerator
@@ -967,7 +994,10 @@ pub mod cuda_tracegen {
     }
 
     impl TraceGenModule<GlobalCtxGpu, GpuBackend> for BatchConstraintModule {
-        type ModuleSpecificCtx<'a> = Arc<PowerCheckerCpuTraceGenerator<2, POW_CHECKER_HEIGHT>>;
+        type ModuleSpecificCtx<'a> = (
+            Option<&'a CachedTraceRecord>,
+            Arc<PowerCheckerCpuTraceGenerator<2, POW_CHECKER_HEIGHT>>,
+        );
 
         #[tracing::instrument(skip_all)]
         fn generate_proving_ctxs(
@@ -975,9 +1005,11 @@ pub mod cuda_tracegen {
             child_vk: &VerifyingKeyGpu,
             proofs: &[ProofGpu],
             preflights: &[PreflightGpu],
-            pow_checker: &Self::ModuleSpecificCtx<'_>,
+            module_ctx: &Self::ModuleSpecificCtx<'_>,
             required_heights: Option<&[usize]>,
         ) -> Option<Vec<AirProvingContext<GpuBackend>>> {
+            let cached_trace_record = module_ctx.0;
+            let pow_checker = module_ctx.1.clone();
             let blob = BatchConstraintBlobGpu::new(child_vk, proofs, preflights);
             let ctx = (
                 StandardTracegenGpuCtx {
@@ -986,12 +1018,14 @@ pub mod cuda_tracegen {
                     preflights,
                 },
                 &blob,
+                cached_trace_record,
             );
 
             // Chips with cuda kernels for tracegen
             let gpu_chips = [
                 BatchConstraintModuleChip::SymbolicExpression {
                     max_num_proofs: self.max_num_proofs,
+                    has_cached: self.has_cached,
                 },
                 BatchConstraintModuleChip::Eq3b,
                 BatchConstraintModuleChip::ConstraintsFolding,
@@ -1006,9 +1040,7 @@ pub mod cuda_tracegen {
                 BatchConstraintModuleChip::EqSharpUni,
                 BatchConstraintModuleChip::EqSharpUniReceiver,
                 BatchConstraintModuleChip::EqUni,
-                BatchConstraintModuleChip::ExpressionClaim {
-                    pow_checker: pow_checker.clone(),
-                },
+                BatchConstraintModuleChip::ExpressionClaim { pow_checker },
                 BatchConstraintModuleChip::EqNeg,
             ];
             let span = tracing::Span::current();
@@ -1044,6 +1076,7 @@ pub mod cuda_tracegen {
                     preflights: &cpu_preflights,
                 },
                 blob,
+                cached_trace_record,
             );
 
             // We parallelize the CPU trace generation
@@ -1088,7 +1121,7 @@ pub mod cuda_tracegen {
                 Matrix = openvm_cuda_backend::base::DeviceMatrix<F>,
             >,
         {
-            let cached_trace_record = build_cached_trace_record(child_vk);
+            let cached_trace_record = build_cached_trace_record(child_vk, self.has_cached);
             let cached_trace = expr_eval::generate_symbolic_expr_cached_trace(&cached_trace_record);
             let d_cached_trace = transport_matrix_h2d_row(&cached_trace).unwrap();
             let (commitment, data) = engine.device().commit(&[&d_cached_trace]).unwrap();

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -51,10 +51,26 @@ pub(crate) mod frame;
 const BATCH_CONSTRAINT_MOD_IDX: usize = 0;
 pub(crate) const POW_CHECKER_HEIGHT: usize = 32;
 
-#[derive(Debug, Default, Copy, Clone)]
+pub enum CachedTraceCtx<PB: ProverBackend> {
+    PcsData(CommittedTraceData<PB>),
+    Records(CachedTraceRecord),
+}
+
+#[derive(Debug, Copy, Clone)]
 pub struct VerifierConfig {
     pub continuations_enabled: bool,
     pub final_state_bus_enabled: bool,
+    pub has_cached: bool,
+}
+
+impl Default for VerifierConfig {
+    fn default() -> Self {
+        Self {
+            continuations_enabled: false,
+            final_state_bus_enabled: false,
+            has_cached: true,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -93,7 +109,7 @@ pub trait VerifierTraceGen<PB: ProverBackend, SC: StarkProtocolConfig<F = F>> {
     >(
         &self,
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-        child_vk_pcs_data: CommittedTraceData<PB>,
+        cached_trace_ctx: CachedTraceCtx<PB>,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         external_data: &mut VerifierExternalData,
         initial_transcript: TS,
@@ -105,7 +121,7 @@ pub trait VerifierTraceGen<PB: ProverBackend, SC: StarkProtocolConfig<F = F>> {
     >(
         &self,
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-        child_vk_pcs_data: CommittedTraceData<PB>,
+        cached_trace_ctx: CachedTraceCtx<PB>,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         initial_transcript: TS,
     ) -> Vec<AirProvingContext<PB>> {
@@ -122,7 +138,7 @@ pub trait VerifierTraceGen<PB: ProverBackend, SC: StarkProtocolConfig<F = F>> {
 
         self.generate_proving_ctxs::<TS>(
             child_vk,
-            child_vk_pcs_data,
+            cached_trace_ctx,
             proofs,
             &mut external_data,
             initial_transcript,
@@ -458,6 +474,7 @@ impl<'a> TraceModuleRef<'a> {
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         preflights: &[Preflight],
+        cached_trace_record: Option<&CachedTraceRecord>,
         pow_checker_gen: &Arc<PowerCheckerCpuTraceGenerator<2, POW_CHECKER_HEIGHT>>,
         exp_bits_len_gen: &ExpBitsLenTraceGenerator,
         external_data: &VerifierExternalData,
@@ -495,7 +512,7 @@ impl<'a> TraceModuleRef<'a> {
                 child_vk,
                 proofs,
                 preflights,
-                pow_checker_gen,
+                &(cached_trace_record, pow_checker_gen.clone()),
                 required_heights,
             ),
             TraceModuleRef::Stacking(module) => {
@@ -585,6 +602,7 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
             &mut bus_idx_manager,
             bus_inventory.clone(),
             MAX_NUM_PROOFS,
+            config.has_cached,
         );
         let stacking = StackingModule::new(&child_mvk, &mut bus_idx_manager, bus_inventory.clone());
         let whir = WhirModule::new(&child_mvk, &mut bus_idx_manager, bus_inventory.clone());
@@ -1010,7 +1028,7 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
     >(
         &self,
         child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-        child_vk_pcs_data: CommittedTraceData<CpuBackend<SC>>,
+        cached_trace_ctx: CachedTraceCtx<CpuBackend<SC>>,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         external_data: &mut VerifierExternalData,
         initial_transcript: TS,
@@ -1065,6 +1083,10 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
             TraceModuleRef::Stacking(&self.stacking),
             TraceModuleRef::Whir(&self.whir),
         ];
+        let cached_trace_record = match &cached_trace_ctx {
+            CachedTraceCtx::Records(cached_trace_record) => Some(cached_trace_record),
+            _ => None,
+        };
 
         let span = tracing::Span::current();
         let ctxs_by_module = modules
@@ -1076,6 +1098,7 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
                     child_vk,
                     proofs,
                     &preflights,
+                    cached_trace_record,
                     &power_checker_gen,
                     &exp_bits_len_gen,
                     external_data,
@@ -1086,8 +1109,18 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
 
         let mut ctxs_by_module: Vec<Vec<AirProvingContext<CpuBackend<SC>>>> =
             ctxs_by_module.into_iter().collect::<Option<Vec<_>>>()?;
-        ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX].cached_mains =
-            vec![child_vk_pcs_data];
+        match cached_trace_ctx {
+            CachedTraceCtx::PcsData(child_vk_pcs_data) => {
+                assert!(self.batch_constraint.has_cached);
+                ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
+                    .cached_mains = vec![child_vk_pcs_data];
+            }
+            CachedTraceCtx::Records(cached_trace_record) => {
+                assert!(!self.batch_constraint.has_cached);
+                ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
+                    .public_values = cached_trace_record.dag_commit_info.unwrap().commit.to_vec();
+            }
+        };
 
         let mut ctx_per_trace = ctxs_by_module.into_iter().flatten().collect::<Vec<_>>();
         if power_checker_required.is_some_and(|h| h != POW_CHECKER_HEIGHT) {
@@ -1137,6 +1170,7 @@ pub mod cuda_tracegen {
             child_vk: &VerifyingKeyGpu,
             proofs: &[ProofGpu],
             preflights: &[PreflightGpu],
+            cached_trace_record: Option<&CachedTraceRecord>,
             pow_checker_gen: &Arc<PowerCheckerGpuTraceGenerator<2, POW_CHECKER_HEIGHT>>,
             exp_bits_len_gen: &ExpBitsLenTraceGenerator,
             external_data: &VerifierExternalData,
@@ -1174,7 +1208,7 @@ pub mod cuda_tracegen {
                     child_vk,
                     proofs,
                     preflights,
-                    &pow_checker_gen.cpu_checker().unwrap(),
+                    &(cached_trace_record, pow_checker_gen.cpu_checker().unwrap()),
                     required_heights,
                 ),
                 TraceModuleRef::Stacking(module) => module.generate_proving_ctxs(
@@ -1242,7 +1276,7 @@ pub mod cuda_tracegen {
         >(
             &self,
             child_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
-            child_vk_pcs_data: CommittedTraceData<GenericGpuBackend<HS>>,
+            cached_trace_ctx: CachedTraceCtx<GenericGpuBackend<HS>>,
             proofs: &[Proof<BabyBearPoseidon2Config>],
             external_data: &mut VerifierExternalData,
             initial_transcript: TS,
@@ -1305,6 +1339,10 @@ pub mod cuda_tracegen {
                 TraceModuleRef::Stacking(&self.stacking),
                 TraceModuleRef::Whir(&self.whir),
             ];
+            let cached_trace_record = match &cached_trace_ctx {
+                CachedTraceCtx::Records(cached_trace_record) => Some(cached_trace_record),
+                _ => None,
+            };
 
             // PERF[jpw]: we avoid par_iter so that kernel launches occur on the same stream.
             // This can be parallelized to separate streams for more CUDA stream parallelism, but it
@@ -1316,6 +1354,7 @@ pub mod cuda_tracegen {
                     &child_vk_gpu,
                     &proofs_gpu,
                     &preflights_gpu,
+                    cached_trace_record,
                     &power_checker_gen,
                     &exp_bits_len_gen,
                     external_data,
@@ -1327,8 +1366,19 @@ pub mod cuda_tracegen {
                     .into_iter()
                     .map(|module_ctxs| module_ctxs.into_iter().map(coerce_gpu_ctx::<HS>).collect())
                     .collect();
-            ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
-                .cached_mains = vec![child_vk_pcs_data];
+            match cached_trace_ctx {
+                CachedTraceCtx::PcsData(child_vk_pcs_data) => {
+                    assert!(self.batch_constraint.has_cached);
+                    ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
+                        .cached_mains = vec![child_vk_pcs_data];
+                }
+                CachedTraceCtx::Records(cached_trace_record) => {
+                    assert!(!self.batch_constraint.has_cached);
+                    ctxs_by_module[BATCH_CONSTRAINT_MOD_IDX][LOCAL_SYMBOLIC_EXPRESSION_AIR_IDX]
+                        .public_values =
+                        cached_trace_record.dag_commit_info.unwrap().commit.to_vec();
+                }
+            }
 
             let mut ctx_per_trace = ctxs_by_module.into_iter().flatten().collect::<Vec<_>>();
             if power_checker_required.is_some_and(|h| h != POW_CHECKER_HEIGHT) {

--- a/crates/recursion/src/tests.rs
+++ b/crates/recursion/src/tests.rs
@@ -23,7 +23,9 @@ use openvm_stark_sdk::{
 use test_case::{test_case, test_matrix};
 use tracing::Level;
 
-use crate::system::{AggregationSubCircuit, VerifierSubCircuit, VerifierTraceGen};
+use crate::system::{
+    AggregationSubCircuit, CachedTraceCtx, VerifierConfig, VerifierSubCircuit, VerifierTraceGen,
+};
 
 pub const MAX_CONSTRAINT_DEGREE: usize = 4;
 
@@ -79,7 +81,7 @@ fn run_test<const MAX_NUM_PROOFS: usize, Fx: TestFixture<BabyBearPoseidon2Config
     let proofs: Vec<_> = (0..num_proofs).map(|_| proof.clone()).collect();
     let ctxs = circuit.generate_proving_ctxs_base(
         &vk,
-        vk_commit_data,
+        CachedTraceCtx::PcsData(vk_commit_data),
         &proofs,
         default_duplex_sponge_recorder(),
     );
@@ -153,7 +155,7 @@ fn test_recursion_circuit_many_fib_airs_some_missing() {
     let vk_commit_data = circuit.commit_child_vk(&parent_engine, &vk);
     let ctxs = circuit.generate_proving_ctxs_base(
         &vk,
-        vk_commit_data,
+        CachedTraceCtx::PcsData(vk_commit_data),
         &[proof],
         default_duplex_sponge_recorder(),
     );
@@ -471,6 +473,38 @@ fn test_recursion_circuit_multiple_cached() {
     run_test::<5, _>(fx, &child_engine, &parent_engine, 5);
 }
 
+#[test]
+fn test_recursion_circuit_dag_commit_subair() {
+    let params = test_system_params_small(3, 5, 3);
+    let child_engine = BabyBearPoseidon2CpuEngine::<DuplexSponge>::new(params.clone());
+    let parent_engine = test_engine_small();
+    let fx = MixtureFixture::standard(
+        5,
+        BabyBearPoseidon2Config::default_from_params(params.clone()),
+    );
+    let (vk, proof) = fx.keygen_and_prove(&child_engine);
+
+    let circuit = VerifierSubCircuit::<2>::new_with_options(
+        Arc::new(vk.clone()),
+        VerifierConfig {
+            has_cached: false,
+            ..Default::default()
+        },
+    );
+    let cached_trace_record = <VerifierSubCircuit<2> as VerifierTraceGen<
+        _,
+        BabyBearPoseidon2Config,
+    >>::cached_trace_record(&circuit, &vk);
+    let ctxs = circuit.generate_proving_ctxs_base(
+        &vk,
+        CachedTraceCtx::Records(cached_trace_record),
+        &[proof],
+        default_duplex_sponge_recorder(),
+    );
+    assert!(ctxs[0].cached_mains.is_empty());
+    debug(&parent_engine, &circuit.airs(), ctxs);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // NEGATIVE HYPERCUBE TESTS
 ///////////////////////////////////////////////////////////////////////////////
@@ -616,7 +650,7 @@ fn test_recursion_circuit_w_stack_too_small() {
     let vk_commit_data = circuit.commit_child_vk(&parent_engine, &vk);
     let ctxs = circuit.generate_proving_ctxs_base(
         &vk,
-        vk_commit_data,
+        CachedTraceCtx::PcsData(vk_commit_data),
         std::slice::from_ref(&proof),
         default_duplex_sponge_recorder(),
     );
@@ -684,13 +718,13 @@ mod cuda {
         let vk_commit_data_gpu = circuit.commit_child_vk(&gpu_engine, &vk);
         let cpu_ctx = circuit.generate_proving_ctxs_base(
             &vk,
-            vk_commit_data_cpu,
+            CachedTraceCtx::PcsData(vk_commit_data_cpu),
             &proofs,
             default_duplex_sponge_recorder(),
         );
         let gpu_ctx = circuit.generate_proving_ctxs_base(
             &vk,
-            vk_commit_data_gpu,
+            CachedTraceCtx::PcsData(vk_commit_data_gpu),
             &proofs,
             default_duplex_sponge_recorder(),
         );

--- a/crates/recursion/src/tests.rs
+++ b/crates/recursion/src/tests.rs
@@ -492,7 +492,7 @@ fn test_recursion_circuit_dag_commit_subair() {
         },
     );
     let cached_trace_record = <VerifierSubCircuit<2> as VerifierTraceGen<
-        _,
+        CpuBackend<BabyBearPoseidon2Config>,
         BabyBearPoseidon2Config,
     >>::cached_trace_record(&circuit, &vk);
     let ctxs = circuit.generate_proving_ctxs_base(

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -174,7 +174,7 @@ pub fn compute_root_proof_heights(
         None,
     );
 
-    let root_proving_ctx = root_prover
+    let root_proving_ctx: ProvingContext<<E as StarkEngine>::PB> = root_prover
         .generate_proving_ctx(
             agg_proof.inner,
             &agg_proof.user_pvs_proof,

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -128,6 +128,7 @@ impl<
             VerifierConfig {
                 continuations_enabled: true,
                 final_state_bus_enabled: true,
+                has_cached: true,
             },
         );
         let engine = E::new(system_params);
@@ -176,6 +177,7 @@ impl<
             VerifierConfig {
                 continuations_enabled: true,
                 final_state_bus_enabled: true,
+                has_cached: true,
             },
         );
         let def_hook_vk_commit = def_hook_vk_commit.map(Into::into);

--- a/guest-libs/verify-stark/circuit/src/prover/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/trace.rs
@@ -6,7 +6,7 @@ use openvm_circuit::{
 };
 use openvm_continuations::{circuit::deferral::DeferralMerkleProofs, SC};
 use openvm_recursion_circuit::system::{
-    AggregationSubCircuit, VerifierExternalData, VerifierTraceGen,
+    AggregationSubCircuit, CachedTraceCtx, VerifierExternalData, VerifierTraceGen,
 };
 use openvm_stark_backend::{
     proof::Proof,
@@ -71,7 +71,7 @@ where
             .verifier_circuit
             .generate_proving_ctxs(
                 &self.child_vk,
-                self.child_vk_pcs_data.clone(),
+                CachedTraceCtx::PcsData(self.child_vk_pcs_data.clone()),
                 proof_slice,
                 &mut external_data,
                 default_duplex_sponge_recorder(),


### PR DESCRIPTION
Resolves INT-6981 and INT-6982. The PR to remove `DagCommitSubAir` is [here](https://github.com/openvm-org/openvm/pull/2533/changes).

## Overview

This branch does two primary things:

1. Re-introduces `DagCommitSubAir` into the recursion circuit (reversing the recursion-side functional removal from `c6e042f3b8f833dde0222cb48d5c81f04e2274f8`).
2. Moves the root prover path to **no cached trace** mode (`has_cached = false`), using `CachedTraceCtx::Records` instead of cached PCS data.

Branch commits:
- `a97b89e37` — re-introduce `DagCommitSubAir` into recursion + API plumbing updates
- `27e1c48d9` — root prover switched to no-cached mode
- `6a25c5b35` — follow-up compile/test/type fixes

## Review Guide
Suggested review order:
1. **Recursion DagCommit reintroduction** (`crates/recursion/**`)
2. **Root prover no-cached flow** (`crates/continuations/src/prover/root/**`)
3. **Cross-crate API updates** (`continuations` non-root traces, `guest-libs/verify-stark/circuit`, `sdk`, tests)

---

## 1) Recursion: DagCommitSubAir Reintroduced

### 1.1 New DagCommit sub-AIR implementation
Files:
- `crates/recursion/src/batch_constraint/expr_eval/dag_commit.rs` (new)
- `crates/recursion/src/batch_constraint/expr_eval/mod.rs`

What changed:
- Restores `DagCommitSubAir`, `DagCommitCols`, `DagCommitPvs`, and helper logic for digest packing/collapse.
- Adds `DagCommitInfo` generation (`commit` + Poseidon2 input stream) for no-cached mode.

### 1.2 SymbolicExpressionAir dual-mode behavior (cached vs no-cached)
Files:
- `crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/air.rs`

What changed:
- `SymbolicExpressionAir` now carries `dag_commit_subair: Option<Arc<DagCommitSubAir<_>>>`.
- In cached mode:
  - uses cached main width (`CachedSymbolicExpressionColumns`), zero public values.
- In no-cached mode:
  - prefixes common main with `DagCommitCols`,
  - exposes `DagCommitPvs` public values,
  - evaluates DagCommit sub-AIR directly from common main prefix.

### 1.3 Trace generation restored for no-cached mode
Files:
- `crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/trace.rs`

What changed:
- `SymbolicExpressionTraceGenerator` now takes `has_cached`.
- `CachedTraceRecord` again carries optional `dag_commit_info`.
- `build_cached_trace_record(child_vk, has_cached)` computes DagCommit inputs/commit when `has_cached == false`.
- CPU tracegen writes DagCommit columns + symbolic-expression columns in no-cached mode.

### 1.4 Batch constraint/system plumbing and explicit cached context API
Files:
- `crates/recursion/src/batch_constraint/mod.rs`
- `crates/recursion/src/system/mod.rs`

What changed:
- `BatchConstraintModule` now stores `has_cached` and configures `SymbolicExpressionAir` accordingly.
- `VerifierConfig` includes `has_cached`.
- Reintroduces explicit `CachedTraceCtx<PB>` API:
  - `PcsData(CommittedTraceData<PB>)`
  - `Records(CachedTraceRecord)`
- `VerifierTraceGen::generate_proving_ctxs(_base)` now accepts `CachedTraceCtx` again.
- CPU/GPU verifier tracegen paths now set either:
  - `cached_mains` from `PcsData`, or
  - symbolic-expression public values from `Records` (DagCommit commit).

Note:
- `DagCommitBus` is **not** reintroduced. DagCommit remains folded as sub-AIR, so bus-level wiring is still intentionally absent.

### 1.5 CUDA symbolic-expression DagCommit path restored
Files:
- `crates/recursion/cuda/src/batch_constraint/expr_eval/dag_commit.cuh` (new)
- `crates/recursion/cuda/src/batch_constraint/expr_eval/symbolic_expression.cu`
- `crates/recursion/src/batch_constraint/cuda_abi.rs`
- `crates/recursion/src/batch_constraint/cuda_utils.rs`

What changed:
- Restores DagCommit column writing in CUDA symbolic-expression tracegen when no-cached mode is used.
- Adds per-row cached metadata (`CachedGpuRecord`) carrying Poseidon2 start state + `is_constraint`.
- `_sym_expr_common_tracegen`/Rust ABI now takes `d_cached_records` pointer.

---

## 2) Continuations Root Prover: No Cached Trace

Files:
- `crates/continuations/src/prover/root/mod.rs`
- `crates/continuations/src/prover/root/trace.rs`
- `crates/continuations/src/prover/mod.rs`

What changed:
- Root verifier subcircuit is built with `VerifierConfig { has_cached: false, ... }`.
- Root prover now computes/stores `CachedTraceRecord` and feeds recursion via:
  - `CachedTraceCtx::Records(self.cached_trace_record.clone())`
- Removed root prover dependency on cached PCS data for recursion tracegen (`child_vk_pcs_data` removed).
- Removed root cached-commit getter (no longer needed by root path).
- Simplified `RootProver` type shape by removing struct-level `PB`; backend type is now method-generic.
- Updated root prover aliases accordingly.

---

## 3) Cross-Crate API Compatibility Updates

### 3.1 Continuations non-root prover calls updated to explicit `CachedTraceCtx`
Files:
- `crates/continuations/src/prover/inner/trace.rs`
- `crates/continuations/src/prover/deferral/inner/trace.rs`
- `crates/continuations/src/prover/deferral/hook/trace.rs`

What changed:
- Calls to recursion `generate_proving_ctxs` now pass `CachedTraceCtx::PcsData(...)`.

### 3.2 Verify-stark guest lib updated for recursion API changes
Files:
- `guest-libs/verify-stark/circuit/src/prover/mod.rs`
- `guest-libs/verify-stark/circuit/src/prover/trace.rs`

What changed:
- Sets `VerifierConfig.has_cached = true` explicitly where required.
- Uses `CachedTraceCtx::PcsData(...)` for recursion tracegen calls.

### 3.3 SDK/test call-site inference fixes after root prover generic changes
Files:
- `crates/sdk/src/prover/root.rs`
- `crates/continuations/src/tests/mod.rs`
- `crates/continuations/src/tests/e2e.rs`

What changed:
- Adds explicit PB typing where inference became ambiguous after moving root prover backend typing to method generics.

---

## 4) Test Updates

Files:
- `crates/recursion/src/tests.rs`

What changed:
- Adds coverage for no-cached DagCommit-subAIR path:
  - `test_recursion_circuit_dag_commit_subair`
  - uses `MixtureFixture::standard(...)`
  - builds verifier with `has_cached: false`
  - runs with `CachedTraceCtx::Records(...)`.
- Existing recursion tests updated to pass `CachedTraceCtx::PcsData(...)` where appropriate.

---

## Primary Reviewer Focus
If you only review a subset, prioritize:
1. `recursion` symbolic-expression + DagCommit integration (`air.rs`, `trace.rs`, `dag_commit.rs`, system wiring)
2. root prover no-cached migration (`continuations/prover/root/*`)
3. CUDA DagCommit tracegen plumbing (`symbolic_expression.cu`, `cuda_abi.rs`, `cuda_utils.rs`)
