### PR TITLE
feat: rvr support for sha2 extension

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -47,7 +47,7 @@ jobs:
           # TODO(rvr): re-enable these once RV64 RVR support lands.
           - { name: "riscv", path: "riscv", aot: false, rvr: true }
           # - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
-          # - { name: "sha2", path: "sha2", aot: false, rvr: true }
+          - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
           # - { name: "algebra", path: "algebra", aot: false, rvr: true }
           # - { name: "ecc", path: "ecc", aot: false, rvr: true }

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - { name: "pairing", path: "pairing", rvr: false }
           - { name: "verify-stark", path: "verify-stark/circuit", rvr: false }
           # TODO(rvr): re-enable these once RV64 RVR support lands.
-          # - { name: "sha2", path: "sha2", rvr: true }
+          - { name: "sha2", path: "sha2", rvr: true }
           # - { name: "keccak256", path: "keccak256", rvr: true }
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
           # - { name: "k256", path: "k256", rvr: true }
@@ -102,13 +102,13 @@ jobs:
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
           EXTRA_ARGS=()
           # TODO(rvr): restore this branch when the rvr matrix entries above are re-enabled.
-          # if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
-          #   if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
-          #     EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
-          #   else
-          #     EXTRA_ARGS+=(--features=rvr)
-          #   fi
-          if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+          if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
+            if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+              EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
+            else
+              EXTRA_ARGS+=(--features=rvr)
+            fi
+          elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381 -E 'not test(fallback)')
           fi
 

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -36,11 +36,11 @@ jobs:
               features: "",
             }
           # TODO(rvr): re-enable once RV64 RVR support lands.
