### PR TITLE
fix(docs): fix --app-vk flag name and trailing comma in EVM proof JSON example

### DIFF
--- a/docs/vocs/docs/pages/book/writing-apps/verifying-proofs.mdx
+++ b/docs/vocs/docs/pages/book/writing-apps/verifying-proofs.mdx
@@ -16,7 +16,7 @@ cargo openvm verify app
     --proof <path_to_proof>
 ```
 
-Options `--manifest-path`, `--target-dir` are also available to `verify`. If you omit `--app_vk` the command will search for the verifying key at `${target_dir}/openvm/app.vk`.
+Options `--manifest-path`, `--target-dir` are also available to `verify`. If you omit `--app-vk` the command will search for the verifying key at `${target_dir}/openvm/app.vk`.
 
 If you omit `--proof`, the command will search the working directory for files with the `.app.proof` extension. In this 
 case, we expect to find a single proof, and `verify` will fail otherwise.
@@ -72,7 +72,7 @@ The EVM proof is written as a JSON of the following format:
   "proof_data": {
     "accumulator": "..",
     "proof": ".."
-  },
+  }
 }
 ```
 


### PR DESCRIPTION

### 1. Typo in flag name: `--app_vk` → `--app-vk`

In the `/verifying-proofs.md`, the prose uses `--app_vk` (underscore) but the CLI example right above it uses `--app-vk` (hyphen). Small inconsistency, but the underscore version won't actually work as a flag.

### 2. Trailing comma in EVM proof JSON example

The JSON example in "EVM Proof: JSON Format" has a trailing comma after `proof_data` that makes it invalid JSON, anyone copying it directly will hit a parse error.

Before:
```json
  "proof_data": {
    "accumulator": "..",
    "proof": ".."
  },
}
```

After:
```json
  "proof_data": {
    "accumulator": "..",
    "proof": ".."
  }
}
```

## Changes
- `docs/book/verifying-proofs.md`: fix `--app_vk` → `--app-vk`
- `docs/book/verifying-proofs.md`: remove trailing comma in JSON example