### PR TITLE
fix(v2-rc2): tie execution instances to executor inventory

### DIFF
--- a/crates/vm/derive/src/tco.rs
+++ b/crates/vm/derive/src/tco.rs
@@ -56,7 +56,7 @@ pub fn tco_impl(item: TokenStream) -> TokenStream {
     let handler_fn = quote! {
         #[inline(never)]
         unsafe fn #handler_name #handler_generics (
-            interpreter: &::openvm_circuit::arch::interpreter::InterpretedInstance<#f_type, #ctx_type>,
+            interpreter: &::openvm_circuit::arch::interpreter::InterpretedInstance<'_, #f_type, #ctx_type>,
             exec_state: &mut ::openvm_circuit::arch::VmExecState<
                 #f_type,
                 ::openvm_circuit::system::memory::online::GuestMemory,

--- a/crates/vm/src/arch/aot/metered_execute.rs
+++ b/crates/vm/src/arch/aot/metered_execute.rs
@@ -20,15 +20,18 @@ use crate::{
     },
     system::memory::online::GuestMemory,
 };
-static_assertions::assert_impl_all!(AotInstance<p3_baby_bear::BabyBear, MeteredCtx>: Send, Sync);
+static_assertions::assert_impl_all!(
+    AotInstance<'static, p3_baby_bear::BabyBear, MeteredCtx>: Send,
+    Sync
+);
 
-impl<F> AotInstance<F, MeteredCtx>
+impl<'a, F> AotInstance<'a, F, MeteredCtx>
 where
     F: PrimeField32,
 {
     /// Creates a new instance for metered execution.
     pub fn new_metered<E>(
-        inventory: &ExecutorInventory<E>,
+        inventory: &'a ExecutorInventory<E>,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
     ) -> Result<Self, StaticProgramError>
@@ -63,7 +66,7 @@ where
             start.elapsed().as_millis()
         );
         Ok(Self {
-            system_config: inventory.config().clone(),
+            system_config: inventory.config(),
             pre_compute_buf,
             pre_compute_insns,
             pc_start: exe.pc_start,
@@ -71,7 +74,7 @@ where
             lib,
         })
     }
