### PR TITLE
chore: add debug_assert to eval_in_uni_assigned

### DIFF
--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -75,6 +75,7 @@ fn eval_in_uni_assigned(
     n: isize,
     z: BabyBearExtWire,
 ) -> BabyBearExtWire {
+    debug_assert!(n >= -(l_skip as isize));
     if n.is_negative() {
         let z_pow = ext_chip.pow_power_of_two(ctx, z, l_skip.wrapping_add_signed(n));
         eval_eq_uni_at_one_assigned(ctx, ext_chip, n.unsigned_abs(), &z_pow)


### PR DESCRIPTION
Resolves INT-6945. It seems like `stark-backend` uses `wrapping_add_signed` though: https://github.com/openvm-org/stark-backend/blob/127b44b09f32a19f3820fe661b82f69c5eaad93a/crates/stark-backend/src/poly_common.rs#L99