### PR TITLE
feat: complete rvr feature for rv32im extension

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -27,22 +27,30 @@ jobs:
     strategy:
       matrix:
         extension:
-          - { name: "rv32im", path: "rv32im", aot: false }
-          - { name: "keccak256", path: "keccak256", aot: false }
-          - { name: "sha2", path: "sha2", aot: false }
-          - { name: "bigint", path: "bigint", aot: false }
-          - { name: "algebra", path: "algebra", aot: false }
-          - { name: "ecc", path: "ecc", aot: false }
-          - { name: "pairing", path: "pairing", aot: false }
-          - { name: "deferral", path: "deferral", aot: false }
-          - { name: "rv32im", path: "rv32im", aot: true }
-          - { name: "keccak256", path: "keccak256", aot: true }
-          - { name: "sha2", path: "sha2", aot: true }
-          - { name: "bigint", path: "bigint", aot: true }
-          - { name: "algebra", path: "algebra", aot: true }
-          - { name: "ecc", path: "ecc", aot: true }
-          - { name: "pairing", path: "pairing", aot: true }
-          - { name: "deferral", path: "deferral", aot: true }
+          - { name: "rv32im", path: "rv32im", aot: false, rvr: false }
+          - { name: "keccak256", path: "keccak256", aot: false, rvr: false }
+          - { name: "sha2", path: "sha2", aot: false, rvr: false }
+          - { name: "bigint", path: "bigint", aot: false, rvr: false }
+          - { name: "algebra", path: "algebra", aot: false, rvr: false }
+          - { name: "ecc", path: "ecc", aot: false, rvr: false }
+          - { name: "pairing", path: "pairing", aot: false, rvr: false }
+          - { name: "deferral", path: "deferral", aot: false, rvr: false }
+          - { name: "rv32im", path: "rv32im", aot: true, rvr: false }
+          - { name: "keccak256", path: "keccak256", aot: true, rvr: false }
+          - { name: "sha2", path: "sha2", aot: true, rvr: false }
+          - { name: "bigint", path: "bigint", aot: true, rvr: false }
+          - { name: "algebra", path: "algebra", aot: true, rvr: false }
+          - { name: "ecc", path: "ecc", aot: true, rvr: false }
+          - { name: "pairing", path: "pairing", aot: true, rvr: false }
+          - { name: "deferral", path: "deferral", aot: true, rvr: false }
+          - { name: "rv32im", path: "rv32im", aot: false, rvr: true }
+          - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
+          - { name: "sha2", path: "sha2", aot: false, rvr: true }
+          - { name: "bigint", path: "bigint", aot: false, rvr: true }
+          - { name: "algebra", path: "algebra", aot: false, rvr: true }
+          - { name: "ecc", path: "ecc", aot: false, rvr: true }
+          - { name: "pairing", path: "pairing", aot: false, rvr: true }
+          - { name: "deferral", path: "deferral", aot: false, rvr: true }
         platform:
           - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
@@ -78,7 +86,15 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
 
-      - name: Run ${{ format('{0}{1}', matrix.extension.name, matrix.extension.aot && '-aot' || '') }} circuit crate tests
+      - name: Install clang-22 and lld (required for rvr)
+        if: matrix.extension.rvr == true
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22
+          sudo apt-get install -y lld
+
+      - name: Run ${{ format('{0}{1}{2}', matrix.extension.name, matrix.extension.aot && '-aot' || '', matrix.extension.rvr && '-rvr' || '') }} circuit crate tests
         working-directory: extensions/${{ matrix.extension.path }}/circuit
         run: |
           TEST_THREADS="--test-threads=32"
@@ -87,6 +103,8 @@ jobs:
           fi
           if [[ "${{ matrix.extension.aot }}" == 'true' ]]; then
             cargo nextest run --cargo-profile=fast --features aot $TEST_THREADS --no-tests=pass --success-output=immediate
+          elif [[ "${{ matrix.extension.rvr }}" == 'true' ]]; then
+            cargo nextest run --cargo-profile=fast --features rvr $TEST_THREADS --no-tests=pass --success-output=immediate
           else
             cargo nextest run --cargo-profile=fast $TEST_THREADS --no-tests=pass --success-output=immediate
           fi
@@ -102,13 +120,15 @@ jobs:
           fi
           cargo nextest run --cargo-profile=fast  $GUEST_FEATURE_ARGS --no-tests=pass
 
-      - name: Run ${{ format('{0}{1}', matrix.extension.name, matrix.extension.aot && '-aot' || '') }} integration tests
-        if: hashFiles(format('extensions/{0}/tests', matrix.extension.path)) != ''
+      - name: Run ${{ format('{0}{1}{2}', matrix.extension.name, matrix.extension.aot && '-aot' || '', matrix.extension.rvr && '-rvr' || '') }} integration tests
+        if: hashFiles(format('extensions/{0}/tests', matrix.extension.path)) != '' && (matrix.extension.rvr != true || matrix.extension.name == 'rv32im')
         working-directory: extensions/${{ matrix.extension.path }}/tests
         run: |
           rustup component add rust-src --toolchain nightly-2026-01-18
           if [[ "${{ matrix.extension.aot }}" == 'true' ]]; then
             cargo nextest run --cargo-profile=fast --features aot --profile=heavy --no-tests=pass --success-output=immediate
