### PR TITLE
fix(cuda): Poseidon2 dedup aliasing, buffer capacity, and zero-record crash

### DIFF
--- a/crates/circuits/primitives/cuda/include/primitives/shared_buffer.cuh
+++ b/crates/circuits/primitives/cuda/include/primitives/shared_buffer.cuh
@@ -5,6 +5,8 @@
 #include "trace_access.h"
 #include <cassert>
 
+/// Thread-safe append-only device buffer. `capacity` is the maximum number of
+/// `T` records that can be stored (not the byte size or field-element count).
 template <typename T> struct SharedBuffer {
     T *data;
     uint32_t *idx;
@@ -20,6 +22,8 @@ template <typename T> struct SharedBuffer {
     }
 };
 
+/// Poseidon2 record buffer backed by a SharedBuffer of FpArray<16> records.
+/// `capacity` is the number of FpArray<16> records, NOT the number of Fp elements.
 struct Poseidon2Buffer {
     SharedBuffer<FpArray<16>> state;
 

--- a/crates/recursion/cuda/src/transcript/poseidon2.cu
+++ b/crates/recursion/cuda/src/transcript/poseidon2.cu
@@ -154,6 +154,8 @@ extern "C" int _poseidon2_deduplicate_records_get_temp_bytes(
 extern "C" int _poseidon2_deduplicate_records(
     Fp *d_records,
     Poseidon2Count *d_counts,
+    Fp *d_records_out,
+    Poseidon2Count *d_counts_out,
     size_t num_records,
     size_t *d_num_records,
     size_t num_prefix_perms,
@@ -168,6 +170,7 @@ extern "C" int _poseidon2_deduplicate_records(
     );
 
     FpArray<16> *d_records_fp16 = reinterpret_cast<FpArray<16> *>(d_records);
+    FpArray<16> *d_records_out_fp16 = reinterpret_cast<FpArray<16> *>(d_records_out);
 
     // TODO: We currently can't use DeviceRadixSort since each key is 64 bytes
     // which causes Fp16Decomposer usage to exceed shared memory. We need to
@@ -184,14 +187,14 @@ extern "C" int _poseidon2_deduplicate_records(
 
     // Removes duplicate values from d_records, and stores the number of times
     // they occur in d_counts. The number of unique values is stored into
-    // d_num_records.
+    // d_num_records. Output buffers must not alias the inputs (CUB requirement).
     cub::DeviceReduce::ReduceByKey(
         d_temp_storage,
         temp_storage_bytes,
         d_records_fp16,
-        d_records_fp16,
+        d_records_out_fp16,
         d_counts,
-        d_counts,
+        d_counts_out,
         d_num_records,
         Poseidon2CountCompose{},
         num_records,

--- a/crates/recursion/src/transcript/cuda_abi.rs
+++ b/crates/recursion/src/transcript/cuda_abi.rs
@@ -1,7 +1,11 @@
 #![allow(clippy::missing_safety_doc)]
 
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F};
-use openvm_cuda_common::{copy::cuda_memcpy, d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{
+    copy::cuda_memcpy,
+    d_buffer::DeviceBuffer,
+    error::{CudaError, MemCopyError},
+};
 use openvm_poseidon2_air::POSEIDON2_WIDTH;
 use openvm_stark_backend::prover::MatrixDimensions;
 
@@ -141,10 +145,22 @@ pub unsafe fn poseidon2_deduplicate_records(
     ))?;
     let records_bytes = num_records * POSEIDON2_WIDTH * std::mem::size_of::<F>();
     let counts_bytes = num_records * std::mem::size_of::<Poseidon2Count>();
-    cuda_memcpy::<true, true>(d_records.as_mut_raw_ptr(), d_records_out.as_raw_ptr(), records_bytes)
-        .expect("Failed to copy deduplicated records");
-    cuda_memcpy::<true, true>(d_counts.as_mut_raw_ptr(), d_counts_out.as_raw_ptr(), counts_bytes)
-        .expect("Failed to copy deduplicated counts");
+    let map_err = |e: MemCopyError| match e {
+        MemCopyError::Cuda(e) => e,
+        other => panic!("{other}"),
+    };
+    cuda_memcpy::<true, true>(
+        d_records.as_mut_raw_ptr(),
+        d_records_out.as_raw_ptr(),
+        records_bytes,
+    )
+    .map_err(&map_err)?;
+    cuda_memcpy::<true, true>(
+        d_counts.as_mut_raw_ptr(),
+        d_counts_out.as_raw_ptr(),
+        counts_bytes,
+    )
+    .map_err(map_err)?;
     Ok(())
 }
 

--- a/crates/recursion/src/transcript/cuda_abi.rs
+++ b/crates/recursion/src/transcript/cuda_abi.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F};
-use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_cuda_common::{copy::cuda_memcpy, d_buffer::DeviceBuffer, error::CudaError};
 use openvm_poseidon2_air::POSEIDON2_WIDTH;
 use openvm_stark_backend::prover::MatrixDimensions;
 
@@ -32,6 +32,8 @@ extern "C" {
     fn _poseidon2_deduplicate_records(
         d_records: *mut F,
         d_counts: *mut Poseidon2Count,
+        d_records_out: *mut F,
+        d_counts_out: *mut Poseidon2Count,
         num_records: usize,
         d_num_records: *mut usize,
         num_prefix_perms: usize,
@@ -120,9 +122,15 @@ pub unsafe fn poseidon2_deduplicate_records(
     d_temp_storage: &DeviceBuffer<u8>,
     temp_storage_bytes: usize,
 ) -> Result<(), CudaError> {
+    // CUB ReduceByKey requires non-overlapping input and output ranges.
+    // Allocate separate output buffers, then copy results back.
+    let d_records_out = DeviceBuffer::<F>::with_capacity(num_records * POSEIDON2_WIDTH);
+    let d_counts_out = DeviceBuffer::<Poseidon2Count>::with_capacity(num_records);
     CudaError::from_result(_poseidon2_deduplicate_records(
         d_records.as_mut_ptr(),
         d_counts.as_mut_ptr(),
+        d_records_out.as_mut_ptr(),
+        d_counts_out.as_mut_ptr(),
         num_records,
         d_num_records.as_mut_ptr(),
         num_prefix_perms,
@@ -130,7 +138,14 @@ pub unsafe fn poseidon2_deduplicate_records(
         num_suffix_perms,
         d_temp_storage.as_mut_ptr() as *mut std::ffi::c_void,
         temp_storage_bytes,
-    ))
+    ))?;
+    let records_bytes = num_records * POSEIDON2_WIDTH * std::mem::size_of::<F>();
+    let counts_bytes = num_records * std::mem::size_of::<Poseidon2Count>();
+    cuda_memcpy::<true, true>(d_records.as_mut_raw_ptr(), d_records_out.as_raw_ptr(), records_bytes)
+        .expect("Failed to copy deduplicated records");
+    cuda_memcpy::<true, true>(d_counts.as_mut_raw_ptr(), d_counts_out.as_raw_ptr(), counts_bytes)
+        .expect("Failed to copy deduplicated counts");
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/recursion/src/transcript/cuda_abi.rs
+++ b/crates/recursion/src/transcript/cuda_abi.rs
@@ -154,7 +154,7 @@ pub unsafe fn poseidon2_deduplicate_records(
         d_records_out.as_raw_ptr(),
         records_bytes,
     )
-    .map_err(&map_err)?;
+    .map_err(map_err)?;
     cuda_memcpy::<true, true>(
         d_counts.as_mut_raw_ptr(),
         d_counts_out.as_raw_ptr(),

--- a/crates/vm/cuda/src/system/boundary.cu
+++ b/crates/vm/cuda/src/system/boundary.cu
@@ -106,6 +106,9 @@ extern "C" int _persistent_boundary_tracegen(
     BoundaryRecord<PERSISTENT_CHUNK, BLOCKS_PER_CHUNK> *d_records =
         reinterpret_cast<BoundaryRecord<PERSISTENT_CHUNK, BLOCKS_PER_CHUNK> *>(d_raw_records);
     FpArray<16> *d_poseidon2_buffer = reinterpret_cast<FpArray<16> *>(d_poseidon2_raw_buffer);
+    // poseidon2_capacity arrives from Rust in units of Fp elements; convert to record count.
+    assert(poseidon2_capacity % 16 == 0 && "poseidon2_capacity must be a multiple of 16");
+    size_t poseidon2_record_capacity = poseidon2_capacity / 16;
     cukernel_persistent_boundary_tracegen<<<grid, block>>>(
         d_trace,
         height,
@@ -115,7 +118,7 @@ extern "C" int _persistent_boundary_tracegen(
         num_records,
         d_poseidon2_buffer,
         d_poseidon2_buffer_idx,
-        poseidon2_capacity
+        poseidon2_record_capacity
     );
     return CHECK_KERNEL();
 }

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -576,6 +576,9 @@ extern "C" int _update_merkle_tree(
     size_t poseidon2_capacity
 ) {
     assert(num_leaves > 0);
+    // poseidon2_capacity arrives from Rust in units of Fp elements; convert to record count.
+    assert(poseidon2_capacity % 16 == 0 && "poseidon2_capacity must be a multiple of 16");
+    size_t poseidon2_record_capacity = poseidon2_capacity / 16;
     uint32_t num_children = num_leaves;
     size_t const trace_height = [](uint32_t x) {
         return x ? (1u << (32 - __builtin_clz(x - 1))) : 0;
@@ -664,7 +667,7 @@ extern "C" int _update_merkle_tree(
             trace_height,
             d_poseidon2_raw_buffer,
             d_poseidon2_buffer_idx,
-            poseidon2_capacity
+            poseidon2_record_capacity
         );
         num_children = num_parents;
     }
@@ -681,7 +684,7 @@ extern "C" int _update_merkle_tree(
         subtree_height + __builtin_ctz(num_subtrees),
         d_poseidon2_raw_buffer,
         d_poseidon2_buffer_idx,
-        poseidon2_capacity
+        poseidon2_record_capacity
     );
 
     return CHECK_KERNEL();

--- a/crates/vm/cuda/src/system/poseidon2.cu
+++ b/crates/vm/cuda/src/system/poseidon2.cu
@@ -127,12 +127,15 @@ extern "C" int _system_poseidon2_deduplicate_records_get_temp_bytes(
 extern "C" int _system_poseidon2_deduplicate_records(
     Fp *d_records,
     uint32_t *d_counts,
+    Fp *d_records_out,
+    uint32_t *d_counts_out,
     size_t num_records,
     size_t *d_num_records,
     void *d_temp_storage,
     size_t temp_storage_bytes
 ) {
     FpArray<16> *d_records_fp16 = reinterpret_cast<FpArray<16> *>(d_records);
+    FpArray<16> *d_records_out_fp16 = reinterpret_cast<FpArray<16> *>(d_records_out);
 
     // TODO: We currently can't use DeviceRadixSort since each key is 64 bytes
     // which causes Fp16Decomposer usage to exceed shared memory. We need to
@@ -148,14 +151,14 @@ extern "C" int _system_poseidon2_deduplicate_records(
 
     // Removes duplicate values from d_records, and stores the number of times
     // they occur in d_counts. The number of unique values is stored into
-    // d_num_records.
+    // d_num_records. Output buffers must not alias the inputs (CUB requirement).
     cub::DeviceReduce::ReduceByKey(
         d_temp_storage,
         temp_storage_bytes,
         d_records_fp16,
-        d_records_fp16,
+        d_records_out_fp16,
         d_counts,
-        d_counts,
+        d_counts_out,
         d_num_records,
         std::plus(),
         num_records,

--- a/crates/vm/src/cuda_abi.rs
+++ b/crates/vm/src/cuda_abi.rs
@@ -182,7 +182,7 @@ pub mod poseidon2 {
             d_records_out.as_raw_ptr(),
             records_bytes,
         )
-        .map_err(&map_err)?;
+        .map_err(map_err)?;
         cuda_memcpy::<true, true>(
             d_counts.as_mut_raw_ptr(),
             d_counts_out.as_raw_ptr(),

--- a/crates/vm/src/cuda_abi.rs
+++ b/crates/vm/src/cuda_abi.rs
@@ -76,6 +76,9 @@ pub mod phantom {
 }
 
 pub mod poseidon2 {
+    use openvm_cuda_common::copy::cuda_memcpy;
+    use openvm_poseidon2_air::POSEIDON2_WIDTH;
+
     use super::*;
 
     extern "C" {
@@ -100,6 +103,8 @@ pub mod poseidon2 {
         fn _system_poseidon2_deduplicate_records(
             d_records: *mut F,
             d_counts: *mut u32,
+            d_records_out: *mut F,
+            d_counts_out: *mut u32,
             num_records: usize,
             d_num_records: *mut usize,
             d_temp_storage: *mut std::ffi::c_void,
@@ -151,14 +156,27 @@ pub mod poseidon2 {
         d_temp_storage: &DeviceBuffer<u8>,
         temp_storage_bytes: usize,
     ) -> Result<(), CudaError> {
+        // CUB ReduceByKey requires non-overlapping input and output ranges.
+        // Allocate separate output buffers, then copy results back.
+        let d_records_out = DeviceBuffer::<F>::with_capacity(num_records * POSEIDON2_WIDTH);
+        let d_counts_out = DeviceBuffer::<u32>::with_capacity(num_records);
         CudaError::from_result(_system_poseidon2_deduplicate_records(
             d_records.as_mut_ptr(),
             d_counts.as_mut_ptr(),
+            d_records_out.as_mut_ptr(),
+            d_counts_out.as_mut_ptr(),
             num_records,
             d_num_records.as_mut_ptr(),
             d_temp_storage.as_mut_raw_ptr(),
             temp_storage_bytes,
-        ))
+        ))?;
+        let records_bytes = num_records * POSEIDON2_WIDTH * std::mem::size_of::<F>();
+        let counts_bytes = num_records * std::mem::size_of::<u32>();
+        cuda_memcpy::<true, true>(d_records.as_mut_raw_ptr(), d_records_out.as_raw_ptr(), records_bytes)
+            .expect("Failed to copy deduplicated records");
+        cuda_memcpy::<true, true>(d_counts.as_mut_raw_ptr(), d_counts_out.as_raw_ptr(), counts_bytes)
+            .expect("Failed to copy deduplicated counts");
+        Ok(())
     }
 }
 

--- a/crates/vm/src/cuda_abi.rs
+++ b/crates/vm/src/cuda_abi.rs
@@ -43,6 +43,7 @@ pub mod boundary {
             num_records,
             d_poseidon2_raw_buffer.as_mut_ptr(),
             d_poseidon2_buffer_idx.as_mut_ptr(),
+            // Length in F elements; the CUDA side converts to record count.
             d_poseidon2_raw_buffer.len(),
         ))
     }

--- a/crates/vm/src/cuda_abi.rs
+++ b/crates/vm/src/cuda_abi.rs
@@ -77,7 +77,7 @@ pub mod phantom {
 }
 
 pub mod poseidon2 {
-    use openvm_cuda_common::copy::cuda_memcpy;
+    use openvm_cuda_common::{copy::cuda_memcpy, error::MemCopyError};
     use openvm_poseidon2_air::POSEIDON2_WIDTH;
 
     use super::*;
@@ -173,10 +173,22 @@ pub mod poseidon2 {
         ))?;
         let records_bytes = num_records * POSEIDON2_WIDTH * std::mem::size_of::<F>();
         let counts_bytes = num_records * std::mem::size_of::<u32>();
-        cuda_memcpy::<true, true>(d_records.as_mut_raw_ptr(), d_records_out.as_raw_ptr(), records_bytes)
-            .expect("Failed to copy deduplicated records");
-        cuda_memcpy::<true, true>(d_counts.as_mut_raw_ptr(), d_counts_out.as_raw_ptr(), counts_bytes)
-            .expect("Failed to copy deduplicated counts");
+        let map_err = |e: MemCopyError| match e {
+            MemCopyError::Cuda(e) => e,
+            other => panic!("{other}"),
+        };
+        cuda_memcpy::<true, true>(
+            d_records.as_mut_raw_ptr(),
+            d_records_out.as_raw_ptr(),
+            records_bytes,
+        )
+        .map_err(&map_err)?;
+        cuda_memcpy::<true, true>(
+            d_counts.as_mut_raw_ptr(),
+            d_counts_out.as_raw_ptr(),
+            counts_bytes,
+        )
+        .map_err(map_err)?;
         Ok(())
     }
 }

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -167,6 +167,7 @@ pub mod merkle_tree {
             actual_heights.as_ptr(),
             hasher_buffer.buffer.as_mut_raw_ptr(),
             hasher_buffer.idx.as_mut_ptr(),
+            // Length in F elements; the CUDA side converts to record count.
             hasher_buffer.buffer.len(),
         ))
     }

--- a/crates/vm/src/system/cuda/poseidon2.rs
+++ b/crates/vm/src/system/cuda/poseidon2.rs
@@ -29,6 +29,9 @@ pub struct Poseidon2ChipGPU<const SBOX_REGISTERS: usize> {
 }
 
 impl<const SBOX_REGISTERS: usize> Poseidon2ChipGPU<SBOX_REGISTERS> {
+    /// Creates a new Poseidon2 chip with a device buffer of `max_buffer_size` field elements.
+    /// Each Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, so the buffer
+    /// can hold `max_buffer_size / POSEIDON2_WIDTH` records.
     pub fn new(max_buffer_size: usize) -> Self {
         let idx = Arc::new(DeviceBuffer::<u32>::with_capacity(1));
         idx.fill_zero().unwrap();

--- a/crates/vm/src/system/cuda/poseidon2.rs
+++ b/crates/vm/src/system/cuda/poseidon2.rs
@@ -59,7 +59,6 @@ impl<RA, const SBOX_REGISTERS: usize> Chip<RA, GpuBackend> for Poseidon2ChipGPU<
     fn generate_proving_ctx(&self, _: RA) -> AirProvingContext<GpuBackend> {
         let mut num_records = self.idx.to_host().unwrap()[0] as usize;
         if num_records == 0 {
-            self.idx.fill_zero().unwrap();
             return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
         }
         let counts = DeviceBuffer::<u32>::with_capacity(num_records);

--- a/crates/vm/src/system/cuda/poseidon2.rs
+++ b/crates/vm/src/system/cuda/poseidon2.rs
@@ -58,6 +58,10 @@ impl<const SBOX_REGISTERS: usize> Poseidon2ChipGPU<SBOX_REGISTERS> {
 impl<RA, const SBOX_REGISTERS: usize> Chip<RA, GpuBackend> for Poseidon2ChipGPU<SBOX_REGISTERS> {
     fn generate_proving_ctx(&self, _: RA) -> AirProvingContext<GpuBackend> {
         let mut num_records = self.idx.to_host().unwrap()[0] as usize;
+        if num_records == 0 {
+            self.idx.fill_zero().unwrap();
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
         let counts = DeviceBuffer::<u32>::with_capacity(num_records);
         unsafe {
             let d_num_records = [num_records].to_device().unwrap();

--- a/extensions/deferral/circuit/cuda/include/def_poseidon2_buffer.cuh
+++ b/extensions/deferral/circuit/cuda/include/def_poseidon2_buffer.cuh
@@ -16,6 +16,8 @@ struct DeferralPoseidon2Count {
     uint32_t capacity_mult;
 };
 
+/// Deferral Poseidon2 record buffer. `capacity` is the number of FpArray<16>
+/// records, NOT the number of Fp elements.
 struct DeferralPoseidon2Buffer {
     FpArray<16> *records;
     DeferralPoseidon2Count *counts;

--- a/extensions/deferral/circuit/cuda/src/call.cu
+++ b/extensions/deferral/circuit/cuda/src/call.cu
@@ -388,6 +388,10 @@ extern "C" int _deferral_call_tracegen(
     auto [grid, block] = kernel_launch_params(height);
     assert(width == sizeof(DeferralCallCols<uint8_t>));
 
+    // poseidon2_capacity arrives from Rust in units of Fp elements; convert to record count.
+    assert(poseidon2_capacity % 16 == 0 && "poseidon2_capacity must be a multiple of 16");
+    size_t poseidon2_record_capacity = poseidon2_capacity / 16;
+
     deferral_call_tracegen<<<grid, block>>>(
         d_trace,
         height,
@@ -403,7 +407,7 @@ extern "C" int _deferral_call_tracegen(
         reinterpret_cast<FpArray<16> *>(d_poseidon2_records),
         d_poseidon2_counts,
         d_poseidon2_idx,
-        poseidon2_capacity,
+        poseidon2_record_capacity,
         address_bits
     );
     return CHECK_KERNEL();

--- a/extensions/deferral/circuit/cuda/src/output.cu
+++ b/extensions/deferral/circuit/cuda/src/output.cu
@@ -328,6 +328,10 @@ extern "C" int _deferral_output_tracegen(
     auto [grid, block] = kernel_launch_params(height);
     assert(width == sizeof(DeferralOutputCols<uint8_t>));
 
+    // poseidon2_capacity arrives from Rust in units of Fp elements; convert to record count.
+    assert(poseidon2_capacity % 16 == 0 && "poseidon2_capacity must be a multiple of 16");
+    size_t poseidon2_record_capacity = poseidon2_capacity / 16;
+
     deferral_output_tracegen<<<grid, block>>>(
         d_trace,
         height,
@@ -346,7 +350,7 @@ extern "C" int _deferral_output_tracegen(
         reinterpret_cast<FpArray<16> *>(d_poseidon2_records),
         d_poseidon2_counts,
         d_poseidon2_idx,
-        poseidon2_capacity
+        poseidon2_record_capacity
     );
     return CHECK_KERNEL();
 }

--- a/extensions/deferral/circuit/cuda/src/poseidon2.cu
+++ b/extensions/deferral/circuit/cuda/src/poseidon2.cu
@@ -164,12 +164,15 @@ extern "C" int _deferral_poseidon2_deduplicate_records_get_temp_bytes(
 extern "C" int _deferral_poseidon2_deduplicate_records(
     Fp *d_records,
     DeferralPoseidon2Count *d_counts,
+    Fp *d_records_out,
+    DeferralPoseidon2Count *d_counts_out,
     size_t num_records,
     size_t *d_num_records,
     void *d_temp_storage,
     size_t temp_storage_bytes
 ) {
     FpArray<16> *d_records_fp16 = reinterpret_cast<FpArray<16> *>(d_records);
+    FpArray<16> *d_records_out_fp16 = reinterpret_cast<FpArray<16> *>(d_records_out);
 
     cub::DeviceMergeSort::SortPairs(
         d_temp_storage,
@@ -181,13 +184,14 @@ extern "C" int _deferral_poseidon2_deduplicate_records(
         cudaStreamPerThread
     );
 
+    // Output buffers must not alias the inputs (CUB requirement).
     cub::DeviceReduce::ReduceByKey(
         d_temp_storage,
         temp_storage_bytes,
         d_records_fp16,
-        d_records_fp16,
+        d_records_out_fp16,
         d_counts,
-        d_counts,
+        d_counts_out,
         d_num_records,
         DeferralPoseidon2CountCompose{},
         num_records,

--- a/extensions/deferral/circuit/src/call/cuda.rs
+++ b/extensions/deferral/circuit/src/call/cuda.rs
@@ -62,6 +62,7 @@ impl Chip<DenseRecordArena, GpuBackend> for DeferralCallChipGpu {
                 &self.poseidon2.records,
                 &self.poseidon2.counts,
                 &self.poseidon2.idx,
+                // Length in F elements; the CUDA side converts to record count.
                 self.poseidon2.records.len(),
                 self.address_bits,
             )

--- a/extensions/deferral/circuit/src/cuda_abi.rs
+++ b/extensions/deferral/circuit/src/cuda_abi.rs
@@ -143,7 +143,7 @@ pub mod poseidon2 {
             d_records_out.as_raw_ptr(),
             records_bytes,
         )
-        .map_err(&map_err)?;
+        .map_err(map_err)?;
         cuda_memcpy::<true, true>(
             d_counts.as_mut_raw_ptr(),
             d_counts_out.as_raw_ptr(),

--- a/extensions/deferral/circuit/src/cuda_abi.rs
+++ b/extensions/deferral/circuit/src/cuda_abi.rs
@@ -31,6 +31,9 @@ pub mod count {
 }
 
 pub mod poseidon2 {
+    use openvm_cuda_common::copy::cuda_memcpy;
+    use openvm_poseidon2_air::POSEIDON2_WIDTH;
+
     use super::*;
 
     #[repr(C)]
@@ -62,6 +65,8 @@ pub mod poseidon2 {
         fn _deferral_poseidon2_deduplicate_records(
             d_records: *mut F,
             d_counts: *mut DeferralPoseidon2Count,
+            d_records_out: *mut F,
+            d_counts_out: *mut DeferralPoseidon2Count,
             num_records: usize,
             d_num_records: *mut usize,
             d_temp_storage: *mut std::ffi::c_void,
@@ -113,14 +118,36 @@ pub mod poseidon2 {
         d_temp_storage: &DeviceBuffer<u8>,
         temp_storage_bytes: usize,
     ) -> Result<(), CudaError> {
+        // CUB ReduceByKey requires non-overlapping input and output ranges.
+        // Allocate separate output buffers, then copy results back.
+        let d_records_out = DeviceBuffer::<F>::with_capacity(num_records * POSEIDON2_WIDTH);
+        let d_counts_out =
+            DeviceBuffer::<DeferralPoseidon2Count>::with_capacity(num_records);
         CudaError::from_result(_deferral_poseidon2_deduplicate_records(
             d_records.as_mut_ptr(),
             d_counts.as_mut_ptr(),
+            d_records_out.as_mut_ptr(),
+            d_counts_out.as_mut_ptr(),
             num_records,
             d_num_records.as_mut_ptr(),
             d_temp_storage.as_mut_raw_ptr(),
             temp_storage_bytes,
-        ))
+        ))?;
+        let records_bytes = num_records * POSEIDON2_WIDTH * std::mem::size_of::<F>();
+        let counts_bytes = num_records * std::mem::size_of::<DeferralPoseidon2Count>();
+        cuda_memcpy::<true, true>(
+            d_records.as_mut_raw_ptr(),
+            d_records_out.as_raw_ptr(),
+            records_bytes,
+        )
+        .expect("Failed to copy deduplicated records");
+        cuda_memcpy::<true, true>(
+            d_counts.as_mut_raw_ptr(),
+            d_counts_out.as_raw_ptr(),
+            counts_bytes,
+        )
+        .expect("Failed to copy deduplicated counts");
+        Ok(())
     }
 }
 

--- a/extensions/deferral/circuit/src/cuda_abi.rs
+++ b/extensions/deferral/circuit/src/cuda_abi.rs
@@ -31,7 +31,7 @@ pub mod count {
 }
 
 pub mod poseidon2 {
-    use openvm_cuda_common::copy::cuda_memcpy;
+    use openvm_cuda_common::{copy::cuda_memcpy, error::MemCopyError};
     use openvm_poseidon2_air::POSEIDON2_WIDTH;
 
     use super::*;
@@ -121,8 +121,7 @@ pub mod poseidon2 {
         // CUB ReduceByKey requires non-overlapping input and output ranges.
         // Allocate separate output buffers, then copy results back.
         let d_records_out = DeviceBuffer::<F>::with_capacity(num_records * POSEIDON2_WIDTH);
-        let d_counts_out =
-            DeviceBuffer::<DeferralPoseidon2Count>::with_capacity(num_records);
+        let d_counts_out = DeviceBuffer::<DeferralPoseidon2Count>::with_capacity(num_records);
         CudaError::from_result(_deferral_poseidon2_deduplicate_records(
             d_records.as_mut_ptr(),
             d_counts.as_mut_ptr(),
@@ -135,18 +134,22 @@ pub mod poseidon2 {
         ))?;
         let records_bytes = num_records * POSEIDON2_WIDTH * std::mem::size_of::<F>();
         let counts_bytes = num_records * std::mem::size_of::<DeferralPoseidon2Count>();
+        let map_err = |e: MemCopyError| match e {
+            MemCopyError::Cuda(e) => e,
+            other => panic!("{other}"),
+        };
         cuda_memcpy::<true, true>(
             d_records.as_mut_raw_ptr(),
             d_records_out.as_raw_ptr(),
             records_bytes,
         )
-        .expect("Failed to copy deduplicated records");
+        .map_err(&map_err)?;
         cuda_memcpy::<true, true>(
             d_counts.as_mut_raw_ptr(),
             d_counts_out.as_raw_ptr(),
             counts_bytes,
         )
-        .expect("Failed to copy deduplicated counts");
+        .map_err(map_err)?;
         Ok(())
     }
 }

--- a/extensions/deferral/circuit/src/output/cuda.rs
+++ b/extensions/deferral/circuit/src/output/cuda.rs
@@ -137,6 +137,7 @@ impl Chip<DenseRecordArena, GpuBackend> for DeferralOutputChipGpu {
                 &self.poseidon2.records,
                 &self.poseidon2.counts,
                 &self.poseidon2.idx,
+                // Length in F elements; the CUDA side converts to record count.
                 self.poseidon2.records.len(),
             )
             .expect("Failed to generate deferral output trace");

--- a/extensions/deferral/circuit/src/poseidon2/cuda.rs
+++ b/extensions/deferral/circuit/src/poseidon2/cuda.rs
@@ -30,6 +30,9 @@ pub struct DeferralPoseidon2ChipGpu {
 }
 
 impl DeferralPoseidon2ChipGpu {
+    /// Creates a new deferral Poseidon2 chip with a device buffer of `max_buffer_size` field
+    /// elements. Each Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, so the
+    /// buffer can hold `max_buffer_size / POSEIDON2_WIDTH` records.
     pub fn new(max_buffer_size: usize, sbox_registers: usize) -> Self {
         let idx = Arc::new(DeviceBuffer::<u32>::with_capacity(1));
         idx.fill_zero().unwrap();


### PR DESCRIPTION
## Summary

- **CUB ReduceByKey aliasing UB**: Three Poseidon2 dedup call sites passed the same buffer as both input and output to `cub::DeviceReduce::ReduceByKey`, which is [explicitly forbidden by the CUB API](https://nvidia.github.io/cccl/cub/api/structcub_1_1DeviceReduce.html). Fixed by adding separate output pointer parameters to the CUDA functions and allocating temporary output buffers on the Rust side with `cuda_memcpy` D2D copy-back.
- **Buffer capacity units mismatch**: The shared Poseidon2 buffer is allocated as `DeviceBuffer<F>` (len in field elements), but the CUDA side indexes it as `FpArray<16>*` (records of 16 fields each). The overflow guard was 16x too permissive. Fixed by converting `len / 16` at each CUDA extern "C" entry point with an assert that len is a multiple of 16. Added documentation on both sides clarifying the units.
- **Zero-record crash**: `Poseidon2ChipGPU::generate_proving_ctx` would panic on `DeviceBuffer::with_capacity(0)` when no records were written. Fixed with an early return matching the deferral GPU chip and CPU implementation.

## Test plan

- [ ] Run CUDA Poseidon2 dedup tests to verify correct sort+reduce behavior with separate output buffers
- [ ] Run boundary and merkle tree GPU tests to verify the capacity fix doesn't cause false overflow asserts
- [ ] Verify zero-record path returns dummy trace without panicking
- [ ] Run full GPU proving pipeline end-to-end