### PR TITLE
ci: trigger publish-vocs and release workflows on published release

### DIFF
--- a/.github/workflows/publish-vocs.yml
+++ b/.github/workflows/publish-vocs.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
         default: "main"
+  release:
+    types: [released]
 
 permissions:
   contents: write
@@ -20,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.event.release.tag_name }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
         required: true
         default: "v2.0.0-beta.2"
         type: string
+  release:
+    types: [released]
 
 env:
   S3_BUCKET: ${{ vars.OPENVM_S3_ARTIFACTS_BUCKET }}
@@ -25,7 +27,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set version
-        run: echo "version=${{ github.event.inputs.version || 'v2.0.0-beta.2' }}" >> $GITHUB_ENV
+        run: echo "version=${{ github.event.inputs.version || github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Adds `release: types: [released]` so a non-prerelease, non-draft release publish triggers both workflows, using the release tag as the checkout ref and version. `workflow_dispatch` remains supported for manual runs.