### PR TITLE
chore(v2-rc.2): remove obsolete system profiling flag

### DIFF
--- a/benchmarks/prove/src/lib.rs
+++ b/benchmarks/prove/src/lib.rs
@@ -35,10 +35,6 @@ pub struct BenchmarkCli {
     #[arg(long)]
     pub evm: bool,
 
-    /// Whether to execute with additional profiling metric collection
-    #[arg(long)]
-    pub profiling: bool,
-
     /// Halo2 wrapper circuit degree `k` (for e2e proving). If omitted, auto-tuned.
     #[arg(long)]
     pub halo2_wrapper_k: Option<usize>,
@@ -60,7 +56,6 @@ impl BenchmarkCli {
             .as_mut()
             .segmentation_limits
             .set_max_trace_height(max_height);
-        vm_config.as_mut().profiling = self.profiling;
     }
 
     pub fn run(&self, mut vm_config: SdkVmConfig, elf: Elf, stdin: StdIn) -> eyre::Result<()> {

--- a/ci/scripts/bench.py
+++ b/ci/scripts/bench.py
@@ -42,8 +42,6 @@ def run_cargo_command(
         command.extend(["--evm"])
     if kzg_params_dir is not None:
         command.extend(["--kzg-params-dir", kzg_params_dir])
-    if "perf-metrics" in feature_flags:
-        command.extend(["--profiling"])
 
     output_path_old = None
     # Create the output directory if it doesn't exist

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -223,9 +223,6 @@ pub struct SystemConfig {
     /// Public values are stored in a special address space.
     /// `num_public_values` indicates the number of allowed addresses in that address space.
     pub num_public_values: usize,
-    /// Whether to collect detailed profiling metrics.
-    /// **Warning**: this slows down the runtime.
-    pub profiling: bool,
     /// Segmentation limits
     /// This field is skipped in serde as it's only used in execution and
     /// not needed after any serialize/deserialize.
@@ -249,7 +246,6 @@ impl SystemConfig {
             max_constraint_degree,
             memory_config,
             num_public_values,
-            profiling: false,
             segmentation_limits: SegmentationLimits::default(),
         }
     }
@@ -271,16 +267,6 @@ impl SystemConfig {
     pub fn with_max_segment_len(mut self, max_segment_len: usize) -> Self {
         self.segmentation_limits
             .set_max_trace_height(max_segment_len as u32);
-        self
-    }
-
-    pub fn with_profiling(mut self) -> Self {
-        self.profiling = true;
-        self
-    }
-
-    pub fn without_profiling(mut self) -> Self {
-        self.profiling = false;
         self
     }
 

--- a/docs/crates/benchmarks.md
+++ b/docs/crates/benchmarks.md
@@ -136,10 +136,10 @@ for more detailed profiling we generate special flamegraphs that visualize VM-sp
 The benchmark must be run with special configuration so that additional metrics are collected for profiling. Note that the additional metric collection will slow down the benchmark. To run a benchmark with the additional profiling, run the following command:
 
 ```bash
-OUTPUT_PATH="metrics.json" GUEST_SYMBOLS_PATH="guest.syms" cargo run --release --bin <benchmark_name> --features perf-metrics -- --profiling
+OUTPUT_PATH="metrics.json" GUEST_SYMBOLS_PATH="guest.syms" cargo run --release --bin <benchmark_name> --features perf-metrics
 ```
 
-The `perf-metrics` feature tells the VM to run with additional metric collection. The `--profiling` CLI argument tells the script to build the guest program with `profile=profiling` so that the guest program is compiled without stripping debug symbols. When the `perf-metrics` feature is enabled, the `GUEST_SYMBOLS_PATH` environment variable must be set to the file path where function symbols of the guest program will be exported. Those symbols are then used to annotate the flamegraph with function names.
+The `perf-metrics` feature tells the VM to run with additional metric collection. When the `perf-metrics` feature is enabled, the `GUEST_SYMBOLS_PATH` environment variable must be set to the file path where function symbols of the guest program will be exported. Those symbols are then used to annotate the flamegraph with function names.
 
 After the collected metrics are written to `$OUTPUT_PATH`, these flamegraphs can be generated if you have [inferno-flamegraph](https://crates.io/crates/inferno) installed. Install via
 


### PR DESCRIPTION
## Summary
- Remove the obsolete `SystemConfig::profiling` runtime flag and its helper methods.
- Remove the benchmark `--profiling` argument that only set that dead config field.
- Update benchmark CI/docs to rely on the `perf-metrics` feature for VM perf metrics.

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo build --profile fast -p openvm-circuit`
- `cargo check --profile fast -p openvm-benchmarks-prove --lib`
- `cargo check --profile fast -p openvm-benchmarks-prove --lib --features perf-metrics`

Resolves INT-4522