### PR TITLE
fix: SDK verify_app_proof checks number of user pvs

### DIFF
--- a/benchmarks/prove/src/bin/keccak_par.rs
+++ b/benchmarks/prove/src/bin/keccak_par.rs
@@ -41,7 +41,6 @@ fn main() -> eyre::Result<()> {
     stdin.write(&num_keccak_iters);
 
     let exe = VmExe::from_elf(elf, vm_config.transpiler())?;
-    let memory_dims = vm_config.system.config.memory_config.memory_dimensions();
     let app_config = AppConfig::new(vm_config, default_bench_app_params());
     let main_sdk = Sdk::new(app_config.clone(), Default::default())?;
     let (app_pk, app_vk) = main_sdk.app_keygen();
@@ -63,7 +62,12 @@ fn main() -> eyre::Result<()> {
                     .build()?;
                 let mut prover = sdk.app_prover(exe)?;
                 let proof = prover.prove(stdin)?;
-                let _ = verify_app_proof::<DefaultStarkEngine>(&app_vk.vk, memory_dims, &proof)?;
+                let _ = verify_app_proof::<DefaultStarkEngine>(
+                    &app_vk.vk,
+                    app_vk.memory_dimensions,
+                    app_vk.num_user_pvs,
+                    &proof,
+                )?;
                 Ok(proof)
             });
             handles.push(handle);

--- a/benchmarks/prove/src/bin/keccak_par.rs
+++ b/benchmarks/prove/src/bin/keccak_par.rs
@@ -62,12 +62,7 @@ fn main() -> eyre::Result<()> {
                     .build()?;
                 let mut prover = sdk.app_prover(exe)?;
                 let proof = prover.prove(stdin)?;
-                let _ = verify_app_proof::<DefaultStarkEngine>(
-                    &app_vk.vk,
-                    app_vk.memory_dimensions,
-                    app_vk.num_user_pvs,
-                    &proof,
-                )?;
+                let _ = verify_app_proof::<DefaultStarkEngine>(&app_vk, &proof)?;
                 Ok(proof)
             });
             handles.push(handle);

--- a/benchmarks/prove/src/lib.rs
+++ b/benchmarks/prove/src/lib.rs
@@ -132,13 +132,17 @@ pub fn run_app_benchmark(
 ) -> eyre::Result<()> {
     run_with_metric_collection("OUTPUT_PATH", || -> eyre::Result<_> {
         let exe = VmExe::from_elf(elf, vm_config.transpiler())?;
-        let memory_dims = vm_config.system.config.memory_config.memory_dimensions();
         let app_config = AppConfig::new(vm_config, app_params);
         let sdk = Sdk::new(app_config, Default::default())?;
         let (_, app_vk) = sdk.app_keygen();
         let mut prover = sdk.app_prover(exe)?;
         let proof = prover.prove(stdin)?;
-        let _ = verify_app_proof::<DefaultStarkEngine>(&app_vk.vk, memory_dims, &proof)?;
+        let _ = verify_app_proof::<DefaultStarkEngine>(
+            &app_vk.vk,
+            app_vk.memory_dimensions,
+            app_vk.num_user_pvs,
+            &proof,
+        )?;
         Ok(())
     })
 }

--- a/benchmarks/prove/src/lib.rs
+++ b/benchmarks/prove/src/lib.rs
@@ -137,12 +137,7 @@ pub fn run_app_benchmark(
         let (_, app_vk) = sdk.app_keygen();
         let mut prover = sdk.app_prover(exe)?;
         let proof = prover.prove(stdin)?;
-        let _ = verify_app_proof::<DefaultStarkEngine>(
-            &app_vk.vk,
-            app_vk.memory_dimensions,
-            app_vk.num_user_pvs,
-            &proof,
-        )?;
+        let _ = verify_app_proof::<DefaultStarkEngine>(&app_vk, &proof)?;
         Ok(())
     })
 }

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -149,6 +149,7 @@ impl VerifyCmd {
                 let _exe_commit = verify_app_proof::<openvm_sdk::DefaultStarkEngine>(
                     &app_vk.vk,
                     app_vk.memory_dimensions,
+                    app_vk.num_user_pvs,
                     &app_proof,
                 )?;
             }

