### PR TITLE
fix(docs): fix non-compiling fallback branches in keccak, sha256, and bigint examples

### DIFF
--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/big-integer.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/big-integer.mdx
@@ -51,7 +51,7 @@ fn wrapping_add(a: &CustomU256, b: &CustomU256) -> CustomU256 {
         unsafe { result.assume_init() }
     }
     #[cfg(not(target_os = "zkvm"))] {
-        // Regular wrapping add implementation
+        unimplemented!("native bigint ops are only available on zkvm target")
     }
 }
 ```

--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/keccak.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/keccak.mdx
@@ -26,7 +26,7 @@ fn keccak256(input: &[u8]) -> [u8; 32] {
         output
     }
     #[cfg(not(target_os = "zkvm"))] {
-        // Regular Keccak-256 implementation
+        unimplemented!("native keccak256 is only available on zkvm target")
     }
 }
 ```

--- a/docs/vocs/docs/pages/book/acceleration-using-extensions/sha-2.mdx
+++ b/docs/vocs/docs/pages/book/acceleration-using-extensions/sha-2.mdx
@@ -45,7 +45,7 @@ fn sha256(input: &[u8]) -> [u8; 32] {
         digest
     }
     #[cfg(not(target_os = "zkvm"))] {
-        // Regular SHA-256 implementation
+        unimplemented!("native sha256 is only available on zkvm target")
     }
 }
 ```


### PR DESCRIPTION
## Problem

The `#[cfg(not(target_os = "zkvm"))]` fallback branches in three extension examples contain only placeholder comments instead of `unimplemented!()`, causing a compile error on non-zkvm targets.

## Changes

keccak.mdx:
`// Regular Keccak-256 implementation` → `unimplemented!("native keccak256 is only available on zkvm target")`

sha-256.mdx:
`// Regular SHA-256 implementation` → `unimplemented!("native sha256 is only available on zkvm target")`

big-integer.mdx:
`// Regular wrapping add implementation` → `unimplemented!("native bigint ops are only available on zkvm target")`

## Test plan

Documentation-only change; no library code paths affected.

Fixes #2830