### PR TITLE
fix: preserve x0 for AOT unsigned loads

### DIFF
--- a/docs/vocs/docs/pages/specs/reference/transpiler.mdx
+++ b/docs/vocs/docs/pages/specs/reference/transpiler.mdx
@@ -69,7 +69,7 @@ to handling of the `x0` register, which discards writes and has value `0` in all
 We handle writes to `x0` in transpilation as follows:
 
 - Instructions that write to `x0` with no side effects are transpiled to the PHANTOM instruction with `c = 0x00` (`Nop`).
-- Instructions that write to a register which might be `x0` with side effects (JAL, JALR) are transpiled to the corresponding custom instruction whose write behavior is controlled by a flag specifying whether the target register is `x0`.
+- Instructions that write to a register which might be `x0` with side effects (loads, JAL, JALR) are transpiled to the corresponding custom instruction whose write behavior is controlled by a flag specifying whether the target register is `x0`.
 
 Because `[0:4]_1` is initialized to `0` and never written to, this guarantees that reads from `x0` yield `0` and enforces that any OpenVM program transpiled from RV32IM conforms to the RV32IM specification for `x0`.
 

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -18,7 +18,7 @@ mod aot {
 
     pub(crate) fn gpr_to_rv32_register(gpr: &str, rv32_reg: u8) -> String {
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")
@@ -65,7 +65,7 @@ mod aot {
             return (override_reg.to_string(), "".to_string());
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             (
                 gpr.to_string(),
                 format!("   pextrd {gpr}, xmm{xmm_map_reg}, 0\n"),
@@ -87,7 +87,7 @@ mod aot {
             return format!("   mov {override_reg}, {gpr}\n");
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")

--- a/extensions/rv32im/circuit/src/loadstore/aot.rs
+++ b/extensions/rv32im/circuit/src/loadstore/aot.rs
@@ -138,34 +138,37 @@ fn generate_x86_asm_impl<F: PrimeField32>(
 
     match local_opcode {
         Rv32LoadStoreOpcode::LOADW => {
-            let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
             } else {
-                REG_B_W
+                REG_C_W
             };
-
             asm_str += &format!("   mov {str_reg_a}, [{gpr_reg_w64}]\n");
-            asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            if enabled {
+                asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            }
         }
         Rv32LoadStoreOpcode::LOADHU => {
-            let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
             } else {
-                REG_B_W
+                REG_C_W
             };
-
             asm_str += &format!("   movzx {str_reg_a}, word ptr [{gpr_reg_w64}]\n");
-            asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            if enabled {
+                asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            }
         }
         Rv32LoadStoreOpcode::LOADBU => {
-            let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
             } else {
-                REG_B_W
+                REG_C_W
             };
-
             asm_str += &format!("   movzx {str_reg_a}, byte ptr [{gpr_reg_w64}]\n");
-            asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            if enabled {
+                asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            }
         }
         Rv32LoadStoreOpcode::STOREW => {
             if !enabled {
@@ -199,4 +202,61 @@ fn generate_x86_asm_impl<F: PrimeField32>(
     }
 
     Ok(asm_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use openvm_instructions::riscv::RV32_MEMORY_AS;
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
+    use super::*;
+
+    fn disabled_load_to_x0(opcode: Rv32LoadStoreOpcode) -> Instruction<BabyBear> {
+        Instruction::from_usize(
+            opcode.global_opcode(),
+            [
+                0,
+                4,
+                0,
+                RV32_REGISTER_AS as usize,
+                RV32_MEMORY_AS as usize,
+                0,
+                0,
+            ],
+        )
+    }
+
+    #[test]
+    fn disabled_unsigned_loads_still_emit_memory_read_without_register_write() {
+        let cases = [
+            (
+                Rv32LoadStoreOpcode::LOADW,
+                format!("   mov {REG_C_W}, [{REG_B}]\n"),
+            ),
+            (
+                Rv32LoadStoreOpcode::LOADHU,
+                format!("   movzx {REG_C_W}, word ptr [{REG_B}]\n"),
+            ),
+            (
+                Rv32LoadStoreOpcode::LOADBU,
+                format!("   movzx {REG_C_W}, byte ptr [{REG_B}]\n"),
+            ),
+        ];
+
+        for (opcode, expected_read) in cases {
+            let asm = generate_x86_asm_impl(&disabled_load_to_x0(opcode), 0, |_, _, _, _, _| {
+                Ok(String::new())
+            })
+            .expect("load to x0 should be AOT-supported");
+
+            assert!(
+                asm.contains(&expected_read),
+                "{opcode:?} to x0 must still perform the memory read"
+            );
+            assert!(
+                !asm.contains("pinsrd"),
+                "{opcode:?} to x0 must not write the loaded value to an XMM register"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2853.

## Summary

AOT unsigned loads targeting `x0` now still perform the memory read but skip the register write. This matches interpreter behavior and RV32IM `x0` semantics: the destination register remains zero, but load side effects still occur.

## Testing

- `OPENVM_FAST_TEST=1 OPENVM_SKIP_DEBUG=1 cargo test -p openvm-rv32im-circuit --features aot disabled_unsigned_loads_still_emit_memory_read_without_register_write`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p openvm-rv32im-circuit --features aot --all-targets -- -D warnings`