### PR TITLE
fix: differentiate deferral circuit leaf and internal hashes

### DIFF
--- a/crates/continuations/src/circuit/deferral/hook/decommit/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/decommit/air.rs
@@ -3,7 +3,7 @@ use std::borrow::Borrow;
 use openvm_circuit_primitives::{
     utils::not, ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
 };
-use openvm_recursion_circuit::utils::assert_zeros;
+use openvm_recursion_circuit::{prelude::DIGEST_SIZE, utils::assert_zeros};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
@@ -21,6 +21,7 @@ use crate::circuit::{
 #[derive(AlignedBorrow, StructReflection)]
 pub struct MerkleDecommitCols<F> {
     pub merkle_tree_cols: MerkleTreeCols<F>,
+    pub tagged_left_child: [F; DIGEST_SIZE],
     pub send_commits: F,
     pub num_rows: F,
 }
@@ -58,6 +59,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                 &local.merkle_tree_cols,
                 &next.merkle_tree_cols,
                 local.num_rows.into(),
+                Some(&local.tagged_left_child),
             ),
         );
         builder.assert_eq(local.num_rows, next.num_rows);

--- a/crates/continuations/src/circuit/deferral/hook/decommit/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/decommit/trace.rs
@@ -3,13 +3,15 @@ use std::borrow::BorrowMut;
 use openvm_circuit::arch::POSEIDON2_WIDTH;
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::prover::AirProvingContext;
-use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, DIGEST_SIZE, F};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{
+    poseidon2_compress_with_capacity, BabyBearPoseidon2Config, DIGEST_SIZE, F,
+};
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
     circuit::{
-        deferral::hook::decommit::air::MerkleDecommitCols,
+        deferral::{hook::decommit::air::MerkleDecommitCols, DEF_INTERNAL_TAG, DEF_LEAF_TAG},
         subair::{generate_cols_from_leaf_children, MerkleTreeCols},
     },
     utils::digests_to_poseidon2_input,
@@ -40,12 +42,12 @@ pub fn generate_proving_ctx(
         (1..=leaf_children.len()).contains(&num_real_leaves),
         "deferral hook Merkle decommit requires 1 <= num_real_leaves <= num_leaves"
     );
-    let merkle_rows: Vec<MerkleTreeCols<F>> = generate_cols_from_leaf_children(leaf_children);
+    let merkle_rows: Vec<MerkleTreeCols<F>> = generate_cols_from_leaf_children(leaf_children, true);
     let width = MerkleDecommitCols::<u8>::width();
     let height = merkle_rows.len();
     let num_rows_f = F::from_usize(height);
     let mut trace = vec![F::ZERO; height * width];
-    let mut poseidon2_inputs = Vec::with_capacity(height.saturating_sub(1));
+    let mut poseidon2_inputs = Vec::with_capacity(2 * height.saturating_sub(1));
     let mut io_commits = Vec::with_capacity(num_real_leaves);
 
     for (row_idx, merkle_row) in merkle_rows.iter().copied().enumerate() {
@@ -59,8 +61,15 @@ pub fn generate_proving_ctx(
         cols.send_commits = F::from_bool(should_send_commit);
 
         if merkle_row.send_type != F::ZERO {
+            let tag = if is_leaf {
+                DEF_LEAF_TAG.map(F::from_u8)
+            } else {
+                DEF_INTERNAL_TAG.map(F::from_u8)
+            };
+            cols.tagged_left_child = poseidon2_compress_with_capacity(tag, merkle_row.left_child).0;
+            poseidon2_inputs.push(digests_to_poseidon2_input(tag, merkle_row.left_child));
             poseidon2_inputs.push(digests_to_poseidon2_input(
-                merkle_row.left_child,
+                cols.tagged_left_child,
                 merkle_row.right_child,
             ));
         }

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -27,15 +27,15 @@ use crate::{
             DefPvsConsistencyBus, DefPvsConsistencyMessage, InputOrMerkleCommitBus,
             InputOrMerkleCommitMessage,
         },
+        utils::def_zero_hashes_from_depth_one,
         DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
-        MAX_DEF_AGG_MERKLE_DEPTH,
+        DEF_INTERNAL_TAG, DEF_LEAF_TAG, MAX_DEF_AGG_MERKLE_DEPTH,
     },
-    utils::{digests_to_poseidon2_input, zero_hashes_from_depth_one},
+    utils::digests_to_poseidon2_input,
     CommitBytes,
 };
 
 const ENCODER_MAX_DEGREE: u32 = 2;
-
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection)]
 pub struct DeferralAggPvsCols<F> {
@@ -44,6 +44,9 @@ pub struct DeferralAggPvsCols<F> {
     pub has_verifier_pvs: F,
 
     pub merkle_commit: [F; DIGEST_SIZE],
+    pub tagged_input_commit: [F; DIGEST_SIZE],
+    pub tagged_left_merkle: [F; DIGEST_SIZE],
+
     pub child_pvs: DeferralCircuitPvs<F>,
 }
 
@@ -81,7 +84,7 @@ impl DeferralAggPvsAir {
             input_or_merkle_commit_bus,
             def_pvs_consistency_bus,
             encoder,
-            zero_hashes: zero_hashes_from_depth_one().map(Into::into),
+            zero_hashes: def_zero_hashes_from_depth_one().map(Into::into),
         }
     }
 }
