### PR TITLE
feat: halo2-gpu feature flag

### DIFF
--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -138,6 +138,10 @@ jobs:
 
           if [[ "${E2E_BENCH}" == "true" ]]; then
             FEATURE_FLAGS=${FEATURE_FLAGS},evm
+            # On GPU instances, prove the halo2/EVM layer on GPU too (halo2-gpu implies cuda + evm).
+            if [[ "${{ inputs.instance_type || github.event.inputs.instance_type }}" =~ ^g ]]; then
+              FEATURE_FLAGS=${FEATURE_FLAGS},halo2-gpu
+            fi
             echo "FEATURE_FLAGS=${FEATURE_FLAGS}" >> $GITHUB_ENV
             bash ./scripts/trusted_setup_s3.sh
             PARAMS_DIR=${{ inputs.kzg_params_dir || github.event.inputs.kzg_params_dir || '$HOME/.openvm/params' }}

--- a/benchmarks/prove/Cargo.toml
+++ b/benchmarks/prove/Cargo.toml
@@ -47,6 +47,11 @@ cuda = [
     "openvm-circuit/cuda",
     "openvm-sdk/cuda",
 ]
+halo2-gpu = [
+    "evm",
+    "cuda",
+    "openvm-sdk/halo2-gpu",
+]
 
 [[bin]]
 name = "fibonacci"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -59,6 +59,7 @@ mimalloc = ["openvm-sdk/mimalloc"]
 jemalloc = ["openvm-sdk/jemalloc"]
 jemalloc-prof = ["openvm-sdk/jemalloc-prof"]
 cuda = ["openvm-sdk/cuda"]
+halo2-gpu = ["cuda", "openvm-sdk/halo2-gpu"]
 ci = []
 
 [dev-dependencies]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -107,6 +107,10 @@ cuda = [
     "openvm-verify-stark-circuit/cuda",
     "openvm-static-verifier?/cuda",
 ]
+halo2-gpu = [
+    "cuda",
+    "openvm-static-verifier?/halo2-gpu",
+]
 cell-profiling = [
     "evm-prove",
     "openvm-static-verifier/cell-profiling",

--- a/crates/static-verifier/Cargo.toml
+++ b/crates/static-verifier/Cargo.toml
@@ -34,7 +34,8 @@ openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
 
 [features]
 default = []
-cuda = ["dep:openvm-cuda-backend", "snark-verifier-sdk/cuda"]
+cuda = ["dep:openvm-cuda-backend"]
+halo2-gpu = ["cuda", "snark-verifier-sdk/cuda"]
 evm-prove = ["dep:snark-verifier-sdk", "dep:serde_with", "dep:once_cell", "dep:serde_json"]
 evm-verify = ["evm-prove", "snark-verifier-sdk/revm"]
 cell-profiling = ["dep:inferno"]

--- a/docs/repo/cuda.md
+++ b/docs/repo/cuda.md
@@ -21,7 +21,7 @@ GPU acceleration of the **halo2 prover** used by the static / EVM verifier (the 
 | `cuda` | GPU | CPU |
 | `halo2-gpu` | GPU | GPU |
 
-The feature is exposed on `openvm-static-verifier` (where the halo2 prover lives), `openvm-sdk`, and `cargo-openvm`.
+The feature is exposed on `openvm-static-verifier` (where the halo2 prover lives), `openvm-sdk`, and `cargo-openvm`. It is also exposed on `openvm-benchmarks-prove`, where it additionally implies `evm` (the halo2 layer is only exercised by the EVM benchmark).
 
 ## Project Structure
 

--- a/docs/repo/cuda.md
+++ b/docs/repo/cuda.md
@@ -8,6 +8,21 @@ See [Development with CUDA](../contributor-setup.md#development-with-cuda) for m
 
 The OpenVM framework includes optional GPU acceleration via CUDA for performance-critical components. GPU implementations are available as an optional feature `cuda` and can significantly speed up proof and trace generation.
 
+### Halo2 GPU proving (`halo2-gpu`)
+
+GPU acceleration of the **halo2 prover** used by the static / EVM verifier (the final BN254 wrapping proof) is gated behind a separate `halo2-gpu` feature rather than the general `cuda` feature. This lets you run STARK proving on GPU while keeping the halo2 layer on CPU.
+
+- `halo2-gpu` enables Axiom's CUDA halo2 prover (`halo2_proofs_axiom_gpu`) in place of the CPU `halo2_proofs_axiom` prover.
+- `halo2-gpu` **implies `cuda`** — enabling it automatically turns on the STARK GPU backend, so it cannot be enabled without `cuda`.
+- It only has an effect together with `evm-prove` / `evm-verify` (the build paths that exercise the halo2 verifier).
+
+| Features | STARK proving | Halo2 (EVM verifier) proving |
+| --- | --- | --- |
+| `cuda` | GPU | CPU |
+| `halo2-gpu` | GPU | GPU |
+
+The feature is exposed on `openvm-static-verifier` (where the halo2 prover lives), `openvm-sdk`, and `cargo-openvm`.
+
 ## Project Structure
 
 ### Directory Organization


### PR DESCRIPTION
Closes INT-8517

## Add separate `halo2-gpu` feature
                                                                                                        
  Decouples the halo2 GPU prover (used by the static/EVM verifier) from the general `cuda` feature.
                                                                                                        
  Previously `cuda` always pulled in `snark-verifier-sdk/cuda`. Now it's opt-in via a new `halo2-gpu` feature that implies `cuda`.
                                                                                                        
  | Features | STARK | Halo2 |                                                                          
  |---|---|---|                                                                                         
  | `cuda` | GPU | CPU |                                                                                
  | `halo2-gpu` | GPU | GPU |                                                                           
                                                                                                        
  **Changes:** `halo2-gpu` feature added to `openvm-static-verifier` (the actual switch), `openvm-sdk`, and `cargo-openvm`; removed `snark-verifier-sdk/cuda` from `static-verifier`'s `cuda`. Docs updated in
  `docs/repo/cuda.md`.