### PR TITLE
ci: cache guest build artifacts

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -7,11 +7,11 @@ on:
   pull_request:
     branches: ["**"]
     paths:
-      - "crates/circuits/**"
-      - "crates/vm/**"
-      - "crates/toolchain/**"
+#      - "crates/circuits/**"
+#      - "crates/vm/**"
+#      - "crates/toolchain/**"
       - "extensions/**"
-      - "Cargo.toml"
+#      - "Cargo.toml"
       - ".github/workflows/extension-tests.yml"
 
 concurrency:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -7,11 +7,11 @@ on:
   pull_request:
     branches: ["**"]
     paths:
-#     - "crates/circuits/**"
-#     - "crates/vm/**"
-#     - "crates/toolchain/**"
+      - "crates/circuits/**"
+      - "crates/vm/**"
+      - "crates/toolchain/**"
       - "extensions/**"
-#     - "Cargo.toml"
+      - "Cargo.toml"
       - ".github/workflows/extension-tests.yml"
 
 concurrency:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -7,14 +7,14 @@ on:
   pull_request:
     branches: ["**"]
     paths:
-      - "crates/circuits/**"
-      - "crates/vm/**"
-      - "crates/toolchain/**"
-      - "extensions/**"
+#      - "crates/circuits/**"
+#      - "crates/vm/**"
+#      - "crates/toolchain/**"
+#      - "extensions/**"
       - "guest-libs/**"
-      - "Cargo.toml"
+#      - "Cargo.toml"
       - ".github/workflows/guest-lib-tests.yml"
-      - "crates/sdk/guest/fib/**"
+#      - "crates/sdk/guest/fib/**"
 
 concurrency:
   group: ${{ github.workflow_ref }}-guest-lib-tests-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -34,7 +34,7 @@ jobs:
           - { name: "ff_derive", path: "ff_derive", runner: "64cpu-linux-x64" }
           - { name: "k256", path: "k256", runner: "64cpu-linux-x64" }
           - { name: "p256", path: "p256", runner: "64cpu-linux-x64" }
-          - { name: "ruint", path: "ruint", runner: "96cpu-linux-x64" }
+          - { name: "ruint", path: "ruint", runner: "64cpu-linux-x64" }
           - { name: "pairing", path: "pairing", runner: "64cpu-linux-x64" }
           - { name: "verify-stark", path: "verify-stark/circuit", runner: "64cpu-linux-x64" }
       # Ensure tests run in parallel even if one fails

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -7,14 +7,14 @@ on:
   pull_request:
     branches: ["**"]
     paths:
-#     - "crates/circuits/**"
-#     - "crates/vm/**"
-#     - "crates/toolchain/**"
-#     - "extensions/**"
+      - "crates/circuits/**"
+      - "crates/vm/**"
+      - "crates/toolchain/**"
+      - "extensions/**"
       - "guest-libs/**"
-#     - "Cargo.toml"
+      - "Cargo.toml"
       - ".github/workflows/guest-lib-tests.yml"
-#     - "crates/sdk/guest/fib/**"
+      - "crates/sdk/guest/fib/**"
 
 concurrency:
   group: ${{ github.workflow_ref }}-guest-lib-tests-${{ github.event.pull_request.number || github.sha }}
@@ -29,21 +29,19 @@ jobs:
     strategy:
       matrix:
         crate:
-          - { name: "sha2", path: "sha2" }
-          - { name: "keccak256", path: "keccak256" }
-          - { name: "ff_derive", path: "ff_derive" }
-          - { name: "k256", path: "k256" }
-          - { name: "p256", path: "p256" }
-          - { name: "ruint", path: "ruint" }
-          - { name: "pairing", path: "pairing" }
-          - { name: "verify-stark", path: "verify-stark/circuit" }
-        platform:
-          - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
+          - { name: "sha2", path: "sha2", runner: "64cpu-linux-x64" }
+          - { name: "keccak256", path: "keccak256", runner: "64cpu-linux-x64" }
+          - { name: "ff_derive", path: "ff_derive", runner: "64cpu-linux-x64" }
+          - { name: "k256", path: "k256", runner: "64cpu-linux-x64" }
+          - { name: "p256", path: "p256", runner: "64cpu-linux-x64" }
+          - { name: "ruint", path: "ruint", runner: "96cpu-linux-x64" }
+          - { name: "pairing", path: "pairing", runner: "64cpu-linux-x64" }
+          - { name: "verify-stark", path: "verify-stark/circuit", runner: "64cpu-linux-x64" }
       # Ensure tests run in parallel even if one fails
       fail-fast: false
 
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.crate.runner }}/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -74,8 +72,8 @@ jobs:
         working-directory: guest-libs/${{ matrix.crate.path }}
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
-          PAIRING_FEATURE_ARGS=""
+          EXTRA_ARGS=""
           if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
-            PAIRING_FEATURE_ARGS="--features=bn254,bls12_381,aot"
+            EXTRA_ARGS="--features=bn254,bls12_381,aot -E 'not test(fallback)'"
           fi
