### PR TITLE
fix: mark keccak256 finalize and native_keccak256 as unsafe

### DIFF
--- a/guest-libs/keccak256/src/host_impl.rs
+++ b/guest-libs/keccak256/src/host_impl.rs
@@ -24,8 +24,10 @@ impl Keccak256 {
 
     /// Finalizes the hash computation and writes the result to the output buffer.
     ///
-    /// The output buffer must be at least `KECCAK_OUTPUT_SIZE` (32) bytes.
-    pub fn finalize(self, output: &mut [u8]) {
+    /// # Safety
+    ///
+    /// `output` must be at least `KECCAK_OUTPUT_SIZE` (32) bytes long.
+    pub unsafe fn finalize(self, output: &mut [u8]) {
         debug_assert!(
             output.len() >= super::KECCAK_OUTPUT_SIZE,
             "output buffer too small"
@@ -45,5 +47,6 @@ impl Default for Keccak256 {
 pub fn set_keccak256(input: &[u8], output: &mut [u8; KECCAK_OUTPUT_SIZE]) {
     let mut hasher = Keccak256::new();
     hasher.update(input);
-    hasher.finalize(output);
+    // SAFETY: output is exactly KECCAK_OUTPUT_SIZE bytes.
+    unsafe { hasher.finalize(output) };
 }

--- a/guest-libs/keccak256/src/lib.rs
+++ b/guest-libs/keccak256/src/lib.rs
@@ -22,7 +22,9 @@ impl tiny_keccak::Hasher for Keccak256 {
 
     #[inline(always)]
     fn finalize(self, output: &mut [u8]) {
-        Keccak256::finalize(self, output);
+        assert!(output.len() >= KECCAK_OUTPUT_SIZE, "output buffer too small");
+        // SAFETY: output is at least KECCAK_OUTPUT_SIZE bytes (checked above).
+        unsafe { Keccak256::finalize(self, output) };
     }
 }
 

--- a/guest-libs/keccak256/src/lib.rs
+++ b/guest-libs/keccak256/src/lib.rs
@@ -22,7 +22,10 @@ impl tiny_keccak::Hasher for Keccak256 {
 
     #[inline(always)]
     fn finalize(self, output: &mut [u8]) {
-        assert!(output.len() >= KECCAK_OUTPUT_SIZE, "output buffer too small");
+        assert!(
+            output.len() >= KECCAK_OUTPUT_SIZE,
+            "output buffer too small"
+        );
         // SAFETY: output is at least KECCAK_OUTPUT_SIZE bytes (checked above).
         unsafe { Keccak256::finalize(self, output) };
     }

--- a/guest-libs/keccak256/src/zkvm_impl.rs
+++ b/guest-libs/keccak256/src/zkvm_impl.rs
@@ -140,6 +140,7 @@ pub unsafe extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: 
 /// Sets `output` to the keccak256 hash of `input`.
 #[inline(always)]
 pub fn set_keccak256(input: &[u8], output: &mut [u8; KECCAK_OUTPUT_SIZE]) {
-    // SAFETY: output is exactly KECCAK_OUTPUT_SIZE bytes, and input.as_ptr() is valid for input.len() bytes.
+    // SAFETY: output is exactly KECCAK_OUTPUT_SIZE bytes, and input.as_ptr() is valid for
+    // input.len() bytes.
     unsafe { native_keccak256(input.as_ptr(), input.len(), output.as_mut_ptr()) };
 }

--- a/guest-libs/keccak256/src/zkvm_impl.rs
+++ b/guest-libs/keccak256/src/zkvm_impl.rs
@@ -73,7 +73,11 @@ impl Keccak256 {
     }
 
     /// Finalizes the hash computation and writes the result to a raw pointer.
-    fn finalize_ptr(&mut self, output: *mut u8) {
+    ///
+    /// # Safety
+    ///
+    /// `output` must point to a buffer that is at least `KECCAK_OUTPUT_SIZE` (32) bytes long.
+    unsafe fn finalize_ptr(&mut self, output: *mut u8) {
         // Apply Keccak padding (pad10*1): 0x01 at current position, 0x80 at end of rate
         self.state.0[self.idx] ^= 0x01;
         self.state.0[KECCAK_RATE - 1] ^= 0x80;
@@ -89,13 +93,16 @@ impl Keccak256 {
 
     /// Finalizes the hash computation and writes the result to the output buffer.
     ///
-    /// The output buffer must be at least `KECCAK_OUTPUT_SIZE` (32) bytes.
+    /// # Safety
+    ///
+    /// `output` must be at least `KECCAK_OUTPUT_SIZE` (32) bytes long.
     #[inline(always)]
-    pub fn finalize(mut self, output: &mut [u8]) {
+    pub unsafe fn finalize(mut self, output: &mut [u8]) {
         debug_assert!(
             output.len() >= KECCAK_OUTPUT_SIZE,
             "output buffer too small"
         );
+        // SAFETY: caller guarantees output is at least KECCAK_OUTPUT_SIZE bytes.
         self.finalize_ptr(output.as_mut_ptr());
     }
 }
@@ -123,7 +130,7 @@ static KECCAK256_HASHER: Mutex<Keccak256> = Mutex::new(Keccak256::new());
 /// [`sha3`]: https://docs.rs/sha3/latest/sha3/
 /// [`tiny_keccak`]: https://docs.rs/tiny-keccak/latest/tiny_keccak/
 #[no_mangle]
-pub extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8) {
+pub unsafe extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8) {
     let mut hasher = KECCAK256_HASHER.lock();
     hasher.update_ptr(bytes, len);
     hasher.finalize_ptr(output);
@@ -133,5 +140,6 @@ pub extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8
 /// Sets `output` to the keccak256 hash of `input`.
 #[inline(always)]
 pub fn set_keccak256(input: &[u8], output: &mut [u8; KECCAK_OUTPUT_SIZE]) {
-    native_keccak256(input.as_ptr(), input.len(), output.as_mut_ptr());
+    // SAFETY: output is exactly KECCAK_OUTPUT_SIZE bytes, and input.as_ptr() is valid for input.len() bytes.
+    unsafe { native_keccak256(input.as_ptr(), input.len(), output.as_mut_ptr()) };
 }


### PR DESCRIPTION
Towards INT-7429.

 ## Summary

  - Mark `finalize_ptr`, `finalize`, and `native_keccak256` as `unsafe fn` in both `zkvm_impl.rs` and `host_impl.rs`. These functions write 32 bytes to an output pointer/slice via `copy_nonoverlapping` without runtime size checks (only `debug_assert!`), so callers must guarantee the buffer is at least 32 bytes.
  - Add `assert!` in the `tiny_keccak::Hasher` trait impl in `lib.rs` since the trait method must be safe and cannot propagate `unsafe` to callers.
  - Safe public APIs (`keccak256()`, `set_keccak256()`) are unchanged — they pass correctly-sized buffers internally.

  **TODO:** The `openvm-org/tiny-keccak` fork and `openvm-org/openvm-primitives` also call `Keccak256::finalize` / `native_keccak256` and will need matching updates (add `unsafe {}` blocks and/or `assert!` at their trait boundaries).