### PR TITLE
perf: fewer cells in static verifier

### DIFF
--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -519,7 +519,6 @@ fn eval_symbolic_nodes_assigned(
     evaluator: &ConstraintEvaluatorWire<'_>,
     nodes: &[SymbolicExpressionNode<RootF>],
 ) -> Vec<BabyBearExtWire> {
-    let one = ext_chip.from_base_const(ctx, RootF::ONE);
     let mut exprs: Vec<BabyBearExtWire> = Vec::with_capacity(nodes.len());
     for node in nodes {
         let expr = match node {
@@ -558,7 +557,10 @@ fn eval_symbolic_nodes_assigned(
             }
             SymbolicExpressionNode::IsFirstRow => evaluator.is_first_row,
             SymbolicExpressionNode::IsLastRow => evaluator.is_last_row,
-            SymbolicExpressionNode::IsTransition => ext_chip.sub(ctx, one, evaluator.is_last_row),
+            SymbolicExpressionNode::IsTransition => {
+                let one = ext_chip.from_base_const(ctx, RootF::ONE);
+                ext_chip.sub(ctx, one, evaluator.is_last_row)
+            }
         };
         exprs.push(expr);
     }
@@ -690,7 +692,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         let p1_q0 = ext_chip.mul(ctx, layer0[2], layer0[1]);
         let p_cross = ext_chip.add(ctx, p0_q1, p1_q0);
         let q_cross = ext_chip.mul(ctx, layer0[1], layer0[3]);
-        ext_chip.assert_equal(ctx, p_cross, zero);
+        ext_chip.assert_zero(ctx, p_cross);
         ext_chip.assert_equal(ctx, q_cross, gkr_q0_claim);
 
         let mu0 = transcript.sample_ext(ctx, baby_bear);
@@ -969,6 +971,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         );
         eq_ns[i] = ext_chip.mul(ctx, eq_ns[i - 1], eq_mle);
         eq_sharp_ns[i] = ext_chip.mul(ctx, eq_sharp_ns[i - 1], eq_mle);
+        eq_ns[i] = ext_chip.reduce_max_bits(ctx, eq_ns[i]);
+        eq_sharp_ns[i] = ext_chip.reduce_max_bits(ctx, eq_sharp_ns[i]);
     }
     if n_max_host > 0 {
         let n_max_usize = n_max_host;
@@ -976,6 +980,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         for i in (0..n_max_usize).rev() {
             eq_ns[i] = ext_chip.mul(ctx, eq_ns[i], r_rev_prod);
             eq_sharp_ns[i] = ext_chip.mul(ctx, eq_sharp_ns[i], r_rev_prod);
+            eq_ns[i] = ext_chip.reduce_max_bits(ctx, eq_ns[i]);
+            eq_sharp_ns[i] = ext_chip.reduce_max_bits(ctx, eq_sharp_ns[i]);
             r_rev_prod = ext_chip.mul(ctx, r_rev_prod, r[i]);
         }
     }
@@ -985,6 +991,9 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let mut interactions_evals = Vec::new();
     let mut constraints_evals = Vec::new();
+
+    let mut beta_pows = vec![one];
+    let mut lambda_pows = vec![one];
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
         let air_idx = trace_id_to_air_id_host[trace_idx];
         let n = n_per_trace[trace_idx];
@@ -1041,8 +1050,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         let evaluator = ConstraintEvaluatorWire {
             preprocessed: preprocessed.as_deref(),
             partitioned_main: &partitioned_main,
-            is_first_row,
-            is_last_row,
+            is_first_row: ext_chip.reduce_max_bits(ctx, is_first_row),
+            is_last_row: ext_chip.reduce_max_bits(ctx, is_last_row),
             public_values: public_values[air_idx].as_slice(),
         };
 
@@ -1054,15 +1063,19 @@ pub(crate) fn constrain_batch_constraints_verification(
         );
 
         let mut expr = ext_chip.zero(ctx);
-        let mut lambda_pow = one;
         for (i, &constraint_idx) in trace_constraint_indices[trace_idx].iter().enumerate() {
             let term = if i == 0 {
                 node_values[constraint_idx]
             } else {
-                ext_chip.mul(ctx, node_values[constraint_idx], lambda_pow)
+                if i >= lambda_pows.len() {
+                    debug_assert_eq!(i, lambda_pows.len());
+                    let new_pow = ext_chip.mul(ctx, *lambda_pows.last().unwrap(), lambda);
+                    lambda_pows.push(ext_chip.reduce_max_bits(ctx, new_pow));
+                }
+
+                ext_chip.mul(ctx, node_values[constraint_idx], lambda_pows[i])
             };
             expr = ext_chip.add(ctx, expr, term);
-            lambda_pow = ext_chip.mul(ctx, lambda_pow, lambda);
         }
         constraints_evals.push(ext_chip.mul(ctx, eq_ns[n_lift], expr));
 
