### PR TITLE
fix(static-verifier): fold carry bit into BabyBear div reduction guards

### DIFF
--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -254,13 +254,13 @@ impl BabyBearChip {
 
         // Constrain a = b * c (mod p)
         let mut c = self.load_witness(ctx, a.to_baby_bear() * b_inv_val);
-        if a.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+        if a.max_bits + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             a = self.reduce(ctx, a);
         }
-        if b.max_bits + c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+        if b.max_bits + c.max_bits + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             b = self.reduce(ctx, b);
         }
-        if b.max_bits + c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+        if b.max_bits + c.max_bits + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             c = self.reduce(ctx, c);
         }
         let diff = self.gate().sub_mul(ctx, a.value, b.value, c.value);

--- a/crates/static-verifier/src/field/baby_bear/tests.rs
+++ b/crates/static-verifier/src/field/baby_bear/tests.rs
@@ -102,6 +102,31 @@ fn baby_bear_base_ops_match_native_mod_arithmetic() {
 }
 
 #[test]
+fn div_reduces_operand_at_max_bits_boundary() {
+    run_mock(|builder| {
+        let range = builder.range_chip();
+        let chip = BabyBearChip::new(Arc::new(range.clone()));
+        let ctx = builder.main(0);
+        let gate = range.gate();
+
+        // Honest value is 1, but the wire is deliberately tagged as unreduced with
+        // `max_bits` exactly at the pre-reduction threshold.
+        const BOUNDARY_MAX_BITS: usize = 251; // Fr::CAPACITY (253) - RESERVED_HIGH_BITS (2)
+        let a = BabyBearWire {
+            value: ctx.load_witness(Fr::from(1u64)),
+            max_bits: BOUNDARY_MAX_BITS,
+        };
+        let b = chip.load_constant(ctx, RootF::ONE);
+
+        // Before the fix this panics in `assert_zero`; after the fix `a` is reduced
+        // first and the division yields 1.
+        let c = chip.div(ctx, a, b);
+        let c = chip.reduce(ctx, c);
+        gate.assert_is_const(ctx, &c.value, &Fr::from(1u64));
+    });
+}
+
+#[test]
 fn baby_bear_ext_mul_matches_native_binomial_extension() {
     run_mock(|builder| {
         let range = builder.range_chip();


### PR DESCRIPTION
`div` tags the `a - b*c` difference with a `+ 1` carry bit but its pre-reduction guards omitted it, so an operand sitting exactly at `max_bits == Fr::CAPACITY - RESERVED_HIGH_BITS` (251) was left unreduced and pushed the difference to 252, tripping the `assert_zero` invariant and panicking during witness generation. Mirror the `add`/`sub`/`mul_add` guards by folding the carry bit in.