### PR TITLE
docs: resolve further book docs findings

### DIFF
--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/algebra.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/algebra.mdx
@@ -115,9 +115,10 @@ To have the correct imports for the above example, add the following to the `Car
 
 ```toml
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.5.0" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.5.0", features = ["std"] }
 openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.5.0" }
-serde = { version = "1.0.216", default-features = false }
+serde = { version = "1.0.216" }
+num-bigint = { version = "0.4.6", features = ["serde"] }
 ```
 
 Here is the full `openvm.toml` to accompany the above example:

--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/elliptic-curve-cryptography.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/elliptic-curve-cryptography.mdx
@@ -21,7 +21,9 @@ Developers can enable arbitrary Weierstrass curves by configuring this extension
   - `x()`, `y()` are used to get the affine coordinates
   - `from_xy` is a constructor for the point, which checks if the point is either identity or on the affine curve.
   - The point supports elliptic curve operations through intrinsic functions `add_ne_nonidentity` and `double_nonidentity`.
-  - `decompress`: Sometimes an elliptic curve point is compressed and represented by its `x` coordinate and the odd/even parity of the `y` coordinate. `decompress` is used to decompress the point back to `(x, y)`.
+
+- `FromCompressed` trait:
+  `decompress`: Sometimes an elliptic curve point is compressed and represented by its `x` coordinate and the odd/even parity of the `y` coordinate. `decompress` is used to decompress the point back to `(x, y)`.
 
 - `msm`: for multi-scalar multiplication.
 

--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/elliptic-curve-cryptography.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/elliptic-curve-cryptography.mdx
@@ -23,7 +23,7 @@ Developers can enable arbitrary Weierstrass curves by configuring this extension
   - The point supports elliptic curve operations through intrinsic functions `add_ne_nonidentity` and `double_nonidentity`.
 
 - `FromCompressed` trait:
-  `decompress`: Sometimes an elliptic curve point is compressed and represented by its `x` coordinate and the odd/even parity of the `y` coordinate. `decompress` is used to decompress the point back to `(x, y)`.
+  - `decompress`: Sometimes an elliptic curve point is compressed and represented by its `x` coordinate and the odd/even parity of the `y` coordinate. `decompress` is used to decompress the point back to `(x, y)`.
 
 - `msm`: for multi-scalar multiplication.
 

--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/keccak.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/keccak.mdx
@@ -3,7 +3,7 @@
 The Keccak256 extension guest provides functions that are meant to be linked to other external libraries. The external libraries can use these functions as hooks for the Keccak-256 intrinsics. This is enabled only when the target is `zkvm`.
 
 We provide the following functions for the low-level Keccak sponge operations:
-- `native_xorin(buffer: *mut u8, input: *const u8, len: usize)`: XORs `len` input bytes into a state buffer in-place. `len` is constrained to be a positive multiple of 4 and at most 136.
+- `native_xorin(buffer: *mut u8, input: *const u8, len: usize)`: XORs `len` input bytes into a state buffer in-place. `len` is constrained in-circuit to be a positive multiple of 4 and at most 136.
 - `native_keccakf(buffer: *mut u8)`: Applies the keccak-f[1600] permutation in-place on a 200-byte state buffer.
 
 The `openvm-keccak256` guest library builds on these to provide `native_keccak256`, a C ABI function that implements the full Keccak-256 hash:

--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/overview.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/overview.mdx
@@ -1,6 +1,6 @@
 # Acceleration Using Pre-Built Extensions
 
-OpenVM ships with a set of pre-built extensions maintained by the OpenVM team. Below, we highlight six of these extensions designed to accelerate common arithmetic and cryptographic operations that are notoriously expensive to execute. Some of these extensions have corresponding guest libraries which provide convenient, high-level interfaces for your guest program to interact with the extension.
+OpenVM ships with a set of pre-built extensions maintained by the OpenVM team. Below, we highlight seven of these extensions designed to accelerate common arithmetic and cryptographic operations that are notoriously expensive to execute. Some of these extensions have corresponding guest libraries which provide convenient, high-level interfaces for your guest program to interact with the extension.
 
 - [`openvm-keccak-guest`](/book/acceleration-using-extensions/keccak) - Keccak256 hash function. See the [Keccak256 guest library](/book/guest-libraries/keccak256) for usage details.
 - [`openvm-sha2-guest`](/book/acceleration-using-extensions/sha-2) - SHA-2 family of hash functions. See the [SHA-2 guest library](/book/guest-libraries/sha2) for usage details.
@@ -46,7 +46,6 @@ range_tuple_checker_sizes = [256, 8192]
 [app_vm_config.keccak]
 
 [app_vm_config.sha2]
-[app_vm_config.native]
 
 [app_vm_config.bigint]
 range_tuple_checker_sizes = [256, 8192]

--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/overview.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/overview.mdx
@@ -1,6 +1,6 @@
 # Acceleration Using Pre-Built Extensions
 
-OpenVM ships with a set of pre-built extensions maintained by the OpenVM team. Below, we highlight seven of these extensions designed to accelerate common arithmetic and cryptographic operations that are notoriously expensive to execute. Some of these extensions have corresponding guest libraries which provide convenient, high-level interfaces for your guest program to interact with the extension.
+OpenVM ships with a set of pre-built extensions maintained by the OpenVM team. Below, we highlight some of these extensions designed to accelerate common arithmetic and cryptographic operations that are notoriously expensive to execute. Some of these extensions have corresponding guest libraries which provide convenient, high-level interfaces for your guest program to interact with the extension.
 
 - [`openvm-keccak-guest`](/book/acceleration-using-extensions/keccak) - Keccak256 hash function. See the [Keccak256 guest library](/book/guest-libraries/keccak256) for usage details.
 - [`openvm-sha2-guest`](/book/acceleration-using-extensions/sha-2) - SHA-2 family of hash functions. See the [SHA-2 guest library](/book/guest-libraries/sha2) for usage details.

--- a/docs/vocs/docs/pages/book/advanced-usage/recursive-verification.mdx
+++ b/docs/vocs/docs/pages/book/advanced-usage/recursive-verification.mdx
@@ -1,3 +1,3 @@
 # Recursive Verification
 
-OpenVM supports recursively verifying its own proofs using the [Verify STARK guest library](https://github.com/openvm-org/openvm/tree/main/guest-libs/verify_stark). See its [dedicated page](/book/guest-libraries/verify-stark) to learn more.
+OpenVM supports recursively verifying its own proofs using the [Verify STARK guest library](https://github.com/openvm-org/openvm/tree/main/guest-libs/verify-stark). See its [dedicated page](/book/guest-libraries/verify-stark) to learn more.

--- a/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
+++ b/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
@@ -76,10 +76,8 @@ A custom OpenVM configuration can also be specified in an `openvm.toml` file and
 <summary>To customize your `Sdk`, you may need additional dependencies. Click here to view.</summary>
 
 ```rust
