### PR TITLE
fix: root layer tracegen and proving on the same GPU context

### DIFF
--- a/crates/continuations/src/prover/root/mod.rs
+++ b/crates/continuations/src/prover/root/mod.rs
@@ -44,8 +44,19 @@ pub struct RootProver<S: AggregationSubCircuit, T> {
 }
 
 impl<S: AggregationSubCircuit, T> RootProver<S, T> {
+    pub fn create_engine<E>(&self) -> E
+    where
+        E: StarkEngine<SC = RootSC>,
+    {
+        E::new(self.pk.params.clone())
+    }
+
     #[instrument(name = "total_proof", skip_all)]
-    pub fn root_prove_from_ctx<E>(&self, ctx: ProvingContext<E::PB>) -> Result<Proof<RootSC>>
+    pub fn root_prove_from_ctx<E>(
+        &self,
+        ctx: ProvingContext<E::PB>,
+        engine: &E,
+    ) -> Result<Proof<RootSC>>
     where
         E: StarkEngine<SC = RootSC>,
         E::PB: ProverBackend<Val = F, Challenge = EF, Commitment = [Bn254; 1]>,
@@ -56,10 +67,9 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         if tracing::enabled!(tracing::Level::DEBUG) {
             trace_heights_tracing_info::<_, RootSC>(&ctx.per_trace, &self.circuit.airs());
         }
-        let engine = E::new(self.pk.params.clone());
         #[cfg(debug_assertions)]
         if crate::prover::debug_checks_enabled() {
-            crate::prover::debug_constraints(&self.circuit, &ctx, &engine);
+            crate::prover::debug_constraints(&self.circuit, &ctx, engine);
         }
         let d_pk = engine.device().transport_pk_to_device(self.pk.as_ref());
         let proof = engine.prove(&d_pk, ctx)?;

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -746,7 +746,7 @@ fn test_deferral_e2e() -> Result<()> {
         None,
     );
     let root_vk = root_prover.get_vk();
-    let engine = RootEngine::new(root_vk.inner.params.clone());
+    let engine = root_prover.create_engine::<RootEngine>();
     let proving_ctx = root_prover.generate_proving_ctx::<<RootEngine as StarkEngine>::PB, _>(
         combined_proof,
         &user_pvs_proof,
@@ -754,7 +754,8 @@ fn test_deferral_e2e() -> Result<()> {
         engine_device_ctx(&engine),
     );
     warn!("proving root (GPU)");
-    let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(proving_ctx.unwrap())?;
+    let root_proof =
+        root_prover.root_prove_from_ctx::<RootEngine>(proving_ctx.unwrap(), &engine)?;
     engine.verify(&root_vk, &root_proof)?;
 
     Ok(())

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -311,13 +311,13 @@ fn test_root_prover(extra_recursive_layers: usize) -> Result<()> {
         None,
         None,
     );
-    let engine = RootEngine::new(root_prover.get_vk().inner.params.clone());
+    let engine = root_prover.create_engine::<RootEngine>();
     let ctx = root_prover.generate_proving_ctx_no_def::<<RootEngine as StarkEngine>::PB, _>(
         internal_recursive_proof,
         &user_pvs_proof,
         &engine.device().device_ctx,
     );
-    let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx.unwrap())?;
+    let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx.unwrap(), &engine)?;
 
     let vk = root_prover.get_vk();
     engine.verify(&vk, &root_proof)?;
@@ -347,7 +347,7 @@ fn test_root_prover_trace_heights() -> Result<()> {
         None,
     );
     let root_pk = root_base_prover.get_pk();
