### PR TITLE
feat: add verify-stark deferral path prover constructor in SDK

### DIFF
--- a/crates/continuations/src/circuit/deferral/dummy.rs
+++ b/crates/continuations/src/circuit/deferral/dummy.rs
@@ -45,6 +45,7 @@ impl<AB: AirBuilder + AirBuilderWithPublicValues> Air<AB> for EmptyAirWithPvs {
             .map(|pv| (*pv).into())
             .collect::<Vec<AB::Expr>>();
         for pv in pvs {
+            // Trivial asserts to ensure pvs get placed in the DAG
             builder.assert_eq(pv.clone(), pv);
         }
     }

--- a/crates/continuations/src/circuit/deferral/dummy.rs
+++ b/crates/continuations/src/circuit/deferral/dummy.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use openvm_circuit_primitives::ColumnsAir;
+use openvm_stark_backend::{
+    keygen::types::MultiStarkVerifyingKey, p3_matrix::Matrix, AirRef, PartitionedBaseAir,
+    StarkEngine, SystemParams,
+};
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, BaseAirWithPublicValues};
+
+use super::DeferralCircuitPvs;
+use crate::SC;
+
+/// Minimal AIR with a single zero column and deferral-circuit public values.
+///
+/// This is used only as a cheap verifying-key seed for deferral path fixed-point derivation; it is
+/// not intended to be proven.
+pub(crate) struct EmptyAirWithPvs(pub(crate) usize);
+
+// No columns provided: this dummy AIR has a single anonymous column and no matching `Cols` struct.
+impl ColumnsAir for EmptyAirWithPvs {}
+
+impl<F> BaseAir<F> for EmptyAirWithPvs {
+    fn width(&self) -> usize {
+        1
+    }
+}
+
+impl<F> BaseAirWithPublicValues<F> for EmptyAirWithPvs {
+    fn num_public_values(&self) -> usize {
+        self.0
+    }
+}
+
+impl<F> PartitionedBaseAir<F> for EmptyAirWithPvs {}
+
+impl<AB: AirBuilder + AirBuilderWithPublicValues> Air<AB> for EmptyAirWithPvs {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.row_slice(0).unwrap();
+        builder.assert_zero(local[0].clone());
+
+        let pvs = builder
+            .public_values()
+            .iter()
+            .map(|pv| (*pv).into())
+            .collect::<Vec<AB::Expr>>();
+        for pv in pvs {
+            builder.assert_eq(pv.clone(), pv);
+        }
+    }
+}
+
+pub fn dummy_deferral_circuit_vk<E>(system_params: SystemParams) -> Arc<MultiStarkVerifyingKey<SC>>
+where
+    E: StarkEngine<SC = SC>,
+{
+    let engine = E::new(system_params);
+    let dummy_air = Arc::new(EmptyAirWithPvs(DeferralCircuitPvs::<u8>::width())) as AirRef<SC>;
+    Arc::new(engine.keygen(&[dummy_air]).1)
+}

--- a/crates/continuations/src/circuit/deferral/mod.rs
+++ b/crates/continuations/src/circuit/deferral/mod.rs
@@ -3,6 +3,7 @@ use openvm_recursion_circuit::prelude::DIGEST_SIZE;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 pub use openvm_verify_stark_host::deferral::DeferralMerkleProofs;
 
+pub mod dummy;
 pub mod hook;
 pub mod inner;
 

--- a/crates/continuations/src/tests/dummy.rs
+++ b/crates/continuations/src/tests/dummy.rs
@@ -1,53 +1,20 @@
 use std::{borrow::BorrowMut, sync::Arc};
 
 use eyre::Result;
-use openvm_circuit_primitives::ColumnsAir;
 use openvm_stark_backend::{
     keygen::types::{MultiStarkProvingKey, MultiStarkVerifyingKey},
     proof::Proof,
     prover::{AirProvingContext, DeviceDataTransporter, ProvingContext},
-    AirRef, PartitionedBaseAir, StarkEngine,
+    AirRef, StarkEngine,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     BabyBearPoseidon2CpuEngine, DuplexSponge, DIGEST_SIZE, F,
 };
-use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, BaseAirWithPublicValues};
 use p3_field::PrimeCharacteristicRing;
-use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use p3_matrix::dense::RowMajorMatrix;
 
+pub(in crate::tests) use crate::circuit::deferral::dummy::EmptyAirWithPvs;
 use crate::{circuit::deferral::DeferralCircuitPvs, SC};
