### PR TITLE
feat: rvr support for rv64 bigint extension

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -51,7 +51,7 @@ jobs:
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
           - { name: "algebra", path: "algebra", aot: false, rvr: true }
           - { name: "ecc", path: "ecc", aot: false, rvr: true }
-          # - { name: "pairing", path: "pairing", aot: false, rvr: true }
+          - { name: "pairing", path: "pairing", aot: false, rvr: true }
           # - { name: "deferral", path: "deferral", aot: false, rvr: true }
         platform:
           - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -47,7 +47,7 @@ jobs:
           # TODO(rvr): re-enable these once RV64 RVR support lands.
           - { name: "riscv", path: "riscv", aot: false, rvr: true }
           # - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
-          # - { name: "sha2", path: "sha2", aot: false, rvr: true }
+          - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
           # - { name: "algebra", path: "algebra", aot: false, rvr: true }
           # - { name: "ecc", path: "ecc", aot: false, rvr: true }

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -50,7 +50,7 @@ jobs:
           - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
           - { name: "algebra", path: "algebra", aot: false, rvr: true }
-          # - { name: "ecc", path: "ecc", aot: false, rvr: true }
+          - { name: "ecc", path: "ecc", aot: false, rvr: true }
           # - { name: "pairing", path: "pairing", aot: false, rvr: true }
           # - { name: "deferral", path: "deferral", aot: false, rvr: true }
         platform:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -49,7 +49,7 @@ jobs:
           - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
           - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
-          # - { name: "algebra", path: "algebra", aot: false, rvr: true }
+          - { name: "algebra", path: "algebra", aot: false, rvr: true }
           # - { name: "ecc", path: "ecc", aot: false, rvr: true }
           # - { name: "pairing", path: "pairing", aot: false, rvr: true }
           # - { name: "deferral", path: "deferral", aot: false, rvr: true }

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -48,7 +48,7 @@ jobs:
           - { name: "riscv", path: "riscv", aot: false, rvr: true }
           # - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
           # - { name: "sha2", path: "sha2", aot: false, rvr: true }
-          # - { name: "bigint", path: "bigint", aot: false, rvr: true }
+          - { name: "bigint", path: "bigint", aot: false, rvr: true }
           # - { name: "algebra", path: "algebra", aot: false, rvr: true }
           # - { name: "ecc", path: "ecc", aot: false, rvr: true }
           # - { name: "pairing", path: "pairing", aot: false, rvr: true }

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -46,7 +46,7 @@ jobs:
           # - { name: "deferral", path: "deferral", aot: true, rvr: false }
           # TODO(rvr): re-enable these once RV64 RVR support lands.
           - { name: "riscv", path: "riscv", aot: false, rvr: true }
-          # - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
+          - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
           - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
           # - { name: "algebra", path: "algebra", aot: false, rvr: true }

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -40,8 +40,8 @@ jobs:
           - { name: "keccak256", path: "keccak256", rvr: true }
           - { name: "sha2", path: "sha2", rvr: true }
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
-          # - { name: "k256", path: "k256", rvr: true }
-          # - { name: "p256", path: "p256", rvr: true }
+          - { name: "k256", path: "k256", rvr: true }
+          - { name: "p256", path: "p256", rvr: true }
           # - { name: "pairing", path: "pairing", rvr: true }
         platform:
           - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -36,10 +36,9 @@ jobs:
           - { name: "p256", path: "p256", rvr: false }
           - { name: "pairing", path: "pairing", rvr: false }
           - { name: "verify-stark", path: "verify-stark/circuit", rvr: false }
-          # TODO(rvr): re-enable these once RV64 RVR support lands.
           - { name: "keccak256", path: "keccak256", rvr: true }
           - { name: "sha2", path: "sha2", rvr: true }
-          # - { name: "ff_derive", path: "ff_derive", rvr: true }
+          - { name: "ff_derive", path: "ff_derive", rvr: true }
           - { name: "k256", path: "k256", rvr: true }
           - { name: "p256", path: "p256", rvr: true }
           - { name: "pairing", path: "pairing", rvr: true }
@@ -101,7 +100,6 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
           EXTRA_ARGS=()
-          # TODO(rvr): restore this branch when the rvr matrix entries above are re-enabled.
           if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
             if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
               EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -42,7 +42,7 @@ jobs:
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
           - { name: "k256", path: "k256", rvr: true }
           - { name: "p256", path: "p256", rvr: true }
-          # - { name: "pairing", path: "pairing", rvr: true }
+          - { name: "pairing", path: "pairing", rvr: true }
         platform:
           - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -37,8 +37,8 @@ jobs:
           - { name: "pairing", path: "pairing", rvr: false }
           - { name: "verify-stark", path: "verify-stark/circuit", rvr: false }
           # TODO(rvr): re-enable these once RV64 RVR support lands.
+          - { name: "keccak256", path: "keccak256", rvr: true }
           - { name: "sha2", path: "sha2", rvr: true }
-          # - { name: "keccak256", path: "keccak256", rvr: true }
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
           # - { name: "k256", path: "k256", rvr: true }
           # - { name: "p256", path: "p256", rvr: true }

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - { name: "pairing", path: "pairing", rvr: false }
           - { name: "verify-stark", path: "verify-stark/circuit", rvr: false }
           # TODO(rvr): re-enable these once RV64 RVR support lands.
-          # - { name: "sha2", path: "sha2", rvr: true }
+          - { name: "sha2", path: "sha2", rvr: true }
           # - { name: "keccak256", path: "keccak256", rvr: true }
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
           # - { name: "k256", path: "k256", rvr: true }
@@ -102,13 +102,13 @@ jobs:
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
           EXTRA_ARGS=()
           # TODO(rvr): restore this branch when the rvr matrix entries above are re-enabled.
-          # if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
-          #   if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
-          #     EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
-          #   else
-          #     EXTRA_ARGS+=(--features=rvr)
-          #   fi
-          if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+          if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
+            if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+              EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
+            else
+              EXTRA_ARGS+=(--features=rvr)
+            fi
+          elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381 -E 'not test(fallback)')
           fi
 

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -36,11 +36,11 @@ jobs:
               features: "",
             }
           # TODO(rvr): re-enable once RV64 RVR support lands.
-          # - {
-          #     labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
-          #     image: "ubuntu24-full-x64",
-          #     features: "rvr",
-          #   }
+          - {
+              labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
+              image: "ubuntu24-full-x64",
+              features: "rvr",
+            }
           - {
               labels: "image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized",
               image: "ubuntu24-gpu-x64",

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -35,7 +35,6 @@ jobs:
               image: "ubuntu24-full-x64",
               features: "",
             }
