### PR TITLE
fix(docs): correct Cargo.toml dependencies for I256 example in ruint.mdx

### DIFF
--- a/docs/vocs/docs/pages/book/guest-libraries/ruint.mdx
+++ b/docs/vocs/docs/pages/book/guest-libraries/ruint.mdx
@@ -27,7 +27,8 @@ See the full example [here](https://github.com/openvm-org/openvm/blob/main/examp
 To be able to import the `I256` struct, add the following to your `Cargo.toml` file:
 
 ```toml
-openvm-ruint = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.6.0", package = "ruint" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", features = ["std"] }
+alloy-primitives = "1.1.2"
 ```
 
 ### Config parameters


### PR DESCRIPTION
fix(docs): correct Cargo.toml dependencies for I256 example in ruint.mdx

## Problem
The `ruint.mdx` documentation instructs users to add `openvm-ruint` to import `I256`, but the actual example uses `alloy_primitives::I256` which comes from `alloy-primitives`, not `openvm-ruint`. Following the current documentation results in a compile error.

## Changes
`docs/vocs/docs/pages/book/guest-libraries/ruint.mdx`:
replace incorrect `Cargo.toml` snippet for the I256 section

## Before / After

**Before:**
```toml
openvm-ruint = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.6.0", package = "ruint" }
```

**After:**
```toml
openvm = { git = "https://github.com/openvm-org/openvm.git", features = ["std"] }
alloy-primitives = "1.1.2"
```

## Test plan
Documentation-only change; no library code paths affected.
Verified against `examples/i256/Cargo.toml`.