### PR TITLE
fix: resolve issues revealed during reth benchmark

### DIFF
--- a/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds_unprotected.h
+++ b/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds_unprotected.h
@@ -19,5 +19,7 @@ static __attribute__((always_inline)) inline void check_mem_bounds_range(
     uint32_t start, size_t size) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_u32_range(
     uint32_t base_addr, uint32_t num_words) {}
+static __attribute__((always_inline)) inline void check_mem_bounds_u64_range(
+    uint32_t base_addr, uint32_t num_words) {}
 
 #endif


### PR DESCRIPTION
this PR resolves issues revealed during reth benchmarking. One of the issues was forgetting to update `unprotected` mode related code, such as `openvm_check_mem_bounds_unprotected.h`