-          # TODO(rvr): re-enable once RV64 RVR support lands.
           - {
               labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
               image: "ubuntu24-full-x64",

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -25,8 +25,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        mode: ["default", "ignored"]
-        # TODO(rvr): add "rvr" here once RV64 RVR support lands.
+        mode: ["default", "ignored", "rvr"]
 
     runs-on:
       - runs-on=${{ github.run_id }}-sdk-${{ github.run_attempt }}-${{ strategy.job-index }}/family=m7a.24xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
@@ -100,17 +99,15 @@ jobs:
         run: |
           export RUST_BACKTRACE=1
           export RUST_MIN_STACK=8388608
-          # TODO(rvr): switch back to this feature-selection block when "rvr" mode is re-enabled.
-          # FEATURES="parallel,root-prover,evm-verify"
-          # if [[ "${{ matrix.mode }}" == "default" ]]; then
-          #   : # no additional features
-          # elif [[ "${{ matrix.mode }}" == "rvr" ]]; then
-          #   FEATURES="$FEATURES,rvr"
-          # else
-          #   echo "Unknown matrix mode: ${{ matrix.mode }}" && exit 1
-          # fi
-          # CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo nextest run --release --features "$FEATURES"
-          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo nextest run --release --features parallel,root-prover,evm-verify
+          FEATURES="parallel,root-prover,evm-verify"
+          if [[ "${{ matrix.mode }}" == "default" ]]; then
+            : # no additional features
+          elif [[ "${{ matrix.mode }}" == "rvr" ]]; then
+            FEATURES="$FEATURES,rvr"
+          else
+            echo "Unknown matrix mode: ${{ matrix.mode }}" && exit 1
+          fi
+          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo nextest run --release --features "$FEATURES"
 
       - name: Run ignored tests
         if: ${{ matrix.mode == 'ignored' }}

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -54,6 +54,10 @@ extern "C" {
     pub fn trace_wr_mem_u32_wrapper(state: *mut c_void, addr: u32, new_val: u32);
     pub fn trace_mem_access_u32_wrapper(state: *mut c_void, addr: u32, addr_space: u32);
 
+    // ── Memory access (single u64 word, data)
+    pub fn rd_mem_u64_wrapper(state: *mut c_void, addr: u32) -> u64;
+    pub fn trace_rd_mem_u64_wrapper(state: *mut c_void, addr: u32, val: u64);
+
     // ── Memory access (u32 ranges, data) ─────────────────────────────
     pub fn rd_mem_u32_range_wrapper(
         state: *mut c_void,

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -101,6 +101,12 @@ extern "C" {
         vals: *const u64,
         num_words: u32,
     );
+    pub fn trace_mem_access_u64_range_wrapper(
+        state: *mut c_void,
+        base_addr: u32,
+        num_words: u32,
+        addr_space: u32,
+    );
 
     // ── Memory access (u64-word ranges, trace-only) ───────────────────
     pub fn trace_rd_mem_u64_range_wrapper(
@@ -244,5 +250,5 @@ pub unsafe fn trace_mem_access_range(
         num_words >= 1,
         "trace_mem_access_range requires num_words >= 1"
     );
-    trace_mem_access_u32_range_wrapper(state, base_addr, num_words, addr_space);
+    trace_mem_access_u64_range_wrapper(state, base_addr, num_words, addr_space);
 }

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -54,7 +54,7 @@ extern "C" {
     pub fn trace_wr_mem_u32_wrapper(state: *mut c_void, addr: u32, new_val: u32);
     pub fn trace_mem_access_u32_wrapper(state: *mut c_void, addr: u32, addr_space: u32);
 
-    // ── Memory access (word-aligned ranges, data) ─────────────────────
+    // ── Memory access (u32 ranges, data) ─────────────────────────────
     pub fn rd_mem_u32_range_wrapper(
         state: *mut c_void,
         base_addr: u32,
@@ -68,7 +68,7 @@ extern "C" {
         num_words: u32,
     );
 
-    // ── Memory access (word-aligned ranges, trace-only) ───────────────
+    // ── Memory access (u32 ranges, trace-only) ────────────────────────
     pub fn trace_rd_mem_u32_range_wrapper(
         state: *mut c_void,
         base_addr: u32,
@@ -86,6 +86,34 @@ extern "C" {
         base_addr: u32,
         num_words: u32,
         addr_space: u32,
+    );
+
+    // ── Memory access (u64-word ranges, data) — WORD_SIZE = 8 bytes ──
+    pub fn rd_mem_u64_range_wrapper(
+        state: *mut c_void,
+        base_addr: u32,
+        out: *mut u64,
+        num_words: u32,
+    );
+    pub fn wr_mem_u64_range_wrapper(
+        state: *mut c_void,
+        base_addr: u32,
+        vals: *const u64,
+        num_words: u32,
+    );
+
+    // ── Memory access (u64-word ranges, trace-only) ───────────────────
+    pub fn trace_rd_mem_u64_range_wrapper(
+        state: *mut c_void,
+        base_addr: u32,
+        vals: *const u64,
+        num_words: u32,
+    );
+    pub fn trace_wr_mem_u64_range_wrapper(
+        state: *mut c_void,
+        base_addr: u32,
+        vals: *const u64,
+        num_words: u32,
     );
 
     // ── Instruction dispatch / chip cost ──────────────────────────────
@@ -157,8 +185,9 @@ pub fn u32s_as_u64s(words: &[u32]) -> &[u64] {
 
 // ── Ergonomic batched memory helpers ─────────────────────────────────────
 
-/// Read `out.len()` consecutive u32 words from guest memory into `out`,
-/// then trace each as a memory read.
+/// Read `out.len()` consecutive u64 words from guest memory into `out`,
+/// then trace each as a memory read. A word is 8 bytes (`WORD_SIZE`),
+/// matching the circuit's `MEMORY_BLOCK_BYTES` granularity.
 ///
 /// `out` must be non-empty; the C trace functions assume `num_words >= 1`
 /// to avoid an underflow check on the hot path. Callers handling
@@ -168,33 +197,34 @@ pub fn u32s_as_u64s(words: &[u32]) -> &[u64] {
 /// # Safety
 /// `state` must be a valid `RvState` pointer; the byte range
 /// `[base_addr, base_addr + out.len()*WORD_SIZE)` must lie within guest memory.
-pub unsafe fn rd_mem_words_traced(state: *mut c_void, base_addr: u32, out: &mut [u32]) {
+pub unsafe fn rd_mem_words_traced(state: *mut c_void, base_addr: u32, out: &mut [u64]) {
     debug_assert!(
         !out.is_empty(),
         "rd_mem_words_traced requires a non-empty range"
     );
     let n = out.len() as u32;
-    rd_mem_u32_range_wrapper(state, base_addr, out.as_mut_ptr(), n);
-    trace_rd_mem_u32_range_wrapper(state, base_addr, out.as_ptr(), n);
+    rd_mem_u64_range_wrapper(state, base_addr, out.as_mut_ptr(), n);
+    trace_rd_mem_u64_range_wrapper(state, base_addr, out.as_ptr(), n);
 }
 
 /// Trace each value in `vals` as a write at `base_addr + i*WORD_SIZE`,
 /// then write them to guest memory. Trace-before-write so future tracers
-/// can read the old value before it is overwritten.
+/// can read the old value before it is overwritten. A word is 8 bytes
+/// (`WORD_SIZE`), matching the circuit's `MEMORY_BLOCK_BYTES` granularity.
 ///
 /// `vals` must be non-empty; see [`rd_mem_words_traced`] for rationale.
 ///
 /// # Safety
 /// `state` must be a valid `RvState` pointer; the byte range
 /// `[base_addr, base_addr + vals.len()*WORD_SIZE)` must lie within guest memory.
-pub unsafe fn wr_mem_words_traced(state: *mut c_void, base_addr: u32, vals: &[u32]) {
+pub unsafe fn wr_mem_words_traced(state: *mut c_void, base_addr: u32, vals: &[u64]) {
     debug_assert!(
         !vals.is_empty(),
         "wr_mem_words_traced requires a non-empty range"
     );
     let n = vals.len() as u32;
-    trace_wr_mem_u32_range_wrapper(state, base_addr, vals.as_ptr(), n);
-    wr_mem_u32_range_wrapper(state, base_addr, vals.as_ptr(), n);
+    trace_wr_mem_u64_range_wrapper(state, base_addr, vals.as_ptr(), n);
+    wr_mem_u64_range_wrapper(state, base_addr, vals.as_ptr(), n);
 }
 
 /// Trace `num_words` consecutive memory-access notifications (no value)

--- a/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.h
+++ b/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.h
@@ -71,4 +71,9 @@ static __attribute__((always_inline)) inline void check_mem_bounds_u32_range(
   check_mem_bounds_range(base_addr, (size_t)num_words * sizeof(uint32_t));
 }
 
+static __attribute__((always_inline)) inline void check_mem_bounds_u64_range(
+    uint32_t base_addr, uint32_t num_words) {
+  check_mem_bounds_range(base_addr, (size_t)num_words * sizeof(uint64_t));
+}
+
 #endif

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -203,6 +203,26 @@ static __attribute__((always_inline)) inline void wr_mem_u32_range(
   memcpy(p, vals, (size_t)num_words * sizeof(uint32_t));
 }
 
+/* A "word" in RV64 is 8 bytes (sizeof(uint64_t)), matching MEMORY_BLOCK_BYTES.
+ * All extension multi-word memory I/O uses this granularity. */
+static __attribute__((always_inline)) inline void rd_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
+  check_mem_bounds_u64_range(base_addr, num_words);
+  const void* p =
+      __builtin_assume_aligned(mem_ptr(state->memory, base_addr), sizeof(uint64_t));
+  memcpy(out, p, (size_t)num_words * sizeof(uint64_t));
+}
+
+static __attribute__((always_inline)) inline void wr_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* restrict vals,
+    uint32_t num_words) {
+  check_mem_bounds_u64_range(base_addr, num_words);
+  void* p =
+      __builtin_assume_aligned(mem_ptr(state->memory, base_addr), sizeof(uint64_t));
+  memcpy(p, vals, (size_t)num_words * sizeof(uint64_t));
+}
+
 /* ── Traced memory helpers ───────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u8(
@@ -232,6 +252,12 @@ static __attribute__((always_inline)) inline void trace_rd_mem_u32_range(
     uint32_t num_words);
 static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
     RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
+    uint32_t num_words);
+static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    uint32_t num_words);
+static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words);
 
 /* Per-width traced reads widen to 32 bits. */
@@ -320,6 +346,20 @@ static __attribute__((always_inline)) inline void wr_mem_u32_range_traced(
     uint32_t num_words) {
   trace_wr_mem_u32_range(state, base_addr, vals, num_words);
   wr_mem_u32_range(state, base_addr, vals, num_words);
+}
+
+static __attribute__((always_inline)) inline void rd_mem_u64_range_traced(
+    RvState* restrict state, uint32_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
+  rd_mem_u64_range(state, base_addr, out, num_words);
+  trace_rd_mem_u64_range(state, base_addr, out, num_words);
+}
+
+static __attribute__((always_inline)) inline void wr_mem_u64_range_traced(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* restrict vals,
+    uint32_t num_words) {
+  trace_wr_mem_u64_range(state, base_addr, vals, num_words);
+  wr_mem_u64_range(state, base_addr, vals, num_words);
 }
 
 #endif /* OPENVM_STATE_H */

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -34,6 +34,13 @@ void trace_wr_mem_u32_wrapper(RvState* s, uint32_t addr, uint32_t val) {
   trace_wr_mem_u32(s, addr, val);
 }
 
+uint64_t rd_mem_u64_wrapper(RvState* s, uint32_t addr) {
+  return rd_mem_u64(s->memory, addr);
+}
+void trace_rd_mem_u64_wrapper(RvState* s, uint32_t addr, uint64_t val) {
+  trace_rd_mem_u64(s, addr, val);
+}
+
 /* ── Memory access (u32 ranges, inline-backed) ─────────────────────── */
 
 void rd_mem_u32_range_wrapper(RvState* s, uint32_t base_addr, uint32_t* out,

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -85,6 +85,12 @@ void trace_wr_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
   trace_wr_mem_u64_range(s, base_addr, vals, num_words);
 }
 
+void trace_mem_access_u64_range_wrapper(RvState* s, uint32_t base_addr,
+                                        uint32_t num_words,
+                                        uint32_t addr_space) {
+  trace_mem_access_u64_range(s, base_addr, num_words, addr_space);
+}
+
 /* ── Instruction dispatch / chip cost ──────────────────────────────── */
 
 void trace_pc_wrapper(RvState* s, uint32_t pc) { trace_pc(s, pc); }

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -34,7 +34,7 @@ void trace_wr_mem_u32_wrapper(RvState* s, uint32_t addr, uint32_t val) {
   trace_wr_mem_u32(s, addr, val);
 }
 
-/* ── Memory access (word-aligned ranges, inline-backed) ────────────── */
+/* ── Memory access (u32 ranges, inline-backed) ─────────────────────── */
 
 void rd_mem_u32_range_wrapper(RvState* s, uint32_t base_addr, uint32_t* out,
                               uint32_t num_words) {
@@ -60,6 +60,29 @@ void trace_mem_access_u32_range_wrapper(RvState* s, uint32_t base_addr,
                                         uint32_t num_words,
                                         uint32_t addr_space) {
   trace_mem_access_u32_range(s, base_addr, num_words, addr_space);
+}
+
+/* A "word" in RV64 is 8 bytes (sizeof(uint64_t)), matching MEMORY_BLOCK_BYTES.
+ * All extension multi-word memory I/O uses this granularity. */
+
+void rd_mem_u64_range_wrapper(RvState* s, uint32_t base_addr, uint64_t* out,
+                              uint32_t num_words) {
+  rd_mem_u64_range(s, base_addr, out, num_words);
+}
+
+void wr_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
+                              const uint64_t* vals, uint32_t num_words) {
+  wr_mem_u64_range(s, base_addr, vals, num_words);
+}
+
+void trace_rd_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
+                                    const uint64_t* vals, uint32_t num_words) {
+  trace_rd_mem_u64_range(s, base_addr, vals, num_words);
+}
+
+void trace_wr_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
+                                    const uint64_t* vals, uint32_t num_words) {
+  trace_wr_mem_u64_range(s, base_addr, vals, num_words);
 }
 
 /* ── Instruction dispatch / chip cost ──────────────────────────────── */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -294,6 +294,24 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
                         byte_addr_to_local_page(last_addr));
 }
 
+static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    uint32_t num_words) {
+  assume(num_words > 0);
+  uint32_t last_addr = base_addr + (num_words - 1) * sizeof(uint64_t);
+  record_mem_page_range(state->tracer, byte_addr_to_local_page(base_addr),
+                        byte_addr_to_local_page(last_addr));
+}
+
+static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    uint32_t num_words) {
+  assume(num_words > 0);
+  uint32_t last_addr = base_addr + (num_words - 1) * sizeof(uint64_t);
+  record_mem_page_range(state->tracer, byte_addr_to_local_page(base_addr),
+                        byte_addr_to_local_page(last_addr));
+}
+
 /* ── Trace-only operations ────────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void trace_mem_access(

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -61,6 +61,12 @@ static __attribute__((always_inline)) inline void trace_rd_mem_u32_range(
 static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
     RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
     uint32_t num_words) {}
+static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    uint32_t num_words) {}
+static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    uint32_t num_words) {}
 
 /* ── Trace-only operations ────────────────────────────────────────── */
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -57,6 +57,12 @@ static __attribute__((always_inline)) inline void trace_rd_mem_u32_range(
 static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
     RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
     uint32_t num_words) {}
+static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    uint32_t num_words) {}
+static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
+    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    uint32_t num_words) {}
 
 /* ── Trace-only operations (no-ops in pure mode) ──────────────────── */
 

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -5,7 +5,11 @@ use std::ffi::c_void;
 use halo2curves_axiom::ff::PrimeField;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
