### PR TITLE
chore(v2.1-rv64): clean up SDK compile and execute APIs

### DIFF
--- a/benchmarks/execute/examples/regex_execute.rs
+++ b/benchmarks/execute/examples/regex_execute.rs
@@ -29,7 +29,7 @@ fn main() {
 
     // let timer = std::time::Instant::now();
     // executor
-    //     .execute(exe.clone(), StdIn::from_bytes(data.as_bytes()))
+    //     .compile_and_execute(exe.clone(), StdIn::from_bytes(data.as_bytes()))
     //     .unwrap();
     // println!("execute_time: {:?}", timer.elapsed());
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -269,18 +269,19 @@ impl RunCmd {
 
         match self.run_args.mode {
             ExecutionMode::Pure => {
-                let output = sdk.execute(exe, inputs)?;
+                let output = sdk.compile_and_execute(exe, inputs)?;
                 println!("Execution output: {output:?}");
             }
             ExecutionMode::Meter => {
-                let (output, (cost, instret)) = sdk.execute_metered_cost(exe, inputs)?;
+                let (output, (cost, instret)) =
+                    sdk.compile_and_execute_metered_cost(exe, inputs)?;
                 println!("Execution output: {output:?}");
 
                 println!("Number of instructions executed: {instret}");
                 println!("Total cost: {cost}");
             }
             ExecutionMode::Segment => {
-                let (output, segments) = sdk.execute_metered(exe, inputs)?;
+                let (output, segments) = sdk.compile_and_execute_metered(exe, inputs)?;
                 println!("Execution output: {output:?}");
 
                 let total_instructions: u64 = segments.iter().map(|s| s.num_insns).sum();

--- a/crates/sdk/examples/sdk_app.rs
+++ b/crates/sdk/examples/sdk_app.rs
@@ -24,7 +24,7 @@ fn main() -> eyre::Result<()> {
 
     // [!region execution]
     // 3. Run the program with default inputs.
-    let output = sdk.execute(elf.clone(), stdin.clone())?;
+    let output = sdk.compile_and_execute(elf.clone(), stdin.clone())?;
     println!("public values output: {output:?}");
     // [!endregion execution]
 

--- a/crates/sdk/examples/sdk_stark.rs
+++ b/crates/sdk/examples/sdk_stark.rs
@@ -55,7 +55,7 @@ fn main() -> eyre::Result<()> {
     stdin.write(&my_input);
 
     // 4. Run the program
-    let output = sdk.execute(exe.clone(), stdin.clone())?;
+    let output = sdk.compile_and_execute(exe.clone(), stdin.clone())?;
     println!("public values output: {output:?}");
     // [!endregion execution]
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -112,7 +112,7 @@ pub const OPENVM_VERSION: &str = concat!(
 /// that depends on the program executable.
 ///
 /// Some commonly used methods are:
-/// - [`execute`](Self::execute)
+/// - [`compile_and_execute`](Self::compile_and_execute)
 /// - [`prove`](Self::prove)
 /// - [`verify_proof`](Self::verify_proof)
 #[derive(Getters)]
@@ -313,18 +313,19 @@ where
     <VB::VmConfig as VmExecutionConfig<F>>::Executor:
         Executor<F> + MeteredExecutor<F> + PreflightExecutor<F, VB::RecordArena>,
 {
-    /// Returns the user public values as field elements.
-    pub fn execute(
+    /// Compile `app_exe` and execute it, returning the user public values as bytes.
+    pub fn compile_and_execute(
         &self,
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
     ) -> Result<Vec<u8>, SdkError> {
-        let compiled = self.compile_pure(app_exe)?;
-        self.execute_compiled(&compiled, inputs)
+        let compiled = self.compile(app_exe)?;
+        self.execute(&compiled, inputs)
     }
 
     /// Compile `app_exe` for pure execution.
-    pub fn compile_pure(
+    #[tracing::instrument(name = "sdk.compile", level = "info", skip_all)]
+    pub fn compile(
         &self,
         app_exe: impl Into<ExecutableFormat>,
     ) -> Result<CompiledExePure<'_, F>, SdkError> {
@@ -337,7 +338,7 @@ where
 
     /// Load a previously saved pure-mode rvr artifact. No compatibility validation is performed.
     #[cfg(feature = "rvr")]
-    pub fn load_compiled_pure(
+    pub fn load_compiled(
         &self,
         lib_path: &std::path::Path,
         app_exe: impl Into<ExecutableFormat>,
@@ -350,7 +351,8 @@ where
     }
 
     /// Run a [`CompiledExePure`] against `inputs` and extract the user public values.
-    pub fn execute_compiled(
+    #[tracing::instrument(name = "sdk.execute", level = "info", skip_all)]
+    pub fn execute(
         &self,
         compiled: &CompiledExePure<'_, F>,
         inputs: StdIn,
@@ -368,18 +370,19 @@ where
 
     /// Executes with segmentation for proof generation.
     /// Returns both user public values and segments with instruction counts and trace heights.
-    pub fn execute_metered(
+    pub fn compile_and_execute_metered(
         &self,
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
     ) -> Result<(Vec<u8>, Vec<Segment>), SdkError> {
         let compiled = self.compile_metered(app_exe)?;
-        self.execute_compiled_metered(&compiled, inputs)
+        self.execute_metered(&compiled, inputs)
     }
 
     /// Compile `app_exe` for metered execution. The returned [`CompiledExeMetered`] bundles
     /// a precomputed [`MeteredCtx`](openvm_circuit::arch::execution_mode::MeteredCtx) so
     /// subsequent runs just clone it.
+    #[tracing::instrument(name = "sdk.compile_metered", level = "info", skip_all)]
     pub fn compile_metered(
         &self,
         app_exe: impl Into<ExecutableFormat>,
@@ -420,7 +423,8 @@ where
     }
 
     /// Run a [`CompiledExeMetered`] against `inputs`.
-    pub fn execute_compiled_metered(
+    #[tracing::instrument(name = "sdk.execute_metered", level = "info", skip_all)]
+    pub fn execute_metered(
         &self,
         compiled: &CompiledExeMetered<'_>,
         inputs: StdIn,
@@ -439,16 +443,17 @@ where
 
     /// Executes with cost metering to measure computational cost in trace cells.
     /// Returns both user public values, and cost along with instruction count.
-    pub fn execute_metered_cost(
+    pub fn compile_and_execute_metered_cost(
         &self,
         app_exe: impl Into<ExecutableFormat>,
         inputs: StdIn,
     ) -> Result<(Vec<u8>, (u64, u64)), SdkError> {
         let compiled = self.compile_metered_cost(app_exe)?;
-        self.execute_compiled_metered_cost(&compiled, inputs)
+        self.execute_metered_cost(&compiled, inputs)
     }
 
     /// Compile `app_exe` for metered-cost execution. See [`Self::compile_metered`].
+    #[tracing::instrument(name = "sdk.compile_metered_cost", level = "info", skip_all)]
     pub fn compile_metered_cost(
         &self,
         app_exe: impl Into<ExecutableFormat>,
@@ -495,7 +500,8 @@ where
     }
 
     /// Run a [`CompiledExeMeteredCost`] against `inputs`.
-    pub fn execute_compiled_metered_cost(
+    #[tracing::instrument(name = "sdk.execute_metered_cost", level = "info", skip_all)]
+    pub fn execute_metered_cost(
         &self,
         compiled: &CompiledExeMeteredCost<'_>,
         inputs: StdIn,

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -309,15 +309,15 @@ fn test_sdk_compiled_pure_save_load_roundtrip() -> Result<()> {
     let mut stdin = StdIn::default();
     stdin.write(&100u64);
 
-    let compiled_a = sdk.compile_pure(exe.clone())?;
-    let baseline = sdk.execute_compiled(&compiled_a, stdin.clone())?;
+    let compiled_a = sdk.compile(exe.clone())?;
+    let baseline = sdk.execute(&compiled_a, stdin.clone())?;
 
     let tmp = tempfile::tempdir()?;
     let lib_path = compiled_a.save(tmp.path())?;
     drop(compiled_a);
 
-    let compiled_b = sdk.load_compiled_pure(&lib_path, exe)?;
-    let reloaded = sdk.execute_compiled(&compiled_b, stdin)?;
+    let compiled_b = sdk.load_compiled(&lib_path, exe)?;
+    let reloaded = sdk.execute(&compiled_b, stdin)?;
 
     assert_eq!(baseline, reloaded);
     Ok(())
@@ -337,15 +337,14 @@ fn test_sdk_compiled_metered_save_load_roundtrip() -> Result<()> {
     stdin.write(&100u64);
 
     let compiled_a = sdk.compile_metered(exe.clone())?;
-    let (baseline_pv, baseline_segments) =
-        sdk.execute_compiled_metered(&compiled_a, stdin.clone())?;
+    let (baseline_pv, baseline_segments) = sdk.execute_metered(&compiled_a, stdin.clone())?;
 
     let tmp = tempfile::tempdir()?;
     let lib_path = compiled_a.save(tmp.path())?;
     drop(compiled_a);
 
     let compiled_b = sdk.load_compiled_metered(&lib_path, exe)?;
-    let (reloaded_pv, reloaded_segments) = sdk.execute_compiled_metered(&compiled_b, stdin)?;
+    let (reloaded_pv, reloaded_segments) = sdk.execute_metered(&compiled_b, stdin)?;
 
     assert_eq!(baseline_pv, reloaded_pv);
     assert_eq!(baseline_segments.len(), reloaded_segments.len());
@@ -371,15 +370,14 @@ fn test_sdk_compiled_metered_cost_save_load_roundtrip() -> Result<()> {
     stdin.write(&100u64);
 
     let compiled_a = sdk.compile_metered_cost(exe.clone())?;
-    let (baseline_pv, baseline_cost) =
-        sdk.execute_compiled_metered_cost(&compiled_a, stdin.clone())?;
+    let (baseline_pv, baseline_cost) = sdk.execute_metered_cost(&compiled_a, stdin.clone())?;
 
     let tmp = tempfile::tempdir()?;
     let lib_path = compiled_a.save(tmp.path())?;
     drop(compiled_a);
 
     let compiled_b = sdk.load_compiled_metered_cost(&lib_path, exe)?;
-    let (reloaded_pv, reloaded_cost) = sdk.execute_compiled_metered_cost(&compiled_b, stdin)?;
+    let (reloaded_pv, reloaded_cost) = sdk.execute_metered_cost(&compiled_b, stdin)?;
 
     assert_eq!(baseline_pv, reloaded_pv);
     assert_eq!(baseline_cost, reloaded_cost);
@@ -399,7 +397,7 @@ fn test_sdk_compiled_metered_execute() -> Result<()> {
     stdin.write(&100u64);
 
     let compiled = sdk.compile_metered(exe)?;
-    let (_, segments) = sdk.execute_compiled_metered(&compiled, stdin)?;
+    let (_, segments) = sdk.execute_metered(&compiled, stdin)?;
     assert!(!segments.is_empty());
     Ok(())
 }
@@ -417,7 +415,7 @@ fn test_sdk_compiled_metered_cost_execute() -> Result<()> {
     stdin.write(&100u64);
 
     let compiled = sdk.compile_metered_cost(exe)?;
-    let (_, (_, instret)) = sdk.execute_compiled_metered_cost(&compiled, stdin)?;
+    let (_, (_, instret)) = sdk.execute_metered_cost(&compiled, stdin)?;
     assert!(instret > 0);
     Ok(())
 }


### PR DESCRIPTION
## Summary

Clarifies the SDK execution API by separating compile, execute, and compile-and-execute entry points for pure and metered flows. This renames the previous compiled-execution helpers to the shorter `execute*` forms and updates SDK examples, tests, and CLI call sites accordingly.

## Testing

- `cargo check --profile fast -p openvm-sdk`
- `cargo check --profile fast -p openvm-sdk --tests`
- `cargo check --profile fast -p openvm-sdk --examples`
- `cargo check --profile fast -p cargo-openvm`
- `cargo check --profile fast -p openvm-prof`