### PR TITLE
fix(v2-rc.2): derive segmentation limits from prover params

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -1,0 +1,13 @@
+name: "Setup sccache"
+description: "Configures sccache startup timeout and delegates to mozilla-actions/sccache-action."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure sccache
+      shell: bash
+      run: |
+        printf 'server_startup_timeout_ms = 30000\n' > "$RUNNER_TEMP/sccache.conf"
+        echo "SCCACHE_CONF=$RUNNER_TEMP/sccache.conf" >> "$GITHUB_ENV"
+
+    - uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -66,7 +66,7 @@ jobs:
       # - name: Run async concurrency test
       #   working-directory: benchmarks/prove
       #   run: |
-      #     CUDA_OPT_LEVEL=3 MAX_CONCURRENCY=5 cargo run --bin async_regex --features cuda,async -- --max-segment-length $((1<<20)) --segment-max-memory 16106127360
+      #     CUDA_OPT_LEVEL=3 MAX_CONCURRENCY=5 cargo run --bin async_regex --features cuda,async -- --segment-max-memory 16106127360
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -104,7 +104,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -17,11 +17,6 @@ on:
         required: false
         description: Memory allocator to use (mimalloc or jemalloc)
         default: jemalloc
-      max_segment_length:
-        type: number
-        required: false
-        description: Max segment length for continuations (default 2^20 = 1048576)
-        default: 1048576
       e2e_bench:
         type: boolean
         required: false
@@ -55,11 +50,6 @@ on:
         required: false
         description: Memory allocator to use (mimalloc or jemalloc)
         default: jemalloc
-      max_segment_length:
-        type: number
-        required: false
-        description: Max segment length for continuations (default 2^20 = 1048576)
-        default: 1048576
       e2e_bench:
         type: boolean
         required: false
@@ -187,9 +177,8 @@ jobs:
       - name: Set input args
         run: |
           FEATURES="--features $FEATURE_FLAGS"
-          MAX_SEGMENT_LENGTH="--max_segment_length ${{ inputs.max_segment_length }}"
           OUTPUT_PATH="--output_path $(pwd)/$METRIC_PATH"
-          echo "INPUT_ARGS=${FEATURES} ${MAX_SEGMENT_LENGTH} ${OUTPUT_PATH} ${INPUT_ARGS}" >> $GITHUB_ENV
+          echo "INPUT_ARGS=${FEATURES} ${OUTPUT_PATH} ${INPUT_ARGS}" >> $GITHUB_ENV
           echo "VPMM_PAGES=2048" >> $GITHUB_ENV # 4GB
 
       ##########################################################################

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -169,6 +169,10 @@ jobs:
           ref: ${{ env.CURRENT_SHA }}
           repository: ${{ env.REPO }}
       - uses: dtolnay/rust-toolchain@stable
+      - name: Configure sccache
+        run: |
+          printf 'server_startup_timeout_ms = 30000\n' > "$RUNNER_TEMP/sccache.conf"
+          echo "SCCACHE_CONF=$RUNNER_TEMP/sccache.conf" >> "$GITHUB_ENV"
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Build openvm-prof

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -106,8 +106,7 @@ jobs:
                 features: $features,
                 id: $id,
                 instance_type: .instance_type,
-                memory_allocator: .memory_allocator,
-                max_segment_length: (.max_segment_length // 1048576)
+                memory_allocator: .memory_allocator
               }
             ]
           ' ./ci/benchmark-config.json)
@@ -128,7 +127,6 @@ jobs:
       benchmark_id: ${{ matrix.benchmark_run.id }}
       instance_type: ${{ matrix.benchmark_run.instance_type }}
       memory_allocator: ${{ matrix.benchmark_run.memory_allocator }}
