### PR TITLE
perf(static-verifier): optimize cell count and wire up SDK EVM proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,7 +3304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4786,7 +4786,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9148,7 +9148,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10363,7 +10363,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11532,7 +11532,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,17 +105,268 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-chains"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9247f0a399ef71aeb68f497b2b8fb348014f742b50d3b83b1e00dfe1b7d64b3d"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "serde",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "arbitrary",
+ "derive_more 2.1.1",
+ "itoa",
+ "proptest",
+ "serde",
+ "serde_json",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "op-alloy",
+ "op-revm",
+ "revm 33.1.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more 2.1.1",
  "foldhash 0.2.0",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -123,6 +374,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
+ "proptest-derive",
  "rand 0.9.2",
  "rapidhash",
  "ruint 1.17.2",
@@ -132,13 +384,368 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d181c8cc7cf4805d7e589bf4074d56d55064fa1a979f005a45a62b047616d870"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.16.3",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8bd82953194dec221aa4cbbbb0b1e2df46066fe9d0333ac25b43a311e122d13"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "auto_impl",
+ "bimap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2792758a93ae32a32e9047c843d536e1448044f78422d71bf7d7c05149e103f"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ac61f03f1edabccde1c687b5b25fff28f183afee64eaa2e767def3929e4457"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more 2.1.1",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive",
+ "jsonwebtoken",
+ "rand 0.8.5",
+ "serde",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve 0.13.8",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.13.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "syn 2.0.117",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
+dependencies = [
+ "alloy-json-rpc",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more 2.1.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "itertools 0.14.0",
+ "reqwest 0.12.28",
+ "serde_json",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ef85688e5ac2da72afc804e0a1f153a1f309f05a864b1998bbbed7804dbaab"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-pubsub",
+ "alloy-transport",
+ "bytes",
+ "futures",
+ "interprocess",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f00445db69d63298e2b00a0ea1d859f00e6424a3144ffc5eba9c31da995e16"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http 1.4.0",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 2.1.1",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -155,6 +762,17 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "ansi_term"
@@ -259,6 +877,21 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
 
 [[package]]
 name = "ark-bn254"
@@ -283,6 +916,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,12 +948,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff 0.4.2",
- "ark-poly",
+ "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-integer",
  "num-traits",
  "zeroize",
 ]
@@ -453,6 +1119,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,7 +1178,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint 0.4.6",
@@ -480,6 +1190,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -495,6 +1206,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -552,6 +1274,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,10 +1307,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
 
 [[package]]
 name = "auto_impl"
