### PR TITLE
fix: constrain canonical deferral hook location in main agg tree

### DIFF
--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -304,16 +304,19 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * Finally, we need to constrain that the public values this AIR produces are consistent
          * with the child's. initial_acc_hash should be the compression of a padded
          * def_circuit_commit, and final_acc_hash should be the compression of the input and
-         * output onions. Note that the Merkle root computation hashes each leaf with the
+         * output onions. node_idx should be equal to the def_idx of the deferral circuit this
+         * hook proof is for. Note that the Merkle root computation hashes each leaf with the
          * zero digest prior.
          */
         let &DeferralPvs::<_> {
             initial_acc_hash,
             final_acc_hash,
             depth,
+            node_idx,
         } = builder.public_values().borrow();
 
         builder.assert_one(depth);
+        builder.assert_eq(node_idx, local.def_pvs.def_idx);
 
         self.poseidon2_compress_bus.lookup_key(
             builder,

--- a/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
@@ -99,6 +99,7 @@ pub fn generate_proving_ctx(
     root_pvs.initial_acc_hash = initial_acc_hash;
     root_pvs.final_acc_hash = final_acc_hash;
     root_pvs.depth = F::ONE;
+    root_pvs.node_idx = def_pvs.def_idx;
 
     poseidon2_compress_inputs.extend_from_slice(&[
         pad_slice_to_poseidon2_input(&def_circuit_commit, F::ZERO),

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -158,6 +158,17 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             );
         }
 
+        self.public_values_bus.receive(
+            builder,
+            local.proof_idx,
+            PublicValuesBusMessage {
+                air_idx,
+                pv_idx: AB::Expr::from_usize(2 * DIGEST_SIZE),
+                value: local.child_pvs.def_idx.into(),
+            },
+            is_present_leaf.clone(),
+        );
+
         self.input_or_merkle_commit_bus.receive(
             builder,
             local.proof_idx,
@@ -213,9 +224,9 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         /*
-         * On internal layers we receive num_def_circuit_proofs and merkle_depth from
+         * On internal layers we receive num_def_circuit_proofs, merkle_depth, and def_idx from
          * PublicValuesBus. To save columns, we repurpose the first two elements of the unused
-         * local.child_pvs.input_commit.
+         * local.child_pvs.input_commit for num_def_circuit_proofs and merkle_depth.
          */
         let local_num_def_circuit_proofs = local.child_pvs.input_commit[0];
         let local_merkle_depth = local.child_pvs.input_commit[1];
@@ -246,16 +257,29 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             is_internal * local.is_present,
         );
 
+        self.public_values_bus.receive(
+            builder,
+            local.proof_idx,
+            PublicValuesBusMessage {
+                air_idx: AB::Expr::from_usize(DEF_AGG_PVS_AIR_ID),
+                pv_idx: AB::Expr::from_usize(DIGEST_SIZE + 2),
+                value: local.child_pvs.def_idx.into(),
+            },
+            is_internal * local.is_present,
+        );
+
         /*
          * If there is only one row, then this proof is a wrapper and its public values should
          * match those of its child's. Otherwise, constrain that num_def_circuit_proofs is the
          * sum of the present children's and that merkle_depth is the child merkle_depth + 1.
          * If both children are present, we constrain that their merkle_depth values are equal.
+         * Every present child's def_idx should match this proof's.
          */
         let &DeferralAggregationPvs::<_> {
             merkle_commit,
             num_def_circuit_proofs,
             merkle_depth,
+            def_idx,
         } = builder.public_values().borrow();
 
         let is_first = not(local.proof_idx);
@@ -283,6 +307,9 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .when_transition()
             .when(next.is_present)
             .assert_eq(local_merkle_depth, next_merkle_depth);
+        builder
+            .when(local.is_present)
+            .assert_eq(local.child_pvs.def_idx, def_idx);
 
         /*
          * MAX_DEF_AGG_MERKLE_DEPTH - merkle_depth is range checked to be in [0, 256). This,

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/trace.rs
@@ -40,6 +40,7 @@ pub fn generate_proving_ctx(
     let mut trace = vec![F::ZERO; num_rows * width];
     let mut num_def_circuit_proofs = F::ZERO;
     let mut merkle_depth = F::ZERO;
+    let mut def_idx = F::ZERO;
 
     for (proof_idx, (proof, chunk)) in proofs.iter().zip(trace.chunks_exact_mut(width)).enumerate()
     {
@@ -54,11 +55,14 @@ pub fn generate_proving_ctx(
             cols.merkle_commit = child_pvs.merkle_commit;
             cols.child_pvs.input_commit[0] = child_pvs.num_def_circuit_proofs;
             cols.child_pvs.input_commit[1] = child_pvs.merkle_depth;
+            cols.child_pvs.def_idx = child_pvs.def_idx;
             num_def_circuit_proofs += child_pvs.num_def_circuit_proofs;
             if proof_idx == 0 {
                 merkle_depth = child_pvs.merkle_depth;
+                def_idx = child_pvs.def_idx;
             } else {
                 debug_assert_eq!(merkle_depth, child_pvs.merkle_depth);
+                debug_assert_eq!(def_idx, child_pvs.def_idx);
             }
         } else {
             let child_pvs: &DeferralCircuitPvs<F> = proof.public_values[DEF_CIRCUIT_PVS_AIR_ID]
@@ -78,12 +82,18 @@ pub fn generate_proving_ctx(
             cols.child_pvs = DeferralCircuitPvs {
                 input_commit: folded_input_commit,
                 output_commit: child_pvs.output_commit,
+                def_idx: child_pvs.def_idx,
             };
             let (tagged_input_commit, merkle_commit) =
                 def_leaf_compress(folded_input_commit, child_pvs.output_commit);
             cols.tagged_input_commit = tagged_input_commit;
             cols.merkle_commit = merkle_commit;
             num_def_circuit_proofs += F::ONE;
+            if proof_idx == 0 {
+                def_idx = child_pvs.def_idx;
+            } else {
+                debug_assert_eq!(def_idx, child_pvs.def_idx);
+            }
         }
     }
 
@@ -122,6 +132,7 @@ pub fn generate_proving_ctx(
         pvs.merkle_depth = merkle_depth + F::ONE;
     }
     pvs.num_def_circuit_proofs = num_def_circuit_proofs;
+    pvs.def_idx = def_idx;
 
     let merkle_depth = pvs.merkle_depth.as_canonical_u32() as usize;
     let max_depth_minus_merkle_depth = MAX_DEF_AGG_MERKLE_DEPTH

--- a/crates/continuations/src/circuit/deferral/mod.rs
+++ b/crates/continuations/src/circuit/deferral/mod.rs
@@ -30,6 +30,8 @@ pub struct DeferralCircuitPvs<F> {
     pub input_commit: [F; DIGEST_SIZE],
     /// Commit to the output of the deferral circuit given the input
     pub output_commit: [F; DIGEST_SIZE],
+    /// Deferral circuit index, must be constrained to a constant
+    pub def_idx: F,
 }
 
 #[repr(C)]
@@ -44,4 +46,6 @@ pub struct DeferralAggregationPvs<F> {
     /// Current Merkle depth of this subtree, there are be 2^merkle_depth
     /// leaves (including padding)
     pub merkle_depth: F,
+    /// Deferral circuit index that this subtree belongs to
+    pub def_idx: F,
 }

--- a/crates/continuations/src/circuit/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/def_pvs/air.rs
@@ -19,7 +19,7 @@ use openvm_verify_stark_host::pvs::{
     DeferralPvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
 
 use crate::{
@@ -292,8 +292,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .when(has_two_rows)
             .assert_one(depth.into() - local.child_pvs.depth);
 
-        let canonical_parent_node_idx =
-            (local.child_pvs.node_idx - local.single_present_is_right) * AB::F::TWO.inverse();
+        let canonical_child_node_idx =
+            AB::Expr::TWO * node_idx.into() + local.single_present_is_right;
 
         builder
             .when(is_first_of_two_rows)
@@ -301,7 +301,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .assert_one(next.child_pvs.node_idx - local.child_pvs.node_idx);
         builder
             .when(is_first_of_two_rows)
-            .assert_eq(canonical_parent_node_idx, node_idx);
+            .assert_eq(local.child_pvs.node_idx, canonical_child_node_idx);
 
         self.range_bus.lookup_key(
             builder,

--- a/crates/continuations/src/circuit/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/def_pvs/air.rs
@@ -4,9 +4,12 @@ use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
     ColumnsAir, StructReflection, StructReflectionHelper,
 };
-use openvm_recursion_circuit::bus::{
-    CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
-    PublicValuesBus, PublicValuesBusMessage,
+use openvm_recursion_circuit::{
+    bus::{
+        CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
+        PublicValuesBus, PublicValuesBusMessage,
+    },
+    primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
@@ -48,6 +51,7 @@ pub struct DeferralPvsAir {
     pub public_values_bus: PublicValuesBus,
     pub cached_commit_bus: CachedCommitBus,
     pub poseidon2_bus: Poseidon2CompressBus,
+    pub range_bus: RangeCheckerBus,
     pub pvs_air_consistency_bus: PvsAirConsistencyBus,
 
     pub expected_def_hook_cached_commit: CommitBytes,
@@ -210,19 +214,21 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
 
         /*
          * Finally, we constrain the public values to be consistent with the
-         * child's. If there is one row then the pvs are simply passed through.
-         * If there are two, then initial_acc_hash and final_acc_hash are
-         * combined and depth is incremented by 1.
+         * child's. If there is one row then the pvs are simply passed through
+         * and node_idx must be 0.
          */
         let &DeferralPvs::<_> {
             initial_acc_hash,
             final_acc_hash,
             depth,
+            node_idx,
         } = builder.public_values().borrow();
 
         // constrain that pvs are passed through if there is one row
         let mut when_one_row = builder.when(has_one_row);
         when_one_row.assert_eq(local.child_pvs.depth, depth);
+        when_one_row.assert_eq(local.child_pvs.node_idx, node_idx);
+        when_one_row.assert_zero(node_idx);
 
         assert_array_eq(
             &mut when_one_row,
@@ -235,11 +241,16 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             final_acc_hash,
         );
 
-        // constrain that pvs are updated properly if there are two rows
-        let row_delta = next.row_idx - local.row_idx;
+        /*
+         * If there are two rows, then initial_acc_hash and final_acc_hash are
+         * combined, depth is incremented by 1, and child node indices are
+         * constrained to be adjacent. The left child node_idx must be even,
+         * and the parent node_idx is the left child node_idx divided by 2.
+         * Note that we range check the parent node_idx to be in [0, 256),
+         * which forces each def_idx into [0, 512).
+         */
+        let is_first_of_two_rows = next.row_idx;
         let single_present_is_left = not(local.single_present_is_right);
-        let single_present_is_local =
-            row_delta.clone() * (row_delta + AB::Expr::ONE) * AB::F::TWO.inverse();
 
         let left_init_child = from_fn(|i| {
             single_present_is_left.clone() * local.child_pvs.initial_acc_hash[i]
@@ -256,7 +267,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
                 input: digests_to_poseidon2_input(left_init_child, right_init_child),
                 output: initial_acc_hash.map(Into::into),
             },
-            single_present_is_local.clone(),
+            is_first_of_two_rows,
         );
 
         let left_final_child = from_fn(|i| {
@@ -274,11 +285,31 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
                 input: digests_to_poseidon2_input(left_final_child, right_final_child),
                 output: final_acc_hash.map(Into::into),
             },
-            single_present_is_local,
+            is_first_of_two_rows,
         );
 
         builder
             .when(has_two_rows)
             .assert_one(depth.into() - local.child_pvs.depth);
+
+        let canonical_parent_node_idx =
+            (local.child_pvs.node_idx - local.single_present_is_right) * AB::F::TWO.inverse();
+
+        builder
+            .when(is_first_of_two_rows)
+            .when(next.is_present)
+            .assert_one(next.child_pvs.node_idx - local.child_pvs.node_idx);
+        builder
+            .when(is_first_of_two_rows)
+            .assert_eq(canonical_parent_node_idx, node_idx);
+
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: node_idx.into(),
+                max_bits: AB::Expr::from_u8(8),
+            },
+            is_first_of_two_rows,
+        );
     }
 }

