### PR TITLE
refactor: rvr 64bit address ptr

### DIFF
--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -45,27 +45,27 @@ pub const DEFAULT_SEGMENT_CHECK_INSNS: u32 = 1000;
 
 extern "C" {
     // ── Memory access (single u64 word, data) ─────────────────────────
-    pub fn rd_mem_u64_wrapper(state: *mut c_void, addr: u32) -> u64;
+    pub fn rd_mem_u64_wrapper(state: *mut c_void, addr: u64) -> u64;
 
     // ── Memory access (single u64 word, trace-only) ───────────────────
-    pub fn trace_rd_mem_u64_wrapper(state: *mut c_void, addr: u32, val: u64);
+    pub fn trace_rd_mem_u64_wrapper(state: *mut c_void, addr: u64, val: u64);
 
     // ── Memory access (u64-word ranges, data) ───────────────────────
     pub fn rd_mem_u64_range_wrapper(
         state: *mut c_void,
-        base_addr: u32,
+        base_addr: u64,
         out: *mut u64,
         num_words: u32,
     );
     pub fn wr_mem_u64_range_wrapper(
         state: *mut c_void,
-        base_addr: u32,
+        base_addr: u64,
         vals: *const u64,
         num_words: u32,
     );
     pub fn trace_mem_access_u64_range_wrapper(
         state: *mut c_void,
-        base_addr: u32,
+        base_addr: u64,
         num_words: u32,
         addr_space: u32,
     );
@@ -73,13 +73,13 @@ extern "C" {
     // ── Memory access (u64-word ranges, trace-only) ───────────────────
     pub fn trace_rd_mem_u64_range_wrapper(
         state: *mut c_void,
-        base_addr: u32,
+        base_addr: u64,
         vals: *const u64,
         num_words: u32,
     );
     pub fn trace_wr_mem_u64_range_wrapper(
         state: *mut c_void,
-        base_addr: u32,
+        base_addr: u64,
         vals: *const u64,
         num_words: u32,
     );
@@ -131,7 +131,7 @@ pub fn u64s_as_u32s_mut(lanes: &mut [u64]) -> &mut [u32] {
 /// # Safety
 /// `state` must be a valid `RvState` pointer; the byte range
 /// `[base_addr, base_addr + out.len() * WORD_SIZE)` must lie within guest memory.
-pub unsafe fn rd_mem_words_traced(state: *mut c_void, base_addr: u32, out: &mut [u64]) {
+pub unsafe fn rd_mem_words_traced(state: *mut c_void, base_addr: u64, out: &mut [u64]) {
     debug_assert!(
         !out.is_empty(),
         "rd_mem_words_traced requires a non-empty range"
@@ -150,7 +150,7 @@ pub unsafe fn rd_mem_words_traced(state: *mut c_void, base_addr: u32, out: &mut 
 /// # Safety
 /// `state` must be a valid `RvState` pointer; the byte range
 /// `[base_addr, base_addr + vals.len() * WORD_SIZE)` must lie within guest memory.
-pub unsafe fn wr_mem_words_traced(state: *mut c_void, base_addr: u32, vals: &[u64]) {
+pub unsafe fn wr_mem_words_traced(state: *mut c_void, base_addr: u64, vals: &[u64]) {
     debug_assert!(
         !vals.is_empty(),
         "wr_mem_words_traced requires a non-empty range"
@@ -169,7 +169,7 @@ pub unsafe fn wr_mem_words_traced(state: *mut c_void, base_addr: u32, vals: &[u6
 /// `state` must be a valid `RvState` pointer.
 pub unsafe fn trace_mem_access_range(
     state: *mut c_void,
-    base_addr: u32,
+    base_addr: u64,
     num_words: u32,
     addr_space: u32,
 ) {

--- a/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.c
+++ b/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.c
@@ -1,12 +1,14 @@
 #include "openvm_check_mem_bounds.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-__attribute__((noreturn, cold)) void abort_oob(uint32_t start, size_t size,
+__attribute__((noreturn, cold)) void abort_oob(uint64_t start, size_t size,
                                                size_t mem_size) {
   fprintf(stderr,
-          "Memory access out of bounds: start=%u size=%zu memory_size=%zu\n",
+          "Memory access out of bounds: start=%" PRIu64
+          " size=%zu memory_size=%zu\n",
           start, size, mem_size);
   fflush(stderr);
   abort();

--- a/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.h
+++ b/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds.h
@@ -6,13 +6,13 @@
 #include "openvm_constants.h"
 #include "openvm_util.h"
 
-__attribute__((noreturn, cold)) void abort_oob(uint32_t start, size_t size,
+__attribute__((noreturn, cold)) void abort_oob(uint64_t start, size_t size,
                                                size_t mem_size);
 
 static constexpr size_t OPENVM_MEM_SIZE = (size_t)MEMORY_MASK + 1u;
 
 static __attribute__((always_inline)) inline void check_mem_bounds_u8(
-    uint32_t start) {
+    uint64_t start) {
   if (unlikely(start > OPENVM_MEM_SIZE - sizeof(uint8_t))) {
     abort_oob(start, sizeof(uint8_t), OPENVM_MEM_SIZE);
   }
@@ -20,7 +20,7 @@ static __attribute__((always_inline)) inline void check_mem_bounds_u8(
 }
 
 static __attribute__((always_inline)) inline void check_mem_bounds_i8(
-    uint32_t start) {
+    uint64_t start) {
   if (unlikely(start > OPENVM_MEM_SIZE - sizeof(int8_t))) {
     abort_oob(start, sizeof(int8_t), OPENVM_MEM_SIZE);
   }
@@ -28,7 +28,7 @@ static __attribute__((always_inline)) inline void check_mem_bounds_i8(
 }
 
 static __attribute__((always_inline)) inline void check_mem_bounds_u16(
-    uint32_t start) {
+    uint64_t start) {
   if (unlikely(start > OPENVM_MEM_SIZE - sizeof(uint16_t))) {
     abort_oob(start, sizeof(uint16_t), OPENVM_MEM_SIZE);
   }
@@ -36,7 +36,7 @@ static __attribute__((always_inline)) inline void check_mem_bounds_u16(
 }
 
 static __attribute__((always_inline)) inline void check_mem_bounds_i16(
-    uint32_t start) {
+    uint64_t start) {
   if (unlikely(start > OPENVM_MEM_SIZE - sizeof(int16_t))) {
     abort_oob(start, sizeof(int16_t), OPENVM_MEM_SIZE);
   }
@@ -44,7 +44,7 @@ static __attribute__((always_inline)) inline void check_mem_bounds_i16(
 }
 
 static __attribute__((always_inline)) inline void check_mem_bounds_u32(
-    uint32_t start) {
+    uint64_t start) {
   if (unlikely(start > OPENVM_MEM_SIZE - sizeof(uint32_t))) {
     abort_oob(start, sizeof(uint32_t), OPENVM_MEM_SIZE);
   }
@@ -52,7 +52,7 @@ static __attribute__((always_inline)) inline void check_mem_bounds_u32(
 }
 
 static __attribute__((always_inline)) inline void check_mem_bounds_u64(
-    uint32_t start) {
+    uint64_t start) {
   if (unlikely(start > OPENVM_MEM_SIZE - sizeof(uint64_t))) {
     abort_oob(start, sizeof(uint64_t), OPENVM_MEM_SIZE);
   }
@@ -60,14 +60,14 @@ static __attribute__((always_inline)) inline void check_mem_bounds_u64(
 }
 
 static __attribute__((always_inline)) inline void check_mem_bounds_range(
-    uint32_t start, size_t size) {
+    uint64_t start, size_t size) {
   if (unlikely(start > OPENVM_MEM_SIZE || size > OPENVM_MEM_SIZE - start)) {
     abort_oob(start, size, OPENVM_MEM_SIZE);
   }
 }
 
 static __attribute__((always_inline)) inline void check_mem_bounds_u64_range(
-    uint32_t base_addr, uint32_t num_words) {
+    uint64_t base_addr, uint32_t num_words) {
   check_mem_bounds_range(base_addr, (size_t)num_words * sizeof(uint64_t));
 }
 

--- a/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds_unprotected.h
+++ b/crates/rvr/rvr-openvm/c/openvm_check_mem_bounds_unprotected.h
@@ -4,20 +4,20 @@
 #include <stdint.h>
 
 static __attribute__((always_inline)) inline void check_mem_bounds_u8(
-    uint32_t start) {}
+    uint64_t start) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_i8(
-    uint32_t start) {}
+    uint64_t start) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_u16(
-    uint32_t start) {}
+    uint64_t start) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_i16(
-    uint32_t start) {}
+    uint64_t start) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_u32(
-    uint32_t start) {}
+    uint64_t start) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_u64(
-    uint32_t start) {}
+    uint64_t start) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_range(
-    uint32_t start, size_t size) {}
+    uint64_t start, size_t size) {}
 static __attribute__((always_inline)) inline void check_mem_bounds_u64_range(
-    uint32_t base_addr, uint32_t num_words) {}
+    uint64_t base_addr, uint32_t num_words) {}
 
 #endif

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -80,7 +80,7 @@ static __attribute__((always_inline)) inline bool rv_pc_is_dispatchable(
  * so guest multi-byte accesses are naturally aligned.
  * TODO: addr &= MEMORY_MASK for defense-in-depth. */
 static __attribute__((always_inline)) inline uint8_t* mem_ptr(
-    uint8_t* restrict memory, uint32_t addr) {
+    uint8_t* restrict memory, uint64_t addr) {
   assume(addr <= MEMORY_MASK);
   return memory + addr;
 }
@@ -100,19 +100,19 @@ static __attribute__((always_inline)) inline void reg_write(
 /* ── Per-width memory reads ──────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline uint8_t rd_mem_u8(
-    uint8_t* restrict memory, uint32_t addr) {
+    uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u8(addr);
   return *mem_ptr(memory, addr);
 }
 
 static __attribute__((always_inline)) inline int8_t rd_mem_i8(
-    uint8_t* restrict memory, uint32_t addr) {
+    uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_i8(addr);
   return (int8_t)*mem_ptr(memory, addr);
 }
 
 static __attribute__((always_inline)) inline uint16_t rd_mem_u16(
-    uint8_t* restrict memory, uint32_t addr) {
+    uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u16(addr);
   uint16_t v;
   const void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(v));
@@ -121,7 +121,7 @@ static __attribute__((always_inline)) inline uint16_t rd_mem_u16(
 }
 
 static __attribute__((always_inline)) inline int16_t rd_mem_i16(
-    uint8_t* restrict memory, uint32_t addr) {
+    uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_i16(addr);
   int16_t v;
   const void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(v));
@@ -130,7 +130,7 @@ static __attribute__((always_inline)) inline int16_t rd_mem_i16(
 }
 
 static __attribute__((always_inline)) inline int32_t rd_mem_i32(
-    uint8_t* restrict memory, uint32_t addr) {
+    uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u32(addr);
   int32_t v;
   const void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(v));
@@ -139,8 +139,8 @@ static __attribute__((always_inline)) inline int32_t rd_mem_i32(
 }
 
 static __attribute__((always_inline)) inline uint32_t rd_mem_u32(
-    uint8_t* restrict memory, uint32_t addr) {
-  /* TODO(rvr): handle unaligned 32-bit load/store semantics in opcode
+    uint8_t* restrict memory, uint64_t addr) {
+  /* TODO(rvr): handle unaligned 32-bit word load/store semantics in opcode
    * codegen if needed; this generic helper assumes aligned callers. */
   check_mem_bounds_u32(addr);
   uint32_t v;
@@ -150,7 +150,7 @@ static __attribute__((always_inline)) inline uint32_t rd_mem_u32(
 }
 
 static __attribute__((always_inline)) inline uint64_t rd_mem_u64(
-    uint8_t* restrict memory, uint32_t addr) {
+    uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u64(addr);
   uint64_t v;
   const void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(v));
@@ -161,21 +161,21 @@ static __attribute__((always_inline)) inline uint64_t rd_mem_u64(
 /* ── Per-width memory writes ─────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void wr_mem_u8(
-    uint8_t* restrict memory, uint32_t addr, uint8_t val) {
+    uint8_t* restrict memory, uint64_t addr, uint8_t val) {
   check_mem_bounds_u8(addr);
   *mem_ptr(memory, addr) = val;
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u16(
-    uint8_t* restrict memory, uint32_t addr, uint16_t val) {
+    uint8_t* restrict memory, uint64_t addr, uint16_t val) {
   check_mem_bounds_u16(addr);
   void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(val));
   memcpy(p, &val, sizeof(val));
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u32(
-    uint8_t* restrict memory, uint32_t addr, uint32_t val) {
-  /* TODO(rvr): handle unaligned 32-bit load/store semantics in opcode
+    uint8_t* restrict memory, uint64_t addr, uint32_t val) {
+  /* TODO(rvr): handle unaligned 32-bit word load/store semantics in opcode
    * codegen if needed; this generic helper assumes aligned callers. */
   check_mem_bounds_u32(addr);
   void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(val));
@@ -183,7 +183,7 @@ static __attribute__((always_inline)) inline void wr_mem_u32(
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u64(
-    uint8_t* restrict memory, uint32_t addr, uint64_t val) {
+    uint8_t* restrict memory, uint64_t addr, uint64_t val) {
   check_mem_bounds_u64(addr);
   void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(val));
   memcpy(p, &val, sizeof(val));
@@ -194,7 +194,7 @@ static __attribute__((always_inline)) inline void wr_mem_u64(
 /* `base_addr` is word-aligned; the guest pointer is word-aligned too,
  * so these lower to a single memcpy. */
 static __attribute__((always_inline)) inline void rd_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, uint64_t* restrict out,
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
     uint32_t num_words) {
   check_mem_bounds_u64_range(base_addr, num_words);
   const void* p =
@@ -203,7 +203,7 @@ static __attribute__((always_inline)) inline void rd_mem_u64_range(
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* restrict vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* restrict vals,
     uint32_t num_words) {
   check_mem_bounds_u64_range(base_addr, num_words);
   void* p =
@@ -214,118 +214,118 @@ static __attribute__((always_inline)) inline void wr_mem_u64_range(
 /* ── Traced memory helpers ───────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t val);
+    RvState* restrict state, uint64_t addr, uint8_t val);
 static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state, uint32_t addr, int8_t val);
+    RvState* restrict state, uint64_t addr, int8_t val);
 static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t val);
+    RvState* restrict state, uint64_t addr, uint16_t val);
 static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state, uint32_t addr, int16_t val);
+    RvState* restrict state, uint64_t addr, int16_t val);
 static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t val);
+    RvState* restrict state, uint64_t addr, uint32_t val);
 static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state, uint32_t addr, int32_t val);
+    RvState* restrict state, uint64_t addr, int32_t val);
 static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t val);
+    RvState* restrict state, uint64_t addr, uint64_t val);
 static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t val);
+    RvState* restrict state, uint64_t addr, uint8_t val);
 static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t val);
+    RvState* restrict state, uint64_t addr, uint16_t val);
 static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t val);
+    RvState* restrict state, uint64_t addr, uint32_t val);
 static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t val);
+    RvState* restrict state, uint64_t addr, uint64_t val);
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words);
 static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words);
 
 /* Per-width traced reads return a 32-bit C type; callers widen to uint64_t at
  * register assignment via C implicit promotion. */
 static __attribute__((always_inline)) inline uint32_t rd_mem_u8_traced(
-    RvState* restrict state, uint32_t addr) {
+    RvState* restrict state, uint64_t addr) {
   uint8_t v = rd_mem_u8(state->memory, addr);
   trace_rd_mem_u8(state, addr, v);
   return v;
 }
 
 static __attribute__((always_inline)) inline int32_t rd_mem_i8_traced(
-    RvState* restrict state, uint32_t addr) {
+    RvState* restrict state, uint64_t addr) {
   int8_t v = rd_mem_i8(state->memory, addr);
   trace_rd_mem_i8(state, addr, v);
   return v;
 }
 
 static __attribute__((always_inline)) inline uint32_t rd_mem_u16_traced(
-    RvState* restrict state, uint32_t addr) {
+    RvState* restrict state, uint64_t addr) {
   uint16_t v = rd_mem_u16(state->memory, addr);
   trace_rd_mem_u16(state, addr, v);
   return v;
 }
 
 static __attribute__((always_inline)) inline int32_t rd_mem_i16_traced(
-    RvState* restrict state, uint32_t addr) {
+    RvState* restrict state, uint64_t addr) {
   int16_t v = rd_mem_i16(state->memory, addr);
   trace_rd_mem_i16(state, addr, v);
   return v;
 }
 
 static __attribute__((always_inline)) inline int32_t rd_mem_i32_traced(
-    RvState* restrict state, uint32_t addr) {
+    RvState* restrict state, uint64_t addr) {
   int32_t v = rd_mem_i32(state->memory, addr);
   trace_rd_mem_i32(state, addr, v);
   return v;
 }
 
 static __attribute__((always_inline)) inline uint32_t rd_mem_u32_traced(
-    RvState* restrict state, uint32_t addr) {
+    RvState* restrict state, uint64_t addr) {
   uint32_t v = rd_mem_u32(state->memory, addr);
   trace_rd_mem_u32(state, addr, v);
   return v;
 }
 
 static __attribute__((always_inline)) inline uint64_t rd_mem_u64_traced(
-    RvState* restrict state, uint32_t addr) {
+    RvState* restrict state, uint64_t addr) {
   uint64_t v = rd_mem_u64(state->memory, addr);
   trace_rd_mem_u64(state, addr, v);
   return v;
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u8_traced(
-    RvState* restrict state, uint32_t addr, uint8_t val) {
+    RvState* restrict state, uint64_t addr, uint8_t val) {
   trace_wr_mem_u8(state, addr, val);
   wr_mem_u8(state->memory, addr, val);
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u16_traced(
-    RvState* restrict state, uint32_t addr, uint16_t val) {
+    RvState* restrict state, uint64_t addr, uint16_t val) {
   trace_wr_mem_u16(state, addr, val);
   wr_mem_u16(state->memory, addr, val);
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u32_traced(
-    RvState* restrict state, uint32_t addr, uint32_t val) {
+    RvState* restrict state, uint64_t addr, uint32_t val) {
   trace_wr_mem_u32(state, addr, val);
   wr_mem_u32(state->memory, addr, val);
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u64_traced(
-    RvState* restrict state, uint32_t addr, uint64_t val) {
+    RvState* restrict state, uint64_t addr, uint64_t val) {
   trace_wr_mem_u64(state, addr, val);
   wr_mem_u64(state->memory, addr, val);
 }
 
 static __attribute__((always_inline)) inline void rd_mem_u64_range_traced(
-    RvState* restrict state, uint32_t base_addr, uint64_t* restrict out,
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
     uint32_t num_words) {
   rd_mem_u64_range(state, base_addr, out, num_words);
   trace_rd_mem_u64_range(state, base_addr, out, num_words);
 }
 
 static __attribute__((always_inline)) inline void wr_mem_u64_range_traced(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* restrict vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* restrict vals,
     uint32_t num_words) {
   trace_wr_mem_u64_range(state, base_addr, vals, num_words);
   wr_mem_u64_range(state, base_addr, vals, num_words);

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -15,34 +15,34 @@
 
 /* ── Memory access (single word) ───────────────────────────────────── */
 
-uint64_t rd_mem_u64_wrapper(RvState* s, uint32_t addr) {
+uint64_t rd_mem_u64_wrapper(RvState* s, uint64_t addr) {
   return rd_mem_u64(s->memory, addr);
 }
-void trace_rd_mem_u64_wrapper(RvState* s, uint32_t addr, uint64_t val) {
+void trace_rd_mem_u64_wrapper(RvState* s, uint64_t addr, uint64_t val) {
   trace_rd_mem_u64(s, addr, val);
 }
 
-void rd_mem_u64_range_wrapper(RvState* s, uint32_t base_addr, uint64_t* out,
+void rd_mem_u64_range_wrapper(RvState* s, uint64_t base_addr, uint64_t* out,
                               uint32_t num_words) {
   rd_mem_u64_range(s, base_addr, out, num_words);
 }
 
-void wr_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
+void wr_mem_u64_range_wrapper(RvState* s, uint64_t base_addr,
                               const uint64_t* vals, uint32_t num_words) {
   wr_mem_u64_range(s, base_addr, vals, num_words);
 }
 
-void trace_rd_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
+void trace_rd_mem_u64_range_wrapper(RvState* s, uint64_t base_addr,
                                     const uint64_t* vals, uint32_t num_words) {
   trace_rd_mem_u64_range(s, base_addr, vals, num_words);
 }
 
-void trace_wr_mem_u64_range_wrapper(RvState* s, uint32_t base_addr,
+void trace_wr_mem_u64_range_wrapper(RvState* s, uint64_t base_addr,
                                     const uint64_t* vals, uint32_t num_words) {
   trace_wr_mem_u64_range(s, base_addr, vals, num_words);
 }
 
-void trace_mem_access_u64_range_wrapper(RvState* s, uint32_t base_addr,
+void trace_mem_access_u64_range_wrapper(RvState* s, uint64_t base_addr,
                                         uint32_t num_words,
                                         uint32_t addr_space) {
   trace_mem_access_u64_range(s, base_addr, num_words, addr_space);

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -61,17 +61,17 @@ typedef struct TraceMemory {
 /* ── Page tracking ─────────────────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline uint32_t byte_addr_to_local_leaf(
-    uint32_t ptr) {
+    uint64_t ptr) {
   return ptr >> TRACER_BYTE_SPACE_PTRS_PER_LEAF_BITS;
 }
 
 static __attribute__((always_inline)) inline uint32_t deferral_addr_to_local_leaf(
-    uint32_t ptr) {
+    uint64_t ptr) {
   return ptr >> TRACER_DEFERRAL_PTRS_PER_LEAF_BITS;
 }
 
 static __attribute__((always_inline)) inline uint32_t addr_to_local_leaf(
-    uint32_t addr_space, uint32_t ptr) {
+    uint32_t addr_space, uint64_t ptr) {
   if (likely(addr_space == AS_MEMORY || addr_space == AS_PUBLIC_VALUES)) {
     return byte_addr_to_local_leaf(ptr);
   }
@@ -178,7 +178,7 @@ static __attribute__((always_inline)) inline void record_deferral_page_range(
 /* Record a single page access. `addr_space` is a compile-time constant at
  * every direct call site in generated C, so the branches below fold away. */
 static __attribute__((always_inline)) inline void record_page(
-    Tracer* t, uint32_t addr_space, uint32_t ptr, uint32_t size) {
+    Tracer* t, uint32_t addr_space, uint64_t ptr, uint32_t size) {
   uint32_t first_leaf = addr_to_local_leaf(addr_space, ptr);
   uint32_t last_leaf = addr_to_local_leaf(addr_space, ptr + size - 1u);
   uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
@@ -207,7 +207,7 @@ static __attribute__((always_inline)) inline void record_page(
 /* Record leaves touched by [first_addr, last_addr]. Duplicates are fine —
  * Rust-side checkpoint processing deduplicates by page mask. */
 static __attribute__((always_inline)) inline void record_page_range(
-    Tracer* t, uint32_t addr_space, uint32_t first_addr, uint32_t last_addr) {
+    Tracer* t, uint32_t addr_space, uint64_t first_addr, uint64_t last_addr) {
   uint32_t first_leaf = addr_to_local_leaf(addr_space, first_addr);
   uint32_t last_leaf = addr_to_local_leaf(addr_space, last_addr);
   if (likely(addr_space == AS_MEMORY)) {
@@ -275,7 +275,7 @@ static __attribute__((always_inline)) inline void trace_memory_access_page(
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access_leaf(
-    TraceMemory* restrict memory, uint32_t addr) {
+    TraceMemory* restrict memory, uint64_t addr) {
   uint32_t leaf = byte_addr_to_local_leaf(addr);
   trace_memory_access_page(memory, leaf >> TRACER_PAGE_BITS,
                            1ull << (leaf & ((1u << TRACER_PAGE_BITS) - 1u)));
@@ -291,59 +291,59 @@ static __attribute__((always_inline)) inline void trace_reg_write(
 /* ── Trace-only memory reads (record page in metered mode) ───────── */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t val) {
+    RvState* restrict state, uint64_t addr, uint8_t val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint8_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state, uint32_t addr, int8_t val) {
+    RvState* restrict state, uint64_t addr, int8_t val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(int8_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t val) {
+    RvState* restrict state, uint64_t addr, uint16_t val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint16_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state, uint32_t addr, int16_t val) {
+    RvState* restrict state, uint64_t addr, int16_t val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(int16_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t val) {
+    RvState* restrict state, uint64_t addr, uint32_t val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint32_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state, uint32_t addr, int32_t val) {
+    RvState* restrict state, uint64_t addr, int32_t val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(int32_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t val) {
+    RvState* restrict state, uint64_t addr, uint64_t val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint64_t));
 }
 
 /* ── Trace-only memory writes (record page in metered mode) ──────── */
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t new_val) {
+    RvState* restrict state, uint64_t addr, uint8_t new_val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint8_t));
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t new_val) {
+    RvState* restrict state, uint64_t addr, uint16_t new_val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint16_t));
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t new_val) {
+    RvState* restrict state, uint64_t addr, uint32_t new_val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint32_t));
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t new_val) {
+    RvState* restrict state, uint64_t addr, uint64_t new_val) {
   record_page(state->tracer, AS_MEMORY, addr, sizeof(uint64_t));
 }
 
@@ -354,33 +354,33 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64(
  * so we can skip the branch on the hot path. */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words) {
   assume(num_words > 0);
-  uint32_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
+  uint64_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
   record_page_range(state->tracer, AS_MEMORY, base_addr, last_addr);
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words) {
   assume(num_words > 0);
-  uint32_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
+  uint64_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
   record_page_range(state->tracer, AS_MEMORY, base_addr, last_addr);
 }
 
 /* ── Trace-only operations ────────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void trace_mem_access(
-    RvState* restrict state, uint32_t addr, uint32_t addr_space) {
+    RvState* restrict state, uint64_t addr, uint32_t addr_space) {
   record_page(state->tracer, addr_space, addr, WORD_SIZE);
 }
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
-    RvState* restrict state, uint32_t base_addr, uint32_t num_dwords,
+    RvState* restrict state, uint64_t base_addr, uint32_t num_dwords,
     uint32_t addr_space) {
   assume(num_dwords > 0);
-  uint32_t last_addr = base_addr + num_dwords * WORD_SIZE - 1u;
+  uint64_t last_addr = base_addr + num_dwords * WORD_SIZE - 1u;
   record_page_range(state->tracer, addr_space, base_addr, last_addr);
 }
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -28,47 +28,47 @@ static __attribute__((always_inline)) inline void trace_reg_write(
 /* ── Trace-only memory reads (no-ops in metered cost mode) ───────── */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t val) {}
+    RvState* restrict state, uint64_t addr, uint8_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state, uint32_t addr, int8_t val) {}
+    RvState* restrict state, uint64_t addr, int8_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t val) {}
+    RvState* restrict state, uint64_t addr, uint16_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state, uint32_t addr, int16_t val) {}
+    RvState* restrict state, uint64_t addr, int16_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t val) {}
+    RvState* restrict state, uint64_t addr, uint32_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state, uint32_t addr, int32_t val) {}
+    RvState* restrict state, uint64_t addr, int32_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t val) {}
+    RvState* restrict state, uint64_t addr, uint64_t val) {}
 
 /* ── Trace-only memory writes (no-ops in metered cost mode) ──────── */
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint8_t new_val) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint16_t new_val) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint32_t new_val) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint64_t new_val) {}
 
 /* ── Trace-only word-range memory access (no-ops in metered cost mode) */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words) {}
 
 /* ── Trace-only operations ────────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void trace_mem_access(
-    RvState* restrict state, uint32_t addr, uint32_t addr_space) {}
+    RvState* restrict state, uint64_t addr, uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
-    RvState* restrict state, uint32_t base_addr, uint32_t num_dwords,
+    RvState* restrict state, uint64_t base_addr, uint32_t num_dwords,
     uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_pc(

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -24,47 +24,47 @@ static __attribute__((always_inline)) inline void trace_reg_write(
 /* ── Trace-only memory reads (no-ops in pure mode) ───────────────── */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t val) {}
+    RvState* restrict state, uint64_t addr, uint8_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state, uint32_t addr, int8_t val) {}
+    RvState* restrict state, uint64_t addr, int8_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t val) {}
+    RvState* restrict state, uint64_t addr, uint16_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state, uint32_t addr, int16_t val) {}
+    RvState* restrict state, uint64_t addr, int16_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t val) {}
+    RvState* restrict state, uint64_t addr, uint32_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state, uint32_t addr, int32_t val) {}
+    RvState* restrict state, uint64_t addr, int32_t val) {}
 static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t val) {}
+    RvState* restrict state, uint64_t addr, uint64_t val) {}
 
 /* ── Trace-only memory writes (no-ops in pure mode) ──────────────── */
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state, uint32_t addr, uint8_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint8_t new_val) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state, uint32_t addr, uint16_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint16_t new_val) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state, uint32_t addr, uint32_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint32_t new_val) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state, uint32_t addr, uint64_t new_val) {}
+    RvState* restrict state, uint64_t addr, uint64_t new_val) {}
 
 /* ── Trace-only word-range memory access (no-ops in pure mode) ───── */
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words) {}
 static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
+    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
     uint32_t num_words) {}
 
 /* ── Trace-only operations (no-ops in pure mode) ──────────────────── */
 
 static __attribute__((always_inline)) inline void trace_mem_access(
-    RvState* restrict state, uint32_t addr, uint32_t addr_space) {}
+    RvState* restrict state, uint64_t addr, uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
-    RvState* restrict state, uint32_t base_addr, uint32_t num_dwords,
+    RvState* restrict state, uint64_t base_addr, uint32_t num_dwords,
     uint32_t addr_space) {}
 
 static __attribute__((always_inline)) inline void trace_pc(

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -58,7 +58,7 @@ pub fn constants_header(text_start: u64, text_end: u64, dispatch_table_size: usi
 #pragma once
 #include <stdint.h>
 
-static constexpr uint32_t MEMORY_MASK = 0x{memory_mask:x}u;
+static constexpr uint64_t MEMORY_MASK = 0x{memory_mask:x}ull;
 static constexpr uint32_t AS_REGISTER = {AS_REGISTER};
 static constexpr uint32_t AS_MEMORY = {AS_MEMORY};
 static constexpr uint32_t AS_PUBLIC_VALUES = {AS_PUBLIC_VALUES};

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -1,6 +1,6 @@
 //! OpenVM IO runtime: ctx (`OpenVmIoState`) borrowed from `VmState<F>`.
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, ffi::c_void};
 
 #[cfg(not(feature = "unprotected"))]
 use openvm_platform::memory::MEM_SIZE;
@@ -44,3 +44,23 @@ pub fn check_mem_bounds_range(start: u64, num_bytes: usize) {
 #[cfg(feature = "unprotected")]
 #[inline(always)]
 pub fn check_mem_bounds_range(_start: u64, _num_bytes: usize) {}
+
+/// Replace the hint stream contents. Called via `ext_hint_stream_set` from extension FFI.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `OpenVmIoState` pointer. `data` must point to `len` bytes (or be null).
+pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
+    ctx: *mut c_void,
+    data: *const u8,
+    len: u32,
+) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+    io.hint_stream.clear();
+    if len > 0 && !data.is_null() {
+        let slice = unsafe { std::slice::from_raw_parts(data, len as usize) };
+        for &b in slice {
+            io.hint_stream.push_back(F::from_u8(b));
+        }
+    }
+}

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -1,6 +1,6 @@
 //! OpenVM IO runtime: ctx (`OpenVmIoState`) borrowed from `VmState<F>`.
 
-use std::{collections::VecDeque, ffi::c_void};
+use std::collections::VecDeque;
 
 #[cfg(not(feature = "unprotected"))]
 use openvm_platform::memory::MEM_SIZE;
@@ -32,7 +32,7 @@ pub struct OpenVmIoState<'a, F: PrimeField32> {
 /// matching the C-side `abort_oob` termination used by `rd_mem_*`/`wr_mem_*`.
 /// Compiles to a no-op under the `unprotected` feature.
 #[cfg(not(feature = "unprotected"))]
-pub fn check_mem_bounds_range(start: u32, num_bytes: usize) {
+pub fn check_mem_bounds_range(start: u64, num_bytes: usize) {
     let start = start as usize;
     if start > MEM_SIZE || num_bytes > MEM_SIZE - start {
         panic!(
@@ -43,24 +43,4 @@ pub fn check_mem_bounds_range(start: u32, num_bytes: usize) {
 
 #[cfg(feature = "unprotected")]
 #[inline(always)]
-pub fn check_mem_bounds_range(_start: u32, _num_bytes: usize) {}
-
-/// Replace the hint stream contents. Called via `ext_hint_stream_set` from extension FFI.
-///
-/// # Safety
-///
-/// `ctx` must be a valid `OpenVmIoState` pointer. `data` must point to `len` bytes (or be null).
-pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
-    ctx: *mut c_void,
-    data: *const u8,
-    len: u32,
-) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
-    io.hint_stream.clear();
-    if len > 0 && !data.is_null() {
-        let slice = unsafe { std::slice::from_raw_parts(data, len as usize) };
-        for &b in slice {
-            io.hint_stream.push_back(F::from_u8(b));
-        }
-    }
-}
+pub fn check_mem_bounds_range(_start: u64, _num_bytes: usize) {}

--- a/extensions/algebra/rvr/c/rvr_ext_fp2.h
+++ b/extensions/algebra/rvr/c/rvr_ext_fp2.h
@@ -9,33 +9,33 @@ struct RvState;
 
 /* Fp2 arithmetic fallback FFI for unknown base fields.
  * One entry point per opcode; modulus is still provided at runtime. */
-extern void rvr_ext_fp2_add(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_fp2_add(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
-extern void rvr_ext_fp2_sub(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_fp2_sub(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
-extern void rvr_ext_fp2_mul(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_fp2_mul(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
-extern void rvr_ext_fp2_div(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_fp2_div(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
 
 /* Fp2 SETUP extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_fp2_setup(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_fp2_setup(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                               uint32_t num_limbs);
 
 /* ── Specialized per-curve fp2 FFI ─────────────────────────────────────── */
 
-extern void rvr_ext_fp2_add_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_fp2_sub_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_fp2_mul_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_fp2_div_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_fp2_add_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_fp2_sub_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_fp2_mul_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_fp2_div_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
-extern void rvr_ext_fp2_add_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                      uint32_t rs2_ptr);
-extern void rvr_ext_fp2_sub_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                      uint32_t rs2_ptr);
-extern void rvr_ext_fp2_mul_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                      uint32_t rs2_ptr);
-extern void rvr_ext_fp2_div_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                      uint32_t rs2_ptr);
+extern void rvr_ext_fp2_add_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                      uint64_t rs2_ptr);
+extern void rvr_ext_fp2_sub_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                      uint64_t rs2_ptr);
+extern void rvr_ext_fp2_mul_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                      uint64_t rs2_ptr);
+extern void rvr_ext_fp2_div_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                      uint64_t rs2_ptr);
 
 #endif /* RVR_EXT_FP2_H */

--- a/extensions/algebra/rvr/c/rvr_ext_mod.h
+++ b/extensions/algebra/rvr/c/rvr_ext_mod.h
@@ -14,115 +14,115 @@ struct RvState;
 
 /* Modular arithmetic fallback FFI for unknown moduli.
  * One entry point per opcode; modulus is still provided at runtime. */
-extern void rvr_ext_mod_add(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_mod_add(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
-extern void rvr_ext_mod_sub(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_mod_sub(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
-extern void rvr_ext_mod_mul(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_mod_mul(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
-extern void rvr_ext_mod_div(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_mod_div(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
 
 /* Modular IS_EQ extension FFI entry point (implemented in Rust).
  * Returns 1 if equal, 0 otherwise. */
-extern uint32_t rvr_ext_mod_iseq(RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern uint32_t rvr_ext_mod_iseq(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr,
                                  uint32_t num_limbs, const uint8_t* modulus);
 
 /* Modular SETUP extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_mod_setup(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr,
+extern void rvr_ext_mod_setup(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                               uint32_t num_limbs);
 
 /* HintSqrt phantom: computes sqrt hint and sets hint stream (implemented in
  * Rust). */
-extern void rvr_ext_algebra_hint_sqrt(RvState* state, uint32_t rs1_ptr, uint32_t num_limbs,
+extern void rvr_ext_algebra_hint_sqrt(RvState* state, uint64_t rs1_ptr, uint32_t num_limbs,
                                       const uint8_t* modulus, const uint8_t* non_qr);
 
 /* ── Specialized per-curve-per-op FFI (native Montgomery arithmetic) ─── */
 
 /* k256 coord/scalar: C-implemented with preserve_most. */
-extern __attribute__((preserve_most)) void rvr_ext_mod_add_k256_coord(RvState*, uint32_t rd_ptr,
-                                                                      uint32_t rs1_ptr,
-                                                                      uint32_t rs2_ptr);
-extern __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_coord(RvState*, uint32_t rd_ptr,
-                                                                      uint32_t rs1_ptr,
-                                                                      uint32_t rs2_ptr);
-extern __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_coord(RvState*, uint32_t rd_ptr,
-                                                                      uint32_t rs1_ptr,
-                                                                      uint32_t rs2_ptr);
-extern __attribute__((preserve_most)) void rvr_ext_mod_div_k256_coord(RvState*, uint32_t rd_ptr,
-                                                                      uint32_t rs1_ptr,
-                                                                      uint32_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_add_k256_coord(RvState*, uint64_t rd_ptr,
+                                                                      uint64_t rs1_ptr,
+                                                                      uint64_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_coord(RvState*, uint64_t rd_ptr,
+                                                                      uint64_t rs1_ptr,
+                                                                      uint64_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_coord(RvState*, uint64_t rd_ptr,
+                                                                      uint64_t rs1_ptr,
+                                                                      uint64_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_div_k256_coord(RvState*, uint64_t rd_ptr,
+                                                                      uint64_t rs1_ptr,
+                                                                      uint64_t rs2_ptr);
 extern __attribute__((preserve_most)) uint32_t rvr_ext_mod_iseq_k256_coord(RvState*,
-                                                                           uint32_t rs1_ptr,
-                                                                           uint32_t rs2_ptr);
+                                                                           uint64_t rs1_ptr,
+                                                                           uint64_t rs2_ptr);
 
-extern __attribute__((preserve_most)) void rvr_ext_mod_add_k256_scalar(RvState*, uint32_t rd_ptr,
-                                                                       uint32_t rs1_ptr,
-                                                                       uint32_t rs2_ptr);
-extern __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_scalar(RvState*, uint32_t rd_ptr,
-                                                                       uint32_t rs1_ptr,
-                                                                       uint32_t rs2_ptr);
-extern __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_scalar(RvState*, uint32_t rd_ptr,
-                                                                       uint32_t rs1_ptr,
-                                                                       uint32_t rs2_ptr);
-extern __attribute__((preserve_most)) void rvr_ext_mod_div_k256_scalar(RvState*, uint32_t rd_ptr,
-                                                                       uint32_t rs1_ptr,
-                                                                       uint32_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_add_k256_scalar(RvState*, uint64_t rd_ptr,
+                                                                       uint64_t rs1_ptr,
+                                                                       uint64_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_scalar(RvState*, uint64_t rd_ptr,
+                                                                       uint64_t rs1_ptr,
+                                                                       uint64_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_scalar(RvState*, uint64_t rd_ptr,
+                                                                       uint64_t rs1_ptr,
+                                                                       uint64_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_mod_div_k256_scalar(RvState*, uint64_t rd_ptr,
+                                                                       uint64_t rs1_ptr,
+                                                                       uint64_t rs2_ptr);
 extern __attribute__((preserve_most)) uint32_t rvr_ext_mod_iseq_k256_scalar(RvState*,
-                                                                            uint32_t rs1_ptr,
-                                                                            uint32_t rs2_ptr);
+                                                                            uint64_t rs1_ptr,
+                                                                            uint64_t rs2_ptr);
 
 /* Remaining curves: Rust-implemented, standard C ABI. */
-extern void rvr_ext_mod_add_p256_coord(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                       uint32_t rs2_ptr);
-extern void rvr_ext_mod_sub_p256_coord(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                       uint32_t rs2_ptr);
-extern void rvr_ext_mod_mul_p256_coord(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                       uint32_t rs2_ptr);
-extern void rvr_ext_mod_div_p256_coord(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                       uint32_t rs2_ptr);
-extern uint32_t rvr_ext_mod_iseq_p256_coord(RvState*, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_mod_add_p256_coord(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                       uint64_t rs2_ptr);
+extern void rvr_ext_mod_sub_p256_coord(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                       uint64_t rs2_ptr);
+extern void rvr_ext_mod_mul_p256_coord(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                       uint64_t rs2_ptr);
+extern void rvr_ext_mod_div_p256_coord(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                       uint64_t rs2_ptr);
+extern uint32_t rvr_ext_mod_iseq_p256_coord(RvState*, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
-extern void rvr_ext_mod_add_p256_scalar(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                        uint32_t rs2_ptr);
-extern void rvr_ext_mod_sub_p256_scalar(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                        uint32_t rs2_ptr);
-extern void rvr_ext_mod_mul_p256_scalar(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                        uint32_t rs2_ptr);
-extern void rvr_ext_mod_div_p256_scalar(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                        uint32_t rs2_ptr);
-extern uint32_t rvr_ext_mod_iseq_p256_scalar(RvState*, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_mod_add_p256_scalar(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                        uint64_t rs2_ptr);
+extern void rvr_ext_mod_sub_p256_scalar(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                        uint64_t rs2_ptr);
+extern void rvr_ext_mod_mul_p256_scalar(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                        uint64_t rs2_ptr);
+extern void rvr_ext_mod_div_p256_scalar(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                        uint64_t rs2_ptr);
+extern uint32_t rvr_ext_mod_iseq_p256_scalar(RvState*, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
-extern void rvr_ext_mod_add_bn254_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_mod_sub_bn254_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_mod_mul_bn254_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_mod_div_bn254_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern uint32_t rvr_ext_mod_iseq_bn254_fq(RvState*, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_mod_add_bn254_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_mod_sub_bn254_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_mod_mul_bn254_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_mod_div_bn254_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern uint32_t rvr_ext_mod_iseq_bn254_fq(RvState*, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
-extern void rvr_ext_mod_add_bn254_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_mod_sub_bn254_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_mod_mul_bn254_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_mod_div_bn254_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern uint32_t rvr_ext_mod_iseq_bn254_fr(RvState*, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_mod_add_bn254_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_mod_sub_bn254_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_mod_mul_bn254_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_mod_div_bn254_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern uint32_t rvr_ext_mod_iseq_bn254_fr(RvState*, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
-extern void rvr_ext_mod_add_bls12_381_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern void rvr_ext_mod_sub_bls12_381_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern void rvr_ext_mod_mul_bls12_381_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern void rvr_ext_mod_div_bls12_381_fq(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern uint32_t rvr_ext_mod_iseq_bls12_381_fq(RvState*, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_mod_add_bls12_381_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern void rvr_ext_mod_sub_bls12_381_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern void rvr_ext_mod_mul_bls12_381_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern void rvr_ext_mod_div_bls12_381_fq(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern uint32_t rvr_ext_mod_iseq_bls12_381_fq(RvState*, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
-extern void rvr_ext_mod_add_bls12_381_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern void rvr_ext_mod_sub_bls12_381_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern void rvr_ext_mod_mul_bls12_381_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern void rvr_ext_mod_div_bls12_381_fr(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern uint32_t rvr_ext_mod_iseq_bls12_381_fr(RvState*, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_mod_add_bls12_381_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern void rvr_ext_mod_sub_bls12_381_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern void rvr_ext_mod_mul_bls12_381_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern void rvr_ext_mod_div_bls12_381_fr(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern uint32_t rvr_ext_mod_iseq_bls12_381_fr(RvState*, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
 #endif /* RVR_EXT_MOD_H */

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -25,10 +25,10 @@ pub trait FieldArith {
 
     /// # Safety
     /// `state` must be a valid pointer to the C `RvState` struct.
-    unsafe fn read_elem(&self, state: *mut c_void, ptr: u32) -> Self::Elem;
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem;
     /// # Safety
     /// `state` must be a valid pointer to the C `RvState` struct.
-    unsafe fn write_elem(&self, state: *mut c_void, ptr: u32, val: &Self::Elem);
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem);
 
     fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem;
     fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem;
@@ -44,7 +44,7 @@ pub trait FieldArith {
 /// # Safety
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
-pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void, ptr: u32) -> F {
+pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void, ptr: u64) -> F {
     let mut words = [0u64; FIELD_256_WORDS];
     rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; FIELD_256_BYTES];
@@ -70,7 +70,7 @@ pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void,
 #[inline(always)]
 pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
     state: *mut c_void,
-    ptr: u32,
+    ptr: u64,
     val: &F,
 ) {
     let bytes = val.to_repr();
@@ -90,7 +90,7 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
 /// # Safety
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
-pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> blstrs::Fp {
+pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u64) -> blstrs::Fp {
     let mut words = [0u64; BLS12_381_ELEM_WORDS];
     rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; BLS12_381_ELEM_BYTES];
@@ -113,7 +113,7 @@ pub unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> blstrs::Fp {
 /// # Safety
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
-pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp) {
+pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u64, val: &blstrs::Fp) {
     let bytes = val.to_bytes_le();
     let mut words = [0u64; BLS12_381_ELEM_WORDS];
     for (i, w) in words.iter_mut().enumerate() {
@@ -134,7 +134,7 @@ pub unsafe fn write_bls12_381_fq(state: *mut c_void, ptr: u32, val: &blstrs::Fp)
 /// `state` must be a valid `RvState` pointer; `num_limbs` must be a multiple
 /// of `WORD_SIZE`.
 #[inline]
-pub unsafe fn read_bigint(state: *mut c_void, ptr: u32, num_limbs: u32) -> BigUint {
+pub unsafe fn read_bigint(state: *mut c_void, ptr: u64, num_limbs: u32) -> BigUint {
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
     let mut words = vec![0u64; num_words];
     rd_mem_words_traced(state, ptr, &mut words);
@@ -151,7 +151,7 @@ pub unsafe fn read_bigint(state: *mut c_void, ptr: u32, num_limbs: u32) -> BigUi
 /// `state` must be a valid `RvState` pointer; `num_limbs` must be a multiple
 /// of `WORD_SIZE` and large enough to hold `value`.
 #[inline]
-pub unsafe fn write_bigint(state: *mut c_void, ptr: u32, value: &BigUint, num_limbs: u32) {
+pub unsafe fn write_bigint(state: *mut c_void, ptr: u64, value: &BigUint, num_limbs: u32) {
     let num_words = (num_limbs / WORD_SIZE as u32) as usize;
     let mut bytes = value.to_bytes_le();
     bytes.resize(num_limbs as usize, 0);
@@ -193,9 +193,9 @@ pub fn mod_inverse(a: &BigUint, p: &BigUint) -> BigUint {
 pub unsafe fn exec_op<F, Op>(
     f: &F,
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
     op: Op,
 ) where
     F: FieldArith,

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -45,11 +45,7 @@ impl FieldArith for KnownComplexField<halo2curves_axiom::bn256::Fq2> {
     #[inline(always)]
     unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr, &val.c0);
-        write_field_256::<halo2curves_axiom::bn256::Fq>(
-            state,
-            ptr + FIELD_256_BYTES,
-            &val.c1,
-        );
+        write_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr + FIELD_256_BYTES, &val.c1);
     }
 
     #[inline(always)]

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -32,19 +32,19 @@ impl FieldArith for KnownComplexField<halo2curves_axiom::bn256::Fq2> {
     type Elem = halo2curves_axiom::bn256::Fq2;
 
     #[inline(always)]
-    unsafe fn read_elem(&self, state: *mut c_void, ptr: u32) -> Self::Elem {
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         halo2curves_axiom::bn256::Fq2::new(
             read_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr),
-            read_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr + FIELD_256_BYTES as u32),
+            read_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr + FIELD_256_BYTES as u64),
         )
     }
 
     #[inline(always)]
-    unsafe fn write_elem(&self, state: *mut c_void, ptr: u32, val: &Self::Elem) {
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr, &val.c0);
         write_field_256::<halo2curves_axiom::bn256::Fq>(
             state,
-            ptr + FIELD_256_BYTES as u32,
+            ptr + FIELD_256_BYTES as u64,
             &val.c1,
         );
     }
@@ -75,17 +75,17 @@ impl FieldArith for KnownComplexField<blstrs::Fp2> {
     type Elem = blstrs::Fp2;
 
     #[inline(always)]
-    unsafe fn read_elem(&self, state: *mut c_void, ptr: u32) -> Self::Elem {
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         blstrs::Fp2::new(
             read_bls12_381_fq(state, ptr),
-            read_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES as u32),
+            read_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES as u64),
         )
     }
 
     #[inline(always)]
-    unsafe fn write_elem(&self, state: *mut c_void, ptr: u32, val: &Self::Elem) {
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_bls12_381_fq(state, ptr, &val.c0());
-        write_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES as u32, &val.c1());
+        write_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES as u64, &val.c1());
     }
 
     #[inline(always)]
@@ -115,15 +115,15 @@ impl FieldArith for KnownComplexField<blstrs::Fp2> {
 impl FieldArith for UnknownComplexField {
     type Elem = (BigUint, BigUint);
 
-    unsafe fn read_elem(&self, state: *mut c_void, ptr: u32) -> Self::Elem {
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         let c0 = read_bigint(state, ptr, self.num_limbs);
-        let c1 = read_bigint(state, ptr + self.num_limbs, self.num_limbs);
+        let c1 = read_bigint(state, ptr + self.num_limbs as u64, self.num_limbs);
         (c0, c1)
     }
 
-    unsafe fn write_elem(&self, state: *mut c_void, ptr: u32, val: &Self::Elem) {
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_bigint(state, ptr, &val.0, self.num_limbs);
-        write_bigint(state, ptr + self.num_limbs, &val.1, self.num_limbs);
+        write_bigint(state, ptr + self.num_limbs as u64, &val.1, self.num_limbs);
     }
 
     fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
@@ -167,7 +167,7 @@ macro_rules! field_op_fn {
         /// # Safety
         /// `state` must be a valid `RvState` pointer.
         #[no_mangle]
-        pub unsafe extern "C" fn $name(state: *mut c_void, rd: u32, rs1: u32, rs2: u32) {
+        pub unsafe extern "C" fn $name(state: *mut c_void, rd: u64, rs1: u64, rs2: u64) {
             let f = KnownComplexField::<$field>(PhantomData);
             exec_op(&f, state, rd, rs1, rs2, |f, a, b| f.$op(a, b));
         }
@@ -198,9 +198,9 @@ macro_rules! unknown_field_op_fn {
         #[no_mangle]
         pub unsafe extern "C" fn $name(
             state: *mut c_void,
-            rd_ptr: u32,
-            rs1_ptr: u32,
-            rs2_ptr: u32,
+            rd_ptr: u64,
+            rs1_ptr: u64,
+            rs2_ptr: u64,
             num_limbs: u32,
             modulus_ptr: *const u8,
         ) {
@@ -222,9 +222,9 @@ unknown_field_op_fn!(rvr_ext_fp2_div, div);
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_fp2_setup(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
     num_limbs: u32,
 ) {
     let total_limbs = num_limbs * 2;

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -11,11 +11,14 @@ use halo2curves_axiom::ff::Field;
 use num_bigint::BigUint;
 use rvr_openvm_ext_algebra_ffi_common::{
     exec_op, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256, write_bigint,
-    write_bls12_381_fq, write_field_256, FieldArith, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
+    write_bls12_381_fq, write_field_256, FieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
     rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
 };
+
+const FIELD_256_BYTES: u64 = rvr_openvm_ext_algebra_ffi_common::FIELD_256_BYTES as u64;
+const BLS12_381_ELEM_BYTES: u64 = rvr_openvm_ext_algebra_ffi_common::BLS12_381_ELEM_BYTES as u64;
 
 // ── Field structs ───────────────────────────────────────────────────────────
 
@@ -35,7 +38,7 @@ impl FieldArith for KnownComplexField<halo2curves_axiom::bn256::Fq2> {
     unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         halo2curves_axiom::bn256::Fq2::new(
             read_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr),
-            read_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr + FIELD_256_BYTES as u64),
+            read_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr + FIELD_256_BYTES),
         )
     }
 
@@ -44,7 +47,7 @@ impl FieldArith for KnownComplexField<halo2curves_axiom::bn256::Fq2> {
         write_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr, &val.c0);
         write_field_256::<halo2curves_axiom::bn256::Fq>(
             state,
-            ptr + FIELD_256_BYTES as u64,
+            ptr + FIELD_256_BYTES,
             &val.c1,
         );
     }
@@ -78,14 +81,14 @@ impl FieldArith for KnownComplexField<blstrs::Fp2> {
     unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         blstrs::Fp2::new(
             read_bls12_381_fq(state, ptr),
-            read_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES as u64),
+            read_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES),
         )
     }
 
     #[inline(always)]
     unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_bls12_381_fq(state, ptr, &val.c0());
-        write_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES as u64, &val.c1());
+        write_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES, &val.c1());
     }
 
     #[inline(always)]

--- a/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
+++ b/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
@@ -39,7 +39,7 @@ static inline void bytes_reverse_32(uint8_t out[SECP256K1_ELEM_BYTES],
   memcpy(out, reversed, sizeof(reversed));
 }
 
-static inline secp256k1_fe fe_read(RvState* state, uint32_t ptr) {
+static inline secp256k1_fe fe_read(RvState* state, uint64_t ptr) {
   uint64_t words[SECP256K1_ELEM_WORDS];
   rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
@@ -52,7 +52,7 @@ static inline secp256k1_fe fe_read(RvState* state, uint32_t ptr) {
   return r;
 }
 
-static inline void fe_write(RvState* state, uint32_t ptr,
+static inline void fe_write(RvState* state, uint64_t ptr,
                             const secp256k1_fe* val) {
   secp256k1_fe t = *val;
   secp256k1_fe_normalize_var(&t);
@@ -102,7 +102,7 @@ static inline int fe_is_zero(const secp256k1_fe* a) {
 
 /* ── k256 scalar (mod n) helpers ─────────────────────────────────────── */
 
-static inline secp256k1_scalar scalar_read(RvState* state, uint32_t ptr) {
+static inline secp256k1_scalar scalar_read(RvState* state, uint64_t ptr) {
   uint64_t words[SECP256K1_ELEM_WORDS];
   rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
@@ -114,7 +114,7 @@ static inline secp256k1_scalar scalar_read(RvState* state, uint32_t ptr) {
   return r;
 }
 
-static inline void scalar_write(RvState* state, uint32_t ptr,
+static inline void scalar_write(RvState* state, uint64_t ptr,
                                 const secp256k1_scalar* val) {
   uint8_t be[SECP256K1_ELEM_BYTES];
   secp256k1_scalar_get_b32(be, val);
@@ -128,7 +128,7 @@ static inline void scalar_write(RvState* state, uint32_t ptr,
 /* ── Modular arithmetic: secp256k1 coordinate field (mod p) ──────────── */
 
 __attribute__((preserve_most)) void rvr_ext_mod_add_k256_coord(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_fe a = fe_read(state, rs1_ptr);
   secp256k1_fe b = fe_read(state, rs2_ptr);
   secp256k1_fe r = fe_add(a, &b);
@@ -136,7 +136,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_add_k256_coord(
 }
 
 __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_coord(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_fe a = fe_read(state, rs1_ptr);
   secp256k1_fe b = fe_read(state, rs2_ptr);
   secp256k1_fe r = fe_sub(&a, &b);
@@ -144,7 +144,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_coord(
 }
 
 __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_coord(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_fe a = fe_read(state, rs1_ptr);
   secp256k1_fe b = fe_read(state, rs2_ptr);
   secp256k1_fe r = fe_mul(&a, &b);
@@ -152,7 +152,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_coord(
 }
 
 __attribute__((preserve_most)) void rvr_ext_mod_div_k256_coord(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_fe a = fe_read(state, rs1_ptr);
   secp256k1_fe b = fe_read(state, rs2_ptr);
   debug_assume(!fe_is_zero(&b));
@@ -162,7 +162,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_div_k256_coord(
 }
 
 __attribute__((preserve_most)) uint32_t rvr_ext_mod_iseq_k256_coord(
-    RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_fe a = fe_read(state, rs1_ptr);
   secp256k1_fe b = fe_read(state, rs2_ptr);
   return secp256k1_fe_equal(&a, &b) ? 1u : 0u;
@@ -171,7 +171,7 @@ __attribute__((preserve_most)) uint32_t rvr_ext_mod_iseq_k256_coord(
 /* ── Modular arithmetic: secp256k1 scalar field (mod n) ──────────────── */
 
 __attribute__((preserve_most)) void rvr_ext_mod_add_k256_scalar(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_scalar a = scalar_read(state, rs1_ptr);
   secp256k1_scalar b = scalar_read(state, rs2_ptr);
   secp256k1_scalar r;
@@ -180,7 +180,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_add_k256_scalar(
 }
 
 __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_scalar(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_scalar a = scalar_read(state, rs1_ptr);
   secp256k1_scalar b = scalar_read(state, rs2_ptr);
   secp256k1_scalar neg_b;
@@ -191,7 +191,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_sub_k256_scalar(
 }
 
 __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_scalar(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_scalar a = scalar_read(state, rs1_ptr);
   secp256k1_scalar b = scalar_read(state, rs2_ptr);
   secp256k1_scalar r;
@@ -200,7 +200,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_mul_k256_scalar(
 }
 
 __attribute__((preserve_most)) void rvr_ext_mod_div_k256_scalar(
-    RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_scalar a = scalar_read(state, rs1_ptr);
   secp256k1_scalar b = scalar_read(state, rs2_ptr);
   debug_assume(!secp256k1_scalar_is_zero(&b));
@@ -212,7 +212,7 @@ __attribute__((preserve_most)) void rvr_ext_mod_div_k256_scalar(
 }
 
 __attribute__((preserve_most)) uint32_t rvr_ext_mod_iseq_k256_scalar(
-    RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr) {
+    RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr) {
   secp256k1_scalar a = scalar_read(state, rs1_ptr);
   secp256k1_scalar b = scalar_read(state, rs2_ptr);
   return secp256k1_scalar_eq(&a, &b) ? 1u : 0u;
@@ -222,9 +222,9 @@ __attribute__((preserve_most)) uint32_t rvr_ext_mod_iseq_k256_scalar(
  * the ECC extension is configured at lift time) ──────────────────────── */
 
 __attribute__((preserve_most)) void rvr_ext_ec_add_ne_k256(RvState* state,
-                                                           uint32_t rd_ptr,
-                                                           uint32_t rs1_ptr,
-                                                           uint32_t rs2_ptr) {
+                                                           uint64_t rd_ptr,
+                                                           uint64_t rs1_ptr,
+                                                           uint64_t rs2_ptr) {
   secp256k1_fe x1 = fe_read(state, rs1_ptr);
   secp256k1_fe y1 = fe_read(state, rs1_ptr + SECP256K1_ELEM_BYTES);
   secp256k1_fe x2 = fe_read(state, rs2_ptr);
@@ -252,8 +252,8 @@ __attribute__((preserve_most)) void rvr_ext_ec_add_ne_k256(RvState* state,
 }
 
 __attribute__((preserve_most)) void rvr_ext_ec_double_k256(RvState* state,
-                                                           uint32_t rd_ptr,
-                                                           uint32_t rs1_ptr) {
+                                                           uint64_t rd_ptr,
+                                                           uint64_t rs1_ptr) {
   secp256k1_fe x1 = fe_read(state, rs1_ptr);
   secp256k1_fe y1 = fe_read(state, rs1_ptr + SECP256K1_ELEM_BYTES);
 

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -48,11 +48,11 @@ struct UnknownPrimeField {
 impl<F: PrimeField<Repr = [u8; 32]>> FieldArith for KnownPrimeField<F> {
     type Elem = F;
     #[inline(always)]
-    unsafe fn read_elem(&self, state: *mut c_void, ptr: u32) -> Self::Elem {
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         read_field_256(state, ptr)
     }
     #[inline(always)]
-    unsafe fn write_elem(&self, state: *mut c_void, ptr: u32, val: &Self::Elem) {
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_field_256(state, ptr, val)
     }
     #[inline(always)]
@@ -82,11 +82,11 @@ impl<F: PrimeField<Repr = [u8; 32]>> FieldArith for KnownPrimeField<F> {
 impl FieldArith for KnownPrimeField<Bls12381Fq> {
     type Elem = blstrs::Fp;
     #[inline(always)]
-    unsafe fn read_elem(&self, state: *mut c_void, ptr: u32) -> Self::Elem {
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         read_bls12_381_fq(state, ptr)
     }
     #[inline(always)]
-    unsafe fn write_elem(&self, state: *mut c_void, ptr: u32, val: &Self::Elem) {
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_bls12_381_fq(state, ptr, val)
     }
     #[inline(always)]
@@ -116,11 +116,11 @@ impl FieldArith for KnownPrimeField<Bls12381Fq> {
 impl FieldArith for UnknownPrimeField {
     type Elem = BigUint;
 
-    unsafe fn read_elem(&self, state: *mut c_void, ptr: u32) -> Self::Elem {
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
         read_bigint(state, ptr, self.num_limbs)
     }
 
-    unsafe fn write_elem(&self, state: *mut c_void, ptr: u32, val: &Self::Elem) {
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_bigint(state, ptr, val, self.num_limbs)
     }
 
@@ -149,7 +149,7 @@ impl FieldArith for UnknownPrimeField {
 // ── Instruction execution helpers ────────────────────────────────────────────
 
 #[inline(always)]
-unsafe fn exec_iseq<F: FieldArith>(f: &F, state: *mut c_void, rs1_ptr: u32, rs2_ptr: u32) -> u32 {
+unsafe fn exec_iseq<F: FieldArith>(f: &F, state: *mut c_void, rs1_ptr: u64, rs2_ptr: u64) -> u32 {
     let a = f.read_elem(state, rs1_ptr);
     let b = f.read_elem(state, rs2_ptr);
     if f.is_eq(&a, &b) {
@@ -166,7 +166,7 @@ macro_rules! field_op_fn {
         /// # Safety
         /// `state` must be a valid `RvState` pointer.
         #[no_mangle]
-        pub unsafe extern "C" fn $name(state: *mut c_void, rd: u32, rs1: u32, rs2: u32) {
+        pub unsafe extern "C" fn $name(state: *mut c_void, rd: u64, rs1: u64, rs2: u64) {
             let f = KnownPrimeField::<$field>(PhantomData);
             exec_op(&f, state, rd, rs1, rs2, |f, a, b| f.$op(a, b));
         }
@@ -184,7 +184,7 @@ macro_rules! define_mod_ffi {
             /// `state` must be a valid `RvState` pointer.
             #[no_mangle]
             pub unsafe extern "C" fn [<rvr_ext_mod_iseq_ $suffix>](
-                state: *mut c_void, rs1: u32, rs2: u32,
+                state: *mut c_void, rs1: u64, rs2: u64,
             ) -> u32 { exec_iseq(&KnownPrimeField::<$field>(PhantomData), state, rs1, rs2) }
         }
     };
@@ -211,9 +211,9 @@ macro_rules! unknown_field_op_fn {
         #[no_mangle]
         pub unsafe extern "C" fn $name(
             state: *mut c_void,
-            rd_ptr: u32,
-            rs1_ptr: u32,
-            rs2_ptr: u32,
+            rd_ptr: u64,
+            rs1_ptr: u64,
+            rs2_ptr: u64,
             num_limbs: u32,
             modulus_ptr: *const u8,
         ) {
@@ -235,8 +235,8 @@ unknown_field_op_fn!(rvr_ext_mod_div, div);
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_mod_iseq(
     state: *mut c_void,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
     num_limbs: u32,
     modulus_ptr: *const u8,
 ) -> u32 {
@@ -251,9 +251,9 @@ pub unsafe extern "C" fn rvr_ext_mod_iseq(
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_mod_setup(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
     num_limbs: u32,
 ) {
     let num_words = num_limbs / WORD_SIZE as u32;
@@ -329,7 +329,7 @@ fn mod_sqrt_impl(x: &BigUint, modulus: &BigUint, non_qr: &BigUint) -> Option<Big
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_algebra_hint_sqrt(
     state: *mut c_void,
-    rs1_ptr: u32,
+    rs1_ptr: u64,
     num_limbs: u32,
     modulus_ptr: *const u8,
     non_qr_ptr: *const u8,

--- a/extensions/bigint/rvr/c/rvr_ext_bigint.h
+++ b/extensions/bigint/rvr/c/rvr_ext_bigint.h
@@ -7,25 +7,25 @@ struct RvState;
 
 /* 256-bit ALU operations (implemented in Rust). One specialized FFI entry
  * point per opcode so the C compiler does not see a runtime `op` switch. */
-extern void rvr_ext_int256_add(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_sub(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_xor(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_or(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_and(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_sll(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_srl(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_sra(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_int256_slt(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_int256_add(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_sub(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_xor(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_or(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_and(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_sll(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_srl(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_sra(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_int256_slt(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
 extern void rvr_ext_int256_sltu(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr,
                                 uint32_t rs2_ptr);
-extern void rvr_ext_int256_mul(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern void rvr_ext_int256_mul(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
 /* 256-bit branch predicates. Each returns 1 if the branch should be taken. */
-extern uint32_t rvr_ext_int256_beq(RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern uint32_t rvr_ext_int256_bne(RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern uint32_t rvr_ext_int256_blt(RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern uint32_t rvr_ext_int256_bltu(RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern uint32_t rvr_ext_int256_bge(RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern uint32_t rvr_ext_int256_bgeu(RvState* state, uint32_t rs1_ptr, uint32_t rs2_ptr);
+extern uint32_t rvr_ext_int256_beq(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern uint32_t rvr_ext_int256_bne(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern uint32_t rvr_ext_int256_blt(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern uint32_t rvr_ext_int256_bltu(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern uint32_t rvr_ext_int256_bge(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern uint32_t rvr_ext_int256_bgeu(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
 #endif /* RVR_EXT_BIGINT_H */

--- a/extensions/bigint/rvr/c/rvr_ext_bigint.h
+++ b/extensions/bigint/rvr/c/rvr_ext_bigint.h
@@ -16,8 +16,8 @@ extern void rvr_ext_int256_sll(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr
 extern void rvr_ext_int256_srl(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
 extern void rvr_ext_int256_sra(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
 extern void rvr_ext_int256_slt(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
-extern void rvr_ext_int256_sltu(RvState* state, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                uint32_t rs2_ptr);
+extern void rvr_ext_int256_sltu(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                uint64_t rs2_ptr);
 extern void rvr_ext_int256_mul(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
 
 /* 256-bit branch predicates. Each returns 1 if the branch should be taken. */

--- a/extensions/bigint/rvr/ffi/src/lib.rs
+++ b/extensions/bigint/rvr/ffi/src/lib.rs
@@ -41,7 +41,7 @@ const SIGN_BIT_MASK: u8 = 1 << SIGN_BIT_SHIFT;
 
 /// Read a 256-bit value from memory as INT256_WORDS LE words.
 #[inline]
-unsafe fn read_int256(state: *mut c_void, ptr: u32) -> [u8; INT256_BYTES] {
+unsafe fn read_int256(state: *mut c_void, ptr: u64) -> [u8; INT256_BYTES] {
     let mut words = [0u64; INT256_WORDS];
     rd_mem_words_traced(state, ptr, &mut words);
     let mut bytes = [0u8; INT256_BYTES];
@@ -53,7 +53,7 @@ unsafe fn read_int256(state: *mut c_void, ptr: u32) -> [u8; INT256_BYTES] {
 
 /// Write a 256-bit value to memory as INT256_WORDS LE words.
 #[inline]
-unsafe fn write_int256(state: *mut c_void, ptr: u32, bytes: &[u8; INT256_BYTES]) {
+unsafe fn write_int256(state: *mut c_void, ptr: u64, bytes: &[u8; INT256_BYTES]) {
     let mut words = [0u64; INT256_WORDS];
     for (i, w) in words.iter_mut().enumerate() {
         *w = u64::from_le_bytes(
@@ -302,9 +302,9 @@ macro_rules! int256_alu_fn {
         #[no_mangle]
         pub unsafe extern "C" fn $name(
             state: *mut c_void,
-            rd_ptr: u32,
-            rs1_ptr: u32,
-            rs2_ptr: u32,
+            rd_ptr: u64,
+            rs1_ptr: u64,
+            rs2_ptr: u64,
         ) {
             let rs1 = read_int256(state, rs1_ptr);
             let rs2 = read_int256(state, rs2_ptr);
@@ -332,7 +332,7 @@ macro_rules! int256_branch_fn {
         /// # Safety
         /// `state` must be a valid pointer to the C `RvState` struct.
         #[no_mangle]
-        pub unsafe extern "C" fn $name(state: *mut c_void, rs1_ptr: u32, rs2_ptr: u32) -> u32 {
+        pub unsafe extern "C" fn $name(state: *mut c_void, rs1_ptr: u64, rs2_ptr: u64) -> u32 {
             let rs1 = read_int256(state, rs1_ptr);
             let rs2 = read_int256(state, rs2_ptr);
             ($cond(&rs1, &rs2)) as u32

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -106,8 +106,8 @@ void rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
    * row is an independent batched write (the trace API is per-row). */
   uint32_t num_data_rows = (uint32_t)(output_len / DEFERRAL_DIGEST_SIZE);
   uint64_t row_words[DIGEST_MEMORY_OPS];
-  for (uint32_t row_idx = 0; row_idx < num_data_rows; row_idx++) {
-    uint64_t row_byte_base = (uint64_t)row_idx * DEFERRAL_DIGEST_SIZE;
+  for (uint64_t row_idx = 0; row_idx < num_data_rows; row_idx++) {
+    uint64_t row_byte_base = row_idx * DEFERRAL_DIGEST_SIZE;
     memcpy(row_words, output_raw + row_byte_base, DEFERRAL_DIGEST_SIZE);
     wr_mem_u64_range_traced(state, output_ptr + row_byte_base, row_words,
                             DIGEST_MEMORY_OPS);

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -46,8 +46,8 @@ void register_deferral_callbacks(const DeferralHostCallbacks* cb) {
 }
 
 /* Deferral CALL: read input_commit, look up output_key, write it. */
-void rvr_ext_deferral_call(RvState* restrict state, uint32_t output_ptr,
-                           uint32_t input_ptr, uint32_t def_idx,
+void rvr_ext_deferral_call(RvState* restrict state, uint64_t output_ptr,
+                           uint64_t input_ptr, uint32_t def_idx,
                            uint32_t poseidon2_chip_idx) {
   /* Read input_commit (COMMIT_WORDS words) from guest memory. */
   uint64_t commit_words[COMMIT_WORDS];
@@ -58,8 +58,8 @@ void rvr_ext_deferral_call(RvState* restrict state, uint32_t output_ptr,
    * TODO: deferral address space elements are field elements, not u32.
    * Page tracking currently assumes u32 cells — verify that the page and
    * chunk geometry is correct for field-element-typed cells. */
-  uint32_t input_acc_ptr = 2u * def_idx * DEFERRAL_DIGEST_SIZE;
-  uint32_t output_acc_ptr = input_acc_ptr + DEFERRAL_DIGEST_SIZE;
+  uint64_t input_acc_ptr = 2u * def_idx * DEFERRAL_DIGEST_SIZE;
+  uint64_t output_acc_ptr = input_acc_ptr + DEFERRAL_DIGEST_SIZE;
   trace_mem_access_u64_range(state, input_acc_ptr, DIGEST_MEMORY_OPS,
                              AS_DEFERRAL);
   trace_mem_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
@@ -83,8 +83,8 @@ void rvr_ext_deferral_call(RvState* restrict state, uint32_t output_ptr,
 }
 
 /* Deferral OUTPUT: read output_key, look up raw output, write it. */
-void rvr_ext_deferral_output(RvState* restrict state, uint32_t output_ptr,
-                             uint32_t input_ptr, uint32_t def_idx,
+void rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
+                             uint64_t input_ptr, uint32_t def_idx,
                              uint32_t output_chip_idx,
                              uint32_t poseidon2_chip_idx) {
   /* Read output_key (OUTPUT_KEY_WORDS words) from guest memory. */
@@ -107,7 +107,7 @@ void rvr_ext_deferral_output(RvState* restrict state, uint32_t output_ptr,
   uint32_t num_data_rows = (uint32_t)(output_len / DEFERRAL_DIGEST_SIZE);
   uint64_t row_words[DIGEST_MEMORY_OPS];
   for (uint32_t row_idx = 0; row_idx < num_data_rows; row_idx++) {
-    uint32_t row_byte_base = row_idx * DEFERRAL_DIGEST_SIZE;
+    uint64_t row_byte_base = (uint64_t)row_idx * DEFERRAL_DIGEST_SIZE;
     memcpy(row_words, output_raw + row_byte_base, DEFERRAL_DIGEST_SIZE);
     wr_mem_u64_range_traced(state, output_ptr + row_byte_base, row_words,
                             DIGEST_MEMORY_OPS);

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.h
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.h
@@ -6,13 +6,13 @@
 struct RvState;
 
 /* Deferral CALL extension entry point (defined in rvr_ext_deferral.c). */
-extern void rvr_ext_deferral_call(RvState* state, uint32_t output_ptr,
-                                  uint32_t input_ptr, uint32_t def_idx,
+extern void rvr_ext_deferral_call(RvState* state, uint64_t output_ptr,
+                                  uint64_t input_ptr, uint32_t def_idx,
                                   uint32_t poseidon2_chip_idx);
 
 /* Deferral OUTPUT extension entry point (defined in rvr_ext_deferral.c). */
-extern void rvr_ext_deferral_output(RvState* state, uint32_t output_ptr,
-                                    uint32_t input_ptr, uint32_t def_idx,
+extern void rvr_ext_deferral_output(RvState* state, uint64_t output_ptr,
+                                    uint64_t input_ptr, uint32_t def_idx,
                                     uint32_t output_chip_idx,
                                     uint32_t poseidon2_chip_idx);
 

--- a/extensions/ecc/rvr/c/rvr_ext_ecc.h
+++ b/extensions/ecc/rvr/c/rvr_ext_ecc.h
@@ -10,32 +10,32 @@ struct RvState;
  * live state in registers across the call. The remaining entry points are
  * Rust-implemented and use the standard C ABI. */
 
-extern __attribute__((preserve_most)) void rvr_ext_ec_add_ne_k256(RvState*, uint32_t rd_ptr,
-                                                                  uint32_t rs1_ptr,
-                                                                  uint32_t rs2_ptr);
-extern void rvr_ext_setup_ec_add_ne_k256(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern __attribute__((preserve_most)) void rvr_ext_ec_double_k256(RvState*, uint32_t rd_ptr,
-                                                                  uint32_t rs1_ptr);
-extern void rvr_ext_setup_ec_double_k256(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_ec_add_ne_k256(RvState*, uint64_t rd_ptr,
+                                                                  uint64_t rs1_ptr,
+                                                                  uint64_t rs2_ptr);
+extern void rvr_ext_setup_ec_add_ne_k256(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern __attribute__((preserve_most)) void rvr_ext_ec_double_k256(RvState*, uint64_t rd_ptr,
+                                                                  uint64_t rs1_ptr);
+extern void rvr_ext_setup_ec_double_k256(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr);
 
-extern void rvr_ext_ec_add_ne_p256(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_setup_ec_add_ne_p256(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                         uint32_t rs2_ptr);
-extern void rvr_ext_ec_double_p256(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr);
-extern void rvr_ext_setup_ec_double_p256(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr);
+extern void rvr_ext_ec_add_ne_p256(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_setup_ec_add_ne_p256(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                         uint64_t rs2_ptr);
+extern void rvr_ext_ec_double_p256(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr);
+extern void rvr_ext_setup_ec_double_p256(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr);
 
-extern void rvr_ext_ec_add_ne_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr, uint32_t rs2_ptr);
-extern void rvr_ext_setup_ec_add_ne_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                          uint32_t rs2_ptr);
-extern void rvr_ext_ec_double_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr);
-extern void rvr_ext_setup_ec_double_bn254(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr);
+extern void rvr_ext_ec_add_ne_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
+extern void rvr_ext_setup_ec_add_ne_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                          uint64_t rs2_ptr);
+extern void rvr_ext_ec_double_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr);
+extern void rvr_ext_setup_ec_double_bn254(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr);
 
-extern void rvr_ext_ec_add_ne_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                        uint32_t rs2_ptr);
-extern void rvr_ext_setup_ec_add_ne_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr,
-                                              uint32_t rs2_ptr);
-extern void rvr_ext_ec_double_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr);
-extern void rvr_ext_setup_ec_double_bls12_381(RvState*, uint32_t rd_ptr, uint32_t rs1_ptr);
+extern void rvr_ext_ec_add_ne_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                        uint64_t rs2_ptr);
+extern void rvr_ext_setup_ec_add_ne_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr,
+                                              uint64_t rs2_ptr);
+extern void rvr_ext_ec_double_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr);
+extern void rvr_ext_setup_ec_double_bls12_381(RvState*, uint64_t rd_ptr, uint64_t rs1_ptr);
 
 #endif /* RVR_EXT_ECC_H */

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -68,60 +68,60 @@ fn ec_double_impl<F: Field>(x1: F, y1: F, a: F) -> (F, F) {
 #[inline(always)]
 unsafe fn ec_add_ne_256<F: halo2curves_axiom::ff::PrimeField<Repr = [u8; FIELD_256_BYTES]>>(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
 ) {
     let x1: F = read_field_256(state, rs1_ptr);
-    let y1: F = read_field_256(state, rs1_ptr + FIELD_256_BYTES as u32);
+    let y1: F = read_field_256(state, rs1_ptr + FIELD_256_BYTES as u64);
     let x2: F = read_field_256(state, rs2_ptr);
-    let y2: F = read_field_256(state, rs2_ptr + FIELD_256_BYTES as u32);
+    let y2: F = read_field_256(state, rs2_ptr + FIELD_256_BYTES as u64);
     let (x3, y3) = ec_add_ne_impl(x1, y1, x2, y2);
     write_field_256(state, rd_ptr, &x3);
-    write_field_256(state, rd_ptr + FIELD_256_BYTES as u32, &y3);
+    write_field_256(state, rd_ptr + FIELD_256_BYTES as u64, &y3);
 }
 
 /// Execute ec_double for a 256-bit PrimeField curve.
 #[inline(always)]
 unsafe fn ec_double_256<F: halo2curves_axiom::ff::PrimeField<Repr = [u8; FIELD_256_BYTES]>>(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
     a: F,
 ) {
     let x1: F = read_field_256(state, rs1_ptr);
-    let y1: F = read_field_256(state, rs1_ptr + FIELD_256_BYTES as u32);
+    let y1: F = read_field_256(state, rs1_ptr + FIELD_256_BYTES as u64);
     let (x3, y3) = ec_double_impl(x1, y1, a);
     write_field_256(state, rd_ptr, &x3);
-    write_field_256(state, rd_ptr + FIELD_256_BYTES as u32, &y3);
+    write_field_256(state, rd_ptr + FIELD_256_BYTES as u64, &y3);
 }
 
 // ── BLS12-381 helpers ─────────────────────────────────────────────────────────
 
-unsafe fn ec_add_ne_bls12_381(state: *mut c_void, rd_ptr: u32, rs1_ptr: u32, rs2_ptr: u32) {
+unsafe fn ec_add_ne_bls12_381(state: *mut c_void, rd_ptr: u64, rs1_ptr: u64, rs2_ptr: u64) {
     let x1 = read_bls12_381_fq(state, rs1_ptr);
-    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_ELEM_BYTES as u32);
+    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_ELEM_BYTES as u64);
     let x2 = read_bls12_381_fq(state, rs2_ptr);
-    let y2 = read_bls12_381_fq(state, rs2_ptr + BLS12_381_ELEM_BYTES as u32);
+    let y2 = read_bls12_381_fq(state, rs2_ptr + BLS12_381_ELEM_BYTES as u64);
     let (x3, y3) = ec_add_ne_impl(x1, y1, x2, y2);
     write_bls12_381_fq(state, rd_ptr, &x3);
-    write_bls12_381_fq(state, rd_ptr + BLS12_381_ELEM_BYTES as u32, &y3);
+    write_bls12_381_fq(state, rd_ptr + BLS12_381_ELEM_BYTES as u64, &y3);
 }
 
-unsafe fn ec_double_bls12_381(state: *mut c_void, rd_ptr: u32, rs1_ptr: u32) {
+unsafe fn ec_double_bls12_381(state: *mut c_void, rd_ptr: u64, rs1_ptr: u64) {
     let x1 = read_bls12_381_fq(state, rs1_ptr);
-    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_ELEM_BYTES as u32);
+    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_ELEM_BYTES as u64);
     // BLS12-381 has a = 0
     let (x3, y3) = ec_double_impl(x1, y1, blstrs::Fp::ZERO);
     write_bls12_381_fq(state, rd_ptr, &x3);
-    write_bls12_381_fq(state, rd_ptr + BLS12_381_ELEM_BYTES as u32, &y3);
+    write_bls12_381_fq(state, rd_ptr + BLS12_381_ELEM_BYTES as u64, &y3);
 }
 
 // ── Curve constants ──────────────────────────────────────────────────────────
 
 const P256_A_ABS: u64 = 3;
 
-unsafe fn trace_read_bytes(state: *mut c_void, ptr: u32, len: u32) -> Vec<u8> {
+unsafe fn trace_read_bytes(state: *mut c_void, ptr: u64, len: u32) -> Vec<u8> {
     debug_assert_eq!(len % WORD_SIZE as u32, 0);
     let num_words = (len as usize) / WORD_SIZE;
     let mut words = vec![0u64; num_words];
@@ -133,7 +133,7 @@ unsafe fn trace_read_bytes(state: *mut c_void, ptr: u32, len: u32) -> Vec<u8> {
     bytes
 }
 
-unsafe fn trace_write_bytes(state: *mut c_void, ptr: u32, bytes: &[u8]) {
+unsafe fn trace_write_bytes(state: *mut c_void, ptr: u64, bytes: &[u8]) {
     debug_assert_eq!(bytes.len() % WORD_SIZE, 0);
     let words: Vec<u64> = bytes
         .chunks_exact(WORD_SIZE)
@@ -174,9 +174,9 @@ fn ecc_setup_expr(point_bytes: u32, setup_bytes: &[u8], is_double: bool) -> Vec<
 
 unsafe fn ec_add_ne_setup(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
     point_bytes: u32,
 ) {
     let mut setup_bytes = trace_read_bytes(state, rs1_ptr, point_bytes);
@@ -185,7 +185,7 @@ unsafe fn ec_add_ne_setup(
     trace_write_bytes(state, rd_ptr, &output);
 }
 
-unsafe fn ec_double_setup(state: *mut c_void, rd_ptr: u32, rs1_ptr: u32, point_bytes: u32) {
+unsafe fn ec_double_setup(state: *mut c_void, rd_ptr: u64, rs1_ptr: u64, point_bytes: u32) {
     let setup_bytes = trace_read_bytes(state, rs1_ptr, point_bytes);
     let output = ecc_setup_expr(point_bytes, &setup_bytes, true);
     trace_write_bytes(state, rd_ptr, &output);
@@ -195,9 +195,9 @@ unsafe fn ec_add_ne_256_entry<
     F: halo2curves_axiom::ff::PrimeField<Repr = [u8; FIELD_256_BYTES]>,
 >(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
 ) {
     ec_add_ne_256::<F>(state, rd_ptr, rs1_ptr, rs2_ptr);
 }
@@ -206,8 +206,8 @@ unsafe fn ec_double_256_entry<
     F: halo2curves_axiom::ff::PrimeField<Repr = [u8; FIELD_256_BYTES]>,
 >(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
     a: F,
 ) {
     ec_double_256(state, rd_ptr, rs1_ptr, a);
@@ -222,9 +222,9 @@ macro_rules! ecc_add_ne_entry {
         #[no_mangle]
         pub unsafe extern "C" fn $name(
             state: *mut c_void,
-            rd_ptr: u32,
-            rs1_ptr: u32,
-            rs2_ptr: u32,
+            rd_ptr: u64,
+            rs1_ptr: u64,
+            rs2_ptr: u64,
         ) {
             ec_add_ne_256_entry::<$curve>(state, rd_ptr, rs1_ptr, rs2_ptr);
         }
@@ -238,7 +238,7 @@ macro_rules! ecc_double_entry {
         /// `state` must point to a valid native tracer state for this execution.
         /// Pointer parameters must point to valid affine point coordinates.
         #[no_mangle]
-        pub unsafe extern "C" fn $name(state: *mut c_void, rd_ptr: u32, rs1_ptr: u32) {
+        pub unsafe extern "C" fn $name(state: *mut c_void, rd_ptr: u64, rs1_ptr: u64) {
             ec_double_256_entry::<$curve>(state, rd_ptr, rs1_ptr, $a);
         }
     };
@@ -253,9 +253,9 @@ macro_rules! ecc_add_ne_setup_entry {
         #[no_mangle]
         pub unsafe extern "C" fn $name(
             state: *mut c_void,
-            rd_ptr: u32,
-            rs1_ptr: u32,
-            rs2_ptr: u32,
+            rd_ptr: u64,
+            rs1_ptr: u64,
+            rs2_ptr: u64,
         ) {
             ec_add_ne_setup(state, rd_ptr, rs1_ptr, rs2_ptr, $point_bytes);
         }
@@ -269,7 +269,7 @@ macro_rules! ecc_double_setup_entry {
         /// `state` must point to a valid native tracer state for this execution.
         /// Pointer parameters must point to valid affine point coordinates.
         #[no_mangle]
-        pub unsafe extern "C" fn $name(state: *mut c_void, rd_ptr: u32, rs1_ptr: u32) {
+        pub unsafe extern "C" fn $name(state: *mut c_void, rd_ptr: u64, rs1_ptr: u64) {
             ec_double_setup(state, rd_ptr, rs1_ptr, $point_bytes);
         }
     };
@@ -306,9 +306,9 @@ ecc_double_setup_entry!(rvr_ext_setup_ec_double_bn254, POINT_256_BYTES);
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_ec_add_ne_bls12_381(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
 ) {
     ec_add_ne_bls12_381(state, rd_ptr, rs1_ptr, rs2_ptr);
 }
@@ -323,8 +323,8 @@ ecc_add_ne_setup_entry!(rvr_ext_setup_ec_add_ne_bls12_381, POINT_BLS12_381_BYTES
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_ec_double_bls12_381(
     state: *mut c_void,
-    rd_ptr: u32,
-    rs1_ptr: u32,
+    rd_ptr: u64,
+    rs1_ptr: u64,
 ) {
     ec_double_bls12_381(state, rd_ptr, rs1_ptr);
 }

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -17,6 +17,11 @@ use rvr_openvm_ext_algebra_ffi_common::{
 };
 use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_SIZE};
 
+/// BN254 base field element size in bytes, as `u64` for address arithmetic.
+const BN254_FQ_BYTES: u64 = FIELD_256_BYTES as u64;
+/// BLS12-381 base field element size in bytes, as `u64` for address arithmetic.
+const BLS12_381_FQ_BYTES: u64 = BLS12_381_ELEM_BYTES as u64;
+
 /// Affine point: two field coordinates (x, y).
 const AFFINE_COORDS: u32 = 2;
 /// Size of a 256-bit affine point in bytes.
@@ -73,12 +78,12 @@ unsafe fn ec_add_ne_256<F: halo2curves_axiom::ff::PrimeField<Repr = [u8; FIELD_2
     rs2_ptr: u64,
 ) {
     let x1: F = read_field_256(state, rs1_ptr);
-    let y1: F = read_field_256(state, rs1_ptr + FIELD_256_BYTES as u64);
+    let y1: F = read_field_256(state, rs1_ptr + BN254_FQ_BYTES);
     let x2: F = read_field_256(state, rs2_ptr);
-    let y2: F = read_field_256(state, rs2_ptr + FIELD_256_BYTES as u64);
+    let y2: F = read_field_256(state, rs2_ptr + BN254_FQ_BYTES);
     let (x3, y3) = ec_add_ne_impl(x1, y1, x2, y2);
     write_field_256(state, rd_ptr, &x3);
-    write_field_256(state, rd_ptr + FIELD_256_BYTES as u64, &y3);
+    write_field_256(state, rd_ptr + BN254_FQ_BYTES, &y3);
 }
 
 /// Execute ec_double for a 256-bit PrimeField curve.
@@ -90,31 +95,31 @@ unsafe fn ec_double_256<F: halo2curves_axiom::ff::PrimeField<Repr = [u8; FIELD_2
     a: F,
 ) {
     let x1: F = read_field_256(state, rs1_ptr);
-    let y1: F = read_field_256(state, rs1_ptr + FIELD_256_BYTES as u64);
+    let y1: F = read_field_256(state, rs1_ptr + BN254_FQ_BYTES);
     let (x3, y3) = ec_double_impl(x1, y1, a);
     write_field_256(state, rd_ptr, &x3);
-    write_field_256(state, rd_ptr + FIELD_256_BYTES as u64, &y3);
+    write_field_256(state, rd_ptr + BN254_FQ_BYTES, &y3);
 }
 
 // ── BLS12-381 helpers ─────────────────────────────────────────────────────────
 
 unsafe fn ec_add_ne_bls12_381(state: *mut c_void, rd_ptr: u64, rs1_ptr: u64, rs2_ptr: u64) {
     let x1 = read_bls12_381_fq(state, rs1_ptr);
-    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_ELEM_BYTES as u64);
+    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_FQ_BYTES);
     let x2 = read_bls12_381_fq(state, rs2_ptr);
-    let y2 = read_bls12_381_fq(state, rs2_ptr + BLS12_381_ELEM_BYTES as u64);
+    let y2 = read_bls12_381_fq(state, rs2_ptr + BLS12_381_FQ_BYTES);
     let (x3, y3) = ec_add_ne_impl(x1, y1, x2, y2);
     write_bls12_381_fq(state, rd_ptr, &x3);
-    write_bls12_381_fq(state, rd_ptr + BLS12_381_ELEM_BYTES as u64, &y3);
+    write_bls12_381_fq(state, rd_ptr + BLS12_381_FQ_BYTES, &y3);
 }
 
 unsafe fn ec_double_bls12_381(state: *mut c_void, rd_ptr: u64, rs1_ptr: u64) {
     let x1 = read_bls12_381_fq(state, rs1_ptr);
-    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_ELEM_BYTES as u64);
+    let y1 = read_bls12_381_fq(state, rs1_ptr + BLS12_381_FQ_BYTES);
     // BLS12-381 has a = 0
     let (x3, y3) = ec_double_impl(x1, y1, blstrs::Fp::ZERO);
     write_bls12_381_fq(state, rd_ptr, &x3);
-    write_bls12_381_fq(state, rd_ptr + BLS12_381_ELEM_BYTES as u64, &y3);
+    write_bls12_381_fq(state, rd_ptr + BLS12_381_FQ_BYTES, &y3);
 }
 
 // ── Curve constants ──────────────────────────────────────────────────────────

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.c
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.c
@@ -12,7 +12,7 @@ static constexpr uint32_t KECCAK_NUM_ROUNDS = 24;
 extern void rvr_keccak_f1600(uint64_t state[25]);
 
 __attribute__((preserve_most)) void rvr_ext_keccakf(RvState* restrict state,
-                                                    uint32_t buffer_ptr,
+                                                    uint64_t buffer_ptr,
                                                     uint32_t _op_chip_idx,
                                                     uint32_t perm_chip_idx) {
   uint64_t st[KECCAK_WIDTH_WORDS];
@@ -29,8 +29,8 @@ __attribute__((preserve_most)) void rvr_ext_keccakf(RvState* restrict state,
 }
 
 __attribute__((preserve_most)) void rvr_ext_xorin(RvState* restrict state,
-                                                  uint32_t buffer_ptr,
-                                                  uint32_t input_ptr,
+                                                  uint64_t buffer_ptr,
+                                                  uint64_t input_ptr,
                                                   uint32_t len,
                                                   uint32_t _chip_idx) {
   uint32_t num_words = (len + WORD_SIZE - 1) / WORD_SIZE;

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.h
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.h
@@ -11,12 +11,12 @@ struct RvState;
  * caller convention. */
 
 extern __attribute__((preserve_most)) void rvr_ext_keccakf(
-    RvState* state, uint32_t buffer_ptr, uint32_t op_chip_idx,
+    RvState* state, uint64_t buffer_ptr, uint32_t op_chip_idx,
     uint32_t perm_chip_idx);
 
 extern __attribute__((preserve_most)) void rvr_ext_xorin(RvState* state,
-                                                         uint32_t buffer_ptr,
-                                                         uint32_t input_ptr,
+                                                         uint64_t buffer_ptr,
+                                                         uint64_t input_ptr,
                                                          uint32_t len,
                                                          uint32_t chip_idx);
 

--- a/extensions/pairing/rvr/c/rvr_ext_pairing.h
+++ b/extensions/pairing/rvr/c/rvr_ext_pairing.h
@@ -7,10 +7,10 @@ struct RvState;
 
 /* HintFinalExp phantom: computes pairing final exponentiation hint and
  * sets the hint stream (implemented in Rust). */
-extern void rvr_ext_pairing_hint_final_exp_bn254(RvState* state, uint32_t rs1_val,
-                                                 uint32_t rs2_val);
+extern void rvr_ext_pairing_hint_final_exp_bn254(RvState* state, uint64_t rs1_val,
+                                                 uint64_t rs2_val);
 
-extern void rvr_ext_pairing_hint_final_exp_bls12_381(RvState* state, uint32_t rs1_val,
-                                                     uint32_t rs2_val);
+extern void rvr_ext_pairing_hint_final_exp_bls12_381(RvState* state, uint64_t rs1_val,
+                                                     uint64_t rs2_val);
 
 #endif /* RVR_EXT_PAIRING_H */

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -17,15 +17,15 @@ use rvr_openvm_ext_ffi_common::{
 };
 
 /// BN254 base field element size in bytes.
-const BN254_FQ_BYTES: u32 = FIELD_256_BYTES as u32;
+const BN254_FQ_BYTES: u64 = FIELD_256_BYTES as u64;
 /// BLS12-381 base field element size in bytes.
-const BLS12_381_FQ_BYTES: u32 = BLS12_381_ELEM_BYTES as u32;
+const BLS12_381_FQ_BYTES: u64 = BLS12_381_ELEM_BYTES as u64;
 /// G1 affine point: two field coordinates (x, y).
-const G1_AFFINE_COORDS: u32 = 2;
+const G1_AFFINE_COORDS: u64 = 2;
 /// G2 affine point: two Fp2 coordinates, each containing two Fp elements.
-const G2_AFFINE_COORDS: u32 = 4;
+const G2_AFFINE_COORDS: u64 = 4;
 /// Offset of `len` in a guest slice header `(data_ptr, len)`.
-const SLICE_LEN_OFFSET: u32 = WORD_SIZE as u32;
+const SLICE_LEN_OFFSET: u64 = WORD_SIZE as u64;
 
 unsafe fn set_hint_stream(bytes: &[u8]) {
     let len: u32 = bytes.len().try_into().unwrap();
@@ -68,8 +68,8 @@ unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u64) -> Option<bls12_381::F
     Option::from(bls12_381::Fq::from_repr(bytes.into()))
 }
 
-fn point_base(ptr: u64, idx: u64, words_per_point: u32) -> Option<u64> {
-    let offset = idx.checked_mul(words_per_point as u64)?;
+fn point_base(ptr: u64, idx: u64, words_per_point: u64) -> Option<u64> {
+    let offset = idx.checked_mul(words_per_point)?;
     ptr.checked_add(offset)
 }
 
@@ -77,9 +77,9 @@ fn point_base(ptr: u64, idx: u64, words_per_point: u32) -> Option<u64> {
 
 unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
     let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
-    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET as u64);
+    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
     let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
-    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET as u64);
+    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
 
     if p_len != q_len {
         return None;
@@ -90,7 +90,7 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<V
             let base = point_base(p_ptr, i, G1_AFFINE_COORDS * BN254_FQ_BYTES)?;
             Some(AffinePoint::new(
                 read_bn254_fq(state, base)?,
-                read_bn254_fq(state, base + BN254_FQ_BYTES as u64)?,
+                read_bn254_fq(state, base + BN254_FQ_BYTES)?,
             ))
         })
         .collect::<Option<_>>()?;
@@ -101,11 +101,11 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<V
             // BN254 Fq2 exposes a constructor helper.
             let x = bn256::Fq2::new(
                 read_bn254_fq(state, base)?,
-                read_bn254_fq(state, base + BN254_FQ_BYTES as u64)?,
+                read_bn254_fq(state, base + BN254_FQ_BYTES)?,
             );
             let y = bn256::Fq2::new(
-                read_bn254_fq(state, base + 2 * BN254_FQ_BYTES as u64)?,
-                read_bn254_fq(state, base + 3 * BN254_FQ_BYTES as u64)?,
+                read_bn254_fq(state, base + 2 * BN254_FQ_BYTES)?,
+                read_bn254_fq(state, base + 3 * BN254_FQ_BYTES)?,
             );
             Some(AffinePoint::new(x, y))
         })
@@ -129,9 +129,9 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<V
 
 unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
     let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
-    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET as u64);
+    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
     let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
-    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET as u64);
+    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
 
     if p_len != q_len {
         return None;
@@ -142,7 +142,7 @@ unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Opti
             let base = point_base(p_ptr, i, G1_AFFINE_COORDS * BLS12_381_FQ_BYTES)?;
             Some(AffinePoint::new(
                 read_bls12_381_fq(state, base)?,
-                read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES as u64)?,
+                read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES)?,
             ))
         })
         .collect::<Option<_>>()?;
@@ -153,11 +153,11 @@ unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Opti
             // BLS12-381 Fq2 uses struct fields instead of an `Fq2::new` helper.
             let x = bls12_381::Fq2 {
                 c0: read_bls12_381_fq(state, base)?,
-                c1: read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES as u64)?,
+                c1: read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES)?,
             };
             let y = bls12_381::Fq2 {
-                c0: read_bls12_381_fq(state, base + 2 * BLS12_381_FQ_BYTES as u64)?,
-                c1: read_bls12_381_fq(state, base + 3 * BLS12_381_FQ_BYTES as u64)?,
+                c0: read_bls12_381_fq(state, base + 2 * BLS12_381_FQ_BYTES)?,
+                c1: read_bls12_381_fq(state, base + 3 * BLS12_381_FQ_BYTES)?,
             };
             Some(AffinePoint::new(x, y))
         })

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -39,7 +39,7 @@ unsafe fn clear_hint_stream() {
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 /// Read `N` bytes from guest memory (untraced, word-aligned reads).
-unsafe fn read_bytes<const N: usize>(state: *mut c_void, ptr: u32) -> [u8; N] {
+unsafe fn read_bytes<const N: usize>(state: *mut c_void, ptr: u64) -> [u8; N] {
     const {
         assert!(
             N.is_multiple_of(WORD_SIZE),
@@ -57,29 +57,29 @@ unsafe fn read_bytes<const N: usize>(state: *mut c_void, ptr: u32) -> [u8; N] {
 }
 
 /// Read an Fq element from guest memory for BN254.
-unsafe fn read_bn254_fq(state: *mut c_void, ptr: u32) -> Option<bn256::Fq> {
+unsafe fn read_bn254_fq(state: *mut c_void, ptr: u64) -> Option<bn256::Fq> {
     let bytes = read_bytes::<{ BN254_FQ_BYTES as usize }>(state, ptr);
     Option::from(bn256::Fq::from_repr(bytes))
 }
 
 /// Read an Fq element from guest memory for BLS12-381.
-unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u32) -> Option<bls12_381::Fq> {
+unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u64) -> Option<bls12_381::Fq> {
     let bytes = read_bytes::<{ BLS12_381_FQ_BYTES as usize }>(state, ptr);
     Option::from(bls12_381::Fq::from_repr(bytes.into()))
 }
 
-fn point_base(ptr: u64, idx: u64, words_per_point: u32) -> Option<u32> {
+fn point_base(ptr: u64, idx: u64, words_per_point: u32) -> Option<u64> {
     let offset = idx.checked_mul(words_per_point as u64)?;
-    ptr.checked_add(offset)?.try_into().ok()
+    ptr.checked_add(offset)
 }
 
 // ── BN254 pairing hint ──────────────────────────────────────────────────
 
-unsafe fn hint_bn254(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<Vec<u8>> {
+unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
     let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
-    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
+    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET as u64);
     let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
-    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
+    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET as u64);
 
     if p_len != q_len {
         return None;
@@ -90,7 +90,7 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<V
             let base = point_base(p_ptr, i, G1_AFFINE_COORDS * BN254_FQ_BYTES)?;
             Some(AffinePoint::new(
                 read_bn254_fq(state, base)?,
-                read_bn254_fq(state, base + BN254_FQ_BYTES)?,
+                read_bn254_fq(state, base + BN254_FQ_BYTES as u64)?,
             ))
         })
         .collect::<Option<_>>()?;
@@ -101,11 +101,11 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<V
             // BN254 Fq2 exposes a constructor helper.
             let x = bn256::Fq2::new(
                 read_bn254_fq(state, base)?,
-                read_bn254_fq(state, base + BN254_FQ_BYTES)?,
+                read_bn254_fq(state, base + BN254_FQ_BYTES as u64)?,
             );
             let y = bn256::Fq2::new(
-                read_bn254_fq(state, base + 2 * BN254_FQ_BYTES)?,
-                read_bn254_fq(state, base + 3 * BN254_FQ_BYTES)?,
+                read_bn254_fq(state, base + 2 * BN254_FQ_BYTES as u64)?,
+                read_bn254_fq(state, base + 3 * BN254_FQ_BYTES as u64)?,
             );
             Some(AffinePoint::new(x, y))
         })
@@ -127,11 +127,11 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<V
 
 // ── BLS12-381 pairing hint ──────────────────────────────────────────────
 
-unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Option<Vec<u8>> {
+unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
     let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
-    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
+    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET as u64);
     let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
-    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
+    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET as u64);
 
     if p_len != q_len {
         return None;
@@ -142,7 +142,7 @@ unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Opti
             let base = point_base(p_ptr, i, G1_AFFINE_COORDS * BLS12_381_FQ_BYTES)?;
             Some(AffinePoint::new(
                 read_bls12_381_fq(state, base)?,
-                read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES)?,
+                read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES as u64)?,
             ))
         })
         .collect::<Option<_>>()?;
@@ -153,11 +153,11 @@ unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Opti
             // BLS12-381 Fq2 uses struct fields instead of an `Fq2::new` helper.
             let x = bls12_381::Fq2 {
                 c0: read_bls12_381_fq(state, base)?,
-                c1: read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES)?,
+                c1: read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES as u64)?,
             };
             let y = bls12_381::Fq2 {
-                c0: read_bls12_381_fq(state, base + 2 * BLS12_381_FQ_BYTES)?,
-                c1: read_bls12_381_fq(state, base + 3 * BLS12_381_FQ_BYTES)?,
+                c0: read_bls12_381_fq(state, base + 2 * BLS12_381_FQ_BYTES as u64)?,
+                c1: read_bls12_381_fq(state, base + 3 * BLS12_381_FQ_BYTES as u64)?,
             };
             Some(AffinePoint::new(x, y))
         })
@@ -183,8 +183,8 @@ unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u32, rs2_val: u32) -> Opti
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_pairing_hint_final_exp_bn254(
     state: *mut c_void,
-    rs1_val: u32,
-    rs2_val: u32,
+    rs1_val: u64,
+    rs2_val: u64,
 ) {
     if let Some(hint_bytes) = hint_bn254(state, rs1_val, rs2_val) {
         set_hint_stream(&hint_bytes);
@@ -198,8 +198,8 @@ pub unsafe extern "C" fn rvr_ext_pairing_hint_final_exp_bn254(
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_pairing_hint_final_exp_bls12_381(
     state: *mut c_void,
-    rs1_val: u32,
-    rs2_val: u32,
+    rs1_val: u64,
+    rs2_val: u64,
 ) {
     if let Some(hint_bytes) = hint_bls12_381(state, rs1_val, rs2_val) {
         set_hint_stream(&hint_bytes);

--- a/extensions/riscv/rvr/c/rv64i_phantom_callbacks.c
+++ b/extensions/riscv/rvr/c/rv64i_phantom_callbacks.c
@@ -9,7 +9,7 @@
 
 typedef struct {
   void (*hint_input)(void* ctx);
-  void (*print_str)(void* ctx, uint32_t ptr, uint32_t len);
+  void (*print_str)(void* ctx, uint64_t ptr, uint32_t len);
   void (*hint_random)(void* ctx, uint32_t num_words);
 } Rv64IPhantomCallbacks;
 
@@ -22,7 +22,7 @@ void register_rv64i_phantom_callbacks(const Rv64IPhantomCallbacks* cb) {
 
 void openvm_hint_input(void) { g_rv64i_phantom_callbacks.hint_input(openvm_get_io_ctx()); }
 
-void openvm_print_str(uint32_t ptr, uint32_t len) {
+void openvm_print_str(uint64_t ptr, uint32_t len) {
   g_rv64i_phantom_callbacks.print_str(openvm_get_io_ctx(), ptr, len);
 }
 

--- a/extensions/riscv/rvr/c/rv64i_phantom_callbacks.h
+++ b/extensions/riscv/rvr/c/rv64i_phantom_callbacks.h
@@ -7,7 +7,7 @@
  * (HINT_INPUT, PRINT_STR, HINT_RANDOM). Backed by a dispatch table installed
  * by `Rv64IExtension::register_host_callbacks`. */
 void openvm_hint_input(void);
-void openvm_print_str(uint32_t ptr, uint32_t len);
+void openvm_print_str(uint64_t ptr, uint32_t len);
 void openvm_hint_random(uint32_t num_words);
 
 #endif /* RV64I_PHANTOM_CALLBACKS_H */

--- a/extensions/riscv/rvr/c/rv64io_callbacks.c
+++ b/extensions/riscv/rvr/c/rv64io_callbacks.c
@@ -9,9 +9,9 @@
 #include "openvm_io.h"
 
 typedef struct {
-  void (*hint_storew)(void* ctx, uint32_t dest_addr);
-  void (*hint_buffer)(void* ctx, uint32_t dest_addr, uint32_t num_words);
-  void (*reveal)(void* ctx, uint64_t src_val, uint32_t ptr, uint32_t offset, uint32_t width);
+  void (*hint_storew)(void* ctx, uint64_t dest_addr);
+  void (*hint_buffer)(void* ctx, uint64_t dest_addr, uint32_t num_words);
+  void (*reveal)(void* ctx, uint64_t src_val, uint64_t ptr, uint32_t offset, uint32_t width);
 } Rv64IoHostCallbacks;
 
 /* NOT thread-safe: installs one process-global callback table. */
@@ -19,14 +19,14 @@ static Rv64IoHostCallbacks g_rv64io_callbacks;
 
 void register_rv64io_callbacks(const Rv64IoHostCallbacks* cb) { g_rv64io_callbacks = *cb; }
 
-void openvm_hint_storew(uint32_t dest_addr) {
+void openvm_hint_storew(uint64_t dest_addr) {
   g_rv64io_callbacks.hint_storew(openvm_get_io_ctx(), dest_addr);
 }
 
-void openvm_hint_buffer(uint32_t dest_addr, uint32_t num_words) {
+void openvm_hint_buffer(uint64_t dest_addr, uint32_t num_words) {
   g_rv64io_callbacks.hint_buffer(openvm_get_io_ctx(), dest_addr, num_words);
 }
 
-void openvm_reveal(uint64_t src_val, uint32_t ptr, uint32_t offset, uint32_t width) {
+void openvm_reveal(uint64_t src_val, uint64_t ptr, uint32_t offset, uint32_t width) {
   g_rv64io_callbacks.reveal(openvm_get_io_ctx(), src_val, ptr, offset, width);
 }

--- a/extensions/riscv/rvr/c/rv64io_callbacks.h
+++ b/extensions/riscv/rvr/c/rv64io_callbacks.h
@@ -7,8 +7,8 @@
  * consumers (HINT_STOREW, HINT_BUFFER) and public-values stores routed through
  * openvm_reveal. Backed by a dispatch table installed by
  * `Rv64IoExtension::register_host_callbacks`. */
-void openvm_hint_storew(uint32_t dest_addr);
-void openvm_hint_buffer(uint32_t dest_addr, uint32_t num_words);
-void openvm_reveal(uint64_t src_val, uint32_t ptr, uint32_t offset, uint32_t width);
+void openvm_hint_storew(uint64_t dest_addr);
+void openvm_hint_buffer(uint64_t dest_addr, uint32_t num_words);
+void openvm_reveal(uint64_t src_val, uint64_t ptr, uint32_t offset, uint32_t width);
 
 #endif /* RV64IO_CALLBACKS_H */

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -378,16 +378,16 @@ type RegisterRv64IoFn = unsafe extern "C" fn(*const Rv64IoHostCallbacks);
 #[repr(C)]
 pub struct Rv64IPhantomCallbacks {
     pub hint_input: extern "C" fn(*mut c_void),
-    pub print_str: extern "C" fn(*mut c_void, u32, u32),
+    pub print_str: extern "C" fn(*mut c_void, u64, u32),
     pub hint_random: extern "C" fn(*mut c_void, u32),
 }
 
 /// Must match the C `Rv64IoHostCallbacks` layout in `rv64io_callbacks.c`.
 #[repr(C)]
 pub struct Rv64IoHostCallbacks {
-    pub hint_storew: extern "C" fn(*mut c_void, u32),
-    pub hint_buffer: extern "C" fn(*mut c_void, u32, u32),
-    pub reveal: extern "C" fn(*mut c_void, u64, u32, u32, u32),
+    pub hint_storew: extern "C" fn(*mut c_void, u64),
+    pub hint_buffer: extern "C" fn(*mut c_void, u64, u32),
+    pub reveal: extern "C" fn(*mut c_void, u64, u64, u32, u32),
 }
 
 // ── Callback implementations ────────────────────────────────────────────────
@@ -411,7 +411,7 @@ pub extern "C" fn host_hint_input<F: PrimeField32>(ctx: *mut c_void) {
 }
 
 /// PrintStr: read UTF-8 from guest memory and print to stdout.
-pub extern "C" fn host_print_str<F: PrimeField32>(ctx: *mut c_void, ptr: u32, len: u32) {
+pub extern "C" fn host_print_str<F: PrimeField32>(ctx: *mut c_void, ptr: u64, len: u32) {
     let io = unsafe { &*(ctx as *const OpenVmIoState<'_, F>) };
     if len > 0 && !io.memory_ptr.is_null() {
         check_mem_bounds_range(ptr, len as usize);
@@ -435,7 +435,7 @@ pub extern "C" fn host_hint_random<F: PrimeField32>(ctx: *mut c_void, num_words:
 
 /// HINT_STOREW: pop one rv64 register-width word (8 bytes) from the hint stream
 /// and write it to guest memory at `dest_addr`.
-pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr: u32) {
+pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr: u64) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
     if io.hint_stream.len() < RV64_REGISTER_NUM_LIMBS || io.memory_ptr.is_null() {
         return;
@@ -458,7 +458,7 @@ pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr:
 /// and copy them as bytes into guest memory.
 pub extern "C" fn host_hint_buffer<F: PrimeField32>(
     ctx: *mut c_void,
-    dest_addr: u32,
+    dest_addr: u64,
     num_words: u32,
 ) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
@@ -479,7 +479,7 @@ pub extern "C" fn host_hint_buffer<F: PrimeField32>(
 pub extern "C" fn host_reveal<F: PrimeField32>(
     ctx: *mut c_void,
     src_val: u64,
-    ptr: u32,
+    ptr: u64,
     offset: u32,
     width: u32,
 ) {

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -495,7 +495,6 @@ pub extern "C" fn host_reveal<F: PrimeField32>(
     io.public_values[start..end].copy_from_slice(&src_val.to_le_bytes()[..width]);
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;

--- a/extensions/sha2/rvr/c/rvr_ext_sha2.h
+++ b/extensions/sha2/rvr/c/rvr_ext_sha2.h
@@ -6,11 +6,11 @@
 struct RvState;
 
 /* SHA-256 compress extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_sha256(RvState* state, uint32_t dst_ptr, uint32_t state_ptr, uint32_t input_ptr,
+extern void rvr_ext_sha256(RvState* state, uint64_t dst_ptr, uint64_t state_ptr, uint64_t input_ptr,
                            uint32_t main_chip_idx, uint32_t block_hasher_chip_idx);
 
 /* SHA-512 compress extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_sha512(RvState* state, uint32_t dst_ptr, uint32_t state_ptr, uint32_t input_ptr,
+extern void rvr_ext_sha512(RvState* state, uint64_t dst_ptr, uint64_t state_ptr, uint64_t input_ptr,
                            uint32_t main_chip_idx, uint32_t block_hasher_chip_idx);
 
 #endif /* RVR_EXT_SHA2_H */

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -47,9 +47,9 @@ fn u64_words_as_bytes(words: &[u64]) -> &[u8] {
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_sha256(
     state: *mut c_void,
-    dst_ptr: u32,
-    state_ptr: u32,
-    input_ptr: u32,
+    dst_ptr: u64,
+    state_ptr: u64,
+    input_ptr: u64,
     _main_chip_idx: u32,
     block_hasher_chip_idx: u32,
 ) {
@@ -83,9 +83,9 @@ pub unsafe extern "C" fn rvr_ext_sha256(
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_sha512(
     state: *mut c_void,
-    dst_ptr: u32,
-    state_ptr: u32,
-    input_ptr: u32,
+    dst_ptr: u64,
+    state_ptr: u64,
+    input_ptr: u64,
     _main_chip_idx: u32,
     block_hasher_chip_idx: u32,
 ) {


### PR DESCRIPTION
refactor address pointer related variables to 64bit instead of 32bit. this PR modifies multiple files:
1) rvr core c and trace headers
2) ffi files
3) rvr code for extensions


reth benchmark result (original 32bit address space variables):
1) https://github.com/openvm-org/rvr-openvm/actions/runs/28121173062
2) https://github.com/openvm-org/rvr-openvm/actions/runs/28122726878

reth benchmark result (64bit address pointer variables):
1) https://github.com/openvm-org/rvr-openvm/actions/runs/28119229848
2) https://github.com/openvm-org/rvr-openvm/actions/runs/28122157089

By comparing "Exec Median (ms)" columns, it seems that 64bit version is `10ms` faster or slower compared with the original 32bit version (in both pure and metered modes). I am not sure why, it could be system noises affecting it. Also, the comparison only compares execution speed, excluding other possible important metrics when evaluating this pr.

resolves INT-8321