-
-pub(in crate::tests) struct EmptyAirWithPvs(pub(in crate::tests) usize);
-// No columns provided: test dummy with a single anonymous column and no matching `Cols` struct.
-impl ColumnsAir for EmptyAirWithPvs {}
-
-impl<F> BaseAir<F> for EmptyAirWithPvs {
-    fn width(&self) -> usize {
-        1
-    }
-}
-impl<F> BaseAirWithPublicValues<F> for EmptyAirWithPvs {
-    fn num_public_values(&self) -> usize {
-        self.0
-    }
-}
-impl<F> PartitionedBaseAir<F> for EmptyAirWithPvs {}
-impl<AB: AirBuilder + AirBuilderWithPublicValues> Air<AB> for EmptyAirWithPvs {
-    fn eval(&self, builder: &mut AB) {
-        let main = builder.main();
-        let local = main.row_slice(0).unwrap();
-        builder.assert_zero(local[0].clone());
-
-        let pvs: Vec<AB::Expr> = builder
-            .public_values()
-            .iter()
-            .map(|pv| (*pv).into())
-            .collect();
-        for pv in pvs {
-            builder.assert_eq(pv.clone(), pv);
-        }
-    }
-}
 
 pub(in crate::tests) fn generate_dummy_def_proof(
     engine: &BabyBearPoseidon2CpuEngine<DuplexSponge>,

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -24,6 +24,7 @@ openvm-recursion-circuit = { workspace = true }
 openvm-deferral-circuit = { workspace = true }
 openvm-continuations = { workspace = true }
 openvm-verify-stark-host = { workspace = true }
+openvm-verify-stark-circuit = { workspace = true }
 openvm-static-verifier = { workspace = true, optional = true }
 halo2-base = { workspace = true, optional = true, features = ["halo2-axiom"] }
 p3-bn254 = { workspace = true, optional = true }
@@ -54,7 +55,6 @@ tokio = { workspace = true, features = ["rt", "sync"], optional = true }
 toml = { workspace = true }
 
 [dev-dependencies]
-openvm-verify-stark-circuit = { workspace = true }
 openvm-toolchain-tests = { workspace = true }
 
 [features]

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -42,6 +42,12 @@ enum AggSource {
     Pk(AggProvingKey),
 }
 
+#[allow(clippy::large_enum_variant)]
+enum DeferralSource {
+    Prover(DeferralProver),
+    PathProver(DeferralPathProver),
+}
+
 #[cfg(feature = "root-prover")]
 enum RootSource {
     Params(SystemParams),
@@ -73,7 +79,7 @@ where
     root_source: Option<RootSource>,
     agg_tree_config: Option<AggregationTreeConfig>,
     transpiler: Option<Transpiler<F>>,
-    deferral_prover: Option<DeferralProver>,
+    deferral_source: Option<DeferralSource>,
     #[cfg(feature = "evm-prove")]
     halo2_source: Option<Halo2Source>,
     #[cfg(feature = "evm-prove")]
@@ -335,7 +341,7 @@ where
                 root_source: _,
             agg_tree_config,
             transpiler,
-            deferral_prover,
+            deferral_source,
             #[cfg(feature = "evm-prove")]
                 halo2_source: _,
             #[cfg(feature = "evm-prove")]
@@ -352,8 +358,15 @@ where
             .map_err(|e| SdkError::Vm(e.into()))?;
         let agg_tree_config = agg_tree_config.unwrap_or_default();
 
-        let def_path_prover = deferral_prover
-            .map(|deferral_prover| Self::build_deferral_path_prover(&agg_config, deferral_prover));
+        let def_path_prover = match deferral_source {
+            Some(DeferralSource::Prover(deferral_prover)) => Some(
+                Self::build_deferral_path_prover(&agg_config, deferral_prover),
+            ),
+            Some(DeferralSource::PathProver(deferral_path_prover)) => {
+                Some(Arc::new(deferral_path_prover))
+            }
+            None => None,
+        };
         let def_hook_cached_commit = def_path_prover
             .as_ref()
             .map(|def_path_prover| def_path_prover.def_hook_cached_commit());
@@ -460,9 +473,23 @@ where
     /// VM config.
     pub fn deferral_prover(mut self, deferral_prover: DeferralProver) -> Self {
         Self::set_once(
-            &mut self.deferral_prover,
-            "deferral_prover",
-            deferral_prover,
+            &mut self.deferral_source,
+            "deferral_source",
+            DeferralSource::Prover(deferral_prover),
+        );
+        self
+    }
+
+    /// Enables deferrals in this SDK build using a pre-built [`DeferralPathProver`].
+    ///
+    /// This is mutually exclusive with [`Self::deferral_prover`]. Use this when the deferral
+    /// aggregation path has already been constructed, for example by
+    /// [`DeferralPathProver::verify_stark`].
+    pub fn deferral_path_prover(mut self, deferral_path_prover: DeferralPathProver) -> Self {
+        Self::set_once(
+            &mut self.deferral_source,
+            "deferral_source",
+            DeferralSource::PathProver(deferral_path_prover),
         );
         self
     }
@@ -515,7 +542,7 @@ where
             root_source: None,
             agg_tree_config: None,
             transpiler: None,
-            deferral_prover: None,
+            deferral_source: None,
             #[cfg(feature = "evm-prove")]
             halo2_source: None,
             #[cfg(feature = "evm-prove")]

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -140,14 +140,10 @@ where
         agg_config: &AggregationConfig,
         deferral_prover: DeferralProver,
     ) -> Arc<DeferralPathProver> {
-        let deferral_tree_config = AggregationTreeConfig {
-            num_children_leaf: 2,
-            num_children_internal: 2,
-        };
         let agg_prover = AggProver::new(
             deferral_prover.def_hook_prover.get_vk(),
             agg_config.clone(),
-            deferral_tree_config,
+            AggregationTreeConfig::deferral(),
             Some(deferral_prover.def_hook_prover.get_cached_commit()),
         );
         Arc::new(DeferralPathProver {

--- a/crates/sdk/src/config.rs
+++ b/crates/sdk/src/config.rs
@@ -90,6 +90,15 @@ impl Default for AggregationTreeConfig {
     }
 }
 
+impl AggregationTreeConfig {
+    pub const fn deferral() -> Self {
+        Self {
+            num_children_leaf: 2,
+            num_children_internal: 2,
+        }
+    }
+}
+
 /// Configuration for the Halo2 proving and wrapper keygen.
 #[cfg(feature = "evm-prove")]
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use eyre::Result;
 use openvm_circuit::arch::ContinuationVmProof;
 use openvm_continuations::{circuit::inner::ProofsType, prover::ChildVkKind};
-use openvm_recursion_circuit::prelude::Digest;
+use openvm_recursion_circuit::{prelude::Digest, utils::poseidon2_hash_slice};
 use openvm_stark_backend::{
     codec::{Decode, Encode},
     keygen::types::MultiStarkVerifyingKey,
@@ -136,6 +136,22 @@ impl AggProver {
             internal_recursive_prover,
             agg_tree_config,
         }
+    }
+
+    pub fn vm_or_hook_commit(&self) -> Digest {
+        let app_or_def_vk_commit = self.leaf_prover.get_vk_commit(false);
+        let leaf_vk_commit = self.internal_for_leaf_prover.get_vk_commit(false);
+        let internal_for_leaf_vk_commit = self.internal_recursive_prover.get_vk_commit(false);
+        let components = vec![
+            app_or_def_vk_commit.cached_commit,
+            app_or_def_vk_commit.vk_pre_hash,
+            leaf_vk_commit.cached_commit,
+            leaf_vk_commit.vk_pre_hash,
+            internal_for_leaf_vk_commit.cached_commit,
+            internal_for_leaf_vk_commit.vk_pre_hash,
+        ]
+        .into_flattened();
+        poseidon2_hash_slice(&components).0
     }
 
     pub fn prove_vm(

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -34,6 +34,7 @@ cfg_if::cfg_if! {
 
 mod circuit;
 mod merkle;
+mod verify_stark;
 pub use circuit::*;
 pub use merkle::*;
 

--- a/crates/sdk/src/prover/deferral/verify_stark.rs
+++ b/crates/sdk/src/prover/deferral/verify_stark.rs
@@ -1,0 +1,140 @@
+use std::sync::Arc;
+
+use openvm_circuit::system::memory::dimensions::MemoryDimensions;
+use openvm_continuations::{
+    circuit::deferral::dummy::dummy_deferral_circuit_vk, prover::DeferralCircuitProver,
+    CommitBytes, SC,
+};
+use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, proof::Proof, SystemParams};
+use openvm_stark_sdk::config::baby_bear_poseidon2::Digest;
+
+use crate::{
+    config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
+    prover::{AggProver, DeferralPathProver, DeferralProver},
+};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "cuda")] {
+        use openvm_verify_stark_circuit::prover::DeferredVerifyGpuProver as VerifyProver;
+        use openvm_verify_stark_circuit::prover::DeferredVerifyGpuCircuitProver as VerifyCircuitProver;
+        type E = openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
+    } else {
+        use openvm_verify_stark_circuit::prover::DeferredVerifyCpuProver as VerifyProver;
+        use openvm_verify_stark_circuit::prover::DeferredVerifyCpuCircuitProver as VerifyCircuitProver;
+        type E = openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2CpuEngine;
+    }
+}
+
+struct DeferralPathArtifacts {
+    def_hook_commit: Digest,
+    ir_vk: Arc<MultiStarkVerifyingKey<SC>>,
+    ir_cached_commit: CommitBytes,
+    agg_prover: Arc<AggProver>,
+}
+
+impl DeferralPathProver {
+    /// Derives the deferral path's fixed-point artifacts with a cheap dummy deferral circuit.
+    ///
+    /// These artifacts depend only on the aggregation and hook params, not on the concrete
+    /// deferral circuit whose proofs are later fed into the path.
+    fn fixed_point_artifacts(
+        agg_params: &AggregationSystemParams,
+        hook_params: &SystemParams,
+    ) -> DeferralPathArtifacts {
+        let dummy = DummyDefCircuitProver {
+            vk: dummy_deferral_circuit_vk::<E>(agg_params.internal.clone()),
+        };
+
+        let agg_config = AggregationConfig {
+            params: agg_params.clone(),
+        };
+        let deferral_prover = DeferralProver::new(dummy, agg_config.clone(), hook_params.clone());
+
+        let deferral_tree_config = AggregationTreeConfig {
+            num_children_leaf: 2,
+            num_children_internal: 2,
+        };
+        let agg_prover = Arc::new(AggProver::new(
+            deferral_prover.def_hook_prover.get_vk(),
+            agg_config,
+            deferral_tree_config,
+            Some(deferral_prover.def_hook_prover.get_cached_commit()),
+        ));
+
+        // The deferral-path aggregation tree's internal-recursive vk is a universal copy of the VM
+        // internal-recursive vk that a verify-stark circuit verifies.
+        let ir_vk = agg_prover.internal_recursive_prover.get_vk();
+        let ir_cached_commit = agg_prover
+            .internal_recursive_prover
+            .get_self_vk_pcs_data()
+            .expect("internal-recursive prover must expose its self vk pcs data")
+            .commitment
+            .into();
+        let path_prover = Self::new(Arc::new(deferral_prover), agg_prover.clone());
+
+        DeferralPathArtifacts {
+            def_hook_commit: path_prover.def_hook_commit(),
+            ir_vk,
+            ir_cached_commit,
+            agg_prover,
+        }
+    }
+
+    /// Builds a [`DeferralPathProver`] backed by the verify-stark circuit, configured so an SDK
+    /// with the given params can recursively verify the VM STARK proofs it produces, including its
+    /// own deferral-carrying proofs.
+    ///
+    /// The deferral-enabled internal-recursive vk and the self-referential `def_hook_commit` are
+    /// derived internally from a dummy deferral circuit.
+    pub fn verify_stark(
+        agg_params: &AggregationSystemParams,
+        hook_params: SystemParams,
+        memory_dimensions: MemoryDimensions,
+        num_user_pvs: usize,
+    ) -> Self {
+        let DeferralPathArtifacts {
+            def_hook_commit,
+            ir_vk,
+            ir_cached_commit,
+            agg_prover,
+        } = Self::fixed_point_artifacts(agg_params, &hook_params);
+
+        let deferred_verify_prover = VerifyProver::new::<E>(
+            ir_vk,
+            ir_cached_commit,
+            agg_params.internal.clone(),
+            memory_dimensions,
+            num_user_pvs,
+            Some(def_hook_commit),
+            0,
+        );
+        let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
+
+        let agg_config = AggregationConfig {
+            params: agg_params.clone(),
+        };
+        let deferral_prover = DeferralProver::new(verify_stark_prover, agg_config, hook_params);
+        Self::new(Arc::new(deferral_prover), agg_prover)
+    }
+}
+
+/// A dummy [`DeferralCircuitProver`] that only exposes a trivial verifying key. It exists solely to
+/// seed the deferral aggregation chain when deriving the deferral path fixed point; its `prove`
+/// method is never called.
+struct DummyDefCircuitProver {
+    vk: Arc<MultiStarkVerifyingKey<SC>>,
+}
+
+impl DeferralCircuitProver<SC> for DummyDefCircuitProver {
+    fn get_vk(&self) -> Arc<MultiStarkVerifyingKey<SC>> {
+        self.vk.clone()
+    }
+
+    fn prove(&self, _input_bytes: &[u8]) -> Proof<SC> {
+        unreachable!("DummyDefCircuitProver is only used to derive deferral path artifacts")
+    }
+
+    fn get_def_idx(&self) -> usize {
+        0
+    }
+}

--- a/crates/sdk/src/prover/deferral/verify_stark.rs
+++ b/crates/sdk/src/prover/deferral/verify_stark.rs
@@ -2,11 +2,9 @@ use std::sync::Arc;
 
 use openvm_circuit::system::memory::dimensions::MemoryDimensions;
 use openvm_continuations::{
-    circuit::deferral::dummy::dummy_deferral_circuit_vk, prover::DeferralCircuitProver,
-    CommitBytes, SC,
+    circuit::deferral::dummy::dummy_deferral_circuit_vk, prover::DeferralCircuitProver, SC,
 };
 use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, proof::Proof, SystemParams};
