### PR TITLE
refactor: remove unused u32 functions

### DIFF
--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -44,52 +44,11 @@ pub const DEFAULT_PAGE_BITS: usize = 6;
 pub const DEFAULT_SEGMENT_CHECK_INSNS: u32 = 1000;
 
 extern "C" {
-    // ── Memory access (single word, data) ─────────────────────────────
-    pub fn rd_mem_u32_wrapper(state: *mut c_void, addr: u32) -> u32;
-    pub fn wr_mem_u32_wrapper(state: *mut c_void, addr: u32, val: u32);
-
-    // ── Memory access (single word, trace-only) ───────────────────────
-    pub fn trace_rd_mem_u32_wrapper(state: *mut c_void, addr: u32, val: u32);
-    pub fn trace_wr_mem_u32_wrapper(state: *mut c_void, addr: u32, new_val: u32);
-    pub fn trace_mem_access_u32_wrapper(state: *mut c_void, addr: u32, addr_space: u32);
-
-    // ── Memory access (single u64 word, data)
+    // ── Memory access (single u64 word, data) ─────────────────────────
     pub fn rd_mem_u64_wrapper(state: *mut c_void, addr: u32) -> u64;
+
+    // ── Memory access (single u64 word, trace-only) ───────────────────
     pub fn trace_rd_mem_u64_wrapper(state: *mut c_void, addr: u32, val: u64);
-
-    // ── Memory access (u32 ranges, data) ─────────────────────────────
-    pub fn rd_mem_u32_range_wrapper(
-        state: *mut c_void,
-        base_addr: u32,
-        out: *mut u32,
-        num_words: u32,
-    );
-    pub fn wr_mem_u32_range_wrapper(
-        state: *mut c_void,
-        base_addr: u32,
-        vals: *const u32,
-        num_words: u32,
-    );
-
-    // ── Memory access (u32 ranges, trace-only) ────────────────────────
-    pub fn trace_rd_mem_u32_range_wrapper(
-        state: *mut c_void,
-        base_addr: u32,
-        vals: *const u32,
-        num_words: u32,
-    );
-    pub fn trace_wr_mem_u32_range_wrapper(
-        state: *mut c_void,
-        base_addr: u32,
-        vals: *const u32,
-        num_words: u32,
-    );
-    pub fn trace_mem_access_u32_range_wrapper(
-        state: *mut c_void,
-        base_addr: u32,
-        num_words: u32,
-        addr_space: u32,
-    );
 
     // ── Memory access (u64-word ranges, data) — WORD_SIZE = 8 bytes ──
     pub fn rd_mem_u64_range_wrapper(
@@ -140,56 +99,23 @@ extern "C" {
 
 // ── Zero-copy lane reinterpretation ─────────────────────────────────────
 
-// We assume a little-endian host (x86_64, aarch64). All u64↔u32 reinterpret
-// helpers below depend on that.
+// We assume a little-endian host (x86_64, aarch64). The u64→u32 reinterpret
+// helper below depends on that.
 const _: () = assert!(
     cfg!(target_endian = "little"),
     "rvr-openvm-ext-ffi-common assumes a little-endian host"
 );
 
-/// Reinterpret a `[u64]` slice as a `[u32]` slice (twice as many elements).
-/// Zero-copy on LE: the low u32 of each u64 comes first, then the high u32.
-#[inline(always)]
-pub fn u64s_as_u32s(lanes: &[u64]) -> &[u32] {
-    let len = lanes.len() * 2;
-    // SAFETY: u64 alignment (8) >= u32 alignment (4); total bytes match;
-    // POD types; LE host (asserted above) makes the layout (lo, hi).
-    unsafe { std::slice::from_raw_parts(lanes.as_ptr().cast::<u32>(), len) }
-}
-
-/// Mutable counterpart of [`u64s_as_u32s`]. Mutating through the returned
-/// slice mutates the underlying u64 lanes.
+/// Reinterpret a `[u64]` slice as a `[u32]` slice (twice as many elements),
+/// mutably. Zero-copy on LE: the low u32 of each u64 comes first, then the
+/// high u32. Mutating through the returned slice mutates the underlying u64
+/// lanes.
 #[inline(always)]
 pub fn u64s_as_u32s_mut(lanes: &mut [u64]) -> &mut [u32] {
     let len = lanes.len() * 2;
-    // SAFETY: see u64s_as_u32s.
+    // SAFETY: u64 alignment (8) >= u32 alignment (4); total bytes match;
+    // POD types; LE host (asserted above) makes the layout (lo, hi).
     unsafe { std::slice::from_raw_parts_mut(lanes.as_mut_ptr().cast::<u32>(), len) }
-}
-
-/// Reinterpret a `[u32]` slice as a `[u8]` slice (4× as many elements).
-/// Zero-copy: each u32 contributes its LE bytes in order.
-#[inline(always)]
-pub fn u32s_as_u8s(words: &[u32]) -> &[u8] {
-    let len = words.len() * WORD_SIZE;
-    // SAFETY: u32 alignment (4) >= u8 alignment (1); total bytes match;
-    // POD; LE host (asserted above).
-    unsafe { std::slice::from_raw_parts(words.as_ptr().cast::<u8>(), len) }
-}
-
-/// Reinterpret a `[u32]` slice as a `[u64]` slice (half as many elements).
-/// `words.len()` must be even and the slice must be u64-aligned (a stack
-/// `[u32; 2N]` is **not** guaranteed to be 8-aligned; use this only on slices
-/// that originated as `[u64]`).
-#[inline(always)]
-pub fn u32s_as_u64s(words: &[u32]) -> &[u64] {
-    debug_assert!(words.len().is_multiple_of(2));
-    debug_assert!(
-        (words.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u64>()),
-        "u32s_as_u64s requires 8-byte aligned input"
-    );
-    let len = words.len() / 2;
-    // SAFETY: alignment debug-asserted; total bytes match; POD; LE host.
-    unsafe { std::slice::from_raw_parts(words.as_ptr().cast::<u64>(), len) }
 }
 
 // ── Ergonomic batched memory helpers ─────────────────────────────────────

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -38,9 +38,6 @@ pub trait ExtEmitCtx {
     /// Emit a single memory-page trace.
     fn trace_mem_access(&mut self, addr: &str, addr_space: u32);
 
-    /// Emit a word-range memory-page trace.
-    fn trace_mem_access_u32_range(&mut self, base_addr: &str, num_words: &str, addr_space: u32);
-
     /// Emit a dword-range memory-page trace (rv64: each unit is 8 bytes).
     fn trace_mem_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32);
 }

--- a/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.h
+++ b/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.h
@@ -66,11 +66,6 @@ static __attribute__((always_inline)) inline void check_mem_bounds_range(
   }
 }
 
-static __attribute__((always_inline)) inline void check_mem_bounds_u32_range(
-    uint32_t base_addr, uint32_t num_words) {
-  check_mem_bounds_range(base_addr, (size_t)num_words * sizeof(uint32_t));
-}
-
 static __attribute__((always_inline)) inline void check_mem_bounds_u64_range(
     uint32_t base_addr, uint32_t num_words) {
   check_mem_bounds_range(base_addr, (size_t)num_words * sizeof(uint64_t));

--- a/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds_unprotected.h
+++ b/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds_unprotected.h
@@ -17,8 +17,6 @@ static __attribute__((always_inline)) inline void check_mem_bounds_u64(
     uint32_t start) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_range(
     uint32_t start, size_t size) {}
-static __attribute__((always_inline)) inline void check_mem_bounds_u32_range(
-    uint32_t base_addr, uint32_t num_words) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_u64_range(
     uint32_t base_addr, uint32_t num_words) {}
 

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -184,26 +184,9 @@ static __attribute__((always_inline)) inline void wr_mem_u64(
 /* ── Word-aligned range memory access ────────────────────────────── */
 
 /* `base_addr` is word-aligned; the guest pointer is word-aligned too,
- * so these lower to a single memcpy. */
-static __attribute__((always_inline)) inline void rd_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, uint32_t* restrict out,
-    uint32_t num_words) {
-  check_mem_bounds_u32_range(base_addr, num_words);
-  const void* p =
-      __builtin_assume_aligned(mem_ptr(state->memory, base_addr), WORD_SIZE);
-  memcpy(out, p, (size_t)num_words * sizeof(uint32_t));
-}
-
-static __attribute__((always_inline)) inline void wr_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* restrict vals,
-    uint32_t num_words) {
-  check_mem_bounds_u32_range(base_addr, num_words);
-  void* p =
-      __builtin_assume_aligned(mem_ptr(state->memory, base_addr), WORD_SIZE);
-  memcpy(p, vals, (size_t)num_words * sizeof(uint32_t));
-}
-
-/* A "word" in RV64 is 8 bytes (sizeof(uint64_t)), matching MEMORY_BLOCK_BYTES.
+ * so these lower to a single memcpy.
+ *
+ * A "word" in RV64 is 8 bytes (sizeof(uint64_t)), matching MEMORY_BLOCK_BYTES.
  * All extension multi-word memory I/O uses this granularity. */
 static __attribute__((always_inline)) inline void rd_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, uint64_t* restrict out,
@@ -247,12 +230,6 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u32(
     RvState* restrict state, uint32_t addr, uint32_t val);
 static __attribute__((always_inline)) inline void trace_wr_mem_u64(
     RvState* restrict state, uint32_t addr, uint64_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words);
-static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words);
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words);
@@ -332,20 +309,6 @@ static __attribute__((always_inline)) inline void wr_mem_u64_traced(
     RvState* restrict state, uint32_t addr, uint64_t val) {
   trace_wr_mem_u64(state, addr, val);
   wr_mem_u64(state->memory, addr, val);
-}
-
-static __attribute__((always_inline)) inline void rd_mem_u32_range_traced(
-    RvState* restrict state, uint32_t base_addr, uint32_t* restrict out,
-    uint32_t num_words) {
-  rd_mem_u32_range(state, base_addr, out, num_words);
-  trace_rd_mem_u32_range(state, base_addr, out, num_words);
-}
-
-static __attribute__((always_inline)) inline void wr_mem_u32_range_traced(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* restrict vals,
-    uint32_t num_words) {
-  trace_wr_mem_u32_range(state, base_addr, vals, num_words);
-  wr_mem_u32_range(state, base_addr, vals, num_words);
 }
 
 static __attribute__((always_inline)) inline void rd_mem_u64_range_traced(

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -15,58 +15,11 @@
 
 /* ── Memory access (single word) ───────────────────────────────────── */
 
-void trace_mem_access_u32_wrapper(RvState* s, uint32_t addr,
-                                  uint32_t addr_space) {
-  trace_mem_access(s, addr, addr_space);
-}
-
-uint32_t rd_mem_u32_wrapper(RvState* s, uint32_t addr) {
-  return rd_mem_u32(s->memory, addr);
-}
-void wr_mem_u32_wrapper(RvState* s, uint32_t addr, uint32_t val) {
-  wr_mem_u32(s->memory, addr, val);
-}
-
-void trace_rd_mem_u32_wrapper(RvState* s, uint32_t addr, uint32_t val) {
-  trace_rd_mem_u32(s, addr, val);
-}
-void trace_wr_mem_u32_wrapper(RvState* s, uint32_t addr, uint32_t val) {
-  trace_wr_mem_u32(s, addr, val);
-}
-
 uint64_t rd_mem_u64_wrapper(RvState* s, uint32_t addr) {
   return rd_mem_u64(s->memory, addr);
 }
 void trace_rd_mem_u64_wrapper(RvState* s, uint32_t addr, uint64_t val) {
   trace_rd_mem_u64(s, addr, val);
-}
-
-/* ── Memory access (u32 ranges, inline-backed) ─────────────────────── */
-
-void rd_mem_u32_range_wrapper(RvState* s, uint32_t base_addr, uint32_t* out,
-                              uint32_t num_words) {
-  rd_mem_u32_range(s, base_addr, out, num_words);
-}
-
-void wr_mem_u32_range_wrapper(RvState* s, uint32_t base_addr,
-                              const uint32_t* vals, uint32_t num_words) {
-  wr_mem_u32_range(s, base_addr, vals, num_words);
-}
-
-void trace_rd_mem_u32_range_wrapper(RvState* s, uint32_t base_addr,
-                                    const uint32_t* vals, uint32_t num_words) {
-  trace_rd_mem_u32_range(s, base_addr, vals, num_words);
-}
-
-void trace_wr_mem_u32_range_wrapper(RvState* s, uint32_t base_addr,
-                                    const uint32_t* vals, uint32_t num_words) {
-  trace_wr_mem_u32_range(s, base_addr, vals, num_words);
-}
-
-void trace_mem_access_u32_range_wrapper(RvState* s, uint32_t base_addr,
-                                        uint32_t num_words,
-                                        uint32_t addr_space) {
-  trace_mem_access_u32_range(s, base_addr, num_words, addr_space);
 }
 
 /* A "word" in RV64 is 8 bytes (sizeof(uint64_t)), matching MEMORY_BLOCK_BYTES.

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -272,28 +272,6 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64(
  * Callers are responsible for guarding empty ranges (e.g. xorin with len=0)
  * so we can skip the branch on the hot path. */
 
-static __attribute__((always_inline)) inline void trace_rd_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words) {
-  assume(num_words > 0);
-  /* TODO(follow-up): WORD_SIZE == 8 (rv64 register width), but the stride
-   * here should be sizeof(uint32_t) == 4. Currently tracks 2x the actual
-   * page range. Fix to: base_addr + (num_words - 1) * sizeof(uint32_t). */
-  uint32_t last_addr = base_addr + (num_words - 1) * WORD_SIZE;
-  record_mem_page_range(state->tracer, byte_addr_to_local_page(base_addr),
-                        byte_addr_to_local_page(last_addr));
-}
-
-static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words) {
-  assume(num_words > 0);
-  /* TODO(follow-up): same WORD_SIZE stride bug as trace_rd_mem_u32_range. */
-  uint32_t last_addr = base_addr + (num_words - 1) * WORD_SIZE;
-  record_mem_page_range(state->tracer, byte_addr_to_local_page(base_addr),
-                        byte_addr_to_local_page(last_addr));
-}
-
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words) {
@@ -317,15 +295,6 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
 static __attribute__((always_inline)) inline void trace_mem_access(
     RvState* restrict state, uint32_t addr, uint32_t addr_space) {
   record_page(state->tracer, addr_space, addr);
-}
-
-static __attribute__((always_inline)) inline void trace_mem_access_u32_range(
-    RvState* restrict state, uint32_t base_addr, uint32_t num_words,
-    uint32_t addr_space) {
-  assume(num_words > 0);
-  /* TODO(follow-up): same WORD_SIZE stride bug as trace_rd_mem_u32_range. */
-  uint32_t last_addr = base_addr + (num_words - 1) * WORD_SIZE;
-  record_page_range(state->tracer, addr_space, base_addr, last_addr);
 }
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -55,12 +55,6 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64(
 
 /* ── Trace-only word-range memory access (no-ops in metered cost mode) */
 
-static __attribute__((always_inline)) inline void trace_rd_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words) {}
@@ -72,10 +66,6 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
 
 static __attribute__((always_inline)) inline void trace_mem_access(
     RvState* restrict state, uint32_t addr, uint32_t addr_space) {}
-
-static __attribute__((always_inline)) inline void trace_mem_access_u32_range(
-    RvState* restrict state, uint32_t base_addr, uint32_t num_words,
-    uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
     RvState* restrict state, uint32_t base_addr, uint32_t num_dwords,

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -51,12 +51,6 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64(
 
 /* ── Trace-only word-range memory access (no-ops in pure mode) ───── */
 
-static __attribute__((always_inline)) inline void trace_rd_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u32_range(
-    RvState* restrict state, uint32_t base_addr, const uint32_t* vals,
-    uint32_t num_words) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words) {}
@@ -68,10 +62,6 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
 
 static __attribute__((always_inline)) inline void trace_mem_access(
     RvState* restrict state, uint32_t addr, uint32_t addr_space) {}
-
-static __attribute__((always_inline)) inline void trace_mem_access_u32_range(
-    RvState* restrict state, uint32_t base_addr, uint32_t num_words,
-    uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
     RvState* restrict state, uint32_t base_addr, uint32_t num_dwords,

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -340,19 +340,6 @@ impl EmitContext {
         self.reload_page_locals();
     }
 
-    pub fn trace_mem_access_u32_range(
-        &mut self,
-        base_addr: &str,
-        num_words: &str,
-        addr_space: u32,
-    ) {
-        self.flush_page_locals();
-        self.write_line(&format!(
-            "trace_mem_access_u32_range(state, {base_addr}, {num_words}, {addr_space}u);"
-        ));
-        self.reload_page_locals();
-    }
-
     pub fn trace_mem_access_u64_range(
         &mut self,
         base_addr: &str,
@@ -448,10 +435,6 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext {
 
     fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {
         EmitContext::trace_mem_access(self, addr, addr_space);
-    }
-
-    fn trace_mem_access_u32_range(&mut self, base_addr: &str, num_words: &str, addr_space: u32) {
-        EmitContext::trace_mem_access_u32_range(self, base_addr, num_words, addr_space);
     }
 
     fn trace_mem_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32) {

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -554,17 +554,6 @@ mod tests {
             self.write_line(&format!("trace_mem_access(state, {addr}, {addr_space}u);"));
         }
 
-        fn trace_mem_access_u32_range(
-            &mut self,
-            base_addr: &str,
-            num_words: &str,
-            addr_space: u32,
-        ) {
-            self.write_line(&format!(
-                "trace_mem_access_u32_range(state, {base_addr}, {num_words}, {addr_space}u);"
-            ));
-        }
-
         fn trace_mem_access_u64_range(
             &mut self,
             base_addr: &str,
@@ -639,13 +628,6 @@ mod tests {
                 .iter()
                 .any(|l| l.contains("trace_mem_access_u64_range")),
             "expected trace_mem_access_u64_range, got: {:#?}",
-            ctx.lines
-        );
-        assert!(
-            !ctx.lines
-                .iter()
-                .any(|l| l.contains("trace_mem_access_u32_range")),
-            "unexpected trace_mem_access_u32_range in: {:#?}",
             ctx.lines
         );
     }


### PR DESCRIPTION
remove no longer relevant u32 ranged reads/writes and related functions. RV64 RVR writes ranges in 8 byte granularity, not in 4 bytes.

resolves INT-8425