### PR TITLE
fix(v2-rc1): deduplicate keccakf round code in tracegen kernel

### DIFF
--- a/crates/circuits/primitives/cuda/include/primitives/utils.cuh
+++ b/crates/circuits/primitives/cuda/include/primitives/utils.cuh
@@ -31,9 +31,11 @@ template <typename T> __device__ __host__ __forceinline__ T next_multiple_of(T a
     return d_div_ceil(a, b) * b;
 }
 
-// UB-free 64-bit rotate left. (-(s)) & 63 equals (64 - s) % 64, so when
-// s == 0 the right shift is by 0 instead of by 64 (which would be UB).
-#define ROTL64(x, s) (((uint64_t)(x) << ((s) & 63)) | ((uint64_t)(x) >> ((-(s)) & 63)))
+// UB-free 64-bit rotate left. (-(n)) & 63 equals (64 - n) % 64, so when
+// n == 0 the right shift is by 0 instead of by 64 (which would be UB).
+__device__ __forceinline__ uint64_t rotl64(uint64_t x, int n) {
+    return (x << (n & 63)) | (x >> ((-n) & 63));
+}
 
 __device__ __host__ __forceinline__ uint32_t rotr(uint32_t value, int n) {
     return (value >> n) | (value << (32 - n));

--- a/crates/circuits/primitives/cuda/include/primitives/utils.cuh
+++ b/crates/circuits/primitives/cuda/include/primitives/utils.cuh
@@ -33,7 +33,7 @@ template <typename T> __device__ __host__ __forceinline__ T next_multiple_of(T a
 
 // UB-free 64-bit rotate left. (-(n)) & 63 equals (64 - n) % 64, so when
 // n == 0 the right shift is by 0 instead of by 64 (which would be UB).
-__device__ __host__ __forceinline__ uint64_t rotl64(uint64_t x, int n) {
+__device__ __host__ __forceinline__ uint64_t rotl64(uint64_t x, uint32_t n) {
     return (x << (n & 63)) | (x >> ((-n) & 63));
 }
 

--- a/crates/circuits/primitives/cuda/include/primitives/utils.cuh
+++ b/crates/circuits/primitives/cuda/include/primitives/utils.cuh
@@ -33,7 +33,7 @@ template <typename T> __device__ __host__ __forceinline__ T next_multiple_of(T a
 
 // UB-free 64-bit rotate left. (-(n)) & 63 equals (64 - n) % 64, so when
 // n == 0 the right shift is by 0 instead of by 64 (which would be UB).
-__device__ __forceinline__ uint64_t rotl64(uint64_t x, int n) {
+__device__ __host__ __forceinline__ uint64_t rotl64(uint64_t x, int n) {
     return (x << (n & 63)) | (x >> ((-n) & 63));
 }
 

--- a/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
+++ b/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
@@ -45,7 +45,7 @@ inline constexpr size_t NUM_KECCAKF_OP_COLS = sizeof(KeccakfOpCols<uint8_t>);
 // Delegates to the shared round body in keccak256::keccakf_round_body;
 // __forceinline__ so the full permutation folds into the caller's frame.
 __device__ __forceinline__ void keccakf_permutation(uint64_t state[25]) {
-    for (uint32_t round = 0; round < 24; round++) {
+    for (int round = 0; round < 24; round++) {
         keccak256::keccakf_round_body(state, round);
     }
 }

--- a/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
+++ b/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
@@ -41,63 +41,12 @@ template <typename T> struct KeccakfOpCols {
 
 inline constexpr size_t NUM_KECCAKF_OP_COLS = sizeof(KeccakfOpCols<uint8_t>);
 
-// Helper to rotate left a 64-bit value.
-// Guard: when n == 0, (x >> 64) is undefined behavior per C++ standard.
-// R[0][0] == 0 in the Keccak rho step, so this path is reachable.
-__device__ __forceinline__ uint64_t rotl64(uint64_t x, int n) {
-    n &= 63;
-    return n ? ((x << n) | (x >> (64 - n))) : x;
-}
-
 // Compute keccak-f permutation on a 200-byte state.
-//
-// Uses in-place rho/pi via the 24-element permutation cycle and in-place chi
-// with two temporaries per row, so no scratch array is needed.
+// Delegates to the shared round body in keccak256::keccakf_round_body;
+// __forceinline__ so the full permutation folds into the caller's frame.
 __device__ __forceinline__ void keccakf_permutation(uint64_t state[25]) {
-    using keccak256::RHO_PI_CYCLE_IDX;
-    using keccak256::RHO_PI_CYCLE_ROT;
-
     for (int round = 0; round < 24; round++) {
-        // Theta: C[x] = xor(A[x, 0..4])
-        uint64_t c[5];
-#pragma unroll 5
-        for (int x = 0; x < 5; x++) {
-            c[x] = state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20];
-        }
-        // A'[x, y] = A[x, y] ^ D[x] where D[x] = C[x-1] ^ ROTL(C[x+1], 1).
-        // Use a scalar `d` instead of materializing D[5].
-        for (int x = 0; x < 5; x++) {
-            uint64_t d = c[(x + 4) % 5] ^ rotl64(c[(x + 1) % 5], 1);
-#pragma unroll 5
-            for (int y = 0; y < 5; y++) {
-                state[x + 5 * y] ^= d;
-            }
-        }
-
-        // Rho/Pi in place via the 24-element permutation cycle (one temp).
-        uint64_t temp = rotl64(state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
-        // Prevent unrolling to avoid 23 simultaneous rotations in flight.
-#pragma unroll 1
-        for (int i = 0; i < 23; i++) {
-            state[RHO_PI_CYCLE_IDX[i]] =
-                rotl64(state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
-        }
-        state[RHO_PI_CYCLE_IDX[23]] = temp;
-
-        // Chi in place with 2 temps per row.
-        for (int y = 0; y < 5; y++) {
-            uint64_t *row_state = &state[5 * y];
-            uint64_t t0 = row_state[0];
-            uint64_t t1 = row_state[1];
-            row_state[0] = t0 ^ ((~t1) & row_state[2]);
-            row_state[1] = t1 ^ ((~row_state[2]) & row_state[3]);
-            row_state[2] ^= (~row_state[3]) & row_state[4];
-            row_state[3] ^= (~row_state[4]) & t0;
-            row_state[4] ^= (~t0) & t1;
-        }
-
-        // Iota
-        state[0] ^= RC[round];
+        keccak256::keccakf_round_body(state, round);
     }
 }
 

--- a/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
+++ b/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
@@ -45,7 +45,7 @@ inline constexpr size_t NUM_KECCAKF_OP_COLS = sizeof(KeccakfOpCols<uint8_t>);
 // Delegates to the shared round body in keccak256::keccakf_round_body;
 // __forceinline__ so the full permutation folds into the caller's frame.
 __device__ __forceinline__ void keccakf_permutation(uint64_t state[25]) {
-    for (int round = 0; round < 24; round++) {
+    for (uint32_t round = 0; round < 24; round++) {
         keccak256::keccakf_round_body(state, round);
     }
 }

--- a/extensions/keccak256/circuit/cuda/include/p3_keccakf.cuh
+++ b/extensions/keccak256/circuit/cuda/include/p3_keccakf.cuh
@@ -29,9 +29,9 @@ __device__ __constant__ inline uint64_t RC[NUM_ROUNDS] = {
 // In-place rho/pi permutation cycle (24 elements, flat index y*5+x).
 // Follows (x,y) -> (y, 2x+3y mod 5); (0,0) is a fixed point.
 // cycle[i] receives its value from cycle[(i+1) % 24] with the listed rotation.
-__device__ __constant__ inline int RHO_PI_CYCLE_IDX[24] = {1,  6,  9,  22, 14, 20, 2,  12,
-                                                           13, 19, 23, 15, 4,  24, 21, 8,
-                                                           16, 5,  3,  18, 17, 11, 7,  10};
+__device__ __constant__ inline uint32_t RHO_PI_CYCLE_IDX[24] = {1,  6,  9,  22, 14, 20, 2,  12,
+                                                                13, 19, 23, 15, 4,  24, 21, 8,
+                                                                16, 5,  3,  18, 17, 11, 7,  10};
 __device__ __constant__ inline uint8_t RHO_PI_CYCLE_ROT[24] = {44, 20, 61, 39, 18, 62, 43, 25,
                                                                8,  56, 41, 27, 14, 2,  55, 45,
                                                                36, 28, 21, 15, 10, 6,  3,  1};
@@ -39,18 +39,18 @@ __device__ __constant__ inline uint8_t RHO_PI_CYCLE_ROT[24] = {44, 20, 61, 39, 1
 // Single-round keccak-f body, operating on a flat 25-element state array.
 // Marked __forceinline__ so callers control whether the round gets its own
 // stack frame (__noinline__ wrapper) or folds into a multi-round loop.
-__device__ __forceinline__ void keccakf_round_body(uint64_t *state, int round) {
+__device__ __forceinline__ void keccakf_round_body(uint64_t *state, uint32_t round) {
     // Theta: C[x] = xor(A[x, 0..4])
     uint64_t c[5];
 #pragma unroll 5
-    for (int x = 0; x < 5; x++) {
+    for (uint32_t x = 0; x < 5; x++) {
         c[x] = state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20];
     }
     // A'[x, y] = A[x, y] ^ D[x] where D[x] = C[x-1] ^ ROTL(C[x+1], 1).
-    for (int x = 0; x < 5; x++) {
+    for (uint32_t x = 0; x < 5; x++) {
         uint64_t d = c[(x + 4) % 5] ^ rotl64(c[(x + 1) % 5], 1);
 #pragma unroll 5
-        for (int y = 0; y < 5; y++) {
+        for (uint32_t y = 0; y < 5; y++) {
             state[x + 5 * y] ^= d;
         }
     }
@@ -58,14 +58,14 @@ __device__ __forceinline__ void keccakf_round_body(uint64_t *state, int round) {
     // Rho/Pi in place via the 24-element permutation cycle (one temp).
     uint64_t temp = rotl64(state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
 #pragma unroll 1
-    for (int i = 0; i < 23; i++) {
+    for (uint32_t i = 0; i < 23; i++) {
         state[RHO_PI_CYCLE_IDX[i]] =
             rotl64(state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
     }
     state[RHO_PI_CYCLE_IDX[23]] = temp;
 
     // Chi in place with 2 temps per row.
-    for (int y = 0; y < 5; y++) {
+    for (uint32_t y = 0; y < 5; y++) {
         uint64_t *row_state = &state[5 * y];
         uint64_t t0 = row_state[0];
         uint64_t t1 = row_state[1];
@@ -150,7 +150,7 @@ static __device__ __noinline__ void generate_trace_row_for_round(
     // Populate C[x] = xor(A[x, 0], A[x, 1], A[x, 2], A[x, 3], A[x, 4]).
     uint64_t state_c[5];
 #pragma unroll 5
-    for (auto x = 0; x < 5; x++) {
+    for (uint32_t x = 0; x < 5; x++) {
         state_c[x] = current_state[0][x] ^ current_state[1][x] ^ current_state[2][x] ^
                      current_state[3][x] ^ current_state[4][x];
         COL_WRITE_BITS(row, KeccakCols, c[x], state_c[x]);
@@ -158,12 +158,12 @@ static __device__ __noinline__ void generate_trace_row_for_round(
 
     // Populate C'[x, z] and A'[x, y] using scalar d = C[x-1] ^ ROTL(C[x+1], 1).
     // Avoids materializing state_c_prime[5] array (~10 regs saved).
-    for (int x = 0; x < 5; x++) {
+    for (uint32_t x = 0; x < 5; x++) {
         uint64_t d = state_c[(x + 4) % 5] ^ rotl64(state_c[(x + 1) % 5], 1);
         COL_WRITE_BITS(row, KeccakCols, c_prime[x], state_c[x] ^ d);
 
 #pragma unroll 5
-        for (int y = 0; y < 5; y++) {
+        for (uint32_t y = 0; y < 5; y++) {
             current_state[y][x] ^= d;
             COL_WRITE_BITS(row, KeccakCols, a_prime[y][x], current_state[y][x]);
         }
@@ -175,14 +175,14 @@ static __device__ __noinline__ void generate_trace_row_for_round(
     uint64_t temp = rotl64(flat_state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
     // Prevent unrolling to avoid code bloat and register pressure from 23 simultaneous rotations.
 #pragma unroll 1
-    for (int i = 0; i < 23; i++) {
+    for (uint32_t i = 0; i < 23; i++) {
         flat_state[RHO_PI_CYCLE_IDX[i]] =
             rotl64(flat_state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
     }
     flat_state[RHO_PI_CYCLE_IDX[23]] = temp;
 
     // Populate A'' = B[x,y] ^ (~B[x+1,y] & B[x+2,y]), in-place chi with 2 temps per row.
-    for (int y = 0; y < 5; y++) {
+    for (uint32_t y = 0; y < 5; y++) {
         uint64_t t0 = current_state[y][0];
         uint64_t t1 = current_state[y][1];
         current_state[y][0] = t0 ^ ((~t1) & current_state[y][2]);

--- a/extensions/keccak256/circuit/cuda/include/p3_keccakf.cuh
+++ b/extensions/keccak256/circuit/cuda/include/p3_keccakf.cuh
@@ -36,6 +36,50 @@ __device__ __constant__ inline uint8_t RHO_PI_CYCLE_ROT[24] = {44, 20, 61, 39, 1
                                                                8,  56, 41, 27, 14, 2,  55, 45,
                                                                36, 28, 21, 15, 10, 6,  3,  1};
 
+// Single-round keccak-f body, operating on a flat 25-element state array.
+// Marked __forceinline__ so callers control whether the round gets its own
+// stack frame (__noinline__ wrapper) or folds into a multi-round loop.
+__device__ __forceinline__ void keccakf_round_body(uint64_t *state, int round) {
+    // Theta: C[x] = xor(A[x, 0..4])
+    uint64_t c[5];
+#pragma unroll 5
+    for (int x = 0; x < 5; x++) {
+        c[x] = state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20];
+    }
+    // A'[x, y] = A[x, y] ^ D[x] where D[x] = C[x-1] ^ ROTL(C[x+1], 1).
+    for (int x = 0; x < 5; x++) {
+        uint64_t d = c[(x + 4) % 5] ^ rotl64(c[(x + 1) % 5], 1);
+#pragma unroll 5
+        for (int y = 0; y < 5; y++) {
+            state[x + 5 * y] ^= d;
+        }
+    }
+
+    // Rho/Pi in place via the 24-element permutation cycle (one temp).
+    uint64_t temp = rotl64(state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
+#pragma unroll 1
+    for (int i = 0; i < 23; i++) {
+        state[RHO_PI_CYCLE_IDX[i]] =
+            rotl64(state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
+    }
+    state[RHO_PI_CYCLE_IDX[23]] = temp;
+
+    // Chi in place with 2 temps per row.
+    for (int y = 0; y < 5; y++) {
+        uint64_t *row_state = &state[5 * y];
+        uint64_t t0 = row_state[0];
+        uint64_t t1 = row_state[1];
+        row_state[0] = t0 ^ ((~t1) & row_state[2]);
+        row_state[1] = t1 ^ ((~row_state[2]) & row_state[3]);
+        row_state[2] ^= (~row_state[3]) & row_state[4];
+        row_state[3] ^= (~row_state[4]) & t0;
+        row_state[4] ^= (~t0) & t1;
+    }
+
+    // Iota
+    state[0] ^= RC[round];
+}
+
 } // namespace keccak256
 
 namespace p3_keccak_air {
@@ -84,50 +128,13 @@ inline constexpr size_t NUM_KECCAK_COLS = sizeof(KeccakCols<uint8_t>);
 
 // Apply one keccak-f round in-place without trace writes.
 // Used by phase 1 to advance state between rounds.
+// Thin __noinline__ wrapper around the shared round body so each round gets
+// its own stack frame (keeps register pressure manageable in the caller's loop).
 static __device__ __noinline__ void apply_round_in_place(
     uint32_t round,
     uint64_t current_state[5][5]
 ) {
-    // Theta: C[x] = xor(A[x, 0], A[x, 1], A[x, 2], A[x, 3], A[x, 4])
-    uint64_t state_c[5];
-#pragma unroll 5
-    for (auto x = 0; x < 5; x++) {
-        state_c[x] = current_state[0][x] ^ current_state[1][x] ^ current_state[2][x] ^
-                     current_state[3][x] ^ current_state[4][x];
-    }
-
-    // Theta: A'[x, y] = A[x, y] ^ D[x], where D[x] = C[x-1] ^ ROT(C[x+1], 1)
-    for (int x = 0; x < 5; x++) {
-        uint64_t d = state_c[(x + 4) % 5] ^ ROTL64(state_c[(x + 1) % 5], 1);
-#pragma unroll 5
-        for (int y = 0; y < 5; y++) {
-            current_state[y][x] ^= d;
-        }
-    }
-
-    // Rho/Pi: B[x, y] = ROT(A'[x, y], R[x][y]) via 24-element permutation cycle
-    uint64_t *flat_state = &current_state[0][0];
-    uint64_t temp = ROTL64(flat_state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
-#pragma unroll 1
-    for (int i = 0; i < 23; i++) {
-        flat_state[RHO_PI_CYCLE_IDX[i]] =
-            ROTL64(flat_state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
-    }
-    flat_state[RHO_PI_CYCLE_IDX[23]] = temp;
-
-    // Chi: A''[x, y] = B[x, y] ^ (~B[x+1, y] & B[x+2, y]), in-place with 2 temps per row
-    for (int y = 0; y < 5; y++) {
-        uint64_t t0 = current_state[y][0];
-        uint64_t t1 = current_state[y][1];
-        current_state[y][0] = t0 ^ ((~t1) & current_state[y][2]);
-        current_state[y][1] = t1 ^ ((~current_state[y][2]) & current_state[y][3]);
-        current_state[y][2] ^= (~current_state[y][3]) & current_state[y][4];
-        current_state[y][3] ^= (~current_state[y][4]) & t0;
-        current_state[y][4] ^= (~t0) & t1;
-    }
-
-    // Iota: A'''[0, 0] = A''[0, 0] ^ RC[round]
-    current_state[0][0] ^= RC[round];
+    keccak256::keccakf_round_body(&current_state[0][0], round);
 }
 
 // tracegen matching plonky3
@@ -152,7 +159,7 @@ static __device__ __noinline__ void generate_trace_row_for_round(
     // Populate C'[x, z] and A'[x, y] using scalar d = C[x-1] ^ ROTL(C[x+1], 1).
     // Avoids materializing state_c_prime[5] array (~10 regs saved).
     for (int x = 0; x < 5; x++) {
-        uint64_t d = state_c[(x + 4) % 5] ^ ROTL64(state_c[(x + 1) % 5], 1);
+        uint64_t d = state_c[(x + 4) % 5] ^ rotl64(state_c[(x + 1) % 5], 1);
         COL_WRITE_BITS(row, KeccakCols, c_prime[x], state_c[x] ^ d);
 
 #pragma unroll 5
@@ -165,12 +172,12 @@ static __device__ __noinline__ void generate_trace_row_for_round(
     // In-place rho/pi using the 24-element permutation cycle.
     // Avoids allocating state_b[5][5] (~50 regs saved).
     uint64_t *flat_state = &current_state[0][0];
-    uint64_t temp = ROTL64(flat_state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
+    uint64_t temp = rotl64(flat_state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
     // Prevent unrolling to avoid code bloat and register pressure from 23 simultaneous rotations.
 #pragma unroll 1
     for (int i = 0; i < 23; i++) {
         flat_state[RHO_PI_CYCLE_IDX[i]] =
-            ROTL64(flat_state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
+            rotl64(flat_state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
     }
     flat_state[RHO_PI_CYCLE_IDX[23]] = temp;
 

--- a/extensions/keccak256/circuit/cuda/include/p3_keccakf.cuh
+++ b/extensions/keccak256/circuit/cuda/include/p3_keccakf.cuh
@@ -43,14 +43,14 @@ __device__ __forceinline__ void keccakf_round_body(uint64_t *state, uint32_t rou
     // Theta: C[x] = xor(A[x, 0..4])
     uint64_t c[5];
 #pragma unroll 5
-    for (uint32_t x = 0; x < 5; x++) {
+    for (int x = 0; x < 5; x++) {
         c[x] = state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20];
     }
     // A'[x, y] = A[x, y] ^ D[x] where D[x] = C[x-1] ^ ROTL(C[x+1], 1).
-    for (uint32_t x = 0; x < 5; x++) {
+    for (int x = 0; x < 5; x++) {
         uint64_t d = c[(x + 4) % 5] ^ rotl64(c[(x + 1) % 5], 1);
 #pragma unroll 5
-        for (uint32_t y = 0; y < 5; y++) {
+        for (int y = 0; y < 5; y++) {
             state[x + 5 * y] ^= d;
         }
     }
@@ -58,14 +58,14 @@ __device__ __forceinline__ void keccakf_round_body(uint64_t *state, uint32_t rou
     // Rho/Pi in place via the 24-element permutation cycle (one temp).
     uint64_t temp = rotl64(state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
 #pragma unroll 1
-    for (uint32_t i = 0; i < 23; i++) {
+    for (int i = 0; i < 23; i++) {
         state[RHO_PI_CYCLE_IDX[i]] =
             rotl64(state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
     }
     state[RHO_PI_CYCLE_IDX[23]] = temp;
 
     // Chi in place with 2 temps per row.
-    for (uint32_t y = 0; y < 5; y++) {
+    for (int y = 0; y < 5; y++) {
         uint64_t *row_state = &state[5 * y];
         uint64_t t0 = row_state[0];
         uint64_t t1 = row_state[1];
@@ -150,7 +150,7 @@ static __device__ __noinline__ void generate_trace_row_for_round(
     // Populate C[x] = xor(A[x, 0], A[x, 1], A[x, 2], A[x, 3], A[x, 4]).
     uint64_t state_c[5];
 #pragma unroll 5
-    for (uint32_t x = 0; x < 5; x++) {
+    for (auto x = 0; x < 5; x++) {
         state_c[x] = current_state[0][x] ^ current_state[1][x] ^ current_state[2][x] ^
                      current_state[3][x] ^ current_state[4][x];
         COL_WRITE_BITS(row, KeccakCols, c[x], state_c[x]);
@@ -158,12 +158,12 @@ static __device__ __noinline__ void generate_trace_row_for_round(
 
     // Populate C'[x, z] and A'[x, y] using scalar d = C[x-1] ^ ROTL(C[x+1], 1).
     // Avoids materializing state_c_prime[5] array (~10 regs saved).
-    for (uint32_t x = 0; x < 5; x++) {
+    for (int x = 0; x < 5; x++) {
         uint64_t d = state_c[(x + 4) % 5] ^ rotl64(state_c[(x + 1) % 5], 1);
         COL_WRITE_BITS(row, KeccakCols, c_prime[x], state_c[x] ^ d);
 
 #pragma unroll 5
-        for (uint32_t y = 0; y < 5; y++) {
+        for (int y = 0; y < 5; y++) {
             current_state[y][x] ^= d;
             COL_WRITE_BITS(row, KeccakCols, a_prime[y][x], current_state[y][x]);
         }
@@ -175,14 +175,14 @@ static __device__ __noinline__ void generate_trace_row_for_round(
     uint64_t temp = rotl64(flat_state[RHO_PI_CYCLE_IDX[0]], RHO_PI_CYCLE_ROT[23]);
     // Prevent unrolling to avoid code bloat and register pressure from 23 simultaneous rotations.
 #pragma unroll 1
-    for (uint32_t i = 0; i < 23; i++) {
+    for (int i = 0; i < 23; i++) {
         flat_state[RHO_PI_CYCLE_IDX[i]] =
             rotl64(flat_state[RHO_PI_CYCLE_IDX[i + 1]], RHO_PI_CYCLE_ROT[i]);
     }
     flat_state[RHO_PI_CYCLE_IDX[23]] = temp;
 
     // Populate A'' = B[x,y] ^ (~B[x+1,y] & B[x+2,y]), in-place chi with 2 temps per row.
-    for (uint32_t y = 0; y < 5; y++) {
+    for (int y = 0; y < 5; y++) {
         uint64_t t0 = current_state[y][0];
         uint64_t t1 = current_state[y][1];
         current_state[y][0] = t0 ^ ((~t1) & current_state[y][2]);

--- a/extensions/keccak256/circuit/cuda/src/keccakf_perm.cu
+++ b/extensions/keccak256/circuit/cuda/src/keccakf_perm.cu
@@ -56,12 +56,12 @@ __global__ void keccakf_perm_phase1(
         // generate_trace_row_for_round expects current_state[y][x] = A[x][y] (keccak notation)
         // In keccak buffer: A[x][y] is stored at offset (x + 5*y)
         // So current_state[y][x] should get keccak_buffer[x + 5*y]
-        for (uint32_t x = 0; x < 5; x++) {
-            for (uint32_t y = 0; y < 5; y++) {
+        for (int x = 0; x < 5; x++) {
+            for (int y = 0; y < 5; y++) {
                 // keccak spec: A[x][y] is at byte offset (x + 5*y) * 8
-                uint32_t keccak_offset = x + 5 * y;
+                int keccak_offset = x + 5 * y;
                 uint64_t val = 0;
-                for (uint32_t j = 0; j < 8; j++) {
+                for (int j = 0; j < 8; j++) {
                     val |= static_cast<uint64_t>(rec.preimage_buffer_bytes[keccak_offset * 8 + j])
                            << (j * 8);
                 }

--- a/extensions/keccak256/circuit/cuda/src/keccakf_perm.cu
+++ b/extensions/keccak256/circuit/cuda/src/keccakf_perm.cu
@@ -56,12 +56,12 @@ __global__ void keccakf_perm_phase1(
         // generate_trace_row_for_round expects current_state[y][x] = A[x][y] (keccak notation)
         // In keccak buffer: A[x][y] is stored at offset (x + 5*y)
         // So current_state[y][x] should get keccak_buffer[x + 5*y]
-        for (int x = 0; x < 5; x++) {
-            for (int y = 0; y < 5; y++) {
+        for (uint32_t x = 0; x < 5; x++) {
+            for (uint32_t y = 0; y < 5; y++) {
                 // keccak spec: A[x][y] is at byte offset (x + 5*y) * 8
-                int keccak_offset = x + 5 * y;
+                uint32_t keccak_offset = x + 5 * y;
                 uint64_t val = 0;
-                for (int j = 0; j < 8; j++) {
+                for (uint32_t j = 0; j < 8; j++) {
                     val |= static_cast<uint64_t>(rec.preimage_buffer_bytes[keccak_offset * 8 + j])
                            << (j * 8);
                 }


### PR DESCRIPTION
## Deduplicate Keccak round logic in CUDA code

Addresses https://github.com/openvm-org/openvm/pull/2670#discussion_r3053633831

### Problem

`keccakf_op.cuh` carried a second copy of the Keccak-f round logic that already existed in `p3_keccakf.cuh`. Both were correct, but maintaining two copies creates drift risk for future bug fixes or tuning.

### Changes

- **`p3_keccakf.cuh`**: Extracted a shared `__forceinline__` helper `keccak256::keccakf_round_body()` that implements a single Keccak-f round on a flat `uint64_t[25]` state. Reduced `apply_round_in_place()` to a thin `__noinline__` wrapper that delegates to it.

- **`keccakf_op.cuh`**: Replaced the 50-line duplicate `keccakf_permutation()` (and its local `rotl64()` helper) with a 5-line loop over the shared round body.

- **`primitives/utils.cuh`**: Replaced the `ROTL64` macro with a proper `__forceinline__` function `rotl64()` for type safety and single-evaluation guarantees.

### Performance

No impact. All helpers are `__forceinline__`, so the compiler produces identical code. The `__noinline__` / `__forceinline__` wrapper pattern (same as `sha2_main.cu`) preserves the existing stack frame topology.
