### PR TITLE
chore: change kitchen-sink benchmark instance type

### DIFF
--- a/ci/benchmark-config.json
+++ b/ci/benchmark-config.json
@@ -79,7 +79,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6e.2xlarge",
+          "instance_type": "g6.2xlarge",
           "memory_allocator": "jemalloc",
           "max_segment_length": 4194304
         }


### PR DESCRIPTION
Prover is much faster now, not really a need kitchen-sink to be on a `g6e` machine