-          cargo nextest run --cargo-profile=fast $PAIRING_FEATURE_ARGS --no-tests=pass --test-threads=1
+          eval cargo nextest run --cargo-profile=fast $EXTRA_ARGS --no-tests=pass --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6092,7 +6092,6 @@ dependencies = [
  "eyre",
  "openvm-build",
  "openvm-transpiler",
- "tempfile",
  "tracing",
  "tracing-subscriber 0.3.23",
 ]
@@ -7256,7 +7255,6 @@ dependencies = [
  "openvm-transpiler",
  "rand 0.9.2",
  "serde",
- "tempfile",
  "test-case",
 ]
 

--- a/benchmarks/utils/Cargo.toml
+++ b/benchmarks/utils/Cargo.toml
@@ -14,7 +14,6 @@ openvm-transpiler.workspace = true
 cargo_metadata.workspace = true
 clap = { version = "4.5.9", features = ["derive", "env"] }
 eyre.workspace = true
-tempfile.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/benchmarks/utils/src/lib.rs
+++ b/benchmarks/utils/src/lib.rs
@@ -7,7 +7,6 @@ use cargo_metadata::Package;
 use eyre::Result;
 use openvm_build::{build_guest_package, get_package, guest_methods, GuestOptions};
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE};
-use tempfile::tempdir;
 
 pub fn get_fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../fixtures")
@@ -27,38 +26,32 @@ pub fn build_elf_with_path(
     profile: impl ToString,
     elf_path: Option<&PathBuf>,
 ) -> Result<Elf> {
-    // Use a temporary directory for the build
-    let temp_dir = tempdir()?;
-    let target_dir = temp_dir.path();
+    let guest_opts = GuestOptions::default().with_profile(profile.to_string());
 
-    // Build guest with default features
-    let guest_opts = GuestOptions::default()
-        .with_target_dir(target_dir)
-        .with_profile(profile.to_string());
+    let output_dir = match build_guest_package(pkg, &guest_opts, None, &None) {
+        Ok(dir) => dir,
+        Err(Some(code)) => std::process::exit(code),
+        Err(None) => eyre::bail!("Guest build was skipped"),
+    };
 
-    if let Err(Some(code)) = build_guest_package(pkg, &guest_opts, None, &None) {
-        std::process::exit(code);
-    }
-
-    // Assumes the package has a single target binary
-    let temp_elf_path = guest_methods(pkg, target_dir, &guest_opts.features, &guest_opts.profile)
+    let target_dir = output_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("Could not determine target dir from output path");
+    let built_elf_path = guest_methods(pkg, target_dir, &guest_opts.features, &guest_opts.profile)
         .pop()
         .unwrap();
 
-    // If an elf_path is provided, copy the built ELF to that location
     if let Some(dest_path) = elf_path {
-        // Create parent directories if they don't exist
         if let Some(parent) = dest_path.parent() {
             if !parent.exists() {
                 std::fs::create_dir_all(parent)?;
             }
         }
-
-        // Copy the built ELF to the destination
-        std::fs::copy(&temp_elf_path, dest_path)?;
+        std::fs::copy(&built_elf_path, dest_path)?;
     }
 
-    read_elf_file(&temp_elf_path)
+    read_elf_file(&built_elf_path)
 }
 
 pub fn get_elf_path(manifest_dir: &PathBuf) -> PathBuf {

--- a/crates/toolchain/tests/Cargo.toml
+++ b/crates/toolchain/tests/Cargo.toml
@@ -12,7 +12,6 @@ openvm-build.workspace = true
 openvm-circuit.workspace = true
 openvm-transpiler.workspace = true
 eyre.workspace = true
-tempfile.workspace = true
 
 [dev-dependencies]
 openvm-stark-backend.workspace = true

--- a/crates/toolchain/tests/src/lib.rs
+++ b/crates/toolchain/tests/src/lib.rs
@@ -4,12 +4,9 @@ use std::{
 };
 
 use eyre::{Context, Result};
-use openvm_build::{
-    build_guest_package, get_dir_with_profile, get_package, GuestOptions, TargetFilter,
-};
+use openvm_build::{build_guest_package, get_package, GuestOptions, TargetFilter};
 use openvm_circuit::arch::{InitFileGenerator, OPENVM_DEFAULT_INIT_FILE_BASENAME};
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE};
-use tempfile::tempdir;
 
 #[macro_export]
 macro_rules! get_programs_dir {
@@ -67,11 +64,7 @@ pub fn build_example_program_at_path_with_features<S: AsRef<str>>(
     init_config: &impl InitFileGenerator,
 ) -> Result<Elf> {
     let pkg = get_package(&manifest_dir);
-    let target_dir = tempdir()?;
-    // Build guest with default features
-    let guest_opts = GuestOptions::default()
-        .with_features(features.clone())
-        .with_target_dir(target_dir.path());
+    let guest_opts = GuestOptions::default().with_features(features.clone());
     let features = features
         .into_iter()
         .map(|x| x.as_ref().to_string())
@@ -87,7 +80,7 @@ pub fn build_example_program_at_path_with_features<S: AsRef<str>>(
             "{OPENVM_DEFAULT_INIT_FILE_BASENAME}_{example_name}{features_str}.rs"
         )),
     )?;