@@ -695,10 +1469,10 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "lru",
+ "lru 0.12.5",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -747,7 +1521,7 @@ dependencies = [
  "p256 0.11.1",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -781,7 +1555,7 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -961,6 +1735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,10 +1837,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1064,6 +1869,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -1086,6 +1892,15 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "constant_time_eq",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1202,6 +2017,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +2061,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1246,6 +2080,21 @@ name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
+name = "c-kzg"
+version = "2.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "camino"
@@ -1280,7 +2129,7 @@ dependencies = [
  "target-lexicon 0.12.16",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "toml_edit 0.22.27",
  "tracing",
  "vergen",
@@ -1326,6 +2175,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1398,6 +2253,9 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1441,6 +2299,27 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1517,6 +2396,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1695,6 +2584,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +2682,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -1790,6 +2712,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
@@ -1798,6 +2734,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
  "syn 2.0.117",
 ]
@@ -1812,6 +2749,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1851,6 +2799,12 @@ dependencies = [
  "parking_lot_core",
  "rayon",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -1910,6 +2864,28 @@ name = "derive-new"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2007,10 +2983,31 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2022,6 +3019,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2121,6 +3133,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elf"
@@ -2198,6 +3213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +3287,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +3335,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_serde_utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "ethereum_ssz"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +3356,33 @@ dependencies = [
  "ethereum-types",
  "itertools 0.10.5",
  "smallvec",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2388,6 +3463,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +3492,17 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2424,12 +3524,265 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "forge-fmt"
+version = "1.5.0"
+source = "git+https://github.com/foundry-rs/foundry.git?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+dependencies = [
+ "foundry-common",
+ "foundry-config",
+ "itertools 0.14.0",
+ "similar",
+ "solar-compiler",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foundry-block-explorers"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff814624bb21bfe43b70fb736ab39527b405d04cdc94d90b7e182fba28b25ec7"
+dependencies = [
+ "alloy-chains",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "foundry-compilers",
+ "reqwest 0.12.28",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "foundry-common"
+version = "1.5.0"
+source = "git+https://github.com/foundry-rs/foundry.git?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-eips",
+ "alloy-json-abi",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "anstream 0.6.21",
+ "anstyle",
+ "chrono",
+ "ciborium",
+ "clap",
+ "comfy-table",
+ "dunce",
+ "eyre",
+ "flate2",
+ "foundry-block-explorers",
+ "foundry-common-fmt",
+ "foundry-compilers",
+ "itertools 0.14.0",
+ "jiff",
+ "num-format",
+ "path-slash",
+ "regex",
+ "reqwest 0.12.28",
+ "revm 33.1.0",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "solar-compiler",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "vergen",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-common-fmt"
+version = "1.5.0"
+source = "git+https://github.com/foundry-rs/foundry.git?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "chrono",
+ "eyre",
+ "revm 33.1.0",
+ "serde",
+ "serde_json",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-compilers"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e639f98fe54d1cc0011a4bdb2eb1d838b379c9f004991ae7555a4cc09e8da32a"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "dyn-clone",
+ "foundry-compilers-artifacts",
+ "foundry-compilers-core",
+ "itertools 0.14.0",
+ "path-slash",
+ "rayon",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "solar-compiler",
+ "svm-rs",
+ "svm-rs-builds",
+ "thiserror 2.0.18",
+ "tracing",
+ "winnow 0.7.15",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-compilers-artifacts"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ec96df20055211f4e46b5a61fa479b2ea7d1ce0659818e0359afadfcded8d2"
+dependencies = [
+ "foundry-compilers-artifacts-solc",
+ "foundry-compilers-artifacts-vyper",
+]
+
+[[package]]
+name = "foundry-compilers-artifacts-solc"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a206e475b5dd1a77dc33cd917cde4846148f5136729a24edb3a16ab431b90a"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "foundry-compilers-core",
+ "memchr",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-compilers-artifacts-vyper"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74883db8036522fa21d0853c21ac318e165ec88e141f1ef1d6f7b4dfa841ff7"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "foundry-compilers-artifacts-solc",
+ "foundry-compilers-core",
+ "path-slash",
+ "semver 1.0.27",
+ "serde",
+]
+
+[[package]]
+name = "foundry-compilers-core"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab384daeaea5c33cad8c3c094a1eb6f98e70922e18380c660980c74c19e362b"
+dependencies = [
+ "alloy-primitives",
+ "cfg-if",
+ "dunce",
+ "path-slash",
+ "regex",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "svm-rs",
+ "thiserror 2.0.18",
+ "tokio",
+ "walkdir",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "foundry-config"
+version = "1.5.0"
+source = "git+https://github.com/foundry-rs/foundry.git?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+dependencies = [
+ "alloy-chains",
+ "alloy-primitives",
+ "clap",
+ "dirs",
+ "dunce",
+ "eyre",
+ "figment",
+ "foundry-block-explorers",
+ "foundry-compilers",
+ "foundry-evm-networks",
+ "glob",
+ "globset",
+ "heck",
+ "itertools 0.14.0",
+ "mesc",
+ "number_prefix",
+ "path-slash",
+ "rayon",
+ "regex",
+ "reqwest 0.12.28",
+ "revm 33.1.0",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "solar-compiler",
+ "soldeer-core",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.23.10+spec-1.0.0",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-evm-networks"
+version = "1.5.0"
+source = "git+https://github.com/foundry-rs/foundry.git?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+dependencies = [
+ "alloy-chains",
+ "alloy-evm",
+ "alloy-primitives",
+ "clap",
+ "revm 33.1.0",
+ "serde",
 ]
 
 [[package]]
@@ -2443,6 +3796,21 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -2459,6 +3827,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-intrusive"
@@ -2478,6 +3857,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,14 +3885,22 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generational-arena"
@@ -2544,9 +3942,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2599,6 +3999,29 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfc928d8ff4ab3767a3674cf55f81186436fb6070866bb1443ffe65a640d2d6"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "group"
@@ -2763,7 +4186,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_arrays",
- "sha2",
+ "sha2 0.10.9",
  "static_assertions",
  "subtle",
  "unroll",
@@ -2790,7 +4213,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_arrays",
- "sha2",
+ "sha2 0.10.9",
  "static_assertions",
  "subtle",
  "unroll",
@@ -2837,7 +4260,11 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2871,6 +4298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,6 +4328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2992,6 +4437,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3012,9 +4458,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3156,6 +4604,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +4683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
+name = "index_vec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44faf5bb8861a9c72e20d3fb0fdbd59233e43056e2b80475ab0aacdc2e781355"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +4705,7 @@ version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
+ "arbitrary",
  "equivalent",
  "hashbrown 0.16.1",
  "serde",
@@ -3258,10 +4729,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "inturn"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2efbe120e37f17bb33fcdc82bc1c65087242608be37ace3cf7ebf49f3164e37"
+dependencies = [
+ "boxcar",
+ "bumpalo",
+ "dashmap",
+ "hashbrown 0.14.5",
+ "thread_local",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -3323,6 +4838,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +4923,21 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -3400,7 +4998,8 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
- "sha2",
+ "serdect",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3501,6 +5100,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64 0.22.1",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,6 +5176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,6 +5201,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -3558,6 +5212,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3620,6 +5300,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
+name = "mesc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04b0347d2799ef17df4623dbcb03531031142105168e0c549e0bf1f980e9e7e"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "metrics"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,7 +5334,7 @@ dependencies = [
  "once_cell",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -3675,12 +5366,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3704,12 +5412,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-path"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -3733,6 +5461,15 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "serde",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3761,6 +5498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-modular"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3779,12 +5527,23 @@ checksum = "e238432a7881ec7164503ccc516c014bf009be7984cde1ba56837862543bdec3"
 dependencies = [
  "bitvec",
  "either",
- "lru",
+ "lru 0.12.5",
  "num-bigint 0.4.6",
  "num-integer",
  "num-modular",
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3808,12 +5567,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint 1.17.2",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -3860,10 +5661,141 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "once_map"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29eefd5038c9eee9e788d90966d6b5578dd3f88363a91edaec117a7ae0adc2d5"
+dependencies = [
+ "ahash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "op-alloy"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b13412d297c1f9341f678b763750b120a73ffe998fa54a94d6eda98449e7ca"
+dependencies = [
+ "op-alloy-consensus",
+ "op-alloy-network",
+ "op-alloy-provider",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more 2.1.1",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63f27e65be273ec8fcb0b6af0fd850b550979465ab93423705ceb3dfddbd2ab"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
+]
+
+[[package]]
+name = "op-alloy-provider"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71456699aa256dc20119736422ad9a44da8b9585036117afb936778122093b9"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
+ "async-trait",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562dd4462562c41f9fdc4d860858c40e14a25df7f983ae82047f15f08fce4d19"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more 2.1.1",
+ "op-alloy-consensus",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f24b8cb66e4b33e6c9e508bf46b8ecafc92eadd0b93fedd306c0accb477657"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "derive_more 2.1.1",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive",
+ "op-alloy-consensus",
+ "serde",
+ "snap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-revm"
+version = "14.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
+dependencies = [
+ "auto_impl",
+ "revm 33.1.0",
+ "serde",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -3918,7 +5850,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_with",
- "strum",
+ "strum 0.26.3",
  "test-case",
 ]
 
@@ -3943,7 +5875,7 @@ dependencies = [
  "openvm-custom-insn",
  "openvm-rv32im-guest",
  "serde-big-array",
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -3984,7 +5916,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-transpiler",
  "rrs-lib",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4020,7 +5952,7 @@ name = "openvm-bigint-guest"
 version = "2.0.0-alpha"
 dependencies = [
  "openvm-platform",
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -4034,7 +5966,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-transpiler",
  "rrs-lib",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4296,7 +6228,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "static_assertions",
- "strum",
+ "strum 0.26.3",
  "test-case",
  "test-log",
 ]
@@ -4306,7 +6238,7 @@ name = "openvm-deferral-guest"
 version = "2.0.0-alpha"
 dependencies = [
  "openvm-custom-insn",
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -4341,7 +6273,7 @@ dependencies = [
  "p3-field",
  "rrs-lib",
  "serde",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4375,7 +6307,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_with",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4393,7 +6325,7 @@ dependencies = [
  "openvm-ecc-sw-macros",
  "openvm-rv32im-guest",
  "serde",
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -4416,7 +6348,7 @@ dependencies = [
  "openvm-transpiler",
  "serde",
  "serde_with",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -4438,7 +6370,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-transpiler",
  "rrs-lib",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4480,8 +6412,8 @@ dependencies = [
  "p3-baby-bear",
  "rand 0.9.2",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -4490,8 +6422,8 @@ version = "2.0.0-alpha"
 dependencies = [
  "openvm-instructions",
  "quote",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "syn 2.0.117",
 ]
 
@@ -4537,7 +6469,7 @@ dependencies = [
  "p3-keccak-air",
  "rand 0.9.2",
  "serde",
- "strum",
+ "strum 0.26.3",
  "tiny-keccak",
  "tokio",
 ]
@@ -4559,7 +6491,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-transpiler",
  "rrs-lib",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4659,7 +6591,7 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "serde",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4680,7 +6612,7 @@ dependencies = [
  "openvm-ecc-guest",
  "rand 0.8.5",
  "serde",
- "strum_macros",
+ "strum_macros 0.26.4",
  "subtle",
 ]
 
@@ -4693,7 +6625,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-transpiler",
  "rrs-lib",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -4761,8 +6693,8 @@ dependencies = [
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-symmetric",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "test-case",
  "tracing",
 ]
@@ -4815,7 +6747,7 @@ dependencies = [
  "openvm-stark-sdk",
  "rand 0.9.2",
  "serde",
- "strum",
+ "strum 0.26.3",
  "test-case",
 ]
 
@@ -4825,7 +6757,7 @@ version = "2.0.0-alpha"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -4843,7 +6775,7 @@ dependencies = [
  "openvm-toolchain-tests",
  "openvm-transpiler",
  "serde",
- "strum",
+ "strum 0.26.3",
  "test-case",
 ]
 
@@ -4858,7 +6790,7 @@ dependencies = [
  "openvm-transpiler",
  "rrs-lib",
  "serde",
- "strum",
+ "strum 0.26.3",
  "tracing",
 ]
 
@@ -4878,6 +6810,7 @@ dependencies = [
 name = "openvm-sdk"
 version = "2.0.0-alpha"
 dependencies = [
+ "alloy-sol-types",
  "bitcode",
  "bon",
  "cfg-if",
@@ -4886,7 +6819,9 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
+ "forge-fmt",
  "getset",
+ "halo2-base",
  "hex",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4900,16 +6835,19 @@ dependencies = [
  "openvm-sdk-config",
  "openvm-stark-backend",
  "openvm-stark-sdk",
+ "openvm-static-verifier",
  "openvm-toolchain-tests",
  "openvm-transpiler",
  "openvm-verify-stark-circuit",
  "openvm-verify-stark-host",
+ "p3-bn254",
  "serde",
  "serde_json",
  "serde_with",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
 ]
 
@@ -4944,7 +6882,7 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-transpiler",
  "serde",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -4961,7 +6899,7 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-toolchain-tests",
  "openvm-transpiler",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4974,7 +6912,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "rand 0.9.2",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5000,8 +6938,8 @@ dependencies = [
  "openvm-stark-sdk",
  "rand 0.9.2",
  "serde",
- "sha2",
- "strum",
+ "sha2 0.10.9",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -5021,7 +6959,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-transpiler",
  "rrs-lib",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -5084,7 +7022,7 @@ dependencies = [
  "static_assertions",
  "tracing",
  "tracing-forest",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "zkhash",
 ]
 
@@ -5097,6 +7035,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
+ "once_cell",
  "openvm-circuit-primitives-derive",
  "openvm-continuations",
  "openvm-cpu-backend",
@@ -5107,6 +7046,7 @@ dependencies = [
  "openvm-verify-stark-host",
  "rand_chacha 0.3.1",
  "serde",
+ "serde_json",
  "serde_with",
  "snark-verifier-sdk",
  "tracing",
@@ -5210,6 +7150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5232,7 +7178,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5265,6 +7211,18 @@ dependencies = [
  "openvm-transpiler",
  "rand 0.9.2",
  "serde",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5602,6 +7560,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5627,13 +7624,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+ "serde",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -5643,6 +7717,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5718,6 +7812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "poseidon-primitives"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5772,7 +7875,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand 0.9.2",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
 ]
 
@@ -5819,6 +7922,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -5885,6 +7997,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "proptest"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5901,6 +8026,17 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5977,6 +8113,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6022,6 +8214,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -6032,6 +8225,7 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -6080,6 +8274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
 ]
 
 [[package]]
@@ -6112,6 +8307,7 @@ version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
+ "rand 0.9.2",
  "rustversion",
 ]
 
@@ -6145,12 +8341,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6218,6 +8431,471 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "revm"
+version = "27.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6bf82101a1ad8a2b637363a37aef27f88b4efc8a6e24c72bf5f64923dc5532"
+dependencies = [
+ "revm-bytecode 6.2.2",
+ "revm-context 8.0.4",
+ "revm-context-interface 9.0.0",
+ "revm-database 7.0.5",
+ "revm-database-interface 7.0.5",
+ "revm-handler 8.1.0",
+ "revm-inspector 8.1.0",
+ "revm-interpreter 24.0.0",
+ "revm-precompile 25.0.0",
+ "revm-primitives 20.2.1",
+ "revm-state 7.0.5",
+]
+
+[[package]]
+name = "revm"
+version = "33.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
+dependencies = [
+ "revm-bytecode 7.1.1",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database 9.0.6",
+ "revm-database-interface 8.0.5",
+ "revm-handler 14.1.0",
+ "revm-inspector 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
+dependencies = [
+ "bitvec",
+ "phf 0.11.3",
+ "revm-primitives 20.2.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
+dependencies = [
+ "bitvec",
+ "phf 0.13.1",
+ "revm-primitives 21.0.2",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd508416a35a4d8a9feaf5ccd06ac6d6661cd31ee2dc0252f9f7316455d71f9"
+dependencies = [
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 6.2.2",
+ "revm-context-interface 9.0.0",
+ "revm-database-interface 7.0.5",
+ "revm-primitives 20.2.1",
+ "revm-state 7.0.5",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "12.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 7.1.1",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90302642d21c8f93e0876e201f3c5f7913c4fcb66fb465b0fd7b707dfe1c79"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 7.0.5",
+ "revm-primitives 20.2.1",
+ "revm-state 7.0.5",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode 6.2.2",
+ "revm-database-interface 7.0.5",
+ "revm-primitives 20.2.1",
+ "revm-state 7.0.5",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "9.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode 7.1.1",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 20.2.1",
+ "revm-state 7.0.5",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1529c8050e663be64010e80ec92bf480315d21b1f2dbf65540028653a621b27d"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 6.2.2",
+ "revm-context 8.0.4",
+ "revm-context-interface 9.0.0",
+ "revm-database-interface 7.0.5",
+ "revm-interpreter 24.0.0",
+ "revm-precompile 25.0.0",
+ "revm-primitives 20.2.1",
+ "revm-state 7.0.5",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "14.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 7.1.1",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78db140e332489094ef314eaeb0bd1849d6d01172c113ab0eb6ea8ab9372926"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 8.0.4",
+ "revm-database-interface 7.0.5",
+ "revm-handler 8.1.0",
+ "revm-interpreter 24.0.0",
+ "revm-primitives 20.2.1",
+ "revm-state 7.0.5",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "14.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 12.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-handler 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9d7d9d71e8a33740b277b602165b6e3d25fff091ba3d7b5a8d373bf55f28a7"
+dependencies = [
+ "revm-bytecode 6.2.2",
+ "revm-context-interface 9.0.0",
+ "revm-primitives 20.2.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "31.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
+dependencies = [
+ "revm-bytecode 7.1.1",
+ "revm-context-interface 13.1.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cee3f336b83621294b4cfe84d817e3eef6f3d0fce00951973364cc7f860424d"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsecp256k1",
+ "once_cell",
+ "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 20.2.1",
+ "ripemd",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 21.0.2",
+ "ripemd",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "20.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
+dependencies = [
+ "bitflags",
+ "revm-bytecode 6.2.2",
+ "revm-primitives 20.2.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
+dependencies = [
+ "bitflags",
+ "revm-bytecode 7.1.1",
+ "revm-primitives 21.0.2",
+ "serde",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6262,6 +8940,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6295,6 +8982,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rug"
+version = "1.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f6c8f906c90b48e0c1745c9f814c3a31c5eba847043b05c3e9a934dec7c4b3"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
+]
+
+[[package]]
 name = "ruint"
 version = "1.14.0"
 dependencies = [
@@ -6313,7 +9012,7 @@ dependencies = [
  "criterion",
  "der 0.7.10",
  "diesel",
- "ethereum_ssz",
+ "ethereum_ssz 0.5.4",
  "eyre",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -6359,6 +9058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
@@ -6410,6 +9110,9 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -6456,6 +9159,7 @@ checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -6480,8 +9184,36 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6529,6 +9261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanitize-filename"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6560,6 +9301,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6597,13 +9344,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.2",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6646,6 +9434,12 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -6696,11 +9490,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_fmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e497af288b3b95d067a23a4f749f2861121ffcb2f6d8379310dcda040c345ed"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -6714,6 +9518,27 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -6780,6 +9605,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -6859,6 +9697,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6881,6 +9743,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "snark-verifier"
@@ -6898,6 +9769,7 @@ dependencies = [
  "num-traits",
  "pairing 0.23.0",
  "rand 0.8.5",
+ "revm 27.1.0",
  "ruint 1.17.2",
  "serde",
  "sha3",
@@ -6934,6 +9806,183 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "solar-ast"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6aaf98d032ba3be85dca5f969895ade113a9137bb5956f80c5faf14689de59"
+dependencies = [
+ "alloy-primitives",
+ "bumpalo",
+ "either",
+ "num-rational",
+ "semver 1.0.27",
+ "solar-data-structures",
+ "solar-interface",
+ "solar-macros",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "solar-compiler"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e792060bcbb007a6b9b060292945fb34ff854c7d93a9628f81b6c809eb4360"
+dependencies = [
+ "alloy-primitives",
+ "solar-ast",
+ "solar-config",
+ "solar-data-structures",
+ "solar-interface",
+ "solar-macros",
+ "solar-parse",
+ "solar-sema",
+]
+
+[[package]]
+name = "solar-config"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff16d692734c757edd339f5db142ba91b42772f8cbe1db1ce3c747f1e777185f"
+dependencies = [
+ "colorchoice",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "solar-data-structures"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dea34e58332c7d6a8cde1f1740186d31682b7be46e098b8cc16fcb7ffd98bf5"
+dependencies = [
+ "bumpalo",
+ "index_vec",
+ "indexmap 2.13.0",
+ "parking_lot",
+ "rayon",
+ "rustc-hash 2.1.1",
+ "smallvec",
+]
+
+[[package]]
+name = "solar-interface"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6163af2e773f4d455212fa9ba2c0664506029dd26232eb406f5046092ac311"
+dependencies = [
+ "annotate-snippets",
+ "anstream 0.6.21",
+ "anstyle",
+ "derive_more 2.1.1",
+ "dunce",
+ "inturn",
+ "itertools 0.14.0",
+ "itoa",
+ "normalize-path",
+ "once_map",
+ "rayon",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "solar-config",
+ "solar-data-structures",
+ "solar-macros",
+ "thiserror 2.0.18",
+ "tracing",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "solar-macros"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a98045888d75d17f52e7b76f6098844b76078b5742a450c3ebcdbdb02da124"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "solar-parse"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b77a9cbb07948e4586cdcf64f0a483424197308816ebd57a4cf06130b68562"
+dependencies = [
+ "alloy-primitives",
+ "bitflags",
+ "bumpalo",
+ "itertools 0.14.0",
+ "memchr",
+ "num-bigint 0.4.6",
+ "num-rational",
+ "num-traits",
+ "ruint 1.17.2",
+ "smallvec",
+ "solar-ast",
+ "solar-data-structures",
+ "solar-interface",
+ "tracing",
+]
+
+[[package]]
+name = "solar-sema"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd033af43a38da316a04b25bbd20b121ce5d728b61e6988fd8fd6e2f1e68d0a1"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "bitflags",
+ "bumpalo",
+ "derive_more 2.1.1",
+ "either",
+ "once_map",
+ "paste",
+ "rayon",
+ "serde",
+ "serde_json",
+ "solar-ast",
+ "solar-data-structures",
+ "solar-interface",
+ "solar-macros",
+ "solar-parse",
+ "strum 0.27.2",
+ "thread_local",
+ "tracing",
+]
+
+[[package]]
+name = "soldeer-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3cc77f4a8e3c18148e5907b1fbd5de20c05669a3f0497fe37e1ef72b887fd2"
+dependencies = [
+ "bon",
+ "chrono",
+ "const-hex",
+ "derive_more 2.1.1",
+ "dunce",
+ "home",
+ "ignore",
+ "log",
+ "path-slash",
+ "rayon",
+ "regex",
+ "reqwest 0.12.28",
+ "sanitize-filename",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml_edit 0.23.10+spec-1.0.0",
+ "uuid",
+ "zip",
+ "zip-extract",
 ]
 
 [[package]]
@@ -7046,7 +10095,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -7063,10 +10121,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sval"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aaf178a50bbdd86043fce9bf0a5867007d9b382db89d1c96ccae4601ff1ff9"
+
+[[package]]
+name = "sval_buffer"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89273e48f03807ebf51c4d81c52f28d35ffa18a593edf97e041b52de143df89"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0430f4e18e7eba21a49d10d25a8dec3ce0e044af40b162347e99a8e3c3ced864"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835f51b9d7331b9d7fc48fc716c02306fa88c4a076b1573531910c91a525882d"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13cbfe3ef406ee2366e7e8ab3678426362085fa9eaedf28cb878a967159dced3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20358af4af787c34321a86618c3cae12eabdd0e9df22cd9dd2c6834214c518"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5e500f8eb2efa84f75e7090f7fc43f621b9f8b6cde571c635b3855f97b332a"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2032ae39b11dcc6c18d5fbc50a661ea191cac96484c59ccf49b002261ca2c1"
+dependencies = [
+ "serde_core",
+ "sval",
+ "sval_nested",
+]
 
 [[package]]
 name = "svgbobdoc"
@@ -7078,7 +10226,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "unicode-width",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "svm-rs"
+version = "0.5.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230df06b463c7251e4d1b39b1b3e6f25a9b3a42630179053a1e5f919e6e15534"
+dependencies = [
+ "const-hex",
+ "dirs",
+ "reqwest 0.13.2",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "url",
+ "zip",
+]
+
+[[package]]
+name = "svm-rs-builds"
+version = "0.5.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b271921143e5b12947a526de464db02b00363919d582a7ea712374840f928328"
+dependencies = [
+ "const-hex",
+ "semver 1.0.27",
+ "serde_json",
+ "svm-rs",
 ]
 
 [[package]]
@@ -7104,6 +10283,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7112,6 +10312,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7143,6 +10364,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7186,7 +10417,7 @@ checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
 dependencies = [
  "env_logger",
  "test-log-macros",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -7398,7 +10629,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
@@ -7417,6 +10648,34 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7439,9 +10698,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7451,6 +10725,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -7481,9 +10764,24 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
  "winnow 0.7.15",
 ]
 
@@ -7515,11 +10813,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "toml_writer"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -7579,7 +10906,7 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -7590,6 +10917,15 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -7643,10 +10979,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -7683,6 +11044,21 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -7722,6 +11098,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -7770,6 +11152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7787,7 +11175,9 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -7796,6 +11186,42 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16530907bfe2999a1773ca5900a65101e092c70f642f25cc23ca0c43573262c5"
+dependencies = [
+ "erased-serde",
+ "serde_core",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ae130edd690eaa877e4f40605d534790d1cf1d651e7685bd6a144521b251f"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -7912,6 +11338,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7966,6 +11406,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7978,6 +11431,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7985,6 +11452,43 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7999,6 +11503,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -8073,6 +11583,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8092,11 +11613,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8110,19 +11640,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -8132,9 +11683,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8150,9 +11713,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8162,9 +11737,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8285,6 +11872,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.1",
+ "send_wrapper",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8298,6 +11904,21 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+dependencies = [
+ "is-terminal",
+]
 
 [[package]]
 name = "yoke"
@@ -8417,6 +12038,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip-extract"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa5b9958fd0b5b685af54f2c3fa21fca05fe295ebaf3e77b6d24d96c4174037"
+dependencies = [
+ "log",
+ "thiserror 2.0.18",
+ "zip",
+]
+
+[[package]]
 name = "zkhash"
 version = "0.2.0"
 source = "git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9#bb476b9ca38198cf5092487283c8b8c5d4317c4e"
@@ -8437,16 +12083,34 @@ dependencies = [
  "pasta_curves 0.5.1",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "subtle",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -25,6 +25,13 @@ openvm-deferral-circuit = { workspace = true }
 # TODO[INT-6957]: evm-prove should enable root-prover
 openvm-continuations = { workspace = true, features = ["root-prover"] }
 openvm-verify-stark-host = { workspace = true }
+openvm-static-verifier = { workspace = true, optional = true }
+halo2-base = { workspace = true, optional = true, features = ["halo2-axiom"] }
+p3-bn254 = { workspace = true, optional = true }
+
+alloy-sol-types = { workspace = true, optional = true }
+forge-fmt = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
 
 bitcode = { workspace = true }
 bon = { workspace = true }
@@ -52,18 +59,23 @@ openvm-toolchain-tests = { workspace = true }
 
 [features]
 default = ["parallel", "jemalloc"]
-evm-prove = []
-# evm-prove = [
-#     "openvm-continuations/static-verifier",
-#     "dep:snark-verifier",
-#     "dep:snark-verifier-sdk",
-# ]
-evm-verify = []
-# evm-verify = [
-#     "evm-prove",
-#     "dep:alloy-sol-types",
-#     "dep:forge-fmt",
-# ]
+evm-prove = [
+    "dep:openvm-static-verifier",
+    "dep:halo2-base",
+    "dep:p3-bn254",
+    "openvm-static-verifier/evm-prove",
+]
+evm-verify = [
+    "evm-prove",
+    "openvm-static-verifier/evm-verify",
+    "dep:alloy-sol-types",
+    "dep:tempfile",
+]
+# Optional Solidity code formatting; requires Rust 1.91+ due to foundry/alloy transitive deps.
+evm-verify-fmt = [
+    "evm-verify",
+    "dep:forge-fmt",
+]
 metrics = ["openvm-continuations/metrics", "openvm-sdk-config/metrics"]
 aot = [
     "openvm-circuit/aot",

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -112,6 +112,10 @@ cuda = [
     "openvm-verify-stark-circuit/cuda",
     "openvm-cuda-backend/baby-bear-bn254-poseidon2",
 ]
+cell-profiling = [
+    "evm-prove",
+    "openvm-static-verifier/cell-profiling",
+]
 
 # [[example]]
 # name = "sdk_evm"

--- a/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
+++ b/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
@@ -18,15 +18,17 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     /// @dev Proof verification failed
     error ProofVerificationFailed();
 
-    /// @dev The length of the proof data, in bytes.
-    uint256 private constant PROOF_DATA_LENGTH = (12 + 43) * 32;
+    /// @dev The length of the proof data, in bytes. This is the raw SHPLONK proof
+    /// (no KZG accumulator).
+    uint256 private constant PROOF_DATA_LENGTH = {PROOF_DATA_LENGTH};
 
     /// @dev The length of the public values, in bytes. This value is set by
     /// OpenVM and is guaranteed to be no larger than 8192.
     uint256 private constant PUBLIC_VALUES_LENGTH = {PUBLIC_VALUES_LENGTH};
 
-    /// @dev The length of the full proof, in bytes
-    uint256 private constant FULL_PROOF_LENGTH = (12 + 2 + PUBLIC_VALUES_LENGTH + 43) * 32;
+    /// @dev The length of the full proof, in bytes.
+    /// Layout: appExeCommit (32) + appVmCommit (32) + PUBLIC_VALUES_LENGTH * 32 + PROOF_DATA_LENGTH
+    uint256 private constant FULL_PROOF_LENGTH = (2 + PUBLIC_VALUES_LENGTH) * 32 + PROOF_DATA_LENGTH;
 
     /// @dev The version of OpenVM that generated this verifier.
     string public constant OPENVM_VERSION = "{OPENVM_VERSION}";
@@ -35,16 +37,13 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     /// use with the `snark-verifier` verification.
     ///
     /// @dev The verifier expected proof format is:
-    /// proof[..12 * 32]: KZG accumulator
-    /// proof[12 * 32..13 * 32]: app exe commit
-    /// proof[13 * 32..14 * 32]: app vm commit
-    /// proof[14 * 32..(14 + PUBLIC_VALUES_LENGTH) * 32]: publicValues[0..PUBLIC_VALUES_LENGTH]
-    /// proof[(14 + PUBLIC_VALUES_LENGTH) * 32..]: Proof Suffix
+    /// proof[0x00..0x20]: app exe commit
+    /// proof[0x20..0x40]: app vm commit
+    /// proof[0x40..(0x40 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
+    /// proof[(0x40 + PUBLIC_VALUES_LENGTH * 32)..]: proofData (raw SHPLONK proof bytes)
     ///
     /// @param publicValues The PVs revealed by the OpenVM guest program.
-    /// @param proofData All components of the proof except the public values and
-    /// app exe and vm commits. The expected format is:
-    /// `abi.encodePacked(kzgAccumulator, proofSuffix)`
+    /// @param proofData The raw SHPLONK proof bytes.
     /// @param appExeCommit The commitment to the OpenVM application executable whose execution
     /// is being verified.
     /// @param appVmCommit The commitment to the VM configuration.
@@ -74,7 +73,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     //
     /// ```solidity
     /// bytes memory proof =
-    ///     abi.encodePacked(proofData[0:0x180], appExeCommit, appVmCommit, publicValuesPayload, proofData[0x180:]);
+    ///     abi.encodePacked(appExeCommit, appVmCommit, publicValuesPayload, proofData);
     /// ```
     //
     /// where `publicValuesPayload` is a memory payload with each byte in
@@ -92,14 +91,14 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
         returns (MemoryPointer proofPtr)
     {
         uint256 fullProofLength = FULL_PROOF_LENGTH;
+        uint256 proofDataLength = PROOF_DATA_LENGTH;
 
         // The expected proof format using hex offsets:
         //
-        // proof[..0x180]: KZG accumulator
-        // proof[0x180..0x1a0]: app exe commit
-        // proof[0x1a0..0x1c0]: app vm commit
-        // proof[0x1c0..(0x1c0 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
-        // proof[(0x1c0 + PUBLIC_VALUES_LENGTH * 32)..]: Proof Suffix
+        // proof[0x00..0x20]: app exe commit
+        // proof[0x20..0x40]: app vm commit
+        // proof[0x40..(0x40 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
+        // proof[(0x40 + PUBLIC_VALUES_LENGTH * 32)..]: proofData
 
         /// @solidity memory-safe-assembly
         assembly {
@@ -107,26 +106,18 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
             // Allocate the memory as a safety measure.
             mstore(0x40, add(proofPtr, fullProofLength))
 
-            // Copy the KZG accumulator (length 0x180) into the beginning of
-            // the memory buffer
-            calldatacopy(proofPtr, proofData.offset, 0x180)
+            // Copy the App Exe Commit and App Vm Commit into the beginning of the memory buffer
+            mstore(proofPtr, appExeCommit)
+            mstore(add(proofPtr, 0x20), appVmCommit)
 
-            // Copy the App Exe Commit and App Vm Commit into the memory buffer
-            mstore(add(proofPtr, 0x180), appExeCommit)
-            mstore(add(proofPtr, 0x1a0), appVmCommit)
-
-            // Copy the Proof Suffix (length 43 * 32 = 0x560) into the
-            // end of the memory buffer, leaving PUBLIC_VALUES_LENGTH words in
-            // between for the publicValuesPayload.
-            //
-            // Begin copying from the end of the KZG accumulator in the
-            // calldata buffer (0x180)
-            let proofSuffixOffset := add(0x1c0, shl(5, PUBLIC_VALUES_LENGTH))
-            calldatacopy(add(proofPtr, proofSuffixOffset), add(proofData.offset, 0x180), 0x560)
+            // Copy the proofData into the end of the memory buffer, leaving
+            // PUBLIC_VALUES_LENGTH words in between for the publicValuesPayload.
+            let proofDataOffset := add(0x40, shl(5, PUBLIC_VALUES_LENGTH))
+            calldatacopy(add(proofPtr, proofDataOffset), proofData.offset, proofDataLength)
 
             // Copy each byte of the public values into the proof. It copies the
             // most significant bytes of public values first.
-            let publicValuesMemOffset := add(add(proofPtr, 0x1c0), 0x1f)
+            let publicValuesMemOffset := add(add(proofPtr, 0x40), 0x1f)
             for { let i := 0 } iszero(eq(i, PUBLIC_VALUES_LENGTH)) { i := add(i, 1) } {
                 calldatacopy(add(publicValuesMemOffset, shl(5, i)), add(publicValues.offset, i), 0x01)
             }

--- a/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
+++ b/crates/sdk/contracts/template/OpenVmHalo2Verifier.sol
@@ -18,17 +18,15 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     /// @dev Proof verification failed
     error ProofVerificationFailed();
 
-    /// @dev The length of the proof data, in bytes. This is the raw SHPLONK proof
-    /// (no KZG accumulator).
-    uint256 private constant PROOF_DATA_LENGTH = {PROOF_DATA_LENGTH};
+    /// @dev The length of the proof data, in bytes.
+    uint256 private constant PROOF_DATA_LENGTH = (12 + 43) * 32;
 
     /// @dev The length of the public values, in bytes. This value is set by
     /// OpenVM and is guaranteed to be no larger than 8192.
     uint256 private constant PUBLIC_VALUES_LENGTH = {PUBLIC_VALUES_LENGTH};
 
-    /// @dev The length of the full proof, in bytes.
-    /// Layout: appExeCommit (32) + appVmCommit (32) + PUBLIC_VALUES_LENGTH * 32 + PROOF_DATA_LENGTH
-    uint256 private constant FULL_PROOF_LENGTH = (2 + PUBLIC_VALUES_LENGTH) * 32 + PROOF_DATA_LENGTH;
+    /// @dev The length of the full proof, in bytes
+    uint256 private constant FULL_PROOF_LENGTH = (12 + 2 + PUBLIC_VALUES_LENGTH + 43) * 32;
 
     /// @dev The version of OpenVM that generated this verifier.
     string public constant OPENVM_VERSION = "{OPENVM_VERSION}";
@@ -37,13 +35,16 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     /// use with the `snark-verifier` verification.
     ///
     /// @dev The verifier expected proof format is:
-    /// proof[0x00..0x20]: app exe commit
-    /// proof[0x20..0x40]: app vm commit
-    /// proof[0x40..(0x40 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
-    /// proof[(0x40 + PUBLIC_VALUES_LENGTH * 32)..]: proofData (raw SHPLONK proof bytes)
+    /// proof[..12 * 32]: KZG accumulator
+    /// proof[12 * 32..13 * 32]: app exe commit
+    /// proof[13 * 32..14 * 32]: app vm commit
+    /// proof[14 * 32..(14 + PUBLIC_VALUES_LENGTH) * 32]: publicValues[0..PUBLIC_VALUES_LENGTH]
+    /// proof[(14 + PUBLIC_VALUES_LENGTH) * 32..]: Proof Suffix
     ///
     /// @param publicValues The PVs revealed by the OpenVM guest program.
-    /// @param proofData The raw SHPLONK proof bytes.
+    /// @param proofData All components of the proof except the public values and
+    /// app exe and vm commits. The expected format is:
+    /// `abi.encodePacked(kzgAccumulator, proofSuffix)`
     /// @param appExeCommit The commitment to the OpenVM application executable whose execution
     /// is being verified.
     /// @param appVmCommit The commitment to the VM configuration.
@@ -73,7 +74,7 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
     //
     /// ```solidity
     /// bytes memory proof =
-    ///     abi.encodePacked(appExeCommit, appVmCommit, publicValuesPayload, proofData);
+    ///     abi.encodePacked(proofData[0:0x180], appExeCommit, appVmCommit, publicValuesPayload, proofData[0x180:]);
     /// ```
     //
     /// where `publicValuesPayload` is a memory payload with each byte in
@@ -91,14 +92,14 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
         returns (MemoryPointer proofPtr)
     {
         uint256 fullProofLength = FULL_PROOF_LENGTH;
-        uint256 proofDataLength = PROOF_DATA_LENGTH;
 
         // The expected proof format using hex offsets:
         //
-        // proof[0x00..0x20]: app exe commit
-        // proof[0x20..0x40]: app vm commit
-        // proof[0x40..(0x40 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
-        // proof[(0x40 + PUBLIC_VALUES_LENGTH * 32)..]: proofData
+        // proof[..0x180]: KZG accumulator
+        // proof[0x180..0x1a0]: app exe commit
+        // proof[0x1a0..0x1c0]: app vm commit
+        // proof[0x1c0..(0x1c0 + PUBLIC_VALUES_LENGTH * 32)]: publicValues[0..PUBLIC_VALUES_LENGTH]
+        // proof[(0x1c0 + PUBLIC_VALUES_LENGTH * 32)..]: Proof Suffix
 
         /// @solidity memory-safe-assembly
         assembly {
@@ -106,18 +107,26 @@ contract OpenVmHalo2Verifier is Halo2Verifier, IOpenVmHalo2Verifier {
             // Allocate the memory as a safety measure.
             mstore(0x40, add(proofPtr, fullProofLength))
 
-            // Copy the App Exe Commit and App Vm Commit into the beginning of the memory buffer
-            mstore(proofPtr, appExeCommit)
-            mstore(add(proofPtr, 0x20), appVmCommit)
+            // Copy the KZG accumulator (length 0x180) into the beginning of
+            // the memory buffer
+            calldatacopy(proofPtr, proofData.offset, 0x180)
 
-            // Copy the proofData into the end of the memory buffer, leaving
-            // PUBLIC_VALUES_LENGTH words in between for the publicValuesPayload.
-            let proofDataOffset := add(0x40, shl(5, PUBLIC_VALUES_LENGTH))
-            calldatacopy(add(proofPtr, proofDataOffset), proofData.offset, proofDataLength)
+            // Copy the App Exe Commit and App Vm Commit into the memory buffer
+            mstore(add(proofPtr, 0x180), appExeCommit)
+            mstore(add(proofPtr, 0x1a0), appVmCommit)
+
+            // Copy the Proof Suffix (length 43 * 32 = 0x560) into the
+            // end of the memory buffer, leaving PUBLIC_VALUES_LENGTH words in
+            // between for the publicValuesPayload.
+            //
+            // Begin copying from the end of the KZG accumulator in the
+            // calldata buffer (0x180)
+            let proofSuffixOffset := add(0x1c0, shl(5, PUBLIC_VALUES_LENGTH))
+            calldatacopy(add(proofPtr, proofSuffixOffset), add(proofData.offset, 0x180), 0x560)
 
             // Copy each byte of the public values into the proof. It copies the
             // most significant bytes of public values first.
-            let publicValuesMemOffset := add(add(proofPtr, 0x40), 0x1f)
+            let publicValuesMemOffset := add(add(proofPtr, 0x1c0), 0x1f)
             for { let i := 0 } iszero(eq(i, PUBLIC_VALUES_LENGTH)) { i := add(i, 1) } {
                 calldatacopy(add(publicValuesMemOffset, shl(5, i)), add(publicValues.offset, i), 0x01)
             }

--- a/crates/sdk/src/config.rs
+++ b/crates/sdk/src/config.rs
@@ -90,14 +90,13 @@ impl Default for AggregationTreeConfig {
     }
 }
 
-/// Configuration for the Halo2 (static verifier + wrapper) keygen and proving.
+/// Configuration for the Halo2 proving and wrapper keygen.
 #[cfg(feature = "evm-prove")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Halo2Config {
-    /// The degree `k` for the static verifier circuit.
-    pub verifier_k: usize,
     /// The degree `k` for the wrapper circuit. If `None`, auto-tune to pick the
-    /// smallest `k` that results in a single advice column.
+    /// smallest `k` that results in a single advice column. Note: that `k` for
+    /// the verifier circuit is determined by StaticVerifierShape.
     pub wrapper_k: Option<usize>,
     /// Whether to collect detailed profiling metrics during proving.
     pub profiling: bool,

--- a/crates/sdk/src/config.rs
+++ b/crates/sdk/src/config.rs
@@ -89,3 +89,16 @@ impl Default for AggregationTreeConfig {
         }
     }
 }
+
+/// Configuration for the Halo2 (static verifier + wrapper) keygen and proving.
+#[cfg(feature = "evm-prove")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Halo2Config {
+    /// The degree `k` for the static verifier circuit.
+    pub verifier_k: usize,
+    /// The degree `k` for the wrapper circuit. If `None`, auto-tune to pick the
+    /// smallest `k` that results in a single advice column.
+    pub wrapper_k: Option<usize>,
+    /// Whether to collect detailed profiling metrics during proving.
+    pub profiling: bool,
+}

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -8,7 +8,10 @@ use openvm_stark_backend::codec::{Decode, Encode};
 use serde::{de::DeserializeOwned, Serialize};
 
 #[cfg(feature = "evm-prove")]
-use crate::{types::EvmHalo2Verifier, OPENVM_VERSION};
+use crate::{
+    types::{EvmHalo2Verifier, EvmVerifierByteCode},
+    OPENVM_VERSION,
+};
 
 pub const EVM_HALO2_VERIFIER_INTERFACE_NAME: &str = "IOpenVmHalo2Verifier.sol";
 pub const EVM_HALO2_VERIFIER_PARENT_NAME: &str = "Halo2Verifier.sol";

--- a/crates/sdk/src/halo2_params.rs
+++ b/crates/sdk/src/halo2_params.rs
@@ -1,0 +1,53 @@
+use std::{
+    collections::HashMap,
+    io::BufReader,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use openvm_static_verifier::Halo2Params;
+
+/// Caching reader for Halo2 KZG parameters.
+///
+/// Reads SRS files from a directory and caches them in memory for reuse.
+pub struct CacheHalo2ParamsReader {
+    params_dir: PathBuf,
+    cached: Mutex<HashMap<usize, Arc<Halo2Params>>>,
+}
+
+impl CacheHalo2ParamsReader {
+    pub fn new(params_dir: impl AsRef<Path>) -> Self {
+        Self {
+            params_dir: params_dir.as_ref().to_path_buf(),
+            cached: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create a reader using the default params directory: `~/.openvm/params/`.
+    pub fn new_with_default_params_dir() -> Self {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        let params_dir = PathBuf::from(home).join(".openvm").join("params");
+        Self::new(params_dir)
+    }
+
+    /// Read the KZG params for a given `k` value, caching the result.
+    pub fn read_params(&self, k: usize) -> Arc<Halo2Params> {
+        let mut cache = self.cached.lock().unwrap();
+        if let Some(params) = cache.get(&k) {
+            return params.clone();
+        }
+        let path = self.params_dir.join(format!("kzg_bn254_{k}.srs"));
+        let file = std::fs::File::open(&path)
+            .unwrap_or_else(|e| panic!("Failed to open params file {}: {e}", path.display()));
+        let mut reader = BufReader::new(file);
+
+        // read_custom with RawBytes format
+        let params =
+            Halo2Params::read_custom(&mut reader, halo2_base::halo2_proofs::SerdeFormat::RawBytes)
+                .unwrap_or_else(|e| panic!("Failed to read params from {}: {e}", path.display()));
+
+        let params = Arc::new(params);
+        cache.insert(k, params.clone());
+        params
+    }
+}

--- a/crates/sdk/src/halo2_params.rs
+++ b/crates/sdk/src/halo2_params.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use openvm_static_verifier::Halo2Params;
+use openvm_static_verifier::{Halo2Params, Halo2ParamsReader};
 
 /// Caching reader for Halo2 KZG parameters.
 ///
@@ -13,6 +13,12 @@ use openvm_static_verifier::Halo2Params;
 pub struct CacheHalo2ParamsReader {
     params_dir: PathBuf,
     cached: Mutex<HashMap<usize, Arc<Halo2Params>>>,
+}
+
+impl Halo2ParamsReader for CacheHalo2ParamsReader {
+    fn read_params(&self, k: usize) -> Arc<Halo2Params> {
+        self.read_params(k)
+    }
 }
 
 impl CacheHalo2ParamsReader {

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -1,21 +1,117 @@
 use std::sync::Arc;
 
+use eyre::Result;
 use openvm_circuit::arch::{
-    instructions::{instruction::Instruction, program::Program, LocalOpcode, SystemOpcode},
-    Executor, MeteredExecutor, PreflightExecutor, VmBuilder, VmExecutionConfig,
+    instructions::{
+        exe::VmExe, instruction::Instruction, program::Program, LocalOpcode, SystemOpcode,
+    },
+    Executor, MeteredExecutor, PreflightExecutor, SystemConfig, VmBuilder, VmExecutionConfig,
 };
 use openvm_continuations::RootSC;
-use openvm_stark_backend::{p3_field::PrimeField32, proof::Proof, StarkEngine, Val};
+use openvm_stark_backend::{
+    keygen::types::MultiStarkProvingKey, p3_field::PrimeField32, prover::ProvingContext,
+    StarkEngine, SystemParams, Val,
+};
+#[cfg(feature = "evm-prove")]
+use {
+    crate::prover::{EvmProver, RootProver},
+    openvm_stark_backend::proof::Proof,
+};
 
 use crate::{
-    prover::{vm::types::VmProvingKey, AggProver, DeferralPathProver, EvmProver, RootProver},
+    prover::{vm::types::VmProvingKey, AggProver, DeferralPathProver, StarkProver},
     StdIn, F, SC,
 };
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "cuda")] {
+        use openvm_continuations::prover::RootCpuProver as RootInnerProver;
+        type RootE = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
+    } else {
+        use openvm_continuations::prover::RootCpuProver as RootInnerProver;
+        type RootE = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
+    }
+}
+
+fn dummy_terminate_exe() -> Arc<VmExe<F>> {
+    let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
+        SystemOpcode::TERMINATE.global_opcode(),
+        0,
+        0,
+        0,
+        0,
+        0,
+    )]);
+    Arc::new(VmExe::new(dummy_program))
+}
+
+pub fn compute_root_proof_heights<E, VB>(
+    vm_builder: VB,
+    app_vm_pk: &VmProvingKey<VB::VmConfig>,
+    agg_prover: Arc<AggProver>,
+    root_params: SystemParams,
+    def_prover: Option<Arc<DeferralPathProver>>,
+) -> Result<(Vec<usize>, Arc<MultiStarkProvingKey<RootSC>>)>
+where
+    E: StarkEngine<SC = SC>,
+    VB: VmBuilder<E>,
+    VB::VmConfig: VmExecutionConfig<F> + AsRef<SystemConfig>,
+    Val<SC>: PrimeField32,
+    <VB::VmConfig as VmExecutionConfig<F>>::Executor:
+        Executor<F> + MeteredExecutor<F> + PreflightExecutor<F, VB::RecordArena>,
+{
+    let dummy_exe = dummy_terminate_exe();
+
+    let system_config = app_vm_pk.vm_config.as_ref();
+    let memory_dimensions = system_config.memory_config.memory_dimensions();
+    let num_user_pvs = system_config.num_public_values;
+
+    let def_hook_vk_commit = def_prover.as_ref().map(|p| p.def_hook_vk_commit().into());
+
+    let mut stark_prover = StarkProver::<E, VB>::new(
+        vm_builder,
+        app_vm_pk,
+        dummy_exe,
+        agg_prover.clone(),
+        def_prover,
+    )?;
+    let (agg_proof, _) = stark_prover.prove(StdIn::default(), &[])?;
+
+    let root_prover = RootInnerProver::new::<RootE>(
+        agg_prover.internal_recursive_prover.get_vk(),
+        agg_prover
+            .internal_recursive_prover
+            .get_self_vk_pcs_data()
+            .unwrap()
+            .commitment
+            .into(),
+        root_params,
+        memory_dimensions,
+        num_user_pvs,
+        def_hook_vk_commit,
+        None,
+    );
+
+    let root_proving_ctx: ProvingContext<<RootE as StarkEngine>::PB> = root_prover
+        .generate_proving_ctx(
+            agg_proof.inner,
+            &agg_proof.user_pvs_proof,
+            agg_proof.deferral_merkle_proofs.as_ref(),
+        )
+        .unwrap();
+
+    let trace_heights = root_proving_ctx
+        .into_iter()
+        .map(|(_, air_ctx)| air_ctx.height())
+        .collect();
+    Ok((trace_heights, root_prover.get_pk()))
+}
 
 /// Generate a dummy root proof for keygen purposes.
 ///
 /// Runs a trivial TERMINATE-only program through the full EVM prover pipeline
 /// (app → aggregation → root) and returns the resulting root proof.
+#[cfg(feature = "evm-prove")]
 pub fn generate_dummy_root_proof<E, VB>(
     vm_builder: VB,
     app_vm_pk: &VmProvingKey<VB::VmConfig>,
@@ -30,17 +126,7 @@ where
     <VB::VmConfig as VmExecutionConfig<F>>::Executor:
         Executor<F> + MeteredExecutor<F> + PreflightExecutor<F, VB::RecordArena>,
 {
-    let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
-        SystemOpcode::TERMINATE.global_opcode(),
-        0,
-        0,
-        0,
-        0,
-        0,
-    )]);
-    let dummy_exe = Arc::new(openvm_circuit::arch::instructions::exe::VmExe::new(
-        dummy_program,
-    ));
+    let dummy_exe = dummy_terminate_exe();
 
     let mut evm_prover = EvmProver::<E, _>::new(
         vm_builder,
@@ -49,10 +135,11 @@ where
         agg_prover,
         def_path_prover,
         root_prover,
+        None,
     )
     .expect("Failed to create dummy EVM prover");
 
     evm_prover
-        .prove(StdIn::default(), &[])
+        .prove_unwrapped(StdIn::default(), &[])
         .expect("Failed to generate dummy root proof")
 }

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use openvm_circuit::arch::{
+    instructions::{instruction::Instruction, program::Program, LocalOpcode, SystemOpcode},
+    Executor, MeteredExecutor, PreflightExecutor, VmBuilder, VmExecutionConfig,
+};
+use openvm_continuations::RootSC;
+use openvm_stark_backend::{p3_field::PrimeField32, proof::Proof, StarkEngine, Val};
+
+use crate::{
+    prover::{
+        vm::types::VmProvingKey, AggProver, DeferralPathProver, EvmProver, RootProver,
+    },
+    StdIn, F, SC,
+};
+
+/// Generate a dummy root proof for keygen purposes.
+///
+/// Runs a trivial TERMINATE-only program through the full EVM prover pipeline
+/// (app → aggregation → root) and returns the resulting root proof.
+pub fn generate_dummy_root_proof<E, VB>(
+    vm_builder: VB,
+    app_vm_pk: &VmProvingKey<VB::VmConfig>,
+    agg_prover: Arc<AggProver>,
+    def_path_prover: Option<Arc<DeferralPathProver>>,
+    root_prover: Arc<RootProver>,
+) -> Proof<RootSC>
+where
+    E: StarkEngine<SC = SC>,
+    VB: VmBuilder<E> + Clone,
+    Val<SC>: PrimeField32,
+    <VB::VmConfig as VmExecutionConfig<F>>::Executor:
+        Executor<F> + MeteredExecutor<F> + PreflightExecutor<F, VB::RecordArena>,
+{
+    let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
+        SystemOpcode::TERMINATE.global_opcode(),
+        0,
+        0,
+        0,
+        0,
+        0,
+    )]);
+    let dummy_exe = Arc::new(openvm_circuit::arch::instructions::exe::VmExe::new(
+        dummy_program,
+    ));
+
+    let mut evm_prover = EvmProver::<E, _>::new(
+        vm_builder,
+        app_vm_pk,
+        dummy_exe,
+        agg_prover,
+        def_path_prover,
+        root_prover,
+    )
+    .expect("Failed to create dummy EVM prover");
+
+    evm_prover
+        .prove(StdIn::default(), &[])
+        .expect("Failed to generate dummy root proof")
+}

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -8,9 +8,7 @@ use openvm_continuations::RootSC;
 use openvm_stark_backend::{p3_field::PrimeField32, proof::Proof, StarkEngine, Val};
 
 use crate::{
-    prover::{
-        vm::types::VmProvingKey, AggProver, DeferralPathProver, EvmProver, RootProver,
-    },
+    prover::{vm::types::VmProvingKey, AggProver, DeferralPathProver, EvmProver, RootProver},
     StdIn, F, SC,
 };
 

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{config::AppConfig, prover::vm::types::VmProvingKey, SC};
 
-#[cfg(feature = "evm-prove")]
 pub mod dummy;
 #[cfg(feature = "evm-prove")]
 pub mod static_verifier;

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use itertools::Itertools;
-// use dummy::{compute_root_proof_heights, dummy_internal_proof_riscv_app_vm};
 use openvm_circuit::{
     arch::{AirInventoryError, SystemConfig, VmCircuitConfig},
     system::memory::dimensions::MemoryDimensions,
@@ -15,8 +14,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{config::AppConfig, prover::vm::types::VmProvingKey, SC};
 
-// TODO[jpw]: copied from v1, needs update
-// pub mod perm;
 #[cfg(feature = "evm-prove")]
 pub mod dummy;
 #[cfg(feature = "evm-prove")]
@@ -93,4 +90,17 @@ where
             system_params: self.app_vm_pk.vm_pk.params.clone(),
         }
     }
+}
+
+/// Attention: the serialized size of this struct is VERY large, usually >10GB.
+#[cfg(feature = "evm-prove")]
+#[derive(Clone)]
+pub struct Halo2ProvingKey {
+    /// Static verifier to verify a stark proof of the root verifier.
+    pub verifier: Arc<openvm_static_verifier::StaticVerifierProvingKey>,
+    /// Wrapper circuit to verify static verifier and reduce the verification costs in the final
+    /// proof.
+    pub wrapper: Arc<openvm_static_verifier::Halo2WrapperProvingKey>,
+    /// Whether to collect detailed profiling metrics.
+    pub profiling: bool,
 }

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -17,8 +17,8 @@ use crate::{config::AppConfig, prover::vm::types::VmProvingKey, SC};
 
 // TODO[jpw]: copied from v1, needs update
 // pub mod perm;
-// #[cfg(feature = "evm-prove")]
-// pub mod static_verifier;
+#[cfg(feature = "evm-prove")]
+pub mod static_verifier;
 
 /// This is lightweight to clone as it contains smart pointers to the proving keys.
 #[derive(Clone, Serialize, Deserialize)]

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -18,6 +18,8 @@ use crate::{config::AppConfig, prover::vm::types::VmProvingKey, SC};
 // TODO[jpw]: copied from v1, needs update
 // pub mod perm;
 #[cfg(feature = "evm-prove")]
+pub mod dummy;
+#[cfg(feature = "evm-prove")]
 pub mod static_verifier;
 
 /// This is lightweight to clone as it contains smart pointers to the proving keys.

--- a/crates/sdk/src/keygen/static_verifier.rs
+++ b/crates/sdk/src/keygen/static_verifier.rs
@@ -1,61 +1,33 @@
-use openvm_circuit::arch::{SingleSegmentVmProver, VirtualMachineError};
-use openvm_continuations::{
-    static_verifier::{StaticVerifierConfig, StaticVerifierPvHandler},
-    verifier::root::types::RootVmVerifierInput,
+use openvm_continuations::{CommitBytes, RootSC};
+use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, proof::Proof};
+use openvm_static_verifier::{
+    log_heights_per_air_from_proof, Halo2Params, StaticVerifierCircuit, StaticVerifierProvingKey,
+    StaticVerifierShape,
 };
-use openvm_native_circuit::NATIVE_MAX_TRACE_HEIGHTS;
-use openvm_native_compiler::prelude::*;
-use openvm_native_recursion::{
-    halo2::{verifier::Halo2VerifierProvingKey, Halo2Params, Halo2Prover},
-    hints::Hintable,
-    witness::Witnessable,
-};
-use openvm_stark_sdk::openvm_stark_backend::{p3_field::PrimeCharacteristicRing, proof::Proof};
 
-use crate::{keygen::RootVerifierProvingKey, prover::RootVerifierLocalProver, RootSC, F, SC};
+/// Generate a [`StaticVerifierProvingKey`] by running a dummy root proof through the pipeline.
+///
+/// This is the self-contained keygen flow:
+/// 1. Use a pre-generated dummy root proof
+/// 2. Extract per-AIR log heights from the dummy proof
+/// 3. Build a [`StaticVerifierCircuit`] from the root VK and heights
+/// 4. Run keygen to produce the final Halo2 proving key
+pub fn keygen_static_verifier(
+    params: &Halo2Params,
+    shape: StaticVerifierShape,
+    root_vk: &MultiStarkVerifyingKey<RootSC>,
+    internal_recursive_dag_cached_commit: CommitBytes,
+    dummy_root_proof: &Proof<RootSC>,
+) -> StaticVerifierProvingKey {
+    let log_heights = log_heights_per_air_from_proof(dummy_root_proof);
 
-impl RootVerifierProvingKey {
-    /// Keygen the static verifier for this root verifier.
-    pub fn keygen_static_verifier(
-        &self,
-        params: &Halo2Params,
-        root_proof: Proof<RootSC>,
-        pv_handler: &impl StaticVerifierPvHandler,
-    ) -> Halo2VerifierProvingKey {
-        let mut witness = Witness::default();
-        root_proof.write(&mut witness);
-        let special_air_ids = self.air_id_permutation().get_special_air_ids();
-        let config = StaticVerifierConfig {
-            root_verifier_fri_params: self.vm_pk.fri_params,
-            special_air_ids,
-            root_verifier_program_commit: self.root_committed_exe.get_program_commit().into(),
-        };
-        let dsl_operations = config.build_static_verifier_operations(
-            &self.vm_pk.vm_pk.get_vk(),
-            &root_proof,
-            pv_handler,
-        );
-        Halo2VerifierProvingKey {
-            pinning: Halo2Prover::keygen(params, dsl_operations.clone(), witness),
-            dsl_ops: dsl_operations,
-        }
-    }
+    // Convert CommitBytes → RootDigest ([Bn254; 1])
+    use p3_bn254::Bn254;
+    let bn254: Bn254 = internal_recursive_dag_cached_commit.into();
+    let root_digest = [bn254];
 
-    pub fn generate_dummy_root_proof(
-        &self,
-        dummy_internal_proof: Proof<SC>,
-    ) -> Result<Proof<RootSC>, VirtualMachineError> {
-        let mut prover = RootVerifierLocalProver::new(self)?;
-        // 2 * DIGEST_SIZE for exe_commit and leaf_commit
-        let num_public_values = prover.vm_config().as_ref().num_public_values - 2 * DIGEST_SIZE;
-        SingleSegmentVmProver::prove(
-            &mut prover,
-            RootVmVerifierInput {
-                proofs: vec![dummy_internal_proof],
-                public_values: vec![F::ZERO; num_public_values],
-            }
-            .write(),
-            NATIVE_MAX_TRACE_HEIGHTS,
-        )
-    }
+    let circuit = StaticVerifierCircuit::try_new(root_vk.clone(), root_digest, &log_heights)
+        .expect("Failed to construct StaticVerifierCircuit");
+
+    StaticVerifierProvingKey::keygen(params, shape, circuit, dummy_root_proof)
 }

--- a/crates/sdk/src/keygen/static_verifier.rs
+++ b/crates/sdk/src/keygen/static_verifier.rs
@@ -1,17 +1,57 @@
+use std::sync::Arc;
+
 use openvm_continuations::{CommitBytes, RootSC};
 use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, proof::Proof};
 use openvm_static_verifier::{
-    log_heights_per_air_from_proof, Halo2Params, StaticVerifierCircuit, StaticVerifierProvingKey,
-    StaticVerifierShape,
+    log_heights_per_air_from_proof, Halo2Params, Halo2ParamsReader, Halo2WrapperProvingKey,
+    StaticVerifierCircuit, StaticVerifierProvingKey, StaticVerifierShape,
 };
 
-/// Generate a [`StaticVerifierProvingKey`] by running a dummy root proof through the pipeline.
+use crate::{config::Halo2Config, keygen::Halo2ProvingKey};
+
+/// Generate a [`Halo2ProvingKey`] (static verifier + wrapper) by running a
+/// dummy root proof through the pipeline.
 ///
 /// This is the self-contained keygen flow:
-/// 1. Use a pre-generated dummy root proof
-/// 2. Extract per-AIR log heights from the dummy proof
-/// 3. Build a [`StaticVerifierCircuit`] from the root VK and heights
-/// 4. Run keygen to produce the final Halo2 proving key
+/// 1. Build a [`StaticVerifierProvingKey`] from the root VK and proof shape
+/// 2. Generate a dummy snark from the static verifier
+/// 3. Build a [`Halo2WrapperProvingKey`] (auto-tuned or fixed `k`)
+/// 4. Return the composite [`Halo2ProvingKey`]
+pub fn keygen_halo2(
+    halo2_config: &Halo2Config,
+    reader: &impl Halo2ParamsReader,
+    shape: StaticVerifierShape,
+    root_vk: &MultiStarkVerifyingKey<RootSC>,
+    internal_recursive_dag_cached_commit: CommitBytes,
+    dummy_root_proof: &Proof<RootSC>,
+) -> Halo2ProvingKey {
+    let params = reader.read_params(halo2_config.verifier_k);
+
+    let verifier = keygen_static_verifier(
+        &params,
+        shape,
+        root_vk,
+        internal_recursive_dag_cached_commit,
+        dummy_root_proof,
+    );
+
+    let dummy_snark = verifier.generate_dummy_snark(reader);
+
+    let wrapper = if let Some(wrapper_k) = halo2_config.wrapper_k {
+        Halo2WrapperProvingKey::keygen(&reader.read_params(wrapper_k), dummy_snark)
+    } else {
+        Halo2WrapperProvingKey::keygen_auto_tune(reader, dummy_snark)
+    };
+
+    Halo2ProvingKey {
+        verifier: Arc::new(verifier),
+        wrapper: Arc::new(wrapper),
+        profiling: halo2_config.profiling,
+    }
+}
+
+/// Generate a [`StaticVerifierProvingKey`] from a root VK, heights, and a
+/// dummy root proof. This is the lower-level keygen without the wrapper.
 pub fn keygen_static_verifier(
     params: &Halo2Params,
     shape: StaticVerifierShape,

--- a/crates/sdk/src/keygen/static_verifier.rs
+++ b/crates/sdk/src/keygen/static_verifier.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use openvm_continuations::{CommitBytes, RootSC};
+use openvm_continuations::{RootSC, SC};
 use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, proof::Proof};
 use openvm_static_verifier::{
-    log_heights_per_air_from_proof, Halo2Params, Halo2ParamsReader, Halo2WrapperProvingKey,
-    StaticVerifierCircuit, StaticVerifierProvingKey, StaticVerifierShape,
+    compute_dag_onion_commit, log_heights_per_air_from_proof, Halo2Params, Halo2ParamsReader,
+    Halo2WrapperProvingKey, StaticVerifierCircuit, StaticVerifierProvingKey, StaticVerifierShape,
 };
 
 use crate::{config::Halo2Config, keygen::Halo2ProvingKey};
@@ -21,8 +21,8 @@ pub fn keygen_halo2(
     halo2_config: &Halo2Config,
     reader: &impl Halo2ParamsReader,
     shape: StaticVerifierShape,
+    internal_recursive_vk: &MultiStarkVerifyingKey<SC>,
     root_vk: &MultiStarkVerifyingKey<RootSC>,
-    internal_recursive_dag_cached_commit: CommitBytes,
     dummy_root_proof: &Proof<RootSC>,
 ) -> Halo2ProvingKey {
     let params = reader.read_params(halo2_config.verifier_k);
@@ -30,8 +30,8 @@ pub fn keygen_halo2(
     let verifier = keygen_static_verifier(
         &params,
         shape,
+        internal_recursive_vk,
         root_vk,
-        internal_recursive_dag_cached_commit,
         dummy_root_proof,
     );
 
@@ -55,18 +55,14 @@ pub fn keygen_halo2(
 pub fn keygen_static_verifier(
     params: &Halo2Params,
     shape: StaticVerifierShape,
+    internal_recursive_vk: &MultiStarkVerifyingKey<SC>,
     root_vk: &MultiStarkVerifyingKey<RootSC>,
-    internal_recursive_dag_cached_commit: CommitBytes,
     dummy_root_proof: &Proof<RootSC>,
 ) -> StaticVerifierProvingKey {
     let log_heights = log_heights_per_air_from_proof(dummy_root_proof);
+    let onion_commit = compute_dag_onion_commit(internal_recursive_vk);
 
-    // Convert CommitBytes → RootDigest ([Bn254; 1])
-    use p3_bn254::Bn254;
-    let bn254: Bn254 = internal_recursive_dag_cached_commit.into();
-    let root_digest = [bn254];
-
-    let circuit = StaticVerifierCircuit::try_new(root_vk.clone(), root_digest, &log_heights)
+    let circuit = StaticVerifierCircuit::try_new(root_vk.clone(), onion_commit, &log_heights)
         .expect("Failed to construct StaticVerifierCircuit");
 
     StaticVerifierProvingKey::keygen(params, shape, circuit, dummy_root_proof)

--- a/crates/sdk/src/keygen/static_verifier.rs
+++ b/crates/sdk/src/keygen/static_verifier.rs
@@ -25,7 +25,7 @@ pub fn keygen_halo2(
     root_vk: &MultiStarkVerifyingKey<RootSC>,
     dummy_root_proof: &Proof<RootSC>,
 ) -> Halo2ProvingKey {
-    let params = reader.read_params(halo2_config.verifier_k);
+    let params = reader.read_params(shape.k);
 
     let verifier = keygen_static_verifier(
         &params,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -32,7 +32,7 @@ use openvm_stark_sdk::config::{
     root_params_with_100_bits_security,
 };
 #[cfg(feature = "evm-prove")]
-use openvm_static_verifier::{StaticVerifierProvingKey, StaticVerifierShape};
+use openvm_static_verifier::StaticVerifierShape;
 use openvm_transpiler::{
     elf::Elf, openvm_platform::memory::MEM_SIZE, transpiler::Transpiler, FromElf,
 };
@@ -133,6 +133,9 @@ where
     #[cfg(feature = "evm-prove")]
     #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
     halo2_shape: StaticVerifierShape,
+    #[cfg(feature = "evm-prove")]
+    #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
+    halo2_config: config::Halo2Config,
 
     #[getset(get = "pub")]
     app_vm_builder: VB,
@@ -155,7 +158,7 @@ where
     #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
     halo2_params_reader: CacheHalo2ParamsReader,
     #[cfg(feature = "evm-prove")]
-    halo2_pk: OnceLock<StaticVerifierProvingKey>,
+    halo2_pk: OnceLock<keygen::Halo2ProvingKey>,
 
     _phantom: PhantomData<E>,
 }
@@ -233,6 +236,12 @@ where
             agg_tree_config: Default::default(),
             #[cfg(feature = "evm-prove")]
             halo2_shape: StaticVerifierShape::default(),
+            #[cfg(feature = "evm-prove")]
+            halo2_config: config::Halo2Config {
+                verifier_k: StaticVerifierShape::default().k,
+                wrapper_k: None,
+                profiling: false,
+            },
             app_vm_builder: Default::default(),
             transpiler: None,
             executor,
@@ -477,17 +486,9 @@ where
         inputs: StdIn,
     ) -> Result<types::EvmProof, SdkError> {
         let app_exe = self.convert_to_exe(app_exe)?;
-        let mut evm_prover = self.evm_prover(app_exe)?;
-        // Generate the root STARK proof
-        let root_proof = evm_prover.prove(inputs, &[])?;
-
-        // Run the static verifier (Halo2) to produce an EVM-compatible proof
-        let halo2_pk = self.halo2_pk();
-        let params = self.halo2_params_reader.read_params(halo2_pk.shape.k);
-        let raw_evm_proof = halo2_pk.prove_for_evm(&params, &root_proof);
-
-        // Convert RawEvmProof → EvmProof
-        Ok(types::EvmProof::from(raw_evm_proof))
+        let mut evm_halo2_prover = self.evm_halo2_prover(app_exe)?;
+        let evm_proof = evm_halo2_prover.prove_evm(inputs, &[])?;
+        Ok(evm_proof)
     }
 
     // ========================= Prover Constructors =========================
@@ -528,7 +529,6 @@ where
         Ok(stark_prover)
     }
 
-    // #[cfg(feature = "evm-prove")]
     pub fn evm_prover(
         &self,
         app_exe: impl Into<ExecutableFormat>,
@@ -544,6 +544,27 @@ where
             self.root_prover(),
         )?;
         Ok(evm_prover)
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn evm_halo2_prover(
+        &self,
+        app_exe: impl Into<ExecutableFormat>,
+    ) -> Result<prover::EvmHalo2Prover<E, VB>, SdkError> {
+        let app_exe = self.convert_to_exe(app_exe)?;
+        let app_pk = self.app_pk();
+        let halo2_pk = self.halo2_pk().clone();
+        let evm_halo2_prover = prover::EvmHalo2Prover::<E, _>::new(
+            &self.halo2_params_reader,
+            self.app_vm_builder.clone(),
+            &app_pk.app_vm_pk,
+            app_exe,
+            self.agg_prover(),
+            self.def_path_prover.clone(),
+            self.root_prover(),
+            halo2_pk,
+        )?;
+        Ok(evm_halo2_prover)
     }
 
     // ===================== Component Prover Constructors =====================
@@ -654,21 +675,21 @@ where
     }
 
     #[cfg(feature = "evm-prove")]
-    pub fn halo2_keygen(&self) -> &StaticVerifierProvingKey {
+    pub fn halo2_keygen(&self) -> &keygen::Halo2ProvingKey {
         self.halo2_pk()
     }
 
-    /// Generates the Halo2 (static verifier) proving key once and caches it.
+    /// Generates the Halo2 (static verifier + wrapper) proving key once and caches it.
     ///
     /// The flow:
     /// 1. Get the root VK and internal recursive DAG cached commit
     /// 2. Generate a dummy root proof via the EVM prover pipeline
-    /// 3. Use the dummy root proof to keygen the static verifier circuit
+    /// 3. Keygen the static verifier circuit
+    /// 4. Generate a dummy snark from the verifier
+    /// 5. Keygen the wrapper circuit (auto-tuned or fixed k)
     #[cfg(feature = "evm-prove")]
-    pub fn halo2_pk(&self) -> &StaticVerifierProvingKey {
+    pub fn halo2_pk(&self) -> &keygen::Halo2ProvingKey {
         self.halo2_pk.get_or_init(|| {
-            let params = self.halo2_params_reader.read_params(self.halo2_shape.k);
-
             let root_prover = self.root_prover();
             let root_vk = root_prover.0.get_vk().as_ref().clone();
 
@@ -690,8 +711,9 @@ where
                 self.root_prover(),
             );
 
-            keygen::static_verifier::keygen_static_verifier(
-                &params,
+            keygen::static_verifier::keygen_halo2(
+                &self.halo2_config,
+                &self.halo2_params_reader,
                 self.halo2_shape,
                 &root_vk,
                 internal_recursive_dag_cached_commit,
@@ -706,14 +728,14 @@ where
     #[allow(clippy::result_large_err)]
     pub fn set_halo2_pk(
         &self,
-        halo2_pk: StaticVerifierProvingKey,
-    ) -> Result<(), StaticVerifierProvingKey> {
+        halo2_pk: keygen::Halo2ProvingKey,
+    ) -> Result<(), keygen::Halo2ProvingKey> {
         self.halo2_pk.set(halo2_pk)
     }
     /// See [`set_halo2_pk`](Self::set_halo2_pk). This should only be used in a constructor, and
     /// panics if halo2 keygen has already been called.
     #[cfg(feature = "evm-prove")]
-    pub fn with_halo2_pk(self, halo2_pk: StaticVerifierProvingKey) -> Self {
+    pub fn with_halo2_pk(self, halo2_pk: keygen::Halo2ProvingKey) -> Self {
         let _ = self
             .set_halo2_pk(halo2_pk)
             .map_err(|_| panic!("halo2_pk already set"));
@@ -768,36 +790,42 @@ where
         };
 
         let halo2_pk = self.halo2_pk();
-        let params = self.halo2_params_reader.read_params(halo2_pk.shape.k);
+        let wrapper_k = halo2_pk.wrapper.pinning.metadata.config_params.k;
+        let params = self.halo2_params_reader.read_params(wrapper_k);
 
         // Generate the base Halo2Verifier Solidity code from snark-verifier
-        let halo2_verifier_code = halo2_pk.generate_fallback_evm_verifier(&params);
+        // (via the wrapper circuit, which is what produces the final EVM proof)
+        let fallback_verifier = halo2_pk.wrapper.generate_fallback_evm_verifier(&params);
+        let halo2_verifier_code = fallback_verifier.sol_code;
 
-        // Compute public values length: num_pvs[0] - 2 (subtract exe and vk commits)
+        // Compute public values length from the wrapper circuit's instances.
+        // The wrapper's instances layout is:
+        //   [0..12]: KZG accumulator
+        //   [12]: app_exe_commit
+        //   [13]: app_vm_commit
+        //   [14..]: user public values
         let num_pvs = halo2_pk
+            .wrapper
             .pinning
             .metadata
             .num_pvs
             .first()
             .expect("Expected at least one instance column");
+        // Subtract 12 (accumulator) + 2 (commits) = 14
         let pvs_length = num_pvs
-            .checked_sub(2)
-            .expect("Unexpected number of static verifier public values");
+            .checked_sub(types::NUM_BN254_ACCUMULATOR + 2)
+            .expect("Unexpected number of wrapper circuit public values");
 
         assert!(
             pvs_length <= 8192,
             "OpenVM Halo2 verifier contract does not support more than 8192 public values"
         );
 
-        // Compute proof data length: generate a dummy EVM proof to measure its size
-        // In practice, this is deterministic for a given circuit configuration
-        let proof_data_length = self.compute_evm_proof_data_length();
-
+        // PROOF_DATA_LENGTH is now a constant in the template: (12 + 43) * 32
         // Fill out template placeholders
         let openvm_verifier_code = EVM_HALO2_VERIFIER_TEMPLATE
             .replace("{PUBLIC_VALUES_LENGTH}", &pvs_length.to_string())
-            .replace("{OPENVM_VERSION}", OPENVM_VERSION)
-            .replace("{PROOF_DATA_LENGTH}", &proof_data_length.to_string());
+            .replace("{OPENVM_VERSION}", OPENVM_VERSION);
 
         // Format Solidity code if forge-fmt is available (requires Rust 1.91+)
         let (formatted_interface, formatted_halo2_verifier_code, formatted_openvm_verifier_code) =
@@ -931,24 +959,6 @@ where
             },
         };
         Ok(evm_verifier)
-    }
-
-    /// Compute the expected EVM proof data length (raw proof bytes, no instances).
-    /// This is deterministic for a given static verifier circuit config.
-    #[cfg(feature = "evm-verify")]
-    fn compute_evm_proof_data_length(&self) -> usize {
-        // Generate a dummy EVM proof to determine the proof data length
-        let dummy_root_proof = keygen::dummy::generate_dummy_root_proof::<E, _>(
-            self.app_vm_builder.clone(),
-            &self.app_pk().app_vm_pk,
-            self.agg_prover(),
-            self.def_path_prover.clone(),
-            self.root_prover(),
-        );
-        let halo2_pk = self.halo2_pk();
-        let params = self.halo2_params_reader.read_params(halo2_pk.shape.k);
-        let raw_evm_proof = halo2_pk.prove_for_evm(&params, &dummy_root_proof);
-        raw_evm_proof.proof.len()
     }
 
     #[cfg(feature = "evm-verify")]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -31,6 +31,8 @@ use openvm_stark_sdk::config::{
     baby_bear_poseidon2::{BabyBearPoseidon2CpuEngine as BabyBearPoseidon2Engine, Digest},
     root_params_with_100_bits_security,
 };
+#[cfg(feature = "evm-prove")]
+use openvm_static_verifier::{StaticVerifierProvingKey, StaticVerifierShape};
 use openvm_transpiler::{
     elf::Elf, openvm_platform::memory::MEM_SIZE, transpiler::Transpiler, FromElf,
 };
@@ -40,6 +42,8 @@ use openvm_verify_stark_host::{
     NonRootStarkProof,
 };
 
+#[cfg(feature = "evm-prove")]
+use crate::halo2_params::CacheHalo2ParamsReader;
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
     keygen::AggProvingKey,
@@ -66,6 +70,8 @@ pub use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config 
 
 pub mod config;
 pub mod fs;
+#[cfg(feature = "evm-prove")]
+pub mod halo2_params;
 pub mod keygen;
 pub mod prover;
 pub mod types;
@@ -84,6 +90,21 @@ pub const OPENVM_VERSION: &str = concat!(
     ".",
     env!("CARGO_PKG_VERSION_MINOR")
 );
+
+#[cfg(feature = "evm-verify")]
+const EVM_HALO2_VERIFIER_TEMPLATE: &str =
+    include_str!("../contracts/template/OpenVmHalo2Verifier.sol");
+#[cfg(feature = "evm-verify")]
+const EVM_HALO2_VERIFIER_INTERFACE: &str =
+    include_str!("../contracts/src/IOpenVmHalo2Verifier.sol");
+
+#[cfg(feature = "evm-verify")]
+alloy_sol_types::sol! {
+    #[allow(missing_docs)]
+    interface IOpenVmHalo2Verifier {
+        function verify(bytes calldata publicValues, bytes calldata proofData, bytes32 appExeCommit, bytes32 appVmCommit) external view;
+    }
+}
 
 // The SDK is only generic in the engine for the non-root SC. The root SC is fixed to
 // BabyBearPoseidon2RootEngine right now.
@@ -111,7 +132,7 @@ where
     agg_tree_config: AggregationTreeConfig,
     #[cfg(feature = "evm-prove")]
     #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
-    halo2_config: Halo2Config,
+    halo2_shape: StaticVerifierShape,
 
     #[getset(get = "pub")]
     app_vm_builder: VB,
@@ -134,7 +155,7 @@ where
     #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
     halo2_params_reader: CacheHalo2ParamsReader,
     #[cfg(feature = "evm-prove")]
-    halo2_pk: OnceLock<Halo2ProvingKey>,
+    halo2_pk: OnceLock<StaticVerifierProvingKey>,
 
     _phantom: PhantomData<E>,
 }
@@ -210,6 +231,8 @@ where
             app_config,
             agg_config,
             agg_tree_config: Default::default(),
+            #[cfg(feature = "evm-prove")]
+            halo2_shape: StaticVerifierShape::default(),
             app_vm_builder: Default::default(),
             transpiler: None,
             executor,
@@ -217,6 +240,10 @@ where
             agg_prover: OnceLock::new(),
             root_prover: OnceLock::new(),
             def_path_prover: None,
+            #[cfg(feature = "evm-prove")]
+            halo2_params_reader: CacheHalo2ParamsReader::new_with_default_params_dir(),
+            #[cfg(feature = "evm-prove")]
+            halo2_pk: OnceLock::new(),
             _phantom: Default::default(),
         })
     }
@@ -448,11 +475,19 @@ where
         &self,
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
-    ) -> Result<EvmProof, SdkError> {
+    ) -> Result<types::EvmProof, SdkError> {
         let app_exe = self.convert_to_exe(app_exe)?;
         let mut evm_prover = self.evm_prover(app_exe)?;
-        let proof = evm_prover.prove_evm(inputs)?;
-        Ok(proof)
+        // Generate the root STARK proof
+        let root_proof = evm_prover.prove(inputs, &[])?;
+
+        // Run the static verifier (Halo2) to produce an EVM-compatible proof
+        let halo2_pk = self.halo2_pk();
+        let params = self.halo2_params_reader.read_params(halo2_pk.shape.k);
+        let raw_evm_proof = halo2_pk.prove_for_evm(&params, &root_proof);
+
+        // Convert RawEvmProof → EvmProof
+        Ok(types::EvmProof::from(raw_evm_proof))
     }
 
     // ========================= Prover Constructors =========================
@@ -619,35 +654,95 @@ where
     }
 
     #[cfg(feature = "evm-prove")]
-    pub fn halo2_keygen(&self) -> Halo2ProvingKey {
-        self.halo2_pk().clone()
+    pub fn halo2_keygen(&self) -> &StaticVerifierProvingKey {
+        self.halo2_pk()
     }
 
+    /// Generates the Halo2 (static verifier) proving key once and caches it.
+    ///
+    /// The flow:
+    /// 1. Get the root VK and internal recursive DAG cached commit
+    /// 2. Generate a dummy root proof via the EVM prover pipeline
+    /// 3. Use the dummy root proof to keygen the static verifier circuit
     #[cfg(feature = "evm-prove")]
-    pub fn halo2_pk(&self) -> &Halo2ProvingKey {
-        let (agg_pk, dummy_internal_proof) = self.agg_pk_and_dummy_internal_proof();
-        // TODO[jpw]: use `get_or_try_init` once it is stable
+    pub fn halo2_pk(&self) -> &StaticVerifierProvingKey {
         self.halo2_pk.get_or_init(|| {
-            Halo2ProvingKey::keygen(
-                self.halo2_config,
-                self.halo2_params_reader(),
-                &DefaultStaticVerifierPvHandler,
-                agg_pk,
-                dummy_internal_proof.clone(),
+            let params = self.halo2_params_reader.read_params(self.halo2_shape.k);
+
+            let root_prover = self.root_prover();
+            let root_vk = root_prover.0.get_vk().as_ref().clone();
+
+            let agg_prover = self.agg_prover();
+            let internal_recursive_dag_cached_commit: openvm_continuations::CommitBytes =
+                agg_prover
+                    .internal_recursive_prover
+                    .get_self_vk_pcs_data()
+                    .unwrap()
+                    .commitment
+                    .into();
+
+            // Generate a dummy root proof by running a trivial program through the pipeline
+            let dummy_root_proof = self.generate_dummy_root_proof();
+
+            keygen::static_verifier::keygen_static_verifier(
+                &params,
+                self.halo2_shape,
+                &root_vk,
+                internal_recursive_dag_cached_commit,
+                &dummy_root_proof,
             )
-            .expect("halo2_keygen failed")
         })
     }
+
+    /// Generate a dummy root proof for keygen purposes.
+    /// Runs a trivial TERMINATE program through the full pipeline.
+    #[cfg(feature = "evm-prove")]
+    fn generate_dummy_root_proof(
+        &self,
+    ) -> openvm_stark_backend::proof::Proof<openvm_continuations::RootSC> {
+        use openvm_circuit::arch::instructions::{
+            instruction::Instruction, program::Program, LocalOpcode, SystemOpcode,
+        };
+
+        let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
+            SystemOpcode::TERMINATE.global_opcode(),
+            0,
+            0,
+            0,
+            0,
+            0,
+        )]);
+        let dummy_exe = Arc::new(VmExe::new(dummy_program));
+
+        let mut evm_prover = EvmProver::<E, _>::new(
+            self.app_vm_builder.clone(),
+            &self.app_pk().app_vm_pk,
+            dummy_exe,
+            self.agg_prover(),
+            self.def_path_prover.clone(),
+            self.root_prover(),
+        )
+        .expect("Failed to create dummy EVM prover");
+
+        evm_prover
+            .prove(StdIn::default(), &[])
+            .expect("Failed to generate dummy root proof")
+    }
+
     /// Sets the halo2 proving keys. Returns `Ok(())` if halo2 keygen has not been called and
     /// `Err(halo2_pk)` if keygen has already been called.
     #[cfg(feature = "evm-prove")]
-    pub fn set_halo2_pk(&self, halo2_pk: Halo2ProvingKey) -> Result<(), Halo2ProvingKey> {
+    #[allow(clippy::result_large_err)]
+    pub fn set_halo2_pk(
+        &self,
+        halo2_pk: StaticVerifierProvingKey,
+    ) -> Result<(), StaticVerifierProvingKey> {
         self.halo2_pk.set(halo2_pk)
     }
     /// See [`set_halo2_pk`](Self::set_halo2_pk). This should only be used in a constructor, and
     /// panics if halo2 keygen has already been called.
     #[cfg(feature = "evm-prove")]
-    pub fn with_halo2_pk(self, halo2_pk: Halo2ProvingKey) -> Self {
+    pub fn with_halo2_pk(self, halo2_pk: StaticVerifierProvingKey) -> Self {
         let _ = self
             .set_halo2_pk(halo2_pk)
             .map_err(|_| panic!("halo2_pk already set"));
@@ -692,86 +787,54 @@ where
         };
 
         use eyre::Context;
-        use forge_fmt::{
-            format, FormatterConfig, IntTypes, MultilineFuncHeaderStyle, NumberUnderscore,
-            QuoteStyle, SingleLineBlockStyle,
-        };
-        use openvm_native_recursion::halo2::wrapper::EvmVerifierByteCode;
         use serde_json::{json, Value};
-        use snark_verifier::halo2_base::halo2_proofs::poly::commitment::Params;
-        use snark_verifier_sdk::SHPLONK;
         use tempfile::tempdir;
-        use types::EvmHalo2Verifier;
+        use types::{EvmHalo2Verifier, EvmVerifierByteCode};
 
         use crate::fs::{
             EVM_HALO2_VERIFIER_BASE_NAME, EVM_HALO2_VERIFIER_INTERFACE_NAME,
             EVM_HALO2_VERIFIER_PARENT_NAME,
         };
 
-        let reader = self.halo2_params_reader();
         let halo2_pk = self.halo2_pk();
+        let params = self.halo2_params_reader.read_params(halo2_pk.shape.k);
 
-        let params = reader.read_params(halo2_pk.wrapper.pinning.metadata.config_params.k);
-        let pinning = &halo2_pk.wrapper.pinning;
+        // Generate the base Halo2Verifier Solidity code from snark-verifier
+        let halo2_verifier_code = halo2_pk.generate_fallback_evm_verifier(&params);
 
-        assert_eq!(
-            pinning.metadata.config_params.k as u32,
-            params.k(),
-            "Provided params don't match circuit config"
-        );
-
-        let halo2_verifier_code = gen_evm_verifier_sol_code::<AggregationCircuit, SHPLONK>(
-            &params,
-            pinning.pk.get_vk(),
-            pinning.metadata.num_pvs.clone(),
-        );
-
-        let wrapper_pvs = halo2_pk.wrapper.pinning.metadata.num_pvs.clone();
-        let pvs_length = match wrapper_pvs.first() {
-            // We subtract 14 to exclude the KZG accumulator and the app exe
-            // and vm commits.
-            Some(v) => v
-                .checked_sub(14)
-                .expect("Unexpected number of static verifier wrapper public values"),
-            _ => panic!("Unexpected amount of instance columns in the static verifier wrapper"),
-        };
+        // Compute public values length: num_pvs[0] - 2 (subtract exe and vk commits)
+        let num_pvs = halo2_pk
+            .pinning
+            .metadata
+            .num_pvs
+            .first()
+            .expect("Expected at least one instance column");
+        let pvs_length = num_pvs
+            .checked_sub(2)
+            .expect("Unexpected number of static verifier public values");
 
         assert!(
             pvs_length <= 8192,
             "OpenVM Halo2 verifier contract does not support more than 8192 public values"
         );
 
-        // Fill out the public values length and OpenVM version in the template
+        // Compute proof data length: generate a dummy EVM proof to measure its size
+        // In practice, this is deterministic for a given circuit configuration
+        let proof_data_length = self.compute_evm_proof_data_length();
+
+        // Fill out template placeholders
         let openvm_verifier_code = EVM_HALO2_VERIFIER_TEMPLATE
             .replace("{PUBLIC_VALUES_LENGTH}", &pvs_length.to_string())
-            .replace("{OPENVM_VERSION}", OPENVM_VERSION);
+            .replace("{OPENVM_VERSION}", OPENVM_VERSION)
+            .replace("{PROOF_DATA_LENGTH}", &proof_data_length.to_string());
 
-        let formatter_config = FormatterConfig {
-            line_length: 120,
-            tab_width: 4,
-            bracket_spacing: true,
-            int_types: IntTypes::Long,
-            multiline_func_header: MultilineFuncHeaderStyle::AttributesFirst,
-            quote_style: QuoteStyle::Double,
-            number_underscore: NumberUnderscore::Thousands,
-            single_line_statement_blocks: SingleLineBlockStyle::Preserve,
-            override_spacing: false,
-            wrap_comments: false,
-            ignore: vec![],
-            contract_new_lines: false,
-            sort_imports: false,
-            ..Default::default()
-        };
-
-        let formatted_interface = format(EVM_HALO2_VERIFIER_INTERFACE, formatter_config.clone())
-            .into_result()
-            .expect("Failed to format interface");
-        let formatted_halo2_verifier_code = format(&halo2_verifier_code, formatter_config.clone())
-            .into_result()
-            .expect("Failed to format halo2 verifier code");
-        let formatted_openvm_verifier_code = format(&openvm_verifier_code, formatter_config)
-            .into_result()
-            .expect("Failed to format openvm verifier code");
+        // Format Solidity code if forge-fmt is available (requires Rust 1.91+)
+        let (formatted_interface, formatted_halo2_verifier_code, formatted_openvm_verifier_code) =
+            format_solidity_sources(
+                EVM_HALO2_VERIFIER_INTERFACE,
+                &halo2_verifier_code,
+                &openvm_verifier_code,
+            );
 
         // Create temp dir
         let temp_dir = tempdir()
@@ -899,20 +962,89 @@ where
         Ok(evm_verifier)
     }
 
+    /// Compute the expected EVM proof data length (raw proof bytes, no instances).
+    /// This is deterministic for a given static verifier circuit config.
+    #[cfg(feature = "evm-verify")]
+    fn compute_evm_proof_data_length(&self) -> usize {
+        // Generate a dummy EVM proof to determine the proof data length
+        let dummy_root_proof = self.generate_dummy_root_proof();
+        let halo2_pk = self.halo2_pk();
+        let params = self.halo2_params_reader.read_params(halo2_pk.shape.k);
+        let raw_evm_proof = halo2_pk.prove_for_evm(&params, &dummy_root_proof);
+        raw_evm_proof.proof.len()
+    }
+
     #[cfg(feature = "evm-verify")]
     /// Uses the `verify(..)` interface of the `OpenVmHalo2Verifier` contract.
+    ///
+    /// Requires the `evm-verify` feature. Internally deploys the verifier bytecode in a local EVM
+    /// and executes the verification call.
     pub fn verify_evm_halo2_proof(
         openvm_verifier: &types::EvmHalo2Verifier,
-        evm_proof: EvmProof,
+        evm_proof: types::EvmProof,
     ) -> Result<u64, SdkError> {
-        let calldata = evm_proof.verifier_calldata();
-        let deployment_code = openvm_verifier.artifact.bytecode.clone();
+        // Convert EvmProof → RawEvmProof for the static verifier's evm_verify
+        let raw_evm_proof: openvm_static_verifier::keygen::RawEvmProof = evm_proof.into();
+        let deployment_code = &openvm_verifier.artifact.bytecode;
 
-        let gas_cost = snark_verifier::loader::evm::deploy_and_call(deployment_code, calldata)
+        let gas_cost = openvm_static_verifier::keygen::evm_verify(deployment_code, &raw_evm_proof)
             .map_err(|reason| {
-                SdkError::Other(eyre::eyre!("Sdk::verify_openvm_evm_proof: {reason:?}"))
+                SdkError::Other(eyre::eyre!("Sdk::verify_openvm_evm_proof: {reason}"))
             })?;
 
         Ok(gas_cost)
+    }
+}
+
+/// Format Solidity sources using forge-fmt when available, or return them as-is.
+#[cfg(feature = "evm-verify")]
+fn format_solidity_sources(
+    interface: &str,
+    halo2_verifier: &str,
+    openvm_verifier: &str,
+) -> (String, String, String) {
+    #[cfg(feature = "evm-verify-fmt")]
+    {
+        use forge_fmt::{
+            format, FormatterConfig, IntTypes, MultilineFuncHeaderStyle, NumberUnderscore,
+            QuoteStyle, SingleLineBlockStyle,
+        };
+
+        let config = FormatterConfig {
+            line_length: 120,
+            tab_width: 4,
+            bracket_spacing: true,
+            int_types: IntTypes::Long,
+            multiline_func_header: MultilineFuncHeaderStyle::AttributesFirst,
+            quote_style: QuoteStyle::Double,
+            number_underscore: NumberUnderscore::Thousands,
+            single_line_statement_blocks: SingleLineBlockStyle::Preserve,
+            override_spacing: false,
+            wrap_comments: false,
+            ignore: vec![],
+            contract_new_lines: false,
+            sort_imports: false,
+            ..Default::default()
+        };
+
+        let formatted_interface = format(interface, config.clone())
+            .into_result()
+            .expect("Failed to format interface");
+        let formatted_halo2 = format(halo2_verifier, config.clone())
+            .into_result()
+            .expect("Failed to format halo2 verifier code");
+        let formatted_openvm = format(openvm_verifier, config)
+            .into_result()
+            .expect("Failed to format openvm verifier code");
+
+        (formatted_interface, formatted_halo2, formatted_openvm)
+    }
+    #[cfg(not(feature = "evm-verify-fmt"))]
+    {
+        (
+            interface.to_string(),
+            halo2_verifier.to_string(),
+            openvm_verifier.to_string(),
+        )
     }
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -682,7 +682,13 @@ where
                     .into();
 
             // Generate a dummy root proof by running a trivial program through the pipeline
-            let dummy_root_proof = self.generate_dummy_root_proof();
+            let dummy_root_proof = keygen::dummy::generate_dummy_root_proof::<E, _>(
+                self.app_vm_builder.clone(),
+                &self.app_pk().app_vm_pk,
+                self.agg_prover(),
+                self.def_path_prover.clone(),
+                self.root_prover(),
+            );
 
             keygen::static_verifier::keygen_static_verifier(
                 &params,
@@ -692,41 +698,6 @@ where
                 &dummy_root_proof,
             )
         })
-    }
-
-    /// Generate a dummy root proof for keygen purposes.
-    /// Runs a trivial TERMINATE program through the full pipeline.
-    #[cfg(feature = "evm-prove")]
-    fn generate_dummy_root_proof(
-        &self,
-    ) -> openvm_stark_backend::proof::Proof<openvm_continuations::RootSC> {
-        use openvm_circuit::arch::instructions::{
-            instruction::Instruction, program::Program, LocalOpcode, SystemOpcode,
-        };
-
-        let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
-            SystemOpcode::TERMINATE.global_opcode(),
-            0,
-            0,
-            0,
-            0,
-            0,
-        )]);
-        let dummy_exe = Arc::new(VmExe::new(dummy_program));
-
-        let mut evm_prover = EvmProver::<E, _>::new(
-            self.app_vm_builder.clone(),
-            &self.app_pk().app_vm_pk,
-            dummy_exe,
-            self.agg_prover(),
-            self.def_path_prover.clone(),
-            self.root_prover(),
-        )
-        .expect("Failed to create dummy EVM prover");
-
-        evm_prover
-            .prove(StdIn::default(), &[])
-            .expect("Failed to generate dummy root proof")
     }
 
     /// Sets the halo2 proving keys. Returns `Ok(())` if halo2 keygen has not been called and
@@ -967,7 +938,13 @@ where
     #[cfg(feature = "evm-verify")]
     fn compute_evm_proof_data_length(&self) -> usize {
         // Generate a dummy EVM proof to determine the proof data length
-        let dummy_root_proof = self.generate_dummy_root_proof();
+        let dummy_root_proof = keygen::dummy::generate_dummy_root_proof::<E, _>(
+            self.app_vm_builder.clone(),
+            &self.app_pk().app_vm_pk,
+            self.agg_prover(),
+            self.def_path_prover.clone(),
+            self.root_prover(),
+        );
         let halo2_pk = self.halo2_pk();
         let params = self.halo2_params_reader.read_params(halo2_pk.shape.k);
         let raw_evm_proof = halo2_pk.prove_for_evm(&params, &dummy_root_proof);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -238,7 +238,6 @@ where
             halo2_shape: StaticVerifierShape::default(),
             #[cfg(feature = "evm-prove")]
             halo2_config: config::Halo2Config {
-                verifier_k: StaticVerifierShape::default().k,
                 wrapper_k: None,
                 profiling: false,
             },

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -42,17 +42,17 @@ use openvm_verify_stark_host::{
     NonRootStarkProof,
 };
 
-#[cfg(feature = "evm-prove")]
-use crate::halo2_params::CacheHalo2ParamsReader;
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
-    keygen::AggProvingKey,
+    keygen::{dummy::compute_root_proof_heights, AggProvingKey},
     prover::{
-        compute_root_proof_heights, AggProver, AppProver, DeferralPathProver, DeferralProver,
-        EvmProver, RootProver, StarkProver,
+        AggProver, AppProver, DeferralPathProver, DeferralProver, EvmProver, RootProver,
+        StarkProver,
     },
     types::ExecutableFormat,
 };
+#[cfg(feature = "evm-prove")]
+use crate::{halo2_params::CacheHalo2ParamsReader, keygen::Halo2ProvingKey, prover::Halo2Prover};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
@@ -158,7 +158,7 @@ where
     #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
     halo2_params_reader: CacheHalo2ParamsReader,
     #[cfg(feature = "evm-prove")]
-    halo2_pk: OnceLock<keygen::Halo2ProvingKey>,
+    halo2_prover: OnceLock<Halo2Prover>,
 
     _phantom: PhantomData<E>,
 }
@@ -252,7 +252,7 @@ where
             #[cfg(feature = "evm-prove")]
             halo2_params_reader: CacheHalo2ParamsReader::new_with_default_params_dir(),
             #[cfg(feature = "evm-prove")]
-            halo2_pk: OnceLock::new(),
+            halo2_prover: OnceLock::new(),
             _phantom: Default::default(),
         })
     }
@@ -484,10 +484,11 @@ where
         &self,
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
+        def_inputs: &[DeferralInput],
     ) -> Result<types::EvmProof, SdkError> {
         let app_exe = self.convert_to_exe(app_exe)?;
-        let mut evm_halo2_prover = self.evm_halo2_prover(app_exe)?;
-        let evm_proof = evm_halo2_prover.prove_evm(inputs, &[])?;
+        let mut evm_prover = self.evm_prover(app_exe)?;
+        let evm_proof = evm_prover.prove_evm(inputs, def_inputs)?;
         Ok(evm_proof)
     }
 
@@ -542,31 +543,11 @@ where
             self.agg_prover(),
             self.def_path_prover.clone(),
             self.root_prover(),
+            #[cfg(feature = "evm-prove")]
+            Some(self.halo2_prover()),
         )?;
         Ok(evm_prover)
     }
-
-    #[cfg(feature = "evm-prove")]
-    pub fn evm_halo2_prover(
-        &self,
-        app_exe: impl Into<ExecutableFormat>,
-    ) -> Result<prover::EvmHalo2Prover<E, VB>, SdkError> {
-        let app_exe = self.convert_to_exe(app_exe)?;
-        let app_pk = self.app_pk();
-        let halo2_pk = self.halo2_pk().clone();
-        let evm_halo2_prover = prover::EvmHalo2Prover::<E, _>::new(
-            &self.halo2_params_reader,
-            self.app_vm_builder.clone(),
-            &app_pk.app_vm_pk,
-            app_exe,
-            self.agg_prover(),
-            self.def_path_prover.clone(),
-            self.root_prover(),
-            halo2_pk,
-        )?;
-        Ok(evm_halo2_prover)
-    }
-
     // ===================== Component Prover Constructors =====================
 
     pub fn agg_prover(&self) -> Arc<AggProver> {
@@ -589,11 +570,13 @@ where
                 // TODO[INT-6073]: store root_params
                 let system_config = self.app_config.app_vm_config.as_ref();
                 let root_params = root_params_with_100_bits_security();
+                let app_pk = self.app_pk();
+                let agg_prover = self.agg_prover();
 
-                let trace_heights = compute_root_proof_heights(
-                    system_config.clone(),
-                    self.agg_config.params.clone(),
-                    self.agg_tree_config,
+                let (trace_heights, root_pk) = compute_root_proof_heights::<E, VB>(
+                    self.app_vm_builder.clone(),
+                    &app_pk.app_vm_pk,
+                    agg_prover.clone(),
                     root_params.clone(),
                     self.def_path_prover.clone(),
                 )
@@ -602,8 +585,7 @@ where
                 let memory_dimensions = system_config.memory_config.memory_dimensions();
                 let num_user_pvs = system_config.num_public_values;
 
-                let agg_prover = self.agg_prover();
-                Arc::new(RootProver::new(
+                Arc::new(RootProver::from_pk(
                     agg_prover.internal_recursive_prover.get_vk(),
                     agg_prover
                         .internal_recursive_prover
@@ -611,12 +593,45 @@ where
                         .unwrap()
                         .commitment
                         .into(),
-                    root_params,
+                    root_pk,
                     memory_dimensions,
                     num_user_pvs,
                     self.def_hook_vk_commit(),
                     Some(trace_heights),
                 ))
+            })
+            .clone()
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn halo2_prover(&self) -> Halo2Prover {
+        self.halo2_prover
+            .get_or_init(|| {
+                use crate::keygen::static_verifier::keygen_halo2;
+
+                let root_prover = self.root_prover();
+                let root_vk = root_prover.0.get_vk().as_ref().clone();
+                let agg_prover = self.agg_prover();
+
+                // Generate a dummy root proof by running a trivial program through the pipeline
+                let dummy_root_proof = keygen::dummy::generate_dummy_root_proof::<E, _>(
+                    self.app_vm_builder.clone(),
+                    &self.app_pk().app_vm_pk,
+                    agg_prover.clone(),
+                    self.def_path_prover.clone(),
+                    root_prover,
+                );
+
+                let halo2_pk = keygen_halo2(
+                    &self.halo2_config,
+                    &self.halo2_params_reader,
+                    self.halo2_shape,
+                    &agg_prover.internal_recursive_prover.get_vk(),
+                    &root_vk,
+                    &dummy_root_proof,
+                );
+
+                Halo2Prover::new(self.halo2_params_reader(), halo2_pk)
             })
             .clone()
     }
@@ -674,11 +689,6 @@ where
         self.agg_prover().internal_recursive_prover.get_vk()
     }
 
-    #[cfg(feature = "evm-prove")]
-    pub fn halo2_keygen(&self) -> &keygen::Halo2ProvingKey {
-        self.halo2_pk()
-    }
-
     /// Generates the Halo2 (static verifier + wrapper) proving key once and caches it.
     ///
     /// The flow:
@@ -688,58 +698,8 @@ where
     /// 4. Generate a dummy snark from the verifier
     /// 5. Keygen the wrapper circuit (auto-tuned or fixed k)
     #[cfg(feature = "evm-prove")]
-    pub fn halo2_pk(&self) -> &keygen::Halo2ProvingKey {
-        self.halo2_pk.get_or_init(|| {
-            let root_prover = self.root_prover();
-            let root_vk = root_prover.0.get_vk().as_ref().clone();
-
-            let agg_prover = self.agg_prover();
-            let internal_recursive_dag_cached_commit: openvm_continuations::CommitBytes =
-                agg_prover
-                    .internal_recursive_prover
-                    .get_self_vk_pcs_data()
-                    .unwrap()
-                    .commitment
-                    .into();
-
-            // Generate a dummy root proof by running a trivial program through the pipeline
-            let dummy_root_proof = keygen::dummy::generate_dummy_root_proof::<E, _>(
-                self.app_vm_builder.clone(),
-                &self.app_pk().app_vm_pk,
-                self.agg_prover(),
-                self.def_path_prover.clone(),
-                self.root_prover(),
-            );
-
-            keygen::static_verifier::keygen_halo2(
-                &self.halo2_config,
-                &self.halo2_params_reader,
-                self.halo2_shape,
-                &root_vk,
-                internal_recursive_dag_cached_commit,
-                &dummy_root_proof,
-            )
-        })
-    }
-
-    /// Sets the halo2 proving keys. Returns `Ok(())` if halo2 keygen has not been called and
-    /// `Err(halo2_pk)` if keygen has already been called.
-    #[cfg(feature = "evm-prove")]
-    #[allow(clippy::result_large_err)]
-    pub fn set_halo2_pk(
-        &self,
-        halo2_pk: keygen::Halo2ProvingKey,
-    ) -> Result<(), keygen::Halo2ProvingKey> {
-        self.halo2_pk.set(halo2_pk)
-    }
-    /// See [`set_halo2_pk`](Self::set_halo2_pk). This should only be used in a constructor, and
-    /// panics if halo2 keygen has already been called.
-    #[cfg(feature = "evm-prove")]
-    pub fn with_halo2_pk(self, halo2_pk: keygen::Halo2ProvingKey) -> Self {
-        let _ = self
-            .set_halo2_pk(halo2_pk)
-            .map_err(|_| panic!("halo2_pk already set"));
-        self
+    pub fn halo2_pk(&self) -> Halo2ProvingKey {
+        self.halo2_prover().pk()
     }
 
     #[cfg(feature = "evm-prove")]
@@ -747,6 +707,7 @@ where
         self.set_halo2_params_dir(params_dir);
         self
     }
+
     #[cfg(feature = "evm-prove")]
     pub fn set_halo2_params_dir(&mut self, params_dir: impl AsRef<Path>) {
         self.halo2_params_reader = CacheHalo2ParamsReader::new(params_dir);

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -13,6 +13,10 @@ use crate::{
     DeferralInput, StdIn, SC,
 };
 
+/// EVM prover that produces a root STARK proof (without Halo2 wrapping).
+///
+/// Use [`EvmHalo2Prover`] for the full two-step flow that produces an
+/// EVM-verifiable Halo2 proof.
 pub struct EvmProver<E, VB>
 where
     E: StarkEngine,
@@ -42,7 +46,6 @@ where
         })
     }
 
-    // TODO[INT-5581]: should output an EvmProof
     pub fn prove(
         &mut self,
         input: StdIn<Val<SC>>,
@@ -102,5 +105,67 @@ where
 
         let root_proof = self.root_prover.prove_from_ctx(root_ctx)?;
         Ok(root_proof)
+    }
+}
+
+/// Full EVM prover that combines STARK proving with Halo2 wrapping.
+///
+/// Produces an [`EvmProof`](crate::types::EvmProof) suitable for on-chain
+/// verification.
+#[cfg(feature = "evm-prove")]
+pub struct EvmHalo2Prover<E, VB>
+where
+    E: StarkEngine,
+    VB: VmBuilder<E>,
+{
+    pub evm_prover: EvmProver<E, VB>,
+    pub halo2_prover: super::Halo2Prover,
+}
+
+#[cfg(feature = "evm-prove")]
+impl<E, VB> EvmHalo2Prover<E, VB>
+where
+    E: StarkEngine<SC = SC>,
+    VB: VmBuilder<E> + Clone,
+    Val<SC>: PrimeField32,
+{
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        reader: &impl openvm_static_verifier::Halo2ParamsReader,
+        vm_builder: VB,
+        app_vm_pk: &VmProvingKey<VB::VmConfig>,
+        app_exe: Arc<VmExe<Val<SC>>>,
+        agg_prover: Arc<AggProver>,
+        def_prover: Option<Arc<DeferralPathProver>>,
+        root_prover: Arc<RootProver>,
+        halo2_pk: crate::keygen::Halo2ProvingKey,
+    ) -> Result<Self> {
+        let evm_prover = EvmProver::new(
+            vm_builder,
+            app_vm_pk,
+            app_exe,
+            agg_prover,
+            def_prover,
+            root_prover,
+        )?;
+        Ok(Self {
+            evm_prover,
+            halo2_prover: super::Halo2Prover::new(reader, halo2_pk),
+        })
+    }
+
+    pub fn prove_evm(
+        &mut self,
+        input: StdIn<Val<SC>>,
+        def_inputs: &[DeferralInput],
+    ) -> Result<crate::types::EvmProof>
+    where
+        <VB::VmConfig as VmExecutionConfig<Val<SC>>>::Executor: Executor<Val<SC>>
+            + MeteredExecutor<Val<SC>>
+            + PreflightExecutor<Val<SC>, VB::RecordArena>,
+    {
+        let root_proof = self.evm_prover.prove(input, def_inputs)?;
+        let evm_proof = self.halo2_prover.prove_for_evm(&root_proof);
+        Ok(evm_proof)
     }
 }

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -8,15 +8,18 @@ use openvm_circuit::arch::{
 use openvm_continuations::RootSC;
 use openvm_stark_backend::{p3_field::PrimeField32, proof::Proof, StarkEngine, Val};
 
+#[cfg(feature = "evm-prove")]
+use crate::prover::Halo2Prover;
 use crate::{
     prover::{vm::types::VmProvingKey, AggProver, DeferralPathProver, RootProver, StarkProver},
     DeferralInput, StdIn, SC,
 };
 
-/// EVM prover that produces a root STARK proof (without Halo2 wrapping).
+/// EVM prover that produces a root STARK proof with Halo2 wrapping.
 ///
-/// Use [`EvmHalo2Prover`] for the full two-step flow that produces an
-/// EVM-verifiable Halo2 proof.
+/// [`EvmProver::prove_unwrapped`] outputs the unwrapped root STARK, while
+/// [`EvmProver::prove_evm`] produces an [`EvmProof`](crate::types::EvmProof)
+/// suitable for on-chain verification.
 pub struct EvmProver<E, VB>
 where
     E: StarkEngine,
@@ -24,6 +27,8 @@ where
 {
     pub stark_prover: StarkProver<E, VB>,
     pub root_prover: Arc<RootProver>,
+    #[cfg(feature = "evm-prove")]
+    pub halo2_prover: Option<Halo2Prover>,
 }
 
 impl<E, VB> EvmProver<E, VB>
@@ -39,14 +44,17 @@ where
         agg_prover: Arc<AggProver>,
         def_prover: Option<Arc<DeferralPathProver>>,
         root_prover: Arc<RootProver>,
+        #[cfg(feature = "evm-prove")] halo2_prover: Option<Halo2Prover>,
     ) -> Result<Self> {
         Ok(Self {
             stark_prover: StarkProver::new(vm_builder, app_vm_pk, app_exe, agg_prover, def_prover)?,
             root_prover,
+            #[cfg(feature = "evm-prove")]
+            halo2_prover,
         })
     }
 
-    pub fn prove(
+    pub fn prove_unwrapped(
         &mut self,
         input: StdIn<Val<SC>>,
         def_inputs: &[DeferralInput],
@@ -106,54 +114,8 @@ where
         let root_proof = self.root_prover.prove_from_ctx(root_ctx)?;
         Ok(root_proof)
     }
-}
 
-/// Full EVM prover that combines STARK proving with Halo2 wrapping.
-///
-/// Produces an [`EvmProof`](crate::types::EvmProof) suitable for on-chain
-/// verification.
-#[cfg(feature = "evm-prove")]
-pub struct EvmHalo2Prover<E, VB>
-where
-    E: StarkEngine,
-    VB: VmBuilder<E>,
-{
-    pub evm_prover: EvmProver<E, VB>,
-    pub halo2_prover: super::Halo2Prover,
-}
-
-#[cfg(feature = "evm-prove")]
-impl<E, VB> EvmHalo2Prover<E, VB>
-where
-    E: StarkEngine<SC = SC>,
-    VB: VmBuilder<E> + Clone,
-    Val<SC>: PrimeField32,
-{
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        reader: &impl openvm_static_verifier::Halo2ParamsReader,
-        vm_builder: VB,
-        app_vm_pk: &VmProvingKey<VB::VmConfig>,
-        app_exe: Arc<VmExe<Val<SC>>>,
-        agg_prover: Arc<AggProver>,
-        def_prover: Option<Arc<DeferralPathProver>>,
-        root_prover: Arc<RootProver>,
-        halo2_pk: crate::keygen::Halo2ProvingKey,
-    ) -> Result<Self> {
-        let evm_prover = EvmProver::new(
-            vm_builder,
-            app_vm_pk,
-            app_exe,
-            agg_prover,
-            def_prover,
-            root_prover,
-        )?;
-        Ok(Self {
-            evm_prover,
-            halo2_prover: super::Halo2Prover::new(reader, halo2_pk),
-        })
-    }
-
+    #[cfg(feature = "evm-prove")]
     pub fn prove_evm(
         &mut self,
         input: StdIn<Val<SC>>,
@@ -164,8 +126,12 @@ where
             + MeteredExecutor<Val<SC>>
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
-        let root_proof = self.evm_prover.prove(input, def_inputs)?;
-        let evm_proof = self.halo2_prover.prove_for_evm(&root_proof);
+        let root_proof = self.prove_unwrapped(input, def_inputs)?;
+        let evm_proof = self
+            .halo2_prover
+            .as_ref()
+            .unwrap()
+            .prove_for_evm(&root_proof);
         Ok(evm_proof)
     }
 }

--- a/crates/sdk/src/prover/halo2.rs
+++ b/crates/sdk/src/prover/halo2.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use openvm_continuations::RootSC;
+use openvm_stark_backend::proof::Proof;
+use openvm_static_verifier::{Halo2Params, Halo2ParamsReader};
+use tracing::info_span;
+
+use crate::{keygen::Halo2ProvingKey, types::EvmProof};
+
+pub struct Halo2Prover {
+    halo2_pk: Halo2ProvingKey,
+    verifier_srs: Arc<Halo2Params>,
+    wrapper_srs: Arc<Halo2Params>,
+}
+
+impl Halo2Prover {
+    pub fn new(reader: &impl Halo2ParamsReader, halo2_pk: Halo2ProvingKey) -> Self {
+        let verifier_k = halo2_pk.verifier.pinning.metadata.config_params.k;
+        let wrapper_k = halo2_pk.wrapper.pinning.metadata.config_params.k;
+        let verifier_srs = reader.read_params(verifier_k);
+        let wrapper_srs = reader.read_params(wrapper_k);
+        Self {
+            halo2_pk,
+            verifier_srs,
+            wrapper_srs,
+        }
+    }
+
+    pub fn prove_for_evm(&self, root_proof: &Proof<RootSC>) -> EvmProof {
+        let snark = info_span!("prove", group = "halo2_outer").in_scope(|| {
+            self.halo2_pk
+                .verifier
+                .prove_wrapped(&self.verifier_srs, root_proof)
+        });
+        info_span!("prove_for_evm", group = "halo2_wrapper").in_scope(|| {
+            let raw = self
+                .halo2_pk
+                .wrapper
+                .prove_for_evm(&self.wrapper_srs, snark);
+            EvmProof::from(raw)
+        })
+    }
+}

--- a/crates/sdk/src/prover/halo2.rs
+++ b/crates/sdk/src/prover/halo2.rs
@@ -7,6 +7,7 @@ use tracing::info_span;
 
 use crate::{keygen::Halo2ProvingKey, types::EvmProof};
 
+#[derive(Clone)]
 pub struct Halo2Prover {
     halo2_pk: Halo2ProvingKey,
     verifier_srs: Arc<Halo2Params>,
@@ -39,5 +40,9 @@ impl Halo2Prover {
                 .prove_for_evm(&self.wrapper_srs, snark);
             EvmProof::from(raw)
         })
+    }
+
+    pub fn pk(&self) -> Halo2ProvingKey {
+        self.halo2_pk.clone()
     }
 }

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -1,10 +1,8 @@
 mod agg;
 mod app;
 mod deferral;
-// TODO[jpw]: feature gate
-// #[cfg(feature = "evm-prove")]
-mod evm;
 // TODO[jpw]: feature gate behind evm-prove
+mod evm;
 mod root;
 mod stark;
 pub mod vm;
@@ -13,93 +11,6 @@ pub use agg::*;
 pub use app::*;
 pub use deferral::*;
 // TODO[jpw]: feature gate
-// #[cfg(feature = "evm-prove")]
 pub use evm::*;
 pub use root::*;
 pub use stark::*;
-
-#[cfg(feature = "evm-prove")]
-mod evm {
-    use std::sync::Arc;
-
-    use openvm_circuit::arch::{
-        instructions::exe::VmExe, Executor, MeteredExecutor, PreflightExecutor,
-        VirtualMachineError, VmBuilder, VmExecutionConfig,
-    };
-    use openvm_native_circuit::NativeConfig;
-    use openvm_native_recursion::halo2::utils::Halo2ParamsReader;
-    use openvm_stark_sdk::engine::StarkFriEngine;
-
-    use super::{Halo2Prover, StarkProver};
-    use crate::{
-        config::AggregationTreeConfig,
-        keygen::{AggProvingKey, AppProvingKey, Halo2ProvingKey},
-        stdin::StdIn,
-        types::EvmProof,
-        F, SC,
-    };
-
-    pub struct EvmHalo2Prover<E, VB, NativeBuilder>
-    where
-        E: StarkFriEngine<SC = SC>,
-        VB: VmBuilder<E>,
-        NativeBuilder: VmBuilder<E, VmConfig = NativeConfig>,
-    {
-        pub stark_prover: StarkProver<E, VB, NativeBuilder>,
-        pub halo2_prover: Halo2Prover,
-    }
-
-    impl<E, VB, NativeBuilder> EvmHalo2Prover<E, VB, NativeBuilder>
-    where
-        E: StarkFriEngine<SC = SC>,
-        VB: VmBuilder<E>,
-        <VB::VmConfig as VmExecutionConfig<F>>::Executor: Executor<F>
-            + MeteredExecutor<F>
-            + PreflightExecutor<F, <VB as VmBuilder<E>>::RecordArena>,
-        NativeBuilder: VmBuilder<E, VmConfig = NativeConfig> + Clone,
-        <NativeConfig as VmExecutionConfig<F>>::Executor:
-            PreflightExecutor<F, <NativeBuilder as VmBuilder<E>>::RecordArena>,
-    {
-        #[allow(clippy::too_many_arguments)]
-        pub fn new(
-            reader: &impl Halo2ParamsReader,
-            app_vm_builder: VB,
-            native_builder: NativeBuilder,
-            app_pk: &AppProvingKey<VB::VmConfig>,
-            app_exe: Arc<VmExe<F>>,
-            agg_pk: &AggProvingKey,
-            halo2_pk: Halo2ProvingKey,
-            agg_tree_config: AggregationTreeConfig,
-        ) -> Result<Self, VirtualMachineError> {
-            let stark_prover = StarkProver::new(
-                app_vm_builder,
-                native_builder,
-                app_pk,
-                app_exe,
-                agg_pk,
-                agg_tree_config,
-            )?;
-            Ok(Self {
-                stark_prover,
-                halo2_prover: Halo2Prover::new(reader, halo2_pk),
-            })
-        }
-
-        pub fn with_program_name(mut self, program_name: impl AsRef<str>) -> Self {
-            self.set_program_name(program_name);
-            self
-        }
-        pub fn set_program_name(&mut self, program_name: impl AsRef<str>) -> &mut Self {
-            self.stark_prover.set_program_name(program_name);
-            self
-        }
-
-        pub fn prove_evm(&mut self, input: StdIn) -> Result<EvmProof, VirtualMachineError> {
-            let root_proof = self
-                .stark_prover
-                .generate_proof_for_outer_recursion(input)?;
-            let evm_proof = self.halo2_prover.prove_for_evm(&root_proof);
-            Ok(evm_proof)
-        }
-    }
-}

--- a/crates/sdk/src/prover/mod.rs
+++ b/crates/sdk/src/prover/mod.rs
@@ -1,8 +1,9 @@
 mod agg;
 mod app;
 mod deferral;
-// TODO[jpw]: feature gate behind evm-prove
 mod evm;
+#[cfg(feature = "evm-prove")]
+mod halo2;
 mod root;
 mod stark;
 pub mod vm;
@@ -10,7 +11,8 @@ pub mod vm;
 pub use agg::*;
 pub use app::*;
 pub use deferral::*;
-// TODO[jpw]: feature gate
 pub use evm::*;
+#[cfg(feature = "evm-prove")]
+pub use halo2::*;
 pub use root::*;
 pub use stark::*;

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -1,47 +1,25 @@
 use std::sync::Arc;
 
 use eyre::Result;
-use openvm_circuit::{
-    arch::{
-        instructions::{
-            exe::VmExe, instruction::Instruction, program::Program, LocalOpcode, SystemOpcode,
-        },
-        SystemConfig,
-    },
-    system::memory::dimensions::MemoryDimensions,
-};
+use openvm_circuit::system::memory::dimensions::MemoryDimensions;
 use openvm_continuations::{CommitBytes, RootSC, SC};
-use openvm_sdk_config::SdkVmBuilder;
 use openvm_stark_backend::{
     keygen::types::{MultiStarkProvingKey, MultiStarkVerifyingKey},
     proof::Proof,
     prover::ProvingContext,
     StarkEngine, SystemParams,
 };
-use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security,
-    baby_bear_poseidon2::{Digest, F},
-    MAX_APP_LOG_STACKED_HEIGHT,
-};
+use openvm_stark_sdk::config::baby_bear_poseidon2::Digest;
 use openvm_verify_stark_host::NonRootStarkProof;
 use tracing::info_span;
-
-use crate::{
-    config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig},
-    keygen::AppProvingKey,
-    prover::{AggProver, DeferralPathProver, StarkProver},
-    StdIn,
-};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
         use openvm_continuations::prover::RootCpuProver as RootInnerProver;
