### PR TITLE
fix: sign-extend AUIPC result

### DIFF
--- a/extensions/riscv/circuit/cuda/src/auipc.cu
+++ b/extensions/riscv/circuit/cuda/src/auipc.cu
@@ -10,6 +10,7 @@ using namespace program;
 
 template <typename T> struct Rv64AuipcCoreCols {
     T is_valid;
+    T is_sign_extend;
     // The limbs of the immediate except the least significant limb since it is always 0
     T imm_limbs[RV64_WORD_NUM_LIMBS - 1];
     // The limbs of the PC except the most significant and the least significant limbs
@@ -44,10 +45,16 @@ struct Rv64AuipcCore {
         for (size_t i = 0; i < RV64_WORD_NUM_LIMBS; i += 2) {
             bitwise_lookup.add_range(rd_data[i], rd_data[i + 1]);
         }
+        uint32_t is_sign_ext = (rd_data[RV64_WORD_NUM_LIMBS - 1] >> (RV64_CELL_BITS - 1)) & 1;
+        bitwise_lookup.add_range(
+            rd_data[RV64_WORD_NUM_LIMBS - 1],
+            2 * rd_data[RV64_WORD_NUM_LIMBS - 1] - is_sign_ext * (1 << RV64_CELL_BITS)
+        );
 
         COL_WRITE_ARRAY(row, Rv64AuipcCoreCols, imm_limbs, imm_limbs);
         COL_WRITE_ARRAY(row, Rv64AuipcCoreCols, pc_limbs, pc_limbs + 1);
         COL_WRITE_ARRAY(row, Rv64AuipcCoreCols, rd_data, rd_data);
+        COL_WRITE_VALUE(row, Rv64AuipcCoreCols, is_sign_extend, is_sign_ext);
         COL_WRITE_VALUE(row, Rv64AuipcCoreCols, is_valid, 1);
     }
 };

--- a/extensions/riscv/circuit/cuda/src/auipc.cu
+++ b/extensions/riscv/circuit/cuda/src/auipc.cu
@@ -41,13 +41,10 @@ struct Rv64AuipcCore {
         bitwise_lookup.add_range(imm_limbs[2], pc_limbs[1]);
         auto msl_shift = RV64_WORD_NUM_LIMBS * RV64_CELL_BITS - PC_BITS;
         bitwise_lookup.add_range(pc_limbs[2], pc_limbs[3] << msl_shift);
-#pragma unroll
-        for (size_t i = 0; i < RV64_WORD_NUM_LIMBS; i += 2) {
-            bitwise_lookup.add_range(rd_data[i], rd_data[i + 1]);
-        }
+        bitwise_lookup.add_range(rd_data[0], rd_data[1]);
         uint32_t is_sign_ext = (rd_data[RV64_WORD_NUM_LIMBS - 1] >> (RV64_CELL_BITS - 1)) & 1;
         bitwise_lookup.add_range(
-            rd_data[RV64_WORD_NUM_LIMBS - 1],
+            rd_data[RV64_WORD_NUM_LIMBS - 2],
             2 * rd_data[RV64_WORD_NUM_LIMBS - 1] - is_sign_ext * (1 << RV64_CELL_BITS)
         );
 

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -26,14 +26,15 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    expand_to_rv64_register, Rv64RdWriteAdapterExecutor, Rv64RdWriteAdapterFiller, RV64_CELL_BITS,
-    RV64_REGISTER_NUM_LIMBS, RV64_WORD_NUM_LIMBS,
+    Rv64RdWriteAdapterExecutor, Rv64RdWriteAdapterFiller, RV64_CELL_BITS, RV64_REGISTER_NUM_LIMBS,
+    RV64_WORD_NUM_LIMBS,
 };
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow)]
 pub struct Rv64AuipcCoreCols<T> {
     pub is_valid: T,
+    pub is_sign_extend: T,
     // The limbs of the immediate except the least significant limb since it is always 0
     pub imm_limbs: [T; RV64_WORD_NUM_LIMBS - 1],
     // The limbs of the PC except the most significant and the least significant limbs
@@ -72,11 +73,13 @@ where
 
         let Rv64AuipcCoreCols {
             is_valid,
+            is_sign_extend,
             imm_limbs,
             pc_limbs,
             rd_data,
         } = *cols;
         builder.assert_bool(is_valid);
+        builder.assert_bool(is_sign_extend);
 
         // We want to constrain rd = pc + imm (i32 add) where:
         // - rd_data represents limbs of rd
@@ -125,6 +128,15 @@ where
                 .eval(builder, is_valid);
         }
 
