### PR TITLE
fix(v2.1): correct RV64 PC and address handling

### DIFF
--- a/crates/rvr/rvr-openvm-ir/src/instr.rs
+++ b/crates/rvr/rvr-openvm-ir/src/instr.rs
@@ -101,10 +101,10 @@ pub enum Instr {
         rd: Reg,
         value: u32,
     },
-    /// Add upper immediate to PC (rd = pc + (imm << 12), pre-computed).
+    /// Add upper immediate to PC (rd = pc + sign_extend(imm << 12), pre-computed).
     Auipc {
         rd: Reg,
-        value: u32,
+        value: u64,
     },
     /// Load from memory.
     Load {

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -7,10 +7,12 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP as INSTR_SIZE, PC_BITS},
+    program::{DEFAULT_PC_STEP as INSTR_SIZE, MAX_ALLOWED_PC},
     riscv::RV64_NUM_REGISTERS as NUM_REGS,
 };
 use rvr_openvm_ir::{AluOp, Block, Instr, InstrAt, LiftedInstr, MulDivOp, Terminator};
+
+use crate::helpers::sext32;
 
 const MAX_VALUES: usize = 16;
 const MAX_ITERATIONS_MULTIPLIER: usize = 20;
@@ -168,12 +170,6 @@ impl RegisterState {
         }
         changed
     }
-}
-
-/// Sign-extend a 32-bit value to 64 bits.
-#[inline(always)]
-fn sext32(value: u32) -> u64 {
-    value as i32 as u64
 }
 
 // ── Binary operation evaluation (u64) ─────────────────────────────────────
