### PR TITLE
fix(v2.1): projective partialeq implementation in impl_sw_proj

### DIFF
--- a/extensions/ecc/guest/src/weierstrass.rs
+++ b/extensions/ecc/guest/src/weierstrass.rs
@@ -247,13 +247,22 @@ macro_rules! impl_sw_proj {
     ($struct_name:ident, $field:ty, $b:expr) => {
         /// A projective point on a short Weierstrass curve, implementing elliptic curve operations
         /// using complete formulas from [ePrint 2015/1060](https://eprint.iacr.org/2015/1060).
-        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
         #[repr(C)]
         pub struct $struct_name {
             pub x: $field,
             pub y: $field,
             pub z: $field,
         }
+
+        impl core::cmp::PartialEq for $struct_name {
+            fn eq(&self, other: &Self) -> bool {
+                (&self.x * &other.z) == (&other.x * &self.z)
+                    && (&self.y * &other.z) == (&other.y * &self.z)
+            }
+        }
+
+        impl core::cmp::Eq for $struct_name {}
 
         impl $struct_name {
             pub const fn new(x: $field, y: $field, z: $field) -> Self {


### PR DESCRIPTION
## Summary

- Fix `PartialEq` for projective points in `impl_sw_proj` macro to use mathematically correct equality: two projective points `(X1:Y1:Z1)` and `(X2:Y2:Z2)` are equal iff `X1*Z2 == X2*Z1` and `Y1*Z2 == Y2*Z1`, instead of the derived field-by-field comparison which is incorrect for projective coordinates.

## Changes

- `extensions/ecc/guest/src/weierstrass.rs`: Replaced `derive(PartialEq, Eq)` with a manual `PartialEq` impl that performs cross-multiplication checks, and a manual `Eq` impl.
