### PR TITLE
fix: remove unused fields in rvstate

### DIFF
--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -40,18 +40,12 @@ typedef struct RvState {
    * InstretSuspender. Replace this flattened field with a generated suspender
    * state layout once non-instret suspenders need runtime state. */
   uint64_t target_instret;
-  uint32_t reservation_addr;
-  uint8_t reservation_valid;
   /* Field name preserved for ABI compatibility with rvr's RvState.
    * Semantically stores an OpenVmExecStatus value. */
   uint8_t has_exited;
   uint8_t exit_code;
-  uint8_t _pad0;
-  uint32_t brk;
-  uint32_t start_brk;
   uint8_t* memory;
   struct Tracer* tracer;
-  uint32_t csrs[4096];
 } RvState;
 
 static __attribute__((always_inline)) inline void rv_set_status(

--- a/crates/rvr/rvr-state/src/lib.rs
+++ b/crates/rvr/rvr-state/src/lib.rs
@@ -11,7 +11,7 @@ mod tracer;
 mod xlen;
 
 pub use memory::{GuardedMemory, MemoryError, GUARD_SIZE};
-pub use state::{ExecutionStatus, Rv64State, RvState, NUM_CSRS, NUM_REGS_I};
+pub use state::{ExecutionStatus, Rv64State, RvState, NUM_REGS_I};
 pub use suspender::{InstretSuspender, SuspenderState};
 pub use tracer::TracerState;
 pub use xlen::{Rv64, Xlen};

--- a/crates/rvr/rvr-state/src/state.rs
+++ b/crates/rvr/rvr-state/src/state.rs
@@ -13,9 +13,6 @@ pub enum ExecutionStatus {
     Trapped = 3,
 }
 
-/// Number of CSRs.
-pub const NUM_CSRS: usize = 4096;
-
 /// Number of registers for I extension (32 GPRs).
 pub const NUM_REGS_I: usize = 32;
 
@@ -46,40 +43,17 @@ pub struct RvState<
     /// Suspender state (ZST when S = (), real struct when suspending).
     pub suspender: S,
 
-    // TODO(follow-up): dead field — remove once rv32 no longer required.
-    /// Reservation address for LR/SC.
-    pub reservation_addr: u32,
-
-    // TODO(follow-up): dead field — remove once rv32 no longer required.
-    /// Reservation valid flag for LR/SC.
-    pub reservation_valid: u8,
-
     /// Legacy execution-status byte.
     pub has_exited: u8,
 
     /// Legacy result payload byte.
     pub exit_code: u8,
 
-    /// Alignment padding.
-    _pad0: u8,
-
-    // TODO(follow-up): dead field — remove once rv32 no longer required.
-    /// Current heap break.
-    pub brk: u32,
-
-    // TODO(follow-up): dead field — remove once rv32 no longer required.
-    /// Initial heap break.
-    pub start_brk: u32,
-
     /// Guest memory pointer (cold).
     pub memory: *mut u8,
 
     /// Tracer state (ZST when T = (), real struct when tracing).
     pub tracer: T,
-
-    // TODO(follow-up): dead field — remove once rv32 no longer required.
-    /// Control and status registers (cold).
-    pub csrs: [u32; NUM_CSRS],
 }
 
 impl<X: Xlen, T: TracerState, S: SuspenderState, const NUM_REGS: usize> RvState<X, T, S, NUM_REGS> {
@@ -99,16 +73,10 @@ impl<X: Xlen, T: TracerState, S: SuspenderState, const NUM_REGS: usize> Default
             pc: X::from_u64(0),
             instret: 0,
             suspender: S::default(),
-            reservation_addr: 0,
-            reservation_valid: 0,
             has_exited: 0,
             exit_code: 0,
-            _pad0: 0,
-            brk: 0,
-            start_brk: 0,
             memory: std::ptr::null_mut(),
             tracer: T::default(),
-            csrs: [0; NUM_CSRS],
         }
     }
 }


### PR DESCRIPTION
removes unused `reservation_addr`, `reservation_valid`, `brk`, `start_brk`, `csrs` fields from RvState.