### PR TITLE
chore: split app-dependent and independent fields in agg pk

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -70,8 +70,8 @@ pub struct ProvingKeyArgs {
     #[arg(
         long,
         action,
-        help = "Path to aggregation proving key, by default will be ${openvm_dir}/agg.pk",
+        help = "Path to aggregation prefix proving key, by default will be ${openvm_dir}/agg_prefix.pk",
         help_heading = "OpenVM Options"
     )]
-    pub agg_pk: Option<PathBuf>,
+    pub agg_prefix_pk: Option<PathBuf>,
 }

--- a/crates/cli/src/bin/cargo-openvm.rs
+++ b/crates/cli/src/bin/cargo-openvm.rs
@@ -30,7 +30,6 @@ pub enum VmCliCommands {
     Init(InitCmd),
     Prove(ProveCmd),
     Run(RunCmd),
-    #[cfg(feature = "evm-verify")]
     Setup(SetupCmd),
     Verify(VerifyCmd),
 }
@@ -53,7 +52,6 @@ async fn main() -> Result<()> {
         VmCliCommands::Init(cmd) => cmd.run(),
         VmCliCommands::Prove(cmd) => cmd.run(),
         VmCliCommands::Run(cmd) => cmd.run(),
-        #[cfg(feature = "evm-verify")]
         VmCliCommands::Setup(cmd) => cmd.run().await,
         VmCliCommands::Verify(cmd) => cmd.run(),
     }

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -13,10 +13,7 @@ use openvm_sdk::{
 };
 use p3_bn254::Bn254;
 
-use super::{
-    prove::load_required_agg_pk,
-    RunArgs, RunCargoArgs
-};
+use super::{prove::load_required_agg_pk, RunArgs, RunCargoArgs};
 use crate::{
     args::{OpenVmConfigArgs, ProvingKeyArgs},
     commands::{load_app_pk, load_or_build_exe, ExecutionMode},
@@ -66,10 +63,7 @@ impl CommitCmd {
         let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
 
         let agg_pk = load_required_agg_pk(&self.keys.agg_prefix_pk, &self.cargo_args)?;
-        let sdk = Sdk::builder()
-            .app_pk(app_pk)
-            .agg_pk(agg_pk)
-            .build()?;
+        let sdk = Sdk::builder().app_pk(app_pk).agg_pk(agg_pk).build()?;
 
         let prover = sdk.prover(exe)?;
         let baseline = prover.generate_baseline();

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -7,20 +7,22 @@ use clap::Parser;
 use eyre::{Context, Result};
 use openvm_continuations::CommitBytes;
 use openvm_sdk::{
-    config::AggregationSystemParams,
-    fs::{read_object_from_file, write_object_to_file, write_to_file_json},
+    fs::write_to_file_json,
     types::{AppExecutionCommit, VerificationBaselineJson},
     Sdk,
 };
 use p3_bn254::Bn254;
 
-use super::{RunArgs, RunCargoArgs};
+use super::{
+    prove::load_required_agg_pk,
+    RunArgs, RunCargoArgs
+};
 use crate::{
-    args::OpenVmConfigArgs,
+    args::{OpenVmConfigArgs, ProvingKeyArgs},
     commands::{load_app_pk, load_or_build_exe, ExecutionMode},
     util::{
-        get_agg_pk_path, get_agg_vk_path, get_app_baseline_path, get_app_commit_path,
-        get_manifest_path_and_dir, get_single_target_name, get_target_dir, get_target_output_dir,
+        get_app_baseline_path, get_app_commit_path, get_manifest_path_and_dir,
+        get_single_target_name, get_target_dir, get_target_output_dir,
     },
 };
 
@@ -33,18 +35,13 @@ pub struct CommitCmd {
     #[arg(
         long,
         action,
-        help = "Path to app proving key, by default will be ${openvm_dir}/app.pk",
-        help_heading = "OpenVM Options"
-    )]
-    pub app_pk: Option<PathBuf>,
-
-    #[arg(
-        long,
-        action,
         help = "Path to OpenVM executable, if specified build will be skipped",
         help_heading = "OpenVM Options"
     )]
     pub exe: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub keys: ProvingKeyArgs,
 
     #[clap(flatten)]
     pub openvm_config: OpenVmConfigArgs,
