### PR TITLE
chore: match cpu/gpu program air tracegen for empty program

### DIFF
--- a/crates/vm/src/system/cuda/program.rs
+++ b/crates/vm/src/system/cuda/program.rs
@@ -1,8 +1,6 @@
 use std::{mem::size_of, sync::Arc};
 
-use openvm_circuit::{
-    primitives::Chip, system::program::ProgramExecutionCols,
-};
+use openvm_circuit::{primitives::Chip, system::program::ProgramExecutionCols};
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend, GpuDevice};
 use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer};
 use openvm_instructions::{

--- a/crates/vm/src/system/cuda/program.rs
+++ b/crates/vm/src/system/cuda/program.rs
@@ -1,7 +1,7 @@
 use std::{mem::size_of, sync::Arc};
 
 use openvm_circuit::{
-    primitives::Chip, system::program::ProgramExecutionCols, utils::next_power_of_two_or_zero,
+    primitives::Chip, system::program::ProgramExecutionCols,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend, GpuDevice};
 use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer};
@@ -45,7 +45,7 @@ impl ProgramChipGPU {
             .collect::<Vec<_>>();
 
         let num_records = instructions.len();
-        let height = next_power_of_two_or_zero(num_records);
+        let height = num_records.next_power_of_two();
         let records = instructions
             .into_iter()
             .flatten()


### PR DESCRIPTION
## Summary

- Fix GPU cached program trace generation to match CPU behavior for empty or small programs
- Replace `next_power_of_two_or_zero(num_records)` with `num_records.next_power_of_two()` so the minimum trace height is 1 instead of 0

## Motivation

The CPU path (`generate_cached_trace` in `trace.rs`) pads instructions with `while !len.is_power_of_two()`, which rounds 0 up to 1 and emits a TERMINATE padding row. The GPU path used `next_power_of_two_or_zero`, which returns 0 for empty input — producing a zero-height trace with no TERMINATE row. This is a CPU/GPU semantic mismatch.

`next_power_of_two()` returns 1 for input 0, matching the CPU behavior. The CUDA kernel already fills padding rows with TERMINATE + EXIT_CODE_FAIL, so both height and content now agree.

## Changes

- `crates/vm/src/system/cuda/program.rs`: Use `num_records.next_power_of_two()` instead of `next_power_of_two_or_zero(num_records)`, remove unused import

Closes INT-7167