--- a/crates/continuations/src/circuit/inner/def_pvs/trace.rs
+++ b/crates/continuations/src/circuit/inner/def_pvs/trace.rs
@@ -8,7 +8,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{
     poseidon2_compress_with_capacity, BabyBearPoseidon2Config, F,
 };
 use openvm_verify_stark_host::pvs::{DeferralPvs, DEF_PVS_AIR_ID};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
@@ -27,6 +27,7 @@ pub fn generate_proving_ctx(
 ) -> (
     AirProvingContext<CpuBackend<BabyBearPoseidon2Config>>,
     Vec<[F; POSEIDON2_WIDTH]>,
+    Vec<usize>,
 ) {
     assert!(
         absent_trace_pvs.is_none()
@@ -94,6 +95,7 @@ pub fn generate_proving_ctx(
     }
 
     let mut poseidon2_inputs = vec![];
+    let mut range_check_inputs = vec![];
     let mut public_values = vec![F::ZERO; DeferralPvs::<u8>::width()];
     let pvs: &mut DeferralPvs<F> = public_values.as_mut_slice().borrow_mut();
 
@@ -122,6 +124,8 @@ pub fn generate_proving_ctx(
         pvs.final_acc_hash = poseidon2_compress_with_capacity(left_final, right_final).0;
         poseidon2_inputs.push(digests_to_poseidon2_input(left_final, right_final));
         pvs.depth = first_child.depth + F::ONE;
+        pvs.node_idx = (first_child.node_idx - F::from_bool(single_present_is_right)).halve();
+        range_check_inputs.push(pvs.node_idx.as_canonical_u32() as usize);
     }
 
     (
@@ -131,5 +135,6 @@ pub fn generate_proving_ctx(
             public_values,
         },
         poseidon2_inputs,
+        range_check_inputs,
     )
 }

--- a/crates/continuations/src/circuit/inner/mod.rs
+++ b/crates/continuations/src/circuit/inner/mod.rs
@@ -48,6 +48,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for I
         let pre_hash_bus = bus_inventory.pre_hash_bus;
         let poseidon2_compress_bus = bus_inventory.poseidon2_compress_bus;
         let poseidon2_permute_bus = bus_inventory.poseidon2_permute_bus;
+        let range_bus = bus_inventory.range_checker_bus;
         let pvs_air_consistency_bus =
             PvsAirConsistencyBus::new(self.verifier_circuit.next_bus_idx());
 
@@ -84,6 +85,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for I
                 public_values_bus,
                 cached_commit_bus,
                 poseidon2_bus: poseidon2_compress_bus,
+                range_bus,
                 pvs_air_consistency_bus,
                 expected_def_hook_cached_commit: self.def_hook_cached_commit.unwrap(),
             }) as AirRef<SC>;

