### PR TITLE
perf(cuda): reduce stack/regs/spills in `keccakf_op` and `sha2_main` tracegen

### DIFF
--- a/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
+++ b/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
@@ -49,35 +49,51 @@ __device__ __forceinline__ uint64_t rotl64(uint64_t x, int n) {
     return n ? ((x << n) | (x >> (64 - n))) : x;
 }
 
-// Compute keccak-f permutation on a 200-byte state
+// Compute keccak-f permutation on a 200-byte state.
+//
+// Uses in-place rho/pi via the 24-element permutation cycle and in-place chi
+// with two temporaries per row, so no scratch array is needed.
 __device__ __forceinline__ void keccakf_permutation(uint64_t state[25]) {
+    using keccak256::RHO_PI_CYCLE_IDX;
+    using keccak256::RHO_PI_CYCLE_ROT;
+
     for (int round = 0; round < 24; round++) {
-        // Theta
+        // Theta: C[x] = xor(A[x, 0..4])
         uint64_t c[5];
+#pragma unroll 5
         for (int x = 0; x < 5; x++) {
             c[x] = state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20];
         }
+        // A'[x, y] = A[x, y] ^ D[x] where D[x] = C[x-1] ^ ROTL(C[x+1], 1).
+        // Use a scalar `d` instead of materializing D[5].
         for (int x = 0; x < 5; x++) {
             uint64_t d = c[(x + 4) % 5] ^ rotl64(c[(x + 1) % 5], 1);
+#pragma unroll 5
             for (int y = 0; y < 5; y++) {
                 state[x + 5 * y] ^= d;
             }
         }
 
-        // Rho and Pi
-        uint64_t temp[25];
-        for (int y = 0; y < 5; y++) {
-            for (int x = 0; x < 5; x++) {
-                temp[y + 5 * ((2 * x + 3 * y) % 5)] = rotl64(state[x + 5 * y], R[x][y]);
-            }
+        // Rho/Pi in place via the 24-element permutation cycle (one temp).
+        uint64_t temp = rotl64(state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
+        // Prevent unrolling to avoid 23 simultaneous rotations in flight.
+#pragma unroll 1
+        for (int i = 0; i < 23; i++) {
+            state[RHO_PI_CYCLE_IDX[i]] =
+                rotl64(state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
         }
+        state[RHO_PI_CYCLE_IDX[23]] = temp;
 
-        // Chi
+        // Chi in place with 2 temps per row.
         for (int y = 0; y < 5; y++) {
-            for (int x = 0; x < 5; x++) {
-                state[x + 5 * y] =
-                    temp[x + 5 * y] ^ ((~temp[(x + 1) % 5 + 5 * y]) & temp[(x + 2) % 5 + 5 * y]);
-            }
+            uint64_t *row_state = &state[5 * y];
+            uint64_t t0 = row_state[0];
+            uint64_t t1 = row_state[1];
+            row_state[0] = t0 ^ ((~t1) & row_state[2]);
+            row_state[1] = t1 ^ ((~row_state[2]) & row_state[3]);
+            row_state[2] ^= (~row_state[3]) & row_state[4];
+            row_state[3] ^= (~row_state[4]) & t0;
+            row_state[4] ^= (~t0) & t1;
         }
 
         // Iota

--- a/extensions/keccak256/circuit/cuda/src/keccakf_op.cu
+++ b/extensions/keccak256/circuit/cuda/src/keccakf_op.cu
@@ -20,6 +20,81 @@ using namespace riscv;
 #define KECCAKF_OP_FILL_ZERO(FIELD) COL_FILL_ZERO(row, KeccakfOpCols, FIELD)
 #define KECCAKF_OP_SLICE(FIELD) row.slice_from(COL_INDEX(KeccakfOpCols, FIELD))
 
+// Fill the single trace row for one keccakf_op record.
+//
+// Marked __noinline__ so the large local working set (200 B keccak state union,
+// MemoryAuxColsFactory, BitwiseOperationLookup, plus per-call spills around
+// keccakf_permutation) lives in this helper's own stack frame instead of the
+// kernel's. The kernel itself only does the index/dummy-row plumbing.
+static __device__ __noinline__ void fill_keccakf_op_row(
+    RowSlice row,
+    KeccakfOpRecord const &rec,
+    uint32_t *d_range_checker_ptr,
+    uint32_t range_checker_num_bins,
+    uint32_t *d_bitwise_lookup_ptr,
+    size_t bitwise_num_bits,
+    uint32_t pointer_max_bits,
+    uint32_t timestamp_max_bits
+) {
+    MemoryAuxColsFactory mem_helper(
+        VariableRangeChecker(d_range_checker_ptr, range_checker_num_bins), timestamp_max_bits
+    );
+    BitwiseOperationLookup bitwise_lookup(d_bitwise_lookup_ptr, bitwise_num_bits);
+
+    // CUDA is little-endian, so the u64 word and byte representations below are the same memory
+    // layout.
+    union KeccakState {
+        uint64_t u64[25];
+        uint8_t bytes[KECCAK_WIDTH_BYTES];
+    };
+    // Compute postimage
+    KeccakState state;
+    memcpy(state.u64, rec.preimage_buffer_bytes, KECCAK_WIDTH_BYTES);
+    keccakf_permutation(state.u64);
+
+    KECCAKF_OP_WRITE(pc, rec.pc);
+    KECCAKF_OP_WRITE(is_valid, 1);
+    KECCAKF_OP_WRITE(timestamp, rec.timestamp);
+    KECCAKF_OP_WRITE(rd_ptr, rec.rd_ptr);
+
+    // Write buffer_ptr_limbs
+    uint8_t buffer_ptr_limbs[RV32_REGISTER_NUM_LIMBS];
+    buffer_ptr_limbs[0] = rec.buffer_ptr & 0xFF;
+    buffer_ptr_limbs[1] = (rec.buffer_ptr >> 8) & 0xFF;
+    buffer_ptr_limbs[2] = (rec.buffer_ptr >> 16) & 0xFF;
+    buffer_ptr_limbs[3] = (rec.buffer_ptr >> 24) & 0xFF;
+    KECCAKF_OP_WRITE_ARRAY(buffer_ptr_limbs, buffer_ptr_limbs);
+
+    // Write preimage buffer
+    KECCAKF_OP_WRITE_ARRAY(preimage, rec.preimage_buffer_bytes);
+    // Write postimage buffer
+    KECCAKF_OP_WRITE_ARRAY(postimage, state.bytes);
+
+    // Fill rd_aux - memory read for rd_ptr
+    uint32_t ts = rec.timestamp;
+    mem_helper.fill(KECCAKF_OP_SLICE(rd_aux.base), rec.rd_aux.prev_timestamp, ts);
+    ts++;
+
+    // Fill buffer_word_aux - memory writes for 50 words
+    for (uint32_t w = 0; w < KECCAK_WIDTH_WORDS; w++) {
+        mem_helper.fill(
+            KECCAKF_OP_SLICE(buffer_word_aux[w]), rec.buffer_word_aux[w].prev_timestamp, ts
+        );
+        ts++;
+    }
+
+    // Range check for buffer pointer (scaled MSB limb)
+    constexpr uint32_t RV32_TOTAL_BITS = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS;
+    uint32_t scaled_limb = (buffer_ptr_limbs[RV32_REGISTER_NUM_LIMBS - 1])
+                           << (RV32_TOTAL_BITS - pointer_max_bits);
+    bitwise_lookup.add_range(scaled_limb, scaled_limb);
+
+    // Range check for postimage bytes (pairs)
+    for (size_t i = 0; i < KECCAK_WIDTH_BYTES; i += 2) {
+        bitwise_lookup.add_range(state.bytes[i], state.bytes[i + 1]);
+    }
+}
+
 // Main kernel for KeccakfOpChip trace generation
 // Each thread processes one record (1 rows)
 __global__ void keccakf_op_tracegen(
@@ -46,72 +121,20 @@ __global__ void keccakf_op_tracegen(
 
     RowSlice row0(d_trace + row0_idx, height);
 
-    // Initialize both rows to zero
+    // Initialize the row to zero (also covers the dummy-row case below)
     row0.fill_zero(0, sizeof(KeccakfOpCols<uint8_t>));
 
     if (record_idx < num_records) {
-        auto const &rec = d_records[record_idx];
-
-        MemoryAuxColsFactory mem_helper(
-            VariableRangeChecker(d_range_checker_ptr, range_checker_num_bins), timestamp_max_bits
+        fill_keccakf_op_row(
+            row0,
+            d_records[record_idx],
+            d_range_checker_ptr,
+            range_checker_num_bins,
+            d_bitwise_lookup_ptr,
+            bitwise_num_bits,
+            pointer_max_bits,
+            timestamp_max_bits
         );
-        BitwiseOperationLookup bitwise_lookup(d_bitwise_lookup_ptr, bitwise_num_bits);
-
-        // CUDA is little-endian, so the u64 word and byte representations below are the same memory layout.
-        union KeccakState {
-            uint64_t u64[25];
-            uint8_t bytes[KECCAK_WIDTH_BYTES];
-        };
-        // Compute postimage
-        KeccakState state;
-        memcpy(state.u64, rec.preimage_buffer_bytes, KECCAK_WIDTH_BYTES);
-        keccakf_permutation(state.u64);
-
-        // =========== Row 0: is_valid = 1, preimage buffer ===========
-        {
-            RowSlice row = row0;
-            KECCAKF_OP_WRITE(pc, rec.pc);
-            KECCAKF_OP_WRITE(is_valid, 1);
-            KECCAKF_OP_WRITE(timestamp, rec.timestamp);
-            KECCAKF_OP_WRITE(rd_ptr, rec.rd_ptr);
-
-            // Write buffer_ptr_limbs
-            uint8_t buffer_ptr_limbs[RV32_REGISTER_NUM_LIMBS];
-            buffer_ptr_limbs[0] = rec.buffer_ptr & 0xFF;
-            buffer_ptr_limbs[1] = (rec.buffer_ptr >> 8) & 0xFF;
-            buffer_ptr_limbs[2] = (rec.buffer_ptr >> 16) & 0xFF;
-            buffer_ptr_limbs[3] = (rec.buffer_ptr >> 24) & 0xFF;
-            KECCAKF_OP_WRITE_ARRAY(buffer_ptr_limbs, buffer_ptr_limbs);
-
-            // Write preimage buffer
-            KECCAKF_OP_WRITE_ARRAY(preimage, rec.preimage_buffer_bytes);
-            // Write postimage buffer
-            KECCAKF_OP_WRITE_ARRAY(postimage, state.bytes);
-
-            // Fill rd_aux - memory read for rd_ptr
-            uint32_t ts = rec.timestamp;
-            mem_helper.fill(KECCAKF_OP_SLICE(rd_aux.base), rec.rd_aux.prev_timestamp, ts);
-            ts++;
-
-            // Fill buffer_word_aux - memory writes for 50 words
-            for (uint32_t w = 0; w < KECCAK_WIDTH_WORDS; w++) {
-                mem_helper.fill(
-                    KECCAKF_OP_SLICE(buffer_word_aux[w]), rec.buffer_word_aux[w].prev_timestamp, ts
-                );
-                ts++;
-            }
-
-            // Range check for buffer pointer (scaled MSB limb)
-            constexpr uint32_t RV32_TOTAL_BITS = RV32_CELL_BITS * RV32_REGISTER_NUM_LIMBS;
-            uint32_t scaled_limb = (buffer_ptr_limbs[RV32_REGISTER_NUM_LIMBS - 1])
-                                   << (RV32_TOTAL_BITS - pointer_max_bits);
-            bitwise_lookup.add_range(scaled_limb, scaled_limb);
-
-            // Range check for postimage bytes (pairs)
-            for (size_t i = 0; i < KECCAK_WIDTH_BYTES; i += 2) {
-                bitwise_lookup.add_range(state.bytes[i], state.bytes[i + 1]);
-            }
-        }
     }
     // Dummy rows are already zeroed
 }

--- a/extensions/sha2/circuit/cuda/src/sha2_main.cu
+++ b/extensions/sha2/circuit/cuda/src/sha2_main.cu
@@ -15,14 +15,16 @@
 using namespace riscv;
 using namespace sha2;
 
-// ===== MAIN CHIP KERNEL =====
+// Body shared by both the inlined (SHA-256) and outlined (SHA-512) paths.
+//
+// Marked `__forceinline__` so it always inlines into its caller; this lets us
+// share one definition while still controlling whether the work ends up in the
+// kernel's frame (SHA-256) or in a separate function frame (SHA-512).
 template <typename V>
-__global__ void sha2_main_tracegen(
-    Fp *trace,
-    size_t trace_height,
-    uint8_t *records,
-    size_t num_records,
-    size_t *record_offsets,
+static __device__ __forceinline__ void sha2_main_row_body(
+    RowSlice row,
+    uint32_t row_idx,
+    Sha2RecordMut<V> record,
     uint32_t ptr_max_bits,
     uint32_t *range_checker_ptr,
     uint32_t range_checker_num_bins,
@@ -30,19 +32,6 @@ __global__ void sha2_main_tracegen(
     uint32_t bitwise_num_bits,
     uint32_t timestamp_max_bits
 ) {
-    uint32_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (row_idx >= trace_height) {
-        return;
-    }
-
-    RowSlice row(trace + row_idx, trace_height);
-    row.fill_zero(0, sha2::Sha2MainLayout<V>::WIDTH);
-
-    if (row_idx >= num_records) {
-        return;
-    }
-
-    Sha2RecordMut<V> record(records + record_offsets[row_idx]);
     Sha2RecordHeader<V> *header = record.header;
 
     BitwiseOperationLookup bitwise_lookup(bitwise_lookup_ptr, bitwise_num_bits);
@@ -123,6 +112,93 @@ __global__ void sha2_main_tracegen(
         RowSlice base_slice = write_aux.slice_from(COL_INDEX(MemoryWriteAuxCols, base));
         mem_helper.fill(base_slice, record.write_aux[i].prev_timestamp, timestamp);
         timestamp += 1;
+    }
+}
+
+// __noinline__ wrapper used by the SHA-512 instantiation. SHA-512 has twice as
+// many memory aux iterations as SHA-256 (BLOCK_READS=32, STATE_READS=16,
+// STATE_WRITES=16), so outlining keeps the heavy working set in its own stack
+// frame rather than bloating the kernel's.
+template <typename V>
+static __device__ __noinline__ void sha2_main_row_outlined(
+    RowSlice row,
+    uint32_t row_idx,
+    Sha2RecordMut<V> record,
+    uint32_t ptr_max_bits,
+    uint32_t *range_checker_ptr,
+    uint32_t range_checker_num_bins,
+    uint32_t *bitwise_lookup_ptr,
+    uint32_t bitwise_num_bits,
+    uint32_t timestamp_max_bits
+) {
+    sha2_main_row_body<V>(
+        row,
+        row_idx,
+        record,
+        ptr_max_bits,
+        range_checker_ptr,
+        range_checker_num_bins,
+        bitwise_lookup_ptr,
+        bitwise_num_bits,
+        timestamp_max_bits
+    );
+}
+
+// ===== MAIN CHIP KERNEL =====
+template <typename V>
+__global__ void sha2_main_tracegen(
+    Fp *trace,
+    size_t trace_height,
+    uint8_t *records,
+    size_t num_records,
+    size_t *record_offsets,
+    uint32_t ptr_max_bits,
+    uint32_t *range_checker_ptr,
+    uint32_t range_checker_num_bins,
+    uint32_t *bitwise_lookup_ptr,
+    uint32_t bitwise_num_bits,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row_idx >= trace_height) {
+        return;
+    }
+
+    RowSlice row(trace + row_idx, trace_height);
+    row.fill_zero(0, sha2::Sha2MainLayout<V>::WIDTH);
+
+    if (row_idx >= num_records) {
+        return;
+    }
+
+    Sha2RecordMut<V> record(records + record_offsets[row_idx]);
+    // SHA-512 routes through the __noinline__ wrapper to keep the heavy
+    // working set out of the kernel's stack frame; SHA-256 inlines directly
+    // since it fits comfortably in registers.
+    if constexpr (V::WORD_BITS > 32) {
+        sha2_main_row_outlined<V>(
+            row,
+            row_idx,
+            record,
+            ptr_max_bits,
+            range_checker_ptr,
+            range_checker_num_bins,
+            bitwise_lookup_ptr,
+            bitwise_num_bits,
+            timestamp_max_bits
+        );
+    } else {
+        sha2_main_row_body<V>(
+            row,
+            row_idx,
+            record,
+            ptr_max_bits,
+            range_checker_ptr,
+            range_checker_num_bins,
+            bitwise_lookup_ptr,
+            bitwise_num_bits,
+            timestamp_max_bits
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Reduce CUDA stack usage, register pressure, and spills in `keccakf_op` and `sha2_main` trace generation kernels, inspired by #2524.

### keccakf_op_tracegen
- Rewrote `keccakf_permutation` to operate in-place: eliminated the 200 B `temp[25]` scratch array, walk the rho/pi 24-element cycle with a single saved temp, compute chi in-place with two temps per row, and use a scalar `d` in theta. Stays `__forceinline__` so the state never has to live in local memory.
- Moved the row-fill body into a `__noinline__` helper `fill_keccakf_op_row` so the heavy working set (200 B keccak state union, `MemoryAuxColsFactory`, `BitwiseOperationLookup`, the 50-iteration `mem_helper.fill` loop) lives in the helper's own frame instead of the kernel's.

### sha2_main_tracegen
- Factored the body into a shared `__forceinline__` template `sha2_main_row_body<V>` plus a thin `__noinline__` wrapper `sha2_main_row_outlined<V>`. Uses `if constexpr (V::WORD_BITS > 32)` to route SHA-512 through the outlined wrapper while keeping SHA-256 on the inlined path (SHA-256 was already tight at 16 B stack / 255 regs, and unconditional outlining would regress it).

### ptxas -v results (sm_89)

| Kernel | Before | After |
|---|---|---|
| `keccakf_op_tracegen` | 1656 B stack / 1268 spills / 255 regs | 16 B kernel + 368 B helper / 168 spills / 24 regs |
| `sha2_main_tracegen<512>` | 1256 B stack / 1260 spills / 255 regs | 64 B kernel + 144 B helper / 144 spills / 24 regs |
| `sha2_main_tracegen<256>` | 16 B / 16 spills / 255 regs | unchanged |

[Reth benchmark comparison](https://github.com/axiom-crypto/openvm-eth/actions/runs/24105029878)
