### PR TITLE
fix(static-verifier): phase3 nits

### DIFF
--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -193,6 +193,9 @@ impl BabyBearChip {
         mut a: BabyBearWire,
         mut b: BabyBearWire,
     ) -> BabyBearWire {
+        if a.max_bits < b.max_bits {
+            std::mem::swap(&mut a, &mut b);
+        }
         if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
             a = self.reduce(ctx, a);
             if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
@@ -201,11 +204,8 @@ impl BabyBearChip {
         }
         let value = self.gate().add(ctx, a.value, b.value);
         let max_bits = a.max_bits.max(b.max_bits) + 1;
-        let mut c = BabyBearWire { value, max_bits };
+        let c = BabyBearWire { value, max_bits };
         guarded_debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() + b.to_baby_bear());
-        if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
-            c = self.reduce(ctx, c);
-        }
         c
     }
 
@@ -225,7 +225,14 @@ impl BabyBearChip {
         mut a: BabyBearWire,
         mut b: BabyBearWire,
     ) -> BabyBearWire {
+        #[cfg(debug_assertions)]
+        let expected = a.to_baby_bear() - b.to_baby_bear();
+        let mut negate_result = false;
         if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
+            if a.max_bits < b.max_bits {
+                std::mem::swap(&mut a, &mut b);
+                negate_result = true;
+            }
             a = self.reduce(ctx, a);
             if a.max_bits.max(b.max_bits) + 1 > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
                 b = self.reduce(ctx, b);
@@ -234,10 +241,10 @@ impl BabyBearChip {
         let value = self.gate().sub(ctx, a.value, b.value);
         let max_bits = a.max_bits.max(b.max_bits) + 1;
         let mut c = BabyBearWire { value, max_bits };
-        guarded_debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() - b.to_baby_bear());
-        if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
-            c = self.reduce(ctx, c);
+        if negate_result {
+            c = self.neg(ctx, c);
         }
+        guarded_debug_assert_eq!(c.to_baby_bear(), expected);
         c
     }
 
@@ -259,10 +266,7 @@ impl BabyBearChip {
         let value = self.gate().mul(ctx, a.value, b.value);
         let max_bits = a.max_bits + b.max_bits;
 
-        let mut c = BabyBearWire { value, max_bits };
-        if c.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
-            c = self.reduce(ctx, c);
-        }
+        let c = BabyBearWire { value, max_bits };
         guarded_debug_assert_eq!(c.to_baby_bear(), a.to_baby_bear() * b.to_baby_bear());
         c
     }
