### PR TITLE
feat(v2-rc.2): emit segmentation trigger metric

### DIFF
--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -45,7 +45,7 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvcc --version
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
           echo "NEXTEST_ARGS=cuda --features parallel,cuda,touchemall --test-threads=1" >> $GITHUB_ENV
 
       - name: Run tests for primitives

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -40,7 +40,7 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvcc --version
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
 
       - name: Setup CUDA environment
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g4dn+g6e/cpu=32/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=32/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -40,7 +40,7 @@ jobs:
         run: |
           nvidia-smi
           nvidia-smi -L
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
 
       - name: Cargo check
         run: cargo check

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -106,7 +106,7 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvcc --version
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
           echo "NEXTEST_ENV=CUDA_OPT_LEVEL=3" >> $GITHUB_ENV
           echo "FEATURE_ARGS=--features=cuda" >> $GITHUB_ENV
           echo "VPMM_PAGES=1" >> $GITHUB_ENV

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -117,7 +117,7 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvcc --version
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
           echo "NEXTEST_ENV=CUDA_OPT_LEVEL=3" >> $GITHUB_ENV
           echo "FEATURE_ARGS=--features=cuda" >> $GITHUB_ENV
 

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -111,7 +111,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.cuda == 'true' }}
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g6.*+g5+g4dn+g6e/cpu=8/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=8/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -128,7 +128,7 @@ jobs:
         run: |
           nvidia-smi
           nvidia-smi -L
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
       - name: Run clippy
         run: |
           # includes GPU specific features cuda and touchemall

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -39,7 +39,7 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvcc --version
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
 
       - name: Setup CUDA environment
         run: |

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -74,7 +74,7 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvcc --version
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
           echo "VPMM_PAGES=1" >> $GITHUB_ENV
 
       - name: Download and install risc64-elf-gcc

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -41,7 +41,7 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvcc --version
-          echo "CUDA_ARCH=75,86,89,120" >> $GITHUB_ENV
+          echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
 
       - name: Setup CUDA environment
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e9be8164882b54f311c56a004756ff6ab5e49b82"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -5921,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e9be8164882b54f311c56a004756ff6ab5e49b82"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e9be8164882b54f311c56a004756ff6ab5e49b82"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e9be8164882b54f311c56a004756ff6ab5e49b82"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
 dependencies = [
  "cc",
  "glob",
@@ -5982,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e9be8164882b54f311c56a004756ff6ab5e49b82"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6774,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e9be8164882b54f311c56a004756ff6ab5e49b82"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -6809,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#e9be8164882b54f311c56a004756ff6ab5e49b82"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#036657f96eec879b2d7c30875e059137828b34ad"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -93,6 +93,25 @@ pub struct SegmentationCtx {
     checkpoint_instret: u64,
 }
 
+#[cfg_attr(not(feature = "metrics"), allow(dead_code))]
+#[derive(Clone, Copy, Debug)]
+enum SegmentationTrigger {
+    Height { air_id: usize },
+    Memory,
+    Interactions,
+}
+
+#[cfg(feature = "metrics")]
+impl SegmentationTrigger {
+    fn reason(self) -> &'static str {
+        match self {
+            SegmentationTrigger::Height { .. } => "height",
+            SegmentationTrigger::Memory => "memory",
+            SegmentationTrigger::Interactions => "interactions",
+        }
+    }
+}
+
 #[cfg(feature = "metrics")]
 #[derive(Default)]
 struct MeteredCounts {
@@ -320,6 +339,17 @@ impl SegmentationCtx {
         trace_heights: &[u32],
         is_trace_height_constant: &[bool],
     ) -> bool {
+        self.segmentation_trigger(instret, trace_heights, is_trace_height_constant)
+            .is_some()
+    }
+
+    #[inline(always)]
+    fn segmentation_trigger(
+        &self,
+        instret: u64,
+        trace_heights: &[u32],
+        is_trace_height_constant: &[bool],
+    ) -> Option<SegmentationTrigger> {
         debug_assert_eq!(trace_heights.len(), is_trace_height_constant.len());
         debug_assert_eq!(trace_heights.len(), self.air_names.len());
         debug_assert_eq!(trace_heights.len(), self.widths.len());
@@ -334,7 +364,7 @@ impl SegmentationCtx {
 
         // Segment should contain at least one cycle
         if num_insns == 0 {
-            return false;
+            return None;
         }
 
         let mut main_cnt_with_rot = 0usize;
@@ -361,7 +391,7 @@ impl SegmentationCtx {
                     i,
                     air_name,
                 );
-                return true;
+                return Some(SegmentationTrigger::Height { air_id: i });
             }
             let main_cells = padded_height as usize * width;
             if need_rot {
@@ -383,7 +413,7 @@ impl SegmentationCtx {
                 ByteSize::b(main_memory as u64),
                 ByteSize::b(interaction_memory as u64),
             );
-            return true;
+            return Some(SegmentationTrigger::Memory);
         }
 
         let total_interactions = self.calculate_total_interactions(trace_heights);
@@ -394,10 +424,10 @@ impl SegmentationCtx {
                 total_interactions,
                 self.limits.max_interactions
             );
-            return true;
+            return Some(SegmentationTrigger::Interactions);
         }
 
-        false
+        None
     }
 
     #[inline(always)]
