### PR TITLE
fix: resolve openvm v2.0 audit issues

### DIFF
--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -157,6 +157,7 @@ impl XorinVmAir {
 
         // SAFETY: this approach only works when self.ptr_max_bits >= 24
         // because we are only range checking the last limb
+        assert!(self.ptr_max_bits >= RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1));
         let need_range_check = [
             *instruction.buffer_ptr_limbs.last().unwrap(),
             *instruction.input_ptr_limbs.last().unwrap(),

--- a/extensions/keccak256/guest/src/lib.rs
+++ b/extensions/keccak256/guest/src/lib.rs
@@ -16,6 +16,11 @@ pub const MIN_ALIGN: usize = 4;
 
 /// XOR `len` bytes from `input` into `buffer` using the native XORIN instruction.
 ///
+/// # Panics
+///
+/// Panics if `len > KECCAK_RATE` (136): the XORIN circuit absorbs at most `KECCAK_RATE` bytes
+/// per instruction, so a larger length would execute but fail to prove.
+///
 /// # Safety
 ///
 /// - `buffer` must point to a buffer of at least `len` bytes.
@@ -23,6 +28,11 @@ pub const MIN_ALIGN: usize = 4;
 #[cfg(target_os = "zkvm")]
 #[no_mangle]
 pub unsafe extern "C" fn native_xorin(buffer: *mut u8, input: *const u8, len: usize) {
+    assert!(
+        len <= KECCAK_RATE,
+        "native_xorin: len exceeds the XORIN circuit's maximum rate of {} bytes",
+        KECCAK_RATE
+    );
     if len == 0 {
         return;
     }

--- a/extensions/sha2/circuit/src/sha2_chips/main_chip/air.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/main_chip/air.rs
@@ -221,6 +221,7 @@ impl<C: Sha2MainChipConfig + Sha2BlockHasherSubairConfig> Sha2MainAir<C> {
         }
 
         // range check the memory pointers
+        assert!(self.ptr_max_bits >= RV32_CELL_BITS * (RV32_REGISTER_NUM_LIMBS - 1));
         let shift = AB::Expr::from_usize(
             1 << (RV32_REGISTER_NUM_LIMBS * RV32_CELL_BITS - self.ptr_max_bits),
         );

--- a/guest-libs/keccak256/src/host_impl.rs
+++ b/guest-libs/keccak256/src/host_impl.rs
@@ -26,11 +26,12 @@ impl Keccak256 {
     ///
     /// # Safety
     ///
-    /// `output` must be at least `KECCAK_OUTPUT_SIZE` (32) bytes long.
+    /// `output` must be exactly `KECCAK_OUTPUT_SIZE` (32) bytes long.
     pub unsafe fn finalize(self, output: &mut [u8]) {
-        debug_assert!(
-            output.len() >= super::KECCAK_OUTPUT_SIZE,
-            "output buffer too small"
+        debug_assert_eq!(
+            output.len(),
+            KECCAK_OUTPUT_SIZE,
+            "output must be exactly 32 bytes"
         );
         self.inner.finalize(output);
     }

--- a/guest-libs/keccak256/src/lib.rs
+++ b/guest-libs/keccak256/src/lib.rs
@@ -22,11 +22,12 @@ impl tiny_keccak::Hasher for Keccak256 {
 
     #[inline(always)]
     fn finalize(self, output: &mut [u8]) {
-        assert!(
-            output.len() >= KECCAK_OUTPUT_SIZE,
-            "output buffer too small"
+        assert_eq!(
+            output.len(),
+            KECCAK_OUTPUT_SIZE,
+            "output must be exactly 32 bytes"
         );
-        // SAFETY: output is at least KECCAK_OUTPUT_SIZE bytes (checked above).
+        // SAFETY: output is exactly KECCAK_OUTPUT_SIZE bytes (checked above).
         unsafe { Keccak256::finalize(self, output) };
     }
 }

--- a/guest-libs/keccak256/src/zkvm_impl.rs
+++ b/guest-libs/keccak256/src/zkvm_impl.rs
@@ -102,14 +102,15 @@ impl Keccak256 {
     ///
     /// # Safety
     ///
-    /// `output` must be at least `KECCAK_OUTPUT_SIZE` (32) bytes long.
+    /// `output` must be exactly `KECCAK_OUTPUT_SIZE` (32) bytes long.
     #[inline(always)]
     pub unsafe fn finalize(mut self, output: &mut [u8]) {
-        debug_assert!(
-            output.len() >= KECCAK_OUTPUT_SIZE,
-            "output buffer too small"
+        debug_assert_eq!(
+            output.len(),
+            KECCAK_OUTPUT_SIZE,
+            "output must be exactly 32 bytes"
         );
-        // SAFETY: caller guarantees output is at least KECCAK_OUTPUT_SIZE bytes.
+        // SAFETY: caller guarantees output is exactly KECCAK_OUTPUT_SIZE bytes.
         self.finalize_ptr(output.as_mut_ptr());
     }
 }


### PR DESCRIPTION
- made Keccak `finalize` panic for output buffers that are longer that 32 bytes instead of silently truncating
- added an assertion to ensure the zkvm implementation of `xorin` only handles input lengths up to the Keccak rate
- added assertion `ptr_max_bits >= 24` to Sha2 and Keccak

closes INT-8048, INT-8049, INT-8051