+        // Constrain is_sign_extend to the MSB of rd_data[RV64_WORD_NUM_LIMBS - 1].
+        self.bus
+            .send_range(
+                rd_data[3],
+                AB::Expr::from_u32(2) * rd_data[3]
+                    - is_sign_extend * AB::Expr::from_u32(1 << RV64_CELL_BITS),
+            )
+            .eval(builder, is_valid);
+
         // The immediate and PC limbs need range checking to ensure they're within [0,
         // 2^RV64_CELL_BITS) Since we range check two items at a time, doing this way helps
         // efficiently divide the limbs into groups of 2 Note: range checking the limbs of
@@ -169,7 +181,14 @@ where
                 acc + val * AB::Expr::from_u32(1 << (i * RV64_CELL_BITS))
             });
 
-        let write_data = expand_to_rv64_register(&rd_data);
+        let sign_extend_limb = is_sign_extend * AB::Expr::from_u32(u8::MAX as u32);
+        let write_data: [AB::Expr; RV64_REGISTER_NUM_LIMBS] = array::from_fn(|i| {
+            if i < RV64_WORD_NUM_LIMBS {
+                rd_data[i].into()
+            } else {
+                sign_extend_limb.clone()
+            }
+        });
         let expected_opcode = VmCoreAir::<AB, I>::opcode_to_global_expr(self, AUIPC);
         AdapterAirContext {
             to_pc: None,
@@ -279,11 +298,19 @@ where
             self.bitwise_lookup_chip
                 .request_range(pair[0] as u32, pair[1] as u32);
         }
+        let is_sign_extend = (rd_data[RV64_WORD_NUM_LIMBS - 1] >> (RV64_CELL_BITS - 1)) & 1;
+        self.bitwise_lookup_chip.request_range(
+            rd_data[RV64_WORD_NUM_LIMBS - 1] as u32,
+            2 * rd_data[RV64_WORD_NUM_LIMBS - 1] as u32
+                - is_sign_extend as u32 * (1 << RV64_CELL_BITS),
+        );
+
         // Writing in reverse order
         core_row.rd_data = from_fn(|i| F::from_u8(rd_data[i]));
         // only the middle 2 limbs:
         core_row.pc_limbs = from_fn(|i| F::from_u8(pc_limbs[i + 1]));
         core_row.imm_limbs = from_fn(|i| F::from_u8(imm_limbs[i]));
+        core_row.is_sign_extend = F::from_bool(is_sign_extend != 0);
 
         core_row.is_valid = F::ONE;
     }
@@ -295,5 +322,7 @@ pub(super) fn run_auipc(pc: u32, imm: u32) -> [u8; RV64_REGISTER_NUM_LIMBS] {
     let rd = pc.wrapping_add(imm << RV64_CELL_BITS);
     let mut rd_data = [0u8; RV64_REGISTER_NUM_LIMBS];
     rd_data[..RV64_WORD_NUM_LIMBS].copy_from_slice(&rd.to_le_bytes());
+    let sign_extend_limb = (rd_data[RV64_WORD_NUM_LIMBS - 1] >> (RV64_CELL_BITS - 1)) * u8::MAX;
+    rd_data[RV64_WORD_NUM_LIMBS..].fill(sign_extend_limb);
     rd_data
 }

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -121,18 +121,18 @@ where
             builder.when(is_valid).assert_bool(carry[i].clone());
         }
 
