### PR TITLE
fix: constraint DagCommitSubAir public value and change AIR_ID constant

### DIFF
--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -27,6 +27,7 @@ mod trace;
 #[cfg(feature = "root-prover")]
 pub use trace::*;
 
+pub const USER_PVS_COMMIT_AIR_ID: usize = 1;
 pub const NUM_DIGESTS_IN_VK_COMMIT: usize = 6;
 
 #[derive(derive_new::new, Clone)]

--- a/crates/static-verifier/src/circuit.rs
+++ b/crates/static-verifier/src/circuit.rs
@@ -7,11 +7,14 @@ use halo2_base::{
     gates::circuit::builder::BaseCircuitBuilder, halo2_proofs::halo2curves::bn256::Fr, Context,
 };
 use itertools::Itertools;
-use openvm_recursion_circuit::batch_constraint::expr_eval::DagCommitPvs;
+use openvm_recursion_circuit::{
+    batch_constraint::expr_eval::DagCommitPvs,
+    system::{VerifierConfig, VerifierSubCircuit, VerifierTraceGen},
+};
 use openvm_stark_sdk::{
     config::{
         baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
-        baby_bear_poseidon2::Digest as InnerDigest,
+        baby_bear_poseidon2::{BabyBearPoseidon2Config, Digest as InnerDigest},
     },
     openvm_stark_backend::{
         keygen::types::{MultiStarkVerifyingKey, MultiStarkVerifyingKey0},
@@ -264,4 +267,25 @@ impl StaticVerifierCircuit {
 
         StaticVerifierPvs::from_slice(&pvs_fr)
     }
+}
+
+pub fn compute_dag_onion_commit(
+    internal_recursive_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
+) -> InnerDigest {
+    // Note: the MAX_NUM_PROOFS const generic does not impact the build_cached_trace_record function
+    // used internally below, but we use the default 3
+    let verifier_circuit = VerifierSubCircuit::<3>::new_with_options(
+        Arc::new(internal_recursive_vk.clone()),
+        VerifierConfig {
+            continuations_enabled: true,
+            has_cached: false,
+            ..Default::default()
+        },
+    );
+    let cached_trace_record = VerifierTraceGen::<_, BabyBearPoseidon2Config>::cached_trace_record(
+        &verifier_circuit,
+        internal_recursive_vk,
+    );
+    // despite the name, this returns the DAG onion commit for when there is no cached trace
+    cached_trace_record.dag_commit_info.unwrap().commit
 }

--- a/crates/static-verifier/src/circuit.rs
+++ b/crates/static-verifier/src/circuit.rs
@@ -273,8 +273,9 @@ pub fn compute_dag_onion_commit(
     internal_recursive_vk: &MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
 ) -> InnerDigest {
     // Note: the MAX_NUM_PROOFS const generic does not impact the build_cached_trace_record function
-    // used internally below, but we use the default 3
-    let verifier_circuit = VerifierSubCircuit::<3>::new_with_options(
+    // used internally below, but we use 1 to match the root circuit. The internal_recursive circuit
+    // itself uses MAX_NUM_PROOFS = 3, but here it is the child.
+    let verifier_circuit = VerifierSubCircuit::<1>::new_with_options(
         Arc::new(internal_recursive_vk.clone()),
         VerifierConfig {
             continuations_enabled: true,

--- a/crates/static-verifier/src/circuit.rs
+++ b/crates/static-verifier/src/circuit.rs
@@ -1,15 +1,17 @@
 //! Host-fixed parameters for the static verifier Halo2 circuit (see crate `lib.rs`).
 
 use core::cmp::Reverse;
-use std::{fmt, sync::Arc};
+use std::{borrow::Borrow, fmt, sync::Arc};
 
 use halo2_base::{
     gates::circuit::builder::BaseCircuitBuilder, halo2_proofs::halo2curves::bn256::Fr, Context,
 };
 use itertools::Itertools;
+use openvm_recursion_circuit::batch_constraint::expr_eval::DagCommitPvs;
 use openvm_stark_sdk::{
-    config::baby_bear_bn254_poseidon2::{
-        BabyBearBn254Poseidon2Config as RootConfig, Digest as RootDigest,
+    config::{
+        baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2Config as RootConfig,
+        baby_bear_poseidon2::Digest as InnerDigest,
     },
     openvm_stark_backend::{
         keygen::types::{MultiStarkVerifyingKey, MultiStarkVerifyingKey0},
@@ -17,6 +19,7 @@ use openvm_stark_sdk::{
         prover::stacked_pcs::StackedLayout,
     },
 };
+use openvm_verify_stark_host::pvs::CONSTRAINT_EVAL_AIR_ID;
 
 use crate::{
     field::baby_bear::{BabyBearChip, BabyBearExtChip},
@@ -104,10 +107,13 @@ impl std::error::Error for StaticCircuitParamsError {}
 #[derive(Clone, Debug)]
 pub struct StaticVerifierCircuit {
     pub root_vk: MultiStarkVerifyingKey<RootConfig>,
-    /// The [RootConfig] commitment of the cached trace in the SymbolicExpressionAir in the
-    /// RootVerifierCircuit. This is the commitment to the symbolic constraints DAG of the
-    /// internal-recursive verifier circuit.
-    pub internal_recursive_dag_cached_commit: RootDigest,
+    /// The [RootConfig] hash onion commitment to the internal-recursive verifier circuit's
+    /// symbolic constraints DAG. This is exposed as a public value by the DagCommitSubAir within
+    /// the SymbolicExpressionAir in the RootVerifierCircuit.
+    ///
+    /// This value can be obtained from `cached_trace_record.dag_commit_info.commit` in the
+    /// `RootProver`.
+    pub internal_recursive_dag_onion_commit: InnerDigest,
     pub log_heights_per_air: Vec<usize>,
     pub trace_id_to_air_id: Vec<usize>,
     pub stacked_layouts: Vec<StackedLayout>,
@@ -121,7 +127,7 @@ impl StaticVerifierCircuit {
     /// first).
     pub fn try_new(
         root_vk: MultiStarkVerifyingKey<RootConfig>,
-        internal_recursive_dag_cached_commit: RootDigest,
+        internal_recursive_dag_onion_commit: InnerDigest,
         log_heights_per_air: &[usize],
     ) -> Result<Self, StaticCircuitParamsError> {
         let n = root_vk.inner.per_air.len();
@@ -138,7 +144,7 @@ impl StaticVerifierCircuit {
             build_stacked_layouts_for_static_vk(&root_vk.inner, &log_heights_per_air);
         Ok(Self {
             root_vk,
-            internal_recursive_dag_cached_commit,
+            internal_recursive_dag_onion_commit,
             log_heights_per_air,
             trace_id_to_air_id,
             stacked_layouts,
@@ -218,6 +224,20 @@ impl StaticVerifierCircuit {
                 .all(|commits| commits.is_empty()),
             "RootVerifierCircuit has no cached trace"
         );
+        profiler.push("pin_dag_onion_commit", ctx.advice.len());
+        let &DagCommitPvs::<_> {
+            commit: onion_commit,
+        } = proof_wire.public_values[CONSTRAINT_EVAL_AIR_ID]
+            .as_slice()
+            .borrow();
+        for (bb_wire, bb_const) in onion_commit
+            .into_iter()
+            .zip_eq(self.internal_recursive_dag_onion_commit)
+        {
+            let loaded_const = ext_chip.base().load_constant(ctx, bb_const);
+            ext_chip.base().assert_equal(ctx, bb_wire, loaded_const);
+        }
+        profiler.pop(ctx.advice.len());
 
         profiler.push("extract_public_values", ctx.advice.len());
         let pvs_wire = extract_public_values(ctx, ext_chip.base(), proof_wire);

--- a/crates/static-verifier/src/lib.rs
+++ b/crates/static-verifier/src/lib.rs
@@ -30,7 +30,7 @@ pub mod stages;
 pub mod transcript;
 mod utils;
 
-pub use circuit::{StaticCircuitParamsError, StaticVerifierCircuit};
+pub use circuit::{compute_dag_onion_commit, StaticCircuitParamsError, StaticVerifierCircuit};
 pub use config::{
     StaticVerifierShape, STATIC_VERIFIER_LOOKUP_ADVICE_COLS, STATIC_VERIFIER_NUM_ADVICE_COLS,
 };

--- a/crates/static-verifier/src/stages/full_pipeline/public_values.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/public_values.rs
@@ -3,9 +3,9 @@ use std::borrow::Borrow;
 use halo2_base::{
     gates::GateInstructions, halo2_proofs::arithmetic::Field, AssignedValue, Context, QuantumCell,
 };
-use openvm_continuations::circuit::root::RootVerifierPvs;
+use openvm_continuations::circuit::root::{RootVerifierPvs, USER_PVS_COMMIT_AIR_ID};
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE as APP_DIGEST_SIZE;
-use openvm_verify_stark_host::pvs::{VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID};
+use openvm_verify_stark_host::pvs::VERIFIER_PVS_AIR_ID;
 
 use crate::{
     field::baby_bear::{BabyBearChip, BabyBearWire, BABY_BEAR_MODULUS_U64},
@@ -56,7 +56,7 @@ pub fn extract_public_values(
     let app_exe_commit = compress_babybear_wires_to_bn254(ctx, chip, root_pvs.app_exe_commit);
     let app_vk_commit = compress_babybear_wires_to_bn254(ctx, chip, root_pvs.app_vk_commit);
     // not reduced:
-    let user_pvs_nr = &proof.public_values[VM_PVS_AIR_ID];
+    let user_pvs_nr = &proof.public_values[USER_PVS_COMMIT_AIR_ID];
     let user_public_values = user_pvs_nr
         .iter()
         .map(|bb| chip.reduce(ctx, *bb).value)

--- a/crates/static-verifier/src/stages/full_pipeline/tests.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/tests.rs
@@ -7,7 +7,7 @@ use halo2_base::{
 use itertools::Itertools;
 use openvm_stark_sdk::{
     config::baby_bear_bn254_poseidon2::{
-        BabyBearBn254Poseidon2Config as RootConfig, BabyBearBn254Poseidon2CpuEngine, Bn254Scalar,
+        BabyBearBn254Poseidon2Config as RootConfig, BabyBearBn254Poseidon2CpuEngine,
     },
     openvm_stark_backend::{
         p3_field::{PrimeCharacteristicRing, PrimeField64, TwoAdicField},
@@ -111,8 +111,8 @@ where
 {
     let (vk, proof) = fixture.keygen_and_prove(engine);
     let log_heights_per_air = log_heights_per_air_from_proof(&proof);
-    let dummy_cached_commit = [Bn254Scalar::ZERO];
-    let circuit = StaticVerifierCircuit::try_new(vk, dummy_cached_commit, &log_heights_per_air)
+    let dummy_onion_commit = Default::default();
+    let circuit = StaticVerifierCircuit::try_new(vk, dummy_onion_commit, &log_heights_per_air)
         .expect("static circuit params");
 
     run_mock(0, true, |ctx, ext_chip| {

--- a/crates/static-verifier/src/stages/full_pipeline/tests.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/tests.rs
@@ -248,13 +248,14 @@ fn pipeline_cell_count_profiling() {
         }
         #[cfg(not(feature = "cuda"))]
         {
-            let engine = BabyBearBn254Poseidon2CpuEngine::new(system_params);
+            let engine: BabyBearBn254Poseidon2CpuEngine =
+                BabyBearBn254Poseidon2CpuEngine::new(system_params);
             fib.keygen_and_prove(&engine)
         }
     };
     let log_heights_per_air = log_heights_per_air_from_proof(&proof);
-    let dummy_cached_commit = [Bn254Scalar::ZERO];
-    let circuit = StaticVerifierCircuit::try_new(vk, dummy_cached_commit, &log_heights_per_air)
+    let dummy_onion_commit = Default::default();
+    let circuit = StaticVerifierCircuit::try_new(vk, dummy_onion_commit, &log_heights_per_air)
         .expect("static circuit params");
 
     let profile_dir = std::env::var("OPENVM_PROFILE_DIR").unwrap_or_else(|_| "profile".to_string());

--- a/crates/static-verifier/tests/real_prover_roundtrip.rs
+++ b/crates/static-verifier/tests/real_prover_roundtrip.rs
@@ -13,7 +13,6 @@ use halo2_base::{
     utils::fs::gen_srs,
 };
 use openvm_stark_backend::{
-    p3_field::PrimeCharacteristicRing,
     p3_util::log2_ceil_usize,
     proof::Proof,
     test_utils::{FibFixture, TestFixture},
@@ -23,8 +22,8 @@ use openvm_stark_sdk::{
     config::{
         baby_bear_bn254_poseidon2::{
             BabyBearBn254Poseidon2Config as RootConfig, BabyBearBn254Poseidon2CpuEngine,
-            Bn254Scalar,
         },
+        baby_bear_poseidon2::Digest as InnerDigest,
         log_up_params::log_up_security_params_baby_bear_100_bits,
     },
     utils::setup_tracing,
@@ -93,7 +92,7 @@ fn real_prover_keygen_prove_verify_roundtrip() {
     let (_vk_prove, proof_prove) = FibFixture::new(1, 1, 1 << 5).keygen_and_prove(&engine);
 
     let log_heights_per_air = log_heights_per_air_from_proof(&proof_keygen);
-    let circuit = StaticVerifierCircuit::try_new(vk, [Bn254Scalar::ZERO], &log_heights_per_air)
+    let circuit = StaticVerifierCircuit::try_new(vk, InnerDigest::default(), &log_heights_per_air)
         .expect("static circuit params");
 
     let k = select_k_verify_stark(&circuit, &proof_keygen);


### PR DESCRIPTION
closes INT-6987 INT-6986

- Constrains the root circuit's DagCommitSubAir's public values to equal the constant expected onion hash.
- Add `USER_PVS_COMMIT_AIR_ID`

~~Note that currently it seems not straightforward to computing the onion hash value in a standalone way, besides generating a dummy proof or constructing the root prover. We should add a standalone method that can be used to separate the functionalities needed for keygen versus proving.~~ Added a helper function.