### PR TITLE
fix(v2-rc.2): reject public values writes past configured limit

### DIFF
--- a/crates/vm/src/system/memory/merkle/public_values.rs
+++ b/crates/vm/src/system/memory/merkle/public_values.rs
@@ -277,4 +277,18 @@ mod tests {
             .verify(&hasher, memory_dimensions, final_memory_root)
             .unwrap();
     }
+
+    #[test]
+    #[should_panic]
+    fn test_public_values_write_beyond_num_public_values_is_rejected() {
+        let num_public_values = 16;
+        let mut addr_spaces_config = MemoryConfig::empty_address_space_configs(4);
+        addr_spaces_config[PUBLIC_VALUES_AS as usize].num_cells = num_public_values;
+        let mut memory = GuestMemory {
+            memory: AddressMap::new(addr_spaces_config),
+        };
+        unsafe {
+            memory.write::<u8, 4>(PUBLIC_VALUES_AS, num_public_values as u32 + 4, [0, 0, 0, 1]);
+        }
+    }
 }

--- a/crates/vm/src/system/memory/online/memmap.rs
+++ b/crates/vm/src/system/memory/online/memmap.rs
@@ -13,13 +13,17 @@ pub const CELL_STRIDE: usize = 1;
 #[derive(Debug)]
 pub struct MmapMemory {
     mmap: MmapMut,
+    size: usize,
 }
 
 impl Clone for MmapMemory {
     fn clone(&self) -> Self {
         let mut new_mmap = MmapMut::map_anon(self.mmap.len()).unwrap();
         new_mmap.copy_from_slice(&self.mmap);
-        Self { mmap: new_mmap }
+        Self {
+            mmap: new_mmap,
+            size: self.size,
+        }
     }
 }
 