-use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_SIZE};
+use rvr_openvm_ext_ffi_common::{
+    // TODO(follow-up): migrate algebra to rd_mem_words_traced / wr_mem_words_traced ([u64])
+    rd_mem_u32_range_wrapper, trace_rd_mem_u32_range_wrapper, trace_wr_mem_u32_range_wrapper,
+    wr_mem_u32_range_wrapper, WORD_SIZE,
+};
 
 /// Size of a 256-bit field element in bytes.
 pub const FIELD_256_BYTES: usize = 32;
@@ -46,7 +50,8 @@ pub trait FieldArith {
 #[inline(always)]
 pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void, ptr: u32) -> F {
     let mut words = [0u32; FIELD_256_WORDS];
-    rd_mem_words_traced(state, ptr, &mut words);
+    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), FIELD_256_WORDS as u32);
+    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
     let mut bytes = [0u8; FIELD_256_BYTES];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -82,7 +87,8 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
                 .unwrap(),
         );
     }
-    wr_mem_words_traced(state, ptr, &words);
+    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
+    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
 }
 
 /// Read a BLS12-381 Fq element (48 bytes) from guest memory (traced).
@@ -92,7 +98,8 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
 #[inline(always)]
 pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> blstrs::Fp {
     let mut words = [0u32; BLS12_381_ELEM_WORDS];
-    rd_mem_words_traced(state, ptr, &mut words);
+    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), BLS12_381_ELEM_WORDS as u32);
+    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
     let mut bytes = [0u8; BLS12_381_ELEM_BYTES];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -123,7 +130,8 @@ pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp)
                 .unwrap(),
         );
     }
-    wr_mem_words_traced(state, ptr, &words);
+    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
+    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
 }
 
 // ── BigUint helpers (for unknown-modulus fallbacks) ──────────────────────────
@@ -137,7 +145,8 @@ pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp)
 pub unsafe fn read_bigint(state: *mut c_void, ptr: u32, num_limbs: u32) -> BigUint {
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
     let mut words = vec![0u32; num_words];
-    rd_mem_words_traced(state, ptr, &mut words);
+    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), num_words as u32);
+    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
     let mut bytes = vec![0u8; num_limbs as usize];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -163,7 +172,8 @@ pub unsafe fn write_bigint(state: *mut c_void, ptr: u32, value: &BigUint, num_li
                 .unwrap(),
         );
     }
-    wr_mem_words_traced(state, ptr, &words);
+    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
+    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
 }
 
 /// Modular inverse of `a` modulo `p` via extended GCD. Caller must ensure

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -7,8 +7,11 @@ use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use rvr_openvm_ext_ffi_common::{
     // TODO(follow-up): migrate algebra to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper, trace_rd_mem_u32_range_wrapper, trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper, WORD_SIZE,
+    rd_mem_u32_range_wrapper,
+    trace_rd_mem_u32_range_wrapper,
+    trace_wr_mem_u32_range_wrapper,
+    wr_mem_u32_range_wrapper,
+    WORD_SIZE,
 };
 
 /// Size of a 256-bit field element in bytes.

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -5,23 +5,16 @@ use std::ffi::c_void;
 use halo2curves_axiom::ff::PrimeField;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
-use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate algebra to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper,
-    WORD_SIZE,
-};
+use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_SIZE};
 
 /// Size of a 256-bit field element in bytes.
 pub const FIELD_256_BYTES: usize = 32;
-/// Number of 4-byte words in a 256-bit field element.
+/// Number of 8-byte words in a 256-bit field element.
 pub const FIELD_256_WORDS: usize = FIELD_256_BYTES / WORD_SIZE;
 
 /// Size of a BLS12-381 Fq element in bytes.
 pub const BLS12_381_ELEM_BYTES: usize = 48;
-/// Number of 4-byte words in a BLS12-381 Fq element.
+/// Number of 8-byte words in a BLS12-381 Fq element.
 pub const BLS12_381_ELEM_WORDS: usize = BLS12_381_ELEM_BYTES / WORD_SIZE;
 
 // ── FieldArith trait ─────────────────────────────────────────────────────────
@@ -52,9 +45,8 @@ pub trait FieldArith {
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
 pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void, ptr: u32) -> F {
-    let mut words = [0u32; FIELD_256_WORDS];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), FIELD_256_WORDS as u32);
-    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
+    let mut words = [0u64; FIELD_256_WORDS];
+    rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; FIELD_256_BYTES];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -82,16 +74,15 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
     val: &F,
 ) {
     let bytes = val.to_repr();
-    let mut words = [0u32; FIELD_256_WORDS];
+    let mut words = [0u64; FIELD_256_WORDS];
     for (i, w) in words.iter_mut().enumerate() {
-        *w = u32::from_le_bytes(
+        *w = u64::from_le_bytes(
             bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE]
                 .try_into()
                 .unwrap(),
         );
     }
-    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
-    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
+    wr_mem_words_traced(state, ptr, &words);
 }
 
 /// Read a BLS12-381 Fq element (48 bytes) from guest memory (traced).
