### PR TITLE
perf(static-verifier): scalar_mul and specialized sample_bits in WHIR

### DIFF
--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -406,7 +406,6 @@ pub(crate) fn constrain_whir_verification(
     let mut profiler =
         crate::profiling::CellProfiler::new("whir_verification", ctx.advice.len());
 
-    let gate = ext_chip.range().gate();
     let base_chip = ext_chip.base();
     let params = &mvk0.params;
     let k_whir = params.k_whir();
@@ -454,10 +453,8 @@ pub(crate) fn constrain_whir_verification(
     let mut folding_alphas = Vec::new();
     let mut z0_challenges = Vec::new();
     let mut gammas = Vec::with_capacity(num_whir_rounds);
-    let mut query_indices = Vec::new();
     let mut folding_counts_per_round = Vec::with_capacity(num_whir_rounds);
     let mut query_counts_per_round = Vec::with_capacity(num_whir_rounds);
-    let mut query_index_bits = Vec::new();
     let mut zs_per_round = Vec::with_capacity(num_whir_rounds);
 
     let mut sumcheck_cursor = 0usize;
@@ -541,14 +538,8 @@ pub(crate) fn constrain_whir_verification(
 
         profiler.push("queries", ctx.advice.len());
         for query_idx in 0..num_queries {
-            let query_index = transcript.sample_bits(ctx, ext_chip.base(), query_bits);
-            query_index_bits.push(query_bits);
-            query_indices.push(query_index);
-            let query_bits_vec = if query_bits == 0 {
-                Vec::new()
-            } else {
-                gate.num_to_bits(ctx, query_index, query_bits)
-            };
+            let query_bits_vec =
+                transcript.sample_bits_as_bits(ctx, ext_chip.base(), query_bits);
             let zi_root = query_root_from_bits_assigned(
                 ctx,
                 ext_chip.base(),
@@ -573,12 +564,10 @@ pub(crate) fn constrain_whir_verification(
                         let mu_pow = mu_pows[mu_power_idx];
                         for (row_idx, row) in merkle_path.leaf_values.iter().enumerate() {
                             let opened_base = row[col_idx];
-                            let opened_ext = ext_chip.from_base_var(ctx, opened_base);
-                            let weighted = ext_chip.mul(ctx, opened_ext, mu_pow);
                             codeword_vals[row_idx] = if let Some(prev) = codeword_vals[row_idx] {
-                                Some(ext_chip.add(ctx, prev, weighted))
+                                Some(ext_chip.scalar_mul_add(ctx, mu_pow, opened_base, prev))
                             } else {
-                                Some(weighted)
+                                Some(ext_chip.scalar_mul(ctx, mu_pow, opened_base))
                             };
                         }
                         mu_power_idx += 1;

--- a/crates/static-verifier/src/transcript/mod.rs
+++ b/crates/static-verifier/src/transcript/mod.rs
@@ -3,8 +3,8 @@ use std::sync::OnceLock;
 use halo2_base::{
     gates::{range::RangeChip, GateInstructions, RangeInstructions},
     halo2_proofs::arithmetic::Field,
-    utils::{biguint_to_fe, fe_to_biguint},
-    AssignedValue, Context,
+    utils::{biguint_to_fe, fe_to_biguint, ScalarField},
+    AssignedValue, Context, QuantumCell,
 };
 use itertools::Itertools;
 use num_bigint::BigUint;
@@ -250,6 +250,83 @@ impl TranscriptGadget {
             BABY_BEAR_BITS,
         );
         rem
+    }
+
+    /// Optimized `sample_bits` for power-of-two moduli that returns the bit
+    /// decomposition directly, avoiding both the generic `div_mod` and the
+    /// caller's subsequent `num_to_bits`.
+    ///
+    /// Decomposes the reduced sample into `bits` boolean witnesses via
+    /// `inner_product` + `assert_bit`, then witnesses a quotient and
+    /// constrains `quotient * 2^bits + remainder == reduced_value`.
+    pub fn sample_bits_as_bits(
+        &mut self,
+        ctx: &mut Context<Fr>,
+        baby_bear: &BabyBearChip,
+        bits: usize,
+    ) -> Vec<AssignedValue<Fr>> {
+        assert!(
+            bits < (u32::BITS as usize),
+            "sample_bits_as_bits requires bits < 32: {bits}"
+        );
+        assert!(
+            (1u64 << bits) < BABY_BEAR_MODULUS_U64,
+            "sample_bits_as_bits requires (1 << bits) < modulus: bits={bits}"
+        );
+
+        if bits == 0 {
+            return Vec::new();
+        }
+        let sampled = self.sample(ctx, baby_bear);
+        // Reduce BabyBearWire so it is constrained to be less than BabyBear modulus
+        let sampled_reduced = baby_bear.reduce(ctx, sampled);
+        let gate = baby_bear.range().gate();
+        let range = baby_bear.range();
+        let val = sampled_reduced.value;
+
+        // Decompose the low `bits` of val into boolean witnesses via inner_product,
+        // mirroring the layout of GateChip::num_to_bits so we can extract cell refs.
+        let bit_witnesses = val
+            .value()
+            .to_u64_limbs(bits, 1)
+            .into_iter()
+            .map(|x| QuantumCell::Witness(Fr::from(x)));
+        let row_offset = ctx.advice.len();
+        let rem = gate.inner_product(
+            ctx,
+            bit_witnesses,
+            gate.pow_of_two[..bits]
+                .iter()
+                .map(|c| QuantumCell::Constant(*c)),
+        );
+
+        // Extract bit cells from inner_product layout (same indexing as num_to_bits)
+        let mut bit_cells = Vec::with_capacity(bits);
+        bit_cells.push(ctx.get(row_offset as isize));
+        for i in 1..bits {
+            bit_cells.push(ctx.get((row_offset + 1 + 3 * (i - 1)) as isize));
+        }
+        for &bit in &bit_cells {
+            gate.assert_bit(ctx, bit);
+        }
+
+        // Witness the quotient q = val >> bits, then constrain q * 2^bits + rem == val.
+        let q_val = fe_to_biguint(val.value()) >> bits;
+        let q = ctx.load_witness(biguint_to_fe::<Fr>(&q_val));
+        let reconstructed = gate.mul_add(
+            ctx,
+            QuantumCell::Existing(q),
+            QuantumCell::Constant(Fr::from(1u64 << bits)),
+            QuantumCell::Existing(rem),
+        );
+        ctx.constrain_equal(&reconstructed, &val);
+
+        // Range check quotient: q < 2^(BABY_BEAR_BITS - bits)
+        let q_range_bits =
+            (BABY_BEAR_BITS - bits).div_ceil(range.lookup_bits()) * range.lookup_bits();
+        range.range_check(ctx, q, q_range_bits);
+
+        bit_cells
     }
 
     /// Asserts that the PoW witness must pass.


### PR DESCRIPTION
## Summary
- Replace full extension multiply with `scalar_mul`/`scalar_mul_add` when batching opened base values by mu in the initial round query loop (~40.9k cells saved)
- Add `sample_bits_as_bits` to avoid generic `div_mod` + `num_to_bits` by directly decomposing into boolean witnesses with a quotient constraint (~2.8k cells saved)
- Remove dead `query_indices` and `query_index_bits` variables

Total cell count reduction: ~43,650 (~0.23%)

## Test plan
- [x] All 10 `openvm-static-verifier` tests pass (`cargo nextest run --cargo-profile=fast -p openvm-static-verifier --features cuda`)
- [x] Cell count verified via `pipeline_cell_count_profiling` with `--features cell-profiling,cuda`

🤖 Generated with [Claude Code](https://claude.com/claude-code)