### PR TITLE
feat(v2-rc.2): emit metered execution metrics

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -49,9 +49,6 @@ jobs:
           cache-on-failure: true
           key: v1
 
-      - name: Generate docs
-        run: |
-          cargo doc --workspace  --exclude "openvm-benchmarks" --exclude "*-tests" --exclude "*-test"
       - name: Run fmt
         run: |
           rustup install nightly
@@ -101,6 +98,9 @@ jobs:
         run: |
           cargo binstall --no-confirm --force cargo-audit
           cargo audit
+      - name: Generate docs
+        run: |
+          cargo doc --workspace  --exclude "openvm-benchmarks" --exclude "*-tests" --exclude "*-test"
 
       - name: sccache stats
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f4fa467593d67c0a890e3020302373ba9a2e13b8"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -5921,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f4fa467593d67c0a890e3020302373ba9a2e13b8"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f4fa467593d67c0a890e3020302373ba9a2e13b8"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f4fa467593d67c0a890e3020302373ba9a2e13b8"
 dependencies = [
  "cc",
  "glob",
@@ -5982,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f4fa467593d67c0a890e3020302373ba9a2e13b8"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6774,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f4fa467593d67c0a890e3020302373ba9a2e13b8"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -6809,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f4fa467593d67c0a890e3020302373ba9a2e13b8"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -25,8 +25,7 @@ const DEFAULT_MAIN_CELL_WEIGHT: usize = 3; // 1 + 2^{log_blowup=1}
 ///               = (1 + need_rot) × main_cnt bytes     (per trace, summed)
 /// ```
 ///
-/// This accounts for the extra memory after `fold_ple` in stark-backend
-/// crates/cuda-backend/src/logup_zerocheck/mod.rs.
+/// This accounts for the extra memory after `fold_ple` in the interaction prover.
 ///
 /// While the `mat_eval` is not dropped, inside `sumcheck_polys_batch_eval` we need to interpolate
 /// each MLE matrix further which takes `(constraint_degree \* padded_height / 2^l_skip / 2) \*
@@ -50,13 +49,74 @@ const DEFAULT_MAIN_CELL_SECONDARY_WEIGHT: f64 = 0.75;
 /// `2 * (1 / 16 + 1 / 256)` of the real leaf memory.
 const DEFAULT_INTERACTION_CELL_WEIGHT: f64 =
     (2 * D_EF) as f64 * (1.0 + 2.0 * (1.0 / 16.0 + 1.0 / 256.0));
-/// Constant overhead for interaction memory: sqrt-decomposed eq buffers, M matrix,
-/// and misc small buffers. Bounded by ~2 MB assuming fewer than 2^32 leaves.
-const DEFAULT_INTERACTION_CONSTANT_OVERHEAD: usize = 2 << 20; // 2 MiB
+/// Interaction memory overhead: eq buffers, M matrix, and misc small buffers.
+/// Added once per segment and bounded by ~2 MB assuming fewer than 2^32 leaves.
+const DEFAULT_INTERACTION_MEMORY_OVERHEAD: usize = 2 << 20; // 2 MiB
 
 /// Returns `ceil(cell_count * base_field_size * weight)`.
 fn ceil_weighted_bytes(cell_count: usize, base_field_size: usize, weight: f64) -> usize {
     ((cell_count * base_field_size) as f64 * weight).ceil() as usize
+}
+
+#[inline(always)]
+fn secondary_weight_for_rot(need_rot: bool, main_secondary_weight: f64) -> f64 {
+    if need_rot {
+        2.0 * main_secondary_weight
+    } else {
+        main_secondary_weight
+    }
+}
+
+#[inline(always)]
+fn calculate_main_secondary_memory(
+    main_cnt_with_rot: usize,
+    main_cnt_no_rot: usize,
+    base_field_size: usize,
+    main_secondary_weight: f64,
+) -> usize {
+    ceil_weighted_bytes(
+        main_cnt_with_rot,
+        base_field_size,
+        secondary_weight_for_rot(true, main_secondary_weight),
+    ) + ceil_weighted_bytes(
+        main_cnt_no_rot,
+        base_field_size,
+        secondary_weight_for_rot(false, main_secondary_weight),
+    )
+}
+
+#[cfg(feature = "metrics")]
+#[derive(Clone, Debug, Default)]
+struct MeteredCounts {
+    /// Rows before power-of-two padding.
+    unpadded_rows: usize,
+    /// Rows added by power-of-two padding.
+    padding_rows: usize,
+    /// Main trace cells for AIRs that open next-row rotations, before padding.
+    main_unpadded_with_rot: usize,
+    /// Main trace cells for AIRs that open next-row rotations, from padding rows.
+    main_padding_with_rot: usize,
+    /// Main trace cells for AIRs without next-row rotations, before padding.
+    main_unpadded_no_rot: usize,
+    /// Main trace cells for AIRs without next-row rotations, from padding rows.
+    main_padding_no_rot: usize,
+    /// Metered row-interaction slots before padding.
+    interaction_cells_unpadded: usize,
+    /// Metered row-interaction slots from padding rows.
+    interaction_cells_padding: usize,
+}
+
+#[cfg(feature = "metrics")]
+#[derive(Clone, Debug)]
+struct MeteredMemoryBreakdown {
+    /// Total selected segment memory estimate.
+    total: usize,
+    /// Unpadded-row contribution to the selected memory estimate.
+    unpadded: usize,
+    /// Padding-row contribution to the selected memory estimate.
+    padding: usize,
+    /// Interaction memory overhead added once per segment.
+    interaction_memory_overhead: usize,
 }
 
 #[derive(derive_new::new, Clone, Debug, Serialize, Deserialize)]
@@ -79,6 +139,7 @@ pub struct SegmentationConfig {
     #[getset(set_with = "pub")]
     pub main_cell_secondary_weight: f64,
     /// Weight multiplier for interaction cells in memory calculation.
+    /// An interaction cell is one metered row-interaction slot.
     #[getset(set_with = "pub")]
     pub interaction_cell_weight: f64,
     /// Size of the base field in bytes. Used to convert cell count to memory bytes.
@@ -233,16 +294,17 @@ impl SegmentationCtx {
             .unwrap_or((0, "unknown"))
     }
 
-    /// Convert main and interaction cell counts to memory bytes.
+    /// Convert main trace cells and interaction cells to memory bytes.
     /// Formula: base_field_size * (main_cell_weight * main_cells + interaction_cell_weight *
-    /// interaction_cells). `main_cnt_with_rot` cells commit 2 PCS openings per column so use
-    /// `2 * main_cell_secondary_weight`; `main_cnt_no_rot` cells use the base weight.
+    /// interaction_cells). `main_cnt_with_rot` cells commit 2 PCS openings per column so use `2 *
+    /// main_cell_secondary_weight`; `main_cnt_no_rot` cells use the base weight.
+    /// An interaction cell is one metered row-interaction slot.
     #[inline(always)]
     fn counts_to_memory(
         &self,
         main_cnt_with_rot: usize,
         main_cnt_no_rot: usize,
-        interaction_cnt: usize,
+        interaction_cells: usize,
     ) -> (
         usize, /* memory */
         usize, /* main */
@@ -255,15 +317,15 @@ impl SegmentationCtx {
 
         let main_cnt = main_cnt_with_rot + main_cnt_no_rot;
         let main_memory = main_cnt * main_weight * base_field_size;
-        let main_secondary_memory =
-            ceil_weighted_bytes(
-                main_cnt_with_rot,
-                base_field_size,
-                2.0 * main_secondary_weight,
-            ) + ceil_weighted_bytes(main_cnt_no_rot, base_field_size, main_secondary_weight);
+        let main_secondary_memory = calculate_main_secondary_memory(
+            main_cnt_with_rot,
+            main_cnt_no_rot,
+            base_field_size,
+            main_secondary_weight,
+        );
         let interaction_memory =
-            ceil_weighted_bytes(interaction_cnt, base_field_size, interaction_weight)
-                + DEFAULT_INTERACTION_CONSTANT_OVERHEAD;
+            ceil_weighted_bytes(interaction_cells, base_field_size, interaction_weight)
+                + DEFAULT_INTERACTION_MEMORY_OVERHEAD;
         (
             main_memory + max(main_secondary_memory, interaction_memory),
             main_memory,
@@ -271,8 +333,44 @@ impl SegmentationCtx {
         )
     }
 
-    /// Sum padded main and interaction cell counts across all chips, splitting main cells by
-    /// per-AIR `need_rot`.
+    /// Sum padded main trace cells and interaction cells across all chips, splitting main
+    /// cells by per-AIR `need_rot`.
+    #[cfg(feature = "metrics")]
+    #[inline(always)]
+    fn calculate_count_breakdown(&self, trace_heights: &[u32]) -> MeteredCounts {
+        debug_assert_eq!(trace_heights.len(), self.widths.len());
+        debug_assert_eq!(trace_heights.len(), self.interactions.len());
+        debug_assert_eq!(trace_heights.len(), self.need_rot.len());
+
+        let mut counts = MeteredCounts::default();
+        for (((&height, &width), &interactions), &need_rot) in trace_heights
+            .iter()
+            .zip(self.widths.iter())
+            .zip(self.interactions.iter())
+            .zip(self.need_rot.iter())
+        {
+            let padded_height = height.next_power_of_two() as usize;
+            let unpadded_height = height as usize;
+            let padding_height = padded_height - unpadded_height;
+            counts.unpadded_rows += unpadded_height;
+            counts.padding_rows += padding_height;
+            let main_unpadded_cells = unpadded_height * width;
+            let main_padding_cells = padding_height * width;
+            if need_rot {
+                counts.main_unpadded_with_rot += main_unpadded_cells;
+                counts.main_padding_with_rot += main_padding_cells;
+            } else {
+                counts.main_unpadded_no_rot += main_unpadded_cells;
+                counts.main_padding_no_rot += main_padding_cells;
+            }
+            counts.interaction_cells_unpadded += unpadded_height * interactions;
+            counts.interaction_cells_padding += padding_height * interactions;
+        }
+        counts
+    }
+
+    /// Sum padded main trace cells and interaction cells across all chips, splitting main
+    /// cells by per-AIR `need_rot`.
     #[inline(always)]
     fn calculate_cell_counts(&self, trace_heights: &[u32]) -> (usize, usize, usize) {
         debug_assert_eq!(trace_heights.len(), self.widths.len());
@@ -281,7 +379,7 @@ impl SegmentationCtx {
 
         let mut main_cnt_with_rot = 0;
         let mut main_cnt_no_rot = 0;
-        let mut interaction_cnt = 0;
+        let mut interaction_cells = 0;
         for (((&height, &width), &interactions), &need_rot) in trace_heights
             .iter()
             .zip(self.widths.iter())
@@ -295,9 +393,9 @@ impl SegmentationCtx {
             } else {
                 main_cnt_no_rot += main_cells;
             }
-            interaction_cnt += padded_height * interactions;
+            interaction_cells += padded_height * interactions;
         }
-        (main_cnt_with_rot, main_cnt_no_rot, interaction_cnt)
+        (main_cnt_with_rot, main_cnt_no_rot, interaction_cells)
     }
 
     /// Calculate total memory in bytes based on trace heights and widths.
@@ -310,9 +408,70 @@ impl SegmentationCtx {
         usize, /* main */
         usize, /* interaction */
     ) {
-        let (main_cnt_with_rot, main_cnt_no_rot, interaction_cnt) =
+        let (main_cnt_with_rot, main_cnt_no_rot, interaction_cells) =
             self.calculate_cell_counts(trace_heights);
-        self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cnt)
+        self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cells)
+    }
+
+    #[cfg(feature = "metrics")]
+    #[inline(always)]
+    fn calculate_memory_breakdown(&self, counts: &MeteredCounts) -> MeteredMemoryBreakdown {
+        let main_weight = self.config.main_cell_weight;
+        let main_secondary_weight = self.config.main_cell_secondary_weight;
+        let interaction_weight = self.config.interaction_cell_weight;
+        let base_field_size = self.config.base_field_size;
+
+        let main_unpadded_cells = counts.main_unpadded_with_rot + counts.main_unpadded_no_rot;
+        let main_padding_cells = counts.main_padding_with_rot + counts.main_padding_no_rot;
+        let main_unpadded = main_unpadded_cells * main_weight * base_field_size;
+        let main_padding = main_padding_cells * main_weight * base_field_size;
+        let main = main_unpadded + main_padding;
+
+        let main_secondary_unpadded = calculate_main_secondary_memory(
+            counts.main_unpadded_with_rot,
+            counts.main_unpadded_no_rot,
+            base_field_size,
+            main_secondary_weight,
+        );
+        let main_secondary = calculate_main_secondary_memory(
+            counts.main_unpadded_with_rot + counts.main_padding_with_rot,
+            counts.main_unpadded_no_rot + counts.main_padding_no_rot,
+            base_field_size,
+            main_secondary_weight,
+        );
+        let main_secondary_padding = main_secondary - main_secondary_unpadded;
+
+        let interaction_weighted_unpadded = ceil_weighted_bytes(
+            counts.interaction_cells_unpadded,
+            base_field_size,
+            interaction_weight,
+        );
+        let interaction_weighted = ceil_weighted_bytes(
+            counts.interaction_cells_unpadded + counts.interaction_cells_padding,
+            base_field_size,
+            interaction_weight,
+        );
+        let interaction_unpadded =
+            interaction_weighted_unpadded + DEFAULT_INTERACTION_MEMORY_OVERHEAD;
+        let interaction_padding = interaction_weighted - interaction_weighted_unpadded;
+        let interaction = interaction_unpadded + interaction_padding;
+
+        let (peak_unpadded, peak_padding, peak) = if interaction >= main_secondary {
+            (interaction_unpadded, interaction_padding, interaction)
+        } else {
+            (
+                main_secondary_unpadded,
+                main_secondary_padding,
+                main_secondary,
+            )
+        };
+
+        MeteredMemoryBreakdown {
+            total: main + peak,
+            unpadded: main_unpadded + peak_unpadded,
+            padding: main_padding + peak_padding,
+            interaction_memory_overhead: DEFAULT_INTERACTION_MEMORY_OVERHEAD,
+        }
     }
 
     /// Calculate the total interactions based on trace heights
@@ -355,7 +514,7 @@ impl SegmentationCtx {
 
         let mut main_cnt_with_rot = 0usize;
         let mut main_cnt_no_rot = 0usize;
-        let mut interaction_cnt = 0usize;
+        let mut interaction_cells = 0usize;
         for (i, ((((padded_height, width), interactions), is_constant), &need_rot)) in trace_heights
             .iter()
             .map(|&height| height.next_power_of_two())
@@ -385,11 +544,11 @@ impl SegmentationCtx {
             } else {
                 main_cnt_no_rot += main_cells;
             }
-            interaction_cnt += padded_height as usize * interactions;
+            interaction_cells += padded_height as usize * interactions;
         }
 
         let (total_memory, main_memory, interaction_memory) =
-            self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cnt);
+            self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cells);
         if total_memory > self.config.limits.max_memory {
             tracing::info!(
                 "overshoot: instret {:10} | total memory ({:5}) > max ({:5}) | main ({:5}) | interaction ({:5})",
@@ -532,6 +691,12 @@ impl SegmentationCtx {
         );
 
         self.log_segment_info::<IS_FINAL>(instret_start, num_insns, &trace_heights);
+        #[cfg(feature = "metrics")]
+        {
+            let segment = self.segments.len().to_string();
+            self.emit_metered_segment_metrics(&segment, &trace_heights);
+            self.emit_metered_air_metrics(&segment, &trace_heights);
+        }
         self.segments.push(Segment {
             instret_start,
             num_insns,
@@ -590,5 +755,96 @@ impl SegmentationCtx {
             utilization,
             final_marker
         );
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl SegmentationCtx {
+    fn emit_metered_segment_metrics(&self, segment: &str, trace_heights: &[u32]) {
+        let counts = self.calculate_count_breakdown(trace_heights);
+        let memory = self.calculate_memory_breakdown(&counts);
+        let (max_padded_height, _) = self.calculate_max_trace_height_with_name(trace_heights);
+        let labels = [("segment", segment.to_string())];
+        metrics::counter!("metered_memory_bytes", &labels).absolute(memory.total as u64);
+        metrics::counter!("metered_memory_unpadded_bytes", &labels)
+            .absolute(memory.unpadded as u64);
+        metrics::counter!("metered_memory_padding_bytes", &labels).absolute(memory.padding as u64);
+        metrics::counter!("metered_interaction_memory_overhead_bytes", &labels)
+            .absolute(memory.interaction_memory_overhead as u64);
+        metrics::counter!("metered_max_padded_height", &labels).absolute(max_padded_height as u64);
+    }
+
+    fn emit_metered_air_metrics(&self, segment: &str, trace_heights: &[u32]) {
+        let main_weight = self.config.main_cell_weight;
+        let main_secondary_weight = self.config.main_cell_secondary_weight;
+        let interaction_weight = self.config.interaction_cell_weight;
+        let base_field_size = self.config.base_field_size;
+
+        for (air_id, ((((&height, &width), &interactions), &need_rot), air_name)) in trace_heights
+            .iter()
+            .zip(self.widths.iter())
+            .zip(self.interactions.iter())
+            .zip(self.need_rot.iter())
+            .zip(self.air_names.iter())
+            .enumerate()
+        {
+            let padded_height = height.next_power_of_two();
+            let padding_height = padded_height - height;
+            if height == 0 && padding_height == 0 {
+                continue;
+            }
+            let labels = [
+                ("air_name", air_name.clone()),
+                ("air_id", air_id.to_string()),
+                ("segment", segment.to_string()),
+            ];
+            let unpadded_cells = height as usize * width;
+            let padding_cells = padding_height as usize * width;
+            // One interaction cell is one metered row-interaction slot.
+            let interaction_cells_unpadded = height as usize * interactions;
+            let interaction_cells_padding = padding_height as usize * interactions;
+            let secondary_weight = secondary_weight_for_rot(need_rot, main_secondary_weight);
+            let main_secondary_unpadded =
+                ceil_weighted_bytes(unpadded_cells, base_field_size, secondary_weight);
+            let main_secondary = ceil_weighted_bytes(
+                unpadded_cells + padding_cells,
+                base_field_size,
+                secondary_weight,
+            );
+            let interaction_unpadded = ceil_weighted_bytes(
+                interaction_cells_unpadded,
+                base_field_size,
+                interaction_weight,
+            );
+            let interaction_total = ceil_weighted_bytes(
+                interaction_cells_unpadded + interaction_cells_padding,
+                base_field_size,
+                interaction_weight,
+            );
+
+            metrics::counter!("metered_rows_unpadded", &labels).absolute(height as u64);
+            metrics::counter!("metered_rows_padding", &labels).absolute(padding_height as u64);
+            metrics::counter!("metered_main_cells_unpadded", &labels)
+                .absolute(unpadded_cells as u64);
+            metrics::counter!("metered_main_cells_padding", &labels).absolute(padding_cells as u64);
+            metrics::counter!("metered_interaction_cells_unpadded", &labels)
+                .absolute(interaction_cells_unpadded as u64);
+            metrics::counter!("metered_interaction_cells_padding", &labels)
+                .absolute(interaction_cells_padding as u64);
+            metrics::counter!("metered_main_memory_unpadded_bytes", &labels)
+                .absolute((unpadded_cells * main_weight * base_field_size) as u64);
+            metrics::counter!("metered_main_memory_padding_bytes", &labels)
+                .absolute((padding_cells * main_weight * base_field_size) as u64);
+            metrics::counter!("metered_main_secondary_memory_unpadded_bytes", &labels)
+                .absolute(main_secondary_unpadded as u64);
+            metrics::counter!("metered_main_secondary_memory_padding_bytes", &labels)
+                .absolute((main_secondary - main_secondary_unpadded) as u64);
+            metrics::counter!("metered_interaction_memory_unpadded_bytes", &labels)
+                .absolute(interaction_unpadded as u64);
+            metrics::counter!("metered_interaction_memory_padding_bytes", &labels)
+                .absolute((interaction_total - interaction_unpadded) as u64);
+            metrics::counter!("metered_interactions", &labels)
+                .absolute(((height as usize + 1) * interactions) as u64);
+        }
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -6,6 +6,8 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use p3_baby_bear::BabyBear;
 use serde::{Deserialize, Serialize};
 
+use crate::utils::next_power_of_two_or_zero;
+
 /// Extension field size.
 const D_EF: usize = 4;
 pub const DEFAULT_SEGMENT_CHECK_INSNS: u64 = 1000;
@@ -83,6 +85,15 @@ fn calculate_main_secondary_memory(
         base_field_size,
         secondary_weight_for_rot(false, main_secondary_weight),
     )
+}
+
+#[inline(always)]
+fn add_one_or_zero(n: u32) -> usize {
+    if n == 0 {
+        0
+    } else {
+        n as usize + 1
+    }
 }
 
 #[cfg(feature = "metrics")]
@@ -288,7 +299,7 @@ impl SegmentationCtx {
         trace_heights
             .iter()
             .enumerate()
-            .map(|(i, &height)| (height.next_power_of_two(), i))
+            .map(|(i, &height)| (next_power_of_two_or_zero(height as usize) as u32, i))
             .max_by_key(|(height, _)| *height)
             .map(|(height, idx)| (height, self.air_names[idx].as_str()))
             .unwrap_or((0, "unknown"))
@@ -349,7 +360,7 @@ impl SegmentationCtx {
             .zip(self.interactions.iter())
             .zip(self.need_rot.iter())
         {
-            let padded_height = height.next_power_of_two() as usize;
+            let padded_height = next_power_of_two_or_zero(height as usize);
             let unpadded_height = height as usize;
             let padding_height = padded_height - unpadded_height;
             counts.unpadded_rows += unpadded_height;
@@ -386,7 +397,7 @@ impl SegmentationCtx {
             .zip(self.interactions.iter())
             .zip(self.need_rot.iter())
         {
-            let padded_height = height.next_power_of_two() as usize;
+            let padded_height = next_power_of_two_or_zero(height as usize);
             let main_cells = padded_height * width;
             if need_rot {
                 main_cnt_with_rot += main_cells;
@@ -484,7 +495,7 @@ impl SegmentationCtx {
         trace_heights
             .iter()
             .zip(self.interactions.iter())
-            .map(|(&height, &interactions)| (height + 1) as usize * interactions)
+            .map(|(&height, &interactions)| add_one_or_zero(height) * interactions)
             .sum()
     }
 
@@ -517,7 +528,7 @@ impl SegmentationCtx {
         let mut interaction_cells = 0usize;
         for (i, ((((padded_height, width), interactions), is_constant), &need_rot)) in trace_heights
             .iter()
-            .map(|&height| height.next_power_of_two())
+            .map(|&height| next_power_of_two_or_zero(height as usize) as u32)
             .zip(self.widths.iter())
             .zip(self.interactions.iter())
             .zip(is_trace_height_constant.iter())
@@ -714,7 +725,7 @@ impl SegmentationCtx {
             .zip(self.widths.iter())
             .map(|(&height, &width)| {
                 let used = height as usize * width;
-                let padded = height.next_power_of_two() as usize * width;
+                let padded = next_power_of_two_or_zero(height as usize) * width;
                 (used, padded)
             })
             .fold((0, 0), |(u, p), (used, padded)| (u + used, p + padded));
@@ -788,9 +799,10 @@ impl SegmentationCtx {
             .zip(self.air_names.iter())
             .enumerate()
         {
-            let padded_height = height.next_power_of_two();
-            let padding_height = padded_height - height;
-            if height == 0 && padding_height == 0 {
+            let padded_height = next_power_of_two_or_zero(height as usize);
+            let unpadded_height = height as usize;
+            let padding_height = padded_height - unpadded_height;
+            if padded_height == 0 {
                 continue;
             }
             let labels = [
@@ -798,11 +810,11 @@ impl SegmentationCtx {
                 ("air_id", air_id.to_string()),
                 ("segment", segment.to_string()),
             ];
-            let unpadded_cells = height as usize * width;
-            let padding_cells = padding_height as usize * width;
+            let unpadded_cells = unpadded_height * width;
+            let padding_cells = padding_height * width;
             // One interaction cell is one metered row-interaction slot.
-            let interaction_cells_unpadded = height as usize * interactions;
-            let interaction_cells_padding = padding_height as usize * interactions;
+            let interaction_cells_unpadded = unpadded_height * interactions;
+            let interaction_cells_padding = padding_height * interactions;
             let secondary_weight = secondary_weight_for_rot(need_rot, main_secondary_weight);
             let main_secondary_unpadded =
                 ceil_weighted_bytes(unpadded_cells, base_field_size, secondary_weight);
@@ -844,7 +856,7 @@ impl SegmentationCtx {
             metrics::counter!("metered_interaction_memory_padding_bytes", &labels)
                 .absolute((interaction_total - interaction_unpadded) as u64);
             metrics::counter!("metered_interactions", &labels)
-                .absolute(((height as usize + 1) * interactions) as u64);
+                .absolute((add_one_or_zero(height) * interactions) as u64);
         }
     }
 }

--- a/crates/vm/src/arch/interpreter_preflight.rs
+++ b/crates/vm/src/arch/interpreter_preflight.rs
@@ -199,22 +199,27 @@ impl<F: PrimeField32, E> PreflightInterpretedInstance<F, E> {
         unsafe {
             *self.execution_frequencies.get_unchecked_mut(pc_idx) += 1;
         };
-        // SAFETY: the `executor_idx` comes from ExecutorInventory, which ensures that
-        // `executor_idx` is within bounds
+        tracing::trace!("pc: {pc:#x} | {:?}", pc_entry.insn);
+
+        if !pc_entry.is_some() {
+            return Err(ExecutionError::Unreachable(pc));
+        }
+
+        let opcode = pc_entry.insn.opcode;
+        let c = pc_entry.insn.c;
+        // Handle termination instruction
+        if opcode == SystemOpcode::TERMINATE.global_opcode() {
+            state.exit_code = Ok(Some(c.as_canonical_u32()));
+            return Ok(());
+        }
+
+        // SAFETY: non-system `executor_idx` values come from `ExecutorInventory`, which ensures
+        // that `executor_idx` is within bounds.
         let executor = unsafe {
             self.inventory
                 .executors
                 .get_unchecked(pc_entry.executor_idx as usize)
         };
-        tracing::trace!("pc: {pc:#x} | {:?}", pc_entry.insn);
-
-        let opcode = pc_entry.insn.opcode;
-        let c = pc_entry.insn.c;
-        // Handle termination instruction
-        if opcode.as_usize() == SystemOpcode::CLASS_OFFSET + SystemOpcode::TERMINATE as usize {
-            state.exit_code = Ok(Some(c.as_canonical_u32()));
-            return Ok(());
-        }
 
         // Execute the instruction using the control implementation
         tracing::trace!(

--- a/crates/vm/src/arch/interpreter_preflight.rs
+++ b/crates/vm/src/arch/interpreter_preflight.rs
@@ -129,7 +129,10 @@ impl<F: PrimeField32, E> PreflightInterpretedInstance<F, E> {
     {
         let mut counts = BTreeMap::new();
         for (entry, &freq) in self.pc_handler.iter().zip(&self.execution_frequencies) {
-            if freq == 0 || !entry.is_some() {
+            if freq == 0
+                || !entry.is_some()
+                || entry.insn.opcode == SystemOpcode::TERMINATE.global_opcode()
+            {
                 continue;
             }
             let executor_idx = entry.executor_idx as usize;

--- a/crates/vm/src/arch/interpreter_preflight.rs
+++ b/crates/vm/src/arch/interpreter_preflight.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "metrics")]
+use std::collections::BTreeMap;
 use std::{iter::repeat_n, sync::Arc};
 
 #[cfg(not(feature = "parallel"))]
@@ -119,6 +121,33 @@ impl<F: Field, E> PreflightInterpretedInstance<F, E> {
 }
 
 impl<F: PrimeField32, E> PreflightInterpretedInstance<F, E> {
+    #[cfg(feature = "metrics")]
+    pub fn opcode_counts_by_air<RA>(&self) -> BTreeMap<(usize, String), u64>
+    where
+        RA: Arena,
+        E: PreflightExecutor<F, RA>,
+    {
+        let mut counts = BTreeMap::new();
+        for (entry, &freq) in self.pc_handler.iter().zip(&self.execution_frequencies) {
+            if freq == 0 || !entry.is_some() {
+                continue;
+            }
+            let executor_idx = entry.executor_idx as usize;
+            let air_idx = unsafe {
+                // SAFETY: `entry.executor_idx` was produced by `ExecutorInventory`, and
+                // `executor_idx_to_air_idx` has one entry per executor.
+                *self.executor_idx_to_air_idx.get_unchecked(executor_idx)
+            };
+            let executor = unsafe {
+                // SAFETY: same invariant as in `execute_instruction`.
+                self.inventory.executors.get_unchecked(executor_idx)
+            };
+            let opcode = executor.get_opcode_name(entry.insn.opcode.as_usize());
+            *counts.entry((air_idx, opcode)).or_insert(0) += freq as u64;
+        }
+        counts
+    }
+
     /// Stopping is triggered by should_stop() or if VM is terminated
     pub fn execute_from_state<RA>(
         &mut self,

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -45,6 +45,10 @@ use super::{
     VmExecutionConfig, VmState, BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, MERKLE_AIR_ID, PROGRAM_AIR_ID,
     PROGRAM_CACHED_TRACE_INDEX,
 };
+#[cfg(feature = "metrics")]
+use crate::metrics::emit_opcode_counts;
+#[cfg(feature = "perf-metrics")]
+use crate::metrics::end_segment_metrics;
 use crate::{
     arch::deferral::DeferralState,
     execute_spanned,
@@ -617,9 +621,14 @@ where
         interpreter.reset_execution_frequencies();
         execute_spanned!("execute_preflight", interpreter, &mut exec_state)?;
         let filtered_exec_frequencies = interpreter.filtered_execution_frequencies();
+        #[cfg(feature = "metrics")]
+        emit_opcode_counts(
+            &exec_state.vm_state.metrics,
+            interpreter.opcode_counts_by_air::<VB::RecordArena>(),
+        );
         let touched_memory = exec_state.vm_state.memory.finalize::<Val<E::SC>>();
         #[cfg(feature = "perf-metrics")]
-        crate::metrics::end_segment_metrics(&mut exec_state);
+        end_segment_metrics(&mut exec_state);
 
         let pc = exec_state.vm_state.pc();
         let memory = exec_state.vm_state.memory;
@@ -671,9 +680,13 @@ where
             state.metrics.fn_bounds = exe.fn_bounds.clone();
             state.metrics.debug_infos = exe.program.debug_infos();
         }
+        #[cfg(feature = "metrics")]
+        {
+            state.metrics.set_pk_air_names(&self.pk);
+        }
         #[cfg(feature = "perf-metrics")]
         {
-            state.metrics.set_pk_info(&self.pk);
+            state.metrics.set_pk_trace_info(&self.pk);
             state.metrics.num_sys_airs = self.config().as_ref().num_airs();
         }
         state

--- a/crates/vm/src/metrics/mod.rs
+++ b/crates/vm/src/metrics/mod.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, mem};
 
 use backtrace::Backtrace;
 use cycle_tracker::CycleTracker;
+#[cfg(feature = "perf-metrics")]
 use itertools::Itertools;
 use metrics::counter;
 use openvm_instructions::{
@@ -27,7 +28,9 @@ pub struct VmMetrics {
     pub debug_infos: ProgramDebugInfo,
     #[cfg(feature = "perf-metrics")]
     pub(crate) num_sys_airs: usize,
+    #[cfg(feature = "perf-metrics")]
     pub(crate) main_widths: Vec<usize>,
+    #[cfg(feature = "perf-metrics")]
     pub(crate) total_widths: Vec<usize>,
 
     // Dynamic stats
@@ -38,6 +41,7 @@ pub struct VmMetrics {
     /// Metric collection tools. Only collected when "perf-metrics" feature is enabled.
     pub cycle_tracker: CycleTracker,
 
+    #[cfg(feature = "perf-metrics")]
     pub(crate) current_trace_cells: Vec<usize>,
 
     /// Backtrace for guest debug panic display
@@ -107,32 +111,50 @@ where
     state.metrics.current_trace_cells.fill(0);
 }
 
+#[cfg(feature = "metrics")]
+pub fn emit_opcode_counts(metrics: &VmMetrics, counts: BTreeMap<(usize, String), u64>) {
+    for ((air_idx, opcode), count) in counts {
+        let Some(air_name) = metrics.air_names.get(air_idx) else {
+            continue;
+        };
+        let labels = [
+            ("air_name", air_name.clone()),
+            ("air_id", air_idx.to_string()),
+            ("opcode", opcode),
+        ];
+        counter!("opcode_count", &labels).absolute(count);
+    }
+}
+
 impl VmMetrics {
-    pub fn set_pk_info<PB: ProverBackend>(&mut self, pk: &DeviceMultiStarkProvingKey<PB>) {
-        let (air_names, main_widths, total_widths): (Vec<_>, Vec<_>, Vec<_>) = pk
+    #[cfg(feature = "metrics")]
+    pub fn set_pk_air_names<PB: ProverBackend>(&mut self, pk: &DeviceMultiStarkProvingKey<PB>) {
+        self.air_names = pk.per_air.iter().map(|pk| pk.air_name.clone()).collect();
+    }
+
+    #[cfg(feature = "perf-metrics")]
+    pub fn set_pk_trace_info<PB: ProverBackend>(&mut self, pk: &DeviceMultiStarkProvingKey<PB>) {
+        let (main_widths, total_widths): (Vec<_>, Vec<_>) = pk
             .per_air
             .iter()
             .map(|pk| {
-                let air_names = pk.air_name.clone();
                 let width = &pk.vk.params.width;
-                let main_width = width.main_width();
-                let total_width = width.total_width();
-                (air_names, main_width, total_width)
+                (width.main_width(), width.total_width())
             })
-            .multiunzip();
-        self.air_names = air_names;
+            .unzip();
         self.main_widths = main_widths;
         self.total_widths = total_widths;
         self.current_trace_cells = vec![0; self.air_names.len()];
     }
 
+    #[cfg(feature = "perf-metrics")]
     pub fn update_trace_cells(
         &mut self,
         now_trace_cells: Vec<usize>,
         opcode_name: String,
         dsl_instr: Option<String>,
     ) {
-        let key = (dsl_instr, opcode_name);
+        let key = (dsl_instr, opcode_name.clone());
         self.cycle_tracker.increment_opcode(&key);
         *self.counts.entry(key.clone()).or_insert(0) += 1;
 
@@ -140,10 +162,10 @@ impl VmMetrics {
             itertools::izip!(&self.air_names, &now_trace_cells, &self.current_trace_cells)
         {
             if prev_value != now_value {
+                let cells_used = now_value - prev_value;
                 let key = (key.0.clone(), key.1.clone(), air_name.to_owned());
-                self.cycle_tracker
-                    .increment_cells_used(&key, now_value - prev_value);
-                *self.trace_cells.entry(key).or_insert(0) += now_value - prev_value;
+                self.cycle_tracker.increment_cells_used(&key, cells_used);
+                *self.trace_cells.entry(key).or_insert(0) += cells_used;
             }
         }
         self.current_trace_cells = now_trace_cells;


### PR DESCRIPTION
- Adds metered segment and per-AIR metrics for rows, cells, memory, padding, and interactions.
- Emits opcode execution counts from preflight execution frequencies, labeled by AIR and opcode.
- Keeps exact opcode trace-cell attribution behind `perf-metrics`.
- Defines interaction cells as `rows * interactions`; emits interaction memory overhead separately because it is added once per segment.