### PR TITLE
feat(ci): set up sccache for compilation caching

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -22,6 +22,12 @@ runs:
     - name: Configure sccache S3 backend
       shell: bash
       run: |
+        if [[ -z "${{ inputs.s3-bucket }}" ]]; then
+          echo "::warning::S3 bucket not configured, sccache will use local cache only"
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          exit 0
+        fi
+
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> $GITHUB_ENV
         echo "SCCACHE_REGION=${{ inputs.s3-region }}" >> $GITHUB_ENV
@@ -30,7 +36,8 @@ runs:
         # Auto-detect CUDA architecture for cache key partitioning
         PREFIX="${{ inputs.s3-key-prefix }}"
         if command -v nvidia-smi &> /dev/null; then
-          CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.' || echo "unknown")
+          CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.' || true)
+          CUDA_ARCH="${CUDA_ARCH:-unknown}"
           PREFIX="${PREFIX:+${PREFIX}/}cuda-${CUDA_ARCH}"
           echo "Detected CUDA architecture: $CUDA_ARCH"
         fi

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,41 @@
+name: "Setup sccache with S3"
+description: "Configures sccache with S3 backend for distributed Rust compilation caching"
+
+inputs:
+  s3-bucket:
+    description: "S3 bucket name for sccache"
+    required: true
+  s3-region:
+    description: "AWS region for S3 bucket"
+    required: true
+  s3-key-prefix:
+    description: "Additional S3 key prefix for cache partitioning"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Configure sccache S3 backend
+      shell: bash
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        echo "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> $GITHUB_ENV
+        echo "SCCACHE_REGION=${{ inputs.s3-region }}" >> $GITHUB_ENV
+        echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
+
+        # Auto-detect CUDA architecture for cache key partitioning
+        PREFIX="${{ inputs.s3-key-prefix }}"
+        if command -v nvidia-smi &> /dev/null; then
+          CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.' || echo "unknown")
+          PREFIX="${PREFIX:+${PREFIX}/}cuda-${CUDA_ARCH}"
+          echo "Detected CUDA architecture: $CUDA_ARCH"
+        fi
+
+        if [[ -n "$PREFIX" ]]; then
+          echo "SCCACHE_S3_KEY_PREFIX=$PREFIX" >> $GITHUB_ENV
+          echo "sccache S3 key prefix: $PREFIX"
+        fi

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -4,10 +4,12 @@ description: "Configures sccache with S3 backend for distributed Rust compilatio
 inputs:
   s3-bucket:
     description: "S3 bucket name for sccache"
-    required: true
+    required: false
+    default: ""
   s3-region:
     description: "AWS region for S3 bucket"
-    required: true
+    required: false
+    default: ""
   s3-key-prefix:
     description: "Additional S3 key prefix for cache partitioning"
     required: false
@@ -23,15 +25,16 @@ runs:
       shell: bash
       run: |
         if [[ -z "${{ inputs.s3-bucket }}" ]]; then
-          echo "::warning::S3 bucket not configured, sccache will use local cache only"
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "::warning::S3 bucket not configured, skipping sccache"
+          echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
           exit 0
         fi
 
-        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-        echo "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> $GITHUB_ENV
-        echo "SCCACHE_REGION=${{ inputs.s3-region }}" >> $GITHUB_ENV
-        echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV
+        # Set up env for health check
+        export SCCACHE_CONF="${{ github.action_path }}/sccache.toml"
+        export SCCACHE_BUCKET="${{ inputs.s3-bucket }}"
+        export SCCACHE_REGION="${{ inputs.s3-region }}"
+        export SCCACHE_S3_USE_SSL=true
 
         # Auto-detect CUDA architecture for cache key partitioning
         PREFIX="${{ inputs.s3-key-prefix }}"
@@ -41,8 +44,27 @@ runs:
           PREFIX="${PREFIX:+${PREFIX}/}cuda-${CUDA_ARCH}"
           echo "Detected CUDA architecture: $CUDA_ARCH"
         fi
-
         if [[ -n "$PREFIX" ]]; then
