### PR TITLE
chore(v2-rc.2): add tracegen observability spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6633,6 +6633,7 @@ dependencies = [
  "serde",
  "strum 0.26.3",
  "test-case",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/prof/src/aggregate.rs
+++ b/crates/prof/src/aggregate.rs
@@ -648,6 +648,7 @@ pub const EXECUTE_METERED_TIME_LABEL: &str = "execute_metered_time_ms";
 pub const EXECUTE_METERED_INSN_MI_S_LABEL: &str = "execute_metered_insn_mi/s";
 pub const EXECUTE_PREFLIGHT_TIME_LABEL: &str = "execute_preflight_time_ms";
 pub const EXECUTE_PREFLIGHT_INSN_MI_S_LABEL: &str = "execute_preflight_insn_mi/s";
+pub const RECORD_ARENA_ALLOC_TIME_LABEL: &str = "record_arena.alloc_time_ms";
 pub const TRACE_GEN_TIME_LABEL: &str = "trace_gen_time_ms";
 pub const GENERATE_BLOB_TIME_LABEL: &str = "generate_blob_total_time_ms";
 pub const MEM_FIN_TIME_LABEL: &str = "memory_finalize_time_ms";
@@ -670,6 +671,7 @@ pub const AGGREGATED_METRIC_NAMES: &[&str] = &[
     EXECUTE_PREFLIGHT_INSNS_LABEL,
     EXECUTE_PREFLIGHT_TIME_LABEL,
     EXECUTE_PREFLIGHT_INSN_MI_S_LABEL,
+    RECORD_ARENA_ALLOC_TIME_LABEL,
     TRACE_GEN_TIME_LABEL,
     GENERATE_BLOB_TIME_LABEL,
     MEM_FIN_TIME_LABEL,

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -742,6 +742,19 @@ where
                             let air_name = self.inventory.airs.ext_airs[insertion_idx].name();
                             info_span!("single_trace_gen", air = air_name).entered()
                         });
+                        #[cfg(feature = "metrics")]
+                        if let Some(allocated_bytes) = (!records.is_empty())
+                            .then(|| records.allocated_bytes())
+                            .flatten()
+                        {
+                            let air_name = self.inventory.airs.ext_airs[insertion_idx].name();
+                            let labels = [
+                                ("air_name", air_name.to_string()),
+                                ("air_id", (num_sys_airs + insertion_idx).to_string()),
+                            ];
+                            metrics::counter!("trace_gen.record_arena_bytes", &labels)
+                                .absolute(allocated_bytes as u64);
+                        }
                         chip.generate_proving_ctx(records)
                     },
                 ),

