### PR TITLE
chore: finalize SDK and naming nomenclature

### DIFF
--- a/benchmarks/prove/src/lib.rs
+++ b/benchmarks/prove/src/lib.rs
@@ -15,7 +15,7 @@ use openvm_stark_sdk::{
     },
 };
 use openvm_transpiler::{elf::Elf, FromElf};
-use openvm_verify_stark_host::{verify_vm_stark_proof_decoded, vk::NonRootStarkVerifyingKey};
+use openvm_verify_stark_host::{verify_vm_stark_proof_decoded, vk::VmStarkVerifyingKey};
 
 pub const DEFAULT_MAX_SEGMENT: u32 = 1 << 20;
 pub const DEFAULT_LOG_STACKED_HEIGHT: usize = 21;
@@ -100,7 +100,7 @@ pub fn run_benchmark(
             metrics::gauge!("proof_size_bytes.total").set(encoded.len() as f64);
             metrics::gauge!("proof_size_bytes.compressed").set(compressed.len() as f64);
         }
-        let vk = NonRootStarkVerifyingKey {
+        let vk = VmStarkVerifyingKey {
             mvk: (*sdk.agg_vk()).clone(),
             baseline,
         };

--- a/crates/cli/src/commands/commit.rs
+++ b/crates/cli/src/commands/commit.rs
@@ -67,16 +67,16 @@ impl CommitCmd {
 
         let prover = sdk.prover(exe)?;
         let baseline = prover.generate_baseline();
-        let app_vk_commit = prover.app_vk_commit();
+        let app_vm_commit = prover.app_vm_commit();
 
         let app_commit = AppExecutionCommit {
             app_exe_commit: CommitBytes::from(baseline.app_exe_commit),
-            app_vk_commit: CommitBytes::from(app_vk_commit),
+            app_vm_commit: CommitBytes::from(app_vm_commit),
         };
         let exe_commit_bn254 = Bn254::from(app_commit.app_exe_commit);
-        let vk_commit_bn254 = Bn254::from(app_commit.app_vk_commit);
+        let vm_commit_bn254 = Bn254::from(app_commit.app_vm_commit);
         println!("exe commit: {:?}", exe_commit_bn254);
-        println!("vk commit: {:?}", vk_commit_bn254);
+        println!("vm commit: {:?}", vm_commit_bn254);
 
         let target_output_dir = get_target_output_dir(&target_dir, &self.cargo_args.profile);
 

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -193,16 +193,16 @@ impl ProveCmd {
                     .build()?;
                 let mut prover = sdk.prover(exe)?;
                 let baseline = prover.generate_baseline();
-                let app_vk_commit = prover.app_vk_commit();
+                let app_vm_commit = prover.app_vm_commit();
 
                 let app_commit = AppExecutionCommit {
                     app_exe_commit: CommitBytes::from(baseline.app_exe_commit),
-                    app_vk_commit: CommitBytes::from(app_vk_commit),
+                    app_vm_commit: CommitBytes::from(app_vm_commit),
                 };
                 let exe_commit_bn254 = Bn254::from(app_commit.app_exe_commit);
-                let vk_commit_bn254 = Bn254::from(app_commit.app_vk_commit);
+                let vm_commit_bn254 = Bn254::from(app_commit.app_vm_commit);
                 println!("exe commit: {:?}", exe_commit_bn254);
-                println!("vk commit: {:?}", vk_commit_bn254);
+                println!("vm commit: {:?}", vm_commit_bn254);
 
                 let (stark_proof, _metadata) =
                     prover.prove(read_to_stdin(&run_args.input)?, &[])?;

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -15,7 +15,7 @@ use openvm_sdk::{
     config::{AggregationSystemParams, AggregationTreeConfig},
     fs::{read_object_from_file, write_object_to_file, write_to_file_json},
     keygen::{AggPrefixProvingKey, AggProvingKey, AppProvingKey},
-    types::{AppExecutionCommit, VerificationBaselineJson, VersionedNonRootStarkProof},
+    types::{AppExecutionCommit, VerificationBaselineJson, VersionedVmStarkProof},
     Sdk, F, SC,
 };
 use openvm_sdk_config::SdkVmConfig;
@@ -206,7 +206,7 @@ impl ProveCmd {
 
                 let (stark_proof, _metadata) =
                     prover.prove(read_to_stdin(&run_args.input)?, &[])?;
-                let stark_proof_bytes = VersionedNonRootStarkProof::new(stark_proof)?;
+                let stark_proof_bytes = VersionedVmStarkProof::new(stark_proof)?;
 
                 let target_dir = target_dir_from_cargo_args(cargo_args)?;
                 let target_output_dir = get_target_output_dir(&target_dir, &cargo_args.profile);

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -5,7 +5,7 @@ use eyre::{Context, Result};
 use openvm_sdk::{
     fs::{read_from_file_json, read_object_from_file},
     prover::verify_app_proof,
-    types::{VerificationBaselineJson, VersionedNonRootStarkProof},
+    types::{VerificationBaselineJson, VersionedVmStarkProof},
     Sdk, OPENVM_VERSION, SC,
 };
 use openvm_stark_backend::keygen::types::MultiStarkProvingKey;
@@ -187,7 +187,7 @@ impl VerifyCmd {
 
                 let proof_path = resolve_proof_path(proof, STARK_PROOF_EXT)?;
                 println!("Verifying STARK proof at {}", proof_path.display());
-                let stark_proof: VersionedNonRootStarkProof = read_from_file_json(proof_path)
+                let stark_proof: VersionedVmStarkProof = read_from_file_json(proof_path)
                     .with_context(|| {
                         format!("Proof needs to be compatible with openvm v{OPENVM_VERSION}",)
                     })?;

--- a/crates/continuations/README.md
+++ b/crates/continuations/README.md
@@ -22,7 +22,7 @@ pub fn new(
 - `system_params` — parent system parameters
 - `self_recursion_enabled` — indicates whether this prover is internal-recursive (i.e., can use its own `vk` as `child_vk`)
 
-Constructing the prover pre-generates the child layer's **cached trace commit** (and, together with the child VK's pre-hash, the **DAG commit**) as well as the parent layer's proving and verifying keys. Functions to construct the prover from a saved `pk` and cached trace are available.
+Constructing the prover pre-generates the child layer's **cached trace commit** (and, together with the child VK's pre-hash, the **vk commit**) as well as the parent layer's proving and verifying keys. Functions to construct the prover from a saved `pk` and cached trace are available.
 
 Each inner layer should use the following constructor arguments:
 

--- a/crates/continuations/README.md
+++ b/crates/continuations/README.md
@@ -69,7 +69,7 @@ pub fn new(
     system_params: SystemParams,
     memory_dimensions: MemoryDimensions,
     num_user_pvs: usize,
-    def_hook_vk_commit: Option<CommitBytes>,
+    def_hook_commit: Option<CommitBytes>,
     trace_heights: Option<Vec<usize>>,
 ) -> Self
 ```
@@ -79,7 +79,7 @@ pub fn new(
 - `system_params` — parent system parameters
 - `memory_dimensions` — the memory dimensions used for app execution, used to compute whether each sibling hash in the Merkle proof should be the left or right sibling
 - `num_user_pvs` — number of user public values
-- `def_hook_vk_commit` — `vk_commit` hash of the deferral hook aggregation tree
+- `def_hook_commit` — commitment hash of the deferral hook aggregation tree
 - `trace_heights` - constant heights that the traces of the root proof must be
 
 The constructor pre-generates the parent proving and verifying keys, which can be saved.

--- a/crates/continuations/src/circuit/deferral/hook/bus.rs
+++ b/crates/continuations/src/circuit/deferral/hook/bus.rs
@@ -24,8 +24,8 @@ define_typed_permutation_bus!(OnionResultBus, OnionResultMessage);
 
 #[repr(C)]
 #[derive(AlignedBorrow, Debug, Clone)]
-pub struct DefVkCommitMessage<T> {
-    pub def_vk_commit: [T; DIGEST_SIZE],
+pub struct DefCircuitCommitMessage<T> {
+    pub def_circuit_commit: [T; DIGEST_SIZE],
 }
 
-define_typed_permutation_bus!(DefVkCommitBus, DefVkCommitMessage);
+define_typed_permutation_bus!(DefCircuitCommitBus, DefCircuitCommitMessage);

--- a/crates/continuations/src/circuit/deferral/hook/mod.rs
+++ b/crates/continuations/src/circuit/deferral/hook/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         subair::{HashSliceSubAir, MerkleRootBus, MerkleTreeInternalBus, MerkleTreeSubAir},
         Circuit,
     },
-    DagCommitBytes,
+    VkCommitBytes,
 };
 
 pub mod bus;
@@ -23,7 +23,7 @@ pub use trace::*;
 #[derive(derive_new::new, Clone)]
 pub struct DeferralHookCircuit<S: AggregationSubCircuit> {
     pub verifier_circuit: Arc<S>,
-    pub(crate) internal_recursive_dag_commit: DagCommitBytes,
+    pub(crate) internal_recursive_vk_commit: VkCommitBytes,
 }
 
 impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
@@ -50,7 +50,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             def_circuit_commit_bus,
             merkle_root_bus,
             onion_res_bus,
-            self.internal_recursive_dag_commit,
+            self.internal_recursive_vk_commit,
         );
 
         let decommit_air = decommit::MerkleDecommitAir {

--- a/crates/continuations/src/circuit/deferral/hook/mod.rs
+++ b/crates/continuations/src/circuit/deferral/hook/mod.rs
@@ -34,7 +34,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
         let next_bus_idx = self.verifier_circuit.next_bus_idx();
         let io_commit_bus = bus::IoCommitBus::new(next_bus_idx);
         let onion_res_bus = bus::OnionResultBus::new(next_bus_idx + 1);
-        let def_vk_commit_bus = bus::DefVkCommitBus::new(next_bus_idx + 2);
+        let def_circuit_commit_bus = bus::DefCircuitCommitBus::new(next_bus_idx + 2);
         let merkle_root_bus = MerkleRootBus::new(next_bus_idx + 3);
         let merkle_tree_internal_bus = MerkleTreeInternalBus::new(next_bus_idx + 4);
 
@@ -47,7 +47,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
                 compress_bus: bus_inventory.poseidon2_compress_bus,
                 permute_bus: bus_inventory.poseidon2_permute_bus,
             },
-            def_vk_commit_bus,
+            def_circuit_commit_bus,
             merkle_root_bus,
             onion_res_bus,
             self.internal_recursive_dag_commit,
@@ -65,7 +65,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
 
         let onion_air = onion::OnionHashAir {
             poseidon2_bus: bus_inventory.poseidon2_compress_bus,
-            def_vk_commit_bus,
+            def_circuit_commit_bus,
             io_commit_bus,
             onion_res_bus,
         };

--- a/crates/continuations/src/circuit/deferral/hook/onion/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/onion/air.rs
@@ -15,7 +15,7 @@ use p3_matrix::Matrix;
 
 use crate::{
     circuit::deferral::hook::bus::{
-        DefVkCommitBus, DefVkCommitMessage, IoCommitBus, IoCommitMessage, OnionResultBus,
+        DefCircuitCommitBus, DefCircuitCommitMessage, IoCommitBus, IoCommitMessage, OnionResultBus,
         OnionResultMessage,
     },
     utils::digests_to_poseidon2_input,
@@ -37,7 +37,7 @@ pub struct OnionHashCols<F> {
 
 pub struct OnionHashAir {
     pub poseidon2_bus: Poseidon2CompressBus,
-    pub def_vk_commit_bus: DefVkCommitBus,
+    pub def_circuit_commit_bus: DefCircuitCommitBus,
     pub io_commit_bus: IoCommitBus,
     pub onion_res_bus: OnionResultBus,
 }
@@ -81,14 +81,14 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .assert_one(next.row_idx - local.row_idx);
 
         /*
-         * On the first row we want input_onion to initially be def_vk_commit and
+         * On the first row we want input_onion to initially be def_circuit_commit and
          * output_onion to be all zeroes.
          */
         assert_zeros(&mut builder.when(local.is_first), local.output_onion);
-        self.def_vk_commit_bus.receive(
+        self.def_circuit_commit_bus.receive(
             builder,
-            DefVkCommitMessage {
-                def_vk_commit: local.input_onion,
+            DefCircuitCommitMessage {
+                def_circuit_commit: local.input_onion,
             },
             local.is_first,
         );

--- a/crates/continuations/src/circuit/deferral/hook/onion/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/onion/trace.rs
@@ -23,7 +23,7 @@ pub struct OnionTraceCtx {
 }
 
 pub fn generate_proving_ctx(
-    def_vk_commit: [F; DIGEST_SIZE],
+    def_circuit_commit: [F; DIGEST_SIZE],
     io_commits: Vec<IoCommit>,
 ) -> OnionTraceCtx {
     let num_commits = io_commits.len();
@@ -34,7 +34,7 @@ pub fn generate_proving_ctx(
     let mut trace = vec![F::ZERO; height * width];
     let mut poseidon2_inputs = Vec::with_capacity(2 * num_commits);
 
-    let mut current_input_onion = def_vk_commit;
+    let mut current_input_onion = def_circuit_commit;
     let mut current_output_onion = [F::ZERO; DIGEST_SIZE];
 
     for (row_idx, (input_commit, output_commit)) in io_commits.iter().copied().enumerate() {

--- a/crates/continuations/src/circuit/deferral/hook/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/trace.rs
@@ -78,14 +78,15 @@ impl DeferralHookTraceGen<CpuBackend<BabyBearPoseidon2Config>> for DeferralHookT
         );
 
         let verifier_pvs: &VerifierBasePvs<F> = proof.public_values[0].as_slice().borrow();
-        let def_vk_commit = super::verifier::def_vk_commit_from_verifier_pvs(verifier_pvs);
+        let def_circuit_commit =
+            super::verifier::def_circuit_commit_from_verifier_pvs(verifier_pvs);
 
         let super::onion::OnionTraceCtx {
             proving_ctx: onion_ctx,
             poseidon2_inputs: onion_p2_inputs,
             input_onion,
             output_onion,
-        } = super::onion::generate_proving_ctx(def_vk_commit, io_commits);
+        } = super::onion::generate_proving_ctx(def_circuit_commit, io_commits);
 
         let super::verifier::DeferralHookVerifierTraceCtx {
             trace_data:

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -190,7 +190,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             AB::F::ZERO,
             PreHashMessage::<AB::F> {
-                vk_pre_hash: self.expected_internal_recursive_vk_commit.pre_hash.into(),
+                vk_pre_hash: self
+                    .expected_internal_recursive_vk_commit
+                    .vk_pre_hash
+                    .into(),
             },
             AB::F::ONE,
         );

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
-    DagCommit, DeferralPvs, VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX,
+    DeferralPvs, VerifierBasePvs, VkCommit, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX,
     VERIFIER_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
@@ -22,15 +22,17 @@ use p3_matrix::Matrix;
 use crate::{
     circuit::{
         deferral::{
-            hook::bus::{DefCircuitCommitBus, DefCircuitCommitMessage, OnionResultBus, OnionResultMessage},
+            hook::bus::{
+                DefCircuitCommitBus, DefCircuitCommitMessage, OnionResultBus, OnionResultMessage,
+            },
             DeferralAggregationPvs, DEF_AGG_PVS_AIR_ID,
         },
         root::NUM_DIGESTS_IN_VK_COMMIT,
         subair::{HashSliceCtx, HashSliceSubAir, MerkleRootBus, MerkleRootMessage},
-        utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
+        utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
     },
     utils::{digests_to_poseidon2_input, pad_slice_to_poseidon2_input, zero_hash},
-    CommitBytes, DagCommitBytes,
+    CommitBytes, VkCommitBytes,
 };
 
 #[repr(C)]
@@ -61,7 +63,7 @@ pub struct DeferralHookPvsAir {
     pub merkle_root_bus: MerkleRootBus,
     pub onion_res_bus: OnionResultBus,
 
-    pub expected_internal_recursive_dag_commit: DagCommitBytes,
+    pub expected_internal_recursive_vk_commit: VkCommitBytes,
     pub zero_hash: CommitBytes,
 }
 
@@ -76,7 +78,7 @@ impl DeferralHookPvsAir {
         def_circuit_commit_bus: DefCircuitCommitBus,
         merkle_root_bus: MerkleRootBus,
         onion_res_bus: OnionResultBus,
-        expected_internal_recursive_dag_commit: DagCommitBytes,
+        expected_internal_recursive_vk_commit: VkCommitBytes,
     ) -> Self {
         let zero_hash = zero_hash(1).into();
         Self {
@@ -88,7 +90,7 @@ impl DeferralHookPvsAir {
             def_circuit_commit_bus,
             merkle_root_bus,
             onion_res_bus,
-            expected_internal_recursive_dag_commit,
+            expected_internal_recursive_vk_commit,
             zero_hash,
         }
     }
@@ -158,20 +160,17 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * We also need to receive the cached commit from ProofShapeModule, which is either for
          * the internal-for-leaf (i.e. if recursion_flag == 1) or internal-recursive layer. In
-         * the former case we constrain verifier_pvs.internal_recursive_dag_commit to be unset
+         * the former case we constrain verifier_pvs.internal_recursive_vk_commit to be unset
          * (i.e. all 0), and in the latter we constrain it to be equal to a pre-generated
          * constant as it should be the same regardless of def_vk (provided internal system
          * params are the same).
          */
         let cached_commit = from_fn(|i| {
-            local
-                .verifier_pvs
-                .internal_for_leaf_dag_commit
-                .cached_commit[i]
+            local.verifier_pvs.internal_for_leaf_vk_commit.cached_commit[i]
                 * (AB::Expr::TWO - local.verifier_pvs.recursion_flag)
                 + local
                     .verifier_pvs
-                    .internal_recursive_dag_commit
+                    .internal_recursive_vk_commit
                     .cached_commit[i]
                     * (local.verifier_pvs.recursion_flag - AB::F::ONE)
         });
@@ -191,27 +190,27 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             AB::F::ZERO,
             PreHashMessage::<AB::F> {
-                vk_pre_hash: self.expected_internal_recursive_dag_commit.pre_hash.into(),
+                vk_pre_hash: self.expected_internal_recursive_vk_commit.pre_hash.into(),
             },
             AB::F::ONE,
         );
 
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when_ne(local.verifier_pvs.recursion_flag, AB::F::TWO),
-            local.verifier_pvs.internal_recursive_dag_commit,
+            local.verifier_pvs.internal_recursive_vk_commit,
         );
 
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when_ne(local.verifier_pvs.recursion_flag, AB::F::ONE),
-            local.verifier_pvs.internal_recursive_dag_commit,
-            DagCommit::<AB::Expr>::from(self.expected_internal_recursive_dag_commit),
+            local.verifier_pvs.internal_recursive_vk_commit,
+            VkCommit::<AB::Expr>::from(self.expected_internal_recursive_vk_commit),
         );
 
         /*
          * Commit def_circuit_commit is hash_slice of the 6 vk_commit_components (cached_commit and
-         * vk_pre_hash for each of def_dag_commit (called app_dag_commit in the struct),
-         * leaf_dag_commit, and internal_for_leaf_dag_commit).
-         * We constrain this here and send def_circuit_commit to its bus.
+         * vk_pre_hash for each of def_vk_commit (called app_vk_commit in the struct), leaf_vk_commit,
+         * and internal_for_leaf_vk_commit). We constrain this here and send def_circuit_commit to its
+         * bus.
          */
         let vk_commit_components: Vec<_> = vk_commit_components(&local.verifier_pvs)
             .into_iter()

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -207,10 +207,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         /*
-         * Commit def_circuit_commit is hash_slice of the 6 vk_commit_components (cached_commit and
-         * vk_pre_hash for each of def_vk_commit (called app_vk_commit in the struct), leaf_vk_commit,
-         * and internal_for_leaf_vk_commit). We constrain this here and send def_circuit_commit to its
-         * bus.
+         * Commit def_circuit_commit is hash_slice of the 6 vk_commit_components (cached_commit
+         * and vk_pre_hash for each of def_vk_commit (called app_vk_commit in the
+         * struct), leaf_vk_commit, and internal_for_leaf_vk_commit). We constrain this
+         * here and send def_circuit_commit to its bus.
          */
         let vk_commit_components: Vec<_> = vk_commit_components(&local.verifier_pvs)
             .into_iter()

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -27,7 +27,7 @@ use crate::{
             },
             DeferralAggregationPvs, DEF_AGG_PVS_AIR_ID,
         },
-        root::NUM_DIGESTS_IN_VK_COMMIT,
+        root::NUM_DIGESTS_IN_VM_COMMIT,
         subair::{HashSliceCtx, HashSliceSubAir, MerkleRootBus, MerkleRootMessage},
         utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
     },
@@ -41,7 +41,7 @@ pub struct DeferralHookPvsCols<F> {
     pub verifier_pvs: VerifierBasePvs<F>,
     pub def_pvs: DeferralAggregationPvs<F>,
 
-    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
+    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
     pub def_circuit_commit: [F; DIGEST_SIZE],
 
     pub input_onion: [F; DIGEST_SIZE],

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -22,7 +22,7 @@ use p3_matrix::Matrix;
 use crate::{
     circuit::{
         deferral::{
-            hook::bus::{DefVkCommitBus, DefVkCommitMessage, OnionResultBus, OnionResultMessage},
+            hook::bus::{DefCircuitCommitBus, DefCircuitCommitMessage, OnionResultBus, OnionResultMessage},
             DeferralAggregationPvs, DEF_AGG_PVS_AIR_ID,
         },
         root::NUM_DIGESTS_IN_VK_COMMIT,
@@ -40,12 +40,12 @@ pub struct DeferralHookPvsCols<F> {
     pub def_pvs: DeferralAggregationPvs<F>,
 
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
-    pub def_vk_commit: [F; DIGEST_SIZE],
+    pub def_circuit_commit: [F; DIGEST_SIZE],
 
     pub input_onion: [F; DIGEST_SIZE],
     pub output_onion: [F; DIGEST_SIZE],
 
-    pub def_vk_commit_padded: [F; DIGEST_SIZE],
+    pub def_circuit_commit_padded: [F; DIGEST_SIZE],
     pub input_onion_padded: [F; DIGEST_SIZE],
     pub output_onion_padded: [F; DIGEST_SIZE],
 }
@@ -57,7 +57,7 @@ pub struct DeferralHookPvsAir {
     pub poseidon2_compress_bus: Poseidon2CompressBus,
     pub hash_slice_subair: HashSliceSubAir,
 
-    pub def_vk_commit_bus: DefVkCommitBus,
+    pub def_circuit_commit_bus: DefCircuitCommitBus,
     pub merkle_root_bus: MerkleRootBus,
     pub onion_res_bus: OnionResultBus,
 
@@ -73,7 +73,7 @@ impl DeferralHookPvsAir {
         pre_hash_bus: PreHashBus,
         poseidon2_compress_bus: Poseidon2CompressBus,
         hash_slice_subair: HashSliceSubAir,
-        def_vk_commit_bus: DefVkCommitBus,
+        def_circuit_commit_bus: DefCircuitCommitBus,
         merkle_root_bus: MerkleRootBus,
         onion_res_bus: OnionResultBus,
         expected_internal_recursive_dag_commit: DagCommitBytes,
@@ -85,7 +85,7 @@ impl DeferralHookPvsAir {
             pre_hash_bus,
             poseidon2_compress_bus,
             hash_slice_subair,
-            def_vk_commit_bus,
+            def_circuit_commit_bus,
             merkle_root_bus,
             onion_res_bus,
             expected_internal_recursive_dag_commit,
@@ -208,10 +208,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         /*
-         * Commit def_vk_commit is hash_slice of the 6 vk_commit_components (cached_commit and
+         * Commit def_circuit_commit is hash_slice of the 6 vk_commit_components (cached_commit and
          * vk_pre_hash for each of def_dag_commit (called app_dag_commit in the struct),
          * leaf_dag_commit, and internal_for_leaf_dag_commit).
-         * We constrain this here and send def_vk_commit to its bus.
+         * We constrain this here and send def_circuit_commit to its bus.
          */
         let vk_commit_components: Vec<_> = vk_commit_components(&local.verifier_pvs)
             .into_iter()
@@ -225,15 +225,15 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                     .intermediate_vk_states
                     .map(|v| v.map(Into::into))
                     .as_slice(),
-                result: &local.def_vk_commit.map(Into::into),
+                result: &local.def_circuit_commit.map(Into::into),
                 enabled: &AB::Expr::ONE,
             },
         );
 
-        self.def_vk_commit_bus.send(
+        self.def_circuit_commit_bus.send(
             builder,
-            DefVkCommitMessage {
-                def_vk_commit: local.def_vk_commit,
+            DefCircuitCommitMessage {
+                def_circuit_commit: local.def_circuit_commit,
             },
             AB::F::ONE,
         );
@@ -265,7 +265,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * Finally, we need to constrain that the public values this AIR produces are consistent
          * with the child's. initial_acc_hash should be the compression of a padded
-         * def_vk_commit, and final_acc_hash should be the compression of the input and
+         * def_circuit_commit, and final_acc_hash should be the compression of the input and
          * output onions. Note that the Merkle root computation hashes each leaf with the
          * zero digest prior.
          */
@@ -281,10 +281,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             Poseidon2CompressMessage {
                 input: pad_slice_to_poseidon2_input(
-                    &local.def_vk_commit.map(Into::into),
+                    &local.def_circuit_commit.map(Into::into),
                     AB::Expr::ZERO,
                 ),
-                output: local.def_vk_commit_padded.map(Into::into),
+                output: local.def_circuit_commit_padded.map(Into::into),
             },
             AB::F::ONE,
         );
@@ -317,7 +317,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             Poseidon2CompressMessage {
                 input: digests_to_poseidon2_input(
-                    local.def_vk_commit_padded.map(Into::into),
+                    local.def_circuit_commit_padded.map(Into::into),
                     self.zero_hash.into(),
                 ),
                 output: initial_acc_hash.map(Into::into),

--- a/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
@@ -15,7 +15,7 @@ use crate::{
             hook::verifier::air::DeferralHookPvsCols, DeferralAggregationPvs, DEF_AGG_PVS_AIR_ID,
             DEF_AGG_VERIFIER_AIR_ID,
         },
-        root::NUM_DIGESTS_IN_VK_COMMIT,
+        root::NUM_DIGESTS_IN_VM_COMMIT,
         subair::hash_slice_trace,
         SingleAirTraceData,
     },
@@ -69,7 +69,7 @@ pub fn generate_proving_ctx(
     cols.output_onion = output_onion;
 
     let mut poseidon2_compress_inputs = Vec::with_capacity(6);
-    let mut poseidon2_permute_inputs = Vec::with_capacity(NUM_DIGESTS_IN_VK_COMMIT - 1);
+    let mut poseidon2_permute_inputs = Vec::with_capacity(NUM_DIGESTS_IN_VM_COMMIT - 1);
     let (intermediate_vk_states, def_circuit_commit) = hash_slice_trace(
         &hash_elements,
         Some(&mut poseidon2_permute_inputs),
@@ -79,7 +79,8 @@ pub fn generate_proving_ctx(
     cols.def_circuit_commit = def_circuit_commit;
 
     const ZERO_DIGEST: [F; DIGEST_SIZE] = [F::ZERO; DIGEST_SIZE];
-    let def_circuit_commit_padded = poseidon2_compress_with_capacity(def_circuit_commit, ZERO_DIGEST).0;
+    let def_circuit_commit_padded =
+        poseidon2_compress_with_capacity(def_circuit_commit, ZERO_DIGEST).0;
     let input_onion_padded = poseidon2_compress_with_capacity(input_onion, ZERO_DIGEST).0;
     let output_onion_padded = poseidon2_compress_with_capacity(output_onion, ZERO_DIGEST).0;
     cols.def_circuit_commit_padded = def_circuit_commit_padded;

--- a/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
@@ -25,10 +25,10 @@ use crate::{
 
 pub struct DeferralHookVerifierTraceCtx {
     pub trace_data: SingleAirTraceData<CpuBackend<BabyBearPoseidon2Config>>,
-    pub def_vk_commit: [F; DIGEST_SIZE],
+    pub def_circuit_commit: [F; DIGEST_SIZE],
 }
 
-pub fn def_vk_commit_from_verifier_pvs(verifier_pvs: &VerifierBasePvs<F>) -> [F; DIGEST_SIZE] {
+pub fn def_circuit_commit_from_verifier_pvs(verifier_pvs: &VerifierBasePvs<F>) -> [F; DIGEST_SIZE] {
     let hash_elements = [
         verifier_pvs.app_dag_commit.cached_commit,
         verifier_pvs.app_dag_commit.vk_pre_hash,
@@ -70,24 +70,24 @@ pub fn generate_proving_ctx(
 
     let mut poseidon2_compress_inputs = Vec::with_capacity(6);
     let mut poseidon2_permute_inputs = Vec::with_capacity(NUM_DIGESTS_IN_VK_COMMIT - 1);
-    let (intermediate_vk_states, def_vk_commit) = hash_slice_trace(
+    let (intermediate_vk_states, def_circuit_commit) = hash_slice_trace(
         &hash_elements,
         Some(&mut poseidon2_permute_inputs),
         Some(&mut poseidon2_compress_inputs),
     );
     cols.intermediate_vk_states = intermediate_vk_states.try_into().unwrap();
-    cols.def_vk_commit = def_vk_commit;
+    cols.def_circuit_commit = def_circuit_commit;
 
     const ZERO_DIGEST: [F; DIGEST_SIZE] = [F::ZERO; DIGEST_SIZE];
-    let def_vk_commit_padded = poseidon2_compress_with_capacity(def_vk_commit, ZERO_DIGEST).0;
+    let def_circuit_commit_padded = poseidon2_compress_with_capacity(def_circuit_commit, ZERO_DIGEST).0;
     let input_onion_padded = poseidon2_compress_with_capacity(input_onion, ZERO_DIGEST).0;
     let output_onion_padded = poseidon2_compress_with_capacity(output_onion, ZERO_DIGEST).0;
-    cols.def_vk_commit_padded = def_vk_commit_padded;
+    cols.def_circuit_commit_padded = def_circuit_commit_padded;
     cols.input_onion_padded = input_onion_padded;
     cols.output_onion_padded = output_onion_padded;
 
     let zero_hash = zero_hash(1);
-    let initial_acc_hash = poseidon2_compress_with_capacity(def_vk_commit_padded, zero_hash).0;
+    let initial_acc_hash = poseidon2_compress_with_capacity(def_circuit_commit_padded, zero_hash).0;
     let final_acc_hash =
         poseidon2_compress_with_capacity(input_onion_padded, output_onion_padded).0;
 
@@ -98,10 +98,10 @@ pub fn generate_proving_ctx(
     root_pvs.depth = F::ONE;
 
     poseidon2_compress_inputs.extend_from_slice(&[
-        pad_slice_to_poseidon2_input(&def_vk_commit, F::ZERO),
+        pad_slice_to_poseidon2_input(&def_circuit_commit, F::ZERO),
         pad_slice_to_poseidon2_input(&input_onion, F::ZERO),
         pad_slice_to_poseidon2_input(&output_onion, F::ZERO),
-        digests_to_poseidon2_input(def_vk_commit_padded, zero_hash),
+        digests_to_poseidon2_input(def_circuit_commit_padded, zero_hash),
         digests_to_poseidon2_input(input_onion_padded, output_onion_padded),
     ]);
 
@@ -115,6 +115,6 @@ pub fn generate_proving_ctx(
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
         },
-        def_vk_commit,
+        def_circuit_commit,
     }
 }

--- a/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
@@ -30,12 +30,12 @@ pub struct DeferralHookVerifierTraceCtx {
 
 pub fn def_circuit_commit_from_verifier_pvs(verifier_pvs: &VerifierBasePvs<F>) -> [F; DIGEST_SIZE] {
     let hash_elements = [
-        verifier_pvs.app_dag_commit.cached_commit,
-        verifier_pvs.app_dag_commit.vk_pre_hash,
-        verifier_pvs.leaf_dag_commit.cached_commit,
-        verifier_pvs.leaf_dag_commit.vk_pre_hash,
-        verifier_pvs.internal_for_leaf_dag_commit.cached_commit,
-        verifier_pvs.internal_for_leaf_dag_commit.vk_pre_hash,
+        verifier_pvs.app_vk_commit.cached_commit,
+        verifier_pvs.app_vk_commit.vk_pre_hash,
+        verifier_pvs.leaf_vk_commit.cached_commit,
+        verifier_pvs.leaf_vk_commit.vk_pre_hash,
+        verifier_pvs.internal_for_leaf_vk_commit.cached_commit,
+        verifier_pvs.internal_for_leaf_vk_commit.vk_pre_hash,
     ];
     hash_slice_trace(&hash_elements, None, None).1
 }
@@ -52,12 +52,12 @@ pub fn generate_proving_ctx(
         proof.public_values[DEF_AGG_PVS_AIR_ID].as_slice().borrow();
 
     let hash_elements = [
-        verifier_pvs.app_dag_commit.cached_commit,
-        verifier_pvs.app_dag_commit.vk_pre_hash,
-        verifier_pvs.leaf_dag_commit.cached_commit,
-        verifier_pvs.leaf_dag_commit.vk_pre_hash,
-        verifier_pvs.internal_for_leaf_dag_commit.cached_commit,
-        verifier_pvs.internal_for_leaf_dag_commit.vk_pre_hash,
+        verifier_pvs.app_vk_commit.cached_commit,
+        verifier_pvs.app_vk_commit.vk_pre_hash,
+        verifier_pvs.leaf_vk_commit.cached_commit,
+        verifier_pvs.leaf_vk_commit.vk_pre_hash,
+        verifier_pvs.internal_for_leaf_vk_commit.cached_commit,
+        verifier_pvs.internal_for_leaf_vk_commit.vk_pre_hash,
     ];
 
     let width = DeferralHookPvsCols::<u8>::width();

--- a/crates/continuations/src/circuit/deferral/inner/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/trace.rs
@@ -15,7 +15,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     poseidon2_compress_with_capacity, BabyBearPoseidon2Config, DIGEST_SIZE, F,
 };
-use openvm_verify_stark_host::pvs::DagCommit;
+use openvm_verify_stark_host::pvs::VkCommit;
 
 use crate::{
     circuit::deferral::{
@@ -116,7 +116,7 @@ pub trait DeferralInnerTraceGen<PB: ProverBackend> {
         &self,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         child_is_agg: bool,
-        child_dag_commit: DagCommit<F>,
+        child_vk_commit: VkCommit<F>,
         child_merkle_depth: Option<usize>,
     ) -> DeferralInnerPreCtx<PB>;
 }
@@ -132,7 +132,7 @@ impl DeferralInnerTraceGen<CpuBackend<BabyBearPoseidon2Config>> for DeferralInne
         &self,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         child_is_agg: bool,
-        child_dag_commit: DagCommit<F>,
+        child_vk_commit: VkCommit<F>,
         child_merkle_depth: Option<usize>,
     ) -> DeferralInnerPreCtx<CpuBackend<BabyBearPoseidon2Config>> {
         let (poseidon2_compress_inputs, poseidon2_permute_inputs) =
@@ -141,7 +141,7 @@ impl DeferralInnerTraceGen<CpuBackend<BabyBearPoseidon2Config>> for DeferralInne
             verifier_pvs_ctx: super::verifier::generate_proving_ctx(
                 proofs,
                 child_is_agg,
-                child_dag_commit,
+                child_vk_commit,
             ),
             def_pvs_ctx: super::def_pvs::generate_proving_ctx(
                 proofs,
@@ -165,7 +165,7 @@ impl DeferralInnerTraceGen<GpuBackend> for DeferralInnerTraceGenImpl {
         &self,
         proofs: &[Proof<BabyBearPoseidon2Config>],
         child_is_agg: bool,
-        child_dag_commit: DagCommit<F>,
+        child_vk_commit: VkCommit<F>,
         child_merkle_depth: Option<usize>,
     ) -> DeferralInnerPreCtx<GpuBackend> {
         let DeferralInnerPreCtx {
@@ -178,7 +178,7 @@ impl DeferralInnerTraceGen<GpuBackend> for DeferralInnerTraceGenImpl {
             self,
             proofs,
             child_is_agg,
-            child_dag_commit,
+            child_vk_commit,
             child_merkle_depth,
         );
         DeferralInnerPreCtx {

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -18,7 +18,7 @@ use p3_matrix::Matrix;
 
 use crate::circuit::{
     deferral::inner::bus::{DefPvsConsistencyBus, DefPvsConsistencyMessage},
-    utils::{assert_dag_commit_eq, assert_dag_commit_unset},
+    utils::{assert_vk_commit_eq, assert_vk_commit_unset},
 };
 
 #[repr(C)]
@@ -97,8 +97,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * Similarly, if the child recursion_flag is 1 then we know that we are on the 2nd (i.e.
          * index 1) internal_recursive layer, and if it's 2 then we are on the 3rd or beyond.
          */
-        // constrain verifier pvs columns are the same across all rows (note app_dag_commit is
-        // def_dag_commit here)
+        // constrain verifier pvs columns are the same across all rows (note app_vk_commit is
+        // def_vk_commit here)
         let mut when_both = builder.when(and(local.is_valid, next.is_valid));
         let is_leaf = not(local.has_verifier_pvs);
         let is_internal = local.has_verifier_pvs;
@@ -109,25 +109,25 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             local.child_pvs.recursion_flag,
             next.child_pvs.recursion_flag,
         );
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_both,
-            local.child_pvs.app_dag_commit,
-            next.child_pvs.app_dag_commit,
+            local.child_pvs.app_vk_commit,
+            next.child_pvs.app_vk_commit,
         );
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_both,
-            local.child_pvs.leaf_dag_commit,
-            next.child_pvs.leaf_dag_commit,
+            local.child_pvs.leaf_vk_commit,
+            next.child_pvs.leaf_vk_commit,
         );
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_both,
-            local.child_pvs.internal_for_leaf_dag_commit,
-            next.child_pvs.internal_for_leaf_dag_commit,
+            local.child_pvs.internal_for_leaf_vk_commit,
+            next.child_pvs.internal_for_leaf_vk_commit,
         );
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_both,
-            local.child_pvs.internal_recursive_dag_commit,
-            next.child_pvs.internal_recursive_dag_commit,
+            local.child_pvs.internal_recursive_vk_commit,
+            next.child_pvs.internal_recursive_vk_commit,
         );
 
         // constrain that the flags are ternary
@@ -150,24 +150,24 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .when(is_leaf.clone())
             .assert_zero(local.child_pvs.internal_flag);
 
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(is_leaf.clone()),
-            local.child_pvs.app_dag_commit,
+            local.child_pvs.app_vk_commit,
         );
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(
                 (local.child_pvs.internal_flag - AB::F::ONE)
                     * (local.child_pvs.internal_flag - AB::F::TWO),
             ),
-            local.child_pvs.leaf_dag_commit,
+            local.child_pvs.leaf_vk_commit,
         );
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(local.child_pvs.internal_flag - AB::F::TWO),
-            local.child_pvs.internal_for_leaf_dag_commit,
+            local.child_pvs.internal_for_leaf_vk_commit,
         );
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(local.child_pvs.recursion_flag - AB::F::TWO),
-            local.child_pvs.internal_recursive_dag_commit,
+            local.child_pvs.internal_recursive_vk_commit,
         );
 
         /*
@@ -211,11 +211,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          */
         let &VerifierBasePvs::<_> {
             internal_flag,
-            app_dag_commit: def_dag_commit,
-            leaf_dag_commit,
-            internal_for_leaf_dag_commit,
+            app_vk_commit: def_vk_commit,
+            leaf_vk_commit,
+            internal_for_leaf_vk_commit,
             recursion_flag,
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
         } = builder.public_values().borrow();
 
         // constrain internal_flag is 0 at the leaf level
@@ -238,21 +238,21 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .when_ne(local.child_pvs.internal_flag, AB::F::TWO)
             .assert_eq(internal_flag, local.child_pvs.internal_flag + AB::F::ONE);
 
-        // constrain def_dag_commit is set at all internal levels
-        assert_dag_commit_eq(
+        // constrain def_vk_commit is set at all internal levels
+        assert_vk_commit_eq(
             &mut builder.when(is_internal),
-            local.child_pvs.app_dag_commit,
-            def_dag_commit,
+            local.child_pvs.app_vk_commit,
+            def_vk_commit,
         );
 
         // constrain verifier-specific pvs at all internal_recursive levels
         builder
             .when(local.child_pvs.internal_flag)
             .assert_zero(internal_flag.into() - AB::F::TWO);
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when(local.child_pvs.internal_flag),
-            local.child_pvs.leaf_dag_commit,
-            leaf_dag_commit,
+            local.child_pvs.leaf_vk_commit,
+            leaf_vk_commit,
         );
 
         // constrain recursion_flag is 1 at the first internal_recursive level
@@ -264,19 +264,19 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         builder
             .when(local.child_pvs.recursion_flag)
             .assert_eq(recursion_flag, AB::F::TWO);
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when(local.child_pvs.recursion_flag),
-            local.child_pvs.internal_for_leaf_dag_commit,
-            internal_for_leaf_dag_commit,
+            local.child_pvs.internal_for_leaf_vk_commit,
+            internal_for_leaf_vk_commit,
         );
 
         // constrain verifier-specific pvs at internal_recursive levels after the second
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when(
                 local.child_pvs.recursion_flag * (local.child_pvs.recursion_flag - AB::F::ONE),
             ),
-            local.child_pvs.internal_recursive_dag_commit,
-            internal_recursive_dag_commit,
+            local.child_pvs.internal_recursive_vk_commit,
+            internal_recursive_vk_commit,
         );
 
         /*
@@ -295,12 +295,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             * local.child_pvs.recursion_flag
             * AB::F::TWO.inverse();
         let cached_commit = from_fn(|i| {
-            is_internal_flag_zero.clone() * local.child_pvs.app_dag_commit.cached_commit[i]
-                + is_internal_flag_one.clone() * local.child_pvs.leaf_dag_commit.cached_commit[i]
+            is_internal_flag_zero.clone() * local.child_pvs.app_vk_commit.cached_commit[i]
+                + is_internal_flag_one.clone() * local.child_pvs.leaf_vk_commit.cached_commit[i]
                 + is_recursion_flag_one.clone()
-                    * local.child_pvs.internal_for_leaf_dag_commit.cached_commit[i]
+                    * local.child_pvs.internal_for_leaf_vk_commit.cached_commit[i]
                 + is_recursion_flag_two.clone()
-                    * local.child_pvs.internal_recursive_dag_commit.cached_commit[i]
+                    * local.child_pvs.internal_recursive_vk_commit.cached_commit[i]
         });
 
         self.cached_commit_bus.receive(
@@ -333,11 +333,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             (recursion_flag.clone() - AB::Expr::ONE) * recursion_flag.clone() * half;
 
         let vk_pre_hash = from_fn(|i| {
-            is_internal_flag_zero.clone() * def_dag_commit.vk_pre_hash[i].into()
-                + is_internal_flag_one.clone() * leaf_dag_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_one.clone() * internal_for_leaf_dag_commit.vk_pre_hash[i].into()
+            is_internal_flag_zero.clone() * def_vk_commit.vk_pre_hash[i].into()
+                + is_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
+                + is_recursion_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
                 + is_recursion_flag_two.clone()
-                    * internal_recursive_dag_commit.vk_pre_hash[i].into()
+                    * internal_recursive_vk_commit.vk_pre_hash[i].into()
         });
 
         self.pre_hash_bus.receive(

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -336,8 +336,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             is_internal_flag_zero.clone() * def_vk_commit.vk_pre_hash[i].into()
                 + is_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
                 + is_recursion_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_two.clone()
-                    * internal_recursive_vk_commit.vk_pre_hash[i].into()
+                + is_recursion_flag_two.clone() * internal_recursive_vk_commit.vk_pre_hash[i].into()
         });
 
         self.pre_hash_bus.receive(

--- a/crates/continuations/src/circuit/deferral/inner/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/trace.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{proof::Proof, prover::AirProvingContext};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
-use openvm_verify_stark_host::pvs::{VkCommit, VerifierBasePvs, VERIFIER_PVS_AIR_ID};
+use openvm_verify_stark_host::pvs::{VerifierBasePvs, VkCommit, VERIFIER_PVS_AIR_ID};
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::dense::RowMajorMatrix;
 

--- a/crates/continuations/src/circuit/deferral/inner/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/trace.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{proof::Proof, prover::AirProvingContext};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
-use openvm_verify_stark_host::pvs::{DagCommit, VerifierBasePvs, VERIFIER_PVS_AIR_ID};
+use openvm_verify_stark_host::pvs::{VkCommit, VerifierBasePvs, VERIFIER_PVS_AIR_ID};
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::dense::RowMajorMatrix;
 
@@ -12,7 +12,7 @@ use crate::circuit::deferral::inner::verifier::air::{DeferralChildLevel, Deferra
 pub fn generate_proving_ctx(
     proofs: &[Proof<BabyBearPoseidon2Config>],
     child_is_agg: bool,
-    child_dag_commit: DagCommit<F>,
+    child_vk_commit: VkCommit<F>,
 ) -> AirProvingContext<CpuBackend<BabyBearPoseidon2Config>> {
     let num_proofs = proofs.len();
     let height = num_proofs.next_power_of_two();
@@ -49,22 +49,22 @@ pub fn generate_proving_ctx(
         trace[(num_proofs - 1) * width..num_proofs * width].borrow();
     let mut pvs = last_row.child_pvs;
 
-    // Note app_dag_commit is def_dag_commit here
+    // Note app_vk_commit is def_vk_commit here
     match child_level {
         DeferralChildLevel::App => {
-            pvs.app_dag_commit = child_dag_commit;
+            pvs.app_vk_commit = child_vk_commit;
         }
         DeferralChildLevel::Leaf => {
-            pvs.leaf_dag_commit = child_dag_commit;
+            pvs.leaf_vk_commit = child_vk_commit;
             pvs.internal_flag = F::ONE;
         }
         DeferralChildLevel::InternalForLeaf => {
-            pvs.internal_for_leaf_dag_commit = child_dag_commit;
+            pvs.internal_for_leaf_vk_commit = child_vk_commit;
             pvs.internal_flag = F::TWO;
             pvs.recursion_flag = F::ONE;
         }
         DeferralChildLevel::InternalRecursive => {
-            pvs.internal_recursive_dag_commit = child_dag_commit;
+            pvs.internal_recursive_vk_commit = child_vk_commit;
             pvs.internal_flag = F::TWO;
             pvs.recursion_flag = F::TWO;
         }

--- a/crates/continuations/src/circuit/inner/trace.rs
+++ b/crates/continuations/src/circuit/inner/trace.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     prover::{AirProvingContext, ProverBackend},
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
-use openvm_verify_stark_host::pvs::{DagCommit, DeferralPvs};
+use openvm_verify_stark_host::pvs::{VkCommit, DeferralPvs};
 
 use crate::circuit::{SingleAirTraceData, SubCircuitTraceData};
 
@@ -30,7 +30,7 @@ pub trait InnerTraceGen<PB: ProverBackend> {
         proofs_type: ProofsType,
         absent_trace_pvs: Option<(DeferralPvs<F>, bool)>,
         child_is_app: bool,
-        child_dag_commit: DagCommit<F>,
+        child_vk_commit: VkCommit<F>,
     ) -> SubCircuitTraceData<PB>;
     fn generate_post_verifier_subcircuit_ctxs(
         &self,
@@ -55,7 +55,7 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>> for InnerTraceGenImpl {
         proofs_type: ProofsType,
         absent_trace_pvs: Option<(DeferralPvs<F>, bool)>,
         child_is_app: bool,
-        child_dag_commit: DagCommit<F>,
+        child_vk_commit: VkCommit<F>,
     ) -> SubCircuitTraceData<CpuBackend<BabyBearPoseidon2Config>> {
         let SingleAirTraceData {
             air_proving_ctx: verifier_pvs_ctx,
@@ -65,7 +65,7 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>> for InnerTraceGenImpl {
             proofs,
             proofs_type,
             child_is_app,
-            child_dag_commit,
+            child_vk_commit,
             self.deferral_enabled,
         );
         let vm_pvs_ctx = super::vm_pvs::generate_proving_ctx(
@@ -136,14 +136,14 @@ impl InnerTraceGen<GpuBackend> for InnerTraceGenImpl {
         proofs_type: ProofsType,
         absent_trace_pvs: Option<(DeferralPvs<F>, bool)>,
         child_is_app: bool,
-        child_dag_commit: DagCommit<F>,
+        child_vk_commit: VkCommit<F>,
     ) -> SubCircuitTraceData<GpuBackend> {
         let data = self.generate_pre_verifier_subcircuit_ctxs(
             proofs,
             proofs_type,
             absent_trace_pvs,
             child_is_app,
-            child_dag_commit,
+            child_vk_commit,
         );
         SubCircuitTraceData {
             air_proving_ctxs: data

--- a/crates/continuations/src/circuit/inner/trace.rs
+++ b/crates/continuations/src/circuit/inner/trace.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     prover::{AirProvingContext, ProverBackend},
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
-use openvm_verify_stark_host::pvs::{VkCommit, DeferralPvs};
+use openvm_verify_stark_host::pvs::{DeferralPvs, VkCommit};
 
 use crate::circuit::{SingleAirTraceData, SubCircuitTraceData};
 

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -501,7 +501,7 @@ impl VerifierPvsAir {
 
         /*
          * We also need to constrain the deferral-related public values. In particular, the
-         * def_hook_vk_commit should be defined exactly when internal_for_leaf_dag_commit
+         * def_hook_commit should be defined exactly when internal_for_leaf_dag_commit
          * is for deferral_flag == 1.
          */
         // constrain that delta == 1 only at some internal_recursive layer
@@ -513,10 +513,10 @@ impl VerifierPvsAir {
             .when_ne(def_local.child_pvs.deferral_flag, AB::F::ONE)
             .assert_eq(base_local.child_pvs.internal_flag, AB::F::TWO);
 
-        // constrain that def_hook_vk_commit is unset when internal_flag < 2
+        // constrain that def_hook_commit is unset when internal_flag < 2
         assert_zeros(
             &mut builder.when(base_local.child_pvs.internal_flag - AB::F::TWO),
-            def_local.child_pvs.def_hook_vk_commit,
+            def_local.child_pvs.def_hook_commit,
         );
 
         /*
@@ -553,7 +553,7 @@ impl VerifierPvsAir {
 
         let &VerifierDefPvs::<_> {
             deferral_flag,
-            def_hook_vk_commit,
+            def_hook_commit,
         } = def_pvs.as_slice().borrow();
 
         // constrain deferral_flag either matches each row, or is 2 when delta is non-zero
@@ -565,16 +565,16 @@ impl VerifierPvsAir {
             .when_ne(delta.clone(), -AB::F::ONE)
             .assert_eq(deferral_flag, def_local.child_pvs.deferral_flag);
 
-        // constrain def_hook_vk_commit matches if set in child_pvs
+        // constrain def_hook_commit matches if set in child_pvs
         assert_array_eq(
             &mut builder
                 .when(base_local.child_pvs.recursion_flag)
                 .when(def_local.child_pvs.deferral_flag),
-            def_local.child_pvs.def_hook_vk_commit,
-            def_hook_vk_commit,
+            def_local.child_pvs.def_hook_commit,
+            def_hook_commit,
         );
 
-        // constrain the child def_hook_vk_commit is defined when internal_flag is 2 and
+        // constrain the child def_hook_commit is defined when internal_flag is 2 and
         // deferral_flag is non-zero
         let is_child_def_hook_vk_defined = base_local.child_pvs.internal_flag
             * (base_local.child_pvs.internal_flag - AB::Expr::ONE)
@@ -582,13 +582,13 @@ impl VerifierPvsAir {
 
         assert_array_eq(
             &mut builder.when(is_child_def_hook_vk_defined),
-            def_local.child_pvs.def_hook_vk_commit,
-            def_hook_vk_commit,
+            def_local.child_pvs.def_hook_commit,
+            def_hook_commit,
         );
 
-        // constrain def_hook_vk_commit = hash_slice(vk_commit_components) when
+        // constrain def_hook_commit = hash_slice(vk_commit_components) when
         // internal_flag is 2 and deferral_flag is 1
-        let compute_def_hook_vk_commit = internal_flag.into()
+        let compute_def_hook_commit = internal_flag.into()
             * (internal_flag.into() - AB::Expr::ONE)
             * deferral_flag.into()
             * (AB::Expr::TWO - deferral_flag.into())
@@ -605,8 +605,8 @@ impl VerifierPvsAir {
                     .intermediate_states
                     .map(|v| v.map(Into::into))
                     .as_slice(),
-                result: &def_hook_vk_commit.map(Into::into),
-                enabled: &compute_def_hook_vk_commit,
+                result: &def_hook_commit.map(Into::into),
+                enabled: &compute_def_hook_commit,
             },
         );
 

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -28,7 +28,7 @@ use crate::circuit::{
     inner::bus::{PvsAirConsistencyBus, PvsAirConsistencyMessage},
     root::NUM_DIGESTS_IN_VK_COMMIT,
     subair::{HashSliceCtx, HashSliceSubAir},
-    utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
+    utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
 };
 
 #[repr(C)]
@@ -77,11 +77,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
 
         /*
          * This AIR can optionally handle deferrals, the constraints for which are defined in
-         * function eval_deferrals. We expect dag_commit_cond to be a boolean value that is
+         * function eval_deferrals. We expect vk_commit_cond to be a boolean value that is
          * true iff local and next's app, leaf, and internal-for-leaf DAG commits should be
          * constrained for equality.
          */
-        let (dag_commit_cond, deferral_flag, consistency_mult) = match &self.deferral_config {
+        let (vk_commit_cond, deferral_flag, consistency_mult) = match &self.deferral_config {
             VerifierDeferralConfig::Enabled {
                 hash_slice_subair: subair,
             } => {
@@ -130,7 +130,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
          *   - recursion_flag == 1: 2nd (i.e. index 1) internal_recursive layer
          *   - recursion_flag == 1: 3rd internal_recursive layer or beyond
          */
-        // constrain the verifier pvs flags and internal_recursive_dag_commit are the same
+        // constrain the verifier pvs flags and internal_recursive_vk_commit are the same
         // across all valid rows
         let both_valid = and(local.is_valid, next.is_valid);
         let mut when_both_valid = builder.when(both_valid.clone());
@@ -142,29 +142,29 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             next.child_pvs.recursion_flag,
         );
 
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_both_valid,
-            local.child_pvs.internal_recursive_dag_commit,
-            next.child_pvs.internal_recursive_dag_commit,
+            local.child_pvs.internal_recursive_vk_commit,
+            next.child_pvs.internal_recursive_vk_commit,
         );
 
         // constrain the other commits are the same when needed
-        let mut when_dag_compare = builder.when(dag_commit_cond);
+        let mut when_dag_compare = builder.when(vk_commit_cond);
 
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_dag_compare,
-            local.child_pvs.app_dag_commit,
-            next.child_pvs.app_dag_commit,
+            local.child_pvs.app_vk_commit,
+            next.child_pvs.app_vk_commit,
         );
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_dag_compare,
-            local.child_pvs.leaf_dag_commit,
-            next.child_pvs.leaf_dag_commit,
+            local.child_pvs.leaf_vk_commit,
+            next.child_pvs.leaf_vk_commit,
         );
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut when_dag_compare,
-            local.child_pvs.internal_for_leaf_dag_commit,
-            next.child_pvs.internal_for_leaf_dag_commit,
+            local.child_pvs.internal_for_leaf_vk_commit,
+            next.child_pvs.internal_for_leaf_vk_commit,
         );
 
         // constrain that the flags are ternary
@@ -190,24 +190,24 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .when(is_leaf.clone())
             .assert_zero(local.child_pvs.internal_flag);
 
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(is_leaf.clone()),
-            local.child_pvs.app_dag_commit,
+            local.child_pvs.app_vk_commit,
         );
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(
                 (local.child_pvs.internal_flag - AB::F::ONE)
                     * (local.child_pvs.internal_flag - AB::F::TWO),
             ),
-            local.child_pvs.leaf_dag_commit,
+            local.child_pvs.leaf_vk_commit,
         );
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(local.child_pvs.internal_flag - AB::F::TWO),
-            local.child_pvs.internal_for_leaf_dag_commit,
+            local.child_pvs.internal_for_leaf_vk_commit,
         );
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when(local.child_pvs.recursion_flag - AB::F::TWO),
-            local.child_pvs.internal_recursive_dag_commit,
+            local.child_pvs.internal_recursive_vk_commit,
         );
 
         /*
@@ -245,12 +245,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         let is_recursion_flag_two =
             (local.child_pvs.recursion_flag - AB::F::ONE) * local.child_pvs.recursion_flag * half;
         let cached_commit = from_fn(|i| {
-            is_internal_flag_zero.clone() * local.child_pvs.app_dag_commit.cached_commit[i]
-                + is_internal_flag_one.clone() * local.child_pvs.leaf_dag_commit.cached_commit[i]
+            is_internal_flag_zero.clone() * local.child_pvs.app_vk_commit.cached_commit[i]
+                + is_internal_flag_one.clone() * local.child_pvs.leaf_vk_commit.cached_commit[i]
                 + is_recursion_flag_one.clone()
-                    * local.child_pvs.internal_for_leaf_dag_commit.cached_commit[i]
+                    * local.child_pvs.internal_for_leaf_vk_commit.cached_commit[i]
                 + is_recursion_flag_two.clone()
-                    * local.child_pvs.internal_recursive_dag_commit.cached_commit[i]
+                    * local.child_pvs.internal_recursive_vk_commit.cached_commit[i]
         });
 
         self.cached_commit_bus.receive(
@@ -288,11 +288,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         let base_pvs_width = VerifierBasePvs::<AB::Var>::width();
         let &VerifierBasePvs::<_> {
             internal_flag,
-            app_dag_commit,
-            leaf_dag_commit,
-            internal_for_leaf_dag_commit,
+            app_vk_commit,
+            leaf_vk_commit,
+            internal_for_leaf_vk_commit,
             recursion_flag,
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
         } = builder.public_values()[0..base_pvs_width].borrow();
 
         // constrain internal_flag is 0 at the leaf level
@@ -315,21 +315,21 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .when_ne(local.child_pvs.internal_flag, AB::F::TWO)
             .assert_eq(internal_flag, local.child_pvs.internal_flag + AB::F::ONE);
 
-        // constrain app_dag_commit is set at all internal levels and matches the first row
-        assert_dag_commit_eq(
+        // constrain app_vk_commit is set at all internal levels and matches the first row
+        assert_vk_commit_eq(
             &mut builder.when_first_row().when(is_internal),
-            local.child_pvs.app_dag_commit,
-            app_dag_commit,
+            local.child_pvs.app_vk_commit,
+            app_vk_commit,
         );
 
         // constrain verifier-specific pvs at all internal_recursive levels
         builder
             .when(local.child_pvs.internal_flag)
             .assert_zero(internal_flag.into() - AB::F::TWO);
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when_first_row().when(local.child_pvs.internal_flag),
-            local.child_pvs.leaf_dag_commit,
-            leaf_dag_commit,
+            local.child_pvs.leaf_vk_commit,
+            leaf_vk_commit,
         );
 
         // constrain recursion_flag is 1 at the first internal_recursive level
@@ -341,21 +341,21 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         builder
             .when(local.child_pvs.recursion_flag)
             .assert_eq(recursion_flag, AB::F::TWO);
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder
                 .when_first_row()
                 .when(local.child_pvs.recursion_flag),
-            local.child_pvs.internal_for_leaf_dag_commit,
-            internal_for_leaf_dag_commit,
+            local.child_pvs.internal_for_leaf_vk_commit,
+            internal_for_leaf_vk_commit,
         );
 
         // constrain verifier-specific pvs at internal_recursive levels after the second
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when(
                 local.child_pvs.recursion_flag * (local.child_pvs.recursion_flag - AB::F::ONE),
             ),
-            local.child_pvs.internal_recursive_dag_commit,
-            internal_recursive_dag_commit,
+            local.child_pvs.internal_recursive_vk_commit,
+            internal_recursive_vk_commit,
         );
 
         /*
@@ -375,11 +375,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             (recursion_flag.clone() - AB::Expr::ONE) * recursion_flag.clone() * half;
 
         let vk_pre_hash = from_fn(|i| {
-            is_internal_flag_zero.clone() * app_dag_commit.vk_pre_hash[i].into()
-                + is_internal_flag_one.clone() * leaf_dag_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_one.clone() * internal_for_leaf_dag_commit.vk_pre_hash[i].into()
+            is_internal_flag_zero.clone() * app_vk_commit.vk_pre_hash[i].into()
+                + is_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
+                + is_recursion_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
                 + is_recursion_flag_two.clone()
-                    * internal_recursive_dag_commit.vk_pre_hash[i].into()
+                    * internal_recursive_vk_commit.vk_pre_hash[i].into()
         });
 
         self.pre_hash_bus.receive(
@@ -501,7 +501,7 @@ impl VerifierPvsAir {
 
         /*
          * We also need to constrain the deferral-related public values. In particular, the
-         * def_hook_commit should be defined exactly when internal_for_leaf_dag_commit
+         * def_hook_commit should be defined exactly when internal_for_leaf_vk_commit
          * is for deferral_flag == 1.
          */
         // constrain that delta == 1 only at some internal_recursive layer
@@ -612,15 +612,15 @@ impl VerifierPvsAir {
 
         /*
          * Finally, we need to generate some expressions for use in the outer constraints.
-         * dag_commit_cond is non-zero iff on a transition row and all deferral flags are
+         * vk_commit_cond is non-zero iff on a transition row and all deferral flags are
          * the same, and consistency_mult is the number of lookups this AIR will receive
          * on the PvsAirConsistencyBus.
          */
-        let dag_commit_cond =
+        let vk_commit_cond =
             and(base_local.is_valid, not(def_local.is_last)) * (AB::Expr::ONE - delta);
         let deferral_flag = def_local.child_pvs.deferral_flag.into();
         let consistency_mult = base_local.has_verifier_pvs + AB::Expr::ONE;
 
-        (dag_commit_cond, deferral_flag, consistency_mult)
+        (vk_commit_cond, deferral_flag, consistency_mult)
     }
 }

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -26,7 +26,7 @@ use p3_matrix::Matrix;
 
 use crate::circuit::{
     inner::bus::{PvsAirConsistencyBus, PvsAirConsistencyMessage},
-    root::NUM_DIGESTS_IN_VK_COMMIT,
+    root::NUM_DIGESTS_IN_VM_COMMIT,
     subair::{HashSliceCtx, HashSliceSubAir},
     utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
 };
@@ -378,8 +378,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             is_internal_flag_zero.clone() * app_vk_commit.vk_pre_hash[i].into()
                 + is_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
                 + is_recursion_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_two.clone()
-                    * internal_recursive_vk_commit.vk_pre_hash[i].into()
+                + is_recursion_flag_two.clone() * internal_recursive_vk_commit.vk_pre_hash[i].into()
         });
 
         self.pre_hash_bus.receive(
@@ -420,7 +419,7 @@ impl VerifierDeferralConfig {
 #[derive(AlignedBorrow)]
 pub struct VerifierDeferralCols<F> {
     pub is_last: F,
-    pub intermediate_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
+    pub intermediate_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
     pub child_pvs: VerifierDefPvs<F>,
 }
 

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -78,7 +78,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         /*
          * This AIR can optionally handle deferrals, the constraints for which are defined in
          * function eval_deferrals. We expect vk_commit_cond to be a boolean value that is
-         * true iff local and next's app, leaf, and internal-for-leaf DAG commits should be
+         * true iff local and next's app, leaf, and internal-for-leaf vk commits should be
          * constrained for equality.
          */
         let (vk_commit_cond, deferral_flag, consistency_mult) = match &self.deferral_config {
@@ -149,20 +149,20 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         );
 
         // constrain the other commits are the same when needed
-        let mut when_dag_compare = builder.when(vk_commit_cond);
+        let mut when_vk_compare = builder.when(vk_commit_cond);
 
         assert_vk_commit_eq(
-            &mut when_dag_compare,
+            &mut when_vk_compare,
             local.child_pvs.app_vk_commit,
             next.child_pvs.app_vk_commit,
         );
         assert_vk_commit_eq(
-            &mut when_dag_compare,
+            &mut when_vk_compare,
             local.child_pvs.leaf_vk_commit,
             next.child_pvs.leaf_vk_commit,
         );
         assert_vk_commit_eq(
-            &mut when_dag_compare,
+            &mut when_vk_compare,
             local.child_pvs.internal_for_leaf_vk_commit,
             next.child_pvs.internal_for_leaf_vk_commit,
         );

--- a/crates/continuations/src/circuit/inner/verifier/trace.rs
+++ b/crates/continuations/src/circuit/inner/verifier/trace.rs
@@ -149,7 +149,7 @@ pub fn generate_proving_ctx(
         }
     };
 
-    let mut def_hook_vk_commit = None;
+    let mut def_hook_commit = None;
     if deferral_enabled && deferral_flag_pv == F::ONE && base_pvs.internal_flag == F::TWO {
         let hash_elements = [
             base_pvs.app_dag_commit.cached_commit,
@@ -162,7 +162,7 @@ pub fn generate_proving_ctx(
 
         let mut row_compress_inputs = vec![];
         let mut row_permute_inputs = vec![];
-        let (intermediate_states_vec, computed_def_hook_vk_commit) = hash_slice_trace(
+        let (intermediate_states_vec, computed_def_hook_commit) = hash_slice_trace(
             &hash_elements,
             Some(&mut row_permute_inputs),
             Some(&mut row_compress_inputs),
@@ -182,7 +182,7 @@ pub fn generate_proving_ctx(
         for &input in &row_permute_inputs {
             poseidon2_permute_inputs.extend((0..height).map(|_| input));
         }
-        def_hook_vk_commit = Some(computed_def_hook_vk_commit);
+        def_hook_commit = Some(computed_def_hook_commit);
     }
 
     let public_values = if deferral_enabled {
@@ -191,8 +191,8 @@ pub fn generate_proving_ctx(
         let mut def_pvs = last_row_def.child_pvs;
         def_pvs.deferral_flag = deferral_flag_pv;
 
-        if let Some(def_hook_vk_commit) = def_hook_vk_commit {
-            def_pvs.def_hook_vk_commit = def_hook_vk_commit;
+        if let Some(def_hook_commit) = def_hook_commit {
+            def_pvs.def_hook_commit = def_hook_commit;
         }
 
         let mut combined = vec![F::ZERO; VerifierCombinedPvs::<u8>::width()];

--- a/crates/continuations/src/circuit/inner/verifier/trace.rs
+++ b/crates/continuations/src/circuit/inner/verifier/trace.rs
@@ -5,7 +5,7 @@ use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{proof::Proof, prover::AirProvingContext};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
 use openvm_verify_stark_host::pvs::{
-    DagCommit, VerifierBasePvs, VerifierDefPvs, VERIFIER_PVS_AIR_ID,
+    VkCommit, VerifierBasePvs, VerifierDefPvs, VERIFIER_PVS_AIR_ID,
 };
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::dense::RowMajorMatrix;
@@ -31,7 +31,7 @@ pub fn generate_proving_ctx(
     proofs: &[Proof<BabyBearPoseidon2Config>],
     proofs_type: ProofsType,
     child_is_app: bool,
-    child_dag_commit: DagCommit<F>,
+    child_vk_commit: VkCommit<F>,
     deferral_enabled: bool,
 ) -> SingleAirTraceData<CpuBackend<BabyBearPoseidon2Config>> {
     let num_proofs = proofs.len();
@@ -118,19 +118,19 @@ pub fn generate_proving_ctx(
 
     match child_level {
         VerifierChildLevel::App => {
-            base_pvs.app_dag_commit = child_dag_commit;
+            base_pvs.app_vk_commit = child_vk_commit;
         }
         VerifierChildLevel::Leaf => {
-            base_pvs.leaf_dag_commit = child_dag_commit;
+            base_pvs.leaf_vk_commit = child_vk_commit;
             base_pvs.internal_flag = F::ONE;
         }
         VerifierChildLevel::InternalForLeaf => {
-            base_pvs.internal_for_leaf_dag_commit = child_dag_commit;
+            base_pvs.internal_for_leaf_vk_commit = child_vk_commit;
             base_pvs.internal_flag = F::TWO;
             base_pvs.recursion_flag = F::ONE;
         }
         VerifierChildLevel::InternalRecursive => {
-            base_pvs.internal_recursive_dag_commit = child_dag_commit;
+            base_pvs.internal_recursive_vk_commit = child_vk_commit;
             base_pvs.internal_flag = F::TWO;
             base_pvs.recursion_flag = F::TWO;
         }
@@ -152,12 +152,12 @@ pub fn generate_proving_ctx(
     let mut def_hook_commit = None;
     if deferral_enabled && deferral_flag_pv == F::ONE && base_pvs.internal_flag == F::TWO {
         let hash_elements = [
-            base_pvs.app_dag_commit.cached_commit,
-            base_pvs.app_dag_commit.vk_pre_hash,
-            base_pvs.leaf_dag_commit.cached_commit,
-            base_pvs.leaf_dag_commit.vk_pre_hash,
-            base_pvs.internal_for_leaf_dag_commit.cached_commit,
-            base_pvs.internal_for_leaf_dag_commit.vk_pre_hash,
+            base_pvs.app_vk_commit.cached_commit,
+            base_pvs.app_vk_commit.vk_pre_hash,
+            base_pvs.leaf_vk_commit.cached_commit,
+            base_pvs.leaf_vk_commit.vk_pre_hash,
+            base_pvs.internal_for_leaf_vk_commit.cached_commit,
+            base_pvs.internal_for_leaf_vk_commit.vk_pre_hash,
         ];
 
         let mut row_compress_inputs = vec![];

--- a/crates/continuations/src/circuit/inner/verifier/trace.rs
+++ b/crates/continuations/src/circuit/inner/verifier/trace.rs
@@ -5,7 +5,7 @@ use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{proof::Proof, prover::AirProvingContext};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
 use openvm_verify_stark_host::pvs::{
-    VkCommit, VerifierBasePvs, VerifierDefPvs, VERIFIER_PVS_AIR_ID,
+    VerifierBasePvs, VerifierDefPvs, VkCommit, VERIFIER_PVS_AIR_ID,
 };
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::dense::RowMajorMatrix;

--- a/crates/continuations/src/circuit/mod.rs
+++ b/crates/continuations/src/circuit/mod.rs
@@ -39,21 +39,21 @@ pub mod utils {
     use openvm_circuit_primitives::utils::assert_array_eq;
     use openvm_recursion_circuit::utils::assert_zeros;
     use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
-    use openvm_verify_stark_host::pvs::{DagCommit, VerifierBasePvs};
+    use openvm_verify_stark_host::pvs::{VkCommit, VerifierBasePvs};
     use p3_air::AirBuilder;
 
-    pub fn assert_dag_commit_eq<AB: AirBuilder, I1: Into<AB::Expr>, I2: Into<AB::Expr>>(
+    pub fn assert_vk_commit_eq<AB: AirBuilder, I1: Into<AB::Expr>, I2: Into<AB::Expr>>(
         builder: &mut AB,
-        x: DagCommit<I1>,
-        y: DagCommit<I2>,
+        x: VkCommit<I1>,
+        y: VkCommit<I2>,
     ) {
         assert_array_eq(builder, x.cached_commit, y.cached_commit);
         assert_array_eq(builder, x.vk_pre_hash, y.vk_pre_hash);
     }
 
-    pub fn assert_dag_commit_unset<AB: AirBuilder, I1: Into<AB::Expr>>(
+    pub fn assert_vk_commit_unset<AB: AirBuilder, I1: Into<AB::Expr>>(
         builder: &mut AB,
-        x: DagCommit<I1>,
+        x: VkCommit<I1>,
     ) {
         assert_zeros(builder, x.cached_commit);
         assert_zeros(builder, x.vk_pre_hash);
@@ -61,12 +61,12 @@ pub mod utils {
 
     pub fn vk_commit_components<F: Copy>(pvs: &VerifierBasePvs<F>) -> Vec<[F; DIGEST_SIZE]> {
         vec![
-            pvs.app_dag_commit.cached_commit,
-            pvs.app_dag_commit.vk_pre_hash,
-            pvs.leaf_dag_commit.cached_commit,
-            pvs.leaf_dag_commit.vk_pre_hash,
-            pvs.internal_for_leaf_dag_commit.cached_commit,
-            pvs.internal_for_leaf_dag_commit.vk_pre_hash,
+            pvs.app_vk_commit.cached_commit,
+            pvs.app_vk_commit.vk_pre_hash,
+            pvs.leaf_vk_commit.cached_commit,
+            pvs.leaf_vk_commit.vk_pre_hash,
+            pvs.internal_for_leaf_vk_commit.cached_commit,
+            pvs.internal_for_leaf_vk_commit.vk_pre_hash,
         ]
     }
 }

--- a/crates/continuations/src/circuit/mod.rs
+++ b/crates/continuations/src/circuit/mod.rs
@@ -39,7 +39,7 @@ pub mod utils {
     use openvm_circuit_primitives::utils::assert_array_eq;
     use openvm_recursion_circuit::utils::assert_zeros;
     use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
-    use openvm_verify_stark_host::pvs::{VkCommit, VerifierBasePvs};
+    use openvm_verify_stark_host::pvs::{VerifierBasePvs, VkCommit};
     use p3_air::AirBuilder;
 
     pub fn assert_vk_commit_eq<AB: AirBuilder, I1: Into<AB::Expr>, I2: Into<AB::Expr>>(

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         subair::{HashSliceSubAir, MerkleRootBus, MerkleTreeInternalBus},
         Circuit,
     },
-    CommitBytes, DagCommitBytes,
+    CommitBytes, VkCommitBytes,
 };
 
 pub mod bus;
@@ -33,7 +33,7 @@ pub const NUM_DIGESTS_IN_VK_COMMIT: usize = 6;
 #[derive(derive_new::new, Clone)]
 pub struct RootCircuit<S: AggregationSubCircuit> {
     pub verifier_circuit: Arc<S>,
-    pub(crate) internal_recursive_dag_commit: DagCommitBytes,
+    pub(crate) internal_recursive_vk_commit: VkCommitBytes,
     pub(crate) def_hook_commit: Option<CommitBytes>,
     pub(crate) memory_dimensions: MemoryDimensions,
     pub(crate) num_user_pvs: usize,
@@ -62,7 +62,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for R
                 compress_bus: bus_inventory.poseidon2_compress_bus,
                 permute_bus: bus_inventory.poseidon2_permute_bus,
             },
-            expected_internal_recursive_dag_commit: self.internal_recursive_dag_commit,
+            expected_internal_recursive_vk_commit: self.internal_recursive_vk_commit,
             expected_def_hook_commit: self.def_hook_commit,
         };
         let user_pvs_commit_air = commit::UserPvsCommitAir::new(

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -28,7 +28,7 @@ mod trace;
 pub use trace::*;
 
 pub const USER_PVS_COMMIT_AIR_ID: usize = 1;
-pub const NUM_DIGESTS_IN_VK_COMMIT: usize = 6;
+pub const NUM_DIGESTS_IN_VM_COMMIT: usize = 6;
 
 #[derive(derive_new::new, Clone)]
 pub struct RootCircuit<S: AggregationSubCircuit> {

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -106,5 +106,5 @@ pub struct RootVerifierPvs<F> {
     pub app_exe_commit: [F; DIGEST_SIZE],
     /// Commit to the app-level verifying key, computed by hashing the cached_commit and
     /// vk_pre_hash components of the app, leaf, and internal-for-leaf DAG commits.
-    pub app_vk_commit: [F; DIGEST_SIZE],
+    pub app_vm_commit: [F; DIGEST_SIZE],
 }

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -34,7 +34,7 @@ pub const NUM_DIGESTS_IN_VK_COMMIT: usize = 6;
 pub struct RootCircuit<S: AggregationSubCircuit> {
     pub verifier_circuit: Arc<S>,
     pub(crate) internal_recursive_dag_commit: DagCommitBytes,
-    pub(crate) def_hook_vk_commit: Option<CommitBytes>,
+    pub(crate) def_hook_commit: Option<CommitBytes>,
     pub(crate) memory_dimensions: MemoryDimensions,
     pub(crate) num_user_pvs: usize,
 }
@@ -63,7 +63,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for R
                 permute_bus: bus_inventory.poseidon2_permute_bus,
             },
             expected_internal_recursive_dag_commit: self.internal_recursive_dag_commit,
-            expected_def_hook_vk_commit: self.def_hook_vk_commit,
+            expected_def_hook_commit: self.def_hook_commit,
         };
         let user_pvs_commit_air = commit::UserPvsCommitAir::new(
             bus_inventory.poseidon2_compress_bus,
@@ -78,7 +78,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for R
             self.memory_dimensions,
             self.num_user_pvs,
         );
-        let acc_paths_air = self.def_hook_vk_commit.map(|_| {
+        let acc_paths_air = self.def_hook_commit.map(|_| {
             Arc::new(def_paths::DeferralAccMerklePathsAir::new(
                 bus_inventory.poseidon2_compress_bus,
                 def_acc_paths_bus,

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -105,6 +105,6 @@ pub struct RootVerifierPvs<F> {
     /// (i.e. initial_pc).
     pub app_exe_commit: [F; DIGEST_SIZE],
     /// Commit to the app-level verifying key, computed by hashing the cached_commit and
-    /// vk_pre_hash components of the app, leaf, and internal-for-leaf DAG commits.
+    /// vk_pre_hash components of the app, leaf, and internal-for-leaf vk commits.
     pub app_vm_commit: [F; DIGEST_SIZE],
 }

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -64,13 +64,13 @@ pub struct RootVerifierPvsAir {
     pub hash_slice_subair: HashSliceSubAir,
 
     pub expected_internal_recursive_dag_commit: DagCommitBytes,
-    pub expected_def_hook_vk_commit: Option<CommitBytes>,
+    pub expected_def_hook_commit: Option<CommitBytes>,
 }
 
 impl<F: Field> BaseAir<F> for RootVerifierPvsAir {
     fn width(&self) -> usize {
         RootVerifierPvsCols::<u8>::width()
-            + if self.expected_def_hook_vk_commit.is_some() {
+            + if self.expected_def_hook_commit.is_some() {
                 RootDefVerifierCols::<u8>::width()
             } else {
                 0
@@ -94,9 +94,9 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let (base_local, rec_local) = local.split_at(base_cols_width);
         let local: &RootVerifierPvsCols<AB::Var> = (*base_local).borrow();
 
-        if let Some(def_hook_vk_commit) = self.expected_def_hook_vk_commit {
+        if let Some(def_hook_commit) = self.expected_def_hook_commit {
             let def: &RootDefVerifierCols<AB::Var> = (*rec_local).borrow();
-            self.eval_deferrals(builder, local, def, def_hook_vk_commit);
+            self.eval_deferrals(builder, local, def, def_hook_commit);
         }
 
         /*
@@ -331,7 +331,7 @@ impl RootVerifierPvsAir {
         builder: &mut AB,
         base: &RootVerifierPvsCols<AB::Var>,
         def: &RootDefVerifierCols<AB::Var>,
-        expected_def_hook_vk_commit: CommitBytes,
+        expected_def_hook_commit: CommitBytes,
     ) where
         AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues,
     {
@@ -373,14 +373,14 @@ impl RootVerifierPvsAir {
 
         /*
          * The final internal-recursive proof's deferral_flag must be either 0 or 2, and
-         * in the latter case the def_hook_vk_commit must match the expected one.
+         * in the latter case the def_hook_commit must match the expected one.
          */
         builder
             .assert_zero(verifier_pvs.deferral_flag * (verifier_pvs.deferral_flag - AB::Expr::TWO));
         assert_array_eq::<_, _, AB::Expr, _>(
             &mut builder.when(verifier_pvs.deferral_flag),
-            verifier_pvs.def_hook_vk_commit,
-            expected_def_hook_vk_commit.into(),
+            verifier_pvs.def_hook_commit,
+            expected_def_hook_commit.into(),
         );
 
         /*

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -29,7 +29,7 @@ use crate::{
                 DeferralAccPathBus, DeferralAccPathMessage, DeferralMerkleRootsBus,
                 DeferralMerkleRootsMessage, MemoryMerkleCommitBus, MemoryMerkleCommitMessage,
             },
-            RootVerifierPvs, NUM_DIGESTS_IN_VK_COMMIT,
+            RootVerifierPvs, NUM_DIGESTS_IN_VM_COMMIT,
         },
         subair::{HashSliceCtx, HashSliceSubAir},
         utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
@@ -49,7 +49,7 @@ pub struct RootVerifierPvsCols<F> {
     pub initial_pc_hash: [F; DIGEST_SIZE],
     pub intermediate_exe_commit: [F; DIGEST_SIZE],
 
-    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
+    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
 }
 
 pub struct RootVerifierPvsAir {

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -15,7 +15,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
-    DagCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
+    VkCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
     CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
@@ -32,10 +32,10 @@ use crate::{
             RootVerifierPvs, NUM_DIGESTS_IN_VK_COMMIT,
         },
         subair::{HashSliceCtx, HashSliceSubAir},
-        utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
+        utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
     },
     utils::{digests_to_poseidon2_input, pad_slice_to_poseidon2_input},
-    CommitBytes, DagCommitBytes,
+    CommitBytes, VkCommitBytes,
 };
 
 #[repr(C)]
@@ -63,7 +63,7 @@ pub struct RootVerifierPvsAir {
 
     pub hash_slice_subair: HashSliceSubAir,
 
-    pub expected_internal_recursive_dag_commit: DagCommitBytes,
+    pub expected_internal_recursive_vk_commit: VkCommitBytes,
     pub expected_def_hook_commit: Option<CommitBytes>,
 }
 
@@ -165,7 +165,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * We also need to receive the cached commit from ProofShapeModule, which is either for
          * the internal-for-leaf (i.e. if recursion_flag == 1) or internal-recursive layer. In
-         * the former case we constrain child_pvs.internal_recursive_dag_commit to be unset (i.e.
+         * the former case we constrain child_pvs.internal_recursive_vk_commit to be unset (i.e.
          * all 0), and in the latter we constrain it to be equal to a pre-generated constant as
          * it should be the same regardless of app_vk (provided internal system params are the
          * same).
@@ -173,12 +173,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let cached_commit = from_fn(|i| {
             local
                 .child_verifier_pvs
-                .internal_for_leaf_dag_commit
+                .internal_for_leaf_vk_commit
                 .cached_commit[i]
                 * (AB::Expr::TWO - local.child_verifier_pvs.recursion_flag)
                 + local
                     .child_verifier_pvs
-                    .internal_recursive_dag_commit
+                    .internal_recursive_vk_commit
                     .cached_commit[i]
                     * (local.child_verifier_pvs.recursion_flag - AB::F::ONE)
         });
@@ -198,20 +198,20 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             AB::F::ZERO,
             PreHashMessage::<AB::F> {
-                vk_pre_hash: self.expected_internal_recursive_dag_commit.pre_hash.into(),
+                vk_pre_hash: self.expected_internal_recursive_vk_commit.pre_hash.into(),
             },
             AB::F::ONE,
         );
 
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::TWO),
-            local.child_verifier_pvs.internal_recursive_dag_commit,
+            local.child_verifier_pvs.internal_recursive_vk_commit,
         );
 
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::ONE),
-            local.child_verifier_pvs.internal_recursive_dag_commit,
-            DagCommit::<AB::Expr>::from(self.expected_internal_recursive_dag_commit),
+            local.child_verifier_pvs.internal_recursive_vk_commit,
+            VkCommit::<AB::Expr>::from(self.expected_internal_recursive_vk_commit),
         );
 
         /*

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -198,7 +198,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             AB::F::ZERO,
             PreHashMessage::<AB::F> {
-                vk_pre_hash: self.expected_internal_recursive_vk_commit.pre_hash.into(),
+                vk_pre_hash: self
+                    .expected_internal_recursive_vk_commit
+                    .vk_pre_hash
+                    .into(),
             },
             AB::F::ONE,
         );

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -15,7 +15,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
-    VkCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
+    DeferralPvs, VerifierBasePvs, VerifierDefPvs, VkCommit, VmPvs, CONSTRAINT_EVAL_AIR_ID,
     CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -218,7 +218,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * Finally, we need to constrain that the public values this AIR produces are consistent
          * with the child's. The app_vm_commit is constrained to be hash_slice of the 6
          * vk_commit_components (cached_commit and vk_pre_hash for each of app, leaf, and
-         * internal-for-leaf DAG commits).
+         * internal-for-leaf vk commits).
          */
         let &RootVerifierPvs::<_> {
             app_exe_commit,

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -216,13 +216,13 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * Finally, we need to constrain that the public values this AIR produces are consistent
-         * with the child's. The app_vk_commit is constrained to be hash_slice of the 6
+         * with the child's. The app_vm_commit is constrained to be hash_slice of the 6
          * vk_commit_components (cached_commit and vk_pre_hash for each of app, leaf, and
          * internal-for-leaf DAG commits).
          */
         let &RootVerifierPvs::<_> {
             app_exe_commit,
-            app_vk_commit,
+            app_vm_commit,
         } = builder.public_values().borrow();
 
         let vk_commit_components: Vec<_> = vk_commit_components(&local.child_verifier_pvs)
@@ -238,7 +238,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                     .intermediate_vk_states
                     .map(|v| v.map(Into::into))
                     .as_slice(),
-                result: &app_vk_commit.map(Into::into),
+                result: &app_vm_commit.map(Into::into),
                 enabled: &AB::Expr::ONE,
             },
         );

--- a/crates/continuations/src/circuit/root/verifier/trace.rs
+++ b/crates/continuations/src/circuit/root/verifier/trace.rs
@@ -78,14 +78,14 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
     ));
 
     let vk_elements = [
-        child_verifier_pvs.app_dag_commit.cached_commit,
-        child_verifier_pvs.app_dag_commit.vk_pre_hash,
-        child_verifier_pvs.leaf_dag_commit.cached_commit,
-        child_verifier_pvs.leaf_dag_commit.vk_pre_hash,
+        child_verifier_pvs.app_vk_commit.cached_commit,
+        child_verifier_pvs.app_vk_commit.vk_pre_hash,
+        child_verifier_pvs.leaf_vk_commit.cached_commit,
+        child_verifier_pvs.leaf_vk_commit.vk_pre_hash,
         child_verifier_pvs
-            .internal_for_leaf_dag_commit
+            .internal_for_leaf_vk_commit
             .cached_commit,
-        child_verifier_pvs.internal_for_leaf_dag_commit.vk_pre_hash,
+        child_verifier_pvs.internal_for_leaf_vk_commit.vk_pre_hash,
     ];
     let (intermediate_vk_states, app_vm_commit) = hash_slice_trace(
         &vk_elements,

--- a/crates/continuations/src/circuit/root/verifier/trace.rs
+++ b/crates/continuations/src/circuit/root/verifier/trace.rs
@@ -82,9 +82,7 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
         child_verifier_pvs.app_vk_commit.vk_pre_hash,
         child_verifier_pvs.leaf_vk_commit.cached_commit,
         child_verifier_pvs.leaf_vk_commit.vk_pre_hash,
-        child_verifier_pvs
-            .internal_for_leaf_vk_commit
-            .cached_commit,
+        child_verifier_pvs.internal_for_leaf_vk_commit.cached_commit,
         child_verifier_pvs.internal_for_leaf_vk_commit.vk_pre_hash,
     ];
     let (intermediate_vk_states, app_vm_commit) = hash_slice_trace(

--- a/crates/continuations/src/circuit/root/verifier/trace.rs
+++ b/crates/continuations/src/circuit/root/verifier/trace.rs
@@ -87,7 +87,7 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
             .cached_commit,
         child_verifier_pvs.internal_for_leaf_dag_commit.vk_pre_hash,
     ];
-    let (intermediate_vk_states, app_vk_commit) = hash_slice_trace(
+    let (intermediate_vk_states, app_vm_commit) = hash_slice_trace(
         &vk_elements,
         Some(&mut poseidon2_permute_inputs),
         Some(&mut poseidon2_compress_inputs),
@@ -104,7 +104,7 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
         cols.initial_pc_hash,
     ));
 
-    root_pvs.app_vk_commit = app_vk_commit;
+    root_pvs.app_vm_commit = app_vm_commit;
 
     if deferral_enabled {
         let def_verifier_pvs: &VerifierDefPvs<F> = def_pvs_slice.borrow();

--- a/crates/continuations/src/commit_bytes.rs
+++ b/crates/continuations/src/commit_bytes.rs
@@ -30,14 +30,14 @@ impl CommitBytes {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct VkCommitBytes {
     pub cached_commit: CommitBytes,
-    pub pre_hash: CommitBytes,
+    pub vk_pre_hash: CommitBytes,
 }
 
 impl<F: PrimeCharacteristicRing> From<VkCommitBytes> for VkCommit<F> {
     fn from(value: VkCommitBytes) -> Self {
         VkCommit {
             cached_commit: value.cached_commit.into(),
-            vk_pre_hash: value.pre_hash.into(),
+            vk_pre_hash: value.vk_pre_hash.into(),
         }
     }
 }

--- a/crates/continuations/src/commit_bytes.rs
+++ b/crates/continuations/src/commit_bytes.rs
@@ -2,7 +2,7 @@ use std::array::from_fn;
 
 use num_bigint::BigUint;
 use openvm_stark_sdk::config::baby_bear_poseidon2::{DIGEST_SIZE, F};
-use openvm_verify_stark_host::pvs::DagCommit;
+use openvm_verify_stark_host::pvs::VkCommit;
 use p3_field::{PrimeCharacteristicRing, PrimeField32};
 
 pub const COMMIT_NUM_BYTES: usize = 32;
@@ -28,14 +28,14 @@ impl CommitBytes {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct DagCommitBytes {
+pub struct VkCommitBytes {
     pub cached_commit: CommitBytes,
     pub pre_hash: CommitBytes,
 }
 
-impl<F: PrimeCharacteristicRing> From<DagCommitBytes> for DagCommit<F> {
-    fn from(value: DagCommitBytes) -> Self {
-        DagCommit {
+impl<F: PrimeCharacteristicRing> From<VkCommitBytes> for VkCommit<F> {
+    fn from(value: VkCommitBytes) -> Self {
+        VkCommit {
             cached_commit: value.cached_commit.into(),
             vk_pre_hash: value.pre_hash.into(),
         }

--- a/crates/continuations/src/prover/deferral/hook/mod.rs
+++ b/crates/continuations/src/prover/deferral/hook/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         Circuit,
     },
     prover::trace_heights_tracing_info,
-    CommitBytes, DagCommitBytes, SC,
+    CommitBytes, VkCommitBytes, SC,
 };
 
 mod trace;
@@ -98,13 +98,13 @@ impl<
         );
         let engine = E::new(system_params);
         let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
-        let internal_recursive_dag_commit = DagCommitBytes {
+        let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(DeferralHookCircuit::new(
             Arc::new(verifier_circuit),
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
         ));
         let (pk, vk) = engine.keygen(&circuit.airs());
         let d_pk = engine.device().transport_pk_to_device(&pk);
@@ -139,13 +139,13 @@ impl<
         );
         let engine = E::new(pk.params.clone());
         let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
-        let internal_recursive_dag_commit = DagCommitBytes {
+        let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(DeferralHookCircuit::new(
             Arc::new(verifier_circuit),
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
         ));
         let vk = Arc::new(pk.get_vk());
         let d_pk = engine.device().transport_pk_to_device(pk.as_ref());

--- a/crates/continuations/src/prover/deferral/hook/mod.rs
+++ b/crates/continuations/src/prover/deferral/hook/mod.rs
@@ -100,7 +100,7 @@ impl<
         let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
         let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
-            pre_hash: child_vk.pre_hash.into(),
+            vk_pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(DeferralHookCircuit::new(
             Arc::new(verifier_circuit),
@@ -141,7 +141,7 @@ impl<
         let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
         let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
-            pre_hash: child_vk.pre_hash.into(),
+            vk_pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(DeferralHookCircuit::new(
             Arc::new(verifier_circuit),

--- a/crates/continuations/src/prover/deferral/inner/mod.rs
+++ b/crates/continuations/src/prover/deferral/inner/mod.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
     StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, EF, F};
-use openvm_verify_stark_host::pvs::DagCommit;
+use openvm_verify_stark_host::pvs::VkCommit;
 use tracing::instrument;
 
 use crate::{
@@ -172,14 +172,14 @@ impl<
         self.vk.clone()
     }
 
-    pub fn get_dag_commit(&self, is_self_recursive: bool) -> DagCommit<PB::Val> {
+    pub fn get_vk_commit(&self, is_self_recursive: bool) -> VkCommit<PB::Val> {
         if is_self_recursive {
-            DagCommit {
+            VkCommit {
                 cached_commit: self.self_vk_pcs_data.as_ref().unwrap().commitment,
                 vk_pre_hash: self.vk.pre_hash,
             }
         } else {
-            DagCommit {
+            VkCommit {
                 cached_commit: self.child_vk_pcs_data.commitment,
                 vk_pre_hash: self.child_vk.pre_hash,
             }

--- a/crates/continuations/src/prover/deferral/inner/trace.rs
+++ b/crates/continuations/src/prover/deferral/inner/trace.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     default_duplex_sponge_recorder, Digest, EF, F,
 };
-use openvm_verify_stark_host::pvs::DagCommit;
+use openvm_verify_stark_host::pvs::VkCommit;
 use tracing::instrument;
 
 use super::{DeferralChildVkKind, DeferralInnerProver};
@@ -53,7 +53,7 @@ where
                 (&self.vk, self.self_vk_pcs_data.clone().unwrap(), true)
             }
         };
-        let child_dag_commit = DagCommit {
+        let child_vk_commit = VkCommit {
             cached_commit: child_vk_pcs_data.commitment,
             vk_pre_hash: child_vk.pre_hash,
         };
@@ -67,7 +67,7 @@ where
         } = self.agg_node_tracegen.pre_verifier_subcircuit_tracegen(
             proofs,
             child_is_agg,
-            child_dag_commit,
+            child_vk_commit,
             child_merkle_depth,
         );
 

--- a/crates/continuations/src/prover/inner/mod.rs
+++ b/crates/continuations/src/prover/inner/mod.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
     StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, EF, F};
-use openvm_verify_stark_host::pvs::{VkCommit, DeferralPvs};
+use openvm_verify_stark_host::pvs::{DeferralPvs, VkCommit};
 use tracing::instrument;
 
 use crate::{

--- a/crates/continuations/src/prover/inner/mod.rs
+++ b/crates/continuations/src/prover/inner/mod.rs
@@ -11,7 +11,7 @@ use openvm_stark_backend::{
     StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, EF, F};
-use openvm_verify_stark_host::pvs::{DagCommit, DeferralPvs};
+use openvm_verify_stark_host::pvs::{VkCommit, DeferralPvs};
 use tracing::instrument;
 
 use crate::{
@@ -196,14 +196,14 @@ impl<
         self.circuit.def_hook_cached_commit.is_some()
     }
 
-    pub fn get_dag_commit(&self, is_self_recursive: bool) -> DagCommit<PB::Val> {
+    pub fn get_vk_commit(&self, is_self_recursive: bool) -> VkCommit<PB::Val> {
         if is_self_recursive {
-            DagCommit {
+            VkCommit {
                 cached_commit: self.self_vk_pcs_data.as_ref().unwrap().commitment,
                 vk_pre_hash: self.vk.pre_hash,
             }
         } else {
-            DagCommit {
+            VkCommit {
                 cached_commit: self.child_vk_pcs_data.commitment,
                 vk_pre_hash: self.child_vk.pre_hash,
             }

--- a/crates/continuations/src/prover/inner/trace.rs
+++ b/crates/continuations/src/prover/inner/trace.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     default_duplex_sponge_recorder, Digest, EF, F,
 };
-use openvm_verify_stark_host::pvs::{VkCommit, DeferralPvs};
+use openvm_verify_stark_host::pvs::{DeferralPvs, VkCommit};
 use tracing::instrument;
 
 use super::{ChildVkKind, InnerAggregationProver};

--- a/crates/continuations/src/prover/inner/trace.rs
+++ b/crates/continuations/src/prover/inner/trace.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     default_duplex_sponge_recorder, Digest, EF, F,
 };
-use openvm_verify_stark_host::pvs::{DagCommit, DeferralPvs};
+use openvm_verify_stark_host::pvs::{VkCommit, DeferralPvs};
 use tracing::instrument;
 
 use super::{ChildVkKind, InnerAggregationProver};
@@ -41,7 +41,7 @@ where
             _ => (&self.child_vk, self.child_vk_pcs_data.clone()),
         };
         let child_is_app = matches!(child_vk_kind, ChildVkKind::App);
-        let child_dag_commit = DagCommit {
+        let child_vk_commit = VkCommit {
             cached_commit: child_vk_pcs_data.commitment,
             vk_pre_hash: child_vk.pre_hash,
         };
@@ -53,7 +53,7 @@ where
                 proofs_type,
                 absent_trace_pvs,
                 child_is_app,
-                child_dag_commit,
+                child_vk_commit,
             );
 
         let range_check_inputs = vec![];

--- a/crates/continuations/src/prover/root/mod.rs
+++ b/crates/continuations/src/prover/root/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         Circuit,
     },
     prover::trace_heights_tracing_info,
-    CommitBytes, VkCommitBytes, RootSC, SC,
+    CommitBytes, RootSC, VkCommitBytes, SC,
 };
 
 mod trace;

--- a/crates/continuations/src/prover/root/mod.rs
+++ b/crates/continuations/src/prover/root/mod.rs
@@ -99,7 +99,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         let engine = E::new(system_params);
         let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
-            pre_hash: child_vk.pre_hash.into(),
+            vk_pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(RootCircuit::new(
             Arc::new(verifier_circuit),
@@ -148,7 +148,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         let cached_trace_record = verifier_circuit.cached_trace_record(&child_vk);
         let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
-            pre_hash: child_vk.pre_hash.into(),
+            vk_pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(RootCircuit::new(
             Arc::new(verifier_circuit),

--- a/crates/continuations/src/prover/root/mod.rs
+++ b/crates/continuations/src/prover/root/mod.rs
@@ -75,7 +75,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         system_params: SystemParams,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
-        def_hook_vk_commit: Option<CommitBytes>,
+        def_hook_commit: Option<CommitBytes>,
         trace_heights: Option<Vec<usize>>,
     ) -> Self
     where
@@ -104,7 +104,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         let circuit = Arc::new(RootCircuit::new(
             Arc::new(verifier_circuit),
             internal_recursive_dag_commit,
-            def_hook_vk_commit,
+            def_hook_commit,
             memory_dimensions,
             num_user_pvs,
         ));
@@ -112,7 +112,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         Self {
             pk: Arc::new(pk),
             vk: Arc::new(vk),
-            agg_node_tracegen: T::new(def_hook_vk_commit.is_some()),
+            agg_node_tracegen: T::new(def_hook_commit.is_some()),
             child_vk,
             cached_trace_record,
             circuit,
@@ -126,7 +126,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         pk: Arc<MultiStarkProvingKey<RootSC>>,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
-        def_hook_vk_commit: Option<CommitBytes>,
+        def_hook_commit: Option<CommitBytes>,
         trace_heights: Option<Vec<usize>>,
     ) -> Self
     where
@@ -153,7 +153,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         let circuit = Arc::new(RootCircuit::new(
             Arc::new(verifier_circuit),
             internal_recursive_dag_commit,
-            def_hook_vk_commit,
+            def_hook_commit,
             memory_dimensions,
             num_user_pvs,
         ));
@@ -161,7 +161,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         Self {
             pk,
             vk,
-            agg_node_tracegen: T::new(def_hook_vk_commit.is_some()),
+            agg_node_tracegen: T::new(def_hook_commit.is_some()),
             child_vk,
             cached_trace_record,
             circuit,

--- a/crates/continuations/src/prover/root/mod.rs
+++ b/crates/continuations/src/prover/root/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         Circuit,
     },
     prover::trace_heights_tracing_info,
-    CommitBytes, DagCommitBytes, RootSC, SC,
+    CommitBytes, VkCommitBytes, RootSC, SC,
 };
 
 mod trace;
@@ -97,13 +97,13 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         );
         let cached_trace_record = verifier_circuit.cached_trace_record(&child_vk);
         let engine = E::new(system_params);
-        let internal_recursive_dag_commit = DagCommitBytes {
+        let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(RootCircuit::new(
             Arc::new(verifier_circuit),
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
             def_hook_commit,
             memory_dimensions,
             num_user_pvs,
@@ -146,13 +146,13 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
             },
         );
         let cached_trace_record = verifier_circuit.cached_trace_record(&child_vk);
-        let internal_recursive_dag_commit = DagCommitBytes {
+        let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
         };
         let circuit = Arc::new(RootCircuit::new(
             Arc::new(verifier_circuit),
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
             def_hook_commit,
             memory_dimensions,
             num_user_pvs,

--- a/crates/continuations/src/prover/root/trace.rs
+++ b/crates/continuations/src/prover/root/trace.rs
@@ -100,7 +100,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         T: RootTraceGen<PB>,
     {
         assert!(
-            self.circuit.def_hook_vk_commit.is_none(),
+            self.circuit.def_hook_commit.is_none(),
             "deferral-enabled root prover requires generate_proving_ctx_with_deferrals"
         );
         self.generate_proving_ctx(proof, user_pvs_proof, None)

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -284,7 +284,7 @@ fn test_deferral_e2e() -> Result<()> {
     let def_leaf_dag_commit = def_i0_prover.get_dag_commit(false);
     let def_i4l_dag_commit = def_i1_prover.get_dag_commit(false);
 
-    let def_vk_commit = poseidon2_hash_slice_with_states(
+    let def_circuit_commit = poseidon2_hash_slice_with_states(
         &[
             def_circuit_dag_commit.cached_commit,
             def_circuit_dag_commit.vk_pre_hash,
@@ -299,13 +299,13 @@ fn test_deferral_e2e() -> Result<()> {
     )
     .0;
 
-    let def_vk_commit_bytes = def_vk_commit
+    let def_circuit_commit_bytes = def_circuit_commit
         .iter()
         .flat_map(|f| f.to_unique_u32().to_le_bytes())
         .collect::<Vec<_>>()
         .try_into()
         .unwrap();
-    let transpiler_commits = vec![def_vk_commit_bytes; NUM_DEF_CIRCUITS];
+    let transpiler_commits = vec![def_circuit_commit_bytes; NUM_DEF_CIRCUITS];
 
     // =========================================================================
     // SECTION 1: Set up Rv32DeferralConfig, build ELF, set up deferral streams.
@@ -439,7 +439,7 @@ fn test_deferral_e2e() -> Result<()> {
 
     let mut initial_commits = Vec::with_capacity(2 * NUM_DEF_CIRCUITS);
     for _ in 0..NUM_DEF_CIRCUITS {
-        initial_commits.push(def_vk_commit);
+        initial_commits.push(def_circuit_commit);
         initial_commits.push([F::ZERO; DIGEST_SIZE]);
     }
     let mut final_commits = initial_commits.clone();
@@ -600,7 +600,7 @@ fn test_deferral_e2e() -> Result<()> {
     assert_eq!(hook1_pvs.depth, hook2_pvs.depth);
     let zero_leaf = hash_deferral_commit([F::ZERO; DIGEST_SIZE]);
     let idx0_untouched_root =
-        poseidon2_compress_with_capacity(hash_deferral_commit(def_vk_commit), zero_leaf).0;
+        poseidon2_compress_with_capacity(hash_deferral_commit(def_circuit_commit), zero_leaf).0;
     let zero_depth1_root = poseidon2_compress_with_capacity(zero_leaf, zero_leaf).0;
 
     warn!("proving deferral-path leaf A (idx0 untouched + idx1)");

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -274,24 +274,24 @@ fn test_deferral_e2e() -> Result<()> {
     );
     let hook_prover_for_commit = DeferralHookProver::new::<GpuEngine>(
         def_i1_prover.get_vk(),
-        def_i1_prover.get_dag_commit(true).cached_commit.into(),
+        def_i1_prover.get_vk_commit(true).cached_commit.into(),
         root_system_params(),
     );
     let def_hook_cached_commit = hook_prover_for_commit.get_cached_commit();
 
     // Compute vk commit using [cached_commit, vk_pre_hash] for def/leaf/i4l.
-    let def_circuit_dag_commit = def_leaf_prover.get_dag_commit(false);
-    let def_leaf_dag_commit = def_i0_prover.get_dag_commit(false);
-    let def_i4l_dag_commit = def_i1_prover.get_dag_commit(false);
+    let def_circuit_vk_commit = def_leaf_prover.get_vk_commit(false);
+    let def_leaf_vk_commit = def_i0_prover.get_vk_commit(false);
+    let def_i4l_vk_commit = def_i1_prover.get_vk_commit(false);
 
     let def_circuit_commit = poseidon2_hash_slice_with_states(
         &[
-            def_circuit_dag_commit.cached_commit,
-            def_circuit_dag_commit.vk_pre_hash,
-            def_leaf_dag_commit.cached_commit,
-            def_leaf_dag_commit.vk_pre_hash,
-            def_i4l_dag_commit.cached_commit,
-            def_i4l_dag_commit.vk_pre_hash,
+            def_circuit_vk_commit.cached_commit,
+            def_circuit_vk_commit.vk_pre_hash,
+            def_leaf_vk_commit.cached_commit,
+            def_leaf_vk_commit.vk_pre_hash,
+            def_i4l_vk_commit.cached_commit,
+            def_i4l_vk_commit.vk_pre_hash,
         ]
         .into_iter()
         .flatten()
@@ -537,7 +537,7 @@ fn test_deferral_e2e() -> Result<()> {
 
         let hook_prover = DeferralHookProver::new::<GpuEngine>(
             ir_prover.get_vk(),
-            ir_prover.get_dag_commit(true).cached_commit.into(),
+            ir_prover.get_vk_commit(true).cached_commit.into(),
             root_system_params(),
         );
         warn!("proving deferral hook");
@@ -713,18 +713,18 @@ fn test_deferral_e2e() -> Result<()> {
     let vm_ir_vk = ir_prover.get_vk();
     let vm_ir_pcs_data = ir_prover.get_self_vk_pcs_data().unwrap();
 
-    let def_hook_dag_commit = deferral_leaf_prover.get_dag_commit(false);
-    let def_leaf_dag_commit = def_i4l_prover.get_dag_commit(false);
-    let def_i4l_dag_commit = def_ir_prover.get_dag_commit(false);
+    let def_hook_vk_commit = deferral_leaf_prover.get_vk_commit(false);
+    let def_leaf_vk_commit = def_i4l_prover.get_vk_commit(false);
+    let def_i4l_vk_commit = def_ir_prover.get_vk_commit(false);
 
     let def_hook_commit = poseidon2_hash_slice_with_states(
         &[
-            def_hook_dag_commit.cached_commit,
-            def_hook_dag_commit.vk_pre_hash,
-            def_leaf_dag_commit.cached_commit,
-            def_leaf_dag_commit.vk_pre_hash,
-            def_i4l_dag_commit.cached_commit,
-            def_i4l_dag_commit.vk_pre_hash,
+            def_hook_vk_commit.cached_commit,
+            def_hook_vk_commit.vk_pre_hash,
+            def_leaf_vk_commit.cached_commit,
+            def_leaf_vk_commit.vk_pre_hash,
+            def_i4l_vk_commit.cached_commit,
+            def_i4l_vk_commit.vk_pre_hash,
         ]
         .into_iter()
         .flatten()

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -707,7 +707,7 @@ fn test_deferral_e2e() -> Result<()> {
     // =========================================================================
     // SECTION 9: Root prover (CPU) and final verification.
     //
-    // The root verifier checks def_hook_vk_commit from the deferral path's
+    // The root verifier checks def_hook_commit from the deferral path's
     // [cached_commit, vk_pre_hash] tuples for app/leaf/i4l.
     // =========================================================================
     let vm_ir_vk = ir_prover.get_vk();
@@ -717,7 +717,7 @@ fn test_deferral_e2e() -> Result<()> {
     let def_leaf_dag_commit = def_i4l_prover.get_dag_commit(false);
     let def_i4l_dag_commit = def_ir_prover.get_dag_commit(false);
 
-    let def_hook_vk_commit = poseidon2_hash_slice_with_states(
+    let def_hook_commit = poseidon2_hash_slice_with_states(
         &[
             def_hook_dag_commit.cached_commit,
             def_hook_dag_commit.vk_pre_hash,
@@ -738,7 +738,7 @@ fn test_deferral_e2e() -> Result<()> {
         root_system_params(),
         system.memory_config.memory_dimensions(),
         system.num_public_values,
-        Some(def_hook_vk_commit.into()),
+        Some(def_hook_commit.into()),
         None,
     );
     let ctx = root_prover.generate_proving_ctx::<<RootEngine as StarkEngine>::PB>(

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -250,8 +250,8 @@ fn test_internal_recursive_vk_stabilization(def_hook_cached_commit_set: bool) ->
         def_hook_cached_commit,
     );
     assert_eq!(
-        test_prover.get_dag_commit(false),
-        test_prover.get_dag_commit(true)
+        test_prover.get_vk_commit(false),
+        test_prover.get_vk_commit(true)
     );
     Ok(())
 }
@@ -268,8 +268,8 @@ fn test_internal_recursive_deep_layers() -> Result<()> {
 }
 
 #[cfg(all(feature = "cuda", feature = "root-prover"))]
-#[test_case(0 ; "internal_recursive_dag_commit not set")]
-#[test_case(1 ; "internal_recursive_dag_commit set")]
+#[test_case(0 ; "internal_recursive_vk_commit not set")]
+#[test_case(1 ; "internal_recursive_vk_commit set")]
 fn test_root_prover(extra_recursive_layers: usize) -> Result<()> {
     setup_tracing_with_log_level(Level::INFO);
     let (
@@ -453,7 +453,7 @@ pub(in crate::tests) fn generate_deferral_internal_recursive_proof_from_copies(
             return Ok((
                 internal_recursive_prover.get_vk(),
                 internal_recursive_prover
-                    .get_dag_commit(true)
+                    .get_vk_commit(true)
                     .cached_commit
                     .into(),
                 wrapped,
@@ -606,8 +606,8 @@ fn test_deferral_internal_recursive_vk_stabilization() -> Result<()> {
     );
 
     assert_eq!(
-        test_prover.get_dag_commit(false),
-        test_prover.get_dag_commit(true)
+        test_prover.get_vk_commit(false),
+        test_prover.get_vk_commit(true)
     );
     Ok(())
 }
@@ -647,7 +647,7 @@ fn test_deferral_hook_prover(num_children: usize) -> Result<()> {
     let child_verifier_pvs: &VerifierBasePvs<F> =
         final_inner_proof.public_values[0].as_slice().borrow();
 
-    // app_dag_commit is def_dag_commit here
+    // app_vk_commit is def_vk_commit here
     let def_vk = poseidon2_hash_slice_with_states(
         &vk_commit_components(child_verifier_pvs)
             .into_iter()

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -199,7 +199,7 @@ impl TranspilerConfig<F> for SdkVmConfig {
         }
         if let Some(ext) = &self.deferral {
             transpiler = transpiler
-                .with_extension(DeferralTranspilerExtension::new(ext.def_vk_commits.clone()));
+                .with_extension(DeferralTranspilerExtension::new(ext.def_circuit_commits.clone()));
         }
         transpiler
     }

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -198,8 +198,9 @@ impl TranspilerConfig<F> for SdkVmConfig {
             transpiler = transpiler.with_extension(EccTranspilerExtension);
         }
         if let Some(ext) = &self.deferral {
-            transpiler = transpiler
-                .with_extension(DeferralTranspilerExtension::new(ext.def_circuit_commits.clone()));
+            transpiler = transpiler.with_extension(DeferralTranspilerExtension::new(
+                ext.def_circuit_commits.clone(),
+            ));
         }
         transpiler
     }

--- a/crates/sdk/programs/examples/verify-stark.rs
+++ b/crates/sdk/programs/examples/verify-stark.rs
@@ -13,12 +13,12 @@ openvm::entry!(main);
 
 pub fn main() {
     let app_exe_commit: Commit = read();
-    let app_vk_commit: Commit = read();
+    let app_vm_commit: Commit = read();
     let user_public_values: Vec<u8> = read();
 
     let expected = ProofOutput {
         app_exe_commit,
-        app_vk_commit,
+        app_vm_commit,
         user_public_values,
     };
 

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -348,9 +348,9 @@ where
             .as_ref()
             .map(|def_path_prover| def_path_prover.def_hook_cached_commit());
         #[cfg(feature = "root-prover")]
-        let def_hook_vk_commit = def_path_prover
+        let def_hook_commit = def_path_prover
             .as_ref()
-            .map(|def_path_prover| def_path_prover.def_hook_vk_commit());
+            .map(|def_path_prover| def_path_prover.def_hook_commit());
 
         let app_vm_vk = app_pk_seed
             .as_ref()
@@ -388,7 +388,7 @@ where
                 root_pk.root_pk,
                 memory_dimensions,
                 num_user_pvs,
-                def_hook_vk_commit,
+                def_hook_commit,
                 Some(root_pk.trace_heights),
             ))
         });

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -375,7 +375,7 @@ where
             let system_config = app_config.app_vm_config.as_ref();
             let memory_dimensions = system_config.memory_config.memory_dimensions();
             let num_user_pvs = system_config.num_public_values;
-            let internal_recursive_dag_commit = agg_prover
+            let internal_recursive_vk_commit = agg_prover
                 .internal_recursive_prover
                 .get_self_vk_pcs_data()
                 .unwrap()
@@ -384,7 +384,7 @@ where
 
             Arc::new(RootProver::from_pk(
                 agg_prover.internal_recursive_prover.get_vk(),
-                internal_recursive_dag_commit,
+                internal_recursive_vk_commit,
                 root_pk.root_pk,
                 memory_dimensions,
                 num_user_pvs,

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -66,7 +66,7 @@ where
     let memory_dimensions = system_config.memory_config.memory_dimensions();
     let num_user_pvs = system_config.num_public_values;
 
-    let def_hook_vk_commit = def_prover.as_ref().map(|p| p.def_hook_vk_commit().into());
+    let def_hook_commit = def_prover.as_ref().map(|p| p.def_hook_commit().into());
 
     let mut stark_prover = StarkProver::<E, VB>::new(
         vm_builder,
@@ -88,7 +88,7 @@ where
         root_params,
         memory_dimensions,
         num_user_pvs,
-        def_hook_vk_commit,
+        def_hook_commit,
         None,
     );
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -37,7 +37,7 @@ use openvm_transpiler::{
 };
 use openvm_verify_stark_host::{
     verify_vm_stark_proof_decoded,
-    vk::{VmStarkVerifyingKey, VerificationBaseline},
+    vk::{VerificationBaseline, VmStarkVerifyingKey},
     VmStarkProof,
 };
 
@@ -274,9 +274,7 @@ where
 
     /// Returns the def_hook_prover vk commit.
     pub fn def_hook_commit(&self) -> Option<Digest> {
-        self.def_path_prover
-            .as_ref()
-            .map(|p| p.def_hook_commit())
+        self.def_path_prover.as_ref().map(|p| p.def_hook_commit())
     }
 
     /// Builds the guest package located at `pkg_dir`. This function requires that the build target

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -235,7 +235,7 @@ where
 
     /// Enables deferrals in this GenericSdk. The DeferralProver must be created ahead of time
     /// because the DeferralExtension should be created using DeferralProver::make_extension, as
-    /// it has the capability to generate def_vk_commits.
+    /// it has the capability to generate def_circuit_commits.
     pub fn with_deferral_prover(mut self, deferral_prover: DeferralProver) -> Self {
         assert!(
             self.def_path_prover.is_none(),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -37,8 +37,8 @@ use openvm_transpiler::{
 };
 use openvm_verify_stark_host::{
     verify_vm_stark_proof_decoded,
-    vk::{NonRootStarkVerifyingKey, VerificationBaseline},
-    NonRootStarkProof,
+    vk::{VmStarkVerifyingKey, VerificationBaseline},
+    VmStarkProof,
 };
 
 use crate::{
@@ -441,7 +441,7 @@ where
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
         def_inputs: &[DeferralInput],
-    ) -> Result<(NonRootStarkProof, VerificationBaseline), SdkError> {
+    ) -> Result<(VmStarkProof, VerificationBaseline), SdkError> {
         let mut prover = self.prover(app_exe)?;
         let proof = prover.prove(inputs, def_inputs)?.0;
         let baseline = prover.generate_baseline();
@@ -698,9 +698,9 @@ where
     pub fn verify_proof(
         agg_vk: MultiStarkVerifyingKey<SC>,
         baseline: VerificationBaseline,
-        proof: &NonRootStarkProof,
+        proof: &VmStarkProof,
     ) -> Result<(), SdkError> {
-        let vk = NonRootStarkVerifyingKey {
+        let vk = VmStarkVerifyingKey {
             mvk: agg_vk,
             baseline,
         };

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -273,10 +273,10 @@ where
     }
 
     /// Returns the def_hook_prover vk commit.
-    pub fn def_hook_vk_commit(&self) -> Option<Digest> {
+    pub fn def_hook_commit(&self) -> Option<Digest> {
         self.def_path_prover
             .as_ref()
-            .map(|p| p.def_hook_vk_commit())
+            .map(|p| p.def_hook_commit())
     }
 
     /// Builds the guest package located at `pkg_dir`. This function requires that the build target
@@ -567,7 +567,7 @@ where
                     root_pk,
                     memory_dimensions,
                     num_user_pvs,
-                    self.def_hook_vk_commit(),
+                    self.def_hook_commit(),
                     Some(trace_heights),
                 ))
             })

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -679,7 +679,7 @@ where
     /// Generates the Halo2 (static verifier + wrapper) proving key once and caches it.
     ///
     /// The flow:
-    /// 1. Get the root VK and internal recursive DAG cached commit
+    /// 1. Get the root VK and internal recursive VK cached commit
     /// 2. Generate a dummy root proof via the EVM prover pipeline
     /// 3. Keygen the static verifier circuit
     /// 4. Generate a dummy snark from the verifier

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -8,7 +8,7 @@ use openvm_stark_backend::{
     keygen::types::MultiStarkVerifyingKey, p3_field::PrimeCharacteristicRing,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{poseidon2_compress_with_capacity, F};
-use openvm_verify_stark_host::{pvs::DeferralPvs, NonRootStarkProof};
+use openvm_verify_stark_host::{pvs::DeferralPvs, VmStarkProof};
 use tracing::info_span;
 
 use crate::{
@@ -137,7 +137,7 @@ impl AggProver {
     pub fn prove_vm(
         &self,
         continuation_proof: ContinuationVmProof<SC>,
-    ) -> Result<(NonRootStarkProof, InternalLayerMetadata)> {
+    ) -> Result<(VmStarkProof, InternalLayerMetadata)> {
         // Verify app-layer proofs and generate leaf-layer proofs
         let leaf_proofs = info_span!("agg_layer", group = "leaf").in_scope(|| {
             continuation_proof
@@ -207,7 +207,7 @@ impl AggProver {
         }
 
         Ok((
-            NonRootStarkProof {
+            VmStarkProof {
                 inner: internal_proofs.pop().unwrap(),
                 user_pvs_proof: continuation_proof.user_public_values,
                 deferral_merkle_proofs: None,
@@ -267,10 +267,10 @@ impl AggProver {
 
     pub fn prove_mixed(
         &self,
-        mut vm_proof: NonRootStarkProof,
+        mut vm_proof: VmStarkProof,
         def_proof: DeferralProof,
         metadata: &mut InternalLayerMetadata,
-    ) -> Result<NonRootStarkProof> {
+    ) -> Result<VmStarkProof> {
         let DeferralProof::Present(def_inner) = def_proof else {
             return Ok(vm_proof);
         };
@@ -298,9 +298,9 @@ impl AggProver {
 
     pub fn wrap_proof(
         &self,
-        mut proof: NonRootStarkProof,
+        mut proof: VmStarkProof,
         metadata: &mut InternalLayerMetadata,
-    ) -> Result<NonRootStarkProof> {
+    ) -> Result<VmStarkProof> {
         proof.inner = info_span!(
             "agg_layer",
             group = format!("internal_recursive.{}", metadata.internal_recursive_layer)

--- a/crates/sdk/src/prover/deferral/circuit.rs
+++ b/crates/sdk/src/prover/deferral/circuit.rs
@@ -145,7 +145,7 @@ impl SingleDefCircuitProver {
         })
     }
 
-    pub fn vk_commit(&self, internal_for_leaf_dag_commit: DagCommit<F>) -> Digest {
+    pub fn circuit_commit(&self, internal_for_leaf_dag_commit: DagCommit<F>) -> Digest {
         let def_dag_commit = self.leaf_prover.get_dag_commit(false);
         let leaf_dag_commit = self.internal_for_leaf_prover.get_dag_commit(false);
 

--- a/crates/sdk/src/prover/deferral/circuit.rs
+++ b/crates/sdk/src/prover/deferral/circuit.rs
@@ -10,7 +10,7 @@ use openvm_continuations::{
 use openvm_recursion_circuit::utils::poseidon2_hash_slice;
 use openvm_stark_backend::{keygen::types::MultiStarkProvingKey, proof::Proof, SystemParams};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, F};
-use openvm_verify_stark_host::pvs::DagCommit;
+use openvm_verify_stark_host::pvs::VkCommit;
 use tracing::info_span;
 
 use crate::DeferralInput;
@@ -145,17 +145,17 @@ impl SingleDefCircuitProver {
         })
     }
 
-    pub fn circuit_commit(&self, internal_for_leaf_dag_commit: DagCommit<F>) -> Digest {
-        let def_dag_commit = self.leaf_prover.get_dag_commit(false);
-        let leaf_dag_commit = self.internal_for_leaf_prover.get_dag_commit(false);
+    pub fn circuit_commit(&self, internal_for_leaf_vk_commit: VkCommit<F>) -> Digest {
+        let def_vk_commit = self.leaf_prover.get_vk_commit(false);
+        let leaf_vk_commit = self.internal_for_leaf_prover.get_vk_commit(false);
 
         let vk_commit_components = vec![
-            def_dag_commit.cached_commit,
-            def_dag_commit.vk_pre_hash,
-            leaf_dag_commit.cached_commit,
-            leaf_dag_commit.vk_pre_hash,
-            internal_for_leaf_dag_commit.cached_commit,
-            internal_for_leaf_dag_commit.vk_pre_hash,
+            def_vk_commit.cached_commit,
+            def_vk_commit.vk_pre_hash,
+            leaf_vk_commit.cached_commit,
+            leaf_vk_commit.vk_pre_hash,
+            internal_for_leaf_vk_commit.cached_commit,
+            internal_for_leaf_vk_commit.vk_pre_hash,
         ];
         poseidon2_hash_slice(&vk_commit_components.into_flattened()).0
     }

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -150,9 +150,9 @@ impl DeferralProver {
             .map(|(circuit_idx, res)| {
                 let mut proofs = res.internal_for_leaf_proofs;
                 if proofs.is_empty() {
-                    let def_vk_commit = self.single_circuit_provers[circuit_idx]
-                        .vk_commit(self.internal_recursive_prover.get_dag_commit(false));
-                    let input_acc_hash = poseidon2_hash_slice(&def_vk_commit).0;
+                    let def_circuit_commit = self.single_circuit_provers[circuit_idx]
+                        .circuit_commit(self.internal_recursive_prover.get_dag_commit(false));
+                    let input_acc_hash = poseidon2_hash_slice(&def_circuit_commit).0;
                     let output_acc_hash = poseidon2_hash_slice(&[F::ZERO]).0;
                     let combined_hash =
                         poseidon2_compress_with_capacity(input_acc_hash, output_acc_hash).0;
@@ -222,11 +222,11 @@ impl DeferralProver {
 
     pub fn make_extension(&self, fns: Vec<Arc<DeferralFn>>) -> DeferralExtension {
         let dag_commit = self.internal_recursive_prover.get_dag_commit(false);
-        let def_vk_commits = self
+        let def_circuit_commits = self
             .single_circuit_provers
             .iter()
             .map(|p| {
-                p.vk_commit(dag_commit)
+                p.circuit_commit(dag_commit)
                     .iter()
                     .flat_map(|f| f.to_unique_u32().to_le_bytes())
                     .collect::<Vec<_>>()
@@ -236,7 +236,7 @@ impl DeferralProver {
             .collect();
         DeferralExtension {
             fns,
-            def_vk_commits,
+            def_circuit_commits,
         }
     }
 }

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -69,7 +69,7 @@ impl DeferralProver {
             true,
         );
         let internal_recursive_cached_commit = internal_recursive_prover
-            .get_dag_commit(true)
+            .get_vk_commit(true)
             .cached_commit
             .into();
         let def_hook_prover = DeferralHookProver::new::<E>(
@@ -151,7 +151,7 @@ impl DeferralProver {
                 let mut proofs = res.internal_for_leaf_proofs;
                 if proofs.is_empty() {
                     let def_circuit_commit = self.single_circuit_provers[circuit_idx]
-                        .circuit_commit(self.internal_recursive_prover.get_dag_commit(false));
+                        .circuit_commit(self.internal_recursive_prover.get_vk_commit(false));
                     let input_acc_hash = poseidon2_hash_slice(&def_circuit_commit).0;
                     let output_acc_hash = poseidon2_hash_slice(&[F::ZERO]).0;
                     let combined_hash =
@@ -221,12 +221,12 @@ impl DeferralProver {
     }
 
     pub fn make_extension(&self, fns: Vec<Arc<DeferralFn>>) -> DeferralExtension {
-        let dag_commit = self.internal_recursive_prover.get_dag_commit(false);
+        let vk_commit = self.internal_recursive_prover.get_vk_commit(false);
         let def_circuit_commits = self
             .single_circuit_provers
             .iter()
             .map(|p| {
-                p.circuit_commit(dag_commit)
+                p.circuit_commit(vk_commit)
                     .iter()
                     .flat_map(|f| f.to_unique_u32().to_le_bytes())
                     .collect::<Vec<_>>()

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -59,7 +59,7 @@ impl RootProver {
         system_params: SystemParams,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
-        def_hook_vk_commit: Option<Digest>,
+        def_hook_commit: Option<Digest>,
         trace_heights: Option<Vec<usize>>,
     ) -> Self {
         let inner = RootInnerProver::new::<E>(
@@ -68,7 +68,7 @@ impl RootProver {
             system_params,
             memory_dimensions,
             num_user_pvs,
-            def_hook_vk_commit.map(Into::into),
+            def_hook_commit.map(Into::into),
             trace_heights,
         );
         Self(inner)
@@ -80,7 +80,7 @@ impl RootProver {
         pk: Arc<MultiStarkProvingKey<RootSC>>,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
-        def_hook_vk_commit: Option<Digest>,
+        def_hook_commit: Option<Digest>,
         trace_heights: Option<Vec<usize>>,
     ) -> Self {
         let inner = RootInnerProver::from_pk::<E>(
@@ -89,7 +89,7 @@ impl RootProver {
             pk,
             memory_dimensions,
             num_user_pvs,
-            def_hook_vk_commit.map(Into::into),
+            def_hook_commit.map(Into::into),
             trace_heights,
         );
         Self(inner)
@@ -145,7 +145,7 @@ pub fn compute_root_proof_heights(
     app_config.app_vm_config.system.config = system_config;
 
     let def_hook_cached_commit = def_prover.as_ref().map(|p| p.def_hook_cached_commit());
-    let def_hook_vk_commit = def_prover.as_ref().map(|p| p.def_hook_vk_commit().into());
+    let def_hook_commit = def_prover.as_ref().map(|p| p.def_hook_commit().into());
 
     let app_pk = AppProvingKey::keygen(app_config)?;
 
@@ -178,7 +178,7 @@ pub fn compute_root_proof_heights(
         root_params,
         memory_dimensions,
         num_user_pvs,
-        def_hook_vk_commit,
+        def_hook_commit,
         None,
     );
     let root_proving_ctx: ProvingContext<<CpuRootE as StarkEngine>::PB> = root_prover

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -55,7 +55,7 @@ pub struct RootProver(pub RootInnerProver);
 impl RootProver {
     pub fn new(
         internal_recursive_vk: Arc<MultiStarkVerifyingKey<SC>>,
-        internal_recursive_dag_commit: CommitBytes,
+        internal_recursive_vk_commit: CommitBytes,
         system_params: SystemParams,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
@@ -64,7 +64,7 @@ impl RootProver {
     ) -> Self {
         let inner = RootInnerProver::new::<E>(
             internal_recursive_vk,
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
             system_params,
             memory_dimensions,
             num_user_pvs,
@@ -76,7 +76,7 @@ impl RootProver {
 
     pub fn from_pk(
         internal_recursive_vk: Arc<MultiStarkVerifyingKey<SC>>,
-        internal_recursive_dag_commit: CommitBytes,
+        internal_recursive_vk_commit: CommitBytes,
         pk: Arc<MultiStarkProvingKey<RootSC>>,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
@@ -85,7 +85,7 @@ impl RootProver {
     ) -> Self {
         let inner = RootInnerProver::from_pk::<E>(
             internal_recursive_vk,
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
             pk,
             memory_dimensions,
             num_user_pvs,

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -23,7 +23,7 @@ use openvm_stark_sdk::config::{
     baby_bear_poseidon2::{Digest, F},
     MAX_APP_LOG_STACKED_HEIGHT,
 };
-use openvm_verify_stark_host::NonRootStarkProof;
+use openvm_verify_stark_host::VmStarkProof;
 use tracing::info_span;
 
 use crate::{
@@ -97,7 +97,7 @@ impl RootProver {
 
     pub fn generate_proving_ctx(
         &self,
-        input: NonRootStarkProof,
+        input: VmStarkProof,
     ) -> Option<ProvingContext<<E as StarkEngine>::PB>> {
         let ctx = info_span!("tracegen_attempt", group = format!("root")).in_scope(|| {
             self.0.generate_proving_ctx(

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -162,7 +162,7 @@ where
                 .agg_prover
                 .internal_recursive_prover
                 .get_dag_commit(true),
-            expected_def_vk_commit: self.def_prover.as_ref().map(|dp| dp.def_hook_vk_commit()),
+            expected_def_hook_commit: self.def_prover.as_ref().map(|dp| dp.def_hook_commit()),
         }
     }
 
@@ -194,7 +194,7 @@ impl DeferralPathProver {
         self.deferral_prover.def_hook_prover.get_cached_commit()
     }
 
-    pub fn def_hook_vk_commit(&self) -> Digest {
+    pub fn def_hook_commit(&self) -> Digest {
         let def_dag_commit = self.agg_prover.leaf_prover.get_dag_commit(false);
         let leaf_dag_commit = self
             .agg_prover

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -166,7 +166,7 @@ where
         }
     }
 
-    pub fn app_vk_commit(&self) -> Digest {
+    pub fn app_vm_commit(&self) -> Digest {
         let app_dag_commit = self.agg_prover.leaf_prover.get_dag_commit(false);
         let leaf_dag_commit = self
             .agg_prover

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -14,7 +14,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, F};
 use openvm_verify_stark_host::{
     pvs::{DeferralPvs, DEF_PVS_AIR_ID},
     vk::VerificationBaseline,
-    NonRootStarkProof,
+    VmStarkProof,
 };
 
 use crate::{
@@ -65,7 +65,7 @@ where
         &mut self,
         vm_input: StdIn<Val<SC>>,
         def_inputs: &[DeferralInput],
-    ) -> Result<(NonRootStarkProof, InternalLayerMetadata)>
+    ) -> Result<(VmStarkProof, InternalLayerMetadata)>
     where
         <VB::VmConfig as VmExecutionConfig<Val<SC>>>::Executor: Executor<Val<SC>>
             + MeteredExecutor<Val<SC>>

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -149,40 +149,40 @@ where
         VerificationBaseline {
             app_exe_commit: self.app_prover.app_exe_commit(),
             memory_dimensions: self.app_prover.memory_dimensions(),
-            app_dag_commit: self.agg_prover.leaf_prover.get_dag_commit(false),
-            leaf_dag_commit: self
+            app_vk_commit: self.agg_prover.leaf_prover.get_vk_commit(false),
+            leaf_vk_commit: self
                 .agg_prover
                 .internal_for_leaf_prover
-                .get_dag_commit(false),
-            internal_for_leaf_dag_commit: self
+                .get_vk_commit(false),
+            internal_for_leaf_vk_commit: self
                 .agg_prover
                 .internal_recursive_prover
-                .get_dag_commit(false),
-            internal_recursive_dag_commit: self
+                .get_vk_commit(false),
+            internal_recursive_vk_commit: self
                 .agg_prover
                 .internal_recursive_prover
-                .get_dag_commit(true),
+                .get_vk_commit(true),
             expected_def_hook_commit: self.def_prover.as_ref().map(|dp| dp.def_hook_commit()),
         }
     }
 
     pub fn app_vm_commit(&self) -> Digest {
-        let app_dag_commit = self.agg_prover.leaf_prover.get_dag_commit(false);
-        let leaf_dag_commit = self
+        let app_vk_commit = self.agg_prover.leaf_prover.get_vk_commit(false);
+        let leaf_vk_commit = self
             .agg_prover
             .internal_for_leaf_prover
-            .get_dag_commit(false);
-        let internal_for_leaf_dag_commit = self
+            .get_vk_commit(false);
+        let internal_for_leaf_vk_commit = self
             .agg_prover
             .internal_recursive_prover
-            .get_dag_commit(false);
+            .get_vk_commit(false);
         let components = vec![
-            app_dag_commit.cached_commit,
-            app_dag_commit.vk_pre_hash,
-            leaf_dag_commit.cached_commit,
-            leaf_dag_commit.vk_pre_hash,
-            internal_for_leaf_dag_commit.cached_commit,
-            internal_for_leaf_dag_commit.vk_pre_hash,
+            app_vk_commit.cached_commit,
+            app_vk_commit.vk_pre_hash,
+            leaf_vk_commit.cached_commit,
+            leaf_vk_commit.vk_pre_hash,
+            internal_for_leaf_vk_commit.cached_commit,
+            internal_for_leaf_vk_commit.vk_pre_hash,
         ]
         .into_flattened();
         poseidon2_hash_slice(&components).0
@@ -195,22 +195,22 @@ impl DeferralPathProver {
     }
 
     pub fn def_hook_commit(&self) -> Digest {
-        let def_dag_commit = self.agg_prover.leaf_prover.get_dag_commit(false);
-        let leaf_dag_commit = self
+        let def_vk_commit = self.agg_prover.leaf_prover.get_vk_commit(false);
+        let leaf_vk_commit = self
             .agg_prover
             .internal_for_leaf_prover
-            .get_dag_commit(false);
-        let internal_for_leaf_dag_commit = self
+            .get_vk_commit(false);
+        let internal_for_leaf_vk_commit = self
             .agg_prover
             .internal_recursive_prover
-            .get_dag_commit(false);
+            .get_vk_commit(false);
         let components = vec![
-            def_dag_commit.cached_commit,
-            def_dag_commit.vk_pre_hash,
-            leaf_dag_commit.cached_commit,
-            leaf_dag_commit.vk_pre_hash,
-            internal_for_leaf_dag_commit.cached_commit,
-            internal_for_leaf_dag_commit.vk_pre_hash,
+            def_vk_commit.cached_commit,
+            def_vk_commit.vk_pre_hash,
+            leaf_vk_commit.cached_commit,
+            leaf_vk_commit.vk_pre_hash,
+            internal_for_leaf_vk_commit.cached_commit,
+            internal_for_leaf_vk_commit.vk_pre_hash,
         ]
         .into_flattened();
         poseidon2_hash_slice(&components).0

--- a/crates/sdk/src/solidity.rs
+++ b/crates/sdk/src/solidity.rs
@@ -49,7 +49,7 @@ pub(crate) fn generate_halo2_verifier_solidity(
     // The wrapper's instances layout is:
     //   [0..12]: KZG accumulator
     //   [12]: app_exe_commit
-    //   [13]: app_vk_commit
+    //   [13]: app_vm_commit
     //   [14..]: user public values
     let num_pvs = halo2_pk
         .wrapper

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -143,7 +143,7 @@ fn test_verify_stark_deferral() -> Result<()> {
     let input_commit: [u8; 32] = raw_results[0].input.clone().try_into().unwrap();
     let output_raw = &raw_results[0].output_raw;
     let app_exe_commit: [u8; 32] = output_raw[..32].try_into().unwrap();
-    let app_vk_commit: [u8; 32] = output_raw[32..64].try_into().unwrap();
+    let app_vm_commit: [u8; 32] = output_raw[32..64].try_into().unwrap();
     let user_public_values = output_raw[64..].to_vec();
 
     // Build the deferral state for execution
@@ -171,7 +171,7 @@ fn test_verify_stark_deferral() -> Result<()> {
     // ---- Step 8: Set up stdin for the verify-stark guest program ----
     let mut vs_stdin = StdIn::default();
     vs_stdin.write(&app_exe_commit);
-    vs_stdin.write(&app_vk_commit);
+    vs_stdin.write(&app_vm_commit);
     vs_stdin.write(&user_public_values);
     vs_stdin.write(&input_commit);
     vs_stdin.deferrals = vec![deferral_state];

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -344,7 +344,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
                 .internal_recursive_prover
                 .get_self_vk_pcs_data()
                 .unwrap();
-            let dag_commit: CommitBytes = ir_pcs_data.commitment.into();
+            let vk_commit: CommitBytes = ir_pcs_data.commitment.into();
             let onion_commit = compute_dag_onion_commit(&ir_vk);
 
             let memory_dimensions = system_config.memory_config.memory_dimensions();
@@ -352,7 +352,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
 
             let root_prover = Arc::new(RootProver::from_pk(
                 ir_vk,
-                dag_commit,
+                vk_commit,
                 root_pk,
                 memory_dimensions,
                 num_user_pvs,

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -16,7 +16,7 @@ use openvm_transpiler::elf::Elf;
 use openvm_verify_stark_circuit::extension::{
     get_deferral_state, get_raw_deferral_results, verify_stark_deferral_fn,
 };
-use openvm_verify_stark_host::vk::NonRootStarkVerifyingKey;
+use openvm_verify_stark_host::vk::VmStarkVerifyingKey;
 
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AppConfig, DEFAULT_APP_L_SKIP},
@@ -132,7 +132,7 @@ fn test_verify_stark_deferral() -> Result<()> {
         deferral_prover.make_extension(vec![Arc::new(DeferralFn::new(verify_stark_deferral_fn))]);
 
     // ---- Step 5: Compute deferral state and guest stdin values ----
-    let fib_vk = NonRootStarkVerifyingKey {
+    let fib_vk = VmStarkVerifyingKey {
         mvk: fib_sdk.agg_vk().as_ref().clone(),
         baseline: fib_baseline,
     };

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
 };
 use openvm_transpiler::elf::Elf;
 use openvm_verify_stark_host::{
-    deferral::DeferralMerkleProofs, pvs::DagCommit, vk::VerificationBaseline, NonRootStarkProof,
+    deferral::DeferralMerkleProofs, pvs::DagCommit, vk::VerificationBaseline, VmStarkProof,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -305,10 +305,10 @@ impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
 
 // =================== Non-EVM types ===================
 
-/// Struct purely for encoding and decoding of [NonRootStarkProof].
+/// Struct purely for encoding and decoding of [VmStarkProof].
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize, Encode, Decode)]
-pub struct VersionedNonRootStarkProof {
+pub struct VersionedVmStarkProof {
     /// The openvm major and minor version v{}.{}. The proof format will not change on patch
     /// versions.
     pub version: String,
@@ -321,8 +321,8 @@ pub struct VersionedNonRootStarkProof {
     pub deferral_merkle_proofs: Option<Vec<u8>>,
 }
 
-impl VersionedNonRootStarkProof {
-    pub fn new(proof: NonRootStarkProof) -> Result<Self> {
+impl VersionedVmStarkProof {
+    pub fn new(proof: VmStarkProof) -> Result<Self> {
         Ok(Self {
             version: format!("v{}", OPENVM_VERSION),
             proof: proof.inner.encode_to_vec()?,
@@ -343,10 +343,10 @@ impl VersionedNonRootStarkProof {
     }
 }
 
-impl TryFrom<VersionedNonRootStarkProof> for NonRootStarkProof {
+impl TryFrom<VersionedVmStarkProof> for VmStarkProof {
     type Error = std::io::Error;
-    fn try_from(proof: VersionedNonRootStarkProof) -> Result<Self, std::io::Error> {
-        let VersionedNonRootStarkProof {
+    fn try_from(proof: VersionedVmStarkProof) -> Result<Self, std::io::Error> {
+        let VersionedVmStarkProof {
             proof,
             user_pvs_proof,
             deferral_merkle_proofs,

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -389,7 +389,7 @@ pub struct VerificationBaselineJson {
     pub internal_for_leaf_dag_commit: DagCommitJson,
     pub internal_recursive_dag_commit: DagCommitJson,
     #[serde(with = "option_hex_bytes32")]
-    pub expected_def_vk_commit: Option<CommitBytes>,
+    pub expected_def_hook_commit: Option<CommitBytes>,
 }
 
 impl From<VerificationBaseline> for VerificationBaselineJson {
@@ -405,7 +405,7 @@ impl From<VerificationBaseline> for VerificationBaselineJson {
             leaf_dag_commit: dag(b.leaf_dag_commit),
             internal_for_leaf_dag_commit: dag(b.internal_for_leaf_dag_commit),
             internal_recursive_dag_commit: dag(b.internal_recursive_dag_commit),
-            expected_def_vk_commit: b.expected_def_vk_commit.map(CommitBytes::from),
+            expected_def_hook_commit: b.expected_def_hook_commit.map(CommitBytes::from),
         }
     }
 }
@@ -424,7 +424,7 @@ impl From<VerificationBaselineJson> for VerificationBaseline {
             leaf_dag_commit: dag(b.leaf_dag_commit),
             internal_for_leaf_dag_commit: dag(b.internal_for_leaf_dag_commit),
             internal_recursive_dag_commit: dag(b.internal_recursive_dag_commit),
-            expected_def_vk_commit: b.expected_def_vk_commit.map(|c| c.into()),
+            expected_def_hook_commit: b.expected_def_hook_commit.map(|c| c.into()),
         }
     }
 }

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -102,7 +102,7 @@ pub struct AppExecutionCommit {
     #[serde(with = "hex_bytes32")]
     pub app_exe_commit: openvm_continuations::CommitBytes,
     #[serde(with = "hex_bytes32")]
-    pub app_vk_commit: openvm_continuations::CommitBytes,
+    pub app_vm_commit: openvm_continuations::CommitBytes,
 }
 
 #[cfg(feature = "evm-prove")]
@@ -156,7 +156,7 @@ impl EvmProof {
             publicValues: user_public_values.into(),
             proofData: proof_data_bytes.into(),
             appExeCommit: (*app_commit.app_exe_commit.as_slice()).into(),
-            appVmCommit: (*app_commit.app_vk_commit.as_slice()).into(),
+            appVmCommit: (*app_commit.app_vm_commit.as_slice()).into(),
         }
         .abi_encode()
     }
@@ -192,7 +192,7 @@ pub fn encode_raw_evm_proof_calldata(
 /// Instance layout (with KZG accumulator from wrapper circuit):
 /// - `instances[0..12]`: KZG accumulator (12 Fr values)
 /// - `instances[12]`: app_exe_commit (Fr)
-/// - `instances[13]`: app_vk_commit (Fr)
+/// - `instances[13]`: app_vm_commit (Fr)
 /// - `instances[14..]`: user public values (each byte as Fr)
 #[cfg(feature = "evm-prove")]
 impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
@@ -235,7 +235,7 @@ impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
 
         let app_commit = AppExecutionCommit {
             app_exe_commit: CommitBytes::new(app_exe_bytes),
-            app_vk_commit: CommitBytes::new(app_vm_bytes),
+            app_vm_commit: CommitBytes::new(app_vm_bytes),
         };
 
         Self {
@@ -276,7 +276,7 @@ impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
         app_exe_bytes.reverse();
         let app_exe_fr = Fr::from_bytes(&app_exe_bytes).unwrap();
 
-        let mut app_vm_bytes = *app_commit.app_vk_commit.as_slice();
+        let mut app_vm_bytes = *app_commit.app_vm_commit.as_slice();
         app_vm_bytes.reverse();
         let app_vm_fr = Fr::from_bytes(&app_vm_bytes).unwrap();
 

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -394,17 +394,17 @@ pub struct VerificationBaselineJson {
 
 impl From<VerificationBaseline> for VerificationBaselineJson {
     fn from(b: VerificationBaseline) -> Self {
-        let dag = |d: VkCommit<crate::F>| VkCommitJson {
+        let vk = |d: VkCommit<crate::F>| VkCommitJson {
             cached_commit: CommitBytes::from(d.cached_commit),
             vk_pre_hash: CommitBytes::from(d.vk_pre_hash),
         };
         Self {
             app_exe_commit: CommitBytes::from(b.app_exe_commit),
             memory_dimensions: b.memory_dimensions,
-            app_vk_commit: dag(b.app_vk_commit),
-            leaf_vk_commit: dag(b.leaf_vk_commit),
-            internal_for_leaf_vk_commit: dag(b.internal_for_leaf_vk_commit),
-            internal_recursive_vk_commit: dag(b.internal_recursive_vk_commit),
+            app_vk_commit: vk(b.app_vk_commit),
+            leaf_vk_commit: vk(b.leaf_vk_commit),
+            internal_for_leaf_vk_commit: vk(b.internal_for_leaf_vk_commit),
+            internal_recursive_vk_commit: vk(b.internal_recursive_vk_commit),
             expected_def_hook_commit: b.expected_def_hook_commit.map(CommitBytes::from),
         }
     }
@@ -413,17 +413,17 @@ impl From<VerificationBaseline> for VerificationBaselineJson {
 impl From<VerificationBaselineJson> for VerificationBaseline {
     fn from(b: VerificationBaselineJson) -> Self {
         use openvm_verify_stark_host::pvs::VkCommit;
-        let dag = |d: VkCommitJson| VkCommit {
+        let vk = |d: VkCommitJson| VkCommit {
             cached_commit: d.cached_commit.into(),
             vk_pre_hash: d.vk_pre_hash.into(),
         };
         Self {
             app_exe_commit: b.app_exe_commit.into(),
             memory_dimensions: b.memory_dimensions,
-            app_vk_commit: dag(b.app_vk_commit),
-            leaf_vk_commit: dag(b.leaf_vk_commit),
-            internal_for_leaf_vk_commit: dag(b.internal_for_leaf_vk_commit),
-            internal_recursive_vk_commit: dag(b.internal_recursive_vk_commit),
+            app_vk_commit: vk(b.app_vk_commit),
+            leaf_vk_commit: vk(b.leaf_vk_commit),
+            internal_for_leaf_vk_commit: vk(b.internal_for_leaf_vk_commit),
+            internal_recursive_vk_commit: vk(b.internal_recursive_vk_commit),
             expected_def_hook_commit: b.expected_def_hook_commit.map(|c| c.into()),
         }
     }

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
 };
 use openvm_transpiler::elf::Elf;
 use openvm_verify_stark_host::{
-    deferral::DeferralMerkleProofs, pvs::DagCommit, vk::VerificationBaseline, VmStarkProof,
+    deferral::DeferralMerkleProofs, pvs::VkCommit, vk::VerificationBaseline, VmStarkProof,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -366,9 +366,9 @@ impl TryFrom<VersionedVmStarkProof> for VmStarkProof {
 
 // =================== Verification baseline JSON types ===================
 
-/// Hex-formatted [`DagCommit`](openvm_verify_stark_host::pvs::DagCommit) for JSON serialization.
+/// Hex-formatted [`VkCommit`](openvm_verify_stark_host::pvs::VkCommit) for JSON serialization.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DagCommitJson {
+pub struct VkCommitJson {
     #[serde(with = "hex_bytes32")]
     pub cached_commit: CommitBytes,
     #[serde(with = "hex_bytes32")]
@@ -384,27 +384,27 @@ pub struct VerificationBaselineJson {
     #[serde(with = "hex_bytes32")]
     pub app_exe_commit: CommitBytes,
     pub memory_dimensions: MemoryDimensions,
-    pub app_dag_commit: DagCommitJson,
-    pub leaf_dag_commit: DagCommitJson,
-    pub internal_for_leaf_dag_commit: DagCommitJson,
-    pub internal_recursive_dag_commit: DagCommitJson,
+    pub app_vk_commit: VkCommitJson,
+    pub leaf_vk_commit: VkCommitJson,
+    pub internal_for_leaf_vk_commit: VkCommitJson,
+    pub internal_recursive_vk_commit: VkCommitJson,
     #[serde(with = "option_hex_bytes32")]
     pub expected_def_hook_commit: Option<CommitBytes>,
 }
 
 impl From<VerificationBaseline> for VerificationBaselineJson {
     fn from(b: VerificationBaseline) -> Self {
-        let dag = |d: DagCommit<crate::F>| DagCommitJson {
+        let dag = |d: VkCommit<crate::F>| VkCommitJson {
             cached_commit: CommitBytes::from(d.cached_commit),
             vk_pre_hash: CommitBytes::from(d.vk_pre_hash),
         };
         Self {
             app_exe_commit: CommitBytes::from(b.app_exe_commit),
             memory_dimensions: b.memory_dimensions,
-            app_dag_commit: dag(b.app_dag_commit),
-            leaf_dag_commit: dag(b.leaf_dag_commit),
-            internal_for_leaf_dag_commit: dag(b.internal_for_leaf_dag_commit),
-            internal_recursive_dag_commit: dag(b.internal_recursive_dag_commit),
+            app_vk_commit: dag(b.app_vk_commit),
+            leaf_vk_commit: dag(b.leaf_vk_commit),
+            internal_for_leaf_vk_commit: dag(b.internal_for_leaf_vk_commit),
+            internal_recursive_vk_commit: dag(b.internal_recursive_vk_commit),
             expected_def_hook_commit: b.expected_def_hook_commit.map(CommitBytes::from),
         }
     }
@@ -412,18 +412,18 @@ impl From<VerificationBaseline> for VerificationBaselineJson {
 
 impl From<VerificationBaselineJson> for VerificationBaseline {
     fn from(b: VerificationBaselineJson) -> Self {
-        use openvm_verify_stark_host::pvs::DagCommit;
-        let dag = |d: DagCommitJson| DagCommit {
+        use openvm_verify_stark_host::pvs::VkCommit;
+        let dag = |d: VkCommitJson| VkCommit {
             cached_commit: d.cached_commit.into(),
             vk_pre_hash: d.vk_pre_hash.into(),
         };
         Self {
             app_exe_commit: b.app_exe_commit.into(),
             memory_dimensions: b.memory_dimensions,
-            app_dag_commit: dag(b.app_dag_commit),
-            leaf_dag_commit: dag(b.leaf_dag_commit),
-            internal_for_leaf_dag_commit: dag(b.internal_for_leaf_dag_commit),
-            internal_recursive_dag_commit: dag(b.internal_recursive_dag_commit),
+            app_vk_commit: dag(b.app_vk_commit),
+            leaf_vk_commit: dag(b.leaf_vk_commit),
+            internal_for_leaf_vk_commit: dag(b.internal_for_leaf_vk_commit),
+            internal_recursive_vk_commit: dag(b.internal_recursive_vk_commit),
             expected_def_hook_commit: b.expected_def_hook_commit.map(|c| c.into()),
         }
     }

--- a/crates/static-verifier/src/stages/full_pipeline/public_values.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/public_values.rs
@@ -21,7 +21,7 @@ pub struct StaticVerifierPvs<T> {
     pub app_exe_commit: T,
     /// Commit to the app-level verifying key, computed by hashing the cached_commit and
     /// vk_pre_hash components of the app, leaf, and internal-for-leaf DAG commits.
-    pub app_vk_commit: T,
+    pub app_vm_commit: T,
     /// The number of user public values is a configuration parameter in the App VM. This parameter
     /// is treated as a constant in the static verifier circuit.
     pub user_public_values: Vec<T>,
@@ -29,7 +29,7 @@ pub struct StaticVerifierPvs<T> {
 
 impl<T: Clone> StaticVerifierPvs<T> {
     pub fn to_vec(&self) -> Vec<T> {
-        let mut vec = vec![self.app_exe_commit.clone(), self.app_vk_commit.clone()];
+        let mut vec = vec![self.app_exe_commit.clone(), self.app_vm_commit.clone()];
         vec.extend_from_slice(&self.user_public_values);
         vec
     }
@@ -37,7 +37,7 @@ impl<T: Clone> StaticVerifierPvs<T> {
     pub fn from_slice(slice: &[T]) -> Self {
         Self {
             app_exe_commit: slice[0].clone(),
-            app_vk_commit: slice[1].clone(),
+            app_vm_commit: slice[1].clone(),
             user_public_values: slice[2..].to_vec(),
         }
     }
@@ -54,7 +54,7 @@ pub fn extract_public_values(
     let root_pvs: &RootVerifierPvs<BabyBearWire> =
         proof.public_values[VERIFIER_PVS_AIR_ID].as_slice().borrow();
     let app_exe_commit = compress_babybear_wires_to_bn254(ctx, chip, root_pvs.app_exe_commit);
-    let app_vk_commit = compress_babybear_wires_to_bn254(ctx, chip, root_pvs.app_vk_commit);
+    let app_vm_commit = compress_babybear_wires_to_bn254(ctx, chip, root_pvs.app_vm_commit);
     // not reduced:
     let user_pvs_nr = &proof.public_values[USER_PVS_COMMIT_AIR_ID];
     let user_public_values = user_pvs_nr
@@ -64,7 +64,7 @@ pub fn extract_public_values(
 
     StaticVerifierPvs {
         app_exe_commit,
-        app_vk_commit,
+        app_vm_commit,
         user_public_values,
     }
 }

--- a/crates/static-verifier/src/stages/full_pipeline/public_values.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/public_values.rs
@@ -20,7 +20,7 @@ pub struct StaticVerifierPvs<T> {
     /// (i.e. initial_pc).
     pub app_exe_commit: T,
     /// Commit to the app-level verifying key, computed by hashing the cached_commit and
-    /// vk_pre_hash components of the app, leaf, and internal-for-leaf DAG commits.
+    /// vk_pre_hash components of the app, leaf, and internal-for-leaf vk commits.
     pub app_vm_commit: T,
     /// The number of user public values is a configuration parameter in the App VM. This parameter
     /// is treated as a constant in the static verifier circuit.

--- a/crates/verify/README.md
+++ b/crates/verify/README.md
@@ -22,7 +22,7 @@ The final internal-recursive proof will expose the following public values:
 - `final_root`: Merkle root of VM memory after app execution
 - `internal_flag`: Internal aggregation layer indicator (0, 1, or 2)
 - `recursion_flag`: Internal aggregation recursive layer indicator (0, 1, or 2). For the final proof verified by this crate, it should be 1 or 2.
-- `app_dag_commit`, `leaf_dag_commit`, `internal_for_leaf_dag_commit`, `internal_recursive_dag_commit`: Each is a `DagCommit` containing a `cached_commit` (PCS commitment of the parent verifier circuit's cached trace) and a `vk_pre_hash` (field pre-hash of the child `MultiStarkVerifyingKey`), for the app, leaf, internal-for-leaf, and internal-recursive layers respectively
+- `app_vk_commit`, `leaf_vk_commit`, `internal_for_leaf_vk_commit`, `internal_recursive_vk_commit`: Each is a `VkCommit` containing a `cached_commit` (PCS commitment of the parent verifier circuit's cached trace) and a `vk_pre_hash` (field pre-hash of the child `MultiStarkVerifyingKey`), for the app, leaf, internal-for-leaf, and internal-recursive layers respectively
 
 ## Verification Checks
 
@@ -35,8 +35,8 @@ The final internal-recursive STARK proof is verified using the internal-recursiv
 Given a fixed VM and executable, we must check certain exposed public values against a set of baseline artifacts (which can be generated ahead of time given the exe and VM, app, and aggregation configs).
 
 - `program_commit`, `initial_root`, and `initial_pc` are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`.
-- `app_dag_commit`, `leaf_dag_commit`, and `internal_for_leaf_dag_commit` (each containing both `cached_commit` and `vk_pre_hash`) are compared against pre-computed baselines
-- `internal_recursive_dag_commit` is checked conditionally:
+- `app_vk_commit`, `leaf_vk_commit`, and `internal_for_leaf_vk_commit` (each containing both `cached_commit` and `vk_pre_hash`) are compared against pre-computed baselines
+- `internal_recursive_vk_commit` is checked conditionally:
   - if `recursion_flag == 2`, it is compared against the pre-computed baseline
   - if `recursion_flag == 1`, it must be unset (all zeros)
 

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -56,13 +56,13 @@ pub enum VerifyStarkError {
     #[error("Invalid deferral flag {0}, should be 0 or 2")]
     InvalidDeferralFlag(F),
     #[error("Deferral hook VK commit mismatch: expected {expected:?}, actual {actual:?}")]
-    DefHookVkCommitMismatch { expected: Digest, actual: Digest },
-    #[error("Proof has deferrals but baseline has no expected_def_hook_vk_commit")]
+    DefHookCommitMismatch { expected: Digest, actual: Digest },
+    #[error("Proof has deferrals but baseline has no expected_def_hook_commit")]
     UnexpectedDeferralDisabled,
     #[error("Baseline expects deferrals but proof has no deferral Merkle proofs")]
     MissingDeferralMerkleProofs,
-    #[error("Proof has deferral_flag=0 but def_hook_vk_commit is set, actual {actual:?}")]
-    DefHookVkCommitSet { actual: Digest },
+    #[error("Proof has deferral_flag=0 but def_hook_commit is set, actual {actual:?}")]
+    DefHookCommitSet { actual: Digest },
     #[error("Proof has deferral_flag=0 but initial_acc_hash is set, actual {actual:?}")]
     DefInitialAccHashCommitSet { actual: Digest },
     #[error("Proof has deferral_flag=0 but final_acc_hash is set, actual {actual:?}")]

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -12,25 +12,25 @@ pub enum VerifyStarkError {
     #[error("Invalid app exe commit: expected {expected:?}, actual {actual:?}")]
     AppExeCommitMismatch { expected: Digest, actual: Digest },
     #[error("Invalid app cached commit: expected {expected:?}, actual {actual:?}")]
-    AppDagCachedCommitMismatch { expected: Digest, actual: Digest },
+    AppVkCachedCommitMismatch { expected: Digest, actual: Digest },
     #[error("Invalid app vk pre-hash: expected {expected:?}, actual {actual:?}")]
-    AppDagPreHashMismatch { expected: Digest, actual: Digest },
+    AppVkPreHashMismatch { expected: Digest, actual: Digest },
     #[error("Invalid leaf cached commit: expected {expected:?}, actual {actual:?}")]
-    LeafDagCachedCommitMismatch { expected: Digest, actual: Digest },
+    LeafVkCachedCommitMismatch { expected: Digest, actual: Digest },
     #[error("Invalid leaf vk pre-hash: expected {expected:?}, actual {actual:?}")]
-    LeafDagPreHashMismatch { expected: Digest, actual: Digest },
+    LeafVkPreHashMismatch { expected: Digest, actual: Digest },
     #[error("Invalid internal for leaf cached commit: expected {expected:?}, actual {actual:?}")]
-    InternalForLeafDagCachedCommitMismatch { expected: Digest, actual: Digest },
+    InternalForLeafVkCachedCommitMismatch { expected: Digest, actual: Digest },
     #[error("Invalid internal for leaf vk pre-hash: expected {expected:?}, actual {actual:?}")]
-    InternalForLeafDagPreHashMismatch { expected: Digest, actual: Digest },
+    InternalForLeafVkPreHashMismatch { expected: Digest, actual: Digest },
     #[error("Invalid internal recursive cached commit: expected {expected:?}, actual {actual:?}")]
-    InternalRecursiveDagCachedCommitMismatch { expected: Digest, actual: Digest },
+    InternalRecursiveVkCachedCommitMismatch { expected: Digest, actual: Digest },
     #[error("Invalid internal recursive vk pre-hash: expected {expected:?}, actual {actual:?}")]
-    InternalRecursiveDagPreHashMismatch { expected: Digest, actual: Digest },
+    InternalRecursiveVkPreHashMismatch { expected: Digest, actual: Digest },
     #[error("Internal recursive cached commit should be unset, actual {actual:?}")]
-    InternalRecursiveDagCachedCommitSet { actual: Digest },
+    InternalRecursiveVkCachedCommitSet { actual: Digest },
     #[error("Internal recursive vk pre-hash should be unset, actual {actual:?}")]
-    InternalRecursiveDagPreHashSet { actual: Digest },
+    InternalRecursiveVkPreHashSet { actual: Digest },
     #[error("Invalid proof cached commit: expected {expected:?}, actual {actual:?}")]
     ProofCachedCommitMismatch { expected: Digest, actual: Digest },
     #[error("Missing constraint-eval trace vdata, expected at AIR idx {air_idx}")]

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -266,10 +266,10 @@ pub fn verify_vm_stark_proof_pvs(
     }
 
     // Deferral verification
-    if let Some(expected_def_vk_commit) = vk.baseline.expected_def_vk_commit {
+    if let Some(expected_def_hook_commit) = vk.baseline.expected_def_hook_commit {
         let &VerifierDefPvs {
             deferral_flag,
-            def_hook_vk_commit,
+            def_hook_commit,
         } = verifier_def_pvs_slice.borrow();
 
         let &DeferralPvs {
@@ -281,9 +281,9 @@ pub fn verify_vm_stark_proof_pvs(
             .borrow();
 
         if deferral_flag == F::ZERO {
-            if !is_unset(&def_hook_vk_commit) {
-                return Err(VerifyStarkError::DefHookVkCommitSet {
-                    actual: def_hook_vk_commit,
+            if !is_unset(&def_hook_commit) {
+                return Err(VerifyStarkError::DefHookCommitSet {
+                    actual: def_hook_commit,
                 });
             } else if !is_unset(&initial_acc_hash) {
                 return Err(VerifyStarkError::DefInitialAccHashCommitSet {
@@ -297,10 +297,10 @@ pub fn verify_vm_stark_proof_pvs(
                 return Err(VerifyStarkError::DefDepthSet { actual: depth });
             }
         } else if deferral_flag == F::TWO {
-            if def_hook_vk_commit != expected_def_vk_commit {
-                return Err(VerifyStarkError::DefHookVkCommitMismatch {
-                    expected: expected_def_vk_commit,
-                    actual: def_hook_vk_commit,
+            if def_hook_commit != expected_def_hook_commit {
+                return Err(VerifyStarkError::DefHookCommitMismatch {
+                    expected: expected_def_hook_commit,
+                    actual: def_hook_commit,
                 });
             }
             let deferral_merkle_proofs = proof

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -151,13 +151,13 @@ pub fn verify_vm_stark_proof_pvs(
 
     // Check app_vk_commit against expected_commits.
     if app_vk_commit.cached_commit != vk.baseline.app_vk_commit.cached_commit {
-        return Err(VerifyStarkError::AppDagCachedCommitMismatch {
+        return Err(VerifyStarkError::AppVkCachedCommitMismatch {
             expected: vk.baseline.app_vk_commit.cached_commit,
             actual: app_vk_commit.cached_commit,
         });
     }
     if app_vk_commit.vk_pre_hash != vk.baseline.app_vk_commit.vk_pre_hash {
-        return Err(VerifyStarkError::AppDagPreHashMismatch {
+        return Err(VerifyStarkError::AppVkPreHashMismatch {
             expected: vk.baseline.app_vk_commit.vk_pre_hash,
             actual: app_vk_commit.vk_pre_hash,
         });
@@ -165,13 +165,13 @@ pub fn verify_vm_stark_proof_pvs(
 
     // Check leaf_vk_commit against expected_commits.
     if leaf_vk_commit.cached_commit != vk.baseline.leaf_vk_commit.cached_commit {
-        return Err(VerifyStarkError::LeafDagCachedCommitMismatch {
+        return Err(VerifyStarkError::LeafVkCachedCommitMismatch {
             expected: vk.baseline.leaf_vk_commit.cached_commit,
             actual: leaf_vk_commit.cached_commit,
         });
     }
     if leaf_vk_commit.vk_pre_hash != vk.baseline.leaf_vk_commit.vk_pre_hash {
-        return Err(VerifyStarkError::LeafDagPreHashMismatch {
+        return Err(VerifyStarkError::LeafVkPreHashMismatch {
             expected: vk.baseline.leaf_vk_commit.vk_pre_hash,
             actual: leaf_vk_commit.vk_pre_hash,
         });
@@ -181,7 +181,7 @@ pub fn verify_vm_stark_proof_pvs(
     if internal_for_leaf_vk_commit.cached_commit
         != vk.baseline.internal_for_leaf_vk_commit.cached_commit
     {
-        return Err(VerifyStarkError::InternalForLeafDagCachedCommitMismatch {
+        return Err(VerifyStarkError::InternalForLeafVkCachedCommitMismatch {
             expected: vk.baseline.internal_for_leaf_vk_commit.cached_commit,
             actual: internal_for_leaf_vk_commit.cached_commit,
         });
@@ -189,7 +189,7 @@ pub fn verify_vm_stark_proof_pvs(
     if internal_for_leaf_vk_commit.vk_pre_hash
         != vk.baseline.internal_for_leaf_vk_commit.vk_pre_hash
     {
-        return Err(VerifyStarkError::InternalForLeafDagPreHashMismatch {
+        return Err(VerifyStarkError::InternalForLeafVkPreHashMismatch {
             expected: vk.baseline.internal_for_leaf_vk_commit.vk_pre_hash,
             actual: internal_for_leaf_vk_commit.vk_pre_hash,
         });
@@ -227,7 +227,7 @@ pub fn verify_vm_stark_proof_pvs(
         if internal_recursive_vk_commit.cached_commit
             != vk.baseline.internal_recursive_vk_commit.cached_commit
         {
-            return Err(VerifyStarkError::InternalRecursiveDagCachedCommitMismatch {
+            return Err(VerifyStarkError::InternalRecursiveVkCachedCommitMismatch {
                 expected: vk.baseline.internal_recursive_vk_commit.cached_commit,
                 actual: internal_recursive_vk_commit.cached_commit,
             });
@@ -235,7 +235,7 @@ pub fn verify_vm_stark_proof_pvs(
         if internal_recursive_vk_commit.vk_pre_hash
             != vk.baseline.internal_recursive_vk_commit.vk_pre_hash
         {
-            return Err(VerifyStarkError::InternalRecursiveDagPreHashMismatch {
+            return Err(VerifyStarkError::InternalRecursiveVkPreHashMismatch {
                 expected: vk.baseline.internal_recursive_vk_commit.vk_pre_hash,
                 actual: internal_recursive_vk_commit.vk_pre_hash,
             });
@@ -248,12 +248,12 @@ pub fn verify_vm_stark_proof_pvs(
         }
     } else {
         if !is_unset(&internal_recursive_vk_commit.cached_commit) {
-            return Err(VerifyStarkError::InternalRecursiveDagCachedCommitSet {
+            return Err(VerifyStarkError::InternalRecursiveVkCachedCommitSet {
                 actual: internal_recursive_vk_commit.cached_commit,
             });
         }
         if !is_unset(&internal_recursive_vk_commit.vk_pre_hash) {
-            return Err(VerifyStarkError::InternalRecursiveDagPreHashSet {
+            return Err(VerifyStarkError::InternalRecursiveVkPreHashSet {
                 actual: internal_recursive_vk_commit.vk_pre_hash,
             });
         }

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -32,7 +32,7 @@ pub mod error;
 pub mod pvs;
 pub mod vk;
 
-pub(crate) type DagCommit = pvs::DagCommit<F>;
+pub(crate) type VkCommit = pvs::VkCommit<F>;
 
 // Final internal recursive STARK proof to be verified against the baseline
 #[derive(Clone, Debug)]
@@ -104,11 +104,11 @@ pub fn verify_vm_stark_proof_pvs(
 
     let &VerifierBasePvs::<F> {
         internal_flag,
-        app_dag_commit,
-        leaf_dag_commit,
-        internal_for_leaf_dag_commit,
+        app_vk_commit,
+        leaf_vk_commit,
+        internal_for_leaf_vk_commit,
         recursion_flag,
-        internal_recursive_dag_commit,
+        internal_recursive_vk_commit,
     } = verifier_base_pvs_slice.borrow();
 
     let &VmPvs::<F> {
@@ -149,49 +149,49 @@ pub fn verify_vm_stark_proof_pvs(
         return Err(VerifyStarkError::InvalidInternalFlag(internal_flag));
     }
 
-    // Check app_dag_commit against expected_commits.
-    if app_dag_commit.cached_commit != vk.baseline.app_dag_commit.cached_commit {
+    // Check app_vk_commit against expected_commits.
+    if app_vk_commit.cached_commit != vk.baseline.app_vk_commit.cached_commit {
         return Err(VerifyStarkError::AppDagCachedCommitMismatch {
-            expected: vk.baseline.app_dag_commit.cached_commit,
-            actual: app_dag_commit.cached_commit,
+            expected: vk.baseline.app_vk_commit.cached_commit,
+            actual: app_vk_commit.cached_commit,
         });
     }
-    if app_dag_commit.vk_pre_hash != vk.baseline.app_dag_commit.vk_pre_hash {
+    if app_vk_commit.vk_pre_hash != vk.baseline.app_vk_commit.vk_pre_hash {
         return Err(VerifyStarkError::AppDagPreHashMismatch {
-            expected: vk.baseline.app_dag_commit.vk_pre_hash,
-            actual: app_dag_commit.vk_pre_hash,
+            expected: vk.baseline.app_vk_commit.vk_pre_hash,
+            actual: app_vk_commit.vk_pre_hash,
         });
     }
 
-    // Check leaf_dag_commit against expected_commits.
-    if leaf_dag_commit.cached_commit != vk.baseline.leaf_dag_commit.cached_commit {
+    // Check leaf_vk_commit against expected_commits.
+    if leaf_vk_commit.cached_commit != vk.baseline.leaf_vk_commit.cached_commit {
         return Err(VerifyStarkError::LeafDagCachedCommitMismatch {
-            expected: vk.baseline.leaf_dag_commit.cached_commit,
-            actual: leaf_dag_commit.cached_commit,
+            expected: vk.baseline.leaf_vk_commit.cached_commit,
+            actual: leaf_vk_commit.cached_commit,
         });
     }
-    if leaf_dag_commit.vk_pre_hash != vk.baseline.leaf_dag_commit.vk_pre_hash {
+    if leaf_vk_commit.vk_pre_hash != vk.baseline.leaf_vk_commit.vk_pre_hash {
         return Err(VerifyStarkError::LeafDagPreHashMismatch {
-            expected: vk.baseline.leaf_dag_commit.vk_pre_hash,
-            actual: leaf_dag_commit.vk_pre_hash,
+            expected: vk.baseline.leaf_vk_commit.vk_pre_hash,
+            actual: leaf_vk_commit.vk_pre_hash,
         });
     }
 
-    // Check internal_for_leaf_dag_commit against expected_commits.
-    if internal_for_leaf_dag_commit.cached_commit
-        != vk.baseline.internal_for_leaf_dag_commit.cached_commit
+    // Check internal_for_leaf_vk_commit against expected_commits.
+    if internal_for_leaf_vk_commit.cached_commit
+        != vk.baseline.internal_for_leaf_vk_commit.cached_commit
     {
         return Err(VerifyStarkError::InternalForLeafDagCachedCommitMismatch {
-            expected: vk.baseline.internal_for_leaf_dag_commit.cached_commit,
-            actual: internal_for_leaf_dag_commit.cached_commit,
+            expected: vk.baseline.internal_for_leaf_vk_commit.cached_commit,
+            actual: internal_for_leaf_vk_commit.cached_commit,
         });
     }
-    if internal_for_leaf_dag_commit.vk_pre_hash
-        != vk.baseline.internal_for_leaf_dag_commit.vk_pre_hash
+    if internal_for_leaf_vk_commit.vk_pre_hash
+        != vk.baseline.internal_for_leaf_vk_commit.vk_pre_hash
     {
         return Err(VerifyStarkError::InternalForLeafDagPreHashMismatch {
-            expected: vk.baseline.internal_for_leaf_dag_commit.vk_pre_hash,
-            actual: internal_for_leaf_dag_commit.vk_pre_hash,
+            expected: vk.baseline.internal_for_leaf_vk_commit.vk_pre_hash,
+            actual: internal_for_leaf_vk_commit.vk_pre_hash,
         });
     }
 
@@ -221,45 +221,45 @@ pub fn verify_vm_stark_proof_pvs(
         return Err(VerifyStarkError::InvalidRecursionFlag(recursion_flag));
     }
 
-    // Check internal_recursive_dag_commit against expected_commits if recursion_flag
+    // Check internal_recursive_vk_commit against expected_commits if recursion_flag
     // is 2, and check it is unset if recursion_flag is 1.
     if recursion_flag == F::TWO {
-        if internal_recursive_dag_commit.cached_commit
-            != vk.baseline.internal_recursive_dag_commit.cached_commit
+        if internal_recursive_vk_commit.cached_commit
+            != vk.baseline.internal_recursive_vk_commit.cached_commit
         {
             return Err(VerifyStarkError::InternalRecursiveDagCachedCommitMismatch {
-                expected: vk.baseline.internal_recursive_dag_commit.cached_commit,
-                actual: internal_recursive_dag_commit.cached_commit,
+                expected: vk.baseline.internal_recursive_vk_commit.cached_commit,
+                actual: internal_recursive_vk_commit.cached_commit,
             });
         }
-        if internal_recursive_dag_commit.vk_pre_hash
-            != vk.baseline.internal_recursive_dag_commit.vk_pre_hash
+        if internal_recursive_vk_commit.vk_pre_hash
+            != vk.baseline.internal_recursive_vk_commit.vk_pre_hash
         {
             return Err(VerifyStarkError::InternalRecursiveDagPreHashMismatch {
-                expected: vk.baseline.internal_recursive_dag_commit.vk_pre_hash,
-                actual: internal_recursive_dag_commit.vk_pre_hash,
+                expected: vk.baseline.internal_recursive_vk_commit.vk_pre_hash,
+                actual: internal_recursive_vk_commit.vk_pre_hash,
             });
         }
-        if proof_cached_commit != vk.baseline.internal_recursive_dag_commit.cached_commit {
+        if proof_cached_commit != vk.baseline.internal_recursive_vk_commit.cached_commit {
             return Err(VerifyStarkError::ProofCachedCommitMismatch {
-                expected: vk.baseline.internal_recursive_dag_commit.cached_commit,
+                expected: vk.baseline.internal_recursive_vk_commit.cached_commit,
                 actual: proof_cached_commit,
             });
         }
     } else {
-        if !is_unset(&internal_recursive_dag_commit.cached_commit) {
+        if !is_unset(&internal_recursive_vk_commit.cached_commit) {
             return Err(VerifyStarkError::InternalRecursiveDagCachedCommitSet {
-                actual: internal_recursive_dag_commit.cached_commit,
+                actual: internal_recursive_vk_commit.cached_commit,
             });
         }
-        if !is_unset(&internal_recursive_dag_commit.vk_pre_hash) {
+        if !is_unset(&internal_recursive_vk_commit.vk_pre_hash) {
             return Err(VerifyStarkError::InternalRecursiveDagPreHashSet {
-                actual: internal_recursive_dag_commit.vk_pre_hash,
+                actual: internal_recursive_vk_commit.vk_pre_hash,
             });
         }
-        if proof_cached_commit != vk.baseline.internal_for_leaf_dag_commit.cached_commit {
+        if proof_cached_commit != vk.baseline.internal_for_leaf_vk_commit.cached_commit {
             return Err(VerifyStarkError::ProofCachedCommitMismatch {
-                expected: vk.baseline.internal_for_leaf_dag_commit.cached_commit,
+                expected: vk.baseline.internal_for_leaf_vk_commit.cached_commit,
                 actual: proof_cached_commit,
             });
         }

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -24,7 +24,7 @@ use crate::{
         DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
         CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
     },
-    vk::NonRootStarkVerifyingKey,
+    vk::VmStarkVerifyingKey,
 };
 
 pub mod deferral;
@@ -36,13 +36,13 @@ pub(crate) type DagCommit = pvs::DagCommit<F>;
 
 // Final internal recursive STARK proof to be verified against the baseline
 #[derive(Clone, Debug)]
-pub struct NonRootStarkProof {
+pub struct VmStarkProof {
     pub inner: Proof<SC>,
     pub user_pvs_proof: UserPublicValuesProof<DIGEST_SIZE, F>,
     pub deferral_merkle_proofs: Option<DeferralMerkleProofs<F>>,
 }
 
-impl Encode for NonRootStarkProof {
+impl Encode for VmStarkProof {
     fn encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         self.inner.encode(writer)?;
         self.user_pvs_proof.encode::<SC, _>(writer)?;
@@ -54,7 +54,7 @@ impl Encode for NonRootStarkProof {
     }
 }
 
-impl Decode for NonRootStarkProof {
+impl Decode for VmStarkProof {
     fn decode<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let inner = Proof::<SC>::decode(reader)?;
         let user_pvs_proof = UserPublicValuesProof::decode::<SC, _>(reader)?;
@@ -74,18 +74,18 @@ impl Decode for NonRootStarkProof {
 /// Verifies a non-root VM STARK proof (as a byte stream) given the internal-recursive
 /// layer verifying key and VM- and exe-specific baseline artifacts.
 pub fn verify_vm_stark_proof(
-    vk: &NonRootStarkVerifyingKey,
+    vk: &VmStarkVerifyingKey,
     encoded_proof: &[u8],
 ) -> Result<(), VerifyStarkError> {
     let decompressed = zstd::decode_all(encoded_proof)?;
-    verify_vm_stark_proof_decoded(vk, &NonRootStarkProof::decode_from_bytes(&decompressed)?)
+    verify_vm_stark_proof_decoded(vk, &VmStarkProof::decode_from_bytes(&decompressed)?)
 }
 
 /// Verifies a non-root VM STARK proof given the internal-recursive layer verifying
 /// key and VM- and exe-specific baseline artifacts.
 pub fn verify_vm_stark_proof_decoded(
-    vk: &NonRootStarkVerifyingKey,
-    proof: &NonRootStarkProof,
+    vk: &VmStarkVerifyingKey,
+    proof: &VmStarkProof,
 ) -> Result<(), VerifyStarkError> {
     // Verify the STARK proof.
     let engine = BabyBearPoseidon2CpuEngine::<DuplexSponge>::new(vk.mvk.inner.params.clone());
@@ -94,8 +94,8 @@ pub fn verify_vm_stark_proof_decoded(
 }
 
 pub fn verify_vm_stark_proof_pvs(
-    vk: &NonRootStarkVerifyingKey,
-    proof: &NonRootStarkProof,
+    vk: &VmStarkVerifyingKey,
+    proof: &VmStarkProof,
 ) -> Result<(), VerifyStarkError> {
     let (verifier_base_pvs_slice, verifier_def_pvs_slice) = proof.inner.public_values
         [VERIFIER_PVS_AIR_ID]

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -62,7 +62,7 @@ pub struct VerifierDefPvs<F> {
     /// Commit to the deferral hook verifying key, computed by hashing the cached_commit and
     /// vk_pre_hash components of the app, leaf, and internal-for-leaf DAG commits when
     /// deferral_flag == 1. Is set exactly when internal_for_leaf_dag_commit is set.
-    pub def_hook_vk_commit: [F; DIGEST_SIZE],
+    pub def_hook_commit: [F; DIGEST_SIZE],
 }
 
 #[repr(C)]

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -60,7 +60,7 @@ pub struct VerifierDefPvs<F> {
     /// has only VM public values defined, 1 if only deferral public values, and 2 if both.
     pub deferral_flag: F,
     /// Commit to the deferral hook verifying key, computed by hashing the cached_commit and
-    /// vk_pre_hash components of the app, leaf, and internal-for-leaf DAG commits when
+    /// vk_pre_hash components of the app, leaf, and internal-for-leaf vk commits when
     /// deferral_flag == 1. Is set exactly when internal_for_leaf_vk_commit is set.
     pub def_hook_commit: [F; DIGEST_SIZE],
 }

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -11,7 +11,7 @@ pub const CONSTRAINT_EVAL_CACHED_INDEX: usize = 0;
 
 #[repr(C)]
 #[derive(AlignedBorrow, Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
-pub struct DagCommit<F> {
+pub struct VkCommit<F> {
     /// Cached trace commit of this verifier circuit's SymbolicExpressionAir, which is derived
     /// from its child_vk.
     pub cached_commit: [F; DIGEST_SIZE],
@@ -30,13 +30,13 @@ pub struct VerifierBasePvs<F> {
     /// recursive verifier.
     pub internal_flag: F,
     /// Commit to the app_vk's DAG and its pre-hash, first exposed by the leaf verifier.
-    pub app_dag_commit: DagCommit<F>,
+    pub app_vk_commit: VkCommit<F>,
     /// Commit to the leaf_vk's DAG and its pre-hash, first exposed by the internal-for-leaf
     /// verifier.
-    pub leaf_dag_commit: DagCommit<F>,
+    pub leaf_vk_commit: VkCommit<F>,
     /// Commit to the internal_for_leaf_vk's DAG and its pre-hash, first exposed by the first
     /// (i.e. index 0) internal-recursive layer verifier.
-    pub internal_for_leaf_dag_commit: DagCommit<F>,
+    pub internal_for_leaf_vk_commit: VkCommit<F>,
 
     //////////////////////////////////////////////////////////////////////
     /// VERIFIER-SPECIFIC RECURSION PVS
@@ -47,7 +47,7 @@ pub struct VerifierBasePvs<F> {
     pub recursion_flag: F,
     /// Commit to the internal_recursive_vk's DAG and its pre-hash, exposed by subsequent (i.e.
     /// index > 0) internal-recursive layer verifiers.
-    pub internal_recursive_dag_commit: DagCommit<F>,
+    pub internal_recursive_vk_commit: VkCommit<F>,
 }
 
 #[repr(C)]
@@ -61,7 +61,7 @@ pub struct VerifierDefPvs<F> {
     pub deferral_flag: F,
     /// Commit to the deferral hook verifying key, computed by hashing the cached_commit and
     /// vk_pre_hash components of the app, leaf, and internal-for-leaf DAG commits when
-    /// deferral_flag == 1. Is set exactly when internal_for_leaf_dag_commit is set.
+    /// deferral_flag == 1. Is set exactly when internal_for_leaf_vk_commit is set.
     pub def_hook_commit: [F; DIGEST_SIZE],
 }
 

--- a/crates/verify/src/vk.rs
+++ b/crates/verify/src/vk.rs
@@ -40,9 +40,9 @@ pub struct VerificationBaseline {
     pub internal_recursive_dag_commit: DagCommit,
     /// Expected deferral VK commit (hash of the deferral aggregation prover's DAG commits).
     /// When `Some`, the proof must have `deferral_flag == 2` with a matching
-    /// `def_hook_vk_commit` and valid deferral Merkle proofs. When `None`, the proof must
+    /// `def_hook_commit` and valid deferral Merkle proofs. When `None`, the proof must
     /// have no deferral public values.
-    pub expected_def_vk_commit: Option<Digest>,
+    pub expected_def_hook_commit: Option<Digest>,
 }
 
 pub fn read_vk_from_file<P: AsRef<Path>>(path: P) -> Result<VmStarkVerifyingKey> {

--- a/crates/verify/src/vk.rs
+++ b/crates/verify/src/vk.rs
@@ -38,7 +38,7 @@ pub struct VerificationBaseline {
     /// Commit to the internal_recursive_vk's DAG and its pre-hash, exposed by subsequent (i.e.
     /// index > 0) internal-recursive layer verifiers.
     pub internal_recursive_vk_commit: VkCommit,
-    /// Expected deferral VK commit (hash of the deferral aggregation prover's DAG commits).
+    /// Expected deferral VK commit (hash of the deferral aggregation prover's vk commits).
     /// When `Some`, the proof must have `deferral_flag == 2` with a matching
     /// `def_hook_commit` and valid deferral Merkle proofs. When `None`, the proof must
     /// have no deferral public values.

--- a/crates/verify/src/vk.rs
+++ b/crates/verify/src/vk.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::keygen::types::MultiStarkVerifyingKey;
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, Digest};
 use serde::{Deserialize, Serialize};
 
-use crate::DagCommit;
+use crate::VkCommit;
 
 /// Verifying key and artifacts used to verify a STARK proof for a fixed VM and executable
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -28,16 +28,16 @@ pub struct VerificationBaseline {
     /// VM memory metadata used to verify the user public values merkle proof
     pub memory_dimensions: MemoryDimensions,
     /// Commit to the app_vk's DAG and its pre-hash, first exposed by the leaf verifier.
-    pub app_dag_commit: DagCommit,
+    pub app_vk_commit: VkCommit,
     /// Commit to the leaf_vk's DAG and its pre-hash, first exposed by the internal-for-leaf
     /// verifier.
-    pub leaf_dag_commit: DagCommit,
+    pub leaf_vk_commit: VkCommit,
     /// Commit to the internal_for_leaf_vk's DAG and its pre-hash, first exposed by the first
     /// (i.e. index 0) internal-recursive layer verifier.
-    pub internal_for_leaf_dag_commit: DagCommit,
+    pub internal_for_leaf_vk_commit: VkCommit,
     /// Commit to the internal_recursive_vk's DAG and its pre-hash, exposed by subsequent (i.e.
     /// index > 0) internal-recursive layer verifiers.
-    pub internal_recursive_dag_commit: DagCommit,
+    pub internal_recursive_vk_commit: VkCommit,
     /// Expected deferral VK commit (hash of the deferral aggregation prover's DAG commits).
     /// When `Some`, the proof must have `deferral_flag == 2` with a matching
     /// `def_hook_commit` and valid deferral Merkle proofs. When `None`, the proof must

--- a/crates/verify/src/vk.rs
+++ b/crates/verify/src/vk.rs
@@ -13,7 +13,7 @@ use crate::DagCommit;
 
 /// Verifying key and artifacts used to verify a STARK proof for a fixed VM and executable
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct NonRootStarkVerifyingKey {
+pub struct VmStarkVerifyingKey {
     pub mvk: MultiStarkVerifyingKey<BabyBearPoseidon2Config>,
     pub baseline: VerificationBaseline,
 }
@@ -45,7 +45,7 @@ pub struct VerificationBaseline {
     pub expected_def_vk_commit: Option<Digest>,
 }
 
-pub fn read_vk_from_file<P: AsRef<Path>>(path: P) -> Result<NonRootStarkVerifyingKey> {
+pub fn read_vk_from_file<P: AsRef<Path>>(path: P) -> Result<VmStarkVerifyingKey> {
     let ret = read(&path)
         .map_err(|e| read_error(&path, e.into()))
         .and_then(|data| {
@@ -54,7 +54,7 @@ pub fn read_vk_from_file<P: AsRef<Path>>(path: P) -> Result<NonRootStarkVerifyin
     Ok(ret)
 }
 
-pub fn write_vk_to_file<P: AsRef<Path>>(path: P, vk: &NonRootStarkVerifyingKey) -> Result<()> {
+pub fn write_vk_to_file<P: AsRef<Path>>(path: P, vk: &VmStarkVerifyingKey) -> Result<()> {
     if let Some(parent) = path.as_ref().parent() {
         create_dir_all(parent).map_err(|e| write_error(&path, e.into()))?;
     }

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -47,7 +47,7 @@ There should be a unique `DeferredVerifyCircuit` for each STARK verifying key yo
 To use `DeferredVerifyCircuit` in an app, you must wire it into your VM config via `DeferralExtension`. A VM config can support up to 1024 different deferral circuits at one time. `DeferralExtension` stores:
 
 - `fns: Vec<Arc<DeferralFn>>` - one function per deferral circuit
-- `def_vk_commits: Vec<[u8; 32]>` - the corresponding deferral-circuit VK commitments
+- `def_circuit_commits: Vec<[u8; 32]>` - the corresponding deferral-circuit VK commitments
 
 These vectors are aligned by index.
 

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -47,7 +47,7 @@ There should be a unique `DeferredVerifyCircuit` for each STARK verifying key yo
 To use `DeferredVerifyCircuit` in an app, you must wire it into your VM config via `DeferralExtension`. A VM config can support up to 1024 different deferral circuits at one time. `DeferralExtension` stores:
 
 - `fns: Vec<Arc<DeferralFn>>` - one function per deferral circuit
-- `def_circuit_commits: Vec<[u8; 32]>` - the corresponding deferral-circuit VK commitments
+- `def_circuit_commits: Vec<[u8; 32]>` - the corresponding deferral-circuit vk commitments
 
 These vectors are aligned by index.
 

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -17,7 +17,7 @@ pub fn verify_stark_unchecked<const DEF_IDX: u16>(input_commit: &Commit) -> Proo
 Invokes a deferred call at deferral index `DEF_IDX` with the given `input_commit` (a 32-byte commitment identifying the proof). Returns a `ProofOutput` containing:
 
 - `app_exe_commit: Commit` — commitment to the app executable whose execution is being verified
-- `app_vk_commit: Commit` — commitment to the app VM configuration
+- `app_vm_commit: Commit` — commitment to the app VM configuration
 - `user_public_values: Vec<u8>` — public values revealed by the verified app
 
 When correctly configured with the [`DeferredVerifyCircuit`](#circuit), verification is performed outside the VM circuit as part of the [deferral flow](/specs/architecture/deferral). From the guest perspective, this establishes that **there exists a proof** matching `input_commit` that verifies and yields the returned `ProofOutput`; the proof itself is never accessible from the guest program.
@@ -38,7 +38,7 @@ The circuit crate (`openvm-verify-stark-circuit`) provides the `DeferredVerifyCi
 
 1. Verifies the child STARK proof using the recursion verifier sub-circuit
 2. Constrains that the user public values are present in the final memory state
-3. Produces the output commitment containing `app_exe_commit`, `app_vk_commit`, and `user_public_values`
+3. Produces the output commitment containing `app_exe_commit`, `app_vm_commit`, and `user_public_values`
 
 There should be a unique `DeferredVerifyCircuit` for each STARK verifying key you want to support.
 

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -248,7 +248,7 @@ The root subcircuit exposes a new set of public values for the static verifier. 
   - The app-level `ProgramAir` cached trace commit
   - The Merkle root of the starting app memory state (`initial_root`)
   - The initial app program counter (`initial_pc`)
-- `app_vk_commit: Digest` — commitment to the app VM verifier key, computed by hashing the 6 components of the child proof's app, leaf, and internal-for-leaf DAG commits (`cached_commit` and `vk_pre_hash` for each) via `hash_slice`
+- `app_vm_commit: Digest` — commitment to the app VM verifier key, computed by hashing the 6 components of the child proof's app, leaf, and internal-for-leaf DAG commits (`cached_commit` and `vk_pre_hash` for each) via `hash_slice`
 
 #### Constraints
 
@@ -265,7 +265,7 @@ The root subcircuit also constrains its own public values:
     - Computing the Merkle root of `user_public_values`, denoted `user_pvs_commit`
     - Constraining that a Merkle proof (where the path to the root depends on the `MemoryDimensions`) exists between `user_pvs_commit` and `final_root`
 - `app_exe_commit` is computed as specified above
-- `app_vk_commit` is computed from the child proof's `app_dag_commit`, `leaf_dag_commit`, and `internal_for_leaf_dag_commit` (using all 6 `cached_commit` and `vk_pre_hash` components) as specified above
+- `app_vm_commit` is computed from the child proof's `app_dag_commit`, `leaf_dag_commit`, and `internal_for_leaf_dag_commit` (using all 6 `cached_commit` and `vk_pre_hash` components) as specified above
 
 ## Deferral Integration
 

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -30,7 +30,7 @@ A **circuit** is a set of AIRs that collectively constrain one or more trace mat
 A **prover** is a struct that generates a proof for a specific circuit given appropriate inputs. We distinguish:
 
 - **Basic provers** — generate a single aggregated `Proof` from child `Proof`s. Each basic prover corresponds to a specific aggregation subcircuit (see [Layer Architecture](#layer-architecture) for more information).
-- **SDK provers** — orchestrate basic provers to produce client-facing proof formats (`ContinuationVmProof`, `NonRootStarkProof`, `EvmProof`) or their intermediate forms.
+- **SDK provers** — orchestrate basic provers to produce client-facing proof formats (`ContinuationVmProof`, `VmStarkProof`, `EvmProof`) or their intermediate forms.
 
 ## Client-Facing Proofs
 
@@ -39,7 +39,7 @@ There are three **client-facing proof** types:
 | Type | Struct | Description |
 |------|--------|-------------|
 | App proof | `ContinuationVmProof` | Non-aggregated segment `Proof`s plus the user public values Merkle proof |
-| STARK proof | `NonRootStarkProof` | A single aggregated `Proof` plus the user public values Merkle proof |
+| STARK proof | `VmStarkProof` | A single aggregated `Proof` plus the user public values Merkle proof |
 | EVM proof | `EvmProof` | A single, constant-sized aggregated `Proof` formatted for verification by a fixed on-chain verifier |
 
 ### Aggregation Pipelines
@@ -69,15 +69,15 @@ For convenience the SDK provides several **SDK provers**, which orchestrate basi
 | Component SDK Prover | Aggregation Pipeline Section | Input | Output |
 |-------|-----------------|------------------|-------|
 | `AppProver` | app | Executable and `StdIn` input | `ContinuationVmProof` (i.e. app proof) |
-| `AggProver` | leaf → internal-for-leaf → internal-recursive (repeated at least until one `Proof` remains) | `ContinuationVmProof` | `NonRootStarkProof` (i.e. STARK proof) |
-| `RootProver` | root | `NonRootStarkProof` | `Proof` (EVM input) |
+| `AggProver` | leaf → internal-for-leaf → internal-recursive (repeated at least until one `Proof` remains) | `ContinuationVmProof` | `VmStarkProof` (i.e. STARK proof) |
+| `RootProver` | root | `VmStarkProof` | `Proof` (EVM input) |
 | `StaticProver` | static | `Proof` | `EvmProof` (EVM proof) |
 
 `StarkProver` and `EvmProver` use these component SDK provers to encapsulate end-to-end STARK and EVM proving.
 
 | E2E SDK Prover | Component Prover Pipeline | Input | Output |
 |-------|-----------------|-------|-------|
-| `StarkProver` | `AppProver` → `AggProver` | Executable and `StdIn` input | `NonRootStarkProof` |
+| `StarkProver` | `AppProver` → `AggProver` | Executable and `StdIn` input | `VmStarkProof` |
 | `EvmProver` | `AppProver` → `AggProver` → `RootProver` → `StaticProver` | Executable and `StdIn` input | `EvmProof` |
 
 ## Layer Architecture
@@ -191,7 +191,7 @@ Layers with a single child `Proof` practically only need to constrain 3.
 
 ### Inner Aggregation Subcircuit
 
-The inner subcircuit takes up to $N$ child `Proof`s and does **not** constrain the user public values' presence in memory. Its output `Proof` is meant to either be recursively aggregated or used as the `Proof` component in a `NonRootStarkProof`.
+The inner subcircuit takes up to $N$ child `Proof`s and does **not** constrain the user public values' presence in memory. Its output `Proof` is meant to either be recursively aggregated or used as the `Proof` component in a `VmStarkProof`.
 
 #### Public Values
 

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -130,7 +130,7 @@ Because of the dependency on `child_vk`, different layers have different verifie
 
 A verifier subcircuit must verify that a child proof satisfies the constraints defined by `child_vk`. These constraints are encoded as a **constraint DAG**, where each node represents a symbolic expression over trace values. This DAG includes interaction constraints.
 
-To avoid recomputing the DAG in-circuit, verifier subcircuits use a **cached trace**: before proving, the DAG is serialized per-node into a cached trace, committed via SWIRL's stacked PCS, and the commitment is exposed as a public value. Each such commitment is paired with the child VK's **field pre-hash** (`vk_pre_hash`) to form a **DAG commit** (`VkCommit`):
+To avoid recomputing the DAG in-circuit, verifier subcircuits use a **cached trace**: before proving, the DAG is serialized per-node into a cached trace, committed via SWIRL's stacked PCS, and the commitment is exposed as a public value. Each such commitment is paired with the child VK's **field pre-hash** (`vk_pre_hash`) to form a **VK commit** (`VkCommit`):
 
 ```
 VkCommit {
@@ -139,7 +139,7 @@ VkCommit {
 }
 ```
 
-The four DAG commits are:
+The four VK commits are:
 
 | Public Value | Commits to |
 |--------------|------------|
@@ -204,15 +204,15 @@ Public values are processed by `VerifierPvsAir`. The inner subcircuit re-exposes
       - `0` for leaf
       - `1` for internal-for-leaf
       - `2` for internal-recursive
-    - `app_vk_commit: VkCommit` — DAG commit (cached trace commit + VK pre-hash) for the leaf verifier subcircuit, derived from `app_vk`
-    - `leaf_vk_commit: VkCommit` — DAG commit for the internal-for-leaf verifier subcircuit, derived from `leaf_vk`
-    - `internal_for_leaf_vk_commit: VkCommit` — DAG commit for the first (index 0) internal-recursive layer verifier subcircuit, derived from `internal_for_leaf_vk`
+    - `app_vk_commit: VkCommit` — VK commit (cached trace commit + VK pre-hash) for the leaf verifier subcircuit, derived from `app_vk`
+    - `leaf_vk_commit: VkCommit` — VK commit for the internal-for-leaf verifier subcircuit, derived from `leaf_vk`
+    - `internal_for_leaf_vk_commit: VkCommit` — VK commit for the first (index 0) internal-recursive layer verifier subcircuit, derived from `internal_for_leaf_vk`
 - **Internal Recursion-Related Public Values**
     - `recursion_flag: F` — ternary flag indicating which internal-recursive layer this proof is for:
       - `0` for non-internal-recursive layers
       - `1` for the first (index 0) internal-recursive layer
       - `2` for subsequent internal-recursive layers
-    - `internal_recursive_vk_commit: VkCommit` — DAG commit for each subsequent (index > 0) internal-recursive layer verifier subcircuit, derived from `internal_recursive_vk`
+    - `internal_recursive_vk_commit: VkCommit` — VK commit for each subsequent (index > 0) internal-recursive layer verifier subcircuit, derived from `internal_recursive_vk`
 
 The `program_commit` should be set at every layer, but the flags and `*_vk_commits` should be set according to which layer we are currently proving for. Unset `*_vk_commits` are filled with 0s.
 
@@ -248,7 +248,7 @@ The root subcircuit exposes a new set of public values for the static verifier. 
   - The app-level `ProgramAir` cached trace commit
   - The Merkle root of the starting app memory state (`initial_root`)
   - The initial app program counter (`initial_pc`)
-- `app_vm_commit: Digest` — commitment to the app VM verifier key, computed by hashing the 6 components of the child proof's app, leaf, and internal-for-leaf DAG commits (`cached_commit` and `vk_pre_hash` for each) via `hash_slice`
+- `app_vm_commit: Digest` — commitment to the app VM verifier key, computed by hashing the 6 components of the child proof's app, leaf, and internal-for-leaf VK commits (`cached_commit` and `vk_pre_hash` for each) via `hash_slice`
 
 #### Constraints
 
@@ -273,14 +273,14 @@ When the VM uses the [deferral framework](/specs/architecture/deferral), deferra
 
 ### Deferral Aggregation Overview
 
-Each deferral circuit `C_i` produces its own proofs, which are aggregated through a **separate** per-circuit aggregation tree (leaf → internal-for-leaf → internal-recursive) using a deferral-specific inner aggregation subcircuit. This subcircuit builds Merkle trees of the input and output commits and propagates deferral DAG commits.
+Each deferral circuit `C_i` produces its own proofs, which are aggregated through a **separate** per-circuit aggregation tree (leaf → internal-for-leaf → internal-recursive) using a deferral-specific inner aggregation subcircuit. This subcircuit builds Merkle trees of the input and output commits and propagates deferral VK commits.
 
 The final internal-recursive proof for each `C_i` is then passed to a **deferral hook** layer, which:
 
 1. Verifies the child proof
 2. Converts the input and output commit Merkle roots into **onion hashes** (the hash-onion accumulators used by the VM)
 3. Exposes `initial_acc_hash` and `final_acc_hash` — the initial and final deferral accumulator values as memory subtree Merkle leaves
-4. Computes and exposes a `def_hook_commit` from the deferral circuit's DAG commits
+4. Computes and exposes a `def_hook_commit` from the deferral circuit's VK commits
 
 ### Combined VM-Deferral Tree
 
@@ -306,7 +306,7 @@ When multiple deferral hook proofs are combined, the inner subcircuit Merklizes 
 
 ### Root Verifier Deferral Constraints
 
-The inner aggregation subcircuit also computes and propagates a `def_hook_commit` — a commitment to the deferral hook verifying key, derived by hashing the DAG commit components of deferral-only child proofs. This is computed at the internal-for-leaf layer (when `internal_flag == 2`) and propagated unchanged through subsequent layers. The `def_hook_commit` ensures that the correct deferral circuits were used.
+The inner aggregation subcircuit also computes and propagates a `def_hook_commit` — a commitment to the deferral hook verifying key, derived by hashing the VK commit components of deferral-only child proofs. This is computed at the internal-for-leaf layer (when `internal_flag == 2`) and propagated unchanged through subsequent layers. The `def_hook_commit` ensures that the correct deferral circuits were used.
 
 When deferral is enabled, the root subcircuit additionally constrains:
 

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -280,7 +280,7 @@ The final internal-recursive proof for each `C_i` is then passed to a **deferral
 1. Verifies the child proof
 2. Converts the input and output commit Merkle roots into **onion hashes** (the hash-onion accumulators used by the VM)
 3. Exposes `initial_acc_hash` and `final_acc_hash` — the initial and final deferral accumulator values as memory subtree Merkle leaves
-4. Computes and exposes a `def_hook_vk_commit` from the deferral circuit's DAG commits
+4. Computes and exposes a `def_hook_commit` from the deferral circuit's DAG commits
 
 ### Combined VM-Deferral Tree
 
@@ -306,11 +306,11 @@ When multiple deferral hook proofs are combined, the inner subcircuit Merklizes 
 
 ### Root Verifier Deferral Constraints
 
-The inner aggregation subcircuit also computes and propagates a `def_hook_vk_commit` — a commitment to the deferral hook verifying key, derived by hashing the DAG commit components of deferral-only child proofs. This is computed at the internal-for-leaf layer (when `internal_flag == 2`) and propagated unchanged through subsequent layers. The `def_hook_vk_commit` ensures that the correct deferral circuits were used.
+The inner aggregation subcircuit also computes and propagates a `def_hook_commit` — a commitment to the deferral hook verifying key, derived by hashing the DAG commit components of deferral-only child proofs. This is computed at the internal-for-leaf layer (when `internal_flag == 2`) and propagated unchanged through subsequent layers. The `def_hook_commit` ensures that the correct deferral circuits were used.
 
 When deferral is enabled, the root subcircuit additionally constrains:
 
-- The child proof's `def_hook_vk_commit` matches a pre-generated constant
+- The child proof's `def_hook_commit` matches a pre-generated constant
 - The child proof's `initial_acc_hash` was present in the **initial** memory state at the deferral address space region
 - The child proof's `final_acc_hash` was present in the **final** memory state at the deferral address space region
 

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -130,10 +130,10 @@ Because of the dependency on `child_vk`, different layers have different verifie
 
 A verifier subcircuit must verify that a child proof satisfies the constraints defined by `child_vk`. These constraints are encoded as a **constraint DAG**, where each node represents a symbolic expression over trace values. This DAG includes interaction constraints.
 
-To avoid recomputing the DAG in-circuit, verifier subcircuits use a **cached trace**: before proving, the DAG is serialized per-node into a cached trace, committed via SWIRL's stacked PCS, and the commitment is exposed as a public value. Each such commitment is paired with the child VK's **field pre-hash** (`vk_pre_hash`) to form a **DAG commit** (`DagCommit`):
+To avoid recomputing the DAG in-circuit, verifier subcircuits use a **cached trace**: before proving, the DAG is serialized per-node into a cached trace, committed via SWIRL's stacked PCS, and the commitment is exposed as a public value. Each such commitment is paired with the child VK's **field pre-hash** (`vk_pre_hash`) to form a **DAG commit** (`VkCommit`):
 
 ```
-DagCommit {
+VkCommit {
     cached_commit: [F; DIGEST_SIZE],  // PCS commitment of the cached trace
     vk_pre_hash:   [F; DIGEST_SIZE],  // field pre-hash of the child MultiStarkVerifyingKey
 }
@@ -143,15 +143,15 @@ The four DAG commits are:
 
 | Public Value | Commits to |
 |--------------|------------|
-| `app_dag_commit` | `app_vk` constraint DAG + VK pre-hash |
-| `leaf_dag_commit` | `leaf_vk` constraint DAG + VK pre-hash |
-| `internal_for_leaf_dag_commit` | `internal_for_leaf_vk` constraint DAG + VK pre-hash |
-| `internal_recursive_dag_commit` | `internal_recursive_vk` constraint DAG + VK pre-hash |
+| `app_vk_commit` | `app_vk` constraint DAG + VK pre-hash |
+| `leaf_vk_commit` | `leaf_vk` constraint DAG + VK pre-hash |
+| `internal_for_leaf_vk_commit` | `internal_for_leaf_vk` constraint DAG + VK pre-hash |
+| `internal_recursive_vk_commit` | `internal_recursive_vk` constraint DAG + VK pre-hash |
 
-Each `*_dag_commit` is checked for consistency by the aggregation subcircuit and/or the final client-facing verifier. The `cached_commit` component is verified against the PCS commitment received from `ProofShapeModule` via the `CachedCommitBus`, while the `vk_pre_hash` component is verified via a separate `PreHashBus`.
+Each `*_vk_commit` is checked for consistency by the aggregation subcircuit and/or the final client-facing verifier. The `cached_commit` component is verified against the PCS commitment received from `ProofShapeModule` via the `CachedCommitBus`, while the `vk_pre_hash` component is verified via a separate `PreHashBus`.
 
 :::note
-System parameters and per-AIR `is_required` flags are not included in `*_dag_commit`; they are fixed by the parent circuit.
+System parameters and per-AIR `is_required` flags are not included in `*_vk_commit`; they are fixed by the parent circuit.
 :::
 
 | Subcircuit Layer | `child_vk` | Max child proofs |
@@ -204,17 +204,17 @@ Public values are processed by `VerifierPvsAir`. The inner subcircuit re-exposes
       - `0` for leaf
       - `1` for internal-for-leaf
       - `2` for internal-recursive
-    - `app_dag_commit: DagCommit` — DAG commit (cached trace commit + VK pre-hash) for the leaf verifier subcircuit, derived from `app_vk`
-    - `leaf_dag_commit: DagCommit` — DAG commit for the internal-for-leaf verifier subcircuit, derived from `leaf_vk`
-    - `internal_for_leaf_dag_commit: DagCommit` — DAG commit for the first (index 0) internal-recursive layer verifier subcircuit, derived from `internal_for_leaf_vk`
+    - `app_vk_commit: VkCommit` — DAG commit (cached trace commit + VK pre-hash) for the leaf verifier subcircuit, derived from `app_vk`
+    - `leaf_vk_commit: VkCommit` — DAG commit for the internal-for-leaf verifier subcircuit, derived from `leaf_vk`
+    - `internal_for_leaf_vk_commit: VkCommit` — DAG commit for the first (index 0) internal-recursive layer verifier subcircuit, derived from `internal_for_leaf_vk`
 - **Internal Recursion-Related Public Values**
     - `recursion_flag: F` — ternary flag indicating which internal-recursive layer this proof is for:
       - `0` for non-internal-recursive layers
       - `1` for the first (index 0) internal-recursive layer
       - `2` for subsequent internal-recursive layers
-    - `internal_recursive_dag_commit: DagCommit` — DAG commit for each subsequent (index > 0) internal-recursive layer verifier subcircuit, derived from `internal_recursive_vk`
+    - `internal_recursive_vk_commit: VkCommit` — DAG commit for each subsequent (index > 0) internal-recursive layer verifier subcircuit, derived from `internal_recursive_vk`
 
-The `program_commit` should be set at every layer, but the flags and `*_dag_commits` should be set according to which layer we are currently proving for. Unset `*_dag_commits` are filled with 0s.
+The `program_commit` should be set at every layer, but the flags and `*_vk_commits` should be set according to which layer we are currently proving for. Unset `*_vk_commits` are filled with 0s.
 
 | Layer | `internal_flag` | `recursion_flag` | `app` | `leaf` | `internal_for_leaf` | `internal_recursive` |
 |-------|-----------------|------------------|-------|--------|---------------------|----------------------|
@@ -232,8 +232,8 @@ The `program_commit` should be set at every layer, but the flags and `*_dag_comm
 - Child proof verifier-specific public values are set according to the table above
 - Output proof verifier-specific public values match the child proofs':
   - Flags are incremented properly
-  - The next unset `*_dag_commit` is set (if any remain unset)
-  - Previously defined `*_dag_commit`s match between child and output
+  - The next unset `*_vk_commit` is set (if any remain unset)
+  - Previously defined `*_vk_commit`s match between child and output
 
 ### Root Aggregation Subcircuit
 
@@ -256,8 +256,8 @@ The root subcircuit constrains the child proof's public values:
 
 - `is_terminate == 1` and `exit_code == ExitCode::Success` (successful app termination)
 - `internal_flag == 2` and `recursion_flag` is `1` or `2` (child is internal-recursive)
-- `SymbolicExpressionAir`'s cached commit equals `internal_recursive_dag_commit.cached_commit`
-- `internal_recursive_dag_commit` (both `cached_commit` and `vk_pre_hash`) matches a pre-generated constant
+- `SymbolicExpressionAir`'s cached commit equals `internal_recursive_vk_commit.cached_commit`
+- `internal_recursive_vk_commit` (both `cached_commit` and `vk_pre_hash`) matches a pre-generated constant
 
 The root subcircuit also constrains its own public values:
 
@@ -265,7 +265,7 @@ The root subcircuit also constrains its own public values:
     - Computing the Merkle root of `user_public_values`, denoted `user_pvs_commit`
     - Constraining that a Merkle proof (where the path to the root depends on the `MemoryDimensions`) exists between `user_pvs_commit` and `final_root`
 - `app_exe_commit` is computed as specified above
-- `app_vm_commit` is computed from the child proof's `app_dag_commit`, `leaf_dag_commit`, and `internal_for_leaf_dag_commit` (using all 6 `cached_commit` and `vk_pre_hash` components) as specified above
+- `app_vm_commit` is computed from the child proof's `app_vk_commit`, `leaf_vk_commit`, and `internal_for_leaf_vk_commit` (using all 6 `cached_commit` and `vk_pre_hash` components) as specified above
 
 ## Deferral Integration
 

--- a/docs/vocs/docs/pages/specs/architecture/deferral.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/deferral.mdx
@@ -117,7 +117,7 @@ Deferral circuits that are not used are still included in the Merklization of ac
 STARK proof verification is implemented using the deferral framework. See the [Verify STARK guest library](/book/guest-libraries/verify-stark) for usage details.
 
 - `Input_i`: `Proof`
-- `Output_i`: `(app_exe_commit, app_vk_commit, user_pvs)` tuple
+- `Output_i`: `(app_exe_commit, app_vm_commit, user_pvs)` tuple
 - `C_i`: a recursion circuit that exposes the compressed final transcript state as `input_i_commit` **and** constrains the listed public values against the `Proof`'s
 
 The compressed final transcript state serves as `input_i_commit` because it deterministically binds the entire proof — any change to the proof produces a different transcript, so committing to it is equivalent to committing to the `Proof`.

--- a/docs/vocs/docs/pages/specs/architecture/deferral.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/deferral.mdx
@@ -93,7 +93,7 @@ The proofs for each `C_i` are aggregated separately. The leaf, internal-for-leaf
 
 - Constrains the validity of each child proof
 - Exposes the Merkle hashes of the child proofs' input and output commits
-- Exposes the `def_dag_commit`, `leaf_dag_commit`, and `internal_for_leaf_dag_commit`
+- Exposes the `def_vk_commit`, `leaf_vk_commit`, and `internal_for_leaf_vk_commit`
 
 Note that because we are building a Merkle tree of input and output commits, tail proofs are combined with "non-present" proofs. The input and output commit of a non-present proof at a particular depth is the Merkle root of a zeroed tree of that depth.
 

--- a/docs/vocs/docs/pages/specs/architecture/deferral.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/deferral.mdx
@@ -10,7 +10,7 @@ Suppose we have a collection of standalone circuits `C_0, C_1, ..` each handling
 
 We model each `C_i` as a function `f_i: Input_i -> Output_i`, where `Input_i` and `Output_i` are types such that there exist hash functions `g_i: Input_i -> Digest` and `h_i: Output_i -> Digest`. Given a raw `input_i_raw: Input_i` and `output_i_raw: Output_i`, we call `g_i(input_i_raw)` and `h_i(output_i_raw)` the **input commit** and **output commit** respectively.
 
-We also define the **circuit commit** as the `def_vk_commit` [defined below](#aggregation-subcircuit-and-tree).
+We also define the **circuit commit** as the `def_circuit_commit` [defined below](#aggregation-subcircuit-and-tree).
 
 ### High Level Summary
 
@@ -24,7 +24,7 @@ We also define the **circuit commit** as the `def_vk_commit` [defined below](#ag
 
 During guest program execution, we maintain an `input_i_accumulator: Digest` and `output_i_accumulator: Digest` for each `C_i`. These accumulators are stored in order at the beginning of the **deferral address space** (address space `4`), meaning that the accumulators for some `C_i` will be stored starting at `[2 * i * DIGEST_SIZE]_4`.
 
-Each accumulator is a **hash onion**, i.e. the result of folding `π` (Poseidon2 compression) over the sequence of commits seen so far. `input_i_accumulator` and `output_i_accumulator` accumulate the input and output commits for calls to `C_i` specifically. `input_i_accumulator` will initially be the `def_vk_commit`, and `output_i_accumulator` all zero — this is required to [constrain that the correct deferral circuits were used](#aggregation-subcircuit-and-tree).
+Each accumulator is a **hash onion**, i.e. the result of folding `π` (Poseidon2 compression) over the sequence of commits seen so far. `input_i_accumulator` and `output_i_accumulator` accumulate the input and output commits for calls to `C_i` specifically. `input_i_accumulator` will initially be the `def_circuit_commit`, and `output_i_accumulator` all zero — this is required to [constrain that the correct deferral circuits were used](#aggregation-subcircuit-and-tree).
 
 ### New Opcodes
 
@@ -71,7 +71,7 @@ We provide the following guarantees on the opcodes defined above:
 
 ### Extension Chips and Constraints
 
-The deferral extension contains several executor and peripheral chips to constrain the opcode functions and contracts above. It is configured with a `Vec<DeferralFn>` defining the `f_i` functions and a `Vec<def_vk_commit>` for the circuit commits of each `C_i`.
+The deferral extension contains several executor and peripheral chips to constrain the opcode functions and contracts above. It is configured with a `Vec<DeferralFn>` defining the `f_i` functions and a `Vec<def_circuit_commit>` for the circuit commits of each `C_i`.
 
 :::info
 Because the deferral extension has a single opcode for all deferral operations, in practice the `h_i` hash function is the Poseidon2 sponge hash of `Output_i` represented as bytes.
@@ -101,7 +101,7 @@ The final internal-recursive layer is passed to a **deferral hook** layer, which
 
 - Constrains its validity
 - Reconciles the input and output Merkle hashes into the input and output **onion hashes**, which are exposed as public values
-- Exposes `initial_acc_hash = π(π(def_vk_commit, 0), π(0, 0))` and `final_acc_hash = π(π(input_onion, 0), π(output_onion, 0))`, where `def_vk_commit` is computed by combining the DAG commits above
+- Exposes `initial_acc_hash = π(π(def_circuit_commit, 0), π(0, 0))` and `final_acc_hash = π(π(input_onion, 0), π(output_onion, 0))`, where `def_circuit_commit` is computed by combining the DAG commits above
     - Note that `initial_acc_hash` and `final_acc_hash` are memory subtree Merkle leaves, with each leaf zero-padded before Merklization
 
 ![Deferral Aggregation Diagram](/deferral-aggregation-diagram.png)

--- a/docs/vocs/docs/pages/specs/architecture/deferral.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/deferral.mdx
@@ -101,7 +101,7 @@ The final internal-recursive layer is passed to a **deferral hook** layer, which
 
 - Constrains its validity
 - Reconciles the input and output Merkle hashes into the input and output **onion hashes**, which are exposed as public values
-- Exposes `initial_acc_hash = π(π(def_circuit_commit, 0), π(0, 0))` and `final_acc_hash = π(π(input_onion, 0), π(output_onion, 0))`, where `def_circuit_commit` is computed by combining the DAG commits above
+- Exposes `initial_acc_hash = π(π(def_circuit_commit, 0), π(0, 0))` and `final_acc_hash = π(π(input_onion, 0), π(output_onion, 0))`, where `def_circuit_commit` is computed by combining the vk commits above
     - Note that `initial_acc_hash` and `final_acc_hash` are memory subtree Merkle leaves, with each leaf zero-padded before Merklization
 
 ![Deferral Aggregation Diagram](/deferral-aggregation-diagram.png)

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -62,7 +62,7 @@ pub(crate) const OUTPUT_AIR_REL_IDX: usize = 3;
 pub struct DeferralExtension {
     #[serde(skip)]
     pub fns: Vec<Arc<DeferralFn>>,
-    pub def_vk_commits: Vec<[u8; COMMIT_NUM_BYTES]>,
+    pub def_circuit_commits: Vec<[u8; COMMIT_NUM_BYTES]>,
 }
 
 #[derive(Clone, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]

--- a/extensions/deferral/tests/src/lib.rs
+++ b/extensions/deferral/tests/src/lib.rs
@@ -92,7 +92,7 @@ mod tests {
                 .with_extension(Rv32MTranspilerExtension)
                 .with_extension(Rv32IoTranspilerExtension)
                 .with_extension(DeferralTranspilerExtension::new(
-                    config.deferral.def_vk_commits.clone(),
+                    config.deferral.def_circuit_commits.clone(),
                 )),
         )?;
         air_test_with_min_segments(Rv32DeferralBuilder, config, exe, streams, 1).unwrap();

--- a/extensions/deferral/transpiler/src/lib.rs
+++ b/extensions/deferral/transpiler/src/lib.rs
@@ -37,13 +37,15 @@ pub enum DeferralOpcode {
 
 #[derive(Default)]
 pub struct DeferralTranspilerExtension {
-    def_vk_commits: Vec<[u8; COMMIT_NUM_BYTES]>,
+    def_circuit_commits: Vec<[u8; COMMIT_NUM_BYTES]>,
 }
 
 impl DeferralTranspilerExtension {
-    pub fn new(def_vk_commits: Vec<[u8; COMMIT_NUM_BYTES]>) -> Self {
-        assert!(def_vk_commits.len() <= MAX_DEF_CIRCUITS as usize);
-        Self { def_vk_commits }
+    pub fn new(def_circuit_commits: Vec<[u8; COMMIT_NUM_BYTES]>) -> Self {
+        assert!(def_circuit_commits.len() <= MAX_DEF_CIRCUITS as usize);
+        Self {
+            def_circuit_commits,
+        }
     }
 }
 
@@ -107,9 +109,9 @@ impl<F: PrimeField32> TranspilerExtension<F> for DeferralTranspilerExtension {
         const COMMIT_SIZE: usize = COMMIT_NUM_BYTES / F_NUM_BYTES;
 
         // Each input_acc starts at cell 2 * def_idx * COMMIT_SIZE, and each output_acc
-        // immediately follows it. The initial input_acc must be the def_vk_commit, and
-        // the initial output_acc must be all 0 (i.e. untouched).
-        for (def_idx, commit) in self.def_vk_commits.iter().enumerate() {
+        // immediately follows it. The initial input_acc must be the def_circuit_commit,
+        // and the initial output_acc must be all 0 (i.e. untouched).
+        for (def_idx, commit) in self.def_circuit_commits.iter().enumerate() {
             let start_cell = 2 * def_idx * COMMIT_SIZE;
             let start_byte = start_cell * F_NUM_BYTES;
 

--- a/guest-libs/verify-stark/circuit/src/commit/air.rs
+++ b/guest-libs/verify-stark/circuit/src/commit/air.rs
@@ -89,7 +89,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * Send the left_child of each leaf node to output_values to be processed
          * elsewhere. Note that in this case, this AIR has no public values. Also,
-         * output_val_bus expects to receive the app_exe_commit and app_vk_commit
+         * output_val_bus expects to receive the app_exe_commit and app_vm_commit
          * at indices 0..OUTPUT_USER_PVS_START_IDX. Note a row is a leaf node if
          * its receive_type == 1.
          */

--- a/guest-libs/verify-stark/circuit/src/extension.rs
+++ b/guest-libs/verify-stark/circuit/src/extension.rs
@@ -39,7 +39,7 @@ pub fn verify_stark_deferral_fn(encoded_proof: &[u8]) -> OutputRaw {
 }
 
 fn output_raw_from_proof(proof: &NonRootStarkProof) -> OutputRaw {
-    // get (app_exe_commit, app_vk_commit, public values)
+    // get (app_exe_commit, app_vm_commit, public values)
     let (base_pvs_slice, _) = proof.inner.public_values[VERIFIER_PVS_AIR_ID]
         .as_slice()
         .split_at(VerifierBasePvs::<u8>::width());
@@ -52,12 +52,12 @@ fn output_raw_from_proof(proof: &NonRootStarkProof) -> OutputRaw {
         &vm_pvs.initial_root,
         vm_pvs.initial_pc,
     );
-    let app_vk_commit =
+    let app_vm_commit =
         poseidon2_hash_slice(&vk_commit_components(verifier_pvs).into_flattened()).0;
 
     let output_f = app_exe_commit
         .into_iter()
-        .chain(app_vk_commit)
+        .chain(app_vm_commit)
         .chain(proof.user_pvs_proof.public_values.iter().copied())
         .collect_vec();
     f_slice_to_bytes(&output_f)

--- a/guest-libs/verify-stark/circuit/src/extension.rs
+++ b/guest-libs/verify-stark/circuit/src/extension.rs
@@ -92,7 +92,7 @@ pub fn get_raw_deferral_results(
             let final_ts_state = *ts.into_log().perm_results().last().unwrap();
             let (left_ts, right_ts) = poseidon2_input_to_digests(final_ts_state);
             let ts_commit = poseidon2_compress_with_capacity(left_ts, right_ts).0;
-            let cached_commit = vk.baseline.internal_recursive_dag_commit.cached_commit;
+            let cached_commit = vk.baseline.internal_recursive_vk_commit.cached_commit;
             let input_commit =
                 poseidon2_hash_slice(&vec![ts_commit, cached_commit].into_flattened()).0;
 

--- a/guest-libs/verify-stark/circuit/src/extension.rs
+++ b/guest-libs/verify-stark/circuit/src/extension.rs
@@ -26,19 +26,19 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{
 use openvm_verify_stark_host::{
     pvs::{VerifierBasePvs, VmPvs, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID},
     verify_vm_stark_proof_pvs,
-    vk::NonRootStarkVerifyingKey,
-    NonRootStarkProof,
+    vk::VmStarkVerifyingKey,
+    VmStarkProof,
 };
 
 ///////////////////////////////////////////////////////////////////////////////
 /// DEFERRAL FN IMPLEMENTATION
 ///////////////////////////////////////////////////////////////////////////////
 pub fn verify_stark_deferral_fn(encoded_proof: &[u8]) -> OutputRaw {
-    let proof = NonRootStarkProof::decode_from_bytes(encoded_proof).unwrap();
+    let proof = VmStarkProof::decode_from_bytes(encoded_proof).unwrap();
     output_raw_from_proof(&proof)
 }
 
-fn output_raw_from_proof(proof: &NonRootStarkProof) -> OutputRaw {
+fn output_raw_from_proof(proof: &VmStarkProof) -> OutputRaw {
     // get (app_exe_commit, app_vm_commit, public values)
     let (base_pvs_slice, _) = proof.inner.public_values[VERIFIER_PVS_AIR_ID]
         .as_slice()
@@ -76,8 +76,8 @@ fn f_slice_to_bytes(slice: &[F]) -> Vec<u8> {
 /// DEFERRAL STATE GENERATION
 ///////////////////////////////////////////////////////////////////////////////
 pub fn get_raw_deferral_results(
-    vk: &NonRootStarkVerifyingKey,
-    proofs: &[NonRootStarkProof],
+    vk: &VmStarkVerifyingKey,
+    proofs: &[VmStarkProof],
 ) -> Result<Vec<RawDeferralResult>> {
     let config = SC::default_from_params(vk.mvk.inner.params.clone());
 
@@ -105,8 +105,8 @@ pub fn get_raw_deferral_results(
 }
 
 pub fn get_deferral_state(
-    vk: &NonRootStarkVerifyingKey,
-    proofs: &[NonRootStarkProof],
+    vk: &VmStarkVerifyingKey,
+    proofs: &[VmStarkProof],
     deferral_idx: u32,
 ) -> Result<DeferralState> {
     let raw_results = get_raw_deferral_results(vk, proofs)?;

--- a/guest-libs/verify-stark/circuit/src/lib.rs
+++ b/guest-libs/verify-stark/circuit/src/lib.rs
@@ -11,7 +11,7 @@ use openvm_continuations::{
         subair::{HashSliceSubAir, MerkleRootBus, MerkleTreeInternalBus},
         Circuit,
     },
-    CommitBytes, DagCommitBytes,
+    CommitBytes, VkCommitBytes,
 };
 use openvm_recursion_circuit::{prelude::F, system::AggregationSubCircuit};
 use openvm_stark_backend::{AirRef, StarkProtocolConfig};
@@ -42,7 +42,7 @@ mod tests;
 #[derive(derive_new::new, Clone)]
 pub struct DeferredVerifyCircuit<S: AggregationSubCircuit> {
     pub verifier_circuit: Arc<S>,
-    internal_recursive_dag_commit: DagCommitBytes,
+    internal_recursive_vk_commit: VkCommitBytes,
     def_hook_commit: Option<CommitBytes>,
     pub(crate) memory_dimensions: MemoryDimensions,
     pub(crate) num_user_pvs: usize,
@@ -79,7 +79,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             final_state_bus: bus_inventory.final_state_bus,
             def_acc_paths_bus,
             def_merkle_roots_bus: memory_merkle_roots_bus,
-            expected_internal_recursive_dag_commit: self.internal_recursive_dag_commit,
+            expected_internal_recursive_vk_commit: self.internal_recursive_vk_commit,
             expected_def_hook_commit: self.def_hook_commit,
         };
         let user_pvs_commit_air = UserPvsCommitValuesAir::new(

--- a/guest-libs/verify-stark/circuit/src/lib.rs
+++ b/guest-libs/verify-stark/circuit/src/lib.rs
@@ -43,7 +43,7 @@ mod tests;
 pub struct DeferredVerifyCircuit<S: AggregationSubCircuit> {
     pub verifier_circuit: Arc<S>,
     internal_recursive_dag_commit: DagCommitBytes,
-    def_hook_vk_commit: Option<CommitBytes>,
+    def_hook_commit: Option<CommitBytes>,
     pub(crate) memory_dimensions: MemoryDimensions,
     pub(crate) num_user_pvs: usize,
     pub(crate) def_idx: usize,
@@ -80,7 +80,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             def_acc_paths_bus,
             def_merkle_roots_bus: memory_merkle_roots_bus,
             expected_internal_recursive_dag_commit: self.internal_recursive_dag_commit,
-            expected_def_hook_vk_commit: self.def_hook_vk_commit,
+            expected_def_hook_commit: self.def_hook_commit,
         };
         let user_pvs_commit_air = UserPvsCommitValuesAir::new(
             bus_inventory.poseidon2_compress_bus,
@@ -104,7 +104,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             def_idx: self.def_idx,
         };
 
-        let acc_paths_air = self.def_hook_vk_commit.map(|_| {
+        let acc_paths_air = self.def_hook_commit.map(|_| {
             Arc::new(DeferralAccMerklePathsAir::new(
                 bus_inventory.poseidon2_compress_bus,
                 def_acc_paths_bus,

--- a/guest-libs/verify-stark/circuit/src/output/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/output/trace.rs
@@ -23,7 +23,7 @@ pub struct DeferralOutputCtx<PB: ProverBackend> {
 
 pub fn generate_proving_ctx(
     app_exe_commit: [F; DIGEST_SIZE],
-    app_vk_commit: [F; DIGEST_SIZE],
+    app_vm_commit: [F; DIGEST_SIZE],
     user_pvs: Vec<F>,
     def_idx: usize,
 ) -> DeferralOutputCtx<CpuBackend<BabyBearPoseidon2Config>> {
@@ -32,7 +32,7 @@ pub fn generate_proving_ctx(
     debug_assert!(user_pvs.len().is_multiple_of(VALS_IN_DIGEST));
 
     let mut input_val_rows = values_to_rows(&app_exe_commit);
-    input_val_rows.extend(values_to_rows(&app_vk_commit));
+    input_val_rows.extend(values_to_rows(&app_vm_commit));
     input_val_rows.extend(values_to_rows(&user_pvs));
 
     let num_rows = input_val_rows.len() + 1;

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -7,7 +7,7 @@ use openvm_circuit::system::memory::{
 use openvm_continuations::{
     circuit::{deferral::DeferralMerkleProofs, Circuit},
     prover::{debug_constraints, DeferralCircuitProver},
-    CommitBytes, DagCommitBytes, SC,
+    CommitBytes, VkCommitBytes, SC,
 };
 use openvm_cpu_backend::CpuBackend;
 #[cfg(feature = "cuda")]
@@ -132,7 +132,7 @@ impl<
             },
         );
         let engine = E::new(system_params);
-        let internal_recursive_dag_commit = DagCommitBytes {
+        let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
         };
@@ -140,7 +140,7 @@ impl<
         let def_hook_commit = def_hook_commit.map(Into::into);
         let circuit = Arc::new(DeferredVerifyCircuit::new(
             Arc::new(verifier_circuit),
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
             def_hook_commit,
             memory_dimensions,
             num_user_pvs,
@@ -182,7 +182,7 @@ impl<
             },
         );
         let def_hook_commit = def_hook_commit.map(Into::into);
-        let internal_recursive_dag_commit = DagCommitBytes {
+        let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
         };
@@ -192,7 +192,7 @@ impl<
         // or else the generated proof will be incorrect.
         let circuit = Arc::new(DeferredVerifyCircuit::new(
             Arc::new(verifier_circuit),
-            internal_recursive_dag_commit,
+            internal_recursive_vk_commit,
             def_hook_commit,
             memory_dimensions,
             num_user_pvs,

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -25,7 +25,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     BabyBearPoseidon2CpuEngine, Digest, DIGEST_SIZE, EF, F,
 };
-use openvm_verify_stark_host::NonRootStarkProof;
+use openvm_verify_stark_host::VmStarkProof;
 use p3_field::{Field, PrimeField32};
 use tracing::instrument;
 
@@ -263,9 +263,9 @@ where
     }
 
     fn prove(&self, input_bytes: &[u8]) -> Proof<SC> {
-        let non_root_proof = NonRootStarkProof::decode_from_bytes(input_bytes).unwrap();
+        let vm_proof = VmStarkProof::decode_from_bytes(input_bytes).unwrap();
         self.prover
-            .prove_no_def::<E>(non_root_proof.inner, &non_root_proof.user_pvs_proof)
+            .prove_no_def::<E>(vm_proof.inner, &vm_proof.user_pvs_proof)
             .expect("DeferredVerifyProver::prove_no_def failed")
     }
 

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -114,7 +114,7 @@ impl<
         system_params: SystemParams,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
-        def_hook_vk_commit: Option<PB::Commitment>,
+        def_hook_commit: Option<PB::Commitment>,
         def_idx: usize,
     ) -> Self
     where
@@ -137,11 +137,11 @@ impl<
             pre_hash: child_vk.pre_hash.into(),
         };
         let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
-        let def_hook_vk_commit = def_hook_vk_commit.map(Into::into);
+        let def_hook_commit = def_hook_commit.map(Into::into);
         let circuit = Arc::new(DeferredVerifyCircuit::new(
             Arc::new(verifier_circuit),
             internal_recursive_dag_commit,
-            def_hook_vk_commit,
+            def_hook_commit,
             memory_dimensions,
             num_user_pvs,
             def_idx,
@@ -150,7 +150,7 @@ impl<
         Self {
             pk: Arc::new(pk),
             vk: Arc::new(vk),
-            agg_node_tracegen: T::new(def_hook_vk_commit.is_some()),
+            agg_node_tracegen: T::new(def_hook_commit.is_some()),
             child_vk,
             child_vk_pcs_data,
             circuit,
@@ -164,7 +164,7 @@ impl<
         pk: Arc<MultiStarkProvingKey<SC>>,
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
-        def_hook_vk_commit: Option<PB::Commitment>,
+        def_hook_commit: Option<PB::Commitment>,
         def_idx: usize,
     ) -> Self
     where
@@ -181,7 +181,7 @@ impl<
                 has_cached: true,
             },
         );
-        let def_hook_vk_commit = def_hook_vk_commit.map(Into::into);
+        let def_hook_commit = def_hook_commit.map(Into::into);
         let internal_recursive_dag_commit = DagCommitBytes {
             cached_commit: internal_recursive_cached_commit,
             pre_hash: child_vk.pre_hash.into(),
@@ -193,7 +193,7 @@ impl<
         let circuit = Arc::new(DeferredVerifyCircuit::new(
             Arc::new(verifier_circuit),
             internal_recursive_dag_commit,
-            def_hook_vk_commit,
+            def_hook_commit,
             memory_dimensions,
             num_user_pvs,
             def_idx,
@@ -202,7 +202,7 @@ impl<
         Self {
             pk,
             vk,
-            agg_node_tracegen: T::new(def_hook_vk_commit.is_some()),
+            agg_node_tracegen: T::new(def_hook_commit.is_some()),
             child_vk,
             child_vk_pcs_data,
             circuit,

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -134,7 +134,7 @@ impl<
         let engine = E::new(system_params);
         let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
-            pre_hash: child_vk.pre_hash.into(),
+            vk_pre_hash: child_vk.pre_hash.into(),
         };
         let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
         let def_hook_commit = def_hook_commit.map(Into::into);
@@ -184,7 +184,7 @@ impl<
         let def_hook_commit = def_hook_commit.map(Into::into);
         let internal_recursive_vk_commit = VkCommitBytes {
             cached_commit: internal_recursive_cached_commit,
-            pre_hash: child_vk.pre_hash.into(),
+            vk_pre_hash: child_vk.pre_hash.into(),
         };
         let engine = E::new(pk.params.clone());
         let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);

--- a/guest-libs/verify-stark/circuit/src/tests.rs
+++ b/guest-libs/verify-stark/circuit/src/tests.rs
@@ -218,11 +218,11 @@ fn test_deferral_verify_prover(child_extra_recursive_layers: usize) -> Result<()
         &vm_pvs.initial_root,
         vm_pvs.initial_pc,
     );
-    let app_vk_commit =
+    let app_vm_commit =
         poseidon2_hash_slice(&vk_commit_components(verifier_pvs).into_flattened()).0;
     let expected_output_commit = crate::output::generate_proving_ctx(
         app_exe_commit,
-        app_vk_commit,
+        app_vm_commit,
         user_pvs_proof.public_values,
         0,
     )

--- a/guest-libs/verify-stark/circuit/src/tests.rs
+++ b/guest-libs/verify-stark/circuit/src/tests.rs
@@ -164,8 +164,8 @@ fn run_full_aggregation(
     ))
 }
 
-#[test_case(0 ; "internal_recursive_dag_commit not set")]
-#[test_case(1 ; "internal_recursive_dag_commit set")]
+#[test_case(0 ; "internal_recursive_vk_commit not set")]
+#[test_case(1 ; "internal_recursive_vk_commit set")]
 fn test_deferral_verify_prover(child_extra_recursive_layers: usize) -> Result<()> {
     setup_tracing_with_log_level(Level::INFO);
     let (

--- a/guest-libs/verify-stark/circuit/src/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/trace.rs
@@ -95,7 +95,7 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>> for DeferredVerifyTraceGenImpl {
             output_commit,
         } = super::output::generate_proving_ctx(
             verifier_pvs_record.app_exe_commit,
-            verifier_pvs_record.app_vk_commit,
+            verifier_pvs_record.app_vm_commit,
             user_pvs_proof.public_values.clone(),
             def_idx,
         );

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -213,7 +213,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             AB::F::ZERO,
             PreHashMessage::<AB::F> {
-                vk_pre_hash: self.expected_internal_recursive_vk_commit.pre_hash.into(),
+                vk_pre_hash: self
+                    .expected_internal_recursive_vk_commit
+                    .vk_pre_hash
+                    .into(),
             },
             AB::F::ONE,
         );

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -58,7 +58,7 @@ pub struct DeferredVerifyPvsCols<F> {
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
 
     pub app_exe_commit: [F; DIGEST_SIZE],
-    pub app_vk_commit: [F; DIGEST_SIZE],
+    pub app_vm_commit: [F; DIGEST_SIZE],
     pub final_transcript_state: [F; POSEIDON2_WIDTH],
 }
 
@@ -230,7 +230,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         /*
-         * We need to verify the commits to the app executable and vk. The app_vk_commit is
+         * We need to verify the commits to the app executable and vk. The app_vm_commit is
          * constrained to be hash_slice of the 6 vk_commit_components (cached_commit and
          * vk_pre_hash for each of the child's app, leaf, and internal-for-leaf DAG commits).
          */
@@ -246,7 +246,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                     .intermediate_vk_states
                     .map(|v| v.map(Into::into))
                     .as_slice(),
-                result: &local.app_vk_commit.map(Into::into),
+                result: &local.app_vm_commit.map(Into::into),
                 enabled: &AB::Expr::ONE,
             },
         );
@@ -320,7 +320,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * Finally, we constrain the public values of this AIR - input_commit should be the
          * compression of the final verifier sub-circuit transcript state, and output_commit
          * should be the Poseidon2 sponge hash of the byte representations of app_exe_commit,
-         * app_vk_commit, and the user public values. The latter is constrained by the
+         * app_vm_commit, and the user public values. The latter is constrained by the
          * DeferralOutputCommitAir, to which we need to send the app commits.
          */
         let &DeferralCircuitPvs::<_> {
@@ -359,7 +359,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             output_idx += 1;
         }
 
-        for vk_val in local.app_vk_commit.chunks_exact(VALS_IN_DIGEST) {
+        for vk_val in local.app_vm_commit.chunks_exact(VALS_IN_DIGEST) {
             self.output_val_bus.send(
                 builder,
                 OutputValMessage {

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -232,7 +232,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * We need to verify the commits to the app executable and vk. The app_vm_commit is
          * constrained to be hash_slice of the 6 vk_commit_components (cached_commit and
-         * vk_pre_hash for each of the child's app, leaf, and internal-for-leaf DAG commits).
+         * vk_pre_hash for each of the child's app, leaf, and internal-for-leaf vk commits).
          */
         let vk_commit_components: Vec<_> = vk_commit_components(&local.child_verifier_pvs)
             .into_iter()

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -13,10 +13,10 @@ use openvm_continuations::{
             NUM_DIGESTS_IN_VK_COMMIT,
         },
         subair::{HashSliceCtx, HashSliceSubAir},
-        utils::{assert_dag_commit_eq, assert_dag_commit_unset, vk_commit_components},
+        utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
     },
     utils::{digests_to_poseidon2_input, pad_slice_to_poseidon2_input},
-    CommitBytes, DagCommitBytes,
+    CommitBytes, VkCommitBytes,
 };
 use openvm_recursion_circuit::{
     bus::{
@@ -32,7 +32,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
-    DagCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
+    VkCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
     CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
@@ -76,7 +76,7 @@ pub struct DeferredVerifyPvsAir {
     pub def_acc_paths_bus: DeferralAccPathBus,
     pub def_merkle_roots_bus: DeferralMerkleRootsBus,
 
-    pub expected_internal_recursive_dag_commit: DagCommitBytes,
+    pub expected_internal_recursive_vk_commit: VkCommitBytes,
     pub expected_def_hook_commit: Option<CommitBytes>,
 }
 
@@ -180,7 +180,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * We also need to receive the cached commit from ProofShapeModule, which is either for
          * the internal-for-leaf (i.e. if recursion_flag == 1) or internal-recursive layer. In
-         * the former case we constrain child_pvs.internal_recursive_dag_commit to be unset (i.e.
+         * the former case we constrain child_pvs.internal_recursive_vk_commit to be unset (i.e.
          * all 0), and in the latter we constrain it to be equal to a pre-generated constant as
          * it should be the same regardless of app_vk (provided internal system params are the
          * same).
@@ -188,12 +188,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let cached_commit = from_fn(|i| {
             local
                 .child_verifier_pvs
-                .internal_for_leaf_dag_commit
+                .internal_for_leaf_vk_commit
                 .cached_commit[i]
                 * (AB::Expr::TWO - local.child_verifier_pvs.recursion_flag)
                 + local
                     .child_verifier_pvs
-                    .internal_recursive_dag_commit
+                    .internal_recursive_vk_commit
                     .cached_commit[i]
                     * (local.child_verifier_pvs.recursion_flag - AB::F::ONE)
         });
@@ -213,20 +213,20 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             AB::F::ZERO,
             PreHashMessage::<AB::F> {
-                vk_pre_hash: self.expected_internal_recursive_dag_commit.pre_hash.into(),
+                vk_pre_hash: self.expected_internal_recursive_vk_commit.pre_hash.into(),
             },
             AB::F::ONE,
         );
 
-        assert_dag_commit_unset(
+        assert_vk_commit_unset(
             &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::TWO),
-            local.child_verifier_pvs.internal_recursive_dag_commit,
+            local.child_verifier_pvs.internal_recursive_vk_commit,
         );
 
-        assert_dag_commit_eq(
+        assert_vk_commit_eq(
             &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::ONE),
-            local.child_verifier_pvs.internal_recursive_dag_commit,
-            DagCommit::<AB::Expr>::from(self.expected_internal_recursive_dag_commit),
+            local.child_verifier_pvs.internal_recursive_vk_commit,
+            VkCommit::<AB::Expr>::from(self.expected_internal_recursive_vk_commit),
         );
 
         /*

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -10,7 +10,7 @@ use openvm_continuations::{
                 DeferralAccPathBus, DeferralAccPathMessage, DeferralMerkleRootsBus,
                 DeferralMerkleRootsMessage, MemoryMerkleCommitBus, MemoryMerkleCommitMessage,
             },
-            NUM_DIGESTS_IN_VK_COMMIT,
+            NUM_DIGESTS_IN_VM_COMMIT,
         },
         subair::{HashSliceCtx, HashSliceSubAir},
         utils::{assert_vk_commit_eq, assert_vk_commit_unset, vk_commit_components},
@@ -55,7 +55,7 @@ pub struct DeferredVerifyPvsCols<F> {
     pub initial_pc_hash: [F; DIGEST_SIZE],
 
     pub intermediate_exe_commit: [F; DIGEST_SIZE],
-    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
+    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
 
     pub app_exe_commit: [F; DIGEST_SIZE],
     pub app_vm_commit: [F; DIGEST_SIZE],

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -77,13 +77,13 @@ pub struct DeferredVerifyPvsAir {
     pub def_merkle_roots_bus: DeferralMerkleRootsBus,
 
     pub expected_internal_recursive_dag_commit: DagCommitBytes,
-    pub expected_def_hook_vk_commit: Option<CommitBytes>,
+    pub expected_def_hook_commit: Option<CommitBytes>,
 }
 
 impl<F> BaseAir<F> for DeferredVerifyPvsAir {
     fn width(&self) -> usize {
         DeferredVerifyPvsCols::<u8>::width()
-            + if self.expected_def_hook_vk_commit.is_some() {
+            + if self.expected_def_hook_commit.is_some() {
                 RecursiveDeferredVerifyCols::<u8>::width()
             } else {
                 0
@@ -108,9 +108,9 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let (base_local, rec_local) = local.split_at(base_cols_width);
         let local: &DeferredVerifyPvsCols<AB::Var> = (*base_local).borrow();
 
-        if let Some(def_hook_vk_commit) = self.expected_def_hook_vk_commit {
+        if let Some(def_hook_commit) = self.expected_def_hook_commit {
             let rec: &RecursiveDeferredVerifyCols<AB::Var> = (*rec_local).borrow();
-            self.eval_deferrals(builder, local, rec, def_hook_vk_commit);
+            self.eval_deferrals(builder, local, rec, def_hook_commit);
         }
 
         /*
@@ -401,7 +401,7 @@ impl DeferredVerifyPvsAir {
         builder: &mut AB,
         base: &DeferredVerifyPvsCols<AB::Var>,
         rec: &RecursiveDeferredVerifyCols<AB::Var>,
-        expected_def_hook_vk_commit: CommitBytes,
+        expected_def_hook_commit: CommitBytes,
     ) where
         AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues,
     {
@@ -443,14 +443,14 @@ impl DeferredVerifyPvsAir {
 
         /*
          * The final internal-recursive proof's deferral_flag must be either 0 or 2, and
-         * in the latter case the def_hook_vk_commit must match the expected one.
+         * in the latter case the def_hook_commit must match the expected one.
          */
         builder
             .assert_zero(verifier_pvs.deferral_flag * (verifier_pvs.deferral_flag - AB::Expr::TWO));
         assert_array_eq::<_, _, AB::Expr, _>(
             &mut builder.when(verifier_pvs.deferral_flag),
-            verifier_pvs.def_hook_vk_commit,
-            expected_def_hook_vk_commit.into(),
+            verifier_pvs.def_hook_commit,
+            expected_def_hook_commit.into(),
         );
 
         /*

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -32,7 +32,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
-    VkCommit, DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
+    DeferralPvs, VerifierBasePvs, VerifierDefPvs, VkCommit, VmPvs, CONSTRAINT_EVAL_AIR_ID,
     CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};

--- a/guest-libs/verify-stark/circuit/src/verifier/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/trace.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, BorrowMut};
 use openvm_circuit::arch::POSEIDON2_WIDTH;
 use openvm_continuations::{
     circuit::{
-        deferral::DeferralCircuitPvs, root::NUM_DIGESTS_IN_VK_COMMIT, subair::hash_slice_trace,
+        deferral::DeferralCircuitPvs, root::NUM_DIGESTS_IN_VM_COMMIT, subair::hash_slice_trace,
         utils::vk_commit_components,
     },
     utils::{digests_to_poseidon2_input, pad_slice_to_poseidon2_input, poseidon2_input_to_digests},
@@ -30,7 +30,7 @@ pub struct DeferredVerifyPvsRecord<F> {
     pub initial_root_hash: [F; DIGEST_SIZE],
     pub initial_pc_hash: [F; DIGEST_SIZE],
     pub intermediate_exe_commit: [F; DIGEST_SIZE],
-    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
+    pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
     pub app_exe_commit: [F; DIGEST_SIZE],
     pub app_vm_commit: [F; DIGEST_SIZE],
 }

--- a/guest-libs/verify-stark/circuit/src/verifier/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/trace.rs
@@ -32,7 +32,7 @@ pub struct DeferredVerifyPvsRecord<F> {
     pub intermediate_exe_commit: [F; DIGEST_SIZE],
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VK_COMMIT - 1],
     pub app_exe_commit: [F; DIGEST_SIZE],
-    pub app_vk_commit: [F; DIGEST_SIZE],
+    pub app_vm_commit: [F; DIGEST_SIZE],
 }
 
 pub fn generate_record(
@@ -78,7 +78,7 @@ pub fn generate_record(
         initial_root_hash,
     ));
 
-    let (intermediate_vk_states_vec, app_vk_commit) = hash_slice_trace(
+    let (intermediate_vk_states_vec, app_vm_commit) = hash_slice_trace(
         &vk_commit_components(child_verifier_pvs),
         Some(&mut poseidon2_permute_inputs),
         Some(&mut poseidon2_compress_inputs),
@@ -100,7 +100,7 @@ pub fn generate_record(
             intermediate_exe_commit,
             intermediate_vk_states,
             app_exe_commit,
-            app_vk_commit,
+            app_vm_commit,
         },
         poseidon2_compress_inputs,
         poseidon2_permute_inputs,
@@ -136,7 +136,7 @@ pub fn generate_proving_ctx(
     cols.intermediate_exe_commit = record.intermediate_exe_commit;
     cols.intermediate_vk_states = record.intermediate_vk_states;
     cols.app_exe_commit = record.app_exe_commit;
-    cols.app_vk_commit = record.app_vk_commit;
+    cols.app_vm_commit = record.app_vm_commit;
     cols.final_transcript_state = final_transcript_state;
 
     if deferral_enabled {

--- a/guest-libs/verify-stark/guest/src/lib.rs
+++ b/guest-libs/verify-stark/guest/src/lib.rs
@@ -9,7 +9,7 @@ use openvm_deferral_guest::{deferred_compute, get_deferred_output, Commit, COMMI
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProofOutput {
     pub app_exe_commit: Commit,
-    pub app_vk_commit: Commit,
+    pub app_vm_commit: Commit,
     pub user_public_values: Vec<u8>,
 }
 
@@ -26,14 +26,14 @@ pub fn verify_stark_unchecked<const DEF_IDX: u16>(input_commit: &Commit) -> Proo
     get_deferred_output::<DEF_IDX>(&mut output_bytes, &output_key);
 
     let app_exe_commit = output_bytes[..COMMIT_NUM_BYTES].try_into().unwrap();
-    let app_vk_commit = output_bytes[COMMIT_NUM_BYTES..MIN_OUTPUT_BYTES]
+    let app_vm_commit = output_bytes[COMMIT_NUM_BYTES..MIN_OUTPUT_BYTES]
         .try_into()
         .unwrap();
     let user_public_values = output_bytes[MIN_OUTPUT_BYTES..].to_vec();
 
     ProofOutput {
         app_exe_commit,
-        app_vk_commit,
+        app_vm_commit,
         user_public_values,
     }
 }


### PR DESCRIPTION
Resolves INT-6073.

# PR: Naming cleanup across continuations, SDK, and CLI

Standardizes terminology across the continuations, SDK, CLI, verify, and guest-libs crates. 75 files changed.

## Commits

### `417ecae6c` — split app-dependent and independent fields in agg pk

Refactors `AggProvingKey` to separate app-dependent fields from app-independent ones.

### `c68abd659` — rename `app_vk_commit` to `app_vm_commit`

The hash over the full aggregation tree's `VkCommit`s was confusingly named `app_vk_commit` — it's not a single VK's commit, it's the tree-level identity for the app VM aggregation path. Renamed to `app_vm_commit` everywhere including the Solidity interface variable (`appVmCommit` was already correct), CLI print messages, and docs.

### `c2ed1f434` — rename `NonRootStark{Proof,VerifyingKey}` to `VmStark{Proof,VerifyingKey}`

`NonRootStarkProof` was a negative-definition name ("not root"). Renamed to `VmStarkProof` which says what it _is_. Also renamed `VersionedNonRootStarkProof` → `VersionedVmStarkProof` and `NonRootStarkVerifyingKey` → `VmStarkVerifyingKey`.

### `046d74722` — rename `def_vk_commit` to `def_circuit_commit`

The per-deferral-circuit commit (hash of a single deferral circuit's VK commits) was named `def_vk_commit`, which was ambiguous with the tree-level commit. Renamed to `def_circuit_commit` to clarify it's per-circuit. Also renamed:
- `def_vk_commits` → `def_circuit_commits` (the config/transpiler list)
- `DefVkCommitBus` → `DefCircuitCommitBus`
- `DefVkCommitMessage` → `DefCircuitCommitMessage`
- `def_vk_commit_from_verifier_pvs()` → `def_circuit_commit_from_verifier_pvs()`
- `vk_commit()` method on `SingleDefCircuitProver` → `circuit_commit()`

### `d193e40de` — rename `def_hook_vk_commit` to `def_hook_commit`

The tree-level commit for the deferral hook aggregation path had an unnecessary `_vk_` infix. Renamed to `def_hook_commit`. Also renamed `expected_def_vk_commit` → `expected_def_hook_commit` (the baseline's expected value of the above) and error variants `DefHookVkCommit{Mismatch,Set}` → `DefHookCommit{Mismatch,Set}`.

### `d5861b390` — rename `DagCommit` to `VkCommit`

The `(cached_commit, vk_pre_hash)` pair struct was called `DagCommit`, which was an implementation detail name (referring to the constraint DAG). Renamed to `VkCommit` since it's a commitment derived from a verifying key. Also renamed:
- `DagCommitBytes` → `VkCommitBytes`
- `DagCommitJson` → `VkCommitJson`
- All field names: `app_dag_commit` → `app_vk_commit`, `leaf_dag_commit` → `leaf_vk_commit`, `internal_for_leaf_dag_commit` → `internal_for_leaf_vk_commit`, `internal_recursive_dag_commit` → `internal_recursive_vk_commit`, `def_dag_commit` → `def_vk_commit`, `child_dag_commit` → `child_vk_commit`
- `get_dag_commit()` → `get_vk_commit()`

Note: `DagCommitSubAir` and related types in `crates/recursion/` are unchanged — those refer to a different concept (the constraint DAG evaluation circuit).

### `dbd04e2c5` — rename `NUM_DIGESTS_IN_VK_COMMIT` to `NUM_DIGESTS_IN_VM_COMMIT`

### `222ed34b8` — cleanup: error variants, comments, and docs

- Renamed 10 error variants from `*Dag*` to `*Vk*` (e.g., `AppDagCachedCommitMismatch` → `AppVkCachedCommitMismatch`)
- Renamed variable `when_dag_compare` → `when_vk_compare`
- Updated doc comments across `verify/`, `continuations/`, `guest-libs/`, and `docs/` to replace stale "DAG commit" references with "vk commit"
