### PR TITLE
chore: CLI cleanup refactor

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -38,7 +38,7 @@ impl Default for OpenVmConfigArgs {
     }
 }
 
-#[derive(Clone, Parser)]
+#[derive(Clone, Default, Parser)]
 pub struct ManifestArgs {
     #[arg(
         long,
@@ -57,16 +57,7 @@ pub struct ManifestArgs {
     pub manifest_path: Option<PathBuf>,
 }
 
-impl Default for ManifestArgs {
-    fn default() -> Self {
-        Self {
-            target_dir: None,
-            manifest_path: None,
-        }
-    }
-}
-
-#[derive(Clone, Parser)]
+#[derive(Clone, Default, Parser)]
 pub struct ProvingKeyArgs {
     #[arg(
         long,

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1,0 +1,86 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use openvm_circuit::arch::OPENVM_DEFAULT_INIT_FILE_NAME;
+
+#[derive(Clone, Parser)]
+pub struct OpenVmConfigArgs {
+    #[arg(
+        long,
+        help = "Path to the OpenVM config .toml file that specifies the VM extensions, by default will search for the file at ${manifest_dir}/openvm.toml",
+        help_heading = "OpenVM Options"
+    )]
+    pub config: Option<PathBuf>,
+
+    #[arg(
+        long,
+        help = "Output directory that OpenVM proving artifacts will be copied to",
+        help_heading = "OpenVM Options"
+    )]
+    pub output_dir: Option<PathBuf>,
+
+    #[arg(
+        long,
+        default_value = OPENVM_DEFAULT_INIT_FILE_NAME,
+        help = "Name of the init file",
+        help_heading = "OpenVM Options"
+    )]
+    pub init_file_name: String,
+}
+
+impl Default for OpenVmConfigArgs {
+    fn default() -> Self {
+        Self {
+            config: None,
+            output_dir: None,
+            init_file_name: OPENVM_DEFAULT_INIT_FILE_NAME.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Parser)]
+pub struct ManifestArgs {
+    #[arg(
+        long,
+        value_name = "DIR",
+        help = "Directory for all generated artifacts and intermediate files",
+        help_heading = "Output Options"
+    )]
+    pub target_dir: Option<PathBuf>,
+
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Path to the Cargo.toml file, by default searches for the file in the current or any parent directory",
+        help_heading = "Manifest Options"
+    )]
+    pub manifest_path: Option<PathBuf>,
+}
+
+impl Default for ManifestArgs {
+    fn default() -> Self {
+        Self {
+            target_dir: None,
+            manifest_path: None,
+        }
+    }
+}
+
+#[derive(Clone, Parser)]
+pub struct ProvingKeyArgs {
+    #[arg(
+        long,
+        action,
+        help = "Path to app proving key, by default will be ${openvm_dir}/app.pk",
+        help_heading = "OpenVM Options"
+    )]
+    pub app_pk: Option<PathBuf>,
+
+    #[arg(
+        long,
+        action,
+        help = "Path to aggregation proving key, by default will be ${openvm_dir}/agg.pk",
+        help_heading = "OpenVM Options"
+    )]
+    pub agg_pk: Option<PathBuf>,
+}

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -41,7 +41,7 @@ impl BuildCmd {
     }
 }
 
-#[derive(Clone, Parser)]
+#[derive(Clone, Default, Parser)]
 pub struct BuildArgs {
     #[arg(
         long,
@@ -52,15 +52,6 @@ pub struct BuildArgs {
 
     #[clap(flatten)]
     pub openvm_config: OpenVmConfigArgs,
-}
-
-impl Default for BuildArgs {
-    fn default() -> Self {
-        Self {
-            no_transpile: false,
-            openvm_config: OpenVmConfigArgs::default(),
-        }
-    }
 }
 
 #[derive(Clone, Parser)]

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -10,14 +10,13 @@ use itertools::izip;
 use openvm_build::{
     build_generic, get_package, get_workspace_packages, get_workspace_root, GuestOptions,
 };
-use openvm_circuit::arch::{
-    instructions::exe::VmExe, InitFileGenerator, OPENVM_DEFAULT_INIT_FILE_NAME,
-};
+use openvm_circuit::arch::{instructions::exe::VmExe, InitFileGenerator};
 use openvm_sdk::fs::write_object_to_file;
 use openvm_sdk_config::TranspilerConfig;
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE, FromElf};
 
 use crate::{
+    args::{ManifestArgs, OpenVmConfigArgs},
     default::{OPENVM_CONFIG_FILENAME, VMEXE_EXT},
     util::{
         get_manifest_path_and_dir, get_target_dir, get_target_output_dir,
@@ -51,36 +50,15 @@ pub struct BuildArgs {
     )]
     pub no_transpile: bool,
 
-    #[arg(
-        long,
-        help = "Path to the OpenVM config .toml file that specifies the VM extensions, by default will search for the file at ${manifest_dir}/openvm.toml",
-        help_heading = "OpenVM Options"
-    )]
-    pub config: Option<PathBuf>,
-
-    #[arg(
-        long,
-        help = "Output directory that OpenVM proving artifacts will be copied to",
-        help_heading = "OpenVM Options"
-    )]
-    pub output_dir: Option<PathBuf>,
-
-    #[arg(
-        long,
-        default_value = OPENVM_DEFAULT_INIT_FILE_NAME,
-        help = "Name of the init file",
-        help_heading = "OpenVM Options"
-    )]
-    pub init_file_name: String,
+    #[clap(flatten)]
+    pub openvm_config: OpenVmConfigArgs,
 }
 
 impl Default for BuildArgs {
     fn default() -> Self {
         Self {
             no_transpile: false,
-            config: None,
-            output_dir: None,
-            init_file_name: OPENVM_DEFAULT_INIT_FILE_NAME.to_string(),
+            openvm_config: OpenVmConfigArgs::default(),
         }
     }
 }
@@ -189,13 +167,8 @@ pub struct BuildCargoArgs {
     )]
     pub profile: String,
 
-    #[arg(
-        long,
-        value_name = "DIR",
-        help = "Directory for all generated artifacts and intermediate files",
-        help_heading = "Output Options"
-    )]
-    pub target_dir: Option<PathBuf>,
+    #[clap(flatten)]
+    pub manifest: ManifestArgs,
 
     #[arg(
         long,
@@ -221,14 +194,6 @@ pub struct BuildCargoArgs {
         help_heading = "Display Options"
     )]
     pub color: String,
-
-    #[arg(
-        long,
-        value_name = "PATH",
-        help = "Path to the Cargo.toml file, by default searches for the file in the current or any parent directory",
-        help_heading = "Manifest Options"
-    )]
-    pub manifest_path: Option<PathBuf>,
 
     #[arg(
         long,
