### PR TITLE
fix(v2-rc.2): use max trace height from config in tests

### DIFF
--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -46,7 +46,7 @@ impl Default for SegmentationLimits {
 
 impl SegmentationLimits {
     pub fn new(max_trace_height: u32, max_memory: usize, max_interactions: usize) -> Self {
-        debug_assert!(
+        assert!(
             max_trace_height.is_power_of_two(),
             "max_trace_height should be a power of two"
         );
@@ -58,7 +58,7 @@ impl SegmentationLimits {
     }
 
     pub fn with_max_trace_height(mut self, max_trace_height: u32) -> Self {
-        debug_assert!(
+        assert!(
             max_trace_height.is_power_of_two(),
             "max_trace_height should be a power of two"
         );
@@ -67,11 +67,15 @@ impl SegmentationLimits {
     }
 
     pub fn set_max_trace_height(&mut self, max_trace_height: u32) {
-        debug_assert!(
+        assert!(
             max_trace_height.is_power_of_two(),
             "max_trace_height should be a power of two"
         );
         self.max_trace_height = max_trace_height;
+    }
+
+    pub fn max_trace_height_bits(&self) -> usize {
+        self.max_trace_height.ilog2() as usize
     }
 }
 

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -85,7 +85,8 @@ where
     while config.as_ref().max_constraint_degree > (1 << log_blowup) + 1 {
         log_blowup += 1;
     }
-    let params = SystemParams::new_for_testing(22); // max log_trace_height=22
+    let params =
+        SystemParams::new_for_testing(config.as_ref().segmentation_limits.max_trace_height_bits());
     let debug = std::env::var("OPENVM_SKIP_DEBUG") != Result::Ok(String::from("1"));
     let (final_memory, _) = air_test_impl::<TestStarkEngine, VB>(
         params,


### PR DESCRIPTION
## Summary

- Derive test `SystemParams` from `segmentation_limits.max_trace_height` instead of the old hard-coded `2^22` cap.
- Keep the max trace-height power-of-two invariant at the `SegmentationLimits` config boundary.
- Verified the SHA2 CUDA guest-lib proving tests pass with the new `2^24` default.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo build --profile fast -p openvm-circuit`
- `CUDA_OPT_LEVEL=3 OPENVM_SKIP_DEBUG=1 cargo nextest run --cargo-profile=fast --features=cuda --run-ignored=all --no-tests=pass --test-threads=1` in `guest-libs/sha2` on `ayush-gpu`