### PR TITLE
fix(v2-beta): race condition in recursion tracegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5701,6 +5701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "nvtx"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2e855e8019f99e4b94ac33670eb4e4f570a2e044f3749a0b2c7f83b841e52c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "nybbles"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6236,7 +6245,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#d03d55792149624433853685a86af51be78fd61e"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4fe0be244cba8f47a7e78c4eced34b25a9c323e1"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6283,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#d03d55792149624433853685a86af51be78fd61e"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4fe0be244cba8f47a7e78c4eced34b25a9c323e1"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -6308,7 +6317,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#d03d55792149624433853685a86af51be78fd61e"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4fe0be244cba8f47a7e78c4eced34b25a9c323e1"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6335,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#d03d55792149624433853685a86af51be78fd61e"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4fe0be244cba8f47a7e78c4eced34b25a9c323e1"
 dependencies = [
  "cc",
  "glob",
@@ -6344,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#d03d55792149624433853685a86af51be78fd61e"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4fe0be244cba8f47a7e78c4eced34b25a9c323e1"
 dependencies = [
  "bytesize",
  "ctor",
@@ -7134,7 +7143,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#d03d55792149624433853685a86af51be78fd61e"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4fe0be244cba8f47a7e78c4eced34b25a9c323e1"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -7168,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#d03d55792149624433853685a86af51be78fd61e"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4fe0be244cba8f47a7e78c4eced34b25a9c323e1"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",
@@ -7179,6 +7188,7 @@ dependencies = [
  "metrics-tracing-context",
  "metrics-util",
  "num-bigint 0.4.6",
+ "nvtx",
  "openvm-cpu-backend",
  "openvm-stark-backend",
  "p3-baby-bear",

--- a/crates/recursion/src/batch_constraint/mod.rs
+++ b/crates/recursion/src/batch_constraint/mod.rs
@@ -905,7 +905,7 @@ pub mod cuda_tracegen {
             interactions_folding::cuda::InteractionsFoldingBlobGpu,
         },
         cuda::{preflight::PreflightGpu, proof::ProofGpu, vk::VerifyingKeyGpu, GlobalCtxGpu},
-        tracegen::cuda::{generate_gpu_proving_ctx, StandardTracegenGpuCtx},
+        tracegen::cuda::StandardTracegenGpuCtx,
     };
 
     impl ModuleChip<GpuBackend> for BatchConstraintModuleChip {
@@ -1079,19 +1079,30 @@ pub mod cuda_tracegen {
                 cached_trace_record,
             );
 
-            // We parallelize the CPU trace generation
-            let indexed_cpu_traces = cpu_chips
+            // Phase 1: CPU trace generation in parallel
+            let indexed_cpu_rm_traces = cpu_chips
                 .par_iter()
                 .map(|chip| {
-                    // span within par_iter to handle parallelism
                     let _guard = span.enter();
                     (
                         chip.index(),
-                        generate_gpu_proving_ctx(
-                            chip,
+                        chip.generate_trace(
                             &cpu_ctx,
                             required_heights.map(|heights| heights[chip.index()]),
                         ),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            // Phase 2: H2D transfer serially on main thread
+            let indexed_cpu_traces = indexed_cpu_rm_traces
+                .into_iter()
+                .map(|(idx, trace)| {
+                    (
+                        idx,
+                        trace.map(|m| {
+                            AirProvingContext::simple_no_pis(transport_matrix_h2d_row(&m).unwrap())
+                        }),
                     )
                 })
                 .collect::<Vec<_>>();

--- a/crates/recursion/src/batch_constraint/mod.rs
+++ b/crates/recursion/src/batch_constraint/mod.rs
@@ -1095,7 +1095,7 @@ pub mod cuda_tracegen {
                 .collect::<Vec<_>>();
 
             // Phase 2: H2D transfer serially on main thread
-            let indexed_cpu_traces = indexed_cpu_rm_traces
+            let indexed_cpu_gpu_traces = indexed_cpu_rm_traces
                 .into_iter()
                 .map(|(idx, trace)| {
                     (
@@ -1109,7 +1109,7 @@ pub mod cuda_tracegen {
 
             indexed_gpu_traces
                 .into_iter()
-                .chain(indexed_cpu_traces)
+                .chain(indexed_cpu_gpu_traces)
                 .sorted_by(|a, b| a.0.cmp(&b.0))
                 .map(|(_index, ctx)| ctx)
                 .collect()

--- a/crates/recursion/src/gkr/mod.rs
+++ b/crates/recursion/src/gkr/mod.rs
@@ -650,13 +650,12 @@ impl RowMajorChip<F> for GkrModuleChip {
 #[cfg(feature = "cuda")]
 mod cuda_tracegen {
     use itertools::Itertools;
-    use openvm_cuda_backend::GpuBackend;
-    use openvm_stark_backend::p3_maybe_rayon::prelude::*;
+    use openvm_cuda_backend::{data_transporter::transport_matrix_h2d_row, GpuBackend};
+    use openvm_stark_backend::{p3_maybe_rayon::prelude::*, prover::AirProvingContext};
 
     use super::*;
-    use crate::{
-        cuda::{preflight::PreflightGpu, proof::ProofGpu, vk::VerifyingKeyGpu, GlobalCtxGpu},
-        tracegen::cuda::generate_gpu_proving_ctx,
+    use crate::cuda::{
+        preflight::PreflightGpu, proof::ProofGpu, vk::VerifyingKeyGpu, GlobalCtxGpu,
     };
 
     impl TraceGenModule<GlobalCtxGpu, GpuBackend> for GkrModule {
@@ -689,19 +688,27 @@ mod cuda_tracegen {
                 GkrModuleChip::XiSampler,
             ];
 
+            // Phase 1: CPU trace generation in parallel
             let span = tracing::Span::current();
-            chips
+            let cpu_traces: Vec<_> = chips
                 .par_iter()
                 .map(|chip| {
                     let _guard = span.enter();
-                    generate_gpu_proving_ctx(
-                        chip,
+                    chip.generate_trace(
                         &blob,
                         required_heights.map(|heights| heights[chip.index()]),
                     )
                 })
-                .collect::<Vec<_>>()
+                .collect();
+
+            // Phase 2: H2D transfer serially on main thread
+            cpu_traces
                 .into_iter()
+                .map(|trace| {
+                    trace.map(|m| {
+                        AirProvingContext::simple_no_pis(transport_matrix_h2d_row(&m).unwrap())
+                    })
+                })
                 .collect()
         }
     }

--- a/crates/recursion/src/stacking/mod.rs
+++ b/crates/recursion/src/stacking/mod.rs
@@ -339,7 +339,9 @@ impl<SC: StarkProtocolConfig<F = F>> TraceGenModule<GlobalCtxCpu, CpuBackend<SC>
 #[cfg(feature = "cuda")]
 mod cuda_tracegen {
     use itertools::Itertools;
-    use openvm_cuda_backend::{prelude::EF, GpuBackend};
+    use openvm_cuda_backend::{
+        data_transporter::transport_matrix_h2d_row, prelude::EF, GpuBackend,
+    };
     use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer};
     use openvm_stark_backend::p3_maybe_rayon::prelude::*;
 
@@ -354,7 +356,7 @@ mod cuda_tracegen {
             },
             opening::cuda::OpeningClaimsTraceGeneratorGpu,
         },
-        tracegen::cuda::{generate_gpu_proving_ctx, StandardTracegenGpuCtx},
+        tracegen::{cuda::StandardTracegenGpuCtx, RowMajorChip, StandardTracegenCtx},
     };
 
     impl ModuleChip<GpuBackend> for StackingModuleChip {
@@ -380,7 +382,10 @@ mod cuda_tracegen {
                         proofs: &proofs_cpu,
                         preflights: &preflights_cpu,
                     };
-                    generate_gpu_proving_ctx(self, &cpu_ctx, required_height)
+                    let trace = RowMajorChip::generate_trace(self, &cpu_ctx, required_height);
+                    trace.map(|m| {
+                        AirProvingContext::simple_no_pis(transport_matrix_h2d_row(&m).unwrap())
+                    })
                 }
             }
         }
@@ -610,18 +615,39 @@ mod cuda_tracegen {
                 })
                 .collect::<Vec<_>>();
 
-            // Then run CPU tracegen for remaining AIRs in parallel
+            // Phase 1: CPU trace generation in parallel
+            let proofs_cpu = ctx.0.proofs.iter().map(|p| &p.cpu).collect_vec();
+            let preflights_cpu = ctx.0.preflights.iter().map(|p| &p.cpu).collect_vec();
+            let cpu_ctx = StandardTracegenCtx {
+                vk: &ctx.0.vk.cpu,
+                proofs: &proofs_cpu,
+                preflights: &preflights_cpu,
+            };
             let span = tracing::Span::current();
-            let indexed_cpu_ctxs = cpu_chips
+            let indexed_cpu_rm_traces = cpu_chips
                 .par_iter()
                 .map(|chip| {
                     let _guard = span.enter();
                     (
                         chip.index(),
-                        chip.generate_proving_ctx(
-                            &ctx,
+                        RowMajorChip::generate_trace(
+                            chip,
+                            &cpu_ctx,
                             required_heights.map(|heights| heights[chip.index()]),
                         ),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            // Phase 2: H2D transfer serially on main thread
+            let indexed_cpu_ctxs = indexed_cpu_rm_traces
+                .into_iter()
+                .map(|(idx, trace)| {
+                    (
+                        idx,
+                        trace.map(|m| {
+                            AirProvingContext::simple_no_pis(transport_matrix_h2d_row(&m).unwrap())
+                        }),
                     )
                 })
                 .collect::<Vec<_>>();

--- a/crates/recursion/src/stacking/mod.rs
+++ b/crates/recursion/src/stacking/mod.rs
@@ -640,7 +640,7 @@ mod cuda_tracegen {
                 .collect::<Vec<_>>();
 
             // Phase 2: H2D transfer serially on main thread
-            let indexed_cpu_ctxs = indexed_cpu_rm_traces
+            let indexed_cpu_gpu_ctxs = indexed_cpu_rm_traces
                 .into_iter()
                 .map(|(idx, trace)| {
                     (
@@ -654,7 +654,7 @@ mod cuda_tracegen {
 
             indexed_gpu_ctxs
                 .into_iter()
-                .chain(indexed_cpu_ctxs)
+                .chain(indexed_cpu_gpu_ctxs)
                 .sorted_by(|a, b| a.0.cmp(&b.0))
                 .map(|(_idx, ctx)| ctx)
                 .collect()

--- a/crates/recursion/src/tracegen.rs
+++ b/crates/recursion/src/tracegen.rs
@@ -61,8 +61,6 @@ impl<SC: StarkProtocolConfig<F = F>, T: RowMajorChip<F>> ModuleChip<CpuBackend<S
 
 #[cfg(feature = "cuda")]
 pub(crate) mod cuda {
-    use openvm_cuda_backend::{data_transporter::transport_matrix_h2d_row, GpuBackend};
-
     use super::*;
     use crate::cuda::{preflight::PreflightGpu, proof::ProofGpu, vk::VerifyingKeyGpu};
 
@@ -70,15 +68,5 @@ pub(crate) mod cuda {
         pub vk: &'a VerifyingKeyGpu,
         pub proofs: &'a [ProofGpu],
         pub preflights: &'a [PreflightGpu],
-    }
-
-    pub(crate) fn generate_gpu_proving_ctx<T: RowMajorChip<F>>(
-        t: &T,
-        ctx: &T::Ctx<'_>,
-        required_height: Option<usize>,
-    ) -> Option<AirProvingContext<GpuBackend>> {
-        let common_main_rm = t.generate_trace(ctx, required_height);
-        common_main_rm
-            .map(|m| AirProvingContext::simple_no_pis(transport_matrix_h2d_row(&m).unwrap()))
     }
 }

--- a/crates/recursion/src/whir/mod.rs
+++ b/crates/recursion/src/whir/mod.rs
@@ -1382,7 +1382,7 @@ impl RowMajorChip<F> for WhirModuleChip {
 mod cuda_tracegen {
     use std::cmp;
 
-    use openvm_cuda_backend::GpuBackend;
+    use openvm_cuda_backend::{data_transporter::transport_matrix_h2d_row, GpuBackend};
     use openvm_cuda_common::d_buffer::DeviceBuffer;
     use openvm_poseidon2_air::POSEIDON2_WIDTH;
     use openvm_stark_backend::p3_maybe_rayon::prelude::*;
@@ -1394,7 +1394,7 @@ mod cuda_tracegen {
             preflight::PreflightGpu, proof::ProofGpu, to_device_or_nullptr, vk::VerifyingKeyGpu,
             GlobalCtxGpu,
         },
-        tracegen::cuda::{generate_gpu_proving_ctx, StandardTracegenGpuCtx},
+        tracegen::{cuda::StandardTracegenGpuCtx, RowMajorChip, StandardTracegenCtx},
         whir::cuda_abi::PoseidonStatePair,
     };
 
@@ -1640,7 +1640,10 @@ mod cuda_tracegen {
                         },
                         ctx.2,
                     );
-                    generate_gpu_proving_ctx(self, &cpu_ctx, required_height)
+                    let trace = RowMajorChip::generate_trace(self, &cpu_ctx, required_height);
+                    trace.map(|m| {
+                        AirProvingContext::simple_no_pis(transport_matrix_h2d_row(&m).unwrap())
+                    })
                 }
             }
         }
@@ -1708,18 +1711,42 @@ mod cuda_tracegen {
                 })
                 .collect::<Vec<_>>();
 
-            // Then run CPU tracegen for the remaining AIRs in parallel.
+            // Phase 1: CPU trace generation in parallel
+            let cpu_proofs = ctx.0.proofs.iter().map(|p| &p.cpu).collect_vec();
+            let cpu_preflights = ctx.0.preflights.iter().map(|p| &p.cpu).collect_vec();
+            let cpu_ctx = (
+                StandardTracegenCtx {
+                    vk: &ctx.0.vk.cpu,
+                    proofs: &cpu_proofs,
+                    preflights: &cpu_preflights,
+                },
+                ctx.2,
+            );
             let span = tracing::Span::current();
-            let indexed_cpu_ctxs = cpu_chips
+            let indexed_cpu_rm_traces = cpu_chips
                 .par_iter()
                 .map(|chip| {
                     let _guard = span.enter();
                     (
                         chip.index(),
-                        chip.generate_proving_ctx(
-                            &ctx,
+                        RowMajorChip::generate_trace(
+                            chip,
+                            &cpu_ctx,
                             required_heights.map(|heights| heights[chip.index()]),
                         ),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            // Phase 2: H2D transfer serially on main thread
+            let indexed_cpu_ctxs = indexed_cpu_rm_traces
+                .into_iter()
+                .map(|(idx, trace)| {
+                    (
+                        idx,
+                        trace.map(|m| {
+                            AirProvingContext::simple_no_pis(transport_matrix_h2d_row(&m).unwrap())
+                        }),
                     )
                 })
                 .collect::<Vec<_>>();

--- a/crates/recursion/src/whir/mod.rs
+++ b/crates/recursion/src/whir/mod.rs
@@ -1739,7 +1739,7 @@ mod cuda_tracegen {
                 .collect::<Vec<_>>();
 
             // Phase 2: H2D transfer serially on main thread
-            let indexed_cpu_ctxs = indexed_cpu_rm_traces
+            let indexed_cpu_gpu_ctxs = indexed_cpu_rm_traces
                 .into_iter()
                 .map(|(idx, trace)| {
                     (
@@ -1753,7 +1753,7 @@ mod cuda_tracegen {
 
             indexed_gpu_ctxs
                 .into_iter()
-                .chain(indexed_cpu_ctxs)
+                .chain(indexed_cpu_gpu_ctxs)
                 .sorted_by(|a, b| a.0.cmp(&b.0))
                 .map(|(_idx, ctx)| ctx)
                 .collect()


### PR DESCRIPTION
## Summary

- Fix CUDA stream safety issue: `generate_gpu_proving_ctx` was called inside `par_iter` in 4 modules (batch_constraint, gkr, stacking, whir), causing GPU buffer allocations and H2D transfers to run on rayon worker threads instead of the main/default CUDA stream
- Split all affected sites into two phases: (1) CPU trace generation in parallel via `par_iter`, (2) H2D transfer serially on the main thread via `transport_matrix_h2d_row`
- Delete the now-unused `generate_gpu_proving_ctx` helper from `tracegen.rs`
- Inline H2D transfer in the `_ =>` fallback arms of `ModuleChip<GpuBackend>` impls for stacking and whir