### PR TITLE
chore: some sdk refactor for distributed use case

### DIFF
--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -142,6 +142,6 @@ where
     .expect("Failed to create dummy EVM prover");
 
     evm_prover
-        .root_prove(StdIn::default(), &[])
+        .prove_root(StdIn::default(), &[])
         .expect("Failed to generate dummy root proof")
 }

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -142,6 +142,6 @@ where
     .expect("Failed to create dummy EVM prover");
 
     evm_prover
-        .prove_unwrapped(StdIn::default(), &[])
+        .root_prove(StdIn::default(), &[])
         .expect("Failed to generate dummy root proof")
 }

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -21,8 +21,8 @@ use crate::{
 
 /// EVM prover that produces a root STARK proof with Halo2 wrapping.
 ///
-/// [`EvmProver::root_prove`] outputs the unwrapped root STARK, while
-/// [`EvmProver::root_prove_with_stark_proof`] outputs the unwrapped root STARK from an
+/// [`EvmProver::prove_root`] outputs the unwrapped root STARK, while
+/// [`EvmProver::prove_root_from_vm_stark_proof`] outputs the unwrapped root STARK from an
 /// intermediate STARK proof, for more finegrained separation of work
 /// [`EvmProver::prove_evm`] produces an [`EvmProof`](crate::types::EvmProof)
 /// suitable for on-chain verification.
@@ -60,7 +60,7 @@ where
         })
     }
 
-    pub fn root_prove_with_stark_proof(
+    pub fn prove_root_from_vm_stark_proof(
         &mut self,
         stark_proof: VmStarkProof,
         metadata: &mut InternalLayerMetadata,
@@ -84,14 +84,14 @@ where
         }
 
         const MAX_ROOT_TRACEGEN_RETRIES: usize = 8;
-        let root_prover = Arc::clone(&self.root_prover);
         let agg_prover = &self.stark_prover.agg_prover;
-        root_prover.wrap_and_prove(stark_proof, MAX_ROOT_TRACEGEN_RETRIES, |p| {
-            agg_prover.wrap_proof(p, metadata)
-        })
+        self.root_prover
+            .prove(stark_proof, MAX_ROOT_TRACEGEN_RETRIES, |p| {
+                agg_prover.wrap_proof(p, metadata)
+            })
     }
 
-    pub fn root_prove(
+    pub fn prove_root(
         &mut self,
         input: StdIn<Val<SC>>,
         def_inputs: &[DeferralInput],
@@ -102,7 +102,7 @@ where
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
         let (stark_proof, mut internal_metadata) = self.stark_prover.prove(input, def_inputs)?;
-        self.root_prove_with_stark_proof(stark_proof, &mut internal_metadata)
+        self.prove_root_from_vm_stark_proof(stark_proof, &mut internal_metadata)
     }
 
     #[cfg(feature = "evm-prove")]
@@ -116,7 +116,7 @@ where
             + MeteredExecutor<Val<SC>>
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
-        let root_proof = self.root_prove(input, def_inputs)?;
+        let root_proof = self.prove_root(input, def_inputs)?;
         let evm_proof = self
             .halo2_prover
             .as_ref()

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -21,8 +21,8 @@ use crate::{
 
 /// EVM prover that produces a root STARK proof with Halo2 wrapping.
 ///
-/// [`EvmProver::prove_unwrapped`] outputs the unwrapped root STARK, while
-/// [`EvmProver::prove_unwrapped_with_stark_proof`] outputs the unwrapped root STARK from an
+/// [`EvmProver::root_prove`] outputs the unwrapped root STARK, while
+/// [`EvmProver::root_prove_with_stark_proof`] outputs the unwrapped root STARK from an
 /// intermediate STARK proof, for more finegrained separation of work
 /// [`EvmProver::prove_evm`] produces an [`EvmProof`](crate::types::EvmProof)
 /// suitable for on-chain verification.
@@ -60,7 +60,7 @@ where
         })
     }
 