@@ -138,6 +141,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * final Merkle root checks at the deferral hook layer.
          */
         let is_leaf = not(local.has_verifier_pvs);
+        let is_present_leaf = is_leaf.clone() * local.is_present;
         let is_internal = local.has_verifier_pvs;
         let air_idx = AB::Expr::from_usize(DEF_CIRCUIT_PVS_AIR_ID);
 
@@ -150,7 +154,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                     pv_idx: AB::Expr::from_usize(pv_idx + DIGEST_SIZE),
                     value: (*value).into(),
                 },
-                is_leaf.clone() * local.is_present,
+                is_present_leaf.clone(),
             );
         }
 
@@ -169,18 +173,30 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * On the leaf layer we need to constrain that merkle_commit is the Poseidon2 compression
-         * of input_commit and output_commit.
+         * of the tagged input_commit and output_commit.
          */
         self.poseidon2_bus.lookup_key(
             builder,
             Poseidon2CompressMessage {
                 input: digests_to_poseidon2_input(
-                    local.child_pvs.input_commit,
-                    local.child_pvs.output_commit,
+                    DEF_LEAF_TAG.map(AB::Expr::from_u8),
+                    local.child_pvs.input_commit.map(Into::into),
                 ),
-                output: local.merkle_commit,
+                output: local.tagged_input_commit.map(Into::into),
             },
-            is_leaf.clone() * local.is_present,
+            is_present_leaf.clone(),
+        );
+
+        self.poseidon2_bus.lookup_key(
+            builder,
+            Poseidon2CompressMessage {
+                input: digests_to_poseidon2_input(
+                    local.tagged_input_commit.map(Into::into),
+                    local.child_pvs.output_commit.map(Into::into),
+                ),
+                output: local.merkle_commit.map(Into::into),
+            },
+            is_present_leaf,
         );
 
         /*
@@ -321,7 +337,22 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         self.poseidon2_bus.lookup_key(
             builder,
             Poseidon2CompressMessage {
-                input: digests_to_poseidon2_input(local.merkle_commit.map(Into::into), right_child),
+                input: digests_to_poseidon2_input(
+                    DEF_INTERNAL_TAG.map(AB::Expr::from_u8),
+                    local.merkle_commit.map(Into::into),
+                ),
+                output: local.tagged_left_merkle.map(Into::into),
+            },
+            is_first_of_two_rows.clone(),
+        );
+
+        self.poseidon2_bus.lookup_key(
+            builder,
+            Poseidon2CompressMessage {
+                input: digests_to_poseidon2_input(
+                    local.tagged_left_merkle.map(Into::into),
+                    right_child,
+                ),
                 output: merkle_commit.map(Into::into),
             },
             is_first_of_two_rows,

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
@@ -7,19 +7,15 @@ use itertools::Itertools;
 use openvm_cpu_backend::CpuBackend;
 use openvm_recursion_circuit::utils::poseidon2_hash_slice;
 use openvm_stark_backend::{proof::Proof, prover::AirProvingContext};
-use openvm_stark_sdk::config::baby_bear_poseidon2::{
-    poseidon2_compress_with_capacity, BabyBearPoseidon2Config, F,
-};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
 use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
-use crate::{
-    circuit::deferral::{
-        inner::def_pvs::air::{DeferralAggPvsAir, DeferralAggPvsCols},
-        DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
-        MAX_DEF_AGG_MERKLE_DEPTH,
-    },
-    utils::zero_hash,
+use crate::circuit::deferral::{
+    inner::def_pvs::air::{DeferralAggPvsAir, DeferralAggPvsCols},
+    utils::{def_internal_compress, def_leaf_compress, def_zero_hash},
+    DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
+    MAX_DEF_AGG_MERKLE_DEPTH,
 };
 
 pub struct DeferralAggPvsTraceCtx {
@@ -83,8 +79,10 @@ pub fn generate_proving_ctx(
                 input_commit: folded_input_commit,
                 output_commit: child_pvs.output_commit,
             };
-            cols.merkle_commit =
-                poseidon2_compress_with_capacity(folded_input_commit, child_pvs.output_commit).0;
+            let (tagged_input_commit, merkle_commit) =
+                def_leaf_compress(folded_input_commit, child_pvs.output_commit);
+            cols.tagged_input_commit = tagged_input_commit;
+            cols.merkle_commit = merkle_commit;
             num_def_circuit_proofs += F::ONE;
         }
     }
@@ -105,19 +103,22 @@ pub fn generate_proving_ctx(
     let mut public_values = vec![F::ZERO; DeferralAggregationPvs::<u8>::width()];
     let pvs: &mut DeferralAggregationPvs<F> = public_values.as_mut_slice().borrow_mut();
 
-    let first_row: &DeferralAggPvsCols<F> = trace[..width].borrow();
     if is_wrapper {
+        let first_row: &DeferralAggPvsCols<F> = trace[..width].borrow();
         pvs.merkle_commit = first_row.merkle_commit;
         pvs.merkle_depth = merkle_depth;
     } else {
-        let second_row: &DeferralAggPvsCols<F> = trace[width..2 * width].borrow();
         let right_child = if num_proofs == 1 {
-            zero_hash(child_merkle_depth.unwrap() + 1)
+            def_zero_hash(child_merkle_depth.unwrap() + 1)
         } else {
+            let second_row: &DeferralAggPvsCols<F> = trace[width..2 * width].borrow();
             second_row.merkle_commit
         };
-        pvs.merkle_commit =
-            poseidon2_compress_with_capacity(first_row.merkle_commit, right_child).0;
+        let first_row: &mut DeferralAggPvsCols<F> = trace[..width].borrow_mut();
+        let (tagged_left_merkle, merkle_commit) =
+            def_internal_compress(first_row.merkle_commit, right_child);
+        first_row.tagged_left_merkle = tagged_left_merkle;
+        pvs.merkle_commit = merkle_commit;
         pvs.merkle_depth = merkle_depth + F::ONE;
     }
     pvs.num_def_circuit_proofs = num_def_circuit_proofs;

--- a/crates/continuations/src/circuit/deferral/inner/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/trace.rs
@@ -14,16 +14,17 @@ use openvm_stark_backend::{
     proof::Proof,
     prover::{AirProvingContext, ProverBackend},
 };
-use openvm_stark_sdk::config::baby_bear_poseidon2::{
-    poseidon2_compress_with_capacity, BabyBearPoseidon2Config, DIGEST_SIZE, F,
-};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, DIGEST_SIZE, F};
 use openvm_verify_stark_host::pvs::VkCommit;
+use p3_field::PrimeCharacteristicRing;
 
 use crate::{
     circuit::deferral::{
+        utils::{def_leaf_compress, def_tagged_compress, def_zero_hash},
         DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID, DEF_CIRCUIT_PVS_AIR_ID,
+        DEF_INTERNAL_TAG, DEF_LEAF_TAG,
     },
-    utils::{digests_to_poseidon2_input, zero_hash},
+    utils::digests_to_poseidon2_input,
 };
 
 pub struct DeferralInnerPreCtx<PB: ProverBackend> {
@@ -66,8 +67,19 @@ fn child_merkle_commit(
             .as_slice()
             .borrow();
         let (folded_input_commit, _) = fold_leaf_input_commit(proof, child_pvs.input_commit);
-        poseidon2_compress_with_capacity(folded_input_commit, child_pvs.output_commit).0
+        def_leaf_compress(folded_input_commit, child_pvs.output_commit).1
     }
+}
+
+fn push_deferral_compress_inputs(
+    inputs: &mut Vec<[F; POSEIDON2_WIDTH]>,
+    tag: [u8; DIGEST_SIZE],
+    left: [F; DIGEST_SIZE],
+    right: [F; DIGEST_SIZE],
+) {
+    let (tagged_left, _) = def_tagged_compress(tag, left, right);
+    inputs.push(digests_to_poseidon2_input(tag.map(F::from_u8), left));
+    inputs.push(digests_to_poseidon2_input(tagged_left, right));
 }
 
 fn generate_poseidon2_inputs(
@@ -92,10 +104,12 @@ fn generate_poseidon2_inputs(
         poseidon2_permute_inputs.extend(input_permute_inputs);
 
         // DeferralAggPvsAir (leaf): hash folded input_commit and output_commit into merkle_commit.
-        poseidon2_compress_inputs.push(digests_to_poseidon2_input(
+        push_deferral_compress_inputs(
+            &mut poseidon2_compress_inputs,
+            DEF_LEAF_TAG,
             folded_input_commit,
             child_pvs.output_commit,
-        ));
+        );
     }
 
     // DeferralAggPvsAir: hash child merkle commits when this is not a wrapper.
@@ -104,9 +118,14 @@ fn generate_poseidon2_inputs(
         let right_merkle = if proofs.len() == 2 {
             child_merkle_commit(&proofs[1], child_is_agg)
         } else {
-            zero_hash(depth + 1)
+            def_zero_hash(depth + 1)
         };
-        poseidon2_compress_inputs.push(digests_to_poseidon2_input(left_merkle, right_merkle));
+        push_deferral_compress_inputs(
+            &mut poseidon2_compress_inputs,
+            DEF_INTERNAL_TAG,
+            left_merkle,
+            right_merkle,
+        );
     }
 
     (poseidon2_compress_inputs, poseidon2_permute_inputs)

--- a/crates/continuations/src/circuit/deferral/mod.rs
+++ b/crates/continuations/src/circuit/deferral/mod.rs
@@ -6,6 +6,7 @@ pub use openvm_verify_stark_host::deferral::DeferralMerkleProofs;
 pub mod dummy;
 pub mod hook;
 pub mod inner;
+pub mod utils;
 
 pub const DEF_CIRCUIT_PVS_AIR_ID: usize = 0;
 
@@ -13,6 +14,9 @@ pub const DEF_AGG_VERIFIER_AIR_ID: usize = 0;
 pub const DEF_AGG_PVS_AIR_ID: usize = 1;
 
 pub const DEF_HOOK_PVS_AIR_ID: usize = 0;
+
+pub const DEF_LEAF_TAG: [u8; DIGEST_SIZE] = [1, 0, 0, 0, 0, 0, 0, 0];
+pub const DEF_INTERNAL_TAG: [u8; DIGEST_SIZE] = [2, 0, 0, 0, 0, 0, 0, 0];
 
 // Set to the default max trace log height of the deferral hook circuit
 const MAX_DEF_AGG_MERKLE_DEPTH: usize = 20;

--- a/crates/continuations/src/circuit/deferral/mod.rs
+++ b/crates/continuations/src/circuit/deferral/mod.rs
@@ -15,6 +15,8 @@ pub const DEF_AGG_PVS_AIR_ID: usize = 1;
 
 pub const DEF_HOOK_PVS_AIR_ID: usize = 0;
 
+// Used to domain-separate deferral Merkle leaves, which hash input_commit and
+// output_commit, from internal nodes, which hash two merkle_commit values.
 pub const DEF_LEAF_TAG: [u8; DIGEST_SIZE] = [1, 0, 0, 0, 0, 0, 0, 0];
 pub const DEF_INTERNAL_TAG: [u8; DIGEST_SIZE] = [2, 0, 0, 0, 0, 0, 0, 0];
 

--- a/crates/continuations/src/circuit/deferral/utils.rs
+++ b/crates/continuations/src/circuit/deferral/utils.rs
@@ -1,0 +1,57 @@
+use std::array::from_fn;
+
+use openvm_stark_sdk::config::baby_bear_poseidon2::{
+    poseidon2_compress_with_capacity, DIGEST_SIZE, F,
+};
+use p3_field::PrimeCharacteristicRing;
+
+use crate::circuit::deferral::{DEF_INTERNAL_TAG, DEF_LEAF_TAG};
+
+pub(crate) fn def_tagged_compress(
+    tag: [u8; DIGEST_SIZE],
+    left: [F; DIGEST_SIZE],
+    right: [F; DIGEST_SIZE],
+) -> ([F; DIGEST_SIZE], [F; DIGEST_SIZE]) {
+    let tagged_left = poseidon2_compress_with_capacity(tag.map(F::from_u8), left).0;
+    let parent = poseidon2_compress_with_capacity(tagged_left, right).0;
+    (tagged_left, parent)
+}
+
+pub fn def_leaf_compress(
+    left: [F; DIGEST_SIZE],
+    right: [F; DIGEST_SIZE],
+) -> ([F; DIGEST_SIZE], [F; DIGEST_SIZE]) {
+    def_tagged_compress(DEF_LEAF_TAG, left, right)
+}
+
+pub(crate) fn def_internal_compress(
+    left: [F; DIGEST_SIZE],
+    right: [F; DIGEST_SIZE],
+) -> ([F; DIGEST_SIZE], [F; DIGEST_SIZE]) {
+    def_tagged_compress(DEF_INTERNAL_TAG, left, right)
+}
+
+pub(crate) fn def_zero_hash(depth: usize) -> [F; DIGEST_SIZE] {
+    let mut zero_hash = [F::ZERO; DIGEST_SIZE];
+    for level in 0..depth {
+        zero_hash = if level == 0 {
+            def_leaf_compress(zero_hash, zero_hash).1
+        } else {
+            def_internal_compress(zero_hash, zero_hash).1
+        };
+    }
+    zero_hash
+}
+
+pub(crate) fn def_zero_hashes_from_depth_one<const MAX_DEPTH: usize>(
+) -> [[F; DIGEST_SIZE]; MAX_DEPTH] {
+    let mut zero_hash = [F::ZERO; DIGEST_SIZE];
+    from_fn(|depth| {
+        zero_hash = if depth == 0 {
+            def_leaf_compress(zero_hash, zero_hash).1
+        } else {
+            def_internal_compress(zero_hash, zero_hash).1
+        };
+        zero_hash
+    })
+}

--- a/crates/continuations/src/circuit/root/commit/air.rs
+++ b/crates/continuations/src/circuit/root/commit/air.rs
@@ -90,7 +90,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let next: &MerkleTreeCols<AB::Var> = (*next)[..const_width].borrow();
 
         let num_rows = AB::F::from_usize(2 * self.num_user_pvs / DIGEST_SIZE);
-        self.subair.eval(builder, (local, next, num_rows.into()));
+        self.subair
+            .eval(builder, (local, next, num_rows.into(), None));
 
         /*
          * Constrain that the left_child of each leaf node at row_idx corresponds to this

--- a/crates/continuations/src/circuit/root/commit/trace.rs
+++ b/crates/continuations/src/circuit/root/commit/trace.rs
@@ -41,7 +41,7 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
             )
         })
         .collect();
-    let rows = generate_cols_from_leaf_children(leaf_children);
+    let rows = generate_cols_from_leaf_children(leaf_children, false);
     let poseidon2_compress_inputs = rows
         .iter()
         .take(rows.len() - 1)

--- a/crates/continuations/src/circuit/subair/merkle_tree/air.rs
+++ b/crates/continuations/src/circuit/subair/merkle_tree/air.rs
@@ -1,3 +1,5 @@
+use std::array::from_fn;
+
 use openvm_circuit_primitives::{StructReflection, StructReflectionHelper, SubAir};
 use openvm_recursion_circuit::bus::{Poseidon2CompressBus, Poseidon2CompressMessage};
 use openvm_recursion_circuit_derive::AlignedBorrow;
@@ -7,8 +9,11 @@ use p3_air::AirBuilder;
 use p3_field::{Field, PrimeCharacteristicRing};
 
 use crate::{
-    circuit::subair::merkle_tree::bus::{
-        MerkleRootBus, MerkleRootMessage, MerkleTreeInternalBus, MerkleTreeInternalMessage,
+    circuit::{
+        deferral::{DEF_INTERNAL_TAG, DEF_LEAF_TAG},
+        subair::merkle_tree::bus::{
+            MerkleRootBus, MerkleRootMessage, MerkleTreeInternalBus, MerkleTreeInternalMessage,
+        },
     },
     utils::digests_to_poseidon2_input,
 };
@@ -50,6 +55,7 @@ impl<AB: AirBuilder + InteractionBuilder> SubAir<AB> for MerkleTreeSubAir {
         &'a MerkleTreeCols<AB::Var>,
         &'a MerkleTreeCols<AB::Var>,
         AB::Expr,
+        Option<&'a [AB::Var; DIGEST_SIZE]>,
     )
     where
         AB: 'a,
@@ -61,7 +67,7 @@ impl<AB: AirBuilder + InteractionBuilder> SubAir<AB> for MerkleTreeSubAir {
         AB::Var: 'a,
         AB::Expr: 'a,
     {
-        let (local, next, num_rows) = ctx;
+        let (local, next, num_rows, tagged_left_child) = ctx;
 
         /*
          * Constrain that row_idx actually corresponds to the matrix row index, and
@@ -176,14 +182,43 @@ impl<AB: AirBuilder + InteractionBuilder> SubAir<AB> for MerkleTreeSubAir {
         let is_valid = local.send_type * (AB::Expr::from_u8(3) - local.send_type) * half;
         let is_root = local.send_type * (local.send_type - AB::F::ONE) * half;
 
-        self.poseidon2_bus.lookup_key(
-            builder,
-            Poseidon2CompressMessage {
-                input: digests_to_poseidon2_input(local.left_child, local.right_child),
-                output: local.parent,
-            },
-            is_valid,
-        );
+        if let Some(tagged_left_child) = tagged_left_child {
+            let is_leaf = local.receive_type * (AB::Expr::TWO - local.receive_type);
+            let is_internal = local.receive_type * (local.receive_type - AB::F::ONE) * half;
+            let tag = from_fn(|i| {
+                is_leaf.clone() * AB::Expr::from_u8(DEF_LEAF_TAG[i])
+                    + is_internal.clone() * AB::Expr::from_u8(DEF_INTERNAL_TAG[i])
+            });
+
+            self.poseidon2_bus.lookup_key(
+                builder,
+                Poseidon2CompressMessage {
+                    input: digests_to_poseidon2_input(tag, local.left_child.map(Into::into)),
+                    output: tagged_left_child.map(Into::into),
+                },
+                is_valid.clone(),
+            );
+            self.poseidon2_bus.lookup_key(
+                builder,
+                Poseidon2CompressMessage {
+                    input: digests_to_poseidon2_input(
+                        tagged_left_child.map(Into::into),
+                        local.right_child.map(Into::into),
+                    ),
+                    output: local.parent.map(Into::into),
+                },
+                is_valid,
+            );
+        } else {
+            self.poseidon2_bus.lookup_key(
+                builder,
+                Poseidon2CompressMessage {
+                    input: digests_to_poseidon2_input(local.left_child, local.right_child),
+                    output: local.parent,
+                },
+                is_valid,
+            );
+        }
 
         self.merkle_root_bus.send(
             builder,

--- a/crates/continuations/src/circuit/subair/merkle_tree/trace.rs
+++ b/crates/continuations/src/circuit/subair/merkle_tree/trace.rs
@@ -4,7 +4,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{
 use p3_field::PrimeCharacteristicRing;
 
 use super::MerkleTreeCols;
-use crate::circuit::deferral::{DEF_INTERNAL_TAG, DEF_LEAF_TAG};
+use crate::circuit::deferral::{utils::def_tagged_compress, DEF_INTERNAL_TAG, DEF_LEAF_TAG};
 
 /// Build Merkle-tree rows from leaf `(left_child, right_child)` inputs using
 /// Poseidon2 compression over BabyBear.
@@ -20,20 +20,13 @@ pub fn generate_cols_from_leaf_children(
     debug_assert!(num_leaves > 0);
     debug_assert!(num_leaves.is_power_of_two());
 
-    let compress = |left: [F; DIGEST_SIZE], right: [F; DIGEST_SIZE], tag: [u8; DIGEST_SIZE]| {
-        let left = if tagged {
-            poseidon2_compress_with_capacity(tag.map(F::from_u8), left).0
-        } else {
-            left
-        };
-        poseidon2_compress_with_capacity(left, right).0
-    };
-
     let mut rows = Vec::with_capacity(2 * num_leaves);
     let mut next_layer = Vec::with_capacity(num_leaves);
+    let leaf_tag = tagged.then_some(DEF_LEAF_TAG);
+    let internal_tag = tagged.then_some(DEF_INTERNAL_TAG);
 
     for (row_idx, (left, right)) in leaf_children.into_iter().enumerate() {
-        let parent = compress(left, right, DEF_LEAF_TAG);
+        let parent = compress_with_optional_tag(left, right, leaf_tag);
         rows.push(MerkleTreeCols {
             row_idx: F::from_usize(row_idx),
             send_type: if num_leaves == 1 { F::TWO } else { F::ONE },
@@ -52,7 +45,7 @@ pub fn generate_cols_from_leaf_children(
         for parent_idx in 0..parent_layer_len {
             let left = next_layer[2 * parent_idx];
             let right = next_layer[2 * parent_idx + 1];
-            let parent = compress(left, right, DEF_INTERNAL_TAG);
+            let parent = compress_with_optional_tag(left, right, internal_tag);
 
             rows.push(MerkleTreeCols {
                 row_idx: F::from_usize(row_idx),
@@ -81,4 +74,15 @@ pub fn generate_cols_from_leaf_children(
     });
 
     rows
+}
+
+fn compress_with_optional_tag(
+    left: [F; DIGEST_SIZE],
+    right: [F; DIGEST_SIZE],
+    tag: Option<[u8; DIGEST_SIZE]>,
+) -> [F; DIGEST_SIZE] {
+    match tag {
+        Some(tag) => def_tagged_compress(tag, left, right).1,
+        None => poseidon2_compress_with_capacity(left, right).0,
+    }
 }

--- a/crates/continuations/src/circuit/subair/merkle_tree/trace.rs
+++ b/crates/continuations/src/circuit/subair/merkle_tree/trace.rs
@@ -4,6 +4,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{
 use p3_field::PrimeCharacteristicRing;
 
 use super::MerkleTreeCols;
+use crate::circuit::deferral::{DEF_INTERNAL_TAG, DEF_LEAF_TAG};
 
 /// Build Merkle-tree rows from leaf `(left_child, right_child)` inputs using
 /// Poseidon2 compression over BabyBear.
@@ -13,16 +14,26 @@ use super::MerkleTreeCols;
 /// terminal row (`send_type = receive_type = 0`).
 pub fn generate_cols_from_leaf_children(
     leaf_children: Vec<([F; DIGEST_SIZE], [F; DIGEST_SIZE])>,
+    tagged: bool,
 ) -> Vec<MerkleTreeCols<F>> {
     let num_leaves = leaf_children.len();
     debug_assert!(num_leaves > 0);
     debug_assert!(num_leaves.is_power_of_two());
 
+    let compress = |left: [F; DIGEST_SIZE], right: [F; DIGEST_SIZE], tag: [u8; DIGEST_SIZE]| {
+        let left = if tagged {
+            poseidon2_compress_with_capacity(tag.map(F::from_u8), left).0
+        } else {
+            left
+        };
+        poseidon2_compress_with_capacity(left, right).0
+    };
+
     let mut rows = Vec::with_capacity(2 * num_leaves);
     let mut next_layer = Vec::with_capacity(num_leaves);
 
     for (row_idx, (left, right)) in leaf_children.into_iter().enumerate() {
-        let parent = poseidon2_compress_with_capacity(left, right).0;
+        let parent = compress(left, right, DEF_LEAF_TAG);
         rows.push(MerkleTreeCols {
             row_idx: F::from_usize(row_idx),
             send_type: if num_leaves == 1 { F::TWO } else { F::ONE },
@@ -41,7 +52,7 @@ pub fn generate_cols_from_leaf_children(
         for parent_idx in 0..parent_layer_len {
             let left = next_layer[2 * parent_idx];
             let right = next_layer[2 * parent_idx + 1];
-            let parent = poseidon2_compress_with_capacity(left, right).0;
+            let parent = compress(left, right, DEF_INTERNAL_TAG);
 
             rows.push(MerkleTreeCols {
                 row_idx: F::from_usize(row_idx),

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -42,12 +42,18 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
         use std::borrow::Borrow;
         use crate::{
-            circuit::deferral::{DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID},
+            circuit::deferral::{
+                DeferralAggregationPvs, DeferralCircuitPvs, DEF_AGG_PVS_AIR_ID,
+                utils::{
+                    def_internal_compress, def_leaf_compress, def_zero_hash,
+                },
+            },
             prover::{
                 DeferralChildVkKind, DeferralInnerGpuProver as DeferralInnerProver,
                 InnerGpuProver as InnerProver,
             },
-            utils::zero_hash, CommitBytes,
+            utils::zero_hash,
+            CommitBytes,
         };
 
         #[cfg(feature = "root-prover")]
@@ -482,7 +488,7 @@ pub(in crate::tests) fn generate_deferral_internal_recursive_proof_from_copies(
 #[cfg(feature = "cuda")]
 fn expected_deferral_leaf_merkle_commit(def_proof: &Proof<SC>) -> [F; DIGEST_SIZE] {
     let (folded_input_commit, output_commit) = expected_deferral_leaf_io_commit(def_proof);
-    poseidon2_compress_with_capacity(folded_input_commit, output_commit).0
+    def_leaf_compress(folded_input_commit, output_commit).1
 }
 
 #[cfg(feature = "cuda")]
@@ -523,9 +529,9 @@ fn expected_deferral_inner_merkle_commit_from_copies(
                 let right = if chunk.len() == 2 {
                     chunk[1]
                 } else {
-                    zero_hash(child_merkle_depth + 1)
+                    def_zero_hash(child_merkle_depth + 1)
                 };
-                poseidon2_compress_with_capacity(chunk[0], right).0
+                def_internal_compress(chunk[0], right).1
             })
             .collect();
         child_merkle_depth += 1;

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -52,21 +52,25 @@ cfg_if::cfg_if! {
                 DeferralChildVkKind, DeferralInnerGpuProver as DeferralInnerProver,
                 InnerGpuProver as InnerProver,
             },
-            utils::zero_hash,
             CommitBytes,
         };
 
         #[cfg(feature = "root-prover")]
         use {
-            crate::prover::{DeferralHookGpuProver as DeferralHookProver, RootGpuProver as RootProver},
+            crate::{
+                prover::{
+                    DeferralHookGpuProver as DeferralHookProver, RootGpuProver as RootProver,
+                },
+                utils::zero_hash,
+            },
             openvm_cuda_backend::BabyBearBn254Poseidon2GpuEngine,
+            openvm_stark_sdk::config::baby_bear_poseidon2::poseidon2_compress_with_capacity,
             openvm_verify_stark_host::pvs::{DeferralPvs, VerifierBasePvs},
         };
 
         use openvm_recursion_circuit::utils::poseidon2_hash_slice_with_states;
         use openvm_cuda_backend::{BabyBearPoseidon2GpuEngine, GpuBackend};
         use openvm_stark_backend::prover::CommittedTraceData;
-        use openvm_stark_sdk::config::baby_bear_poseidon2::poseidon2_compress_with_capacity;
         use openvm_verify_stark_host::pvs::VERIFIER_PVS_AIR_ID;
         use p3_field::PrimeField32;
 

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use eyre::Result;
 use itertools::Itertools;
 use openvm_continuations::{
+    circuit::deferral::utils::def_leaf_compress,
     prover::{DeferralChildVkKind, DeferralCircuitProver},
     CommitBytes, SC,
 };
@@ -14,7 +15,7 @@ use openvm_stark_backend::{
     proof::Proof,
     SystemParams,
 };
-use openvm_stark_sdk::config::baby_bear_poseidon2::{poseidon2_compress_with_capacity, F};
+use openvm_stark_sdk::config::baby_bear_poseidon2::F;
 use openvm_verify_stark_host::pvs::DeferralPvs;
 use tracing::info_span;
 
@@ -156,8 +157,7 @@ impl DeferralProver {
                         .circuit_commit(self.internal_recursive_prover.get_vk_commit(false));
                     let input_acc_hash = poseidon2_hash_slice(&def_circuit_commit).0;
                     let output_acc_hash = poseidon2_hash_slice(&[F::ZERO]).0;
-                    let combined_hash =
-                        poseidon2_compress_with_capacity(input_acc_hash, output_acc_hash).0;
+                    let combined_hash = def_leaf_compress(input_acc_hash, output_acc_hash).1;
                     Ok(DeferralProof::Absent(DeferralPvs {
                         initial_acc_hash: combined_hash,
                         final_acc_hash: combined_hash,

--- a/guest-libs/verify-stark/circuit/src/commit/air.rs
+++ b/guest-libs/verify-stark/circuit/src/commit/air.rs
@@ -84,7 +84,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let next: &MerkleTreeCols<AB::Var> = (*next).borrow();
 
         let num_rows = AB::F::from_usize(2 * self.num_user_pvs / DIGEST_SIZE);
-        self.subair.eval(builder, (local, next, num_rows.into()));
+        self.subair
+            .eval(builder, (local, next, num_rows.into(), None));
 
         /*
          * Send the left_child of each leaf node to output_values to be processed

--- a/guest-libs/verify-stark/circuit/src/commit/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/commit/trace.rs
@@ -26,7 +26,7 @@ pub fn generate_proving_ctx(
             )
         })
         .collect();
-    let rows = generate_cols_from_leaf_children(leaf_children);
+    let rows = generate_cols_from_leaf_children(leaf_children, false);
     let poseidon2_compress_inputs = rows
         .iter()
         .take(rows.len() - 1)


### PR DESCRIPTION
Resolves INT-7921.

## Overview

This branch domain-separates deferral Merkle hashing by using different tags for leaf and internal nodes:

- Leaf: `H(H(DEF_LEAF_TAG, left), right)`
- Internal: `H(H(DEF_INTERNAL_TAG, left), right)`

The change affects deferral aggregation public values, deferral hook Merkle decommitment, shared Merkle-tree constraints, SDK absent-deferral proof construction, and CUDA continuation test expectations.

Commits on this branch:

- `fix: differentiate deferral circuit leaf and internal hashes`
- `chore: feature-gate imports in continuations tests`

## `crates/continuations`: Deferral Hash Utilities

New constants and helpers:

- `DEF_LEAF_TAG = [1, 0, ..., 0]`
- `DEF_INTERNAL_TAG = [2, 0, ..., 0]`
- `circuit::deferral::utils::{def_leaf_compress, def_internal_compress, def_zero_hash, def_zero_hashes_from_depth_one}`

`def_leaf_compress` is public so the SDK can use the exact same leaf-hash definition when constructing absent deferral proofs. Other helpers remain crate-private.

## `DeferralAggPvsAir`

### What Changed

`DeferralAggPvsAir` now constrains deferral Merkle commits with tagged leaf/internal compression.

Added columns:

- `tagged_input_commit`: intermediate `H(DEF_LEAF_TAG, folded_input_commit)` for deferral-circuit leaf children.
- `tagged_left_merkle`: intermediate `H(DEF_INTERNAL_TAG, left_merkle_commit)` for internal aggregation rows.

The previous one-step hashes:

- `H(folded_input_commit, output_commit)`
- `H(left_merkle, right_merkle)`

are now two-step tagged hashes.

### Example Rows

| Case | `is_present` | `has_verifier_pvs` | `merkle_commit` | `tagged_input_commit` | `tagged_left_merkle` |
| --- | ---: | ---: | --- | --- | --- |
| Deferral circuit child | `1` | `0` | `H(tagged_input_commit, output_commit)` | `H(DEF_LEAF_TAG, folded_input_commit)` | `0` unless row is also the left internal child |
| Aggregation child | `1` | `1` | child aggregation `merkle_commit` | `0` | `0` unless row is also the left internal child |
| Padding row for missing right child | `0` | `child_is_agg` | depth encoder point | `0` | `0` |
| Non-wrapper first row | usually `1` | `0` or `1` | left child Merkle commit | as above | `H(DEF_INTERNAL_TAG, merkle_commit)` |

For non-wrapper aggregation, the public output `DeferralAggregationPvs.merkle_commit` is:

```text
H(tagged_left_merkle, right_child)
```

where `right_child` is either the second child Merkle commit or the tagged deferral zero hash at the next depth.

### Poseidon Bus Interactions

Leaf child:

```text
DeferralAggPvsAir
  -> Poseidon2CompressBus: (DEF_LEAF_TAG, folded_input_commit) -> tagged_input_commit
  -> Poseidon2CompressBus: (tagged_input_commit, output_commit) -> merkle_commit
```

Internal aggregation:

```text
DeferralAggPvsAir
  -> Poseidon2CompressBus: (DEF_INTERNAL_TAG, left_merkle) -> tagged_left_merkle
  -> Poseidon2CompressBus: (tagged_left_merkle, right_merkle_or_zero) -> output merkle_commit
```

Other existing buses in this AIR are unchanged.

## Shared `MerkleTreeSubAir` and Deferral Hook Decommit

### What Changed

`MerkleTreeSubAir` now supports both untagged and tagged compression:

- `None`: existing behavior, constrain `parent = H(left_child, right_child)`.
- `Some(tagged_left_child)`: tagged behavior, constrain:
  - `tagged_left_child = H(tag, left_child)`
  - `parent = H(tagged_left_child, right_child)`

The tag is selected from `receive_type`:

- leaf rows use `DEF_LEAF_TAG`
- internal rows use `DEF_INTERNAL_TAG`

Callers that are unrelated to deferrals pass `None`, preserving existing behavior:

- root public-value commit
- verify-stark guest public-value commit

The deferral hook decommit AIR passes `Some(&local.tagged_left_child)`.

### `MerkleDecommitCols` Example Rows

| Row kind | `receive_type` | `send_type` | `left_child` / `right_child` | `tagged_left_child` | `parent` |
| --- | ---: | ---: | --- | --- | --- |
| Leaf | `1` | `1` or `2` | IO commit pair | `H(DEF_LEAF_TAG, left_child)` | `H(tagged_left_child, right_child)` |
| Internal | `2` | `1` or `2` | child Merkle commits | `H(DEF_INTERNAL_TAG, left_child)` | `H(tagged_left_child, right_child)` |
| Terminal | `0` | `0` | zero | zero | zero |

### Bus Interactions

Untagged callers:

```text
MerkleTreeSubAir
  -> Poseidon2CompressBus: (left_child, right_child) -> parent
  -> MerkleTreeInternalBus / MerkleRootBus unchanged
```

Tagged deferral hook caller:

```text
MerkleDecommitAir trace column: tagged_left_child
        |
        v
MerkleTreeSubAir
  -> Poseidon2CompressBus: (DEF_*_TAG, left_child) -> tagged_left_child
  -> Poseidon2CompressBus: (tagged_left_child, right_child) -> parent
  -> MerkleTreeInternalBus / MerkleRootBus unchanged
```

`MerkleDecommitAir` still sends real leaf IO commits to `IoCommitBus` exactly as before.

## Trace Generation Changes

### Deferral Aggregation Traces

Trace generation now mirrors the AIR:

- deferral-circuit child rows store `tagged_input_commit` and tagged leaf `merkle_commit`
- non-wrapper aggregation computes `tagged_left_merkle` and final Merkle commit via `def_internal_compress`
- deferral zero hashes use the same tagged leaf/internal convention

`generate_poseidon2_inputs` now emits both Poseidon compress inputs for each tagged compression.

### Deferral Hook Decommit Traces

Decommit trace generation now:

- calls `generate_cols_from_leaf_children(..., true)`
- fills `tagged_left_child`
- records two Poseidon inputs per valid Merkle row

### Untagged Public-Value Commit Traces

Root and verify-stark public-value Merkle commits pass `tagged = false`; their hash semantics are unchanged.

## SDK

The SDK absent-deferral proof path now uses:

```rust
def_leaf_compress(input_acc_hash, output_acc_hash).1
```

This keeps SDK absent-proof construction aligned with the deferral circuit leaf hash definition.

## Tests

Continuation CUDA expected-value helpers were updated to use:

- `def_leaf_compress`
- `def_internal_compress`
- `def_zero_hash`

Imports used only by CUDA root-prover tests are now feature-gated under `root-prover`.