### PR TITLE
fix: send `r` instead of squared over the `EqNegBaseRandBus`

### DIFF
--- a/crates/recursion/src/batch_constraint/eq_airs/eq_neg/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_neg/air.rs
@@ -185,8 +185,8 @@ where
             builder,
             local.proof_idx,
             EqNegBaseRandMessage {
-                u: local.u_pow.map(Into::into),
-                r_squared: ext_field_multiply::<AB::Expr>(local.r_pow, local.r_pow),
+                u: local.u_pow,
+                r: local.r_pow,
             },
             local.is_first,
         );

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -635,8 +635,8 @@ define_typed_per_proof_permutation_bus!(EqNegResultBus, EqNegResultMessage);
 pub struct EqNegBaseRandMessage<T> {
     // sampled value u_0
     pub u: [T; D_EF],
-    // sampled value r_0^2
-    pub r_squared: [T; D_EF],
+    // sampled value r_0
+    pub r: [T; D_EF],
 }
 
 define_typed_per_proof_permutation_bus!(EqNegBaseRandBus, EqNegBaseRandMessage);

--- a/crates/recursion/src/stacking/eq_base/air.rs
+++ b/crates/recursion/src/stacking/eq_base/air.rs
@@ -173,7 +173,7 @@ where
 
         /*
          * Receive the values of u_0 and r_0 from the AIRs that sample them. Send u_0
-         * and r_0^2 to EqNegAir.
+         * and r_0 to EqNegAir.
          */
         self.constraint_randomness_bus.receive(
             builder,
@@ -202,8 +202,8 @@ where
             builder,
             local.proof_idx,
             EqNegBaseRandMessage {
-                u: local.u_pow.map(Into::into),
-                r_squared: ext_field_multiply(local.r_pow, local.r_pow),
+                u: local.u_pow,
+                r: local.r_pow,
             },
             local.is_first,
         );


### PR DESCRIPTION
This resolves INT-8372.

---

## Overview

This PR changes the `EqNegBaseRandBus` interface so `EqBaseAir` sends the sampled sumcheck challenge `r_0` directly to `EqNegAir`, instead of sending only `r_0^2`.

`EqBaseAir` already binds `local.r_pow` to `ConstraintSumcheckRandomness { idx: 0, challenge: r_0 }`. With this change, `EqNegAir` receives that exact value over the permutation bus. This removes the previous square-root sign ambiguity where `EqNegAir` could satisfy the bus receive with `-r_0` because `(-r_0)^2 == r_0^2`.

No trace columns are added or removed. The `EqNegBaseRandMessage` width is unchanged: one extension-field element for `u_0` and one extension-field element for the random challenge value.

## Review Map

| File | Change |
| --- | --- |
| `crates/recursion/src/bus.rs` | Renames `EqNegBaseRandMessage::r_squared` to `r` and updates the comment from `r_0^2` to `r_0`. |
| `crates/recursion/src/stacking/eq_base/air.rs` | Sends `local.r_pow` directly on `EqNegBaseRandBus` after receiving it from `ConstraintSumcheckRandomnessBus`. |
| `crates/recursion/src/batch_constraint/eq_airs/eq_neg/air.rs` | Receives `local.r_pow` directly from `EqNegBaseRandBus` instead of receiving a value constrained to `local.r_pow * local.r_pow`. |

## Bus Interaction Change

Before this PR, `EqBaseAir` and `EqNegAir` agreed only on `r_0^2`:

```text
ConstraintSumcheckRandomnessBus
    -> EqBaseAir receives (proof_idx, idx = 0, challenge = r_0)

EqBaseAir
    -> EqNegBaseRandBus sends (proof_idx, u_0, r_0^2)

EqNegAir
    <- EqNegBaseRandBus receives (proof_idx, u_0, local.r_pow^2)
```

After this PR, the bus carries the exact sampled challenge:

```text
ConstraintSumcheckRandomnessBus
    -> EqBaseAir receives (proof_idx, idx = 0, challenge = r_0)

EqBaseAir
    -> EqNegBaseRandBus sends (proof_idx, u_0, r_0)

EqNegAir
    <- EqNegBaseRandBus receives (proof_idx, u_0, local.r_pow)
```

This means a prover can no longer choose `local.r_pow = -r_0` in `EqNegAir` while still matching the base randomness message, except in the degenerate case `r_0 = 0`.

## AIR Changes

### `EqBaseAir`

`EqBaseAir` still receives `r_0` from `ConstraintSumcheckRandomnessBus` on the first row:

```text
(proof_idx, idx = 0, challenge = local.r_pow)
```

The changed part is the message sent to `EqNegAir`:

```text
EqNegBaseRandMessage {
    u: local.u_pow,
    r: local.r_pow,
}
```

The surrounding running-product constraints for `r_pow`, `r_omega_pow`, `eq_0(u, r)`, and negative-dimension lookup inputs are unchanged.

### `EqNegAir`

`EqNegAir` now receives the exact first-row `r_0` value:

```text
EqNegBaseRandMessage {
    u: local.u_pow,
    r: local.r_pow,
}
```

The existing constraints still derive `r_omega_pow = r_pow * omega` on the first row and still use squaring recurrences for later rows and later negative hypercubes. Those internal squaring recurrences remain valid, but the initial sign is now fixed by the bus message from `EqBaseAir`.

### Columns

No AIR columns changed, so there is no new trace shape to review.

## Validation

Ran:

```sh
cargo build --profile fast -p openvm-recursion-circuit
```

Result: passed.
