### PR TITLE
fix(v2-rc.2): handle dead AOT PC dispatch slots

### DIFF
--- a/crates/vm/src/arch/aot/metered_execute.rs
+++ b/crates/vm/src/arch/aot/metered_execute.rs
@@ -1,6 +1,6 @@
 use std::{ffi::c_void, mem::offset_of};
 
-use openvm_instructions::exe::VmExe;
+use openvm_instructions::{exe::VmExe, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::{common::*, AotInstance};
@@ -174,14 +174,17 @@ where
         asm_str += &format!("   jmp {REG_A}\n");
 
         let pc_base = exe.program.pc_base;
+        let base_idx = (pc_base / DEFAULT_PC_STEP) as usize;
+        let num_pc_slots = base_idx + exe.program.instructions_and_debug_infos.len();
 
-        for i in 0..(pc_base / 4) {
-            asm_str += &format!("asm_execute_pc_{}:", i * 4);
-            asm_str += "\n";
-        }
-
-        for (pc, instruction, _) in exe.program.enumerate_by_pc() {
+        for pc_idx in 0..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
+            let pc = pc_idx as u32 * DEFAULT_PC_STEP;
+            let instruction = pc_idx.checked_sub(base_idx).and_then(|idx| {
+                exe.program.instructions_and_debug_infos[idx]
+                    .as_ref()
+                    .map(|(instruction, _)| instruction)
+            });
             asm_str += &format!("asm_execute_pc_{pc}:\n");
 
             asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
@@ -197,80 +200,86 @@ where
             // continue with execution, as should_suspend returned false
             asm_str += &format!("execute_instruction_{pc}:\n");
 
-            if instruction.opcode.as_usize() == 0 {
-                // terminal opcode has no associated executor, so can handle with default fallback
-                asm_str += &Self::xmm_to_rv32_regs();
-                asm_str += &Self::push_address_space_start();
-                asm_str += &Self::push_internal_registers();
-                asm_str += &sync_reg_to_instret_until_end();
-                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
-                asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
-                asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
-                asm_str += &format!("   call {REG_D}\n");
-                asm_str += &format!("   cmp {REG_D}, 1\n");
+            if let Some(instruction) = instruction {
+                if instruction.opcode.as_usize() == 0 {
+                    // terminal opcode has no associated executor, so can handle with default
+                    // fallback
+                    asm_str += &Self::xmm_to_rv32_regs();
+                    asm_str += &Self::push_address_space_start();
+                    asm_str += &Self::push_internal_registers();
+                    asm_str += &sync_reg_to_instret_until_end();
+                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+                    asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
+                    asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+                    asm_str += &format!("   call {REG_D}\n");
+                    asm_str += &format!("   cmp {REG_D}, 1\n");
 
-                asm_str += &Self::pop_internal_registers();
-                asm_str += &Self::pop_address_space_start();
-                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
-                asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
-                asm_str += &format!("   call {REG_D}\n");
-                asm_str += &format!(
-                    "   mov {REG_RETURN_VAL}, {}\n",
-                    instruction.c.as_canonical_u32()
-                );
-                asm_str += &Self::pop_external_registers();
-                asm_str += "    ret\n";
+                    asm_str += &Self::pop_internal_registers();
+                    asm_str += &Self::pop_address_space_start();
+                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
+                    asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
+                    asm_str += &format!("   call {REG_D}\n");
+                    asm_str += &format!(
+                        "   mov {REG_RETURN_VAL}, {}\n",
+                        instruction.c.as_canonical_u32()
+                    );
+                    asm_str += &Self::pop_external_registers();
+                    asm_str += "    ret\n";
 
-                continue;
+                    continue;
+                }
+
+                let executor = inventory
+                    .get_executor(instruction.opcode)
+                    .expect("executor not found for opcode");
+                let executor_idx = inventory.instruction_lookup[&instruction.opcode] as usize;
+                let air_idx = executor_idx_to_air_idx[executor_idx];
+
+                if executor.is_aot_metered_supported(instruction) {
+                    let segment = executor
+                        .generate_x86_metered_asm(instruction, pc, air_idx, inventory.config())
+                        .map_err(|err| match err {
+                            AotError::InvalidInstruction => {
+                                StaticProgramError::InvalidInstruction(pc)
+                            }
+                            AotError::NotSupported => StaticProgramError::DisabledOperation {
+                                pc,
+                                opcode: instruction.opcode,
+                            },
+                            AotError::NoExecutorFound(opcode) => {
+                                StaticProgramError::ExecutorNotFound { opcode }
+                            }
+                            AotError::Other(_message) => StaticProgramError::InvalidInstruction(pc),
+                        })?;
+                    asm_str += &segment;
+                    continue;
+                }
             }
 
-            let executor = inventory
-                .get_executor(instruction.opcode)
-                .expect("executor not found for opcode");
-            let executor_idx = inventory.instruction_lookup[&instruction.opcode] as usize;
-            let air_idx = executor_idx_to_air_idx[executor_idx];
-
-            if executor.is_aot_metered_supported(&instruction) {
-                let segment = executor
-                    .generate_x86_metered_asm(&instruction, pc, air_idx, inventory.config())
-                    .map_err(|err| match err {
-                        AotError::InvalidInstruction => StaticProgramError::InvalidInstruction(pc),
-                        AotError::NotSupported => StaticProgramError::DisabledOperation {
-                            pc,
-                            opcode: instruction.opcode,
-                        },
-                        AotError::NoExecutorFound(opcode) => {
-                            StaticProgramError::ExecutorNotFound { opcode }
-                        }
-                        AotError::Other(_message) => StaticProgramError::InvalidInstruction(pc),
-                    })?;
-                asm_str += &segment;
-            } else {
-                asm_str += &Self::xmm_to_rv32_regs();
-                asm_str += &Self::push_address_space_start();
-                asm_str += &Self::push_internal_registers();
-                asm_str += &sync_reg_to_instret_until_end();
-                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
-                asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
-                asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
-                asm_str += &format!("   call {REG_D}\n");
-                asm_str += &format!("   cmp {REG_RETURN_VAL}, 1\n");
-                asm_str += &Self::pop_internal_registers(); // pop the internal registers from the stack
-                asm_str += &Self::pop_address_space_start();
-                asm_str += &sync_instret_until_end_to_reg();
-                asm_str += &Self::rv32_regs_to_xmm(); // read the memory from the memory location of the RV32 registers in `GuestMemory`
-                                                      // registers, to the appropriate XMM registers
-                asm_str += &format!("   je asm_run_end_{pc}\n");
-                asm_str += &format!("   lea {REG_C}, [rip + map_pc_base]\n");
-                asm_str += &format!("   pextrq {REG_A}, xmm3, 1\n"); // extract the upper 64 bits of the xmm3 register to REG_A
-                asm_str += &format!("   mov {REG_A_W}, dword ptr [{REG_A}]\n");
-                asm_str += &format!("   movsxd {REG_A}, [{REG_C} + {REG_A}]\n");
-                asm_str += &format!("   add {REG_A}, {REG_C}\n");
-                asm_str += &format!("   jmp {REG_A}\n");
-            }
+            asm_str += &Self::xmm_to_rv32_regs();
+            asm_str += &Self::push_address_space_start();
+            asm_str += &Self::push_internal_registers();
+            asm_str += &sync_reg_to_instret_until_end();
+            asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+            asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+            asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
+            asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+            asm_str += &format!("   call {REG_D}\n");
+            asm_str += &format!("   cmp {REG_RETURN_VAL}, 1\n");
+            asm_str += &Self::pop_internal_registers(); // pop the internal registers from the stack
+            asm_str += &Self::pop_address_space_start();
+            asm_str += &sync_instret_until_end_to_reg();
+            asm_str += &Self::rv32_regs_to_xmm(); // read the memory from the memory location of the RV32 registers in `GuestMemory`
+                                                  // registers, to the appropriate XMM registers
+            asm_str += &format!("   je asm_run_end_{pc}\n");
+            asm_str += &format!("   lea {REG_C}, [rip + map_pc_base]\n");
+            asm_str += &format!("   pextrq {REG_A}, xmm3, 1\n"); // extract the upper 64 bits of the xmm3 register to REG_A
+            asm_str += &format!("   mov {REG_A_W}, dword ptr [{REG_A}]\n");
+            asm_str += &format!("   movsxd {REG_A}, [{REG_C} + {REG_A}]\n");
+            asm_str += &format!("   add {REG_A}, {REG_C}\n");
+            asm_str += &format!("   jmp {REG_A}\n");
         }
         asm_str += "asm_handle_segment_check:\n";
         asm_str += "    push r14\n";
@@ -291,7 +300,8 @@ where
         asm_str += "    ret\n";
 
         // asm_run_end part
-        for (pc, _instruction, _) in exe.program.enumerate_by_pc() {
+        for pc_idx in 0..num_pc_slots {
+            let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             asm_str += &format!("asm_run_end_{pc}:\n");
             asm_str += &Self::xmm_to_rv32_regs();
             asm_str += &format!("    mov {REG_FIRST_ARG}, rbx\n");
@@ -307,11 +317,8 @@ where
         asm_str += ".section .rodata\n";
         asm_str += "map_pc_base:\n";
 
-        for i in 0..(pc_base / 4) {
-            asm_str += &format!("   .long asm_execute_pc_{} - map_pc_base\n", i * 4);
-        }
-
-        for (pc, _instruction, _) in exe.program.enumerate_by_pc() {
+        for pc_idx in 0..num_pc_slots {
+            let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
         }
 

--- a/crates/vm/src/arch/aot/metered_execute.rs
+++ b/crates/vm/src/arch/aot/metered_execute.rs
@@ -177,17 +177,6 @@ where
         let base_idx = (pc_base / DEFAULT_PC_STEP) as usize;
         let num_pc_slots = base_idx + exe.program.instructions_and_debug_infos.len();
 
-        // `None` pc slots below `pc_base`
-        if base_idx > 0 {
-            for i in 0..base_idx - 1 {
-                asm_str += &format!("asm_execute_pc_{}:\n", i as u32 * DEFAULT_PC_STEP);
-            }
-            let pc = (base_idx - 1) as u32 * DEFAULT_PC_STEP;
-            asm_str += &format!("asm_execute_pc_{pc}:\n");
-            asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
-            asm_str += "    jmp asm_dead_pc_handler\n";
-        }
-
         for pc_idx in base_idx..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
@@ -199,9 +188,6 @@ where
 
             // a `None` slot at or above `pc_base`
             let Some(instruction) = instruction else {
-                asm_str += &format!("asm_execute_pc_{pc}:\n");
-                asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
-                asm_str += "    jmp asm_dead_pc_handler\n";
                 continue;
             };
 
@@ -315,47 +301,12 @@ where
         asm_str += "    pop r14\n";
         asm_str += "    ret\n";
 
-        // Shared dead-pc handler. Reached from a dead-slot stub with the dead pc held in
-        // `REG_THIRD_ARG` (= `REG_C`). It mirrors the real-instruction suspend check, then
-        // dispatches to `extern_handler`, whose pre-compute table holds an `unreachable_handler`
-        // for every dead pc, so it records `ExecutionError::Unreachable(pc)` and returns 1. The
-        // pc in `REG_C` survives the calls below because `push_internal_registers` saves it.
-        asm_str += "asm_dead_pc_handler:\n";
-        asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
-        asm_str += "    je asm_dead_pc_instret_zero\n";
-        asm_str += &format!("    dec {REG_INSTRET_END}\n");
-        asm_str += "    jmp asm_dead_pc_execute\n";
-
-        asm_str += "asm_dead_pc_instret_zero:\n";
-        asm_str += "    call asm_handle_segment_check\n";
-        asm_str += "    test al, al\n";
-        asm_str += "    jnz asm_dead_pc_run_end\n";
-
-        asm_str += "asm_dead_pc_execute:\n";
-        asm_str += &Self::xmm_to_rv32_regs();
-        asm_str += &Self::push_address_space_start();
-        asm_str += &Self::push_internal_registers();
-        asm_str += &sync_reg_to_instret_until_end();
-        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-        asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
-        // `REG_THIRD_ARG` already holds the dead pc.
-        asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
-        asm_str += &format!("   call {REG_D}\n");
-        asm_str += &Self::pop_internal_registers();
-        asm_str += &Self::pop_address_space_start();
-        asm_str += &sync_instret_until_end_to_reg();
-        asm_str += &Self::rv32_regs_to_xmm();
-        // `extern_handler` always reports an error for a dead pc, so fall through to run end.
-
-        asm_str += "asm_dead_pc_run_end:\n";
-        asm_str += &Self::xmm_to_rv32_regs();
-        asm_str += &format!("    mov {REG_FIRST_ARG}, rbx\n");
-        asm_str += &format!("    mov {REG_SECOND_ARG}, {REG_C}\n");
-        asm_str += &format!("    mov {REG_D}, {set_pc_ptr}\n");
-        asm_str += &format!("    call {REG_D}\n");
-        asm_str += &Self::pop_external_registers();
-        asm_str += &format!("    xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
-        asm_str += "    ret\n";
+        asm_str += &Self::dead_pc_handler_asm(
+            &extern_handler_ptr,
+            &pre_compute_insns_ptr,
+            &set_pc_ptr,
+            instret_until_end_offset,
+        );
 
         // asm_run_end part. Only real instructions reach a per-pc suspend target; dead slots
         // use the shared run-end path inside the dead-pc handler instead.
@@ -384,10 +335,71 @@ where
 
         for pc_idx in 0..num_pc_slots {
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
-            asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
+            let is_real = pc_idx
+                .checked_sub(base_idx)
+                .is_some_and(|idx| exe.program.instructions_and_debug_infos[idx].is_some());
+            if is_real {
+                asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
+            } else {
+                asm_str += "   .long asm_dead_pc_handler - map_pc_base\n";
+            }
         }
 
         Ok(asm_str)
+    }
+
+    fn dead_pc_handler_asm(
+        extern_handler_ptr: &str,
+        pre_compute_insns_ptr: &str,
+        set_pc_ptr: &str,
+        instret_until_end_offset: usize,
+    ) -> String {
+        let mut asm_str = String::new();
+
+        // Dead dispatch-table entries share this handler. Load the current PC from VmState so
+        // extern_handler records Unreachable(pc) for the actual dead slot.
+        asm_str += "asm_dead_pc_handler:\n";
+        asm_str += &format!("   pextrq {REG_THIRD_ARG}, xmm3, 1\n");
+        asm_str += &format!("   mov {REG_C_W}, dword ptr [{REG_THIRD_ARG}]\n");
+        asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
+        asm_str += "    je asm_dead_pc_instret_zero\n";
+        asm_str += &format!("    dec {REG_INSTRET_END}\n");
+        asm_str += "    jmp asm_dead_pc_execute\n";
+
+        asm_str += "asm_dead_pc_instret_zero:\n";
+        asm_str += "    call asm_handle_segment_check\n";
+        asm_str += "    test al, al\n";
+        asm_str += "    jnz asm_dead_pc_run_end\n";
+
+        asm_str += "asm_dead_pc_execute:\n";
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &Self::push_address_space_start();
+        asm_str += &Self::push_internal_registers();
+        asm_str += &format!(
+            "    mov QWORD PTR [{REG_EXEC_STATE_PTR} + {instret_until_end_offset}], {REG_INSTRET_END}\n"
+        );
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+        asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &Self::pop_internal_registers();
+        asm_str += &Self::pop_address_space_start();
+        asm_str += &format!(
+            "    mov {REG_INSTRET_END}, [{REG_EXEC_STATE_PTR} + {instret_until_end_offset}]\n"
+        );
+        asm_str += &Self::rv32_regs_to_xmm();
+
+        asm_str += "asm_dead_pc_run_end:\n";
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &format!("    mov {REG_FIRST_ARG}, rbx\n");
+        asm_str += &format!("    mov {REG_SECOND_ARG}, {REG_C}\n");
+        asm_str += &format!("    mov {REG_D}, {set_pc_ptr}\n");
+        asm_str += &format!("    call {REG_D}\n");
+        asm_str += &Self::pop_external_registers();
+        asm_str += &format!("    xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
+        asm_str += "    ret\n";
+
+        asm_str
     }
 
     /// Metered exeecution for the given `inputs`. Execution begins from the initial

--- a/crates/vm/src/arch/aot/metered_execute.rs
+++ b/crates/vm/src/arch/aot/metered_execute.rs
@@ -177,7 +177,7 @@ where
         let base_idx = (pc_base / DEFAULT_PC_STEP) as usize;
         let num_pc_slots = base_idx + exe.program.instructions_and_debug_infos.len();
 
-        for pc_idx in base_idx..num_pc_slots {
+        for pc_idx in 0..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             let instruction = pc_idx.checked_sub(base_idx).and_then(|idx| {
@@ -186,8 +186,10 @@ where
                     .map(|(instruction, _)| instruction)
             });
 
-            // a `None` slot at or above `pc_base`
             let Some(instruction) = instruction else {
+                asm_str += &format!("asm_execute_pc_{pc}:\n");
+                asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
+                asm_str += "   jmp asm_dead_pc_handler\n";
                 continue;
             };
 
@@ -335,14 +337,7 @@ where
 
         for pc_idx in 0..num_pc_slots {
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
-            let is_real = pc_idx
-                .checked_sub(base_idx)
-                .is_some_and(|idx| exe.program.instructions_and_debug_infos[idx].is_some());
-            if is_real {
-                asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
-            } else {
-                asm_str += "   .long asm_dead_pc_handler - map_pc_base\n";
-            }
+            asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
         }
 
         Ok(asm_str)
@@ -356,11 +351,8 @@ where
     ) -> String {
         let mut asm_str = String::new();
 
-        // Dead dispatch-table entries share this handler. Load the current PC from VmState so
-        // extern_handler records Unreachable(pc) for the actual dead slot.
+        // Dead-slot stubs enter with the dead pc held in REG_THIRD_ARG (= REG_C).
         asm_str += "asm_dead_pc_handler:\n";
-        asm_str += &format!("   pextrq {REG_THIRD_ARG}, xmm3, 1\n");
-        asm_str += &format!("   mov {REG_C_W}, dword ptr [{REG_THIRD_ARG}]\n");
         asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
         asm_str += "    je asm_dead_pc_instret_zero\n";
         asm_str += &format!("    dec {REG_INSTRET_END}\n");

--- a/crates/vm/src/arch/aot/metered_execute.rs
+++ b/crates/vm/src/arch/aot/metered_execute.rs
@@ -185,6 +185,17 @@ where
                     .as_ref()
                     .map(|(instruction, _)| instruction)
             });
+
+            // Dead pc slot: either below `pc_base` or a hole in the program. Emit a tiny stub
+            // that records its pc in `REG_THIRD_ARG` and jumps to the single shared dead-pc
+            // handler below.
+            let Some(instruction) = instruction else {
+                asm_str += &format!("asm_execute_pc_{pc}:\n");
+                asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
+                asm_str += "    jmp asm_dead_pc_handler\n";
+                continue;
+            };
+
             asm_str += &format!("asm_execute_pc_{pc}:\n");
 
             asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
@@ -200,62 +211,58 @@ where
             // continue with execution, as should_suspend returned false
             asm_str += &format!("execute_instruction_{pc}:\n");
 
-            if let Some(instruction) = instruction {
-                if instruction.opcode.as_usize() == 0 {
-                    // terminal opcode has no associated executor, so can handle with default
-                    // fallback
-                    asm_str += &Self::xmm_to_rv32_regs();
-                    asm_str += &Self::push_address_space_start();
-                    asm_str += &Self::push_internal_registers();
-                    asm_str += &sync_reg_to_instret_until_end();
-                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
-                    asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
-                    asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
-                    asm_str += &format!("   call {REG_D}\n");
-                    asm_str += &format!("   cmp {REG_D}, 1\n");
+            if instruction.opcode.as_usize() == 0 {
+                // terminal opcode has no associated executor, so can handle with default
+                // fallback
+                asm_str += &Self::xmm_to_rv32_regs();
+                asm_str += &Self::push_address_space_start();
+                asm_str += &Self::push_internal_registers();
+                asm_str += &sync_reg_to_instret_until_end();
+                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+                asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
+                asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+                asm_str += &format!("   call {REG_D}\n");
+                asm_str += &format!("   cmp {REG_D}, 1\n");
 
-                    asm_str += &Self::pop_internal_registers();
-                    asm_str += &Self::pop_address_space_start();
-                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
-                    asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
-                    asm_str += &format!("   call {REG_D}\n");
-                    asm_str += &format!(
-                        "   mov {REG_RETURN_VAL}, {}\n",
-                        instruction.c.as_canonical_u32()
-                    );
-                    asm_str += &Self::pop_external_registers();
-                    asm_str += "    ret\n";
+                asm_str += &Self::pop_internal_registers();
+                asm_str += &Self::pop_address_space_start();
+                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
+                asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
+                asm_str += &format!("   call {REG_D}\n");
+                asm_str += &format!(
+                    "   mov {REG_RETURN_VAL}, {}\n",
+                    instruction.c.as_canonical_u32()
+                );
+                asm_str += &Self::pop_external_registers();
+                asm_str += "    ret\n";
 
-                    continue;
-                }
+                continue;
+            }
 
-                let executor = inventory
-                    .get_executor(instruction.opcode)
-                    .expect("executor not found for opcode");
-                let executor_idx = inventory.instruction_lookup[&instruction.opcode] as usize;
-                let air_idx = executor_idx_to_air_idx[executor_idx];
+            let executor = inventory
+                .get_executor(instruction.opcode)
+                .expect("executor not found for opcode");
+            let executor_idx = inventory.instruction_lookup[&instruction.opcode] as usize;
+            let air_idx = executor_idx_to_air_idx[executor_idx];
 
-                if executor.is_aot_metered_supported(instruction) {
-                    let segment = executor
-                        .generate_x86_metered_asm(instruction, pc, air_idx, inventory.config())
-                        .map_err(|err| match err {
-                            AotError::InvalidInstruction => {
-                                StaticProgramError::InvalidInstruction(pc)
-                            }
-                            AotError::NotSupported => StaticProgramError::DisabledOperation {
-                                pc,
-                                opcode: instruction.opcode,
-                            },
-                            AotError::NoExecutorFound(opcode) => {
-                                StaticProgramError::ExecutorNotFound { opcode }
-                            }
-                            AotError::Other(_message) => StaticProgramError::InvalidInstruction(pc),
-                        })?;
-                    asm_str += &segment;
-                    continue;
-                }
+            if executor.is_aot_metered_supported(instruction) {
+                let segment = executor
+                    .generate_x86_metered_asm(instruction, pc, air_idx, inventory.config())
+                    .map_err(|err| match err {
+                        AotError::InvalidInstruction => StaticProgramError::InvalidInstruction(pc),
+                        AotError::NotSupported => StaticProgramError::DisabledOperation {
+                            pc,
+                            opcode: instruction.opcode,
+                        },
+                        AotError::NoExecutorFound(opcode) => {
+                            StaticProgramError::ExecutorNotFound { opcode }
+                        }
+                        AotError::Other(_message) => StaticProgramError::InvalidInstruction(pc),
+                    })?;
+                asm_str += &segment;
+                continue;
             }
 
             asm_str += &Self::xmm_to_rv32_regs();
@@ -299,9 +306,58 @@ where
         asm_str += "    pop r14\n";
         asm_str += "    ret\n";
 
-        // asm_run_end part
+        // Shared dead-pc handler. Reached from a dead-slot stub with the dead pc held in
+        // `REG_THIRD_ARG` (= `REG_C`). It mirrors the real-instruction suspend check, then
+        // dispatches to `extern_handler`, whose pre-compute table holds an `unreachable_handler`
+        // for every dead pc, so it records `ExecutionError::Unreachable(pc)` and returns 1. The
+        // pc in `REG_C` survives the calls below because `push_internal_registers` saves it.
+        asm_str += "asm_dead_pc_handler:\n";
+        asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
+        asm_str += "    je asm_dead_pc_instret_zero\n";
+        asm_str += &format!("    dec {REG_INSTRET_END}\n");
+        asm_str += "    jmp asm_dead_pc_execute\n";
+
+        asm_str += "asm_dead_pc_instret_zero:\n";
+        asm_str += "    call asm_handle_segment_check\n";
+        asm_str += "    test al, al\n";
+        asm_str += "    jnz asm_dead_pc_run_end\n";
+
+        asm_str += "asm_dead_pc_execute:\n";
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &Self::push_address_space_start();
+        asm_str += &Self::push_internal_registers();
+        asm_str += &sync_reg_to_instret_until_end();
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+        // `REG_THIRD_ARG` already holds the dead pc.
+        asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &Self::pop_internal_registers();
+        asm_str += &Self::pop_address_space_start();
+        asm_str += &sync_instret_until_end_to_reg();
+        asm_str += &Self::rv32_regs_to_xmm();
+        // `extern_handler` always reports an error for a dead pc, so fall through to run end.
+
+        asm_str += "asm_dead_pc_run_end:\n";
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &format!("    mov {REG_FIRST_ARG}, rbx\n");
+        asm_str += &format!("    mov {REG_SECOND_ARG}, {REG_C}\n");
+        asm_str += &format!("    mov {REG_D}, {set_pc_ptr}\n");
+        asm_str += &format!("    call {REG_D}\n");
+        asm_str += &Self::pop_external_registers();
+        asm_str += &format!("    xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
+        asm_str += "    ret\n";
+
+        // asm_run_end part. Only real instructions reach a per-pc suspend target; dead slots
+        // use the shared run-end path inside the dead-pc handler instead.
         for pc_idx in 0..num_pc_slots {
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
+            let is_real = pc_idx
+                .checked_sub(base_idx)
+                .is_some_and(|idx| exe.program.instructions_and_debug_infos[idx].is_some());
+            if !is_real {
+                continue;
+            }
             asm_str += &format!("asm_run_end_{pc}:\n");
             asm_str += &Self::xmm_to_rv32_regs();
             asm_str += &format!("    mov {REG_FIRST_ARG}, rbx\n");

--- a/crates/vm/src/arch/aot/metered_execute.rs
+++ b/crates/vm/src/arch/aot/metered_execute.rs
@@ -177,7 +177,18 @@ where
         let base_idx = (pc_base / DEFAULT_PC_STEP) as usize;
         let num_pc_slots = base_idx + exe.program.instructions_and_debug_infos.len();
 
-        for pc_idx in 0..num_pc_slots {
+        // `None` pc slots below `pc_base`
+        if base_idx > 0 {
+            for i in 0..base_idx - 1 {
+                asm_str += &format!("asm_execute_pc_{}:\n", i as u32 * DEFAULT_PC_STEP);
+            }
+            let pc = (base_idx - 1) as u32 * DEFAULT_PC_STEP;
+            asm_str += &format!("asm_execute_pc_{pc}:\n");
+            asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
+            asm_str += "    jmp asm_dead_pc_handler\n";
+        }
+
+        for pc_idx in base_idx..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             let instruction = pc_idx.checked_sub(base_idx).and_then(|idx| {
@@ -186,9 +197,7 @@ where
                     .map(|(instruction, _)| instruction)
             });
 
-            // Dead pc slot: either below `pc_base` or a hole in the program. Emit a tiny stub
-            // that records its pc in `REG_THIRD_ARG` and jumps to the single shared dead-pc
-            // handler below.
+            // a `None` slot at or above `pc_base`
             let Some(instruction) = instruction else {
                 asm_str += &format!("asm_execute_pc_{pc}:\n");
                 asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");

--- a/crates/vm/src/arch/aot/pure.rs
+++ b/crates/vm/src/arch/aot/pure.rs
@@ -117,17 +117,6 @@ where
         let pre_compute_insns_ptr = format!("{:p}", pre_compute_insns_ptr as *const ());
         let instret_left_ptr = format!("{:p}", set_instret_left_shim::<F> as *const ());
 
-        // `None` pc slots below `pc_base`
-        if base_idx > 0 {
-            for i in 0..base_idx - 1 {
-                asm_str += &format!("asm_execute_pc_{}:\n", i as u32 * DEFAULT_PC_STEP);
-            }
-            let pc = (base_idx - 1) as u32 * DEFAULT_PC_STEP;
-            asm_str += &format!("asm_execute_pc_{pc}:\n");
-            asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
-            asm_str += "    jmp asm_dead_pc_handler\n";
-        }
-
         for pc_idx in base_idx..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
@@ -139,9 +128,6 @@ where
 
             // a `None` slot at or above `pc_base`
             let Some(instruction) = instruction else {
-                asm_str += &format!("asm_execute_pc_{pc}:\n");
-                asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
-                asm_str += "    jmp asm_dead_pc_handler\n";
                 continue;
             };
 
@@ -235,43 +221,12 @@ where
             }
         }
 
-        // Shared dead-pc handler. Reached from a dead-slot stub with the dead pc held in
-        // `REG_THIRD_ARG` (= `REG_C`). It mirrors the real-instruction suspend check, then
-        // dispatches to `extern_handler`, whose pre-compute table holds an `unreachable_handler`
-        // for every dead pc, so it records `ExecutionError::Unreachable(pc)` and returns 1. The
-        // pc in `REG_C` survives the calls below because `push_internal_registers` saves it.
-        asm_str += "asm_dead_pc_handler:\n";
-        asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
-        asm_str += "    je asm_dead_pc_exit\n";
-        asm_str += &format!("    dec {REG_INSTRET_END}\n");
-        asm_str += &Self::xmm_to_rv32_regs();
-        asm_str += &Self::push_address_space_start();
-        asm_str += &Self::push_internal_registers();
-        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-        asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
-        // `REG_THIRD_ARG` already holds the dead pc.
-        asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
-        asm_str += &format!("   call {REG_D}\n");
-        asm_str += &Self::pop_internal_registers();
-        asm_str += &Self::pop_address_space_start();
-        asm_str += &Self::rv32_regs_to_xmm();
-        // `extern_handler` always reports an error for a dead pc, so fall through to the exit.
-
-        // Exit path: set_pc runs before set_instret_left so the pc in `REG_C` is consumed before
-        // the call clobbers it (`REG_INSTRET_END` is callee-saved and survives).
-        asm_str += "asm_dead_pc_exit:\n";
-        asm_str += &Self::xmm_to_rv32_regs();
-        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-        asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_C}\n");
-        asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
-        asm_str += &format!("   call {REG_D}\n");
-        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-        asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
-        asm_str += &format!("   mov {REG_D}, {instret_left_ptr}\n");
-        asm_str += &format!("   call {REG_D}\n");
-        asm_str += &Self::pop_external_registers();
-        asm_str += &format!("   xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
-        asm_str += "    ret\n";
+        asm_str += &Self::dead_pc_handler_asm(
+            &extern_handler_ptr,
+            &pre_compute_insns_ptr,
+            &set_pc_ptr,
+            &instret_left_ptr,
+        );
 
         // asm_run_end part. Only real instructions reach a per-pc suspend target; dead slots
         // use the shared exit path inside the dead-pc handler instead.
@@ -304,13 +259,65 @@ where
 
         for pc_idx in 0..num_pc_slots {
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
-            asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
+            let is_real = pc_idx
+                .checked_sub(base_idx)
+                .is_some_and(|idx| exe.program.instructions_and_debug_infos[idx].is_some());
+            if is_real {
+                asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
+            } else {
+                asm_str += "   .long asm_dead_pc_handler - map_pc_base\n";
+            }
         }
 
         // std::fs::write("/tmp/asm_dump.s", &asm_str).expect("failed to write asm_str");
 
         Ok(asm_str)
     }
+
+    fn dead_pc_handler_asm(
+        extern_handler_ptr: &str,
+        pre_compute_insns_ptr: &str,
+        set_pc_ptr: &str,
+        instret_left_ptr: &str,
+    ) -> String {
+        let mut asm_str = String::new();
+
+        // Dead dispatch-table entries share this handler. Load the current PC from VmState so
+        // extern_handler records Unreachable(pc) for the actual dead slot.
+        asm_str += "asm_dead_pc_handler:\n";
+        asm_str += &format!("   pextrq {REG_THIRD_ARG}, xmm3, 1\n");
+        asm_str += &format!("   mov {REG_C_W}, dword ptr [{REG_THIRD_ARG}]\n");
+        asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
+        asm_str += "    je asm_dead_pc_exit\n";
+        asm_str += &format!("    dec {REG_INSTRET_END}\n");
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &Self::push_address_space_start();
+        asm_str += &Self::push_internal_registers();
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+        asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &Self::pop_internal_registers();
+        asm_str += &Self::pop_address_space_start();
+        asm_str += &Self::rv32_regs_to_xmm();
+
+        asm_str += "asm_dead_pc_exit:\n";
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_C}\n");
+        asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
+        asm_str += &format!("   mov {REG_D}, {instret_left_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &Self::pop_external_registers();
+        asm_str += &format!("   xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
+        asm_str += "    ret\n";
+
+        asm_str
+    }
+
     /// Creates a new instance for pure execution
     pub fn new<E>(
         inventory: &'a ExecutorInventory<E>,

--- a/crates/vm/src/arch/aot/pure.rs
+++ b/crates/vm/src/arch/aot/pure.rs
@@ -125,6 +125,17 @@ where
                     .as_ref()
                     .map(|(instruction, _)| instruction)
             });
+
+            // Dead pc slot: either below `pc_base` or a hole in the program. Emit a tiny stub
+            // that records its pc in `REG_THIRD_ARG` and jumps to the single shared dead-pc
+            // handler below.
+            let Some(instruction) = instruction else {
+                asm_str += &format!("asm_execute_pc_{pc}:\n");
+                asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
+                asm_str += "    jmp asm_dead_pc_handler\n";
+                continue;
+            };
+
             asm_str += &format!("asm_execute_pc_{pc}:\n");
 
             // Check if we should suspend or not
@@ -133,65 +144,61 @@ where
             asm_str += &format!("    je asm_run_end_{pc}\n");
             asm_str += &format!("    dec {REG_INSTRET_END}\n");
 
-            if let Some(instruction) = instruction {
-                if instruction.opcode.as_usize() == 0 {
-                    // terminal opcode has no associated executor, so can handle with default
-                    // fallback
-                    asm_str += &Self::xmm_to_rv32_regs();
-                    asm_str += &Self::push_address_space_start();
-                    asm_str += &Self::push_internal_registers();
+            if instruction.opcode.as_usize() == 0 {
+                // terminal opcode has no associated executor, so can handle with default
+                // fallback
+                asm_str += &Self::xmm_to_rv32_regs();
+                asm_str += &Self::push_address_space_start();
+                asm_str += &Self::push_internal_registers();
 
-                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                    asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
-                    asm_str += &format!("   mov {REG_D}, {instret_left_ptr}\n");
-                    asm_str += &format!("   call {REG_D}\n");
+                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
+                asm_str += &format!("   mov {REG_D}, {instret_left_ptr}\n");
+                asm_str += &format!("   call {REG_D}\n");
 
-                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
-                    asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
-                    asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
-                    asm_str += &format!("   call {REG_D}\n");
-                    asm_str += &format!("   cmp {REG_RETURN_VAL}, 1\n");
+                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+                asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
+                asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+                asm_str += &format!("   call {REG_D}\n");
+                asm_str += &format!("   cmp {REG_RETURN_VAL}, 1\n");
 
-                    asm_str += &Self::pop_internal_registers();
-                    asm_str += &Self::pop_address_space_start();
-                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
-                    asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
-                    asm_str += &format!("   call {REG_D}\n");
-                    asm_str += &format!("   xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
-                    asm_str += &Self::pop_external_registers();
-                    asm_str += "    ret\n";
+                asm_str += &Self::pop_internal_registers();
+                asm_str += &Self::pop_address_space_start();
+                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
+                asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
+                asm_str += &format!("   call {REG_D}\n");
+                asm_str += &format!("   xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
+                asm_str += &Self::pop_external_registers();
+                asm_str += "    ret\n";
 
-                    continue;
-                }
+                continue;
+            }
 
-                let executor = inventory
-                    .get_executor(instruction.opcode)
-                    .expect("executor not found for opcode");
+            let executor = inventory
+                .get_executor(instruction.opcode)
+                .expect("executor not found for opcode");
 
-                if executor.is_aot_supported(instruction) {
-                    let segment =
-                        executor
-                            .generate_x86_asm(instruction, pc)
-                            .map_err(|err| match err {
-                                AotError::InvalidInstruction => {
-                                    StaticProgramError::InvalidInstruction(pc)
-                                }
-                                AotError::NotSupported => StaticProgramError::DisabledOperation {
-                                    pc,
-                                    opcode: instruction.opcode,
-                                },
-                                AotError::NoExecutorFound(opcode) => {
-                                    StaticProgramError::ExecutorNotFound { opcode }
-                                }
-                                AotError::Other(_message) => {
-                                    StaticProgramError::InvalidInstruction(pc)
-                                }
-                            })?;
-                    asm_str += &segment;
-                    continue;
-                }
+            if executor.is_aot_supported(instruction) {
+                let segment =
+                    executor
+                        .generate_x86_asm(instruction, pc)
+                        .map_err(|err| match err {
+                            AotError::InvalidInstruction => {
+                                StaticProgramError::InvalidInstruction(pc)
+                            }
+                            AotError::NotSupported => StaticProgramError::DisabledOperation {
+                                pc,
+                                opcode: instruction.opcode,
+                            },
+                            AotError::NoExecutorFound(opcode) => {
+                                StaticProgramError::ExecutorNotFound { opcode }
+                            }
+                            AotError::Other(_message) => StaticProgramError::InvalidInstruction(pc),
+                        })?;
+                asm_str += &segment;
+                continue;
             }
 
             {
@@ -219,9 +226,54 @@ where
             }
         }
 
-        // asm_run_end part
+        // Shared dead-pc handler. Reached from a dead-slot stub with the dead pc held in
+        // `REG_THIRD_ARG` (= `REG_C`). It mirrors the real-instruction suspend check, then
+        // dispatches to `extern_handler`, whose pre-compute table holds an `unreachable_handler`
+        // for every dead pc, so it records `ExecutionError::Unreachable(pc)` and returns 1. The
+        // pc in `REG_C` survives the calls below because `push_internal_registers` saves it.
+        asm_str += "asm_dead_pc_handler:\n";
+        asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
+        asm_str += "    je asm_dead_pc_exit\n";
+        asm_str += &format!("    dec {REG_INSTRET_END}\n");
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &Self::push_address_space_start();
+        asm_str += &Self::push_internal_registers();
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+        // `REG_THIRD_ARG` already holds the dead pc.
+        asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &Self::pop_internal_registers();
+        asm_str += &Self::pop_address_space_start();
+        asm_str += &Self::rv32_regs_to_xmm();
+        // `extern_handler` always reports an error for a dead pc, so fall through to the exit.
+
+        // Exit path: set_pc runs before set_instret_left so the pc in `REG_C` is consumed before
+        // the call clobbers it (`REG_INSTRET_END` is callee-saved and survives).
+        asm_str += "asm_dead_pc_exit:\n";
+        asm_str += &Self::xmm_to_rv32_regs();
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_C}\n");
+        asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+        asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
+        asm_str += &format!("   mov {REG_D}, {instret_left_ptr}\n");
+        asm_str += &format!("   call {REG_D}\n");
+        asm_str += &Self::pop_external_registers();
+        asm_str += &format!("   xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
+        asm_str += "    ret\n";
+
+        // asm_run_end part. Only real instructions reach a per-pc suspend target; dead slots
+        // use the shared exit path inside the dead-pc handler instead.
         for pc_idx in 0..num_pc_slots {
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
+            let is_real = pc_idx
+                .checked_sub(base_idx)
+                .is_some_and(|idx| exe.program.instructions_and_debug_infos[idx].is_some());
+            if !is_real {
+                continue;
+            }
             asm_str += &format!("asm_run_end_{pc}:\n");
             asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
             asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");

--- a/crates/vm/src/arch/aot/pure.rs
+++ b/crates/vm/src/arch/aot/pure.rs
@@ -1,6 +1,6 @@
 use std::ffi::c_void;
 
-use openvm_instructions::exe::VmExe;
+use openvm_instructions::{exe::VmExe, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::{common::*, AotInstance, AsmRunFn};
@@ -108,11 +108,8 @@ where
         // do fallback first for now but expand per instruction
 
         let pc_base = exe.program.pc_base;
-
-        for i in 0..(pc_base / 4) {
-            asm_str += &format!("asm_execute_pc_{}:", i * 4);
-            asm_str += "\n";
-        }
+        let base_idx = (pc_base / DEFAULT_PC_STEP) as usize;
+        let num_pc_slots = base_idx + exe.program.instructions_and_debug_infos.len();
 
         let extern_handler_ptr =
             format!("{:p}", extern_handler::<F, ExecutionCtx, true> as *const ());
@@ -120,8 +117,14 @@ where
         let pre_compute_insns_ptr = format!("{:p}", pre_compute_insns_ptr as *const ());
         let instret_left_ptr = format!("{:p}", set_instret_left_shim::<F> as *const ());
 
-        for (pc, instruction, _) in exe.program.enumerate_by_pc() {
+        for pc_idx in 0..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
+            let pc = pc_idx as u32 * DEFAULT_PC_STEP;
+            let instruction = pc_idx.checked_sub(base_idx).and_then(|idx| {
+                exe.program.instructions_and_debug_infos[idx]
+                    .as_ref()
+                    .map(|(instruction, _)| instruction)
+            });
             asm_str += &format!("asm_execute_pc_{pc}:\n");
 
             // Check if we should suspend or not
@@ -130,16 +133,71 @@ where
             asm_str += &format!("    je asm_run_end_{pc}\n");
             asm_str += &format!("    dec {REG_INSTRET_END}\n");
 
-            if instruction.opcode.as_usize() == 0 {
-                // terminal opcode has no associated executor, so can handle with default fallback
+            if let Some(instruction) = instruction {
+                if instruction.opcode.as_usize() == 0 {
+                    // terminal opcode has no associated executor, so can handle with default
+                    // fallback
+                    asm_str += &Self::xmm_to_rv32_regs();
+                    asm_str += &Self::push_address_space_start();
+                    asm_str += &Self::push_internal_registers();
+
+                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                    asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
+                    asm_str += &format!("   mov {REG_D}, {instret_left_ptr}\n");
+                    asm_str += &format!("   call {REG_D}\n");
+
+                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
+                    asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
+                    asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
+                    asm_str += &format!("   call {REG_D}\n");
+                    asm_str += &format!("   cmp {REG_RETURN_VAL}, 1\n");
+
+                    asm_str += &Self::pop_internal_registers();
+                    asm_str += &Self::pop_address_space_start();
+                    asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
+                    asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
+                    asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
+                    asm_str += &format!("   call {REG_D}\n");
+                    asm_str += &format!("   xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
+                    asm_str += &Self::pop_external_registers();
+                    asm_str += "    ret\n";
+
+                    continue;
+                }
+
+                let executor = inventory
+                    .get_executor(instruction.opcode)
+                    .expect("executor not found for opcode");
+
+                if executor.is_aot_supported(instruction) {
+                    let segment =
+                        executor
+                            .generate_x86_asm(instruction, pc)
+                            .map_err(|err| match err {
+                                AotError::InvalidInstruction => {
+                                    StaticProgramError::InvalidInstruction(pc)
+                                }
+                                AotError::NotSupported => StaticProgramError::DisabledOperation {
+                                    pc,
+                                    opcode: instruction.opcode,
+                                },
+                                AotError::NoExecutorFound(opcode) => {
+                                    StaticProgramError::ExecutorNotFound { opcode }
+                                }
+                                AotError::Other(_message) => {
+                                    StaticProgramError::InvalidInstruction(pc)
+                                }
+                            })?;
+                    asm_str += &segment;
+                    continue;
+                }
+            }
+
+            {
                 asm_str += &Self::xmm_to_rv32_regs();
                 asm_str += &Self::push_address_space_start();
                 asm_str += &Self::push_internal_registers();
-
-                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
-                asm_str += &format!("   mov {REG_D}, {instret_left_ptr}\n");
-                asm_str += &format!("   call {REG_D}\n");
 
                 asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
                 asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
@@ -150,54 +208,7 @@ where
 
                 asm_str += &Self::pop_internal_registers();
                 asm_str += &Self::pop_address_space_start();
-                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                asm_str += &format!("   mov {REG_SECOND_ARG}, {pc}\n");
-                asm_str += &format!("   mov {REG_D}, {set_pc_ptr}\n");
-                asm_str += &format!("   call {REG_D}\n");
-                asm_str += &format!("   xor {REG_RETURN_VAL}, {REG_RETURN_VAL}\n");
-                asm_str += &Self::pop_external_registers();
-                asm_str += "    ret\n";
-
-                continue;
-            }
-
-            let executor = inventory
-                .get_executor(instruction.opcode)
-                .expect("executor not found for opcode");
-
-            if executor.is_aot_supported(&instruction) {
-                let segment =
-                    executor
-                        .generate_x86_asm(&instruction, pc)
-                        .map_err(|err| match err {
-                            AotError::InvalidInstruction => {
-                                StaticProgramError::InvalidInstruction(pc)
-                            }
-                            AotError::NotSupported => StaticProgramError::DisabledOperation {
-                                pc,
-                                opcode: instruction.opcode,
-                            },
-                            AotError::NoExecutorFound(opcode) => {
-                                StaticProgramError::ExecutorNotFound { opcode }
-                            }
-                            AotError::Other(_message) => StaticProgramError::InvalidInstruction(pc),
-                        })?;
-                asm_str += &segment;
-            } else {
-                asm_str += &Self::xmm_to_rv32_regs();
-                asm_str += &Self::push_address_space_start();
-                asm_str += &Self::push_internal_registers();
-                asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
-                asm_str += &format!("   mov {REG_SECOND_ARG}, {pre_compute_insns_ptr}\n");
-                asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
-                asm_str += &format!("   mov {REG_D}, {extern_handler_ptr}\n");
-                asm_str += &format!("   call {REG_D}\n");
-                asm_str += &format!("   cmp {REG_RETURN_VAL}, 1\n");
-                asm_str += &Self::pop_internal_registers(); // pop the internal registers from the stack
-                asm_str += &Self::pop_address_space_start();
-                asm_str += &Self::rv32_regs_to_xmm(); // read the memory from the memory location of the RV32 registers in `GuestMemory`
-                                                      // registers, to the appropriate XMM registers
-
+                asm_str += &Self::rv32_regs_to_xmm();
                 asm_str += &format!("   je asm_run_end_{pc}\n");
                 asm_str += &format!("   lea {REG_C}, [rip + map_pc_base]\n");
                 asm_str += &format!("   pextrq {REG_A}, xmm3, 1\n"); // extract the upper 64 bits of the xmm3 register to REG_A
@@ -209,7 +220,8 @@ where
         }
 
         // asm_run_end part
-        for (pc, _instruction, _) in exe.program.enumerate_by_pc() {
+        for pc_idx in 0..num_pc_slots {
+            let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             asm_str += &format!("asm_run_end_{pc}:\n");
             asm_str += &format!("   mov {REG_FIRST_ARG}, {REG_EXEC_STATE_PTR}\n");
             asm_str += &format!("   mov {REG_SECOND_ARG}, {REG_INSTRET_END}\n");
@@ -229,11 +241,8 @@ where
         asm_str += ".section .rodata\n";
         asm_str += "map_pc_base:\n";
 
-        for i in 0..(pc_base / 4) {
-            asm_str += &format!("   .long asm_execute_pc_{} - map_pc_base\n", i * 4);
-        }
-
-        for (pc, _instruction, _) in exe.program.enumerate_by_pc() {
+        for pc_idx in 0..num_pc_slots {
+            let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
         }
 

--- a/crates/vm/src/arch/aot/pure.rs
+++ b/crates/vm/src/arch/aot/pure.rs
@@ -117,7 +117,18 @@ where
         let pre_compute_insns_ptr = format!("{:p}", pre_compute_insns_ptr as *const ());
         let instret_left_ptr = format!("{:p}", set_instret_left_shim::<F> as *const ());
 
-        for pc_idx in 0..num_pc_slots {
+        // `None` pc slots below `pc_base`
+        if base_idx > 0 {
+            for i in 0..base_idx - 1 {
+                asm_str += &format!("asm_execute_pc_{}:\n", i as u32 * DEFAULT_PC_STEP);
+            }
+            let pc = (base_idx - 1) as u32 * DEFAULT_PC_STEP;
+            asm_str += &format!("asm_execute_pc_{pc}:\n");
+            asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");
+            asm_str += "    jmp asm_dead_pc_handler\n";
+        }
+
+        for pc_idx in base_idx..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             let instruction = pc_idx.checked_sub(base_idx).and_then(|idx| {
@@ -126,9 +137,7 @@ where
                     .map(|(instruction, _)| instruction)
             });
 
-            // Dead pc slot: either below `pc_base` or a hole in the program. Emit a tiny stub
-            // that records its pc in `REG_THIRD_ARG` and jumps to the single shared dead-pc
-            // handler below.
+            // a `None` slot at or above `pc_base`
             let Some(instruction) = instruction else {
                 asm_str += &format!("asm_execute_pc_{pc}:\n");
                 asm_str += &format!("    mov {REG_THIRD_ARG}, {pc}\n");

--- a/crates/vm/src/arch/aot/pure.rs
+++ b/crates/vm/src/arch/aot/pure.rs
@@ -117,7 +117,7 @@ where
         let pre_compute_insns_ptr = format!("{:p}", pre_compute_insns_ptr as *const ());
         let instret_left_ptr = format!("{:p}", set_instret_left_shim::<F> as *const ());
 
-        for pc_idx in base_idx..num_pc_slots {
+        for pc_idx in 0..num_pc_slots {
             /* Preprocessing step, to check if we should suspend or not */
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
             let instruction = pc_idx.checked_sub(base_idx).and_then(|idx| {
@@ -126,8 +126,10 @@ where
                     .map(|(instruction, _)| instruction)
             });
 
-            // a `None` slot at or above `pc_base`
             let Some(instruction) = instruction else {
+                asm_str += &format!("asm_execute_pc_{pc}:\n");
+                asm_str += &format!("   mov {REG_THIRD_ARG}, {pc}\n");
+                asm_str += "   jmp asm_dead_pc_handler\n";
                 continue;
             };
 
@@ -259,14 +261,7 @@ where
 
         for pc_idx in 0..num_pc_slots {
             let pc = pc_idx as u32 * DEFAULT_PC_STEP;
-            let is_real = pc_idx
-                .checked_sub(base_idx)
-                .is_some_and(|idx| exe.program.instructions_and_debug_infos[idx].is_some());
-            if is_real {
-                asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
-            } else {
-                asm_str += "   .long asm_dead_pc_handler - map_pc_base\n";
-            }
+            asm_str += &format!("   .long asm_execute_pc_{pc} - map_pc_base\n");
         }
 
         // std::fs::write("/tmp/asm_dump.s", &asm_str).expect("failed to write asm_str");
@@ -282,11 +277,8 @@ where
     ) -> String {
         let mut asm_str = String::new();
 
-        // Dead dispatch-table entries share this handler. Load the current PC from VmState so
-        // extern_handler records Unreachable(pc) for the actual dead slot.
+        // Dead-slot stubs enter with the dead pc held in REG_THIRD_ARG (= REG_C).
         asm_str += "asm_dead_pc_handler:\n";
-        asm_str += &format!("   pextrq {REG_THIRD_ARG}, xmm3, 1\n");
-        asm_str += &format!("   mov {REG_C_W}, dword ptr [{REG_THIRD_ARG}]\n");
         asm_str += &format!("    cmp {REG_INSTRET_END}, 0\n");
         asm_str += "    je asm_dead_pc_exit\n";
         asm_str += &format!("    dec {REG_INSTRET_END}\n");

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -18,7 +18,7 @@ mod aot {
 
     pub(crate) fn gpr_to_rv32_register(gpr: &str, rv32_reg: u8) -> String {
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")
@@ -65,7 +65,7 @@ mod aot {
             return (override_reg.to_string(), "".to_string());
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             (
                 gpr.to_string(),
                 format!("   pextrd {gpr}, xmm{xmm_map_reg}, 0\n"),
@@ -87,7 +87,7 @@ mod aot {
             return format!("   mov {override_reg}, {gpr}\n");
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg.is_multiple_of(2) {
+        if rv32_reg % 2 == 0 {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")

--- a/extensions/rv32im/circuit/src/common/mod.rs
+++ b/extensions/rv32im/circuit/src/common/mod.rs
@@ -18,7 +18,7 @@ mod aot {
 
     pub(crate) fn gpr_to_rv32_register(gpr: &str, rv32_reg: u8) -> String {
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg % 2 == 0 {
+        if rv32_reg.is_multiple_of(2) {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")
@@ -65,7 +65,7 @@ mod aot {
             return (override_reg.to_string(), "".to_string());
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg % 2 == 0 {
+        if rv32_reg.is_multiple_of(2) {
             (
                 gpr.to_string(),
                 format!("   pextrd {gpr}, xmm{xmm_map_reg}, 0\n"),
@@ -87,7 +87,7 @@ mod aot {
             return format!("   mov {override_reg}, {gpr}\n");
         }
         let xmm_map_reg = rv32_reg / 2;
-        if rv32_reg % 2 == 0 {
+        if rv32_reg.is_multiple_of(2) {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 0\n")
         } else {
             format!("   pinsrd xmm{xmm_map_reg}, {gpr}, 1\n")

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -417,6 +417,14 @@ fn test_aot_dispatch_rejects_dead_pc_slots() {
         ),
         (
             VmExe::new(Program::new_without_debug_infos_with_option(
+                &[Some(terminate_instruction())],
+                8,
+            ))
+            .with_pc_start(0),
+            0,
+        ),
+        (
+            VmExe::new(Program::new_without_debug_infos_with_option(
                 &[
                     Some(terminate_instruction()),
                     None,

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -1,7 +1,7 @@
 use std::{array, borrow::BorrowMut, sync::Arc};
 
 #[cfg(feature = "aot")]
-use openvm_circuit::arch::{ExecutionError, testing::assert_vm_states_equivalent, VmExecutor, VmState};
+use openvm_circuit::arch::{ExecutionError, VirtualMachine, testing::assert_vm_states_equivalent, VmExecutor, VmState};
 use openvm_circuit::{
     arch::{
         testing::{TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
@@ -32,6 +32,10 @@ use openvm_stark_backend::{
     utils::disable_debug_builder,
 };
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
+#[cfg(feature = "aot")]
+use openvm_stark_sdk::config::{
+    baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters,
+};
 use rand::{rngs::StdRng, Rng};
 #[cfg(feature = "cuda")]
 use {
@@ -47,7 +51,7 @@ use {
 
 use super::Rv32JalrCoreAir;
 #[cfg(feature = "aot")]
-use crate::Rv32ImConfig;
+use crate::{Rv32ImBuilder, Rv32ImConfig};
 use crate::{
     adapters::{
         compose, Rv32JalrAdapterAir, Rv32JalrAdapterExecutor, Rv32JalrAdapterFiller,
@@ -399,37 +403,95 @@ fn read_register(state: &VmState<F>, offset: usize) -> u32 {
 
 #[cfg(feature = "aot")]
 #[test]
-fn test_aot_dispatch_rejects_dead_pc_before_pc_base() {
-    let program = Program::new_without_debug_infos_with_option(
-        &[Some(Instruction::<F>::from_isize(
-            SystemOpcode::TERMINATE.global_opcode(),
+fn test_aot_dispatch_rejects_dead_pc_slots() {
+    let cases = [
+        (
+            VmExe::new(Program::new_without_debug_infos_with_option(
+                &[Some(terminate_instruction())],
+                4,
+            ))
+            .with_pc_start(0),
             0,
-            0,
-            0,
-            0,
-            0,
-        ))],
-        4,
-    );
-    let exe = VmExe::new(program).with_pc_start(0);
-    let config = Rv32ImConfig::default();
-    let executor = VmExecutor::new(config).expect("failed to create Rv32IM executor");
+        ),
+        (
+            VmExe::new(Program::new_without_debug_infos_with_option(
+                &[Some(terminate_instruction()), None, Some(terminate_instruction())],
+                0,
+            ))
+            .with_pc_start(4),
+            4,
+        ),
+    ];
 
+    let config = Rv32ImConfig::default();
+    let executor = VmExecutor::new(config.clone()).expect("failed to create Rv32IM executor");
+    let engine = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));
+    let (vm, _) =
+        VirtualMachine::new_with_keygen(engine, Rv32ImBuilder, config).expect("vm init");
+    let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
+
+    for (exe, dead_pc) in cases {
+        assert_dead_pc_rejected_by_pure_aot(&executor, &exe, dead_pc);
+        assert_dead_pc_rejected_by_metered_aot(&vm, &executor_idx_to_air_idx, &exe, dead_pc);
+    }
+}
+
+#[cfg(feature = "aot")]
+fn terminate_instruction() -> Instruction<F> {
+    Instruction::from_isize(SystemOpcode::TERMINATE.global_opcode(), 0, 0, 0, 0, 0)
+}
+
+#[cfg(feature = "aot")]
+fn assert_dead_pc_rejected_by_pure_aot(
+    executor: &VmExecutor<F, Rv32ImConfig>,
+    exe: &VmExe<F>,
+    dead_pc: u32,
+) {
     let interpreter = executor
-        .interpreter_instance(&exe)
+        .interpreter_instance(exe)
         .expect("interpreter build must succeed");
     let interp_err = match interpreter.execute(vec![], None) {
         Ok(_) => panic!("interpreter must reject the dead pc slot"),
         Err(err) => err,
     };
-    assert!(matches!(interp_err, ExecutionError::Unreachable(0)));
+    assert!(matches!(interp_err, ExecutionError::Unreachable(pc) if pc == dead_pc));
 
-    let aot_instance = executor.aot_instance(&exe).expect("AOT build must succeed");
+    let aot_instance = executor.aot_instance(exe).expect("AOT build must succeed");
     let aot_err = match aot_instance.execute(vec![], None) {
         Ok(_) => panic!("AOT must reject the dead pc slot"),
         Err(err) => err,
     };
-    assert!(matches!(aot_err, ExecutionError::Unreachable(0)));
+    assert!(matches!(aot_err, ExecutionError::Unreachable(pc) if pc == dead_pc));
+}
+
+#[cfg(feature = "aot")]
+fn assert_dead_pc_rejected_by_metered_aot(
+    vm: &VirtualMachine<BabyBearPoseidon2Engine, Rv32ImBuilder>,
+    executor_idx_to_air_idx: &[usize],
+    exe: &VmExe<F>,
+    dead_pc: u32,
+) {
+    let metered_ctx = vm.build_metered_ctx(exe);
+
+    let metered_interpreter = vm
+        .executor()
+        .metered_interpreter_instance(exe, executor_idx_to_air_idx)
+        .expect("metered interpreter build must succeed");
+    let interp_err = match metered_interpreter.execute_metered(vec![], metered_ctx.clone()) {
+        Ok(_) => panic!("metered interpreter must reject the dead pc slot"),
+        Err(err) => err,
+    };
+    assert!(matches!(interp_err, ExecutionError::Unreachable(pc) if pc == dead_pc));
+
+    let metered_aot = vm
+        .executor()
+        .metered_aot_instance(exe, executor_idx_to_air_idx)
+        .expect("metered AOT build must succeed");
+    let aot_err = match metered_aot.execute_metered(vec![], metered_ctx) {
+        Ok(_) => panic!("metered AOT must reject the dead pc slot"),
+        Err(err) => err,
+    };
+    assert!(matches!(aot_err, ExecutionError::Unreachable(pc) if pc == dead_pc));
 }
 
 #[cfg(feature = "aot")]

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -31,13 +31,11 @@ use openvm_stark_backend::{
     },
     utils::disable_debug_builder,
 };
-use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 #[cfg(feature = "aot")]
-use openvm_stark_sdk::config::{
-    baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters,
-};
+use openvm_stark_sdk::config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters};
 #[cfg(feature = "aot")]
 use openvm_stark_sdk::engine::StarkFriEngine;
+use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 #[cfg(feature = "cuda")]
 use {
@@ -52,8 +50,6 @@ use {
 };
 
 use super::Rv32JalrCoreAir;
-#[cfg(feature = "aot")]
-use crate::{Rv32ImBuilder, Rv32ImConfig};
 use crate::{
     adapters::{
         compose, Rv32JalrAdapterAir, Rv32JalrAdapterExecutor, Rv32JalrAdapterFiller,
@@ -62,6 +58,8 @@ use crate::{
     jalr::{run_jalr, Rv32JalrChip, Rv32JalrCoreCols, Rv32JalrExecutor},
     Rv32JalrAir, Rv32JalrFiller,
 };
+#[cfg(feature = "aot")]
+use crate::{Rv32ImBuilder, Rv32ImConfig};
 
 const IMM_BITS: usize = 16;
 const MAX_INS_CAPACITY: usize = 128;
@@ -417,7 +415,11 @@ fn test_aot_dispatch_rejects_dead_pc_slots() {
         ),
         (
             VmExe::new(Program::new_without_debug_infos_with_option(
-                &[Some(terminate_instruction()), None, Some(terminate_instruction())],
+                &[
+                    Some(terminate_instruction()),
+                    None,
+                    Some(terminate_instruction()),
+                ],
                 0,
             ))
             .with_pc_start(4),
@@ -428,8 +430,7 @@ fn test_aot_dispatch_rejects_dead_pc_slots() {
     let config = Rv32ImConfig::default();
     let executor = VmExecutor::new(config.clone()).expect("failed to create Rv32IM executor");
     let engine = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));
-    let (vm, _) =
-        VirtualMachine::new_with_keygen(engine, Rv32ImBuilder, config).expect("vm init");
+    let (vm, _) = VirtualMachine::new_with_keygen(engine, Rv32ImBuilder, config).expect("vm init");
     let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
 
     for (exe, dead_pc) in cases {

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -1,7 +1,7 @@
 use std::{array, borrow::BorrowMut, sync::Arc};
 
 #[cfg(feature = "aot")]
-use openvm_circuit::arch::{testing::assert_vm_states_equivalent, VmExecutor, VmState};
+use openvm_circuit::arch::{ExecutionError, testing::assert_vm_states_equivalent, VmExecutor, VmState};
 use openvm_circuit::{
     arch::{
         testing::{TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
@@ -395,6 +395,41 @@ fn run_jalr_program(instructions: Vec<Instruction<F>>) -> (VmState<F>, VmState<F
 fn read_register(state: &VmState<F>, offset: usize) -> u32 {
     let bytes = unsafe { state.memory.read::<u8, 4>(RV32_REGISTER_AS, offset as u32) };
     u32::from_le_bytes(bytes)
+}
+
+#[cfg(feature = "aot")]
+#[test]
+fn test_aot_dispatch_rejects_dead_pc_before_pc_base() {
+    let program = Program::new_without_debug_infos_with_option(
+        &[Some(Instruction::<F>::from_isize(
+            SystemOpcode::TERMINATE.global_opcode(),
+            0,
+            0,
+            0,
+            0,
+            0,
+        ))],
+        4,
+    );
+    let exe = VmExe::new(program).with_pc_start(0);
+    let config = Rv32ImConfig::default();
+    let executor = VmExecutor::new(config).expect("failed to create Rv32IM executor");
+
+    let interpreter = executor
+        .interpreter_instance(&exe)
+        .expect("interpreter build must succeed");
+    let interp_err = match interpreter.execute(vec![], None) {
+        Ok(_) => panic!("interpreter must reject the dead pc slot"),
+        Err(err) => err,
+    };
+    assert!(matches!(interp_err, ExecutionError::Unreachable(0)));
+
+    let aot_instance = executor.aot_instance(&exe).expect("AOT build must succeed");
+    let aot_err = match aot_instance.execute(vec![], None) {
+        Ok(_) => panic!("AOT must reject the dead pc slot"),
+        Err(err) => err,
+    };
+    assert!(matches!(aot_err, ExecutionError::Unreachable(0)));
 }
 
 #[cfg(feature = "aot")]

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -435,6 +435,31 @@ fn test_aot_dispatch_rejects_dead_pc_slots() {
             .with_pc_start(4),
             4,
         ),
+        (
+            VmExe::new(Program::new_without_debug_infos_with_option(
+                &[
+                    Some(add_instruction(4, 0, 1)),
+                    None,
+                    Some(terminate_instruction()),
+                ],
+                0,
+            ))
+            .with_pc_start(0),
+            4,
+        ),
+        (
+            VmExe::new(Program::new_without_debug_infos_with_option(
+                &[
+                    Some(add_instruction(4, 0, 8)),
+                    Some(jalr_instruction(4)),
+                    None,
+                    Some(terminate_instruction()),
+                ],
+                0,
+            ))
+            .with_pc_start(0),
+            8,
+        ),
     ];
 
     let config = Rv32ImConfig::default();
@@ -452,6 +477,22 @@ fn test_aot_dispatch_rejects_dead_pc_slots() {
 #[cfg(feature = "aot")]
 fn terminate_instruction() -> Instruction<F> {
     Instruction::from_isize(SystemOpcode::TERMINATE.global_opcode(), 0, 0, 0, 0, 0)
+}
+
+#[cfg(feature = "aot")]
+fn add_instruction(rd: usize, rs1: usize, imm: usize) -> Instruction<F> {
+    Instruction::from_usize(
+        ADD.global_opcode(),
+        [rd, rs1, imm, RV32_REGISTER_AS as usize, 0],
+    )
+}
+
+#[cfg(feature = "aot")]
+fn jalr_instruction(rs1: usize) -> Instruction<F> {
+    Instruction::from_usize(
+        JALR.global_opcode(),
+        [0, rs1, 0, RV32_REGISTER_AS as usize, 0, 0, 0],
+    )
 }
 
 #[cfg(feature = "aot")]

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -425,8 +425,29 @@ fn test_aot_dispatch_rejects_dead_pc_slots() {
         ),
         (
             VmExe::new(Program::new_without_debug_infos_with_option(
+                &[Some(terminate_instruction())],
+                4096,
+            ))
+            .with_pc_start(2048),
+            2048,
+        ),
+        (
+            VmExe::new(Program::new_without_debug_infos_with_option(
+                &[
+                    Some(add_instruction(4, 0, 4)),
+                    Some(jalr_instruction(4)),
+                    Some(terminate_instruction()),
+                ],
+                8,
+            ))
+            .with_pc_start(8),
+            4,
+        ),
+        (
+            VmExe::new(Program::new_without_debug_infos_with_option(
                 &[
                     Some(terminate_instruction()),
+                    None,
                     None,
                     Some(terminate_instruction()),
                 ],

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -36,6 +36,8 @@ use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use openvm_stark_sdk::config::{
     baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters,
 };
+#[cfg(feature = "aot")]
+use openvm_stark_sdk::engine::StarkFriEngine;
 use rand::{rngs::StdRng, Rng};
 #[cfg(feature = "cuda")]
 use {

--- a/extensions/rv32im/circuit/src/jalr/tests.rs
+++ b/extensions/rv32im/circuit/src/jalr/tests.rs
@@ -1,7 +1,9 @@
 use std::{array, borrow::BorrowMut, sync::Arc};
 
 #[cfg(feature = "aot")]
-use openvm_circuit::arch::{ExecutionError, VirtualMachine, testing::assert_vm_states_equivalent, VmExecutor, VmState};
+use openvm_circuit::arch::{
+    testing::assert_vm_states_equivalent, ExecutionError, VirtualMachine, VmExecutor, VmState,
+};
 use openvm_circuit::{
     arch::{
         testing::{TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
@@ -32,9 +34,9 @@ use openvm_stark_backend::{
     utils::disable_debug_builder,
 };
 #[cfg(feature = "aot")]
-use openvm_stark_sdk::config::{baby_bear_poseidon2::BabyBearPoseidon2Engine, FriParameters};
+use openvm_stark_backend::{StarkEngine, SystemParams};
 #[cfg(feature = "aot")]
-use openvm_stark_sdk::engine::StarkFriEngine;
+use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2CpuEngine, DuplexSponge};
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 #[cfg(feature = "cuda")]
@@ -429,7 +431,7 @@ fn test_aot_dispatch_rejects_dead_pc_slots() {
 
     let config = Rv32ImConfig::default();
     let executor = VmExecutor::new(config.clone()).expect("failed to create Rv32IM executor");
-    let engine = BabyBearPoseidon2Engine::new(FriParameters::new_for_testing(3));
+    let engine = BabyBearPoseidon2CpuEngine::<DuplexSponge>::new(SystemParams::new_for_testing(20));
     let (vm, _) = VirtualMachine::new_with_keygen(engine, Rv32ImBuilder, config).expect("vm init");
     let executor_idx_to_air_idx = vm.executor_idx_to_air_idx();
 
@@ -469,7 +471,7 @@ fn assert_dead_pc_rejected_by_pure_aot(
 
 #[cfg(feature = "aot")]
 fn assert_dead_pc_rejected_by_metered_aot(
-    vm: &VirtualMachine<BabyBearPoseidon2Engine, Rv32ImBuilder>,
+    vm: &VirtualMachine<BabyBearPoseidon2CpuEngine<DuplexSponge>, Rv32ImBuilder>,
     executor_idx_to_air_idx: &[usize],
     exe: &VmExe<F>,
     dead_pc: u32,


### PR DESCRIPTION
## Summary
- Generate AOT dispatch labels for every PC slot covered by the program dispatch table.
- Emit dead-slot stubs that pass the exact PC to the unreachable handler, so pure and metered AOT match interpreter behavior for dead PCs.
- Cover dead slots below `pc_base`, explicit `None` holes, fallthrough into dead slots, and JALR into dead slots.

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p openvm-rv32im-circuit --all-targets --tests -- -D warnings`
- `cargo clippy -p openvm-rv32im-circuit --target x86_64-apple-darwin --features aot --all-targets --tests -- -D warnings`
- `cargo test -p openvm-rv32im-circuit --target x86_64-apple-darwin --features aot test_aot_dispatch_rejects_dead_pc_slots --no-run`

Supersedes and closes #2856, fixes #2852