### PR TITLE
chore: better hygiene in user public values commit AIRs

### DIFF
--- a/crates/continuations/src/circuit/root/commit/air.rs
+++ b/crates/continuations/src/circuit/root/commit/air.rs
@@ -42,9 +42,9 @@ impl UserPvsCommitAir {
     ) -> Self {
         // Each leaf consumes `DIGEST_SIZE` public values, which are compressed with zeros
         // to compute the leaf hash. We require at least one leaf, and a full binary tree.
-        debug_assert!(num_user_pvs >= DIGEST_SIZE);
-        debug_assert!(num_user_pvs.is_multiple_of(DIGEST_SIZE));
-        debug_assert!((num_user_pvs / DIGEST_SIZE).is_power_of_two());
+        assert!(num_user_pvs >= DIGEST_SIZE);
+        assert!(num_user_pvs.is_multiple_of(DIGEST_SIZE));
+        assert!((num_user_pvs / DIGEST_SIZE).is_power_of_two());
         let encoder = Encoder::new(num_user_pvs / DIGEST_SIZE, MAX_ENCODER_DEGREE, true);
 
         UserPvsCommitAir {

--- a/guest-libs/verify-stark/circuit/src/commit/air.rs
+++ b/guest-libs/verify-stark/circuit/src/commit/air.rs
@@ -79,11 +79,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             main.row_slice(1).expect("window should have two elements"),
         );
 
-        let const_width = MerkleTreeCols::<u8>::width();
-        let row_idx_flags = &(*local)[const_width..];
-
-        let local: &MerkleTreeCols<AB::Var> = (*local)[..const_width].borrow();
-        let next: &MerkleTreeCols<AB::Var> = (*next)[..const_width].borrow();
+        let local: &MerkleTreeCols<AB::Var> = (*local).borrow();
+        let next: &MerkleTreeCols<AB::Var> = (*next).borrow();
 
         let num_rows = AB::F::from_usize(2 * self.num_user_pvs / DIGEST_SIZE);
         self.subair.eval(builder, (local, next, num_rows.into()));
@@ -100,8 +97,6 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         const OUTPUT_USER_PVS_START_IDX: usize = (2 * DIGEST_SIZE) / VALS_IN_DIGEST;
         const OUTPUT_VAL_MSGS_PER_ROW: usize = DIGEST_SIZE / VALS_IN_DIGEST;
-
-        debug_assert_eq!(row_idx_flags.len(), 0);
 
         for (i, output_values) in local.left_child.chunks_exact(VALS_IN_DIGEST).enumerate() {
             self.output_val_bus.send(

--- a/guest-libs/verify-stark/circuit/src/commit/air.rs
+++ b/guest-libs/verify-stark/circuit/src/commit/air.rs
@@ -44,9 +44,9 @@ impl UserPvsCommitValuesAir {
     ) -> Self {
         // Each leaf consumes `DIGEST_SIZE` public values, which are compressed with zeros
         // to compute the leaf hash. We require at least one leaf, and a full binary tree.
-        debug_assert!(num_user_pvs >= DIGEST_SIZE);
-        debug_assert!(num_user_pvs.is_multiple_of(DIGEST_SIZE));
-        debug_assert!((num_user_pvs / DIGEST_SIZE).is_power_of_two());
+        assert!(num_user_pvs >= DIGEST_SIZE);
+        assert!(num_user_pvs.is_multiple_of(DIGEST_SIZE));
+        assert!((num_user_pvs / DIGEST_SIZE).is_power_of_two());
 
         UserPvsCommitValuesAir {
             subair: MerkleTreeSubAir::new(


### PR DESCRIPTION
Resolves INT-8072.

## Overview

This branch tightens setup for user public value Merkle-commit AIRs.

Both `UserPvsCommitAir::new` and `UserPvsCommitValuesAir::new` now enforce their `num_user_pvs` shape assumptions with `assert!` instead of `debug_assert!`:

- at least one digest of user public values,
- digest-aligned length,
- power-of-two number of digest leaves.

These are constructor checks, not new AIR constraints.

## AIR Notes

Files:

- `crates/continuations/src/circuit/root/commit/air.rs`
- `guest-libs/verify-stark/circuit/src/commit/air.rs`

`UserPvsCommitAir` is otherwise unchanged: it still uses encoder flags to bind digest-sized public-value chunks to leaf rows and commits them through `MerkleTreeSubAir`.

`UserPvsCommitValuesAir` no longer creates an always-empty `row_idx_flags` slice. Its row width is exactly `MerkleTreeCols::width()`, so the old slice and `debug_assert_eq!(row_idx_flags.len(), 0)` were dead code.

No AIR columns changed.