-        type E = openvm_cuda_backend::BabyBearBn254Poseidon2GpuEngine;
-        type ChildE = openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
+        type E = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
     } else {
         use openvm_continuations::prover::RootCpuProver as RootInnerProver;
         type E = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
-        type ChildE = openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2CpuEngine;
     }
 }
 
@@ -112,79 +90,4 @@ impl RootProver {
             .in_scope(|| info_span!("root").in_scope(|| self.0.root_prove_from_ctx::<E>(ctx)))?;
         Ok(proof)
     }
-}
-
-pub fn compute_root_proof_heights(
-    system_config: SystemConfig,
-    agg_params: AggregationSystemParams,
-    agg_tree_config: AggregationTreeConfig,
-    root_params: SystemParams,
-    def_prover: Option<Arc<DeferralPathProver>>,
-) -> Result<Vec<usize>> {
-    let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
-        SystemOpcode::TERMINATE.global_opcode(),
-        0,
-        0,
-        0,
-        0,
-        0,
-    )]);
-    let dummy_exe = Arc::new(VmExe::new(dummy_program));
-
-    let memory_dimensions = system_config.memory_config.memory_dimensions();
-    let num_user_pvs = system_config.num_public_values;
-
-    let mut app_config = AppConfig::riscv32(app_params_with_100_bits_security(
-        MAX_APP_LOG_STACKED_HEIGHT,
-    ));
-    app_config.app_vm_config.system.config = system_config;
-
-    let def_hook_cached_commit = def_prover.as_ref().map(|p| p.def_hook_cached_commit());
-    let def_hook_vk_commit = def_prover.as_ref().map(|p| p.def_hook_vk_commit().into());
-
-    let app_pk = AppProvingKey::keygen(app_config)?;
-    let agg_prover = Arc::new(AggProver::new(
-        Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()),
-        AggregationConfig { params: agg_params },
-        agg_tree_config,
-        def_hook_cached_commit,
-    ));
-
-    let mut stark_prover = StarkProver::<ChildE, SdkVmBuilder>::new(
-        Default::default(),
-        &app_pk.app_vm_pk,
-        dummy_exe,
-        agg_prover.clone(),
-        def_prover,
-    )?;
-    let (agg_proof, _) = stark_prover.prove(StdIn::default(), &[])?;
-
-    let root_prover = RootInnerProver::new::<E>(
-        agg_prover.internal_recursive_prover.get_vk(),
-        agg_prover
-            .internal_recursive_prover
-            .get_self_vk_pcs_data()
-            .unwrap()
-            .commitment
-            .into(),
-        root_params,
-        memory_dimensions,
-        num_user_pvs,
-        def_hook_vk_commit,
-        None,
-    );
-
-    let root_proving_ctx: ProvingContext<<E as StarkEngine>::PB> = root_prover
-        .generate_proving_ctx(
-            agg_proof.inner,
-            &agg_proof.user_pvs_proof,
-            agg_proof.deferral_merkle_proofs.as_ref(),
-        )
-        .unwrap();
-
-    let ret = root_proving_ctx
-        .into_iter()
-        .map(|(_, air_ctx)| air_ctx.height())
-        .collect();
-    Ok(ret)
 }

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -36,7 +36,7 @@ use crate::{
 cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
         use openvm_continuations::prover::RootCpuProver as RootInnerProver;
-        type E = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
+        type E = openvm_cuda_backend::BabyBearBn254Poseidon2GpuEngine;
         type ChildE = openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
     } else {
         use openvm_continuations::prover::RootCpuProver as RootInnerProver;

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -5,9 +5,12 @@ use openvm::platform::memory::MEM_SIZE;
 use openvm_circuit::arch::instructions::DEFERRAL_AS;
 use openvm_deferral_circuit::DeferralFn;
 use openvm_stark_backend::StarkEngine;
-use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security, internal_params_with_100_bits_security,
-    root_params_with_100_bits_security,
+use openvm_stark_sdk::{
+    config::{
+        app_params_with_100_bits_security, internal_params_with_100_bits_security,
+        root_params_with_100_bits_security,
+    },
+    utils::setup_tracing,
 };
 use openvm_transpiler::elf::Elf;
 use openvm_verify_stark_circuit::extension::{
@@ -36,7 +39,8 @@ cfg_if::cfg_if! {
 }
 
 #[test]
-fn test_root_prover_trace_heights() -> Result<()> {
+fn test_sdk_fibonacci() -> Result<()> {
+    setup_tracing();
     let n_stack = 19;
     let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
     let agg_params = AggregationSystemParams::default();
@@ -48,16 +52,25 @@ fn test_root_prover_trace_heights() -> Result<()> {
 
     let sdk = Sdk::riscv32(app_params, agg_params);
     let app_exe = sdk.convert_to_exe(elf)?;
-    let mut evm_prover = sdk.evm_prover(app_exe)?;
 
     let n = 1000u64;
     let mut stdin = StdIn::default();
     stdin.write(&n);
 
-    let proof = evm_prover.prove(stdin, &[])?;
-    let vk = evm_prover.root_prover.0.get_vk();
-    let engine = RootE::new(vk.inner.params.clone());
-    engine.verify(&vk, &proof)?;
+    #[cfg(not(feature = "evm-verify"))]
+    {
+        let mut evm_prover = sdk.evm_prover(app_exe)?;
+        let proof = evm_prover.prove_unwrapped(stdin, &[])?;
+        let vk = evm_prover.root_prover.0.get_vk();
+        let engine = RootE::new(vk.inner.params.clone());
+        engine.verify(&vk, &proof)?;
+    }
+    #[cfg(feature = "evm-verify")]
+    {
+        let evm_proof = sdk.prove_evm(app_exe, stdin, &[])?;
+        let openvm_verifier = sdk.generate_halo2_verifier_solidity()?;
+        let _gas_cost = Sdk::verify_evm_halo2_proof(&openvm_verifier, evm_proof)?;
+    }
 
     Ok(())
 }
@@ -164,7 +177,7 @@ fn test_verify_stark_deferral() -> Result<()> {
 
     // ---- Step 10: Prove and verify ----
     let mut evm_prover = vs_sdk.evm_prover(vs_exe)?;
-    let vs_proof = evm_prover.prove(vs_stdin, &[def_input])?;
+    let vs_proof = evm_prover.prove_unwrapped(vs_stdin, &[def_input])?;
 
     let vk = evm_prover.root_prover.0.get_vk();
     let engine = RootE::new(vk.inner.params.clone());
@@ -221,7 +234,7 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
     stdin.write(&n);
 
     let mut evm_prover = sdk.evm_prover(app_exe)?;
-    let proof = evm_prover.prove(stdin, &[])?;
+    let proof = evm_prover.prove_unwrapped(stdin, &[])?;
 
     // ---- Step 3: Verify the final result ----
     let vk = evm_prover.root_prover.0.get_vk();
@@ -322,15 +335,15 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
 
             // Compute trace heights for root prover with profiling params
             let system_config = sdk.app_config().app_vm_config.as_ref();
-            let trace_heights = compute_root_proof_heights(
-                system_config.clone(),
-                sdk.agg_config().params.clone(),
-                *sdk.agg_tree_config(),
+            let agg_prover = sdk.agg_prover();
+            let (trace_heights, root_pk) = compute_root_proof_heights::<E, _>(
+                sdk.app_vm_builder().clone(),
+                &sdk.app_pk().app_vm_pk,
+                agg_prover.clone(),
                 root_params.clone(),
                 None,
             )?;
 
-            let agg_prover = sdk.agg_prover();
             let ir_vk = agg_prover.internal_recursive_prover.get_vk();
             let ir_pcs_data = agg_prover
                 .internal_recursive_prover
@@ -341,9 +354,10 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
             let memory_dimensions = system_config.memory_config.memory_dimensions();
             let num_user_pvs = system_config.num_public_values;
 
-            let root_prover = Arc::new(RootProver::new(
+            let root_prover = Arc::new(RootProver::from_pk(
                 ir_vk,
                 dag_commit,
+                root_pk,
                 root_params.clone(),
                 memory_dimensions,
                 num_user_pvs,

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -270,14 +270,15 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
     };
     use openvm_stark_sdk::config::log_up_params::log_up_security_params_baby_bear_100_bits;
     use openvm_static_verifier::{
+        compute_dag_onion_commit,
         field::baby_bear::{BabyBearChip, BabyBearExtChip},
         log_heights_per_air_from_proof, StaticVerifierCircuit,
     };
-    use p3_bn254::Bn254;
 
     use crate::{
         config::{AggregationSystemParams, DEFAULT_APP_L_SKIP},
-        prover::{compute_root_proof_heights, EvmProver, RootProver},
+        keygen::dummy::compute_root_proof_heights,
+        prover::{EvmProver, RootProver},
         Sdk, StdIn,
     };
 
@@ -300,9 +301,9 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
 
     let proof_path = format!("{cache_dir}/sdk_root_proof.bin");
     let vk_path = format!("{cache_dir}/sdk_root_vk.bin");
-    let commit_path = format!("{cache_dir}/sdk_dag_commit.bin");
+    let commit_path = format!("{cache_dir}/sdk_onion_commit.bin");
 
-    let (root_vk, root_proof, dag_commit) =
+    let (root_vk, root_proof, onion_commit) =
         if Path::new(&proof_path).exists() && Path::new(&vk_path).exists() {
             eprintln!("Loading cached root proof from {cache_dir}/");
             let proof_bytes = std::fs::read(&proof_path)?;
@@ -315,9 +316,9 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
             let commit_bytes: [u8; 32] = std::fs::read(&commit_path)?
                 .try_into()
                 .map_err(|_| eyre::eyre!("invalid commit file"))?;
-            let dag_commit = CommitBytes::new(commit_bytes);
+            let onion_commit = CommitBytes::new(commit_bytes).into();
 
-            (root_vk, root_proof, dag_commit)
+            (root_vk, root_proof, onion_commit)
         } else {
             eprintln!("Generating root proof via SDK pipeline (this takes a while)...");
             let n_stack = 19;
@@ -350,6 +351,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
                 .get_self_vk_pcs_data()
                 .unwrap();
             let dag_commit: CommitBytes = ir_pcs_data.commitment.into();
+            let onion_commit = compute_dag_onion_commit(&ir_vk);
 
             let memory_dimensions = system_config.memory_config.memory_dimensions();
             let num_user_pvs = system_config.num_public_values;
@@ -358,7 +360,6 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
                 ir_vk,
                 dag_commit,
                 root_pk,
-                root_params.clone(),
                 memory_dimensions,
                 num_user_pvs,
                 None,
@@ -372,13 +373,14 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
                 agg_prover,
                 None,
                 root_prover.clone(),
+                None,
             )?;
 
             let n = 100u64;
             let mut stdin = StdIn::default();
             stdin.write(&n);
 
-            let root_proof = evm_prover.prove(stdin, &[])?;
+            let root_proof = evm_prover.prove_unwrapped(stdin, &[])?;
             let root_vk_arc = root_prover.0.get_vk();
             let root_vk = root_vk_arc.as_ref().clone();
 
@@ -394,17 +396,16 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
                 bitcode::serialize(&root_vk)
                     .map_err(|e| eyre::eyre!("failed to serialize root VK: {e}"))?,
             )?;
-            std::fs::write(&commit_path, dag_commit.as_slice())?;
+            std::fs::write(&commit_path, CommitBytes::from(onion_commit).as_slice())?;
 
-            (root_vk, root_proof, dag_commit)
+            (root_vk, root_proof, onion_commit)
         };
 
     // Run static verifier cell profiling
     eprintln!("Running static verifier cell profiling...");
     let log_heights = log_heights_per_air_from_proof(&root_proof);
 
-    let bn254: Bn254 = dag_commit.into();
-    let circuit = StaticVerifierCircuit::try_new(root_vk, [bn254], &log_heights)
+    let circuit = StaticVerifierCircuit::try_new(root_vk, onion_commit, &log_heights)
         .expect("Failed to construct StaticVerifierCircuit");
 
     let profile_dir = std::env::var("OPENVM_PROFILE_DIR").unwrap_or_else(|_| "profile".to_string());

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -230,3 +230,192 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
 
     Ok(())
 }
+
+/// Cell-count profiling test for the static verifier circuit using a production root proof.
+///
+/// Root verifier params match `pipeline_cell_count_profiling` in static-verifier crate.
+/// The root proof is generated from a full SDK aggregation pipeline and cached to disk.
+///
+/// Run with:
+/// ```sh
+/// OPENVM_CACHE_DIR=cache OPENVM_PROFILE_DIR=profile \
+///   cargo nextest run --cargo-profile=fast -p openvm-sdk --features cuda,cell-profiling \
+///   -- sdk_static_verifier_cell_profiling
+/// ```
+#[cfg(feature = "cell-profiling")]
+#[test]
+fn sdk_static_verifier_cell_profiling() -> Result<()> {
+    use std::path::Path;
+
+    use halo2_base::gates::circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage};
+    use openvm::platform::memory::MEM_SIZE;
+    use openvm_continuations::{CommitBytes, RootSC};
+    use openvm_stark_backend::{
+        codec::{Decode, Encode},
+        proof::Proof,
+        SystemParams, WhirProximityStrategy,
+    };
+    use openvm_stark_sdk::config::log_up_params::log_up_security_params_baby_bear_100_bits;
+    use openvm_static_verifier::{
+        field::baby_bear::{BabyBearChip, BabyBearExtChip},
+        log_heights_per_air_from_proof, StaticVerifierCircuit,
+    };
+    use p3_bn254::Bn254;
+
+    use crate::{
+        config::{AggregationSystemParams, DEFAULT_APP_L_SKIP},
+        prover::{compute_root_proof_heights, EvmProver, RootProver},
+        Sdk, StdIn,
+    };
+
+    // Root verifier params matching pipeline_cell_count_profiling in static-verifier
+    let root_params = SystemParams::new(
+        4,  // log_blowup
+        2,  // l_skip
+        19, // n_stack
+        16, // w_stack
+        10, // max_log_final_poly_len
+        20, // folding pow
+        20, // mu pow
+        WhirProximityStrategy::ListDecoding { m: 2 },
+        100,
+        log_up_security_params_baby_bear_100_bits(),
+    );
+
+    let cache_dir = std::env::var("OPENVM_CACHE_DIR").unwrap_or_else(|_| "cache".to_string());
+    std::fs::create_dir_all(&cache_dir)?;
+
+    let proof_path = format!("{cache_dir}/sdk_root_proof.bin");
+    let vk_path = format!("{cache_dir}/sdk_root_vk.bin");
+    let commit_path = format!("{cache_dir}/sdk_dag_commit.bin");
+
+    let (root_vk, root_proof, dag_commit) =
+        if Path::new(&proof_path).exists() && Path::new(&vk_path).exists() {
+            eprintln!("Loading cached root proof from {cache_dir}/");
+            let proof_bytes = std::fs::read(&proof_path)?;
+            let root_proof = Proof::<RootSC>::decode_from_bytes(&proof_bytes)?;
+
+            let vk_bytes = std::fs::read(&vk_path)?;
+            let root_vk = bitcode::deserialize(&vk_bytes)
+                .map_err(|e| eyre::eyre!("failed to deserialize root VK: {e}"))?;
+
+            let commit_bytes: [u8; 32] = std::fs::read(&commit_path)?
+                .try_into()
+                .map_err(|_| eyre::eyre!("invalid commit file"))?;
+            let dag_commit = CommitBytes::new(commit_bytes);
+
+            (root_vk, root_proof, dag_commit)
+        } else {
+            eprintln!("Generating root proof via SDK pipeline (this takes a while)...");
+            let n_stack = 19;
+            let app_params = openvm_stark_sdk::config::app_params_with_100_bits_security(
+                DEFAULT_APP_L_SKIP + n_stack,
+            );
+            let agg_params = AggregationSystemParams::default();
+
+            let elf = Elf::decode(
+                include_bytes!("../programs/examples/fibonacci.elf"),
+                MEM_SIZE as u32,
+            )?;
+            let sdk = Sdk::riscv32(app_params, agg_params);
+            let app_exe = sdk.convert_to_exe(elf)?;
+
+            // Compute trace heights for root prover with profiling params
+            let system_config = sdk.app_config().app_vm_config.as_ref();
+            let trace_heights = compute_root_proof_heights(
+                system_config.clone(),
+                sdk.agg_config().params.clone(),
+                *sdk.agg_tree_config(),
+                root_params.clone(),
+                None,
+            )?;
+
+            let agg_prover = sdk.agg_prover();
+            let ir_vk = agg_prover.internal_recursive_prover.get_vk();
+            let ir_pcs_data = agg_prover
+                .internal_recursive_prover
+                .get_self_vk_pcs_data()
+                .unwrap();
+            let dag_commit: CommitBytes = ir_pcs_data.commitment.into();
+
+            let memory_dimensions = system_config.memory_config.memory_dimensions();
+            let num_user_pvs = system_config.num_public_values;
+
+            let root_prover = Arc::new(RootProver::new(
+                ir_vk,
+                dag_commit,
+                root_params.clone(),
+                memory_dimensions,
+                num_user_pvs,
+                None,
+                Some(trace_heights),
+            ));
+
+            let mut evm_prover = EvmProver::<E, _>::new(
+                sdk.app_vm_builder().clone(),
+                &sdk.app_pk().app_vm_pk,
+                app_exe,
+                agg_prover,
+                None,
+                root_prover.clone(),
+            )?;
+
+            let n = 100u64;
+            let mut stdin = StdIn::default();
+            stdin.write(&n);
+
+            let root_proof = evm_prover.prove(stdin, &[])?;
+            let root_vk_arc = root_prover.0.get_vk();
+            let root_vk = root_vk_arc.as_ref().clone();
+
+            // Verify the root proof
+            let engine = RootE::new(root_vk.inner.params.clone());
+            engine.verify(&root_vk, &root_proof)?;
+
+            // Cache to disk
+            eprintln!("Caching root proof to {cache_dir}/");
+            std::fs::write(&proof_path, root_proof.encode_to_vec()?)?;
+            std::fs::write(
+                &vk_path,
+                bitcode::serialize(&root_vk)
+                    .map_err(|e| eyre::eyre!("failed to serialize root VK: {e}"))?,
+            )?;
+            std::fs::write(&commit_path, dag_commit.as_slice())?;
+
+            (root_vk, root_proof, dag_commit)
+        };
+
+    // Run static verifier cell profiling
+    eprintln!("Running static verifier cell profiling...");
+    let log_heights = log_heights_per_air_from_proof(&root_proof);
+
+    let bn254: Bn254 = dag_commit.into();
+    let circuit = StaticVerifierCircuit::try_new(root_vk, [bn254], &log_heights)
+        .expect("Failed to construct StaticVerifierCircuit");
+
+    let profile_dir = std::env::var("OPENVM_PROFILE_DIR").unwrap_or_else(|_| "profile".to_string());
+    std::env::set_var("OPENVM_PROFILE_DIR", &profile_dir);
+
+    let mut builder = BaseCircuitBuilder::from_stage(CircuitBuilderStage::Mock)
+        .use_k(22)
+        .use_lookup_bits(8)
+        .use_instance_columns(0);
+    let range = builder.range_chip();
+    let ext_chip = BabyBearExtChip::new(BabyBearChip::new(Arc::new(range)));
+    let ctx = builder.main(0);
+
+    let initial_cells = ctx.advice.len();
+    circuit.populate_verify_stark_constraints(ctx, &ext_chip, &root_proof);
+    let final_cells = ctx.advice.len();
+    eprintln!(
+        "Static verifier cell count: {} (delta: {})",
+        final_cells,
+        final_cells - initial_cells
+    );
+    assert!(
+        final_cells > initial_cells,
+        "expected advice cells to increase"
+    );
+
+    Ok(())
+}

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -398,7 +398,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
 
     let mut builder = BaseCircuitBuilder::from_stage(CircuitBuilderStage::Mock)
         .use_k(22)
-        .use_lookup_bits(8)
+        .use_lookup_bits(21)
         .use_instance_columns(0);
     let range = builder.range_chip();
     let ext_chip = BabyBearExtChip::new(BabyBearChip::new(Arc::new(range)));

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -36,11 +36,24 @@ impl From<Vec<u8>> for ExecutableFormat {
     }
 }
 
+/// Number of bytes in a Bn254.
+pub(crate) const BN254_BYTES: usize = 32;
+/// Number of Bn254 in `accumulator` field (KZG accumulator).
+pub const NUM_BN254_ACCUMULATOR: usize = 12;
+/// Number of Bn254 in `proof` field for a circuit with only 1 advice column.
+#[cfg(feature = "evm-prove")]
+#[allow(dead_code)]
+pub(crate) const NUM_BN254_PROOF: usize = 43;
+
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ProofData {
     #[serde_as(as = "serde_with::hex::Hex")]
-    /// Bn254 proof in little-endian bytes.
+    /// KZG accumulator.
+    pub accumulator: Vec<u8>,
+    #[serde_as(as = "serde_with::hex::Hex")]
+    /// Bn254 proof in little-endian bytes. The circuit only has 1 advice column, so the proof is
+    /// of length `NUM_BN254_PROOF * BN254_BYTES`.
     pub proof: Vec<u8>,
 }
 
@@ -130,9 +143,14 @@ impl EvmProof {
             version: _,
         } = self;
 
+        let ProofData { accumulator, proof } = proof_data;
+
+        let mut proof_data_bytes = accumulator;
+        proof_data_bytes.extend(proof);
+
         IOpenVmHalo2Verifier::verifyCall {
             publicValues: user_public_values.into(),
-            proofData: proof_data.proof.into(),
+            proofData: proof_data_bytes.into(),
             appExeCommit: (*app_commit.app_exe_commit.as_slice()).into(),
             appVmCommit: (*app_commit.app_vm_commit.as_slice()).into(),
         }
@@ -167,10 +185,11 @@ pub fn encode_raw_evm_proof_calldata(
 
 /// Convert `RawEvmProof` → `EvmProof`.
 ///
-/// Instance layout (no KZG accumulator):
-/// - `instances[0]`: app_exe_commit (Fr)
-/// - `instances[1]`: app_vk_commit (Fr)
-/// - `instances[2..]`: user public values (each byte as Fr)
+/// Instance layout (with KZG accumulator from wrapper circuit):
+/// - `instances[0..12]`: KZG accumulator (12 Fr values)
+/// - `instances[12]`: app_exe_commit (Fr)
+/// - `instances[13]`: app_vk_commit (Fr)
+/// - `instances[14..]`: user public values (each byte as Fr)
 #[cfg(feature = "evm-prove")]
 impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
     fn from(raw: openvm_static_verifier::keygen::RawEvmProof) -> Self {
@@ -178,18 +197,31 @@ impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
 
         let openvm_static_verifier::keygen::RawEvmProof { instances, proof } = raw;
         assert!(
-            instances.len() >= 2,
-            "RawEvmProof instances must have at least 2 elements (exe commit + vk commit)"
+            instances.len() > NUM_BN254_ACCUMULATOR + 2,
+            "RawEvmProof instances must have at least {} elements (accumulator + exe commit + vk commit)",
+            NUM_BN254_ACCUMULATOR + 2
         );
 
-        // instances[0] and [1] are Fr values encoding commits.
+        // instances[0..12] are the KZG accumulator
+        let accumulator = instances[0..NUM_BN254_ACCUMULATOR]
+            .iter()
+            .flat_map(|f| f.to_bytes())
+            .collect::<Vec<_>>();
+
+        // Reverse each 32-byte chunk for big-endian EVM format
+        let mut evm_accumulator = Vec::with_capacity(accumulator.len());
+        accumulator
+            .chunks(BN254_BYTES)
+            .for_each(|chunk| evm_accumulator.extend(chunk.iter().rev().copied()));
+
+        // instances[12] and [13] are Fr values encoding commits.
         // Fr::to_bytes() returns 32 bytes in little-endian; CommitBytes expects big-endian.
-        let mut app_exe_bytes = instances[0].to_bytes();
+        let mut app_exe_bytes = instances[NUM_BN254_ACCUMULATOR].to_bytes();
         app_exe_bytes.reverse();
-        let mut app_vm_bytes = instances[1].to_bytes();
+        let mut app_vm_bytes = instances[NUM_BN254_ACCUMULATOR + 1].to_bytes();
         app_vm_bytes.reverse();
 
-        let user_public_values = instances[2..]
+        let user_public_values = instances[NUM_BN254_ACCUMULATOR + 2..]
             .iter()
             .map(|f| {
                 // Each user public value is a single byte stored in the least significant position
@@ -206,7 +238,10 @@ impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
             version: format!("v{OPENVM_VERSION}"),
             app_commit,
             user_public_values,
-            proof_data: ProofData { proof },
+            proof_data: ProofData {
+                accumulator: evm_accumulator,
+                proof,
+            },
         }
     }
 }
@@ -223,6 +258,14 @@ impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
             proof_data,
             version: _,
         } = evm_proof;
+
+        let ProofData { accumulator, proof } = proof_data;
+
+        // Reverse each 32-byte chunk from big-endian (EVM) to little-endian (Fr)
+        let mut reversed_accumulator = Vec::with_capacity(accumulator.len());
+        accumulator
+            .chunks(BN254_BYTES)
+            .for_each(|chunk| reversed_accumulator.extend(chunk.iter().rev().copied()));
 
         // CommitBytes is big-endian; Fr::from_bytes expects little-endian
         let mut app_exe_bytes = *app_commit.app_exe_commit.as_slice();
@@ -242,13 +285,17 @@ impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
             })
             .collect();
 
-        let mut instances = vec![app_exe_fr, app_vm_fr];
+        // Reconstruct instances: accumulator + commits + user PVs
+        let mut instances = Vec::new();
+        for chunk in reversed_accumulator.chunks(BN254_BYTES) {
+            let c: [u8; 32] = chunk.try_into().unwrap();
+            instances.push(Fr::from_bytes(&c).unwrap());
+        }
+        instances.push(app_exe_fr);
+        instances.push(app_vm_fr);
         instances.extend(user_pvs_frs);
 
-        openvm_static_verifier::keygen::RawEvmProof {
-            instances,
-            proof: proof_data.proof,
-        }
+        openvm_static_verifier::keygen::RawEvmProof { instances, proof }
     }
 }
 

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -39,14 +39,53 @@ impl From<Vec<u8>> for ExecutableFormat {
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ProofData {
-    // TODO[jpw]: halo2 proof will NOT need accumulator
-    // #[serde_as(as = "serde_with::hex::Hex")]
-    // /// KZG accumulator.
-    // pub accumulator: Vec<u8>,
     #[serde_as(as = "serde_with::hex::Hex")]
-    /// Bn254 proof in little-endian bytes. The circuit only has 1 advice column, so the proof is
-    /// of length `NUM_BN254_PROOF * BN254_BYTES`.
+    /// Bn254 proof in little-endian bytes.
     pub proof: Vec<u8>,
+}
+
+// =================== EVM types (evm-prove feature) ===================
+
+#[cfg(feature = "evm-prove")]
+pub use openvm_static_verifier::keygen::EvmVerifierByteCode;
+
+#[cfg(feature = "evm-prove")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EvmHalo2Verifier {
+    pub halo2_verifier_code: String,
+    pub openvm_verifier_code: String,
+    pub openvm_verifier_interface: String,
+    pub artifact: EvmVerifierByteCode,
+}
+
+/// Application execution commitment pair (big-endian 32-byte values).
+#[cfg(feature = "evm-prove")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AppExecutionCommit {
+    #[serde(with = "hex_bytes32")]
+    pub app_exe_commit: openvm_continuations::CommitBytes,
+    #[serde(with = "hex_bytes32")]
+    pub app_vm_commit: openvm_continuations::CommitBytes,
+}
+
+/// Custom serde for CommitBytes as hex-encoded [u8; 32].
+#[cfg(feature = "evm-prove")]
+mod hex_bytes32 {
+    use openvm_continuations::CommitBytes;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(val: &CommitBytes, s: S) -> Result<S::Ok, S::Error> {
+        hex::encode(val.as_slice()).serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<CommitBytes, D::Error> {
+        let hex_str = String::deserialize(d)?;
+        let bytes: [u8; 32] = hex::decode(hex_str)
+            .map_err(serde::de::Error::custom)?
+            .try_into()
+            .map_err(|_| serde::de::Error::custom("expected 32 bytes"))?;
+        Ok(CommitBytes::new(bytes))
+    }
 }
 
 #[cfg(feature = "evm-prove")]
@@ -67,16 +106,12 @@ pub struct EvmProof {
 }
 
 #[cfg(feature = "evm-prove")]
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum EvmProofConversionError {
-    #[error("Invalid length of proof")]
-    InvalidLengthProof,
-    #[error("Invalid length of instances")]
-    InvalidLengthInstances,
+    #[error("Invalid length of instances: expected at least 3, got {0}")]
+    InvalidLengthInstances(usize),
     #[error("Invalid length of user public values")]
     InvalidUserPublicValuesLength,
-    #[error("Invalid length of accumulator")]
-    InvalidLengthAccumulator,
 }
 
 #[cfg(feature = "evm-prove")]
@@ -95,132 +130,129 @@ impl EvmProof {
             version: _,
         } = self;
 
-        let ProofData { accumulator, proof } = proof_data;
-
-        let mut proof_data = accumulator;
-        proof_data.extend(proof);
-
         IOpenVmHalo2Verifier::verifyCall {
             publicValues: user_public_values.into(),
-            proofData: proof_data.into(),
-            appExeCommit: app_commit.app_exe_commit.as_slice().into(),
-            appVmCommit: app_commit.app_vm_commit.as_slice().into(),
+            proofData: proof_data.proof.into(),
+            appExeCommit: (*app_commit.app_exe_commit.as_slice()).into(),
+            appVmCommit: (*app_commit.app_vm_commit.as_slice()).into(),
         }
         .abi_encode()
     }
 
     #[cfg(feature = "evm-verify")]
     pub fn fallback_calldata(&self) -> Vec<u8> {
-        let evm_proof: RawEvmProof = self.clone().try_into().unwrap();
-        evm_proof.verifier_calldata()
+        let raw: openvm_static_verifier::keygen::RawEvmProof = self.clone().into();
+        encode_raw_evm_proof_calldata(&raw)
     }
 }
 