-    let engine = RootEngine::new(root_pk.params.clone());
+    let engine = root_base_prover.create_engine::<RootEngine>();
     let ctx = root_base_prover
         .generate_proving_ctx_no_def::<<RootEngine as StarkEngine>::PB, _>(
             internal_recursive_proof.clone(),
@@ -373,7 +373,7 @@ fn test_root_prover_trace_heights() -> Result<()> {
         None,
         Some(trace_heights.clone()),
     );
-    let engine2 = RootEngine::new(root_prover.get_pk().params.clone());
+    let engine2 = root_prover.create_engine::<RootEngine>();
     let ctx = root_prover
         .generate_proving_ctx_no_def::<<RootEngine as StarkEngine>::PB, _>(
             internal_recursive_proof,
@@ -385,7 +385,7 @@ fn test_root_prover_trace_heights() -> Result<()> {
     for ((air_idx, air_ctx), expected_height) in ctx.per_trace.iter().zip(trace_heights) {
         assert_eq!(air_ctx.height(), expected_height, "air_idx {air_idx}");
     }
-    let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx)?;
+    let root_proof = root_prover.root_prove_from_ctx::<RootEngine>(ctx, &engine2)?;
 
     let vk = root_prover.get_vk();
     let engine = RootEngine::new(vk.inner.params.clone());

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -92,7 +92,7 @@ where
         None,
     );
 
-    let engine = RootE::new(root_prover.get_pk().params.clone());
+    let engine = root_prover.create_engine::<RootE>();
     let root_proving_ctx: ProvingContext<<RootE as StarkEngine>::PB> = root_prover
         .generate_proving_ctx(
             agg_proof.inner,

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -85,8 +85,9 @@ where
 
         const MAX_ROOT_TRACEGEN_RETRIES: usize = 8;
         let agg_prover = &self.stark_prover.agg_prover;
+        let root_engine = self.root_prover.create_engine();
         self.root_prover
-            .prove(stark_proof, MAX_ROOT_TRACEGEN_RETRIES, |p| {
+            .prove(stark_proof, &root_engine, MAX_ROOT_TRACEGEN_RETRIES, |p| {
                 agg_prover.wrap_proof(p, metadata)
             })
     }

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -95,17 +95,21 @@ impl RootProver {
         Self(inner)
     }
 
+    pub fn create_engine(&self) -> E {
+        self.0.create_engine::<E>()
+    }
+
     pub fn generate_proving_ctx(
         &self,
         input: VmStarkProof,
+        engine: &E,
     ) -> Option<ProvingContext<<E as StarkEngine>::PB>> {
-        let engine = E::new(self.0.get_pk().params.clone());
         let ctx = info_span!("tracegen_attempt", group = format!("root")).in_scope(|| {
             self.0.generate_proving_ctx(
                 input.inner,
                 &input.user_pvs_proof,
                 input.deferral_merkle_proofs.as_ref(),
-                engine_device_ctx(&engine),
+                engine_device_ctx(engine),
             )
         });
         ctx
@@ -114,21 +118,24 @@ impl RootProver {
     pub fn prove_from_ctx(
         &self,
         ctx: ProvingContext<<E as StarkEngine>::PB>,
+        engine: &E,
     ) -> Result<Proof<RootSC>> {
-        let proof = info_span!("agg_layer", group = format!("root"))
-            .in_scope(|| info_span!("root").in_scope(|| self.0.root_prove_from_ctx::<E>(ctx)))?;
+        let proof = info_span!("agg_layer", group = format!("root")).in_scope(|| {
+            info_span!("root").in_scope(|| self.0.root_prove_from_ctx::<E>(ctx, engine))
+        })?;
         Ok(proof)
     }
 
     pub fn prove(
         &self,
         mut stark_proof: VmStarkProof,
+        engine: &E,
         max_retries: usize,
         mut wrap: impl FnMut(VmStarkProof) -> Result<VmStarkProof>,
     ) -> Result<Proof<RootSC>> {
         let mut attempt = 0usize;
         let ctx = loop {
-            if let Some(ctx) = self.generate_proving_ctx(stark_proof.clone()) {
+            if let Some(ctx) = self.generate_proving_ctx(stark_proof.clone(), engine) {
                 break ctx;
             }
             if attempt >= max_retries {
@@ -155,7 +162,7 @@ impl RootProver {
             );
         }
 
-        self.prove_from_ctx(ctx)
+        self.prove_from_ctx(ctx, engine)
     }
 }
 
@@ -221,12 +228,13 @@ pub fn compute_root_proof_heights(
         def_hook_commit,
         None,
     );
+    let engine = root_prover.create_engine::<CpuRootE>();
     let root_proving_ctx: ProvingContext<<CpuRootE as StarkEngine>::PB> = root_prover
         .generate_proving_ctx(
             agg_proof.inner,
             &agg_proof.user_pvs_proof,
             agg_proof.deferral_merkle_proofs.as_ref(),
-            &(),
+            engine_device_ctx(&engine),
         )
         .unwrap();
 


### PR DESCRIPTION
Resolves INT-8503.

## Overview

Fix root proof generation so root trace generation and proving use the same caller-owned `StarkEngine` instance. This keeps GPU-backed root proving on a single device context instead of constructing a second engine between trace generation and proof creation.

Changes include:

- Add `RootProver::create_engine` helpers in the continuations prover and SDK wrapper.
- Thread an explicit root engine through `generate_proving_ctx`, `prove_from_ctx`, and `prove`.
- Update EVM proving, dummy keygen, root proof height computation, and root prover tests to reuse the shared engine.
- Preserve debug constraint checks and device proving-key transport against the same engine used for trace generation.