-    pub fn create_metered_asm<E>(
+    fn create_metered_asm<E>(
         exe: &VmExe<F>,
         inventory: &ExecutorInventory<E>,
         executor_idx_to_air_idx: &[usize],

--- a/crates/vm/src/arch/aot/mod.rs
+++ b/crates/vm/src/arch/aot/mod.rs
@@ -24,9 +24,9 @@ mod pure;
 /// Verify installation by `as --version`, `ar --version` and `cargo --version`
 /// Refer to AOT.md for further clarification about AOT
 ///  
-pub struct AotInstance<F, Ctx> {
+pub struct AotInstance<'a, F, Ctx> {
     init_memory: SparseMemoryImage,
-    system_config: SystemConfig,
+    system_config: &'a SystemConfig,
     // SAFETY: this is not actually dead code, but `pre_compute_insns` contains raw pointer refers
     // to this buffer.
     #[allow(dead_code)]
@@ -43,18 +43,13 @@ type AsmRunFn = unsafe extern "C" fn(
     instret_left: u64,
 );
 
-impl<F, Ctx> AotInstance<F, Ctx>
+impl<'a, F, Ctx> AotInstance<'a, F, Ctx>
 where
     F: PrimeField32,
     Ctx: ExecutionCtxTrait,
 {
     pub fn create_initial_vm_state(&self, inputs: impl Into<Streams<F>>) -> VmState<F> {
-        VmState::initial(
-            &self.system_config,
-            &self.init_memory,
-            self.pc_start,
-            inputs,
-        )
+        VmState::initial(self.system_config, &self.init_memory, self.pc_start, inputs)
     }
 
     fn push_external_registers() -> String {

--- a/crates/vm/src/arch/aot/pure.rs
+++ b/crates/vm/src/arch/aot/pure.rs
@@ -21,13 +21,16 @@ use crate::{
     system::memory::online::GuestMemory,
 };
 
-static_assertions::assert_impl_all!(AotInstance<p3_baby_bear::BabyBear, ExecutionCtx>: Send, Sync);
+static_assertions::assert_impl_all!(
+    AotInstance<'static, p3_baby_bear::BabyBear, ExecutionCtx>: Send,
+    Sync
+);
 
-impl<'a, F> AotInstance<F, ExecutionCtx>
+impl<'a, F> AotInstance<'a, F, ExecutionCtx>
 where
     F: PrimeField32,
 {
-    pub fn create_pure_asm<E>(
+    fn create_pure_asm<E>(
         exe: &VmExe<F>,
         inventory: &ExecutorInventory<E>,
         pre_compute_insns_ptr: *const PreComputeInstruction<F, ExecutionCtx>,
@@ -263,7 +266,7 @@ where
         let init_memory = exe.init_memory.clone();
 
         Ok(Self {
-            system_config: inventory.config().clone(),
+            system_config: inventory.config(),
             pre_compute_buf,
             pre_compute_insns,
             pc_start: exe.pc_start,

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -134,7 +134,7 @@ pub type ExecuteFunc<F, CTX> =
 ///   pointer is typeless to avoid self-referential types.
 #[cfg(feature = "tco")]
 pub type Handler<F, CTX> = unsafe fn(
-    interpreter: &InterpretedInstance<F, CTX>,
+    interpreter: &InterpretedInstance<'_, F, CTX>,
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 );
 

--- a/crates/vm/src/arch/interpreter.rs
+++ b/crates/vm/src/arch/interpreter.rs
@@ -37,8 +37,8 @@ use crate::{
 // NOTE: the lifetime 'a represents the lifetime of borrowed ExecutorInventory, which must outlive
 // the InterpretedInstance because `pre_compute_buf` may contain pointers to references held by
 // executors.
-pub struct InterpretedInstance<F, Ctx> {
-    system_config: SystemConfig,
+pub struct InterpretedInstance<'a, F, Ctx> {
+    system_config: &'a SystemConfig,
     // SAFETY: this is not actually dead code, but `pre_compute_insns` contains raw pointer refers
     // to this buffer.
     #[allow(dead_code)]
@@ -62,9 +62,9 @@ pub struct InterpretedInstance<F, Ctx> {
 
 #[repr(C)]
 #[cfg_attr(feature = "tco", allow(dead_code))]
-pub struct PreComputeInstruction<F, Ctx> {
-    pub handler: ExecuteFunc<F, Ctx>,
-    pub pre_compute: *const u8,
+pub(crate) struct PreComputeInstruction<F, Ctx> {
+    pub(crate) handler: ExecuteFunc<F, Ctx>,
+    pub(crate) pre_compute: *const u8,
 }
 
 unsafe impl<F, Ctx> Send for PreComputeInstruction<F, Ctx> {}
@@ -114,7 +114,7 @@ macro_rules! run {
 // pointers
 // - Generic in `Ctx`
 
-impl<F, Ctx> InterpretedInstance<F, Ctx>
+impl<'a, F, Ctx> InterpretedInstance<'a, F, Ctx>
 where
     F: PrimeField32,
     Ctx: ExecutionCtxTrait,
@@ -122,7 +122,7 @@ where
     /// Creates a new interpreter instance for pure execution.
     // (E1 execution)
     pub fn new<E>(
-        inventory: &ExecutorInventory<E>,
+        inventory: &'a ExecutorInventory<E>,
         exe: &VmExe<F>,
     ) -> Result<Self, StaticProgramError>
     where
@@ -166,7 +166,7 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            system_config: inventory.config().clone(),
+            system_config: inventory.config(),
             pre_compute_buf,
             #[cfg(not(feature = "tco"))]
             pre_compute_insns,
@@ -180,12 +180,7 @@ where
     }
 
     pub fn create_initial_vm_state(&self, inputs: impl Into<Streams<F>>) -> VmState<F> {
-        VmState::initial(
-            &self.system_config,
-            &self.init_memory,
-            self.pc_start,
-            inputs,
-        )
+        VmState::initial(self.system_config, &self.init_memory, self.pc_start, inputs)
     }
 
     /// # Safety
@@ -223,7 +218,7 @@ where
     }
 }
 
-impl<'a, F, Ctx> InterpretedInstance<F, Ctx>
+impl<'a, F, Ctx> InterpretedInstance<'a, F, Ctx>
 where
     F: PrimeField32,
     Ctx: MeteredExecutionCtxTrait,
@@ -280,7 +275,7 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            system_config: inventory.config().clone(),
+            system_config: inventory.config(),
             pre_compute_buf,
             #[cfg(not(feature = "tco"))]
             pre_compute_insns,
@@ -296,7 +291,7 @@ where
 
 // Execute functions specialize to relevant Ctx types to provide more streamlines APIs
 
-impl<F> InterpretedInstance<F, ExecutionCtx>
+impl<'a, F> InterpretedInstance<'a, F, ExecutionCtx>
 where
     F: PrimeField32,
 {
@@ -310,12 +305,8 @@ where
         inputs: impl Into<Streams<F>>,
         num_insns: Option<u64>,
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
-        let vm_state = VmState::initial(
-            &self.system_config,
-            &self.init_memory,
-            self.pc_start,
-            inputs,
-        );
+        let vm_state =
+            VmState::initial(self.system_config, &self.init_memory, self.pc_start, inputs);
         self.execute_from_state(vm_state, num_insns)
     }
 
@@ -360,7 +351,7 @@ where
     }
 }
 
-impl<F> InterpretedInstance<F, MeteredCtx>
+impl<'a, F> InterpretedInstance<'a, F, MeteredCtx>
 where
     F: PrimeField32,
 {
@@ -451,7 +442,7 @@ where
     }
 }
 
-impl<F> InterpretedInstance<F, MeteredCostCtx>
+impl<'a, F> InterpretedInstance<'a, F, MeteredCostCtx>
 where
     F: PrimeField32,
 {
@@ -503,14 +494,17 @@ where
     }
 }
 
-pub fn alloc_pre_compute_buf<F>(program: &Program<F>, pre_compute_max_size: usize) -> AlignedBuf {
+pub(crate) fn alloc_pre_compute_buf<F>(
+    program: &Program<F>,
+    pre_compute_max_size: usize,
+) -> AlignedBuf {
     let base_idx = get_pc_index(program.pc_base);
     let padded_program_len = base_idx + program.instructions_and_debug_infos.len();
     let buf_len = padded_program_len * pre_compute_max_size;
     AlignedBuf::uninit(buf_len, pre_compute_max_size)
 }
 
-pub fn split_pre_compute_buf<'a, F>(
+pub(crate) fn split_pre_compute_buf<'a, F>(
     program: &Program<F>,
     pre_compute_buf: &'a mut AlignedBuf,
     pre_compute_max_size: usize,
@@ -568,7 +562,7 @@ pub fn get_pc_index(pc: u32) -> usize {
 /// initialization.git
 // @dev: This is duplicate from the openvm crate, but it doesn't seem worth importing `openvm` here
 // just for this.
-pub struct AlignedBuf {
+pub(crate) struct AlignedBuf {
     pub ptr: *mut u8,
     pub layout: Layout,
 }
@@ -620,7 +614,7 @@ unsafe fn terminate_execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
 
 #[cfg(feature = "tco")]
 unsafe fn terminate_execute_e12_tco_handler<F: PrimeField32, CTX: ExecutionCtxTrait>(
-    interpreter: &InterpretedInstance<F, CTX>,
+    interpreter: &InterpretedInstance<'_, F, CTX>,
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 ) {
     let pre_compute = interpreter.get_pre_compute(exec_state.vm_state.pc());
@@ -629,13 +623,13 @@ unsafe fn terminate_execute_e12_tco_handler<F: PrimeField32, CTX: ExecutionCtxTr
 
 #[cfg(feature = "tco")]
 unsafe fn unreachable_tco_handler<F: PrimeField32, CTX>(
-    _: &InterpretedInstance<F, CTX>,
+    _: &InterpretedInstance<'_, F, CTX>,
     exec_state: &mut VmExecState<F, GuestMemory, CTX>,
 ) {
     exec_state.exit_code = Err(ExecutionError::Unreachable(exec_state.vm_state.pc()));
 }
 
-pub fn get_pre_compute_max_size<F, E: Executor<F>>(
+pub(crate) fn get_pre_compute_max_size<F, E: Executor<F>>(
     program: &Program<F>,
     inventory: &ExecutorInventory<E>,
 ) -> usize {
@@ -661,7 +655,7 @@ pub fn get_pre_compute_max_size<F, E: Executor<F>>(
         .next_power_of_two()
 }
 
-pub fn get_metered_pre_compute_max_size<F, E: MeteredExecutor<F>>(
+pub(crate) fn get_metered_pre_compute_max_size<F, E: MeteredExecutor<F>>(
     program: &Program<F>,
     inventory: &ExecutorInventory<E>,
 ) -> usize {
@@ -695,7 +689,7 @@ fn system_opcode_pre_compute_size<F>(inst: &Instruction<F>) -> Option<usize> {
 }
 
 #[cfg(not(feature = "tco"))]
-pub fn get_pre_compute_instructions<F, Ctx, E>(
+pub(crate) fn get_pre_compute_instructions<F, Ctx, E>(
     program: &Program<F>,
     inventory: &ExecutorInventory<E>,
     pre_compute: &mut [&mut [u8]],
@@ -751,7 +745,7 @@ where
 }
 
 #[cfg(not(feature = "tco"))]
-pub fn get_metered_pre_compute_instructions<F, Ctx, E>(
+pub(crate) fn get_metered_pre_compute_instructions<F, Ctx, E>(
     program: &Program<F>,
     inventory: &ExecutorInventory<E>,
     executor_idx_to_air_idx: &[usize],

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -223,7 +223,7 @@ where
     pub fn instance(
         &self,
         exe: &VmExe<F>,
-    ) -> Result<InterpretedInstance<F, ExecutionCtx>, StaticProgramError> {
+    ) -> Result<InterpretedInstance<'_, F, ExecutionCtx>, StaticProgramError> {
         InterpretedInstance::new(&self.inventory, exe)
     }
 
@@ -231,7 +231,7 @@ where
     pub fn interpreter_instance(
         &self,
         exe: &VmExe<F>,
-    ) -> Result<InterpretedInstance<F, ExecutionCtx>, StaticProgramError> {
+    ) -> Result<InterpretedInstance<'_, F, ExecutionCtx>, StaticProgramError> {
         InterpretedInstance::new(&self.inventory, exe)
     }
 
@@ -239,7 +239,7 @@ where
     pub fn instance(
         &self,
         exe: &VmExe<F>,
-    ) -> Result<AotInstance<F, ExecutionCtx>, StaticProgramError> {
+    ) -> Result<AotInstance<'_, F, ExecutionCtx>, StaticProgramError> {
         Self::aot_instance(self, exe)
     }
 }
@@ -253,7 +253,7 @@ where
     pub fn aot_instance(
         &self,
         exe: &VmExe<F>,
-    ) -> Result<AotInstance<F, ExecutionCtx>, StaticProgramError> {
+    ) -> Result<AotInstance<'_, F, ExecutionCtx>, StaticProgramError> {
         AotInstance::new(&self.inventory, exe)
     }
 }
@@ -270,7 +270,7 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<InterpretedInstance<F, MeteredCtx>, StaticProgramError> {
+    ) -> Result<InterpretedInstance<'_, F, MeteredCtx>, StaticProgramError> {
         InterpretedInstance::new_metered(&self.inventory, exe, executor_idx_to_air_idx)
     }
 
@@ -279,7 +279,7 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<InterpretedInstance<F, MeteredCtx>, StaticProgramError> {
+    ) -> Result<InterpretedInstance<'_, F, MeteredCtx>, StaticProgramError> {
         InterpretedInstance::new_metered(&self.inventory, exe, executor_idx_to_air_idx)
     }
 
@@ -288,7 +288,7 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<AotInstance<F, MeteredCtx>, StaticProgramError> {
+    ) -> Result<AotInstance<'_, F, MeteredCtx>, StaticProgramError> {
         Self::metered_aot_instance(self, exe, executor_idx_to_air_idx)
     }
 
@@ -298,7 +298,7 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<AotInstance<F, MeteredCtx>, StaticProgramError> {
+    ) -> Result<AotInstance<'_, F, MeteredCtx>, StaticProgramError> {
         AotInstance::new_metered(&self.inventory, exe, executor_idx_to_air_idx)
     }
 
@@ -308,7 +308,7 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<InterpretedInstance<F, MeteredCostCtx>, StaticProgramError> {
+    ) -> Result<InterpretedInstance<'_, F, MeteredCostCtx>, StaticProgramError> {
         InterpretedInstance::new_metered(&self.inventory, exe, executor_idx_to_air_idx)
     }
 }
@@ -450,7 +450,7 @@ where
     pub fn interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<InterpretedInstance<Val<E::SC>, ExecutionCtx>, StaticProgramError>
+    ) -> Result<InterpretedInstance<'_, Val<E::SC>, ExecutionCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
@@ -463,7 +463,7 @@ where
     pub fn naive_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<InterpretedInstance<Val<E::SC>, ExecutionCtx>, StaticProgramError>
+    ) -> Result<InterpretedInstance<'_, Val<E::SC>, ExecutionCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
@@ -476,7 +476,7 @@ where
     pub fn interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<AotInstance<Val<E::SC>, ExecutionCtx>, StaticProgramError>
+    ) -> Result<AotInstance<'_, Val<E::SC>, ExecutionCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
@@ -488,7 +488,7 @@ where
     pub fn get_aot_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<AotInstance<Val<E::SC>, ExecutionCtx>, StaticProgramError>
+    ) -> Result<AotInstance<'_, Val<E::SC>, ExecutionCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
@@ -500,7 +500,7 @@ where
     pub fn metered_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<InterpretedInstance<Val<E::SC>, MeteredCtx>, StaticProgramError>
+    ) -> Result<InterpretedInstance<'_, Val<E::SC>, MeteredCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -514,7 +514,7 @@ where
     pub fn metered_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<AotInstance<Val<E::SC>, MeteredCtx>, StaticProgramError>
+    ) -> Result<AotInstance<'_, Val<E::SC>, MeteredCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -529,7 +529,7 @@ where
     pub fn get_metered_aot_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<AotInstance<Val<E::SC>, MeteredCtx>, StaticProgramError>
+    ) -> Result<AotInstance<'_, Val<E::SC>, MeteredCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -543,7 +543,7 @@ where
     pub fn naive_metered_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<InterpretedInstance<Val<E::SC>, MeteredCtx>, StaticProgramError>
+    ) -> Result<InterpretedInstance<'_, Val<E::SC>, MeteredCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -556,7 +556,7 @@ where
     pub fn metered_cost_interpreter(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<InterpretedInstance<Val<E::SC>, MeteredCostCtx>, StaticProgramError>
+    ) -> Result<InterpretedInstance<'_, Val<E::SC>, MeteredCostCtx>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,


### PR DESCRIPTION
Fixes undefined behavior in interpreter/AOT execution instances where instruction precompute buffers can contain pointers back into executor-owned data, such as field expressions, deferral functions, or phantom sub-executors. Before this change, an execution instance could outlive the `ExecutorInventory` that owned those targets, leaving dangling pointers and causing a possible use-after-free during execution.

This threads the `ExecutorInventory` lifetime through `InterpretedInstance` and `AotInstance` so Rust prevents execution instances from outliving the inventory they borrow. It also makes raw precompute construction helpers crate-private so external callers cannot build lifetime-erased precompute buffers directly.