### PR TITLE
ci: drop `cargo clean` before workspace build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,4 @@ jobs:
           cache-on-failure: true
 
       - name: Run build
-        run: |
-          cargo clean
-          cargo build --verbose
+        run: cargo build --verbose


### PR DESCRIPTION
The workspace `Build` job runs `cargo clean` immediately after `Swatinem/rust-cache@v2` restores the cache, wiping the restored `target/` and forcing a from-scratch rebuild every run.

The `cargo clean` was added in #1446 ("feat: update stark-backend commit") as an unexplained one-line change inside a stark-backend dep bump.

`Swatinem/rust-cache@v2` keys its cache on `Cargo.lock`, which records the resolved commit SHA for every git dependency (according to [the readme](https://github.com/Swatinem/rust-cache/blob/master/README.md)). When a git-dep tag or pin changes, `Cargo.lock` updates, the cache key changes, and the action invalidates the cache automatically — so the manual clean is not needed to handle dep bumps, which is the most likely thing #1446 was guarding against.

Was there a specific cache-staleness case this was guarding against that I've missed?