### PR TITLE
fix(v2.1-rv64): update guest lib structs/fns to use rv64 prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6203,6 +6203,7 @@ dependencies = [
  "openvm-instructions",
  "openvm-mod-circuit-builder",
  "openvm-pairing-guest",
+ "openvm-riscv-adapters",
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "rand 0.9.2",

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -12,16 +12,14 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
-use openvm_riscv_circuit::adapters::expand_to_rv64_register;
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
     program::DEFAULT_PC_STEP,
-    riscv::{
-        RV64_CELL_BITS, RV64_MEMORY_AS, RV64_REGISTER_AS, RV64_WORD_NUM_LIMBS,
-    },
+    riscv::{RV64_CELL_BITS, RV64_MEMORY_AS, RV64_REGISTER_AS, RV64_WORD_NUM_LIMBS},
     LocalOpcode, DEFERRAL_AS,
 };
+use openvm_riscv_circuit::adapters::expand_to_rv64_register;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,

--- a/extensions/deferral/circuit/src/call/execution.rs
+++ b/extensions/deferral/circuit/src/call/execution.rs
@@ -171,11 +171,19 @@ unsafe fn execute_e12_impl<F: VmField, CTX: ExecutionCtxTrait>(
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 ) {
     // TODO: use rv64_register_to_u32 helper
-    let output_ptr_val = u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rd_ptr));
-    debug_assert!(output_ptr_val <= u32::MAX as u64, "upper 4 bytes of register must be zero for pointer");
+    let output_ptr_val =
+        u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rd_ptr));
+    debug_assert!(
+        output_ptr_val <= u32::MAX as u64,
+        "upper 4 bytes of register must be zero for pointer"
+    );
     let output_ptr = output_ptr_val as u32;
-    let input_ptr_val = u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rs_ptr));
-    debug_assert!(input_ptr_val <= u32::MAX as u64, "upper 4 bytes of register must be zero for pointer");
+    let input_ptr_val =
+        u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rs_ptr));
+    debug_assert!(
+        input_ptr_val <= u32::MAX as u64,
+        "upper 4 bytes of register must be zero for pointer"
+    );
     let input_ptr = input_ptr_val as u32;
 
     let input_commit_chunks: [[u8; DEFAULT_BLOCK_SIZE]; COMMIT_MEMORY_OPS] = from_fn(|i| {

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -289,7 +289,10 @@ impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
             a.as_canonical_u32(),
             &mut record.rd_aux.prev_timestamp,
         );
-        debug_assert_eq!(rd_bytes[RV64_WORD_NUM_LIMBS..], [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]);
+        debug_assert_eq!(
+            rd_bytes[RV64_WORD_NUM_LIMBS..],
+            [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]
+        );
         record.rd_val = u32::from_le_bytes(rd_bytes[..RV64_WORD_NUM_LIMBS].try_into().unwrap());
 
         let rs_bytes: [u8; RV64_REGISTER_NUM_LIMBS] = tracing_read(
@@ -298,7 +301,10 @@ impl<F: PrimeField32> AdapterTraceExecutor<F> for DeferralCallAdapterExecutor {
             b.as_canonical_u32(),
             &mut record.rs_aux.prev_timestamp,
         );
-        debug_assert_eq!(rs_bytes[RV64_WORD_NUM_LIMBS..], [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]);
+        debug_assert_eq!(
+            rs_bytes[RV64_WORD_NUM_LIMBS..],
+            [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]
+        );
         record.rs_val = u32::from_le_bytes(rs_bytes[..RV64_WORD_NUM_LIMBS].try_into().unwrap());
 
         let input_commit_chunks: [[u8; DEFAULT_BLOCK_SIZE]; COMMIT_MEMORY_OPS] = from_fn(|i| {

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -13,15 +13,13 @@ use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_riscv_circuit::adapters::expand_to_rv64_register;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
     program::DEFAULT_PC_STEP,
-    riscv::{
-        RV64_CELL_BITS, RV64_MEMORY_AS, RV64_REGISTER_AS, RV64_WORD_NUM_LIMBS,
-    },
+    riscv::{RV64_CELL_BITS, RV64_MEMORY_AS, RV64_REGISTER_AS, RV64_WORD_NUM_LIMBS},
     LocalOpcode,
 };
+use openvm_riscv_circuit::adapters::expand_to_rv64_register;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},

--- a/extensions/deferral/circuit/src/output/execution.rs
+++ b/extensions/deferral/circuit/src/output/execution.rs
@@ -155,11 +155,19 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 ) -> u32 {
     // TODO: use rv64_register_to_u32 helper
-    let output_ptr_val = u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rd_ptr));
-    debug_assert!(output_ptr_val <= u32::MAX as u64, "upper 4 bytes of register must be zero for pointer");
+    let output_ptr_val =
+        u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rd_ptr));
+    debug_assert!(
+        output_ptr_val <= u32::MAX as u64,
+        "upper 4 bytes of register must be zero for pointer"
+    );
     let output_ptr = output_ptr_val as u32;