-          # - {
-          #     labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
-          #     image: "ubuntu24-full-x64",
-          #     features: "rvr",
-          #   }
+          - {
+              labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
+              image: "ubuntu24-full-x64",
+              features: "rvr",
+            }
           - {
               labels: "image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized",
               image: "ubuntu24-gpu-x64",

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -29,7 +29,7 @@ const SHA512_ROWS_PER_BLOCK: u32 = 21;
 
 #[inline(always)]
 fn u64_words_as_bytes(words: &[u64]) -> &[u8] {
-    let len = words.len() * core::mem::size_of::<u64>();
+    let len = std::mem::size_of_val(words);
     // SAFETY: u64 alignment is stricter than u8 alignment, total bytes match,
     // and the FFI backend is only supported on little-endian hosts.
     unsafe { core::slice::from_raw_parts(words.as_ptr().cast::<u8>(), len) }

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -9,38 +9,28 @@ use std::ffi::c_void;
 
 use generic_array::GenericArray;
 use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate sha2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper,
-    trace_chip_wrapper,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    u64s_as_u32s,
-    u64s_as_u32s_mut,
-    wr_mem_u32_range_wrapper,
+    rd_mem_words_traced, trace_chip_wrapper, u64s_as_u32s_mut, wr_mem_words_traced, WORD_SIZE,
 };
 use sha2::{compress256, compress512};
 
-const U32_BYTES: usize = core::mem::size_of::<u32>();
-
-// SHA-256 constants
+// SHA-256: 32-byte state (4 u64s / 8 u32s), 64-byte block (8 u64s)
 const SHA256_STATE_BYTES: usize = 32;
 const SHA256_BLOCK_BYTES: usize = 64;
-const SHA256_STATE_WORDS: usize = SHA256_STATE_BYTES / U32_BYTES;
-const SHA256_BLOCK_WORDS: usize = SHA256_BLOCK_BYTES / U32_BYTES;
+const SHA256_STATE_WORDS: usize = SHA256_STATE_BYTES / WORD_SIZE;
+const SHA256_BLOCK_WORDS: usize = SHA256_BLOCK_BYTES / WORD_SIZE;
 const SHA256_ROWS_PER_BLOCK: u32 = 17;
 
-// SHA-512 constants
+// SHA-512: 64-byte state (8 u64s), 128-byte block (16 u64s)
+const SHA512_STATE_BYTES: usize = 64;
 const SHA512_BLOCK_BYTES: usize = 128;
-const SHA512_BLOCK_WORDS: usize = SHA512_BLOCK_BYTES / U32_BYTES;
+const SHA512_STATE_WORDS: usize = SHA512_STATE_BYTES / WORD_SIZE;
+const SHA512_BLOCK_WORDS: usize = SHA512_BLOCK_BYTES / WORD_SIZE;
 const SHA512_ROWS_PER_BLOCK: u32 = 21;
 
-/// Both SHA-256 and SHA-512 use 8-element internal state arrays.
-const HASH_STATE_LEN: usize = 8;
-
 #[inline(always)]
-fn u32_words_as_bytes(words: &[u32]) -> &[u8] {
-    let len = words.len() * U32_BYTES;
-    // SAFETY: u32 alignment is stricter than u8 alignment, total bytes match,
+fn u64_words_as_bytes(words: &[u64]) -> &[u8] {
+    let len = words.len() * core::mem::size_of::<u64>();
+    // SAFETY: u64 alignment is stricter than u8 alignment, total bytes match,
     // and the FFI backend is only supported on little-endian hosts.
     unsafe { core::slice::from_raw_parts(words.as_ptr().cast::<u8>(), len) }
 }
@@ -63,57 +53,21 @@ pub unsafe extern "C" fn rvr_ext_sha256(
     _main_chip_idx: u32,
     block_hasher_chip_idx: u32,
 ) {
-    // Read state (8 u32) and input block (16 u32) from memory.
-    let mut state_words = [0u32; SHA256_STATE_WORDS];
-    rd_mem_u32_range_wrapper(
-        state,
-        state_ptr,
-        state_words.as_mut_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
-    trace_rd_mem_u32_range_wrapper(
-        state,
-        state_ptr,
-        state_words.as_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
-    let mut block_words = [0u32; SHA256_BLOCK_WORDS];
-    rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_mut_ptr(),
-        SHA256_BLOCK_WORDS as u32,
-    );
-    trace_rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_ptr(),
-        SHA256_BLOCK_WORDS as u32,
-    );
+    // Read state as 4 u64s (32 bytes); view as [u32; 8] for compress256.
+    let mut state_words = [0u64; SHA256_STATE_WORDS];
+    rd_mem_words_traced(state, state_ptr, &mut state_words);
+    let state_u32s: &mut [u32; 8] = u64s_as_u32s_mut(&mut state_words).try_into().unwrap();
 
-    // compress256 wants the block as `GenericArray<u8, U64>`. Reinterpret the
-    // u32 buffer as bytes (zero-copy on LE).
+    // Read block as 8 u64s (64 bytes); view as bytes for compress256.
+    let mut block_words = [0u64; SHA256_BLOCK_WORDS];
+    rd_mem_words_traced(state, input_ptr, &mut block_words);
     let block_array: &GenericArray<u8, _> =
-        GenericArray::from_slice(u32_words_as_bytes(&block_words));
-    compress256(&mut state_words, &[*block_array]);
+        GenericArray::from_slice(u64_words_as_bytes(&block_words));
 
-    trace_wr_mem_u32_range_wrapper(
-        state,
-        dst_ptr,
-        state_words.as_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
-    wr_mem_u32_range_wrapper(
-        state,
-        dst_ptr,
-        state_words.as_ptr(),
-        SHA256_STATE_WORDS as u32,
-    );
+    compress256(state_u32s, &[*block_array]);
+    // state_u32s borrow ends here; state_words now holds the compressed state.
 
-    // Trace chip height for metering.
-    // The per-instruction Sha2Main cost (1 row) is covered by the per-block
-    // chip update emitted at block entry.
-    // Only the additional Sha2BlockHasher rows need trace_chip.
+    wr_mem_words_traced(state, dst_ptr, &state_words);
     trace_chip_wrapper(state, block_hasher_chip_idx, SHA256_ROWS_PER_BLOCK);
 }
 
@@ -135,38 +89,18 @@ pub unsafe extern "C" fn rvr_ext_sha512(
     _main_chip_idx: u32,
     block_hasher_chip_idx: u32,
 ) {
-    // u64-aligned scratch holds the SHA-512 state; reinterpret as u32 words at
-    // the FFI boundary (zero-copy on LE).
-    let mut state_u64s = [0u64; HASH_STATE_LEN];
-    {
-        let s = u64s_as_u32s_mut(&mut state_u64s);
-        rd_mem_u32_range_wrapper(state, state_ptr, s.as_mut_ptr(), s.len() as u32);
-        trace_rd_mem_u32_range_wrapper(state, state_ptr, s.as_ptr(), s.len() as u32);
-    }
-    let mut block_words = [0u32; SHA512_BLOCK_WORDS];
-    rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_mut_ptr(),
-        SHA512_BLOCK_WORDS as u32,
-    );
-    trace_rd_mem_u32_range_wrapper(
-        state,
-        input_ptr,
-        block_words.as_ptr(),
-        SHA512_BLOCK_WORDS as u32,
-    );
+    // SHA-512 state is naturally [u64; 8]; read directly.
+    let mut state_u64s = [0u64; SHA512_STATE_WORDS];
+    rd_mem_words_traced(state, state_ptr, &mut state_u64s);
 
+    // Read block as 16 u64s (128 bytes); view as bytes for compress512.
+    let mut block_words = [0u64; SHA512_BLOCK_WORDS];
+    rd_mem_words_traced(state, input_ptr, &mut block_words);
     let block_array: &GenericArray<u8, _> =
-        GenericArray::from_slice(u32_words_as_bytes(&block_words));
+        GenericArray::from_slice(u64_words_as_bytes(&block_words));
+
     compress512(&mut state_u64s, &[*block_array]);
 
-    {
-        let s = u64s_as_u32s(&state_u64s);
-        trace_wr_mem_u32_range_wrapper(state, dst_ptr, s.as_ptr(), s.len() as u32);
-        wr_mem_u32_range_wrapper(state, dst_ptr, s.as_ptr(), s.len() as u32);
-    }
-
-    // Trace chip height for metering.
+    wr_mem_words_traced(state, dst_ptr, &state_u64s);
     trace_chip_wrapper(state, block_hasher_chip_idx, SHA512_ROWS_PER_BLOCK);
 }


### PR DESCRIPTION
rvr support for sha extension. Branched from `feat/rvr-support-rv64-bigint` due to the updated `rd/wr_mem_words_traced` functions.

SHA-2 state and block are now read and written at WORD_SIZE=8 byte granularity. The previous u32 version would have done it in 4-byte memory accesses.

towards INT-8109