### PR TITLE
fix: SDK merkle path generation uses right child when depth == 0

### DIFF
--- a/crates/sdk/src/prover/deferral/merkle.rs
+++ b/crates/sdk/src/prover/deferral/merkle.rs
@@ -39,8 +39,9 @@ fn deferral_merkle_proof_from_tree(
 
     // Leaf index for DEFERRAL_AS, block_id=0 in the full tree (1-indexed).
     let leaf_idx = (1u64 << overall_height) + memory_dimensions.label_to_index((DEFERRAL_AS, 0));
+    debug_assert_eq!(leaf_idx % 2, 0);
 
-    // Start at level `depth` above the leaf. When `depth == 0``, the first node in the
+    // Start at level `depth` above the leaf. When `depth == 0`, the first node in the
     // path is the right sibling of the node at `leaf_idx`.
     let mut node_idx = if depth == 0 {
         leaf_idx + 1

--- a/crates/sdk/src/prover/deferral/merkle.rs
+++ b/crates/sdk/src/prover/deferral/merkle.rs
@@ -40,8 +40,13 @@ fn deferral_merkle_proof_from_tree(
     // Leaf index for DEFERRAL_AS, block_id=0 in the full tree (1-indexed).
     let leaf_idx = (1u64 << overall_height) + memory_dimensions.label_to_index((DEFERRAL_AS, 0));
 
-    // Start at level `depth` above the leaf.
-    let mut node_idx = leaf_idx >> depth;
+    // Start at level `depth` above the leaf. When `depth == 0``, the first node in the
+    // path is the right sibling of the node at `leaf_idx`.
+    let mut node_idx = if depth == 0 {
+        leaf_idx + 1
+    } else {
+        leaf_idx >> depth
+    };
 
     // Pad the first `depth` entries with zeros (skipped levels).
     let mut proof = vec![[F::ZERO; DIGEST_SIZE]; depth];

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -93,6 +93,28 @@ fn make_deferral_prover(sdk: &Sdk, agg_params: &AggregationSystemParams) -> Defe
     DeferralProver::new(verify_stark_prover, agg_config, hook_params)
 }
 
+/// Builds a deferral-enabled riscv32 SDK whose App VM inventory includes the
+/// deferral periphery chips (DeferralPoseidon2Chip, count chip, etc.).
+fn make_deferral_enabled_sdk(
+    fib_sdk: &Sdk,
+    app_params: SystemParams,
+    agg_params: AggregationSystemParams,
+) -> Result<Sdk> {
+    let deferral_prover = make_deferral_prover(fib_sdk, &agg_params);
+    let deferral_ext =
+        deferral_prover.make_extension(vec![Arc::new(DeferralFn::new(verify_stark_deferral_fn))]);
+
+    let mut vm_config = openvm_sdk_config::SdkVmConfig::riscv32();
+    vm_config.deferral = Some(deferral_ext);
+    vm_config.system.config.memory_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 25;
+
+    Ok(Sdk::builder()
+        .app_config(AppConfig::new(vm_config, app_params))
+        .agg_params(agg_params)
+        .deferral_prover(deferral_prover)
+        .build()?)
+}
+
 /// Builds a deferral-enabled verify-stark SDK from a fibonacci SDK and proof.
 ///
 /// Returns the SDK, the verify-stark stdin, and the deferral input.
@@ -103,10 +125,6 @@ fn make_deferral_sdk(
     app_params: SystemParams,
     agg_params: AggregationSystemParams,
 ) -> Result<(Sdk, StdIn, DeferralInput)> {
-    let deferral_prover = make_deferral_prover(fib_sdk, &agg_params);
-    let deferral_ext =
-        deferral_prover.make_extension(vec![Arc::new(DeferralFn::new(verify_stark_deferral_fn))]);
-
     let fib_vk = VmStarkVerifyingKey {
         mvk: fib_sdk.agg_vk().as_ref().clone(),
         baseline: fib_baseline,
@@ -121,16 +139,7 @@ fn make_deferral_sdk(
     let user_public_values = output_raw[64..].to_vec();
     let deferral_state = get_deferral_state(&fib_vk, from_ref(&fib_proof), 0)?;
 
-    let mut vs_config = openvm_sdk_config::SdkVmConfig::riscv32();
-    vs_config.deferral = Some(deferral_ext);
-    vs_config.system.config.memory_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 25;
-
-    let vs_app_config = AppConfig::new(vs_config, app_params);
-    let vs_sdk = Sdk::builder()
-        .app_config(vs_app_config)
-        .agg_params(agg_params)
-        .deferral_prover(deferral_prover)
-        .build()?;
+    let vs_sdk = make_deferral_enabled_sdk(fib_sdk, app_params, agg_params)?;
 
     let mut vs_stdin = StdIn::default();
     vs_stdin.write(&app_exe_commit);
@@ -260,13 +269,7 @@ fn test_verify_stark_with_deferral_child() -> Result<()> {
 fn test_deferrals_enabled_without_usage() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
-    let deferral_prover = make_deferral_prover(&fib_sdk, &agg_params);
-
-    let sdk = Sdk::builder()
-        .app_config(AppConfig::riscv32(app_params))
-        .agg_params(agg_params.clone())
-        .deferral_prover(deferral_prover)
-        .build()?;
+    let sdk = make_deferral_enabled_sdk(&fib_sdk, app_params, agg_params)?;
 
     let elf = Elf::decode(
         include_bytes!("../programs/examples/fibonacci.elf"),


### PR DESCRIPTION
Resolves INT-7542.

## Overview

Fixes an off-by-one bug in `deferral_merkle_proof_from_tree` (`crates/sdk/src/prover/deferral/merkle.rs`) when generating deferral merkle proofs with `depth == 0`. Also factors out a shared test helper that constructs a deferral-enabled SDK so the new "deferrals enabled without usage" test path exercises the same configuration used by the full deferral flow.

## Changes

### `crates/sdk/src/prover/deferral/merkle.rs` — the fix

`deferral_merkle_proof_from_tree` builds a merkle path from the deferral leaf up to the root, optionally skipping the first `depth` levels (which are covered by the deferral subtree).

The previous code computed the starting node as `leaf_idx >> depth`. When `depth == 0`, this returns `leaf_idx` itself, so the first sibling collected was `leaf_idx ^ 1` — the left neighbor of the deferral leaf. The proof expected here is actually the right sibling of the deferral leaf (the neighboring node at the same level).

The fix special-cases `depth == 0` to start at `leaf_idx + 1` (i.e., the right sibling), so the first collected sibling is correct. For `depth > 0`, behavior is unchanged.

```rust
let mut node_idx = if depth == 0 {
    leaf_idx + 1
} else {
    leaf_idx >> depth
};
```

**Review focus:** confirm that in the deferral memory layout, the expected first merkle path element at `depth == 0` is the right sibling (i.e., the deferral leaf lives at an even `leaf_idx` so `leaf_idx + 1` is its sibling).

### `crates/sdk/src/tests.rs` — test refactor

Extracts the deferral-enabled SDK construction into a new helper `make_deferral_enabled_sdk(...)`:

- Builds `SdkVmConfig::riscv32()`, attaches the deferral extension, bumps the deferral address-space cell count, and wires up the deferral prover on the SDK builder.
- `make_deferral_sdk` now delegates to this helper instead of inlining the same construction.
- `test_deferrals_enabled_without_usage` now uses this helper as well, so it runs with the full deferral VM inventory (previously it used the plain `AppConfig::riscv32`, which did not include the deferral extension).

**Review focus:** the behavioral change in `test_deferrals_enabled_without_usage` — it now exercises an SDK whose app VM includes deferral periphery chips but where no deferral usage occurs at runtime. This is the intended coverage for "deferrals compiled in but unused" rather than "deferrals not compiled in."
