### PR TITLE
chore: remove air index requirement from rvr pure execution

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -386,19 +386,10 @@ fn create_rvr_instance(program: &str) -> Arc<RvrPureInstance<BabyBear>> {
         .or_insert_with(|| {
             let exe = load_program_executable(program)
                 .expect("Failed to load program executable for RVR cache");
-            let config = ExecuteConfig::default();
-            let engine = Engine::new(SystemParams::new_for_testing(21));
-            let pk = vm_proving_key();
-            let d_pk = engine.device().transport_pk_to_device(pk);
-            let vm = VirtualMachine::new(engine, ExecuteBuilder, config, d_pk)
-                .expect("Failed to create VM for RVR setup");
-            let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
             Arc::new(
-                executor()
-                    .instance(&exe, &executor_idx_to_air_idx)
-                    .unwrap_or_else(|err| {
-                        panic!("Failed to create RVR instance for {program}: {err}")
-                    }),
+                executor().instance(&exe).unwrap_or_else(|err| {
+                    panic!("Failed to create RVR instance for {program}: {err}")
+                }),
             )
         })
         .clone()

--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -9,6 +9,12 @@ use openvm_instructions::{instruction::Instruction, VmOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::LiftedInstr;
 
+/// Sentinel air index meaning "no chip" — used for opcodes/instructions that do
+/// not contribute to a chip's trace (e.g. `TERMINATE`) and to fill placeholder
+/// `executor_idx_to_air_idx` arrays in pure execution where air indices are
+/// irrelevant.
+pub const NO_CHIP: u32 = u32::MAX;
+
 /// Data needed by extension crates to resolve opcode/chip metadata when
 /// registering rvr extension handlers.
 #[derive(Clone, Debug, Default)]

--- a/crates/rvr/rvr-openvm-lift/src/lib.rs
+++ b/crates/rvr/rvr-openvm-lift/src/lib.rs
@@ -21,6 +21,6 @@ pub use convert::{
     ConvertError,
 };
 pub use extension::{
-    ExtensionError, ExtensionRegistry, RvrExtension, RvrExtensionCtx, VmRvrExtension,
+    ExtensionError, ExtensionRegistry, RvrExtension, RvrExtensionCtx, VmRvrExtension, NO_CHIP,
 };
 pub use helpers::decode_reg;

--- a/crates/rvr/rvr-openvm-test-utils/src/lib.rs
+++ b/crates/rvr/rvr-openvm-test-utils/src/lib.rs
@@ -237,7 +237,7 @@ where
         compare_full_memory: bool,
     ) -> Result<()> {
         // OpenVM reference
-        let interpreter = self.vm.executor().instance(exe, &self.air_idx)?;
+        let interpreter = self.vm.executor().instance(exe)?;
         let interp_state = interpreter.execute(self.make_streams(&input), None)?;
 
         // rvr execution

--- a/crates/rvr/rvr-openvm-tests/tests/deferral.rs
+++ b/crates/rvr/rvr-openvm-tests/tests/deferral.rs
@@ -295,7 +295,7 @@ impl DeferralTestHarness {
         let input_stream = streams.input_stream.clone();
 
         // OpenVM reference
-        let interpreter = self.vm.executor().instance(exe, &self.air_idx)?;
+        let interpreter = self.vm.executor().instance(exe)?;
         let interp_state = interpreter.execute(streams, None)?;
 
         // rvr compile + execute

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -316,25 +316,11 @@ where
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
     ) -> Result<Vec<u8>, SdkError> {
-        // rvr's `instance` needs an executor-to-AIR index map, only available
-        // post-keygen; route through `app_prover` to get a `VirtualMachine`.
-        #[cfg(feature = "rvr")]
-        let instance = {
-            let app_prover = self.app_prover(app_exe)?;
-            let exe = app_prover.exe();
-            app_prover
-                .vm()
-                .interpreter(&exe)
-                .map_err(VirtualMachineError::from)?
-        };
-        #[cfg(not(feature = "rvr"))]
-        let instance = {
-            let exe = self.convert_to_exe(app_exe)?;
-            self.executor
-                .instance(&exe)
-                .map_err(VirtualMachineError::from)?
-        };
-        let final_memory = instance
+        let exe = self.convert_to_exe(app_exe)?;
+        let final_memory = self
+            .executor
+            .instance(&exe)
+            .map_err(VirtualMachineError::from)?
             .execute(inputs, None)
             .map_err(VirtualMachineError::from)?
             .memory;

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -9,7 +9,7 @@ use openvm_instructions::{
 use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 use rvr_state::{GuardedMemory, TracerState};
 
 use super::{
@@ -42,8 +42,6 @@ use crate::{
         merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory, CHUNK as MERKLE_CHUNK,
     },
 };
-
-const NO_CHIP: u32 = u32::MAX;
 
 pub struct RvrMeteredInstance<F: PrimeField32, E> {
     pub(crate) system_config: SystemConfig,

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
 use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 use rvr_state::{GuardedMemory, TracerState};
 
 use super::{
@@ -51,8 +51,6 @@ impl MeteredCostConfig {
         }
     }
 }
-
-const NO_CHIP: u32 = u32::MAX;
 
 pub struct RvrMeteredCostInstance<F: PrimeField32, E> {
     pub(crate) system_config: SystemConfig,

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -466,6 +466,9 @@ where
         // Pure execution does not consult air indices, so we hand the extension
         // registry a placeholder filled with `NO_CHIP` sentinels sized to cover
         // every executor.
+        // TODO: Drop this placeholder by making `RvrExtensionCtx` take an
+        // `Option<Vec<usize>>` (or be generic over a trait/value) so pure
+        // execution can avoid passing `executor_idx_to_air_idx` altogether.
         let executor_idx_to_air_idx = vec![NO_CHIP as usize; self.inventory.executors.len()];
         let extensions = self.build_rvr_extensions(&executor_idx_to_air_idx);
         let compiled =

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -36,7 +36,7 @@ use openvm_stark_backend::{
 };
 use p3_baby_bear::BabyBear;
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{info_span, instrument};
@@ -439,12 +439,8 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    pub fn instance(
-        &self,
-        exe: &VmExe<F>,
-        executor_idx_to_air_idx: &[usize],
-    ) -> Result<RvrPureInstance<F>, StaticProgramError> {
-        Self::rvr_instance(self, exe, executor_idx_to_air_idx)
+    pub fn instance(&self, exe: &VmExe<F>) -> Result<RvrPureInstance<F>, StaticProgramError> {
+        Self::rvr_instance(self, exe)
     }
 }
 
@@ -466,12 +462,12 @@ where
     VC: VmExecutionConfig<F>,
     VC::Executor: Executor<F>,
 {
-    pub fn rvr_instance(
-        &self,
-        exe: &VmExe<F>,
-        executor_idx_to_air_idx: &[usize],
-    ) -> Result<RvrPureInstance<F>, StaticProgramError> {
-        let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+    pub fn rvr_instance(&self, exe: &VmExe<F>) -> Result<RvrPureInstance<F>, StaticProgramError> {
+        // Pure execution does not consult air indices, so we hand the extension
+        // registry a placeholder filled with `NO_CHIP` sentinels sized to cover
+        // every executor.
+        let executor_idx_to_air_idx = vec![NO_CHIP as usize; self.inventory.executors.len()];
+        let extensions = self.build_rvr_extensions(&executor_idx_to_air_idx);
         let compiled =
             rvr::compile_with_extensions(exe, &extensions).map_err(map_rvr_compile_error)?;
 
@@ -776,8 +772,7 @@ where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
     {
-        let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
-        self.executor().rvr_instance(exe, &executor_idx_to_air_idx)
+        self.executor().rvr_instance(exe)
     }
 
     // Pure AOT / RVR execution


### PR DESCRIPTION
Previously rvr execution had to use `executor_idx_to_air_idx` information in order to construct `ExtensionRegistry`. This was a problem for pure execution which didn't need air indices so the interface diverged between rvr and aot/interpreted. Now for rvr pure execution, dummy index values of `NO_CHIP` are used instead to keep the interface consistent.

towards INT-7611