-          echo "SCCACHE_S3_KEY_PREFIX=$PREFIX" >> $GITHUB_ENV
+          export SCCACHE_S3_KEY_PREFIX="$PREFIX"
           echo "sccache S3 key prefix: $PREFIX"
+        fi
+
+        # Stop any server the sccache-action may have started (without S3 config)
+        sccache --stop-server 2>/dev/null || true
+
+        # Start server and verify it runs; fall back to plain rustc if it fails
+        if sccache --start-server && sccache --show-stats > /dev/null; then
+          echo "sccache server started successfully"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CONF=${{ github.action_path }}/sccache.toml" >> "$GITHUB_ENV"
+          echo "SCCACHE_BUCKET=${{ inputs.s3-bucket }}" >> "$GITHUB_ENV"
+          echo "SCCACHE_REGION=${{ inputs.s3-region }}" >> "$GITHUB_ENV"
+          echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
+          if [[ -n "$PREFIX" ]]; then
+            echo "SCCACHE_S3_KEY_PREFIX=$PREFIX" >> "$GITHUB_ENV"
+          fi
+        else
+          echo "::warning::sccache server failed to start, compiling without cache"
+          sccache --stop-server 2>/dev/null || true
+          echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
         fi

--- a/.github/actions/setup-sccache/sccache.toml
+++ b/.github/actions/setup-sccache/sccache.toml
@@ -1,0 +1,1 @@
+server_startup_timeout_ms = 60000

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -32,6 +32,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
@@ -61,3 +65,7 @@ jobs:
       #   working-directory: benchmarks/prove
       #   run: |
       #     CUDA_OPT_LEVEL=3 MAX_CONCURRENCY=5 cargo run --bin async_regex --features cuda,async -- --max-segment-length $((1<<20)) --segment-max-memory 16106127360
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   tests-cuda:
     runs-on:
-      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/runner=test-gpu-nvidia/family=g6.*+g5 # ensure 24G vram for async test
+      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/runner=test-gpu-nvidia/family=g6.*+g5/extras=s3-cache # ensure 24G vram for async test
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -85,8 +85,8 @@ on:
         default: false
 
 env:
-  S3_METRICS_PATH: s3://openvm-public-data-sandbox-us-east-1/benchmark/github/metrics
-  S3_PUBLIC_PATH_BASE: s3://openvm-public-data-sandbox-us-east-1/benchmark/github
+  S3_METRICS_PATH: s3://${{ vars.OPENVM_S3_DATA_BUCKET }}/benchmark/github/metrics
+  S3_PUBLIC_PATH_BASE: s3://${{ vars.OPENVM_S3_DATA_BUCKET }}/benchmark/github
   FEATURE_FLAGS: "metrics,parallel,tco"
   INPUT_ARGS: ""
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -112,6 +112,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
@@ -246,3 +250,7 @@ jobs:
             REF_HASH=$(echo "${{ github.ref }}" | sha256sum | cut -d' ' -f1)
           fi
           s5cmd cp $METRIC_PATH "${{ env.S3_METRICS_PATH }}/${REF_HASH}-${METRIC_NAME}.json"
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -47,6 +47,10 @@ jobs:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -76,6 +80,10 @@ jobs:
           run: cargo $TOOLCHAIN codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
 
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
   codspeed-instrumentation-benchmarks:
     name: Run codspeed instrumentation benchmarks
     runs-on:
@@ -89,6 +97,10 @@ jobs:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -124,3 +136,7 @@ jobs:
           working-directory: benchmarks/execute
           run: cargo $TOOLCHAIN codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  S3_FIXTURES_PATH: s3://openvm-public-data-sandbox-us-east-1/benchmark/fixtures
+  S3_FIXTURES_PATH: s3://${{ vars.OPENVM_S3_DATA_BUCKET }}/benchmark/fixtures
   JEMALLOC_SYS_WITH_MALLOC_CONF: "retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
   TOOLCHAIN: "+nightly-2025-08-19"
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -190,9 +190,10 @@ jobs:
             sccache --stop-server 2>/dev/null || true
           fi
 