-use openvm_stark_sdk::config::baby_bear_poseidon2::Digest;
 
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
@@ -25,61 +23,7 @@ cfg_if::cfg_if! {
     }
 }
 
-struct DeferralPathArtifacts {
-    def_hook_commit: Digest,
-    ir_vk: Arc<MultiStarkVerifyingKey<SC>>,
-    ir_cached_commit: CommitBytes,
-    agg_prover: Arc<AggProver>,
-}
-
 impl DeferralPathProver {
-    /// Derives the deferral path's fixed-point artifacts with a cheap dummy deferral circuit.
-    ///
-    /// These artifacts depend only on the aggregation and hook params, not on the concrete
-    /// deferral circuit whose proofs are later fed into the path.
-    fn fixed_point_artifacts(
-        agg_params: &AggregationSystemParams,
-        hook_params: &SystemParams,
-    ) -> DeferralPathArtifacts {
-        let dummy = DummyDefCircuitProver {
-            vk: dummy_deferral_circuit_vk::<E>(agg_params.internal.clone()),
-        };
-
-        let agg_config = AggregationConfig {
-            params: agg_params.clone(),
-        };
-        let deferral_prover = DeferralProver::new(dummy, agg_config.clone(), hook_params.clone());
-
-        let deferral_tree_config = AggregationTreeConfig {
-            num_children_leaf: 2,
-            num_children_internal: 2,
-        };
-        let agg_prover = Arc::new(AggProver::new(
-            deferral_prover.def_hook_prover.get_vk(),
-            agg_config,
-            deferral_tree_config,
-            Some(deferral_prover.def_hook_prover.get_cached_commit()),
-        ));
-
-        // The deferral-path aggregation tree's internal-recursive vk is a universal copy of the VM
-        // internal-recursive vk that a verify-stark circuit verifies.
-        let ir_vk = agg_prover.internal_recursive_prover.get_vk();
-        let ir_cached_commit = agg_prover
-            .internal_recursive_prover
-            .get_self_vk_pcs_data()
-            .expect("internal-recursive prover must expose its self vk pcs data")
-            .commitment
-            .into();
-        let path_prover = Self::new(Arc::new(deferral_prover), agg_prover.clone());
-
-        DeferralPathArtifacts {
-            def_hook_commit: path_prover.def_hook_commit(),
-            ir_vk,
-            ir_cached_commit,
-            agg_prover,
-        }
-    }
-
     /// Builds a [`DeferralPathProver`] backed by the verify-stark circuit, configured so an SDK
     /// with the given params can recursively verify the VM STARK proofs it produces, including its
     /// own deferral-carrying proofs.
@@ -92,13 +36,38 @@ impl DeferralPathProver {
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
     ) -> Self {
-        let DeferralPathArtifacts {
-            def_hook_commit,
-            ir_vk,
-            ir_cached_commit,
-            agg_prover,
-        } = Self::fixed_point_artifacts(agg_params, &hook_params);
+        // Derive the deferral path's fixed-point artifacts with a cheap dummy deferral circuit.
+        let dummy = DummyDefCircuitProver {
+            vk: dummy_deferral_circuit_vk::<E>(agg_params.internal.clone()),
+        };
+        let agg_config = AggregationConfig {
+            params: agg_params.clone(),
+        };
+        let dummy_deferral_prover =
+            DeferralProver::new(dummy, agg_config.clone(), hook_params.clone());
 
+        // Construct the deferral-path AggProver, which can aggregate hook proofs from both the
+        // dummy DeferralProver above and the verify-stark one below.
+        let agg_prover = Arc::new(AggProver::new(
+            dummy_deferral_prover.def_hook_prover.get_vk(),
+            agg_config.clone(),
+            AggregationTreeConfig::deferral(),
+            Some(dummy_deferral_prover.def_hook_prover.get_cached_commit()),
+        ));
+
+        // The deferral-path aggregation tree's internal-recursive vk is a universal copy of the VM
+        // internal-recursive vk that a verify-stark circuit verifies.
+        let ir_vk = agg_prover.internal_recursive_prover.get_vk();
+        let ir_cached_commit = agg_prover
+            .internal_recursive_prover
+            .get_self_vk_pcs_data()
+            .expect("internal-recursive prover must expose its self vk pcs data")
+            .commitment
+            .into();
+        let def_hook_commit = agg_prover.vm_or_hook_commit();
+
+        // Construct the verify-stark DeferralProver, which should have the same hook vk and cached
+        // commit as the dummy one.
         let deferred_verify_prover = VerifyProver::new::<E>(
             ir_vk,
             ir_cached_commit,
@@ -109,11 +78,18 @@ impl DeferralPathProver {
             0,
         );
         let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
-
-        let agg_config = AggregationConfig {
-            params: agg_params.clone(),
-        };
         let deferral_prover = DeferralProver::new(verify_stark_prover, agg_config, hook_params);
+
+        assert_eq!(
+            deferral_prover.def_hook_prover.get_vk().pre_hash,
+            dummy_deferral_prover.def_hook_prover.get_vk().pre_hash
+        );
+        assert_eq!(
+            deferral_prover.def_hook_prover.get_cached_commit(),
+            dummy_deferral_prover.def_hook_prover.get_cached_commit()
+        );
+
+        // Return the deferral-enabled verify-stark DeferralPathProver.
         Self::new(Arc::new(deferral_prover), agg_prover)
     }
 }

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -8,7 +8,6 @@ use openvm_circuit::{
     },
     system::memory::merkle::MerkleTree,
 };
