### PR TITLE
refactor(static-verifier): TranscriptGadget → TranscriptChip with owned BabyBearChip

### DIFF
--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -53,7 +53,7 @@ impl BabyBearWire {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BabyBearChip {
     pub range: Arc<RangeChip<Fr>>,
     /// Cache for loaded constants, keyed by canonical u64 value.

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearExtWire, BabyBearWire},
     profiling::CellProfiler,
     stages::shared_math::{self, horner_eval_ext_poly_assigned},
-    transcript::TranscriptGadget,
+    transcript::TranscriptChip,
     Fr, RootF,
 };
 
@@ -581,12 +581,11 @@ fn column_openings_by_rot_assigned(
 
 fn observe_layer_claims_assigned(
     ctx: &mut Context<Fr>,
-    transcript: &mut TranscriptGadget,
-    baby_bear: &BabyBearChip,
+    transcript: &mut TranscriptChip,
     claims: &[BabyBearExtWire],
 ) {
     for claim in claims {
-        transcript.observe_ext(ctx, baby_bear, claim);
+        transcript.observe_ext(ctx, claim);
     }
 }
 
@@ -594,7 +593,7 @@ fn observe_layer_claims_assigned(
 pub(crate) fn constrain_batch_constraints_verification(
     ctx: &mut Context<Fr>,
     ext_chip: &BabyBearExtChip,
-    transcript: &mut TranscriptGadget,
+    transcript: &mut TranscriptChip,
     mvk0: &MultiStarkVerifyingKey0<RootConfig>,
     gkr_wire: &GkrProofWire,
     batch_wire: &BatchConstraintProofWire,
@@ -603,8 +602,6 @@ pub(crate) fn constrain_batch_constraints_verification(
     public_values: Vec<Vec<BabyBearWire>>,
     profiler: &mut CellProfiler,
 ) -> BatchConstraintIntermediatesWire {
-    let baby_bear = ext_chip.base();
-
     let l_skip = mvk0.params.l_skip;
 
     let trace_id_to_air_id_host = trace_id_to_air_id.to_vec();
@@ -668,10 +665,10 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let logup_pow_bits = mvk0.params.logup.pow_bits;
     let logup_pow_witness = gkr_wire.logup_pow_witness;
-    transcript.check_witness(ctx, baby_bear, logup_pow_bits, &logup_pow_witness);
+    transcript.check_witness(ctx,logup_pow_bits, &logup_pow_witness);
 
-    let alpha_logup = transcript.sample_ext(ctx, baby_bear);
-    let beta_logup = transcript.sample_ext(ctx, baby_bear);
+    let alpha_logup = transcript.sample_ext(ctx);
+    let beta_logup = transcript.sample_ext(ctx);
 
     profiler.push("gkr_verification", ctx.advice.len());
 
@@ -683,10 +680,10 @@ pub(crate) fn constrain_batch_constraints_verification(
     let one = ext_chip.from_base_const(ctx, RootF::ONE);
     let total_gkr_rounds = l_skip + n_logup_host;
     let (mut gkr_p_xi_claim, mut gkr_q_xi_claim, mut xi) = {
-        transcript.observe_ext(ctx, baby_bear, &gkr_q0_claim);
+        transcript.observe_ext(ctx,&gkr_q0_claim);
 
         let layer0 = &gkr_claims_per_layer[0];
-        observe_layer_claims_assigned(ctx, transcript, baby_bear, layer0);
+        observe_layer_claims_assigned(ctx, transcript,layer0);
 
         let p0_q1 = ext_chip.mul(ctx, layer0[0], layer0[3]);
         let p1_q0 = ext_chip.mul(ctx, layer0[2], layer0[1]);
@@ -695,7 +692,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         ext_chip.assert_zero(ctx, p_cross);
         ext_chip.assert_equal(ctx, q_cross, gkr_q0_claim);
 
-        let mu0 = transcript.sample_ext(ctx, baby_bear);
+        let mu0 = transcript.sample_ext(ctx);
         let mut numer_claim =
             interpolate_linear_at_01_assigned(ctx, ext_chip, &layer0[0], &layer0[2], &mu0);
         let mut denom_claim =
@@ -703,7 +700,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         let mut gkr_r = vec![mu0];
 
         for round in 1..total_gkr_rounds {
-            let lambda_round = transcript.sample_ext(ctx, baby_bear);
+            let lambda_round = transcript.sample_ext(ctx);
 
             let lambda_denom = ext_chip.mul(ctx, lambda_round, denom_claim);
             let mut claim = ext_chip.add(ctx, numer_claim, lambda_denom);
@@ -715,11 +712,11 @@ pub(crate) fn constrain_batch_constraints_verification(
                 let ev1 = round_polys[subround * 3];
                 let ev2 = round_polys[subround * 3 + 1];
                 let ev3 = round_polys[subround * 3 + 2];
-                transcript.observe_ext(ctx, baby_bear, &ev1);
-                transcript.observe_ext(ctx, baby_bear, &ev2);
-                transcript.observe_ext(ctx, baby_bear, &ev3);
+                transcript.observe_ext(ctx,&ev1);
+                transcript.observe_ext(ctx,&ev2);
+                transcript.observe_ext(ctx,&ev3);
 
-                let ri = transcript.sample_ext(ctx, baby_bear);
+                let ri = transcript.sample_ext(ctx);
                 gkr_r_prime.push(ri);
 
                 let ev0 = ext_chip.sub(ctx, claim, ev1);
@@ -738,7 +735,7 @@ pub(crate) fn constrain_batch_constraints_verification(
             }
 
             let layer_claims = &gkr_claims_per_layer[round];
-            observe_layer_claims_assigned(ctx, transcript, baby_bear, layer_claims);
+            observe_layer_claims_assigned(ctx, transcript,layer_claims);
 
             let p0_q1 = ext_chip.mul(ctx, layer_claims[0], layer_claims[3]);
             let p1_q0 = ext_chip.mul(ctx, layer_claims[2], layer_claims[1]);
@@ -749,7 +746,7 @@ pub(crate) fn constrain_batch_constraints_verification(
             let expected_claim = ext_chip.mul(ctx, claim_sum, eq);
             ext_chip.assert_equal(ctx, expected_claim, claim);
 
-            let mu_round = transcript.sample_ext(ctx, baby_bear);
+            let mu_round = transcript.sample_ext(ctx);
             numer_claim = interpolate_linear_at_01_assigned(
                 ctx,
                 ext_chip,
@@ -773,10 +770,10 @@ pub(crate) fn constrain_batch_constraints_verification(
     };
 
     while xi.len() != l_skip + n_global_host {
-        xi.push(transcript.sample_ext(ctx, baby_bear));
+        xi.push(transcript.sample_ext(ctx));
     }
 
-    let lambda = transcript.sample_ext(ctx, baby_bear);
+    let lambda = transcript.sample_ext(ctx);
 
     profiler.pop(ctx.advice.len());
     profiler.push("batch_sumcheck", ctx.advice.len());
@@ -789,8 +786,8 @@ pub(crate) fn constrain_batch_constraints_verification(
     {
         gkr_p_xi_claim = ext_chip.sub(ctx, gkr_p_xi_claim, *num_term);
         gkr_q_xi_claim = ext_chip.sub(ctx, gkr_q_xi_claim, *den_term);
-        transcript.observe_ext(ctx, baby_bear, num_term);
-        transcript.observe_ext(ctx, baby_bear, den_term);
+        transcript.observe_ext(ctx,num_term);
+        transcript.observe_ext(ctx,den_term);
     }
     let gkr_numerator_residual = gkr_p_xi_claim;
     let gkr_denominator_claim = gkr_q_xi_claim;
@@ -798,7 +795,7 @@ pub(crate) fn constrain_batch_constraints_verification(
     ext_chip.assert_equal(ctx, gkr_numerator_residual, zero);
     ext_chip.assert_equal(ctx, gkr_denominator_residual, zero);
 
-    let mu = transcript.sample_ext(ctx, baby_bear);
+    let mu = transcript.sample_ext(ctx);
 
     let mut sum_claim = ext_chip.zero(ctx);
     let mut cur_mu_pow = one;
@@ -823,9 +820,9 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let univariate_round_coeffs = &batch_wire.univariate_round_coeffs;
     for coeff in univariate_round_coeffs {
-        transcript.observe_ext(ctx, baby_bear, coeff);
+        transcript.observe_ext(ctx,coeff);
     }
-    let mut r = vec![transcript.sample_ext(ctx, baby_bear)];
+    let mut r = vec![transcript.sample_ext(ctx)];
 
     let stride = 1usize << l_skip;
     let mut sum_univ_domain_s_0 = ext_chip.zero(ctx);
@@ -841,7 +838,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         horner_eval_ext_poly_assigned(ctx, ext_chip, univariate_round_coeffs, &r[0]);
     for round_evals in sumcheck_round_polys {
         for eval in round_evals {
-            transcript.observe_ext(ctx, baby_bear, eval);
+            transcript.observe_ext(ctx,eval);
         }
 
         let s_1 = round_evals[0];
@@ -849,7 +846,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         let mut interpolation_evals = Vec::with_capacity(round_evals.len() + 1);
         interpolation_evals.push(s_0);
         interpolation_evals.extend(round_evals.iter().copied());
-        let next_r = transcript.sample_ext(ctx, baby_bear);
+        let next_r = transcript.sample_ext(ctx);
         consistency_lhs =
             eval_lagrange_on_integer_grid(ctx, ext_chip, &next_r, &interpolation_evals);
         r.push(next_r);
@@ -863,8 +860,8 @@ pub(crate) fn constrain_batch_constraints_verification(
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
         let need_rot = column_openings_need_rot[trace_idx][0];
         for claim in column_openings_by_rot_assigned(ctx, ext_chip, &air_openings[0], need_rot) {
-            transcript.observe_ext(ctx, baby_bear, &claim.local);
-            transcript.observe_ext(ctx, baby_bear, &claim.next);
+            transcript.observe_ext(ctx,&claim.local);
+            transcript.observe_ext(ctx,&claim.next);
         }
     }
 
@@ -872,8 +869,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         for (part_idx, claims) in air_openings.iter().enumerate().skip(1) {
             let need_rot = column_openings_need_rot[trace_idx][part_idx];
             for claim in column_openings_by_rot_assigned(ctx, ext_chip, claims, need_rot) {
-                transcript.observe_ext(ctx, baby_bear, &claim.local);
-                transcript.observe_ext(ctx, baby_bear, &claim.next);
+                transcript.observe_ext(ctx,&claim.local);
+                transcript.observe_ext(ctx,&claim.next);
             }
         }
     }

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -665,7 +665,7 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let logup_pow_bits = mvk0.params.logup.pow_bits;
     let logup_pow_witness = gkr_wire.logup_pow_witness;
-    transcript.check_witness(ctx,logup_pow_bits, &logup_pow_witness);
+    transcript.check_witness(ctx, logup_pow_bits, &logup_pow_witness);
 
     let alpha_logup = transcript.sample_ext(ctx);
     let beta_logup = transcript.sample_ext(ctx);
@@ -680,10 +680,10 @@ pub(crate) fn constrain_batch_constraints_verification(
     let one = ext_chip.from_base_const(ctx, RootF::ONE);
     let total_gkr_rounds = l_skip + n_logup_host;
     let (mut gkr_p_xi_claim, mut gkr_q_xi_claim, mut xi) = {
-        transcript.observe_ext(ctx,&gkr_q0_claim);
+        transcript.observe_ext(ctx, &gkr_q0_claim);
 
         let layer0 = &gkr_claims_per_layer[0];
-        observe_layer_claims_assigned(ctx, transcript,layer0);
+        observe_layer_claims_assigned(ctx, transcript, layer0);
 
         let p0_q1 = ext_chip.mul(ctx, layer0[0], layer0[3]);
         let p1_q0 = ext_chip.mul(ctx, layer0[2], layer0[1]);
@@ -712,9 +712,9 @@ pub(crate) fn constrain_batch_constraints_verification(
                 let ev1 = round_polys[subround * 3];
                 let ev2 = round_polys[subround * 3 + 1];
                 let ev3 = round_polys[subround * 3 + 2];
-                transcript.observe_ext(ctx,&ev1);
-                transcript.observe_ext(ctx,&ev2);
-                transcript.observe_ext(ctx,&ev3);
+                transcript.observe_ext(ctx, &ev1);
+                transcript.observe_ext(ctx, &ev2);
+                transcript.observe_ext(ctx, &ev3);
 
                 let ri = transcript.sample_ext(ctx);
                 gkr_r_prime.push(ri);
@@ -735,7 +735,7 @@ pub(crate) fn constrain_batch_constraints_verification(
             }
 
             let layer_claims = &gkr_claims_per_layer[round];
-            observe_layer_claims_assigned(ctx, transcript,layer_claims);
+            observe_layer_claims_assigned(ctx, transcript, layer_claims);
 
             let p0_q1 = ext_chip.mul(ctx, layer_claims[0], layer_claims[3]);
             let p1_q0 = ext_chip.mul(ctx, layer_claims[2], layer_claims[1]);
@@ -786,8 +786,8 @@ pub(crate) fn constrain_batch_constraints_verification(
     {
         gkr_p_xi_claim = ext_chip.sub(ctx, gkr_p_xi_claim, *num_term);
         gkr_q_xi_claim = ext_chip.sub(ctx, gkr_q_xi_claim, *den_term);
-        transcript.observe_ext(ctx,num_term);
-        transcript.observe_ext(ctx,den_term);
+        transcript.observe_ext(ctx, num_term);
+        transcript.observe_ext(ctx, den_term);
     }
     let gkr_numerator_residual = gkr_p_xi_claim;
     let gkr_denominator_claim = gkr_q_xi_claim;
@@ -820,7 +820,7 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let univariate_round_coeffs = &batch_wire.univariate_round_coeffs;
     for coeff in univariate_round_coeffs {
-        transcript.observe_ext(ctx,coeff);
+        transcript.observe_ext(ctx, coeff);
     }
     let mut r = vec![transcript.sample_ext(ctx)];
 
@@ -838,7 +838,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         horner_eval_ext_poly_assigned(ctx, ext_chip, univariate_round_coeffs, &r[0]);
     for round_evals in sumcheck_round_polys {
         for eval in round_evals {
-            transcript.observe_ext(ctx,eval);
+            transcript.observe_ext(ctx, eval);
         }
 
         let s_1 = round_evals[0];
@@ -860,8 +860,8 @@ pub(crate) fn constrain_batch_constraints_verification(
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
         let need_rot = column_openings_need_rot[trace_idx][0];
         for claim in column_openings_by_rot_assigned(ctx, ext_chip, &air_openings[0], need_rot) {
-            transcript.observe_ext(ctx,&claim.local);
-            transcript.observe_ext(ctx,&claim.next);
+            transcript.observe_ext(ctx, &claim.local);
+            transcript.observe_ext(ctx, &claim.next);
         }
     }
 
@@ -869,8 +869,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         for (part_idx, claims) in air_openings.iter().enumerate().skip(1) {
             let need_rot = column_openings_need_rot[trace_idx][part_idx];
             for claim in column_openings_by_rot_assigned(ctx, ext_chip, claims, need_rot) {
-                transcript.observe_ext(ctx,&claim.local);
-                transcript.observe_ext(ctx,&claim.next);
+                transcript.observe_ext(ctx, &claim.local);
+                transcript.observe_ext(ctx, &claim.next);
             }
         }
     }

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -145,7 +145,9 @@ fn observe_preamble(
             // Fixed circuit parameter (not loaded from the proof witness).
             let lh = u32::try_from(log_heights_per_air[air_idx])
                 .expect("log_height must fit in u32 for BabyBear constant");
-            let log_height = transcript.baby_bear().load_constant(ctx, BabyBear::from_u32(lh));
+            let log_height = transcript
+                .baby_bear()
+                .load_constant(ctx, BabyBear::from_u32(lh));
             transcript.observe(ctx, &log_height);
         }
 

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -11,7 +11,7 @@ use openvm_stark_sdk::{
 };
 
 use crate::{
-    field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearWire},
+    field::baby_bear::{BabyBearExtChip, BabyBearWire},
     stages::{
         batch_constraints::{
             constrain_batch_constraints_verification, load_batch_constraint_proof_wire,
@@ -23,7 +23,7 @@ use crate::{
         },
         whir::{constrain_whir_verification, load_whir_proof_wire, WhirProofWire},
     },
-    transcript::{digest_wire_from_root, DigestWire, TranscriptGadget},
+    transcript::{digest_wire_from_root, DigestWire, TranscriptChip},
     Fr,
 };
 
@@ -114,8 +114,7 @@ pub fn load_proof_wire(
 #[allow(clippy::too_many_arguments)]
 fn observe_preamble(
     ctx: &mut Context<Fr>,
-    base_chip: &BabyBearChip,
-    transcript: &mut TranscriptGadget,
+    transcript: &mut TranscriptChip,
     mvk: &MultiStarkVerifyingKey<RootConfig>,
     log_heights_per_air: &[usize],
     public_values: &[Vec<BabyBearWire>],
@@ -123,8 +122,8 @@ fn observe_preamble(
     vk_pre_hash: DigestWire,
     common_main_commit: DigestWire,
 ) {
-    transcript.observe_commit(ctx, base_chip, &vk_pre_hash);
-    transcript.observe_commit(ctx, base_chip, &common_main_commit);
+    transcript.observe_commit(ctx, &vk_pre_hash);
+    transcript.observe_commit(ctx, &common_main_commit);
 
     for air_idx in 0..mvk.inner.per_air.len() {
         if !mvk.inner.per_air[air_idx].is_required {
@@ -132,7 +131,6 @@ fn observe_preamble(
             let presence_flag = ctx.load_constant(Fr::one());
             transcript.observe(
                 ctx,
-                base_chip,
                 &BabyBearWire {
                     value: presence_flag,
                     max_bits: 1,
@@ -142,21 +140,21 @@ fn observe_preamble(
 
         if let Some(preprocessed) = mvk.inner.per_air[air_idx].preprocessed_data.as_ref() {
             let preprocessed_root = ctx.load_constant(digest_scalar_to_fr(preprocessed.commit[0]));
-            transcript.observe_commit(ctx, base_chip, &digest_wire_from_root(preprocessed_root));
+            transcript.observe_commit(ctx, &digest_wire_from_root(preprocessed_root));
         } else {
             // Fixed circuit parameter (not loaded from the proof witness).
             let lh = u32::try_from(log_heights_per_air[air_idx])
                 .expect("log_height must fit in u32 for BabyBear constant");
-            let log_height = base_chip.load_constant(ctx, BabyBear::from_u32(lh));
-            transcript.observe(ctx, base_chip, &log_height);
+            let log_height = transcript.baby_bear().load_constant(ctx, BabyBear::from_u32(lh));
+            transcript.observe(ctx, &log_height);
         }
 
         for root in &cached_commitment_roots[air_idx] {
-            transcript.observe_commit(ctx, base_chip, &digest_wire_from_root(*root));
+            transcript.observe_commit(ctx, &digest_wire_from_root(*root));
         }
 
         for value in &public_values[air_idx] {
-            transcript.observe(ctx, base_chip, value);
+            transcript.observe(ctx, value);
         }
     }
 }
@@ -196,12 +194,11 @@ pub fn constrained_verify(
     let mut profiler = crate::profiling::CellProfiler::new("constrained_verify", ctx.advice.len());
 
     let mvk_pre_hash_root = ctx.load_constant(digest_scalar_to_fr(root_vk.pre_hash[0]));
-    let mut transcript = TranscriptGadget::new(ctx);
+    let mut transcript = TranscriptChip::new(ctx, ext_chip.base().clone());
 
     profiler.push("observe_preamble", ctx.advice.len());
     observe_preamble(
         ctx,
-        ext_chip.base(),
         &mut transcript,
         root_vk,
         log_heights_per_air,

--- a/crates/static-verifier/src/stages/full_pipeline/tests.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/tests.rs
@@ -24,8 +24,8 @@ use crate::{
     circuit::build_stacked_layouts_for_static_vk,
     config::{STATIC_VERIFIER_LOOKUP_ADVICE_COLS, STATIC_VERIFIER_NUM_ADVICE_COLS},
     field::baby_bear::{
-        clear_recorded_ext_base_consts, take_recorded_ext_base_consts, RecordedExtBaseConst,
-        BABY_BEAR_MODULUS_U64,
+        clear_recorded_ext_base_consts, take_recorded_ext_base_consts, BabyBearChip,
+        RecordedExtBaseConst, BABY_BEAR_MODULUS_U64,
     },
     stages::proof_shape::{log_heights_per_air_from_proof, trace_id_order_from_static_heights},
     RootF, StaticVerifierCircuit,

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -180,7 +180,7 @@ pub(crate) fn constrain_stacked_reduction(
     ext_chip.assert_equal(ctx, s_0_residual, zero);
 
     for coeff in univariate_round_coeffs {
-        transcript.observe_ext(ctx,coeff);
+        transcript.observe_ext(ctx, coeff);
     }
 
     let mut u = Vec::with_capacity(n_stack + 1);
@@ -193,8 +193,8 @@ pub(crate) fn constrain_stacked_reduction(
     for round_poly in sumcheck_round_polys {
         let s_j_1 = round_poly[0];
         let s_j_2 = round_poly[1];
-        transcript.observe_ext(ctx,&s_j_1);
-        transcript.observe_ext(ctx,&s_j_2);
+        transcript.observe_ext(ctx, &s_j_1);
+        transcript.observe_ext(ctx, &s_j_2);
         let u_j = transcript.sample_ext(ctx);
         let s_j_0 = ext_chip.sub(ctx, final_claim, s_j_1);
         final_claim =
@@ -289,7 +289,7 @@ pub(crate) fn constrain_stacked_reduction(
     let mut final_sum = ext_chip.zero(ctx);
     for (coeff_row, opening_row) in derived_q_coeffs.iter().zip(stacking_openings.iter()) {
         for (coeff, opening) in coeff_row.iter().zip(opening_row.iter()) {
-            transcript.observe_ext(ctx,opening);
+            transcript.observe_ext(ctx, opening);
             let term = ext_chip.mul(ctx, *coeff, *opening);
             final_sum = ext_chip.add(ctx, final_sum, term);
         }

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -19,7 +19,7 @@ use crate::{
             interpolate_quadratic_at_012_assigned,
         },
     },
-    transcript::TranscriptGadget,
+    transcript::TranscriptChip,
     Fr, RootF,
 };
 
@@ -91,7 +91,7 @@ fn eval_in_uni_assigned(
 pub(crate) fn constrain_stacked_reduction(
     ctx: &mut Context<Fr>,
     ext_chip: &BabyBearExtChip,
-    transcript: &mut TranscriptGadget,
+    transcript: &mut TranscriptChip,
     stacking_wire: &StackingProofWire,
     layouts: &[StackedLayout],
     need_rot_per_commit: &[Vec<bool>],
@@ -141,7 +141,7 @@ pub(crate) fn constrain_stacked_reduction(
         }
     }
 
-    let lambda = transcript.sample_ext(ctx, ext_chip.base());
+    let lambda = transcript.sample_ext(ctx);
     let lambda_sqr = ext_chip.mul(ctx, lambda, lambda);
     let mut lambda_sqr_powers = Vec::with_capacity(t_claims.len());
     let mut cur_lambda_sqr = one;
@@ -180,11 +180,11 @@ pub(crate) fn constrain_stacked_reduction(
     ext_chip.assert_equal(ctx, s_0_residual, zero);
 
     for coeff in univariate_round_coeffs {
-        transcript.observe_ext(ctx, ext_chip.base(), coeff);
+        transcript.observe_ext(ctx,coeff);
     }
 
     let mut u = Vec::with_capacity(n_stack + 1);
-    u.push(transcript.sample_ext(ctx, ext_chip.base()));
+    u.push(transcript.sample_ext(ctx));
 
     let sumcheck_round_polys = &stacking_wire.sumcheck_round_polys;
 
@@ -193,9 +193,9 @@ pub(crate) fn constrain_stacked_reduction(
     for round_poly in sumcheck_round_polys {
         let s_j_1 = round_poly[0];
         let s_j_2 = round_poly[1];
-        transcript.observe_ext(ctx, ext_chip.base(), &s_j_1);
-        transcript.observe_ext(ctx, ext_chip.base(), &s_j_2);
-        let u_j = transcript.sample_ext(ctx, ext_chip.base());
+        transcript.observe_ext(ctx,&s_j_1);
+        transcript.observe_ext(ctx,&s_j_2);
+        let u_j = transcript.sample_ext(ctx);
         let s_j_0 = ext_chip.sub(ctx, final_claim, s_j_1);
         final_claim =
             interpolate_quadratic_at_012_assigned(ctx, ext_chip, [&s_j_0, &s_j_1, &s_j_2], &u_j);
@@ -289,7 +289,7 @@ pub(crate) fn constrain_stacked_reduction(
     let mut final_sum = ext_chip.zero(ctx);
     for (coeff_row, opening_row) in derived_q_coeffs.iter().zip(stacking_openings.iter()) {
         for (coeff, opening) in coeff_row.iter().zip(opening_row.iter()) {
-            transcript.observe_ext(ctx, ext_chip.base(), opening);
+            transcript.observe_ext(ctx,opening);
             let term = ext_chip.mul(ctx, *coeff, *opening);
             final_sum = ext_chip.add(ctx, final_sum, term);
         }

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -482,16 +482,12 @@ pub(crate) fn constrain_whir_verification(
             if let Some(evals) = whir_sumcheck_polys.get(sumcheck_cursor) {
                 let ev1 = evals[0];
                 let ev2 = evals[1];
-                transcript.observe_ext(ctx,&ev1);
-                transcript.observe_ext(ctx,&ev2);
+                transcript.observe_ext(ctx, &ev1);
+                transcript.observe_ext(ctx, &ev2);
 
                 let pow_witness = folding_pow_witnesses[folding_pow_cursor];
                 folding_pow_cursor += 1;
-                transcript.check_witness(
-                    ctx,
-                    params.whir.folding_pow_bits,
-                    &pow_witness,
-                );
+                transcript.check_witness(ctx, params.whir.folding_pow_bits, &pow_witness);
 
                 let alpha = transcript.sample_ext(ctx);
                 alphas_round.push(alpha);
@@ -512,19 +508,16 @@ pub(crate) fn constrain_whir_verification(
 
         let y0 = if is_final_round {
             for coeff in final_poly {
-                transcript.observe_ext(ctx,coeff);
+                transcript.observe_ext(ctx, coeff);
             }
             None
         } else {
-            transcript.observe_commit(
-                ctx,
-                &codeword_commitment_digests[round_idx],
-            );
+            transcript.observe_commit(ctx, &codeword_commitment_digests[round_idx]);
             let z0 = transcript.sample_ext(ctx);
             z0_challenges.push(z0);
 
             let y0 = ood_values[round_idx];
-            transcript.observe_ext(ctx,&y0);
+            transcript.observe_ext(ctx, &y0);
             Some(y0)
         };
 

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -31,7 +31,7 @@ use crate::{
             interpolate_quadratic_at_012_assigned,
         },
     },
-    transcript::{digest_wire_from_root, TranscriptGadget},
+    transcript::{digest_wire_from_root, TranscriptChip},
     Fr, RootEF, RootF,
 };
 
@@ -399,7 +399,7 @@ fn constrain_merkle_path(
 pub(crate) fn constrain_whir_verification(
     ctx: &mut Context<Fr>,
     ext_chip: &BabyBearExtChip,
-    transcript: &mut TranscriptGadget,
+    transcript: &mut TranscriptChip,
     mvk0: &MultiStarkVerifyingKey0<RootConfig>,
     whir_wire: &WhirProofWire,
     stacking_openings: &[Vec<BabyBearExtWire>],
@@ -408,7 +408,6 @@ pub(crate) fn constrain_whir_verification(
     profiler: &mut CellProfiler,
 ) {
     let gate = ext_chip.range().gate();
-    let base_chip = ext_chip.base();
     let params = &mvk0.params;
     let k_whir = params.k_whir();
     let num_whir_rounds = params.num_whir_rounds();
@@ -416,8 +415,8 @@ pub(crate) fn constrain_whir_verification(
     profiler.push("mu_pows_and_claim", ctx.advice.len());
 
     let mu_pow_witness = whir_wire.mu_pow_witness;
-    transcript.check_witness(ctx, base_chip, params.whir.mu_pow_bits, &mu_pow_witness);
-    let mu_challenge = transcript.sample_ext(ctx, ext_chip.base());
+    transcript.check_witness(ctx, params.whir.mu_pow_bits, &mu_pow_witness);
+    let mu_challenge = transcript.sample_ext(ctx);
 
     let folding_pow_witnesses = &whir_wire.folding_pow_witnesses;
     let query_phase_pow_witnesses = &whir_wire.query_phase_pow_witnesses;
@@ -483,19 +482,18 @@ pub(crate) fn constrain_whir_verification(
             if let Some(evals) = whir_sumcheck_polys.get(sumcheck_cursor) {
                 let ev1 = evals[0];
                 let ev2 = evals[1];
-                transcript.observe_ext(ctx, ext_chip.base(), &ev1);
-                transcript.observe_ext(ctx, ext_chip.base(), &ev2);
+                transcript.observe_ext(ctx,&ev1);
+                transcript.observe_ext(ctx,&ev2);
 
                 let pow_witness = folding_pow_witnesses[folding_pow_cursor];
                 folding_pow_cursor += 1;
                 transcript.check_witness(
                     ctx,
-                    base_chip,
                     params.whir.folding_pow_bits,
                     &pow_witness,
                 );
 
-                let alpha = transcript.sample_ext(ctx, ext_chip.base());
+                let alpha = transcript.sample_ext(ctx);
                 alphas_round.push(alpha);
                 folding_alphas.push(alpha);
 
@@ -514,26 +512,24 @@ pub(crate) fn constrain_whir_verification(
 
         let y0 = if is_final_round {
             for coeff in final_poly {
-                transcript.observe_ext(ctx, ext_chip.base(), coeff);
+                transcript.observe_ext(ctx,coeff);
             }
             None
         } else {
             transcript.observe_commit(
                 ctx,
-                ext_chip.base(),
                 &codeword_commitment_digests[round_idx],
             );
-            let z0 = transcript.sample_ext(ctx, ext_chip.base());
+            let z0 = transcript.sample_ext(ctx);
             z0_challenges.push(z0);
 
             let y0 = ood_values[round_idx];
-            transcript.observe_ext(ctx, ext_chip.base(), &y0);
+            transcript.observe_ext(ctx,&y0);
             Some(y0)
         };
 
         transcript.check_witness(
             ctx,
-            base_chip,
             params.whir.query_phase_pow_bits,
             &query_phase_pow_witnesses[round_idx],
         );
@@ -547,7 +543,7 @@ pub(crate) fn constrain_whir_verification(
 
         profiler.push("queries", ctx.advice.len());
         for query_idx in 0..num_queries {
-            let query_index = transcript.sample_bits(ctx, ext_chip.base(), query_bits);
+            let query_index = transcript.sample_bits(ctx, query_bits);
             query_index_bits.push(query_bits);
             query_indices.push(query_index);
             let query_bits_vec = if query_bits == 0 {
@@ -618,7 +614,7 @@ pub(crate) fn constrain_whir_verification(
         profiler.pop(ctx.advice.len());
 
         profiler.push("gamma_accumulation", ctx.advice.len());
-        let gamma = transcript.sample_ext(ctx, ext_chip.base());
+        let gamma = transcript.sample_ext(ctx);
         if let Some(y0) = y0 {
             let y0_term = ext_chip.mul(ctx, y0, gamma);
             final_claim = ext_chip.add(ctx, final_claim, y0_term);

--- a/crates/static-verifier/src/transcript/mod.rs
+++ b/crates/static-verifier/src/transcript/mod.rs
@@ -116,11 +116,7 @@ impl TranscriptChip {
         self.sponge_state = state.s;
     }
 
-    fn reduce_32(
-        &self,
-        ctx: &mut Context<Fr>,
-        values: &[BabyBearWire],
-    ) -> AssignedValue<Fr> {
+    fn reduce_32(&self, ctx: &mut Context<Fr>, values: &[BabyBearWire]) -> AssignedValue<Fr> {
         reduce_32_cells(
             ctx,
             self.baby_bear.range().gate(),
@@ -134,7 +130,9 @@ impl TranscriptChip {
         packed: AssignedValue<Fr>,
     ) -> [BabyBearWire; NUM_SPLIT_LIMBS] {
         let limbs = decompose_packed_bn254_to_split_limbs(ctx, self.baby_bear.range(), packed);
-        core::array::from_fn(|idx| reduce_assigned_limb_to_babybear(ctx, &self.baby_bear, limbs[idx]))
+        core::array::from_fn(|idx| {
+            reduce_assigned_limb_to_babybear(ctx, &self.baby_bear, limbs[idx])
+        })
     }
 
     fn duplexing(&mut self, ctx: &mut Context<Fr>) {
@@ -157,11 +155,7 @@ impl TranscriptChip {
         }
     }
 
-    pub fn observe(
-        &mut self,
-        ctx: &mut Context<Fr>,
-        value: &BabyBearWire,
-    ) {
+    pub fn observe(&mut self, ctx: &mut Context<Fr>, value: &BabyBearWire) {
         self.output_buffer.clear();
         self.input_buffer.push(*value);
         if self.input_buffer.len() == NUM_SPLIT_LIMBS * POSEIDON2_RATE {
@@ -169,21 +163,13 @@ impl TranscriptChip {
         }
     }
 
-    pub fn observe_ext(
-        &mut self,
-        ctx: &mut Context<Fr>,
-        value: &BabyBearExtWire,
-    ) {
+    pub fn observe_ext(&mut self, ctx: &mut Context<Fr>, value: &BabyBearExtWire) {
         for coeff in &value.0 {
             self.observe(ctx, coeff);
         }
     }
 
-    pub fn observe_commit(
-        &mut self,
-        ctx: &mut Context<Fr>,
-        digest: &DigestWire,
-    ) {
+    pub fn observe_commit(&mut self, ctx: &mut Context<Fr>, digest: &DigestWire) {
         for packed in &digest.elems {
             let limbs = self.split_state_to_babybear(ctx, *packed);
             for limb in &limbs {
@@ -202,19 +188,12 @@ impl TranscriptChip {
             .expect("transcript output buffer must be non-empty after duplexing")
     }
 
-    pub fn sample_ext(
-        &mut self,
-        ctx: &mut Context<Fr>,
-    ) -> BabyBearExtWire {
+    pub fn sample_ext(&mut self, ctx: &mut Context<Fr>) -> BabyBearExtWire {
         let coeffs = core::array::from_fn(|_| self.sample(ctx));
         BabyBearExt4Wire(coeffs)
     }
 
-    pub fn sample_bits(
-        &mut self,
-        ctx: &mut Context<Fr>,
-        bits: usize,
-    ) -> AssignedValue<Fr> {
+    pub fn sample_bits(&mut self, ctx: &mut Context<Fr>, bits: usize) -> AssignedValue<Fr> {
         assert!(
             bits < (u32::BITS as usize),
             "sample_bits requires bits < 32: {bits}"
@@ -240,12 +219,7 @@ impl TranscriptChip {
     }
 
     /// Asserts that the PoW witness must pass.
-    pub fn check_witness(
-        &mut self,
-        ctx: &mut Context<Fr>,
-        bits: usize,
-        witness: &BabyBearWire,
-    ) {
+    pub fn check_witness(&mut self, ctx: &mut Context<Fr>, bits: usize, witness: &BabyBearWire) {
         if bits == 0 {
             return;
         }

--- a/crates/static-verifier/src/transcript/mod.rs
+++ b/crates/static-verifier/src/transcript/mod.rs
@@ -39,7 +39,8 @@ pub fn digest_wire_from_root(root: AssignedValue<Fr>) -> DigestWire {
 }
 
 #[derive(Clone, Debug)]
-pub struct TranscriptGadget {
+pub struct TranscriptChip {
+    baby_bear: BabyBearChip,
     sponge_state: [AssignedValue<Fr>; POSEIDON2_WIDTH],
     input_buffer: Vec<BabyBearWire>,
     output_buffer: Vec<BabyBearWire>,
@@ -86,15 +87,20 @@ fn reduce_assigned_limb_to_babybear(
     }
 }
 
-impl TranscriptGadget {
-    pub fn new(ctx: &mut Context<Fr>) -> Self {
+impl TranscriptChip {
+    pub fn new(ctx: &mut Context<Fr>, baby_bear: BabyBearChip) -> Self {
         let zero = ctx.load_zero();
         let sponge_state = core::array::from_fn(|_| zero);
         Self {
+            baby_bear,
             sponge_state,
             input_buffer: Vec::new(),
             output_buffer: Vec::new(),
         }
+    }
+
+    pub fn baby_bear(&self) -> &BabyBearChip {
+        &self.baby_bear
     }
 
     pub fn load_digest_witness(ctx: &mut Context<Fr>, digest: RootDigest) -> DigestWire {
@@ -103,8 +109,8 @@ impl TranscriptGadget {
         }
     }
 
-    fn permute_state(&mut self, ctx: &mut Context<Fr>, range: &RangeChip<Fr>) {
-        let gate = range.gate();
+    fn permute_state(&mut self, ctx: &mut Context<Fr>) {
+        let gate = self.baby_bear.range().gate();
         let mut state = Poseidon2State::new(self.sponge_state);
         state.permutation(ctx, gate, &POSEIDON2_PARAMS);
         self.sponge_state = state.s;
@@ -113,12 +119,11 @@ impl TranscriptGadget {
     fn reduce_32(
         &self,
         ctx: &mut Context<Fr>,
-        range: &RangeChip<Fr>,
         values: &[BabyBearWire],
     ) -> AssignedValue<Fr> {
         reduce_32_cells(
             ctx,
-            range.gate(),
+            self.baby_bear.range().gate(),
             &values.iter().map(|v| v.value).collect_vec(),
         )
     }
@@ -126,30 +131,28 @@ impl TranscriptGadget {
     fn split_state_to_babybear(
         &self,
         ctx: &mut Context<Fr>,
-        baby_bear: &BabyBearChip,
         packed: AssignedValue<Fr>,
     ) -> [BabyBearWire; NUM_SPLIT_LIMBS] {
-        let limbs = decompose_packed_bn254_to_split_limbs(ctx, baby_bear.range(), packed);
-        core::array::from_fn(|idx| reduce_assigned_limb_to_babybear(ctx, baby_bear, limbs[idx]))
+        let limbs = decompose_packed_bn254_to_split_limbs(ctx, self.baby_bear.range(), packed);
+        core::array::from_fn(|idx| reduce_assigned_limb_to_babybear(ctx, &self.baby_bear, limbs[idx]))
     }
 
-    fn duplexing(&mut self, ctx: &mut Context<Fr>, baby_bear: &BabyBearChip) {
+    fn duplexing(&mut self, ctx: &mut Context<Fr>) {
         assert!(
             self.input_buffer.len() <= NUM_SPLIT_LIMBS * POSEIDON2_RATE,
             "input buffer exceeds transcript absorb rate"
         );
 
-        let range = baby_bear.range();
         for (idx, chunk) in self.input_buffer.chunks(NUM_SPLIT_LIMBS).enumerate() {
-            self.sponge_state[idx] = self.reduce_32(ctx, range, chunk);
+            self.sponge_state[idx] = self.reduce_32(ctx, chunk);
         }
         self.input_buffer.clear();
 
-        self.permute_state(ctx, range);
+        self.permute_state(ctx);
 
         self.output_buffer.clear();
         for packed in self.sponge_state {
-            let parts = self.split_state_to_babybear(ctx, baby_bear, packed);
+            let parts = self.split_state_to_babybear(ctx, packed);
             self.output_buffer.extend(parts);
         }
     }
@@ -157,44 +160,41 @@ impl TranscriptGadget {
     pub fn observe(
         &mut self,
         ctx: &mut Context<Fr>,
-        baby_bear: &BabyBearChip,
         value: &BabyBearWire,
     ) {
         self.output_buffer.clear();
         self.input_buffer.push(*value);
         if self.input_buffer.len() == NUM_SPLIT_LIMBS * POSEIDON2_RATE {
-            self.duplexing(ctx, baby_bear);
+            self.duplexing(ctx);
         }
     }
 
     pub fn observe_ext(
         &mut self,
         ctx: &mut Context<Fr>,
-        baby_bear: &BabyBearChip,
         value: &BabyBearExtWire,
     ) {
         for coeff in &value.0 {
-            self.observe(ctx, baby_bear, coeff);
+            self.observe(ctx, coeff);
         }
     }
 
     pub fn observe_commit(
         &mut self,
         ctx: &mut Context<Fr>,
-        baby_bear: &BabyBearChip,
         digest: &DigestWire,
     ) {
         for packed in &digest.elems {
-            let limbs = self.split_state_to_babybear(ctx, baby_bear, *packed);
+            let limbs = self.split_state_to_babybear(ctx, *packed);
             for limb in &limbs {
-                self.observe(ctx, baby_bear, limb);
+                self.observe(ctx, limb);
             }
         }
     }
 
-    pub fn sample(&mut self, ctx: &mut Context<Fr>, baby_bear: &BabyBearChip) -> BabyBearWire {
+    pub fn sample(&mut self, ctx: &mut Context<Fr>) -> BabyBearWire {
         if !self.input_buffer.is_empty() || self.output_buffer.is_empty() {
-            self.duplexing(ctx, baby_bear);
+            self.duplexing(ctx);
         }
 
         self.output_buffer
@@ -205,16 +205,14 @@ impl TranscriptGadget {
     pub fn sample_ext(
         &mut self,
         ctx: &mut Context<Fr>,
-        baby_bear: &BabyBearChip,
     ) -> BabyBearExtWire {
-        let coeffs = core::array::from_fn(|_| self.sample(ctx, baby_bear));
+        let coeffs = core::array::from_fn(|_| self.sample(ctx));
         BabyBearExt4Wire(coeffs)
     }
 
     pub fn sample_bits(
         &mut self,
         ctx: &mut Context<Fr>,
-        baby_bear: &BabyBearChip,
         bits: usize,
     ) -> AssignedValue<Fr> {
         assert!(
@@ -229,9 +227,9 @@ impl TranscriptGadget {
         if bits == 0 {
             return ctx.load_zero();
         }
-        let sampled = self.sample(ctx, baby_bear);
+        let sampled = self.sample(ctx);
         // PERF[jpw]: we could optimize this since the divisor is a power of 2
-        let range = baby_bear.range();
+        let range = self.baby_bear.range();
         let (_, rem) = range.div_mod(
             ctx,
             sampled.value,
@@ -245,7 +243,6 @@ impl TranscriptGadget {
     pub fn check_witness(
         &mut self,
         ctx: &mut Context<Fr>,
-        baby_bear: &BabyBearChip,
         bits: usize,
         witness: &BabyBearWire,
     ) {
@@ -253,9 +250,9 @@ impl TranscriptGadget {
             return;
         }
 
-        self.observe(ctx, baby_bear, witness);
-        let sampled_bits = self.sample_bits(ctx, baby_bear, bits);
-        baby_bear
+        self.observe(ctx, witness);
+        let sampled_bits = self.sample_bits(ctx, bits);
+        self.baby_bear
             .range()
             .gate()
             .assert_is_const(ctx, &sampled_bits, &Fr::ZERO);

--- a/crates/static-verifier/src/transcript/tests.rs
+++ b/crates/static-verifier/src/transcript/tests.rs
@@ -117,39 +117,39 @@ fn transcript_outputs_match_native_interleaved_flow() {
         let ctx = builder.main(0);
         let gate = range.gate();
 
-        let mut transcript = TranscriptGadget::new(ctx);
+        let mut transcript = TranscriptChip::new(ctx, baby_bear.clone());
 
         let one = baby_bear.load_witness(ctx, RootF::from_u64(1));
         let two = baby_bear.load_witness(ctx, RootF::from_u64(2));
         let three = baby_bear.load_witness(ctx, RootF::from_u64(3));
-        transcript.observe(ctx, &baby_bear, &one);
-        transcript.observe(ctx, &baby_bear, &two);
-        transcript.observe(ctx, &baby_bear, &three);
+        transcript.observe(ctx, &one);
+        transcript.observe(ctx, &two);
+        transcript.observe(ctx, &three);
 
         let observed_ext = BabyBearExt4Wire(core::array::from_fn(|i| {
             baby_bear.load_witness(ctx, RootF::from_u64(observed_ext_coeffs[i]))
         }));
-        transcript.observe_ext(ctx, &baby_bear, &observed_ext);
+        transcript.observe_ext(ctx, &observed_ext);
 
-        let digest_wire = TranscriptGadget::load_digest_witness(ctx, digest);
-        transcript.observe_commit(ctx, &baby_bear, &digest_wire);
+        let digest_wire = TranscriptChip::load_digest_witness(ctx, digest);
+        transcript.observe_commit(ctx, &digest_wire);
 
-        let sampled = transcript.sample(ctx, &baby_bear);
+        let sampled = transcript.sample(ctx);
         gate.assert_is_const(ctx, &sampled.value, &Fr::from(expected_sample));
 
-        let sampled_ext = transcript.sample_ext(ctx, &baby_bear);
+        let sampled_ext = transcript.sample_ext(ctx);
         for (i, coeff) in sampled_ext.0.iter().enumerate() {
             gate.assert_is_const(ctx, &coeff.value, &Fr::from(expected_ext[i]));
         }
 
-        let sampled_bits = transcript.sample_bits(ctx, &baby_bear, 17);
+        let sampled_bits = transcript.sample_bits(ctx, 17);
         gate.assert_is_const(ctx, &sampled_bits, &Fr::from(expected_bits));
 
         let pow_witness = baby_bear.load_witness(ctx, RootF::from_u64(witness_for_pow));
         // check_witness now returns () and asserts internally
-        transcript.check_witness(ctx, &baby_bear, 9, &pow_witness);
+        transcript.check_witness(ctx, 9, &pow_witness);
 
-        let followup = transcript.sample(ctx, &baby_bear);
+        let followup = transcript.sample(ctx);
         gate.assert_is_const(ctx, &followup.value, &Fr::from(expected_followup));
     });
 }
@@ -170,19 +170,19 @@ fn transcript_check_witness_zero_bits_matches_native() {
         let ctx = builder.main(0);
         let gate = range.gate();
 
-        let mut transcript = TranscriptGadget::new(ctx);
+        let mut transcript = TranscriptChip::new(ctx, baby_bear.clone());
 
         let obs = baby_bear.load_witness(ctx, RootF::from_u64(99));
-        transcript.observe(ctx, &baby_bear, &obs);
+        transcript.observe(ctx, &obs);
 
-        let first = transcript.sample(ctx, &baby_bear);
+        let first = transcript.sample(ctx);
         gate.assert_is_const(ctx, &first.value, &Fr::from(expected_first));
 
         let witness = baby_bear.load_witness(ctx, RootF::from_u64(7));
         // check_witness now returns () and asserts internally
-        transcript.check_witness(ctx, &baby_bear, 0, &witness);
+        transcript.check_witness(ctx, 0, &witness);
 
-        let second = transcript.sample(ctx, &baby_bear);
+        let second = transcript.sample(ctx);
         gate.assert_is_const(ctx, &second.value, &Fr::from(expected_second));
     });
 }
@@ -194,8 +194,8 @@ fn transcript_sample_bits_rejects_bits_equal_31() {
             let range = builder.range_chip();
             let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
             let ctx = builder.main(0);
-            let mut transcript = TranscriptGadget::new(ctx);
-            let _ = transcript.sample_bits(ctx, &baby_bear, 31);
+            let mut transcript = TranscriptChip::new(ctx, baby_bear);
+            let _ = transcript.sample_bits(ctx, 31);
         });
     }));
     assert!(


### PR DESCRIPTION
## Summary
- Rename `TranscriptGadget` to `TranscriptChip`, which now owns a `BabyBearChip` field
- Remove the `baby_bear: &BabyBearChip` parameter from all transcript method signatures (`observe`, `sample`, `check_witness`, etc.)
- Add `baby_bear()` getter on `TranscriptChip` for callers that need the chip for non-transcript operations

## Test plan
- [x] `cargo build -p openvm-static-verifier` compiles cleanly with no warnings
- [ ] Existing transcript tests pass (`cargo nextest run --cargo-profile=fast -p openvm-static-verifier`)

closes INT-6946

🤖 Generated with [Claude Code](https://claude.com/claude-code)