@@ -407,12 +437,18 @@ impl SegmentationCtx {
         trace_heights: &mut [u32],
         is_trace_height_constant: &[bool],
     ) -> bool {
-        let should_seg = self.should_segment(instret, trace_heights, is_trace_height_constant);
-
-        if should_seg {
+        if let Some(trigger) =
+            self.segmentation_trigger(instret, trace_heights, is_trace_height_constant)
+        {
+            #[cfg(feature = "metrics")]
+            self.emit_segmentation_trigger_metric(trigger);
+            #[cfg(not(feature = "metrics"))]
+            let _ = trigger;
             self.create_segment_from_checkpoint(instret, trace_heights);
+            true
+        } else {
+            false
         }
-        should_seg
     }
 
     #[inline(always)]
@@ -585,6 +621,26 @@ impl SegmentationCtx {
 
 #[cfg(feature = "metrics")]
 impl SegmentationCtx {
+    fn emit_segmentation_trigger_metric(&self, trigger: SegmentationTrigger) {
+        let segment = self.segments.len().to_string();
+        let reason = trigger.reason();
+        match trigger {
+            SegmentationTrigger::Height { air_id } => {
+                let labels = [
+                    ("segment", segment),
+                    ("reason", reason.to_string()),
+                    ("air_id", air_id.to_string()),
+                    ("air_name", self.air_names[air_id].clone()),
+                ];
+                metrics::counter!("segmentation_trigger", &labels).absolute(1);
+            }
+            SegmentationTrigger::Memory | SegmentationTrigger::Interactions => {
+                let labels = [("segment", segment), ("reason", reason.to_string())];
+                metrics::counter!("segmentation_trigger", &labels).absolute(1);
+            }
+        }
+    }
+
     fn emit_metered_segment_metrics(&self, segment: &str, trace_heights: &[u32]) {
         let counts = self.calculate_count_breakdown(trace_heights);
         let memory = self.calculate_memory_breakdown(&counts);

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -437,13 +437,15 @@ impl SegmentationCtx {
         trace_heights: &mut [u32],
         is_trace_height_constant: &[bool],
     ) -> bool {
-        if let Some(trigger) =
-            self.segmentation_trigger(instret, trace_heights, is_trace_height_constant)
-        {
-            #[cfg(feature = "metrics")]
+        let trigger = self.segmentation_trigger(instret, trace_heights, is_trace_height_constant);
+        let should_segment = trigger.is_some();
+
+        #[cfg(feature = "metrics")]
+        if let Some(trigger) = trigger {
             self.emit_segmentation_trigger_metric(trigger);
-            #[cfg(not(feature = "metrics"))]
-            let _ = trigger;
+        }
+
+        if should_segment {
             self.create_segment_from_checkpoint(instret, trace_heights);
             true
         } else {


### PR DESCRIPTION
## Summary

- Emit a `segmentation_trigger` metric when metered execution creates a segment, labeled by trigger reason.
- Include AIR id/name labels for height-triggered segmentation so the metric identifies the chip that crossed the trace-height limit.
- Drop `g4dn`/SM75 CUDA CI coverage from this branch now that G4dn is no longer a supported runner family.

## Validation

- Parsed all workflow YAML files locally.
- Checked `.github` for remaining `g4dn` references and `CUDA_ARCH` values containing `75`; none remain.
- Rust tests were not run locally for this metadata/CI cleanup pass.
