### PR TITLE
fix: constrain deferral circuit aggregation padding and depth

### DIFF
--- a/crates/circuits/primitives/src/encoder/mod.rs
+++ b/crates/circuits/primitives/src/encoder/mod.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 
 use openvm_stark_backend::{
-    interaction::InteractionBuilder,
+    p3_air::AirBuilder,
     p3_field::{Field, PrimeCharacteristicRing},
 };
 
@@ -84,7 +84,7 @@ impl Encoder {
     /// Construct the multivariate Lagrange polynomial for a specific point
     /// This polynomial equals 1 at the given point and 0 at all other points
     /// in our solution set
-    fn expression_for_point<AB: InteractionBuilder>(
+    fn expression_for_point<AB: AirBuilder<F: Field, Var: Copy>>(
         &self,
         pt: &[u32],
         vars: &[AB::Var],
@@ -116,7 +116,7 @@ impl Encoder {
 
     /// Get the polynomial expression that equals 1 when the variables encode the flag at index
     /// flag_idx
-    pub fn get_flag_expr<AB: InteractionBuilder>(
+    pub fn get_flag_expr<AB: AirBuilder<F: Field, Var: Copy>>(
         &self,
         flag_idx: usize,
         vars: &[AB::Var],
@@ -133,13 +133,13 @@ impl Encoder {
 
     /// Returns an expression that is 1 if the variables encode a valid flag and 0 if they encode
     /// the invalid point
-    pub fn is_valid<AB: InteractionBuilder>(&self, vars: &[AB::Var]) -> AB::Expr {
+    pub fn is_valid<AB: AirBuilder<F: Field, Var: Copy>>(&self, vars: &[AB::Var]) -> AB::Expr {
         debug_assert!(self.reserve_invalid);
         AB::Expr::ONE - self.expression_for_point::<AB>(&self.pts[0], vars)
     }
 
     /// Returns all flag expressions for the given variables
-    pub fn flags<AB: InteractionBuilder>(&self, vars: &[AB::Var]) -> Vec<AB::Expr> {
+    pub fn flags<AB: AirBuilder<F: Field, Var: Copy>>(&self, vars: &[AB::Var]) -> Vec<AB::Expr> {
         (0..self.flag_cnt)
             .map(|i| self.get_flag_expr::<AB>(i, vars))
             .collect()
@@ -147,7 +147,7 @@ impl Encoder {
 
     /// Returns the sum of expressions for all unused points
     /// This is used to ensure that variables encode only valid flags
-    pub fn sum_of_unused<AB: InteractionBuilder>(&self, vars: &[AB::Var]) -> AB::Expr {
+    pub fn sum_of_unused<AB: AirBuilder<F: Field, Var: Copy>>(&self, vars: &[AB::Var]) -> AB::Expr {
         let mut expr = AB::Expr::ZERO;
         for i in (self.flag_cnt + self.reserve_invalid as usize)..self.pts.len() {
             expr += self.expression_for_point::<AB>(&self.pts[i], vars);
@@ -161,7 +161,7 @@ impl Encoder {
     }
 
     /// Returns an expression that is 1 if `flag_idxs` contains the encoded flag and 0 otherwise
-    pub fn contains_flag<AB: InteractionBuilder>(
+    pub fn contains_flag<AB: AirBuilder<F: Field, Var: Copy>>(
         &self,
         vars: &[AB::Var],
         flag_idxs: &[usize],
@@ -172,7 +172,7 @@ impl Encoder {
     }
 
     /// Returns an expression that is 1 if (l..=r) contains the encoded flag and 0 otherwise
-    pub fn contains_flag_range<AB: InteractionBuilder>(
+    pub fn contains_flag_range<AB: AirBuilder<F: Field, Var: Copy>>(
         &self,
         vars: &[AB::Var],
         range: RangeInclusive<usize>,
@@ -183,7 +183,7 @@ impl Encoder {
     /// Returns an expression that is 0 if `flag_idxs_vals` doesn't contain the encoded flag
     /// and the corresponding val if it does
     /// `flag_idxs_vals` is a list of tuples (flag_idx, val)
-    pub fn flag_with_val<AB: InteractionBuilder>(
+    pub fn flag_with_val<AB: AirBuilder<F: Field, Var: Copy>>(
         &self,
         vars: &[AB::Var],
         flag_idx_vals: &[(usize, usize)],
@@ -196,7 +196,7 @@ impl Encoder {
     }
 }
 
-impl<AB: InteractionBuilder> SubAir<AB> for Encoder {
+impl<AB: AirBuilder<F: Field, Var: Copy>> SubAir<AB> for Encoder {
     type AirContext<'a>
         = &'a [AB::Var]
     where

--- a/crates/continuations/src/circuit/deferral/hook/mod.rs
+++ b/crates/continuations/src/circuit/deferral/hook/mod.rs
@@ -47,6 +47,8 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
                 compress_bus: bus_inventory.poseidon2_compress_bus,
                 permute_bus: bus_inventory.poseidon2_permute_bus,
             },
+            bus_inventory.power_checker_bus,
+            bus_inventory.range_checker_bus,
             def_circuit_commit_bus,
             merkle_root_bus,
             onion_res_bus,
@@ -59,6 +61,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
                 merkle_root_bus,
                 merkle_tree_internal_bus,
                 0,
+                true,
             ),
             io_commit_bus,
         };

--- a/crates/continuations/src/circuit/deferral/hook/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/trace.rs
@@ -14,9 +14,12 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, DIGEST_SIZE, F};
 use openvm_verify_stark_host::pvs::VerifierBasePvs;
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 
-use crate::{circuit::SingleAirTraceData, SC};
+use crate::{
+    circuit::{deferral::MAX_DEF_AGG_MERKLE_DEPTH, SingleAirTraceData},
+    SC,
+};
 
 pub type DeferralIoCommit<F> = ([F; DIGEST_SIZE], [F; DIGEST_SIZE]);
 
@@ -26,6 +29,8 @@ pub struct DeferralHookPreCtx<PB: ProverBackend> {
     pub onion_ctx: AirProvingContext<PB>,
     pub poseidon2_compress_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
     pub poseidon2_permute_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
+    pub range_check_inputs: Vec<usize>,
+    pub power_check_inputs: Vec<usize>,
 }
 
 // Trait used to remain generic in PB.
@@ -76,6 +81,10 @@ impl DeferralHookTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for DeferralH
 
         let def_pvs: &crate::circuit::deferral::DeferralAggregationPvs<F> =
             proof.public_values[1].as_slice().borrow();
+        let merkle_depth = def_pvs.merkle_depth.as_canonical_u32() as usize;
+        let max_depth_minus_merkle_depth = MAX_DEF_AGG_MERKLE_DEPTH
+            .checked_sub(merkle_depth)
+            .expect("deferral merkle depth exceeds max depth");
         assert_eq!(
             computed_merkle_root, def_pvs.merkle_commit,
             "leaf_children do not match the child proof merkle_commit"
@@ -112,6 +121,8 @@ impl DeferralHookTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for DeferralH
                 .chain(onion_p2_inputs)
                 .collect(),
             poseidon2_permute_inputs: verifier_p2_permute_inputs,
+            range_check_inputs: vec![max_depth_minus_merkle_depth],
+            power_check_inputs: vec![merkle_depth],
         }
     }
 }
@@ -134,6 +145,8 @@ impl DeferralHookTraceGen<GpuBackend, GpuDeviceCtx> for DeferralHookTraceGenImpl
             onion_ctx,
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
+            power_check_inputs,
         } = <Self as DeferralHookTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()>>::pre_verifier_subcircuit_tracegen(self, proof, leaf_children, &());
 
         DeferralHookPreCtx {
@@ -142,6 +155,8 @@ impl DeferralHookTraceGen<GpuBackend, GpuDeviceCtx> for DeferralHookTraceGenImpl
             onion_ctx: cpu_proving_ctx_to_gpu(onion_ctx, device_ctx),
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
+            power_check_inputs,
         }
     }
 }

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -2,9 +2,14 @@ use std::{array::from_fn, borrow::Borrow};
 
 use openvm_circuit::arch::POSEIDON2_WIDTH;
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper, SubAir};
-use openvm_recursion_circuit::bus::{
-    CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
-    PreHashBus, PreHashMessage, PublicValuesBus, PublicValuesBusMessage,
+use openvm_recursion_circuit::{
+    bus::{
+        CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
+        PreHashBus, PreHashMessage, PublicValuesBus, PublicValuesBusMessage,
+    },
+    primitives::bus::{
+        PowerCheckerBus, PowerCheckerBusMessage, RangeCheckerBus, RangeCheckerBusMessage,
+    },
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
@@ -25,7 +30,7 @@ use crate::{
             hook::bus::{
                 DefCircuitCommitBus, DefCircuitCommitMessage, OnionResultBus, OnionResultMessage,
             },
-            DeferralAggregationPvs, DEF_AGG_PVS_AIR_ID,
+            DeferralAggregationPvs, DEF_AGG_PVS_AIR_ID, MAX_DEF_AGG_MERKLE_DEPTH,
         },
         root::NUM_DIGESTS_IN_VM_COMMIT,
         subair::{HashSliceCtx, HashSliceSubAir, MerkleRootBus, MerkleRootMessage},
@@ -40,6 +45,8 @@ use crate::{
 pub struct DeferralHookPvsCols<F> {
     pub verifier_pvs: VerifierBasePvs<F>,
     pub def_pvs: DeferralAggregationPvs<F>,
+
+    pub num_merkle_leaves: F,
 
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
     pub def_circuit_commit: [F; DIGEST_SIZE],
@@ -60,6 +67,8 @@ pub struct DeferralHookPvsAir {
     pub pre_hash_bus: PreHashBus,
     pub poseidon2_compress_bus: Poseidon2CompressBus,
     pub hash_slice_subair: HashSliceSubAir,
+    pub pow_checker_bus: PowerCheckerBus,
+    pub range_checker_bus: RangeCheckerBus,
 
     pub def_circuit_commit_bus: DefCircuitCommitBus,
     pub merkle_root_bus: MerkleRootBus,
@@ -77,6 +86,8 @@ impl DeferralHookPvsAir {
         pre_hash_bus: PreHashBus,
         poseidon2_compress_bus: Poseidon2CompressBus,
         hash_slice_subair: HashSliceSubAir,
+        pow_checker_bus: PowerCheckerBus,
+        range_checker_bus: RangeCheckerBus,
         def_circuit_commit_bus: DefCircuitCommitBus,
         merkle_root_bus: MerkleRootBus,
         onion_res_bus: OnionResultBus,
@@ -89,6 +100,8 @@ impl DeferralHookPvsAir {
             pre_hash_bus,
             poseidon2_compress_bus,
             hash_slice_subair,
+            pow_checker_bus,
+            range_checker_bus,
             def_circuit_commit_bus,
             merkle_root_bus,
             onion_res_bus,
@@ -247,11 +260,30 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * and performing two onion hashes. Both steps are done in different AIRs, but we
          * must receive these commits to constrain consistency.
          */
+        self.pow_checker_bus.lookup_key(
+            builder,
+            PowerCheckerBusMessage {
+                log: local.def_pvs.merkle_depth,
+                exp: local.num_merkle_leaves,
+            },
+            AB::F::ONE,
+        );
+
+        self.range_checker_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: AB::Expr::from_usize(MAX_DEF_AGG_MERKLE_DEPTH) - local.def_pvs.merkle_depth,
+                max_bits: AB::Expr::from_usize(8),
+            },
+            AB::F::ONE,
+        );
+
         self.merkle_root_bus.receive(
             builder,
             MerkleRootMessage {
                 merkle_root: local.def_pvs.merkle_commit.map(Into::into),
                 idx: AB::Expr::ZERO,
+                num_rows_or_zero: local.num_merkle_leaves * AB::Expr::TWO,
             },
             AB::F::ONE,
         );

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -258,7 +258,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * The input_onion and output_onion are computed by decommitting def_pvs.merkle_commit
          * and performing two onion hashes. Both steps are done in different AIRs, but we
-         * must receive these commits to constrain consistency.
+         * must receive these commits to constrain consistency. We range check merkle_depth to
+         * ensure it's less than or equal to MAX_DEF_AGG_MERKLE_DEPTH.
          */
         self.pow_checker_bus.lookup_key(
             builder,

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -257,9 +257,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * The input_onion and output_onion are computed by decommitting def_pvs.merkle_commit
-         * and performing two onion hashes. Both steps are done in different AIRs, but we
-         * must receive these commits to constrain consistency. We range check merkle_depth to
-         * ensure it's less than or equal to MAX_DEF_AGG_MERKLE_DEPTH.
+         * and performing two onion hashes. Both steps are done in different AIRs, but we must
+         * receive these commits to constrain consistency. Note that merkle_depth is constrained
+         * to be in [0, MAX_DEF_AGG_MERKLE_DEPTH] - the power check forces merkle_depth to be in
+         * [0, 31], and the range check forces merkle_depth <= MAX_DEF_AGG_MERKLE_DEPTH.
          */
         self.pow_checker_bus.lookup_key(
             builder,

--- a/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
@@ -6,7 +6,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{
     poseidon2_compress_with_capacity, BabyBearPoseidon2Config, DIGEST_SIZE, F,
 };
 use openvm_verify_stark_host::pvs::{DeferralPvs, VerifierBasePvs};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
@@ -65,6 +65,8 @@ pub fn generate_proving_ctx(
     let cols: &mut DeferralHookPvsCols<F> = trace.as_mut_slice().borrow_mut();
     cols.verifier_pvs = *verifier_pvs;
     cols.def_pvs = *def_pvs;
+    cols.num_merkle_leaves =
+        F::from_usize(1usize << def_pvs.merkle_depth.as_canonical_u32() as usize);
     cols.input_onion = input_onion;
     cols.output_onion = output_onion;
 

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -10,13 +10,12 @@ use openvm_recursion_circuit::{
     bus::{
         Poseidon2CompressBus, Poseidon2CompressMessage, PublicValuesBus, PublicValuesBusMessage,
     },
-    prelude::{DIGEST_SIZE, F},
+    prelude::DIGEST_SIZE,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
-use openvm_stark_sdk::config::baby_bear_poseidon2::poseidon2_compress_with_capacity;
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
@@ -30,7 +29,7 @@ use crate::{
         DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
         MAX_DEF_AGG_MERKLE_DEPTH,
     },
-    utils::digests_to_poseidon2_input,
+    utils::{digests_to_poseidon2_input, zero_hashes_from_depth_one},
     CommitBytes,
 };
 
@@ -72,17 +71,13 @@ impl DeferralAggPvsAir {
     ) -> Self {
         let encoder = Self::depth_encoder();
         assert!(encoder.width() < DIGEST_SIZE);
-        let mut zero_hash = [F::ZERO; DIGEST_SIZE];
         Self {
             public_values_bus,
             poseidon2_bus,
             input_or_merkle_commit_bus,
             def_pvs_consistency_bus,
             encoder,
-            zero_hashes: from_fn(|_| {
-                zero_hash = poseidon2_compress_with_capacity(zero_hash, zero_hash).0;
-                zero_hash.into()
-            }),
+            zero_hashes: zero_hashes_from_depth_one().map(Into::into),
         }
     }
 }
@@ -198,8 +193,9 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         /*
-         * On internal layers we receive num_def_circuit_proofs from PublicValuesBus. To save
-         * columns, we repurpose the unused local.child_pvs.input_commit[0].
+         * On internal layers we receive num_def_circuit_proofs and merkle_depth from
+         * PublicValuesBus. To save columns, we repurpose the first two elements of the unused
+         * local.child_pvs.input_commit.
          */
         let local_num_def_circuit_proofs = local.child_pvs.input_commit[0];
         let local_merkle_depth = local.child_pvs.input_commit[1];
@@ -271,8 +267,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * If there are two rows, then the second (next) is either present or not. If present
          * the parent merkle_hash should be the compression of both children's merkle_commit.
-         * If not the second merkle_commit contains encoder flags for the child merkle depth,
-         * which is used to select the correct zero hash depth.
+         * If not the second row's merkle_commit columns are repurposed into encoder flags for
+         * the child merkle depth. They're used to select the correct zero hash depth.
          */
         let flags = next
             .merkle_commit
@@ -283,18 +279,20 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .eval(&mut builder.when(not(next.is_present)), &flags);
 
         let mut zero_hash = [AB::Expr::ZERO; DIGEST_SIZE];
+        let mut encoded_parent_depth = AB::Expr::ZERO;
+
         for i in 0..=MAX_DEF_AGG_MERKLE_DEPTH {
             let is_current = self.encoder.get_flag_expr::<AB>(i, &flags);
-            builder
-                .when(not(next.is_present))
-                .when(is_current.clone())
-                .assert_eq(merkle_depth, AB::Expr::from_usize(i + 1));
-
             let current_zero_hash: [AB::F; DIGEST_SIZE] = self.zero_hashes[i].into();
             for j in 0..DIGEST_SIZE {
                 zero_hash[j] += is_current.clone() * current_zero_hash[j];
             }
+            encoded_parent_depth += is_current * AB::Expr::from_usize(i);
         }
+
+        builder
+            .when(not(next.is_present))
+            .assert_eq(merkle_depth, encoded_parent_depth + AB::Expr::ONE);
 
         let right_child = from_fn(|i| {
             next.is_present * next.merkle_commit[i] + not(next.is_present) * zero_hash[i].clone()

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -1,19 +1,22 @@
 use std::{array::from_fn, borrow::Borrow};
 
+use itertools::Itertools;
 use openvm_circuit_primitives::{
+    encoder::Encoder,
     utils::{assert_array_eq, not},
-    ColumnsAir, StructReflection, StructReflectionHelper,
+    ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
 };
 use openvm_recursion_circuit::{
     bus::{
         Poseidon2CompressBus, Poseidon2CompressMessage, PublicValuesBus, PublicValuesBusMessage,
     },
-    prelude::DIGEST_SIZE,
+    prelude::{DIGEST_SIZE, F},
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
+use openvm_stark_sdk::config::baby_bear_poseidon2::poseidon2_compress_with_capacity;
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
@@ -25,9 +28,13 @@ use crate::{
             InputOrMerkleCommitMessage,
         },
         DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
+        MAX_DEF_AGG_MERKLE_DEPTH,
     },
     utils::digests_to_poseidon2_input,
+    CommitBytes,
 };
+
+const ENCODER_MAX_DEGREE: u32 = 2;
 
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection)]
@@ -47,6 +54,37 @@ pub struct DeferralAggPvsAir {
     pub poseidon2_bus: Poseidon2CompressBus,
     pub input_or_merkle_commit_bus: InputOrMerkleCommitBus,
     pub def_pvs_consistency_bus: DefPvsConsistencyBus,
+
+    pub encoder: Encoder,
+    pub zero_hashes: [CommitBytes; MAX_DEF_AGG_MERKLE_DEPTH + 1],
+}
+
+impl DeferralAggPvsAir {
+    pub(super) fn depth_encoder() -> Encoder {
+        Encoder::new(MAX_DEF_AGG_MERKLE_DEPTH + 1, ENCODER_MAX_DEGREE, false)
+    }
+
+    pub fn new(
+        public_values_bus: PublicValuesBus,
+        poseidon2_bus: Poseidon2CompressBus,
+        input_or_merkle_commit_bus: InputOrMerkleCommitBus,
+        def_pvs_consistency_bus: DefPvsConsistencyBus,
+    ) -> Self {
+        let encoder = Self::depth_encoder();
+        assert!(encoder.width() < DIGEST_SIZE);
+        let mut zero_hash = [F::ZERO; DIGEST_SIZE];
+        Self {
+            public_values_bus,
+            poseidon2_bus,
+            input_or_merkle_commit_bus,
+            def_pvs_consistency_bus,
+            encoder,
+            zero_hashes: from_fn(|_| {
+                zero_hash = poseidon2_compress_with_capacity(zero_hash, zero_hash).0;
+                zero_hash.into()
+            }),
+        }
+    }
 }
 
 impl<F> BaseAir<F> for DeferralAggPvsAir {
@@ -164,11 +202,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * columns, we repurpose the unused local.child_pvs.input_commit[0].
          */
         let local_num_def_circuit_proofs = local.child_pvs.input_commit[0];
+        let local_merkle_depth = local.child_pvs.input_commit[1];
 
-        builder
-            .when(not(local.is_present))
-            .when(is_internal)
-            .assert_zero(local_num_def_circuit_proofs);
+        let mut when_dummy_internal = builder.when(not(local.is_present) * is_internal);
+        when_dummy_internal.assert_zero(local_num_def_circuit_proofs);
+        when_dummy_internal.assert_zero(local_merkle_depth);
 
         self.public_values_bus.receive(
             builder,
@@ -181,15 +219,27 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             is_internal * local.is_present,
         );
 
+        self.public_values_bus.receive(
+            builder,
+            local.proof_idx,
+            PublicValuesBusMessage {
+                air_idx: AB::Expr::from_usize(DEF_AGG_PVS_AIR_ID),
+                pv_idx: AB::Expr::from_usize(DIGEST_SIZE + 1),
+                value: local_merkle_depth.into(),
+            },
+            is_internal * local.is_present,
+        );
+
         /*
          * If there is only one row, then this proof is a wrapper and its public values should
-         * match those of its child's. Otherwise, constrain that merkle_commit is the hash of
-         * the child proofs'. We also constrain that num_def_circuit_proofs is the sum of the
-         * present children's.
+         * match those of its child's. Otherwise, constrain that num_def_circuit_proofs is the
+         * sum of the present children's and that merkle_depth is the child merkle_depth + 1.
+         * If both children are present, we constrain that their merkle_depth values are equal.
          */
         let &DeferralAggregationPvs::<_> {
             merkle_commit,
             num_def_circuit_proofs,
+            merkle_depth,
         } = builder.public_values().borrow();
 
         let is_first = not(local.proof_idx);
@@ -199,20 +249,61 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             local.is_present * is_leaf.clone() + is_internal * local_num_def_circuit_proofs;
         let next_num_proofs =
             next.is_present * is_leaf + is_internal * next.child_pvs.input_commit[0];
+        let local_merkle_depth = is_internal * local_merkle_depth;
+        let next_merkle_depth = is_internal * next.child_pvs.input_commit[1];
 
         let mut when_one_row = builder.when(is_first * not(next.proof_idx));
         when_one_row.assert_eq(local_num_proofs.clone(), num_def_circuit_proofs);
+        when_one_row.assert_eq(local_merkle_depth.clone(), merkle_depth);
         assert_array_eq(&mut when_one_row, local.merkle_commit, merkle_commit);
 
         builder
             .when_transition()
             .assert_eq(local_num_proofs + next_num_proofs, num_def_circuit_proofs);
+        builder
+            .when_transition()
+            .assert_eq(local_merkle_depth.clone() + AB::Expr::ONE, merkle_depth);
+        builder
+            .when_transition()
+            .when(next.is_present)
+            .assert_eq(local_merkle_depth, next_merkle_depth);
+
+        /*
+         * If there are two rows, then the second (next) is either present or not. If present
+         * the parent merkle_hash should be the compression of both children's merkle_commit.
+         * If not the second merkle_commit contains encoder flags for the child merkle depth,
+         * which is used to select the correct zero hash depth.
+         */
+        let flags = next
+            .merkle_commit
+            .into_iter()
+            .take(self.encoder.width())
+            .collect_vec();
+        self.encoder
+            .eval(&mut builder.when(not(next.is_present)), &flags);
+
+        let mut zero_hash = [AB::Expr::ZERO; DIGEST_SIZE];
+        for i in 0..=MAX_DEF_AGG_MERKLE_DEPTH {
+            let is_current = self.encoder.get_flag_expr::<AB>(i, &flags);
+            builder
+                .when(not(next.is_present))
+                .when(is_current.clone())
+                .assert_eq(merkle_depth, AB::Expr::from_usize(i + 1));
+
+            let current_zero_hash: [AB::F; DIGEST_SIZE] = self.zero_hashes[i].into();
+            for j in 0..DIGEST_SIZE {
+                zero_hash[j] += is_current.clone() * current_zero_hash[j];
+            }
+        }
+
+        let right_child = from_fn(|i| {
+            next.is_present * next.merkle_commit[i] + not(next.is_present) * zero_hash[i].clone()
+        });
 
         self.poseidon2_bus.lookup_key(
             builder,
             Poseidon2CompressMessage {
-                input: digests_to_poseidon2_input(local.merkle_commit, next.merkle_commit)
-                    .map(Into::into),
+                input: digests_to_poseidon2_input(local.merkle_commit.map(Into::into), right_child),
                 output: merkle_commit.map(Into::into),
             },
             is_first_of_two_rows,

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
@@ -15,8 +15,8 @@ use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
     circuit::deferral::{
-        inner::def_pvs::air::DeferralAggPvsCols, DeferralAggregationPvs, DeferralCircuitPvs,
-        DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
+        inner::def_pvs::air::{DeferralAggPvsAir, DeferralAggPvsCols},
+        DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
     },
     utils::zero_hash,
 };
@@ -37,6 +37,7 @@ pub fn generate_proving_ctx(
 
     let mut trace = vec![F::ZERO; num_rows * width];
     let mut num_def_circuit_proofs = F::ZERO;
+    let mut merkle_depth = F::ZERO;
 
     for (proof_idx, (proof, chunk)) in proofs.iter().zip(trace.chunks_exact_mut(width)).enumerate()
     {
@@ -50,7 +51,13 @@ pub fn generate_proving_ctx(
                 proof.public_values[DEF_AGG_PVS_AIR_ID].as_slice().borrow();
             cols.merkle_commit = child_pvs.merkle_commit;
             cols.child_pvs.input_commit[0] = child_pvs.num_def_circuit_proofs;
+            cols.child_pvs.input_commit[1] = child_pvs.merkle_depth;
             num_def_circuit_proofs += child_pvs.num_def_circuit_proofs;
+            if proof_idx == 0 {
+                merkle_depth = child_pvs.merkle_depth;
+            } else {
+                debug_assert_eq!(merkle_depth, child_pvs.merkle_depth);
+            }
         } else {
             let child_pvs: &DeferralCircuitPvs<F> = proof.public_values[DEF_CIRCUIT_PVS_AIR_ID]
                 .as_slice()
@@ -80,7 +87,13 @@ pub fn generate_proving_ctx(
         let cols: &mut DeferralAggPvsCols<F> = trace[width..2 * width].borrow_mut();
         cols.proof_idx = F::ONE;
         cols.has_verifier_pvs = F::from_bool(child_is_agg);
-        cols.merkle_commit = zero_hash(child_merkle_depth.unwrap() + 1);
+        for (dst, value) in cols
+            .merkle_commit
+            .iter_mut()
+            .zip(DeferralAggPvsAir::depth_encoder().get_flag_pt(child_merkle_depth.unwrap()))
+        {
+            *dst = F::from_u32(value);
+        }
     }
 
     let mut public_values = vec![F::ZERO; DeferralAggregationPvs::<u8>::width()];
@@ -89,10 +102,17 @@ pub fn generate_proving_ctx(
     let first_row: &DeferralAggPvsCols<F> = trace[..width].borrow();
     if is_wrapper {
         pvs.merkle_commit = first_row.merkle_commit;
+        pvs.merkle_depth = merkle_depth;
     } else {
         let second_row: &DeferralAggPvsCols<F> = trace[width..2 * width].borrow();
+        let right_child = if num_proofs == 1 {
+            zero_hash(child_merkle_depth.unwrap() + 1)
+        } else {
+            second_row.merkle_commit
+        };
         pvs.merkle_commit =
-            poseidon2_compress_with_capacity(first_row.merkle_commit, second_row.merkle_commit).0;
+            poseidon2_compress_with_capacity(first_row.merkle_commit, right_child).0;
+        pvs.merkle_depth = merkle_depth + F::ONE;
     }
     pvs.num_def_circuit_proofs = num_def_circuit_proofs;
 

--- a/crates/continuations/src/circuit/deferral/inner/mod.rs
+++ b/crates/continuations/src/circuit/deferral/inner/mod.rs
@@ -35,12 +35,12 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             def_pvs_consistency_bus,
         };
 
-        let def_pvs_air = def_pvs::DeferralAggPvsAir {
-            public_values_bus: bus_inventory.public_values_bus,
-            poseidon2_bus: bus_inventory.poseidon2_compress_bus,
+        let def_pvs_air = def_pvs::DeferralAggPvsAir::new(
+            bus_inventory.public_values_bus,
+            bus_inventory.poseidon2_compress_bus,
             input_or_merkle_commit_bus,
             def_pvs_consistency_bus,
-        };
+        );
 
         let input_commit_air = input::InputCommitAir {
             public_values_bus: bus_inventory.public_values_bus,

--- a/crates/continuations/src/circuit/deferral/mod.rs
+++ b/crates/continuations/src/circuit/deferral/mod.rs
@@ -13,6 +13,7 @@ pub const DEF_AGG_PVS_AIR_ID: usize = 1;
 
 pub const DEF_HOOK_PVS_AIR_ID: usize = 0;
 
+// Set to the default max trace log height of the deferral hook circuit
 const MAX_DEF_AGG_MERKLE_DEPTH: usize = 20;
 
 #[repr(C)]

--- a/crates/continuations/src/circuit/deferral/mod.rs
+++ b/crates/continuations/src/circuit/deferral/mod.rs
@@ -13,6 +13,8 @@ pub const DEF_AGG_PVS_AIR_ID: usize = 1;
 
 pub const DEF_HOOK_PVS_AIR_ID: usize = 0;
 
+const MAX_DEF_AGG_MERKLE_DEPTH: usize = 20;
+
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Clone, Copy)]
 pub struct DeferralCircuitPvs<F> {
@@ -31,4 +33,7 @@ pub struct DeferralAggregationPvs<F> {
     pub merkle_commit: [F; DIGEST_SIZE],
     /// Number of present deferral circuit proofs that we've seen so far
     pub num_def_circuit_proofs: F,
+    /// Current Merkle depth of this subtree, there are be 2^merkle_depth
+    /// leaves (including padding)
+    pub merkle_depth: F,
 }

--- a/crates/continuations/src/circuit/root/commit/air.rs
+++ b/crates/continuations/src/circuit/root/commit/air.rs
@@ -53,6 +53,7 @@ impl UserPvsCommitAir {
                 merkle_root_bus,
                 merkle_tree_internal_bus,
                 0,
+                false,
             ),
             encoder,
             num_user_pvs,

--- a/crates/continuations/src/circuit/root/memory/air.rs
+++ b/crates/continuations/src/circuit/root/memory/air.rs
@@ -92,13 +92,15 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for UserPvsInMemoryAir {
 
         /*
          * Receive the user public values commit on the first row. The first DIGEST_SIZE
-         * elements of perm state are this merkle tree node's commit.
+         * elements of perm state are this merkle tree node's commit. We do not receive
+         * the number of rows here.
          */
         self.merkle_root_bus.receive(
             builder,
             MerkleRootMessage {
                 merkle_root: local.node_commit.map(Into::into),
                 idx: AB::Expr::ZERO,
+                num_rows_or_zero: AB::Expr::ZERO,
             },
             local.is_valid * (local.is_valid - AB::F::ONE) * AB::F::TWO.inverse(),
         );

--- a/crates/continuations/src/circuit/subair/merkle_tree/air.rs
+++ b/crates/continuations/src/circuit/subair/merkle_tree/air.rs
@@ -39,6 +39,9 @@ pub struct MerkleTreeSubAir {
 
     // Identifier in case multiple AIRs use this sub-AIR
     pub idx: usize,
+    // Flag that indicates whether we should send row_idx (i.e. num_nodes) on
+    // the root row or not
+    pub send_num_rows: bool,
 }
 
 impl<AB: AirBuilder + InteractionBuilder> SubAir<AB> for MerkleTreeSubAir {
@@ -138,7 +141,7 @@ impl<AB: AirBuilder + InteractionBuilder> SubAir<AB> for MerkleTreeSubAir {
             MerkleTreeInternalMessage {
                 child_value: local.parent.map(Into::into),
                 is_right_child: local.is_right_child.into(),
-                parent_idx: (local.row_idx - local.is_right_child + num_rows) * half,
+                parent_idx: (local.row_idx - local.is_right_child + num_rows.clone()) * half,
             },
             internal_send,
         );
@@ -187,6 +190,11 @@ impl<AB: AirBuilder + InteractionBuilder> SubAir<AB> for MerkleTreeSubAir {
             MerkleRootMessage {
                 merkle_root: local.parent.map(Into::into),
                 idx: AB::Expr::from_usize(self.idx),
+                num_rows_or_zero: if self.send_num_rows {
+                    num_rows
+                } else {
+                    AB::Expr::ZERO
+                },
             },
             is_root,
         );

--- a/crates/continuations/src/circuit/subair/merkle_tree/bus.rs
+++ b/crates/continuations/src/circuit/subair/merkle_tree/bus.rs
@@ -7,6 +7,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 pub struct MerkleRootMessage<T> {
     pub merkle_root: [T; DIGEST_SIZE],
     pub idx: T,
+    pub num_rows_or_zero: T,
 }
 
 define_typed_permutation_bus!(MerkleRootBus, MerkleRootMessage);

--- a/crates/continuations/src/prover/deferral/hook/trace.rs
+++ b/crates/continuations/src/prover/deferral/hook/trace.rs
@@ -43,17 +43,19 @@ where
             onion_ctx,
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
+            power_check_inputs,
         } = self.agg_node_tracegen.pre_verifier_subcircuit_tracegen(
             &proof,
             leaf_children,
             device_ctx,
         );
 
-        let range_check_inputs = vec![];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &poseidon2_compress_inputs,
             poseidon2_permute_inputs: &poseidon2_permute_inputs,
             range_check_inputs: &range_check_inputs,
+            power_check_inputs: &power_check_inputs,
             required_heights: None,
             final_transcript_state: None,
         };

--- a/crates/continuations/src/prover/deferral/inner/trace.rs
+++ b/crates/continuations/src/prover/deferral/inner/trace.rs
@@ -77,10 +77,12 @@ where
         );
 
         let range_check_inputs = vec![];
+        let power_check_inputs = vec![];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &poseidon2_compress_inputs,
             poseidon2_permute_inputs: &poseidon2_permute_inputs,
             range_check_inputs: &range_check_inputs,
+            power_check_inputs: &power_check_inputs,
             required_heights: None,
             final_transcript_state: None,
         };

--- a/crates/continuations/src/prover/inner/trace.rs
+++ b/crates/continuations/src/prover/inner/trace.rs
@@ -62,10 +62,12 @@ where
             );
 
         let range_check_inputs = vec![];
+        let power_check_inputs = vec![];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &pre_data.poseidon2_compress_inputs,
             poseidon2_permute_inputs: &pre_data.poseidon2_permute_inputs,
             range_check_inputs: &range_check_inputs,
+            power_check_inputs: &power_check_inputs,
             required_heights: None,
             final_transcript_state: None,
         };

--- a/crates/continuations/src/prover/root/trace.rs
+++ b/crates/continuations/src/prover/root/trace.rs
@@ -63,10 +63,12 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         });
 
         let range_check_inputs = vec![];
+        let power_check_inputs = vec![];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &pre_data.poseidon2_compress_inputs,
             poseidon2_permute_inputs: &pre_data.poseidon2_permute_inputs,
             range_check_inputs: &range_check_inputs,
+            power_check_inputs: &power_check_inputs,
             required_heights: verifier_trace_heights,
             final_transcript_state: None,
         };

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -528,6 +528,12 @@ fn expected_deferral_inner_merkle_commit_from_copies(
 }
 
 #[cfg(feature = "cuda")]
+fn expected_deferral_inner_merkle_depth(num_copies: usize) -> u32 {
+    assert!(num_copies > 0, "num_copies must be non-zero");
+    num_copies.next_power_of_two().ilog2()
+}
+
+#[cfg(feature = "cuda")]
 #[test_case(1)]
 #[test_case(2)]
 fn test_deferral_leaf_prover(num_children: usize) -> Result<()> {
@@ -560,6 +566,10 @@ fn test_deferral_leaf_prover(num_children: usize) -> Result<()> {
         num_children as u32,
         wrapped_pvs.num_def_circuit_proofs.as_canonical_u32()
     );
+    assert_eq!(
+        expected_deferral_inner_merkle_depth(num_children),
+        wrapped_pvs.merkle_depth.as_canonical_u32()
+    );
 
     Ok(())
 }
@@ -591,6 +601,10 @@ fn test_deferral_aggregation(num_children: usize) -> Result<()> {
     assert_eq!(
         num_children as u32,
         wrapped_pvs.num_def_circuit_proofs.as_canonical_u32()
+    );
+    assert_eq!(
+        expected_deferral_inner_merkle_depth(num_children),
+        wrapped_pvs.merkle_depth.as_canonical_u32()
     );
 
     Ok(())

--- a/crates/continuations/src/utils.rs
+++ b/crates/continuations/src/utils.rs
@@ -45,3 +45,11 @@ pub fn zero_hash(depth: usize) -> [F; DIGEST_SIZE] {
     }
     ret
 }
+
+pub fn zero_hashes_from_depth_one<const MAX_DEPTH: usize>() -> [[F; DIGEST_SIZE]; MAX_DEPTH] {
+    let mut zero_hash = [F::ZERO; DIGEST_SIZE];
+    from_fn(|_| {
+        zero_hash = poseidon2_compress_with_capacity(zero_hash, zero_hash).0;
+        zero_hash
+    })
+}

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -80,6 +80,7 @@ pub struct VerifierExternalData<'a> {
     pub poseidon2_compress_inputs: &'a Vec<[F; POSEIDON2_WIDTH]>,
     pub poseidon2_permute_inputs: &'a Vec<[F; POSEIDON2_WIDTH]>,
     pub range_check_inputs: &'a Vec<usize>,
+    pub power_check_inputs: &'a Vec<usize>,
     pub required_heights: Option<&'a [usize]>,
     pub final_transcript_state: Option<&'a mut [F; POSEIDON2_WIDTH]>,
 }
@@ -139,11 +140,13 @@ pub trait VerifierTraceGen<
     ) -> Vec<AirProvingContext<PB>> {
         let poseidon2_compress_inputs = vec![];
         let range_check_inputs = vec![];
+        let power_check_inputs = vec![];
 
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &poseidon2_compress_inputs,
             poseidon2_permute_inputs: &poseidon2_compress_inputs,
             range_check_inputs: &range_check_inputs,
+            power_check_inputs: &power_check_inputs,
             required_heights: None,
             final_transcript_state: None,
         };
@@ -1135,6 +1138,9 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
 
         let power_checker_gen =
             Arc::new(PowerCheckerCpuTraceGenerator::<2, POW_CHECKER_HEIGHT>::default());
+        for &log in external_data.power_check_inputs {
+            power_checker_gen.add_pow(log);
+        }
         let exp_bits_len_gen = ExpBitsLenCpuTraceGenerator::default();
 
         let (module_required, power_checker_required, exp_bits_len_required) =
@@ -1411,6 +1417,11 @@ pub mod cuda_tracegen {
             let power_checker_gen = Arc::new(
                 PowerCheckerGpuTraceGenerator::<2, POW_CHECKER_HEIGHT>::hybrid(device_ctx.clone()),
             );
+            if let Some(cpu_checker) = power_checker_gen.cpu_checker() {
+                for &log in external_data.power_check_inputs {
+                    cpu_checker.add_pow(log);
+                }
+            }
             let exp_bits_len_gen = GpuExpBitsLenTraceGenerator::new(device_ctx.clone());
 
             let (module_required, power_checker_required, exp_bits_len_required) =

--- a/guest-libs/verify-stark/circuit/src/commit/air.rs
+++ b/guest-libs/verify-stark/circuit/src/commit/air.rs
@@ -54,6 +54,7 @@ impl UserPvsCommitValuesAir {
                 merkle_root_bus,
                 merkle_tree_internal_bus,
                 0,
+                false,
             ),
             output_val_bus,
             num_user_pvs,

--- a/guest-libs/verify-stark/circuit/src/prover/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/trace.rs
@@ -61,11 +61,13 @@ where
             device_ctx,
         );
 
+        let power_check_inputs = vec![];
         let mut final_transcript_state = [F::ZERO; POSEIDON2_WIDTH];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &poseidon2_compress_inputs,
             poseidon2_permute_inputs: &poseidon2_permute_inputs,
             range_check_inputs: &range_inputs,
+            power_check_inputs: &power_check_inputs,
             required_heights: None,
             final_transcript_state: Some(&mut final_transcript_state),
         };


### PR DESCRIPTION
Resolves INT-7918 and INT-7920.

## Overview

This PR tightens deferral aggregation around padded Merkle subtrees.

The main changes are:

- `DeferralAggregationPvs` now carries `merkle_depth`, in addition to `merkle_commit` and `num_def_circuit_proofs`.
- `DeferralAggPvsAir` constrains aggregation depth and canonical padding hashes when the second child is absent.
- `DeferralHookPvsAir` constrains the final decommitment tree size from `merkle_depth`, and range-checks the depth against `MAX_DEF_AGG_MERKLE_DEPTH`.
- `MerkleRootMessage` optionally carries the Merkle trace row count so the hook can bind the final aggregation root to the expected tree size.
- Verifier trace generation now supports external power-check inputs, mirroring existing external range-check plumbing.

## `DeferralAggPvsAir`

### Purpose

The deferral aggregation public values now include:

| Public value | Meaning |
| --- | --- |
| `merkle_commit` | Root commit for the current deferral aggregation subtree. |
| `num_def_circuit_proofs` | Number of real deferral circuit proofs contained in the subtree. |
| `merkle_depth` | Log2 of the padded Merkle leaf count represented by the subtree. |

The AIR constrains:

- Leaf children still hash `input_commit || output_commit` into `merkle_commit`.
- Internal children receive both `num_def_circuit_proofs` and `merkle_depth` from the child aggregation PVS.
- One-row wrapper proofs preserve the child `merkle_commit`, `num_def_circuit_proofs`, and `merkle_depth`.
- Two-row aggregation proofs set parent `num_def_circuit_proofs` to the sum of present children.
- Two-row aggregation proofs set parent `merkle_depth = child_merkle_depth + 1`.
- If both children are present, their child depths must be equal.
- If the second child is absent, its `merkle_commit` columns encode a depth selector; the AIR uses that selector to choose the canonical zero hash at the matching child depth.

### Example Trace Shapes

`DeferralAggPvsCols` did not add physical columns. For internal rows, unused `child_pvs.input_commit` entries are repurposed; for padded second rows, the start of `merkle_commit` stores encoder flags instead of a digest.

| Case | Row | `is_present` | `has_verifier_pvs` | `child_pvs.input_commit[0]` | `child_pvs.input_commit[1]` | `merkle_commit` |
| --- | ---: | ---: | ---: | --- | --- | --- |
| Leaf child | 0 | `1` | `0` | child input digest word | child input digest word | `H(input_commit, output_commit)` |
| Internal child | 0 | `1` | `1` | child `num_def_circuit_proofs` | child `merkle_depth` | child aggregation root |
| Present sibling | 1 | `1` | same as row 0 | same meaning as row 0 | same meaning as row 0 | sibling root |
| Padded sibling | 1 | `0` | same as row 0 | `0` if internal | `0` if internal | depth encoder flags in the first encoder-width words |

For a padded two-row proof:

| Child depth | Parent depth | Encoded padding choice | Right child used in Poseidon lookup |
| ---: | ---: | --- | --- |
| `0` | `1` | flag `0` | `zero_hash(1)` |
| `d` | `d + 1` | flag `d` | `zero_hash(d + 1)` |

This prevents a prover from using an arbitrary value as the missing sibling. The padded sibling must select one of the precomputed canonical zero hashes, and the selected hash must match the parent depth relation.

### Bus Interactions

```text
Child proof public values
        |
        | PublicValuesBus
        v
DeferralAggPvsAir
  - receives child aggregation num_def_circuit_proofs
  - receives child aggregation merkle_depth
  - receives leaf output commits
  - receives input-or-merkle commits
        |
        | Poseidon2CompressBus
        v
Hashes leaf commits and parent aggregation commits
```

## Deferral Hook AIR

### Purpose

The hook layer binds the final aggregation PVS to the Merkle decommitment trace.

`DeferralHookPvsCols` adds:

| Column | Meaning |
| --- | --- |
| `num_merkle_leaves` | Witnessed value constrained to equal `2^def_pvs.merkle_depth`. |

The AIR constrains:

- `num_merkle_leaves = 2^merkle_depth` through `PowerCheckerBus`.
- `MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth` is externally range-checked.
- The `MerkleRootBus` receive includes `num_rows_or_zero = 2 * num_merkle_leaves`.

The row-count relation matters because this Merkle tree trace has `2 * num_leaves` rows: one row for each leaf-pair hash, one row for each internal hash up to the root, and one final terminal row.

### Bus Interactions

```text
DeferralHookPvsAir
  |
  | PowerCheckerBus: (log = merkle_depth, exp = num_merkle_leaves)
  | RangeCheckerBus: MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth
  |
  v
MerkleRootBus receive:
  merkle_root       = def_pvs.merkle_commit
  idx               = 0
  num_rows_or_zero  = 2 * num_merkle_leaves

MerkleTreeSubAir send:
  merkle_root       = computed root
  idx               = 0
  num_rows_or_zero  = actual trace row count, when enabled
```

This prevents arbitrary unchecked wrapping: increasing `merkle_depth` requires a matching power-check result and a matching Merkle decommitment trace size.

## Shared Merkle Tree Sub-AIR

`MerkleRootMessage` now includes `num_rows_or_zero`.

`MerkleTreeSubAir` adds `send_num_rows`:

| Caller | `send_num_rows` | Bus value |
| --- | ---: | --- |
| Deferral hook Merkle tree | `true` | actual `num_rows` |
| Root/user public value commits | `false` | `0` |
| verify-stark user public value commits | `false` | `0` |

This keeps existing Merkle root users compatible while allowing the deferral hook to enforce the tree size.

## Tracegen And Prover Plumbing

Deferral inner tracegen now computes and publishes `merkle_depth`:

- Wrapper proofs copy the child depth.
- Two-child proofs increment the child depth by one.
- Padded second rows store depth encoder flags in `merkle_commit`.
- Public `merkle_commit` for padded siblings still uses the actual canonical zero hash.

Deferral hook tracegen now:

- Computes `num_merkle_leaves = 1 << merkle_depth`.
- Emits external range-check input `MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth`.
- Emits external power-check input `merkle_depth`.

`VerifierExternalData` now carries `power_check_inputs`, and CPU/GPU verifier tracegen feeds those inputs into the power checker generators.

## Primitive Encoder Change

`Encoder` methods now require `AirBuilder<F: Field, Var: Copy>` instead of `InteractionBuilder`.

This lets `DeferralAggPvsAir` use `Encoder` as a plain sub-AIR for canonical padding selectors without requiring interaction-builder-specific APIs.

## Tests

Continuation CUDA tests now check `merkle_depth` next to existing `num_def_circuit_proofs` checks:

- Deferral leaf prover tests assert `merkle_depth = log2(next_power_of_two(num_children))`.
- Deferral aggregation tests assert the same relation.

## Review Guide

Suggested review order:

1. Review `DeferralAggPvsAir` first, especially the depth relation and padded sibling selector.
2. Review hook constraints next, especially `PowerCheckerBus`, `RangeCheckerBus`, and `MerkleRootMessage.num_rows_or_zero`.
3. Review `MerkleTreeSubAir` to confirm only the hook sends row counts.
4. Review tracegen to confirm witnesses match the new AIR semantics.
5. Review tests for the new `merkle_depth` assertions.
