### PR TITLE
fix(ci): use bash array for nextest args in guest-lib-tests

### DIFF
--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -73,9 +73,7 @@ jobs:
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
           EXTRA_ARGS=()
-          if [[ "${{ matrix.crate.name }}" == "sha2" || "${{ matrix.crate.name }}" == "keccak256" ]]; then
-            EXTRA_ARGS+=(--features=aot)
-          elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+          if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381,aot -E 'not test(fallback)')
           fi
 

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -72,8 +72,11 @@ jobs:
         working-directory: guest-libs/${{ matrix.crate.path }}
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
-          EXTRA_ARGS=""
-          if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
-            EXTRA_ARGS="--features=bn254,bls12_381,aot -E 'not test(fallback)'"
+          EXTRA_ARGS=()
+          if [[ "${{ matrix.crate.name }}" == "sha2" || "${{ matrix.crate.name }}" == "keccak256" ]]; then
+            EXTRA_ARGS+=(--features=aot)
+          elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+            EXTRA_ARGS+=(--features=bn254,bls12_381,aot -E 'not test(fallback)')
           fi
-          eval cargo nextest run --cargo-profile=fast $EXTRA_ARGS --no-tests=pass --test-threads=1
+
+          cargo nextest run --cargo-profile=fast "${EXTRA_ARGS[@]}" --no-tests=pass --test-threads=1


### PR DESCRIPTION
## Summary
- Fixes broken `pairing` job in guest-lib-tests CI by using a bash array for `EXTRA_ARGS` instead of a plain string
- Unquoted `$EXTRA_ARGS` word-splits `-E 'not test(fallback)'` into `'not` and `test(fallback)'`, causing nextest to fail with "failed to parse filterset"

## Test plan
- [ ] Verify the `pairing` matrix job in guest-lib-tests CI passes on this PR