### PR TITLE
fix: resolve deferral extension CUDA audit fixes

### DIFF
--- a/extensions/deferral/circuit/cuda/src/call.cu
+++ b/extensions/deferral/circuit/cuda/src/call.cu
@@ -347,10 +347,7 @@ __global__ void deferral_call_tracegen(
     );
     BitwiseOperationLookup bitwise_buffer(bitwise_ptr, bitwise_num_bits);
     DeferralPoseidon2Buffer poseidon2_buffer(
-        poseidon2_records,
-        poseidon2_counts,
-        poseidon2_idx,
-        poseidon2_capacity
+        poseidon2_records, poseidon2_counts, poseidon2_idx, poseidon2_capacity
     );
 
     deferral_call_adapter_tracegen(row, record.adapter, bitwise_buffer, mem_helper, address_bits);
@@ -385,7 +382,7 @@ extern "C" int _deferral_call_tracegen(
     size_t poseidon2_capacity,
     size_t address_bits
 ) {
-    auto [grid, block] = kernel_launch_params(height);
+    auto [grid, block] = kernel_launch_params(height, 256);
     assert(width == sizeof(DeferralCallCols<uint8_t>));
 
     // poseidon2_capacity arrives from Rust in units of Fp elements; convert to record count.

--- a/extensions/deferral/circuit/cuda/src/output.cu
+++ b/extensions/deferral/circuit/cuda/src/output.cu
@@ -325,7 +325,7 @@ extern "C" int _deferral_output_tracegen(
     uint32_t *d_poseidon2_idx,
     size_t poseidon2_capacity
 ) {
-    auto [grid, block] = kernel_launch_params(height);
+    auto [grid, block] = kernel_launch_params(height, 256);
     assert(width == sizeof(DeferralOutputCols<uint8_t>));
 
     // poseidon2_capacity arrives from Rust in units of Fp elements; convert to record count.

--- a/extensions/deferral/circuit/src/call/tests.rs
+++ b/extensions/deferral/circuit/src/call/tests.rs
@@ -28,10 +28,7 @@ use rand::{rngs::StdRng, Rng};
 #[cfg(feature = "cuda")]
 use {
     super::{DeferralCallAdapterRecord, DeferralCallChipGpu, DeferralCallCoreRecord},
-    crate::{
-        count::DeferralCircuitCountChipGpu,
-        poseidon2::{poseidon2_buffer_capacity, DeferralPoseidon2ChipGpu},
-    },
+    crate::{count::DeferralCircuitCountChipGpu, poseidon2::DeferralPoseidon2ChipGpu},
     openvm_circuit::arch::{
         testing::{default_bitwise_lookup_bus, GpuChipTestBuilder, GpuTestChipHarness},
         DenseRecordArena, EmptyAdapterCoreLayout,
@@ -349,8 +346,7 @@ fn create_cuda_harness(
 
     let count = Arc::new(DeviceBuffer::<u32>::with_capacity(num_deferrals));
     count.fill_zero().unwrap();
-    let poseidon2_chip_gpu =
-        DeferralPoseidon2ChipGpu::new(poseidon2_buffer_capacity(MAX_INS_CAPACITY.max(1)), 1);
+    let poseidon2_chip_gpu = DeferralPoseidon2ChipGpu::new(MAX_INS_CAPACITY.max(1), 1);
     let gpu_chip = DeferralCallChipGpu::new(
         tester.range_checker(),
         tester.bitwise_op_lookup(),

--- a/extensions/deferral/circuit/src/extension/cuda.rs
+++ b/extensions/deferral/circuit/src/extension/cuda.rs
@@ -23,7 +23,7 @@ use crate::{
     call::{DeferralCallAir, DeferralCallChipGpu},
     count::{DeferralCircuitCountAir, DeferralCircuitCountChipGpu},
     output::{DeferralOutputAir, DeferralOutputChipGpu},
-    poseidon2::{poseidon2_buffer_capacity, DeferralPoseidon2Air, DeferralPoseidon2ChipGpu},
+    poseidon2::{DeferralPoseidon2Air, DeferralPoseidon2ChipGpu},
     DeferralExtension, Rv32DeferralConfig,
 };
 
@@ -53,13 +53,6 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, DeferralExt
             count.fill_zero().unwrap();
         }
 
-        let max_trace_height = inventory
-            .config()
-            .segmentation_config
-            .limits
-            .max_trace_height as usize;
-        let poseidon2_capacity = poseidon2_buffer_capacity(max_trace_height.max(1));
-
         inventory.next_air::<DeferralCircuitCountAir>()?;
         let count_chip = Arc::new(DeferralCircuitCountChipGpu::new(
             count.clone(),
@@ -68,7 +61,12 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, DeferralExt
         inventory.add_periphery_chip(count_chip);
 
         inventory.next_air::<DeferralPoseidon2Air<CudaF>>()?;
-        let poseidon2_chip = Arc::new(DeferralPoseidon2ChipGpu::new(poseidon2_capacity, 1));
+        let max_trace_height = inventory
+            .config()
+            .segmentation_config
+            .limits
+            .max_trace_height as usize;
+        let poseidon2_chip = Arc::new(DeferralPoseidon2ChipGpu::new(max_trace_height.max(1), 1));
         let poseidon2_shared = poseidon2_chip.shared_buffer();
         inventory.add_periphery_chip(poseidon2_chip);
 

--- a/extensions/deferral/circuit/src/output/tests.rs
+++ b/extensions/deferral/circuit/src/output/tests.rs
@@ -25,10 +25,7 @@ use rand::{rngs::StdRng, Rng, RngCore};
 #[cfg(feature = "cuda")]
 use {
     super::{DeferralOutputChipGpu, DeferralOutputRecordMut},
-    crate::{
-        count::DeferralCircuitCountChipGpu,
-        poseidon2::{poseidon2_buffer_capacity, DeferralPoseidon2ChipGpu},
-    },
+    crate::{count::DeferralCircuitCountChipGpu, poseidon2::DeferralPoseidon2ChipGpu},
     openvm_circuit::arch::{
         testing::{default_bitwise_lookup_bus, GpuChipTestBuilder, GpuTestChipHarness},
         DenseRecordArena,
@@ -279,8 +276,7 @@ fn create_cuda_harness(tester: &GpuChipTestBuilder, num_deferrals: usize) -> Cud
 
     let count = Arc::new(DeviceBuffer::<u32>::with_capacity(num_deferrals));
     count.fill_zero().unwrap();
-    let poseidon2_chip_gpu =
-        DeferralPoseidon2ChipGpu::new(poseidon2_buffer_capacity(MAX_INS_CAPACITY.max(1)), 1);
+    let poseidon2_chip_gpu = DeferralPoseidon2ChipGpu::new(MAX_INS_CAPACITY.max(1), 1);
     let gpu_chip = DeferralOutputChipGpu::new(
         tester.range_checker(),
         tester.bitwise_op_lookup(),

--- a/extensions/deferral/circuit/src/poseidon2/cuda.rs
+++ b/extensions/deferral/circuit/src/poseidon2/cuda.rs
@@ -30,9 +30,9 @@ pub struct DeferralPoseidon2ChipGpu {
 }
 
 impl DeferralPoseidon2ChipGpu {
-    /// Creates a new deferral Poseidon2 chip with a device buffer of `max_buffer_size` field
-    /// elements. Each Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, so the
-    /// buffer can hold `max_buffer_size / POSEIDON2_WIDTH` records.
+    /// Creates a new deferral Poseidon2 chip configured for `max_trace_height` records. Each
+    /// Each Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, and a buffer of
+    /// that size is allocated.
     pub fn new(max_trace_height: usize, sbox_registers: usize) -> Self {
         let max_num_records = max_trace_height.next_power_of_two();
         let max_record_buf_size = max_num_records * (DIGEST_SIZE * 2);

--- a/extensions/deferral/circuit/src/poseidon2/cuda.rs
+++ b/extensions/deferral/circuit/src/poseidon2/cuda.rs
@@ -31,8 +31,8 @@ pub struct DeferralPoseidon2ChipGpu {
 
 impl DeferralPoseidon2ChipGpu {
     /// Creates a new deferral Poseidon2 chip configured for `max_trace_height` records. Each
-    /// Each Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, and a buffer of
-    /// that size is allocated.
+    /// Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, and a buffer of that
+    /// size is allocated.
     pub fn new(max_trace_height: usize, sbox_registers: usize) -> Self {
         let max_num_records = max_trace_height.next_power_of_two();
         let max_record_buf_size = max_num_records * (DIGEST_SIZE * 2);

--- a/extensions/deferral/circuit/src/poseidon2/cuda.rs
+++ b/extensions/deferral/circuit/src/poseidon2/cuda.rs
@@ -33,14 +33,17 @@ impl DeferralPoseidon2ChipGpu {
     /// Creates a new deferral Poseidon2 chip with a device buffer of `max_buffer_size` field
     /// elements. Each Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, so the
     /// buffer can hold `max_buffer_size / POSEIDON2_WIDTH` records.
-    pub fn new(max_buffer_size: usize, sbox_registers: usize) -> Self {
+    pub fn new(max_trace_height: usize, sbox_registers: usize) -> Self {
+        let max_num_records = max_trace_height.next_power_of_two();
+        let max_record_buf_size = max_num_records * (DIGEST_SIZE * 2);
+
         let idx = Arc::new(DeviceBuffer::<u32>::with_capacity(1));
         idx.fill_zero().unwrap();
 
         Self {
-            records: Arc::new(DeviceBuffer::<F>::with_capacity(max_buffer_size)),
+            records: Arc::new(DeviceBuffer::<F>::with_capacity(max_record_buf_size)),
             counts: Arc::new(DeviceBuffer::<DeferralPoseidon2Count>::with_capacity(
-                max_buffer_size,
+                max_num_records,
             )),
             idx,
             sbox_registers,
@@ -120,8 +123,4 @@ impl Chip<DenseRecordArena, GpuBackend> for DeferralPoseidon2ChipGpu {
 
         AirProvingContext::simple_no_pis(trace)
     }
-}
-
-pub fn poseidon2_buffer_capacity(max_trace_height: usize) -> usize {
-    max_trace_height.next_power_of_two() * 2 * (DIGEST_SIZE * 2)
 }


### PR DESCRIPTION
Resolves INT-7151, INT-7154.

## INT-7151: Cap deferral call/output CUDA block sizes

Sets max threads per block to 256 in both the `call.cu` and `output.cu` tracegen kernels.

## INT-7154: Allocate deferral Poseidon2 counts by record capacity

`DeferralPoseidon2ChipGpu` constructor now passes in `max_trace_height` instead of `max_buffer_size`, and uses that to compute the appropriate size for the `records` and `count` buffer. Note that the maximum number of records has been lowered to `max_trace_height` from `2 * max_trace_height`, as we should always estimate that one record corresponds to one row in the poseidon2 trace.
