### PR TITLE
fix: resolve proof shape module CUDA audit items

### DIFF
--- a/crates/recursion/cuda/include/switch_macro.h
+++ b/crates/recursion/cuda/include/switch_macro.h
@@ -25,6 +25,13 @@
 
 #define GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, NAME, ...) NAME
 
+// Dispatches a runtime `value` into a switch statement where each case binds the value as a
+// compile-time `constexpr`, allowing it to be used as a template parameter. The caller supplies
+// the set of allowed case values via __VA_ARGS__.
+//
+// The supported number of cases (currently up to 8) is sized for existing use sites, not for
+// generality. This is non-security-critical CUDA code — we can add more APPLY_CASES_N macros
+// if new use cases require additional cases.
 #define SWITCH_BLOCK(value, name, body, ...)                                                                                                            \
     switch (value) {                                                                                                                                    \
         GET_MACRO(__VA_ARGS__, APPLY_CASES_8, APPLY_CASES_7, APPLY_CASES_6, APPLY_CASES_5, APPLY_CASES_4, APPLY_CASES_3, APPLY_CASES_2, APPLY_CASES_1)( \

--- a/crates/recursion/cuda/src/proof_shape/air.cu
+++ b/crates/recursion/cuda/src/proof_shape/air.cu
@@ -89,7 +89,6 @@ __device__ __forceinline__ void fill_present_row(
     Digest *cached_commits,
     size_t l_skip,
     size_t cached_commits_idx,
-    size_t min_cached_idx,
     RangeChecker &range_checker,
     PowerChecker<32> &pow_checker
 ) {
@@ -180,9 +179,7 @@ __device__ __forceinline__ void fill_present_row(
         if (i < air_data.num_cached) {
             row.write_array(commit_idx, DIGEST_SIZE, cached_commits[trace_data.cached_idx + i]);
         } else {
-            if (i + 1 != MAX_CACHED || min_cached_idx != trace_height.air_idx) {
-                row.fill_zero(commit_idx, DIGEST_SIZE);
-            }
+            row.fill_zero(commit_idx, DIGEST_SIZE);
         }
     }
 }
@@ -397,14 +394,6 @@ __global__ void proof_shape_tracegen(
 
             encoder.write_flag_pt(row.slice_from(encoder_flags_idx), trace_height.air_idx);
 
-            if (inputs.min_cached_idx == trace_height.air_idx) {
-                row.write_array(
-                    cached_commits_idx + DIGEST_SIZE * (MAX_CACHED - 1),
-                    DIGEST_SIZE,
-                    proof_data.main_commit
-                );
-            }
-
             if (record_idx + 1 < inputs.num_airs) {
                 uint8_t current_log_height = trace_height.log_height;
                 uint8_t next_log_height =
@@ -428,7 +417,6 @@ __global__ void proof_shape_tracegen(
                     cached_commits[proof_idx],
                     inputs.l_skip,
                     cached_commits_idx,
-                    inputs.min_cached_idx,
                     range_checker,
                     pow_checker
                 );
@@ -446,6 +434,14 @@ __global__ void proof_shape_tracegen(
                     proof_data.final_total_interactions,
                     cached_commits_idx,
                     range_checker
+                );
+            }
+
+            if (inputs.min_cached_idx == trace_height.air_idx) {
+                row.write_array(
+                    cached_commits_idx + DIGEST_SIZE * (MAX_CACHED - 1),
+                    DIGEST_SIZE,
+                    proof_data.main_commit
                 );
             }
         }


### PR DESCRIPTION
Resolves INT-7138, INT-7158, INT-7164.

### INT-7138: Preserve `main_commit` on non-present `min_cached_idx` rows

Moves the `main_commit` set to after `fill_present_row` and `fill_non_present_row` so it won't be overwritten in the latter.

### INT-7158: Reject unsupported `max_cached` values in proof-shape CUDA

### INT-7164: Validate transcript CUDA proof count range

No fix required, but added a comment to explain `SWITCH_BLOCK` usage so this doesn't get flagged as often. We may want to consider removing it later as a maintenance item if it doesn't hurt performance.