@@ -55,7 +52,7 @@ pub struct CommitCmd {
 
 impl CommitCmd {
     pub fn run(&self) -> Result<()> {
-        let app_pk = load_app_pk(&self.app_pk, &self.cargo_args)?;
+        let app_pk = load_app_pk(&self.keys.app_pk, &self.cargo_args)?;
 
         let run_args = RunArgs {
             exe: self.exe.clone(),
@@ -68,18 +65,11 @@ impl CommitCmd {
             get_manifest_path_and_dir(&self.cargo_args.manifest.manifest_path)?;
         let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
 
-        let mut builder = Sdk::builder().app_pk(app_pk);
-        let agg_pk_path = get_agg_pk_path(&target_dir);
-        if agg_pk_path.exists() {
-            builder = builder.agg_pk(read_object_from_file(&agg_pk_path)?);
-        } else {
-            builder = builder.agg_params(AggregationSystemParams::default());
-        }
-        let root_pk_path = PathBuf::from(crate::default::default_root_pk_path());
-        if root_pk_path.exists() {
-            builder = builder.root_pk(read_object_from_file(&root_pk_path)?);
-        }
-        let sdk = builder.build()?;
+        let agg_pk = load_required_agg_pk(&self.keys.agg_prefix_pk, &self.cargo_args)?;
+        let sdk = Sdk::builder()
+            .app_pk(app_pk)
+            .agg_pk(agg_pk)
+            .build()?;
 
         let prover = sdk.prover(exe)?;
         let baseline = prover.generate_baseline();
@@ -93,27 +83,6 @@ impl CommitCmd {
         let vk_commit_bn254 = Bn254::from(app_commit.app_vk_commit);
         println!("exe commit: {:?}", exe_commit_bn254);
         println!("vk commit: {:?}", vk_commit_bn254);
-
-        // Save keys for reuse
-        let agg_vk_path = get_agg_vk_path(&target_dir);
-        if !agg_pk_path.exists() {
-            println!(
-                "Writing aggregation proving key to {}",
-                agg_pk_path.display()
-            );
-            write_object_to_file(&agg_pk_path, sdk.agg_pk())?;
-        }
-        if !agg_vk_path.exists() {
-            println!(
-                "Writing aggregation verifying key to {}",
-                agg_vk_path.display()
-            );
-            write_object_to_file(&agg_vk_path, sdk.agg_vk().as_ref().clone())?;
-        }
-        if !root_pk_path.exists() {
-            println!("Writing root proving key to {}", root_pk_path.display());
-            write_object_to_file(&root_pk_path, sdk.root_pk())?;
-        }
 
         let target_output_dir = get_target_output_dir(&target_dir, &self.cargo_args.profile);
 

--- a/crates/cli/src/commands/keygen.rs
+++ b/crates/cli/src/commands/keygen.rs
@@ -10,12 +10,12 @@ use openvm_sdk::{config::AggregationSystemParams, fs::write_object_to_file, Sdk}
 use crate::{
     args::ManifestArgs,
     default::{
-        DEFAULT_AGG_PK_NAME, DEFAULT_AGG_VK_NAME, DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME,
+        default_app_config, DEFAULT_AGG_PREFIX_PK_NAME, DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME,
         OPENVM_CONFIG_FILENAME,
     },
     util::{
-        get_agg_pk_path, get_agg_vk_path, get_app_pk_path, get_app_vk_path,
-        get_manifest_path_and_dir, get_target_dir, read_config_toml_or_default,
+        get_agg_prefix_pk_path, get_app_pk_path, get_app_vk_path, get_manifest_path_and_dir,
+        get_target_dir, read_config_toml_or_default,
     },
 };
 
@@ -38,7 +38,7 @@ pub struct KeygenCmd {
 
     #[arg(
         long,
-        help = "Only generate app keys (app.pk/app.vk), skip aggregation keys (agg.pk/agg.vk)",
+        help = "Only generate app keys (app.pk/app.vk), skip the aggregation prefix proving key (agg_prefix.pk)",
         help_heading = "OpenVM Options"
     )]
     app_only: bool,
@@ -60,8 +60,7 @@ impl KeygenCmd {
         let target_dir = get_target_dir(&self.cargo_args.manifest.target_dir, &manifest_path);
         let app_pk_path = get_app_pk_path(&target_dir);
         let app_vk_path = get_app_vk_path(&target_dir);
-        let agg_pk_path = get_agg_pk_path(&target_dir);
-        let agg_vk_path = get_agg_vk_path(&target_dir);
+        let agg_prefix_pk_path = get_agg_prefix_pk_path(&target_dir);
 
         keygen(
             self.config
@@ -69,8 +68,7 @@ impl KeygenCmd {
                 .unwrap_or_else(|| manifest_dir.join(OPENVM_CONFIG_FILENAME)),
             &app_pk_path,
             &app_vk_path,
-            &agg_pk_path,
-            &agg_vk_path,
+            &agg_prefix_pk_path,
             self.output_dir.as_ref(),
             !self.app_only,
         )?;
@@ -79,7 +77,7 @@ impl KeygenCmd {
             if self.app_only {
                 "app pk and vk"
             } else {
-                "app/agg pk and vk"
+                "app pk/vk and agg_prefix pk"
             },
             if let Some(output_dir) = self.output_dir.as_ref() {
                 output_dir.display()
@@ -95,20 +93,18 @@ pub(crate) fn keygen(
     config: impl AsRef<Path>,
     app_pk_path: impl AsRef<Path>,
     app_vk_path: impl AsRef<Path>,
-    agg_pk_path: impl AsRef<Path>,
-    agg_vk_path: impl AsRef<Path>,
+    agg_prefix_pk_path: impl AsRef<Path>,
     output_dir: Option<impl AsRef<Path>>,
     generate_agg: bool,
 ) -> Result<()> {
     let app_config = read_config_toml_or_default(config)?;
+    assert_default_root_shape(&app_config);
     let sdk = Sdk::new(app_config, AggregationSystemParams::default())?;
     let (app_pk, app_vk) = sdk.app_keygen();
     write_object_to_file(&app_vk_path, app_vk)?;
     write_object_to_file(&app_pk_path, app_pk)?;
     if generate_agg {
-        let (agg_pk, agg_vk) = sdk.agg_keygen();
-        write_object_to_file(&agg_pk_path, agg_pk)?;
-        write_object_to_file(&agg_vk_path, agg_vk)?;
+        write_object_to_file(&agg_prefix_pk_path, sdk.agg_prefix_pk())?;
     }
 
     if let Some(output_dir) = output_dir {
@@ -120,12 +116,33 @@ pub(crate) fn keygen(
         copy(&app_vk_path, output_dir.join(DEFAULT_APP_VK_NAME))
             .with_context(|| format!("failed to copy app vk to {}", output_dir.display()))?;
         if generate_agg {
-            copy(&agg_pk_path, output_dir.join(DEFAULT_AGG_PK_NAME))
-                .with_context(|| format!("failed to copy agg pk to {}", output_dir.display()))?;
-            copy(&agg_vk_path, output_dir.join(DEFAULT_AGG_VK_NAME))
-                .with_context(|| format!("failed to copy agg vk to {}", output_dir.display()))?;
+            copy(
+                &agg_prefix_pk_path,
+                output_dir.join(DEFAULT_AGG_PREFIX_PK_NAME),
+            )
+            .with_context(|| format!("failed to copy agg prefix pk to {}", output_dir.display()))?;
         }
     }
 
     Ok(())
+}
+
+fn assert_default_root_shape(
+    app_config: &openvm_sdk::config::AppConfig<openvm_sdk_config::SdkVmConfig>,
+) {
+    let default_system_config = default_app_config().app_vm_config;
+    let actual_system_config = app_config.app_vm_config.as_ref();
+    let default_system_config = default_system_config.as_ref();
+
+    assert_eq!(
+        actual_system_config.num_public_values, default_system_config.num_public_values,
+        "cargo openvm keygen only supports the default num_public_values"
+    );
+    let actual_memory_dimensions = actual_system_config.memory_config.memory_dimensions();
+    let default_memory_dimensions = default_system_config.memory_config.memory_dimensions();
+    assert!(
+        actual_memory_dimensions.addr_space_height == default_memory_dimensions.addr_space_height
+            && actual_memory_dimensions.address_height == default_memory_dimensions.address_height,
+        "cargo openvm keygen only supports the default memory_dimensions"
+    );
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -16,9 +16,7 @@ pub use prove::*;
 mod run;
 pub use run::*;
 
-#[cfg(feature = "evm-verify")]
 mod setup;
-#[cfg(feature = "evm-verify")]
 pub use setup::*;
 
 mod verify;

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -14,21 +14,22 @@ use openvm_sdk::keygen::RootProvingKey;
 use openvm_sdk::{
     config::{AggregationSystemParams, AggregationTreeConfig},
     fs::{read_object_from_file, write_object_to_file, write_to_file_json},
-    keygen::{AggProvingKey, AppProvingKey},
+    keygen::{AggPrefixProvingKey, AggProvingKey, AppProvingKey},
     types::{AppExecutionCommit, VerificationBaselineJson, VersionedNonRootStarkProof},
-    Sdk, F,
+    Sdk, F, SC,
 };
 use openvm_sdk_config::SdkVmConfig;
+use openvm_stark_backend::keygen::types::MultiStarkProvingKey;
 use p3_bn254::Bn254;
 
 use super::{RunArgs, RunCargoArgs};
 use crate::{
     args::ProvingKeyArgs,
     commands::build,
-    default::{APP_PROOF_EXT, STARK_PROOF_EXT, VMEXE_EXT},
+    default::{default_internal_recursive_pk_path, APP_PROOF_EXT, STARK_PROOF_EXT, VMEXE_EXT},
     input::read_to_stdin,
     util::{
-        get_agg_pk_path, get_app_baseline_path, get_app_pk_path, get_manifest_path_and_dir,
+        get_agg_prefix_pk_path, get_app_baseline_path, get_app_pk_path, get_manifest_path_and_dir,
         get_single_target_name, get_target_dir, get_target_output_dir,
     },
 };
@@ -184,7 +185,7 @@ impl ProveCmd {
                 let mut app_pk = load_app_pk(&keys.app_pk, cargo_args)?;
                 let (exe, target_name) = load_or_build_exe(run_args, cargo_args)?;
                 configure_app_pk(&mut app_pk, segmentation_args);
-                let agg_pk = load_required_agg_pk(&keys.agg_pk, cargo_args)?;
+                let agg_pk = load_required_agg_pk(&keys.agg_prefix_pk, cargo_args)?;
                 let sdk = Sdk::builder()
                     .app_pk(app_pk)
                     .agg_pk(agg_pk)
@@ -241,7 +242,7 @@ impl ProveCmd {
 
                 println!("Generating EVM proof, this may take a lot of compute and memory...");
                 configure_app_pk(&mut app_pk, segmentation_args);
-                let agg_pk = load_required_agg_pk(&keys.agg_pk, cargo_args)?;
+                let agg_pk = load_required_agg_pk(&keys.agg_prefix_pk, cargo_args)?;
                 let root_pk = load_required_root_pk()?;
                 let sdk = Sdk::builder()
                     .app_pk(app_pk)
@@ -328,24 +329,49 @@ fn target_dir_from_cargo_args(cargo_args: &RunCargoArgs) -> Result<PathBuf> {
     ))
 }
 
-fn resolve_agg_pk_path(agg_pk: &Option<PathBuf>, cargo_args: &RunCargoArgs) -> Result<PathBuf> {
-    if let Some(agg_pk) = agg_pk {
-        Ok(agg_pk.to_path_buf())
+fn resolve_agg_prefix_pk_path(
+    agg_prefix_pk: &Option<PathBuf>,
+    cargo_args: &RunCargoArgs,
+) -> Result<PathBuf> {
+    if let Some(agg_prefix_pk) = agg_prefix_pk {
+        Ok(agg_prefix_pk.to_path_buf())
     } else {
         let target_dir = target_dir_from_cargo_args(cargo_args)?;
-        Ok(get_agg_pk_path(&target_dir))
+        Ok(get_agg_prefix_pk_path(&target_dir))
     }
 }
 
-fn load_required_agg_pk(
-    agg_pk: &Option<PathBuf>,
+pub(crate) fn load_required_agg_pk(
+    agg_prefix_pk: &Option<PathBuf>,
     cargo_args: &RunCargoArgs,
 ) -> Result<AggProvingKey> {
-    let agg_pk_path = resolve_agg_pk_path(agg_pk, cargo_args)?;
-    read_object_from_file(&agg_pk_path).map_err(|e| {
+    let prefix_pk = load_required_agg_prefix_pk(agg_prefix_pk, cargo_args)?;
+    let internal_recursive_pk = load_required_internal_recursive_pk()?;
+    Ok(AggProvingKey {
+        prefix_pk,
+        internal_recursive_pk,
+    })
+}
+
+pub(crate) fn load_required_agg_prefix_pk(
+    agg_prefix_pk: &Option<PathBuf>,
+    cargo_args: &RunCargoArgs,
+) -> Result<AggPrefixProvingKey> {
+    let agg_prefix_pk_path = resolve_agg_prefix_pk_path(agg_prefix_pk, cargo_args)?;
+    read_object_from_file(&agg_prefix_pk_path).map_err(|e| {
         eyre!(
-            "Failed to read aggregation proving key from {}: {e}\nRun 'cargo openvm keygen' first to generate it",
-            agg_pk_path.display()
+            "Failed to read aggregation prefix proving key from {}: {e}\nRun 'cargo openvm keygen' first to generate it",
+            agg_prefix_pk_path.display()
+        )
+    })
+}
+
+pub(crate) fn load_required_internal_recursive_pk() -> Result<Arc<MultiStarkProvingKey<SC>>> {
+    let internal_recursive_pk_path = PathBuf::from(default_internal_recursive_pk_path());
+    read_object_from_file(&internal_recursive_pk_path).map_err(|e| {
+        eyre!(
+            "Failed to read internal-recursive proving key from {}: {e}\nRun 'cargo openvm setup' first to generate it",
+            internal_recursive_pk_path.display()
         )
     })
 }
@@ -355,7 +381,7 @@ fn load_required_root_pk() -> Result<RootProvingKey> {
     let root_pk_path = PathBuf::from(crate::default::default_root_pk_path());
     read_object_from_file(&root_pk_path).map_err(|e| {
         eyre!(
-            "Failed to read root proving key from {}: {e}\nRun 'cargo openvm setup' first to generate it",
+            "Failed to read root proving key from {}: {e}\nRun 'cargo openvm setup --evm' first to generate it",
             root_pk_path.display()
         )
     })

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -348,8 +348,8 @@ pub(crate) fn load_required_agg_pk(
     let prefix_pk = load_required_agg_prefix_pk(agg_prefix_pk, cargo_args)?;
     let internal_recursive_pk = load_required_internal_recursive_pk()?;
     Ok(AggProvingKey {
-        prefix_pk,
-        internal_recursive_pk,
+        prefix: prefix_pk,
+        internal_recursive: internal_recursive_pk,
     })
 }
 

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{create_dir_all, write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use aws_config::{defaults, BehaviorVersion, Region};
@@ -10,15 +10,16 @@ use eyre::{eyre, Context, Result};
 use openvm_sdk::{
     config::AggregationSystemParams,
     fs::{
-        write_evm_halo2_verifier_to_folder, EVM_HALO2_VERIFIER_BASE_NAME,
-        EVM_HALO2_VERIFIER_INTERFACE_NAME, EVM_HALO2_VERIFIER_PARENT_NAME,
-        EVM_VERIFIER_ARTIFACT_FILENAME,
+        write_object_to_file, EVM_HALO2_VERIFIER_BASE_NAME, EVM_HALO2_VERIFIER_INTERFACE_NAME,
+        EVM_HALO2_VERIFIER_PARENT_NAME, EVM_VERIFIER_ARTIFACT_FILENAME,
     },
     Sdk, OPENVM_VERSION,
 };
-use openvm_stark_sdk::config::{app_params_with_100_bits_security, MAX_APP_LOG_STACKED_HEIGHT};
 
-use crate::default::{default_evm_halo2_verifier_path, default_params_dir};
+use crate::default::{
+    default_app_config, default_evm_halo2_verifier_path, default_internal_recursive_pk_path,
+    default_params_dir, default_root_pk_path,
+};
 
 /// The maximum value of `k` to download Halo2 KZG trusted setup parameters for. This depends on the
 /// default verifier circuit and wrapper circuit sizes.
@@ -27,52 +28,58 @@ const MAX_HALO2_VERIFIER_K_FOR_DOWNLOAD: usize = 24;
 #[derive(Parser)]
 #[command(
     name = "setup",
-    about = "Set up for generating EVM proofs. ATTENTION: this requires large amounts of computation and memory. "
+    about = "Set up OpenVM recursive proving artifacts. ATTENTION: this requires large amounts of computation and memory."
 )]
 pub struct SetupCmd {
     #[arg(
         long,
         default_value = "false",
-        help = "Force verifier regeneration even if the verifier contract already exists"
+        help = "Force verifier regeneration even if the verifier artifacts already exist"
     )]
     pub force: bool,
 
     #[arg(
         long,
         default_value = "false",
-        help = "Download pre-built verifier artifacts from S3 instead of generating locally"
+        help = "Also cache the root proving key and download EVM verifier artifacts"
+    )]
+    pub evm: bool,
+
+    #[arg(
+        long,
+        default_value = "false",
+        help = "Download pre-built EVM verifier artifacts from S3 instead of generating locally"
     )]
     pub download: bool,
 }
 
 impl SetupCmd {
     pub async fn run(&self) -> Result<()> {
-        if !Self::check_solc_installed() && !self.download {
-            return Err(eyre!(
-                "solc is not installed, please install solc to continue"
-            ));
+        let sdk = Sdk::new(default_app_config(), AggregationSystemParams::default())?;
+
+        let internal_recursive_pk_path = PathBuf::from(default_internal_recursive_pk_path());
+        println!(
+            "Writing internal-recursive proving key to {}",
+            internal_recursive_pk_path.display()
+        );
+        write_object_to_file(
+            &internal_recursive_pk_path,
+            sdk.agg_pk().internal_recursive_pk,
+        )?;
+
+        if !self.evm {
+            return Ok(());
         }
+
+        let root_pk_path = PathBuf::from(default_root_pk_path());
+        println!("Writing root proving key to {}", root_pk_path.display());
+        write_object_to_file(&root_pk_path, sdk.root_pk())?;
 
         Self::download_params(10, MAX_HALO2_VERIFIER_K_FOR_DOWNLOAD as u32).await?;
 
         let verifier_dir = PathBuf::from(default_evm_halo2_verifier_path());
         let versioned_verifier_dir = verifier_dir.join("src").join(format!("v{OPENVM_VERSION}"));
-        let interface_dir = versioned_verifier_dir.join("interfaces");
-
-        if !self.force
-            && versioned_verifier_dir
-                .join(EVM_HALO2_VERIFIER_PARENT_NAME)
-                .exists()
-            && versioned_verifier_dir
-                .join(EVM_HALO2_VERIFIER_BASE_NAME)
-                .exists()
-            && versioned_verifier_dir
-                .join(EVM_VERIFIER_ARTIFACT_FILENAME)
-                .exists()
-            && interface_dir
-                .join(EVM_HALO2_VERIFIER_INTERFACE_NAME)
-                .exists()
-        {
+        if !self.force && Self::verifier_artifacts_exist(&versioned_verifier_dir) {
             println!(
                 "EVM verifier artifacts already exist in {}",
                 verifier_dir.display()
@@ -83,20 +90,26 @@ impl SetupCmd {
         if self.download {
             Self::download_verifier(&versioned_verifier_dir).await?;
         } else {
-            let sdk = Sdk::standard(
-                app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT),
-                AggregationSystemParams::default(),
-            );
-
-            println!(
-                "Generating verifier contract. Use --download to download pre-generated contract instead."
-            );
-            let verifier = sdk.generate_halo2_verifier_solidity()?;
-
-            println!("Writing verifier contract to {}", verifier_dir.display());
-            write_evm_halo2_verifier_to_folder(verifier, &verifier_dir)?;
+            Self::generate_verifier(&sdk, &verifier_dir)?;
         }
+
         Ok(())
+    }
+
+    fn verifier_artifacts_exist(versioned_verifier_dir: &Path) -> bool {
+        versioned_verifier_dir
+            .join(EVM_HALO2_VERIFIER_PARENT_NAME)
+            .exists()
+            && versioned_verifier_dir
+                .join(EVM_HALO2_VERIFIER_BASE_NAME)
+                .exists()
+            && versioned_verifier_dir
+                .join(EVM_VERIFIER_ARTIFACT_FILENAME)
+                .exists()
+            && versioned_verifier_dir
+                .join("interfaces")
+                .join(EVM_HALO2_VERIFIER_INTERFACE_NAME)
+                .exists()
     }
 
     fn check_solc_installed() -> bool {
@@ -104,6 +117,34 @@ impl SetupCmd {
             .arg("--version")
             .output()
             .is_ok()
+    }
+
+    fn generate_verifier(sdk: &Sdk, verifier_dir: &Path) -> Result<()> {
+        if !Self::check_solc_installed() {
+            return Err(eyre!(
+                "solc is not installed, please install solc or rerun with --download"
+            ));
+        }
+
+        #[cfg(feature = "evm-verify")]
+        {
+            use openvm_sdk::fs::write_evm_halo2_verifier_to_folder;
+
+            println!("Generating verifier contract locally.");
+            let verifier = sdk.generate_halo2_verifier_solidity()?;
+            println!("Writing verifier contract to {}", verifier_dir.display());
+            write_evm_halo2_verifier_to_folder(verifier, verifier_dir)?;
+            Ok(())
+        }
+
+        #[cfg(not(feature = "evm-verify"))]
+        {
+            let _ = sdk;
+            let _ = verifier_dir;
+            Err(eyre!(
+                "this cargo-openvm build does not include local EVM verifier generation support; rerun with --download"
+            ))
+        }
     }
 
     async fn download_verifier(versioned_verifier_dir: &PathBuf) -> Result<()> {

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -26,10 +26,7 @@ use crate::default::{
 const MAX_HALO2_VERIFIER_K_FOR_DOWNLOAD: usize = 24;
 
 #[derive(Parser)]
-#[command(
-    name = "setup",
-    about = "Set up OpenVM recursive proving artifacts. ATTENTION: this requires large amounts of computation and memory."
-)]
+#[command(name = "setup", about = "Set up OpenVM recursive proving artifacts.")]
 pub struct SetupCmd {
     #[arg(
         long,
@@ -41,7 +38,7 @@ pub struct SetupCmd {
     #[arg(
         long,
         default_value = "false",
-        help = "Also cache the root proving key and download EVM verifier artifacts"
+        help = "Also cache the root proving key and download EVM verifier artifacts. ATTENTION: this requires large amounts of computation and memory."
     )]
     pub evm: bool,
 
@@ -62,10 +59,7 @@ impl SetupCmd {
             "Writing internal-recursive proving key to {}",
             internal_recursive_pk_path.display()
         );
-        write_object_to_file(
-            &internal_recursive_pk_path,
-            sdk.agg_pk().internal_recursive_pk,
-        )?;
+        write_object_to_file(&internal_recursive_pk_path, sdk.agg_pk().internal_recursive)?;
 
         if !self.evm {
             return Ok(());

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -6,15 +6,16 @@ use openvm_sdk::{
     fs::{read_from_file_json, read_object_from_file},
     prover::verify_app_proof,
     types::{VerificationBaselineJson, VersionedNonRootStarkProof},
-    Sdk, OPENVM_VERSION,
+    Sdk, OPENVM_VERSION, SC,
 };
+use openvm_stark_backend::keygen::types::MultiStarkProvingKey;
 
 use super::KeygenCargoArgs;
 use crate::{
     args::ManifestArgs,
     default::{APP_PROOF_EXT, STARK_PROOF_EXT},
     util::{
-        get_agg_vk_path, get_app_baseline_path, get_app_vk_path, get_manifest_path_and_dir,
+        get_app_baseline_path, get_app_vk_path, get_manifest_path_and_dir,
         get_single_target_name_raw, get_target_dir, get_target_output_dir, resolve_proof_path,
     },
 };
@@ -159,13 +160,16 @@ impl VerifyCmd {
                 let (manifest_path, _) =
                     get_manifest_path_and_dir(&cargo_args.manifest.manifest_path)?;
                 let target_dir = get_target_dir(&cargo_args.manifest.target_dir, &manifest_path);
-                let agg_vk_path = get_agg_vk_path(&target_dir);
-                let agg_vk = read_object_from_file(&agg_vk_path).map_err(|e| {
+                let internal_recursive_pk_path =
+                    PathBuf::from(crate::default::default_internal_recursive_pk_path());
+                let internal_recursive_pk: std::sync::Arc<MultiStarkProvingKey<SC>> =
+                    read_object_from_file(&internal_recursive_pk_path).map_err(|e| {
                     eyre::eyre!(
-                        "Failed to read aggregation verifying key from {}: {e}\nRun 'cargo openvm keygen' first to generate it",
-                        agg_vk_path.display()
+                        "Failed to read internal-recursive proving key from {}: {e}\nRun 'cargo openvm setup' first to generate it",
+                        internal_recursive_pk_path.display()
                     )
                 })?;
+                let agg_vk = internal_recursive_pk.get_vk();
                 let baseline_path = if let Some(app_baseline) = app_baseline {
                     app_baseline.to_path_buf()
                 } else {

--- a/crates/cli/src/default.rs
+++ b/crates/cli/src/default.rs
@@ -8,8 +8,7 @@ pub const DEFAULT_MANIFEST_DIR: &str = ".";
 
 pub const DEFAULT_APP_PK_NAME: &str = "app.pk";
 pub const DEFAULT_APP_VK_NAME: &str = "app.vk";
-pub const DEFAULT_AGG_PK_NAME: &str = "agg.pk";
-pub const DEFAULT_AGG_VK_NAME: &str = "agg.vk";
+pub const DEFAULT_AGG_PREFIX_PK_NAME: &str = "agg_prefix.pk";
 
 pub const VMEXE_EXT: &str = "vmexe";
 pub const OPENVM_CONFIG_FILENAME: &str = "openvm.toml";
@@ -23,6 +22,10 @@ pub const BASELINE_JSON_EXT: &str = "baseline.json";
 
 pub fn default_params_dir() -> String {
     env::var("HOME").unwrap() + "/.openvm/params/"
+}
+
+pub fn default_internal_recursive_pk_path() -> String {
+    env::var("HOME").unwrap() + "/.openvm/internal_recursive.pk"
 }
 
 pub fn default_root_pk_path() -> String {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -12,8 +12,8 @@ use serde::de::DeserializeOwned;
 use crate::{
     commands::RunCargoArgs,
     default::{
-        default_app_config, BASELINE_JSON_EXT, COMMIT_JSON_EXT, DEFAULT_AGG_PK_NAME,
-        DEFAULT_AGG_VK_NAME, DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME,
+        default_app_config, BASELINE_JSON_EXT, COMMIT_JSON_EXT, DEFAULT_AGG_PREFIX_PK_NAME,
+        DEFAULT_APP_PK_NAME, DEFAULT_APP_VK_NAME,
     },
 };
 
@@ -90,12 +90,8 @@ pub fn get_app_vk_path(target_dir: &Path) -> PathBuf {
     get_openvm_dir(target_dir).join(DEFAULT_APP_VK_NAME)
 }
 
-pub fn get_agg_pk_path(target_dir: &Path) -> PathBuf {
-    get_openvm_dir(target_dir).join(DEFAULT_AGG_PK_NAME)
-}
-
-pub fn get_agg_vk_path(target_dir: &Path) -> PathBuf {
-    get_openvm_dir(target_dir).join(DEFAULT_AGG_VK_NAME)
+pub fn get_agg_prefix_pk_path(target_dir: &Path) -> PathBuf {
+    get_openvm_dir(target_dir).join(DEFAULT_AGG_PREFIX_PK_NAME)
 }
 
 pub fn get_app_commit_path(target_output_dir: &Path, target_name: PathBuf) -> PathBuf {

--- a/crates/cli/tests/scripts/cli_stark_e2e_no_commit.sh
+++ b/crates/cli/tests/scripts/cli_stark_e2e_no_commit.sh
@@ -9,6 +9,8 @@ proof_path="$temp_dir/fibonacci.stark.proof"
 cargo openvm keygen \
   --manifest-path tests/programs/multi/Cargo.toml
 
+cargo openvm setup
+
 cargo openvm prove stark \
   --manifest-path tests/programs/multi/Cargo.toml \
   --example fibonacci \

--- a/crates/cli/tests/scripts/cli_stark_e2e_simplified.sh
+++ b/crates/cli/tests/scripts/cli_stark_e2e_simplified.sh
@@ -9,6 +9,8 @@ proof_path="$temp_dir/fibonacci.stark.proof"
 cargo openvm keygen \
   --manifest-path tests/programs/multi/Cargo.toml
 
+cargo openvm setup
+
 cargo openvm commit \
   --manifest-path tests/programs/multi/Cargo.toml \
   --example fibonacci

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -110,7 +110,7 @@ where
     fn agg_config_from_pk(agg_pk: &AggProvingKey) -> AggregationConfig {
         AggregationConfig {
             params: AggregationSystemParams {
-                leaf: agg_pk.leaf_pk.params.clone(),
+                leaf: agg_pk.prefix_pk.leaf_pk.params.clone(),
                 internal: agg_pk.internal_recursive_pk.params.clone(),
             },
         }

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -110,8 +110,8 @@ where
     fn agg_config_from_pk(agg_pk: &AggProvingKey) -> AggregationConfig {
         AggregationConfig {
             params: AggregationSystemParams {
-                leaf: agg_pk.prefix_pk.leaf_pk.params.clone(),
-                internal: agg_pk.internal_recursive_pk.params.clone(),
+                leaf: agg_pk.prefix.leaf.params.clone(),
+                internal: agg_pk.internal_recursive.params.clone(),
             },
         }
     }

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -34,9 +34,14 @@ pub struct AppVerifyingKey {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-pub struct AggProvingKey {
+pub struct AggPrefixProvingKey {
     pub leaf_pk: Arc<MultiStarkProvingKey<SC>>,
     pub internal_for_leaf_pk: Arc<MultiStarkProvingKey<SC>>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AggProvingKey {
+    pub prefix_pk: AggPrefixProvingKey,
     pub internal_recursive_pk: Arc<MultiStarkProvingKey<SC>>,
 }
 

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -35,14 +35,14 @@ pub struct AppVerifyingKey {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AggPrefixProvingKey {
-    pub leaf_pk: Arc<MultiStarkProvingKey<SC>>,
-    pub internal_for_leaf_pk: Arc<MultiStarkProvingKey<SC>>,
+    pub leaf: Arc<MultiStarkProvingKey<SC>>,
+    pub internal_for_leaf: Arc<MultiStarkProvingKey<SC>>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AggProvingKey {
-    pub prefix_pk: AggPrefixProvingKey,
-    pub internal_recursive_pk: Arc<MultiStarkProvingKey<SC>>,
+    pub prefix: AggPrefixProvingKey,
+    pub internal_recursive: Arc<MultiStarkProvingKey<SC>>,
 }
 
 #[cfg(feature = "root-prover")]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -43,7 +43,7 @@ use openvm_verify_stark_host::{
 
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
-    keygen::AggProvingKey,
+    keygen::{AggPrefixProvingKey, AggProvingKey},
     prover::{AggProver, AppProver, DeferralPathProver, DeferralProver, StarkProver},
     types::ExecutableFormat,
 };
@@ -636,6 +636,22 @@ where
         (pk, vk)
     }
 
+    pub fn agg_prefix_pk(&self) -> AggPrefixProvingKey {
+        if let Some(agg_prover) = self.agg_prover.get() {
+            return AggPrefixProvingKey {
+                leaf_pk: agg_prover.leaf_prover.get_pk(),
+                internal_for_leaf_pk: agg_prover.internal_for_leaf_prover.get_pk(),
+            };
+        }
+
+        let app_pk = self.app_pk();
+        AggProver::keygen_prefix(
+            Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()),
+            self.agg_config.clone(),
+            self.def_hook_cached_commit(),
+        )
+    }
+
     #[cfg(feature = "root-prover")]
     pub fn root_pk(&self) -> RootProvingKey {
         let root_prover = self.root_prover();
@@ -648,8 +664,10 @@ where
     pub fn agg_pk(&self) -> AggProvingKey {
         let agg_prover = self.agg_prover();
         AggProvingKey {
-            leaf_pk: agg_prover.leaf_prover.get_pk(),
-            internal_for_leaf_pk: agg_prover.internal_for_leaf_prover.get_pk(),
+            prefix_pk: AggPrefixProvingKey {
+                leaf_pk: agg_prover.leaf_prover.get_pk(),
+                internal_for_leaf_pk: agg_prover.internal_for_leaf_prover.get_pk(),
+            },
             internal_recursive_pk: agg_prover.internal_recursive_prover.get_pk(),
         }
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -639,8 +639,8 @@ where
     pub fn agg_prefix_pk(&self) -> AggPrefixProvingKey {
         if let Some(agg_prover) = self.agg_prover.get() {
             return AggPrefixProvingKey {
-                leaf_pk: agg_prover.leaf_prover.get_pk(),
-                internal_for_leaf_pk: agg_prover.internal_for_leaf_prover.get_pk(),
+                leaf: agg_prover.leaf_prover.get_pk(),
+                internal_for_leaf: agg_prover.internal_for_leaf_prover.get_pk(),
             };
         }
 
@@ -664,11 +664,11 @@ where
     pub fn agg_pk(&self) -> AggProvingKey {
         let agg_prover = self.agg_prover();
         AggProvingKey {
-            prefix_pk: AggPrefixProvingKey {
-                leaf_pk: agg_prover.leaf_prover.get_pk(),
-                internal_for_leaf_pk: agg_prover.internal_for_leaf_prover.get_pk(),
+            prefix: AggPrefixProvingKey {
+                leaf: agg_prover.leaf_prover.get_pk(),
+                internal_for_leaf: agg_prover.internal_for_leaf_prover.get_pk(),
             },
-            internal_recursive_pk: agg_prover.internal_recursive_prover.get_pk(),
+            internal_recursive: agg_prover.internal_recursive_prover.get_pk(),
         }
     }
 

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -62,8 +62,8 @@ impl AggProver {
             def_hook_cached_commit,
         );
         AggPrefixProvingKey {
-            leaf_pk: leaf_prover.get_pk(),
-            internal_for_leaf_pk: internal_for_leaf_prover.get_pk(),
+            leaf: leaf_prover.get_pk(),
+            internal_for_leaf: internal_for_leaf_prover.get_pk(),
         }
     }
 
@@ -110,19 +110,19 @@ impl AggProver {
     ) -> Self {
         let leaf_prover = InnerAggregationProver::from_pk::<E>(
             app_or_def_vk,
-            agg_pk.prefix_pk.leaf_pk,
+            agg_pk.prefix.leaf,
             false,
             def_hook_cached_commit,
         );
         let internal_for_leaf_prover = InnerAggregationProver::from_pk::<E>(
             leaf_prover.get_vk(),
-            agg_pk.prefix_pk.internal_for_leaf_pk,
+            agg_pk.prefix.internal_for_leaf,
             false,
             def_hook_cached_commit,
         );
         let internal_recursive_prover = InnerAggregationProver::from_pk::<E>(
             internal_for_leaf_prover.get_vk(),
-            agg_pk.internal_recursive_pk,
+            agg_pk.internal_recursive,
             true,
             def_hook_cached_commit,
         );

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{
         AggregationConfig, AggregationTreeConfig, MAX_NUM_CHILDREN_INTERNAL, MAX_NUM_CHILDREN_LEAF,
     },
-    keygen::AggProvingKey,
+    keygen::{AggPrefixProvingKey, AggProvingKey},
     prover::deferral::DeferralProof,
     SC,
 };
@@ -44,6 +44,29 @@ pub struct InternalLayerMetadata {
 }
 
 impl AggProver {
+    pub fn keygen_prefix(
+        app_or_def_vk: Arc<MultiStarkVerifyingKey<SC>>,
+        agg_config: AggregationConfig,
+        def_hook_cached_commit: Option<Digest>,
+    ) -> AggPrefixProvingKey {
+        let leaf_prover = InnerAggregationProver::<MAX_NUM_CHILDREN_LEAF>::new::<E>(
+            app_or_def_vk,
+            agg_config.params.leaf.clone(),
+            false,
+            def_hook_cached_commit,
+        );
+        let internal_for_leaf_prover = InnerAggregationProver::<MAX_NUM_CHILDREN_INTERNAL>::new::<E>(
+            leaf_prover.get_vk(),
+            agg_config.params.internal,
+            false,
+            def_hook_cached_commit,
+        );
+        AggPrefixProvingKey {
+            leaf_pk: leaf_prover.get_pk(),
+            internal_for_leaf_pk: internal_for_leaf_prover.get_pk(),
+        }
+    }
+
     #[tracing::instrument(level = "info", fields(group = "agg_keygen"), skip_all)]
     pub fn new(
         app_or_def_vk: Arc<MultiStarkVerifyingKey<SC>>,
@@ -87,13 +110,13 @@ impl AggProver {
     ) -> Self {
         let leaf_prover = InnerAggregationProver::from_pk::<E>(
             app_or_def_vk,
-            agg_pk.leaf_pk,
+            agg_pk.prefix_pk.leaf_pk,
             false,
             def_hook_cached_commit,
         );
         let internal_for_leaf_prover = InnerAggregationProver::from_pk::<E>(
             leaf_prover.get_vk(),
-            agg_pk.internal_for_leaf_pk,
+            agg_pk.prefix_pk.internal_for_leaf_pk,
             false,
             def_hook_cached_commit,
         );

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -93,12 +93,12 @@ impl DeferralProver {
         assert_eq!(def_circuit_prover.get_def_idx(), 0);
         let single_circuit_prover = SingleDefCircuitProver::from_pks(
             def_circuit_prover,
-            def_agg_pk.prefix_pk.leaf_pk,
-            def_agg_pk.prefix_pk.internal_for_leaf_pk,
+            def_agg_pk.prefix.leaf,
+            def_agg_pk.prefix.internal_for_leaf,
         );
         let internal_recursive_prover = DeferralInnerProver::from_pk::<E>(
             single_circuit_prover.internal_for_leaf_prover.get_vk(),
-            def_agg_pk.internal_recursive_pk,
+            def_agg_pk.internal_recursive,
             false,
         );
         let def_hook_prover = DeferralHookProver::from_pk::<E>(

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -93,8 +93,8 @@ impl DeferralProver {
         assert_eq!(def_circuit_prover.get_def_idx(), 0);
         let single_circuit_prover = SingleDefCircuitProver::from_pks(
             def_circuit_prover,
-            def_agg_pk.leaf_pk,
-            def_agg_pk.internal_for_leaf_pk,
+            def_agg_pk.prefix_pk.leaf_pk,
+            def_agg_pk.prefix_pk.internal_for_leaf_pk,
         );
         let internal_recursive_prover = DeferralInnerProver::from_pk::<E>(
             single_circuit_prover.internal_for_leaf_prover.get_vk(),


### PR DESCRIPTION
Resolves INT-7125.

## Overview

This PR splits the aggregation proving key into app-dependent and app-independent pieces, then updates the CLI to cache the app-independent recursion artifacts in `~/.openvm`.

- Local per-target artifacts are now `app.pk`, `app.vk`, and `agg_prefix.pk`.
- Global cached artifacts are now `~/.openvm/internal_recursive.pk`, and `~/.openvm/root.pk` for EVM setup.
- CLI commands that previously consumed `agg.pk` now reconstruct a full `AggProvingKey` from the local prefix key plus the cached global recursive key.
- `cargo openvm keygen` now enforces the CLI invariant that root-circuit shape stays at the default `num_public_values` / `memory_dimensions`.

## Suggested Review Order

1. `crates/sdk/src/keygen/mod.rs`, `crates/sdk/src/lib.rs`, `crates/sdk/src/prover/agg.rs`, `crates/sdk/src/builder.rs`, `crates/sdk/src/prover/deferral/mod.rs`
2. `crates/cli/src/commands/setup.rs`
3. `crates/cli/src/commands/keygen.rs`, `crates/cli/src/commands/prove.rs`, `crates/cli/src/commands/commit.rs`, `crates/cli/src/commands/verify.rs`
4. `crates/cli/src/{args.rs,default.rs,util.rs,bin/cargo-openvm.rs,commands/mod.rs}` and the updated CLI scripts

## SDK: Split `AggProvingKey` into prefix + recursive pieces

Files:
- `crates/sdk/src/keygen/mod.rs`
- `crates/sdk/src/lib.rs`
- `crates/sdk/src/prover/agg.rs`
- `crates/sdk/src/builder.rs`
- `crates/sdk/src/prover/deferral/mod.rs`

What changed:
- Introduces `AggPrefixProvingKey { leaf_pk, internal_for_leaf_pk }`.
- Changes `AggProvingKey` to hold:
  - `prefix_pk: AggPrefixProvingKey`
  - `internal_recursive_pk`
- Adds `Sdk::agg_prefix_pk()` and `AggProver::keygen_prefix(...)` so callers can generate only the app-dependent prefix portion.
- Updates SDK builder / prover / deferral call sites to read the new nested layout.

Review focus:
- The new prefix-only keygen path should produce exactly the material needed to rebuild the old full aggregation PK when paired with `internal_recursive_pk`.
- All code that previously read `leaf_pk` / `internal_for_leaf_pk` directly should now go through `prefix_pk`.

## CLI: `setup` now owns the global recursive cache

Files:
- `crates/cli/src/commands/setup.rs`
- `crates/cli/src/bin/cargo-openvm.rs`
- `crates/cli/src/commands/mod.rs`
- `crates/cli/src/default.rs`

What changed:
- `cargo openvm setup` is no longer feature-gated at the command level.
- `setup` always builds the default SDK and writes `~/.openvm/internal_recursive.pk`.
- `setup --evm` additionally:
  - writes `~/.openvm/root.pk`
  - downloads Halo2 params
  - either generates verifier artifacts locally or downloads them with `--download`
- `--download` only applies to verifier artifacts; the recursive/root proving keys are still generated locally.
- Existing verifier artifacts short-circuit unless `--force` is passed.
- Local verifier generation still requires `solc`; if the CLI was built without `evm-verify`, `--evm` must use `--download`.

Review focus:
- `setup` is now the single owner for machine-global recursive/root artifacts.
- STARK-only flows can use `setup` without enabling the EVM verifier feature.

## CLI: `keygen` now emits local app keys + `agg_prefix.pk`

Files:
- `crates/cli/src/commands/keygen.rs`
- `crates/cli/src/args.rs`
- `crates/cli/src/default.rs`
- `crates/cli/src/util.rs`

What changed:
- Renames the local aggregation artifact from `agg.pk` to `agg_prefix.pk`.
- `keygen` writes:
  - `app.pk`
  - `app.vk`
  - `agg_prefix.pk` unless `--app-only`
- Stops emitting `agg.vk`.
- Adds `assert_default_root_shape(...)`, which panics if `openvm.toml` changes:
  - `num_public_values`
  - derived `memory_dimensions`

Review focus:
- This enforces the CLI invariant that global recursion/root setup only supports the default root shape.
- The output-dir copy path mirrors the new artifact names.

## CLI: `prove`, `commit`, and `verify` now compose local + global keys

Files:
- `crates/cli/src/commands/prove.rs`
- `crates/cli/src/commands/commit.rs`
- `crates/cli/src/commands/verify.rs`
- `crates/cli/src/args.rs`

What changed:
- `ProvingKeyArgs` now exposes `--agg-prefix-pk` instead of `--agg-pk`.
- `prove stark`, `prove evm`, and `commit` all use `load_required_agg_pk(...)`, which:
  - loads local `agg_prefix.pk`
  - loads cached `~/.openvm/internal_recursive.pk`
  - reconstructs `AggProvingKey` in memory
- `prove evm` additionally requires cached `~/.openvm/root.pk` and points users to `cargo openvm setup --evm` if it is missing.
- `commit` now uses shared `ProvingKeyArgs` and no longer lazily generates or persists aggregation/root keys.
- `verify stark` now derives the aggregation VK from cached `internal_recursive.pk` instead of reading a local `agg.vk`.

Review focus:
- STARK proving and commit now require `setup` to run first, not just `keygen`.
- Verification is now tied to the global internal-recursive cache rather than per-target aggregation artifacts.

## CLI Scripts

Files:
- `crates/cli/tests/scripts/cli_stark_e2e_no_commit.sh`
- `crates/cli/tests/scripts/cli_stark_e2e_simplified.sh`

What changed:
- Both STARK e2e scripts now run `cargo openvm setup` before `prove` / `commit` so the shared internal-recursive cache exists.