--- a/crates/cli/src/commands/verify.rs
+++ b/crates/cli/src/commands/verify.rs
@@ -146,12 +146,8 @@ impl VerifyCmd {
                 let proof_path = resolve_proof_path(proof, APP_PROOF_EXT)?;
                 println!("Verifying application proof at {}", proof_path.display());
                 let app_proof = read_object_from_file(proof_path)?;
-                let _exe_commit = verify_app_proof::<openvm_sdk::DefaultStarkEngine>(
-                    &app_vk.vk,
-                    app_vk.memory_dimensions,
-                    app_vk.num_user_pvs,
-                    &app_proof,
-                )?;
+                let _exe_commit =
+                    verify_app_proof::<openvm_sdk::DefaultStarkEngine>(&app_vk, &app_proof)?;
             }
             VerifySubCommand::Stark {
                 app_baseline,

--- a/crates/sdk/examples/sdk_app.rs
+++ b/crates/sdk/examples/sdk_app.rs
@@ -41,6 +41,7 @@ fn main() -> eyre::Result<()> {
     let _ = verify_app_proof::<openvm_sdk::DefaultStarkEngine>(
         &app_vk.vk,
         app_vk.memory_dimensions,
+        app_vk.num_user_pvs,
         &proof,
     )?;
     // [!endregion verification]

--- a/crates/sdk/examples/sdk_app.rs
+++ b/crates/sdk/examples/sdk_app.rs
@@ -38,12 +38,7 @@ fn main() -> eyre::Result<()> {
     // 6. Do this once to save the app_vk, independent of the proof.
     let (_app_pk, app_vk) = sdk.app_keygen();
     // 7. Verify your program.
-    let _ = verify_app_proof::<openvm_sdk::DefaultStarkEngine>(
-        &app_vk.vk,
-        app_vk.memory_dimensions,
-        app_vk.num_user_pvs,
-        &proof,
-    )?;
+    let _ = verify_app_proof::<openvm_sdk::DefaultStarkEngine>(&app_vk, &proof)?;
     // [!endregion verification]
 
     Ok(())

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -31,6 +31,7 @@ pub struct AppProvingKey<VC> {
 pub struct AppVerifyingKey {
     pub vk: MultiStarkVerifyingKey<SC>,
     pub memory_dimensions: MemoryDimensions,
+    pub num_user_pvs: usize,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -84,14 +85,11 @@ where
     }
 
     pub fn get_app_vk(&self) -> AppVerifyingKey {
+        let system_config = self.app_vm_pk.vm_config.as_ref();
         AppVerifyingKey {
             vk: self.app_vm_pk.vm_pk.get_vk(),
-            memory_dimensions: self
-                .app_vm_pk
-                .vm_config
-                .as_ref()
-                .memory_config
-                .memory_dimensions(),
+            memory_dimensions: system_config.memory_config.memory_dimensions(),
+            num_user_pvs: system_config.num_public_values,
         }
     }
 

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -21,6 +21,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::Digest;
 use tracing::instrument;
 
 use crate::{
+    keygen::AppVerifyingKey,
     prover::vm::{new_local_prover, types::VmProvingKey},
     util::check_max_constraint_degrees,
     SdkError, StdIn, F, SC,
@@ -133,7 +134,7 @@ where
         );
         let proof = ContinuationVmProver::prove(&mut self.instance, input)?;
         #[cfg(debug_assertions)]
-        let _ = verify_app_proof::<E>(
+        let _ = verify_app_proof_inner::<E>(
             &self.app_vm_vk,
             self.memory_dimensions(),
             self.num_user_pvs(),
@@ -161,6 +162,20 @@ where
 
 /// Verifies a ContinuationVmProof and returns the app_exe_commit
 pub fn verify_app_proof<E: StarkEngine<SC = SC>>(
+    app_vk: &AppVerifyingKey,
+    proof: &ContinuationVmProof<E::SC>,
+) -> Result<Digest, SdkError> {
+    verify_app_proof_inner::<E>(
+        &app_vk.vk,
+        app_vk.memory_dimensions,
+        app_vk.num_user_pvs,
+        proof,
+    )
+}
+
+/// Verifies a ContinuationVmProof from the borrowed components of an
+/// [`AppVerifyingKey`], returning the app_exe_commit.
+fn verify_app_proof_inner<E: StarkEngine<SC = SC>>(
     vk: &MultiStarkVerifyingKey<SC>,
     memory_dimensions: MemoryDimensions,
     num_user_pvs: usize,

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 use crate::{
     prover::vm::{new_local_prover, types::VmProvingKey},
     util::check_max_constraint_degrees,
-    StdIn, F, SC,
+    SdkError, StdIn, F, SC,
 };
 
 #[derive(Getters)]
@@ -133,8 +133,13 @@ where
         );
         let proof = ContinuationVmProver::prove(&mut self.instance, input)?;
         #[cfg(debug_assertions)]
-        let _ = verify_app_proof::<E>(&self.app_vm_vk, self.memory_dimensions(), &proof)
-            .expect("app proof verification failed");
+        let _ = verify_app_proof::<E>(
+            &self.app_vm_vk,
+            self.memory_dimensions(),
+            self.num_user_pvs(),
+            &proof,
+        )
+        .expect("app proof verification failed");
         Ok(proof)
     }
 
@@ -158,8 +163,9 @@ where
 pub fn verify_app_proof<E: StarkEngine<SC = SC>>(
     vk: &MultiStarkVerifyingKey<SC>,
     memory_dimensions: MemoryDimensions,
+    num_user_pvs: usize,
     proof: &ContinuationVmProof<E::SC>,
-) -> Result<Digest, VmVerificationError<SC>> {
+) -> Result<Digest, SdkError> {
     static POSEIDON2_HASHER: OnceLock<Poseidon2Hasher<F>> = OnceLock::new();
     let engine = E::new(vk.inner.params.clone());
     let VerifiedExecutionPayload {
@@ -167,11 +173,22 @@ pub fn verify_app_proof<E: StarkEngine<SC = SC>>(
         final_memory_root,
     } = verify_segments(&engine, vk, &proof.per_segment)?;
 
-    proof.user_public_values.verify(
-        POSEIDON2_HASHER.get_or_init(vm_poseidon2_hasher),
-        memory_dimensions,
-        final_memory_root,
-    )?;
+    if proof.user_public_values.public_values.len() != num_user_pvs {
+        return Err(SdkError::Other(eyre::eyre!(
+            "wrong number of user public values (expected: {}, actual: {})",
+            num_user_pvs,
+            proof.user_public_values.public_values.len()
+        )));
+    }
+
+    proof
+        .user_public_values
+        .verify(
+            POSEIDON2_HASHER.get_or_init(vm_poseidon2_hasher),
+            memory_dimensions,
+            final_memory_root,
+        )
+        .map_err(VmVerificationError::from)?;
 
     Ok(exe_commit)
 }


### PR DESCRIPTION
Resolves INT-8046.

## Overview

This branch makes SDK app proof verification reject proofs with the wrong number of user public values.

`verify_app_proof` now takes `num_user_pvs` and checks it against `proof.user_public_values.public_values.len()` before verifying the user-PVS commitment. This prevents callers from verifying against only memory dimensions while silently accepting a proof with an unexpected user-PVS shape.

## SDK Changes

Files:

- `crates/sdk/src/prover/app.rs`
- `crates/sdk/src/keygen/mod.rs`

`AppVerifyingKey` now stores `num_user_pvs`, derived from `SystemConfig::num_public_values` during keygen.

`verify_app_proof` now:

- accepts `num_user_pvs`,
- returns `SdkError`,
- fails with a clear error if the proof has the wrong number of user public values,
- continues to verify segments and the user-PVS commitment as before.

## Call Sites

Files:

- `crates/cli/src/commands/verify.rs`
- `crates/sdk/examples/sdk_app.rs`
- `benchmarks/prove/src/lib.rs`
- `benchmarks/prove/src/bin/keccak_par.rs`

Callers now pass `app_vk.num_user_pvs` into `verify_app_proof`. The benchmark paths also use `app_vk.memory_dimensions` instead of recomputing memory dimensions from the VM config.