@@ -60,24 +64,25 @@ impl MmapMemory {
 impl LinearMemory for MmapMemory {
     /// Create a new MmapMemory with the given `size` in bytes.
     /// We round `size` up to be a multiple of the mmap page size (4kb by default).
-    fn new(mut size: usize) -> Self {
-        size = size.div_ceil(PAGE_SIZE) * PAGE_SIZE;
+    fn new(size: usize) -> Self {
+        let mmap_size = size.div_ceil(PAGE_SIZE) * PAGE_SIZE;
         // anonymous mapping means pages are zero-initialized on first use
         Self {
-            mmap: MmapMut::map_anon(size).unwrap(),
+            mmap: MmapMut::map_anon(mmap_size).unwrap(),
+            size,
         }
     }
 
     fn size(&self) -> usize {
-        self.mmap.len()
+        self.size
     }
 
     fn as_slice(&self) -> &[u8] {
-        &self.mmap
+        &self.mmap[..self.size]
     }
 
     fn as_mut_slice(&mut self) -> &mut [u8] {
-        &mut self.mmap
+        &mut self.mmap[..self.size]
     }
 
     #[cfg(target_os = "linux")]

--- a/extensions/rv32im/circuit/src/load_sign_extend/aot.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/aot.rs
@@ -1,6 +1,9 @@
-use openvm_circuit::arch::{
-    aot::common::{convert_x86_reg, Width, RISCV_TO_X86_OVERRIDE_MAP},
-    AotError, AotExecutor, AotMeteredExecutor, SystemConfig,
+use openvm_circuit::{
+    arch::{
+        aot::common::{convert_x86_reg, Width, RISCV_TO_X86_OVERRIDE_MAP},
+        AotError, AotExecutor, AotMeteredExecutor, SystemConfig,
+    },
+    system::memory::merkle::public_values::PUBLIC_VALUES_AS,
 };
 use openvm_instructions::{
     instruction::Instruction,
@@ -28,7 +31,9 @@ where
                 .local_opcode_idx(Rv32LoadStoreOpcode::CLASS_OFFSET),
         );
         match local_opcode {
-            Rv32LoadStoreOpcode::LOADB | Rv32LoadStoreOpcode::LOADH => true,
+            Rv32LoadStoreOpcode::LOADB | Rv32LoadStoreOpcode::LOADH => {
+                inst.e.as_canonical_u32() != PUBLIC_VALUES_AS
+            }
             _ => unreachable!(),
         }
     }

--- a/extensions/rv32im/circuit/src/loadstore/aot.rs
+++ b/extensions/rv32im/circuit/src/loadstore/aot.rs
@@ -1,6 +1,9 @@
-use openvm_circuit::arch::{
-    aot::common::{convert_x86_reg, Width, RISCV_TO_X86_OVERRIDE_MAP},
-    AotError, AotExecutor, AotMeteredExecutor, SystemConfig,
+use openvm_circuit::{
+    arch::{
+        aot::common::{convert_x86_reg, Width, RISCV_TO_X86_OVERRIDE_MAP},
+        AotError, AotExecutor, AotMeteredExecutor, SystemConfig,
+    },
+    system::memory::merkle::public_values::PUBLIC_VALUES_AS,
 };
 use openvm_instructions::{
     instruction::Instruction,
@@ -18,8 +21,8 @@ impl<F, A, const NUM_CELLS: usize> AotExecutor<F> for LoadStoreExecutor<A, NUM_C
 where
     F: PrimeField32,
 {
-    fn is_aot_supported(&self, inst: &openvm_instructions::instruction::Instruction<F>) -> bool {
-        true
+    fn is_aot_supported(&self, inst: &Instruction<F>) -> bool {
+        is_aot_supported_impl(inst)
     }
 
     fn generate_x86_asm(&self, inst: &Instruction<F>, pc: u32) -> Result<String, AotError> {
@@ -31,7 +34,7 @@ where
     F: PrimeField32,
 {
     fn is_aot_metered_supported(&self, inst: &Instruction<F>) -> bool {
-        true
+        is_aot_supported_impl(inst)
     }
     fn generate_x86_metered_asm(
         &self,
@@ -57,10 +60,8 @@ where
     }
 }
 
-fn is_aot_supported_impl<F: PrimeField32>(
-    _inst: &openvm_instructions::instruction::Instruction<F>,
-) -> bool {
-    true
+fn is_aot_supported_impl<F: PrimeField32>(inst: &Instruction<F>) -> bool {
+    inst.e.as_canonical_u32() != PUBLIC_VALUES_AS
 }
 
 // arguments of `update_boundary_merkle_heights_f`:

--- a/extensions/rv32im/tests/src/lib.rs
+++ b/extensions/rv32im/tests/src/lib.rs
@@ -208,9 +208,31 @@ mod tests {
         Ok(())
     }
 
+    // AOT reaches the same check via fallback, but the panic aborts across its C ABI callback.
+    #[cfg_attr(feature = "aot", ignore)]
+    #[test]
+    #[should_panic(expected = "Memory access out of bounds")]
+    fn test_reveal_beyond_num_public_values_errors() {
+        let config = test_rv32im_config();
+        let elf = build_example_program_at_path(get_programs_dir!(), "reveal", &config).unwrap();
+        let exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv32ITranspilerExtension)
+                .with_extension(Rv32MTranspilerExtension)
+                .with_extension(Rv32IoTranspilerExtension),
+        )
+        .unwrap();
+
+        let executor = VmExecutor::new(config).unwrap();
+        let instance = executor.instance(&exe).unwrap();
+        instance.execute(vec![], None).unwrap();
+    }
+
     #[test]
     fn test_reveal() -> Result<()> {
-        let config = test_rv32im_config();
+        let mut config = test_rv32im_config();
+        config.rv32i.system = config.rv32i.system.with_public_values(64);
         let elf = build_example_program_at_path(get_programs_dir!(), "reveal", &config)?;
         let exe = VmExe::from_elf(
             elf,


### PR DESCRIPTION
Fixes INT-5507
Fixes INT-5505
Fixes INT-5506

## Summary

Reject public-values accesses past the configured `num_public_values` limit instead of silently accepting them.

Neither execution path rejected this before. Non-AOT now gets the expected bounds check because `MmapMemory` exposes the configured size through `size()` and slices, rather than the page-rounded mmap length. AOT public-values load/store instructions now fall back to the normal executor path, so they use the same checked memory access instead of emitting unchecked x86 memory access.

## Tests

Adds regressions for direct public-values memory writes and `reveal` past the configured public-values limit.