### PR TITLE
fix(static-verifier): require reduced BabyBear transcript inputs

### DIFF
--- a/crates/static-verifier/src/circuit.rs
+++ b/crates/static-verifier/src/circuit.rs
@@ -242,7 +242,9 @@ impl StaticVerifierCircuit {
             .zip_eq(self.internal_recursive_dag_onion_commit)
         {
             let loaded_const = ext_chip.base().load_constant(ctx, bb_const);
-            ext_chip.base().assert_equal(ctx, bb_wire, loaded_const);
+            ext_chip
+                .base()
+                .assert_equal(ctx, bb_wire.into(), loaded_const);
         }
         profiler.pop(ctx.advice.len());
 

--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -17,6 +17,7 @@ use openvm_stark_sdk::{
     p3_baby_bear::BabyBear,
 };
 
+use super::BABY_BEAR_MODULUS_U64;
 use crate::utils::{guarded_debug_assert, guarded_debug_assert_eq};
 
 pub(crate) const BABYBEAR_MAX_BITS: usize = 31;
@@ -37,6 +38,34 @@ pub struct BabyBearWire {
     pub value: AssignedValue<Fr>,
     /// The value is guaranteed to be less than 2^max_bits.
     pub max_bits: usize,
+}
+
+/// A BabyBear wire constrained to its canonical representative in `[0, p)`.
+///
+/// This type marks values that are safe to absorb into BabyBear-domain transcript
+/// and hash inputs. Arithmetic may still use the underlying `BabyBearWire`; converting
+/// via `BabyBearWire::from` only drops this type-level evidence and does not add or
+/// remove constraints.
+#[derive(Copy, Clone, Debug)]
+pub struct ReducedBabyBearWire(BabyBearWire);
+
+impl ReducedBabyBearWire {
+    pub fn value(&self) -> AssignedValue<Fr> {
+        self.0.value
+    }
+}
+
+impl From<ReducedBabyBearWire> for BabyBearWire {
+    /// Drops the canonicality evidence and returns the underlying arithmetic wire.
+    fn from(wire: ReducedBabyBearWire) -> Self {
+        wire.0
+    }
+}
+
+impl From<&ReducedBabyBearWire> for BabyBearWire {
+    fn from(wire: &ReducedBabyBearWire) -> Self {
+        (*wire).into()
+    }
 }
 
 impl BabyBearWire {
@@ -76,6 +105,12 @@ impl BabyBearChip {
         &self.range
     }
 
+    /// Loads a BabyBear witness and constrains only that the assigned advice cell
+    /// fits in 31 bits.
+    ///
+    /// The Rust input is canonicalized for the honest witness assignment, but the
+    /// circuit does not prove the advice cell is `< p`. Use `load_reduced_witness`
+    /// for values that will be absorbed into transcripts or hashes.
     pub fn load_witness(&self, ctx: &mut Context<Fr>, value: BabyBear) -> BabyBearWire {
         let value = ctx.load_witness(Fr::from(PrimeField64::as_canonical_u64(&value)));
         self.range.range_check(ctx, value, BABYBEAR_MAX_BITS);
@@ -83,6 +118,21 @@ impl BabyBearChip {
             value,
             max_bits: BABYBEAR_MAX_BITS,
         }
+    }
+
+    /// Loads a witness and constrains it to the canonical BabyBear range `[0, p)`.
+    pub fn load_reduced_witness(
+        &self,
+        ctx: &mut Context<Fr>,
+        value: BabyBear,
+    ) -> ReducedBabyBearWire {
+        let value = ctx.load_witness(Fr::from(PrimeField64::as_canonical_u64(&value)));
+        self.range
+            .check_less_than_safe(ctx, value, BABY_BEAR_MODULUS_U64);
+        ReducedBabyBearWire(BabyBearWire {
+            value,
+            max_bits: BABYBEAR_MAX_BITS,
+        })
     }
 
     pub fn load_constant(&self, ctx: &mut Context<Fr>, value: BabyBear) -> BabyBearWire {
@@ -102,6 +152,16 @@ impl BabyBearChip {
         };
         self.const_cache.borrow_mut().insert(key, wire);
         wire
+    }
+
+    /// Loads a canonical BabyBear constant and returns it with reduced type evidence.
+    pub fn load_reduced_constant(
+        &self,
+        ctx: &mut Context<Fr>,
+        value: BabyBear,
+    ) -> ReducedBabyBearWire {
+        // Constants are canonical by construction.
+        ReducedBabyBearWire(self.load_constant(ctx, value))
     }
 
     pub fn reduce(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {

--- a/crates/static-verifier/src/field/baby_bear/extension.rs
+++ b/crates/static-verifier/src/field/baby_bear/extension.rs
@@ -1,3 +1,4 @@
+use core::array;
 #[cfg(test)]
 use std::{cell::RefCell, vec::Vec};
 
@@ -16,7 +17,7 @@ use openvm_stark_sdk::{
 };
 
 use crate::{
-    field::baby_bear::{BabyBearChip, BabyBearWire},
+    field::baby_bear::{BabyBearChip, BabyBearWire, ReducedBabyBearWire},
     utils::guarded_debug_assert_eq,
 };
 
@@ -49,12 +50,39 @@ pub struct BabyBearExt4Chip {
 
 #[derive(Copy, Clone, Debug)]
 pub struct BabyBearExt4Wire(pub [BabyBearWire; 4]);
+
+/// An extension-field wire whose BabyBear basis coefficients are all reduced.
+///
+/// This is the extension-field analogue of `ReducedBabyBearWire`: it is safe for
+/// transcript/hash absorption coefficient-by-coefficient. Converting via
+/// `BabyBearExt4Wire::from` drops that evidence when the value is used by arithmetic
+/// helpers.
+#[derive(Copy, Clone, Debug)]
+pub struct ReducedBabyBearExt4Wire([ReducedBabyBearWire; 4]);
 pub type BabyBearExt4 = BinomialExtensionField<BabyBear, 4>;
 
 impl BabyBearExt4Wire {
     pub fn to_extension_field(&self) -> BabyBearExt4 {
-        let b_val = (0..4).map(|i| self.0[i].to_baby_bear()).collect_vec();
-        BabyBearExt4::from_basis_coefficients_slice(&b_val).unwrap()
+        BabyBearExt4::from_basis_coefficients_fn(|i| self.0[i].to_baby_bear())
+    }
+}
+
+impl ReducedBabyBearExt4Wire {
+    pub fn coeffs(&self) -> &[ReducedBabyBearWire; 4] {
+        &self.0
+    }
+}
+
+impl From<ReducedBabyBearExt4Wire> for BabyBearExt4Wire {
+    /// Drops the canonicality evidence and returns the underlying arithmetic wire.
+    fn from(wire: ReducedBabyBearExt4Wire) -> Self {
+        BabyBearExt4Wire(wire.0.map(BabyBearWire::from))
+    }
+}
+
+impl From<&ReducedBabyBearExt4Wire> for BabyBearExt4Wire {
+    fn from(wire: &ReducedBabyBearExt4Wire) -> Self {
+        (*wire).into()
     }
 }
 
@@ -62,27 +90,46 @@ impl BabyBearExt4Chip {
     pub fn new(base_chip: BabyBearChip) -> Self {
         BabyBearExt4Chip { base: base_chip }
     }
+
+    /// Loads each BabyBear coefficient and constrains only that its assigned
+    /// advice cell fits in 31 bits.
+    ///
+    /// The Rust input is canonicalized for the honest witness assignment, but the
+    /// circuit does not prove each advice cell is `< p`. Use
+    /// `load_reduced_witness` for transcript/hash inputs.
     pub fn load_witness(&self, ctx: &mut Context<Fr>, value: BabyBearExt4) -> BabyBearExt4Wire {
-        BabyBearExt4Wire(
-            value
-                .as_basis_coefficients_slice()
-                .iter()
-                .map(|x| self.base.load_witness(ctx, *x))
-                .collect_vec()
-                .try_into()
-                .unwrap(),
-        )
+        let coeffs = value.as_basis_coefficients_slice();
+        BabyBearExt4Wire(array::from_fn(|i| self.base.load_witness(ctx, coeffs[i])))
+    }
+
+    /// Loads each coefficient and constrains it to the canonical BabyBear range.
+    pub fn load_reduced_witness(
+        &self,
+        ctx: &mut Context<Fr>,
+        value: BabyBearExt4,
+    ) -> ReducedBabyBearExt4Wire {
+        let coeffs = value.as_basis_coefficients_slice();
+        ReducedBabyBearExt4Wire(array::from_fn(|i| {
+            self.base.load_reduced_witness(ctx, coeffs[i])
+        }))
+    }
+
+    /// Loads canonical BabyBear constants for each coefficient and returns them
+    /// with reduced type evidence.
+    pub fn load_reduced_constant(
+        &self,
+        ctx: &mut Context<Fr>,
+        value: BabyBearExt4,
+    ) -> ReducedBabyBearExt4Wire {
+        let coeffs = value.as_basis_coefficients_slice();
+        // Constants are canonical by construction.
+        ReducedBabyBearExt4Wire(array::from_fn(|i| {
+            self.base.load_reduced_constant(ctx, coeffs[i])
+        }))
     }
     pub fn load_constant(&self, ctx: &mut Context<Fr>, value: BabyBearExt4) -> BabyBearExt4Wire {
-        BabyBearExt4Wire(
-            value
-                .as_basis_coefficients_slice()
-                .iter()
-                .map(|x| self.base.load_constant(ctx, *x))
-                .collect_vec()
-                .try_into()
-                .unwrap(),
-        )
+        let coeffs = value.as_basis_coefficients_slice();
+        BabyBearExt4Wire(array::from_fn(|i| self.base.load_constant(ctx, coeffs[i])))
     }
     pub fn add(
         &self,

--- a/crates/static-verifier/src/field/baby_bear/mod.rs
+++ b/crates/static-verifier/src/field/baby_bear/mod.rs
@@ -10,6 +10,7 @@ pub(crate) const BABY_BEAR_BITS: usize = BABYBEAR_MAX_BITS;
 
 pub type BabyBearExtChip = BabyBearExt4Chip;
 pub type BabyBearExtWire = BabyBearExt4Wire;
+pub type ReducedBabyBearExtWire = ReducedBabyBearExt4Wire;
 
 #[cfg(test)]
 mod tests;

--- a/crates/static-verifier/src/hash/poseidon2.rs
+++ b/crates/static-verifier/src/hash/poseidon2.rs
@@ -12,7 +12,7 @@ pub(crate) use openvm_stark_sdk::config::baby_bear_bn254_poseidon2::{
     BABY_BEAR_RATE as MULTI_FIELD32_RATE, BN254_RATE as POSEIDON2_RATE, DIGEST_WIDTH,
 };
 
-use crate::{field::baby_bear::BabyBearWire, Fr};
+use crate::{field::baby_bear::ReducedBabyBearWire, Fr};
 
 const MULTI_FIELD32_NUM_F_ELMS: usize = MULTI_FIELD32_RATE / POSEIDON2_RATE;
 
@@ -204,12 +204,12 @@ impl<F: ScalarField, const T: usize> Poseidon2State<F, T> {
 pub(crate) fn pack_base_2_31_cells(
     ctx: &mut Context<Fr>,
     gate: &impl GateInstructions<Fr>,
-    values: &[AssignedValue<Fr>],
+    values: &[ReducedBabyBearWire],
 ) -> AssignedValue<Fr> {
     let base = Fr::from(1u64 << 31);
     gate.inner_product(
         ctx,
-        values.iter().copied(),
+        values.iter().map(|value| value.value()),
         core::iter::successors(Some(Fr::from(1u64)), |power| Some(*power * base))
             .take(values.len())
             .map(Constant),
@@ -219,7 +219,7 @@ pub(crate) fn pack_base_2_31_cells(
 pub(crate) fn hash_babybear_slice_to_digest(
     ctx: &mut Context<Fr>,
     range: &RangeChip<Fr>,
-    values: &[BabyBearWire],
+    values: &[ReducedBabyBearWire],
 ) -> AssignedValue<Fr> {
     let gate = range.gate();
     let params = &*super::POSEIDON2_PARAMS;
@@ -227,8 +227,7 @@ pub(crate) fn hash_babybear_slice_to_digest(
     let mut state = Poseidon2State::new(core::array::from_fn(|_| zero));
     for block_chunk in values.chunks(MULTI_FIELD32_RATE) {
         for (chunk_id, chunk) in block_chunk.chunks(MULTI_FIELD32_NUM_F_ELMS).enumerate() {
-            let cells = chunk.iter().map(|value| value.value).collect::<Vec<_>>();
-            state.s[chunk_id] = pack_base_2_31_cells(ctx, gate, &cells);
+            state.s[chunk_id] = pack_base_2_31_cells(ctx, gate, chunk);
         }
         state.permutation(ctx, gate, params);
     }

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -15,34 +15,37 @@ use openvm_stark_sdk::{
 };
 
 use crate::{
-    field::baby_bear::{BabyBearChip, BabyBearExtChip, BabyBearExtWire, BabyBearWire},
+    field::baby_bear::{
+        BabyBearChip, BabyBearExtChip, BabyBearExtWire, BabyBearWire, ReducedBabyBearExtWire,
+        ReducedBabyBearWire,
+    },
     profiling::CellProfiler,
-    stages::shared_math::{self, horner_eval_ext_poly_assigned},
+    stages::shared_math::{column_openings_by_rot_assigned, horner_eval_ext_poly_assigned},
     transcript::TranscriptChip,
-    Fr, RootF,
+    Fr, RootEF, RootF,
 };
 
 #[derive(Clone, Debug)]
 pub struct BatchConstraintIntermediatesWire {
-    pub column_openings: Vec<Vec<Vec<BabyBearExtWire>>>,
+    pub column_openings: Vec<Vec<Vec<ReducedBabyBearExtWire>>>,
     pub r: Vec<BabyBearExtWire>,
 }
 
 #[derive(Clone, Debug)]
 pub struct GkrProofWire {
-    pub logup_pow_witness: BabyBearWire,
-    pub q0_claim: BabyBearExtWire,
-    pub claims_per_layer: Vec<Vec<BabyBearExtWire>>,
-    pub sumcheck_polys: Vec<Vec<[BabyBearExtWire; 3]>>,
+    pub logup_pow_witness: ReducedBabyBearWire,
+    pub q0_claim: ReducedBabyBearExtWire,
+    pub claims_per_layer: Vec<Vec<ReducedBabyBearExtWire>>,
+    pub sumcheck_polys: Vec<Vec<[ReducedBabyBearExtWire; 3]>>,
 }
 
 #[derive(Clone, Debug)]
 pub struct BatchConstraintProofWire {
-    pub numerator_term_per_air: Vec<BabyBearExtWire>,
-    pub denominator_term_per_air: Vec<BabyBearExtWire>,
-    pub univariate_round_coeffs: Vec<BabyBearExtWire>,
-    pub sumcheck_round_polys: Vec<Vec<BabyBearExtWire>>,
-    pub column_openings: Vec<Vec<Vec<BabyBearExtWire>>>,
+    pub numerator_term_per_air: Vec<ReducedBabyBearExtWire>,
+    pub denominator_term_per_air: Vec<ReducedBabyBearExtWire>,
+    pub univariate_round_coeffs: Vec<ReducedBabyBearExtWire>,
+    pub sumcheck_round_polys: Vec<Vec<ReducedBabyBearExtWire>>,
+    pub column_openings: Vec<Vec<Vec<ReducedBabyBearExtWire>>>,
 }
 
 pub(crate) fn load_gkr_proof_wire(
@@ -51,17 +54,17 @@ pub(crate) fn load_gkr_proof_wire(
     ext_chip: &BabyBearExtChip,
     gkr_proof: &openvm_stark_sdk::openvm_stark_backend::proof::GkrProof<RootConfig>,
 ) -> GkrProofWire {
-    let logup_pow_witness = base_chip.load_witness(ctx, gkr_proof.logup_pow_witness);
-    let q0_claim = ext_chip.load_witness(ctx, gkr_proof.q0_claim);
+    let logup_pow_witness = base_chip.load_reduced_witness(ctx, gkr_proof.logup_pow_witness);
+    let q0_claim = ext_chip.load_reduced_witness(ctx, gkr_proof.q0_claim);
     let claims_per_layer = gkr_proof
         .claims_per_layer
         .iter()
         .map(|claims| {
             vec![
-                ext_chip.load_witness(ctx, claims.p_xi_0),
-                ext_chip.load_witness(ctx, claims.q_xi_0),
-                ext_chip.load_witness(ctx, claims.p_xi_1),
-                ext_chip.load_witness(ctx, claims.q_xi_1),
+                ext_chip.load_reduced_witness(ctx, claims.p_xi_0),
+                ext_chip.load_reduced_witness(ctx, claims.q_xi_0),
+                ext_chip.load_reduced_witness(ctx, claims.p_xi_1),
+                ext_chip.load_reduced_witness(ctx, claims.q_xi_1),
             ]
         })
         .collect::<Vec<_>>();
@@ -70,7 +73,7 @@ pub(crate) fn load_gkr_proof_wire(
         .iter()
         .map(|poly| {
             poly.iter()
-                .map(|evals| evals.map(|value| ext_chip.load_witness(ctx, value)))
+                .map(|evals| evals.map(|value| ext_chip.load_reduced_witness(ctx, value)))
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
@@ -90,24 +93,24 @@ pub(crate) fn load_batch_constraint_proof_wire(
     let numerator_term_per_air = batch_proof
         .numerator_term_per_air
         .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
+        .map(|&value| ext_chip.load_reduced_witness(ctx, value))
         .collect::<Vec<_>>();
     let denominator_term_per_air = batch_proof
         .denominator_term_per_air
         .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
+        .map(|&value| ext_chip.load_reduced_witness(ctx, value))
         .collect::<Vec<_>>();
     let univariate_round_coeffs = batch_proof
         .univariate_round_coeffs
         .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
+        .map(|&value| ext_chip.load_reduced_witness(ctx, value))
         .collect::<Vec<_>>();
     let sumcheck_round_polys = batch_proof
         .sumcheck_round_polys
         .iter()
         .map(|poly| {
             poly.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
+                .map(|&value| ext_chip.load_reduced_witness(ctx, value))
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
@@ -119,7 +122,7 @@ pub(crate) fn load_batch_constraint_proof_wire(
                 .iter()
                 .map(|part| {
                     part.iter()
-                        .map(|&value| ext_chip.load_witness(ctx, value))
+                        .map(|&value| ext_chip.load_reduced_witness(ctx, value))
                         .collect::<Vec<_>>()
                 })
                 .collect::<Vec<_>>()
@@ -467,12 +470,18 @@ struct ViewPairWire {
     next: BabyBearExtWire,
 }
 
+impl From<(BabyBearExtWire, BabyBearExtWire)> for ViewPairWire {
+    fn from((local, next): (BabyBearExtWire, BabyBearExtWire)) -> Self {
+        Self { local, next }
+    }
+}
+
 struct ConstraintEvaluatorWire<'a> {
     preprocessed: Option<&'a [ViewPairWire]>,
     partitioned_main: &'a [Vec<ViewPairWire>],
     is_first_row: BabyBearExtWire,
     is_last_row: BabyBearExtWire,
-    public_values: &'a [BabyBearWire],
+    public_values: &'a [ReducedBabyBearWire],
 }
 
 impl ConstraintEvaluatorWire<'_> {
@@ -502,7 +511,7 @@ impl ConstraintEvaluatorWire<'_> {
             }
             Entry::Public => {
                 let value = self.public_values[index];
-                ext_chip.from_base_var(ctx, value)
+                ext_chip.from_base_var(ctx, value.into())
             }
             _ => panic!("invalid constraint"),
         }
@@ -563,22 +572,26 @@ fn eval_symbolic_nodes_assigned(
     exprs
 }
 
-fn column_openings_by_rot_assigned(
+fn local_next_opening_views(
     ctx: &mut Context<Fr>,
     ext_chip: &BabyBearExtChip,
-    openings: &[BabyBearExtWire],
+    openings: &[ReducedBabyBearExtWire],
     need_rot: bool,
 ) -> Vec<ViewPairWire> {
-    shared_math::column_openings_by_rot_assigned(ctx, ext_chip, openings, need_rot)
+    let openings = openings
+        .iter()
+        .map(BabyBearExtWire::from)
+        .collect::<Vec<_>>();
+    column_openings_by_rot_assigned(ctx, ext_chip, &openings, need_rot)
         .into_iter()
-        .map(|(local, next)| ViewPairWire { local, next })
-        .collect::<Vec<_>>()
+        .map(ViewPairWire::from)
+        .collect()
 }
 
 fn observe_layer_claims_assigned(
     ctx: &mut Context<Fr>,
     transcript: &mut TranscriptChip,
-    claims: &[BabyBearExtWire],
+    claims: &[ReducedBabyBearExtWire],
 ) {
     for claim in claims {
         transcript.observe_ext(ctx, claim);
@@ -595,7 +608,7 @@ pub(crate) fn constrain_batch_constraints_verification(
     batch_wire: &BatchConstraintProofWire,
     n_per_trace: &[isize],
     trace_id_to_air_id: &[usize],
-    public_values: Vec<Vec<BabyBearWire>>,
+    public_values: Vec<Vec<ReducedBabyBearWire>>,
     profiler: &mut CellProfiler,
 ) -> BatchConstraintIntermediatesWire {
     let l_skip = mvk0.params.l_skip;
@@ -668,7 +681,6 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     profiler.push("gkr_verification", ctx.advice.len());
 
-    let gkr_q0_claim = gkr_wire.q0_claim;
     let gkr_claims_per_layer = &gkr_wire.claims_per_layer;
     let gkr_sumcheck_polys = &gkr_wire.sumcheck_polys;
 
@@ -676,23 +688,28 @@ pub(crate) fn constrain_batch_constraints_verification(
     let one = ext_chip.from_base_const(ctx, RootF::ONE);
     let total_gkr_rounds = l_skip + n_logup_host;
     let (mut gkr_p_xi_claim, mut gkr_q_xi_claim, mut xi) = {
+        let gkr_q0_claim = gkr_wire.q0_claim;
         transcript.observe_ext(ctx, &gkr_q0_claim);
 
         let layer0 = &gkr_claims_per_layer[0];
         observe_layer_claims_assigned(ctx, transcript, layer0);
 
-        let p0_q1 = ext_chip.mul(ctx, layer0[0], layer0[3]);
-        let p1_q0 = ext_chip.mul(ctx, layer0[2], layer0[1]);
+        let layer0_p0 = layer0[0].into();
+        let layer0_q0 = layer0[1].into();
+        let layer0_p1 = layer0[2].into();
+        let layer0_q1 = layer0[3].into();
+        let p0_q1 = ext_chip.mul(ctx, layer0_p0, layer0_q1);
+        let p1_q0 = ext_chip.mul(ctx, layer0_p1, layer0_q0);
         let p_cross = ext_chip.add(ctx, p0_q1, p1_q0);
-        let q_cross = ext_chip.mul(ctx, layer0[1], layer0[3]);
+        let q_cross = ext_chip.mul(ctx, layer0_q0, layer0_q1);
         ext_chip.assert_zero(ctx, p_cross);
-        ext_chip.assert_equal(ctx, q_cross, gkr_q0_claim);
+        ext_chip.assert_equal(ctx, q_cross, gkr_q0_claim.into());
 
         let mu0 = transcript.sample_ext(ctx);
         let mut numer_claim =
-            interpolate_linear_at_01_assigned(ctx, ext_chip, &layer0[0], &layer0[2], &mu0);
+            interpolate_linear_at_01_assigned(ctx, ext_chip, &layer0_p0, &layer0_p1, &mu0);
         let mut denom_claim =
-            interpolate_linear_at_01_assigned(ctx, ext_chip, &layer0[1], &layer0[3], &mu0);
+            interpolate_linear_at_01_assigned(ctx, ext_chip, &layer0_q0, &layer0_q1, &mu0);
         let mut gkr_r = vec![mu0];
 
         for round in 1..total_gkr_rounds {
@@ -713,6 +730,9 @@ pub(crate) fn constrain_batch_constraints_verification(
                 let ri = transcript.sample_ext(ctx);
                 gkr_r_prime.push(ri);
 
+                let ev1 = ev1.into();
+                let ev2 = ev2.into();
+                let ev3 = ev3.into();
                 let ev0 = ext_chip.sub(ctx, claim, ev1);
                 claim = interpolate_cubic_at_0123_assigned(
                     ctx,
@@ -731,30 +751,24 @@ pub(crate) fn constrain_batch_constraints_verification(
             let layer_claims = &gkr_claims_per_layer[round];
             observe_layer_claims_assigned(ctx, transcript, layer_claims);
 
-            let p0_q1 = ext_chip.mul(ctx, layer_claims[0], layer_claims[3]);
-            let p1_q0 = ext_chip.mul(ctx, layer_claims[2], layer_claims[1]);
+            let layer_p0 = layer_claims[0].into();
+            let layer_q0 = layer_claims[1].into();
+            let layer_p1 = layer_claims[2].into();
+            let layer_q1 = layer_claims[3].into();
+            let p0_q1 = ext_chip.mul(ctx, layer_p0, layer_q1);
+            let p1_q0 = ext_chip.mul(ctx, layer_p1, layer_q0);
             let p_cross = ext_chip.add(ctx, p0_q1, p1_q0);
-            let q_cross = ext_chip.mul(ctx, layer_claims[1], layer_claims[3]);
+            let q_cross = ext_chip.mul(ctx, layer_q0, layer_q1);
             let lambda_q_cross = ext_chip.mul(ctx, lambda_round, q_cross);
             let claim_sum = ext_chip.add(ctx, p_cross, lambda_q_cross);
             let expected_claim = ext_chip.mul(ctx, claim_sum, eq);
             ext_chip.assert_equal(ctx, expected_claim, claim);
 
             let mu_round = transcript.sample_ext(ctx);
-            numer_claim = interpolate_linear_at_01_assigned(
-                ctx,
-                ext_chip,
-                &layer_claims[0],
-                &layer_claims[2],
-                &mu_round,
-            );
-            denom_claim = interpolate_linear_at_01_assigned(
-                ctx,
-                ext_chip,
-                &layer_claims[1],
-                &layer_claims[3],
-                &mu_round,
-            );
+            numer_claim =
+                interpolate_linear_at_01_assigned(ctx, ext_chip, &layer_p0, &layer_p1, &mu_round);
+            denom_claim =
+                interpolate_linear_at_01_assigned(ctx, ext_chip, &layer_q0, &layer_q1, &mu_round);
             gkr_r = core::iter::once(mu_round)
                 .chain(gkr_r_prime.into_iter())
                 .collect();
@@ -778,8 +792,8 @@ pub(crate) fn constrain_batch_constraints_verification(
         .iter()
         .zip(denominator_term_per_air.iter())
     {
-        gkr_p_xi_claim = ext_chip.sub(ctx, gkr_p_xi_claim, *num_term);
-        gkr_q_xi_claim = ext_chip.sub(ctx, gkr_q_xi_claim, *den_term);
+        gkr_p_xi_claim = ext_chip.sub(ctx, gkr_p_xi_claim, num_term.into());
+        gkr_q_xi_claim = ext_chip.sub(ctx, gkr_q_xi_claim, den_term.into());
         transcript.observe_ext(ctx, num_term);
         transcript.observe_ext(ctx, den_term);
     }
@@ -798,16 +812,18 @@ pub(crate) fn constrain_batch_constraints_verification(
         .iter()
         .zip(denominator_term_per_air.iter())
     {
+        let num_term = num_term.into();
+        let den_term = den_term.into();
         let num_weighted = if first_mu_term {
             first_mu_term = false;
-            *num_term
+            num_term
         } else {
-            ext_chip.mul(ctx, *num_term, cur_mu_pow)
+            ext_chip.mul(ctx, num_term, cur_mu_pow)
         };
         sum_claim = ext_chip.add(ctx, sum_claim, num_weighted);
         cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
 
-        let den_weighted = ext_chip.mul(ctx, *den_term, cur_mu_pow);
+        let den_weighted = ext_chip.mul(ctx, den_term, cur_mu_pow);
         sum_claim = ext_chip.add(ctx, sum_claim, den_weighted);
         cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
     }
@@ -816,11 +832,15 @@ pub(crate) fn constrain_batch_constraints_verification(
     for coeff in univariate_round_coeffs {
         transcript.observe_ext(ctx, coeff);
     }
+    let univariate_round_coeffs_raw = univariate_round_coeffs
+        .iter()
+        .map(|coeff| coeff.into())
+        .collect::<Vec<_>>();
     let mut r = vec![transcript.sample_ext(ctx)];
 
     let stride = 1usize << l_skip;
     let mut sum_univ_domain_s_0 = ext_chip.zero(ctx);
-    for coeff in univariate_round_coeffs.iter().step_by(stride) {
+    for coeff in univariate_round_coeffs_raw.iter().step_by(stride) {
         sum_univ_domain_s_0 = ext_chip.add(ctx, sum_univ_domain_s_0, *coeff);
     }
     let sum_univ_domain_s_0 =
@@ -829,17 +849,17 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let sumcheck_round_polys = &batch_wire.sumcheck_round_polys;
     let mut consistency_lhs =
-        horner_eval_ext_poly_assigned(ctx, ext_chip, univariate_round_coeffs, &r[0]);
+        horner_eval_ext_poly_assigned(ctx, ext_chip, &univariate_round_coeffs_raw, &r[0]);
     for round_evals in sumcheck_round_polys {
         for eval in round_evals {
             transcript.observe_ext(ctx, eval);
         }
 
-        let s_1 = round_evals[0];
+        let s_1 = round_evals[0].into();
         let s_0 = ext_chip.sub(ctx, consistency_lhs, s_1);
         let mut interpolation_evals = Vec::with_capacity(round_evals.len() + 1);
         interpolation_evals.push(s_0);
-        interpolation_evals.extend(round_evals.iter().copied());
+        interpolation_evals.extend(round_evals.iter().map(BabyBearExtWire::from));
         let next_r = transcript.sample_ext(ctx);
         consistency_lhs =
             eval_lagrange_on_integer_grid(ctx, ext_chip, &next_r, &interpolation_evals);
@@ -851,20 +871,44 @@ pub(crate) fn constrain_batch_constraints_verification(
 
     let column_openings = &batch_wire.column_openings;
 
+    let reduced_zero = ext_chip.load_reduced_constant(ctx, RootEF::ZERO);
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
         let need_rot = column_openings_need_rot[trace_idx][0];
-        for claim in column_openings_by_rot_assigned(ctx, ext_chip, &air_openings[0], need_rot) {
-            transcript.observe_ext(ctx, &claim.local);
-            transcript.observe_ext(ctx, &claim.next);
+        let openings = &air_openings[0];
+        if need_rot {
+            assert!(
+                openings.len().is_multiple_of(2),
+                "rotated opening vector must be even",
+            );
+            for claim in openings.chunks_exact(2) {
+                transcript.observe_ext(ctx, &claim[0]);
+                transcript.observe_ext(ctx, &claim[1]);
+            }
+        } else {
+            for opening in openings {
+                transcript.observe_ext(ctx, opening);
+                transcript.observe_ext(ctx, &reduced_zero);
+            }
         }
     }
 
     for (trace_idx, air_openings) in column_openings.iter().enumerate() {
         for (part_idx, claims) in air_openings.iter().enumerate().skip(1) {
             let need_rot = column_openings_need_rot[trace_idx][part_idx];
-            for claim in column_openings_by_rot_assigned(ctx, ext_chip, claims, need_rot) {
-                transcript.observe_ext(ctx, &claim.local);
-                transcript.observe_ext(ctx, &claim.next);
+            if need_rot {
+                assert!(
+                    claims.len().is_multiple_of(2),
+                    "rotated opening vector must be even",
+                );
+                for claim in claims.chunks_exact(2) {
+                    transcript.observe_ext(ctx, &claim[0]);
+                    transcript.observe_ext(ctx, &claim[1]);
+                }
+            } else {
+                for claim in claims {
+                    transcript.observe_ext(ctx, claim);
+                    transcript.observe_ext(ctx, &reduced_zero);
+                }
             }
         }
     }
@@ -992,17 +1036,16 @@ pub(crate) fn constrain_batch_constraints_verification(
 
         let need_rot_flags = &column_openings_need_rot[trace_idx];
         let common_main =
-            column_openings_by_rot_assigned(ctx, ext_chip, &air_openings[0], need_rot_flags[0]);
+            local_next_opening_views(ctx, ext_chip, &air_openings[0], need_rot_flags[0]);
         let has_preprocessed = trace_has_preprocessed[trace_idx];
-        let preprocessed = has_preprocessed.then(|| {
-            column_openings_by_rot_assigned(ctx, ext_chip, &air_openings[1], need_rot_flags[1])
-        });
+        let preprocessed = has_preprocessed
+            .then(|| local_next_opening_views(ctx, ext_chip, &air_openings[1], need_rot_flags[1]));
         let cached_idx = 1 + has_preprocessed as usize;
         let mut partitioned_main = air_openings[cached_idx..]
             .iter()
             .enumerate()
             .map(|(part_offset, opening)| {
-                column_openings_by_rot_assigned(
+                local_next_opening_views(
                     ctx,
                     ext_chip,
                     opening,

--- a/crates/static-verifier/src/stages/full_pipeline/mod.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/mod.rs
@@ -11,7 +11,7 @@ use openvm_stark_sdk::{
 };
 
 use crate::{
-    field::baby_bear::{BabyBearExtChip, BabyBearWire},
+    field::baby_bear::{BabyBearExtChip, ReducedBabyBearWire},
     stages::{
         batch_constraints::{
             constrain_batch_constraints_verification, load_batch_constraint_proof_wire,
@@ -36,7 +36,7 @@ pub use public_values::*;
 #[derive(Clone, Debug)]
 pub struct ProofWire {
     pub common_main_commit_root: AssignedValue<Fr>,
-    pub public_values: Vec<Vec<BabyBearWire>>,
+    pub public_values: Vec<Vec<ReducedBabyBearWire>>,
     pub cached_commitment_roots: Vec<Vec<AssignedValue<Fr>>>,
     pub gkr: GkrProofWire,
     pub batch: BatchConstraintProofWire,
@@ -74,7 +74,7 @@ pub fn load_proof_wire(
         .map(|values| {
             values
                 .iter()
-                .map(|&value| base_chip.load_witness(ctx, value))
+                .map(|&value| base_chip.load_reduced_witness(ctx, value))
                 .collect()
         })
         .collect();
@@ -117,7 +117,7 @@ fn observe_preamble(
     transcript: &mut TranscriptChip,
     mvk: &MultiStarkVerifyingKey<RootConfig>,
     log_heights_per_air: &[usize],
-    public_values: &[Vec<BabyBearWire>],
+    public_values: &[Vec<ReducedBabyBearWire>],
     cached_commitment_roots: &[Vec<AssignedValue<Fr>>],
     vk_pre_hash: DigestWire,
     common_main_commit: DigestWire,
@@ -128,14 +128,10 @@ fn observe_preamble(
     for air_idx in 0..mvk.inner.per_air.len() {
         if !mvk.inner.per_air[air_idx].is_required {
             // Static verifier: every AIR in the child VK has a trace (see crate `lib.rs`).
-            let presence_flag = ctx.load_constant(Fr::one());
-            transcript.observe(
-                ctx,
-                &BabyBearWire {
-                    value: presence_flag,
-                    max_bits: 1,
-                },
-            );
+            let presence_flag = transcript
+                .baby_bear()
+                .load_reduced_constant(ctx, BabyBear::ONE);
+            transcript.observe(ctx, &presence_flag);
         }
 
         if let Some(preprocessed) = mvk.inner.per_air[air_idx].preprocessed_data.as_ref() {
@@ -147,7 +143,7 @@ fn observe_preamble(
                 .expect("log_height must fit in u32 for BabyBear constant");
             let log_height = transcript
                 .baby_bear()
-                .load_constant(ctx, BabyBear::from_u32(lh));
+                .load_reduced_constant(ctx, BabyBear::from_u32(lh));
             transcript.observe(ctx, &log_height);
         }
 

--- a/crates/static-verifier/src/stages/full_pipeline/public_values.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/public_values.rs
@@ -8,7 +8,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE as APP_DIGEST_SIZ
 use openvm_verify_stark_host::pvs::VERIFIER_PVS_AIR_ID;
 
 use crate::{
-    field::baby_bear::{BabyBearChip, BabyBearWire, BABY_BEAR_MODULUS_U64},
+    field::baby_bear::{BabyBearChip, ReducedBabyBearWire, BABY_BEAR_MODULUS_U64},
     stages::full_pipeline::ProofWire,
     Fr,
 };
@@ -51,16 +51,12 @@ pub fn extract_public_values(
     chip: &BabyBearChip,
     proof: &ProofWire,
 ) -> StaticVerifierPvs<AssignedValue<Fr>> {
-    let root_pvs: &RootVerifierPvs<BabyBearWire> =
+    let root_pvs: &RootVerifierPvs<ReducedBabyBearWire> =
         proof.public_values[VERIFIER_PVS_AIR_ID].as_slice().borrow();
     let app_exe_commit = compress_babybear_wires_to_bn254(ctx, chip, root_pvs.app_exe_commit);
     let app_vm_commit = compress_babybear_wires_to_bn254(ctx, chip, root_pvs.app_vm_commit);
-    // not reduced:
-    let user_pvs_nr = &proof.public_values[USER_PVS_COMMIT_AIR_ID];
-    let user_public_values = user_pvs_nr
-        .iter()
-        .map(|bb| chip.reduce(ctx, *bb).value)
-        .collect::<Vec<_>>();
+    let user_pvs = &proof.public_values[USER_PVS_COMMIT_AIR_ID];
+    let user_public_values = user_pvs.iter().map(|bb| bb.value()).collect::<Vec<_>>();
 
     StaticVerifierPvs {
         app_exe_commit,
@@ -72,11 +68,9 @@ pub fn extract_public_values(
 pub fn compress_babybear_wires_to_bn254(
     ctx: &mut Context<Fr>,
     chip: &BabyBearChip,
-    base_elts: [BabyBearWire; APP_DIGEST_SIZE],
+    base_elts: [ReducedBabyBearWire; APP_DIGEST_SIZE],
 ) -> AssignedValue<Fr> {
-    // BabyBearWire is not constrained to be < BABY_BEAR_MODULUS so we need to range check them
-    // before compressing.
-    let reduced_elts = base_elts.map(|bb| chip.reduce(ctx, bb).value);
+    let reduced_elts = base_elts.map(|bb| bb.value());
     let order = Fr::from(BABY_BEAR_MODULUS_U64);
     let mut bases = [Fr::ONE; APP_DIGEST_SIZE];
     for i in 1..APP_DIGEST_SIZE {

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -7,7 +7,7 @@ use openvm_stark_sdk::{
 };
 
 use crate::{
-    field::baby_bear::{BabyBearExtChip, BabyBearExtWire},
+    field::baby_bear::{BabyBearExtChip, BabyBearExtWire, ReducedBabyBearExtWire},
     profiling::CellProfiler,
     stages::{
         batch_constraints::{
@@ -25,15 +25,15 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct StackedReductionIntermediatesWire {
-    pub stacking_openings: Vec<Vec<BabyBearExtWire>>,
+    pub stacking_openings: Vec<Vec<ReducedBabyBearExtWire>>,
     pub u: Vec<BabyBearExtWire>,
 }
 
 #[derive(Clone, Debug)]
 pub struct StackingProofWire {
-    pub univariate_round_coeffs: Vec<BabyBearExtWire>,
-    pub sumcheck_round_polys: Vec<Vec<BabyBearExtWire>>,
-    pub stacking_openings: Vec<Vec<BabyBearExtWire>>,
+    pub univariate_round_coeffs: Vec<ReducedBabyBearExtWire>,
+    pub sumcheck_round_polys: Vec<Vec<ReducedBabyBearExtWire>>,
+    pub stacking_openings: Vec<Vec<ReducedBabyBearExtWire>>,
 }
 
 pub(crate) fn load_stacking_proof_wire(
@@ -44,14 +44,14 @@ pub(crate) fn load_stacking_proof_wire(
     let univariate_round_coeffs = stacking_proof
         .univariate_round_coeffs
         .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
+        .map(|&value| ext_chip.load_reduced_witness(ctx, value))
         .collect::<Vec<_>>();
     let sumcheck_round_polys = stacking_proof
         .sumcheck_round_polys
         .iter()
         .map(|poly| {
             poly.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
+                .map(|&value| ext_chip.load_reduced_witness(ctx, value))
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
@@ -60,7 +60,7 @@ pub(crate) fn load_stacking_proof_wire(
         .iter()
         .map(|row| {
             row.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
+                .map(|&value| ext_chip.load_reduced_witness(ctx, value))
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
@@ -97,7 +97,7 @@ pub(crate) fn constrain_stacked_reduction(
     need_rot_per_commit: &[Vec<bool>],
     l_skip: usize,
     n_stack: usize,
-    batch_column_openings: &[Vec<Vec<BabyBearExtWire>>],
+    batch_column_openings: &[Vec<Vec<ReducedBabyBearExtWire>>],
     r: &[BabyBearExtWire],
     profiler: &mut CellProfiler,
 ) -> StackedReductionIntermediatesWire {
@@ -126,16 +126,24 @@ pub(crate) fn constrain_stacked_reduction(
     let mut t_claims = Vec::with_capacity(lambda_idx);
     for (trace_idx, parts) in batch_column_openings.iter().enumerate() {
         let need_rot = need_rot_per_commit[0][trace_idx];
+        let openings = parts[0]
+            .iter()
+            .map(|opening| opening.into())
+            .collect::<Vec<_>>();
         t_claims.extend(column_openings_by_rot_assigned(
-            ctx, ext_chip, &parts[0], need_rot,
+            ctx, ext_chip, &openings, need_rot,
         ));
     }
     let mut commit_idx = 1usize;
     for parts in batch_column_openings {
         for cols in parts.iter().skip(1) {
             let need_rot = need_rot_per_commit[commit_idx][0];
+            let openings = cols
+                .iter()
+                .map(|opening| opening.into())
+                .collect::<Vec<_>>();
             t_claims.extend(column_openings_by_rot_assigned(
-                ctx, ext_chip, cols, need_rot,
+                ctx, ext_chip, &openings, need_rot,
             ));
             commit_idx += 1;
         }
@@ -169,8 +177,12 @@ pub(crate) fn constrain_stacked_reduction(
     profiler.push("univariate_sumcheck", ctx.advice.len());
 
     let univariate_round_coeffs = &stacking_wire.univariate_round_coeffs;
+    let univariate_round_coeffs_raw = univariate_round_coeffs
+        .iter()
+        .map(|coeff| coeff.into())
+        .collect::<Vec<_>>();
     let mut s_0_sum_eval = ext_chip.zero(ctx);
-    for coeff in univariate_round_coeffs.iter().step_by(omega_order) {
+    for coeff in univariate_round_coeffs_raw.iter().step_by(omega_order) {
         s_0_sum_eval = ext_chip.add(ctx, s_0_sum_eval, *coeff);
     }
     let s_0_sum_eval =
@@ -189,13 +201,15 @@ pub(crate) fn constrain_stacked_reduction(
     let sumcheck_round_polys = &stacking_wire.sumcheck_round_polys;
 
     let mut final_claim =
-        horner_eval_ext_poly_assigned(ctx, ext_chip, univariate_round_coeffs, &u[0]);
+        horner_eval_ext_poly_assigned(ctx, ext_chip, &univariate_round_coeffs_raw, &u[0]);
     for round_poly in sumcheck_round_polys {
         let s_j_1 = round_poly[0];
         let s_j_2 = round_poly[1];
         transcript.observe_ext(ctx, &s_j_1);
         transcript.observe_ext(ctx, &s_j_2);
         let u_j = transcript.sample_ext(ctx);
+        let s_j_1 = s_j_1.into();
+        let s_j_2 = s_j_2.into();
         let s_j_0 = ext_chip.sub(ctx, final_claim, s_j_1);
         final_claim =
             interpolate_quadratic_at_012_assigned(ctx, ext_chip, [&s_j_0, &s_j_1, &s_j_2], &u_j);
@@ -290,7 +304,7 @@ pub(crate) fn constrain_stacked_reduction(
     for (coeff_row, opening_row) in derived_q_coeffs.iter().zip(stacking_openings.iter()) {
         for (coeff, opening) in coeff_row.iter().zip(opening_row.iter()) {
             transcript.observe_ext(ctx, opening);
-            let term = ext_chip.mul(ctx, *coeff, *opening);
+            let term = ext_chip.mul(ctx, *coeff, opening.into());
             final_sum = ext_chip.add(ctx, final_sum, term);
         }
     }

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -20,7 +20,7 @@ use openvm_stark_sdk::{
 use crate::{
     field::baby_bear::{
         BabyBearChip, BabyBearExt4Wire, BabyBearExtChip, BabyBearExtWire, BabyBearWire,
-        BABY_BEAR_EXT_DEGREE,
+        ReducedBabyBearExtWire, ReducedBabyBearWire, BABY_BEAR_EXT_DEGREE,
     },
     hash::poseidon2::{compress_bn254_digests, hash_babybear_slice_to_digest},
     profiling::CellProfiler,
@@ -37,18 +37,18 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct MerklePathWire {
-    pub leaf_values: Vec<Vec<BabyBearWire>>,
+    pub leaf_values: Vec<Vec<ReducedBabyBearWire>>,
     pub siblings: Vec<AssignedValue<Fr>>,
 }
 
 #[derive(Clone, Debug)]
 pub struct WhirProofWire {
-    pub mu_pow_witness: BabyBearWire,
-    pub folding_pow_witnesses: Vec<BabyBearWire>,
-    pub query_phase_pow_witnesses: Vec<BabyBearWire>,
-    pub whir_sumcheck_polys: Vec<Vec<BabyBearExtWire>>,
-    pub ood_values: Vec<BabyBearExtWire>,
-    pub final_poly: Vec<BabyBearExtWire>,
+    pub mu_pow_witness: ReducedBabyBearWire,
+    pub folding_pow_witnesses: Vec<ReducedBabyBearWire>,
+    pub query_phase_pow_witnesses: Vec<ReducedBabyBearWire>,
+    pub whir_sumcheck_polys: Vec<Vec<ReducedBabyBearExtWire>>,
+    pub ood_values: Vec<ReducedBabyBearExtWire>,
+    pub final_poly: Vec<ReducedBabyBearExtWire>,
     pub codeword_commitment_roots: Vec<AssignedValue<Fr>>,
     pub initial_round_merkle_paths: Vec<Vec<MerklePathWire>>,
     pub codeword_merkle_paths: Vec<Vec<MerklePathWire>>,
@@ -60,35 +60,39 @@ pub(crate) fn load_whir_proof_wire(
     ext_chip: &BabyBearExtChip,
     whir_proof: &WhirProof<RootConfig>,
 ) -> WhirProofWire {
-    let mu_pow_witness = base_chip.load_witness(ctx, whir_proof.mu_pow_witness);
+    let mu_pow_witness = base_chip.load_reduced_witness(ctx, whir_proof.mu_pow_witness);
     let folding_pow_witnesses = whir_proof
         .folding_pow_witnesses
         .iter()
-        .map(|&witness| base_chip.load_witness(ctx, RootF::from_u64(witness.as_canonical_u64())))
+        .map(|&witness| {
+            base_chip.load_reduced_witness(ctx, RootF::from_u64(witness.as_canonical_u64()))
+        })
         .collect::<Vec<_>>();
     let query_phase_pow_witnesses = whir_proof
         .query_phase_pow_witnesses
         .iter()
-        .map(|&witness| base_chip.load_witness(ctx, RootF::from_u64(witness.as_canonical_u64())))
+        .map(|&witness| {
+            base_chip.load_reduced_witness(ctx, RootF::from_u64(witness.as_canonical_u64()))
+        })
         .collect::<Vec<_>>();
     let whir_sumcheck_polys = whir_proof
         .whir_sumcheck_polys
         .iter()
         .map(|poly| {
             poly.iter()
-                .map(|&value| ext_chip.load_witness(ctx, value))
+                .map(|&value| ext_chip.load_reduced_witness(ctx, value))
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
     let ood_values = whir_proof
         .ood_values
         .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
+        .map(|&value| ext_chip.load_reduced_witness(ctx, value))
         .collect::<Vec<_>>();
     let final_poly = whir_proof
         .final_poly
         .iter()
-        .map(|&value| ext_chip.load_witness(ctx, value))
+        .map(|&value| ext_chip.load_reduced_witness(ctx, value))
         .collect::<Vec<_>>();
     let codeword_commitment_roots = whir_proof
         .codeword_commits
@@ -109,8 +113,8 @@ pub(crate) fn load_whir_proof_wire(
                         .iter()
                         .map(|row| {
                             row.iter()
-                                .map(|&value| base_chip.load_witness(ctx, value))
-                                .collect::<Vec<BabyBearWire>>()
+                                .map(|&value| base_chip.load_reduced_witness(ctx, value))
+                                .collect::<Vec<ReducedBabyBearWire>>()
                         })
                         .collect::<Vec<_>>();
                     let siblings = merkle_proof
@@ -140,8 +144,10 @@ pub(crate) fn load_whir_proof_wire(
                         .map(|value| {
                             ext_to_coeffs(*value)
                                 .iter()
-                                .map(|&coeff| base_chip.load_witness(ctx, RootF::from_u64(coeff)))
-                                .collect::<Vec<BabyBearWire>>()
+                                .map(|&coeff| {
+                                    base_chip.load_reduced_witness(ctx, RootF::from_u64(coeff))
+                                })
+                                .collect::<Vec<ReducedBabyBearWire>>()
                         })
                         .collect::<Vec<_>>();
                     let siblings = merkle_proof
@@ -402,7 +408,7 @@ pub(crate) fn constrain_whir_verification(
     transcript: &mut TranscriptChip,
     mvk0: &MultiStarkVerifyingKey0<RootConfig>,
     whir_wire: &WhirProofWire,
-    stacking_openings: &[Vec<BabyBearExtWire>],
+    stacking_openings: &[Vec<ReducedBabyBearExtWire>],
     initial_commitment_roots: &[AssignedValue<Fr>],
     u_cube: &[BabyBearExtWire],
     profiler: &mut CellProfiler,
@@ -422,7 +428,11 @@ pub(crate) fn constrain_whir_verification(
     let query_phase_pow_witnesses = &whir_wire.query_phase_pow_witnesses;
     let whir_sumcheck_polys = &whir_wire.whir_sumcheck_polys;
     let ood_values = &whir_wire.ood_values;
-    let final_poly = &whir_wire.final_poly;
+    let final_poly_reduced = &whir_wire.final_poly;
+    let final_poly = final_poly_reduced
+        .iter()
+        .map(|coeff| coeff.into())
+        .collect::<Vec<_>>();
     let codeword_commitment_roots = &whir_wire.codeword_commitment_roots;
     let codeword_commitment_digests = codeword_commitment_roots
         .iter()
@@ -445,9 +455,9 @@ pub(crate) fn constrain_whir_verification(
     for commit_openings in stacking_openings {
         for opening in commit_openings {
             let weighted = if mu_idx == 0 {
-                *opening
+                (*opening).into()
             } else {
-                ext_chip.mul(ctx, *opening, mu_pows[mu_idx])
+                ext_chip.mul(ctx, opening.into(), mu_pows[mu_idx])
             };
             final_claim = ext_chip.add(ctx, final_claim, weighted);
             mu_idx += 1;
@@ -493,6 +503,8 @@ pub(crate) fn constrain_whir_verification(
                 alphas_round.push(alpha);
                 folding_alphas.push(alpha);
 
+                let ev1 = ev1.into();
+                let ev2 = ev2.into();
                 let ev0 = ext_chip.sub(ctx, final_claim, ev1);
                 final_claim = interpolate_quadratic_at_012_assigned(
                     ctx,
@@ -507,7 +519,7 @@ pub(crate) fn constrain_whir_verification(
         profiler.pop(ctx.advice.len());
 
         let y0 = if is_final_round {
-            for coeff in final_poly {
+            for coeff in final_poly_reduced {
                 transcript.observe_ext(ctx, coeff);
             }
             None
@@ -568,7 +580,7 @@ pub(crate) fn constrain_whir_verification(
                         let mu_pow = mu_pows[mu_power_idx];
                         let is_first_mu = mu_power_idx == 0;
                         for (row_idx, row) in merkle_path.leaf_values.iter().enumerate() {
-                            let opened_base = row[col_idx];
+                            let opened_base = row[col_idx].into();
                             codeword_vals[row_idx] = if let Some(prev) = codeword_vals[row_idx] {
                                 Some(ext_chip.scalar_mul_add(ctx, mu_pow, opened_base, prev))
                             } else if is_first_mu {
@@ -596,7 +608,7 @@ pub(crate) fn constrain_whir_verification(
                 let opened_values = merkle_path
                     .leaf_values
                     .iter()
-                    .map(|row| BabyBearExt4Wire(core::array::from_fn(|idx| row[idx])))
+                    .map(|row| BabyBearExt4Wire(core::array::from_fn(|idx| row[idx].into())))
                     .collect::<Vec<_>>();
                 binary_k_fold_assigned(ctx, ext_chip, opened_values, &alphas_round, zi_root)
             };
@@ -609,7 +621,7 @@ pub(crate) fn constrain_whir_verification(
         profiler.push("gamma_accumulation", ctx.advice.len());
         let gamma = transcript.sample_ext(ctx);
         if let Some(y0) = y0 {
-            let y0_term = ext_chip.mul(ctx, y0, gamma);
+            let y0_term = ext_chip.mul(ctx, y0.into(), gamma);
             final_claim = ext_chip.add(ctx, final_claim, y0_term);
         }
         let mut gamma_pow = ext_chip.mul(ctx, gamma, gamma);
@@ -633,7 +645,7 @@ pub(crate) fn constrain_whir_verification(
 
     profiler.push("eq_mle_prefix_suffix", ctx.advice.len());
     let prefix = eval_mobius_eq_mle_assigned(ctx, ext_chip, &u_cube[..t], &folding_alphas[..t]);
-    let suffix = eval_mle_evals_at_point_assigned(ctx, ext_chip, final_poly, &u_cube[t..]);
+    let suffix = eval_mle_evals_at_point_assigned(ctx, ext_chip, &final_poly, &u_cube[t..]);
     let mut final_acc = ext_chip.mul(ctx, prefix, suffix);
     profiler.pop(ctx.advice.len());
 
@@ -668,7 +680,7 @@ pub(crate) fn constrain_whir_verification(
                 alpha_slc,
                 &z0_pows_reduced[..z0_pows_reduced.len().saturating_sub(1)],
             );
-            let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, final_poly, &z0_max);
+            let poly_eval = horner_eval_ext_poly_assigned(ctx, ext_chip, &final_poly, &z0_max);
             let term = ext_chip.mul(ctx, *gamma, eq);
             let term = ext_chip.mul(ctx, term, poly_eval);
             final_acc = ext_chip.add(ctx, final_acc, term);
@@ -701,7 +713,7 @@ pub(crate) fn constrain_whir_verification(
             let poly_eval = horner_eval_ext_poly_f_assigned(
                 ctx,
                 ext_chip,
-                final_poly,
+                &final_poly,
                 zi_pows_reduced.last().unwrap(),
             );
 

--- a/crates/static-verifier/src/transcript/mod.rs
+++ b/crates/static-verifier/src/transcript/mod.rs
@@ -15,8 +15,8 @@ use openvm_stark_sdk::{
 
 use crate::{
     field::baby_bear::{
-        BabyBearChip, BabyBearExt4Wire, BabyBearExtWire, BabyBearWire, BABY_BEAR_BITS,
-        BABY_BEAR_MODULUS_U64,
+        BabyBearChip, BabyBearExt4Wire, BabyBearExtWire, BabyBearWire, ReducedBabyBearExtWire,
+        ReducedBabyBearWire, BABY_BEAR_BITS, BABY_BEAR_MODULUS_U64,
     },
     hash::{
         poseidon2::{Poseidon2State, DIGEST_WIDTH, POSEIDON2_RATE},
@@ -188,11 +188,11 @@ fn decompose_bn254_to_base_baby_bear_digits(
 fn pack_base_2_31(
     ctx: &mut Context<Fr>,
     gate: &impl GateInstructions<Fr>,
-    values: &[BabyBearWire],
+    values: &[ReducedBabyBearWire],
 ) -> AssignedValue<Fr> {
     gate.inner_product(
         ctx,
-        values.iter().map(|v| v.value),
+        values.iter().map(|v| v.value()),
         gate.pow_of_two()
             .iter()
             .step_by(BABY_BEAR_BITS)
@@ -227,7 +227,7 @@ pub struct TranscriptChip {
     sponge_state: [AssignedValue<Fr>; POSEIDON2_WIDTH],
     absorb_idx: usize,
     sample_idx: usize,
-    observe_buf: Vec<BabyBearWire>,
+    observe_buf: Vec<ReducedBabyBearWire>,
     sample_buf: Vec<BabyBearWire>,
 }
 
@@ -310,7 +310,7 @@ impl TranscriptChip {
         }
     }
 
-    pub fn observe(&mut self, ctx: &mut Context<Fr>, value: &BabyBearWire) {
+    pub fn observe(&mut self, ctx: &mut Context<Fr>, value: &ReducedBabyBearWire) {
         self.invalidate_samples();
         self.observe_buf.push(*value);
         if self.observe_buf.len() == NUM_OBS_PER_WORD {
@@ -318,8 +318,8 @@ impl TranscriptChip {
         }
     }
 
-    pub fn observe_ext(&mut self, ctx: &mut Context<Fr>, value: &BabyBearExtWire) {
-        for coeff in &value.0 {
+    pub fn observe_ext(&mut self, ctx: &mut Context<Fr>, value: &ReducedBabyBearExtWire) {
+        for coeff in value.coeffs() {
             self.observe(ctx, coeff);
         }
     }
@@ -374,7 +374,12 @@ impl TranscriptChip {
     }
 
     /// Asserts that the PoW witness must pass.
-    pub fn check_witness(&mut self, ctx: &mut Context<Fr>, bits: usize, witness: &BabyBearWire) {
+    pub fn check_witness(
+        &mut self,
+        ctx: &mut Context<Fr>,
+        bits: usize,
+        witness: &ReducedBabyBearWire,
+    ) {
         if bits == 0 {
             return;
         }

--- a/crates/static-verifier/src/transcript/tests.rs
+++ b/crates/static-verifier/src/transcript/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use halo2_base::{
     gates::{
         circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
-        GateInstructions, RangeInstructions,
+        GateInstructions,
     },
     halo2_proofs::dev::MockProver,
 };
@@ -21,7 +21,7 @@ use openvm_stark_sdk::{
 use super::*;
 use crate::{
     config::{STATIC_VERIFIER_LOOKUP_ADVICE_COLS, STATIC_VERIFIER_NUM_ADVICE_COLS},
-    field::baby_bear::{BabyBearChip, BabyBearExt4Wire},
+    field::baby_bear::{BabyBearChip, BabyBearExtChip},
     RootEF, RootF,
 };
 
@@ -148,22 +148,23 @@ fn transcript_outputs_match_native_interleaved_flow() {
     run_mock(true, |builder| {
         let range = builder.range_chip();
         let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
+        let baby_bear_ext = BabyBearExtChip::new(baby_bear.clone());
 
         let ctx = builder.main(0);
         let gate = range.gate();
 
         let mut transcript = TranscriptChip::new(ctx, baby_bear.clone());
 
-        let one = baby_bear.load_witness(ctx, RootF::from_u64(1));
-        let two = baby_bear.load_witness(ctx, RootF::from_u64(2));
-        let three = baby_bear.load_witness(ctx, RootF::from_u64(3));
+        let one = baby_bear.load_reduced_witness(ctx, RootF::from_u64(1));
+        let two = baby_bear.load_reduced_witness(ctx, RootF::from_u64(2));
+        let three = baby_bear.load_reduced_witness(ctx, RootF::from_u64(3));
         transcript.observe(ctx, &one);
         transcript.observe(ctx, &two);
         transcript.observe(ctx, &three);
 
-        let observed_ext = BabyBearExt4Wire(core::array::from_fn(|i| {
-            baby_bear.load_witness(ctx, RootF::from_u64(observed_ext_coeffs[i]))
-        }));
+        let observed_ext =
+            RootEF::from_basis_coefficients_fn(|i| RootF::from_u64(observed_ext_coeffs[i]));
+        let observed_ext = baby_bear_ext.load_reduced_witness(ctx, observed_ext);
         transcript.observe_ext(ctx, &observed_ext);
 
         let digest_wire = TranscriptChip::load_digest_witness(ctx, digest);
@@ -180,7 +181,7 @@ fn transcript_outputs_match_native_interleaved_flow() {
         let sampled_bits = transcript.sample_bits(ctx, 17);
         gate.assert_is_const(ctx, &sampled_bits, &Fr::from(expected_bits));
 
-        let pow_witness = baby_bear.load_witness(ctx, RootF::from_u64(witness_for_pow));
+        let pow_witness = baby_bear.load_reduced_witness(ctx, RootF::from_u64(witness_for_pow));
         transcript.check_witness(ctx, 9, &pow_witness);
 
         let followup = transcript.sample(ctx);
@@ -205,13 +206,13 @@ fn transcript_check_witness_zero_bits_matches_native() {
 
         let mut transcript = TranscriptChip::new(ctx, baby_bear.clone());
 
-        let obs = baby_bear.load_witness(ctx, RootF::from_u64(99));
+        let obs = baby_bear.load_reduced_witness(ctx, RootF::from_u64(99));
         transcript.observe(ctx, &obs);
 
         let first = transcript.sample(ctx);
         gate.assert_is_const(ctx, &first.value, &Fr::from(expected_first));
 
-        let witness = baby_bear.load_witness(ctx, RootF::from_u64(7));
+        let witness = baby_bear.load_reduced_witness(ctx, RootF::from_u64(7));
         transcript.check_witness(ctx, 0, &witness);
 
         let second = transcript.sample(ctx);


### PR DESCRIPTION
Introduce reduced wire for BabyBear values absorbed by the transcript and hash.