### PR TITLE
fix(v2.1-rvr): make rvr execution and preflight consistent

### DIFF
--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -614,3 +614,36 @@ impl SegmentationCtx {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn small_segmentation_ctx() -> SegmentationCtx {
+        let config = SegmentationConfig {
+            limits: SegmentationLimits::new(4, usize::MAX, usize::MAX),
+            ..SegmentationConfig::default()
+        };
+        SegmentationCtx::new(
+            vec!["air".to_string()],
+            vec![1],
+            vec![0],
+            vec![false],
+            config,
+        )
+    }
+
+    #[test]
+    fn test_check_and_segment_uses_last_safe_checkpoint() {
+        let mut ctx = small_segmentation_ctx();
+        ctx.update_checkpoint(10, &[2]);
+
+        let mut trace_heights = vec![8];
+        assert!(ctx.check_and_segment(15, &mut trace_heights, &[false]));
+
+        assert_eq!(ctx.segments.len(), 1);
+        assert_eq!(ctx.segments[0].instret_start, 0);
+        assert_eq!(ctx.segments[0].num_insns, 10);
+        assert_eq!(ctx.segments[0].trace_heights, vec![2]);
+    }
+}

--- a/crates/vm/src/arch/rvr/bridge.rs
+++ b/crates/vm/src/arch/rvr/bridge.rs
@@ -5,7 +5,12 @@
 //! `Streams<F>` and the host RNG are borrowed directly into [`OpenVmIoState`]
 //! and never converted upfront.
 
-use openvm_instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS};
+use std::mem::{align_of, size_of};
+
+use openvm_instructions::{
+    riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS},
+    DEFERRAL_AS,
+};
 use rvr_state::NUM_REGS_I;
 
 use super::{compile::CompileError, ExecuteError};
