### PR TITLE
fix: ensure verify crate and root continuations layer match

### DIFF
--- a/crates/continuations/src/circuit/root/def_paths/air.rs
+++ b/crates/continuations/src/circuit/root/def_paths/air.rs
@@ -118,6 +118,12 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
             .assert_one(next.depth - local.depth);
 
         let is_set = not(next.is_unset);
+        let is_next_start_depth = (local.is_skip - next.is_skip) * (AB::Expr::TWO - next.is_valid)
+            + local.is_unset
+                * local.is_valid
+                * (local.is_valid - AB::Expr::ONE)
+                * AB::F::TWO.inverse();
+
         self.def_acc_paths_bus.receive(
             builder,
             DeferralAccPathMessage {
@@ -126,11 +132,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
                 depth: next.depth * is_set,
                 is_unset: next.is_unset.into(),
             },
-            (local.is_skip - next.is_skip) * (AB::Expr::TWO - next.is_valid)
-                + local.is_unset
-                    * local.is_valid
-                    * (local.is_valid - AB::Expr::ONE)
-                    * AB::F::TWO.inverse(),
+            is_next_start_depth.clone(),
         );
 
         assert_array_eq::<_, _, AB::Expr, _>(
@@ -159,7 +161,8 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
          * Constrain that is_within_deferral_as is set until address_height. We constrain
          * the two paths to be equal as long as is_within_deferral_as is set, i.e. that the
          * part of DEFERRAL_AS that is not included in the Merkle root is left untouched
-         * for the duration of the program execution.
+         * for the duration of the program execution. We also constrain that the received
+         * depth is less than or equal to the address height.
          */
         builder.assert_bool(local.is_within_deferral_as);
         builder
@@ -175,6 +178,9 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for DeferralAccMerklePathsAir 
         builder
             .when_last_row()
             .assert_zero(local.is_within_deferral_as);
+        builder
+            .when(not(local.is_within_deferral_as))
+            .assert_zero(is_next_start_depth);
 
         assert_array_eq(
             &mut builder.when(local.is_within_deferral_as),

--- a/crates/continuations/src/circuit/root/def_paths/trace.rs
+++ b/crates/continuations/src/circuit/root/def_paths/trace.rs
@@ -82,8 +82,8 @@ pub fn generate_proving_input<SC: StarkProtocolConfig<F = F>>(
         0
     } else {
         assert!(
-            depth > 0 && depth <= proof_len,
-            "depth must be in 1..=proof_len when is_unset is false"
+            depth > 0 && depth <= address_height,
+            "depth must be in 1..=address_height when is_unset is false"
         );
         depth
     };

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -393,12 +393,14 @@ impl RootVerifierPvsAir {
         /*
          * If deferral_flag is 2, there must be a Merkle path from initial_acc_hash to
          * initial_root and from final_acc_hash to final_root. Else, we constrain that
-         * they are 0 and that the deferral address space remained unchanged.
+         * they are 0, that def_hook_commit is unset, and that the deferral address
+         * space remained unchanged.
          */
         let mut when_no_deferral = builder.when_ne(verifier_pvs.deferral_flag, AB::Expr::TWO);
         when_no_deferral.assert_zero(def_pvs.depth);
         assert_zeros(&mut when_no_deferral, def_pvs.initial_acc_hash);
         assert_zeros(&mut when_no_deferral, def_pvs.final_acc_hash);
+        assert_zeros(&mut when_no_deferral, verifier_pvs.def_hook_commit);
 
         self.def_acc_paths_bus.send(
             builder,

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -108,6 +108,10 @@ where
             .memory_dimensions()
     }
 
+    pub fn num_user_pvs(&self) -> usize {
+        self.instance.vm.config().as_ref().num_public_values
+    }
+
     /// Generates proof for every continuation segment
     #[instrument(
         name = "app_prove",

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -163,6 +163,7 @@ where
         VerificationBaseline {
             app_exe_commit: self.app_prover.app_exe_commit(),
             memory_dimensions: self.app_prover.memory_dimensions(),
+            num_user_pvs: self.app_prover.num_user_pvs(),
             app_vk_commit: self.agg_prover.leaf_prover.get_vk_commit(false),
             leaf_vk_commit: self
                 .agg_prover

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -384,6 +384,7 @@ pub struct VerificationBaselineJson {
     #[serde(with = "hex_bytes32")]
     pub app_exe_commit: CommitBytes,
     pub memory_dimensions: MemoryDimensions,
+    pub num_user_pvs: usize,
     pub app_vk_commit: VkCommitJson,
     pub leaf_vk_commit: VkCommitJson,
     pub internal_for_leaf_vk_commit: VkCommitJson,
@@ -401,6 +402,7 @@ impl From<VerificationBaseline> for VerificationBaselineJson {
         Self {
             app_exe_commit: CommitBytes::from(b.app_exe_commit),
             memory_dimensions: b.memory_dimensions,
+            num_user_pvs: b.num_user_pvs,
             app_vk_commit: vk(b.app_vk_commit),
             leaf_vk_commit: vk(b.leaf_vk_commit),
             internal_for_leaf_vk_commit: vk(b.internal_for_leaf_vk_commit),
@@ -420,6 +422,7 @@ impl From<VerificationBaselineJson> for VerificationBaseline {
         Self {
             app_exe_commit: b.app_exe_commit.into(),
             memory_dimensions: b.memory_dimensions,
+            num_user_pvs: b.num_user_pvs,
             app_vk_commit: vk(b.app_vk_commit),
             leaf_vk_commit: vk(b.leaf_vk_commit),
             internal_for_leaf_vk_commit: vk(b.internal_for_leaf_vk_commit),

--- a/crates/verify/src/deferral.rs
+++ b/crates/verify/src/deferral.rs
@@ -64,10 +64,10 @@ impl DeferralMerkleProofs<F> {
             });
         }
 
-        if depth > overall_height {
+        if depth > memory_dimensions.address_height {
             return Err(VerifyStarkError::DeferralDepthTooLarge {
                 depth,
-                overall_height,
+                address_height: memory_dimensions.address_height,
             });
         }
 

--- a/crates/verify/src/deferral.rs
+++ b/crates/verify/src/deferral.rs
@@ -133,7 +133,7 @@ fn merkle_path_root(
         if i < depth {
             continue;
         }
-        let is_right = depth == 0 && i == 0 || (idx_prefix >> i) & 1 == 1;
+        let is_right = (depth == 0 && i == 0) || (idx_prefix >> i) & 1 == 1;
         node = if is_right {
             poseidon2_compress_with_capacity(*sibling, node).0
         } else {

--- a/crates/verify/src/deferral.rs
+++ b/crates/verify/src/deferral.rs
@@ -64,6 +64,23 @@ impl DeferralMerkleProofs<F> {
             });
         }
 
+        if depth > overall_height {
+            return Err(VerifyStarkError::DeferralDepthTooLarge {
+                depth,
+                overall_height,
+            });
+        }
+
+        for i in 0..memory_dimensions.address_height {
+            if self.initial_merkle_proof[i] != self.final_merkle_proof[i] {
+                return Err(VerifyStarkError::DeferralMerkleProofSiblingMismatch {
+                    depth: i,
+                    initial: self.initial_merkle_proof[i],
+                    final_: self.final_merkle_proof[i],
+                });
+            }
+        }
+
         let is_unset = depth == 0;
         let skip_depth = if is_unset { 0 } else { depth };
         let idx_prefix =

--- a/crates/verify/src/deferral.rs
+++ b/crates/verify/src/deferral.rs
@@ -82,7 +82,6 @@ impl DeferralMerkleProofs<F> {
         }
 
         let is_unset = depth == 0;
-        let skip_depth = if is_unset { 0 } else { depth };
         let idx_prefix =
             usize::try_from(memory_dimensions.label_to_index((DEFERRAL_AS, 0))).unwrap();
 
@@ -98,12 +97,8 @@ impl DeferralMerkleProofs<F> {
             final_acc_hash
         };
 
-        let computed_initial_root = merkle_path_root(
-            initial_leaf,
-            &self.initial_merkle_proof,
-            idx_prefix,
-            skip_depth,
-        );
+        let computed_initial_root =
+            merkle_path_root(initial_leaf, &self.initial_merkle_proof, idx_prefix, depth);
         if computed_initial_root != initial_root {
             return Err(VerifyStarkError::DeferralInitialRootMismatch {
                 expected: initial_root,
@@ -112,7 +107,7 @@ impl DeferralMerkleProofs<F> {
         }
 
         let computed_final_root =
-            merkle_path_root(final_leaf, &self.final_merkle_proof, idx_prefix, skip_depth);
+            merkle_path_root(final_leaf, &self.final_merkle_proof, idx_prefix, depth);
         if computed_final_root != final_root {
             return Err(VerifyStarkError::DeferralFinalRootMismatch {
                 expected: final_root,
@@ -124,20 +119,21 @@ impl DeferralMerkleProofs<F> {
     }
 }
 
-/// Walk a Merkle path from `leaf` to root, skipping the first `skip_depth` levels.
-/// `idx_prefix` determines which side the node is on at each level (bit i => right child).
+/// Walk a Merkle path from `leaf` to root, skipping the first `depth` levels. `idx_prefix`
+/// determines which side the node is on at each level (bit i => right child). The first
+/// node is a right node if depth == 0.
 fn merkle_path_root(
     leaf: [F; DIGEST_SIZE],
     proof: &[[F; DIGEST_SIZE]],
     idx_prefix: usize,
-    skip_depth: usize,
+    depth: usize,
 ) -> [F; DIGEST_SIZE] {
     let mut node = leaf;
     for (i, sibling) in proof.iter().enumerate() {
-        if i < skip_depth {
+        if i < depth {
             continue;
         }
-        let is_right = (idx_prefix >> i) & 1 == 1;
+        let is_right = depth == 0 && i == 0 || (idx_prefix >> i) & 1 == 1;
         node = if is_right {
             poseidon2_compress_with_capacity(*sibling, node).0
         } else {

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -49,8 +49,8 @@ pub enum VerifyStarkError {
     Other(#[from] eyre::Error),
     #[error("Deferral Merkle proof length mismatch: expected {expected}, actual {actual}")]
     DeferralMerkleProofLengthMismatch { expected: usize, actual: usize },
-    #[error("Deferral depth exceeds overall memory height: depth {depth}, overall_height {overall_height}")]
-    DeferralDepthTooLarge { depth: usize, overall_height: usize },
+    #[error("Deferral depth exceeds address space height: depth {depth}, address_height {address_height}")]
+    DeferralDepthTooLarge { depth: usize, address_height: usize },
     #[error("Deferral Merkle proofs differ inside DEFERRAL_AS at depth {depth}: initial {initial:?}, final {final_:?}")]
     DeferralMerkleProofSiblingMismatch {
         depth: usize,

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -9,6 +9,8 @@ pub enum VerifyStarkError {
     StarkVerificationFailure(#[from] VerifierError<EF>),
     #[error("User public value proof verification failed with error: {0}")]
     UserPvsVerificationFailure(#[from] UserPublicValuesProofError),
+    #[error("Invalid user public values length: expected {expected}, actual {actual}")]
+    UserPvsLengthMismatch { expected: usize, actual: usize },
     #[error("Invalid app exe commit: expected {expected:?}, actual {actual:?}")]
     AppExeCommitMismatch { expected: Digest, actual: Digest },
     #[error("Invalid app cached commit: expected {expected:?}, actual {actual:?}")]

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -49,6 +49,14 @@ pub enum VerifyStarkError {
     Other(#[from] eyre::Error),
     #[error("Deferral Merkle proof length mismatch: expected {expected}, actual {actual}")]
     DeferralMerkleProofLengthMismatch { expected: usize, actual: usize },
+    #[error("Deferral depth exceeds overall memory height: depth {depth}, overall_height {overall_height}")]
+    DeferralDepthTooLarge { depth: usize, overall_height: usize },
+    #[error("Deferral Merkle proofs differ inside DEFERRAL_AS at depth {depth}: initial {initial:?}, final {final_:?}")]
+    DeferralMerkleProofSiblingMismatch {
+        depth: usize,
+        initial: Digest,
+        final_: Digest,
+    },
     #[error("Deferral initial root mismatch: expected {expected:?}, actual {actual:?}")]
     DeferralInitialRootMismatch { expected: Digest, actual: Digest },
     #[error("Deferral final root mismatch: expected {expected:?}, actual {actual:?}")]

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -303,21 +303,22 @@ pub fn verify_vm_stark_proof_pvs(
                     actual: def_hook_commit,
                 });
             }
-            let deferral_merkle_proofs = proof
-                .deferral_merkle_proofs
-                .as_ref()
-                .ok_or(VerifyStarkError::MissingDeferralMerkleProofs)?;
-            deferral_merkle_proofs.verify(
-                vk.baseline.memory_dimensions,
-                initial_root,
-                final_root,
-                initial_acc_hash,
-                final_acc_hash,
-                depth.as_canonical_u32() as usize,
-            )?;
         } else {
             return Err(VerifyStarkError::InvalidDeferralFlag(deferral_flag));
         }
+
+        let deferral_merkle_proofs = proof
+            .deferral_merkle_proofs
+            .as_ref()
+            .ok_or(VerifyStarkError::MissingDeferralMerkleProofs)?;
+        deferral_merkle_proofs.verify(
+            vk.baseline.memory_dimensions,
+            initial_root,
+            final_root,
+            initial_acc_hash,
+            final_acc_hash,
+            depth.as_canonical_u32() as usize,
+        )?;
     } else if !verifier_def_pvs_slice.is_empty()
         || !proof.inner.public_values[DEF_PVS_AIR_ID].is_empty()
         || proof.deferral_merkle_proofs.is_some()

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -128,6 +128,14 @@ pub fn verify_vm_stark_proof_pvs(
         .user_pvs_proof
         .verify(&hasher, vk.baseline.memory_dimensions, final_root)?;
 
+    // Check that user_pvs_proof has the correct number of public values.
+    if proof.user_pvs_proof.public_values.len() != vk.baseline.num_user_pvs {
+        return Err(VerifyStarkError::UserPvsLengthMismatch {
+            expected: vk.baseline.num_user_pvs,
+            actual: proof.user_pvs_proof.public_values.len(),
+        });
+    }
+
     // Check that the app_commit is as expected.
     let claimed_app_exe_commit =
         compute_exe_commit(&hasher, &program_commit, &initial_root, initial_pc);

--- a/crates/verify/src/vk.rs
+++ b/crates/verify/src/vk.rs
@@ -27,6 +27,8 @@ pub struct VerificationBaseline {
     pub app_exe_commit: Digest,
     /// VM memory metadata used to verify the user public values merkle proof
     pub memory_dimensions: MemoryDimensions,
+    /// Number of raw user public values
+    pub num_user_pvs: usize,
     /// Commit to the app_vk's DAG and its pre-hash, first exposed by the leaf verifier.
     pub app_vk_commit: VkCommit,
     /// Commit to the leaf_vk's DAG and its pre-hash, first exposed by the internal-for-leaf

--- a/crates/verify/src/vk.rs
+++ b/crates/verify/src/vk.rs
@@ -39,9 +39,11 @@ pub struct VerificationBaseline {
     /// index > 0) internal-recursive layer verifiers.
     pub internal_recursive_vk_commit: VkCommit,
     /// Expected deferral VK commit (hash of the deferral aggregation prover's vk commits).
-    /// When `Some`, the proof must have `deferral_flag == 2` with a matching
-    /// `def_hook_commit` and valid deferral Merkle proofs. When `None`, the proof must
-    /// have no deferral public values.
+    /// When Some, the proof must have deferral_flag == 0 || deferral_flag == 2 and valid
+    /// deferral Merkle proofs. If deferral_flag == 2, def_hook_commit must match this value.
+    /// If deferral_flag == 0, the deferral public values must be unset and the Merkle proofs
+    /// must show that the deferral address space is unchanged. When None, there must be no
+    /// deferral public values.
     pub expected_def_hook_commit: Option<Digest>,
 }
 

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -463,12 +463,14 @@ impl DeferredVerifyPvsAir {
         /*
          * If deferral_flag is 2, there must be a Merkle path from initial_acc_hash to
          * initial_root and from final_acc_hash to final_root. Else, we constrain that
-         * they are 0 and that the deferral address space remained unchanged.
+         * they are 0, that def_hook_commit is unset, and that the deferral address
+         * space remained unchanged.
          */
         let mut when_no_deferral = builder.when_ne(verifier_pvs.deferral_flag, AB::Expr::TWO);
         when_no_deferral.assert_zero(def_pvs.depth);
         assert_zeros(&mut when_no_deferral, def_pvs.initial_acc_hash);
         assert_zeros(&mut when_no_deferral, def_pvs.final_acc_hash);
+        assert_zeros(&mut when_no_deferral, verifier_pvs.def_hook_commit);
 
         self.def_acc_paths_bus.send(
             builder,


### PR DESCRIPTION
Resolves INT-7919.

## Overview

This PR aligns the Rust STARK verifier with the root-layer continuation AIR semantics for deferral-enabled proofs.

The main security fixes are:

- The native verifier now requires and verifies deferral Merkle proofs whenever deferrals are enabled, including the `deferral_flag == 0` case.
- Native deferral Merkle proof verification now checks that the deferral address space is unchanged outside the claimed aggregated subtree.
- Native verification and the root deferral-path AIR now reject deferral depths larger than the deferral address-space height.
- Root verifier AIRs now explicitly constrain `def_hook_commit` to be unset when `deferral_flag != 2`, matching the native verifier.
- Verification baselines now record the expected number of raw user public values, and the native verifier rejects proofs whose user public value proof length differs.

The branch also expands the SDK CUDA workflow trigger paths so changes in continuations and recursion run that workflow.

## Verification Baseline and User Public Values

### Baseline Schema

`VerificationBaseline` now includes `num_user_pvs`, the expected number of raw user public values for the fixed VM configuration and executable. The SDK fills this from `vm.config().num_public_values` when generating a baseline, and `VerificationBaselineJson` now serializes/deserializes the field alongside `app_exe_commit`, `memory_dimensions`, and verifier key commits.

Affected files:

- `crates/verify/src/vk.rs`
- `crates/sdk/src/prover/app.rs`
- `crates/sdk/src/prover/stark.rs`
- `crates/sdk/src/types.rs`

### Native Verifier Check

`verify_vm_stark_proof_pvs` now compares `proof.user_pvs_proof.public_values.len()` with `vk.baseline.num_user_pvs`.

| Case | `user_pvs_proof.public_values.len()` | `baseline.num_user_pvs` | Result |
| --- | ---: | ---: | --- |
| Matching baseline | `N` | `N` | Continue with normal verification. |
| Too short | `< N` | `N` | `UserPvsLengthMismatch`. |
| Too long | `> N` | `N` | `UserPvsLengthMismatch`. |

This supplements the existing Merkle proof verification: the Merkle proof checks commitment consistency, while the baseline length check ensures the proof exposes the exact number of user public values expected by the committed VM configuration.

## `crates/verify`

### Native Deferral Verification

`verify_vm_stark_proof_pvs` now extracts and verifies `deferral_merkle_proofs` outside the per-flag branch whenever `expected_def_hook_commit` is set.

Before this change:

- `deferral_flag == 2` required deferral Merkle proofs.
- `deferral_flag == 0` only checked that deferral public values were unset.

After this change:

| `expected_def_hook_commit` | `deferral_flag` | Required checks |
| --- | ---: | --- |
| `Some` | `0` | `def_hook_commit`, accumulators, and depth are unset; deferral Merkle proofs verify the unset accumulator path and unchanged deferral address space. |
| `Some` | `2` | `def_hook_commit` matches expected value; deferral Merkle proofs verify accumulator paths and unchanged deferral address space outside the aggregate. |
| `Some` | other | rejected. |
| `None` | any deferral PVS/proofs present | rejected. |

This closes the native verifier discrepancy where a proof could set `deferral_flag == 0`, omit deferral Merkle proofs, and skip the root-layer unchanged-address-space check that the AIR requires.

### `DeferralMerkleProofs::verify`

`DeferralMerkleProofs::verify` now performs two additional checks:

- `depth <= memory_dimensions.address_height`
- `initial_merkle_proof[i] == final_merkle_proof[i]` for `i in 0..memory_dimensions.address_height`

The sibling equality check matches `DeferralAccMerklePathsAir`'s invariant that the part of `DEFERRAL_AS` outside the aggregated deferral subtree is left untouched for the duration of execution.

New error variants were added for these checks:

- `DeferralDepthTooLarge { depth, address_height }`
- `DeferralMerkleProofSiblingMismatch`

The depth bound is deliberately the address-space height, not the full memory Merkle path height. Deferral aggregation depth describes a subtree inside `DEFERRAL_AS`; allowing it to extend past the address-space boundary would skip levels that the AIR expects to compare as unchanged.

### Verification Baseline Docs

The `expected_def_hook_commit` comment now describes the actual semantics:

- `Some` means deferral public values are enabled.
- The proof may have `deferral_flag == 0` or `deferral_flag == 2`.
- Valid deferral Merkle proofs are required in both cases.
- `None` means no deferral public values may be present.

## Root Verifier AIRs

### DeferralAccMerklePathsAir

`crates/continuations/src/circuit/root/def_paths/air.rs` now constrains received deferral depths to be less than or equal to the deferral address-space height.

No columns were added or removed, and the `DeferralAccPathMessage` bus shape is unchanged. The change factors the receive multiplicity into `is_next_start_depth` and adds:

- while inside `DEFERRAL_AS`, the existing path equality constraints still apply;
- after leaving `DEFERRAL_AS`, no new `DeferralAccPathMessage` may be received.

Example row behavior:

| Region | `is_within_deferral_as` | `is_next_start_depth` | Meaning |
| --- | ---: | ---: | --- |
| Before/inside `DEFERRAL_AS` | `1` | `0` or `1` | A deferral subtree may start while still inside the address-space path. |
| First level after `DEFERRAL_AS` | `0` | `0` | A new deferral subtree start is rejected past `address_height`. |
| Later path levels | `0` | `0` | Continue normal path verification to the memory root. |

The trace generator now uses the same bound and asserts `depth in 1..=address_height` when the accumulator is set.

### AIRs Changed

- `crates/continuations/src/circuit/root/verifier/air.rs`
- `guest-libs/verify-stark/circuit/src/verifier/air.rs`

Both AIRs now constrain `def_hook_commit` to be zero in the no-deferral branch.

No columns were added or removed.

### Constraint Summary

The root verifier AIR already constrained:

- `deferral_flag` is either `0` or `2`.
- If `deferral_flag == 2`, `def_hook_commit == expected_def_hook_commit`.
- If `deferral_flag != 2`, deferral depth and accumulator hashes are unset.
- A `DeferralAccPathMessage` is sent in both cases, so `DeferralAccMerklePathsAir` checks the relevant memory paths.

This PR adds the missing no-deferral constraint:

- If `deferral_flag != 2`, `def_hook_commit == 0`.

Example accepted/rejected public value shapes:

| Case | `deferral_flag` | `def_hook_commit` | `depth` | `initial_acc_hash` / `final_acc_hash` |
| --- | ---: | --- | ---: | --- |
| No deferral | `0` | zero | `0` | zero |
| Deferral present | `2` | expected deferral hook commit | nonzero aggregate depth | committed accumulator roots |
| Invalid no-deferral | `0` | nonzero | `0` | zero |
| Invalid flag | `1` or other | any | any | any |

### Existing Bus Interaction

No bus interface changes were made, but the unchanged root-layer bus flow is important to this fix:

```text
RootVerifierPvsAir / DeferredVerifyPvsAir
  |
  | sends DeferralAccPathMessage
  |   initial_acc_hash
  |   final_acc_hash
  |   depth
  |   is_unset = 1 when deferral_flag == 0
  |
  v
DeferralAccMerklePathsAir
  |
  | receives DeferralMerkleRootsMessage
  |   initial_root
  |   final_root
  |
  v
Checks initial/final accumulator paths and unchanged DEFERRAL_AS prefix
```

The native verifier changes mirror this AIR behavior directly.

## CI

`.github/workflows/sdk.cuda.yml` now runs on PR changes under:

- `crates/continuations/**`
- `crates/recursion/**`

This ensures SDK CUDA coverage is triggered for continuation and recursion changes that affect SDK proving flows.

## Review Guide

Suggested review order:

1. Review `crates/verify/src/lib.rs` and the baseline JSON plumbing to confirm the user public value length check uses the VM-configured `num_public_values`.
2. Review `crates/verify/src/lib.rs` to confirm deferral Merkle proofs are required for both `deferral_flag == 0` and `deferral_flag == 2`.
3. Review `crates/verify/src/deferral.rs` and `crates/continuations/src/circuit/root/def_paths/air.rs` to confirm the depth bound is `address_height` and the `DEFERRAL_AS` sibling equality matches the root AIR semantics.
4. Review both root verifier AIR copies to confirm `def_hook_commit` is unset in the no-deferral branch.
5. Review the workflow path additions.