@@ -504,14 +500,14 @@ fn simple_process_instr(instr: &Instr, regs: &mut [Option<u64>; NUM_REGS]) {
             if rd == 0 {
                 return;
             }
-            regs[rd as usize] = Some(*value as i32 as i64 as u64);
+            regs[rd as usize] = Some(sext32(*value));
         }
         Instr::Auipc { rd, value } => {
             let rd = *rd;
             if rd == 0 {
                 return;
             }
-            regs[rd as usize] = Some(*value as u64);
+            regs[rd as usize] = Some(*value);
         }
         Instr::Load { rd, .. } => {
             let rd = *rd;
@@ -841,7 +837,7 @@ fn transfer_instr(instr: &Instr, state: &mut RegisterState) {
             if *rd == 0 {
                 return;
             }
-            state.set(*rd, RegisterValue::constant(*value as u64));
+            state.set(*rd, RegisterValue::constant(*value));
         }
         Instr::Load { rd, .. } => {
             if *rd != 0 {
@@ -920,7 +916,7 @@ fn get_successors(
                             .iter()
                             .filter_map(|&t| {
                                 assert!(
-                                    t < (1u64 << PC_BITS),
+                                    t <= u64::from(MAX_ALLOWED_PC),
                                     "JumpDyn target {t:#x} exceeds PC address space"
                                 );
                                 let pc32 = t as u32;
@@ -981,7 +977,7 @@ fn get_successors(
 /// the result exceeds the valid PC address space.
 fn eval_jumpdyn_target(base: u64, imm: i32) -> Option<u64> {
     let target = base.wrapping_add(imm as i64 as u64) & !1u64;
-    if target < (1u64 << PC_BITS) {
+    if target <= u64::from(MAX_ALLOWED_PC) {
         Some(target)
     } else {
         None

--- a/crates/rvr/rvr-openvm-lift/src/helpers.rs
+++ b/crates/rvr/rvr-openvm-lift/src/helpers.rs
@@ -17,3 +17,8 @@ pub fn decode_imm_cg<F: PrimeField32>(insn: &Instruction<F>) -> u32 {
     let is_neg = insn.g.as_canonical_u32() != 0;
     low16.wrapping_add(if is_neg { 0xFFFF0000 } else { 0 })
 }
+
+/// Sign-extend a 32-bit value into an RV64 register value.
+pub fn sext32(value: u32) -> u64 {
+    value as i32 as i64 as u64
+}

--- a/crates/rvr/rvr-openvm-lift/src/opcode.rs
+++ b/crates/rvr/rvr-openvm-lift/src/opcode.rs
@@ -22,7 +22,10 @@ use rvr_openvm_ir::{
     AluOp, BranchCond, Instr, InstrAt, LiftedInstr, MemWidth, MulDivOp, Terminator,
 };
 
-use crate::{helpers::decode_imm_cg, ExtensionRegistry};
+use crate::{
+    helpers::{decode_imm_cg, sext32},
+    ExtensionRegistry,
+};
 
 /// Lift a single OpenVM instruction to the new IR types.
 ///
@@ -503,7 +506,7 @@ fn lift_auipc<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let shifted = field_to_u32(insn.c);
     let upper = shifted << 8; // reconstruct the upper 20 bits with low 12 zeros
-    let value = pc.wrapping_add(upper);
+    let value = (pc as u64).wrapping_add(sext32(upper));
 
     if rd == 0 {
         return body(pc, Instr::Nop);
@@ -588,12 +591,16 @@ mod tests {
     use openvm_instructions::{
         instruction::Instruction, LocalOpcode, DEFERRAL_AS, PUBLIC_VALUES_AS,
     };
-    use openvm_riscv_transpiler::Rv64LoadStoreOpcode::{
-        LOADB, LOADBU, LOADD, LOADH, LOADHU, LOADW, LOADWU, STOREB, STORED, STOREH, STOREW,
+    use openvm_riscv_transpiler::{
+        Rv64AuipcOpcode,
+        Rv64LoadStoreOpcode::{
+            LOADB, LOADBU, LOADD, LOADH, LOADHU, LOADW, LOADWU, STOREB, STORED, STOREH, STOREW,
+        },
     };
     use p3_baby_bear::BabyBear;
 
-    use super::{lift_instruction, ExtensionRegistry, AS_MEMORY, AS_REGISTER};
+    use super::{lift_instruction, Instr, InstrAt, LiftedInstr, AS_MEMORY, AS_REGISTER};
+    use crate::ExtensionRegistry;
 
     #[test]
     fn load_store_address_space_domain() {
@@ -662,6 +669,29 @@ mod tests {
                 [8, 16, 0, AS_REGISTER as usize, AS_MEMORY as usize, 1, 0],
             );
             assert!(lift_instruction(&valid_memory_inst, 0x100, &extensions).is_some());
+        }
+    }
+
+    #[test]
+    fn auipc_lifts_sign_extended_64_bit_value() {
+        let pc = 0x1000;
+        let insn = Instruction::<BabyBear>::from_usize(
+            Rv64AuipcOpcode::AUIPC.global_opcode(),
+            [8, 0, 0x80_0000],
+        );
+
+        let lifted = lift_instruction(&insn, pc, &ExtensionRegistry::default());
+        match lifted {
+            Some(LiftedInstr::Body(InstrAt {
+                pc: lifted_pc,
+                instr: Instr::Auipc { rd, value },
+                ..
+            })) => {
+                assert_eq!(lifted_pc, pc);
+                assert_eq!(rd, 1);
+                assert_eq!(value, 0xffff_ffff_8000_1000);
+            }
+            other => panic!("unexpected lift: {other:?}"),
         }
     }
 }

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -66,6 +66,14 @@ static __attribute__((always_inline)) inline uint32_t rv_dispatch_index(
   return (pc - RV_TEXT_START) >> 2;
 }
 
+/* True if pc names a 4-byte dispatch slot in the dense table. The alignment
+ * check prevents an unaligned pc from aliasing to a neighboring slot. */
+static __attribute__((always_inline)) inline bool rv_pc_is_dispatchable(
+    uint64_t pc) {
+  return pc >= RV_TEXT_START && pc <= RV_TEXT_END &&
+         ((pc - RV_TEXT_START) & 3ull) == 0;
+}
+
 /* ── Guest memory pointer ────────────────────────────────────────── */
 
 /* GuardedMemory's mmap guard pages catch OOB. Buffer is page-aligned,

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -38,7 +38,7 @@ pub fn emit_instr(ctx: &mut EmitContext, instr: &Instr) {
             ctx.write_reg(*rd, &sext32(*value));
         }
         Instr::Auipc { rd, value } => {
-            ctx.write_reg(*rd, &sext32(*value));
+            ctx.write_reg(*rd, &hex_u64(*value));
         }
         Instr::Load {
             width,
@@ -122,7 +122,7 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
             // Save base to a temporary when link_rd == rs1 to prevent
             // the link write from clobbering the jump target (e.g. jalr ra, ra, 0).
             let base = if link_rd.is_some_and(|rd| rd == *rs1) {
-                ctx.materialize_u32(&base)
+                ctx.materialize_u64(&base)
             } else {
                 base
             };
@@ -131,19 +131,28 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
             }
             let imm_val = *imm;
             let next_pc = if imm_val == 0 {
-                ctx.materialize_u32(&format!("{base} & ~0x00000001u"))
+                ctx.materialize_u64(&format!("{base} & ~0x0000000000000001ull"))
             } else if imm_val > 0 {
-                ctx.materialize_u32(&format!(
-                    "({base} + {}) & ~0x00000001u",
-                    hex_u32(imm_val as u32)
+                ctx.materialize_u64(&format!(
+                    "({base} + {}) & ~0x0000000000000001ull",
+                    hex_u64(imm_val as u64)
                 ))
             } else {
-                let abs = (-(imm_val as i64)) as u32;
-                ctx.materialize_u32(&format!("({base} - {}) & ~0x00000001u", hex_u32(abs)))
+                let abs = (-(imm_val as i64)) as u64;
+                ctx.materialize_u64(&format!(
+                    "({base} - {}) & ~0x0000000000000001ull",
+                    hex_u64(abs)
+                ))
             };
-            ctx.write_line(&format!("state->pc = {next_pc};"));
             ctx.write_line(&format!(
-                "[[clang::musttail]] return dispatch_table[rv_dispatch_index({next_pc})]({args});"
+                "if (unlikely({next_pc} < RV_TEXT_START || {next_pc} > RV_TEXT_END)) {{"
+            ));
+            ctx.write_line(&format!("  [[clang::musttail]] return rv_trap({args});"));
+            ctx.write_line("}");
+            let next_pc_u32 = ctx.materialize_u32(&format!("(uint32_t){next_pc}"));
+            ctx.write_line(&format!("state->pc = {next_pc_u32};"));
+            ctx.write_line(&format!(
+                "[[clang::musttail]] return dispatch_table[rv_dispatch_index({next_pc_u32})]({args});"
             ));
         }
         Terminator::Branch {
@@ -284,8 +293,11 @@ fn imm_literal(imm: i32) -> String {
 
 /// Sign-extend a u32 value to a 64-bit C literal (uint64_t).
 fn sext32(value: u32) -> String {
-    let extended = value as i32 as i64 as u64;
-    format!("0x{extended:016x}ull")
+    hex_u64(value as i32 as i64 as u64)
+}
+
+fn hex_u64(value: u64) -> String {
+    format!("0x{value:016x}ull")
 }
 
 pub(super) fn hex_u32(value: u32) -> String {

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -145,7 +145,7 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
                 ))
             };
             ctx.write_line(&format!(
-                "if (unlikely({next_pc} < RV_TEXT_START || {next_pc} > RV_TEXT_END)) {{"
+                "if (unlikely(!rv_pc_is_dispatchable({next_pc}))) {{"
             ));
             ctx.write_line(&format!("  [[clang::musttail]] return rv_trap({args});"));
             ctx.write_line("}");

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -77,6 +77,12 @@ impl EmitContext {
         tmp
     }
 
+    pub fn materialize_u64(&mut self, expr: &str) -> String {
+        let tmp = self.next_var();
+        self.write_line(&format!("uint64_t {tmp} = {expr};"));
+        tmp
+    }
+
     pub fn take_buf(&mut self) -> String {
         std::mem::take(&mut self.buf)
     }

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -528,6 +528,19 @@ impl CProject {
             "typedef __attribute__((preserve_none)) void (*BlockFn)({typedef_params});"
         )
         .unwrap();
+        let trap_signature =
+            self.block_signature("__attribute__((preserve_none, cold)) void", "rv_trap");
+        writeln!(
+            h,
+            "// Used when a computed jump or dispatch slot does not point to a real block."
+        )
+        .unwrap();
+        writeln!(
+            h,
+            "// It takes the same arguments as a block so those register values can still be saved."
+        )
+        .unwrap();
+        writeln!(h, "{trap_signature};").unwrap();
         writeln!(h, "extern BlockFn dispatch_table[RV_DISPATCH_TABLE_SIZE];").unwrap();
         writeln!(h).unwrap();
 
@@ -868,11 +881,18 @@ impl CProject {
         writeln!(src).unwrap();
 
         let save = self.save_hot_regs_call();
-        // rv_trap — cold fallback for dispatch to non-block PCs.
-        let trap_signature = self.block_signature(
-            "static __attribute__((preserve_none, cold)) void",
-            "rv_trap",
-        );
+        let trap_signature =
+            self.block_signature("__attribute__((preserve_none, cold)) void", "rv_trap");
+        writeln!(
+            src,
+            "// If a computed jump reaches an invalid PC, guest registers are still in"
+        )
+        .unwrap();
+        writeln!(
+            src,
+            "// this function's arguments. Save them back to state before trapping."
+        )
+        .unwrap();
         writeln!(src, "{trap_signature} {{").unwrap();
         writeln!(src, "    {save}").unwrap();
         if self.tracer_mode == TracerMode::Metered {

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -260,6 +260,25 @@ impl CProject {
         out
     }
 
+    fn trap_signature(&self) -> String {
+        self.block_signature("__attribute__((preserve_none, cold)) void", "rv_trap")
+    }
+
+    fn emit_trap_declaration(&self, out: &mut String) {
+        let trap_signature = self.trap_signature();
+        writeln!(
+            out,
+            "// Used when a computed jump or dispatch slot does not point to a real block."
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "// It takes the same arguments as a block so those register values can still be saved."
+        )
+        .unwrap();
+        writeln!(out, "{trap_signature};").unwrap();
+    }
+
     /// C argument list extracting hot regs from state:
     /// "state, state->regs[1], state->regs[2]".
     fn fn_args_from_state(&self) -> String {
@@ -528,19 +547,7 @@ impl CProject {
             "typedef __attribute__((preserve_none)) void (*BlockFn)({typedef_params});"
         )
         .unwrap();
-        let trap_signature =
-            self.block_signature("__attribute__((preserve_none, cold)) void", "rv_trap");
-        writeln!(
-            h,
-            "// Used when a computed jump or dispatch slot does not point to a real block."
-        )
-        .unwrap();
-        writeln!(
-            h,
-            "// It takes the same arguments as a block so those register values can still be saved."
-        )
-        .unwrap();
-        writeln!(h, "{trap_signature};").unwrap();
+        self.emit_trap_declaration(&mut h);
         writeln!(h, "extern BlockFn dispatch_table[RV_DISPATCH_TABLE_SIZE];").unwrap();
         writeln!(h).unwrap();
 
@@ -881,8 +888,7 @@ impl CProject {
         writeln!(src).unwrap();
 
         let save = self.save_hot_regs_call();
-        let trap_signature =
-            self.block_signature("__attribute__((preserve_none, cold)) void", "rv_trap");
+        let trap_signature = self.trap_signature();
         writeln!(
             src,
             "// If a computed jump reaches an invalid PC, guest registers are still in"
@@ -931,7 +937,7 @@ impl CProject {
         .unwrap();
         writeln!(
             src,
-            "    if (state->pc < RV_TEXT_START || state->pc > RV_TEXT_END) {{"
+            "    if (unlikely(!rv_pc_is_dispatchable(state->pc))) {{"
         )
         .unwrap();
         writeln!(src, "        rv_trap({args_from_state});").unwrap();

--- a/extensions/riscv/circuit/cuda/src/auipc.cu
+++ b/extensions/riscv/circuit/cuda/src/auipc.cu
@@ -59,7 +59,7 @@ struct Rv64AuipcCore {
         range_checker.add_count(imm_high_16, U16_BITS);
         range_checker.add_count(rd_lo, U16_BITS);
         range_checker.add_count(rd_hi, U16_BITS);
-        // Mirrors the AIR sign-bit check for imm_high_16.
+        // Check that imm_sign matches the top bit of imm_high_16.
         range_checker.add_count(2u * imm_high_16 - (imm_sign << U16_BITS), U16_BITS);
 
         uint32_t rd_u16[RV64_PTR_U16_LIMBS] = {rd_lo, rd_hi};

--- a/extensions/riscv/circuit/cuda/src/auipc.cu
+++ b/extensions/riscv/circuit/cuda/src/auipc.cu
@@ -1,3 +1,5 @@
+#include <assert.h>
+
 #include "launcher.cuh"
 #include "primitives/buffer_view.cuh"
 #include "primitives/constants.h"
@@ -41,11 +43,14 @@ struct Rv64AuipcCore {
         uint16_t pc_limbs[RV64_PTR_U16_LIMBS];
         ptr_to_u16_limbs(pc_limbs, record.from_pc);
         uint64_t auipc = run_auipc(record.from_pc, record.imm);
+        uint64_t auipc_hi = auipc >> 32;
+        assert(auipc_hi == 0ull || auipc_hi == 0xffffffffull);
+        uint32_t auipc_lo = (uint32_t)auipc;
         uint16_t rd_limbs[RV64_PTR_U16_LIMBS];
-        ptr_to_u16_limbs(rd_limbs, (uint32_t)auipc);
+        ptr_to_u16_limbs(rd_limbs, auipc_lo);
         uint32_t rd_lo = rd_limbs[0];
         uint32_t rd_hi = rd_limbs[1];
-        uint32_t is_sign_ext = ((auipc >> 32) != 0) ? 1u : 0u;
+        uint32_t is_sign_ext = (auipc_hi != 0) ? 1u : 0u;
         uint32_t imm_sign = (imm_high_16 >> (U16_BITS - 1)) & 1u;
 
         range_checker.add_count(pc_limbs[0], U16_BITS);

--- a/extensions/riscv/circuit/cuda/src/auipc.cu
+++ b/extensions/riscv/circuit/cuda/src/auipc.cu
@@ -24,7 +24,11 @@ struct Rv64AuipcCoreRecord {
     uint32_t imm;
 };
 
-__device__ uint32_t run_auipc(uint32_t pc, uint32_t imm) { return pc + (imm << RV64_BYTE_BITS); }
+__device__ uint64_t run_auipc(uint32_t pc, uint32_t imm) {
+    uint32_t offset = imm << RV64_BYTE_BITS;
+    int64_t signed_offset = (int64_t)(int32_t)offset;
+    return (uint64_t)pc + (uint64_t)signed_offset;
+}
 
 struct Rv64AuipcCore {
     VariableRangeChecker range_checker;
@@ -36,22 +40,24 @@ struct Rv64AuipcCore {
         uint32_t imm_high_16 = (record.imm >> RV64_BYTE_BITS) & uint32_t(UINT16_MAX);
         uint16_t pc_limbs[RV64_PTR_U16_LIMBS];
         ptr_to_u16_limbs(pc_limbs, record.from_pc);
-        auto auipc = run_auipc(record.from_pc, record.imm);
-        uint16_t rd_u16[RV64_PTR_U16_LIMBS];
-        ptr_to_u16_limbs(rd_u16, auipc);
-        uint16_t rd_hi = rd_u16[1];
-        uint32_t is_sign_ext = (rd_hi >> (U16_BITS - 1)) & 1;
+        uint64_t auipc = run_auipc(record.from_pc, record.imm);
+        uint16_t rd_limbs[RV64_PTR_U16_LIMBS];
+        ptr_to_u16_limbs(rd_limbs, (uint32_t)auipc);
+        uint32_t rd_lo = rd_limbs[0];
+        uint32_t rd_hi = rd_limbs[1];
+        uint32_t is_sign_ext = ((auipc >> 32) != 0) ? 1u : 0u;
+        uint32_t imm_sign = (imm_high_16 >> (U16_BITS - 1)) & 1u;
 
         range_checker.add_count(pc_limbs[0], U16_BITS);
         range_checker.add_count(pc_limbs[1], PC_BITS - U16_BITS);
         range_checker.add_count(imm_low_8, RV64_BYTE_BITS);
         range_checker.add_count(imm_high_16, U16_BITS);
-        range_checker.add_count(rd_u16[0], U16_BITS);
+        range_checker.add_count(rd_lo, U16_BITS);
         range_checker.add_count(rd_hi, U16_BITS);
-        range_checker.add_count(
-            2u * rd_hi - (is_sign_ext << U16_BITS), U16_BITS
-        );
+        // Mirrors the AIR sign-bit check for imm_high_16.
+        range_checker.add_count(2u * imm_high_16 - (imm_sign << U16_BITS), U16_BITS);
 
+        uint32_t rd_u16[RV64_PTR_U16_LIMBS] = {rd_lo, rd_hi};
         COL_WRITE_VALUE(row, Rv64AuipcCoreCols, imm_low_8, imm_low_8);
         COL_WRITE_VALUE(row, Rv64AuipcCoreCols, imm_high_16, imm_high_16);
         COL_WRITE_VALUE(row, Rv64AuipcCoreCols, pc_high, pc_limbs[1]);

--- a/extensions/riscv/circuit/cuda/src/jalr.cu
+++ b/extensions/riscv/circuit/cuda/src/jalr.cu
@@ -35,10 +35,11 @@ __device__ void run_jalr(
     uint16_t rd_data[BLOCK_FE_WIDTH]
 ) {
     uint32_t offset = imm + (imm_sign ? (uint32_t(UINT16_MAX) << U16_BITS) : 0);
-    uint32_t to_pc = rs1 + offset;
+    int64_t signed_offset = (int64_t)(int32_t)offset;
+    uint64_t to_pc = uint64_t(rs1) + signed_offset;
 
-    assert(to_pc < (1u << PC_BITS));
-    out_pc = to_pc;
+    assert(to_pc < (uint64_t(1) << PC_BITS));
+    out_pc = uint32_t(to_pc);
     uint32_t rd_val = pc + DEFAULT_PC_STEP;
     rd_data[0] = uint16_t(rd_val);
     rd_data[1] = uint16_t(rd_val >> U16_BITS);

--- a/extensions/riscv/circuit/src/adapters/loadstore.rs
+++ b/extensions/riscv/circuit/src/adapters/loadstore.rs
@@ -476,16 +476,10 @@ where
                         // TODO: Remove loadstore read/write support for DEFERRAL_AS.
                         unreachable!("STORE to DEFERRAL_AS is unsupported");
                     }
-                    timed_write(memory, record.mem_as as u32, ptr, data.map(|x| x as u8)).0
+                    timed_write(memory, record.mem_as as u32, ptr, data).0
                 }
                 LOADD | LOADW | LOADB | LOADH | LOADWU | LOADBU | LOADHU => {
-                    timed_write(
-                        memory,
-                        RV64_REGISTER_AS,
-                        record.rd_rs2_ptr,
-                        data.map(|x| x as u8),
-                    )
-                    .0
+                    timed_write(memory, RV64_REGISTER_AS, record.rd_rs2_ptr, data).0
                 }
             };
         } else {

--- a/extensions/riscv/circuit/src/adapters/loadstore.rs
+++ b/extensions/riscv/circuit/src/adapters/loadstore.rs
@@ -306,7 +306,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv64LoadStoreAdapterAir {
 }
 
 #[repr(C)]
-#[derive(AlignedBytesBorrow, Clone, Debug)]
+#[derive(AlignedBytesBorrow, Debug)]
 pub struct Rv64LoadStoreAdapterRecord {
     pub from_pc: u32,
     pub from_timestamp: u32,
@@ -317,10 +317,11 @@ pub struct Rv64LoadStoreAdapterRecord {
 
     pub rd_rs2_ptr: u32,
     pub read_data_aux: MemoryReadAuxRecord,
-
     pub imm: u16,
     pub imm_sign: bool,
+
     pub mem_as: u8,
+
     pub write_prev_timestamp: u32,
 }
 
@@ -503,9 +504,8 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv64LoadStoreAdapterFiller {
         // - caller ensures `adapter_row` contains a valid record representation that was previously
         //   written by the executor
         // - get_record_from_slice correctly interprets the bytes as Rv64LoadStoreAdapterRecord
-        let record_ref: &Rv64LoadStoreAdapterRecord =
+        let record: &Rv64LoadStoreAdapterRecord =
             unsafe { get_record_from_slice(&mut adapter_row, ()) };
-        let record = record_ref.clone();
         let adapter_row: &mut Rv64LoadStoreAdapterCols<F> = adapter_row.borrow_mut();
 
         let needs_write = record.rd_rs2_ptr != u32::MAX;

--- a/extensions/riscv/circuit/src/adapters/loadstore.rs
+++ b/extensions/riscv/circuit/src/adapters/loadstore.rs
@@ -178,11 +178,11 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv64LoadStoreAdapterAir {
             .eval(builder, is_valid.clone());
 
         // Constrain mem_ptr = rs1 + sign_extend(imm) as a 32-bit addition.
-        let rs1_low = local_cols.rs1_data[0];
-        let rs1_high = local_cols.rs1_data[1];
+        let limbs_01 = local_cols.rs1_data[0];
+        let limbs_23 = local_cols.rs1_data[1];
 
         let inv = AB::F::from_u32(1u32 << U16_BITS).inverse();
-        let carry = (rs1_low + local_cols.imm - local_cols.mem_ptr_limbs[0]) * inv;
+        let carry = (limbs_01 + local_cols.imm - local_cols.mem_ptr_limbs[0]) * inv;
 
         builder.when(is_valid.clone()).assert_bool(carry.clone());
 
@@ -190,7 +190,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv64LoadStoreAdapterAir {
             .when(is_valid.clone())
             .assert_bool(local_cols.imm_sign);
         let imm_extend_limb = local_cols.imm_sign * AB::F::from_u32(u16::MAX as u32);
-        let carry = (rs1_high + imm_extend_limb + carry - local_cols.mem_ptr_limbs[1]) * inv;
+        let carry = (limbs_23 + imm_extend_limb + carry - local_cols.mem_ptr_limbs[1]) * inv;
         builder.when(is_valid.clone()).assert_bool(carry.clone());
         builder
             .when(is_valid.clone())
@@ -466,24 +466,26 @@ where
 
         if enabled != F::ZERO {
             record.rd_rs2_ptr = a.as_canonical_u32();
-            let write_data = data.map(|x| x as u8);
 
             record.write_prev_timestamp = match local_opcode {
                 STORED | STOREW | STOREH | STOREB => {
+                    let imm_extended = sign_extend_imm16(record.imm as u32, record.imm_sign as u32);
+                    let ptr = record.rs1_val.wrapping_add(imm_extended)
+                        & !(RV64_REGISTER_NUM_LIMBS as u32 - 1);
                     if record.mem_as == DEFERRAL_AS as u8 {
                         // TODO: Remove loadstore read/write support for DEFERRAL_AS.
                         unreachable!("STORE to DEFERRAL_AS is unsupported");
                     }
-                    let write_as = record.mem_as as u32;
-                    let imm_extended = sign_extend_imm16(record.imm as u32, record.imm_sign as u32);
-                    let mem_ptr = record.rs1_val.wrapping_add(imm_extended);
-                    let alignment_mask = RV64_REGISTER_NUM_LIMBS as u32 - 1;
-                    let write_ptr = mem_ptr - (mem_ptr & alignment_mask);
-                    timed_write(memory, write_as, write_ptr, write_data).0
+                    timed_write(memory, record.mem_as as u32, ptr, data.map(|x| x as u8)).0
                 }
                 LOADD | LOADW | LOADB | LOADH | LOADWU | LOADBU | LOADHU => {
-                    let write_ptr = record.rd_rs2_ptr;
-                    timed_write(memory, RV64_REGISTER_AS, write_ptr, write_data).0
+                    timed_write(
+                        memory,
+                        RV64_REGISTER_AS,
+                        record.rd_rs2_ptr,
+                        data.map(|x| x as u8),
+                    )
+                    .0
                 }
             };
         } else {
@@ -509,6 +511,7 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv64LoadStoreAdapterFiller {
         let adapter_row: &mut Rv64LoadStoreAdapterCols<F> = adapter_row.borrow_mut();
 
         let needs_write = record.rd_rs2_ptr != u32::MAX;
+        // Writing in reverse order
         adapter_row.needs_write = F::from_bool(needs_write);
 
         if needs_write {
@@ -522,14 +525,15 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv64LoadStoreAdapterFiller {
         }
 
         adapter_row.mem_as = F::from_u8(record.mem_as);
-        let imm_extended = sign_extend_imm16(record.imm as u32, record.imm_sign as u32);
-        let mem_ptr = record.rs1_val.wrapping_add(imm_extended);
-        let mem_ptr_limbs = ptr_to_u16_limbs(mem_ptr).map(u32::from);
+        let ptr = record
+            .rs1_val
+            .wrapping_add(sign_extend_imm16(record.imm as u32, record.imm_sign as u32));
+        let ptr_limbs = ptr_to_u16_limbs(ptr).map(u32::from);
         self.range_checker_chip
-            .add_count(mem_ptr_limbs[0] >> 3, U16_BITS - 3);
+            .add_count(ptr_limbs[0] >> 3, U16_BITS - 3);
         self.range_checker_chip
-            .add_count(mem_ptr_limbs[1], self.pointer_max_bits - U16_BITS);
-        adapter_row.mem_ptr_limbs = mem_ptr_limbs.map(F::from_u32);
+            .add_count(ptr_limbs[1], self.pointer_max_bits - U16_BITS);
+        adapter_row.mem_ptr_limbs = ptr_limbs.map(F::from_u32);
 
         adapter_row.imm_sign = F::from_bool(record.imm_sign);
         adapter_row.imm = F::from_u16(record.imm);

--- a/extensions/riscv/circuit/src/adapters/loadstore.rs
+++ b/extensions/riscv/circuit/src/adapters/loadstore.rs
@@ -29,7 +29,7 @@ use openvm_instructions::{
     instruction::Instruction,
     program::DEFAULT_PC_STEP,
     riscv::{RV64_IMM_AS, RV64_MEMORY_AS, RV64_REGISTER_AS},
-    LocalOpcode,
+    LocalOpcode, DEFERRAL_AS,
 };
 use openvm_riscv_transpiler::Rv64LoadStoreOpcode::{self, *};
 use openvm_stark_backend::{
@@ -40,9 +40,10 @@ use openvm_stark_backend::{
 
 use super::{
     byte_ptr_to_u16_ptr, expand_to_rv64_block, ptr_to_field_u16_limbs, ptr_to_u16_limbs,
-    sign_extend_imm16, RV64_PTR_U16_LIMBS, RV64_REGISTER_NUM_LIMBS, U16_BITS,
+    rv64_address_add_imm, sign_extend_imm16, try_rv64_bytes_to_u32, RV64_PTR_BITS,
+    RV64_PTR_U16_LIMBS, RV64_REGISTER_NUM_LIMBS, U16_BITS,
 };
-use crate::adapters::{memory_read, rv64_bytes_to_u32, timed_write, tracing_read};
+use crate::adapters::{memory_read, timed_write, tracing_read};
 
 /// LoadStore Adapter handles all memory and register operations, so it must be aware
 /// of the instruction type, specifically whether it is a load or store.
@@ -177,11 +178,11 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv64LoadStoreAdapterAir {
             .eval(builder, is_valid.clone());
 
         // Constrain mem_ptr = rs1 + sign_extend(imm) as a 32-bit addition.
-        let limbs_01 = local_cols.rs1_data[0];
-        let limbs_23 = local_cols.rs1_data[1];
+        let rs1_low = local_cols.rs1_data[0];
+        let rs1_high = local_cols.rs1_data[1];
 
         let inv = AB::F::from_u32(1u32 << U16_BITS).inverse();
-        let carry = (limbs_01 + local_cols.imm - local_cols.mem_ptr_limbs[0]) * inv;
+        let carry = (rs1_low + local_cols.imm - local_cols.mem_ptr_limbs[0]) * inv;
 
         builder.when(is_valid.clone()).assert_bool(carry.clone());
 
@@ -189,8 +190,11 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv64LoadStoreAdapterAir {
             .when(is_valid.clone())
             .assert_bool(local_cols.imm_sign);
         let imm_extend_limb = local_cols.imm_sign * AB::F::from_u32(u16::MAX as u32);
-        let carry = (limbs_23 + imm_extend_limb + carry - local_cols.mem_ptr_limbs[1]) * inv;
+        let carry = (rs1_high + imm_extend_limb + carry - local_cols.mem_ptr_limbs[1]) * inv;
         builder.when(is_valid.clone()).assert_bool(carry.clone());
+        builder
+            .when(is_valid.clone())
+            .assert_eq(carry, local_cols.imm_sign);
 
         // preventing mem_ptr overflow
         self.range_bus
@@ -302,7 +306,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv64LoadStoreAdapterAir {
 }
 
 #[repr(C)]
-#[derive(AlignedBytesBorrow, Debug)]
+#[derive(AlignedBytesBorrow, Clone, Debug)]
 pub struct Rv64LoadStoreAdapterRecord {
     pub from_pc: u32,
     pub from_timestamp: u32,
@@ -313,11 +317,10 @@ pub struct Rv64LoadStoreAdapterRecord {
 
     pub rd_rs2_ptr: u32,
     pub read_data_aux: MemoryReadAuxRecord,
+
     pub imm: u16,
     pub imm_sign: bool,
-
     pub mem_as: u8,
-
     pub write_prev_timestamp: u32,
 }
 
@@ -377,23 +380,29 @@ where
         );
 
         record.rs1_ptr = b.as_canonical_u32();
-        record.rs1_val = rv64_bytes_to_u32(tracing_read(
+        let rs1_bytes = tracing_read(
             memory,
             RV64_REGISTER_AS,
             record.rs1_ptr,
             &mut record.rs1_aux_record.prev_timestamp,
-        ));
-        let rs1_val = record.rs1_val;
+        );
+        let rs1_val = try_rv64_bytes_to_u32(rs1_bytes).expect("upper 4 bytes must be zero");
+        record.rs1_val = rs1_val;
 
         record.imm = c.as_canonical_u32() as u16;
         record.imm_sign = g.is_one();
         let imm_extended = sign_extend_imm16(record.imm as u32, record.imm_sign as u32);
 
-        let ptr_val = rs1_val.wrapping_add(imm_extended);
+        let addr = rv64_address_add_imm(rs1_val, imm_extended);
+        let ptr_val = u32::try_from(addr)
+            .ok()
+            .filter(|&ptr| {
+                self.pointer_max_bits >= RV64_PTR_BITS
+                    || u64::from(ptr) < (1u64 << self.pointer_max_bits)
+            })
+            .expect("effective address exceeds implemented memory address space");
         let shift_amount = ptr_val & (RV64_REGISTER_NUM_LIMBS as u32 - 1);
-        let ptr_val = ptr_val - shift_amount;
-
-        debug_assert!((ptr_val as u64) < (1u64 << self.pointer_max_bits));
+        let aligned_ptr = ptr_val - shift_amount;
 
         // prev_data: We need to keep values of some cells to keep them unchanged when writing to
         // those cells
@@ -404,7 +413,7 @@ where
                 let read_data = tracing_read(
                     memory,
                     RV64_MEMORY_AS,
-                    ptr_val,
+                    aligned_ptr,
                     &mut record.read_data_aux.prev_timestamp,
                 );
                 let prev_data = memory_read(memory.data(), RV64_REGISTER_AS, a.as_canonical_u32());
@@ -421,7 +430,7 @@ where
                     a.as_canonical_u32(),
                     &mut record.read_data_aux.prev_timestamp,
                 );
-                let prev_data = memory_read(memory.data(), e, ptr_val);
+                let prev_data = memory_read(memory.data(), e, aligned_ptr);
                 (read_data, prev_data)
             }
         };
@@ -456,16 +465,24 @@ where
 
         if enabled != F::ZERO {
             record.rd_rs2_ptr = a.as_canonical_u32();
+            let write_data = data.map(|x| x as u8);
 
             record.write_prev_timestamp = match local_opcode {
                 STORED | STOREW | STOREH | STOREB => {
+                    if record.mem_as == DEFERRAL_AS as u8 {
+                        // TODO: Remove loadstore read/write support for DEFERRAL_AS.
+                        unreachable!("STORE to DEFERRAL_AS is unsupported");
+                    }
+                    let write_as = record.mem_as as u32;
                     let imm_extended = sign_extend_imm16(record.imm as u32, record.imm_sign as u32);
-                    let ptr = record.rs1_val.wrapping_add(imm_extended)
-                        & !(RV64_REGISTER_NUM_LIMBS as u32 - 1);
-                    timed_write(memory, record.mem_as as u32, ptr, data).0
+                    let mem_ptr = record.rs1_val.wrapping_add(imm_extended);
+                    let alignment_mask = RV64_REGISTER_NUM_LIMBS as u32 - 1;
+                    let write_ptr = mem_ptr - (mem_ptr & alignment_mask);
+                    timed_write(memory, write_as, write_ptr, write_data).0
                 }
                 LOADD | LOADW | LOADB | LOADH | LOADWU | LOADBU | LOADHU => {
-                    timed_write(memory, RV64_REGISTER_AS, record.rd_rs2_ptr, data).0
+                    let write_ptr = record.rd_rs2_ptr;
+                    timed_write(memory, RV64_REGISTER_AS, write_ptr, write_data).0
                 }
             };
         } else {
@@ -486,12 +503,12 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv64LoadStoreAdapterFiller {
         // - caller ensures `adapter_row` contains a valid record representation that was previously
         //   written by the executor
         // - get_record_from_slice correctly interprets the bytes as Rv64LoadStoreAdapterRecord
-        let record: &Rv64LoadStoreAdapterRecord =
+        let record_ref: &Rv64LoadStoreAdapterRecord =
             unsafe { get_record_from_slice(&mut adapter_row, ()) };
+        let record = record_ref.clone();
         let adapter_row: &mut Rv64LoadStoreAdapterCols<F> = adapter_row.borrow_mut();
 
         let needs_write = record.rd_rs2_ptr != u32::MAX;
-        // Writing in reverse order
         adapter_row.needs_write = F::from_bool(needs_write);
 
         if needs_write {
@@ -505,16 +522,14 @@ impl<F: PrimeField32> AdapterTraceFiller<F> for Rv64LoadStoreAdapterFiller {
         }
 
         adapter_row.mem_as = F::from_u8(record.mem_as);
-        let ptr = record
-            .rs1_val
-            .wrapping_add(sign_extend_imm16(record.imm as u32, record.imm_sign as u32));
-
-        let ptr_limbs = ptr_to_u16_limbs(ptr).map(u32::from);
+        let imm_extended = sign_extend_imm16(record.imm as u32, record.imm_sign as u32);
+        let mem_ptr = record.rs1_val.wrapping_add(imm_extended);
+        let mem_ptr_limbs = ptr_to_u16_limbs(mem_ptr).map(u32::from);
         self.range_checker_chip
-            .add_count(ptr_limbs[0] >> 3, U16_BITS - 3);
+            .add_count(mem_ptr_limbs[0] >> 3, U16_BITS - 3);
         self.range_checker_chip
-            .add_count(ptr_limbs[1], self.pointer_max_bits - U16_BITS);
-        adapter_row.mem_ptr_limbs = ptr_limbs.map(F::from_u32);
+            .add_count(mem_ptr_limbs[1], self.pointer_max_bits - U16_BITS);
+        adapter_row.mem_ptr_limbs = mem_ptr_limbs.map(F::from_u32);
 
         adapter_row.imm_sign = F::from_bool(record.imm_sign);
         adapter_row.imm = F::from_u16(record.imm);

--- a/extensions/riscv/circuit/src/adapters/mod.rs
+++ b/extensions/riscv/circuit/src/adapters/mod.rs
@@ -117,6 +117,12 @@ pub fn sign_extend_imm16(imm: u32, sign: u32) -> u32 {
     imm + sign * (u32::MAX << U16_BITS)
 }
 
+/// Sign-extends a 32-bit value into RV64 register arithmetic form.
+#[inline(always)]
+pub fn sext32_to_u64(value: u32) -> u64 {
+    value as i32 as i64 as u64
+}
+
 // For soundness, should be <= 16
 pub const RV_IS_TYPE_IMM_BITS: usize = 12;
 
@@ -191,6 +197,18 @@ pub fn u64_to_u32_checked(value: u64) -> u32 {
 #[inline(always)]
 pub fn rv64_bytes_to_u32(bytes: [u8; RV64_REGISTER_NUM_LIMBS]) -> u32 {
     u64_to_u32_checked(u64::from_le_bytes(bytes))
+}
+
+/// Attempts to convert RV64 register bytes to a `u32`, requiring the upper 4 bytes to be zero.
+#[inline(always)]
+pub fn try_rv64_bytes_to_u32(bytes: [u8; RV64_REGISTER_NUM_LIMBS]) -> Option<u32> {
+    u32::try_from(u64::from_le_bytes(bytes)).ok()
+}
+
+/// Adds an already-sign-extended 16-bit RV64 immediate to an implemented low-32-bit address.
+#[inline(always)]
+pub fn rv64_address_add_imm(base: u32, imm_extended: u32) -> u64 {
+    u64::from(base).wrapping_add(sext32_to_u64(imm_extended))
 }
 
 #[inline(always)]

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -23,8 +23,8 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    ptr_to_u16_limbs, Rv64RdWriteAdapterExecutor, Rv64RdWriteAdapterFiller, RV64_BYTE_BITS,
-    RV64_PTR_U16_LIMBS, U16_BITS,
+    ptr_to_u16_limbs, sext32_to_u64, Rv64RdWriteAdapterExecutor, Rv64RdWriteAdapterFiller,
+    RV64_BYTE_BITS, RV64_PTR_U16_LIMBS, U16_BITS,
 };
 
 #[repr(C)]
@@ -102,12 +102,15 @@ where
         builder.when(is_valid).assert_bool(carry_low.clone());
 
         let carry_top = (pc_high + imm_high_16 + carry_low - rd_data[1]) * carry_divide;
-        builder.when(is_valid).assert_bool(carry_top);
+        builder.when(is_valid).assert_bool(carry_top.clone());
 
+        // `imm_sign` is the sign bit after accounting for carry out of bit 31.
+        // Range-checking `2 * imm_high_16 - imm_sign * 2^16` ties that sign bit
+        // to the 15-bit magnitude of the shifted immediate.
+        let imm_sign = is_sign_extend + carry_top;
         self.range_bus
             .range_check(
-                AB::Expr::from_u32(2) * rd_data[1]
-                    - is_sign_extend * AB::Expr::from_u32(1 << U16_BITS),
+                AB::Expr::from_u32(2) * imm_high_16 - imm_sign * AB::Expr::from_u32(1 << U16_BITS),
                 U16_BITS,
             )
             .eval(builder, is_valid);
@@ -230,7 +233,10 @@ where
         let [pc_low, pc_high] = ptr_to_u16_limbs(record.from_pc);
 
         let rd_block = run_auipc(record.from_pc, record.imm);
-        let rd_u16 = [rd_block[0], rd_block[1]];
+        let rd_lo = rd_block[0];
+        let rd_hi = rd_block[1];
+        let is_sign_extend = rd_block[2] != 0;
+        let imm_sign = (imm_high_16 >> (U16_BITS - 1)) & 1;
 
         // range checks:
         self.range_checker_chip.add_count(pc_low as u32, U16_BITS);
@@ -239,22 +245,19 @@ where
         self.range_checker_chip
             .add_count(imm_low_8 as u32, RV64_BYTE_BITS);
         self.range_checker_chip.add_count(imm_high_16, U16_BITS);
+        self.range_checker_chip.add_count(rd_lo as u32, U16_BITS);
+        self.range_checker_chip.add_count(rd_hi as u32, U16_BITS);
+        // Mirrors the AIR sign-bit check for imm_high_16.
+        let imm_magnitude_check = 2u32 * imm_high_16 - imm_sign * (1 << U16_BITS);
         self.range_checker_chip
-            .add_count(rd_u16[0] as u32, U16_BITS);
-        self.range_checker_chip
-            .add_count(rd_u16[1] as u32, U16_BITS);
-        let is_sign_extend = (rd_u16[1] >> (U16_BITS - 1)) & 1;
-        let second_range_limb =
-            2u32 * (rd_u16[1] as u32) - (is_sign_extend as u32) * (1 << U16_BITS);
-        self.range_checker_chip
-            .add_count(second_range_limb, U16_BITS);
+            .add_count(imm_magnitude_check, U16_BITS);
 
         // Writing in reverse order
-        core_row.rd_data = rd_u16.map(F::from_u16);
+        core_row.rd_data = [F::from_u16(rd_lo), F::from_u16(rd_hi)];
         core_row.imm_low_8 = F::from_u8(imm_low_8);
         core_row.imm_high_16 = F::from_u32(imm_high_16);
         core_row.pc_high = F::from_u16(pc_high);
-        core_row.is_sign_extend = F::from_bool(is_sign_extend != 0);
+        core_row.is_sign_extend = F::from_bool(is_sign_extend);
         core_row.is_valid = F::ONE;
     }
 }
@@ -262,12 +265,9 @@ where
 // returns rd_data
 #[inline(always)]
 pub(super) fn run_auipc(pc: u32, imm: u32) -> [u16; BLOCK_FE_WIDTH] {
-    let rd_low_32 = pc.wrapping_add(imm << RV64_BYTE_BITS);
-    let [lo, hi] = ptr_to_u16_limbs(rd_low_32);
-    let sign = if (hi >> (U16_BITS - 1)) & 1 == 1 {
-        u16::MAX
-    } else {
-        0
-    };
+    let offset = imm << RV64_BYTE_BITS;
+    let rd = (pc as u64).wrapping_add(sext32_to_u64(offset));
+    let [lo, hi] = ptr_to_u16_limbs(rd as u32);
+    let sign = if rd >> 32 != 0 { u16::MAX } else { 0 };
     [lo, hi, sign, sign]
 }

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -104,9 +104,7 @@ where
         let carry_top = (pc_high + imm_high_16 + carry_low - rd_data[1]) * carry_divide;
         builder.when(is_valid).assert_bool(carry_top.clone());
 
-        // `imm_sign` is the sign bit after accounting for carry out of bit 31.
-        // Range-checking `2 * imm_high_16 - imm_sign * 2^16` ties that sign bit
-        // to the 15-bit magnitude of the shifted immediate.
+        // Check that the computed sign matches the top bit of `imm_high_16`.
         let imm_sign = is_sign_extend + carry_top;
         self.range_bus
             .range_check(
@@ -247,7 +245,7 @@ where
         self.range_checker_chip.add_count(imm_high_16, U16_BITS);
         self.range_checker_chip.add_count(rd_lo as u32, U16_BITS);
         self.range_checker_chip.add_count(rd_hi as u32, U16_BITS);
-        // Mirrors the AIR sign-bit check for imm_high_16.
+        // Check that imm_sign matches the top bit of imm_high_16.
         let imm_magnitude_check = 2u32 * imm_high_16 - imm_sign * (1 << U16_BITS);
         self.range_checker_chip
             .add_count(imm_magnitude_check, U16_BITS);

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -266,8 +266,12 @@ where
 #[inline(always)]
 pub(super) fn run_auipc(pc: u32, imm: u32) -> [u16; BLOCK_FE_WIDTH] {
     let offset = imm << RV64_BYTE_BITS;
-    let rd = (pc as u64).wrapping_add(sext32_to_u64(offset));
-    let [lo, hi] = ptr_to_u16_limbs(rd as u32);
-    let sign = if rd >> 32 != 0 { u16::MAX } else { 0 };
+    let auipc = (pc as u64).wrapping_add(sext32_to_u64(offset));
+    let auipc_hi = auipc >> 32;
+    debug_assert!(auipc_hi == 0 || auipc_hi == u64::from(u32::MAX));
+    let auipc_lo = auipc as u32;
+
+    let [lo, hi] = ptr_to_u16_limbs(auipc_lo);
+    let sign = if auipc_hi != 0 { u16::MAX } else { 0 };
     [lo, hi, sign, sign]
 }

--- a/extensions/riscv/circuit/src/auipc/tests.rs
+++ b/extensions/riscv/circuit/src/auipc/tests.rs
@@ -368,6 +368,20 @@ fn sign_extend_flag_negative_tests() {
 }
 
 #[test]
+fn positive_offset_crossing_sign_extend_negative_tests() {
+    run_negative_auipc_test(
+        AUIPC,
+        Some(0x7f_fff0),
+        Some(0x1000),
+        AuipcPrankValues {
+            is_sign_extend: Some(1),
+            ..Default::default()
+        },
+        true,
+    );
+}
+
+#[test]
 fn overflow_negative_tests() {
     let (imm_low_8, imm_high_16) = split_imm_u8_limbs([3592, 219, 3]);
     run_negative_auipc_test(
@@ -442,6 +456,18 @@ fn run_auipc_sanity_test() {
     assert_eq!(
         rv64_u16_block_to_bytes(rd_data),
         [210, 107, 113, 186, 255, 255, 255, 255]
+    );
+
+    let rd_data = run_auipc(0x1000, 0x7f_fff0);
+    assert_eq!(
+        rv64_u16_block_to_bytes(rd_data),
+        [0, 0, 0, 0x80, 0, 0, 0, 0]
+    );
+
+    let rd_data = run_auipc(0x2000, 0xff_fff0);
+    assert_eq!(
+        rv64_u16_block_to_bytes(rd_data),
+        [0, 0x10, 0, 0, 0, 0, 0, 0]
     );
 }
 

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -164,8 +164,6 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Rv64I {
         &self,
         inventory: &mut ExecutorInventoryBuilder<F, Rv64IExecutor>,
     ) -> Result<(), ExecutorInventoryError> {
-        let byte_ptr_max_bits = to_byte_ptr_bits(inventory.pointer_max_bits());
-
         let add_sub =
             Rv64AddSubExecutor::new(Rv64BaseAluU16AdapterExecutor, BaseAluOpcode::CLASS_OFFSET);
         inventory.add_executor(
@@ -222,6 +220,7 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Rv64I {
             [ShiftWOpcode::SRAW].map(|x| x.global_opcode()),
         )?;
 
+        let byte_ptr_max_bits = to_byte_ptr_bits(inventory.pointer_max_bits());
         let load_store = Rv64LoadStoreExecutor::new(
             Rv64LoadStoreAdapterExecutor::new(byte_ptr_max_bits),
             Rv64LoadStoreOpcode::CLASS_OFFSET,

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -164,6 +164,8 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Rv64I {
         &self,
         inventory: &mut ExecutorInventoryBuilder<F, Rv64IExecutor>,
     ) -> Result<(), ExecutorInventoryError> {
+        let byte_ptr_max_bits = to_byte_ptr_bits(inventory.pointer_max_bits());
+
         let add_sub =
             Rv64AddSubExecutor::new(Rv64BaseAluU16AdapterExecutor, BaseAluOpcode::CLASS_OFFSET);
         inventory.add_executor(
@@ -220,7 +222,6 @@ impl<F: PrimeField32> VmExecutionExtension<F> for Rv64I {
             [ShiftWOpcode::SRAW].map(|x| x.global_opcode()),
         )?;
 
-        let byte_ptr_max_bits = to_byte_ptr_bits(inventory.pointer_max_bits());
         let load_store = Rv64LoadStoreExecutor::new(
             Rv64LoadStoreAdapterExecutor::new(byte_ptr_max_bits),
             Rv64LoadStoreOpcode::CLASS_OFFSET,

--- a/extensions/riscv/circuit/src/jalr/core.rs
+++ b/extensions/riscv/circuit/src/jalr/core.rs
@@ -11,7 +11,7 @@ use openvm_circuit_primitives::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction,
-    program::{DEFAULT_PC_STEP, PC_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_BITS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::Rv64JalrOpcode::{self, *};
@@ -23,9 +23,9 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    expand_to_rv64_block, ptr_to_u16_limbs, rv64_bytes_to_u32, rv64_u16_block_to_bytes,
-    rv64_u32_to_u16_block, Rv64JalrAdapterExecutor, Rv64JalrAdapterFiller, RV64_PTR_U16_LIMBS,
-    U16_BITS,
+    expand_to_rv64_block, ptr_to_u16_limbs, rv64_address_add_imm, rv64_bytes_to_u32,
+    rv64_u16_block_to_bytes, rv64_u32_to_u16_block, Rv64JalrAdapterExecutor, Rv64JalrAdapterFiller,
+    RV64_PTR_U16_LIMBS, U16_BITS,
 };
 
 #[repr(C)]
@@ -119,7 +119,8 @@ where
         // Sign-extend the 16-bit immediate into the high u16 limb.
         let imm_extend_limb = imm_sign * AB::F::from_u32(u16::MAX as u32);
         let carry = (rs1[1] + imm_extend_limb + carry - to_pc_limbs[1]) * inv;
-        builder.when(is_valid).assert_bool(carry);
+        builder.when(is_valid).assert_bool(carry.clone());
+        builder.when(is_valid).assert_eq(carry, imm_sign);
 
         // Prevent to_pc overflow. to_pc_limbs[0] is 15 bits because it is
         // multiplied by 2 when reconstructing the aligned target.
@@ -300,8 +301,13 @@ pub(super) fn run_jalr(
     imm: u16,
     imm_sign: bool,
 ) -> (u32, [u16; BLOCK_FE_WIDTH]) {
-    let to_pc = rs1.wrapping_add(imm as u32 + (imm_sign as u32 * ((u16::MAX as u32) << U16_BITS)));
-    assert!(to_pc < (1 << PC_BITS));
+    let imm_extended = imm as u32 + (imm_sign as u32 * ((u16::MAX as u32) << U16_BITS));
+    let to_pc = rv64_address_add_imm(rs1, imm_extended);
+    assert!(
+        to_pc <= u64::from(MAX_ALLOWED_PC),
+        "JALR target exceeds implemented PC address space"
+    );
+    let to_pc = to_pc as u32;
 
     let rd_low_u32 = pc.wrapping_add(DEFAULT_PC_STEP);
     let rd_data = rv64_u32_to_u16_block(rd_low_u32);

--- a/extensions/riscv/circuit/src/jalr/execution.rs
+++ b/extensions/riscv/circuit/src/jalr/execution.rs
@@ -7,13 +7,13 @@ use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
-    program::{DEFAULT_PC_STEP, PC_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
     riscv::{RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
 };
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::core::Rv64JalrExecutor;
-use crate::adapters::rv64_bytes_to_u32;
+use crate::adapters::{rv64_address_add_imm, try_rv64_bytes_to_u32};
 #[cfg(feature = "aot")]
 use crate::common::*;
 
@@ -210,10 +210,26 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait, const ENABLE
     let pc = exec_state.pc();
     let rs1 =
         exec_state.vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.b as u32);
-    let rs1 = rv64_bytes_to_u32(rs1);
-    let to_pc = rs1.wrapping_add(pre_compute.imm_extended);
-    let to_pc = to_pc - (to_pc & 1);
-    debug_assert!(to_pc < (1 << PC_BITS));
+    let Some(rs1) = try_rv64_bytes_to_u32(rs1) else {
+        exec_state.exit_code = Err(ExecutionError::Fail {
+            pc,
+            msg: "JALR base exceeds implemented PC address space",
+        });
+        return;
+    };
+    let unaligned_to_pc = rv64_address_add_imm(rs1, pre_compute.imm_extended);
+    // JALR clears bit 0 before jumping.
+    let to_pc = unaligned_to_pc & !1;
+    let Some(to_pc) = u32::try_from(to_pc)
+        .ok()
+        .filter(|&to_pc| to_pc <= MAX_ALLOWED_PC)
+    else {
+        exec_state.exit_code = Err(ExecutionError::Fail {
+            pc,
+            msg: "JALR target exceeds PC address space",
+        });
+        return;
+    };
     let mut rd = [0u8; RV64_REGISTER_NUM_LIMBS];
     rd[..4].copy_from_slice(&(pc + DEFAULT_PC_STEP).to_le_bytes());
 

--- a/extensions/riscv/circuit/src/jalr/execution.rs
+++ b/extensions/riscv/circuit/src/jalr/execution.rs
@@ -13,7 +13,7 @@ use openvm_instructions::{
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::core::Rv64JalrExecutor;
-use crate::adapters::{rv64_address_add_imm, try_rv64_bytes_to_u32};
+use crate::adapters::{rv64_address_add_imm, rv64_bytes_to_u32};
 #[cfg(feature = "aot")]
 use crate::common::*;
 
@@ -210,26 +210,12 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait, const ENABLE
     let pc = exec_state.pc();
     let rs1 =
         exec_state.vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.b as u32);
-    let Some(rs1) = try_rv64_bytes_to_u32(rs1) else {
-        exec_state.exit_code = Err(ExecutionError::Fail {
-            pc,
-            msg: "JALR base exceeds implemented PC address space",
-        });
-        return;
-    };
+    let rs1 = rv64_bytes_to_u32(rs1);
     let unaligned_to_pc = rv64_address_add_imm(rs1, pre_compute.imm_extended);
     // JALR clears bit 0 before jumping.
     let to_pc = unaligned_to_pc & !1;
-    let Some(to_pc) = u32::try_from(to_pc)
-        .ok()
-        .filter(|&to_pc| to_pc <= MAX_ALLOWED_PC)
-    else {
-        exec_state.exit_code = Err(ExecutionError::Fail {
-            pc,
-            msg: "JALR target exceeds PC address space",
-        });
-        return;
-    };
+    debug_assert!(to_pc <= u64::from(MAX_ALLOWED_PC));
+    let to_pc = to_pc as u32;
     let mut rd = [0u8; RV64_REGISTER_NUM_LIMBS];
     rd[..4].copy_from_slice(&(pc + DEFAULT_PC_STEP).to_le_bytes());
 

--- a/extensions/riscv/circuit/src/jalr/tests.rs
+++ b/extensions/riscv/circuit/src/jalr/tests.rs
@@ -138,9 +138,11 @@ fn set_and_execute<RA: Arena, E: PreflightExecutor<F, RA>>(
     let imm_ext = imm + (imm_sign * 0xffff0000);
     let a = rd_ptr.unwrap_or_else(|| rng.random_range(0..32) << 3);
     let b = rng.random_range(1..32) << 3;
-    let to_pc = rng.random_range(0..(1 << PC_BITS));
+    let imm_signed = (imm_ext as i32) as i64;
+    let min_to_pc = imm_signed.max(0) as u32;
+    let to_pc = rng.random_range(min_to_pc..(1 << PC_BITS));
 
-    let rs1 = rs1.unwrap_or(into_limbs((to_pc as u32).wrapping_sub(imm_ext)));
+    let rs1 = rs1.unwrap_or(into_limbs((i64::from(to_pc) - imm_signed) as u32));
     let rs1 = rs1.map(F::from_u32);
 
     tester.write_bytes(1, b, rs1);
@@ -572,6 +574,12 @@ fn run_jalr_sanity_test() {
     assert_eq!(next_pc & !1, 736481674);
     // u32 pc+4 = 789456124 = 0x2f0e24fc => low u16=0x24fc, high u16=0x2f0e.
     assert_eq!(rd_data, [0x24fc, 0x2f0e, 0, 0]);
+}
+
+#[test]
+#[should_panic(expected = "JALR target exceeds implemented PC address space")]
+fn run_jalr_rejects_low_32_wraparound_test() {
+    run_jalr(0, 0xffff_fff8, 16, false);
 }
 
 #[test]

--- a/extensions/riscv/circuit/src/load_sign_extend/execution.rs
+++ b/extensions/riscv/circuit/src/load_sign_extend/execution.rs
@@ -16,7 +16,7 @@ use openvm_riscv_transpiler::Rv64LoadStoreOpcode::{self, *};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::core::LoadSignExtendExecutor;
-use crate::adapters::{rv64_address_add_imm, try_rv64_bytes_to_u32};
+use crate::adapters::{rv64_address_add_imm, rv64_bytes_to_u32};
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
@@ -235,19 +235,9 @@ unsafe fn execute_e12_impl<
     let pc = exec_state.pc();
     let rs1_bytes: [u8; RV64_REGISTER_NUM_LIMBS] =
         exec_state.vm_read_bytes(RV64_REGISTER_AS, pre_compute.b as u32);
-    let Some(rs1) = try_rv64_bytes_to_u32(rs1_bytes) else {
-        return Err(ExecutionError::Fail {
-            pc,
-            msg: "load base exceeds implemented memory address space",
-        });
-    };
-    let addr = rv64_address_add_imm(rs1, pre_compute.imm_extended);
-    if addr >= RV64_MEMORY_BYTES as u64 {
-        return Err(ExecutionError::Fail {
-            pc,
-            msg: "load effective address out of range",
-        });
-    }
+    let rs1_val = rv64_bytes_to_u32(rs1_bytes);
+    let addr = rv64_address_add_imm(rs1_val, pre_compute.imm_extended);
+    debug_assert!((addr as usize) < RV64_MEMORY_BYTES);
     let ptr_val = addr as u32;
 
     let shift_amount = ptr_val % RV64_REGISTER_NUM_LIMBS as u32;

--- a/extensions/riscv/circuit/src/load_sign_extend/execution.rs
+++ b/extensions/riscv/circuit/src/load_sign_extend/execution.rs
@@ -16,7 +16,7 @@ use openvm_riscv_transpiler::Rv64LoadStoreOpcode::{self, *};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::core::LoadSignExtendExecutor;
-use crate::adapters::rv64_bytes_to_u32;
+use crate::adapters::{rv64_address_add_imm, try_rv64_bytes_to_u32};
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
@@ -235,10 +235,20 @@ unsafe fn execute_e12_impl<
     let pc = exec_state.pc();
     let rs1_bytes: [u8; RV64_REGISTER_NUM_LIMBS] =
         exec_state.vm_read_bytes(RV64_REGISTER_AS, pre_compute.b as u32);
-    let rs1_val = rv64_bytes_to_u32(rs1_bytes);
-    let ptr_val = rs1_val.wrapping_add(pre_compute.imm_extended);
-    // sign_extend([r64{c,g}(b):N]_e)
-    debug_assert!((ptr_val as usize) < RV64_MEMORY_BYTES);
+    let Some(rs1) = try_rv64_bytes_to_u32(rs1_bytes) else {
+        return Err(ExecutionError::Fail {
+            pc,
+            msg: "load base exceeds implemented memory address space",
+        });
+    };
+    let addr = rv64_address_add_imm(rs1, pre_compute.imm_extended);
+    if addr >= RV64_MEMORY_BYTES as u64 {
+        return Err(ExecutionError::Fail {
+            pc,
+            msg: "load effective address out of range",
+        });
+    }
+    let ptr_val = addr as u32;
 
     let shift_amount = ptr_val % RV64_REGISTER_NUM_LIMBS as u32;
     let ptr_val = ptr_val - shift_amount; // aligned ptr

--- a/extensions/riscv/circuit/src/loadstore/execution.rs
+++ b/extensions/riscv/circuit/src/loadstore/execution.rs
@@ -16,7 +16,7 @@ use openvm_riscv_transpiler::Rv64LoadStoreOpcode::{self, *};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::core::LoadStoreExecutor;
-use crate::adapters::{rv64_bytes_to_u32, sign_extend_imm16};
+use crate::adapters::{rv64_address_add_imm, sign_extend_imm16, try_rv64_bytes_to_u32};
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
@@ -205,10 +205,20 @@ unsafe fn execute_e12_impl<
     let pc = exec_state.pc();
     let rs1_bytes: [u8; RV64_REGISTER_NUM_LIMBS] =
         exec_state.vm_read_bytes(RV64_REGISTER_AS, pre_compute.b as u32);
-    let rs1_val = rv64_bytes_to_u32(rs1_bytes);
-    let ptr_val = rs1_val.wrapping_add(pre_compute.imm_extended);
-    // sign_extend([r64{c,g}(b):2]_e)
-    debug_assert!((ptr_val as usize) < RV64_MEMORY_BYTES);
+    let Some(rs1) = try_rv64_bytes_to_u32(rs1_bytes) else {
+        return Err(ExecutionError::Fail {
+            pc,
+            msg: "load/store base exceeds implemented memory address space",
+        });
+    };
+    let addr = rv64_address_add_imm(rs1, pre_compute.imm_extended);
+    if addr >= RV64_MEMORY_BYTES as u64 {
+        return Err(ExecutionError::Fail {
+            pc,
+            msg: "load/store effective address out of range",
+        });
+    }
+    let ptr_val = addr as u32;
 
     let shift_amount = ptr_val % RV64_REGISTER_NUM_LIMBS as u32;
     let ptr_val = ptr_val - shift_amount; // aligned ptr

--- a/extensions/riscv/circuit/src/loadstore/execution.rs
+++ b/extensions/riscv/circuit/src/loadstore/execution.rs
@@ -16,7 +16,7 @@ use openvm_riscv_transpiler::Rv64LoadStoreOpcode::{self, *};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::core::LoadStoreExecutor;
-use crate::adapters::{rv64_address_add_imm, sign_extend_imm16, try_rv64_bytes_to_u32};
+use crate::adapters::{rv64_address_add_imm, rv64_bytes_to_u32, sign_extend_imm16};
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
@@ -205,19 +205,9 @@ unsafe fn execute_e12_impl<
     let pc = exec_state.pc();
     let rs1_bytes: [u8; RV64_REGISTER_NUM_LIMBS] =
         exec_state.vm_read_bytes(RV64_REGISTER_AS, pre_compute.b as u32);
-    let Some(rs1) = try_rv64_bytes_to_u32(rs1_bytes) else {
-        return Err(ExecutionError::Fail {
-            pc,
-            msg: "load/store base exceeds implemented memory address space",
-        });
-    };
-    let addr = rv64_address_add_imm(rs1, pre_compute.imm_extended);
-    if addr >= RV64_MEMORY_BYTES as u64 {
-        return Err(ExecutionError::Fail {
-            pc,
-            msg: "load/store effective address out of range",
-        });
-    }
+    let rs1_val = rv64_bytes_to_u32(rs1_bytes);
+    let addr = rv64_address_add_imm(rs1_val, pre_compute.imm_extended);
+    debug_assert!((addr as usize) < RV64_MEMORY_BYTES);
     let ptr_val = addr as u32;
 
     let shift_amount = ptr_val % RV64_REGISTER_NUM_LIMBS as u32;

--- a/extensions/riscv/circuit/src/loadstore/tests.rs
+++ b/extensions/riscv/circuit/src/loadstore/tests.rs
@@ -566,6 +566,19 @@ fn negative_write_data_tests() {
 }
 
 #[test]
+#[should_panic(expected = "effective address exceeds implemented memory address space")]
+fn negative_32_bit_address_wraparound_test() {
+    run_negative_loadstore_test(
+        LOADBU,
+        Some([0xf8, 0xff, 0xff, 0xff, 0, 0, 0, 0]),
+        Some(16),
+        Some(0),
+        LoadStorePrankValues::default(),
+        false,
+    );
+}
+
+#[test]
 fn negative_wrong_address_space_tests() {
     run_negative_loadstore_test(
         LOADD,


### PR DESCRIPTION
## Summary

- Fix RV64 AUIPC sign-extension so `pc + sign_extend(imm << 12)` is handled consistently in execution, AIR, CUDA tracegen, and RVR lifting/emission.
- Fix JALR and load/store effective-address handling so RV64 register values are not silently truncated or wrapped into the implemented PC/memory address space.
- Restore missing load/store carry/sign constraints and add negative coverage for effective-address overflow.
- Harden RVR dynamic jumps so computed RV64 targets are bounds-checked before narrowing to the dispatch-table PC type.

resolves int-8294