### PR TITLE
perf: change page bits constant to 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ profile.json.gz
 
 # test fixtures
 benchmarks/fixtures
+
+# openvm artifacts
+*.pk
+*.vk
+*.vmexe

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -14,7 +14,7 @@ use crate::{
     system::memory::online::GuestMemory,
 };
 
-pub const DEFAULT_PAGE_BITS: usize = 6;
+pub const DEFAULT_PAGE_BITS: usize = 4;
 
 #[derive(Clone, Debug, Getters, Setters, WithSetters)]
 pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -8,13 +8,14 @@ mod aot {
     pub(crate) use openvm_circuit::arch::aot::common::*;
     use openvm_circuit::{
         arch::{
-            execution_mode::{metered::memory_ctx::MemoryCtx, MeteredCtx},
+            execution_mode::{
+                metered::{ctx::DEFAULT_PAGE_BITS, memory_ctx::MemoryCtx},
+                MeteredCtx,
+            },
             AotError, SystemConfig, VmExecState, ADDR_SPACE_OFFSET,
         },
         system::memory::{online::GuestMemory, CHUNK},
     };
-    /// This is DIRTY because PAGE_BITS is a generic parameter of E2 context.
-    const DEFAULT_PAGE_BITS: usize = 6;
 
     pub(crate) fn gpr_to_rv32_register(gpr: &str, rv32_reg: u8) -> String {
         let xmm_map_reg = rv32_reg / 2;

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -192,7 +192,7 @@ mod aot {
         // `start_block_id`: `chunk_idx + as_offset`
         asm_str += &format!("    add {ptr_reg}, {as_offset}\n");
         // `start_page_id`: `start_block_id >> PAGE_BITS`
-        // NOTE: This is DIRTY because PAGE_BITS is a generic parameter of E2 context.
+        // NOTE: AOT assumes PAGE_BITS == DEFAULT_PAGE_BITS (the generic default).
         asm_str += &format!("    shr {ptr_reg}, {DEFAULT_PAGE_BITS}\n");
 
         let memory_ctx_offset = offset_of!(VmExecState<F, GuestMemory, MeteredCtx>, ctx)


### PR DESCRIPTION
Lower the default `PAGE_BITS` for `MeteredCtx` from 6 to 4. With 4 we produce the fewest segments across the swept range while keeping runtime roughly flat. Smaller pages give more accurate per-page boundary/merkle tracking, which reduces over-counted memory work in segmentation.

Benchmark (`execute-metered` on the workload that motivated this):

| page_bits | segments | runtime | status |
|----------:|---------:|--------:|:-------|
| 3 | 134 | 99 s | ok |
| **4** | **132** | **93 s** | **ok (fewest segments)** |
| 5 | 133 | 97 s | ok |
| 6 | 142 | 89 s | ok (previous default) |
| 7 | 191 | 96 s | ok |
| 8 | 243 | 95 s | ok |
| 9 | — | — | SIGSEGV |
| 10 | — | — | SIGSEGV |

Also dedups the duplicate `DEFAULT_PAGE_BITS = 6` in `extensions/rv32im/circuit/src/common/mod.rs` by importing the canonical constant from `openvm_circuit::arch::execution_mode::metered::ctx`, so a future bump only needs to touch one place.