--- a/crates/vm/src/arch/record_arena.rs
+++ b/crates/vm/src/arch/record_arena.rs
@@ -25,6 +25,11 @@ pub trait Arena {
     fn current_trace_height(&self) -> usize {
         0
     }
+
+    #[cfg(feature = "metrics")]
+    fn allocated_bytes(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Given some minimum layout of type `Layout`, the `RecordArena` should allocate a buffer, of
@@ -256,6 +261,11 @@ impl Arena for DenseRecordArena {
 
     fn is_empty(&self) -> bool {
         self.allocated().is_empty()
+    }
+
+    #[cfg(feature = "metrics")]
+    fn allocated_bytes(&self) -> Option<usize> {
+        Some(self.allocated().len())
     }
 }
 

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -601,7 +601,8 @@ where
         let capacities = zip_eq(trace_heights, main_widths)
             .map(|(&h, w)| (h as usize, w))
             .collect::<Vec<_>>();
-        let ctx = PreflightCtx::new_with_capacity(&capacities, num_insns);
+        let ctx = info_span!("record_arena.alloc")
+            .in_scope(|| PreflightCtx::new_with_capacity(&capacities, num_insns));
 
         let pc = state.pc();
         let memory = TracingMemory::from_image(state.memory);
@@ -831,6 +832,7 @@ where
         self.chip_complex.system.load_program(cached_program_trace);
     }
 
+    #[instrument(name = "vm.transport_init_memory", skip_all)]
     pub fn transport_init_memory_to_device(&mut self, memory: &GuestMemory) {
         self.chip_complex
             .system

--- a/extensions/rv32im/circuit/Cargo.toml
+++ b/extensions/rv32im/circuit/Cargo.toml
@@ -25,6 +25,7 @@ derive_more = { workspace = true, features = ["from"] }
 rand.workspace = true
 eyre.workspace = true
 cfg-if.workspace = true
+tracing.workspace = true
 
 # for div_rem:
 num-bigint.workspace = true

--- a/extensions/rv32im/circuit/src/auipc/cuda.rs
+++ b/extensions/rv32im/circuit/src/auipc/cuda.rs
@@ -35,7 +35,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32AuipcChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/base_alu/cuda.rs
+++ b/extensions/rv32im/circuit/src/base_alu/cuda.rs
@@ -41,7 +41,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32BaseAluChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/branch_eq/cuda.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/cuda.rs
@@ -36,7 +36,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32BranchEqualChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/branch_lt/cuda.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/cuda.rs
@@ -42,7 +42,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32BranchLessThanChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/divrem/cuda.rs
+++ b/extensions/rv32im/circuit/src/divrem/cuda.rs
@@ -47,7 +47,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32DivRemChipGpu {
         let tuple_checker_sizes = UInt2::new(tuple_checker_sizes[0], tuple_checker_sizes[1]);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(padded_height, trace_width, device_ctx);
         unsafe {
             tracegen(

--- a/extensions/rv32im/circuit/src/hintstore/cuda.rs
+++ b/extensions/rv32im/circuit/src/hintstore/cuda.rs
@@ -58,7 +58,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32HintStoreChipGpu {
         }
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_record_offsets = offsets.to_device_on(device_ctx).unwrap();
 
         let trace_height = next_power_of_two_or_zero(offsets.len());

--- a/extensions/rv32im/circuit/src/jal_lui/cuda.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/cuda.rs
@@ -36,7 +36,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32JalLuiChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/jalr/cuda.rs
+++ b/extensions/rv32im/circuit/src/jalr/cuda.rs
@@ -34,7 +34,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32JalrChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/less_than/cuda.rs
+++ b/extensions/rv32im/circuit/src/less_than/cuda.rs
@@ -41,7 +41,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LessThanChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/load_sign_extend/cuda.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/cuda.rs
@@ -39,7 +39,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadSignExtendChipGpu {
         let padded_height = next_power_of_two_or_zero(height);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(padded_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/loadstore/cuda.rs
+++ b/extensions/rv32im/circuit/src/loadstore/cuda.rs
@@ -39,7 +39,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadStoreChipGpu {
         let padded_height = next_power_of_two_or_zero(height);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(padded_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/mul/cuda.rs
+++ b/extensions/rv32im/circuit/src/mul/cuda.rs
@@ -46,7 +46,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32MultiplicationChipGpu {
         let tuple_checker_sizes = UInt2::new(tuple_checker_sizes[0], tuple_checker_sizes[1]);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/mulh/cuda.rs
+++ b/extensions/rv32im/circuit/src/mulh/cuda.rs
@@ -46,7 +46,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32MulHChipGpu {
         let tuple_checker_sizes = UInt2::new(tuple_checker_sizes[0], tuple_checker_sizes[1]);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/shift/cuda.rs
+++ b/extensions/rv32im/circuit/src/shift/cuda.rs
@@ -41,7 +41,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32ShiftChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
         unsafe {
             rv32_shift_tracegen(


### PR DESCRIPTION
## Summary
- Add trace-gen observability spans around record arena allocation, initial memory transport, and RV32IM CUDA record H2D enqueue points.
- Emit per-AIR `trace_gen.record_arena_bytes` only for arenas that can report real byte counts.
- Surface `record_arena.alloc_time_ms` in `openvm-prof` aggregate output.

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --profile fast -p openvm-circuit --features metrics`
- `cargo check --profile fast -p openvm-rv32im-circuit`