### PR TITLE
feat: implement vm execution instance that uses rvr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9235,6 +9235,7 @@ dependencies = [
  "openvm-platform",
  "openvm-rv32im-circuit",
  "openvm-rv32im-transpiler",
+ "openvm-sdk",
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "openvm-toolchain-tests",

--- a/crates/rvr/rvr-openvm-test-utils/Cargo.toml
+++ b/crates/rvr/rvr-openvm-test-utils/Cargo.toml
@@ -8,10 +8,11 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-openvm-circuit = { workspace = true, features = ["test-utils", "rvr"] }
+openvm-circuit = { workspace = true, features = ["test-utils"] }
 openvm-instructions.workspace = true
 openvm-platform.workspace = true
 openvm-rv32im-circuit.workspace = true
+openvm-sdk.workspace = true
 openvm-rv32im-transpiler.workspace = true
 openvm-stark-backend = { workspace = true, features = ["test-utils"] }
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
@@ -23,3 +24,7 @@ rvr-openvm-lift.workspace = true
 rvr-state.workspace = true
 
 eyre.workspace = true
+
+[features]
+default = []
+rvr = ["openvm-sdk/rvr"]

--- a/crates/rvr/rvr-openvm-test-utils/src/lib.rs
+++ b/crates/rvr/rvr-openvm-test-utils/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared test helpers: compile with rvr, compare against OpenVM interpreter.
 
+#![cfg(feature = "rvr")]
 #![allow(dead_code)]
 
 use std::{
@@ -12,7 +13,7 @@ use eyre::Result;
 use openvm_circuit::arch::{
     execution_mode::{MeteredCostCtx, MeteredCtx, Segment},
     rvr as rvr_openvm, Executor, ExecutorInventory, MeteredExecutor, Streams, SystemConfig,
-    VirtualMachine, VmExecutionConfig,
+    VirtualMachine, VmBuilder, VmExecutionConfig, VmState,
 };
 use openvm_instructions::{
     exe::VmExe,
@@ -136,7 +137,7 @@ pub fn rvr_extension_ctx<E>(
 
 /// Holds keygen results and an extension registry. Provides `compare` to run
 /// rvr against the OpenVM interpreter for any `ExecutionMode`.
-pub struct VmTestHarness<VB: openvm_circuit::arch::VmBuilder<Engine>> {
+pub struct VmTestHarness<VB: VmBuilder<Engine>> {
     config: VB::VmConfig,
     vm: VirtualMachine<Engine, VB>,
     pk: MultiStarkProvingKey<BabyBearPoseidon2Config>,
@@ -146,7 +147,7 @@ pub struct VmTestHarness<VB: openvm_circuit::arch::VmBuilder<Engine>> {
 
 impl<VB> VmTestHarness<VB>
 where
-    VB: openvm_circuit::arch::VmBuilder<Engine>,
+    VB: VmBuilder<Engine>,
     VB::VmConfig: Clone,
     <VB::VmConfig as VmExecutionConfig<F>>::Executor: Executor<F> + MeteredExecutor<F>,
 {
@@ -236,7 +237,7 @@ where
         compare_full_memory: bool,
     ) -> Result<()> {
         // OpenVM reference
-        let interpreter = self.vm.executor().instance(exe)?;
+        let interpreter = self.vm.executor().instance(exe, &self.air_idx)?;
         let interp_state = interpreter.execute(self.make_streams(&input), None)?;
 
         // rvr execution
@@ -382,7 +383,7 @@ where
 
 fn assert_full_guest_memory(
     label: &str,
-    interp_state: &openvm_circuit::arch::VmState<F>,
+    interp_state: &VmState<F>,
     rvr_memory: &rvr_state::GuardedMemory,
 ) {
     for addr in 0..MEM_SIZE as u32 {

--- a/crates/rvr/rvr-openvm-test-utils/src/lib.rs
+++ b/crates/rvr/rvr-openvm-test-utils/src/lib.rs
@@ -247,7 +247,8 @@ where
         } else {
             rvr_openvm::compile_with_extensions(exe, &self.extensions)?
         };
-        let rvr_result = rvr_openvm::execute(&compiled, exe, input_stream, Default::default())?;
+        let rvr_result =
+            rvr_openvm::execute(&compiled, exe, input_stream, Vec::new(), Default::default())?;
 
         // Compare PC + registers
         assert_eq!(
@@ -303,6 +304,7 @@ where
             &compiled,
             exe,
             VecDeque::from(input),
+            Vec::new(),
             metered_cost_config,
             Default::default(),
         )?;
@@ -372,6 +374,7 @@ where
             &compiled,
             exe,
             VecDeque::from(input),
+            Vec::new(),
             trace_config,
             Default::default(),
         )?;

--- a/crates/rvr/rvr-openvm-tests/Cargo.toml
+++ b/crates/rvr/rvr-openvm-tests/Cargo.toml
@@ -12,21 +12,21 @@ publish = false
 path = "src/lib.rs"
 
 [dev-dependencies]
-rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
+rvr-openvm-test-utils.workspace = true
 rvr-openvm.workspace = true
 rvr-openvm-ir.workspace = true
 rvr-openvm-lift.workspace = true
 rvr-openvm-ext-deferral.workspace = true
 
 openvm.workspace = true
-openvm-circuit = { workspace = true, features = ["test-utils", "rvr"] }
-openvm-deferral-circuit = { workspace = true, features = ["rvr"] }
+openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-deferral-circuit.workspace = true
 openvm-deferral-transpiler.workspace = true
 openvm-instructions.workspace = true
 openvm-platform.workspace = true
-openvm-rv32im-circuit = { workspace = true, features = ["rvr"] }
+openvm-rv32im-circuit.workspace = true
 openvm-rv32im-transpiler.workspace = true
-openvm-sdk = { workspace = true, features = ["rvr"] }
+openvm-sdk.workspace = true
 openvm-stark-backend = { workspace = true, features = ["test-utils"] }
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
 openvm-toolchain-tests.workspace = true
@@ -37,3 +37,7 @@ openvm-verify-stark-host.workspace = true
 eyre.workspace = true
 serde.workspace = true
 tempfile.workspace = true
+
+[features]
+default = []
+rvr = ["rvr-openvm-test-utils/rvr"]

--- a/crates/rvr/rvr-openvm-tests/Cargo.toml
+++ b/crates/rvr/rvr-openvm-tests/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 path = "src/lib.rs"
 
 [dev-dependencies]
-rvr-openvm-test-utils.workspace = true
+rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
 rvr-openvm.workspace = true
 rvr-openvm-ir.workspace = true
 rvr-openvm-lift.workspace = true
@@ -20,13 +20,13 @@ rvr-openvm-ext-deferral.workspace = true
 
 openvm.workspace = true
 openvm-circuit = { workspace = true, features = ["test-utils", "rvr"] }
-openvm-deferral-circuit.workspace = true
+openvm-deferral-circuit = { workspace = true, features = ["rvr"] }
 openvm-deferral-transpiler.workspace = true
 openvm-instructions.workspace = true
 openvm-platform.workspace = true
-openvm-rv32im-circuit.workspace = true
+openvm-rv32im-circuit = { workspace = true, features = ["rvr"] }
 openvm-rv32im-transpiler.workspace = true
-openvm-sdk.workspace = true
+openvm-sdk = { workspace = true, features = ["rvr"] }
 openvm-stark-backend = { workspace = true, features = ["test-utils"] }
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
 openvm-toolchain-tests.workspace = true

--- a/crates/rvr/rvr-openvm-tests/tests/asm_and_bench.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/asm_and_bench.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 use eyre::Result;
 use rvr_openvm_test_utils::{self as utils, ExecutionMode::Pure};
 

--- a/crates/rvr/rvr-openvm-tests/tests/debug_info.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/debug_info.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 //! End-to-end validation for source annotations and DWARF line info.
 
 use std::{

--- a/crates/rvr/rvr-openvm-tests/tests/deferral.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/deferral.rs
@@ -293,7 +293,7 @@ impl DeferralTestHarness {
         let input_stream = streams.input_stream.clone();
 
         // OpenVM reference
-        let interpreter = self.vm.executor().instance(exe)?;
+        let interpreter = self.vm.executor().instance(exe, &self.air_idx)?;
         let interp_state = interpreter.execute(streams, None)?;
 
         // rvr compile + execute

--- a/crates/rvr/rvr-openvm-tests/tests/deferral.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/deferral.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 //! Deferral extension integration tests.
 //!
 //! Builds guest programs that use deferral, transpiles them with the deferral

--- a/crates/rvr/rvr-openvm-tests/tests/guest_programs.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/guest_programs.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 use eyre::Result;
 use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 use rvr_openvm_test_utils::{self as utils, ExecutionMode::Pure, F};

--- a/crates/rvr/rvr-openvm-tests/tests/metered.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/metered.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 use eyre::Result;
 use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 use rvr_openvm_test_utils::{self as utils, ExecutionMode::*, F};

--- a/crates/rvr/rvr-openvm-tests/tests/metered_cost.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/metered_cost.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 use eyre::Result;
 use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 use rvr_openvm_test_utils::{self as utils, ExecutionMode::MeteredCost, F};

--- a/crates/rvr/rvr-openvm-tests/tests/riscv_tests.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/riscv_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 use eyre::Result;
 use rvr_openvm_test_utils::{self as utils, ExecutionMode::Pure};
 

--- a/crates/rvr/rvr-state/src/memory.rs
+++ b/crates/rvr/rvr-state/src/memory.rs
@@ -82,9 +82,15 @@ impl GuardedMemory {
         })
     }
 
-    /// Returns pointer to usable memory (after first guard page).
+    /// Returns a read-only pointer to usable memory (after first guard page).
     #[must_use]
-    pub const fn as_ptr(&self) -> *mut u8 {
+    pub const fn as_ptr(&self) -> *const u8 {
+        unsafe { self.region.as_ptr().cast::<u8>().add(GUARD_SIZE) }
+    }
+
+    /// Returns a mutable pointer to usable memory (after first guard page).
+    #[must_use]
+    pub const fn as_mut_ptr(&mut self) -> *mut u8 {
         unsafe { self.region.as_ptr().cast::<u8>().add(GUARD_SIZE) }
     }
 
@@ -102,7 +108,7 @@ impl GuardedMemory {
     pub unsafe fn copy_from(&mut self, offset: usize, data: &[u8]) {
         debug_assert!(offset + data.len() <= self.memory_size);
         unsafe {
-            std::ptr::copy_nonoverlapping(data.as_ptr(), self.as_ptr().add(offset), data.len());
+            std::ptr::copy_nonoverlapping(data.as_ptr(), self.as_mut_ptr().add(offset), data.len());
         }
     }
 
@@ -124,7 +130,7 @@ impl GuardedMemory {
     /// Caller must ensure `offset < self.size()`.
     pub unsafe fn write_u8(&mut self, offset: usize, value: u8) {
         debug_assert!(offset < self.memory_size);
-        unsafe { *self.as_ptr().add(offset) = value };
+        unsafe { *self.as_mut_ptr().add(offset) = value };
     }
 }
 

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -340,19 +340,6 @@ where
     }
 }
 
-#[cfg(feature = "rvr")]
-impl SdkVmConfig {
-    pub fn create_rvr_extensions<F>(
-        &self,
-        air_idx: &[usize],
-    ) -> rvr_openvm_lift::ExtensionRegistry<F>
-    where
-        F: VmField,
-    {
-        self.to_inner().create_rvr_extensions(air_idx)
-    }
-}
-
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 type SC = BabyBearPoseidon2Config;
 impl<E> VmBuilder<E> for SdkVmCpuBuilder

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -21,9 +21,13 @@ use openvm_rv32im_circuit::*;
 use openvm_rv32im_transpiler::*;
 use openvm_sha2_circuit::*;
 use openvm_sha2_transpiler::*;
+#[cfg(feature = "rvr")]
+use openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_backend::{p3_field::Field, StarkEngine, StarkProtocolConfig, Val};
 use openvm_stark_sdk::config::baby_bear_poseidon2::F;
 use openvm_transpiler::transpiler::Transpiler;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::ExtensionRegistry;
 use serde::{Deserialize, Serialize};
 cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
@@ -323,9 +327,9 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    fn create_rvr_extensions(&self, air_idx: &[usize]) -> rvr_openvm_lift::ExtensionRegistry<F>
+    fn create_rvr_extensions(&self, air_idx: &[usize]) -> ExtensionRegistry<F>
     where
-        F: openvm_stark_backend::p3_field::PrimeField32,
+        F: PrimeField32,
     {
         self.to_inner().create_rvr_extensions(air_idx)
     }

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -321,6 +321,14 @@ where
     ) -> Result<ExecutorInventory<Self::Executor>, ExecutorInventoryError> {
         self.to_inner().create_executors()
     }
+
+    #[cfg(feature = "rvr")]
+    fn create_rvr_extensions(&self, air_idx: &[usize]) -> rvr_openvm_lift::ExtensionRegistry<F>
+    where
+        F: openvm_stark_backend::p3_field::PrimeField32,
+    {
+        self.to_inner().create_rvr_extensions(air_idx)
+    }
 }
 
 impl<SC: StarkProtocolConfig> VmCircuitConfig<SC> for SdkVmConfig

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -316,11 +316,24 @@ where
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
     ) -> Result<Vec<u8>, SdkError> {
-        let exe = self.convert_to_exe(app_exe)?;
-        let instance = self
-            .executor
-            .instance(&exe)
-            .map_err(VirtualMachineError::from)?;
+        // rvr's `instance` needs an executor-to-AIR index map, only available
+        // post-keygen; route through `app_prover` to get a `VirtualMachine`.
+        #[cfg(feature = "rvr")]
+        let instance = {
+            let app_prover = self.app_prover(app_exe)?;
+            let exe = app_prover.exe();
+            app_prover
+                .vm()
+                .interpreter(&exe)
+                .map_err(VirtualMachineError::from)?
+        };
+        #[cfg(not(feature = "rvr"))]
+        let instance = {
+            let exe = self.convert_to_exe(app_exe)?;
+            self.executor
+                .instance(&exe)
+                .map_err(VirtualMachineError::from)?
+        };
         let final_memory = instance
             .execute(inputs, None)
             .map_err(VirtualMachineError::from)?

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -109,6 +109,7 @@ rvr = [
     "dep:openvm-platform",
     "dep:libloading",
     "dep:tempfile",
+    "openvm-circuit-derive/rvr",
 ]
 # Disable bounds checking in memory operations for performance
 unprotected = []

--- a/crates/vm/derive/Cargo.toml
+++ b/crates/vm/derive/Cargo.toml
@@ -17,4 +17,5 @@ itertools = { workspace = true }
 
 [features]
 aot = []
+rvr = []
 tco = []

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -903,9 +903,7 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
     let mut extend_rvr = Vec::new();
     let mut execution_where_predicates: Vec<syn::WherePredicate> = Vec::new();
     let mut circuit_where_predicates: Vec<syn::WherePredicate> = Vec::new();
-    let mut rvr_where_predicates: Vec<syn::WherePredicate> = Vec::new();
     execution_where_predicates.push(parse_quote! { F: ::openvm_circuit::arch::VmField });
-    rvr_where_predicates.push(parse_quote! { F: ::openvm_circuit::arch::VmField });
 
     let source_field_ty = source_field.ty.clone();
 
@@ -924,14 +922,11 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
         execution_where_predicates.push(parse_quote! {
             #extension_ty: ::openvm_circuit::arch::VmExecutionExtension<F, Executor = #executor_type>
         });
-        rvr_where_predicates.push(parse_quote! {
-            #extension_ty: ::rvr_openvm_lift::VmRvrExtension<F>
-        });
         extend_rvr.push(quote! {
             <#extension_ty as ::rvr_openvm_lift::VmRvrExtension<F>>::extend_rvr(
                 &self.#ext_field_name,
-                registry,
-                ctx,
+                &mut registry,
+                &ctx,
             );
         });
         create_airs.push(quote! {
@@ -951,15 +946,8 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
     circuit_where_predicates.push(parse_quote! {
         #source_field_ty: ::openvm_circuit::arch::VmCircuitConfig<SC>
     });
-    rvr_where_predicates.push(parse_quote! {
-        #source_field_ty: ::openvm_circuit::arch::VmExecutionConfig<F, Executor = #source_executor_type>
-    });
-    rvr_where_predicates.push(parse_quote! {
-        #source_field_ty: ::rvr_openvm_lift::VmRvrExtension<F>
-    });
     let execution_where_clause = quote! { where #(#execution_where_predicates),* };
     let circuit_where_clause = quote! { where #(#circuit_where_predicates),* };
-    let rvr_where_clause = quote! { where #(#rvr_where_predicates),* };
 
     let executor_type = Ident::new(&format!("{name}Executor"), name.span());
 
@@ -989,40 +977,13 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
                 #(#create_executors)*
                 Ok(inventory)
             }
-        }
 
-        impl<SC: openvm_stark_backend::StarkProtocolConfig> ::openvm_circuit::arch::VmCircuitConfig<SC> for #name #circuit_where_clause {
-            fn create_airs(
-                &self,
-            ) -> Result<::openvm_circuit::arch::AirInventory<SC>, ::openvm_circuit::arch::AirInventoryError> {
-                let mut inventory = self.#source_name.create_airs()?;
-                #(#create_airs)*
-                Ok(inventory)
-            }
-        }
-
-        #[cfg(feature = "rvr")]
-        impl<F: ::openvm_circuit::arch::VmField> ::rvr_openvm_lift::VmRvrExtension<F> for #name #rvr_where_clause {
-            fn extend_rvr(
-                &self,
-                registry: &mut ::rvr_openvm_lift::ExtensionRegistry<F>,
-                ctx: &::rvr_openvm_lift::RvrExtensionCtx,
-            ) {
-                <#source_field_ty as ::rvr_openvm_lift::VmRvrExtension<F>>::extend_rvr(
-                    &self.#source_name,
-                    registry,
-                    ctx,
-                );
-                #(#extend_rvr)*
-            }
-        }
-
-        #[cfg(feature = "rvr")]
-        impl #name {
-            pub fn create_rvr_extensions<F>(
+            #[cfg(feature = "rvr")]
+            fn create_rvr_extensions(
                 &self,
                 air_idx: &[usize],
-            ) -> ::rvr_openvm_lift::ExtensionRegistry<F> #rvr_where_clause {
+            ) -> ::rvr_openvm_lift::ExtensionRegistry<F>
+            {
                 let inventory = <Self as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_executors(self)
                     .expect("create_executors failed in create_rvr_extensions");
                 let opcode_to_executor_idx = inventory
@@ -1033,13 +994,22 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
                     opcode_to_executor_idx,
                     air_idx.to_vec(),
                 );
-                let mut registry = ::rvr_openvm_lift::ExtensionRegistry::new();
-                <Self as ::rvr_openvm_lift::VmRvrExtension<F>>::extend_rvr(
-                    self,
-                    &mut registry,
-                    &ctx,
+                let mut registry = <#source_field_ty as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_rvr_extensions(
+                    &self.#source_name,
+                    air_idx,
                 );
+                #(#extend_rvr)*
                 registry
+            }
+        }
+
+        impl<SC: openvm_stark_backend::StarkProtocolConfig> ::openvm_circuit::arch::VmCircuitConfig<SC> for #name #circuit_where_clause {
+            fn create_airs(
+                &self,
+            ) -> Result<::openvm_circuit::arch::AirInventory<SC>, ::openvm_circuit::arch::AirInventoryError> {
+                let mut inventory = self.#source_name.create_airs()?;
+                #(#create_airs)*
+                Ok(inventory)
             }
         }
 

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
     p3_field::Field, EngineDeviceCtx, StarkEngine, StarkProtocolConfig, Val,
 };
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::VmRvrExtension;
+use rvr_openvm_lift::ExtensionRegistry;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::{AnyEnum, VmChipComplex, BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, PROGRAM_AIR_ID};
@@ -72,6 +72,11 @@ pub trait VmExecutionConfig<F> {
 
     fn create_executors(&self)
         -> Result<ExecutorInventory<Self::Executor>, ExecutorInventoryError>;
+
+    #[cfg(feature = "rvr")]
+    fn create_rvr_extensions(&self, air_idx: &[usize]) -> ExtensionRegistry<F>
+    where
+        F: PrimeField32;
 }
 
 pub trait VmCircuitConfig<SC: StarkProtocolConfig> {
@@ -334,9 +339,6 @@ impl AsMut<SystemConfig> for SystemConfig {
 
 // Default implementation uses no init file
 impl InitFileGenerator for SystemConfig {}
-
-#[cfg(feature = "rvr")]
-impl<F: PrimeField32> VmRvrExtension<F> for SystemConfig {}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, new)]
 pub struct AddressSpaceHostConfig {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -82,6 +82,9 @@ pub enum ExecutionError {
     Inventory(#[from] ExecutorInventoryError),
     #[error("static program error: {0}")]
     Static(#[from] StaticProgramError),
+    #[cfg(feature = "rvr")]
+    #[error("rvr execution failed: {0}")]
+    RvrExecution(String),
 }
 
 /// Errors in the program that can be statically analyzed before runtime.

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -207,6 +207,22 @@ impl SegmentationCtx {
         self.config.base_field_size = base_field_size;
     }
 
+    pub fn widths(&self) -> &[usize] {
+        &self.widths
+    }
+
+    pub fn interactions(&self) -> &[usize] {
+        &self.interactions
+    }
+
+    pub fn config(&self) -> &SegmentationConfig {
+        &self.config
+    }
+
+    pub fn segment_check_insns(&self) -> u64 {
+        self.segment_check_insns
+    }
+
     /// Calculate the maximum trace height and corresponding air name
     #[inline(always)]
     fn calculate_max_trace_height_with_name(&self, trace_heights: &[u32]) -> (u32, &str) {

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -142,12 +142,12 @@ impl SegmentationLimits {
 pub struct SegmentationCtx {
     pub segments: Vec<Segment>,
     pub(crate) air_names: Vec<String>,
-    pub(crate) widths: Vec<usize>,
-    interactions: Vec<usize>,
-    pub(crate) config: SegmentationConfig,
+    pub widths: Vec<usize>,
+    pub interactions: Vec<usize>,
+    pub config: SegmentationConfig,
     pub instret: u64,
     pub instrets_until_check: u64,
-    pub(super) segment_check_insns: u64,
+    pub segment_check_insns: u64,
     /// Checkpoint of trace heights at last known state where all thresholds satisfied
     pub(crate) checkpoint_trace_heights: Vec<u32>,
     /// Instruction count at the checkpoint
@@ -205,22 +205,6 @@ impl SegmentationCtx {
 
     pub fn set_base_field_size(&mut self, base_field_size: usize) {
         self.config.base_field_size = base_field_size;
-    }
-
-    pub fn widths(&self) -> &[usize] {
-        &self.widths
-    }
-
-    pub fn interactions(&self) -> &[usize] {
-        &self.interactions
-    }
-
-    pub fn config(&self) -> &SegmentationConfig {
-        &self.config
-    }
-
-    pub fn segment_check_insns(&self) -> u64 {
-        self.segment_check_insns
     }
 
     /// Calculate the maximum trace height and corresponding air name

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -214,6 +214,7 @@ pub fn execute<F: PrimeField32>(
     compiled: &RvrCompiled,
     exe: &VmExe<F>,
     input_stream: VecDeque<Vec<F>>,
+    hint_stream: Vec<u8>,
     deferral: DeferralData,
 ) -> Result<RvrExecutionResult, ExecuteError> {
     let mut memory = GuardedMemory::new(MEM_SIZE)?;
@@ -226,6 +227,8 @@ pub fn execute<F: PrimeField32>(
         memory.as_ptr(),
         deferral,
     );
+    io_state.hint_stream = hint_stream;
+    io_state.hint_pos = 0;
     let callbacks = build_callbacks(&mut io_state);
     // SAFETY: state pointer is valid and matches the tracer variant.
     unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
@@ -253,6 +256,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
     compiled: &RvrCompiled,
     exe: &VmExe<F>,
     input_stream: VecDeque<Vec<F>>,
+    hint_stream: Vec<u8>,
     metered_cost_config: MeteredCostConfig,
     deferral: DeferralData,
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
@@ -271,6 +275,8 @@ pub fn execute_metered_cost<F: PrimeField32>(
         memory.as_ptr(),
         deferral,
     );
+    io_state.hint_stream = hint_stream;
+    io_state.hint_pos = 0;
     let callbacks = build_callbacks(&mut io_state);
     // SAFETY: state pointer is valid and matches the tracer variant.
     unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
@@ -305,6 +311,7 @@ pub fn execute_with_limit<F: PrimeField32>(
     compiled: &RvrCompiled,
     exe: &VmExe<F>,
     input_stream: VecDeque<Vec<F>>,
+    hint_stream: Vec<u8>,
     instruction_limit: u64,
     deferral: DeferralData,
 ) -> Result<RvrLimitedResult, ExecuteError> {
@@ -319,6 +326,8 @@ pub fn execute_with_limit<F: PrimeField32>(
         memory.as_ptr(),
         deferral,
     );
+    io_state.hint_stream = hint_stream;
+    io_state.hint_pos = 0;
     let callbacks = build_callbacks(&mut io_state);
     // SAFETY: state pointer is valid and matches the tracer variant.
     unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
@@ -356,6 +365,7 @@ pub fn execute_metered_cost_with_limit<F: PrimeField32>(
     compiled: &RvrCompiled,
     exe: &VmExe<F>,
     input_stream: VecDeque<Vec<F>>,
+    hint_stream: Vec<u8>,
     metered_cost_config: MeteredCostConfig,
     instruction_limit: u64,
     deferral: DeferralData,
@@ -376,6 +386,8 @@ pub fn execute_metered_cost_with_limit<F: PrimeField32>(
         memory.as_ptr(),
         deferral,
     );
+    io_state.hint_stream = hint_stream;
+    io_state.hint_pos = 0;
     let callbacks = build_callbacks(&mut io_state);
     // SAFETY: state pointer is valid and matches the tracer variant.
     unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
@@ -416,6 +428,7 @@ pub fn execute_metered<F: PrimeField32>(
     compiled: &RvrCompiled,
     exe: &VmExe<F>,
     input_stream: VecDeque<Vec<F>>,
+    hint_stream: Vec<u8>,
     trace_config: MeteredConfig,
     deferral: DeferralData,
 ) -> Result<RvrMeteredResult, ExecuteError> {
@@ -446,6 +459,8 @@ pub fn execute_metered<F: PrimeField32>(
         memory.as_ptr(),
         deferral,
     );
+    io_state.hint_stream = hint_stream;
+    io_state.hint_pos = 0;
     let callbacks = build_callbacks(&mut io_state);
     // SAFETY: state pointer is valid and matches the tracer variant.
     unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -3,6 +3,7 @@
 use std::{collections::VecDeque, ffi::c_void};
 
 use openvm_instructions::exe::VmExe;
+use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, SeedableRng};
 use rvr_state::GuardedMemory;
@@ -215,7 +216,7 @@ pub fn execute<F: PrimeField32>(
     input_stream: VecDeque<Vec<F>>,
     deferral: DeferralData,
 ) -> Result<RvrExecutionResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(openvm_platform::memory::MEM_SIZE)?;
+    let mut memory = GuardedMemory::new(MEM_SIZE)?;
     let mut tracer_data = PureTracerData;
     let mut state = init_rvr_state(exe, &mut memory);
     state.tracer = PureTracer(&mut tracer_data);
@@ -255,7 +256,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
     metered_cost_config: MeteredCostConfig,
     deferral: DeferralData,
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(openvm_platform::memory::MEM_SIZE)?;
+    let mut memory = GuardedMemory::new(MEM_SIZE)?;
     let mut tracer_data = MeteredCostData::default();
     let mut state = init_rvr_state_with_metered_cost(exe, &mut memory);
     state.tracer = MeteredCostMeter(&mut tracer_data);
@@ -307,7 +308,7 @@ pub fn execute_with_limit<F: PrimeField32>(
     instruction_limit: u64,
     deferral: DeferralData,
 ) -> Result<RvrLimitedResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(openvm_platform::memory::MEM_SIZE)?;
+    let mut memory = GuardedMemory::new(MEM_SIZE)?;
     let mut tracer_data = PureTracerData;
     let mut state = init_rvr_state(exe, &mut memory);
     state.tracer = PureTracer(&mut tracer_data);
@@ -359,7 +360,7 @@ pub fn execute_metered_cost_with_limit<F: PrimeField32>(
     instruction_limit: u64,
     deferral: DeferralData,
 ) -> Result<RvrMeteredCostLimitedResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(openvm_platform::memory::MEM_SIZE)?;
+    let mut memory = GuardedMemory::new(MEM_SIZE)?;
     let mut tracer_data = MeteredCostData::default();
     let mut state = init_rvr_state_with_metered_cost(exe, &mut memory);
     state.tracer = MeteredCostMeter(&mut tracer_data);
@@ -418,7 +419,7 @@ pub fn execute_metered<F: PrimeField32>(
     trace_config: MeteredConfig,
     deferral: DeferralData,
 ) -> Result<RvrMeteredResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(openvm_platform::memory::MEM_SIZE)?;
+    let mut memory = GuardedMemory::new(MEM_SIZE)?;
     let mut tracer_data = MeteredTracerData::default();
     let mut state = init_rvr_state_with_metered(exe, &mut memory);
     state.tracer = MeteredTracer(&mut tracer_data);
@@ -467,5 +468,5 @@ pub fn execute_metered<F: PrimeField32>(
         ));
     }
 
-    Ok(seg_state.into_result())
+    Ok(seg_state.into_result(state, memory, io_state.public_values))
 }

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -224,7 +224,7 @@ pub fn execute<F: PrimeField32>(
 
     let mut io_state = build_io_state(
         convert_input_stream(&input_stream),
-        memory.as_ptr(),
+        memory.as_mut_ptr(),
         deferral,
     );
     io_state.hint_stream = hint_stream;
@@ -272,7 +272,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
 
     let mut io_state = build_io_state(
         convert_input_stream(&input_stream),
-        memory.as_ptr(),
+        memory.as_mut_ptr(),
         deferral,
     );
     io_state.hint_stream = hint_stream;
@@ -323,7 +323,7 @@ pub fn execute_with_limit<F: PrimeField32>(
 
     let mut io_state = build_io_state(
         convert_input_stream(&input_stream),
-        memory.as_ptr(),
+        memory.as_mut_ptr(),
         deferral,
     );
     io_state.hint_stream = hint_stream;
@@ -383,7 +383,7 @@ pub fn execute_metered_cost_with_limit<F: PrimeField32>(
 
     let mut io_state = build_io_state(
         convert_input_stream(&input_stream),
-        memory.as_ptr(),
+        memory.as_mut_ptr(),
         deferral,
     );
     io_state.hint_stream = hint_stream;
@@ -456,7 +456,7 @@ pub fn execute_metered<F: PrimeField32>(
 
     let mut io_state = build_io_state(
         convert_input_stream(&input_stream),
-        memory.as_ptr(),
+        memory.as_mut_ptr(),
         deferral,
     );
     io_state.hint_stream = hint_stream;

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -862,7 +862,7 @@ where
         state.tracer.on_check = Some(metered_periodic_check);
         state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut std::ffi::c_void;
 
-        let mut io_state = build_io_state(input_stream, memory.as_ptr(), Default::default());
+        let mut io_state = build_io_state(input_stream, memory.as_mut_ptr(), Default::default());
         io_state.hint_stream = hint_stream;
         io_state.hint_pos = 0;
         io_state.public_values = read_public_values_from_guest_memory(&guest_memory);

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -745,14 +745,14 @@ where
             self.exe.as_ref(),
             self.inventory.as_ref(),
             &self.executor_idx_to_air_idx,
-            ctx.segmentation_ctx.widths(),
-            ctx.segmentation_ctx.interactions(),
+            &ctx.segmentation_ctx.widths,
+            &ctx.segmentation_ctx.interactions,
             &constant_trace_heights,
             &self.system_config,
             None,
         );
-        trace_config.segmentation_config = ctx.segmentation_ctx.config().clone();
-        trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns();
+        trace_config.segmentation_config = ctx.segmentation_ctx.config.clone();
+        trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns;
         trace_config.initial_trace_heights = ctx.trace_heights.clone();
         trace_config.is_constant = ctx.is_trace_height_constant.clone();
 
@@ -819,14 +819,14 @@ where
             self.exe.as_ref(),
             self.inventory.as_ref(),
             &self.executor_idx_to_air_idx,
-            ctx.segmentation_ctx.widths(),
-            ctx.segmentation_ctx.interactions(),
+            &ctx.segmentation_ctx.widths,
+            &ctx.segmentation_ctx.interactions,
             &constant_trace_heights,
             &self.system_config,
             None,
         );
-        trace_config.segmentation_config = ctx.segmentation_ctx.config().clone();
-        trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns();
+        trace_config.segmentation_config = ctx.segmentation_ctx.config.clone();
+        trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns;
         trace_config.initial_trace_heights = ctx.trace_heights.clone();
         trace_config.is_constant = ctx.is_trace_height_constant.clone();
 

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -36,8 +36,7 @@ use crate::{
             read_rv32_regs_from_guest_memory, state_from_rvr, streams_from_io_state,
             streams_to_io_seed, write_rvr_memory_to_guest_memory,
         },
-        ExecutionError, ExecutorInventory, MeteredExecutor, StaticProgramError, Streams,
-        SystemConfig, VmState,
+        ExecutionError, ExecutorInventory, MeteredExecutor, Streams, SystemConfig, VmState,
     },
     system::memory::{
         merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory, CHUNK as MERKLE_CHUNK,
@@ -839,11 +838,8 @@ where
         }
         .map_err(map_rvr_compile_error)?;
 
-        let mut memory = GuardedMemory::new(MEM_SIZE).map_err(|err| {
-            ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
-                err: err.to_string(),
-            })
-        })?;
+        let mut memory = GuardedMemory::new(MEM_SIZE)
+            .map_err(|err| ExecutionError::RvrExecution(err.to_string()))?;
         let mut tracer_data = MeteredTracerData::default();
         let mut state = init_rvr_state_with_metered(self.exe.as_ref(), &mut memory);
         state.tracer = MeteredTracer(&mut tracer_data);

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -728,6 +728,12 @@ where
         ctx: MeteredCtx,
     ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
         let inputs = inputs.into();
+        let input_stream = inputs.input_stream;
+        let hint_stream: Vec<u8> = inputs
+            .hint_stream
+            .into_iter()
+            .map(|f| f.as_canonical_u32() as u8)
+            .collect();
 
         let constant_trace_heights: Vec<Option<usize>> = ctx
             .trace_heights
@@ -762,7 +768,8 @@ where
         let metered_result = execute_metered(
             &compiled_metered,
             self.exe.as_ref(),
-            inputs.input_stream,
+            input_stream,
+            hint_stream,
             trace_config,
             Default::default(),
         )

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -1,28 +1,58 @@
 //! Per-chip metered execution: page tracking and segmentation
 //! matching OpenVM's `MeteredCtx`.
 
+use std::sync::Arc;
+
 use openvm_instructions::{
     exe::VmExe, riscv::RV32_MEMORY_AS, LocalOpcode, SystemOpcode, VmOpcode, DEFERRAL_AS,
 };
+use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
-use rvr_state::TracerState;
+use rvr_openvm_lift::ExtensionRegistry;
+use rvr_state::{GuardedMemory, TracerState};
 
+use super::{
+    build_callbacks, build_io_state,
+    compile::ChipMapping,
+    compile_metered, compile_metered_with_extensions, execute_metered, register_and_execute,
+    state::{init_rvr_state_with_metered, state_as_void_ptr, MeteredState},
+};
 use crate::{
     arch::{
-        execution_mode::metered::{
-            ctx::DEFAULT_PAGE_BITS,
-            segment_ctx::{
-                SegmentationConfig, DEFAULT_INTERACTION_CONSTANT_OVERHEAD,
-                DEFAULT_SEGMENT_CHECK_INSNS,
+        execution_mode::{
+            metered::{
+                ctx::DEFAULT_PAGE_BITS,
+                segment_ctx::{
+                    SegmentationConfig, DEFAULT_INTERACTION_CONSTANT_OVERHEAD,
+                    DEFAULT_SEGMENT_CHECK_INSNS,
+                },
             },
+            MeteredCtx, Segment,
         },
-        ExecutorInventory, SystemConfig,
+        vm::{
+            copy_guest_memory_to_rvr_memory, ensure_rvr_outcome, map_rvr_compile_error,
+            map_rvr_execute_error, read_public_values_from_guest_memory,
+            read_rv32_regs_from_guest_memory, state_from_rvr, streams_from_io_state,
+            streams_to_io_seed, write_rvr_memory_to_guest_memory,
+        },
+        ExecutionError, ExecutorInventory, MeteredExecutor, StaticProgramError, Streams,
+        SystemConfig, VmState,
     },
-    system::memory::{merkle::public_values::PUBLIC_VALUES_AS, CHUNK as MERKLE_CHUNK},
+    system::memory::{
+        merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory, CHUNK as MERKLE_CHUNK,
+    },
 };
 
 const NO_CHIP: u32 = u32::MAX;
+
+pub struct RvrMeteredInstance<F: PrimeField32, E> {
+    pub(crate) system_config: SystemConfig,
+    pub(crate) exe: Arc<VmExe<F>>,
+    pub(crate) inventory: Arc<ExecutorInventory<E>>,
+    pub(crate) executor_idx_to_air_idx: Vec<usize>,
+    pub(crate) extensions: ExtensionRegistry<F>,
+}
 
 // ── C-compatible tracer struct ───────────────────────────────────────────────
 
@@ -131,8 +161,8 @@ pub struct MeteredConfig {
 
 impl MeteredConfig {
     /// Extract chip mapping for compilation.
-    pub fn chip_mapping(&self) -> super::compile::ChipMapping {
-        super::compile::ChipMapping {
+    pub fn chip_mapping(&self) -> ChipMapping {
+        ChipMapping {
             pc_to_chip: self.pc_to_chip.clone(),
             hint_store_chip_idx: self.hint_store_chip_idx,
             chip_widths: None,
@@ -271,6 +301,9 @@ pub struct RvrSegment {
 pub struct RvrMeteredResult {
     pub segments: Vec<RvrSegment>,
     pub instret: u64,
+    pub state: MeteredState,
+    pub memory: GuardedMemory,
+    pub public_values: Vec<u8>,
 }
 
 /// Runtime state for metered segmentation.
@@ -640,10 +673,18 @@ impl SegmentationState {
     }
 
     /// Consume and return the result.
-    pub fn into_result(self) -> RvrMeteredResult {
+    pub fn into_result(
+        self,
+        state: MeteredState,
+        memory: GuardedMemory,
+        public_values: Vec<u8>,
+    ) -> RvrMeteredResult {
         RvrMeteredResult {
             instret: self.instret,
             segments: self.segments,
+            state,
+            memory,
+            public_values,
         }
     }
 }
@@ -674,4 +715,202 @@ pub unsafe extern "C" fn metered_periodic_check(t: *mut MeteredTracerData) {
     tracer.check_counter += seg_state.config().segment_check_insns as u32;
 
     seg_state.on_periodic_check(mem_len, pv_len, deferral_len);
+}
+
+impl<F, E> RvrMeteredInstance<F, E>
+where
+    F: PrimeField32,
+    E: MeteredExecutor<F>,
+{
+    pub fn execute_metered(
+        &self,
+        inputs: impl Into<Streams<F>>,
+        ctx: MeteredCtx,
+    ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
+        let inputs = inputs.into();
+
+        let constant_trace_heights: Vec<Option<usize>> = ctx
+            .trace_heights
+            .iter()
+            .zip(ctx.is_trace_height_constant.iter())
+            .map(|(&height, &is_constant)| is_constant.then_some(height as usize))
+            .collect();
+
+        let mut trace_config = build_metered_config(
+            self.exe.as_ref(),
+            self.inventory.as_ref(),
+            &self.executor_idx_to_air_idx,
+            ctx.segmentation_ctx.widths(),
+            ctx.segmentation_ctx.interactions(),
+            &constant_trace_heights,
+            &self.system_config,
+            None,
+        );
+        trace_config.segmentation_config = ctx.segmentation_ctx.config().clone();
+        trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns();
+        trace_config.initial_trace_heights = ctx.trace_heights.clone();
+        trace_config.is_constant = ctx.is_trace_height_constant.clone();
+
+        let chips = trace_config.chip_mapping();
+        let compiled_metered = if self.extensions.is_empty() {
+            compile_metered(self.exe.as_ref(), &chips)
+        } else {
+            compile_metered_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
+        }
+        .map_err(map_rvr_compile_error)?;
+
+        let metered_result = execute_metered(
+            &compiled_metered,
+            self.exe.as_ref(),
+            inputs.input_stream,
+            trace_config,
+            Default::default(),
+        )
+        .map_err(map_rvr_execute_error)?;
+
+        let segments = metered_result
+            .segments
+            .into_iter()
+            .map(|segment| Segment {
+                instret_start: segment.instret_start,
+                num_insns: segment.num_insns,
+                trace_heights: segment.trace_heights,
+            })
+            .collect();
+
+        let final_state = state_from_rvr(
+            &self.system_config,
+            self.exe.as_ref(),
+            metered_result.state.pc,
+            &metered_result.state.regs,
+            &metered_result.memory,
+            &metered_result.public_values,
+        );
+
+        Ok((segments, final_state))
+    }
+
+    pub fn execute_metered_from_state(
+        &self,
+        from_state: VmState<F, GuestMemory>,
+        ctx: MeteredCtx,
+    ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
+        let pc = from_state.pc();
+        let mut guest_memory = from_state.memory;
+        let (input_stream, hint_stream, deferrals) = streams_to_io_seed(from_state.streams);
+        let rng = from_state.rng;
+        #[cfg(feature = "metrics")]
+        let metrics = from_state.metrics;
+
+        let constant_trace_heights: Vec<Option<usize>> = ctx
+            .trace_heights
+            .iter()
+            .zip(ctx.is_trace_height_constant.iter())
+            .map(|(&height, &is_constant)| is_constant.then_some(height as usize))
+            .collect();
+
+        let mut trace_config = build_metered_config(
+            self.exe.as_ref(),
+            self.inventory.as_ref(),
+            &self.executor_idx_to_air_idx,
+            ctx.segmentation_ctx.widths(),
+            ctx.segmentation_ctx.interactions(),
+            &constant_trace_heights,
+            &self.system_config,
+            None,
+        );
+        trace_config.segmentation_config = ctx.segmentation_ctx.config().clone();
+        trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns();
+        trace_config.initial_trace_heights = ctx.trace_heights.clone();
+        trace_config.is_constant = ctx.is_trace_height_constant.clone();
+
+        let chips = trace_config.chip_mapping();
+        let compiled_metered = if self.extensions.is_empty() {
+            compile_metered(self.exe.as_ref(), &chips)
+        } else {
+            compile_metered_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
+        }
+        .map_err(map_rvr_compile_error)?;
+
+        let mut memory = GuardedMemory::new(MEM_SIZE).map_err(|err| {
+            ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
+                err: err.to_string(),
+            })
+        })?;
+        let mut tracer_data = MeteredTracerData::default();
+        let mut state = init_rvr_state_with_metered(self.exe.as_ref(), &mut memory);
+        state.tracer = MeteredTracer(&mut tracer_data);
+        state.pc = pc;
+        state
+            .regs
+            .copy_from_slice(&read_rv32_regs_from_guest_memory(&guest_memory));
+        copy_guest_memory_to_rvr_memory(&guest_memory, &mut memory);
+
+        let mut seg_state = SegmentationState::new(trace_config);
+        state.tracer.trace_heights = seg_state.trace_heights_ptr();
+        state.tracer.mem_page_buf = seg_state.mem_page_buf_ptr();
+        state.tracer.pv_page_buf = seg_state.pv_page_buf_ptr();
+        state.tracer.deferral_page_buf = seg_state.deferral_page_buf_ptr();
+        state.tracer.mem_page_buf_len = 0;
+        state.tracer.pv_page_buf_len = 0;
+        state.tracer.deferral_page_buf_len = 0;
+        state.tracer.last_mem_page = NO_LAST_PAGE;
+        state.tracer.check_counter = seg_state.config().segment_check_insns as u32;
+        state.tracer.on_check = Some(metered_periodic_check);
+        state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut std::ffi::c_void;
+
+        let mut io_state = build_io_state(input_stream, memory.as_ptr(), Default::default());
+        io_state.hint_stream = hint_stream;
+        io_state.hint_pos = 0;
+        io_state.public_values = read_public_values_from_guest_memory(&guest_memory);
+        io_state.rng = rng;
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe {
+            register_and_execute(&compiled_metered, &callbacks, state_as_void_ptr(&mut state))
+        }
+        .map_err(map_rvr_execute_error)?;
+        ensure_rvr_outcome(
+            "metered execution from state",
+            state.is_terminated(),
+            state.is_suspended(),
+            state.result_code(),
+            false,
+        )?;
+
+        seg_state.on_termination(
+            state.tracer.mem_page_buf_len,
+            state.tracer.pv_page_buf_len,
+            state.tracer.deferral_page_buf_len,
+            state.tracer.check_counter,
+        );
+        let public_values = std::mem::take(&mut io_state.public_values);
+        let metered_result = seg_state.into_result(state, memory, public_values);
+
+        let segments = metered_result
+            .segments
+            .into_iter()
+            .map(|segment| Segment {
+                instret_start: segment.instret_start,
+                num_insns: segment.num_insns,
+                trace_heights: segment.trace_heights,
+            })
+            .collect();
+
+        write_rvr_memory_to_guest_memory(
+            &mut guest_memory,
+            &metered_result.state.regs,
+            &metered_result.memory,
+            &metered_result.public_values,
+        );
+        let final_state = VmState::new(
+            metered_result.state.pc,
+            guest_memory,
+            streams_from_io_state(&io_state, deferrals),
+            io_state.rng,
+            #[cfg(feature = "metrics")]
+            metrics,
+        );
+
+        Ok((segments, final_state))
+    }
 }

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -306,7 +306,7 @@ where
         state.tracer.chip_widths = widths_u64.as_ptr();
         state.tracer.cost = 0;
 
-        let mut io_state = build_io_state(input_stream, memory.as_ptr(), Default::default());
+        let mut io_state = build_io_state(input_stream, memory.as_mut_ptr(), Default::default());
         io_state.hint_stream = hint_stream;
         io_state.hint_pos = 0;
         io_state.public_values = read_public_values_from_guest_memory(&guest_memory);

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -24,8 +24,7 @@ use crate::{
             read_rv32_regs_from_guest_memory, state_from_rvr, streams_from_io_state,
             streams_to_io_seed, write_rvr_memory_to_guest_memory,
         },
-        ExecutionError, ExecutorInventory, MeteredExecutor, StaticProgramError, Streams,
-        SystemConfig, VmState,
+        ExecutionError, ExecutorInventory, MeteredExecutor, Streams, SystemConfig, VmState,
     },
     system::memory::online::GuestMemory,
 };
@@ -292,11 +291,8 @@ where
         }
         .map_err(map_rvr_compile_error)?;
 
-        let mut memory = GuardedMemory::new(MEM_SIZE).map_err(|err| {
-            ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
-                err: err.to_string(),
-            })
-        })?;
+        let mut memory = GuardedMemory::new(MEM_SIZE)
+            .map_err(|err| ExecutionError::RvrExecution(err.to_string()))?;
         let mut tracer_data = MeteredCostData::default();
         let mut state = init_rvr_state_with_metered_cost(self.exe.as_ref(), &mut memory);
         state.tracer = MeteredCostMeter(&mut tracer_data);

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -215,6 +215,13 @@ where
         ctx: MeteredCostCtx,
     ) -> Result<(MeteredCostCtx, VmState<F, GuestMemory>), ExecutionError> {
         let inputs = inputs.into();
+        let input_stream = inputs.input_stream;
+        let hint_stream: Vec<u8> = inputs
+            .hint_stream
+            .into_iter()
+            .map(|f| f.as_canonical_u32() as u8)
+            .collect();
+
         let metered_cost_config = build_metered_cost_config(
             self.exe.as_ref(),
             self.inventory.as_ref(),
@@ -234,7 +241,8 @@ where
         let result = execute_metered_cost(
             &compiled,
             self.exe.as_ref(),
-            inputs.input_stream,
+            input_stream,
+            hint_stream,
             metered_cost_config,
             Default::default(),
         )

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -1,10 +1,34 @@
 //! Metered cost execution: per-chip trace cost tracking matching OpenVM's `MeteredCostCtx`.
 
-use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
-use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_state::TracerState;
+use std::sync::Arc;
 
-use crate::arch::ExecutorInventory;
+use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
+use openvm_platform::memory::MEM_SIZE;
+use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_openvm_lift::ExtensionRegistry;
+use rvr_state::{GuardedMemory, TracerState};
+
+use super::{
+    build_callbacks, build_io_state,
+    compile::ChipMapping,
+    compile_metered_cost, compile_metered_cost_with_extensions, execute_metered_cost,
+    register_and_execute,
+    state::{init_rvr_state_with_metered_cost, state_as_void_ptr},
+};
+use crate::{
+    arch::{
+        execution_mode::MeteredCostCtx,
+        vm::{
+            copy_guest_memory_to_rvr_memory, ensure_rvr_outcome, map_rvr_compile_error,
+            map_rvr_execute_error, read_public_values_from_guest_memory,
+            read_rv32_regs_from_guest_memory, state_from_rvr, streams_from_io_state,
+            streams_to_io_seed, write_rvr_memory_to_guest_memory,
+        },
+        ExecutionError, ExecutorInventory, MeteredExecutor, StaticProgramError, Streams,
+        SystemConfig, VmState,
+    },
+    system::memory::online::GuestMemory,
+};
 
 /// Configuration for mapping PCs and memory operations to metering costs.
 pub struct MeteredCostConfig {
@@ -20,8 +44,8 @@ pub struct MeteredCostConfig {
 
 impl MeteredCostConfig {
     /// Extract chip mapping for compilation.
-    pub fn chip_mapping(&self) -> super::compile::ChipMapping {
-        super::compile::ChipMapping {
+    pub fn chip_mapping(&self) -> ChipMapping {
+        ChipMapping {
             pc_to_chip: self.pc_to_chip.clone(),
             hint_store_chip_idx: self.hint_store_chip_idx,
             chip_widths: Some(self.widths.iter().map(|&w| w as u64).collect()),
@@ -30,6 +54,14 @@ impl MeteredCostConfig {
 }
 
 const NO_CHIP: u32 = u32::MAX;
+
+pub struct RvrMeteredCostInstance<F: PrimeField32, E> {
+    pub(crate) system_config: SystemConfig,
+    pub(crate) exe: Arc<VmExe<F>>,
+    pub(crate) inventory: Arc<ExecutorInventory<E>>,
+    pub(crate) executor_idx_to_air_idx: Vec<usize>,
+    pub(crate) extensions: ExtensionRegistry<F>,
+}
 
 /// Build a `MeteredCostConfig` from the program, executor inventory, AIR index mapping, and widths.
 pub fn build_metered_cost_config<F, E>(
@@ -170,4 +202,141 @@ impl std::ops::DerefMut for PureTracer {
 /// Returns `widths_u64` for the C tracer.
 pub fn prepare_metered_cost(config: &MeteredCostConfig) -> Vec<u64> {
     config.widths.iter().map(|&w| w as u64).collect()
+}
+
+impl<F, E> RvrMeteredCostInstance<F, E>
+where
+    F: PrimeField32,
+    E: MeteredExecutor<F>,
+{
+    pub fn execute_metered_cost(
+        &self,
+        inputs: impl Into<Streams<F>>,
+        ctx: MeteredCostCtx,
+    ) -> Result<(MeteredCostCtx, VmState<F, GuestMemory>), ExecutionError> {
+        let inputs = inputs.into();
+        let metered_cost_config = build_metered_cost_config(
+            self.exe.as_ref(),
+            self.inventory.as_ref(),
+            &self.executor_idx_to_air_idx,
+            &ctx.widths,
+            None,
+        );
+        let chips = metered_cost_config.chip_mapping();
+
+        let compiled = if self.extensions.is_empty() {
+            compile_metered_cost(self.exe.as_ref(), &chips)
+        } else {
+            compile_metered_cost_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
+        }
+        .map_err(map_rvr_compile_error)?;
+
+        let result = execute_metered_cost(
+            &compiled,
+            self.exe.as_ref(),
+            inputs.input_stream,
+            metered_cost_config,
+            Default::default(),
+        )
+        .map_err(map_rvr_execute_error)?;
+
+        let mut output_ctx = ctx;
+        output_ctx.instret = result.instret;
+        output_ctx.cost = result.cost;
+
+        let state = state_from_rvr(
+            &self.system_config,
+            self.exe.as_ref(),
+            result.state.pc,
+            &result.state.regs,
+            &result.memory,
+            &[],
+        );
+
+        Ok((output_ctx, state))
+    }
+
+    pub fn execute_metered_cost_from_state(
+        &self,
+        from_state: VmState<F, GuestMemory>,
+        ctx: MeteredCostCtx,
+    ) -> Result<(MeteredCostCtx, VmState<F, GuestMemory>), ExecutionError> {
+        let pc = from_state.pc();
+        let mut guest_memory = from_state.memory;
+        let (input_stream, hint_stream, deferrals) = streams_to_io_seed(from_state.streams);
+        let rng = from_state.rng;
+        #[cfg(feature = "metrics")]
+        let metrics = from_state.metrics;
+
+        let metered_cost_config = build_metered_cost_config(
+            self.exe.as_ref(),
+            self.inventory.as_ref(),
+            &self.executor_idx_to_air_idx,
+            &ctx.widths,
+            None,
+        );
+        let chips = metered_cost_config.chip_mapping();
+
+        let compiled = if self.extensions.is_empty() {
+            compile_metered_cost(self.exe.as_ref(), &chips)
+        } else {
+            compile_metered_cost_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
+        }
+        .map_err(map_rvr_compile_error)?;
+
+        let mut memory = GuardedMemory::new(MEM_SIZE).map_err(|err| {
+            ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
+                err: err.to_string(),
+            })
+        })?;
+        let mut tracer_data = MeteredCostData::default();
+        let mut state = init_rvr_state_with_metered_cost(self.exe.as_ref(), &mut memory);
+        state.tracer = MeteredCostMeter(&mut tracer_data);
+        state.pc = pc;
+        state
+            .regs
+            .copy_from_slice(&read_rv32_regs_from_guest_memory(&guest_memory));
+        copy_guest_memory_to_rvr_memory(&guest_memory, &mut memory);
+
+        let widths_u64 = prepare_metered_cost(&metered_cost_config);
+        state.tracer.chip_widths = widths_u64.as_ptr();
+        state.tracer.cost = 0;
+
+        let mut io_state = build_io_state(input_stream, memory.as_ptr(), Default::default());
+        io_state.hint_stream = hint_stream;
+        io_state.hint_pos = 0;
+        io_state.public_values = read_public_values_from_guest_memory(&guest_memory);
+        io_state.rng = rng;
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe { register_and_execute(&compiled, &callbacks, state_as_void_ptr(&mut state)) }
+            .map_err(map_rvr_execute_error)?;
+        ensure_rvr_outcome(
+            "metered-cost execution from state",
+            state.is_terminated(),
+            state.is_suspended(),
+            state.result_code(),
+            false,
+        )?;
+
+        let mut output_ctx = ctx;
+        output_ctx.instret = state.instret;
+        output_ctx.cost = state.tracer.cost;
+
+        write_rvr_memory_to_guest_memory(
+            &mut guest_memory,
+            &state.regs,
+            &memory,
+            &io_state.public_values,
+        );
+        let to_state = VmState::new(
+            state.pc,
+            guest_memory,
+            streams_from_io_state(&io_state, deferrals),
+            io_state.rng,
+            #[cfg(feature = "metrics")]
+            metrics,
+        );
+
+        Ok((output_ctx, to_state))
+    }
 }

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -7,6 +7,7 @@ pub mod execute;
 pub mod io;
 pub mod metered;
 pub mod metered_cost;
+pub mod pure;
 pub mod state;
 
 pub use compile::{
@@ -22,11 +23,14 @@ pub use execute::{
     RvrExecutionResult, RvrLimitedResult, RvrMeteredCostLimitedResult, RvrMeteredCostResult,
 };
 pub use io::DeferralData;
-pub use metered::{build_metered_config, MeteredConfig, RvrMeteredResult, RvrSegment};
+pub use metered::{
+    build_metered_config, MeteredConfig, RvrMeteredInstance, RvrMeteredResult, RvrSegment,
+};
 pub use metered_cost::{
     build_metered_cost_config, MeteredCostConfig, MeteredCostData, MeteredCostMeter, PureTracer,
-    PureTracerData,
+    PureTracerData, RvrMeteredCostInstance,
 };
+pub use pure::RvrPureInstance;
 pub use rvr_openvm::{
     default_compiler as default_native_compiler, default_compiler_command, default_dwarfdump_cmd,
     default_linker, TracerMode,

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -112,7 +112,7 @@ where
             None => state.suspender.disable(),
         }
 
-        let mut io_state = build_io_state(input_stream, memory.as_ptr(), Default::default());
+        let mut io_state = build_io_state(input_stream, memory.as_mut_ptr(), Default::default());
         io_state.hint_stream = hint_stream;
         io_state.hint_pos = 0;
         io_state.public_values = read_public_values_from_guest_memory(&guest_memory);

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -17,7 +17,7 @@ use crate::{
             read_public_values_from_guest_memory, read_rv32_regs_from_guest_memory, state_from_rvr,
             streams_from_io_state, streams_to_io_seed, write_rvr_memory_to_guest_memory,
         },
-        ExecutionError, StaticProgramError, Streams, SystemConfig, VmState,
+        ExecutionError, Streams, SystemConfig, VmState,
     },
     system::memory::online::GuestMemory,
 };
@@ -96,11 +96,8 @@ where
         #[cfg(feature = "metrics")]
         let metrics = from_state.metrics;
 
-        let mut memory = GuardedMemory::new(MEM_SIZE).map_err(|err| {
-            ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
-                err: err.to_string(),
-            })
-        })?;
+        let mut memory = GuardedMemory::new(MEM_SIZE)
+            .map_err(|err| ExecutionError::RvrExecution(err.to_string()))?;
 
         let mut tracer_data = PureTracerData;
         let mut state = init_rvr_state(self.exe.as_ref(), &mut memory);

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -39,12 +39,18 @@ where
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
         let inputs = inputs.into();
         let input_stream = inputs.input_stream;
+        let hint_stream: Vec<u8> = inputs
+            .hint_stream
+            .into_iter()
+            .map(|f| f.as_canonical_u32() as u8)
+            .collect();
 
         if let Some(limit) = num_insns {
             let result = execute_with_limit(
                 &self.compiled,
                 self.exe.as_ref(),
                 input_stream,
+                hint_stream,
                 limit,
                 Default::default(),
             )
@@ -63,6 +69,7 @@ where
             &self.compiled,
             self.exe.as_ref(),
             input_stream,
+            hint_stream,
             Default::default(),
         )
         .map_err(map_rvr_execute_error)?;

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -32,6 +32,8 @@ impl<F> RvrPureInstance<F>
 where
     F: PrimeField32,
 {
+    // TODO: deduplicate `execute` and `execute_from_state` — they share the rvr invocation
+    // and result-translation logic and only differ in how the initial state is set up.
     pub fn execute(
         &self,
         inputs: impl Into<Streams<F>>,

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+
+use openvm_instructions::exe::VmExe;
+use openvm_platform::memory::MEM_SIZE;
+use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_state::GuardedMemory;
+
+use super::{
+    build_callbacks, build_io_state, execute, execute_with_limit, register_and_execute,
+    state::{init_rvr_state, state_as_void_ptr},
+    PureTracer, PureTracerData, RvrCompiled,
+};
+use crate::{
+    arch::{
+        vm::{
+            copy_guest_memory_to_rvr_memory, ensure_rvr_outcome, map_rvr_execute_error,
+            read_public_values_from_guest_memory, read_rv32_regs_from_guest_memory, state_from_rvr,
+            streams_from_io_state, streams_to_io_seed, write_rvr_memory_to_guest_memory,
+        },
+        ExecutionError, StaticProgramError, Streams, SystemConfig, VmState,
+    },
+    system::memory::online::GuestMemory,
+};
+
+pub struct RvrPureInstance<F> {
+    pub(crate) system_config: SystemConfig,
+    pub(crate) exe: Arc<VmExe<F>>,
+    pub(crate) compiled: RvrCompiled,
+}
+
+impl<F> RvrPureInstance<F>
+where
+    F: PrimeField32,
+{
+    pub fn execute(
+        &self,
+        inputs: impl Into<Streams<F>>,
+        num_insns: Option<u64>,
+    ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
+        let inputs = inputs.into();
+        let input_stream = inputs.input_stream;
+
+        if let Some(limit) = num_insns {
+            let result = execute_with_limit(
+                &self.compiled,
+                self.exe.as_ref(),
+                input_stream,
+                limit,
+                Default::default(),
+            )
+            .map_err(map_rvr_execute_error)?;
+            return Ok(state_from_rvr(
+                &self.system_config,
+                self.exe.as_ref(),
+                result.state.pc,
+                &result.state.regs,
+                &result.memory,
+                &[],
+            ));
+        }
+
+        let result = execute(
+            &self.compiled,
+            self.exe.as_ref(),
+            input_stream,
+            Default::default(),
+        )
+        .map_err(map_rvr_execute_error)?;
+
+        Ok(state_from_rvr(
+            &self.system_config,
+            self.exe.as_ref(),
+            result.state.pc,
+            &result.state.regs,
+            &result.memory,
+            &result.public_values,
+        ))
+    }
+
+    pub fn execute_from_state(
+        &self,
+        from_state: VmState<F, GuestMemory>,
+        num_insns: Option<u64>,
+    ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
+        let pc = from_state.pc();
+        let mut guest_memory = from_state.memory;
+        let (input_stream, hint_stream, deferrals) = streams_to_io_seed(from_state.streams);
+        let rng = from_state.rng;
+        #[cfg(feature = "metrics")]
+        let metrics = from_state.metrics;
+
+        let mut memory = GuardedMemory::new(MEM_SIZE).map_err(|err| {
+            ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
+                err: err.to_string(),
+            })
+        })?;
+
+        let mut tracer_data = PureTracerData;
+        let mut state = init_rvr_state(self.exe.as_ref(), &mut memory);
+        state.tracer = PureTracer(&mut tracer_data);
+        state.pc = pc;
+        state
+            .regs
+            .copy_from_slice(&read_rv32_regs_from_guest_memory(&guest_memory));
+        copy_guest_memory_to_rvr_memory(&guest_memory, &mut memory);
+        match num_insns {
+            Some(limit) => state.suspender.set_target(limit),
+            None => state.suspender.disable(),
+        }
+
+        let mut io_state = build_io_state(input_stream, memory.as_ptr(), Default::default());
+        io_state.hint_stream = hint_stream;
+        io_state.hint_pos = 0;
+        io_state.public_values = read_public_values_from_guest_memory(&guest_memory);
+        io_state.rng = rng;
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe { register_and_execute(&self.compiled, &callbacks, state_as_void_ptr(&mut state)) }
+            .map_err(map_rvr_execute_error)?;
+        ensure_rvr_outcome(
+            "execution from state",
+            state.is_terminated(),
+            state.is_suspended(),
+            state.result_code(),
+            num_insns.is_some(),
+        )?;
+
+        write_rvr_memory_to_guest_memory(
+            &mut guest_memory,
+            &state.regs,
+            &memory,
+            &io_state.public_values,
+        );
+        Ok(VmState::new(
+            state.pc,
+            guest_memory,
+            streams_from_io_state(&io_state, deferrals),
+            io_state.rng,
+            #[cfg(feature = "metrics")]
+            metrics,
+        ))
+    }
+}

--- a/crates/vm/src/arch/rvr/state.rs
+++ b/crates/vm/src/arch/rvr/state.rs
@@ -39,7 +39,7 @@ fn init_memory<F: PrimeField32>(exe: &VmExe<F>, memory: &mut GuardedMemory) {
 pub fn init_rvr_state<F: PrimeField32>(exe: &VmExe<F>, memory: &mut GuardedMemory) -> PureState {
     let mut state = PureState::new();
     init_memory(exe, memory);
-    state.set_memory(memory.as_ptr());
+    state.set_memory(memory.as_mut_ptr());
     state.pc = exe.pc_start;
     state.suspender.disable();
     state
@@ -52,7 +52,7 @@ pub fn init_rvr_state_with_metered_cost<F: PrimeField32>(
 ) -> MeteredCostState {
     let mut state = MeteredCostState::new();
     init_memory(exe, memory);
-    state.set_memory(memory.as_ptr());
+    state.set_memory(memory.as_mut_ptr());
     state.pc = exe.pc_start;
     state.suspender.disable();
     state
@@ -65,7 +65,7 @@ pub fn init_rvr_state_with_metered<F: PrimeField32>(
 ) -> MeteredState {
     let mut state = MeteredState::new();
     init_memory(exe, memory);
-    state.set_memory(memory.as_ptr());
+    state.set_memory(memory.as_mut_ptr());
     state.pc = exe.pc_start;
     state.suspender.disable();
     state

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -253,7 +253,7 @@ pub(crate) fn copy_guest_memory_to_rvr_memory(
             .memory
             .get_u8_slice(RV32_MEMORY_AS, 0, memory_capacity)
     };
-    let dst = unsafe { std::slice::from_raw_parts_mut(rvr_memory.as_ptr(), rvr_memory.size()) };
+    let dst = unsafe { std::slice::from_raw_parts_mut(rvr_memory.as_mut_ptr(), rvr_memory.size()) };
     let len = std::cmp::min(dst.len(), source_memory.len());
     dst[..len].copy_from_slice(&source_memory[..len]);
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -11,6 +11,8 @@ use std::{any::TypeId, borrow::Borrow, collections::VecDeque, marker::PhantomDat
 use getset::{Getters, MutGetters, Setters, WithSetters};
 use itertools::{zip_eq, Itertools};
 use openvm_circuit::system::program::trace::compute_exe_commit;
+#[cfg(feature = "rvr")]
+use openvm_instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS};
 use openvm_instructions::{
     exe::{SparseMemoryImage, VmExe},
     program::Program,
@@ -33,12 +35,16 @@ use openvm_stark_backend::{
     Com, StarkEngine, StarkProtocolConfig, Val,
 };
 use p3_baby_bear::BabyBear;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::ExtensionRegistry;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{info_span, instrument};
 
 #[cfg(feature = "aot")]
 use super::aot::AotInstance;
+#[cfg(feature = "rvr")]
+use super::rvr::{self, RvrMeteredCostInstance, RvrMeteredInstance, RvrPureInstance};
 use super::{
     execution_mode::{ExecutionCtx, MeteredCostCtx, MeteredCtx, PreflightCtx, Segment},
     hasher::poseidon2::vm_poseidon2_hasher,
@@ -50,6 +56,8 @@ use super::{
     VmExecutionConfig, VmState, CONNECTOR_AIR_ID, MERKLE_AIR_ID, PROGRAM_AIR_ID,
     PROGRAM_CACHED_TRACE_INDEX,
 };
+#[cfg(feature = "rvr")]
+use crate::system::memory::merkle::public_values::PUBLIC_VALUES_AS;
 use crate::{
     arch::deferral::DeferralState,
     execute_spanned,
@@ -139,6 +147,199 @@ impl<F> From<Vec<Vec<F>>> for Streams<F> {
 type PreflightInterpretedInstance2<F, VC> =
     PreflightInterpretedInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
 
+/// Typedef for [RvrMeteredInstance] that is generic in `VC: VmExecutionConfig<F>`
+#[cfg(feature = "rvr")]
+type RvrMeteredInstance2<F, VC> = RvrMeteredInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
+
+/// Typedef for [RvrMeteredCostInstance] that is generic in `VC: VmExecutionConfig<F>`
+#[cfg(feature = "rvr")]
+type RvrMeteredCostInstance2<F, VC> =
+    RvrMeteredCostInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
+
+#[cfg(feature = "rvr")]
+pub(crate) fn map_rvr_compile_error(err: rvr::CompileError) -> StaticProgramError {
+    StaticProgramError::FailToGenerateDynamicLibrary {
+        err: err.to_string(),
+    }
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn map_rvr_execute_error(err: rvr::ExecuteError) -> ExecutionError {
+    match err {
+        rvr::ExecuteError::GuestExit(code) => ExecutionError::FailedWithExitCode(code as u32),
+        other => ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
+            err: other.to_string(),
+        }),
+    }
+}
+
+// TODO: Unify format of the VM state for rvr and interpreted execution.
+#[cfg(feature = "rvr")]
+pub(crate) fn state_from_rvr<F: PrimeField32>(
+    system_config: &SystemConfig,
+    exe: &VmExe<F>,
+    pc: u32,
+    regs: &[u32],
+    rvr_memory: &rvr_state::GuardedMemory,
+    public_values: &[u8],
+) -> VmState<F, GuestMemory> {
+    let mut guest_memory = create_memory_image(&system_config.memory_config, &exe.init_memory);
+    write_rvr_memory_to_guest_memory(&mut guest_memory, regs, rvr_memory, public_values);
+
+    VmState::new_with_defaults(pc, guest_memory, Streams::default(), 0)
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn write_rvr_memory_to_guest_memory(
+    guest_memory: &mut GuestMemory,
+    regs: &[u32],
+    rvr_memory: &rvr_state::GuardedMemory,
+    public_values: &[u8],
+) {
+    let source_memory =
+        unsafe { std::slice::from_raw_parts(rvr_memory.as_ptr(), rvr_memory.size()) };
+    let memory_capacity = guest_memory.memory.config[RV32_MEMORY_AS as usize].num_cells;
+    let memory_len = std::cmp::min(memory_capacity, source_memory.len());
+    unsafe {
+        guest_memory
+            .memory
+            .copy_slice_nonoverlapping((RV32_MEMORY_AS, 0), &source_memory[..memory_len]);
+    }
+
+    let mut register_bytes = Vec::with_capacity(std::mem::size_of_val(regs));
+    for reg in regs {
+        register_bytes.extend_from_slice(&reg.to_le_bytes());
+    }
+    let register_capacity = guest_memory.memory.config[RV32_REGISTER_AS as usize].num_cells;
+    let register_len = std::cmp::min(register_capacity, register_bytes.len());
+    unsafe {
+        guest_memory
+            .memory
+            .copy_slice_nonoverlapping((RV32_REGISTER_AS, 0), &register_bytes[..register_len]);
+    }
+
+    if !public_values.is_empty() {
+        let pv_capacity = guest_memory.memory.config[PUBLIC_VALUES_AS as usize].num_cells;
+        let pv_len = std::cmp::min(pv_capacity, public_values.len());
+        unsafe {
+            guest_memory
+                .memory
+                .copy_slice_nonoverlapping((PUBLIC_VALUES_AS, 0), &public_values[..pv_len]);
+        }
+    }
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn read_rv32_regs_from_guest_memory(guest_memory: &GuestMemory) -> [u32; 32] {
+    let reg_capacity = guest_memory.memory.config[RV32_REGISTER_AS as usize].num_cells;
+    let regs_u8 = unsafe {
+        guest_memory
+            .memory
+            .get_u8_slice(RV32_REGISTER_AS, 0, reg_capacity)
+    };
+    let mut regs = [0u32; 32];
+    for (i, chunk) in regs_u8.chunks_exact(4).take(32).enumerate() {
+        regs[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    }
+    regs
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn copy_guest_memory_to_rvr_memory(
+    guest_memory: &GuestMemory,
+    rvr_memory: &mut rvr_state::GuardedMemory,
+) {
+    let memory_capacity = guest_memory.memory.config[RV32_MEMORY_AS as usize].num_cells;
+    let source_memory = unsafe {
+        guest_memory
+            .memory
+            .get_u8_slice(RV32_MEMORY_AS, 0, memory_capacity)
+    };
+    let dst = unsafe { std::slice::from_raw_parts_mut(rvr_memory.as_ptr(), rvr_memory.size()) };
+    let len = std::cmp::min(dst.len(), source_memory.len());
+    dst[..len].copy_from_slice(&source_memory[..len]);
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn read_public_values_from_guest_memory(guest_memory: &GuestMemory) -> Vec<u8> {
+    let pv_capacity = guest_memory.memory.config[PUBLIC_VALUES_AS as usize].num_cells;
+    unsafe {
+        guest_memory
+            .memory
+            .get_u8_slice(PUBLIC_VALUES_AS, 0, pv_capacity)
+            .to_vec()
+    }
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn streams_to_io_seed<F: PrimeField32>(
+    streams: Streams<F>,
+) -> (VecDeque<Vec<u8>>, Vec<u8>, Vec<DeferralState>) {
+    let mut input_stream = VecDeque::with_capacity(streams.input_stream.len());
+    for vec in streams.input_stream {
+        input_stream.push_back(
+            vec.into_iter()
+                .map(|f| f.as_canonical_u32() as u8)
+                .collect::<Vec<u8>>(),
+        );
+    }
+    let hint_stream = streams
+        .hint_stream
+        .into_iter()
+        .map(|f| f.as_canonical_u32() as u8)
+        .collect();
+    (input_stream, hint_stream, streams.deferrals)
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn streams_from_io_state<F: PrimeField32>(
+    io_state: &rvr::io::OpenVmIoState,
+    deferrals: Vec<DeferralState>,
+) -> Streams<F> {
+    let input_stream = io_state
+        .input_stream
+        .iter()
+        .map(|vec| vec.iter().map(|&b| F::from_u8(b)).collect::<Vec<F>>())
+        .collect::<VecDeque<_>>();
+    let hint_stream = io_state
+        .hint_stream
+        .iter()
+        .skip(io_state.hint_pos)
+        .map(|&b| F::from_u8(b))
+        .collect::<VecDeque<_>>();
+    Streams {
+        input_stream,
+        hint_stream,
+        deferrals,
+    }
+}
+
+#[cfg(feature = "rvr")]
+pub(crate) fn ensure_rvr_outcome(
+    context: &str,
+    terminated: bool,
+    suspended: bool,
+    guest_exit_code: u8,
+    allow_suspended: bool,
+) -> Result<(), ExecutionError> {
+    if allow_suspended && suspended {
+        return Ok(());
+    }
+    if terminated {
+        if guest_exit_code == 0 {
+            return Ok(());
+        }
+        return Err(ExecutionError::FailedWithExitCode(guest_exit_code as u32));
+    }
+    Err(ExecutionError::Static(
+        StaticProgramError::FailToGenerateDynamicLibrary {
+            err: format!(
+                "{context} failed: terminated={terminated}, suspended={suspended}, guest_exit_code={guest_exit_code}"
+            ),
+        },
+    ))
+}
+
 /// [VmExecutor] is the struct that can execute an _arbitrary_ program, provided in the form of a
 /// [VmExe], for a fixed set of OpenVM instructions corresponding to a [VmExecutionConfig].
 /// Internally once it is given a program, it will preprocess the program to rewrite it into a more
@@ -219,7 +420,7 @@ where
     /// the given `exe`.
     ///
     /// For metered execution, use the [`metered_instance`](Self::metered_instance) constructor.
-    #[cfg(not(feature = "aot"))]
+    #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     pub fn instance(
         &self,
         exe: &VmExe<F>,
@@ -227,7 +428,7 @@ where
         InterpretedInstance::new(&self.inventory, exe)
     }
 
-    #[cfg(feature = "aot")]
+    #[cfg(any(feature = "aot", feature = "rvr"))]
     pub fn interpreter_instance(
         &self,
         exe: &VmExe<F>,
@@ -242,7 +443,52 @@ where
     ) -> Result<AotInstance<F, ExecutionCtx>, StaticProgramError> {
         Self::aot_instance(self, exe)
     }
+
+    #[cfg(feature = "rvr")]
+    pub fn instance(
+        &self,
+        exe: &VmExe<F>,
+        executor_idx_to_air_idx: &[usize],
+    ) -> Result<RvrPureInstance<F>, StaticProgramError> {
+        Self::rvr_instance(self, exe, executor_idx_to_air_idx)
+    }
 }
+
+#[cfg(feature = "rvr")]
+impl<F, VC> VmExecutor<F, VC>
+where
+    F: PrimeField32,
+    VC: VmExecutionConfig<F>,
+{
+    fn build_rvr_extensions(&self, executor_idx_to_air_idx: &[usize]) -> ExtensionRegistry<F> {
+        self.config.create_rvr_extensions(executor_idx_to_air_idx)
+    }
+}
+
+#[cfg(feature = "rvr")]
+impl<F, VC> VmExecutor<F, VC>
+where
+    F: PrimeField32,
+    VC: VmExecutionConfig<F>,
+    VC::Executor: Executor<F>,
+{
+    pub fn rvr_instance(
+        &self,
+        exe: &VmExe<F>,
+        executor_idx_to_air_idx: &[usize],
+    ) -> Result<RvrPureInstance<F>, StaticProgramError> {
+        let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+        let compiled =
+            rvr::compile_with_extensions(exe, &extensions).map_err(map_rvr_compile_error)?;
+
+        Ok(RvrPureInstance {
+            system_config: self.inventory.config().clone(),
+            exe: Arc::new(exe.clone()),
+            compiled,
+        })
+    }
+}
+
 #[cfg(feature = "aot")]
 impl<F, VC> VmExecutor<F, VC>
 where
@@ -265,7 +511,7 @@ where
     VC::Executor: MeteredExecutor<F>,
 {
     /// Creates an instance of the interpreter specialized for metered execution of the given `exe`.
-    #[cfg(not(feature = "aot"))]
+    #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     pub fn metered_instance(
         &self,
         exe: &VmExe<F>,
@@ -274,7 +520,7 @@ where
         InterpretedInstance::new_metered(&self.inventory, exe, executor_idx_to_air_idx)
     }
 
-    #[cfg(feature = "aot")]
+    #[cfg(any(feature = "aot", feature = "rvr"))]
     pub fn metered_interpreter_instance(
         &self,
         exe: &VmExe<F>,
@@ -304,12 +550,69 @@ where
 
     /// Creates an instance of the interpreter specialized for cost metering execution of the given
     /// `exe`.
+    #[cfg(not(feature = "rvr"))]
     pub fn metered_cost_instance(
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
     ) -> Result<InterpretedInstance<F, MeteredCostCtx>, StaticProgramError> {
         InterpretedInstance::new_metered(&self.inventory, exe, executor_idx_to_air_idx)
+    }
+}
+
+#[cfg(feature = "rvr")]
+impl<F, VC> VmExecutor<F, VC>
+where
+    F: PrimeField32,
+    VC: VmExecutionConfig<F>,
+    VC::Executor: MeteredExecutor<F>,
+{
+    pub fn metered_instance(
+        &self,
+        exe: &VmExe<F>,
+        executor_idx_to_air_idx: &[usize],
+    ) -> Result<RvrMeteredInstance<F, VC::Executor>, StaticProgramError> {
+        Self::metered_rvr_instance(self, exe, executor_idx_to_air_idx)
+    }
+
+    pub fn metered_rvr_instance(
+        &self,
+        exe: &VmExe<F>,
+        executor_idx_to_air_idx: &[usize],
+    ) -> Result<RvrMeteredInstance<F, VC::Executor>, StaticProgramError> {
+        let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+
+        Ok(RvrMeteredInstance {
+            system_config: self.inventory.config().clone(),
+            exe: Arc::new(exe.clone()),
+            inventory: self.inventory.clone(),
+            executor_idx_to_air_idx: executor_idx_to_air_idx.to_vec(),
+            extensions,
+        })
+    }
+
+    pub fn metered_cost_instance(
+        &self,
+        exe: &VmExe<F>,
+        executor_idx_to_air_idx: &[usize],
+    ) -> Result<RvrMeteredCostInstance<F, VC::Executor>, StaticProgramError> {
+        Self::metered_cost_rvr_instance(self, exe, executor_idx_to_air_idx)
+    }
+
+    pub fn metered_cost_rvr_instance(
+        &self,
+        exe: &VmExe<F>,
+        executor_idx_to_air_idx: &[usize],
+    ) -> Result<RvrMeteredCostInstance<F, VC::Executor>, StaticProgramError> {
+        let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+
+        Ok(RvrMeteredCostInstance {
+            system_config: self.inventory.config().clone(),
+            exe: Arc::new(exe.clone()),
+            inventory: self.inventory.clone(),
+            executor_idx_to_air_idx: executor_idx_to_air_idx.to_vec(),
+            extensions,
+        })
     }
 }
 
@@ -446,7 +749,7 @@ where
     }
 
     /// Pure interpreter.
-    #[cfg(not(feature = "aot"))]
+    #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     pub fn interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
@@ -458,8 +761,33 @@ where
         self.executor().instance(exe)
     }
 
-    // Pure AOT execution
-    #[cfg(feature = "aot")]
+    #[cfg(feature = "rvr")]
+    pub fn interpreter(
+        &self,
+        exe: &VmExe<Val<E::SC>>,
+    ) -> Result<RvrPureInstance<Val<E::SC>>, StaticProgramError>
+    where
+        Val<E::SC>: PrimeField32,
+        <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
+    {
+        Self::get_rvr_instance(self, exe)
+    }
+
+    #[cfg(feature = "rvr")]
+    pub fn get_rvr_instance(
+        &self,
+        exe: &VmExe<Val<E::SC>>,
+    ) -> Result<RvrPureInstance<Val<E::SC>>, StaticProgramError>
+    where
+        Val<E::SC>: PrimeField32,
+        <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
+    {
+        let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
+        self.executor().rvr_instance(exe, &executor_idx_to_air_idx)
+    }
+
+    // Pure AOT / RVR execution
+    #[cfg(any(feature = "aot", feature = "rvr"))]
     pub fn naive_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
@@ -496,7 +824,7 @@ where
         self.executor().aot_instance(exe)
     }
 
-    #[cfg(not(feature = "aot"))]
+    #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     pub fn metered_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
@@ -508,6 +836,34 @@ where
         let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
         self.executor()
             .metered_instance(exe, &executor_idx_to_air_idx)
+    }
+
+    #[cfg(feature = "rvr")]
+    pub fn metered_interpreter(
+        &self,
+        exe: &VmExe<Val<E::SC>>,
+    ) -> Result<RvrMeteredInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    where
+        Val<E::SC>: PrimeField32,
+        <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
+    {
+        let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
+        self.executor()
+            .metered_instance(exe, &executor_idx_to_air_idx)
+    }
+
+    #[cfg(feature = "rvr")]
+    pub fn get_metered_rvr_instance(
+        &self,
+        exe: &VmExe<Val<E::SC>>,
+    ) -> Result<RvrMeteredInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    where
+        Val<E::SC>: PrimeField32,
+        <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
+    {
+        let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
+        self.executor()
+            .metered_rvr_instance(exe, &executor_idx_to_air_idx)
     }
 
     #[cfg(feature = "aot")]
@@ -539,7 +895,7 @@ where
             .metered_aot_instance(exe, &executor_idx_to_air_idx)
     }
 
-    #[cfg(feature = "aot")]
+    #[cfg(any(feature = "aot", feature = "rvr"))]
     pub fn naive_metered_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
@@ -553,6 +909,7 @@ where
             .metered_interpreter_instance(exe, &executor_idx_to_air_idx)
     }
 
+    #[cfg(not(feature = "rvr"))]
     pub fn metered_cost_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
@@ -564,6 +921,32 @@ where
         let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
         self.executor()
             .metered_cost_instance(exe, &executor_idx_to_air_idx)
+    }
+
+    #[cfg(feature = "rvr")]
+    pub fn metered_cost_interpreter(
+        &self,
+        exe: &VmExe<Val<E::SC>>,
+    ) -> Result<RvrMeteredCostInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    where
+        Val<E::SC>: PrimeField32,
+        <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
+    {
+        Self::get_metered_cost_rvr_instance(self, exe)
+    }
+
+    #[cfg(feature = "rvr")]
+    pub fn get_metered_cost_rvr_instance(
+        &self,
+        exe: &VmExe<Val<E::SC>>,
+    ) -> Result<RvrMeteredCostInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    where
+        Val<E::SC>: PrimeField32,
+        <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
+    {
+        let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
+        self.executor()
+            .metered_cost_rvr_instance(exe, &executor_idx_to_air_idx)
     }
 
     pub fn preflight_interpreter(

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -167,9 +167,7 @@ pub(crate) fn map_rvr_compile_error(err: rvr::CompileError) -> StaticProgramErro
 pub(crate) fn map_rvr_execute_error(err: rvr::ExecuteError) -> ExecutionError {
     match err {
         rvr::ExecuteError::GuestExit(code) => ExecutionError::FailedWithExitCode(code as u32),
-        other => ExecutionError::Static(StaticProgramError::FailToGenerateDynamicLibrary {
-            err: other.to_string(),
-        }),
+        other => ExecutionError::RvrExecution(other.to_string()),
     }
 }
 
@@ -331,13 +329,9 @@ pub(crate) fn ensure_rvr_outcome(
         }
         return Err(ExecutionError::FailedWithExitCode(guest_exit_code as u32));
     }
-    Err(ExecutionError::Static(
-        StaticProgramError::FailToGenerateDynamicLibrary {
-            err: format!(
-                "{context} failed: terminated={terminated}, suspended={suspended}, guest_exit_code={guest_exit_code}"
-            ),
-        },
-    ))
+    Err(ExecutionError::RvrExecution(format!(
+        "{context} failed: terminated={terminated}, suspended={suspended}, guest_exit_code={guest_exit_code}"
+    )))
 }
 
 /// [VmExecutor] is the struct that can execute an _arbitrary_ program, provided in the form of a

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -219,6 +219,11 @@ impl<F: PrimeField32> VmExecutionConfig<F> for SystemConfig {
 
         Ok(inventory)
     }
+
+    #[cfg(feature = "rvr")]
+    fn create_rvr_extensions(&self, _air_idx: &[usize]) -> rvr_openvm_lift::ExtensionRegistry<F> {
+        rvr_openvm_lift::ExtensionRegistry::new()
+    }
 }
 
 impl<SC> VmCircuitConfig<SC> for SystemConfig

--- a/extensions/algebra/rvr/Cargo.toml
+++ b/extensions/algebra/rvr/Cargo.toml
@@ -21,7 +21,7 @@ rand.workspace = true
 strum.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
+rvr-openvm-test-utils.workspace = true
 
 openvm-ecc-circuit.workspace = true
 openvm-instructions.workspace = true
@@ -31,3 +31,7 @@ openvm-transpiler.workspace = true
 
 eyre.workspace = true
 num-bigint.workspace = true
+
+[features]
+default = []
+rvr = ["rvr-openvm-test-utils/rvr"]

--- a/extensions/algebra/rvr/Cargo.toml
+++ b/extensions/algebra/rvr/Cargo.toml
@@ -21,7 +21,7 @@ rand.workspace = true
 strum.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils.workspace = true
+rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
 
 openvm-ecc-circuit.workspace = true
 openvm-instructions.workspace = true

--- a/extensions/algebra/rvr/tests/algebra.rs
+++ b/extensions/algebra/rvr/tests/algebra.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 //! Algebra extension integration tests.
 
 use std::{path::PathBuf, process::Command, str::FromStr};

--- a/extensions/ecc/rvr/Cargo.toml
+++ b/extensions/ecc/rvr/Cargo.toml
@@ -19,7 +19,7 @@ openvm-stark-backend.workspace = true
 strum.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils.workspace = true
+rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
 rvr-openvm-ext-algebra.workspace = true
 
 openvm-algebra-transpiler.workspace = true

--- a/extensions/ecc/rvr/Cargo.toml
+++ b/extensions/ecc/rvr/Cargo.toml
@@ -19,7 +19,7 @@ openvm-stark-backend.workspace = true
 strum.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
+rvr-openvm-test-utils.workspace = true
 rvr-openvm-ext-algebra.workspace = true
 
 openvm-algebra-transpiler.workspace = true
@@ -29,3 +29,7 @@ openvm-transpiler.workspace = true
 
 eyre.workspace = true
 num-bigint.workspace = true
+
+[features]
+default = []
+rvr = ["rvr-openvm-test-utils/rvr"]

--- a/extensions/ecc/rvr/tests/ecc.rs
+++ b/extensions/ecc/rvr/tests/ecc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 //! ECC extension integration tests.
 //!
 //! Builds a guest program that uses elliptic curve operations on secp256k1,

--- a/extensions/keccak256/rvr/Cargo.toml
+++ b/extensions/keccak256/rvr/Cargo.toml
@@ -16,7 +16,7 @@ openvm-keccak256-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils.workspace = true
+rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
 
 openvm-keccak256-circuit.workspace = true
 openvm-rv32im-transpiler.workspace = true

--- a/extensions/keccak256/rvr/Cargo.toml
+++ b/extensions/keccak256/rvr/Cargo.toml
@@ -16,7 +16,7 @@ openvm-keccak256-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
+rvr-openvm-test-utils.workspace = true
 
 openvm-keccak256-circuit.workspace = true
 openvm-rv32im-transpiler.workspace = true
@@ -26,3 +26,7 @@ openvm-transpiler.workspace = true
 
 eyre.workspace = true
 tiny-keccak.workspace = true
+
+[features]
+default = []
+rvr = ["rvr-openvm-test-utils/rvr"]

--- a/extensions/keccak256/rvr/tests/keccak.rs
+++ b/extensions/keccak256/rvr/tests/keccak.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 //! Keccak-256 extension integration tests.
 //!
 //! Builds a guest program that uses keccak256, transpiles it with the keccak

--- a/extensions/pairing/rvr/Cargo.toml
+++ b/extensions/pairing/rvr/Cargo.toml
@@ -16,7 +16,7 @@ openvm-pairing-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils.workspace = true
+rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
 rvr-openvm-ext-algebra.workspace = true
 
 openvm-algebra-circuit.workspace = true

--- a/extensions/pairing/rvr/Cargo.toml
+++ b/extensions/pairing/rvr/Cargo.toml
@@ -16,7 +16,7 @@ openvm-pairing-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
+rvr-openvm-test-utils.workspace = true
 rvr-openvm-ext-algebra.workspace = true
 
 openvm-algebra-circuit.workspace = true
@@ -34,3 +34,7 @@ eyre.workspace = true
 halo2curves-axiom.workspace = true
 num-bigint.workspace = true
 rand08 = { package = "rand", version = "0.8.5", features = ["std_rng"] }
+
+[features]
+default = []
+rvr = ["rvr-openvm-test-utils/rvr"]

--- a/extensions/pairing/rvr/tests/pairing.rs
+++ b/extensions/pairing/rvr/tests/pairing.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 //! Pairing extension integration tests.
 //!
 //! Tests pairing guest programs (fp12_mul, pairing_check) against the

--- a/extensions/rv32im/circuit/Cargo.toml
+++ b/extensions/rv32im/circuit/Cargo.toml
@@ -46,7 +46,7 @@ parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils", "dep:openvm-stark-sdk"]
 tco = ["openvm-circuit/tco"]
 aot = ["openvm-circuit/aot", "openvm-circuit-derive/aot"]
-rvr = ["dep:rvr-openvm-lift"]
+rvr = ["dep:rvr-openvm-lift", "openvm-circuit/rvr"]
 # performance features:
 mimalloc = ["openvm-circuit/mimalloc"]
 jemalloc = ["openvm-circuit/jemalloc"]

--- a/extensions/sha2/rvr/Cargo.toml
+++ b/extensions/sha2/rvr/Cargo.toml
@@ -16,7 +16,7 @@ openvm-sha2-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
+rvr-openvm-test-utils.workspace = true
 
 openvm-rv32im-transpiler.workspace = true
 openvm-sha2-circuit.workspace = true
@@ -26,3 +26,7 @@ openvm-transpiler.workspace = true
 
 eyre.workspace = true
 sha2 = { workspace = true, features = ["std"] }
+
+[features]
+default = []
+rvr = ["rvr-openvm-test-utils/rvr"]

--- a/extensions/sha2/rvr/Cargo.toml
+++ b/extensions/sha2/rvr/Cargo.toml
@@ -16,7 +16,7 @@ openvm-sha2-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
 [dev-dependencies]
-rvr-openvm-test-utils.workspace = true
+rvr-openvm-test-utils = { workspace = true, features = ["rvr"] }
 
 openvm-rv32im-transpiler.workspace = true
 openvm-sha2-circuit.workspace = true

--- a/extensions/sha2/rvr/tests/sha2.rs
+++ b/extensions/sha2/rvr/tests/sha2.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rvr")]
+
 //! SHA-2 extension integration tests.
 //!
 //! Builds a guest program that uses sha2, transpiles it with the sha2


### PR DESCRIPTION
- Vm execution instance is made to use rvr execution, depending on the feature. Helper functions to convert between the existing `VmState` and the rvr state are also added.
- The `VmConfig` macro now has a `create_rvr_extensions` method implementation, but instead of defining a new `VmRvrConfig` trait, the `create_rvr_extensions` method piggybacks on the existing `VmExecutionConfig`. This is to avoid complex feature-gated trait bounds.

closes INT-6810, INT-7476