+          elif [[ "${{ matrix.extension.rvr }}" == 'true' ]]; then
+            cargo nextest run --cargo-profile=fast --features rvr --profile=heavy --no-tests=pass --success-output=immediate
           else
             cargo nextest run --cargo-profile=fast --profile=heavy --no-tests=pass --success-output=immediate
           fi

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -35,6 +35,11 @@ jobs:
               features: "aot",
             }
           - {
+              runner: "64cpu-linux-x64",
+              image: "ubuntu24-full-x64",
+              features: "rvr",
+            }
+          - {
               runner: "test-gpu-nvidia",
               image: "ubuntu24-gpu-x64",
               features: "cuda,touchemall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6653,6 +6653,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "rand 0.9.2",
+ "rvr-openvm-ext-rv32im",
  "rvr-openvm-lift",
  "serde",
  "strum 0.26.3",
@@ -9143,6 +9144,18 @@ dependencies = [
  "openvm-pairing-guest",
  "rvr-openvm-ext-algebra-ffi",
  "rvr-openvm-ext-ffi-common",
+]
+
+[[package]]
+name = "rvr-openvm-ext-rv32im"
+version = "2.0.0-beta.2"
+dependencies = [
+ "openvm-instructions",
+ "openvm-rv32im-transpiler",
+ "openvm-stark-backend",
+ "rvr-openvm-ext-ffi-common",
+ "rvr-openvm-ir",
+ "rvr-openvm-lift",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "crates/rvr/rvr-openvm-ir",
     "crates/rvr/rvr-openvm-lift",
     "crates/rvr/rvr-openvm-ffi-common",
+    "extensions/rv32im/rvr",
     "extensions/keccak256/rvr",
     "extensions/keccak256/rvr/ffi",
     "extensions/sha2/rvr",
@@ -209,6 +210,7 @@ rvr-openvm = { path = "crates/rvr/rvr-openvm" }
 rvr-openvm-ir = { path = "crates/rvr/rvr-openvm-ir" }
 rvr-openvm-lift = { path = "crates/rvr/rvr-openvm-lift" }
 rvr-openvm-ext-ffi-common = { path = "crates/rvr/rvr-openvm-ffi-common" }
+rvr-openvm-ext-rv32im = { path = "extensions/rv32im/rvr" }
 rvr-openvm-ext-keccak = { path = "extensions/keccak256/rvr" }
 rvr-openvm-ext-keccak-ffi = { path = "extensions/keccak256/rvr/ffi" }
 rvr-openvm-ext-sha2 = { path = "extensions/sha2/rvr" }

--- a/crates/rvr/rvr-openvm-ir/src/instr.rs
+++ b/crates/rvr/rvr-openvm-ir/src/instr.rs
@@ -116,18 +116,6 @@ pub enum Instr {
     HintRandom {
         num_words_reg: Reg,
     },
-    HintStoreW {
-        ptr_reg: Reg,
-    },
-    HintBuffer {
-        ptr_reg: Reg,
-        num_words_reg: Reg,
-    },
-    Reveal {
-        src_reg: Reg,
-        ptr_reg: Reg,
-        offset: u32,
-    },
     /// Extension instruction (dispatched via trait object).
     Ext(Box<dyn ExtInstr>),
 }
@@ -191,9 +179,6 @@ impl Instr {
             Instr::HintInput => "hint_input",
             Instr::PrintStr { .. } => "print_str",
             Instr::HintRandom { .. } => "hint_random",
-            Instr::HintStoreW { .. } => "hint_storew",
-            Instr::HintBuffer { .. } => "hint_buffer",
-            Instr::Reveal { .. } => "reveal",
             Instr::Ext(e) => e.opname(),
         }
     }

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -425,9 +425,6 @@ fn simple_process_instr(instr: &Instr, regs: &mut [Option<u32>; NUM_REGS]) {
         | Instr::HintInput
         | Instr::PrintStr { .. }
         | Instr::HintRandom { .. }
-        | Instr::HintStoreW { .. }
-        | Instr::HintBuffer { .. }
-        | Instr::Reveal { .. }
         | Instr::Ext(_) => {}
     }
 }
@@ -725,9 +722,6 @@ fn transfer_instr(instr: &Instr, state: &mut RegisterState) {
         | Instr::HintInput
         | Instr::PrintStr { .. }
         | Instr::HintRandom { .. }
-        | Instr::HintStoreW { .. }
-        | Instr::HintBuffer { .. }
-        | Instr::Reveal { .. }
         | Instr::Ext(_) => {}
     }
 }

--- a/crates/rvr/rvr-openvm-lift/src/helpers.rs
+++ b/crates/rvr/rvr-openvm-lift/src/helpers.rs
@@ -1,7 +1,19 @@
-use openvm_instructions::riscv::RV32_REGISTER_NUM_LIMBS;
+use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_NUM_LIMBS};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 /// Decode register index from an OpenVM operand.
 pub fn decode_reg<F: PrimeField32>(f: F) -> u8 {
     (f.as_canonical_u32() / RV32_REGISTER_NUM_LIMBS as u32) as u8
+}
+
+/// Decode the immediate from the (c, g) field pair used by JALR, LOAD, STORE,
+/// and REVEAL.
+///
+/// OpenVM stores the lower 16 bits of the sign-extended immediate in `c`, and
+/// the sign bit in `g`. The full 32-bit value is reconstructed as:
+///   imm = (c & 0xFFFF) + g * 0xFFFF0000
+pub fn decode_imm_cg<F: PrimeField32>(insn: &Instruction<F>) -> u32 {
+    let low16 = insn.c.as_canonical_u32() & 0xffff;
+    let is_neg = insn.g.as_canonical_u32() != 0;
+    low16.wrapping_add(if is_neg { 0xFFFF0000 } else { 0 })
 }

