### PR TITLE
chore(v2.1-rvr): enable lto for macos

### DIFF
--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -49,8 +49,8 @@ pub fn default_compiler_command() -> String {
     "clang".to_string()
 }
 
-/// Check that `compiler` resolves to clang.
-pub fn ensure_clang_compiler(compiler: &str) -> Result<(), String> {
+/// Check that `compiler` resolves to clang; returns its `--version` output.
+pub fn ensure_clang_compiler(compiler: &str) -> Result<String, String> {
     let output = Command::new(compiler)
         .arg("--version")
         .output()
@@ -64,13 +64,20 @@ pub fn ensure_clang_compiler(compiler: &str) -> Result<(), String> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let version = format!("{stdout}\n{stderr}");
-    if !output.status.success() || !version.to_ascii_lowercase().contains("clang") {
-        return Err(format!(
+    if output.status.success() && version.to_ascii_lowercase().contains("clang") {
+        Ok(version)
+    } else {
+        Err(format!(
             "RVR C compilation requires clang, but selected compiler '{compiler}' is not clang; \
              install clang-22 or set RVR_CC=clang"
-        ));
+        ))
     }
+}
 
+/// Check that `compiler` can compile the generated RVR C project: LLVM (not
+/// Apple) clang >= [`MIN_CLANG_MAJOR`]. Stricter than [`ensure_clang_compiler`].
+pub fn ensure_rvr_clang_compiler(compiler: &str) -> Result<(), String> {
+    let version = ensure_clang_compiler(compiler)?;
     // Unparsable versions pass; only reject known-bad configurations.
     let Some((is_apple, major)) = parse_clang_version_output(&version) else {
         return Ok(());

--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -12,6 +12,7 @@ pub const DEFAULT_CLANG_COMMAND: &str = "clang-22";
 pub const MIN_CLANG_MAJOR: u32 = 19;
 
 /// Keg-only Homebrew LLVM locations (not on PATH by default).
+#[cfg(target_os = "macos")]
 const HOMEBREW_LLVM_BIN_DIRS: &[&str] = &["/opt/homebrew/opt/llvm/bin", "/usr/local/opt/llvm/bin"];
 
 /// Select the C compiler for RVR native code.
@@ -33,6 +34,7 @@ pub fn default_compiler_command() -> String {
     }
     // Probe Homebrew LLVM before falling back to plain `clang`, which on
     // macOS is Apple clang and fails `ensure_clang_compiler`.
+    #[cfg(target_os = "macos")]
     for dir in HOMEBREW_LLVM_BIN_DIRS {
         for name in [DEFAULT_CLANG_COMMAND, "clang"] {
             let candidate = format!("{dir}/{name}");

--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -8,6 +8,12 @@ use std::{
 /// Default clang command used for RVR native C builds.
 pub const DEFAULT_CLANG_COMMAND: &str = "clang-22";
 
+/// Minimum supported LLVM clang major version (c23, preserve_none on AArch64).
+pub const MIN_CLANG_MAJOR: u32 = 19;
+
+/// Keg-only Homebrew LLVM locations (not on PATH by default).
+const HOMEBREW_LLVM_BIN_DIRS: &[&str] = &["/opt/homebrew/opt/llvm/bin", "/usr/local/opt/llvm/bin"];
+
 /// Select the C compiler for RVR native code.
 ///
 /// `RVR_CC` is the explicit override and is returned even if the command name
@@ -24,6 +30,16 @@ pub fn default_compiler_command() -> String {
     }
     if command_exists(DEFAULT_CLANG_COMMAND) {
         return DEFAULT_CLANG_COMMAND.to_string();
+    }
+    // Probe Homebrew LLVM before falling back to plain `clang`, which on
+    // macOS is Apple clang and fails `ensure_clang_compiler`.
+    for dir in HOMEBREW_LLVM_BIN_DIRS {
+        for name in [DEFAULT_CLANG_COMMAND, "clang"] {
+            let candidate = format!("{dir}/{name}");
+            if command_exists(&candidate) {
+                return candidate;
+            }
+        }
     }
     if let Some(compiler) = env_command("CC").filter(|compiler| is_clang_command(compiler)) {
         return compiler;
@@ -46,14 +62,47 @@ pub fn ensure_clang_compiler(compiler: &str) -> Result<(), String> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let version = format!("{stdout}\n{stderr}");
-    if output.status.success() && version.to_ascii_lowercase().contains("clang") {
-        Ok(())
-    } else {
-        Err(format!(
+    if !output.status.success() || !version.to_ascii_lowercase().contains("clang") {
+        return Err(format!(
             "RVR C compilation requires clang, but selected compiler '{compiler}' is not clang; \
              install clang-22 or set RVR_CC=clang"
-        ))
+        ));
     }
+
+    // Unparsable versions pass; only reject known-bad configurations.
+    let Some((is_apple, major)) = parse_clang_version_output(&version) else {
+        return Ok(());
+    };
+    if is_apple {
+        return Err(format!(
+            "selected compiler '{compiler}' is Apple clang {major}, whose LTO bitcode is \
+             incompatible with the lld linker used for RVR builds; install LLVM clang \
+             (e.g. `brew install llvm`) and put clang-22 on PATH, or set \
+             RVR_CC=$(brew --prefix llvm)/bin/clang"
+        ));
+    }
+    if major < MIN_CLANG_MAJOR {
+        return Err(format!(
+            "selected compiler '{compiler}' is clang {major}, but RVR requires \
+             clang >= {MIN_CLANG_MAJOR} (c23, preserve_none); install a newer LLVM \
+             (e.g. clang-22) or set RVR_CC to a newer clang"
+        ));
+    }
+    Ok(())
+}
+
+/// Parse `clang --version` output into `(is_apple, major_version)`.
+/// Returns `None` if no `clang version <N>` marker is found.
+fn parse_clang_version_output(version: &str) -> Option<(bool, u32)> {
+    let lower = version.to_ascii_lowercase();
+    let is_apple = lower.contains("apple clang");
+    let rest = lower.split("clang version ").nth(1)?;
+    let major = rest
+        .split(|c: char| !c.is_ascii_digit())
+        .next()?
+        .parse()
+        .ok()?;
+    Some((is_apple, major))
 }
 
 pub fn command_exists(command: &str) -> bool {
@@ -146,7 +195,7 @@ fn is_executable_file(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{clang_version_suffix, is_clang_command};
+    use super::{clang_version_suffix, is_clang_command, parse_clang_version_output};
 
     #[test]
     fn detects_clang_command_names() {
@@ -170,5 +219,30 @@ mod tests {
         assert_eq!(clang_version_suffix("clang-22"), Some("-22"));
         assert_eq!(clang_version_suffix("/usr/bin/clang-18"), Some("-18"));
         assert_eq!(clang_version_suffix("gcc"), None);
+    }
+
+    #[test]
+    fn parses_clang_version_output() {
+        assert_eq!(
+            parse_clang_version_output(
+                "Apple clang version 17.0.0 (clang-1700.4.4.1)\nTarget: arm64-apple-darwin25.3.0"
+            ),
+            Some((true, 17))
+        );
+        assert_eq!(
+            parse_clang_version_output(
+                "Homebrew clang version 22.1.5\nTarget: arm64-apple-darwin25.3.0"
+            ),
+            Some((false, 22))
+        );
+        assert_eq!(
+            parse_clang_version_output("Ubuntu clang version 18.1.3 (1ubuntu1)"),
+            Some((false, 18))
+        );
+        assert_eq!(
+            parse_clang_version_output("clang version 19.1.0"),
+            Some((false, 19))
+        );
+        assert_eq!(parse_clang_version_output("gcc (GCC) 13.2.0"), None);
     }
 }

--- a/crates/rvr/rvr-openvm/src/toolchain.rs
+++ b/crates/rvr/rvr-openvm/src/toolchain.rs
@@ -3,6 +3,7 @@ use std::{fmt, process::Command};
 use rvr_openvm_build::{clang_version_suffix, is_clang_command};
 pub use rvr_openvm_build::{
     command_exists, default_compiler_command, ensure_clang_compiler, DEFAULT_CLANG_COMMAND,
+    MIN_CLANG_MAJOR,
 };
 
 /// C compiler to use for generated code.

--- a/crates/rvr/rvr-openvm/src/toolchain.rs
+++ b/crates/rvr/rvr-openvm/src/toolchain.rs
@@ -2,8 +2,8 @@ use std::{fmt, process::Command};
 
 use rvr_openvm_build::{clang_version_suffix, is_clang_command};
 pub use rvr_openvm_build::{
-    command_exists, default_compiler_command, ensure_clang_compiler, DEFAULT_CLANG_COMMAND,
-    MIN_CLANG_MAJOR,
+    command_exists, default_compiler_command, ensure_clang_compiler, ensure_rvr_clang_compiler,
+    DEFAULT_CLANG_COMMAND, MIN_CLANG_MAJOR,
 };
 
 /// C compiler to use for generated code.
@@ -126,7 +126,7 @@ impl RuntimeToolchain {
 
     pub fn check(self) -> Result<Self, RuntimeToolchainError> {
         let mut missing = Vec::new();
-        if let Err(message) = ensure_clang_compiler(&self.compiler) {
+        if let Err(message) = ensure_rvr_clang_compiler(&self.compiler) {
             missing.push(MissingTool {
                 role: "C compiler",
                 command: self.compiler.clone(),

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -359,9 +359,6 @@ fn compile_impl<F: PrimeField32>(
         }
     }
 
-    if cfg!(target_os = "macos") {
-        project.enable_lto = false;
-    }
     project.native_debug_info = opts.native_debug_info;
 
     let entry_point = exe.pc_start;

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -7,7 +7,7 @@
 //! adjustments for IO instructions are handled entirely in the generated C
 //! code; these callbacks are pure IO logic.
 
-use std::{collections::VecDeque, ffi::c_void, io::Write, mem::size_of};
+use std::{collections::VecDeque, ffi::c_void, io::Write};
 
 #[cfg(not(feature = "unprotected"))]
 use openvm_platform::memory::MEM_SIZE;


### PR DESCRIPTION
## Summary

Removes the unconditional `enable_lto = false` override for macOS in `crates/vm/src/arch/rvr/compile.rs`, and adds graceful compiler validation so unsupported clang setups fail with an actionable error instead of a linker crash.

## Why the disable existed

The macOS LTO disable protected against a toolchain mismatch: Apple clang's LTO bitcode fed to a mismatched `lld` crashes at link time (`LLVM ERROR: Unsupported stack probing method`). This was reproducible with the generated project's Makefile when `CC` falls back to Apple `cc`.

The rvr compile pipeline no longer hits this path: it resolves `CC` via `default_compiler_command()`, which requires clang and prefers a versioned LLVM clang (`clang-22`) matched with `lld`. With that pairing, thin LTO links cleanly on macOS.

## Changes

- Remove the macOS-only `enable_lto = false` override; `enable_lto: true` (the existing default) now applies on all platforms.
- `ensure_clang_compiler` parses `clang --version` and rejects:
  - Apple clang (LTO bitcode incompatible with `lld`), with a hint to `brew install llvm` or set `RVR_CC`.
  - LLVM clang older than `MIN_CLANG_MAJOR = 19` (needed for c23 and `preserve_none` on AArch64).
- `default_compiler_command()` now probes the keg-only Homebrew LLVM locations (`/opt/homebrew/opt/llvm/bin`, `/usr/local/opt/llvm/bin`) before falling back to plain `clang`, so macOS machines with `brew install llvm` resolve the right compiler without PATH changes.
