### PR TITLE
feat: implement rvr for keccak256 extension

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -64,6 +64,11 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
+      - name: Init keccak rvr FFI submodules
+        if: matrix.extension.name == 'keccak256' && matrix.extension.rvr == true
+        run: |
+          git submodule update --init extensions/keccak256/rvr/ffi/openssl
+          git submodule update --init extensions/keccak256/rvr/ffi/xkcp
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -29,13 +29,14 @@ jobs:
     strategy:
       matrix:
         crate:
-          - { name: "sha2", path: "sha2" }
-          - { name: "keccak256", path: "keccak256" }
-          - { name: "ff_derive", path: "ff_derive" }
-          - { name: "k256", path: "k256" }
-          - { name: "p256", path: "p256" }
-          - { name: "pairing", path: "pairing" }
-          - { name: "verify-stark", path: "verify-stark/circuit" }
+          - { name: "sha2", path: "sha2", rvr: false }
+          - { name: "keccak256", path: "keccak256", rvr: false }
+          - { name: "ff_derive", path: "ff_derive", rvr: false }
+          - { name: "k256", path: "k256", rvr: false }
+          - { name: "p256", path: "p256", rvr: false }
+          - { name: "pairing", path: "pairing", rvr: false }
+          - { name: "verify-stark", path: "verify-stark/circuit", rvr: false }
+          - { name: "keccak256", path: "keccak256", rvr: true }
         platform:
           - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
@@ -49,6 +50,11 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
+      - name: Init keccak rvr FFI submodules
+        if: matrix.crate.name == 'keccak256' && matrix.crate.rvr == true
+        run: |
+          git submodule update --init extensions/keccak256/rvr/ffi/openssl
+          git submodule update --init extensions/keccak256/rvr/ffi/xkcp
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -72,12 +78,22 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
 
-      - name: Run ${{ matrix.crate.name }} guest library tests
+      - name: Install clang-22 and lld (required for rvr)
+        if: matrix.crate.rvr == true
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22
+          sudo apt-get install -y lld
+
+      - name: Run ${{ format('{0}{1}', matrix.crate.name, matrix.crate.rvr && '-rvr' || '') }} guest library tests
         working-directory: guest-libs/${{ matrix.crate.path }}
         run: |
           rustup component add rust-src --toolchain nightly-2026-01-18
           EXTRA_ARGS=()
-          if [[ "${{ matrix.crate.name }}" == "sha2" || "${{ matrix.crate.name }}" == "keccak256" ]]; then
+          if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
+            EXTRA_ARGS+=(--features=rvr)
+          elif [[ "${{ matrix.crate.name }}" == "sha2" || "${{ matrix.crate.name }}" == "keccak256" ]]; then
             EXTRA_ARGS+=(--features=aot)
           elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381,aot -E 'not test(fallback)')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,6 +6378,7 @@ dependencies = [
  "openvm-stark-sdk",
  "p3-keccak-air",
  "rand 0.9.2",
+ "rvr-openvm-ext-keccak",
  "rvr-openvm-lift",
  "serde",
  "strum 0.26.3",

--- a/extensions/keccak256/circuit/Cargo.toml
+++ b/extensions/keccak256/circuit/Cargo.toml
@@ -21,6 +21,7 @@ openvm-instructions = { workspace = true }
 openvm-rv32im-circuit = { workspace = true }
 openvm-keccak256-transpiler = { workspace = true }
 rvr-openvm-lift = { workspace = true, optional = true }
+rvr-openvm-ext-keccak = { workspace = true, optional = true }
 
 p3-keccak-air = { workspace = true }
 
@@ -45,7 +46,11 @@ parallel = ["openvm-circuit/parallel"]
 test-utils = ["openvm-circuit/test-utils"]
 tco = ["openvm-rv32im-circuit/tco"]
 aot = ["openvm-circuit/aot", "openvm-rv32im-circuit/aot"]
-rvr = ["dep:rvr-openvm-lift", "openvm-rv32im-circuit/rvr"]
+rvr = [
+    "dep:rvr-openvm-lift",
+    "dep:rvr-openvm-ext-keccak",
+    "openvm-rv32im-circuit/rvr",
+]
 # performance features:
 mimalloc = ["openvm-circuit/mimalloc"]
 jemalloc = ["openvm-circuit/jemalloc"]

--- a/extensions/keccak256/circuit/src/extension/mod.rs
+++ b/extensions/keccak256/circuit/src/extension/mod.rs
@@ -122,7 +122,17 @@ where
 pub struct Keccak256;
 
 #[cfg(feature = "rvr")]
-impl<F: PrimeField32> VmRvrExtension<F> for Keccak256 {}
+impl<F: PrimeField32> VmRvrExtension<F> for Keccak256 {
+    fn extend_rvr(
+        &self,
+        registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
+        ctx: &rvr_openvm_lift::RvrExtensionCtx,
+    ) {
+        let ext = rvr_openvm_ext_keccak::KeccakExtension::new(ctx)
+            .expect("failed to construct rvr KeccakExtension");
+        registry.register(ext);
+    }
+}
 
 #[derive(Clone, Copy, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 #[cfg_attr(

--- a/extensions/keccak256/rvr/build.rs
+++ b/extensions/keccak256/rvr/build.rs
@@ -1,0 +1,45 @@
+// Build the keccak FFI staticlib alongside this crate so callers don't have
+// to. The path to the resulting `librvr_openvm_ext_keccak_ffi.a` is exposed
+// to the source via the `RVR_KECCAK_FFI_STATICLIB` cargo env var.
+
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+    let manifest_dir =
+        PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR"));
+
+    let ffi_manifest = manifest_dir.join("ffi/Cargo.toml");
+    // Use a private target dir to avoid lock contention with the outer cargo.
+    let ffi_target_dir = out_dir.join("ffi-target");
+
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let status = Command::new(&cargo)
+        .args(["build", "--release", "--manifest-path"])
+        .arg(&ffi_manifest)
+        .arg("--target-dir")
+        .arg(&ffi_target_dir)
+        .status()
+        .expect("failed to spawn cargo for rvr-openvm-ext-keccak-ffi");
+    assert!(
+        status.success(),
+        "cargo build for rvr-openvm-ext-keccak-ffi failed"
+    );
+
+    let lib_path = ffi_target_dir.join("release/librvr_openvm_ext_keccak_ffi.a");
+    assert!(
+        lib_path.exists(),
+        "expected staticlib at {} after cargo build",
+        lib_path.display()
+    );
+
+    println!(
+        "cargo:rustc-env=RVR_KECCAK_FFI_STATICLIB={}",
+        lib_path.display()
+    );
+    println!("cargo:rerun-if-changed=ffi/Cargo.toml");
+    println!("cargo:rerun-if-changed=ffi/build.rs");
+    println!("cargo:rerun-if-changed=ffi/src");
+    println!("cargo:rerun-if-changed=ffi/openssl");
+    println!("cargo:rerun-if-changed=ffi/xkcp");
+}

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -11,7 +11,7 @@ use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_keccak256_transpiler::{KeccakfOpcode, XorinOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
-use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx};
+use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
 
 /// keccak-f[1600]: read 200 bytes via `buffer_ptr_reg`, permute in place.
 #[derive(Debug, Clone)]