-        // Range checking of rd_data entries to RV64_CELL_BITS bits
-        for i in 0..(RV64_WORD_NUM_LIMBS / 2) {
-            self.bus
-                .send_range(rd_data[i * 2], rd_data[i * 2 + 1])
-                .eval(builder, is_valid);
-        }
-
-        // Constrain is_sign_extend to the MSB of rd_data[RV64_WORD_NUM_LIMBS - 1].
+        // Byte-range check rd_data with two bus sends:
+        //   1. (rd_data[0], rd_data[1]).
+        //   2. (rd_data[2], 2*rd_data[3] - is_sign_extend * 2^RV64_CELL_BITS) — constraining the
+        //      second value to [0, 2^RV64_CELL_BITS) forces is_sign_extend = msb(rd_data[3]) and
+        //      (combined with the carry chain) byte-bounds rd_data[3].
+        self.bus
+            .send_range(rd_data[0], rd_data[1])
+            .eval(builder, is_valid);
         self.bus
             .send_range(
-                rd_data[3],
-                AB::Expr::from_u32(2) * rd_data[3]
+                rd_data[RV64_WORD_NUM_LIMBS - 2],
+                AB::Expr::from_u32(2) * rd_data[RV64_WORD_NUM_LIMBS - 1]
                     - is_sign_extend * AB::Expr::from_u32(1 << RV64_CELL_BITS),
             )
             .eval(builder, is_valid);
@@ -294,13 +294,13 @@ where
         let msl_shift = RV64_WORD_NUM_LIMBS * RV64_CELL_BITS - PC_BITS;
         self.bitwise_lookup_chip
             .request_range(pc_limbs[2] as u32, (pc_limbs[3] as u32) << msl_shift);
-        for pair in rd_data[..RV64_WORD_NUM_LIMBS].chunks_exact(2) {
-            self.bitwise_lookup_chip
-                .request_range(pair[0] as u32, pair[1] as u32);
-        }
+        // Mirror the AIR: rd_data[0..2] pair, then rd_data[2] paired with the sign-extend
+        // constraint on rd_data[3].
+        self.bitwise_lookup_chip
+            .request_range(rd_data[0] as u32, rd_data[1] as u32);
         let is_sign_extend = (rd_data[RV64_WORD_NUM_LIMBS - 1] >> (RV64_CELL_BITS - 1)) & 1;
         self.bitwise_lookup_chip.request_range(
-            rd_data[RV64_WORD_NUM_LIMBS - 1] as u32,
+            rd_data[RV64_WORD_NUM_LIMBS - 2] as u32,
             2 * rd_data[RV64_WORD_NUM_LIMBS - 1] as u32
                 - is_sign_extend as u32 * (1 << RV64_CELL_BITS),
         );

--- a/extensions/riscv/circuit/src/auipc/tests.rs
+++ b/extensions/riscv/circuit/src/auipc/tests.rs
@@ -321,6 +321,34 @@ fn rd_upper_bytes_trace_tamper_negative_test() {
 }
 
 #[test]