-      - name: Install openvm-prof
-        working-directory: crates/prof
-        run: cargo install --force --profile=dev --path .
+      - name: Build openvm-prof
+        run: |
+          cargo build --locked -p openvm-prof
+          echo "${{ github.workspace }}/target/debug" >> $GITHUB_PATH
 
       - name: Set github pages path for dispatch
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -166,6 +166,11 @@ jobs:
         with:
           ref: ${{ env.CURRENT_SHA }}
           repository: ${{ env.REPO }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
 
       - name: Install openvm-prof
         working-directory: crates/prof
@@ -379,3 +384,7 @@ jobs:
               repo: context.repo.repo,
               body: `<!--Benchmark Results-->\n${newBenchmark}`
             });
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -51,10 +51,10 @@ env:
   CURRENT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-  S3_METRICS_PATH: s3://openvm-public-data-sandbox-us-east-1/benchmark/github/metrics
-  S3_MD_PATH: s3://openvm-public-data-sandbox-us-east-1/benchmark/github/results
-  S3_PUBLIC_PATH_BASE: s3://openvm-public-data-sandbox-us-east-1/benchmark/github
-  S3_PUBLIC_URL_BASE: https://openvm-public-data-sandbox-us-east-1.s3.us-east-1.amazonaws.com/benchmark/github
+  S3_METRICS_PATH: s3://${{ vars.OPENVM_S3_DATA_BUCKET }}/benchmark/github/metrics
+  S3_MD_PATH: s3://${{ vars.OPENVM_S3_DATA_BUCKET }}/benchmark/github/results
+  S3_PUBLIC_PATH_BASE: s3://${{ vars.OPENVM_S3_DATA_BUCKET }}/benchmark/github
+  S3_PUBLIC_URL_BASE: https://${{ vars.OPENVM_S3_DATA_BUCKET }}.s3.${{ vars.OPENVM_S3_REGION }}.amazonaws.com/benchmark/github
   FEATURE_FLAGS: ""
 
 permissions:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -140,6 +140,7 @@ jobs:
     runs-on:
       - runs-on=${{ github.run_id }}
       - runner=8cpu-linux-x64
+      - extras=s3-cache
     steps:
       ##########################################################################
       # Install S3 if necessary                                                #

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -168,17 +168,27 @@ jobs:
           ref: ${{ env.CURRENT_SHA }}
           repository: ${{ env.REPO }}
       - uses: dtolnay/rust-toolchain@stable
-      - name: Check for sccache action
-        id: check-sccache
+      # TODO: replace with `uses: ./.github/actions/setup-sccache` once the action exists on main
+      - name: Setup sccache
+        env:
+          SCCACHE_BUCKET: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          SCCACHE_REGION: ${{ vars.OPENVM_S3_REGION }}
         run: |
-          if [[ -f ".github/actions/setup-sccache/action.yml" ]]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
+          if ! command -v sccache &> /dev/null || [[ -z "$SCCACHE_BUCKET" ]]; then
+            echo "::warning::sccache or S3 bucket not available, skipping"
+            exit 0
           fi
