### PR TITLE
chore(k256): revert `sha256` -> `sha2` feature rename

### DIFF
--- a/guest-libs/k256/Cargo.toml
+++ b/guest-libs/k256/Cargo.toml
@@ -72,7 +72,7 @@ pkcs8 = ["ecdsa-core/pkcs8", "elliptic-curve/pkcs8"]
 precomputed-tables = ["arithmetic", "once_cell"]
 schnorr = ["arithmetic", "signature"]
 serde = ["ecdsa-core/serde", "elliptic-curve/serde"]
-sha2 = []
+sha256 = []
 test-vectors = []
 
 # Internal feature for testing only.

--- a/guest-libs/k256/src/ecdsa.rs
+++ b/guest-libs/k256/src/ecdsa.rs
@@ -3,7 +3,7 @@
 // Use these types instead of unpatched k256::ecdsa::{Signature, VerifyingKey}
 // because those are type aliases that use non-zkvm implementations
 
-#[cfg(any(feature = "ecdsa", feature = "sha2"))]
+#[cfg(any(feature = "ecdsa", feature = "sha256"))]
 pub use ecdsa_core::hazmat;
 pub use ecdsa_core::{
     signature::{self, Error},


### PR DESCRIPTION
This was done erroneously in the SHA2 refactor but the upstream feature is called sha256 so we shouldn't change it.