+fn sign_extend_flag_negative_tests() {
+    // is_sign_extend = 1 when the result fits in 32 bits (MSB of rd_data[3] is 0).
+    // pc=4, imm=0 ⟹ rd = 4 ⟹ rd_data = [4, 0, 0, 0, 0, 0, 0, 0].
+    run_negative_auipc_test(
+        AUIPC,
+        Some(0),
+        Some(4),
+        AuipcPrankValues {
+            is_sign_extend: Some(1),
+            ..Default::default()
+        },
+        true,
+    );
+    // is_sign_extend = 0 when the result has bit 31 set (MSB of rd_data[3] is 1).
+    // pc=0, imm=2^23 ⟹ rd = 2^31 ⟹ rd_data = [0, 0, 0, 128, 255, 255, 255, 255].
+    run_negative_auipc_test(
+        AUIPC,
+        Some(1 << 23),
+        Some(0),
+        AuipcPrankValues {
+            is_sign_extend: Some(0),
+            ..Default::default()
+        },
+        true,
+    );
+}
+
+#[test]
 fn overflow_negative_tests() {
     run_negative_auipc_test(
         AUIPC,

--- a/extensions/riscv/circuit/src/auipc/tests.rs
+++ b/extensions/riscv/circuit/src/auipc/tests.rs
@@ -162,6 +162,7 @@ fn rand_auipc_test() {
 
 #[derive(Clone, Copy, Default, PartialEq)]
 struct AuipcPrankValues {
+    pub is_sign_extend: Option<u32>,
     pub rd_data: Option<[u32; RV64_WORD_NUM_LIMBS]>,
     pub imm_limbs: Option<[u32; RV64_WORD_NUM_LIMBS - 1]>,
     pub pc_limbs: Option<[u32; RV64_WORD_NUM_LIMBS - 2]>,
@@ -194,6 +195,9 @@ fn run_negative_auipc_test(
         let (_, core_row) = trace_row.split_at_mut(adapter_width);
         let core_cols: &mut Rv64AuipcCoreCols<F> = core_row.borrow_mut();
 
+        if let Some(val) = prank_vals.is_sign_extend {
+            core_cols.is_sign_extend = F::from_u32(val);
+        }
         if let Some(data) = prank_vals.rd_data {
             core_cols.rd_data = data.map(F::from_u32);
         }
@@ -269,6 +273,7 @@ fn invalid_limb_negative_tests() {
             rd_data: Some([197, 202, 49, 70]),
             imm_limbs: Some([166, 243, 17]),
             pc_limbs: Some([36, 62]),
+            ..Default::default()
         },
         true,
     );
@@ -355,6 +360,7 @@ fn overflow_negative_tests() {
             rd_data: Some([F::NEG_ONE.as_canonical_u32(), 1, 0, 0]),
             imm_limbs: Some([0, 0, 0]),
             pc_limbs: Some([1, 0]),
+            ..Default::default()
         },
         true,
     );
@@ -372,7 +378,7 @@ fn run_auipc_sanity_test() {
     let imm = 11302451;
     let rd_data = run_auipc(initial_pc, imm);
 
-    assert_eq!(rd_data, [210, 107, 113, 186, 0, 0, 0, 0]);
+    assert_eq!(rd_data, [210, 107, 113, 186, 255, 255, 255, 255]);
 }
 
 // ////////////////////////////////////////////////////////////////////////////////////

--- a/extensions/riscv/circuit/src/jal_lui/tests.rs
+++ b/extensions/riscv/circuit/src/jal_lui/tests.rs
@@ -405,6 +405,34 @@ fn rd_upper_bytes_trace_tamper_negative_test() {
 }
 
 #[test]
+fn sign_extend_flag_negative_tests() {
+    // LUI with imm small enough that imm << 12 has bit 31 unset (MSB of rd[3] is 0).
+    // is_sign_extend pranked to true should fail.
+    run_negative_jal_lui_test(
+        LUI,
+        Some(1),
+        None,
+        JalLuiPrankValues {
+            is_sign_extend: Some(true),
+            ..Default::default()
+        },
+        true,
+    );
+    // JAL writes pc+4 with pc < 2^30, so MSB of rd[3] is always 0.
+    // is_sign_extend pranked to true should fail.
+    run_negative_jal_lui_test(
+        JAL,
+        None,
+        None,
+        JalLuiPrankValues {
+            is_sign_extend: Some(true),
+            ..Default::default()
+        },
+        true,
+    );
+}
+
+#[test]
 fn overflow_negative_tests() {
     run_negative_jal_lui_test(
         JAL,


### PR DESCRIPTION
Towards INT-6339.

AUIPC was zero-extending `pc + (imm << 12)` into the upper 32 bits of rd, but the RV64 spec requires sign extension, causing riscv test `rv64ui-p-auipc` to fail. Add `is_sign_extend` column to constrain the MSB of the 32-bit result and fill the upper 4 bytes accordingly.