-use openvm_recursion_circuit::utils::poseidon2_hash_slice;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, Val};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{Digest, F};
 use openvm_verify_stark_host::{
@@ -181,25 +180,7 @@ where
     }
 
     pub fn app_vm_commit(&self) -> Digest {
-        let app_vk_commit = self.agg_prover.leaf_prover.get_vk_commit(false);
-        let leaf_vk_commit = self
-            .agg_prover
-            .internal_for_leaf_prover
-            .get_vk_commit(false);
-        let internal_for_leaf_vk_commit = self
-            .agg_prover
-            .internal_recursive_prover
-            .get_vk_commit(false);
-        let components = vec![
-            app_vk_commit.cached_commit,
-            app_vk_commit.vk_pre_hash,
-            leaf_vk_commit.cached_commit,
-            leaf_vk_commit.vk_pre_hash,
-            internal_for_leaf_vk_commit.cached_commit,
-            internal_for_leaf_vk_commit.vk_pre_hash,
-        ]
-        .into_flattened();
-        poseidon2_hash_slice(&components).0
+        self.agg_prover.vm_or_hook_commit()
     }
 }
 
@@ -209,24 +190,6 @@ impl DeferralPathProver {
     }
 
     pub fn def_hook_commit(&self) -> Digest {
-        let def_vk_commit = self.agg_prover.leaf_prover.get_vk_commit(false);
-        let leaf_vk_commit = self
-            .agg_prover
-            .internal_for_leaf_prover
-            .get_vk_commit(false);
-        let internal_for_leaf_vk_commit = self
-            .agg_prover
-            .internal_recursive_prover
-            .get_vk_commit(false);
-        let components = vec![
-            def_vk_commit.cached_commit,
-            def_vk_commit.vk_pre_hash,
-            leaf_vk_commit.cached_commit,
-            leaf_vk_commit.vk_pre_hash,
-            internal_for_leaf_vk_commit.cached_commit,
-            internal_for_leaf_vk_commit.vk_pre_hash,
-        ]
-        .into_flattened();
-        poseidon2_hash_slice(&components).0
+        self.agg_prover.vm_or_hook_commit()
     }
 }

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -24,7 +24,7 @@ use openvm_verify_stark_host::{
 
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AppConfig, DEFAULT_APP_L_SKIP},
-    prover::{DeferralProof, DeferralProver},
+    prover::{DeferralPathProver, DeferralProof, DeferralProver},
     DeferralInput, Sdk, StdIn,
 };
 
