### PR TITLE
fix: add global_cached_idx to CachedCommitBusMessage

### DIFF
--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -181,6 +181,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             CachedCommitBusMessage {
                 air_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_AIR_ID),
                 cached_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_CACHED_INDEX),
+                global_cached_idx: AB::Expr::ZERO,
                 cached_commit,
             },
             AB::F::ONE,

--- a/crates/continuations/src/circuit/deferral/inner/input/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/input/air.rs
@@ -32,6 +32,7 @@ pub struct InputCommitCols<F> {
     pub is_first: F,
 
     pub proof_idx: F,
+    pub row_in_proof_idx: F,
     pub has_verifier_pvs: F,
 
     pub air_idx: F,
@@ -67,19 +68,19 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         let local: &InputCommitCols<AB::Var> = (*local).borrow();
         let next: &InputCommitCols<AB::Var> = (*next).borrow();
 
-        NestedForLoopSubAir::<1> {}.eval(
+        NestedForLoopSubAir::<2> {}.eval(
             builder,
             (
                 NestedForLoopIoCols {
                     is_enabled: local.is_valid,
-                    counter: [local.proof_idx],
-                    is_first: [local.is_first],
+                    counter: [local.proof_idx, local.row_in_proof_idx],
+                    is_first: [local.is_first, local.is_valid],
                 }
                 .map_into(),
                 NestedForLoopIoCols {
                     is_enabled: next.is_valid,
-                    counter: [next.proof_idx],
-                    is_first: [next.is_first],
+                    counter: [next.proof_idx, next.row_in_proof_idx],
+                    is_first: [next.is_first, next.is_valid],
                 }
                 .map_into(),
             ),
@@ -126,9 +127,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             builder,
             local.proof_idx,
             CachedCommitBusMessage {
-                air_idx: local.air_idx,
-                cached_idx: local.cached_idx,
-                cached_commit: local.current_commit,
+                air_idx: local.air_idx.into(),
+                cached_idx: local.cached_idx.into(),
+                global_cached_idx: local.row_in_proof_idx - AB::Expr::ONE,
+                cached_commit: local.current_commit.map(Into::into),
             },
             is_leaf.clone() * (local.is_valid - local.is_first),
         );

--- a/crates/continuations/src/circuit/deferral/inner/input/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/input/trace.rs
@@ -67,6 +67,7 @@ pub fn generate_proving_ctx(
             cols.is_valid = F::ONE;
             cols.is_first = F::from_bool(row_in_proof == 0);
             cols.proof_idx = F::from_usize(proof_idx);
+            cols.row_in_proof_idx = F::from_usize(row_in_proof);
             cols.has_verifier_pvs = F::from_bool(child_is_agg);
             cols.air_idx = F::from_usize(air_idx);
             cols.cached_idx = F::from_usize(cached_idx);

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -309,6 +309,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             CachedCommitBusMessage {
                 air_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_AIR_ID),
                 cached_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_CACHED_INDEX),
+                global_cached_idx: AB::Expr::ZERO,
                 cached_commit,
             },
             local.is_valid * is_internal,

--- a/crates/continuations/src/circuit/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/def_pvs/air.rs
@@ -197,6 +197,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             CachedCommitBusMessage {
                 air_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_AIR_ID),
                 cached_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_CACHED_INDEX),
+                global_cached_idx: AB::Expr::ZERO,
                 cached_commit: self.expected_def_hook_cached_commit.into(),
             },
             local.is_present * not(local.has_verifier_pvs),

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -259,6 +259,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             CachedCommitBusMessage {
                 air_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_AIR_ID),
                 cached_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_CACHED_INDEX),
+                global_cached_idx: AB::Expr::ZERO,
                 cached_commit,
             },
             local.is_valid * is_internal,

--- a/crates/continuations/src/circuit/inner/vm_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/vm_pvs/air.rs
@@ -274,6 +274,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             CachedCommitBusMessage {
                 air_idx: AB::Expr::from_usize(PROGRAM_AIR_ID),
                 cached_idx: AB::Expr::from_usize(PROGRAM_CACHED_TRACE_INDEX),
+                global_cached_idx: AB::Expr::ZERO,
                 cached_commit: local.child_pvs.program_commit.map(Into::into),
             },
             local.is_valid * is_leaf,

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -188,6 +188,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             CachedCommitBusMessage {
                 air_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_AIR_ID),
                 cached_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_CACHED_INDEX),
+                global_cached_idx: AB::Expr::ZERO,
                 cached_commit,
             },
             AB::F::ONE,

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -515,6 +515,7 @@ define_typed_per_proof_lookup_bus!(CommitmentsBus, CommitmentsBusMessage);
 pub struct CachedCommitBusMessage<T> {
     pub air_idx: T,
     pub cached_idx: T,
+    pub global_cached_idx: T,
     pub cached_commit: [T; DIGEST_SIZE],
 }
 

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -279,6 +279,10 @@ where
         let mut num_pvs = AB::Expr::ZERO;
         let mut has_pvs = AB::Expr::ZERO;
 
