### PR TITLE
fix(v2.1-rvr): use clang-only rvr native builds

### DIFF
--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -34,6 +34,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
         with:

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -114,6 +114,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -171,6 +171,10 @@ jobs:
           ref: ${{ env.CURRENT_SHA }}
           repository: ${{ env.REPO }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Build openvm-prof

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,6 +42,10 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"

--- a/.github/workflows/continuations.yml
+++ b/.github/workflows/continuations.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"

--- a/.github/workflows/continuations.yml
+++ b/.github/workflows/continuations.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,10 @@ jobs:
           git submodule update --init --depth 1 extensions/algebra/rvr/ffi/modular/secp256k1
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cargo check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,9 +35,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Init rvr FFI submodules
         run: |
-          git submodule update --init extensions/keccak256/rvr/ffi/openssl
-          git submodule update --init extensions/keccak256/rvr/ffi/xkcp
-          git submodule update --init --recursive extensions/algebra/rvr/ffi/modular/secp256k1
+          git submodule update --init --depth 1 extensions/keccak256/rvr/ffi/openssl
+          git submodule update --init --depth 1 extensions/algebra/rvr/ffi/modular/secp256k1
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       - uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -95,6 +95,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
         with:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -85,6 +85,10 @@ jobs:
           exit 0
 
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -67,9 +67,8 @@ jobs:
       - name: Init rvr FFI submodules
         if: matrix.extension.rvr == true
         run: |
-          git submodule update --init extensions/keccak256/rvr/ffi/openssl
-          git submodule update --init extensions/keccak256/rvr/ffi/xkcp
-          git submodule update --init --recursive extensions/algebra/rvr/ffi/modular/secp256k1
+          git submodule update --init --depth 1 extensions/keccak256/rvr/ffi/openssl
+          git submodule update --init --depth 1 extensions/algebra/rvr/ffi/modular/secp256k1
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -106,6 +106,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
         with:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -77,6 +77,10 @@ jobs:
           exit 0
 
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -58,9 +58,8 @@ jobs:
       - name: Init rvr FFI submodules
         if: matrix.crate.rvr == true
         run: |
-          git submodule update --init extensions/keccak256/rvr/ffi/openssl
-          git submodule update --init extensions/keccak256/rvr/ffi/xkcp
-          git submodule update --init --recursive extensions/algebra/rvr/ffi/modular/secp256k1
+          git submodule update --init --depth 1 extensions/keccak256/rvr/ffi/openssl
+          git submodule update --init --depth 1 extensions/algebra/rvr/ffi/modular/secp256k1
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -47,6 +47,10 @@ jobs:
           skip: Cargo.lock,./docs/vocs/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,./audits/*.pdf,./crates/toolchain/tests/rv32im-test-vectors/riscv-tests,./crates/sdk/contracts/lib/forge-std,./extensions/algebra/rvr/ffi/modular/secp256k1,./extensions/keccak256/rvr/ffi/openssl
           ignore_words_file: .codespellignore
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:
@@ -128,6 +132,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -38,11 +38,13 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
+      - name: Init rvr FFI submodules
+        run: |
+          git submodule update --init --depth 1 extensions/keccak256/rvr/ffi/openssl
+          git submodule update --init --depth 1 extensions/algebra/rvr/ffi/modular/secp256k1
       - uses: codespell-project/actions-codespell@v2
         with:
-          skip: Cargo.lock,./docs/vocs/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,./audits/*.pdf,./crates/toolchain/tests/rv32im-test-vectors/riscv-tests,./crates/sdk/contracts/lib/forge-std,./extensions/algebra/rvr/ffi/modular/secp256k1,./extensions/keccak256/rvr/ffi/xkcp,./extensions/keccak256/rvr/ffi/openssl
+          skip: Cargo.lock,./docs/vocs/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,./audits/*.pdf,./crates/toolchain/tests/rv32im-test-vectors/riscv-tests,./crates/sdk/contracts/lib/forge-std,./extensions/algebra/rvr/ffi/modular/secp256k1,./extensions/keccak256/rvr/ffi/openssl
           ignore_words_file: .codespellignore
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
@@ -67,7 +69,7 @@ jobs:
           # cargo clippy --all-targets --all --tests --features "aggregation bls12_381 bn254 build-elfs default entrypoint evm-prove evm-verify export-intrinsics export-libm function-span getrandom-unsupported halo2-compiler halo2curves heap-embedded-alloc jemalloc jemalloc-prof metrics panic-handler parallel perf-metrics rust-runtime static-verifier std test-utils" -- -D warnings
           cargo clippy --all-targets --all --tests --features "bls12_381 bn254 default entrypoint export-intrinsics export-libm function-span getrandom-unsupported halo2curves heap-embedded-alloc jemalloc jemalloc-prof metrics panic-handler parallel perf-metrics rust-runtime std test-utils" -- -D warnings
           # cargo clippy --all-targets --all --tests --no-default-features --features "mimalloc" -- -D warnings
-          cargo clippy --all-targets --all --tests --no-default-features --features "mimalloc rvr-openvm-ext-keccak-ffi/backend-openssl" -- -D warnings
+          cargo clippy --all-targets --all --tests --no-default-features --features "mimalloc" -- -D warnings
       - name: Run fmt, clippy for guest
         run: |
           # Find all directories named "programs" and include additional static paths
@@ -119,8 +121,10 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
+      - name: Init rvr FFI submodules
+        run: |
+          git submodule update --init --depth 1 extensions/keccak256/rvr/ffi/openssl
+          git submodule update --init --depth 1 extensions/algebra/rvr/ffi/modular/secp256k1
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -40,6 +40,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cache Cargo dependencies

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -63,6 +63,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Init RISC-V test-vector submodule
         run: git submodule update --init --depth 1 crates/toolchain/tests/rv32im-test-vectors/riscv-tests
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Set feature flags

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -61,8 +61,8 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
+      - name: Init RISC-V test-vector submodule
+        run: git submodule update --init --depth 1 crates/toolchain/tests/rv32im-test-vectors/riscv-tests
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Set feature flags

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -36,6 +36,10 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/static-verifier.yml
+++ b/.github/workflows/static-verifier.yml
@@ -31,6 +31,10 @@ jobs:
       - run: | # avoid cross-device link error
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -31,6 +31,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cache Cargo dependencies

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -39,6 +39,10 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache startup timeout
+        run: |
+          mkdir -p ~/.config/sccache
+          echo "server_startup_timeout_ms = 60000" > ~/.config/sccache/config
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,7 @@
 [submodule "extensions/algebra/rvr/ffi/modular/secp256k1"]
 	path = extensions/algebra/rvr/ffi/modular/secp256k1
 	url = https://github.com/bitcoin-core/secp256k1.git
-[submodule "extensions/keccak256/rvr/ffi/xkcp"]
-	path = extensions/keccak256/rvr/ffi/xkcp
-	url = https://github.com/XKCP/XKCP.git
+	shallow = true
 [submodule "extensions/keccak256/rvr/ffi/openssl"]
 	path = extensions/keccak256/rvr/ffi/openssl
 	url = https://github.com/openssl/openssl.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8842,10 +8842,15 @@ version = "2.0.0-beta.2"
 dependencies = [
  "openvm-instructions",
  "openvm-stark-backend",
+ "rvr-openvm-build",
  "rvr-openvm-ext-ffi-common",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
 ]
+
+[[package]]
+name = "rvr-openvm-build"
+version = "2.0.0-beta.2"
 
 [[package]]
 name = "rvr-openvm-ext-algebra"
@@ -8857,6 +8862,7 @@ dependencies = [
  "openvm-instructions",
  "openvm-stark-backend",
  "rand 0.9.2",
+ "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
  "strum 0.26.3",
@@ -8906,6 +8912,7 @@ dependencies = [
  "openvm-instructions",
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",
+ "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
  "strum 0.26.3",
@@ -8927,6 +8934,7 @@ dependencies = [
  "openvm-deferral-transpiler",
  "openvm-instructions",
  "openvm-stark-backend",
+ "rvr-openvm-build",
  "rvr-openvm-ext-ffi-common",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -8946,6 +8954,7 @@ dependencies = [
  "openvm-ecc-transpiler",
  "openvm-instructions",
  "openvm-stark-backend",
+ "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
  "strum 0.26.3",
@@ -8976,6 +8985,7 @@ dependencies = [
  "openvm-instructions",
  "openvm-keccak256-transpiler",
  "openvm-stark-backend",
+ "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
 ]
@@ -8985,6 +8995,7 @@ name = "rvr-openvm-ext-keccak-ffi"
 version = "2.0.0-beta.2"
 dependencies = [
  "cc",
+ "rvr-openvm-build",
 ]
 
 [[package]]
@@ -8994,6 +9005,7 @@ dependencies = [
  "openvm-instructions",
  "openvm-pairing-transpiler",
  "openvm-stark-backend",
+ "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
 ]
@@ -9028,6 +9040,7 @@ dependencies = [
  "openvm-instructions",
  "openvm-sha2-transpiler",
  "openvm-stark-backend",
+ "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
 
     # rvr
     "crates/rvr/rvr-state",
+    "crates/rvr/rvr-openvm-build",
     "crates/rvr/rvr-openvm",
     "crates/rvr/rvr-openvm-ir",
     "crates/rvr/rvr-openvm-lift",
@@ -210,6 +211,7 @@ openvm-deferral-transpiler = { path = "extensions/deferral/transpiler", default-
 
 # rvr
 rvr-state = { path = "crates/rvr/rvr-state" }
+rvr-openvm-build = { path = "crates/rvr/rvr-openvm-build" }
 rvr-openvm = { path = "crates/rvr/rvr-openvm" }
 rvr-openvm-ir = { path = "crates/rvr/rvr-openvm-ir" }
 rvr-openvm-lift = { path = "crates/rvr/rvr-openvm-lift" }

--- a/crates/rvr/rvr-openvm-build/Cargo.toml
+++ b/crates/rvr/rvr-openvm-build/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rvr-openvm-build"
+description = "Build and toolchain helpers for rvr-openvm"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -1,0 +1,114 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Default clang command used for RVR native C builds.
+pub const DEFAULT_CLANG_COMMAND: &str = "clang-22";
+
+/// Select the C compiler for RVR native code.
+///
+/// `RVR_CC` is the explicit override. Otherwise prefer `clang-22`, then a
+/// clang-valued `CC`, then plain `clang`. Non-clang `CC` values are ignored so
+/// ambient Cargo C compiler settings do not make RVR use GCC by accident.
+pub fn default_compiler_command() -> String {
+    if let Some(compiler) = env_command("RVR_CC") {
+        return compiler;
+    }
+    if command_exists(DEFAULT_CLANG_COMMAND) {
+        return DEFAULT_CLANG_COMMAND.to_string();
+    }
+    if let Some(compiler) = env_command("CC").filter(|compiler| is_clang_command(compiler)) {
+        return compiler;
+    }
+    "clang".to_string()
+}
+
+/// Check that `compiler` resolves to clang.
+pub fn ensure_clang_compiler(compiler: &str) -> Result<(), String> {
+    let output = Command::new(compiler)
+        .arg("--version")
+        .output()
+        .map_err(|e| {
+            format!(
+                "required RVR C compiler '{compiler}' could not be executed: {e}; \
+                 install clang-22 or set RVR_CC=clang"
+            )
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let version = format!("{stdout}\n{stderr}");
+    if output.status.success() && version.to_ascii_lowercase().contains("clang") {
+        Ok(())
+    } else {
+        Err(format!(
+            "RVR C compilation requires clang, but selected compiler '{compiler}' is not clang; \
+             install clang-22 or set RVR_CC=clang"
+        ))
+    }
+}
+
+pub fn command_exists(command: &str) -> bool {
+    if command.contains(std::path::MAIN_SEPARATOR) && Path::new(command).exists() {
+        return true;
+    }
+
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return false;
+    };
+
+    std::env::split_paths(&path_var).any(|dir| dir.join(command).is_file())
+}
+
+/// Build a Rust staticlib crate in a private target directory and return the
+/// expected archive path.
+pub fn build_rust_staticlib(
+    manifest_path: &Path,
+    target_dir: &Path,
+    lib_name: &str,
+    crate_name: &str,
+) -> PathBuf {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let output = Command::new(&cargo)
+        .args([
+            "build",
+            "--release",
+            "--config",
+            "profile.release.lto=false",
+            "--manifest-path",
+        ])
+        .arg(manifest_path)
+        .arg("--target-dir")
+        .arg(target_dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn cargo for {crate_name}: {e}"));
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("cargo build for {crate_name} failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    let lib_path = target_dir.join("release").join(lib_name);
+    assert!(
+        lib_path.exists(),
+        "expected staticlib at {} after cargo build",
+        lib_path.display()
+    );
+    lib_path
+}
+
+fn env_command(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .and_then(|value| value.split_whitespace().next().map(str::to_string))
+}
+
+fn is_clang_command(command: &str) -> bool {
+    command
+        .rsplit('/')
+        .next()
+        .is_some_and(|name| name == "clang" || name.starts_with("clang-"))
+}

--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -8,9 +10,11 @@ pub const DEFAULT_CLANG_COMMAND: &str = "clang-22";
 
 /// Select the C compiler for RVR native code.
 ///
-/// `RVR_CC` is the explicit override. Otherwise prefer `clang-22`, then a
-/// clang-valued `CC`, then plain `clang`. Non-clang `CC` values are ignored so
-/// ambient Cargo C compiler settings do not make RVR use GCC by accident.
+/// `RVR_CC` is the explicit override and is returned even if the command name
+/// is not clang. Callers must validate the selected command with
+/// [`ensure_clang_compiler`]. Otherwise prefer `clang-22`, then a clang-valued
+/// `CC`, then plain `clang`. Non-clang `CC` values are ignored so ambient Cargo
+/// C compiler settings do not make RVR use GCC by accident.
 pub fn default_compiler_command() -> String {
     if let Some(compiler) = env_command("RVR_CC") {
         return compiler;
@@ -50,15 +54,15 @@ pub fn ensure_clang_compiler(compiler: &str) -> Result<(), String> {
 }
 
 pub fn command_exists(command: &str) -> bool {
-    if command.contains(std::path::MAIN_SEPARATOR) && Path::new(command).exists() {
-        return true;
+    if command.contains(std::path::MAIN_SEPARATOR) {
+        return is_executable_file(Path::new(command));
     }
 
     let Some(path_var) = std::env::var_os("PATH") else {
         return false;
     };
 
-    std::env::split_paths(&path_var).any(|dir| dir.join(command).is_file())
+    std::env::split_paths(&path_var).any(|dir| is_executable_file(&dir.join(command)))
 }
 
 /// Build a Rust staticlib crate in a private target directory and return the
@@ -107,8 +111,19 @@ fn env_command(name: &str) -> Option<String> {
 }
 
 fn is_clang_command(command: &str) -> bool {
-    command
-        .rsplit('/')
-        .next()
+    Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str())
         .is_some_and(|name| name == "clang" || name.starts_with("clang-"))
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    path.metadata()
+        .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }

--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -15,6 +15,9 @@ pub const DEFAULT_CLANG_COMMAND: &str = "clang-22";
 /// [`ensure_clang_compiler`]. Otherwise prefer `clang-22`, then a clang-valued
 /// `CC`, then plain `clang`. Non-clang `CC` values are ignored so ambient Cargo
 /// C compiler settings do not make RVR use GCC by accident.
+///
+/// Only the first whitespace-delimited token from `RVR_CC` or `CC` is used;
+/// pass compiler flags through `CFLAGS`.
 pub fn default_compiler_command() -> String {
     if let Some(compiler) = env_command("RVR_CC") {
         return compiler;
@@ -65,6 +68,19 @@ pub fn command_exists(command: &str) -> bool {
     std::env::split_paths(&path_var).any(|dir| is_executable_file(&dir.join(command)))
 }
 
+pub fn is_clang_command(command: &str) -> bool {
+    clang_version_suffix(command).is_some()
+}
+
+pub fn clang_version_suffix(command: &str) -> Option<&str> {
+    let basename = command_basename(command);
+    if basename == "clang" || basename.starts_with("clang-") {
+        basename.strip_prefix("clang")
+    } else {
+        None
+    }
+}
+
 /// Build a Rust staticlib crate in a private target directory and return the
 /// expected archive path.
 pub fn build_rust_staticlib(
@@ -110,11 +126,11 @@ fn env_command(name: &str) -> Option<String> {
         .and_then(|value| value.split_whitespace().next().map(str::to_string))
 }
 
-fn is_clang_command(command: &str) -> bool {
+fn command_basename(command: &str) -> &str {
     Path::new(command)
         .file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name == "clang" || name.starts_with("clang-"))
+        .unwrap_or(command)
 }
 
 #[cfg(unix)]

--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -143,3 +143,32 @@ fn is_executable_file(path: &Path) -> bool {
 fn is_executable_file(path: &Path) -> bool {
     path.is_file()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{clang_version_suffix, is_clang_command};
+
+    #[test]
+    fn detects_clang_command_names() {
+        assert!(is_clang_command("clang"));
+        assert!(is_clang_command("clang-22"));
+        assert!(is_clang_command("/usr/bin/clang-22"));
+        assert!(is_clang_command("/opt/homebrew/opt/llvm/bin/clang"));
+    }
+
+    #[test]
+    fn rejects_non_clang_command_names() {
+        assert!(!is_clang_command("gcc"));
+        assert!(!is_clang_command("/opt/not-clang-tools/gcc"));
+        assert!(!is_clang_command("my-clang-wrapper"));
+        assert!(!is_clang_command("clang++"));
+    }
+
+    #[test]
+    fn extracts_clang_version_suffix() {
+        assert_eq!(clang_version_suffix("clang"), Some(""));
+        assert_eq!(clang_version_suffix("clang-22"), Some("-22"));
+        assert_eq!(clang_version_suffix("/usr/bin/clang-18"), Some("-18"));
+        assert_eq!(clang_version_suffix("gcc"), None);
+    }
+}

--- a/crates/rvr/rvr-openvm/Cargo.toml
+++ b/crates/rvr/rvr-openvm/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+rvr-openvm-build.workspace = true
 rvr-openvm-ext-ffi-common.workspace = true
 rvr-openvm-ir.workspace = true
 rvr-openvm-lift.workspace = true

--- a/crates/rvr/rvr-openvm/c/Makefile
+++ b/crates/rvr/rvr-openvm/c/Makefile
@@ -1,4 +1,4 @@
-CC ?= clang
+CC ?= clang-22
 LINKER ?= lld
 OPT ?= -O3
 DEBUG ?=

--- a/crates/rvr/rvr-openvm/src/lib.rs
+++ b/crates/rvr/rvr-openvm/src/lib.rs
@@ -8,5 +8,5 @@ pub use constants::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 pub use emit::{CProject, EmitContext, InstrCodegen, TracerMode};
 pub use toolchain::{
     default_addr2line_cmd, default_compiler, default_compiler_command, default_dwarfdump_cmd,
-    default_linker, default_linker_or_lld, linker_exists, Compiler,
+    default_linker, default_linker_or_lld, ensure_clang_compiler, linker_exists, Compiler,
 };

--- a/crates/rvr/rvr-openvm/src/toolchain.rs
+++ b/crates/rvr/rvr-openvm/src/toolchain.rs
@@ -1,12 +1,12 @@
-use std::{path::Path, process::Command};
+use std::process::Command;
 
-/// Default clang command used across the workspace.
-pub const DEFAULT_CLANG_COMMAND: &str = "clang-22";
+pub use rvr_openvm_build::{
+    command_exists, default_compiler_command, ensure_clang_compiler, DEFAULT_CLANG_COMMAND,
+};
 
 /// C compiler to use for generated code.
 ///
-/// Accepts any compiler command (e.g., "clang", "clang-20", "gcc-13").
-/// Clang vs GCC is auto-detected from the command name to determine flags.
+/// Accepts clang compiler commands (e.g., "clang", "clang-20").
 /// For clang, the linker (lld) version is auto-derived from the compiler
 /// command (e.g., "clang-20" → "lld-20"). Use `with_linker()` to override.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -82,15 +82,6 @@ impl Default for Compiler {
     fn default() -> Self {
         Self::clang()
     }
-}
-
-pub fn default_compiler_command() -> String {
-    std::env::var("RVR_CC")
-        .ok()
-        .or_else(|| std::env::var("CC").ok())
-        .filter(|value| !value.trim().is_empty())
-        .and_then(|value| value.split_whitespace().next().map(str::to_string))
-        .unwrap_or_else(|| DEFAULT_CLANG_COMMAND.to_string())
 }
 
 pub fn default_compiler() -> Compiler {
@@ -181,21 +172,6 @@ fn detect_clang_major(compiler: &str) -> Option<u32> {
         .split_whitespace()
         .find(|token| token.as_bytes().first().is_some_and(u8::is_ascii_digit))?;
     version.split('.').next()?.parse().ok()
-}
-
-fn command_exists(command: &str) -> bool {
-    if command.contains(std::path::MAIN_SEPARATOR) && Path::new(command).exists() {
-        return true;
-    }
-
-    let Some(path_var) = std::env::var_os("PATH") else {
-        return false;
-    };
-
-    std::env::split_paths(&path_var).any(|dir| {
-        let candidate = dir.join(command);
-        candidate.is_file()
-    })
 }
 
 fn dedup_preserve_order(candidates: Vec<String>) -> Vec<String> {

--- a/crates/rvr/rvr-openvm/src/toolchain.rs
+++ b/crates/rvr/rvr-openvm/src/toolchain.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 
+use rvr_openvm_build::{clang_version_suffix, is_clang_command};
 pub use rvr_openvm_build::{
     command_exists, default_compiler_command, ensure_clang_compiler, DEFAULT_CLANG_COMMAND,
 };
@@ -46,7 +47,7 @@ impl Compiler {
     /// Check if this is a clang-based compiler (for flag selection).
     #[must_use]
     pub fn is_clang(&self) -> bool {
-        self.command.contains("clang")
+        is_clang_command(&self.command)
     }
 
     /// Get the linker to use with `-fuse-ld=`. Returns the linker (explicit
@@ -70,11 +71,7 @@ impl Compiler {
 
     /// Extract version suffix from compiler command (e.g., "clang-20" → "-20").
     fn version_suffix(&self) -> &str {
-        if !self.is_clang() {
-            return "";
-        }
-        let basename = self.command.rsplit('/').next().unwrap_or(&self.command);
-        basename.strip_prefix("clang").unwrap_or("")
+        clang_version_suffix(&self.command).unwrap_or("")
     }
 }
 
@@ -151,8 +148,7 @@ fn resolve_llvm_tool(base_name: &str, preferred: Option<String>) -> Option<Strin
 
 fn derive_llvm_tool_from_compiler(base_name: &str) -> Option<String> {
     let compiler = default_compiler_command();
-    let basename = compiler.rsplit('/').next().unwrap_or(&compiler);
-    let version_suffix = basename.strip_prefix("clang")?;
+    let version_suffix = clang_version_suffix(&compiler)?;
     if version_suffix.is_empty() {
         detect_clang_major(&compiler).map(|major| format!("{base_name}-{major}"))
     } else {

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -11,7 +11,10 @@ use openvm_instructions::{
     exe::VmExe, program::DEFAULT_PC_STEP, LocalOpcode, SystemOpcode, VmOpcode,
 };
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm::{CProject, TracerMode};
+use rvr_openvm::{
+    default_compiler_command, default_linker_or_lld, ensure_clang_compiler, linker_exists,
+    CProject, TracerMode,
+};
 use rvr_openvm_lift::{
     build_blocks, convert_vmexe_to_ir_with_debug, scan_init_memory_for_code_pointers, AirIndex,
     ExtensionRegistry, TraceChipIndex,
@@ -296,16 +299,16 @@ fn compile_generated_project(output_dir: &Path, make_args: &[String]) -> Result<
     let jobs = std::thread::available_parallelism()
         .map_or(4, |n| n.get().saturating_sub(2).max(1))
         .to_string();
-    let compiler = rvr_openvm::default_compiler_command();
-    let linker = rvr_openvm::default_linker_or_lld();
+    let compiler = default_compiler_command();
+    let linker = default_linker_or_lld();
 
     eprintln!(
         "[rvr-openvm] Building native library: {total_objects} translation units with make -j{jobs}"
     );
 
-    rvr_openvm::ensure_clang_compiler(&compiler).map_err(CompileError::Toolchain)?;
+    ensure_clang_compiler(&compiler).map_err(CompileError::Toolchain)?;
 
-    if !rvr_openvm::linker_exists(&linker) {
+    if !linker_exists(&linker) {
         return Err(CompileError::Toolchain(format!(
             "required linker '{linker}' not found in PATH; install lld or set RVR_LD/LD"
         )));

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -296,11 +296,14 @@ fn compile_generated_project(output_dir: &Path, make_args: &[String]) -> Result<
     let jobs = std::thread::available_parallelism()
         .map_or(4, |n| n.get().saturating_sub(2).max(1))
         .to_string();
+    let compiler = rvr_openvm::default_compiler_command();
     let linker = rvr_openvm::default_linker_or_lld();
 
     eprintln!(
         "[rvr-openvm] Building native library: {total_objects} translation units with make -j{jobs}"
     );
+
+    rvr_openvm::ensure_clang_compiler(&compiler).map_err(CompileError::Toolchain)?;
 
     if !rvr_openvm::linker_exists(&linker) {
         return Err(CompileError::Toolchain(format!(
@@ -316,7 +319,7 @@ fn compile_generated_project(output_dir: &Path, make_args: &[String]) -> Result<
         .arg("-s")
         .arg("shared")
         .args(make_args)
-        .env("CC", rvr_openvm::default_compiler_command())
+        .env("CC", compiler)
         .env("LINKER", linker)
         .stdout(Stdio::from(stdout_file))
         .stderr(Stdio::from(stderr_file))

--- a/extensions/algebra/rvr/Cargo.toml
+++ b/extensions/algebra/rvr/Cargo.toml
@@ -20,3 +20,5 @@ num-bigint.workspace = true
 rand.workspace = true
 strum.workspace = true
 
+[build-dependencies]
+rvr-openvm-build.workspace = true

--- a/extensions/algebra/rvr/build.rs
+++ b/extensions/algebra/rvr/build.rs
@@ -6,8 +6,9 @@
 use std::{
     env,
     path::{Path, PathBuf},
-    process::Command,
 };
+
+use rvr_openvm_build::build_rust_staticlib;
 
 fn main() {
     let manifest_dir =
@@ -44,29 +45,10 @@ fn main() {
 }
 
 fn build_subffi(crate_dir: &Path, target_dir: &Path, lib_name: &str, crate_name: &str) -> PathBuf {
-    let manifest = crate_dir.join("Cargo.toml");
-
-    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(&cargo)
-        .args([
-            "build",
-            "--release",
-            "--config",
-            "profile.release.lto=false",
-            "--manifest-path",
-        ])
-        .arg(&manifest)
-        .arg("--target-dir")
-        .arg(target_dir)
-        .status()
-        .unwrap_or_else(|e| panic!("failed to spawn cargo for {crate_name}: {e}"));
-    assert!(status.success(), "cargo build for {crate_name} failed");
-
-    let lib_path = target_dir.join("release").join(lib_name);
-    assert!(
-        lib_path.exists(),
-        "expected staticlib at {} after cargo build",
-        lib_path.display()
-    );
-    lib_path
+    build_rust_staticlib(
+        &crate_dir.join("Cargo.toml"),
+        target_dir,
+        lib_name,
+        crate_name,
+    )
 }

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -266,8 +266,7 @@ fn secp256k1_dir() -> PathBuf {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("ffi/modular/secp256k1");
     assert!(
         dir.join("src/secp256k1.c").exists(),
-        "missing secp256k1 submodule at {}. Run `git submodule update --init {}`.",
-        dir.display(),
+        "missing secp256k1 submodule at {}. Run `git submodule update --init extensions/algebra/rvr/ffi/modular/secp256k1`.",
         dir.display()
     );
     dir

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -266,7 +266,8 @@ fn secp256k1_dir() -> PathBuf {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("ffi/modular/secp256k1");
     assert!(
         dir.join("src/secp256k1.c").exists(),
-        "missing secp256k1 submodule at {}. Run `git submodule update --init --recursive`.",
+        "missing secp256k1 submodule at {}. Run `git submodule update --init {}`.",
+        dir.display(),
         dir.display()
     );
     dir

--- a/extensions/bigint/rvr/Cargo.toml
+++ b/extensions/bigint/rvr/Cargo.toml
@@ -17,3 +17,6 @@ openvm-rv32im-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
 strum.workspace = true
+
+[build-dependencies]
+rvr-openvm-build.workspace = true

--- a/extensions/bigint/rvr/build.rs
+++ b/extensions/bigint/rvr/build.rs
@@ -2,7 +2,9 @@
 // to. The path to the resulting `librvr_openvm_ext_bigint_ffi.a` is exposed
 // to the source via the `RVR_BIGINT_FFI_STATICLIB` cargo env var.
 
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
+
+use rvr_openvm_build::build_rust_staticlib;
 
 fn main() {
     let manifest_dir =
@@ -13,30 +15,11 @@ fn main() {
     // Use a private target dir to avoid lock contention with the outer cargo.
     let ffi_target_dir = out_dir.join("ffi-target");
 
-    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(&cargo)
-        .args([
-            "build",
-            "--release",
-            "--config",
-            "profile.release.lto=false",
-            "--manifest-path",
-        ])
-        .arg(&ffi_manifest)
-        .arg("--target-dir")
-        .arg(&ffi_target_dir)
-        .status()
-        .expect("failed to spawn cargo for rvr-openvm-ext-bigint-ffi");
-    assert!(
-        status.success(),
-        "cargo build for rvr-openvm-ext-bigint-ffi failed"
-    );
-
-    let lib_path = ffi_target_dir.join("release/librvr_openvm_ext_bigint_ffi.a");
-    assert!(
-        lib_path.exists(),
-        "expected staticlib at {} after cargo build",
-        lib_path.display()
+    let lib_path = build_rust_staticlib(
+        &ffi_manifest,
+        &ffi_target_dir,
+        "librvr_openvm_ext_bigint_ffi.a",
+        "rvr-openvm-ext-bigint-ffi",
     );
 
     println!(

--- a/extensions/deferral/rvr/Cargo.toml
+++ b/extensions/deferral/rvr/Cargo.toml
@@ -30,3 +30,6 @@ rvr = [
     "dep:openvm-stark-backend",
     "dep:libloading",
 ]
+
+[build-dependencies]
+rvr-openvm-build.workspace = true

--- a/extensions/deferral/rvr/build.rs
+++ b/extensions/deferral/rvr/build.rs
@@ -2,7 +2,9 @@
 // to. The path to the resulting `librvr_openvm_ext_deferral_ffi.a` is exposed
 // to the source via the `RVR_DEFERRAL_FFI_STATICLIB` cargo env var.
 
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
+
+use rvr_openvm_build::build_rust_staticlib;
 
 fn main() {
     let manifest_dir =
@@ -12,30 +14,11 @@ fn main() {
     let ffi_manifest = manifest_dir.join("ffi/Cargo.toml");
     let ffi_target_dir = out_dir.join("ffi-target");
 
-    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(&cargo)
-        .args([
-            "build",
-            "--release",
-            "--config",
-            "profile.release.lto=false",
-            "--manifest-path",
-        ])
-        .arg(&ffi_manifest)
-        .arg("--target-dir")
-        .arg(&ffi_target_dir)
-        .status()
-        .expect("failed to spawn cargo for rvr-openvm-ext-deferral-ffi");
-    assert!(
-        status.success(),
-        "cargo build for rvr-openvm-ext-deferral-ffi failed"
-    );
-
-    let lib_path = ffi_target_dir.join("release/librvr_openvm_ext_deferral_ffi.a");
-    assert!(
-        lib_path.exists(),
-        "expected staticlib at {} after cargo build",
-        lib_path.display()
+    let lib_path = build_rust_staticlib(
+        &ffi_manifest,
+        &ffi_target_dir,
+        "librvr_openvm_ext_deferral_ffi.a",
+        "rvr-openvm-ext-deferral-ffi",
     );
 
     println!(

--- a/extensions/ecc/rvr/Cargo.toml
+++ b/extensions/ecc/rvr/Cargo.toml
@@ -17,3 +17,5 @@ openvm-stark-backend.workspace = true
 
 strum.workspace = true
 
+[build-dependencies]
+rvr-openvm-build.workspace = true

--- a/extensions/ecc/rvr/build.rs
+++ b/extensions/ecc/rvr/build.rs
@@ -2,7 +2,9 @@
 // to. The path to the resulting `librvr_openvm_ext_ecc_ffi.a` is exposed
 // to the source via the `RVR_ECC_FFI_STATICLIB` cargo env var.
 
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
+
+use rvr_openvm_build::build_rust_staticlib;
 
 fn main() {
     let manifest_dir =
@@ -12,30 +14,11 @@ fn main() {
     let ffi_manifest = manifest_dir.join("ffi/Cargo.toml");
     let ffi_target_dir = out_dir.join("ffi-target");
 
-    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(&cargo)
-        .args([
-            "build",
-            "--release",
-            "--config",
-            "profile.release.lto=false",
-            "--manifest-path",
-        ])
-        .arg(&ffi_manifest)
-        .arg("--target-dir")
-        .arg(&ffi_target_dir)
-        .status()
-        .expect("failed to spawn cargo for rvr-openvm-ext-ecc-ffi");
-    assert!(
-        status.success(),
-        "cargo build for rvr-openvm-ext-ecc-ffi failed"
-    );
-
-    let lib_path = ffi_target_dir.join("release/librvr_openvm_ext_ecc_ffi.a");
-    assert!(
-        lib_path.exists(),
-        "expected staticlib at {} after cargo build",
-        lib_path.display()
+    let lib_path = build_rust_staticlib(
+        &ffi_manifest,
+        &ffi_target_dir,
+        "librvr_openvm_ext_ecc_ffi.a",
+        "rvr-openvm-ext-ecc-ffi",
     );
 
     println!(

--- a/extensions/keccak256/rvr/Cargo.toml
+++ b/extensions/keccak256/rvr/Cargo.toml
@@ -15,3 +15,5 @@ openvm-instructions.workspace = true
 openvm-keccak256-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
+[build-dependencies]
+rvr-openvm-build.workspace = true

--- a/extensions/keccak256/rvr/build.rs
+++ b/extensions/keccak256/rvr/build.rs
@@ -2,7 +2,9 @@
 // to. The path to the resulting `librvr_openvm_ext_keccak_ffi.a` is exposed
 // to the source via the `RVR_KECCAK_FFI_STATICLIB` cargo env var.
 
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
+
+use rvr_openvm_build::build_rust_staticlib;
 
 fn main() {
     let manifest_dir =
@@ -13,30 +15,11 @@ fn main() {
     // Use a private target dir to avoid lock contention with the outer cargo.
     let ffi_target_dir = out_dir.join("ffi-target");
 
-    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(&cargo)
-        .args([
-            "build",
-            "--release",
-            "--config",
-            "profile.release.lto=false",
-            "--manifest-path",
-        ])
-        .arg(&ffi_manifest)
-        .arg("--target-dir")
-        .arg(&ffi_target_dir)
-        .status()
-        .expect("failed to spawn cargo for rvr-openvm-ext-keccak-ffi");
-    assert!(
-        status.success(),
-        "cargo build for rvr-openvm-ext-keccak-ffi failed"
-    );
-
-    let lib_path = ffi_target_dir.join("release/librvr_openvm_ext_keccak_ffi.a");
-    assert!(
-        lib_path.exists(),
-        "expected staticlib at {} after cargo build",
-        lib_path.display()
+    let lib_path = build_rust_staticlib(
+        &ffi_manifest,
+        &ffi_target_dir,
+        "librvr_openvm_ext_keccak_ffi.a",
+        "rvr-openvm-ext-keccak-ffi",
     );
 
     println!(
@@ -46,6 +29,14 @@ fn main() {
     println!("cargo:rerun-if-changed=ffi/Cargo.toml");
     println!("cargo:rerun-if-changed=ffi/build.rs");
     println!("cargo:rerun-if-changed=ffi/src");
-    println!("cargo:rerun-if-changed=ffi/openssl");
-    println!("cargo:rerun-if-changed=ffi/xkcp");
+    println!("cargo:rerun-if-changed=ffi/openssl/crypto/arm_arch.h");
+    println!("cargo:rerun-if-changed=ffi/openssl/crypto/perlasm/arm-xlate.pl");
+    println!("cargo:rerun-if-changed=ffi/openssl/crypto/perlasm/x86_64-xlate.pl");
+    println!("cargo:rerun-if-changed=ffi/openssl/crypto/sha/asm/keccak1600-armv8.pl");
+    println!("cargo:rerun-if-changed=ffi/openssl/crypto/sha/asm/keccak1600-x86_64.pl");
+    println!("cargo:rerun-if-env-changed=RVR_CC");
+    println!("cargo:rerun-if-env-changed=CC");
+    println!("cargo:rerun-if-env-changed=AS");
+    println!("cargo:rerun-if-env-changed=CFLAGS");
+    println!("cargo:rerun-if-env-changed=PATH");
 }

--- a/extensions/keccak256/rvr/ffi/Cargo.toml
+++ b/extensions/keccak256/rvr/ffi/Cargo.toml
@@ -10,11 +10,6 @@ repository.workspace = true
 [lib]
 crate-type = ["staticlib"]
 
-[features]
-# TODO: delete the xkcp backend and keep only openssl.
-default = ["backend-openssl"]
-backend-openssl = []
-backend-xkcp = []
-
 [build-dependencies]
 cc = "1"
+rvr-openvm-build.workspace = true

--- a/extensions/keccak256/rvr/ffi/build.rs
+++ b/extensions/keccak256/rvr/ffi/build.rs
@@ -148,7 +148,7 @@ mod openssl {
         let (script, flavor, extra_globals, native_entry) =
             match (ctx.target_arch.as_str(), ctx.target_os.as_str()) {
                 ("x86_64", "macos") => (x86_64.as_path(), "macosx", &[] as &[&str], "KeccakF1600"),
-                ("x86_64", _) => (x86_64.as_path(), "elf", &[] as &[&str], "KeccakF1600"),
+                ("x86_64", "linux") => (x86_64.as_path(), "linux64", &[] as &[&str], "KeccakF1600"),
                 ("aarch64", "macos") => (
                     armv8.as_path(),
                     "ios64+sha3",

--- a/extensions/keccak256/rvr/ffi/build.rs
+++ b/extensions/keccak256/rvr/ffi/build.rs
@@ -1,6 +1,5 @@
-// Compile a keccak-f[1600] asm backend into a staticlib that exports
-// `rvr_keccak_f1600(uint64_t state[25])`. Backend selected via cargo features
-// (see Cargo.toml).
+// Compile OpenSSL's keccak-f[1600] asm backend into a staticlib that exports
+// `rvr_keccak_f1600(uint64_t state[25])`.
 
 use std::{
     env, fs,
@@ -8,12 +7,17 @@ use std::{
     process::Command,
 };
 
+use rvr_openvm_build::{default_compiler_command, ensure_clang_compiler};
+
 fn main() {
+    println!("cargo:rerun-if-env-changed=RVR_CC");
+    println!("cargo:rerun-if-env-changed=CC");
+    println!("cargo:rerun-if-env-changed=AS");
+    println!("cargo:rerun-if-env-changed=CFLAGS");
+    println!("cargo:rerun-if-env-changed=PATH");
+
     let ctx = BuildCtx::from_env();
-    let native_entry = match ctx.backend {
-        Backend::Xkcp => xkcp::build(&ctx),
-        Backend::Openssl => openssl::build(&ctx),
-    };
+    let native_entry = openssl::build(&ctx);
 
     let shim_path = ctx.out_dir.join("rvr_keccak_shim.c");
     fs::write(&shim_path, shim_c(&native_entry)).expect("write shim");
@@ -22,14 +26,8 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 }
 
-#[derive(Copy, Clone)]
-enum Backend {
-    Xkcp,
-    Openssl,
-}
-
 struct BuildCtx {
-    backend: Backend,
+    compiler: String,
     manifest_dir: PathBuf,
     out_dir: PathBuf,
     target_arch: String,
@@ -44,8 +42,19 @@ impl BuildCtx {
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
         let is_macos = target_os == "macos" || target_os == "ios";
+        let compiler = default_compiler_command();
+        ensure_clang_compiler(&compiler).unwrap_or_else(|e| {
+            panic!(
+                "\n\n\
+                 rvr-openvm-ext-keccak-ffi requires clang to build its \
+                 OpenSSL assembly backend.\n\
+                 {e}\n\n\
+                 Install clang-22 and re-run with:\n\
+                   export RVR_CC=clang-22 CC=clang-22 AS=clang-22 CFLAGS=-fintegrated-as\n"
+            )
+        });
         Self {
-            backend: select_backend(),
+            compiler,
             manifest_dir,
             out_dir,
             target_arch,
@@ -56,23 +65,12 @@ impl BuildCtx {
 
     fn cc(&self) -> cc::Build {
         let mut b = cc::Build::new();
+        b.compiler(&self.compiler).flag("-fintegrated-as");
         if self.is_macos {
             // GNU `ar`'s slash-member format is rejected by the macOS linker.
             b.archiver("/usr/bin/ar");
         }
         b
-    }
-}
-
-fn select_backend() -> Backend {
-    match (
-        cfg!(feature = "backend-xkcp"),
-        cfg!(feature = "backend-openssl"),
-    ) {
-        (true, false) => Backend::Xkcp,
-        (false, true) => Backend::Openssl,
-        (false, false) => panic!("keccak-ffi: enable backend-openssl or backend-xkcp"),
-        (true, true) => panic!("keccak-ffi: enable exactly one backend feature"),
     }
 }
 
@@ -109,47 +107,6 @@ fn export_asm_symbols(asm: &str, labels: &[&str], is_macos: bool) -> String {
     out
 }
 
-/// Rewrite gas-only NEON lane notation `vN.2d[i]` to `vN.d[i]` for clang's
-/// Mach-O assembler. Requires the `.2d[` to be preceded by a `vN` register
-/// digit so a stray `.2d[0]` in a comment can't be mis-rewritten. Panics if
-/// any unguarded match appears or if zero rewrites fire (upstream shape
-/// changed). Operates on raw bytes; non-ASCII bytes pass through unsplit.
-fn rewrite_xkcp_neon_lane_syntax(asm: &str) -> String {
-    let bytes = asm.as_bytes();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    let mut rewrites = 0usize;
-    let mut unguarded = 0usize;
-    while i < bytes.len() {
-        let tail_is_lane = i + 6 <= bytes.len()
-            && &bytes[i..i + 4] == b".2d["
-            && (bytes[i + 4] == b'0' || bytes[i + 4] == b'1')
-            && bytes[i + 5] == b']';
-        if tail_is_lane {
-            let guarded = i > 0 && bytes[i - 1].is_ascii_digit();
-            if guarded {
-                out.extend_from_slice(b".d[");
-                out.push(bytes[i + 4]);
-                out.push(b']');
-                i += 6;
-                rewrites += 1;
-                continue;
-            } else {
-                unguarded += 1;
-            }
-        }
-        out.push(bytes[i]);
-        i += 1;
-    }
-    assert!(unguarded == 0, "unguarded `.2d[0/1]` in XKCP NEON asm");
-    assert!(
-        rewrites > 0,
-        "no `vN.2d[i]` rewrites; upstream shape changed?"
-    );
-    println!("cargo:warning=xkcp: rewrote {rewrites} `vN.2d[i]` lane tokens");
-    String::from_utf8(out).expect("rewrite preserves UTF-8")
-}
-
 fn run_perl(script: &Path, flavor: &str, out_path: &Path) {
     let output = Command::new("perl")
         .arg(script)
@@ -173,46 +130,6 @@ fn run_perl(script: &Path, flavor: &str, out_path: &Path) {
     assert!(out_path.exists(), "asm not generated at {out_path:?}");
 }
 
-mod xkcp {
-    use super::*;
-
-    pub fn build(ctx: &BuildCtx) -> String {
-        let xkcp = ctx.manifest_dir.join("xkcp");
-        assert!(
-            xkcp.join("lib/low/KeccakP-1600").is_dir(),
-            "xkcp submodule missing. Run: git submodule update --init --recursive"
-        );
-
-        let (src_rel, native_entry) = match ctx.target_arch.as_str() {
-            // AVX-512 file already exports both plain and `_`-prefix forms.
-            "x86_64" => (
-                "lib/low/KeccakP-1600/AVX512/KeccakP-1600-AVX512.s",
-                "KeccakP1600_AVX512_Permute_24rounds",
-            ),
-            "aarch64" => (
-                "lib/low/KeccakP-1600/ARMv8A/KeccakP-1600-armv8a-neon.s",
-                "KeccakP1600_Permute_24rounds",
-            ),
-            arch => panic!("xkcp: unsupported target {arch}-{}", ctx.target_os),
-        };
-
-        let asm_path = ctx.out_dir.join("keccak1600_xkcp.S");
-        let src = fs::read_to_string(xkcp.join(src_rel)).unwrap();
-        let patched = if ctx.target_arch == "aarch64" {
-            let with_globals = export_asm_symbols(&src, &[native_entry], ctx.is_macos);
-            rewrite_xkcp_neon_lane_syntax(&with_globals)
-        } else {
-            src
-        };
-        fs::write(&asm_path, patched).unwrap();
-
-        ctx.cc().file(&asm_path).compile("keccak_xkcp");
-        println!("cargo:rerun-if-changed={}", xkcp.display());
-
-        native_entry.to_string()
-    }
-}
-
 mod openssl {
     use super::*;
 
@@ -222,7 +139,7 @@ mod openssl {
         let x86_64 = openssl.join("crypto/sha/asm/keccak1600-x86_64.pl");
         assert!(
             armv8.exists() && x86_64.exists(),
-            "openssl submodule missing. Run: git submodule update --init --recursive"
+            "openssl submodule missing. Run: git submodule update --init extensions/keccak256/rvr/ffi/openssl"
         );
 
         // `+sha3` flavor enables ARMv8.2 SHA3-ext (`KeccakF1600_cext`); we use
@@ -255,7 +172,20 @@ mod openssl {
             .include(openssl.join("crypto"))
             .file(&asm_path)
             .compile("keccak_openssl");
-        println!("cargo:rerun-if-changed={}", openssl.display());
+        println!("cargo:rerun-if-changed={}", armv8.display());
+        println!("cargo:rerun-if-changed={}", x86_64.display());
+        println!(
+            "cargo:rerun-if-changed={}",
+            openssl.join("crypto/arm_arch.h").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            openssl.join("crypto/perlasm/arm-xlate.pl").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            openssl.join("crypto/perlasm/x86_64-xlate.pl").display()
+        );
 
         native_entry.to_string()
     }

--- a/extensions/keccak256/rvr/ffi/build.rs
+++ b/extensions/keccak256/rvr/ffi/build.rs
@@ -17,7 +17,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=PATH");
 
     let ctx = BuildCtx::from_env();
-    let native_entry = openssl::build(&ctx);
+    let native_entry = build_openssl(&ctx);
 
     let shim_path = ctx.out_dir.join("rvr_keccak_shim.c");
     fs::write(&shim_path, shim_c(&native_entry)).expect("write shim");
@@ -130,63 +130,59 @@ fn run_perl(script: &Path, flavor: &str, out_path: &Path) {
     assert!(out_path.exists(), "asm not generated at {out_path:?}");
 }
 
-mod openssl {
-    use super::*;
+fn build_openssl(ctx: &BuildCtx) -> String {
+    let openssl = ctx.manifest_dir.join("openssl");
+    let armv8 = openssl.join("crypto/sha/asm/keccak1600-armv8.pl");
+    let x86_64 = openssl.join("crypto/sha/asm/keccak1600-x86_64.pl");
+    assert!(
+        armv8.exists() && x86_64.exists(),
+        "openssl submodule missing. Run: git submodule update --init extensions/keccak256/rvr/ffi/openssl"
+    );
 
-    pub fn build(ctx: &BuildCtx) -> String {
-        let openssl = ctx.manifest_dir.join("openssl");
-        let armv8 = openssl.join("crypto/sha/asm/keccak1600-armv8.pl");
-        let x86_64 = openssl.join("crypto/sha/asm/keccak1600-x86_64.pl");
-        assert!(
-            armv8.exists() && x86_64.exists(),
-            "openssl submodule missing. Run: git submodule update --init extensions/keccak256/rvr/ffi/openssl"
-        );
+    // `+sha3` flavor enables ARMv8.2 SHA3-ext (`KeccakF1600_cext`); we use
+    // it on Apple Silicon (always SHA3-capable) and skip it on Linux aarch64
+    // to avoid emitting unreachable code.
+    let (script, flavor, extra_globals, native_entry) =
+        match (ctx.target_arch.as_str(), ctx.target_os.as_str()) {
+            ("x86_64", "macos") => (x86_64.as_path(), "macosx", &[] as &[&str], "KeccakF1600"),
+            ("x86_64", "linux") => (x86_64.as_path(), "linux64", &[] as &[&str], "KeccakF1600"),
+            ("aarch64", "macos") => (
+                armv8.as_path(),
+                "ios64+sha3",
+                &["KeccakF1600_cext"][..],
+                "KeccakF1600_cext",
+            ),
+            ("aarch64", "linux") => (armv8.as_path(), "linux64", &[] as &[&str], "KeccakF1600"),
+            (arch, os) => panic!("openssl: unsupported target {arch}-{os}"),
+        };
 
-        // `+sha3` flavor enables ARMv8.2 SHA3-ext (`KeccakF1600_cext`); we use
-        // it on Apple Silicon (always SHA3-capable) and skip it on Linux
-        // aarch64 to avoid emitting unreachable code.
-        let (script, flavor, extra_globals, native_entry) =
-            match (ctx.target_arch.as_str(), ctx.target_os.as_str()) {
-                ("x86_64", "macos") => (x86_64.as_path(), "macosx", &[] as &[&str], "KeccakF1600"),
-                ("x86_64", "linux") => (x86_64.as_path(), "linux64", &[] as &[&str], "KeccakF1600"),
-                ("aarch64", "macos") => (
-                    armv8.as_path(),
-                    "ios64+sha3",
-                    &["KeccakF1600_cext"][..],
-                    "KeccakF1600_cext",
-                ),
-                ("aarch64", "linux") => (armv8.as_path(), "linux64", &[] as &[&str], "KeccakF1600"),
-                (arch, os) => panic!("openssl: unsupported target {arch}-{os}"),
-            };
+    let asm_path = ctx.out_dir.join("keccak1600_openssl.S");
+    run_perl(script, flavor, &asm_path);
 
-        let asm_path = ctx.out_dir.join("keccak1600_openssl.S");
-        run_perl(script, flavor, &asm_path);
+    let mut labels: Vec<&str> = vec!["KeccakF1600"];
+    labels.extend_from_slice(extra_globals);
+    let asm = fs::read_to_string(&asm_path).unwrap();
+    fs::write(&asm_path, export_asm_symbols(&asm, &labels, ctx.is_macos)).unwrap();
 
-        let mut labels: Vec<&str> = vec!["KeccakF1600"];
-        labels.extend_from_slice(extra_globals);
-        let asm = fs::read_to_string(&asm_path).unwrap();
-        fs::write(&asm_path, export_asm_symbols(&asm, &labels, ctx.is_macos)).unwrap();
+    // The emitted armv8 asm `#include`s `arm_arch.h` for PAC/BTI hints.
+    ctx.cc()
+        .include(openssl.join("crypto"))
+        .file(&asm_path)
+        .compile("keccak_openssl");
+    println!("cargo:rerun-if-changed={}", armv8.display());
+    println!("cargo:rerun-if-changed={}", x86_64.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        openssl.join("crypto/arm_arch.h").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        openssl.join("crypto/perlasm/arm-xlate.pl").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        openssl.join("crypto/perlasm/x86_64-xlate.pl").display()
+    );
 
-        // The emitted armv8 asm `#include`s `arm_arch.h` for PAC/BTI hints.
-        ctx.cc()
-            .include(openssl.join("crypto"))
-            .file(&asm_path)
-            .compile("keccak_openssl");
-        println!("cargo:rerun-if-changed={}", armv8.display());
-        println!("cargo:rerun-if-changed={}", x86_64.display());
-        println!(
-            "cargo:rerun-if-changed={}",
-            openssl.join("crypto/arm_arch.h").display()
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            openssl.join("crypto/perlasm/arm-xlate.pl").display()
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            openssl.join("crypto/perlasm/x86_64-xlate.pl").display()
-        );
-
-        native_entry.to_string()
-    }
+    native_entry.to_string()
 }

--- a/extensions/keccak256/rvr/ffi/src/lib.rs
+++ b/extensions/keccak256/rvr/ffi/src/lib.rs
@@ -1,21 +1,6 @@
 //! Rust-side handle for the keccak-f[1600] asm staticlib (built in `build.rs`).
 
-#[cfg(all(feature = "backend-xkcp", feature = "backend-openssl"))]
-compile_error!("pick exactly one keccak backend (backend-openssl / backend-xkcp)");
-
 unsafe extern "C" {
     /// Apply keccak-f[1600] to a 25-lane u64 state in place.
     pub fn rvr_keccak_f1600(state: *mut u64);
 }
-
-/// Name of the backend compiled into this crate.
-pub const ACTIVE_BACKEND: &str = {
-    #[cfg(feature = "backend-openssl")]
-    {
-        "openssl"
-    }
-    #[cfg(feature = "backend-xkcp")]
-    {
-        "xkcp"
-    }
-};

--- a/extensions/pairing/rvr/Cargo.toml
+++ b/extensions/pairing/rvr/Cargo.toml
@@ -15,3 +15,5 @@ openvm-instructions.workspace = true
 openvm-pairing-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
+[build-dependencies]
+rvr-openvm-build.workspace = true

--- a/extensions/pairing/rvr/build.rs
+++ b/extensions/pairing/rvr/build.rs
@@ -2,7 +2,9 @@
 // to. The path to the resulting `librvr_openvm_ext_pairing_ffi.a` is exposed
 // to the source via the `RVR_PAIRING_FFI_STATICLIB` cargo env var.
 
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
+
+use rvr_openvm_build::build_rust_staticlib;
 
 fn main() {
     let manifest_dir =
@@ -12,30 +14,11 @@ fn main() {
     let ffi_manifest = manifest_dir.join("ffi/Cargo.toml");
     let ffi_target_dir = out_dir.join("ffi-target");
 
-    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(&cargo)
-        .args([
-            "build",
-            "--release",
-            "--config",
-            "profile.release.lto=false",
-            "--manifest-path",
-        ])
-        .arg(&ffi_manifest)
-        .arg("--target-dir")
-        .arg(&ffi_target_dir)
-        .status()
-        .expect("failed to spawn cargo for rvr-openvm-ext-pairing-ffi");
-    assert!(
-        status.success(),
-        "cargo build for rvr-openvm-ext-pairing-ffi failed"
-    );
-
-    let lib_path = ffi_target_dir.join("release/librvr_openvm_ext_pairing_ffi.a");
-    assert!(
-        lib_path.exists(),
-        "expected staticlib at {} after cargo build",
-        lib_path.display()
+    let lib_path = build_rust_staticlib(
+        &ffi_manifest,
+        &ffi_target_dir,
+        "librvr_openvm_ext_pairing_ffi.a",
+        "rvr-openvm-ext-pairing-ffi",
     );
 
     println!(

--- a/extensions/sha2/rvr/Cargo.toml
+++ b/extensions/sha2/rvr/Cargo.toml
@@ -15,3 +15,5 @@ openvm-instructions.workspace = true
 openvm-sha2-transpiler.workspace = true
 openvm-stark-backend.workspace = true
 
+[build-dependencies]
+rvr-openvm-build.workspace = true

--- a/extensions/sha2/rvr/build.rs
+++ b/extensions/sha2/rvr/build.rs
@@ -2,7 +2,9 @@
 // to. The path to the resulting `librvr_openvm_ext_sha2_ffi.a` is exposed
 // to the source via the `RVR_SHA2_FFI_STATICLIB` cargo env var.
 
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
+
+use rvr_openvm_build::build_rust_staticlib;
 
 fn main() {
     let manifest_dir =
@@ -13,30 +15,11 @@ fn main() {
     // Use a private target dir to avoid lock contention with the outer cargo.
     let ffi_target_dir = out_dir.join("ffi-target");
 
-    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(&cargo)
-        .args([
-            "build",
-            "--release",
-            "--config",
-            "profile.release.lto=false",
-            "--manifest-path",
-        ])
-        .arg(&ffi_manifest)
-        .arg("--target-dir")
-        .arg(&ffi_target_dir)
-        .status()
-        .expect("failed to spawn cargo for rvr-openvm-ext-sha2-ffi");
-    assert!(
-        status.success(),
-        "cargo build for rvr-openvm-ext-sha2-ffi failed"
-    );
-
-    let lib_path = ffi_target_dir.join("release/librvr_openvm_ext_sha2_ffi.a");
-    assert!(
-        lib_path.exists(),
-        "expected staticlib at {} after cargo build",
-        lib_path.display()
+    let lib_path = build_rust_staticlib(
+        &ffi_manifest,
+        &ffi_target_dir,
+        "librvr_openvm_ext_sha2_ffi.a",
+        "rvr-openvm-ext-sha2-ffi",
     );
 
     println!(


### PR DESCRIPTION
## Summary

- Standardize all RVR native FFI builds on clang (default `clang-22`). Non-clang `CC` values are now ignored and an explicit error points users at `RVR_CC=clang-22` / `clang-22` install instructions instead of silently falling back to GCC.
- Drop the XKCP keccak backend and its submodule; keep only the OpenSSL asm backend. Removes the `backend-openssl` / `backend-xkcp` cargo features from `rvr-openvm-ext-keccak-ffi`.
- Extract shared RVR build-script logic into a new `rvr-openvm-build` crate (`default_compiler_command`, `ensure_clang_compiler`, `command_exists`, `build_rust_staticlib`) and reuse it from every `extensions/*/rvr/build.rs` and from `rvr-openvm`'s toolchain module.
- Replace `submodules: recursive` checkouts in `lints.yml` and `riscv.yml` with targeted `git submodule update --init --depth 1` for just the submodules each job needs; mark the secp256k1 submodule shallow.


resolves int-7568
