### PR TITLE
feat: constrain AIRs are sorted by air_idx after trace height in recursion

### DIFF
--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["**"]
     paths:
+      - "crates/continuations/**"
+      - "crates/recursion/**"
       - "crates/sdk/**"
       - ".github/workflows/sdk.cuda.yml"
 

--- a/crates/recursion/cuda/src/proof_shape/air.cu
+++ b/crates/recursion/cuda/src/proof_shape/air.cu
@@ -52,6 +52,7 @@ template <typename T, size_t MAX_CACHED> struct ProofShapeCols {
 
     T is_present;
     T height;
+    T is_height_equal_to_next;
     T num_present;
 
     T lifted_height_limbs[NUM_LIMBS];
@@ -245,6 +246,9 @@ __device__ __forceinline__ void fill_summary_row(
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, is_last, Fp::one());
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, sorted_idx, Fp::zero());
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, is_present, Fp::zero());
+    COL_WRITE_VALUE(
+        row, typename Cols<MAX_CACHED>::template Type, is_height_equal_to_next, Fp::zero()
+    );
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, starting_cidx, Fp::zero());
     COL_WRITE_VALUE(row, typename Cols<MAX_CACHED>::template Type, num_air_id_lookups, Fp::zero());
     row.fill_zero(cached_commits_idx, MAX_CACHED * DIGEST_SIZE);
