### PR TITLE
fix(v2-rc.2): size GPU Poseidon2 scratch per segment

### DIFF
--- a/crates/circuits/primitives/cuda/include/primitives/shared_buffer.cuh
+++ b/crates/circuits/primitives/cuda/include/primitives/shared_buffer.cuh
@@ -18,7 +18,10 @@ template <typename T> struct SharedBuffer {
     __device__ void push(T value) {
         uint32_t idx = atomicAdd(this->idx, 1);
         assert(idx < capacity && "SharedBuffer overflow");
-        data[idx] = value;
+        // Host checks idx > capacity.
+        if (idx < capacity) {
+            data[idx] = value;
+        }
     }
 };
 

--- a/crates/circuits/primitives/cuda/include/primitives/shared_buffer.cuh
+++ b/crates/circuits/primitives/cuda/include/primitives/shared_buffer.cuh
@@ -18,7 +18,8 @@ template <typename T> struct SharedBuffer {
     __device__ void push(T value) {
         uint32_t idx = atomicAdd(this->idx, 1);
         assert(idx < capacity && "SharedBuffer overflow");
-        // Host checks idx > capacity.
+        // On overflow, skip the write to avoid corrupting memory; the counter
+        // still advances, so the host sees a final count > capacity and panics.
         if (idx < capacity) {
             data[idx] = value;
         }

--- a/crates/vm/src/arch/testing/memory/cuda.rs
+++ b/crates/vm/src/arch/testing/memory/cuda.rs
@@ -51,7 +51,6 @@ impl DeviceMemoryTester {
         let range_bus = range_checker.cpu_chip.as_ref().unwrap().bus();
         let sbox_regs = 1;
         let poseidon2_periphery = Arc::new(Poseidon2PeripheryChipGPU::new(
-            1 << 20, // probably enough for our tests
             sbox_regs,
             device_ctx.clone(),
         ));

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -96,6 +96,7 @@ impl<RA> Chip<RA, GpuBackend> for BoundaryChipGPU {
             DeviceMatrix::<F>::with_capacity_on(trace_height, self.trace_width(), &self.device_ctx);
         trace.buffer().fill_zero_on(&self.device_ctx).unwrap();
         let mem_ptrs = self.initial_leaves.to_device_on(&self.device_ctx).unwrap();
+        let poseidon2_records = self.poseidon2_buffer.records();
         unsafe {
             persistent_boundary_tracegen(
                 trace.buffer(),
@@ -104,7 +105,7 @@ impl<RA> Chip<RA, GpuBackend> for BoundaryChipGPU {
                 &mem_ptrs,
                 self.records.as_ref().unwrap(),
                 num_records,
-                &self.poseidon2_buffer.buffer,
+                &poseidon2_records,
                 &self.poseidon2_buffer.idx,
                 self.device_ctx.stream.as_raw(),
             )

--- a/crates/vm/src/system/cuda/extensions.rs
+++ b/crates/vm/src/system/cuda/extensions.rs
@@ -17,9 +17,7 @@ use openvm_cuda_backend::{BabyBearPoseidon2GpuEngine, GpuBackend};
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 use p3_baby_bear::BabyBear;
 
-use super::{
-    phantom::PhantomChipGPU, Poseidon2PeripheryChipGPU, SystemChipInventoryGPU, DIGEST_WIDTH,
-};
+use super::{phantom::PhantomChipGPU, Poseidon2PeripheryChipGPU, SystemChipInventoryGPU};
 
 /// A utility method to get the `VariableRangeCheckerChipGPU` from [ChipInventory].
 /// Note, `VariableRangeCheckerChipGPU` always will always exist in the inventory.
@@ -97,9 +95,6 @@ impl VmBuilder<BabyBearPoseidon2GpuEngine> for SystemGpuBuilder {
         inventory.next_air::<VariableRangeCheckerAir>()?;
         inventory.add_periphery_chip(range_checker.clone());
 
-        let max_buffer_size = (config.segmentation_limits.max_trace_height as usize)
-            .next_power_of_two() * 2 // seems like a reliable estimate
-            * (DIGEST_WIDTH * 2); // size of one record
         assert_eq!(inventory.chips().len(), POSEIDON2_INSERTION_IDX);
         let sbox_registers = if config.max_constraint_degree >= 7 {
             0
@@ -117,7 +112,6 @@ impl VmBuilder<BabyBearPoseidon2GpuEngine> for SystemGpuBuilder {
                 .bus
         };
         let hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(
-            max_buffer_size,
             sbox_registers,
             device_ctx.clone(),
         ));

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -26,6 +26,7 @@ pub struct MemoryInventoryGPU {
     pub device_ctx: GpuDeviceCtx,
     pub boundary: BoundaryChipGPU,
     pub merkle_tree: MemoryMerkleTree,
+    pub hasher_chip: Arc<Poseidon2PeripheryChipGPU>,
     pub initial_memory: Vec<DeviceBuffer<u8>>,
     pub merkle_records: Option<DeviceBuffer<u32>>,
     #[cfg(feature = "metrics")]
@@ -65,6 +66,7 @@ impl MemoryInventoryGPU {
             device_ctx: device_ctx.clone(),
             boundary: BoundaryChipGPU::new(hasher_chip.shared_buffer(), device_ctx.clone()),
             merkle_tree: MemoryMerkleTree::new(config.clone(), hasher_chip.clone(), device_ctx),
+            hasher_chip,
             initial_memory: Vec::new(),
             merkle_records: None,
             #[cfg(feature = "metrics")]
@@ -161,6 +163,7 @@ impl MemoryInventoryGPU {
             }
 
             self.boundary.finalize_records::<DIGEST_WIDTH>(Vec::new());
+            self.prepare_poseidon2_records(0, unpadded_merkle_height);
             mem.tracing_info("merkle update");
             self.merkle_tree.finalize();
             self.merkle_tree.update_with_touched_blocks(
@@ -268,6 +271,7 @@ impl MemoryInventoryGPU {
                 self.unpadded_merkle_height = unpadded_merkle_height;
             }
 
+            self.prepare_poseidon2_records(out_num_records, unpadded_merkle_height);
             mem.tracing_info("merkle update");
             self.merkle_tree.finalize();
             self.merkle_tree.update_with_touched_blocks(
@@ -285,6 +289,14 @@ impl MemoryInventoryGPU {
         self.initial_memory = Vec::new();
         mem.emit_metrics();
         ret
+    }
+
+    fn prepare_poseidon2_records(&self, boundary_records: usize, merkle_height: usize) {
+        let num_records = boundary_records
+            .checked_mul(2)
+            .and_then(|n| n.checked_add(merkle_height))
+            .expect("Poseidon2 records count overflow");
+        self.hasher_chip.prepare_records(num_records);
     }
 }
 
@@ -339,24 +351,11 @@ mod tests {
         );
         let expected_root = cpu_merkle_tree.root();
 
-        let max_buffer_size = (mem_config
-            .addr_spaces
-            .iter()
-            .map(|ashc| ashc.num_cells * 2 + mem_config.memory_dimensions().overall_height())
-            .sum::<usize>()
-            * 2)
-        .next_power_of_two()
-            * 2
-            * DIGEST_WIDTH;
         let device_ctx = GpuDeviceCtx {
             device_id: get_device().unwrap() as u32,
             stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
         };
-        let hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(
-            max_buffer_size,
-            1,
-            device_ctx.clone(),
-        ));
+        let hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(1, device_ctx.clone()));
         let mut inventory =
             MemoryInventoryGPU::new(mem_config.clone(), hasher_chip, device_ctx.clone());
         inventory.set_initial_memory(&memory.memory);
@@ -422,24 +421,11 @@ mod tests {
         );
         let expected_root = cpu_merkle_tree.root();
 
-        let max_buffer_size = (mem_config
-            .addr_spaces
-            .iter()
-            .map(|ashc| ashc.num_cells * 2 + mem_config.memory_dimensions().overall_height())
-            .sum::<usize>()
-            * 2)
-        .next_power_of_two()
-            * 2
-            * DIGEST_WIDTH;
         let device_ctx = GpuDeviceCtx {
             device_id: get_device().unwrap() as u32,
             stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
         };
-        let hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(
-            max_buffer_size,
-            1,
-            device_ctx.clone(),
-        ));
+        let hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(1, device_ctx.clone()));
         let mut inventory =
             MemoryInventoryGPU::new(mem_config.clone(), hasher_chip, device_ctx.clone());
         inventory.set_initial_memory(&memory.memory);

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -176,6 +176,7 @@ pub mod merkle_tree {
         )?;
         let tmp_storage = DeviceBuffer::<u8>::with_capacity_on(need_tmp_storage_bytes, device_ctx);
         let actual_heights = actual_heights.to_device_on(device_ctx).unwrap();
+        let poseidon2_records = hasher_buffer.records();
         CudaError::from_result(_update_merkle_tree(
             num_leaves,
             touched_blocks.as_mut_ptr(),
@@ -191,10 +192,10 @@ pub mod merkle_tree {
             top_roots.as_mut_ptr() as *mut u32,
             zero_hash.as_ptr() as *mut u32,
             actual_heights.as_ptr(),
-            hasher_buffer.buffer.as_mut_raw_ptr(),
+            poseidon2_records.as_mut_raw_ptr(),
             hasher_buffer.idx.as_mut_ptr(),
             // Length in F elements; the CUDA side converts to record count.
-            hasher_buffer.buffer.len(),
+            poseidon2_records.len(),
             device_ctx.stream.as_raw(),
         ))
     }

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -509,20 +509,14 @@ mod tests {
             stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
         };
         let gpu_hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(
-            (mem_config
-                .addr_spaces
-                .iter()
-                .map(|ashc| ashc.num_cells * 2 + mem_config.memory_dimensions().overall_height())
-                .sum::<usize>()
-                * 2)
-            .next_power_of_two()
-                * 2
-                * DIGEST_WIDTH, // max_buffer_size
             1, // sbox_regs
             device_ctx.clone(),
         ));
-        let mut gpu_merkle_tree =
-            MemoryMerkleTree::new(mem_config.clone(), gpu_hasher_chip, device_ctx.clone());
+        let mut gpu_merkle_tree = MemoryMerkleTree::new(
+            mem_config.clone(),
+            gpu_hasher_chip.clone(),
+            device_ctx.clone(),
+        );
         let mem_slices = initial_memory
             .memory
             .get_memory()
@@ -623,11 +617,9 @@ mod tests {
             .to_device_on(&gpu_merkle_tree.device_ctx)
             .unwrap();
 
-        gpu_merkle_tree.update_with_touched_blocks(
-            gpu_merkle_tree.calculate_unpadded_height(&touched_blocks),
-            &d_touched_blocks,
-            false,
-        );
+        let unpadded_height = gpu_merkle_tree.calculate_unpadded_height(&touched_blocks);
+        gpu_hasher_chip.prepare_records(unpadded_height);
+        gpu_merkle_tree.update_with_touched_blocks(unpadded_height, &d_touched_blocks, false);
 
         assert_eq!(
             cpu_merkle_tree.root(),

--- a/crates/vm/src/system/cuda/poseidon2.rs
+++ b/crates/vm/src/system/cuda/poseidon2.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "metrics")]
 use std::sync::atomic::AtomicUsize;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use openvm_circuit::{
     primitives::Chip, system::poseidon2::columns::Poseidon2PeripheryCols,
@@ -19,35 +19,60 @@ use crate::cuda_abi::poseidon2;
 
 #[derive(Clone)]
 pub struct SharedBuffer<T> {
-    pub buffer: Arc<DeviceBuffer<T>>,
+    buffer: Arc<Mutex<Option<Arc<DeviceBuffer<T>>>>>,
     pub idx: Arc<DeviceBuffer<u32>>,
+}
+
+impl<T> SharedBuffer<T> {
+    pub fn records(&self) -> Arc<DeviceBuffer<T>> {
+        let records = self.buffer.lock().unwrap();
+        records
+            .clone()
+            .expect("Poseidon2 records buffer must be prepared before tracegen")
+    }
 }
 
 pub struct Poseidon2ChipGPU<const SBOX_REGISTERS: usize> {
     pub device_ctx: GpuDeviceCtx,
-    pub records: Arc<DeviceBuffer<F>>,
+    pub records: Arc<Mutex<Option<Arc<DeviceBuffer<F>>>>>,
     pub idx: Arc<DeviceBuffer<u32>>,
     #[cfg(feature = "metrics")]
     pub(crate) current_trace_height: Arc<AtomicUsize>,
 }
 
 impl<const SBOX_REGISTERS: usize> Poseidon2ChipGPU<SBOX_REGISTERS> {
-    /// Creates a new Poseidon2 chip with a device buffer of `max_buffer_size` field elements.
-    /// Each Poseidon2 record occupies `POSEIDON2_WIDTH` (16) field elements, so the buffer
-    /// can hold `max_buffer_size / POSEIDON2_WIDTH` records.
-    pub fn new(max_buffer_size: usize, device_ctx: GpuDeviceCtx) -> Self {
+    pub fn new(device_ctx: GpuDeviceCtx) -> Self {
         let idx = Arc::new(DeviceBuffer::<u32>::with_capacity_on(1, &device_ctx));
         idx.fill_zero_on(&device_ctx).unwrap();
         Self {
             device_ctx: device_ctx.clone(),
-            records: Arc::new(DeviceBuffer::<F>::with_capacity_on(
-                max_buffer_size,
-                &device_ctx,
-            )),
+            records: Arc::new(Mutex::new(None)),
             idx,
             #[cfg(feature = "metrics")]
             current_trace_height: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    /// Prepare an exact one-segment scratch buffer for Poseidon2 records.
+    ///
+    /// Each Poseidon2 record occupies `POSEIDON2_WIDTH` field elements.
+    pub fn prepare_records(&self, num_records: usize) {
+        self.idx.fill_zero_on(&self.device_ctx).unwrap();
+        let mut records = self.records.lock().unwrap();
+        assert!(
+            records.is_none(),
+            "Poseidon2 records buffer already prepared"
+        );
+        if num_records == 0 {
+            return;
+        }
+        let num_elements = num_records
+            .checked_mul(POSEIDON2_WIDTH)
+            .expect("Poseidon2 records buffer size overflow");
+        records.replace(Arc::new(DeviceBuffer::<F>::with_capacity_on(
+            num_elements,
+            &self.device_ctx,
+        )));
     }
 
     pub fn shared_buffer(&self) -> SharedBuffer<F> {
@@ -64,8 +89,19 @@ impl<const SBOX_REGISTERS: usize> Poseidon2ChipGPU<SBOX_REGISTERS> {
 
 impl<RA, const SBOX_REGISTERS: usize> Chip<RA, GpuBackend> for Poseidon2ChipGPU<SBOX_REGISTERS> {
     fn generate_proving_ctx(&self, _: RA) -> AirProvingContext<GpuBackend> {
+        let Some(records) = self.records.lock().unwrap().take() else {
+            self.idx.fill_zero_on(&self.device_ctx).unwrap();
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        };
+        debug_assert_eq!(records.len() % POSEIDON2_WIDTH, 0);
+        let capacity_records = records.len() / POSEIDON2_WIDTH;
         let mut num_records = self.idx.to_host_on(&self.device_ctx).unwrap()[0] as usize;
+        assert!(
+            num_records <= capacity_records,
+            "Poseidon2 records buffer overflow: pushed {num_records} records into capacity {capacity_records}"
+        );
         if num_records == 0 {
+            self.idx.fill_zero_on(&self.device_ctx).unwrap();
             return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
         }
         let counts = DeviceBuffer::<u32>::with_capacity_on(num_records, &self.device_ctx);
@@ -76,7 +112,7 @@ impl<RA, const SBOX_REGISTERS: usize> Chip<RA, GpuBackend> for Poseidon2ChipGPU<
             let d_num_records = [num_records].to_device_on(&self.device_ctx).unwrap();
             let mut temp_bytes = 0;
             poseidon2::deduplicate_records_get_temp_bytes(
-                &self.records,
+                &records,
                 &counts,
                 num_records,
                 &d_num_records,
@@ -90,7 +126,7 @@ impl<RA, const SBOX_REGISTERS: usize> Chip<RA, GpuBackend> for Poseidon2ChipGPU<
                 DeviceBuffer::<u8>::with_capacity_on(temp_bytes, &self.device_ctx)
             };
             poseidon2::deduplicate_records(
-                &self.records,
+                &records,
                 &counts,
                 &dedup_records,
                 &dedup_counts,
@@ -107,6 +143,8 @@ impl<RA, const SBOX_REGISTERS: usize> Chip<RA, GpuBackend> for Poseidon2ChipGPU<
                 .first()
                 .unwrap();
         }
+        drop(records);
+        drop(counts);
         #[cfg(feature = "metrics")]
         self.current_trace_height
             .store(num_records, std::sync::atomic::Ordering::Relaxed);
@@ -142,11 +180,18 @@ pub enum Poseidon2PeripheryChipGPU {
 }
 
 impl Poseidon2PeripheryChipGPU {
-    pub fn new(max_buffer_size: usize, sbox_registers: usize, device_ctx: GpuDeviceCtx) -> Self {
+    pub fn new(sbox_registers: usize, device_ctx: GpuDeviceCtx) -> Self {
         match sbox_registers {
-            0 => Self::Register0(Poseidon2ChipGPU::new(max_buffer_size, device_ctx)),
-            1 => Self::Register1(Poseidon2ChipGPU::new(max_buffer_size, device_ctx)),
+            0 => Self::Register0(Poseidon2ChipGPU::new(device_ctx)),
+            1 => Self::Register1(Poseidon2ChipGPU::new(device_ctx)),
             _ => panic!("Invalid number of sbox registers: {sbox_registers}"),
+        }
+    }
+
+    pub fn prepare_records(&self, num_records: usize) {
+        match self {
+            Self::Register0(chip) => chip.prepare_records(num_records),
+            Self::Register1(chip) => chip.prepare_records(num_records),
         }
     }
 


### PR DESCRIPTION
## Summary
- Allocate the system Poseidon2 GPU record scratch buffer per segment from exact memory tracegen counts instead of `max_trace_height`.
- Drop the scratch buffer before Poseidon2 trace allocation and guard release builds against OOB writes.
- Save GPU memory by decoupling this scratch allocation from `max_segment_length` for memory-bound segments.

## Memory Impact
With `max_segment_length = 2^24`, the standalone reth benchmarks on block `23992138`, `g7e.2xlarge`, `prove-stark` show the sampled whole-process GPU peak dropping by 1.40 GB while keeping the same 85 memory-triggered segments:

| Run | Commit | Segments | Peak GPU memory (`nvidia-smi`) |
| --- | --- | ---: | ---: |
| [Before](https://github.com/axiom-crypto/openvm-eth/actions/runs/27349752147) | `d519aa6` | 85 | 17.30 GB |
| [After](https://github.com/axiom-crypto/openvm-eth/actions/runs/27349786356) | `d3a30b6` | 85 | 15.90 GB |
| Savings | | | -1.40 GB |

The same runs show the expected drop in OpenVM tracked GPU allocation peaks from removing the persistent `max_trace_height`-sized Poseidon2 scratch buffer:

| Module | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `generate mem proving ctxs` | 7.09 GB | 5.20 GB | -1.89 GB |
| `set initial memory` | 6.87 GB | 4.87 GB | -2.00 GB |
| `prover.rs_code_matrix` | 10.69 GB | 8.70 GB | -1.99 GB |
| `prover.batch_constraints.before_round0` | 16.51 GB | 14.51 GB | -2.00 GB |

A separate [openvm-eth comparison run 27329017888](https://github.com/axiom-crypto/openvm-eth/actions/runs/27329017888) with a smaller resolved segment length also shows the affected tracked peaks dropping:

| Module | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `generate mem proving ctxs` | 5.59 GB | 5.20 GB | -0.39 GB |
| `set initial memory` | 5.37 GB | 4.87 GB | -0.50 GB |
| `prover.rs_code_matrix` | 9.19 GB | 8.70 GB | -0.49 GB |
| `prover.batch_constraints.before_round0` | 14.70 GB | 14.25 GB | -0.45 GB |

## Testing
- `cargo build --profile fast -p openvm-circuit`
- `cargo +nightly fmt --all -- --check`
- `cargo build --profile fast -p openvm-circuit --features cuda`
- `cargo nextest run --cargo-profile=fast -p openvm-circuit --features cuda test_empty_touched_memory_uses_full_chunk_values test_touched_memory_updates_memory_address_space test_cuda_merkle_tree_cpu_gpu_root_equivalence`

Resolves int-8291