@@ -100,9 +91,8 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
 pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> blstrs::Fp {
-    let mut words = [0u32; BLS12_381_ELEM_WORDS];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), BLS12_381_ELEM_WORDS as u32);
-    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
+    let mut words = [0u64; BLS12_381_ELEM_WORDS];
+    rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; BLS12_381_ELEM_BYTES];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -125,16 +115,15 @@ pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> blstrs::Fp {
 #[inline(always)]
 pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp) {
     let bytes = val.to_bytes_le();
-    let mut words = [0u32; BLS12_381_ELEM_WORDS];
+    let mut words = [0u64; BLS12_381_ELEM_WORDS];
     for (i, w) in words.iter_mut().enumerate() {
-        *w = u32::from_le_bytes(
+        *w = u64::from_le_bytes(
             bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE]
                 .try_into()
                 .unwrap(),
         );
     }
-    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
-    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
+    wr_mem_words_traced(state, ptr, &words);
 }
 
 // ── BigUint helpers (for unknown-modulus fallbacks) ──────────────────────────
@@ -147,9 +136,8 @@ pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp)
 #[inline]
 pub unsafe fn read_bigint(state: *mut c_void, ptr: u32, num_limbs: u32) -> BigUint {
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
-    let mut words = vec![0u32; num_words];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), num_words as u32);
-    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
+    let mut words = vec![0u64; num_words];
+    rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = vec![0u8; num_limbs as usize];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -167,16 +155,15 @@ pub unsafe fn write_bigint(state: *mut c_void, ptr: u32, value: &BigUint, num_li
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
     let mut bytes = value.to_bytes_le();
     bytes.resize(num_limbs as usize, 0);
-    let mut words = vec![0u32; num_words];
+    let mut words = vec![0u64; num_words];
     for (i, w) in words.iter_mut().enumerate() {
-        *w = u32::from_le_bytes(
+        *w = u64::from_le_bytes(
             bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE]
                 .try_into()
                 .unwrap(),
         );
     }
-    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
-    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
+    wr_mem_words_traced(state, ptr, &words);
 }
 
 /// Modular inverse of `a` modulo `p` via extended GCD. Caller must ensure

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -14,14 +14,7 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_bls12_381_fq, write_field_256, FieldArith, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
 };
 use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate fp2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper,
-    trace_mem_access_range,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper,
-    AS_MEMORY,
-    WORD_SIZE,
+    rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
 };
 
 // ── Field structs ───────────────────────────────────────────────────────────
@@ -238,9 +231,8 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     let num_words = total_limbs / WORD_SIZE as u32;
     debug_assert!(num_words >= 1);
 
-    let mut input_words = vec![0u32; num_words as usize];
-    rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_mut_ptr(), num_words);
-    trace_rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_ptr(), num_words);
+    let mut input_words = vec![0u64; num_words as usize];
+    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
 
     // Setup validates that the guest-provided base-field modulus and setup
@@ -249,7 +241,6 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     // In mod-builder, `Input(0)` means the first input slot. For setup, that
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so each setup coordinate writes p % p = 0.
-    let output_words = vec![0u32; num_words as usize];
-    trace_wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
-    wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
+    let output_words = vec![0u64; num_words as usize];
+    wr_mem_words_traced(state, rd_ptr, &output_words);
 }

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -15,8 +15,13 @@ use rvr_openvm_ext_algebra_ffi_common::{
 };
 use rvr_openvm_ext_ffi_common::{
     // TODO(follow-up): migrate fp2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper, trace_mem_access_range, trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper, wr_mem_u32_range_wrapper, AS_MEMORY, WORD_SIZE,
+    rd_mem_u32_range_wrapper,
+    trace_mem_access_range,
+    trace_rd_mem_u32_range_wrapper,
+    trace_wr_mem_u32_range_wrapper,
+    wr_mem_u32_range_wrapper,
+    AS_MEMORY,
+    WORD_SIZE,
 };
 
 // ── Field structs ───────────────────────────────────────────────────────────

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -14,7 +14,9 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_bls12_381_fq, write_field_256, FieldArith, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
 };
 use rvr_openvm_ext_ffi_common::{
-    rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
+    // TODO(follow-up): migrate fp2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
+    rd_mem_u32_range_wrapper, trace_mem_access_range, trace_rd_mem_u32_range_wrapper,
+    trace_wr_mem_u32_range_wrapper, wr_mem_u32_range_wrapper, AS_MEMORY, WORD_SIZE,
 };
 
 // ── Field structs ───────────────────────────────────────────────────────────
@@ -232,7 +234,8 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     debug_assert!(num_words >= 1);
 
     let mut input_words = vec![0u32; num_words as usize];
-    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
+    rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_mut_ptr(), num_words);
+    trace_rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_ptr(), num_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
 
     // Setup validates that the guest-provided base-field modulus and setup
@@ -242,5 +245,6 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so each setup coordinate writes p % p = 0.
     let output_words = vec![0u32; num_words as usize];
-    wr_mem_words_traced(state, rd_ptr, &output_words);
+    trace_wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
+    wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
 }

--- a/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
+++ b/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
@@ -13,7 +13,9 @@
 #error "k256 guest limb codecs require a little-endian host"
 #endif
 
-static constexpr uint32_t RVR_WORD_SIZE = 4;
+// TODO(follow-up): add some kind of checker during build time to ensure that
+//    RVR_WORD_SIZE and OpenVM WORD_SIZE don't differ from each other
+static constexpr uint32_t RVR_WORD_SIZE = 8;
 static constexpr uint32_t SECP256K1_ELEM_BYTES = 32;
 static constexpr uint32_t SECP256K1_ELEM_WORDS =
     SECP256K1_ELEM_BYTES / RVR_WORD_SIZE;
@@ -38,8 +40,8 @@ static inline void bytes_reverse_32(uint8_t out[SECP256K1_ELEM_BYTES],
 }
 
 static inline secp256k1_fe fe_read(RvState* state, uint32_t ptr) {
-  uint32_t words[SECP256K1_ELEM_WORDS];
-  rd_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  uint64_t words[SECP256K1_ELEM_WORDS];
+  rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
   memcpy(le, words, SECP256K1_ELEM_BYTES);
   uint8_t be[SECP256K1_ELEM_BYTES];
@@ -58,9 +60,9 @@ static inline void fe_write(RvState* state, uint32_t ptr,
   secp256k1_fe_get_b32(be, &t);
   uint8_t le[SECP256K1_ELEM_BYTES];
   bytes_reverse_32(le, be);
-  uint32_t words[SECP256K1_ELEM_WORDS];
+  uint64_t words[SECP256K1_ELEM_WORDS];
   memcpy(words, le, SECP256K1_ELEM_BYTES);
-  wr_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  wr_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
 }
 
 static inline secp256k1_fe fe_add(secp256k1_fe a, const secp256k1_fe* b) {
@@ -101,8 +103,8 @@ static inline int fe_is_zero(const secp256k1_fe* a) {
 /* ── k256 scalar (mod n) helpers ─────────────────────────────────────── */
 
 static inline secp256k1_scalar scalar_read(RvState* state, uint32_t ptr) {
-  uint32_t words[SECP256K1_ELEM_WORDS];
-  rd_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  uint64_t words[SECP256K1_ELEM_WORDS];
+  rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
   memcpy(le, words, SECP256K1_ELEM_BYTES);
   uint8_t be[SECP256K1_ELEM_BYTES];
@@ -118,9 +120,9 @@ static inline void scalar_write(RvState* state, uint32_t ptr,
   secp256k1_scalar_get_b32(be, val);
   uint8_t le[SECP256K1_ELEM_BYTES];
   bytes_reverse_32(le, be);
-  uint32_t words[SECP256K1_ELEM_WORDS];
+  uint64_t words[SECP256K1_ELEM_WORDS];
   memcpy(words, le, SECP256K1_ELEM_BYTES);
-  wr_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  wr_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
 }
 
 /* ── Modular arithmetic: secp256k1 coordinate field (mod p) ──────────── */

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -20,8 +20,10 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_bls12_381_fq, write_field_256, FieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
-    ext_hint_stream_set, rd_mem_u32_range_wrapper, rd_mem_words_traced, trace_mem_access_range,
-    wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
+    // TODO(follow-up): migrate modular to rd_mem_words_traced / wr_mem_words_traced ([u64])
+    ext_hint_stream_set, rd_mem_u32_range_wrapper, trace_mem_access_range,
+    trace_rd_mem_u32_range_wrapper, trace_wr_mem_u32_range_wrapper, wr_mem_u32_range_wrapper,
+    AS_MEMORY, WORD_SIZE,
 };
 
 // ── Field structs ────────────────────────────────────────────────────────────
@@ -260,7 +262,8 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     debug_assert!(num_words >= 1);
 
     let mut input_words = vec![0u32; num_words as usize];
-    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
+    rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_mut_ptr(), num_words);
+    trace_rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_ptr(), num_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
 
     // Setup validates that the guest-provided modulus and setup inputs match
@@ -270,7 +273,8 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so the setup output is p % p = 0.
     let output_words = vec![0u32; num_words as usize];
-    wr_mem_words_traced(state, rd_ptr, &output_words);
+    trace_wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
+    wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
 }
 
 // ── Phantom: HintSqrt ────────────────────────────────────────────────────────
@@ -341,6 +345,7 @@ pub unsafe extern "C" fn rvr_ext_algebra_hint_sqrt(
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
     let mut words = vec![0u32; num_words];
     rd_mem_u32_range_wrapper(state, rs1_ptr, words.as_mut_ptr(), num_words as u32);
+    // Note: no trace here — this is a phantom (hint) instruction, reads are not traced
     let mut x_bytes = vec![0u8; num_limbs as usize];
     for (i, &w) in words.iter().enumerate() {
         x_bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -21,9 +21,14 @@ use rvr_openvm_ext_algebra_ffi_common::{
 };
 use rvr_openvm_ext_ffi_common::{
     // TODO(follow-up): migrate modular to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    ext_hint_stream_set, rd_mem_u32_range_wrapper, trace_mem_access_range,
-    trace_rd_mem_u32_range_wrapper, trace_wr_mem_u32_range_wrapper, wr_mem_u32_range_wrapper,
-    AS_MEMORY, WORD_SIZE,
+    ext_hint_stream_set,
+    rd_mem_u32_range_wrapper,
+    trace_mem_access_range,
+    trace_rd_mem_u32_range_wrapper,
+    trace_wr_mem_u32_range_wrapper,
+    wr_mem_u32_range_wrapper,
+    AS_MEMORY,
+    WORD_SIZE,
 };
 
 // ── Field structs ────────────────────────────────────────────────────────────

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -20,15 +20,8 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_bls12_381_fq, write_field_256, FieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate modular to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    ext_hint_stream_set,
-    rd_mem_u32_range_wrapper,
-    trace_mem_access_range,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper,
-    AS_MEMORY,
-    WORD_SIZE,
+    ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_words_traced, trace_mem_access_range,
+    wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
 };
 
 // ── Field structs ────────────────────────────────────────────────────────────
@@ -266,9 +259,8 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     let num_words = num_limbs / WORD_SIZE as u32;
     debug_assert!(num_words >= 1);
 
-    let mut input_words = vec![0u32; num_words as usize];
-    rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_mut_ptr(), num_words);
-    trace_rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_ptr(), num_words);
+    let mut input_words = vec![0u64; num_words as usize];
+    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
 
     // Setup validates that the guest-provided modulus and setup inputs match