-use openvm_sdk::{
-    config::{AggregationSystemParams, AppConfig, SdkVmConfig},
-    Sdk,
-};
+use openvm_sdk::{config::{AggregationSystemParams, AppConfig}, Sdk};
+use openvm_sdk_config::SdkVmConfig;
 use openvm_stark_sdk::config::{app_params_with_100_bits_security, MAX_APP_LOG_STACKED_HEIGHT};
 ```
 
@@ -122,7 +120,7 @@ To get the VM byte representation of a serializable struct `data` (i.e. for use 
 OpenVM supports generating three types of proofs. The sections below describe how to generate and verify each type of proof.
 
 - [App Proof](#app-proof): Generates STARK proof(s) of the guest program
-- [STARK Proof](#stark-proof): Generates a STARK proof that can be posted on-chain
+- [STARK Proof](#stark-proof): Generates a STARK proof that can be verified using [`openvm-verify-stark-host`](https://github.com/openvm-org/openvm/tree/main/crates/verify)
 - [EVM Proof](#evm-proof): Generates a halo2 proof that can be posted on-chain
 
 ## App Proof

--- a/docs/vocs/docs/pages/book/guest-libraries/keccak256.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/keccak256.mdx
@@ -30,7 +30,12 @@ To be able to import the `keccak256` function, add the following to your `Cargo.
 
 ```toml
 openvm-keccak256 = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.5.0" }
-hex = { version = "0.4.3" }
+```
+
+Alternatively, you can use [`tiny-keccak`](https://github.com/openvm-org/tiny-keccak) directly, as shown in the [example](https://github.com/openvm-org/openvm/blob/main/examples/keccak/src/main.rs). When compiled for the zkVM target, `tiny-keccak` automatically routes through the accelerated OpenVM Keccak256 extension; when running natively, it falls back to a pure software implementation. To use `tiny-keccak`, add the following to your `Cargo.toml`:
+
+```toml
+tiny-keccak = { git = "https://github.com/openvm-org/tiny-keccak", features = ["keccak"] }
 ```
 
 ### Config parameters

--- a/docs/vocs/docs/pages/book/guest-libraries/pairing.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/pairing.mdx
@@ -50,10 +50,13 @@ The multi-Miller loop can also be run separately by importing the `MultiMillerLo
 ```rust
 use openvm_pairing_guest::pairing::MultiMillerLoop;
 
-let f = Bls12_381::multi_miller_loop(
-    &[p0, p1],
-    &[q0, q1],
-);
+struct MillerLoopInput {
+    p: Vec<AffinePoint<Fp>>,   // G1 points
+    q: Vec<AffinePoint<Fp2>>,  // G2 points
+}
+
+let input: MillerLoopInput = /* ... */;
+let f = Bls12_381::multi_miller_loop(&input.p, &input.q);
 ```
 
 ## Running via CLI

--- a/docs/vocs/docs/pages/book/guest-libraries/sha2.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/sha2.mdx
@@ -21,8 +21,8 @@ The following example can be run as guest code or host code (i.e. run in the zkv
 To run with guest code, use `cargo openvm run`, and for host code use `cargo run`.
 The implementations for `Sha256`, `Sha512`, and `Sha384` fall back to using `sha2` when running as host code.
 ```rust
-[!include ~/snippets/examples/sha2/src/main.rs:imports]
-[!include ~/snippets/examples/sha2/src/main.rs:main]
+// [!include ~/snippets/examples/sha2/src/main.rs:imports]
+// [!include ~/snippets/examples/sha2/src/main.rs:main]
 ```
 
 To be able to import the `shaXXX` functions and run the example, add the following to your `Cargo.toml` file:
@@ -38,3 +38,4 @@ For the guest program to build successfully add the following to your `.toml` fi
 
 ```toml
 [app_vm_config.sha2]
+```

--- a/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/verify-stark.mdx
@@ -64,7 +64,7 @@ For example, to initialize the SDK with the `verify-stark` deferral circuit:
 let def_idx = 0;
 let deferred_verify_prover = DeferredVerifyCpuProver::new::<E>(
     ir_vk,
-    ir_pcs_data,
+    ir_pcs_data.commitment.into(),
     def_circuit_params,
     memory_dimensions,
     num_user_pvs,

--- a/docs/vocs/docs/pages/book/writing-apps/generating-proofs.mdx
+++ b/docs/vocs/docs/pages/book/writing-apps/generating-proofs.mdx
@@ -163,6 +163,10 @@ The `app` subcommand generates an application-level proof, the `stark` command g
 `cargo openvm prove` may execute your program several times during generation, so `print` statements may be outputted several times as well. For more information on why this is the case, see the spec on our [Distributed Proving Architecture](/specs/architecture/distributed-proving).
 :::
 
+:::info
+The `cargo openvm prove evm` subcommand requires the `evm-prove` cargo feature on `cargo-openvm`. This feature is enabled by default.
+:::
+
 :::warning
 The `stark` subcommand requires STARK aggregation key generation to have been run via
 `cargo openvm setup`, and the `evm` subcommand requires EVM key generation to have been run via

--- a/docs/vocs/docs/pages/book/writing-apps/verifying-proofs.mdx
+++ b/docs/vocs/docs/pages/book/writing-apps/verifying-proofs.mdx
@@ -50,6 +50,10 @@ baseline is written. To ensure the correct baseline is being verified, keep the 
 
 ## Verifying EVM Proofs
 
+:::info
+The `cargo openvm verify evm` subcommand requires the `evm-verify` cargo feature on `cargo-openvm`. This feature is enabled by default.
+:::
+
 To verify an EVM proof, you can run the following command or call the `IOpenVmHalo2Verifier.verify()` function in the [OpenVM Solidity SDK](/book/writing-apps/solidity-sdk).
 
 ```bash
@@ -72,7 +76,7 @@ The EVM proof is written as a JSON of the following format:
   "proof_data": {
     "accumulator": "..",
     "proof": ".."
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
Resolves INT-7326.

## Critical Fixes

### 2. sha2.mdx — Unclosed code fence + malformed includes
- Added closing ``` to the `[app_vm_config.sha2]` TOML block that was left open at end of file.
- Prefixed include directives with `//` to match the pattern used across all other docs (`// [!include ...]`).

### 3. recursive-verification.mdx — Broken GitHub URL
- Fixed link from `guest-libs/verify_stark` to `guest-libs/verify-stark` (underscore → hyphen).

### 4. overview.mdx — Non-existent `[app_vm_config.native]` config
- Removed `[app_vm_config.native]` from the template TOML since `SdkVmConfig` has no `native` field.

### 5. keccak256.mdx — Incorrect Cargo.toml example
- Removed the `hex` dependency, making the example strictly about OpenVM
- Added documentation about using `tiny-keccak` from the OpenVM fork as an alternative, which is what the actual example uses and automatically routes through the accelerated Keccak256 extension on zkVM.

### 6. elliptic-curve-cryptography.mdx — `decompress` misattributed
- Moved `decompress` out of the `WeierstrassPoint` trait description and into its own `FromCompressed` trait section.

### 7. algebra.mdx — Cargo.toml snippet errors
- Added `features = ["std"]` to the `openvm` dependency.
- Removed incorrect `default-features = false` from `serde`.
- Added missing `num-bigint` dependency.

### 8. sdk.mdx — STARK proof description
- Changed misleading "can be posted on-chain" to link to `openvm-verify-stark-host`, since STARK proofs are verified off-chain via Rust code; only EVM proofs go on-chain.

### 10. pairing.mdx — `MultiMillerLoop` snippet type error
- Replaced the incorrect `&[p0, p1]` / `&[q0, q1]` call with a struct-based example that makes the expected types (`&[AffinePoint<Fp>]` and `&[AffinePoint<Fp2>]`) clear.

### 11. verify-stark.mdx — `DeferredVerifyCpuProver::new` wrong parameter
- Changed `ir_pcs_data` to `ir_pcs_data.commitment.into()` to match the actual function signature.

## Warning Fixes

### overview.mdx — Says "six" extensions but lists seven
- Changed "six" to "seven" to match the actual number of extensions listed.

### sdk.mdx — `SdkVmConfig` import path wrong
- Changed `openvm_sdk::config::SdkVmConfig` to `openvm_sdk_config::SdkVmConfig`, since it lives in the `openvm_sdk_config` crate, not `openvm_sdk::config`.

### verifying-proofs.mdx — Trailing comma in JSON example
- Removed trailing comma after `"proof_data"` object, which made the example invalid JSON.

### generating-proofs.mdx / verifying-proofs.mdx — Missing feature gate docs for EVM commands
- Added info callouts noting that `cargo openvm prove evm` requires the `evm-prove` cargo feature and `cargo openvm verify evm` requires the `evm-verify` cargo feature on `cargo-openvm`.
