### PR TITLE
perf: gpu memory optimization by omitting the bottom rows of the merkle tree

### DIFF
--- a/crates/vm/cuda/include/system/memory/params.cuh
+++ b/crates/vm/cuda/include/system/memory/params.cuh
@@ -60,6 +60,9 @@ inline constexpr size_t BLOCK_FE_WIDTH = MEMORY_BLOCK_BYTES / U16_CELL_SIZE;
 // Blocks per merkle leaf.
 inline constexpr size_t BLOCKS_PER_LEAF = DIGEST_WIDTH / BLOCK_FE_WIDTH;
 
+// Number of bottom merkle levels omitted from large GPU subtree buffers.
+inline constexpr size_t OMITTED_BOTTOM_LEVELS = 3;
+
 // Address space ID for the F-celled deferral AS. Matches
 // `openvm_instructions::DEFERRAL_AS`.
 inline constexpr uint32_t DEFERRAL_AS = 4;

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -326,7 +326,6 @@ __device__ __forceinline__ bool virtual_node_exists(
 __device__ __forceinline__ size_t stored_node_index(
     uint32_t const subtree_height,
     uint32_t const actual_height,
-    uint8_t const layout,
     uint32_t const node_height,
     size_t const label
 ) {
@@ -359,7 +358,7 @@ __device__ void load_virtual_node(
         return;
     }
 
-    auto const idx = stored_node_index(subtree_height, actual_height, layout, node_height, label);
+    auto const idx = stored_node_index(subtree_height, actual_height, node_height, label);
     COPY_DIGEST(out, &subtree[idx]);
 }
 
@@ -375,7 +374,7 @@ __device__ void store_virtual_node(
     if (layout == OMIT_BOTTOM_LEVELS && node_height < OMITTED_BOTTOM_LEVELS) {
         return;
     }
-    auto const idx = stored_node_index(subtree_height, actual_height, layout, node_height, label);
+    auto const idx = stored_node_index(subtree_height, actual_height, node_height, label);
     COPY_DIGEST(&subtree[idx], value);
 }
 

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -15,6 +15,32 @@ struct alignas(32) digest_t {
 
 #define COPY_DIGEST(dst, src) memcpy(dst, src, sizeof(digest_t))
 
+enum MemoryMerkleSubTreeLayout : uint8_t {
+    FULL = 0,
+    OMIT_BOTTOM_LEVELS = 1,
+};
+
+__device__ __forceinline__ void hash_raw_memory_leaf(
+    uint8_t const *__restrict__ data,
+    uint32_t const addr_space_idx,
+    size_t const leaf_label,
+    digest_t *out
+) {
+    Fp cells[CELLS] = {0};
+#pragma unroll
+    for (size_t i = 0; i < DIGEST_WIDTH; ++i) {
+        if (addr_space_idx + 1 == DEFERRAL_AS) {
+            cells[i] = reinterpret_cast<Fp const *>(data)[DIGEST_WIDTH * leaf_label + i];
+        } else {
+            auto byte_off = U16_CELL_SIZE * (DIGEST_WIDTH * leaf_label + i);
+            cells[i] = Fp(u16_from_bytes_le(data + byte_off));
+        }
+    }
+
+    poseidon2_mix(cells);
+    COPY_DIGEST(out, cells);
+}
+
 // `ADDR_SPACE_IDX` is the address space minus `ADDR_SPACE_OFFSET` (which is 1)
 //
 // DEFERRAL_AS stores Fp cells directly.
@@ -23,21 +49,56 @@ template <int ADDR_SPACE_IDX>
 __global__ void merkle_tree_init(uint8_t *__restrict__ data, digest_t *__restrict__ out) {
     auto gid = blockDim.x * blockIdx.x + threadIdx.x;
 
-    Fp cells[CELLS] = {0};
-#pragma unroll
-    for (size_t i = 0; i < DIGEST_WIDTH; ++i) {
-        if constexpr (ADDR_SPACE_IDX + 1 == DEFERRAL_AS) {
-            cells[i] = reinterpret_cast<Fp *>(data)[DIGEST_WIDTH * gid + i];
-        } else {
-            // u16 cells, little-endian.
-            auto byte_off = U16_CELL_SIZE * (DIGEST_WIDTH * gid + i);
-            cells[i] = Fp(u16_from_bytes_le(data + byte_off));
-        }
+    digest_t digest;
+    hash_raw_memory_leaf(data, ADDR_SPACE_IDX, gid, &digest);
+
+    COPY_DIGEST(&out[gid], &digest);
+}
+
+__device__ void recompute_omitted_node(
+    uint8_t const *__restrict__ data,
+    uint32_t const addr_space_idx,
+    uint32_t const node_height,
+    // label is the index of the node within its level `node_height` (label 0 = leftmost). 
+    // the node roots a subtree of `2^node_height` leaves, 
+    // namely leaf labels `[label << node_height .. (label + 1) << node_height)`.
+    // i.e. those leaves get hashed to this node.
+    size_t const label,
+    digest_t *out
+) {
+    // layer is a fixed-size, thread-local scratch buffer of 2^OMITTED_BOTTOM_LEVELS 
+    // digests, used to rebuild an omitted subtree bottom-up.
+    digest_t layer[1 << OMITTED_BOTTOM_LEVELS];
+    // num_leaves denote the number of leaves of the subtree rooted at this node 
+    size_t const num_leaves = 1 << node_height;
+    // recall again that node_height is counted starting from the bottom
+    // that is, node_height = 0 for the leafs
+    size_t const first_leaf = label << node_height;
+
+    for (size_t i = 0; i < num_leaves; ++i) {
+        hash_raw_memory_leaf(data, addr_space_idx, first_leaf + i, &layer[i]);
     }
 
-    poseidon2_mix(cells);
+    // cells is a 2-to-1 compression buffer
+    Fp cells[CELLS];
+    for (size_t width = num_leaves / 2; width > 0; width /= 2) {
+        for (size_t i = 0; i < width; ++i) {
+            COPY_DIGEST(cells, &layer[2 * i]);
+            COPY_DIGEST(cells + CELLS_OUT, &layer[2 * i + 1]);
+            poseidon2_mix(cells);
+            COPY_DIGEST(&layer[i], cells);
+        }
+    }
+    COPY_DIGEST(out, &layer[0]);
+}
 
-    COPY_DIGEST(&out[gid], cells);
+__global__ void merkle_tree_init_omitted(
+    uint8_t *__restrict__ data,
+    digest_t *__restrict__ out,
+    uint32_t const addr_space_idx
+) {
+    auto gid = blockDim.x * blockIdx.x + threadIdx.x;
+    recompute_omitted_node(data, addr_space_idx, OMITTED_BOTTOM_LEVELS, gid, &out[gid]);
 }
 
 __global__ void merkle_tree_compress(
@@ -120,36 +181,6 @@ __global__ void merkle_tree_root(
 }
 
 // ================== Merkle tree update routine ==================
-
-__global__ void initial_subtrees_advance(
-    uintptr_t *d_subtrees,
-    size_t const *actual_subtree_heights,
-    size_t const num_subtrees,
-    size_t const subtree_height
-) {
-    auto gid = blockDim.x * blockIdx.x + threadIdx.x;
-    if (gid >= num_subtrees) {
-        return;
-    }
-    digest_t **subtrees = reinterpret_cast<digest_t **>(d_subtrees);
-    auto const h = actual_subtree_heights[gid];
-    subtrees[gid] += (1 << (h + 1)) - 1 + (subtree_height - h);
-}
-
-__global__ void adjust_subtrees_before_layer_update(
-    uintptr_t *d_subtrees,
-    size_t const *actual_subtree_heights,
-    size_t const num_subtrees,
-    size_t const h
-) {
-    auto gid = blockDim.x * blockIdx.x + threadIdx.x;
-    if (gid >= num_subtrees) {
-        return;
-    }
-    digest_t **subtrees = reinterpret_cast<digest_t **>(d_subtrees);
-    subtrees[gid] -=
-        h <= actual_subtree_heights[gid] ? 1 << (actual_subtree_heights[gid] - h + 1) : 1;
-}
 
 template <typename T> struct MerkleCols {
     T expand_direction;
@@ -265,27 +296,101 @@ __device__ void fill_merkle_trace_row(
     COL_WRITE_VALUE(row, MerkleCols, right_direction_different, right_new != new_values);
 }
 
-__device__ __forceinline__ digest_t const *layer_value_on_height(
-    digest_t const *subtree_layer,
-    digest_t const *zero_hash,
-    uint32_t const height,
-    uint32_t const layer_actual_height,
+// A "virtual node" is a node of the conceptual full subtree, addressed by
+// (node_height, label). It is "virtual" because depending on where it falls it
+// can map to one of four different physical representations:
+//   1. Non-existent: `label` lies beyond the touched layer (higher memory
+//      addresses that were never written). It is not stored at all; its value
+//      is the precomputed constant `zero_hash[node_height]`.
+//   2. Omitted bottom level: under the OMIT_BOTTOM_LEVELS layout, nodes with
+//      `node_height < OMITTED_BOTTOM_LEVELS` are not stored either; they are
+//      recomputed on demand from `initial_data`.
+//   3. On the vertical path (`node_height > actual_height`): a stored node
+//      above the touched subtree, indexed linearly by height.
+//   4. Inside the actual touched subtree (`node_height <= actual_height`): a
+//      stored node at the heap-style index for its (height, label).
+// virtual_node_exists / stored_node_index / load_virtual_node implement this
+// mapping; see stored_node_index for the exact stored indices of cases 3 and 4.
+__device__ __forceinline__ bool virtual_node_exists(
+    uint32_t const node_height,
+    // actual height denotes the height of the subtree excluding the vertical path length
+    // that is, the height of the subtree excluding the higher memory addresses
+    // which are never touched
+    uint32_t const actual_height, 
     size_t const label
 ) {
-    auto const layer_size =
-        1 << (height <= layer_actual_height ? (layer_actual_height - height) : 0);
-    return label < layer_size ? subtree_layer + label : zero_hash + height;
+    auto const layer_size = 1 << (node_height <= actual_height ? (actual_height - node_height) : 0);
+    return label < layer_size;
+}
+
+__device__ __forceinline__ size_t stored_node_index(
+    uint32_t const subtree_height,
+    uint32_t const actual_height,
+    uint8_t const layout,
+    uint32_t const node_height,
+    size_t const label
+) {
+    if (node_height > actual_height) {
+        return subtree_height - node_height;
+    }
+    auto const path_len = subtree_height - actual_height;
+    return path_len + ((1 << (actual_height - node_height)) - 1) + label;
+}
+
+__device__ void load_virtual_node(
+    digest_t const *subtree,
+    digest_t const *zero_hash,
+    uint8_t const layout,
+    uint8_t const *initial_data,
+    uint32_t const address_space_idx,
+    uint32_t const subtree_height,
+    uint32_t const actual_height,
+    uint32_t const node_height,
+    size_t const label,
+    digest_t *out
+) {
+    if (!virtual_node_exists(node_height, actual_height, label)) {
+        COPY_DIGEST(out, &zero_hash[node_height]);
+        return;
+    }
+
+    if (layout == OMIT_BOTTOM_LEVELS && node_height < OMITTED_BOTTOM_LEVELS) {
+        recompute_omitted_node(initial_data, address_space_idx, node_height, label, out);
+        return;
+    }
+
+    auto const idx = stored_node_index(subtree_height, actual_height, layout, node_height, label);
+    COPY_DIGEST(out, &subtree[idx]);
+}
+
+__device__ void store_virtual_node(
+    digest_t *subtree,
+    uint8_t const layout,
+    uint32_t const subtree_height,
+    uint32_t const actual_height,
+    uint32_t const node_height,
+    size_t const label,
+    digest_t const *value
+) {
+    if (layout == OMIT_BOTTOM_LEVELS && node_height < OMITTED_BOTTOM_LEVELS) {
+        return;
+    }
+    auto const idx = stored_node_index(subtree_height, actual_height, layout, node_height, label);
+    COPY_DIGEST(&subtree[idx], value);
 }
 
 __global__ void update_merkle_layer(
     uint32_t layer_height,
     digest_t const *zero_hash,
     size_t const *actual_subtree_heights,
+    uint8_t const *subtree_layouts,
+    uintptr_t const *initial_data_ptrs,
+    uint32_t const subtree_height,
     LabeledDigest *layer,
     uint32_t const *child_ptrs,
     uint32_t *parent_ptrs,
     size_t const num_parents,
-    uintptr_t *d_subtree_layers,
+    uintptr_t *d_subtrees,
     Fp *const merkle_trace,
     size_t const trace_height,
     Fp *poseidon2_buffer,
@@ -297,33 +402,48 @@ __global__ void update_merkle_layer(
         return;
     }
     Fp cells[CELLS];
-    digest_t **subtree_layers = reinterpret_cast<digest_t **>(d_subtree_layers);
+    digest_t **subtrees = reinterpret_cast<digest_t **>(d_subtrees);
 
     uint32_t const parent_ptr = parent_ptrs[idx] =
         ((child_ptrs[2 * idx] == MISSING_CHILD) ? child_ptrs[2 * idx + 1] : child_ptrs[2 * idx]);
     uint32_t const address_space_idx = layer[parent_ptr].address_space_idx;
     uint32_t const parent_label = layer[parent_ptr].label >> layer_height;
-    auto const subtree_layer = subtree_layers[address_space_idx];
+    auto const subtree = subtrees[address_space_idx];
+    uint32_t const actual_height = actual_subtree_heights[address_space_idx];
+    uint8_t const layout = subtree_layouts[address_space_idx];
+    auto const initial_data = reinterpret_cast<uint8_t const *>(initial_data_ptrs[address_space_idx]);
     Poseidon2Buffer poseidon2(
         reinterpret_cast<FpArray<16> *>(poseidon2_buffer), poseidon2_buffer_idx, poseidon2_capacity
     );
-    auto const old_left_digest = layer_value_on_height(
-        subtree_layer,
+    digest_t old_left_digest;
+    load_virtual_node(
+        subtree,
         zero_hash,
+        layout,
+        initial_data,
+        address_space_idx,
+        subtree_height,
+        actual_height,
         layer_height - 1,
-        actual_subtree_heights[address_space_idx],
-        2 * parent_label
+        2 * parent_label,
+        &old_left_digest
     );
-    auto const old_right_digest = layer_value_on_height(
-        subtree_layer,
+    digest_t old_right_digest;
+    load_virtual_node(
+        subtree,
         zero_hash,
+        layout,
+        initial_data,
+        address_space_idx,
+        subtree_height,
+        actual_height,
         layer_height - 1,
-        actual_subtree_heights[address_space_idx],
-        2 * parent_label + 1
+        2 * parent_label + 1,
+        &old_right_digest
     );
     { // old values trace row
-        COPY_DIGEST(cells, old_left_digest);
-        COPY_DIGEST(cells + CELLS_OUT, old_right_digest);
+        COPY_DIGEST(cells, &old_left_digest);
+        COPY_DIGEST(cells + CELLS_OUT, &old_right_digest);
         RowSlice row(merkle_trace + 2 * idx, trace_height);
         fill_merkle_trace_row(
             row,
@@ -341,16 +461,36 @@ __global__ void update_merkle_layer(
     { // new values trace row + actual update
         bool left_new = false;
         if (auto const child_ptr = child_ptrs[2 * idx]; child_ptr != MISSING_CHILD) {
-            COPY_DIGEST(&subtree_layer[2 * parent_label], layer[child_ptr].digest_raw);
+            COPY_DIGEST(cells, layer[child_ptr].digest_raw);
+            store_virtual_node(
+                subtree,
+                layout,
+                subtree_height,
+                actual_height,
+                layer_height - 1,
+                2 * parent_label,
+                reinterpret_cast<digest_t const *>(layer[child_ptr].digest_raw)
+            );
             left_new = true;
+        } else {
+            COPY_DIGEST(cells, &old_left_digest);
         }
-        COPY_DIGEST(cells, old_left_digest);
         bool right_new = false;
         if (auto const child_ptr = child_ptrs[2 * idx + 1]; child_ptr != MISSING_CHILD) {
-            COPY_DIGEST(&subtree_layer[2 * parent_label + 1], layer[child_ptr].digest_raw);
+            COPY_DIGEST(cells + CELLS_OUT, layer[child_ptr].digest_raw);
+            store_virtual_node(
+                subtree,
+                layout,
+                subtree_height,
+                actual_height,
+                layer_height - 1,
+                2 * parent_label + 1,
+                reinterpret_cast<digest_t const *>(layer[child_ptr].digest_raw)
+            );
             right_new = true;
+        } else {
+            COPY_DIGEST(cells + CELLS_OUT, &old_right_digest);
         }
-        COPY_DIGEST(cells + CELLS_OUT, old_right_digest);
         RowSlice row(merkle_trace + 2 * idx + 1, trace_height);
         fill_merkle_trace_row(
             row,
@@ -487,27 +627,34 @@ extern "C" int _build_merkle_subtree(
     digest_t *buffer,
     const size_t tree_offset,
     const uint addr_space_idx,
+    const uint8_t layout,
     cudaStream_t stream
 ) {
     digest_t *tree = buffer + tree_offset;
     assert((size & (size - 1)) == 0);
     {
         auto [grid, block] = kernel_launch_params(size);
-        switch (addr_space_idx) { // TODO: revisit when we sort out address space handling
-        case 0:
-            merkle_tree_init<0><<<grid, block, 0, stream>>>(data, tree + (size - 1));
-            break;
-        case 1:
-            merkle_tree_init<1><<<grid, block, 0, stream>>>(data, tree + (size - 1));
-            break;
-        case 2:
-            merkle_tree_init<2><<<grid, block, 0, stream>>>(data, tree + (size - 1));
-            break;
-        case 3:
-            merkle_tree_init<3><<<grid, block, 0, stream>>>(data, tree + (size - 1));
-            break;
-        default:
-            return -1;
+        if (layout == OMIT_BOTTOM_LEVELS) {
+            merkle_tree_init_omitted<<<grid, block, 0, stream>>>(
+                data, tree + (size - 1), addr_space_idx
+            );
+        } else {
+            switch (addr_space_idx) { // TODO: revisit when we sort out address space handling
+            case 0:
+                merkle_tree_init<0><<<grid, block, 0, stream>>>(data, tree + (size - 1));
+                break;
+            case 1:
+                merkle_tree_init<1><<<grid, block, 0, stream>>>(data, tree + (size - 1));
+                break;
+            case 2:
+                merkle_tree_init<2><<<grid, block, 0, stream>>>(data, tree + (size - 1));
+                break;
+            case 3:
+                merkle_tree_init<3><<<grid, block, 0, stream>>>(data, tree + (size - 1));
+                break;
+            default:
+                return -1;
+            }
         }
     }
     for (auto i = size / 2; i > 0; i /= 2) {
@@ -577,6 +724,8 @@ extern "C" int _update_merkle_tree(
     digest_t *top_roots,
     digest_t const *zero_hash,
     size_t const *actual_subtree_heights,
+    uint8_t const *subtree_layouts,
+    uintptr_t const *initial_data_ptrs,
     Fp *d_poseidon2_raw_buffer,
     uint32_t *d_poseidon2_buffer_idx,
     size_t poseidon2_capacity,
@@ -594,12 +743,6 @@ extern "C" int _update_merkle_tree(
     {
         auto [grid, block] = kernel_launch_params(num_leaves, 256);
         prepare_for_updating<<<grid, block, 0, stream>>>(child_buf, layer, num_children);
-    }
-    {
-        auto [grid, block] = kernel_launch_params(num_subtrees);
-        initial_subtrees_advance<<<grid, block, 0, stream>>>(
-            subtrees, actual_subtree_heights, num_subtrees, subtree_height
-        );
     }
 
     uint32_t merkle_trace_offset = unpadded_trace_height;
@@ -653,18 +796,15 @@ extern "C" int _update_merkle_tree(
         }
         cudaStreamSynchronize(stream);
         ++num_parents;
-        {
-            auto [grid, block] = kernel_launch_params(num_subtrees);
-            adjust_subtrees_before_layer_update<<<grid, block, 0, stream>>>(
-                subtrees, actual_subtree_heights, num_subtrees, h
-            );
-        }
         merkle_trace_offset -= 2 * num_parents;
         auto [grid, block] = kernel_launch_params(num_parents, 256);
         update_merkle_layer<<<grid, block, 0, stream>>>(
             h,
             zero_hash,
             actual_subtree_heights,
+            subtree_layouts,
+            initial_data_ptrs,
+            subtree_height,
             layer,
             tmp_buf,
             child_buf,

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -37,7 +37,7 @@ pub struct MemoryInventoryGPU {
     pub device_ctx: GpuDeviceCtx,
     pub boundary: BoundaryChipGPU,
     pub merkle_tree: MemoryMerkleTree,
-    pub initial_memory: Vec<DeviceBuffer<u8>>,
+    pub initial_memory: Vec<Arc<DeviceBuffer<u8>>>,
     pub merkle_records: Option<DeviceBuffer<u32>>,
     #[cfg(feature = "metrics")]
     pub(super) unpadded_merkle_height: usize,
@@ -97,15 +97,15 @@ impl MemoryInventoryGPU {
                 addr_sp,
                 raw_mem.len()
             );
-            self.initial_memory.push(if raw_mem.is_empty() {
+            self.initial_memory.push(Arc::new(if raw_mem.is_empty() {
                 DeviceBuffer::new()
             } else {
                 raw_mem
                     .to_device_on(&self.device_ctx)
                     .expect("failed to copy memory to device")
-            });
+            }));
             self.merkle_tree
-                .build_async(&self.initial_memory[addr_sp], addr_sp);
+                .build_async(self.initial_memory[addr_sp].clone(), addr_sp);
         }
         self.boundary.initial_leaves = self
             .initial_memory

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -20,6 +20,7 @@ pub mod merkle_tree {
             d_tree: *mut std::ffi::c_void,
             tree_offset: usize,
             addr_space_idx: u32,
+            layout: u8,
             stream: cudaStream_t,
         ) -> i32;
 
@@ -66,6 +67,8 @@ pub mod merkle_tree {
             top_roots: *mut u32,         // are actually `H`s
             zero_hashes_end: *const u32, // are actually `H`s
             actual_subtree_heights: *const usize,
+            subtree_layouts: *const u8,
+            initial_data_ptrs: *const usize,
             d_poseidon2_raw_buffer: *mut std::ffi::c_void,
             d_poseidon2_buffer_idx: *mut u32,
             poseidon2_capacity: usize,
@@ -79,6 +82,7 @@ pub mod merkle_tree {
         d_tree: &DeviceBuffer<T>,
         tree_offset: usize,
         addr_space_idx: u32,
+        layout: u8,
         stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_build_merkle_subtree(
@@ -87,6 +91,7 @@ pub mod merkle_tree {
             d_tree.as_mut_raw_ptr(),
             tree_offset,
             addr_space_idx,
+            layout,
             stream,
         ))
     }
@@ -160,6 +165,8 @@ pub mod merkle_tree {
         touched_blocks: &DeviceBuffer<u32>,
         subtree_height: usize,
         actual_heights: &[usize],
+        subtree_layouts: &[u8],
+        initial_data_ptrs: &[usize],
         unpadded_height: usize,
         hasher_buffer: &SharedBuffer<F>,
         device_ctx: &GpuDeviceCtx,
@@ -176,6 +183,8 @@ pub mod merkle_tree {
         )?;
         let tmp_storage = DeviceBuffer::<u8>::with_capacity_on(need_tmp_storage_bytes, device_ctx);
         let actual_heights = actual_heights.to_device_on(device_ctx).unwrap();
+        let subtree_layouts = subtree_layouts.to_device_on(device_ctx).unwrap();
+        let initial_data_ptrs = initial_data_ptrs.to_device_on(device_ctx).unwrap();
         CudaError::from_result(_update_merkle_tree(
             num_leaves,
             touched_blocks.as_mut_ptr(),
@@ -191,6 +200,8 @@ pub mod merkle_tree {
             top_roots.as_mut_ptr() as *mut u32,
             zero_hash.as_ptr() as *mut u32,
             actual_heights.as_ptr(),
+            subtree_layouts.as_ptr(),
+            initial_data_ptrs.as_ptr(),
             hasher_buffer.buffer.as_mut_raw_ptr(),
             hasher_buffer.idx.as_mut_ptr(),
             // Length in F elements; the CUDA side converts to record count.

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -7,6 +7,7 @@ use openvm_cuda_common::{
     error::CudaError,
     stream::{cudaStream_t, GpuDeviceCtx},
 };
+use tracing::instrument;
 
 use super::{SharedBuffer, DIGEST_WIDTH, MERKLE_TOUCHED_BLOCK_WIDTH};
 
@@ -157,6 +158,7 @@ pub mod merkle_tree {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[instrument(name = "update_merkle_tree", skip_all)]
     pub unsafe fn update_merkle_tree<T>(
         trace: &DeviceMatrix<T>,
         subtree_ptrs: &DeviceBuffer<usize>,

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -58,19 +58,15 @@ pub struct MemoryMerkleSubTree {
     pub height: usize,
     pub path_len: usize,
     layout: MemoryMerkleSubTreeLayout,
-    /// Shared handle to the initial-memory buffer (`d_data`) captured in [`Self::build_async`].
-    /// `None` for empty/dummy subtrees that have no backing buffer.
+    /// Shared handle to the initial-memory buffer (`d_data`) from [`Self::build_async`], or
+    /// `None` for empty/dummy subtrees. Co-owning the buffer keeps the host from freeing it: under
+    /// `OmitBottomLevels` the omitted levels aren't in `buf` and are recomputed from this buffer
+    /// during [`MemoryMerkleTree::update_with_touched_blocks`] (`recompute_omitted_node` in
+    /// `merkle_tree.cu`).
     ///
-    /// Holding an `Arc` makes the subtree a co-owner of the buffer, so the host cannot free it
-    /// while the subtree is alive. Under the `OmitBottomLevels` layout the omitted bottom levels
-    /// are never materialized into `buf`; they are recomputed on demand from this buffer during
-    /// [`MemoryMerkleTree::update_with_touched_blocks`] (see `recompute_omitted_node` in
-    /// `merkle_tree.cu`), so the buffer must stay alive until that update completes.
-    ///
-    /// NOTE: this only fixes host-side ownership. The buffer is also consumed by GPU kernels
-    /// enqueued on the stream, so it must additionally outlive those kernels — that ordering is
-    /// guaranteed by the `stream.synchronize()` in [`MemoryMerkleTree::drop_subtrees`], not by the
-    /// `Arc`. Drop the subtrees (which releases these handles) only after that sync.
+    /// This only covers host-side ownership; the buffer also feeds GPU kernels on the stream, so
+    /// drop the subtrees (releasing these handles) only after the `stream.synchronize()` in
+    /// [`MemoryMerkleTree::drop_subtrees`].
     initial_data: Option<Arc<DeviceBuffer<u8>>>,
 }
 
@@ -220,32 +216,6 @@ impl MemoryMerkleSubTree {
             }
         }
         self.build_completion_event = Some(event);
-    }
-
-    /// Returns the bounds [start, end) of the layer at the given depth.
-    /// These bounds correspond to the indices of the layer in the buffer.
-    /// depth: 0 = root, 1 = root's children, ..., height-1 = leaves
-    pub fn layer_bounds(&self, depth: usize) -> (usize, usize) {
-        let global_height = self.height + self.path_len;
-        assert!(
-            depth < global_height,
-            "Depth {depth} out of bounds for height {global_height}",
-        );
-        if depth >= self.path_len {
-            // depth is within the heap-ordered subtree
-            let d = depth - self.path_len;
-            let max_stored_depth = self.stored_heap_height();
-            assert!(
-                d <= max_stored_depth,
-                "Depth {depth} is in an omitted subtree layer"
-            );
-            let start = self.path_len + ((1 << d) - 1);
-            let end = self.path_len + ((1 << (d + 1)) - 1);
-            (start, end)
-        } else {
-            // vertical path layer: single node per level
-            (depth, depth + 1)
-        }
     }
 }
 

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -30,15 +30,24 @@ pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + BLOCK_FE_WIDTH;
 /// Width of `((u32, u32), TimestampedValues<F, DIGEST_WIDTH>)` in u32 units.
 /// = 2 (key) + 1 (timestamp) + DIGEST_WIDTH (values)
 pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + DIGEST_WIDTH;
+pub(crate) const OMITTED_BOTTOM_LEVELS: usize = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum MemoryMerkleSubTreeLayout {
+    Full = 0,
+    OmitBottomLevels = 1,
+}
 
 /// A Merkle subtree stored in a single flat buffer, combining a vertical path and a heap-ordered
-/// binary tree.
+/// retained tree.
 ///
 /// Memory layout:
 /// - The first `path_len` elements form a vertical path (one node per level), used when the actual
 ///   size is smaller than the max size.
-/// - The remaining elements store the subtree nodes in heap-order (breadth-first), with `size`
-///   leaves and `2 * size - 1` total nodes.
+/// - `Full` subtrees store the remaining nodes as the complete subtree heap.
+/// - `OmitBottomLevels` subtrees omit the bottom `OMITTED_BOTTOM_LEVELS` levels and store only the
+///   retained heap whose leaves are the first stored hashes above the omitted levels.
 ///
 /// All GPU work is issued on the subtree's `GpuDeviceCtx` stream.
 /// `build_completion_event` records when the build kernels finish so that downstream consumers can
@@ -48,9 +57,36 @@ pub struct MemoryMerkleSubTree {
     pub buf: DeviceBuffer<H>,
     pub height: usize,
     pub path_len: usize,
+    layout: MemoryMerkleSubTreeLayout,
+    initial_data_ptr: usize,
 }
 
 impl MemoryMerkleSubTree {
+    fn layout_for_height(height: usize) -> MemoryMerkleSubTreeLayout {
+        if height > OMITTED_BOTTOM_LEVELS {
+            MemoryMerkleSubTreeLayout::OmitBottomLevels
+        } else {
+            MemoryMerkleSubTreeLayout::Full
+        }
+    }
+
+    fn heap_len(height: usize, layout: MemoryMerkleSubTreeLayout) -> usize {
+        let retained_height = match layout {
+            MemoryMerkleSubTreeLayout::Full => height,
+            MemoryMerkleSubTreeLayout::OmitBottomLevels => height - OMITTED_BOTTOM_LEVELS,
+        };
+        2 * (1 << retained_height) - 1
+    }
+
+    fn buffer_len(
+        addr_space_size: usize,
+        path_len: usize,
+        layout: MemoryMerkleSubTreeLayout,
+    ) -> usize {
+        let height = log2_ceil_usize(addr_space_size);
+        path_len + Self::heap_len(height, layout)
+    }
+
     /// Constructs a new Merkle subtree with a vertical path and heap-ordered tree.
     /// The buffer is sized based on the actual address space and the maximum size.
     ///
@@ -76,19 +112,22 @@ impl MemoryMerkleSubTree {
         }
         let height = log2_ceil_usize(addr_space_size);
         let path_len = log2_ceil_usize(max_size).checked_sub(height).unwrap();
+        let layout = Self::layout_for_height(height);
+        let buffer_len = Self::buffer_len(addr_space_size, path_len, layout);
         tracing::debug!(
             "Creating a subtree buffer, size is {} (addr space size is {})",
-            path_len + (2 * addr_space_size - 1),
+            buffer_len,
             addr_space_size
         );
-        let buf =
-            DeviceBuffer::<H>::with_capacity_on(path_len + (2 * addr_space_size - 1), device_ctx);
+        let buf = DeviceBuffer::<H>::with_capacity_on(buffer_len, device_ctx);
 
         Self {
             build_completion_event: None,
             height,
             buf,
             path_len,
+            layout,
+            initial_data_ptr: 0,
         }
     }
 
@@ -98,6 +137,19 @@ impl MemoryMerkleSubTree {
             height: 0,
             buf: DeviceBuffer::new(),
             path_len: 0,
+            layout: MemoryMerkleSubTreeLayout::Full,
+            initial_data_ptr: 0,
+        }
+    }
+
+    fn layout_tag(&self) -> u8 {
+        self.layout as u8
+    }
+
+    fn stored_heap_height(&self) -> usize {
+        match self.layout {
+            MemoryMerkleSubTreeLayout::Full => self.height,
+            MemoryMerkleSubTreeLayout::OmitBottomLevels => self.height - OMITTED_BOTTOM_LEVELS,
         }
     }
 
@@ -113,6 +165,7 @@ impl MemoryMerkleSubTree {
         device_ctx: &GpuDeviceCtx,
     ) {
         let event = CudaEvent::new().unwrap();
+        self.initial_data_ptr = d_data.as_ptr() as usize;
         if self.buf.is_empty() {
             self.buf = DeviceBuffer::with_capacity_on(1, device_ctx);
             unsafe {
@@ -129,10 +182,11 @@ impl MemoryMerkleSubTree {
             unsafe {
                 build_merkle_subtree(
                     d_data,
-                    1 << self.height,
+                    1 << self.stored_heap_height(),
                     &self.buf,
                     self.path_len,
                     addr_space_idx as u32,
+                    self.layout_tag(),
                     device_ctx.stream.as_raw(),
                 )
                 .unwrap();
@@ -165,6 +219,11 @@ impl MemoryMerkleSubTree {
         if depth >= self.path_len {
             // depth is within the heap-ordered subtree
             let d = depth - self.path_len;
+            let max_stored_depth = self.stored_heap_height();
+            assert!(
+                d <= max_stored_depth,
+                "Depth {depth} is in an omitted subtree layer"
+            );
             let start = self.path_len + ((1 << d) - 1);
             let end = self.path_len + ((1 << (d + 1)) - 1);
             (start, end)
@@ -336,6 +395,16 @@ impl MemoryMerkleTree {
             output.buffer().fill_zero_on(&self.device_ctx).unwrap();
 
             let actual_heights = self.subtrees.iter().map(|s| s.height).collect::<Vec<_>>();
+            let subtree_layouts = self
+                .subtrees
+                .iter()
+                .map(|s| s.layout_tag())
+                .collect::<Vec<_>>();
+            let initial_data_ptrs = self
+                .subtrees
+                .iter()
+                .map(|s| s.initial_data_ptr)
+                .collect::<Vec<_>>();
             let subtrees_pointers = self
                 .subtrees
                 .iter()
@@ -352,6 +421,8 @@ impl MemoryMerkleTree {
                     d_touched_blocks,
                     self.height - log2_ceil_usize(self.subtrees.len()),
                     &actual_heights,
+                    &subtree_layouts,
+                    &initial_data_ptrs,
                     unpadded_height,
                     &self.hasher_buffer,
                     &self.device_ctx,
@@ -446,8 +517,42 @@ mod tests {
     use p3_field::{PrimeCharacteristicRing, PrimeField32};
     use rand::Rng;
 
-    use super::MemoryMerkleTree;
+    use super::{
+        MemoryMerkleSubTree, MemoryMerkleSubTreeLayout, MemoryMerkleTree, OMITTED_BOTTOM_LEVELS,
+    };
     use crate::system::cuda::{Poseidon2PeripheryChipGPU, DIGEST_WIDTH};
+
+    #[test]
+    fn test_cuda_merkle_subtree_layout_and_buffer_sizes() {
+        let device_ctx = GpuDeviceCtx {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        };
+        let max_size = 1 << (OMITTED_BOTTOM_LEVELS + 3);
+
+        let below =
+            MemoryMerkleSubTree::new(1 << (OMITTED_BOTTOM_LEVELS - 1), max_size, &device_ctx);
+        assert_eq!(below.layout, MemoryMerkleSubTreeLayout::Full);
+        assert_eq!(
+            below.buf.len(),
+            below.path_len + (2 * (1 << (OMITTED_BOTTOM_LEVELS - 1)) - 1)
+        );
+
+        let equal = MemoryMerkleSubTree::new(1 << OMITTED_BOTTOM_LEVELS, max_size, &device_ctx);
+        assert_eq!(equal.layout, MemoryMerkleSubTreeLayout::Full);
+        assert_eq!(
+            equal.buf.len(),
+            equal.path_len + (2 * (1 << OMITTED_BOTTOM_LEVELS) - 1)
+        );
+
+        let above =
+            MemoryMerkleSubTree::new(1 << (OMITTED_BOTTOM_LEVELS + 1), max_size, &device_ctx);
+        let full_len = above.path_len + (2 * (1 << (OMITTED_BOTTOM_LEVELS + 1)) - 1);
+        let optimized_len = above.path_len + (2 * (1 << 1) - 1);
+        assert_eq!(above.layout, MemoryMerkleSubTreeLayout::OmitBottomLevels);
+        assert_eq!(above.buf.len(), optimized_len);
+        assert!(above.buf.len() < full_len);
+    }
 
     #[test]
     fn test_cuda_merkle_tree_cpu_gpu_root_equivalence() {
@@ -532,6 +637,18 @@ mod tests {
         for (i, mem_slice) in mem_slices.iter().enumerate() {
             gpu_merkle_tree.build_async(mem_slice, i);
         }
+        assert_eq!(
+            gpu_merkle_tree.subtrees[RV64_REGISTER_AS as usize - 1].layout,
+            MemoryMerkleSubTreeLayout::OmitBottomLevels
+        );
+        assert_eq!(
+            gpu_merkle_tree.subtrees[RV64_MEMORY_AS as usize - 1].layout,
+            MemoryMerkleSubTreeLayout::OmitBottomLevels
+        );
+        assert_eq!(
+            gpu_merkle_tree.subtrees[DEFERRAL_AS as usize - 1].layout,
+            MemoryMerkleSubTreeLayout::OmitBottomLevels
+        );
         gpu_merkle_tree.finalize();
 
         let cpu_hasher_chip = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -58,6 +58,17 @@ pub struct MemoryMerkleSubTree {
     pub height: usize,
     pub path_len: usize,
     layout: MemoryMerkleSubTreeLayout,
+    /// initial_data_ptr is a raw device pointer to the initial-memory buffer (`d_data`) captured in
+    /// [`Self::build_async`], stored as a `usize` so the borrow is erased.
+    ///
+    /// SAFETY / lifetime: under the `OmitBottomLevels` layout the omitted bottom levels are never
+    /// materialized into `buf`; they are recomputed on demand from this buffer during
+    /// [`MemoryMerkleTree::update_with_touched_blocks`] (see `recompute_omitted_node` in
+    /// `merkle_tree.cu`). The pointed-to buffer must therefore stay alive and unmodified from the
+    /// `build_async` call all the way until that update completes — not merely until the build
+    /// kernel runs. The compiler cannot enforce this through the erased pointer, so the caller is
+    /// responsible: in production the owning `DeviceBuffer`s are held in
+    /// `MemoryInventoryGPU::initial_memory` and only dropped after `update_with_touched_blocks` is done.
     initial_data_ptr: usize,
 }
 
@@ -165,6 +176,8 @@ impl MemoryMerkleSubTree {
         device_ctx: &GpuDeviceCtx,
     ) {
         let event = CudaEvent::new().unwrap();
+        // Capture the raw device pointer; `d_data` must outlive `update_with_touched_blocks`,
+        // which re-reads it under the `OmitBottomLevels` layout (see the `initial_data_ptr` field).
         self.initial_data_ptr = d_data.as_ptr() as usize;
         if self.buf.is_empty() {
             self.buf = DeviceBuffer::with_capacity_on(1, device_ctx);
@@ -322,7 +335,11 @@ impl MemoryMerkleTree {
     /// address space, which should be ignored.
     ///
     /// **Note:** the caller MUST ENSURE that `d_data` lives long enough to be there
-    /// when the enqueued task actually starts.
+    /// when the enqueued task actually starts. Moreover, when the subtree uses the
+    /// `OmitBottomLevels` layout, `d_data` is also re-read during
+    /// [`Self::update_with_touched_blocks`] to recompute the omitted bottom levels, so it must
+    /// remain valid until that update completes — not just until the build kernel runs. See
+    /// [`MemoryMerkleSubTree`]'s `initial_data_ptr` field for details.
     pub fn build_async(&mut self, d_data: &DeviceBuffer<u8>, addr_space: usize) {
         if addr_space < ADDR_SPACE_OFFSET as usize {
             return;
@@ -488,21 +505,21 @@ impl Drop for MemoryMerkleTree {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::BTreeMap, sync::Arc};
 
     use openvm_circuit::{
         arch::{vm_poseidon2_config, MemoryCellType, MemoryConfig, U16_CELL_SIZE},
         system::{
             cuda::merkle_tree::MERKLE_TOUCHED_BLOCK_WIDTH,
             memory::{
-                merkle::MerkleTree,
+                merkle::{MemoryMerkleChip, MerkleTree},
                 online::{GuestMemory, LinearMemory},
                 AddressMap, TimestampedValues,
             },
             poseidon2::Poseidon2PeripheryChip,
         },
     };
-    use openvm_cuda_backend::prelude::F;
+    use openvm_cuda_backend::prelude::{F, SC};
     use openvm_cuda_common::{
         common::get_device,
         copy::{MemCopyD2H, MemCopyH2D},
@@ -513,6 +530,7 @@ mod tests {
         riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
         DEFERRAL_AS,
     };
+    use openvm_stark_backend::{interaction::PermutationCheckBus, prover::MatrixDimensions};
     use openvm_stark_sdk::utils::create_seeded_rng;
     use p3_field::{PrimeCharacteristicRing, PrimeField32};
     use rand::Rng;
@@ -520,7 +538,10 @@ mod tests {
     use super::{
         MemoryMerkleSubTree, MemoryMerkleSubTreeLayout, MemoryMerkleTree, OMITTED_BOTTOM_LEVELS,
     };
-    use crate::system::cuda::{Poseidon2PeripheryChipGPU, DIGEST_WIDTH};
+    use crate::{
+        arch::testing::{MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
+        system::cuda::{Poseidon2PeripheryChipGPU, DIGEST_WIDTH},
+    };
 
     #[test]
     fn test_cuda_merkle_subtree_layout_and_buffer_sizes() {
@@ -753,6 +774,202 @@ mod tests {
                 .top_roots
                 .to_host_on(&gpu_merkle_tree.device_ctx)
                 .unwrap()[0]
+        );
+    }
+
+    /// Checks that the *trace* (not just the root) produced by the GPU
+    /// `update_with_touched_blocks` contains exactly the same rows as the canonical trace
+    /// produced by the CPU `MemoryMerkleChip`. The CPU trace is known to satisfy the
+    /// `MemoryMerkleAir` constraints (covered by the CPU-side merkle tests), so matching every
+    /// row content-for-content implies the GPU emits the correct merkle trace. This exercises the
+    /// `OmitBottomLevels` trace-generation path, whose row contents (the reconstructed omitted
+    /// levels) are not checked by the root-equivalence test.
+    ///
+    /// The comparison is order-independent: the `MemoryMerkleAir` permits more than one valid row
+    /// ordering and the GPU lays rows out differently than the CPU, so we compare the two traces
+    /// as multisets of rows rather than positionally.
+    #[test]
+    fn test_cuda_merkle_tree_cpu_gpu_trace_equivalence() {
+        let mut rng = create_seeded_rng();
+        let mem_config = {
+            let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
+            let max_ptr_bits = 16;
+            let max_cells = 1 << max_ptr_bits;
+            // RV64_REGISTER_AS uses u16 storage cells.
+            addr_spaces[RV64_REGISTER_AS as usize].num_cells =
+                32 * size_of::<u64>() / U16_CELL_SIZE;
+            addr_spaces[RV64_MEMORY_AS as usize].num_cells = max_cells;
+            addr_spaces[DEFERRAL_AS as usize].num_cells = max_cells;
+            MemoryConfig::new(2, addr_spaces, max_ptr_bits, 29, 17)
+        };
+
+        let mut initial_memory = GuestMemory::new(AddressMap::from_mem_config(&mem_config));
+        for (idx, space) in mem_config.addr_spaces.iter().enumerate() {
+            unsafe {
+                match space.layout {
+                    MemoryCellType::Null => {}
+                    MemoryCellType::U8 => {
+                        for i in 0..space.num_cells {
+                            initial_memory.write::<u8, 1>(idx as u32, i as u32, [rng.random()]);
+                        }
+                    }
+                    MemoryCellType::U16 => {
+                        for i in 0..space.num_cells {
+                            initial_memory.write::<u16, 1>(idx as u32, i as u32, [rng.random()]);
+                        }
+                    }
+                    MemoryCellType::U32 => {
+                        for i in 0..space.num_cells {
+                            initial_memory.write::<u32, 1>(idx as u32, i as u32, [rng.random()]);
+                        }
+                    }
+                    MemoryCellType::F { .. } => {
+                        for i in 0..space.num_cells {
+                            initial_memory.write::<F, 1>(
+                                idx as u32,
+                                i as u32,
+                                [F::from_u32(rng.random_range(0..F::ORDER_U32))],
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let device_ctx = GpuDeviceCtx {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        };
+        let gpu_hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(
+            (mem_config
+                .addr_spaces
+                .iter()
+                .map(|ashc| ashc.num_cells * 2 + mem_config.memory_dimensions().overall_height())
+                .sum::<usize>()
+                * 2)
+            .next_power_of_two()
+                * 2
+                * DIGEST_WIDTH, // max_buffer_size
+            1, // sbox_regs
+            device_ctx.clone(),
+        ));
+        let mut gpu_merkle_tree =
+            MemoryMerkleTree::new(mem_config.clone(), gpu_hasher_chip, device_ctx.clone());
+        let mem_slices = initial_memory
+            .memory
+            .get_memory()
+            .iter()
+            .map(|mem| {
+                let mem_slice = mem.as_slice();
+                if !mem_slice.is_empty() {
+                    mem_slice.to_device_on(&gpu_merkle_tree.device_ctx).unwrap()
+                } else {
+                    DeviceBuffer::new()
+                }
+            })
+            .collect::<Vec<_>>();
+        for (i, mem_slice) in mem_slices.iter().enumerate() {
+            gpu_merkle_tree.build_async(mem_slice, i);
+        }
+        gpu_merkle_tree.finalize();
+
+        // Touched blocks: ~1/3 of digest-aligned pointers get fresh random values.
+        let touched_ptrs = mem_config
+            .addr_spaces
+            .iter()
+            .enumerate()
+            .flat_map(|(i, cnf)| {
+                let mut ptrs = Vec::new();
+                for j in 0..(cnf.num_cells / DIGEST_WIDTH) {
+                    if rng.random_bool(0.333) {
+                        ptrs.push((i as u32, (j * DIGEST_WIDTH) as u32));
+                    }
+                }
+                ptrs
+            })
+            .collect::<Vec<_>>();
+        let new_data = touched_ptrs
+            .iter()
+            .map(|_| std::array::from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32))))
+            .collect::<Vec<[F; DIGEST_WIDTH]>>();
+        assert!(!touched_ptrs.is_empty());
+
+        // Build the canonical CPU trace from the same initial memory and touched blocks, using a
+        // Poseidon2 hasher equivalent to the GPU one.
+        let cpu_hasher_chip = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);
+        let mut cpu_merkle_chip = MemoryMerkleChip::<DIGEST_WIDTH, F>::new(
+            mem_config.memory_dimensions(),
+            PermutationCheckBus::new(MEMORY_MERKLE_BUS),
+            PermutationCheckBus::new(POSEIDON2_DIRECT_BUS),
+        );
+        let final_partition: BTreeMap<(u32, u32), [F; DIGEST_WIDTH]> = touched_ptrs
+            .iter()
+            .copied()
+            .zip(new_data.iter().copied())
+            .collect();
+        cpu_merkle_chip.finalize(&initial_memory.memory, &final_partition, &cpu_hasher_chip);
+        let cpu_ctx = cpu_merkle_chip.generate_proving_ctx::<SC>();
+
+        // Run the GPU update and capture the resulting trace.
+        let touched_blocks = touched_ptrs
+            .into_iter()
+            .zip(new_data)
+            .map(|(address, data)| {
+                (
+                    address,
+                    TimestampedValues {
+                        timestamp: rng.random_range(0..(1u32 << mem_config.timestamp_max_bits)),
+                        values: data,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut merkle_records =
+            Vec::<u32>::with_capacity(touched_blocks.len() * MERKLE_TOUCHED_BLOCK_WIDTH);
+        for (address, ts_values) in &touched_blocks {
+            let (address_space, ptr) = *address;
+            merkle_records.push(address_space);
+            merkle_records.push(ptr);
+            merkle_records.push(ts_values.timestamp);
+            for &v in &ts_values.values {
+                merkle_records.push(unsafe { std::mem::transmute::<F, u32>(v) });
+            }
+        }
+        let d_touched_blocks = merkle_records
+            .to_device_on(&gpu_merkle_tree.device_ctx)
+            .unwrap();
+
+        let merkle_ctx = gpu_merkle_tree.update_with_touched_blocks(
+            gpu_merkle_tree.calculate_unpadded_height(&touched_blocks),
+            &d_touched_blocks,
+            false,
+        );
+
+        // The GPU trace must contain exactly the same rows as the constraint-valid CPU trace.
+        let width = cpu_ctx.common_main.width;
+        let height = cpu_ctx.common_main.values.len() / width;
+        let gpu_trace = &merkle_ctx.common_main;
+        assert_eq!(gpu_trace.width(), width, "trace width mismatch");
+        assert_eq!(gpu_trace.height(), height, "trace (padded) height mismatch");
+
+        // CPU trace is row-major; GPU trace is column-major on device.
+        let cpu_vals = &cpu_ctx.common_main.values;
+        let gpu_vals = gpu_trace
+            .buffer()
+            .to_host_on(&gpu_merkle_tree.device_ctx)
+            .unwrap();
+        let row_to_u32 = |get: &dyn Fn(usize, usize) -> F, r: usize| -> Vec<u32> {
+            (0..width).map(|c| get(r, c).as_canonical_u32()).collect()
+        };
+        let cpu_get = |r: usize, c: usize| cpu_vals[r * width + c];
+        let gpu_get = |r: usize, c: usize| gpu_vals[c * height + r];
+        let mut cpu_rows: Vec<Vec<u32>> = (0..height).map(|r| row_to_u32(&cpu_get, r)).collect();
+        let mut gpu_rows: Vec<Vec<u32>> = (0..height).map(|r| row_to_u32(&gpu_get, r)).collect();
+        cpu_rows.sort_unstable();
+        gpu_rows.sort_unstable();
+        assert_eq!(
+            gpu_rows, cpu_rows,
+            "GPU merkle trace rows do not match the CPU reference trace"
         );
     }
 }

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -58,8 +58,8 @@ pub struct MemoryMerkleSubTree {
     pub height: usize,
     pub path_len: usize,
     layout: MemoryMerkleSubTreeLayout,
-    /// initial_data_ptr is a raw device pointer to the initial-memory buffer (`d_data`) captured in
-    /// [`Self::build_async`], stored as a `usize` so the borrow is erased.
+    /// initial_data_ptr is a raw device pointer to the initial-memory buffer (`d_data`) captured
+    /// in [`Self::build_async`], stored as a `usize` so the borrow is erased.
     ///
     /// SAFETY / lifetime: under the `OmitBottomLevels` layout the omitted bottom levels are never
     /// materialized into `buf`; they are recomputed on demand from this buffer during
@@ -68,7 +68,8 @@ pub struct MemoryMerkleSubTree {
     /// `build_async` call all the way until that update completes — not merely until the build
     /// kernel runs. The compiler cannot enforce this through the erased pointer, so the caller is
     /// responsible: in production the owning `DeviceBuffer`s are held in
-    /// `MemoryInventoryGPU::initial_memory` and only dropped after `update_with_touched_blocks` is done.
+    /// `MemoryInventoryGPU::initial_memory` and only dropped after `update_with_touched_blocks` is
+    /// done.
     initial_data_ptr: usize,
 }
 

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -58,19 +58,20 @@ pub struct MemoryMerkleSubTree {
     pub height: usize,
     pub path_len: usize,
     layout: MemoryMerkleSubTreeLayout,
-    /// initial_data_ptr is a raw device pointer to the initial-memory buffer (`d_data`) captured
-    /// in [`Self::build_async`], stored as a `usize` so the borrow is erased.
+    /// Shared handle to the initial-memory buffer (`d_data`) captured in [`Self::build_async`].
+    /// `None` for empty/dummy subtrees that have no backing buffer.
     ///
-    /// SAFETY / lifetime: under the `OmitBottomLevels` layout the omitted bottom levels are never
-    /// materialized into `buf`; they are recomputed on demand from this buffer during
+    /// Holding an `Arc` makes the subtree a co-owner of the buffer, so the host cannot free it
+    /// while the subtree is alive. Under the `OmitBottomLevels` layout the omitted bottom levels
+    /// are never materialized into `buf`; they are recomputed on demand from this buffer during
     /// [`MemoryMerkleTree::update_with_touched_blocks`] (see `recompute_omitted_node` in
-    /// `merkle_tree.cu`). The pointed-to buffer must therefore stay alive and unmodified from the
-    /// `build_async` call all the way until that update completes — not merely until the build
-    /// kernel runs. The compiler cannot enforce this through the erased pointer, so the caller is
-    /// responsible: in production the owning `DeviceBuffer`s are held in
-    /// `MemoryInventoryGPU::initial_memory` and only dropped after `update_with_touched_blocks` is
-    /// done.
-    initial_data_ptr: usize,
+    /// `merkle_tree.cu`), so the buffer must stay alive until that update completes.
+    ///
+    /// NOTE: this only fixes host-side ownership. The buffer is also consumed by GPU kernels
+    /// enqueued on the stream, so it must additionally outlive those kernels — that ordering is
+    /// guaranteed by the `stream.synchronize()` in [`MemoryMerkleTree::drop_subtrees`], not by the
+    /// `Arc`. Drop the subtrees (which releases these handles) only after that sync.
+    initial_data: Option<Arc<DeviceBuffer<u8>>>,
 }
 
 impl MemoryMerkleSubTree {
@@ -139,7 +140,7 @@ impl MemoryMerkleSubTree {
             buf,
             path_len,
             layout,
-            initial_data_ptr: 0,
+            initial_data: None,
         }
     }
 
@@ -150,7 +151,7 @@ impl MemoryMerkleSubTree {
             buf: DeviceBuffer::new(),
             path_len: 0,
             layout: MemoryMerkleSubTreeLayout::Full,
-            initial_data_ptr: 0,
+            initial_data: None,
         }
     }
 
@@ -171,15 +172,15 @@ impl MemoryMerkleSubTree {
     /// Here `addr_space_idx` is the address space _shifted_ by ADDR_SPACE_OFFSET = 1
     pub fn build_async(
         &mut self,
-        d_data: &DeviceBuffer<u8>,
+        d_data: Arc<DeviceBuffer<u8>>,
         addr_space_idx: usize,
         zero_hash: &DeviceBuffer<H>,
         device_ctx: &GpuDeviceCtx,
     ) {
         let event = CudaEvent::new().unwrap();
-        // Capture the raw device pointer; `d_data` must outlive `update_with_touched_blocks`,
-        // which re-reads it under the `OmitBottomLevels` layout (see the `initial_data_ptr` field).
-        self.initial_data_ptr = d_data.as_ptr() as usize;
+        // Co-own the buffer; it must outlive `update_with_touched_blocks`, which re-reads it under
+        // the `OmitBottomLevels` layout (see the `initial_data` field).
+        self.initial_data = Some(d_data.clone());
         if self.buf.is_empty() {
             self.buf = DeviceBuffer::with_capacity_on(1, device_ctx);
             unsafe {
@@ -195,7 +196,7 @@ impl MemoryMerkleSubTree {
         } else {
             unsafe {
                 build_merkle_subtree(
-                    d_data,
+                    &d_data,
                     1 << self.stored_heap_height(),
                     &self.buf,
                     self.path_len,
@@ -340,8 +341,8 @@ impl MemoryMerkleTree {
     /// `OmitBottomLevels` layout, `d_data` is also re-read during
     /// [`Self::update_with_touched_blocks`] to recompute the omitted bottom levels, so it must
     /// remain valid until that update completes — not just until the build kernel runs. See
-    /// [`MemoryMerkleSubTree`]'s `initial_data_ptr` field for details.
-    pub fn build_async(&mut self, d_data: &DeviceBuffer<u8>, addr_space: usize) {
+    /// [`MemoryMerkleSubTree`]'s `initial_data` field for details.
+    pub fn build_async(&mut self, d_data: Arc<DeviceBuffer<u8>>, addr_space: usize) {
         if addr_space < ADDR_SPACE_OFFSET as usize {
             return;
         }
@@ -421,7 +422,7 @@ impl MemoryMerkleTree {
             let initial_data_ptrs = self
                 .subtrees
                 .iter()
-                .map(|s| s.initial_data_ptr)
+                .map(|s| s.initial_data.as_ref().map_or(0, |b| b.as_ptr() as usize))
                 .collect::<Vec<_>>();
             let subtrees_pointers = self
                 .subtrees
@@ -649,15 +650,15 @@ mod tests {
             .iter()
             .map(|mem| {
                 let mem_slice = mem.as_slice();
-                if !mem_slice.is_empty() {
+                Arc::new(if !mem_slice.is_empty() {
                     mem_slice.to_device_on(&gpu_merkle_tree.device_ctx).unwrap()
                 } else {
                     DeviceBuffer::new()
-                }
+                })
             })
             .collect::<Vec<_>>();
         for (i, mem_slice) in mem_slices.iter().enumerate() {
-            gpu_merkle_tree.build_async(mem_slice, i);
+            gpu_merkle_tree.build_async(mem_slice.clone(), i);
         }
         assert_eq!(
             gpu_merkle_tree.subtrees[RV64_REGISTER_AS as usize - 1].layout,
@@ -862,15 +863,15 @@ mod tests {
             .iter()
             .map(|mem| {
                 let mem_slice = mem.as_slice();
-                if !mem_slice.is_empty() {
+                Arc::new(if !mem_slice.is_empty() {
                     mem_slice.to_device_on(&gpu_merkle_tree.device_ctx).unwrap()
                 } else {
                     DeviceBuffer::new()
-                }
+                })
             })
             .collect::<Vec<_>>();
         for (i, mem_slice) in mem_slices.iter().enumerate() {
-            gpu_merkle_tree.build_async(mem_slice, i);
+            gpu_merkle_tree.build_async(mem_slice.clone(), i);
         }
         gpu_merkle_tree.finalize();
 


### PR DESCRIPTION
Motivation: A memory optimization of the GPU merkle tree is needed (once we go to 2^32 address space size) because currently how the MemoryMerkleTree works is that if we have N bytes then we will have N/16 leaves (and N/8 nodes in total) and each leaf is stored as 8 field elements. This means we need 4N bytes of VRAM to store the memory merkle tree in the GPU. With N = 2^32 (once we go to 2^32 AS size), 4N is roughy 17 GB which will OOM the GPU (our current limit is ~15 G). 

Optimization idea of this PR: Don't store the last OMITTED_BOTTOM_LEVELS levels of the MemoryMerkleSubTree in the GPU memory and only computing it when needed for address spaces with large sizes (AS2 and deferral AS). This is done by recomputing (i.e. re-computing the poseidon2 hash) from the raw memory. This saves the GPU memory required for the Merkle tree itself by a factor of 8.   

Reth benchmark results: https://github.com/axiom-crypto/openvm-eth/actions/runs/26959247863

The summary of the result is proving time increased by 0.77s but the generate mem proving ctxs went down from 3.84 G to 2.09 G and set initial memory went down from 3.63 G to 1.88 G. Note that it didn't went down by a factor of 8 because there are other things that uses the memory. The other things here include the boundarychipgpu and initial_memory buffer (see the MemoryInventoryGPU struct for details). 

Closes INT-8079