### PR TITLE
feat: rvr support for rv64 algebra extension (FP2)

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -49,7 +49,7 @@ jobs:
           # - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
           # - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
-          - { name: "algebra", path: "algebra", aot: false, rvr: true }
+          # - { name: "algebra", path: "algebra", aot: false, rvr: true }
           # - { name: "ecc", path: "ecc", aot: false, rvr: true }
           # - { name: "pairing", path: "pairing", aot: false, rvr: true }
           # - { name: "deferral", path: "deferral", aot: false, rvr: true }

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -49,7 +49,7 @@ jobs:
           # - { name: "keccak256", path: "keccak256", aot: false, rvr: true }
           # - { name: "sha2", path: "sha2", aot: false, rvr: true }
           - { name: "bigint", path: "bigint", aot: false, rvr: true }
-          # - { name: "algebra", path: "algebra", aot: false, rvr: true }
+          - { name: "algebra", path: "algebra", aot: false, rvr: true }
           # - { name: "ecc", path: "ecc", aot: false, rvr: true }
           # - { name: "pairing", path: "pairing", aot: false, rvr: true }
           # - { name: "deferral", path: "deferral", aot: false, rvr: true }

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -40,8 +40,8 @@ jobs:
           # - { name: "sha2", path: "sha2", rvr: true }
           # - { name: "keccak256", path: "keccak256", rvr: true }
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
-          - { name: "k256", path: "k256", rvr: true }
-          - { name: "p256", path: "p256", rvr: true }
+          # - { name: "k256", path: "k256", rvr: true }
+          # - { name: "p256", path: "p256", rvr: true }
           # - { name: "pairing", path: "pairing", rvr: true }
         platform:
           - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
@@ -102,13 +102,13 @@ jobs:
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
           EXTRA_ARGS=()
           # TODO(rvr): restore this branch when the rvr matrix entries above are re-enabled.
-          if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
-            if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
-              EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
-            else
-              EXTRA_ARGS+=(--features=rvr)
-            fi
-          elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+          # if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
+          #   if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+          #     EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
+          #   else
+          #     EXTRA_ARGS+=(--features=rvr)
+          #   fi
+          if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381 -E 'not test(fallback)')
           fi
 

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -40,8 +40,8 @@ jobs:
           # - { name: "sha2", path: "sha2", rvr: true }
           # - { name: "keccak256", path: "keccak256", rvr: true }
           # - { name: "ff_derive", path: "ff_derive", rvr: true }
-          # - { name: "k256", path: "k256", rvr: true }
-          # - { name: "p256", path: "p256", rvr: true }
+          - { name: "k256", path: "k256", rvr: true }
+          - { name: "p256", path: "p256", rvr: true }
           # - { name: "pairing", path: "pairing", rvr: true }
         platform:
           - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
@@ -102,13 +102,13 @@ jobs:
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
           EXTRA_ARGS=()
           # TODO(rvr): restore this branch when the rvr matrix entries above are re-enabled.
-          # if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
-          #   if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
-          #     EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
-          #   else
-          #     EXTRA_ARGS+=(--features=rvr)
-          #   fi
-          if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+          if [[ "${{ matrix.crate.rvr }}" == 'true' ]]; then
+            if [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
+              EXTRA_ARGS+=(--features=bn254,bls12_381,rvr -E 'not test(fallback)')
+            else
+              EXTRA_ARGS+=(--features=rvr)
+            fi
+          elif [[ "${{ matrix.crate.name }}" == "pairing" ]]; then
             EXTRA_ARGS+=(--features=bn254,bls12_381 -E 'not test(fallback)')
           fi
 

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -101,6 +101,12 @@ extern "C" {
         vals: *const u64,
         num_words: u32,
     );
+    pub fn trace_mem_access_u64_range_wrapper(
+        state: *mut c_void,
+        base_addr: u32,
+        num_words: u32,
+        addr_space: u32,
+    );
 
     // ── Memory access (u64-word ranges, trace-only) ───────────────────
     pub fn trace_rd_mem_u64_range_wrapper(
@@ -244,5 +250,5 @@ pub unsafe fn trace_mem_access_range(
         num_words >= 1,
         "trace_mem_access_range requires num_words >= 1"
     );
-    trace_mem_access_u32_range_wrapper(state, base_addr, num_words, addr_space);
+    trace_mem_access_u64_range_wrapper(state, base_addr, num_words, addr_space);
 }

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -85,6 +85,12 @@ void trace_wr_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
   trace_wr_mem_u64_range(s, base_addr, vals, num_words);
 }
 
