### PR TITLE
feat: change the recursion_flag public value to recursion_depth

### DIFF
--- a/crates/continuations/src/circuit/deferral/hook/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/trace.rs
@@ -107,9 +107,12 @@ impl DeferralHookTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for DeferralH
                     air_proving_ctx: verifier_pvs_ctx,
                     poseidon2_compress_inputs: verifier_p2_compress_inputs,
                     poseidon2_permute_inputs: verifier_p2_permute_inputs,
+                    mut range_check_inputs,
                 },
             ..
         } = super::verifier::generate_proving_ctx(proof, input_onion, output_onion);
+
+        range_check_inputs.push(max_depth_minus_merkle_depth);
 
         DeferralHookPreCtx {
             verifier_pvs_ctx,
@@ -121,7 +124,7 @@ impl DeferralHookTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for DeferralH
                 .chain(onion_p2_inputs)
                 .collect(),
             poseidon2_permute_inputs: verifier_p2_permute_inputs,
-            range_check_inputs: vec![max_depth_minus_merkle_depth],
+            range_check_inputs,
             power_check_inputs: vec![merkle_depth],
         }
     }

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -18,7 +18,7 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
     DeferralPvs, VerifierBasePvs, VkCommit, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX,
-    VERIFIER_PVS_AIR_ID,
+    LOG_MAX_RECURSION_DEPTH, VERIFIER_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -47,6 +47,7 @@ pub struct DeferralHookPvsCols<F> {
     pub def_pvs: DeferralAggregationPvs<F>,
 
     pub num_merkle_leaves: F,
+    pub recursion_depth_minus_one_inv: F,
 
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
     pub def_circuit_commit: [F; DIGEST_SIZE],
@@ -133,10 +134,27 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * Check that the final proof is computed by the internal recursive prover, i.e.
-         * that internal_flag is 2 and recursion flag is 1 or 2.
+         * that internal_flag is 2 and that recursion_depth is in [1, MAX_RECURSION_DEPTH].
          */
         builder.assert_eq(local.verifier_pvs.internal_flag, AB::F::TWO);
-        builder.assert_bool(local.verifier_pvs.recursion_flag - AB::F::ONE);
+
+        let depth_minus_one = local.verifier_pvs.recursion_depth - AB::F::ONE;
+        let is_depth_not_one = depth_minus_one.clone() * local.recursion_depth_minus_one_inv;
+        let is_depth_one = AB::Expr::ONE - is_depth_not_one.clone();
+
+        builder.assert_bool(is_depth_one.clone());
+        builder
+            .when(is_depth_one.clone())
+            .assert_one(local.verifier_pvs.recursion_depth);
+
+        self.range_checker_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: depth_minus_one,
+                max_bits: AB::Expr::from_u8(LOG_MAX_RECURSION_DEPTH),
+            },
+            AB::F::ONE,
+        );
 
         /*
          * We need to receive public values from ProofShapeModule to ensure the values read
@@ -174,20 +192,19 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * We also need to receive the cached commit from ProofShapeModule, which is either for
-         * the internal-for-leaf (i.e. if recursion_flag == 1) or internal-recursive layer. In
+         * the internal-for-leaf (i.e. if recursion_depth == 1) or internal-recursive layer. In
          * the former case we constrain verifier_pvs.internal_recursive_vk_commit to be unset
          * (i.e. all 0), and in the latter we constrain it to be equal to a pre-generated
          * constant as it should be the same regardless of def_vk (provided internal system
          * params are the same).
          */
         let cached_commit = from_fn(|i| {
-            local.verifier_pvs.internal_for_leaf_vk_commit.cached_commit[i]
-                * (AB::Expr::TWO - local.verifier_pvs.recursion_flag)
+            local.verifier_pvs.internal_for_leaf_vk_commit.cached_commit[i] * is_depth_one.clone()
                 + local
                     .verifier_pvs
                     .internal_recursive_vk_commit
                     .cached_commit[i]
-                    * (local.verifier_pvs.recursion_flag - AB::F::ONE)
+                    * is_depth_not_one.clone()
         });
         self.cached_commit_bus.receive(
             builder,
@@ -214,12 +231,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         assert_vk_commit_unset(
-            &mut builder.when_ne(local.verifier_pvs.recursion_flag, AB::F::TWO),
+            &mut builder.when(is_depth_one),
             local.verifier_pvs.internal_recursive_vk_commit,
         );
 
         assert_vk_commit_eq(
-            &mut builder.when_ne(local.verifier_pvs.recursion_flag, AB::F::ONE),
+            &mut builder.when(is_depth_not_one),
             local.verifier_pvs.internal_recursive_vk_commit,
             VkCommit::<AB::Expr>::from(self.expected_internal_recursive_vk_commit),
         );

--- a/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/trace.rs
@@ -6,7 +6,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{
     poseidon2_compress_with_capacity, BabyBearPoseidon2Config, DIGEST_SIZE, F,
 };
 use openvm_verify_stark_host::pvs::{DeferralPvs, VerifierBasePvs};
-use p3_field::{PrimeCharacteristicRing, PrimeField32};
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
@@ -65,6 +65,13 @@ pub fn generate_proving_ctx(
     let cols: &mut DeferralHookPvsCols<F> = trace.as_mut_slice().borrow_mut();
     cols.verifier_pvs = *verifier_pvs;
     cols.def_pvs = *def_pvs;
+    let depth_minus_one = verifier_pvs.recursion_depth - F::ONE;
+    cols.recursion_depth_minus_one_inv = if depth_minus_one == F::ZERO {
+        F::ZERO
+    } else {
+        depth_minus_one.inverse()
+    };
+    let range_check_inputs = vec![depth_minus_one.as_canonical_u32() as usize];
     cols.num_merkle_leaves =
         F::from_usize(1usize << def_pvs.merkle_depth.as_canonical_u32() as usize);
     cols.input_onion = input_onion;
@@ -118,6 +125,7 @@ pub fn generate_proving_ctx(
             },
             poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            range_check_inputs,
         },
         def_circuit_commit,
     }

--- a/crates/continuations/src/circuit/deferral/inner/mod.rs
+++ b/crates/continuations/src/circuit/deferral/inner/mod.rs
@@ -32,6 +32,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             public_values_bus: bus_inventory.public_values_bus,
             cached_commit_bus: bus_inventory.cached_commit_bus,
             pre_hash_bus: bus_inventory.pre_hash_bus,
+            range_bus: bus_inventory.range_checker_bus,
             def_pvs_consistency_bus,
         };
 

--- a/crates/continuations/src/circuit/deferral/inner/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/trace.rs
@@ -163,15 +163,16 @@ impl DeferralInnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for Deferral
             generate_poseidon2_inputs(proofs, child_is_agg, child_merkle_depth);
         let super::def_pvs::DeferralAggPvsTraceCtx {
             proving_ctx: def_pvs_ctx,
-            range_check_inputs,
+            mut range_check_inputs,
         } = super::def_pvs::generate_proving_ctx(proofs, child_is_agg, child_merkle_depth);
