### PR TITLE
fix(v2-rc.2/ci): speed up docs check, re-enable cargo shear

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -89,18 +89,41 @@ jobs:
           done
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@main
-      # TODO: re-enable cargo shear after fixing unused deps
-      # - name: Cargo shear
-      #   run: |
-      #     cargo binstall --no-confirm --force cargo-shear --version 1.1.9
-      #     cargo shear
+      - name: Cargo shear
+        run: |
+          cargo binstall --no-confirm --force cargo-shear --version 1.1.11
+          cargo shear
       - name: Cargo audit
         run: |
           cargo binstall --no-confirm --force cargo-audit
           cargo audit
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  docs:
+    name: Check Docs
+    runs-on:
+      - runs-on=${{ github.run_id }}-docs/runner=32cpu-linux-x64/extras=s3-cache
+    steps:
+      - uses: runs-on/action@v2
+        with:
+          sccache: s3
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: v1
+
       - name: Generate docs
+        # full docs with dependencies are built by docs.yml on main/tags
         run: |
-          cargo doc --workspace  --exclude "openvm-benchmarks" --exclude "*-tests" --exclude "*-test"
+          cargo doc --workspace --no-deps --exclude "openvm-benchmarks*" --exclude "*-tests"
+        env:
+          RUSTDOCFLAGS: -D warnings
 
       - name: sccache stats
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,7 +2014,6 @@ dependencies = [
  "p3-bn254",
  "serde",
  "serde_json",
- "static_assertions",
  "target-lexicon",
  "tempfile",
  "tokio",
@@ -3089,39 +3088,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "log",
 ]
 
 [[package]]
