### PR TITLE
fix(v2-rc.2): preserve AOT load side effects into x0

### DIFF
--- a/crates/vm/src/arch/aot/pure.rs
+++ b/crates/vm/src/arch/aot/pure.rs
@@ -283,12 +283,8 @@ where
         inputs: impl Into<Streams<F>>,
         num_insns: Option<u64>,
     ) -> Result<VmState<F, GuestMemory>, ExecutionError> {
-        let vm_state = VmState::initial(
-            &self.system_config,
-            &self.init_memory,
-            self.pc_start,
-            inputs,
-        );
+        let vm_state =
+            VmState::initial(self.system_config, &self.init_memory, self.pc_start, inputs);
         self.execute_from_state(vm_state, num_insns)
     }
 

--- a/docs/vocs/docs/pages/specs/reference/transpiler.mdx
+++ b/docs/vocs/docs/pages/specs/reference/transpiler.mdx
@@ -69,7 +69,7 @@ to handling of the `x0` register, which discards writes and has value `0` in all
 We handle writes to `x0` in transpilation as follows:
 
 - Instructions that write to `x0` with no side effects are transpiled to the PHANTOM instruction with `c = 0x00` (`Nop`).
-- Instructions that write to a register which might be `x0` with side effects (loads, JAL, JALR) are transpiled to the corresponding custom instruction whose write behavior is controlled by a flag specifying whether the target register is `x0`.
+- Instructions that write to a register which might be `x0` with side effects (LB, LH, LW, LBU, LHU, JAL, JALR) are transpiled to the corresponding custom instruction whose write behavior is controlled by a flag specifying whether the target register is `x0`.
 
 Because `[0:4]_1` is initialized to `0` and never written to, this guarantees that reads from `x0` yield `0` and enforces that any OpenVM program transpiled from RV32IM conforms to the RV32IM specification for `x0`.
 

--- a/docs/vocs/docs/pages/specs/reference/transpiler.mdx
+++ b/docs/vocs/docs/pages/specs/reference/transpiler.mdx
@@ -69,7 +69,7 @@ to handling of the `x0` register, which discards writes and has value `0` in all
 We handle writes to `x0` in transpilation as follows:
 
 - Instructions that write to `x0` with no side effects are transpiled to the PHANTOM instruction with `c = 0x00` (`Nop`).
-- Instructions that write to a register which might be `x0` with side effects (JAL, JALR) are transpiled to the corresponding custom instruction whose write behavior is controlled by a flag specifying whether the target register is `x0`.
+- Instructions that write to a register which might be `x0` with side effects (loads, JAL, JALR) are transpiled to the corresponding custom instruction whose write behavior is controlled by a flag specifying whether the target register is `x0`.
 
 Because `[0:4]_1` is initialized to `0` and never written to, this guarantees that reads from `x0` yield `0` and enforces that any OpenVM program transpiled from RV32IM conforms to the RV32IM specification for `x0`.
 

--- a/extensions/rv32im/circuit/src/auipc/execution.rs
+++ b/extensions/rv32im/circuit/src/auipc/execution.rs
@@ -176,7 +176,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = update_height_change_asm(chip_idx, 1)?;
         asm_str += &self.generate_x86_asm(inst, pc)?;

--- a/extensions/rv32im/circuit/src/base_alu/execution.rs
+++ b/extensions/rv32im/circuit/src/base_alu/execution.rs
@@ -250,7 +250,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = self.generate_x86_asm(inst, pc)?;
         asm_str += &update_height_change_asm(chip_idx, 1)?;

--- a/extensions/rv32im/circuit/src/branch_eq/execution.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/execution.rs
@@ -213,7 +213,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = String::from("");
 

--- a/extensions/rv32im/circuit/src/branch_lt/aot.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/aot.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "aot")]
 use openvm_circuit::arch::{AotError, AotExecutor, AotMeteredExecutor, SystemConfig};