+        let super::verifier::DeferralVerifierPvsTraceCtx {
+            proving_ctx: verifier_pvs_ctx,
+            range_check_inputs: verifier_range_check_inputs,
+        } = super::verifier::generate_proving_ctx(proofs, child_is_agg, child_vk_commit);
+        range_check_inputs.extend(verifier_range_check_inputs);
 
         DeferralInnerPreCtx {
-            verifier_pvs_ctx: super::verifier::generate_proving_ctx(
-                proofs,
-                child_is_agg,
-                child_vk_commit,
-            ),
+            verifier_pvs_ctx,
             def_pvs_ctx,
             input_ctx: super::input::generate_proving_ctx(proofs, child_is_agg),
             poseidon2_compress_inputs,

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -4,16 +4,20 @@ use openvm_circuit_primitives::{
     utils::{and, not},
     ColumnsAir, StructReflection, StructReflectionHelper,
 };
-use openvm_recursion_circuit::bus::{
-    CachedCommitBus, CachedCommitBusMessage, PreHashBus, PreHashMessage, PublicValuesBus,
-    PublicValuesBusMessage,
+use openvm_recursion_circuit::{
+    bus::{
+        CachedCommitBus, CachedCommitBusMessage, PreHashBus, PreHashMessage, PublicValuesBus,
+        PublicValuesBusMessage,
+    },
+    primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_verify_stark_host::pvs::{
-    VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX, VERIFIER_PVS_AIR_ID,
+    VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX, LOG_MAX_RECURSION_DEPTH,
+    VERIFIER_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -30,6 +34,10 @@ pub struct DeferralVerifierPvsCols<F> {
     pub proof_idx: F,
     pub is_valid: F,
     pub has_verifier_pvs: F,
+
+    pub recursion_flag: F,
+    pub depth_inv: F,
+
     pub child_pvs: VerifierBasePvs<F>,
 }
 
@@ -46,6 +54,7 @@ pub struct DeferralVerifierPvsAir {
     pub public_values_bus: PublicValuesBus,
     pub cached_commit_bus: CachedCommitBus,
     pub pre_hash_bus: PreHashBus,
+    pub range_bus: RangeCheckerBus,
     pub def_pvs_consistency_bus: DefPvsConsistencyBus,
 }
 
@@ -99,8 +108,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
          * we have internal_for_leaf children. Finally, if internal_flag is 2 then we are
          * verifying internal_recursive children.
          *
-         * Similarly, if the child recursion_flag is 1 then we know that we are on the 2nd (i.e.
-         * index 1) internal_recursive layer, and if it's 2 then we are on the 3rd or beyond.
+         * The recursion_flag column is a saturated selector derived from the child
+         * recursion_depth.
          */
         // constrain verifier pvs columns are the same across all rows (note app_vk_commit is
         // def_vk_commit here)
@@ -109,10 +118,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         let is_internal = local.has_verifier_pvs;
 
         when_both.assert_eq(local.has_verifier_pvs, next.has_verifier_pvs);
+        when_both.assert_eq(local.recursion_flag, next.recursion_flag);
         when_both.assert_eq(local.child_pvs.internal_flag, next.child_pvs.internal_flag);
         when_both.assert_eq(
-            local.child_pvs.recursion_flag,
-            next.child_pvs.recursion_flag,
+            local.child_pvs.recursion_depth,
+            next.child_pvs.recursion_depth,
         );
         assert_vk_commit_eq(
             &mut when_both,
@@ -137,17 +147,49 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         // constrain that the flags are ternary
         builder.assert_tern(local.child_pvs.internal_flag);
-        builder.assert_tern(local.child_pvs.recursion_flag);
+        builder.assert_tern(local.recursion_flag);
+
+        // constrain that recursion_flag is 0 iff recursion_depth == 0, recursion_flag == 1
+        // if recursion_depth == 1, and recursion_flag == 2 iff recursion_depth >= 2
+        let half = AB::F::TWO.inverse();
+        let is_recursion_flag_two =
+            (local.recursion_flag - AB::F::ONE) * local.recursion_flag * half;
+
+        builder
+            .when_ne(local.recursion_flag, AB::F::TWO)
+            .assert_eq(local.child_pvs.recursion_depth, local.recursion_flag);
+        builder
+            .when_ne(local.child_pvs.recursion_depth, AB::F::ZERO)
+            .when_ne(local.child_pvs.recursion_depth, AB::F::ONE)
+            .assert_eq(local.recursion_flag, AB::F::TWO);
+        builder.assert_eq(
+            is_recursion_flag_two.clone(),
+            local.child_pvs.recursion_depth
+                * (local.child_pvs.recursion_depth - AB::F::ONE)
+                * local.depth_inv,
+        );
+
+        // constrain recursion_depth is 0 when internal_flag is 0 or 1
+        builder
+            .when_ne(local.child_pvs.internal_flag, AB::F::TWO)
+            .assert_zero(local.child_pvs.recursion_depth);
+
+        // range check child recursion_depth to be in [0, MAX_RECURSION_DEPTH)
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: local.child_pvs.recursion_depth.into(),
+                max_bits: AB::Expr::from_u8(LOG_MAX_RECURSION_DEPTH),
+            },
+            local.is_valid,
+        );
 
         // constrain that internal_flag is 2 when recursion_flag is set, and not 2 otherwise
         builder
-            .when(local.child_pvs.recursion_flag)
+            .when(local.recursion_flag)
             .assert_eq(local.child_pvs.internal_flag, AB::F::TWO);
         builder
-            .when(
-                (local.child_pvs.recursion_flag - AB::F::ONE)
-                    * (local.child_pvs.recursion_flag - AB::F::TWO),
-            )
+            .when((local.recursion_flag - AB::F::ONE) * (local.recursion_flag - AB::F::TWO))
             .assert_bool(local.child_pvs.internal_flag);
 
         // constrain that child commits are 0 when they shouldn't be defined
@@ -171,7 +213,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             local.child_pvs.internal_for_leaf_vk_commit,
         );
         assert_vk_commit_unset(
-            &mut builder.when(local.child_pvs.recursion_flag - AB::F::TWO),
+            &mut builder.when(local.recursion_flag - AB::F::TWO),
             local.child_pvs.internal_recursive_vk_commit,
         );
 
@@ -219,7 +261,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             app_vk_commit: def_vk_commit,
             leaf_vk_commit,
             internal_for_leaf_vk_commit,
-            recursion_flag,
+            recursion_depth,
             internal_recursive_vk_commit,
         } = builder.public_values().borrow();
 
@@ -228,14 +270,14 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .when(and(local.is_valid, is_leaf.clone()))
             .assert_zero(internal_flag);
 
-        // constrain recursion_flag is 0 at the leaf and internal_for_leaf levels
+        // constrain recursion_depth is 0 at the leaf and internal_for_leaf levels
         builder
             .when(
                 local.is_valid
                     * (local.child_pvs.internal_flag - AB::F::ONE)
                     * (local.child_pvs.internal_flag - AB::F::TWO),
             )
-            .assert_zero(recursion_flag);
+            .assert_zero(recursion_depth);
 
         // constraint internal_flag is incremented properly at internal levels
         builder
@@ -260,26 +302,23 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             leaf_vk_commit,
         );
 
-        // constrain recursion_flag is 1 at the first internal_recursive level
+        // constrain recursion_depth increments at each internal_recursive level
         builder
-            .when(local.child_pvs.internal_flag * (local.child_pvs.internal_flag - AB::F::TWO))
-            .assert_one(recursion_flag);
+            .when(local.child_pvs.internal_flag)
+            .assert_one(recursion_depth.into() - local.child_pvs.recursion_depth);
 
-        // constrain verifier-specific pvs at internal_recursive levels after the first
-        builder
-            .when(local.child_pvs.recursion_flag)
-            .assert_eq(recursion_flag, AB::F::TWO);
+        // constrain internal_for_leaf_vk_commit is set at internal_recursive levels after
+        // the first and matches the output public value
         assert_vk_commit_eq(
-            &mut builder.when(local.child_pvs.recursion_flag),
+            &mut builder.when(local.recursion_flag),
             local.child_pvs.internal_for_leaf_vk_commit,
             internal_for_leaf_vk_commit,
         );
 
-        // constrain verifier-specific pvs at internal_recursive levels after the second
+        // constrain internal_recursive_vk_commit is set at internal_recursive levels after
+        // the second and matches the output public value
         assert_vk_commit_eq(
-            &mut builder.when(
-                local.child_pvs.recursion_flag * (local.child_pvs.recursion_flag - AB::F::ONE),
-            ),
+            &mut builder.when(local.recursion_flag * (local.recursion_flag - AB::F::ONE)),
             local.child_pvs.internal_recursive_vk_commit,
             internal_recursive_vk_commit,
         );
@@ -294,11 +333,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             * AB::F::TWO.inverse();
         let is_internal_flag_one =
             (AB::Expr::TWO - local.child_pvs.internal_flag) * local.child_pvs.internal_flag;