+void trace_mem_access_u64_range_wrapper(RvState* s, uint32_t base_addr,
+                                        uint32_t num_words,
+                                        uint32_t addr_space) {
+  trace_mem_access_u64_range(s, base_addr, num_words, addr_space);
+}
+
 /* ── Instruction dispatch / chip cost ──────────────────────────────── */
 
 void trace_pc_wrapper(RvState* s, uint32_t pc) { trace_pc(s, pc); }

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -6,22 +6,19 @@ use halo2curves_axiom::ff::PrimeField;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate algebra to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper,
+    rd_mem_words_traced,
+    wr_mem_words_traced,
     WORD_SIZE,
 };
 
 /// Size of a 256-bit field element in bytes.
 pub const FIELD_256_BYTES: usize = 32;
-/// Number of 4-byte words in a 256-bit field element.
+/// Number of 8-byte words in a 256-bit field element.
 pub const FIELD_256_WORDS: usize = FIELD_256_BYTES / WORD_SIZE;
 
 /// Size of a BLS12-381 Fq element in bytes.
 pub const BLS12_381_ELEM_BYTES: usize = 48;
-/// Number of 4-byte words in a BLS12-381 Fq element.
+/// Number of 8-byte words in a BLS12-381 Fq element.
 pub const BLS12_381_ELEM_WORDS: usize = BLS12_381_ELEM_BYTES / WORD_SIZE;
 
 // ── FieldArith trait ─────────────────────────────────────────────────────────
@@ -52,9 +49,8 @@ pub trait FieldArith {
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
 pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void, ptr: u32) -> F {
-    let mut words = [0u32; FIELD_256_WORDS];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), FIELD_256_WORDS as u32);
-    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
+    let mut words = [0u64; FIELD_256_WORDS];
+    rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; FIELD_256_BYTES];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -82,16 +78,15 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
     val: &F,
 ) {
     let bytes = val.to_repr();
-    let mut words = [0u32; FIELD_256_WORDS];
+    let mut words = [0u64; FIELD_256_WORDS];
     for (i, w) in words.iter_mut().enumerate() {
-        *w = u32::from_le_bytes(
+        *w = u64::from_le_bytes(
             bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE]
                 .try_into()
                 .unwrap(),
         );
     }
-    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
-    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), FIELD_256_WORDS as u32);
+    wr_mem_words_traced(state, ptr, &words);
 }
 
 /// Read a BLS12-381 Fq element (48 bytes) from guest memory (traced).
@@ -100,9 +95,8 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
 pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> blstrs::Fp {
-    let mut words = [0u32; BLS12_381_ELEM_WORDS];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), BLS12_381_ELEM_WORDS as u32);
-    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
+    let mut words = [0u64; BLS12_381_ELEM_WORDS];
+    rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; BLS12_381_ELEM_BYTES];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -125,16 +119,15 @@ pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> blstrs::Fp {
 #[inline(always)]
 pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp) {
     let bytes = val.to_bytes_le();
-    let mut words = [0u32; BLS12_381_ELEM_WORDS];
+    let mut words = [0u64; BLS12_381_ELEM_WORDS];
     for (i, w) in words.iter_mut().enumerate() {
-        *w = u32::from_le_bytes(
+        *w = u64::from_le_bytes(
             bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE]
                 .try_into()
                 .unwrap(),
         );
     }
-    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
-    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), BLS12_381_ELEM_WORDS as u32);
+    wr_mem_words_traced(state, ptr, &words);
 }
 
 // ── BigUint helpers (for unknown-modulus fallbacks) ──────────────────────────