@@ -275,11 +240,10 @@ impl Default for BuildCargoArgs {
             all_features: false,
             no_default_features: false,
             profile: "release".to_string(),
-            target_dir: None,
+            manifest: ManifestArgs::default(),
             verbose: false,
             quiet: false,
             color: "always".to_string(),
-            manifest_path: None,
             ignore_rust_version: false,
             locked: false,
             offline: false,
@@ -294,8 +258,9 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
     println!("[openvm] Building the package...");
 
     // Find manifest_path, manifest_dir, and target_dir
-    let (manifest_path, manifest_dir) = get_manifest_path_and_dir(&cargo_args.manifest_path)?;
-    let target_dir = get_target_dir(&cargo_args.target_dir, &manifest_path);
+    let (manifest_path, manifest_dir) =
+        get_manifest_path_and_dir(&cargo_args.manifest.manifest_path)?;
+    let target_dir = get_target_dir(&cargo_args.manifest.target_dir, &manifest_path);
 
     // Set guest options using build arguments; use found manifest directory for consistency
     let mut guest_options = GuestOptions::default()
@@ -355,13 +320,15 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
     // Write to init file
     let app_config = read_config_toml_or_default(
         build_args
+            .openvm_config
             .config
             .to_owned()
             .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME)),
     )?;
-    app_config
-        .app_vm_config
-        .write_to_init_file(&manifest_dir, Some(&build_args.init_file_name))?;
+    app_config.app_vm_config.write_to_init_file(
+        &manifest_dir,
+        Some(&build_args.openvm_config.init_file_name),
+    )?;
 
     // Build (allowing passed options to decide what gets built)
     let elf_target_dir = match build_generic(&guest_options) {
@@ -377,7 +344,7 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
 
     // If transpilation is skipped, return the raw target directory
     if build_args.no_transpile {
-        if build_args.output_dir.is_some() {
+        if build_args.openvm_config.output_dir.is_some() {
             println!("[openvm] WARNING: Output directory set but transpilation skipped");
         }
         return Ok(elf_target_dir);
@@ -453,7 +420,7 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
         let file_path = target_output_dir.join(&file_name);
 
         write_object_to_file(&file_path, exe)?;
-        if let Some(output_dir) = &build_args.output_dir {
+        if let Some(output_dir) = &build_args.openvm_config.output_dir {
             create_dir_all(output_dir)
                 .with_context(|| format!("failed to create directory {}", output_dir.display()))?;
             copy(&file_path, output_dir.join(&file_name)).with_context(|| {
@@ -466,7 +433,7 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
         }
     }
 
-    let final_output_dir = if let Some(output_dir) = &build_args.output_dir {
+    let final_output_dir = if let Some(output_dir) = &build_args.openvm_config.output_dir {
         output_dir
     } else {
         &target_output_dir

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -17,8 +17,12 @@ use openvm_sdk::fs::write_object_to_file;
 use openvm_sdk_config::TranspilerConfig;
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE, FromElf};
 
-use crate::util::{
-    get_manifest_path_and_dir, get_target_dir, get_target_output_dir, read_config_toml_or_default,
+use crate::{
+    default::{OPENVM_CONFIG_FILENAME, VMEXE_EXT},
+    util::{
+        get_manifest_path_and_dir, get_target_dir, get_target_output_dir,
+        read_config_toml_or_default,
+    },
 };
 
 #[derive(Parser)]
@@ -353,7 +357,7 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
         build_args
             .config
             .to_owned()
-            .unwrap_or_else(|| manifest_dir.join("openvm.toml")),
+            .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME)),
     )?;
     app_config
         .app_vm_config
@@ -445,7 +449,7 @@ pub fn build(build_args: &BuildArgs, cargo_args: &BuildCargoArgs) -> Result<Path
         } else {
             PathBuf::from(&target.name)
         };
-        let file_name = target_name.with_extension("vmexe");
+        let file_name = target_name.with_extension(VMEXE_EXT);
         let file_path = target_output_dir.join(&file_name);
 
         write_object_to_file(&file_path, exe)?;

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -5,7 +5,6 @@ use std::{
 
 use clap::Parser;
 use eyre::{Context, Result};
-use openvm_circuit::arch::OPENVM_DEFAULT_INIT_FILE_NAME;
 use openvm_continuations::CommitBytes;
 use openvm_sdk::{
     config::AggregationSystemParams,
@@ -17,6 +16,7 @@ use p3_bn254::Bn254;
 
 use super::{RunArgs, RunCargoArgs};
 use crate::{
+    args::OpenVmConfigArgs,
     commands::{load_app_pk, load_or_build_exe, ExecutionMode},
     util::{
         get_agg_pk_path, get_agg_vk_path, get_app_baseline_path, get_app_commit_path,
@@ -46,27 +46,8 @@ pub struct CommitCmd {
     )]
     pub exe: Option<PathBuf>,
 
-    #[arg(
-        long,
-        help = "Path to the OpenVM config .toml file that specifies the VM extensions, by default will search for the file at ${manifest_dir}/openvm.toml",
-        help_heading = "OpenVM Options"
-    )]
-    pub config: Option<PathBuf>,
-
-    #[arg(
-        long,
-        help = "Output directory that OpenVM proving artifacts will be copied to",
-        help_heading = "OpenVM Options"
-    )]
-    pub output_dir: Option<PathBuf>,
-
-    #[arg(
-        long,
-        default_value = OPENVM_DEFAULT_INIT_FILE_NAME,
-        help = "Name of the init file",
-        help_heading = "OpenVM Options"
-    )]
-    pub init_file_name: String,
+    #[clap(flatten)]
+    pub openvm_config: OpenVmConfigArgs,
 
     #[command(flatten)]
     cargo_args: RunCargoArgs,