--- a/crates/continuations/src/circuit/inner/trace.rs
+++ b/crates/continuations/src/circuit/inner/trace.rs
@@ -80,14 +80,17 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for InnerTraceGenImp
             self.deferral_enabled,
         );
 
+        let mut range_check_inputs = vec![];
         let idx2_ctx = if self.deferral_enabled {
-            let (def_pvs_ctx, def_poseidon2_inputs) = super::def_pvs::generate_proving_ctx(
-                proofs,
-                proofs_type,
-                child_is_app,
-                absent_trace_pvs,
-            );
+            let (def_pvs_ctx, def_poseidon2_inputs, def_range_check_inputs) =
+                super::def_pvs::generate_proving_ctx(
+                    proofs,
+                    proofs_type,
+                    child_is_app,
+                    absent_trace_pvs,
+                );
             poseidon2_compress_inputs.extend_from_slice(&def_poseidon2_inputs);
+            range_check_inputs = def_range_check_inputs;
             def_pvs_ctx
         } else {
             super::unset::generate_proving_ctx(&[], child_is_app)
@@ -97,6 +100,7 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for InnerTraceGenImp
             air_proving_ctxs: vec![verifier_pvs_ctx, vm_pvs_ctx, idx2_ctx],
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
         }
     }
 
@@ -163,6 +167,7 @@ impl InnerTraceGen<GpuBackend, GpuDeviceCtx> for InnerTraceGenImpl {
                 .collect_vec(),
             poseidon2_compress_inputs: data.poseidon2_compress_inputs,
             poseidon2_permute_inputs: data.poseidon2_permute_inputs,
+            range_check_inputs: data.range_check_inputs,
         }
     }
 

