### PR TITLE
fix(v2-rc.2): cleanup prove-evm metrics

### DIFF
--- a/crates/prof/src/aggregate.rs
+++ b/crates/prof/src/aggregate.rs
@@ -432,15 +432,26 @@ impl AggregateMetrics {
 
         let metric_names = metric_names.to_vec();
         for (group_name, summaries) in self.to_vec() {
-            writeln!(writer, "| {group_name} |||||")?;
-            writeln!(writer, "|:---|---:|---:|---:|---:|")?;
-            writeln!(writer, "|metric|avg|sum|max|min|")?;
+            if group_name.contains("keygen") {
+                continue;
+            }
 
             let names: Vec<&str> = if metric_names.is_empty() {
                 summaries.keys().map(|s| s.as_str()).collect()
             } else {
                 metric_names.clone()
             };
+            let names: Vec<&str> = names
+                .into_iter()
+                .filter(|name| summaries.contains_key(*name))
+                .collect();
+            if names.is_empty() {
+                continue;
+            }
+
+            writeln!(writer, "| {group_name} |||||")?;
+            writeln!(writer, "|:---|---:|---:|---:|---:|")?;
+            writeln!(writer, "|metric|avg|sum|max|min|")?;
 
             // Group metrics by phase
             let get_phase = |name: &str| -> Option<&str> {
@@ -648,7 +659,6 @@ pub const EXECUTE_METERED_TIME_LABEL: &str = "execute_metered_time_ms";
 pub const EXECUTE_METERED_INSN_MI_S_LABEL: &str = "execute_metered_insn_mi/s";
 pub const EXECUTE_PREFLIGHT_TIME_LABEL: &str = "execute_preflight_time_ms";
 pub const EXECUTE_PREFLIGHT_INSN_MI_S_LABEL: &str = "execute_preflight_insn_mi/s";
-pub const RECORD_ARENA_ALLOC_TIME_LABEL: &str = "record_arena.alloc_time_ms";
 pub const TRACE_GEN_TIME_LABEL: &str = "trace_gen_time_ms";
 pub const GENERATE_BLOB_TIME_LABEL: &str = "generate_blob_total_time_ms";
 pub const MEM_FIN_TIME_LABEL: &str = "memory_finalize_time_ms";
@@ -671,7 +681,6 @@ pub const AGGREGATED_METRIC_NAMES: &[&str] = &[
     EXECUTE_PREFLIGHT_INSNS_LABEL,
     EXECUTE_PREFLIGHT_TIME_LABEL,
     EXECUTE_PREFLIGHT_INSN_MI_S_LABEL,
-    RECORD_ARENA_ALLOC_TIME_LABEL,
     TRACE_GEN_TIME_LABEL,
     GENERATE_BLOB_TIME_LABEL,
     MEM_FIN_TIME_LABEL,

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -75,6 +75,7 @@ where
         agg_prover.clone(),
         def_prover,
     )?;
+    stark_prover.set_program_name("root_keygen");
     let (agg_proof, _) = stark_prover.prove(StdIn::default(), &[])?;
 
     let root_prover = RootInnerProver::new::<RootE>(
@@ -140,6 +141,7 @@ where
         None,
     )
     .expect("Failed to create dummy EVM prover");
+    evm_prover.stark_prover.set_program_name("halo2_keygen");
 
     evm_prover
         .prove_root(StdIn::default(), &[])

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -601,8 +601,7 @@ where
         let capacities = zip_eq(trace_heights, main_widths)
             .map(|(&h, w)| (h as usize, w))
             .collect::<Vec<_>>();
-        let ctx = info_span!("record_arena.alloc")
-            .in_scope(|| PreflightCtx::new_with_capacity(&capacities, num_insns));
+        let ctx = PreflightCtx::new_with_capacity(&capacities, num_insns);
 
         let pc = state.pc();
         let memory = TracingMemory::from_image(state.memory);


### PR DESCRIPTION
resolves INT-7126

## Summary
- Relabel terminate-only dummy proofs used during root/Halo2 keygen as keygen groups so prove-evm reports do not get an extra one-instruction `app_proof` group.
- Stop emitting and reporting `record_arena.alloc_time_ms`.
- Hide keygen groups and skip empty groups in generated detailed markdown tables.

## Notes
- Comparing the linked prove-evm/prove-stark runs, the dummy proof pollution is limited to the tiny `app_proof` group. Aggregation counts line up with the real proof pipeline (`leaf` 22 and `internal_for_leaf` 8 in both runs).

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo check --profile fast -p openvm-sdk --features evm-prove,metrics`
- `cargo check --profile fast -p openvm-prof`