-    if let Err(Some(code)) = build_guest_package(
+    let output_dir = match build_guest_package(
         &pkg,
         &guest_opts,
         None,
@@ -96,21 +89,11 @@ pub fn build_example_program_at_path_with_features<S: AsRef<str>>(
             kind: "example".to_string(),
         }),
     ) {
-        std::process::exit(code);
-    }
-    // Assumes the package has a single target binary
-    let profile = "release";
-    let elf_path = pkg
-        .targets
-        .iter()
-        .find(|target| target.name == example_name)
-        .map(|target| {
-            get_dir_with_profile(&target_dir, profile, true)
-                .join(&target.name)
-                .to_path_buf()
-        })
-        .expect("Could not find target binary");
+        Ok(dir) => dir,
+        Err(Some(code)) => std::process::exit(code),
+        Err(None) => eyre::bail!("Guest build was skipped"),
+    };
+    let elf_path = output_dir.join(example_name);
     let data = read(&elf_path).with_context(|| format!("Path not found: {elf_path:?}"))?;
-    target_dir.close()?;
     Elf::decode(&data, MEM_SIZE as u32)
 }

--- a/scripts/clean-guest-builds.sh
+++ b/scripts/clean-guest-builds.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Remove cached guest build artifacts from the workspace target directory.
+# Guest builds target riscv32im-risc0-zkvm-elf and store transpiled output under openvm/.
+#
+# Usage: ./scripts/clean-guest-builds.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TARGET_DIR="${REPO_ROOT}/target"
+
+dirs_to_clean=(
+    "${TARGET_DIR}/riscv32im-risc0-zkvm-elf"
+    "${TARGET_DIR}/openvm"
+)
+
+for dir in "${dirs_to_clean[@]}"; do
+    if [ -d "$dir" ]; then
+        echo "Removing $dir"
+        rm -rf "$dir"
+    fi
+done
+
+echo "Guest build cache cleaned."

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -2,6 +2,9 @@
 # Local pre-CI check: runs fmt, clippy, and tests only on crates changed vs a target branch.
 # Usage: ./scripts/pre-push.sh [target-branch]  (default: develop-v2.0.0-beta)
 #
+# Guest program builds are cached in target/ for fast re-runs.
+# To reclaim disk space: ./scripts/clean-guest-builds.sh
+#
 # To install as a git pre-push hook:
 #
 #   ln -sf ../../scripts/pre-push.sh .git/hooks/pre-push


### PR DESCRIPTION
# PR Summary: Cache guest build artifacts

## Overview

Guest program builds previously created a fresh `tempdir()` for every invocation, preventing Cargo from caching compiled artifacts (the `riscv32im` std lib, dependencies, etc.). This PR removes the temp directory usage so builds go to the workspace's default `target/` directory, which is automatically picked up by `rust-cache` in CI. It also fixes several CI workflow issues.

## Changes

### 1. `benchmarks/utils/src/lib.rs` — Remove tempdir in benchmark ELF builds

- **Removed** `tempfile` dependency and `tempdir()` usage from `build_elf_with_path`.
- The function now relies on `build_guest_package` returning the output directory (which defaults to the workspace `target/` when no `target_dir` is set in `GuestOptions`).
- The `target_dir` needed by `guest_methods()` is derived by walking up two parents from the returned output path instead of being explicitly set.

### 2. `crates/toolchain/tests/src/lib.rs` — Remove tempdir in test ELF builds

- **Removed** `tempfile` dependency and `tempdir()` usage from `build_example_program_at_path_with_features`.
- Instead of manually locating the ELF via `get_dir_with_profile`, uses the output directory returned by `build_guest_package` directly (appending the example name).
- Both call sites now handle the updated `build_guest_package` return type (`Result<PathBuf, Option<i32>>`) with a match that also handles the `Err(None)` (build skipped) case.

### 3. `Cargo.lock`, `benchmarks/utils/Cargo.toml`, `crates/toolchain/tests/Cargo.toml`

- Removed `tempfile` dependency from both crates (no longer needed).

### 4. `scripts/clean-guest-builds.sh` (new file)

- Utility script to remove cached guest build artifacts (`target/riscv32im-risc0-zkvm-elf/` and `target/openvm/`) for reclaiming disk space.

### 5. `scripts/pre-push.sh`

- Added a comment pointing users to `clean-guest-builds.sh` for disk space reclamation.

### 6. `.github/workflows/extension-tests.yml`

- **Uncommented** path filters (`crates/circuits/**`, `crates/vm/**`, `crates/toolchain/**`, `Cargo.toml`) that were previously disabled. This restores proper path-based triggering so the workflow runs when upstream crate changes land, not only on `extensions/**` changes.

### 7. `.github/workflows/guest-lib-tests.yml`

- **Uncommented** path filters (same set as above, plus `crates/sdk/guest/fib/**`).
- **Flattened the matrix**: moved `runner` from a separate `platform` axis into each `crate` entry, allowing per-crate runner selection. 
- **Pairing test filter**: added `-E 'not test(fallback)'` to skip fallback tests on CPU runners, and uses `eval` to correctly expand the filter expression.