@@ -78,15 +59,14 @@ impl CommitCmd {
 
         let run_args = RunArgs {
             exe: self.exe.clone(),
-            config: self.config.clone(),
-            output_dir: self.output_dir.clone(),
-            init_file_name: self.init_file_name.clone(),
+            openvm_config: self.openvm_config.clone(),
             input: None,
             mode: ExecutionMode::Pure,
         };
         let (exe, target_name_stem) = load_or_build_exe(&run_args, &self.cargo_args)?;
-        let (manifest_path, _) = get_manifest_path_and_dir(&self.cargo_args.manifest_path)?;
-        let target_dir = get_target_dir(&self.cargo_args.target_dir, &manifest_path);
+        let (manifest_path, _) =
+            get_manifest_path_and_dir(&self.cargo_args.manifest.manifest_path)?;
+        let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
 
         let mut sdk =
             Sdk::new(app_pk.app_config(), AggregationSystemParams::default())?.with_app_pk(app_pk);
@@ -150,7 +130,7 @@ impl CommitCmd {
         let baseline_json: VerificationBaselineJson = baseline.into();
         write_to_file_json(&baseline_path, &baseline_json)?;
 
-        if let Some(output_dir) = &self.output_dir {
+        if let Some(output_dir) = &self.openvm_config.output_dir {
             create_dir_all(output_dir)
                 .with_context(|| format!("failed to create directory {}", output_dir.display()))?;
             let commit_name = commit_path.file_name().unwrap();

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -133,7 +133,7 @@ impl InitCmd {
         }
 
         // Write template openvm.toml
-        write_template_file("openvm.toml", &path)?;
+        write_template_file(crate::default::OPENVM_CONFIG_FILENAME, &path)?;
 
         Ok(())
     }

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -8,6 +8,7 @@ use eyre::{Context, Result};
 use openvm_sdk::{config::AggregationSystemParams, fs::write_object_to_file, Sdk};
 
 use crate::{
+    args::ManifestArgs,
     default::{
         DEFAULT_AGG_PK_NAME, DEFAULT_AGG_VK_NAME, DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME,
         OPENVM_CONFIG_FILENAME,
@@ -48,28 +49,15 @@ pub struct KeygenCmd {
 
 #[derive(Parser)]
 pub struct KeygenCargoArgs {
-    #[arg(
-        long,
-        value_name = "DIR",
-        help = "Directory for all Cargo-generated artifacts and intermediate files",
-        help_heading = "Cargo Options"
-    )]
-    pub(crate) target_dir: Option<PathBuf>,
-
-    #[arg(
-        long,
-        value_name = "PATH",
-        help = "Path to the Cargo.toml file, by default searches for the file in the current or any parent directory",
-        help_heading = "Cargo Options"
-    )]
-    pub(crate) manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub(crate) manifest: ManifestArgs,
 }
 
 impl KeygenCmd {
     pub fn run(&self) -> Result<()> {
         let (manifest_path, manifest_dir) =
-            get_manifest_path_and_dir(&self.cargo_args.manifest_path)?;
-        let target_dir = get_target_dir(&self.cargo_args.target_dir, &manifest_path);
+            get_manifest_path_and_dir(&self.cargo_args.manifest.manifest_path)?;
+        let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
         let app_pk_path = get_app_pk_path(&target_dir);
         let app_vk_path = get_app_vk_path(&target_dir);
         let agg_pk_path = get_agg_pk_path(&target_dir);

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -8,7 +8,10 @@ use eyre::{Context, Result};
 use openvm_sdk::{config::AggregationSystemParams, fs::write_object_to_file, Sdk};
 
 use crate::{
-    default::{DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME},
+    default::{
+        DEFAULT_AGG_PK_NAME, DEFAULT_AGG_VK_NAME, DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME,
+        OPENVM_CONFIG_FILENAME,
+    },
     util::{
         get_agg_pk_path, get_agg_vk_path, get_app_pk_path, get_app_vk_path,
         get_manifest_path_and_dir, get_target_dir, read_config_toml_or_default,
@@ -75,7 +78,7 @@ impl KeygenCmd {
         keygen(
             self.config
                 .to_owned()
-                .unwrap_or_else(|| manifest_dir.join("openvm.toml")),
+                .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME)),
             &app_pk_path,
             &app_vk_path,
             &agg_pk_path,
@@ -129,9 +132,9 @@ pub(crate) fn keygen(
         copy(&app_vk_path, output_dir.join(DEFAULT_APP_VK_NAME))
             .with_context(|| format!("failed to copy app vk to {}", output_dir.display()))?;
         if generate_agg {
-            copy(&agg_pk_path, output_dir.join("agg.pk"))
+            copy(&agg_pk_path, output_dir.join(DEFAULT_AGG_PK_NAME))
                 .with_context(|| format!("failed to copy agg pk to {}", output_dir.display()))?;
-            copy(&agg_vk_path, output_dir.join("agg.vk"))
+            copy(&agg_vk_path, output_dir.join(DEFAULT_AGG_VK_NAME))
                 .with_context(|| format!("failed to copy agg vk to {}", output_dir.display()))?;
         }
     }

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -22,6 +22,7 @@ use p3_bn254::Bn254;
 use super::{RunArgs, RunCargoArgs};
 use crate::{
     commands::build,
+    default::{APP_PROOF_EXT, EVM_PROOF_EXT, STARK_PROOF_EXT, VMEXE_EXT},
     input::read_to_stdin,
     util::{
         get_agg_pk_path, get_app_baseline_path, get_app_pk_path, get_manifest_path_and_dir,
@@ -185,7 +186,7 @@ impl ProveCmd {
                 let proof_path = if let Some(proof) = proof {
                     proof
                 } else {
-                    &PathBuf::from(target_name).with_extension("app.proof")
+                    &PathBuf::from(target_name).with_extension(APP_PROOF_EXT)
                 };
                 println!(
                     "App proof completed! Writing App proof to {}",
@@ -241,7 +242,7 @@ impl ProveCmd {
                 let proof_path = if let Some(proof) = proof {
                     proof
                 } else {
-                    &PathBuf::from(target_name).with_extension("stark.proof")
+                    &PathBuf::from(target_name).with_extension(STARK_PROOF_EXT)
                 };
                 println!(
                     "STARK proof completed! Writing STARK proof to {}",
@@ -280,7 +281,7 @@ impl ProveCmd {
                 let proof_path = if let Some(proof) = proof {
                     proof
                 } else {
-                    &PathBuf::from(target_name).with_extension("evm.proof")
+                    &PathBuf::from(target_name).with_extension(EVM_PROOF_EXT)
                 };
                 println!(
                     "EVM proof completed! Writing EVM proof to {}",
@@ -322,7 +323,7 @@ pub(crate) fn load_or_build_exe(
         let build_args = run_args.clone().into();
         let cargo_args = cargo_args.clone().into();
         let output_dir = build(&build_args, &cargo_args)?;
-        &output_dir.join(target_name.with_extension("vmexe"))
+        &output_dir.join(target_name.with_extension(VMEXE_EXT))
     };
 
     let app_exe = read_object_from_file(exe_path)?;

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -23,7 +23,7 @@ use super::{RunArgs, RunCargoArgs};
 use crate::{
     args::ProvingKeyArgs,
     commands::build,
-    default::{APP_PROOF_EXT, EVM_PROOF_EXT, STARK_PROOF_EXT, VMEXE_EXT},
+    default::{APP_PROOF_EXT, STARK_PROOF_EXT, VMEXE_EXT},
     input::read_to_stdin,
     util::{
         get_agg_pk_path, get_app_baseline_path, get_app_pk_path, get_manifest_path_and_dir,
@@ -254,7 +254,7 @@ impl ProveCmd {
                 let proof_path = if let Some(proof) = proof {
                     proof
                 } else {
-                    &PathBuf::from(target_name).with_extension(EVM_PROOF_EXT)
+                    &PathBuf::from(target_name).with_extension(crate::default::EVM_PROOF_EXT)
                 };
                 println!(
                     "EVM proof completed! Writing EVM proof to {}",

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -21,6 +21,7 @@ use p3_bn254::Bn254;
 
 use super::{RunArgs, RunCargoArgs};
 use crate::{
+    args::ProvingKeyArgs,
     commands::build,
     default::{APP_PROOF_EXT, EVM_PROOF_EXT, STARK_PROOF_EXT, VMEXE_EXT},
     input::read_to_stdin,
@@ -74,21 +75,8 @@ enum ProveSubCommand {
         )]
         proof: Option<PathBuf>,
 
-        #[arg(
-            long,
-            action,
-            help = "Path to app proving key, by default will be ${openvm_dir}/app.pk",
-            help_heading = "OpenVM Options"
-        )]
-        app_pk: Option<PathBuf>,
-
-        #[arg(
-            long,
-            action,
-            help = "Path to aggregation proving key, by default will be ${openvm_dir}/agg.pk",
-            help_heading = "OpenVM Options"
-        )]
-        agg_pk: Option<PathBuf>,
+        #[command(flatten)]
+        keys: ProvingKeyArgs,
 
         #[command(flatten)]
         run_args: RunArgs,
@@ -112,21 +100,8 @@ enum ProveSubCommand {
         )]
         proof: Option<PathBuf>,
 
-        #[arg(
-            long,
-            action,
-            help = "Path to app proving key, by default will be ${openvm_dir}/app.pk",
-            help_heading = "OpenVM Options"
-        )]
-        app_pk: Option<PathBuf>,
-
-        #[arg(
-            long,
-            action,
-            help = "Path to aggregation proving key, by default will be ${openvm_dir}/agg.pk",
-            help_heading = "OpenVM Options"
-        )]
-        agg_pk: Option<PathBuf>,
+        #[command(flatten)]
+        keys: ProvingKeyArgs,
 
         #[command(flatten)]
         run_args: RunArgs,
@@ -195,22 +170,21 @@ impl ProveCmd {
                 write_object_to_file(proof_path, app_proof)?;
             }
             ProveSubCommand::Stark {
-                app_pk,
-                agg_pk,
+                keys,
                 proof,
                 run_args,
                 cargo_args,
                 segmentation_args,
                 agg_tree_config,
             } => {
-                let mut app_pk = load_app_pk(app_pk, cargo_args)?;
+                let mut app_pk = load_app_pk(&keys.app_pk, cargo_args)?;
                 let (exe, target_name) = load_or_build_exe(run_args, cargo_args)?;
                 let app_config = get_app_config(&mut app_pk, segmentation_args);
                 let sdk = with_required_agg_pk(
                     Sdk::new(app_config, AggregationSystemParams::default())?
                         .with_agg_tree_config(*agg_tree_config)
                         .with_app_pk(app_pk),
-                    agg_pk,
+                    &keys.agg_pk,
                     cargo_args,
                 )?;
                 let mut prover = sdk.prover(exe)?;
@@ -252,15 +226,14 @@ impl ProveCmd {
             }
             #[cfg(feature = "evm-prove")]
             ProveSubCommand::Evm {
-                app_pk,
-                agg_pk,
+                keys,
                 proof,
                 run_args,
                 cargo_args,
                 segmentation_args,
                 agg_tree_config,
             } => {
-                let mut app_pk = load_app_pk(app_pk, cargo_args)?;
+                let mut app_pk = load_app_pk(&keys.app_pk, cargo_args)?;
                 let (exe, target_name) = load_or_build_exe(run_args, cargo_args)?;
 
                 println!("Generating EVM proof, this may take a lot of compute and memory...");
@@ -269,7 +242,7 @@ impl ProveCmd {
                     Sdk::new(app_config, AggregationSystemParams::default())?
                         .with_agg_tree_config(*agg_tree_config)
                         .with_app_pk(app_pk),
-                    agg_pk,
+                    &keys.agg_pk,
                     cargo_args,
                 )?;
                 let sdk = with_required_root_pk(sdk)?;
@@ -301,8 +274,8 @@ pub(crate) fn load_app_pk(
     let app_pk_path = if let Some(app_pk) = app_pk {
         app_pk.to_path_buf()
     } else {
-        let (manifest_path, _) = get_manifest_path_and_dir(&cargo_args.manifest_path)?;
-        let target_dir = get_target_dir(&cargo_args.target_dir, &manifest_path);
+        let (manifest_path, _) = get_manifest_path_and_dir(&cargo_args.manifest.manifest_path)?;
+        let target_dir = get_target_dir(&cargo_args.manifest.target_dir, &manifest_path);
         get_app_pk_path(&target_dir)
     };
 
@@ -349,8 +322,11 @@ fn get_app_config(
 }
 
 fn target_dir_from_cargo_args(cargo_args: &RunCargoArgs) -> Result<PathBuf> {
-    let (manifest_path, _) = get_manifest_path_and_dir(&cargo_args.manifest_path)?;
-    Ok(get_target_dir(&cargo_args.target_dir, &manifest_path))
+    let (manifest_path, _) = get_manifest_path_and_dir(&cargo_args.manifest.manifest_path)?;
+    Ok(get_target_dir(
+        &cargo_args.manifest.target_dir,
+        &manifest_path,
+    ))
 }
 
 fn resolve_agg_pk_path(agg_pk: &Option<PathBuf>, cargo_args: &RunCargoArgs) -> Result<PathBuf> {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
 use eyre::{eyre, Result};
-use openvm_circuit::arch::{instructions::exe::VmExe, OPENVM_DEFAULT_INIT_FILE_NAME};
+use openvm_circuit::arch::instructions::exe::VmExe;
 use openvm_sdk::{
     config::AggregationSystemParams, fs::read_object_from_file, keygen::AppProvingKey, Sdk, F,
 };
@@ -10,6 +10,7 @@ use openvm_sdk_config::SdkVmConfig;
 
 use super::{build, BuildArgs, BuildCargoArgs};
 use crate::{
+    args::{ManifestArgs, OpenVmConfigArgs},
     default::{OPENVM_CONFIG_FILENAME, VMEXE_EXT},
     input::{read_to_stdin, Input},
     util::{
@@ -49,19 +50,8 @@ pub struct RunArgs {
     )]
     pub exe: Option<PathBuf>,
 
-    #[arg(
-        long,
-        help = "Path to the OpenVM config .toml file that specifies the VM extensions, by default will search for the file at ${manifest_dir}/openvm.toml",
-        help_heading = "OpenVM Options"
-    )]
-    pub config: Option<PathBuf>,
-
-    #[arg(
-        long,
-        help = "Output directory that OpenVM proving artifacts will be copied to",
-        help_heading = "OpenVM Options"
-    )]
-    pub output_dir: Option<PathBuf>,
+    #[clap(flatten)]
+    pub openvm_config: OpenVmConfigArgs,
 
     #[arg(
         long,
@@ -70,14 +60,6 @@ pub struct RunArgs {
         help_heading = "OpenVM Options"
     )]
     pub input: Option<Input>,
-
-    #[arg(
-        long,
-        default_value = OPENVM_DEFAULT_INIT_FILE_NAME,
-        help = "Name of the init file",
-        help_heading = "OpenVM Options"
-    )]
-    pub init_file_name: String,
 
     #[arg(
         long,
@@ -92,9 +74,7 @@ pub struct RunArgs {
 impl From<RunArgs> for BuildArgs {
     fn from(args: RunArgs) -> Self {
         BuildArgs {
-            config: args.config,
-            output_dir: args.output_dir,
-            init_file_name: args.init_file_name,
+            openvm_config: args.openvm_config,
             ..Default::default()
         }
     }
@@ -160,13 +140,8 @@ pub struct RunCargoArgs {
     )]
     pub profile: String,
 
-    #[arg(
-        long,
-        value_name = "DIR",
-        help = "Directory for all generated artifacts and intermediate files",
-        help_heading = "Output Options"
-    )]
-    pub target_dir: Option<PathBuf>,
+    #[clap(flatten)]
+    pub manifest: ManifestArgs,
 
     #[arg(
         long,
@@ -192,14 +167,6 @@ pub struct RunCargoArgs {
         help_heading = "Display Options"
     )]
     pub color: String,
-
-    #[arg(
-        long,
-        value_name = "PATH",
-        help = "Path to the Cargo.toml file, by default searches for the file in the current or any parent directory",
-        help_heading = "Manifest Options"
-    )]
-    pub manifest_path: Option<PathBuf>,
 
     #[arg(
         long,
@@ -240,11 +207,10 @@ impl From<RunCargoArgs> for BuildCargoArgs {
             all_features: args.all_features,
             no_default_features: args.no_default_features,
             profile: args.profile,
-            target_dir: args.target_dir,
+            manifest: args.manifest,
             verbose: args.verbose,
             quiet: args.quiet,
             color: args.color,
-            manifest_path: args.manifest_path,
             ignore_rust_version: args.ignore_rust_version,
             locked: args.locked,
             offline: args.offline,
@@ -268,9 +234,10 @@ impl RunCmd {
         };
 
         let (manifest_path, manifest_dir) =
-            get_manifest_path_and_dir(&self.cargo_args.manifest_path)?;
+            get_manifest_path_and_dir(&self.cargo_args.manifest.manifest_path)?;
         let config_path = self
             .run_args
+            .openvm_config
             .config
             .to_owned()
             .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME));
@@ -286,7 +253,7 @@ impl RunCmd {
             self.run_args.mode,
             ExecutionMode::Segment | ExecutionMode::Meter
         ) {
-            let target_dir = get_target_dir(&self.cargo_args.target_dir, &manifest_path);
+            let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
             let app_pk_path = get_app_pk_path(&target_dir);
 
             // Load the app pk and set it

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -10,6 +10,7 @@ use openvm_sdk_config::SdkVmConfig;
 
 use super::{build, BuildArgs, BuildCargoArgs};
 use crate::{
+    default::{OPENVM_CONFIG_FILENAME, VMEXE_EXT},
     input::{read_to_stdin, Input},
     util::{
         get_app_pk_path, get_manifest_path_and_dir, get_single_target_name, get_target_dir,
@@ -263,7 +264,7 @@ impl RunCmd {
             let build_args = self.run_args.clone().into();
             let cargo_args = self.cargo_args.clone().into();
             let output_dir = build(&build_args, &cargo_args)?;
-            &output_dir.join(target_name.with_extension("vmexe"))
+            &output_dir.join(target_name.with_extension(VMEXE_EXT))
         };
 
         let (manifest_path, manifest_dir) =
@@ -272,7 +273,7 @@ impl RunCmd {
             .run_args
             .config
             .to_owned()
-            .unwrap_or_else(|| manifest_dir.join("openvm.toml"));
+            .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME));
         let app_config = read_config_toml_or_default(&config_path)?;
         let exe: VmExe<F> = read_object_from_file(exe_path)?;
         let inputs = read_to_stdin(&self.run_args.input)?;

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -12,7 +12,7 @@ use openvm_sdk::{
 use super::KeygenCargoArgs;
 use crate::{
     args::ManifestArgs,
-    default::{APP_PROOF_EXT, EVM_PROOF_EXT, STARK_PROOF_EXT},
+    default::{APP_PROOF_EXT, STARK_PROOF_EXT},
     util::{
         get_agg_vk_path, get_app_baseline_path, get_app_vk_path, get_manifest_path_and_dir,
         get_single_target_name_raw, get_target_dir, get_target_output_dir, resolve_proof_path,
@@ -207,7 +207,7 @@ impl VerifyCmd {
                     },
                 )?;
 
-                let proof_path = resolve_proof_path(proof, EVM_PROOF_EXT)?;
+                let proof_path = resolve_proof_path(proof, crate::default::EVM_PROOF_EXT)?;
                 // The app config used here doesn't matter, it is ignored in verification
                 println!("Verifying EVM proof at {}", proof_path.display());
                 let evm_proof: EvmProof = read_from_file_json(proof_path).with_context(|| {

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -10,9 +10,13 @@ use openvm_sdk::{
 };
 
 use super::KeygenCargoArgs;
-use crate::util::{
-    get_agg_vk_path, get_app_baseline_path, get_app_vk_path, get_files_with_ext,
-    get_manifest_path_and_dir, get_single_target_name_raw, get_target_dir, get_target_output_dir,
+use crate::{
+    default::{APP_PROOF_EXT, EVM_PROOF_EXT, STARK_PROOF_EXT},
+    util::{
+        get_agg_vk_path, get_app_baseline_path, get_app_vk_path, get_files_with_ext,
+        get_manifest_path_and_dir, get_single_target_name_raw, get_target_dir,
+        get_target_output_dir,
+    },
 };
 
 #[derive(Parser)]
@@ -152,11 +156,11 @@ impl VerifyCmd {
                 let proof_path = if let Some(proof) = proof {
                     proof.clone()
                 } else {
-                    let files = get_files_with_ext(Path::new("."), "app.proof")?;
+                    let files = get_files_with_ext(Path::new("."), APP_PROOF_EXT)?;
                     if files.len() > 1 {
-                        return Err(eyre::eyre!("multiple .app.proof files found, please specify the path using option --proof"));
+                        return Err(eyre::eyre!("multiple .{APP_PROOF_EXT} files found, please specify the path using option --proof"));
                     } else if files.is_empty() {
-                        return Err(eyre::eyre!("no .app.proof file found, please specify the path using option --proof"));
+                        return Err(eyre::eyre!("no .{APP_PROOF_EXT} file found, please specify the path using option --proof"));
                     }
                     files[0].clone()
                 };
@@ -200,11 +204,11 @@ impl VerifyCmd {
                 let proof_path = if let Some(proof) = proof {
                     proof.clone()
                 } else {
-                    let files = get_files_with_ext(Path::new("."), "stark.proof")?;
+                    let files = get_files_with_ext(Path::new("."), STARK_PROOF_EXT)?;
                     if files.len() > 1 {
-                        return Err(eyre::eyre!("multiple .stark.proof files found, please specify the path using option --proof"));
+                        return Err(eyre::eyre!("multiple .{STARK_PROOF_EXT} files found, please specify the path using option --proof"));
                     } else if files.is_empty() {
-                        return Err(eyre::eyre!("no .stark.proof file found, please specify the path using option --proof"));
+                        return Err(eyre::eyre!("no .{STARK_PROOF_EXT} file found, please specify the path using option --proof"));
                     }
                     files[0].clone()
                 };
@@ -236,11 +240,11 @@ impl VerifyCmd {
                 let proof_path = if let Some(proof) = proof {
                     proof.clone()
                 } else {
-                    let files = get_files_with_ext(Path::new("."), "evm.proof")?;
+                    let files = get_files_with_ext(Path::new("."), EVM_PROOF_EXT)?;
                     if files.len() > 1 {
-                        return Err(eyre::eyre!("multiple .evm.proof files found, please specify the path using option --proof"));
+                        return Err(eyre::eyre!("multiple .{EVM_PROOF_EXT} files found, please specify the path using option --proof"));
                     } else if files.is_empty() {
-                        return Err(eyre::eyre!("no .evm.proof file found, please specify the path using option --proof"));
+                        return Err(eyre::eyre!("no .{EVM_PROOF_EXT} file found, please specify the path using option --proof"));
                     }
                     files[0].clone()
                 };

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
 use eyre::{Context, Result};
@@ -11,11 +11,11 @@ use openvm_sdk::{
 
 use super::KeygenCargoArgs;
 use crate::{
+    args::ManifestArgs,
     default::{APP_PROOF_EXT, EVM_PROOF_EXT, STARK_PROOF_EXT},
     util::{
-        get_agg_vk_path, get_app_baseline_path, get_app_vk_path, get_files_with_ext,
-        get_manifest_path_and_dir, get_single_target_name_raw, get_target_dir,
-        get_target_output_dir,
+        get_agg_vk_path, get_app_baseline_path, get_app_vk_path, get_manifest_path_and_dir,
+        get_single_target_name_raw, get_target_dir, get_target_output_dir, resolve_proof_path,
     },
 };
 
@@ -118,21 +118,8 @@ pub struct SingleTargetCargoArgs {
     )]
     pub profile: String,
 
-    #[arg(
-        long,
-        value_name = "DIR",
-        help = "Directory for all generated artifacts and intermediate files",
-        help_heading = "Output Options"
-    )]
-    pub target_dir: Option<PathBuf>,
-
-    #[arg(
-        long,
-        value_name = "PATH",
-        help = "Path to the Cargo.toml file, by default searches for the file in the current or any parent directory",
-        help_heading = "Manifest Options"
-    )]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub manifest: ManifestArgs,
 }
 
 impl VerifyCmd {
@@ -146,24 +133,16 @@ impl VerifyCmd {
                 let app_vk_path = if let Some(app_vk) = app_vk {
                     app_vk.to_path_buf()
                 } else {
-                    let (manifest_path, _) = get_manifest_path_and_dir(&cargo_args.manifest_path)?;
-                    let target_dir = get_target_dir(&cargo_args.target_dir, &manifest_path);
+                    let (manifest_path, _) =
+                        get_manifest_path_and_dir(&cargo_args.manifest.manifest_path)?;
+                    let target_dir =
+                        get_target_dir(&cargo_args.manifest.target_dir, &manifest_path);
                     get_app_vk_path(&target_dir)
                 };
                 let app_vk: openvm_sdk::keygen::AppVerifyingKey =
                     read_object_from_file(app_vk_path)?;
 
-                let proof_path = if let Some(proof) = proof {
-                    proof.clone()
-                } else {
-                    let files = get_files_with_ext(Path::new("."), APP_PROOF_EXT)?;
-                    if files.len() > 1 {
-                        return Err(eyre::eyre!("multiple .{APP_PROOF_EXT} files found, please specify the path using option --proof"));
-                    } else if files.is_empty() {
-                        return Err(eyre::eyre!("no .{APP_PROOF_EXT} file found, please specify the path using option --proof"));
-                    }
-                    files[0].clone()
-                };
+                let proof_path = resolve_proof_path(proof, APP_PROOF_EXT)?;
                 println!("Verifying application proof at {}", proof_path.display());
                 let app_proof = read_object_from_file(proof_path)?;
                 let _exe_commit = verify_app_proof::<openvm_sdk::DefaultStarkEngine>(
@@ -177,8 +156,9 @@ impl VerifyCmd {
                 proof,
                 cargo_args,
             } => {
-                let (manifest_path, _) = get_manifest_path_and_dir(&cargo_args.manifest_path)?;
-                let target_dir = get_target_dir(&cargo_args.target_dir, &manifest_path);
+                let (manifest_path, _) =
+                    get_manifest_path_and_dir(&cargo_args.manifest.manifest_path)?;
+                let target_dir = get_target_dir(&cargo_args.manifest.target_dir, &manifest_path);
                 let agg_vk_path = get_agg_vk_path(&target_dir);
                 let agg_vk = read_object_from_file(&agg_vk_path).map_err(|e| {
                     eyre::eyre!(
@@ -193,7 +173,7 @@ impl VerifyCmd {
                     let target_name = get_single_target_name_raw(
                         &cargo_args.bin,
                         &cargo_args.example,
-                        &cargo_args.manifest_path,
+                        &cargo_args.manifest.manifest_path,
                         &cargo_args.package,
                     )?;
                     get_app_baseline_path(&target_output_dir, target_name)
@@ -201,17 +181,7 @@ impl VerifyCmd {
                 let baseline_json: VerificationBaselineJson = read_from_file_json(baseline_path)?;
                 let expected_app_commit = baseline_json.into();
 
-                let proof_path = if let Some(proof) = proof {
-                    proof.clone()
-                } else {
-                    let files = get_files_with_ext(Path::new("."), STARK_PROOF_EXT)?;
-                    if files.len() > 1 {
-                        return Err(eyre::eyre!("multiple .{STARK_PROOF_EXT} files found, please specify the path using option --proof"));
-                    } else if files.is_empty() {
-                        return Err(eyre::eyre!("no .{STARK_PROOF_EXT} file found, please specify the path using option --proof"));
-                    }
-                    files[0].clone()
-                };
+                let proof_path = resolve_proof_path(proof, STARK_PROOF_EXT)?;
                 println!("Verifying STARK proof at {}", proof_path.display());
                 let stark_proof: VersionedNonRootStarkProof = read_from_file_json(proof_path)
                     .with_context(|| {
@@ -237,17 +207,7 @@ impl VerifyCmd {
                     },
                 )?;
 
-                let proof_path = if let Some(proof) = proof {
-                    proof.clone()
-                } else {
-                    let files = get_files_with_ext(Path::new("."), EVM_PROOF_EXT)?;
-                    if files.len() > 1 {
-                        return Err(eyre::eyre!("multiple .{EVM_PROOF_EXT} files found, please specify the path using option --proof"));
-                    } else if files.is_empty() {
-                        return Err(eyre::eyre!("no .{EVM_PROOF_EXT} file found, please specify the path using option --proof"));
-                    }
-                    files[0].clone()
-                };
+                let proof_path = resolve_proof_path(proof, EVM_PROOF_EXT)?;
                 // The app config used here doesn't matter, it is ignored in verification
                 println!("Verifying EVM proof at {}", proof_path.display());
                 let evm_proof: EvmProof = read_from_file_json(proof_path).with_context(|| {

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -8,6 +8,18 @@ pub const DEFAULT_MANIFEST_DIR: &str = ".";
 
 pub const DEFAULT_APP_PK_NAME: &str = "app.pk";
 pub const DEFAULT_APP_VK_NAME: &str = "app.vk";
+pub const DEFAULT_AGG_PK_NAME: &str = "agg.pk";
+pub const DEFAULT_AGG_VK_NAME: &str = "agg.vk";
+
+pub const VMEXE_EXT: &str = "vmexe";
+pub const OPENVM_CONFIG_FILENAME: &str = "openvm.toml";
+
+pub const APP_PROOF_EXT: &str = "app.proof";
+pub const STARK_PROOF_EXT: &str = "stark.proof";
+pub const EVM_PROOF_EXT: &str = "evm.proof";
+
+pub const COMMIT_JSON_EXT: &str = "commit.json";
+pub const BASELINE_JSON_EXT: &str = "baseline.json";
 
 pub fn default_params_dir() -> String {
     env::var("HOME").unwrap() + "/.openvm/params/"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "tco", allow(incomplete_features))]
 #![cfg_attr(feature = "tco", feature(explicit_tail_calls))]
 
+pub mod args;
 pub mod commands;
 pub mod default;
 pub mod input;

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -11,7 +11,10 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     commands::RunCargoArgs,
-    default::{default_app_config, DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME},
+    default::{
+        default_app_config, BASELINE_JSON_EXT, COMMIT_JSON_EXT, DEFAULT_AGG_PK_NAME,
+        DEFAULT_AGG_VK_NAME, DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME,
+    },
 };
 
 pub(crate) fn read_to_struct_toml<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {
@@ -88,20 +91,20 @@ pub fn get_app_vk_path(target_dir: &Path) -> PathBuf {
 }
 
 pub fn get_agg_pk_path(target_dir: &Path) -> PathBuf {
-    get_openvm_dir(target_dir).join("agg.pk")
+    get_openvm_dir(target_dir).join(DEFAULT_AGG_PK_NAME)
 }
 
 pub fn get_agg_vk_path(target_dir: &Path) -> PathBuf {
-    get_openvm_dir(target_dir).join("agg.vk")
+    get_openvm_dir(target_dir).join(DEFAULT_AGG_VK_NAME)
 }
 
 pub fn get_app_commit_path(target_output_dir: &Path, target_name: PathBuf) -> PathBuf {
-    let commit_name = target_name.with_extension("commit.json");
+    let commit_name = target_name.with_extension(COMMIT_JSON_EXT);
     target_output_dir.join(commit_name)
 }
 
 pub fn get_app_baseline_path(target_output_dir: &Path, target_name: PathBuf) -> PathBuf {
-    let baseline_name = target_name.with_extension("baseline.json");
+    let baseline_name = target_name.with_extension(BASELINE_JSON_EXT);
     target_output_dir.join(baseline_name)
 }
 

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -116,7 +116,7 @@ pub fn get_single_target_name(cargo_args: &RunCargoArgs) -> Result<PathBuf> {
     get_single_target_name_raw(
         &cargo_args.bin,
         &cargo_args.example,
-        &cargo_args.manifest_path,
+        &cargo_args.manifest.manifest_path,
         &cargo_args.package,
     )
 }
@@ -175,6 +175,23 @@ pub fn get_single_target_name_raw(
         PathBuf::from(bin[0].clone())
     };
     Ok(single_target_name)
+}
+
+pub fn resolve_proof_path(proof: &Option<PathBuf>, extension: &str) -> Result<PathBuf> {
+    if let Some(proof) = proof {
+        return Ok(proof.clone());
+    }
+    let files = get_files_with_ext(Path::new("."), extension)?;
+    if files.len() > 1 {
+        return Err(eyre::eyre!(
+            "multiple .{extension} files found, please specify the path using option --proof"
+        ));
+    } else if files.is_empty() {
+        return Err(eyre::eyre!(
+            "no .{extension} file found, please specify the path using option --proof"
+        ));
+    }
+    Ok(files[0].clone())
 }
 
 pub fn get_files_with_ext(dir: &Path, extension: &str) -> Result<Vec<PathBuf>> {

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -1,32 +1,42 @@
 use std::path::PathBuf;
 
-use cargo_openvm::commands::{build, BuildArgs, BuildCargoArgs};
+use cargo_openvm::{
+    args::{ManifestArgs, OpenVmConfigArgs},
+    commands::{build, BuildArgs, BuildCargoArgs},
+};
 use eyre::Result;
 use openvm_build::RUSTC_TARGET;
 
 fn default_build_test_args(example: &str) -> BuildArgs {
-    let mut args = BuildArgs::default();
-    args.no_transpile = true;
-    args.openvm_config.config = Some(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("programs")
-            .join(example)
-            .join("openvm.toml"),
-    );
-    args
+    BuildArgs {
+        no_transpile: true,
+        openvm_config: OpenVmConfigArgs {
+            config: Some(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("tests")
+                    .join("programs")
+                    .join(example)
+                    .join("openvm.toml"),
+            ),
+            ..Default::default()
+        },
+    }
 }
 
 fn default_cargo_test_args(example: &str) -> BuildCargoArgs {
-    let mut args = BuildCargoArgs::default();
-    args.manifest.manifest_path = Some(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("programs")
-            .join(example)
-            .join("Cargo.toml"),
-    );
-    args
+    BuildCargoArgs {
+        manifest: ManifestArgs {
+            manifest_path: Some(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("tests")
+                    .join("programs")
+                    .join(example)
+                    .join("Cargo.toml"),
+            ),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
 }
 
 #[test]

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -5,30 +5,28 @@ use eyre::Result;
 use openvm_build::RUSTC_TARGET;
 
 fn default_build_test_args(example: &str) -> BuildArgs {
-    BuildArgs {
-        no_transpile: true,
-        config: Some(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests")
-                .join("programs")
-                .join(example)
-                .join("openvm.toml"),
-        ),
-        ..Default::default()
-    }
+    let mut args = BuildArgs::default();
+    args.no_transpile = true;
+    args.openvm_config.config = Some(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("programs")
+            .join(example)
+            .join("openvm.toml"),
+    );
+    args
 }
 
 fn default_cargo_test_args(example: &str) -> BuildCargoArgs {
-    BuildCargoArgs {
-        manifest_path: Some(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests")
-                .join("programs")
-                .join(example)
-                .join("Cargo.toml"),
-        ),
-        ..Default::default()
-    }
+    let mut args = BuildCargoArgs::default();
+    args.manifest.manifest_path = Some(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("programs")
+            .join(example)
+            .join("Cargo.toml"),
+    );
+    args
 }
 
 #[test]
@@ -38,7 +36,7 @@ fn test_build_with_profile() -> Result<()> {
 
     let build_args = default_build_test_args("fibonacci");
     let mut cargo_args = default_cargo_test_args("fibonacci");
-    cargo_args.target_dir = Some(target_dir.to_path_buf());
+    cargo_args.manifest.target_dir = Some(target_dir.to_path_buf());
     cargo_args.profile = "dev".to_string();
 
     build(&build_args, &cargo_args)?;
@@ -57,7 +55,7 @@ fn test_multi_target_build() -> Result<()> {
 
     let build_args = default_build_test_args("multi");
     let mut cargo_args = default_cargo_test_args("multi");
-    cargo_args.target_dir = Some(target_dir.to_path_buf());
+    cargo_args.manifest.target_dir = Some(target_dir.to_path_buf());
 
     // Build lib
     cargo_args.lib = true;
@@ -121,7 +119,7 @@ fn test_multi_target_transpile_default() -> Result<()> {
     let mut build_args = default_build_test_args("multi");
     let mut cargo_args = default_cargo_test_args("multi");
     build_args.no_transpile = false;
-    cargo_args.target_dir = Some(target_dir.to_path_buf());
+    cargo_args.manifest.target_dir = Some(target_dir.to_path_buf());
     cargo_args.all_targets = true;
 
     build(&build_args, &cargo_args)?;
@@ -163,9 +161,9 @@ fn test_output_dir_copy() -> Result<()> {
 
     let mut build_args = default_build_test_args("fibonacci");
     let mut cargo_args = default_cargo_test_args("fibonacci");
-    build_args.output_dir = Some(output_dir.to_path_buf());
+    build_args.openvm_config.output_dir = Some(output_dir.to_path_buf());
     build_args.no_transpile = false;
-    cargo_args.target_dir = Some(target_dir.to_path_buf());
+    cargo_args.manifest.target_dir = Some(target_dir.to_path_buf());
 
     build(&build_args, &cargo_args)?;
 


### PR DESCRIPTION
Resolves INT-4076.

# CLI: Replace hard-coded strings with constants and reduce code duplication

## Summary

Two related cleanups to the `cargo-openvm` CLI crate:

1. **Constants for file names/extensions** -- Hard-coded strings like `"vmexe"`, `"openvm.toml"`, `"app.proof"`, `"agg.pk"`, etc. are replaced with named constants in `default.rs`. This makes the strings discoverable and ensures consistency if names change.

2. **Shared CLI argument structs and helpers** -- Duplicated clap option groups are extracted into reusable structs in a new `args.rs` module. A `resolve_proof_path` helper eliminates copy-pasted proof-file-search logic in `verify.rs`.

No functional or CLI interface changes. All flags, defaults, and help text are preserved.

## Changes by file

### New files

| File | Purpose |
|---|---|
| `src/args.rs` | Shared clap argument structs: `OpenVmConfigArgs`, `ManifestArgs`, `ProvingKeyArgs` |

### Modified files

| File | What changed |
|---|---|
| `src/default.rs` | Added 9 constants: `DEFAULT_AGG_PK_NAME`, `DEFAULT_AGG_VK_NAME`, `VMEXE_EXT`, `OPENVM_CONFIG_FILENAME`, `APP_PROOF_EXT`, `STARK_PROOF_EXT`, `EVM_PROOF_EXT`, `COMMIT_JSON_EXT`, `BASELINE_JSON_EXT` |
| `src/lib.rs` | Registered `pub mod args` |
| `src/util.rs` | Inline literals replaced with constants; added `resolve_proof_path` helper |
| `src/commands/build.rs` | Moved `OpenVmConfigArgs` and `ManifestArgs` definitions to `args.rs`; flattened them into `BuildArgs` and `BuildCargoArgs`; replaced inline `"vmexe"` / `"openvm.toml"` |
| `src/commands/run.rs` | `RunArgs` flattens `OpenVmConfigArgs`; `RunCargoArgs` flattens `ManifestArgs`; `From` impls simplified; replaced inline literals |
| `src/commands/commit.rs` | Replaced 3 inline option fields (`config`, `output_dir`, `init_file_name`) with flattened `OpenVmConfigArgs` |
| `src/commands/keygen.rs` | `KeygenCargoArgs` now flattens `ManifestArgs` (was 2 duplicate field definitions); replaced inline `"agg.pk"` / `"agg.vk"` / `"openvm.toml"` |
| `src/commands/prove.rs` | Moved `ProvingKeyArgs` definition to `args.rs`; `Stark` and `Evm` subcommands flatten it (replaces duplicated `app_pk`/`agg_pk` fields); replaced inline `"vmexe"` / proof extension literals |
| `src/commands/verify.rs` | All 3 proof-search blocks (app/stark/evm) replaced with `resolve_proof_path` calls; `SingleTargetCargoArgs` flattens `ManifestArgs`; replaced inline proof extension literals |
| `src/commands/init.rs` | Replaced inline `"openvm.toml"` with `OPENVM_CONFIG_FILENAME` |

## Shared structs in `args.rs`

| Struct | Fields | Used by |
|---|---|---|
| `OpenVmConfigArgs` | `--config`, `--output-dir`, `--init-file-name` | `BuildArgs`, `RunArgs`, `CommitCmd` |
| `ManifestArgs` | `--target-dir`, `--manifest-path` | `BuildCargoArgs`, `RunCargoArgs`, `SingleTargetCargoArgs`, `KeygenCargoArgs` |
| `ProvingKeyArgs` | `--app-pk`, `--agg-pk` | `prove stark`, `prove evm` |

Each is incorporated via `#[clap(flatten)]`, so the CLI interface is unchanged.

## Design decisions

- **`prove app` keeps a standalone `--app-pk` field** rather than flattening `ProvingKeyArgs`, to avoid exposing an irrelevant `--agg-pk` flag on the `app` subcommand.
- **`KeygenCargoArgs` remains a separate struct** (wrapping `ManifestArgs`) rather than being replaced outright, since it's a distinct concept that could gain keygen-specific fields later.
- **`BuildCargoArgs` / `RunCargoArgs` are not unified** because their `package` field differs in type (`Vec<String>` vs `Option<String>`) and `BuildCargoArgs` has 6 extra build-only flags. The existing `From<RunCargoArgs> for BuildCargoArgs` conversion is preserved.
- **`KeygenCargoArgs` help headings changed** from `"Cargo Options"` to the split `"Output Options"` / `"Manifest Options"` used by all other commands. This is a minor help-text normalization, not a functional change.