-use openvm_instructions::{instruction::Instruction, riscv::RV32_REGISTER_AS};
+use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use crate::{
@@ -90,7 +90,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = String::from("");
 

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -18,7 +18,7 @@ mod aot {
 
     pub(crate) fn gpr_to_rv32_register(gpr: &str, rv32_reg: u8) -> String {
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")
@@ -65,7 +65,7 @@ mod aot {
             return (override_reg.to_string(), "".to_string());
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             (
                 gpr.to_string(),
                 format!("   pextrd {gpr}, xmm{xmm_map_reg}, 0\n"),
@@ -87,7 +87,7 @@ mod aot {
             return format!("   mov {override_reg}, {gpr}\n");
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -18,7 +18,7 @@ mod aot {
 
     pub(crate) fn gpr_to_rv32_register(gpr: &str, rv32_reg: u8) -> String {
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg % 2 == 0 {
+        if rv32_reg.is_multiple_of(2) {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")
@@ -65,7 +65,7 @@ mod aot {
             return (override_reg.to_string(), "".to_string());
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg % 2 == 0 {
+        if rv32_reg.is_multiple_of(2) {
             (
                 gpr.to_string(),
                 format!("   pextrd {gpr}, xmm{xmm_map_reg}, 0\n"),
@@ -87,7 +87,7 @@ mod aot {
             return format!("   mov {override_reg}, {gpr}\n");
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg % 2 == 0 {
+        if rv32_reg.is_multiple_of(2) {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")

--- a/extensions/rv32im/circuit/src/divrem/execution.rs
+++ b/extensions/rv32im/circuit/src/divrem/execution.rs
@@ -282,7 +282,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         use crate::common::update_height_change_asm;
 

--- a/extensions/rv32im/circuit/src/jal_lui/execution.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/execution.rs
@@ -195,7 +195,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         use crate::common::update_height_change_asm;
         let mut asm_str = update_height_change_asm(chip_idx, 1)?;

--- a/extensions/rv32im/circuit/src/jalr/execution.rs
+++ b/extensions/rv32im/circuit/src/jalr/execution.rs
@@ -194,7 +194,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = update_height_change_asm(chip_idx, 1)?;
         asm_str += &self.generate_x86_asm(inst, pc)?;

--- a/extensions/rv32im/circuit/src/less_than/execution.rs
+++ b/extensions/rv32im/circuit/src/less_than/execution.rs
@@ -254,7 +254,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = self.generate_x86_asm(inst, pc)?;
         asm_str += &update_height_change_asm(chip_idx, 1)?;

--- a/extensions/rv32im/circuit/src/load_sign_extend/aot.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/aot.rs
@@ -151,31 +151,84 @@ fn generate_x86_asm_impl<F: PrimeField32>(
         }
     }
 
-    if enabled {
-        match local_opcode {
-            Rv32LoadStoreOpcode::LOADH => {
-                let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                    RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
-                } else {
-                    REG_B_W
-                };
-
-                asm_str += &format!("   movsx {str_reg_a}, word ptr [{gpr_reg_w64}]\n");
+    match local_opcode {
+        Rv32LoadStoreOpcode::LOADH => {
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
+            } else {
+                REG_C_W
+            };
+            asm_str += &format!("   movsx {str_reg_a}, word ptr [{gpr_reg_w64}]\n");
+            if enabled {
                 asm_str += &gpr_to_rv32_register(str_reg_a, a_reg);
             }
-            Rv32LoadStoreOpcode::LOADB => {
-                let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                    RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
-                } else {
-                    REG_B_W
-                };
-
-                asm_str += &format!("   movsx {str_reg_a}, byte ptr [{gpr_reg_w64}]\n");
-                asm_str += &gpr_to_rv32_register(str_reg_a, a_reg);
-            }
-            _ => unreachable!("LoadSignExtendExecutor should only handle LOADB/LOADH opcodes"),
         }
+        Rv32LoadStoreOpcode::LOADB => {
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
+            } else {
+                REG_C_W
+            };
+            asm_str += &format!("   movsx {str_reg_a}, byte ptr [{gpr_reg_w64}]\n");
+            if enabled {
+                asm_str += &gpr_to_rv32_register(str_reg_a, a_reg);
+            }
+        }
+        _ => unreachable!("LoadSignExtendExecutor should only handle LOADB/LOADH opcodes"),
     }
 
     Ok(asm_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use openvm_instructions::riscv::RV32_MEMORY_AS;
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
+    use super::*;
+
+    fn disabled_load_to_x0(opcode: Rv32LoadStoreOpcode) -> Instruction<BabyBear> {
+        Instruction::from_usize(
+            opcode.global_opcode(),
+            [
+                0,
+                4,
+                0,
+                RV32_REGISTER_AS as usize,
+                RV32_MEMORY_AS as usize,
+                0,
+                0,
+            ],
+        )
+    }
+
+    #[test]
+    fn disabled_signed_loads_still_emit_memory_read_without_register_write() {
+        let cases = [
+            (
+                Rv32LoadStoreOpcode::LOADH,
+                format!("   movsx {REG_C_W}, word ptr [{REG_B}]\n"),
+            ),
+            (
+                Rv32LoadStoreOpcode::LOADB,
+                format!("   movsx {REG_C_W}, byte ptr [{REG_B}]\n"),
+            ),
+        ];
+
+        for (opcode, expected_read) in cases {
+            let asm = generate_x86_asm_impl(&disabled_load_to_x0(opcode), 0, |_, _, _, _, _| {
+                Ok(String::new())
+            })
+            .expect("load to x0 should be AOT-supported");
+
+            assert!(
+                asm.contains(&expected_read),
+                "{opcode:?} to x0 must still perform the memory read"
+            );
+            assert!(
+                !asm.contains("pinsrd"),
+                "{opcode:?} to x0 must not write the loaded value to an XMM register"
+            );
+        }
+    }
 }

--- a/extensions/rv32im/circuit/src/loadstore/aot.rs
+++ b/extensions/rv32im/circuit/src/loadstore/aot.rs
@@ -138,34 +138,37 @@ fn generate_x86_asm_impl<F: PrimeField32>(
 
     match local_opcode {
         Rv32LoadStoreOpcode::LOADW => {
-            let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
             } else {
-                REG_B_W
+                REG_C_W
             };
-
             asm_str += &format!("   mov {str_reg_a}, [{gpr_reg_w64}]\n");
-            asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            if enabled {
+                asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            }
         }
         Rv32LoadStoreOpcode::LOADHU => {
-            let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
             } else {
-                REG_B_W
+                REG_C_W
             };
-
             asm_str += &format!("   movzx {str_reg_a}, word ptr [{gpr_reg_w64}]\n");
-            asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            if enabled {
+                asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            }
         }
         Rv32LoadStoreOpcode::LOADBU => {
-            let str_reg_a = if RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].is_some() {
-                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap()
+            let str_reg_a = if enabled {
+                RISCV_TO_X86_OVERRIDE_MAP[a_reg as usize].unwrap_or(REG_B_W)
             } else {
-                REG_B_W
+                REG_C_W
             };
-
             asm_str += &format!("   movzx {str_reg_a}, byte ptr [{gpr_reg_w64}]\n");
-            asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            if enabled {
+                asm_str += &gpr_to_xmm(str_reg_a, a_reg);
+            }
         }
         Rv32LoadStoreOpcode::STOREW => {
             if !enabled {
@@ -199,4 +202,61 @@ fn generate_x86_asm_impl<F: PrimeField32>(
     }
 
     Ok(asm_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use openvm_instructions::riscv::RV32_MEMORY_AS;
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
+    use super::*;
+
+    fn disabled_load_to_x0(opcode: Rv32LoadStoreOpcode) -> Instruction<BabyBear> {
+        Instruction::from_usize(
+            opcode.global_opcode(),
+            [
+                0,
+                4,
+                0,
+                RV32_REGISTER_AS as usize,
+                RV32_MEMORY_AS as usize,
+                0,
+                0,
+            ],
+        )
+    }
+
+    #[test]
+    fn disabled_unsigned_loads_still_emit_memory_read_without_register_write() {
+        let cases = [
+            (
+                Rv32LoadStoreOpcode::LOADW,
+                format!("   mov {REG_C_W}, [{REG_B}]\n"),
+            ),
+            (
+                Rv32LoadStoreOpcode::LOADHU,
+                format!("   movzx {REG_C_W}, word ptr [{REG_B}]\n"),
+            ),
+            (
+                Rv32LoadStoreOpcode::LOADBU,
+                format!("   movzx {REG_C_W}, byte ptr [{REG_B}]\n"),
+            ),
+        ];
+
+        for (opcode, expected_read) in cases {
+            let asm = generate_x86_asm_impl(&disabled_load_to_x0(opcode), 0, |_, _, _, _, _| {
+                Ok(String::new())
+            })
+            .expect("load to x0 should be AOT-supported");
+
+            assert!(
+                asm.contains(&expected_read),
+                "{opcode:?} to x0 must still perform the memory read"
+            );
+            assert!(
+                !asm.contains("pinsrd"),
+                "{opcode:?} to x0 must not write the loaded value to an XMM register"
+            );
+        }
+    }
 }

--- a/extensions/rv32im/circuit/src/loadstore/aot.rs
+++ b/extensions/rv32im/circuit/src/loadstore/aot.rs
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn disabled_unsigned_loads_still_emit_memory_read_without_register_write() {
+    fn disabled_loads_still_emit_memory_read_without_register_write() {
         let cases = [
             (
                 Rv32LoadStoreOpcode::LOADW,

--- a/extensions/rv32im/circuit/src/mul/execution.rs
+++ b/extensions/rv32im/circuit/src/mul/execution.rs
@@ -199,7 +199,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = self.generate_x86_asm(inst, pc)?;
 

--- a/extensions/rv32im/circuit/src/mulh/execution.rs
+++ b/extensions/rv32im/circuit/src/mulh/execution.rs
@@ -216,7 +216,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = self.generate_x86_asm(inst, pc)?;
 

--- a/extensions/rv32im/circuit/src/shift/execution.rs
+++ b/extensions/rv32im/circuit/src/shift/execution.rs
@@ -243,7 +243,7 @@ where
         inst: &Instruction<F>,
         pc: u32,
         chip_idx: usize,
-        config: &SystemConfig,
+        _config: &SystemConfig,
     ) -> Result<String, AotError> {
         let mut asm_str = self.generate_x86_asm(inst, pc)?;
         asm_str += &update_height_change_asm(chip_idx, 1)?;


### PR DESCRIPTION
## Summary
- Keep AOT loads to `x0` performing their memory read while skipping the register write.
- Cover both unsigned/word and signed load AOT paths, and update the transpiler docs.

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p openvm-rv32im-circuit --target x86_64-apple-darwin --features aot --all-targets --tests -- -D warnings`
- `cargo clippy -p openvm-rv32im-circuit --all-targets --tests -- -D warnings`
- `OPENVM_SKIP_DEBUG=1 cargo nextest run --cargo-profile=fast -p openvm-rv32im-circuit`

Supersedes #2854