--- a/crates/continuations/src/circuit/mod.rs
+++ b/crates/continuations/src/circuit/mod.rs
@@ -16,6 +16,7 @@ pub struct SubCircuitTraceData<PB: ProverBackend> {
     pub air_proving_ctxs: Vec<AirProvingContext<PB>>,
     pub poseidon2_compress_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
     pub poseidon2_permute_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
+    pub range_check_inputs: Vec<usize>,
 }
 
 pub struct SingleAirTraceData<PB: ProverBackend> {

--- a/crates/continuations/src/circuit/root/trace.rs
+++ b/crates/continuations/src/circuit/root/trace.rs
@@ -84,6 +84,7 @@ impl<SC: StarkProtocolConfig<F = F>> RootTraceGen<CpuBackend<SC>, ()> for RootTr
                 .chain(memory_inputs)
                 .collect_vec(),
             poseidon2_permute_inputs: verifier_permute_inputs,
+            range_check_inputs: vec![],
         }
     }
 
@@ -151,6 +152,7 @@ impl RootTraceGen<GenericGpuBackend<BabyBearBn254Poseidon2HashScheme>, GpuDevice
                 .collect_vec(),
             poseidon2_compress_inputs: data.poseidon2_compress_inputs,
             poseidon2_permute_inputs: data.poseidon2_permute_inputs,