+        // Select values for CachedCommitBus
+        let mut current_air_found = AB::Expr::ZERO;
+        let mut global_cached_start_idx = AB::Expr::ZERO;
+
         for (i, air_data) in self.per_air.iter().enumerate() {
             // We keep a running tally of how many transcript reads there should be up to any
             // given point, and use that to constrain initial_tidx
@@ -332,9 +336,13 @@ where
                 });
             }
 
+            current_air_found += is_current_air.clone();
+            let global_cached_idx_increment = not::<AB::Expr>(current_air_found.clone());
+
             for (cached_idx, width) in air_data.cached_widths.iter().enumerate() {
                 cached_present[cached_idx] += is_current_air.clone();
                 cached_widths[cached_idx] += is_current_air.clone() * AB::Expr::from_usize(*width);
+                global_cached_start_idx += global_cached_idx_increment.clone();
             }
         }
 
@@ -671,12 +679,14 @@ where
             );
             cidx_offset += cached_present[cached_idx].clone();
 
+            let cached_idx_expr = AB::Expr::from_usize(cached_idx);
             self.cached_commit_bus.send(
                 builder,
                 local.proof_idx,
                 CachedCommitBusMessage {
                     air_idx: air_idx.clone(),
-                    cached_idx: AB::Expr::from_usize(cached_idx),
+                    cached_idx: cached_idx_expr.clone(),
+                    global_cached_idx: global_cached_start_idx.clone() + cached_idx_expr,
                     cached_commit: localv.cached_commits[cached_idx].map(Into::into),
                 },
                 cached_present[cached_idx].clone()

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -203,6 +203,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             CachedCommitBusMessage {
                 air_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_AIR_ID),
                 cached_idx: AB::Expr::from_usize(CONSTRAINT_EVAL_CACHED_INDEX),
+                global_cached_idx: AB::Expr::ZERO,
                 cached_commit,
             },
             AB::F::ONE,


### PR DESCRIPTION
Resolves INT-7117.

## Overview

This PR adds a `global_cached_idx` field to `CachedCommitBusMessage` to enforce the **ordering** of cached trace commitments across AIRs within a proof. Previously, the bus message only carried `(air_idx, cached_idx)`, which identifies *which* cached trace a commitment belongs to but does not constrain the *order* in which they appear. The new field assigns each cached trace a globally sequential index (0, 1, 2, ...) across all AIRs, enabling the `InputCommitAir` to verify it processes them in the correct order.

## Bus interface change: `CachedCommitBusMessage` (`crates/recursion/src/bus.rs`)

A new field is added to the message struct:

```rust
pub struct CachedCommitBusMessage<T> {
    pub air_idx: T,
    pub cached_idx: T,
    pub global_cached_idx: T,   // NEW
    pub cached_commit: [T; DIGEST_SIZE],
}
```

`global_cached_idx` is a 0-based index that counts cached traces sequentially across all AIRs in the proof. For a proof with 3 AIRs where AIR 0 has 1 cached trace, AIR 1 has 0, and AIR 2 has 2:

| air_idx | cached_idx | global_cached_idx |
|---------|-----------|-------------------|
| 0       | 0         | 0                 |
| 2       | 0         | 1                 |
| 2       | 1         | 2                 |

### Bus interaction diagram

```
  ProofShapeAir                              Receiver AIRs
 ┌─────────────┐                          ┌──────────────────────┐
 │  Iterates    │  ── send per cached ──► │  InputCommitAir      │
 │  over all    │     trace (leaf only)   │  (receives ALL       │
 │  AIRs in     │                         │   cached commits     │
 │  the proof   │                         │   for leaf proofs)   │
 │              │                         └──────────────────────┘
 │              │                         ┌──────────────────────┐
 │              │  ── send per cached ──► │  Verifier AIRs       │
 │              │     trace (internal)    │  (receive single     │
 │              │                         │   CONSTRAINT_EVAL    │
 └─────────────┘                         │   cached commit for  │
                                          │   internal proofs)   │
                                          └──────────────────────┘
                                          ┌──────────────────────┐
                                          │  VmPvsAir            │
                                          │  (receives PROGRAM   │
                                          │   cached commit for  │
                                          │   leaf proofs)       │
                                          └──────────────────────┘
```

## Sender: `ProofShapeAir` (`crates/recursion/src/proof_shape/proof_shape/air.rs`)

Computes `global_cached_idx` for each cached trace it sends. The logic works by accumulating a `global_cached_start_idx` as it iterates over AIRs:

```
current_air_found += is_current_air;
global_cached_idx_increment = NOT(current_air_found);   // 1 for AIRs before current, 0 at/after

for each cached trace in this AIR:
    global_cached_start_idx += global_cached_idx_increment;
```