@@ -289,10 +293,7 @@ impl BabyBearChip {
         let value = self.gate().mul_add(ctx, a.value, b.value, c.value);
         let max_bits = c.max_bits.max(a.max_bits + b.max_bits) + 1;
 
-        let mut d = BabyBearWire { value, max_bits };
-        if d.max_bits > Fr::CAPACITY as usize - RESERVED_HIGH_BITS {
-            d = self.reduce(ctx, d);
-        }
+        let d = BabyBearWire { value, max_bits };
         guarded_debug_assert_eq!(
             d.to_baby_bear(),
             a.to_baby_bear() * b.to_baby_bear() + c.to_baby_bear()

--- a/crates/static-verifier/src/field/baby_bear/base.rs
+++ b/crates/static-verifier/src/field/baby_bear/base.rs
@@ -6,6 +6,7 @@ use halo2_base::{
         arithmetic::Field as _,
         halo2curves::{bn256::Fr, ff::PrimeField as _},
     },
+    safe_types::SafeBool,
     utils::{bigint_to_fe, biguint_to_fe, bit_length, fe_to_bigint, modulus, BigPrimeField},
     AssignedValue, Context, QuantumCell,
 };
@@ -165,6 +166,7 @@ impl BabyBearChip {
     }
 
     pub fn reduce(&self, ctx: &mut Context<Fr>, a: BabyBearWire) -> BabyBearWire {
+        assert!(a.max_bits <= Fr::CAPACITY as usize - RESERVED_HIGH_BITS);
         guarded_debug_assert!(fe_to_bigint(a.value.value()).bits() as usize <= a.max_bits);
         let (_, r) = signed_div_mod(&self.range, ctx, a.value, a.max_bits);
         let r = BabyBearWire {
@@ -400,11 +402,11 @@ impl BabyBearChip {
     pub fn select(
         &self,
         ctx: &mut Context<Fr>,
-        cond: AssignedValue<Fr>,
+        cond: SafeBool<Fr>,
         a: BabyBearWire,
         b: BabyBearWire,
     ) -> BabyBearWire {
-        let value = self.gate().select(ctx, a.value, b.value, cond);
+        let value = self.gate().select(ctx, a.value, b.value, *cond.as_ref());
         let max_bits = a.max_bits.max(b.max_bits);
         BabyBearWire { value, max_bits }
     }
@@ -504,6 +506,7 @@ fn signed_div_mod<F>(
 where
     F: BigPrimeField,
 {
+    assert!(a_num_bits <= F::CAPACITY as usize - RESERVED_HIGH_BITS);
     // Proof sketch:
     //
     // Let `b = BabyBear::ORDER_U32`, `p = F::MODULUS`, and let

--- a/crates/static-verifier/src/field/baby_bear/extension.rs
+++ b/crates/static-verifier/src/field/baby_bear/extension.rs
@@ -2,8 +2,10 @@ use core::array;
 #[cfg(test)]
 use std::{cell::RefCell, vec::Vec};
 
+#[cfg(test)]
+use halo2_base::AssignedValue;
 use halo2_base::{
-    gates::range::RangeChip, halo2_proofs::halo2curves::bn256::Fr, AssignedValue, Context,
+    gates::range::RangeChip, halo2_proofs::halo2curves::bn256::Fr, safe_types::SafeBool, Context,
 };
 use itertools::Itertools;
 #[cfg(test)]
@@ -210,7 +212,7 @@ impl BabyBearExt4Chip {
     pub fn select(
         &self,
         ctx: &mut Context<Fr>,
-        cond: AssignedValue<Fr>,
+        cond: SafeBool<Fr>,
         a: BabyBearExt4Wire,
         b: BabyBearExt4Wire,
     ) -> BabyBearExt4Wire {

--- a/crates/static-verifier/src/hash/poseidon2.rs
+++ b/crates/static-verifier/src/hash/poseidon2.rs
@@ -3,7 +3,6 @@
 
 use halo2_base::{
     gates::{range::RangeChip, GateInstructions, RangeInstructions},
-    safe_types::SafeBool,
     utils::ScalarField,
     AssignedValue, Context,
     QuantumCell::{self, Constant},
@@ -82,19 +81,6 @@ impl<F: ScalarField, const T: usize> Poseidon2State<F, T> {
             self.add_rc(ctx, gate, params.external_rc[r]);
             self.sbox(ctx, gate);
             self.matmul_external(ctx, gate);
-        }
-    }
-
-    /// Constrains and set self to a specific state if `selector` is true.
-    pub fn select(
-        &mut self,
-        ctx: &mut Context<F>,
-        gate: &impl GateInstructions<F>,
-        selector: SafeBool<F>,
-        set_to: &Self,
-    ) {
-        for i in 0..T {
-            self.s[i] = gate.select(ctx, set_to.s[i], self.s[i], *selector.as_ref());
         }
     }
 

--- a/crates/static-verifier/src/hash/poseidon2.rs
+++ b/crates/static-verifier/src/hash/poseidon2.rs
@@ -206,6 +206,10 @@ pub(crate) fn pack_base_2_31_cells(
     gate: &impl GateInstructions<Fr>,
     values: &[ReducedBabyBearWire],
 ) -> AssignedValue<Fr> {
+    assert!(
+        values.len() <= MULTI_FIELD32_NUM_F_ELMS,
+        "base-2^31 packing supports at most {MULTI_FIELD32_NUM_F_ELMS} limbs"
+    );
     let base = Fr::from(1u64 << 31);
     gate.inner_product(
         ctx,

--- a/crates/static-verifier/src/prover.rs
+++ b/crates/static-verifier/src/prover.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use halo2_base::{
     gates::{
         circuit::{builder::BaseCircuitBuilder, BaseCircuitParams, CircuitBuilderStage},
@@ -30,11 +28,7 @@ use openvm_stark_sdk::{
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{
-    circuit::StaticVerifierCircuit,
-    config::StaticVerifierShape,
-    field::baby_bear::{BabyBearChip, BabyBearExtChip},
-};
+use crate::{circuit::StaticVerifierCircuit, config::StaticVerifierShape};
 
 /// KZG parameters for the Halo2 BN256 proving system.
 pub type Halo2Params = ParamsKZG<Bn256>;
@@ -92,58 +86,6 @@ impl StaticVerifierCircuit {
         let prover = MockProver::run(shape.k as u32, &builder, vec![public_inputs.to_vec()])
             .expect("MockProver should initialize");
         prover.assert_satisfied();
-    }
-
-    /// Prove using only [`Self::populate_verify_stark_constraints`]. `shape.instance_columns` must
-    /// be `0`. [`StaticVerifierProof::public_inputs`] is empty.
-    pub fn prove_verify_stark_constraints_only(
-        &self,
-        params: &Halo2Params,
-        pinning: &Halo2ProvingPinning,
-        shape: &StaticVerifierShape,
-        proof: &Proof<RootConfig>,
-    ) -> StaticVerifierProof {
-        assert_eq!(
-            shape.instance_columns, 0,
-            "prove_verify_stark_constraints_only requires instance_columns == 0"
-        );
-        let mut builder = BaseCircuitBuilder::prover(
-            pinning.metadata.config_params.clone(),
-            pinning.metadata.break_points.clone(),
-        );
-        builder = builder.use_instance_columns(0);
-
-        let range = builder.range_chip();
-        let ext_chip = BabyBearExtChip::new(BabyBearChip::new(Arc::new(range)));
-        let ctx = builder.main(0);
-        let _ = self.populate_verify_stark_constraints(ctx, &ext_chip, proof);
-
-        let public_inputs = Vec::new();
-
-        let rng = ChaCha20Rng::from_seed(Default::default());
-        let instances: &[&[Fr]] = &[];
-        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-        create_proof::<
-            KZGCommitmentScheme<Bn256>,
-            ProverSHPLONK<'_, Bn256>,
-            Challenge255<_>,
-            _,
-            Blake2bWrite<Vec<u8>, G1Affine, _>,
-            _,
-        >(
-            params,
-            &pinning.pk,
-            &[builder],
-            &[instances],
-            rng,
-            &mut transcript,
-        )
-        .expect("Halo2 proof generation should succeed");
-
-        StaticVerifierProof {
-            proof_bytes: transcript.finalize(),
-            public_inputs,
-        }
     }
 
     /// Generate a Halo2 proof using a previously computed [`Halo2ProvingPinning`].

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -35,7 +35,7 @@ pub struct BatchConstraintIntermediatesWire {
 pub struct GkrProofWire {
     pub logup_pow_witness: ReducedBabyBearWire,
     pub q0_claim: ReducedBabyBearExtWire,
-    pub claims_per_layer: Vec<Vec<ReducedBabyBearExtWire>>,
+    pub claims_per_layer: Vec<[ReducedBabyBearExtWire; 4]>,
     pub sumcheck_polys: Vec<Vec<[ReducedBabyBearExtWire; 3]>>,
 }
 
@@ -60,7 +60,7 @@ pub(crate) fn load_gkr_proof_wire(
         .claims_per_layer
         .iter()
         .map(|claims| {
-            vec![
+            [
                 ext_chip.load_reduced_witness(ctx, claims.p_xi_0),
                 ext_chip.load_reduced_witness(ctx, claims.q_xi_0),
                 ext_chip.load_reduced_witness(ctx, claims.p_xi_1),
@@ -495,18 +495,18 @@ impl ConstraintEvaluatorWire<'_> {
         match symbolic_var.entry {
             Entry::Preprocessed { offset } => {
                 let value = &self.preprocessed.unwrap()[index];
-                if offset == 0 {
-                    value.local
-                } else {
-                    value.next
+                match offset {
+                    0 => value.local,
+                    1 => value.next,
+                    _ => panic!("unsupported preprocessed rotation offset {offset}"),
                 }
             }
             Entry::Main { part_index, offset } => {
                 let value = &self.partitioned_main[part_index][index];
-                if offset == 0 {
-                    value.local
-                } else {
-                    value.next
+                match offset {
+                    0 => value.local,
+                    1 => value.next,
+                    _ => panic!("unsupported main rotation offset {offset}"),
                 }
             }
             Entry::Public => {

--- a/crates/static-verifier/src/stages/batch_constraints/mod.rs
+++ b/crates/static-verifier/src/stages/batch_constraints/mod.rs
@@ -684,7 +684,6 @@ pub(crate) fn constrain_batch_constraints_verification(
     let gkr_claims_per_layer = &gkr_wire.claims_per_layer;
     let gkr_sumcheck_polys = &gkr_wire.sumcheck_polys;
 
-    let zero = ext_chip.zero(ctx);
     let one = ext_chip.from_base_const(ctx, RootF::ONE);
     let total_gkr_rounds = l_skip + n_logup_host;
     let (mut gkr_p_xi_claim, mut gkr_q_xi_claim, mut xi) = {
@@ -799,9 +798,8 @@ pub(crate) fn constrain_batch_constraints_verification(
     }
     let gkr_numerator_residual = gkr_p_xi_claim;
     let gkr_denominator_claim = gkr_q_xi_claim;
-    let gkr_denominator_residual = ext_chip.sub(ctx, gkr_denominator_claim, alpha_logup);
-    ext_chip.assert_equal(ctx, gkr_numerator_residual, zero);
-    ext_chip.assert_equal(ctx, gkr_denominator_residual, zero);
+    ext_chip.assert_zero(ctx, gkr_numerator_residual);
+    ext_chip.assert_equal(ctx, gkr_denominator_claim, alpha_logup);
 
     let mu = transcript.sample_ext(ctx);
 
@@ -1180,8 +1178,7 @@ pub(crate) fn constrain_batch_constraints_verification(
         consistency_rhs = ext_chip.add(ctx, consistency_rhs, weighted_term);
         cur_mu_pow = ext_chip.mul(ctx, cur_mu_pow, mu);
     }
-    let consistency_residual = ext_chip.sub(ctx, consistency_lhs, consistency_rhs);
-    ext_chip.assert_equal(ctx, consistency_residual, zero);
+    ext_chip.assert_equal(ctx, consistency_lhs, consistency_rhs);
 
     profiler.pop(ctx.advice.len());
 

--- a/crates/static-verifier/src/stages/stacked_reduction/mod.rs
+++ b/crates/static-verifier/src/stages/stacked_reduction/mod.rs
@@ -187,9 +187,7 @@ pub(crate) fn constrain_stacked_reduction(
     }
     let s_0_sum_eval =
         ext_chip.mul_base_const(ctx, s_0_sum_eval, RootF::from_u64(omega_order as u64));
-    let s_0_residual = ext_chip.sub(ctx, s_0, s_0_sum_eval);
-    let zero = ext_chip.zero(ctx);
-    ext_chip.assert_equal(ctx, s_0_residual, zero);
+    ext_chip.assert_equal(ctx, s_0, s_0_sum_eval);
 
     for coeff in univariate_round_coeffs {
         transcript.observe_ext(ctx, coeff);
@@ -309,8 +307,7 @@ pub(crate) fn constrain_stacked_reduction(
         }
     }
 
-    let final_residual = ext_chip.sub(ctx, final_claim, final_sum);
-    ext_chip.assert_equal(ctx, final_residual, zero);
+    ext_chip.assert_equal(ctx, final_claim, final_sum);
 
     profiler.pop(ctx.advice.len());
 

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -730,8 +730,6 @@ pub(crate) fn constrain_whir_verification(
         alpha_offset += k_whir;
     }
 
-    let final_residual = ext_chip.sub(ctx, final_acc, final_claim);
-    let zero = ext_chip.zero(ctx);
-    ext_chip.assert_equal(ctx, final_residual, zero);
+    ext_chip.assert_equal(ctx, final_acc, final_claim);
     profiler.pop(ctx.advice.len());
 }

--- a/crates/static-verifier/src/stages/whir/mod.rs
+++ b/crates/static-verifier/src/stages/whir/mod.rs
@@ -46,7 +46,7 @@ pub struct WhirProofWire {
     pub mu_pow_witness: ReducedBabyBearWire,
     pub folding_pow_witnesses: Vec<ReducedBabyBearWire>,
     pub query_phase_pow_witnesses: Vec<ReducedBabyBearWire>,
-    pub whir_sumcheck_polys: Vec<Vec<ReducedBabyBearExtWire>>,
+    pub whir_sumcheck_polys: Vec<[ReducedBabyBearExtWire; 2]>,
     pub ood_values: Vec<ReducedBabyBearExtWire>,
     pub final_poly: Vec<ReducedBabyBearExtWire>,
     pub codeword_commitment_roots: Vec<AssignedValue<Fr>>,
@@ -82,6 +82,8 @@ pub(crate) fn load_whir_proof_wire(
             poly.iter()
                 .map(|&value| ext_chip.load_reduced_witness(ctx, value))
                 .collect::<Vec<_>>()
+                .try_into()
+                .expect("WHIR sumcheck polynomial must have two evaluations")
         })
         .collect::<Vec<_>>();
     let ood_values = whir_proof

--- a/crates/static-verifier/src/transcript/mod.rs
+++ b/crates/static-verifier/src/transcript/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         ReducedBabyBearWire, BABY_BEAR_BITS, BABY_BEAR_MODULUS_U64,
     },
     hash::{
-        poseidon2::{Poseidon2State, DIGEST_WIDTH, POSEIDON2_RATE},
+        poseidon2::{pack_base_2_31_cells, Poseidon2State, DIGEST_WIDTH, POSEIDON2_RATE},
         POSEIDON2_PARAMS, POSEIDON2_WIDTH,
     },
     Fr,
@@ -183,25 +183,6 @@ fn decompose_bn254_to_base_baby_bear_digits(
     output_digits
 }
 
-/// Pack BabyBear values into a BN254 element using base-2^31 encoding.
-/// Result = values[0] + values[1]*2^31 + values[2]*2^62 + ...
-fn pack_base_2_31(
-    ctx: &mut Context<Fr>,
-    gate: &impl GateInstructions<Fr>,
-    values: &[ReducedBabyBearWire],
-) -> AssignedValue<Fr> {
-    gate.inner_product(
-        ctx,
-        values.iter().map(|v| v.value()),
-        gate.pow_of_two()
-            .iter()
-            .step_by(BABY_BEAR_BITS)
-            .take(values.len())
-            .copied()
-            .map(QuantumCell::Constant),
-    )
-}
-
 #[derive(Clone, Debug)]
 pub struct DigestWire {
     pub elems: [AssignedValue<Fr>; DIGEST_WIDTH],
@@ -296,7 +277,7 @@ impl TranscriptChip {
     fn flush_observe_buf(&mut self, ctx: &mut Context<Fr>) {
         if !self.observe_buf.is_empty() {
             let gate = self.baby_bear.range().gate();
-            let packed = pack_base_2_31(ctx, gate, &self.observe_buf);
+            let packed = pack_base_2_31_cells(ctx, gate, &self.observe_buf);
             self.sponge_absorb(ctx, packed);
             self.observe_buf.clear();
         }

--- a/crates/static-verifier/src/transcript/mod.rs
+++ b/crates/static-verifier/src/transcript/mod.rs
@@ -343,10 +343,10 @@ impl TranscriptChip {
             "sample_bits requires (1 << bits) < modulus: bits={bits}"
         );
 
+        let sampled = self.sample(ctx);
         if bits == 0 {
             return ctx.load_zero();
         }
-        let sampled = self.sample(ctx);
         // PERF[jpw]: we could optimize this since the divisor is a power of 2
         let range = self.baby_bear.range();
         let divisor = BigUint::from(1u64) << bits;

--- a/crates/static-verifier/src/transcript/tests.rs
+++ b/crates/static-verifier/src/transcript/tests.rs
@@ -221,6 +221,34 @@ fn transcript_check_witness_zero_bits_matches_native() {
 }
 
 #[test]
+fn transcript_sample_bits_zero_matches_native() {
+    let mut native = default_transcript();
+    native.observe(RootF::from_u64(99));
+    let expected_bits = FiatShamirTranscript::<RootConfig>::sample_bits(&mut native, 0);
+    assert_eq!(expected_bits, 0);
+    let expected_followup = native.sample().as_canonical_u64();
+
+    run_mock(true, |builder| {
+        let range = builder.range_chip();
+        let baby_bear = BabyBearChip::new(Arc::new(range.clone()));
+
+        let ctx = builder.main(0);
+        let gate = range.gate();
+
+        let mut transcript = TranscriptChip::new(ctx, baby_bear.clone());
+
+        let obs = baby_bear.load_reduced_witness(ctx, RootF::from_u64(99));
+        transcript.observe(ctx, &obs);
+
+        let sampled_bits = transcript.sample_bits(ctx, 0);
+        gate.assert_is_const(ctx, &sampled_bits, &Fr::ZERO);
+
+        let followup = transcript.sample(ctx);
+        gate.assert_is_const(ctx, &followup.value, &Fr::from(expected_followup));
+    });
+}
+
+#[test]
 fn transcript_sample_bits_rejects_bits_equal_31() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         run_mock(true, |builder| {

--- a/crates/static-verifier/tests/real_prover_roundtrip.rs
+++ b/crates/static-verifier/tests/real_prover_roundtrip.rs
@@ -8,8 +8,13 @@
 use std::sync::Arc;
 
 use halo2_base::{
-    gates::circuit::CircuitBuilderStage,
-    halo2_proofs::plonk::{keygen_pk, keygen_vk},
+    gates::circuit::{builder::BaseCircuitBuilder, CircuitBuilderStage},
+    halo2_proofs::{
+        halo2curves::bn256::{Bn256, G1Affine},
+        plonk::{create_proof, keygen_pk, keygen_vk},
+        poly::kzg::{commitment::KZGCommitmentScheme, multiopen::ProverSHPLONK},
+        transcript::{Blake2bWrite, Challenge255, TranscriptWriterBuffer},
+    },
     utils::fs::gen_srs,
 };
 use openvm_stark_backend::{
@@ -29,9 +34,10 @@ use openvm_stark_sdk::{
 };
 use openvm_static_verifier::{
     field::baby_bear::{BabyBearChip, BabyBearExtChip},
-    log_heights_per_air_from_proof, Halo2ProvingMetadata, Halo2ProvingPinning,
-    StaticVerifierCircuit, StaticVerifierShape,
+    log_heights_per_air_from_proof, Fr, Halo2Params, Halo2ProvingMetadata, Halo2ProvingPinning,
+    StaticVerifierCircuit, StaticVerifierProof, StaticVerifierShape,
 };
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
 const MIN_ROWS: usize = 20;
 
@@ -65,6 +71,49 @@ fn select_k_verify_stark(circuit: &StaticVerifierCircuit, proof: &Proof<RootConf
     }
     tracing::info!("Auto-tuned halo2 k={k} (verify-stark constraints only)");
     k
+}
+
+fn prove_verify_stark_constraints_only(
+    circuit: &StaticVerifierCircuit,
+    params: &Halo2Params,
+    pinning: &Halo2ProvingPinning,
+    proof: &Proof<RootConfig>,
+) -> StaticVerifierProof {
+    let mut builder = BaseCircuitBuilder::prover(
+        pinning.metadata.config_params.clone(),
+        pinning.metadata.break_points.clone(),
+    );
+    builder = builder.use_instance_columns(0);
+
+    let range = builder.range_chip();
+    let ext_chip = BabyBearExtChip::new(BabyBearChip::new(Arc::new(range)));
+    let ctx = builder.main(0);
+    let _ = circuit.populate_verify_stark_constraints(ctx, &ext_chip, proof);
+
+    let rng = ChaCha20Rng::from_seed(Default::default());
+    let instances: &[&[Fr]] = &[];
+    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+    create_proof::<
+        KZGCommitmentScheme<Bn256>,
+        ProverSHPLONK<'_, Bn256>,
+        Challenge255<_>,
+        _,
+        Blake2bWrite<Vec<u8>, G1Affine, _>,
+        _,
+    >(
+        params,
+        &pinning.pk,
+        &[builder],
+        &[instances],
+        rng,
+        &mut transcript,
+    )
+    .expect("Halo2 proof generation should succeed");
+
+    StaticVerifierProof {
+        proof_bytes: transcript.finalize(),
+        public_inputs: Vec::new(),
+    }
 }
 
 #[test]
@@ -116,8 +165,9 @@ fn real_prover_keygen_prove_verify_roundtrip() {
             },
         }
     };
+    assert_eq!(shape.instance_columns, 0);
     let halo2_proof =
-        circuit.prove_verify_stark_constraints_only(&params, &pinning, &shape, &proof_prove);
+        prove_verify_stark_constraints_only(&circuit, &params, &pinning, &proof_prove);
 
     assert!(StaticVerifierCircuit::verify(
         &params,


### PR DESCRIPTION
This tightens several static verifier invariants and trims redundant Halo2 cells in the verifier circuit.

- Require `SafeBool` for BabyBear field select APIs
- Add explicit shape/width checks for BabyBear reduction, base-2^31 packing, GKR claims, WHIR sumcheck polys, and unsupported rotations
- Keep the constraints-only prover harness private to the integration test instead of exposing it on `StaticVerifierCircuit`
- Remove unused Poseidon selector code and reuse the shared packing helper in the transcript
- Avoid redundant BabyBear reductions in `add`, `sub`, `mul`, and `mul_add`
- Assert verifier equalities directly instead of materializing residuals first