-      max_segment_length: ${{ matrix.benchmark_run.max_segment_length }}
       e2e_bench: ${{ matrix.benchmark_run.e2e_bench || false }}
       features: ${{ matrix.benchmark_run.features }}
       is_merge_queue: ${{ inputs.is_merge_queue || false }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
       - name: Verify GPU setup

--- a/.github/workflows/continuations.yml
+++ b/.github/workflows/continuations.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - name: Verify GPU setup
         run: |
           nvidia-smi

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -72,7 +72,7 @@ jobs:
           exit 0
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -66,7 +66,7 @@ jobs:
           exit 0
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -43,7 +43,7 @@ jobs:
           skip: Cargo.lock,./docs/vocs/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,./audits/*.pdf
           ignore_words_file: .codespellignore
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -112,7 +112,7 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -143,7 +143,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -40,7 +40,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
       - name: Verify GPU setup

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: Configure sccache
+        run: |
+          printf 'server_startup_timeout_ms = 30000\n' > "$RUNNER_TEMP/sccache.conf"
+          echo "SCCACHE_CONF=$RUNNER_TEMP/sccache.conf" >> "$GITHUB_ENV"
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cache Cargo dependencies

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
 
       - name: Set feature flags
         run: |

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
       - name: Verify GPU setup

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -36,7 +36,7 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/static-verifier.yml
+++ b/.github/workflows/static-verifier.yml
@@ -32,7 +32,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -31,6 +31,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: Configure sccache
+        run: |
+          printf 'server_startup_timeout_ms = 30000\n' > "$RUNNER_TEMP/sccache.conf"
+          echo "SCCACHE_CONF=$RUNNER_TEMP/sccache.conf" >> "$GITHUB_ENV"
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cache Cargo dependencies

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -39,7 +39,7 @@ jobs:
           rustup component remove clippy || true
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/benchmarks/prove/src/bin/keccak_par.rs
+++ b/benchmarks/prove/src/bin/keccak_par.rs
@@ -18,10 +18,7 @@ struct ParallelCli {
 }
 
 fn main() -> eyre::Result<()> {
-    let ParallelCli {
-        inner: _,
-        concurrency,
-    } = ParallelCli::parse();
+    let ParallelCli { inner, concurrency } = ParallelCli::parse();
     let vm_config = SdkVmConfig::builder()
         .system(Default::default())
         .rv32i(Default::default())
@@ -39,6 +36,10 @@ fn main() -> eyre::Result<()> {
     let num_keccak_iters: u64 = 1 << 12;
     let mut stdin = StdIn::default();
     stdin.write(&num_keccak_iters);
+
+    if !inner.app_only {
+        return inner.run(vm_config, elf, stdin);
+    }
 
     let exe = VmExe::from_elf(elf, vm_config.transpiler())?;
     let app_config = AppConfig::new(vm_config, default_bench_app_params());

--- a/benchmarks/prove/src/bin/keccak_par.rs
+++ b/benchmarks/prove/src/bin/keccak_par.rs
@@ -18,8 +18,11 @@ struct ParallelCli {
 }
 
 fn main() -> eyre::Result<()> {
-    let par_args = ParallelCli::parse();
-    let mut vm_config = SdkVmConfig::builder()
+    let ParallelCli {
+        inner: _,
+        concurrency,
+    } = ParallelCli::parse();
+    let vm_config = SdkVmConfig::builder()
         .system(Default::default())
         .rv32i(Default::default())
         .rv32m(Default::default())
@@ -27,14 +30,11 @@ fn main() -> eyre::Result<()> {
         .keccak(Default::default())
         .build()
         .optimize();
-    let args = par_args.inner;
-    let concurrency = par_args.concurrency;
 
     let elf = Elf::decode(
         include_bytes!("../../../guest/keccak256_iter/elf/openvm-keccak256-iter-program.elf"),
         MEM_SIZE as u32,
     )?;
-    args.apply_config(&mut vm_config);
 
     let num_keccak_iters: u64 = 1 << 12;
     let mut stdin = StdIn::default();

--- a/benchmarks/prove/src/lib.rs
+++ b/benchmarks/prove/src/lib.rs
@@ -17,16 +17,11 @@ use openvm_stark_sdk::{
 use openvm_transpiler::{elf::Elf, FromElf};
 use openvm_verify_stark_host::{verify_vm_stark_proof_decoded, vk::VmStarkVerifyingKey};
 
-pub const DEFAULT_MAX_SEGMENT: u32 = 1 << 20;
 pub const DEFAULT_LOG_STACKED_HEIGHT: usize = 21;
 
 #[derive(Parser, Debug)]
 #[command(allow_external_subcommands = true)]
 pub struct BenchmarkCli {
-    /// Max trace height per chip in segment for continuations
-    #[arg(long, alias = "max_segment_length")]
-    pub max_segment_length: Option<u32>,
-
     /// Only runs the app proof
     #[arg(long)]
     pub app_only: bool,
@@ -45,21 +40,7 @@ pub struct BenchmarkCli {
 }
 
 impl BenchmarkCli {
-    /// Applies CLI-specified segmentation config to the VM config.
-    /// The max trace height is always rounded up to the next power of two.
-    pub fn apply_config(&self, vm_config: &mut SdkVmConfig) {
-        let max_height = self
-            .max_segment_length
-            .unwrap_or(DEFAULT_MAX_SEGMENT)
-            .next_power_of_two();
-        vm_config
-            .as_mut()
-            .segmentation_limits
-            .set_max_trace_height(max_height);
-    }
-
-    pub fn run(&self, mut vm_config: SdkVmConfig, elf: Elf, stdin: StdIn) -> eyre::Result<()> {
-        self.apply_config(&mut vm_config);
+    pub fn run(&self, vm_config: SdkVmConfig, elf: Elf, stdin: StdIn) -> eyre::Result<()> {
         if self.app_only {
             run_default_app_benchmark(vm_config, elf, stdin)
         } else if self.evm {

--- a/ci/benchmark-config.example.json
+++ b/ci/benchmark-config.example.json
@@ -82,8 +82,7 @@
           "app_log_blowup": 2,
           "leaf_log_blowup": 2,
           "root_log_blowup": 2,
-          "internal_log_blowup": 2,
-          "max_segment_length": 1048476
+          "internal_log_blowup": 2
         }
       ]
     },

--- a/ci/benchmark-config.json
+++ b/ci/benchmark-config.json
@@ -80,8 +80,7 @@
       "run_params": [
         {
           "instance_type": "g6.2xlarge",
-          "memory_allocator": "jemalloc",
-          "max_segment_length": 4194304
+          "memory_allocator": "jemalloc"
         }
       ]
     },
@@ -141,8 +140,7 @@
       "run_params": [
         {
           "instance_type": "g6e.4xlarge",
-          "memory_allocator": "jemalloc",
-          "max_segment_length": 4194304
+          "memory_allocator": "jemalloc"
         }
       ]
     }

--- a/ci/scripts/bench.py
+++ b/ci/scripts/bench.py
@@ -7,7 +7,6 @@ import subprocess
 def run_cargo_command(
     bin_name,
     feature_flags,
-    max_segment_length,
     output_path,
     app_only,
     evm,
@@ -34,8 +33,6 @@ def run_cargo_command(
         "--",
     ]
 
-    if max_segment_length is not None:
-        command.extend(["--max_segment_length", max_segment_length])
     if app_only:
         command.extend(["--app-only"])
     if evm:
@@ -71,9 +68,6 @@ def bench():
     parser = argparse.ArgumentParser()
     parser.add_argument("bench_name", type=str, help="Name of the benchmark to run")
     parser.add_argument(
-        "--max_segment_length", type=str, help="Max segment length for continuations"
-    )
-    parser.add_argument(
         "--kzg-params-dir",
         type=str,
         help="Directory containing KZG trusted setup files",
@@ -105,7 +99,6 @@ def bench():
     run_cargo_command(
         args.bench_name,
         feature_flags,
-        args.max_segment_length,
         args.output_path,
         args.app_only,
         args.evm,

--- a/ci/scripts/utils.sh
+++ b/ci/scripts/utils.sh
@@ -12,21 +12,18 @@ add_metadata_and_flamegraphs() {
     inputs=$(echo "$matrix" | jq -r --arg id "$id" '.[] |
       select(.id == $id) |
       {
-        max_segment_length: .max_segment_length,
         instance_type: .instance_type,
         memory_allocator: .memory_allocator
       }')
     echo "inputs: $inputs"
 
     if [ ! -z "$inputs" ]; then
-      max_segment_length=$(echo "$inputs" | jq -r '.max_segment_length')
       instance_type=$(echo "$inputs" | jq -r '.instance_type')
       memory_allocator=$(echo "$inputs" | jq -r '.memory_allocator')
 
       # Call add_metadata for each file with its corresponding data
       add_metadata \
         "$md_path" \
-        "$max_segment_length" \
         "$instance_type" \
         "$memory_allocator" \
         "$commit_url" \
@@ -36,11 +33,10 @@ add_metadata_and_flamegraphs() {
 
 add_metadata() {
     local result_path="$1"
-    local max_segment_length="$2"
-    local instance_type="$3"
-    local memory_allocator="$4"
-    local commit_url="$5"
-    local benchmark_workflow_url="$6"
+    local instance_type="$2"
+    local memory_allocator="$3"
+    local commit_url="$4"
+    local benchmark_workflow_url="$5"
     # vars: $FLAMEGRAPHS, $S3_PUBLIC_PATH_BASE, $S3_PUBLIC_URL_BASE, $CURRENT_SHA
 
     # Upload memory chart SVG to S3 and update md link
@@ -68,8 +64,6 @@ add_metadata() {
         echo "" >> $result_path
     fi
     echo "Commit: ${commit_url}" >> $result_path
-    echo "" >> $result_path
-    echo "Max Segment Length: $max_segment_length" >> $result_path
     echo "" >> $result_path
     echo "Instance Type: $instance_type" >> $result_path
     echo "" >> $result_path

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -390,10 +390,7 @@ fn load_required_root_pk() -> Result<RootProvingKey> {
 impl From<SegmentationArgs> for SegmentationLimits {
     fn from(args: SegmentationArgs) -> Self {
         SegmentationLimits::default()
-            .with_max_trace_height(
-                1u32.checked_shl(args.segment_max_height_bits as u32)
-                    .expect("segment_max_height_bits too large"),
-            )
+            .with_max_trace_height_bits(args.segment_max_height_bits)
             .with_max_memory(args.segment_max_memory)
     }
 }

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -3,9 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use clap::Parser;
 use eyre::{eyre, Result};
 use openvm_circuit::arch::{
-    execution_mode::metered::segment_ctx::{
-        SegmentationLimits, DEFAULT_MAX_MEMORY, DEFAULT_MAX_TRACE_HEIGHT_BITS,
-    },
+    execution_mode::metered::segment_ctx::{SegmentationLimits, DEFAULT_MAX_MEMORY},
     instructions::exe::VmExe,
 };
 use openvm_continuations::CommitBytes;
@@ -122,15 +120,6 @@ enum ProveSubCommand {
 
 #[derive(Clone, Copy, Parser)]
 pub struct SegmentationArgs {
-    /// Trace height threshold, in bits, across all chips for triggering segmentation for
-    /// continuations in the app proof. These thresholds are not exceeded except when they are too
-    /// small.
-    #[arg(
-        long,
-        default_value_t = DEFAULT_MAX_TRACE_HEIGHT_BITS,
-        help_heading = "OpenVM Options"
-    )]
-    pub segment_max_height_bits: u8,
     /// Total memory in bytes used across all chips for triggering segmentation for continuations
     /// in the app proof. These thresholds are not exceeded except when they are too small.
     #[arg(
@@ -389,8 +378,6 @@ fn load_required_root_pk() -> Result<RootProvingKey> {
 
 impl From<SegmentationArgs> for SegmentationLimits {
     fn from(args: SegmentationArgs) -> Self {
-        SegmentationLimits::default()
-            .with_max_trace_height_bits(args.segment_max_height_bits)
-            .with_max_memory(args.segment_max_memory)
+        SegmentationLimits::default().with_max_memory(args.segment_max_memory)
     }
 }

--- a/crates/cli/src/commands/prove.rs
+++ b/crates/cli/src/commands/prove.rs
@@ -3,8 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use clap::Parser;
 use eyre::{eyre, Result};
 use openvm_circuit::arch::{
-    execution_mode::metered::segment_ctx::{SegmentationLimits, DEFAULT_MAX_MEMORY},
-    instructions::exe::VmExe,
+    execution_mode::metered::segment_ctx::DEFAULT_MAX_MEMORY, instructions::exe::VmExe,
 };
 use openvm_continuations::CommitBytes;
 #[cfg(feature = "evm-prove")]
@@ -307,7 +306,7 @@ fn configure_app_pk(app_pk: &mut AppProvingKey<SdkVmConfig>, segmentation_args: 
         .vm_config
         .system
         .config
-        .set_segmentation_limits((*segmentation_args).into());
+        .set_segmentation_max_memory(segmentation_args.segment_max_memory);
 }
 
 fn target_dir_from_cargo_args(cargo_args: &RunCargoArgs) -> Result<PathBuf> {
@@ -374,10 +373,4 @@ fn load_required_root_pk() -> Result<RootProvingKey> {
             root_pk_path.display()
         )
     })
-}
-
-impl From<SegmentationArgs> for SegmentationLimits {
-    fn from(args: SegmentationArgs) -> Self {
-        SegmentationLimits::default().with_max_memory(args.segment_max_memory)
-    }
 }

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -312,7 +312,7 @@ fn test_deferral_e2e() -> Result<()> {
     // =========================================================================
     // SECTION 1: Set up Rv32DeferralConfig, build ELF, set up deferral streams.
     // =========================================================================
-    let mut system = test_system_config().with_max_segment_len(1 << 20);
+    let mut system = test_system_config();
     system.memory_config.addr_spaces[DEFERRAL_AS as usize].num_cells = 1 << 25;
 
     let config = Rv32DeferralConfig {

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -85,7 +85,6 @@ cfg_if::cfg_if! {
     }
 }
 
-const LOG_MAX_TRACE_HEIGHT: usize = 20;
 const DEFAULT_MAX_NUM_PROOFS: usize = 4;
 
 pub(in crate::tests) fn app_system_params() -> SystemParams {
@@ -115,7 +114,7 @@ pub(in crate::tests) fn hook_system_params() -> SystemParams {
 pub(in crate::tests) fn test_rv32im_config() -> Rv32ImConfig {
     Rv32ImConfig {
         rv32i: Rv32IConfig {
-            system: test_system_config().with_max_segment_len(1 << LOG_MAX_TRACE_HEIGHT),
+            system: test_system_config(),
             ..Default::default()
         },
         ..Default::default()

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -264,15 +264,6 @@ impl SystemConfig {
         self
     }
 
-    pub fn with_max_segment_len(mut self, max_segment_len: usize) -> Self {
-        let max_segment_len: u32 = max_segment_len
-            .try_into()
-            .expect("max_segment_len must fit in u32");
-        self.segmentation_limits
-            .set_max_trace_height(max_segment_len);
-        self
-    }
-
     /// Returns the AIR ID of the memory boundary AIR. Panic if the boundary AIR is not enabled.
     pub fn memory_boundary_air_id(&self) -> usize {
         BOUNDARY_AIR_ID

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -265,8 +265,11 @@ impl SystemConfig {
     }
 
     pub fn with_max_segment_len(mut self, max_segment_len: usize) -> Self {
+        let max_segment_len: u32 = max_segment_len
+            .try_into()
+            .expect("max_segment_len must fit in u32");
         self.segmentation_limits
-            .set_max_trace_height(max_segment_len as u32);
+            .set_max_trace_height(max_segment_len);
         self
     }
 

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -16,7 +16,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use super::{AnyEnum, VmChipComplex, BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, PROGRAM_AIR_ID};
 use crate::{
     arch::{
-        execution_mode::metered::segment_ctx::SegmentationLimits, AirInventory, AirInventoryError,
+        execution_mode::metered::segment_ctx::DEFAULT_MAX_MEMORY, AirInventory, AirInventoryError,
         Arena, ChipInventoryError, ExecutorInventory, ExecutorInventoryError,
     },
     system::{
@@ -33,6 +33,10 @@ pub const DEFAULT_MAX_NUM_PUBLIC_VALUES: usize = 32;
 pub const POSEIDON2_WIDTH: usize = 16;
 /// Offset for address space indices. This is used to distinguish between different memory spaces.
 pub const ADDR_SPACE_OFFSET: u32 = 1;
+
+fn default_segmentation_max_memory() -> usize {
+    DEFAULT_MAX_MEMORY
+}
 /// Returns a Poseidon2 config for the VM.
 pub fn vm_poseidon2_config<F: Field>() -> Poseidon2Config<F> {
     Poseidon2Config::default()
@@ -223,12 +227,12 @@ pub struct SystemConfig {
     /// Public values are stored in a special address space.
     /// `num_public_values` indicates the number of allowed addresses in that address space.
     pub num_public_values: usize,
-    /// Segmentation limits
+    /// Max memory in bytes used across all chips for triggering segmentation.
     /// This field is skipped in serde as it's only used in execution and
     /// not needed after any serialize/deserialize.
-    #[serde(skip, default)]
+    #[serde(skip, default = "default_segmentation_max_memory")]
     #[getset(set = "pub")]
-    pub segmentation_limits: SegmentationLimits,
+    pub segmentation_max_memory: usize,
 }
 
 impl SystemConfig {
@@ -246,7 +250,7 @@ impl SystemConfig {
             max_constraint_degree,
             memory_config,
             num_public_values,
-            segmentation_limits: SegmentationLimits::default(),
+            segmentation_max_memory: DEFAULT_MAX_MEMORY,
         }
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -27,49 +27,56 @@ pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
     suspend_on_segment: bool,
 }
 
+pub struct MeteredCtxInputs<'a> {
+    pub constant_trace_heights: &'a [Option<usize>],
+    pub air_names: &'a [String],
+    pub widths: &'a [usize],
+    pub interactions: &'a [usize],
+    pub need_rot: &'a [bool],
+    pub max_trace_height_bits: u8,
+}
+
 impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
-    // Note[jpw]: prefer to use `build_metered_ctx` in `VmExecutor` or `VirtualMachine`.
+    // Note: prefer to use `build_metered_ctx` in `VmExecutor` or `VirtualMachine`.
     pub fn new(
-        constant_trace_heights: Vec<Option<usize>>,
-        air_names: Vec<String>,
-        widths: Vec<usize>,
-        interactions: Vec<usize>,
-        need_rot: Vec<bool>,
+        inputs: MeteredCtxInputs<'_>,
         config: &SystemConfig,
         memory_config: ProvingMemoryConfig,
     ) -> Self {
-        let (trace_heights, is_trace_height_constant): (Vec<u32>, Vec<bool>) =
-            constant_trace_heights
-                .iter()
-                .map(|&constant_height| {
-                    if let Some(height) = constant_height {
-                        (height as u32, true)
-                    } else {
-                        (0, false)
-                    }
-                })
-                .unzip();
+        let (trace_heights, is_trace_height_constant): (Vec<u32>, Vec<bool>) = inputs
+            .constant_trace_heights
+            .iter()
+            .map(|&constant_height| {
+                if let Some(height) = constant_height {
+                    (height as u32, true)
+                } else {
+                    (0, false)
+                }
+            })
+            .unzip();
 
         let segmentation_ctx = SegmentationCtx::new(
-            air_names,
-            widths,
-            interactions,
-            need_rot,
+            inputs.air_names.to_vec(),
+            inputs.widths.to_vec(),
+            inputs.interactions.to_vec(),
+            inputs.need_rot.to_vec(),
+            inputs.max_trace_height_bits,
             config.segmentation_limits.clone(),
             memory_config,
         );
-        let memory_ctx = MemoryCtx::new(config, segmentation_ctx.segment_check_insns);
+        let memory_ctx = MemoryCtx::new(config, segmentation_ctx.segment_check_insns());
 
         // Assert that the indices are correct
+        let air_names = segmentation_ctx.air_names();
         debug_assert!(
-            segmentation_ctx.air_names[BOUNDARY_AIR_ID].contains("Boundary"),
+            air_names[BOUNDARY_AIR_ID].contains("Boundary"),
             "air_name={}",
-            segmentation_ctx.air_names[BOUNDARY_AIR_ID]
+            air_names[BOUNDARY_AIR_ID]
         );
         debug_assert!(
-            segmentation_ctx.air_names[MERKLE_AIR_ID].contains("Merkle"),
+            air_names[MERKLE_AIR_ID].contains("Merkle"),
             "air_name={}",
-            segmentation_ctx.air_names[MERKLE_AIR_ID]
+            air_names[MERKLE_AIR_ID]
         );
         let mut ctx = Self {
             trace_heights,
@@ -87,36 +94,6 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         ctx
     }
 
-    /// This changes the frequency of segment checks. BE CAREFUL when you change this during
-    /// execution!
-    pub fn with_max_trace_height_bits(mut self, max_trace_height_bits: u8) -> Self {
-        self.segmentation_ctx
-            .set_max_trace_height_bits(max_trace_height_bits);
-        let max_trace_height = self.segmentation_ctx.limits.max_trace_height();
-        let max_check_freq = (max_trace_height / 2) as u64;
-        if max_check_freq < self.segmentation_ctx.segment_check_insns {
-            self = self.with_segment_check_insns(max_check_freq);
-        }
-        self
-    }
-
-    /// Sets max trace-height bits, capped by another log2 bound.
-    pub fn with_max_trace_height_bits_bound(
-        self,
-        max_trace_height_bits: u8,
-        max_trace_height_bits_bound: u8,
-    ) -> Self {
-        if max_trace_height_bits > max_trace_height_bits_bound {
-            tracing::warn!(
-                configured_max_trace_height_bits = max_trace_height_bits,
-                max_trace_height_bits_bound,
-                "configured max trace-height bits exceeds bound; using bounded value for segmentation"
-            );
-            return self.with_max_trace_height_bits(max_trace_height_bits_bound);
-        }
-        self.with_max_trace_height_bits(max_trace_height_bits)
-    }
-
     pub fn with_max_memory(mut self, max_memory: usize) -> Self {
         self.segmentation_ctx.set_max_memory(max_memory);
         self
@@ -124,20 +101,6 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     pub fn with_max_interactions(mut self, max_interactions: usize) -> Self {
         self.segmentation_ctx.set_max_interactions(max_interactions);
-        self
-    }
-
-    pub fn with_segment_check_insns(mut self, segment_check_insns: u64) -> Self {
-        self.segmentation_ctx.segment_check_insns = segment_check_insns;
-        self.segmentation_ctx.instrets_until_check = segment_check_insns;
-
-        // Update memory context with new segment check instructions
-        let page_indices_since_checkpoint_cap =
-            MemoryCtx::<PAGE_BITS>::calculate_checkpoint_capacity(segment_check_insns);
-
-        self.memory_ctx.page_indices_since_checkpoint =
-            vec![0; page_indices_since_checkpoint_cap].into_boxed_slice();
-        self.memory_ctx.page_indices_since_checkpoint_len = 0;
         self
     }
 
@@ -156,8 +119,9 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         if self.segmentation_ctx.instrets_until_check > 0 {
             return false;
         }
-        self.segmentation_ctx.instrets_until_check = self.segmentation_ctx.segment_check_insns;
-        self.segmentation_ctx.instret += self.segmentation_ctx.segment_check_insns;
+        let segment_check_insns = self.segmentation_ctx.segment_check_insns();
+        self.segmentation_ctx.instrets_until_check = segment_check_insns;
+        self.segmentation_ctx.instret += segment_check_insns;
 
         self.memory_ctx
             .lazy_update_boundary_heights(&mut self.trace_heights);
@@ -182,7 +146,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
                 let trace_heights_str = self
                     .trace_heights
                     .iter()
-                    .zip(self.segmentation_ctx.air_names.iter())
+                    .zip(self.segmentation_ctx.air_names().iter())
                     .filter(|(&height, _)| height > 0)
                     .map(|(&height, name)| format!("  {name} = {height}"))
                     .collect::<Vec<_>>()
@@ -214,10 +178,10 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         println!("{}", "-".repeat(80));
         for ((&width, &height), air_name) in self
             .segmentation_ctx
-            .widths
+            .widths()
             .iter()
             .zip_eq(self.trace_heights.iter())
-            .zip_eq(self.segmentation_ctx.air_names.iter())
+            .zip_eq(self.segmentation_ctx.air_names().iter())
         {
             println!("{:>10} {:>10} {:<30}", width, height, air_name.as_str());
         }

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -5,7 +5,7 @@ use openvm_stark_backend::memory_metering::ProvingMemoryConfig;
 
 use super::{
     memory_ctx::MemoryCtx,
-    segment_ctx::{Segment, SegmentationCtx},
+    segment_ctx::{Segment, SegmentationCtx, SegmentationLimits},
 };
 use crate::{
     arch::{
@@ -33,7 +33,7 @@ pub struct MeteredCtxInputs<'a> {
     pub widths: &'a [usize],
     pub interactions: &'a [usize],
     pub need_rot: &'a [bool],
-    pub max_trace_height_bits: u8,
+    pub segmentation_limits: SegmentationLimits,
 }
 
 impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
@@ -60,8 +60,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
             inputs.widths.to_vec(),
             inputs.interactions.to_vec(),
             inputs.need_rot.to_vec(),
-            inputs.max_trace_height_bits,
-            config.segmentation_limits.clone(),
+            inputs.segmentation_limits,
             memory_config,
         );
         let memory_ctx = MemoryCtx::new(config, segmentation_ctx.segment_check_insns());
@@ -96,11 +95,6 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     pub fn with_max_memory(mut self, max_memory: usize) -> Self {
         self.segmentation_ctx.set_max_memory(max_memory);
-        self
-    }
-
-    pub fn with_max_interactions(mut self, max_interactions: usize) -> Self {
-        self.segmentation_ctx.set_max_interactions(max_interactions);
         self
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -89,13 +89,32 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     /// This changes the frequency of segment checks. BE CAREFUL when you change this during
     /// execution!
-    pub fn with_max_trace_height(mut self, max_trace_height: u32) -> Self {
-        self.segmentation_ctx.set_max_trace_height(max_trace_height);
+    pub fn with_max_trace_height_bits(mut self, max_trace_height_bits: u8) -> Self {
+        self.segmentation_ctx
+            .set_max_trace_height_bits(max_trace_height_bits);
+        let max_trace_height = self.segmentation_ctx.limits.max_trace_height();
         let max_check_freq = (max_trace_height / 2) as u64;
         if max_check_freq < self.segmentation_ctx.segment_check_insns {
             self = self.with_segment_check_insns(max_check_freq);
         }
         self
+    }
+
+    /// Sets max trace-height bits, capped by another log2 bound.
+    pub fn with_max_trace_height_bits_bound(
+        self,
+        max_trace_height_bits: u8,
+        max_trace_height_bits_bound: u8,
+    ) -> Self {
+        if max_trace_height_bits > max_trace_height_bits_bound {
+            tracing::warn!(
+                configured_max_trace_height_bits = max_trace_height_bits,
+                max_trace_height_bits_bound,
+                "configured max trace-height bits exceeds bound; using bounded value for segmentation"
+            );
+            return self.with_max_trace_height_bits(max_trace_height_bits_bound);
+        }
+        self.with_max_trace_height_bits(max_trace_height_bits)
     }
 
     pub fn with_max_memory(mut self, max_memory: usize) -> Self {

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -124,21 +124,19 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
 
         let bitset_size = 1 << (merkle_height.saturating_sub(PAGE_BITS));
         let addr_space_size = (1 << memory_dimensions.addr_space_height) + 1;
-        let page_indices_since_checkpoint_cap =
-            Self::calculate_checkpoint_capacity(segment_check_insns);
+        let checkpoint_capacity = Self::calculate_checkpoint_capacity(segment_check_insns);
 
         Self {
             memory_dimensions,
             page_indices: BitSet::new(bitset_size),
             addr_space_access_count: vec![0; addr_space_size].into(),
-            page_indices_since_checkpoint: vec![0; page_indices_since_checkpoint_cap]
-                .into_boxed_slice(),
+            page_indices_since_checkpoint: vec![0; checkpoint_capacity].into_boxed_slice(),
             page_indices_since_checkpoint_len: 0,
         }
     }
 
     #[inline(always)]
-    pub(super) fn calculate_checkpoint_capacity(segment_check_insns: u64) -> usize {
+    fn calculate_checkpoint_capacity(segment_check_insns: u64) -> usize {
         segment_check_insns as usize * MAX_MEM_PAGE_OPS_PER_INSN
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -27,7 +27,7 @@ pub struct Segment {
 
 #[derive(Clone, Debug, WithSetters, Setters)]
 pub struct SegmentationLimits {
-    pub max_trace_height: u32,
+    pub max_trace_height_bits: u8,
     #[getset(set = "pub", set_with = "pub")]
     pub max_memory: usize,
     #[getset(set_with = "pub")]
@@ -37,7 +37,7 @@ pub struct SegmentationLimits {
 impl Default for SegmentationLimits {
     fn default() -> Self {
         Self {
-            max_trace_height: DEFAULT_MAX_TRACE_HEIGHT,
+            max_trace_height_bits: DEFAULT_MAX_TRACE_HEIGHT_BITS,
             max_memory: DEFAULT_MAX_MEMORY,
             max_interactions: DEFAULT_MAX_INTERACTIONS,
         }
@@ -45,25 +45,46 @@ impl Default for SegmentationLimits {
 }
 
 impl SegmentationLimits {
-    pub fn new(max_trace_height: u32, max_memory: usize, max_interactions: usize) -> Self {
+    pub fn new(max_trace_height_bits: u8, max_memory: usize, max_interactions: usize) -> Self {
         assert!(
-            max_trace_height.is_power_of_two(),
-            "max_trace_height should be a power of two"
+            max_trace_height_bits < u32::BITS as u8,
+            "max_trace_height_bits must be less than {}",
+            u32::BITS
         );
         Self {
-            max_trace_height,
+            max_trace_height_bits,
             max_memory,
             max_interactions,
         }
     }
 
-    pub fn with_max_trace_height(mut self, max_trace_height: u32) -> Self {
+    pub fn max_trace_height(&self) -> u32 {
+        1u32.checked_shl(u32::from(self.max_trace_height_bits))
+            .expect("max_trace_height_bits must fit in u32 trace height")
+    }
+
+    pub fn with_max_trace_height_bits(mut self, max_trace_height_bits: u8) -> Self {
         assert!(
-            max_trace_height.is_power_of_two(),
-            "max_trace_height should be a power of two"
+            max_trace_height_bits < u32::BITS as u8,
+            "max_trace_height_bits must be less than {}",
+            u32::BITS
         );
-        self.max_trace_height = max_trace_height;
+        self.max_trace_height_bits = max_trace_height_bits;
         self
+    }
+
+    pub fn with_max_trace_height(mut self, max_trace_height: u32) -> Self {
+        self.set_max_trace_height(max_trace_height);
+        self
+    }
+
+    pub fn set_max_trace_height_bits(&mut self, max_trace_height_bits: u8) {
+        assert!(
+            max_trace_height_bits < u32::BITS as u8,
+            "max_trace_height_bits must be less than {}",
+            u32::BITS
+        );
+        self.max_trace_height_bits = max_trace_height_bits;
     }
 
     pub fn set_max_trace_height(&mut self, max_trace_height: u32) {
@@ -71,11 +92,7 @@ impl SegmentationLimits {
             max_trace_height.is_power_of_two(),
             "max_trace_height should be a power of two"
         );
-        self.max_trace_height = max_trace_height;
-    }
-
-    pub fn max_trace_height_bits(&self) -> usize {
-        self.max_trace_height.ilog2() as usize
+        self.set_max_trace_height_bits(max_trace_height.ilog2() as u8);
     }
 }
 
@@ -177,8 +194,8 @@ impl SegmentationCtx {
         }
     }
 
-    pub fn set_max_trace_height(&mut self, max_trace_height: u32) {
-        self.limits.set_max_trace_height(max_trace_height);
+    pub fn set_max_trace_height_bits(&mut self, max_trace_height_bits: u8) {
+        self.limits.set_max_trace_height_bits(max_trace_height_bits);
     }
 
     pub fn set_max_memory(&mut self, max_memory: usize) {
@@ -385,13 +402,13 @@ impl SegmentationCtx {
         {
             // Only segment if the height is not constant and exceeds the maximum height after
             // padding
-            if !is_constant && padded_height > self.limits.max_trace_height {
+            if !is_constant && padded_height > self.limits.max_trace_height() {
                 let air_name = unsafe { self.air_names.get_unchecked(i) };
                 tracing::info!(
                     "overshoot: instret {:10} | height ({:8}) > max ({:8}) | chip {:3} ({}) ",
                     instret,
                     padded_height,
-                    self.limits.max_trace_height,
+                    self.limits.max_trace_height(),
                     i,
                     air_name,
                 );

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -13,8 +13,6 @@ use crate::utils::{add_one_or_zero, next_power_of_two_or_zero};
 
 pub const DEFAULT_SEGMENT_CHECK_INSNS: u64 = 1000;
 
-pub const DEFAULT_MAX_TRACE_HEIGHT_BITS: u8 = 24;
-pub const DEFAULT_MAX_TRACE_HEIGHT: u32 = 1 << DEFAULT_MAX_TRACE_HEIGHT_BITS;
 pub const DEFAULT_MAX_MEMORY: usize = 15 << 30; // 15GiB
 const DEFAULT_MAX_INTERACTIONS: usize = BabyBear::ORDER_U32 as usize;
 
@@ -27,7 +25,6 @@ pub struct Segment {
 
 #[derive(Clone, Debug, WithSetters, Setters)]
 pub struct SegmentationLimits {
-    pub max_trace_height_bits: u8,
     #[getset(set = "pub", set_with = "pub")]
     pub max_memory: usize,
     #[getset(set_with = "pub")]
@@ -37,7 +34,6 @@ pub struct SegmentationLimits {
 impl Default for SegmentationLimits {
     fn default() -> Self {
         Self {
-            max_trace_height_bits: DEFAULT_MAX_TRACE_HEIGHT_BITS,
             max_memory: DEFAULT_MAX_MEMORY,
             max_interactions: DEFAULT_MAX_INTERACTIONS,
         }
@@ -45,69 +41,72 @@ impl Default for SegmentationLimits {
 }
 
 impl SegmentationLimits {
-    pub fn new(max_trace_height_bits: u8, max_memory: usize, max_interactions: usize) -> Self {
-        assert!(
-            max_trace_height_bits < u32::BITS as u8,
-            "max_trace_height_bits must be less than {}",
-            u32::BITS
-        );
+    pub fn new(max_memory: usize, max_interactions: usize) -> Self {
         Self {
-            max_trace_height_bits,
             max_memory,
             max_interactions,
         }
     }
+}
 
-    pub fn max_trace_height(&self) -> u32 {
-        1u32.checked_shl(u32::from(self.max_trace_height_bits))
-            .expect("max_trace_height_bits must fit in u32 trace height")
-    }
+#[derive(Clone, Debug)]
+struct SegmentationParams {
+    air_names: Vec<String>,
+    widths: Vec<usize>,
+    interactions: Vec<usize>,
+    need_rot: Vec<bool>,
+    limits: SegmentationLimits,
+    memory_config: ProvingMemoryConfig,
+    max_trace_height: u32,
+    segment_check_insns: u64,
+}
 
-    pub fn with_max_trace_height_bits(mut self, max_trace_height_bits: u8) -> Self {
+impl SegmentationParams {
+    fn new(
+        air_names: Vec<String>,
+        widths: Vec<usize>,
+        interactions: Vec<usize>,
+        need_rot: Vec<bool>,
+        max_trace_height_bits: u8,
+        limits: SegmentationLimits,
+        memory_config: ProvingMemoryConfig,
+    ) -> Self {
+        assert_eq!(air_names.len(), widths.len());
+        assert_eq!(air_names.len(), interactions.len());
+        assert_eq!(air_names.len(), need_rot.len());
         assert!(
             max_trace_height_bits < u32::BITS as u8,
             "max_trace_height_bits must be less than {}",
             u32::BITS
         );
-        self.max_trace_height_bits = max_trace_height_bits;
-        self
-    }
 
-    pub fn with_max_trace_height(mut self, max_trace_height: u32) -> Self {
-        self.set_max_trace_height(max_trace_height);
-        self
-    }
-
-    pub fn set_max_trace_height_bits(&mut self, max_trace_height_bits: u8) {
+        let max_trace_height = 1u32
+            .checked_shl(u32::from(max_trace_height_bits))
+            .expect("max_trace_height_bits must fit in u32 trace height");
         assert!(
-            max_trace_height_bits < u32::BITS as u8,
-            "max_trace_height_bits must be less than {}",
-            u32::BITS
+            u64::from(max_trace_height) >= 2 * DEFAULT_SEGMENT_CHECK_INSNS,
+            "max_trace_height must be at least twice DEFAULT_SEGMENT_CHECK_INSNS"
         );
-        self.max_trace_height_bits = max_trace_height_bits;
-    }
 
-    pub fn set_max_trace_height(&mut self, max_trace_height: u32) {
-        assert!(
-            max_trace_height.is_power_of_two(),
-            "max_trace_height should be a power of two"
-        );
-        self.set_max_trace_height_bits(max_trace_height.ilog2() as u8);
+        Self {
+            air_names,
+            widths,
+            interactions,
+            need_rot,
+            limits,
+            memory_config,
+            max_trace_height,
+            segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
+        }
     }
 }
 
-#[derive(Clone, Debug, WithSetters)]
+#[derive(Clone, Debug)]
 pub struct SegmentationCtx {
     pub segments: Vec<Segment>,
-    pub(crate) air_names: Vec<String>,
-    pub(crate) widths: Vec<usize>,
-    interactions: Vec<usize>,
-    need_rot: Vec<bool>,
-    pub(crate) limits: SegmentationLimits,
-    pub(crate) memory_config: ProvingMemoryConfig,
+    params: SegmentationParams,
     pub instret: u64,
     pub instrets_until_check: u64,
-    pub(super) segment_check_insns: u64,
     /// Checkpoint of trace heights at last known state where all thresholds satisfied
     pub(crate) checkpoint_trace_heights: Vec<u32>,
     /// Instruction count at the checkpoint
@@ -170,40 +169,51 @@ impl SegmentationCtx {
         widths: Vec<usize>,
         interactions: Vec<usize>,
         need_rot: Vec<bool>,
+        max_trace_height_bits: u8,
         limits: SegmentationLimits,
         memory_config: ProvingMemoryConfig,
     ) -> Self {
-        assert_eq!(air_names.len(), widths.len());
-        assert_eq!(air_names.len(), interactions.len());
-        assert_eq!(air_names.len(), need_rot.len());
-
         let num_airs = air_names.len();
-        Self {
-            segments: Vec::new(),
+        let params = SegmentationParams::new(
             air_names,
             widths,
             interactions,
             need_rot,
+            max_trace_height_bits,
             limits,
             memory_config,
+        );
+        Self {
+            segments: Vec::new(),
+            instrets_until_check: params.segment_check_insns,
+            params,
             instret: 0,
-            instrets_until_check: DEFAULT_SEGMENT_CHECK_INSNS,
-            segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
             checkpoint_trace_heights: vec![0; num_airs],
             checkpoint_instret: 0,
         }
     }
 
-    pub fn set_max_trace_height_bits(&mut self, max_trace_height_bits: u8) {
-        self.limits.set_max_trace_height_bits(max_trace_height_bits);
+    #[inline(always)]
+    pub(crate) fn air_names(&self) -> &[String] {
+        &self.params.air_names
+    }
+
+    #[inline(always)]
+    pub(crate) fn widths(&self) -> &[usize] {
+        &self.params.widths
+    }
+
+    #[inline(always)]
+    pub(super) fn segment_check_insns(&self) -> u64 {
+        self.params.segment_check_insns
     }
 
     pub fn set_max_memory(&mut self, max_memory: usize) {
-        self.limits.max_memory = max_memory;
+        self.params.limits.max_memory = max_memory;
     }
 
     pub fn set_max_interactions(&mut self, max_interactions: usize) {
-        self.limits.max_interactions = max_interactions;
+        self.params.limits.max_interactions = max_interactions;
     }
 
     /// Calculate the maximum trace height and corresponding air name
@@ -214,7 +224,7 @@ impl SegmentationCtx {
             .enumerate()
             .map(|(i, &height)| (next_power_of_two_or_zero(height as usize) as u32, i))
             .max_by_key(|(height, _)| *height)
-            .map(|(height, idx)| (height, self.air_names[idx].as_str()))
+            .map(|(height, idx)| (height, self.params.air_names[idx].as_str()))
             .unwrap_or((0, "unknown"))
     }
 
@@ -230,7 +240,7 @@ impl SegmentationCtx {
         usize, /* main */
         usize, /* interaction */
     ) {
-        let estimate = self.memory_config.estimate(ProvingMemoryCounts::new(
+        let estimate = self.params.memory_config.estimate(ProvingMemoryCounts::new(
             main_cnt_with_rot,
             main_cnt_no_rot,
             interaction_cells,
@@ -243,16 +253,16 @@ impl SegmentationCtx {
     #[cfg(feature = "metrics")]
     #[inline(always)]
     fn calculate_count_breakdown(&self, trace_heights: &[u32]) -> MeteredCounts {
-        debug_assert_eq!(trace_heights.len(), self.widths.len());
-        debug_assert_eq!(trace_heights.len(), self.interactions.len());
-        debug_assert_eq!(trace_heights.len(), self.need_rot.len());
+        debug_assert_eq!(trace_heights.len(), self.params.widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
+        debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
         let mut counts = MeteredCounts::default();
         for (((&height, &width), &interactions), &need_rot) in trace_heights
             .iter()
-            .zip(self.widths.iter())
-            .zip(self.interactions.iter())
-            .zip(self.need_rot.iter())
+            .zip(self.params.widths.iter())
+            .zip(self.params.interactions.iter())
+            .zip(self.params.need_rot.iter())
         {
             let padded_height = next_power_of_two_or_zero(height as usize);
             let unpadded_height = height as usize;
@@ -278,18 +288,18 @@ impl SegmentationCtx {
     /// cells by per-AIR `need_rot`.
     #[inline(always)]
     fn calculate_cell_counts(&self, trace_heights: &[u32]) -> (usize, usize, usize) {
-        debug_assert_eq!(trace_heights.len(), self.widths.len());
-        debug_assert_eq!(trace_heights.len(), self.interactions.len());
-        debug_assert_eq!(trace_heights.len(), self.need_rot.len());
+        debug_assert_eq!(trace_heights.len(), self.params.widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
+        debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
         let mut main_cnt_with_rot = 0;
         let mut main_cnt_no_rot = 0;
         let mut interaction_cells = 0;
         for (((&height, &width), &interactions), &need_rot) in trace_heights
             .iter()
-            .zip(self.widths.iter())
-            .zip(self.interactions.iter())
-            .zip(self.need_rot.iter())
+            .zip(self.params.widths.iter())
+            .zip(self.params.interactions.iter())
+            .zip(self.params.need_rot.iter())
         {
             let padded_height = next_power_of_two_or_zero(height as usize);
             let main_cells = padded_height * width;
@@ -321,12 +331,12 @@ impl SegmentationCtx {
     #[cfg(feature = "metrics")]
     #[inline(always)]
     fn calculate_memory_breakdown(&self, counts: &MeteredCounts) -> MeteredMemoryBreakdown {
-        let unpadded = self.memory_config.estimate(ProvingMemoryCounts::new(
+        let unpadded = self.params.memory_config.estimate(ProvingMemoryCounts::new(
             counts.main_unpadded_with_rot,
             counts.main_unpadded_no_rot,
             counts.interaction_cells_unpadded,
         ));
-        let total = self.memory_config.estimate(ProvingMemoryCounts::new(
+        let total = self.params.memory_config.estimate(ProvingMemoryCounts::new(
             counts.main_unpadded_with_rot + counts.main_padding_with_rot,
             counts.main_unpadded_no_rot + counts.main_padding_no_rot,
             counts.interaction_cells_unpadded + counts.interaction_cells_padding,
@@ -344,11 +354,11 @@ impl SegmentationCtx {
     /// we assume chips don't send/receive with nonzero multiplicity on padding rows.
     #[inline(always)]
     fn calculate_total_interactions(&self, trace_heights: &[u32]) -> usize {
-        debug_assert_eq!(trace_heights.len(), self.interactions.len());
+        debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
 
         trace_heights
             .iter()
-            .zip(self.interactions.iter())
+            .zip(self.params.interactions.iter())
             .map(|(&height, &interactions)| add_one_or_zero(height) * interactions)
             .sum()
     }
@@ -372,10 +382,10 @@ impl SegmentationCtx {
         is_trace_height_constant: &[bool],
     ) -> Option<SegmentationTrigger> {
         debug_assert_eq!(trace_heights.len(), is_trace_height_constant.len());
-        debug_assert_eq!(trace_heights.len(), self.air_names.len());
-        debug_assert_eq!(trace_heights.len(), self.widths.len());
-        debug_assert_eq!(trace_heights.len(), self.interactions.len());
-        debug_assert_eq!(trace_heights.len(), self.need_rot.len());
+        debug_assert_eq!(trace_heights.len(), self.params.air_names.len());
+        debug_assert_eq!(trace_heights.len(), self.params.widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
+        debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
         let instret_start = self
             .segments
@@ -394,21 +404,21 @@ impl SegmentationCtx {
         for (i, ((((padded_height, width), interactions), is_constant), &need_rot)) in trace_heights
             .iter()
             .map(|&height| next_power_of_two_or_zero(height as usize) as u32)
-            .zip(self.widths.iter())
-            .zip(self.interactions.iter())
+            .zip(self.params.widths.iter())
+            .zip(self.params.interactions.iter())
             .zip(is_trace_height_constant.iter())
-            .zip(self.need_rot.iter())
+            .zip(self.params.need_rot.iter())
             .enumerate()
         {
             // Only segment if the height is not constant and exceeds the maximum height after
             // padding
-            if !is_constant && padded_height > self.limits.max_trace_height() {
-                let air_name = unsafe { self.air_names.get_unchecked(i) };
+            if !is_constant && padded_height > self.params.max_trace_height {
+                let air_name = unsafe { self.params.air_names.get_unchecked(i) };
                 tracing::info!(
                     "overshoot: instret {:10} | height ({:8}) > max ({:8}) | chip {:3} ({}) ",
                     instret,
                     padded_height,
-                    self.limits.max_trace_height(),
+                    self.params.max_trace_height,
                     i,
                     air_name,
                 );
@@ -425,12 +435,12 @@ impl SegmentationCtx {
 
         let (total_memory, main_memory, interaction_memory) =
             self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cells);
-        if total_memory > self.limits.max_memory {
+        if total_memory > self.params.limits.max_memory {
             tracing::info!(
                 "overshoot: instret {:10} | total memory ({:5}) > max ({:5}) | main ({:5}) | interaction ({:5})",
                 instret,
                 ByteSize::b(total_memory as u64),
-                ByteSize::b(self.limits.max_memory as u64),
+                ByteSize::b(self.params.limits.max_memory as u64),
                 ByteSize::b(main_memory as u64),
                 ByteSize::b(interaction_memory as u64),
             );
@@ -438,12 +448,12 @@ impl SegmentationCtx {
         }
 
         let total_interactions = self.calculate_total_interactions(trace_heights);
-        if total_interactions > self.limits.max_interactions {
+        if total_interactions > self.params.limits.max_interactions {
             tracing::info!(
                 "overshoot: instret {:10} | total interactions ({:10}) > max ({:10})",
                 instret,
                 total_interactions,
-                self.limits.max_interactions
+                self.params.limits.max_interactions
             );
             return Some(SegmentationTrigger::Interactions);
         }
@@ -489,7 +499,7 @@ impl SegmentationCtx {
         } else {
             let trace_heights_str = trace_heights
                 .iter()
-                .zip(self.air_names.iter())
+                .zip(self.params.air_names.iter())
                 .filter(|(&height, _)| height > 0)
                 .map(|(&height, name)| format!("  {name} = {height}"))
                 .collect::<Vec<_>>()
@@ -550,8 +560,8 @@ impl SegmentationCtx {
     /// Try segment if there is at least one instruction
     #[inline(always)]
     pub fn create_final_segment(&mut self, trace_heights: &[u32]) {
-        self.instret += self.segment_check_insns - self.instrets_until_check;
-        self.instrets_until_check = self.segment_check_insns;
+        self.instret += self.params.segment_check_insns - self.instrets_until_check;
+        self.instrets_until_check = self.params.segment_check_insns;
         let instret_start = self
             .segments
             .last()
@@ -595,7 +605,7 @@ impl SegmentationCtx {
     fn calculate_trace_utilization(&self, trace_heights: &[u32]) -> f64 {
         let (used, padded) = trace_heights
             .iter()
-            .zip(self.widths.iter())
+            .zip(self.params.widths.iter())
             .map(|(&height, &width)| {
                 let used = height as usize * width;
                 let padded = next_power_of_two_or_zero(height as usize) * width;
@@ -653,7 +663,7 @@ impl SegmentationCtx {
                     ("segment", segment),
                     ("reason", reason.to_string()),
                     ("air_id", air_id.to_string()),
-                    ("air_name", self.air_names[air_id].clone()),
+                    ("air_name", self.params.air_names[air_id].clone()),
                 ];
                 metrics::counter!("segmentation_trigger", &labels).absolute(1);
             }
@@ -677,14 +687,14 @@ impl SegmentationCtx {
     }
 
     fn emit_metered_air_metrics(&self, segment: &str, trace_heights: &[u32]) {
-        let memory_config = self.memory_config;
+        let memory_config = self.params.memory_config;
 
         for (air_id, ((((&height, &width), &interactions), &need_rot), air_name)) in trace_heights
             .iter()
-            .zip(self.widths.iter())
-            .zip(self.interactions.iter())
-            .zip(self.need_rot.iter())
-            .zip(self.air_names.iter())
+            .zip(self.params.widths.iter())
+            .zip(self.params.interactions.iter())
+            .zip(self.params.need_rot.iter())
+            .zip(self.params.air_names.iter())
             .enumerate()
         {
             let padded_height = next_power_of_two_or_zero(height as usize);

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -1,12 +1,7 @@
 use bytesize::ByteSize;
-use getset::{Setters, WithSetters};
 #[cfg(feature = "metrics")]
 use openvm_stark_backend::memory_metering::INTERACTION_MEMORY_OVERHEAD;
-use openvm_stark_backend::{
-    memory_metering::{ProvingMemoryConfig, ProvingMemoryCounts},
-    p3_field::PrimeField32,
-};
-use p3_baby_bear::BabyBear;
+use openvm_stark_backend::memory_metering::{ProvingMemoryConfig, ProvingMemoryCounts};
 use serde::{Deserialize, Serialize};
 
 use crate::utils::{add_one_or_zero, next_power_of_two_or_zero};
@@ -14,7 +9,6 @@ use crate::utils::{add_one_or_zero, next_power_of_two_or_zero};
 pub const DEFAULT_SEGMENT_CHECK_INSNS: u64 = 1000;
 
 pub const DEFAULT_MAX_MEMORY: usize = 15 << 30; // 15GiB
-const DEFAULT_MAX_INTERACTIONS: usize = BabyBear::ORDER_U32 as usize;
 
 #[derive(derive_new::new, Clone, Debug, Serialize, Deserialize)]
 pub struct Segment {
@@ -23,30 +17,11 @@ pub struct Segment {
     pub trace_heights: Vec<u32>,
 }
 
-#[derive(Clone, Debug, WithSetters, Setters)]
+#[derive(Clone, Copy, Debug)]
 pub struct SegmentationLimits {
-    #[getset(set = "pub", set_with = "pub")]
+    pub max_trace_height_bits: u8,
     pub max_memory: usize,
-    #[getset(set_with = "pub")]
-    pub max_interactions: usize,
-}
-
-impl Default for SegmentationLimits {
-    fn default() -> Self {
-        Self {
-            max_memory: DEFAULT_MAX_MEMORY,
-            max_interactions: DEFAULT_MAX_INTERACTIONS,
-        }
-    }
-}
-
-impl SegmentationLimits {
-    pub fn new(max_memory: usize, max_interactions: usize) -> Self {
-        Self {
-            max_memory,
-            max_interactions,
-        }
-    }
+    pub max_interactions: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -55,9 +30,10 @@ struct SegmentationParams {
     widths: Vec<usize>,
     interactions: Vec<usize>,
     need_rot: Vec<bool>,
-    limits: SegmentationLimits,
-    memory_config: ProvingMemoryConfig,
     max_trace_height: u32,
+    max_memory: usize,
+    max_interactions: u32,
+    memory_config: ProvingMemoryConfig,
     segment_check_insns: u64,
 }
 
@@ -67,7 +43,6 @@ impl SegmentationParams {
         widths: Vec<usize>,
         interactions: Vec<usize>,
         need_rot: Vec<bool>,
-        max_trace_height_bits: u8,
         limits: SegmentationLimits,
         memory_config: ProvingMemoryConfig,
     ) -> Self {
@@ -75,13 +50,13 @@ impl SegmentationParams {
         assert_eq!(air_names.len(), interactions.len());
         assert_eq!(air_names.len(), need_rot.len());
         assert!(
-            max_trace_height_bits < u32::BITS as u8,
+            limits.max_trace_height_bits < u32::BITS as u8,
             "max_trace_height_bits must be less than {}",
             u32::BITS
         );
 
         let max_trace_height = 1u32
-            .checked_shl(u32::from(max_trace_height_bits))
+            .checked_shl(u32::from(limits.max_trace_height_bits))
             .expect("max_trace_height_bits must fit in u32 trace height");
         assert!(
             u64::from(max_trace_height) >= 2 * DEFAULT_SEGMENT_CHECK_INSNS,
@@ -93,9 +68,10 @@ impl SegmentationParams {
             widths,
             interactions,
             need_rot,
-            limits,
-            memory_config,
             max_trace_height,
+            max_memory: limits.max_memory,
+            max_interactions: limits.max_interactions,
+            memory_config,
             segment_check_insns: DEFAULT_SEGMENT_CHECK_INSNS,
         }
     }
@@ -169,7 +145,6 @@ impl SegmentationCtx {
         widths: Vec<usize>,
         interactions: Vec<usize>,
         need_rot: Vec<bool>,
-        max_trace_height_bits: u8,
         limits: SegmentationLimits,
         memory_config: ProvingMemoryConfig,
     ) -> Self {
@@ -179,7 +154,6 @@ impl SegmentationCtx {
             widths,
             interactions,
             need_rot,
-            max_trace_height_bits,
             limits,
             memory_config,
         );
@@ -209,11 +183,7 @@ impl SegmentationCtx {
     }
 
     pub fn set_max_memory(&mut self, max_memory: usize) {
-        self.params.limits.max_memory = max_memory;
-    }
-
-    pub fn set_max_interactions(&mut self, max_interactions: usize) {
-        self.params.limits.max_interactions = max_interactions;
+        self.params.max_memory = max_memory;
     }
 
     /// Calculate the maximum trace height and corresponding air name
@@ -353,13 +323,13 @@ impl SegmentationCtx {
     /// All padding rows contribute a single message to the interactions (+1) since
     /// we assume chips don't send/receive with nonzero multiplicity on padding rows.
     #[inline(always)]
-    fn calculate_total_interactions(&self, trace_heights: &[u32]) -> usize {
+    fn calculate_total_interactions(&self, trace_heights: &[u32]) -> u64 {
         debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
 
         trace_heights
             .iter()
             .zip(self.params.interactions.iter())
-            .map(|(&height, &interactions)| add_one_or_zero(height) * interactions)
+            .map(|(&height, &interactions)| add_one_or_zero(height) as u64 * interactions as u64)
             .sum()
     }
 
@@ -435,12 +405,12 @@ impl SegmentationCtx {
 
         let (total_memory, main_memory, interaction_memory) =
             self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cells);
-        if total_memory > self.params.limits.max_memory {
+        if total_memory > self.params.max_memory {
             tracing::info!(
                 "overshoot: instret {:10} | total memory ({:5}) > max ({:5}) | main ({:5}) | interaction ({:5})",
                 instret,
                 ByteSize::b(total_memory as u64),
-                ByteSize::b(self.params.limits.max_memory as u64),
+                ByteSize::b(self.params.max_memory as u64),
                 ByteSize::b(main_memory as u64),
                 ByteSize::b(interaction_memory as u64),
             );
@@ -448,12 +418,12 @@ impl SegmentationCtx {
         }
 
         let total_interactions = self.calculate_total_interactions(trace_heights);
-        if total_interactions > self.params.limits.max_interactions {
+        if total_interactions > u64::from(self.params.max_interactions) {
             tracing::info!(
                 "overshoot: instret {:10} | total interactions ({:10}) > max ({:10})",
                 instret,
                 total_interactions,
-                self.params.limits.max_interactions
+                self.params.max_interactions
             );
             return Some(SegmentationTrigger::Interactions);
         }

--- a/crates/vm/src/arch/execution_mode/mod.rs
+++ b/crates/vm/src/arch/execution_mode/mod.rs
@@ -5,7 +5,10 @@ pub mod metered_cost;
 mod preflight;
 mod pure;
 
-pub use metered::{ctx::MeteredCtx, segment_ctx::Segment};
+pub use metered::{
+    ctx::{MeteredCtx, MeteredCtxInputs},
+    segment_ctx::Segment,
+};
 pub use metered_cost::MeteredCostCtx;
 pub use preflight::PreflightCtx;
 pub use pure::ExecutionCtx;

--- a/crates/vm/src/arch/execution_mode/mod.rs
+++ b/crates/vm/src/arch/execution_mode/mod.rs
@@ -7,7 +7,7 @@ mod pure;
 
 pub use metered::{
     ctx::{MeteredCtx, MeteredCtxInputs},
-    segment_ctx::Segment,
+    segment_ctx::{Segment, SegmentationLimits},
 };
 pub use metered_cost::MeteredCostCtx;
 pub use preflight::PreflightCtx;

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -39,7 +39,9 @@ use tracing::{info_span, instrument};
 #[cfg(feature = "aot")]
 use super::aot::AotInstance;
 use super::{
-    execution_mode::{ExecutionCtx, MeteredCostCtx, MeteredCtx, PreflightCtx, Segment},
+    execution_mode::{
+        ExecutionCtx, MeteredCostCtx, MeteredCtx, MeteredCtxInputs, PreflightCtx, Segment,
+    },
     hasher::poseidon2::vm_poseidon2_hasher,
     interpreter::InterpretedInstance,
     interpreter_preflight::PreflightInterpretedInstance,
@@ -193,22 +195,10 @@ where
 {
     pub fn build_metered_ctx(
         &self,
-        constant_trace_heights: &[Option<usize>],
-        air_names: &[String],
-        widths: &[usize],
-        interactions: &[usize],
-        need_rot: &[bool],
+        inputs: MeteredCtxInputs<'_>,
         memory_config: ProvingMemoryConfig,
     ) -> MeteredCtx {
-        MeteredCtx::new(
-            constant_trace_heights.to_vec(),
-            air_names.to_vec(),
-            widths.to_vec(),
-            interactions.to_vec(),
-            need_rot.to_vec(),
-            self.config.as_ref(),
-            memory_config,
-        )
+        MeteredCtx::new(inputs, self.config.as_ref(), memory_config)
     }
 
     pub fn build_metered_cost_ctx(&self, widths: &[usize]) -> MeteredCostCtx {
@@ -905,30 +895,23 @@ where
             }
         }
 
-        let stacked_max_trace_height_bits = self
+        let log_stacked_height = self
             .engine
             .params()
             .log_stacked_height()
             .try_into()
             .expect("log_stacked_height must fit in u8");
-        let configured_max_trace_height_bits = self
-            .config()
-            .as_ref()
-            .segmentation_limits
-            .max_trace_height_bits;
-        self.executor()
-            .build_metered_ctx(
-                &constant_trace_heights,
-                &air_names,
-                &widths,
-                &interactions,
-                &need_rot,
-                self.engine.proving_memory_config(),
-            )
-            .with_max_trace_height_bits_bound(
-                configured_max_trace_height_bits,
-                stacked_max_trace_height_bits,
-            )
+        self.executor().build_metered_ctx(
+            MeteredCtxInputs {
+                constant_trace_heights: &constant_trace_heights,
+                air_names: &air_names,
+                widths: &widths,
+                interactions: &interactions,
+                need_rot: &need_rot,
+                max_trace_height_bits: log_stacked_height,
+            },
+            self.engine.proving_memory_config(),
+        )
     }
 
     /// Convenience method to construct a [MeteredCostCtx] using data from the stored proving key.

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -905,14 +905,30 @@ where
             }
         }
 
-        self.executor().build_metered_ctx(
-            &constant_trace_heights,
-            &air_names,
-            &widths,
-            &interactions,
-            &need_rot,
-            self.engine.proving_memory_config(),
-        )
+        let stacked_max_trace_height_bits = self
+            .engine
+            .params()
+            .log_stacked_height()
+            .try_into()
+            .expect("log_stacked_height must fit in u8");
+        let configured_max_trace_height_bits = self
+            .config()
+            .as_ref()
+            .segmentation_limits
+            .max_trace_height_bits;
+        self.executor()
+            .build_metered_ctx(
+                &constant_trace_heights,
+                &air_names,
+                &widths,
+                &interactions,
+                &need_rot,
+                self.engine.proving_memory_config(),
+            )
+            .with_max_trace_height_bits_bound(
+                configured_max_trace_height_bits,
+                stacked_max_trace_height_bits,
+            )
     }
 
     /// Convenience method to construct a [MeteredCostCtx] using data from the stored proving key.

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -41,6 +41,7 @@ use super::aot::AotInstance;
 use super::{
     execution_mode::{
         ExecutionCtx, MeteredCostCtx, MeteredCtx, MeteredCtxInputs, PreflightCtx, Segment,
+        SegmentationLimits,
     },
     hasher::poseidon2::vm_poseidon2_hasher,
     interpreter::InterpretedInstance,
@@ -849,7 +850,10 @@ where
     }
 
     /// Convenience method to construct a [MeteredCtx] using data from the stored proving key.
-    pub fn build_metered_ctx(&self, exe: &VmExe<Val<E::SC>>) -> MeteredCtx {
+    pub fn build_metered_ctx(&self, exe: &VmExe<Val<E::SC>>) -> MeteredCtx
+    where
+        Val<E::SC>: PrimeField32,
+    {
         let program_len = exe.program.num_defined_instructions();
 
         let (mut constant_trace_heights, air_names, widths, interactions, need_rot): (
@@ -908,7 +912,11 @@ where
                 widths: &widths,
                 interactions: &interactions,
                 need_rot: &need_rot,
-                max_trace_height_bits: log_stacked_height,
+                segmentation_limits: SegmentationLimits {
+                    max_trace_height_bits: log_stacked_height,
+                    max_memory: self.config().as_ref().segmentation_max_memory,
+                    max_interactions: <Val<E::SC> as PrimeField32>::ORDER_U32,
+                },
             },
             self.engine.proving_memory_config(),
         )

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -85,8 +85,7 @@ where
     while config.as_ref().max_constraint_degree > (1 << log_blowup) + 1 {
         log_blowup += 1;
     }
-    let params =
-        SystemParams::new_for_testing(config.as_ref().segmentation_limits.max_trace_height_bits());
+    let params = SystemParams::new_for_testing(22); // max log_trace_height=22
     let debug = std::env::var("OPENVM_SKIP_DEBUG") != Result::Ok(String::from("1"));
     let (final_memory, _) = air_test_impl::<TestStarkEngine, VB>(
         params,

--- a/extensions/deferral/circuit/src/extension/cuda.rs
+++ b/extensions/deferral/circuit/src/extension/cuda.rs
@@ -29,6 +29,8 @@ use crate::{
 
 pub struct DeferralGpuProverExt;
 
+const DEFAULT_DEFERRAL_POSEIDON2_MAX_TRACE_HEIGHT: usize = 1 << 24;
+
 impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, DeferralExtension>
     for DeferralGpuProverExt
 {
@@ -62,9 +64,8 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, DeferralExt
         inventory.add_periphery_chip(count_chip);
 
         inventory.next_air::<DeferralPoseidon2Air<CudaF>>()?;
-        let max_trace_height = inventory.config().segmentation_limits.max_trace_height() as usize;
         let poseidon2_chip = Arc::new(DeferralPoseidon2ChipGpu::new(
-            max_trace_height.max(1),
+            DEFAULT_DEFERRAL_POSEIDON2_MAX_TRACE_HEIGHT,
             1,
             range_checker.device_ctx.clone(),
         ));

--- a/extensions/deferral/circuit/src/extension/cuda.rs
+++ b/extensions/deferral/circuit/src/extension/cuda.rs
@@ -62,7 +62,7 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, DeferralExt
         inventory.add_periphery_chip(count_chip);
 
         inventory.next_air::<DeferralPoseidon2Air<CudaF>>()?;
-        let max_trace_height = inventory.config().segmentation_limits.max_trace_height as usize;
+        let max_trace_height = inventory.config().segmentation_limits.max_trace_height() as usize;
         let poseidon2_chip = Arc::new(DeferralPoseidon2ChipGpu::new(
             max_trace_height.max(1),
             1,

--- a/extensions/rv32im/circuit/src/lib.rs
+++ b/extensions/rv32im/circuit/src/lib.rs
@@ -117,30 +117,12 @@ impl Rv32IConfig {
             io: Default::default(),
         }
     }
-
-    pub fn with_public_values_and_segment_len(public_values: usize, segment_len: usize) -> Self {
-        let system = SystemConfig::default()
-            .with_public_values(public_values)
-            .with_max_segment_len(segment_len);
-        Self {
-            system,
-            base: Default::default(),
-            io: Default::default(),
-        }
-    }
 }
 
 impl Rv32ImConfig {
     pub fn with_public_values(public_values: usize) -> Self {
         Self {
             rv32i: Rv32IConfig::with_public_values(public_values),
-            mul: Default::default(),
-        }
-    }
-
-    pub fn with_public_values_and_segment_len(public_values: usize, segment_len: usize) -> Self {
-        Self {
-            rv32i: Rv32IConfig::with_public_values_and_segment_len(public_values, segment_len),
             mul: Default::default(),
         }
     }

--- a/guest-libs/verify-stark/circuit/src/tests.rs
+++ b/guest-libs/verify-stark/circuit/src/tests.rs
@@ -62,13 +62,12 @@ cfg_if::cfg_if! {
     }
 }
 
-const LOG_MAX_TRACE_HEIGHT: usize = 20;
 const DEFAULT_MAX_NUM_PROOFS: usize = 4;
 
 fn test_rv32im_config() -> Rv32ImConfig {
     Rv32ImConfig {
         rv32i: Rv32IConfig {
-            system: test_system_config().with_max_segment_len(1 << LOG_MAX_TRACE_HEIGHT),
+            system: test_system_config(),
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
## Summary

- Remove configurable segmentation trace-height and interaction-limit knobs.
- Derive segmentation trace-height limits from the engine stacked height and interaction limits from the proving field order.
- Keep only segmentation max memory configurable through `SystemConfig` / CLI.
- Remove stale max segment height plumbing from benchmarks, workflows, and tests.
- Add sccache startup-timeout configuration to reduce CI server startup races.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --profile fast -p openvm-circuit --all-targets --tests -- -D warnings`
- `cargo check --profile fast -p cargo-openvm`
- `cargo check --profile fast --no-default-features -p openvm-benchmarks-prove --bin keccak_par --features metrics,parallel,jemalloc`
- `cargo clippy --profile fast --no-default-features -p openvm-benchmarks-prove --bin keccak_par --features metrics,parallel,jemalloc -- -D warnings`
- `python3 -m json.tool ci/benchmark-config.json >/dev/null && python3 -m json.tool ci/benchmark-config.example.json >/dev/null && bash -n ci/scripts/utils.sh && python3 -m py_compile ci/scripts/bench.py`
- `actionlint -ignore 'label ".*" is unknown' -ignore '"github.head_ref" is potentially untrusted' -ignore 'object, array, and null values should not be evaluated' .github/workflows/*.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/sccache/action.yml"); puts "ok"'`
