### PR TITLE
fix: do not account for an absent air's interactions when computing total interactions

### DIFF
--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -635,7 +635,7 @@ where
         // Note that log_lifted_height = max(log_height, l_skip) is constrained to be
         // at most n_stack + l_skip in the stacking module by EqBitsAir.
         let lifted_height = select(
-            local.n_sign_bit,
+            and(local.n_sign_bit, local.is_present),
             AB::F::from_usize(1 << self.l_skip),
             local.height,
         );


### PR DESCRIPTION
This resolves INT-8426. An absent AIR no longer contributes to calculation of the total number of interactions.

---

## Overview

This PR fixes `ProofShapeAir` so absent AIR rows cannot contribute to the accumulated interaction count used to derive `n_logup`.

`ProofShapeAir` computes:

```text
total_interactions = sum(num_interactions_per_row * lifted_height)
```

For present rows, `lifted_height = max(height, 2^l_skip)`. For absent rows, `height` and `log_height` are constrained to zero, and this PR makes `lifted_height` stay zero regardless of the unconstrained absent-row value of `n_sign_bit`.

The diff is intentionally narrow: one expression in `crates/recursion/src/proof_shape/proof_shape/air.rs` changes from selecting the minimum lifted height based only on `n_sign_bit` to selecting it based on `n_sign_bit && is_present`.

## Review Map

| File | Change |
| --- | --- |
| `crates/recursion/src/proof_shape/proof_shape/air.rs` | Gates the `2^l_skip` lifted-height branch by `local.is_present`, so absent rows use `local.height`, which is already constrained to zero. |

## `ProofShapeAir` Change

Before:

```rust
let lifted_height = select(
    local.n_sign_bit,
    AB::F::from_usize(1 << self.l_skip),
    local.height,
);
```

After:

```rust
let lifted_height = select(
    and(local.n_sign_bit, local.is_present),
    AB::F::from_usize(1 << self.l_skip),
    local.height,
);
```

The existing absent-row constraints remain unchanged:

```text
if !is_present && is_valid:
    height = 0
    log_height = 0
```

This means an absent row with `n_sign_bit = 1` no longer forces `lifted_height = 2^l_skip`; it now uses `height = 0`.

## Existing Column Behavior

No columns are added or removed. The table below illustrates the affected existing columns for valid non-summary rows:

| Case | `is_present` | `height` | `log_height` | `n_sign_bit` | `lifted_height` after this PR | Interaction contribution |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Present, `log_height < l_skip` | 1 | `2^log_height` | `< l_skip` | 1 | `2^l_skip` | `num_interactions_per_row * 2^l_skip` |
| Present, `log_height >= l_skip` | 1 | `2^log_height` | `>= l_skip` | 0 | `2^log_height` | `num_interactions_per_row * 2^log_height` |
| Absent, benign sign bit | 0 | 0 | 0 | 0 | 0 | 0 |
| Absent, malicious sign bit | 0 | 0 | 0 | 1 | 0 | 0 |

The last row is the fixed case. Previously, it produced `lifted_height = 2^l_skip` and could inflate `total_interactions`.

## Interaction Accumulation Flow

There are no bus interface changes in this PR. The affected internal flow is:

```text
ProofShapeAir row
    existing columns:
        is_present, height, log_height, n_sign_bit

    lifted_height = is_present && n_sign_bit ? 2^l_skip : height

    lifted_height_limbs
        constrained to decompose lifted_height

    num_interactions_limbs
        constrained to lifted_height * selected VK num_interactions_per_row

    next.total_interactions_limbs
        constrained to local.total_interactions_limbs + num_interactions_limbs

    summary row
        derives n_logup from total_interactions_limbs
        sends n_logup/n_max to GKR and batch-constraint modules
```

Because absent rows now have `lifted_height = 0`, their `num_interactions_limbs` are forced to zero and the running total matches the reference verifier's present-trace-only sum.

## Validation

Ran:

```sh
cargo build --profile fast -p openvm-recursion-circuit
```

Result: passed.
