### PR TITLE
fix(static-verifier): bound signed_div_mod quotient for negative dividends

### DIFF
--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -6,7 +6,7 @@ use halo2_base::{
         arithmetic::Field as _,
         halo2curves::{bn256::Fr, ff::PrimeField as _},
     },
-    utils::{bigint_to_fe, biguint_to_fe, bit_length, fe_to_bigint, BigPrimeField},
+    utils::{bigint_to_fe, biguint_to_fe, bit_length, fe_to_bigint, modulus, BigPrimeField},
     AssignedValue, Context, QuantumCell,
 };
 use itertools::Itertools;
@@ -417,14 +417,24 @@ impl BabyBearChip {
     }
 }
 
-/// Constrains and returns `(c, r)` such that `a = BabyBear::ORDER_U32 * c + r`.
+/// Constrains and returns `(div, rem)` encoding integers `D` and `R` such that
+/// `A = BabyBear::ORDER_U32 * D + R` with `0 <= R < BabyBear::ORDER_U32`, where
+/// `A = fe_to_bigint(a)` is the canonical signed representative of `a` in
+/// `(-p/2, p/2]` and `p = F::MODULUS`.
 ///
-/// * a: [QuantumCell] value to divide
-/// * a_num_bits: number of bits needed to represent the absolute value of `a`
+/// The returned `div` cell encodes the possibly negative integer `D` modulo
+/// `p`; the returned `rem` cell encodes the canonical nonnegative integer `R`.
 ///
-/// ## Assumptions
-/// * `a_max_bits < F::CAPACITY = F::NUM_BITS - RESERVED_HIGH_BITS`
-///   * Unsafe behavior if `a_max_bits >= F::CAPACITY`
+/// # Arguments
+///
+/// * `a` - the [`QuantumCell`] value to divide.
+/// * `a_num_bits` - a bound such that `|A| < 2^a_num_bits`.
+///
+/// # Preconditions
+///
+/// This function does not itself range-check `a`. The caller must ensure,
+/// either by prior constraints or by construction, that the canonical signed
+/// representative `A = fe_to_bigint(a)` satisfies `|A| < 2^a_num_bits`.
 fn signed_div_mod<F>(
     range: &RangeChip<F>,
     ctx: &mut Context<F>,
@@ -434,42 +444,72 @@ fn signed_div_mod<F>(
 where
     F: BigPrimeField,
 {
-    // Proof of correctness:
-    // Let `b` be the order of `BabyBear` and `p` be the order of `Fr`.
-    // First we introduce witness `div` and `rem`.
-    // We constraint:
-    // (1) `div * b + rem ≡ a (mod p)`
-    // (2) `0 <= rem < b`
-    // Logically we want `div = a // b`. Because (2) and `a` could be negative, `div` could
-    // be negative. Therefore, we have `|div| = |a // b| = |a| // b < 2^max_bits // b = bound` and
-    // we can say `shifted_div = div + bound` is in `[0, 2 * bound)`.
-    // In practice, it's expensive to assert `shifted_div` is less than `2 * bound` which is not a
-    // power of 2s. Instead, we add a looser constraint:
-    // (3) `shifted_div < 2^max_bits/2^(BABYBEAR_ORDER_BITS-1)=2^(max_bits-BABYBEAR_ORDER_BITS+1)`
+    // Proof sketch:
     //
-    // Let's check if |div * b + rem| can overflow:
-    // - `div` has at most `max_bits-BABYBEAR_ORDER_BITS` bits
-    // - `b` has `BABYBEAR_ORDER_BITS` bits.
-    // - `rem` has at most `BABYBEAR_ORDER_BITS` bits.
-    // When `max_bits > BABYBEAR_ORDER_BITS`, `|div * b + rem|` has at most `max_bits+1` bits.
-    // Because of the invariant `max_bits <= Fr::CAPACITY - RESERVED_HIGH_BITS`, `|div * b + rem|`
-    // cannot overflow.
+    // Let `b = BabyBear::ORDER_U32`, `p = F::MODULUS`, and let
+    // `A = fe_to_bigint(a)` be the canonical signed representative of `a`.
+    // Assume `|A| < 2^a_num_bits`.
     //
-    // Let's check if the looser constraint will cause some problem:
-    // Assume there are other `div'` and `rem'` satisfying:
-    // `div * b + rem ≡ div' * b + rem' (mod p)`
-    // Then we have:
-    // `(div - div') * b ≡ rem' - rem (mod p)`
-    // (3) => `|(div - div') * b| < 2^(max_bits+1) < p`
-    // (2) => `|rem' - rem| < b`
-    // There could be 3 cases:
-    // a. `-b < (div - div') * b < b` or;
-    // b. `0 < (div - div') * b + p < b` or;
-    // c. `-b < (div - div') * b - p < 0`
-    // Case (a) is impossible because `div != div'`.
-    // Case (b) and (c) imply:
-    // |div - div'|  > (p-b) // b > 2^(Fr::CAPACITY - (BABYBEAR_ORDER_BITS - 1) - 1) = 2^(Fr::CAPACITY - BABYBEAR_ORDER_BITS)
-    // (3) also constrains that this is impossible.
+    // The intended witnesses are the Euclidean quotient and remainder:
+    //
+    //   div = floor(A / b),   rem = A mod b,   0 <= rem < b.
+    //
+    // We enforce:
+    //
+    //   (1) rem + b * div = a      over F
+    //   (2) 0 <= rem < b
+    //   (3) 0 <= div + bound < 2^k
+    //
+    // where
+    //
+    //   bound = ceil((2^a_num_bits - 1) / b)
+    //   k     = bits(2 * bound + 1).
+    //
+    // Completeness is immediate: since `|A| <= 2^a_num_bits - 1`, the honest
+    // quotient satisfies `|div| <= bound`, so `div + bound` lies in
+    // `[0, 2 * bound]` and passes the `k`-bit range check.
+    //
+    // For soundness, note that the `k`-bit check is slightly looser than
+    // `div + bound <= 2 * bound`. For any satisfying assignment, let `S` be the
+    // canonical integer value of `div + bound`, so `0 <= S < 2^k`, and set
+    // `D = S - bound`. Since `2^k <= 4 * bound + 2`, we have
+    //
+    //   -bound <= D <= 3 * bound + 1.
+    //
+    // Thus any two satisfying assignments `(D, R)` and `(D', R')` obey
+    //
+    //   |D - D'| <= 4 * bound + 1,
+    //   |R - R'| < b.
+    //
+    // Both assignments satisfy:
+    //
+    //   R  + b * D  = a mod p
+    //   R' + b * D' = a mod p
+    //
+    // Subtracting the second congruence from the first gives
+    //
+    //   (D - D') * b - (R' - R) = 0 mod p.
+    //
+    // Equivalently, this integer is some multiple of `p`:
+    //
+    //   (D - D') * b - (R' - R) = m * p.
+    //
+    // Its magnitude is bounded by
+    //
+    //   |(D - D') * b - (R' - R)| < (4 * bound + 2) * b.
+    //
+    // The runtime assertion
+    //
+    //   assert!((4 * bound + 2) * b <= p)
+    //
+    // ensures this magnitude is strictly less than `p`. The only multiple of `p`
+    // with magnitude less than `p` is zero, so `m = 0`. Therefore
+    //
+    //   (D - D') * b = R' - R.
+    //
+    // The left side is divisible by `b`, while the right side has magnitude `< b`.
+    // Hence both sides are zero, so `D = D'` and `R = R'`.
+    assert!(a_num_bits <= F::CAPACITY as usize - RESERVED_HIGH_BITS);
     let a = a.into();
     let b = BigUint::from(BabyBear::ORDER_U32);
     let a_val = fe_to_bigint(a.value());
@@ -487,8 +527,11 @@ where
     );
     let rem = ctx.get(-4);
     let div = ctx.get(-2);
-    // Constrain that `abs(div) <= 2 ** (2 ** a_num_bits / b).bits()`.
-    let bound = (BigUint::from(1u32) << (a_num_bits as u32)) / &b;
+    // `bound = ceil((2^a_num_bits - 1) / b)`; the bit-length range check below admits
+    // `div in [-bound, 3*bound+1]`, and the assertion enforces the no-wrap headroom
+    // `(4 * bound + 2) * b <= p`. See the proof above for both.
+    let bound = ((BigUint::from(1u32) << a_num_bits) - 1u32).div_ceil(&b);
+    assert!((&bound * 4u32 + 2u32) * &b <= modulus::<F>());
     let shifted_div = range
         .gate()
         .add(ctx, div, QuantumCell::Constant(biguint_to_fe(&bound)));

--- a/crates/static-verifier/src/field/baby_bear/tests.rs
+++ b/crates/static-verifier/src/field/baby_bear/tests.rs
@@ -101,6 +101,27 @@ fn baby_bear_base_ops_match_native_mod_arithmetic() {
     });
 }
 