@@ -115,6 +115,62 @@ fn make_deferral_enabled_sdk(
         .build()?)
 }
 
+fn make_verify_stark_path_sdk(
+    app_params: SystemParams,
+    agg_params: AggregationSystemParams,
+) -> Result<Sdk> {
+    let mut vm_config = openvm_sdk_config::SdkVmConfig::riscv32();
+    vm_config.system.config.memory_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 25;
+    let memory_dimensions = vm_config.system.config.memory_config.memory_dimensions();
+    let num_user_pvs = vm_config.system.config.num_public_values;
+
+    let deferral_path_prover = DeferralPathProver::verify_stark(
+        &agg_params,
+        hook_params_with_100_bits_security(),
+        memory_dimensions,
+        num_user_pvs,
+    );
+    let deferral_ext = deferral_path_prover
+        .deferral_prover
+        .make_extension(vec![Arc::new(DeferralFn::new(verify_stark_deferral_fn))]);
+    vm_config.deferral = Some(deferral_ext);
+
+    Ok(Sdk::builder()
+        .app_config(AppConfig::new(vm_config, app_params))
+        .agg_params(agg_params)
+        .deferral_path_prover(deferral_path_prover)
+        .build()?)
+}
+
+fn make_verify_stark_inputs(
+    child_sdk: &Sdk,
+    child_proof: &VmStarkProof,
+    child_baseline: VerificationBaseline,
+) -> Result<(StdIn, DeferralInput)> {
+    let child_vk = VmStarkVerifyingKey {
+        mvk: child_sdk.agg_vk().as_ref().clone(),
+        baseline: child_baseline,
+    };
+
+    let raw_results = get_raw_deferral_results(&child_vk, from_ref(child_proof))?;
+    assert_eq!(raw_results.len(), 1);
+    let input_commit: [u8; 32] = raw_results[0].input.clone().try_into().unwrap();
+    let output_raw = &raw_results[0].output_raw;
+    let app_exe_commit: [u8; 32] = output_raw[..32].try_into().unwrap();
+    let app_vm_commit: [u8; 32] = output_raw[32..64].try_into().unwrap();
+    let user_public_values = output_raw[64..].to_vec();
+    let deferral_state = get_deferral_state(&child_vk, from_ref(child_proof), 0)?;
+
+    let mut stdin = StdIn::default();
+    stdin.write(&app_exe_commit);
+    stdin.write(&app_vm_commit);
+    stdin.write(&user_public_values);
+    stdin.write(&input_commit);
+    stdin.deferrals = vec![deferral_state];
+
+    Ok((stdin, DeferralInput::from_inputs(from_ref(child_proof))))
+}
+
 /// Builds a deferral-enabled verify-stark SDK from a fibonacci SDK and proof.
 ///
 /// Returns the SDK, the verify-stark stdin, and the deferral input.
