### PR TITLE
fix: resolve OOB read in native_xorin and mark unsafe

### DIFF
--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/keccak.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/keccak.mdx
@@ -12,8 +12,8 @@ The `openvm-keccak256` guest library builds on these to provide `native_keccak25
 In the external library, you can do the following:
 
 ```rust
-extern "C" {
-    fn native_keccak256(input: *const u8, len: usize, output: *mut u8);
+unsafe extern "C" {
+    unsafe fn native_keccak256(input: *const u8, len: usize, output: *mut u8);
 }
 
 fn keccak256(input: &[u8]) -> [u8; 32] {

--- a/extensions/keccak256/guest/src/lib.rs
+++ b/extensions/keccak256/guest/src/lib.rs
@@ -14,9 +14,15 @@ pub const KECCAK_RATE: usize = 136;
 pub const KECCAK_OUTPUT_SIZE: usize = 32;
 pub const MIN_ALIGN: usize = 4;
 
+/// XOR `len` bytes from `input` into `buffer` using the native XORIN instruction.
+///
+/// # Safety
+///
+/// - `buffer` must point to a buffer of at least `len` bytes.
+/// - `input` must point to a buffer of at least `len` bytes.
 #[cfg(target_os = "zkvm")]
 #[no_mangle]
-pub extern "C" fn native_xorin(buffer: *mut u8, input: *const u8, len: usize) {
+pub unsafe extern "C" fn native_xorin(buffer: *mut u8, input: *const u8, len: usize) {
     if len == 0 {
         return;
     }
@@ -36,14 +42,16 @@ pub extern "C" fn native_xorin(buffer: *mut u8, input: *const u8, len: usize) {
             let actual_buffer = if buffer_aligned && len_aligned {
                 buffer
             } else {
-                aligned_buffer = AlignedBuf::new(buffer, adjusted_len, MIN_ALIGN);
+                aligned_buffer = AlignedBuf::uninit(adjusted_len, MIN_ALIGN);
+                core::ptr::copy_nonoverlapping(buffer, aligned_buffer.ptr, len);
                 aligned_buffer.ptr
             };
 
             let actual_input = if input_aligned && len_aligned {
                 input
             } else {
-                aligned_input = AlignedBuf::new(input, adjusted_len, MIN_ALIGN);
+                aligned_input = AlignedBuf::uninit(adjusted_len, MIN_ALIGN);
+                core::ptr::copy_nonoverlapping(input, aligned_input.ptr, len);
                 aligned_input.ptr
             };
 
@@ -56,9 +64,14 @@ pub extern "C" fn native_xorin(buffer: *mut u8, input: *const u8, len: usize) {
     }
 }
 
+/// Apply the Keccak-f[1600] permutation to the 200-byte state buffer.
+///
+/// # Safety
+///
+/// - `buffer` must point to a buffer of at least `KECCAK_WIDTH_BYTES` (200) bytes.
 #[cfg(target_os = "zkvm")]
 #[no_mangle]
-pub extern "C" fn native_keccakf(buffer: *mut u8) {
+pub unsafe extern "C" fn native_keccakf(buffer: *mut u8) {
     unsafe {
         if buffer as usize % MIN_ALIGN == 0 {
             __native_keccakf(buffer);

--- a/guest-libs/keccak256/src/zkvm_impl.rs
+++ b/guest-libs/keccak256/src/zkvm_impl.rs
@@ -37,14 +37,21 @@ impl Keccak256 {
     /// XOR input bytes into state at the current index and advance the index.
     #[inline(always)]
     fn xorin(&mut self, input: *const u8, len: usize) {
-        openvm_keccak256_guest::native_xorin(self.state.0[self.idx..].as_mut_ptr(), input, len);
+        // SAFETY: buffer points into the 200-byte AlignedState with at least len bytes available,
+        // and the caller guarantees input is valid for len bytes.
+        unsafe {
+            openvm_keccak256_guest::native_xorin(self.state.0[self.idx..].as_mut_ptr(), input, len);
+        }
         self.idx += len;
     }
 
     /// Keccak-f[1600] permutation using native zkvm instruction.
     #[inline(always)]
     fn keccakf(&mut self) {
-        openvm_keccak256_guest::native_keccakf(self.state.0.as_mut_ptr());
+        // SAFETY: state is a 200-byte AlignedState, satisfying the KECCAK_WIDTH_BYTES requirement.
+        unsafe {
+            openvm_keccak256_guest::native_keccakf(self.state.0.as_mut_ptr());
+        }
     }
 
     /// Absorbs input data into the sponge state from a raw pointer.


### PR DESCRIPTION
Towards INT-7429.

## Summary

  - Fix OOB read in `native_xorin` when `len` is not 4-byte aligned: `AlignedBuf::new` copied `adjusted_len` bytes from source buffers, reading 1-3 bytes past the valid region. Replace with `AlignedBuf::uninit` + `copy_nonoverlapping` of only `len` bytes.
  - Mark `native_xorin` and `native_keccakf` as `unsafe extern "C" fn` since they take raw pointers and require callers to guarantee pointer validity and buffer sizes. Add `unsafe` blocks in callers `xorin` and `keccakf` with safety comments.
  - Update keccak extension docs code example to reflect the new unsafe signatures.