### PR TITLE
[codex] Reproduce and fix mixed proof deferral stage mismatch

### DIFF
--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -1,14 +1,19 @@
-use std::sync::Arc;
+use std::{borrow::Borrow, sync::Arc};
 
 use eyre::Result;
 use openvm_circuit::arch::ContinuationVmProof;
 use openvm_continuations::{circuit::inner::ProofsType, prover::ChildVkKind};
 use openvm_recursion_circuit::prelude::Digest;
 use openvm_stark_backend::{
-    keygen::types::MultiStarkVerifyingKey, p3_field::PrimeCharacteristicRing,
+    keygen::types::MultiStarkVerifyingKey,
+    p3_field::{PrimeCharacteristicRing, PrimeField32},
+    proof::Proof,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{poseidon2_compress_with_capacity, F};
-use openvm_verify_stark_host::{pvs::DeferralPvs, VmStarkProof};
+use openvm_verify_stark_host::{
+    pvs::{DeferralPvs, VerifierBasePvs, VERIFIER_PVS_AIR_ID},
+    VmStarkProof,
+};
 use tracing::info_span;
 
 use crate::{
@@ -271,9 +276,22 @@ impl AggProver {
         def_proof: DeferralProof,
         metadata: &mut InternalLayerMetadata,
     ) -> Result<VmStarkProof> {
-        let DeferralProof::Present(def_inner) = def_proof else {
+        let DeferralProof::Present(mut def_inner) = def_proof else {
             return Ok(vm_proof);
         };
+
+        let vm_base = verifier_base_pvs(&vm_proof.inner);
+        let mut def_base = verifier_base_pvs(&def_inner);
+        while def_base.recursion_flag.as_canonical_u32() < vm_base.recursion_flag.as_canonical_u32()
+        {
+            def_inner = self.internal_recursive_prover.agg_prove::<E>(
+                &[def_inner],
+                ChildVkKind::RecursiveSelf,
+                ProofsType::Deferral,
+                None,
+            )?;
+            def_base = verifier_base_pvs(&def_inner);
+        }
 
         vm_proof.inner = info_span!(
             "agg_layer",
@@ -319,6 +337,12 @@ impl AggProver {
         })?;
         Ok(proof)
     }
+}
+
+fn verifier_base_pvs(proof: &Proof<SC>) -> VerifierBasePvs<F> {
+    let slice = proof.public_values[VERIFIER_PVS_AIR_ID].as_slice();
+    let pvs: &VerifierBasePvs<F> = slice[..VerifierBasePvs::<u8>::width()].borrow();
+    *pvs
 }
 
 fn reduce_def_round<const N: usize>(

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -1,10 +1,19 @@
-use std::{slice::from_ref, sync::Arc};
+use std::{borrow::Borrow, slice::from_ref, sync::Arc};
 
 use eyre::Result;
 use openvm::platform::memory::MEM_SIZE;
-use openvm_circuit::arch::instructions::DEFERRAL_AS;
+use openvm_circuit::{
+    arch::{hasher::poseidon2::vm_poseidon2_hasher, instructions::DEFERRAL_AS},
+    system::memory::merkle::MerkleTree,
+};
+use openvm_continuations::{circuit::inner::ProofsType, prover::ChildVkKind};
 use openvm_deferral_circuit::DeferralFn;
-use openvm_stark_backend::StarkEngine;
+use openvm_stark_backend::{
+    p3_field::PrimeField32,
+    proof::Proof,
+    verifier::{batch_constraints::BatchConstraintError, VerifierError},
+    StarkEngine,
+};
 use openvm_stark_sdk::{
     config::{
         app_params_with_100_bits_security, internal_params_with_100_bits_security,
@@ -16,11 +25,22 @@ use openvm_transpiler::elf::Elf;
 use openvm_verify_stark_circuit::extension::{
     get_deferral_state, get_raw_deferral_results, verify_stark_deferral_fn,
 };
-use openvm_verify_stark_host::vk::VmStarkVerifyingKey;
+use openvm_verify_stark_host::{
+    error::VerifyStarkError,
+    pvs::{DeferralPvs, VerifierBasePvs, VerifierDefPvs, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID},
+    vk::VmStarkVerifyingKey,
+    VmStarkProof,
+};
 
 use crate::{
-    config::{AggregationConfig, AggregationSystemParams, AppConfig, DEFAULT_APP_L_SKIP},
-    prover::DeferralProver,
+    config::{
+        AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig,
+        DEFAULT_APP_L_SKIP,
+    },
+    error::SdkError,
+    prover::{
+        compute_deferral_merkle_proofs, DeferralProof, DeferralProver, InternalLayerMetadata,
+    },
     DeferralInput, Sdk, StdIn,
 };
 
@@ -191,6 +211,266 @@ fn test_verify_stark_deferral() -> Result<()> {
 }
 
 #[test]
+fn test_prove_mixed_requires_stage_aligned_deferral_child() -> Result<()> {
+    // ---- Step 1: Create a fibonacci proof ----
+    let n_stack = 19;
+    let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
+    let agg_params = AggregationSystemParams::default();
+
+    let fib_elf = Elf::decode(
+        include_bytes!("../programs/examples/fibonacci.elf"),
+        MEM_SIZE as u32,
+    )?;
+
+    let fib_sdk = Sdk::riscv32(app_params.clone(), agg_params.clone());
+    let fib_exe = fib_sdk.convert_to_exe(fib_elf)?;
+
+    let n = 100u64;
+    let mut fib_stdin = StdIn::default();
+    fib_stdin.write(&n);
+
+    let (fib_proof, fib_baseline) = fib_sdk.prove(fib_exe, fib_stdin, &[])?;
+
+    // ---- Step 2: Build the DeferredVerifyCircuitProver ----
+    let fib_agg_prover = fib_sdk.agg_prover();
+    let ir_vk = fib_agg_prover.internal_recursive_prover.get_vk();
+    let ir_pcs_data = fib_agg_prover
+        .internal_recursive_prover
+        .get_self_vk_pcs_data()
+        .unwrap();
+
+    let fib_system_config = fib_sdk.app_config().app_vm_config.as_ref().clone();
+    let memory_dimensions = fib_system_config.memory_config.memory_dimensions();
+    let num_user_pvs = fib_system_config.num_public_values;
+
+    let def_circuit_params = internal_params_with_100_bits_security();
+    let deferred_verify_prover = VerifyProver::new::<E>(
+        ir_vk,
+        ir_pcs_data.commitment.into(),
+        def_circuit_params,
+        memory_dimensions,
+        num_user_pvs,
+        None,
+        0,
+    );
+    let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
+
+    // ---- Step 3: Create DeferralProver and extension ----
+    let hook_params = root_params_with_100_bits_security();
+    let agg_config = AggregationConfig {
+        params: agg_params.clone(),
+    };
+    let deferral_prover = DeferralProver::new(verify_stark_prover, agg_config, hook_params);
+    let deferral_ext =
+        deferral_prover.make_extension(vec![Arc::new(DeferralFn::new(verify_stark_deferral_fn))]);
+
+    // ---- Step 4: Compute deferral state and guest stdin values ----
+    let fib_vk = VmStarkVerifyingKey {
+        mvk: fib_sdk.agg_vk().as_ref().clone(),
+        baseline: fib_baseline,
+    };
+
+    let raw_results = get_raw_deferral_results(&fib_vk, from_ref(&fib_proof))?;
+    assert_eq!(raw_results.len(), 1);
+    let input_commit: [u8; 32] = raw_results[0].input.clone().try_into().unwrap();
+    let output_raw = &raw_results[0].output_raw;
+    let app_exe_commit: [u8; 32] = output_raw[..32].try_into().unwrap();
+    let app_vm_commit: [u8; 32] = output_raw[32..64].try_into().unwrap();
+    let user_public_values = output_raw[64..].to_vec();
+    let deferral_state = get_deferral_state(&fib_vk, from_ref(&fib_proof), 0)?;
+
+    // ---- Step 5: Build verify-stark SDK with a forced aggregation tree ----
+    let mut vs_config = openvm_sdk_config::SdkVmConfig::riscv32();
+    vs_config.deferral = Some(deferral_ext);
+    vs_config.system.config.memory_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 25;
+
+    let vs_app_config = AppConfig::new(vs_config, app_params);
+    let vs_sdk = Sdk::builder()
+        .app_config(vs_app_config)
+        .agg_params(agg_params)
+        .agg_tree_config(AggregationTreeConfig {
+            num_children_leaf: 1,
+            num_children_internal: 2,
+        })
+        .deferral_prover(deferral_prover)
+        .build()?;
+
+    let vs_elf = Elf::decode(
+        include_bytes!("../programs/examples/verify-stark.elf"),
+        MEM_SIZE as u32,
+    )?;
+    let vs_exe = vs_sdk.convert_to_exe(vs_elf)?;
+
+    let mut vs_stdin = StdIn::default();
+    vs_stdin.write(&app_exe_commit);
+    vs_stdin.write(&app_vm_commit);
+    vs_stdin.write(&user_public_values);
+    vs_stdin.write(&input_commit);
+    vs_stdin.deferrals = vec![deferral_state];
+
+    let def_input = DeferralInput::from_inputs(&[fib_proof]);
+
+    // ---- Step 6: Prove the VM child and deferral child separately ----
+    let mut stark_prover = vs_sdk.prover(vs_exe)?;
+    let memory_dimensions = stark_prover.app_prover.memory_dimensions();
+    let hasher = vm_poseidon2_hasher();
+    let initial_memory = &stark_prover
+        .app_prover
+        .instance()
+        .state()
+        .as_ref()
+        .expect("initial state should exist before proving")
+        .memory
+        .memory;
+    let initial_merkle_tree = MerkleTree::from_memory(initial_memory, &memory_dimensions, &hasher);
+
+    let continuation_proof = stark_prover.app_prover.prove(vs_stdin)?;
+    eprintln!(
+        "verify-stark continuation segments = {}",
+        continuation_proof.per_segment.len()
+    );
+
+    let (mut vm_proof, mut metadata) = stark_prover.agg_prover.prove_vm(continuation_proof)?;
+    while verifier_base_pvs(&vm_proof.inner)
+        .recursion_flag
+        .as_canonical_u32()
+        < 2
+    {
+        vm_proof = stark_prover
+            .agg_prover
+            .wrap_proof(vm_proof, &mut metadata)?;
+    }
+    let def_path_prover = stark_prover
+        .def_prover
+        .as_ref()
+        .expect("verify-stark repro requires deferral path prover");
+    let def_hook_proofs = def_path_prover.deferral_prover.prove(&[def_input])?;
+    let def_proof = def_path_prover.agg_prover.prove_def(def_hook_proofs)?;
+
+    let vm_base = verifier_base_pvs(&vm_proof.inner);
+    let vm_def = verifier_def_pvs(&vm_proof.inner);
+    let def_inner = match def_proof {
+        DeferralProof::Present(proof) => proof,
+        DeferralProof::Absent(_) => panic!("repro expects a present deferral proof"),
+    };
+    let def_base = verifier_base_pvs(&def_inner);
+    let def_def = verifier_def_pvs(&def_inner);
+
+    eprintln!(
+        "vm verifier base = ({}, {}), deferral_flag = {}",
+        vm_base.internal_flag.as_canonical_u32(),
+        vm_base.recursion_flag.as_canonical_u32(),
+        vm_def.deferral_flag.as_canonical_u32()
+    );
+    eprintln!(
+        "def verifier base = ({}, {}), deferral_flag = {}",
+        def_base.internal_flag.as_canonical_u32(),
+        def_base.recursion_flag.as_canonical_u32(),
+        def_def.deferral_flag.as_canonical_u32()
+    );
+
+    assert_eq!(vm_base.internal_flag.as_canonical_u32(), 2);
+    assert_eq!(vm_base.recursion_flag.as_canonical_u32(), 2);
+    assert_eq!(vm_def.deferral_flag.as_canonical_u32(), 0);
+    assert_eq!(def_base.internal_flag.as_canonical_u32(), 2);
+    assert_eq!(def_base.recursion_flag.as_canonical_u32(), 1);
+    assert_eq!(def_def.deferral_flag.as_canonical_u32(), 1);
+    assert_ne!(
+        vm_base.internal_recursive_vk_commit,
+        def_base.internal_recursive_vk_commit,
+        "expected the proof-embedded recursive-self VK commit visibility to differ before alignment"
+    );
+
+    let final_memory = &stark_prover
+        .app_prover
+        .instance()
+        .state()
+        .as_ref()
+        .expect("final state should exist after proving")
+        .memory
+        .memory;
+    let final_merkle_tree = MerkleTree::from_memory(final_memory, &memory_dimensions, &hasher);
+
+    // ---- Step 7: Show that the pre-fix beta.2 prove_mixed path returns a proof but fails ----
+    let mut mixed_proof = legacy_prove_mixed_unaligned(
+        &stark_prover.agg_prover,
+        vm_proof.clone(),
+        def_inner.clone(),
+        &mut copy_metadata(&metadata),
+    )?;
+    attach_deferral_merkle_proofs(
+        &mut mixed_proof,
+        memory_dimensions,
+        &initial_merkle_tree,
+        &final_merkle_tree,
+    );
+
+    let mixed_err = Sdk::verify_proof(
+        vs_sdk.agg_vk().as_ref().clone(),
+        stark_prover.generate_baseline(),
+        &mixed_proof,
+    )
+    .expect_err("unaligned prove_mixed should return a proof whose host verification fails");
+    assert_sum_claim_mismatch(mixed_err);
+
+    // ---- Step 8: Manually lift the deferral child until recursion_flag matches ----
+    let mut aligned_def_inner = def_inner;
+    while verifier_base_pvs(&aligned_def_inner)
+        .recursion_flag
+        .as_canonical_u32()
+        < vm_base.recursion_flag.as_canonical_u32()
+    {
+        aligned_def_inner = stark_prover
+            .agg_prover
+            .internal_recursive_prover
+            .agg_prove::<E>(
+                &[aligned_def_inner],
+                ChildVkKind::RecursiveSelf,
+                ProofsType::Deferral,
+                None,
+            )?;
+    }
+
+    let aligned_def_base = verifier_base_pvs(&aligned_def_inner);
+    eprintln!(
+        "aligned def verifier base = ({}, {})",
+        aligned_def_base.internal_flag.as_canonical_u32(),
+        aligned_def_base.recursion_flag.as_canonical_u32(),
+    );
+    assert_eq!(aligned_def_base.internal_flag.as_canonical_u32(), 2);
+    assert_eq!(
+        aligned_def_base.recursion_flag.as_canonical_u32(),
+        vm_base.recursion_flag.as_canonical_u32()
+    );
+    assert_eq!(
+        aligned_def_base.internal_recursive_vk_commit,
+        vm_base.internal_recursive_vk_commit,
+        "expected the aligned deferral child to encode the same recursive-self VK commit as the VM child"
+    );
+
+    let mut aligned_mixed_proof = stark_prover.agg_prover.prove_mixed(
+        vm_proof,
+        DeferralProof::Present(aligned_def_inner),
+        &mut copy_metadata(&metadata),
+    )?;
+    attach_deferral_merkle_proofs(
+        &mut aligned_mixed_proof,
+        memory_dimensions,
+        &initial_merkle_tree,
+        &final_merkle_tree,
+    );
+
+    Sdk::verify_proof(
+        vs_sdk.agg_vk().as_ref().clone(),
+        stark_prover.generate_baseline(),
+        &aligned_mixed_proof,
+    )
+    .expect("aligned prove_mixed output should host-verify");
+
+    Ok(())
+}
+
+#[test]
 fn test_deferrals_enabled_without_usage() -> Result<()> {
     let n_stack = 19;
     let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
@@ -250,6 +530,74 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
     engine.verify(&vk, &proof)?;
 
     Ok(())
+}
+
+fn verifier_base_pvs(proof: &Proof<crate::SC>) -> VerifierBasePvs<crate::F> {
+    let slice = proof.public_values[VERIFIER_PVS_AIR_ID].as_slice();
+    let pvs: &VerifierBasePvs<crate::F> = slice[..VerifierBasePvs::<u8>::width()].borrow();
+    *pvs
+}
+
+fn verifier_def_pvs(proof: &Proof<crate::SC>) -> VerifierDefPvs<crate::F> {
+    let slice = proof.public_values[VERIFIER_PVS_AIR_ID].as_slice();
+    let (_, def_slice) = slice.split_at(VerifierBasePvs::<u8>::width());
+    let pvs: &VerifierDefPvs<crate::F> = def_slice.borrow();
+    *pvs
+}
+
+fn copy_metadata(metadata: &InternalLayerMetadata) -> InternalLayerMetadata {
+    InternalLayerMetadata {
+        internal_recursive_layer: metadata.internal_recursive_layer,
+        internal_node_idx: metadata.internal_node_idx,
+        proofs_type: metadata.proofs_type,
+    }
+}
+
+fn attach_deferral_merkle_proofs(
+    proof: &mut VmStarkProof,
+    memory_dimensions: openvm_circuit::system::memory::dimensions::MemoryDimensions,
+    initial_merkle_tree: &MerkleTree<crate::F, 8>,
+    final_merkle_tree: &MerkleTree<crate::F, 8>,
+) {
+    let def_pvs: &DeferralPvs<crate::F> = proof.inner.public_values[DEF_PVS_AIR_ID]
+        .as_slice()
+        .borrow();
+    let depth = def_pvs.depth.as_canonical_u32() as usize;
+    proof.deferral_merkle_proofs = Some(compute_deferral_merkle_proofs(
+        memory_dimensions,
+        initial_merkle_tree,
+        final_merkle_tree,
+        depth,
+    ));
+}
+
+fn legacy_prove_mixed_unaligned(
+    agg_prover: &crate::prover::AggProver,
+    mut vm_proof: VmStarkProof,
+    def_inner: Proof<crate::SC>,
+    metadata: &mut InternalLayerMetadata,
+) -> Result<VmStarkProof> {
+    vm_proof.inner = agg_prover.internal_recursive_prover.agg_prove::<E>(
+        &[vm_proof.inner, def_inner],
+        ChildVkKind::RecursiveSelf,
+        ProofsType::Mix,
+        None,
+    )?;
+    metadata.internal_recursive_layer += 1;
+    metadata.internal_node_idx += 1;
+    metadata.proofs_type = ProofsType::Combined;
+    Ok(vm_proof)
+}
+
+fn assert_sum_claim_mismatch(err: SdkError) {
+    match err {
+        SdkError::VerifyStark(VerifyStarkError::StarkVerificationFailure(
+            VerifierError::BatchConstraintError(BatchConstraintError::SumClaimMismatch { .. }),
+        )) => {}
+        other => panic!(
+            "expected unaligned mixed proof to fail with BatchConstraintError::SumClaimMismatch, got {other:?}"
+        ),
+    }
 }
 
 /// Cell-count profiling test for the static verifier circuit using a production root proof.


### PR DESCRIPTION
## What changed

This PR isolates the mixed-proof stage-mismatch issue on `preview-v2.0.0-beta.2` into two commits:

1. `test(sdk): reproduce mixed proof stage mismatch`
   - adds a focused SDK repro in `crates/sdk/src/tests.rs`
   - forces the aggregation tree shape
   - constructs a VM child at verifier-base stage `(2,2)` and a deferral child at `(2,1)`
   - models the pre-fix `AggProver::prove_mixed(...)` path locally and shows that the resulting mixed proof is constructed but host verification fails with `BatchConstraintError::SumClaimMismatch`
   - shows that manually lifting the deferral child with `ProofsType::Deferral` and `ChildVkKind::RecursiveSelf` to `(2,2)` makes the mixed proof host-verify

2. `fix(sdk): align deferral child before prove_mixed`
   - updates `crates/sdk/src/prover/agg.rs`
   - reads verifier-base PVS from the VM child and deferral child
   - wraps the deferral child with `ProofsType::Deferral` / `ChildVkKind::RecursiveSelf` until its `recursion_flag` matches the VM child
   - only then performs `ProofsType::Mix`

## Root cause

On beta.2, `AggProver::prove_mixed(...)` could combine a VM child that had already reached a deeper internal-recursive verifier-base stage with a deferral child that had not.

In the reproduced case:

- VM child verifier-base stage: `(internal_flag=2, recursion_flag=2)`
- deferral child verifier-base stage: `(2,1)`

That unaligned mix produces a proof object, but host verification fails on the batch-constraint path with `SumClaimMismatch`.

One nuance from the proof PVS is worth calling out explicitly: at `(2,1)`, the deferral child still has `internal_recursive_vk_commit` unset in its proof-embedded verifier-base public values. After lifting it to `(2,2)`, that proof-embedded VK commit matches the VM child, and the mixed proof host-verifies.

## Why the repro is structured this way

The test uses a local helper that mirrors the pre-fix `prove_mixed` behavior rather than calling the fixed method directly for the failing path. That keeps the repro commit stable after the runtime fix lands while still demonstrating the exact beta.2 behavior that the fix addresses.

## Validation

Passed:

- `cargo +nightly fmt --all -- --check`
- `OPENVM_SKIP_DEBUG=1 cargo test --profile fast -p openvm-sdk --features root-prover test_prove_mixed_requires_stage_aligned_deferral_child -- --nocapture`

Additional targeted check attempted:

- `OPENVM_SKIP_DEBUG=1 cargo test --profile fast -p openvm-sdk --features root-prover test_verify_stark_deferral -- --nocapture`

That second test currently panics in `p3-poseidon2-air` with `Callers expected to pad inputs to a power of two`. I did not treat that as part of this PR because it does not exercise the mixed-proof stage-alignment path introduced here.