@@ -147,9 +140,8 @@ pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp)
 #[inline]
 pub unsafe fn read_bigint(state: *mut c_void, ptr: u32, num_limbs: u32) -> BigUint {
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
-    let mut words = vec![0u32; num_words];
-    rd_mem_u32_range_wrapper(state, ptr, words.as_mut_ptr(), num_words as u32);
-    trace_rd_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
+    let mut words = vec![0u64; num_words];
+    rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = vec![0u8; num_limbs as usize];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -167,16 +159,15 @@ pub unsafe fn write_bigint(state: *mut c_void, ptr: u32, value: &BigUint, num_li
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
     let mut bytes = value.to_bytes_le();
     bytes.resize(num_limbs as usize, 0);
-    let mut words = vec![0u32; num_words];
+    let mut words = vec![0u64; num_words];
     for (i, w) in words.iter_mut().enumerate() {
-        *w = u32::from_le_bytes(
+        *w = u64::from_le_bytes(
             bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE]
                 .try_into()
                 .unwrap(),
         );
     }
-    trace_wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
-    wr_mem_u32_range_wrapper(state, ptr, words.as_ptr(), num_words as u32);
+    wr_mem_words_traced(state, ptr, &words);
 }
 
 /// Modular inverse of `a` modulo `p` via extended GCD. Caller must ensure

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -5,11 +5,7 @@ use std::ffi::c_void;
 use halo2curves_axiom::ff::PrimeField;
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
-use rvr_openvm_ext_ffi_common::{
-    rd_mem_words_traced,
-    wr_mem_words_traced,
-    WORD_SIZE,
-};
+use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_SIZE};
 
 /// Size of a 256-bit field element in bytes.
 pub const FIELD_256_BYTES: usize = 32;

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -14,14 +14,7 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_bls12_381_fq, write_field_256, FieldArith, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
 };
 use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate fp2 to rd_mem_words_traced / wr_mem_words_traced ([u64])
-    rd_mem_u32_range_wrapper,
-    trace_mem_access_range,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper,
-    AS_MEMORY,
-    WORD_SIZE,
+    rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
 };
 
 // ── Field structs ───────────────────────────────────────────────────────────
@@ -238,9 +231,8 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     let num_words = total_limbs / WORD_SIZE as u32;
     debug_assert!(num_words >= 1);
 
-    let mut input_words = vec![0u32; num_words as usize];
-    rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_mut_ptr(), num_words);
-    trace_rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_ptr(), num_words);
+    let mut input_words = vec![0u64; num_words as usize];
+    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
 
     // Setup validates that the guest-provided base-field modulus and setup
@@ -249,7 +241,6 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     // In mod-builder, `Input(0)` means the first input slot. For setup, that
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so each setup coordinate writes p % p = 0.
-    let output_words = vec![0u32; num_words as usize];
-    trace_wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
-    wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
+    let output_words = vec![0u64; num_words as usize];
+    wr_mem_words_traced(state, rd_ptr, &output_words);
 }

--- a/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
+++ b/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
@@ -13,7 +13,9 @@
 #error "k256 guest limb codecs require a little-endian host"
 #endif
 
-static constexpr uint32_t RVR_WORD_SIZE = 4;
+// TODO(follow-up): add some kind of checker during build time to ensure that
+//    RVR_WORD_SIZE and OpenVM WORD_SIZE don't differ from each other
+static constexpr uint32_t RVR_WORD_SIZE = 8;
 static constexpr uint32_t SECP256K1_ELEM_BYTES = 32;
 static constexpr uint32_t SECP256K1_ELEM_WORDS =
     SECP256K1_ELEM_BYTES / RVR_WORD_SIZE;
