### PR TITLE
Persist EVM setup keys before verifier generation

### DIFF
--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -130,9 +130,6 @@ impl SetupCmd {
             println!("Generating root verifier ASM...");
             let root_verifier_asm = sdk.generate_root_verifier_asm();
 
-            println!("Generating verifier contract...");
-            let verifier = sdk.generate_halo2_verifier_solidity()?;
-
             println!("Writing stark proving key to file...");
             write_object_to_file(&default_agg_stark_pk_path, sdk.agg_pk())?;
 
@@ -144,6 +141,9 @@ impl SetupCmd {
 
             println!("Writing root verifier ASM to file...");
             write(&default_asm_path, root_verifier_asm)?;
+
+            println!("Generating verifier contract...");
+            let verifier = sdk.generate_halo2_verifier_solidity()?;
 
             println!("Writing verifier contract to file...");
             write_evm_halo2_verifier_to_folder(verifier, &default_evm_halo2_verifier_path)?;


### PR DESCRIPTION
### Summary

Persist reusable EVM setup artifacts before attempting Solidity verifier generation.

### Problem

`cargo openvm setup --evm` generates the aggregation/Halo2 key material before calling `generate_halo2_verifier_solidity()`, but it only writes those reusable artifacts to disk afterwards.

If verifier generation fails, the command exits before persisting:

- `agg_stark.pk`
- `agg_stark.vk`
- `agg_halo2.pk`
- `root.asm`

This forces the next run to regenerate expensive key material unnecessarily.

### Change

Write the reusable setup artifacts before Solidity verifier generation in the EVM setup path:

- write `agg_stark.pk`
- write `agg_stark.vk`
- write `agg_halo2.pk`
- write `root.asm`
- then call `generate_halo2_verifier_solidity()`
- then write the verifier contract bundle

This keeps the fix scoped to CLI-side ordering without changing SDK key generation or verifier generation behavior.

### Verification

- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Local `cargo check` remains blocked on this Windows machine by an MSVC/libgit2 link environment issue unrelated to `setup.rs`.

Closes #2356.
