### PR TITLE
refactor: move rvr compile stage into instance construction

### DIFF
--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -89,7 +89,7 @@ static METERED_AOT_CACHE: OnceLock<
 #[cfg(feature = "rvr")]
 type BenchExecutor = <ExecuteConfig as VmExecutionConfig<BabyBear>>::Executor;
 #[cfg(feature = "rvr")]
-type RvrMetered = (RvrMeteredInstance<BabyBear, BenchExecutor>, MeteredCtx);
+type RvrMetered = (RvrMeteredInstance<BabyBear>, MeteredCtx);
 #[cfg(feature = "rvr")]
 type RvrMeteredCost = RvrMeteredCostInstance<BabyBear, BenchExecutor>;
 #[cfg(feature = "rvr")]
@@ -396,9 +396,7 @@ fn create_rvr_instance(program: &str) -> Arc<RvrPureInstance<BabyBear>> {
 }
 
 #[cfg(feature = "rvr")]
-fn create_metered_rvr_instance(
-    program: &str,
-) -> Arc<(RvrMeteredInstance<BabyBear, BenchExecutor>, MeteredCtx)> {
+fn create_metered_rvr_instance(program: &str) -> Arc<(RvrMeteredInstance<BabyBear>, MeteredCtx)> {
     let cache = METERED_RVR_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
     let mut cache = cache.lock().unwrap();
     cache
@@ -435,10 +433,10 @@ fn create_metered_cost_rvr_instance(
         .or_insert_with(|| {
             let exe = load_program_executable(program)
                 .expect("Failed to load program executable for metered cost RVR cache");
-            let (_, executor_idx_to_air_idx) = metered_cost_setup();
+            let (ctx, executor_idx_to_air_idx) = metered_cost_setup();
             Arc::new(
                 executor()
-                    .metered_cost_instance(&exe, executor_idx_to_air_idx)
+                    .metered_cost_instance(&exe, executor_idx_to_air_idx, &ctx.widths)
                     .unwrap_or_else(|err| {
                         panic!("Failed to create metered cost RVR instance for {program}: {err}")
                     }),

--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -87,11 +87,9 @@ static METERED_AOT_CACHE: OnceLock<
     Mutex<HashMap<String, Arc<(AotInstance<BabyBear, MeteredCtx>, MeteredCtx)>>>,
 > = OnceLock::new();
 #[cfg(feature = "rvr")]
-type BenchExecutor = <ExecuteConfig as VmExecutionConfig<BabyBear>>::Executor;
-#[cfg(feature = "rvr")]
 type RvrMetered = (RvrMeteredInstance<BabyBear>, MeteredCtx);
 #[cfg(feature = "rvr")]
-type RvrMeteredCost = RvrMeteredCostInstance<BabyBear, BenchExecutor>;
+type RvrMeteredCost = RvrMeteredCostInstance<BabyBear>;
 #[cfg(feature = "rvr")]
 static RVR_CACHE: OnceLock<Mutex<HashMap<String, Arc<RvrPureInstance<BabyBear>>>>> =
     OnceLock::new();
@@ -423,9 +421,7 @@ fn create_metered_rvr_instance(program: &str) -> Arc<(RvrMeteredInstance<BabyBea
 }
 
 #[cfg(feature = "rvr")]
-fn create_metered_cost_rvr_instance(
-    program: &str,
-) -> Arc<RvrMeteredCostInstance<BabyBear, BenchExecutor>> {
+fn create_metered_cost_rvr_instance(program: &str) -> Arc<RvrMeteredCostInstance<BabyBear>> {
     let cache = METERED_COST_RVR_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
     let mut cache = cache.lock().unwrap();
     cache

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -19,10 +19,7 @@ use super::{
         host_hint_stream_set, host_print_str, host_reveal, OpenVmHostCallbacks, OpenVmIoState,
     },
     metered::{metered_periodic_check, MeteredTracerData, SegmentationState, NO_LAST_PAGE},
-    metered_cost::{
-        prepare_metered_cost, MeteredCostConfig, MeteredCostData, PureTracerData,
-        RvrMeteredCostResult,
-    },
+    metered_cost::{MeteredCostData, PureTracerData, RvrMeteredCostResult},
     pure::RvrPureResult,
     state::{
         init_rvr_state, init_rvr_state_with_metered, init_rvr_state_with_metered_cost, TracerPtr,
@@ -209,7 +206,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
     compiled: &RvrCompiled,
     extensions: &ExtensionRegistry<F>,
     vm_state: &mut VmState<F, GuestMemory>,
-    metered_cost_config: MeteredCostConfig,
+    widths: &[u64],
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
     let pc = vm_state.pc();
     let initial_regs = read_rv32_registers(vm_state);
@@ -219,8 +216,7 @@ pub fn execute_metered_cost<F: PrimeField32>(
     state.regs = initial_regs;
     state.tracer = TracerPtr(&mut tracer_data);
 
-    let widths_u64 = prepare_metered_cost(&metered_cost_config);
-    state.tracer.chip_widths = widths_u64.as_ptr();
+    state.tracer.chip_widths = widths.as_ptr();
     state.tracer.cost = 0;
 
     run_and_finalize(compiled, extensions, vm_state, &mut state, false)

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -11,10 +11,10 @@ use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
 
 use super::{
-    bridge::{map_rvr_compile_error, map_rvr_execute_error},
-    compile::ChipMapping,
-    compile_metered, execute_metered,
+    bridge::map_rvr_execute_error,
+    execute_metered,
     state::{TracerPayload, TracerPtr},
+    RvrCompiled,
 };
 use crate::{
     arch::{
@@ -26,20 +26,19 @@ use crate::{
             },
             MeteredCtx,
         },
-        ExecutionError, ExecutorInventory, MeteredExecutor, Streams, SystemConfig, VmState,
-        BOUNDARY_AIR_ID, MERKLE_AIR_ID,
+        ExecutionError, ExecutorInventory, Streams, SystemConfig, VmState, BOUNDARY_AIR_ID,
+        MERKLE_AIR_ID,
     },
     system::memory::{
         merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory, CHUNK as MERKLE_CHUNK,
     },
 };
 
-pub struct RvrMeteredInstance<F: PrimeField32, E> {
+pub struct RvrMeteredInstance<F: PrimeField32> {
     pub(crate) system_config: SystemConfig,
     pub(crate) exe: Arc<VmExe<F>>,
-    pub(crate) inventory: Arc<ExecutorInventory<E>>,
-    pub(crate) executor_idx_to_air_idx: Vec<usize>,
     pub(crate) extensions: ExtensionRegistry<F>,
+    pub(crate) compiled: RvrCompiled,
 }
 
 // ── C-compatible tracer struct ───────────────────────────────────────────────
@@ -93,17 +92,16 @@ pub type MeteredTracer = TracerPtr<MeteredTracerData>;
 
 // ── Chip mapping ─────────────────────────────────────────────────────────────
 
-fn build_chip_mapping<F, E>(
+pub fn build_pc_to_chip<F, E>(
     exe: &VmExe<F>,
     inventory: &ExecutorInventory<E>,
     executor_idx_to_air_idx: &[usize],
-) -> ChipMapping
+) -> Vec<u32>
 where
     F: PrimeField32,
 {
     let terminate_opcode = SystemOpcode::TERMINATE.global_opcode();
-    let pc_to_chip: Vec<u32> = exe
-        .program
+    exe.program
         .instructions_and_debug_infos
         .iter()
         .map(|slot| {
@@ -120,11 +118,7 @@ where
                 NO_CHIP
             }
         })
-        .collect();
-    ChipMapping {
-        pc_to_chip,
-        chip_widths: None,
-    }
+        .collect()
 }
 
 // ── Segmentation runtime ─────────────────────────────────────────────────────
@@ -380,11 +374,7 @@ pub unsafe extern "C" fn metered_periodic_check(t: *mut MeteredTracerData) {
     tracer.check_counter += seg_state.segmentation_ctx.segment_check_insns as u32;
 }
 
-impl<F, E> RvrMeteredInstance<F, E>
-where
-    F: PrimeField32,
-    E: MeteredExecutor<F>,
-{
+impl<F: PrimeField32> RvrMeteredInstance<F> {
     pub fn execute_metered(
         &self,
         inputs: impl Into<Streams<F>>,
@@ -404,26 +394,13 @@ where
         mut vm_state: VmState<F, GuestMemory>,
         ctx: MeteredCtx,
     ) -> Result<(Vec<Segment>, VmState<F, GuestMemory>), ExecutionError> {
-        let chips = build_chip_mapping(
-            self.exe.as_ref(),
-            self.inventory.as_ref(),
-            &self.executor_idx_to_air_idx,
-        );
-        let compiled_metered = compile_metered(self.exe.as_ref(), &self.extensions, &chips)
-            .map_err(map_rvr_compile_error)?;
-
         let seg_state = SegmentationState::new(ctx, &self.system_config);
 
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let result_seg_state = tracing::info_span!("execute_metered")
             .in_scope(|| {
-                execute_metered(
-                    &compiled_metered,
-                    &self.extensions,
-                    &mut vm_state,
-                    seg_state,
-                )
+                execute_metered(&self.compiled, &self.extensions, &mut vm_state, seg_state)
             })
             .map_err(map_rvr_execute_error)?;
         let result_seg_ctx = result_seg_state.segmentation_ctx;

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -2,15 +2,17 @@
 
 use std::sync::Arc;
 
-use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
+use openvm_instructions::exe::VmExe;
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
+use rvr_openvm_lift::ExtensionRegistry;
 
 use super::{
-    bridge::{map_rvr_compile_error, map_rvr_execute_error},
+    bridge::map_rvr_execute_error,
     compile::ChipMapping,
-    compile_metered_cost, execute_metered_cost,
+    execute_metered_cost,
+    metered::build_pc_to_chip,
     state::{MeteredCostState, TracerPayload, TracerPtr},
+    RvrCompiled,
 };
 use crate::{
     arch::{
@@ -51,6 +53,7 @@ pub struct RvrMeteredCostInstance<F: PrimeField32, E> {
     pub(crate) inventory: Arc<ExecutorInventory<E>>,
     pub(crate) executor_idx_to_air_idx: Vec<usize>,
     pub(crate) extensions: ExtensionRegistry<F>,
+    pub(crate) compiled: RvrCompiled,
 }
 
 /// Build a `MeteredCostConfig` from the program, executor inventory, AIR index mapping, and widths.
@@ -63,34 +66,9 @@ pub fn build_metered_cost_config<F, E>(
 where
     F: PrimeField32,
 {
-    let program = &exe.program;
-    let pc_base = program.pc_base;
-
-    let terminate_opcode = SystemOpcode::TERMINATE.global_opcode();
-
-    let pc_to_chip: Vec<u32> = program
-        .instructions_and_debug_infos
-        .iter()
-        .map(|slot| {
-            if let Some((inst, _)) = slot {
-                let opcode: VmOpcode = inst.opcode;
-                if opcode == terminate_opcode {
-                    NO_CHIP
-                } else if let Some(&executor_idx) = inventory.instruction_lookup.get(&opcode) {
-                    let air_idx = executor_idx_to_air_idx[executor_idx as usize];
-                    air_idx as u32
-                } else {
-                    NO_CHIP
-                }
-            } else {
-                NO_CHIP
-            }
-        })
-        .collect();
-
     MeteredCostConfig {
-        pc_to_chip,
-        pc_base,
+        pc_to_chip: build_pc_to_chip(exe, inventory, executor_idx_to_air_idx),
+        pc_base: exe.program.pc_base,
         widths: widths.to_vec(),
     }
 }
@@ -171,17 +149,13 @@ where
             &self.executor_idx_to_air_idx,
             &ctx.widths,
         );
-        let chips = metered_cost_config.chip_mapping();
-
-        let compiled = compile_metered_cost(self.exe.as_ref(), &self.extensions, &chips)
-            .map_err(map_rvr_compile_error)?;
 
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let result = tracing::info_span!("execute_metered_cost")
             .in_scope(|| {
                 execute_metered_cost(
-                    &compiled,
+                    &self.compiled,
                     &self.extensions,
                     &mut vm_state,
                     metered_cost_config,

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -8,17 +8,12 @@ use rvr_openvm_lift::ExtensionRegistry;
 
 use super::{
     bridge::map_rvr_execute_error,
-    compile::ChipMapping,
     execute_metered_cost,
-    metered::build_pc_to_chip,
     state::{MeteredCostState, TracerPayload, TracerPtr},
     RvrCompiled,
 };
 use crate::{
-    arch::{
-        execution_mode::MeteredCostCtx, ExecutionError, ExecutorInventory, MeteredExecutor,
-        Streams, SystemConfig, VmState,
-    },
+    arch::{execution_mode::MeteredCostCtx, ExecutionError, Streams, SystemConfig, VmState},
     system::memory::online::GuestMemory,
 };
 
@@ -27,50 +22,14 @@ pub struct RvrMeteredCostResult {
     pub cost: u64,
 }
 
-/// Configuration for mapping PCs and memory operations to metering costs.
-pub struct MeteredCostConfig {
-    /// pc_index -> chip_idx. pc_index = (pc - pc_base) / 4.
-    /// `u32::MAX` means no chip (e.g., TERMINATE).
-    pub pc_to_chip: Vec<u32>,
-    pub pc_base: u32,
-    /// Per-AIR widths (for cost = height * width).
-    pub widths: Vec<usize>,
-}
-
-impl MeteredCostConfig {
-    /// Extract chip mapping for compilation.
-    pub fn chip_mapping(&self) -> ChipMapping {
-        ChipMapping {
-            pc_to_chip: self.pc_to_chip.clone(),
-            chip_widths: Some(self.widths.iter().map(|&w| w as u64).collect()),
-        }
-    }
-}
-
-pub struct RvrMeteredCostInstance<F: PrimeField32, E> {
+pub struct RvrMeteredCostInstance<F: PrimeField32> {
     pub(crate) system_config: SystemConfig,
     pub(crate) exe: Arc<VmExe<F>>,
-    pub(crate) inventory: Arc<ExecutorInventory<E>>,
-    pub(crate) executor_idx_to_air_idx: Vec<usize>,
     pub(crate) extensions: ExtensionRegistry<F>,
     pub(crate) compiled: RvrCompiled,
-}
-
-/// Build a `MeteredCostConfig` from the program, executor inventory, AIR index mapping, and widths.
-pub fn build_metered_cost_config<F, E>(
-    exe: &VmExe<F>,
-    inventory: &ExecutorInventory<E>,
-    executor_idx_to_air_idx: &[usize],
-    widths: &[usize],
-) -> MeteredCostConfig
-where
-    F: PrimeField32,
-{
-    MeteredCostConfig {
-        pc_to_chip: build_pc_to_chip(exe, inventory, executor_idx_to_air_idx),
-        pc_base: exe.program.pc_base,
-        widths: widths.to_vec(),
-    }
+    /// Must match the widths baked into `compiled` so per-block constants and
+    /// extension `trace_chip` calls compute cost against the same values.
+    pub(crate) widths: Vec<u64>,
 }
 
 /// C-compatible metered cost meter data.
@@ -112,18 +71,7 @@ impl TracerPayload for PureTracerData {
 
 pub type PureTracer = TracerPtr<PureTracerData>;
 
-/// Prepare metering data from a `MeteredCostConfig`.
-///
-/// Returns `widths_u64` for the C tracer.
-pub fn prepare_metered_cost(config: &MeteredCostConfig) -> Vec<u64> {
-    config.widths.iter().map(|&w| w as u64).collect()
-}
-
-impl<F, E> RvrMeteredCostInstance<F, E>
-where
-    F: PrimeField32,
-    E: MeteredExecutor<F>,
-{
+impl<F: PrimeField32> RvrMeteredCostInstance<F> {
     pub fn execute_metered_cost(
         &self,
         inputs: impl Into<Streams<F>>,
@@ -143,13 +91,6 @@ where
         mut vm_state: VmState<F, GuestMemory>,
         ctx: MeteredCostCtx,
     ) -> Result<(MeteredCostCtx, VmState<F, GuestMemory>), ExecutionError> {
-        let metered_cost_config = build_metered_cost_config(
-            self.exe.as_ref(),
-            self.inventory.as_ref(),
-            &self.executor_idx_to_air_idx,
-            &ctx.widths,
-        );
-
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
         let result = tracing::info_span!("execute_metered_cost")
@@ -158,7 +99,7 @@ where
                     &self.compiled,
                     &self.extensions,
                     &mut vm_state,
-                    metered_cost_config,
+                    &self.widths,
                 )
             })
             .map_err(map_rvr_execute_error)?;

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -20,7 +20,7 @@ pub use execute::{
     build_callbacks, execute, execute_metered, execute_metered_cost, register_openvm_callbacks,
     rv_execute, ExecuteError,
 };
-pub use metered::RvrMeteredInstance;
+pub use metered::{build_pc_to_chip, RvrMeteredInstance};
 pub use metered_cost::{
     build_metered_cost_config, MeteredCostConfig, MeteredCostData, MeteredCostMeter, PureTracer,
     PureTracerData, RvrMeteredCostInstance, RvrMeteredCostResult,

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -22,8 +22,8 @@ pub use execute::{
 };
 pub use metered::{build_pc_to_chip, RvrMeteredInstance};
 pub use metered_cost::{
-    build_metered_cost_config, MeteredCostConfig, MeteredCostData, MeteredCostMeter, PureTracer,
-    PureTracerData, RvrMeteredCostInstance, RvrMeteredCostResult,
+    MeteredCostData, MeteredCostMeter, PureTracer, PureTracerData, RvrMeteredCostInstance,
+    RvrMeteredCostResult,
 };
 pub use pure::{RvrPureInstance, RvrPureResult};
 pub use rvr_openvm::{

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -43,8 +43,8 @@ use tracing::{info_span, instrument};
 use super::aot::AotInstance;
 #[cfg(feature = "rvr")]
 use super::rvr::{
-    self, bridge::map_rvr_compile_error, RvrMeteredCostInstance, RvrMeteredInstance,
-    RvrPureInstance,
+    bridge::map_rvr_compile_error, build_pc_to_chip, compile, compile_metered,
+    compile_metered_cost, ChipMapping, RvrMeteredCostInstance, RvrMeteredInstance, RvrPureInstance,
 };
 use super::{
     execution_mode::{ExecutionCtx, MeteredCostCtx, MeteredCtx, PreflightCtx, Segment},
@@ -145,10 +145,6 @@ impl<F> From<Vec<Vec<F>>> for Streams<F> {
 /// Typedef for [PreflightInterpretedInstance] that is generic in `VC: VmExecutionConfig<F>`
 type PreflightInterpretedInstance2<F, VC> =
     PreflightInterpretedInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
-
-/// Typedef for [RvrMeteredInstance] that is generic in `VC: VmExecutionConfig<F>`
-#[cfg(feature = "rvr")]
-type RvrMeteredInstance2<F, VC> = RvrMeteredInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
 
 /// Typedef for [RvrMeteredCostInstance] that is generic in `VC: VmExecutionConfig<F>`
 #[cfg(feature = "rvr")]
@@ -294,7 +290,7 @@ where
         // execution can avoid passing `executor_idx_to_air_idx` altogether.
         let executor_idx_to_air_idx = vec![NO_CHIP as usize; self.inventory.executors.len()];
         let extensions = self.build_rvr_extensions(&executor_idx_to_air_idx);
-        let compiled = rvr::compile(exe, &extensions).map_err(map_rvr_compile_error)?;
+        let compiled = compile(exe, &extensions).map_err(map_rvr_compile_error)?;
 
         Ok(RvrPureInstance {
             system_config: self.inventory.config().clone(),
@@ -396,23 +392,27 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<RvrMeteredInstance<F, VC::Executor>, StaticProgramError> {
-        Self::metered_rvr_instance(self, exe, executor_idx_to_air_idx)
+    ) -> Result<RvrMeteredInstance<F>, StaticProgramError> {
+        self.metered_rvr_instance(exe, executor_idx_to_air_idx)
     }
 
     pub fn metered_rvr_instance(
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<RvrMeteredInstance<F, VC::Executor>, StaticProgramError> {
+    ) -> Result<RvrMeteredInstance<F>, StaticProgramError> {
         let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+        let chips = ChipMapping {
+            pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx),
+            chip_widths: None,
+        };
+        let compiled = compile_metered(exe, &extensions, &chips).map_err(map_rvr_compile_error)?;
 
         Ok(RvrMeteredInstance {
             system_config: self.inventory.config().clone(),
             exe: Arc::new(exe.clone()),
-            inventory: self.inventory.clone(),
-            executor_idx_to_air_idx: executor_idx_to_air_idx.to_vec(),
             extensions,
+            compiled,
         })
     }
 
@@ -420,16 +420,24 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
+        widths: &[usize],
     ) -> Result<RvrMeteredCostInstance<F, VC::Executor>, StaticProgramError> {
-        Self::metered_cost_rvr_instance(self, exe, executor_idx_to_air_idx)
+        self.metered_cost_rvr_instance(exe, executor_idx_to_air_idx, widths)
     }
 
     pub fn metered_cost_rvr_instance(
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
+        widths: &[usize],
     ) -> Result<RvrMeteredCostInstance<F, VC::Executor>, StaticProgramError> {
         let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+        let chips = ChipMapping {
+            pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx),
+            chip_widths: Some(widths.iter().map(|&w| w as u64).collect()),
+        };
+        let compiled =
+            compile_metered_cost(exe, &extensions, &chips).map_err(map_rvr_compile_error)?;
 
         Ok(RvrMeteredCostInstance {
             system_config: self.inventory.config().clone(),
@@ -437,6 +445,7 @@ where
             inventory: self.inventory.clone(),
             executor_idx_to_air_idx: executor_idx_to_air_idx.to_vec(),
             extensions,
+            compiled,
         })
     }
 }
@@ -666,7 +675,7 @@ where
     pub fn metered_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    ) -> Result<RvrMeteredInstance<Val<E::SC>>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -680,7 +689,7 @@ where
     pub fn get_metered_rvr_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    ) -> Result<RvrMeteredInstance<Val<E::SC>>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -769,8 +778,14 @@ where
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
     {
         let executor_idx_to_air_idx = self.executor_idx_to_air_idx();
+        let widths: Vec<usize> = self
+            .pk
+            .per_air
+            .iter()
+            .map(|pk| pk.vk.params.width.total_width())
+            .collect();
         self.executor()
-            .metered_cost_rvr_instance(exe, &executor_idx_to_air_idx)
+            .metered_cost_rvr_instance(exe, &executor_idx_to_air_idx, &widths)
     }
 
     pub fn preflight_interpreter(

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -146,11 +146,6 @@ impl<F> From<Vec<Vec<F>>> for Streams<F> {
 type PreflightInterpretedInstance2<F, VC> =
     PreflightInterpretedInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
 
-/// Typedef for [RvrMeteredCostInstance] that is generic in `VC: VmExecutionConfig<F>`
-#[cfg(feature = "rvr")]
-type RvrMeteredCostInstance2<F, VC> =
-    RvrMeteredCostInstance<F, <VC as VmExecutionConfig<F>>::Executor>;
-
 /// [VmExecutor] is the struct that can execute an _arbitrary_ program, provided in the form of a
 /// [VmExe], for a fixed set of OpenVM instructions corresponding to a [VmExecutionConfig].
 /// Internally once it is given a program, it will preprocess the program to rewrite it into a more
@@ -421,7 +416,7 @@ where
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
         widths: &[usize],
-    ) -> Result<RvrMeteredCostInstance<F, VC::Executor>, StaticProgramError> {
+    ) -> Result<RvrMeteredCostInstance<F>, StaticProgramError> {
         self.metered_cost_rvr_instance(exe, executor_idx_to_air_idx, widths)
     }
 
@@ -430,11 +425,12 @@ where
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
         widths: &[usize],
-    ) -> Result<RvrMeteredCostInstance<F, VC::Executor>, StaticProgramError> {
+    ) -> Result<RvrMeteredCostInstance<F>, StaticProgramError> {
         let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+        let widths: Vec<u64> = widths.iter().map(|&w| w as u64).collect();
         let chips = ChipMapping {
             pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx),
-            chip_widths: Some(widths.iter().map(|&w| w as u64).collect()),
+            chip_widths: Some(widths.clone()),
         };
         let compiled =
             compile_metered_cost(exe, &extensions, &chips).map_err(map_rvr_compile_error)?;
@@ -442,10 +438,9 @@ where
         Ok(RvrMeteredCostInstance {
             system_config: self.inventory.config().clone(),
             exe: Arc::new(exe.clone()),
-            inventory: self.inventory.clone(),
-            executor_idx_to_air_idx: executor_idx_to_air_idx.to_vec(),
             extensions,
             compiled,
+            widths,
         })
     }
 }
@@ -760,7 +755,7 @@ where
     pub fn metered_cost_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredCostInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    ) -> Result<RvrMeteredCostInstance<Val<E::SC>>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -772,7 +767,7 @@ where
     pub fn get_metered_cost_rvr_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredCostInstance2<Val<E::SC>, VB::VmConfig>, StaticProgramError>
+    ) -> Result<RvrMeteredCostInstance<Val<E::SC>>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,


### PR DESCRIPTION
moves the rvr compilation stage for metered and metered cost out of execution and into instance construction

closes INT-7626