### PR TITLE
chore: remove VmCommittedExe struct

### DIFF
--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -9,7 +9,9 @@ use openvm_circuit::{
         PreflightExecutor, VerifiedExecutionPayload, VirtualMachine, VirtualMachineError,
         VmBuilder, VmExecutionConfig, VmInstance, VmVerificationError,
     },
-    system::{memory::dimensions::MemoryDimensions, program::trace::VmCommittedExe},
+    system::{
+        memory::dimensions::MemoryDimensions, program::trace::compute_exe_commit_from_mem_config,
+    },
 };
 use openvm_stark_backend::{
     keygen::types::MultiStarkVerifyingKey, p3_field::PrimeField32, prover::ProverBackend,
@@ -89,7 +91,7 @@ where
     /// Returns commitment to the executable
     pub fn app_exe_commit(&self) -> Digest {
         *self.app_exe_commit.get_or_init(|| {
-            VmCommittedExe::<SC>::compute_exe_commit(
+            compute_exe_commit_from_mem_config(
                 &self.app_program_commit(),
                 self.instance.exe(),
                 &self.instance.vm.config().as_ref().memory_config,

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -64,7 +64,7 @@ use crate::{
             online::{GuestMemory, TracingMemory},
             AddressMap, CHUNK,
         },
-        program::trace::{generate_cached_trace, VmCommittedExe},
+        program::trace::generate_cached_trace,
         SystemChipComplex, SystemRecords, SystemWithFixedTraceHeights,
     },
 };
@@ -875,27 +875,6 @@ where
         }
     }
 
-    /// Convenience method to transport a host committed Exe to device. This can be used if you have
-    /// a pre-committed program and want to transport to device instead of re-committing. One should
-    /// benchmark the latency of this function versus
-    /// [`commit_program_on_device`](Self::commit_program_on_device), which directly re-commits on
-    /// device, to determine which method is more suitable.
-    pub fn transport_committed_exe_to_device(
-        &self,
-        committed_exe: &VmCommittedExe<E::SC>,
-    ) -> CommittedTraceData<E::PB> {
-        let data = &committed_exe.prover_data;
-        let trace = data.mat_view(0).to_matrix();
-        let d_trace = self.engine.device().transport_matrix_to_device(&trace);
-        let d_data = self.engine.device().transport_pcs_data_to_device(data);
-        let commitment = data.commit().unwrap();
-        CommittedTraceData {
-            commitment,
-            data: Arc::new(d_data),
-            trace: d_trace,
-        }
-    }
-
     /// Loads cached program trace into the VM.
     pub fn load_program(&mut self, cached_program_trace: CommittedTraceData<E::PB>) {
         self.chip_complex.system.load_program(cached_program_trace);
@@ -1197,8 +1176,8 @@ pub struct VerifiedExecutionPayload<F> {
 /// - `vk` is a valid verifying key of a VM circuit.
 ///
 /// Returns:
-/// - The commitment to the [VmCommittedExe] extracted from `proofs`. It is the responsibility of
-///   the caller to check that the returned commitment matches the VM executable that the VM was
+/// - The commitment to the VM executable extracted from `proofs`. It is the responsibility of the
+///   caller to check that the returned commitment matches the VM executable that the VM was
 ///   supposed to execute.
 /// - The Merkle root of the final memory state.
 ///

--- a/crates/vm/src/system/connector/tests.rs
+++ b/crates/vm/src/system/connector/tests.rs
@@ -1,11 +1,8 @@
-use std::{
-    borrow::{Borrow, BorrowMut},
-    sync::Arc,
-};
+use std::borrow::{Borrow, BorrowMut};
 
 use openvm_cpu_backend::CpuBackend;
 use openvm_instructions::{
-    instruction::Instruction, program::Program, LocalOpcode, SystemOpcode::TERMINATE,
+    exe::VmExe, instruction::Instruction, program::Program, LocalOpcode, SystemOpcode::TERMINATE,
 };
 use openvm_stark_backend::{
     p3_field::PrimeCharacteristicRing, prover::AirProvingContext, verifier::VerifierError,
@@ -22,7 +19,6 @@ use crate::{
     },
     system::{
         memory::{online::GuestMemory, AddressMap},
-        program::trace::VmCommittedExe,
         SystemCpuBuilder,
     },
     utils::test_cpu_engine,
@@ -77,13 +73,13 @@ fn test_impl(should_pass: bool, exit_code: u32, f: impl FnOnce(&mut AirProvingCo
     )];
 
     let program = Program::from_instructions(&instructions);
-    let committed_exe = Arc::new(VmCommittedExe::<SC>::commit(program.into(), &vm.engine));
+    let vm_exe: VmExe<F> = program.into();
     let max_trace_heights = vec![0; vk.inner.per_air.len()];
     let memory = GuestMemory::new(AddressMap::from_mem_config(&vm_config.memory_config));
     vm.transport_init_memory_to_device(&memory);
-    vm.load_program(vm.commit_program_on_device(&committed_exe.exe.program));
+    vm.load_program(vm.commit_program_on_device(&vm_exe.program));
     let from_state = VmState::new_with_defaults(0, memory, Streams::default(), 0);
-    let mut interpreter = vm.preflight_interpreter(&committed_exe.exe).unwrap();
+    let mut interpreter = vm.preflight_interpreter(&vm_exe).unwrap();
     let PreflightExecutionOutput {
         system_records,
         record_arenas,

--- a/crates/vm/src/system/cuda/program.rs
+++ b/crates/vm/src/system/cuda/program.rs
@@ -122,23 +122,23 @@ impl Chip<Vec<u32>, GpuBackend> for ProgramChipGPU {
 
 #[cfg(test)]
 mod tests {
-    use openvm_circuit::system::program::trace::VmCommittedExe;
-    use openvm_cuda_backend::{
-        data_transporter::assert_eq_host_and_device_matrix_col_maj,
-        prelude::{F, SC},
-    };
+    use std::sync::Arc;
+
+    use openvm_cuda_backend::{data_transporter::assert_eq_host_and_device_matrix, prelude::F};
     use openvm_instructions::{
-        exe::VmExe,
         instruction::Instruction,
         program::{Program, DEFAULT_PC_STEP},
         LocalOpcode,
         SystemOpcode::*,
     };
-    use openvm_stark_backend::StarkEngine;
+    use openvm_stark_backend::{prover::TraceCommitter, StarkEngine};
 
     use super::ProgramChipGPU;
     use crate::{
-        system::program::tests::{BEQ, BNE, JAL, STOREW, SUB},
+        system::program::{
+            tests::{BEQ, BNE, JAL, STOREW, SUB},
+            trace::generate_cached_trace,
+        },
         utils::{test_cpu_engine, test_gpu_engine},
     };
 
@@ -149,13 +149,13 @@ mod tests {
         let gpu_cached = ProgramChipGPU::get_committed_trace(gpu_trace, gpu_device);
 
         let cpu_engine = test_cpu_engine();
-        let cpu_exe = VmExe::new(program.clone());
-        let cpu_committed_exe = VmCommittedExe::<SC>::commit(cpu_exe, &cpu_engine);
-        let cpu_cached = cpu_committed_exe.get_committed_trace();
+        let cpu_device = cpu_engine.device();
+        let cpu_trace = Arc::new(generate_cached_trace(&program));
+        let (cpu_commit, _) = cpu_device.commit(&[&cpu_trace]).unwrap();
 
         // NOTE: This compares the stacked matrices, not the original cached trace
-        assert_eq_host_and_device_matrix_col_maj(&cpu_cached.trace, &gpu_cached.trace);
-        assert_eq!(gpu_cached.commitment, cpu_cached.commitment);
+        assert_eq_host_and_device_matrix(cpu_trace, &gpu_cached.trace);
+        assert_eq!(gpu_cached.commitment, cpu_commit);
     }
 
     #[test]

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -15,15 +15,11 @@ use openvm_stark_backend::{
     test_utils::dummy_airs::interaction::dummy_interaction_air::DummyInteractionAir,
     StarkEngine, StarkTestError,
 };
-use openvm_stark_sdk::{
-    config::baby_bear_poseidon2::BabyBearPoseidon2Config, p3_baby_bear::BabyBear,
-};
-use serde::{de::DeserializeOwned, Serialize};
-use static_assertions::assert_impl_all;
+use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 use crate::{
     arch::{instructions::SystemOpcode::*, testing::READ_INSTRUCTION_BUS},
-    system::program::{trace::VmCommittedExe, ProgramAir, ProgramBus, ProgramChip},
+    system::program::{trace::generate_cached_trace, ProgramAir, ProgramBus, ProgramChip},
     utils::test_cpu_engine,
 };
 
@@ -35,8 +31,6 @@ pub(crate) const BEQ: VmOpcode = VmOpcode::from_usize(0x220);
 pub(crate) const SUB: VmOpcode = VmOpcode::from_usize(0x201);
 pub(crate) const JAL: VmOpcode = VmOpcode::from_usize(0x230);
 pub(crate) const BNE: VmOpcode = VmOpcode::from_usize(0x221);
-
-assert_impl_all!(VmCommittedExe<BabyBearPoseidon2Config>: Serialize, DeserializeOwned);
 
 fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
     let mut execution_frequencies = vec![0; program.len()];
@@ -57,13 +51,12 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
 
     let engine = test_cpu_engine();
     let exe = VmExe::new(program);
-    let committed_exe = VmCommittedExe::<BabyBearPoseidon2Config>::commit(exe, &engine);
-    let (commitment, pcs_data) =
-        TraceCommitter::commit(engine.device(), &[committed_exe.trace.as_ref()]).unwrap();
+    let cached_trace = generate_cached_trace(&exe.program);
+    let (commitment, pcs_data) = TraceCommitter::commit(engine.device(), &[&cached_trace]).unwrap();
     let cached = CommittedTraceData {
         commitment,
         data: Arc::new(pcs_data),
-        trace: committed_exe.trace.as_ref().clone(),
+        trace: cached_trace,
     };
     let chip = ProgramChip {
         filtered_exec_frequencies,
@@ -74,9 +67,8 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
 
     let counter_air = DummyInteractionAir::new(9, true, bus.inner.index);
     let mut program_cells = vec![];
-    let program = &committed_exe.exe.program;
     for (index, frequency) in execution_frequencies.into_iter().enumerate() {
-        let option = program.get_instruction_and_debug_info(index);
+        let option = exe.program.get_instruction_and_debug_info(index);
         if let Some((instruction, _)) = option {
             program_cells.extend([
                 BabyBear::from_u32(frequency),
@@ -171,13 +163,12 @@ fn test_program_negative() {
     let execution_frequencies = vec![1; instructions.len()];
     let engine = test_cpu_engine();
     let exe = VmExe::new(program);
-    let committed_exe = VmCommittedExe::<BabyBearPoseidon2Config>::commit(exe, &engine);
-    let (commitment, pcs_data) =
-        TraceCommitter::commit(engine.device(), &[committed_exe.trace.as_ref()]).unwrap();
+    let cached_trace = generate_cached_trace(&exe.program);
+    let (commitment, pcs_data) = TraceCommitter::commit(engine.device(), &[&cached_trace]).unwrap();
     let cached = CommittedTraceData {
         commitment,
         data: Arc::new(pcs_data),
-        trace: committed_exe.trace.as_ref().clone(),
+        trace: cached_trace,
     };
     let chip = ProgramChip {
         filtered_exec_frequencies: execution_frequencies.clone(),

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -70,8 +70,7 @@ pub fn compute_exe_commit_from_mem_config<F: PrimeField32>(
 ) -> [F; CHUNK] {
     let hasher = vm_poseidon2_hasher();
     let memory_dimensions = memory_config.memory_dimensions();
-    let mem_config = memory_config;
-    let mut memory_image = AddressMap::new(mem_config.addr_spaces.clone());
+    let mut memory_image = AddressMap::new(memory_config.addr_spaces.clone());
     memory_image.set_from_sparse(&exe.init_memory);
     let init_memory_commit =
         MerkleTree::from_memory(&memory_image, &memory_dimensions, &hasher).root();

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -1,6 +1,5 @@
-use std::{borrow::BorrowMut, sync::Arc};
+use std::borrow::BorrowMut;
 
-use derivative::Derivative;
 use itertools::Itertools;
 use openvm_circuit::{arch::hasher::poseidon2::Poseidon2Hasher, primitives::Chip};
 use openvm_cpu_backend::CpuBackend;
@@ -13,13 +12,9 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
     p3_maybe_rayon::prelude::*,
-    prover::{
-        stacked_pcs::StackedPcsData, AirProvingContext, ColMajorMatrix, CommittedTraceData,
-        CpuColMajorBackend, ReferenceDevice, TraceCommitter,
-    },
-    Com, StarkEngine, StarkProtocolConfig, Val,
+    prover::AirProvingContext,
+    StarkProtocolConfig, Val,
 };
-use serde::{Deserialize, Serialize};
 
 use super::{Instruction, ProgramExecutionCols, EXIT_CODE_FAIL};
 use crate::{
@@ -32,87 +27,6 @@ use crate::{
         program::ProgramChip,
     },
 };
-
-/// **Note**: this struct stores the program ROM twice: once in [VmExe] and once as a cached trace
-/// matrix `trace`.
-#[derive(Serialize, Deserialize, Derivative)]
-#[serde(bound(
-    serialize = "VmExe<Val<SC>>: Serialize, Com<SC>: Serialize",
-    deserialize = "VmExe<Val<SC>>: Deserialize<'de>, Com<SC>: Deserialize<'de>"
-))]
-#[derivative(Clone(bound = "Com<SC>: Clone"))]
-pub struct VmCommittedExe<SC: StarkProtocolConfig> {
-    /// Raw executable.
-    pub exe: Arc<VmExe<Val<SC>>>,
-    program_commitment: Com<SC>,
-    /// Program ROM as cached trace matrix.
-    pub trace: Arc<RowMajorMatrix<Val<SC>>>,
-    pub prover_data: Arc<StackedPcsData<SC::F, SC::Digest>>,
-}
-
-impl<SC: StarkProtocolConfig> VmCommittedExe<SC> {
-    /// Creates [VmCommittedExe] from [VmExe] by using `pcs` to commit to the
-    /// program code as a _cached trace_ matrix.
-    pub fn commit<E: StarkEngine<SC = SC>>(exe: VmExe<Val<SC>>, e: &E) -> Self {
-        let trace = generate_cached_trace(&exe.program);
-        let ref_device = ReferenceDevice::new(e.config().clone());
-        let (commit, prover_data) = ref_device
-            .commit(&[&ColMajorMatrix::from_row_major(&trace)])
-            .unwrap();
-        Self {
-            exe: Arc::new(exe),
-            program_commitment: commit,
-            trace: Arc::new(trace),
-            prover_data: Arc::new(prover_data),
-        }
-    }
-    pub fn get_program_commit(&self) -> Com<SC> {
-        self.program_commitment
-    }
-
-    pub fn get_committed_trace(&self) -> CommittedTraceData<CpuColMajorBackend<SC>> {
-        CommittedTraceData {
-            commitment: self.prover_data.commit().unwrap(),
-            data: self.prover_data.clone(),
-            trace: ColMajorMatrix::from_row_major(&self.trace),
-        }
-    }
-
-    /// Computes a commitment to [VmCommittedExe]. This is a Merklelized hash of:
-    /// - Program code commitment (commitment of the cached trace)
-    /// - Merkle root of the initial memory
-    /// - Starting program counter (`pc_start`)
-    ///
-    /// The program code commitment is itself a commitment (via the proof system PCS) to
-    /// the program code.
-    ///
-    /// The Merklelization uses Poseidon2 as a cryptographic hash function (for the leaves)
-    /// and a cryptographic compression function (for internal nodes).
-    ///
-    /// **Note**: This function recomputes the Merkle tree for the initial memory image.
-    pub fn compute_exe_commit(
-        program_commitment: &[Val<SC>; CHUNK],
-        exe: &VmExe<Val<SC>>,
-        memory_config: &MemoryConfig,
-    ) -> [Val<SC>; CHUNK]
-    where
-        Val<SC>: PrimeField32,
-    {
-        let hasher = vm_poseidon2_hasher();
-        let memory_dimensions = memory_config.memory_dimensions();
-        let mem_config = memory_config;
-        let mut memory_image = AddressMap::new(mem_config.addr_spaces.clone());
-        memory_image.set_from_sparse(&exe.init_memory);
-        let init_memory_commit =
-            MerkleTree::from_memory(&memory_image, &memory_dimensions, &hasher).root();
-        compute_exe_commit(
-            &hasher,
-            program_commitment,
-            &init_memory_commit,
-            Val::<SC>::from_u32(exe.pc_start),
-        )
-    }
-}
 
 impl<SC: StarkProtocolConfig> Chip<(), CpuBackend<SC>> for ProgramChip<SC> {
     /// The cached program trace is cloned and left for future use. The clone is cheap because the
@@ -135,6 +49,38 @@ impl<SC: StarkProtocolConfig> Chip<(), CpuBackend<SC>> for ProgramChip<SC> {
             public_values: vec![],
         }
     }
+}
+
+/// Computes a commitment to a VM executable. This is a Merklelized hash of:
+/// - Program code commitment (commitment of the cached trace)
+/// - Merkle root of the initial memory
+/// - Starting program counter (`pc_start`)
+///
+/// The program code commitment is itself a commitment (via the proof system PCS) to
+/// the program code.
+///
+/// The Merklelization uses Poseidon2 as a cryptographic hash function (for the leaves)
+/// and a cryptographic compression function (for internal nodes).
+///
+/// **Note**: This function recomputes the Merkle tree for the initial memory image.
+pub fn compute_exe_commit_from_mem_config<F: PrimeField32>(
+    program_commitment: &[F; CHUNK],
+    exe: &VmExe<F>,
+    memory_config: &MemoryConfig,
+) -> [F; CHUNK] {
+    let hasher = vm_poseidon2_hasher();
+    let memory_dimensions = memory_config.memory_dimensions();
+    let mem_config = memory_config;
+    let mut memory_image = AddressMap::new(mem_config.addr_spaces.clone());
+    memory_image.set_from_sparse(&exe.init_memory);
+    let init_memory_commit =
+        MerkleTree::from_memory(&memory_image, &memory_dimensions, &hasher).root();
+    compute_exe_commit(
+        &hasher,
+        program_commitment,
+        &init_memory_commit,
+        F::from_u32(exe.pc_start),
+    )
 }
 
 /// Computes a Merklelized hash of:


### PR DESCRIPTION
Resolves INT-4505. Removes `VmCommittedExe`, which is currently a test-only utility.