### PR TITLE
refactor: use enum for air index

### DIFF
--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -9,39 +9,45 @@ use openvm_instructions::{instruction::Instruction, LocalOpcode, VmOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::LiftedInstr;
 
-/// Index of an AIR in the trace.
+/// Real AIR index in the trace.
 ///
-/// - `Uninitialized` is a placeholder used only during pure execution where air indices are
-///   irrelevant. Metered execution panics when it encounters this variant.
-/// - `NoChip` marks opcodes/instructions that do not contribute to any chip's trace (e.g.
-///   `TERMINATE`).
-/// - `Chip(u32)` is a real AIR index.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum AirIndex {
-    Uninitialized,
-    NoChip,
-    Chip(u32),
-}
+/// `Option<AirIndex>` represents an extension's dynamic tracing metadata: `None`
+/// in pure mode (AIR metadata was not requested), `Some(idx)` in metered modes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AirIndex(u32);
 
 impl AirIndex {
     #[inline]
-    pub fn next(self) -> AirIndex {
-        match self {
-            AirIndex::Chip(n) => AirIndex::Chip(n + 1),
-            other => other,
-        }
+    pub const fn new(idx: u32) -> Self {
+        Self(idx)
     }
 
-    /// Lower to the `u32` chip index baked into generated C source. Both
-    /// `NoChip` and `Uninitialized` become `u32::MAX` (the `NO_CHIP` sentinel
-    /// on the C side, where `trace_chip` is a no-op for that value).
     #[inline]
-    pub fn to_c_chip_idx(self) -> u32 {
-        match self {
-            AirIndex::Chip(n) => n,
-            AirIndex::NoChip | AirIndex::Uninitialized => u32::MAX,
-        }
+    pub const fn as_u32(self) -> u32 {
+        self.0
     }
+
+    #[inline]
+    pub fn next(self) -> AirIndex {
+        AirIndex(self.0 + 1)
+    }
+}
+
+/// PC-to-chip mapping entry. `NoChip` means the instruction at this PC
+/// intentionally does not contribute to any chip's trace (e.g. `TERMINATE` or
+/// unmapped slots).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TraceChipIndex {
+    Chip(AirIndex),
+    NoChip,
+}
+
+/// Lower an extension's `Option<AirIndex>` to the `u32` chip index baked into
+/// generated C source. `None` (pure mode) becomes `u32::MAX` (the `NO_CHIP`
+/// sentinel on the C side, where `trace_chip` is a no-op for that value).
+#[inline]
+pub fn air_index_to_c(idx: Option<AirIndex>) -> u32 {
+    idx.map_or(u32::MAX, AirIndex::as_u32)
 }
 
 /// Data needed by extension crates to resolve opcode/chip metadata when
@@ -71,15 +77,15 @@ impl RvrExtensionCtx {
 }
 
 /// Resolve the AIR index for `opcode`. In pure mode (`ctx = None`) returns
-/// `Ok(Uninitialized)`; in metered mode returns `Ok(Chip(n))` for the
-/// registered opcode and errors if the opcode is unknown.
+/// `Ok(None)`; in metered mode returns `Ok(Some(idx))` for the registered
+/// opcode and errors if the opcode is unknown.
 pub fn opcode_air_idx(
     ctx: Option<&RvrExtensionCtx>,
     opcode: impl LocalOpcode,
-) -> Result<AirIndex, ExtensionError> {
+) -> Result<Option<AirIndex>, ExtensionError> {
     let opcode = opcode.global_opcode();
     let Some(ctx) = ctx else {
-        return Ok(AirIndex::Uninitialized);
+        return Ok(None);
     };
     let executor_idx = ctx
         .resolve_opcode_executor_idx(opcode)
@@ -90,7 +96,7 @@ pub fn opcode_air_idx(
             executor_idx,
         },
     )?;
-    Ok(AirIndex::Chip(*raw as u32))
+    Ok(Some(AirIndex::new(*raw as u32)))
 }
 
 /// Errors raised when resolving extension metadata from a `RvrExtensionCtx`.

--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -5,15 +5,44 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use openvm_instructions::{instruction::Instruction, VmOpcode};
+use openvm_instructions::{instruction::Instruction, LocalOpcode, VmOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::LiftedInstr;
 
-/// Sentinel air index meaning "no chip" — used for opcodes/instructions that do
-/// not contribute to a chip's trace (e.g. `TERMINATE`) and to fill placeholder
-/// `executor_idx_to_air_idx` arrays in pure execution where air indices are
-/// irrelevant.
-pub const NO_CHIP: u32 = u32::MAX;
+/// Index of an AIR in the trace.
+///
+/// - `Uninitialized` is a placeholder used only during pure execution where air indices are
+///   irrelevant. Metered execution panics when it encounters this variant.
+/// - `NoChip` marks opcodes/instructions that do not contribute to any chip's trace (e.g.
+///   `TERMINATE`).
+/// - `Chip(u32)` is a real AIR index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AirIndex {
+    Uninitialized,
+    NoChip,
+    Chip(u32),
+}
+
+impl AirIndex {
+    #[inline]
+    pub fn next(self) -> AirIndex {
+        match self {
+            AirIndex::Chip(n) => AirIndex::Chip(n + 1),
+            other => other,
+        }
+    }
+
+    /// Lower to the `u32` chip index baked into generated C source. Both
+    /// `NoChip` and `Uninitialized` become `u32::MAX` (the `NO_CHIP` sentinel
+    /// on the C side, where `trace_chip` is a no-op for that value).
+    #[inline]
+    pub fn to_c_chip_idx(self) -> u32 {
+        match self {
+            AirIndex::Chip(n) => n,
+            AirIndex::NoChip | AirIndex::Uninitialized => u32::MAX,
+        }
+    }
+}
 
 /// Data needed by extension crates to resolve opcode/chip metadata when
 /// registering rvr extension handlers.
@@ -39,26 +68,29 @@ impl RvrExtensionCtx {
     pub fn resolve_opcode_executor_idx(&self, opcode: VmOpcode) -> Option<usize> {
         self.opcode_to_executor_idx.get(&opcode).copied()
     }
+}
 
-    pub fn resolve_opcode_air_idx(&self, opcode: VmOpcode) -> Option<u32> {
-        let executor_idx = self.resolve_opcode_executor_idx(opcode)?;
-        self.executor_idx_to_air_idx
-            .get(executor_idx)
-            .map(|air_idx| *air_idx as u32)
-    }
-
-    pub fn require_opcode_air_idx(&self, opcode: VmOpcode) -> Result<u32, ExtensionError> {
-        let executor_idx = self
-            .resolve_opcode_executor_idx(opcode)
-            .ok_or(ExtensionError::UnknownOpcode(opcode))?;
-        let air_idx = self.executor_idx_to_air_idx.get(executor_idx).ok_or(
-            ExtensionError::ExecutorIndexOutOfBounds {
-                opcode,
-                executor_idx,
-            },
-        )?;
-        Ok(*air_idx as u32)
-    }
+/// Resolve the AIR index for `opcode`. In pure mode (`ctx = None`) returns
+/// `Ok(Uninitialized)`; in metered mode returns `Ok(Chip(n))` for the
+/// registered opcode and errors if the opcode is unknown.
+pub fn opcode_air_idx(
+    ctx: Option<&RvrExtensionCtx>,
+    opcode: impl LocalOpcode,
+) -> Result<AirIndex, ExtensionError> {
+    let opcode = opcode.global_opcode();
+    let Some(ctx) = ctx else {
+        return Ok(AirIndex::Uninitialized);
+    };
+    let executor_idx = ctx
+        .resolve_opcode_executor_idx(opcode)
+        .ok_or(ExtensionError::UnknownOpcode(opcode))?;
+    let raw = ctx.executor_idx_to_air_idx.get(executor_idx).ok_or(
+        ExtensionError::ExecutorIndexOutOfBounds {
+            opcode,
+            executor_idx,
+        },
+    )?;
+    Ok(AirIndex::Chip(*raw as u32))
 }
 
 /// Errors raised when resolving extension metadata from a `RvrExtensionCtx`.
