### PR TITLE
fix(codec): reject non-canonical field encodings during deserialization

### DIFF
--- a/crates/sdk/src/codec.rs
+++ b/crates/sdk/src/codec.rs
@@ -585,7 +585,14 @@ impl Decode for Option<FriLogUpPartialProof<F>> {
         }
 
         // Reconstruct the field element from the u32 value
-        let logup_pow_witness = F::from_u32(value);
+        let modulus = F::ORDER_U32;
+        if value >= modulus {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Non-canonical field element in logup witness: {value} >= {modulus}"),
+            ));
+        }
+        let logup_pow_witness = F::from_canonical_u32(value);
         Ok(Some(FriLogUpPartialProof { logup_pow_witness }))
     }
 }
@@ -631,7 +638,14 @@ impl Decode for F {
         reader.read_exact(&mut bytes)?;
 
         let value = u32::from_le_bytes(bytes);
-        Ok(F::from_u32(value))
+        let modulus = F::ORDER_U32;
+        if value >= modulus {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Non-canonical field element: {value} >= {modulus}"),
+            ));
+        }
+        Ok(F::from_canonical_u32(value))
     }
 }
 


### PR DESCRIPTION
The proof deserializer accepted non-canonical field encodings via F::fromu32, allowing multiple distinct byte sequences to decode into the same field element.The proof deserializer accepted non-canonical field encodings via F::from_u32, allowing multiple distinct byte sequences to decode into the same field element. This fix adds a bounds check that rejects any value ≥ F::ORDER_U32, restoring the canonical serialization invariant and eliminating proof malleability.