@@ -5656,8 +5622,6 @@ dependencies = [
 name = "openvm-benchmarks-execute"
 version = "2.0.0-beta.2"
 dependencies = [
- "bitcode",
- "clap",
  "codspeed-divan-compat",
  "derive_more 1.0.0",
  "eyre",
@@ -5682,8 +5646,6 @@ dependencies = [
  "openvm-transpiler",
  "rand 0.9.2",
  "serde",
- "tracing",
- "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -5791,10 +5753,8 @@ dependencies = [
  "bytesize",
  "cfg-if",
  "dashmap",
- "derivative",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "enum_dispatch",
  "eyre",
  "getset",
  "itertools 0.14.0",
@@ -5812,7 +5772,6 @@ dependencies = [
  "openvm-cuda-common",
  "openvm-instructions",
  "openvm-poseidon2-air",
- "openvm-rv32im-transpiler",
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "p3-baby-bear",
@@ -5824,7 +5783,6 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "test-case",
- "test-log",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -5895,11 +5853,9 @@ dependencies = [
  "openvm-circuit-primitives",
  "openvm-cpu-backend",
  "openvm-cuda-backend",
- "openvm-cuda-builder",
  "openvm-cuda-common",
  "openvm-deferral-circuit",
  "openvm-deferral-transpiler",
- "openvm-instructions",
  "openvm-poseidon2-air",
  "openvm-recursion-circuit",
  "openvm-recursion-circuit-derive",
@@ -5907,7 +5863,6 @@ dependencies = [
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "openvm-toolchain-tests",
  "openvm-transpiler",
  "openvm-verify-stark-host",
  "p3-air",
@@ -6010,7 +5965,6 @@ dependencies = [
  "dashmap",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "eyre",
  "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-derive",
@@ -6024,18 +5978,12 @@ dependencies = [
  "openvm-instructions",
  "openvm-poseidon2-air",
  "openvm-rv32im-circuit",
- "openvm-rv32im-transpiler",
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "p3-field",
- "p3-symmetric",
  "rand 0.9.2",
  "rustc-hash 2.1.1",
  "serde",
- "static_assertions",
- "strum 0.26.3",
- "test-case",
- "test-log",
 ]
 
 [[package]]
@@ -6050,11 +5998,9 @@ dependencies = [
 name = "openvm-deferral-integration-tests"
 version = "2.0.0-beta.2"
 dependencies = [
- "derive_more 1.0.0",
  "eyre",
  "itertools 0.14.0",
  "openvm-circuit",
- "openvm-circuit-derive",
  "openvm-deferral-circuit",
  "openvm-deferral-transpiler",
  "openvm-instructions",
@@ -6063,7 +6009,6 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-toolchain-tests",
  "openvm-transpiler",
- "serde",
 ]
 
 [[package]]
@@ -6153,7 +6098,6 @@ dependencies = [
  "openvm-transpiler",
  "serde",
  "serde_with",
- "toml 0.8.23",
 ]
 
 [[package]]
@@ -6477,7 +6421,6 @@ name = "openvm-recursion-circuit"
 version = "2.0.0-beta.2"
 dependencies = [
  "derive-new 0.6.0",
- "eyre",
  "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-primitives",
@@ -6558,7 +6501,6 @@ name = "openvm-rv32im-guest"
 version = "2.0.0-beta.2"
 dependencies = [
  "openvm-custom-insn",
- "p3-field",
  "strum_macros 0.26.4",
 ]
 
@@ -6615,7 +6557,6 @@ version = "2.0.0-beta.2"
 dependencies = [
  "alloy-sol-types",
  "bitcode",
- "bon",
  "cfg-if",
  "clap",
  "derivative",
@@ -6628,7 +6569,6 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "metrics",
- "num-bigint 0.4.6",
  "openvm",
  "openvm-build",
  "openvm-circuit",
@@ -6640,18 +6580,14 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "openvm-static-verifier",
- "openvm-toolchain-tests",
  "openvm-transpiler",
  "openvm-verify-stark-circuit",
  "openvm-verify-stark-host",
- "p3-bn254",
  "serde",
  "serde_json",
  "serde_with",
  "tempfile",
  "thiserror 1.0.69",
- "tokio",
- "toml 0.8.23",
  "tracing",
 ]
 
@@ -6662,7 +6598,6 @@ dependencies = [
  "bon",
  "cfg-if",
  "derive_more 1.0.0",
- "openvm",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
  "openvm-bigint-circuit",
@@ -6695,7 +6630,6 @@ version = "2.0.0-beta.2"
 dependencies = [
  "eyre",
  "hex",
- "openvm",
  "openvm-circuit",
  "openvm-instructions",
  "openvm-rv32im-transpiler",
@@ -6847,7 +6781,6 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
  "once_cell",
- "openvm-circuit-primitives-derive",
  "openvm-continuations",
  "openvm-cpu-backend",
  "openvm-cuda-backend",
@@ -6915,7 +6848,6 @@ dependencies = [
  "openvm-continuations",
  "openvm-cpu-backend",
  "openvm-cuda-backend",
- "openvm-cuda-builder",
  "openvm-cuda-common",
  "openvm-deferral-circuit",
  "openvm-poseidon2-air",
@@ -6928,7 +6860,6 @@ dependencies = [
  "openvm-transpiler",
  "openvm-verify-stark-host",
  "p3-air",
- "p3-bn254",
  "p3-field",
  "p3-matrix",
  "test-case",
@@ -9943,28 +9874,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
  "test-case-core",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
-dependencies = [
- "env_logger",
- "test-log-macros",
- "tracing-subscriber 0.3.20",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,6 @@ lto = "thin"
 [workspace.dependencies]
 # Stark Backend
 openvm-stark-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
-openvm-codec-derive = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
 openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
 openvm-cpu-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
 openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git", branch = "develop-v2", default-features = false }
@@ -177,7 +176,6 @@ openvm-pairing-circuit = { path = "extensions/pairing/circuit", default-features
 openvm-pairing-transpiler = { path = "extensions/pairing/transpiler", default-features = false }
 openvm-pairing-guest = { path = "extensions/pairing/guest", default-features = false }
 openvm-verify-stark-circuit = { path = "guest-libs/verify-stark/circuit", default-features = false }
-openvm-verify-stark-guest = { path = "guest-libs/verify-stark/guest", default-features = false }
 openvm-deferral-circuit = { path = "extensions/deferral/circuit", default-features = false }
 openvm-deferral-guest = { path = "extensions/deferral/guest", default-features = false }
 openvm-deferral-transpiler = { path = "extensions/deferral/transpiler", default-features = false }
@@ -190,19 +188,15 @@ p3-air = { version = "=0.4.3", default-features = false }
 p3-field = { version = "=0.4.3", default-features = false }
 p3-baby-bear = { version = "=0.4.3", default-features = false }
 p3-bn254 = { version = "=0.4.3", default-features = false }
-p3-dft = { version = "=0.4.3", default-features = false }
-p3-fri = { version = "=0.4.3", default-features = false }
 p3-keccak-air = { version = "=0.4.3", default-features = false }
 p3-matrix = { version = "=0.4.3", default-features = false }
 p3-maybe-rayon = { version = "=0.4.3", default-features = false }
-p3-merkle-tree = { version = "=0.4.3", default-features = false }
 p3-poseidon2 = { version = "=0.4.3", default-features = false }
 p3-poseidon2-air = { version = "=0.4.3", default-features = false }
 p3-symmetric = { version = "=0.4.3", default-features = false }
 
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
 snark-verifier-sdk = { version = "0.2.0", default-features = false, features = ["loader_halo2", "halo2-axiom"] }
-snark-verifier = { version = "0.2.0", default-features = false }
 halo2-base = { version = "0.5.0", default-features = false }
 halo2curves-axiom = { git = "https://github.com/axiom-crypto/halo2curves.git", tag = "v0.7.2" }
 struct-reflection = "0.1.0"
@@ -226,8 +220,6 @@ backtrace = "0.3.71"
 metrics = "0.23.0"
 cfg-if = "1.0.0"
 test-case = "3.3.1"
-test-log = "0.2.16"
-enum_dispatch = "0.3.13"
 eyre = "0.6.12"
 tempfile = "3.13.0"
 thiserror = "1.0.65"
@@ -272,9 +264,6 @@ num-traits = { version = "0.2.19", default-features = false }
 ff = { version = "0.13.1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 blstrs = { version = "0.7.1", default-features = true }
-
-# specific to CUDA and GPU
-cuda-runtime-sys = "0.3.0-alpha.1"
 
 [workspace.metadata.cargo-shear]
 ignored = ["cargo-openvm"]

--- a/benchmarks/execute/Cargo.toml
+++ b/benchmarks/execute/Cargo.toml
@@ -8,38 +8,32 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-openvm-benchmarks-utils.workspace = true
-openvm-circuit.workspace = true
-openvm-stark-sdk.workspace = true
-openvm-transpiler.workspace = true
-openvm-algebra-circuit.workspace = true
-openvm-algebra-transpiler.workspace = true
-openvm-bigint-circuit.workspace = true
-openvm-bigint-transpiler.workspace = true
-openvm-ecc-circuit.workspace = true
-openvm-ecc-transpiler.workspace = true
-openvm-pairing-circuit.workspace = true
-openvm-pairing-guest.workspace = true
-openvm-pairing-transpiler.workspace = true
-openvm-keccak256-circuit.workspace = true
-openvm-keccak256-transpiler.workspace = true
-openvm-rv32im-circuit.workspace = true
-openvm-rv32im-transpiler.workspace = true
-openvm-sha2-circuit.workspace = true
-openvm-sha2-transpiler.workspace = true
-
-clap.workspace = true
-eyre.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 rand.workspace = true
-serde = { workspace = true, features = ["derive"] }
-bitcode.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
 
 [dev-dependencies]
 openvm-circuit = { workspace = true, features = ["test-utils"] }
 divan = { package = "codspeed-divan-compat", version = "3.0.2" }
+eyre.workspace = true
+openvm-algebra-circuit.workspace = true
+openvm-algebra-transpiler.workspace = true
+openvm-benchmarks-utils.workspace = true
+openvm-bigint-circuit.workspace = true
+openvm-bigint-transpiler.workspace = true
+openvm-ecc-circuit.workspace = true
+openvm-ecc-transpiler.workspace = true
+openvm-keccak256-circuit.workspace = true
+openvm-keccak256-transpiler.workspace = true
+openvm-pairing-circuit.workspace = true
+openvm-pairing-guest.workspace = true
+openvm-pairing-transpiler.workspace = true
+openvm-rv32im-circuit.workspace = true
+openvm-rv32im-transpiler.workspace = true
+openvm-sha2-circuit.workspace = true
+openvm-sha2-transpiler.workspace = true
+openvm-stark-sdk.workspace = true
+openvm-transpiler.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [features]
 default = ["jemalloc"]

--- a/crates/circuits/primitives/derive/src/lib.rs
+++ b/crates/circuits/primitives/derive/src/lib.rs
@@ -127,7 +127,7 @@ pub fn aligned_borrow_derive(input: TokenStream) -> TokenStream {
 }
 
 /// `S` is the type the derive macro is being called on
-/// Implements Borrow<S> and BorrowMut<S> for [u8]
+/// Implements `Borrow<S>` and `BorrowMut<S>` for `[u8]`
 /// [u8] has to have (checked via `debug_assert!`s)
 /// - at least size_of(S) length
 /// - at least align_of(S) alignment

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -30,9 +30,9 @@ mod tests;
 #[derive(AlignedBorrow, StructReflection, Copy, Clone)]
 #[repr(C)]
 pub struct BitwiseOperationLookupCols<T, const NUM_BITS: usize> {
-    /// Binary decomposition of x (x_bits[0] is LSB, x_bits[NUM_BITS-1] is MSB)
+    /// Binary decomposition of x (`x_bits[0]` is LSB, `x_bits[NUM_BITS-1]` is MSB)
     pub x_bits: [T; NUM_BITS],
-    /// Binary decomposition of y (y_bits[0] is LSB, y_bits[NUM_BITS-1] is MSB)
+    /// Binary decomposition of y (`y_bits[0]` is LSB, `y_bits[NUM_BITS-1]` is MSB)
     pub y_bits: [T; NUM_BITS],
     /// Number of range check operations requested for each (x, y) pair
     pub mult_range: T,

--- a/crates/circuits/sha2-air/src/config.rs
+++ b/crates/circuits/sha2-air/src/config.rs
@@ -42,7 +42,8 @@ pub trait Sha2BlockHasherSubairConfig: Send + Sync + Clone {
     const ROUNDS_PER_BLOCK: usize;
     /// Number of words in a SHA hash
     const HASH_WORDS: usize;
-    /// Number of vars needed to encode the row index with [Encoder]
+    /// Number of vars needed to encode the row index with
+    /// [`Encoder`](openvm_circuit_primitives::encoder::Encoder)
     const ROW_VAR_CNT: usize;
 
     /// We also store the SHA constants K and H
@@ -102,7 +103,8 @@ impl Sha2BlockHasherSubairConfig for Sha256Config {
     const ROUNDS_PER_BLOCK: usize = 64;
     /// Number of words in a SHA256 hash
     const HASH_WORDS: usize = 8;
-    /// Number of vars needed to encode the row index with [Encoder]
+    /// Number of vars needed to encode the row index with
+    /// [`Encoder`](openvm_circuit_primitives::encoder::Encoder)
     const ROW_VAR_CNT: usize = 5;
 
     fn get_k() -> &'static [u32] {
@@ -145,7 +147,8 @@ impl Sha2BlockHasherSubairConfig for Sha512Config {
     const ROUNDS_PER_BLOCK: usize = 80;
     /// Number of words in a SHA512 hash
     const HASH_WORDS: usize = 8;
-    /// Number of vars needed to encode the row index with [Encoder]
+    /// Number of vars needed to encode the row index with
+    /// [`Encoder`](openvm_circuit_primitives::encoder::Encoder)
     const ROW_VAR_CNT: usize = 6;
 
     fn get_k() -> &'static [u64] {
@@ -267,7 +270,8 @@ impl Sha2BlockHasherSubairConfig for Sha384Config {
     const ROUNDS_PER_BLOCK: usize = <Sha512Config as Sha2BlockHasherSubairConfig>::ROUNDS_PER_BLOCK;
     /// Number of words in a SHA384 hash
     const HASH_WORDS: usize = <Sha512Config as Sha2BlockHasherSubairConfig>::HASH_WORDS;
-    /// Number of vars needed to encode the row index with [Encoder]
+    /// Number of vars needed to encode the row index with
+    /// [`Encoder`](openvm_circuit_primitives::encoder::Encoder)
     const ROW_VAR_CNT: usize = <Sha512Config as Sha2BlockHasherSubairConfig>::ROW_VAR_CNT;
 
     fn get_k() -> &'static [u64] {

--- a/crates/circuits/sha2-air/src/utils.rs
+++ b/crates/circuits/sha2-air/src/utils.rs
@@ -271,7 +271,7 @@ pub fn get_flag_pt_array(encoder: &Encoder, flag_idx: usize) -> Vec<u32> {
     encoder.get_flag_pt(flag_idx)
 }
 
-/// Constrain the addition of [C::WORD_BITS] bit words in 16-bit limbs
+/// Constrain the addition of `C::WORD_BITS` bit words in 16-bit limbs
 /// It takes in the terms some in bits some in 16-bit limbs,
 /// the expected sum in bits and the carries
 pub fn constraint_word_addition<AB: AirBuilder, C: Sha2BlockHasherSubairConfig>(

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,12 +37,10 @@ serde.workspace = true
 serde_json.workspace = true
 hex = "0.4.3"
 target-lexicon = "0.12.15"
-tempfile = "3.10.1"
 toml = { workspace = true }
 itertools.workspace = true
 toml_edit = "0.22"
 include_dir = "0.7"
-static_assertions.workspace = true
 
 [features]
 default = ["parallel", "jemalloc", "evm-verify", "metrics"]
@@ -62,3 +60,6 @@ jemalloc = ["openvm-sdk/jemalloc"]
 jemalloc-prof = ["openvm-sdk/jemalloc-prof"]
 cuda = ["openvm-sdk/cuda"]
 ci = []
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/crates/continuations/Cargo.toml
+++ b/crates/continuations/Cargo.toml
@@ -35,13 +35,8 @@ openvm-rv32im-circuit = { workspace = true, features = ["test-utils"] }
 openvm-rv32im-transpiler = { workspace = true }
 openvm-deferral-circuit = { workspace = true }
 openvm-deferral-transpiler = { workspace = true }
-openvm-instructions = { workspace = true }
-openvm-toolchain-tests = { workspace = true }
 openvm-transpiler = { workspace = true }
 test-case = { workspace = true }
-
-[build-dependencies]
-openvm-cuda-builder = { workspace = true, optional = true }
 
 [features]
 default = ["parallel"]
@@ -54,7 +49,6 @@ parallel = ["openvm-circuit/parallel", "openvm-recursion-circuit/parallel"]
 metrics = ["openvm-circuit/metrics"]
 
 cuda = [
-    "dep:openvm-cuda-builder",
     "dep:openvm-cuda-common",
     "dep:openvm-cuda-backend",
     "openvm-circuit-primitives/cuda",

--- a/crates/continuations/src/circuit/subair/hash_slice/trace.rs
+++ b/crates/continuations/src/circuit/subair/hash_slice/trace.rs
@@ -3,7 +3,7 @@ use openvm_recursion_circuit::utils::poseidon2_hash_slice_with_states;
 use openvm_stark_sdk::config::baby_bear_poseidon2::{DIGEST_SIZE, F};
 
 /// Given N element digests, compute the N−1 intermediate full permutation states
-/// and the final digest, matching the layout of [`HashSliceCtx`].
+/// and the final digest, matching the layout of [`HashSliceCtx`](super::HashSliceCtx).
 ///
 /// If provided, the pre-permutation inputs for the first N−1 elements are appended
 /// to `poseidon2_permute_inputs`, and the pre-permutation input for the last element

--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -22,7 +22,6 @@ openvm-poseidon2-air = { workspace = true }
 
 itertools.workspace = true
 tracing.workspace = true
-eyre.workspace = true
 derive-new.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
@@ -54,3 +53,7 @@ touchemall = [
     "openvm-cuda-backend/touchemall",
     "openvm-circuit/touchemall",
 ]
+
+# used only for feature forwarding (parallel/cuda/touchemall), which cargo-shear misses
+[package.metadata.cargo-shear]
+ignored = ["openvm-circuit"]

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -442,7 +442,7 @@ define_typed_per_proof_permutation_bus!(MerkleVerifyBus, MerkleVerifyBusMessage)
 pub struct AirShapeBusMessage<T> {
     pub sort_idx: T,
     /// The property this message encodes.
-    /// See associated enum [AirShapeProperty].
+    /// See associated enum `AirShapeProperty`.
     pub property_idx: T,
     /// The value of the corresponding property.
     pub value: T,

--- a/crates/recursion/src/gkr/mod.rs
+++ b/crates/recursion/src/gkr/mod.rs
@@ -5,7 +5,7 @@
 //! random point. This is done through a layer-by-layer recursive reduction, where each layer uses a
 //! sumcheck protocol.
 //!
-//! The GKR Air Module verifies the [`GkrProof`](openvm_stark_backend::proof::GkrProof) struct and
+//! The GKR Air Module verifies the [`GkrProof`] struct and
 //! consists of four AIRs:
 //!
 //! 1. **GkrInputAir** - Handles initial setup, coordinates other AIRs, and sends final claims to
@@ -13,7 +13,7 @@
 //! 2. **GkrLayerAir** - Manages layer-by-layer GKR reduction (verifies
 //!    [`verify_gkr`](openvm_stark_backend::verifier::fractional_sumcheck_gkr::verify_gkr))
 //! 3. **GkrLayerSumcheckAir** - Executes sumcheck protocol for each layer (verifies
-//!    [`verify_gkr_sumcheck`](openvm_stark_backend::verifier::fractional_sumcheck_gkr::verify_gkr_sumcheck))
+//!    `verify_gkr_sumcheck`)
 //! 4. **GkrXiSamplerAir** - Samples additional xi randomness challenges if required
 //!
 //! ## Architecture

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -128,9 +128,9 @@ pub struct ProofShapeVarColsMut<'a, F> {
 ///
 /// The bound is enforced via a limb-decomposed comparison (see `eval` on `is_last`).
 ///
-/// [`VerifierSubCircuit::new_with_options`] also asserts at verifier-circuit construction time
-/// that every `LinearConstraint` in the child VK's `trace_height_constraints` is implied by this
-/// bound. Otherwise, construction fails.
+/// [`VerifierSubCircuit::new_with_options`](crate::system::VerifierSubCircuit::new_with_options)
+/// also asserts at verifier-circuit construction time that every `LinearConstraint` in the child
+/// VK's `trace_height_constraints` is implied by this bound. Otherwise, construction fails.
 pub struct ProofShapeAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     // Parameters derived from vk
     pub per_air: Vec<AirMetadata>,

--- a/crates/recursion/src/system/mod.rs
+++ b/crates/recursion/src/system/mod.rs
@@ -298,7 +298,7 @@ pub struct Preflight {
     pub poseidon2_perm_inputs: Vec<[F; POSEIDON2_WIDTH]>,
     pub poseidon2_compress_inputs: Vec<[F; POSEIDON2_WIDTH]>,
     pub initial_row_states: Vec<Vec<Vec<Vec<[F; POSEIDON2_WIDTH]>>>>,
-    /// Indexed by [round][query][coset]. Stores post-permutation state.
+    /// Indexed by `[round][query][coset]`. Stores post-permutation state.
     pub codeword_states: Vec<Vec<Vec<[F; POSEIDON2_WIDTH]>>>,
 }
 

--- a/crates/recursion/src/transcript/merkle_verify/trace.rs
+++ b/crates/recursion/src/transcript/merkle_verify/trace.rs
@@ -257,15 +257,15 @@ fn build_merkle_logs(preflight: &Preflight, params: &SystemParams) -> Vec<Merkle
 // to produce arr[result_layer][result_index].
 #[derive(Debug, PartialEq)]
 pub struct CombinationIndices {
-    /// The index of the array (vector) containing the two elements to be combined (arr[j]).
+    /// The index of the array (vector) containing the two elements to be combined (`arr[j]`).
     pub source_layer: usize,
-    /// The index of the left element in the source layer (arr[j][2*c]).
+    /// The index of the left element in the source layer (`arr[j][2*c]`).
     pub left_source_index: usize,
-    /// The index of the right element in the source layer (arr[j][2*c + 1]).
+    /// The index of the right element in the source layer (`arr[j][2*c + 1]`).
     pub right_source_index: usize,
-    /// The index of the array (vector) where the result is stored (arr[j+1]).
+    /// The index of the array (vector) where the result is stored (`arr[j+1]`).
     pub result_layer: usize,
-    /// The index of the result element in the result layer (arr[j+1][c]).
+    /// The index of the result element in the result layer (`arr[j+1][c]`).
     pub result_index: usize,
 }
 

--- a/crates/sdk-config/Cargo.toml
+++ b/crates/sdk-config/Cargo.toml
@@ -28,7 +28,6 @@ openvm-rv32im-circuit = { workspace = true }
 openvm-rv32im-transpiler = { workspace = true }
 openvm-transpiler = { workspace = true }
 openvm-circuit = { workspace = true }
-openvm = { workspace = true }
 
 serde.workspace = true
 toml.workspace = true
@@ -84,3 +83,8 @@ test-utils = ["openvm-circuit/test-utils"]
 parallel = ["openvm-circuit/parallel"]
 mimalloc = ["openvm-circuit/mimalloc"]
 jemalloc = ["openvm-circuit/jemalloc"]
+
+# openvm-cuda-backend is used inside cfg_if! blocks, which cargo-shear cannot see into;
+# derive_more is referenced by the VmConfig derive expansion
+[package.metadata.cargo-shear]
+ignored = ["openvm-cuda-backend", "derive_more"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -27,14 +27,12 @@ openvm-verify-stark-host = { workspace = true }
 openvm-verify-stark-circuit = { workspace = true }
 openvm-static-verifier = { workspace = true, optional = true }
 halo2-base = { workspace = true, optional = true, features = ["halo2-axiom"] }
-p3-bn254 = { workspace = true, optional = true }
 
 alloy-sol-types = { workspace = true, optional = true }
 forge-fmt = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 
 bitcode = { workspace = true }
-bon = { workspace = true }
 cfg-if = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 derivative = { workspace = true }
@@ -44,18 +42,12 @@ eyre = { workspace = true }
 getset = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }
-num-bigint = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["hex"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 metrics = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["rt", "sync"], optional = true }
-toml = { workspace = true }
-
-[dev-dependencies]
-openvm-toolchain-tests = { workspace = true }
 
 [features]
 default = ["parallel", "jemalloc"]
@@ -68,7 +60,6 @@ evm-prove = [
     "root-prover",
     "dep:openvm-static-verifier",
     "dep:halo2-base",
-    "dep:p3-bn254",
     "openvm-static-verifier/evm-prove",
 ]
 evm-verify = [
@@ -104,7 +95,6 @@ perf-metrics = [
 stark-debug = ["openvm-circuit/stark-debug"]
 test-utils = ["openvm-circuit/test-utils"]
 
-async = ["tokio"]
 parallel = ["openvm-continuations/parallel", "openvm-sdk-config/parallel"]
 mimalloc = ["openvm-circuit/mimalloc", "openvm-sdk-config/mimalloc"]
 jemalloc = ["openvm-circuit/jemalloc", "openvm-sdk-config/jemalloc"]

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -283,8 +283,9 @@ where
 
     /// Builds the SDK without inferring a transpiler from the app source.
     ///
-    /// This is useful when callers only operate on pre-transpiled [`VmExe`] values and want ELF
-    /// conversion to remain unavailable unless a transpiler was explicitly supplied via
+    /// This is useful when callers only operate on pre-transpiled
+    /// [`VmExe`](openvm_circuit::arch::instructions::exe::VmExe) values and want ELF conversion
+    /// to remain unavailable unless a transpiler was explicitly supplied via
     /// [`Self::transpiler`].
     pub fn build_without_transpiler(self) -> Result<GenericSdk<E, VB>, SdkError>
     where

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -400,7 +400,7 @@ where
     /// commitment to the App [VmExe] and aggregation verifiers. It does **not** depend on the
     /// `inputs`. It can be generated separately from the proof by creating a
     /// [`prover`](Self::prover) and calling
-    /// [`app_commit`](StarkProver::app_commit).
+    /// [`app_vm_commit`](StarkProver::app_vm_commit).
     ///
     /// If STARK aggregation is not needed and a proof whose size may grow linearly with the length
     /// of the program runtime is desired, create an [`app_prover`](Self::app_prover) and call

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -366,7 +366,7 @@ impl TryFrom<VersionedVmStarkProof> for VmStarkProof {
 
 // =================== Verification baseline JSON types ===================
 
-/// Hex-formatted [`VkCommit`](openvm_verify_stark_host::pvs::VkCommit) for JSON serialization.
+/// Hex-formatted [`VkCommit`] for JSON serialization.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VkCommitJson {
     #[serde(with = "hex_bytes32")]

--- a/crates/static-verifier/Cargo.toml
+++ b/crates/static-verifier/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 [dependencies]
 openvm-stark-sdk = { workspace = true, features = ["baby-bear-bn254-poseidon2"] }
 openvm-cuda-backend = { workspace = true, optional = true, features = ["baby-bear-bn254-poseidon2"] }
-openvm-circuit-primitives-derive.workspace = true
 openvm-verify-stark-host.workspace = true
 openvm-recursion-circuit.workspace = true
 openvm-cpu-backend.workspace = true

--- a/crates/static-verifier/src/keygen.rs
+++ b/crates/static-verifier/src/keygen.rs
@@ -113,7 +113,7 @@ impl StaticVerifierProvingKey {
         )
     }
 
-    /// Produce a [`Snark`] for consumption by the wrapper circuit.
+    /// Produce a [`Snark`](snark_verifier_sdk::Snark) for consumption by the wrapper circuit.
     ///
     /// Unlike [`prove_for_evm_unwrapped`](Self::prove_for_evm_unwrapped), this
     /// returns a `Snark` (not a raw EVM proof), which should be fed into

--- a/crates/toolchain/instructions/src/exe.rs
+++ b/crates/toolchain/instructions/src/exe.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::program::Program;
 
 // TODO[jpw]: delete this
-/// Memory image is a map from (address space, address * size_of<CellType>) to u8.
+/// Memory image is a map from `(address space, address * size_of<CellType>)` to u8.
 pub type SparseMemoryImage = BTreeMap<(u32, u32), u8>;
 /// Stores the starting address, end address, and name of a set of function.
 pub type FnBounds = BTreeMap<u32, FnBound>;

--- a/crates/toolchain/tests/Cargo.toml
+++ b/crates/toolchain/tests/Cargo.toml
@@ -30,7 +30,7 @@ rand = { workspace = true }
 serde = { workspace = true, features = ["alloc"] }
 derive_more = { workspace = true, features = ["from"] }
 
-[target.'cfg(not(target_os = "zkvm"))'.dependencies]
+[target.'cfg(not(target_os = "zkvm"))'.dev-dependencies]
 num-bigint.workspace = true
 
 [features]

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -16,7 +16,6 @@ openvm-circuit-primitives = { workspace = true }
 openvm-circuit-primitives-derive = { workspace = true }
 openvm-circuit-derive = { workspace = true }
 openvm-instructions = { workspace = true }
-openvm-rv32im-transpiler = { workspace = true, optional = true }
 
 openvm-stark-backend = { workspace = true }
 openvm-stark-sdk = { workspace = true, optional = true, features = ["cpu-backend"] }
@@ -28,7 +27,6 @@ itertools.workspace = true
 tracing.workspace = true
 derive-new.workspace = true
 derive_more = { workspace = true, features = ["from"] }
-enum_dispatch.workspace = true
 backtrace.workspace = true
 rand.workspace = true
 serde.workspace = true
@@ -37,7 +35,6 @@ metrics = { workspace = true, optional = true }
 thiserror.workspace = true
 rustc-hash.workspace = true
 eyre.workspace = true
-derivative.workspace = true
 static_assertions.workspace = true
 getset.workspace = true
 dashmap.workspace = true
@@ -56,7 +53,6 @@ memmap2.workspace = true
 libc.workspace = true
 
 [dev-dependencies]
-test-log.workspace = true
 test-case.workspace = true
 
 openvm-stark-backend = { workspace = true, features = ["test-utils"] }
@@ -90,7 +86,6 @@ tco = ["openvm-circuit-derive/tco"]
 # Ahead-of-time execution
 aot = [
     "dep:libloading",
-    "dep:openvm-rv32im-transpiler",
     "openvm-circuit-derive/aot",
     "dep:tempfile",
 ]

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -95,8 +95,8 @@ pub struct AdapterAirContext<T, I: VmAdapterInterface<T>> {
 /// Helper trait for CPU tracegen.
 pub trait TraceFiller<F>: Send + Sync {
     /// Populates `trace`. This function will always be called after
-    /// [`TraceExecutor::execute`], so the `trace` should already contain the records necessary to
-    /// fill in the rest of it.
+    /// [`PreflightExecutor::execute`](crate::arch::execution::PreflightExecutor::execute), so the
+    /// `trace` should already contain the records necessary to fill in the rest of it.
     fn fill_trace(
         &self,
         mem_helper: &MemoryAuxColsFactory<F>,
@@ -119,9 +119,10 @@ pub trait TraceFiller<F>: Send + Sync {
     }
 
     /// Populates `row_slice`. This function will always be called after
-    /// [`TraceExecutor::execute`], so the `row_slice` should already contain context necessary to
-    /// fill in the rest of the row. This function will be called for each row in the trace which
-    /// is being used, and for all other rows in the trace see `fill_dummy_trace_row`.
+    /// [`PreflightExecutor::execute`](crate::arch::execution::PreflightExecutor::execute), so the
+    /// `row_slice` should already contain context necessary to fill in the rest of the row.
+    /// This function will be called for each row in the trace which is being used, and for all
+    /// other rows in the trace see `fill_dummy_trace_row`.
     ///
     /// The provided `row_slice` will have length equal to the width of the AIR.
     fn fill_trace_row(&self, _mem_helper: &MemoryAuxColsFactory<F>, _row_slice: &mut [F]) {
@@ -168,9 +169,11 @@ where
 }
 
 /// A helper trait for expressing generic state accesses within the implementation of
-/// [TraceExecutor]. Note that this is only a helper trait when the same interface of state access
-/// is reused or shared by multiple implementations. It is not required to implement this trait if
-/// it is easier to implement the [TraceExecutor] trait directly without this trait.
+/// [PreflightExecutor](crate::arch::execution::PreflightExecutor). Note that this is only a helper
+/// trait when the same interface of state access is reused or shared by multiple implementations.
+/// It is not required to implement this trait if it is easier to implement the
+/// [PreflightExecutor](crate::arch::execution::PreflightExecutor) trait directly without this
+/// trait.
 pub trait AdapterTraceExecutor<F>: Clone {
     const WIDTH: usize;
     type ReadData;

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -1,5 +1,6 @@
 //! [VmExecutor] is the struct that can execute an _arbitrary_ program, provided in the form of a
-//! [VmExe], for a fixed set of OpenVM instructions corresponding to a [VmExecutionConfig].
+//! [VmExe](openvm_instructions::exe::VmExe), for a fixed set of OpenVM instructions
+//! corresponding to a [VmExecutionConfig].
 //! Internally once it is given a program, it will preprocess the program to rewrite it into a more
 //! optimized format for runtime execution. This **instance** of the executor will be a separate
 //! struct specialized to running a _fixed_ program on different program inputs.
@@ -380,7 +381,7 @@ pub enum VirtualMachineError {
 /// The [VirtualMachine] struct contains the API to generate proofs for _arbitrary_ programs for a
 /// fixed set of OpenVM instructions and a fixed VM circuit corresponding to those instructions. The
 /// API is specific to a particular [StarkEngine], which specifies a fixed [StarkProtocolConfig] and
-/// [ProverBackend] via associated types. The [VmProverBuilder] also fixes the choice of
+/// [ProverBackend] via associated types. The [VmBuilder] also fixes the choice of
 /// `RecordArena` associated to the prover backend via an associated type.
 ///
 /// In other words, this struct _is_ the zkVM.

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -62,7 +62,8 @@ const POSEIDON2_INSERTION_IDX: usize = 1;
 
 /// Trait for trace generation of all system AIRs. The system chip complex is special because we may
 /// not exactly following the exact matching between `Air` and `Chip`. Moreover we may require more
-/// flexibility than what is provided through the trait object [`AnyChip`].
+/// flexibility than what is provided through the trait object
+/// [`AnyChip`](openvm_circuit_primitives::AnyChip).
 ///
 /// The [SystemChipComplex] is meant to be constructible once the VM configuration is known, and it
 /// can be loaded with arbitrary programs supported by the instruction set available to its

--- a/extensions/deferral/circuit/Cargo.toml
+++ b/extensions/deferral/circuit/Cargo.toml
@@ -18,22 +18,17 @@ openvm-circuit = { workspace = true }
 openvm-circuit-derive = { workspace = true }
 openvm-instructions = { workspace = true }
 openvm-rv32im-circuit = { workspace = true }
-openvm-rv32im-transpiler = { workspace = true }
 openvm-deferral-transpiler = { workspace = true }
 
 openvm-cuda-backend = { workspace = true, optional = true }
 openvm-cuda-common = { workspace = true, optional = true }
 
 p3-field = { workspace = true }
-
-strum.workspace = true
 itertools.workspace = true
 derive-new.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 rand.workspace = true
-eyre.workspace = true
 serde.workspace = true
-static_assertions.workspace = true
 cfg-if.workspace = true
 dashmap.workspace = true
 rustc-hash.workspace = true
@@ -44,9 +39,6 @@ openvm-cuda-builder = { workspace = true, optional = true }
 [dev-dependencies]
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
 openvm-circuit = { workspace = true, features = ["test-utils"] }
-p3-symmetric = { workspace = true }
-test-case = { workspace = true }
-test-log = { workspace = true }
 
 [features]
 default = ["parallel", "jemalloc"]

--- a/extensions/deferral/circuit/src/canonicity/mod.rs
+++ b/extensions/deferral/circuit/src/canonicity/mod.rs
@@ -20,8 +20,8 @@ pub struct CanonicityIo<T> {
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Clone, Copy, Debug)]
 pub struct CanonicityAuxCols<T> {
-    /// Marker for the first index where x[i] != order[i] (big-endian).
+    /// Marker for the first index where `x[i] != order[i]` (big-endian).
     pub diff_marker: [T; F_NUM_BYTES],
-    /// order[i] - x[i] at the first differing index, constrained to [1, 255].
+    /// `order[i] - x[i]` at the first differing index, constrained to `[1, 255]`.
     pub diff_val: T,
 }

--- a/extensions/deferral/tests/Cargo.toml
+++ b/extensions/deferral/tests/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 [dependencies]
 openvm-stark-sdk.workspace = true
 openvm-circuit = { workspace = true, features = ["test-utils"] }
-openvm-circuit-derive.workspace = true
 openvm-instructions.workspace = true
 openvm-transpiler.workspace = true
 openvm-rv32im-circuit.workspace = true
@@ -20,8 +19,6 @@ openvm-deferral-transpiler.workspace = true
 openvm-toolchain-tests = { path = "../../../crates/toolchain/tests" }
 eyre.workspace = true
 itertools.workspace = true
-derive_more.workspace = true
-serde.workspace = true
 
 [features]
 default = ["parallel"]

--- a/extensions/ecc/circuit/Cargo.toml
+++ b/extensions/ecc/circuit/Cargo.toml
@@ -68,4 +68,5 @@ touchemall = [
 ]
 
 [package.metadata.cargo-shear]
-ignored = ["rand"]
+# derive_more is referenced by the VmConfig derive expansion
+ignored = ["rand", "derive_more"]

--- a/extensions/ecc/guest/src/ecdsa.rs
+++ b/extensions/ecc/guest/src/ecdsa.rs
@@ -91,7 +91,7 @@ where
     C::Point: WeierstrassPoint + Group + FromCompressed<Coordinate<C>>,
     Coordinate<C>: IntMod,
 {
-    /// Convert an [`AffinePoint`] into a [`PublicKey`].
+    /// Convert an `AffinePoint` into a [`PublicKey`].
     /// In addition, for `Coordinate<C>` implementing `IntMod`, this function will assert that the
     /// affine coordinates of `point` are both in canonical form.
     pub fn from_affine(point: AffinePoint<C>) -> Result<Self> {
@@ -274,7 +274,7 @@ where
     }
 }
 
-/// To match the RustCrypto trait [VerifyPrimitive]. Certain curves have special verification logic
+/// To match the RustCrypto trait `VerifyPrimitive`. Certain curves have special verification logic
 /// outside of the general ECDSA verification algorithm. This trait provides a hook for such logic.
 ///
 /// This trait is intended to be implemented on type which can access

--- a/extensions/ecc/tests/Cargo.toml
+++ b/extensions/ecc/tests/Cargo.toml
@@ -20,7 +20,6 @@ openvm-sdk.workspace = true
 openvm-sdk-config.workspace = true
 serde.workspace = true
 serde_with.workspace = true
-toml.workspace = true
 eyre.workspace = true
 hex-literal.workspace = true
 num-bigint.workspace = true

--- a/extensions/rv32im/guest/Cargo.toml
+++ b/extensions/rv32im/guest/Cargo.toml
@@ -11,8 +11,5 @@ repository.workspace = true
 openvm-custom-insn = { workspace = true }
 strum_macros = { workspace = true }
 
-[target.'cfg(not(target_os = "zkvm"))'.dependencies]
-p3-field = { workspace = true }
-
 [features]
 default = []

--- a/guest-libs/sha2/Cargo.toml
+++ b/guest-libs/sha2/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-openvm = { workspace = true }
 openvm-sha2-guest = { workspace = true }
 sha2 = { workspace = true, default-features = false, optional = true }
 

--- a/guest-libs/verify-stark/circuit/Cargo.toml
+++ b/guest-libs/verify-stark/circuit/Cargo.toml
@@ -26,7 +26,6 @@ openvm-cuda-common = { workspace = true, optional = true }
 openvm-cuda-backend = { workspace = true, optional = true }
 
 p3-air = { workspace = true }
-p3-bn254 = { workspace = true }
 p3-field = { workspace = true }
 p3-matrix = { workspace = true }
 
@@ -47,16 +46,12 @@ openvm-verify-stark-host = { workspace = true }
 eyre.workspace = true
 test-case.workspace = true
 
-[build-dependencies]
-openvm-cuda-builder = { workspace = true, optional = true }
-
 [features]
 default = ["parallel"]
 parallel = ["openvm-circuit/parallel", "openvm-recursion-circuit/parallel"]
 metrics = ["openvm-circuit/metrics"]
 
 cuda = [
-    "dep:openvm-cuda-builder",
     "dep:openvm-cuda-common",
     "dep:openvm-cuda-backend",
     "openvm-continuations/cuda",


### PR DESCRIPTION
The docs step took 10–20 min per PR: `cargo doc --workspace` without `--no-deps` documents ~425 third-party crates, and rustdoc output is not cached by sccache.

- Split the docs check into a parallel job that only documents workspace crates with `RUSTDOCFLAGS=-D warnings`; full docs with dependencies are still published by `docs.yml` on main/tags.
- Fix all 37 rustdoc intra-doc link warnings (including stale references to renamed items).
- Re-enable `cargo shear`: remove 50+ unused dependencies and dead feature entries, move dev-only deps to `[dev-dependencies]`, and ignore false positives (deps referenced via derive expansions, `cfg_if!`, and feature forwarding). Pinned to 1.1.11 — 1.13+ falsely flags `ff_derive`'s `num-bigint03` because two renames of the same package collide in its package→import map.

Verified: `cargo check --workspace --all-targets`, `cargo shear`, and the docs build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)