@@ -28,6 +33,19 @@ pub fn rv32_memory_ptr<F>(vm_state: &mut VmState<F, GuestMemory>) -> *mut u8 {
 
 pub fn public_values_slice(memory: &mut AddressMap) -> &mut [u8] {
     memory.mem[PUBLIC_VALUES_AS as usize].as_mut_slice()
+}
+
+/// Raw alias of the `F`-typed DEFERRAL address space.
+/// The returned length is in `F` cells, not bytes.
+pub fn deferral_memory_ptr<F>(memory: &mut AddressMap) -> (*mut F, usize) {
+    let bytes = memory.mem[DEFERRAL_AS as usize].as_mut_slice();
+    debug_assert_eq!(
+        bytes.as_mut_ptr().addr() % align_of::<F>(),
+        0,
+        "DEFERRAL_AS buffer must be aligned for F"
+    );
+    debug_assert_eq!(bytes.len() % size_of::<F>(), 0);
+    (bytes.as_mut_ptr().cast::<F>(), bytes.len() / size_of::<F>())
 }
 
 pub fn read_rv32_registers<F>(vm_state: &VmState<F, GuestMemory>) -> [u32; NUM_REGS_I] {

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -12,7 +12,10 @@ use rvr_openvm_lift::{ExtensionError, ExtensionRegistry};
 use rvr_state::{ExecutionStatus, MemoryError, Rv32, RvState, SuspenderState, TracerState};
 
 use super::{
-    bridge::{public_values_slice, read_rv32_registers, rv32_memory_ptr, write_rv32_registers},
+    bridge::{
+        deferral_memory_ptr, public_values_slice, read_rv32_registers, rv32_memory_ptr,
+        write_rv32_registers,
+    },
     compile::RvrCompiled,
     io::{
         host_hint_buffer, host_hint_input, host_hint_random, host_hint_storew,
@@ -71,6 +74,8 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
     vm_state: &'a mut VmState<F, GuestMemory>,
 ) -> OpenVmIoState<'a, F> {
     let memory_ptr = rv32_memory_ptr(vm_state);
+    let (deferral_memory, deferral_memory_len) =
+        deferral_memory_ptr::<F>(&mut vm_state.memory.memory);
     let streams = &mut vm_state.streams;
     OpenVmIoState {
         input_stream: &mut streams.input_stream,
@@ -78,6 +83,8 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
         rng: &mut vm_state.rng,
         memory_ptr,
         public_values: public_values_slice(&mut vm_state.memory.memory),
+        deferral_memory,
+        deferral_memory_len,
         deferrals: &mut streams.deferrals,
     }
 }

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -18,12 +18,16 @@ use crate::arch::deferral::DeferralState;
 /// one rvr call. Streams, rng, and the public-values byte slice are mutable
 /// borrows; `memory_ptr` is a raw alias of VmState's main memory buffer
 /// (raw because the C engine accesses it directly via pointer).
+///
+/// `deferral_memory` aliases AS=4 as `F` cells for deferral accumulator updates.
 pub struct OpenVmIoState<'a, F: PrimeField32> {
     pub input_stream: &'a mut VecDeque<Vec<F>>,
     pub hint_stream: &'a mut VecDeque<F>,
     pub rng: &'a mut StdRng,
     pub memory_ptr: *mut u8,
     pub public_values: &'a mut [u8],
+    pub deferral_memory: *mut F,
+    pub deferral_memory_len: usize,
     pub deferrals: &'a mut Vec<DeferralState>,
 }
 
@@ -182,6 +186,8 @@ mod tests {
             rng: &mut rng,
             memory_ptr: memory.as_mut_ptr(),
             public_values: &mut public_values,
+            deferral_memory: std::ptr::null_mut(),
+            deferral_memory_len: 0,
             deferrals: &mut deferrals,
         };
 

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -281,11 +281,12 @@ impl SegmentationState {
 
         self.memory_ctx.page_indices.clear();
         self.memory_ctx.addr_space_access_count.fill(0);
-        // RVR only suspends at segment boundaries today, after flushing the
-        // boundary-crossing page buffers below. Mid-segment suspension would
-        // need to preserve this checkpoint buffer instead of resetting it.
         self.memory_ctx.page_indices_since_checkpoint_len = 0;
 
+        // RVR can only suspend at block boundaries, so segmentation uses the
+        // last safe checkpoint. The pages accumulated since that checkpoint
+        // belong to the next segment and must seed its memory trace heights
+        // after the previous segment's heights are subtracted.
         self.flush_page_buffer(mem_len, pv_len, deferral_len);
         self.apply_height_updates();
 
@@ -304,13 +305,14 @@ impl SegmentationState {
         remaining_counter: u32,
     ) -> bool {
         let seg_check_insns = self.segmentation_ctx.segment_check_insns;
-        self.segmentation_ctx.instret += seg_check_insns;
+        let insns_since_last_check = seg_check_insns - remaining_counter as u64;
+        let instret = self.segmentation_ctx.instret + insns_since_last_check;
+        self.segmentation_ctx.instret = instret;
         self.segmentation_ctx.instrets_until_check = seg_check_insns;
 
         self.flush_page_buffer(mem_len, pv_len, deferral_len);
         self.apply_height_updates();
 
-        let instret = self.segmentation_ctx.instret - remaining_counter as u64;
         let did_segment = self.segmentation_ctx.check_and_segment(
             instret,
             &mut self.trace_heights,
@@ -320,8 +322,6 @@ impl SegmentationState {
         if did_segment {
             self.segmentation_ctx
                 .initialize_segment(&mut self.trace_heights, &self.is_trace_height_constant);
-            // Re-apply the boundary-crossing page accesses after clearing the
-            // segment-local page set so the new segment starts with them.
             self.initialize_segment_memory(mem_len, pv_len, deferral_len);
 
             self.segmentation_ctx.warn_if_exceeds_limits(
@@ -387,8 +387,10 @@ pub unsafe extern "C" fn metered_periodic_check(t: *mut MeteredTracerData) -> u8
         seg_state.segmentation_ctx.segment_check_insns
     );
 
-    // Reset the countdown for the next interval.
-    tracer.check_counter += segment_check_insns;
+    // We are at the start of a block that would cross the old countdown.
+    // `remaining_counter` was used to record this block start as the metering
+    // boundary, so the next interval starts here with a full countdown.
+    tracer.check_counter = segment_check_insns;
     did_segment as u8
 }
 
@@ -478,5 +480,124 @@ impl<F: PrimeField32> RvrMeteredSegmentInstance<F> {
             metrics.record(insns);
         }
         Ok((result, vm_state))
+    }
+}
+
+#[cfg(all(test, feature = "rvr"))]
+mod tests {
+    use super::*;
+    use crate::{
+        arch::{execution_mode::metered::ctx::DEFAULT_PAGE_BITS, BOUNDARY_AIR_ID, MERKLE_AIR_ID},
+        utils::test_system_config,
+    };
+
+    fn make_segmentation_state() -> SegmentationState {
+        let system_config = test_system_config();
+        let num_airs = 6;
+        let mut air_names = (0..num_airs)
+            .map(|idx| format!("Air {idx}"))
+            .collect::<Vec<_>>();
+        air_names[BOUNDARY_AIR_ID] = "Memory Boundary".to_string();
+        air_names[MERKLE_AIR_ID] = "Memory Merkle".to_string();
+
+        let ctx = MeteredCtx::<DEFAULT_PAGE_BITS>::new(
+            vec![None; num_airs],
+            air_names,
+            vec![1; num_airs],
+            vec![0; num_airs],
+            vec![false; num_airs],
+            &system_config,
+        );
+        SegmentationState::new(ctx, &system_config)
+    }
+
+    #[test]
+    fn test_initialize_segment_memory_replays_checkpoint_pages() {
+        let mut with_interval_buffer = make_segmentation_state();
+        with_interval_buffer.mem_page_buf[0] = 7;
+        with_interval_buffer.pv_page_buf[0] = 3;
+        with_interval_buffer.deferral_page_buf[0] = 2;
+        with_interval_buffer.initialize_segment_memory(1, 1, 1);
+
+        let mut clean = make_segmentation_state();
+        clean.initialize_segment_memory(0, 0, 0);
+
+        assert!(
+            with_interval_buffer.trace_heights[BOUNDARY_AIR_ID]
+                > clean.trace_heights[BOUNDARY_AIR_ID]
+        );
+        assert!(
+            with_interval_buffer.trace_heights[MERKLE_AIR_ID] > clean.trace_heights[MERKLE_AIR_ID]
+        );
+        let poseidon2_idx = clean.trace_heights.len() - 2;
+        assert!(
+            with_interval_buffer.trace_heights[poseidon2_idx] > clean.trace_heights[poseidon2_idx]
+        );
+    }
+
+    #[test]
+    fn test_periodic_check_records_block_boundary_instret() {
+        let mut seg_state = make_segmentation_state();
+        seg_state.segmentation_ctx.segment_check_insns = 1000;
+        seg_state.segmentation_ctx.instrets_until_check = 1000;
+
+        assert!(!seg_state.on_periodic_check(0, 0, 0, 250));
+
+        assert_eq!(seg_state.segmentation_ctx.instret, 750);
+        assert_eq!(seg_state.segmentation_ctx.instrets_until_check, 1000);
+    }
+
+    #[test]
+    fn test_periodic_callback_starts_next_interval_at_block_boundary() {
+        let mut seg_state = make_segmentation_state();
+        seg_state.segmentation_ctx.segment_check_insns = 1000;
+        seg_state.segmentation_ctx.instrets_until_check = 1000;
+        let mut tracer = MeteredTracerData {
+            trace_heights: seg_state.trace_heights_ptr(),
+            mem_page_buf: seg_state.mem_page_buf_ptr(),
+            pv_page_buf: seg_state.pv_page_buf_ptr(),
+            deferral_page_buf: seg_state.deferral_page_buf_ptr(),
+            on_check: Some(metered_periodic_check),
+            seg_state: &mut seg_state as *mut SegmentationState as *mut c_void,
+            mem_page_buf_len: 0,
+            pv_page_buf_len: 0,
+            deferral_page_buf_len: 0,
+            check_counter: 250,
+            last_mem_page: NO_LAST_PAGE,
+        };
+
+        let did_segment = unsafe { metered_periodic_check(&mut tracer) };
+
+        assert_eq!(did_segment, 0);
+        assert_eq!(tracer.check_counter, 1000);
+        assert_eq!(seg_state.segmentation_ctx.instret, 750);
+    }
+
+    #[test]
+    fn test_periodic_callback_starts_next_interval_when_suspending() {
+        let mut seg_state = make_segmentation_state();
+        seg_state.segmentation_ctx.segment_check_insns = 1000;
+        seg_state.segmentation_ctx.instrets_until_check = 1000;
+        seg_state.segmentation_ctx.config.limits.max_trace_height = 1;
+        *seg_state.trace_heights.last_mut().unwrap() = 2;
+        let mut tracer = MeteredTracerData {
+            trace_heights: seg_state.trace_heights_ptr(),
+            mem_page_buf: seg_state.mem_page_buf_ptr(),
+            pv_page_buf: seg_state.pv_page_buf_ptr(),
+            deferral_page_buf: seg_state.deferral_page_buf_ptr(),
+            on_check: Some(metered_periodic_check),
+            seg_state: &mut seg_state as *mut SegmentationState as *mut c_void,
+            mem_page_buf_len: 0,
+            pv_page_buf_len: 0,
+            deferral_page_buf_len: 0,
+            check_counter: 250,
+            last_mem_page: NO_LAST_PAGE,
+        };
+
+        let did_segment = unsafe { metered_periodic_check(&mut tracer) };
+
+        assert_eq!(did_segment, 1);
+        assert_eq!(tracer.check_counter, 1000);
+        assert_eq!(seg_state.segmentation_ctx.instret, 750);
     }
 }

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -9,11 +9,9 @@ use openvm_stark_sdk::{
 };
 
 #[cfg(any(feature = "aot", feature = "rvr"))]
-use crate::arch::SystemConfig;
-#[cfg(any(feature = "aot", feature = "rvr"))]
 use crate::arch::VmState;
 #[cfg(any(feature = "aot", feature = "rvr"))]
-use crate::system::memory::online::GuestMemory;
+use crate::system::memory::online::{GuestMemory, LinearMemory};
 use crate::{
     arch::{
         debug_proving_ctx, execution_mode::Segment, verify_segments, vm::VirtualMachine, Executor,
@@ -114,7 +112,6 @@ fn is_periphery_air(air_name: &str) -> bool {
 #[cfg(feature = "aot")]
 pub fn check_aot_equivalence<E, VB>(
     vm: &VirtualMachine<E, VB>,
-    config: &VB::VmConfig,
     exe: &VmExe<Val<E::SC>>,
     input: &Streams<Val<E::SC>>,
 ) -> eyre::Result<()>
@@ -141,18 +138,7 @@ where
             .execute(input.clone(), None)
             .expect("Failed to execute");
 
-        let system_config: &SystemConfig = config.as_ref();
-        let addr_spaces = &system_config.memory_config.addr_spaces;
-        let assert_vm_state_eq =
-            |lhs: &VmState<Val<E::SC>, GuestMemory>, rhs: &VmState<Val<E::SC>, GuestMemory>| {
-                assert_eq!(lhs.pc(), rhs.pc());
-                for r in 0..addr_spaces[1].num_cells {
-                    let a = unsafe { lhs.memory.read::<u8, 1>(1, r as u32) };
-                    let b = unsafe { rhs.memory.read::<u8, 1>(1, r as u32) };
-                    assert_eq!(a, b);
-                }
-            };
-        assert_vm_state_eq(&interp_state_pure, &aot_state_pure);
+        check_vm_state_eq(&interp_state_pure, &aot_state_pure)?;
     }
 
     /*
@@ -169,16 +155,7 @@ where
             .naive_metered_interpreter(exe)?
             .execute_metered(input.clone(), metered_ctx.clone())?;
 
-        assert_eq!(interp_state_metered.pc(), aot_state_metered.pc());
-
-        let system_config: &SystemConfig = config.as_ref();
-        let addr_spaces = &system_config.memory_config.addr_spaces;
-
-        for r in 0..addr_spaces[1].num_cells {
-            let interp = unsafe { interp_state_metered.memory.read::<u8, 1>(1, r as u32) };
-            let aot_interp = unsafe { aot_state_metered.memory.read::<u8, 1>(1, r as u32) };
-            assert_eq!(interp, aot_interp);
-        }
+        check_vm_state_eq(&interp_state_metered, &aot_state_metered)?;
 
         assert_eq!(segments.len(), aot_segments.len());
         for i in 0..segments.len() {
@@ -191,6 +168,47 @@ where
     Ok(())
 }
 
+/// Checks that two `VmState`s are byte-identical: same `pc` and the same
+/// bytes in every guest address space. Reports the diverging AS, byte offset,
+/// and both byte values on failure. Short-circuits at the first mismatch.
+#[cfg(any(feature = "aot", feature = "rvr"))]
+fn check_vm_state_eq<F: PrimeField32>(
+    lhs: &VmState<F, GuestMemory>,
+    rhs: &VmState<F, GuestMemory>,
+) -> eyre::Result<()> {
+    if lhs.pc() != rhs.pc() {
+        eyre::bail!("pc mismatch: interp={}, rvr={}", lhs.pc(), rhs.pc());
+    }
+    let lhs_mems = &lhs.memory.memory.mem;
+    let rhs_mems = &rhs.memory.memory.mem;
+    if lhs_mems.len() != rhs_mems.len() {
+        eyre::bail!(
+            "address space count mismatch: interp={}, rvr={}",
+            lhs_mems.len(),
+            rhs_mems.len()
+        );
+    }
+    for (as_idx, (l_mem, r_mem)) in lhs_mems.iter().zip(rhs_mems).enumerate() {
+        let l = l_mem.as_slice();
+        let r = r_mem.as_slice();
+        if l.len() != r.len() {
+            eyre::bail!(
+                "address space {as_idx} size mismatch: interp={}, rvr={}",
+                l.len(),
+                r.len()
+            );
+        }
+        if let Some(offset) = l.iter().zip(r).position(|(a, b)| a != b) {
+            eyre::bail!(
+                "guest memory mismatch in AS={as_idx} at byte offset 0x{offset:08x}: interp={}, rvr={}",
+                l[offset],
+                r[offset]
+            );
+        }
+    }
+    Ok(())
+}
+
 // Compares the output of the interpreter and the RVR instance for pure and metered execution.
 // Metered comparison is relaxed because rvr segments at block granularity while OpenVM segments
 // per-instruction, so segment boundaries differ. We assert: equal pure end-state, equal total
@@ -199,7 +217,6 @@ where
 #[cfg(feature = "rvr")]
 pub fn check_rvr_equivalence<E, VB>(
     vm: &VirtualMachine<E, VB>,
-    config: &VB::VmConfig,
     exe: &VmExe<Val<E::SC>>,
     input: &Streams<Val<E::SC>>,
 ) -> eyre::Result<()>
@@ -226,18 +243,7 @@ where
             .execute(input.clone(), None)
             .expect("Failed to execute");
 
-        let system_config: &SystemConfig = config.as_ref();
-        let addr_spaces = &system_config.memory_config.addr_spaces;
-        let assert_vm_state_eq =
-            |lhs: &VmState<Val<E::SC>, GuestMemory>, rhs: &VmState<Val<E::SC>, GuestMemory>| {
-                assert_eq!(lhs.pc(), rhs.pc());
-                for r in 0..addr_spaces[1].num_cells {
-                    let a = unsafe { lhs.memory.read::<u8, 1>(1, r as u32) };
-                    let b = unsafe { rhs.memory.read::<u8, 1>(1, r as u32) };
-                    assert_eq!(a, b);
-                }
-            };
-        assert_vm_state_eq(&interp_state_pure, &rvr_state_pure);
+        check_vm_state_eq(&interp_state_pure, &rvr_state_pure)?;
     }
 
     /*
@@ -366,10 +372,10 @@ where
     let metered_ctx = vm.build_metered_ctx(&exe);
 
     #[cfg(feature = "aot")]
-    check_aot_equivalence(&vm, &config, &exe, &input)?;
+    check_aot_equivalence(&vm, &exe, &input)?;
 
     #[cfg(feature = "rvr")]
-    check_rvr_equivalence(&vm, &config, &exe, &input)?;
+    check_rvr_equivalence(&vm, &exe, &input)?;
 
     let (segments, _) = vm
         .metered_interpreter(&exe)?

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -231,8 +231,16 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     let num_words = total_limbs / WORD_SIZE as u32;
     debug_assert!(num_words >= 1);
 
-    let mut src_words = vec![0u32; num_words as usize];
-    rd_mem_words_traced(state, rs1_ptr, &mut src_words);
+    let mut input_words = vec![0u32; num_words as usize];
+    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
-    wr_mem_words_traced(state, rd_ptr, &src_words);
+
+    // Setup validates that the guest-provided base-field modulus and setup
+    // inputs match the constants configured into this chip.
+    //
+    // In mod-builder, `Input(0)` means the first input slot. For setup, that
+    // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
+    // so each setup coordinate writes p % p = 0.
+    let output_words = vec![0u32; num_words as usize];
+    wr_mem_words_traced(state, rd_ptr, &output_words);
 }

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -259,10 +259,18 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     let num_words = num_limbs / WORD_SIZE as u32;
     debug_assert!(num_words >= 1);
 
-    let mut src_words = vec![0u32; num_words as usize];
-    rd_mem_words_traced(state, rs1_ptr, &mut src_words);
+    let mut input_words = vec![0u32; num_words as usize];
+    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
-    wr_mem_words_traced(state, rd_ptr, &src_words);
+
+    // Setup validates that the guest-provided modulus and setup inputs match
+    // the constants configured into this chip.
+    //
+    // In mod-builder, `Input(0)` means the first input slot. For setup, that
+    // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
+    // so the setup output is p % p = 0.
+    let output_words = vec![0u32; num_words as usize];
+    wr_mem_words_traced(state, rd_ptr, &output_words);
 }
 
 // ── Phantom: HintSqrt ────────────────────────────────────────────────────────

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -29,7 +29,7 @@ use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "rvr")]
-use crate::runtime::make_deferral_hash;
+use crate::runtime::{make_deferral_compress, make_deferral_hash};
 use crate::{
     call::{
         DeferralCallAdapterAir, DeferralCallAdapterExecutor, DeferralCallAdapterFiller,
@@ -75,7 +75,8 @@ pub struct DeferralExtension {
 impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
     fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: Option<&RvrExtensionCtx>) {
         let hash = make_deferral_hash::<F>();
-        let ext = DeferralRvrExtension::new(ctx, self.fns.clone(), hash)
+        let compress = make_deferral_compress::<F>();
+        let ext = DeferralRvrExtension::new(ctx, self.fns.clone(), hash, compress)
             .expect("failed to construct rvr DeferralRvrExtension");
         registry.register(ext);
     }

--- a/extensions/deferral/circuit/src/runtime.rs
+++ b/extensions/deferral/circuit/src/runtime.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use openvm_circuit::arch::VmField;
-use rvr_openvm_ext_deferral::DeferralHashFn;
+use rvr_openvm_ext_deferral::{DeferralCompressFn, DeferralHashFn};
 use rvr_openvm_ext_ffi_common::DEFERRAL_COMMIT_NUM_BYTES;
 
 use crate::{def_fn::hash_output_raw, poseidon2::deferral_poseidon2_chip};
@@ -18,4 +18,17 @@ pub fn make_deferral_hash<F: VmField>() -> DeferralHashFn {
                 .unwrap()
         },
     )
+}
+
+/// Builds the accumulator compression used by RVR deferral CALL.
+/// Inputs and outputs are canonical u32 field values.
+pub fn make_deferral_compress<F: VmField>() -> DeferralCompressFn {
+    let hasher = deferral_poseidon2_chip::<F>();
+    Arc::new(move |lhs, rhs| {
+        let lhs_f = lhs.map(F::from_u32);
+        let rhs_f = rhs.map(F::from_u32);
+        hasher
+            .perm(&lhs_f, &rhs_f, true)
+            .map(|v| v.as_canonical_u32())
+    })
 }

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -11,7 +11,9 @@ use openvm_circuit::arch::{
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_BYTES};
+use rvr_openvm_ext_ffi_common::{
+    DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_DIGEST_SIZE, DEFERRAL_OUTPUT_KEY_BYTES,
+};
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
     air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
@@ -21,14 +23,31 @@ use rvr_openvm_lift::{
 /// `(def_idx, output_raw) → output_commit` hasher registered by the host.
 pub type DeferralHashFn = Arc<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
 
+/// Poseidon2 compression over deferral accumulator field elements.
+/// Values cross the crate boundary as canonical u32s.
+pub type DeferralCompressFn = Arc<
+    dyn Fn([u32; DEFERRAL_DIGEST_SIZE], [u32; DEFERRAL_DIGEST_SIZE]) -> [u32; DEFERRAL_DIGEST_SIZE]
+        + Send
+        + Sync,
+>;
+
 pub struct DeferralCtx {
     pub fns: Vec<Arc<DeferralFn>>,
     pub hash: DeferralHashFn,
+    pub compress: DeferralCompressFn,
 }
 
 impl DeferralCtx {
-    pub fn new(fns: Vec<Arc<DeferralFn>>, hash: DeferralHashFn) -> Self {
-        Self { fns, hash }
+    pub fn new(
+        fns: Vec<Arc<DeferralFn>>,
+        hash: DeferralHashFn,
+        compress: DeferralCompressFn,
+    ) -> Self {
+        Self {
+            fns,
+            hash,
+            compress,
+        }
     }
 }
 
@@ -118,6 +137,7 @@ impl DeferralRvrExtension {
         ctx: Option<&RvrExtensionCtx>,
         fns: Vec<Arc<DeferralFn>>,
         hash: DeferralHashFn,
+        compress: DeferralCompressFn,
     ) -> Result<Self, ExtensionError> {
         let call_chip_idx = opcode_air_idx(ctx, DeferralOpcode::CALL)?;
         let output_chip_idx = opcode_air_idx(ctx, DeferralOpcode::OUTPUT)?;
@@ -130,7 +150,7 @@ impl DeferralRvrExtension {
             call_chip_idx,
             output_chip_idx,
             poseidon2_chip_idx,
-            deferral_ctx: DeferralCtx::new(fns, hash),
+            deferral_ctx: DeferralCtx::new(fns, hash, compress),
         })
     }
 }
@@ -217,6 +237,90 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
     }
 }
 
+// ── Deferral accumulator sync (DEFERRAL_AS) ────────────────────────────────
+//
+// CALL writes new `(input_acc, output_acc)` values to DEFERRAL_AS.
+
+fn commit_bytes_to_field_values(
+    bytes: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
+) -> [u32; DEFERRAL_DIGEST_SIZE] {
+    let mut out = [0u32; DEFERRAL_DIGEST_SIZE];
+    for (dst, chunk) in out.iter_mut().zip(bytes.chunks_exact(4)) {
+        *dst = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+    out
+}
+
+fn has_deferral_digest_range<F: PrimeField32>(io: &OpenVmIoState<'_, F>, ptr: usize) -> bool {
+    !io.deferral_memory.is_null()
+        && ptr
+            .checked_add(DEFERRAL_DIGEST_SIZE)
+            .is_some_and(|end| end <= io.deferral_memory_len)
+}
+
+/// Reads one accumulator digest from DEFERRAL_AS as canonical u32 values.
+///
+/// # Safety
+/// Caller must ensure `io.deferral_memory` is a valid `*mut F` pointing into
+/// a live DEFERRAL_AS buffer with at least `io.deferral_memory_len` F slots.
+unsafe fn read_deferral_digest<F: PrimeField32>(
+    io: &OpenVmIoState<'_, F>,
+    ptr: usize,
+) -> Option<[u32; DEFERRAL_DIGEST_SIZE]> {
+    if !has_deferral_digest_range(io, ptr) {
+        return None;
+    }
+    let mut out = [0u32; DEFERRAL_DIGEST_SIZE];
+    for (i, dst) in out.iter_mut().enumerate() {
+        *dst = (*io.deferral_memory.add(ptr + i)).as_canonical_u32();
+    }
+    Some(out)
+}
+
+/// Writes one accumulator digest to DEFERRAL_AS.
+///
+/// # Safety
+/// See `read_deferral_digest`. Each canonical u32 is converted back to `F`
+/// before writing to AS=4.
+unsafe fn write_deferral_digest<F: PrimeField32>(
+    io: &mut OpenVmIoState<'_, F>,
+    ptr: usize,
+    values: [u32; DEFERRAL_DIGEST_SIZE],
+) -> bool {
+    if !has_deferral_digest_range(io, ptr) {
+        return false;
+    }
+    for (i, value) in values.into_iter().enumerate() {
+        *io.deferral_memory.add(ptr + i) = F::from_u32(value);
+    }
+    true
+}
+
+/// Updates the input/output accumulator slots for one deferral CALL.
+/// Slot offsets are in F-element units.
+unsafe fn update_deferral_accumulators<F: PrimeField32>(
+    deferral_ctx: &DeferralCtx,
+    io: &mut OpenVmIoState<'_, F>,
+    def_idx: u32,
+    input_commit: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
+    output_commit: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
+) -> bool {
+    let input_acc_ptr = 2 * def_idx as usize * DEFERRAL_DIGEST_SIZE;
+    let output_acc_ptr = input_acc_ptr + DEFERRAL_DIGEST_SIZE;
+    let Some(old_input_acc) = read_deferral_digest(io, input_acc_ptr) else {
+        return false;
+    };
+    let Some(old_output_acc) = read_deferral_digest(io, output_acc_ptr) else {
+        return false;
+    };
+    let new_input_acc =
+        (deferral_ctx.compress)(old_input_acc, commit_bytes_to_field_values(input_commit));
+    let new_output_acc =
+        (deferral_ctx.compress)(old_output_acc, commit_bytes_to_field_values(output_commit));
+    write_deferral_digest(io, input_acc_ptr, new_input_acc)
+        && write_deferral_digest(io, output_acc_ptr, new_output_acc)
+}
+
 // ── Host callbacks ──────────────────────────────────────────────────────────
 
 type RegisterFn = unsafe extern "C" fn(*const DeferralHostCallbacks);
@@ -245,34 +349,44 @@ pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
     input_commit_raw: *const u8,
     output_key_out: *mut u8,
 ) -> i32 {
-    let dc = unsafe { &*(d_ctx as *const DeferralCtx) };
+    let deferral_ctx = unsafe { &*(d_ctx as *const DeferralCtx) };
     let io = unsafe { &mut *(io_ctx as *mut OpenVmIoState<'_, F>) };
 
-    let input_commit: Vec<u8> =
-        unsafe { std::slice::from_raw_parts(input_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec() };
+    let mut input_commit = [0u8; DEFERRAL_COMMIT_NUM_BYTES];
+    input_commit.copy_from_slice(unsafe {
+        std::slice::from_raw_parts(input_commit_raw, DEFERRAL_COMMIT_NUM_BYTES)
+    });
+    let input_commit_key = input_commit.to_vec();
 
-    let Some(state) = io.deferrals.get_mut(def_idx as usize) else {
+    let Some(deferral_state) = io.deferrals.get_mut(def_idx as usize) else {
         return 0;
     };
 
-    let (output_commit, output_len) = match state.get_input(&input_commit).clone() {
+    let (output_commit, output_len) = match deferral_state.get_input(&input_commit_key).clone() {
         InputMapVal::Output(commit) => {
-            let len = state.get_output(&commit).len() as u64;
-            let arr: [u8; DEFERRAL_COMMIT_NUM_BYTES] = commit.as_slice().try_into().unwrap();
-            (arr, len)
+            let len = deferral_state.get_output(&commit).len() as u64;
+            let output_commit: [u8; DEFERRAL_COMMIT_NUM_BYTES] =
+                commit.as_slice().try_into().unwrap();
+            (output_commit, len)
         }
         InputMapVal::Raw(input_raw) => {
-            let func = dc
+            let deferral_fn = deferral_ctx
                 .fns
                 .get(def_idx as usize)
                 .expect("deferral CALL: def_idx has no closure registered");
-            let output_raw = func.call_raw(&input_raw);
-            let commit = (dc.hash)(def_idx, &output_raw);
+            let output_raw = deferral_fn.call_raw(&input_raw);
+            let commit = (deferral_ctx.hash)(def_idx, &output_raw);
             let len = output_raw.len() as u64;
-            io.deferrals[def_idx as usize].store_output(&input_commit, commit.to_vec(), output_raw);
+            deferral_state.store_output(&input_commit_key, commit.to_vec(), output_raw);
             (commit, len)
         }
     };
+
+    if !unsafe {
+        update_deferral_accumulators(deferral_ctx, io, def_idx, &input_commit, &output_commit)
+    } {
+        return 0;
+    }
 
     let mut output_key = [0u8; DEFERRAL_OUTPUT_KEY_BYTES];
     output_key[..DEFERRAL_COMMIT_NUM_BYTES].copy_from_slice(&output_commit);


### PR DESCRIPTION
Three correctness fixes in the RVR backend so that its per-segment VM state is byte-identical to the Rust preflight executor's, plus a test-coverage fix that closes the gap that hid all three bugs from `check_rvr_equivalence`.

## Commits

### `test(v2.1-rvr): cover all guest address spaces in pure RVR equivalence check`

- `check_rvr_equivalence` (and its AOT sibling) only walked AS=1 (registers) byte-by-byte, silently missing any divergence in RV32 main memory (AS=2), public values (AS=3), and deferral (AS=4). All three correctness fixes below live in AS=2 or AS=4 and would have surfaced on the first `air_test`-style run if the check had walked every address space.

Extracted the closure into a `check_vm_state_eq(lhs, rhs) -> eyre::Result<()>` free function shared by both the RVR and AOT equivalence checks, replacing the AS=1-only loop with a slice-level diff over every `LinearMemory`. Short-circuits at the first mismatch and reports `(AS, byte offset, lhs, rhs)`. Microseconds on typical test VM configs.

### `fix(v2.1-rvr): use block-boundary instret in on_periodic_check`

- `SegmentationState::on_periodic_check` was bumping `segmentation_ctx.instret` by a full `segment_check_insns` interval up-front, then incrementing `tracer.check_counter` by the same delta on the way out. The anchor and the countdown ended up ahead of the actual VM by exactly `remaining_counter`, so the next interval inherited an inconsistent baseline.

In termination paths this could let the segmenter seal a non-terminal block as the final segment. The callback now:
- computes the actual block-boundary instret directly: `prev_anchor + (segment_check_insns - remaining_counter)`,
- writes that back as the new anchor,
- resets `check_counter` to a full fresh interval rather than incrementing.

This matches the Rust metered executor's behavior at the same point.

### `fix(v2.1-rvr): write zero output for modular/fp2 setup ops`

Mod-builder evaluates `SymbolicExpr` inputs **modulo the configured prime**. For `SETUP_ADDSUB` / `SETUP_MULDIV` and their Fp2 counterparts, the compute formula resolves to `Input(0)`, which during setup is the modulus `p` itself — so the variable is `p % p = 0`. The VM writes 32 zero bytes (64 for Fp2) to `rd`.

`rvr_ext_mod_setup` and `rvr_ext_fp2_setup` were copying `rs1`'s bytes (the modulus) to `rd`. Those bytes then leaked into the guest's stack as register-loaded values, propagating downstream as a memory divergence between RVR and preflight at later segment boundaries.

The FFI now traces the `rs1`/`rs2` reads (still required for chip metering) but writes zero bytes to `rd`.

### `fix(v2.1-rvr): sync DEFERRAL_AS in rvr_ext_deferral_call`

The deferral CALL FFI in RVR only traced AS=4 access for metering and never updated the `(input_acc, output_acc)` accumulator bytes. The Rust preflight executor (`DeferralCallExecutor::execute_e12_impl`) hashes each `(old_acc, commit)` pair via poseidon2 and writes the new accumulator F's to DEFERRAL_AS. Every deferral CALL therefore left RVR's AS=4 a hash-round behind preflight, producing a memory divergence that cascaded through subsequent CALLs.

Plumbed a `(*mut F, len_in_F_units)` alias of DEFERRAL_AS through `OpenVmIoState` (via a new `deferral_memory_ptr` helper in `bridge.rs` with a debug-mode alignment check on the `u8 → F` cast) and registered a `DeferralCompressFn` poseidon2 closure on the host side. `host_deferral_call_lookup` now hashes the accumulators and writes the new F bytes into AS=4 in F-element units that exactly match preflight's `vm_write::<F, BLOCK_SIZE>` layout. `F::from_u32` is bijective with the perm output for `MontyField31`, so the stored bytes are byte-identical to what the preflight executor writes.

resolves int-7974