@@ -277,9 +269,8 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     // In mod-builder, `Input(0)` means the first input slot. For setup, that
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so the setup output is p % p = 0.
-    let output_words = vec![0u32; num_words as usize];
-    trace_wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
-    wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
+    let output_words = vec![0u64; num_words as usize];
+    wr_mem_words_traced(state, rd_ptr, &output_words);
 }
 
 // ── Phantom: HintSqrt ────────────────────────────────────────────────────────
@@ -348,8 +339,8 @@ pub unsafe extern "C" fn rvr_ext_algebra_hint_sqrt(
     let non_qr = BigUint::from_bytes_le(std::slice::from_raw_parts(non_qr_ptr, num_limbs as usize));
 
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
-    let mut words = vec![0u32; num_words];
-    rd_mem_u32_range_wrapper(state, rs1_ptr, words.as_mut_ptr(), num_words as u32);
+    let mut words = vec![0u64; num_words];
+    rd_mem_u64_range_wrapper(state, rs1_ptr, words.as_mut_ptr(), num_words as u32);
     // Note: no trace here — this is a phantom (hint) instruction, reads are not traced
     let mut x_bytes = vec![0u8; num_limbs as usize];
     for (i, &w) in words.iter().enumerate() {

--- a/extensions/bigint/rvr/ffi/src/lib.rs
+++ b/extensions/bigint/rvr/ffi/src/lib.rs
@@ -12,8 +12,14 @@ use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_S
 /// Number of bytes in a 256-bit integer.
 const INT256_BYTES: usize = 32;
 
-/// Number of 4-byte words in a 256-bit integer.
+/// Number of 8-byte (u64) words in a 256-bit integer; matches MEMORY_BLOCK_BYTES granularity.
 const INT256_WORDS: usize = INT256_BYTES / WORD_SIZE;
+
+/// Bytes in one u32 limb.
+const U32_LIMB_BYTES: usize = size_of::<u32>();
+
+/// Number of 4-byte (u32) limbs in a 256-bit integer; used for multiplication.
+const INT256_NUM_U32_LIMBS: usize = INT256_BYTES / U32_LIMB_BYTES;
 
 /// Bytes in one u64 limb.
 const U64_LIMB_BYTES: usize = size_of::<u64>();
@@ -36,7 +42,7 @@ const SIGN_BIT_MASK: u8 = 1 << SIGN_BIT_SHIFT;
 /// Read a 256-bit value from memory as INT256_WORDS LE words.
 #[inline]
 unsafe fn read_int256(state: *mut c_void, ptr: u32) -> [u8; INT256_BYTES] {
-    let mut words = [0u32; INT256_WORDS];
+    let mut words = [0u64; INT256_WORDS];
     rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; INT256_BYTES];
     for (i, w) in words.iter().enumerate() {
@@ -48,9 +54,9 @@ unsafe fn read_int256(state: *mut c_void, ptr: u32) -> [u8; INT256_BYTES] {
 /// Write a 256-bit value to memory as INT256_WORDS LE words.
 #[inline]
 unsafe fn write_int256(state: *mut c_void, ptr: u32, bytes: &[u8; INT256_BYTES]) {
-    let mut words = [0u32; INT256_WORDS];
+    let mut words = [0u64; INT256_WORDS];
     for (i, w) in words.iter_mut().enumerate() {
-        *w = u32::from_le_bytes(
+        *w = u64::from_le_bytes(
             bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE]
                 .try_into()
                 .unwrap(),
@@ -84,19 +90,23 @@ fn from_u64(a: &[u64; INT256_U64_LIMBS]) -> [u8; INT256_BYTES] {
 }
 
 #[inline]
-fn to_u32_arr(b: &[u8; INT256_BYTES]) -> [u32; INT256_WORDS] {
-    let mut out = [0u32; INT256_WORDS];
-    for i in 0..INT256_WORDS {
-        out[i] = u32::from_le_bytes(b[i * WORD_SIZE..(i + 1) * WORD_SIZE].try_into().unwrap());
+fn to_u32_arr(b: &[u8; INT256_BYTES]) -> [u32; INT256_NUM_U32_LIMBS] {
+    let mut out = [0u32; INT256_NUM_U32_LIMBS];
+    for i in 0..INT256_NUM_U32_LIMBS {
+        out[i] = u32::from_le_bytes(
+            b[i * U32_LIMB_BYTES..(i + 1) * U32_LIMB_BYTES]
+                .try_into()
+                .unwrap(),
+        );
     }
     out
 }
 
 #[inline]
-fn from_u32_arr(a: &[u32; INT256_WORDS]) -> [u8; INT256_BYTES] {
+fn from_u32_arr(a: &[u32; INT256_NUM_U32_LIMBS]) -> [u8; INT256_BYTES] {
     let mut out = [0u8; INT256_BYTES];
-    for i in 0..INT256_WORDS {
-        out[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&a[i].to_le_bytes());
+    for i in 0..INT256_NUM_U32_LIMBS {
+        out[i * U32_LIMB_BYTES..(i + 1) * U32_LIMB_BYTES].copy_from_slice(&a[i].to_le_bytes());
     }
     out
 }
@@ -232,10 +242,10 @@ fn u256_sltu(a: &[u8; INT256_BYTES], b: &[u8; INT256_BYTES]) -> [u8; INT256_BYTE
 fn u256_mul(a: &[u8; INT256_BYTES], b: &[u8; INT256_BYTES]) -> [u8; INT256_BYTES] {
     let a = to_u32_arr(a);
     let b = to_u32_arr(b);
-    let mut r = [0u32; INT256_WORDS];
-    for i in 0..INT256_WORDS {
+    let mut r = [0u32; INT256_NUM_U32_LIMBS];
+    for i in 0..INT256_NUM_U32_LIMBS {
         let mut carry = 0u64;
-        for j in 0..(INT256_WORDS - i) {
+        for j in 0..(INT256_NUM_U32_LIMBS - i) {
             let res = a[i] as u64 * b[j] as u64 + r[i + j] as u64 + carry;
             r[i + j] = res as u32;
             carry = res >> u32::BITS;
@@ -347,7 +357,7 @@ mod tests {
 
     fn shift_arg(shift: u32) -> [u8; INT256_BYTES] {
         let mut bytes = [0u8; INT256_BYTES];
-        bytes[..WORD_SIZE].copy_from_slice(&shift.to_le_bytes());
+        bytes[..U32_LIMB_BYTES].copy_from_slice(&shift.to_le_bytes());
         bytes
     }
 
@@ -355,7 +365,7 @@ mod tests {
     fn test_u256_add_and_sub_across_limbs() {
         let a = u256_from_u64s([u64::MAX, u64::MAX, 0, 0]);
         let one = u256_from_u64s([1, 0, 0, 0]);
-        let sum = u256_add(&a, &one);
+        let sum: [u8; 32] = u256_add(&a, &one);
         assert_eq!(to_u64(&sum), [0, 0, 1, 0]);
 
         let back = u256_sub(&sum, &one);

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -17,8 +17,11 @@ use rvr_openvm_ext_algebra_ffi_common::{
 };
 use rvr_openvm_ext_ffi_common::{
     // TODO(follow-up): migrate ecc to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper, trace_rd_mem_u32_range_wrapper, trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper, WORD_SIZE,
+    rd_mem_u32_range_wrapper,
+    trace_rd_mem_u32_range_wrapper,
+    trace_wr_mem_u32_range_wrapper,
+    wr_mem_u32_range_wrapper,
+    WORD_SIZE,
 };
 
 /// Affine point: two field coordinates (x, y).

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -15,14 +15,7 @@ use rvr_openvm_ext_algebra_ffi_common::{
     read_bls12_381_fq, read_field_256, write_bls12_381_fq, write_field_256, BLS12_381_ELEM_BYTES,
     FIELD_256_BYTES,
 };
-use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate ecc to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper,
-    WORD_SIZE,
-};
+use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_SIZE};
 
 /// Affine point: two field coordinates (x, y).
 const AFFINE_COORDS: u32 = 2;
@@ -131,9 +124,8 @@ const P256_A_ABS: u64 = 3;
 unsafe fn trace_read_bytes(state: *mut c_void, ptr: u32, len: u32) -> Vec<u8> {
     debug_assert_eq!(len % WORD_SIZE as u32, 0);
     let num_words = (len as usize) / WORD_SIZE;
-    let mut words = vec![0u32; num_words];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), num_words as u32);
-    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
+    let mut words = vec![0u64; num_words];
+    rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = Vec::with_capacity(len as usize);
     for &w in &words {
         bytes.extend_from_slice(&w.to_le_bytes());
@@ -143,12 +135,11 @@ unsafe fn trace_read_bytes(state: *mut c_void, ptr: u32, len: u32) -> Vec<u8> {
 
 unsafe fn trace_write_bytes(state: *mut c_void, ptr: u32, bytes: &[u8]) {
     debug_assert_eq!(bytes.len() % WORD_SIZE, 0);
-    let words: Vec<u32> = bytes
+    let words: Vec<u64> = bytes
         .chunks_exact(WORD_SIZE)
-        .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
         .collect();
-    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), words.len() as u32);
-    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), words.len() as u32);
+    wr_mem_words_traced(state, ptr, &words);
 }
 
 fn ecc_setup_expr(point_bytes: u32, setup_bytes: &[u8], is_double: bool) -> Vec<u8> {

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -15,7 +15,11 @@ use rvr_openvm_ext_algebra_ffi_common::{
     read_bls12_381_fq, read_field_256, write_bls12_381_fq, write_field_256, BLS12_381_ELEM_BYTES,
     FIELD_256_BYTES,
 };
-use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_SIZE};
+use rvr_openvm_ext_ffi_common::{
+    // TODO(follow-up): migrate ecc to rd_mem_words_traced / wr_mem_words_traced ([u64])
+    rd_mem_u32_range_wrapper, trace_rd_mem_u32_range_wrapper, trace_wr_mem_u32_range_wrapper,
+    wr_mem_u32_range_wrapper, WORD_SIZE,
+};
 
 /// Affine point: two field coordinates (x, y).
 const AFFINE_COORDS: u32 = 2;
@@ -125,7 +129,8 @@ unsafe fn trace_read_bytes(state: *mut c_void, ptr: u32, len: u32) -> Vec<u8> {
     debug_assert_eq!(len % WORD_SIZE as u32, 0);
     let num_words = (len as usize) / WORD_SIZE;
     let mut words = vec![0u32; num_words];
-    rd_mem_words_traced(state, ptr, &mut words);
+    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), num_words as u32);
+    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
     let mut bytes = Vec::with_capacity(len as usize);
     for &w in &words {
         bytes.extend_from_slice(&w.to_le_bytes());
@@ -139,7 +144,8 @@ unsafe fn trace_write_bytes(state: *mut c_void, ptr: u32, bytes: &[u8]) {
         .chunks_exact(WORD_SIZE)
         .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
         .collect();
-    wr_mem_words_traced(state, ptr, &words);
+    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), words.len() as u32);
+    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), words.len() as u32);
 }
 
 fn ecc_setup_expr(point_bytes: u32, setup_bytes: &[u8], is_double: bool) -> Vec<u8> {

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.c
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.c
@@ -3,8 +3,6 @@
  * time). Compiled into the generated native project so clang can inline the
  * tracer helpers. */
 
-#include <string.h>
-
 #include "openvm.h"
 
 static constexpr uint32_t KECCAK_WIDTH_BYTES = 200;
@@ -17,18 +15,12 @@ __attribute__((preserve_most)) void rvr_ext_keccakf(RvState* restrict state,
                                                     uint32_t buffer_ptr,
                                                     uint32_t _op_chip_idx,
                                                     uint32_t perm_chip_idx) {
-  /* u64-aligned scratch; the u32 view is zero-copy on LE. */
-  uint64_t st[KECCAK_WIDTH_WORDS / 2];
+  uint64_t st[KECCAK_WIDTH_WORDS];
   static_assert(sizeof(st) == KECCAK_WIDTH_BYTES, "keccak state size mismatch");
 
-  uint32_t words[KECCAK_WIDTH_WORDS];
-  rd_mem_u32_range_traced(state, buffer_ptr, words, KECCAK_WIDTH_WORDS);
-  memcpy(st, words, KECCAK_WIDTH_BYTES);
-
+  rd_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
   rvr_keccak_f1600(st);
-
-  memcpy(words, st, KECCAK_WIDTH_BYTES);
-  wr_mem_u32_range_traced(state, buffer_ptr, words, KECCAK_WIDTH_WORDS);
+  wr_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
 
   /* KeccakfOp cost (1 row) is covered by the per-block chip update emitted
    * at block entry; only the additional KeccakfPerm rows (24 per
@@ -46,14 +38,14 @@ __attribute__((preserve_most)) void rvr_ext_xorin(RvState* restrict state,
     return;
   }
 
-  uint32_t buffer[KECCAK_WIDTH_WORDS];
-  uint32_t input[KECCAK_WIDTH_WORDS];
+  uint64_t buffer[KECCAK_WIDTH_WORDS];
+  uint64_t input[KECCAK_WIDTH_WORDS];
   assume(num_words <= KECCAK_WIDTH_WORDS);
 
-  rd_mem_u32_range_traced(state, buffer_ptr, buffer, num_words);
-  rd_mem_u32_range_traced(state, input_ptr, input, num_words);
+  rd_mem_u64_range_traced(state, buffer_ptr, buffer, num_words);
+  rd_mem_u64_range_traced(state, input_ptr, input, num_words);
   for (uint32_t i = 0; i < num_words; i++) {
     buffer[i] ^= input[i];
   }
-  wr_mem_u32_range_traced(state, buffer_ptr, buffer, num_words);
+  wr_mem_u64_range_traced(state, buffer_ptr, buffer, num_words);
 }

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -13,7 +13,7 @@ use openvm_pairing_guest::{
 };
 use rvr_openvm_ext_algebra_ffi_common::{BLS12_381_ELEM_BYTES, FIELD_256_BYTES};
 use rvr_openvm_ext_ffi_common::{
-    ext_hint_stream_set, rd_mem_u32_range_wrapper, rd_mem_u32_wrapper, WORD_SIZE,
+    ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_u64_wrapper, WORD_SIZE,
 };
 
 /// BN254 base field element size in bytes.
@@ -47,8 +47,8 @@ unsafe fn read_bytes<const N: usize>(state: *mut c_void, ptr: u32) -> [u8; N] {
         );
     }
     let num_words = N / WORD_SIZE;
-    let mut words = vec![0u32; num_words];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), num_words as u32);
+    let mut words = vec![0u64; num_words];
+    rd_mem_u64_range_wrapper(state, ptr, words.as_mut_ptr(), num_words as u32);
     let mut bytes = [0u8; N];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -68,17 +68,18 @@ unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> Option<bls12_381::F
     Option::from(bls12_381::Fq::from_repr(bytes.into()))
 }
 
-fn point_base(ptr: u32, idx: u32, words_per_point: u32) -> Option<u32> {
-    idx.checked_mul(words_per_point)?.checked_add(ptr)
+fn point_base(ptr: u64, idx: u64, words_per_point: u32) -> Option<u32> {
+    let offset = idx.checked_mul(words_per_point as u64)?;
+    ptr.checked_add(offset)?.try_into().ok()
 }
 
 // ── BN254 pairing hint ──────────────────────────────────────────────────
 
 unsafe fn hint_bn254(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<Vec<u8>> {
-    let p_ptr = rd_mem_u32_wrapper(state, rs1_val);
-    let p_len = rd_mem_u32_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
-    let q_ptr = rd_mem_u32_wrapper(state, rs2_val);
-    let q_len = rd_mem_u32_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
+    let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
+    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
+    let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
+    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
 
     if p_len != q_len {
         return None;
@@ -127,10 +128,10 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<V
 // ── BLS12-381 pairing hint ──────────────────────────────────────────────
 
 unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<Vec<u8>> {
-    let p_ptr = rd_mem_u32_wrapper(state, rs1_val);
-    let p_len = rd_mem_u32_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
-    let q_ptr = rd_mem_u32_wrapper(state, rs2_val);
-    let q_len = rd_mem_u32_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
+    let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
+    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
+    let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
+    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
 
     if p_len != q_len {
         return None;

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -10,8 +10,13 @@ use std::ffi::c_void;
 use generic_array::GenericArray;
 use rvr_openvm_ext_ffi_common::{
     // TODO(follow-up): migrate sha2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper, trace_chip_wrapper, trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper, u64s_as_u32s, u64s_as_u32s_mut, wr_mem_u32_range_wrapper,
+    rd_mem_u32_range_wrapper,
+    trace_chip_wrapper,
+    trace_rd_mem_u32_range_wrapper,
+    trace_wr_mem_u32_range_wrapper,
+    u64s_as_u32s,
+    u64s_as_u32s_mut,
+    wr_mem_u32_range_wrapper,
 };
 use sha2::{compress256, compress512};
 
@@ -60,11 +65,31 @@ pub unsafe extern "C" fn rvr_ext_sha256(
 ) {
     // Read state (8 u32) and input block (16 u32) from memory.
     let mut state_words = [0u32; SHA256_STATE_WORDS];
-    rd_mem_u32_range_wrapper(state, state_ptr, state_words.as_mut_ptr(), SHA256_STATE_WORDS as u32);
-    trace_rd_mem_u32_range_wrapper(state, state_ptr, state_words.as_ptr(), SHA256_STATE_WORDS as u32);
+    rd_mem_u32_range_wrapper(
+        state,
+        state_ptr,
+        state_words.as_mut_ptr(),
+        SHA256_STATE_WORDS as u32,
+    );
+    trace_rd_mem_u32_range_wrapper(
+        state,
+        state_ptr,
+        state_words.as_ptr(),
+        SHA256_STATE_WORDS as u32,
+    );
     let mut block_words = [0u32; SHA256_BLOCK_WORDS];
-    rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_mut_ptr(), SHA256_BLOCK_WORDS as u32);
-    trace_rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_ptr(), SHA256_BLOCK_WORDS as u32);
+    rd_mem_u32_range_wrapper(
+        state,
+        input_ptr,
+        block_words.as_mut_ptr(),
+        SHA256_BLOCK_WORDS as u32,
+    );
+    trace_rd_mem_u32_range_wrapper(
+        state,
+        input_ptr,
+        block_words.as_ptr(),
+        SHA256_BLOCK_WORDS as u32,
+    );
 
     // compress256 wants the block as `GenericArray<u8, U64>`. Reinterpret the
     // u32 buffer as bytes (zero-copy on LE).
@@ -72,8 +97,18 @@ pub unsafe extern "C" fn rvr_ext_sha256(
         GenericArray::from_slice(u32_words_as_bytes(&block_words));
     compress256(&mut state_words, &[*block_array]);
 
-    trace_wr_mem_u32_range_wrapper(state, dst_ptr, state_words.as_ptr(), SHA256_STATE_WORDS as u32);
-    wr_mem_u32_range_wrapper(state, dst_ptr, state_words.as_ptr(), SHA256_STATE_WORDS as u32);
+    trace_wr_mem_u32_range_wrapper(
+        state,
+        dst_ptr,
+        state_words.as_ptr(),
+        SHA256_STATE_WORDS as u32,
+    );
+    wr_mem_u32_range_wrapper(
+        state,
+        dst_ptr,
+        state_words.as_ptr(),
+        SHA256_STATE_WORDS as u32,
+    );
 
     // Trace chip height for metering.
     // The per-instruction Sha2Main cost (1 row) is covered by the per-block
@@ -109,8 +144,18 @@ pub unsafe extern "C" fn rvr_ext_sha512(
         trace_rd_mem_u32_range_wrapper(state, state_ptr, s.as_ptr(), s.len() as u32);
     }
     let mut block_words = [0u32; SHA512_BLOCK_WORDS];
-    rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_mut_ptr(), SHA512_BLOCK_WORDS as u32);
-    trace_rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_ptr(), SHA512_BLOCK_WORDS as u32);
+    rd_mem_u32_range_wrapper(
+        state,
+        input_ptr,
+        block_words.as_mut_ptr(),
+        SHA512_BLOCK_WORDS as u32,
+    );
+    trace_rd_mem_u32_range_wrapper(
+        state,
+        input_ptr,
+        block_words.as_ptr(),
+        SHA512_BLOCK_WORDS as u32,
+    );
 
     let block_array: &GenericArray<u8, _> =
         GenericArray::from_slice(u32_words_as_bytes(&block_words));

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -9,7 +9,9 @@ use std::ffi::c_void;
 
 use generic_array::GenericArray;
 use rvr_openvm_ext_ffi_common::{
-    rd_mem_words_traced, trace_chip_wrapper, u64s_as_u32s, u64s_as_u32s_mut, wr_mem_words_traced,
+    // TODO(follow-up): migrate sha2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
+    rd_mem_u32_range_wrapper, trace_chip_wrapper, trace_rd_mem_u32_range_wrapper,
+    trace_wr_mem_u32_range_wrapper, u64s_as_u32s, u64s_as_u32s_mut, wr_mem_u32_range_wrapper,
 };
 use sha2::{compress256, compress512};
 
@@ -58,9 +60,11 @@ pub unsafe extern "C" fn rvr_ext_sha256(
 ) {
     // Read state (8 u32) and input block (16 u32) from memory.
     let mut state_words = [0u32; SHA256_STATE_WORDS];
-    rd_mem_words_traced(state, state_ptr, &mut state_words);
+    rd_mem_u32_range_wrapper(state, state_ptr, state_words.as_mut_ptr(), SHA256_STATE_WORDS as u32);
+    trace_rd_mem_u32_range_wrapper(state, state_ptr, state_words.as_ptr(), SHA256_STATE_WORDS as u32);
     let mut block_words = [0u32; SHA256_BLOCK_WORDS];
-    rd_mem_words_traced(state, input_ptr, &mut block_words);
+    rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_mut_ptr(), SHA256_BLOCK_WORDS as u32);
+    trace_rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_ptr(), SHA256_BLOCK_WORDS as u32);
 
     // compress256 wants the block as `GenericArray<u8, U64>`. Reinterpret the
     // u32 buffer as bytes (zero-copy on LE).
@@ -68,7 +72,8 @@ pub unsafe extern "C" fn rvr_ext_sha256(
         GenericArray::from_slice(u32_words_as_bytes(&block_words));
     compress256(&mut state_words, &[*block_array]);
 
-    wr_mem_words_traced(state, dst_ptr, &state_words);
+    trace_wr_mem_u32_range_wrapper(state, dst_ptr, state_words.as_ptr(), SHA256_STATE_WORDS as u32);
+    wr_mem_u32_range_wrapper(state, dst_ptr, state_words.as_ptr(), SHA256_STATE_WORDS as u32);
 
     // Trace chip height for metering.
     // The per-instruction Sha2Main cost (1 row) is covered by the per-block
@@ -98,15 +103,24 @@ pub unsafe extern "C" fn rvr_ext_sha512(
     // u64-aligned scratch holds the SHA-512 state; reinterpret as u32 words at
     // the FFI boundary (zero-copy on LE).
     let mut state_u64s = [0u64; HASH_STATE_LEN];
-    rd_mem_words_traced(state, state_ptr, u64s_as_u32s_mut(&mut state_u64s));
+    {
+        let s = u64s_as_u32s_mut(&mut state_u64s);
+        rd_mem_u32_range_wrapper(state, state_ptr, s.as_mut_ptr(), s.len() as u32);
+        trace_rd_mem_u32_range_wrapper(state, state_ptr, s.as_ptr(), s.len() as u32);
+    }
     let mut block_words = [0u32; SHA512_BLOCK_WORDS];
-    rd_mem_words_traced(state, input_ptr, &mut block_words);
+    rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_mut_ptr(), SHA512_BLOCK_WORDS as u32);
+    trace_rd_mem_u32_range_wrapper(state, input_ptr, block_words.as_ptr(), SHA512_BLOCK_WORDS as u32);
 
     let block_array: &GenericArray<u8, _> =
         GenericArray::from_slice(u32_words_as_bytes(&block_words));
     compress512(&mut state_u64s, &[*block_array]);
 
-    wr_mem_words_traced(state, dst_ptr, u64s_as_u32s(&state_u64s));
+    {
+        let s = u64s_as_u32s(&state_u64s);
+        trace_wr_mem_u32_range_wrapper(state, dst_ptr, s.as_ptr(), s.len() as u32);
+        wr_mem_u32_range_wrapper(state, dst_ptr, s.as_ptr(), s.len() as u32);
+    }
 
     // Trace chip height for metering.
     trace_chip_wrapper(state, block_hasher_chip_idx, SHA512_ROWS_PER_BLOCK);

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -9,38 +9,28 @@ use std::ffi::c_void;
 
 use generic_array::GenericArray;
 use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate sha2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper,
-    trace_chip_wrapper,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    u64s_as_u32s,
-    u64s_as_u32s_mut,
-    wr_mem_u32_range_wrapper,
+    rd_mem_words_traced, trace_chip_wrapper, u64s_as_u32s_mut, wr_mem_words_traced, WORD_SIZE,
 };
 use sha2::{compress256, compress512};
 
-const U32_BYTES: usize = core::mem::size_of::<u32>();
-
-// SHA-256 constants
+// SHA-256: 32-byte state (4 u64s / 8 u32s), 64-byte block (8 u64s)
 const SHA256_STATE_BYTES: usize = 32;
 const SHA256_BLOCK_BYTES: usize = 64;
-const SHA256_STATE_WORDS: usize = SHA256_STATE_BYTES / U32_BYTES;
-const SHA256_BLOCK_WORDS: usize = SHA256_BLOCK_BYTES / U32_BYTES;
+const SHA256_STATE_WORDS: usize = SHA256_STATE_BYTES / WORD_SIZE;
+const SHA256_BLOCK_WORDS: usize = SHA256_BLOCK_BYTES / WORD_SIZE;
 const SHA256_ROWS_PER_BLOCK: u32 = 17;
 
-// SHA-512 constants
+// SHA-512: 64-byte state (8 u64s), 128-byte block (16 u64s)
+const SHA512_STATE_BYTES: usize = 64;
 const SHA512_BLOCK_BYTES: usize = 128;
-const SHA512_BLOCK_WORDS: usize = SHA512_BLOCK_BYTES / U32_BYTES;
+const SHA512_STATE_WORDS: usize = SHA512_STATE_BYTES / WORD_SIZE;
+const SHA512_BLOCK_WORDS: usize = SHA512_BLOCK_BYTES / WORD_SIZE;
 const SHA512_ROWS_PER_BLOCK: u32 = 21;
 
-/// Both SHA-256 and SHA-512 use 8-element internal state arrays.
-const HASH_STATE_LEN: usize = 8;
-
 #[inline(always)]
-fn u32_words_as_bytes(words: &[u32]) -> &[u8] {
-    let len = words.len() * U32_BYTES;
-    // SAFETY: u32 alignment is stricter than u8 alignment, total bytes match,
+fn u64_words_as_bytes(words: &[u64]) -> &[u8] {
+    let len = std::mem::size_of_val(words);
+    // SAFETY: u64 alignment is stricter than u8 alignment, total bytes match,
     // and the FFI backend is only supported on little-endian hosts.
     unsafe { core::slice::from_raw_parts(words.as_ptr().cast::<u8>(), len) }
 }
@@ -63,57 +53,21 @@ pub unsafe extern "C" fn rvr_ext_sha256(
     _main_chip_idx: u32,
     block_hasher_chip_idx: u32,
 ) {
-    // Read state (8 u32) and input block (16 u32) from memory.
-    let mut state_words = [0u32; SHA256_STATE_WORDS];
-    rd_mem_u32_range_wrapper(
-        state,
-        state_ptr,
-        state_words.as_mut_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
-    trace_rd_mem_u32_range_wrapper(
-        state,
-        state_ptr,
-        state_words.as_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
-    let mut block_words = [0u32; SHA256_BLOCK_WORDS];
-    rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_mut_ptr(),
-        SHA256_BLOCK_WORDS as u32,
-    );
-    trace_rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_ptr(),
-        SHA256_BLOCK_WORDS as u32,
-    );
+    // Read state as 4 u64s (32 bytes); view as [u32; 8] for compress256.
+    let mut state_words = [0u64; SHA256_STATE_WORDS];
+    rd_mem_words_traced(state, state_ptr, &mut state_words);
+    let state_u32s: &mut [u32; 8] = u64s_as_u32s_mut(&mut state_words).try_into().unwrap();
 
-    // compress256 wants the block as `GenericArray<u8, U64>`. Reinterpret the
-    // u32 buffer as bytes (zero-copy on LE).
+    // Read block as 8 u64s (64 bytes); view as bytes for compress256.
+    let mut block_words = [0u64; SHA256_BLOCK_WORDS];
+    rd_mem_words_traced(state, input_ptr, &mut block_words);
     let block_array: &GenericArray<u8, _> =
-        GenericArray::from_slice(u32_words_as_bytes(&block_words));
-    compress256(&mut state_words, &[*block_array]);
+        GenericArray::from_slice(u64_words_as_bytes(&block_words));
 
-    trace_wr_mem_u32_range_wrapper(
-        state,
-        dst_ptr,
-        state_words.as_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
-    wr_mem_u32_range_wrapper(
-        state,
-        dst_ptr,
-        state_words.as_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
+    compress256(state_u32s, &[*block_array]);
+    // state_u32s borrow ends here; state_words now holds the compressed state.
 
-    // Trace chip height for metering.
-    // The per-instruction Sha2Main cost (1 row) is covered by the per-block
-    // chip update emitted at block entry.
-    // Only the additional Sha2BlockHasher rows need trace_chip.
+    wr_mem_words_traced(state, dst_ptr, &state_words);
     trace_chip_wrapper(state, block_hasher_chip_idx, SHA256_ROWS_PER_BLOCK);
 }
 
@@ -135,38 +89,18 @@ pub unsafe extern "C" fn rvr_ext_sha512(
     _main_chip_idx: u32,
     block_hasher_chip_idx: u32,
 ) {
-    // u64-aligned scratch holds the SHA-512 state; reinterpret as u32 words at
-    // the FFI boundary (zero-copy on LE).
-    let mut state_u64s = [0u64; HASH_STATE_LEN];
-    {
-        let s = u64s_as_u32s_mut(&mut state_u64s);
-        rd_mem_u32_range_wrapper(state, state_ptr, s.as_mut_ptr(), s.len() as u32);
-        trace_rd_mem_u32_range_wrapper(state, state_ptr, s.as_ptr(), s.len() as u32);
-    }
-    let mut block_words = [0u32; SHA512_BLOCK_WORDS];
-    rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_mut_ptr(),
-        SHA512_BLOCK_WORDS as u32,
-    );
-    trace_rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_ptr(),
-        SHA512_BLOCK_WORDS as u32,
-    );
+    // SHA-512 state is naturally [u64; 8]; read directly.
+    let mut state_u64s = [0u64; SHA512_STATE_WORDS];
+    rd_mem_words_traced(state, state_ptr, &mut state_u64s);
 
+    // Read block as 16 u64s (128 bytes); view as bytes for compress512.
+    let mut block_words = [0u64; SHA512_BLOCK_WORDS];
+    rd_mem_words_traced(state, input_ptr, &mut block_words);
     let block_array: &GenericArray<u8, _> =
-        GenericArray::from_slice(u32_words_as_bytes(&block_words));
+        GenericArray::from_slice(u64_words_as_bytes(&block_words));
+
     compress512(&mut state_u64s, &[*block_array]);
 
-    {
-        let s = u64s_as_u32s(&state_u64s);
-        trace_wr_mem_u32_range_wrapper(state, dst_ptr, s.as_ptr(), s.len() as u32);
-        wr_mem_u32_range_wrapper(state, dst_ptr, s.as_ptr(), s.len() as u32);
-    }
-
-    // Trace chip height for metering.
+    wr_mem_words_traced(state, dst_ptr, &state_u64s);
     trace_chip_wrapper(state, block_hasher_chip_idx, SHA512_ROWS_PER_BLOCK);
 }


### PR DESCRIPTION
rvr support for the rv64 bigint extension

`rd/wr_mem_words_traced` in `rvr-openvm-ffi-common` was updated to operate at OpenVM's native word size (8 bytes, matching `MEMORY_BLOCK_BYTES`). Previously it used 4-byte (u32) granularity, which was logically incorrect for rv64. The bigint extension uses the corrected API.

This change broke compilation for other extensions (sha2, ecc, algebra) that depended on the old u32 signature. As a temporary fix, those extensions bypass `rd/wr_mem_words_traced` and call the underlying u32 range wrappers directly. Each call site is marked with a TODO to migrate properly when rvr support is added for that extension.

The bigint MULT operation follows the interpreter and uses a u32/u64 combination (8 × u32 limbs, accumulating into u64). RISC-V's native MULW/MUL uses u64/u128. Should we align to the u64/u128 approach, or keep it consistent with the interpreter?

towards INT-8108

