### PR TITLE
perf(v2.1-rv64): pair byte range checks

### DIFF
--- a/extensions/riscv/circuit/cuda/src/load_sign_extend.cu
+++ b/extensions/riscv/circuit/cuda/src/load_sign_extend.cu
@@ -36,11 +36,15 @@ template <size_t NUM_CELLS> struct LoadSignExtendCoreRecord {
 
 template <size_t NUM_CELLS> struct LoadSignExtendCore {
     VariableRangeChecker range_checker;
+    BitwiseOperationLookup bitwise_lookup;
 
     template <typename T> using Cols = LoadSignExtendCoreCols<T, NUM_CELLS>;
 
-    __device__ LoadSignExtendCore(VariableRangeChecker range_checker)
-        : range_checker(range_checker) {}
+    __device__ LoadSignExtendCore(
+        VariableRangeChecker range_checker,
+        BitwiseOperationLookup bitwise_lookup
+    )
+        : range_checker(range_checker), bitwise_lookup(bitwise_lookup) {}
 
     __device__ void fill_trace_row(RowSlice row, LoadSignExtendCoreRecord<NUM_CELLS> record) {
         uint8_t shift = record.shift_amount;
@@ -69,8 +73,8 @@ template <size_t NUM_CELLS> struct LoadSignExtendCore {
 
         range_checker.add_count(most_sig_limb - most_sig_bit, RV64_BYTE_BITS - 1);
 #pragma unroll
-        for (size_t i = 0; i < NUM_CELLS; i++) {
-            range_checker.add_count(shifted_read_data[i], RV64_BYTE_BITS);
+        for (size_t i = 0; i < NUM_CELLS; i += 2) {
+            bitwise_lookup.add_range(shifted_read_data[i], shifted_read_data[i + 1]);
         }
         COL_WRITE_VALUE(row, Cols, opcode_loadb_flag0, record.is_byte && inner_shift == 0);
         COL_WRITE_VALUE(row, Cols, opcode_loadb_flag1, record.is_byte && inner_shift == 1);
@@ -106,6 +110,7 @@ __global__ void rv64_load_sign_extend_tracegen(
     size_t pointer_max_bits,
     uint32_t *range_checker_ptr,
     uint32_t range_checker_num_bins,
+    uint32_t *bitwise_lookup_ptr,
     uint32_t timestamp_max_bits
 ) {
     uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -121,7 +126,8 @@ __global__ void rv64_load_sign_extend_tracegen(
         adapter.fill_trace_row(row, record.adapter);
 
         auto core = LoadSignExtendCore<RV64_REGISTER_NUM_LIMBS>(
-            VariableRangeChecker(range_checker_ptr, range_checker_num_bins)
+            VariableRangeChecker(range_checker_ptr, range_checker_num_bins),
+            BitwiseOperationLookup(bitwise_lookup_ptr)
         );
         core.fill_trace_row(row.slice_from(COL_INDEX(Rv64LoadSignExtendCols, core)), record.core);
     } else {
@@ -137,6 +143,7 @@ extern "C" int _rv64_load_sign_extend_tracegen(
     size_t pointer_max_bits,
     uint32_t *__restrict__ d_range_checker,
     uint32_t range_checker_num_bins,
+    uint32_t *__restrict__ d_bitwise_lookup,
     uint32_t timestamp_max_bits,
     cudaStream_t stream
 ) {
@@ -151,6 +158,7 @@ extern "C" int _rv64_load_sign_extend_tracegen(
         pointer_max_bits,
         d_range_checker,
         range_checker_num_bins,
+        d_bitwise_lookup,
         timestamp_max_bits
     );
     return CHECK_KERNEL();

--- a/extensions/riscv/circuit/cuda/src/loadstore.cu
+++ b/extensions/riscv/circuit/cuda/src/loadstore.cu
@@ -108,10 +108,10 @@ __device__ __forceinline__ void run_write_data(
 }
 
 template <size_t NUM_CELLS> struct LoadStoreCore {
-    VariableRangeChecker range_checker;
+    BitwiseOperationLookup bitwise_lookup;
 
-    __device__ LoadStoreCore(VariableRangeChecker range_checker)
-        : range_checker(range_checker) {}
+    __device__ LoadStoreCore(BitwiseOperationLookup bitwise_lookup)
+        : bitwise_lookup(bitwise_lookup) {}
 
     template <typename T> using Cols = LoadStoreCoreCols<T, NUM_CELLS>;
 
@@ -139,9 +139,9 @@ template <size_t NUM_CELLS> struct LoadStoreCore {
         COL_WRITE_ARRAY(row, Cols, read_data, record.read_data);
         COL_WRITE_ARRAY(row, Cols, prev_data, record.prev_data);
 #pragma unroll
-        for (size_t i = 0; i < NUM_CELLS; i++) {
-            range_checker.add_count(record.read_data[i], 8);
-            range_checker.add_count(record.prev_data[i], 8);
+        for (size_t i = 0; i < NUM_CELLS; i += 2) {
+            bitwise_lookup.add_range(record.read_data[i], record.read_data[i + 1]);
+            bitwise_lookup.add_range(record.prev_data[i], record.prev_data[i + 1]);
         }
 
         run_write_data(write_data, opcode, record.read_data, record.prev_data, shift);
@@ -168,6 +168,7 @@ __global__ void rv64_load_store_tracegen(
     size_t pointer_max_bits,
     uint32_t *range_checker_ptr,
     uint32_t range_checker_num_bins,
+    uint32_t *bitwise_lookup_ptr,
     uint32_t timestamp_max_bits
 ) {
     uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -183,7 +184,7 @@ __global__ void rv64_load_store_tracegen(
         adapter.fill_trace_row(row, record.adapter);
 
         auto core = LoadStoreCore<RV64_REGISTER_NUM_LIMBS>(
-            VariableRangeChecker(range_checker_ptr, range_checker_num_bins)
+            BitwiseOperationLookup(bitwise_lookup_ptr)
         );
         core.fill_trace_row(row.slice_from(COL_INDEX(Rv64LoadStoreCols, core)), record.core);
     } else {
@@ -199,6 +200,7 @@ extern "C" int _rv64_load_store_tracegen(
     size_t pointer_max_bits,
     uint32_t *d_range_checker,
     uint32_t range_checker_num_bins,
+    uint32_t *d_bitwise_lookup,
     uint32_t timestamp_max_bits,
     cudaStream_t stream
 ) {
@@ -213,6 +215,7 @@ extern "C" int _rv64_load_store_tracegen(
         pointer_max_bits,
         d_range_checker,
         range_checker_num_bins,
+        d_bitwise_lookup,
         timestamp_max_bits
     );
     return CHECK_KERNEL();

--- a/extensions/riscv/circuit/src/cuda_abi.rs
+++ b/extensions/riscv/circuit/src/cuda_abi.rs
@@ -372,6 +372,7 @@ pub mod loadstore_cuda {
             pointer_max_bits: usize,
             d_range_checker: *mut u32,
             range_checker_num_bins: u32,
+            d_bitwise_lookup: *mut u32,
             timestamp_max_bits: u32,
             stream: cudaStream_t,
         ) -> i32;
@@ -384,6 +385,7 @@ pub mod loadstore_cuda {
         d_records: &DeviceBuffer<u8>,
         pointer_max_bits: usize,
         d_range_checker: &DeviceBuffer<F>,
+        d_bitwise_lookup: &DeviceBuffer<F>,
         timestamp_max_bits: u32,
         stream: cudaStream_t,
     ) -> Result<(), CudaError> {
@@ -395,6 +397,7 @@ pub mod loadstore_cuda {
             pointer_max_bits,
             d_range_checker.as_mut_ptr() as *mut u32,
             d_range_checker.len() as u32,
+            d_bitwise_lookup.as_mut_ptr() as *mut u32,
             timestamp_max_bits,
             stream,
         ))
@@ -413,6 +416,7 @@ pub mod load_sign_extend_cuda {
             pointer_max_bits: usize,
             d_range_checker: *mut u32,
             range_checker_num_bins: u32,
+            d_bitwise_lookup: *mut u32,
             timestamp_max_bits: u32,
             stream: cudaStream_t,
         ) -> i32;
@@ -425,6 +429,7 @@ pub mod load_sign_extend_cuda {
         d_records: &DeviceBuffer<u8>,
         pointer_max_bits: usize,
         d_range_checker: &DeviceBuffer<F>,
+        d_bitwise_lookup: &DeviceBuffer<F>,
         timestamp_max_bits: u32,
         stream: cudaStream_t,
     ) -> Result<(), CudaError> {
@@ -436,6 +441,7 @@ pub mod load_sign_extend_cuda {
             pointer_max_bits,
             d_range_checker.as_mut_ptr() as *mut u32,
             d_range_checker.len() as u32,
+            d_bitwise_lookup.as_mut_ptr() as *mut u32,
             timestamp_max_bits,
             stream,
         ))

--- a/extensions/riscv/circuit/src/extension/cuda.rs
+++ b/extensions/riscv/circuit/src/extension/cuda.rs
@@ -76,13 +76,18 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Rv64I> for 
         inventory.add_executor_chip(shift_w);
 
         inventory.next_air::<Rv64LoadStoreAir>()?;
-        let load_store_chip =
-            Rv64LoadStoreChipGpu::new(range_checker.clone(), byte_ptr_max_bits, timestamp_max_bits);
+        let load_store_chip = Rv64LoadStoreChipGpu::new(
+            range_checker.clone(),
+            bitwise_lu.clone(),
+            byte_ptr_max_bits,
+            timestamp_max_bits,
+        );
         inventory.add_executor_chip(load_store_chip);
 
         inventory.next_air::<Rv64LoadSignExtendAir>()?;
         let load_sign_extend = Rv64LoadSignExtendChipGpu::new(
             range_checker.clone(),
+            bitwise_lu.clone(),
             byte_ptr_max_bits,
             timestamp_max_bits,
         );

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -296,7 +296,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Rv64I {
                 range_checker,
                 byte_ptr_max_bits,
             ),
-            LoadStoreCoreAir::new(Rv64LoadStoreOpcode::CLASS_OFFSET, range_checker),
+            LoadStoreCoreAir::new(Rv64LoadStoreOpcode::CLASS_OFFSET, bitwise_lu),
         );
         inventory.add_air(load_store);
 
@@ -307,7 +307,7 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Rv64I {
                 range_checker,
                 byte_ptr_max_bits,
             ),
-            LoadSignExtendCoreAir::new(range_checker),
+            LoadSignExtendCoreAir::new(range_checker, bitwise_lu),
         );
         inventory.add_air(load_sign_extend);
 
@@ -444,7 +444,7 @@ where
             LoadStoreFiller::new(
                 Rv64LoadStoreAdapterFiller::new(byte_ptr_max_bits, range_checker.clone()),
                 Rv64LoadStoreOpcode::CLASS_OFFSET,
-                range_checker.clone(),
+                bitwise_lu.clone(),
             ),
             mem_helper.clone(),
         );
@@ -455,6 +455,7 @@ where
             LoadSignExtendFiller::new(
                 Rv64LoadStoreAdapterFiller::new(byte_ptr_max_bits, range_checker.clone()),
                 range_checker.clone(),
+                bitwise_lu.clone(),
             ),
             mem_helper.clone(),
         );

--- a/extensions/riscv/circuit/src/load_sign_extend/core.rs
+++ b/extensions/riscv/circuit/src/load_sign_extend/core.rs
@@ -8,6 +8,7 @@ use openvm_circuit::{
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::{
+    bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::select,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
     AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
@@ -55,10 +56,24 @@ pub struct LoadSignExtendCoreCols<T, const NUM_CELLS: usize> {
     pub prev_data: [T; NUM_CELLS],
 }
 
-#[derive(Debug, Clone, derive_new::new, ColumnsAir)]
+#[derive(Debug, Clone, ColumnsAir)]
 #[columns_via(LoadSignExtendCoreCols<u8, NUM_CELLS>)]
 pub struct LoadSignExtendCoreAir<const NUM_CELLS: usize, const LIMB_BITS: usize> {
     pub range_bus: VariableRangeCheckerBus,
+    pub bitwise_lookup_bus: BitwiseOperationLookupBus,
+}
+
+impl<const NUM_CELLS: usize, const LIMB_BITS: usize> LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS> {
+    pub fn new(
+        range_bus: VariableRangeCheckerBus,
+        bitwise_lookup_bus: BitwiseOperationLookupBus,
+    ) -> Self {
+        assert!(NUM_CELLS.is_multiple_of(2));
+        Self {
+            range_bus,
+            bitwise_lookup_bus,
+        }
+    }
 }
 
 impl<F: Field, const NUM_CELLS: usize, const LIMB_BITS: usize> BaseAir<F>
@@ -161,9 +176,9 @@ where
                 LIMB_BITS - 1,
             )
             .eval(builder, is_valid.clone());
-        for cell in shifted_read_data {
-            self.range_bus
-                .range_check(cell, LIMB_BITS)
+        for pair in shifted_read_data.chunks_exact(2) {
+            self.bitwise_lookup_bus
+                .send_range(pair[0], pair[1])
                 .eval(builder, is_valid.clone());
         }
 
@@ -216,7 +231,7 @@ pub struct LoadSignExtendExecutor<A, const NUM_CELLS: usize, const LIMB_BITS: us
     adapter: A,
 }
 
-#[derive(Clone, derive_new::new)]
+#[derive(Clone)]
 pub struct LoadSignExtendFiller<
     A = Rv64LoadStoreAdapterFiller,
     const NUM_CELLS: usize = RV64_REGISTER_NUM_LIMBS,
@@ -224,6 +239,24 @@ pub struct LoadSignExtendFiller<
 > {
     adapter: A,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
+    pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+}
+
+impl<A, const NUM_CELLS: usize, const LIMB_BITS: usize>
+    LoadSignExtendFiller<A, NUM_CELLS, LIMB_BITS>
+{
+    pub fn new(
+        adapter: A,
+        range_checker_chip: SharedVariableRangeCheckerChip,
+        bitwise_lookup_chip: SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+    ) -> Self {
+        assert!(NUM_CELLS.is_multiple_of(2));
+        Self {
+            adapter,
+            range_checker_chip,
+            bitwise_lookup_chip,
+        }
+    }
 }
 
 impl<F, A, RA, const NUM_CELLS: usize, const LIMB_BITS: usize> PreflightExecutor<F, RA>
@@ -332,8 +365,9 @@ where
         let most_sig_bit = most_sig_limb & (1 << (LIMB_BITS - 1));
         self.range_checker_chip
             .add_count((most_sig_limb - most_sig_bit) as u32, LIMB_BITS - 1);
-        for cell in shifted {
-            self.range_checker_chip.add_count(cell as u32, LIMB_BITS);
+        for pair in shifted.chunks_exact(2) {
+            self.bitwise_lookup_chip
+                .request_range(pair[0] as u32, pair[1] as u32);
         }
 
         core_row.prev_data = record.prev_data.map(F::from_u8);

--- a/extensions/riscv/circuit/src/load_sign_extend/cuda.rs
+++ b/extensions/riscv/circuit/src/load_sign_extend/cuda.rs
@@ -2,14 +2,16 @@ use std::{mem::size_of, sync::Arc};
 
 use derive_new::new;
 use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
-use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
+};
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
 use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_instructions::riscv::RV64_REGISTER_NUM_LIMBS;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
-    adapters::{Rv64LoadStoreAdapterCols, Rv64LoadStoreAdapterRecord},
+    adapters::{Rv64LoadStoreAdapterCols, Rv64LoadStoreAdapterRecord, RV64_BYTE_BITS},
     cuda_abi::load_sign_extend_cuda::tracegen,
     LoadSignExtendCoreCols, LoadSignExtendCoreRecord,
 };
@@ -17,6 +19,7 @@ use crate::{
 #[derive(new)]
 pub struct Rv64LoadSignExtendChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV64_BYTE_BITS>>,
     pub pointer_max_bits: usize,
     pub timestamp_max_bits: usize,
 }
@@ -50,6 +53,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv64LoadSignExtendChipGpu {
                 &d_records,
                 self.pointer_max_bits,
                 &self.range_checker.count,
+                &self.bitwise_lookup.count,
                 self.timestamp_max_bits as u32,
                 device_ctx.stream.as_raw(),
             )

--- a/extensions/riscv/circuit/src/load_sign_extend/tests.rs
+++ b/extensions/riscv/circuit/src/load_sign_extend/tests.rs
@@ -2,12 +2,21 @@ use std::{array, borrow::BorrowMut, sync::Arc};
 
 use openvm_circuit::{
     arch::{
-        testing::{memory::gen_pointer, TestBuilder, TestChipHarness, VmChipTestBuilder},
+        testing::{
+            memory::gen_pointer, TestBuilder, TestChipHarness, VmChipTestBuilder,
+            BITWISE_OP_LOOKUP_BUS,
+        },
         Arena, ExecutionBridge, PreflightExecutor,
     },
     system::memory::{offline_checker::MemoryBridge, SharedMemoryHelper},
 };
-use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::{
+        BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+        SharedBitwiseOperationLookupChip,
+    },
+    var_range::VariableRangeCheckerChip,
+};
 use openvm_instructions::{
     instruction::Instruction,
     riscv::{RV64_BYTE_BITS, RV64_REGISTER_NUM_LIMBS},
@@ -33,8 +42,8 @@ use {
     },
     openvm_circuit::arch::{
         testing::{
-            default_var_range_checker_bus, dummy_range_checker, GpuChipTestBuilder,
-            GpuTestChipHarness,
+            default_bitwise_lookup_bus, default_var_range_checker_bus, dummy_range_checker,
+            GpuChipTestBuilder, GpuTestChipHarness,
         },
         EmptyAdapterCoreLayout,
     },
@@ -65,6 +74,7 @@ fn create_harness_fields(
     memory_bridge: MemoryBridge,
     execution_bridge: ExecutionBridge,
     range_checker_chip: Arc<VariableRangeCheckerChip>,
+    bitwise_chip: SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
     memory_helper: SharedMemoryHelper<F>,
     address_bits: usize,
 ) -> (
@@ -79,28 +89,45 @@ fn create_harness_fields(
             range_checker_chip.bus(),
             address_bits,
         ),
-        LoadSignExtendCoreAir::new(range_checker_chip.bus()),
+        LoadSignExtendCoreAir::new(range_checker_chip.bus(), bitwise_chip.bus()),
     );
     let executor = Rv64LoadSignExtendExecutor::new(Rv64LoadStoreAdapterExecutor::new(address_bits));
     let chip = Rv64LoadSignExtendChip::<F>::new(
         LoadSignExtendFiller::new(
             Rv64LoadStoreAdapterFiller::new(address_bits, range_checker_chip.clone()),
             range_checker_chip,
+            bitwise_chip,
         ),
         memory_helper,
     );
     (air, executor, chip)
 }
 
-fn create_test_chip(tester: &mut VmChipTestBuilder<F>) -> Harness {
+fn create_test_chip(
+    tester: &mut VmChipTestBuilder<F>,
+) -> (
+    Harness,
+    (
+        BitwiseOperationLookupAir<RV64_BYTE_BITS>,
+        SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+    ),
+) {
+    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
+    let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        bitwise_bus,
+    ));
     let (air, executor, chip) = create_harness_fields(
         tester.memory_bridge(),
         tester.execution_bridge(),
         tester.range_checker(),
+        bitwise_chip.clone(),
         tester.memory_helper(),
         tester.address_bits(),
     );
-    Harness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
+    (
+        Harness::with_capacity(executor, air, chip, MAX_INS_CAPACITY),
+        (bitwise_chip.air, bitwise_chip),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -196,7 +223,7 @@ fn rand_load_sign_extend_test(opcode: Rv64LoadStoreOpcode, num_ops: usize) {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
 
-    let mut harness = create_test_chip(&mut tester);
+    let (mut harness, bitwise) = create_test_chip(&mut tester);
     for _ in 0..num_ops {
         set_and_execute(
             &mut tester,
@@ -211,7 +238,11 @@ fn rand_load_sign_extend_test(opcode: Rv64LoadStoreOpcode, num_ops: usize) {
         );
     }
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -219,7 +250,7 @@ fn rand_load_sign_extend_test(opcode: Rv64LoadStoreOpcode, num_ops: usize) {
 fn positive_loadb_shift7_test() {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let mut harness = create_test_chip(&mut tester);
+    let (mut harness, bitwise) = create_test_chip(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -233,7 +264,11 @@ fn positive_loadb_shift7_test() {
         Some(0),
     );
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -241,7 +276,7 @@ fn positive_loadb_shift7_test() {
 fn positive_loadh_shift6_test() {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let mut harness = create_test_chip(&mut tester);
+    let (mut harness, bitwise) = create_test_chip(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -255,7 +290,11 @@ fn positive_loadh_shift6_test() {
         Some(0),
     );
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -263,7 +302,7 @@ fn positive_loadh_shift6_test() {
 fn positive_loadw_shift4_test() {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let mut harness = create_test_chip(&mut tester);
+    let (mut harness, bitwise) = create_test_chip(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -277,7 +316,11 @@ fn positive_loadw_shift4_test() {
         Some(0),
     );
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -307,7 +350,7 @@ fn run_negative_load_sign_extend_test(
 ) {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
-    let mut harness = create_test_chip(&mut tester);
+    let (mut harness, bitwise) = create_test_chip(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -354,6 +397,7 @@ fn run_negative_load_sign_extend_test(
     let tester = tester
         .build()
         .load_and_prank_trace(harness, modify_trace)
+        .load_periphery(bitwise)
         .finalize();
     tester
         .simple_test()
@@ -602,16 +646,21 @@ type GpuHarness = GpuTestChipHarness<
 #[cfg(feature = "cuda")]
 fn create_cuda_harness(tester: &GpuChipTestBuilder) -> GpuHarness {
     let dummy_range_checker_chip = dummy_range_checker(default_var_range_checker_bus());
+    let dummy_bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        default_bitwise_lookup_bus(),
+    ));
 
     let (air, executor, cpu_chip) = create_harness_fields(
         tester.memory_bridge(),
         tester.execution_bridge(),
         dummy_range_checker_chip,
+        dummy_bitwise_chip,
         tester.dummy_memory_helper(),
         tester.address_bits(),
     );
     let gpu_chip = Rv64LoadSignExtendChipGpu::new(
         tester.range_checker(),
+        tester.bitwise_op_lookup(),
         tester.address_bits(),
         tester.timestamp_max_bits(),
     );
@@ -625,7 +674,8 @@ fn create_cuda_harness(tester: &GpuChipTestBuilder) -> GpuHarness {
 #[test_case(LOADW, 100)]
 fn test_cuda_rand_load_sign_extend_tracegen(opcode: Rv64LoadStoreOpcode, num_ops: usize) {
     let mut rng = create_seeded_rng();
-    let mut tester = GpuChipTestBuilder::default();
+    let mut tester =
+        GpuChipTestBuilder::default().with_bitwise_op_lookup(default_bitwise_lookup_bus());
 
     let mut harness = create_cuda_harness(&tester);
     for _ in 0..num_ops {

--- a/extensions/riscv/circuit/src/loadstore/core.rs
+++ b/extensions/riscv/circuit/src/loadstore/core.rs
@@ -9,8 +9,8 @@ use openvm_circuit::{
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::{
+    bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     encoder::Encoder,
-    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
     AlignedBorrow, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
     SubAir,
 };
@@ -216,15 +216,16 @@ pub struct LoadStoreCoreCols<T, const NUM_CELLS: usize> {
 pub struct LoadStoreCoreAir<const NUM_CELLS: usize> {
     pub offset: usize,
     encoder: Encoder,
-    range_bus: VariableRangeCheckerBus,
+    bitwise_lookup_bus: BitwiseOperationLookupBus,
 }
 
 impl<const NUM_CELLS: usize> LoadStoreCoreAir<NUM_CELLS> {
-    pub fn new(offset: usize, range_bus: VariableRangeCheckerBus) -> Self {
+    pub fn new(offset: usize, bitwise_lookup_bus: BitwiseOperationLookupBus) -> Self {
+        assert!(NUM_CELLS.is_multiple_of(2));
         Self {
             offset,
             encoder: loadstore_encoder(),
-            range_bus,
+            bitwise_lookup_bus,
         }
     }
 }
@@ -278,14 +279,14 @@ where
         builder.assert_eq(is_valid, expected_is_valid.clone());
         builder.assert_eq(is_load, expected_is_load.clone());
 
-        for cell in read_data {
-            self.range_bus
-                .range_check(cell, 8)
+        for pair in read_data.chunks_exact(2) {
+            self.bitwise_lookup_bus
+                .send_range(pair[0], pair[1])
                 .eval(builder, is_valid.into());
         }
-        for cell in prev_data {
-            self.range_bus
-                .range_check(cell, 8)
+        for pair in prev_data.chunks_exact(2) {
+            self.bitwise_lookup_bus
+                .send_range(pair[0], pair[1])
                 .eval(builder, is_valid.into());
         }
 
@@ -382,20 +383,21 @@ pub struct LoadStoreFiller<
     adapter: A,
     pub offset: usize,
     encoder: Encoder,
-    range_checker_chip: SharedVariableRangeCheckerChip,
+    bitwise_lookup_chip: SharedBitwiseOperationLookupChip<8>,
 }
 
 impl<A, const NUM_CELLS: usize> LoadStoreFiller<A, NUM_CELLS> {
     pub fn new(
         adapter: A,
         offset: usize,
-        range_checker_chip: SharedVariableRangeCheckerChip,
+        bitwise_lookup_chip: SharedBitwiseOperationLookupChip<8>,
     ) -> Self {
+        assert!(NUM_CELLS.is_multiple_of(2));
         Self {
             adapter,
             offset,
             encoder: loadstore_encoder(),
-            range_checker_chip,
+            bitwise_lookup_chip,
         }
     }
 }
@@ -478,11 +480,12 @@ where
         let shift = record.shift_amount as usize;
         let write_data = run_write_data(opcode, record.read_data, record.prev_data, shift);
 
-        for cell in record.read_data {
-            self.range_checker_chip.add_count(cell as u32, 8);
+        for pair in record.read_data.chunks_exact(2) {
+            self.bitwise_lookup_chip
+                .request_range(pair[0] as u32, pair[1] as u32);
         }
-        for cell in record.prev_data {
-            self.range_checker_chip.add_count(cell, 8);
+        for pair in record.prev_data.chunks_exact(2) {
+            self.bitwise_lookup_chip.request_range(pair[0], pair[1]);
         }
 
         core_row.write_data = write_data.map(F::from_u32);

--- a/extensions/riscv/circuit/src/loadstore/cuda.rs
+++ b/extensions/riscv/circuit/src/loadstore/cuda.rs
@@ -2,14 +2,16 @@ use std::{mem::size_of, sync::Arc};
 
 use derive_new::new;
 use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
-use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
+};
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
 use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_instructions::riscv::RV64_REGISTER_NUM_LIMBS;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
-    adapters::{Rv64LoadStoreAdapterCols, Rv64LoadStoreAdapterRecord},
+    adapters::{Rv64LoadStoreAdapterCols, Rv64LoadStoreAdapterRecord, RV64_BYTE_BITS},
     cuda_abi::loadstore_cuda::tracegen,
     LoadStoreCoreCols, LoadStoreCoreRecord,
 };
@@ -17,6 +19,7 @@ use crate::{
 #[derive(new)]
 pub struct Rv64LoadStoreChipGpu {
     pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV64_BYTE_BITS>>,
     pub pointer_max_bits: usize,
     pub timestamp_max_bits: usize,
 }
@@ -50,6 +53,7 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv64LoadStoreChipGpu {
                 &d_records,
                 self.pointer_max_bits,
                 &self.range_checker.count,
+                &self.bitwise_lookup.count,
                 self.timestamp_max_bits as u32,
                 device_ctx.stream.as_raw(),
             )

--- a/extensions/riscv/circuit/src/loadstore/tests.rs
+++ b/extensions/riscv/circuit/src/loadstore/tests.rs
@@ -2,14 +2,20 @@ use std::{array, borrow::BorrowMut, sync::Arc};
 
 use openvm_circuit::{
     arch::{
-        testing::{TestBuilder, TestChipHarness, VmChipTestBuilder},
+        testing::{TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
         Arena, ExecutionBridge, MemoryConfig, PreflightExecutor,
     },
     system::memory::{
         merkle::public_values::PUBLIC_VALUES_AS, offline_checker::MemoryBridge, SharedMemoryHelper,
     },
 };
-use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::{
+        BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+        SharedBitwiseOperationLookupChip,
+    },
+    var_range::VariableRangeCheckerChip,
+};
 #[cfg(feature = "cuda")]
 use openvm_instructions::riscv::RV64_MEMORY_AS;
 use openvm_instructions::{
@@ -33,8 +39,8 @@ use {
     crate::{adapters::Rv64LoadStoreAdapterRecord, LoadStoreCoreRecord, Rv64LoadStoreChipGpu},
     openvm_circuit::arch::{
         testing::{
-            default_var_range_checker_bus, dummy_range_checker, GpuChipTestBuilder,
-            GpuTestChipHarness,
+            default_bitwise_lookup_bus, default_var_range_checker_bus, dummy_range_checker,
+            GpuChipTestBuilder, GpuTestChipHarness,
         },
         EmptyAdapterCoreLayout,
     },
@@ -63,6 +69,7 @@ fn create_harness_fields(
     memory_bridge: MemoryBridge,
     execution_bridge: ExecutionBridge,
     range_checker_chip: Arc<VariableRangeCheckerChip>,
+    bitwise_chip: SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
     memory_helper: SharedMemoryHelper<F>,
     address_bits: usize,
 ) -> (
@@ -77,7 +84,7 @@ fn create_harness_fields(
             range_checker_chip.bus(),
             address_bits,
         ),
-        LoadStoreCoreAir::new(Rv64LoadStoreOpcode::CLASS_OFFSET, range_checker_chip.bus()),
+        LoadStoreCoreAir::new(Rv64LoadStoreOpcode::CLASS_OFFSET, bitwise_chip.bus()),
     );
     let executor = Rv64LoadStoreExecutor::new(
         Rv64LoadStoreAdapterExecutor::new(address_bits),
@@ -87,22 +94,38 @@ fn create_harness_fields(
         LoadStoreFiller::new(
             Rv64LoadStoreAdapterFiller::new(address_bits, range_checker_chip.clone()),
             Rv64LoadStoreOpcode::CLASS_OFFSET,
-            range_checker_chip,
+            bitwise_chip,
         ),
         memory_helper,
     );
     (air, executor, chip)
 }
 
-fn create_harness(tester: &mut VmChipTestBuilder<F>) -> Harness {
+fn create_harness(
+    tester: &mut VmChipTestBuilder<F>,
+) -> (
+    Harness,
+    (
+        BitwiseOperationLookupAir<RV64_BYTE_BITS>,
+        SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+    ),
+) {
+    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
+    let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        bitwise_bus,
+    ));
     let (air, executor, chip) = create_harness_fields(
         tester.memory_bridge(),
         tester.execution_bridge(),
         tester.range_checker(),
+        bitwise_chip.clone(),
         tester.memory_helper(),
         tester.address_bits(),
     );
-    Harness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
+    (
+        Harness::with_capacity(executor, air, chip, MAX_INS_CAPACITY),
+        (bitwise_chip.air, bitwise_chip),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -242,7 +265,7 @@ fn rand_loadstore_test(opcode: Rv64LoadStoreOpcode, num_ops: usize) {
         mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     }
     let mut tester = VmChipTestBuilder::from_config(mem_config);
-    let mut harness = create_harness(&mut tester);
+    let (mut harness, bitwise) = create_harness(&mut tester);
 
     for _ in 0..num_ops {
         set_and_execute(
@@ -258,7 +281,11 @@ fn rand_loadstore_test(opcode: Rv64LoadStoreOpcode, num_ops: usize) {
         );
     }
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -268,7 +295,7 @@ fn positive_loadwu_shift4_test() {
     let mut mem_config = MemoryConfig::default();
     mem_config.addr_spaces[RV64_REGISTER_AS as usize].num_cells = 1 << 29;
     let mut tester = VmChipTestBuilder::from_config(mem_config);
-    let mut harness = create_harness(&mut tester);
+    let (mut harness, bitwise) = create_harness(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -282,7 +309,11 @@ fn positive_loadwu_shift4_test() {
         Some(2),
     );
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -292,7 +323,7 @@ fn positive_loadhu_shift6_test() {
     let mut mem_config = MemoryConfig::default();
     mem_config.addr_spaces[RV64_REGISTER_AS as usize].num_cells = 1 << 29;
     let mut tester = VmChipTestBuilder::from_config(mem_config);
-    let mut harness = create_harness(&mut tester);
+    let (mut harness, bitwise) = create_harness(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -306,7 +337,11 @@ fn positive_loadhu_shift6_test() {
         Some(2),
     );
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -317,7 +352,7 @@ fn positive_storew_public_values_test() {
     mem_config.addr_spaces[RV64_REGISTER_AS as usize].num_cells = 1 << 29;
     mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     let mut tester = VmChipTestBuilder::from_config(mem_config);
-    let mut harness = create_harness(&mut tester);
+    let (mut harness, bitwise) = create_harness(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -331,7 +366,11 @@ fn positive_storew_public_values_test() {
         Some(3),
     );
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -344,7 +383,7 @@ fn positive_stored_native_test() {
     mem_config.addr_spaces[RV64_REGISTER_AS as usize].num_cells = 1 << 29;
     mem_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 29;
     let mut tester = VmChipTestBuilder::from_config(mem_config);
-    let mut harness = create_harness(&mut tester);
+    let (mut harness, bitwise) = create_harness(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -358,7 +397,11 @@ fn positive_stored_native_test() {
         Some(4),
     );
 
-    let tester = tester.build().load(harness).finalize();
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
     tester.simple_test().expect("Verification failed");
 }
 
@@ -394,7 +437,7 @@ fn run_negative_loadstore_test(
     mem_config.addr_spaces[RV64_REGISTER_AS as usize].num_cells = 1 << 29;
     mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 29;
     let mut tester = VmChipTestBuilder::from_config(mem_config);
-    let mut harness = create_harness(&mut tester);
+    let (mut harness, bitwise) = create_harness(&mut tester);
 
     set_and_execute(
         &mut tester,
@@ -446,6 +489,7 @@ fn run_negative_loadstore_test(
     let tester = tester
         .build()
         .load_and_prank_trace(harness, modify_trace)
+        .load_periphery(bitwise)
         .finalize();
     tester
         .simple_test()
@@ -794,16 +838,22 @@ type GpuHarness = GpuTestChipHarness<
 fn create_cuda_harness(tester: &GpuChipTestBuilder) -> GpuHarness {
     let range_bus = default_var_range_checker_bus();
     let dummy_range_checker_chip = dummy_range_checker(range_bus);
+    let bitwise_bus = default_bitwise_lookup_bus();
+    let dummy_bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        bitwise_bus,
+    ));
 
     let (air, executor, cpu_chip) = create_harness_fields(
         tester.memory_bridge(),
         tester.execution_bridge(),
         dummy_range_checker_chip,
+        dummy_bitwise_chip,
         tester.dummy_memory_helper(),
         tester.address_bits(),
     );
     let gpu_chip = Rv64LoadStoreChipGpu::new(
         tester.range_checker(),
+        tester.bitwise_op_lookup(),
         tester.address_bits(),
         tester.timestamp_max_bits(),
     );
@@ -832,7 +882,8 @@ fn test_cuda_rand_load_store_tracegen(opcode: Rv64LoadStoreOpcode, num_ops: usiz
         mem_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = 1 << 20;
         mem_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 20;
     }
-    let mut tester = GpuChipTestBuilder::new(mem_config, default_var_range_checker_bus());
+    let mut tester = GpuChipTestBuilder::new(mem_config, default_var_range_checker_bus())
+        .with_bitwise_op_lookup(default_bitwise_lookup_bus());
 
     let mut harness = create_cuda_harness(&tester);
     for _ in 0..num_ops {


### PR DESCRIPTION
## Summary

Reduce RV64 loadstore and load-sign-extend interaction counts by using the existing 8-bit `BitwiseOperationLookup` for byte-limb range checks. These checks are still required because the u16 memory bus only bounds packed u16 cells, but pairing bytes through the bitwise lookup matches the older byte-oriented pattern and avoids one interaction per checked byte.

## Changes

- Switch `LoadStoreCoreAir` read/previous byte checks from per-byte `VariableRangeChecker` lookups to paired bitwise range lookups.
- Switch `LoadSignExtendCoreAir` shifted-read byte checks to paired bitwise range lookups while keeping the separate sign-bit tail range check.
- Thread the bitwise lookup chip/bus through CPU and CUDA loadstore/load-sign-extend wiring.
- Update CPU and CUDA tests to include the bitwise lookup periphery.

[reth benchmark comparison](https://github.com/axiom-crypto/openvm-eth/actions/runs/26968844374#summary-79578787595)
144 -> 120 segments 🤯 