@@ -125,30 +181,8 @@ fn make_deferral_sdk(
     app_params: SystemParams,
     agg_params: AggregationSystemParams,
 ) -> Result<(Sdk, StdIn, DeferralInput)> {
-    let fib_vk = VmStarkVerifyingKey {
-        mvk: fib_sdk.agg_vk().as_ref().clone(),
-        baseline: fib_baseline,
-    };
-
-    let raw_results = get_raw_deferral_results(&fib_vk, from_ref(&fib_proof))?;
-    assert_eq!(raw_results.len(), 1);
-    let input_commit: [u8; 32] = raw_results[0].input.clone().try_into().unwrap();
-    let output_raw = &raw_results[0].output_raw;
-    let app_exe_commit: [u8; 32] = output_raw[..32].try_into().unwrap();
-    let app_vm_commit: [u8; 32] = output_raw[32..64].try_into().unwrap();
-    let user_public_values = output_raw[64..].to_vec();
-    let deferral_state = get_deferral_state(&fib_vk, from_ref(&fib_proof), 0)?;
-
+    let (vs_stdin, def_input) = make_verify_stark_inputs(fib_sdk, &fib_proof, fib_baseline)?;
     let vs_sdk = make_deferral_enabled_sdk(fib_sdk, app_params, agg_params)?;
-
-    let mut vs_stdin = StdIn::default();
-    vs_stdin.write(&app_exe_commit);
-    vs_stdin.write(&app_vm_commit);
-    vs_stdin.write(&user_public_values);
-    vs_stdin.write(&input_commit);
-    vs_stdin.deferrals = vec![deferral_state];
-
-    let def_input = DeferralInput::from_inputs(&[fib_proof]);
 
     Ok((vs_sdk, vs_stdin, def_input))
 }