-        let is_recursion_flag_one =
-            (AB::Expr::TWO - local.child_pvs.recursion_flag) * local.child_pvs.recursion_flag;
-        let is_recursion_flag_two = (local.child_pvs.recursion_flag - AB::F::ONE)
-            * local.child_pvs.recursion_flag
-            * AB::F::TWO.inverse();
+        let is_recursion_flag_one = (AB::Expr::TWO - local.recursion_flag) * local.recursion_flag;
         let cached_commit = from_fn(|i| {
             is_internal_flag_zero.clone() * local.child_pvs.app_vk_commit.cached_commit[i]
                 + is_internal_flag_one.clone() * local.child_pvs.leaf_vk_commit.cached_commit[i]
@@ -323,25 +358,26 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         /*
          * Unlike the cached commits, we receive the pre-hash on the same layer that it's
          * observed. We receive it from ProofShapeModule also.
+         *
+         * By the constraints above, the output recursion_depth is 1 iff the child internal_flag
+         * is 1, and is at least 2 iff the child internal_flag is 2.
          */
-        let half = AB::F::TWO.inverse();
         let internal_flag = internal_flag.into();
-        let recursion_flag = recursion_flag.into();
 
-        let is_internal_flag_zero = (internal_flag.clone() - AB::Expr::ONE)
+        let is_pvs_internal_flag_zero = (internal_flag.clone() - AB::Expr::ONE)
             * (internal_flag.clone() - AB::Expr::TWO)
             * half;
-        let is_internal_flag_one = (AB::Expr::TWO - internal_flag.clone()) * internal_flag.clone();
-        let is_recursion_flag_one =
-            (AB::Expr::TWO - recursion_flag.clone()) * recursion_flag.clone();
-        let is_recursion_flag_two =
-            (recursion_flag.clone() - AB::Expr::ONE) * recursion_flag.clone() * half;
+        let is_pvs_internal_flag_one =
+            (AB::Expr::TWO - internal_flag.clone()) * internal_flag.clone();
+        let is_internal_flag_two = (local.child_pvs.internal_flag - AB::Expr::ONE)
+            * local.child_pvs.internal_flag.clone()
+            * half;
 
         let vk_pre_hash = from_fn(|i| {
-            is_internal_flag_zero.clone() * def_vk_commit.vk_pre_hash[i].into()
-                + is_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_two.clone() * internal_recursive_vk_commit.vk_pre_hash[i].into()
+            is_pvs_internal_flag_zero.clone() * def_vk_commit.vk_pre_hash[i].into()
+                + is_pvs_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
+                + is_internal_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
+                + is_internal_flag_two.clone() * internal_recursive_vk_commit.vk_pre_hash[i].into()
         });
 
         self.pre_hash_bus.receive(

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -369,9 +369,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             * half;
         let is_pvs_internal_flag_one =
             (AB::Expr::TWO - internal_flag.clone()) * internal_flag.clone();
-        let is_internal_flag_two = (local.child_pvs.internal_flag - AB::Expr::ONE)
-            * local.child_pvs.internal_flag.clone()
-            * half;
+        let is_internal_flag_two =
+            (local.child_pvs.internal_flag - AB::Expr::ONE) * local.child_pvs.internal_flag * half;
 
         let vk_pre_hash = from_fn(|i| {
             is_pvs_internal_flag_zero.clone() * def_vk_commit.vk_pre_hash[i].into()

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -189,7 +189,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             .when(local.recursion_flag)
             .assert_eq(local.child_pvs.internal_flag, AB::F::TWO);
         builder
-            .when((local.recursion_flag - AB::F::ONE) * (local.recursion_flag - AB::F::TWO))
+            .when_ne(local.recursion_flag, AB::F::ONE)
+            .when_ne(local.recursion_flag, AB::F::TWO)
             .assert_bool(local.child_pvs.internal_flag);
 
         // constrain that child commits are 0 when they shouldn't be defined

--- a/crates/continuations/src/circuit/deferral/inner/verifier/trace.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/trace.rs
@@ -4,16 +4,21 @@ use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{proof::Proof, prover::AirProvingContext};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
 use openvm_verify_stark_host::pvs::{VerifierBasePvs, VkCommit, VERIFIER_PVS_AIR_ID};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::circuit::deferral::inner::verifier::air::{DeferralChildLevel, DeferralVerifierPvsCols};
+
+pub struct DeferralVerifierPvsTraceCtx {
+    pub proving_ctx: AirProvingContext<CpuBackend<BabyBearPoseidon2Config>>,
+    pub range_check_inputs: Vec<usize>,
+}
 
 pub fn generate_proving_ctx(
     proofs: &[Proof<BabyBearPoseidon2Config>],
     child_is_agg: bool,
     child_vk_commit: VkCommit<F>,
-) -> AirProvingContext<CpuBackend<BabyBearPoseidon2Config>> {
+) -> DeferralVerifierPvsTraceCtx {
     let num_proofs = proofs.len();
     let height = num_proofs.next_power_of_two();
     let width = DeferralVerifierPvsCols::<u8>::width();
@@ -21,6 +26,7 @@ pub fn generate_proving_ctx(
     debug_assert!(num_proofs > 0);
 
     let mut trace = vec![F::ZERO; height * width];
+    let mut range_check_inputs = vec![];
     let mut child_level = DeferralChildLevel::App;
 
     for (proof_idx, (proof, chunk)) in proofs.iter().zip(trace.chunks_exact_mut(width)).enumerate()
@@ -43,6 +49,15 @@ pub fn generate_proving_ctx(
                 _ => unreachable!(),
             };
         }
+
+        let depth = cols.child_pvs.recursion_depth.as_canonical_u32();
+        cols.recursion_flag = F::from_u32(depth.min(2));
+        cols.depth_inv = if depth >= 2 {
+            (cols.child_pvs.recursion_depth * (cols.child_pvs.recursion_depth - F::ONE)).inverse()
+        } else {
+            F::ZERO
+        };
+        range_check_inputs.push(depth as usize);
     }
 
     let last_row: &DeferralVerifierPvsCols<F> =
@@ -61,18 +76,21 @@ pub fn generate_proving_ctx(
         DeferralChildLevel::InternalForLeaf => {
             pvs.internal_for_leaf_vk_commit = child_vk_commit;
             pvs.internal_flag = F::TWO;
-            pvs.recursion_flag = F::ONE;
+            pvs.recursion_depth = F::ONE;
         }
         DeferralChildLevel::InternalRecursive => {
             pvs.internal_recursive_vk_commit = child_vk_commit;
             pvs.internal_flag = F::TWO;
-            pvs.recursion_flag = F::TWO;
+            pvs.recursion_depth = last_row.child_pvs.recursion_depth + F::ONE;
         }
     }
 
-    AirProvingContext {
-        cached_mains: vec![],
-        common_main: RowMajorMatrix::new(trace, width),
-        public_values: pvs.to_vec(),
+    DeferralVerifierPvsTraceCtx {
+        proving_ctx: AirProvingContext {
+            cached_mains: vec![],
+            common_main: RowMajorMatrix::new(trace, width),
+            public_values: pvs.to_vec(),
+        },
+        range_check_inputs,
     }
 }

--- a/crates/continuations/src/circuit/inner/mod.rs
+++ b/crates/continuations/src/circuit/inner/mod.rs
@@ -69,6 +69,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for I
             public_values_bus,
             cached_commit_bus,
             pre_hash_bus,
+            range_bus,
             pvs_air_consistency_bus,
             deferral_config,
         });

--- a/crates/continuations/src/circuit/inner/trace.rs
+++ b/crates/continuations/src/circuit/inner/trace.rs
@@ -66,6 +66,7 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for InnerTraceGenImp
             air_proving_ctx: verifier_pvs_ctx,
             mut poseidon2_compress_inputs,
             poseidon2_permute_inputs,
+            mut range_check_inputs,
         } = super::verifier::generate_proving_ctx(
             proofs,
             proofs_type,
@@ -80,7 +81,6 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for InnerTraceGenImp
             self.deferral_enabled,
         );
 
-        let mut range_check_inputs = vec![];
         let idx2_ctx = if self.deferral_enabled {
             let (def_pvs_ctx, def_poseidon2_inputs, def_range_check_inputs) =
                 super::def_pvs::generate_proving_ctx(
@@ -90,7 +90,7 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>, ()> for InnerTraceGenImp
                     absent_trace_pvs,
                 );
             poseidon2_compress_inputs.extend_from_slice(&def_poseidon2_inputs);
-            range_check_inputs = def_range_check_inputs;
+            range_check_inputs.extend(def_range_check_inputs);
             def_pvs_ctx
         } else {
             super::unset::generate_proving_ctx(&[], child_is_app)

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -10,6 +10,7 @@ use openvm_recursion_circuit::{
         CachedCommitBus, CachedCommitBusMessage, PreHashBus, PreHashMessage, PublicValuesBus,
         PublicValuesBusMessage,
     },
+    primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
     utils::assert_zeros,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
@@ -18,7 +19,7 @@ use openvm_stark_backend::{
 };
 use openvm_verify_stark_host::pvs::{
     VerifierBasePvs, VerifierDefPvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX,
-    VERIFIER_PVS_AIR_ID,
+    LOG_MAX_RECURSION_DEPTH, VERIFIER_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -37,6 +38,10 @@ pub struct VerifierPvsCols<F> {
     pub proof_idx: F,
     pub is_valid: F,
     pub has_verifier_pvs: F,
+
+    pub recursion_flag: F,
+    pub depth_inv: F,
+
     pub child_pvs: VerifierBasePvs<F>,
 }
 
@@ -46,6 +51,7 @@ pub struct VerifierPvsAir {
     pub public_values_bus: PublicValuesBus,
     pub cached_commit_bus: CachedCommitBus,
     pub pre_hash_bus: PreHashBus,
+    pub range_bus: RangeCheckerBus,
     pub pvs_air_consistency_bus: PvsAirConsistencyBus,
     pub deferral_config: VerifierDeferralConfig,
 }
@@ -125,12 +131,19 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
          * We constrain the consistency of verifier-specific public values. We can determine
          * what layer a verifier is at using the has_verifier_pvs and internal_flag columns.
          * There are several cases we cover:
+         *
          * - has_verifier_pvs == 0: leaf verifier, app (or deferral circuit) children
          * - has_verifier_pvs == 1 && internal_flag == 0: internal verifier with leaf children
          * - has_verifier_pvs == 1 && internal_flag == 1: internal_for_leaf children
          * - has_verifier_pvs == 1 && internal_flag == 2: internal_recursive children
-         *   - recursion_flag == 1: 2nd (i.e. index 1) internal_recursive layer
-         *   - recursion_flag == 2: 3rd internal_recursive layer or beyond
+         *
+         * Note the first (i.e. index 0) internal-recursive layer has recursion_depth 1, the
+         * second has recursion_depth 2, and so on. The recursion_flag column is used to
+         * differentiate between the cases.
+         *
+         * - recursion_flag == 0: non-internal_recursive child
+         * - recursion_flag == 1: internal_recursive child at recursion_depth 1
+         * - recursion_flag == 2: internal_recursive child at recursion_depth 2 or beyond
          */
         // constrain the verifier pvs flags and internal_recursive_vk_commit are the same
         // across all valid rows
@@ -138,10 +151,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         let mut when_both_valid = builder.when(both_valid.clone());
 
         when_both_valid.assert_eq(local.has_verifier_pvs, next.has_verifier_pvs);
+        when_both_valid.assert_eq(local.recursion_flag, next.recursion_flag);
         when_both_valid.assert_eq(local.child_pvs.internal_flag, next.child_pvs.internal_flag);
         when_both_valid.assert_eq(
-            local.child_pvs.recursion_flag,
-            next.child_pvs.recursion_flag,
+            local.child_pvs.recursion_depth,
+            next.child_pvs.recursion_depth,
         );
 
         assert_vk_commit_eq(
@@ -171,17 +185,49 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
 
         // constrain that the flags are ternary
         builder.assert_tern(local.child_pvs.internal_flag);
-        builder.assert_tern(local.child_pvs.recursion_flag);
+        builder.assert_tern(local.recursion_flag);
+
+        // constrain that recursion_flag is 0 iff recursion_depth == 0, recursion_flag == 1
+        // if recursion_depth == 1, and recursion_flag == 2 iff recursion_depth >= 2
+        let half = AB::F::TWO.inverse();
+        let is_recursion_flag_two =
+            (local.recursion_flag - AB::F::ONE) * local.recursion_flag * half;
+
+        builder
+            .when_ne(local.recursion_flag, AB::F::TWO)
+            .assert_eq(local.child_pvs.recursion_depth, local.recursion_flag);
+        builder
+            .when_ne(local.child_pvs.recursion_depth, AB::F::ZERO)
+            .when_ne(local.child_pvs.recursion_depth, AB::F::ONE)
+            .assert_eq(local.recursion_flag, AB::F::TWO);
+        builder.assert_eq(
+            is_recursion_flag_two.clone(),
+            local.child_pvs.recursion_depth
+                * (local.child_pvs.recursion_depth - AB::F::ONE)
+                * local.depth_inv,
+        );
+
+        // constrain recursion_depth is 0 when internal_flag is 0 or 1
+        builder
+            .when_ne(local.child_pvs.internal_flag, AB::F::TWO)
+            .assert_zero(local.child_pvs.recursion_depth);
+
+        // range check child recursion_depth to be in [0, MAX_RECURSION_DEPTH)
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: local.child_pvs.recursion_depth.into(),
+                max_bits: AB::Expr::from_u8(LOG_MAX_RECURSION_DEPTH),
+            },
+            local.is_valid,
+        );
 
         // constrain that internal_flag is 2 when recursion_flag is set, and not 2 otherwise
         builder
-            .when(local.child_pvs.recursion_flag)
+            .when(local.recursion_flag)
             .assert_eq(local.child_pvs.internal_flag, AB::F::TWO);
         builder
-            .when(
-                (local.child_pvs.recursion_flag - AB::F::ONE)
-                    * (local.child_pvs.recursion_flag - AB::F::TWO),
-            )
+            .when((local.recursion_flag - AB::F::ONE) * (local.recursion_flag - AB::F::TWO))
             .assert_bool(local.child_pvs.internal_flag);
 
         // constrain that child commits are 0 when they shouldn't be defined
@@ -208,7 +254,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             local.child_pvs.internal_for_leaf_vk_commit,
         );
         assert_vk_commit_unset(
-            &mut builder.when(local.child_pvs.recursion_flag - AB::F::TWO),
+            &mut builder.when(local.recursion_flag - AB::F::TWO),
             local.child_pvs.internal_recursive_vk_commit,
         );
 
@@ -236,16 +282,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
          * app/deferral circuit cached commits are received in another AIR, so only the
          * internal verifier will receive them here.
          */
-        let half = AB::F::TWO.inverse();
         let is_internal_flag_zero = (local.child_pvs.internal_flag - AB::F::ONE)
             * (local.child_pvs.internal_flag - AB::F::TWO)
             * half;
         let is_internal_flag_one =
             (AB::Expr::TWO - local.child_pvs.internal_flag) * local.child_pvs.internal_flag;
-        let is_recursion_flag_one =
-            (AB::Expr::TWO - local.child_pvs.recursion_flag) * local.child_pvs.recursion_flag;
-        let is_recursion_flag_two =
-            (local.child_pvs.recursion_flag - AB::F::ONE) * local.child_pvs.recursion_flag * half;
+        let is_recursion_flag_one = (AB::Expr::TWO - local.recursion_flag) * local.recursion_flag;
         let cached_commit = from_fn(|i| {
             is_internal_flag_zero.clone() * local.child_pvs.app_vk_commit.cached_commit[i]
                 + is_internal_flag_one.clone() * local.child_pvs.leaf_vk_commit.cached_commit[i]
@@ -293,7 +335,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             app_vk_commit,
             leaf_vk_commit,
             internal_for_leaf_vk_commit,
-            recursion_flag,
+            recursion_depth,
             internal_recursive_vk_commit,
         } = builder.public_values()[0..base_pvs_width].borrow();
 
@@ -302,14 +344,14 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .when(and(local.is_valid, is_leaf.clone()))
             .assert_zero(internal_flag);
 
-        // constrain recursion_flag is 0 at the leaf and internal_for_leaf levels
+        // constrain recursion_depth is 0 at the leaf and internal_for_leaf levels
         builder
             .when(
                 local.is_valid
                     * (local.child_pvs.internal_flag - AB::F::ONE)
                     * (local.child_pvs.internal_flag - AB::F::TWO),
             )
-            .assert_zero(recursion_flag);
+            .assert_zero(recursion_depth);
 
         // constraint internal_flag is incremented properly at internal levels
         builder
@@ -334,28 +376,23 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             leaf_vk_commit,
         );
 
-        // constrain recursion_flag is 1 at the first internal_recursive level
+        // constrain recursion_depth increments at each internal_recursive level
         builder
-            .when(local.child_pvs.internal_flag * (local.child_pvs.internal_flag - AB::F::TWO))
-            .assert_one(recursion_flag);
+            .when(local.child_pvs.internal_flag)
+            .assert_one(recursion_depth.into() - local.child_pvs.recursion_depth);
 
-        // constrain verifier-specific pvs at internal_recursive levels after the first
-        builder
-            .when(local.child_pvs.recursion_flag)
-            .assert_eq(recursion_flag, AB::F::TWO);
+        // constrain internal_for_leaf_vk_commit is set at internal_recursive levels after
+        // the first and matches the first row
         assert_vk_commit_eq(
-            &mut builder
-                .when_first_row()
-                .when(local.child_pvs.recursion_flag),
+            &mut builder.when_first_row().when(local.recursion_flag),
             local.child_pvs.internal_for_leaf_vk_commit,
             internal_for_leaf_vk_commit,
         );
 
-        // constrain verifier-specific pvs at internal_recursive levels after the second
+        // constrain internal_recursive_vk_commit is set at internal_recursive levels after
+        // the first and matches the first row
         assert_vk_commit_eq(
-            &mut builder.when(
-                local.child_pvs.recursion_flag * (local.child_pvs.recursion_flag - AB::F::ONE),
-            ),
+            &mut builder.when(local.recursion_flag * (local.recursion_flag - AB::F::ONE)),
             local.child_pvs.internal_recursive_vk_commit,
             internal_recursive_vk_commit,
         );
@@ -363,24 +400,26 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         /*
          * Unlike the cached commits, we receive the pre-hash on the same layer that it's
          * observed. We receive it from ProofShapeModule also.
+         *
+         * By the constraints above, the pvs recursion_depth is 1 iff the child internal_flag
+         * is 1, and is at least 2 iff the child internal_flag is 2.
          */
         let internal_flag = internal_flag.into();
-        let recursion_flag = recursion_flag.into();
 
-        let is_internal_flag_zero = (internal_flag.clone() - AB::Expr::ONE)
+        let is_pvs_internal_flag_zero = (internal_flag.clone() - AB::Expr::ONE)
             * (internal_flag.clone() - AB::Expr::TWO)
             * half;
-        let is_internal_flag_one = (AB::Expr::TWO - internal_flag.clone()) * internal_flag.clone();
-        let is_recursion_flag_one =
-            (AB::Expr::TWO - recursion_flag.clone()) * recursion_flag.clone();
-        let is_recursion_flag_two =
-            (recursion_flag.clone() - AB::Expr::ONE) * recursion_flag.clone() * half;
+        let is_pvs_internal_flag_one =
+            (AB::Expr::TWO - internal_flag.clone()) * internal_flag.clone();
+        let is_internal_flag_two = (local.child_pvs.internal_flag - AB::Expr::ONE)
+            * local.child_pvs.internal_flag.clone()
+            * half;
 
         let vk_pre_hash = from_fn(|i| {
-            is_internal_flag_zero.clone() * app_vk_commit.vk_pre_hash[i].into()
-                + is_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
-                + is_recursion_flag_two.clone() * internal_recursive_vk_commit.vk_pre_hash[i].into()
+            is_pvs_internal_flag_zero.clone() * app_vk_commit.vk_pre_hash[i].into()
+                + is_pvs_internal_flag_one.clone() * leaf_vk_commit.vk_pre_hash[i].into()
+                + is_internal_flag_one.clone() * internal_for_leaf_vk_commit.vk_pre_hash[i].into()
+                + is_internal_flag_two.clone() * internal_recursive_vk_commit.vk_pre_hash[i].into()
         });
 
         self.pre_hash_bus.receive(
@@ -569,7 +608,7 @@ impl VerifierPvsAir {
         // constrain def_hook_commit matches if set in child_pvs
         assert_array_eq(
             &mut builder
-                .when(base_local.child_pvs.recursion_flag)
+                .when(base_local.recursion_flag)
                 .when(def_local.child_pvs.deferral_flag),
             def_local.child_pvs.def_hook_commit,
             def_hook_commit,

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -227,7 +227,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .when(local.recursion_flag)
             .assert_eq(local.child_pvs.internal_flag, AB::F::TWO);
         builder
-            .when((local.recursion_flag - AB::F::ONE) * (local.recursion_flag - AB::F::TWO))
+            .when_ne(local.recursion_flag, AB::F::ONE)
+            .when_ne(local.recursion_flag, AB::F::TWO)
             .assert_bool(local.child_pvs.internal_flag);
 
         // constrain that child commits are 0 when they shouldn't be defined

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -411,9 +411,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             * half;
         let is_pvs_internal_flag_one =
             (AB::Expr::TWO - internal_flag.clone()) * internal_flag.clone();
-        let is_internal_flag_two = (local.child_pvs.internal_flag - AB::Expr::ONE)
-            * local.child_pvs.internal_flag.clone()
-            * half;
+        let is_internal_flag_two =
+            (local.child_pvs.internal_flag - AB::Expr::ONE) * local.child_pvs.internal_flag * half;
 
         let vk_pre_hash = from_fn(|i| {
             is_pvs_internal_flag_zero.clone() * app_vk_commit.vk_pre_hash[i].into()

--- a/crates/continuations/src/circuit/inner/verifier/trace.rs
+++ b/crates/continuations/src/circuit/inner/verifier/trace.rs
@@ -7,7 +7,7 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
 use openvm_verify_stark_host::pvs::{
     VerifierBasePvs, VerifierDefPvs, VkCommit, VERIFIER_PVS_AIR_ID,
 };
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::circuit::{
@@ -69,6 +69,7 @@ pub fn generate_proving_ctx(
     let mut chunks = trace.chunks_exact_mut(width);
     let mut poseidon2_compress_inputs = vec![];
     let mut poseidon2_permute_inputs = vec![];
+    let mut range_check_inputs = vec![];
     let mut trailing_deferral_flag = F::ZERO;
 
     for (proof_idx, proof) in proofs.iter().enumerate() {
@@ -103,6 +104,15 @@ pub fn generate_proving_ctx(
                 trailing_deferral_flag = def_pvs.deferral_flag;
             }
         }
+
+        let depth = cols.child_pvs.recursion_depth.as_canonical_u32();
+        cols.recursion_flag = F::from_u32(depth.min(2));
+        cols.depth_inv = if depth >= 2 {
+            (cols.child_pvs.recursion_depth * (cols.child_pvs.recursion_depth - F::ONE)).inverse()
+        } else {
+            F::ZERO
+        };
+        range_check_inputs.push(depth as usize);
     }
 
     if deferral_enabled {
@@ -127,12 +137,12 @@ pub fn generate_proving_ctx(
         VerifierChildLevel::InternalForLeaf => {
             base_pvs.internal_for_leaf_vk_commit = child_vk_commit;
             base_pvs.internal_flag = F::TWO;
-            base_pvs.recursion_flag = F::ONE;
+            base_pvs.recursion_depth = F::ONE;
         }
         VerifierChildLevel::InternalRecursive => {
             base_pvs.internal_recursive_vk_commit = child_vk_commit;
             base_pvs.internal_flag = F::TWO;
-            base_pvs.recursion_flag = F::TWO;
+            base_pvs.recursion_depth = first_row.child_pvs.recursion_depth + F::ONE;
         }
     }
 
@@ -212,5 +222,6 @@ pub fn generate_proving_ctx(
         },
         poseidon2_compress_inputs,
         poseidon2_permute_inputs,
+        range_check_inputs,
     }
 }

--- a/crates/continuations/src/circuit/mod.rs
+++ b/crates/continuations/src/circuit/mod.rs
@@ -23,6 +23,7 @@ pub struct SingleAirTraceData<PB: ProverBackend> {
     pub air_proving_ctx: AirProvingContext<PB>,
     pub poseidon2_compress_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
     pub poseidon2_permute_inputs: Vec<[PB::Val; POSEIDON2_WIDTH]>,
+    pub range_check_inputs: Vec<usize>,
 }
 
 // TODO: move to stark-backend-v2

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -54,6 +54,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for R
             public_values_bus: bus_inventory.public_values_bus,
             cached_commit_bus: bus_inventory.cached_commit_bus,
             pre_hash_bus: bus_inventory.pre_hash_bus,
+            range_bus: bus_inventory.range_checker_bus,
             poseidon2_compress_bus: bus_inventory.poseidon2_compress_bus,
             memory_merkle_commit_bus,
             def_acc_paths_bus,

--- a/crates/continuations/src/circuit/root/trace.rs
+++ b/crates/continuations/src/circuit/root/trace.rs
@@ -67,6 +67,7 @@ impl<SC: StarkProtocolConfig<F = F>> RootTraceGen<CpuBackend<SC>, ()> for RootTr
             air_proving_ctx: verifier_ctx,
             poseidon2_compress_inputs: verifier_compress_inputs,
             poseidon2_permute_inputs: verifier_permute_inputs,
+            range_check_inputs,
         } = super::verifier::generate_proving_ctx(proof, self.deferral_enabled);
         let (commit_ctx, commit_inputs) =
             commit::generate_proving_ctx(user_pvs_proof.public_values.clone());
@@ -84,7 +85,7 @@ impl<SC: StarkProtocolConfig<F = F>> RootTraceGen<CpuBackend<SC>, ()> for RootTr
                 .chain(memory_inputs)
                 .collect_vec(),
             poseidon2_permute_inputs: verifier_permute_inputs,
-            range_check_inputs: vec![],
+            range_check_inputs,
         }
     }
 

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -9,6 +9,7 @@ use openvm_recursion_circuit::{
         CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
         PreHashBus, PreHashMessage, PublicValuesBus, PublicValuesBusMessage,
     },
+    primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
     utils::assert_zeros,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
@@ -18,7 +19,8 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
     DeferralPvs, VerifierBasePvs, VerifierDefPvs, VkCommit, VmPvs, CONSTRAINT_EVAL_AIR_ID,
-    CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
+    CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, LOG_MAX_RECURSION_DEPTH, VERIFIER_PVS_AIR_ID,
+    VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -46,6 +48,8 @@ pub struct RootVerifierPvsCols<F> {
     pub child_verifier_pvs: VerifierBasePvs<F>,
     pub child_vm_pvs: VmPvs<F>,
 
+    pub recursion_depth_minus_one_inv: F,
+
     pub program_commit_hash: [F; DIGEST_SIZE],
     pub initial_root_hash: [F; DIGEST_SIZE],
     pub initial_pc_hash: [F; DIGEST_SIZE],
@@ -60,6 +64,7 @@ pub struct RootVerifierPvsAir {
     pub public_values_bus: PublicValuesBus,
     pub cached_commit_bus: CachedCommitBus,
     pub pre_hash_bus: PreHashBus,
+    pub range_bus: RangeCheckerBus,
     pub poseidon2_compress_bus: Poseidon2CompressBus,
     pub memory_merkle_commit_bus: MemoryMerkleCommitBus,
     pub def_acc_paths_bus: DeferralAccPathBus,
@@ -114,10 +119,27 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * Check that the final proof is computed by the internal recursive prover, i.e.
-         * that internal_flag is 2 and recursion flag is 1 or 2.
+         * that internal_flag is 2 and that recursion_depth is in [1, MAX_RECURSION_DEPTH].
          */
         builder.assert_eq(local.child_verifier_pvs.internal_flag, AB::F::TWO);
-        builder.assert_bool(local.child_verifier_pvs.recursion_flag - AB::F::ONE);
+
+        let depth_minus_one = local.child_verifier_pvs.recursion_depth - AB::F::ONE;
+        let is_depth_not_one = depth_minus_one.clone() * local.recursion_depth_minus_one_inv;
+        let is_depth_one = AB::Expr::ONE - is_depth_not_one.clone();
+
+        builder.assert_bool(is_depth_one.clone());
+        builder
+            .when(is_depth_one.clone())
+            .assert_one(local.child_verifier_pvs.recursion_depth);
+
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: depth_minus_one,
+                max_bits: AB::Expr::from_u8(LOG_MAX_RECURSION_DEPTH),
+            },
+            AB::F::ONE,
+        );
 
         /*
          * UserPvsCommitAir constrains that the Merkle root of the original app user public
@@ -168,7 +190,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * We also need to receive the cached commit from ProofShapeModule, which is either for
-         * the internal-for-leaf (i.e. if recursion_flag == 1) or internal-recursive layer. In
+         * the internal-for-leaf (i.e. if recursion_depth == 1) or internal-recursive layer. In
          * the former case we constrain child_pvs.internal_recursive_vk_commit to be unset (i.e.
          * all 0), and in the latter we constrain it to be equal to a pre-generated constant as
          * it should be the same regardless of app_vk (provided internal system params are the
@@ -179,12 +201,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                 .child_verifier_pvs
                 .internal_for_leaf_vk_commit
                 .cached_commit[i]
-                * (AB::Expr::TWO - local.child_verifier_pvs.recursion_flag)
+                * is_depth_one.clone()
                 + local
                     .child_verifier_pvs
                     .internal_recursive_vk_commit
                     .cached_commit[i]
-                    * (local.child_verifier_pvs.recursion_flag - AB::F::ONE)
+                    * is_depth_not_one.clone()
         });
         self.cached_commit_bus.receive(
             builder,
@@ -211,12 +233,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         assert_vk_commit_unset(
-            &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::TWO),
+            &mut builder.when(is_depth_one),
             local.child_verifier_pvs.internal_recursive_vk_commit,
         );
 
         assert_vk_commit_eq(
-            &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::ONE),
+            &mut builder.when(is_depth_not_one),
             local.child_verifier_pvs.internal_recursive_vk_commit,
             VkCommit::<AB::Expr>::from(self.expected_internal_recursive_vk_commit),
         );

--- a/crates/continuations/src/circuit/root/verifier/trace.rs
+++ b/crates/continuations/src/circuit/root/verifier/trace.rs
@@ -10,7 +10,7 @@ use openvm_verify_stark_host::pvs::{
     DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID,
     VM_PVS_AIR_ID,
 };
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
@@ -45,6 +45,13 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
 
     cols.child_verifier_pvs = *child_verifier_pvs;
     cols.child_vm_pvs = *child_vm_pvs;
+    let depth_minus_one = child_verifier_pvs.recursion_depth - F::ONE;
+    cols.recursion_depth_minus_one_inv = if depth_minus_one == F::ZERO {
+        F::ZERO
+    } else {
+        depth_minus_one.inverse()
+    };
+    let range_check_inputs = vec![depth_minus_one.as_canonical_u32() as usize];
 
     let padded_program_commit = pad_slice_to_poseidon2_input(&child_vm_pvs.program_commit, F::ZERO);
     let padded_initial_root = pad_slice_to_poseidon2_input(&child_vm_pvs.initial_root, F::ZERO);
@@ -120,5 +127,6 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
         },
         poseidon2_compress_inputs,
         poseidon2_permute_inputs,
+        range_check_inputs,
     }
 }

--- a/crates/continuations/src/prover/root/trace.rs
+++ b/crates/continuations/src/prover/root/trace.rs
@@ -62,12 +62,11 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
             &v[3..num_airs]
         });
 
-        let range_check_inputs = vec![];
         let power_check_inputs = vec![];
         let mut external_data = VerifierExternalData {
             poseidon2_compress_inputs: &pre_data.poseidon2_compress_inputs,
             poseidon2_permute_inputs: &pre_data.poseidon2_permute_inputs,
-            range_check_inputs: &range_check_inputs,
+            range_check_inputs: &pre_data.range_check_inputs,
             power_check_inputs: &power_check_inputs,
             required_heights: verifier_trace_heights,
             final_transcript_state: None,

--- a/crates/sdk/src/prover/agg.rs
+++ b/crates/sdk/src/prover/agg.rs
@@ -292,19 +292,20 @@ impl AggProver {
         mut vm_proof: VmStarkProof,
         def_proof: DeferralProof,
         metadata: &mut InternalLayerMetadata,
-        def_internal_recursive_layer: u32,
+        mut def_internal_recursive_layer: u32,
     ) -> Result<VmStarkProof> {
         let DeferralProof::Present(mut def_inner) = def_proof else {
             return Ok(vm_proof);
         };
 
-        // The VM and deferral proofs must be at the same stage in internal recursion, i.e.
-        // both have to be the parent of either internal-for-leaf or internal-recursive child
-        // proofs. If this is not the case, we wrap the internal-for-leaf parent proof here.
-        if metadata.internal_recursive_layer == 1 && def_internal_recursive_layer != 1 {
-            vm_proof = self.wrap_proof(vm_proof, metadata)?
-        } else if def_internal_recursive_layer == 1 && metadata.internal_recursive_layer != 1 {
-            def_inner = self.wrap_def_inner(def_inner, def_internal_recursive_layer)?
+        // Aggregation requires equal child recursion_depth values, so we wrap the
+        // shallower side until both proofs are at the same internal-recursive depth.
+        while metadata.internal_recursive_layer < def_internal_recursive_layer {
+            vm_proof = self.wrap_proof(vm_proof, metadata)?;
+        }
+        while def_internal_recursive_layer < metadata.internal_recursive_layer {
+            def_inner = self.wrap_def_inner(def_inner, def_internal_recursive_layer)?;
+            def_internal_recursive_layer += 1;
         }
 
         vm_proof.inner = info_span!(

--- a/crates/verify/README.md
+++ b/crates/verify/README.md
@@ -21,7 +21,7 @@ The final internal-recursive proof will expose the following public values:
 - `initial_root`: Merkle root of VM memory at the start of app execution
 - `final_root`: Merkle root of VM memory after app execution
 - `internal_flag`: Internal aggregation layer indicator (0, 1, or 2)
-- `recursion_flag`: Internal aggregation recursive layer indicator (0, 1, or 2). For the final proof verified by this crate, it should be 1 or 2.
+- `recursion_depth`: Internal aggregation recursive depth. For the final proof verified by this crate, it should be in `[1, MAX_RECURSION_DEPTH]`.
 - `app_vk_commit`, `leaf_vk_commit`, `internal_for_leaf_vk_commit`, `internal_recursive_vk_commit`: Each is a `VkCommit` containing a `cached_commit` (PCS commitment of the parent verifier circuit's cached trace) and a `vk_pre_hash` (field pre-hash of the child `MultiStarkVerifyingKey`), for the app, leaf, internal-for-leaf, and internal-recursive layers respectively
 - If deferrals are enabled: `deferral_flag`, `def_hook_commit`, and `DeferralPvs { initial_acc_hash, final_acc_hash, depth, node_idx }`
 
@@ -39,8 +39,8 @@ Given a fixed VM and executable, we must check certain exposed public values aga
 - `program_commit`, `initial_root`, and `initial_pc` are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`.
 - `app_vk_commit`, `leaf_vk_commit`, and `internal_for_leaf_vk_commit` (each containing both `cached_commit` and `vk_pre_hash`) are compared against pre-computed baselines
 - `internal_recursive_vk_commit` is checked conditionally:
-  - if `recursion_flag == 2`, it is compared against the pre-computed baseline
-  - if `recursion_flag == 1`, it must be unset (all zeros)
+  - if `recursion_depth > 1`, it is compared against the pre-computed baseline
+  - if `recursion_depth == 1`, it must be unset (all zeros)
 
 **Other Public Values Validation:**
 
@@ -48,7 +48,7 @@ The other public values are checked for completeness.
 
 - `exit_code` is checked to be 0 (success) and `is_terminate` is checked to be true.
 - `internal_flag` is checked to be 2, i.e. the final layer must be internal-recursive
-- `recursion_flag` is checked to be 1 or 2
+- `recursion_depth` is checked to be in `[1, 256]`
 
 Note there is no expected value for `final_pc`, and thus it is left unchecked.
 

--- a/crates/verify/src/error.rs
+++ b/crates/verify/src/error.rs
@@ -43,8 +43,8 @@ pub enum VerifyStarkError {
     ExecutionUnsuccessful(F),
     #[error("Invalid internal flag {0}, should be 2")]
     InvalidInternalFlag(F),
-    #[error("Invalid recursion flag {0}, should be 1 or 2")]
-    InvalidRecursionFlag(F),
+    #[error("Invalid recursion depth {actual}, should be in [1, {max}]")]
+    InvalidRecursionDepth { actual: F, max: u32 },
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Other error: {0}")]

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -22,7 +22,8 @@ use crate::{
     error::VerifyStarkError,
     pvs::{
         DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, CONSTRAINT_EVAL_AIR_ID,
-        CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
+        CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, MAX_RECURSION_DEPTH, VERIFIER_PVS_AIR_ID,
+        VM_PVS_AIR_ID,
     },
     vk::VmStarkVerifyingKey,
 };
@@ -107,7 +108,7 @@ pub fn verify_vm_stark_proof_pvs(
         app_vk_commit,
         leaf_vk_commit,
         internal_for_leaf_vk_commit,
-        recursion_flag,
+        recursion_depth,
         internal_recursive_vk_commit,
     } = verifier_base_pvs_slice.borrow();
 
@@ -223,15 +224,37 @@ pub fn verify_vm_stark_proof_pvs(
             });
         };
 
-    // Check that recursion_flag is 1 or 2, i.e. that the penultimate layer is
-    // internal-for-leaf or internal-recursive.
-    if recursion_flag != F::ONE && recursion_flag != F::TWO {
-        return Err(VerifyStarkError::InvalidRecursionFlag(recursion_flag));
+    // Check that recursion_depth is within [1, MAX_RECURSION_DEPTH]. If
+    // recursion_depth == 1 then the penultimate layer is internal-for-leaf,
+    // else it is internal-recursive.
+    let recursion_depth_u32 = recursion_depth.as_canonical_u32();
+    if recursion_depth_u32 == 0 || recursion_depth_u32 > MAX_RECURSION_DEPTH {
+        return Err(VerifyStarkError::InvalidRecursionDepth {
+            actual: recursion_depth,
+            max: MAX_RECURSION_DEPTH,
+        });
     }
 
-    // Check internal_recursive_vk_commit against expected_commits if recursion_flag
-    // is 2, and check it is unset if recursion_flag is 1.
-    if recursion_flag == F::TWO {
+    // Check that internal_recursive_vk_commit is unset if recursion_depth == 1,
+    // and against expected_commits otherwise.
+    if recursion_depth == F::ONE {
+        if !is_unset(&internal_recursive_vk_commit.cached_commit) {
+            return Err(VerifyStarkError::InternalRecursiveVkCachedCommitSet {
+                actual: internal_recursive_vk_commit.cached_commit,
+            });
+        }
+        if !is_unset(&internal_recursive_vk_commit.vk_pre_hash) {
+            return Err(VerifyStarkError::InternalRecursiveVkPreHashSet {
+                actual: internal_recursive_vk_commit.vk_pre_hash,
+            });
+        }
+        if proof_cached_commit != vk.baseline.internal_for_leaf_vk_commit.cached_commit {
+            return Err(VerifyStarkError::ProofCachedCommitMismatch {
+                expected: vk.baseline.internal_for_leaf_vk_commit.cached_commit,
+                actual: proof_cached_commit,
+            });
+        }
+    } else {
         if internal_recursive_vk_commit.cached_commit
             != vk.baseline.internal_recursive_vk_commit.cached_commit
         {
@@ -251,23 +274,6 @@ pub fn verify_vm_stark_proof_pvs(
         if proof_cached_commit != vk.baseline.internal_recursive_vk_commit.cached_commit {
             return Err(VerifyStarkError::ProofCachedCommitMismatch {
                 expected: vk.baseline.internal_recursive_vk_commit.cached_commit,
-                actual: proof_cached_commit,
-            });
-        }
-    } else {
-        if !is_unset(&internal_recursive_vk_commit.cached_commit) {
-            return Err(VerifyStarkError::InternalRecursiveVkCachedCommitSet {
-                actual: internal_recursive_vk_commit.cached_commit,
-            });
-        }
-        if !is_unset(&internal_recursive_vk_commit.vk_pre_hash) {
-            return Err(VerifyStarkError::InternalRecursiveVkPreHashSet {
-                actual: internal_recursive_vk_commit.vk_pre_hash,
-            });
-        }
-        if proof_cached_commit != vk.baseline.internal_for_leaf_vk_commit.cached_commit {
-            return Err(VerifyStarkError::ProofCachedCommitMismatch {
-                expected: vk.baseline.internal_for_leaf_vk_commit.cached_commit,
                 actual: proof_cached_commit,
             });
         }

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -10,6 +10,9 @@ pub const CONSTRAINT_EVAL_AIR_ID: usize = 3;
 
 pub const CONSTRAINT_EVAL_CACHED_INDEX: usize = 0;
 
+pub const LOG_MAX_RECURSION_DEPTH: u8 = 8;
+pub const MAX_RECURSION_DEPTH: u32 = 1 << LOG_MAX_RECURSION_DEPTH;
+
 #[repr(C)]
 #[derive(
     AlignedBorrow, StructReflection, Clone, Copy, Debug, Serialize, Deserialize, PartialEq,
@@ -44,10 +47,10 @@ pub struct VerifierBasePvs<F> {
     //////////////////////////////////////////////////////////////////////
     /// VERIFIER-SPECIFIC RECURSION PVS
     //////////////////////////////////////////////////////////////////////
-    /// Ternary flag to indicate which internal-recursive layer this Proof is for. Should be
-    /// 1 for the first (i.e. index 0) internal-recursive layer, 2 for subsequent layers, and
-    /// 0 everywhere else.
-    pub recursion_flag: F,
+    /// Depth of the internal-recursive layer this Proof is for: 0 for non-internal-recursive
+    /// layers, 1 for the first (i.e. index 0) internal-recursive layer, 2 for the second (i.e.
+    /// index 1) internal-recursive layer, and so on.
+    pub recursion_depth: F,
     /// Commit to the internal_recursive_vk's DAG and its pre-hash, exposed by subsequent (i.e.
     /// index > 0) internal-recursive layer verifiers.
     pub internal_recursive_vk_commit: VkCommit<F>,

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -208,20 +208,20 @@ Public values are processed by `VmPvsAir` and `VerifierPvsAir`. The inner subcir
     - `leaf_vk_commit: VkCommit` — VK commit for the internal-for-leaf verifier subcircuit, derived from `leaf_vk`
     - `internal_for_leaf_vk_commit: VkCommit` — VK commit for the first (index 0) internal-recursive layer verifier subcircuit, derived from `internal_for_leaf_vk`
 - **Internal Recursion-Related Public Values**
-    - `recursion_flag: F` — ternary flag indicating which internal-recursive layer this proof is for:
+    - `recursion_depth: F` — depth of the internal-recursive layer this proof is for:
       - `0` for non-internal-recursive layers
       - `1` for the first (index 0) internal-recursive layer
-      - `2` for subsequent internal-recursive layers
+      - `2` for the second (index 1) internal-recursive layer, and so on
     - `internal_recursive_vk_commit: VkCommit` — VK commit for each subsequent (index > 0) internal-recursive layer verifier subcircuit, derived from `internal_recursive_vk`
 
 The `program_commit` should be set at every layer, but the flags and `*_vk_commits` should be set according to which layer we are currently proving for. Unset `*_vk_commits` are filled with 0s.
 
-| Layer | `internal_flag` | `recursion_flag` | `app` | `leaf` | `internal_for_leaf` | `internal_recursive` |
+| Layer | `internal_flag` | `recursion_depth` | `app` | `leaf` | `internal_for_leaf` | `internal_recursive` |
 |-------|-----------------|------------------|-------|--------|---------------------|----------------------|
 | leaf | 0 | 0 | set | unset | unset | unset |
 | internal-for-leaf | 1 | 0 | set | set | unset | unset |
 | internal-recursive (layer 0) | 2 | 1 | set | set | set | unset |
-| internal-recursive (layer 1+) | 2 | 2 | set | set | set | set |
+| internal-recursive (layer 1+) | 2 | 2+ | set | set | set | set |
 
 #### Constraints
 
@@ -255,10 +255,10 @@ The root subcircuit exposes a new set of public values for the static verifier. 
 The root subcircuit constrains the child proof's public values:
 
 - `is_terminate == 1` and `exit_code == ExitCode::Success` (successful app termination)
-- `internal_flag == 2` and `recursion_flag` is `1` or `2` (child is internal-recursive)
-- The verifier subcircuit's `SymbolicExpressionAir` cached commit and `internal_recursive_vk_commit` are verified depending on `recursion_flag`:
-  - `recursion_flag == 1`: cached commit is verified against `internal_for_leaf_vk_commit.cached_commit`, and `internal_recursive_vk_commit` must be unset (all zeros)
-  - `recursion_flag == 2`: cached commit is verified against `internal_recursive_vk_commit.cached_commit`, and `internal_recursive_vk_commit` (both `cached_commit` and `vk_pre_hash`) matches a pre-generated constant
+- `internal_flag == 2` and `recursion_depth` is in `[1, MAX_RECURSION_DEPTH]` (child is internal-recursive)
+- The verifier subcircuit's `SymbolicExpressionAir` cached commit and `internal_recursive_vk_commit` are verified depending on `recursion_depth`:
+  - `recursion_depth == 1`: cached commit is verified against `internal_for_leaf_vk_commit.cached_commit`, and `internal_recursive_vk_commit` must be unset (all zeros)
+  - `recursion_depth > 1`: cached commit is verified against `internal_recursive_vk_commit.cached_commit`, and `internal_recursive_vk_commit` (both `cached_commit` and `vk_pre_hash`) matches a pre-generated constant
 
 The root subcircuit also constrains its own public values:
 

--- a/guest-libs/verify-stark/circuit/src/lib.rs
+++ b/guest-libs/verify-stark/circuit/src/lib.rs
@@ -68,6 +68,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC>
             public_values_bus: bus_inventory.public_values_bus,
             cached_commit_bus: bus_inventory.cached_commit_bus,
             pre_hash_bus: bus_inventory.pre_hash_bus,
+            range_bus: bus_inventory.range_checker_bus,
             poseidon2_compress_bus: bus_inventory.poseidon2_compress_bus,
             hash_slice_subair: HashSliceSubAir {
                 compress_bus: bus_inventory.poseidon2_compress_bus,

--- a/guest-libs/verify-stark/circuit/src/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/trace.rs
@@ -83,8 +83,12 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>, ()> for DeferredVerifyTraceGenImpl {
         deferral_merkle_proofs: Option<&DeferralMerkleProofs<F>>,
         _device_ctx: &(),
     ) -> PreVerifierData<CpuBackend<SC>> {
-        let (verifier_pvs_record, verifier_p2_compress_inputs, verifier_p2_permute_inputs) =
-            generate_record(proof);
+        let (
+            verifier_pvs_record,
+            verifier_p2_compress_inputs,
+            verifier_p2_permute_inputs,
+            verifier_range_inputs,
+        ) = generate_record(proof);
         let (commit_ctx, commit_p2_inputs) =
             super::commit::generate_proving_ctx(user_pvs_proof.public_values.clone());
         let (memory_ctx, memory_p2_inputs) = memory::generate_proving_input(
@@ -140,7 +144,7 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>, ()> for DeferredVerifyTraceGenImpl {
                 .into_iter()
                 .chain(output_p2_inputs)
                 .collect_vec(),
-            range_inputs,
+            range_inputs: verifier_range_inputs.into_iter().chain(range_inputs).collect_vec(),
             verifier_pvs_record,
             output_commit,
         }

--- a/guest-libs/verify-stark/circuit/src/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/trace.rs
@@ -144,7 +144,10 @@ impl DeferredVerifyTraceGen<CpuBackend<SC>, ()> for DeferredVerifyTraceGenImpl {
                 .into_iter()
                 .chain(output_p2_inputs)
                 .collect_vec(),
-            range_inputs: verifier_range_inputs.into_iter().chain(range_inputs).collect_vec(),
+            range_inputs: verifier_range_inputs
+                .into_iter()
+                .chain(range_inputs)
+                .collect_vec(),
             verifier_pvs_record,
             output_commit,
         }

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -26,6 +26,7 @@ use openvm_recursion_circuit::{
         FinalTranscriptStateMessage, Poseidon2CompressBus, Poseidon2CompressMessage, PreHashBus,
         PreHashMessage, PublicValuesBus, PublicValuesBusMessage,
     },
+    primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
     utils::assert_zeros,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
@@ -35,7 +36,8 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{
     DeferralPvs, VerifierBasePvs, VerifierDefPvs, VkCommit, VmPvs, CONSTRAINT_EVAL_AIR_ID,
-    CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID,
+    CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID, LOG_MAX_RECURSION_DEPTH, VERIFIER_PVS_AIR_ID,
+    VM_PVS_AIR_ID,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -51,6 +53,8 @@ use crate::{
 pub struct DeferredVerifyPvsCols<F> {
     pub child_verifier_pvs: VerifierBasePvs<F>,
     pub child_vm_pvs: VmPvs<F>,
+
+    pub recursion_depth_minus_one_inv: F,
 
     pub program_commit_hash: [F; DIGEST_SIZE],
     pub initial_root_hash: [F; DIGEST_SIZE],
@@ -70,6 +74,7 @@ pub struct DeferredVerifyPvsAir {
     pub public_values_bus: PublicValuesBus,
     pub cached_commit_bus: CachedCommitBus,
     pub pre_hash_bus: PreHashBus,
+    pub range_bus: RangeCheckerBus,
     pub poseidon2_compress_bus: Poseidon2CompressBus,
     pub hash_slice_subair: HashSliceSubAir,
     pub memory_merkle_commit_bus: MemoryMerkleCommitBus,
@@ -130,10 +135,27 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * Check that the final proof is computed by the internal recursive prover, i.e.
-         * that internal_flag is 2 and recursion flag is 1 or 2.
+         * that internal_flag is 2 and that recursion_depth is in [1, MAX_RECURSION_DEPTH].
          */
         builder.assert_eq(local.child_verifier_pvs.internal_flag, AB::F::TWO);
-        builder.assert_bool(local.child_verifier_pvs.recursion_flag - AB::F::ONE);
+
+        let depth_minus_one = local.child_verifier_pvs.recursion_depth - AB::F::ONE;
+        let is_depth_not_one = depth_minus_one.clone() * local.recursion_depth_minus_one_inv;
+        let is_depth_one = AB::Expr::ONE - is_depth_not_one.clone();
+
+        builder.assert_bool(is_depth_one.clone());
+        builder
+            .when(is_depth_one.clone())
+            .assert_one(local.child_verifier_pvs.recursion_depth);
+
+        self.range_bus.lookup_key(
+            builder,
+            RangeCheckerBusMessage {
+                value: depth_minus_one,
+                max_bits: AB::Expr::from_u8(LOG_MAX_RECURSION_DEPTH),
+            },
+            AB::F::ONE,
+        );
 
         /*
          * UserPvsCommitValuesAir constrains that the Merkle root of the original app user
@@ -185,7 +207,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * We also need to receive the cached commit from ProofShapeModule, which is either for
-         * the internal-for-leaf (i.e. if recursion_flag == 1) or internal-recursive layer. In
+         * the internal-for-leaf (i.e. if recursion_depth == 1) or internal-recursive layer. In
          * the former case we constrain child_pvs.internal_recursive_vk_commit to be unset (i.e.
          * all 0), and in the latter we constrain it to be equal to a pre-generated constant as
          * it should be the same regardless of app_vk (provided internal system params are the
@@ -196,12 +218,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
                 .child_verifier_pvs
                 .internal_for_leaf_vk_commit
                 .cached_commit[i]
-                * (AB::Expr::TWO - local.child_verifier_pvs.recursion_flag)
+                * is_depth_one.clone()
                 + local
                     .child_verifier_pvs
                     .internal_recursive_vk_commit
                     .cached_commit[i]
-                    * (local.child_verifier_pvs.recursion_flag - AB::F::ONE)
+                    * is_depth_not_one.clone()
         });
         self.cached_commit_bus.receive(
             builder,
@@ -228,12 +250,12 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
         );
 
         assert_vk_commit_unset(
-            &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::TWO),
+            &mut builder.when(is_depth_one),
             local.child_verifier_pvs.internal_recursive_vk_commit,
         );
 
         assert_vk_commit_eq(
-            &mut builder.when_ne(local.child_verifier_pvs.recursion_flag, AB::F::ONE),
+            &mut builder.when(is_depth_not_one),
             local.child_verifier_pvs.internal_recursive_vk_commit,
             VkCommit::<AB::Expr>::from(self.expected_internal_recursive_vk_commit),
         );

--- a/guest-libs/verify-stark/circuit/src/verifier/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/trace.rs
@@ -18,7 +18,7 @@ use openvm_verify_stark_host::pvs::{
     DeferralPvs, VerifierBasePvs, VerifierDefPvs, VmPvs, DEF_PVS_AIR_ID, VERIFIER_PVS_AIR_ID,
     VM_PVS_AIR_ID,
 };
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::verifier::{DeferredVerifyPvsCols, RecursiveDeferredVerifyCols};
@@ -41,12 +41,15 @@ pub fn generate_record(
     DeferredVerifyPvsRecord<F>,
     Vec<[F; POSEIDON2_WIDTH]>,
     Vec<[F; POSEIDON2_WIDTH]>,
+    Vec<usize>,
 ) {
     let (base_pvs_slice, _) = proof.public_values[VERIFIER_PVS_AIR_ID]
         .as_slice()
         .split_at(VerifierBasePvs::<u8>::width());
     let child_verifier_pvs: &VerifierBasePvs<F> = base_pvs_slice.borrow();
     let child_vm_pvs: &VmPvs<F> = proof.public_values[VM_PVS_AIR_ID].as_slice().borrow();
+    let depth_minus_one = child_verifier_pvs.recursion_depth - F::ONE;
+    let range_check_inputs = vec![depth_minus_one.as_canonical_u32() as usize];
 
     let padded_program_commit = pad_slice_to_poseidon2_input(&child_vm_pvs.program_commit, F::ZERO);
     let padded_initial_root = pad_slice_to_poseidon2_input(&child_vm_pvs.initial_root, F::ZERO);
@@ -104,6 +107,7 @@ pub fn generate_record(
         },
         poseidon2_compress_inputs,
         poseidon2_permute_inputs,
+        range_check_inputs,
     )
 }
 
@@ -131,6 +135,12 @@ pub fn generate_proving_ctx(
 
     cols.child_verifier_pvs = *child_verifier_pvs;
     cols.child_vm_pvs = *child_vm_pvs;
+    let depth_minus_one = child_verifier_pvs.recursion_depth - F::ONE;
+    cols.recursion_depth_minus_one_inv = if depth_minus_one == F::ZERO {
+        F::ZERO
+    } else {
+        depth_minus_one.inverse()
+    };
     cols.program_commit_hash = record.program_commit_hash;
     cols.initial_root_hash = record.initial_root_hash;
     cols.initial_pc_hash = record.initial_pc_hash;

--- a/guest-libs/verify-stark/circuit/src/verifier/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/trace.rs
@@ -35,6 +35,7 @@ pub struct DeferredVerifyPvsRecord<F> {
     pub app_vm_commit: [F; DIGEST_SIZE],
 }
 
+#[allow(clippy::type_complexity)]
 pub fn generate_record(
     proof: &Proof<BabyBearPoseidon2Config>,
 ) -> (


### PR DESCRIPTION
Resolves INT-8278.

## Overview

This PR changes the verifier public value that used to encode recursive aggregation as a saturated ternary `recursion_flag` into a true `recursion_depth`.

The new public value semantics are:

| Layer | `internal_flag` | `recursion_depth` |
|---|---:|---:|
| leaf | 0 | 0 |
| internal-for-leaf | 1 | 0 |
| internal-recursive, index 0 | 2 | 1 |
| internal-recursive, index 1 | 2 | 2 |
| internal-recursive, index `d - 1` | 2 | `d` |

`LOG_MAX_RECURSION_DEPTH = 8` is defined in `openvm_verify_stark_host::pvs`, giving a maximum final recursive depth of `MAX_RECURSION_DEPTH = 256`. Inner aggregation range-checks child `recursion_depth` in `[0, 256)`, while root-like final checks range-check `recursion_depth - 1` in `[0, 256)`, i.e. final child depth in `[1, 256]`.

The branch has one commit:

- `feat: change the recursion_flag public value to recursion_depth`

## 1. Inner AIR Changes

Affected AIRs:

- `crates/continuations/src/circuit/inner/verifier/air.rs`
- `crates/continuations/src/circuit/deferral/inner/verifier/air.rs`

These AIRs still need saturated selector behavior internally, but no longer expose that selector as a public value. Instead, each AIR adds local helper columns:

| Column | Purpose |
|---|---|
| `recursion_flag` | Local saturated selector derived from child `recursion_depth`: `0`, `1`, or `2` for depth `>= 2`. |
| `depth_inv` | Inverse witness for proving the `recursion_depth >= 2` case. Set to `1 / (depth * (depth - 1))` when depth is at least 2, else 0. |

Example row values:

| Child layer | Child `internal_flag` | Child `recursion_depth` | Local `recursion_flag` | `depth_inv` | Output `recursion_depth` |
|---|---:|---:|---:|---|---:|
| app / leaf | 0 or no verifier PVS | 0 | 0 | 0 | 0 or unchanged by next layer rules |
| internal-for-leaf | 1 | 0 | 0 | 0 | 1 |
| internal-recursive index 0 | 2 | 1 | 1 | 0 | 2 |
| internal-recursive index 1 | 2 | 2 | 2 | `1 / (2 * 1)` | 3 |
| internal-recursive index `d - 1` | 2 | `d >= 2` | 2 | `1 / (d * (d - 1))` | `d + 1` |

The AIR constraints now:

- enforce that all valid rows agree on child `recursion_depth` and the local saturated `recursion_flag`;
- constrain `recursion_flag == min(recursion_depth, 2)`;
- force `recursion_depth == 0` when child `internal_flag` is not internal-recursive;
- range-check child `recursion_depth` with `LOG_MAX_RECURSION_DEPTH` bits;
- increment the exposed output `recursion_depth` at every internal-recursive layer;
- preserve the old cached-commit and VK-commit branching by using the local saturated selector.

Trace generation now fills the new helper columns and contributes the child depth to `range_check_inputs`. `SingleAirTraceData` gained a `range_check_inputs` field so verifier-PVS range checks can be merged with existing deferral range inputs.

Bus interactions:

```text
ProofShapeModule
  ├─ PublicValuesBus ───────────────► Inner VerifierPvsAir / DeferralVerifierPvsAir
  ├─ CachedCommitBus ───────────────► selected child VK cached commit check
  └─ PreHashBus ────────────────────► selected child VK pre-hash check

RangeCheckerAir
  ◄─ RangeCheckerBus(value = child recursion_depth, max_bits = LOG_MAX_RECURSION_DEPTH)
     from Inner VerifierPvsAir / DeferralVerifierPvsAir
```

## 2. Root-Like AIR Changes

Affected AIRs:

- `crates/continuations/src/circuit/root/verifier/air.rs`
- `crates/continuations/src/circuit/deferral/hook/verifier/air.rs`
- `guest-libs/verify-stark/circuit/src/verifier/air.rs`

These are final/root-like verifier-PVS AIRs. They verify a single child proof that must already be internal-recursive. Previously they accepted `recursion_flag` values `1` or `2`; now they accept true `recursion_depth` values in `[1, MAX_RECURSION_DEPTH]`.

Each AIR adds:

| Column | Purpose |
|---|---|
| `recursion_depth_minus_one_inv` | Inverse witness for selecting `depth == 1` versus `depth > 1`. Set to `1 / (recursion_depth - 1)` when depth is greater than 1, else 0. |

Example row values:

| Child `recursion_depth` | `depth_minus_one` | `recursion_depth_minus_one_inv` | Selector behavior | Cached commit checked against | `internal_recursive_vk_commit` |
|---:|---:|---|---|---|---|
| 1 | 0 | 0 | `is_depth_one = 1` | `internal_for_leaf_vk_commit.cached_commit` | must be unset |
| 2 | 1 | 1 | `is_depth_not_one = 1` | `internal_recursive_vk_commit.cached_commit` | must match expected constant |
| `d`, 3..256 | `d - 1` | `1 / (d - 1)` | `is_depth_not_one = 1` | `internal_recursive_vk_commit.cached_commit` | must match expected constant |

The root-like AIR constraints now:

- require `internal_flag == 2`;
- range-check `recursion_depth - 1` with `LOG_MAX_RECURSION_DEPTH` bits;
- use `recursion_depth == 1` to select the internal-for-leaf cached commit and require `internal_recursive_vk_commit` to be unset;
- use `recursion_depth > 1` to select `internal_recursive_vk_commit.cached_commit` and require the full `internal_recursive_vk_commit` to match the expected internal-recursive VK commit.

Trace generation fills `recursion_depth_minus_one_inv` and adds `recursion_depth - 1` to range-check inputs. For deferral hook, the existing deferral Merkle-depth range input is preserved and the new recursion-depth range input is merged with it. The verify-stark trace path returns verifier range inputs from `verifier/trace.rs` and merges them before generating the child verifier subcircuit trace.

Bus interactions:

```text
ProofShapeModule
  ├─ PublicValuesBus ───────────────► root-like verifier AIR
  ├─ CachedCommitBus ───────────────► selected cached commit:
  │                                    depth == 1  -> internal_for_leaf
  │                                    depth > 1   -> internal_recursive
  └─ PreHashBus ────────────────────► expected internal_recursive vk_pre_hash

RangeCheckerAir
  ◄─ RangeCheckerBus(value = recursion_depth - 1, max_bits = LOG_MAX_RECURSION_DEPTH)
     from root / deferral hook / verify-stark verifier AIR
```

Other root-like wiring:

- `RootCircuit`, `DeferralHookPvsAir`, and `DeferredVerifyCircuit` now pass the existing `range_checker_bus` into the verifier-PVS AIR.
- Root, hook, and verify-stark pre-verifier trace data now carry the verifier-PVS range input along with existing range inputs.
- Root prover tracegen now forwards those pre-verifier range inputs into `VerifierExternalData`, so `ProofShapeAir` can generate the matching range-check multiplicities before the verifier subcircuit is proven.

## 3. Verify Crate Changes

Affected files:

- `crates/verify/src/pvs.rs`
- `crates/verify/src/lib.rs`
- `crates/verify/src/error.rs`
- `crates/verify/README.md`
- `docs/vocs/docs/pages/specs/architecture/continuations.mdx`

`VerifierBasePvs` replaces the public field:

```rust
pub recursion_flag: F
```

with:

```rust
pub recursion_depth: F
```

The field occupies the same struct position, so the public-value layout width/order is unchanged except for semantics and naming.

New constants:

```rust
pub const LOG_MAX_RECURSION_DEPTH: u8 = 8;
pub const MAX_RECURSION_DEPTH: u32 = 1 << LOG_MAX_RECURSION_DEPTH;
```

Host verification now mirrors the root-like AIR behavior:

- reject `recursion_depth == 0`;
- reject `recursion_depth > MAX_RECURSION_DEPTH`;
- for `recursion_depth == 1`, require `internal_recursive_vk_commit` to be unset and check the proof cached commit against `internal_for_leaf_vk_commit.cached_commit`;
- for `recursion_depth > 1`, require `internal_recursive_vk_commit` to match the baseline and check the proof cached commit against `internal_recursive_vk_commit.cached_commit`.

The old `InvalidRecursionFlag` error was renamed to:

```rust
InvalidRecursionDepth { actual: F, max: u32 }
```

Docs were updated to describe `recursion_depth`, `MAX_RECURSION_DEPTH`, and the `depth == 1` versus `depth > 1` cached-commit behavior.

## 4. SDK Mixed-Proof Depth Equalization

Affected file:

- `crates/sdk/src/prover/agg.rs`

`prove_mixed` now equalizes exact VM and deferral internal-recursive depths before mixing them. This was not required with the old saturated public value because any depth at or beyond 2 exposed the same `recursion_flag == 2`. With true `recursion_depth`, inner verifier AIRs require all valid child rows to agree on the exact child depth.

Behavior before mixed aggregation:

| VM depth | Deferral depth | Action before mixing |
|---:|---:|---|
| equal | equal | mix directly |
| less | greater | wrap VM until depths match |
| greater | less | wrap deferral proof until depths match |

This preserves existing mixed-proof flows while making them compatible with the new exact-depth public value constraints.

## Review Checklist

- Confirm that all public `VerifierBasePvs` users now read/write `recursion_depth`, not `recursion_flag`.
- Confirm that local `recursion_flag` helper columns in inner AIRs are treated as saturated selectors only and are not public values.
- Confirm range-check semantics:
  - inner verifier AIRs: child `recursion_depth` in `[0, 256)`;
  - root-like verifier AIRs and host verifier: final child `recursion_depth` in `[1, 256]`.
- Confirm tracegen supplies every new range-check input:
  - child `recursion_depth` for inner/deferral-inner;
  - `recursion_depth - 1` for root/hook/verify-stark.
- Confirm root prover passes pre-verifier range inputs to `VerifierExternalData` before generating the verifier subcircuit.
- Confirm `prove_mixed` wraps the shallower VM/deferral side until exact depths match.
- Confirm cached-commit selection is unchanged at the semantic level:
  - first internal-recursive layer selects `internal_for_leaf_vk_commit`;
  - later internal-recursive layers select `internal_recursive_vk_commit`.