This counts the total number of cached traces in all AIRs preceding the current row's AIR. The sent `global_cached_idx` is then `global_cached_start_idx + cached_idx`.

## Receiver: `InputCommitAir` (`crates/continuations/src/circuit/deferral/inner/input/`)

### Column changes

A new column `row_in_proof_idx` is added to `InputCommitCols`, tracking the 0-based row index within each proof. The `NestedForLoopSubAir` is upgraded from `<1>` (single counter) to `<2>` (two counters) to constrain this new counter.

Example trace for a proof with 3 cached traces:

| row | is_valid | is_first | proof_idx | row_in_proof_idx | air_idx | cached_idx | current_commit |
|-----|----------|----------|-----------|------------------|---------|-----------|----------------|
| 0   | 1        | 1        | 0         | 0                | 0       | 0         | initial_commit |
| 1   | 1        | 0        | 0         | 1                | 0       | 0         | cached_0       |
| 2   | 1        | 0        | 0         | 2                | 2       | 0         | cached_1       |
| 3   | 1        | 0        | 0         | 3                | 2       | 1         | cached_2       |
| 4   | 1        | 1        | 1         | 0                | 0       | 0         | initial_commit |
| ... | ...      | ...      | ...       | ...              | ...     | ...       | ...            |

Row 0 per proof is the initial commit (read from public values, not from the bus). Cached commits start at `row_in_proof_idx = 1`. The bus receive uses `global_cached_idx = row_in_proof_idx - 1` to convert to 0-based indexing, matching the sender. The multiplicity `is_leaf * (is_valid - is_first)` disables the bus interaction on the initial-commit row, so the wrapping subtraction on row 0 is harmless.

### `NestedForLoopSubAir` upgrade

Changed from `NestedForLoopSubAir::<1>` to `NestedForLoopSubAir::<2>`:

| Parameter      | Old (depth=2)     | New (depth=3)                            |
|----------------|-------------------|------------------------------------------|
| `counter`      | `[proof_idx]`     | `[proof_idx, row_in_proof_idx]`          |
| `is_first`     | `[is_first]`      | `[is_first, is_valid]`                   |

The inner `is_first = is_valid` means the innermost (implicit) loop has exactly one iteration per row, effectively making this a 2-level loop that constrains `row_in_proof_idx` resets to 0 at each new `proof_idx`.

## Receivers with `global_cached_idx: ZERO` (6 files)

The following AIRs all receive a single known cached commit and set `global_cached_idx: AB::Expr::ZERO`:

| File | AIR | `air_idx` | `cached_idx` | Active when |
|------|-----|-----------|-------------|-------------|
| `continuations/.../deferral/hook/verifier/air.rs` | DeferralHookVerifierAir | `CONSTRAINT_EVAL_AIR_ID` (3) | `CONSTRAINT_EVAL_CACHED_INDEX` (0) | always (mult=1) |
| `continuations/.../deferral/inner/verifier/air.rs` | DeferralInnerVerifierAir | `CONSTRAINT_EVAL_AIR_ID` (3) | `CONSTRAINT_EVAL_CACHED_INDEX` (0) | `is_valid * is_internal` |
| `continuations/.../inner/def_pvs/air.rs` | DefPvsAir | `CONSTRAINT_EVAL_AIR_ID` (3) | `CONSTRAINT_EVAL_CACHED_INDEX` (0) | `is_present * !has_verifier_pvs` |
| `continuations/.../inner/verifier/air.rs` | InnerVerifierAir | `CONSTRAINT_EVAL_AIR_ID` (3) | `CONSTRAINT_EVAL_CACHED_INDEX` (0) | `is_valid * is_internal` |
| `continuations/.../inner/vm_pvs/air.rs` | VmPvsAir | `PROGRAM_AIR_ID` (0) | `PROGRAM_CACHED_TRACE_INDEX` (0) | `is_valid * is_leaf` |
| `continuations/.../root/verifier/air.rs` | RootVerifierAir | `CONSTRAINT_EVAL_AIR_ID` (3) | `CONSTRAINT_EVAL_CACHED_INDEX` (0) | always (mult=1) |
| `guest-libs/verify-stark/circuit/.../verifier/air.rs` | VerifyStarkVerifierAir | `CONSTRAINT_EVAL_AIR_ID` (3) | `CONSTRAINT_EVAL_CACHED_INDEX` (0) | always (mult=1) |

These are correct because:
- **`PROGRAM_AIR_ID=0, cached_idx=0`**: First AIR, first cached trace → `global_cached_idx = 0`. ✓
- **`CONSTRAINT_EVAL_AIR_ID=3, cached_idx=0`**: These receivers are only active for **internal** (recursion-circuit) proofs, where the recursion circuit's AIRs 0–2 have no cached traces, so the global index for AIR 3's first cached trace is 0. ✓
