### PR TITLE
refactor: import openvm constants instead of redefining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8979,6 +8979,10 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-ffi-common"
 version = "2.0.0-beta.2"
+dependencies = [
+ "openvm-instructions",
+ "openvm-platform",
+]
 
 [[package]]
 name = "rvr-openvm-ext-keccak"

--- a/crates/rvr/rvr-openvm-ffi-common/Cargo.toml
+++ b/crates/rvr/rvr-openvm-ffi-common/Cargo.toml
@@ -6,3 +6,7 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
+
+[dependencies]
+openvm-platform.workspace = true
+openvm-instructions.workspace = true

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -12,7 +12,7 @@
 use std::ffi::c_void;
 
 /// Word size for memory access (4 bytes).
-pub const WORD_SIZE: usize = 4;
+pub use openvm_platform::WORD_SIZE;
 
 // ── Deferral constants ───────────────────────────────────────────────────
 
@@ -26,14 +26,10 @@ pub const DEFERRAL_COMMIT_NUM_BYTES: usize = DEFERRAL_DIGEST_SIZE * WORD_SIZE;
 pub const DEFERRAL_OUTPUT_KEY_BYTES: usize = DEFERRAL_COMMIT_NUM_BYTES + 8;
 
 // ── OpenVM address space identifiers (mirror C `openvm_state.h`) ──
-/// Register file address space.
-pub const AS_REGISTER: u32 = 1;
-/// Main guest memory address space.
-pub const AS_MEMORY: u32 = 2;
-/// Public values address space.
-pub const AS_PUBLIC_VALUES: u32 = 3;
-/// Deferral output address space.
-pub const DEFERRAL_AS: u32 = 4;
+pub use openvm_instructions::{
+    riscv::{RV32_MEMORY_AS as AS_MEMORY, RV32_REGISTER_AS as AS_REGISTER},
+    DEFERRAL_AS, PUBLIC_VALUES_AS as AS_PUBLIC_VALUES,
+};
 
 // ── OpenVM metered-execution layout ───────────────────────────────────
 // Redefined here to avoid a cycle with openvm-circuit. Checked against

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -14,6 +14,7 @@ use std::ffi::c_void;
 /// Word size for memory access (4 bytes).
 pub use openvm_platform::WORD_SIZE;
 
+// TODO(dedup): make a common crate that is imported by rvr and openvm-circuit
 // ── Deferral constants ───────────────────────────────────────────────────
 
 /// BabyBear Poseidon2 digest size in field elements.
@@ -31,6 +32,7 @@ pub use openvm_instructions::{
     DEFERRAL_AS, PUBLIC_VALUES_AS as AS_PUBLIC_VALUES,
 };
 
+// TODO(dedup): make a common crate that is imported by rvr and openvm-circuit
 // ── OpenVM metered-execution layout ───────────────────────────────────
 // Redefined here to avoid a cycle with openvm-circuit. Checked against
 // upstream in `openvm-circuit`'s `arch::rvr::abi_consts`.

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -1061,7 +1061,7 @@ fn build_block_list(
 ) -> Vec<Block> {
     // Max block size; used to flush periodically so the segmentation check in
     // metered mode (which fires at block boundaries) stays granular enough.
-    let max_block_insns = rvr_openvm_ext_ffi_common::DEFAULT_SEGMENT_CHECK_INSNS;
+    const MAX_BLOCK_INSNS: u32 = rvr_openvm_ext_ffi_common::DEFAULT_SEGMENT_CHECK_INSNS;
     let mut blocks: Vec<Block> = Vec::new();
 
     // Accumulate body instructions for the current block.
@@ -1096,7 +1096,7 @@ fn build_block_list(
         match li {
             LiftedInstr::Body(instr_at) => {
                 body.push(instr_at.clone());
-                if body.len() >= max_block_insns as usize {
+                if body.len() >= MAX_BLOCK_INSNS as usize {
                     let start = block_start_pc.unwrap();
                     let last_body_pc = body.last().unwrap().pc;
                     blocks.push(Block {

--- a/crates/toolchain/instructions/src/lib.rs
+++ b/crates/toolchain/instructions/src/lib.rs
@@ -18,6 +18,9 @@ pub mod utils;
 
 pub use phantom::*;
 
+/// Public values address space.
+pub const PUBLIC_VALUES_AS: u32 = 3;
+/// Deferral output address space.
 pub const DEFERRAL_AS: u32 = 4;
 
 pub trait LocalOpcode {

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -11,12 +11,11 @@ use std::{collections::VecDeque, ffi::c_void, io::Write, mem::size_of};
 
 #[cfg(not(feature = "unprotected"))]
 use openvm_platform::memory::MEM_SIZE;
+use openvm_platform::WORD_SIZE;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rand::{rngs::StdRng, Rng};
 
 use crate::arch::deferral::DeferralState;
-
-const WORD_SIZE: usize = size_of::<u32>();
 
 /// IO execution state borrowed from the host `VmState<F>` for the duration of
 /// one rvr call. Streams, rng, and the public-values byte slice are mutable

--- a/crates/vm/src/system/memory/merkle/public_values.rs
+++ b/crates/vm/src/system/memory/merkle/public_values.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Write};
 
 use itertools::Itertools;
+pub use openvm_instructions::PUBLIC_VALUES_AS;
 use openvm_stark_backend::{
     codec::{DecodableConfig, EncodableConfig},
     p3_util::log2_strict_usize,
@@ -14,8 +15,6 @@ use crate::{
     arch::{hasher::Hasher, MemoryCellType, ADDR_SPACE_OFFSET},
     system::memory::{dimensions::MemoryDimensions, online::LinearMemory, MemoryImage},
 };
-
-pub const PUBLIC_VALUES_AS: u32 = 3;
 pub const PUBLIC_VALUES_ADDRESS_SPACE_OFFSET: u32 = PUBLIC_VALUES_AS - ADDR_SPACE_OFFSET;
 
 /// Merkle proof for user public values in the memory state.


### PR DESCRIPTION
In `rvr`, some constants are redefined or set as variables. Resolved some of the dependency issues (e.g. circular dependency) to import the constants instead.

Related constants:
1) `WORD_SIZE`: imported from `openvm_platform::WORD_SIZE`

2) `AS_MEMORY`: imported from `openvm_instructions::riscv::RV32_MEMORY_AS`

3) `AS_REGISTER`: imported from `openvm_instructions::riscv::RV32_REGISTER_AS`

4) `AS_PUBLIC_VALUES`: imported from `openvm_instructions::PUBLIC_VALUES_AS` (moved to `openvm_instructions` from `openvm-circuit`. Is it right choice????)

5) `DEFERRAL_AS`: imported from `openvm_instructions::DEFERRAL_AS`

6) `MAX_BLOCK_INSNS` (`rvr-openvm-lift/src/cfg.rs`): was `let`, now `const`

The following ones are kept redefined:
1) `CHUNK`, `DEFERRAL_DIGEST_SIZE`: logically are from `openvm-stark-sdk`. `openvm-circuit` and `openvm-recursion-circuit` already redefine CHUNK. (can not import from them due to circular dependency). 

2) `DEFAULT_PAGE_BITS`, `DEFAULT_SEGMENT_CHECK_INSNS`: logically are from `openvm-circuit::arch::execution_mode::metered::{ctx, segment_ctx}`. These are host-side metered-execution defaults. (can not import from them due to circular dependency)

closes INT-7571