### PR TITLE
refactor: have rvr execution use openvm state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5837,6 +5837,7 @@ dependencies = [
  "rand 0.9.2",
  "rustc-hash 2.1.1",
  "rvr-openvm",
+ "rvr-openvm-ext-deferral",
  "rvr-openvm-ext-ffi-common",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -8925,6 +8926,7 @@ dependencies = [
  "openvm-deferral-transpiler",
  "openvm-instructions",
  "openvm-stark-backend",
+ "rvr-openvm-ext-ffi-common",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8922,7 +8922,7 @@ dependencies = [
 name = "rvr-openvm-ext-deferral"
 version = "2.0.0-beta.2"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.8.8",
  "openvm-circuit",
  "openvm-deferral-transpiler",
  "openvm-instructions",
@@ -9052,7 +9052,7 @@ dependencies = [
 name = "rvr-openvm-lift"
 version = "2.0.0-beta.2"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.8.8",
  "openvm-instructions",
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5837,7 +5837,6 @@ dependencies = [
  "rand 0.9.2",
  "rustc-hash 2.1.1",
  "rvr-openvm",
- "rvr-openvm-ext-deferral",
  "rvr-openvm-ext-ffi-common",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -8923,6 +8922,8 @@ dependencies = [
 name = "rvr-openvm-ext-deferral"
 version = "2.0.0-beta.2"
 dependencies = [
+ "libloading 0.8.9",
+ "openvm-circuit",
  "openvm-deferral-transpiler",
  "openvm-instructions",
  "openvm-stark-backend",
@@ -9051,6 +9052,7 @@ dependencies = [
 name = "rvr-openvm-lift"
 version = "2.0.0-beta.2"
 dependencies = [
+ "libloading 0.8.9",
  "openvm-instructions",
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",

--- a/crates/rvr/rvr-openvm-lift/Cargo.toml
+++ b/crates/rvr/rvr-openvm-lift/Cargo.toml
@@ -13,4 +13,5 @@ rvr-openvm-ir.workspace = true
 openvm-instructions.workspace = true
 openvm-rv32im-transpiler.workspace = true
 openvm-stark-backend.workspace = true
+libloading.workspace = true
 thiserror.workspace = true

--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -74,6 +74,8 @@ pub enum ExtensionError {
         opcode: VmOpcode,
         executor_idx: usize,
     },
+    #[error("failed to register host callbacks: {0}")]
+    HostCallbackRegistration(String),
 }
 
 /// Trait for an rvr-openvm extension. Each extension handles a range of opcodes
@@ -118,6 +120,20 @@ pub trait RvrExtension<F: PrimeField32>: Send + Sync {
     /// paths for submodule headers). Passed to the Makefile as EXT_CFLAGS.
     fn extra_cflags(&self) -> Vec<String> {
         vec![]
+    }
+
+    /// Register host-side callbacks for this extension with the loaded `.so`.
+    /// Called after `register_openvm_callbacks` and before `rv_execute`.
+    ///
+    /// # Safety
+    ///
+    /// `lib` must be the rvr-compiled shared library this extension was lifted
+    /// into.
+    unsafe fn register_host_callbacks(
+        &self,
+        _lib: &libloading::Library,
+    ) -> Result<(), ExtensionError> {
+        Ok(())
     }
 }
 
@@ -206,6 +222,21 @@ impl<F: PrimeField32> ExtensionRegistry<F> {
     /// Whether any extensions are registered.
     pub fn is_empty(&self) -> bool {
         self.extensions.is_empty()
+    }
+
+    /// Register host callbacks for every extension in the registry.
+    ///
+    /// # Safety
+    ///
+    /// Same requirements as [`RvrExtension::register_host_callbacks`].
+    pub unsafe fn register_host_callbacks(
+        &self,
+        lib: &libloading::Library,
+    ) -> Result<(), ExtensionError> {
+        for ext in &self.extensions {
+            unsafe { ext.register_host_callbacks(lib)? };
+        }
+        Ok(())
     }
 }
 

--- a/crates/rvr/rvr-openvm/c/openvm_io.c
+++ b/crates/rvr/rvr-openvm/c/openvm_io.c
@@ -18,16 +18,14 @@ typedef struct {
   void (*hint_buffer)(void* ctx, uint32_t dest_addr, uint32_t num_words);
   void (*reveal)(void* ctx, uint32_t src_val, uint32_t ptr, uint32_t offset);
   void (*hint_stream_set)(void* ctx, const uint8_t* data, uint32_t len);
-  int (*deferral_call_lookup)(void* ctx, uint32_t def_idx, const uint8_t* input_commit,
-                              uint8_t* output_key_out);
-  int (*deferral_output_lookup)(void* ctx, uint32_t def_idx, const uint8_t* output_commit,
-                                uint8_t* output_raw_out, uint32_t expected_len);
 } OpenVmHostCallbacks;
 
 /* NOT thread-safe: installs one process-global host callback set. */
 static OpenVmHostCallbacks g_host;
 
 void register_openvm_callbacks(const OpenVmHostCallbacks* cb) { g_host = *cb; }
+
+void* openvm_get_io_ctx(void) { return g_host.ctx; }
 
 /* ── Forwarding stubs ─────────────────────────────────────────────── */
 
@@ -49,15 +47,4 @@ void openvm_reveal(uint32_t src_val, uint32_t ptr, uint32_t offset) {
 
 void ext_hint_stream_set(const uint8_t* data, uint32_t len) {
   g_host.hint_stream_set(g_host.ctx, data, len);
-}
-
-int ext_deferral_call_lookup(uint32_t def_idx, const uint8_t* input_commit,
-                             uint8_t* output_key_out) {
-  return g_host.deferral_call_lookup(g_host.ctx, def_idx, input_commit, output_key_out);
-}
-
-int ext_deferral_output_lookup(uint32_t def_idx, const uint8_t* output_commit,
-                               uint8_t* output_raw_out, uint32_t expected_len) {
-  return g_host.deferral_output_lookup(g_host.ctx, def_idx, output_commit, output_raw_out,
-                                       expected_len);
 }

--- a/crates/rvr/rvr-openvm/c/openvm_io.h
+++ b/crates/rvr/rvr-openvm/c/openvm_io.h
@@ -14,10 +14,7 @@ void openvm_reveal(uint32_t src_val, uint32_t ptr, uint32_t offset);
 /* Extension hint stream access (called by extension FFI staticlibs). */
 void ext_hint_stream_set(const uint8_t* data, uint32_t len);
 
-/* Deferral extension callbacks (called by deferral FFI staticlib). */
-int ext_deferral_call_lookup(uint32_t def_idx, const uint8_t* input_commit,
-                             uint8_t* output_key_out);
-int ext_deferral_output_lookup(uint32_t def_idx, const uint8_t* output_commit,
-                               uint8_t* output_raw_out, uint32_t expected_len);
+/* Accessor for the openvm callback ctx pointer (the registered `OpenVmIoState`). */
+void* openvm_get_io_ctx(void);
 
 #endif /* OPENVM_IO_H */

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -19,6 +19,7 @@ openvm-instructions = { workspace = true }
 openvm-platform = { workspace = true, optional = true }
 openvm-rv32im-transpiler = { workspace = true, optional = true }
 rvr-openvm-ext-ffi-common = { workspace = true, optional = true }
+rvr-openvm-ext-deferral = { workspace = true, optional = true }
 rvr-openvm-ir = { workspace = true, optional = true }
 rvr-state = { workspace = true, optional = true }
 rvr-openvm = { workspace = true, optional = true }
@@ -105,6 +106,7 @@ rvr = [
     "dep:rvr-openvm",
     "dep:rvr-openvm-lift",
     "dep:rvr-openvm-ext-ffi-common",
+    "dep:rvr-openvm-ext-deferral",
     "dep:rvr-openvm-ir",
     "dep:rvr-state",
     "dep:openvm-platform",

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -19,7 +19,6 @@ openvm-instructions = { workspace = true }
 openvm-platform = { workspace = true, optional = true }
 openvm-rv32im-transpiler = { workspace = true, optional = true }
 rvr-openvm-ext-ffi-common = { workspace = true, optional = true }
-rvr-openvm-ext-deferral = { workspace = true, optional = true }
 rvr-openvm-ir = { workspace = true, optional = true }
 rvr-state = { workspace = true, optional = true }
 rvr-openvm = { workspace = true, optional = true }
@@ -106,7 +105,6 @@ rvr = [
     "dep:rvr-openvm",
     "dep:rvr-openvm-lift",
     "dep:rvr-openvm-ext-ffi-common",
-    "dep:rvr-openvm-ext-deferral",
     "dep:rvr-openvm-ir",
     "dep:rvr-state",
     "dep:openvm-platform",

--- a/crates/vm/src/arch/deferral.rs
+++ b/crates/vm/src/arch/deferral.rs
@@ -8,11 +8,6 @@ pub type InputCommit = Vec<u8>;
 pub type OutputCommit = Vec<u8>;
 
 /// A registered deferral closure: `input_raw → output_raw`.
-///
-/// Lives here (not in the deferral extension) because `Streams<F>` carries
-/// `Vec<Arc<DeferralFn>>` for rvr-mode lazy lookups, and `Streams<F>` is in
-/// `openvm-circuit`. Methods that need the deferral Poseidon2 hasher
-/// (`execute_deferral_fn`) stay in `openvm-deferral-circuit`.
 #[allow(clippy::type_complexity)]
 pub struct DeferralFn {
     f: Box<dyn Fn(&[u8]) -> OutputRaw + Send + Sync + 'static>,

--- a/crates/vm/src/arch/deferral.rs
+++ b/crates/vm/src/arch/deferral.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +6,33 @@ pub type InputRaw = Vec<u8>;
 pub type OutputRaw = Vec<u8>;
 pub type InputCommit = Vec<u8>;
 pub type OutputCommit = Vec<u8>;
+
+/// A registered deferral closure: `input_raw → output_raw`.
+///
+/// Lives here (not in the deferral extension) because `Streams<F>` carries
+/// `Vec<Arc<DeferralFn>>` for rvr-mode lazy lookups, and `Streams<F>` is in
+/// `openvm-circuit`. Methods that need the deferral Poseidon2 hasher
+/// (`execute_deferral_fn`) stay in `openvm-deferral-circuit`.
+#[allow(clippy::type_complexity)]
+pub struct DeferralFn {
+    f: Box<dyn Fn(&[u8]) -> OutputRaw + Send + Sync + 'static>,
+}
+
+impl Debug for DeferralFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeferralFn").finish()
+    }
+}
+
+impl DeferralFn {
+    pub fn new<FN: Fn(&[u8]) -> OutputRaw + Send + Sync + 'static>(f: FN) -> Self {
+        Self { f: Box::new(f) }
+    }
+
+    pub fn call_raw(&self, input_raw: &[u8]) -> OutputRaw {
+        (self.f)(input_raw)
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum InputMapVal {

--- a/crates/vm/src/arch/rvr/bridge.rs
+++ b/crates/vm/src/arch/rvr/bridge.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 
 /// Mut pointer + size of the RV32 main memory address space inside `vm_state`.
-///
 /// The pointer is stable for the lifetime of `vm_state.memory`'s backing.
 pub fn rv32_memory_ptr<F>(vm_state: &mut VmState<F, GuestMemory>) -> (*mut u8, usize) {
     let mem = &mut vm_state.memory.memory.mem[RV32_MEMORY_AS as usize];
@@ -27,12 +26,10 @@ pub fn rv32_memory_ptr<F>(vm_state: &mut VmState<F, GuestMemory>) -> (*mut u8, u
     (mem.as_mut_slice().as_mut_ptr(), len)
 }
 
-/// Mutable byte slice for the public-values address space.
 pub fn public_values_slice(memory: &mut AddressMap) -> &mut [u8] {
     memory.mem[PUBLIC_VALUES_AS as usize].as_mut_slice()
 }
 
-/// Read the 32 RV32 GPRs from `vm_state`'s register address space.
 pub fn read_rv32_registers<F>(vm_state: &VmState<F, GuestMemory>) -> [u32; NUM_REGS_I] {
     let mem = &vm_state.memory.memory.mem[RV32_REGISTER_AS as usize];
     let bytes = mem.as_slice();
@@ -43,7 +40,6 @@ pub fn read_rv32_registers<F>(vm_state: &VmState<F, GuestMemory>) -> [u32; NUM_R
     regs
 }
 
-/// Write the 32 RV32 GPRs back into `vm_state`'s register address space.
 pub fn write_rv32_registers<F>(vm_state: &mut VmState<F, GuestMemory>, regs: &[u32; NUM_REGS_I]) {
     let mem = &mut vm_state.memory.memory.mem[RV32_REGISTER_AS as usize];
     let bytes = mem.as_mut_slice();
@@ -53,7 +49,6 @@ pub fn write_rv32_registers<F>(vm_state: &mut VmState<F, GuestMemory>, regs: &[u
     }
 }
 
-/// Map an rvr execute error into the openvm-circuit `ExecutionError` enum.
 pub fn map_rvr_execute_error(err: ExecuteError) -> ExecutionError {
     match err {
         ExecuteError::GuestExit(code) => ExecutionError::FailedWithExitCode(code as u32),
@@ -61,31 +56,8 @@ pub fn map_rvr_execute_error(err: ExecuteError) -> ExecutionError {
     }
 }
 
-/// Map an rvr compile error into the openvm-circuit `StaticProgramError` enum.
 pub fn map_rvr_compile_error(err: super::compile::CompileError) -> crate::arch::StaticProgramError {
     crate::arch::StaticProgramError::FailToGenerateDynamicLibrary {
         err: err.to_string(),
     }
-}
-
-/// Validate the rvr execution outcome and translate to `ExecutionError`.
-pub fn ensure_rvr_outcome(
-    context: &str,
-    terminated: bool,
-    suspended: bool,
-    guest_exit_code: u8,
-    allow_suspended: bool,
-) -> Result<(), ExecutionError> {
-    if allow_suspended && suspended {
-        return Ok(());
-    }
-    if terminated {
-        if guest_exit_code == 0 {
-            return Ok(());
-        }
-        return Err(ExecutionError::FailedWithExitCode(guest_exit_code as u32));
-    }
-    Err(ExecutionError::RvrExecution(format!(
-        "{context} failed: terminated={terminated}, suspended={suspended}, guest_exit_code={guest_exit_code}"
-    )))
 }

--- a/crates/vm/src/arch/rvr/bridge.rs
+++ b/crates/vm/src/arch/rvr/bridge.rs
@@ -8,9 +8,9 @@
 use openvm_instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS};
 use rvr_state::NUM_REGS_I;
 
-use super::ExecuteError;
+use super::{compile::CompileError, ExecuteError};
 use crate::{
-    arch::{ExecutionError, VmState},
+    arch::{ExecutionError, StaticProgramError, VmState},
     system::memory::{
         merkle::public_values::PUBLIC_VALUES_AS,
         online::{GuestMemory, LinearMemory},
@@ -53,8 +53,8 @@ pub fn map_rvr_execute_error(err: ExecuteError) -> ExecutionError {
     }
 }
 
-pub fn map_rvr_compile_error(err: super::compile::CompileError) -> crate::arch::StaticProgramError {
-    crate::arch::StaticProgramError::FailToGenerateDynamicLibrary {
+pub fn map_rvr_compile_error(err: CompileError) -> StaticProgramError {
+    StaticProgramError::FailToGenerateDynamicLibrary {
         err: err.to_string(),
     }
 }

--- a/crates/vm/src/arch/rvr/bridge.rs
+++ b/crates/vm/src/arch/rvr/bridge.rs
@@ -18,12 +18,12 @@ use crate::{
     },
 };
 
-/// Mut pointer + size of the RV32 main memory address space inside `vm_state`.
+/// Mut pointer to the RV32 main memory address space inside `vm_state`.
 /// The pointer is stable for the lifetime of `vm_state.memory`'s backing.
-pub fn rv32_memory_ptr<F>(vm_state: &mut VmState<F, GuestMemory>) -> (*mut u8, usize) {
-    let mem = &mut vm_state.memory.memory.mem[RV32_MEMORY_AS as usize];
-    let len = mem.size();
-    (mem.as_mut_slice().as_mut_ptr(), len)
+pub fn rv32_memory_ptr<F>(vm_state: &mut VmState<F, GuestMemory>) -> *mut u8 {
+    vm_state.memory.memory.mem[RV32_MEMORY_AS as usize]
+        .as_mut_slice()
+        .as_mut_ptr()
 }
 
 pub fn public_values_slice(memory: &mut AddressMap) -> &mut [u8] {

--- a/crates/vm/src/arch/rvr/bridge.rs
+++ b/crates/vm/src/arch/rvr/bridge.rs
@@ -1,0 +1,91 @@
+//! Buffer access between [`VmState`] and the rvr FFI layer.
+//!
+//! Memory and public-values bytes are aliased via raw pointer; registers are
+//! the only field still copied (a 128-byte memcpy at execution boundaries).
+//! `Streams<F>` and the host RNG are borrowed directly into [`OpenVmIoState`]
+//! and never converted upfront.
+
+use openvm_instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS};
+use rvr_state::NUM_REGS_I;
+
+use super::ExecuteError;
+use crate::{
+    arch::{ExecutionError, VmState},
+    system::memory::{
+        merkle::public_values::PUBLIC_VALUES_AS,
+        online::{GuestMemory, LinearMemory},
+        AddressMap,
+    },
+};
+
+/// Mut pointer + size of the RV32 main memory address space inside `vm_state`.
+///
+/// The pointer is stable for the lifetime of `vm_state.memory`'s backing.
+pub fn rv32_memory_ptr<F>(vm_state: &mut VmState<F, GuestMemory>) -> (*mut u8, usize) {
+    let mem = &mut vm_state.memory.memory.mem[RV32_MEMORY_AS as usize];
+    let len = mem.size();
+    (mem.as_mut_slice().as_mut_ptr(), len)
+}
+
+/// Mutable byte slice for the public-values address space.
+pub fn public_values_slice(memory: &mut AddressMap) -> &mut [u8] {
+    memory.mem[PUBLIC_VALUES_AS as usize].as_mut_slice()
+}
+
+/// Read the 32 RV32 GPRs from `vm_state`'s register address space.
+pub fn read_rv32_registers<F>(vm_state: &VmState<F, GuestMemory>) -> [u32; NUM_REGS_I] {
+    let mem = &vm_state.memory.memory.mem[RV32_REGISTER_AS as usize];
+    let bytes = mem.as_slice();
+    let mut regs = [0u32; NUM_REGS_I];
+    for (i, chunk) in bytes.chunks_exact(4).take(NUM_REGS_I).enumerate() {
+        regs[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    }
+    regs
+}
+
+/// Write the 32 RV32 GPRs back into `vm_state`'s register address space.
+pub fn write_rv32_registers<F>(vm_state: &mut VmState<F, GuestMemory>, regs: &[u32; NUM_REGS_I]) {
+    let mem = &mut vm_state.memory.memory.mem[RV32_REGISTER_AS as usize];
+    let bytes = mem.as_mut_slice();
+    for (i, reg) in regs.iter().enumerate() {
+        let dst = &mut bytes[i * 4..i * 4 + 4];
+        dst.copy_from_slice(&reg.to_le_bytes());
+    }
+}
+
+/// Map an rvr execute error into the openvm-circuit `ExecutionError` enum.
+pub fn map_rvr_execute_error(err: ExecuteError) -> ExecutionError {
+    match err {
+        ExecuteError::GuestExit(code) => ExecutionError::FailedWithExitCode(code as u32),
+        other => ExecutionError::RvrExecution(other.to_string()),
+    }
+}
+
+/// Map an rvr compile error into the openvm-circuit `StaticProgramError` enum.
+pub fn map_rvr_compile_error(err: super::compile::CompileError) -> crate::arch::StaticProgramError {
+    crate::arch::StaticProgramError::FailToGenerateDynamicLibrary {
+        err: err.to_string(),
+    }
+}
+
+/// Validate the rvr execution outcome and translate to `ExecutionError`.
+pub fn ensure_rvr_outcome(
+    context: &str,
+    terminated: bool,
+    suspended: bool,
+    guest_exit_code: u8,
+    allow_suspended: bool,
+) -> Result<(), ExecutionError> {
+    if allow_suspended && suspended {
+        return Ok(());
+    }
+    if terminated {
+        if guest_exit_code == 0 {
+            return Ok(());
+        }
+        return Err(ExecutionError::FailedWithExitCode(guest_exit_code as u32));
+    }
+    Err(ExecutionError::RvrExecution(format!(
+        "{context} failed: terminated={terminated}, suspended={suspended}, guest_exit_code={guest_exit_code}"
+    )))
+}

--- a/crates/vm/src/arch/rvr/bridge.rs
+++ b/crates/vm/src/arch/rvr/bridge.rs
@@ -31,20 +31,17 @@ pub fn public_values_slice(memory: &mut AddressMap) -> &mut [u8] {
 }
 
 pub fn read_rv32_registers<F>(vm_state: &VmState<F, GuestMemory>) -> [u32; NUM_REGS_I] {
-    let mem = &vm_state.memory.memory.mem[RV32_REGISTER_AS as usize];
-    let bytes = mem.as_slice();
+    let bytes = vm_state.memory.memory.mem[RV32_REGISTER_AS as usize].as_slice();
     let mut regs = [0u32; NUM_REGS_I];
-    for (i, chunk) in bytes.chunks_exact(4).take(NUM_REGS_I).enumerate() {
-        regs[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    for (reg, chunk) in regs.iter_mut().zip(bytes.chunks_exact(4)) {
+        *reg = u32::from_le_bytes(chunk.try_into().unwrap());
     }
     regs
 }
 
 pub fn write_rv32_registers<F>(vm_state: &mut VmState<F, GuestMemory>, regs: &[u32; NUM_REGS_I]) {
-    let mem = &mut vm_state.memory.memory.mem[RV32_REGISTER_AS as usize];
-    let bytes = mem.as_mut_slice();
-    for (i, reg) in regs.iter().enumerate() {
-        let dst = &mut bytes[i * 4..i * 4 + 4];
+    let bytes = vm_state.memory.memory.mem[RV32_REGISTER_AS as usize].as_mut_slice();
+    for (reg, dst) in regs.iter().zip(bytes.chunks_exact_mut(4)) {
         dst.copy_from_slice(&reg.to_le_bytes());
     }
 }

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -74,55 +74,28 @@ pub struct CompileOptions<'a, F: PrimeField32> {
     pub native_debug_info: bool,
 }
 
-/// Compile with full options.
-pub fn compile_with_options<F: PrimeField32>(
-    exe: &VmExe<F>,
-    opts: &CompileOptions<'_, F>,
-) -> Result<RvrCompiled, CompileError> {
-    compile_impl(exe, opts)
-}
-
 /// Compile a VmExe into a shared library (pure execution, optional suspension).
-pub fn compile<F: PrimeField32>(exe: &VmExe<F>) -> Result<RvrCompiled, CompileError> {
+pub fn compile<F: PrimeField32>(
+    exe: &VmExe<F>,
+    extensions: &ExtensionRegistry<F>,
+) -> Result<RvrCompiled, CompileError> {
     compile_impl(
         exe,
         &CompileOptions {
             base_name: None,
             tracer_mode: TracerMode::Pure,
-            extensions: &ExtensionRegistry::new(),
+            extensions,
             chips: None,
             guest_debug_map: None,
             native_debug_info: false,
         },
     )
-}
-
-/// Compile a VmExe with inline metered cost tracer enabled.
-pub fn compile_metered_cost<F: PrimeField32>(
-    exe: &VmExe<F>,
-    chips: &ChipMapping,
-) -> Result<RvrCompiled, CompileError> {
-    compile_impl(
-        exe,
-        &CompileOptions {
-            base_name: None,
-            tracer_mode: TracerMode::MeteredCost,
-            extensions: &ExtensionRegistry::new(),
-            chips: Some(chips),
-            guest_debug_map: None,
-            native_debug_info: false,
-        },
-    )
-}
-
-/// Compile a VmExe with instruction-limit suspension support (same as `compile`).
-pub fn compile_with_limit<F: PrimeField32>(exe: &VmExe<F>) -> Result<RvrCompiled, CompileError> {
-    compile(exe)
 }
 
 /// Compile a VmExe with per-chip metered execution.
 pub fn compile_metered<F: PrimeField32>(
     exe: &VmExe<F>,
+    extensions: &ExtensionRegistry<F>,
     chips: &ChipMapping,
 ) -> Result<RvrCompiled, CompileError> {
     compile_impl(
@@ -130,7 +103,7 @@ pub fn compile_metered<F: PrimeField32>(
         &CompileOptions {
             base_name: None,
             tracer_mode: TracerMode::Metered,
-            extensions: &ExtensionRegistry::new(),
+            extensions,
             chips: Some(chips),
             guest_debug_map: None,
             native_debug_info: false,
@@ -138,34 +111,8 @@ pub fn compile_metered<F: PrimeField32>(
     )
 }
 
-/// Compile a VmExe with both metered cost and instruction-limit suspension.
-pub fn compile_metered_cost_with_limit<F: PrimeField32>(
-    exe: &VmExe<F>,
-    chips: &ChipMapping,
-) -> Result<RvrCompiled, CompileError> {
-    compile_metered_cost(exe, chips)
-}
-
-/// Compile a VmExe with extensions into a shared library.
-pub fn compile_with_extensions<F: PrimeField32>(
-    exe: &VmExe<F>,
-    extensions: &ExtensionRegistry<F>,
-) -> Result<RvrCompiled, CompileError> {
-    compile_impl(
-        exe,
-        &CompileOptions {
-            base_name: None,
-            tracer_mode: TracerMode::Pure,
-            extensions,
-            chips: None,
-            guest_debug_map: None,
-            native_debug_info: false,
-        },
-    )
-}
-
-/// Compile a VmExe with extensions and metered cost tracer.
-pub fn compile_metered_cost_with_extensions<F: PrimeField32>(
+/// Compile a VmExe with metered cost tracer.
+pub fn compile_metered_cost<F: PrimeField32>(
     exe: &VmExe<F>,
     extensions: &ExtensionRegistry<F>,
     chips: &ChipMapping,
@@ -175,25 +122,6 @@ pub fn compile_metered_cost_with_extensions<F: PrimeField32>(
         &CompileOptions {
             base_name: None,
             tracer_mode: TracerMode::MeteredCost,
-            extensions,
-            chips: Some(chips),
-            guest_debug_map: None,
-            native_debug_info: false,
-        },
-    )
-}
-
-/// Compile a VmExe with extensions and per-chip metered execution.
-pub fn compile_metered_with_extensions<F: PrimeField32>(
-    exe: &VmExe<F>,
-    extensions: &ExtensionRegistry<F>,
-    chips: &ChipMapping,
-) -> Result<RvrCompiled, CompileError> {
-    compile_impl(
-        exe,
-        &CompileOptions {
-            base_name: None,
-            tracer_mode: TracerMode::Metered,
             extensions,
             chips: Some(chips),
             guest_debug_map: None,

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -22,13 +22,19 @@ use super::{
         metered_periodic_check, MeteredConfig, MeteredTracerData, RvrMeteredResult,
         SegmentationState, NO_LAST_PAGE,
     },
-    metered_cost::{prepare_metered_cost, MeteredCostConfig, MeteredCostData, PureTracerData},
+    metered_cost::{
+        prepare_metered_cost, MeteredCostConfig, MeteredCostData, PureTracerData,
+        RvrMeteredCostResult,
+    },
+    pure::RvrPureResult,
     state::{
-        init_rvr_state, init_rvr_state_with_metered, init_rvr_state_with_metered_cost,
-        MeteredCostState, PureState, TracerPtr,
+        init_rvr_state, init_rvr_state_with_metered, init_rvr_state_with_metered_cost, TracerPtr,
     },
 };
 use crate::{arch::VmState, system::memory::online::GuestMemory};
+
+type RegisterFn = unsafe extern "C" fn(*const OpenVmHostCallbacks);
+type ExecuteFn = unsafe extern "C" fn(*mut c_void);
 
 /// Error during execution.
 #[derive(Debug, thiserror::Error)]
@@ -43,19 +49,6 @@ pub enum ExecuteError {
     MemoryAlloc(#[from] MemoryError),
     #[error("extension host callback registration failed: {0}")]
     ExtensionRegistration(#[from] ExtensionError),
-}
-
-/// `suspended` is `false` for unlimited runs.
-pub struct RvrPureResult {
-    pub state: PureState,
-    pub suspended: bool,
-}
-
-/// `suspended` is `false` for unlimited runs.
-pub struct RvrMeteredCostResult {
-    pub state: MeteredCostState,
-    pub cost: u64,
-    pub suspended: bool,
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -98,7 +91,6 @@ pub unsafe fn register_openvm_callbacks(
     compiled: &RvrCompiled,
     callbacks: &OpenVmHostCallbacks,
 ) -> Result<(), ExecuteError> {
-    type RegisterFn = unsafe extern "C" fn(*const OpenVmHostCallbacks);
     let register_fn: RegisterFn = unsafe {
         let sym = compiled
             .lib
@@ -119,7 +111,6 @@ pub unsafe fn rv_execute(
     compiled: &RvrCompiled,
     state_ptr: *mut c_void,
 ) -> Result<(), ExecuteError> {
-    type ExecuteFn = unsafe extern "C" fn(*mut c_void);
     let execute_fn: ExecuteFn = unsafe {
         let sym = compiled
             .lib
@@ -175,9 +166,11 @@ where
 {
     let mut io_state = build_io_state_borrowed(vm_state);
     let callbacks = build_callbacks(&mut io_state);
-    unsafe { register_openvm_callbacks(compiled, &callbacks) }?;
-    unsafe { extensions.register_host_callbacks(&compiled.lib) }?;
-    unsafe { rv_execute(compiled, state.as_void_ptr()) }?;
+    unsafe {
+        register_openvm_callbacks(compiled, &callbacks)?;
+        extensions.register_host_callbacks(&compiled.lib)?;
+        rv_execute(compiled, state.as_void_ptr())?;
+    }
 
     let status = state.execution_status();
     let success = match status {
@@ -205,14 +198,14 @@ where
 
 /// Execute a VmExe using a compiled rvr shared library against `vm_state`.
 ///
-/// If `limit` is `Some(n)`, the suspender is armed at `n` instructions and a
-/// `Suspended` outcome is accepted as success; otherwise only `Terminated`
+/// If `num_insns` is `Some(n)`, the suspender is armed at `n` instructions and
+/// a `Suspended` outcome is accepted as success; otherwise only `Terminated`
 /// (with exit-code 0) succeeds.
 pub fn execute<F: PrimeField32>(
     compiled: &RvrCompiled,
     extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
-    limit: Option<u64>,
+    num_insns: Option<u64>,
 ) -> Result<RvrPureResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
@@ -221,7 +214,7 @@ pub fn execute<F: PrimeField32>(
     let mut state = init_rvr_state(vm_state, pc);
     state.regs = initial_regs;
     state.tracer = TracerPtr(&mut tracer_data);
-    if let Some(n) = limit {
+    if let Some(n) = num_insns {
         state.suspender.set_target(n);
     }
 
@@ -230,7 +223,7 @@ pub fn execute<F: PrimeField32>(
         extensions,
         vm_state,
         &mut state,
-        limit.is_some(),
+        num_insns.is_some(),
         "execution failed",
     )?;
     Ok(RvrPureResult {
@@ -239,14 +232,14 @@ pub fn execute<F: PrimeField32>(
     })
 }
 
-/// Execute a VmExe with metered cost tracking. If `limit` is `Some(n)`, the
+/// Execute a VmExe with metered cost tracking. If `num_insns` is `Some(n)`, the
 /// suspender is armed at `n` instructions and `Suspended` counts as success.
 pub fn execute_metered_cost<F: PrimeField32>(
     compiled: &RvrCompiled,
     extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
     metered_cost_config: MeteredCostConfig,
-    limit: Option<u64>,
+    num_insns: Option<u64>,
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
@@ -259,7 +252,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
     let widths_u64 = prepare_metered_cost(&metered_cost_config);
     state.tracer.chip_widths = widths_u64.as_ptr();
     state.tracer.cost = 0;
-    if let Some(n) = limit {
+    if let Some(n) = num_insns {
         state.suspender.set_target(n);
     }
 
@@ -268,7 +261,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
         extensions,
         vm_state,
         &mut state,
-        limit.is_some(),
+        num_insns.is_some(),
         "metered-cost execution failed",
     )?;
     let cost = state.tracer.cost;

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -232,14 +232,12 @@ pub fn execute<F: PrimeField32>(
     })
 }
 
-/// Execute a VmExe with metered cost tracking. If `num_insns` is `Some(n)`, the
-/// suspender is armed at `n` instructions and `Suspended` counts as success.
+/// Execute a VmExe with metered cost tracking.
 pub fn execute_metered_cost<F: PrimeField32>(
     compiled: &RvrCompiled,
     extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
     metered_cost_config: MeteredCostConfig,
-    num_insns: Option<u64>,
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
@@ -252,24 +250,17 @@ pub fn execute_metered_cost<F: PrimeField32>(
     let widths_u64 = prepare_metered_cost(&metered_cost_config);
     state.tracer.chip_widths = widths_u64.as_ptr();
     state.tracer.cost = 0;
-    if let Some(n) = num_insns {
-        state.suspender.set_target(n);
-    }
 
-    let status = run_and_finalize(
+    run_and_finalize(
         compiled,
         extensions,
         vm_state,
         &mut state,
-        num_insns.is_some(),
+        false,
         "metered-cost execution failed",
     )?;
     let cost = state.tracer.cost;
-    Ok(RvrMeteredCostResult {
-        state,
-        cost,
-        suspended: status == ExecutionStatus::Suspended,
-    })
+    Ok(RvrMeteredCostResult { state, cost })
 }
 
 /// Execute a VmExe with per-chip metered execution and segmentation.

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -8,15 +8,15 @@
 use std::ffi::c_void;
 
 use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_openvm_lift::{ExtensionError, ExtensionRegistry};
 use rvr_state::{MemoryError, Rv32, RvState, SuspenderState, TracerState, NUM_REGS_I};
 
 use super::{
     bridge::{public_values_slice, read_rv32_registers, rv32_memory_ptr, write_rv32_registers},
     compile::RvrCompiled,
     io::{
-        host_deferral_call_lookup, host_deferral_output_lookup, host_hint_buffer, host_hint_input,
-        host_hint_random, host_hint_storew, host_hint_stream_set, host_print_str, host_reveal,
-        OpenVmHostCallbacks, OpenVmIoState,
+        host_hint_buffer, host_hint_input, host_hint_random, host_hint_storew,
+        host_hint_stream_set, host_print_str, host_reveal, OpenVmHostCallbacks, OpenVmIoState,
     },
     metered::{
         metered_periodic_check, MeteredConfig, MeteredTracerData, RvrMeteredResult,
@@ -41,6 +41,8 @@ pub enum ExecuteError {
     GuestExit(u8),
     #[error("memory allocation failed: {0}")]
     MemoryAlloc(#[from] MemoryError),
+    #[error("extension host callback registration failed: {0}")]
+    ExtensionRegistration(#[from] ExtensionError),
 }
 
 /// `suspended` is `false` for unlimited runs.
@@ -122,8 +124,6 @@ pub fn build_callbacks<F: PrimeField32>(
         hint_buffer: host_hint_buffer::<F>,
         reveal: host_reveal::<F>,
         hint_stream_set: host_hint_stream_set::<F>,
-        deferral_call_lookup: host_deferral_call_lookup::<F>,
-        deferral_output_lookup: host_deferral_output_lookup::<F>,
     }
 }
 
@@ -144,14 +144,11 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
 
 /// # Safety
 ///
-/// - `compiled` must contain a valid rvr-compiled shared library with the expected ABI
-///   (`register_openvm_callbacks` and `rv_execute` symbols).
-/// - `state_ptr` must point to a valid, mutable RV32 state struct whose tracer variant matches the
-///   one compiled into the shared library.
-pub unsafe fn register_and_execute(
+/// `compiled` must contain a valid rvr-compiled shared library exporting the
+/// `register_openvm_callbacks` symbol with the expected ABI.
+pub unsafe fn register_openvm_callbacks(
     compiled: &RvrCompiled,
     callbacks: &OpenVmHostCallbacks,
-    state_ptr: *mut c_void,
 ) -> Result<(), ExecuteError> {
     type RegisterFn = unsafe extern "C" fn(*const OpenVmHostCallbacks);
     let register_fn: RegisterFn = unsafe {
@@ -162,7 +159,18 @@ pub unsafe fn register_and_execute(
         *sym
     };
     unsafe { register_fn(callbacks) };
+    Ok(())
+}
 
+/// # Safety
+///
+/// - `compiled` must contain a valid rvr-compiled shared library exporting the `rv_execute` symbol.
+/// - `state_ptr` must point to a valid, mutable RV32 state struct whose tracer variant matches the
+///   one compiled into the shared library.
+pub unsafe fn rv_execute(
+    compiled: &RvrCompiled,
+    state_ptr: *mut c_void,
+) -> Result<(), ExecuteError> {
     type ExecuteFn = unsafe extern "C" fn(*mut c_void);
     let execute_fn: ExecuteFn = unsafe {
         let sym = compiled
@@ -210,6 +218,7 @@ fn execution_error(
 /// limit-armed callers pass `true`; unlimited callers pass `false`).
 fn run_and_finalize<F, S>(
     compiled: &RvrCompiled,
+    extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
     state: &mut S,
     allow_suspended: bool,
@@ -221,7 +230,9 @@ where
 {
     let mut io_state = build_io_state_borrowed(vm_state);
     let callbacks = build_callbacks(&mut io_state);
-    unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
+    unsafe { register_openvm_callbacks(compiled, &callbacks) }?;
+    unsafe { extensions.register_host_callbacks(&compiled.lib) }?;
+    unsafe { rv_execute(compiled, state.as_void_ptr()) }?;
 
     let outcome = outcome_of(state);
     let success = match outcome {
@@ -254,6 +265,7 @@ where
 /// (with exit-code 0) succeeds.
 pub fn execute<F: PrimeField32>(
     compiled: &RvrCompiled,
+    extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
     limit: Option<u64>,
 ) -> Result<RvrPureResult, ExecuteError> {
@@ -270,6 +282,7 @@ pub fn execute<F: PrimeField32>(
 
     let outcome = run_and_finalize(
         compiled,
+        extensions,
         vm_state,
         &mut state,
         limit.is_some(),
@@ -285,6 +298,7 @@ pub fn execute<F: PrimeField32>(
 /// suspender is armed at `n` instructions and `Suspended` counts as success.
 pub fn execute_metered_cost<F: PrimeField32>(
     compiled: &RvrCompiled,
+    extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
     metered_cost_config: MeteredCostConfig,
     limit: Option<u64>,
@@ -306,6 +320,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
 
     let outcome = run_and_finalize(
         compiled,
+        extensions,
         vm_state,
         &mut state,
         limit.is_some(),
@@ -322,6 +337,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
 /// Execute a VmExe with per-chip metered execution and segmentation.
 pub fn execute_metered<F: PrimeField32>(
     compiled: &RvrCompiled,
+    extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
     trace_config: MeteredConfig,
 ) -> Result<RvrMeteredResult, ExecuteError> {
@@ -348,6 +364,7 @@ pub fn execute_metered<F: PrimeField32>(
 
     run_and_finalize(
         compiled,
+        extensions,
         vm_state,
         &mut state,
         false,

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -8,7 +8,7 @@
 use std::ffi::c_void;
 
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_state::{InstretSuspender, RvState, TracerState, NUM_REGS_I};
+use rvr_state::{MemoryError, Rv32, RvState, SuspenderState, TracerState, NUM_REGS_I};
 
 use super::{
     bridge::{public_values_slice, read_rv32_registers, rv32_memory_ptr, write_rv32_registers},
@@ -40,7 +40,7 @@ pub enum ExecuteError {
     #[error("guest exited with non-zero exit code: {0}")]
     GuestExit(u8),
     #[error("memory allocation failed: {0}")]
-    MemoryAlloc(#[from] rvr_state::MemoryError),
+    MemoryAlloc(#[from] MemoryError),
 }
 
 /// `suspended` is `false` for unlimited runs.
@@ -84,7 +84,7 @@ fn outcome_of<S: RvrStateInspect>(state: &S) -> ExecuteOutcome {
     }
 }
 
-impl<T: TracerState> RvrStateInspect for RvState<rvr_state::Rv32, T, InstretSuspender> {
+impl<T: TracerState, S: SuspenderState> RvrStateInspect for RvState<Rv32, T, S> {
     fn pc(&self) -> u32 {
         self.pc
     }

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -9,7 +9,7 @@ use std::ffi::c_void;
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_lift::{ExtensionError, ExtensionRegistry};
-use rvr_state::{MemoryError, Rv32, RvState, SuspenderState, TracerState, NUM_REGS_I};
+use rvr_state::{ExecutionStatus, MemoryError, Rv32, RvState, SuspenderState, TracerState};
 
 use super::{
     bridge::{public_values_slice, read_rv32_registers, rv32_memory_ptr, write_rv32_registers},
@@ -56,58 +56,6 @@ pub struct RvrMeteredCostResult {
     pub state: MeteredCostState,
     pub cost: u64,
     pub suspended: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ExecuteOutcome {
-    Running,
-    Terminated,
-    Suspended,
-}
-
-/// Read-only view of any RV32 rvr state, regardless of tracer variant.
-pub trait RvrStateInspect {
-    fn pc(&self) -> u32;
-    fn instret(&self) -> u64;
-    fn regs(&self) -> &[u32; NUM_REGS_I];
-    fn is_terminated(&self) -> bool;
-    fn is_suspended(&self) -> bool;
-    fn result_code(&self) -> u8;
-    fn as_void_ptr(&mut self) -> *mut c_void;
-}
-
-fn outcome_of<S: RvrStateInspect>(state: &S) -> ExecuteOutcome {
-    if state.is_terminated() {
-        ExecuteOutcome::Terminated
-    } else if state.is_suspended() {
-        ExecuteOutcome::Suspended
-    } else {
-        ExecuteOutcome::Running
-    }
-}
-
-impl<T: TracerState, S: SuspenderState> RvrStateInspect for RvState<Rv32, T, S> {
-    fn pc(&self) -> u32 {
-        self.pc
-    }
-    fn instret(&self) -> u64 {
-        self.instret
-    }
-    fn regs(&self) -> &[u32; NUM_REGS_I] {
-        &self.regs
-    }
-    fn is_terminated(&self) -> bool {
-        Self::is_terminated(self)
-    }
-    fn is_suspended(&self) -> bool {
-        Self::is_suspended(self)
-    }
-    fn result_code(&self) -> u8 {
-        Self::result_code(self)
-    }
-    fn as_void_ptr(&mut self) -> *mut c_void {
-        Self::as_void_ptr(self)
-    }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -184,30 +132,26 @@ pub unsafe fn rv_execute(
     Ok(())
 }
 
-fn report_failure(prefix: &str, outcome: ExecuteOutcome, pc: u32, instret: u64, exit_code: u8) {
+fn report_failure(prefix: &str, status: ExecutionStatus, pc: u32, instret: u64, exit_code: u8) {
     if std::env::var_os("RVR_OPENVM_DEBUG_EXEC_FAILURE").is_some() {
         eprintln!(
-            "[rvr-openvm] {prefix}: outcome={outcome:?}, pc={pc:#x}, instret={instret}, guest_exit_code={exit_code}"
+            "[rvr-openvm] {prefix}: status={status:?}, pc={pc:#x}, instret={instret}, guest_exit_code={exit_code}"
         );
     }
 }
 
 fn execution_error(
     prefix: &str,
-    outcome: ExecuteOutcome,
+    status: ExecutionStatus,
     pc: u32,
     instret: u64,
     exit_code: u8,
 ) -> ExecuteError {
-    report_failure(prefix, outcome, pc, instret, exit_code);
-    if outcome == ExecuteOutcome::Terminated && exit_code != 0 {
+    report_failure(prefix, status, pc, instret, exit_code);
+    if status == ExecutionStatus::Terminated && exit_code != 0 {
         ExecuteError::GuestExit(exit_code)
     } else {
-        ExecuteError::ExecutionFailed(match outcome {
-            ExecuteOutcome::Running => 0,
-            ExecuteOutcome::Terminated => 1,
-            ExecuteOutcome::Suspended => 2,
-        })
+        ExecuteError::ExecutionFailed(status as i32)
     }
 }
 
@@ -216,17 +160,18 @@ fn execution_error(
 ///
 /// `allow_suspended` permits `Suspended` as a successful outcome (the
 /// limit-armed callers pass `true`; unlimited callers pass `false`).
-fn run_and_finalize<F, S>(
+fn run_and_finalize<F, T, S>(
     compiled: &RvrCompiled,
     extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
-    state: &mut S,
+    state: &mut RvState<Rv32, T, S>,
     allow_suspended: bool,
     failure_prefix: &str,
-) -> Result<ExecuteOutcome, ExecuteError>
+) -> Result<ExecutionStatus, ExecuteError>
 where
     F: PrimeField32,
-    S: RvrStateInspect,
+    T: TracerState,
+    S: SuspenderState,
 {
     let mut io_state = build_io_state_borrowed(vm_state);
     let callbacks = build_callbacks(&mut io_state);
@@ -234,23 +179,23 @@ where
     unsafe { extensions.register_host_callbacks(&compiled.lib) }?;
     unsafe { rv_execute(compiled, state.as_void_ptr()) }?;
 
-    let outcome = outcome_of(state);
-    let success = match outcome {
-        ExecuteOutcome::Terminated => state.is_terminated() && state.result_code() == 0,
-        ExecuteOutcome::Suspended => allow_suspended,
-        ExecuteOutcome::Running => false,
+    let status = state.execution_status();
+    let success = match status {
+        ExecutionStatus::Terminated => state.result_code() == 0,
+        ExecutionStatus::Suspended => allow_suspended,
+        ExecutionStatus::Running | ExecutionStatus::Trapped => false,
     };
 
     if success {
-        write_rv32_registers(vm_state, state.regs());
-        vm_state.set_pc(state.pc());
-        Ok(outcome)
+        write_rv32_registers(vm_state, &state.regs);
+        vm_state.set_pc(state.pc);
+        Ok(status)
     } else {
         Err(execution_error(
             failure_prefix,
-            outcome,
-            state.pc(),
-            state.instret(),
+            status,
+            state.pc,
+            state.instret,
             state.result_code(),
         ))
     }
@@ -280,7 +225,7 @@ pub fn execute<F: PrimeField32>(
         state.suspender.set_target(n);
     }
 
-    let outcome = run_and_finalize(
+    let status = run_and_finalize(
         compiled,
         extensions,
         vm_state,
@@ -290,7 +235,7 @@ pub fn execute<F: PrimeField32>(
     )?;
     Ok(RvrPureResult {
         state,
-        suspended: outcome == ExecuteOutcome::Suspended,
+        suspended: status == ExecutionStatus::Suspended,
     })
 }
 
@@ -318,7 +263,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
         state.suspender.set_target(n);
     }
 
-    let outcome = run_and_finalize(
+    let status = run_and_finalize(
         compiled,
         extensions,
         vm_state,
@@ -330,7 +275,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
     Ok(RvrMeteredCostResult {
         state,
         cost,
-        suspended: outcome == ExecuteOutcome::Suspended,
+        suspended: status == ExecutionStatus::Suspended,
     })
 }
 

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -129,8 +129,8 @@ pub fn build_callbacks<F: PrimeField32>(
 
 fn build_io_state_borrowed<'a, F: PrimeField32>(
     vm_state: &'a mut VmState<F, GuestMemory>,
-    memory_ptr: *mut u8,
 ) -> OpenVmIoState<'a, F> {
+    let memory_ptr = rv32_memory_ptr(vm_state);
     let streams = &mut vm_state.streams;
     OpenVmIoState {
         input_stream: &mut streams.input_stream,
@@ -212,7 +212,6 @@ fn run_and_finalize<F, S>(
     compiled: &RvrCompiled,
     vm_state: &mut VmState<F, GuestMemory>,
     state: &mut S,
-    memory_ptr: *mut u8,
     allow_suspended: bool,
     failure_prefix: &str,
 ) -> Result<ExecuteOutcome, ExecuteError>
@@ -220,8 +219,7 @@ where
     F: PrimeField32,
     S: RvrStateInspect,
 {
-    // SAFETY: state pointer is valid and matches the tracer variant.
-    let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
+    let mut io_state = build_io_state_borrowed(vm_state);
     let callbacks = build_callbacks(&mut io_state);
     unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
 
@@ -261,10 +259,9 @@ pub fn execute<F: PrimeField32>(
 ) -> Result<RvrPureResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
-    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
 
     let mut tracer_data = PureTracerData;
-    let mut state = init_rvr_state(memory_ptr, pc);
+    let mut state = init_rvr_state(vm_state, pc);
     state.regs = initial_regs;
     state.tracer = TracerPtr(&mut tracer_data);
     if let Some(n) = limit {
@@ -275,7 +272,6 @@ pub fn execute<F: PrimeField32>(
         compiled,
         vm_state,
         &mut state,
-        memory_ptr,
         limit.is_some(),
         "execution failed",
     )?;
@@ -295,10 +291,9 @@ pub fn execute_metered_cost<F: PrimeField32>(
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
-    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
 
     let mut tracer_data = MeteredCostData::default();
-    let mut state = init_rvr_state_with_metered_cost(memory_ptr, pc);
+    let mut state = init_rvr_state_with_metered_cost(vm_state, pc);
     state.regs = initial_regs;
     state.tracer = TracerPtr(&mut tracer_data);
 
@@ -313,7 +308,6 @@ pub fn execute_metered_cost<F: PrimeField32>(
         compiled,
         vm_state,
         &mut state,
-        memory_ptr,
         limit.is_some(),
         "metered-cost execution failed",
     )?;
@@ -333,10 +327,9 @@ pub fn execute_metered<F: PrimeField32>(
 ) -> Result<RvrMeteredResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
-    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
 
     let mut tracer_data = MeteredTracerData::default();
-    let mut state = init_rvr_state_with_metered(memory_ptr, pc);
+    let mut state = init_rvr_state_with_metered(vm_state, pc);
     state.regs = initial_regs;
     state.tracer = TracerPtr(&mut tracer_data);
 
@@ -357,7 +350,6 @@ pub fn execute_metered<F: PrimeField32>(
         compiled,
         vm_state,
         &mut state,
-        memory_ptr,
         false,
         "metered execution failed",
     )?;

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -4,10 +4,15 @@
 //! transient `RvState` scratch struct aliases VmState's memory and registers,
 //! and `OpenVmIoState` borrows VmState's `Streams<F>` and rng. There is no
 //! separately-owned guest memory or stream conversion.
+//!
+//! The three public entrypoints (`execute`, `execute_metered_cost`,
+//! `execute_metered`) share their FFI/outcome/writeback logic through
+//! [`run_and_finalize`] and the [`RvrStateInspect`] trait.
 
 use std::{ffi::c_void, marker::PhantomData};
 
 use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_state::{InstretSuspender, RvState, TracerState, NUM_REGS_I};
 
 use super::{
     bridge::{public_values_slice, read_rv32_registers, rv32_memory_ptr, write_rv32_registers},
@@ -18,24 +23,16 @@ use super::{
         OpenVmHostCallbacks, OpenVmIoState,
     },
     metered::{
-        metered_periodic_check, MeteredConfig, MeteredTracer, MeteredTracerData, RvrMeteredResult,
+        metered_periodic_check, MeteredConfig, MeteredTracerData, RvrMeteredResult,
         SegmentationState, NO_LAST_PAGE,
     },
-    metered_cost::{
-        prepare_metered_cost, MeteredCostConfig, MeteredCostData, MeteredCostMeter, PureTracer,
-        PureTracerData,
-    },
+    metered_cost::{prepare_metered_cost, MeteredCostConfig, MeteredCostData, PureTracerData},
     state::{
         init_rvr_state, init_rvr_state_with_metered, init_rvr_state_with_metered_cost,
-        MeteredCostState, MeteredState, PureState,
+        MeteredCostState, PureState, TracerPtr,
     },
 };
 use crate::{arch::VmState, system::memory::online::GuestMemory};
-
-/// Result of executing via rvr (state moved out for tracer/instret access).
-pub struct RvrExecutionResult {
-    pub state: PureState,
-}
 
 /// Error during execution.
 #[derive(Debug, thiserror::Error)]
@@ -50,30 +47,22 @@ pub enum ExecuteError {
     MemoryAlloc(#[from] rvr_state::MemoryError),
 }
 
-/// Result of executing with an instruction limit via rvr.
-pub struct RvrLimitedResult {
+/// Result of a pure (non-metered) execute. Covers both the limited and
+/// unlimited cases — `suspended` is `false` for unlimited runs.
+pub struct RvrPureResult {
     pub state: PureState,
-    pub instret: u64,
     pub suspended: bool,
 }
 
-/// Result of metered cost execution via rvr.
+/// Result of metered-cost execution. Covers both the limited and unlimited
+/// cases — `suspended` is `false` for unlimited runs.
 pub struct RvrMeteredCostResult {
     pub state: MeteredCostState,
     pub cost: u64,
-    pub instret: u64,
     pub suspended: bool,
 }
 
-/// Result of metered cost execution with an instruction limit via rvr.
-pub struct RvrMeteredCostLimitedResult {
-    pub state: MeteredCostState,
-    pub cost: u64,
-    pub instret: u64,
-    pub suspended: bool,
-}
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Outcome classification ───────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExecuteOutcome {
@@ -81,6 +70,57 @@ enum ExecuteOutcome {
     Terminated,
     Suspended,
 }
+
+/// Read-only view of any RV32 rvr state, regardless of tracer variant.
+///
+/// A blanket impl below covers `PureState`, `MeteredCostState`, and
+/// `MeteredState`, so generic helpers can inspect a state without naming
+/// the concrete tracer type.
+pub trait RvrStateInspect {
+    fn pc(&self) -> u32;
+    fn instret(&self) -> u64;
+    fn regs(&self) -> &[u32; NUM_REGS_I];
+    fn is_terminated(&self) -> bool;
+    fn is_suspended(&self) -> bool;
+    fn result_code(&self) -> u8;
+    fn as_void_ptr(&mut self) -> *mut c_void;
+}
+
+fn outcome_of<S: RvrStateInspect>(state: &S) -> ExecuteOutcome {
+    if state.is_terminated() {
+        ExecuteOutcome::Terminated
+    } else if state.is_suspended() {
+        ExecuteOutcome::Suspended
+    } else {
+        ExecuteOutcome::Running
+    }
+}
+
+impl<T: TracerState> RvrStateInspect for RvState<rvr_state::Rv32, T, InstretSuspender> {
+    fn pc(&self) -> u32 {
+        self.pc
+    }
+    fn instret(&self) -> u64 {
+        self.instret
+    }
+    fn regs(&self) -> &[u32; NUM_REGS_I] {
+        &self.regs
+    }
+    fn is_terminated(&self) -> bool {
+        Self::is_terminated(self)
+    }
+    fn is_suspended(&self) -> bool {
+        Self::is_suspended(self)
+    }
+    fn result_code(&self) -> u8 {
+        Self::result_code(self)
+    }
+    fn as_void_ptr(&mut self) -> *mut c_void {
+        Self::as_void_ptr(self)
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Build callbacks bound to an `OpenVmIoState<'a, F>`.
 pub fn build_callbacks<F: PrimeField32>(
@@ -183,54 +223,23 @@ fn execution_error(
     }
 }
 
-fn outcome_from_pure_state(state: &PureState) -> ExecuteOutcome {
-    if state.is_terminated() {
-        ExecuteOutcome::Terminated
-    } else if state.is_suspended() {
-        ExecuteOutcome::Suspended
-    } else {
-        ExecuteOutcome::Running
-    }
-}
-
-fn outcome_from_metered_cost_state(state: &MeteredCostState) -> ExecuteOutcome {
-    if state.is_terminated() {
-        ExecuteOutcome::Terminated
-    } else if state.is_suspended() {
-        ExecuteOutcome::Suspended
-    } else {
-        ExecuteOutcome::Running
-    }
-}
-
-fn outcome_from_metered_state(state: &MeteredState) -> ExecuteOutcome {
-    if state.is_terminated() {
-        ExecuteOutcome::Terminated
-    } else if state.is_suspended() {
-        ExecuteOutcome::Suspended
-    } else {
-        ExecuteOutcome::Running
-    }
-}
-
-// ── Public execute functions ─────────────────────────────────────────────────
-
-/// Execute a VmExe using a compiled rvr shared library against the given
-/// `vm_state`. Pc / regs / streams / rng are read from and written to
-/// `vm_state` directly.
-pub fn execute<F: PrimeField32>(
+/// Run the FFI execute against `vm_state` + `state`, validate the outcome,
+/// and on success write the final pc/regs back into `vm_state`.
+///
+/// `allow_suspended` permits `Suspended` as a successful outcome (the
+/// limit-armed callers pass `true`; unlimited callers pass `false`).
+fn run_and_finalize<F, S>(
     compiled: &RvrCompiled,
     vm_state: &mut VmState<F, GuestMemory>,
-) -> Result<RvrExecutionResult, ExecuteError> {
-    let pc = vm_state.pc();
-    let initial_regs = read_rv32_registers(vm_state);
-    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
-
-    let mut tracer_data = PureTracerData;
-    let mut state = init_rvr_state(memory_ptr, pc);
-    state.regs = initial_regs;
-    state.tracer = PureTracer(&mut tracer_data);
-
+    state: &mut S,
+    memory_ptr: *mut u8,
+    allow_suspended: bool,
+    failure_prefix: &str,
+) -> Result<ExecuteOutcome, ExecuteError>
+where
+    F: PrimeField32,
+    S: RvrStateInspect,
+{
     // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
     // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
     let exec_result = {
@@ -240,27 +249,73 @@ pub fn execute<F: PrimeField32>(
     };
     exec_result?;
 
-    let outcome = outcome_from_pure_state(&state);
-    if outcome == ExecuteOutcome::Terminated && state.is_terminated() && state.result_code() == 0 {
-        write_rv32_registers(vm_state, &state.regs);
-        vm_state.set_pc(state.pc);
-        Ok(RvrExecutionResult { state })
+    let outcome = outcome_of(state);
+    let success = match outcome {
+        ExecuteOutcome::Terminated => state.is_terminated() && state.result_code() == 0,
+        ExecuteOutcome::Suspended => allow_suspended,
+        ExecuteOutcome::Running => false,
+    };
+
+    if success {
+        write_rv32_registers(vm_state, state.regs());
+        vm_state.set_pc(state.pc());
+        Ok(outcome)
     } else {
         Err(execution_error(
-            "execution failed",
+            failure_prefix,
             outcome,
-            state.pc,
-            state.instret,
+            state.pc(),
+            state.instret(),
             state.result_code(),
         ))
     }
 }
 
-/// Execute a VmExe with metered cost tracking, tracking per-chip trace costs.
+// ── Public execute functions ─────────────────────────────────────────────────
+
+/// Execute a VmExe using a compiled rvr shared library against `vm_state`.
+///
+/// If `limit` is `Some(n)`, the suspender is armed at `n` instructions and a
+/// `Suspended` outcome is accepted as success; otherwise only `Terminated`
+/// (with exit-code 0) succeeds.
+pub fn execute<F: PrimeField32>(
+    compiled: &RvrCompiled,
+    vm_state: &mut VmState<F, GuestMemory>,
+    limit: Option<u64>,
+) -> Result<RvrPureResult, ExecuteError> {
+    let pc = vm_state.pc();
+    let initial_regs = read_rv32_registers(vm_state);
+    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
+
+    let mut tracer_data = PureTracerData;
+    let mut state = init_rvr_state(memory_ptr, pc);
+    state.regs = initial_regs;
+    state.tracer = TracerPtr(&mut tracer_data);
+    if let Some(n) = limit {
+        state.suspender.set_target(n);
+    }
+
+    let outcome = run_and_finalize(
+        compiled,
+        vm_state,
+        &mut state,
+        memory_ptr,
+        limit.is_some(),
+        "execution failed",
+    )?;
+    Ok(RvrPureResult {
+        state,
+        suspended: outcome == ExecuteOutcome::Suspended,
+    })
+}
+
+/// Execute a VmExe with metered cost tracking. If `limit` is `Some(n)`, the
+/// suspender is armed at `n` instructions and `Suspended` counts as success.
 pub fn execute_metered_cost<F: PrimeField32>(
     compiled: &RvrCompiled,
     vm_state: &mut VmState<F, GuestMemory>,
     metered_cost_config: MeteredCostConfig,
+    limit: Option<u64>,
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
@@ -269,166 +324,29 @@ pub fn execute_metered_cost<F: PrimeField32>(
     let mut tracer_data = MeteredCostData::default();
     let mut state = init_rvr_state_with_metered_cost(memory_ptr, pc);
     state.regs = initial_regs;
-    state.tracer = MeteredCostMeter(&mut tracer_data);
+    state.tracer = TracerPtr(&mut tracer_data);
 
     let widths_u64 = prepare_metered_cost(&metered_cost_config);
     state.tracer.chip_widths = widths_u64.as_ptr();
     state.tracer.cost = 0;
+    if let Some(n) = limit {
+        state.suspender.set_target(n);
+    }
 
-    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
-    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
-    let exec_result = {
-        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
-        let callbacks = build_callbacks(&mut io_state);
-        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
-    };
-    exec_result?;
-
-    let outcome = outcome_from_metered_cost_state(&state);
+    let outcome = run_and_finalize(
+        compiled,
+        vm_state,
+        &mut state,
+        memory_ptr,
+        limit.is_some(),
+        "metered-cost execution failed",
+    )?;
     let cost = state.tracer.cost;
-    let instret = state.instret;
-
-    if outcome == ExecuteOutcome::Terminated && state.is_terminated() && state.result_code() == 0 {
-        write_rv32_registers(vm_state, &state.regs);
-        vm_state.set_pc(state.pc);
-        Ok(RvrMeteredCostResult {
-            state,
-            cost,
-            instret,
-            suspended: false,
-        })
-    } else {
-        Err(execution_error(
-            "metered-cost execution failed",
-            outcome,
-            state.pc,
-            instret,
-            state.result_code(),
-        ))
-    }
-}
-
-/// Execute a VmExe with an instruction limit. Suspends via `target_instret`
-/// when instret reaches the limit.
-pub fn execute_with_limit<F: PrimeField32>(
-    compiled: &RvrCompiled,
-    vm_state: &mut VmState<F, GuestMemory>,
-    instruction_limit: u64,
-) -> Result<RvrLimitedResult, ExecuteError> {
-    let pc = vm_state.pc();
-    let initial_regs = read_rv32_registers(vm_state);
-    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
-
-    let mut tracer_data = PureTracerData;
-    let mut state = init_rvr_state(memory_ptr, pc);
-    state.regs = initial_regs;
-    state.tracer = PureTracer(&mut tracer_data);
-    state.suspender.set_target(instruction_limit);
-
-    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
-    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
-    let exec_result = {
-        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
-        let callbacks = build_callbacks(&mut io_state);
-        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
-    };
-    exec_result?;
-
-    let outcome = outcome_from_pure_state(&state);
-    let instret = state.instret;
-
-    match outcome {
-        ExecuteOutcome::Suspended => {
-            write_rv32_registers(vm_state, &state.regs);
-            vm_state.set_pc(state.pc);
-            Ok(RvrLimitedResult {
-                state,
-                instret,
-                suspended: true,
-            })
-        }
-        ExecuteOutcome::Terminated if state.is_terminated() && state.result_code() == 0 => {
-            write_rv32_registers(vm_state, &state.regs);
-            vm_state.set_pc(state.pc);
-            Ok(RvrLimitedResult {
-                state,
-                instret,
-                suspended: false,
-            })
-        }
-        _ => Err(execution_error(
-            "limited execution failed",
-            outcome,
-            state.pc,
-            instret,
-            state.result_code(),
-        )),
-    }
-}
-
-/// Execute a VmExe with metered cost and an instruction limit.
-pub fn execute_metered_cost_with_limit<F: PrimeField32>(
-    compiled: &RvrCompiled,
-    vm_state: &mut VmState<F, GuestMemory>,
-    metered_cost_config: MeteredCostConfig,
-    instruction_limit: u64,
-) -> Result<RvrMeteredCostLimitedResult, ExecuteError> {
-    let pc = vm_state.pc();
-    let initial_regs = read_rv32_registers(vm_state);
-    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
-
-    let mut tracer_data = MeteredCostData::default();
-    let mut state = init_rvr_state_with_metered_cost(memory_ptr, pc);
-    state.regs = initial_regs;
-    state.tracer = MeteredCostMeter(&mut tracer_data);
-
-    let widths_u64 = prepare_metered_cost(&metered_cost_config);
-    state.tracer.chip_widths = widths_u64.as_ptr();
-    state.tracer.cost = 0;
-    state.suspender.set_target(instruction_limit);
-
-    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
-    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
-    let exec_result = {
-        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
-        let callbacks = build_callbacks(&mut io_state);
-        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
-    };
-    exec_result?;
-
-    let outcome = outcome_from_metered_cost_state(&state);
-    let cost = state.tracer.cost;
-    let instret = state.instret;
-
-    match outcome {
-        ExecuteOutcome::Suspended => {
-            write_rv32_registers(vm_state, &state.regs);
-            vm_state.set_pc(state.pc);
-            Ok(RvrMeteredCostLimitedResult {
-                state,
-                cost,
-                instret,
-                suspended: true,
-            })
-        }
-        ExecuteOutcome::Terminated if state.is_terminated() && state.result_code() == 0 => {
-            write_rv32_registers(vm_state, &state.regs);
-            vm_state.set_pc(state.pc);
-            Ok(RvrMeteredCostLimitedResult {
-                state,
-                cost,
-                instret,
-                suspended: false,
-            })
-        }
-        _ => Err(execution_error(
-            "limited metered-cost execution failed",
-            outcome,
-            state.pc,
-            instret,
-            state.result_code(),
-        )),
-    }
+    Ok(RvrMeteredCostResult {
+        state,
+        cost,
+        suspended: outcome == ExecuteOutcome::Suspended,
+    })
 }
 
 /// Execute a VmExe with per-chip metered execution and segmentation.
@@ -444,7 +362,7 @@ pub fn execute_metered<F: PrimeField32>(
     let mut tracer_data = MeteredTracerData::default();
     let mut state = init_rvr_state_with_metered(memory_ptr, pc);
     state.regs = initial_regs;
-    state.tracer = MeteredTracer(&mut tracer_data);
+    state.tracer = TracerPtr(&mut tracer_data);
 
     let mut seg_state = SegmentationState::new(trace_config);
 
@@ -463,34 +381,20 @@ pub fn execute_metered<F: PrimeField32>(
     state.tracer.on_check = Some(metered_periodic_check);
     state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut c_void;
 
-    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
-    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
-    let exec_result = {
-        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
-        let callbacks = build_callbacks(&mut io_state);
-        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
-    };
-    exec_result?;
+    run_and_finalize(
+        compiled,
+        vm_state,
+        &mut state,
+        memory_ptr,
+        false,
+        "metered execution failed",
+    )?;
 
-    let outcome = outcome_from_metered_state(&state);
-    if outcome == ExecuteOutcome::Terminated && state.is_terminated() && state.result_code() == 0 {
-        seg_state.on_termination(
-            state.tracer.mem_page_buf_len,
-            state.tracer.pv_page_buf_len,
-            state.tracer.deferral_page_buf_len,
-            state.tracer.check_counter,
-        );
-    } else {
-        return Err(execution_error(
-            "metered execution failed",
-            outcome,
-            state.pc,
-            state.instret,
-            state.result_code(),
-        ));
-    }
-
-    write_rv32_registers(vm_state, &state.regs);
-    vm_state.set_pc(state.pc);
+    seg_state.on_termination(
+        state.tracer.mem_page_buf_len,
+        state.tracer.pv_page_buf_len,
+        state.tracer.deferral_page_buf_len,
+        state.tracer.check_counter,
+    );
     Ok(seg_state.into_result(state))
 }

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -4,12 +4,8 @@
 //! transient `RvState` scratch struct aliases VmState's memory and registers,
 //! and `OpenVmIoState` borrows VmState's `Streams<F>` and rng. There is no
 //! separately-owned guest memory or stream conversion.
-//!
-//! The three public entrypoints (`execute`, `execute_metered_cost`,
-//! `execute_metered`) share their FFI/outcome/writeback logic through
-//! [`run_and_finalize`] and the [`RvrStateInspect`] trait.
 
-use std::{ffi::c_void, marker::PhantomData};
+use std::ffi::c_void;
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_state::{InstretSuspender, RvState, TracerState, NUM_REGS_I};
@@ -47,22 +43,18 @@ pub enum ExecuteError {
     MemoryAlloc(#[from] rvr_state::MemoryError),
 }
 
-/// Result of a pure (non-metered) execute. Covers both the limited and
-/// unlimited cases — `suspended` is `false` for unlimited runs.
+/// `suspended` is `false` for unlimited runs.
 pub struct RvrPureResult {
     pub state: PureState,
     pub suspended: bool,
 }
 
-/// Result of metered-cost execution. Covers both the limited and unlimited
-/// cases — `suspended` is `false` for unlimited runs.
+/// `suspended` is `false` for unlimited runs.
 pub struct RvrMeteredCostResult {
     pub state: MeteredCostState,
     pub cost: u64,
     pub suspended: bool,
 }
-
-// ── Outcome classification ───────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExecuteOutcome {
@@ -72,10 +64,6 @@ enum ExecuteOutcome {
 }
 
 /// Read-only view of any RV32 rvr state, regardless of tracer variant.
-///
-/// A blanket impl below covers `PureState`, `MeteredCostState`, and
-/// `MeteredState`, so generic helpers can inspect a state without naming
-/// the concrete tracer type.
 pub trait RvrStateInspect {
     fn pc(&self) -> u32;
     fn instret(&self) -> u64;
@@ -122,7 +110,6 @@ impl<T: TracerState> RvrStateInspect for RvState<rvr_state::Rv32, T, InstretSusp
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/// Build callbacks bound to an `OpenVmIoState<'a, F>`.
 pub fn build_callbacks<F: PrimeField32>(
     io_state: &mut OpenVmIoState<'_, F>,
 ) -> OpenVmHostCallbacks {
@@ -140,12 +127,6 @@ pub fn build_callbacks<F: PrimeField32>(
     }
 }
 
-/// Construct an `OpenVmIoState` borrowing the relevant fields of `vm_state`.
-///
-/// Splits `vm_state.streams` (active streams + deferral cache), `rng`, and
-/// the `PUBLIC_VALUES_AS` byte slice from `memory`. The registered deferral
-/// closures and hasher live in `rvr-openvm-ext-deferral`'s thread-local
-/// runtime — see `host_deferral_call_lookup`.
 fn build_io_state_borrowed<'a, F: PrimeField32>(
     vm_state: &'a mut VmState<F, GuestMemory>,
     memory_ptr: *mut u8,
@@ -158,7 +139,6 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
         memory_ptr,
         public_values: public_values_slice(&mut vm_state.memory.memory),
         deferrals: &mut streams.deferrals,
-        _marker: PhantomData,
     }
 }
 
@@ -240,14 +220,10 @@ where
     F: PrimeField32,
     S: RvrStateInspect,
 {
-    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
-    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
-    let exec_result = {
-        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
-        let callbacks = build_callbacks(&mut io_state);
-        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
-    };
-    exec_result?;
+    // SAFETY: state pointer is valid and matches the tracer variant.
+    let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
+    let callbacks = build_callbacks(&mut io_state);
+    unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
 
     let outcome = outcome_of(state);
     let success = match outcome {
@@ -365,8 +341,6 @@ pub fn execute_metered<F: PrimeField32>(
     state.tracer = TracerPtr(&mut tracer_data);
 
     let mut seg_state = SegmentationState::new(trace_config);
-
-    // Wire up the C tracer fields
     state.tracer.trace_heights = seg_state.trace_heights_ptr();
     state.tracer.mem_page_buf = seg_state.mem_page_buf_ptr();
     state.tracer.pv_page_buf = seg_state.pv_page_buf_ptr();
@@ -375,8 +349,6 @@ pub fn execute_metered<F: PrimeField32>(
     state.tracer.pv_page_buf_len = 0;
     state.tracer.deferral_page_buf_len = 0;
     state.tracer.last_mem_page = NO_LAST_PAGE;
-
-    // Wire up inline callback for periodic segmentation checks.
     state.tracer.check_counter = seg_state.config().segment_check_insns as u32;
     state.tracer.on_check = Some(metered_periodic_check);
     state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut c_void;

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -123,29 +123,6 @@ pub unsafe fn rv_execute(
     Ok(())
 }
 
-fn report_failure(prefix: &str, status: ExecutionStatus, pc: u32, instret: u64, exit_code: u8) {
-    if std::env::var_os("RVR_OPENVM_DEBUG_EXEC_FAILURE").is_some() {
-        eprintln!(
-            "[rvr-openvm] {prefix}: status={status:?}, pc={pc:#x}, instret={instret}, guest_exit_code={exit_code}"
-        );
-    }
-}
-
-fn execution_error(
-    prefix: &str,
-    status: ExecutionStatus,
-    pc: u32,
-    instret: u64,
-    exit_code: u8,
-) -> ExecuteError {
-    report_failure(prefix, status, pc, instret, exit_code);
-    if status == ExecutionStatus::Terminated && exit_code != 0 {
-        ExecuteError::GuestExit(exit_code)
-    } else {
-        ExecuteError::ExecutionFailed(status as i32)
-    }
-}
-
 /// Run the FFI execute against `vm_state` + `state`, validate the outcome,
 /// and on success write the final pc/regs back into `vm_state`.
 ///
@@ -157,7 +134,6 @@ fn run_and_finalize<F, T, S>(
     vm_state: &mut VmState<F, GuestMemory>,
     state: &mut RvState<Rv32, T, S>,
     allow_suspended: bool,
-    failure_prefix: &str,
 ) -> Result<ExecutionStatus, ExecuteError>
 where
     F: PrimeField32,
@@ -173,24 +149,23 @@ where
     }
 
     let status = state.execution_status();
-    let success = match status {
-        ExecutionStatus::Terminated => state.result_code() == 0,
-        ExecutionStatus::Suspended => allow_suspended,
-        ExecutionStatus::Running | ExecutionStatus::Trapped => false,
-    };
-
-    if success {
-        write_rv32_registers(vm_state, &state.regs);
-        vm_state.set_pc(state.pc);
-        Ok(status)
-    } else {
-        Err(execution_error(
-            failure_prefix,
-            status,
-            state.pc,
-            state.instret,
-            state.result_code(),
-        ))
+    let exit_code = state.result_code();
+    match status {
+        ExecutionStatus::Terminated if exit_code == 0 => {
+            write_rv32_registers(vm_state, &state.regs);
+            vm_state.set_pc(state.pc);
+            Ok(status)
+        }
+        ExecutionStatus::Suspended if allow_suspended => {
+            write_rv32_registers(vm_state, &state.regs);
+            vm_state.set_pc(state.pc);
+            Ok(status)
+        }
+        _ => Err(if status == ExecutionStatus::Terminated {
+            ExecuteError::GuestExit(exit_code)
+        } else {
+            ExecuteError::ExecutionFailed(status as i32)
+        }),
     }
 }
 
@@ -224,8 +199,8 @@ pub fn execute<F: PrimeField32>(
         vm_state,
         &mut state,
         num_insns.is_some(),
-        "execution failed",
-    )?;
+    )
+    .inspect_err(|e| eprintln!("rvr pure execution failed: {e}"))?;
     Ok(RvrPureResult {
         state,
         suspended: status == ExecutionStatus::Suspended,
@@ -251,14 +226,8 @@ pub fn execute_metered_cost<F: PrimeField32>(
     state.tracer.chip_widths = widths_u64.as_ptr();
     state.tracer.cost = 0;
 
-    run_and_finalize(
-        compiled,
-        extensions,
-        vm_state,
-        &mut state,
-        false,
-        "metered-cost execution failed",
-    )?;
+    run_and_finalize(compiled, extensions, vm_state, &mut state, false)
+        .inspect_err(|e| eprintln!("rvr metered-cost execution failed: {e}"))?;
     let cost = state.tracer.cost;
     Ok(RvrMeteredCostResult { state, cost })
 }
@@ -291,14 +260,8 @@ pub fn execute_metered<F: PrimeField32>(
     state.tracer.on_check = Some(metered_periodic_check);
     state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut c_void;
 
-    run_and_finalize(
-        compiled,
-        extensions,
-        vm_state,
-        &mut state,
-        false,
-        "metered execution failed",
-    )?;
+    run_and_finalize(compiled, extensions, vm_state, &mut state, false)
+        .inspect_err(|e| eprintln!("rvr metered execution failed: {e}"))?;
 
     seg_state.on_termination(
         state.tracer.mem_page_buf_len,

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -1,19 +1,20 @@
 //! Load .so, bridge state, call rv_execute.
+//!
+//! Each execution path takes `&mut VmState<F, GuestMemory>` directly: the
+//! transient `RvState` scratch struct aliases VmState's memory and registers,
+//! and `OpenVmIoState` borrows VmState's `Streams<F>` and rng. There is no
+//! separately-owned guest memory or stream conversion.
 
-use std::{collections::VecDeque, ffi::c_void};
+use std::{ffi::c_void, marker::PhantomData};
 
-use openvm_instructions::exe::VmExe;
-use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
-use rand::{rngs::StdRng, SeedableRng};
-use rvr_state::GuardedMemory;
 
 use super::{
+    bridge::{public_values_slice, read_rv32_registers, rv32_memory_ptr, write_rv32_registers},
     compile::RvrCompiled,
     io::{
-        convert_input_stream, host_deferral_call_lookup, host_deferral_output_lookup,
-        host_hint_buffer, host_hint_input, host_hint_random, host_hint_storew,
-        host_hint_stream_set, host_print_str, host_reveal, DeferralFnPtr, DeferralHashFn,
+        host_deferral_call_lookup, host_deferral_output_lookup, host_hint_buffer, host_hint_input,
+        host_hint_random, host_hint_storew, host_hint_stream_set, host_print_str, host_reveal,
         OpenVmHostCallbacks, OpenVmIoState,
     },
     metered::{
@@ -29,13 +30,11 @@ use super::{
         MeteredCostState, MeteredState, PureState,
     },
 };
-use crate::arch::deferral::DeferralState;
+use crate::{arch::VmState, system::memory::online::GuestMemory};
 
-/// Result of executing via rvr.
+/// Result of executing via rvr (state moved out for tracer/instret access).
 pub struct RvrExecutionResult {
     pub state: PureState,
-    pub memory: GuardedMemory,
-    pub public_values: Vec<u8>,
 }
 
 /// Error during execution.
@@ -54,7 +53,6 @@ pub enum ExecuteError {
 /// Result of executing with an instruction limit via rvr.
 pub struct RvrLimitedResult {
     pub state: PureState,
-    pub memory: GuardedMemory,
     pub instret: u64,
     pub suspended: bool,
 }
@@ -62,7 +60,6 @@ pub struct RvrLimitedResult {
 /// Result of metered cost execution via rvr.
 pub struct RvrMeteredCostResult {
     pub state: MeteredCostState,
-    pub memory: GuardedMemory,
     pub cost: u64,
     pub instret: u64,
     pub suspended: bool,
@@ -71,7 +68,6 @@ pub struct RvrMeteredCostResult {
 /// Result of metered cost execution with an instruction limit via rvr.
 pub struct RvrMeteredCostLimitedResult {
     pub state: MeteredCostState,
-    pub memory: GuardedMemory,
     pub cost: u64,
     pub instret: u64,
     pub suspended: bool,
@@ -86,38 +82,44 @@ enum ExecuteOutcome {
     Suspended,
 }
 
-pub fn build_io_state(
-    input_stream: VecDeque<Vec<u8>>,
-    memory: *mut u8,
-    deferrals: Vec<DeferralState>,
-    deferral_fns: Vec<DeferralFnPtr>,
-    deferral_hash: Option<DeferralHashFn>,
-) -> OpenVmIoState {
-    OpenVmIoState {
-        input_stream,
-        hint_stream: Vec::new(),
-        hint_pos: 0,
-        public_values: Vec::new(),
-        memory,
-        rng: StdRng::seed_from_u64(0),
-        deferrals,
-        deferral_fns,
-        deferral_hash,
+/// Build callbacks bound to an `OpenVmIoState<'a, F>`.
+pub fn build_callbacks<F: PrimeField32>(
+    io_state: &mut OpenVmIoState<'_, F>,
+) -> OpenVmHostCallbacks {
+    OpenVmHostCallbacks {
+        ctx: io_state as *mut OpenVmIoState<'_, F> as *mut c_void,
+        hint_input: host_hint_input::<F>,
+        print_str: host_print_str::<F>,
+        hint_random: host_hint_random::<F>,
+        hint_storew: host_hint_storew::<F>,
+        hint_buffer: host_hint_buffer::<F>,
+        reveal: host_reveal::<F>,
+        hint_stream_set: host_hint_stream_set::<F>,
+        deferral_call_lookup: host_deferral_call_lookup::<F>,
+        deferral_output_lookup: host_deferral_output_lookup::<F>,
     }
 }
 
-pub fn build_callbacks(io_state: &mut OpenVmIoState) -> OpenVmHostCallbacks {
-    OpenVmHostCallbacks {
-        ctx: io_state as *mut OpenVmIoState as *mut c_void,
-        hint_input: host_hint_input,
-        print_str: host_print_str,
-        hint_random: host_hint_random,
-        hint_storew: host_hint_storew,
-        hint_buffer: host_hint_buffer,
-        reveal: host_reveal,
-        hint_stream_set: host_hint_stream_set,
-        deferral_call_lookup: host_deferral_call_lookup,
-        deferral_output_lookup: host_deferral_output_lookup,
+/// Construct an `OpenVmIoState` borrowing the relevant fields of `vm_state`.
+///
+/// Splits `vm_state` into disjoint borrows: `streams` fields (mutable for the
+/// active streams + deferral cache, immutable for the registered closures),
+/// `rng`, and the `PUBLIC_VALUES_AS` byte slice from `memory`.
+fn build_io_state_borrowed<'a, F: PrimeField32>(
+    vm_state: &'a mut VmState<F, GuestMemory>,
+    memory_ptr: *mut u8,
+) -> OpenVmIoState<'a, F> {
+    let streams = &mut vm_state.streams;
+    OpenVmIoState {
+        input_stream: &mut streams.input_stream,
+        hint_stream: &mut streams.hint_stream,
+        rng: &mut vm_state.rng,
+        memory_ptr,
+        public_values: public_values_slice(&mut vm_state.memory.memory),
+        deferrals: &mut streams.deferrals,
+        deferral_fns: streams.deferral_fns.as_slice(),
+        deferral_hash: streams.deferral_hash.as_ref(),
+        _marker: PhantomData,
     }
 }
 
@@ -214,41 +216,36 @@ fn outcome_from_metered_state(state: &MeteredState) -> ExecuteOutcome {
 
 // ── Public execute functions ─────────────────────────────────────────────────
 
-/// Execute a VmExe using a compiled rvr shared library.
+/// Execute a VmExe using a compiled rvr shared library against the given
+/// `vm_state`. Pc / regs / streams / rng are read from and written to
+/// `vm_state` directly.
 pub fn execute<F: PrimeField32>(
     compiled: &RvrCompiled,
-    exe: &VmExe<F>,
-    input_stream: VecDeque<Vec<F>>,
-    hint_stream: Vec<u8>,
-    deferrals: Vec<DeferralState>,
-    deferral_fns: Vec<DeferralFnPtr>,
-    deferral_hash: Option<DeferralHashFn>,
+    vm_state: &mut VmState<F, GuestMemory>,
 ) -> Result<RvrExecutionResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(MEM_SIZE)?;
+    let pc = vm_state.pc();
+    let initial_regs = read_rv32_registers(vm_state);
+    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
+
     let mut tracer_data = PureTracerData;
-    let mut state = init_rvr_state(exe, &mut memory);
+    let mut state = init_rvr_state(memory_ptr, pc);
+    state.regs = initial_regs;
     state.tracer = PureTracer(&mut tracer_data);
 
-    let mut io_state = build_io_state(
-        convert_input_stream(&input_stream),
-        memory.as_mut_ptr(),
-        deferrals,
-        deferral_fns,
-        deferral_hash,
-    );
-    io_state.hint_stream = hint_stream;
-    io_state.hint_pos = 0;
-    let callbacks = build_callbacks(&mut io_state);
-    // SAFETY: state pointer is valid and matches the tracer variant.
-    unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
-    let outcome = outcome_from_pure_state(&state);
+    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
+    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
+    let exec_result = {
+        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
+    };
+    exec_result?;
 
+    let outcome = outcome_from_pure_state(&state);
     if outcome == ExecuteOutcome::Terminated && state.is_terminated() && state.result_code() == 0 {
-        Ok(RvrExecutionResult {
-            state,
-            memory,
-            public_values: io_state.public_values,
-        })
+        write_rv32_registers(vm_state, &state.regs);
+        vm_state.set_pc(state.pc);
+        Ok(RvrExecutionResult { state })
     } else {
         Err(execution_error(
             "execution failed",
@@ -261,48 +258,42 @@ pub fn execute<F: PrimeField32>(
 }
 
 /// Execute a VmExe with metered cost tracking, tracking per-chip trace costs.
-#[allow(clippy::too_many_arguments)]
 pub fn execute_metered_cost<F: PrimeField32>(
     compiled: &RvrCompiled,
-    exe: &VmExe<F>,
-    input_stream: VecDeque<Vec<F>>,
-    hint_stream: Vec<u8>,
+    vm_state: &mut VmState<F, GuestMemory>,
     metered_cost_config: MeteredCostConfig,
-    deferrals: Vec<DeferralState>,
-    deferral_fns: Vec<DeferralFnPtr>,
-    deferral_hash: Option<DeferralHashFn>,
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(MEM_SIZE)?;
+    let pc = vm_state.pc();
+    let initial_regs = read_rv32_registers(vm_state);
+    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
+
     let mut tracer_data = MeteredCostData::default();
-    let mut state = init_rvr_state_with_metered_cost(exe, &mut memory);
+    let mut state = init_rvr_state_with_metered_cost(memory_ptr, pc);
+    state.regs = initial_regs;
     state.tracer = MeteredCostMeter(&mut tracer_data);
 
     let widths_u64 = prepare_metered_cost(&metered_cost_config);
-
     state.tracer.chip_widths = widths_u64.as_ptr();
     state.tracer.cost = 0;
 
-    let mut io_state = build_io_state(
-        convert_input_stream(&input_stream),
-        memory.as_mut_ptr(),
-        deferrals,
-        deferral_fns,
-        deferral_hash,
-    );
-    io_state.hint_stream = hint_stream;
-    io_state.hint_pos = 0;
-    let callbacks = build_callbacks(&mut io_state);
-    // SAFETY: state pointer is valid and matches the tracer variant.
-    unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
-    let outcome = outcome_from_metered_cost_state(&state);
+    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
+    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
+    let exec_result = {
+        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
+    };
+    exec_result?;
 
+    let outcome = outcome_from_metered_cost_state(&state);
     let cost = state.tracer.cost;
     let instret = state.instret;
 
     if outcome == ExecuteOutcome::Terminated && state.is_terminated() && state.result_code() == 0 {
+        write_rv32_registers(vm_state, &state.regs);
+        vm_state.set_pc(state.pc);
         Ok(RvrMeteredCostResult {
             state,
-            memory,
             cost,
             instret,
             suspended: false,
@@ -318,53 +309,50 @@ pub fn execute_metered_cost<F: PrimeField32>(
     }
 }
 
-/// Execute a VmExe with an instruction limit.
-///
-/// Suspends via target_instret when instret reaches the limit.
-#[allow(clippy::too_many_arguments)]
+/// Execute a VmExe with an instruction limit. Suspends via `target_instret`
+/// when instret reaches the limit.
 pub fn execute_with_limit<F: PrimeField32>(
     compiled: &RvrCompiled,
-    exe: &VmExe<F>,
-    input_stream: VecDeque<Vec<F>>,
-    hint_stream: Vec<u8>,
+    vm_state: &mut VmState<F, GuestMemory>,
     instruction_limit: u64,
-    deferrals: Vec<DeferralState>,
-    deferral_fns: Vec<DeferralFnPtr>,
-    deferral_hash: Option<DeferralHashFn>,
 ) -> Result<RvrLimitedResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(MEM_SIZE)?;
+    let pc = vm_state.pc();
+    let initial_regs = read_rv32_registers(vm_state);
+    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
+
     let mut tracer_data = PureTracerData;
-    let mut state = init_rvr_state(exe, &mut memory);
+    let mut state = init_rvr_state(memory_ptr, pc);
+    state.regs = initial_regs;
     state.tracer = PureTracer(&mut tracer_data);
     state.suspender.set_target(instruction_limit);
 
-    let mut io_state = build_io_state(
-        convert_input_stream(&input_stream),
-        memory.as_mut_ptr(),
-        deferrals,
-        deferral_fns,
-        deferral_hash,
-    );
-    io_state.hint_stream = hint_stream;
-    io_state.hint_pos = 0;
-    let callbacks = build_callbacks(&mut io_state);
-    // SAFETY: state pointer is valid and matches the tracer variant.
-    unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
-    let outcome = outcome_from_pure_state(&state);
+    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
+    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
+    let exec_result = {
+        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
+    };
+    exec_result?;
 
+    let outcome = outcome_from_pure_state(&state);
     let instret = state.instret;
 
     match outcome {
-        ExecuteOutcome::Suspended => Ok(RvrLimitedResult {
-            state,
-            memory,
-            instret,
-            suspended: true,
-        }),
-        ExecuteOutcome::Terminated if state.is_terminated() && state.result_code() == 0 => {
+        ExecuteOutcome::Suspended => {
+            write_rv32_registers(vm_state, &state.regs);
+            vm_state.set_pc(state.pc);
             Ok(RvrLimitedResult {
                 state,
-                memory,
+                instret,
+                suspended: true,
+            })
+        }
+        ExecuteOutcome::Terminated if state.is_terminated() && state.result_code() == 0 => {
+            write_rv32_registers(vm_state, &state.regs);
+            vm_state.set_pc(state.pc);
+            Ok(RvrLimitedResult {
+                state,
                 instret,
                 suspended: false,
             })
@@ -380,58 +368,55 @@ pub fn execute_with_limit<F: PrimeField32>(
 }
 
 /// Execute a VmExe with metered cost and an instruction limit.
-#[allow(clippy::too_many_arguments)]
 pub fn execute_metered_cost_with_limit<F: PrimeField32>(
     compiled: &RvrCompiled,
-    exe: &VmExe<F>,
-    input_stream: VecDeque<Vec<F>>,
-    hint_stream: Vec<u8>,
+    vm_state: &mut VmState<F, GuestMemory>,
     metered_cost_config: MeteredCostConfig,
     instruction_limit: u64,
-    deferrals: Vec<DeferralState>,
-    deferral_fns: Vec<DeferralFnPtr>,
-    deferral_hash: Option<DeferralHashFn>,
 ) -> Result<RvrMeteredCostLimitedResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(MEM_SIZE)?;
+    let pc = vm_state.pc();
+    let initial_regs = read_rv32_registers(vm_state);
+    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
+
     let mut tracer_data = MeteredCostData::default();
-    let mut state = init_rvr_state_with_metered_cost(exe, &mut memory);
+    let mut state = init_rvr_state_with_metered_cost(memory_ptr, pc);
+    state.regs = initial_regs;
     state.tracer = MeteredCostMeter(&mut tracer_data);
 
     let widths_u64 = prepare_metered_cost(&metered_cost_config);
-
     state.tracer.chip_widths = widths_u64.as_ptr();
     state.tracer.cost = 0;
     state.suspender.set_target(instruction_limit);
 
-    let mut io_state = build_io_state(
-        convert_input_stream(&input_stream),
-        memory.as_mut_ptr(),
-        deferrals,
-        deferral_fns,
-        deferral_hash,
-    );
-    io_state.hint_stream = hint_stream;
-    io_state.hint_pos = 0;
-    let callbacks = build_callbacks(&mut io_state);
-    // SAFETY: state pointer is valid and matches the tracer variant.
-    unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
-    let outcome = outcome_from_metered_cost_state(&state);
+    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
+    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
+    let exec_result = {
+        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
+    };
+    exec_result?;
 
+    let outcome = outcome_from_metered_cost_state(&state);
     let cost = state.tracer.cost;
     let instret = state.instret;
 
     match outcome {
-        ExecuteOutcome::Suspended => Ok(RvrMeteredCostLimitedResult {
-            state,
-            memory,
-            cost,
-            instret,
-            suspended: true,
-        }),
-        ExecuteOutcome::Terminated if state.is_terminated() && state.result_code() == 0 => {
+        ExecuteOutcome::Suspended => {
+            write_rv32_registers(vm_state, &state.regs);
+            vm_state.set_pc(state.pc);
             Ok(RvrMeteredCostLimitedResult {
                 state,
-                memory,
+                cost,
+                instret,
+                suspended: true,
+            })
+        }
+        ExecuteOutcome::Terminated if state.is_terminated() && state.result_code() == 0 => {
+            write_rv32_registers(vm_state, &state.regs);
+            vm_state.set_pc(state.pc);
+            Ok(RvrMeteredCostLimitedResult {
+                state,
                 cost,
                 instret,
                 suspended: false,
@@ -448,20 +433,18 @@ pub fn execute_metered_cost_with_limit<F: PrimeField32>(
 }
 
 /// Execute a VmExe with per-chip metered execution and segmentation.
-#[allow(clippy::too_many_arguments)]
 pub fn execute_metered<F: PrimeField32>(
     compiled: &RvrCompiled,
-    exe: &VmExe<F>,
-    input_stream: VecDeque<Vec<F>>,
-    hint_stream: Vec<u8>,
+    vm_state: &mut VmState<F, GuestMemory>,
     trace_config: MeteredConfig,
-    deferrals: Vec<DeferralState>,
-    deferral_fns: Vec<DeferralFnPtr>,
-    deferral_hash: Option<DeferralHashFn>,
 ) -> Result<RvrMeteredResult, ExecuteError> {
-    let mut memory = GuardedMemory::new(MEM_SIZE)?;
+    let pc = vm_state.pc();
+    let initial_regs = read_rv32_registers(vm_state);
+    let (memory_ptr, _) = rv32_memory_ptr(vm_state);
+
     let mut tracer_data = MeteredTracerData::default();
-    let mut state = init_rvr_state_with_metered(exe, &mut memory);
+    let mut state = init_rvr_state_with_metered(memory_ptr, pc);
+    state.regs = initial_regs;
     state.tracer = MeteredTracer(&mut tracer_data);
 
     let mut seg_state = SegmentationState::new(trace_config);
@@ -481,20 +464,16 @@ pub fn execute_metered<F: PrimeField32>(
     state.tracer.on_check = Some(metered_periodic_check);
     state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut c_void;
 
-    let mut io_state = build_io_state(
-        convert_input_stream(&input_stream),
-        memory.as_mut_ptr(),
-        deferrals,
-        deferral_fns,
-        deferral_hash,
-    );
-    io_state.hint_stream = hint_stream;
-    io_state.hint_pos = 0;
-    let callbacks = build_callbacks(&mut io_state);
-    // SAFETY: state pointer is valid and matches the tracer variant.
-    unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }?;
-    let outcome = outcome_from_metered_state(&state);
+    // SAFETY: state pointer is valid and matches the tracer variant. `io_state`
+    // is scoped so the borrow of `vm_state` ends before we touch `vm_state` again.
+    let exec_result = {
+        let mut io_state = build_io_state_borrowed(vm_state, memory_ptr);
+        let callbacks = build_callbacks(&mut io_state);
+        unsafe { register_and_execute(compiled, &callbacks, state.as_void_ptr()) }
+    };
+    exec_result?;
 
+    let outcome = outcome_from_metered_state(&state);
     if outcome == ExecuteOutcome::Terminated && state.is_terminated() && state.result_code() == 0 {
         seg_state.on_termination(
             state.tracer.mem_page_buf_len,
@@ -512,5 +491,7 @@ pub fn execute_metered<F: PrimeField32>(
         ));
     }
 
-    Ok(seg_state.into_result(state, memory, io_state.public_values))
+    write_rv32_registers(vm_state, &state.regs);
+    vm_state.set_pc(state.pc);
+    Ok(seg_state.into_result(state))
 }

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -102,9 +102,10 @@ pub fn build_callbacks<F: PrimeField32>(
 
 /// Construct an `OpenVmIoState` borrowing the relevant fields of `vm_state`.
 ///
-/// Splits `vm_state` into disjoint borrows: `streams` fields (mutable for the
-/// active streams + deferral cache, immutable for the registered closures),
-/// `rng`, and the `PUBLIC_VALUES_AS` byte slice from `memory`.
+/// Splits `vm_state.streams` (active streams + deferral cache), `rng`, and
+/// the `PUBLIC_VALUES_AS` byte slice from `memory`. The registered deferral
+/// closures and hasher live in `rvr-openvm-ext-deferral`'s thread-local
+/// runtime — see `host_deferral_call_lookup`.
 fn build_io_state_borrowed<'a, F: PrimeField32>(
     vm_state: &'a mut VmState<F, GuestMemory>,
     memory_ptr: *mut u8,
@@ -117,8 +118,6 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
         memory_ptr,
         public_values: public_values_slice(&mut vm_state.memory.memory),
         deferrals: &mut streams.deferrals,
-        deferral_fns: streams.deferral_fns.as_slice(),
-        deferral_hash: streams.deferral_hash.as_ref(),
         _marker: PhantomData,
     }
 }

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -12,7 +12,7 @@
 //! generated C code (via `trace_io_*` functions in tracer headers). These
 //! callbacks are pure IO logic.
 
-use std::{collections::VecDeque, ffi::c_void, io::Write, marker::PhantomData, sync::Arc};
+use std::{collections::VecDeque, ffi::c_void, io::Write, marker::PhantomData};
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, Rng};
@@ -20,18 +20,12 @@ use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_B
 
 use crate::arch::deferral::{DeferralState, InputMapVal};
 
-/// `input_raw → output_raw`.
-pub type DeferralFnPtr = Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>;
-
-/// `(def_idx, output_raw) → output_commit`.
-pub type DeferralHashFn = Arc<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
-
 /// IO execution state borrowed from the host `VmState<F>` for the duration of
 /// one rvr call. Streams, rng, and the public-values byte slice are mutable
 /// borrows; `memory_ptr` is a raw alias of VmState's main memory buffer
-/// (raw because the C engine accesses it directly via pointer). Deferrals
-/// stay in the closure-based form: the host evaluates `deferral_fns[idx]`
-/// lazily on cache-miss, hashes the output, and caches into `deferrals`.
+/// (raw because the C engine accesses it directly via pointer). The deferral
+/// cache lives here; the registered closures and hasher live in
+/// `rvr-openvm-ext-deferral`'s thread-local runtime.
 pub struct OpenVmIoState<'a, F: PrimeField32> {
     pub input_stream: &'a mut VecDeque<Vec<F>>,
     pub hint_stream: &'a mut VecDeque<F>,
@@ -39,8 +33,6 @@ pub struct OpenVmIoState<'a, F: PrimeField32> {
     pub memory_ptr: *mut u8,
     pub public_values: &'a mut [u8],
     pub deferrals: &'a mut Vec<DeferralState>,
-    pub deferral_fns: &'a [DeferralFnPtr],
-    pub deferral_hash: Option<&'a DeferralHashFn>,
     pub _marker: PhantomData<&'a mut F>,
 }
 
@@ -182,6 +174,10 @@ pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
 /// Deferral CALL lookup; same `Raw → Output` transition as `DeferralFn::execute`.
 /// Returns 1 on hit, 0 on miss.
 ///
+/// The closure-evaluation side (Raw → Output_raw + commit) is delegated to
+/// `rvr-openvm-ext-deferral`'s thread-local runtime, installed at
+/// `DeferralExtension::extend_rvr` time. This callback only owns the cache.
+///
 /// # Safety
 ///
 /// `input_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
@@ -207,17 +203,8 @@ pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
             (arr, len)
         }
         InputMapVal::Raw(input_raw) => {
-            let func = io
-                .deferral_fns
-                .get(def_idx as usize)
-                .expect("deferral CALL: def_idx has no closure registered")
-                .clone();
-            let hash = io
-                .deferral_hash
-                .expect("deferral CALL: hash_output not configured")
-                .clone();
-            let output_raw = func(&input_raw);
-            let commit = hash(def_idx, &output_raw);
+            let (commit, output_raw) =
+                rvr_openvm_ext_deferral::eval_deferral_call(def_idx, &input_raw);
             let len = output_raw.len() as u64;
             io.deferrals[def_idx as usize].store_output(&input_commit, commit.to_vec(), output_raw);
             (commit, len)

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -1,18 +1,13 @@
 //! OpenVM IO runtime: Rust-side IO state with FFI callbacks.
 //!
-//! All execution IO state lives on the openvm `VmState<F>`. The C engine
-//! invokes Rust callbacks via function pointers registered through
-//! `register_openvm_callbacks`; the callbacks themselves are generic over
-//! the openvm field `F` and read/write VmState directly. `Streams<F>` is
-//! consumed lazily in field-element form — the F→u8 cast happens one byte
-//! at a time inside `host_hint_storew`/`host_hint_buffer` rather than
-//! upfront.
-//!
-//! Metering adjustments for IO instructions are handled entirely in the
-//! generated C code (via `trace_io_*` functions in tracer headers). These
-//! callbacks are pure IO logic.
+//! All execution IO state lives on the openvm `VmState<F>`; callbacks are
+//! generic over the openvm field `F` and read/write VmState directly.
+//! `Streams<F>` is consumed lazily — the F→u8 cast happens one byte at a
+//! time inside the storew/buffer callbacks rather than upfront. Metering
+//! adjustments for IO instructions are handled entirely in the generated C
+//! code; these callbacks are pure IO logic.
 
-use std::{collections::VecDeque, ffi::c_void, io::Write, marker::PhantomData};
+use std::{collections::VecDeque, ffi::c_void, io::Write};
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, Rng};
@@ -23,9 +18,7 @@ use crate::arch::deferral::{DeferralState, InputMapVal};
 /// IO execution state borrowed from the host `VmState<F>` for the duration of
 /// one rvr call. Streams, rng, and the public-values byte slice are mutable
 /// borrows; `memory_ptr` is a raw alias of VmState's main memory buffer
-/// (raw because the C engine accesses it directly via pointer). The deferral
-/// cache lives here; the registered closures and hasher live in
-/// `rvr-openvm-ext-deferral`'s thread-local runtime.
+/// (raw because the C engine accesses it directly via pointer).
 pub struct OpenVmIoState<'a, F: PrimeField32> {
     pub input_stream: &'a mut VecDeque<Vec<F>>,
     pub hint_stream: &'a mut VecDeque<F>,
@@ -33,10 +26,8 @@ pub struct OpenVmIoState<'a, F: PrimeField32> {
     pub memory_ptr: *mut u8,
     pub public_values: &'a mut [u8],
     pub deferrals: &'a mut Vec<DeferralState>,
-    pub _marker: PhantomData<&'a mut F>,
 }
 
-/// Function-pointer struct passed to C via `register_openvm_callbacks`.
 /// Must match the C `OpenVmHostCallbacks` layout exactly.
 #[repr(C)]
 pub struct OpenVmHostCallbacks {
@@ -173,12 +164,9 @@ pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
 
 // ── Deferral callbacks ─────────────────────────────────────────────────────
 
-/// Deferral CALL lookup; same `Raw → Output` transition as `DeferralFn::execute`.
-/// Returns 1 on hit, 0 on miss.
-///
-/// The closure-evaluation side (Raw → Output_raw + commit) is delegated to
-/// `rvr-openvm-ext-deferral`'s thread-local runtime, installed at
-/// `DeferralExtension::extend_rvr` time. This callback only owns the cache.
+/// Deferral CALL lookup. Returns 1 on hit, 0 on miss. The closure-evaluation
+/// side (Raw → Output_raw + commit) is delegated to a thread-local runtime;
+/// this callback only owns the cache.
 ///
 /// # Safety
 ///

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -11,6 +11,7 @@ use std::{collections::VecDeque, ffi::c_void, io::Write};
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, Rng};
+use rvr_openvm_ext_deferral::eval_deferral_call;
 use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_BYTES};
 
 use crate::arch::deferral::{DeferralState, InputMapVal};
@@ -193,8 +194,7 @@ pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
             (arr, len)
         }
         InputMapVal::Raw(input_raw) => {
-            let (commit, output_raw) =
-                rvr_openvm_ext_deferral::eval_deferral_call(def_idx, &input_raw);
+            let (commit, output_raw) = eval_deferral_call(def_idx, &input_raw);
             let len = output_raw.len() as u64;
             io.deferrals[def_idx as usize].store_output(&input_commit, commit.to_vec(), output_raw);
             (commit, len)

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -11,10 +11,8 @@ use std::{collections::VecDeque, ffi::c_void, io::Write};
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, Rng};
-use rvr_openvm_ext_deferral::eval_deferral_call;
-use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_BYTES};
 
-use crate::arch::deferral::{DeferralState, InputMapVal};
+use crate::arch::deferral::DeferralState;
 
 /// IO execution state borrowed from the host `VmState<F>` for the duration of
 /// one rvr call. Streams, rng, and the public-values byte slice are mutable
@@ -40,9 +38,6 @@ pub struct OpenVmHostCallbacks {
     pub hint_buffer: extern "C" fn(*mut c_void, u32, u32),
     pub reveal: extern "C" fn(*mut c_void, u32, u32, u32),
     pub hint_stream_set: unsafe extern "C" fn(*mut c_void, *const u8, u32),
-    pub deferral_call_lookup: unsafe extern "C" fn(*mut c_void, u32, *const u8, *mut u8) -> i32,
-    pub deferral_output_lookup:
-        unsafe extern "C" fn(*mut c_void, u32, *const u8, *mut u8, u32) -> i32,
 }
 
 // ── Callback implementations ────────────────────────────────────────────────
@@ -161,80 +156,4 @@ pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
             io.hint_stream.push_back(F::from_u8(b));
         }
     }
-}
-
-// ── Deferral callbacks ─────────────────────────────────────────────────────
-
-/// Deferral CALL lookup. Returns 1 on hit, 0 on miss. The closure-evaluation
-/// side (Raw → Output_raw + commit) is delegated to a thread-local runtime;
-/// this callback only owns the cache.
-///
-/// # Safety
-///
-/// `input_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
-/// `output_key_out` must point to `DEFERRAL_OUTPUT_KEY_BYTES` writable bytes.
-pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
-    ctx: *mut c_void,
-    def_idx: u32,
-    input_commit_raw: *const u8,
-    output_key_out: *mut u8,
-) -> i32 {
-    let io = &mut *(ctx as *mut OpenVmIoState<'_, F>);
-    let input_commit: Vec<u8> =
-        std::slice::from_raw_parts(input_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec();
-
-    let Some(state) = io.deferrals.get_mut(def_idx as usize) else {
-        return 0;
-    };
-
-    let (output_commit, output_len) = match state.get_input(&input_commit).clone() {
-        InputMapVal::Output(commit) => {
-            let len = state.get_output(&commit).len() as u64;
-            let arr: [u8; DEFERRAL_COMMIT_NUM_BYTES] = commit.as_slice().try_into().unwrap();
-            (arr, len)
-        }
-        InputMapVal::Raw(input_raw) => {
-            let (commit, output_raw) = eval_deferral_call(def_idx, &input_raw);
-            let len = output_raw.len() as u64;
-            io.deferrals[def_idx as usize].store_output(&input_commit, commit.to_vec(), output_raw);
-            (commit, len)
-        }
-    };
-
-    let mut output_key = [0u8; DEFERRAL_OUTPUT_KEY_BYTES];
-    output_key[..DEFERRAL_COMMIT_NUM_BYTES].copy_from_slice(&output_commit);
-    output_key[DEFERRAL_COMMIT_NUM_BYTES..].copy_from_slice(&output_len.to_le_bytes());
-    std::ptr::copy_nonoverlapping(
-        output_key.as_ptr(),
-        output_key_out,
-        DEFERRAL_OUTPUT_KEY_BYTES,
-    );
-    1
-}
-
-/// Deferral OUTPUT lookup: `deferrals[def_idx].output_map[output_commit]`.
-/// Returns 1 on hit, 0 on miss.
-///
-/// # Safety
-///
-/// `output_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
-/// `output_raw_out` must point to at least `expected_len` writable bytes.
-pub unsafe extern "C" fn host_deferral_output_lookup<F: PrimeField32>(
-    ctx: *mut c_void,
-    def_idx: u32,
-    output_commit_raw: *const u8,
-    output_raw_out: *mut u8,
-    expected_len: u32,
-) -> i32 {
-    let io = &*(ctx as *const OpenVmIoState<'_, F>);
-    let output_commit: Vec<u8> =
-        std::slice::from_raw_parts(output_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec();
-    let Some(state) = io.deferrals.get(def_idx as usize) else {
-        return 0;
-    };
-    let raw = state.get_output(&output_commit);
-    // TODO: change these panics to something better to handle across the FFI boundary.
-    assert_eq!(raw.len(), expected_len as usize);
-    std::ptr::copy_nonoverlapping(raw.as_ptr(), output_raw_out, raw.len());
-    1
 }

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -143,9 +143,11 @@ pub extern "C" fn host_reveal<F: PrimeField32>(
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
     let start = ptr as usize + offset as usize;
     let end = start + 4;
-    if end > io.public_values.len() {
-        return;
-    }
+    assert!(
+        end <= io.public_values.len(),
+        "reveal out of bounds: writing bytes [{start}..{end}) but public_values size is {} (configured via SystemConfig::with_public_values)",
+        io.public_values.len(),
+    );
     io.public_values[start..end].copy_from_slice(&src_val.to_le_bytes());
 }
 

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -1,14 +1,18 @@
 //! OpenVM IO runtime: Rust-side IO state with FFI callbacks.
 //!
-//! All execution IO state (input streams and hint streams) lives in
-//! Rust. The generated C code calls back into Rust via function pointers
-//! registered through `register_openvm_callbacks`.
+//! All execution IO state lives on the openvm `VmState<F>`. The C engine
+//! invokes Rust callbacks via function pointers registered through
+//! `register_openvm_callbacks`; the callbacks themselves are generic over
+//! the openvm field `F` and read/write VmState directly. `Streams<F>` is
+//! consumed lazily in field-element form — the F→u8 cast happens one byte
+//! at a time inside `host_hint_storew`/`host_hint_buffer` rather than
+//! upfront.
 //!
 //! Metering adjustments for IO instructions are handled entirely in the
 //! generated C code (via `trace_io_*` functions in tracer headers). These
 //! callbacks are pure IO logic.
 
-use std::{collections::VecDeque, ffi::c_void, io::Write, sync::Arc};
+use std::{collections::VecDeque, ffi::c_void, io::Write, marker::PhantomData, sync::Arc};
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, Rng};
@@ -22,19 +26,22 @@ pub type DeferralFnPtr = Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>;
 /// `(def_idx, output_raw) → output_commit`.
 pub type DeferralHashFn = Arc<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
 
-/// All IO execution state, owned by Rust.
-pub struct OpenVmIoState {
-    pub input_stream: VecDeque<Vec<u8>>,
-    pub hint_stream: Vec<u8>,
-    pub hint_pos: usize,
-    pub public_values: Vec<u8>,
-    /// Guest memory pointer (constant during execution).
-    pub memory: *mut u8,
-    /// Persistent RNG matching openvm's `StdRng::seed_from_u64(0)`.
-    pub rng: StdRng,
-    pub deferrals: Vec<DeferralState>,
-    pub deferral_fns: Vec<DeferralFnPtr>,
-    pub deferral_hash: Option<DeferralHashFn>,
+/// IO execution state borrowed from the host `VmState<F>` for the duration of
+/// one rvr call. Streams, rng, and the public-values byte slice are mutable
+/// borrows; `memory_ptr` is a raw alias of VmState's main memory buffer
+/// (raw because the C engine accesses it directly via pointer). Deferrals
+/// stay in the closure-based form: the host evaluates `deferral_fns[idx]`
+/// lazily on cache-miss, hashes the output, and caches into `deferrals`.
+pub struct OpenVmIoState<'a, F: PrimeField32> {
+    pub input_stream: &'a mut VecDeque<Vec<F>>,
+    pub hint_stream: &'a mut VecDeque<F>,
+    pub rng: &'a mut StdRng,
+    pub memory_ptr: *mut u8,
+    pub public_values: &'a mut [u8],
+    pub deferrals: &'a mut Vec<DeferralState>,
+    pub deferral_fns: &'a [DeferralFnPtr],
+    pub deferral_hash: Option<&'a DeferralHashFn>,
+    pub _marker: PhantomData<&'a mut F>,
 }
 
 /// Function-pointer struct passed to C via `register_openvm_callbacks`.
@@ -56,89 +63,96 @@ pub struct OpenVmHostCallbacks {
 
 // ── Callback implementations ────────────────────────────────────────────────
 
-/// HintInput: pop next vector from input_stream, build hint buffer with
-/// 4-byte LE length prefix, padded to 4-byte alignment.
-pub extern "C" fn host_hint_input(ctx: *mut c_void) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState) };
-
+/// HintInput: pop next input record from VmState's input_stream and overwrite
+/// the active hint stream with `[len: u32 LE][data][padding to 4-byte align]`,
+/// each byte stored as one field element.
+pub extern "C" fn host_hint_input<F: PrimeField32>(ctx: *mut c_void) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+    io.hint_stream.clear();
     if let Some(vec) = io.input_stream.pop_front() {
-        let vec_len = vec.len() as u32;
-        let padded_len = (vec.len() + 3) & !3;
-        let total = 4 + padded_len;
-        let mut buf = vec![0u8; total];
-        buf[0..4].copy_from_slice(&vec_len.to_le_bytes());
-        buf[4..4 + vec.len()].copy_from_slice(&vec);
-        io.hint_stream = buf;
-    } else {
-        io.hint_stream = Vec::new();
+        let data_len = vec.len();
+        let padded_len = (data_len + 3) & !3;
+        let len_bytes = (data_len as u32).to_le_bytes();
+        for &b in &len_bytes {
+            io.hint_stream.push_back(F::from_u8(b));
+        }
+        io.hint_stream.extend(vec);
+        for _ in data_len..padded_len {
+            io.hint_stream.push_back(F::ZERO);
+        }
     }
-    io.hint_pos = 0;
 }
 
 /// PrintStr: read UTF-8 from guest memory and print to stdout.
-pub extern "C" fn host_print_str(ctx: *mut c_void, ptr: u32, len: u32) {
-    let io = unsafe { &*(ctx as *const OpenVmIoState) };
-    if len > 0 && !io.memory.is_null() {
+pub extern "C" fn host_print_str<F: PrimeField32>(ctx: *mut c_void, ptr: u32, len: u32) {
+    let io = unsafe { &*(ctx as *const OpenVmIoState<'_, F>) };
+    if len > 0 && !io.memory_ptr.is_null() {
         let slice =
-            unsafe { std::slice::from_raw_parts(io.memory.add(ptr as usize), len as usize) };
+            unsafe { std::slice::from_raw_parts(io.memory_ptr.add(ptr as usize), len as usize) };
         let _ = std::io::stdout().write_all(slice);
         let _ = std::io::stdout().flush();
     }
 }
 
-/// HintRandom: fill hint buffer with random bytes using persistent StdRng
-/// (matches openvm's `Rv32HintRandomSubEx`).
-pub extern "C" fn host_hint_random(ctx: *mut c_void, num_words: u32) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState) };
+/// HintRandom: refill the hint stream with `num_words * 4` random bytes drawn
+/// from VmState's persistent RNG (matches openvm's `Rv32HintRandomSubEx`).
+pub extern "C" fn host_hint_random<F: PrimeField32>(ctx: *mut c_void, num_words: u32) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
     let nbytes = num_words as usize * 4;
-    let mut buf = vec![0u8; nbytes];
-
-    for byte in buf.iter_mut() {
-        *byte = io.rng.random::<u8>();
-    }
-
-    io.hint_stream = buf;
-    io.hint_pos = 0;
-}
-
-/// HINT_STOREW: copy 4 bytes from hint buffer to guest memory.
-pub extern "C" fn host_hint_storew(ctx: *mut c_void, dest_addr: u32) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState) };
-    if io.hint_pos + 4 <= io.hint_stream.len() && !io.memory.is_null() {
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                io.hint_stream.as_ptr().add(io.hint_pos),
-                io.memory.add(dest_addr as usize),
-                4,
-            );
-        }
-        io.hint_pos += 4;
+    io.hint_stream.clear();
+    for _ in 0..nbytes {
+        io.hint_stream.push_back(F::from_u8(io.rng.random::<u8>()));
     }
 }
 
-/// HINT_BUFFER: copy num_words * 4 bytes from hint buffer to guest memory.
-pub extern "C" fn host_hint_buffer(ctx: *mut c_void, dest_addr: u32, num_words: u32) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState) };
+/// HINT_STOREW: pop 4 field elements from the hint stream, cast each to a
+/// byte, and write them to guest memory at `dest_addr`.
+pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr: u32) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+    if io.hint_stream.len() < 4 || io.memory_ptr.is_null() {
+        return;
+    }
+    let mut bytes = [0u8; 4];
+    for byte in &mut bytes {
+        *byte = io.hint_stream.pop_front().unwrap().as_canonical_u32() as u8;
+    }
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), io.memory_ptr.add(dest_addr as usize), 4);
+    }
+}
+
+/// HINT_BUFFER: pop `num_words * 4` field elements from the hint stream and
+/// copy them as bytes into guest memory.
+pub extern "C" fn host_hint_buffer<F: PrimeField32>(
+    ctx: *mut c_void,
+    dest_addr: u32,
+    num_words: u32,
+) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
     let nbytes = num_words as usize * 4;
-    if io.hint_pos + nbytes <= io.hint_stream.len() && !io.memory.is_null() {
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                io.hint_stream.as_ptr().add(io.hint_pos),
-                io.memory.add(dest_addr as usize),
-                nbytes,
-            );
-        }
-        io.hint_pos += nbytes;
+    if io.hint_stream.len() < nbytes || io.memory_ptr.is_null() {
+        return;
+    }
+    let dst = unsafe { io.memory_ptr.add(dest_addr as usize) };
+    for i in 0..nbytes {
+        let byte = io.hint_stream.pop_front().unwrap().as_canonical_u32() as u8;
+        unsafe { *dst.add(i) = byte };
     }
 }
 
-/// REVEAL: capture public output bytes in host state. Cost corrections handled in C.
-pub extern "C" fn host_reveal(ctx: *mut c_void, src_val: u32, ptr: u32, offset: u32) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState) };
+/// REVEAL: write public output bytes directly into the guest's `PUBLIC_VALUES_AS`
+/// byte slice. Cost corrections handled in C.
+pub extern "C" fn host_reveal<F: PrimeField32>(
+    ctx: *mut c_void,
+    src_val: u32,
+    ptr: u32,
+    offset: u32,
+) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
     let start = ptr as usize + offset as usize;
     let end = start + 4;
-    if io.public_values.len() < end {
-        io.public_values.resize(end, 0);
+    if end > io.public_values.len() {
+        return;
     }
     io.public_values[start..end].copy_from_slice(&src_val.to_le_bytes());
 }
@@ -148,14 +162,19 @@ pub extern "C" fn host_reveal(ctx: *mut c_void, src_val: u32, ptr: u32, offset: 
 /// # Safety
 ///
 /// `ctx` must be a valid `OpenVmIoState` pointer. `data` must point to `len` bytes (or be null).
-pub unsafe extern "C" fn host_hint_stream_set(ctx: *mut c_void, data: *const u8, len: u32) {
-    let io = &mut *(ctx as *mut OpenVmIoState);
+pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
+    ctx: *mut c_void,
+    data: *const u8,
+    len: u32,
+) {
+    let io = &mut *(ctx as *mut OpenVmIoState<'_, F>);
+    io.hint_stream.clear();
     if len > 0 && !data.is_null() {
-        io.hint_stream = std::slice::from_raw_parts(data, len as usize).to_vec();
-    } else {
-        io.hint_stream = Vec::new();
+        let slice = std::slice::from_raw_parts(data, len as usize);
+        for &b in slice {
+            io.hint_stream.push_back(F::from_u8(b));
+        }
     }
-    io.hint_pos = 0;
 }
 
 // ── Deferral callbacks ─────────────────────────────────────────────────────
@@ -167,13 +186,13 @@ pub unsafe extern "C" fn host_hint_stream_set(ctx: *mut c_void, data: *const u8,
 ///
 /// `input_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
 /// `output_key_out` must point to `DEFERRAL_OUTPUT_KEY_BYTES` writable bytes.
-pub unsafe extern "C" fn host_deferral_call_lookup(
+pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
     ctx: *mut c_void,
     def_idx: u32,
     input_commit_raw: *const u8,
     output_key_out: *mut u8,
 ) -> i32 {
-    let io = &mut *(ctx as *mut OpenVmIoState);
+    let io = &mut *(ctx as *mut OpenVmIoState<'_, F>);
     let input_commit: Vec<u8> =
         std::slice::from_raw_parts(input_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec();
 
@@ -195,7 +214,6 @@ pub unsafe extern "C" fn host_deferral_call_lookup(
                 .clone();
             let hash = io
                 .deferral_hash
-                .as_ref()
                 .expect("deferral CALL: hash_output not configured")
                 .clone();
             let output_raw = func(&input_raw);
@@ -224,14 +242,14 @@ pub unsafe extern "C" fn host_deferral_call_lookup(
 ///
 /// `output_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
 /// `output_raw_out` must point to at least `expected_len` writable bytes.
-pub unsafe extern "C" fn host_deferral_output_lookup(
+pub unsafe extern "C" fn host_deferral_output_lookup<F: PrimeField32>(
     ctx: *mut c_void,
     def_idx: u32,
     output_commit_raw: *const u8,
     output_raw_out: *mut u8,
     expected_len: u32,
 ) -> i32 {
-    let io = &*(ctx as *const OpenVmIoState);
+    let io = &*(ctx as *const OpenVmIoState<'_, F>);
     let output_commit: Vec<u8> =
         std::slice::from_raw_parts(output_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec();
     let Some(state) = io.deferrals.get(def_idx as usize) else {
@@ -242,14 +260,4 @@ pub unsafe extern "C" fn host_deferral_output_lookup(
     assert_eq!(raw.len(), expected_len as usize);
     std::ptr::copy_nonoverlapping(raw.as_ptr(), output_raw_out, raw.len());
     1
-}
-
-// ── Conversion helpers ──────────────────────────────────────────────────────
-
-/// Convert an OpenVM field-element input stream to byte-packed vectors.
-pub fn convert_input_stream<F: PrimeField32>(stream: &VecDeque<Vec<F>>) -> VecDeque<Vec<u8>> {
-    stream
-        .iter()
-        .map(|vec| vec.iter().map(|f| f.as_canonical_u32() as u8).collect())
-        .collect()
 }

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -13,7 +13,7 @@ use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 use super::{
     bridge::{map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
-    compile_metered, compile_metered_with_extensions, execute_metered,
+    compile_metered, execute_metered,
     state::{MeteredState, TracerPayload, TracerPtr},
 };
 use crate::{
@@ -709,12 +709,8 @@ where
         trace_config.is_constant = ctx.is_trace_height_constant.clone();
 
         let chips = trace_config.chip_mapping();
-        let compiled_metered = if self.extensions.is_empty() {
-            compile_metered(self.exe.as_ref(), &chips)
-        } else {
-            compile_metered_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
-        }
-        .map_err(map_rvr_compile_error)?;
+        let compiled_metered = compile_metered(self.exe.as_ref(), &self.extensions, &chips)
+            .map_err(map_rvr_compile_error)?;
 
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -9,13 +9,12 @@ use openvm_instructions::{
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
-use rvr_state::TracerState;
 
 use super::{
     bridge::{ensure_rvr_outcome, map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
     compile_metered, compile_metered_with_extensions, execute_metered,
-    state::MeteredState,
+    state::{MeteredState, TracerPayload, TracerPtr},
 };
 use crate::{
     arch::{
@@ -87,33 +86,12 @@ impl Default for MeteredTracerData {
     }
 }
 
-/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
-#[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct MeteredTracer(pub *mut MeteredTracerData);
-
-impl Default for MeteredTracer {
-    fn default() -> Self {
-        Self(std::ptr::null_mut())
-    }
-}
-
-impl TracerState for MeteredTracer {
+impl TracerPayload for MeteredTracerData {
     const KIND: u32 = 11;
 }
 
-impl std::ops::Deref for MeteredTracer {
-    type Target = MeteredTracerData;
-    fn deref(&self) -> &MeteredTracerData {
-        unsafe { &*self.0 }
-    }
-}
-
-impl std::ops::DerefMut for MeteredTracer {
-    fn deref_mut(&mut self) -> &mut MeteredTracerData {
-        unsafe { &mut *self.0 }
-    }
-}
+/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
+pub type MeteredTracer = TracerPtr<MeteredTracerData>;
 
 // ── Configuration ────────────────────────────────────────────────────────────
 

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -6,17 +6,16 @@ use std::sync::Arc;
 use openvm_instructions::{
     exe::VmExe, riscv::RV32_MEMORY_AS, LocalOpcode, SystemOpcode, VmOpcode, DEFERRAL_AS,
 };
-use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
-use rvr_state::{GuardedMemory, TracerState};
+use rvr_state::TracerState;
 
 use super::{
-    build_callbacks, build_io_state,
+    bridge::{ensure_rvr_outcome, map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
-    compile_metered, compile_metered_with_extensions, execute_metered, register_and_execute,
-    state::{init_rvr_state_with_metered, state_as_void_ptr, MeteredState},
+    compile_metered, compile_metered_with_extensions, execute_metered,
+    state::MeteredState,
 };
 use crate::{
     arch::{
@@ -29,12 +28,6 @@ use crate::{
                 },
             },
             MeteredCtx, Segment,
-        },
-        vm::{
-            copy_guest_memory_to_rvr_memory, ensure_rvr_outcome, map_rvr_compile_error,
-            map_rvr_execute_error, read_public_values_from_guest_memory,
-            read_rv32_regs_from_guest_memory, state_from_rvr, streams_from_io_state,
-            streams_to_io_seed, write_rvr_memory_to_guest_memory,
         },
         ExecutionError, ExecutorInventory, MeteredExecutor, Streams, SystemConfig, VmState,
     },
@@ -287,8 +280,6 @@ pub struct RvrMeteredResult {
     pub segments: Vec<RvrSegment>,
     pub instret: u64,
     pub state: MeteredState,
-    pub memory: GuardedMemory,
-    pub public_values: Vec<u8>,
 }
 
 /// Runtime state for metered segmentation.
@@ -658,18 +649,11 @@ impl SegmentationState {
     }
 
     /// Consume and return the result.
-    pub fn into_result(
-        self,
-        state: MeteredState,
-        memory: GuardedMemory,
-        public_values: Vec<u8>,
-    ) -> RvrMeteredResult {
+    pub fn into_result(self, state: MeteredState) -> RvrMeteredResult {
         RvrMeteredResult {
             instret: self.instret,
             segments: self.segments,
             state,
-            memory,
-            public_values,
         }
     }
 }
@@ -712,17 +696,20 @@ where
         inputs: impl Into<Streams<F>>,
         ctx: MeteredCtx,
     ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
-        let inputs = inputs.into();
-        let input_stream = inputs.input_stream;
-        let hint_stream: Vec<u8> = inputs
-            .hint_stream
-            .into_iter()
-            .map(|f| f.as_canonical_u32() as u8)
-            .collect();
-        let deferrals = inputs.deferrals;
-        let deferral_fns = inputs.deferral_fns;
-        let deferral_hash = inputs.deferral_hash;
+        let vm_state = VmState::initial(
+            &self.system_config,
+            &self.exe.init_memory,
+            self.exe.pc_start,
+            inputs,
+        );
+        self.execute_metered_from_state(vm_state, ctx)
+    }
 
+    pub fn execute_metered_from_state(
+        &self,
+        mut vm_state: VmState<F, GuestMemory>,
+        ctx: MeteredCtx,
+    ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
         let constant_trace_heights: Vec<Option<usize>> = ctx
             .trace_heights
             .iter()
@@ -744,8 +731,6 @@ where
         trace_config.initial_trace_heights = ctx.trace_heights.clone();
         trace_config.is_constant = ctx.is_trace_height_constant.clone();
 
-        // TODO: hoist compilation to instance construction; `ChipMapping` is independent of
-        // `MeteredCtx`.
         let chips = trace_config.chip_mapping();
         let compiled_metered = if self.extensions.is_empty() {
             compile_metered(self.exe.as_ref(), &chips)
@@ -757,18 +742,7 @@ where
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let metered_result = tracing::info_span!("execute_metered")
-            .in_scope(|| {
-                execute_metered(
-                    &compiled_metered,
-                    self.exe.as_ref(),
-                    input_stream,
-                    hint_stream,
-                    trace_config,
-                    deferrals,
-                    deferral_fns,
-                    deferral_hash,
-                )
-            })
+            .in_scope(|| execute_metered(&compiled_metered, &mut vm_state, trace_config))
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {
@@ -780,141 +754,14 @@ where
                 .set(insns as f64 / elapsed.as_micros() as f64);
         }
 
-        let segments = metered_result
-            .segments
-            .into_iter()
-            .map(|segment| Segment {
-                instret_start: segment.instret_start,
-                num_insns: segment.num_insns,
-                trace_heights: segment.trace_heights,
-            })
-            .collect();
-
-        let final_state = state_from_rvr(
-            &self.system_config,
-            self.exe.as_ref(),
-            metered_result.state.pc,
-            &metered_result.state.regs,
-            &metered_result.memory,
-            &metered_result.public_values,
-        );
-
-        Ok((segments, final_state))
-    }
-
-    pub fn execute_metered_from_state(
-        &self,
-        from_state: VmState<F, GuestMemory>,
-        ctx: MeteredCtx,
-    ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
-        let pc = from_state.pc();
-        let mut guest_memory = from_state.memory;
-        let seed = streams_to_io_seed(from_state.streams);
-        let rng = from_state.rng;
-        #[cfg(feature = "metrics")]
-        let metrics = from_state.metrics;
-
-        let constant_trace_heights: Vec<Option<usize>> = ctx
-            .trace_heights
-            .iter()
-            .zip(ctx.is_trace_height_constant.iter())
-            .map(|(&height, &is_constant)| is_constant.then_some(height as usize))
-            .collect();
-
-        let mut trace_config = build_metered_config(
-            self.exe.as_ref(),
-            self.inventory.as_ref(),
-            &self.executor_idx_to_air_idx,
-            &ctx.segmentation_ctx.widths,
-            &ctx.segmentation_ctx.interactions,
-            &constant_trace_heights,
-            &self.system_config,
-        );
-        trace_config.segmentation_config = ctx.segmentation_ctx.config.clone();
-        trace_config.segment_check_insns = ctx.segmentation_ctx.segment_check_insns;
-        trace_config.initial_trace_heights = ctx.trace_heights.clone();
-        trace_config.is_constant = ctx.is_trace_height_constant.clone();
-
-        let chips = trace_config.chip_mapping();
-        let compiled_metered = if self.extensions.is_empty() {
-            compile_metered(self.exe.as_ref(), &chips)
-        } else {
-            compile_metered_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
-        }
-        .map_err(map_rvr_compile_error)?;
-
-        let mut memory = GuardedMemory::new(MEM_SIZE)
-            .map_err(|err| ExecutionError::RvrExecution(err.to_string()))?;
-        let mut tracer_data = MeteredTracerData::default();
-        let mut state = init_rvr_state_with_metered(self.exe.as_ref(), &mut memory);
-        state.tracer = MeteredTracer(&mut tracer_data);
-        state.pc = pc;
-        state
-            .regs
-            .copy_from_slice(&read_rv32_regs_from_guest_memory(&guest_memory));
-        copy_guest_memory_to_rvr_memory(&guest_memory, &mut memory);
-
-        let mut seg_state = SegmentationState::new(trace_config);
-        state.tracer.trace_heights = seg_state.trace_heights_ptr();
-        state.tracer.mem_page_buf = seg_state.mem_page_buf_ptr();
-        state.tracer.pv_page_buf = seg_state.pv_page_buf_ptr();
-        state.tracer.deferral_page_buf = seg_state.deferral_page_buf_ptr();
-        state.tracer.mem_page_buf_len = 0;
-        state.tracer.pv_page_buf_len = 0;
-        state.tracer.deferral_page_buf_len = 0;
-        state.tracer.last_mem_page = NO_LAST_PAGE;
-        state.tracer.check_counter = seg_state.config().segment_check_insns as u32;
-        state.tracer.on_check = Some(metered_periodic_check);
-        state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut std::ffi::c_void;
-
-        let mut io_state = build_io_state(
-            seed.input_stream,
-            memory.as_mut_ptr(),
-            seed.deferrals,
-            seed.deferral_fns,
-            seed.deferral_hash,
-        );
-        io_state.hint_stream = seed.hint_stream;
-        io_state.hint_pos = 0;
-        io_state.public_values = read_public_values_from_guest_memory(&guest_memory);
-        io_state.rng = rng;
-        let callbacks = build_callbacks(&mut io_state);
-        #[cfg(feature = "metrics")]
-        let start = std::time::Instant::now();
-        tracing::info_span!("execute_metered")
-            .in_scope(|| unsafe {
-                register_and_execute(&compiled_metered, &callbacks, state_as_void_ptr(&mut state))
-            })
-            .map_err(map_rvr_execute_error)?;
-        #[cfg(feature = "metrics")]
-        {
-            let elapsed = start.elapsed();
-            let insns = state.instret;
-            tracing::info!("instructions_executed={insns}");
-            metrics::counter!("execute_metered_insns").absolute(insns);
-            metrics::gauge!("execute_metered_insn_mi/s")
-                .set(insns as f64 / elapsed.as_micros() as f64);
-        }
         ensure_rvr_outcome(
             "metered execution from state",
-            state.is_terminated(),
-            state.is_suspended(),
-            state.result_code(),
+            metered_result.state.is_terminated(),
+            metered_result.state.is_suspended(),
+            metered_result.state.result_code(),
             false,
         )?;
 
-        seg_state.on_termination(
-            state.tracer.mem_page_buf_len,
-            state.tracer.pv_page_buf_len,
-            state.tracer.deferral_page_buf_len,
-            state.tracer.check_counter,
-        );
-        let public_values = std::mem::take(&mut io_state.public_values);
-        let deferrals = std::mem::take(&mut io_state.deferrals);
-        let deferral_fns = std::mem::take(&mut io_state.deferral_fns);
-        let deferral_hash = io_state.deferral_hash.take();
-        let metered_result = seg_state.into_result(state, memory, public_values);
-
         let segments = metered_result
             .segments
             .into_iter()
@@ -925,21 +772,6 @@ where
             })
             .collect();
 
-        write_rvr_memory_to_guest_memory(
-            &mut guest_memory,
-            &metered_result.state.regs,
-            &metered_result.memory,
-            &metered_result.public_values,
-        );
-        let final_state = VmState::new(
-            metered_result.state.pc,
-            guest_memory,
-            streams_from_io_state(&io_state, deferrals, deferral_fns, deferral_hash),
-            io_state.rng,
-            #[cfg(feature = "metrics")]
-            metrics,
-        );
-
-        Ok((segments, final_state))
+        Ok((segments, vm_state))
     }
 }

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -719,7 +719,14 @@ where
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let metered_result = tracing::info_span!("execute_metered")
-            .in_scope(|| execute_metered(&compiled_metered, &mut vm_state, trace_config))
+            .in_scope(|| {
+                execute_metered(
+                    &compiled_metered,
+                    &self.extensions,
+                    &mut vm_state,
+                    trace_config,
+                )
+            })
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -11,7 +11,7 @@ use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 
 use super::{
-    bridge::{ensure_rvr_outcome, map_rvr_compile_error, map_rvr_execute_error},
+    bridge::{map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
     compile_metered, compile_metered_with_extensions, execute_metered,
     state::{MeteredState, TracerPayload, TracerPtr},
@@ -90,7 +90,6 @@ impl TracerPayload for MeteredTracerData {
     const KIND: u32 = 11;
 }
 
-/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
 pub type MeteredTracer = TracerPtr<MeteredTracerData>;
 
 // ── Configuration ────────────────────────────────────────────────────────────
@@ -731,14 +730,6 @@ where
             metrics::gauge!("execute_metered_insn_mi/s")
                 .set(insns as f64 / elapsed.as_micros() as f64);
         }
-
-        ensure_rvr_outcome(
-            "metered execution from state",
-            metered_result.state.is_terminated(),
-            metered_result.state.is_suspended(),
-            metered_result.state.result_code(),
-            false,
-        )?;
 
         let segments = metered_result
             .segments

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -9,7 +9,7 @@ use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 use super::{
     bridge::{map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
-    compile_metered_cost, compile_metered_cost_with_extensions, execute_metered_cost,
+    compile_metered_cost, execute_metered_cost,
     state::{MeteredCostState, TracerPayload, TracerPtr},
 };
 use crate::{
@@ -20,11 +20,9 @@ use crate::{
     system::memory::online::GuestMemory,
 };
 
-/// `suspended` is `false` for unlimited runs.
 pub struct RvrMeteredCostResult {
     pub state: MeteredCostState,
     pub cost: u64,
-    pub suspended: bool,
 }
 
 /// Configuration for mapping PCs and memory operations to metering costs.
@@ -175,12 +173,8 @@ where
         );
         let chips = metered_cost_config.chip_mapping();
 
-        let compiled = if self.extensions.is_empty() {
-            compile_metered_cost(self.exe.as_ref(), &chips)
-        } else {
-            compile_metered_cost_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
-        }
-        .map_err(map_rvr_compile_error)?;
+        let compiled = compile_metered_cost(self.exe.as_ref(), &self.extensions, &chips)
+            .map_err(map_rvr_compile_error)?;
 
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
@@ -191,7 +185,6 @@ where
                     &self.extensions,
                     &mut vm_state,
                     metered_cost_config,
-                    None,
                 )
             })
             .map_err(map_rvr_execute_error)?;

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -3,28 +3,19 @@
 use std::sync::Arc;
 
 use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
-use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
-use rvr_state::{GuardedMemory, TracerState};
+use rvr_state::TracerState;
 
 use super::{
-    build_callbacks, build_io_state,
+    bridge::{ensure_rvr_outcome, map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
     compile_metered_cost, compile_metered_cost_with_extensions, execute_metered_cost,
-    register_and_execute,
-    state::{init_rvr_state_with_metered_cost, state_as_void_ptr},
 };
 use crate::{
     arch::{
-        execution_mode::MeteredCostCtx,
-        vm::{
-            copy_guest_memory_to_rvr_memory, ensure_rvr_outcome, map_rvr_compile_error,
-            map_rvr_execute_error, read_public_values_from_guest_memory,
-            read_rv32_regs_from_guest_memory, state_from_rvr, streams_from_io_state,
-            streams_to_io_seed, write_rvr_memory_to_guest_memory,
-        },
-        ExecutionError, ExecutorInventory, MeteredExecutor, Streams, SystemConfig, VmState,
+        execution_mode::MeteredCostCtx, ExecutionError, ExecutorInventory, MeteredExecutor,
+        Streams, SystemConfig, VmState,
     },
     system::memory::online::GuestMemory,
 };
@@ -199,25 +190,26 @@ where
         inputs: impl Into<Streams<F>>,
         ctx: MeteredCostCtx,
     ) -> Result<(MeteredCostCtx, VmState<F, GuestMemory>), ExecutionError> {
-        let inputs = inputs.into();
-        let input_stream = inputs.input_stream;
-        let hint_stream: Vec<u8> = inputs
-            .hint_stream
-            .into_iter()
-            .map(|f| f.as_canonical_u32() as u8)
-            .collect();
-        let deferrals = inputs.deferrals;
-        let deferral_fns = inputs.deferral_fns;
-        let deferral_hash = inputs.deferral_hash;
+        let vm_state = VmState::initial(
+            &self.system_config,
+            &self.exe.init_memory,
+            self.exe.pc_start,
+            inputs,
+        );
+        self.execute_metered_cost_from_state(vm_state, ctx)
+    }
 
+    pub fn execute_metered_cost_from_state(
+        &self,
+        mut vm_state: VmState<F, GuestMemory>,
+        ctx: MeteredCostCtx,
+    ) -> Result<(MeteredCostCtx, VmState<F, GuestMemory>), ExecutionError> {
         let metered_cost_config = build_metered_cost_config(
             self.exe.as_ref(),
             self.inventory.as_ref(),
             &self.executor_idx_to_air_idx,
             &ctx.widths,
         );
-        // TODO: hoist compilation to instance construction; requires moving `ctx.widths` onto the
-        // instance.
         let chips = metered_cost_config.chip_mapping();
 
         let compiled = if self.extensions.is_empty() {
@@ -230,18 +222,7 @@ where
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let result = tracing::info_span!("execute_metered_cost")
-            .in_scope(|| {
-                execute_metered_cost(
-                    &compiled,
-                    self.exe.as_ref(),
-                    input_stream,
-                    hint_stream,
-                    metered_cost_config,
-                    deferrals,
-                    deferral_fns,
-                    deferral_hash,
-                )
-            })
+            .in_scope(|| execute_metered_cost(&compiled, &mut vm_state, metered_cost_config))
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {
@@ -253,122 +234,18 @@ where
                 .set(insns as f64 / elapsed.as_micros() as f64);
         }
 
-        let mut output_ctx = ctx;
-        output_ctx.instret = result.instret;
-        output_ctx.cost = result.cost;
-
-        let state = state_from_rvr(
-            &self.system_config,
-            self.exe.as_ref(),
-            result.state.pc,
-            &result.state.regs,
-            &result.memory,
-            &[],
-        );
-
-        Ok((output_ctx, state))
-    }
-
-    pub fn execute_metered_cost_from_state(
-        &self,
-        from_state: VmState<F, GuestMemory>,
-        ctx: MeteredCostCtx,
-    ) -> Result<(MeteredCostCtx, VmState<F, GuestMemory>), ExecutionError> {
-        let pc = from_state.pc();
-        let mut guest_memory = from_state.memory;
-        let seed = streams_to_io_seed(from_state.streams);
-        let rng = from_state.rng;
-        #[cfg(feature = "metrics")]
-        let metrics = from_state.metrics;
-
-        let metered_cost_config = build_metered_cost_config(
-            self.exe.as_ref(),
-            self.inventory.as_ref(),
-            &self.executor_idx_to_air_idx,
-            &ctx.widths,
-        );
-        let chips = metered_cost_config.chip_mapping();
-
-        let compiled = if self.extensions.is_empty() {
-            compile_metered_cost(self.exe.as_ref(), &chips)
-        } else {
-            compile_metered_cost_with_extensions(self.exe.as_ref(), &self.extensions, &chips)
-        }
-        .map_err(map_rvr_compile_error)?;
-
-        let mut memory = GuardedMemory::new(MEM_SIZE)
-            .map_err(|err| ExecutionError::RvrExecution(err.to_string()))?;
-        let mut tracer_data = MeteredCostData::default();
-        let mut state = init_rvr_state_with_metered_cost(self.exe.as_ref(), &mut memory);
-        state.tracer = MeteredCostMeter(&mut tracer_data);
-        state.pc = pc;
-        state
-            .regs
-            .copy_from_slice(&read_rv32_regs_from_guest_memory(&guest_memory));
-        copy_guest_memory_to_rvr_memory(&guest_memory, &mut memory);
-
-        let widths_u64 = prepare_metered_cost(&metered_cost_config);
-        state.tracer.chip_widths = widths_u64.as_ptr();
-        state.tracer.cost = 0;
-
-        let mut io_state = build_io_state(
-            seed.input_stream,
-            memory.as_mut_ptr(),
-            seed.deferrals,
-            seed.deferral_fns,
-            seed.deferral_hash,
-        );
-        io_state.hint_stream = seed.hint_stream;
-        io_state.hint_pos = 0;
-        io_state.public_values = read_public_values_from_guest_memory(&guest_memory);
-        io_state.rng = rng;
-        let callbacks = build_callbacks(&mut io_state);
-        #[cfg(feature = "metrics")]
-        let start = std::time::Instant::now();
-        tracing::info_span!("execute_metered_cost")
-            .in_scope(|| unsafe {
-                register_and_execute(&compiled, &callbacks, state_as_void_ptr(&mut state))
-            })
-            .map_err(map_rvr_execute_error)?;
-        #[cfg(feature = "metrics")]
-        {
-            let elapsed = start.elapsed();
-            let insns = state.instret;
-            tracing::info!("instructions_executed={insns}");
-            metrics::counter!("execute_metered_cost_insns").absolute(insns);
-            metrics::gauge!("execute_metered_cost_insn_mi/s")
-                .set(insns as f64 / elapsed.as_micros() as f64);
-        }
         ensure_rvr_outcome(
             "metered-cost execution from state",
-            state.is_terminated(),
-            state.is_suspended(),
-            state.result_code(),
+            result.state.is_terminated(),
+            result.suspended,
+            result.state.result_code(),
             false,
         )?;
 
         let mut output_ctx = ctx;
-        output_ctx.instret = state.instret;
-        output_ctx.cost = state.tracer.cost;
+        output_ctx.instret = result.instret;
+        output_ctx.cost = result.cost;
 
-        write_rvr_memory_to_guest_memory(
-            &mut guest_memory,
-            &state.regs,
-            &memory,
-            &io_state.public_values,
-        );
-        let deferrals = std::mem::take(&mut io_state.deferrals);
-        let deferral_fns = std::mem::take(&mut io_state.deferral_fns);
-        let deferral_hash = io_state.deferral_hash.take();
-        let to_state = VmState::new(
-            state.pc,
-            guest_memory,
-            streams_from_io_state(&io_state, deferrals, deferral_fns, deferral_hash),
-            io_state.rng,
-            #[cfg(feature = "metrics")]
-            metrics,
-        );
-
-        Ok((output_ctx, to_state))
+        Ok((output_ctx, vm_state))
     }
 }

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -7,7 +7,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 
 use super::{
-    bridge::{ensure_rvr_outcome, map_rvr_compile_error, map_rvr_execute_error},
+    bridge::{map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
     compile_metered_cost, compile_metered_cost_with_extensions, execute_metered_cost,
     state::{TracerPayload, TracerPtr},
@@ -113,7 +113,6 @@ impl TracerPayload for MeteredCostData {
     const KIND: u32 = 10;
 }
 
-/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
 pub type MeteredCostMeter = TracerPtr<MeteredCostData>;
 
 /// C-compatible pure tracer data.
@@ -128,7 +127,6 @@ impl TracerPayload for PureTracerData {
     const KIND: u32 = 12;
 }
 
-/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
 pub type PureTracer = TracerPtr<PureTracerData>;
 
 /// Prepare metering data from a `MeteredCostConfig`.
@@ -185,20 +183,12 @@ where
         #[cfg(feature = "metrics")]
         {
             let elapsed = start.elapsed();
-            let insns = result.instret;
+            let insns = result.state.instret;
             tracing::info!("instructions_executed={insns}");
             metrics::counter!("execute_metered_cost_insns").absolute(insns);
             metrics::gauge!("execute_metered_cost_insn_mi/s")
                 .set(insns as f64 / elapsed.as_micros() as f64);
         }
-
-        ensure_rvr_outcome(
-            "metered-cost execution from state",
-            result.state.is_terminated(),
-            result.suspended,
-            result.state.result_code(),
-            false,
-        )?;
 
         let mut output_ctx = ctx;
         output_ctx.instret = result.state.instret;

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
-use rvr_state::TracerState;
 
 use super::{
     bridge::{ensure_rvr_outcome, map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
     compile_metered_cost, compile_metered_cost_with_extensions, execute_metered_cost,
+    state::{TracerPayload, TracerPtr},
 };
 use crate::{
     arch::{
@@ -109,33 +109,12 @@ impl Default for MeteredCostData {
     }
 }
 
-/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
-#[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct MeteredCostMeter(pub *mut MeteredCostData);
-
-impl Default for MeteredCostMeter {
-    fn default() -> Self {
-        Self(std::ptr::null_mut())
-    }
-}
-
-impl TracerState for MeteredCostMeter {
+impl TracerPayload for MeteredCostData {
     const KIND: u32 = 10;
 }
 
-impl std::ops::Deref for MeteredCostMeter {
-    type Target = MeteredCostData;
-    fn deref(&self) -> &MeteredCostData {
-        unsafe { &*self.0 }
-    }
-}
-
-impl std::ops::DerefMut for MeteredCostMeter {
-    fn deref_mut(&mut self) -> &mut MeteredCostData {
-        unsafe { &mut *self.0 }
-    }
-}
+/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
+pub type MeteredCostMeter = TracerPtr<MeteredCostData>;
 
 /// C-compatible pure tracer data.
 ///
@@ -145,33 +124,12 @@ impl std::ops::DerefMut for MeteredCostMeter {
 #[derive(Clone, Copy, Default)]
 pub struct PureTracerData;
 
-/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
-#[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct PureTracer(pub *mut PureTracerData);
-
-impl Default for PureTracer {
-    fn default() -> Self {
-        Self(std::ptr::null_mut())
-    }
-}
-
-impl TracerState for PureTracer {
+impl TracerPayload for PureTracerData {
     const KIND: u32 = 12;
 }
 
-impl std::ops::Deref for PureTracer {
-    type Target = PureTracerData;
-    fn deref(&self) -> &PureTracerData {
-        unsafe { &*self.0 }
-    }
-}
-
-impl std::ops::DerefMut for PureTracer {
-    fn deref_mut(&mut self) -> &mut PureTracerData {
-        unsafe { &mut *self.0 }
-    }
-}
+/// Pointer wrapper stored in RvState's tracer field. Matches C `Tracer*` (8 bytes).
+pub type PureTracer = TracerPtr<PureTracerData>;
 
 /// Prepare metering data from a `MeteredCostConfig`.
 ///
@@ -222,7 +180,7 @@ where
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let result = tracing::info_span!("execute_metered_cost")
-            .in_scope(|| execute_metered_cost(&compiled, &mut vm_state, metered_cost_config))
+            .in_scope(|| execute_metered_cost(&compiled, &mut vm_state, metered_cost_config, None))
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {
@@ -243,7 +201,7 @@ where
         )?;
 
         let mut output_ctx = ctx;
-        output_ctx.instret = result.instret;
+        output_ctx.instret = result.state.instret;
         output_ctx.cost = result.cost;
 
         Ok((output_ctx, vm_state))

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -178,7 +178,15 @@ where
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let result = tracing::info_span!("execute_metered_cost")
-            .in_scope(|| execute_metered_cost(&compiled, &mut vm_state, metered_cost_config, None))
+            .in_scope(|| {
+                execute_metered_cost(
+                    &compiled,
+                    &self.extensions,
+                    &mut vm_state,
+                    metered_cost_config,
+                    None,
+                )
+            })
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -10,7 +10,7 @@ use super::{
     bridge::{map_rvr_compile_error, map_rvr_execute_error},
     compile::ChipMapping,
     compile_metered_cost, compile_metered_cost_with_extensions, execute_metered_cost,
-    state::{TracerPayload, TracerPtr},
+    state::{MeteredCostState, TracerPayload, TracerPtr},
 };
 use crate::{
     arch::{
@@ -19,6 +19,13 @@ use crate::{
     },
     system::memory::online::GuestMemory,
 };
+
+/// `suspended` is `false` for unlimited runs.
+pub struct RvrMeteredCostResult {
+    pub state: MeteredCostState,
+    pub cost: u64,
+    pub suspended: bool,
+}
 
 /// Configuration for mapping PCs and memory operations to metering costs.
 pub struct MeteredCostConfig {

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -20,7 +20,7 @@ pub use compile::{
 pub use debug::{default_addr2line_cmd, GuestDebugMap};
 pub use execute::{
     build_callbacks, execute, execute_metered, execute_metered_cost, register_openvm_callbacks,
-    rv_execute, ExecuteError, RvrMeteredCostResult, RvrPureResult, RvrStateInspect,
+    rv_execute, ExecuteError, RvrMeteredCostResult, RvrPureResult,
 };
 pub use metered::{
     build_metered_config, MeteredConfig, RvrMeteredInstance, RvrMeteredResult, RvrSegment,

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -19,8 +19,8 @@ pub use compile::{
 };
 pub use debug::{default_addr2line_cmd, GuestDebugMap};
 pub use execute::{
-    build_callbacks, execute, execute_metered, execute_metered_cost, register_and_execute,
-    ExecuteError, RvrMeteredCostResult, RvrPureResult, RvrStateInspect,
+    build_callbacks, execute, execute_metered, execute_metered_cost, register_openvm_callbacks,
+    rv_execute, ExecuteError, RvrMeteredCostResult, RvrPureResult, RvrStateInspect,
 };
 pub use metered::{
     build_metered_config, MeteredConfig, RvrMeteredInstance, RvrMeteredResult, RvrSegment,

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -20,16 +20,16 @@ pub use compile::{
 pub use debug::{default_addr2line_cmd, GuestDebugMap};
 pub use execute::{
     build_callbacks, execute, execute_metered, execute_metered_cost, register_openvm_callbacks,
-    rv_execute, ExecuteError, RvrMeteredCostResult, RvrPureResult,
+    rv_execute, ExecuteError,
 };
 pub use metered::{
     build_metered_config, MeteredConfig, RvrMeteredInstance, RvrMeteredResult, RvrSegment,
 };
 pub use metered_cost::{
     build_metered_cost_config, MeteredCostConfig, MeteredCostData, MeteredCostMeter, PureTracer,
-    PureTracerData, RvrMeteredCostInstance,
+    PureTracerData, RvrMeteredCostInstance, RvrMeteredCostResult,
 };
-pub use pure::RvrPureInstance;
+pub use pure::{RvrPureInstance, RvrPureResult};
 pub use rvr_openvm::{
     default_compiler as default_native_compiler, default_compiler_command, default_dwarfdump_cmd,
     default_linker, TracerMode,

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -19,9 +19,8 @@ pub use compile::{
 };
 pub use debug::{default_addr2line_cmd, GuestDebugMap};
 pub use execute::{
-    build_callbacks, execute, execute_metered, execute_metered_cost,
-    execute_metered_cost_with_limit, execute_with_limit, register_and_execute, ExecuteError,
-    RvrExecutionResult, RvrLimitedResult, RvrMeteredCostLimitedResult, RvrMeteredCostResult,
+    build_callbacks, execute, execute_metered, execute_metered_cost, register_and_execute,
+    ExecuteError, RvrMeteredCostResult, RvrPureResult, RvrStateInspect,
 };
 pub use metered::{
     build_metered_config, MeteredConfig, RvrMeteredInstance, RvrMeteredResult, RvrSegment,

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -12,10 +12,8 @@ pub mod pure;
 pub mod state;
 
 pub use compile::{
-    compile, compile_metered, compile_metered_cost, compile_metered_cost_with_extensions,
-    compile_metered_cost_with_limit, compile_metered_with_extensions, compile_with_extensions,
-    compile_with_limit, compile_with_options, load_compiled_from_path, ChipMapping, CompileError,
-    CompileOptions, RvrCompiled,
+    compile, compile_metered, compile_metered_cost, load_compiled_from_path, ChipMapping,
+    CompileError, RvrCompiled,
 };
 pub use debug::{default_addr2line_cmd, GuestDebugMap};
 pub use execute::{

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -1,6 +1,7 @@
 //! OpenVM-owned rvr integration layer.
 
 mod abi_consts;
+pub mod bridge;
 pub mod compile;
 pub mod debug;
 pub mod execute;
@@ -18,7 +19,7 @@ pub use compile::{
 };
 pub use debug::{default_addr2line_cmd, GuestDebugMap};
 pub use execute::{
-    build_callbacks, build_io_state, execute, execute_metered, execute_metered_cost,
+    build_callbacks, execute, execute_metered, execute_metered_cost,
     execute_metered_cost_with_limit, execute_with_limit, register_and_execute, ExecuteError,
     RvrExecutionResult, RvrLimitedResult, RvrMeteredCostLimitedResult, RvrMeteredCostResult,
 };

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -23,7 +23,6 @@ pub use execute::{
     execute_metered_cost_with_limit, execute_with_limit, register_and_execute, ExecuteError,
     RvrExecutionResult, RvrLimitedResult, RvrMeteredCostLimitedResult, RvrMeteredCostResult,
 };
-pub use io::{DeferralFnPtr, DeferralHashFn};
 pub use metered::{
     build_metered_config, MeteredConfig, RvrMeteredInstance, RvrMeteredResult, RvrSegment,
 };

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -3,11 +3,7 @@ use std::sync::Arc;
 use openvm_instructions::exe::VmExe;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use super::{
-    bridge::{ensure_rvr_outcome, map_rvr_execute_error},
-    execute::execute,
-    RvrCompiled,
-};
+use super::{bridge::map_rvr_execute_error, execute::execute, RvrCompiled};
 use crate::{
     arch::{ExecutionError, Streams, SystemConfig, VmState},
     system::memory::online::GuestMemory,
@@ -44,6 +40,7 @@ where
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
+        #[allow(unused_variables)]
         let result = tracing::info_span!("execute_e1")
             .in_scope(|| execute(&self.compiled, &mut vm_state, num_insns))
             .map_err(map_rvr_execute_error)?;
@@ -55,13 +52,6 @@ where
             metrics::counter!("execute_e1_insns").absolute(insns);
             metrics::gauge!("execute_e1_insn_mi/s").set(insns as f64 / elapsed.as_micros() as f64);
         }
-        ensure_rvr_outcome(
-            "execution from state",
-            result.state.is_terminated(),
-            result.suspended,
-            result.state.result_code(),
-            num_insns.is_some(),
-        )?;
         Ok(vm_state)
     }
 }

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -4,11 +4,17 @@ use openvm_instructions::exe::VmExe;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_lift::ExtensionRegistry;
 
-use super::{bridge::map_rvr_execute_error, execute::execute, RvrCompiled};
+use super::{bridge::map_rvr_execute_error, execute::execute, state::PureState, RvrCompiled};
 use crate::{
     arch::{ExecutionError, Streams, SystemConfig, VmState},
     system::memory::online::GuestMemory,
 };
+
+/// `suspended` is `false` for unlimited runs.
+pub struct RvrPureResult {
+    pub state: PureState,
+    pub suspended: bool,
+}
 
 pub struct RvrPureInstance<F: PrimeField32> {
     pub(crate) system_config: SystemConfig,

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use openvm_instructions::exe::VmExe;
 use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_openvm_lift::ExtensionRegistry;
 
 use super::{bridge::map_rvr_execute_error, execute::execute, RvrCompiled};
 use crate::{
@@ -9,10 +10,11 @@ use crate::{
     system::memory::online::GuestMemory,
 };
 
-pub struct RvrPureInstance<F> {
+pub struct RvrPureInstance<F: PrimeField32> {
     pub(crate) system_config: SystemConfig,
     pub(crate) exe: Arc<VmExe<F>>,
     pub(crate) compiled: RvrCompiled,
+    pub(crate) extensions: ExtensionRegistry<F>,
 }
 
 impl<F> RvrPureInstance<F>
@@ -42,7 +44,7 @@ where
         let start = std::time::Instant::now();
         #[allow(unused_variables)]
         let result = tracing::info_span!("execute_e1")
-            .in_scope(|| execute(&self.compiled, &mut vm_state, num_insns))
+            .in_scope(|| execute(&self.compiled, &self.extensions, &mut vm_state, num_insns))
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -5,7 +5,7 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::{
     bridge::{ensure_rvr_outcome, map_rvr_execute_error},
-    execute::{execute, execute_with_limit},
+    execute::execute,
     RvrCompiled,
 };
 use crate::{
@@ -44,45 +44,22 @@ where
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
-        let (terminated, suspended, exit_code, _instret) = tracing::info_span!("execute_e1")
-            .in_scope(|| -> Result<(bool, bool, u8, u64), ExecutionError> {
-                match num_insns {
-                    Some(limit) => {
-                        let result = execute_with_limit(&self.compiled, &mut vm_state, limit)
-                            .map_err(map_rvr_execute_error)?;
-                        Ok((
-                            result.state.is_terminated(),
-                            result.suspended,
-                            result.state.result_code(),
-                            result.instret,
-                        ))
-                    }
-                    None => {
-                        let result = execute(&self.compiled, &mut vm_state)
-                            .map_err(map_rvr_execute_error)?;
-                        Ok((
-                            result.state.is_terminated(),
-                            false,
-                            result.state.result_code(),
-                            result.state.instret,
-                        ))
-                    }
-                }
-            })?;
+        let result = tracing::info_span!("execute_e1")
+            .in_scope(|| execute(&self.compiled, &mut vm_state, num_insns))
+            .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {
             let elapsed = start.elapsed();
-            let insns = _instret;
+            let insns = result.state.instret;
             tracing::info!("instructions_executed={insns}");
             metrics::counter!("execute_e1_insns").absolute(insns);
             metrics::gauge!("execute_e1_insn_mi/s").set(insns as f64 / elapsed.as_micros() as f64);
         }
-
         ensure_rvr_outcome(
             "execution from state",
-            terminated,
-            suspended,
-            exit_code,
+            result.state.is_terminated(),
+            result.suspended,
+            result.state.result_code(),
             num_insns.is_some(),
         )?;
         Ok(vm_state)

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -1,24 +1,15 @@
 use std::sync::Arc;
 
 use openvm_instructions::exe::VmExe;
-use openvm_platform::memory::MEM_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_state::GuardedMemory;
 
 use super::{
-    build_callbacks, build_io_state, execute, execute_with_limit, register_and_execute,
-    state::{init_rvr_state, state_as_void_ptr},
-    PureTracer, PureTracerData, RvrCompiled,
+    bridge::{ensure_rvr_outcome, map_rvr_execute_error},
+    execute::{execute, execute_with_limit},
+    RvrCompiled,
 };
 use crate::{
-    arch::{
-        vm::{
-            copy_guest_memory_to_rvr_memory, ensure_rvr_outcome, map_rvr_execute_error,
-            read_public_values_from_guest_memory, read_rv32_regs_from_guest_memory, state_from_rvr,
-            streams_from_io_state, streams_to_io_seed, write_rvr_memory_to_guest_memory,
-        },
-        ExecutionError, Streams, SystemConfig, VmState,
-    },
+    arch::{ExecutionError, Streams, SystemConfig, VmState},
     system::memory::online::GuestMemory,
 };
 
@@ -32,173 +23,68 @@ impl<F> RvrPureInstance<F>
 where
     F: PrimeField32,
 {
-    // TODO: deduplicate `execute` and `execute_from_state` — they share the rvr invocation
-    // and result-translation logic and only differ in how the initial state is set up.
     pub fn execute(
         &self,
         inputs: impl Into<Streams<F>>,
         num_insns: Option<u64>,
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
-        let inputs = inputs.into();
-        let input_stream = inputs.input_stream;
-        let hint_stream: Vec<u8> = inputs
-            .hint_stream
-            .into_iter()
-            .map(|f| f.as_canonical_u32() as u8)
-            .collect();
-        let deferrals = inputs.deferrals;
-        let deferral_fns = inputs.deferral_fns;
-        let deferral_hash = inputs.deferral_hash;
-
-        if let Some(limit) = num_insns {
-            #[cfg(feature = "metrics")]
-            let start = std::time::Instant::now();
-            let result = tracing::info_span!("execute_e1")
-                .in_scope(|| {
-                    execute_with_limit(
-                        &self.compiled,
-                        self.exe.as_ref(),
-                        input_stream,
-                        hint_stream,
-                        limit,
-                        deferrals,
-                        deferral_fns,
-                        deferral_hash,
-                    )
-                })
-                .map_err(map_rvr_execute_error)?;
-            #[cfg(feature = "metrics")]
-            {
-                let elapsed = start.elapsed();
-                let insns = result.instret;
-                tracing::info!("instructions_executed={insns}");
-                metrics::counter!("execute_e1_insns").absolute(insns);
-                metrics::gauge!("execute_e1_insn_mi/s")
-                    .set(insns as f64 / elapsed.as_micros() as f64);
-            }
-            return Ok(state_from_rvr(
-                &self.system_config,
-                self.exe.as_ref(),
-                result.state.pc,
-                &result.state.regs,
-                &result.memory,
-                &[],
-            ));
-        }
-
-        #[cfg(feature = "metrics")]
-        let start = std::time::Instant::now();
-        let result = tracing::info_span!("execute_e1")
-            .in_scope(|| {
-                execute(
-                    &self.compiled,
-                    self.exe.as_ref(),
-                    input_stream,
-                    hint_stream,
-                    deferrals,
-                    deferral_fns,
-                    deferral_hash,
-                )
-            })
-            .map_err(map_rvr_execute_error)?;
-        #[cfg(feature = "metrics")]
-        {
-            let elapsed = start.elapsed();
-            let insns = result.state.instret;
-            tracing::info!("instructions_executed={insns}");
-            metrics::counter!("execute_e1_insns").absolute(insns);
-            metrics::gauge!("execute_e1_insn_mi/s").set(insns as f64 / elapsed.as_micros() as f64);
-        }
-
-        Ok(state_from_rvr(
+        let vm_state = VmState::initial(
             &self.system_config,
-            self.exe.as_ref(),
-            result.state.pc,
-            &result.state.regs,
-            &result.memory,
-            &result.public_values,
-        ))
+            &self.exe.init_memory,
+            self.exe.pc_start,
+            inputs,
+        );
+        self.execute_from_state(vm_state, num_insns)
     }
 
     pub fn execute_from_state(
         &self,
-        from_state: VmState<F, GuestMemory>,
+        mut vm_state: VmState<F, GuestMemory>,
         num_insns: Option<u64>,
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
-        let pc = from_state.pc();
-        let mut guest_memory = from_state.memory;
-        let seed = streams_to_io_seed(from_state.streams);
-        let rng = from_state.rng;
-        #[cfg(feature = "metrics")]
-        let metrics = from_state.metrics;
-
-        let mut memory = GuardedMemory::new(MEM_SIZE)
-            .map_err(|err| ExecutionError::RvrExecution(err.to_string()))?;
-
-        let mut tracer_data = PureTracerData;
-        let mut state = init_rvr_state(self.exe.as_ref(), &mut memory);
-        state.tracer = PureTracer(&mut tracer_data);
-        state.pc = pc;
-        state
-            .regs
-            .copy_from_slice(&read_rv32_regs_from_guest_memory(&guest_memory));
-        copy_guest_memory_to_rvr_memory(&guest_memory, &mut memory);
-        match num_insns {
-            Some(limit) => state.suspender.set_target(limit),
-            None => state.suspender.disable(),
-        }
-
-        let mut io_state = build_io_state(
-            seed.input_stream,
-            memory.as_mut_ptr(),
-            seed.deferrals,
-            seed.deferral_fns,
-            seed.deferral_hash,
-        );
-        io_state.hint_stream = seed.hint_stream;
-        io_state.hint_pos = 0;
-        io_state.public_values = read_public_values_from_guest_memory(&guest_memory);
-        io_state.rng = rng;
-        let callbacks = build_callbacks(&mut io_state);
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
-        tracing::info_span!("execute_e1")
-            .in_scope(|| unsafe {
-                register_and_execute(&self.compiled, &callbacks, state_as_void_ptr(&mut state))
-            })
-            .map_err(map_rvr_execute_error)?;
+        let (terminated, suspended, exit_code, _instret) = tracing::info_span!("execute_e1")
+            .in_scope(|| -> Result<(bool, bool, u8, u64), ExecutionError> {
+                match num_insns {
+                    Some(limit) => {
+                        let result = execute_with_limit(&self.compiled, &mut vm_state, limit)
+                            .map_err(map_rvr_execute_error)?;
+                        Ok((
+                            result.state.is_terminated(),
+                            result.suspended,
+                            result.state.result_code(),
+                            result.instret,
+                        ))
+                    }
+                    None => {
+                        let result = execute(&self.compiled, &mut vm_state)
+                            .map_err(map_rvr_execute_error)?;
+                        Ok((
+                            result.state.is_terminated(),
+                            false,
+                            result.state.result_code(),
+                            result.state.instret,
+                        ))
+                    }
+                }
+            })?;
         #[cfg(feature = "metrics")]
         {
             let elapsed = start.elapsed();
-            let insns = state.instret;
+            let insns = _instret;
             tracing::info!("instructions_executed={insns}");
             metrics::counter!("execute_e1_insns").absolute(insns);
             metrics::gauge!("execute_e1_insn_mi/s").set(insns as f64 / elapsed.as_micros() as f64);
         }
+
         ensure_rvr_outcome(
             "execution from state",
-            state.is_terminated(),
-            state.is_suspended(),
-            state.result_code(),
+            terminated,
+            suspended,
+            exit_code,
             num_insns.is_some(),
         )?;
-
-        write_rvr_memory_to_guest_memory(
-            &mut guest_memory,
-            &state.regs,
-            &memory,
-            &io_state.public_values,
-        );
-        let deferrals = std::mem::take(&mut io_state.deferrals);
-        let deferral_fns = std::mem::take(&mut io_state.deferral_fns);
-        let deferral_hash = io_state.deferral_hash.take();
-        Ok(VmState::new(
-            state.pc,
-            guest_memory,
-            streams_from_io_state(&io_state, deferrals, deferral_fns, deferral_hash),
-            io_state.rng,
-            #[cfg(feature = "metrics")]
-            metrics,
-        ))
+        Ok(vm_state)
     }
 }

--- a/crates/vm/src/arch/rvr/state.rs
+++ b/crates/vm/src/arch/rvr/state.rs
@@ -4,24 +4,71 @@
 //! by fixed offsets. It is built fresh per execution and points at VmState's
 //! existing memory buffer; we do not own a separate allocation.
 
-use std::ffi::c_void;
-
-use rvr_state::{InstretSuspender, Rv32State, RvState, NUM_REGS_I};
+use rvr_state::{InstretSuspender, RvState, TracerState};
 
 use super::{
     metered::MeteredTracer,
     metered_cost::{MeteredCostMeter, PureTracer},
 };
 
+// ── Generic tracer pointer wrapper ───────────────────────────────────────────
+
+/// A payload type that can sit behind a [`TracerPtr`]. The const `KIND`
+/// matches the tracer-kind ABI the rvr-generated C code expects.
+pub trait TracerPayload {
+    const KIND: u32;
+}
+
+/// `#[repr(transparent)]` pointer to a tracer payload. Matches the C
+/// `Tracer*` ABI (8 bytes). Default is a null pointer; consumers set the
+/// pointer at execute-time via `TracerPtr(&mut payload)`.
+///
+/// All three concrete tracer wrappers (`PureTracer`, `MeteredCostMeter`,
+/// `MeteredTracer`) are type aliases of `TracerPtr<P>` for the matching
+/// payload `P`, so the boilerplate `Default`/`TracerState`/`Deref`/`DerefMut`
+/// impls live once here rather than three times.
+#[repr(transparent)]
+pub struct TracerPtr<T>(pub *mut T);
+
+impl<T> Clone for TracerPtr<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for TracerPtr<T> {}
+
+impl<T> Default for TracerPtr<T> {
+    fn default() -> Self {
+        Self(std::ptr::null_mut())
+    }
+}
+
+impl<T: TracerPayload> TracerState for TracerPtr<T> {
+    const KIND: u32 = T::KIND;
+}
+
+impl<T> std::ops::Deref for TracerPtr<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.0 }
+    }
+}
+
+impl<T> std::ops::DerefMut for TracerPtr<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.0 }
+    }
+}
+
 /// Type alias for RV32 state with PureTracer and instret-based suspension.
-pub type PureState = RvState<rvr_state::Rv32, PureTracer, InstretSuspender, NUM_REGS_I>;
+pub type PureState = RvState<rvr_state::Rv32, PureTracer, InstretSuspender>;
 
 /// Type alias for RV32 state with MeteredCostMeter and instret-based suspension.
-pub type MeteredCostState =
-    RvState<rvr_state::Rv32, MeteredCostMeter, InstretSuspender, NUM_REGS_I>;
+pub type MeteredCostState = RvState<rvr_state::Rv32, MeteredCostMeter, InstretSuspender>;
 
 /// Type alias for RV32 state with MeteredTracer and instret-based suspension.
-pub type MeteredState = RvState<rvr_state::Rv32, MeteredTracer, InstretSuspender, NUM_REGS_I>;
+pub type MeteredState = RvState<rvr_state::Rv32, MeteredTracer, InstretSuspender>;
 
 /// Build a `PureState` whose memory pointer aliases `memory_ptr` and pc starts at `pc`.
 ///
@@ -55,18 +102,4 @@ pub fn init_rvr_state_with_metered(memory_ptr: *mut u8, pc: u32) -> MeteredState
     state.pc = pc;
     state.suspender.disable();
     state
-}
-
-/// Get a void pointer to the state for FFI.
-pub fn state_as_void_ptr<S>(state: &mut S) -> *mut c_void {
-    state as *mut S as *mut c_void
-}
-
-/// Copy registers from an `RvState` back to the OpenVM register format.
-pub fn extract_registers(state: &Rv32State) -> [(u32, [u8; 4]); 32] {
-    let mut result = [(0u32, [0u8; 4]); 32];
-    for (i, reg) in state.regs.iter().enumerate() {
-        result[i] = (*reg, reg.to_le_bytes());
-    }
-    result
 }

--- a/crates/vm/src/arch/rvr/state.rs
+++ b/crates/vm/src/arch/rvr/state.rs
@@ -14,6 +14,10 @@ use super::{
 };
 use crate::{arch::VmState, system::memory::online::GuestMemory};
 
+pub type PureState = RvState<Rv32, PureTracer, InstretSuspender>;
+pub type MeteredCostState = RvState<Rv32, MeteredCostMeter, InstretSuspender>;
+pub type MeteredState = RvState<Rv32, MeteredTracer, InstretSuspender>;
+
 /// A payload type that can sit behind a [`TracerPtr`]. The const `KIND`
 /// matches the tracer-kind ABI the rvr-generated C code expects.
 pub trait TracerPayload {
@@ -64,10 +68,6 @@ impl<T> std::ops::DerefMut for TracerPtr<T> {
         unsafe { &mut *self.0 }
     }
 }
-
-pub type PureState = RvState<Rv32, PureTracer, InstretSuspender>;
-pub type MeteredCostState = RvState<Rv32, MeteredCostMeter, InstretSuspender>;
-pub type MeteredState = RvState<Rv32, MeteredTracer, InstretSuspender>;
 
 /// Build a `PureState` whose memory pointer aliases `vm_state`'s
 /// `RV32_MEMORY_AS` segment, with pc set to `pc`. Suspender is disabled by

--- a/crates/vm/src/arch/rvr/state.rs
+++ b/crates/vm/src/arch/rvr/state.rs
@@ -4,12 +4,15 @@
 //! by fixed offsets. It is built fresh per execution and points at VmState's
 //! existing memory buffer; we do not own a separate allocation.
 
+use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_state::{InstretSuspender, Rv32, RvState, TracerState};
 
 use super::{
+    bridge::rv32_memory_ptr,
     metered::MeteredTracer,
     metered_cost::{MeteredCostMeter, PureTracer},
 };
+use crate::{arch::VmState, system::memory::online::GuestMemory};
 
 /// A payload type that can sit behind a [`TracerPtr`]. The const `KIND`
 /// matches the tracer-kind ABI the rvr-generated C code expects.
@@ -66,15 +69,17 @@ pub type PureState = RvState<Rv32, PureTracer, InstretSuspender>;
 pub type MeteredCostState = RvState<Rv32, MeteredCostMeter, InstretSuspender>;
 pub type MeteredState = RvState<Rv32, MeteredTracer, InstretSuspender>;
 
-/// Build a `PureState` whose memory pointer aliases `memory_ptr` and pc starts at `pc`.
+/// Build a `PureState` whose memory pointer aliases `vm_state`'s
+/// `RV32_MEMORY_AS` segment, with pc set to `pc`. Suspender is disabled by
+/// default; the caller may re-arm it via `state.suspender.set_target(_)`.
 ///
-/// Suspender is disabled by default; the caller may re-arm it via `state.suspender.set_target(_)`.
-///
-/// # Safety
-///
-/// `memory_ptr` must be a valid mutable pointer to at least `MEM_SIZE` bytes that stay
-/// alive and untouched by anything else for the duration of rvr execution.
-pub fn init_rvr_state(memory_ptr: *mut u8, pc: u32) -> PureState {
+/// The stored pointer is dereferenced later by the rvr C engine; the segment
+/// must stay alive and be uniquely accessed for the duration of rvr execution.
+pub fn init_rvr_state<F: PrimeField32>(
+    vm_state: &mut VmState<F, GuestMemory>,
+    pc: u32,
+) -> PureState {
+    let memory_ptr = rv32_memory_ptr(vm_state);
     let mut state = PureState::new();
     state.set_memory(memory_ptr);
     state.pc = pc;
@@ -82,7 +87,11 @@ pub fn init_rvr_state(memory_ptr: *mut u8, pc: u32) -> PureState {
     state
 }
 
-pub fn init_rvr_state_with_metered_cost(memory_ptr: *mut u8, pc: u32) -> MeteredCostState {
+pub fn init_rvr_state_with_metered_cost<F: PrimeField32>(
+    vm_state: &mut VmState<F, GuestMemory>,
+    pc: u32,
+) -> MeteredCostState {
+    let memory_ptr = rv32_memory_ptr(vm_state);
     let mut state = MeteredCostState::new();
     state.set_memory(memory_ptr);
     state.pc = pc;
@@ -90,7 +99,11 @@ pub fn init_rvr_state_with_metered_cost(memory_ptr: *mut u8, pc: u32) -> Metered
     state
 }
 
-pub fn init_rvr_state_with_metered(memory_ptr: *mut u8, pc: u32) -> MeteredState {
+pub fn init_rvr_state_with_metered<F: PrimeField32>(
+    vm_state: &mut VmState<F, GuestMemory>,
+    pc: u32,
+) -> MeteredState {
+    let memory_ptr = rv32_memory_ptr(vm_state);
     let mut state = MeteredState::new();
     state.set_memory(memory_ptr);
     state.pc = pc;

--- a/crates/vm/src/arch/rvr/state.rs
+++ b/crates/vm/src/arch/rvr/state.rs
@@ -4,7 +4,7 @@
 //! by fixed offsets. It is built fresh per execution and points at VmState's
 //! existing memory buffer; we do not own a separate allocation.
 
-use rvr_state::{InstretSuspender, RvState, TracerState};
+use rvr_state::{InstretSuspender, Rv32, RvState, TracerState};
 
 use super::{
     metered::MeteredTracer,
@@ -44,19 +44,27 @@ impl<T: TracerPayload> TracerState for TracerPtr<T> {
 impl<T> std::ops::Deref for TracerPtr<T> {
     type Target = T;
     fn deref(&self) -> &T {
+        debug_assert!(
+            !self.0.is_null(),
+            "TracerPtr dereferenced before payload was assigned"
+        );
         unsafe { &*self.0 }
     }
 }
 
 impl<T> std::ops::DerefMut for TracerPtr<T> {
     fn deref_mut(&mut self) -> &mut T {
+        debug_assert!(
+            !self.0.is_null(),
+            "TracerPtr dereferenced before payload was assigned"
+        );
         unsafe { &mut *self.0 }
     }
 }
 
-pub type PureState = RvState<rvr_state::Rv32, PureTracer, InstretSuspender>;
-pub type MeteredCostState = RvState<rvr_state::Rv32, MeteredCostMeter, InstretSuspender>;
-pub type MeteredState = RvState<rvr_state::Rv32, MeteredTracer, InstretSuspender>;
+pub type PureState = RvState<Rv32, PureTracer, InstretSuspender>;
+pub type MeteredCostState = RvState<Rv32, MeteredCostMeter, InstretSuspender>;
+pub type MeteredState = RvState<Rv32, MeteredTracer, InstretSuspender>;
 
 /// Build a `PureState` whose memory pointer aliases `memory_ptr` and pc starts at `pc`.
 ///

--- a/crates/vm/src/arch/rvr/state.rs
+++ b/crates/vm/src/arch/rvr/state.rs
@@ -11,8 +11,6 @@ use super::{
     metered_cost::{MeteredCostMeter, PureTracer},
 };
 
-// ── Generic tracer pointer wrapper ───────────────────────────────────────────
-
 /// A payload type that can sit behind a [`TracerPtr`]. The const `KIND`
 /// matches the tracer-kind ABI the rvr-generated C code expects.
 pub trait TracerPayload {
@@ -22,11 +20,6 @@ pub trait TracerPayload {
 /// `#[repr(transparent)]` pointer to a tracer payload. Matches the C
 /// `Tracer*` ABI (8 bytes). Default is a null pointer; consumers set the
 /// pointer at execute-time via `TracerPtr(&mut payload)`.
-///
-/// All three concrete tracer wrappers (`PureTracer`, `MeteredCostMeter`,
-/// `MeteredTracer`) are type aliases of `TracerPtr<P>` for the matching
-/// payload `P`, so the boilerplate `Default`/`TracerState`/`Deref`/`DerefMut`
-/// impls live once here rather than three times.
 #[repr(transparent)]
 pub struct TracerPtr<T>(pub *mut T);
 
@@ -61,13 +54,8 @@ impl<T> std::ops::DerefMut for TracerPtr<T> {
     }
 }
 
-/// Type alias for RV32 state with PureTracer and instret-based suspension.
 pub type PureState = RvState<rvr_state::Rv32, PureTracer, InstretSuspender>;
-
-/// Type alias for RV32 state with MeteredCostMeter and instret-based suspension.
 pub type MeteredCostState = RvState<rvr_state::Rv32, MeteredCostMeter, InstretSuspender>;
-
-/// Type alias for RV32 state with MeteredTracer and instret-based suspension.
 pub type MeteredState = RvState<rvr_state::Rv32, MeteredTracer, InstretSuspender>;
 
 /// Build a `PureState` whose memory pointer aliases `memory_ptr` and pc starts at `pc`.
@@ -86,7 +74,6 @@ pub fn init_rvr_state(memory_ptr: *mut u8, pc: u32) -> PureState {
     state
 }
 
-/// Build a `MeteredCostState`. See [`init_rvr_state`] for safety.
 pub fn init_rvr_state_with_metered_cost(memory_ptr: *mut u8, pc: u32) -> MeteredCostState {
     let mut state = MeteredCostState::new();
     state.set_memory(memory_ptr);
@@ -95,7 +82,6 @@ pub fn init_rvr_state_with_metered_cost(memory_ptr: *mut u8, pc: u32) -> Metered
     state
 }
 
-/// Build a `MeteredState`. See [`init_rvr_state`] for safety.
 pub fn init_rvr_state_with_metered(memory_ptr: *mut u8, pc: u32) -> MeteredState {
     let mut state = MeteredState::new();
     state.set_memory(memory_ptr);

--- a/crates/vm/src/arch/rvr/state.rs
+++ b/crates/vm/src/arch/rvr/state.rs
@@ -1,10 +1,12 @@
-//! OpenVM VmState <-> rvr RvState bridging.
+//! Initialization helpers for the rvr `RvState` scratch struct.
+//!
+//! `RvState` is a `#[repr(C)]` shim that the rvr-generated C code reads/writes
+//! by fixed offsets. It is built fresh per execution and points at VmState's
+//! existing memory buffer; we do not own a separate allocation.
 
 use std::ffi::c_void;
 
-use openvm_instructions::exe::VmExe;
-use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_state::{GuardedMemory, InstretSuspender, Rv32State, RvState, NUM_REGS_I};
+use rvr_state::{InstretSuspender, Rv32State, RvState, NUM_REGS_I};
 
 use super::{
     metered::MeteredTracer,
@@ -21,52 +23,36 @@ pub type MeteredCostState =
 /// Type alias for RV32 state with MeteredTracer and instret-based suspension.
 pub type MeteredState = RvState<rvr_state::Rv32, MeteredTracer, InstretSuspender, NUM_REGS_I>;
 
-/// Initialize memory from a VmExe into a GuardedMemory buffer.
-fn init_memory<F: PrimeField32>(exe: &VmExe<F>, memory: &mut GuardedMemory) {
-    for (&(addr_space, addr), &byte) in &exe.init_memory {
-        if addr_space == 2 {
-            let addr = addr as usize;
-            debug_assert!(
-                addr < memory.size(),
-                "init_memory address {addr:#x} exceeds buffer"
-            );
-            unsafe { memory.write_u8(addr, byte) };
-        }
-    }
-}
-
-/// Initialize a PureState from a VmExe (no-op tracing, suspension disabled).
-pub fn init_rvr_state<F: PrimeField32>(exe: &VmExe<F>, memory: &mut GuardedMemory) -> PureState {
+/// Build a `PureState` whose memory pointer aliases `memory_ptr` and pc starts at `pc`.
+///
+/// Suspender is disabled by default; the caller may re-arm it via `state.suspender.set_target(_)`.
+///
+/// # Safety
+///
+/// `memory_ptr` must be a valid mutable pointer to at least `MEM_SIZE` bytes that stay
+/// alive and untouched by anything else for the duration of rvr execution.
+pub fn init_rvr_state(memory_ptr: *mut u8, pc: u32) -> PureState {
     let mut state = PureState::new();
-    init_memory(exe, memory);
-    state.set_memory(memory.as_mut_ptr());
-    state.pc = exe.pc_start;
+    state.set_memory(memory_ptr);
+    state.pc = pc;
     state.suspender.disable();
     state
 }
 
-/// Initialize a state with MeteredCostMeter tracer (suspension disabled).
-pub fn init_rvr_state_with_metered_cost<F: PrimeField32>(
-    exe: &VmExe<F>,
-    memory: &mut GuardedMemory,
-) -> MeteredCostState {
+/// Build a `MeteredCostState`. See [`init_rvr_state`] for safety.
+pub fn init_rvr_state_with_metered_cost(memory_ptr: *mut u8, pc: u32) -> MeteredCostState {
     let mut state = MeteredCostState::new();
-    init_memory(exe, memory);
-    state.set_memory(memory.as_mut_ptr());
-    state.pc = exe.pc_start;
+    state.set_memory(memory_ptr);
+    state.pc = pc;
     state.suspender.disable();
     state
 }
 
-/// Initialize a state with MeteredTracer for per-chip metered execution (suspension disabled).
-pub fn init_rvr_state_with_metered<F: PrimeField32>(
-    exe: &VmExe<F>,
-    memory: &mut GuardedMemory,
-) -> MeteredState {
+/// Build a `MeteredState`. See [`init_rvr_state`] for safety.
+pub fn init_rvr_state_with_metered(memory_ptr: *mut u8, pc: u32) -> MeteredState {
     let mut state = MeteredState::new();
-    init_memory(exe, memory);
-    state.set_memory(memory.as_mut_ptr());
-    state.pc = exe.pc_start;
+    state.set_memory(memory_ptr);
+    state.pc = pc;
     state.suspender.disable();
     state
 }
@@ -76,7 +62,7 @@ pub fn state_as_void_ptr<S>(state: &mut S) -> *mut c_void {
     state as *mut S as *mut c_void
 }
 
-/// Copy registers from an RvState back to the OpenVM register format.
+/// Copy registers from an `RvState` back to the OpenVM register format.
 pub fn extract_registers(state: &Rv32State) -> [(u32, [u8; 4]); 32] {
     let mut result = [(0u32, [0u8; 4]); 32];
     for (i, reg) in state.regs.iter().enumerate() {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -294,8 +294,7 @@ where
         // execution can avoid passing `executor_idx_to_air_idx` altogether.
         let executor_idx_to_air_idx = vec![NO_CHIP as usize; self.inventory.executors.len()];
         let extensions = self.build_rvr_extensions(&executor_idx_to_air_idx);
-        let compiled =
-            rvr::compile_with_extensions(exe, &extensions).map_err(map_rvr_compile_error)?;
+        let compiled = rvr::compile(exe, &extensions).map_err(map_rvr_compile_error)?;
 
         Ok(RvrPureInstance {
             system_config: self.inventory.config().clone(),

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -112,10 +112,6 @@ pub struct Streams<F> {
     /// Cached deferred operation inputs and outputs. Each idx corresponds to a
     /// unique function that is constrained outside the VM in its own deferral circuit.
     pub deferrals: Vec<DeferralState>,
-    #[cfg(feature = "rvr")]
-    pub deferral_fns: Vec<rvr::io::DeferralFnPtr>,
-    #[cfg(feature = "rvr")]
-    pub deferral_hash: Option<rvr::io::DeferralHashFn>,
 }
 
 impl<F> Streams<F> {
@@ -124,10 +120,6 @@ impl<F> Streams<F> {
             input_stream: input_stream.into(),
             hint_stream: VecDeque::default(),
             deferrals: Vec::default(),
-            #[cfg(feature = "rvr")]
-            deferral_fns: Vec::default(),
-            #[cfg(feature = "rvr")]
-            deferral_hash: None,
         }
     }
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -11,8 +11,6 @@ use std::{any::TypeId, borrow::Borrow, collections::VecDeque, marker::PhantomDat
 use getset::{Getters, MutGetters, Setters, WithSetters};
 use itertools::{zip_eq, Itertools};
 use openvm_circuit::system::program::trace::compute_exe_commit;
-#[cfg(feature = "rvr")]
-use openvm_instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS};
 use openvm_instructions::{
     exe::{SparseMemoryImage, VmExe},
     program::Program,
@@ -44,7 +42,10 @@ use tracing::{info_span, instrument};
 #[cfg(feature = "aot")]
 use super::aot::AotInstance;
 #[cfg(feature = "rvr")]
-use super::rvr::{self, RvrMeteredCostInstance, RvrMeteredInstance, RvrPureInstance};
+use super::rvr::{
+    self, bridge::map_rvr_compile_error, RvrMeteredCostInstance, RvrMeteredInstance,
+    RvrPureInstance,
+};
 use super::{
     execution_mode::{ExecutionCtx, MeteredCostCtx, MeteredCtx, PreflightCtx, Segment},
     hasher::poseidon2::vm_poseidon2_hasher,
@@ -56,8 +57,6 @@ use super::{
     VmExecutionConfig, VmState, CONNECTOR_AIR_ID, MERKLE_AIR_ID, PROGRAM_AIR_ID,
     PROGRAM_CACHED_TRACE_INDEX,
 };
-#[cfg(feature = "rvr")]
-use crate::system::memory::{merkle::public_values::PUBLIC_VALUES_AS, online::LinearMemory};
 use crate::{
     arch::deferral::DeferralState,
     execute_spanned,
@@ -163,201 +162,6 @@ type RvrMeteredInstance2<F, VC> = RvrMeteredInstance<F, <VC as VmExecutionConfig
 #[cfg(feature = "rvr")]
 type RvrMeteredCostInstance2<F, VC> =
     RvrMeteredCostInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
-
-#[cfg(feature = "rvr")]
-pub(crate) fn map_rvr_compile_error(err: rvr::CompileError) -> StaticProgramError {
-    StaticProgramError::FailToGenerateDynamicLibrary {
-        err: err.to_string(),
-    }
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn map_rvr_execute_error(err: rvr::ExecuteError) -> ExecutionError {
-    match err {
-        rvr::ExecuteError::GuestExit(code) => ExecutionError::FailedWithExitCode(code as u32),
-        other => ExecutionError::RvrExecution(other.to_string()),
-    }
-}
-
-// TODO: Unify format of the VM state for rvr and interpreted execution.
-#[cfg(feature = "rvr")]
-pub(crate) fn state_from_rvr<F: PrimeField32>(
-    system_config: &SystemConfig,
-    exe: &VmExe<F>,
-    pc: u32,
-    regs: &[u32],
-    rvr_memory: &rvr_state::GuardedMemory,
-    public_values: &[u8],
-) -> VmState<F, GuestMemory> {
-    let mut guest_memory = create_memory_image(&system_config.memory_config, &exe.init_memory);
-    write_rvr_memory_to_guest_memory(&mut guest_memory, regs, rvr_memory, public_values);
-
-    VmState::new_with_defaults(pc, guest_memory, Streams::default(), 0)
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn write_rvr_memory_to_guest_memory(
-    guest_memory: &mut GuestMemory,
-    regs: &[u32],
-    rvr_memory: &rvr_state::GuardedMemory,
-    public_values: &[u8],
-) {
-    let source_memory =
-        unsafe { std::slice::from_raw_parts(rvr_memory.as_ptr(), rvr_memory.size()) };
-    let memory_capacity = guest_memory.memory.config[RV32_MEMORY_AS as usize].num_cells;
-    let memory_len = std::cmp::min(memory_capacity, source_memory.len());
-    unsafe {
-        guest_memory
-            .memory
-            .copy_slice_nonoverlapping((RV32_MEMORY_AS, 0), &source_memory[..memory_len]);
-    }
-
-    let mut register_bytes = Vec::with_capacity(std::mem::size_of_val(regs));
-    for reg in regs {
-        register_bytes.extend_from_slice(&reg.to_le_bytes());
-    }
-    let register_capacity = guest_memory.memory.config[RV32_REGISTER_AS as usize].num_cells;
-    let register_len = std::cmp::min(register_capacity, register_bytes.len());
-    unsafe {
-        guest_memory
-            .memory
-            .copy_slice_nonoverlapping((RV32_REGISTER_AS, 0), &register_bytes[..register_len]);
-    }
-
-    if !public_values.is_empty() {
-        let pv_capacity = guest_memory.memory.mem[PUBLIC_VALUES_AS as usize].size();
-        let pv_len = std::cmp::min(pv_capacity, public_values.len());
-        unsafe {
-            guest_memory
-                .memory
-                .copy_slice_nonoverlapping((PUBLIC_VALUES_AS, 0), &public_values[..pv_len]);
-        }
-    }
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn read_rv32_regs_from_guest_memory(guest_memory: &GuestMemory) -> [u32; 32] {
-    let reg_capacity = guest_memory.memory.config[RV32_REGISTER_AS as usize].num_cells;
-    let regs_u8 = unsafe {
-        guest_memory
-            .memory
-            .get_u8_slice(RV32_REGISTER_AS, 0, reg_capacity)
-    };
-    let mut regs = [0u32; 32];
-    for (i, chunk) in regs_u8.chunks_exact(4).take(32).enumerate() {
-        regs[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-    }
-    regs
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn copy_guest_memory_to_rvr_memory(
-    guest_memory: &GuestMemory,
-    rvr_memory: &mut rvr_state::GuardedMemory,
-) {
-    let memory_capacity = guest_memory.memory.config[RV32_MEMORY_AS as usize].num_cells;
-    let source_memory = unsafe {
-        guest_memory
-            .memory
-            .get_u8_slice(RV32_MEMORY_AS, 0, memory_capacity)
-    };
-    let dst = unsafe { std::slice::from_raw_parts_mut(rvr_memory.as_mut_ptr(), rvr_memory.size()) };
-    let len = std::cmp::min(dst.len(), source_memory.len());
-    dst[..len].copy_from_slice(&source_memory[..len]);
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn read_public_values_from_guest_memory(guest_memory: &GuestMemory) -> Vec<u8> {
-    let pv_capacity = guest_memory.memory.config[PUBLIC_VALUES_AS as usize].num_cells;
-    unsafe {
-        guest_memory
-            .memory
-            .get_u8_slice(PUBLIC_VALUES_AS, 0, pv_capacity)
-            .to_vec()
-    }
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) struct RvrIoSeed {
-    pub input_stream: VecDeque<Vec<u8>>,
-    pub hint_stream: Vec<u8>,
-    pub deferrals: Vec<DeferralState>,
-    pub deferral_fns: Vec<rvr::io::DeferralFnPtr>,
-    pub deferral_hash: Option<rvr::io::DeferralHashFn>,
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn streams_to_io_seed<F: PrimeField32>(streams: Streams<F>) -> RvrIoSeed {
-    let mut input_stream = VecDeque::with_capacity(streams.input_stream.len());
-    for vec in streams.input_stream {
-        input_stream.push_back(
-            vec.into_iter()
-                .map(|f| f.as_canonical_u32() as u8)
-                .collect::<Vec<u8>>(),
-        );
-    }
-    let hint_stream = streams
-        .hint_stream
-        .into_iter()
-        .map(|f| f.as_canonical_u32() as u8)
-        .collect();
-    RvrIoSeed {
-        input_stream,
-        hint_stream,
-        deferrals: streams.deferrals,
-        deferral_fns: streams.deferral_fns,
-        deferral_hash: streams.deferral_hash,
-    }
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn streams_from_io_state<F: PrimeField32>(
-    io_state: &rvr::io::OpenVmIoState,
-    deferrals: Vec<DeferralState>,
-    deferral_fns: Vec<rvr::io::DeferralFnPtr>,
-    deferral_hash: Option<rvr::io::DeferralHashFn>,
-) -> Streams<F> {
-    let input_stream = io_state
-        .input_stream
-        .iter()
-        .map(|vec| vec.iter().map(|&b| F::from_u8(b)).collect::<Vec<F>>())
-        .collect::<VecDeque<_>>();
-    let hint_stream = io_state
-        .hint_stream
-        .iter()
-        .skip(io_state.hint_pos)
-        .map(|&b| F::from_u8(b))
-        .collect::<VecDeque<_>>();
-    Streams {
-        input_stream,
-        hint_stream,
-        deferrals,
-        deferral_fns,
-        deferral_hash,
-    }
-}
-
-#[cfg(feature = "rvr")]
-pub(crate) fn ensure_rvr_outcome(
-    context: &str,
-    terminated: bool,
-    suspended: bool,
-    guest_exit_code: u8,
-    allow_suspended: bool,
-) -> Result<(), ExecutionError> {
-    if allow_suspended && suspended {
-        return Ok(());
-    }
-    if terminated {
-        if guest_exit_code == 0 {
-            return Ok(());
-        }
-        return Err(ExecutionError::FailedWithExitCode(guest_exit_code as u32));
-    }
-    Err(ExecutionError::RvrExecution(format!(
-        "{context} failed: terminated={terminated}, suspended={suspended}, guest_exit_code={guest_exit_code}"
-    )))
-}
 
 /// [VmExecutor] is the struct that can execute an _arbitrary_ program, provided in the form of a
 /// [VmExe], for a fixed set of OpenVM instructions corresponding to a [VmExecutionConfig].

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -301,6 +301,7 @@ where
             system_config: self.inventory.config().clone(),
             exe: Arc::new(exe.clone()),
             compiled,
+            extensions,
         })
     }
 }

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -335,6 +335,7 @@ where
 //
 // Same implementation as VmLocalProver, but we need to do something special to run the debug prover
 #[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments)]
 pub fn air_test_impl<E, VB>(
     params: SystemParams,
     builder: VB,

--- a/extensions/deferral/circuit/Cargo.toml
+++ b/extensions/deferral/circuit/Cargo.toml
@@ -58,6 +58,7 @@ aot = ["openvm-circuit/aot"]
 rvr = [
     "dep:rvr-openvm-lift",
     "dep:rvr-openvm-ext-deferral",
+    "rvr-openvm-ext-deferral/rvr",
     "dep:rvr-openvm-ext-ffi-common",
     "openvm-rv32im-circuit/rvr",
 ]

--- a/extensions/deferral/circuit/src/call/execution.rs
+++ b/extensions/deferral/circuit/src/call/execution.rs
@@ -18,6 +18,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 
 use super::DeferralCallExecutor;
 use crate::{
+    def_fn::execute_deferral_fn,
     poseidon2::deferral_poseidon2_chip,
     utils::{
         byte_commit_to_f, combine_output, join_memory_ops, memory_op_chunk, COMMIT_MEMORY_OPS,
@@ -194,7 +195,8 @@ unsafe fn execute_e12_impl<F: VmField, CTX: ExecutionCtxTrait>(
     let old_output_acc = join_memory_ops(old_output_acc_chunks);
 
     let poseidon2_chip = deferral_poseidon2_chip();
-    let (output_commit, output_len) = pre_compute.deferral_fn.execute(
+    let (output_commit, output_len) = execute_deferral_fn(
+        &pre_compute.deferral_fn,
         &input_commit_bytes.to_vec(),
         &mut exec_state.streams.deferrals[pre_compute.deferral_idx as usize],
         pre_compute.deferral_idx,

--- a/extensions/deferral/circuit/src/call/execution.rs
+++ b/extensions/deferral/circuit/src/call/execution.rs
@@ -196,7 +196,7 @@ unsafe fn execute_e12_impl<F: VmField, CTX: ExecutionCtxTrait>(
 
     let poseidon2_chip = deferral_poseidon2_chip();
     let (output_commit, output_len) = execute_deferral_fn(
-        &pre_compute.deferral_fn,
+        pre_compute.deferral_fn,
         &input_commit_bytes.to_vec(),
         &mut exec_state.streams.deferrals[pre_compute.deferral_idx as usize],
         pre_compute.deferral_idx,

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -31,6 +31,7 @@ use crate::{
     call::{DeferralCallAdapterCols, DeferralCallCoreCols, DeferralCallReads, DeferralCallWrites},
     canonicity::CanonicityTraceGen,
     count::DeferralCircuitCountChip,
+    def_fn::execute_deferral_fn,
     poseidon2::{deferral_poseidon2_chip, DeferralPoseidon2Chip},
     utils::{
         byte_commit_to_f, combine_output, join_memory_ops, memory_op_chunk, COMMIT_MEMORY_OPS,
@@ -101,7 +102,8 @@ where
         let def_idx = instruction.c.as_canonical_u32();
         let poseidon2_chip = deferral_poseidon2_chip();
 
-        let (output_commit, output_len) = self.deferral_fns[def_idx as usize].execute(
+        let (output_commit, output_len) = execute_deferral_fn(
+            &self.deferral_fns[def_idx as usize],
             &read_data.input_commit.to_vec(),
             &mut state.streams.deferrals[def_idx as usize],
             def_idx,

--- a/extensions/deferral/circuit/src/def_fn.rs
+++ b/extensions/deferral/circuit/src/def_fn.rs
@@ -1,5 +1,8 @@
-use std::{array::from_fn, fmt::Debug};
+use std::array::from_fn;
 
+// Re-export `DeferralFn` so `use openvm_deferral_circuit::DeferralFn` keeps
+// working after the type moved upstream into `openvm-circuit`.
+pub use openvm_circuit::arch::deferral::DeferralFn;
 use openvm_circuit::arch::{
     deferral::{DeferralResult, DeferralState, InputCommit, InputMapVal, OutputCommit, OutputRaw},
     VmField,
@@ -15,46 +18,28 @@ pub struct RawDeferralResult {
     pub output_raw: OutputRaw,
 }
 
-#[allow(clippy::type_complexity)]
-pub struct DeferralFn {
-    f: Box<dyn Fn(&[u8]) -> OutputRaw + Send + Sync + 'static>,
-}
-
-impl Debug for DeferralFn {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DeferralFn").finish()
-    }
-}
-
-impl DeferralFn {
-    pub fn new<FN: Fn(&[u8]) -> OutputRaw + Send + Sync + 'static>(f: FN) -> Self {
-        Self { f: Box::new(f) }
-    }
-
-    pub fn call_raw(&self, input_raw: &[u8]) -> OutputRaw {
-        (self.f)(input_raw)
-    }
-
-    pub fn execute<F: VmField>(
-        &self,
-        input_commit: &InputCommit,
-        state: &mut DeferralState,
-        deferral_idx: u32,
-        hasher: &DeferralPoseidon2Chip<F>,
-    ) -> (OutputCommit, u64) {
-        let value = state.get_input(input_commit);
-        match value {
-            InputMapVal::Raw(input_raw) => {
-                let output_raw = self.f.as_ref()(input_raw);
-                let output_commit = hash_output_raw(hasher, deferral_idx, &output_raw);
-                let output_len = output_raw.len();
-                state.store_output(input_commit, output_commit.clone(), output_raw);
-                (output_commit, output_len as u64)
-            }
-            InputMapVal::Output(output_commit) => {
-                let output_raw = state.get_output(output_commit);
-                (output_commit.clone(), output_raw.len() as u64)
-            }
+/// Execute `def_fn` against `state`, hashing the output via `hasher` and
+/// caching the result. Used to be `DeferralFn::execute`; moved here as a free
+/// function because the inherent impl must live in `DeferralFn`'s home crate
+/// (`openvm-circuit`), which can't depend on the Poseidon2 chip.
+pub fn execute_deferral_fn<F: VmField>(
+    def_fn: &DeferralFn,
+    input_commit: &InputCommit,
+    state: &mut DeferralState,
+    deferral_idx: u32,
+    hasher: &DeferralPoseidon2Chip<F>,
+) -> (OutputCommit, u64) {
+    match state.get_input(input_commit).clone() {
+        InputMapVal::Raw(input_raw) => {
+            let output_raw = def_fn.call_raw(&input_raw);
+            let output_commit = hash_output_raw(hasher, deferral_idx, &output_raw);
+            let output_len = output_raw.len();
+            state.store_output(input_commit, output_commit.clone(), output_raw);
+            (output_commit, output_len as u64)
+        }
+        InputMapVal::Output(output_commit) => {
+            let output_len = state.get_output(&output_commit).len() as u64;
+            (output_commit, output_len)
         }
     }
 }

--- a/extensions/deferral/circuit/src/def_fn.rs
+++ b/extensions/deferral/circuit/src/def_fn.rs
@@ -1,7 +1,5 @@
 use std::array::from_fn;
 
-// Re-export `DeferralFn` so `use openvm_deferral_circuit::DeferralFn` keeps
-// working after the type moved upstream into `openvm-circuit`.
 pub use openvm_circuit::arch::deferral::DeferralFn;
 use openvm_circuit::arch::{
     deferral::{DeferralResult, DeferralState, InputCommit, InputMapVal, OutputCommit, OutputRaw},
@@ -19,9 +17,7 @@ pub struct RawDeferralResult {
 }
 
 /// Execute `def_fn` against `state`, hashing the output via `hasher` and
-/// caching the result. Used to be `DeferralFn::execute`; moved here as a free
-/// function because the inherent impl must live in `DeferralFn`'s home crate
-/// (`openvm-circuit`), which can't depend on the Poseidon2 chip.
+/// caching the result.
 pub fn execute_deferral_fn<F: VmField>(
     def_fn: &DeferralFn,
     input_commit: &InputCommit,

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -23,7 +23,9 @@ use openvm_rv32im_circuit::{
 };
 use openvm_stark_backend::{StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::VmRvrExtension;
+use rvr_openvm_ext_deferral::{install_deferral_runtime, DeferralFnPtr, DeferralRvrExtension};
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -69,25 +71,23 @@ pub struct DeferralExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
-    fn extend_rvr(
-        &self,
-        registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
-        ctx: &rvr_openvm_lift::RvrExtensionCtx,
-    ) {
-        let raw_fns: Vec<rvr_openvm_ext_deferral::DeferralFnPtr> = self
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: &RvrExtensionCtx) {
+        let raw_fns: Vec<DeferralFnPtr> = self
             .fns
             .iter()
             .map(|fn_arc| {
                 let fn_arc = Arc::clone(fn_arc);
-                Arc::new(move |input: &[u8]| fn_arc.call_raw(input))
-                    as rvr_openvm_ext_deferral::DeferralFnPtr
+                Arc::new(move |input: &[u8]| fn_arc.call_raw(input)) as DeferralFnPtr
             })
             .collect();
         let hash = crate::runtime::make_deferral_hash::<F>();
-        rvr_openvm_ext_deferral::install_deferral_runtime(raw_fns, hash);
+        // `install_deferral_runtime` overwrites a thread-local with no cleanup, so callers must
+        // re-register before each execution — otherwise a later run on the same thread (e.g. a
+        // following test) would see the previous extension's closures.
+        install_deferral_runtime(raw_fns, hash);
 
-        let ext = rvr_openvm_ext_deferral::DeferralRvrExtension::new(ctx)
-            .expect("failed to construct rvr DeferralRvrExtension");
+        let ext =
+            DeferralRvrExtension::new(ctx).expect("failed to construct rvr DeferralRvrExtension");
         registry.register(ext);
     }
 }

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -28,6 +28,8 @@ use rvr_openvm_ext_deferral::DeferralRvrExtension;
 use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "rvr")]
+use crate::runtime::make_deferral_hash;
 use crate::{
     call::{
         DeferralCallAdapterAir, DeferralCallAdapterExecutor, DeferralCallAdapterFiller,
@@ -72,7 +74,7 @@ pub struct DeferralExtension {
 #[cfg(feature = "rvr")]
 impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
     fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: &RvrExtensionCtx) {
-        let hash = crate::runtime::make_deferral_hash::<F>();
+        let hash = make_deferral_hash::<F>();
         let ext = DeferralRvrExtension::new(ctx, self.fns.clone(), hash)
             .expect("failed to construct rvr DeferralRvrExtension");
         registry.register(ext);

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -23,7 +23,7 @@ use openvm_rv32im_circuit::{
 };
 use openvm_stark_backend::{StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_ext_deferral::{install_deferral_runtime, DeferralFnPtr, DeferralRvrExtension};
+use rvr_openvm_ext_deferral::DeferralRvrExtension;
 #[cfg(feature = "rvr")]
 use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
 use serde::{Deserialize, Serialize};
@@ -72,22 +72,9 @@ pub struct DeferralExtension {
 #[cfg(feature = "rvr")]
 impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
     fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: &RvrExtensionCtx) {
-        let raw_fns: Vec<DeferralFnPtr> = self
-            .fns
-            .iter()
-            .map(|fn_arc| {
-                let fn_arc = Arc::clone(fn_arc);
-                Arc::new(move |input: &[u8]| fn_arc.call_raw(input)) as DeferralFnPtr
-            })
-            .collect();
         let hash = crate::runtime::make_deferral_hash::<F>();
-        // `install_deferral_runtime` overwrites a thread-local with no cleanup, so callers must
-        // re-register before each execution — otherwise a later run on the same thread (e.g. a
-        // following test) would see the previous extension's closures.
-        install_deferral_runtime(raw_fns, hash);
-
-        let ext =
-            DeferralRvrExtension::new(ctx).expect("failed to construct rvr DeferralRvrExtension");
+        let ext = DeferralRvrExtension::new(ctx, self.fns.clone(), hash)
+            .expect("failed to construct rvr DeferralRvrExtension");
         registry.register(ext);
     }
 }

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -74,10 +74,6 @@ impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
         registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
         ctx: &rvr_openvm_lift::RvrExtensionCtx,
     ) {
-        // Install host-side deferral closures + hasher into the deferral crate's
-        // thread-local runtime. Consumed during rvr execution by
-        // `openvm-circuit`'s `host_deferral_call_lookup` on cache miss.
-        // Overwrites any prior installation on this thread.
         let raw_fns: Vec<rvr_openvm_ext_deferral::DeferralFnPtr> = self
             .fns
             .iter()

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -74,6 +74,22 @@ impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
         registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
         ctx: &rvr_openvm_lift::RvrExtensionCtx,
     ) {
+        // Install host-side deferral closures + hasher into the deferral crate's
+        // thread-local runtime. Consumed during rvr execution by
+        // `openvm-circuit`'s `host_deferral_call_lookup` on cache miss.
+        // Overwrites any prior installation on this thread.
+        let raw_fns: Vec<rvr_openvm_ext_deferral::DeferralFnPtr> = self
+            .fns
+            .iter()
+            .map(|fn_arc| {
+                let fn_arc = Arc::clone(fn_arc);
+                Arc::new(move |input: &[u8]| fn_arc.call_raw(input))
+                    as rvr_openvm_ext_deferral::DeferralFnPtr
+            })
+            .collect();
+        let hash = crate::runtime::make_deferral_hash::<F>();
+        rvr_openvm_ext_deferral::install_deferral_runtime(raw_fns, hash);
+
         let ext = rvr_openvm_ext_deferral::DeferralRvrExtension::new(ctx)
             .expect("failed to construct rvr DeferralRvrExtension");
         registry.register(ext);

--- a/extensions/deferral/circuit/src/runtime.rs
+++ b/extensions/deferral/circuit/src/runtime.rs
@@ -1,8 +1,4 @@
 //! F-typed builder for the rvr deferral output hasher.
-//!
-//! The hasher is constructed from a Poseidon2 chip parameterized over `F` and
-//! handed off to `rvr-openvm-ext-deferral`'s thread-local runtime by
-//! `DeferralExtension::extend_rvr`.
 
 use std::sync::Arc;
 

--- a/extensions/deferral/circuit/src/runtime.rs
+++ b/extensions/deferral/circuit/src/runtime.rs
@@ -1,28 +1,16 @@
-//! F-typed builders for the rvr-side deferral fields on `Streams<F>`.
+//! F-typed builder for the rvr deferral output hasher.
 //!
-//! TODO: drop this module once rvr execution is unified onto openvm
-//! `VmState<F>`.
+//! The hasher is constructed from a Poseidon2 chip parameterized over `F` and
+//! handed off to `rvr-openvm-ext-deferral`'s thread-local runtime by
+//! `DeferralExtension::extend_rvr`.
 
 use std::sync::Arc;
 
-use openvm_circuit::arch::{
-    rvr::{DeferralFnPtr, DeferralHashFn},
-    VmField,
-};
+use openvm_circuit::arch::VmField;
+use rvr_openvm_ext_deferral::DeferralHashFn;
 use rvr_openvm_ext_ffi_common::DEFERRAL_COMMIT_NUM_BYTES;
 
-use crate::{def_fn::hash_output_raw, poseidon2::deferral_poseidon2_chip, DeferralExtension};
-
-pub fn make_deferral_fns(extension: &DeferralExtension) -> Vec<DeferralFnPtr> {
-    extension
-        .fns
-        .iter()
-        .map(|fn_arc| {
-            let fn_arc = Arc::clone(fn_arc);
-            Arc::new(move |input: &[u8]| fn_arc.call_raw(input)) as DeferralFnPtr
-        })
-        .collect()
-}
+use crate::{def_fn::hash_output_raw, poseidon2::deferral_poseidon2_chip};
 
 pub fn make_deferral_hash<F: VmField>() -> DeferralHashFn {
     let hasher = deferral_poseidon2_chip::<F>();

--- a/extensions/deferral/rvr/Cargo.toml
+++ b/extensions/deferral/rvr/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+rvr-openvm-ext-ffi-common.workspace = true
 rvr-openvm-ir.workspace = true
 rvr-openvm-lift.workspace = true
 

--- a/extensions/deferral/rvr/Cargo.toml
+++ b/extensions/deferral/rvr/Cargo.toml
@@ -8,10 +8,25 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-rvr-openvm-ext-ffi-common.workspace = true
-rvr-openvm-ir.workspace = true
-rvr-openvm-lift.workspace = true
+rvr-openvm-ext-ffi-common = { workspace = true, optional = true }
+rvr-openvm-ir = { workspace = true, optional = true }
+rvr-openvm-lift = { workspace = true, optional = true }
 
-openvm-deferral-transpiler.workspace = true
-openvm-instructions.workspace = true
-openvm-stark-backend.workspace = true
+openvm-circuit = { workspace = true, features = ["rvr"], optional = true }
+openvm-deferral-transpiler = { workspace = true, optional = true }
+openvm-instructions = { workspace = true, optional = true }
+openvm-stark-backend = { workspace = true, optional = true }
+libloading = { workspace = true, optional = true }
+
+[features]
+default = []
+rvr = [
+    "dep:rvr-openvm-ext-ffi-common",
+    "dep:rvr-openvm-ir",
+    "dep:rvr-openvm-lift",
+    "dep:openvm-circuit",
+    "dep:openvm-deferral-transpiler",
+    "dep:openvm-instructions",
+    "dep:openvm-stark-backend",
+    "dep:libloading",
+]

--- a/extensions/deferral/rvr/c/ext_deferral_lookup.c
+++ b/extensions/deferral/rvr/c/ext_deferral_lookup.c
@@ -1,0 +1,35 @@
+/*
+ * ext_deferral_lookup.c — Host callback bridge for the deferral extension.
+ *
+ * Thin stubs that forward ext_deferral_*_lookup calls through function
+ * pointers to Rust handlers registered via register_deferral_callbacks().
+ */
+
+#include <stdint.h>
+
+#include "openvm_io.h"
+
+typedef struct {
+  void* ctx;
+  int (*call_lookup)(void* d_ctx, void* io_ctx, uint32_t def_idx, const uint8_t* input_commit,
+                     uint8_t* output_key_out);
+  int (*output_lookup)(void* d_ctx, void* io_ctx, uint32_t def_idx, const uint8_t* output_commit,
+                       uint8_t* output_raw_out, uint32_t expected_len);
+} DeferralHostCallbacks;
+
+/* NOT thread-safe: installs one process-global deferral callback set. */
+static DeferralHostCallbacks g_deferral;
+
+void register_deferral_callbacks(const DeferralHostCallbacks* cb) { g_deferral = *cb; }
+
+int ext_deferral_call_lookup(uint32_t def_idx, const uint8_t* input_commit,
+                             uint8_t* output_key_out) {
+  return g_deferral.call_lookup(g_deferral.ctx, openvm_get_io_ctx(), def_idx, input_commit,
+                                output_key_out);
+}
+
+int ext_deferral_output_lookup(uint32_t def_idx, const uint8_t* output_commit,
+                               uint8_t* output_raw_out, uint32_t expected_len) {
+  return g_deferral.output_lookup(g_deferral.ctx, openvm_get_io_ctx(), def_idx, output_commit,
+                                  output_raw_out, expected_len);
+}

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -1,5 +1,5 @@
 /*
- * ext_deferral_lookup.c — Host callback bridge for the deferral extension.
+ * rvr_ext_deferral.c — Host callback bridge for the deferral extension.
  *
  * Thin stubs that forward ext_deferral_*_lookup calls through function
  * pointers to Rust handlers registered via register_deferral_callbacks().

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -1,13 +1,81 @@
 //! Deferral extension for rvr-openvm: IR nodes for CALL/OUTPUT and the
 //! `DeferralRvrExtension` for lifting them via double FFI.
+//!
+//! Also owns the host-side deferral runtime: thread-local storage for the
+//! registered deferral closures and output hasher, populated by
+//! `DeferralExtension::extend_rvr` and consumed during rvr execution by
+//! `openvm-circuit`'s `host_deferral_call_lookup` (on cache miss).
 
-use std::path::{Path, PathBuf};
+use std::{
+    cell::RefCell,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
+use rvr_openvm_ext_ffi_common::DEFERRAL_COMMIT_NUM_BYTES;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
+
+// ── Host-side deferral runtime ────────────────────────────────────────────────
+
+/// `input_raw → output_raw` closure registered by the host.
+pub type DeferralFnPtr = Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>;
+
+/// `(def_idx, output_raw) → output_commit` hasher registered by the host.
+pub type DeferralHashFn = Arc<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
+
+#[derive(Default)]
+struct DeferralRuntime {
+    fns: Vec<DeferralFnPtr>,
+    hash: Option<DeferralHashFn>,
+}
+
+thread_local! {
+    static DEFERRAL_RUNTIME: RefCell<DeferralRuntime> = RefCell::new(DeferralRuntime::default());
+}
+
+/// Install the host-side deferral closures and output hasher into this
+/// thread's TLS. Overwrites any prior installation. Called by
+/// `DeferralExtension::extend_rvr` while the rvr `ExtensionRegistry` is being
+/// built; the values stay live until the next install (or thread exit).
+pub fn install_deferral_runtime(fns: Vec<DeferralFnPtr>, hash: DeferralHashFn) {
+    DEFERRAL_RUNTIME.with(|r| {
+        let mut r = r.borrow_mut();
+        r.fns = fns;
+        r.hash = Some(hash);
+    });
+}
+
+/// Evaluate a registered deferral closure: returns `(output_commit, output_raw)`.
+///
+/// Called from openvm-circuit's `host_deferral_call_lookup` on cache miss
+/// (when the cache holds `Raw(input_raw)` but no resolved output yet).
+///
+/// # Panics
+///
+/// Panics if `def_idx` has no registered closure, or no hasher was installed.
+pub fn eval_deferral_call(
+    def_idx: u32,
+    input_raw: &[u8],
+) -> ([u8; DEFERRAL_COMMIT_NUM_BYTES], Vec<u8>) {
+    DEFERRAL_RUNTIME.with(|r| {
+        let r = r.borrow();
+        let func = r
+            .fns
+            .get(def_idx as usize)
+            .expect("deferral CALL: def_idx has no closure registered");
+        let hash = r
+            .hash
+            .as_ref()
+            .expect("deferral CALL: hash_output not configured");
+        let output_raw = func(input_raw);
+        let output_commit = hash(def_idx, &output_raw);
+        (output_commit, output_raw)
+    })
+}
 
 // ── IR Nodes ──────────────────────────────────────────────────────────────────
 

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -205,8 +205,8 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
 
     fn c_sources(&self) -> Vec<(&str, &str)> {
         vec![(
-            "ext_deferral_lookup.c",
-            include_str!("../c/ext_deferral_lookup.c"),
+            "rvr_ext_deferral.c",
+            include_str!("../c/rvr_ext_deferral.c"),
         )]
     }
 
@@ -218,7 +218,6 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
         &self,
         lib: &libloading::Library,
     ) -> Result<(), ExtensionError> {
-        type RegisterFn = unsafe extern "C" fn(*const DeferralHostCallbacks);
         let register_fn: RegisterFn = unsafe {
             let sym = lib
                 .get::<RegisterFn>(b"register_deferral_callbacks")
@@ -238,7 +237,9 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
 
 // ── Host callbacks ──────────────────────────────────────────────────────────
 
-/// Must match the C `DeferralHostCallbacks` layout in `ext_deferral_lookup.c`.
+type RegisterFn = unsafe extern "C" fn(*const DeferralHostCallbacks);
+
+/// Must match the C `DeferralHostCallbacks` layout in `rvr_ext_deferral.c`.
 #[repr(C)]
 pub struct DeferralHostCallbacks {
     pub ctx: *mut c_void,

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -1,69 +1,36 @@
 //! Deferral extension for rvr-openvm: IR nodes for CALL/OUTPUT and the
-//! `DeferralRvrExtension` for lifting them via double FFI. Also owns the
-//! host-side deferral runtime in thread-local storage.
+//! `DeferralRvrExtension` for lifting them via double FFI.
+#![cfg(feature = "rvr")]
 
 use std::{
-    cell::RefCell,
+    ffi::c_void,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
+use openvm_circuit::arch::{
+    deferral::{DeferralFn, InputMapVal},
+    rvr::io::OpenVmIoState,
+};
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_ext_ffi_common::DEFERRAL_COMMIT_NUM_BYTES;
+use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_BYTES};
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
-
-/// `input_raw → output_raw` closure registered by the host.
-pub type DeferralFnPtr = Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>;
 
 /// `(def_idx, output_raw) → output_commit` hasher registered by the host.
 pub type DeferralHashFn = Arc<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
 
-#[derive(Default)]
-struct DeferralRuntime {
-    fns: Vec<DeferralFnPtr>,
-    hash: Option<DeferralHashFn>,
+pub struct DeferralCtx {
+    pub fns: Vec<Arc<DeferralFn>>,
+    pub hash: DeferralHashFn,
 }
 
-thread_local! {
-    static DEFERRAL_RUNTIME: RefCell<DeferralRuntime> = RefCell::new(DeferralRuntime::default());
-}
-
-/// Install the host-side deferral closures and output hasher into this
-/// thread's TLS. Overwrites any prior installation.
-pub fn install_deferral_runtime(fns: Vec<DeferralFnPtr>, hash: DeferralHashFn) {
-    DEFERRAL_RUNTIME.with(|r| {
-        let mut r = r.borrow_mut();
-        r.fns = fns;
-        r.hash = Some(hash);
-    });
-}
-
-/// Evaluate a registered deferral closure: returns `(output_commit, output_raw)`.
-///
-/// # Panics
-///
-/// Panics if `def_idx` has no registered closure, or no hasher was installed.
-pub fn eval_deferral_call(
-    def_idx: u32,
-    input_raw: &[u8],
-) -> ([u8; DEFERRAL_COMMIT_NUM_BYTES], Vec<u8>) {
-    DEFERRAL_RUNTIME.with(|r| {
-        let r = r.borrow();
-        let func = r
-            .fns
-            .get(def_idx as usize)
-            .expect("deferral CALL: def_idx has no closure registered");
-        let hash = r
-            .hash
-            .as_ref()
-            .expect("deferral CALL: hash_output not configured");
-        let output_raw = func(input_raw);
-        let output_commit = hash(def_idx, &output_raw);
-        (output_commit, output_raw)
-    })
+impl DeferralCtx {
+    pub fn new(fns: Vec<Arc<DeferralFn>>, hash: DeferralHashFn) -> Self {
+        Self { fns, hash }
+    }
 }
 
 // ── IR Nodes ──────────────────────────────────────────────────────────────────
@@ -142,21 +109,27 @@ pub struct DeferralRvrExtension {
     output_chip_idx: u32,
     poseidon2_chip_idx: u32,
     staticlib_path: PathBuf,
+    deferral_ctx: DeferralCtx,
 }
 
 impl DeferralRvrExtension {
     /// Create for pure execution (chip indices don't matter).
-    pub fn new_pure() -> Self {
+    pub fn new_pure(fns: Vec<Arc<DeferralFn>>, hash: DeferralHashFn) -> Self {
         Self {
             call_chip_idx: NO_CHIP,
             output_chip_idx: NO_CHIP,
             poseidon2_chip_idx: NO_CHIP,
             staticlib_path: default_staticlib_path(),
+            deferral_ctx: DeferralCtx::new(fns, hash),
         }
     }
 
     /// Create with chip indices resolved from the VM config.
-    pub fn new(ctx: &RvrExtensionCtx) -> Result<Self, ExtensionError> {
+    pub fn new(
+        ctx: &RvrExtensionCtx,
+        fns: Vec<Arc<DeferralFn>>,
+        hash: DeferralHashFn,
+    ) -> Result<Self, ExtensionError> {
         let call_chip_idx = ctx.require_opcode_air_idx(DeferralOpcode::CALL.global_opcode())?;
         let output_chip_idx = ctx.require_opcode_air_idx(DeferralOpcode::OUTPUT.global_opcode())?;
         // Poseidon2 periphery chip: in extend_circuit, the hasher is added
@@ -174,6 +147,7 @@ impl DeferralRvrExtension {
             output_chip_idx,
             poseidon2_chip_idx,
             staticlib_path: default_staticlib_path(),
+            deferral_ctx: DeferralCtx::new(fns, hash),
         })
     }
 }
@@ -229,7 +203,135 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
         )]
     }
 
+    fn c_sources(&self) -> Vec<(&str, &str)> {
+        vec![(
+            "ext_deferral_lookup.c",
+            include_str!("../c/ext_deferral_lookup.c"),
+        )]
+    }
+
     fn staticlib_path(&self) -> &Path {
         &self.staticlib_path
     }
+
+    unsafe fn register_host_callbacks(
+        &self,
+        lib: &libloading::Library,
+    ) -> Result<(), ExtensionError> {
+        type RegisterFn = unsafe extern "C" fn(*const DeferralHostCallbacks);
+        let register_fn: RegisterFn = unsafe {
+            let sym = lib
+                .get::<RegisterFn>(b"register_deferral_callbacks")
+                .map_err(|e| ExtensionError::HostCallbackRegistration(e.to_string()))?;
+            *sym
+        };
+        // `ctx` aliases `self.deferral_ctx`; the C side must not outlive `self`.
+        let callbacks = DeferralHostCallbacks {
+            ctx: &self.deferral_ctx as *const DeferralCtx as *mut c_void,
+            call_lookup: host_deferral_call_lookup::<F>,
+            output_lookup: host_deferral_output_lookup::<F>,
+        };
+        unsafe { register_fn(&callbacks) };
+        Ok(())
+    }
+}
+
+// ── Host callbacks ──────────────────────────────────────────────────────────
+
+/// Must match the C `DeferralHostCallbacks` layout in `ext_deferral_lookup.c`.
+#[repr(C)]
+pub struct DeferralHostCallbacks {
+    pub ctx: *mut c_void,
+    pub call_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, u32, *const u8, *mut u8) -> i32,
+    pub output_lookup:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, u32, *const u8, *mut u8, u32) -> i32,
+}
+
+/// Deferral CALL lookup. Returns 1 on hit, 0 on miss.
+///
+/// # Safety
+///
+/// `d_ctx` must point to a valid `DeferralCtx`. `io_ctx` must point to a valid
+/// `OpenVmIoState<'_, F>`.
+/// `input_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
+/// `output_key_out` must point to `DEFERRAL_OUTPUT_KEY_BYTES` writable bytes.
+pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
+    d_ctx: *mut c_void,
+    io_ctx: *mut c_void,
+    def_idx: u32,
+    input_commit_raw: *const u8,
+    output_key_out: *mut u8,
+) -> i32 {
+    let dc = unsafe { &*(d_ctx as *const DeferralCtx) };
+    let io = unsafe { &mut *(io_ctx as *mut OpenVmIoState<'_, F>) };
+
+    let input_commit: Vec<u8> =
+        unsafe { std::slice::from_raw_parts(input_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec() };
+
+    let Some(state) = io.deferrals.get_mut(def_idx as usize) else {
+        return 0;
+    };
+
+    let (output_commit, output_len) = match state.get_input(&input_commit).clone() {
+        InputMapVal::Output(commit) => {
+            let len = state.get_output(&commit).len() as u64;
+            let arr: [u8; DEFERRAL_COMMIT_NUM_BYTES] = commit.as_slice().try_into().unwrap();
+            (arr, len)
+        }
+        InputMapVal::Raw(input_raw) => {
+            let func = dc
+                .fns
+                .get(def_idx as usize)
+                .expect("deferral CALL: def_idx has no closure registered");
+            let output_raw = func.call_raw(&input_raw);
+            let commit = (dc.hash)(def_idx, &output_raw);
+            let len = output_raw.len() as u64;
+            io.deferrals[def_idx as usize].store_output(&input_commit, commit.to_vec(), output_raw);
+            (commit, len)
+        }
+    };
+
+    let mut output_key = [0u8; DEFERRAL_OUTPUT_KEY_BYTES];
+    output_key[..DEFERRAL_COMMIT_NUM_BYTES].copy_from_slice(&output_commit);
+    output_key[DEFERRAL_COMMIT_NUM_BYTES..].copy_from_slice(&output_len.to_le_bytes());
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            output_key.as_ptr(),
+            output_key_out,
+            DEFERRAL_OUTPUT_KEY_BYTES,
+        );
+    }
+    1
+}
+
+/// Deferral OUTPUT lookup: `deferrals[def_idx].output_map[output_commit]`.
+/// Returns 1 on hit, 0 on miss.
+///
+/// # Safety
+///
+/// `d_ctx` must point to a valid `DeferralCtx`. `io_ctx` must point to a
+/// valid `OpenVmIoState<'_, F>`.
+/// `output_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
+/// `output_raw_out` must point to at least `expected_len` writable bytes.
+pub unsafe extern "C" fn host_deferral_output_lookup<F: PrimeField32>(
+    _d_ctx: *mut c_void,
+    io_ctx: *mut c_void,
+    def_idx: u32,
+    output_commit_raw: *const u8,
+    output_raw_out: *mut u8,
+    expected_len: u32,
+) -> i32 {
+    let io = unsafe { &*(io_ctx as *const OpenVmIoState<'_, F>) };
+
+    let output_commit: Vec<u8> = unsafe {
+        std::slice::from_raw_parts(output_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec()
+    };
+    let Some(state) = io.deferrals.get(def_idx as usize) else {
+        return 0;
+    };
+    let raw = state.get_output(&output_commit);
+    // TODO: change these panics to something better to handle across the FFI boundary.
+    assert_eq!(raw.len(), expected_len as usize);
+    unsafe { std::ptr::copy_nonoverlapping(raw.as_ptr(), output_raw_out, raw.len()) };
+    1
 }

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -1,10 +1,6 @@
 //! Deferral extension for rvr-openvm: IR nodes for CALL/OUTPUT and the
-//! `DeferralRvrExtension` for lifting them via double FFI.
-//!
-//! Also owns the host-side deferral runtime: thread-local storage for the
-//! registered deferral closures and output hasher, populated by
-//! `DeferralExtension::extend_rvr` and consumed during rvr execution by
-//! `openvm-circuit`'s `host_deferral_call_lookup` (on cache miss).
+//! `DeferralRvrExtension` for lifting them via double FFI. Also owns the
+//! host-side deferral runtime in thread-local storage.
 
 use std::{
     cell::RefCell,
@@ -18,8 +14,6 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ext_ffi_common::DEFERRAL_COMMIT_NUM_BYTES;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
-
-// ── Host-side deferral runtime ────────────────────────────────────────────────
 
 /// `input_raw → output_raw` closure registered by the host.
 pub type DeferralFnPtr = Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>;
@@ -38,9 +32,7 @@ thread_local! {
 }
 
 /// Install the host-side deferral closures and output hasher into this
-/// thread's TLS. Overwrites any prior installation. Called by
-/// `DeferralExtension::extend_rvr` while the rvr `ExtensionRegistry` is being
-/// built; the values stay live until the next install (or thread exit).
+/// thread's TLS. Overwrites any prior installation.
 pub fn install_deferral_runtime(fns: Vec<DeferralFnPtr>, hash: DeferralHashFn) {
     DEFERRAL_RUNTIME.with(|r| {
         let mut r = r.borrow_mut();
@@ -50,9 +42,6 @@ pub fn install_deferral_runtime(fns: Vec<DeferralFnPtr>, hash: DeferralHashFn) {
 }
 
 /// Evaluate a registered deferral closure: returns `(output_commit, output_raw)`.
-///
-/// Called from openvm-circuit's `host_deferral_call_lookup` on cache miss
-/// (when the cache holds `Raw(input_raw)` but no resolved output yet).
 ///
 /// # Panics
 ///

--- a/extensions/deferral/tests/src/lib.rs
+++ b/extensions/deferral/tests/src/lib.rs
@@ -11,8 +11,6 @@ mod tests {
         },
         utils::{air_test_with_min_segments, test_system_config},
     };
-    #[cfg(feature = "rvr")]
-    use openvm_deferral_circuit::runtime::{make_deferral_fns, make_deferral_hash};
     use openvm_deferral_circuit::{
         DeferralExtension, DeferralFn, Rv32DeferralBuilder, Rv32DeferralConfig,
     };
@@ -85,11 +83,7 @@ mod tests {
         DeferralExtension::new(fns, commits)
     }
 
-    fn run_test(
-        config: Rv32DeferralConfig,
-        example_name: &str,
-        #[cfg_attr(not(feature = "rvr"), allow(unused_mut))] mut streams: Streams<F>,
-    ) -> Result<()> {
+    fn run_test(config: Rv32DeferralConfig, example_name: &str, streams: Streams<F>) -> Result<()> {
         let elf = build_example_program_at_path(get_programs_dir!(), example_name, &config)?;
         let exe = VmExe::from_elf(
             elf,
@@ -101,11 +95,10 @@ mod tests {
                     config.deferral.def_circuit_commits.clone(),
                 )),
         )?;
-        #[cfg(feature = "rvr")]
-        {
-            streams.deferral_fns = make_deferral_fns(&config.deferral);
-            streams.deferral_hash = Some(make_deferral_hash::<F>());
-        }
+        // Under `rvr`, the deferral closures + hasher are installed into
+        // `rvr-openvm-ext-deferral`'s thread-local runtime by
+        // `DeferralExtension::extend_rvr` when the rvr instance is built.
+        // The test side doesn't need to thread anything extra through.
         air_test_with_min_segments(Rv32DeferralBuilder, config, exe, streams, 1).unwrap();
         Ok(())
     }

--- a/extensions/deferral/tests/src/lib.rs
+++ b/extensions/deferral/tests/src/lib.rs
@@ -95,10 +95,6 @@ mod tests {
                     config.deferral.def_circuit_commits.clone(),
                 )),
         )?;
-        // Under `rvr`, the deferral closures + hasher are installed into
-        // `rvr-openvm-ext-deferral`'s thread-local runtime by
-        // `DeferralExtension::extend_rvr` when the rvr instance is built.
-        // The test side doesn't need to thread anything extra through.
         air_test_with_min_segments(Rv32DeferralBuilder, config, exe, streams, 1).unwrap();
         Ok(())
     }


### PR DESCRIPTION
- Changed rvr execution to use the existing openvm `VmState` instead of defining a new state struct and copying data between the two forms. The references and pointers to the fields in `VmState` are passed to the rvr execution functions so they can be used in C code.
- The Deferral extension now uses a callback registration system to expose the Deferral related data to C code instead of piggybacking on the same mechanism of `OpenVmHostCallbacks`. This is enabled for each extension so that they can have per-extension data and state that is maintained separately.

closes INT-7572