+            range_check_inputs: data.range_check_inputs,
         }
     }
 

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -394,13 +394,15 @@ impl RootVerifierPvsAir {
          * If deferral_flag is 2, there must be a Merkle path from initial_acc_hash to
          * initial_root and from final_acc_hash to final_root. Else, we constrain that
          * they are 0, that def_hook_commit is unset, and that the deferral address
-         * space remained unchanged.
+         * space remained unchanged. Either way, node_idx must be 0.
          */
         let mut when_no_deferral = builder.when_ne(verifier_pvs.deferral_flag, AB::Expr::TWO);
         when_no_deferral.assert_zero(def_pvs.depth);
         assert_zeros(&mut when_no_deferral, def_pvs.initial_acc_hash);
         assert_zeros(&mut when_no_deferral, def_pvs.final_acc_hash);
         assert_zeros(&mut when_no_deferral, verifier_pvs.def_hook_commit);
+
+        builder.assert_zero(def_pvs.node_idx);
 
         self.def_acc_paths_bus.send(
             builder,

--- a/crates/continuations/src/prover/inner/trace.rs
+++ b/crates/continuations/src/prover/inner/trace.rs
@@ -61,12 +61,11 @@ where
                 device_ctx,
             );
 
-        let range_check_inputs = vec![];
         let power_check_inputs = vec![];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &pre_data.poseidon2_compress_inputs,
             poseidon2_permute_inputs: &pre_data.poseidon2_permute_inputs,
-            range_check_inputs: &range_check_inputs,
+            range_check_inputs: &pre_data.range_check_inputs,
             power_check_inputs: &power_check_inputs,
             required_heights: None,
             final_transcript_state: None,

--- a/crates/continuations/src/tests/dummy.rs
+++ b/crates/continuations/src/tests/dummy.rs
@@ -21,11 +21,13 @@ pub(in crate::tests) fn generate_dummy_def_proof(
     pk: &MultiStarkProvingKey<SC>,
     input_commit: [F; DIGEST_SIZE],
     output_commit: [F; DIGEST_SIZE],
+    def_idx: usize,
 ) -> Proof<SC> {
     let mut pvs = vec![F::ZERO; DeferralCircuitPvs::<u8>::width()];
     let pvs_ref: &mut DeferralCircuitPvs<F> = pvs.as_mut_slice().borrow_mut();
     pvs_ref.input_commit = input_commit;
     pvs_ref.output_commit = output_commit;
+    pvs_ref.def_idx = F::from_usize(def_idx);
 
     let trace = RowMajorMatrix::new(vec![F::ZERO], 1);
     let ctx = ProvingContext {
@@ -52,6 +54,7 @@ pub(in crate::tests) fn generate_single_dummy_def_proof(
         &pk,
         [F::ONE; DIGEST_SIZE],
         [F::from_u8(2); DIGEST_SIZE],
+        0,
     );
     Ok((Arc::new(vk), proof))
 }

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -234,6 +234,7 @@ fn make_absent_trace_pvs(
     initial_acc_hash: [F; DIGEST_SIZE],
     final_acc_hash: [F; DIGEST_SIZE],
     depth: F,
+    node_idx: F,
     is_right: bool,
 ) -> (DeferralPvs<F>, bool) {
     (
@@ -241,6 +242,7 @@ fn make_absent_trace_pvs(
             initial_acc_hash,
             final_acc_hash,
             depth,
+            node_idx,
         },
         is_right,
     )
@@ -612,6 +614,7 @@ fn test_deferral_e2e() -> Result<()> {
             idx0_untouched_root,
             idx0_untouched_root,
             hook1_pvs.depth,
+            F::ZERO,
             true,
         )),
     )?;
@@ -624,6 +627,7 @@ fn test_deferral_e2e() -> Result<()> {
             zero_depth1_root,
             zero_depth1_root,
             hook2_pvs.depth,
+            F::from_u32(3),
             false,
         )),
     )?;

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -427,11 +427,11 @@ fn test_deferral_e2e() -> Result<()> {
     warn!("generating dummy deferral circuit proofs");
     let idx1_proofs: Vec<Proof<SC>> = idx1_io
         .iter()
-        .map(|(inp, _, out)| generate_dummy_def_proof(&cpu_engine, &def_pk, *inp, *out))
+        .map(|(inp, _, out)| generate_dummy_def_proof(&cpu_engine, &def_pk, *inp, *out, 1))
         .collect();
     let idx2_proofs: Vec<Proof<SC>> = idx2_io
         .iter()
-        .map(|(inp, _, out)| generate_dummy_def_proof(&cpu_engine, &def_pk, *inp, *out))
+        .map(|(inp, _, out)| generate_dummy_def_proof(&cpu_engine, &def_pk, *inp, *out, 2))
         .collect();
 
     let idx1_io = idx1_io.into_iter().map(|(_, x, y)| (x, y)).collect_vec();

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -422,6 +422,7 @@ fn reduce_def_round<const N: usize>(
                             )
                             .0,
                             depth: pvs0.depth + F::ONE,
+                            node_idx: pvs0.node_idx.halve(),
                         })
                     }
                 };

