### PR TITLE
refactor(rvr): update rvr to have 64bit PC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8997,6 +8997,7 @@ dependencies = [
 name = "rvr-openvm"
 version = "2.0.0-beta.2"
 dependencies = [
+ "openvm-instructions",
  "openvm-platform",
  "openvm-riscv-guest",
  "openvm-stark-backend",

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -85,11 +85,11 @@ extern "C" {
     );
 
     // ── Instruction dispatch / chip cost ──────────────────────────────
-    pub fn trace_pc_wrapper(state: *mut c_void, pc: u32);
+    pub fn trace_pc_wrapper(state: *mut c_void, pc: u64);
     pub fn trace_chip_wrapper(state: *mut c_void, chip_idx: u32, count: u32);
 
     // ── Block metering ────────────────────────────────────────────────
-    pub fn trace_block_wrapper(state: *mut c_void, pc: u32, block_insn_count: u32);
+    pub fn trace_block_wrapper(state: *mut c_void, pc: u64, block_insn_count: u32);
 
     // ── Hint stream (for extension phantom instructions) ──────────────
     /// Replace the hint stream contents. Forwarded through `openvm_io.c`

--- a/crates/rvr/rvr-openvm-ir/src/block.rs
+++ b/crates/rvr/rvr-openvm-ir/src/block.rs
@@ -45,20 +45,20 @@ pub enum Terminator {
     /// Fall through to pc + 4 (implicit next block).
     FallThrough,
     /// Static jump (JAL). `link_rd` writes pc+4 to rd before jumping.
-    Jump { link_rd: Option<Reg>, target: u32 },
+    Jump { link_rd: Option<Reg>, target: u64 },
     /// Dynamic jump (JALR). `resolved` filled in by CFG analysis.
     JumpDyn {
         link_rd: Option<Reg>,
         rs1: Reg,
         imm: i32,
-        resolved: Vec<u32>,
+        resolved: Vec<u64>,
     },
     /// Conditional branch. Falls through if false.
     Branch {
         cond: BranchCond,
         rs1: Reg,
         rs2: Reg,
-        target: u32,
+        target: u64,
     },
     /// Program exit.
     Exit { code: u32 },
@@ -71,7 +71,7 @@ pub enum Terminator {
 
 impl Terminator {
     /// Returns the set of possible successor PCs (for CFG building).
-    pub fn successors(&self, fall_pc: u32) -> Vec<u32> {
+    pub fn successors(&self, fall_pc: u64) -> Vec<u64> {
         match self {
             Terminator::FallThrough => vec![fall_pc],
             Terminator::Jump { target, .. } => vec![*target],
@@ -120,7 +120,7 @@ impl Terminator {
 /// An instruction at a specific PC.
 #[derive(Debug, Clone)]
 pub struct InstrAt {
-    pub pc: u32,
+    pub pc: u64,
     pub instr: Instr,
     /// Source location from guest ELF debug info.
     pub source_loc: Option<SourceLoc>,
@@ -132,14 +132,14 @@ pub struct InstrAt {
 pub enum LiftedInstr {
     Body(InstrAt),
     Term {
-        pc: u32,
+        pc: u64,
         terminator: Terminator,
         source_loc: Option<SourceLoc>,
     },
 }
 
 impl LiftedInstr {
-    pub fn pc(&self) -> u32 {
+    pub fn pc(&self) -> u64 {
         match self {
             LiftedInstr::Body(i) => i.pc,
             LiftedInstr::Term { pc, .. } => *pc,
@@ -150,15 +150,15 @@ impl LiftedInstr {
 /// A basic block.
 #[derive(Debug, Clone)]
 pub struct Block {
-    pub start_pc: u32,
+    pub start_pc: u64,
     /// End PC (exclusive).
-    pub end_pc: u32,
+    pub end_pc: u64,
     /// Body instructions (no branches/jumps).
     pub instructions: Vec<InstrAt>,
     /// Control flow at the end.
     pub terminator: Terminator,
     /// PC of the terminating instruction.
-    pub terminator_pc: u32,
+    pub terminator_pc: u64,
     /// Source location of the terminating instruction.
     pub terminator_source_loc: Option<SourceLoc>,
 }

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -59,7 +59,7 @@ pub trait ExtInstr: std::fmt::Debug + Send + Sync {
     /// to emit comparison logic and use `branch_to` for control flow.
     ///
     /// Default: delegates to `emit_c`.
-    fn emit_c_term(&self, ctx: &mut dyn ExtEmitCtx, _branch_to: &dyn Fn(u32) -> String) {
+    fn emit_c_term(&self, ctx: &mut dyn ExtEmitCtx, _branch_to: &dyn Fn(u64) -> String) {
         self.emit_c(ctx);
     }
 
@@ -83,7 +83,7 @@ pub trait ExtInstr: std::fmt::Debug + Send + Sync {
 
     /// For terminator extensions: return successor PCs for CFG construction.
     /// Default returns `[fall_pc]` (fall-through behavior).
-    fn successors(&self, fall_pc: u32) -> Vec<u32> {
+    fn successors(&self, fall_pc: u64) -> Vec<u64> {
         vec![fall_pc]
     }
 

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -11,7 +11,7 @@ use openvm_instructions::{
 };
 use rvr_openvm_ir::{AluOp, Block, Instr, InstrAt, LiftedInstr, MulDivOp, Terminator};
 
-use crate::helpers::{assert_pc_in_bounds, pc_in_bounds, sext32};
+use crate::helpers::{assert_valid_pc, is_valid_pc, sext32};
 
 const MAX_VALUES: usize = 16;
 const MAX_ITERATIONS_MULTIPLIER: usize = 20;
@@ -898,7 +898,7 @@ fn get_successors(
                     result.insert(pc + INSTR_SIZE as u64);
                 }
                 Terminator::Jump { target, .. } => {
-                    assert_pc_in_bounds(*target, "JAL target");
+                    assert_valid_pc(*target, "JAL target");
                     result.insert(*target);
                     if is_call_instr {
                         result.insert(pc + INSTR_SIZE as u64);
@@ -913,7 +913,7 @@ fn get_successors(
                             .values
                             .iter()
                             .filter_map(|&t| {
-                                assert_pc_in_bounds(t, "JumpDyn target");
+                                assert_valid_pc(t, "JumpDyn target");
                                 if ctx.pc_to_idx.contains_key(&t) {
                                     Some(t)
                                 } else {
@@ -951,14 +951,14 @@ fn get_successors(
                     }
                 }
                 Terminator::Branch { target, .. } => {
-                    assert_pc_in_bounds(*target, "Branch target");
+                    assert_valid_pc(*target, "Branch target");
                     result.insert(pc + INSTR_SIZE as u64);
                     result.insert(*target);
                 }
                 Terminator::Exit { .. } | Terminator::Trap { .. } => {}
                 Terminator::Extension(ext) => {
                     for target in ext.successors(pc + INSTR_SIZE as u64) {
-                        assert_pc_in_bounds(target, "Extension successor");
+                        assert_valid_pc(target, "Extension successor");
                         result.insert(target);
                     }
                 }
@@ -973,11 +973,7 @@ fn get_successors(
 /// the result exceeds the valid PC address space.
 fn eval_jumpdyn_target(base: u64, imm: i32) -> Option<u64> {
     let target = base.wrapping_add(imm as i64 as u64) & !1u64;
-    if pc_in_bounds(target) {
-        Some(target)
-    } else {
-        None
-    }
+    is_valid_pc(target).then_some(target)
 }
 
 /// Evaluate the JumpDyn target as a multi-value register value:

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -543,18 +543,16 @@ fn simple_process_instr(instr: &Instr, regs: &mut [Option<u64>; NUM_REGS]) {
 }
 
 /// Evaluate the JumpDyn target address: (state[rs1] + imm) & !1.
-fn simple_eval_jumpdyn(regs: &[Option<u64>; NUM_REGS], rs1: u8, imm: i32) -> Option<u32> {
-    regs[rs1 as usize]
-        .and_then(|base| eval_jumpdyn_target(base, imm))
-        .map(|t| t as u32)
+fn simple_eval_jumpdyn(regs: &[Option<u64>; NUM_REGS], rs1: u8, imm: i32) -> Option<u64> {
+    regs[rs1 as usize].and_then(|base| eval_jumpdyn_target(base, imm))
 }
 
 // ── Phase 1: collect_potential_targets ─────────────────────────────────────
 
 fn collect_potential_targets(
     instructions: &[LiftedInstr],
-    pc_to_idx: &HashMap<u32, usize>,
-) -> (BTreeSet<u32>, BTreeSet<u32>, BTreeSet<u32>) {
+    pc_to_idx: &HashMap<u64, usize>,
+) -> (BTreeSet<u64>, BTreeSet<u64>, BTreeSet<u64>) {
     let mut function_entries = BTreeSet::new();
     let mut internal_targets = BTreeSet::new();
     let mut return_sites = BTreeSet::new();
@@ -580,7 +578,7 @@ fn collect_potential_targets(
                 Terminator::Jump { target, .. } => {
                     if is_call(li) {
                         function_entries.insert(*target);
-                        return_sites.insert(pc + INSTR_SIZE);
+                        return_sites.insert(pc + INSTR_SIZE as u64);
                     } else {
                         internal_targets.insert(*target);
                     }
@@ -594,14 +592,14 @@ fn collect_potential_targets(
                         }
                     }
                     if is_call(li) {
-                        return_sites.insert(pc + INSTR_SIZE);
+                        return_sites.insert(pc + INSTR_SIZE as u64);
                     }
                     regs = [None; NUM_REGS];
                     regs[0] = Some(0);
                 }
                 Terminator::Branch { target, .. } => {
                     internal_targets.insert(*target);
-                    internal_targets.insert(pc + INSTR_SIZE);
+                    internal_targets.insert(pc + INSTR_SIZE as u64);
                     regs = [None; NUM_REGS];
                     regs[0] = Some(0);
                 }
@@ -610,7 +608,7 @@ fn collect_potential_targets(
                     regs[0] = Some(0);
                 }
                 Terminator::Extension(ext) => {
-                    for target in ext.successors(pc + INSTR_SIZE) {
+                    for target in ext.successors(pc + INSTR_SIZE as u64) {
                         internal_targets.insert(target);
                     }
                     regs = [None; NUM_REGS];
@@ -625,8 +623,8 @@ fn collect_potential_targets(
 
 // ── Phase 2: build_call_return_map ────────────────────────────────────────
 
-fn build_call_return_map(instructions: &[LiftedInstr]) -> HashMap<u32, HashSet<u32>> {
-    let mut map: HashMap<u32, HashSet<u32>> = HashMap::new();
+fn build_call_return_map(instructions: &[LiftedInstr]) -> HashMap<u64, HashSet<u64>> {
+    let mut map: HashMap<u64, HashSet<u64>> = HashMap::new();
 
     for li in instructions {
         if let LiftedInstr::Term {
@@ -639,7 +637,7 @@ fn build_call_return_map(instructions: &[LiftedInstr]) -> HashMap<u32, HashSet<u
             ..
         } = li
         {
-            let return_site = pc + INSTR_SIZE;
+            let return_site = pc + INSTR_SIZE as u64;
             map.entry(*target).or_default().insert(return_site);
         }
     }
@@ -651,31 +649,31 @@ fn build_call_return_map(instructions: &[LiftedInstr]) -> HashMap<u32, HashSet<u
 
 struct WorklistContext<'a> {
     instructions: &'a [LiftedInstr],
-    pc_to_idx: &'a HashMap<u32, usize>,
-    function_entries: &'a BTreeSet<u32>,
-    return_sites: &'a BTreeSet<u32>,
-    sorted_function_entries: &'a [u32],
-    func_internal_targets: &'a HashMap<u32, HashSet<u32>>,
-    call_return_map: &'a HashMap<u32, HashSet<u32>>,
+    pc_to_idx: &'a HashMap<u64, usize>,
+    function_entries: &'a BTreeSet<u64>,
+    return_sites: &'a BTreeSet<u64>,
+    sorted_function_entries: &'a [u64],
+    func_internal_targets: &'a HashMap<u64, HashSet<u64>>,
+    call_return_map: &'a HashMap<u64, HashSet<u64>>,
 }
 
 struct WorklistResult {
-    successors: HashMap<u32, HashSet<u32>>,
-    resolved_jumps: HashMap<u32, HashSet<u32>>,
+    successors: HashMap<u64, HashSet<u64>>,
+    resolved_jumps: HashMap<u64, HashSet<u64>>,
 }
 
 fn worklist(
     ctx: &WorklistContext<'_>,
-    function_entries: &BTreeSet<u32>,
-    internal_targets: &BTreeSet<u32>,
+    function_entries: &BTreeSet<u64>,
+    internal_targets: &BTreeSet<u64>,
 ) -> WorklistResult {
     let estimated_size = function_entries.len() + internal_targets.len();
-    let mut states: HashMap<u32, RegisterState> = HashMap::with_capacity(estimated_size);
-    let mut work: Vec<u32> = Vec::with_capacity(estimated_size);
-    let mut in_work: HashSet<u32> = HashSet::with_capacity(estimated_size);
-    let mut successors: HashMap<u32, HashSet<u32>> = HashMap::with_capacity(estimated_size);
-    let mut unresolved_dynamic_jumps: HashSet<u32> = HashSet::new();
-    let mut resolved_jumps: HashMap<u32, HashSet<u32>> = HashMap::new();
+    let mut states: HashMap<u64, RegisterState> = HashMap::with_capacity(estimated_size);
+    let mut work: Vec<u64> = Vec::with_capacity(estimated_size);
+    let mut in_work: HashSet<u64> = HashSet::with_capacity(estimated_size);
+    let mut successors: HashMap<u64, HashSet<u64>> = HashMap::with_capacity(estimated_size);
+    let mut unresolved_dynamic_jumps: HashSet<u64> = HashSet::new();
+    let mut resolved_jumps: HashMap<u64, HashSet<u64>> = HashMap::new();
 
     for addr in function_entries.iter().chain(internal_targets.iter()) {
         if in_work.insert(*addr) {
@@ -883,9 +881,9 @@ fn get_successors(
     li: &LiftedInstr,
     state: &RegisterState,
     ctx: &WorklistContext<'_>,
-    unresolved_dynamic_jumps: &mut HashSet<u32>,
-    resolved_jumps: &mut HashMap<u32, HashSet<u32>>,
-) -> HashSet<u32> {
+    unresolved_dynamic_jumps: &mut HashSet<u64>,
+    resolved_jumps: &mut HashMap<u64, HashSet<u64>>,
+) -> HashSet<u64> {
     let mut result = HashSet::new();
     let pc = li.pc();
     let is_call_instr = is_call(li);
@@ -893,17 +891,17 @@ fn get_successors(
     match li {
         LiftedInstr::Body(_) => {
             // Body instructions fall through.
-            result.insert(pc + INSTR_SIZE);
+            result.insert(pc + INSTR_SIZE as u64);
         }
         LiftedInstr::Term { terminator, .. } => {
             match terminator {
                 Terminator::FallThrough => {
-                    result.insert(pc + INSTR_SIZE);
+                    result.insert(pc + INSTR_SIZE as u64);
                 }
                 Terminator::Jump { target, .. } => {
                     result.insert(*target);
                     if is_call_instr {
-                        result.insert(pc + INSTR_SIZE);
+                        result.insert(pc + INSTR_SIZE as u64);
                     }
                 }
                 Terminator::JumpDyn { rs1, imm, .. } => {
@@ -911,7 +909,7 @@ fn get_successors(
                     let addr_val = eval_jumpdyn_multi(state, *rs1, *imm);
 
                     if addr_val.is_constant() && !addr_val.values.is_empty() {
-                        let targets: Vec<u32> = addr_val
+                        let targets: Vec<u64> = addr_val
                             .values
                             .iter()
                             .filter_map(|&t| {
@@ -919,9 +917,8 @@ fn get_successors(
                                     t <= u64::from(MAX_ALLOWED_PC),
                                     "JumpDyn target {t:#x} exceeds PC address space"
                                 );
-                                let pc32 = t as u32;
-                                if ctx.pc_to_idx.contains_key(&pc32) {
-                                    Some(pc32)
+                                if ctx.pc_to_idx.contains_key(&t) {
+                                    Some(t)
                                 } else {
                                     None
                                 }
@@ -933,7 +930,7 @@ fn get_successors(
                             let entry = resolved_jumps.entry(pc).or_default();
                             entry.extend(targets.iter().copied());
                             if is_call_instr {
-                                result.insert(pc + INSTR_SIZE);
+                                result.insert(pc + INSTR_SIZE as u64);
                             }
                         } else {
                             handle_unresolved_jump(
@@ -957,12 +954,12 @@ fn get_successors(
                     }
                 }
                 Terminator::Branch { target, .. } => {
-                    result.insert(pc + INSTR_SIZE);
+                    result.insert(pc + INSTR_SIZE as u64);
                     result.insert(*target);
                 }
                 Terminator::Exit { .. } | Terminator::Trap { .. } => {}
                 Terminator::Extension(ext) => {
-                    for target in ext.successors(pc + INSTR_SIZE) {
+                    for target in ext.successors(pc + INSTR_SIZE as u64) {
                         result.insert(target);
                     }
                 }
@@ -1013,11 +1010,11 @@ fn eval_jumpdyn_multi(state: &RegisterState, rs1: u8, imm: i32) -> RegisterValue
 
 fn handle_unresolved_jump(
     li: &LiftedInstr,
-    pc: u32,
+    pc: u64,
     is_call_instr: bool,
     ctx: &WorklistContext<'_>,
-    unresolved_dynamic_jumps: &mut HashSet<u32>,
-    result: &mut HashSet<u32>,
+    unresolved_dynamic_jumps: &mut HashSet<u64>,
+    result: &mut HashSet<u64>,
 ) {
     if is_return(li) {
         if let Some(func_start) = binary_search_le(ctx.sorted_function_entries, pc) {
@@ -1031,10 +1028,10 @@ fn handle_unresolved_jump(
         }
     } else if is_call_instr {
         result.extend(ctx.function_entries.iter().copied());
-        result.insert(pc + INSTR_SIZE);
+        result.insert(pc + INSTR_SIZE as u64);
     } else if is_indirect_jump(li) {
         let duff_targets =
-            scan_jump_table_targets(ctx.instructions, ctx.pc_to_idx, pc + INSTR_SIZE);
+            scan_jump_table_targets(ctx.instructions, ctx.pc_to_idx, pc + INSTR_SIZE as u64);
         if !duff_targets.is_empty() {
             result.extend(duff_targets);
         }
@@ -1056,9 +1053,9 @@ fn handle_unresolved_jump(
 
 fn scan_jump_table_targets(
     instructions: &[LiftedInstr],
-    pc_to_idx: &HashMap<u32, usize>,
-    start_pc: u32,
-) -> HashSet<u32> {
+    pc_to_idx: &HashMap<u64, usize>,
+    start_pc: u64,
+) -> HashSet<u64> {
     let mut targets = HashSet::new();
     let mut pc = start_pc;
     let mut count = 0;
@@ -1090,7 +1087,7 @@ fn scan_jump_table_targets(
             break;
         }
 
-        pc = li.pc() + INSTR_SIZE;
+        pc = li.pc() + INSTR_SIZE as u64;
         count += 1;
     }
 
@@ -1101,12 +1098,12 @@ fn scan_jump_table_targets(
 
 fn compute_leaders(
     instructions: &[LiftedInstr],
-    pc_to_idx: &HashMap<u32, usize>,
-    successors: &HashMap<u32, HashSet<u32>>,
-    function_entries: &BTreeSet<u32>,
-    internal_targets: &BTreeSet<u32>,
-    return_sites: &BTreeSet<u32>,
-) -> BTreeSet<u32> {
+    pc_to_idx: &HashMap<u64, usize>,
+    successors: &HashMap<u64, HashSet<u64>>,
+    function_entries: &BTreeSet<u64>,
+    internal_targets: &BTreeSet<u64>,
+    return_sites: &BTreeSet<u64>,
+) -> BTreeSet<u64> {
     let mut leaders = BTreeSet::new();
 
     leaders.extend(function_entries.iter().copied());
@@ -1120,7 +1117,7 @@ fn compute_leaders(
         let li = &instructions[idx];
         if is_control_flow(li) {
             leaders.extend(succs.iter().copied());
-            let next_pc = li.pc() + INSTR_SIZE;
+            let next_pc = li.pc() + INSTR_SIZE as u64;
             if pc_to_idx.contains_key(&next_pc) {
                 leaders.insert(next_pc);
             }
@@ -1132,7 +1129,7 @@ fn compute_leaders(
 
 // ── binary_search_le ──────────────────────────────────────────────────────
 
-fn binary_search_le(sorted: &[u32], target: u32) -> Option<u32> {
+fn binary_search_le(sorted: &[u64], target: u64) -> Option<u64> {
     if sorted.is_empty() {
         return None;
     }
@@ -1163,13 +1160,13 @@ fn binary_search_le(sorted: &[u32], target: u32) -> Option<u32> {
 /// function pointer arrays).
 ///
 /// Returns `Vec<Block>` with resolved `JumpDyn` targets filled in.
-pub fn build_blocks(instructions: &[LiftedInstr], extra_targets: &[u32]) -> Vec<Block> {
+pub fn build_blocks(instructions: &[LiftedInstr], extra_targets: &[u64]) -> Vec<Block> {
     if instructions.is_empty() {
         return Vec::new();
     }
 
     // Build PC -> instruction index lookup.
-    let pc_to_idx: HashMap<u32, usize> = instructions
+    let pc_to_idx: HashMap<u64, usize> = instructions
         .iter()
         .enumerate()
         .map(|(i, li)| (li.pc(), i))
@@ -1190,10 +1187,10 @@ pub fn build_blocks(instructions: &[LiftedInstr], extra_targets: &[u32]) -> Vec<
     let call_return_map = build_call_return_map(instructions);
 
     // Sorted function entries for binary_search_le.
-    let sorted_function_entries: Vec<u32> = function_entries.iter().copied().collect();
+    let sorted_function_entries: Vec<u64> = function_entries.iter().copied().collect();
 
     // Group internal targets by enclosing function.
-    let mut func_internal_targets: HashMap<u32, HashSet<u32>> = HashMap::new();
+    let mut func_internal_targets: HashMap<u64, HashSet<u64>> = HashMap::new();
     for target in &internal_targets {
         if let Some(func_start) = binary_search_le(&sorted_function_entries, *target) {
             func_internal_targets
@@ -1237,8 +1234,8 @@ pub fn build_blocks(instructions: &[LiftedInstr], extra_targets: &[u32]) -> Vec<
 /// filling in resolved JumpDyn targets.
 fn build_block_list(
     instructions: &[LiftedInstr],
-    leaders: &BTreeSet<u32>,
-    resolved_jumps: &HashMap<u32, HashSet<u32>>,
+    leaders: &BTreeSet<u64>,
+    resolved_jumps: &HashMap<u64, HashSet<u64>>,
 ) -> Vec<Block> {
     // Max block size; used to flush periodically so the segmentation check in
     // metered mode (which fires at block boundaries) stays granular enough.
@@ -1247,7 +1244,7 @@ fn build_block_list(
 
     // Accumulate body instructions for the current block.
     let mut body: Vec<InstrAt> = Vec::new();
-    let mut block_start_pc: Option<u32> = None;
+    let mut block_start_pc: Option<u64> = None;
 
     for li in instructions {
         let pc = li.pc();
@@ -1260,7 +1257,7 @@ fn build_block_list(
                 let last_body_pc = body.last().unwrap().pc;
                 blocks.push(Block {
                     start_pc: start,
-                    end_pc: last_body_pc + INSTR_SIZE,
+                    end_pc: last_body_pc + INSTR_SIZE as u64,
                     instructions: std::mem::take(&mut body),
                     terminator: Terminator::FallThrough,
                     terminator_pc: last_body_pc,
@@ -1282,7 +1279,7 @@ fn build_block_list(
                     let last_body_pc = body.last().unwrap().pc;
                     blocks.push(Block {
                         start_pc: start,
-                        end_pc: last_body_pc + INSTR_SIZE,
+                        end_pc: last_body_pc + INSTR_SIZE as u64,
                         instructions: std::mem::take(&mut body),
                         terminator: Terminator::FallThrough,
                         terminator_pc: last_body_pc,
@@ -1301,7 +1298,7 @@ fn build_block_list(
                 // Patch resolved targets into JumpDyn.
                 if let Some(targets) = resolved_jumps.get(&pc) {
                     if let Terminator::JumpDyn { resolved, .. } = &mut term {
-                        let mut sorted_targets: Vec<u32> = targets.iter().copied().collect();
+                        let mut sorted_targets: Vec<u64> = targets.iter().copied().collect();
                         sorted_targets.sort_unstable();
                         *resolved = sorted_targets;
                     }
@@ -1310,7 +1307,7 @@ fn build_block_list(
                 let start = block_start_pc.unwrap();
                 blocks.push(Block {
                     start_pc: start,
-                    end_pc: pc + INSTR_SIZE,
+                    end_pc: pc + INSTR_SIZE as u64,
                     instructions: std::mem::take(&mut body),
                     terminator: term,
                     terminator_pc: pc,
@@ -1327,7 +1324,7 @@ fn build_block_list(
             let last_body_pc = body.last().unwrap().pc;
             blocks.push(Block {
                 start_pc: start,
-                end_pc: last_body_pc + INSTR_SIZE,
+                end_pc: last_body_pc + INSTR_SIZE as u64,
                 instructions: std::mem::take(&mut body),
                 terminator: Terminator::FallThrough,
                 terminator_pc: last_body_pc,

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -11,11 +11,19 @@ use openvm_instructions::{
 };
 use rvr_openvm_ir::{AluOp, Block, Instr, InstrAt, LiftedInstr, MulDivOp, Terminator};
 
-use crate::helpers::{assert_valid_pc, is_valid_pc, sext32};
+use crate::helpers::{is_valid_pc, sext32};
 
 const MAX_VALUES: usize = 16;
 const MAX_ITERATIONS_MULTIPLIER: usize = 20;
 const MAX_JUMP_TABLE_SCAN: usize = 256;
+
+/// Error during basic-block (CFG) construction.
+#[derive(Debug, thiserror::Error)]
+pub enum CfgError {
+    /// A statically computable control-flow target exceeds the PC address space.
+    #[error("{what} {target:#x} exceeds PC address space")]
+    PcOutOfBounds { what: &'static str, target: u64 },
+}
 
 // ── RegisterValue ──────────────────────────────────────────────────────────
 
@@ -665,7 +673,7 @@ fn worklist(
     ctx: &WorklistContext<'_>,
     function_entries: &BTreeSet<u64>,
     internal_targets: &BTreeSet<u64>,
-) -> WorklistResult {
+) -> Result<WorklistResult, CfgError> {
     let estimated_size = function_entries.len() + internal_targets.len();
     let mut states: HashMap<u64, RegisterState> = HashMap::with_capacity(estimated_size);
     let mut work: Vec<u64> = Vec::with_capacity(estimated_size);
@@ -712,7 +720,7 @@ fn worklist(
             ctx,
             &mut unresolved_dynamic_jumps,
             &mut resolved_jumps,
-        );
+        )?;
 
         let state_out = transfer(li, state);
 
@@ -732,10 +740,10 @@ fn worklist(
         successors.entry(pc).or_default().extend(succs);
     }
 
-    WorklistResult {
+    Ok(WorklistResult {
         successors,
         resolved_jumps,
-    }
+    })
 }
 
 // ── Phase 4: transfer ─────────────────────────────────────────────────────
@@ -882,7 +890,7 @@ fn get_successors(
     ctx: &WorklistContext<'_>,
     unresolved_dynamic_jumps: &mut HashSet<u64>,
     resolved_jumps: &mut HashMap<u64, HashSet<u64>>,
-) -> HashSet<u64> {
+) -> Result<HashSet<u64>, CfgError> {
     let mut result = HashSet::new();
     let pc = li.pc();
     let is_call_instr = is_call(li);
@@ -898,7 +906,12 @@ fn get_successors(
                     result.insert(pc + INSTR_SIZE as u64);
                 }
                 Terminator::Jump { target, .. } => {
-                    assert_valid_pc(*target, "JAL target");
+                    if !is_valid_pc(*target) {
+                        return Err(CfgError::PcOutOfBounds {
+                            what: "JAL target",
+                            target: *target,
+                        });
+                    }
                     result.insert(*target);
                     if is_call_instr {
                         result.insert(pc + INSTR_SIZE as u64);
@@ -909,18 +922,18 @@ fn get_successors(
                     let addr_val = eval_jumpdyn_multi(state, *rs1, *imm);
 
                     if addr_val.is_constant() && !addr_val.values.is_empty() {
-                        let targets: Vec<u64> = addr_val
-                            .values
-                            .iter()
-                            .filter_map(|&t| {
-                                assert_valid_pc(t, "JumpDyn target");
-                                if ctx.pc_to_idx.contains_key(&t) {
-                                    Some(t)
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect();
+                        let mut targets: Vec<u64> = Vec::new();
+                        for &t in &addr_val.values {
+                            if !is_valid_pc(t) {
+                                return Err(CfgError::PcOutOfBounds {
+                                    what: "JumpDyn target",
+                                    target: t,
+                                });
+                            }
+                            if ctx.pc_to_idx.contains_key(&t) {
+                                targets.push(t);
+                            }
+                        }
 
                         if !targets.is_empty() {
                             result.extend(targets.iter().copied());
@@ -951,14 +964,24 @@ fn get_successors(
                     }
                 }
                 Terminator::Branch { target, .. } => {
-                    assert_valid_pc(*target, "Branch target");
+                    if !is_valid_pc(*target) {
+                        return Err(CfgError::PcOutOfBounds {
+                            what: "Branch target",
+                            target: *target,
+                        });
+                    }
                     result.insert(pc + INSTR_SIZE as u64);
                     result.insert(*target);
                 }
                 Terminator::Exit { .. } | Terminator::Trap { .. } => {}
                 Terminator::Extension(ext) => {
                     for target in ext.successors(pc + INSTR_SIZE as u64) {
-                        assert_valid_pc(target, "Extension successor");
+                        if !is_valid_pc(target) {
+                            return Err(CfgError::PcOutOfBounds {
+                                what: "Extension successor",
+                                target,
+                            });
+                        }
                         result.insert(target);
                     }
                 }
@@ -966,7 +989,7 @@ fn get_successors(
         }
     }
 
-    result
+    Ok(result)
 }
 
 /// Compute a single JumpDyn target: `(base + imm) & !1`, returning `None` if
@@ -1155,9 +1178,12 @@ fn binary_search_le(sorted: &[u64], target: u64) -> Option<u64> {
 /// function pointer arrays).
 ///
 /// Returns `Vec<Block>` with resolved `JumpDyn` targets filled in.
-pub fn build_blocks(instructions: &[LiftedInstr], extra_targets: &[u64]) -> Vec<Block> {
+pub fn build_blocks(
+    instructions: &[LiftedInstr],
+    extra_targets: &[u64],
+) -> Result<Vec<Block>, CfgError> {
     if instructions.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     // Build PC -> instruction index lookup.
@@ -1209,7 +1235,7 @@ pub fn build_blocks(instructions: &[LiftedInstr], extra_targets: &[u64]) -> Vec<
     let WorklistResult {
         successors,
         resolved_jumps,
-    } = worklist(&ctx, &function_entries, &internal_targets);
+    } = worklist(&ctx, &function_entries, &internal_targets)?;
 
     // Phase 7: Compute leaders.
     let leaders = compute_leaders(
@@ -1222,7 +1248,7 @@ pub fn build_blocks(instructions: &[LiftedInstr], extra_targets: &[u64]) -> Vec<
     );
 
     // Build blocks by splitting at leaders and patching resolved JumpDyn targets.
-    build_block_list(instructions, &leaders, &resolved_jumps)
+    Ok(build_block_list(instructions, &leaders, &resolved_jumps))
 }
 
 /// Split the flat instruction list into `Block`s at leader boundaries,

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -7,12 +7,11 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP as INSTR_SIZE, MAX_ALLOWED_PC},
-    riscv::RV64_NUM_REGISTERS as NUM_REGS,
+    program::DEFAULT_PC_STEP as INSTR_SIZE, riscv::RV64_NUM_REGISTERS as NUM_REGS,
 };
 use rvr_openvm_ir::{AluOp, Block, Instr, InstrAt, LiftedInstr, MulDivOp, Terminator};
 
-use crate::helpers::sext32;
+use crate::helpers::{assert_pc_in_bounds, pc_in_bounds, sext32};
 
 const MAX_VALUES: usize = 16;
 const MAX_ITERATIONS_MULTIPLIER: usize = 20;
@@ -899,6 +898,7 @@ fn get_successors(
                     result.insert(pc + INSTR_SIZE as u64);
                 }
                 Terminator::Jump { target, .. } => {
+                    assert_pc_in_bounds(*target, "JAL target");
                     result.insert(*target);
                     if is_call_instr {
                         result.insert(pc + INSTR_SIZE as u64);
@@ -913,10 +913,7 @@ fn get_successors(
                             .values
                             .iter()
                             .filter_map(|&t| {
-                                assert!(
-                                    t <= u64::from(MAX_ALLOWED_PC),
-                                    "JumpDyn target {t:#x} exceeds PC address space"
-                                );
+                                assert_pc_in_bounds(t, "JumpDyn target");
                                 if ctx.pc_to_idx.contains_key(&t) {
                                     Some(t)
                                 } else {
@@ -954,12 +951,14 @@ fn get_successors(
                     }
                 }
                 Terminator::Branch { target, .. } => {
+                    assert_pc_in_bounds(*target, "Branch target");
                     result.insert(pc + INSTR_SIZE as u64);
                     result.insert(*target);
                 }
                 Terminator::Exit { .. } | Terminator::Trap { .. } => {}
                 Terminator::Extension(ext) => {
                     for target in ext.successors(pc + INSTR_SIZE as u64) {
+                        assert_pc_in_bounds(target, "Extension successor");
                         result.insert(target);
                     }
                 }
@@ -974,7 +973,7 @@ fn get_successors(
 /// the result exceeds the valid PC address space.
 fn eval_jumpdyn_target(base: u64, imm: i32) -> Option<u64> {
     let target = base.wrapping_add(imm as i64 as u64) & !1u64;
-    if target <= u64::from(MAX_ALLOWED_PC) {
+    if pc_in_bounds(target) {
         Some(target)
     } else {
         None

--- a/crates/rvr/rvr-openvm-lift/src/convert.rs
+++ b/crates/rvr/rvr-openvm-lift/src/convert.rs
@@ -40,7 +40,7 @@ where
     let mut lifted = Vec::new();
 
     for (pc, insn, _debug_info) in exe.program.enumerate_by_pc() {
-        match lift_instruction(&insn, pc, extensions) {
+        match lift_instruction(&insn, u64::from(pc), extensions) {
             Some(mut li) => {
                 if let Some(loc) = source_lookup(pc) {
                     match &mut li {
@@ -72,8 +72,8 @@ where
 /// function pointer arrays, and other code pointers embedded in read-only data.
 pub fn scan_init_memory_for_code_pointers<F: PrimeField32>(
     exe: &VmExe<F>,
-    valid_pcs: &HashSet<u32>,
-) -> Vec<u32> {
+    valid_pcs: &HashSet<u64>,
+) -> Vec<u64> {
     // Collect all bytes in address space 2 (main memory).
     let mut mem_bytes: std::collections::BTreeMap<u32, u8> = std::collections::BTreeMap::new();
     for (&(addr_space, addr), &byte) in &exe.init_memory {
@@ -96,7 +96,7 @@ pub fn scan_init_memory_for_code_pointers<F: PrimeField32>(
             mem_bytes.get(&(addr + 2)),
             mem_bytes.get(&(addr + 3)),
         ) {
-            let val = u32::from_le_bytes([b0, b1, b2, b3]);
+            let val = u64::from(u32::from_le_bytes([b0, b1, b2, b3]));
             if valid_pcs.contains(&val) {
                 targets.push(val);
             }

--- a/crates/rvr/rvr-openvm-lift/src/convert.rs
+++ b/crates/rvr/rvr-openvm-lift/src/convert.rs
@@ -12,7 +12,7 @@ use crate::{extension::ExtensionRegistry, opcode::lift_instruction};
 #[derive(Debug, thiserror::Error)]
 pub enum ConvertError {
     #[error("unrecognized opcode {opcode} at pc {pc:#x}")]
-    UnrecognizedOpcode { opcode: usize, pc: u32 },
+    UnrecognizedOpcode { opcode: usize, pc: u64 },
 }
 
 /// Convert a VmExe to a vector of lifted IR instructions.
@@ -57,7 +57,7 @@ where
             None => {
                 return Err(ConvertError::UnrecognizedOpcode {
                     opcode: insn.opcode.as_usize(),
-                    pc,
+                    pc: u64::from(pc),
                 });
             }
         }

--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -120,7 +120,7 @@ pub trait RvrExtension<F: PrimeField32>: Send + Sync {
     /// Try to lift an OpenVM instruction into IR.
     /// Return `None` if this extension doesn't handle the opcode.
     /// Chip indices are stored on the extension and baked into IR nodes.
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr>;
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr>;
 
     /// C header files for this extension, as `(filename, content)` pairs.
     /// Written to the output directory and `#include`d in the generated code.
@@ -211,7 +211,7 @@ impl<F: PrimeField32> ExtensionRegistry<F> {
 
     /// Try to lift an instruction through all registered extensions.
     /// Returns the first successful lift, or `None`.
-    pub fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    pub fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         self.extensions
             .iter()
             .find_map(|ext| ext.try_lift(insn, pc))

--- a/crates/rvr/rvr-openvm-lift/src/helpers.rs
+++ b/crates/rvr/rvr-openvm-lift/src/helpers.rs
@@ -1,4 +1,6 @@
-use openvm_instructions::{instruction::Instruction, riscv::RV64_REGISTER_NUM_LIMBS};
+use openvm_instructions::{
+    instruction::Instruction, program::MAX_ALLOWED_PC, riscv::RV64_REGISTER_NUM_LIMBS,
+};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 /// Decode register index from an OpenVM operand.
@@ -21,4 +23,20 @@ pub fn decode_imm_cg<F: PrimeField32>(insn: &Instruction<F>) -> u32 {
 /// Sign-extend a 32-bit value into an RV64 register value.
 pub fn sext32(value: u32) -> u64 {
     value as i32 as i64 as u64
+}
+
+/// True if `pc` lies within the implemented PC address space (`<= MAX_ALLOWED_PC`).
+#[inline]
+pub fn pc_in_bounds(pc: u64) -> bool {
+    pc <= u64::from(MAX_ALLOWED_PC)
+}
+
+/// Assert that a control-flow `target` is within the PC address space, panicking
+/// otherwise. `what` labels the source in the message, e.g. `"JAL target"`.
+#[inline]
+pub fn assert_pc_in_bounds(target: u64, what: &str) {
+    assert!(
+        pc_in_bounds(target),
+        "{what} {target:#x} exceeds PC address space"
+    );
 }

--- a/crates/rvr/rvr-openvm-lift/src/helpers.rs
+++ b/crates/rvr/rvr-openvm-lift/src/helpers.rs
@@ -27,16 +27,16 @@ pub fn sext32(value: u32) -> u64 {
 
 /// True if `pc` lies within the implemented PC address space (`<= MAX_ALLOWED_PC`).
 #[inline]
-pub fn pc_in_bounds(pc: u64) -> bool {
+pub fn is_valid_pc(pc: u64) -> bool {
     pc <= u64::from(MAX_ALLOWED_PC)
 }
 
 /// Assert that a control-flow `target` is within the PC address space, panicking
 /// otherwise. `what` labels the source in the message, e.g. `"JAL target"`.
 #[inline]
-pub fn assert_pc_in_bounds(target: u64, what: &str) {
+pub fn assert_valid_pc(target: u64, what: &str) {
     assert!(
-        pc_in_bounds(target),
+        is_valid_pc(target),
         "{what} {target:#x} exceeds PC address space"
     );
 }

--- a/crates/rvr/rvr-openvm-lift/src/helpers.rs
+++ b/crates/rvr/rvr-openvm-lift/src/helpers.rs
@@ -30,13 +30,3 @@ pub fn sext32(value: u32) -> u64 {
 pub fn is_valid_pc(pc: u64) -> bool {
     pc <= u64::from(MAX_ALLOWED_PC)
 }
-
-/// Assert that a control-flow `target` is within the PC address space, panicking
-/// otherwise. `what` labels the source in the message, e.g. `"JAL target"`.
-#[inline]
-pub fn assert_valid_pc(target: u64, what: &str) {
-    assert!(
-        is_valid_pc(target),
-        "{what} {target:#x} exceeds PC address space"
-    );
-}

--- a/crates/rvr/rvr-openvm-lift/src/lib.rs
+++ b/crates/rvr/rvr-openvm-lift/src/lib.rs
@@ -15,7 +15,7 @@ pub mod extension;
 pub mod helpers;
 pub mod opcode;
 
-pub use cfg::build_blocks;
+pub use cfg::{build_blocks, CfgError};
 pub use convert::{
     convert_vmexe_to_ir, convert_vmexe_to_ir_with_debug, scan_init_memory_for_code_pointers,
     ConvertError,

--- a/crates/rvr/rvr-openvm-lift/src/opcode.rs
+++ b/crates/rvr/rvr-openvm-lift/src/opcode.rs
@@ -33,7 +33,7 @@ use crate::{
 /// the opcode, its `try_lift` is called.
 pub fn lift_instruction<F: PrimeField32>(
     insn: &Instruction<F>,
-    pc: u32,
+    pc: u64,
     extensions: &ExtensionRegistry<F>,
 ) -> Option<LiftedInstr> {
     let opcode = insn.opcode.as_usize();
@@ -286,7 +286,7 @@ fn sign_extend_12(val: u32) -> i32 {
 // ============= Instruction Lifters =============
 
 /// Helper to create a body instruction.
-pub fn body(pc: u32, instr: Instr) -> LiftedInstr {
+pub fn body(pc: u64, instr: Instr) -> LiftedInstr {
     LiftedInstr::Body(InstrAt {
         pc,
         instr,
@@ -295,7 +295,7 @@ pub fn body(pc: u32, instr: Instr) -> LiftedInstr {
 }
 
 /// Helper to create a terminator instruction.
-pub fn term(pc: u32, terminator: Terminator) -> LiftedInstr {
+pub fn term(pc: u64, terminator: Terminator) -> LiftedInstr {
     LiftedInstr::Term {
         pc,
         terminator,
@@ -304,7 +304,7 @@ pub fn term(pc: u32, terminator: Terminator) -> LiftedInstr {
 }
 
 /// Lift ALU instruction (R-type when e!=0, I-type when e==0).
-fn lift_alu<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_alu<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -327,7 +327,7 @@ fn lift_alu<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: AluOp) 
 }
 
 /// Lift shift instruction (R-type when e!=0, I-type shamt when e==0).
-fn lift_shift<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_shift<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -349,7 +349,7 @@ fn lift_shift<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: AluOp
 }
 
 /// Lift MUL/DIV/REM R-type instruction.
-fn lift_muldiv<F: PrimeField32>(insn: &Instruction<F>, pc: u32, op: MulDivOp) -> LiftedInstr {
+fn lift_muldiv<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: MulDivOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
     let rs2 = decode_reg(insn.c);
@@ -373,7 +373,7 @@ fn is_public_values_instruction<F: PrimeField32>(insn: &Instruction<F>) -> bool 
 
 fn lift_public_values_store<F: PrimeField32>(
     insn: &Instruction<F>,
-    pc: u32,
+    pc: u64,
     extensions: &ExtensionRegistry<F>,
 ) -> Option<LiftedInstr> {
     if is_public_values_instruction(insn) {
@@ -385,7 +385,7 @@ fn lift_public_values_store<F: PrimeField32>(
 
 fn lift_load<F: PrimeField32>(
     insn: &Instruction<F>,
-    pc: u32,
+    pc: u64,
     width: MemWidth,
     signed: bool,
 ) -> Option<LiftedInstr> {
@@ -416,7 +416,7 @@ fn lift_load<F: PrimeField32>(
 /// OpenVM encoding: rs2=a/4, rs1=b/4, imm low16=c, sign=g!=0
 fn lift_store<F: PrimeField32>(
     insn: &Instruction<F>,
-    pc: u32,
+    pc: u64,
     width: MemWidth,
 ) -> Option<LiftedInstr> {
     if !is_memory_instruction(insn) {
@@ -440,11 +440,11 @@ fn lift_store<F: PrimeField32>(
 
 /// Lift branch instruction.
 /// OpenVM encoding: rs1=a/4, rs2=b/4, offset=c as signed (BabyBear modular)
-fn lift_branch<F: PrimeField32>(insn: &Instruction<F>, pc: u32, cond: BranchCond) -> LiftedInstr {
+fn lift_branch<F: PrimeField32>(insn: &Instruction<F>, pc: u64, cond: BranchCond) -> LiftedInstr {
     let rs1 = decode_reg(insn.a);
     let rs2 = decode_reg(insn.b);
     let offset = field_to_i32(insn.c);
-    let target = (pc as i64 + offset as i64) as u32;
+    let target = (pc as i64 + offset as i64) as u64;
 
     term(
         pc,
@@ -459,10 +459,10 @@ fn lift_branch<F: PrimeField32>(insn: &Instruction<F>, pc: u32, cond: BranchCond
 
 /// Lift JAL instruction.
 /// OpenVM encoding: rd=a/4, offset=c as signed (BabyBear modular)
-fn lift_jal<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
+fn lift_jal<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let offset = field_to_i32(insn.c);
-    let target = (pc as i64 + offset as i64) as u32;
+    let target = (pc as i64 + offset as i64) as u64;
 
     let link_rd = if rd != 0 { Some(rd) } else { None };
     term(pc, Terminator::Jump { link_rd, target })
@@ -470,7 +470,7 @@ fn lift_jal<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
 
 /// Lift JALR instruction.
 /// OpenVM encoding: rd=a/4, rs1=b/4, imm low16=c, sign=g!=0
-fn lift_jalr<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
+fn lift_jalr<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
     let imm = decode_imm_cg(insn) as i32;
@@ -489,7 +489,7 @@ fn lift_jalr<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
 
 /// Lift LUI instruction.
 /// OpenVM encoding: rd=a/4, upper20=c << 12
-fn lift_lui<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
+fn lift_lui<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let upper = field_to_u32(insn.c);
     let value = upper << 12;
@@ -502,11 +502,11 @@ fn lift_lui<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
 
 /// Lift AUIPC instruction.
 /// OpenVM encoding: rd=a/4, upper20 = c << 8 (from rrs.rs: c = (imm & 0xfffff000) >> 8)
-fn lift_auipc<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
+fn lift_auipc<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let shifted = field_to_u32(insn.c);
     let upper = shifted << 8; // reconstruct the upper 20 bits with low 12 zeros
-    let value = (pc as u64).wrapping_add(sext32(upper));
+    let value = pc.wrapping_add(sext32(upper));
 
     if rd == 0 {
         return body(pc, Instr::Nop);
@@ -516,7 +516,7 @@ fn lift_auipc<F: PrimeField32>(insn: &Instruction<F>, pc: u32) -> LiftedInstr {
 
 /// Lift W-suffix ALU instruction (R-type when e!=0, I-type when e==0).
 /// Result is the low 32 bits of the operation, sign-extended to 64 bits.
-fn lift_alu_w<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_alu_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -538,7 +538,7 @@ fn lift_alu_w<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: AluOp
 
 /// Lift W-suffix shift instruction (R-type when e!=0, I-type shamt when e==0).
 /// Shamt is 5-bit (W shifts operate on 32-bit values regardless of register width).
-fn lift_shift_w<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_shift_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -558,7 +558,7 @@ fn lift_shift_w<F: PrimeField32>(insn: &Instruction<F>, pc: u32, e: u32, op: Alu
 }
 
 /// Lift W-suffix MUL/DIV/REM R-type instruction.
-fn lift_muldiv_w<F: PrimeField32>(insn: &Instruction<F>, pc: u32, op: MulDivOp) -> LiftedInstr {
+fn lift_muldiv_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: MulDivOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
     let rs2 = decode_reg(insn.c);
@@ -571,7 +571,7 @@ fn lift_muldiv_w<F: PrimeField32>(insn: &Instruction<F>, pc: u32, op: MulDivOp) 
 // ============= System / IO Instructions =============
 
 /// Lift a system PHANTOM sub-instruction.
-fn lift_phantom(sys: SysPhantom, pc: u32) -> LiftedInstr {
+fn lift_phantom(sys: SysPhantom, pc: u64) -> LiftedInstr {
     match sys {
         // Nop, CtStart, CtEnd — no-ops for execution
         SysPhantom::Nop | SysPhantom::CtStart | SysPhantom::CtEnd => body(pc, Instr::Nop),

--- a/crates/rvr/rvr-openvm/Cargo.toml
+++ b/crates/rvr/rvr-openvm/Cargo.toml
@@ -13,6 +13,7 @@ rvr-openvm-ext-ffi-common.workspace = true
 rvr-openvm-ir.workspace = true
 rvr-openvm-lift.workspace = true
 
+openvm-instructions.workspace = true
 openvm-platform.workspace = true
 openvm-riscv-guest = { workspace = true, default-features = false }
 openvm-stark-backend.workspace = true

--- a/crates/rvr/rvr-openvm/c/block/openvm_block_instret.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_instret.h
@@ -12,7 +12,7 @@
 #include "openvm_state.h"
 
 static __attribute__((always_inline)) inline uint8_t begin_block(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count) {
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count) {
   state->instret += block_insn_count;
   trace_block(state, pc, block_insn_count);
   return 0;

--- a/crates/rvr/rvr-openvm/c/block/openvm_block_metered.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_metered.h
@@ -8,7 +8,7 @@
 #include "openvm_state.h"
 
 static __attribute__((always_inline)) inline uint8_t begin_block(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count) {
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count) {
   trace_block(state, pc, block_insn_count);
   return 0;
 }

--- a/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
@@ -13,7 +13,7 @@ typedef struct MeteredSegmentCheckpointResult {
 } MeteredSegmentCheckpointResult;
 
 static __attribute__((always_inline)) inline uint8_t begin_block(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count) {
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count) {
   return trace_block_with_segment_check(state, pc, block_insn_count);
 }
 

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -62,8 +62,8 @@ static __attribute__((always_inline)) inline void rv_set_status_at(
 }
 
 static __attribute__((always_inline)) inline uint32_t rv_dispatch_index(
-    uint32_t pc) {
-  return (pc - RV_TEXT_START) >> 2;
+    uint64_t pc) {
+  return (uint32_t)((pc - RV_TEXT_START) >> 2);
 }
 
 /* True if pc names a 4-byte dispatch slot in the dense table. The alignment

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -61,9 +61,9 @@ static __attribute__((always_inline)) inline void rv_set_status_at(
   rv_set_status(state, status, exit_code);
 }
 
-static __attribute__((always_inline)) inline uint32_t rv_dispatch_index(
+static __attribute__((always_inline)) inline uint64_t rv_dispatch_index(
     uint64_t pc) {
-  return (uint32_t)((pc - RV_TEXT_START) >> 2);
+  return (pc - RV_TEXT_START) >> 2;
 }
 
 /* True if pc names a 4-byte dispatch slot in the dense table. The alignment

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -50,7 +50,7 @@ void trace_mem_access_u64_range_wrapper(RvState* s, uint32_t base_addr,
 
 /* ── Instruction dispatch / chip cost ──────────────────────────────── */
 
-void trace_pc_wrapper(RvState* s, uint32_t pc) { trace_pc(s, pc); }
+void trace_pc_wrapper(RvState* s, uint64_t pc) { trace_pc(s, pc); }
 
 /* Extension FFI staticlibs use this to add chip rows on top of what the
  * per-block chip accounting in the generated `block_*` functions has already
@@ -75,6 +75,6 @@ void trace_chip_wrapper(RvState* s, uint32_t chip_idx, uint32_t count) {
 
 /* ── Block metering ────────────────────────────────────────────────── */
 
-void trace_block_wrapper(RvState* s, uint32_t pc, uint32_t block_insn_count) {
+void trace_block_wrapper(RvState* s, uint64_t pc, uint32_t block_insn_count) {
   trace_block(s, pc, block_insn_count);
 }

--- a/crates/rvr/rvr-openvm/c/suspender/openvm_suspender_instret_limit.h
+++ b/crates/rvr/rvr-openvm/c/suspender/openvm_suspender_instret_limit.h
@@ -8,7 +8,7 @@
 #include "openvm_state.h"
 
 static __attribute__((always_inline)) inline uint8_t should_suspend(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count,
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count,
     uint8_t suspend_signal) {
   if (unlikely(state->instret > state->target_instret)) {
     state->instret -= block_insn_count;

--- a/crates/rvr/rvr-openvm/c/suspender/openvm_suspender_none.h
+++ b/crates/rvr/rvr-openvm/c/suspender/openvm_suspender_none.h
@@ -8,7 +8,7 @@
 #include "openvm_state.h"
 
 static __attribute__((always_inline)) inline uint8_t should_suspend(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count,
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count,
     uint8_t suspend_signal) {
   return 0;
 }

--- a/crates/rvr/rvr-openvm/c/suspender/openvm_suspender_segment_boundary.h
+++ b/crates/rvr/rvr-openvm/c/suspender/openvm_suspender_segment_boundary.h
@@ -12,7 +12,7 @@
 #include "openvm_state.h"
 
 static __attribute__((always_inline)) inline uint8_t should_suspend(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count,
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count,
     uint8_t suspend_signal) {
   return suspend_signal;
 }

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -306,7 +306,7 @@ static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
 }
 
 static __attribute__((always_inline)) inline void trace_pc(
-    RvState* restrict state, uint32_t pc) {}
+    RvState* restrict state, uint64_t pc) {}
 
 static __attribute__((always_inline)) inline void trace_chip(
     RvState* restrict state, uint32_t chip_idx, uint32_t count) {
@@ -314,7 +314,7 @@ static __attribute__((always_inline)) inline void trace_chip(
 }
 
 static __attribute__((always_inline)) inline void trace_block(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count) {
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count) {
   if (unlikely(state->tracer->check_counter < block_insn_count)) {
     state->tracer->on_check(state->tracer);
   }
@@ -322,7 +322,7 @@ static __attribute__((always_inline)) inline void trace_block(
 }
 
 static __attribute__((always_inline)) inline uint8_t
-trace_block_with_segment_check(RvState* restrict state, uint32_t pc,
+trace_block_with_segment_check(RvState* restrict state, uint64_t pc,
                                uint32_t block_insn_count) {
   if (unlikely(state->tracer->check_counter < block_insn_count)) {
     if (state->tracer->on_check(state->tracer)) {

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -72,7 +72,7 @@ static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
     uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_pc(
-    RvState* restrict state, uint32_t pc) {}
+    RvState* restrict state, uint64_t pc) {}
 
 static __attribute__((always_inline)) inline void trace_chip(
     RvState* restrict state, uint32_t chip_idx, uint32_t count) {
@@ -80,6 +80,6 @@ static __attribute__((always_inline)) inline void trace_chip(
 }
 
 static __attribute__((always_inline)) inline void trace_block(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count) {}
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count) {}
 
 #endif /* OPENVM_TRACER_METERED_COST_H */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -68,12 +68,12 @@ static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
     uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_pc(
-    RvState* restrict state, uint32_t pc) {}
+    RvState* restrict state, uint64_t pc) {}
 
 static __attribute__((always_inline)) inline void trace_chip(
     RvState* restrict state, uint32_t chip_idx, uint32_t count) {}
 
 static __attribute__((always_inline)) inline void trace_block(
-    RvState* restrict state, uint32_t pc, uint32_t block_insn_count) {}
+    RvState* restrict state, uint64_t pc, uint32_t block_insn_count) {}
 
 #endif /* OPENVM_TRACER_PURE_H */

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -48,7 +48,7 @@ pub const DEFERRAL_PAGE_BUF_CAP: usize = 1 << 16;
 
 /// Generate the `openvm_constants.h` content with compile-time constants
 /// for the C tracer headers.
-pub fn constants_header(text_start: u32, text_end: u32, dispatch_table_size: usize) -> String {
+pub fn constants_header(text_start: u64, text_end: u64, dispatch_table_size: usize) -> String {
     let memory_mask = MEM_SIZE as u64 - 1;
     let byte_space_ptrs_per_leaf_bits = BYTE_SPACE_PTRS_PER_LEAF.ilog2();
     let deferral_ptrs_per_leaf_bits = DEFERRAL_PTRS_PER_LEAF.ilog2();
@@ -65,8 +65,8 @@ static constexpr uint32_t AS_PUBLIC_VALUES = {AS_PUBLIC_VALUES};
 static constexpr uint32_t AS_DEFERRAL = {DEFERRAL_AS};
 static constexpr uint32_t WORD_SIZE = {WORD_SIZE};
 static constexpr uint32_t DEFERRAL_DIGEST_SIZE = {DEFERRAL_DIGEST_SIZE};
-static constexpr uint32_t RV_TEXT_START = 0x{text_start:08x}u;
-static constexpr uint32_t RV_TEXT_END = 0x{text_end:08x}u;
+static constexpr uint64_t RV_TEXT_START = 0x{text_start:08x}ull;
+static constexpr uint64_t RV_TEXT_END = 0x{text_end:08x}ull;
 static constexpr uint32_t RV_DISPATCH_TABLE_SIZE = {dispatch_table_size}u;
 static constexpr uint32_t TRACER_BYTE_SPACE_PTRS_PER_LEAF_BITS = {byte_space_ptrs_per_leaf_bits};
 static constexpr uint32_t TRACER_DEFERRAL_PTRS_PER_LEAF_BITS = {deferral_ptrs_per_leaf_bits};

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -94,7 +94,7 @@ pub fn emit_instr(ctx: &mut EmitContext, instr: &Instr) {
 /// Context for terminator code generation (dispatch / tail-call info).
 pub struct TermCtx<'a> {
     /// Set of valid block start PCs (for direct tail calls).
-    pub valid_blocks: &'a std::collections::HashSet<u32>,
+    pub valid_blocks: &'a std::collections::HashSet<u64>,
 }
 
 /// Emit C code for a terminator using tail calls between blocks.
@@ -102,7 +102,8 @@ pub struct TermCtx<'a> {
 /// Static targets use direct tail calls: `return block_0x...(args);`
 /// Dynamic targets go through the dispatch table: `return dispatch_table[idx](args);`
 /// Exit/suspend/trap save hot regs to state and return to `rv_execute`.
-pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &TermCtx) {
+pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u64, tc: &TermCtx) {
+    // TODO(rvr): remove constant 4
     let next_pc = pc.wrapping_add(4);
     let args = ctx.tail_call_args();
     match term {
@@ -111,7 +112,7 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
         }
         Terminator::Jump { link_rd, target } => {
             if let Some(rd) = link_rd {
-                ctx.write_reg(*rd, &hex_u32(next_pc));
+                ctx.write_reg(*rd, &hex_u64(next_pc));
             }
             emit_tail_call(ctx, *target, &args, tc.valid_blocks);
         }
@@ -127,7 +128,7 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
                 base
             };
             if let Some(rd) = link_rd {
-                ctx.write_reg(*rd, &hex_u32(next_pc));
+                ctx.write_reg(*rd, &hex_u64(next_pc));
             }
             let imm_val = *imm;
             let next_pc = if imm_val == 0 {
@@ -169,7 +170,7 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
             } else {
                 format!(
                     "[[clang::musttail]] return dispatch_table[rv_dispatch_index({})]({args});",
-                    hex_u32(*target)
+                    hex_u64(*target)
                 )
             };
             ctx.write_line(&format!("if ({cmp}) {{"));
@@ -181,7 +182,7 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
             ctx.sync_regs_to_state();
             ctx.write_line(&format!(
                 "rv_set_status_at(state, {}, OPENVM_EXEC_TERMINATED, {code});",
-                hex_u32(pc)
+                hex_u64(pc)
             ));
             ctx.write_line("return;");
         }
@@ -190,19 +191,19 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
             ctx.sync_regs_to_state();
             ctx.write_line(&format!(
                 "rv_set_status_at(state, {}, OPENVM_EXEC_TRAPPED, 0);",
-                hex_u32(pc)
+                hex_u64(pc)
             ));
             ctx.write_line(&format!("/* TRAP: {escaped} */"));
             ctx.write_line("return;");
         }
         Terminator::Extension(ext) => {
-            let branch_to = |target: u32| -> String {
+            let branch_to = |target: u64| -> String {
                 if tc.valid_blocks.contains(&target) {
                     format!("[[clang::musttail]] return block_0x{target:08x}({args});")
                 } else {
                     format!(
                         "[[clang::musttail]] return dispatch_table[rv_dispatch_index({})]({args});",
-                        hex_u32(target)
+                        hex_u64(target)
                     )
                 }
             };
@@ -215,9 +216,9 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u32, tc: &T
 /// block; otherwise falls back to the dispatch table.
 fn emit_tail_call(
     ctx: &mut EmitContext,
-    target: u32,
+    target: u64,
     args: &str,
-    valid_blocks: &std::collections::HashSet<u32>,
+    valid_blocks: &std::collections::HashSet<u64>,
 ) {
     if valid_blocks.contains(&target) {
         ctx.write_line(&format!(
@@ -226,7 +227,7 @@ fn emit_tail_call(
     } else {
         ctx.write_line(&format!(
             "[[clang::musttail]] return dispatch_table[rv_dispatch_index({})]({args});",
-            hex_u32(target)
+            hex_u64(target)
         ));
     }
 }

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -1,6 +1,7 @@
 //! C code generation for IR instructions and terminators.
 use std::collections::HashSet;
 
+use openvm_instructions::program::DEFAULT_PC_STEP;
 use rvr_openvm_ir::*;
 
 use super::context::EmitContext;
@@ -104,8 +105,7 @@ pub struct TermCtx<'a> {
 /// Dynamic targets go through the dispatch table: `return dispatch_table[idx](args);`
 /// Exit/suspend/trap save hot regs to state and return to `rv_execute`.
 pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u64, tc: &TermCtx) {
-    // TODO(rvr): remove constant 4
-    let next_pc = pc.wrapping_add(4);
+    let next_pc = pc.wrapping_add(u64::from(DEFAULT_PC_STEP));
     let args = ctx.tail_call_args();
     match term {
         Terminator::FallThrough => {

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -150,10 +150,9 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u64, tc: &T
             ));
             ctx.write_line(&format!("  [[clang::musttail]] return rv_trap({args});"));
             ctx.write_line("}");
-            let next_pc_u32 = ctx.materialize_u32(&format!("(uint32_t){next_pc}"));
-            ctx.write_line(&format!("state->pc = {next_pc_u32};"));
+            ctx.write_line(&format!("state->pc = {next_pc};"));
             ctx.write_line(&format!(
-                "[[clang::musttail]] return dispatch_table[rv_dispatch_index({next_pc_u32})]({args});"
+                "[[clang::musttail]] return dispatch_table[rv_dispatch_index({next_pc})]({args});"
             ));
         }
         Terminator::Branch {

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -1,4 +1,5 @@
 //! C code generation for IR instructions and terminators.
+use std::collections::HashSet;
 
 use rvr_openvm_ir::*;
 
@@ -94,7 +95,7 @@ pub fn emit_instr(ctx: &mut EmitContext, instr: &Instr) {
 /// Context for terminator code generation (dispatch / tail-call info).
 pub struct TermCtx<'a> {
     /// Set of valid block start PCs (for direct tail calls).
-    pub valid_blocks: &'a std::collections::HashSet<u64>,
+    pub valid_blocks: &'a HashSet<u64>,
 }
 
 /// Emit C code for a terminator using tail calls between blocks.
@@ -213,12 +214,7 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u64, tc: &T
 
 /// Emit a tail call to a known PC. Uses a direct call if the target is a valid
 /// block; otherwise falls back to the dispatch table.
-fn emit_tail_call(
-    ctx: &mut EmitContext,
-    target: u64,
-    args: &str,
-    valid_blocks: &std::collections::HashSet<u64>,
-) {
+fn emit_tail_call(ctx: &mut EmitContext, target: u64, args: &str, valid_blocks: &HashSet<u64>) {
     if valid_blocks.contains(&target) {
         ctx.write_line(&format!(
             "[[clang::musttail]] return block_0x{target:08x}({args});"

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -310,7 +310,7 @@ impl EmitContext {
     /// the per-block chip update emitted at block entry by
     /// `CProject::emit_block_function`, not here.
     pub fn trace_pc(&mut self, pc: u64) {
-        self.write_line(&format!("trace_pc(state, 0x{pc:08x}u);"));
+        self.write_line(&format!("trace_pc(state, 0x{pc:016x}ull);"));
     }
 
     pub fn extern_call(&mut self, name: &str, args: &[&str]) {

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -310,7 +310,7 @@ impl EmitContext {
     /// the per-block chip update emitted at block entry by
     /// `CProject::emit_block_function`, not here.
     pub fn trace_pc(&mut self, pc: u64) {
-        self.write_line(&format!("trace_pc(state, 0x{pc:016x}ull);"));
+        self.write_line(&format!("trace_pc(state, 0x{pc:08x}ull);"));
     }
 
     pub fn extern_call(&mut self, name: &str, args: &[&str]) {

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -309,7 +309,7 @@ impl EmitContext {
     /// Emit a trace_pc call. Per-instruction chip accounting is rolled into
     /// the per-block chip update emitted at block entry by
     /// `CProject::emit_block_function`, not here.
-    pub fn trace_pc(&mut self, pc: u32) {
+    pub fn trace_pc(&mut self, pc: u64) {
         self.write_line(&format!("trace_pc(state, 0x{pc:08x}u);"));
     }
 

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -105,7 +105,7 @@ pub struct CProject {
     /// `None` in pure mode (no chip metadata requested); must be set in metered modes.
     pub pc_to_chip: Option<Vec<TraceChipIndex>>,
     /// Program PC base (used to compute pc_to_chip index).
-    pub pc_base: u32,
+    pub pc_base: u64,
     /// Per-AIR widths for MeteredCost precomputation. Indexed by chip index.
     pub chip_widths: Option<Vec<u64>>,
     /// Compile with native debug info (`-g -fno-omit-frame-pointer`).
@@ -318,11 +318,11 @@ impl CProject {
             .replace('\t', "\\t")
     }
 
-    fn block_end_pc(&self, block: &Block) -> u32 {
+    fn block_end_pc(&self, block: &Block) -> u64 {
         block.terminator_pc.saturating_add(4)
     }
 
-    fn dispatch_max_pc(blocks: &[Block], entry_point: u32, text_start: u32) -> u32 {
+    fn dispatch_max_pc(blocks: &[Block], entry_point: u64, text_start: u64) -> u64 {
         blocks
             .iter()
             .map(|b| b.start_pc)
@@ -331,7 +331,7 @@ impl CProject {
             .unwrap_or(text_start)
     }
 
-    fn dispatch_table_size(text_start: u32, text_end: u32) -> usize {
+    fn dispatch_table_size(text_start: u64, text_end: u64) -> usize {
         debug_assert!(text_end >= text_start);
         ((text_end - text_start) / 4 + 1) as usize
     }
@@ -358,7 +358,7 @@ impl CProject {
 
     /// Look up the chip index for a given PC. Must only be called in metered
     /// modes; panics if `pc_to_chip` is unset.
-    fn chip_idx_for_pc(&self, pc: u32) -> TraceChipIndex {
+    fn chip_idx_for_pc(&self, pc: u64) -> TraceChipIndex {
         let mapping = self
             .pc_to_chip
             .as_ref()
@@ -376,8 +376,8 @@ impl CProject {
     pub fn write_all<F: PrimeField32>(
         &self,
         blocks: &[Block],
-        entry_point: u32,
-        text_start: u32,
+        entry_point: u64,
+        text_start: u64,
         extensions: &ExtensionRegistry<F>,
     ) -> io::Result<()> {
         let text_end = Self::dispatch_max_pc(blocks, entry_point, text_start);
@@ -398,8 +398,8 @@ impl CProject {
 
     fn write_constants(
         &self,
-        text_start: u32,
-        text_end: u32,
+        text_start: u64,
+        text_end: u64,
         dispatch_table_size: usize,
     ) -> io::Result<()> {
         let h = constants_header(text_start, text_end, dispatch_table_size);
@@ -597,7 +597,7 @@ impl CProject {
         let num_partitions = blocks.len().div_ceil(self.blocks_per_partition);
 
         // Precompute valid block PCs for tail-call target validation.
-        let valid_blocks: HashSet<u32> = blocks.iter().map(|b| b.start_pc).collect();
+        let valid_blocks: HashSet<u64> = blocks.iter().map(|b| b.start_pc).collect();
 
         for part_idx in 0..num_partitions {
             let start = part_idx * self.blocks_per_partition;
@@ -621,7 +621,7 @@ impl CProject {
         Ok(())
     }
 
-    fn emit_block_function(&self, out: &mut String, block: &Block, valid_blocks: &HashSet<u32>) {
+    fn emit_block_function(&self, out: &mut String, block: &Block, valid_blocks: &HashSet<u64>) {
         let pc = block.start_pc;
         let end_pc = self.block_end_pc(block);
         let insn_count = block.insn_count();
@@ -727,7 +727,7 @@ impl CProject {
         writeln!(out).unwrap();
     }
 
-    fn emit_segment_checkpoint(&self, out: &mut String, pc: u32) {
+    fn emit_segment_checkpoint(&self, out: &mut String, pc: u64) {
         writeln!(
             out,
             "    MeteredSegmentCheckpointResult checkpoint = metered_segment_checkpoint(state, check_counter);"
@@ -758,7 +758,7 @@ impl CProject {
         self.emit_instret_suspend_check(out, pc, insn_count);
     }
 
-    fn emit_metered_counter_check(&self, out: &mut String, pc: u32, insn_count: u32) {
+    fn emit_metered_counter_check(&self, out: &mut String, pc: u64, insn_count: u32) {
         let args = self.fn_args_from_params();
         writeln!(out, "    if (unlikely(check_counter < {insn_count}u)) {{").unwrap();
         writeln!(
@@ -769,7 +769,7 @@ impl CProject {
         writeln!(out, "    }}").unwrap();
     }
 
-    fn emit_instret_suspend_check(&self, out: &mut String, pc: u32, insn_count: u32) {
+    fn emit_instret_suspend_check(&self, out: &mut String, pc: u64, insn_count: u32) {
         debug_assert_ne!(
             self.tracer_mode,
             TracerMode::Metered,
@@ -784,7 +784,7 @@ impl CProject {
         writeln!(out, "    }}").unwrap();
     }
 
-    fn emit_suspend_return(&self, out: &mut String, pc: u32) {
+    fn emit_suspend_return(&self, out: &mut String, pc: u64) {
         let save = self.save_hot_regs_call();
         writeln!(out, "        {save}").unwrap();
         writeln!(
@@ -811,7 +811,7 @@ impl CProject {
         }
 
         let mut chip_counts: BTreeMap<u32, u32> = BTreeMap::new();
-        let mut increment_chip_count = |pc: u32| match self.chip_idx_for_pc(pc) {
+        let mut increment_chip_count = |pc: u64| match self.chip_idx_for_pc(pc) {
             TraceChipIndex::Chip(chip) => *chip_counts.entry(chip.as_u32()).or_insert(0) += 1,
             TraceChipIndex::NoChip => {}
         };
@@ -851,7 +851,7 @@ impl CProject {
     fn emit_source_annotation(
         &self,
         out: &mut String,
-        pc: u32,
+        pc: u64,
         opname: &str,
         source_loc: Option<&SourceLoc>,
     ) {
@@ -876,8 +876,8 @@ impl CProject {
     fn write_dispatch(
         &self,
         blocks: &[Block],
-        entry_point: u32,
-        text_start: u32,
+        entry_point: u64,
+        text_start: u64,
     ) -> io::Result<()> {
         let name = &self.name;
         let mut src = String::with_capacity(16 * 1024);
@@ -914,12 +914,12 @@ impl CProject {
         let table_size = Self::dispatch_table_size(text_start, max_pc);
 
         // Build block-start lookup.
-        let block_starts: std::collections::HashMap<u32, u32> =
+        let block_starts: std::collections::HashMap<u64, u64> =
             blocks.iter().map(|b| (b.start_pc, b.start_pc)).collect();
 
         writeln!(src, "BlockFn dispatch_table[RV_DISPATCH_TABLE_SIZE] = {{").unwrap();
         for i in 0..table_size {
-            let pc = text_start + (i as u32) * 4;
+            let pc = text_start + (i as u64) * 4;
             if block_starts.contains_key(&pc) {
                 writeln!(src, "    block_0x{pc:08x},").unwrap();
             } else {

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -943,7 +943,7 @@ impl CProject {
         writeln!(src, "        rv_trap({args_from_state});").unwrap();
         writeln!(src, "        return;").unwrap();
         writeln!(src, "    }}").unwrap();
-        writeln!(src, "    uint32_t idx = rv_dispatch_index(state->pc);").unwrap();
+        writeln!(src, "    uint64_t idx = rv_dispatch_index(state->pc);").unwrap();
         writeln!(src, "    dispatch_table[idx]({args_from_state});").unwrap();
         writeln!(src, "    return;").unwrap();
         writeln!(src, "}}").unwrap();

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -752,7 +752,7 @@ impl CProject {
 
         writeln!(
             out,
-            "    uint8_t suspend_signal = begin_block(state, 0x{pc:08x}u, {insn_count}u);"
+            "    uint8_t suspend_signal = begin_block(state, 0x{pc:016x}ull, {insn_count}u);"
         )
         .unwrap();
         self.emit_instret_suspend_check(out, pc, insn_count);
@@ -777,7 +777,7 @@ impl CProject {
         );
         writeln!(
             out,
-            "    if (unlikely(should_suspend(state, 0x{pc:08x}u, {insn_count}u, suspend_signal))) {{"
+            "    if (unlikely(should_suspend(state, 0x{pc:016x}ull, {insn_count}u, suspend_signal))) {{"
         )
         .unwrap();
         self.emit_suspend_return(out, pc);
@@ -789,7 +789,7 @@ impl CProject {
         writeln!(out, "        {save}").unwrap();
         writeln!(
             out,
-            "        rv_set_status_at(state, 0x{pc:08x}u, OPENVM_EXEC_SUSPENDED, 0);"
+            "        rv_set_status_at(state, 0x{pc:016x}ull, OPENVM_EXEC_SUSPENDED, 0);"
         )
         .unwrap();
         writeln!(out, "        return;").unwrap();
@@ -943,11 +943,7 @@ impl CProject {
         writeln!(src, "        rv_trap({args_from_state});").unwrap();
         writeln!(src, "        return;").unwrap();
         writeln!(src, "    }}").unwrap();
-        writeln!(
-            src,
-            "    uint32_t idx = rv_dispatch_index((uint32_t)state->pc);"
-        )
-        .unwrap();
+        writeln!(src, "    uint32_t idx = rv_dispatch_index(state->pc);").unwrap();
         writeln!(src, "    dispatch_table[idx]({args_from_state});").unwrap();
         writeln!(src, "    return;").unwrap();
         writeln!(src, "}}").unwrap();

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -752,7 +752,7 @@ impl CProject {
 
         writeln!(
             out,
-            "    uint8_t suspend_signal = begin_block(state, 0x{pc:016x}ull, {insn_count}u);"
+            "    uint8_t suspend_signal = begin_block(state, 0x{pc:08x}ull, {insn_count}u);"
         )
         .unwrap();
         self.emit_instret_suspend_check(out, pc, insn_count);
@@ -777,7 +777,7 @@ impl CProject {
         );
         writeln!(
             out,
-            "    if (unlikely(should_suspend(state, 0x{pc:016x}ull, {insn_count}u, suspend_signal))) {{"
+            "    if (unlikely(should_suspend(state, 0x{pc:08x}ull, {insn_count}u, suspend_signal))) {{"
         )
         .unwrap();
         self.emit_suspend_return(out, pc);
@@ -789,7 +789,7 @@ impl CProject {
         writeln!(out, "        {save}").unwrap();
         writeln!(
             out,
-            "        rv_set_status_at(state, 0x{pc:016x}ull, OPENVM_EXEC_SUSPENDED, 0);"
+            "        rv_set_status_at(state, 0x{pc:08x}ull, OPENVM_EXEC_SUSPENDED, 0);"
         )
         .unwrap();
         writeln!(out, "        return;").unwrap();

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -142,6 +142,8 @@ impl RvrCompiled {
 pub enum CompileError {
     #[error("IR conversion failed: {0}")]
     Convert(#[from] rvr_openvm_lift::ConvertError),
+    #[error("CFG construction failed: {0}")]
+    Cfg(#[from] rvr_openvm_lift::CfgError),
     #[error("C project write failed under {}: {source}", path.display())]
     CProject {
         path: PathBuf,
@@ -359,7 +361,7 @@ fn compile_impl<F: PrimeField32>(
 
     let valid_pcs: std::collections::HashSet<u64> = ir.iter().map(|li| li.pc()).collect();
     let extra_targets = scan_init_memory_for_code_pointers(exe, &valid_pcs);
-    let blocks = build_blocks(&ir, &extra_targets);
+    let blocks = build_blocks(&ir, &extra_targets)?;
 
     let temp_root = std::env::temp_dir();
     let temp_dir = tempfile::Builder::new()

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -357,7 +357,7 @@ fn compile_impl<F: PrimeField32>(
             .and_then(|debug_map| debug_map.get(pc).cloned())
     })?;
 
-    let valid_pcs: std::collections::HashSet<u32> = ir.iter().map(|li| li.pc()).collect();
+    let valid_pcs: std::collections::HashSet<u64> = ir.iter().map(|li| li.pc()).collect();
     let extra_targets = scan_init_memory_for_code_pointers(exe, &valid_pcs);
     let blocks = build_blocks(&ir, &extra_targets);
 
@@ -372,7 +372,7 @@ fn compile_impl<F: PrimeField32>(
     let output_dir = temp_dir.path();
 
     let mut project = CProject::new(output_dir, &base_name, opts.tracer_mode);
-    project.pc_base = exe.program.pc_base;
+    project.pc_base = u64::from(exe.program.pc_base);
     if let Some(suspend_policy) = opts.suspend_policy {
         project.suspend_policy = suspend_policy;
     }
@@ -403,8 +403,8 @@ fn compile_impl<F: PrimeField32>(
 
     project.native_debug_info = opts.native_debug_info;
 
-    let entry_point = exe.pc_start;
-    let text_start = exe.program.pc_base;
+    let entry_point = u64::from(exe.pc_start);
+    let text_start = u64::from(exe.program.pc_base);
     project
         .write_all(&blocks, entry_point, text_start, opts.extensions)
         .map_err(|source| CompileError::CProject {

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -132,7 +132,7 @@ impl Fp2RvrExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for Fp2RvrExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
         self.try_lift_fp2(insn, pc, opcode)
     }
@@ -153,7 +153,7 @@ impl Fp2RvrExtension {
     fn try_lift_fp2<F: PrimeField32>(
         &self,
         insn: &Instruction<F>,
-        pc: u32,
+        pc: u64,
         opcode: usize,
     ) -> Option<LiftedInstr> {
         let base_offset = Fp2Opcode::CLASS_OFFSET;

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -270,7 +270,7 @@ impl ModularRvrExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for ModularRvrExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if let Some(lifted) = self.try_lift_modular(insn, pc, opcode) {
@@ -342,7 +342,7 @@ impl ModularRvrExtension {
     fn try_lift_modular<F: PrimeField32>(
         &self,
         insn: &Instruction<F>,
-        pc: u32,
+        pc: u64,
         opcode: usize,
     ) -> Option<LiftedInstr> {
         let base_offset = Rv64ModularArithmeticOpcode::CLASS_OFFSET;
@@ -451,7 +451,7 @@ impl ModularRvrExtension {
     fn try_lift_phantom<F: PrimeField32>(
         &self,
         insn: &Instruction<F>,
-        pc: u32,
+        pc: u64,
     ) -> Option<LiftedInstr> {
         let c_val = insn.c.as_canonical_u32();
         let discriminant = (c_val & 0xffff) as u16;

--- a/extensions/bigint/rvr/src/lib.rs
+++ b/extensions/bigint/rvr/src/lib.rs
@@ -129,9 +129,9 @@ pub struct Int256BranchEqInstr {
     /// Register index holding pointer to second operand.
     pub rs2_reg: Reg,
     /// PC to jump to if condition is true.
-    pub target_pc: u32,
+    pub target_pc: u64,
     /// PC to fall through to if condition is false.
-    pub fall_pc: u32,
+    pub fall_pc: u64,
     /// If true, branch on *not* equal (BNE); otherwise branch on equal (BEQ).
     pub is_ne: bool,
     /// Chip index for metering. See [`Int256AluInstr::chip_idx`].
@@ -147,7 +147,7 @@ impl ExtInstr for Int256BranchEqInstr {
         // Terminators use emit_c_term instead.
     }
 
-    fn emit_c_term(&self, ctx: &mut dyn ExtEmitCtx, branch_to: &dyn Fn(u32) -> String) {
+    fn emit_c_term(&self, ctx: &mut dyn ExtEmitCtx, branch_to: &dyn Fn(u64) -> String) {
         let rs1 = ctx.read_reg(self.rs1_reg);
         let rs2 = ctx.read_reg(self.rs2_reg);
         let fn_name = if self.is_ne {
@@ -167,7 +167,7 @@ impl ExtInstr for Int256BranchEqInstr {
         Box::new(self.clone())
     }
 
-    fn successors(&self, _fall_pc: u32) -> Vec<u32> {
+    fn successors(&self, _fall_pc: u64) -> Vec<u64> {
         vec![self.target_pc, self.fall_pc]
     }
 
@@ -184,9 +184,9 @@ pub struct Int256BranchLtInstr {
     /// Register index holding pointer to second operand.
     pub rs2_reg: Reg,
     /// PC to jump to if condition is true.
-    pub target_pc: u32,
+    pub target_pc: u64,
     /// PC to fall through to if condition is false.
-    pub fall_pc: u32,
+    pub fall_pc: u64,
     /// The branch-less-than variant (selects the FFI function at codegen time).
     pub op: Int256BranchLtOp,
     /// Chip index for metering. See [`Int256AluInstr::chip_idx`].
@@ -202,7 +202,7 @@ impl ExtInstr for Int256BranchLtInstr {
         // Terminators use emit_c_term instead.
     }
 
-    fn emit_c_term(&self, ctx: &mut dyn ExtEmitCtx, branch_to: &dyn Fn(u32) -> String) {
+    fn emit_c_term(&self, ctx: &mut dyn ExtEmitCtx, branch_to: &dyn Fn(u64) -> String) {
         let rs1 = ctx.read_reg(self.rs1_reg);
         let rs2 = ctx.read_reg(self.rs2_reg);
         let cond = ctx.extern_call_expr("uint8_t", self.op.ffi_name(), &["state", &rs1, &rs2]);
@@ -217,7 +217,7 @@ impl ExtInstr for Int256BranchLtInstr {
         Box::new(self.clone())
     }
 
-    fn successors(&self, _fall_pc: u32) -> Vec<u32> {
+    fn successors(&self, _fall_pc: u64) -> Vec<u64> {
         vec![self.target_pc, self.fall_pc]
     }
 
@@ -316,7 +316,7 @@ fn decode_imm<F: PrimeField32>(f: F) -> i32 {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for Int256Extension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         // ── ALU body instructions ───────────────────────────────────────
@@ -373,8 +373,8 @@ impl<F: PrimeField32> RvrExtension<F> for Int256Extension {
             let rs1_reg = decode_reg(insn.a);
             let rs2_reg = decode_reg(insn.b);
             let imm = decode_imm(insn.c);
-            let target_pc = (pc as i32 + imm) as u32;
-            let fall_pc = pc + DEFAULT_PC_STEP;
+            let target_pc = (pc as i64 + imm as i64) as u64;
+            let fall_pc = pc + DEFAULT_PC_STEP as u64;
             let chip_idx = self.chip_idx_for_opcode(opcode);
 
             return Some(LiftedInstr::Term {
@@ -404,8 +404,8 @@ impl<F: PrimeField32> RvrExtension<F> for Int256Extension {
             let rs1_reg = decode_reg(insn.a);
             let rs2_reg = decode_reg(insn.b);
             let imm = decode_imm(insn.c);
-            let target_pc = (pc as i32 + imm) as u32;
-            let fall_pc = pc + DEFAULT_PC_STEP;
+            let target_pc = (pc as i64 + imm as i64) as u64;
+            let fall_pc = pc + DEFAULT_PC_STEP as u64;
             let chip_idx = self.chip_idx_for_opcode(opcode);
 
             return Some(LiftedInstr::Term {
@@ -442,7 +442,7 @@ impl Int256Extension {
     fn lift_alu<F: PrimeField32>(
         &self,
         insn: &Instruction<F>,
-        pc: u32,
+        pc: u64,
         op: Int256AluOp,
     ) -> LiftedInstr {
         let rd_reg = decode_reg(insn.a);

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -160,7 +160,7 @@ impl DeferralRvrExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == DeferralOpcode::CALL.global_opcode_usize() {

--- a/extensions/ecc/rvr/src/lib.rs
+++ b/extensions/ecc/rvr/src/lib.rs
@@ -165,7 +165,7 @@ impl EccExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for EccExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         let ecc_base = Rv64WeierstrassOpcode::CLASS_OFFSET;

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -104,7 +104,7 @@ impl KeccakExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for KeccakExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == KeccakfOpcode::KECCAKF.global_opcode_usize() {

--- a/extensions/pairing/rvr/src/lib.rs
+++ b/extensions/pairing/rvr/src/lib.rs
@@ -84,7 +84,7 @@ impl Default for PairingExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for PairingExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode != SystemOpcode::PHANTOM.global_opcode_usize() {

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -196,7 +196,7 @@ impl Rv64IoExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for Rv64IoExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == Rv64HintStoreOpcode::HINT_STORED.global_opcode_usize() {
@@ -314,7 +314,7 @@ impl Default for Rv64IExtension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for Rv64IExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         if insn.opcode.as_usize() != SystemOpcode::PHANTOM.global_opcode_usize() {
             return None;
         }

--- a/extensions/sha2/rvr/src/lib.rs
+++ b/extensions/sha2/rvr/src/lib.rs
@@ -127,7 +127,7 @@ impl Sha2Extension {
 }
 
 impl<F: PrimeField32> RvrExtension<F> for Sha2Extension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u32) -> Option<LiftedInstr> {
+    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == Rv64Sha2Opcode::SHA256.global_opcode_usize() {


### PR DESCRIPTION
update rvr to have 64bit PC. This PR consist of multiple parts:
1) Updating Intermediate Representations to have 64bit PC instead of 32bit
2) Updating Lifter to use 64bit PC
3) Updating Emitter to use 64bit PC for its function arguments, update PC related constants to 64bit.
4) Adding boundary checks during compile-time for statically computable PCs (`JAL` and branching instructions)

resolves INT-8319