@@ -90,32 +90,40 @@ pub struct KeccakExtension {
 
 impl KeccakExtension {
     /// Pure-mode constructor; chip indices are unused (`trace_chip` is no-op).
-    pub fn new_pure(asm_staticlib_path: PathBuf) -> Self {
+    pub fn new_pure() -> Self {
         Self {
-            xorin_chip_idx: u32::MAX,
-            keccakf_op_chip_idx: u32::MAX,
-            keccakf_perm_chip_idx: u32::MAX,
-            asm_staticlib_path,
+            xorin_chip_idx: NO_CHIP,
+            keccakf_op_chip_idx: NO_CHIP,
+            keccakf_perm_chip_idx: NO_CHIP,
+            asm_staticlib_path: default_staticlib_path(),
         }
     }
 
     /// Resolves chip indices from the VM config.
-    pub fn new(ctx: &RvrExtensionCtx, asm_staticlib_path: PathBuf) -> Result<Self, ExtensionError> {
+    pub fn new(ctx: &RvrExtensionCtx) -> Result<Self, ExtensionError> {
         let xorin_chip_idx = ctx.require_opcode_air_idx(XorinOpcode::XORIN.global_opcode())?;
         let keccakf_op_chip_idx =
             ctx.require_opcode_air_idx(KeccakfOpcode::KECCAKF.global_opcode())?;
         // KeccakfPermAir is inserted right before KeccakfOpAir in
         // Keccak256Rv32::extend_circuit, and the chip indices are set in
         // reverse order.
-        let keccakf_perm_chip_idx = keccakf_op_chip_idx + 1;
+        let keccakf_perm_chip_idx = if keccakf_op_chip_idx == NO_CHIP {
+            NO_CHIP
+        } else {
+            keccakf_op_chip_idx + 1
+        };
 
         Ok(Self {
             xorin_chip_idx,
             keccakf_op_chip_idx,
             keccakf_perm_chip_idx,
-            asm_staticlib_path,
+            asm_staticlib_path: default_staticlib_path(),
         })
     }
+}
+
+fn default_staticlib_path() -> PathBuf {
+    PathBuf::from(env!("RVR_KECCAK_FFI_STATICLIB"))
 }
 
 impl<F: PrimeField32> RvrExtension<F> for KeccakExtension {

--- a/guest-libs/keccak256/Cargo.toml
+++ b/guest-libs/keccak256/Cargo.toml
@@ -32,6 +32,7 @@ eyre = { workspace = true }
 [features]
 default = ["tiny_keccak"]
 aot = ["openvm-sdk/aot"]
+rvr = ["openvm-sdk/rvr", "openvm-keccak256-circuit/rvr"]
 # Internal feature for testing only.
 cuda = ["openvm-keccak256-circuit/cuda"]
 # Enable tiny_keccak::Hasher trait implementation

--- a/guest-libs/keccak256/tests/lib.rs
+++ b/guest-libs/keccak256/tests/lib.rs
@@ -95,7 +95,7 @@ mod tests {
             #[allow(unused_variables)]
             let state = interpreter.execute(stdin.clone(), None)?;
 
-            #[cfg(feature = "aot")]
+            #[cfg(any(feature = "aot", feature = "rvr"))]
             {
                 use openvm_circuit::{arch::VmState, system::memory::online::GuestMemory};
                 let naive_interpreter = executor.interpreter_instance(&openvm_exe)?;


### PR DESCRIPTION
Implements the rvr feature for the keccak256 extension and also adds rvr tests to CI. Now extensions don't take a `staticlib_path` argument manually and instead uses the auto-built staticlib made by a build.rs file.

closes INT-7468