### PR TITLE
chore: add more context to CLI error messages

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -452,8 +452,13 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
         if let Some(output_dir) = &build_args.output_dir {
             create_dir_all(output_dir)
                 .with_context(|| format!("failed to create directory {}", output_dir.display()))?;
-            copy(&file_path, output_dir.join(&file_name))
-                .with_context(|| format!("failed to copy {} to {}", file_name.display(), output_dir.display()))?;
+            copy(&file_path, output_dir.join(&file_name)).with_context(|| {
+                format!(
+                    "failed to copy {} to {}",
+                    file_name.display(),
+                    output_dir.display()
+                )
+            })?;
         }
     }
 

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use clap::Parser;
-use eyre::Result;
+use eyre::{Context, Result};
 use itertools::izip;
 use openvm_build::{
     build_generic, get_package, get_workspace_packages, get_workspace_root, GuestOptions,
@@ -433,9 +433,12 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
     println!("[openvm] Transpiling the package...");
     for (elf_path, target) in izip!(&elf_paths, &elf_targets) {
         let transpiler = app_config.app_vm_config.transpiler();
-        let data = read(elf_path.clone())?;
-        let elf = Elf::decode(&data, MEM_SIZE as u32)?;
-        let exe = VmExe::from_elf(elf, transpiler)?;
+        let data = read(&elf_path)
+            .with_context(|| format!("failed to read ELF at {}", elf_path.display()))?;
+        let elf = Elf::decode(&data, MEM_SIZE as u32)
+            .with_context(|| format!("failed to decode ELF for target '{}'", target.name))?;
+        let exe = VmExe::from_elf(elf, transpiler)
+            .with_context(|| format!("failed to transpile target '{}'", target.name))?;
 
         let target_name = if target.is_example() {
             PathBuf::from("examples").join(&target.name)
@@ -447,8 +450,10 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
 
         write_object_to_file(&file_path, exe)?;
         if let Some(output_dir) = &build_args.output_dir {
-            create_dir_all(output_dir)?;
-            copy(file_path, output_dir.join(file_name))?;
+            create_dir_all(output_dir)
+                .with_context(|| format!("failed to create directory {}", output_dir.display()))?;
+            copy(&file_path, output_dir.join(&file_name))
+                .with_context(|| format!("failed to copy {} to {}", file_name.display(), output_dir.display()))?;
         }
     }
 

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -433,7 +433,7 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
     println!("[openvm] Transpiling the package...");
     for (elf_path, target) in izip!(&elf_paths, &elf_targets) {
         let transpiler = app_config.app_vm_config.transpiler();
-        let data = read(&elf_path)
+        let data = read(elf_path)
             .with_context(|| format!("failed to read ELF at {}", elf_path.display()))?;
         let elf = Elf::decode(&data, MEM_SIZE as u32)
             .with_context(|| format!("failed to decode ELF for target '{}'", target.name))?;

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use clap::Parser;
-use eyre::Result;
+use eyre::{Context, Result};
 use openvm_circuit::arch::OPENVM_DEFAULT_INIT_FILE_NAME;
 use openvm_continuations::CommitBytes;
 use openvm_sdk::{
@@ -151,11 +151,14 @@ impl CommitCmd {
         write_to_file_json(&baseline_path, &baseline_json)?;
 
         if let Some(output_dir) = &self.output_dir {
-            create_dir_all(output_dir)?;
+            create_dir_all(output_dir)
+                .with_context(|| format!("failed to create directory {}", output_dir.display()))?;
             let commit_name = commit_path.file_name().unwrap();
-            copy(&commit_path, output_dir.join(commit_name))?;
+            copy(&commit_path, output_dir.join(commit_name))
+                .with_context(|| format!("failed to copy commit to {}", output_dir.display()))?;
             let baseline_name = baseline_path.file_name().unwrap();
-            copy(&baseline_path, output_dir.join(baseline_name))?;
+            copy(&baseline_path, output_dir.join(baseline_name))
+                .with_context(|| format!("failed to copy baseline to {}", output_dir.display()))?;
         }
 
         Ok(())

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use clap::Parser;
-use eyre::Result;
+use eyre::{Context, Result};
 use include_dir::{include_dir, Dir};
 use toml_edit::{DocumentMut, Item, Value};
 
@@ -141,8 +141,11 @@ impl InitCmd {
 
 fn add_openvm_dependency(path: &Path, features: &[&str]) -> Result<()> {
     let cargo_toml_path = path.join("Cargo.toml");
-    let cargo_toml_content = read_to_string(&cargo_toml_path)?;
-    let mut doc = cargo_toml_content.parse::<DocumentMut>()?;
+    let cargo_toml_content = read_to_string(&cargo_toml_path)
+        .with_context(|| format!("failed to read {}", cargo_toml_path.display()))?;
+    let mut doc = cargo_toml_content
+        .parse::<DocumentMut>()
+        .with_context(|| format!("failed to parse {}", cargo_toml_path.display()))?;
     let mut openvm_table = toml_edit::InlineTable::new();
     let mut openvm_features = toml_edit::Array::new();
     for feature in features {
@@ -159,7 +162,8 @@ fn add_openvm_dependency(path: &Path, features: &[&str]) -> Result<()> {
 
     openvm_table.insert("features", Value::Array(openvm_features));
     doc["dependencies"]["openvm"] = Item::Value(toml_edit::Value::InlineTable(openvm_table));
-    write(cargo_toml_path, doc.to_string())?;
+    write(&cargo_toml_path, doc.to_string())
+        .with_context(|| format!("failed to write {}", cargo_toml_path.display()))?;
     Ok(())
 }
 
@@ -167,6 +171,7 @@ fn write_template_file(file_name: &str, dest_dir: &Path) -> Result<()> {
     let file = TEMPLATES
         .get_file(file_name)
         .ok_or_else(|| eyre::eyre!("Template not found: {}", file_name))?;
-    write(dest_dir.join(file_name), file.contents())?;
+    let dest = dest_dir.join(file_name);
+    write(&dest, file.contents()).with_context(|| format!("failed to write {}", dest.display()))?;
     Ok(())
 }

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use clap::Parser;
-use eyre::Result;
+use eyre::{Context, Result};
 use openvm_sdk::{config::AggregationSystemParams, fs::write_object_to_file, Sdk};
 
 use crate::{
@@ -122,12 +122,15 @@ pub(crate) fn keygen(
 
     if let Some(output_dir) = output_dir {
         let output_dir = output_dir.as_ref();
-        create_dir_all(output_dir)?;
-        copy(&app_pk_path, output_dir.join(DEFAULT_APP_PK_NAME))?;
-        copy(&app_vk_path, output_dir.join(DEFAULT_APP_VK_NAME))?;
+        create_dir_all(output_dir)
+            .with_context(|| format!("failed to create directory {}", output_dir.display()))?;
+        copy(&app_pk_path, output_dir.join(DEFAULT_APP_PK_NAME))
+            .with_context(|| format!("failed to copy app pk to {}", output_dir.display()))?;
+        copy(&app_vk_path, output_dir.join(DEFAULT_APP_VK_NAME))
+            .with_context(|| format!("failed to copy app vk to {}", output_dir.display()))?;
         if generate_agg {
-            copy(&agg_pk_path, output_dir.join("agg.pk"))?;
-            copy(&agg_vk_path, output_dir.join("agg.vk"))?;
+            copy(&agg_pk_path, output_dir.join("agg.pk")).with_context(|| format!("failed to copy agg pk to {}", output_dir.display()))?;
+            copy(&agg_vk_path, output_dir.join("agg.vk")).with_context(|| format!("failed to copy agg vk to {}", output_dir.display()))?;
         }
     }
 

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -129,8 +129,10 @@ pub(crate) fn keygen(
         copy(&app_vk_path, output_dir.join(DEFAULT_APP_VK_NAME))
             .with_context(|| format!("failed to copy app vk to {}", output_dir.display()))?;
         if generate_agg {
-            copy(&agg_pk_path, output_dir.join("agg.pk")).with_context(|| format!("failed to copy agg pk to {}", output_dir.display()))?;
-            copy(&agg_vk_path, output_dir.join("agg.vk")).with_context(|| format!("failed to copy agg vk to {}", output_dir.display()))?;
+            copy(&agg_pk_path, output_dir.join("agg.pk"))
+                .with_context(|| format!("failed to copy agg pk to {}", output_dir.display()))?;
+            copy(&agg_vk_path, output_dir.join("agg.vk"))
+                .with_context(|| format!("failed to copy agg vk to {}", output_dir.display()))?;
         }
     }
 

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -6,7 +6,7 @@ use std::{
 use aws_config::{defaults, BehaviorVersion, Region};
 use aws_sdk_s3::Client;
 use clap::Parser;
-use eyre::{eyre, Result};
+use eyre::{eyre, Context, Result};
 use openvm_sdk::{
     config::AggregationSystemParams,
     fs::{
@@ -91,7 +91,8 @@ impl SetupCmd {
 
     async fn download_params(min_k: u32, max_k: u32) -> Result<()> {
         let default_params_dir = default_params_dir();
-        create_dir_all(&default_params_dir)?;
+        create_dir_all(&default_params_dir)
+            .with_context(|| format!("failed to create params directory {default_params_dir}"))?;
 
         let config = defaults(BehaviorVersion::latest())
             .region(Region::new("us-east-1"))
@@ -111,9 +112,15 @@ impl SetupCmd {
                     .bucket("axiom-crypto")
                     .key(&key)
                     .send()
-                    .await?;
-                let data = resp.body.collect().await?;
-                write(local_file_path, data.into_bytes())?;
+                    .await
+                    .with_context(|| format!("failed to download {file_name} from S3"))?;
+                let data = resp
+                    .body
+                    .collect()
+                    .await
+                    .with_context(|| format!("failed to download {file_name} body from S3"))?;
+                write(&local_file_path, data.into_bytes())
+                    .with_context(|| format!("failed to write {}", local_file_path.display()))?;
             }
         }
 

--- a/crates/cli/src/input.rs
+++ b/crates/cli/src/input.rs
@@ -1,6 +1,6 @@
 use std::{fs::read, path::PathBuf, str::FromStr};
 
-use eyre::Result;
+use eyre::{Context, Result};
 use openvm_sdk::{StdIn, F};
 use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 
@@ -84,8 +84,10 @@ pub fn read_to_stdin(input: &Option<Input>) -> Result<StdIn> {
         Some(Input::FilePath(path)) => {
             let mut stdin = StdIn::default();
             // read the json
-            let bytes = read(path)?;
-            let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+            let bytes = read(path)
+                .with_context(|| format!("failed to read input file {}", path.display()))?;
+            let json: serde_json::Value = serde_json::from_slice(&bytes)
+                .with_context(|| format!("failed to parse JSON from {}", path.display()))?;
             json["input"]
                 .as_array()
                 .ok_or_else(|| eyre::eyre!("Input must be an array under 'input' key"))?
@@ -97,7 +99,7 @@ pub fn read_to_stdin(input: &Option<Input>) -> Result<StdIn> {
                         .and_then(|s| match decode_hex_string(s) {
                             Err(msg) => Err(eyre::eyre!("Invalid hex string: {}", msg)),
                             Ok(bytes) => {
-                                read_bytes_into_stdin(&mut stdin, &bytes).expect("Fail: input validation accepted an input, but the deserialization rejected it");
+                                read_bytes_into_stdin(&mut stdin, &bytes)?;
                                 Ok(())
                             }
                         })

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use eyre::Result;
+use eyre::{Context, Result};
 use openvm_build::{get_in_scope_packages, get_workspace_packages};
 use openvm_sdk::config::AppConfig;
 use openvm_sdk_config::SdkVmConfig;
@@ -15,8 +15,11 @@ use crate::{
 };
 
 pub(crate) fn read_to_struct_toml<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {
-    let toml = read_to_string(path)?;
-    let ret = toml::from_str(&toml)?;
+    let path = path.as_ref();
+    let toml = read_to_string(path)
+        .with_context(|| format!("failed to read config file {}", path.display()))?;
+    let ret = toml::from_str(&toml)
+        .with_context(|| format!("failed to parse TOML from {}", path.display()))?;
     Ok(ret)
 }
 
@@ -37,7 +40,11 @@ pub fn find_manifest_dir(mut current_dir: PathBuf) -> Result<PathBuf> {
     while !current_dir.join("Cargo.toml").exists() {
         current_dir = current_dir
             .parent()
-            .expect("Could not find Cargo.toml in current directory or any parent directory")
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "could not find Cargo.toml in current directory or any parent directory"
+                )
+            })?
             .to_path_buf();
     }
     Ok(current_dir)

--- a/crates/sdk/src/fs.rs
+++ b/crates/sdk/src/fs.rs
@@ -31,12 +31,19 @@ pub fn read_evm_halo2_verifier_from_folder<P: AsRef<Path>>(folder: P) -> Result<
     let interface_path = folder
         .join("interfaces")
         .join(EVM_HALO2_VERIFIER_INTERFACE_NAME);
-    let halo2_verifier_code = read_to_string(halo2_verifier_code_path)?;
-    let openvm_verifier_code = read_to_string(openvm_verifier_code_path)?;
-    let interface = read_to_string(interface_path)?;
+    let halo2_verifier_code = read_to_string(&halo2_verifier_code_path)
+        .map_err(|e| read_error(&halo2_verifier_code_path, e.into()))?;
+    let openvm_verifier_code = read_to_string(&openvm_verifier_code_path)
+        .map_err(|e| read_error(&openvm_verifier_code_path, e.into()))?;
+    let interface =
+        read_to_string(&interface_path).map_err(|e| read_error(&interface_path, e.into()))?;
 
     let artifact_path = folder.join(EVM_VERIFIER_ARTIFACT_FILENAME);
-    let artifact: EvmVerifierByteCode = serde_json::from_reader(File::open(artifact_path)?)?;
+    let artifact: EvmVerifierByteCode = File::open(&artifact_path)
+        .map_err(|e| read_error(&artifact_path, e.into()))
+        .and_then(|file| {
+            serde_json::from_reader(file).map_err(|e| read_error(&artifact_path, e.into()))
+        })?;
 
     Ok(EvmHalo2Verifier {
         halo2_verifier_code,
@@ -140,7 +147,7 @@ pub fn write_to_file_json<T: Serialize, P: AsRef<Path>>(path: P, data: T) -> Res
 }
 
 pub fn read_from_file_bytes<T: From<Vec<u8>>, P: AsRef<Path>>(path: P) -> Result<T> {
-    let bytes = read(path)?;
+    let bytes = read(&path).map_err(|e| read_error(&path, e.into()))?;
     Ok(T::from(bytes))
 }
 
@@ -153,8 +160,8 @@ pub fn write_to_file_bytes<T: Into<Vec<u8>>, P: AsRef<Path>>(path: P, data: T) -
 }
 
 pub fn decode_from_file<T: Decode, P: AsRef<Path>>(path: P) -> Result<T> {
-    let reader = &mut File::open(path)?;
-    let ret = T::decode(reader)?;
+    let reader = &mut File::open(&path).map_err(|e| read_error(&path, e.into()))?;
+    let ret = T::decode(reader).map_err(|e| read_error(&path, e.into()))?;
     Ok(ret)
 }
 


### PR DESCRIPTION
Resolves INT-5604.

# PR Summary: Improve CLI and SDK error messages with contextual diagnostics

## Overview

This PR replaces bare `?` error propagation throughout the CLI and SDK filesystem layer with contextual error messages. Previously, failures during file I/O, parsing, and S3 downloads surfaced as raw OS errors (e.g., "No such file or directory") with no indication of *which* file or *what operation* failed. Now every fallible operation includes the relevant file path and operation description in the error chain, making CLI failures much easier to diagnose.

A secondary fix in `crates/cli/src/input.rs` replaces a `panic!`-on-error (`.expect(...)`) with proper `?` propagation, and `find_manifest_dir` in `crates/cli/src/util.rs` replaces a `.expect()` panic with an `eyre` error return.

---

## Changes by crate

### `crates/sdk/src/fs.rs`

Wraps low-level file operations with the existing `read_error` helper to attach file paths to error messages:

- **`read_evm_halo2_verifier_from_folder`** — `read_to_string` and `File::open`/`serde_json::from_reader` calls now include the offending path on failure.
- **`read_from_file_bytes`** — `read(path)` wrapped with `read_error`.
- **`decode_from_file`** — both `File::open` and `T::decode` wrapped with `read_error`.

### `crates/cli/src/commands/build.rs`

Adds `eyre::Context` (`.with_context(...)`) to the transpilation pipeline and output-copy step:

- ELF read, decode, and transpile errors now name the target.
- `create_dir_all` and `copy` for `--output-dir` include the directory/file path.

### `crates/cli/src/commands/commit.rs`

Adds context to the `--output-dir` copy path:

- `create_dir_all`, and both `copy` calls (commit file, baseline file) now name the destination directory on failure.

### `crates/cli/src/commands/init.rs`

Adds context in `add_openvm_dependency` and `write_template_file`:

- Reading, parsing, and writing `Cargo.toml` include the file path.
- Template file writes include the destination path.

### `crates/cli/src/commands/keygen.rs`

Adds context to the `--output-dir` copy path for keygen artifacts:

- `create_dir_all` and all `copy` calls (app pk, app vk, agg pk, agg vk) include the destination directory.

### `crates/cli/src/commands/setup.rs`

Adds context to the S3 parameter download pipeline:

- `create_dir_all` for the params directory includes the path.
- S3 `get_object` and body collection name the file being downloaded.
- `write` includes the local destination path.

### `crates/cli/src/input.rs`

Two changes:

- Adds context to `read` and `serde_json::from_slice` with the input file path.
- **Bug fix:** replaces `.expect("Fail: input validation accepted an input, but the deserialization rejected it")` with `?`, so a deserialization failure returns an error instead of panicking the process.

### `crates/cli/src/util.rs`

Two changes in helper functions:

- **`read_to_struct_toml`** — `read_to_string` and `toml::from_str` now include the config file path on failure.
- **`find_manifest_dir`** — replaces `.expect(...)` (panic) on missing `Cargo.toml` with `.ok_or_else(|| eyre::eyre!(...))` so the error is propagated instead of crashing.