@@ -395,13 +399,33 @@ __global__ void proof_shape_tracegen(
             encoder.write_flag_pt(row.slice_from(encoder_flags_idx), trace_height.air_idx);
 
             if (record_idx + 1 < inputs.num_airs) {
+                bool is_present = record_idx < proof_data.num_present;
+                bool next_is_present = record_idx + 1 < proof_data.num_present;
                 uint8_t current_log_height = trace_height.log_height;
-                uint8_t next_log_height =
-                    record_idx + 1 < proof_data.num_present
-                        ? sorted_trace_heights[proof_idx][record_idx + 1].log_height
-                        : 0;
-                pow_checker.add_range_count(
-                    static_cast<uint32_t>(current_log_height - next_log_height)
+                TraceHeight next_trace_height = sorted_trace_heights[proof_idx][record_idx + 1];
+                uint8_t next_log_height = next_trace_height.log_height;
+                bool is_height_equal_to_next =
+                    is_present == next_is_present &&
+                    (!is_present || current_log_height == next_log_height);
+                COL_WRITE_VALUE(
+                    row,
+                    typename Cols<MAX_CACHED>::template Type,
+                    is_height_equal_to_next,
+                    is_height_equal_to_next
+                );
+                if (is_height_equal_to_next) {
+                    range_checker.add_count(next_trace_height.air_idx - trace_height.air_idx - 1);
+                } else {
+                    uint32_t rank = current_log_height + is_present;
+                    uint32_t next_rank = next_log_height + next_is_present;
+                    pow_checker.add_range_count(rank - next_rank - 1);
+                }
+            } else {
+                COL_WRITE_VALUE(
+                    row,
+                    typename Cols<MAX_CACHED>::template Type,
+                    is_height_equal_to_next,
+                    Fp::zero()
                 );
             }
 

--- a/crates/recursion/src/proof_shape/mod.rs
+++ b/crates/recursion/src/proof_shape/mod.rs
@@ -88,6 +88,11 @@ impl ProofShapeModule {
         bus_inventory: BusInventory,
         continuations_enabled: bool,
     ) -> Self {
+        assert!(
+            mvk.per_air.len() <= 1 << 8,
+            "recursion circuit only supports child verifying keys with at most 256 AIRs"
+        );
+
         let idx_encoder = Arc::new(Encoder::new(mvk.per_air.len(), 2, true));
 
         let (min_cached_idx, min_cached) = mvk
@@ -230,7 +235,6 @@ impl AirModule for ProofShapeModule {
     }
 
     fn airs<SC: StarkProtocolConfig<F = F>>(&self) -> Vec<AirRef<SC>> {
-        assert!(self.per_air.len() <= 1 << 8);
         let proof_shape_air = ProofShapeAir::<4, 8> {
             per_air: self.per_air.clone(),
             l_skip: self.l_skip,

--- a/crates/recursion/src/proof_shape/mod.rs
+++ b/crates/recursion/src/proof_shape/mod.rs
@@ -230,6 +230,7 @@ impl AirModule for ProofShapeModule {
     }
 
     fn airs<SC: StarkProtocolConfig<F = F>>(&self) -> Vec<AirRef<SC>> {
+        assert!(self.per_air.len() <= 1 << 8);
         let proof_shape_air = ProofShapeAir::<4, 8> {
             per_air: self.per_air.clone(),
             l_skip: self.l_skip,

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -47,9 +47,8 @@ pub struct ProofShapeCols<F, const NUM_LIMBS: usize> {
     pub is_last: F,
 
     pub sorted_idx: F,
-    /// Represents log2 trace height when `is_present`.
-    ///
-    /// Has a special use on summary row (when `is_last`).
+
+    /// Log2 trace height when `is_present`; has a special use on summary row (when `is_last`).
     pub log_height: F,
     /// When `is_present`, constrained to equal `log_height - l_skip < 0 ? 1 : 0`.
     pub n_sign_bit: F,
@@ -62,12 +61,12 @@ pub struct ProofShapeCols<F, const NUM_LIMBS: usize> {
     // from the transcript.
     pub is_present: F,
 
-    /// Will be constrained to be `2^log_height` when `is_present`.
-    ///
-    /// Has a special use on summary row (when `is_last`).
+    /// Constrained to `2^log_height` when `is_present`; has a special use on summary row.
     pub height: F,
+    /// Indicates whether if this trace's height is equal to the next row's.
+    pub is_height_equal_to_next: F,
 
-    // Number of present AIRs so far
+    /// Number of present AIRs so far.
     pub num_present: F,
 
     // The total number of interactions over all traces needs to fit in a single field element,
@@ -87,8 +86,8 @@ pub struct ProofShapeCols<F, const NUM_LIMBS: usize> {
     pub num_interactions_limbs: [F; NUM_LIMBS],
     pub total_interactions_limbs: [F; NUM_LIMBS],
 
-    /// The maximum hypercube dimension across all present AIR traces, or zero.
-    /// Computed as max(0, n0, n1, ...) where ni = log_height_i - l_skip for each present trace.
+    /// The maximum hypercube dimension across all present AIR traces, or zero. Computed a
+    /// max(0, n0, n1, ...) where ni = log_height_i - l_skip for each present trace.
     pub n_max: F,
     pub is_n_max_greater: F,
     pub n_logup: F,
@@ -216,6 +215,11 @@ where
             self.idx_encoder.width(),
             self.max_cached,
         );
+        let nextv = borrow_var_cols::<AB::Var>(
+            &next[const_width..],
+            self.idx_encoder.width(),
+            self.max_cached,
+        );
         let local: &ProofShapeCols<AB::Var, NUM_LIMBS> = (*local)[..const_width].borrow();
         let next: &ProofShapeCols<AB::Var, NUM_LIMBS> = (*next)[..const_width].borrow();
 
@@ -273,6 +277,9 @@ where
         let mut num_interactions = AB::Expr::ZERO;
         let mut need_rot = AB::Expr::ZERO;
 
+        // Select next AIR idx to ensure sortedness between traces with the same height
+        let mut next_air_idx = AB::Expr::ZERO;
+
         // Select values for LiftedHeightsBus
         let mut main_common_width = AB::Expr::ZERO;
         let mut preprocessed_stacked_width = AB::Expr::ZERO;
@@ -303,6 +310,10 @@ where
                 has_pvs += is_current_air.clone();
             }
             num_pvs += is_current_air.clone() * AB::F::from_usize(air_data.num_public_values);
+
+            // Select the next AIR idx
+            let next_is_current_air = self.idx_encoder.get_flag_expr::<AB>(i, nextv.idx_flags);
+            next_air_idx += next_is_current_air * AB::F::from_usize(i);
 
             // Select number of interactions for use later in the AIR and constrain that the
             // num_interactions_per_row limb decomposition is correct.
@@ -385,14 +396,42 @@ where
             .when(and(not(local.is_present), local.is_valid))
             .assert_zero(local.log_height);
 
-        // Range check difference using ExponentBus to ensure local.log_height >= next.log_height
+        // Constrain local.height == next.height when is_height_equal_to_next is 1, and that
+        // is_height_equal_to_next is 0 for the last AIR
+        let is_valid_transition = and(local.is_valid, not(next.is_last));
+
+        builder.assert_bool(local.is_height_equal_to_next);
+        builder
+            .when(local.is_height_equal_to_next)
+            .assert_one(is_valid_transition.clone());
+        builder
+            .when(local.is_height_equal_to_next)
+            .assert_eq(local.height, next.height);
+
+        // If is_height_equal_to_next == 0, ensure local.height > next.height by constraining
+        // local_rank > next_rank. By definition rank == 0 for non-present AIRs and rank > 0
+        // for present ones.
+        let local_rank = local.log_height + local.is_present;
+        let next_rank = next.log_height + next.is_present;
+
         self.range_bus.lookup_key(
             builder,
             RangeCheckerBusMessage {
-                value: local.log_height - next.log_height,
+                value: local_rank - next_rank - AB::Expr::ONE,
                 max_bits: AB::Expr::from_usize(5),
             },
-            and(local.is_valid, not(next.is_last)),
+            is_valid_transition.clone() * not(local.is_height_equal_to_next),
+        );
+
+        // If is_height_equal_to_next == 1, constrain that local.air_idx < next.air_idx. Note
+        // this means that the gap between air indices cannot exceed 2^8 - 1.
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: next_air_idx - air_idx.clone() - AB::Expr::ONE,
+                max_bits: AB::Expr::from_usize(8),
+            },
+            local.is_height_equal_to_next,
         );
 
         ///////////////////////////////////////////////////////////////////////////////////////////
@@ -702,7 +741,7 @@ where
         });
 
         builder
-            .when(and(local.is_valid, not(next.is_last)))
+            .when(is_valid_transition)
             .assert_eq(local.starting_cidx + cidx_offset, next.starting_cidx);
 
         self.commitments_bus.add_key_with_lookups(

--- a/crates/recursion/src/proof_shape/proof_shape/trace.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/trace.rs
@@ -120,6 +120,21 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 cols.height = F::from_usize(height);
                 cols.num_present = F::from_usize(num_present);
 
+                if sorted_idx < preflight.proof_shape.sorted_trace_vdata.len() {
+                    let (next_idx, next_vdata) =
+                        &preflight.proof_shape.sorted_trace_vdata[sorted_idx];
+                    let diff = vdata.log_height - next_vdata.log_height;
+                    cols.is_height_equal_to_next = F::from_bool(diff == 0);
+                    if diff == 0 {
+                        range_checker.add_count(*next_idx - *idx - 1);
+                    } else {
+                        pow_checker.add_range(diff - 1);
+                    }
+                } else if sorted_idx < num_airs {
+                    cols.is_height_equal_to_next = F::ZERO;
+                    pow_checker.add_range(log_height);
+                }
+
                 let lifted_height = height.max(1 << l_skip);
                 let num_interactions_per_row = child_vk.inner.per_air[*idx].num_interactions();
                 let num_interactions = num_interactions_per_row * lifted_height;
@@ -184,15 +199,6 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                     range_checker.add_count(carry);
                 }
 
-                if sorted_idx < preflight.proof_shape.sorted_trace_vdata.len() {
-                    let diff = vdata.log_height
-                        - preflight.proof_shape.sorted_trace_vdata[sorted_idx]
-                            .1
-                            .log_height;
-                    pow_checker.add_range(diff);
-                } else if sorted_idx < num_airs {
-                    pow_checker.add_range(log_height);
-                }
                 pow_checker.add_range(n.unsigned_abs());
                 pow_checker.add_pow(log_height);
             }
@@ -220,6 +226,14 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 cols.starting_cidx = F::from_usize(cidx);
                 cols.n_logup = F::from_usize(preflight.proof_shape.n_logup);
 
+                if sorted_idx < num_airs {
+                    cols.is_height_equal_to_next = F::ONE;
+                    let next_idx = (idx + 1..num_airs)
+                        .find(|next_idx| proof.trace_vdata[*next_idx].is_none())
+                        .unwrap();
+                    range_checker.add_count(next_idx - idx - 1);
+                }
+
                 cols.total_interactions_limbs = total_interactions_f;
                 cols.n_max = F::from_usize(preflight.proof_shape.n_max);
                 cols.num_air_id_lookups = F::from_usize(bc_air_shape_lookups[idx]);
@@ -246,10 +260,6 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 range_checker.add_count_mult(0, (2 * NUM_LIMBS - 1) as u32);
                 for limb in total_interactions_usize {
                     range_checker.add_count(limb);
-                }
-
-                if sorted_idx < num_airs {
-                    pow_checker.add_range(0);
                 }
             }
 

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -544,6 +544,9 @@ impl<'a> TraceModuleRef<'a> {
 
 /// The recursive verifier sub-circuit consists of multiple chips, grouped into **modules**.
 ///
+/// This circuit supports child verifying keys with at most 256 AIRs. `ProofShapeAir`
+/// range-checks AIR-index gaps with an 8-bit lookup when enforcing sorted proof-shape rows.
+///
 /// This struct is stateful.
 pub struct VerifierSubCircuit<const MAX_NUM_PROOFS: usize> {
     bus_inventory: BusInventory,

--- a/docs/crates/recursion/README.md
+++ b/docs/crates/recursion/README.md
@@ -6,6 +6,8 @@ The recursion circuit verifies SWIRL proofs inside a SWIRL circuit. The circuit 
 
 The circuit is implemented as a collection of 39 AIRs organized into protocol modules plus
 shared lookup/provider AIRs. AIRs communicate through buses (permutation checks and lookups).
+The child verifying key must contain at most 256 AIRs; the ProofShape module uses an 8-bit
+range check to constrain AIR-index ordering among equal-height proof-shape rows.
 
 For the formal correspondence claim and correctness argument, see [verifier-mapping.md](./verifier-mapping.md).
 

--- a/docs/crates/recursion/modules/proof-shape/README.md
+++ b/docs/crates/recursion/modules/proof-shape/README.md
@@ -40,29 +40,18 @@ VK pre-hash: sent on `PreHashBus` when continuations are enabled (see
 
 The reference verifier sorts all `num_airs` AIRs by the key
 `(is_none, Reverse(log_height), air_id)`. ProofShapeAir has one row per AIR (`num_airs`
-rows total), with `sort_idx` ranging from 0 to `num_airs - 1`.
+rows total), with `sort_idx` ranging from 0 to `num_airs - 1`. The recursion circuit
+supports child verifying keys with at most 256 AIRs.
 
 ProofShapeAir constrains the sort order via:
-- **Non-increasing heights:** `log_height[i] - log_height[i+1] >= 0` (range-checked via
-  `RangeCheckerBus`).
+- **Descending heights:** when adjacent rows do not have equal height, a compact rank check
+  enforces that the local row has greater height. The rank is `log_height + is_present`, so
+  absent AIRs are below present height-1 AIRs.
+- **AIR-index tiebreaker:** when adjacent rows have equal height, `air_id[i+1] - air_id[i] - 1`
+  is range-checked as an 8-bit value, enforcing `air_id[i] < air_id[i+1]`.
 - **Absent AIRs last:** `log_height = 0` and `height = 0` when `is_present = 0`.
 - **Permutation:** a permutation bus enforces that the `sort_idx → air_idx` mapping is a
   bijection (every AIR appears exactly once).
-
-The circuit does **not** constrain the tiebreaker within a height tie — the ordering of
-AIRs with equal `log_height` is a prover choice. This is sound because:
-
-- **Internal consistency.** Every downstream use of `sort_idx` receives both structural
-  metadata (air_idx, num_interactions, need_rot via `AirShapeBus`) and proof data (column
-  openings, heights via `LiftedHeightsBus`, etc.) through the same buses, keyed by the same
-  `sort_idx`. Reordering within a tie relabels all data consistently.
-
-- **Verifier invariance.** The reference verifier's algorithm only relies on trace heights
-  being in non-increasing order — it does not depend on which specific AIR occupies which
-  sort position within a height tie. The extraction produces `(trace_vdata, proof_arrays)`
-  indexed by the circuit's sort order; the reference verifier sorts `trace_vdata` (producing
-  *some* non-increasing-height permutation) and iterates. Any such permutation leads to the
-  same verification result.
 
 ## Empty traces
 

--- a/docs/crates/recursion/modules/proof-shape/airs.md
+++ b/docs/crates/recursion/modules/proof-shape/airs.md
@@ -45,6 +45,7 @@ graph LR
     PSA -- "send" --> NLB
     PSA -- "send" --> E3SB
     PSA -- "send" --> NPVB
+    PSA -- "lookup_key" --> RCB
     PSA -- "lookup_key" --> POWB
     PSA -- "send" --> CCBUS
     PSA -- "send" --> PHB
@@ -64,7 +65,7 @@ graph LR
 
 ### Executive Summary
 
-ProofShapeAir is the most complex AIR in the recursion circuit. It iterates over each child proof's AIRs (sorted by descending log_height) and establishes the lookup tables that the rest of the circuit uses. For each AIR, it publishes shape properties (air_id, num_interactions, need_rot), hyperdimensional parameters, lifted heights, and commitments. On the summary row (the last row for each proof), it validates that total interactions stay within bounds and sends module-level messages to kick off GKR and batch constraint verification.
+ProofShapeAir is the most complex AIR in the recursion circuit. It iterates over each child proof's AIRs sorted by descending height and then AIR index, and establishes the lookup tables that the rest of the circuit uses. For each AIR, it publishes shape properties (air_id, num_interactions, need_rot), hyperdimensional parameters, lifted heights, and commitments. On the summary row (the last row for each proof), it validates that total interactions stay within bounds and sends module-level messages to kick off GKR and batch constraint verification.
 
 ### Public Values
 
@@ -77,30 +78,34 @@ None.
 3. **Hyperdimensional parameters (HyperdimBus — provides):** Provides `(sort_idx, n_abs, n_sign_bit)` for each child AIR.
 4. **Lifted heights (LiftedHeightsBus — provides):** Provides `(sort_idx, part_idx, commit_idx, hypercube_dim, lifted_height, log_lifted_height)` for each AIR partition.
 5. **Commitments (CommitmentsBus — provides):** Reads commitments from the transcript (TranscriptBus) and provides `(major_idx, minor_idx, commitment)` for each commitment.
-6. **Interaction bound (RangeCheckerBus — lookup):** Enforces `total_interactions < max_interaction_count` via range checks.
-7. **Height verification (PowerCheckerBus — lookup):** Verifies `height = 2^log_height` for each AIR via power-of-two lookup.
-8. **Module handoffs:** Sends `(tidx, n_logup, n_max, is_n_max_greater)` on GkrModuleBus, `(num_present_airs)` on FractionFolderInputBus, `(n_max)` on ExpressionClaimNMaxBus, `(n_logup, n_max)` on EqNsNLogupMaxBus, and `(air_idx, n_lift)` on NLiftBus.
-9. **Eq3b shape (Eq3bShapeBus — sends):** Sends `(sort_idx, n_lift, n_logup, num_interactions)` for each present AIR, providing shape parameters needed by Eq3bAir.
-10. **Cached commits (CachedCommitBus — sends):** Sends cached commitment data for downstream verifier AIRs, currently including RootVerifierPvsAir and DeferredVerifyPvsAir.
-11. **VK pre-hash (PreHashBus — sends):** Sends the child VK pre-hash for downstream verifier AIRs, currently including RootVerifierPvsAir and DeferredVerifyPvsAir.
-12. **Public values coordination (NumPublicValuesBus — sends):** Sends per-AIR public value counts to PublicValuesAir.
-13. **Transcript (TranscriptBus — receives):** Receives commitment observations from the transcript.
+6. **Proof-shape ordering (RangeCheckerBus — lookup):** Enforces descending height across adjacent rows and increasing AIR index for equal-height rows.
+7. **Interaction bound (RangeCheckerBus — lookup):** Enforces `total_interactions < max_interaction_count` via range checks.
+8. **Height verification (PowerCheckerBus — lookup):** Verifies `height = 2^log_height` for each AIR via power-of-two lookup.
+9. **Module handoffs:** Sends `(tidx, n_logup, n_max, is_n_max_greater)` on GkrModuleBus, `(num_present_airs)` on FractionFolderInputBus, `(n_max)` on ExpressionClaimNMaxBus, `(n_logup, n_max)` on EqNsNLogupMaxBus, and `(air_idx, n_lift)` on NLiftBus.
+10. **Eq3b shape (Eq3bShapeBus — sends):** Sends `(sort_idx, n_lift, n_logup, num_interactions)` for each present AIR, providing shape parameters needed by Eq3bAir.
+11. **Cached commits (CachedCommitBus — sends):** Sends cached commitment data for downstream verifier AIRs, currently including RootVerifierPvsAir and DeferredVerifyPvsAir.
+12. **VK pre-hash (PreHashBus — sends):** Sends the child VK pre-hash for downstream verifier AIRs, currently including RootVerifierPvsAir and DeferredVerifyPvsAir.
+13. **Public values coordination (NumPublicValuesBus — sends):** Sends per-AIR public value counts to PublicValuesAir.
+14. **Transcript (TranscriptBus — receives):** Receives commitment observations from the transcript.
 
 ### Walkthrough
 
-For a child proof with 2 AIRs (air_id=0 at log_height=10, air_id=1 at log_height=8):
+For a child proof with 3 AIRs (`air_id=0` at `log_height=10`, `air_id=1` at
+`log_height=10`, `air_id=2` absent):
 
 ```
-Row | proof_idx | is_first | is_last | sorted_idx | air_id | log_height | is_present | n_abs | n_sign
-----|-----------|----------|---------|------------|--------|------------|------------|-------|-------
- 0  |     0     |    1     |    0    |     0      |   0    |     10     |     1      |   2   |   0
- 1  |     0     |    0     |    0    |     1      |   1    |      8     |     1      |   0   |   0
- 2  |     0     |    0     |    1    |     -      |   -    |      -     |     0      |   -   |   -
+Row | proof_idx | is_first | is_last | sorted_idx | air_id | log_height | height | is_present | is_height_equal_to_next | n_abs | n_sign
+----|-----------|----------|---------|------------|--------|------------|--------|------------|-------------------------|-------|-------
+ 0  |     0     |    1     |    0    |     0      |   0    |     10     |  1024  |     1      |            1            |   2   |   0
+ 1  |     0     |    0     |    0    |     1      |   1    |     10     |  1024  |     1      |            0            |   2   |   0
+ 2  |     0     |    0     |    0    |     2      |   2    |      0     |    0   |     0      |            0            |   0   |   0
+ 3  |     0     |    0     |    1    |     -      |   -    |      -     |    -   |     0      |            0            |   -   |   -
 ```
 
-- **Row 0:** First AIR (highest log_height). Publishes shape properties and hyperdim params. `n_abs = |10 - 8| = 2` (assuming l_skip=8).
-- **Row 1:** Second AIR. `n_abs = |8 - 8| = 0`.
-- **Row 2 (summary):** Validates total interaction count. Sends GkrModuleBus message with accumulated `n_logup` and `n_max`. Sends FractionFolderInputBus with `num_present_airs=2`. Also sends Eq3bShapeBus and EqNsNLogupMaxBus messages.
+- **Row 0:** First present AIR. It has the same height as row 1, so `is_height_equal_to_next=1` and the AIR-index gap `1 - 0 - 1 = 0` is range-checked.
+- **Row 1:** Second present AIR. The next row is absent, so the effective rank decreases from `10 + 1` to `0`; `is_height_equal_to_next=0`.
+- **Row 2:** Absent AIR. It has `log_height=0` and `height=0`.
+- **Row 3 (summary):** Validates total interaction count. Sends GkrModuleBus message with accumulated `n_logup` and `n_max`. Sends FractionFolderInputBus with `num_present_airs=2`. Also sends Eq3bShapeBus and EqNsNLogupMaxBus messages.
 
 AIR selection uses an `idx_flags` encoder (flag columns that decode to the AIR index). The `need_rot` property is loaded from air_data metadata. The `n_logup` value is tracked as an explicit column on each row.
 

--- a/docs/crates/recursion/verifier-mapping.md
+++ b/docs/crates/recursion/verifier-mapping.md
@@ -63,7 +63,7 @@ The stark-backend verifier ([`crates/stark-backend/src/verifier/mod.rs`](https:/
 | Per-AIR: observe public values | PublicValuesAir | TranscriptBus, PublicValuesBus | PublicValuesAir receives per-AIR PV counts from ProofShapeAir via NumPublicValuesBus, then observes each public value into the transcript |
 | Validate proof shape (VData lengths, bounds, etc.) | ProofShapeAir | RangeCheckerBus, AirShapeBus, HyperdimBus, LiftedHeightsBus | ProofShapeAir uses range checks (via RangeCheckerAir) and the idx_encoder to validate log_height bounds, cached commitment counts, and other structural properties |
 | Trace height constraint check | ProofShapeAir | AirShapeBus, LiftedHeightsBus | ProofShapeAir's summary row enforces `sum_i(num_interactions[i] * lifted_height[i]) < max_interaction_count` via limb decomposition (see Section 3.2 below) |
-| Compute trace_id_to_air_id sorting | ProofShapeAir | AirShapeBus | ProofShapeAir processes AIRs in sorted order (by descending log_height, then air_id) matching the verifier's `trace_id_to_air_id` |
+| Compute trace_id_to_air_id sorting | ProofShapeAir | RangeCheckerBus, AirShapeBus | ProofShapeAir processes AIRs in sorted order (by descending height, then air_id) matching the verifier's `trace_id_to_air_id` |
 | Populate per-AIR metadata buses | ProofShapeAir | AirShapeBus, HyperdimBus, NLiftBus, FractionFolderInputBus, ExpressionClaimNMaxBus, GkrModuleBus | ProofShapeAir sends metadata (air_id, num_interactions, need_rot, n_lift, n_max, n_logup, tidx) that downstream modules consume as lookup/permutation bus messages |
 
 #### Host-only Prechecks (No AIR Counterpart)
@@ -247,7 +247,7 @@ is mapped to its circuit counterpart.
 | 63-64 | `config.params() != &mvk.inner.params` | VK params baked into circuit | G1 |
 | 90-92 | `num_traces == 0` -> error | PS1b: VK-required AIRs must be present | [ProofShape](./modules/proof-shape/README.md) |
 | 94 | `verify_proof_shape(mvk, proof)` | Distributed across VK-fixed structure, AIR loops, bus balancing | [proof-shape-validation.md](./proof-shape-validation.md) |
-| 96-106 | Sort AIRs by `(is_none, Reverse(log_height), air_id)` | ProofShapeAir non-increasing height constraint (tiebreaker is prover choice) | [ProofShape](./modules/proof-shape/README.md) |
+| 96-106 | Sort AIRs by `(is_none, Reverse(log_height), air_id)` | ProofShapeAir descending-height constraint plus AIR-index tiebreaker | [ProofShape](./modules/proof-shape/README.md) |
 | 108-120 | Trace height constraints | `total_interactions < max_interaction_count` (PS1c) | G2 |
 | 122-123 | `omega_skip` computation | VK constant | -- |
 | 126-155 | Preamble: observe VK pre-hash, commits, PVs | ProofShapeAir + PublicValuesAir transcript preamble | [ProofShape](./modules/proof-shape/README.md) PS3, PS4 |


### PR DESCRIPTION
Towards INT-7977.

## Overview

This PR tightens recursion proof-shape ordering. `ProofShapeAir` already required rows to be sorted by non-increasing trace height; it now also requires deterministic AIR-index ordering among rows with equal effective height.

The enforced order is lexicographic by:

```text
(-rank, air_idx)
```

where:

```text
rank = log_height + is_present
```

This gives absent AIRs rank `0`, present height-1 AIRs rank `1`, present height-2 AIRs rank `2`, etc. Equal-height/equal-rank rows must appear with strictly increasing `air_idx`.

Base used for this summary: `origin/develop-v2.0.0-rc.2`.

## Recursion: `ProofShapeAir`

Files:

- `crates/recursion/src/proof_shape/proof_shape/air.rs`
- `crates/recursion/src/proof_shape/proof_shape/trace.rs`
- `crates/recursion/cuda/src/proof_shape/air.cu`
- `crates/recursion/src/proof_shape/mod.rs`

### New Column

`ProofShapeCols` adds:

```rust
pub is_height_equal_to_next: F
```

This is a boolean selector for valid non-summary transitions:

- `1`: current row and next row have equal effective height; enforce `air_idx < next_air_idx`.
- `0`: current row must have strictly larger effective height rank than the next row.

Example row patterns:

| Row kind | `is_present` | `log_height` | `height` | `rank` | next row | `is_height_equal_to_next` |
| --- | ---: | ---: | ---: | ---: | --- | ---: |
| present height 8 | 1 | 3 | 8 | 4 | present height 8, larger `air_idx` | 1 |
| present height 8 | 1 | 3 | 8 | 4 | present height 4 | 0 |
| present height 1 | 1 | 0 | 1 | 1 | absent | 0 |
| absent | 0 | 0 | 0 | 0 | absent, larger `air_idx` | 1 |
| last row before summary | varies | varies | varies | varies | summary row | 0 |

### Ordering Constraints

The AIR now borrows the next row's variable columns to decode `next_air_idx`.

For each valid transition where `next` is not the summary row:

1. `is_height_equal_to_next` is boolean.
2. If `is_height_equal_to_next = 1`:
   - constrain `local.height == next.height`;
   - range-check `next_air_idx - air_idx - 1` as 8 bits.
3. If `is_height_equal_to_next = 0`:
   - range-check `local_rank - next_rank - 1` as 5 bits.

This preserves the existing height sort while ruling out ambiguous ordering among equal-height rows.

### Range-Check Bus Flow

The change adds/changes `RangeCheckerBus` lookups from `ProofShapeAir`:

```text
ProofShapeAir
  |-- equal-height transition:
  |     lookup RangeCheckerBus(value = next_air_idx - air_idx - 1, max_bits = 8)
  |        balanced by ProofShapeModule RangeCheckerAir<8>
  |
  |-- strict-height transition:
        lookup RangeCheckerBus(value = local_rank - next_rank - 1, max_bits = 5)
           balanced by global PowerCheckerAir<2, 32> range side
```

`ProofShapeModule::airs` now asserts `per_air.len() <= 2^8`, matching the 8-bit AIR-index gap check.

### Trace Generation

CPU and CUDA tracegen now populate `is_height_equal_to_next` and add the corresponding range-check counts:

- equal effective height: add the AIR-index gap count;
- strict effective-height drop: add the rank-drop count;
- summary transition: set the selector to `0`.

The CUDA proof-shape column layout is updated to include the new column, keeping GPU tracegen aligned with the Rust AIR layout.

## CI

File:

- `.github/workflows/sdk.cuda.yml`

The CUDA SDK workflow trigger now includes:

```text
crates/continuations/**
crates/recursion/**
```

This makes recursion/continuations changes run the CUDA SDK workflow instead of only SDK-path changes.

## Suggested Review Order

1. Review `ProofShapeAir` ordering semantics and the `rank` definition.
2. Check CPU tracegen counts against the two AIR branches.
3. Check CUDA struct layout and CUDA tracegen counts mirror CPU tracegen.
4. Confirm the `per_air.len() <= 2^8` assumption is acceptable for recursion proof shapes.
5. Review the workflow path trigger addition.