--- a/crates/rvr/rvr-openvm-lift/src/lib.rs
+++ b/crates/rvr/rvr-openvm-lift/src/lib.rs
@@ -23,4 +23,4 @@ pub use convert::{
 pub use extension::{
     ExtensionError, ExtensionRegistry, RvrExtension, RvrExtensionCtx, VmRvrExtension, NO_CHIP,
 };
-pub use helpers::decode_reg;
+pub use helpers::{decode_imm_cg, decode_reg};

--- a/crates/rvr/rvr-openvm-lift/src/opcode.rs
+++ b/crates/rvr/rvr-openvm-lift/src/opcode.rs
@@ -6,9 +6,6 @@
 //! - Phantom sub-instructions: Nop, DebugPanic, CtStart, CtEnd, Rv32HintInput, Rv32PrintStr,
 //!   Rv32HintRandom
 //! - STOREW e=2 dispatch (normal memory store)
-//!
-//! HINT_STOREW, HINT_BUFFER, and REVEAL (STOREW with e=3) are handled by the
-//! `Rv32IoExtension`.
 
 use openvm_instructions::{
     instruction::Instruction, riscv::RV32_REGISTER_NUM_LIMBS, LocalOpcode, SysPhantom, SystemOpcode,
@@ -60,9 +57,6 @@ pub fn lift_instruction<F: PrimeField32>(
         }
         return Some(body(pc, Instr::Nop));
     }
-
-    // HINT_STOREW / HINT_BUFFER are handled by `Rv32IoExtension` via the
-    // extension registry below.
 
     // Decode the e field to determine R-type vs I-type
     let e = field_to_u32(insn.e);

--- a/crates/rvr/rvr-openvm-lift/src/opcode.rs
+++ b/crates/rvr/rvr-openvm-lift/src/opcode.rs
@@ -5,21 +5,26 @@
 //! - System instructions: TERMINATE, PHANTOM, PUBLISH
 //! - Phantom sub-instructions: Nop, DebugPanic, CtStart, CtEnd, Rv32HintInput, Rv32PrintStr,
 //!   Rv32HintRandom
-//! - IO instructions: HINT_STOREW, HINT_BUFFER
-//! - STOREW address space dispatch: memory (e=2), reveal (e=3)
+//! - STOREW e=2 dispatch (normal memory store)
+//!
+//! HINT_STOREW, HINT_BUFFER, and REVEAL (STOREW with e=3) are handled by the
+//! `Rv32IoExtension`.
 
 use openvm_instructions::{
     instruction::Instruction, riscv::RV32_REGISTER_NUM_LIMBS, LocalOpcode, SysPhantom, SystemOpcode,
 };
 use openvm_rv32im_transpiler::{
     BaseAluOpcode, BranchEqualOpcode, BranchLessThanOpcode, DivRemOpcode, LessThanOpcode,
-    MulHOpcode, MulOpcode, Rv32AuipcOpcode, Rv32HintStoreOpcode, Rv32JalLuiOpcode, Rv32JalrOpcode,
-    Rv32LoadStoreOpcode, Rv32Phantom, ShiftOpcode,
+    MulHOpcode, MulOpcode, Rv32AuipcOpcode, Rv32JalLuiOpcode, Rv32JalrOpcode, Rv32LoadStoreOpcode,
+    Rv32Phantom, ShiftOpcode,
 };
 use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_openvm_ext_ffi_common::AS_PUBLIC_VALUES;
 use rvr_openvm_ir::{
     AluOp, BranchCond, Instr, InstrAt, LiftedInstr, MemWidth, MulDivOp, Terminator,
 };
+
+use crate::helpers::decode_imm_cg;
 
 /// Lift a single OpenVM instruction to the new IR types.
 ///
@@ -56,14 +61,8 @@ pub fn lift_instruction<F: PrimeField32>(
         return Some(body(pc, Instr::Nop));
     }
 
-    // HINT_STOREW: _,b,_,1,2 — pop 4 bytes from hint stream to mem[[b]_1]
-    if opcode == Rv32HintStoreOpcode::HINT_STOREW.global_opcode_usize() {
-        return Some(lift_hint_storew(insn, pc));
-    }
-    // HINT_BUFFER: a,b,_,1,2 — pop 4*[a]_1 bytes from hint stream to mem[[b]_1]
-    if opcode == Rv32HintStoreOpcode::HINT_BUFFER.global_opcode_usize() {
-        return Some(lift_hint_buffer(insn, pc));
-    }
+    // HINT_STOREW / HINT_BUFFER are handled by `Rv32IoExtension` via the
+    // extension registry below.
 
     // Decode the e field to determine R-type vs I-type
     let e = field_to_u32(insn.e);
@@ -122,14 +121,12 @@ pub fn lift_instruction<F: PrimeField32>(
         return Some(lift_load(insn, pc, MemWidth::Half, true));
     }
     if opcode == Rv32LoadStoreOpcode::STOREW.global_opcode_usize() {
-        // Dispatch based on write address space (field e):
-        //   2 = main memory (normal store)
-        //   3 = user IO / reveal (public outputs)
+        // e = RV32_MEMORY_AS is a normal store; e = AS_PUBLIC_VALUES is REVEAL,
+        // handled by `Rv32IoExtension`.
         let addr_space = field_to_u32(insn.e);
-        return match addr_space {
-            3 => Some(lift_reveal(insn, pc)),
-            _ => Some(lift_store(insn, pc, MemWidth::Word)),
-        };
+        if addr_space != AS_PUBLIC_VALUES {
+            return Some(lift_store(insn, pc, MemWidth::Word));
+        }
     }
     if opcode == Rv32LoadStoreOpcode::STOREH.global_opcode_usize() {
         return Some(lift_store(insn, pc, MemWidth::Half));
@@ -231,17 +228,6 @@ pub fn field_to_i32<F: PrimeField32>(f: F) -> i32 {
 /// Decode register index from OpenVM operand (divided by RV32_REGISTER_NUM_LIMBS).
 pub fn decode_reg<F: PrimeField32>(f: F) -> u8 {
     (field_to_u32(f) / RV32_REGISTER_NUM_LIMBS as u32) as u8
-}
-
-/// Decode an immediate from the (c, g) field pair used by JALR, LOAD, and STORE.
-///
-/// OpenVM stores the lower 16 bits of the sign-extended immediate in `c`,
-/// and the sign bit in `g`. The full 32-bit value is reconstructed as:
-///   imm = (c & 0xFFFF) + g * 0xFFFF0000
-fn decode_imm_cg<F: PrimeField32>(insn: &Instruction<F>) -> u32 {
-    let low16 = field_to_u32(insn.c) & 0xffff;
-    let is_neg = field_to_u32(insn.g) != 0;
-    low16.wrapping_add(if is_neg { 0xFFFF0000 } else { 0 })
 }
 
 /// Sign-extend a 12-bit immediate stored in the low 24 bits.
@@ -498,38 +484,4 @@ fn lift_phantom<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr 
 
     // Unknown phantom — treat as nop (forward compatible).
     body(pc, Instr::Nop)
-}
-
-/// Lift HINT_STOREW: pop 4 bytes from hint_stream, write to mem[ptr].
-fn lift_hint_storew<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
-    let ptr_reg = decode_reg(insn.b);
-    body(pc, Instr::HintStoreW { ptr_reg })
-}
-
-/// Lift HINT_BUFFER: pop num_words*4 bytes from hint_stream, write sequentially.
-fn lift_hint_buffer<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
-    let num_words_reg = decode_reg(insn.a);
-    let ptr_reg = decode_reg(insn.b);
-    body(
-        pc,
-        Instr::HintBuffer {
-            ptr_reg,
-            num_words_reg,
-        },
-    )
-}
-
-/// Lift REVEAL (STOREW with e=3): write register value to user IO address space.
-fn lift_reveal<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
-    let src_reg = decode_reg(insn.a);
-    let ptr_reg = decode_reg(insn.b);
-    let offset = decode_imm_cg(insn);
-    body(
-        pc,
-        Instr::Reveal {
-            src_reg,
-            ptr_reg,
-            offset,
-        },
-    )
 }

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -66,8 +66,6 @@ pub fn emit_instr(ctx: &mut EmitContext, instr: &Instr) {
         }
 
         // ── OpenVM system/IO instructions ────────────────────────────