--- a/crates/sdk/src/prover/deferral/mod.rs
+++ b/crates/sdk/src/prover/deferral/mod.rs
@@ -150,10 +150,10 @@ impl DeferralProver {
         per_circuit
             .into_iter()
             .enumerate()
-            .map(|(circuit_idx, res)| {
+            .map(|(def_idx, res)| {
                 let mut proofs = res.internal_for_leaf_proofs;
                 if proofs.is_empty() {
-                    let def_circuit_commit = self.single_circuit_provers[circuit_idx]
+                    let def_circuit_commit = self.single_circuit_provers[def_idx]
                         .circuit_commit(self.internal_recursive_prover.get_vk_commit(false));
                     let input_acc_hash = poseidon2_hash_slice(&def_circuit_commit).0;
                     let output_acc_hash = poseidon2_hash_slice(&[F::ZERO]).0;
@@ -162,6 +162,7 @@ impl DeferralProver {
                         initial_acc_hash: combined_hash,
                         final_acc_hash: combined_hash,
                         depth: F::ONE,
+                        node_idx: F::from_usize(def_idx),
                     }))
                 } else {
                     let mut merkle_depth = 2usize;
@@ -183,7 +184,7 @@ impl DeferralProver {
                         proofs = info_span!(
                             "agg_layer",
                             group = format!("internal_recursive.{layer}"),
-                            circuit = circuit_idx
+                            circuit = def_idx
                         )
                         .in_scope(|| {
                             proofs

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -79,4 +79,6 @@ pub enum VerifyStarkError {
     DefFinalAccHashCommitSet { actual: Digest },
     #[error("Proof has deferral_flag=0 but depth is set, actual {actual:?}")]
     DefDepthSet { actual: F },
+    #[error("Proof has unsupported deferral node_idx {actual:?}, should be 0")]
+    DefNodeIdxNonZero { actual: F },
 }

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -284,6 +284,7 @@ pub fn verify_vm_stark_proof_pvs(
             initial_acc_hash,
             final_acc_hash,
             depth,
+            node_idx,
         } = proof.inner.public_values[DEF_PVS_AIR_ID]
             .as_slice()
             .borrow();
@@ -313,6 +314,10 @@ pub fn verify_vm_stark_proof_pvs(
             }
         } else {
             return Err(VerifyStarkError::InvalidDeferralFlag(deferral_flag));
+        }
+
+        if node_idx != F::ZERO {
+            return Err(VerifyStarkError::DefNodeIdxNonZero { actual: node_idx });
         }
 
         let deferral_merkle_proofs = proof

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -109,4 +109,6 @@ pub struct DeferralPvs<F> {
     pub final_acc_hash: [F; DIGEST_SIZE],
     /// Depth of the Merkle subtrees above.
     pub depth: F,
+    /// Node index at the current depth of the Merkle memory tree.
+    pub node_idx: F,
 }

--- a/extensions/deferral/guest/src/lib.rs
+++ b/extensions/deferral/guest/src/lib.rs
@@ -12,9 +12,10 @@ pub const DEFERRAL_FUNCT3: u8 = 0b111;
 /// Low bits in immediate used to pick deferral sub-opcode
 pub const DEFERRAL_OPCODE_BITS: u32 = 2;
 
-/// Maximum number of deferral circuits, as each deferral instruction stores its
-/// deferral idx in the most significant 10 bits of the immediate field
-pub const MAX_DEF_CIRCUITS: u16 = 1024;
+/// Maximum number of deferral circuits, as constrained in the deferrals part of the
+/// continuations framework. Note that each deferral instruction stores its deferral
+/// idx in the most significant 10 bits of the immediate field.
+pub const MAX_DEF_CIRCUITS: u16 = 512;
 
 /// Number of bytes in a commit, used as identifiers for raw deferral inputs/outputs
 pub const COMMIT_NUM_BYTES: usize = 32;

--- a/guest-libs/verify-stark/circuit/src/lib.rs
+++ b/guest-libs/verify-stark/circuit/src/lib.rs
@@ -81,6 +81,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             def_merkle_roots_bus: memory_merkle_roots_bus,
             expected_internal_recursive_vk_commit: self.internal_recursive_vk_commit,
             expected_def_hook_commit: self.def_hook_commit,
+            def_idx: self.def_idx,
         };
         let user_pvs_commit_air = UserPvsCommitValuesAir::new(
             bus_inventory.poseidon2_compress_bus,

--- a/guest-libs/verify-stark/circuit/src/prover/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/trace.rs
@@ -91,6 +91,7 @@ where
             verifier_pvs_record,
             final_transcript_state,
             output_commit,
+            self.circuit.def_idx,
             device_ctx,
         );
 

--- a/guest-libs/verify-stark/circuit/src/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/trace.rs
@@ -60,6 +60,7 @@ pub trait DeferredVerifyTraceGen<PB: ProverBackend, DC: Clone + Send + Sync> {
         record: DeferredVerifyPvsRecord<PB::Val>,
         final_transcript_state: [PB::Val; POSEIDON2_WIDTH],
         output_commit: [PB::Val; DIGEST_SIZE],
+        def_idx: usize,
         device_ctx: &DC,
     ) -> AirProvingContext<PB>;
 }
@@ -151,6 +152,7 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>, ()> for DeferredVerifyTraceGenImpl {
         record: DeferredVerifyPvsRecord<F>,
         final_transcript_state: [F; POSEIDON2_WIDTH],
         output_commit: [F; DIGEST_SIZE],
+        def_idx: usize,
         _device_ctx: &(),
     ) -> AirProvingContext<CpuBackend<SC>> {
         super::verifier::generate_proving_ctx(
@@ -158,6 +160,7 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>, ()> for DeferredVerifyTraceGenImpl {
             record,
             final_transcript_state,
             output_commit,
+            def_idx,
             self.deferral_enabled,
         )
     }
@@ -217,6 +220,7 @@ impl DeferredVerifyTraceGen<GpuBackend, GpuDeviceCtx> for DeferredVerifyTraceGen
         record: DeferredVerifyPvsRecord<F>,
         final_transcript_state: [F; POSEIDON2_WIDTH],
         output_commit: [F; DIGEST_SIZE],
+        def_idx: usize,
         device_ctx: &GpuDeviceCtx,
     ) -> AirProvingContext<GpuBackend> {
         cpu_proving_ctx_to_gpu(
@@ -225,6 +229,7 @@ impl DeferredVerifyTraceGen<GpuBackend, GpuDeviceCtx> for DeferredVerifyTraceGen
                 record,
                 final_transcript_state,
                 output_commit,
+                def_idx,
                 self.deferral_enabled,
             ),
             device_ctx,

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -470,13 +470,15 @@ impl DeferredVerifyPvsAir {
          * If deferral_flag is 2, there must be a Merkle path from initial_acc_hash to
          * initial_root and from final_acc_hash to final_root. Else, we constrain that
          * they are 0, that def_hook_commit is unset, and that the deferral address
-         * space remained unchanged.
+         * space remained unchanged. Either way, node_idx must be 0.
          */
         let mut when_no_deferral = builder.when_ne(verifier_pvs.deferral_flag, AB::Expr::TWO);
         when_no_deferral.assert_zero(def_pvs.depth);
         assert_zeros(&mut when_no_deferral, def_pvs.initial_acc_hash);
         assert_zeros(&mut when_no_deferral, def_pvs.final_acc_hash);
         assert_zeros(&mut when_no_deferral, verifier_pvs.def_hook_commit);
+
+        builder.assert_zero(def_pvs.node_idx);
 
         self.def_acc_paths_bus.send(
             builder,

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -82,6 +82,8 @@ pub struct DeferredVerifyPvsAir {
 
     pub expected_internal_recursive_vk_commit: VkCommitBytes,
     pub expected_def_hook_commit: Option<CommitBytes>,
+
+    pub def_idx: usize,
 }
 
 impl<F> BaseAir<F> for DeferredVerifyPvsAir {
@@ -328,12 +330,16 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * compression of the final verifier sub-circuit transcript state, and output_commit
          * should be the Poseidon2 sponge hash of the byte representations of app_exe_commit,
          * app_vm_commit, and the user public values. The latter is constrained by the
-         * DeferralOutputCommitAir, to which we need to send the app commits.
+         * DeferralOutputCommitAir, to which we need to send the app commits. def_idx must be
+         * constrained against a constant.
          */
         let &DeferralCircuitPvs::<_> {
             input_commit,
             output_commit,
+            def_idx,
         } = builder.public_values().borrow();
+
+        builder.assert_eq(def_idx, AB::Expr::from_usize(self.def_idx));
 
         self.final_state_bus.receive(
             builder,

--- a/guest-libs/verify-stark/circuit/src/verifier/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/trace.rs
@@ -112,6 +112,7 @@ pub fn generate_proving_ctx(
     record: DeferredVerifyPvsRecord<F>,
     final_transcript_state: [F; POSEIDON2_WIDTH],
     output_commit: [F; DIGEST_SIZE],
+    def_idx: usize,
     deferral_enabled: bool,
 ) -> AirProvingContext<CpuBackend<BabyBearPoseidon2Config>> {
     let base_width = DeferredVerifyPvsCols::<u8>::width();
@@ -155,6 +156,7 @@ pub fn generate_proving_ctx(
     let (left, right) = poseidon2_input_to_digests(final_transcript_state);
     deferral_pvs.input_commit = poseidon2_compress_with_capacity(left, right).0;
     deferral_pvs.output_commit = output_commit;
+    deferral_pvs.def_idx = F::from_usize(def_idx);
 
     AirProvingContext {
         cached_mains: vec![],


### PR DESCRIPTION
Resolves INT-8115.

## Overview

This PR makes each deferral proof carry and prove its canonical position in the deferral memory subtree.

The first commit adds `def_idx` public values to the deferral-circuit aggregation tree and constrains them to stay consistent while proofs for the same deferral circuit are aggregated. The second commit adds `node_idx` to the main recursive deferral public values, derives it from `def_idx` at the hook layer, updates it during main deferral aggregation, and requires the final/root deferral proof to be at `node_idx = 0`.

The effective supported deferral circuit index range is now `0..512`.

## Continuations: deferral aggregation PVS

Files:

- `crates/continuations/src/circuit/deferral/mod.rs`
- `crates/continuations/src/circuit/deferral/inner/def_pvs/{air,trace}.rs`

### Public values

`DeferralCircuitPvs` now includes:

```rust
pub def_idx: F
```

`DeferralAggregationPvs` now includes:

```rust
pub def_idx: F
```

This index identifies which deferral circuit the subtree belongs to.

### `DeferralAggPvsAir`

The AIR now receives each child's `def_idx` from `PublicValuesBus`:

```text
leaf child:
  DeferralCircuitPvs.air[DEF_CIRCUIT_PVS_AIR_ID]
    pv[2 * DIGEST_SIZE] = child def_idx

internal child:
  DeferralAggregationPvs.air[DEF_AGG_PVS_AIR_ID]
    pv[DIGEST_SIZE + 2] = child def_idx
```

It constrains every present row's child `def_idx` to equal the produced aggregation `def_idx`:

```text
present child def_idx == parent DeferralAggregationPvs.def_idx
```

Example rows:

| case | row | `is_present` | `has_verifier_pvs` | child source | child `def_idx` | output `def_idx` |
|---|---:|---:|---:|---|---:|---:|
| leaf wrapper | 0 | 1 | 0 | `DeferralCircuitPvs` | `k` | `k` |
| two leaf proofs | 0 | 1 | 0 | `DeferralCircuitPvs` | `k` | `k` |
| two leaf proofs | 1 | 1 | 0 | `DeferralCircuitPvs` | `k` | `k` |
| leaf + padding | 0 | 1 | 0 | `DeferralCircuitPvs` | `k` | `k` |
| leaf + padding | 1 | 0 | 0 | padding | unconstrained | `k` |
| internal wrapper | 0 | 1 | 1 | `DeferralAggregationPvs` | `k` | `k` |

Bus diagram:

```text
DeferralCircuit proof PVS
  └─ PublicValuesBus: input_commit, output_commit, def_idx
       └─ DeferralAggPvsAir

DeferralAggregation proof PVS
  └─ PublicValuesBus: merkle_commit, num proofs, merkle_depth, def_idx
       └─ DeferralAggPvsAir

DeferralAggPvsAir
  └─ public values: merkle_commit, num_def_circuit_proofs, merkle_depth, def_idx
```

## Verify-stark deferral circuit

Files:

- `guest-libs/verify-stark/circuit/src/{lib,trace}.rs`
- `guest-libs/verify-stark/circuit/src/verifier/{air,trace}.rs`
- `guest-libs/verify-stark/circuit/src/prover/trace.rs`

The deferred verify circuit now stores a configured `def_idx`. `DeferredVerifyPvsAir` constrains:

```text
DeferralCircuitPvs.def_idx == configured def_idx
```

The trace generator writes that same constant into `DeferralCircuitPvs`.

This is the base constraint that prevents a deferral proof from claiming another circuit index before entering the deferral aggregation tree.

## Continuations: main deferral PVS `node_idx`

Files:

- `crates/verify/src/pvs.rs`
- `crates/continuations/src/circuit/deferral/hook/verifier/{air,trace}.rs`
- `crates/continuations/src/circuit/inner/def_pvs/{air,trace}.rs`
- `crates/continuations/src/circuit/inner/{mod,trace}.rs`
- `crates/continuations/src/prover/inner/trace.rs`
- `crates/continuations/src/circuit/mod.rs`

### Public values

`DeferralPvs` now includes:

```rust
pub node_idx: F
```

This is the node index of the deferral accumulator subtree at the current `depth`.

### Hook layer

`DeferralHookPvsAir` constrains:

```text
depth == 1
node_idx == DeferralAggregationPvs.def_idx
```

So each hook proof starts as the depth-1 subtree for its deferral circuit index.

### Main inner `DeferralPvsAir`

The AIR now constrains how `node_idx` behaves while deferral hook proofs are recursively aggregated.

One-row case:

```text
parent PVS == child PVS
node_idx == 0
```

This means one-row wrapping is only valid once the subtree is already rooted at index 0.

Two-row case:

```text
child depths are equal
parent depth = child depth + 1
if both children are present:
  right_child.node_idx = left_child.node_idx + 1
parent.node_idx = (local_child.node_idx - single_present_is_right) / 2
range_check(parent.node_idx, 8 bits)
```

Example rows:

| case | row | `is_present` | `single_present_is_right` | child `node_idx` | parent `node_idx` |
|---|---:|---:|---:|---:|---:|
| root wrapper | 0 | 1 | 0 | 0 | 0 |
| left + right present | 0 | 1 | 0 | 2n | n |
| left + right present | 1 | 1 | 0 | 2n + 1 | n |
| present left, absent right | 0 | 1 | 0 | 2n | n |
| present left, absent right | 1 | 0 | 0 | unconstrained hash subtree | n |
| absent left, present right | 0 | 1 | 1 | 2n + 1 | n |
| absent left, present right | 1 | 0 | 1 | absent subtree | n |

Range-check bus interaction:

```text
DeferralPvsAir
  └─ RangeCheckerBus: value = parent node_idx, max_bits = 8
       └─ VerifierSubCircuit range checker trace
```

The trace plumbing now carries these range-check inputs through `SubCircuitTraceData` into `VerifierExternalData`.

## Root and host verification

Files:

- `crates/continuations/src/circuit/root/verifier/air.rs`
- `guest-libs/verify-stark/circuit/src/verifier/air.rs`
- `crates/verify/src/{lib,error}.rs`

Both root verifier AIRs now require:

```text
final DeferralPvs.node_idx == 0
```

The host verifier also rejects final proofs with nonzero `node_idx`:

```rust
VerifyStarkError::DefNodeIdxNonZero { actual }
```

This matches the current deferral Merkle path logic, which verifies a deferral accumulator subtree rooted at the canonical leftmost position for `(DEFERRAL_AS, 0)`.

## SDK and guest limits

Files:

- `crates/sdk/src/prover/deferral/mod.rs`
- `crates/sdk/src/prover/agg.rs`
- `extensions/deferral/guest/src/lib.rs`

The SDK now initializes absent per-circuit deferral PVS with:

```text
node_idx = def_idx
depth = 1
```

When two absent subtrees are combined, it updates:

```text
parent.node_idx = left.node_idx / 2
```

The guest/transpiler-visible maximum deferral circuit count is reduced:

```text
MAX_DEF_CIRCUITS: 1024 -> 512
```

This matches the main deferral aggregation range check: parent `node_idx` is 8-bit, so depth-1 child `def_idx` must be below 512.

## Review checklist

- Check that `def_idx` is constrained at every deferral circuit source, especially custom implementations of `DeferralCircuitProver`.
- Check that `DeferralAggPvsAir` only aggregates proofs with the same `def_idx`.
- Check that `DeferralHookPvsAir` correctly maps `def_idx` into depth-1 `node_idx`.
- Check that `DeferralPvsAir` enforces canonical parent indices and rejects non-root one-row wrapping.
- Check that the range-check lookup for parent `node_idx` is backed by trace inputs in both CPU and CUDA trace paths.
- Check that root and host verification consistently require final `node_idx == 0`.