### PR TITLE
feat: make GenericSdk immutable and introduce builder

### DIFF
--- a/benchmarks/prove/src/bin/keccak_par.rs
+++ b/benchmarks/prove/src/bin/keccak_par.rs
@@ -60,7 +60,6 @@ fn main() -> eyre::Result<()> {
                 let sdk = Sdk::builder()
                     .app_pk(app_pk)
                     .agg_params(Default::default())
-                    .default_transpiler()
                     .build()?;
                 let mut prover = sdk.app_prover(exe)?;
                 let proof = prover.prove(stdin)?;

--- a/benchmarks/prove/src/bin/keccak_par.rs
+++ b/benchmarks/prove/src/bin/keccak_par.rs
@@ -50,7 +50,6 @@ fn main() -> eyre::Result<()> {
     run_with_metric_collection("OUTPUT_PATH", || -> eyre::Result<_> {
         let mut handles = vec![];
         for _ in 0..concurrency {
-            let app_config = app_config.clone();
             let app_pk = app_pk.clone();
             let app_vk = app_vk.clone();
             let exe = exe.clone();
@@ -58,9 +57,11 @@ fn main() -> eyre::Result<()> {
             let handle = std::thread::spawn(move || -> eyre::Result<_> {
                 // Sdk uses OnceLock for internal caching and is not Clone/Sync,
                 // so each thread creates its own instance with the shared app_pk.
-                let sdk = Sdk::new(app_config, Default::default())?;
-                sdk.set_app_pk(app_pk)
-                    .map_err(|_| eyre::eyre!("Error setting app pk"))?;
+                let sdk = Sdk::builder()
+                    .app_pk(app_pk)
+                    .agg_params(Default::default())
+                    .default_transpiler()
+                    .build()?;
                 let mut prover = sdk.app_prover(exe)?;
                 let proof = prover.prove(stdin)?;
                 let _ = verify_app_proof::<DefaultStarkEngine>(&app_vk.vk, memory_dims, &proof)?;

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -69,7 +69,7 @@ impl CommitCmd {
             get_manifest_path_and_dir(&self.cargo_args.manifest.manifest_path)?;
         let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
 
-        let mut builder = Sdk::builder().app_pk(app_pk).default_transpiler();
+        let mut builder = Sdk::builder().app_pk(app_pk);
         let agg_pk_path = get_agg_pk_path(&target_dir);
         if agg_pk_path.exists() {
             builder = builder.agg_pk(read_object_from_file(&agg_pk_path)?);

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -9,7 +9,6 @@ use openvm_continuations::CommitBytes;
 use openvm_sdk::{
     config::AggregationSystemParams,
     fs::{read_object_from_file, write_object_to_file, write_to_file_json},
-    keygen::RootProvingKey,
     types::{AppExecutionCommit, VerificationBaselineJson},
     Sdk,
 };
@@ -78,11 +77,7 @@ impl CommitCmd {
         }
         let root_pk_path = PathBuf::from(crate::default::default_root_pk_path());
         if root_pk_path.exists() {
-            let RootProvingKey {
-                root_pk,
-                trace_heights,
-            } = read_object_from_file(&root_pk_path)?;
-            builder = builder.root_pk(root_pk, trace_heights);
+            builder = builder.root_pk(read_object_from_file(&root_pk_path)?);
         }
         let sdk = builder.build()?;
 

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -9,6 +9,7 @@ use openvm_continuations::CommitBytes;
 use openvm_sdk::{
     config::AggregationSystemParams,
     fs::{read_object_from_file, write_object_to_file, write_to_file_json},
+    keygen::RootProvingKey,
     types::{AppExecutionCommit, VerificationBaselineJson},
     Sdk,
 };
@@ -68,16 +69,22 @@ impl CommitCmd {
             get_manifest_path_and_dir(&self.cargo_args.manifest.manifest_path)?;
         let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
 
-        let mut sdk =
-            Sdk::new(app_pk.app_config(), AggregationSystemParams::default())?.with_app_pk(app_pk);
+        let mut builder = Sdk::builder().app_pk(app_pk).default_transpiler();
         let agg_pk_path = get_agg_pk_path(&target_dir);
         if agg_pk_path.exists() {
-            sdk = sdk.with_agg_pk(read_object_from_file(&agg_pk_path)?);
+            builder = builder.agg_pk(read_object_from_file(&agg_pk_path)?);
+        } else {
+            builder = builder.agg_params(AggregationSystemParams::default());
         }
         let root_pk_path = PathBuf::from(crate::default::default_root_pk_path());
         if root_pk_path.exists() {
-            sdk = sdk.with_root_pk(read_object_from_file(&root_pk_path)?);
+            let RootProvingKey {
+                root_pk,
+                trace_heights,
+            } = read_object_from_file(&root_pk_path)?;
+            builder = builder.root_pk(root_pk, trace_heights);
         }
+        let sdk = builder.build()?;
 
         let prover = sdk.prover(exe)?;
         let baseline = prover.generate_baseline();

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -246,7 +246,7 @@ impl ProveCmd {
                 let sdk = Sdk::builder()
                     .app_pk(app_pk)
                     .agg_pk(agg_pk)
-                    .root_pk(root_pk.root_pk, root_pk.trace_heights)
+                    .root_pk(root_pk)
                     .agg_tree_config(*agg_tree_config)
                     .build()?;
                 let mut prover = sdk.evm_prover(exe)?;

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -9,10 +9,12 @@ use openvm_circuit::arch::{
     instructions::exe::VmExe,
 };
 use openvm_continuations::CommitBytes;
+#[cfg(feature = "evm-prove")]
+use openvm_sdk::keygen::RootProvingKey;
 use openvm_sdk::{
     config::{AggregationSystemParams, AggregationTreeConfig},
     fs::{read_object_from_file, write_object_to_file, write_to_file_json},
-    keygen::{AggProvingKey, AppProvingKey, RootProvingKey},
+    keygen::{AggProvingKey, AppProvingKey},
     types::{AppExecutionCommit, VerificationBaselineJson, VersionedNonRootStarkProof},
     Sdk, F,
 };
@@ -153,7 +155,6 @@ impl ProveCmd {
                 let sdk = Sdk::builder()
                     .app_pk(app_pk)
                     .agg_params(AggregationSystemParams::default())
-                    .default_transpiler()
                     .build()?;
                 let (exe, target_name) = load_or_build_exe(run_args, cargo_args)?;
 
@@ -188,7 +189,6 @@ impl ProveCmd {
                     .app_pk(app_pk)
                     .agg_pk(agg_pk)
                     .agg_tree_config(*agg_tree_config)
-                    .default_transpiler()
                     .build()?;
                 let mut prover = sdk.prover(exe)?;
                 let baseline = prover.generate_baseline();
@@ -248,7 +248,6 @@ impl ProveCmd {
                     .agg_pk(agg_pk)
                     .root_pk(root_pk.root_pk, root_pk.trace_heights)
                     .agg_tree_config(*agg_tree_config)
-                    .default_transpiler()
                     .build()?;
                 let mut prover = sdk.evm_prover(exe)?;
                 let exe_commit = prover.stark_prover.app_prover.app_exe_commit();

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -10,9 +10,9 @@ use openvm_circuit::arch::{
 };
 use openvm_continuations::CommitBytes;
 use openvm_sdk::{
-    config::{AggregationSystemParams, AggregationTreeConfig, AppConfig},
+    config::{AggregationSystemParams, AggregationTreeConfig},
     fs::{read_object_from_file, write_object_to_file, write_to_file_json},
-    keygen::AppProvingKey,
+    keygen::{AggProvingKey, AppProvingKey, RootProvingKey},
     types::{AppExecutionCommit, VerificationBaselineJson, VersionedNonRootStarkProof},
     Sdk, F,
 };
@@ -149,9 +149,12 @@ impl ProveCmd {
                 segmentation_args,
             } => {
                 let mut app_pk = load_app_pk(app_pk, cargo_args)?;
-                let app_config = get_app_config(&mut app_pk, segmentation_args);
-                let sdk =
-                    Sdk::new(app_config, AggregationSystemParams::default())?.with_app_pk(app_pk);
+                configure_app_pk(&mut app_pk, segmentation_args);
+                let sdk = Sdk::builder()
+                    .app_pk(app_pk)
+                    .agg_params(AggregationSystemParams::default())
+                    .default_transpiler()
+                    .build()?;
                 let (exe, target_name) = load_or_build_exe(run_args, cargo_args)?;
 
                 let app_proof = sdk
@@ -179,14 +182,14 @@ impl ProveCmd {
             } => {
                 let mut app_pk = load_app_pk(&keys.app_pk, cargo_args)?;
                 let (exe, target_name) = load_or_build_exe(run_args, cargo_args)?;
-                let app_config = get_app_config(&mut app_pk, segmentation_args);
-                let sdk = with_required_agg_pk(
-                    Sdk::new(app_config, AggregationSystemParams::default())?
-                        .with_agg_tree_config(*agg_tree_config)
-                        .with_app_pk(app_pk),
-                    &keys.agg_pk,
-                    cargo_args,
-                )?;
+                configure_app_pk(&mut app_pk, segmentation_args);
+                let agg_pk = load_required_agg_pk(&keys.agg_pk, cargo_args)?;
+                let sdk = Sdk::builder()
+                    .app_pk(app_pk)
+                    .agg_pk(agg_pk)
+                    .agg_tree_config(*agg_tree_config)
+                    .default_transpiler()
+                    .build()?;
                 let mut prover = sdk.prover(exe)?;
                 let baseline = prover.generate_baseline();
                 let app_vk_commit = prover.app_vk_commit();
@@ -237,15 +240,16 @@ impl ProveCmd {
                 let (exe, target_name) = load_or_build_exe(run_args, cargo_args)?;
 
                 println!("Generating EVM proof, this may take a lot of compute and memory...");
-                let app_config = get_app_config(&mut app_pk, segmentation_args);
-                let sdk = with_required_agg_pk(
-                    Sdk::new(app_config, AggregationSystemParams::default())?
-                        .with_agg_tree_config(*agg_tree_config)
-                        .with_app_pk(app_pk),
-                    &keys.agg_pk,
-                    cargo_args,
-                )?;
-                let sdk = with_required_root_pk(sdk)?;
+                configure_app_pk(&mut app_pk, segmentation_args);
+                let agg_pk = load_required_agg_pk(&keys.agg_pk, cargo_args)?;
+                let root_pk = load_required_root_pk()?;
+                let sdk = Sdk::builder()
+                    .app_pk(app_pk)
+                    .agg_pk(agg_pk)
+                    .root_pk(root_pk.root_pk, root_pk.trace_heights)
+                    .agg_tree_config(*agg_tree_config)
+                    .default_transpiler()
+                    .build()?;
                 let mut prover = sdk.evm_prover(exe)?;
                 let exe_commit = prover.stark_prover.app_prover.app_exe_commit();
                 println!("exe commit: {:?}", exe_commit);
@@ -307,18 +311,14 @@ pub(crate) fn load_or_build_exe(
 }
 
 /// Should only be called when `app_pk` has only a single reference internally.
-/// Mutates the `SystemConfig` within `app_pk` and then returns the updated `AppConfig`.
-fn get_app_config(
-    app_pk: &mut AppProvingKey<SdkVmConfig>,
-    segmentation_args: &SegmentationArgs,
-) -> AppConfig<SdkVmConfig> {
+/// Mutates the `SystemConfig` within `app_pk`.
+fn configure_app_pk(app_pk: &mut AppProvingKey<SdkVmConfig>, segmentation_args: &SegmentationArgs) {
     Arc::get_mut(&mut app_pk.app_vm_pk)
         .unwrap()
         .vm_config
         .system
         .config
         .set_segmentation_config((*segmentation_args).into());
-    app_pk.app_config()
 }
 
 fn target_dir_from_cargo_args(cargo_args: &RunCargoArgs) -> Result<PathBuf> {
@@ -338,31 +338,28 @@ fn resolve_agg_pk_path(agg_pk: &Option<PathBuf>, cargo_args: &RunCargoArgs) -> R
     }
 }
 
-fn with_required_agg_pk(
-    sdk: Sdk,
+fn load_required_agg_pk(
     agg_pk: &Option<PathBuf>,
     cargo_args: &RunCargoArgs,
-) -> Result<Sdk> {
+) -> Result<AggProvingKey> {
     let agg_pk_path = resolve_agg_pk_path(agg_pk, cargo_args)?;
-    let agg_pk = read_object_from_file(&agg_pk_path).map_err(|e| {
+    read_object_from_file(&agg_pk_path).map_err(|e| {
         eyre!(
             "Failed to read aggregation proving key from {}: {e}\nRun 'cargo openvm keygen' first to generate it",
             agg_pk_path.display()
         )
-    })?;
-    Ok(sdk.with_agg_pk(agg_pk))
+    })
 }
 
 #[cfg(feature = "evm-prove")]
-fn with_required_root_pk(sdk: Sdk) -> Result<Sdk> {
+fn load_required_root_pk() -> Result<RootProvingKey> {
     let root_pk_path = PathBuf::from(crate::default::default_root_pk_path());
-    let root_pk = read_object_from_file(&root_pk_path).map_err(|e| {
+    read_object_from_file(&root_pk_path).map_err(|e| {
         eyre!(
             "Failed to read root proving key from {}: {e}\nRun 'cargo openvm setup' first to generate it",
             root_pk_path.display()
         )
-    })?;
-    Ok(sdk.with_root_pk(root_pk))
+    })
 }
 
 impl From<SegmentationArgs> for SegmentationConfig {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -235,28 +235,16 @@ impl RunCmd {
 
         let (manifest_path, manifest_dir) =
             get_manifest_path_and_dir(&self.cargo_args.manifest.manifest_path)?;
-        let config_path = self
-            .run_args
-            .openvm_config
-            .config
-            .to_owned()
-            .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME));
-        let app_config = read_config_toml_or_default(&config_path)?;
         let exe: VmExe<F> = read_object_from_file(exe_path)?;
         let inputs = read_to_stdin(&self.run_args.input)?;
 
-        // Create SDK
-        let sdk = Sdk::new(app_config, AggregationSystemParams::default())?;
-
-        // For metered modes, load existing app pk from disk
-        if matches!(
+        let sdk = if matches!(
             self.run_args.mode,
             ExecutionMode::Segment | ExecutionMode::Meter
         ) {
             let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
             let app_pk_path = get_app_pk_path(&target_dir);
 
-            // Load the app pk and set it
             let app_pk: AppProvingKey<SdkVmConfig> =
                 read_object_from_file(&app_pk_path).map_err(|e| {
                     eyre!(
@@ -264,9 +252,21 @@ impl RunCmd {
                         app_pk_path.display()
                     )
                 })?;
-            sdk.set_app_pk(app_pk)
-                .map_err(|_| eyre::eyre!("Failed to set app pk"))?;
-        }
+            Sdk::builder()
+                .app_pk(app_pk)
+                .agg_params(AggregationSystemParams::default())
+                .default_transpiler()
+                .build()?
+        } else {
+            let config_path = self
+                .run_args
+                .openvm_config
+                .config
+                .to_owned()
+                .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME));
+            let app_config = read_config_toml_or_default(&config_path)?;
+            Sdk::new(app_config, AggregationSystemParams::default())?
+        };
 
         match self.run_args.mode {
             ExecutionMode::Pure => {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -255,7 +255,6 @@ impl RunCmd {
             Sdk::builder()
                 .app_pk(app_pk)
                 .agg_params(AggregationSystemParams::default())
-                .default_transpiler()
                 .build()?
         } else {
             let config_path = self

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -1,0 +1,493 @@
+#[cfg(feature = "evm-prove")]
+use std::path::Path;
+use std::{
+    marker::PhantomData,
+    sync::{Arc, OnceLock},
+};
+
+use eyre::eyre;
+use openvm_circuit::arch::{VmBuilder, VmExecutionConfig, VmExecutor};
+use openvm_continuations::RootSC;
+use openvm_sdk_config::TranspilerConfig;
+use openvm_stark_backend::{keygen::types::MultiStarkProvingKey, StarkEngine, SystemParams};
+use openvm_stark_sdk::config::root_params_with_100_bits_security;
+#[cfg(feature = "evm-prove")]
+use openvm_static_verifier::StaticVerifierShape;
+use openvm_transpiler::transpiler::Transpiler;
+
+#[cfg(feature = "evm-prove")]
+use crate::halo2_params::CacheHalo2ParamsReader;
+#[cfg(feature = "evm-prove")]
+use crate::{config::Halo2Config, keygen::Halo2ProvingKey, prover::Halo2Prover};
+use crate::{
+    config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig},
+    keygen::{AggProvingKey, AppProvingKey},
+    prover::{AggProver, DeferralPathProver, DeferralProver, RootProver},
+    GenericSdk, SdkError, F, SC,
+};
+
+enum AppSource<VC> {
+    Config(AppConfig<VC>),
+    Pk(AppProvingKey<VC>),
+}
+
+enum AggSource {
+    Params(AggregationSystemParams),
+    Pk(AggProvingKey),
+}
+
+struct PrebuiltRootPk {
+    pk: Arc<MultiStarkProvingKey<RootSC>>,
+    trace_heights: Vec<usize>,
+}
+
+enum RootSource {
+    Params(SystemParams),
+    Pk(PrebuiltRootPk),
+}
+
+#[cfg(feature = "evm-prove")]
+enum Halo2Source {
+    Config {
+        shape: StaticVerifierShape,
+        config: Halo2Config,
+    },
+    Pk(Halo2ProvingKey),
+}
+
+/// Construction-only API for [`GenericSdk`].
+///
+/// Each proving layer has one source of truth: either user-supplied config/params or a
+/// pre-generated proving key. `build()` normalizes those sources into an immutable [`GenericSdk`].
+pub struct GenericSdkBuilder<E, VB>
+where
+    E: StarkEngine<SC = SC>,
+    VB: VmBuilder<E>,
+    VB::VmConfig: VmExecutionConfig<F>,
+{
+    app_source: Option<AppSource<VB::VmConfig>>,
+    agg_source: Option<AggSource>,
+    root_source: Option<RootSource>,
+    agg_tree_config: Option<AggregationTreeConfig>,
+    transpiler: Option<Transpiler<F>>,
+    deferral_prover: Option<DeferralProver>,
+    #[cfg(feature = "evm-prove")]
+    halo2_source: Option<Halo2Source>,
+    #[cfg(feature = "evm-prove")]
+    halo2_params_reader: Option<CacheHalo2ParamsReader>,
+    _phantom: PhantomData<E>,
+}
+
+impl<E, VB> GenericSdkBuilder<E, VB>
+where
+    E: StarkEngine<SC = SC>,
+    VB: VmBuilder<E>,
+    VB::VmConfig: VmExecutionConfig<F>,
+{
+    pub fn new() -> Self {
+        Self {
+            app_source: None,
+            agg_source: None,
+            root_source: None,
+            agg_tree_config: None,
+            transpiler: None,
+            deferral_prover: None,
+            #[cfg(feature = "evm-prove")]
+            halo2_source: None,
+            #[cfg(feature = "evm-prove")]
+            halo2_params_reader: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn set_once<T>(slot: &mut Option<T>, field_name: &str, value: T) {
+        assert!(slot.is_none(), "{field_name} already set");
+        *slot = Some(value);
+    }
+
+    fn init_once_lock<T>(value: Option<T>, field_name: &str) -> OnceLock<T> {
+        let lock = OnceLock::new();
+        if let Some(value) = value {
+            assert!(
+                lock.set(value).is_ok(),
+                "{field_name} should only be initialized once"
+            );
+        }
+        lock
+    }
+
+    fn agg_config_from_pk(agg_pk: &AggProvingKey) -> AggregationConfig {
+        AggregationConfig {
+            params: AggregationSystemParams {
+                leaf: agg_pk.leaf_pk.params.clone(),
+                internal: agg_pk.internal_recursive_pk.params.clone(),
+            },
+        }
+    }
+
+    #[cfg(feature = "evm-prove")]
+    fn halo2_shape_from_pk(halo2_pk: &Halo2ProvingKey) -> StaticVerifierShape {
+        halo2_pk.verifier.shape
+    }
+
+    #[cfg(feature = "evm-prove")]
+    fn halo2_config_from_pk(halo2_pk: &Halo2ProvingKey) -> Halo2Config {
+        Halo2Config {
+            wrapper_k: Some(halo2_pk.wrapper.pinning.metadata.config_params.k),
+            profiling: halo2_pk.profiling,
+        }
+    }
+
+    fn build_deferral_path_prover(
+        agg_config: &AggregationConfig,
+        deferral_prover: DeferralProver,
+    ) -> Arc<DeferralPathProver> {
+        let deferral_tree_config = AggregationTreeConfig {
+            num_children_leaf: 2,
+            num_children_internal: 2,
+        };
+        let agg_prover = AggProver::new(
+            deferral_prover.def_hook_prover.get_vk(),
+            agg_config.clone(),
+            deferral_tree_config,
+            Some(deferral_prover.def_hook_prover.get_cached_commit()),
+        );
+        Arc::new(DeferralPathProver {
+            deferral_prover: Arc::new(deferral_prover),
+            agg_prover: Arc::new(agg_prover),
+        })
+    }
+
+    fn require_dependency(
+        has_value: bool,
+        value_name: &str,
+        has_dependency: bool,
+        dependency_name: &str,
+    ) -> Result<(), SdkError> {
+        if has_value && !has_dependency {
+            return Err(SdkError::Other(eyre!(
+                "`{value_name}` requires `{dependency_name}` to also be set"
+            )));
+        }
+        Ok(())
+    }
+
+    fn normalize_app_source(
+        app_source: AppSource<VB::VmConfig>,
+    ) -> (AppConfig<VB::VmConfig>, Option<AppProvingKey<VB::VmConfig>>) {
+        match app_source {
+            AppSource::Config(app_config) => (app_config, None),
+            AppSource::Pk(app_pk) => {
+                let app_config = app_pk.app_config();
+                (app_config, Some(app_pk))
+            }
+        }
+    }
+
+    fn normalize_agg_source(agg_source: AggSource) -> (AggregationConfig, Option<AggProvingKey>) {
+        match agg_source {
+            AggSource::Params(agg_params) => (AggregationConfig { params: agg_params }, None),
+            AggSource::Pk(agg_pk) => {
+                let agg_config = Self::agg_config_from_pk(&agg_pk);
+                (agg_config, Some(agg_pk))
+            }
+        }
+    }
+
+    fn normalize_root_source(root_source: RootSource) -> (SystemParams, Option<PrebuiltRootPk>) {
+        match root_source {
+            RootSource::Params(root_params) => (root_params, None),
+            RootSource::Pk(root_pk) => (root_pk.pk.params.clone(), Some(root_pk)),
+        }
+    }
+
+    #[cfg(feature = "evm-prove")]
+    fn normalize_halo2_source(
+        halo2_source: Halo2Source,
+    ) -> (StaticVerifierShape, Halo2Config, Option<Halo2ProvingKey>) {
+        match halo2_source {
+            Halo2Source::Config { shape, config } => (shape, config, None),
+            Halo2Source::Pk(halo2_pk) => (
+                Self::halo2_shape_from_pk(&halo2_pk),
+                Self::halo2_config_from_pk(&halo2_pk),
+                Some(halo2_pk),
+            ),
+        }
+    }
+
+    pub fn app_config(mut self, app_config: AppConfig<VB::VmConfig>) -> Self {
+        Self::set_once(
+            &mut self.app_source,
+            "app_source",
+            AppSource::Config(app_config),
+        );
+        self
+    }
+
+    pub fn app_pk(mut self, app_pk: AppProvingKey<VB::VmConfig>) -> Self {
+        Self::set_once(&mut self.app_source, "app_source", AppSource::Pk(app_pk));
+        self
+    }
+
+    pub fn agg_params(mut self, agg_params: AggregationSystemParams) -> Self {
+        Self::set_once(
+            &mut self.agg_source,
+            "agg_source",
+            AggSource::Params(agg_params),
+        );
+        self
+    }
+
+    pub fn agg_pk(mut self, agg_pk: AggProvingKey) -> Self {
+        Self::set_once(&mut self.agg_source, "agg_source", AggSource::Pk(agg_pk));
+        self
+    }
+
+    pub fn root_params(mut self, root_params: SystemParams) -> Self {
+        Self::set_once(
+            &mut self.root_source,
+            "root_source",
+            RootSource::Params(root_params),
+        );
+        self
+    }
+
+    pub fn root_pk(
+        mut self,
+        root_pk: Arc<MultiStarkProvingKey<RootSC>>,
+        trace_heights: Vec<usize>,
+    ) -> Self {
+        Self::set_once(
+            &mut self.root_source,
+            "root_source",
+            RootSource::Pk(PrebuiltRootPk {
+                pk: root_pk,
+                trace_heights,
+            }),
+        );
+        self
+    }
+
+    pub fn agg_tree_config(mut self, agg_tree_config: AggregationTreeConfig) -> Self {
+        Self::set_once(
+            &mut self.agg_tree_config,
+            "agg_tree_config",
+            agg_tree_config,
+        );
+        self
+    }
+
+    pub fn transpiler(mut self, transpiler: Transpiler<F>) -> Self {
+        Self::set_once(&mut self.transpiler, "transpiler", transpiler);
+        self
+    }
+
+    pub fn default_transpiler(mut self) -> Self
+    where
+        VB::VmConfig: TranspilerConfig<F>,
+    {
+        let transpiler = match self.app_source.as_ref() {
+            Some(AppSource::Config(app_config)) => app_config.app_vm_config.transpiler(),
+            Some(AppSource::Pk(app_pk)) => app_pk.app_vm_pk.vm_config.transpiler(),
+            None => panic!("default_transpiler requires app_source to be set first"),
+        };
+        Self::set_once(&mut self.transpiler, "transpiler", transpiler);
+        self
+    }
+
+    pub fn deferral_prover(mut self, deferral_prover: DeferralProver) -> Self {
+        Self::set_once(
+            &mut self.deferral_prover,
+            "deferral_prover",
+            deferral_prover,
+        );
+        self
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn halo2_config(mut self, shape: StaticVerifierShape, config: Halo2Config) -> Self {
+        Self::set_once(
+            &mut self.halo2_source,
+            "halo2_source",
+            Halo2Source::Config { shape, config },
+        );
+        self
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn halo2_pk(mut self, halo2_pk: Halo2ProvingKey) -> Self {
+        Self::set_once(
+            &mut self.halo2_source,
+            "halo2_source",
+            Halo2Source::Pk(halo2_pk),
+        );
+        self
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn halo2_params_dir(mut self, params_dir: impl AsRef<Path>) -> Self {
+        Self::set_once(
+            &mut self.halo2_params_reader,
+            "halo2_params_reader",
+            CacheHalo2ParamsReader::new(params_dir),
+        );
+        self
+    }
+
+    pub fn build(self) -> Result<GenericSdk<E, VB>, SdkError>
+    where
+        VB: Default,
+    {
+        let app_source = self
+            .app_source
+            .ok_or_else(|| SdkError::Other(eyre!("`app_config` or `app_pk` must be set")))?;
+        let agg_source = self
+            .agg_source
+            .ok_or_else(|| SdkError::Other(eyre!("`agg_params` or `agg_pk` must be set")))?;
+        let root_source = self
+            .root_source
+            .unwrap_or_else(|| RootSource::Params(root_params_with_100_bits_security()));
+        #[cfg(feature = "evm-prove")]
+        let halo2_source = self.halo2_source.unwrap_or(Halo2Source::Config {
+            shape: StaticVerifierShape::default(),
+            config: Halo2Config {
+                wrapper_k: None,
+                profiling: false,
+            },
+        });
+
+        #[cfg(feature = "evm-prove")]
+        Self::require_dependency(
+            matches!(halo2_source, Halo2Source::Pk(_)),
+            "halo2_pk",
+            matches!(root_source, RootSource::Pk(_)),
+            "root_pk",
+        )?;
+        Self::require_dependency(
+            matches!(root_source, RootSource::Pk(_)),
+            "root_pk",
+            matches!(agg_source, AggSource::Pk(_)),
+            "agg_pk",
+        )?;
+        Self::require_dependency(
+            matches!(agg_source, AggSource::Pk(_)),
+            "agg_pk",
+            matches!(app_source, AppSource::Pk(_)),
+            "app_pk",
+        )?;
+
+        let Self {
+            app_source: _,
+            agg_source: _,
+            root_source: _,
+            agg_tree_config,
+            transpiler,
+            deferral_prover,
+            #[cfg(feature = "evm-prove")]
+                halo2_source: _,
+            #[cfg(feature = "evm-prove")]
+            halo2_params_reader,
+            _phantom: _,
+        } = self;
+
+        let (app_config, app_pk_seed) = Self::normalize_app_source(app_source);
+        let (agg_config, agg_pk_seed) = Self::normalize_agg_source(agg_source);
+        let (root_params, root_pk_seed) = Self::normalize_root_source(root_source);
+
+        let executor = VmExecutor::new(app_config.app_vm_config.clone())
+            .map_err(|e| SdkError::Vm(e.into()))?;
+        let agg_tree_config = agg_tree_config.unwrap_or_default();
+
+        let def_path_prover = deferral_prover
+            .map(|deferral_prover| Self::build_deferral_path_prover(&agg_config, deferral_prover));
+        let def_hook_cached_commit = def_path_prover
+            .as_ref()
+            .map(|def_path_prover| def_path_prover.def_hook_cached_commit());
+        let def_hook_vk_commit = def_path_prover
+            .as_ref()
+            .map(|def_path_prover| def_path_prover.def_hook_vk_commit());
+
+        let app_vm_vk = app_pk_seed
+            .as_ref()
+            .map(|app_pk| Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()));
+        let app_pk = Self::init_once_lock(app_pk_seed, "app_pk");
+
+        let agg_prover_seed = agg_pk_seed.map(|agg_pk| {
+            let app_vm_vk = app_vm_vk.expect("validated `agg_pk` dependency on `app_pk`");
+            Arc::new(AggProver::from_pk(
+                app_vm_vk,
+                agg_pk,
+                agg_tree_config,
+                def_hook_cached_commit,
+            ))
+        });
+
+        let root_prover_seed = root_pk_seed.map(|root_pk| {
+            let agg_prover = agg_prover_seed
+                .as_ref()
+                .expect("validated `root_pk` dependency on `agg_pk`");
+            let system_config = app_config.app_vm_config.as_ref();
+            let memory_dimensions = system_config.memory_config.memory_dimensions();
+            let num_user_pvs = system_config.num_public_values;
+            let internal_recursive_dag_commit = agg_prover
+                .internal_recursive_prover
+                .get_self_vk_pcs_data()
+                .unwrap()
+                .commitment
+                .into();
+
+            Arc::new(RootProver::from_pk(
+                agg_prover.internal_recursive_prover.get_vk(),
+                internal_recursive_dag_commit,
+                root_pk.pk,
+                memory_dimensions,
+                num_user_pvs,
+                def_hook_vk_commit,
+                Some(root_pk.trace_heights),
+            ))
+        });
+
+        #[cfg(feature = "evm-prove")]
+        let halo2_params_reader =
+            halo2_params_reader.unwrap_or_else(CacheHalo2ParamsReader::new_with_default_params_dir);
+        #[cfg(feature = "evm-prove")]
+        let (halo2_shape, halo2_config, halo2_pk_seed) = Self::normalize_halo2_source(halo2_source);
+        #[cfg(feature = "evm-prove")]
+        let halo2_prover_seed =
+            halo2_pk_seed.map(|halo2_pk| Halo2Prover::new(&halo2_params_reader, halo2_pk));
+
+        Ok(GenericSdk {
+            app_config,
+            agg_config,
+            agg_tree_config,
+            root_params,
+            #[cfg(feature = "evm-prove")]
+            halo2_shape,
+            #[cfg(feature = "evm-prove")]
+            halo2_config,
+            app_vm_builder: Default::default(),
+            transpiler,
+            executor,
+            app_pk,
+            agg_prover: Self::init_once_lock(agg_prover_seed, "agg_prover"),
+            root_prover: Self::init_once_lock(root_prover_seed, "root_prover"),
+            def_path_prover,
+            #[cfg(feature = "evm-prove")]
+            halo2_params_reader,
+            #[cfg(feature = "evm-prove")]
+            halo2_prover: Self::init_once_lock(halo2_prover_seed, "halo2_prover"),
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<E, VB> GenericSdk<E, VB>
+where
+    E: StarkEngine<SC = SC>,
+    VB: VmBuilder<E>,
+    VB::VmConfig: VmExecutionConfig<F>,
+{
+    pub fn builder() -> GenericSdkBuilder<E, VB> {
+        GenericSdkBuilder::new()
+    }
+}

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -31,6 +31,7 @@ enum AppSource<VC> {
     Pk(AppProvingKey<VC>),
 }
 
+#[allow(clippy::large_enum_variant)]
 enum AggSource {
     Params(AggregationSystemParams),
     Pk(AggProvingKey),
@@ -85,19 +86,7 @@ where
     VB::VmConfig: VmExecutionConfig<F>,
 {
     pub fn new() -> Self {
-        Self {
-            app_source: None,
-            agg_source: None,
-            root_source: None,
-            agg_tree_config: None,
-            transpiler: None,
-            deferral_prover: None,
-            #[cfg(feature = "evm-prove")]
-            halo2_source: None,
-            #[cfg(feature = "evm-prove")]
-            halo2_params_reader: None,
-            _phantom: PhantomData,
-        }
+        Self::default()
     }
 
     fn set_once<T>(slot: &mut Option<T>, field_name: &str, value: T) {
@@ -478,6 +467,29 @@ where
             halo2_prover: Self::init_once_lock(halo2_prover_seed, "halo2_prover"),
             _phantom: PhantomData,
         })
+    }
+}
+
+impl<E, VB> Default for GenericSdkBuilder<E, VB>
+where
+    E: StarkEngine<SC = SC>,
+    VB: VmBuilder<E>,
+    VB::VmConfig: VmExecutionConfig<F>,
+{
+    fn default() -> Self {
+        Self {
+            app_source: None,
+            agg_source: None,
+            root_source: None,
+            agg_tree_config: None,
+            transpiler: None,
+            deferral_prover: None,
+            #[cfg(feature = "evm-prove")]
+            halo2_source: None,
+            #[cfg(feature = "evm-prove")]
+            halo2_params_reader: None,
+            _phantom: PhantomData,
+        }
     }
 }
 

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -7,9 +7,8 @@ use std::{
 
 use eyre::eyre;
 use openvm_circuit::arch::{VmBuilder, VmExecutionConfig, VmExecutor};
-use openvm_continuations::RootSC;
 use openvm_sdk_config::TranspilerConfig;
-use openvm_stark_backend::{keygen::types::MultiStarkProvingKey, StarkEngine, SystemParams};
+use openvm_stark_backend::{StarkEngine, SystemParams};
 use openvm_stark_sdk::config::root_params_with_100_bits_security;
 #[cfg(feature = "evm-prove")]
 use openvm_static_verifier::StaticVerifierShape;
@@ -21,7 +20,7 @@ use crate::halo2_params::CacheHalo2ParamsReader;
 use crate::{config::Halo2Config, keygen::Halo2ProvingKey, prover::Halo2Prover};
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig},
-    keygen::{AggProvingKey, AppProvingKey},
+    keygen::{AggProvingKey, AppProvingKey, RootProvingKey},
     prover::{AggProver, DeferralPathProver, DeferralProver, RootProver},
     GenericSdk, SdkError, F, SC,
 };
@@ -37,14 +36,9 @@ enum AggSource {
     Pk(AggProvingKey),
 }
 
-struct PrebuiltRootPk {
-    pk: Arc<MultiStarkProvingKey<RootSC>>,
-    trace_heights: Vec<usize>,
-}
-
 enum RootSource {
     Params(SystemParams),
-    Pk(PrebuiltRootPk),
+    Pk(RootProvingKey),
 }
 
 #[cfg(feature = "evm-prove")]
@@ -183,10 +177,10 @@ where
         }
     }
 
-    fn normalize_root_source(root_source: RootSource) -> (SystemParams, Option<PrebuiltRootPk>) {
+    fn normalize_root_source(root_source: RootSource) -> (SystemParams, Option<RootProvingKey>) {
         match root_source {
             RootSource::Params(root_params) => (root_params, None),
-            RootSource::Pk(root_pk) => (root_pk.pk.params.clone(), Some(root_pk)),
+            RootSource::Pk(root_pk) => (root_pk.root_pk.params.clone(), Some(root_pk)),
         }
     }
 
@@ -241,18 +235,11 @@ where
         self
     }
 
-    pub fn root_pk(
-        mut self,
-        root_pk: Arc<MultiStarkProvingKey<RootSC>>,
-        trace_heights: Vec<usize>,
-    ) -> Self {
+    pub fn root_pk(mut self, root_pk: RootProvingKey) -> Self {
         Self::set_once(
             &mut self.root_source,
             "root_source",
-            RootSource::Pk(PrebuiltRootPk {
-                pk: root_pk,
-                trace_heights,
-            }),
+            RootSource::Pk(root_pk),
         );
         self
     }
@@ -381,7 +368,7 @@ where
             Arc::new(RootProver::from_pk(
                 agg_prover.internal_recursive_prover.get_vk(),
                 internal_recursive_dag_commit,
-                root_pk.pk,
+                root_pk.root_pk,
                 memory_dimensions,
                 num_user_pvs,
                 def_hook_vk_commit,

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -271,59 +271,12 @@ where
         self
     }
 
-    pub fn default_transpiler(mut self) -> Self
-    where
-        VB::VmConfig: TranspilerConfig<F>,
-    {
-        let transpiler = match self.app_source.as_ref() {
-            Some(AppSource::Config(app_config)) => app_config.app_vm_config.transpiler(),
-            Some(AppSource::Pk(app_pk)) => app_pk.app_vm_pk.vm_config.transpiler(),
-            None => panic!("default_transpiler requires app_source to be set first"),
-        };
-        Self::set_once(&mut self.transpiler, "transpiler", transpiler);
-        self
-    }
-
-    pub fn deferral_prover(mut self, deferral_prover: DeferralProver) -> Self {
-        Self::set_once(
-            &mut self.deferral_prover,
-            "deferral_prover",
-            deferral_prover,
-        );
-        self
-    }
-
-    #[cfg(feature = "evm-prove")]
-    pub fn halo2_config(mut self, shape: StaticVerifierShape, config: Halo2Config) -> Self {
-        Self::set_once(
-            &mut self.halo2_source,
-            "halo2_source",
-            Halo2Source::Config { shape, config },
-        );
-        self
-    }
-
-    #[cfg(feature = "evm-prove")]
-    pub fn halo2_pk(mut self, halo2_pk: Halo2ProvingKey) -> Self {
-        Self::set_once(
-            &mut self.halo2_source,
-            "halo2_source",
-            Halo2Source::Pk(halo2_pk),
-        );
-        self
-    }
-
-    #[cfg(feature = "evm-prove")]
-    pub fn halo2_params_dir(mut self, params_dir: impl AsRef<Path>) -> Self {
-        Self::set_once(
-            &mut self.halo2_params_reader,
-            "halo2_params_reader",
-            CacheHalo2ParamsReader::new(params_dir),
-        );
-        self
-    }
-
-    pub fn build(self) -> Result<GenericSdk<E, VB>, SdkError>
+    /// Builds the SDK without inferring a transpiler from the app source.
+    ///
+    /// This is useful when callers only operate on pre-transpiled [`VmExe`] values and want ELF
+    /// conversion to remain unavailable unless a transpiler was explicitly supplied via
+    /// [`Self::transpiler`].
+    pub fn build_without_transpiler(self) -> Result<GenericSdk<E, VB>, SdkError>
     where
         VB: Default,
     {
@@ -467,6 +420,61 @@ where
             halo2_prover: Self::init_once_lock(halo2_prover_seed, "halo2_prover"),
             _phantom: PhantomData,
         })
+    }
+
+    /// Builds the SDK, deriving a default transpiler from the app source when one was not
+    /// explicitly supplied via [`Self::transpiler`].
+    pub fn build(mut self) -> Result<GenericSdk<E, VB>, SdkError>
+    where
+        VB: Default,
+        VB::VmConfig: TranspilerConfig<F>,
+    {
+        if self.transpiler.is_none() {
+            self.transpiler = self.app_source.as_ref().map(|app_source| match app_source {
+                AppSource::Config(app_config) => app_config.app_vm_config.transpiler(),
+                AppSource::Pk(app_pk) => app_pk.app_vm_pk.vm_config.transpiler(),
+            });
+        }
+        self.build_without_transpiler()
+    }
+
+    pub fn deferral_prover(mut self, deferral_prover: DeferralProver) -> Self {
+        Self::set_once(
+            &mut self.deferral_prover,
+            "deferral_prover",
+            deferral_prover,
+        );
+        self
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn halo2_config(mut self, shape: StaticVerifierShape, config: Halo2Config) -> Self {
+        Self::set_once(
+            &mut self.halo2_source,
+            "halo2_source",
+            Halo2Source::Config { shape, config },
+        );
+        self
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn halo2_pk(mut self, halo2_pk: Halo2ProvingKey) -> Self {
+        Self::set_once(
+            &mut self.halo2_source,
+            "halo2_source",
+            Halo2Source::Pk(halo2_pk),
+        );
+        self
+    }
+
+    #[cfg(feature = "evm-prove")]
+    pub fn halo2_params_dir(mut self, params_dir: impl AsRef<Path>) -> Self {
+        Self::set_once(
+            &mut self.halo2_params_reader,
+            "halo2_params_reader",
+            CacheHalo2ParamsReader::new(params_dir),
+        );
+        self
     }
 }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use config::AppConfig;
-use getset::{Getters, MutGetters, WithSetters};
+use getset::Getters;
 use keygen::{AppProvingKey, AppVerifyingKey};
 use openvm_build::{
     build_guest_package, find_unique_executable, get_package, GuestOptions, TargetFilter,
@@ -27,9 +27,8 @@ use openvm_circuit::{
 };
 use openvm_sdk_config::{SdkVmConfig, SdkVmCpuBuilder, TranspilerConfig};
 use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, StarkEngine, SystemParams};
-use openvm_stark_sdk::config::{
-    baby_bear_poseidon2::{BabyBearPoseidon2CpuEngine as BabyBearPoseidon2Engine, Digest},
-    root_params_with_100_bits_security,
+use openvm_stark_sdk::config::baby_bear_poseidon2::{
+    BabyBearPoseidon2CpuEngine as BabyBearPoseidon2Engine, Digest,
 };
 #[cfg(feature = "evm-prove")]
 use openvm_static_verifier::StaticVerifierShape;
@@ -45,10 +44,7 @@ use openvm_verify_stark_host::{
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
     keygen::{dummy::compute_root_proof_heights, AggProvingKey, RootProvingKey},
-    prover::{
-        AggProver, AppProver, DeferralPathProver, DeferralProver, EvmProver, RootProver,
-        StarkProver,
-    },
+    prover::{AggProver, AppProver, DeferralPathProver, EvmProver, RootProver, StarkProver},
     types::ExecutableFormat,
 };
 #[cfg(feature = "evm-prove")]
@@ -68,6 +64,7 @@ cfg_if::cfg_if! {
 
 pub use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config as SC, F};
 
+pub mod builder;
 pub mod config;
 pub mod fs;
 #[cfg(feature = "evm-prove")]
@@ -97,31 +94,39 @@ pub const OPENVM_VERSION: &str = concat!(
 // BabyBearPoseidon2RootEngine right now.
 /// The SDK provides convenience methods and constructors for provers.
 ///
-/// The SDK is stateful to cache results of computations that depend only on the App VM config and
-/// aggregation config. The SDK will not cache any state that depends on the program executable.
+/// A built SDK is an immutable proving environment: user-supplied config, params, and pre-generated
+/// keys are fixed after construction. Use [`builder`](Self::builder) for advanced initialization,
+/// or [`new`](Self::new) / [`new_without_transpiler`](Self::new_without_transpiler) for the
+/// common config-driven paths.
+///
+/// Internally, the SDK lazily caches proving state that depends only on the app VM config,
+/// aggregation config, root params, and optional pre-generated keys. It does not cache any state
+/// that depends on the program executable.
 ///
 /// Some commonly used methods are:
 /// - [`execute`](Self::execute)
 /// - [`prove`](Self::prove)
 /// - [`verify_proof`](Self::verify_proof)
-#[derive(Getters, MutGetters, WithSetters)]
+#[derive(Getters)]
 pub struct GenericSdk<E, VB>
 where
     E: StarkEngine<SC = SC>,
     VB: VmBuilder<E>,
     VB::VmConfig: VmExecutionConfig<F>,
 {
-    #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
+    #[getset(get = "pub")]
     app_config: AppConfig<VB::VmConfig>,
-    #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
+    #[getset(get = "pub")]
     agg_config: AggregationConfig,
-    #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
+    #[getset(get = "pub")]
     agg_tree_config: AggregationTreeConfig,
+    #[getset(get = "pub")]
+    root_params: SystemParams,
     #[cfg(feature = "evm-prove")]
-    #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
+    #[getset(get = "pub")]
     halo2_shape: StaticVerifierShape,
     #[cfg(feature = "evm-prove")]
-    #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
+    #[getset(get = "pub")]
     halo2_config: config::Halo2Config,
 
     #[getset(get = "pub")]
@@ -142,7 +147,7 @@ where
     def_path_prover: Option<Arc<DeferralPathProver>>,
 
     #[cfg(feature = "evm-prove")]
-    #[getset(get = "pub", get_mut = "pub", set_with = "pub")]
+    #[getset(get = "pub")]
     halo2_params_reader: CacheHalo2ParamsReader,
     #[cfg(feature = "evm-prove")]
     halo2_prover: OnceLock<Halo2Prover>,
@@ -200,9 +205,11 @@ where
         VB: Default,
         VB::VmConfig: TranspilerConfig<F>,
     {
-        let transpiler = app_config.app_vm_config.transpiler();
-        let sdk = Self::new_without_transpiler(app_config, agg_params)?.with_transpiler(transpiler);
-        Ok(sdk)
+        Self::builder()
+            .app_config(app_config)
+            .agg_params(agg_params)
+            .default_transpiler()
+            .build()
     }
 
     /// **Note**: This function does not set the transpiler, which must be done separately to
@@ -214,65 +221,10 @@ where
     where
         VB: Default,
     {
-        let executor = VmExecutor::new(app_config.app_vm_config.clone())
-            .map_err(|e| SdkError::Vm(e.into()))?;
-        let agg_config = AggregationConfig { params: agg_params };
-        Ok(Self {
-            app_config,
-            agg_config,
-            agg_tree_config: Default::default(),
-            #[cfg(feature = "evm-prove")]
-            halo2_shape: StaticVerifierShape::default(),
-            #[cfg(feature = "evm-prove")]
-            halo2_config: config::Halo2Config {
-                wrapper_k: None,
-                profiling: false,
-            },
-            app_vm_builder: Default::default(),
-            transpiler: None,
-            executor,
-            app_pk: OnceLock::new(),
-            agg_prover: OnceLock::new(),
-            root_prover: OnceLock::new(),
-            def_path_prover: None,
-            #[cfg(feature = "evm-prove")]
-            halo2_params_reader: CacheHalo2ParamsReader::new_with_default_params_dir(),
-            #[cfg(feature = "evm-prove")]
-            halo2_prover: OnceLock::new(),
-            _phantom: Default::default(),
-        })
-    }
-
-    /// Enables deferrals in this GenericSdk. The DeferralProver must be created ahead of time
-    /// because the DeferralExtension should be created using DeferralProver::make_extension, as
-    /// it has the capability to generate def_vk_commits.
-    pub fn with_deferral_prover(mut self, deferral_prover: DeferralProver) -> Self {
-        assert!(
-            self.def_path_prover.is_none(),
-            "Deferral prover already defined"
-        );
-        assert!(
-            self.agg_prover.get().is_none(),
-            "Agg prover has already been initialized without deferrals"
-        );
-
-        let deferral_tree_config = AggregationTreeConfig {
-            num_children_leaf: 2,
-            num_children_internal: 2,
-        };
-        let agg_prover = AggProver::new(
-            deferral_prover.def_hook_prover.get_vk(),
-            self.agg_config.clone(),
-            deferral_tree_config,
-            Some(deferral_prover.def_hook_prover.get_cached_commit()),
-        );
-        let def_path_prover = DeferralPathProver {
-            deferral_prover: Arc::new(deferral_prover),
-            agg_prover: Arc::new(agg_prover),
-        };
-
-        self.def_path_prover = Some(Arc::new(def_path_prover));
-        self
+        Self::builder()
+            .app_config(app_config)
+            .agg_params(agg_params)
+            .build()
     }
 
     /// Returns the def_hook_prover cached commit.
@@ -323,13 +275,6 @@ where
         self.transpiler
             .as_ref()
             .ok_or(SdkError::TranspilerNotAvailable)
-    }
-    pub fn set_transpiler(&mut self, transpiler: Transpiler<F>) {
-        self.transpiler = Some(transpiler);
-    }
-    pub fn with_transpiler(mut self, transpiler: Transpiler<F>) -> Self {
-        self.set_transpiler(transpiler);
-        self
     }
 
     pub fn convert_to_exe(
@@ -553,9 +498,8 @@ where
     pub fn root_prover(&self) -> Arc<RootProver> {
         self.root_prover
             .get_or_init(|| {
-                // TODO[INT-6073]: store root_params
                 let system_config = self.app_config.app_vm_config.as_ref();
-                let root_params = root_params_with_100_bits_security();
+                let root_params = self.root_params.clone();
                 let app_pk = self.app_pk();
                 let agg_prover = self.agg_prover();
 
@@ -644,67 +588,11 @@ where
             AppProvingKey::keygen(self.app_config.clone()).expect("app_keygen failed")
         })
     }
-    /// Sets the app proving key. Returns `Ok(())` if app keygen has not been called and
-    /// `Err(app_pk)` if keygen has already been called.
-    pub fn set_app_pk(
-        &self,
-        app_pk: AppProvingKey<VB::VmConfig>,
-    ) -> Result<(), AppProvingKey<VB::VmConfig>> {
-        self.app_pk.set(app_pk)
-    }
-
-    /// See [`set_app_pk`](Self::set_app_pk). This should only be used in a constructor, and panics
-    /// if app keygen has already been called.
-    pub fn with_app_pk(self, app_pk: AppProvingKey<VB::VmConfig>) -> Self {
-        let _ = self
-            .set_app_pk(app_pk)
-            .map_err(|_| panic!("app_pk already set"));
-        self
-    }
 
     pub fn agg_keygen(&self) -> (AggProvingKey, MultiStarkVerifyingKey<SC>) {
         let pk = self.agg_pk();
         let vk = self.agg_vk().as_ref().clone();
         (pk, vk)
-    }
-
-    pub fn with_agg_pk(self, agg_pk: AggProvingKey) -> Self {
-        let app_pk = self.app_pk();
-        let _ = self
-            .agg_prover
-            .set(Arc::new(AggProver::from_pk(
-                Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()),
-                agg_pk,
-                self.agg_tree_config,
-                self.def_hook_cached_commit(),
-            )))
-            .map_err(|_| panic!("agg_pk already set"));
-        self
-    }
-
-    pub fn with_root_pk(self, root_pk: RootProvingKey) -> Self {
-        let system_config = self.app_config.app_vm_config.as_ref();
-        let memory_dimensions = system_config.memory_config.memory_dimensions();
-        let num_user_pvs = system_config.num_public_values;
-        let agg_prover = self.agg_prover();
-        let _ = self
-            .root_prover
-            .set(Arc::new(RootProver::from_pk(
-                agg_prover.internal_recursive_prover.get_vk(),
-                agg_prover
-                    .internal_recursive_prover
-                    .get_self_vk_pcs_data()
-                    .unwrap()
-                    .commitment
-                    .into(),
-                root_pk.root_pk,
-                memory_dimensions,
-                num_user_pvs,
-                self.def_hook_vk_commit(),
-                Some(root_pk.trace_heights),
-            )))
-            .map_err(|_| panic!("root_pk already set"));
-        self
     }
 
     pub fn root_pk(&self) -> RootProvingKey {
@@ -739,17 +627,6 @@ where
     #[cfg(feature = "evm-prove")]
     pub fn halo2_pk(&self) -> Halo2ProvingKey {
         self.halo2_prover().pk()
-    }
-
-    #[cfg(feature = "evm-prove")]
-    pub fn with_halo2_params_dir(mut self, params_dir: impl AsRef<Path>) -> Self {
-        self.set_halo2_params_dir(params_dir);
-        self
-    }
-
-    #[cfg(feature = "evm-prove")]
-    pub fn set_halo2_params_dir(&mut self, params_dir: impl AsRef<Path>) {
-        self.halo2_params_reader = CacheHalo2ParamsReader::new(params_dir);
     }
 
     // ======================== Verification Methods ========================

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -208,7 +208,6 @@ where
         Self::builder()
             .app_config(app_config)
             .agg_params(agg_params)
-            .default_transpiler()
             .build()
     }
 
@@ -224,7 +223,7 @@ where
         Self::builder()
             .app_config(app_config)
             .agg_params(agg_params)
-            .build()
+            .build_without_transpiler()
     }
 
     /// Returns the def_hook_prover cached commit.

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -159,7 +159,6 @@ fn test_verify_stark_deferral() -> Result<()> {
         .app_config(vs_app_config)
         .agg_params(agg_params)
         .deferral_prover(deferral_prover)
-        .default_transpiler()
         .build()?;
 
     // ---- Step 7: Build the verify-stark ELF ----
@@ -230,7 +229,6 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
         .app_config(AppConfig::riscv32(app_params))
         .agg_params(agg_params.clone())
         .deferral_prover(deferral_prover)
-        .default_transpiler()
         .build()?;
 
     let elf = Elf::decode(

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -155,7 +155,12 @@ fn test_verify_stark_deferral() -> Result<()> {
     vs_config.system.config.memory_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 25;
 
     let vs_app_config = AppConfig::new(vs_config, app_params);
-    let vs_sdk = Sdk::new(vs_app_config, agg_params)?.with_deferral_prover(deferral_prover);
+    let vs_sdk = Sdk::builder()
+        .app_config(vs_app_config)
+        .agg_params(agg_params)
+        .deferral_prover(deferral_prover)
+        .default_transpiler()
+        .build()?;
 
     // ---- Step 7: Build the verify-stark ELF ----
     let vs_elf = Elf::decode(
@@ -221,7 +226,12 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
     let deferral_prover = DeferralProver::new(verify_stark_prover, agg_config, hook_params);
 
     // ---- Step 2: Enable deferrals in SDK and prove ----
-    let sdk = Sdk::riscv32(app_params, agg_params.clone()).with_deferral_prover(deferral_prover);
+    let sdk = Sdk::builder()
+        .app_config(AppConfig::riscv32(app_params))
+        .agg_params(agg_params.clone())
+        .deferral_prover(deferral_prover)
+        .default_transpiler()
+        .build()?;
 
     let elf = Elf::decode(
         include_bytes!("../programs/examples/fibonacci.elf"),


### PR DESCRIPTION
Resolves INT-6955.

# PR Summary

Base branch: `develop-v2.0.0-beta`

## Overview

This PR makes `GenericSdk` immutable after construction and introduces a dedicated builder for all advanced SDK initialization. The main effect is a phase split:

- `GenericSdkBuilder` owns construction-time choices such as config vs pre-generated keys, transpiler setup, aggregation tree config, deferral prover setup, root params, and Halo2 setup.
- `GenericSdk` becomes a fixed proving environment with only internal lazy caches (`OnceLock`) mutating after `build()`.

The PR also updates CLI, tests, and one benchmark to use the builder instead of mutating an already-constructed `Sdk`.

## Suggested Review Order

1. `crates/sdk/src/builder.rs`
2. `crates/sdk/src/lib.rs`
3. `crates/cli/src/commands/{prove,run,commit}.rs`
4. `crates/sdk/src/tests.rs`
5. `benchmarks/prove/src/bin/keccak_par.rs`

## `crates/sdk`: immutable `GenericSdk` + new builder

Files:

- `crates/sdk/src/builder.rs`
- `crates/sdk/src/lib.rs`

What changed:

- Added `GenericSdkBuilder` as the construction-only API.
- The builder models each stage with a single source of truth:
  - app: `app_config(...)` or `app_pk(...)`
  - aggregation: `agg_params(...)` or `agg_pk(...)`
  - root: `root_params(...)` or `root_pk(..., trace_heights)`
  - Halo2: `halo2_config(...)` or `halo2_pk(...)`
- The builder also accepts:
  - `agg_tree_config(...)`
  - `transpiler(...)` / `default_transpiler()`
  - `deferral_prover(...)`
  - `halo2_params_dir(...)`
- `build()` normalizes config/key sources into the final `GenericSdk`, validates the pre-generated-key dependency chain, and seeds the SDK’s lazy caches from any prebuilt keys.
- `GenericSdk` is now getter-only for config/state fields; mutable getters and setter-style derives were removed.
- `Sdk::new(...)` and `Sdk::new_without_transpiler(...)` now delegate to the builder.
- `root_params` is now stored on `GenericSdk` and used by `root_prover()` instead of re-deriving default root params there.

Important removals from `GenericSdk`:

- `with_deferral_prover`
- `set_transpiler` / `with_transpiler`
- `set_app_pk` / `with_app_pk`
- `with_agg_pk`
- `with_root_pk`
- `set_halo2_params_dir` / `with_halo2_params_dir`

Reviewer focus:

- Verify the builder covers all existing initialization paths that previously relied on post-construction mutation.
- Check the dependency validation for pre-generated keys, especially `halo2_pk -> root_pk -> agg_pk -> app_pk`.
- Check that root prover construction now uses stored `root_params` consistently.
- Confirm that the remaining lazy caches are only internal and do not reintroduce public mutability.

## `crates/cli`: switch callers to builder-based initialization

Files:

- `crates/cli/src/commands/prove.rs`
- `crates/cli/src/commands/run.rs`
- `crates/cli/src/commands/commit.rs`

What changed:

- `prove` now constructs the SDK through the builder for all proof modes instead of building first and then attaching keys/config.
- The app proving key still has its segmentation config adjusted in-place before SDK construction, but that happens before `build()` via `configure_app_pk(...)`.
- STARK and EVM prove paths now explicitly load aggregation/root proving keys before building the SDK, instead of calling `with_agg_pk(...)` / `with_root_pk(...)` afterward.
- `run` now has two clean construction paths:
  - `pure`: config-driven `Sdk::new(...)`
  - `meter` / `segment`: builder path seeded with an existing `app_pk`
- `commit` now incrementally builds the SDK from available proving artifacts:
  - always starts from `app_pk`
  - uses `agg_pk` if present, otherwise falls back to default aggregation params
  - uses `root_pk` if present

Reviewer focus:

- Check that each CLI mode still loads the same artifacts as before.
- Verify that the order of key loading now matches the builder’s invariants.
- Confirm there are no remaining CLI call sites that rely on mutating a built `Sdk`.

## Tests and benchmark updates

Files:

- `crates/sdk/src/tests.rs`
- `benchmarks/prove/src/bin/keccak_par.rs`

What changed:

- The SDK deferral tests now construct deferral-enabled SDKs through the builder.
- The parallel Keccak benchmark now creates per-thread SDKs from a shared `app_pk` through the builder, instead of constructing from config and setting the proving key afterward.

Reviewer focus:

- These changes are mostly migration-only. Verify they preserve the previous setup semantics while using the new construction model.
