### PR TITLE
fix(v2-beta): add hint buffer check that num_words > 0

### DIFF
--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -38,6 +38,8 @@ pub enum ExecutionError {
     DisabledOperation { pc: u32, opcode: VmOpcode },
     #[error("at pc = {pc}")]
     HintOutOfBounds { pc: u32 },
+    #[error("at pc {pc}, hint buffer num_words is zero")]
+    HintBufferZeroWords { pc: u32 },
     #[error("at pc {pc}, hint buffer num_words {num_words} exceeds MAX_HINT_BUFFER_WORDS {max_hint_buffer_words}")]
     HintBufferTooLarge {
         pc: u32,

--- a/extensions/rv32im/circuit/src/hintstore/execution.rs
+++ b/extensions/rv32im/circuit/src/hintstore/execution.rs
@@ -171,9 +171,10 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait, const IS_HIN
         let num_words_limbs = exec_state.vm_read::<u8, 4>(RV32_REGISTER_AS, pre_compute.a as u32);
         u32::from_le_bytes(num_words_limbs)
     };
-    debug_assert_ne!(num_words, 0);
-
-    // Bounds check: num_words must not exceed MAX_HINT_BUFFER_WORDS
+    // Bounds check: num_words must be in [1, MAX_HINT_BUFFER_WORDS]
+    if num_words == 0 {
+        return Err(ExecutionError::HintBufferZeroWords { pc });
+    }
     if num_words > MAX_HINT_BUFFER_WORDS as u32 {
         return Err(ExecutionError::HintBufferTooLarge {
             pc,

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -417,7 +417,10 @@ where
             read_rv32_register(state.memory.data(), a)
         };
 
-        // Bounds check: num_words must not exceed MAX_HINT_BUFFER_WORDS
+        // Bounds check: num_words must be in [1, MAX_HINT_BUFFER_WORDS]
+        if num_words == 0 {
+            return Err(ExecutionError::HintBufferZeroWords { pc: *state.pc });
+        }
         if num_words > MAX_HINT_BUFFER_WORDS as u32 {
             return Err(ExecutionError::HintBufferTooLarge {
                 pc: *state.pc,
@@ -442,7 +445,6 @@ where
         ));
 
         debug_assert!(record.inner.mem_ptr <= (1 << self.pointer_max_bits));
-        debug_assert_ne!(num_words, 0);
         debug_assert!(num_words <= (1 << self.pointer_max_bits));
 
         record.inner.num_words = num_words;


### PR DESCRIPTION
## Summary

- Reject `HINT_BUFFER` instructions with `num_words == 0` at execution time, before record allocation or trace generation
- Previously this was only guarded by `debug_assert_ne!`, which is stripped in release builds
- Adds new `ExecutionError::HintBufferZeroWords` variant for a clear error message

## Motivation

In release builds, a `HINT_BUFFER` with `num_words == 0` passes through to CUDA tracegen where it produces an empty offsets array, a zero-height `DeviceMatrix` (instead of a proper `dummy()`), and can cause undefined behavior in the GPU kernel (zero-stride `RowSlice`, invalid launch params).

Since `num_words` is read from a register at runtime, this cannot be caught statically during transpilation or program construction. The fix promotes the existing debug assertion to a proper runtime error in both the preflight and interpreter executors, matching the pattern used by the existing `HintBufferTooLarge` check.

## Changes

- `crates/vm/src/arch/execution.rs`: Add `HintBufferZeroWords { pc }` to `ExecutionError`
- `extensions/rv32im/circuit/src/hintstore/mod.rs`: Add `num_words == 0` check in preflight executor, remove redundant `debug_assert_ne!`
- `extensions/rv32im/circuit/src/hintstore/execution.rs`: Replace `debug_assert_ne!` with runtime error in interpreter executor

resolves int-7155