### PR TITLE
fix: prevent DeferralAggregationPvs values from overflowing

### DIFF
--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -11,6 +11,7 @@ use openvm_recursion_circuit::{
         Poseidon2CompressBus, Poseidon2CompressMessage, PublicValuesBus, PublicValuesBusMessage,
     },
     prelude::DIGEST_SIZE,
+    primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
@@ -51,6 +52,7 @@ pub struct DeferralAggPvsCols<F> {
 pub struct DeferralAggPvsAir {
     pub public_values_bus: PublicValuesBus,
     pub poseidon2_bus: Poseidon2CompressBus,
+    pub range_bus: RangeCheckerBus,
     pub input_or_merkle_commit_bus: InputOrMerkleCommitBus,
     pub def_pvs_consistency_bus: DefPvsConsistencyBus,
 
@@ -66,6 +68,7 @@ impl DeferralAggPvsAir {
     pub fn new(
         public_values_bus: PublicValuesBus,
         poseidon2_bus: Poseidon2CompressBus,
+        range_bus: RangeCheckerBus,
         input_or_merkle_commit_bus: InputOrMerkleCommitBus,
         def_pvs_consistency_bus: DefPvsConsistencyBus,
     ) -> Self {
@@ -74,6 +77,7 @@ impl DeferralAggPvsAir {
         Self {
             public_values_bus,
             poseidon2_bus,
+            range_bus,
             input_or_merkle_commit_bus,
             def_pvs_consistency_bus,
             encoder,
@@ -248,7 +252,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let local_merkle_depth = is_internal * local_merkle_depth;
         let next_merkle_depth = is_internal * next.child_pvs.input_commit[1];
 
-        let mut when_one_row = builder.when(is_first * not(next.proof_idx));
+        let mut when_one_row = builder.when(is_first.clone() * not(next.proof_idx));
         when_one_row.assert_eq(local_num_proofs.clone(), num_def_circuit_proofs);
         when_one_row.assert_eq(local_merkle_depth.clone(), merkle_depth);
         assert_array_eq(&mut when_one_row, local.merkle_commit, merkle_commit);
@@ -263,6 +267,22 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .when_transition()
             .when(next.is_present)
             .assert_eq(local_merkle_depth, next_merkle_depth);
+
+        /*
+         * MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth is range checked to be in [0, 256). This,
+         * combined with the constraints above that require at least one valid child proof
+         * with merkle_depth - 1 for any merkle_depth > 0, ensures that merkle_depth does not
+         * overflow F. Inductively num_def_circuit_proofs is bounded by 2^merkle_depth, so it
+         * also cannot wrap in F.
+         */
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: AB::Expr::from_usize(MAX_DEF_AGG_MERKLE_DEPTH) - merkle_depth.into(),
+                max_bits: AB::Expr::from_u8(8),
+            },
+            is_first,
+        );
 
         /*
          * If there are two rows, then the second (next) is either present or not. If present

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
@@ -10,22 +10,28 @@ use openvm_stark_backend::{proof::Proof, prover::AirProvingContext};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     poseidon2_compress_with_capacity, BabyBearPoseidon2Config, F,
 };
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
     circuit::deferral::{
         inner::def_pvs::air::{DeferralAggPvsAir, DeferralAggPvsCols},
         DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
+        MAX_DEF_AGG_MERKLE_DEPTH,
     },
     utils::zero_hash,
 };
+
+pub struct DeferralAggPvsTraceCtx {
+    pub proving_ctx: AirProvingContext<CpuBackend<BabyBearPoseidon2Config>>,
+    pub range_check_inputs: Vec<usize>,
+}
 
 pub fn generate_proving_ctx(
     proofs: &[Proof<BabyBearPoseidon2Config>],
     child_is_agg: bool,
     child_merkle_depth: Option<usize>,
-) -> AirProvingContext<CpuBackend<BabyBearPoseidon2Config>> {
+) -> DeferralAggPvsTraceCtx {
     let num_proofs = proofs.len();
     let is_wrapper = child_merkle_depth.is_none();
     debug_assert!(!is_wrapper || num_proofs == 1);
@@ -116,9 +122,17 @@ pub fn generate_proving_ctx(
     }
     pvs.num_def_circuit_proofs = num_def_circuit_proofs;
 
-    AirProvingContext {
-        cached_mains: vec![],
-        common_main: RowMajorMatrix::new(trace, width),
-        public_values,
+    let merkle_depth = pvs.merkle_depth.as_canonical_u32() as usize;
+    let max_depth_minus_merkle_depth = MAX_DEF_AGG_MERKLE_DEPTH
+        .checked_sub(merkle_depth)
+        .expect("deferral aggregation merkle depth exceeds max depth");
+
+    DeferralAggPvsTraceCtx {
+        proving_ctx: AirProvingContext {
+            cached_mains: vec![],
+            common_main: RowMajorMatrix::new(trace, width),
+            public_values,
+        },
+        range_check_inputs: vec![max_depth_minus_merkle_depth],
     }
 }

--- a/crates/continuations/src/circuit/deferral/inner/mod.rs
+++ b/crates/continuations/src/circuit/deferral/inner/mod.rs
@@ -38,6 +38,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
         let def_pvs_air = def_pvs::DeferralAggPvsAir::new(
             bus_inventory.public_values_bus,
             bus_inventory.poseidon2_compress_bus,
+            bus_inventory.range_checker_bus,
             input_or_merkle_commit_bus,
             def_pvs_consistency_bus,
         );

--- a/crates/continuations/src/circuit/deferral/inner/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/trace.rs
@@ -32,6 +32,7 @@ pub struct DeferralInnerPreCtx<PB: ProverBackend> {
     pub input_ctx: AirProvingContext<PB>,
     pub poseidon2_compress_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
     pub poseidon2_permute_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
+    pub range_check_inputs: Vec<usize>,
 }
 
 fn fold_leaf_input_commit(
@@ -141,20 +142,22 @@ impl DeferralInnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for Deferral
     ) -> DeferralInnerPreCtx<CpuBackend<BabyBearPoseidon2Config>> {
         let (poseidon2_compress_inputs, poseidon2_permute_inputs) =
             generate_poseidon2_inputs(proofs, child_is_agg, child_merkle_depth);
+        let super::def_pvs::DeferralAggPvsTraceCtx {
+            proving_ctx: def_pvs_ctx,
+            range_check_inputs,
+        } = super::def_pvs::generate_proving_ctx(proofs, child_is_agg, child_merkle_depth);
+
         DeferralInnerPreCtx {
             verifier_pvs_ctx: super::verifier::generate_proving_ctx(
                 proofs,
                 child_is_agg,
                 child_vk_commit,
             ),
-            def_pvs_ctx: super::def_pvs::generate_proving_ctx(
-                proofs,
-                child_is_agg,
-                child_merkle_depth,
-            ),
+            def_pvs_ctx,
             input_ctx: super::input::generate_proving_ctx(proofs, child_is_agg),
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
         }
     }
 }
@@ -179,6 +182,7 @@ impl DeferralInnerTraceGen<GpuBackend, GpuDeviceCtx> for DeferralInnerTraceGenIm
             input_ctx,
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
         } = <Self as DeferralInnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()>>::pre_verifier_subcircuit_tracegen(
             self,
             proofs,
@@ -193,6 +197,7 @@ impl DeferralInnerTraceGen<GpuBackend, GpuDeviceCtx> for DeferralInnerTraceGenIm
             input_ctx: cpu_proving_ctx_to_gpu(input_ctx, device_ctx),
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
         }
     }
 }

--- a/crates/continuations/src/prover/deferral/inner/trace.rs
+++ b/crates/continuations/src/prover/deferral/inner/trace.rs
@@ -68,6 +68,7 @@ where
             input_ctx,
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
         } = self.agg_node_tracegen.pre_verifier_subcircuit_tracegen(
             proofs,
             child_is_agg,
@@ -76,7 +77,6 @@ where
             device_ctx,
         );
 
-        let range_check_inputs = vec![];
         let power_check_inputs = vec![];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &poseidon2_compress_inputs,


### PR DESCRIPTION
Resolves INT-8053.

## Overview

This branch prevents `DeferralAggregationPvs::{merkle_depth, num_def_circuit_proofs}` from being accepted only modulo the BabyBear field in the deferral inner aggregation circuit.

The main change is a new 8-bit range-check lookup in `DeferralAggPvsAir` on:

```text
MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth
```

Together with the existing recursive depth constraints, this bounds the canonical aggregation Merkle depth by `MAX_DEF_AGG_MERKLE_DEPTH`. Since the number of deferral circuit proofs is inductively bounded by `2^merkle_depth`, this also prevents `num_def_circuit_proofs` from wrapping in `F`.

Base branch: `fix/canonical-deferral-agg-padding`

Commit in this branch:

- `fix: prevent DeferralAggregationPvs values from overflowing`

## `crates/continuations`: Deferral Inner Aggregation PVS AIR

Files:

- `crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs`
- `crates/continuations/src/circuit/deferral/inner/mod.rs`

### What Changed

`DeferralAggPvsAir` now depends on the shared recursion `RangeCheckerBus`.

On the first row of the AIR, it performs a lookup:

```text
value = MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth
max_bits = 8
```

This records that `MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth` is in `[0, 256)`.

### Constraint Intent

Before this branch, the aggregation public values were related by field equalities:

```text
parent_num_def_circuit_proofs = left_num_proofs + right_num_proofs
parent_merkle_depth = child_merkle_depth + 1
```

Those equalities are over `F`, so a maliciously shaped recursive aggregation could satisfy them with wrapped field values. For example, a child depth of `p - 1` would produce parent depth `0` modulo `p`.

The new range check rules out this wraparound in valid finite recursive aggregation proofs. The proof tree still relies on the existing child-depth recurrence:

- wrapper proofs copy the child depth,
- non-wrapper aggregation proofs set parent depth to child depth plus one,
- present sibling aggregation proofs must have equal child depths,
- one-child padded aggregation proofs use the existing depth encoder to select the padding hash depth.

### AIR Columns

No trace columns were added or removed. The change is a new bus interaction, not a column-layout change.

Existing row shapes are unchanged:

| Case | Rows | `local.is_present` | `next.is_present` | `has_verifier_pvs` | Public `merkle_depth` behavior | New range lookup |
| --- | ---: | ---: | ---: | ---: | --- | --- |
| Wrapper | 1 | `1` | N/A | leaf or aggregation child | Copies child depth | `MAX - copied_depth` on first row |
| Two present children | 2 | `1` | `1` | leaf or aggregation children | `child_depth + 1`; aggregation siblings have equal child depth | `MAX - parent_depth` on first row |
| One child plus padding | 2 | `1` | `0` | leaf or aggregation child | `child_depth + 1`; padding zero hash selected by existing depth encoder | `MAX - parent_depth` on first row |

## `crates/continuations`: Tracegen Plumbing

Files:

- `crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs`
- `crates/continuations/src/circuit/deferral/inner/trace.rs`
- `crates/continuations/src/prover/deferral/inner/trace.rs`

### What Changed

`def_pvs::generate_proving_ctx` now returns:

```rust
DeferralAggPvsTraceCtx {
    proving_ctx,
    range_check_inputs,
}
```

The range-check input is computed from the same `DeferralAggregationPvs` public values generated for the AIR:

```text
MAX_DEF_AGG_MERKLE_DEPTH - pvs.merkle_depth
```

The deferral inner pre-context carries these `range_check_inputs`, and the prover passes them through `VerifierExternalData` to the recursive verifier subcircuit’s existing 8-bit range checker.