### PR TITLE
fix(v2-rc.1): load deferral as elems as felts in memory kernels

### DIFF
--- a/crates/vm/cuda/src/system/boundary.cu
+++ b/crates/vm/cuda/src/system/boundary.cu
@@ -5,6 +5,8 @@
 
 inline constexpr size_t PERSISTENT_CHUNK = 8;
 inline constexpr size_t BLOCKS_PER_CHUNK = 2;
+// TODO better address space handling
+inline constexpr uint32_t DEFERRAL_AS = 4;
 
 template <size_t CHUNK, size_t BLOCKS> struct BoundaryRecord {
     uint32_t address_space;
@@ -43,10 +45,19 @@ __global__ void cukernel_persistent_boundary_tracegen(
         COL_WRITE_VALUE(row, PersistentBoundaryCols, address_space, record.address_space);
         COL_WRITE_VALUE(row, PersistentBoundaryCols, leaf_label, record.ptr / PERSISTENT_CHUNK);
         if (row_idx % 2 == 0) {
-            // TODO better address space handling
             FpArray<8> init_values;
-            if (initial_mem[record.address_space - 1]) {
-                init_values = FpArray<8>::from_u8_array(initial_mem[record.address_space - 1] + record.ptr);
+            uint32_t addr_space_idx = record.address_space - 1;
+            if (initial_mem[addr_space_idx]) {
+                init_values =
+                    record.address_space == DEFERRAL_AS
+                        ? FpArray<8>::from_raw_array(
+                            reinterpret_cast<uint32_t const *>(
+                                initial_mem[addr_space_idx]
+                            ) + record.ptr
+                        )
+                        : FpArray<8>::from_u8_array(
+                            initial_mem[addr_space_idx] + record.ptr
+                        );
             } else {
                 #pragma unroll
                 for (int i = 0; i < 8; ++i) {

--- a/crates/vm/cuda/src/system/inventory.cu
+++ b/crates/vm/cuda/src/system/inventory.cu
@@ -17,8 +17,10 @@ template <size_t CHUNK, size_t BLOCKS> struct MemoryInventoryRecord {
     uint32_t values[CHUNK];      // Montgomery-encoded Fp values (Fp::asRaw())
 };
 
-const uint32_t IN_BLOCK_SIZE = 4;
-const uint32_t OUT_BLOCK_SIZE = 8;
+inline constexpr uint32_t IN_BLOCK_SIZE = 4;
+inline constexpr uint32_t OUT_BLOCK_SIZE = 8;
+// TODO better address space handling
+inline constexpr uint32_t DEFERRAL_AS = 4;
 
 using InRec = MemoryInventoryRecord<IN_BLOCK_SIZE, 1>;
 using OutRec = MemoryInventoryRecord<OUT_BLOCK_SIZE, 2>;
@@ -40,6 +42,8 @@ __device__ inline bool same_output_block(
 /// field elements. The output values must be in Montgomery form because they are
 /// stored directly into MemoryInventoryRecord.values, which boundary.cu later
 /// reads via FpArray::from_raw_array (a raw copy that assumes Montgomery encoding).
+/// DEFERRAL_AS stores field elements (4 bytes per cell, already Montgomery-encoded).
+/// Other address spaces store u8 cells (1 byte per cell).
 __device__ inline void read_initial_chunk(
     uint32_t *out_values, // Montgomery-encoded Fp values
     uint8_t const *const *initial_mem,
@@ -55,12 +59,20 @@ __device__ inline void read_initial_chunk(
         }
         return;
     }
-    size_t byte_offset = static_cast<size_t>(chunk_ptr);
-    #pragma unroll
-    for (int i = 0; i < OUT_BLOCK_SIZE; ++i) {
-        size_t off = byte_offset + static_cast<size_t>(i);
-        // Convert u8 value to field element in Montgomery form.
-        out_values[i] = Fp(mem[off]).asRaw();
+    if (address_space == DEFERRAL_AS) {
+        // F-type cells: 4 bytes per cell, already raw Montgomery u32
+        uint32_t const *cells = reinterpret_cast<uint32_t const *>(mem) + chunk_ptr;
+        #pragma unroll
+        for (int i = 0; i < OUT_BLOCK_SIZE; ++i) {
+            out_values[i] = cells[i];
+        }
+    } else {
+        // U8 cells: 1 byte per cell, convert to Montgomery form
+        size_t byte_offset = static_cast<size_t>(chunk_ptr);
+        #pragma unroll
+        for (int i = 0; i < OUT_BLOCK_SIZE; ++i) {
+            out_values[i] = Fp(mem[byte_offset + i]).asRaw();
+        }
     }
 }
 


### PR DESCRIPTION
Restore DEFERRAL_AS field-element handling in CUDA memory kernels (boundary.cu, inventory.cu). Without this, initial memory values are misread as individual bytes instead of 4-byte Montgomery-encoded field elements, breaking LogUp bus interactions