### PR TITLE
chore: cargo openvm prove generates baseline file

### DIFF
--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -8,22 +8,24 @@ use openvm_circuit::arch::{
     },
     instructions::exe::VmExe,
 };
+use openvm_continuations::CommitBytes;
 use openvm_sdk::{
     config::{AggregationSystemParams, AggregationTreeConfig, AppConfig},
     fs::{read_object_from_file, write_object_to_file, write_to_file_json},
     keygen::AppProvingKey,
-    types::VersionedNonRootStarkProof,
+    types::{AppExecutionCommit, VerificationBaselineJson, VersionedNonRootStarkProof},
     Sdk, F,
 };
 use openvm_sdk_config::SdkVmConfig;
+use p3_bn254::Bn254;
 
 use super::{RunArgs, RunCargoArgs};
 use crate::{
     commands::build,
     input::read_to_stdin,
     util::{
-        get_agg_pk_path, get_app_pk_path, get_manifest_path_and_dir, get_single_target_name,
-        get_target_dir,
+        get_agg_pk_path, get_app_baseline_path, get_app_pk_path, get_manifest_path_and_dir,
+        get_single_target_name, get_target_dir, get_target_output_dir,
     },
 };
 
@@ -212,11 +214,29 @@ impl ProveCmd {
                 )?;
                 let mut prover = sdk.prover(exe)?;
                 let baseline = prover.generate_baseline();
-                println!("exe commit: {:?}", baseline.app_exe_commit);
+                let app_vk_commit = prover.app_vk_commit();
+
+                let app_commit = AppExecutionCommit {
+                    app_exe_commit: CommitBytes::from(baseline.app_exe_commit),
+                    app_vk_commit: CommitBytes::from(app_vk_commit),
+                };
+                let exe_commit_bn254 = Bn254::from(app_commit.app_exe_commit);
+                let vk_commit_bn254 = Bn254::from(app_commit.app_vk_commit);
+                println!("exe commit: {:?}", exe_commit_bn254);
+                println!("vk commit: {:?}", vk_commit_bn254);
 
                 let (stark_proof, _metadata) =
                     prover.prove(read_to_stdin(&run_args.input)?, &[])?;
                 let stark_proof_bytes = VersionedNonRootStarkProof::new(stark_proof)?;
+
+                let target_dir = target_dir_from_cargo_args(cargo_args)?;
+                let target_output_dir = get_target_output_dir(&target_dir, &cargo_args.profile);
+                let target_name_path =
+                    get_single_target_name(cargo_args).unwrap_or(PathBuf::from(&target_name));
+                let baseline_path = get_app_baseline_path(&target_output_dir, target_name_path);
+                println!("Writing baseline to {}", baseline_path.display());
+                let baseline_json: VerificationBaselineJson = baseline.into();
+                write_to_file_json(&baseline_path, &baseline_json)?;
 
                 let proof_path = if let Some(proof) = proof {
                     proof

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -53,6 +53,12 @@ fn test_cli_stark_e2e_simplified() -> Result<()> {
 }
 
 #[test]
+fn test_cli_stark_e2e_no_commit() -> Result<()> {
+    install_cli();
+    run_script("cli_stark_e2e_no_commit.sh", &[])
+}
+
+#[test]
 fn test_cli_init_build() -> Result<()> {
     install_cli();
     run_script("cli_init_build.sh", &[])

--- a/crates/cli/tests/scripts/cli_stark_e2e_no_commit.sh
+++ b/crates/cli/tests/scripts/cli_stark_e2e_no_commit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+proof_path="$temp_dir/fibonacci.stark.proof"
+
+cargo openvm keygen \
+  --manifest-path tests/programs/multi/Cargo.toml
+
+cargo openvm prove stark \
+  --manifest-path tests/programs/multi/Cargo.toml \
+  --example fibonacci \
+  --proof "$proof_path"
+
+cargo openvm verify stark \
+  --manifest-path tests/programs/multi/Cargo.toml \
+  --example fibonacci \
+  --proof "$proof_path"


### PR DESCRIPTION
Resolves INT-5362.

# PR Summary: `prove stark` writes baseline so `commit` is not required

## Overview

Previously, `cargo openvm prove stark` did not write a verification baseline file. This meant `cargo openvm verify stark` would fail unless the user had separately run `cargo openvm commit` first, since `verify stark` reads a `.baseline.json` file to check the proof against expected commits.

This PR makes `prove stark` self-sufficient by having it generate and write the baseline file itself, enabling a simpler `keygen -> prove stark -> verify stark` workflow without requiring `commit`.

---

## `crates/cli/src/commands/prove.rs`

### Baseline generation and commit logging

After generating the baseline (which was already done for its `app_exe_commit`), the STARK proving path now also:

1. Computes `app_vk_commit` from the prover.
2. Constructs an `AppExecutionCommit` and converts both the exe and vk commits to `Bn254` for display.
3. Prints both `exe commit` and `vk commit` (previously only the exe commit was printed, and as raw bytes rather than `Bn254`).
4. Converts the baseline to `VerificationBaselineJson` (the hex-wrapped format) and writes it to `<target_output_dir>/<target_name>.baseline.json` via `write_to_file_json` — the same path and format that `verify stark` expects.

This mirrors what the `commit` command already does, adapting it for the prove-without-commit flow.

### New imports

- `openvm_continuations::CommitBytes`, `openvm_sdk::types::{AppExecutionCommit, VerificationBaselineJson}`, `p3_bn254::Bn254` — for commit formatting and baseline serialization.
- `get_app_baseline_path`, `get_target_output_dir` from `crate::util` — for resolving the baseline output path.

---

## `crates/cli/tests/`

### New integration test: `test_cli_stark_e2e_no_commit`

Added in `integration.rs`, this test exercises the new `keygen -> prove stark -> verify stark` flow (no `commit` step). It calls the new script `cli_stark_e2e_no_commit.sh`.

### New test script: `cli_stark_e2e_no_commit.sh`

A bash script that:

1. Runs `cargo openvm keygen` against the `tests/programs/multi` workspace.
2. Runs `cargo openvm prove stark` for the `fibonacci` example, outputting the proof to a temp directory.
3. Runs `cargo openvm verify stark` for the same example, reading the proof from the temp path.

The temp directory is cleaned up on exit. The script validates that the full STARK prove/verify cycle works without an explicit `commit` step.
