### PR TITLE
fix: resolve recursion_flag mismatch in prove_mixed

### DIFF
--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -280,9 +280,9 @@ impl AggProver {
         // The VM and deferral proofs must be at the same stage in internal recursion, i.e.
         // both have be the parent of either internal-for-leaf or internal-recursive child
         // proofs. If this is not the case, we wrap the internal-for-leaf parent proof here.
-        if metadata.internal_node_idx == 1 && def_internal_recursive_layer != 1 {
+        if metadata.internal_recursive_layer == 1 && def_internal_recursive_layer != 1 {
             vm_proof = self.wrap_proof(vm_proof, metadata)?
-        } else if def_internal_recursive_layer == 1 && metadata.internal_node_idx != 1 {
+        } else if def_internal_recursive_layer == 1 && metadata.internal_recursive_layer != 1 {
             def_inner = self.wrap_def_inner(def_inner, def_internal_recursive_layer)?
         }
 

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -277,6 +277,9 @@ impl AggProver {
             return Ok(vm_proof);
         };
 
+        // The VM and deferral proofs must be at the same stage in internal recursion, i.e.
+        // both have be the parent of either internal-for-leaf or internal-recursive child
+        // proofs. If this is not the case, we wrap the internal-for-leaf parent proof here.
         if metadata.internal_node_idx == 1 && def_internal_recursive_layer != 1 {
             vm_proof = self.wrap_proof(vm_proof, metadata)?
         } else if def_internal_recursive_layer == 1 && metadata.internal_node_idx != 1 {

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -278,7 +278,7 @@ impl AggProver {
         };
 
         // The VM and deferral proofs must be at the same stage in internal recursion, i.e.
-        // both have be the parent of either internal-for-leaf or internal-recursive child
+        // both have to be the parent of either internal-for-leaf or internal-recursive child
         // proofs. If this is not the case, we wrap the internal-for-leaf parent proof here.
         if metadata.internal_recursive_layer == 1 && def_internal_recursive_layer != 1 {
             vm_proof = self.wrap_proof(vm_proof, metadata)?

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -5,7 +5,7 @@ use openvm_circuit::arch::ContinuationVmProof;
 use openvm_continuations::{circuit::inner::ProofsType, prover::ChildVkKind};
 use openvm_recursion_circuit::prelude::Digest;
 use openvm_stark_backend::{
-    keygen::types::MultiStarkVerifyingKey, p3_field::PrimeCharacteristicRing,
+    keygen::types::MultiStarkVerifyingKey, p3_field::PrimeCharacteristicRing, proof::Proof,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{poseidon2_compress_with_capacity, F};
 use openvm_verify_stark_host::{pvs::DeferralPvs, VmStarkProof};
@@ -37,6 +37,7 @@ pub struct AggProver {
     pub agg_tree_config: AggregationTreeConfig,
 }
 
+#[derive(Clone)]
 pub struct InternalLayerMetadata {
     pub internal_recursive_layer: u32,
     pub internal_node_idx: u32,
@@ -220,7 +221,7 @@ impl AggProver {
         ))
     }
 
-    pub fn prove_def(&self, input: Vec<DeferralProof>) -> Result<DeferralProof> {
+    pub fn prove_def(&self, input: Vec<DeferralProof>) -> Result<(DeferralProof, u32)> {
         assert!(!input.is_empty());
 
         // Leaf round: hook-level → leaf-level
@@ -262,7 +263,7 @@ impl AggProver {
             layer += 1;
         }
 
-        Ok(proofs.pop().unwrap())
+        Ok((proofs.pop().unwrap(), layer))
     }
 
     pub fn prove_mixed(
@@ -270,10 +271,17 @@ impl AggProver {
         mut vm_proof: VmStarkProof,
         def_proof: DeferralProof,
         metadata: &mut InternalLayerMetadata,
+        def_internal_recursive_layer: u32,
     ) -> Result<VmStarkProof> {
-        let DeferralProof::Present(def_inner) = def_proof else {
+        let DeferralProof::Present(mut def_inner) = def_proof else {
             return Ok(vm_proof);
         };
+
+        if metadata.internal_node_idx == 1 && def_internal_recursive_layer != 1 {
+            vm_proof = self.wrap_proof(vm_proof, metadata)?
+        } else if def_internal_recursive_layer == 1 && metadata.internal_node_idx != 1 {
+            def_inner = self.wrap_def_inner(def_inner, def_internal_recursive_layer)?
+        }
 
         vm_proof.inner = info_span!(
             "agg_layer",
@@ -316,6 +324,26 @@ impl AggProver {
                     None,
                 )
             })
+        })?;
+        Ok(proof)
+    }
+
+    pub(crate) fn wrap_def_inner(
+        &self,
+        mut proof: Proof<SC>,
+        def_internal_recursive_layer: u32,
+    ) -> Result<Proof<SC>> {
+        proof = info_span!(
+            "agg_layer",
+            group = format!("def_internal_recursive.{def_internal_recursive_layer}")
+        )
+        .in_scope(|| {
+            self.internal_recursive_prover.agg_prove::<E>(
+                &[proof],
+                ChildVkKind::RecursiveSelf,
+                ProofsType::Deferral,
+                None,
+            )
         })?;
         Ok(proof)
     }

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -40,6 +40,7 @@ pub use merkle::*;
 pub type DefAggProvingKey = AggProvingKey;
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 pub enum DeferralProof {
     Present(Proof<SC>),
     Absent(DeferralPvs<F>),

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -111,10 +111,14 @@ where
         if !def_inputs.is_empty() {
             let def_prover = self.def_prover.as_ref().unwrap();
             let def_hook_proofs = def_prover.deferral_prover.prove(def_inputs)?;
-            let def_proof = def_prover.agg_prover.prove_def(def_hook_proofs)?;
-            stark_proof =
-                self.agg_prover
-                    .prove_mixed(stark_proof, def_proof, &mut internal_metadata)?;
+            let (def_proof, def_internal_recursive_layer) =
+                def_prover.agg_prover.prove_def(def_hook_proofs)?;
+            stark_proof = self.agg_prover.prove_mixed(
+                stark_proof,
+                def_proof,
+                &mut internal_metadata,
+                def_internal_recursive_layer,
+            )?;
         }
 
         // We add one additional internal_recursive layer to reduce the proof size.

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -24,7 +24,7 @@ use openvm_verify_stark_host::{
 
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AppConfig, DEFAULT_APP_L_SKIP},
-    prover::DeferralProver,
+    prover::{DeferralProof, DeferralProver},
     DeferralInput, Sdk, StdIn,
 };
 
@@ -285,6 +285,75 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
     let vk = evm_prover.root_prover.0.get_vk();
     let engine = RootE::new(vk.inner.params.clone());
     engine.verify(&vk, &proof)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
+    setup_tracing();
+    let (fib_sdk, app_params, agg_params) = make_fib_sdk();
+    let (fib_proof, fib_baseline) = generate_fib_vm_stark_proof(&fib_sdk)?;
+    let (vs_sdk, vs_stdin, def_input) =
+        make_deferral_sdk(&fib_sdk, fib_proof, fib_baseline, app_params, agg_params)?;
+
+    let vs_elf = Elf::decode(
+        include_bytes!("../programs/examples/verify-stark.elf"),
+        MEM_SIZE as u32,
+    )?;
+    let vs_exe = vs_sdk.convert_to_exe(vs_elf)?;
+
+    // ---- Step 1: Generate base VM and deferral proofs ----
+    let agg_prover = vs_sdk.agg_prover();
+    let app_proof = vs_sdk.app_prover(vs_exe)?.prove(vs_stdin)?;
+    let (vm_proof, mut internal_layer_metadata) = agg_prover.prove_vm(app_proof)?;
+
+    // We assume that the verify-stark program is small enough where only a single
+    // internal_recursive layer is needed to fully aggregate its proof.
+    assert_eq!(internal_layer_metadata.internal_recursive_layer, 1);
+
+    let def_prover = vs_sdk.def_path_prover.unwrap();
+    let def_hook_proofs = def_prover.deferral_prover.prove(&[def_input])?;
+    let (def_proof, mut def_internal_recursive_layer) =
+        def_prover.agg_prover.prove_def(def_hook_proofs)?;
+    assert_eq!(def_internal_recursive_layer, 1);
+
+    // ---- Step 2: Generate mixed proof with wrapped VM proof ----
+    let mut wrapped_vm_metadata = internal_layer_metadata.clone();
+    let mut wrapped_vm_proof = vm_proof.clone();
+    for _ in 0..2 {
+        wrapped_vm_proof = agg_prover.wrap_proof(wrapped_vm_proof, &mut wrapped_vm_metadata)?;
+    }
+    let wrapped_vm_mixed_proof = agg_prover.prove_mixed(
+        wrapped_vm_proof,
+        def_proof.clone(),
+        &mut wrapped_vm_metadata,
+        def_internal_recursive_layer,
+    )?;
+
+    // ---- Step 3: Generate mixed proof with wrapped deferral proof ----
+    let wrapped_def_proof = match def_proof {
+        DeferralProof::Present(mut p) => {
+            for _ in 0..2 {
+                p = agg_prover.wrap_def_inner(p, def_internal_recursive_layer)?;
+            }
+            def_internal_recursive_layer += 1;
+            DeferralProof::Present(p)
+        }
+        DeferralProof::Absent(_) => panic!("expected DeferralProof::Present"),
+    };
+    let wrapped_def_mixed_proof = agg_prover.prove_mixed(
+        vm_proof,
+        wrapped_def_proof,
+        &mut internal_layer_metadata,
+        def_internal_recursive_layer,
+    )?;
+
+    // ---- Step 4: Verify mixed proofs ----
+    let vk = agg_prover.internal_recursive_prover.get_vk();
+    let engine = E::new(vk.inner.params.clone());
+    engine.verify(&vk, &wrapped_vm_mixed_proof.inner)?;
+    engine.verify(&vk, &wrapped_def_mixed_proof.inner)?;
 
     Ok(())
 }

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -336,8 +336,8 @@ fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
         DeferralProof::Present(mut p) => {
             for _ in 0..2 {
                 p = agg_prover.wrap_def_inner(p, def_internal_recursive_layer)?;
+                def_internal_recursive_layer += 1;
             }
-            def_internal_recursive_layer += 1;
             DeferralProof::Present(p)
         }
         DeferralProof::Absent(_) => panic!("expected DeferralProof::Present"),


### PR DESCRIPTION
Resolves INT-7535. Issue found and initially corrected by [Daniel Heim](https://github.com/dghelm).

## Overview

This PR fixes a mixed-aggregation edge case in `openvm-sdk` where `prove_mixed` could combine a VM proof and a deferral proof that were not at compatible internal-recursive shapes. The fix threads deferral-layer metadata through the aggregation path and wraps the VM side or deferral side before mixing when needed.

The diff is limited to `crates/sdk` and is split into:

1. prover-path changes that carry and use deferral aggregation depth metadata
2. a regression test that exercises the mismatch scenarios directly

## `crates/sdk`: Mixed-proof aggregation fix

### Files

- `crates/sdk/src/prover/agg.rs`
- `crates/sdk/src/prover/stark.rs`
- `crates/sdk/src/prover/deferral/mod.rs`

### What changed

- `AggProver::prove_def` now returns both the final `DeferralProof` and the deferral proof's internal-recursive layer.
- `StarkProver::prove` passes that returned layer into `AggProver::prove_mixed`.
- `AggProver::prove_mixed` now conditionally normalizes the two inputs before producing the mixed proof:
  - if the VM proof still needs an extra recursive wrapper, it wraps the VM proof
  - if the deferral proof still needs an extra recursive wrapper, it wraps the deferral proof
- `AggProver` adds `wrap_def_inner` to recursively wrap a deferral proof with `ProofsType::Deferral`.
- `InternalLayerMetadata` and `DeferralProof` now derive `Clone` so the test can reuse intermediate proofs and metadata cleanly.

### Why it matters

The mixed prover path now has explicit visibility into the deferral proof's recursive-layer state instead of assuming the VM and deferral sides are already aligned. Reviewers should focus on whether the new normalization logic in `agg.rs` matches the intended recursion-flag / proof-shape invariants for mixed aggregation.

## `crates/sdk`: Regression coverage

### File

- `crates/sdk/src/tests.rs`

### What changed

- Adds `test_prove_mixed_vm_def_depth_mismatch`.
- The test builds the existing verify-stark deferral flow, then exercises both mismatch directions:
  - a VM proof that has been wrapped further before mixing
  - a deferral proof that has been wrapped further before mixing
- Both resulting mixed proofs are verified against the internal-recursive VK.

### Why it matters

This gives reviewers a concrete regression test for the shape-mismatch bug instead of relying only on end-to-end SDK flows that may not naturally hit the bad case.