-    let input_ptr_val = u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rs_ptr));
-    debug_assert!(input_ptr_val <= u32::MAX as u64, "upper 4 bytes of register must be zero for pointer");
+    let input_ptr_val =
+        u64::from_le_bytes(exec_state.vm_read(RV64_REGISTER_AS, pre_compute.rs_ptr));
+    debug_assert!(
+        input_ptr_val <= u32::MAX as u64,
+        "upper 4 bytes of register must be zero for pointer"
+    );
     let input_ptr = input_ptr_val as u32;
     let output_key_chunks: [[u8; DEFAULT_BLOCK_SIZE]; OUTPUT_TOTAL_MEMORY_OPS] = from_fn(|i| {
         exec_state.vm_read(RV64_MEMORY_AS, input_ptr + (i * DEFAULT_BLOCK_SIZE) as u32)

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -215,8 +215,12 @@ where
             rd_ptr,
             &mut record.header.rd_aux.prev_timestamp,
         );
-        debug_assert_eq!(rd_bytes[RV64_WORD_NUM_LIMBS..], [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]);
-        record.header.rd_val = u32::from_le_bytes(rd_bytes[..RV64_WORD_NUM_LIMBS].try_into().unwrap());
+        debug_assert_eq!(
+            rd_bytes[RV64_WORD_NUM_LIMBS..],
+            [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]
+        );
+        record.header.rd_val =
+            u32::from_le_bytes(rd_bytes[..RV64_WORD_NUM_LIMBS].try_into().unwrap());
 
         let rs_bytes: [u8; RV64_REGISTER_NUM_LIMBS] = tracing_read(
             state.memory,
@@ -224,8 +228,12 @@ where
             rs_ptr,
             &mut record.header.rs_aux.prev_timestamp,
         );
-        debug_assert_eq!(rs_bytes[RV64_WORD_NUM_LIMBS..], [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]);
-        record.header.rs_val = u32::from_le_bytes(rs_bytes[..RV64_WORD_NUM_LIMBS].try_into().unwrap());
+        debug_assert_eq!(
+            rs_bytes[RV64_WORD_NUM_LIMBS..],
+            [0u8; RV64_REGISTER_NUM_LIMBS - RV64_WORD_NUM_LIMBS]
+        );
+        record.header.rs_val =
+            u32::from_le_bytes(rs_bytes[..RV64_WORD_NUM_LIMBS].try_into().unwrap());
 
         let input_ptr = record.header.rs_val;
         let output_ptr = record.header.rd_val;
@@ -343,12 +351,13 @@ where
 
                 if row_idx == 0 {
                     debug_assert!(RV64_CELL_BITS * RV64_WORD_NUM_LIMBS >= self.address_bits);
-                    let limb_shift_bits =
-                        RV64_CELL_BITS * RV64_WORD_NUM_LIMBS - self.address_bits;
+                    let limb_shift_bits = RV64_CELL_BITS * RV64_WORD_NUM_LIMBS - self.address_bits;
 
                     self.bitwise_lookup_chip.request_range(
-                        (header.rd_val.to_le_bytes()[RV64_WORD_NUM_LIMBS - 1] as u32) << limb_shift_bits,
-                        (header.rs_val.to_le_bytes()[RV64_WORD_NUM_LIMBS - 1] as u32) << limb_shift_bits,
+                        (header.rd_val.to_le_bytes()[RV64_WORD_NUM_LIMBS - 1] as u32)
+                            << limb_shift_bits,
+                        (header.rs_val.to_le_bytes()[RV64_WORD_NUM_LIMBS - 1] as u32)
+                            << limb_shift_bits,
                     );
                     self.bitwise_lookup_chip.request_range(
                         (output_len_bytes[F_NUM_BYTES - 1] as u32) << limb_shift_bits,

--- a/extensions/keccak256/circuit/src/extension/cuda.rs
+++ b/extensions/keccak256/circuit/src/extension/cuda.rs
@@ -75,18 +75,18 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Keccak256>
 }
 
 #[derive(Clone)]
-pub struct Keccak256Rv32GpuBuilder;
+pub struct Keccak256Rv64GpuBuilder;
 
 type E = GpuBabyBearPoseidon2Engine;
 
-impl VmBuilder<E> for Keccak256Rv32GpuBuilder {
-    type VmConfig = Keccak256Rv32Config;
+impl VmBuilder<E> for Keccak256Rv64GpuBuilder {
+    type VmConfig = Keccak256Rv64Config;
     type SystemChipInventory = SystemChipInventoryGPU;
     type RecordArena = DenseRecordArena;
 
     fn create_chip_complex(
         &self,
-        config: &Keccak256Rv32Config,
+        config: &Keccak256Rv64Config,
         circuit: AirInventory<<E as StarkEngine>::SC>,
         device_ctx: &openvm_stark_backend::EngineDeviceCtx<E>,
     ) -> Result<
@@ -105,8 +105,8 @@ impl VmBuilder<E> for Keccak256Rv32GpuBuilder {
             device_ctx,
         )?;
         let inventory = &mut chip_complex.inventory;
-        VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, &config.rv32i, inventory)?;
-        VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, &config.rv32m, inventory)?;
+        VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, &config.rv64i, inventory)?;
+        VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, &config.rv64m, inventory)?;
         VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, &config.io, inventory)?;
         VmProverExtension::<E, _, _>::extend_prover(
             &Keccak256GpuProverExt,

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -183,8 +183,8 @@ where
 
         // execute xorin
         result[..len].copy_from_slice(&record.inner.buffer_limbs[..len]);
-        for i in 0..len {
-            result[i] ^= record.inner.input_limbs[i];
+        for (i, byte) in result.iter_mut().enumerate().take(len) {
+            *byte ^= record.inner.input_limbs[i];
         }
         let bytes_covered = num_reads * DEFAULT_BLOCK_SIZE;
         result[len..bytes_covered].copy_from_slice(&record.inner.buffer_limbs[len..bytes_covered]);
@@ -239,10 +239,10 @@ impl<F: PrimeField32> TraceFiller<F> for XorinVmFiller {
         trace_row.instruction.start_timestamp = F::from_u32(record.timestamp);
 
         for i in 0..(record.len as usize / DEFAULT_BLOCK_SIZE) {
-            trace_row.sponge.is_padding_bytes[i as usize] = F::ZERO;
+            trace_row.sponge.is_padding_bytes[i] = F::ZERO;
         }
         for i in (record.len as usize / DEFAULT_BLOCK_SIZE)..(KECCAK_RATE_MEM_OPS) {
-            trace_row.sponge.is_padding_bytes[i as usize] = F::ONE;
+            trace_row.sponge.is_padding_bytes[i] = F::ONE;
         }
 
         let mut timestamp = record.timestamp;

--- a/extensions/pairing/circuit/src/cuda.rs
+++ b/extensions/pairing/circuit/src/cuda.rs
@@ -1,7 +1,7 @@
-//! GPU builder where the [Rv32ModularBuilder], [AlgebraProverExt], and [EccProverExt] will use
+//! GPU builder where the [Rv64ModularBuilder], [AlgebraProverExt], and [EccProverExt] will use
 //! either cuda tracegen or hybrid CPU tracegen depending on what [openvm_algebra_circuit] and
 //! [openvm_ecc_circuit] crates export.
-use openvm_algebra_circuit::{AlgebraProverExt, Rv32ModularBuilder};
+use openvm_algebra_circuit::{AlgebraProverExt, Rv64ModularBuilder};
 use openvm_circuit::{
     arch::{
         AirInventory, ChipInventoryError, DenseRecordArena, VmBuilder, VmChipComplex,
@@ -13,21 +13,21 @@ use openvm_cuda_backend::{BabyBearPoseidon2GpuEngine as GpuBabyBearPoseidon2Engi
 use openvm_ecc_circuit::EccProverExt;
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 
-use crate::{PairingProverExt, Rv32PairingConfig};
+use crate::{PairingProverExt, Rv64PairingConfig};
 
 #[derive(Clone)]
-pub struct Rv32PairingGpuBuilder;
+pub struct Rv64PairingGpuBuilder;
 
 type E = GpuBabyBearPoseidon2Engine;
 
-impl VmBuilder<E> for Rv32PairingGpuBuilder {
-    type VmConfig = Rv32PairingConfig;
+impl VmBuilder<E> for Rv64PairingGpuBuilder {
+    type VmConfig = Rv64PairingConfig;
     type SystemChipInventory = SystemChipInventoryGPU;
     type RecordArena = DenseRecordArena;
 
     fn create_chip_complex(
         &self,
-        config: &Rv32PairingConfig,
+        config: &Rv64PairingConfig,
         circuit: AirInventory<BabyBearPoseidon2Config>,
         device_ctx: &openvm_stark_backend::EngineDeviceCtx<E>,
     ) -> Result<
@@ -40,7 +40,7 @@ impl VmBuilder<E> for Rv32PairingGpuBuilder {
         ChipInventoryError,
     > {
         let mut chip_complex = VmBuilder::<E>::create_chip_complex(
-            &Rv32ModularBuilder,
+            &Rv64ModularBuilder,
             &config.modular,
             circuit,
             device_ctx,

--- a/extensions/pairing/circuit/src/lib.rs
+++ b/extensions/pairing/circuit/src/lib.rs
@@ -18,7 +18,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
         mod cuda;
         pub use cuda::*;
-        pub use cuda::Rv32PairingGpuBuilder as Rv64PairingBuilder;
+        pub use cuda::Rv64PairingGpuBuilder as Rv64PairingBuilder;
     } else {
         pub use config::Rv64PairingCpuBuilder as Rv64PairingBuilder;
     }

--- a/guest-libs/ff_derive/tests/lib.rs
+++ b/guest-libs/ff_derive/tests/lib.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use eyre::Result;
     use num_bigint::BigUint;
-    use openvm_algebra_circuit::{Rv32ModularBuilder, Rv32ModularConfig};
+    use openvm_algebra_circuit::{Rv64ModularBuilder, Rv64ModularConfig};
     use openvm_algebra_transpiler::ModularTranspilerExtension;
     use openvm_circuit::utils::{air_test, test_system_config};
     use openvm_instructions::exe::VmExe;
@@ -21,8 +21,8 @@ mod tests {
     type F = BabyBear;
 
     #[cfg(test)]
-    fn test_rv32modular_config(moduli: Vec<BigUint>) -> Rv32ModularConfig {
-        let mut config = Rv32ModularConfig::new(moduli);
+    fn test_rv64modular_config(moduli: Vec<BigUint>) -> Rv64ModularConfig {
+        let mut config = Rv64ModularConfig::new(moduli);
         config.system = test_system_config();
         config
     }
@@ -31,7 +31,7 @@ mod tests {
     fn test_full_limbs() -> Result<()> {
         let moduli = ["39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319"]
         .map(|s| BigUint::from_str(s).unwrap());
-        let config = test_rv32modular_config(moduli.to_vec());
+        let config = test_rv64modular_config(moduli.to_vec());
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "full_limbs",
@@ -46,14 +46,14 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularBuilder, config, openvm_exe);
+        air_test(Rv64ModularBuilder, config, openvm_exe);
         Ok(())
     }
 
     #[test]
     fn test_fermat() -> Result<()> {
         let moduli = ["65537"].map(|s| BigUint::from_str(s).unwrap());
-        let config = test_rv32modular_config(moduli.to_vec());
+        let config = test_rv64modular_config(moduli.to_vec());
         let elf =
             build_example_program_at_path(get_programs_dir!("tests/programs"), "fermat", &config)?;
         let openvm_exe = VmExe::from_elf(
@@ -65,14 +65,14 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularBuilder, config, openvm_exe);
+        air_test(Rv64ModularBuilder, config, openvm_exe);
         Ok(())
     }
 
     #[test]
     fn test_sqrt() -> Result<()> {
         let moduli = ["357686312646216567629137"].map(|s| BigUint::from_str(s).unwrap());
-        let config = test_rv32modular_config(moduli.to_vec());
+        let config = test_rv64modular_config(moduli.to_vec());
         let elf =
             build_example_program_at_path(get_programs_dir!("tests/programs"), "sqrt", &config)?;
         let openvm_exe = VmExe::from_elf(
@@ -84,7 +84,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularBuilder, config, openvm_exe);
+        air_test(Rv64ModularBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -93,7 +93,7 @@ mod tests {
         let moduli =
             ["52435875175126190479447740508185965837690552500527637822603658699938581184513"]
                 .map(|s| BigUint::from_str(s).unwrap());
-        let config = test_rv32modular_config(moduli.to_vec());
+        let config = test_rv64modular_config(moduli.to_vec());
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "constants",
@@ -108,7 +108,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularBuilder, config, openvm_exe);
+        air_test(Rv64ModularBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -117,7 +117,7 @@ mod tests {
         let moduli =
             ["52435875175126190479447740508185965837690552500527637822603658699938581184513"]
                 .map(|s| BigUint::from_str(s).unwrap());
-        let config = test_rv32modular_config(moduli.to_vec());
+        let config = test_rv64modular_config(moduli.to_vec());
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "from_u128",
@@ -132,7 +132,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularBuilder, config, openvm_exe);
+        air_test(Rv64ModularBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -141,7 +141,7 @@ mod tests {
         let moduli =
             ["52435875175126190479447740508185965837690552500527637822603658699938581184513"]
                 .map(|s| BigUint::from_str(s).unwrap());
-        let config = test_rv32modular_config(moduli.to_vec());
+        let config = test_rv64modular_config(moduli.to_vec());
         let elf = build_example_program_at_path_with_features(
             get_programs_dir!("tests/programs"),
             "batch_inversion",
@@ -157,7 +157,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularBuilder, config, openvm_exe);
+        air_test(Rv64ModularBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -166,7 +166,7 @@ mod tests {
         let moduli =
             ["52435875175126190479447740508185965837690552500527637822603658699938581184513"]
                 .map(|s| BigUint::from_str(s).unwrap());
-        let config = test_rv32modular_config(moduli.to_vec());
+        let config = test_rv64modular_config(moduli.to_vec());
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "operations",
@@ -181,7 +181,7 @@ mod tests {
                 .with_extension(ModularTranspilerExtension),
         )?;
 
-        air_test(Rv32ModularBuilder, config, openvm_exe);
+        air_test(Rv64ModularBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/k256/tests/lib.rs
+++ b/guest-libs/k256/tests/lib.rs
@@ -7,7 +7,7 @@ mod guest_tests {
         utils::{air_test, test_system_config},
     };
     use openvm_ecc_circuit::{
-        CurveConfig, Rv32WeierstrassBuilder, Rv32WeierstrassConfig, SECP256K1_CONFIG,
+        CurveConfig, Rv64WeierstrassBuilder, Rv64WeierstrassConfig, SECP256K1_CONFIG,
     };
     use openvm_ecc_transpiler::EccTranspilerExtension;
     use openvm_riscv_transpiler::{
@@ -23,15 +23,15 @@ mod guest_tests {
     type F = BabyBear;
 
     #[cfg(test)]
-    fn test_rv32weierstrass_config(curves: Vec<CurveConfig>) -> Rv32WeierstrassConfig {
-        let mut config = Rv32WeierstrassConfig::new(curves);
+    fn test_rv64weierstrass_config(curves: Vec<CurveConfig>) -> Rv64WeierstrassConfig {
+        let mut config = Rv64WeierstrassConfig::new(curves);
         *config.as_mut() = test_system_config();
         config
     }
 
     #[test]
     fn test_add() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
         let elf =
             build_example_program_at_path(get_programs_dir!("tests/programs"), "add", &config)?;
         let openvm_exe = VmExe::from_elf(
@@ -43,13 +43,13 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
     #[test]
     fn test_mul() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
         let elf =
             build_example_program_at_path(get_programs_dir!("tests/programs"), "mul", &config)?;
         let openvm_exe = VmExe::from_elf(
@@ -61,13 +61,13 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
     #[test]
     fn test_linear_combination() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "linear_combination",
@@ -82,7 +82,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -96,8 +96,8 @@ mod guest_tests {
             derive::VmConfig,
         };
         use openvm_ecc_circuit::{
-            CurveConfig, Rv32WeierstrassBuilder, Rv32WeierstrassConfig,
-            Rv32WeierstrassConfigExecutor,
+            CurveConfig, Rv64WeierstrassBuilder, Rv64WeierstrassConfig,
+            Rv64WeierstrassConfigExecutor,
         };
         use openvm_sha2_circuit::{Sha2, Sha2Executor, Sha2ProverExt};
         use serde::{Deserialize, Serialize};
@@ -123,7 +123,7 @@ mod guest_tests {
         #[derive(Clone, Debug, VmConfig, Serialize, Deserialize)]
         pub struct EcdsaConfig {
             #[config(generics = true)]
-            pub weierstrass: Rv32WeierstrassConfig,
+            pub weierstrass: Rv64WeierstrassConfig,
             #[extension]
             pub sha2: Sha2,
         }
@@ -131,7 +131,7 @@ mod guest_tests {
         impl EcdsaConfig {
             pub fn new(curves: Vec<CurveConfig>) -> Self {
                 Self {
-                    weierstrass: Rv32WeierstrassConfig::new(curves),
+                    weierstrass: Rv64WeierstrassConfig::new(curves),
                     sha2: Default::default(),
                 }
             }
@@ -172,7 +172,7 @@ mod guest_tests {
                 ChipInventoryError,
             > {
                 let mut chip_complex = VmBuilder::<E>::create_chip_complex(
-                    &Rv32WeierstrassBuilder,
+                    &Rv64WeierstrassBuilder,
                     &config.weierstrass,
                     circuit,
                     device_ctx,
@@ -209,7 +209,7 @@ mod guest_tests {
             > {
                 let mut chip_complex =
                     VmBuilder::<BabyBearPoseidon2GpuEngine>::create_chip_complex(
-                        &Rv32WeierstrassBuilder,
+                        &Rv64WeierstrassBuilder,
                         &config.weierstrass,
                         circuit,
                         device_ctx,
@@ -247,7 +247,7 @@ mod guest_tests {
 
     #[test]
     fn test_scalar_sqrt() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![SECP256K1_CONFIG.clone()]);
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "scalar_sqrt",
@@ -262,7 +262,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/keccak256/tests/lib.rs
+++ b/guest-libs/keccak256/tests/lib.rs
@@ -6,11 +6,11 @@ mod tests {
     use hex::FromHex;
     use openvm_circuit::{arch::VmExecutor, utils::air_test_with_min_segments};
     use openvm_instructions::exe::VmExe;
-    #[cfg(feature = "cuda")]
-    use openvm_keccak256_circuit::Keccak256Rv32GpuBuilder as TestBuilder;
     use openvm_keccak256_circuit::Keccak256Rv64Config;
     #[cfg(not(feature = "cuda"))]
     use openvm_keccak256_circuit::Keccak256Rv64CpuBuilder as TestBuilder;
+    #[cfg(feature = "cuda")]
+    use openvm_keccak256_circuit::Keccak256Rv64GpuBuilder as TestBuilder;
     use openvm_keccak256_transpiler::Keccak256TranspilerExtension;
     use openvm_riscv_transpiler::{
         Rv64ITranspilerExtension, Rv64IoTranspilerExtension, Rv64MTranspilerExtension,

--- a/guest-libs/p256/tests/lib.rs
+++ b/guest-libs/p256/tests/lib.rs
@@ -7,7 +7,7 @@ mod guest_tests {
         utils::{air_test, test_system_config},
     };
     use openvm_ecc_circuit::{
-        CurveConfig, Rv32WeierstrassBuilder, Rv32WeierstrassConfig, P256_CONFIG,
+        CurveConfig, Rv64WeierstrassBuilder, Rv64WeierstrassConfig, P256_CONFIG,
     };
     use openvm_ecc_transpiler::EccTranspilerExtension;
     use openvm_riscv_transpiler::{
@@ -23,15 +23,15 @@ mod guest_tests {
     type F = BabyBear;
 
     #[cfg(test)]
-    fn test_rv32weierstrass_config(curves: Vec<CurveConfig>) -> Rv32WeierstrassConfig {
-        let mut config = Rv32WeierstrassConfig::new(curves);
+    fn test_rv64weierstrass_config(curves: Vec<CurveConfig>) -> Rv64WeierstrassConfig {
+        let mut config = Rv64WeierstrassConfig::new(curves);
         *config.as_mut() = test_system_config();
         config
     }
 
     #[test]
     fn test_add() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![P256_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![P256_CONFIG.clone()]);
         let elf =
             build_example_program_at_path(get_programs_dir!("tests/programs"), "add", &config)?;
         let openvm_exe = VmExe::from_elf(
@@ -43,13 +43,13 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
     #[test]
     fn test_mul() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![P256_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![P256_CONFIG.clone()]);
         let elf =
             build_example_program_at_path(get_programs_dir!("tests/programs"), "mul", &config)?;
         let openvm_exe = VmExe::from_elf(
@@ -61,13 +61,13 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
     #[test]
     fn test_linear_combination() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![P256_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![P256_CONFIG.clone()]);
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "linear_combination",
@@ -82,7 +82,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -96,8 +96,8 @@ mod guest_tests {
             derive::VmConfig,
         };
         use openvm_ecc_circuit::{
-            CurveConfig, Rv32WeierstrassBuilder, Rv32WeierstrassConfig,
-            Rv32WeierstrassConfigExecutor,
+            CurveConfig, Rv64WeierstrassBuilder, Rv64WeierstrassConfig,
+            Rv64WeierstrassConfigExecutor,
         };
         use openvm_sha2_circuit::{Sha2, Sha2Executor, Sha2ProverExt};
         use serde::{Deserialize, Serialize};
@@ -123,7 +123,7 @@ mod guest_tests {
         #[derive(Clone, Debug, VmConfig, Serialize, Deserialize)]
         pub struct EcdsaConfig {
             #[config(generics = true)]
-            pub weierstrass: Rv32WeierstrassConfig,
+            pub weierstrass: Rv64WeierstrassConfig,
             #[extension]
             pub sha2: Sha2,
         }
@@ -131,7 +131,7 @@ mod guest_tests {
         impl EcdsaConfig {
             pub fn new(curves: Vec<CurveConfig>) -> Self {
                 Self {
-                    weierstrass: Rv32WeierstrassConfig::new(curves),
+                    weierstrass: Rv64WeierstrassConfig::new(curves),
                     sha2: Default::default(),
                 }
             }
@@ -172,7 +172,7 @@ mod guest_tests {
                 ChipInventoryError,
             > {
                 let mut chip_complex = VmBuilder::<E>::create_chip_complex(
-                    &Rv32WeierstrassBuilder,
+                    &Rv64WeierstrassBuilder,
                     &config.weierstrass,
                     circuit,
                     device_ctx,
@@ -209,7 +209,7 @@ mod guest_tests {
             > {
                 let mut chip_complex =
                     VmBuilder::<BabyBearPoseidon2GpuEngine>::create_chip_complex(
-                        &Rv32WeierstrassBuilder,
+                        &Rv64WeierstrassBuilder,
                         &config.weierstrass,
                         circuit,
                         device_ctx,
@@ -247,7 +247,7 @@ mod guest_tests {
 
     #[test]
     fn test_scalar_sqrt() -> Result<()> {
-        let config = test_rv32weierstrass_config(vec![P256_CONFIG.clone()]);
+        let config = test_rv64weierstrass_config(vec![P256_CONFIG.clone()]);
         let elf = build_example_program_at_path(
             get_programs_dir!("tests/programs"),
             "scalar_sqrt",
@@ -262,7 +262,7 @@ mod guest_tests {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 }

--- a/guest-libs/pairing/tests/lib.rs
+++ b/guest-libs/pairing/tests/lib.rs
@@ -9,14 +9,14 @@ mod bn254 {
         bn256::{Fq12, Fq2, Fr, G1Affine, G2Affine},
         ff::Field,
     };
-    use openvm_algebra_circuit::{Fp2Extension, Rv32ModularConfig};
+    use openvm_algebra_circuit::{Fp2Extension, Rv64ModularConfig};
     use openvm_algebra_transpiler::{Fp2TranspilerExtension, ModularTranspilerExtension};
     use openvm_circuit::utils::{
         air_test, air_test_impl, air_test_with_min_segments, test_system_config,
         TestStarkEngine as Engine,
     };
     use openvm_ecc_circuit::{
-        CurveConfig, Rv32WeierstrassBuilder, Rv32WeierstrassConfig, WeierstrassExtension,
+        CurveConfig, Rv64WeierstrassBuilder, Rv64WeierstrassConfig, WeierstrassExtension,
     };
     use openvm_ecc_guest::{
         algebra::{field::FieldExtension, IntMod},
@@ -25,7 +25,7 @@ mod bn254 {
     use openvm_ecc_transpiler::EccTranspilerExtension;
     use openvm_instructions::exe::VmExe;
     use openvm_pairing_circuit::{
-        PairingCurve, PairingExtension, Rv32PairingBuilder, Rv32PairingConfig,
+        PairingCurve, PairingExtension, Rv64PairingBuilder, Rv64PairingConfig,
     };
     use openvm_pairing_guest::{
         bn254::{BN254_COMPLEX_STRUCT_NAME, BN254_MODULUS},
@@ -47,15 +47,15 @@ mod bn254 {
     type F = BabyBear;
 
     #[cfg(test)]
-    pub fn get_testing_config() -> Rv32PairingConfig {
+    pub fn get_testing_config() -> Rv64PairingConfig {
         let primes = [BN254_MODULUS.clone()];
         let complex_struct_names = [BN254_COMPLEX_STRUCT_NAME.to_string()];
         let primes_with_names = complex_struct_names
             .into_iter()
             .zip(primes.clone())
             .collect::<Vec<_>>();
-        Rv32PairingConfig {
-            modular: Rv32ModularConfig::new(primes.to_vec()),
+        Rv64PairingConfig {
+            modular: Rv64ModularConfig::new(primes.to_vec()),
             fp2: Fp2Extension::new(primes_with_names),
             weierstrass: WeierstrassExtension::new(vec![]),
             pairing: PairingExtension::new(vec![PairingCurve::Bn254]),
@@ -63,8 +63,8 @@ mod bn254 {
     }
 
     #[cfg(test)]
-    fn test_rv32weierstrass_config(curves: Vec<CurveConfig>) -> Rv32WeierstrassConfig {
-        let mut config = Rv32WeierstrassConfig::new(curves);
+    fn test_rv64weierstrass_config(curves: Vec<CurveConfig>) -> Rv64WeierstrassConfig {
+        let mut config = Rv64WeierstrassConfig::new(curves);
         *config.as_mut() = test_system_config();
         config
     }
@@ -72,7 +72,7 @@ mod bn254 {
     #[test]
     fn test_bn_ec() -> Result<()> {
         let curve = PairingCurve::Bn254.curve_config();
-        let config = test_rv32weierstrass_config(vec![curve]);
+        let config = test_rv64weierstrass_config(vec![curve]);
         let elf = build_example_program_at_path_with_features(
             get_programs_dir!("tests/programs"),
             "bn_ec",
@@ -88,7 +88,7 @@ mod bn254 {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -124,7 +124,7 @@ mod bn254 {
             .map(F::from_u8)
             .collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
         Ok(())
     }
 
@@ -182,7 +182,7 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -231,7 +231,7 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -284,7 +284,7 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -341,7 +341,7 @@ mod bn254 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -400,7 +400,7 @@ mod bn254 {
         // Don't run debugger because it's slow
         air_test_impl::<Engine, _>(
             SystemParams::new_for_testing(22),
-            Rv32PairingBuilder,
+            Rv64PairingBuilder,
             get_testing_config(),
             openvm_exe,
             vec![io_all],
@@ -460,7 +460,7 @@ mod bn254 {
             .flat_map(|w| w.to_le_bytes())
             .map(F::from_u8)
             .collect();
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
         Ok(())
     }
 }
@@ -474,7 +474,7 @@ mod bls12_381 {
     };
     use num_bigint::BigUint;
     use num_traits::{self, FromPrimitive};
-    use openvm_algebra_circuit::{Fp2Extension, Rv32ModularConfig};
+    use openvm_algebra_circuit::{Fp2Extension, Rv64ModularConfig};
     use openvm_algebra_transpiler::{Fp2TranspilerExtension, ModularTranspilerExtension};
     use openvm_circuit::{
         arch::instructions::exe::VmExe,
@@ -484,7 +484,7 @@ mod bls12_381 {
         },
     };
     use openvm_ecc_circuit::{
-        CurveConfig, Rv32WeierstrassBuilder, Rv32WeierstrassConfig, WeierstrassExtension,
+        CurveConfig, Rv64WeierstrassBuilder, Rv64WeierstrassConfig, WeierstrassExtension,
     };
     use openvm_ecc_guest::{
         algebra::{field::FieldExtension, IntMod},
@@ -492,7 +492,7 @@ mod bls12_381 {
     };
     use openvm_ecc_transpiler::EccTranspilerExtension;
     use openvm_pairing_circuit::{
-        PairingCurve, PairingExtension, Rv32PairingBuilder, Rv32PairingConfig,
+        PairingCurve, PairingExtension, Rv64PairingBuilder, Rv64PairingConfig,
     };
     use openvm_pairing_guest::{
         bls12_381::{
@@ -517,15 +517,15 @@ mod bls12_381 {
     type F = BabyBear;
 
     #[cfg(test)]
-    pub fn get_testing_config() -> Rv32PairingConfig {
+    pub fn get_testing_config() -> Rv64PairingConfig {
         let primes = [BLS12_381_MODULUS.clone()];
         let complex_struct_names = [BLS12_381_COMPLEX_STRUCT_NAME.to_string()];
         let primes_with_names = complex_struct_names
             .into_iter()
             .zip(primes.clone())
             .collect::<Vec<_>>();
-        Rv32PairingConfig {
-            modular: Rv32ModularConfig::new(primes.to_vec()),
+        Rv64PairingConfig {
+            modular: Rv64ModularConfig::new(primes.to_vec()),
             fp2: Fp2Extension::new(primes_with_names),
             weierstrass: WeierstrassExtension::new(vec![]),
             pairing: PairingExtension::new(vec![PairingCurve::Bls12_381]),
@@ -533,8 +533,8 @@ mod bls12_381 {
     }
 
     #[cfg(test)]
-    fn test_rv32weierstrass_config(curves: Vec<CurveConfig>) -> Rv32WeierstrassConfig {
-        let mut config = Rv32WeierstrassConfig::new(curves);
+    fn test_rv64weierstrass_config(curves: Vec<CurveConfig>) -> Rv64WeierstrassConfig {
+        let mut config = Rv64WeierstrassConfig::new(curves);
         *config.as_mut() = test_system_config();
         config
     }
@@ -548,7 +548,7 @@ mod bls12_381 {
             a: BigUint::ZERO,
             b: BigUint::from_u8(4).unwrap(),
         };
-        let config = test_rv32weierstrass_config(vec![curve]);
+        let config = test_rv64weierstrass_config(vec![curve]);
         let elf = build_example_program_at_path_with_features(
             get_programs_dir!("tests/programs"),
             "bls_ec",
@@ -564,7 +564,7 @@ mod bls12_381 {
                 .with_extension(EccTranspilerExtension)
                 .with_extension(ModularTranspilerExtension),
         )?;
-        air_test(Rv32WeierstrassBuilder, config, openvm_exe);
+        air_test(Rv64WeierstrassBuilder, config, openvm_exe);
         Ok(())
     }
 
@@ -600,7 +600,7 @@ mod bls12_381 {
             .map(F::from_u8)
             .collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
         Ok(())
     }
 
@@ -659,7 +659,7 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -708,7 +708,7 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -767,7 +767,7 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -823,7 +823,7 @@ mod bls12_381 {
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
 
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io_all], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io_all], 1);
         Ok(())
     }
 
@@ -882,7 +882,7 @@ mod bls12_381 {
         // Don't run debugger because it's slow
         air_test_impl::<Engine, _>(
             SystemParams::new_for_testing(22),
-            Rv32PairingBuilder,
+            Rv64PairingBuilder,
             get_testing_config(),
             openvm_exe,
             vec![io_all],
@@ -942,7 +942,7 @@ mod bls12_381 {
             .flat_map(|w| w.to_le_bytes())
             .map(F::from_u8)
             .collect();
-        air_test_with_min_segments(Rv32PairingBuilder, config, openvm_exe, vec![io], 1);
+        air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
         Ok(())
     }
 }


### PR DESCRIPTION
- also fixes lint