### PR TITLE
fix(v2-beta): assert that divisor is non-zero in static verifier

### DIFF
--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -245,10 +245,15 @@ impl BabyBearChip {
         mut b: BabyBearWire,
     ) -> BabyBearWire {
         let b_val = b.to_baby_bear();
-        let b_inv = b_val.try_inverse().unwrap();
+        let b_inv_val = b_val.try_inverse().unwrap();
+        // Constrain b is non-zero by checking b * b_inv == 1
+        let b_inv = self.load_witness(ctx, b_inv_val);
+        let one = self.load_constant(ctx, BabyBear::ONE);
+        let inv_prod = self.mul(ctx, b, b_inv);
+        self.assert_equal(ctx, inv_prod, one);
 
-        let mut c = self.load_witness(ctx, a.to_baby_bear() * b_inv);
-        // constraint a = b * c (mod p)
+        // Constrain a = b * c (mod p)
+        let mut c = self.load_witness(ctx, a.to_baby_bear() * b_inv_val);
         if a.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             a = self.reduce(ctx, a);
         }

--- a/crates/static-verifier/src/field/baby_bear/extension.rs
+++ b/crates/static-verifier/src/field/baby_bear/extension.rs
@@ -221,10 +221,15 @@ impl BabyBearExt4Chip {
         b: BabyBearExt4Wire,
     ) -> BabyBearExt4Wire {
         let b_val = b.to_extension_field();
-        let b_inv = b_val.try_inverse().unwrap();
+        let b_inv_val = b_val.try_inverse().unwrap();
+        // Constrain b is non-zero by checking b * b_inv == 1
+        let b_inv = self.load_witness(ctx, b_inv_val);
+        let one = self.load_constant(ctx, BinomialExtensionField::<BabyBear, 4>::ONE);
+        let inv_prod = self.mul(ctx, b, b_inv);
+        self.assert_equal(ctx, inv_prod, one);
 
-        let c = self.load_witness(ctx, a.to_extension_field() * b_inv);
-        // constraint a = b * c
+        // Constrain a = b * c (mod p)
+        let c = self.load_witness(ctx, a.to_extension_field() * b_inv_val);
         let prod = self.mul(ctx, b, c);
         self.assert_equal(ctx, a, prod);
 


### PR DESCRIPTION
## Summary

Constrain that the denominator is non-zero in `BabyBearChip::div` and `BabyBearExt4Chip::div` in the static verifier. Previously, the inverse of the denominator was computed as a witness but never constrained. Now both functions constrain `b * b_inv == 1` before proceeding with the division.