@@ -38,8 +40,8 @@ static inline void bytes_reverse_32(uint8_t out[SECP256K1_ELEM_BYTES],
 }
 
 static inline secp256k1_fe fe_read(RvState* state, uint32_t ptr) {
-  uint32_t words[SECP256K1_ELEM_WORDS];
-  rd_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  uint64_t words[SECP256K1_ELEM_WORDS];
+  rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
   memcpy(le, words, SECP256K1_ELEM_BYTES);
   uint8_t be[SECP256K1_ELEM_BYTES];
@@ -58,9 +60,9 @@ static inline void fe_write(RvState* state, uint32_t ptr,
   secp256k1_fe_get_b32(be, &t);
   uint8_t le[SECP256K1_ELEM_BYTES];
   bytes_reverse_32(le, be);
-  uint32_t words[SECP256K1_ELEM_WORDS];
+  uint64_t words[SECP256K1_ELEM_WORDS];
   memcpy(words, le, SECP256K1_ELEM_BYTES);
-  wr_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  wr_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
 }
 
 static inline secp256k1_fe fe_add(secp256k1_fe a, const secp256k1_fe* b) {
@@ -101,8 +103,8 @@ static inline int fe_is_zero(const secp256k1_fe* a) {
 /* ── k256 scalar (mod n) helpers ─────────────────────────────────────── */
 
 static inline secp256k1_scalar scalar_read(RvState* state, uint32_t ptr) {
-  uint32_t words[SECP256K1_ELEM_WORDS];
-  rd_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  uint64_t words[SECP256K1_ELEM_WORDS];
+  rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
   memcpy(le, words, SECP256K1_ELEM_BYTES);
   uint8_t be[SECP256K1_ELEM_BYTES];
@@ -118,9 +120,9 @@ static inline void scalar_write(RvState* state, uint32_t ptr,
   secp256k1_scalar_get_b32(be, val);
   uint8_t le[SECP256K1_ELEM_BYTES];
   bytes_reverse_32(le, be);
-  uint32_t words[SECP256K1_ELEM_WORDS];
+  uint64_t words[SECP256K1_ELEM_WORDS];
   memcpy(words, le, SECP256K1_ELEM_BYTES);
-  wr_mem_u32_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  wr_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
 }
 
 /* ── Modular arithmetic: secp256k1 coordinate field (mod p) ──────────── */

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -20,13 +20,11 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_bls12_381_fq, write_field_256, FieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
-    // TODO(follow-up): migrate modular to rd_mem_words_traced / wr_mem_words_traced ([u64])
     ext_hint_stream_set,
-    rd_mem_u32_range_wrapper,
+    rd_mem_words_traced,
+    wr_mem_words_traced,
+    rd_mem_u64_range_wrapper,
     trace_mem_access_range,
-    trace_rd_mem_u32_range_wrapper,
-    trace_wr_mem_u32_range_wrapper,
-    wr_mem_u32_range_wrapper,
     AS_MEMORY,
     WORD_SIZE,
 };
@@ -266,9 +264,8 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     let num_words = num_limbs / WORD_SIZE as u32;
     debug_assert!(num_words >= 1);
 
-    let mut input_words = vec![0u32; num_words as usize];
-    rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_mut_ptr(), num_words);
-    trace_rd_mem_u32_range_wrapper(state, rs1_ptr, input_words.as_ptr(), num_words);
+    let mut input_words = vec![0u64; num_words as usize];
+    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
     trace_mem_access_range(state, rs2_ptr, num_words, AS_MEMORY);
 
     // Setup validates that the guest-provided modulus and setup inputs match
@@ -277,9 +274,8 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     // In mod-builder, `Input(0)` means the first input slot. For setup, that
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so the setup output is p % p = 0.
-    let output_words = vec![0u32; num_words as usize];
-    trace_wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
-    wr_mem_u32_range_wrapper(state, rd_ptr, output_words.as_ptr(), num_words);
+    let output_words = vec![0u64; num_words as usize];
+    wr_mem_words_traced(state, rd_ptr, &output_words);
 }
 
 // ── Phantom: HintSqrt ────────────────────────────────────────────────────────
@@ -348,8 +344,8 @@ pub unsafe extern "C" fn rvr_ext_algebra_hint_sqrt(
     let non_qr = BigUint::from_bytes_le(std::slice::from_raw_parts(non_qr_ptr, num_limbs as usize));
 
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
-    let mut words = vec![0u32; num_words];
-    rd_mem_u32_range_wrapper(state, rs1_ptr, words.as_mut_ptr(), num_words as u32);
+    let mut words = vec![0u64; num_words];
+    rd_mem_u64_range_wrapper(state, rs1_ptr, words.as_mut_ptr(), num_words as u32);
     // Note: no trace here — this is a phantom (hint) instruction, reads are not traced
     let mut x_bytes = vec![0u8; num_limbs as usize];
     for (i, &w) in words.iter().enumerate() {

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -20,13 +20,8 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_bls12_381_fq, write_field_256, FieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
-    ext_hint_stream_set,
-    rd_mem_words_traced,
-    wr_mem_words_traced,
-    rd_mem_u64_range_wrapper,
-    trace_mem_access_range,
-    AS_MEMORY,
-    WORD_SIZE,
+    ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_words_traced, trace_mem_access_range,
+    wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
 };
 
 // ── Field structs ────────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR is continuation of the previous PR (https://github.com/openvm-org/openvm/pull/2897) for supporting rvr in rv64 algebra extension.

The changes were done in how FP2 accessed memory, switching from 4 byte granularity to rv64's WORD_SIZE=8 bytes.

resolves INT-8111