-    pub fn prove_unwrapped_with_stark_proof(
+    pub fn root_prove_with_stark_proof(
         &mut self,
         stark_proof: VmStarkProof,
         metadata: &mut InternalLayerMetadata,
@@ -86,12 +86,12 @@ where
         const MAX_ROOT_TRACEGEN_RETRIES: usize = 8;
         let root_prover = Arc::clone(&self.root_prover);
         let agg_prover = &self.stark_prover.agg_prover;
-        root_prover.prove_with_wrap_retry(stark_proof, MAX_ROOT_TRACEGEN_RETRIES, |p| {
+        root_prover.wrap_and_prove(stark_proof, MAX_ROOT_TRACEGEN_RETRIES, |p| {
             agg_prover.wrap_proof(p, metadata)
         })
     }
 
-    pub fn prove_unwrapped(
+    pub fn root_prove(
         &mut self,
         input: StdIn<Val<SC>>,
         def_inputs: &[DeferralInput],
@@ -102,7 +102,7 @@ where
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
         let (stark_proof, mut internal_metadata) = self.stark_prover.prove(input, def_inputs)?;
-        self.prove_unwrapped_with_stark_proof(stark_proof, &mut internal_metadata)
+        self.root_prove_with_stark_proof(stark_proof, &mut internal_metadata)
     }
 
     #[cfg(feature = "evm-prove")]
@@ -116,7 +116,7 @@ where
             + MeteredExecutor<Val<SC>>
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
-        let root_proof = self.prove_unwrapped(input, def_inputs)?;
+        let root_proof = self.root_prove(input, def_inputs)?;
         let evm_proof = self
             .halo2_prover
             .as_ref()

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -70,12 +70,6 @@ where
             + MeteredExecutor<Val<SC>>
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
-        // Internal sanity (SDK tests only): the input proof must verify against
-        // the recursive-aggregation vk before we hand it to the root prover.
-        // Tracegen normally succeeds without wrapping, so this is the proof the
-        // root prover consumes; if a wrap does occur, root prove itself rejects
-        // a bad wrapped proof. (The post-tracegen height-match invariant now
-        // lives in `RootProver::prove_with_wrap_retry`.)
         #[cfg(test)]
         {
             let agg_vk = self

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -62,7 +62,7 @@ where
 
     pub fn prove_unwrapped_with_stark_proof(
         &mut self,
-        mut stark_proof: VmStarkProof,
+        stark_proof: VmStarkProof,
         metadata: &mut InternalLayerMetadata,
     ) -> Result<Proof<RootSC>>
     where
@@ -70,39 +70,14 @@ where
             + MeteredExecutor<Val<SC>>
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
-        let root_ctx = {
-            const MAX_ROOT_TRACEGEN_RETRIES: usize = 8;
-            let mut attempt = 0usize;
-            loop {
-                if let Some(ctx) = self.root_prover.generate_proving_ctx(stark_proof.clone()) {
-                    break ctx;
-                }
-                if attempt >= MAX_ROOT_TRACEGEN_RETRIES {
-                    return Err(eyre::eyre!(
-                        "root tracegen returned None after {MAX_ROOT_TRACEGEN_RETRIES} retries"
-                    ));
-                }
-                stark_proof = self
-                    .stark_prover
-                    .agg_prover
-                    .wrap_proof(stark_proof, metadata)?;
-                attempt += 1;
-            }
-        };
-
+        // Internal sanity (SDK tests only): the input proof must verify against
+        // the recursive-aggregation vk before we hand it to the root prover.
+        // Tracegen normally succeeds without wrapping, so this is the proof the
+        // root prover consumes; if a wrap does occur, root prove itself rejects
+        // a bad wrapped proof. (The post-tracegen height-match invariant now
+        // lives in `RootProver::prove_with_wrap_retry`.)
         #[cfg(test)]
         {
-            for ((air_idx, air_ctx), expected_height) in root_ctx
-                .per_trace
-                .iter()
-                .zip(self.root_prover.0.get_trace_heights().unwrap())
-            {
-                assert_eq!(
-                    air_ctx.height(),
-                    expected_height,
-                    "height mismatch at {air_idx}"
-                )
-            }
             let agg_vk = self
                 .stark_prover
                 .agg_prover
@@ -114,8 +89,12 @@ where
             crate::GenericSdk::<E, VB>::verify_proof(agg_vk, baseline, &stark_proof)?;
         }
 
-        let root_proof = self.root_prover.prove_from_ctx(root_ctx)?;
-        Ok(root_proof)
+        const MAX_ROOT_TRACEGEN_RETRIES: usize = 8;
+        let root_prover = Arc::clone(&self.root_prover);
+        let agg_prover = &self.stark_prover.agg_prover;
+        root_prover.prove_with_wrap_retry(stark_proof, MAX_ROOT_TRACEGEN_RETRIES, |p| {
+            agg_prover.wrap_proof(p, metadata)
+        })
     }
 
     pub fn prove_unwrapped(

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -119,6 +119,62 @@ impl RootProver {
             .in_scope(|| info_span!("root").in_scope(|| self.0.root_prove_from_ctx::<E>(ctx)))?;
         Ok(proof)
     }
+
+    /// Prove the root layer for `stark_proof`, retrying with `wrap` when the
+    /// root verifier's tracegen can't fit the input.
+    ///
+    /// The root verifier is a fixed-shape circuit (its expected trace heights
+    /// are fixed at keygen), so `generate_proving_ctx` returns `None` when the
+    /// input proof's heights don't fit. On each `None`, `wrap` is applied to
+    /// grow the proof toward the canonical (root-ready) shape, up to
+    /// `max_retries` times, before failing.
+    ///
+    /// `wrap` is supplied by the caller because *how* a proof is wrapped (and
+    /// any layer bookkeeping) is caller-specific: the in-process [`EvmProver`]
+    /// delegates to [`AggProver::wrap_proof`]; a distributed prover that holds
+    /// only the recursive prover can call `agg_prove` with
+    /// [`ChildVkKind::RecursiveSelf`] on it directly.
+    ///
+    /// [`EvmProver`]: crate::prover::EvmProver
+    /// [`AggProver::wrap_proof`]: crate::prover::AggProver::wrap_proof
+    /// [`ChildVkKind::RecursiveSelf`]: openvm_continuations::prover::ChildVkKind::RecursiveSelf
+    pub fn prove_with_wrap_retry(
+        &self,
+        mut stark_proof: VmStarkProof,
+        max_retries: usize,
+        mut wrap: impl FnMut(VmStarkProof) -> Result<VmStarkProof>,
+    ) -> Result<Proof<RootSC>> {
+        let mut attempt = 0usize;
+        let ctx = loop {
+            if let Some(ctx) = self.generate_proving_ctx(stark_proof.clone()) {
+                break ctx;
+            }
+            if attempt >= max_retries {
+                return Err(eyre::eyre!(
+                    "root tracegen returned None after {max_retries} retries"
+                ));
+            }
+            stark_proof = wrap(stark_proof)?;
+            attempt += 1;
+        };
+
+        // Internal sanity (SDK tests only): a successful tracegen must land at
+        // exactly the root verifier's fixed, expected trace heights.
+        #[cfg(test)]
+        for ((air_idx, air_ctx), expected_height) in ctx
+            .per_trace
+            .iter()
+            .zip(self.0.get_trace_heights().unwrap())
+        {
+            assert_eq!(
+                air_ctx.height(),
+                expected_height,
+                "height mismatch at {air_idx}"
+            );
+        }
+
+        self.prove_from_ctx(ctx)
+    }
 }
 
 pub fn compute_root_proof_heights(

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -120,7 +120,7 @@ impl RootProver {
         Ok(proof)
     }
 
-    pub fn prove_with_wrap_retry(
+    pub fn wrap_and_prove(
         &self,
         mut stark_proof: VmStarkProof,
         max_retries: usize,

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -120,24 +120,6 @@ impl RootProver {
         Ok(proof)
     }
 
-    /// Prove the root layer for `stark_proof`, retrying with `wrap` when the
-    /// root verifier's tracegen can't fit the input.
-    ///
-    /// The root verifier is a fixed-shape circuit (its expected trace heights
-    /// are fixed at keygen), so `generate_proving_ctx` returns `None` when the
-    /// input proof's heights don't fit. On each `None`, `wrap` is applied to
-    /// grow the proof toward the canonical (root-ready) shape, up to
-    /// `max_retries` times, before failing.
-    ///
-    /// `wrap` is supplied by the caller because *how* a proof is wrapped (and
-    /// any layer bookkeeping) is caller-specific: the in-process [`EvmProver`]
-    /// delegates to [`AggProver::wrap_proof`]; a distributed prover that holds
-    /// only the recursive prover can call `agg_prove` with
-    /// [`ChildVkKind::RecursiveSelf`] on it directly.
-    ///
-    /// [`EvmProver`]: crate::prover::EvmProver
-    /// [`AggProver::wrap_proof`]: crate::prover::AggProver::wrap_proof
-    /// [`ChildVkKind::RecursiveSelf`]: openvm_continuations::prover::ChildVkKind::RecursiveSelf
     pub fn prove_with_wrap_retry(
         &self,
         mut stark_proof: VmStarkProof,

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -120,7 +120,7 @@ impl RootProver {
         Ok(proof)
     }
 
-    pub fn wrap_and_prove(
+    pub fn prove(
         &self,
         mut stark_proof: VmStarkProof,
         max_retries: usize,

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -272,7 +272,7 @@ fn test_sdk_fibonacci() -> Result<()> {
     #[cfg(not(feature = "evm-verify"))]
     {
         let mut evm_prover = sdk.evm_prover(app_exe)?;
-        let proof = evm_prover.prove_unwrapped(stdin, &[])?;
+        let proof = evm_prover.root_prove(stdin, &[])?;
         let vk = evm_prover.root_prover.0.get_vk();
         let engine = RootE::new(vk.inner.params.clone());
         engine.verify(&vk, &proof)?;
@@ -302,7 +302,7 @@ fn test_verify_stark_deferral() -> Result<()> {
     let vs_exe = vs_sdk.convert_to_exe(vs_elf)?;
 
     let mut evm_prover = vs_sdk.evm_prover(vs_exe)?;
-    let vs_proof = evm_prover.prove_unwrapped(vs_stdin, &[def_input])?;
+    let vs_proof = evm_prover.root_prove(vs_stdin, &[def_input])?;
 
     let vk = evm_prover.root_prover.0.get_vk();
     let engine = RootE::new(vk.inner.params.clone());
@@ -452,7 +452,7 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
     stdin.write(&n);
 
     let mut evm_prover = sdk.evm_prover(app_exe)?;
-    let proof = evm_prover.prove_unwrapped(stdin, &[])?;
+    let proof = evm_prover.root_prove(stdin, &[])?;
 
     // ---- Step 3: Verify the final result ----
     let vk = evm_prover.root_prover.0.get_vk();
@@ -654,7 +654,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
             let mut stdin = StdIn::default();
             stdin.write(&n);
 
-            let root_proof = evm_prover.prove_unwrapped(stdin, &[])?;
+            let root_proof = evm_prover.root_prove(stdin, &[])?;
             let root_vk_arc = root_prover.0.get_vk();
             let root_vk = root_vk_arc.as_ref().clone();
 

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -272,7 +272,7 @@ fn test_sdk_fibonacci() -> Result<()> {
     #[cfg(not(feature = "evm-verify"))]
     {
         let mut evm_prover = sdk.evm_prover(app_exe)?;
-        let proof = evm_prover.root_prove(stdin, &[])?;
+        let proof = evm_prover.prove_root(stdin, &[])?;
         let vk = evm_prover.root_prover.0.get_vk();
         let engine = RootE::new(vk.inner.params.clone());
         engine.verify(&vk, &proof)?;
@@ -302,7 +302,7 @@ fn test_verify_stark_deferral() -> Result<()> {
     let vs_exe = vs_sdk.convert_to_exe(vs_elf)?;
 
     let mut evm_prover = vs_sdk.evm_prover(vs_exe)?;
-    let vs_proof = evm_prover.root_prove(vs_stdin, &[def_input])?;
+    let vs_proof = evm_prover.prove_root(vs_stdin, &[def_input])?;
 
     let vk = evm_prover.root_prover.0.get_vk();
     let engine = RootE::new(vk.inner.params.clone());
@@ -452,7 +452,7 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
     stdin.write(&n);
 
     let mut evm_prover = sdk.evm_prover(app_exe)?;
-    let proof = evm_prover.root_prove(stdin, &[])?;
+    let proof = evm_prover.prove_root(stdin, &[])?;
 
     // ---- Step 3: Verify the final result ----
     let vk = evm_prover.root_prover.0.get_vk();
@@ -654,7 +654,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
             let mut stdin = StdIn::default();
             stdin.write(&n);
 
-            let root_proof = evm_prover.root_prove(stdin, &[])?;
+            let root_proof = evm_prover.prove_root(stdin, &[])?;
             let root_vk_arc = root_prover.0.get_vk();
             let root_vk = root_vk_arc.as_ref().clone();
 


### PR DESCRIPTION
- rename `prove_unwrapped` to `root_prove`
- move the looping logic to root prover