@@ -1073,19 +1086,27 @@ pub(crate) fn constrain_batch_constraints_verification(
         for (eq_3b, interaction) in eq_3bs.iter().zip(interactions.iter()) {
             let count_eval = node_values[interaction.count];
             let mut denom_eval = ext_chip.zero(ctx);
-            let mut beta_pow = one;
             for (j, &msg_idx) in interaction.message.iter().enumerate() {
                 let term = if j == 0 {
                     node_values[msg_idx]
                 } else {
-                    ext_chip.mul(ctx, node_values[msg_idx], beta_pow)
+                    if j >= beta_pows.len() {
+                        debug_assert_eq!(j, beta_pows.len());
+                        let new_pow = ext_chip.mul(ctx, *beta_pows.last().unwrap(), beta_logup);
+                        beta_pows.push(ext_chip.reduce_max_bits(ctx, new_pow));
+                    }
+
+                    ext_chip.mul(ctx, node_values[msg_idx], beta_pows[j])
                 };
                 denom_eval = ext_chip.add(ctx, denom_eval, term);
-                beta_pow = ext_chip.mul(ctx, beta_pow, beta_logup);
+            }
+            if interaction.message.len() >= beta_pows.len() {
+                let new_pow = ext_chip.mul(ctx, *beta_pows.last().unwrap(), beta_logup);
+                beta_pows.push(ext_chip.reduce_max_bits(ctx, new_pow));
             }
             let bus_term = ext_chip.mul_base_const(
                 ctx,
-                beta_pow,
+                beta_pows[interaction.message.len()],
                 RootF::from_u64(u64::from(interaction.bus_index) + 1),
             );
             denom_eval = ext_chip.add(ctx, denom_eval, bus_term);

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -253,6 +253,7 @@ pub fn constrained_verify(
         for _ in 0..l_skip {
             u_cube.push(power);
             power = ext_chip.square(ctx, power);
+            power = ext_chip.reduce_max_bits(ctx, power);
         }
         u_cube.extend(u.iter().skip(1).copied());
         u_cube

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -148,6 +148,7 @@ pub(crate) fn constrain_stacked_reduction(
     for _ in 0..t_claims.len() {
         lambda_sqr_powers.push(cur_lambda_sqr);
         cur_lambda_sqr = ext_chip.mul(ctx, cur_lambda_sqr, lambda_sqr);
+        cur_lambda_sqr = ext_chip.reduce_max_bits(ctx, cur_lambda_sqr);
     }
 
     let mut s_0 = ext_chip.zero(ctx);

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -438,6 +438,7 @@ pub(crate) fn constrain_whir_verification(
     for _ in 0..total_width {
         mu_pows.push(mu_pow);
         mu_pow = ext_chip.mul(ctx, mu_pow, mu_challenge);
+        mu_pow = ext_chip.reduce_max_bits(ctx, mu_pow);
     }
 
     let mut final_claim = ext_chip.zero(ctx);


### PR DESCRIPTION
This implements two ideas in some places:
- compute powers for batching once instead of recomputing them per AIR
- if we want to use a number several times (e.g. powers for batching), especially for multiplication, it may make sense to reduce it before that in order not to trigger a lot of reductions after.

```
35672315 cells for constrained_verify
| 84747 cells for observe_preamble
| 13975198 cells for batch_constraints
| | 1933185 cells for gkr_verification
| | 485762 cells for batch_sumcheck
| | 9716723 cells for observe_openings
| | 242688 cells for eq_3b_tree
| | 22602 cells for eq_ns_precompute
| | 1521460 cells for constraint_eval
| | 49241 cells for final_consistency
| 5748519 cells for stacked_reduction
| | 806355 cells for claim_batching
| | 163742 cells for univariate_sumcheck
| | 4756003 cells for derived_q_coeffs
| | 22418 cells for final_verification
| 15863465 cells for whir_verification
| | 5932 cells for mu_pows_and_claim
| | 6390172 cells for round_0
| | | 30732 cells for sumcheck
| | | 6334178 cells for queries
| | | 17884 cells for gamma_accumulation
| | 3298059 cells for round_1
| | | 30756 cells for sumcheck
| | | 3247920 cells for queries
| | | 12005 cells for gamma_accumulation
| | 3401479 cells for round_2
| | | 30768 cells for sumcheck
| | | 2164916 cells for queries
| | | 9099 cells for gamma_accumulation
| | 2767823 cells for final_verification
| | | 58106 cells for eq_mle_prefix_suffix
| | | 1460972 cells for final_round_0
| | | | 80817 cells for z0_ood_eval
| | | | 1380155 cells for query_point_evals
| | | 784342 cells for final_round_1
| | | | 77526 cells for z0_ood_eval
| | | | 706816 cells for query_point_evals
| | | 464120 cells for final_round_2
| | | | 464120 cells for query_point_evals
```