-      - uses: ./.github/actions/setup-sccache
-        if: steps.check-sccache.outputs.available == 'true'
-        with:
-          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
-          s3-region: ${{ vars.OPENVM_S3_REGION }}
+          export SCCACHE_S3_USE_SSL=true
+          sccache --stop-server 2>/dev/null || true
+          if sccache --start-server && sccache --show-stats > /dev/null; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "SCCACHE_BUCKET=$SCCACHE_BUCKET" >> "$GITHUB_ENV"
+            echo "SCCACHE_REGION=$SCCACHE_REGION" >> "$GITHUB_ENV"
+            echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
+          else
+            echo "::warning::sccache failed to start, compiling without cache"
+            sccache --stop-server 2>/dev/null || true
+          fi
 
       - name: Install openvm-prof
         working-directory: crates/prof

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -168,7 +168,14 @@ jobs:
           ref: ${{ env.CURRENT_SHA }}
           repository: ${{ env.REPO }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Check for sccache action
+        id: check-sccache
+        run: |
+          if [[ -f ".github/actions/setup-sccache/action.yml" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: ./.github/actions/setup-sccache
+        if: steps.check-sccache.outputs.available == 'true'
         with:
           s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
           s3-region: ${{ vars.OPENVM_S3_REGION }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -178,6 +178,10 @@ jobs:
             echo "::warning::sccache or S3 bucket not available, skipping"
             exit 0
           fi
+          CONF="${{ github.workspace }}/.github/actions/setup-sccache/sccache.toml"
+          if [[ -f "$CONF" ]]; then
+            export SCCACHE_CONF="$CONF"
+          fi
           export SCCACHE_S3_USE_SSL=true
           sccache --stop-server 2>/dev/null || true
           if sccache --start-server && sccache --show-stats > /dev/null; then
@@ -185,6 +189,9 @@ jobs:
             echo "SCCACHE_BUCKET=$SCCACHE_BUCKET" >> "$GITHUB_ENV"
             echo "SCCACHE_REGION=$SCCACHE_REGION" >> "$GITHUB_ENV"
             echo "SCCACHE_S3_USE_SSL=true" >> "$GITHUB_ENV"
+            if [[ -f "$CONF" ]]; then
+              echo "SCCACHE_CONF=$CONF" >> "$GITHUB_ENV"
+            fi
           else
             echo "::warning::sccache failed to start, compiling without cache"
             sccache --stop-server 2>/dev/null || true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -93,3 +97,7 @@ jobs:
         run: |
           export SKIP_INSTALL=1
           cargo nextest run --cargo-profile=fast --test-threads=1
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -51,10 +51,10 @@ jobs:
         run: |
           (hash svm 2>/dev/null || cargo install --locked --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
 
-      - name: Install cargo-openvm
-        working-directory: crates/cli
+      - name: Build cargo-openvm
         run: |
-          cargo install --force --locked --path .
+          cargo build --locked --profile fast -p cargo-openvm
+          echo "${{ github.workspace }}/target/fast" >> $GITHUB_PATH
 
       - name: Build and run book examples
         working-directory: examples

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -21,7 +21,7 @@ jobs:
   cuda-backend:
     name: continuations cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6.*+g5+g6e
+      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6.*+g5+g6e/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
       - name: Verify GPU setup
@@ -60,3 +64,7 @@ jobs:
       - name: Run continuations CUDA e2e test
         working-directory: crates/continuations
         run: cargo nextest run --cargo-profile=fast --features cuda,root-prover --test-threads=1 -E 'test(e2e)'
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/continuations.yml
+++ b/.github/workflows/continuations.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Recursion tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64
+      - runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/continuations.yml
+++ b/.github/workflows/continuations.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
 
@@ -39,3 +43,7 @@ jobs:
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
           cargo nextest run
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/cpu=32
+      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/cpu=32/extras=s3-cache
     steps:
       - uses: actions/checkout@v5
       - name: Set up Rust toolchain

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
 
       - name: Cargo check
         run: cargo check
@@ -74,3 +78,7 @@ jobs:
         env:
           S3_BUCKET: ${{ vars.CRATE_DOCS_S3_BUCKET }}
         run: s5cmd sync . s3://${S3_BUCKET%/}/${{ github.event.inputs.tag }}/
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -36,7 +36,7 @@ jobs:
           - "rv32im"
           - "keccak256 sha2 bigint algebra ecc pairing deferral"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'test-gpu-nvidia/family=g6.*+g6e' }}
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'test-gpu-nvidia/family=g6.*+g6e' }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -93,6 +93,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
@@ -135,3 +139,7 @@ jobs:
               echo "Skipping tests for $ext as no relevant files changed."
             fi
           done
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -70,6 +70,10 @@ jobs:
           exit 0
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -109,3 +113,7 @@ jobs:
           else
             cargo nextest run --cargo-profile=fast --profile=heavy --no-tests=pass --success-output=immediate
           fi
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -34,7 +34,7 @@ jobs:
           - { names: "ruint k256 p256" }
           - { names: "ff_derive pairing" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=test-gpu-nvidia/cpu=8+32/family=g6.*+g5+g6e
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=test-gpu-nvidia/cpu=8+32/family=g6.*+g5+g6e/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -107,6 +107,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
@@ -158,3 +162,7 @@ jobs:
               echo "Skipping tests for $crate as no relevant files changed."
             fi
           done
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -65,6 +65,10 @@ jobs:
           exit 0
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -82,3 +86,7 @@ jobs:
           fi
 
           cargo nextest run --cargo-profile=fast "${EXTRA_ARGS[@]}" --no-tests=pass --test-threads=1
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -112,7 +112,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.cuda == 'true' }}
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda/runner=test-gpu-nvidia/cpu=8
+      - runs-on=${{ github.run_id }}-cuda/runner=test-gpu-nvidia/cpu=8/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -41,6 +41,10 @@ jobs:
           skip: Cargo.lock,./docs/vocs/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,./audits/*.pdf,./guest-libs/ruint/*
           ignore_words_file: .codespellignore
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -98,6 +102,11 @@ jobs:
         run: |
           cargo binstall --no-confirm --force cargo-audit
           cargo audit
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
   lint-cuda:
     name: Lint CUDA
     needs: changes
@@ -110,6 +119,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
@@ -127,3 +140,7 @@ jobs:
       #     sudo apt-get update
       #     sudo apt-get install -y clang-tidy-21
       #     ./scripts/run_clang_tidy.sh
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -38,6 +38,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -76,3 +80,7 @@ jobs:
         working-directory: crates/circuits/mod-builder
         run: |
           cargo nextest run ${{ env.NEXTEST_ARGS }}
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
       - name: Verify GPU setup
@@ -53,3 +57,7 @@ jobs:
       - name: Run recursion CUDA tests
         working-directory: crates/recursion
         run: cargo nextest run cuda --features cuda --test-threads=8
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -20,7 +20,7 @@ jobs:
   cuda-backend:
     name: recursion cuda tracegen tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6.*+g5+g6e
+      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6.*+g5+g6e/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v6

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Recursion tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64
+      - runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
 
@@ -38,3 +42,7 @@ jobs:
         working-directory: crates/recursion
         run: |
           cargo nextest run
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
           ref: ${{ env.version }}
 
       - name: Build tagged CLI
-        run: cargo install --force --locked --path crates/cli cargo-openvm
+        run: |
+          cargo build --release --locked -p cargo-openvm
+          echo "${{ github.workspace }}/target/release" >> $GITHUB_PATH
 
       - name: Run setup from tagged version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 env:
-  S3_BUCKET: openvm-public-artifacts-us-east-1
+  S3_BUCKET: ${{ vars.OPENVM_S3_ARTIFACTS_BUCKET }}
 
 jobs:
   upload-setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -55,3 +59,7 @@ jobs:
 
       - name: Sync ~/.openvm with S3 bucket in tagged dir
         run: s5cmd sync ~/.openvm/ s3://${S3_BUCKET%/}/${{ env.version }}/
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -49,10 +49,6 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: ./.github/actions/setup-sccache
-        with:
-          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
-          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -60,6 +56,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
 
       - name: Set feature flags
         run: |

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -49,6 +49,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -97,3 +101,7 @@ jobs:
             TEST_NAME=test_rv32im_riscv_vector_runtime
           fi
           cargo nextest run ${{ env.FEATURE_ARGS }} --cargo-profile=fast --run-ignored only --no-capture -- $TEST_NAME
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -20,7 +20,7 @@ jobs:
   cuda-backend:
     name: sdk cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6.*+g5+g6e
+      - runs-on=${{ github.run_id }}/runner=test-gpu-nvidia/family=g6.*+g5+g6e/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
       - name: Verify GPU setup
@@ -55,3 +59,7 @@ jobs:
         run: |
           rustup component add rust-src --toolchain nightly-2025-08-02
           cargo nextest run --cargo-profile=fast --features cuda,root-prover --test-threads=1
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -34,6 +34,10 @@ jobs:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -95,3 +99,7 @@ jobs:
         # if: ${{ github.event_name == 'push' }}
         run: |
           CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo nextest run --release --features parallel,root-prover,evm-verify --run-ignored=only test_static_verifier_custom_pv_handler
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/static-verifier.yml
+++ b/.github/workflows/static-verifier.yml
@@ -30,6 +30,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -44,3 +48,7 @@ jobs:
         working-directory: crates/static-verifier
         run: |
           cargo nextest run --release --run-ignored=only real_prover_keygen_prove_verify_roundtrip
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -38,7 +38,9 @@ jobs:
 
       # Build and test from base branch
       - name: Build base branch CLI
-        run: cargo install --force --locked --path crates/cli
+        run: |
+          cargo build --release --locked -p cargo-openvm
+          echo "${{ github.workspace }}/target/release" >> $GITHUB_PATH
 
       - name: Run setup from base branch and snapshot ~/.openvm
         run: |
@@ -82,7 +84,7 @@ jobs:
           clean: false
 
       - name: Build tagged CLI
-        run: cargo install --force --locked --path crates/cli
+        run: cargo build --release --locked -p cargo-openvm
 
       - name: Run setup from tagged version
         run: |

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -28,6 +28,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -205,3 +209,7 @@ jobs:
           echo "✅ All example verification keys are identical"
           echo "✅ All benchmark verification keys are identical"
           echo "✅ Versioning policy maintained - patch upgrade is backward compatible"
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -37,6 +37,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-sccache
+        with:
+          s3-bucket: ${{ vars.OPENVM_S3_SCCACHE_BUCKET }}
+          s3-region: ${{ vars.OPENVM_S3_REGION }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -63,3 +67,7 @@ jobs:
         working-directory: crates/vm
         run: |
           cargo nextest run --cargo-profile=fast --features parallel,basic-memory
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true


### PR DESCRIPTION
## Summary

Set up [sccache](https://github.com/mozilla/sccache) with an S3 backend across all CI workflows for distributed Rust compilation caching. This caches compiled artifacts in S3 so that repeated builds across PRs and branches avoid redundant compilation work.

- Add a reusable `setup-sccache` composite action (`.github/actions/setup-sccache/`) that configures sccache with S3 credentials, auto-detects CUDA architecture for cache key partitioning, and falls back gracefully to uncached builds if sccache fails to start or S3 is unavailable.
- Integrate sccache into all 20+ CI workflows (extension tests, guest library tests, CUDA tests, CLI, benchmarks, lints, SDK, recursion, continuations, etc.).
- Replace `cargo install --force` with `cargo build` + PATH for local tools (`cargo-openvm`, `openvm-prof`). `cargo install --force` always rebuilds from scratch (no incremental compilation), while `cargo build` leverages both sccache and incremental compilation from the `rust-cache` target directory — making no-change rebuilds near-instant.
- Ensure all `runs-on` labels include `extras=s3-cache` for S3 access.

## Performance

Compared against PR #2682 (same day, ~1hr earlier, no sccache), with **98–100% sccache hit rates** across all workflows:

| Workflow | Before (s) | After (s) | Improvement |
|----------|-----------|-----------|-------------|
| CUDA SDK Tests | 724 | 397 | **-45%** |
| CUDA Continuations | 898 | 507 | **-44%** |
| Extension Tests CUDA (combined) | 662 | 404 | **-39%** |
| OpenVM CLI Tests | 738 | 505 | **-32%** |
| Guest Lib: verify-stark | 252 | 133 | **-47%** |
| Guest Lib: sha2 | 158 | 77 | **-51%** |
| Extension Tests: ecc (false) | 228 | 159 | **-30%** |
| Extension Tests: pairing (true) | 132 | 65 | **-51%** |

## Test plan

- [x] All CI workflows pass on this branch
- [x] sccache stats show high cache hit rates (98–100%)
- [x] Graceful fallback: workflows still work if sccache/S3 is unavailable
- [x] `cargo openvm` commands work correctly via `cargo build` + PATH instead of `cargo install`