-        // The rv32im I/O instructions (HINT_STOREW, HINT_BUFFER, REVEAL) are
-        // handled in the `Rv32IoExtension` and reach this match via `Instr::Ext`.
         Instr::Nop => {}
 
         Instr::HintInput => {

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -1,7 +1,5 @@
 //! C code generation for IR instructions and terminators.
 
-use openvm_instructions::riscv::RV32_MEMORY_AS;
-use rvr_openvm_ext_ffi_common::AS_PUBLIC_VALUES;
 use rvr_openvm_ir::*;
 
 use super::context::EmitContext;
@@ -68,6 +66,8 @@ pub fn emit_instr(ctx: &mut EmitContext, instr: &Instr) {
         }
 
         // ── OpenVM system/IO instructions ────────────────────────────
+        // The rv32im I/O instructions (HINT_STOREW, HINT_BUFFER, REVEAL) are
+        // handled in the `Rv32IoExtension` and reach this match via `Instr::Ext`.
         Instr::Nop => {}
 
         Instr::HintInput => {
@@ -85,51 +85,6 @@ pub fn emit_instr(ctx: &mut EmitContext, instr: &Instr) {
             ctx.extern_call("openvm_hint_random", &[&n]);
         }
 
-        // Memory-writing IO: traced register reads + trace-only mem access.
-        Instr::HintStoreW { ptr_reg } => {
-            let ptr = ctx.read_reg(*ptr_reg);
-            ctx.trace_mem_access(&ptr, RV32_MEMORY_AS);
-            ctx.extern_call("openvm_hint_storew", &[&ptr]);
-        }
-        Instr::HintBuffer {
-            ptr_reg,
-            num_words_reg,
-        } => {
-            let ptr = ctx.read_reg(*ptr_reg);
-            let n = ctx.read_reg(*num_words_reg);
-            let chip = ctx.hint_store_chip_idx;
-            // OpenVM's HINT_BUFFER executor adds `num_words` rows to its chip
-            // in one shot. We split that into two pieces:
-            //   - The block-entry chip accounting in `project.rs` already credited +1 to this PC's
-            //     chip (the static per-instruction contribution, like every other opcode).
-            //   - Here we add the remaining +(n - 1) at runtime, since `n` is a register value not
-            //     known at codegen time.
-            // The `n > 1` guard skips the call when the static +1 is already
-            // the whole answer (HINT_STOREW-shaped hints).
-            if chip != u32::MAX {
-                ctx.write_line(&format!("if ({n} > 1) {{"));
-                ctx.write_line(&format!("  trace_chip(state, {chip}u, {n} - 1);"));
-                ctx.write_line("}");
-            }
-            // TODO: change to trace_rd_mem_u32_range
-            ctx.write_line(&format!("if ({n} > 0) {{"));
-            ctx.write_line(&format!(
-                "  trace_mem_access_u32_range(state, {ptr}, {n}, {RV32_MEMORY_AS}u);"
-            ));
-            ctx.write_line("}");
-            ctx.extern_call("openvm_hint_buffer", &[&ptr, &n]);
-        }
-        Instr::Reveal {
-            src_reg,
-            ptr_reg,
-            offset,
-        } => {
-            let src = ctx.read_reg(*src_reg);
-            let ptr = ctx.read_reg(*ptr_reg);
-            ctx.trace_mem_access(&ptr, AS_PUBLIC_VALUES);
-            let off_s = hex_u32(*offset);
-            ctx.extern_call("openvm_reveal", &[&src, &ptr, &off_s]);
-        }
         Instr::Ext(ext) => {
             ext.emit_c(ctx);
         }

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -10,18 +10,15 @@ pub struct EmitContext {
     indent: usize,
     /// Counter for unique variable names.
     var_counter: u32,
-    /// Chip index for hint_store operations (u32::MAX = no chip).
-    pub hint_store_chip_idx: u32,
 }
 
 impl EmitContext {
-    pub fn new(hot_regs: HashSet<u8>, hint_store_chip_idx: u32) -> Self {
+    pub fn new(hot_regs: HashSet<u8>) -> Self {
         Self {
             buf: String::with_capacity(1024),
             hot_regs,
             indent: 2,
             var_counter: 0,
-            hint_store_chip_idx,
         }
     }
 

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -69,8 +69,6 @@ pub struct CProject {
     pub pc_to_chip: Option<Vec<u32>>,
     /// Program PC base (used to compute pc_to_chip index).
     pub pc_base: u32,
-    /// Chip index for hint_store operations (u32::MAX = no chip).
-    pub hint_store_chip_idx: u32,
     /// Per-AIR widths for MeteredCost precomputation. Indexed by chip index.
     pub chip_widths: Option<Vec<u64>>,
     /// Compile with native debug info (`-g -fno-omit-frame-pointer`).
@@ -92,7 +90,6 @@ impl CProject {
             enable_lto: true,
             pc_to_chip: None,
             pc_base: 0,
-            hint_store_chip_idx: u32::MAX,
             chip_widths: None,
             native_debug_info: false,
         }
@@ -448,7 +445,7 @@ impl CProject {
         .unwrap();
 
         // Body instructions (each in its own scope to avoid variable collisions).
-        let mut ctx = EmitContext::new(self.hot_regs.clone(), self.hint_store_chip_idx);
+        let mut ctx = EmitContext::new(self.hot_regs.clone());
 
         // In metered mode, instret is tracked via check_counter, not per-block.
         if self.tracer_mode != TracerMode::Metered {

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -54,8 +54,6 @@ pub enum CompileError {
 pub struct ChipMapping {
     /// Per-PC chip index. Index i = chip for PC = pc_base + i*4.
     pub pc_to_chip: Vec<u32>,
-    /// Chip index for HINT_BUFFER/HINT_STOREW (None if not present).
-    pub hint_store_chip_idx: Option<u32>,
     /// Per-AIR widths (MeteredCost mode only). When present, the emitter
     /// precomputes `sum(width[chip] * count)` per block so the generated C
     /// increments `cost` by a single constant instead of loading from the
@@ -238,7 +236,6 @@ fn compile_impl<F: PrimeField32>(
     if let Some(chips) = opts.chips {
         project.pc_to_chip = Some(chips.pc_to_chip.clone());
         project.pc_base = exe.program.pc_base;
-        project.hint_store_chip_idx = chips.hint_store_chip_idx.unwrap_or(u32::MAX);
         project.chip_widths = chips.chip_widths.clone();
     }
 

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -152,8 +152,6 @@ pub struct MeteredConfig {
     pub chunk_bits: u32,
     /// Number of address spaces configured.
     pub num_addr_spaces: usize,
-    /// Chip index for HINT_BUFFER/HINT_STOREW (for IO corrections).
-    pub hint_store_chip_idx: Option<u32>,
 }
 
 impl MeteredConfig {
@@ -161,7 +159,6 @@ impl MeteredConfig {
     pub fn chip_mapping(&self) -> ChipMapping {
         ChipMapping {
             pc_to_chip: self.pc_to_chip.clone(),
-            hint_store_chip_idx: self.hint_store_chip_idx,
             chip_widths: None,
         }
     }
@@ -177,7 +174,6 @@ pub fn build_metered_config<F, E>(
     interactions: &[usize],
     constant_trace_heights: &[Option<usize>],
     system_config: &SystemConfig,
-    hint_buffer_opcode: Option<VmOpcode>,
 ) -> MeteredConfig
 where
     F: PrimeField32,
@@ -185,13 +181,6 @@ where
     let program = &exe.program;
     let pc_base = program.pc_base;
     let terminate_opcode = SystemOpcode::TERMINATE.global_opcode();
-
-    let hint_store_chip_idx = hint_buffer_opcode.and_then(|opcode| {
-        inventory
-            .instruction_lookup
-            .get(&opcode)
-            .map(|&executor_idx| executor_idx_to_air_idx[executor_idx as usize] as u32)
-    });
 
     let pc_to_chip: Vec<u32> = program
         .instructions_and_debug_infos
@@ -250,7 +239,6 @@ where
         addr_space_height,
         chunk_bits,
         num_addr_spaces,
-        hint_store_chip_idx,
     }
 }
 
@@ -747,7 +735,6 @@ where
             &ctx.segmentation_ctx.interactions,
             &constant_trace_heights,
             &self.system_config,
-            None,
         );
         trace_config.segmentation_config = ctx.segmentation_ctx.config.clone();
         trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns;
@@ -823,7 +810,6 @@ where
             &ctx.segmentation_ctx.interactions,
             &constant_trace_heights,
             &self.system_config,
-            None,
         );
         trace_config.segmentation_config = ctx.segmentation_ctx.config.clone();
         trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns;

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -37,8 +37,6 @@ pub struct MeteredCostConfig {
     pub pc_base: u32,
     /// Per-AIR widths (for cost = height * width).
     pub widths: Vec<usize>,
-    /// Chip index for the HINT_STOREW/HINT_BUFFER executor (if present in program).
-    pub hint_store_chip_idx: Option<u32>,
 }
 
 impl MeteredCostConfig {
@@ -46,7 +44,6 @@ impl MeteredCostConfig {
     pub fn chip_mapping(&self) -> ChipMapping {
         ChipMapping {
             pc_to_chip: self.pc_to_chip.clone(),
-            hint_store_chip_idx: self.hint_store_chip_idx,
             chip_widths: Some(self.widths.iter().map(|&w| w as u64).collect()),
         }
     }
@@ -66,7 +63,6 @@ pub fn build_metered_cost_config<F, E>(
     inventory: &ExecutorInventory<E>,
     executor_idx_to_air_idx: &[usize],
     widths: &[usize],
-    hint_buffer_opcode: Option<VmOpcode>,
 ) -> MeteredCostConfig
 where
     F: PrimeField32,
@@ -75,13 +71,6 @@ where
     let pc_base = program.pc_base;
 
     let terminate_opcode = SystemOpcode::TERMINATE.global_opcode();
-
-    let hint_store_chip_idx = hint_buffer_opcode.and_then(|opcode| {
-        inventory
-            .instruction_lookup
-            .get(&opcode)
-            .map(|&executor_idx| executor_idx_to_air_idx[executor_idx as usize] as u32)
-    });
 
     let pc_to_chip: Vec<u32> = program
         .instructions_and_debug_infos
@@ -107,7 +96,6 @@ where
         pc_to_chip,
         pc_base,
         widths: widths.to_vec(),
-        hint_store_chip_idx,
     }
 }
 
@@ -224,7 +212,6 @@ where
             self.inventory.as_ref(),
             &self.executor_idx_to_air_idx,
             &ctx.widths,
-            None,
         );
         // TODO: hoist compilation to instance construction; requires moving `ctx.widths` onto the
         // instance.
@@ -280,7 +267,6 @@ where
             self.inventory.as_ref(),
             &self.executor_idx_to_air_idx,
             &ctx.widths,
-            None,
         );
         let chips = metered_cost_config.chip_mapping();
 

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -57,7 +57,7 @@ use super::{
     PROGRAM_CACHED_TRACE_INDEX,
 };
 #[cfg(feature = "rvr")]
-use crate::system::memory::merkle::public_values::PUBLIC_VALUES_AS;
+use crate::system::memory::{merkle::public_values::PUBLIC_VALUES_AS, online::LinearMemory};
 use crate::{
     arch::deferral::DeferralState,
     execute_spanned,
@@ -217,7 +217,7 @@ pub(crate) fn write_rvr_memory_to_guest_memory(
     }
 
     if !public_values.is_empty() {
-        let pv_capacity = guest_memory.memory.config[PUBLIC_VALUES_AS as usize].num_cells;
+        let pv_capacity = guest_memory.memory.mem[PUBLIC_VALUES_AS as usize].size();
         let pv_len = std::cmp::min(pv_capacity, public_values.len());
         unsafe {
             guest_memory

--- a/extensions/rv32im/circuit/Cargo.toml
+++ b/extensions/rv32im/circuit/Cargo.toml
@@ -20,6 +20,7 @@ openvm-circuit-derive = { workspace = true }
 openvm-instructions = { workspace = true }
 openvm-rv32im-transpiler = { workspace = true }
 rvr-openvm-lift = { workspace = true, optional = true }
+rvr-openvm-ext-rv32im = { workspace = true, optional = true }
 strum.workspace = true
 derive-new.workspace = true
 derive_more = { workspace = true, features = ["from"] }
@@ -46,7 +47,11 @@ parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils", "dep:openvm-stark-sdk"]
 tco = ["openvm-circuit/tco"]
 aot = ["openvm-circuit/aot", "openvm-circuit-derive/aot"]
-rvr = ["dep:rvr-openvm-lift", "openvm-circuit/rvr"]
+rvr = [
+    "dep:rvr-openvm-lift",
+    "dep:rvr-openvm-ext-rv32im",
+    "openvm-circuit/rvr",
+]
 # performance features:
 mimalloc = ["openvm-circuit/mimalloc"]
 jemalloc = ["openvm-circuit/jemalloc"]

--- a/extensions/rv32im/circuit/src/extension/mod.rs
+++ b/extensions/rv32im/circuit/src/extension/mod.rs
@@ -29,7 +29,9 @@ use openvm_rv32im_transpiler::{
 };
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::VmRvrExtension;
+use rvr_openvm_ext_rv32im::Rv32IoExtension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
@@ -81,7 +83,12 @@ fn default_range_tuple_checker_sizes() -> [u32; 2] {
 impl<F: PrimeField32> VmRvrExtension<F> for Rv32I {}
 
 #[cfg(feature = "rvr")]
-impl<F: PrimeField32> VmRvrExtension<F> for Rv32Io {}
+impl<F: PrimeField32> VmRvrExtension<F> for Rv32Io {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: &RvrExtensionCtx) {
+        registry
+            .register(Rv32IoExtension::new(ctx).expect("Rv32IoExtension chip resolution failed"));
+    }
+}
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Rv32M {}

--- a/extensions/rv32im/rvr/Cargo.toml
+++ b/extensions/rv32im/rvr/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rvr-openvm-ext-rv32im"
+description = "rvr lifter for the OpenVM rv32im I/O extension (HINT_STOREW, HINT_BUFFER, REVEAL)"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+rvr-openvm-ir.workspace = true
+rvr-openvm-lift.workspace = true
+rvr-openvm-ext-ffi-common.workspace = true
+
+openvm-instructions.workspace = true
+openvm-rv32im-transpiler.workspace = true
+openvm-stark-backend.workspace = true
+
+[features]
+default = []

--- a/extensions/rv32im/rvr/src/lib.rs
+++ b/extensions/rv32im/rvr/src/lib.rs
@@ -1,0 +1,196 @@
+//! rvr lifter for the rv32im I/O sub-extension (HINT_STOREW, HINT_BUFFER,
+//! REVEAL).
+
+use std::path::Path;
+
+use openvm_instructions::{instruction::Instruction, riscv::RV32_MEMORY_AS, LocalOpcode};
+use openvm_rv32im_transpiler::{Rv32HintStoreOpcode, Rv32LoadStoreOpcode};
+use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_openvm_ext_ffi_common::AS_PUBLIC_VALUES;
+use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
+use rvr_openvm_lift::{
+    decode_imm_cg, decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP,
+};
+
+/// HINT_STOREW: pop 4 bytes from the hint stream into `mem[reg[ptr_reg]]`.
+#[derive(Debug, Clone)]
+pub struct HintStoreWInstr {
+    pub ptr_reg: Reg,
+}
+
+impl ExtInstr for HintStoreWInstr {
+    fn opname(&self) -> &str {
+        "hint_storew"
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let ptr = ctx.read_reg(self.ptr_reg);
+        ctx.write_line(&format!(
+            "trace_mem_access(state, {ptr}, {RV32_MEMORY_AS}u);"
+        ));
+        ctx.write_line(&format!("openvm_hint_storew({ptr});"));
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+}
+
+/// HINT_BUFFER: pop `4 * reg[num_words_reg]` bytes from the hint stream and
+/// write them sequentially starting at `mem[reg[ptr_reg]]`.
+#[derive(Debug, Clone)]
+pub struct HintBufferInstr {
+    pub ptr_reg: Reg,
+    pub num_words_reg: Reg,
+    pub chip_idx: u32,
+}
+
+impl ExtInstr for HintBufferInstr {
+    fn opname(&self) -> &str {
+        "hint_buffer"
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let ptr = ctx.read_reg(self.ptr_reg);
+        let n = ctx.read_reg(self.num_words_reg);
+        if self.chip_idx != NO_CHIP {
+            // Block-entry already credits a static +1; emit the runtime
+            // `(n - 1)` correction only when there is more than one row.
+            ctx.write_line(&format!("if ({n} > 1) {{"));
+            ctx.write_line(&format!(
+                "  trace_chip(state, {}u, {n} - 1);",
+                self.chip_idx
+            ));
+            ctx.write_line("}");
+        }
+        ctx.write_line(&format!("if ({n} > 0) {{"));
+        ctx.write_line(&format!(
+            "  trace_mem_access_u32_range(state, {ptr}, {n}, {RV32_MEMORY_AS}u);"
+        ));
+        ctx.write_line("}");
+        ctx.write_line(&format!("openvm_hint_buffer({ptr}, {n});"));
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+}
+
+/// REVEAL: write `reg[src_reg]` (4 bytes, little-endian) to user public-output
+/// address space at `reg[ptr_reg] + offset`.
+#[derive(Debug, Clone)]
+pub struct RevealInstr {
+    pub src_reg: Reg,
+    pub ptr_reg: Reg,
+    pub offset: u32,
+}
+
+impl ExtInstr for RevealInstr {
+    fn opname(&self) -> &str {
+        "reveal"
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let src = ctx.read_reg(self.src_reg);
+        let ptr = ctx.read_reg(self.ptr_reg);
+        ctx.write_line(&format!(
+            "trace_mem_access(state, {ptr}, {AS_PUBLIC_VALUES}u);"
+        ));
+        ctx.write_line(&format!(
+            "openvm_reveal({src}, {ptr}, 0x{:08x}u);",
+            self.offset
+        ));
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+}
+
+/// rvr extension for the rv32im I/O instructions HINT_STOREW, HINT_BUFFER, and
+/// REVEAL.
+pub struct Rv32IoExtension {
+    hint_store_chip_idx: u32,
+}
+
+impl Rv32IoExtension {
+    pub fn new_pure() -> Self {
+        Self {
+            hint_store_chip_idx: NO_CHIP,
+        }
+    }
+
+    pub fn new(ctx: &RvrExtensionCtx) -> Result<Self, ExtensionError> {
+        let opcode = Rv32HintStoreOpcode::HINT_STOREW.global_opcode();
+        let hint_store_chip_idx = match ctx.resolve_opcode_air_idx(opcode) {
+            Some(idx) => idx,
+            None => NO_CHIP,
+        };
+        Ok(Self {
+            hint_store_chip_idx,
+        })
+    }
+}
+
+impl<F: PrimeField32> RvrExtension<F> for Rv32IoExtension {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+        let opcode = insn.opcode.as_usize();
+
+        if opcode == Rv32HintStoreOpcode::HINT_STOREW.global_opcode_usize() {
+            let ptr_reg = decode_reg(insn.b);
+            return Some(LiftedInstr::Body(InstrAt {
+                pc,
+                instr: Instr::Ext(Box::new(HintStoreWInstr { ptr_reg })),
+                source_loc: None,
+            }));
+        }
+
+        if opcode == Rv32HintStoreOpcode::HINT_BUFFER.global_opcode_usize() {
+            let num_words_reg = decode_reg(insn.a);
+            let ptr_reg = decode_reg(insn.b);
+            return Some(LiftedInstr::Body(InstrAt {
+                pc,
+                instr: Instr::Ext(Box::new(HintBufferInstr {
+                    ptr_reg,
+                    num_words_reg,
+                    chip_idx: self.hint_store_chip_idx,
+                })),
+                source_loc: None,
+            }));
+        }
+
+        // REVEAL: STOREW with address-space e = AS_PUBLIC_VALUES.
+        if opcode == Rv32LoadStoreOpcode::STOREW.global_opcode_usize()
+            && insn.e.as_canonical_u32() == AS_PUBLIC_VALUES
+        {
+            let src_reg = decode_reg(insn.a);
+            let ptr_reg = decode_reg(insn.b);
+            let offset = decode_imm_cg(insn);
+            return Some(LiftedInstr::Body(InstrAt {
+                pc,
+                instr: Instr::Ext(Box::new(RevealInstr {
+                    src_reg,
+                    ptr_reg,
+                    offset,
+                })),
+                source_loc: None,
+            }));
+        }
+
+        None
+    }
+
+    fn c_headers(&self) -> Vec<(&str, &str)> {
+        Vec::new()
+    }
+
+    fn staticlib_paths(&self) -> Vec<&Path> {
+        Vec::new()
+    }
+
+    fn staticlib_path(&self) -> &Path {
+        // Unused: we override `staticlib_paths()` to return an empty list
+        // because this extension has no native side-car library.
+        Path::new("")
+    }
+}

--- a/extensions/rv32im/rvr/src/lib.rs
+++ b/extensions/rv32im/rvr/src/lib.rs
@@ -1,5 +1,8 @@
 //! rvr lifter for the rv32im I/O sub-extension (HINT_STOREW, HINT_BUFFER,
 //! REVEAL).
+//!
+//! TODO: check if other RV32IM instructions/opcodes can be separated into
+//! extensions.
 
 use std::path::Path;
 

--- a/extensions/rv32im/tests/programs/examples/reveal.rs
+++ b/extensions/rv32im/tests/programs/examples/reveal.rs
@@ -13,6 +13,8 @@ pub fn main() {
     reveal_bytes32(bytes);
     let x: u32 = core::hint::black_box(123);
     let y: u32 = core::hint::black_box(456);
+    // TODO: these reveal indices write past the default num_public_values size limit; check that
+    // going past the limit is properly handled
     reveal_u32(x, 8);
     reveal_u32(y, 10);
 }

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -330,6 +330,7 @@ mod tests {
     // AOT and RVR skip this test since it is not a trusted program: both
     // compile to native code without OpenVM's runtime memory bounds checks,
     // so an out-of-bounds load doesn't surface as a Rust panic.
+    // TODO: add an untrusted/protected mode to rvr that does bounds checking.
     #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     fn test_load_x0() {
         let config = test_rv32im_config();

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -327,7 +327,10 @@ mod tests {
 
     #[test]
     #[should_panic]
-    #[cfg(not(feature = "aot"))] // AOT skips this test since it is not a trusted program
+    // AOT and RVR skip this test since it is not a trusted program: both
+    // compile to native code without OpenVM's runtime memory bounds checks,
+    // so an out-of-bounds load doesn't surface as a Rust panic.
+    #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     fn test_load_x0() {
         let config = test_rv32im_config();
         let elf = build_example_program_at_path(get_programs_dir!(), "load_x0", &config).unwrap();


### PR DESCRIPTION
- Introduces a new `Rv32IoExtension` in rvr that handles the rv32io instructions (hint_storew, hint_buffer, reveal). This is mainly to have a struct managing the hint_store chip index.
- Adds rvr tests to the CI file in the same way as aot.

closes INT-7466