@@ -140,11 +172,11 @@ pub trait RvrExtension<F: PrimeField32>: Send + Sync {
 /// Trait implemented by OpenVM extension owner types to contribute their rvr
 /// lifting/codegen extensions during config assembly.
 pub trait VmRvrExtension<F: PrimeField32> {
-    fn extend_rvr(&self, _registry: &mut ExtensionRegistry<F>, _ctx: &RvrExtensionCtx) {}
+    fn extend_rvr(&self, _registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {}
 }
 
 impl<F: PrimeField32, EXT: VmRvrExtension<F>> VmRvrExtension<F> for Option<EXT> {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: &RvrExtensionCtx) {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: Option<&RvrExtensionCtx>) {
         if let Some(ext) = self {
             ext.extend_rvr(registry, ctx);
         }

--- a/crates/rvr/rvr-openvm-lift/src/lib.rs
+++ b/crates/rvr/rvr-openvm-lift/src/lib.rs
@@ -21,7 +21,7 @@ pub use convert::{
     ConvertError,
 };
 pub use extension::{
-    opcode_air_idx, AirIndex, ExtensionError, ExtensionRegistry, RvrExtension, RvrExtensionCtx,
-    VmRvrExtension,
+    air_index_to_c, opcode_air_idx, AirIndex, ExtensionError, ExtensionRegistry, RvrExtension,
+    RvrExtensionCtx, TraceChipIndex, VmRvrExtension,
 };
 pub use helpers::{decode_imm_cg, decode_reg};

--- a/crates/rvr/rvr-openvm-lift/src/lib.rs
+++ b/crates/rvr/rvr-openvm-lift/src/lib.rs
@@ -21,6 +21,7 @@ pub use convert::{
     ConvertError,
 };
 pub use extension::{
-    ExtensionError, ExtensionRegistry, RvrExtension, RvrExtensionCtx, VmRvrExtension, NO_CHIP,
+    opcode_air_idx, AirIndex, ExtensionError, ExtensionRegistry, RvrExtension, RvrExtensionCtx,
+    VmRvrExtension,
 };
 pub use helpers::{decode_imm_cg, decode_reg};

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -9,7 +9,7 @@ use std::{
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::*;
-use rvr_openvm_lift::{AirIndex, ExtensionRegistry};
+use rvr_openvm_lift::{ExtensionRegistry, TraceChipIndex};
 
 use super::{
     codegen::{emit_terminator, InstrCodegen, TermCtx},
@@ -66,7 +66,8 @@ pub struct CProject {
     pub enable_lto: bool,
     /// Per-PC chip index for hardcoded trace_chip calls.
     /// Index i = chip for PC = pc_base + i*4.
-    pub pc_to_chip: Option<Vec<AirIndex>>,
+    /// `None` in pure mode (no chip metadata requested); must be set in metered modes.
+    pub pc_to_chip: Option<Vec<TraceChipIndex>>,
     /// Program PC base (used to compute pc_to_chip index).
     pub pc_base: u32,
     /// Per-AIR widths for MeteredCost precomputation. Indexed by chip index.
@@ -182,17 +183,20 @@ impl CProject {
     fn block_end_pc(&self, block: &Block) -> u32 {
         block.terminator_pc.saturating_add(4)
     }
-    /// Look up the chip index for a given PC.
-    fn chip_idx_for_pc(&self, pc: u32) -> AirIndex {
-        if let Some(ref mapping) = self.pc_to_chip {
-            let Some(offset) = pc.checked_sub(self.pc_base) else {
-                return AirIndex::NoChip;
-            };
-            let idx = (offset / 4) as usize;
-            mapping.get(idx).copied().unwrap_or(AirIndex::NoChip)
-        } else {
-            AirIndex::Uninitialized
-        }
+    /// Look up the chip index for a given PC. Must only be called in metered
+    /// modes; panics if `pc_to_chip` is unset.
+    fn chip_idx_for_pc(&self, pc: u32) -> TraceChipIndex {
+        let mapping = self
+            .pc_to_chip
+            .as_ref()
+            .expect("pc_to_chip must be set for metered rvr codegen");
+        let Some(offset) = pc.checked_sub(self.pc_base) else {
+            return TraceChipIndex::NoChip;
+        };
+        mapping
+            .get((offset / 4) as usize)
+            .copied()
+            .unwrap_or(TraceChipIndex::NoChip)
     }
 
     /// Write all C project files.
@@ -525,11 +529,8 @@ impl CProject {
 
         let mut chip_counts: BTreeMap<u32, u32> = BTreeMap::new();
         let mut increment_chip_count = |pc: u32| match self.chip_idx_for_pc(pc) {
-            AirIndex::Chip(chip) => *chip_counts.entry(chip).or_insert(0) += 1,
-            AirIndex::NoChip => {}
-            AirIndex::Uninitialized => {
-                panic!("chip index for pc {pc:#x} is Uninitialized")
-            }
+            TraceChipIndex::Chip(chip) => *chip_counts.entry(chip.as_u32()).or_insert(0) += 1,
+            TraceChipIndex::NoChip => {}
         };
         for instr_at in &block.instructions {
             increment_chip_count(instr_at.pc);

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -9,7 +9,7 @@ use std::{
 
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::*;
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::{AirIndex, ExtensionRegistry};
 
 use super::{
     codegen::{emit_terminator, InstrCodegen, TermCtx},
@@ -65,8 +65,8 @@ pub struct CProject {
     /// Enable thin LTO for the generated C code.
     pub enable_lto: bool,
     /// Per-PC chip index for hardcoded trace_chip calls.
-    /// Index i = chip for PC = pc_base + i*4. u32::MAX means no chip.
-    pub pc_to_chip: Option<Vec<u32>>,
+    /// Index i = chip for PC = pc_base + i*4.
+    pub pc_to_chip: Option<Vec<AirIndex>>,
     /// Program PC base (used to compute pc_to_chip index).
     pub pc_base: u32,
     /// Per-AIR widths for MeteredCost precomputation. Indexed by chip index.
@@ -182,16 +182,16 @@ impl CProject {
     fn block_end_pc(&self, block: &Block) -> u32 {
         block.terminator_pc.saturating_add(4)
     }
-    /// Look up the chip index for a given PC. Returns u32::MAX if no mapping.
-    fn chip_idx_for_pc(&self, pc: u32) -> u32 {
+    /// Look up the chip index for a given PC.
+    fn chip_idx_for_pc(&self, pc: u32) -> AirIndex {
         if let Some(ref mapping) = self.pc_to_chip {
             let Some(offset) = pc.checked_sub(self.pc_base) else {
-                return u32::MAX;
+                return AirIndex::NoChip;
             };
             let idx = (offset / 4) as usize;
-            mapping.get(idx).copied().unwrap_or(u32::MAX)
+            mapping.get(idx).copied().unwrap_or(AirIndex::NoChip)
         } else {
-            u32::MAX
+            AirIndex::Uninitialized
         }
     }
 
@@ -522,22 +522,20 @@ impl CProject {
         if matches!(self.tracer_mode, TracerMode::Pure) {
             return;
         }
-        if self.pc_to_chip.is_none() {
-            return;
-        }
 
         let mut chip_counts: BTreeMap<u32, u32> = BTreeMap::new();
-        for instr_at in &block.instructions {
-            let chip = self.chip_idx_for_pc(instr_at.pc);
-            if chip != u32::MAX {
-                *chip_counts.entry(chip).or_insert(0) += 1;
+        let mut increment_chip_count = |pc: u32| match self.chip_idx_for_pc(pc) {
+            AirIndex::Chip(chip) => *chip_counts.entry(chip).or_insert(0) += 1,
+            AirIndex::NoChip => {}
+            AirIndex::Uninitialized => {
+                panic!("chip index for pc {pc:#x} is Uninitialized")
             }
+        };
+        for instr_at in &block.instructions {
+            increment_chip_count(instr_at.pc);
         }
         if !matches!(block.terminator, Terminator::FallThrough) {
-            let chip = self.chip_idx_for_pc(block.terminator_pc);
-            if chip != u32::MAX {
-                *chip_counts.entry(chip).or_insert(0) += 1;
-            }
+            increment_chip_count(block.terminator_pc);
         }
         if chip_counts.is_empty() {
             return;

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -327,7 +327,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    fn create_rvr_extensions(&self, air_idx: &[usize]) -> ExtensionRegistry<F>
+    fn create_rvr_extensions(&self, air_idx: Option<&[usize]>) -> ExtensionRegistry<F>
     where
         F: PrimeField32,
     {

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -926,7 +926,7 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
             <#extension_ty as ::rvr_openvm_lift::VmRvrExtension<F>>::extend_rvr(
                 &self.#ext_field_name,
                 &mut registry,
-                &ctx,
+                ctx.as_ref(),
             );
         });
         create_airs.push(quote! {
@@ -981,19 +981,18 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
             #[cfg(feature = "rvr")]
             fn create_rvr_extensions(
                 &self,
-                air_idx: &[usize],
+                air_idx: Option<&[usize]>,
             ) -> ::rvr_openvm_lift::ExtensionRegistry<F>
             {
-                let inventory = <Self as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_executors(self)
-                    .expect("create_executors failed in create_rvr_extensions");
-                let opcode_to_executor_idx = inventory
-                    .instruction_lookup
-                    .iter()
-                    .map(|(opcode, executor_idx)| (*opcode, *executor_idx as usize));
-                let ctx = ::rvr_openvm_lift::RvrExtensionCtx::new(
-                    opcode_to_executor_idx,
-                    air_idx.to_vec(),
-                );
+                let ctx = air_idx.map(|air_idx| {
+                    let inventory = <Self as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_executors(self)
+                        .expect("create_executors failed in create_rvr_extensions");
+                    let opcode_to_executor_idx = inventory
+                        .instruction_lookup
+                        .iter()
+                        .map(|(opcode, executor_idx)| (*opcode, *executor_idx as usize));
+                    ::rvr_openvm_lift::RvrExtensionCtx::new(opcode_to_executor_idx, air_idx.to_vec())
+                });
                 let mut registry = <#source_field_ty as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_rvr_extensions(
                     &self.#source_name,
                     air_idx,

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -74,7 +74,7 @@ pub trait VmExecutionConfig<F> {
         -> Result<ExecutorInventory<Self::Executor>, ExecutorInventoryError>;
 
     #[cfg(feature = "rvr")]
-    fn create_rvr_extensions(&self, air_idx: &[usize]) -> ExtensionRegistry<F>
+    fn create_rvr_extensions(&self, air_idx: Option<&[usize]>) -> ExtensionRegistry<F>
     where
         F: PrimeField32;
 }

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -7,15 +7,16 @@ use std::{
     time::{Duration, Instant},
 };
 
-use openvm_instructions::exe::VmExe;
+use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{CProject, TracerMode};
 use rvr_openvm_lift::{
-    build_blocks, convert_vmexe_to_ir_with_debug, scan_init_memory_for_code_pointers,
+    build_blocks, convert_vmexe_to_ir_with_debug, scan_init_memory_for_code_pointers, AirIndex,
     ExtensionRegistry,
 };
 
 use super::debug::GuestDebugMap;
+use crate::arch::ExecutorInventory;
 
 /// A compiled rvr shared library ready for execution.
 pub struct RvrCompiled {
@@ -53,12 +54,41 @@ pub enum CompileError {
 #[derive(Clone)]
 pub struct ChipMapping {
     /// Per-PC chip index. Index i = chip for PC = pc_base + i*4.
-    pub pc_to_chip: Vec<u32>,
+    pub pc_to_chip: Vec<AirIndex>,
     /// Per-AIR widths (MeteredCost mode only). When present, the emitter
     /// precomputes `sum(width[chip] * count)` per block so the generated C
     /// increments `cost` by a single constant instead of loading from the
     /// `chip_widths` array at runtime.
     pub chip_widths: Option<Vec<u64>>,
+}
+
+pub fn build_pc_to_chip<F, E>(
+    exe: &VmExe<F>,
+    inventory: &ExecutorInventory<E>,
+    executor_idx_to_air_idx: &[usize],
+) -> Vec<AirIndex>
+where
+    F: PrimeField32,
+{
+    let terminate_opcode = SystemOpcode::TERMINATE.global_opcode();
+    exe.program
+        .instructions_and_debug_infos
+        .iter()
+        .map(|slot| {
+            if let Some((inst, _)) = slot {
+                let opcode: VmOpcode = inst.opcode;
+                if opcode == terminate_opcode {
+                    AirIndex::NoChip
+                } else if let Some(&executor_idx) = inventory.instruction_lookup.get(&opcode) {
+                    AirIndex::Chip(executor_idx_to_air_idx[executor_idx as usize] as u32)
+                } else {
+                    AirIndex::NoChip
+                }
+            } else {
+                AirIndex::NoChip
+            }
+        })
+        .collect()
 }
 
 /// Options for the compilation pipeline.

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -7,12 +7,14 @@ use std::{
     time::{Duration, Instant},
 };
 
-use openvm_instructions::{exe::VmExe, LocalOpcode, SystemOpcode, VmOpcode};
+use openvm_instructions::{
+    exe::VmExe, program::DEFAULT_PC_STEP, LocalOpcode, SystemOpcode, VmOpcode,
+};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{CProject, TracerMode};
 use rvr_openvm_lift::{
     build_blocks, convert_vmexe_to_ir_with_debug, scan_init_memory_for_code_pointers, AirIndex,
-    ExtensionRegistry,
+    ExtensionRegistry, TraceChipIndex,
 };
 
 use super::debug::GuestDebugMap;
@@ -48,13 +50,17 @@ pub enum CompileError {
     Toolchain(String),
     #[error("library load failed: {0}")]
     LibLoad(String),
+    #[error("unknown opcode {opcode:?} at pc {pc:#x}")]
+    UnknownOpcode { pc: u32, opcode: VmOpcode },
+    #[error("invalid compile options: {0}")]
+    InvalidOptions(&'static str),
 }
 
 /// Chip mapping information for hardcoding chip indices into generated code.
 #[derive(Clone)]
 pub struct ChipMapping {
     /// Per-PC chip index. Index i = chip for PC = pc_base + i*4.
-    pub pc_to_chip: Vec<AirIndex>,
+    pub pc_to_chip: Vec<TraceChipIndex>,
     /// Per-AIR widths (MeteredCost mode only). When present, the emitter
     /// precomputes `sum(width[chip] * count)` per block so the generated C
     /// increments `cost` by a single constant instead of loading from the
@@ -66,7 +72,7 @@ pub fn build_pc_to_chip<F, E>(
     exe: &VmExe<F>,
     inventory: &ExecutorInventory<E>,
     executor_idx_to_air_idx: &[usize],
-) -> Vec<AirIndex>
+) -> Result<Vec<TraceChipIndex>, CompileError>
 where
     F: PrimeField32,
 {
@@ -74,19 +80,24 @@ where
     exe.program
         .instructions_and_debug_infos
         .iter()
-        .map(|slot| {
-            if let Some((inst, _)) = slot {
-                let opcode: VmOpcode = inst.opcode;
-                if opcode == terminate_opcode {
-                    AirIndex::NoChip
-                } else if let Some(&executor_idx) = inventory.instruction_lookup.get(&opcode) {
-                    AirIndex::Chip(executor_idx_to_air_idx[executor_idx as usize] as u32)
-                } else {
-                    AirIndex::NoChip
-                }
-            } else {
-                AirIndex::NoChip
+        .enumerate()
+        .map(|(i, slot)| {
+            let Some((inst, _)) = slot else {
+                return Ok(TraceChipIndex::NoChip);
+            };
+            let opcode: VmOpcode = inst.opcode;
+            if opcode == terminate_opcode {
+                return Ok(TraceChipIndex::NoChip);
             }
+            let &executor_idx = inventory.instruction_lookup.get(&opcode).ok_or_else(|| {
+                CompileError::UnknownOpcode {
+                    pc: exe.program.pc_base + (i as u32) * DEFAULT_PC_STEP,
+                    opcode,
+                }
+            })?;
+            Ok(TraceChipIndex::Chip(AirIndex::new(
+                executor_idx_to_air_idx[executor_idx as usize] as u32,
+            )))
         })
         .collect()
 }
@@ -191,10 +202,16 @@ fn compile_impl<F: PrimeField32>(
 
     let mut project = CProject::new(output_dir, &base_name, opts.tracer_mode);
 
-    if let Some(chips) = opts.chips {
-        project.pc_to_chip = Some(chips.pc_to_chip.clone());
-        project.pc_base = exe.program.pc_base;
-        project.chip_widths = chips.chip_widths.clone();
+    match opts.tracer_mode {
+        TracerMode::Pure => {}
+        TracerMode::Metered | TracerMode::MeteredCost => {
+            let chips = opts.chips.ok_or(CompileError::InvalidOptions(
+                "metered rvr compile requires ChipMapping",
+            ))?;
+            project.pc_to_chip = Some(chips.pc_to_chip.clone());
+            project.pc_base = exe.program.pc_base;
+            project.chip_widths = chips.chip_widths.clone();
+        }
     }
 
     if cfg!(target_os = "macos") {

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -8,7 +8,7 @@ use openvm_instructions::{
 };
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
-use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
+use rvr_openvm_lift::ExtensionRegistry;
 
 use super::{
     bridge::map_rvr_execute_error,
@@ -108,14 +108,14 @@ where
             if let Some((inst, _)) = slot {
                 let opcode: VmOpcode = inst.opcode;
                 if opcode == terminate_opcode {
-                    NO_CHIP
+                    u32::MAX
                 } else if let Some(&executor_idx) = inventory.instruction_lookup.get(&opcode) {
                     executor_idx_to_air_idx[executor_idx as usize] as u32
                 } else {
-                    NO_CHIP
+                    u32::MAX
                 }
             } else {
-                NO_CHIP
+                u32::MAX
             }
         })
         .collect()

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -3,9 +3,7 @@
 
 use std::{ffi::c_void, sync::Arc};
 
-use openvm_instructions::{
-    exe::VmExe, riscv::RV32_MEMORY_AS, LocalOpcode, SystemOpcode, VmOpcode, DEFERRAL_AS,
-};
+use openvm_instructions::{exe::VmExe, riscv::RV32_MEMORY_AS, DEFERRAL_AS};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::ExtensionRegistry;
@@ -26,8 +24,7 @@ use crate::{
             },
             MeteredCtx,
         },
-        ExecutionError, ExecutorInventory, Streams, SystemConfig, VmState, BOUNDARY_AIR_ID,
-        MERKLE_AIR_ID,
+        ExecutionError, Streams, SystemConfig, VmState, BOUNDARY_AIR_ID, MERKLE_AIR_ID,
     },
     system::memory::{
         merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory, CHUNK as MERKLE_CHUNK,
@@ -89,37 +86,6 @@ impl TracerPayload for MeteredTracerData {
 }
 
 pub type MeteredTracer = TracerPtr<MeteredTracerData>;
-
-// ── Chip mapping ─────────────────────────────────────────────────────────────
-
-pub fn build_pc_to_chip<F, E>(
-    exe: &VmExe<F>,
-    inventory: &ExecutorInventory<E>,
-    executor_idx_to_air_idx: &[usize],
-) -> Vec<u32>
-where
-    F: PrimeField32,
-{
-    let terminate_opcode = SystemOpcode::TERMINATE.global_opcode();
-    exe.program
-        .instructions_and_debug_infos
-        .iter()
-        .map(|slot| {
-            if let Some((inst, _)) = slot {
-                let opcode: VmOpcode = inst.opcode;
-                if opcode == terminate_opcode {
-                    u32::MAX
-                } else if let Some(&executor_idx) = inventory.instruction_lookup.get(&opcode) {
-                    executor_idx_to_air_idx[executor_idx as usize] as u32
-                } else {
-                    u32::MAX
-                }
-            } else {
-                u32::MAX
-            }
-        })
-        .collect()
-}
 
 // ── Segmentation runtime ─────────────────────────────────────────────────────
 

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -12,15 +12,15 @@ pub mod pure;
 pub mod state;
 
 pub use compile::{
-    compile, compile_metered, compile_metered_cost, load_compiled_from_path, ChipMapping,
-    CompileError, RvrCompiled,
+    build_pc_to_chip, compile, compile_metered, compile_metered_cost, load_compiled_from_path,
+    ChipMapping, CompileError, RvrCompiled,
 };
 pub use debug::{default_addr2line_cmd, GuestDebugMap};
 pub use execute::{
     build_callbacks, execute, execute_metered, execute_metered_cost, register_openvm_callbacks,
     rv_execute, ExecuteError,
 };
-pub use metered::{build_pc_to_chip, RvrMeteredInstance};
+pub use metered::RvrMeteredInstance;
 pub use metered_cost::{
     MeteredCostData, MeteredCostMeter, PureTracer, PureTracerData, RvrMeteredCostInstance,
     RvrMeteredCostResult,

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -34,7 +34,7 @@ use openvm_stark_backend::{
 };
 use p3_baby_bear::BabyBear;
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::{ExtensionRegistry, NO_CHIP};
+use rvr_openvm_lift::ExtensionRegistry;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{info_span, instrument};
@@ -264,7 +264,10 @@ where
     F: PrimeField32,
     VC: VmExecutionConfig<F>,
 {
-    fn build_rvr_extensions(&self, executor_idx_to_air_idx: &[usize]) -> ExtensionRegistry<F> {
+    fn build_rvr_extensions(
+        &self,
+        executor_idx_to_air_idx: Option<&[usize]>,
+    ) -> ExtensionRegistry<F> {
         self.config.create_rvr_extensions(executor_idx_to_air_idx)
     }
 }
@@ -277,14 +280,7 @@ where
     VC::Executor: Executor<F>,
 {
     pub fn rvr_instance(&self, exe: &VmExe<F>) -> Result<RvrPureInstance<F>, StaticProgramError> {
-        // Pure execution does not consult air indices, so we hand the extension
-        // registry a placeholder filled with `NO_CHIP` sentinels sized to cover
-        // every executor.
-        // TODO: Drop this placeholder by making `RvrExtensionCtx` take an
-        // `Option<Vec<usize>>` (or be generic over a trait/value) so pure
-        // execution can avoid passing `executor_idx_to_air_idx` altogether.
-        let executor_idx_to_air_idx = vec![NO_CHIP as usize; self.inventory.executors.len()];
-        let extensions = self.build_rvr_extensions(&executor_idx_to_air_idx);
+        let extensions = self.build_rvr_extensions(None);
         let compiled = compile(exe, &extensions).map_err(map_rvr_compile_error)?;
 
         Ok(RvrPureInstance {
@@ -396,7 +392,7 @@ where
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
     ) -> Result<RvrMeteredInstance<F>, StaticProgramError> {
-        let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+        let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
         let chips = ChipMapping {
             pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx),
             chip_widths: None,
@@ -426,7 +422,7 @@ where
         executor_idx_to_air_idx: &[usize],
         widths: &[usize],
     ) -> Result<RvrMeteredCostInstance<F>, StaticProgramError> {
-        let extensions = self.build_rvr_extensions(executor_idx_to_air_idx);
+        let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
         let widths: Vec<u64> = widths.iter().map(|&w| w as u64).collect();
         let chips = ChipMapping {
             pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx),

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -394,7 +394,8 @@ where
     ) -> Result<RvrMeteredInstance<F>, StaticProgramError> {
         let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
         let chips = ChipMapping {
-            pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx),
+            pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx)
+                .map_err(map_rvr_compile_error)?,
             chip_widths: None,
         };
         let compiled = compile_metered(exe, &extensions, &chips).map_err(map_rvr_compile_error)?;
@@ -425,7 +426,8 @@ where
         let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
         let widths: Vec<u64> = widths.iter().map(|&w| w as u64).collect();
         let chips = ChipMapping {
-            pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx),
+            pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx)
+                .map_err(map_rvr_compile_error)?,
             chip_widths: Some(widths.clone()),
         };
         let compiled =

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -222,7 +222,10 @@ impl<F: PrimeField32> VmExecutionConfig<F> for SystemConfig {
     }
 
     #[cfg(feature = "rvr")]
-    fn create_rvr_extensions(&self, _air_idx: &[usize]) -> rvr_openvm_lift::ExtensionRegistry<F> {
+    fn create_rvr_extensions(
+        &self,
+        _air_idx: Option<&[usize]>,
+    ) -> rvr_openvm_lift::ExtensionRegistry<F> {
         rvr_openvm_lift::ExtensionRegistry::new()
     }
 }

--- a/extensions/algebra/circuit/src/extension/fp2.rs
+++ b/extensions/algebra/circuit/src/extension/fp2.rs
@@ -75,7 +75,7 @@ impl Fp2Extension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Fp2Extension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: &RvrExtensionCtx) {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
         let fp2_moduli = self
             .supported_moduli
             .iter()

--- a/extensions/algebra/circuit/src/extension/modular.rs
+++ b/extensions/algebra/circuit/src/extension/modular.rs
@@ -68,7 +68,7 @@ impl ModularExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for ModularExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: &RvrExtensionCtx) {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
         registry.register(rvr_openvm_ext_algebra::ModularRvrExtension::new(
             self.supported_moduli.clone(),
         ));

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -136,15 +136,11 @@ pub struct Fp2RvrExtension {
 }
 
 impl Fp2RvrExtension {
-    pub fn new_pure(fp2_moduli: Vec<BigUint>) -> Self {
+    pub fn new(fp2_moduli: Vec<BigUint>) -> Self {
         Self {
             fp2_moduli: make_moduli(fp2_moduli),
             staticlib_path: default_fp2_staticlib_path(),
         }
-    }
-
-    pub fn new(fp2_moduli: Vec<BigUint>) -> Self {
-        Self::new_pure(fp2_moduli)
     }
 }
 

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -282,18 +282,11 @@ pub struct ModularRvrExtension {
 }
 
 impl ModularRvrExtension {
-    /// Pure-mode constructor; equivalent to [`Self::new`] today (chip indices
-    /// are unused by this extension).
-    pub fn new_pure(moduli: Vec<BigUint>) -> Self {
+    pub fn new(moduli: Vec<BigUint>) -> Self {
         Self {
             moduli: make_moduli(moduli),
             staticlib_path: default_modular_staticlib_path(),
         }
-    }
-
-    /// Standard constructor.
-    pub fn new(moduli: Vec<BigUint>) -> Self {
-        Self::new_pure(moduli)
     }
 }
 

--- a/extensions/bigint/circuit/src/extension/mod.rs
+++ b/extensions/bigint/circuit/src/extension/mod.rs
@@ -79,7 +79,7 @@ impl<F: PrimeField32> VmRvrExtension<F> for Int256 {
     fn extend_rvr(
         &self,
         registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
-        ctx: &rvr_openvm_lift::RvrExtensionCtx,
+        ctx: Option<&rvr_openvm_lift::RvrExtensionCtx>,
     ) {
         let ext = rvr_openvm_ext_bigint::Int256Extension::new(ctx)
             .expect("failed to construct rvr Int256Extension");

--- a/extensions/bigint/rvr/src/lib.rs
+++ b/extensions/bigint/rvr/src/lib.rs
@@ -99,7 +99,7 @@ pub struct Int256AluInstr {
     /// instruction is one row already counted by the per-block chip update
     /// emitted at block entry), kept on the IR for parity with other
     /// extensions and future trace-chip use.
-    pub chip_idx: AirIndex,
+    pub chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for Int256AluInstr {
@@ -140,7 +140,7 @@ pub struct Int256BranchEqInstr {
     /// If true, branch on *not* equal (BNE); otherwise branch on equal (BEQ).
     pub is_ne: bool,
     /// Chip index for metering. See [`Int256AluInstr::chip_idx`].
-    pub chip_idx: AirIndex,
+    pub chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for Int256BranchEqInstr {
@@ -194,7 +194,7 @@ pub struct Int256BranchLtInstr {
     /// The branch-less-than variant (selects the FFI function at codegen time).
     pub op: Int256BranchLtOp,
     /// Chip index for metering. See [`Int256AluInstr::chip_idx`].
-    pub chip_idx: AirIndex,
+    pub chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for Int256BranchLtInstr {
@@ -236,12 +236,12 @@ impl ExtInstr for Int256BranchLtInstr {
 
 /// The Int256 extension. Register this with the `ExtensionRegistry`.
 pub struct Int256Extension {
-    base_alu_chip_idx: AirIndex,
-    shift_chip_idx: AirIndex,
-    less_than_chip_idx: AirIndex,
-    mul_chip_idx: AirIndex,
-    branch_eq_chip_idx: AirIndex,
-    branch_lt_chip_idx: AirIndex,
+    base_alu_chip_idx: Option<AirIndex>,
+    shift_chip_idx: Option<AirIndex>,
+    less_than_chip_idx: Option<AirIndex>,
+    mul_chip_idx: Option<AirIndex>,
+    branch_eq_chip_idx: Option<AirIndex>,
+    branch_lt_chip_idx: Option<AirIndex>,
     staticlib_path: PathBuf,
 }
 
@@ -268,7 +268,7 @@ impl Int256Extension {
     }
 
     /// Map a global opcode to the chip index for that operation.
-    fn chip_idx_for_opcode(&self, opcode: usize) -> AirIndex {
+    fn chip_idx_for_opcode(&self, opcode: usize) -> Option<AirIndex> {
         let base_alu_start = Rv32BaseAlu256Opcode::CLASS_OFFSET;
         let shift_start = Rv32Shift256Opcode::CLASS_OFFSET;
         let lt_start = Rv32LessThan256Opcode::CLASS_OFFSET;

--- a/extensions/bigint/rvr/src/lib.rs
+++ b/extensions/bigint/rvr/src/lib.rs
@@ -18,7 +18,7 @@ use openvm_rv32im_transpiler::{
 };
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg, Terminator};
-use rvr_openvm_lift::{ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
+use rvr_openvm_lift::{opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx};
 use strum::EnumCount;
 
 // ── ALU / branch opcode enums ───────────────────────────────────────────────
@@ -99,7 +99,7 @@ pub struct Int256AluInstr {
     /// instruction is one row already counted by the per-block chip update
     /// emitted at block entry), kept on the IR for parity with other
     /// extensions and future trace-chip use.
-    pub chip_idx: u32,
+    pub chip_idx: AirIndex,
 }
 
 impl ExtInstr for Int256AluInstr {
@@ -140,7 +140,7 @@ pub struct Int256BranchEqInstr {
     /// If true, branch on *not* equal (BNE); otherwise branch on equal (BEQ).
     pub is_ne: bool,
     /// Chip index for metering. See [`Int256AluInstr::chip_idx`].
-    pub chip_idx: u32,
+    pub chip_idx: AirIndex,
 }
 
 impl ExtInstr for Int256BranchEqInstr {
@@ -194,7 +194,7 @@ pub struct Int256BranchLtInstr {
     /// The branch-less-than variant (selects the FFI function at codegen time).
     pub op: Int256BranchLtOp,
     /// Chip index for metering. See [`Int256AluInstr::chip_idx`].
-    pub chip_idx: u32,
+    pub chip_idx: AirIndex,
 }
 
 impl ExtInstr for Int256BranchLtInstr {
@@ -236,46 +236,25 @@ impl ExtInstr for Int256BranchLtInstr {
 
 /// The Int256 extension. Register this with the `ExtensionRegistry`.
 pub struct Int256Extension {
-    base_alu_chip_idx: u32,
-    shift_chip_idx: u32,
-    less_than_chip_idx: u32,
-    mul_chip_idx: u32,
-    branch_eq_chip_idx: u32,
-    branch_lt_chip_idx: u32,
+    base_alu_chip_idx: AirIndex,
+    shift_chip_idx: AirIndex,
+    less_than_chip_idx: AirIndex,
+    mul_chip_idx: AirIndex,
+    branch_eq_chip_idx: AirIndex,
+    branch_lt_chip_idx: AirIndex,
     staticlib_path: PathBuf,
 }
 
 impl Int256Extension {
-    /// Create a `Int256Extension` for pure execution where chip indices
-    /// don't matter (trace_chip is a no-op in pure mode).
-    pub fn new_pure() -> Self {
-        Self {
-            base_alu_chip_idx: NO_CHIP,
-            shift_chip_idx: NO_CHIP,
-            less_than_chip_idx: NO_CHIP,
-            mul_chip_idx: NO_CHIP,
-            branch_eq_chip_idx: NO_CHIP,
-            branch_lt_chip_idx: NO_CHIP,
-            staticlib_path: default_staticlib_path(),
-        }
-    }
-
-    /// Create a new `Int256Extension`, resolving chip indices from the VM config.
-    pub fn new(ctx: &RvrExtensionCtx) -> Result<Self, ExtensionError> {
-        let base_alu_chip_idx =
-            ctx.require_opcode_air_idx(Rv32BaseAlu256Opcode(BaseAluOpcode::ADD).global_opcode())?;
-        let shift_chip_idx =
-            ctx.require_opcode_air_idx(Rv32Shift256Opcode(ShiftOpcode::SLL).global_opcode())?;
-        let less_than_chip_idx =
-            ctx.require_opcode_air_idx(Rv32LessThan256Opcode(LessThanOpcode::SLT).global_opcode())?;
-        let mul_chip_idx =
-            ctx.require_opcode_air_idx(Rv32Mul256Opcode(MulOpcode::MUL).global_opcode())?;
-        let branch_eq_chip_idx = ctx.require_opcode_air_idx(
-            Rv32BranchEqual256Opcode(BranchEqualOpcode::BEQ).global_opcode(),
-        )?;
-        let branch_lt_chip_idx = ctx.require_opcode_air_idx(
-            Rv32BranchLessThan256Opcode(BranchLessThanOpcode::BLT).global_opcode(),
-        )?;
+    pub fn new(ctx: Option<&RvrExtensionCtx>) -> Result<Self, ExtensionError> {
+        let base_alu_chip_idx = opcode_air_idx(ctx, Rv32BaseAlu256Opcode(BaseAluOpcode::ADD))?;
+        let shift_chip_idx = opcode_air_idx(ctx, Rv32Shift256Opcode(ShiftOpcode::SLL))?;
+        let less_than_chip_idx = opcode_air_idx(ctx, Rv32LessThan256Opcode(LessThanOpcode::SLT))?;
+        let mul_chip_idx = opcode_air_idx(ctx, Rv32Mul256Opcode(MulOpcode::MUL))?;
+        let branch_eq_chip_idx =
+            opcode_air_idx(ctx, Rv32BranchEqual256Opcode(BranchEqualOpcode::BEQ))?;
+        let branch_lt_chip_idx =
+            opcode_air_idx(ctx, Rv32BranchLessThan256Opcode(BranchLessThanOpcode::BLT))?;
 
         Ok(Self {
             base_alu_chip_idx,
@@ -289,7 +268,7 @@ impl Int256Extension {
     }
 
     /// Map a global opcode to the chip index for that operation.
-    fn chip_idx_for_opcode(&self, opcode: usize) -> u32 {
+    fn chip_idx_for_opcode(&self, opcode: usize) -> AirIndex {
         let base_alu_start = Rv32BaseAlu256Opcode::CLASS_OFFSET;
         let shift_start = Rv32Shift256Opcode::CLASS_OFFSET;
         let lt_start = Rv32LessThan256Opcode::CLASS_OFFSET;

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -73,7 +73,7 @@ pub struct DeferralExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: &RvrExtensionCtx) {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: Option<&RvrExtensionCtx>) {
         let hash = make_deferral_hash::<F>();
         let ext = DeferralRvrExtension::new(ctx, self.fns.clone(), hash)
             .expect("failed to construct rvr DeferralRvrExtension");

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -18,7 +18,8 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_BYTES};
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx,
+    air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
+    RvrExtensionCtx,
 };
 
 /// `(def_idx, output_raw) → output_commit` hasher registered by the host.
@@ -43,7 +44,7 @@ pub struct DeferralCallInstr {
     pub rd_reg: Reg,
     pub rs_reg: Reg,
     pub def_idx: u32,
-    pub poseidon2_chip_idx: AirIndex,
+    pub poseidon2_chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for DeferralCallInstr {
@@ -54,7 +55,7 @@ impl ExtInstr for DeferralCallInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let rd = ctx.read_reg(self.rd_reg);
         let rs = ctx.read_reg(self.rs_reg);
-        let poseidon2 = self.poseidon2_chip_idx.to_c_chip_idx();
+        let poseidon2 = air_index_to_c(self.poseidon2_chip_idx);
         ctx.write_line(&format!(
             "rvr_ext_deferral_call(state, {rd}, {rs}, {}u, {poseidon2}u);",
             self.def_idx
@@ -76,8 +77,8 @@ pub struct DeferralOutputInstr {
     pub rd_reg: Reg,
     pub rs_reg: Reg,
     pub def_idx: u32,
-    pub output_chip_idx: AirIndex,
-    pub poseidon2_chip_idx: AirIndex,
+    pub output_chip_idx: Option<AirIndex>,
+    pub poseidon2_chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for DeferralOutputInstr {
@@ -88,8 +89,8 @@ impl ExtInstr for DeferralOutputInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let rd = ctx.read_reg(self.rd_reg);
         let rs = ctx.read_reg(self.rs_reg);
-        let output = self.output_chip_idx.to_c_chip_idx();
-        let poseidon2 = self.poseidon2_chip_idx.to_c_chip_idx();
+        let output = air_index_to_c(self.output_chip_idx);
+        let poseidon2 = air_index_to_c(self.poseidon2_chip_idx);
         ctx.write_line(&format!(
             "rvr_ext_deferral_output(state, {rd}, {rs}, {}u, {output}u, {poseidon2}u);",
             self.def_idx
@@ -110,9 +111,9 @@ impl ExtInstr for DeferralOutputInstr {
 /// The Deferral extension (CALL + OUTPUT opcodes).
 pub struct DeferralRvrExtension {
     #[allow(dead_code)]
-    call_chip_idx: AirIndex,
-    output_chip_idx: AirIndex,
-    poseidon2_chip_idx: AirIndex,
+    call_chip_idx: Option<AirIndex>,
+    output_chip_idx: Option<AirIndex>,
+    poseidon2_chip_idx: Option<AirIndex>,
     staticlib_path: PathBuf,
     deferral_ctx: DeferralCtx,
 }
@@ -128,7 +129,7 @@ impl DeferralRvrExtension {
         // Poseidon2 periphery chip: in extend_circuit, the hasher is added
         // right before the CALL chip. Due to reverse ordering of AIR indices,
         // poseidon2_air_idx = call_air_idx + 1.
-        let poseidon2_chip_idx = call_chip_idx.next();
+        let poseidon2_chip_idx = call_chip_idx.map(AirIndex::next);
 
         Ok(Self {
             call_chip_idx,

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -17,7 +17,9 @@ use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_BYTES};
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
-use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
+use rvr_openvm_lift::{
+    decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx,
+};
 
 /// `(def_idx, output_raw) → output_commit` hasher registered by the host.
 pub type DeferralHashFn = Arc<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
@@ -41,7 +43,7 @@ pub struct DeferralCallInstr {
     pub rd_reg: Reg,
     pub rs_reg: Reg,
     pub def_idx: u32,
-    pub poseidon2_chip_idx: u32,
+    pub poseidon2_chip_idx: AirIndex,
 }
 
 impl ExtInstr for DeferralCallInstr {
@@ -52,9 +54,10 @@ impl ExtInstr for DeferralCallInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let rd = ctx.read_reg(self.rd_reg);
         let rs = ctx.read_reg(self.rs_reg);
+        let poseidon2 = self.poseidon2_chip_idx.to_c_chip_idx();
         ctx.write_line(&format!(
-            "rvr_ext_deferral_call(state, {rd}, {rs}, {}u, {}u);",
-            self.def_idx, self.poseidon2_chip_idx
+            "rvr_ext_deferral_call(state, {rd}, {rs}, {}u, {poseidon2}u);",
+            self.def_idx
         ));
     }
 
@@ -73,8 +76,8 @@ pub struct DeferralOutputInstr {
     pub rd_reg: Reg,
     pub rs_reg: Reg,
     pub def_idx: u32,
-    pub output_chip_idx: u32,
-    pub poseidon2_chip_idx: u32,
+    pub output_chip_idx: AirIndex,
+    pub poseidon2_chip_idx: AirIndex,
 }
 
 impl ExtInstr for DeferralOutputInstr {
@@ -85,9 +88,11 @@ impl ExtInstr for DeferralOutputInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let rd = ctx.read_reg(self.rd_reg);
         let rs = ctx.read_reg(self.rs_reg);
+        let output = self.output_chip_idx.to_c_chip_idx();
+        let poseidon2 = self.poseidon2_chip_idx.to_c_chip_idx();
         ctx.write_line(&format!(
-            "rvr_ext_deferral_output(state, {rd}, {rs}, {}u, {}u, {}u);",
-            self.def_idx, self.output_chip_idx, self.poseidon2_chip_idx
+            "rvr_ext_deferral_output(state, {rd}, {rs}, {}u, {output}u, {poseidon2}u);",
+            self.def_idx
         ));
     }
 
@@ -105,42 +110,25 @@ impl ExtInstr for DeferralOutputInstr {
 /// The Deferral extension (CALL + OUTPUT opcodes).
 pub struct DeferralRvrExtension {
     #[allow(dead_code)]
-    call_chip_idx: u32,
-    output_chip_idx: u32,
-    poseidon2_chip_idx: u32,
+    call_chip_idx: AirIndex,
+    output_chip_idx: AirIndex,
+    poseidon2_chip_idx: AirIndex,
     staticlib_path: PathBuf,
     deferral_ctx: DeferralCtx,
 }
 
 impl DeferralRvrExtension {
-    /// Create for pure execution (chip indices don't matter).
-    pub fn new_pure(fns: Vec<Arc<DeferralFn>>, hash: DeferralHashFn) -> Self {
-        Self {
-            call_chip_idx: NO_CHIP,
-            output_chip_idx: NO_CHIP,
-            poseidon2_chip_idx: NO_CHIP,
-            staticlib_path: default_staticlib_path(),
-            deferral_ctx: DeferralCtx::new(fns, hash),
-        }
-    }
-
-    /// Create with chip indices resolved from the VM config.
     pub fn new(
-        ctx: &RvrExtensionCtx,
+        ctx: Option<&RvrExtensionCtx>,
         fns: Vec<Arc<DeferralFn>>,
         hash: DeferralHashFn,
     ) -> Result<Self, ExtensionError> {
-        let call_chip_idx = ctx.require_opcode_air_idx(DeferralOpcode::CALL.global_opcode())?;
-        let output_chip_idx = ctx.require_opcode_air_idx(DeferralOpcode::OUTPUT.global_opcode())?;
+        let call_chip_idx = opcode_air_idx(ctx, DeferralOpcode::CALL)?;
+        let output_chip_idx = opcode_air_idx(ctx, DeferralOpcode::OUTPUT)?;
         // Poseidon2 periphery chip: in extend_circuit, the hasher is added
         // right before the CALL chip. Due to reverse ordering of AIR indices,
-        // poseidon2_air_idx = call_air_idx + 1. Stay NO_CHIP-safe in case
-        // pure execution sneaks a NO_CHIP `call_chip_idx` through here.
-        let poseidon2_chip_idx = if call_chip_idx == NO_CHIP {
-            NO_CHIP
-        } else {
-            call_chip_idx + 1
-        };
+        // poseidon2_air_idx = call_air_idx + 1.
+        let poseidon2_chip_idx = call_chip_idx.next();
 
         Ok(Self {
             call_chip_idx,

--- a/extensions/ecc/circuit/src/extension/weierstrass.rs
+++ b/extensions/ecc/circuit/src/extension/weierstrass.rs
@@ -93,7 +93,7 @@ impl WeierstrassExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for WeierstrassExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: &RvrExtensionCtx) {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
         let struct_names = self
             .supported_curves
             .iter()

--- a/extensions/ecc/rvr/src/lib.rs
+++ b/extensions/ecc/rvr/src/lib.rs
@@ -166,15 +166,6 @@ impl EccExtension {
         }
     }
 
-    /// Create for pure execution (chip indices are unused).
-    pub fn new_pure(curves: Vec<u32>) -> Self {
-        Self::from_curve_ids(curves, default_staticlib_path())
-    }
-
-    pub fn new_pure_from_struct_names(struct_names: Vec<String>) -> Self {
-        Self::from_struct_names(struct_names, default_staticlib_path())
-    }
-
     pub fn new(curves_info: Vec<u32>) -> Self {
         Self::from_curve_ids(curves_info, default_staticlib_path())
     }

--- a/extensions/keccak256/circuit/src/extension/mod.rs
+++ b/extensions/keccak256/circuit/src/extension/mod.rs
@@ -126,7 +126,7 @@ impl<F: PrimeField32> VmRvrExtension<F> for Keccak256 {
     fn extend_rvr(
         &self,
         registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
-        ctx: &rvr_openvm_lift::RvrExtensionCtx,
+        ctx: Option<&rvr_openvm_lift::RvrExtensionCtx>,
     ) {
         let ext = rvr_openvm_ext_keccak::KeccakExtension::new(ctx)
             .expect("failed to construct rvr KeccakExtension");

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -12,7 +12,8 @@ use openvm_keccak256_transpiler::{KeccakfOpcode, XorinOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx,
+    air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
+    RvrExtensionCtx,
 };
 
 /// keccak-f[1600]: read 200 bytes via `buffer_ptr_reg`, permute in place.
@@ -20,9 +21,9 @@ use rvr_openvm_lift::{
 pub struct KeccakfInstr {
     pub buffer_ptr_reg: Reg,
     /// KeccakfOp chip (1 row per instruction).
-    pub op_chip_idx: AirIndex,
+    pub op_chip_idx: Option<AirIndex>,
     /// KeccakfPerm chip (24 rows per instruction).
-    pub perm_chip_idx: AirIndex,
+    pub perm_chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for KeccakfInstr {
@@ -32,8 +33,8 @@ impl ExtInstr for KeccakfInstr {
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let buf = ctx.read_reg(self.buffer_ptr_reg);
-        let op = self.op_chip_idx.to_c_chip_idx();
-        let perm = self.perm_chip_idx.to_c_chip_idx();
+        let op = air_index_to_c(self.op_chip_idx);
+        let perm = air_index_to_c(self.perm_chip_idx);
         ctx.write_line(&format!("rvr_ext_keccakf(state, {buf}, {op}u, {perm}u);"));
     }
 
@@ -53,7 +54,7 @@ pub struct XorinInstr {
     pub input_ptr_reg: Reg,
     pub len_reg: Reg,
     /// Xorin chip (1 row per instruction).
-    pub chip_idx: AirIndex,
+    pub chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for XorinInstr {
@@ -65,7 +66,7 @@ impl ExtInstr for XorinInstr {
         let buf_ptr = ctx.read_reg(self.buffer_ptr_reg);
         let input = ctx.read_reg(self.input_ptr_reg);
         let len = ctx.read_reg(self.len_reg);
-        let chip = self.chip_idx.to_c_chip_idx();
+        let chip = air_index_to_c(self.chip_idx);
         ctx.write_line(&format!(
             "rvr_ext_xorin(state, {buf_ptr}, {input}, {len}, {chip}u);"
         ));
@@ -82,9 +83,9 @@ impl ExtInstr for XorinInstr {
 
 /// Keccak-256 extension. Register with the `ExtensionRegistry`.
 pub struct KeccakExtension {
-    xorin_chip_idx: AirIndex,
-    keccakf_op_chip_idx: AirIndex,
-    keccakf_perm_chip_idx: AirIndex,
+    xorin_chip_idx: Option<AirIndex>,
+    keccakf_op_chip_idx: Option<AirIndex>,
+    keccakf_perm_chip_idx: Option<AirIndex>,
     /// Path to the keccak-ffi staticlib that exports `rvr_keccak_f1600`.
     asm_staticlib_path: PathBuf,
 }
@@ -96,7 +97,7 @@ impl KeccakExtension {
         // KeccakfPermAir is inserted right before KeccakfOpAir in
         // Keccak256Rv32::extend_circuit, and the chip indices are set in
         // reverse order.
-        let keccakf_perm_chip_idx = keccakf_op_chip_idx.next();
+        let keccakf_perm_chip_idx = keccakf_op_chip_idx.map(AirIndex::next);
 
         Ok(Self {
             xorin_chip_idx,

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -11,16 +11,18 @@ use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_keccak256_transpiler::{KeccakfOpcode, XorinOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
-use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
+use rvr_openvm_lift::{
+    decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx,
+};
 
 /// keccak-f[1600]: read 200 bytes via `buffer_ptr_reg`, permute in place.
 #[derive(Debug, Clone)]
 pub struct KeccakfInstr {
     pub buffer_ptr_reg: Reg,
     /// KeccakfOp chip (1 row per instruction).
-    pub op_chip_idx: u32,
+    pub op_chip_idx: AirIndex,
     /// KeccakfPerm chip (24 rows per instruction).
-    pub perm_chip_idx: u32,
+    pub perm_chip_idx: AirIndex,
 }
 
 impl ExtInstr for KeccakfInstr {
@@ -30,10 +32,9 @@ impl ExtInstr for KeccakfInstr {
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let buf = ctx.read_reg(self.buffer_ptr_reg);
-        ctx.write_line(&format!(
-            "rvr_ext_keccakf(state, {buf}, {}u, {}u);",
-            self.op_chip_idx, self.perm_chip_idx
-        ));
+        let op = self.op_chip_idx.to_c_chip_idx();
+        let perm = self.perm_chip_idx.to_c_chip_idx();
+        ctx.write_line(&format!("rvr_ext_keccakf(state, {buf}, {op}u, {perm}u);"));
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -52,7 +53,7 @@ pub struct XorinInstr {
     pub input_ptr_reg: Reg,
     pub len_reg: Reg,
     /// Xorin chip (1 row per instruction).
-    pub chip_idx: u32,
+    pub chip_idx: AirIndex,
 }
 
 impl ExtInstr for XorinInstr {
@@ -64,9 +65,9 @@ impl ExtInstr for XorinInstr {
         let buf_ptr = ctx.read_reg(self.buffer_ptr_reg);
         let input = ctx.read_reg(self.input_ptr_reg);
         let len = ctx.read_reg(self.len_reg);
+        let chip = self.chip_idx.to_c_chip_idx();
         ctx.write_line(&format!(
-            "rvr_ext_xorin(state, {buf_ptr}, {input}, {len}, {}u);",
-            self.chip_idx
+            "rvr_ext_xorin(state, {buf_ptr}, {input}, {len}, {chip}u);"
         ));
     }
 
@@ -81,37 +82,21 @@ impl ExtInstr for XorinInstr {
 
 /// Keccak-256 extension. Register with the `ExtensionRegistry`.
 pub struct KeccakExtension {
-    xorin_chip_idx: u32,
-    keccakf_op_chip_idx: u32,
-    keccakf_perm_chip_idx: u32,
+    xorin_chip_idx: AirIndex,
+    keccakf_op_chip_idx: AirIndex,
+    keccakf_perm_chip_idx: AirIndex,
     /// Path to the keccak-ffi staticlib that exports `rvr_keccak_f1600`.
     asm_staticlib_path: PathBuf,
 }
 
 impl KeccakExtension {
-    /// Pure-mode constructor; chip indices are unused (`trace_chip` is no-op).
-    pub fn new_pure() -> Self {
-        Self {
-            xorin_chip_idx: NO_CHIP,
-            keccakf_op_chip_idx: NO_CHIP,
-            keccakf_perm_chip_idx: NO_CHIP,
-            asm_staticlib_path: default_staticlib_path(),
-        }
-    }
-
-    /// Resolves chip indices from the VM config.
-    pub fn new(ctx: &RvrExtensionCtx) -> Result<Self, ExtensionError> {
-        let xorin_chip_idx = ctx.require_opcode_air_idx(XorinOpcode::XORIN.global_opcode())?;
-        let keccakf_op_chip_idx =
-            ctx.require_opcode_air_idx(KeccakfOpcode::KECCAKF.global_opcode())?;
+    pub fn new(ctx: Option<&RvrExtensionCtx>) -> Result<Self, ExtensionError> {
+        let xorin_chip_idx = opcode_air_idx(ctx, XorinOpcode::XORIN)?;
+        let keccakf_op_chip_idx = opcode_air_idx(ctx, KeccakfOpcode::KECCAKF)?;
         // KeccakfPermAir is inserted right before KeccakfOpAir in
         // Keccak256Rv32::extend_circuit, and the chip indices are set in
         // reverse order.
-        let keccakf_perm_chip_idx = if keccakf_op_chip_idx == NO_CHIP {
-            NO_CHIP
-        } else {
-            keccakf_op_chip_idx + 1
-        };
+        let keccakf_perm_chip_idx = keccakf_op_chip_idx.next();
 
         Ok(Self {
             xorin_chip_idx,

--- a/extensions/pairing/circuit/src/pairing_extension.rs
+++ b/extensions/pairing/circuit/src/pairing_extension.rs
@@ -70,7 +70,7 @@ pub struct PairingExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for PairingExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: &RvrExtensionCtx) {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
         registry.register(rvr_openvm_ext_pairing::PairingExtension::new());
     }
 }

--- a/extensions/rv32im/circuit/src/extension/mod.rs
+++ b/extensions/rv32im/circuit/src/extension/mod.rs
@@ -84,7 +84,7 @@ impl<F: PrimeField32> VmRvrExtension<F> for Rv32I {}
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Rv32Io {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: &RvrExtensionCtx) {
+    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: Option<&RvrExtensionCtx>) {
         registry
             .register(Rv32IoExtension::new(ctx).expect("Rv32IoExtension chip resolution failed"));
     }

--- a/extensions/rv32im/rvr/src/lib.rs
+++ b/extensions/rv32im/rvr/src/lib.rs
@@ -12,7 +12,8 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ext_ffi_common::AS_PUBLIC_VALUES;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    decode_imm_cg, decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP,
+    decode_imm_cg, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
+    RvrExtensionCtx,
 };
 
 /// HINT_STOREW: pop 4 bytes from the hint stream into `mem[reg[ptr_reg]]`.
@@ -45,7 +46,7 @@ impl ExtInstr for HintStoreWInstr {
 pub struct HintBufferInstr {
     pub ptr_reg: Reg,
     pub num_words_reg: Reg,
-    pub chip_idx: u32,
+    pub chip_idx: AirIndex,
 }
 
 impl ExtInstr for HintBufferInstr {
@@ -56,16 +57,12 @@ impl ExtInstr for HintBufferInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg(self.ptr_reg);
         let n = ctx.read_reg(self.num_words_reg);
-        if self.chip_idx != NO_CHIP {
-            // Block-entry already credits a static +1; emit the runtime
-            // `(n - 1)` correction only when there is more than one row.
-            ctx.write_line(&format!("if ({n} > 1) {{"));
-            ctx.write_line(&format!(
-                "  trace_chip(state, {}u, {n} - 1);",
-                self.chip_idx
-            ));
-            ctx.write_line("}");
-        }
+        // Block-entry already credits a static +1; emit the runtime
+        // `(n - 1)` correction only when there is more than one row.
+        let chip_idx = self.chip_idx.to_c_chip_idx();
+        ctx.write_line(&format!("if ({n} > 1) {{"));
+        ctx.write_line(&format!("  trace_chip(state, {chip_idx}u, {n} - 1);"));
+        ctx.write_line("}");
         ctx.write_line(&format!("if ({n} > 0) {{"));
         ctx.write_line(&format!(
             "  trace_mem_access_u32_range(state, {ptr}, {n}, {RV32_MEMORY_AS}u);"
@@ -113,22 +110,12 @@ impl ExtInstr for RevealInstr {
 /// rvr extension for the rv32im I/O instructions HINT_STOREW, HINT_BUFFER, and
 /// REVEAL.
 pub struct Rv32IoExtension {
-    hint_store_chip_idx: u32,
+    hint_store_chip_idx: AirIndex,
 }
 
 impl Rv32IoExtension {
-    pub fn new_pure() -> Self {
-        Self {
-            hint_store_chip_idx: NO_CHIP,
-        }
-    }
-
-    pub fn new(ctx: &RvrExtensionCtx) -> Result<Self, ExtensionError> {
-        let opcode = Rv32HintStoreOpcode::HINT_STOREW.global_opcode();
-        let hint_store_chip_idx = match ctx.resolve_opcode_air_idx(opcode) {
-            Some(idx) => idx,
-            None => NO_CHIP,
-        };
+    pub fn new(ctx: Option<&RvrExtensionCtx>) -> Result<Self, ExtensionError> {
+        let hint_store_chip_idx = opcode_air_idx(ctx, Rv32HintStoreOpcode::HINT_STOREW)?;
         Ok(Self {
             hint_store_chip_idx,
         })

--- a/extensions/rv32im/rvr/src/lib.rs
+++ b/extensions/rv32im/rvr/src/lib.rs
@@ -12,8 +12,8 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ext_ffi_common::AS_PUBLIC_VALUES;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    decode_imm_cg, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
-    RvrExtensionCtx,
+    air_index_to_c, decode_imm_cg, decode_reg, opcode_air_idx, AirIndex, ExtensionError,
+    RvrExtension, RvrExtensionCtx,
 };
 
 /// HINT_STOREW: pop 4 bytes from the hint stream into `mem[reg[ptr_reg]]`.
@@ -46,7 +46,7 @@ impl ExtInstr for HintStoreWInstr {
 pub struct HintBufferInstr {
     pub ptr_reg: Reg,
     pub num_words_reg: Reg,
-    pub chip_idx: AirIndex,
+    pub chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for HintBufferInstr {
@@ -59,7 +59,7 @@ impl ExtInstr for HintBufferInstr {
         let n = ctx.read_reg(self.num_words_reg);
         // Block-entry already credits a static +1; emit the runtime
         // `(n - 1)` correction only when there is more than one row.
-        let chip_idx = self.chip_idx.to_c_chip_idx();
+        let chip_idx = air_index_to_c(self.chip_idx);
         ctx.write_line(&format!("if ({n} > 1) {{"));
         ctx.write_line(&format!("  trace_chip(state, {chip_idx}u, {n} - 1);"));
         ctx.write_line("}");
@@ -110,7 +110,7 @@ impl ExtInstr for RevealInstr {
 /// rvr extension for the rv32im I/O instructions HINT_STOREW, HINT_BUFFER, and
 /// REVEAL.
 pub struct Rv32IoExtension {
-    hint_store_chip_idx: AirIndex,
+    hint_store_chip_idx: Option<AirIndex>,
 }
 
 impl Rv32IoExtension {

--- a/extensions/sha2/circuit/src/extension/mod.rs
+++ b/extensions/sha2/circuit/src/extension/mod.rs
@@ -122,7 +122,7 @@ impl<F: PrimeField32> VmRvrExtension<F> for Sha2 {
     fn extend_rvr(
         &self,
         registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
-        ctx: &rvr_openvm_lift::RvrExtensionCtx,
+        ctx: Option<&rvr_openvm_lift::RvrExtensionCtx>,
     ) {
         let ext = rvr_openvm_ext_sha2::Sha2Extension::new(ctx)
             .expect("failed to construct rvr Sha2Extension");

--- a/extensions/sha2/rvr/src/lib.rs
+++ b/extensions/sha2/rvr/src/lib.rs
@@ -9,7 +9,9 @@ use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_sha2_transpiler::Rv32Sha2Opcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
-use rvr_openvm_lift::{decode_reg, ExtensionError, RvrExtension, RvrExtensionCtx, NO_CHIP};
+use rvr_openvm_lift::{
+    decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx,
+};
 
 /// IR node for a SHA-256 compress instruction.
 ///
@@ -24,9 +26,9 @@ pub struct Sha256Instr {
     /// Register index holding input pointer (message block).
     pub input_ptr_reg: Reg,
     /// SHA-256 main chip AIR index (1 row per instruction).
-    pub main_chip_idx: u32,
+    pub main_chip_idx: AirIndex,
     /// SHA-256 block hasher chip AIR index (ROWS_PER_BLOCK rows per instruction).
-    pub block_hasher_chip_idx: u32,
+    pub block_hasher_chip_idx: AirIndex,
 }
 
 impl ExtInstr for Sha256Instr {
@@ -38,9 +40,10 @@ impl ExtInstr for Sha256Instr {
         let dst = ctx.read_reg(self.dst_ptr_reg);
         let st = ctx.read_reg(self.state_ptr_reg);
         let inp = ctx.read_reg(self.input_ptr_reg);
+        let main = self.main_chip_idx.to_c_chip_idx();
+        let block = self.block_hasher_chip_idx.to_c_chip_idx();
         ctx.write_line(&format!(
-            "rvr_ext_sha256(state, {dst}, {st}, {inp}, {}u, {}u);",
-            self.main_chip_idx, self.block_hasher_chip_idx
+            "rvr_ext_sha256(state, {dst}, {st}, {inp}, {main}u, {block}u);"
         ));
     }
 
@@ -66,9 +69,9 @@ pub struct Sha512Instr {
     /// Register index holding input pointer (message block).
     pub input_ptr_reg: Reg,
     /// SHA-512 main chip AIR index (1 row per instruction).
-    pub main_chip_idx: u32,
+    pub main_chip_idx: AirIndex,
     /// SHA-512 block hasher chip AIR index (ROWS_PER_BLOCK rows per instruction).
-    pub block_hasher_chip_idx: u32,
+    pub block_hasher_chip_idx: AirIndex,
 }
 
 impl ExtInstr for Sha512Instr {
@@ -80,9 +83,10 @@ impl ExtInstr for Sha512Instr {
         let dst = ctx.read_reg(self.dst_ptr_reg);
         let st = ctx.read_reg(self.state_ptr_reg);
         let inp = ctx.read_reg(self.input_ptr_reg);
+        let main = self.main_chip_idx.to_c_chip_idx();
+        let block = self.block_hasher_chip_idx.to_c_chip_idx();
         ctx.write_line(&format!(
-            "rvr_ext_sha512(state, {dst}, {st}, {inp}, {}u, {}u);",
-            self.main_chip_idx, self.block_hasher_chip_idx
+            "rvr_ext_sha512(state, {dst}, {st}, {inp}, {main}u, {block}u);"
         ));
     }
 
@@ -98,52 +102,23 @@ impl ExtInstr for Sha512Instr {
 /// The SHA-2 extension (SHA-256 + SHA-512 opcodes).
 /// Register this with the `ExtensionRegistry`.
 pub struct Sha2Extension {
-    sha256_main_chip_idx: u32,
-    sha256_block_hasher_chip_idx: u32,
-    sha512_main_chip_idx: u32,
-    sha512_block_hasher_chip_idx: u32,
+    sha256_main_chip_idx: AirIndex,
+    sha256_block_hasher_chip_idx: AirIndex,
+    sha512_main_chip_idx: AirIndex,
+    sha512_block_hasher_chip_idx: AirIndex,
     staticlib_path: PathBuf,
 }
 
 impl Sha2Extension {
-    /// Create a `Sha2Extension` for pure execution where chip indices
-    /// don't matter (trace_chip is a no-op in pure mode).
-    pub fn new_pure() -> Self {
-        Self {
-            sha256_main_chip_idx: NO_CHIP,
-            sha256_block_hasher_chip_idx: NO_CHIP,
-            sha512_main_chip_idx: NO_CHIP,
-            sha512_block_hasher_chip_idx: NO_CHIP,
-            staticlib_path: default_staticlib_path(),
-        }
-    }
-
-    /// Create a new `Sha2Extension`, resolving chip indices from the VM config.
-    pub fn new(ctx: &RvrExtensionCtx) -> Result<Self, ExtensionError> {
-        // SHA-256 main chip AIR index
-        let sha256_main_chip_idx =
-            ctx.require_opcode_air_idx(Rv32Sha2Opcode::SHA256.global_opcode())?;
-
+    pub fn new(ctx: Option<&RvrExtensionCtx>) -> Result<Self, ExtensionError> {
+        let sha256_main_chip_idx = opcode_air_idx(ctx, Rv32Sha2Opcode::SHA256)?;
         // SHA-256 block hasher: in extend_circuit, the block hasher is added right before
         // the main chip. Due to reverse ordering of AIR indices,
-        // block_hasher_air_idx = main_air_idx + 1. Stay NO_CHIP-safe in case
-        // pure execution sneaks a NO_CHIP `main_chip_idx` through here.
-        let sha256_block_hasher_chip_idx = if sha256_main_chip_idx == NO_CHIP {
-            NO_CHIP
-        } else {
-            sha256_main_chip_idx + 1
-        };
+        // block_hasher_air_idx = main_air_idx + 1.
+        let sha256_block_hasher_chip_idx = sha256_main_chip_idx.next();
 
-        // SHA-512 main chip AIR index
-        let sha512_main_chip_idx =
-            ctx.require_opcode_air_idx(Rv32Sha2Opcode::SHA512.global_opcode())?;
-
-        // SHA-512 block hasher: same pattern as SHA-256.
-        let sha512_block_hasher_chip_idx = if sha512_main_chip_idx == NO_CHIP {
-            NO_CHIP
-        } else {
-            sha512_main_chip_idx + 1
-        };
+        let sha512_main_chip_idx = opcode_air_idx(ctx, Rv32Sha2Opcode::SHA512)?;
+        let sha512_block_hasher_chip_idx = sha512_main_chip_idx.next();
 
         Ok(Self {
             sha256_main_chip_idx,

--- a/extensions/sha2/rvr/src/lib.rs
+++ b/extensions/sha2/rvr/src/lib.rs
@@ -10,7 +10,8 @@ use openvm_sha2_transpiler::Rv32Sha2Opcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx,
+    air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
+    RvrExtensionCtx,
 };
 
 /// IR node for a SHA-256 compress instruction.
@@ -26,9 +27,9 @@ pub struct Sha256Instr {
     /// Register index holding input pointer (message block).
     pub input_ptr_reg: Reg,
     /// SHA-256 main chip AIR index (1 row per instruction).
-    pub main_chip_idx: AirIndex,
+    pub main_chip_idx: Option<AirIndex>,
     /// SHA-256 block hasher chip AIR index (ROWS_PER_BLOCK rows per instruction).
-    pub block_hasher_chip_idx: AirIndex,
+    pub block_hasher_chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for Sha256Instr {
@@ -40,8 +41,8 @@ impl ExtInstr for Sha256Instr {
         let dst = ctx.read_reg(self.dst_ptr_reg);
         let st = ctx.read_reg(self.state_ptr_reg);
         let inp = ctx.read_reg(self.input_ptr_reg);
-        let main = self.main_chip_idx.to_c_chip_idx();
-        let block = self.block_hasher_chip_idx.to_c_chip_idx();
+        let main = air_index_to_c(self.main_chip_idx);
+        let block = air_index_to_c(self.block_hasher_chip_idx);
         ctx.write_line(&format!(
             "rvr_ext_sha256(state, {dst}, {st}, {inp}, {main}u, {block}u);"
         ));
@@ -69,9 +70,9 @@ pub struct Sha512Instr {
     /// Register index holding input pointer (message block).
     pub input_ptr_reg: Reg,
     /// SHA-512 main chip AIR index (1 row per instruction).
-    pub main_chip_idx: AirIndex,
+    pub main_chip_idx: Option<AirIndex>,
     /// SHA-512 block hasher chip AIR index (ROWS_PER_BLOCK rows per instruction).
-    pub block_hasher_chip_idx: AirIndex,
+    pub block_hasher_chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for Sha512Instr {
@@ -83,8 +84,8 @@ impl ExtInstr for Sha512Instr {
         let dst = ctx.read_reg(self.dst_ptr_reg);
         let st = ctx.read_reg(self.state_ptr_reg);
         let inp = ctx.read_reg(self.input_ptr_reg);
-        let main = self.main_chip_idx.to_c_chip_idx();
-        let block = self.block_hasher_chip_idx.to_c_chip_idx();
+        let main = air_index_to_c(self.main_chip_idx);
+        let block = air_index_to_c(self.block_hasher_chip_idx);
         ctx.write_line(&format!(
             "rvr_ext_sha512(state, {dst}, {st}, {inp}, {main}u, {block}u);"
         ));
@@ -102,10 +103,10 @@ impl ExtInstr for Sha512Instr {
 /// The SHA-2 extension (SHA-256 + SHA-512 opcodes).
 /// Register this with the `ExtensionRegistry`.
 pub struct Sha2Extension {
-    sha256_main_chip_idx: AirIndex,
-    sha256_block_hasher_chip_idx: AirIndex,
-    sha512_main_chip_idx: AirIndex,
-    sha512_block_hasher_chip_idx: AirIndex,
+    sha256_main_chip_idx: Option<AirIndex>,
+    sha256_block_hasher_chip_idx: Option<AirIndex>,
+    sha512_main_chip_idx: Option<AirIndex>,
+    sha512_block_hasher_chip_idx: Option<AirIndex>,
     staticlib_path: PathBuf,
 }
 
@@ -115,10 +116,10 @@ impl Sha2Extension {
         // SHA-256 block hasher: in extend_circuit, the block hasher is added right before
         // the main chip. Due to reverse ordering of AIR indices,
         // block_hasher_air_idx = main_air_idx + 1.
-        let sha256_block_hasher_chip_idx = sha256_main_chip_idx.next();
+        let sha256_block_hasher_chip_idx = sha256_main_chip_idx.map(AirIndex::next);
 
         let sha512_main_chip_idx = opcode_air_idx(ctx, Rv32Sha2Opcode::SHA512)?;
-        let sha512_block_hasher_chip_idx = sha512_main_chip_idx.next();
+        let sha512_block_hasher_chip_idx = sha512_main_chip_idx.map(AirIndex::next);
 
         Ok(Self {
             sha256_main_chip_idx,


### PR DESCRIPTION
Air indices are now represented as an enum in rvr code. The `AirIndex` enum has `Uninitialized` and `NoChip` variants that replace the previous `NO_CHIP = u32::MAX`. `AirIndex::Uninitialized` is only used in pure execution where air indices don't matter and causes a panic in rvr metered and metered cost execution.

closes INT-7611