+/// Reducing a negative wire with a tight `max_bits` must succeed. `neg(one)` yields
+/// `value == -1`, `max_bits == 1`, so `reduce` drives `signed_div_mod(-1, 1)` whose
+/// quotient `div == -1` has magnitude one even though `floor(2^1 / b) == 0`; this
+/// exercises the `ceil((2^a_num_bits - 1) / b)` quotient bound.
+#[test]
+fn reduce_negative_value_with_tight_max_bits() {
+    run_mock(|builder| {
+        let range = builder.range_chip();
+        let chip = BabyBearChip::new(Arc::new(range.clone()));
+        let ctx = builder.main(0);
+        let gate = range.gate();
+
+        let one = chip.load_constant(ctx, RootF::ONE);
+        let neg_one = chip.neg(ctx, one); // value == -1, max_bits == 1
+
+        // `-1` reduces to its canonical representative `p - 1`.
+        let reduced = chip.reduce(ctx, neg_one);
+        gate.assert_is_const(ctx, &reduced.value, &Fr::from(BABY_BEAR_MODULUS_U64 - 1));
+    });
+}
+
 #[test]
 fn baby_bear_ext_mul_matches_native_binomial_extension() {
     run_mock(|builder| {


### PR DESCRIPTION
`signed_div_mod` range-checked `div = floor(a / b)` against `bound = floor(2^a_num_bits / b)`, justified by `|a // b| = |a| // b`. That identity is false for negative `a` with a nonzero remainder, where `|floor(a / b)| = ceil(|a| / b)` can exceed the bound, making `shifted_div = div + bound` negative and the range check unsatisfiable (e.g. reducing `neg(one)`, which carries `value == -1`, `max_bits == 1`).

Compute `bound = ceil((2^a_num_bits - 1) / b)` so the symmetric shift covers both signs, and correct the proof-of-correctness comment.