@@ -261,6 +295,38 @@ fn test_verify_stark_with_deferral_child() -> Result<()> {
     let vk = nested_verify_circuit_prover.get_vk();
     let engine = E::new(vk.inner.params.clone());
     engine.verify(&vk, &nested_def_proof)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_verify_stark_path_sdk_can_verify_own_proofs() -> Result<()> {
+    setup_tracing();
+    let n_stack = 19;
+    let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
+    let agg_params = AggregationSystemParams::default();
+    let sdk = make_verify_stark_path_sdk(app_params, agg_params)?;
+    let agg_vk = sdk.agg_vk().as_ref().clone();
+
+    let vs_elf = Elf::decode(
+        include_bytes!("../programs/examples/verify-stark.elf"),
+        MEM_SIZE as u32,
+    )?;
+    let vs_exe = sdk.convert_to_exe(vs_elf)?;
+
+    let (fib_proof, fib_baseline) = generate_fib_vm_stark_proof(&sdk)?;
+    assert!(fib_proof.deferral_merkle_proofs.is_some(),);
+    Sdk::verify_proof(agg_vk.clone(), fib_baseline.clone(), &fib_proof)?;
+
+    let (vs_stdin, def_input) = make_verify_stark_inputs(&sdk, &fib_proof, fib_baseline)?;
+    let (vs_proof, vs_baseline) = sdk.prove(vs_exe.clone(), vs_stdin, &[def_input])?;
+    assert!(vs_proof.deferral_merkle_proofs.is_some(),);
+    Sdk::verify_proof(agg_vk.clone(), vs_baseline.clone(), &vs_proof)?;
+
+    let (vs2_stdin, vs2_def_input) = make_verify_stark_inputs(&sdk, &vs_proof, vs_baseline)?;
+    let (vs2_proof, vs2_baseline) = sdk.prove(vs_exe, vs2_stdin, &[vs2_def_input])?;
+    assert!(vs2_proof.deferral_merkle_proofs.is_some(),);
+    Sdk::verify_proof(agg_vk, vs2_baseline, &vs2_proof)?;
 
     Ok(())
 }


### PR DESCRIPTION
Resolves INT-8084.

## Overview

This PR adds an SDK path for constructing a deferral-enabled `DeferralPathProver` backed by the
`verify-stark` circuit. The new constructor lets one SDK recursively verify its own VM STARK proofs:
the same SDK can prove an app execution, prove a `verify-stark` program over that proof, and then
prove `verify-stark` over the previous `verify-stark` proof.

The core idea is to derive the self-referential deferral path from a cheap dummy deferral circuit,
then replace only the leaf deferral circuit prover with the real `verify-stark` prover while
reusing the derived deferral aggregation path.

## `openvm-continuations`

### Dummy Deferral Circuit VK Seed

- Adds `circuit::deferral::dummy`.
- Introduces a crate-private `EmptyAirWithPvs`, a minimal one-column AIR with
  `DeferralCircuitPvs`-shaped public values.
- Adds `dummy_deferral_circuit_vk::<E>(system_params)`, which keygens only the dummy VK needed to
  seed fixed-point deferral path derivation.

### Test Cleanup

- Replaces the test-local duplicate `EmptyAirWithPvs` implementation with a re-export of the new
  shared dummy AIR.

## `openvm-sdk`

### Verify-Stark Deferral Path Constructor

- Moves `openvm-verify-stark-circuit` from a dev-dependency to a normal SDK dependency.
- Adds `prover::deferral::verify_stark`.
- Implements `DeferralPathProver::verify_stark(...)`.

The constructor:

- derives fixed-point deferral path artifacts from the dummy deferral circuit;
- builds a real `DeferredVerify{Cpu,Gpu}CircuitProver`;
- bakes in the derived `def_hook_commit` so verify-stark can accept deferral-carrying child proofs;
- returns a usable `DeferralPathProver` with the derived `AggProver` reused rather than regenerated.

### Builder API

- Replaces the builder's single `Option<DeferralProver>` storage with a `DeferralSource` enum.
- Keeps `deferral_prover(DeferralProver)` working as before by wrapping it into a path prover during
  `build`.
- Adds `deferral_path_prover(DeferralPathProver)` for callers that already constructed the full
  deferral path, such as through `DeferralPathProver::verify_stark`.
- Both entry points share one builder slot, so callers cannot set both.

### SDK Tests

- Adds `make_verify_stark_path_sdk`, which constructs an SDK using
  `DeferralPathProver::verify_stark`.
- Adds `test_verify_stark_path_sdk_can_verify_own_proofs`.

The new test uses one SDK to:

1. prove the Fibonacci program;
2. prove `verify-stark` over the Fibonacci proof;
3. prove `verify-stark` over the first `verify-stark` proof;
4. verify each produced STARK proof with `Sdk::verify_proof`.

It also reuses the decoded/converted `verify-stark` executable across both verify-stark proof
generations.

## Review Notes

- The fixed-point derivation assumes the deferral aggregation path and hook commitments depend only
  on aggregation and hook params, not on the concrete deferral circuit being proven.
- `DeferralPathProver::verify_stark` takes explicit `memory_dimensions` and `num_user_pvs` so the
  caller controls the verify-stark circuit shape without passing a full `SystemConfig`.
- The dummy AIR remains crate-private to `openvm-continuations`; SDK code only uses the public dummy
  VK helper.