+/// Encode a [`RawEvmProof`](openvm_static_verifier::keygen::RawEvmProof) as calldata for the
+/// fallback (raw) verifier.
+///
+/// Format: each instance as 32-byte big-endian, followed by raw proof bytes.
+#[cfg(feature = "evm-verify")]
+pub fn encode_raw_evm_proof_calldata(
+    proof: &openvm_static_verifier::keygen::RawEvmProof,
+) -> Vec<u8> {
+    let mut calldata = Vec::new();
+    for instance in &proof.instances {
+        // Fr::to_bytes() is little-endian; EVM expects big-endian
+        let mut bytes = instance.to_bytes();
+        bytes.reverse();
+        calldata.extend_from_slice(&bytes);
+    }
+    calldata.extend_from_slice(&proof.proof);
+    calldata
+}
+
+/// Convert `RawEvmProof` → `EvmProof`.
+///
+/// Instance layout (no KZG accumulator):
+/// - `instances[0]`: app_exe_commit (Fr)
+/// - `instances[1]`: app_vk_commit (Fr)
+/// - `instances[2..]`: user public values (each byte as Fr)
 #[cfg(feature = "evm-prove")]
-impl TryFrom<RawEvmProof> for EvmProof {
-    type Error = EvmProofConversionError;
+impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
+    fn from(raw: openvm_static_verifier::keygen::RawEvmProof) -> Self {
+        use openvm_continuations::CommitBytes;
 
-    fn try_from(evm_proof: RawEvmProof) -> Result<Self, Self::Error> {
-        let RawEvmProof { instances, proof } = evm_proof;
-        if NUM_BN254_ACCUMULATOR + 2 >= instances.len() {
-            return Err(EvmProofConversionError::InvalidLengthInstances);
-        }
-        if proof.len() != NUM_BN254_PROOF * BN254_BYTES {
-            return Err(EvmProofConversionError::InvalidLengthProof);
-        }
-        let accumulator = instances[0..NUM_BN254_ACCUMULATOR]
-            .iter()
-            .flat_map(|f| f.to_bytes())
-            .collect::<Vec<_>>();
-        let mut app_exe_commit = instances[NUM_BN254_ACCUMULATOR].to_bytes();
-        let mut app_vm_commit = instances[NUM_BN254_ACCUMULATOR + 1].to_bytes();
-        app_exe_commit.reverse();
-        app_vm_commit.reverse();
-
-        let mut evm_accumulator: Vec<u8> = Vec::with_capacity(accumulator.len());
-        accumulator
-            .chunks(32)
-            .for_each(|chunk| evm_accumulator.extend(chunk.iter().rev().cloned()));
-
-        let user_public_values = instances[NUM_BN254_ACCUMULATOR + 2..].iter().fold(
-            Vec::<u8>::new(),
-            |mut acc: Vec<u8>, chunk| {
-                // We only care about the first byte, everything else should be 0-bytes
-                acc.push(*chunk.to_bytes().first().unwrap());
-                acc
-            },
+        let openvm_static_verifier::keygen::RawEvmProof { instances, proof } = raw;
+        assert!(
+            instances.len() >= 2,
+            "RawEvmProof instances must have at least 2 elements (exe commit + vk commit)"
         );
+
+        // instances[0] and [1] are Fr values encoding commits.
+        // Fr::to_bytes() returns 32 bytes in little-endian; CommitBytes expects big-endian.
+        let mut app_exe_bytes = instances[0].to_bytes();
+        app_exe_bytes.reverse();
+        let mut app_vm_bytes = instances[1].to_bytes();
+        app_vm_bytes.reverse();
+
+        let user_public_values = instances[2..]
+            .iter()
+            .map(|f| {
+                // Each user public value is a single byte stored in the least significant position
+                f.to_bytes()[0]
+            })
+            .collect::<Vec<u8>>();
+
         let app_commit = AppExecutionCommit {
-            app_exe_commit: CommitBytes::new(app_exe_commit),
-            app_vm_commit: CommitBytes::new(app_vm_commit),
+            app_exe_commit: CommitBytes::new(app_exe_bytes),
+            app_vm_commit: CommitBytes::new(app_vm_bytes),
         };
 
-        Ok(Self {
+        Self {
             version: format!("v{OPENVM_VERSION}"),
             app_commit,
             user_public_values,
-            proof_data: ProofData {
-                accumulator: evm_accumulator,
-                proof,
-            },
-        })
+            proof_data: ProofData { proof },
+        }
     }
 }
 
+/// Convert `EvmProof` → `RawEvmProof`.
 #[cfg(feature = "evm-prove")]
-impl TryFrom<EvmProof> for RawEvmProof {
-    type Error = EvmProofConversionError;
-    fn try_from(evm_openvm_proof: EvmProof) -> Result<Self, Self::Error> {
+impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
+    fn from(evm_proof: EvmProof) -> Self {
+        use openvm_static_verifier::Fr;
+
         let EvmProof {
-            mut app_commit,
+            app_commit,
             user_public_values,
             proof_data,
             version: _,
-        } = evm_openvm_proof;
+        } = evm_proof;
 
-        app_commit.app_exe_commit.reverse();
-        app_commit.app_vm_commit.reverse();
+        // CommitBytes is big-endian; Fr::from_bytes expects little-endian
+        let mut app_exe_bytes = *app_commit.app_exe_commit.as_slice();
+        app_exe_bytes.reverse();
+        let app_exe_fr = Fr::from_bytes(&app_exe_bytes).unwrap();
 
-        let ProofData { accumulator, proof } = proof_data;
+        let mut app_vm_bytes = *app_commit.app_vm_commit.as_slice();
+        app_vm_bytes.reverse();
+        let app_vm_fr = Fr::from_bytes(&app_vm_bytes).unwrap();
 
-        if proof.len() != NUM_BN254_PROOF * BN254_BYTES {
-            return Err(EvmProofConversionError::InvalidLengthProof);
+        let user_pvs_frs: Vec<Fr> = user_public_values
+            .into_iter()
+            .map(|byte| {
+                let mut bytes = [0u8; 32];
+                bytes[0] = byte;
+                Fr::from_bytes(&bytes).unwrap()
+            })
+            .collect();
+
+        let mut instances = vec![app_exe_fr, app_vm_fr];
+        instances.extend(user_pvs_frs);
+
+        openvm_static_verifier::keygen::RawEvmProof {
+            instances,
+            proof: proof_data.proof,
         }
-        let instances = {
-            if accumulator.len() != NUM_BN254_ACCUMULATOR * BN254_BYTES {
-                return Err(EvmProofConversionError::InvalidLengthAccumulator);
-            }
-
-            let mut reversed_accumulator: Vec<u8> = Vec::with_capacity(accumulator.len());
-            accumulator
-                .chunks(32)
-                .for_each(|chunk| reversed_accumulator.extend(chunk.iter().rev().cloned()));
-
-            if user_public_values.is_empty() {
-                return Err(EvmProofConversionError::InvalidUserPublicValuesLength);
-            }
-
-            let user_public_values = user_public_values
-                .into_iter()
-                .flat_map(|byte| once(byte).chain(repeat_n(0, 31)))
-                .collect::<Vec<_>>();
-
-            let mut ret = Vec::new();
-            for chunk in &reversed_accumulator
-                .iter()
-                .chain(app_commit.app_exe_commit.as_slice())
-                .chain(app_commit.app_vm_commit.as_slice())
-                .chain(&user_public_values)
-                .chunks(BN254_BYTES)
-            {
-                let c = chunk.copied().collect::<Vec<_>>().try_into().unwrap();
-                ret.push(Fr::from_bytes(&c).unwrap());
-            }
-            ret
-        };
-        Ok(RawEvmProof { instances, proof })
     }
 }
+
+// =================== Non-EVM types ===================
 
 /// Struct purely for encoding and decoding of [NonRootStarkProof].
 #[serde_as]

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -61,7 +61,7 @@ pub struct ProofData {
 // =================== EVM types (evm-prove feature) ===================
 
 #[cfg(feature = "evm-prove")]
-pub use openvm_static_verifier::keygen::EvmVerifierByteCode;
+pub use openvm_static_verifier::wrapper::EvmVerifierByteCode;
 
 #[cfg(feature = "evm-prove")]
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -37,6 +37,7 @@ impl From<Vec<u8>> for ExecutableFormat {
 }
 
 /// Number of bytes in a Bn254.
+#[allow(dead_code)]
 pub(crate) const BN254_BYTES: usize = 32;
 /// Number of Bn254 in `accumulator` field (KZG accumulator).
 pub const NUM_BN254_ACCUMULATOR: usize = 12;

--- a/crates/static-verifier/Cargo.toml
+++ b/crates/static-verifier/Cargo.toml
@@ -20,7 +20,9 @@ halo2-base = { workspace = true, features = ["halo2-axiom"] }
 snark-verifier-sdk = { workspace = true, features = ["loader_evm"], optional = true }
 
 rand_chacha.workspace = true
+once_cell = { workspace = true, optional = true }
 serde.workspace = true
+serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, features = ["hex"], optional = true }
 itertools.workspace = true
 num-bigint.workspace = true
@@ -35,6 +37,6 @@ openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
 [features]
 default = []
 cuda = ["dep:openvm-cuda-backend"]
-evm-prove = ["dep:snark-verifier-sdk", "dep:serde_with"]
+evm-prove = ["dep:snark-verifier-sdk", "dep:serde_with", "dep:once_cell", "dep:serde_json"]
 evm-verify = ["evm-prove", "snark-verifier-sdk/revm"]
 cell-profiling = ["dep:inferno"]

--- a/crates/static-verifier/Cargo.toml
+++ b/crates/static-verifier/Cargo.toml
@@ -36,5 +36,5 @@ openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
 default = []
 cuda = ["dep:openvm-cuda-backend"]
 evm-prove = ["dep:snark-verifier-sdk", "dep:serde_with"]
-evm-verify = ["evm-prove"]
+evm-verify = ["evm-prove", "snark-verifier-sdk/revm"]
 cell-profiling = ["dep:inferno"]

--- a/crates/static-verifier/src/circuit.rs
+++ b/crates/static-verifier/src/circuit.rs
@@ -186,6 +186,8 @@ impl StaticVerifierCircuit {
         );
         profiler.pop(ctx.advice.len());
 
+        profiler.print(ctx.advice.len());
+
         #[cfg(feature = "cell-profiling")]
         if let Ok(dir) = std::env::var("OPENVM_PROFILE_DIR") {
             let _ = std::fs::create_dir_all(&dir);

--- a/crates/static-verifier/src/circuit.rs
+++ b/crates/static-verifier/src/circuit.rs
@@ -7,6 +7,7 @@ use halo2_base::{
     gates::circuit::builder::BaseCircuitBuilder, halo2_proofs::halo2curves::bn256::Fr, Context,
 };
 use itertools::Itertools;
+use openvm_cpu_backend::CpuBackend;
 use openvm_recursion_circuit::{
     batch_constraint::expr_eval::DagCommitPvs,
     system::{VerifierConfig, VerifierSubCircuit, VerifierTraceGen},
@@ -285,10 +286,13 @@ pub fn compute_dag_onion_commit(
             ..Default::default()
         },
     );
-    let cached_trace_record = VerifierTraceGen::<_, BabyBearPoseidon2Config>::cached_trace_record(
-        &verifier_circuit,
-        internal_recursive_vk,
-    );
-    // despite the name, this returns the DAG onion commit for when there is no cached trace
+
+    // The ProverBackend and config used here also does not impact the generated CachedTraceRecord
+    let cached_trace_record = VerifierTraceGen::<
+        CpuBackend<BabyBearPoseidon2Config>,
+        BabyBearPoseidon2Config,
+    >::cached_trace_record(&verifier_circuit, internal_recursive_vk);
+
+    // Despite the name, this returns the DAG onion commit for when there is no cached trace
     cached_trace_record.dag_commit_info.unwrap().commit
 }

--- a/crates/static-verifier/src/config.rs
+++ b/crates/static-verifier/src/config.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub const STATIC_VERIFIER_NUM_ADVICE_COLS: usize = 1;
 pub const STATIC_VERIFIER_LOOKUP_ADVICE_COLS: usize = 1;
 
+pub const DEFAULT_HALO2_VERIFIER_K: usize = 23;
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct StaticVerifierShape {
     pub k: usize,
@@ -15,7 +17,7 @@ pub struct StaticVerifierShape {
 impl Default for StaticVerifierShape {
     fn default() -> Self {
         Self {
-            k: 12,
+            k: DEFAULT_HALO2_VERIFIER_K,
             lookup_bits: 11,
             minimum_rows: 20,
             instance_columns: 1,

--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
 use halo2_base::{
     gates::{GateChip, GateInstructions, RangeChip, RangeInstructions},
@@ -56,11 +56,16 @@ impl BabyBearWire {
 #[derive(Clone)]
 pub struct BabyBearChip {
     pub range: Arc<RangeChip<Fr>>,
+    /// Cache for loaded constants, keyed by canonical u64 value.
+    const_cache: RefCell<HashMap<u64, BabyBearWire>>,
 }
 
 impl BabyBearChip {
     pub fn new(range_chip: Arc<RangeChip<Fr>>) -> Self {
-        BabyBearChip { range: range_chip }
+        BabyBearChip {
+            range: range_chip,
+            const_cache: RefCell::new(HashMap::new()),
+        }
     }
 
     pub fn gate(&self) -> &GateChip<Fr> {
@@ -81,13 +86,22 @@ impl BabyBearChip {
     }
 
     pub fn load_constant(&self, ctx: &mut Context<Fr>, value: BabyBear) -> BabyBearWire {
-        let max_bits = bit_length(value.as_canonical_u64());
-        let value = if value == BabyBear::ZERO {
+        let key = value.as_canonical_u64();
+        if let Some(&cached) = self.const_cache.borrow().get(&key) {
+            return cached;
+        }
+        let max_bits = bit_length(key);
+        let assigned = if value == BabyBear::ZERO {
             ctx.load_zero()
         } else {
-            ctx.load_constant(Fr::from(PrimeField64::as_canonical_u64(&value)))
+            ctx.load_constant(Fr::from(key))
         };
-        BabyBearWire { value, max_bits }
+        let wire = BabyBearWire {
+            value: assigned,
+            max_bits,
+        };
+        self.const_cache.borrow_mut().insert(key, wire);
+        wire
     }
 
     pub fn reduce(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {

--- a/crates/static-verifier/src/keygen.rs
+++ b/crates/static-verifier/src/keygen.rs
@@ -89,8 +89,6 @@ use halo2_base::{
 #[cfg(feature = "evm-prove")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "evm-prove")]
-use serde_with::serde_as;
-#[cfg(feature = "evm-prove")]
 use snark_verifier_sdk::{
     evm::{gen_evm_proof_shplonk, gen_evm_verifier_sol_code},
     SHPLONK,
@@ -102,25 +100,6 @@ use snark_verifier_sdk::{
 pub struct RawEvmProof {
     pub instances: Vec<Fr>,
     pub proof: Vec<u8>,
-}
-
-/// Compiled Solidity verifier contract for on-chain verification.
-#[cfg(feature = "evm-prove")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FallbackEvmVerifier {
-    pub sol_code: String,
-    pub artifact: EvmVerifierByteCode,
-}
-
-/// Bytecode of a compiled EVM verifier contract.
-#[cfg(feature = "evm-prove")]
-#[serde_as]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct EvmVerifierByteCode {
-    pub sol_compiler_version: String,
-    pub sol_compiler_options: String,
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub bytecode: Vec<u8>,
 }
 
 #[cfg(feature = "evm-prove")]

--- a/crates/static-verifier/src/keygen.rs
+++ b/crates/static-verifier/src/keygen.rs
@@ -134,8 +134,53 @@ impl StaticVerifierProvingKey {
         )
     }
 
-    /// Generate an EVM-compatible proof.
-    pub fn prove_for_evm(&self, params: &Halo2Params, proof: &Proof<RootConfig>) -> RawEvmProof {
+    /// Produce a [`Snark`] for consumption by the wrapper circuit.
+    ///
+    /// Unlike [`prove_for_evm_unwrapped`](Self::prove_for_evm_unwrapped), this
+    /// returns a `Snark` (not a raw EVM proof), which should be fed into
+    /// [`Halo2WrapperProvingKey::prove_for_evm`](crate::wrapper::Halo2WrapperProvingKey::prove_for_evm).
+    pub fn prove_wrapped(
+        &self,
+        params: &Halo2Params,
+        proof: &Proof<RootConfig>,
+    ) -> snark_verifier_sdk::Snark {
+        let mut builder = BaseCircuitBuilder::prover(
+            self.pinning.metadata.config_params.clone(),
+            self.pinning.metadata.break_points.clone(),
+        )
+        .use_instance_columns(self.shape.instance_columns);
+
+        let _public_inputs = self.circuit.populate(&mut builder, proof);
+
+        snark_verifier_sdk::halo2::gen_snark_shplonk(
+            params,
+            &self.pinning.pk,
+            builder,
+            None::<&str>,
+        )
+    }
+
+    /// Generate a dummy snark for wrapper keygen.
+    pub fn generate_dummy_snark(
+        &self,
+        reader: &impl crate::wrapper::Halo2ParamsReader,
+    ) -> snark_verifier_sdk::Snark {
+        let k = self.pinning.metadata.config_params.k;
+        let params = reader.read_params(k);
+        snark_verifier_sdk::halo2::gen_dummy_snark_from_vk::<SHPLONK>(
+            &params,
+            self.pinning.pk.get_vk(),
+            self.pinning.metadata.num_pvs.clone(),
+            None,
+        )
+    }
+
+    /// Generate an EVM-compatible proof directly (one-step, no wrapper circuit).
+    pub fn prove_for_evm_unwrapped(
+        &self,
+        params: &Halo2Params,
+        proof: &Proof<RootConfig>,
+    ) -> RawEvmProof {
         let mut builder = BaseCircuitBuilder::prover(
             self.pinning.metadata.config_params.clone(),
             self.pinning.metadata.break_points.clone(),

--- a/crates/static-verifier/src/keygen.rs
+++ b/crates/static-verifier/src/keygen.rs
@@ -143,16 +143,17 @@ impl StaticVerifierProvingKey {
         .use_instance_columns(self.shape.instance_columns);
 
         let public_inputs = self.circuit.populate(&mut builder, proof);
+        let instances_vec = public_inputs.to_vec();
 
         let snark = gen_evm_proof_shplonk(
             params,
             &self.pinning.pk,
             builder,
-            vec![public_inputs.clone()],
+            vec![instances_vec.clone()],
         );
 
         RawEvmProof {
-            instances: public_inputs,
+            instances: instances_vec,
             proof: snark,
         }
     }
@@ -163,8 +164,10 @@ impl StaticVerifierProvingKey {
 /// Returns the gas used on success, or an error message on failure.
 #[cfg(feature = "evm-verify")]
 pub fn evm_verify(deployment_code: &[u8], proof: &RawEvmProof) -> Result<u64, String> {
-    let calldata =
-        snark_verifier_sdk::evm::encode_calldata(&[proof.instances.as_slice()], &proof.proof);
-    snark_verifier_sdk::evm::evm_verify(deployment_code.to_vec(), calldata)
-        .map_err(|e| format!("EVM verification failed: {e}"))
+    snark_verifier_sdk::evm::evm_verify(
+        deployment_code.to_vec(),
+        vec![proof.instances.clone()],
+        proof.proof.clone(),
+    )
+    .map_err(|e| format!("EVM verification failed: {e}"))
 }

--- a/crates/static-verifier/src/lib.rs
+++ b/crates/static-verifier/src/lib.rs
@@ -29,6 +29,8 @@ pub mod prover;
 pub mod stages;
 pub mod transcript;
 mod utils;
+#[cfg(feature = "evm-prove")]
+pub mod wrapper;
 
 pub use circuit::{compute_dag_onion_commit, StaticCircuitParamsError, StaticVerifierCircuit};
 pub use config::{
@@ -39,3 +41,7 @@ pub use keygen::StaticVerifierProvingKey;
 pub use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{EF as RootEF, F as RootF};
 pub use prover::{Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning, StaticVerifierProof};
 pub use stages::proof_shape::log_heights_per_air_from_proof;
+#[cfg(feature = "evm-prove")]
+pub use wrapper::{
+    EvmVerifierByteCode, FallbackEvmVerifier, Halo2ParamsReader, Halo2WrapperProvingKey,
+};

--- a/crates/static-verifier/src/profiling.rs
+++ b/crates/static-verifier/src/profiling.rs
@@ -67,6 +67,9 @@ mod disabled {
         pub fn pop(&mut self, _cell_count: usize) {}
 
         #[inline(always)]
+        pub fn print(&self, _cell_count: usize) {}
+
+        #[inline(always)]
         pub fn write_flamegraph(&self, _path: &str, _title: &str, _cell_count: usize) {}
 
         #[inline(always)]

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -519,7 +519,6 @@ fn eval_symbolic_nodes_assigned(
     evaluator: &ConstraintEvaluatorWire<'_>,
     nodes: &[SymbolicExpressionNode<RootF>],
 ) -> Vec<BabyBearExtWire> {
-    let one = ext_chip.from_base_const(ctx, RootF::ONE);
     let mut exprs: Vec<BabyBearExtWire> = Vec::with_capacity(nodes.len());
     for node in nodes {
         let expr = match node {
@@ -558,7 +557,10 @@ fn eval_symbolic_nodes_assigned(
             }
             SymbolicExpressionNode::IsFirstRow => evaluator.is_first_row,
             SymbolicExpressionNode::IsLastRow => evaluator.is_last_row,
-            SymbolicExpressionNode::IsTransition => ext_chip.sub(ctx, one, evaluator.is_last_row),
+            SymbolicExpressionNode::IsTransition => {
+                let one = ext_chip.from_base_const(ctx, RootF::ONE);
+                ext_chip.sub(ctx, one, evaluator.is_last_row)
+            }
         };
         exprs.push(expr);
     }
@@ -690,7 +692,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         let p1_q0 = ext_chip.mul(ctx, layer0[2], layer0[1]);
         let p_cross = ext_chip.add(ctx, p0_q1, p1_q0);
         let q_cross = ext_chip.mul(ctx, layer0[1], layer0[3]);
-        ext_chip.assert_equal(ctx, p_cross, zero);
+        ext_chip.assert_zero(ctx, p_cross);
         ext_chip.assert_equal(ctx, q_cross, gkr_q0_claim);
 
         let mu0 = transcript.sample_ext(ctx, baby_bear);
@@ -969,6 +971,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         );
         eq_ns[i] = ext_chip.mul(ctx, eq_ns[i - 1], eq_mle);
         eq_sharp_ns[i] = ext_chip.mul(ctx, eq_sharp_ns[i - 1], eq_mle);
+        eq_ns[i] = ext_chip.reduce_max_bits(ctx, eq_ns[i]);
+        eq_sharp_ns[i] = ext_chip.reduce_max_bits(ctx, eq_sharp_ns[i]);
     }
     if n_max_host > 0 {
         let n_max_usize = n_max_host;
@@ -976,6 +980,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         for i in (0..n_max_usize).rev() {
             eq_ns[i] = ext_chip.mul(ctx, eq_ns[i], r_rev_prod);
             eq_sharp_ns[i] = ext_chip.mul(ctx, eq_sharp_ns[i], r_rev_prod);
+            eq_ns[i] = ext_chip.reduce_max_bits(ctx, eq_ns[i]);
+            eq_sharp_ns[i] = ext_chip.reduce_max_bits(ctx, eq_sharp_ns[i]);
             r_rev_prod = ext_chip.mul(ctx, r_rev_prod, r[i]);
         }
     }
@@ -985,6 +991,9 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let mut interactions_evals = Vec::new();
     let mut constraints_evals = Vec::new();
+
+    let mut beta_pows = vec![one];
+    let mut lambda_pows = vec![one];
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
         let air_idx = trace_id_to_air_id_host[trace_idx];
         let n = n_per_trace[trace_idx];
@@ -1041,8 +1050,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         let evaluator = ConstraintEvaluatorWire {
             preprocessed: preprocessed.as_deref(),
             partitioned_main: &partitioned_main,
-            is_first_row,
-            is_last_row,
+            is_first_row: ext_chip.reduce_max_bits(ctx, is_first_row),
+            is_last_row: ext_chip.reduce_max_bits(ctx, is_last_row),
             public_values: public_values[air_idx].as_slice(),
         };
 
@@ -1054,15 +1063,19 @@ pub(crate) fn constrain_batch_constraints_verification(
         );
 
         let mut expr = ext_chip.zero(ctx);
-        let mut lambda_pow = one;
         for (i, &constraint_idx) in trace_constraint_indices[trace_idx].iter().enumerate() {
             let term = if i == 0 {
                 node_values[constraint_idx]
             } else {
-                ext_chip.mul(ctx, node_values[constraint_idx], lambda_pow)
+                if i >= lambda_pows.len() {
+                    debug_assert_eq!(i, lambda_pows.len());
+                    let new_pow = ext_chip.mul(ctx, *lambda_pows.last().unwrap(), lambda);
+                    lambda_pows.push(ext_chip.reduce_max_bits(ctx, new_pow));
+                }
+
+                ext_chip.mul(ctx, node_values[constraint_idx], lambda_pows[i])
             };
             expr = ext_chip.add(ctx, expr, term);
-            lambda_pow = ext_chip.mul(ctx, lambda_pow, lambda);
         }
         constraints_evals.push(ext_chip.mul(ctx, eq_ns[n_lift], expr));
 
@@ -1073,19 +1086,27 @@ pub(crate) fn constrain_batch_constraints_verification(
         for (eq_3b, interaction) in eq_3bs.iter().zip(interactions.iter()) {
             let count_eval = node_values[interaction.count];
             let mut denom_eval = ext_chip.zero(ctx);
-            let mut beta_pow = one;
             for (j, &msg_idx) in interaction.message.iter().enumerate() {
                 let term = if j == 0 {
                     node_values[msg_idx]
                 } else {
-                    ext_chip.mul(ctx, node_values[msg_idx], beta_pow)
+                    if j >= beta_pows.len() {
+                        debug_assert_eq!(j, beta_pows.len());
+                        let new_pow = ext_chip.mul(ctx, *beta_pows.last().unwrap(), beta_logup);
+                        beta_pows.push(ext_chip.reduce_max_bits(ctx, new_pow));
+                    }
+
+                    ext_chip.mul(ctx, node_values[msg_idx], beta_pows[j])
                 };
                 denom_eval = ext_chip.add(ctx, denom_eval, term);
-                beta_pow = ext_chip.mul(ctx, beta_pow, beta_logup);
+            }
+            if interaction.message.len() >= beta_pows.len() {
+                let new_pow = ext_chip.mul(ctx, *beta_pows.last().unwrap(), beta_logup);
+                beta_pows.push(ext_chip.reduce_max_bits(ctx, new_pow));
             }
             let bus_term = ext_chip.mul_base_const(
                 ctx,
-                beta_pow,
+                beta_pows[interaction.message.len()],
                 RootF::from_u64(u64::from(interaction.bus_index) + 1),
             );
             denom_eval = ext_chip.add(ctx, denom_eval, bus_term);

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -1,4 +1,4 @@
-use std::iter::zip;
+use std::{collections::BTreeMap, iter::zip};
 
 use halo2_base::Context;
 use openvm_stark_sdk::{
@@ -16,6 +16,7 @@ use openvm_stark_sdk::{
 
 use crate::{
     field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearExtWire, BabyBearWire},
+    profiling::CellProfiler,
     stages::shared_math::{self, horner_eval_ext_poly_assigned},
     transcript::TranscriptGadget,
     Fr, RootF,
@@ -598,6 +599,7 @@ pub(crate) fn constrain_batch_constraints_verification(
     n_per_trace: &[isize],
     trace_id_to_air_id: &[usize],
     public_values: Vec<Vec<BabyBearWire>>,
+    profiler: &mut CellProfiler,
 ) -> BatchConstraintIntermediatesWire {
     let baby_bear = ext_chip.base();
 
@@ -668,6 +670,8 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let alpha_logup = transcript.sample_ext(ctx, baby_bear);
     let beta_logup = transcript.sample_ext(ctx, baby_bear);
+
+    profiler.push("gkr_verification", ctx.advice.len());
 
     let gkr_q0_claim = gkr_wire.q0_claim;
     let gkr_claims_per_layer = &gkr_wire.claims_per_layer;
@@ -772,6 +776,9 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let lambda = transcript.sample_ext(ctx, baby_bear);
 
+    profiler.pop(ctx.advice.len());
+    profiler.push("batch_sumcheck", ctx.advice.len());
+
     let numerator_term_per_air = &batch_wire.numerator_term_per_air;
     let denominator_term_per_air = &batch_wire.denominator_term_per_air;
     for (num_term, den_term) in numerator_term_per_air
@@ -846,6 +853,9 @@ pub(crate) fn constrain_batch_constraints_verification(
         r.push(next_r);
     }
 
+    profiler.pop(ctx.advice.len());
+    profiler.push("observe_openings", ctx.advice.len());
+
     let column_openings = &batch_wire.column_openings;
 
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
@@ -866,6 +876,9 @@ pub(crate) fn constrain_batch_constraints_verification(
         }
     }
 
+    profiler.pop(ctx.advice.len());
+    profiler.push("eq_3b_tree", ctx.advice.len());
+
     let mut eq_3b_per_trace = Vec::with_capacity(n_per_trace.len());
     let mut stacked_idx = 0usize;
     for (trace_idx, &n) in n_per_trace.iter().enumerate() {
@@ -879,6 +892,19 @@ pub(crate) fn constrain_batch_constraints_verification(
         let d = n_logup_host.saturating_sub(n_lift);
         let xi_slice = &xi[l_skip + n_lift..l_skip + n_logup_host];
 
+        // Determine needed leaf indices before building the tree.
+        let needed_leaves: Vec<usize> = {
+            let mut leaves = Vec::with_capacity(interactions.len());
+            let mut tmp_idx = stacked_idx;
+            for _ in 0..interactions.len() {
+                let b_int = tmp_idx >> (l_skip + n_lift);
+                let tree_idx = b_int & ((1 << d) - 1);
+                leaves.push(tree_idx);
+                tmp_idx += 1 << (l_skip + n_lift);
+            }
+            leaves
+        };
+
         // Precompute per-bit factors: (x_i, 1-x_i) for tree product.
         let factors: Vec<(BabyBearExtWire, BabyBearExtWire)> = xi_slice
             .iter()
@@ -888,37 +914,46 @@ pub(crate) fn constrain_batch_constraints_verification(
             })
             .collect();
 
-        // Build a partial product tree of depth d.
-        // tree[level][node] = product of factors for bits [0..level) matching the node index.
-        // Level 0: all nodes are `one` (empty product).
-        // Level j+1: tree[j+1][idx] = tree[j][idx >> 1] * factor_j(bit_j)
-        let mut tree: Vec<Vec<BabyBearExtWire>> = Vec::with_capacity(d + 1);
-        tree.push(vec![one]); // level 0
+        // Build a sparse partial product tree containing only ancestors of needed leaves.
+        // tree[level][node_idx] = product of factors for bits matching node_idx.
+        // Level 0: single root node with value `one`.
+        // Level j+1: only children whose index appears in the needed set for that level.
+        let mut prev_level: BTreeMap<usize, BabyBearExtWire> = BTreeMap::new();
+        prev_level.insert(0, one);
+
         for level_idx in 0..d {
-            // Build tree in reverse factor order so that the LSB of the
-            // tree index corresponds to factors[0] (matching b_int's LSB).
             let factor_j = d - 1 - level_idx;
-            let prev = &tree[level_idx];
-            let mut level = Vec::with_capacity(prev.len() * 2);
-            for parent in prev {
-                let child0 = ext_chip.mul(ctx, *parent, factors[factor_j].1);
-                let child1 = ext_chip.mul(ctx, *parent, factors[factor_j].0);
-                level.push(child0);
-                level.push(child1);
+            // Determine which nodes are needed at level (level_idx + 1):
+            // a leaf index shifted right by the remaining levels.
+            let shift = d - (level_idx + 1);
+            let mut curr_level = BTreeMap::new();
+            for node_idx in needed_leaves.iter().map(|&leaf| leaf >> shift) {
+                if curr_level.contains_key(&node_idx) {
+                    continue;
+                }
+                let parent_idx = node_idx >> 1;
+                let parent = prev_level[&parent_idx];
+                let val = if node_idx & 1 == 0 {
+                    ext_chip.mul(ctx, parent, factors[factor_j].1)
+                } else {
+                    ext_chip.mul(ctx, parent, factors[factor_j].0)
+                };
+                curr_level.insert(node_idx, val);
             }
-            tree.push(level);
+            prev_level = curr_level;
         }
 
-        // For each interaction, look up the tree at the deepest level.
+        // Look up each interaction's eq_3b from the sparse tree leaves.
         let mut eq_3b = Vec::with_capacity(interactions.len());
-        for _ in 0..interactions.len() {
-            let b_int = stacked_idx >> (l_skip + n_lift);
-            let tree_idx = b_int & ((1 << d) - 1);
+        for &tree_idx in &needed_leaves {
             stacked_idx += 1 << (l_skip + n_lift);
-            eq_3b.push(tree[d][tree_idx]);
+            eq_3b.push(prev_level[&tree_idx]);
         }
         eq_3b_per_trace.push(eq_3b);
     }
+
+    profiler.pop(ctx.advice.len());
+    profiler.push("eq_ns_precompute", ctx.advice.len());
 
     let mut eq_ns = vec![one; n_max_host + 1];
     let mut eq_sharp_ns = vec![one; n_max_host + 1];
@@ -944,6 +979,9 @@ pub(crate) fn constrain_batch_constraints_verification(
             r_rev_prod = ext_chip.mul(ctx, r_rev_prod, r[i]);
         }
     }
+
+    profiler.pop(ctx.advice.len());
+    profiler.push("constraint_eval", ctx.advice.len());
 
     let mut interactions_evals = Vec::new();
     let mut constraints_evals = Vec::new();
@@ -1069,6 +1107,9 @@ pub(crate) fn constrain_batch_constraints_verification(
         interactions_evals.push(denom_scaled);
     }
 
+    profiler.pop(ctx.advice.len());
+    profiler.push("final_consistency", ctx.advice.len());
+
     let mut consistency_rhs = ext_chip.zero(ctx);
     let mut cur_mu_pow = one;
     for (i, term) in interactions_evals
@@ -1086,6 +1127,8 @@ pub(crate) fn constrain_batch_constraints_verification(
     }
     let consistency_residual = ext_chip.sub(ctx, consistency_lhs, consistency_rhs);
     ext_chip.assert_equal(ctx, consistency_residual, zero);
+
+    profiler.pop(ctx.advice.len());
 
     BatchConstraintIntermediatesWire {
         column_openings: column_openings.clone(),

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -539,7 +539,22 @@ fn eval_symbolic_nodes_assigned(
                 left_idx,
                 right_idx,
                 ..
-            } => ext_chip.mul(ctx, exprs[*left_idx], exprs[*right_idx]),
+            } => {
+                let left_const = match &nodes[*left_idx] {
+                    SymbolicExpressionNode::Constant(c) => Some(*c),
+                    _ => None,
+                };
+                let right_const = match &nodes[*right_idx] {
+                    SymbolicExpressionNode::Constant(c) => Some(*c),
+                    _ => None,
+                };
+                match (left_const, right_const) {
+                    (Some(lc), Some(rc)) => ext_chip.from_base_const(ctx, lc * rc),
+                    (Some(c), None) => ext_chip.mul_base_const(ctx, exprs[*right_idx], c),
+                    (None, Some(c)) => ext_chip.mul_base_const(ctx, exprs[*left_idx], c),
+                    (None, None) => ext_chip.mul(ctx, exprs[*left_idx], exprs[*right_idx]),
+                }
+            }
             SymbolicExpressionNode::IsFirstRow => evaluator.is_first_row,
             SymbolicExpressionNode::IsLastRow => evaluator.is_last_row,
             SymbolicExpressionNode::IsTransition => ext_chip.sub(ctx, one, evaluator.is_last_row),
@@ -778,11 +793,17 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let mut sum_claim = ext_chip.zero(ctx);
     let mut cur_mu_pow = one;
+    let mut first_mu_term = true;
     for (num_term, den_term) in numerator_term_per_air
         .iter()
         .zip(denominator_term_per_air.iter())
     {
-        let num_weighted = ext_chip.mul(ctx, *num_term, cur_mu_pow);
+        let num_weighted = if first_mu_term {
+            first_mu_term = false;
+            *num_term
+        } else {
+            ext_chip.mul(ctx, *num_term, cur_mu_pow)
+        };
         sum_claim = ext_chip.add(ctx, sum_claim, num_weighted);
         cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
 
@@ -855,22 +876,46 @@ pub(crate) fn constrain_batch_constraints_verification(
             continue;
         }
 
+        let d = n_logup_host.saturating_sub(n_lift);
+        let xi_slice = &xi[l_skip + n_lift..l_skip + n_logup_host];
+
+        // Precompute per-bit factors: (x_i, 1-x_i) for tree product.
+        let factors: Vec<(BabyBearExtWire, BabyBearExtWire)> = xi_slice
+            .iter()
+            .map(|x_i| {
+                let one_minus_x = ext_chip.sub(ctx, one, *x_i);
+                (*x_i, one_minus_x)
+            })
+            .collect();
+
+        // Build a partial product tree of depth d.
+        // tree[level][node] = product of factors for bits [0..level) matching the node index.
+        // Level 0: all nodes are `one` (empty product).
+        // Level j+1: tree[j+1][idx] = tree[j][idx >> 1] * factor_j(bit_j)
+        let mut tree: Vec<Vec<BabyBearExtWire>> = Vec::with_capacity(d + 1);
+        tree.push(vec![one]); // level 0
+        for level_idx in 0..d {
+            // Build tree in reverse factor order so that the LSB of the
+            // tree index corresponds to factors[0] (matching b_int's LSB).
+            let factor_j = d - 1 - level_idx;
+            let prev = &tree[level_idx];
+            let mut level = Vec::with_capacity(prev.len() * 2);
+            for parent in prev {
+                let child0 = ext_chip.mul(ctx, *parent, factors[factor_j].1);
+                let child1 = ext_chip.mul(ctx, *parent, factors[factor_j].0);
+                level.push(child0);
+                level.push(child1);
+            }
+            tree.push(level);
+        }
+
+        // For each interaction, look up the tree at the deepest level.
         let mut eq_3b = Vec::with_capacity(interactions.len());
         for _ in 0..interactions.len() {
-            let mut b_int = stacked_idx >> (l_skip + n_lift);
-            let mut b_vec = Vec::with_capacity(n_logup_host.saturating_sub(n_lift));
-            for _ in 0..n_logup_host.saturating_sub(n_lift) {
-                b_vec.push((b_int & 1) == 1);
-                b_int >>= 1;
-            }
+            let b_int = stacked_idx >> (l_skip + n_lift);
+            let tree_idx = b_int & ((1 << d) - 1);
             stacked_idx += 1 << (l_skip + n_lift);
-            let eq = eval_eq_mle_binary_assigned(
-                ctx,
-                ext_chip,
-                &xi[l_skip + n_lift..l_skip + n_logup_host],
-                &b_vec,
-            );
-            eq_3b.push(eq);
+            eq_3b.push(tree[d][tree_idx]);
         }
         eq_3b_per_trace.push(eq_3b);
     }
@@ -972,8 +1017,12 @@ pub(crate) fn constrain_batch_constraints_verification(
 
         let mut expr = ext_chip.zero(ctx);
         let mut lambda_pow = one;
-        for &constraint_idx in &trace_constraint_indices[trace_idx] {
-            let term = ext_chip.mul(ctx, node_values[constraint_idx], lambda_pow);
+        for (i, &constraint_idx) in trace_constraint_indices[trace_idx].iter().enumerate() {
+            let term = if i == 0 {
+                node_values[constraint_idx]
+            } else {
+                ext_chip.mul(ctx, node_values[constraint_idx], lambda_pow)
+            };
             expr = ext_chip.add(ctx, expr, term);
             lambda_pow = ext_chip.mul(ctx, lambda_pow, lambda);
         }
@@ -987,14 +1036,20 @@ pub(crate) fn constrain_batch_constraints_verification(
             let count_eval = node_values[interaction.count];
             let mut denom_eval = ext_chip.zero(ctx);
             let mut beta_pow = one;
-            for &msg_idx in &interaction.message {
-                let term = ext_chip.mul(ctx, node_values[msg_idx], beta_pow);
+            for (j, &msg_idx) in interaction.message.iter().enumerate() {
+                let term = if j == 0 {
+                    node_values[msg_idx]
+                } else {
+                    ext_chip.mul(ctx, node_values[msg_idx], beta_pow)
+                };
                 denom_eval = ext_chip.add(ctx, denom_eval, term);
                 beta_pow = ext_chip.mul(ctx, beta_pow, beta_logup);
             }
-            let bus_const = ext_chip
-                .from_base_const(ctx, RootF::from_u64(u64::from(interaction.bus_index) + 1));
-            let bus_term = ext_chip.mul(ctx, bus_const, beta_pow);
+            let bus_term = ext_chip.mul_base_const(
+                ctx,
+                beta_pow,
+                RootF::from_u64(u64::from(interaction.bus_index) + 1),
+            );
             denom_eval = ext_chip.add(ctx, denom_eval, bus_term);
 
             let eq_times_count = ext_chip.mul(ctx, *eq_3b, count_eval);
@@ -1003,8 +1058,11 @@ pub(crate) fn constrain_batch_constraints_verification(
             denom = ext_chip.add(ctx, denom, eq_times_denom);
         }
 
-        let norm = ext_chip.from_base_const(ctx, norm_factor);
-        let num_norm = ext_chip.mul(ctx, num, norm);
+        let num_norm = if norm_factor == RootF::ONE {
+            num
+        } else {
+            ext_chip.mul_base_const(ctx, num, norm_factor)
+        };
         let num_scaled = ext_chip.mul(ctx, num_norm, eq_sharp_ns[n_lift]);
         let denom_scaled = ext_chip.mul(ctx, denom, eq_sharp_ns[n_lift]);
         interactions_evals.push(num_scaled);
@@ -1013,8 +1071,16 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let mut consistency_rhs = ext_chip.zero(ctx);
     let mut cur_mu_pow = one;
-    for term in interactions_evals.iter().chain(constraints_evals.iter()) {
-        let weighted_term = ext_chip.mul(ctx, *term, cur_mu_pow);
+    for (i, term) in interactions_evals
+        .iter()
+        .chain(constraints_evals.iter())
+        .enumerate()
+    {
+        let weighted_term = if i == 0 {
+            *term
+        } else {
+            ext_chip.mul(ctx, *term, cur_mu_pow)
+        };
         consistency_rhs = ext_chip.add(ctx, consistency_rhs, weighted_term);
         cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
     }

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -253,6 +253,7 @@ pub fn constrained_verify(
         for _ in 0..l_skip {
             u_cube.push(power);
             power = ext_chip.square(ctx, power);
+            power = ext_chip.reduce_max_bits(ctx, power);
         }
         u_cube.extend(u.iter().skip(1).copied());
         u_cube

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -281,6 +281,8 @@ pub fn constrained_verify(
     );
     profiler.pop(ctx.advice.len());
 
+    profiler.print(ctx.advice.len());
+
     #[cfg(feature = "cell-profiling")]
     if let Ok(dir) = std::env::var("OPENVM_PROFILE_DIR") {
         let _ = std::fs::create_dir_all(&dir);

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -223,6 +223,7 @@ pub fn constrained_verify(
         &n_per_trace,
         trace_id_to_air_id,
         proof_wire.public_values.clone(),
+        &mut profiler,
     );
     profiler.pop(ctx.advice.len());
 
@@ -240,6 +241,7 @@ pub fn constrained_verify(
         root_vk.inner.params.n_stack,
         &batch.column_openings,
         &batch.r,
+        &mut profiler,
     );
     profiler.pop(ctx.advice.len());
 
@@ -278,6 +280,7 @@ pub fn constrained_verify(
         &stacked_reduction.stacking_openings,
         &initial_commitment_roots,
         &u_cube,
+        &mut profiler,
     );
     profiler.pop(ctx.advice.len());
 

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -223,14 +223,16 @@ pub(crate) fn constrain_stacked_reduction(
         })
         .collect::<Vec<_>>();
 
-    // Cache per-n computations: (ind, eq_prism, rot_kernel).
-    // These only depend on n (via l_skip, u, r) and are identical across columns with the same n.
-    let mut n_cache: HashMap<isize, (BabyBearExtWire, BabyBearExtWire, BabyBearExtWire)> =
-        HashMap::new();
     // Determine whether any column needs rotation (to decide if rot_kernel is needed).
     let any_need_rot = lambda_indices_per_layout
         .iter()
         .any(|indices| indices.iter().any(|&(_, rot)| rot));
+
+    // Cache per-n computations: (ind, eq_prism, rot_kernel).
+    let mut n_cache: HashMap<isize, (BabyBearExtWire, BabyBearExtWire, BabyBearExtWire)> =
+        HashMap::new();
+    // Cache eq_mle results by (n, b_bits encoded as usize).
+    let mut eq_mle_cache: HashMap<(isize, usize), BabyBearExtWire> = HashMap::new();
 
     for (commit_idx, layout) in layouts.iter().enumerate() {
         let lambda_indices = &lambda_indices_per_layout[commit_idx];
@@ -238,10 +240,14 @@ pub(crate) fn constrain_stacked_reduction(
             let (lambda_idx, need_rot) = lambda_indices[col_idx];
             let n = s.log_height() as isize - l_skip as isize;
             let n_lift = n.max(0) as usize;
-            let b_bits = (l_skip + n_lift..l_skip + n_stack)
-                .map(|j| ((s.row_idx >> j) & 1) == 1)
-                .collect::<Vec<_>>();
-            let eq_mle = eval_eq_mle_binary_assigned(ctx, ext_chip, &u[n_lift + 1..], &b_bits);
+            let b_key = s.row_idx >> (l_skip + n_lift);
+
+            let eq_mle = *eq_mle_cache.entry((n, b_key)).or_insert_with(|| {
+                let b_bits = (l_skip + n_lift..l_skip + n_stack)
+                    .map(|j| ((s.row_idx >> j) & 1) == 1)
+                    .collect::<Vec<_>>();
+                eval_eq_mle_binary_assigned(ctx, ext_chip, &u[n_lift + 1..], &b_bits)
+            });
 
             let &mut (ind, eq_prism, rot_kernel) = n_cache.entry(n).or_insert_with(|| {
                 let ind = eval_in_uni_assigned(ctx, ext_chip, l_skip, n, u[0]);

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use halo2_base::Context;
 use openvm_stark_sdk::{
     config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
@@ -6,6 +8,7 @@ use openvm_stark_sdk::{
 
 use crate::{
     field::baby_bear::{BabyBearExtChip, BabyBearExtWire},
+    profiling::CellProfiler,
     stages::{
         batch_constraints::{
             eval_eq_mle_binary_assigned, eval_eq_prism_assigned, eval_eq_uni_at_one_assigned,
@@ -96,9 +99,12 @@ pub(crate) fn constrain_stacked_reduction(
     n_stack: usize,
     batch_column_openings: &[Vec<Vec<BabyBearExtWire>>],
     r: &[BabyBearExtWire],
+    profiler: &mut CellProfiler,
 ) -> StackedReductionIntermediatesWire {
     let omega_order = 1usize << l_skip;
     let one = ext_chip.from_base_const(ctx, RootF::ONE);
+
+    profiler.push("claim_batching", ctx.advice.len());
 
     let mut lambda_idx = 0usize;
     let lambda_indices_per_layout = layouts
@@ -158,6 +164,9 @@ pub(crate) fn constrain_stacked_reduction(
         s_0 = ext_chip.add(ctx, s_0, term);
     }
 
+    profiler.pop(ctx.advice.len());
+    profiler.push("univariate_sumcheck", ctx.advice.len());
+
     let univariate_round_coeffs = &stacking_wire.univariate_round_coeffs;
     let mut s_0_sum_eval = ext_chip.zero(ctx);
     for coeff in univariate_round_coeffs.iter().step_by(omega_order) {
@@ -192,6 +201,9 @@ pub(crate) fn constrain_stacked_reduction(
         u.push(u_j);
     }
 
+    profiler.pop(ctx.advice.len());
+    profiler.push("derived_q_coeffs", ctx.advice.len());
+
     let stacking_matrix_expected_widths = layouts
         .iter()
         .map(|layout| {
@@ -211,6 +223,15 @@ pub(crate) fn constrain_stacked_reduction(
         })
         .collect::<Vec<_>>();
 
+    // Cache per-n computations: (ind, eq_prism, rot_kernel).
+    // These only depend on n (via l_skip, u, r) and are identical across columns with the same n.
+    let mut n_cache: HashMap<isize, (BabyBearExtWire, BabyBearExtWire, BabyBearExtWire)> =
+        HashMap::new();
+    // Determine whether any column needs rotation (to decide if rot_kernel is needed).
+    let any_need_rot = lambda_indices_per_layout
+        .iter()
+        .any(|indices| indices.iter().any(|&(_, rot)| rot));
+
     for (commit_idx, layout) in layouts.iter().enumerate() {
         let lambda_indices = &lambda_indices_per_layout[commit_idx];
         for (col_idx, &(_, _, s)) in layout.sorted_cols.iter().enumerate() {
@@ -221,20 +242,28 @@ pub(crate) fn constrain_stacked_reduction(
                 .map(|j| ((s.row_idx >> j) & 1) == 1)
                 .collect::<Vec<_>>();
             let eq_mle = eval_eq_mle_binary_assigned(ctx, ext_chip, &u[n_lift + 1..], &b_bits);
-            let ind = eval_in_uni_assigned(ctx, ext_chip, l_skip, n, u[0]);
-            let (l, rs_n) = if n.is_negative() {
-                (
-                    l_skip.wrapping_add_signed(n),
-                    vec![ext_chip.pow_power_of_two(ctx, r[0], n.unsigned_abs())],
-                )
-            } else {
-                (l_skip, r[..=n_lift].to_vec())
-            };
-            let eq_prism = eval_eq_prism_assigned(ctx, ext_chip, l, &u[..=n_lift], &rs_n);
+
+            let &mut (ind, eq_prism, rot_kernel) = n_cache.entry(n).or_insert_with(|| {
+                let ind = eval_in_uni_assigned(ctx, ext_chip, l_skip, n, u[0]);
+                let (l, rs_n) = if n.is_negative() {
+                    (
+                        l_skip.wrapping_add_signed(n),
+                        vec![ext_chip.pow_power_of_two(ctx, r[0], n.unsigned_abs())],
+                    )
+                } else {
+                    (l_skip, r[..=n_lift].to_vec())
+                };
+                let eq_prism = eval_eq_prism_assigned(ctx, ext_chip, l, &u[..=n_lift], &rs_n);
+                let rot_kernel = if any_need_rot {
+                    eval_rot_kernel_prism_assigned(ctx, ext_chip, l, &u[..=n_lift], &rs_n)
+                } else {
+                    ext_chip.zero(ctx)
+                };
+                (ind, eq_prism, rot_kernel)
+            });
+
             let mut batched = ext_chip.mul(ctx, lambda_sqr_powers[lambda_idx], eq_prism);
             if need_rot {
-                let rot_kernel =
-                    eval_rot_kernel_prism_assigned(ctx, ext_chip, l, &u[..=n_lift], &rs_n);
                 let lambda_rot = ext_chip.mul(ctx, lambda, rot_kernel);
                 let rot_term = ext_chip.mul(ctx, lambda_sqr_powers[lambda_idx], lambda_rot);
                 batched = ext_chip.add(ctx, batched, rot_term);
@@ -245,6 +274,9 @@ pub(crate) fn constrain_stacked_reduction(
             derived_q_coeffs[commit_idx][s.col_idx] = updated;
         }
     }
+
+    profiler.pop(ctx.advice.len());
+    profiler.push("final_verification", ctx.advice.len());
 
     let stacking_openings = &stacking_wire.stacking_openings;
     let mut final_sum = ext_chip.zero(ctx);
@@ -258,6 +290,8 @@ pub(crate) fn constrain_stacked_reduction(
 
     let final_residual = ext_chip.sub(ctx, final_claim, final_sum);
     ext_chip.assert_equal(ctx, final_residual, zero);
+
+    profiler.pop(ctx.advice.len());
 
     StackedReductionIntermediatesWire {
         stacking_openings: stacking_openings.clone(),

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -148,6 +148,7 @@ pub(crate) fn constrain_stacked_reduction(
     for _ in 0..t_claims.len() {
         lambda_sqr_powers.push(cur_lambda_sqr);
         cur_lambda_sqr = ext_chip.mul(ctx, cur_lambda_sqr, lambda_sqr);
+        cur_lambda_sqr = ext_chip.reduce_max_bits(ctx, cur_lambda_sqr);
     }
 
     let mut s_0 = ext_chip.zero(ctx);

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -145,10 +145,16 @@ pub(crate) fn constrain_stacked_reduction(
     }
 
     let mut s_0 = ext_chip.zero(ctx);
-    for ((claim, claim_rot), lambda_pow) in t_claims.iter().zip(lambda_sqr_powers.iter()) {
+    for (i, ((claim, claim_rot), lambda_pow)) in
+        t_claims.iter().zip(lambda_sqr_powers.iter()).enumerate()
+    {
         let claim_rot_lambda = ext_chip.mul(ctx, *claim_rot, lambda);
         let batched_claim = ext_chip.add(ctx, *claim, claim_rot_lambda);
-        let term = ext_chip.mul(ctx, batched_claim, *lambda_pow);
+        let term = if i == 0 {
+            batched_claim
+        } else {
+            ext_chip.mul(ctx, batched_claim, *lambda_pow)
+        };
         s_0 = ext_chip.add(ctx, s_0, term);
     }
 

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -30,6 +30,7 @@ use crate::{
             interpolate_quadratic_at_012_assigned,
         },
     },
+    profiling::CellProfiler,
     transcript::{digest_wire_from_root, TranscriptGadget},
     Fr, RootEF, RootF,
 };
@@ -404,8 +405,8 @@ pub(crate) fn constrain_whir_verification(
     stacking_openings: &[Vec<BabyBearExtWire>],
     initial_commitment_roots: &[AssignedValue<Fr>],
     u_cube: &[BabyBearExtWire],
+    profiler: &mut CellProfiler,
 ) {
-    let mut profiler = crate::profiling::CellProfiler::new("whir_verification", ctx.advice.len());
 
     let gate = ext_chip.range().gate();
     let base_chip = ext_chip.base();
@@ -730,21 +731,4 @@ pub(crate) fn constrain_whir_verification(
     let zero = ext_chip.zero(ctx);
     ext_chip.assert_equal(ctx, final_residual, zero);
     profiler.pop(ctx.advice.len());
-
-    profiler.print(ctx.advice.len());
-
-    #[cfg(feature = "cell-profiling")]
-    if let Ok(dir) = std::env::var("OPENVM_PROFILE_DIR") {
-        let _ = std::fs::create_dir_all(&dir);
-        profiler.write_flamegraph(
-            &format!("{dir}/whir_verification.svg"),
-            "WHIR Verification",
-            ctx.advice.len(),
-        );
-        profiler.write_flamegraph_reversed(
-            &format!("{dir}/whir_verification_rev.svg"),
-            "WHIR Verification (reversed)",
-            ctx.advice.len(),
-        );
-    }
 }

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -725,6 +725,8 @@ pub(crate) fn constrain_whir_verification(
     ext_chip.assert_equal(ctx, final_residual, zero);
     profiler.pop(ctx.advice.len());
 
+    profiler.print(ctx.advice.len());
+
     #[cfg(feature = "cell-profiling")]
     if let Ok(dir) = std::env::var("OPENVM_PROFILE_DIR") {
         let _ = std::fs::create_dir_all(&dir);

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         BABY_BEAR_EXT_DEGREE,
     },
     hash::poseidon2::{compress_bn254_digests, hash_babybear_slice_to_digest},
+    profiling::CellProfiler,
     stages::{
         batch_constraints::{eval_eq_mle_assigned, eval_eq_mle_ef_f_assigned},
         shared_math::{
@@ -30,7 +31,6 @@ use crate::{
             interpolate_quadratic_at_012_assigned,
         },
     },
-    profiling::CellProfiler,
     transcript::{digest_wire_from_root, TranscriptGadget},
     Fr, RootEF, RootF,
 };
@@ -407,7 +407,6 @@ pub(crate) fn constrain_whir_verification(
     u_cube: &[BabyBearExtWire],
     profiler: &mut CellProfiler,
 ) {
-
     let gate = ext_chip.range().gate();
     let base_chip = ext_chip.base();
     let params = &mvk0.params;

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -317,8 +317,7 @@ fn binary_k_fold_assigned(
             let mut alpha_minus_t = *alpha;
             alpha_minus_t.0[0] = base_chip.sub(ctx, alpha_minus_t.0[0], t);
             let fold = ext_chip.mul(ctx, alpha_minus_t, lo_minus_hi);
-            let fold = ext_chip.scalar_mul(ctx, fold, t_inv_half);
-            values[i] = ext_chip.add(ctx, lo, fold);
+            values[i] = ext_chip.scalar_mul_add(ctx, fold, t_inv_half, lo);
         }
         x_pow = base_chip.square(ctx, x_pow);
         x_pow = base_chip.reduce_max_bits(ctx, x_pow);
@@ -445,7 +444,11 @@ pub(crate) fn constrain_whir_verification(
     let mut mu_idx = 0usize;
     for commit_openings in stacking_openings {
         for opening in commit_openings {
-            let weighted = ext_chip.mul(ctx, *opening, mu_pows[mu_idx]);
+            let weighted = if mu_idx == 0 {
+                *opening
+            } else {
+                ext_chip.mul(ctx, *opening, mu_pows[mu_idx])
+            };
             final_claim = ext_chip.add(ctx, final_claim, weighted);
             mu_idx += 1;
         }
@@ -573,10 +576,13 @@ pub(crate) fn constrain_whir_verification(
                     );
                     for col_idx in 0..commit_openings.len() {
                         let mu_pow = mu_pows[mu_power_idx];
+                        let is_first_mu = mu_power_idx == 0;
                         for (row_idx, row) in merkle_path.leaf_values.iter().enumerate() {
                             let opened_base = row[col_idx];
                             codeword_vals[row_idx] = if let Some(prev) = codeword_vals[row_idx] {
                                 Some(ext_chip.scalar_mul_add(ctx, mu_pow, opened_base, prev))
+                            } else if is_first_mu {
+                                Some(ext_chip.from_base_var(ctx, opened_base))
                             } else {
                                 Some(ext_chip.scalar_mul(ctx, mu_pow, opened_base))
                             };

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -438,6 +438,7 @@ pub(crate) fn constrain_whir_verification(
     for _ in 0..total_width {
         mu_pows.push(mu_pow);
         mu_pow = ext_chip.mul(ctx, mu_pow, mu_challenge);
+        mu_pow = ext_chip.reduce_max_bits(ctx, mu_pow);
     }
 
     let mut final_claim = ext_chip.zero(ctx);

--- a/crates/static-verifier/src/wrapper.rs
+++ b/crates/static-verifier/src/wrapper.rs
@@ -73,13 +73,14 @@ pub trait Halo2ParamsReader {
 // ---- Wrapper types ----
 
 /// `FallbackEvmVerifier` is for the raw verifier contract outputted by
-/// `snark-verifier`.
+/// `snark-verifier` for on-chain verification
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FallbackEvmVerifier {
     pub sol_code: String,
     pub artifact: EvmVerifierByteCode,
 }
 
+/// Bytecode of a compiled EVM verifier contract.
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EvmVerifierByteCode {

--- a/crates/static-verifier/src/wrapper.rs
+++ b/crates/static-verifier/src/wrapper.rs
@@ -1,0 +1,287 @@
+use std::sync::Arc;
+
+use halo2_base::{
+    gates::circuit::CircuitBuilderStage,
+    halo2_proofs::{
+        halo2curves::bn256::G1Affine,
+        plonk::keygen_pk2,
+        poly::{
+            commitment::{CommitmentScheme, Params},
+            kzg::commitment::{KZGCommitmentScheme, ParamsKZG},
+        },
+    },
+};
+use itertools::Itertools;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+#[cfg(feature = "evm-prove")]
+use snark_verifier_sdk::snark_verifier::{
+    halo2_base::halo2_proofs::plonk::VerifyingKey, loader::evm::compile_solidity,
+};
+use snark_verifier_sdk::{
+    halo2::aggregation::{AggregationCircuit, AggregationConfigParams, VerifierUniversality},
+    CircuitExt, Snark, SHPLONK,
+};
+
+use crate::{
+    keygen::RawEvmProof,
+    prover::{Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning},
+};
+
+// ---- KZG params for SVK (ported from openvm-main utils.rs) ----
+
+static SVK: Lazy<G1Affine> = Lazy::new(|| {
+    serde_json::from_str("\"0100000000000000000000000000000000000000000000000000000000000000\"")
+        .unwrap()
+});
+
+/// Hacking because of bad interface. This is to construct a fake KZG params to pass
+/// Svk (which only requires ParamsKZG.g[0]) to AggregationCircuit.
+static FAKE_KZG_PARAMS: Lazy<Halo2Params> = Lazy::new(|| KZGCommitmentScheme::new_params(1));
+
+pub static KZG_PARAMS_FOR_SVK: Lazy<Halo2Params> = Lazy::new(|| {
+    if std::env::var("RANDOM_SRS").is_ok() {
+        // For testing: use a random SRS
+        use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let mut params = ParamsKZG::setup(23, &mut rng);
+        params.downsize(1);
+        params
+    } else {
+        build_kzg_params_for_svk(*SVK)
+    }
+});
+
+fn build_kzg_params_for_svk(g: G1Affine) -> Halo2Params {
+    FAKE_KZG_PARAMS.from_parts(
+        1,
+        vec![g],
+        Some(vec![g]),
+        Default::default(),
+        Default::default(),
+    )
+}
+
+// ---- Halo2ParamsReader trait ----
+
+/// Trait for reading Halo2 KZG parameters by degree `k`.
+pub trait Halo2ParamsReader {
+    fn read_params(&self, k: usize) -> Arc<Halo2Params>;
+}
+
+// ---- Wrapper types ----
+
+/// `FallbackEvmVerifier` is for the raw verifier contract outputted by
+/// `snark-verifier`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FallbackEvmVerifier {
+    pub sol_code: String,
+    pub artifact: EvmVerifierByteCode,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EvmVerifierByteCode {
+    pub sol_compiler_version: String,
+    pub sol_compiler_options: String,
+    #[serde_as(as = "serde_with::hex::Hex")]
+    pub bytecode: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Halo2WrapperProvingKey {
+    pub pinning: Halo2ProvingPinning,
+}
+
+const MIN_ROWS: usize = 20;
+
+impl Halo2WrapperProvingKey {
+    /// Auto select k to let Wrapper circuit only have 1 advice column.
+    pub fn keygen_auto_tune(reader: &impl Halo2ParamsReader, dummy_snark: Snark) -> Self {
+        let k = Self::select_k(dummy_snark.clone());
+        tracing::info!("Selected wrapper k: {k}");
+        let params = reader.read_params(k);
+        Self::keygen(&params, dummy_snark)
+    }
+
+    pub fn keygen(params: &Halo2Params, dummy_snark: Snark) -> Self {
+        let k = params.k();
+        let mut circuit =
+            generate_wrapper_circuit_object(CircuitBuilderStage::Keygen, k as usize, dummy_snark);
+        circuit.calculate_params(Some(MIN_ROWS));
+        let config_params = circuit.builder.config_params.clone();
+        tracing::info!(
+            "Wrapper circuit num advice: {:?}",
+            config_params.num_advice_per_phase
+        );
+        let pk = keygen_pk2(params, &circuit, false).unwrap();
+        let num_pvs = circuit.instances().iter().map(|x| x.len()).collect_vec();
+        Self {
+            pinning: Halo2ProvingPinning {
+                pk,
+                metadata: Halo2ProvingMetadata {
+                    config_params,
+                    break_points: circuit.break_points(),
+                    num_pvs,
+                },
+            },
+        }
+    }
+
+    #[cfg(feature = "evm-verify")]
+    /// A helper function for testing to verify the proof of this circuit with evm verifier.
+    pub fn evm_verify(
+        evm_verifier: &FallbackEvmVerifier,
+        evm_proof: &RawEvmProof,
+    ) -> Result<u64, String> {
+        snark_verifier_sdk::evm::evm_verify(
+            evm_verifier.artifact.bytecode.clone(),
+            vec![evm_proof.instances.clone()],
+            evm_proof.proof.clone(),
+        )
+    }
+
+    #[cfg(feature = "evm-prove")]
+    /// Return deployment code for EVM verifier which can verify the snark of this circuit.
+    pub fn generate_fallback_evm_verifier(&self, params: &Halo2Params) -> FallbackEvmVerifier {
+        assert_eq!(
+            self.pinning.metadata.config_params.k as u32,
+            params.k(),
+            "Provided params don't match circuit config"
+        );
+        gen_evm_verifier(
+            params,
+            self.pinning.pk.get_vk(),
+            self.pinning.metadata.num_pvs.clone(),
+        )
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn prove_for_evm(&self, params: &Halo2Params, snark_to_verify: Snark) -> RawEvmProof {
+        let k = self.pinning.metadata.config_params.k;
+        let prover_circuit = self.generate_circuit_object_for_proving(k, snark_to_verify);
+        let mut pvs = prover_circuit.instances();
+        assert_eq!(pvs.len(), 1);
+        let proof = snark_verifier_sdk::evm::gen_evm_proof_shplonk(
+            params,
+            &self.pinning.pk,
+            prover_circuit,
+            pvs.clone(),
+        );
+
+        RawEvmProof {
+            instances: pvs.pop().unwrap(),
+            proof,
+        }
+    }
+
+    #[cfg(feature = "evm-prove")]
+    fn generate_circuit_object_for_proving(
+        &self,
+        k: usize,
+        snark_to_verify: Snark,
+    ) -> AggregationCircuit {
+        assert_eq!(
+            snark_to_verify.instances.len(),
+            1,
+            "Snark should only have 1 instance column"
+        );
+        assert_eq!(
+            self.pinning.metadata.num_pvs[0],
+            snark_to_verify.instances[0].len() + 12,
+        );
+        generate_wrapper_circuit_object(CircuitBuilderStage::Prover, k, snark_to_verify)
+            .use_params(
+                self.pinning
+                    .metadata
+                    .config_params
+                    .clone()
+                    .try_into()
+                    .unwrap(),
+            )
+            .use_break_points(self.pinning.metadata.break_points.clone())
+    }
+
+    pub(crate) fn select_k(dummy_snark: Snark) -> usize {
+        let mut k = 20;
+        let mut first_run = true;
+        loop {
+            let mut circuit = generate_wrapper_circuit_object(
+                CircuitBuilderStage::Keygen,
+                k,
+                dummy_snark.clone(),
+            );
+            circuit.calculate_params(Some(MIN_ROWS));
+            assert_eq!(
+                circuit.builder.config_params.num_advice_per_phase.len(),
+                1,
+                "Snark has multiple phases"
+            );
+            if circuit.builder.config_params.num_advice_per_phase[0] == 1 {
+                circuit.builder.clear();
+                break;
+            }
+            if first_run {
+                k = log2_ceil_usize(
+                    circuit.builder.statistics().gate.total_advice_per_phase[0] + MIN_ROWS,
+                );
+            } else {
+                k += 1;
+            }
+            first_run = false;
+            // Prevent drop warnings
+            circuit.builder.clear();
+        }
+        k
+    }
+}
+
+fn generate_wrapper_circuit_object(
+    stage: CircuitBuilderStage,
+    k: usize,
+    snark: Snark,
+) -> AggregationCircuit {
+    let config_params = AggregationConfigParams {
+        degree: k as u32,
+        lookup_bits: k - 1,
+        ..Default::default()
+    };
+    let mut circuit = AggregationCircuit::new::<SHPLONK>(
+        stage,
+        config_params,
+        &KZG_PARAMS_FOR_SVK,
+        [snark],
+        VerifierUniversality::None,
+    );
+    circuit.expose_previous_instances(false);
+    circuit
+}
+
+#[cfg(feature = "evm-prove")]
+fn gen_evm_verifier(
+    params: &Halo2Params,
+    vk: &VerifyingKey<G1Affine>,
+    num_instance: Vec<usize>,
+) -> FallbackEvmVerifier {
+    let sol_code = snark_verifier_sdk::evm::gen_evm_verifier_sol_code::<AggregationCircuit, SHPLONK>(
+        params,
+        vk,
+        num_instance,
+    );
+    let byte_code = compile_solidity(&sol_code);
+    FallbackEvmVerifier {
+        sol_code,
+        artifact: EvmVerifierByteCode {
+            sol_compiler_version: "0.8.19".to_string(),
+            sol_compiler_options: "".to_string(),
+            bytecode: byte_code,
+        },
+    }
+}
+
+/// Compute ceil(log2(n)) for n > 0.
+fn log2_ceil_usize(n: usize) -> usize {
+    assert!(n > 0);
+    (usize::BITS - (n - 1).leading_zeros()) as usize
+}

--- a/extensions/deferral/circuit/src/poseidon2/cuda.rs
+++ b/extensions/deferral/circuit/src/poseidon2/cuda.rs
@@ -60,38 +60,39 @@ impl DeferralPoseidon2ChipGpu {
 impl Chip<DenseRecordArena, GpuBackend> for DeferralPoseidon2ChipGpu {
     fn generate_proving_ctx(&self, _: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         let mut num_records = self.idx.to_host().unwrap()[0] as usize;
+        if num_records == 0 {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
 
-        if num_records > 0 {
-            unsafe {
-                let d_num_records = [num_records].to_device().unwrap();
-                let mut temp_bytes = 0;
-                poseidon2::deduplicate_records_get_temp_bytes(
-                    &self.records,
-                    &self.counts,
-                    num_records,
-                    &d_num_records,
-                    &mut temp_bytes,
-                )
-                .expect("Failed to get deferral poseidon2 temp bytes");
+        unsafe {
+            let d_num_records = [num_records].to_device().unwrap();
+            let mut temp_bytes = 0;
+            poseidon2::deduplicate_records_get_temp_bytes(
+                &self.records,
+                &self.counts,
+                num_records,
+                &d_num_records,
+                &mut temp_bytes,
+            )
+            .expect("Failed to get deferral poseidon2 temp bytes");
 
-                let d_temp_storage = if temp_bytes == 0 {
-                    DeviceBuffer::<u8>::new()
-                } else {
-                    DeviceBuffer::<u8>::with_capacity(temp_bytes)
-                };
+            let d_temp_storage = if temp_bytes == 0 {
+                DeviceBuffer::<u8>::new()
+            } else {
+                DeviceBuffer::<u8>::with_capacity(temp_bytes)
+            };
 
-                poseidon2::deduplicate_records(
-                    &self.records,
-                    &self.counts,
-                    num_records,
-                    &d_num_records,
-                    &d_temp_storage,
-                    temp_bytes,
-                )
-                .expect("Failed to deduplicate deferral poseidon2 records");
+            poseidon2::deduplicate_records(
+                &self.records,
+                &self.counts,
+                num_records,
+                &d_num_records,
+                &d_temp_storage,
+                temp_bytes,
+            )
+            .expect("Failed to deduplicate deferral poseidon2 records");
 
-                num_records = *d_num_records.to_host().unwrap().first().unwrap();
-            }
+            num_records = *d_num_records.to_host().unwrap().first().unwrap();
         }
 
         let trace_height = next_power_of_two_or_zero(num_records);


### PR DESCRIPTION
## Summary
- Wire up `evm_prove` / `evm_verify` in SDK with `StaticVerifierCircuit`
- Add cell-count profiling test (`sdk_static_verifier_cell_profiling`) with flamegraph support
- Optimize static verifier cell count by ~55% (73M → 33M cells):
  - Use `mul_base_const` instead of full `ext_chip.mul` when symbolic DAG node operand is a constant
  - Precompute partial product tree for binary eq_mle evaluations in batch_constraints
  - Skip multiply-by-one in first iterations of power-accumulation loops (lambda, beta, mu)
  - Fuse `scalar_mul` + `add` into `scalar_mul_add` in WHIR binary_k_fold
  - Set `lookup_bits = k-1` for optimal range check utilization
  - Reduce WHIR verification cell count by 50% via algebraic optimizations
- **Re-introduce Halo2 wrapper for two-step EVM proving**: static verifier produces a Snark, then a wrapper `AggregationCircuit` wraps it into a compact EVM-compatible proof with a KZG accumulator, reducing on-chain verification cost
  - Add `wrapper.rs` to static-verifier with `Halo2WrapperProvingKey`, KZG SVK params
  - Add `prove_wrapped()` and `generate_dummy_snark()` to `StaticVerifierProvingKey`
  - Add `Halo2Prover` to SDK orchestrating the two-step flow
  - Add `EvmHalo2Prover` combining STARK proving with Halo2 wrapping
  - Add `Halo2ProvingKey` (verifier + wrapper) and `Halo2Config` to SDK
  - Update `EvmProof`/`ProofData` types with KZG accumulator field
  - Update Solidity template with hardcoded proof data layout

## Test plan
- [x] All 4 `pipeline_constraints_only_matches_native` tests pass (fib, interactions, cached, preprocessed)
- [x] `pipeline_cell_count_profiling` test passes
- [x] All 10 static-verifier tests pass
- [x] All 3 SDK tests pass
- [ ] `sdk_static_verifier_cell_profiling` profiling test (requires CUDA)
- [ ] EVM prove/verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)