### PR TITLE
feat: rvr support rv64 keccak

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -46,7 +46,7 @@ jobs:
           # - { name: "deferral", path: "deferral", aot: true, rvr: false }
           # TODO(rvr): re-enable these once RV64 RVR support lands.
           - { name: "riscv", path: "riscv", aot: false, rvr: true }
-          # - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
+          - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
           # - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
           # - { name: "algebra", path: "algebra", aot: false, rvr: true }

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -101,14 +101,13 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
           EXTRA_ARGS=()
-          # TODO(rvr): restore this branch when the rvr matrix entries above are re-enabled.
           if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
             if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
               EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
             else
               EXTRA_ARGS+=(--features=rvr)
             fi
-          if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+          elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381 -E 'not test(fallback)')
           fi
 

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -38,7 +38,7 @@ jobs:
           - { name: "verify-stark", path: "verify-stark/circuit", rvr: false }
           # TODO(rvr): re-enable these once RV64 RVR support lands.
           # - { name: "sha2", path: "sha2", rvr: true }
-          # - { name: "keccak256", path: "keccak256", rvr: true }
+          - { name: "keccak256", path: "keccak256", rvr: true }
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
           # - { name: "k256", path: "k256", rvr: true }
           # - { name: "p256", path: "p256", rvr: true }
@@ -102,12 +102,12 @@ jobs:
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
           EXTRA_ARGS=()
           # TODO(rvr): restore this branch when the rvr matrix entries above are re-enabled.
-          # if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
-          #   if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
-          #     EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
-          #   else
-          #     EXTRA_ARGS+=(--features=rvr)
-          #   fi
+          if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
+            if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+              EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
+            else
+              EXTRA_ARGS+=(--features=rvr)
+            fi
           if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381 -E 'not test(fallback)')
           fi

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -36,11 +36,11 @@ jobs:
               features: "",
             }
           # TODO(rvr): re-enable once RV64 RVR support lands.
-          # - {
-          #     labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
-          #     image: "ubuntu24-full-x64",
-          #     features: "rvr",
-          #   }
+          - {
+              labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
+              image: "ubuntu24-full-x64",
+              features: "rvr",
+            }
           - {
               labels: "image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized",
               image: "ubuntu24-gpu-x64",

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.c
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.c
@@ -3,8 +3,6 @@
  * time). Compiled into the generated native project so clang can inline the
  * tracer helpers. */
 
-#include <string.h>
-
 #include "openvm.h"
 
 static constexpr uint32_t KECCAK_WIDTH_BYTES = 200;
@@ -17,18 +15,12 @@ __attribute__((preserve_most)) void rvr_ext_keccakf(RvState* restrict state,
                                                     uint32_t buffer_ptr,
                                                     uint32_t _op_chip_idx,
                                                     uint32_t perm_chip_idx) {
-  /* u64-aligned scratch; the u32 view is zero-copy on LE. */
-  uint64_t st[KECCAK_WIDTH_WORDS / 2];
+  uint64_t st[KECCAK_WIDTH_WORDS];
   static_assert(sizeof(st) == KECCAK_WIDTH_BYTES, "keccak state size mismatch");
 
-  uint32_t words[KECCAK_WIDTH_WORDS];
-  rd_mem_u32_range_traced(state, buffer_ptr, words, KECCAK_WIDTH_WORDS);
-  memcpy(st, words, KECCAK_WIDTH_BYTES);
-
+  rd_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
   rvr_keccak_f1600(st);
-
-  memcpy(words, st, KECCAK_WIDTH_BYTES);
-  wr_mem_u32_range_traced(state, buffer_ptr, words, KECCAK_WIDTH_WORDS);
+  wr_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
 
   /* KeccakfOp cost (1 row) is covered by the per-block chip update emitted
    * at block entry; only the additional KeccakfPerm rows (24 per
@@ -46,14 +38,14 @@ __attribute__((preserve_most)) void rvr_ext_xorin(RvState* restrict state,
     return;
   }
 
-  uint32_t buffer[KECCAK_WIDTH_WORDS];
-  uint32_t input[KECCAK_WIDTH_WORDS];
+  uint64_t buffer[KECCAK_WIDTH_WORDS];
+  uint64_t input[KECCAK_WIDTH_WORDS];
   assume(num_words <= KECCAK_WIDTH_WORDS);
 
-  rd_mem_u32_range_traced(state, buffer_ptr, buffer, num_words);
-  rd_mem_u32_range_traced(state, input_ptr, input, num_words);
+  rd_mem_u64_range_traced(state, buffer_ptr, buffer, num_words);
+  rd_mem_u64_range_traced(state, input_ptr, input, num_words);
   for (uint32_t i = 0; i < num_words; i++) {
     buffer[i] ^= input[i];
   }
-  wr_mem_u32_range_traced(state, buffer_ptr, buffer, num_words);
+  wr_mem_u64_range_traced(state, buffer_ptr, buffer, num_words);
 }


### PR DESCRIPTION
rvr support for rv64 keccak extension. Branched from feat/rvr-support-rv64-bigint due to the updated rd/wr_mem_words_traced functions.

rvr-support required changes in how `keccakf` and `xorin` read and write data, switching from 32bit to 64bit granularity (WORD_SIZE=8)

towards INT-8110