### PR TITLE
perf(v2.1): tighten memory metering estimates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,54 +3,6 @@
 version = 4
 
 [[package]]
-name = "abi_stable"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6512d3eb05ffe5004c59c206de7f99c34951504056ce23fc953842f12c445"
-dependencies = [
- "abi_stable_derive",
- "abi_stable_shared",
- "const_panic",
- "core_extensions",
- "crossbeam-channel",
- "generational-arena",
- "libloading 0.7.4",
- "lock_api",
- "parking_lot",
- "paste",
- "repr_offset",
- "rustc_version 0.4.1",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "abi_stable_derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7178468b407a4ee10e881bc7a328a65e739f0863615cca4429d43916b05e898"
-dependencies = [
- "abi_stable_shared",
- "as_derive_utils",
- "core_extensions",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 1.0.109",
- "typed-arena",
-]
-
-[[package]]
-name = "abi_stable_shared"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b5df7688c123e63f4d4d649cba63f2967ba7f7861b1664fca3f77d3dad2b63"
-dependencies = [
- "core_extensions",
-]
-
-[[package]]
 name = "addchain"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,18 +1105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "as_derive_utils"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3c96645900a44cf11941c111bd08a6573b0e2f9f69bc9264b179d8fae753c4"
-dependencies = [
- "core_extensions",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2353,15 +2293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_panic"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
-dependencies = [
- "typewit",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,21 +2332,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core_extensions"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bb5e5d0269fd4f739ea6cedaf29c16d81c27a7ce7582008e90eb50dcd57003"
-dependencies = [
- "core_extensions_proc_macros",
-]
-
-[[package]]
-name = "core_extensions_proc_macros"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533d38ecd2709b7608fb8e18e4504deb99e9a72879e6aa66373a76d8dc4259ea"
 
 [[package]]
 name = "cpufeatures"
@@ -3761,15 +3677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
-name = "generational-arena"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
-dependencies = [
- "cfg-if 1.0.1",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4904,16 +4811,6 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if 1.0.1",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
@@ -5949,7 +5846,6 @@ dependencies = [
 name = "openvm-circuit"
 version = "2.0.0-beta.2"
 dependencies = [
- "abi_stable",
  "backtrace",
  "bytesize",
  "cfg-if 1.0.1",
@@ -5960,7 +5856,7 @@ dependencies = [
  "getset",
  "itertools 0.14.0",
  "libc",
- "libloading 0.8.8",
+ "libloading",
  "memmap2",
  "metrics",
  "openvm-circuit",
@@ -8272,15 +8168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "repr_offset"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
-dependencies = [
- "tstr",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9089,7 +8976,7 @@ dependencies = [
 name = "rvr-openvm-ext-deferral"
 version = "2.0.0-beta.2"
 dependencies = [
- "libloading 0.8.8",
+ "libloading",
  "openvm-circuit",
  "openvm-deferral-transpiler",
  "openvm-instructions",
@@ -9181,7 +9068,7 @@ dependencies = [
 name = "rvr-openvm-ext-riscv"
 version = "2.0.0-beta.2"
 dependencies = [
- "libloading 0.8.8",
+ "libloading",
  "openvm-circuit",
  "openvm-instructions",
  "openvm-riscv-transpiler",
@@ -9225,7 +9112,7 @@ dependencies = [
 name = "rvr-openvm-lift"
 version = "2.0.0-beta.2"
 dependencies = [
- "libloading 0.8.8",
+ "libloading",
  "openvm-instructions",
  "openvm-riscv-transpiler",
  "openvm-stark-backend",
@@ -10895,21 +10782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tstr"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8e0294f14baae476d0dd0a2d780b2e24d66e349a9de876f5126777a37bdba7"
-dependencies = [
- "tstr_proc_macros",
-]
-
-[[package]]
-name = "tstr_proc_macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
-
-[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10929,12 +10801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10945,12 +10811,6 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "typewit"
-version = "1.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,7 +293,6 @@ libc = "0.2.175"
 libloading = "0.8"
 tracing-subscriber = { version = "0.3.20", features = ["std", "env-filter"] }
 tokio = "1" # >=1.0.0 to allow downstream flexibility
-abi_stable = "0.11.3"
 bytesize = "2.0"
 zstd = { version = "0.13", default-features = false }
 inferno = { version = "0.12", default-features = false }

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -38,8 +38,8 @@ pub use openvm_instructions::{
 // Redefined here to avoid a cycle with openvm-circuit. Checked against
 // upstream in `openvm-circuit`'s `arch::rvr::abi_consts`.
 
-/// Default, not an invariant; see TODO in `abi_consts.rs`.
-pub const DEFAULT_PAGE_BITS: usize = 6;
+/// Number of bits needed to index the leaves represented by one `u64` page mask.
+pub const PAGE_BITS: usize = 6;
 /// Default, not an invariant; see TODO in `abi_consts.rs`.
 pub const DEFAULT_SEGMENT_CHECK_INSNS: u32 = 1000;
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -96,6 +96,20 @@ static __attribute__((always_inline)) inline void append_page_access(
   slot->leaf_mask = leaf_mask;
 }
 
+static __attribute__((always_inline)) inline void append_page_access_range(
+    PageAccess* restrict buf, uint32_t* restrict len, uint32_t first_leaf,
+    uint32_t last_leaf) {
+  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
+  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
+  for (uint32_t page = first_page; page <= last_page; page++) {
+    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
+    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
+    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
+    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
+    append_page_access(buf, len, page, leaf_mask_range(start, end));
+  }
+}
+
 /* No bounds check — see MEM_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_mem_page(
     Tracer* t, uint32_t page, uint64_t leaf_mask) {
@@ -141,16 +155,8 @@ static __attribute__((always_inline)) inline void record_pv_page(
 
 static __attribute__((always_inline)) inline void record_pv_page_range(
     Tracer* t, uint32_t first_leaf, uint32_t last_leaf) {
-  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
-  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   uint32_t len = t->pv_page_buf_len;
-  for (uint32_t page = first_page; page <= last_page; page++) {
-    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
-    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
-    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
-    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    append_page_access(t->pv_page_buf, &len, page, leaf_mask_range(start, end));
-  }
+  append_page_access_range(t->pv_page_buf, &len, first_leaf, last_leaf);
   t->pv_page_buf_len = len;
 }
 
@@ -162,17 +168,8 @@ static __attribute__((always_inline)) inline void record_deferral_page(
 
 static __attribute__((always_inline)) inline void record_deferral_page_range(
     Tracer* t, uint32_t first_leaf, uint32_t last_leaf) {
-  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
-  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   uint32_t len = t->deferral_page_buf_len;
-  for (uint32_t page = first_page; page <= last_page; page++) {
-    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
-    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
-    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
-    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    append_page_access(
-        t->deferral_page_buf, &len, page, leaf_mask_range(start, end));
-  }
+  append_page_access_range(t->deferral_page_buf, &len, first_leaf, last_leaf);
   t->deferral_page_buf_len = len;
 }
 
@@ -273,54 +270,11 @@ static __attribute__((always_inline)) inline void trace_memory_access_page(
   memory->last_mem_leaf_mask = leaf_mask;
 }
 
-static __attribute__((always_inline)) inline void trace_memory_access(
-    TraceMemory* restrict memory, uint32_t addr, uint32_t size) {
-  uint32_t first_leaf = byte_addr_to_local_leaf(addr);
-  uint32_t last_leaf = byte_addr_to_local_leaf(addr + size - 1u);
-  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
-  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
-  if (likely(first_page == last_page)) {
-    trace_memory_access_page(memory, first_page,
-                             leaf_mask_range(first_leaf, last_leaf));
-  } else {
-    trace_memory_access_page(
-        memory, first_page,
-        leaf_mask_range(first_leaf,
-                        ((first_page + 1u) << TRACER_PAGE_BITS) - 1u));
-    for (uint32_t page = first_page + 1u; page < last_page; page++) {
-      trace_memory_access_page(memory, page, UINT64_MAX);
-    }
-    trace_memory_access_page(memory, last_page,
-                             leaf_mask_range(last_page << TRACER_PAGE_BITS,
-                                             last_leaf));
-  }
-}
-
 static __attribute__((always_inline)) inline void trace_memory_access_leaf(
     TraceMemory* restrict memory, uint32_t addr) {
   uint32_t leaf = byte_addr_to_local_leaf(addr);
   trace_memory_access_page(memory, leaf >> TRACER_PAGE_BITS,
                            1ull << (leaf & ((1u << TRACER_PAGE_BITS) - 1u)));
-}
-
-static __attribute__((always_inline)) inline void trace_memory_access_1(
-    TraceMemory* restrict memory, uint32_t addr) {
-  trace_memory_access_leaf(memory, addr);
-}
-
-static __attribute__((always_inline)) inline void trace_memory_access_2(
-    TraceMemory* restrict memory, uint32_t addr) {
-  trace_memory_access_leaf(memory, addr);
-}
-
-static __attribute__((always_inline)) inline void trace_memory_access_4(
-    TraceMemory* restrict memory, uint32_t addr) {
-  trace_memory_access_leaf(memory, addr);
-}
-
-static __attribute__((always_inline)) inline void trace_memory_access_8(
-    TraceMemory* restrict memory, uint32_t addr) {
-  trace_memory_access_leaf(memory, addr);
 }
 
 /* ── Trace-only register access (no-ops in metered mode) ─────────── */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -25,6 +25,7 @@ _Static_assert(
  * (see DEFERRAL_PAGE_BUF_CAP in metered.rs). */
 
 typedef struct PageAccess {
+  /* Scalar page index plus a 64-bit leaf mask for that page. */
   uint32_t page_id;
   uint64_t leaf_mask;
 } PageAccess;
@@ -79,6 +80,7 @@ static __attribute__((always_inline)) inline uint32_t addr_to_local_leaf(
 
 static __attribute__((always_inline)) inline uint64_t leaf_mask_range(
     uint32_t first_leaf, uint32_t last_leaf) {
+  /* Convert an inclusive leaf range within a page into a uint64_t occupancy mask. */
   uint32_t start = first_leaf & ((1u << TRACER_PAGE_BITS) - 1u);
   uint32_t end = (last_leaf & ((1u << TRACER_PAGE_BITS) - 1u)) + 1u;
   uint32_t width = end - start;
@@ -261,6 +263,8 @@ static __attribute__((always_inline)) inline void trace_memory_reload(
 
 static __attribute__((always_inline)) inline void trace_memory_access_page(
     TraceMemory* restrict memory, uint32_t page, uint64_t leaf_mask) {
+  /* Keep one pending AS_MEMORY page in registers for the current generated
+   * block. Consecutive accesses to that page merge by OR-ing leaf masks. */
   if (likely(page == memory->last_mem_page)) {
     memory->last_mem_leaf_mask |= leaf_mask;
     return;

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -225,7 +225,7 @@ static __attribute__((always_inline)) inline void record_page_range(
 static __attribute__((always_inline)) inline TraceMemory trace_memory_setup(
     Tracer* restrict t) {
   TraceMemory memory = {
-      .last_mem_page = t->last_mem_page,
+      .last_mem_page = NO_LAST_PAGE,
       .mem_page_buf_len = t->mem_page_buf_len,
       .last_mem_leaf_mask = 0,
       .mem_page_buf = t->mem_page_buf,
@@ -235,7 +235,10 @@ static __attribute__((always_inline)) inline TraceMemory trace_memory_setup(
 
 static __attribute__((always_inline)) inline void trace_memory_drain(
     TraceMemory* restrict memory) {
-  if (memory->last_mem_page == NO_LAST_PAGE) {
+  if (memory->last_mem_page == NO_LAST_PAGE ||
+      memory->last_mem_leaf_mask == 0) {
+    memory->last_mem_page = NO_LAST_PAGE;
+    memory->last_mem_leaf_mask = 0;
     return;
   }
   append_page_access(memory->mem_page_buf, &memory->mem_page_buf_len,
@@ -253,8 +256,9 @@ static __attribute__((always_inline)) inline void trace_memory_flush(
 
 static __attribute__((always_inline)) inline void trace_memory_reload(
     Tracer* restrict t, TraceMemory* restrict memory) {
-  memory->last_mem_page = t->last_mem_page;
+  memory->last_mem_page = NO_LAST_PAGE;
   memory->mem_page_buf_len = t->mem_page_buf_len;
+  memory->last_mem_leaf_mask = 0;
   memory->mem_page_buf = t->mem_page_buf;
 }
 
@@ -283,6 +287,9 @@ static __attribute__((always_inline)) inline void trace_memory_access(
         memory, first_page,
         leaf_mask_range(first_leaf,
                         ((first_page + 1u) << TRACER_PAGE_BITS) - 1u));
+    for (uint32_t page = first_page + 1u; page < last_page; page++) {
+      trace_memory_access_page(memory, page, UINT64_MAX);
+    }
     trace_memory_access_page(memory, last_page,
                              leaf_mask_range(last_page << TRACER_PAGE_BITS,
                                              last_leaf));

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -369,14 +369,14 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
 
 static __attribute__((always_inline)) inline void trace_mem_access(
     RvState* restrict state, uint32_t addr, uint32_t addr_space) {
-  record_page(state->tracer, addr_space, addr, 8u);
+  record_page(state->tracer, addr_space, addr, WORD_SIZE);
 }
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
     RvState* restrict state, uint32_t base_addr, uint32_t num_dwords,
     uint32_t addr_space) {
   assume(num_dwords > 0);
-  uint32_t last_addr = base_addr + num_dwords * 8u - 1u;
+  uint32_t last_addr = base_addr + num_dwords * WORD_SIZE - 1u;
   record_page_range(state->tracer, addr_space, base_addr, last_addr);
 }
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -25,7 +25,7 @@ _Static_assert(
  * (see DEFERRAL_PAGE_BUF_CAP in metered.rs). */
 
 typedef struct PageAccess {
-  /* Scalar page index plus a 64-bit leaf mask for that page. */
+  /* Page table index plus a 64-bit leaf mask for that page. */
   uint32_t page_id;
   uint64_t leaf_mask;
 } PageAccess;

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -24,13 +24,18 @@ _Static_assert(
 /* No static assert for DEFERRAL — justifying the capacity is a TODO
  * (see DEFERRAL_PAGE_BUF_CAP in metered.rs). */
 
-/* One page buffer per address space so each stores only page ids (1 u32).
+typedef struct PageAccess {
+  uint32_t page_id;
+  uint64_t leaf_mask;
+} PageAccess;
+
+/* One page buffer per address space stores local page ids and leaf masks.
  * AS_REGISTER pages are handled entirely on the Rust side at init. */
 typedef struct Tracer {
   uint32_t* trace_heights;
-  uint32_t* mem_page_buf;
-  uint32_t* pv_page_buf;
-  uint32_t* deferral_page_buf;
+  PageAccess* mem_page_buf;
+  PageAccess* pv_page_buf;
+  PageAccess* deferral_page_buf;
   /* Always initialized by Rust; called unconditionally on the cold checkpoint
    * path to avoid a hot-path null check. */
   uint8_t (*on_check)(struct Tracer*);
@@ -48,116 +53,170 @@ typedef struct Tracer {
 typedef struct TraceMemory {
   uint32_t last_mem_page;
   uint32_t mem_page_buf_len;
-  uint32_t* mem_page_buf;
+  uint64_t last_mem_leaf_mask;
+  PageAccess* mem_page_buf;
 } TraceMemory;
 
 /* ── Page tracking ─────────────────────────────────────────────────── */
 
-static __attribute__((always_inline)) inline uint32_t byte_addr_to_local_page(
+static __attribute__((always_inline)) inline uint32_t byte_addr_to_local_leaf(
     uint32_t ptr) {
-  return (ptr >> TRACER_BYTE_SPACE_PTRS_PER_LEAF_BITS) >> TRACER_PAGE_BITS;
+  return ptr >> TRACER_BYTE_SPACE_PTRS_PER_LEAF_BITS;
 }
 
-static __attribute__((always_inline)) inline uint32_t deferral_addr_to_local_page(
+static __attribute__((always_inline)) inline uint32_t deferral_addr_to_local_leaf(
     uint32_t ptr) {
-  return (ptr >> TRACER_DEFERRAL_PTRS_PER_LEAF_BITS) >> TRACER_PAGE_BITS;
+  return ptr >> TRACER_DEFERRAL_PTRS_PER_LEAF_BITS;
 }
 
-static __attribute__((always_inline)) inline uint32_t addr_to_local_page(
+static __attribute__((always_inline)) inline uint32_t addr_to_local_leaf(
     uint32_t addr_space, uint32_t ptr) {
   if (likely(addr_space == AS_MEMORY || addr_space == AS_PUBLIC_VALUES)) {
-    return byte_addr_to_local_page(ptr);
+    return byte_addr_to_local_leaf(ptr);
   }
-  return deferral_addr_to_local_page(ptr);
+  return deferral_addr_to_local_leaf(ptr);
+}
+
+static __attribute__((always_inline)) inline uint64_t leaf_mask_range(
+    uint32_t first_leaf, uint32_t last_leaf) {
+  uint32_t start = first_leaf & ((1u << TRACER_PAGE_BITS) - 1u);
+  uint32_t end = (last_leaf & ((1u << TRACER_PAGE_BITS) - 1u)) + 1u;
+  uint32_t width = end - start;
+  uint64_t mask = width == 64u ? UINT64_MAX : ((1ull << width) - 1ull);
+  return mask << start;
 }
 
 /* ── Per-address-space page recording ─────────────────────────────── */
 
+static __attribute__((always_inline)) inline void append_page_access(
+    PageAccess* restrict buf, uint32_t* restrict len, uint32_t page,
+    uint64_t leaf_mask) {
+  PageAccess* slot = &buf[(*len)++];
+  slot->page_id = page;
+  slot->leaf_mask = leaf_mask;
+}
+
 /* No bounds check — see MEM_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_mem_page(
-    Tracer* t, uint32_t page) {
+    Tracer* t, uint32_t page, uint64_t leaf_mask) {
   if (likely(page == t->last_mem_page)) {
+    t->mem_page_buf[t->mem_page_buf_len - 1u].leaf_mask |= leaf_mask;
     return;
   }
   t->last_mem_page = page;
-  t->mem_page_buf[t->mem_page_buf_len++] = page;
+  append_page_access(t->mem_page_buf, &t->mem_page_buf_len, page, leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_mem_page_range(
-    Tracer* t, uint32_t first_page, uint32_t last_page) {
+    Tracer* t, uint32_t first_leaf, uint32_t last_leaf) {
+  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
+  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   if (likely(first_page == t->last_mem_page)) {
+    t->mem_page_buf[t->mem_page_buf_len - 1u].leaf_mask |=
+        leaf_mask_range(first_leaf, first_page == last_page
+                                        ? last_leaf
+                                        : ((first_page + 1u) << TRACER_PAGE_BITS) - 1u);
     if (first_page == last_page) {
       return;
     }
     first_page++;
   }
-  uint32_t n = last_page - first_page + 1;
   uint32_t len = t->mem_page_buf_len;
-  for (uint32_t i = 0; i < n; i++) {
-    t->mem_page_buf[len + i] = first_page + i;
+  for (uint32_t page = first_page; page <= last_page; page++) {
+    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
+    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
+    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
+    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
+    append_page_access(t->mem_page_buf, &len, page, leaf_mask_range(start, end));
   }
-  t->mem_page_buf_len = len + n;
+  t->mem_page_buf_len = len;
   t->last_mem_page = last_page;
 }
 
 /* No bounds check — see PV_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_pv_page(
-    Tracer* t, uint32_t page) {
-  t->pv_page_buf[t->pv_page_buf_len++] = page;
+    Tracer* t, uint32_t page, uint64_t leaf_mask) {
+  append_page_access(t->pv_page_buf, &t->pv_page_buf_len, page, leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_pv_page_range(
-    Tracer* t, uint32_t first_page, uint32_t last_page) {
-  uint32_t n = last_page - first_page + 1;
+    Tracer* t, uint32_t first_leaf, uint32_t last_leaf) {
+  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
+  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   uint32_t len = t->pv_page_buf_len;
-  for (uint32_t i = 0; i < n; i++) {
-    t->pv_page_buf[len + i] = first_page + i;
+  for (uint32_t page = first_page; page <= last_page; page++) {
+    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
+    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
+    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
+    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
+    append_page_access(t->pv_page_buf, &len, page, leaf_mask_range(start, end));
   }
-  t->pv_page_buf_len = len + n;
+  t->pv_page_buf_len = len;
 }
 
 /* No bounds check — see DEFERRAL_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_deferral_page(
-    Tracer* t, uint32_t page) {
-  t->deferral_page_buf[t->deferral_page_buf_len++] = page;
+    Tracer* t, uint32_t page, uint64_t leaf_mask) {
+  append_page_access(t->deferral_page_buf, &t->deferral_page_buf_len, page, leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_deferral_page_range(
-    Tracer* t, uint32_t first_page, uint32_t last_page) {
-  uint32_t n = last_page - first_page + 1;
+    Tracer* t, uint32_t first_leaf, uint32_t last_leaf) {
+  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
+  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   uint32_t len = t->deferral_page_buf_len;
-  for (uint32_t i = 0; i < n; i++) {
-    t->deferral_page_buf[len + i] = first_page + i;
+  for (uint32_t page = first_page; page <= last_page; page++) {
+    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
+    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
+    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
+    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
+    append_page_access(
+        t->deferral_page_buf, &len, page, leaf_mask_range(start, end));
   }
-  t->deferral_page_buf_len = len + n;
+  t->deferral_page_buf_len = len;
 }
 
 /* Record a single page access. `addr_space` is a compile-time constant at
  * every direct call site in generated C, so the branches below fold away. */
 static __attribute__((always_inline)) inline void record_page(
-    Tracer* t, uint32_t addr_space, uint32_t ptr) {
-  uint32_t page = addr_to_local_page(addr_space, ptr);
+    Tracer* t, uint32_t addr_space, uint32_t ptr, uint32_t size) {
+  uint32_t first_leaf = addr_to_local_leaf(addr_space, ptr);
+  uint32_t last_leaf = addr_to_local_leaf(addr_space, ptr + size - 1u);
+  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
+  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   if (likely(addr_space == AS_MEMORY)) {
-    record_mem_page(t, page);
+    if (likely(first_page == last_page)) {
+      record_mem_page(t, first_page, leaf_mask_range(first_leaf, last_leaf));
+    } else {
+      record_mem_page_range(t, first_leaf, last_leaf);
+    }
   } else if (addr_space == AS_PUBLIC_VALUES) {
-    record_pv_page(t, page);
+    if (first_page == last_page) {
+      record_pv_page(t, first_page, leaf_mask_range(first_leaf, last_leaf));
+    } else {
+      record_pv_page_range(t, first_leaf, last_leaf);
+    }
   } else {
-    record_deferral_page(t, page);
+    if (first_page == last_page) {
+      record_deferral_page(t, first_page, leaf_mask_range(first_leaf, last_leaf));
+    } else {
+      record_deferral_page_range(t, first_leaf, last_leaf);
+    }
   }
 }
 
-/* Record pages touched by [first_addr, last_addr]. Duplicates are fine —
- * flush_page_buffer deduplicates via BitSet. */
+/* Record leaves touched by [first_addr, last_addr]. Duplicates are fine —
+ * Rust-side checkpoint processing deduplicates by page mask. */
 static __attribute__((always_inline)) inline void record_page_range(
     Tracer* t, uint32_t addr_space, uint32_t first_addr, uint32_t last_addr) {
-  uint32_t first_page = addr_to_local_page(addr_space, first_addr);
-  uint32_t last_page = addr_to_local_page(addr_space, last_addr);
+  uint32_t first_leaf = addr_to_local_leaf(addr_space, first_addr);
+  uint32_t last_leaf = addr_to_local_leaf(addr_space, last_addr);
   if (likely(addr_space == AS_MEMORY)) {
-    record_mem_page_range(t, first_page, last_page);
+    record_mem_page_range(t, first_leaf, last_leaf);
   } else if (addr_space == AS_PUBLIC_VALUES) {
-    record_pv_page_range(t, first_page, last_page);
+    record_pv_page_range(t, first_leaf, last_leaf);
   } else {
-    record_deferral_page_range(t, first_page, last_page);
+    record_deferral_page_range(t, first_leaf, last_leaf);
   }
 }
 
@@ -168,13 +227,26 @@ static __attribute__((always_inline)) inline TraceMemory trace_memory_setup(
   TraceMemory memory = {
       .last_mem_page = t->last_mem_page,
       .mem_page_buf_len = t->mem_page_buf_len,
+      .last_mem_leaf_mask = 0,
       .mem_page_buf = t->mem_page_buf,
   };
   return memory;
 }
 
+static __attribute__((always_inline)) inline void trace_memory_drain(
+    TraceMemory* restrict memory) {
+  if (memory->last_mem_page == NO_LAST_PAGE) {
+    return;
+  }
+  append_page_access(memory->mem_page_buf, &memory->mem_page_buf_len,
+                     memory->last_mem_page, memory->last_mem_leaf_mask);
+  memory->last_mem_page = NO_LAST_PAGE;
+  memory->last_mem_leaf_mask = 0;
+}
+
 static __attribute__((always_inline)) inline void trace_memory_flush(
     Tracer* restrict t, TraceMemory* restrict memory) {
+  trace_memory_drain(memory);
   t->last_mem_page = memory->last_mem_page;
   t->mem_page_buf_len = memory->mem_page_buf_len;
 }
@@ -187,17 +259,61 @@ static __attribute__((always_inline)) inline void trace_memory_reload(
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access_page(
-    TraceMemory* restrict memory, uint32_t page) {
+    TraceMemory* restrict memory, uint32_t page, uint64_t leaf_mask) {
   if (likely(page == memory->last_mem_page)) {
+    memory->last_mem_leaf_mask |= leaf_mask;
     return;
   }
+  trace_memory_drain(memory);
   memory->last_mem_page = page;
-  memory->mem_page_buf[memory->mem_page_buf_len++] = page;
+  memory->last_mem_leaf_mask = leaf_mask;
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access(
+    TraceMemory* restrict memory, uint32_t addr, uint32_t size) {
+  uint32_t first_leaf = byte_addr_to_local_leaf(addr);
+  uint32_t last_leaf = byte_addr_to_local_leaf(addr + size - 1u);
+  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
+  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
+  if (likely(first_page == last_page)) {
+    trace_memory_access_page(memory, first_page,
+                             leaf_mask_range(first_leaf, last_leaf));
+  } else {
+    trace_memory_access_page(
+        memory, first_page,
+        leaf_mask_range(first_leaf,
+                        ((first_page + 1u) << TRACER_PAGE_BITS) - 1u));
+    trace_memory_access_page(memory, last_page,
+                             leaf_mask_range(last_page << TRACER_PAGE_BITS,
+                                             last_leaf));
+  }
+}
+
+static __attribute__((always_inline)) inline void trace_memory_access_leaf(
     TraceMemory* restrict memory, uint32_t addr) {
-  trace_memory_access_page(memory, byte_addr_to_local_page(addr));
+  uint32_t leaf = byte_addr_to_local_leaf(addr);
+  trace_memory_access_page(memory, leaf >> TRACER_PAGE_BITS,
+                           1ull << (leaf & ((1u << TRACER_PAGE_BITS) - 1u)));
+}
+
+static __attribute__((always_inline)) inline void trace_memory_access_1(
+    TraceMemory* restrict memory, uint32_t addr) {
+  trace_memory_access_leaf(memory, addr);
+}
+
+static __attribute__((always_inline)) inline void trace_memory_access_2(
+    TraceMemory* restrict memory, uint32_t addr) {
+  trace_memory_access_leaf(memory, addr);
+}
+
+static __attribute__((always_inline)) inline void trace_memory_access_4(
+    TraceMemory* restrict memory, uint32_t addr) {
+  trace_memory_access_leaf(memory, addr);
+}
+
+static __attribute__((always_inline)) inline void trace_memory_access_8(
+    TraceMemory* restrict memory, uint32_t addr) {
+  trace_memory_access_leaf(memory, addr);
 }
 
 /* ── Trace-only register access (no-ops in metered mode) ─────────── */
@@ -211,59 +327,59 @@ static __attribute__((always_inline)) inline void trace_reg_write(
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u8(
     RvState* restrict state, uint32_t addr, uint8_t val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint8_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_i8(
     RvState* restrict state, uint32_t addr, int8_t val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(int8_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u16(
     RvState* restrict state, uint32_t addr, uint16_t val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint16_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_i16(
     RvState* restrict state, uint32_t addr, int16_t val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(int16_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u32(
     RvState* restrict state, uint32_t addr, uint32_t val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint32_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_i32(
     RvState* restrict state, uint32_t addr, int32_t val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(int32_t));
 }
 
 static __attribute__((always_inline)) inline void trace_rd_mem_u64(
     RvState* restrict state, uint32_t addr, uint64_t val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint64_t));
 }
 
 /* ── Trace-only memory writes (record page in metered mode) ──────── */
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u8(
     RvState* restrict state, uint32_t addr, uint8_t new_val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint8_t));
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u16(
     RvState* restrict state, uint32_t addr, uint16_t new_val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint16_t));
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u32(
     RvState* restrict state, uint32_t addr, uint32_t new_val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint32_t));
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u64(
     RvState* restrict state, uint32_t addr, uint64_t new_val) {
-  record_mem_page(state->tracer, byte_addr_to_local_page(addr));
+  record_page(state->tracer, AS_MEMORY, addr, sizeof(uint64_t));
 }
 
 /* ── Trace-only word-range memory access ──────────────────────────── */
@@ -276,32 +392,30 @@ static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words) {
   assume(num_words > 0);
-  uint32_t last_addr = base_addr + (num_words - 1) * sizeof(uint64_t);
-  record_mem_page_range(state->tracer, byte_addr_to_local_page(base_addr),
-                        byte_addr_to_local_page(last_addr));
+  uint32_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
+  record_page_range(state->tracer, AS_MEMORY, base_addr, last_addr);
 }
 
 static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words) {
   assume(num_words > 0);
-  uint32_t last_addr = base_addr + (num_words - 1) * sizeof(uint64_t);
-  record_mem_page_range(state->tracer, byte_addr_to_local_page(base_addr),
-                        byte_addr_to_local_page(last_addr));
+  uint32_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
+  record_page_range(state->tracer, AS_MEMORY, base_addr, last_addr);
 }
 
 /* ── Trace-only operations ────────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void trace_mem_access(
     RvState* restrict state, uint32_t addr, uint32_t addr_space) {
-  record_page(state->tracer, addr_space, addr);
+  record_page(state->tracer, addr_space, addr, 8u);
 }
 
 static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
     RvState* restrict state, uint32_t base_addr, uint32_t num_dwords,
     uint32_t addr_space) {
   assume(num_dwords > 0);
-  uint32_t last_addr = base_addr + (num_dwords - 1) * 8u;
+  uint32_t last_addr = base_addr + num_dwords * 8u - 1u;
   record_page_range(state->tracer, addr_space, base_addr, last_addr);
 }
 

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -7,8 +7,8 @@
 use openvm_platform::memory::MEM_SIZE;
 use openvm_riscv_guest::MAX_HINT_BUFFER_DWORDS;
 use rvr_openvm_ext_ffi_common::{
-    AS_MEMORY, AS_PUBLIC_VALUES, AS_REGISTER, DEFAULT_PAGE_BITS, DEFAULT_SEGMENT_CHECK_INSNS,
-    DEFERRAL_AS, DEFERRAL_DIGEST_SIZE, WORD_SIZE,
+    AS_MEMORY, AS_PUBLIC_VALUES, AS_REGISTER, DEFAULT_SEGMENT_CHECK_INSNS, DEFERRAL_AS,
+    DEFERRAL_DIGEST_SIZE, PAGE_BITS, WORD_SIZE,
 };
 
 const BYTE_SPACE_PTRS_PER_LEAF: usize = core::mem::size_of::<u16>() * DEFERRAL_DIGEST_SIZE;
@@ -21,7 +21,7 @@ const DEFERRAL_PTRS_PER_LEAF: usize = DEFERRAL_DIGEST_SIZE;
 /// covers `BYTE_SPACE_PTRS_PER_LEAF * 2^PAGE_BITS` bytes. The `+1` covers worst-case
 /// misalignment of the range across page boundaries.
 pub const MAX_MEM_PAGES_PER_INSN: usize = {
-    let page_bytes = BYTE_SPACE_PTRS_PER_LEAF * (1 << DEFAULT_PAGE_BITS);
+    let page_bytes = BYTE_SPACE_PTRS_PER_LEAF * (1 << PAGE_BITS);
     let max_bytes = MAX_HINT_BUFFER_DWORDS * WORD_SIZE;
     max_bytes.div_ceil(page_bytes) + 1
 };
@@ -70,7 +70,7 @@ static constexpr uint64_t RV_TEXT_END = 0x{text_end:08x}ull;
 static constexpr uint32_t RV_DISPATCH_TABLE_SIZE = {dispatch_table_size}u;
 static constexpr uint32_t TRACER_BYTE_SPACE_PTRS_PER_LEAF_BITS = {byte_space_ptrs_per_leaf_bits};
 static constexpr uint32_t TRACER_DEFERRAL_PTRS_PER_LEAF_BITS = {deferral_ptrs_per_leaf_bits};
-static constexpr uint32_t TRACER_PAGE_BITS = {DEFAULT_PAGE_BITS};
+static constexpr uint32_t TRACER_PAGE_BITS = {PAGE_BITS};
 static constexpr uint32_t TRACER_MEM_PAGE_BUF_CAP = {MEM_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_PV_PAGE_BUF_CAP = {PV_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_DEFERRAL_PAGE_BUF_CAP = {DEFERRAL_PAGE_BUF_CAP};

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -264,7 +264,7 @@ impl EmitContext {
             "{var_ty} {var} = {data_func}({data_arg}, {addr});"
         ));
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width);
+            self.emit_inline_page_record(&addr);
         }
         var
     }
@@ -283,22 +283,15 @@ impl EmitContext {
         let data_arg = if value_traced { "state" } else { "memory" };
 
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width);
+            self.emit_inline_page_record(&addr);
         }
         self.write_line(&format!(
             "{wr_func}({data_arg}, {addr}, ({cast_ty})({val}));"
         ));
     }
 
-    fn emit_inline_page_record(&mut self, addr: &str, width: u8) {
-        let func = match width {
-            1 => "trace_memory_access_1",
-            2 => "trace_memory_access_2",
-            4 => "trace_memory_access_4",
-            8 => "trace_memory_access_8",
-            _ => unreachable!("invalid memory width {width}"),
-        };
-        self.write_line(&format!("{func}(&trace_memory, {addr});"));
+    fn emit_inline_page_record(&mut self, addr: &str) {
+        self.write_line(&format!("trace_memory_access_leaf(&trace_memory, {addr});"));
     }
 
     pub fn flush_page_locals(&mut self) {

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -264,7 +264,7 @@ impl EmitContext {
             "{var_ty} {var} = {data_func}({data_arg}, {addr});"
         ));
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr);
+            self.emit_inline_page_record(&addr, width);
         }
         var
     }
@@ -283,15 +283,22 @@ impl EmitContext {
         let data_arg = if value_traced { "state" } else { "memory" };
 
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr);
+            self.emit_inline_page_record(&addr, width);
         }
         self.write_line(&format!(
             "{wr_func}({data_arg}, {addr}, ({cast_ty})({val}));"
         ));
     }
 
-    fn emit_inline_page_record(&mut self, addr: &str) {
-        self.write_line(&format!("trace_memory_access(&trace_memory, {addr});"));
+    fn emit_inline_page_record(&mut self, addr: &str, width: u8) {
+        let func = match width {
+            1 => "trace_memory_access_1",
+            2 => "trace_memory_access_2",
+            4 => "trace_memory_access_4",
+            8 => "trace_memory_access_8",
+            _ => unreachable!("invalid memory width {width}"),
+        };
+        self.write_line(&format!("{func}(&trace_memory, {addr});"));
     }
 
     pub fn flush_page_locals(&mut self) {

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -47,7 +47,6 @@ dashmap.workspace = true
 cfg-if.workspace = true
 libloading = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
-abi_stable.workspace = true
 bytesize.workspace = true
 
 [build-dependencies]

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -353,9 +353,9 @@ mod tests {
         segmentation_ctx.instrets_until_check = 1;
 
         let mut memory_ctx = MemoryCtx::new(&system_config, 1);
-        memory_ctx.record_page_access(7, 1);
-        memory_ctx.record_page_access(8, 1);
-        memory_ctx.record_page_access(9, 1);
+        memory_ctx.update_boundary_merkle_heights(2, 0, 1);
+        memory_ctx.update_boundary_merkle_heights(2, 1024, 1);
+        memory_ctx.update_boundary_merkle_heights(2, 2048, 1);
 
         let mut ctx = MeteredCtx {
             config: MeteredCtxConfig {

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -353,8 +353,9 @@ mod tests {
         segmentation_ctx.instrets_until_check = 1;
 
         let mut memory_ctx = MemoryCtx::<DEFAULT_PAGE_BITS>::new(&system_config, 1);
-        memory_ctx.addr_space_access_count[1] = 7;
-        memory_ctx.page_indices_since_checkpoint_len = 3;
+        memory_ctx.record_page_access(7, 1);
+        memory_ctx.record_page_access(8, 1);
+        memory_ctx.record_page_access(9, 1);
 
         let mut ctx = MeteredCtx::<DEFAULT_PAGE_BITS> {
             config: MeteredCtxConfig {
@@ -378,7 +379,6 @@ mod tests {
             vec![false, true, false, true, false, true]
         );
         assert_eq!(restored.segmentation_ctx.instret, 123);
-        assert_eq!(restored.memory_ctx.addr_space_access_count[1], 7);
         assert_eq!(restored.memory_ctx.page_indices_since_checkpoint_len, 3);
         assert!(*restored.suspend_on_segment());
     }

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -4,7 +4,7 @@ use openvm_stark_backend::memory_metering::ProvingMemoryConfig;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    memory_ctx::MemoryCtx,
+    memory_ctx::{MemoryCtx, PAGE_BITS},
     segment_ctx::{Segment, SegmentationConfig, SegmentationCtx, SegmentationLimits},
 };
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
     system::memory::online::GuestMemory,
 };
 
-pub const DEFAULT_PAGE_BITS: usize = 6;
+pub const DEFAULT_PAGE_BITS: usize = PAGE_BITS;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MeteredCtxConfig {
@@ -27,10 +27,10 @@ pub struct MeteredCtxConfig {
 }
 
 #[derive(Clone, Debug)]
-pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
+pub struct MeteredCtx {
     pub config: MeteredCtxConfig,
     pub trace_heights: Vec<u32>,
-    pub memory_ctx: MemoryCtx<PAGE_BITS>,
+    pub memory_ctx: MemoryCtx,
     pub segmentation_ctx: SegmentationCtx,
 }
 
@@ -44,14 +44,14 @@ pub struct MeteredCtxInputs<'a> {
 }
 
 #[cfg(feature = "rvr")]
-pub(crate) struct MeteredCtxParts<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
+pub(crate) struct MeteredCtxParts {
     pub config: MeteredCtxConfig,
     pub trace_heights: Vec<u32>,
-    pub memory_ctx: MemoryCtx<PAGE_BITS>,
+    pub memory_ctx: MemoryCtx,
     pub segmentation_ctx: SegmentationCtx,
 }
 
-impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
+impl MeteredCtx {
     // Note: prefer to use `build_metered_ctx` in `VmExecutor` or `VirtualMachine`.
     pub fn new(
         inputs: MeteredCtxInputs<'_>,
@@ -171,7 +171,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
     }
 
     #[cfg(feature = "rvr")]
-    pub(crate) fn into_parts(self) -> MeteredCtxParts<PAGE_BITS> {
+    pub(crate) fn into_parts(self) -> MeteredCtxParts {
         MeteredCtxParts {
             config: self.config,
             trace_heights: self.trace_heights,
@@ -181,7 +181,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
     }
 
     #[cfg(feature = "rvr")]
-    pub(crate) fn from_parts(parts: MeteredCtxParts<PAGE_BITS>) -> Self {
+    pub(crate) fn from_parts(parts: MeteredCtxParts) -> Self {
         Self {
             config: parts.config,
             trace_heights: parts.trace_heights,
@@ -252,7 +252,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
     }
 }
 
-impl<const PAGE_BITS: usize> ExecutionCtxTrait for MeteredCtx<PAGE_BITS> {
+impl ExecutionCtxTrait for MeteredCtx {
     #[inline(always)]
     fn on_memory_operation(&mut self, address_space: u32, ptr: u32, size: u32) {
         debug_assert!(
@@ -300,7 +300,7 @@ impl<const PAGE_BITS: usize> ExecutionCtxTrait for MeteredCtx<PAGE_BITS> {
     }
 }
 
-impl<const PAGE_BITS: usize> MeteredExecutionCtxTrait for MeteredCtx<PAGE_BITS> {
+impl MeteredExecutionCtxTrait for MeteredCtx {
     #[inline(always)]
     fn on_height_change(&mut self, chip_idx: usize, height_delta: u32) {
         debug_assert!(
@@ -352,12 +352,12 @@ mod tests {
         segmentation_ctx.instret = 123;
         segmentation_ctx.instrets_until_check = 1;
 
-        let mut memory_ctx = MemoryCtx::<DEFAULT_PAGE_BITS>::new(&system_config, 1);
+        let mut memory_ctx = MemoryCtx::new(&system_config, 1);
         memory_ctx.record_page_access(7, 1);
         memory_ctx.record_page_access(8, 1);
         memory_ctx.record_page_access(9, 1);
 
-        let mut ctx = MeteredCtx::<DEFAULT_PAGE_BITS> {
+        let mut ctx = MeteredCtx {
             config: MeteredCtxConfig {
                 initial_trace_heights: vec![1, 2, 3, 4, 5, 6],
                 is_trace_height_constant: vec![false, true, false, true, false, true],

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -4,7 +4,7 @@ use openvm_stark_backend::memory_metering::ProvingMemoryConfig;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    memory_ctx::{MemoryCtx, PAGE_BITS},
+    memory_ctx::MemoryCtx,
     segment_ctx::{Segment, SegmentationConfig, SegmentationCtx, SegmentationLimits},
 };
 use crate::{
@@ -14,8 +14,6 @@ use crate::{
     },
     system::memory::online::GuestMemory,
 };
-
-pub const DEFAULT_PAGE_BITS: usize = PAGE_BITS;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MeteredCtxConfig {
@@ -105,8 +103,7 @@ impl MeteredCtx {
 
         // Add merkle height contributions for all registers
         ctx.memory_ctx.add_register_merkle_heights();
-        ctx.memory_ctx
-            .lazy_update_boundary_heights(&mut ctx.trace_heights);
+        ctx.memory_ctx.apply_height_updates(&mut ctx.trace_heights);
 
         ctx
     }
@@ -140,7 +137,7 @@ impl MeteredCtx {
         let mut memory_ctx = MemoryCtx::new(system_config, segmentation_ctx.segment_check_insns());
         let mut trace_heights = config.initial_trace_heights.clone();
         memory_ctx.add_register_merkle_heights();
-        memory_ctx.lazy_update_boundary_heights(&mut trace_heights);
+        memory_ctx.apply_height_updates(&mut trace_heights);
         Self {
             trace_heights,
             config,
@@ -202,7 +199,7 @@ impl MeteredCtx {
         self.segmentation_ctx.instret += segment_check_insns;
 
         self.memory_ctx
-            .lazy_update_boundary_heights(&mut self.trace_heights);
+            .apply_height_updates(&mut self.trace_heights);
         let did_segment = self.segmentation_ctx.check_and_segment(
             self.segmentation_ctx.instret,
             &mut self.trace_heights,
@@ -279,6 +276,10 @@ impl ExecutionCtxTrait for MeteredCtx {
         // If `segment_suspend` is set, suspend when a segment is determined (but the VM state might
         // be after the segment boundary because the segment happens in the previous checkpoint).
         // Otherwise, execute until termination.
+        if exec_state.ctx.segmentation_ctx.instrets_until_check > 0 {
+            exec_state.ctx.segmentation_ctx.instrets_until_check -= 1;
+            return false;
+        }
         if exec_state.ctx.check_and_segment() && exec_state.ctx.config.suspend_on_segment {
             true
         } else {
@@ -292,7 +293,7 @@ impl ExecutionCtxTrait for MeteredCtx {
         exec_state
             .ctx
             .memory_ctx
-            .lazy_update_boundary_heights(&mut exec_state.ctx.trace_heights);
+            .apply_height_updates(&mut exec_state.ctx.trace_heights);
         exec_state
             .ctx
             .segmentation_ctx

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -8,8 +8,8 @@ use crate::{
     system::memory::{dimensions::MemoryDimensions, DIGEST_WIDTH},
 };
 
-/// Number of bits needed to index the 64 leaves represented by one page mask.
-pub const PAGE_BITS: usize = 6;
+/// Number of bits needed to index the leaves represented by one `u64` page mask.
+pub const PAGE_BITS: usize = u64::BITS.ilog2() as usize;
 
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -142,7 +142,10 @@ impl BitSet {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PageAccess {
+    /// Scalar page index. The leaf occupancy for this page is stored in
+    /// `leaf_mask`.
     pub page_id: u32,
+    /// Bit `i` is set when leaf `i` inside this 64-leaf page was touched.
     pub leaf_mask: u64,
 }
 
@@ -197,6 +200,8 @@ impl MemoryPageTracker {
         if old_mask == 0 {
             self.dirty_pages.push(page_id);
         }
+        // Newly set bits are the only leaves that can add boundary rows or new
+        // page-local Merkle nodes.
         let added_mask = new_mask ^ old_mask;
         let leaves = added_mask.count_ones();
         let mut merkle_nodes = if leaves <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
@@ -242,6 +247,8 @@ fn leaf_mask_range(start: u32, end: u32) -> u64 {
 
 #[inline(always)]
 fn parent_mask(mut mask: u64) -> u64 {
+    // Collapse 64 child bits into 32 parent bits. Repeated calls walk the
+    // 64-leaf page up to its root without iterating over every child bit.
     mask |= mask >> 1;
     mask &= 0x5555_5555_5555_5555;
     mask = (mask | (mask >> 1)) & 0x3333_3333_3333_3333;
@@ -277,6 +284,9 @@ fn local_merkle_nodes_added(mut old_mask: u64, mut added_mask: u64) -> u32 {
     while added_mask != 0 {
         let leaf = added_mask.trailing_zeros();
         let leaf_bit = 1u64 << leaf;
+        // For a single new leaf, each aligned group corresponds to one
+        // ancestor level. If no old leaf existed in that group, this leaf
+        // creates that ancestor node.
         nodes += u32::from(old_mask & (0x3 << (leaf & !0x1)) == 0);
         nodes += u32::from(old_mask & (0xf << (leaf & !0x3)) == 0);
         nodes += u32::from(old_mask & (0xff << (leaf & !0x7)) == 0);

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -397,8 +397,31 @@ impl MemoryCtx {
     #[inline(always)]
     fn record_page_access_no_len_update(&mut self, page_id: u32, leaf_mask: u64) {
         debug_assert!(leaf_mask != 0);
-        self.page_indices_since_checkpoint
-            .push(PageAccess { page_id, leaf_mask });
+        let len = self.page_indices_since_checkpoint.len();
+        if len != 0 {
+            // SAFETY: len is non-zero, so len - 1 is in bounds.
+            let prev = unsafe {
+                self.page_indices_since_checkpoint
+                    .get_unchecked_mut(len - 1)
+            };
+            if prev.page_id == page_id {
+                prev.leaf_mask |= leaf_mask;
+                return;
+            }
+        }
+
+        if len == self.page_indices_since_checkpoint.capacity() {
+            self.page_indices_since_checkpoint.reserve(1);
+        }
+
+        // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
+        unsafe {
+            self.page_indices_since_checkpoint
+                .as_mut_ptr()
+                .add(len)
+                .write(PageAccess { page_id, leaf_mask });
+            self.page_indices_since_checkpoint.set_len(len + 1);
+        }
     }
 
     #[cfg(feature = "rvr")]
@@ -469,7 +492,7 @@ impl MemoryCtx {
 
         // Add merkle height contributions for all registers
         self.add_register_merkle_heights();
-        self.lazy_update_boundary_heights(trace_heights);
+        self.apply_height_updates(trace_heights);
     }
 
     /// Updates the checkpoint with current safe state
@@ -511,7 +534,7 @@ impl MemoryCtx {
     /// The Poseidon2 count is still an upper bound because tracegen may
     /// deduplicate equal hash inputs by value.
     #[inline(always)]
-    fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
+    pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_leaves;
         let mut merkle_nodes = self.pending_merkle_nodes;
         self.pending_leaves = 0;
@@ -536,12 +559,6 @@ impl MemoryCtx {
             // Merkle AIR: 2 rows per internal node (init + final tree)
             *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += merkle_nodes * 2;
         }
-    }
-
-    /// Resolve all lazy updates of each memory access for poseidon2/merkle chips.
-    #[inline(always)]
-    pub(crate) fn lazy_update_boundary_heights(&mut self, trace_heights: &mut [u32]) {
-        self.apply_height_updates(trace_heights);
     }
 }
 
@@ -738,8 +755,8 @@ mod tests {
 
         let mut range_heights = vec![0; 6];
         let mut explicit_heights = vec![0; 6];
-        range_ctx.lazy_update_boundary_heights(&mut range_heights);
-        explicit_ctx.lazy_update_boundary_heights(&mut explicit_heights);
+        range_ctx.apply_height_updates(&mut range_heights);
+        explicit_ctx.apply_height_updates(&mut explicit_heights);
         assert_eq!(range_heights, explicit_heights);
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -8,6 +8,9 @@ use crate::{
     system::memory::{dimensions::MemoryDimensions, DIGEST_WIDTH},
 };
 
+/// Number of bits needed to index the 64 leaves represented by one page mask.
+pub const PAGE_BITS: usize = 6;
+
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
 const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
@@ -144,8 +147,7 @@ impl MemoryPageTracker {
     }
 
     #[inline(always)]
-    pub fn insert<const PAGE_BITS: usize>(&mut self, page_id: usize, leaf_mask: u64) {
-        debug_assert!(PAGE_BITS <= 6);
+    pub fn insert(&mut self, page_id: usize, leaf_mask: u64) {
         debug_assert!(page_id < self.page_masks.len());
         debug_assert!(leaf_mask != 0);
 
@@ -158,8 +160,7 @@ impl MemoryPageTracker {
 
         *page_mask = new_mask;
         self.leaves += (new_mask ^ old_mask).count_ones();
-        self.merkle_nodes +=
-            local_merkle_nodes::<PAGE_BITS>(new_mask) - local_merkle_nodes::<PAGE_BITS>(old_mask);
+        self.merkle_nodes += local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask);
 
         if old_mask == 0 {
             self.merkle_nodes += self.insert_upper_path(page_id);
@@ -177,16 +178,6 @@ impl MemoryPageTracker {
             }
         }
         count
-    }
-}
-
-#[inline(always)]
-fn full_leaf_mask<const PAGE_BITS: usize>() -> u64 {
-    debug_assert!(PAGE_BITS <= 6);
-    if PAGE_BITS == 6 {
-        u64::MAX
-    } else {
-        (1u64 << (1usize << PAGE_BITS)) - 1
     }
 }
 
@@ -215,12 +206,11 @@ fn parent_mask(mut mask: u64) -> u64 {
 }
 
 #[inline(always)]
-fn local_merkle_nodes<const PAGE_BITS: usize>(mask: u64) -> u32 {
-    debug_assert!(PAGE_BITS <= 6);
-    if mask == 0 || PAGE_BITS == 0 {
+fn local_merkle_nodes(mask: u64) -> u32 {
+    if mask == 0 {
         return 0;
     }
-    if mask == full_leaf_mask::<PAGE_BITS>() {
+    if mask == u64::MAX {
         return ((1usize << PAGE_BITS) - 1) as u32;
     }
 
@@ -234,16 +224,15 @@ fn local_merkle_nodes<const PAGE_BITS: usize>(mask: u64) -> u32 {
 }
 
 #[derive(Clone, Debug)]
-pub struct MemoryCtx<const PAGE_BITS: usize> {
+pub struct MemoryCtx {
     memory_dimensions: MemoryDimensions,
     pub page_tracker: MemoryPageTracker,
     pub page_indices_since_checkpoint: Vec<PageAccess>,
     pub page_indices_since_checkpoint_len: usize,
 }
 
-impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
+impl MemoryCtx {
     pub fn new(config: &SystemConfig, segment_check_insns: u64) -> Self {
-        assert!(PAGE_BITS <= 6, "PAGE_BITS must fit in a u64 leaf mask");
         let memory_dimensions = config.memory_config.memory_dimensions();
         let merkle_height = memory_dimensions.overall_height();
 
@@ -363,7 +352,7 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         let old_merkle_nodes = self.page_tracker.merkle_nodes;
         for &access in &self.page_indices_since_checkpoint {
             self.page_tracker
-                .insert::<PAGE_BITS>(access.page_id as usize, access.leaf_mask);
+                .insert(access.page_id as usize, access.leaf_mask);
         }
 
         let leaves = self.page_tracker.leaves - old_leaves;
@@ -418,21 +407,21 @@ mod tests {
     #[test]
     fn test_local_merkle_nodes_doc_example() {
         let mut tracker = MemoryPageTracker::new(1, 0);
-        tracker.insert::<3>(0, 1 << 0);
-        assert_eq!(tracker.merkle_nodes, 3);
-        tracker.insert::<3>(0, 1 << 4);
-        assert_eq!(tracker.merkle_nodes, 5);
-        tracker.insert::<3>(0, 1 << 2);
+        tracker.insert(0, 1 << 0);
         assert_eq!(tracker.merkle_nodes, 6);
+        tracker.insert(0, 1 << 4);
+        assert_eq!(tracker.merkle_nodes, 8);
+        tracker.insert(0, 1 << 2);
+        assert_eq!(tracker.merkle_nodes, 9);
     }
 
     #[test]
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
         let mut tracker = MemoryPageTracker::new(8, 3);
-        tracker.insert::<3>(0, 1 << 0);
+        tracker.insert(0, 1 << 0);
         let leaves = tracker.leaves;
         let nodes = tracker.merkle_nodes;
-        tracker.insert::<3>(0, 1 << 0);
+        tracker.insert(0, 1 << 0);
         assert_eq!(tracker.leaves, leaves);
         assert_eq!(tracker.merkle_nodes, nodes);
     }
@@ -440,17 +429,17 @@ mod tests {
     #[test]
     fn test_adjacent_pages_share_upper_ancestors() {
         let mut tracker = MemoryPageTracker::new(8, 3);
-        tracker.insert::<3>(0, 1);
+        tracker.insert(0, 1);
         let first = tracker.merkle_nodes;
-        tracker.insert::<3>(1, 1);
-        assert_eq!(tracker.merkle_nodes - first, 3);
+        tracker.insert(1, 1);
+        assert_eq!(tracker.merkle_nodes - first, PAGE_BITS as u32);
     }
 
     #[test]
     fn test_range_insertion_matches_explicit_leaves() {
         let system_config = crate::utils::test_system_config();
-        let mut range_ctx = MemoryCtx::<3>::new(&system_config, 1);
-        let mut explicit_ctx = MemoryCtx::<3>::new(&system_config, 1);
+        let mut range_ctx = MemoryCtx::new(&system_config, 1);
+        let mut explicit_ctx = MemoryCtx::new(&system_config, 1);
 
         range_ctx.update_boundary_merkle_heights(2, 0, 17);
         for ptr in [0, 16] {

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -169,7 +169,8 @@ pub struct MemoryPageTracker {
 }
 
 impl MemoryPageTracker {
-    pub fn new(num_pages: usize, upper_height: usize) -> Self {
+    pub fn new(upper_height: usize) -> Self {
+        let num_pages = 1 << upper_height;
         Self {
             page_masks: vec![0; num_pages].into_boxed_slice(),
             dirty_pages: Vec::new(),
@@ -331,12 +332,11 @@ impl MemoryCtx {
         let merkle_height = memory_dimensions.overall_height();
 
         let upper_height = merkle_height.saturating_sub(PAGE_BITS);
-        let num_pages = 1 << upper_height;
         let checkpoint_capacity = Self::initial_checkpoint_capacity(segment_check_insns);
 
         Self {
             memory_dimensions,
-            page_tracker: MemoryPageTracker::new(num_pages, upper_height),
+            page_tracker: MemoryPageTracker::new(upper_height),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
             page_indices_applied_len: 0,
@@ -639,7 +639,7 @@ mod tests {
 
     #[test]
     fn test_local_merkle_nodes_doc_example() {
-        let mut tracker = MemoryPageTracker::new(1, 0);
+        let mut tracker = MemoryPageTracker::new(0);
         tracker.insert(0, 1 << 0);
         assert_eq!(tracker.merkle_nodes, 6);
         tracker.insert(0, 1 << 4);
@@ -720,7 +720,7 @@ mod tests {
 
     #[test]
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
-        let mut tracker = MemoryPageTracker::new(8, 3);
+        let mut tracker = MemoryPageTracker::new(3);
         tracker.insert(0, 1 << 0);
         let leaves = tracker.leaves;
         let nodes = tracker.merkle_nodes;
@@ -731,7 +731,7 @@ mod tests {
 
     #[test]
     fn test_memory_page_tracker_clear_resets_touched_state() {
-        let mut tracker = MemoryPageTracker::new(8, 3);
+        let mut tracker = MemoryPageTracker::new(3);
         tracker.insert(0, 1 << 0);
         tracker.insert(7, 1 << 63);
         assert!(tracker.leaves > 0);
@@ -748,7 +748,7 @@ mod tests {
 
     #[test]
     fn test_adjacent_pages_share_upper_ancestors() {
-        let mut tracker = MemoryPageTracker::new(8, 3);
+        let mut tracker = MemoryPageTracker::new(3);
         tracker.insert(0, 1);
         let first = tracker.merkle_nodes;
         tracker.insert(1, 1);

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -4,7 +4,7 @@ use openvm_instructions::{
 };
 
 use crate::{
-    arch::{SystemConfig, BOUNDARY_AIR_ID, MERKLE_AIR_ID, U16_CELL_SIZE},
+    arch::{SystemConfig, ADDR_SPACE_OFFSET, BOUNDARY_AIR_ID, MERKLE_AIR_ID, U16_CELL_SIZE},
     system::memory::{dimensions::MemoryDimensions, DIGEST_WIDTH},
 };
 
@@ -15,6 +15,8 @@ pub const PAGE_BITS: usize = u64::BITS.ilog2() as usize;
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
 const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
 const SPARSE_MERKLE_DELTA_LEAF_THRESHOLD: u32 = 8;
+const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
+const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
 
 #[derive(Clone, Debug)]
 pub struct BitSet {
@@ -339,27 +341,43 @@ impl MemoryCtx {
         size: u32,
     ) {
         let end_ptr = ptr + size - 1;
-        let ptrs_per_leaf = if address_space == DEFERRAL_AS {
-            DIGEST_WIDTH as u32
+        let leaf_bits = if address_space == DEFERRAL_AS {
+            DEFERRAL_PTRS_PER_LEAF_BITS
         } else {
-            (U16_CELL_SIZE * DIGEST_WIDTH) as u32
+            BYTE_PTRS_PER_LEAF_BITS
         };
-        let leaf_bits = ptrs_per_leaf.ilog2();
         let leaf_label = ptr >> leaf_bits;
         let end_leaf_label = end_ptr >> leaf_bits;
         let num_leaves = end_leaf_label - leaf_label + 1;
-        let start_leaf_id = self
-            .memory_dimensions
-            .label_to_index((address_space, leaf_label)) as u32;
+        debug_assert!(
+            leaf_label < (1 << self.memory_dimensions.address_height),
+            "leaf_label={leaf_label} exceeds address_height={}",
+            self.memory_dimensions.address_height
+        );
+        let address_space_offset = (((address_space - ADDR_SPACE_OFFSET) as u64)
+            << self.memory_dimensions.address_height) as u32;
+        let start_leaf_id = address_space_offset + leaf_label;
         let end_leaf_id = start_leaf_id + num_leaves;
         let start_page_id = start_leaf_id >> PAGE_BITS;
+
+        if num_leaves == 1 {
+            self.record_page_access_no_len_update(
+                start_page_id,
+                1u64 << (start_leaf_id & ((1 << PAGE_BITS) - 1)),
+            );
+            self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
+            return;
+        }
+
         let end_page_id = ((end_leaf_id - 1) >> PAGE_BITS) + 1;
         let num_pages = (end_page_id - start_page_id) as usize;
         assert!(
             num_pages <= MAX_MEM_PAGE_OPS_PER_INSN,
             "more than {MAX_MEM_PAGE_OPS_PER_INSN} memory pages accessed in a single instruction"
         );
-        self.page_indices_since_checkpoint.reserve(num_pages);
+        if num_pages > 1 {
+            self.page_indices_since_checkpoint.reserve(num_pages);
+        }
 
         for page_id in start_page_id..end_page_id {
             let page_start = page_id << PAGE_BITS;
@@ -367,16 +385,25 @@ impl MemoryCtx {
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
-            self.record_page_access(page_id, leaf_mask);
+            self.record_page_access_no_len_update(page_id, leaf_mask);
         }
+        self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
     }
 
     #[inline(always)]
+    #[allow(dead_code)]
     pub(crate) fn record_page_access(&mut self, page_id: u32, leaf_mask: u64) {
         debug_assert!(leaf_mask != 0);
         self.page_indices_since_checkpoint
             .push(PageAccess { page_id, leaf_mask });
         self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
+    }
+
+    #[inline(always)]
+    fn record_page_access_no_len_update(&mut self, page_id: u32, leaf_mask: u64) {
+        debug_assert!(leaf_mask != 0);
+        self.page_indices_since_checkpoint
+            .push(PageAccess { page_id, leaf_mask });
     }
 
     #[cfg(feature = "rvr")]

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -17,10 +17,6 @@ pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
 // range accesses; this avoids preallocating the worst-case per-instruction page
 // count for the common scalar-access path.
 const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
-// Up to this many new leaves, count page-local Merkle nodes by walking only
-// the added bits. Larger updates use a fixed six-level recompute.
-const SPARSE_MERKLE_DELTA_LEAF_THRESHOLD: u32 = 8;
-
 // Shift amounts from address-space pointer units to memory Merkle leaves.
 const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
 const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
@@ -215,16 +211,16 @@ impl MemoryPageTracker {
         }
         // Newly set bits are the only leaves that can add boundary rows or new
         // page-local Merkle nodes.
-        let added_mask = new_mask ^ old_mask;
+        let added_mask = leaf_mask & !old_mask;
         let leaves = added_mask.count_ones();
-        let mut merkle_nodes = if leaves <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
-            // Sparse path: O(new leaves). For each added leaf, test the aligned
-            // 2/4/8/16/32/64-leaf groups that map to its ancestor levels.
-            local_merkle_nodes_added(old_mask, added_mask)
+        let mut merkle_nodes = if leaves == 1 {
+            // Single-leaf path: test the aligned 2/4/8/16/32/64-leaf groups
+            // containing that leaf.
+            local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros())
         } else {
-            // Dense path: walk old and new occupancy up the six page-local
-            // levels, then count the parent groups that became occupied.
-            local_merkle_nodes_delta(old_mask, new_mask)
+            // Multi-leaf path: walk old and added occupancy up the six
+            // page-local levels, then count groups newly occupied by added leaves.
+            local_merkle_nodes_delta(old_mask, added_mask)
         };
         self.leaves += leaves;
 
@@ -267,25 +263,25 @@ fn leaf_mask_range(start: u32, end: u32) -> u64 {
 #[inline(always)]
 fn add_level_delta<const SHIFT: u32, const MASK: u64>(
     old_mask: &mut u64,
-    new_mask: &mut u64,
+    added_mask: &mut u64,
 ) -> u32 {
     *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
-    *new_mask = (*new_mask | (*new_mask >> SHIFT)) & MASK;
-    (*new_mask & !*old_mask).count_ones()
+    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
+    (*added_mask & !*old_mask).count_ones()
 }
 
 #[inline(always)]
-fn local_merkle_nodes_delta(mut old_mask: u64, mut new_mask: u64) -> u32 {
-    debug_assert_ne!(old_mask, new_mask);
-    debug_assert_eq!(old_mask | new_mask, new_mask);
+fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
+    debug_assert_ne!(added_mask, 0);
+    debug_assert_eq!(old_mask & added_mask, 0);
 
     let mut nodes = 0;
-    nodes += add_level_delta::<1, FIRST_BIT_PER_PAIR>(&mut old_mask, &mut new_mask);
-    nodes += add_level_delta::<2, FIRST_BIT_PER_NIBBLE>(&mut old_mask, &mut new_mask);
-    nodes += add_level_delta::<4, FIRST_BIT_PER_BYTE>(&mut old_mask, &mut new_mask);
-    nodes += add_level_delta::<8, FIRST_BIT_PER_U16>(&mut old_mask, &mut new_mask);
-    nodes += add_level_delta::<16, FIRST_BIT_PER_U32>(&mut old_mask, &mut new_mask);
-    nodes += add_level_delta::<32, FIRST_BIT_PER_U64>(&mut old_mask, &mut new_mask);
+    nodes += add_level_delta::<1, FIRST_BIT_PER_PAIR>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<2, FIRST_BIT_PER_NIBBLE>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<4, FIRST_BIT_PER_BYTE>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<8, FIRST_BIT_PER_U16>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<16, FIRST_BIT_PER_U32>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<32, FIRST_BIT_PER_U64>(&mut old_mask, &mut added_mask);
 
     nodes
 }
@@ -300,25 +296,21 @@ fn aligned_group_is_empty<const GROUP_SIZE: u32>(old_mask: u64, leaf: u32) -> bo
 }
 
 #[inline(always)]
-fn local_merkle_nodes_added(mut old_mask: u64, mut added_mask: u64) -> u32 {
-    debug_assert_eq!(old_mask & added_mask, 0);
+fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
+    debug_assert!(leaf < u64::BITS);
+
+    if old_mask == 0 {
+        return PAGE_BITS as u32;
+    }
 
     let mut nodes = 0;
-    while added_mask != 0 {
-        // Pick one newly added leaf, then clear it from added_mask.
-        let leaf = added_mask.trailing_zeros();
-        let leaf_bit = 1u64 << leaf;
-        // Group sizes 2..32 are the page-local ancestor levels below the
-        // 64-leaf page root. The page root is new when the old page mask is empty.
-        nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
-        nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
-        nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
-        nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
-        nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
-        nodes += u32::from(old_mask == 0);
-        old_mask |= leaf_bit;
-        added_mask &= added_mask - 1;
-    }
+    // Group sizes 2..32 are the page-local ancestor levels below the
+    // 64-leaf page root. The page root already exists for a non-empty page.
+    nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
     nodes
 }
 
@@ -675,17 +667,15 @@ mod tests {
             let new_mask = old_mask | leaf_mask;
             if new_mask != old_mask {
                 let added_mask = new_mask ^ old_mask;
-                if added_mask.count_ones() <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
+                let expected =
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
+                if added_mask.count_ones() == 1 {
                     assert_eq!(
-                        local_merkle_nodes_added(old_mask, added_mask),
-                        reference_local_merkle_nodes(new_mask)
-                            - reference_local_merkle_nodes(old_mask)
+                        local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros()),
+                        expected
                     );
                 }
-                assert_eq!(
-                    local_merkle_nodes_delta(old_mask, new_mask),
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
-                );
+                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
                 old_mask = new_mask;
             }
         }
@@ -695,17 +685,15 @@ mod tests {
             let new_mask = old_mask | leaf_mask;
             if new_mask != old_mask {
                 let added_mask = new_mask ^ old_mask;
-                if added_mask.count_ones() <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
+                let expected =
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
+                if added_mask.count_ones() == 1 {
                     assert_eq!(
-                        local_merkle_nodes_added(old_mask, added_mask),
-                        reference_local_merkle_nodes(new_mask)
-                            - reference_local_merkle_nodes(old_mask)
+                        local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros()),
+                        expected
                     );
                 }
-                assert_eq!(
-                    local_merkle_nodes_delta(old_mask, new_mask),
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
-                );
+                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
                 old_mask = new_mask;
             }
         }
@@ -721,8 +709,9 @@ mod tests {
             seed ^= seed << 8;
             let new_mask = old_mask | seed;
             if new_mask != old_mask {
+                let added_mask = new_mask ^ old_mask;
                 assert_eq!(
-                    local_merkle_nodes_delta(old_mask, new_mask),
+                    local_merkle_nodes_delta(old_mask, added_mask),
                     reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
                 );
             }

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -13,6 +13,9 @@ pub const PAGE_BITS: usize = u64::BITS.ilog2() as usize;
 
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
+// Initial allocation only. Correctness is preserved by `Vec::reserve` for large
+// range accesses; this avoids preallocating the worst-case per-instruction page
+// count for the common scalar-access path.
 const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
 const SPARSE_MERKLE_DELTA_LEAF_THRESHOLD: u32 = 8;
 const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
@@ -302,12 +305,13 @@ impl MemoryCtx {
         let memory_dimensions = config.memory_config.memory_dimensions();
         let merkle_height = memory_dimensions.overall_height();
 
-        let num_pages = 1 << (merkle_height.saturating_sub(PAGE_BITS));
+        let upper_height = merkle_height.saturating_sub(PAGE_BITS);
+        let num_pages = 1 << upper_height;
         let checkpoint_capacity = Self::initial_checkpoint_capacity(segment_check_insns);
 
         Self {
             memory_dimensions,
-            page_tracker: MemoryPageTracker::new(num_pages, merkle_height - PAGE_BITS),
+            page_tracker: MemoryPageTracker::new(num_pages, upper_height),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
             page_indices_applied_len: 0,
@@ -387,15 +391,6 @@ impl MemoryCtx {
             let leaf_mask = leaf_mask_range(start, end);
             self.record_page_access_no_len_update(page_id, leaf_mask);
         }
-        self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
-    }
-
-    #[inline(always)]
-    #[allow(dead_code)]
-    pub(crate) fn record_page_access(&mut self, page_id: u32, leaf_mask: u64) {
-        debug_assert!(leaf_mask != 0);
-        self.page_indices_since_checkpoint
-            .push(PageAccess { page_id, leaf_mask });
         self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
     }
 
@@ -487,9 +482,34 @@ impl MemoryCtx {
         self.pending_merkle_nodes = 0;
     }
 
-    /// Applies exact boundary and Merkle height deltas for the page/leaf masks
-    /// recorded since the last checkpoint. Poseidon2 remains a safe upper bound:
-    /// tracegen may deduplicate equal hash inputs by value.
+    /// Applies boundary and Merkle height deltas for the page/leaf masks recorded
+    /// since the last checkpoint.
+    ///
+    /// Memory leaves form a sparse Merkle tree. Each page contains the 64 leaves
+    /// represented by one `u64` leaf mask:
+    ///
+    /// ```text
+    ///        [root]              height h
+    ///        /    \
+    ///      ...    ...
+    ///      /        \
+    ///   [page]    [page]         (h - PAGE_BITS) nodes above each page
+    ///   / .. \
+    ///  L  ..  L                  PAGE_BITS levels inside a 64-leaf page
+    /// ```
+    ///
+    /// `MemoryPageTracker` counts each newly touched leaf once, each newly
+    /// required internal node inside that page once, and each shared ancestor
+    /// above the page once across all pages in the segment. Each segment has an
+    /// initial and final memory tree, so boundary and Merkle row counts are
+    /// doubled.
+    ///
+    /// - BOUNDARY_AIR: `2 * new_leaves` rows
+    /// - MERKLE_AIR:   `2 * new_merkle_nodes` rows
+    /// - Poseidon2:    `2 * new_leaves + 2 * new_merkle_nodes` hashes
+    ///
+    /// The Poseidon2 count is still an upper bound because tracegen may
+    /// deduplicate equal hash inputs by value.
     #[inline(always)]
     fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_leaves;

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -14,16 +14,19 @@ pub const PAGE_BITS: usize = u64::BITS.ilog2() as usize;
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
 const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
+const SPARSE_MERKLE_DELTA_LEAF_THRESHOLD: u32 = 8;
 
 #[derive(Clone, Debug)]
 pub struct BitSet {
     words: Box<[u64]>,
+    dirty_words: Vec<usize>,
 }
 
 impl BitSet {
     pub fn new(num_bits: usize) -> Self {
         Self {
             words: vec![0; num_bits.div_ceil(u64::BITS as usize)].into_boxed_slice(),
+            dirty_words: Vec::new(),
         }
     }
 
@@ -39,8 +42,12 @@ impl BitSet {
         //         during memory access. The bitset is sized to accommodate all valid
         //         memory addresses, so word_index is always within bounds.
         let word = unsafe { self.words.get_unchecked_mut(word_index) };
-        let was_set = (*word & mask) != 0;
-        *word |= mask;
+        let old_word = *word;
+        let was_set = (old_word & mask) != 0;
+        if old_word == 0 {
+            self.dirty_words.push(word_index);
+        }
+        *word = old_word | mask;
         !was_set
     }
 
@@ -63,8 +70,12 @@ impl BitSet {
             // SAFETY: Caller ensures start < end and end <= self.words.len() * 64,
             // so start_word_index < self.words.len()
             let word = unsafe { self.words.get_unchecked_mut(start_word_index) };
-            ret += mask_bits - (*word & mask).count_ones();
-            *word |= mask;
+            let old_word = *word;
+            ret += mask_bits - (old_word & mask).count_ones();
+            if old_word == 0 {
+                self.dirty_words.push(start_word_index);
+            }
+            *word = old_word | mask;
         } else {
             let end_bit = (end & 63) as u32;
             let mask_bits = 64 - start_bit;
@@ -72,8 +83,12 @@ impl BitSet {
             // SAFETY: Caller ensures start < end and end <= self.words.len() * 64,
             // so start_word_index < self.words.len()
             let start_word = unsafe { self.words.get_unchecked_mut(start_word_index) };
-            ret += mask_bits - (*start_word & mask).count_ones();
-            *start_word |= mask;
+            let old_start_word = *start_word;
+            ret += mask_bits - (old_start_word & mask).count_ones();
+            if old_start_word == 0 {
+                self.dirty_words.push(start_word_index);
+            }
+            *start_word = old_start_word | mask;
 
             let mask_bits = end_bit;
             let mask = if end_bit == 0 {
@@ -84,8 +99,12 @@ impl BitSet {
             // SAFETY: Caller ensures end <= self.words.len() * 64, so
             // end_word_index < self.words.len()
             let end_word = unsafe { self.words.get_unchecked_mut(end_word_index) };
-            ret += mask_bits - (*end_word & mask).count_ones();
-            *end_word |= mask;
+            let old_end_word = *end_word;
+            ret += mask_bits - (old_end_word & mask).count_ones();
+            if mask != 0 && old_end_word == 0 {
+                self.dirty_words.push(end_word_index);
+            }
+            *end_word = old_end_word | mask;
         }
 
         if start_word_index + 1 < end_word_index {
@@ -93,7 +112,11 @@ impl BitSet {
                 // SAFETY: Caller ensures proper start and end, so i is within bounds
                 // of self.words.len()
                 let word = unsafe { self.words.get_unchecked_mut(i) };
-                ret += word.count_zeros();
+                let old_word = *word;
+                ret += old_word.count_zeros();
+                if old_word == 0 {
+                    self.dirty_words.push(i);
+                }
                 *word = u64::MAX;
             }
         }
@@ -102,9 +125,11 @@ impl BitSet {
 
     #[inline(always)]
     pub fn clear(&mut self) {
-        // SAFETY: words is valid for self.words.len() elements
-        unsafe {
-            std::ptr::write_bytes(self.words.as_mut_ptr(), 0, self.words.len());
+        for word_index in self.dirty_words.drain(..) {
+            // SAFETY: dirty_words entries are word indices previously written by this BitSet.
+            unsafe {
+                *self.words.get_unchecked_mut(word_index) = 0;
+            }
         }
     }
 }
@@ -119,6 +144,7 @@ pub struct PageAccess {
 #[derive(Clone, Debug)]
 pub struct MemoryPageTracker {
     page_masks: Box<[u64]>,
+    dirty_pages: Vec<usize>,
     upper_nodes: BitSet,
     upper_height: usize,
     merkle_nodes: u32,
@@ -129,6 +155,7 @@ impl MemoryPageTracker {
     pub fn new(num_pages: usize, upper_height: usize) -> Self {
         Self {
             page_masks: vec![0; num_pages].into_boxed_slice(),
+            dirty_pages: Vec::new(),
             upper_nodes: BitSet::new(num_pages),
             upper_height,
             merkle_nodes: 0,
@@ -138,8 +165,11 @@ impl MemoryPageTracker {
 
     #[inline(always)]
     pub fn clear(&mut self) {
-        unsafe {
-            std::ptr::write_bytes(self.page_masks.as_mut_ptr(), 0, self.page_masks.len());
+        for page_id in self.dirty_pages.drain(..) {
+            // SAFETY: dirty_pages entries are page indices previously written by this tracker.
+            unsafe {
+                *self.page_masks.get_unchecked_mut(page_id) = 0;
+            }
         }
         self.upper_nodes.clear();
         self.merkle_nodes = 0;
@@ -159,9 +189,12 @@ impl MemoryPageTracker {
         }
 
         *page_mask = new_mask;
+        if old_mask == 0 {
+            self.dirty_pages.push(page_id);
+        }
         let added_mask = new_mask ^ old_mask;
         let leaves = added_mask.count_ones();
-        let mut merkle_nodes = if leaves <= 4 {
+        let mut merkle_nodes = if leaves <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
             local_merkle_nodes_added(old_mask, added_mask)
         } else {
             local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask)
@@ -348,39 +381,46 @@ impl MemoryCtx {
 
     #[cfg(feature = "rvr")]
     #[inline(always)]
-    pub(crate) fn record_and_apply_page_accesses_with_offset(
+    pub(crate) fn apply_page_accesses_with_offset(
         &mut self,
         page_offset: u32,
         accesses: &[PageAccess],
     ) {
         let len = accesses.len();
-        if len == 0 {
-            return;
+        let ptr = accesses.as_ptr();
+        for i in 0..len {
+            // SAFETY: i is bounded by accesses.len().
+            let access = unsafe { *ptr.add(i) };
+            debug_assert!(access.leaf_mask != 0);
+            let page_id = page_offset + access.page_id;
+            let (leaves, merkle_nodes) =
+                self.page_tracker.insert(page_id as usize, access.leaf_mask);
+            self.pending_leaves += leaves;
+            self.pending_merkle_nodes += merkle_nodes;
         }
+    }
 
-        let old_len = self.page_indices_since_checkpoint.len();
-        self.page_indices_since_checkpoint.reserve(len);
+    #[cfg(feature = "rvr")]
+    #[inline(always)]
+    pub(crate) fn reset_segment_without_replay(&mut self, trace_heights: &mut [u32]) {
+        self.page_tracker.clear();
+        self.page_indices_since_checkpoint.clear();
+        self.page_indices_since_checkpoint_len = 0;
+        self.page_indices_applied_len = 0;
+        self.pending_leaves = 0;
+        self.pending_merkle_nodes = 0;
 
-        // SAFETY: reserve above ensures capacity for len new initialized entries.
+        // Reset trace heights for memory chips as 0
+        // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
         unsafe {
-            let dst = self.page_indices_since_checkpoint.as_mut_ptr().add(old_len);
-            for (i, access) in accesses.iter().enumerate() {
-                debug_assert!(access.leaf_mask != 0);
-                let page_id = page_offset + access.page_id;
-                dst.add(i).write(PageAccess {
-                    page_id,
-                    leaf_mask: access.leaf_mask,
-                });
-                let (leaves, merkle_nodes) =
-                    self.page_tracker.insert(page_id as usize, access.leaf_mask);
-                self.pending_leaves += leaves;
-                self.pending_merkle_nodes += merkle_nodes;
-            }
-            self.page_indices_since_checkpoint.set_len(old_len + len);
+            *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) = 0;
+            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) = 0;
         }
-
-        self.page_indices_applied_len = self.page_indices_since_checkpoint.len();
-        self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
+        let poseidon2_idx = trace_heights.len() - 2;
+        // SAFETY: poseidon2_idx is trace_heights.len() - 2, guaranteed to be in bounds
+        unsafe {
+            *trace_heights.get_unchecked_mut(poseidon2_idx) = 0;
+        }
     }
 
     /// Initialize state for a new segment
@@ -565,7 +605,7 @@ mod tests {
             let new_mask = old_mask | leaf_mask;
             if new_mask != old_mask {
                 let added_mask = new_mask ^ old_mask;
-                if added_mask.count_ones() <= 4 {
+                if added_mask.count_ones() <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
                     assert_eq!(
                         local_merkle_nodes_added(old_mask, added_mask),
                         reference_local_merkle_nodes(new_mask)
@@ -585,7 +625,7 @@ mod tests {
             let new_mask = old_mask | leaf_mask;
             if new_mask != old_mask {
                 let added_mask = new_mask ^ old_mask;
-                if added_mask.count_ones() <= 4 {
+                if added_mask.count_ones() <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
                     assert_eq!(
                         local_merkle_nodes_added(old_mask, added_mask),
                         reference_local_merkle_nodes(new_mask)
@@ -610,6 +650,23 @@ mod tests {
         tracker.insert(0, 1 << 0);
         assert_eq!(tracker.leaves, leaves);
         assert_eq!(tracker.merkle_nodes, nodes);
+    }
+
+    #[test]
+    fn test_memory_page_tracker_clear_resets_touched_state() {
+        let mut tracker = MemoryPageTracker::new(8, 3);
+        tracker.insert(0, 1 << 0);
+        tracker.insert(7, 1 << 63);
+        assert!(tracker.leaves > 0);
+        assert!(tracker.merkle_nodes > 0);
+
+        tracker.clear();
+        assert_eq!(tracker.leaves, 0);
+        assert_eq!(tracker.merkle_nodes, 0);
+
+        tracker.insert(0, 1 << 0);
+        assert_eq!(tracker.leaves, 1);
+        assert!(tracker.merkle_nodes > 0);
     }
 
     #[test]

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -20,8 +20,18 @@ const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
 // Up to this many new leaves, count page-local Merkle nodes by walking only
 // the added bits. Larger updates use a fixed six-level recompute.
 const SPARSE_MERKLE_DELTA_LEAF_THRESHOLD: u32 = 8;
+
+// Shift amounts from address-space pointer units to memory Merkle leaves.
 const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
 const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
+
+// Masks used to compact even-position parent bits into a dense lower-bit mask.
+const LOW_BIT_PER_PAIR: u64 = 0x5555_5555_5555_5555;
+const LOW_2_BITS_PER_NIBBLE: u64 = 0x3333_3333_3333_3333;
+const LOW_NIBBLE_PER_BYTE: u64 = 0x0f0f_0f0f_0f0f_0f0f;
+const LOW_BYTE_PER_U16: u64 = 0x00ff_00ff_00ff_00ff;
+const LOW_U16_PER_U32: u64 = 0x0000_ffff_0000_ffff;
+const LOW_U32: u64 = 0x0000_0000_ffff_ffff;
 
 #[derive(Clone, Debug)]
 pub struct BitSet {
@@ -144,8 +154,8 @@ impl BitSet {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PageAccess {
-    /// Scalar page index. The leaf occupancy for this page is stored in
-    /// `leaf_mask`.
+    /// Index into the page table. The leaf occupancy for this page is stored
+    /// in `leaf_mask`.
     pub page_id: u32,
     /// Bit `i` is set when leaf `i` inside this 64-leaf page was touched.
     pub leaf_mask: u64,
@@ -208,7 +218,7 @@ impl MemoryPageTracker {
         let leaves = added_mask.count_ones();
         let mut merkle_nodes = if leaves <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
             // Sparse path: O(new leaves). For each added leaf, test the aligned
-            // 2/4/8/16/32/64-leaf groups that map to its parent ancestors.
+            // 2/4/8/16/32/64-leaf groups that map to its ancestor levels.
             local_merkle_nodes_added(old_mask, added_mask)
         } else {
             // Dense path: recompute page-local nodes before/after with six
@@ -258,12 +268,14 @@ fn parent_mask(mut mask: u64) -> u64 {
     // Collapse child occupancy into parent occupancy: each parent bit is set
     // when either child bit is set. Repeated calls walk up to the page root.
     mask |= mask >> 1;
-    mask &= 0x5555_5555_5555_5555;
-    mask = (mask | (mask >> 1)) & 0x3333_3333_3333_3333;
-    mask = (mask | (mask >> 2)) & 0x0f0f_0f0f_0f0f_0f0f;
-    mask = (mask | (mask >> 4)) & 0x00ff_00ff_00ff_00ff;
-    mask = (mask | (mask >> 8)) & 0x0000_ffff_0000_ffff;
-    (mask | (mask >> 16)) & 0x0000_0000_ffff_ffff
+    mask &= LOW_BIT_PER_PAIR;
+
+    // Compact the 32 even-position parent bits into the low 32 bits.
+    mask = (mask | (mask >> 1)) & LOW_2_BITS_PER_NIBBLE;
+    mask = (mask | (mask >> 2)) & LOW_NIBBLE_PER_BYTE;
+    mask = (mask | (mask >> 4)) & LOW_BYTE_PER_U16;
+    mask = (mask | (mask >> 8)) & LOW_U16_PER_U32;
+    (mask | (mask >> 16)) & LOW_U32
 }
 
 #[inline(always)]
@@ -286,6 +298,15 @@ fn local_merkle_nodes(mask: u64) -> u32 {
 }
 
 #[inline(always)]
+fn aligned_group_is_empty<const GROUP_SIZE: u32>(old_mask: u64, leaf: u32) -> bool {
+    // The ancestor at this level covers the aligned group containing `leaf`.
+    // If the old mask has no bit in that group, adding `leaf` creates it.
+    let group_start = leaf & !(GROUP_SIZE - 1);
+    let group_mask = ((1u64 << GROUP_SIZE) - 1) << group_start;
+    old_mask & group_mask == 0
+}
+
+#[inline(always)]
 fn local_merkle_nodes_added(mut old_mask: u64, mut added_mask: u64) -> u32 {
     debug_assert_eq!(old_mask & added_mask, 0);
 
@@ -294,14 +315,13 @@ fn local_merkle_nodes_added(mut old_mask: u64, mut added_mask: u64) -> u32 {
         // Pick one newly added leaf, then clear it from added_mask.
         let leaf = added_mask.trailing_zeros();
         let leaf_bit = 1u64 << leaf;
-        // For a single new leaf, each aligned group corresponds to one
-        // ancestor level. If no old leaf existed in that group, this leaf
-        // creates that ancestor node.
-        nodes += u32::from(old_mask & (0x3 << (leaf & !0x1)) == 0);
-        nodes += u32::from(old_mask & (0xf << (leaf & !0x3)) == 0);
-        nodes += u32::from(old_mask & (0xff << (leaf & !0x7)) == 0);
-        nodes += u32::from(old_mask & (0xffff << (leaf & !0xf)) == 0);
-        nodes += u32::from(old_mask & (0xffff_ffff << (leaf & !0x1f)) == 0);
+        // Group sizes 2..32 are the page-local ancestor levels below the
+        // 64-leaf page root. The page root is new when the old page mask is empty.
+        nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
+        nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
+        nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
+        nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
+        nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
         nodes += u32::from(old_mask == 0);
         old_mask |= leaf_bit;
         added_mask &= added_mask - 1;

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -25,13 +25,14 @@ const SPARSE_MERKLE_DELTA_LEAF_THRESHOLD: u32 = 8;
 const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
 const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
 
-// Masks used to compact even-position parent bits into a dense lower-bit mask.
-const LOW_BIT_PER_PAIR: u64 = 0x5555_5555_5555_5555;
-const LOW_2_BITS_PER_NIBBLE: u64 = 0x3333_3333_3333_3333;
-const LOW_NIBBLE_PER_BYTE: u64 = 0x0f0f_0f0f_0f0f_0f0f;
-const LOW_BYTE_PER_U16: u64 = 0x00ff_00ff_00ff_00ff;
-const LOW_U16_PER_U32: u64 = 0x0000_ffff_0000_ffff;
-const LOW_U32: u64 = 0x0000_0000_ffff_ffff;
+// Masks with the first bit set in each aligned group of leaves. These represent
+// group occupancy at each page-local Merkle level.
+const FIRST_BIT_PER_PAIR: u64 = 0x5555_5555_5555_5555;
+const FIRST_BIT_PER_NIBBLE: u64 = 0x1111_1111_1111_1111;
+const FIRST_BIT_PER_BYTE: u64 = 0x0101_0101_0101_0101;
+const FIRST_BIT_PER_U16: u64 = 0x0001_0001_0001_0001;
+const FIRST_BIT_PER_U32: u64 = 0x0000_0001_0000_0001;
+const FIRST_BIT_PER_U64: u64 = 0x0000_0000_0000_0001;
 
 #[derive(Clone, Debug)]
 pub struct BitSet {
@@ -221,9 +222,9 @@ impl MemoryPageTracker {
             // 2/4/8/16/32/64-leaf groups that map to its ancestor levels.
             local_merkle_nodes_added(old_mask, added_mask)
         } else {
-            // Dense path: recompute page-local nodes before/after with six
-            // shift/mask parent collapses and popcounts.
-            local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask)
+            // Dense path: walk old and new occupancy up the six page-local
+            // levels, then count the parent groups that became occupied.
+            local_merkle_nodes_delta(old_mask, new_mask)
         };
         self.leaves += leaves;
 
@@ -264,36 +265,28 @@ fn leaf_mask_range(start: u32, end: u32) -> u64 {
 }
 
 #[inline(always)]
-fn parent_mask(mut mask: u64) -> u64 {
-    // Collapse child occupancy into parent occupancy: each parent bit is set
-    // when either child bit is set. Repeated calls walk up to the page root.
-    mask |= mask >> 1;
-    mask &= LOW_BIT_PER_PAIR;
-
-    // Compact the 32 even-position parent bits into the low 32 bits.
-    mask = (mask | (mask >> 1)) & LOW_2_BITS_PER_NIBBLE;
-    mask = (mask | (mask >> 2)) & LOW_NIBBLE_PER_BYTE;
-    mask = (mask | (mask >> 4)) & LOW_BYTE_PER_U16;
-    mask = (mask | (mask >> 8)) & LOW_U16_PER_U32;
-    (mask | (mask >> 16)) & LOW_U32
+fn add_level_delta<const SHIFT: u32, const MASK: u64>(
+    old_mask: &mut u64,
+    new_mask: &mut u64,
+) -> u32 {
+    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
+    *new_mask = (*new_mask | (*new_mask >> SHIFT)) & MASK;
+    (*new_mask & !*old_mask).count_ones()
 }
 
 #[inline(always)]
-fn local_merkle_nodes(mask: u64) -> u32 {
-    if mask == 0 {
-        return 0;
-    }
-    if mask == u64::MAX {
-        return ((1usize << PAGE_BITS) - 1) as u32;
-    }
+fn local_merkle_nodes_delta(mut old_mask: u64, mut new_mask: u64) -> u32 {
+    debug_assert_ne!(old_mask, new_mask);
+    debug_assert_eq!(old_mask | new_mask, new_mask);
 
     let mut nodes = 0;
-    let mut level_mask = mask;
-    for _ in 0..PAGE_BITS {
-        level_mask = parent_mask(level_mask);
-        // Each set parent bit is one page-local Merkle node at this level.
-        nodes += level_mask.count_ones();
-    }
+    nodes += add_level_delta::<1, FIRST_BIT_PER_PAIR>(&mut old_mask, &mut new_mask);
+    nodes += add_level_delta::<2, FIRST_BIT_PER_NIBBLE>(&mut old_mask, &mut new_mask);
+    nodes += add_level_delta::<4, FIRST_BIT_PER_BYTE>(&mut old_mask, &mut new_mask);
+    nodes += add_level_delta::<8, FIRST_BIT_PER_U16>(&mut old_mask, &mut new_mask);
+    nodes += add_level_delta::<16, FIRST_BIT_PER_U32>(&mut old_mask, &mut new_mask);
+    nodes += add_level_delta::<32, FIRST_BIT_PER_U64>(&mut old_mask, &mut new_mask);
+
     nodes
 }
 
@@ -664,35 +657,6 @@ mod tests {
     }
 
     #[test]
-    fn test_local_merkle_nodes_matches_reference() {
-        let cases = [
-            0,
-            1,
-            1 << 1,
-            1 << 2,
-            1 << 31,
-            1 << 32,
-            1 << 63,
-            0x5555_5555_5555_5555,
-            0xaaaa_aaaa_aaaa_aaaa,
-            0x0000_ffff_0000_ffff,
-            0xffff_0000_ffff_0000,
-            u64::MAX,
-        ];
-        for mask in cases {
-            assert_eq!(local_merkle_nodes(mask), reference_local_merkle_nodes(mask));
-        }
-
-        let mut mask = 0x9e37_79b9_7f4a_7c15u64;
-        for _ in 0..1024 {
-            mask ^= mask << 7;
-            mask ^= mask >> 9;
-            mask ^= mask << 8;
-            assert_eq!(local_merkle_nodes(mask), reference_local_merkle_nodes(mask));
-        }
-    }
-
-    #[test]
     fn test_local_merkle_nodes_added_matches_reference_delta() {
         let mut old_mask = 0u64;
         let additions = [
@@ -719,7 +683,7 @@ mod tests {
                     );
                 }
                 assert_eq!(
-                    local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask),
+                    local_merkle_nodes_delta(old_mask, new_mask),
                     reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
                 );
                 old_mask = new_mask;
@@ -739,10 +703,28 @@ mod tests {
                     );
                 }
                 assert_eq!(
-                    local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask),
+                    local_merkle_nodes_delta(old_mask, new_mask),
                     reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
                 );
                 old_mask = new_mask;
+            }
+        }
+
+        let mut seed = 0x9e37_79b9_7f4a_7c15u64;
+        for _ in 0..1024 {
+            seed ^= seed << 7;
+            seed ^= seed >> 9;
+            seed ^= seed << 8;
+            let old_mask = seed;
+            seed ^= seed << 7;
+            seed ^= seed >> 9;
+            seed ^= seed << 8;
+            let new_mask = old_mask | seed;
+            if new_mask != old_mask {
+                assert_eq!(
+                    local_merkle_nodes_delta(old_mask, new_mask),
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
+                );
             }
         }
     }

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -17,6 +17,8 @@ pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
 // range accesses; this avoids preallocating the worst-case per-instruction page
 // count for the common scalar-access path.
 const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
+// Up to this many new leaves, count page-local Merkle nodes by walking only
+// the added bits. Larger updates use a fixed six-level recompute.
 const SPARSE_MERKLE_DELTA_LEAF_THRESHOLD: u32 = 8;
 const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
 const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
@@ -205,8 +207,12 @@ impl MemoryPageTracker {
         let added_mask = new_mask ^ old_mask;
         let leaves = added_mask.count_ones();
         let mut merkle_nodes = if leaves <= SPARSE_MERKLE_DELTA_LEAF_THRESHOLD {
+            // Sparse path: O(new leaves). For each added leaf, test the aligned
+            // 2/4/8/16/32/64-leaf groups that map to its parent ancestors.
             local_merkle_nodes_added(old_mask, added_mask)
         } else {
+            // Dense path: recompute page-local nodes before/after with six
+            // shift/mask parent collapses and popcounts.
             local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask)
         };
         self.leaves += leaves;
@@ -220,6 +226,8 @@ impl MemoryPageTracker {
 
     #[inline(always)]
     fn insert_upper_path(&mut self, page_id: usize) -> u32 {
+        // Called only when a page first becomes non-empty in this segment.
+        // `upper_nodes` makes nearby pages share already-counted ancestors.
         let mut count = 0;
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
@@ -247,8 +255,8 @@ fn leaf_mask_range(start: u32, end: u32) -> u64 {
 
 #[inline(always)]
 fn parent_mask(mut mask: u64) -> u64 {
-    // Collapse 64 child bits into 32 parent bits. Repeated calls walk the
-    // 64-leaf page up to its root without iterating over every child bit.
+    // Collapse child occupancy into parent occupancy: each parent bit is set
+    // when either child bit is set. Repeated calls walk up to the page root.
     mask |= mask >> 1;
     mask &= 0x5555_5555_5555_5555;
     mask = (mask | (mask >> 1)) & 0x3333_3333_3333_3333;
@@ -271,6 +279,7 @@ fn local_merkle_nodes(mask: u64) -> u32 {
     let mut level_mask = mask;
     for _ in 0..PAGE_BITS {
         level_mask = parent_mask(level_mask);
+        // Each set parent bit is one page-local Merkle node at this level.
         nodes += level_mask.count_ones();
     }
     nodes
@@ -282,6 +291,7 @@ fn local_merkle_nodes_added(mut old_mask: u64, mut added_mask: u64) -> u32 {
 
     let mut nodes = 0;
     while added_mask != 0 {
+        // Pick one newly added leaf, then clear it from added_mask.
         let leaf = added_mask.trailing_zeros();
         let leaf_bit = 1u64 << leaf;
         // For a single new leaf, each aligned group corresponds to one
@@ -415,6 +425,8 @@ impl MemoryCtx {
                     .get_unchecked_mut(len - 1)
             };
             if prev.page_id == page_id {
+                // Consecutive accesses to the same page merge in-place; the
+                // tracker later deduplicates non-consecutive repeats.
                 prev.leaf_mask |= leaf_mask;
                 return;
             }

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -147,7 +147,7 @@ impl MemoryPageTracker {
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, page_id: usize, leaf_mask: u64) {
+    pub fn insert(&mut self, page_id: usize, leaf_mask: u64) -> (u32, u32) {
         debug_assert!(page_id < self.page_masks.len());
         debug_assert!(leaf_mask != 0);
 
@@ -155,16 +155,24 @@ impl MemoryPageTracker {
         let old_mask = *page_mask;
         let new_mask = old_mask | leaf_mask;
         if new_mask == old_mask {
-            return;
+            return (0, 0);
         }
 
         *page_mask = new_mask;
-        self.leaves += (new_mask ^ old_mask).count_ones();
-        self.merkle_nodes += local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask);
+        let added_mask = new_mask ^ old_mask;
+        let leaves = added_mask.count_ones();
+        let mut merkle_nodes = if leaves <= 4 {
+            local_merkle_nodes_added(old_mask, added_mask)
+        } else {
+            local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask)
+        };
+        self.leaves += leaves;
 
         if old_mask == 0 {
-            self.merkle_nodes += self.insert_upper_path(page_id);
+            merkle_nodes += self.insert_upper_path(page_id);
         }
+        self.merkle_nodes += merkle_nodes;
+        (leaves, merkle_nodes)
     }
 
     #[inline(always)]
@@ -196,13 +204,13 @@ fn leaf_mask_range(start: u32, end: u32) -> u64 {
 
 #[inline(always)]
 fn parent_mask(mut mask: u64) -> u64 {
-    let mut parents = 0;
-    while mask != 0 {
-        let bit = mask.trailing_zeros();
-        parents |= 1u64 << (bit >> 1);
-        mask &= mask - 1;
-    }
-    parents
+    mask |= mask >> 1;
+    mask &= 0x5555_5555_5555_5555;
+    mask = (mask | (mask >> 1)) & 0x3333_3333_3333_3333;
+    mask = (mask | (mask >> 2)) & 0x0f0f_0f0f_0f0f_0f0f;
+    mask = (mask | (mask >> 4)) & 0x00ff_00ff_00ff_00ff;
+    mask = (mask | (mask >> 8)) & 0x0000_ffff_0000_ffff;
+    (mask | (mask >> 16)) & 0x0000_0000_ffff_ffff
 }
 
 #[inline(always)]
@@ -223,12 +231,35 @@ fn local_merkle_nodes(mask: u64) -> u32 {
     nodes
 }
 
+#[inline(always)]
+fn local_merkle_nodes_added(mut old_mask: u64, mut added_mask: u64) -> u32 {
+    debug_assert_eq!(old_mask & added_mask, 0);
+
+    let mut nodes = 0;
+    while added_mask != 0 {
+        let leaf = added_mask.trailing_zeros();
+        let leaf_bit = 1u64 << leaf;
+        nodes += u32::from(old_mask & (0x3 << (leaf & !0x1)) == 0);
+        nodes += u32::from(old_mask & (0xf << (leaf & !0x3)) == 0);
+        nodes += u32::from(old_mask & (0xff << (leaf & !0x7)) == 0);
+        nodes += u32::from(old_mask & (0xffff << (leaf & !0xf)) == 0);
+        nodes += u32::from(old_mask & (0xffff_ffff << (leaf & !0x1f)) == 0);
+        nodes += u32::from(old_mask == 0);
+        old_mask |= leaf_bit;
+        added_mask &= added_mask - 1;
+    }
+    nodes
+}
+
 #[derive(Clone, Debug)]
 pub struct MemoryCtx {
     memory_dimensions: MemoryDimensions,
     pub page_tracker: MemoryPageTracker,
     pub page_indices_since_checkpoint: Vec<PageAccess>,
     pub page_indices_since_checkpoint_len: usize,
+    page_indices_applied_len: usize,
+    pending_leaves: u32,
+    pending_merkle_nodes: u32,
 }
 
 impl MemoryCtx {
@@ -244,6 +275,9 @@ impl MemoryCtx {
             page_tracker: MemoryPageTracker::new(num_pages, merkle_height - PAGE_BITS),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
+            page_indices_applied_len: 0,
+            pending_leaves: 0,
+            pending_merkle_nodes: 0,
         }
     }
 
@@ -312,10 +346,50 @@ impl MemoryCtx {
         self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
     }
 
+    #[cfg(feature = "rvr")]
+    #[inline(always)]
+    pub(crate) fn record_and_apply_page_accesses_with_offset(
+        &mut self,
+        page_offset: u32,
+        accesses: &[PageAccess],
+    ) {
+        let len = accesses.len();
+        if len == 0 {
+            return;
+        }
+
+        let old_len = self.page_indices_since_checkpoint.len();
+        self.page_indices_since_checkpoint.reserve(len);
+
+        // SAFETY: reserve above ensures capacity for len new initialized entries.
+        unsafe {
+            let dst = self.page_indices_since_checkpoint.as_mut_ptr().add(old_len);
+            for (i, access) in accesses.iter().enumerate() {
+                debug_assert!(access.leaf_mask != 0);
+                let page_id = page_offset + access.page_id;
+                dst.add(i).write(PageAccess {
+                    page_id,
+                    leaf_mask: access.leaf_mask,
+                });
+                let (leaves, merkle_nodes) =
+                    self.page_tracker.insert(page_id as usize, access.leaf_mask);
+                self.pending_leaves += leaves;
+                self.pending_merkle_nodes += merkle_nodes;
+            }
+            self.page_indices_since_checkpoint.set_len(old_len + len);
+        }
+
+        self.page_indices_applied_len = self.page_indices_since_checkpoint.len();
+        self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
+    }
+
     /// Initialize state for a new segment
     #[inline(always)]
     pub(crate) fn initialize_segment(&mut self, trace_heights: &mut [u32]) {
         self.page_tracker.clear();
+        self.page_indices_applied_len = 0;
+        self.pending_leaves = 0;
+        self.pending_merkle_nodes = 0;
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -341,6 +415,9 @@ impl MemoryCtx {
     pub(crate) fn update_checkpoint(&mut self) {
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
+        self.page_indices_applied_len = 0;
+        self.pending_leaves = 0;
+        self.pending_merkle_nodes = 0;
     }
 
     /// Applies exact boundary and Merkle height deltas for the page/leaf masks
@@ -348,15 +425,20 @@ impl MemoryCtx {
     /// tracegen may deduplicate equal hash inputs by value.
     #[inline(always)]
     fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
-        let old_leaves = self.page_tracker.leaves;
-        let old_merkle_nodes = self.page_tracker.merkle_nodes;
-        for &access in &self.page_indices_since_checkpoint {
-            self.page_tracker
-                .insert(access.page_id as usize, access.leaf_mask);
-        }
+        let mut leaves = self.pending_leaves;
+        let mut merkle_nodes = self.pending_merkle_nodes;
+        self.pending_leaves = 0;
+        self.pending_merkle_nodes = 0;
 
-        let leaves = self.page_tracker.leaves - old_leaves;
-        let merkle_nodes = self.page_tracker.merkle_nodes - old_merkle_nodes;
+        for &access in &self.page_indices_since_checkpoint[self.page_indices_applied_len..] {
+            let (new_leaves, new_merkle_nodes) = self
+                .page_tracker
+                .insert(access.page_id as usize, access.leaf_mask);
+            leaves += new_leaves;
+            merkle_nodes += new_merkle_nodes;
+        }
+        self.page_indices_applied_len = self.page_indices_since_checkpoint.len();
+
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
@@ -379,6 +461,26 @@ impl MemoryCtx {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn reference_parent_mask(mut mask: u64) -> u64 {
+        let mut parents = 0;
+        while mask != 0 {
+            let bit = mask.trailing_zeros();
+            parents |= 1u64 << (bit >> 1);
+            mask &= mask - 1;
+        }
+        parents
+    }
+
+    fn reference_local_merkle_nodes(mask: u64) -> u32 {
+        let mut nodes = 0;
+        let mut level_mask = mask;
+        for _ in 0..PAGE_BITS {
+            level_mask = reference_parent_mask(level_mask);
+            nodes += level_mask.count_ones();
+        }
+        nodes
+    }
 
     #[test]
     fn test_bitset_insert_range() {
@@ -413,6 +515,90 @@ mod tests {
         assert_eq!(tracker.merkle_nodes, 8);
         tracker.insert(0, 1 << 2);
         assert_eq!(tracker.merkle_nodes, 9);
+    }
+
+    #[test]
+    fn test_local_merkle_nodes_matches_reference() {
+        let cases = [
+            0,
+            1,
+            1 << 1,
+            1 << 2,
+            1 << 31,
+            1 << 32,
+            1 << 63,
+            0x5555_5555_5555_5555,
+            0xaaaa_aaaa_aaaa_aaaa,
+            0x0000_ffff_0000_ffff,
+            0xffff_0000_ffff_0000,
+            u64::MAX,
+        ];
+        for mask in cases {
+            assert_eq!(local_merkle_nodes(mask), reference_local_merkle_nodes(mask));
+        }
+
+        let mut mask = 0x9e37_79b9_7f4a_7c15u64;
+        for _ in 0..1024 {
+            mask ^= mask << 7;
+            mask ^= mask >> 9;
+            mask ^= mask << 8;
+            assert_eq!(local_merkle_nodes(mask), reference_local_merkle_nodes(mask));
+        }
+    }
+
+    #[test]
+    fn test_local_merkle_nodes_added_matches_reference_delta() {
+        let mut old_mask = 0u64;
+        let additions = [
+            1u64 << 0,
+            1u64 << 1,
+            1u64 << 4,
+            1u64 << 17,
+            1u64 << 31,
+            1u64 << 32,
+            1u64 << 63,
+            0x5555_0000_0000_0000,
+            0xaaaa_ffff_0000_0000,
+            u64::MAX,
+        ];
+        for leaf_mask in additions {
+            let new_mask = old_mask | leaf_mask;
+            if new_mask != old_mask {
+                let added_mask = new_mask ^ old_mask;
+                if added_mask.count_ones() <= 4 {
+                    assert_eq!(
+                        local_merkle_nodes_added(old_mask, added_mask),
+                        reference_local_merkle_nodes(new_mask)
+                            - reference_local_merkle_nodes(old_mask)
+                    );
+                }
+                assert_eq!(
+                    local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask),
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
+                );
+                old_mask = new_mask;
+            }
+        }
+
+        old_mask = 1;
+        for leaf_mask in additions {
+            let new_mask = old_mask | leaf_mask;
+            if new_mask != old_mask {
+                let added_mask = new_mask ^ old_mask;
+                if added_mask.count_ones() <= 4 {
+                    assert_eq!(
+                        local_merkle_nodes_added(old_mask, added_mask),
+                        reference_local_merkle_nodes(new_mask)
+                            - reference_local_merkle_nodes(old_mask)
+                    );
+                }
+                assert_eq!(
+                    local_merkle_nodes(new_mask) - local_merkle_nodes(old_mask),
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
+                );
+                old_mask = new_mask;
+            }
+        }
     }
 
     #[test]

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -1,4 +1,3 @@
-use abi_stable::std_types::RVec;
 use openvm_instructions::{
     riscv::{RV64_NUM_REGISTERS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
     DEFERRAL_AS,
@@ -11,6 +10,7 @@ use crate::{
 
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
 pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
+const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
 
 #[derive(Clone, Debug)]
 pub struct BitSet {
@@ -106,36 +106,161 @@ impl BitSet {
     }
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PageAccess {
+    pub page_id: u32,
+    pub leaf_mask: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct MemoryPageTracker {
+    page_masks: Box<[u64]>,
+    upper_nodes: BitSet,
+    upper_height: usize,
+    merkle_nodes: u32,
+    leaves: u32,
+}
+
+impl MemoryPageTracker {
+    pub fn new(num_pages: usize, upper_height: usize) -> Self {
+        Self {
+            page_masks: vec![0; num_pages].into_boxed_slice(),
+            upper_nodes: BitSet::new(num_pages),
+            upper_height,
+            merkle_nodes: 0,
+            leaves: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        unsafe {
+            std::ptr::write_bytes(self.page_masks.as_mut_ptr(), 0, self.page_masks.len());
+        }
+        self.upper_nodes.clear();
+        self.merkle_nodes = 0;
+        self.leaves = 0;
+    }
+
+    #[inline(always)]
+    pub fn insert<const PAGE_BITS: usize>(&mut self, page_id: usize, leaf_mask: u64) {
+        debug_assert!(PAGE_BITS <= 6);
+        debug_assert!(page_id < self.page_masks.len());
+        debug_assert!(leaf_mask != 0);
+
+        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
+        let old_mask = *page_mask;
+        let new_mask = old_mask | leaf_mask;
+        if new_mask == old_mask {
+            return;
+        }
+
+        *page_mask = new_mask;
+        self.leaves += (new_mask ^ old_mask).count_ones();
+        self.merkle_nodes +=
+            local_merkle_nodes::<PAGE_BITS>(new_mask) - local_merkle_nodes::<PAGE_BITS>(old_mask);
+
+        if old_mask == 0 {
+            self.merkle_nodes += self.insert_upper_path(page_id);
+        }
+    }
+
+    #[inline(always)]
+    fn insert_upper_path(&mut self, page_id: usize) -> u32 {
+        let mut count = 0;
+        let mut node = (1usize << self.upper_height) + page_id;
+        while node > 1 {
+            node >>= 1;
+            if self.upper_nodes.insert(node) {
+                count += 1;
+            }
+        }
+        count
+    }
+}
+
+#[inline(always)]
+fn full_leaf_mask<const PAGE_BITS: usize>() -> u64 {
+    debug_assert!(PAGE_BITS <= 6);
+    if PAGE_BITS == 6 {
+        u64::MAX
+    } else {
+        (1u64 << (1usize << PAGE_BITS)) - 1
+    }
+}
+
+#[inline(always)]
+fn leaf_mask_range(start: u32, end: u32) -> u64 {
+    debug_assert!(start < end);
+    debug_assert!(end <= 64);
+    let width = end - start;
+    let mask = if width == 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    };
+    mask << start
+}
+
+#[inline(always)]
+fn parent_mask(mut mask: u64) -> u64 {
+    let mut parents = 0;
+    while mask != 0 {
+        let bit = mask.trailing_zeros();
+        parents |= 1u64 << (bit >> 1);
+        mask &= mask - 1;
+    }
+    parents
+}
+
+#[inline(always)]
+fn local_merkle_nodes<const PAGE_BITS: usize>(mask: u64) -> u32 {
+    debug_assert!(PAGE_BITS <= 6);
+    if mask == 0 || PAGE_BITS == 0 {
+        return 0;
+    }
+    if mask == full_leaf_mask::<PAGE_BITS>() {
+        return ((1usize << PAGE_BITS) - 1) as u32;
+    }
+
+    let mut nodes = 0;
+    let mut level_mask = mask;
+    for _ in 0..PAGE_BITS {
+        level_mask = parent_mask(level_mask);
+        nodes += level_mask.count_ones();
+    }
+    nodes
+}
+
 #[derive(Clone, Debug)]
 pub struct MemoryCtx<const PAGE_BITS: usize> {
     memory_dimensions: MemoryDimensions,
-    pub page_indices: BitSet,
-    pub addr_space_access_count: RVec<u32>,
-    pub page_indices_since_checkpoint: Box<[u32]>,
+    pub page_tracker: MemoryPageTracker,
+    pub page_indices_since_checkpoint: Vec<PageAccess>,
     pub page_indices_since_checkpoint_len: usize,
 }
 
 impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
     pub fn new(config: &SystemConfig, segment_check_insns: u64) -> Self {
+        assert!(PAGE_BITS <= 6, "PAGE_BITS must fit in a u64 leaf mask");
         let memory_dimensions = config.memory_config.memory_dimensions();
         let merkle_height = memory_dimensions.overall_height();
 
-        let bitset_size = 1 << (merkle_height.saturating_sub(PAGE_BITS));
-        let addr_space_size = (1 << memory_dimensions.addr_space_height) + 1;
-        let checkpoint_capacity = Self::calculate_checkpoint_capacity(segment_check_insns);
+        let num_pages = 1 << (merkle_height.saturating_sub(PAGE_BITS));
+        let checkpoint_capacity = Self::initial_checkpoint_capacity(segment_check_insns);
 
         Self {
             memory_dimensions,
-            page_indices: BitSet::new(bitset_size),
-            addr_space_access_count: vec![0; addr_space_size].into(),
-            page_indices_since_checkpoint: vec![0; checkpoint_capacity].into_boxed_slice(),
+            page_tracker: MemoryPageTracker::new(num_pages, merkle_height - PAGE_BITS),
+            page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
         }
     }
 
     #[inline(always)]
-    fn calculate_checkpoint_capacity(segment_check_insns: u64) -> usize {
-        segment_check_insns as usize * MAX_MEM_PAGE_OPS_PER_INSN
+    fn initial_checkpoint_capacity(segment_check_insns: u64) -> usize {
+        segment_check_insns as usize * INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN
     }
 
     #[inline(always)]
@@ -157,8 +282,6 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         ptr: u32,
         size: u32,
     ) {
-        debug_assert!((address_space as usize) < self.addr_space_access_count.len());
-
         let end_ptr = ptr + size - 1;
         let ptrs_per_leaf = if address_space == DEFERRAL_AS {
             DIGEST_WIDTH as u32
@@ -175,39 +298,35 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
         let end_leaf_id = start_leaf_id + num_leaves;
         let start_page_id = start_leaf_id >> PAGE_BITS;
         let end_page_id = ((end_leaf_id - 1) >> PAGE_BITS) + 1;
+        let num_pages = (end_page_id - start_page_id) as usize;
         assert!(
-            self.page_indices_since_checkpoint_len + (end_page_id - start_page_id) as usize
-                <= self.page_indices_since_checkpoint.len(),
+            num_pages <= MAX_MEM_PAGE_OPS_PER_INSN,
             "more than {MAX_MEM_PAGE_OPS_PER_INSN} memory pages accessed in a single instruction"
         );
+        self.page_indices_since_checkpoint.reserve(num_pages);
 
         for page_id in start_page_id..end_page_id {
-            // Append page_id to page_indices_since_checkpoint
-            let len = self.page_indices_since_checkpoint_len;
-            debug_assert!(len < self.page_indices_since_checkpoint.len());
-            // SAFETY: len is within bounds, and we extend length by 1 after writing.
-            unsafe {
-                *self.page_indices_since_checkpoint.as_mut_ptr().add(len) = page_id;
-            }
-            self.page_indices_since_checkpoint_len = len + 1;
-
-            if self.page_indices.insert(page_id as usize) {
-                // SAFETY: address_space passed is usually a hardcoded constant or derived from an
-                // Instruction where it is bounds checked before passing
-                unsafe {
-                    *self
-                        .addr_space_access_count
-                        .get_unchecked_mut(address_space as usize) += 1;
-                }
-            }
+            let page_start = page_id << PAGE_BITS;
+            let page_end = page_start + (1 << PAGE_BITS);
+            let start = start_leaf_id.max(page_start) - page_start;
+            let end = end_leaf_id.min(page_end) - page_start;
+            let leaf_mask = leaf_mask_range(start, end);
+            self.record_page_access(page_id, leaf_mask);
         }
+    }
+
+    #[inline(always)]
+    pub(crate) fn record_page_access(&mut self, page_id: u32, leaf_mask: u64) {
+        debug_assert!(leaf_mask != 0);
+        self.page_indices_since_checkpoint
+            .push(PageAccess { page_id, leaf_mask });
+        self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
     }
 
     /// Initialize state for a new segment
     #[inline(always)]
     pub(crate) fn initialize_segment(&mut self, trace_heights: &mut [u32]) {
-        // Clear page indices for the new segment
-        self.page_indices.clear();
+        self.page_tracker.clear();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -221,27 +340,7 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
             *trace_heights.get_unchecked_mut(poseidon2_idx) = 0;
         }
 
-        // Apply height updates for all pages accessed since last checkpoint, and
-        // initialize page_indices for the new segment.
-        let mut addr_space_access_count = vec![0; self.addr_space_access_count.len()];
-        let pages_len = self.page_indices_since_checkpoint_len;
-        for i in 0..pages_len {
-            // SAFETY: i is within 0..pages_len and pages_len is the slice length.
-            let page_id = unsafe { *self.page_indices_since_checkpoint.get_unchecked(i) } as usize;
-            if self.page_indices.insert(page_id) {
-                let (addr_space, _) = self
-                    .memory_dimensions
-                    .index_to_label((page_id as u64) << PAGE_BITS);
-                let addr_space_idx = addr_space as usize;
-                debug_assert!(addr_space_idx < addr_space_access_count.len());
-                // SAFETY: addr_space_idx is bounds checked in debug and derived from a valid page
-                // id.
-                unsafe {
-                    *addr_space_access_count.get_unchecked_mut(addr_space_idx) += 1;
-                }
-            }
-        }
-        self.apply_height_updates(trace_heights, &addr_space_access_count);
+        self.apply_height_updates(trace_heights);
 
         // Add merkle height contributions for all registers
         self.add_register_merkle_heights();
@@ -251,66 +350,40 @@ impl<const PAGE_BITS: usize> MemoryCtx<PAGE_BITS> {
     /// Updates the checkpoint with current safe state
     #[inline(always)]
     pub(crate) fn update_checkpoint(&mut self) {
+        self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
     }
 
-    /// Overestimates trace heights from page faults.
-    ///
-    /// Memory leaves (DIGEST_WIDTH-sized) form a sparse merkle tree of height `h`. Each segment
-    /// maintains an initial and final tree, so all counts are doubled.
-    ///
-    /// On each page fault, we conservatively assume all `2^PAGE_BITS` leaves in the page
-    /// are touched and no merkle nodes are shared across pages:
-    ///
-    /// ```text
-    ///        [root]              height h
-    ///        /    \
-    ///      ...    ...
-    ///      /        \
-    ///   [page]    [page]         (h - PAGE_BITS) nodes above each page
-    ///   / .. \
-    ///  L  ..  L                  2^PAGE_BITS leaves, (2^PAGE_BITS - 1) internal nodes
-    /// ```
-    ///
-    /// Per page fault:
-    /// - BOUNDARY_AIR: `2 * 2^PAGE_BITS` rows (one init + one final row per leaf)
-    /// - MERKLE_AIR:   `2 * nodes_per_page` rows
-    /// - Poseidon2:    `2 * 2^PAGE_BITS` (leaf compression) + `2 * nodes_per_page` (tree hashes)
+    /// Applies exact boundary and Merkle height deltas for the page/leaf masks
+    /// recorded since the last checkpoint. Poseidon2 remains a safe upper bound:
+    /// tracegen may deduplicate equal hash inputs by value.
     #[inline(always)]
-    fn apply_height_updates(&self, trace_heights: &mut [u32], addr_space_access_count: &[u32]) {
-        let page_access_count: u32 = addr_space_access_count.iter().sum();
+    fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
+        let old_leaves = self.page_tracker.leaves;
+        let old_merkle_nodes = self.page_tracker.merkle_nodes;
+        for &access in &self.page_indices_since_checkpoint {
+            self.page_tracker
+                .insert::<PAGE_BITS>(access.page_id as usize, access.leaf_mask);
+        }
 
-        // Leaves touched: conservatively assume every leaf in each faulted page is touched.
-        let leaves = page_access_count << PAGE_BITS;
+        let leaves = self.page_tracker.leaves - old_leaves;
+        let merkle_nodes = self.page_tracker.merkle_nodes - old_merkle_nodes;
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
-
-        let merkle_height = self.memory_dimensions.overall_height();
-        let nodes_per_page = (((1 << PAGE_BITS) - 1) + (merkle_height - PAGE_BITS)) as u32;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
         unsafe {
             *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves * 2;
             // Poseidon2: 2 hashes per leaf (compression) + 2 per internal node (init + final tree)
-            *trace_heights.get_unchecked_mut(poseidon2_idx) +=
-                leaves * 2 + nodes_per_page * page_access_count * 2;
+            *trace_heights.get_unchecked_mut(poseidon2_idx) += leaves * 2 + merkle_nodes * 2;
             // Merkle AIR: 2 rows per internal node (init + final tree)
-            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) +=
-                nodes_per_page * page_access_count * 2;
+            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += merkle_nodes * 2;
         }
     }
 
     /// Resolve all lazy updates of each memory access for poseidon2/merkle chips.
     #[inline(always)]
     pub(crate) fn lazy_update_boundary_heights(&mut self, trace_heights: &mut [u32]) {
-        self.apply_height_updates(trace_heights, &self.addr_space_access_count);
-        // SAFETY: Resetting array elements to 0 is always safe
-        unsafe {
-            std::ptr::write_bytes(
-                self.addr_space_access_count.as_mut_ptr(),
-                0,
-                self.addr_space_access_count.len(),
-            );
-        }
+        self.apply_height_updates(trace_heights);
     }
 }
 
@@ -340,5 +413,54 @@ mod tests {
         assert_eq!(num_flips, 57);
         let num_flips = bit_set.insert_range(100, 513);
         assert_eq!(num_flips, 413 - 121);
+    }
+
+    #[test]
+    fn test_local_merkle_nodes_doc_example() {
+        let mut tracker = MemoryPageTracker::new(1, 0);
+        tracker.insert::<3>(0, 1 << 0);
+        assert_eq!(tracker.merkle_nodes, 3);
+        tracker.insert::<3>(0, 1 << 4);
+        assert_eq!(tracker.merkle_nodes, 5);
+        tracker.insert::<3>(0, 1 << 2);
+        assert_eq!(tracker.merkle_nodes, 6);
+    }
+
+    #[test]
+    fn test_page_mask_duplicate_leaf_does_not_change_counts() {
+        let mut tracker = MemoryPageTracker::new(8, 3);
+        tracker.insert::<3>(0, 1 << 0);
+        let leaves = tracker.leaves;
+        let nodes = tracker.merkle_nodes;
+        tracker.insert::<3>(0, 1 << 0);
+        assert_eq!(tracker.leaves, leaves);
+        assert_eq!(tracker.merkle_nodes, nodes);
+    }
+
+    #[test]
+    fn test_adjacent_pages_share_upper_ancestors() {
+        let mut tracker = MemoryPageTracker::new(8, 3);
+        tracker.insert::<3>(0, 1);
+        let first = tracker.merkle_nodes;
+        tracker.insert::<3>(1, 1);
+        assert_eq!(tracker.merkle_nodes - first, 3);
+    }
+
+    #[test]
+    fn test_range_insertion_matches_explicit_leaves() {
+        let system_config = crate::utils::test_system_config();
+        let mut range_ctx = MemoryCtx::<3>::new(&system_config, 1);
+        let mut explicit_ctx = MemoryCtx::<3>::new(&system_config, 1);
+
+        range_ctx.update_boundary_merkle_heights(2, 0, 17);
+        for ptr in [0, 16] {
+            explicit_ctx.update_boundary_merkle_heights(2, ptr, 1);
+        }
+
+        let mut range_heights = vec![0; 6];
+        let mut explicit_heights = vec![0; 6];
+        range_ctx.lazy_update_boundary_heights(&mut range_heights);
+        explicit_ctx.lazy_update_boundary_heights(&mut explicit_heights);
+        assert_eq!(range_heights, explicit_heights);
     }
 }

--- a/crates/vm/src/arch/rvr/abi_consts.rs
+++ b/crates/vm/src/arch/rvr/abi_consts.rs
@@ -4,9 +4,9 @@
 //! TODO: decide whether any redefinition can be replaced with a direct
 //! import — e.g. by moving the canonical constant into a leaf crate.
 //!
-//! TODO(defaults): `DEFAULT_PAGE_BITS` / `DEFAULT_SEGMENT_CHECK_INSNS` are
-//! tunable defaults, not invariants — decide whether to keep them as
-//! `const`s or restore runtime plumbing for just these two.
+//! TODO(defaults): `DEFAULT_SEGMENT_CHECK_INSNS` is a tunable default, not an
+//! invariant — decide whether to keep it as a `const` or restore runtime
+//! plumbing for it.
 
 use openvm_instructions::{
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
@@ -16,7 +16,7 @@ use rvr_openvm_ext_ffi_common as ffi;
 
 use crate::{
     arch::execution_mode::metered::{
-        ctx::DEFAULT_PAGE_BITS, segment_ctx::DEFAULT_SEGMENT_CHECK_INSNS,
+        memory_ctx::PAGE_BITS, segment_ctx::DEFAULT_SEGMENT_CHECK_INSNS,
     },
     system::memory::{merkle::public_values::PUBLIC_VALUES_AS, DIGEST_WIDTH},
 };
@@ -37,5 +37,5 @@ const _: () = assert!(
 );
 
 // ── rvr-openvm-ext-ffi-common metered-execution layout ─────────────────
-const _: () = assert!(ffi::DEFAULT_PAGE_BITS == DEFAULT_PAGE_BITS);
+const _: () = assert!(ffi::PAGE_BITS == PAGE_BITS);
 const _: () = assert!(ffi::DEFAULT_SEGMENT_CHECK_INSNS as u64 == DEFAULT_SEGMENT_CHECK_INSNS);

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -188,27 +188,31 @@ impl SegmentationState {
         self.deferral_page_buf.as_mut_ptr()
     }
 
-    /// Flush all page buffers: convert local pages to global ids and append
-    /// their leaf masks to the shared memory metering checkpoint buffer.
-    fn flush_page_buffer(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
+    /// Apply all page buffers: convert local pages to global ids and update
+    /// memory metering state.
+    fn apply_page_buffer(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
         let page_shift = self.address_height as usize - DEFAULT_PAGE_BITS;
-        let mem_offset = ((RV64_MEMORY_AS as usize - 1) << page_shift) as u32;
-        self.memory_ctx.record_and_apply_page_accesses_with_offset(
-            mem_offset,
-            &self.mem_page_buf[..mem_len as usize],
-        );
+        if mem_len != 0 {
+            let mem_offset = ((RV64_MEMORY_AS as usize - 1) << page_shift) as u32;
+            self.memory_ctx.apply_page_accesses_with_offset(
+                mem_offset,
+                &self.mem_page_buf[..mem_len as usize],
+            );
+        }
 
-        let pv_offset = ((PUBLIC_VALUES_AS as usize - 1) << page_shift) as u32;
-        self.memory_ctx.record_and_apply_page_accesses_with_offset(
-            pv_offset,
-            &self.pv_page_buf[..pv_len as usize],
-        );
+        if pv_len != 0 {
+            let pv_offset = ((PUBLIC_VALUES_AS as usize - 1) << page_shift) as u32;
+            self.memory_ctx
+                .apply_page_accesses_with_offset(pv_offset, &self.pv_page_buf[..pv_len as usize]);
+        }
 
-        let deferral_offset = ((DEFERRAL_AS as usize - 1) << page_shift) as u32;
-        self.memory_ctx.record_and_apply_page_accesses_with_offset(
-            deferral_offset,
-            &self.deferral_page_buf[..deferral_len as usize],
-        );
+        if deferral_len != 0 {
+            let deferral_offset = ((DEFERRAL_AS as usize - 1) << page_shift) as u32;
+            self.memory_ctx.apply_page_accesses_with_offset(
+                deferral_offset,
+                &self.deferral_page_buf[..deferral_len as usize],
+            );
+        }
     }
 
     /// Apply boundary and merkle height updates from accumulated page accesses.
@@ -217,12 +221,18 @@ impl SegmentationState {
             .lazy_update_boundary_heights(&mut self.trace_heights);
     }
 
-    fn initialize_segment_memory(&mut self) {
+    fn initialize_segment_memory(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
         // RVR can only suspend at block boundaries, so segmentation uses the
         // last safe checkpoint. The pages accumulated since that checkpoint
         // belong to the next segment and must seed its memory trace heights
         // after the previous segment's heights are subtracted.
-        self.memory_ctx.initialize_segment(&mut self.trace_heights);
+        self.memory_ctx
+            .reset_segment_without_replay(&mut self.trace_heights);
+        self.apply_page_buffer(mem_len, pv_len, deferral_len);
+        self.apply_height_updates();
+
+        self.memory_ctx.add_register_merkle_heights();
+        self.apply_height_updates();
     }
 
     /// Called on each periodic check (approximately every `segment_check_insns` instructions).
@@ -241,7 +251,7 @@ impl SegmentationState {
         self.segmentation_ctx.instret = instret;
         self.segmentation_ctx.instrets_until_check = seg_check_insns;
 
-        self.flush_page_buffer(mem_len, pv_len, deferral_len);
+        self.apply_page_buffer(mem_len, pv_len, deferral_len);
         self.apply_height_updates();
 
         let did_segment = self.segmentation_ctx.check_and_segment(
@@ -255,7 +265,7 @@ impl SegmentationState {
                 &mut self.trace_heights,
                 &self.config.is_trace_height_constant,
             );
-            self.initialize_segment_memory();
+            self.initialize_segment_memory(mem_len, pv_len, deferral_len);
 
             self.segmentation_ctx.warn_if_exceeds_limits(
                 instret,
@@ -281,7 +291,7 @@ impl SegmentationState {
         deferral_len: u32,
         remaining_counter: u32,
     ) {
-        self.flush_page_buffer(mem_len, pv_len, deferral_len);
+        self.apply_page_buffer(mem_len, pv_len, deferral_len);
         self.apply_height_updates();
 
         self.segmentation_ctx.instrets_until_check = remaining_counter as u64;
@@ -479,7 +489,7 @@ mod tests {
     }
 
     #[test]
-    fn test_initialize_segment_memory_replays_checkpoint_pages() {
+    fn test_initialize_segment_memory_replays_page_buffers() {
         let mut with_interval_buffer = make_segmentation_state();
         with_interval_buffer.mem_page_buf[0] = PageAccess {
             page_id: 7,
@@ -493,11 +503,10 @@ mod tests {
             page_id: 2,
             leaf_mask: 1,
         };
-        with_interval_buffer.flush_page_buffer(1, 1, 1);
-        with_interval_buffer.initialize_segment_memory();
+        with_interval_buffer.initialize_segment_memory(1, 1, 1);
 
         let mut clean = make_segmentation_state();
-        clean.initialize_segment_memory();
+        clean.initialize_segment_memory(0, 0, 0);
 
         assert!(
             with_interval_buffer.trace_heights[BOUNDARY_AIR_ID]

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -124,7 +124,7 @@ pub struct SegmentationState {
     config: MeteredCtxConfig,
     pub segmentation_ctx: SegmentationCtx,
     trace_heights: Vec<u32>,
-    memory_ctx: MemoryCtx<DEFAULT_PAGE_BITS>,
+    memory_ctx: MemoryCtx,
     /// Per-address-space page buffers. Each entry = local page id + leaf mask.
     mem_page_buf: Vec<PageAccess>,
     pv_page_buf: Vec<PageAccess>,
@@ -439,7 +439,7 @@ mod tests {
     use crate::{
         arch::{
             execution_mode::metered::{
-                ctx::{MeteredCtxInputs, DEFAULT_PAGE_BITS},
+                ctx::MeteredCtxInputs,
                 segment_ctx::{SegmentationLimits, DEFAULT_MAX_MEMORY},
             },
             BOUNDARY_AIR_ID, MERKLE_AIR_ID,
@@ -460,7 +460,7 @@ mod tests {
         let interactions = vec![0; num_airs];
         let need_rot = vec![false; num_airs];
 
-        let ctx = MeteredCtx::<DEFAULT_PAGE_BITS>::new(
+        let ctx = MeteredCtx::new(
             MeteredCtxInputs {
                 constant_trace_heights: &constant_trace_heights,
                 air_names: &air_names,

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -188,31 +188,47 @@ impl SegmentationState {
         self.deferral_page_buf.as_mut_ptr()
     }
 
+    #[inline(always)]
+    fn apply_addr_space_buffer(
+        memory_ctx: &mut MemoryCtx,
+        address_height: u32,
+        addr_space: u32,
+        buffer: &[PageAccess],
+        len: u32,
+    ) {
+        if len == 0 {
+            return;
+        }
+        let page_shift = address_height as usize - DEFAULT_PAGE_BITS;
+        let page_offset = ((addr_space as usize - 1) << page_shift) as u32;
+        memory_ctx.apply_page_accesses_with_offset(page_offset, &buffer[..len as usize]);
+    }
+
     /// Apply all page buffers: convert local pages to global ids and update
     /// memory metering state.
-    fn apply_page_buffer(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
-        let page_shift = self.address_height as usize - DEFAULT_PAGE_BITS;
-        if mem_len != 0 {
-            let mem_offset = ((RV64_MEMORY_AS as usize - 1) << page_shift) as u32;
-            self.memory_ctx.apply_page_accesses_with_offset(
-                mem_offset,
-                &self.mem_page_buf[..mem_len as usize],
-            );
-        }
-
-        if pv_len != 0 {
-            let pv_offset = ((PUBLIC_VALUES_AS as usize - 1) << page_shift) as u32;
-            self.memory_ctx
-                .apply_page_accesses_with_offset(pv_offset, &self.pv_page_buf[..pv_len as usize]);
-        }
-
-        if deferral_len != 0 {
-            let deferral_offset = ((DEFERRAL_AS as usize - 1) << page_shift) as u32;
-            self.memory_ctx.apply_page_accesses_with_offset(
-                deferral_offset,
-                &self.deferral_page_buf[..deferral_len as usize],
-            );
-        }
+    #[inline(always)]
+    fn apply_page_buffers(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
+        Self::apply_addr_space_buffer(
+            &mut self.memory_ctx,
+            self.address_height,
+            RV64_MEMORY_AS,
+            &self.mem_page_buf,
+            mem_len,
+        );
+        Self::apply_addr_space_buffer(
+            &mut self.memory_ctx,
+            self.address_height,
+            PUBLIC_VALUES_AS,
+            &self.pv_page_buf,
+            pv_len,
+        );
+        Self::apply_addr_space_buffer(
+            &mut self.memory_ctx,
+            self.address_height,
+            DEFERRAL_AS,
+            &self.deferral_page_buf,
+            deferral_len,
+        );
     }
 
     /// Apply boundary and merkle height updates from accumulated page accesses.
@@ -228,7 +244,7 @@ impl SegmentationState {
         // after the previous segment's heights are subtracted.
         self.memory_ctx
             .reset_segment_without_replay(&mut self.trace_heights);
-        self.apply_page_buffer(mem_len, pv_len, deferral_len);
+        self.apply_page_buffers(mem_len, pv_len, deferral_len);
         self.apply_height_updates();
 
         self.memory_ctx.add_register_merkle_heights();
@@ -251,7 +267,7 @@ impl SegmentationState {
         self.segmentation_ctx.instret = instret;
         self.segmentation_ctx.instrets_until_check = seg_check_insns;
 
-        self.apply_page_buffer(mem_len, pv_len, deferral_len);
+        self.apply_page_buffers(mem_len, pv_len, deferral_len);
         self.apply_height_updates();
 
         let did_segment = self.segmentation_ctx.check_and_segment(
@@ -291,7 +307,7 @@ impl SegmentationState {
         deferral_len: u32,
         remaining_counter: u32,
     ) {
-        self.apply_page_buffer(mem_len, pv_len, deferral_len);
+        self.apply_page_buffers(mem_len, pv_len, deferral_len);
         self.apply_height_updates();
 
         self.segmentation_ctx.instrets_until_check = remaining_counter as u64;

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -192,24 +192,23 @@ impl SegmentationState {
     /// their leaf masks to the shared memory metering checkpoint buffer.
     fn flush_page_buffer(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
         let page_shift = self.address_height as usize - DEFAULT_PAGE_BITS;
-        for &(buf_len, addr_space) in &[
-            (mem_len, RV64_MEMORY_AS),
-            (pv_len, PUBLIC_VALUES_AS),
-            (deferral_len, DEFERRAL_AS),
-        ] {
-            let as_idx = addr_space as usize;
-            let as_offset = (as_idx - 1) << page_shift;
-            let buf = match addr_space {
-                RV64_MEMORY_AS => &self.mem_page_buf,
-                PUBLIC_VALUES_AS => &self.pv_page_buf,
-                _ => &self.deferral_page_buf,
-            };
-            for access in &buf[..buf_len as usize] {
-                let page_id = as_offset + access.page_id as usize;
-                self.memory_ctx
-                    .record_page_access(page_id as u32, access.leaf_mask);
-            }
-        }
+        let mem_offset = ((RV64_MEMORY_AS as usize - 1) << page_shift) as u32;
+        self.memory_ctx.record_and_apply_page_accesses_with_offset(
+            mem_offset,
+            &self.mem_page_buf[..mem_len as usize],
+        );
+
+        let pv_offset = ((PUBLIC_VALUES_AS as usize - 1) << page_shift) as u32;
+        self.memory_ctx.record_and_apply_page_accesses_with_offset(
+            pv_offset,
+            &self.pv_page_buf[..pv_len as usize],
+        );
+
+        let deferral_offset = ((DEFERRAL_AS as usize - 1) << page_shift) as u32;
+        self.memory_ctx.record_and_apply_page_accesses_with_offset(
+            deferral_offset,
+            &self.deferral_page_buf[..deferral_len as usize],
+        );
     }
 
     /// Apply boundary and merkle height updates from accumulated page accesses.

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -199,6 +199,9 @@ impl SegmentationState {
         if len == 0 {
             return;
         }
+        // C buffers use page ids local to one address space. `MemoryCtx`
+        // deduplicates against one global memory tree, so convert to global
+        // page ids before applying the leaf masks.
         let page_shift = address_height as usize - PAGE_BITS;
         let page_offset = ((addr_space as usize - 1) << page_shift) as u32;
         memory_ctx.apply_page_accesses_with_offset(page_offset, &buffer[..len as usize]);

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -25,8 +25,8 @@ use crate::{
     arch::{
         execution_mode::{
             metered::{
-                ctx::{MeteredCtxConfig, MeteredCtxParts, DEFAULT_PAGE_BITS},
-                memory_ctx::{MemoryCtx, PageAccess},
+                ctx::{MeteredCtxConfig, MeteredCtxParts},
+                memory_ctx::{MemoryCtx, PageAccess, PAGE_BITS},
                 segment_ctx::{Segment, SegmentationCtx},
             },
             MeteredCtx,
@@ -199,7 +199,7 @@ impl SegmentationState {
         if len == 0 {
             return;
         }
-        let page_shift = address_height as usize - DEFAULT_PAGE_BITS;
+        let page_shift = address_height as usize - PAGE_BITS;
         let page_offset = ((addr_space as usize - 1) << page_shift) as u32;
         memory_ctx.apply_page_accesses_with_offset(page_offset, &buffer[..len as usize]);
     }
@@ -231,12 +231,6 @@ impl SegmentationState {
         );
     }
 
-    /// Apply boundary and merkle height updates from accumulated page accesses.
-    fn apply_height_updates(&mut self) {
-        self.memory_ctx
-            .lazy_update_boundary_heights(&mut self.trace_heights);
-    }
-
     fn initialize_segment_memory(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
         // RVR can only suspend at block boundaries, so segmentation uses the
         // last safe checkpoint. The pages accumulated since that checkpoint
@@ -245,10 +239,12 @@ impl SegmentationState {
         self.memory_ctx
             .reset_segment_without_replay(&mut self.trace_heights);
         self.apply_page_buffers(mem_len, pv_len, deferral_len);
-        self.apply_height_updates();
+        self.memory_ctx
+            .apply_height_updates(&mut self.trace_heights);
 
         self.memory_ctx.add_register_merkle_heights();
-        self.apply_height_updates();
+        self.memory_ctx
+            .apply_height_updates(&mut self.trace_heights);
     }
 
     /// Called on each periodic check (approximately every `segment_check_insns` instructions).
@@ -268,7 +264,8 @@ impl SegmentationState {
         self.segmentation_ctx.instrets_until_check = seg_check_insns;
 
         self.apply_page_buffers(mem_len, pv_len, deferral_len);
-        self.apply_height_updates();
+        self.memory_ctx
+            .apply_height_updates(&mut self.trace_heights);
 
         let did_segment = self.segmentation_ctx.check_and_segment(
             instret,
@@ -308,7 +305,8 @@ impl SegmentationState {
         remaining_counter: u32,
     ) {
         self.apply_page_buffers(mem_len, pv_len, deferral_len);
-        self.apply_height_updates();
+        self.memory_ctx
+            .apply_height_updates(&mut self.trace_heights);
 
         self.segmentation_ctx.instrets_until_check = remaining_counter as u64;
         self.segmentation_ctx

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -8,11 +8,7 @@ use std::{
     sync::Arc,
 };
 
-use openvm_instructions::{
-    exe::VmExe,
-    riscv::{RV64_MEMORY_AS, RV64_NUM_REGISTERS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
-    DEFERRAL_AS,
-};
+use openvm_instructions::{exe::VmExe, riscv::RV64_MEMORY_AS, DEFERRAL_AS};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::ExtensionRegistry;
@@ -30,17 +26,14 @@ use crate::{
         execution_mode::{
             metered::{
                 ctx::{MeteredCtxConfig, MeteredCtxParts, DEFAULT_PAGE_BITS},
-                memory_ctx::MemoryCtx,
+                memory_ctx::{MemoryCtx, PageAccess},
                 segment_ctx::{Segment, SegmentationCtx},
             },
             MeteredCtx,
         },
-        ExecutionError, Streams, SystemConfig, VmState, BOUNDARY_AIR_ID, MERKLE_AIR_ID,
-        U16_CELL_SIZE_BITS,
+        ExecutionError, Streams, SystemConfig, VmState,
     },
-    system::memory::{
-        merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory, DIGEST_WIDTH_BITS,
-    },
+    system::memory::{merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory},
 };
 
 pub struct RunToCompletion;
@@ -80,9 +73,9 @@ pub struct RvrMeteredResult {
 #[derive(Clone, Copy)]
 pub struct MeteredTracerData {
     pub trace_heights: *mut u32,
-    pub mem_page_buf: *mut u32,
-    pub pv_page_buf: *mut u32,
-    pub deferral_page_buf: *mut u32,
+    pub mem_page_buf: *mut PageAccess,
+    pub pv_page_buf: *mut PageAccess,
+    pub deferral_page_buf: *mut PageAccess,
     /// Periodic-check callback. Always initialized; generated C calls it
     /// unconditionally to keep the hot metered path branch-free.
     pub on_check: unsafe extern "C" fn(*mut MeteredTracerData) -> u8,
@@ -132,13 +125,11 @@ pub struct SegmentationState {
     pub segmentation_ctx: SegmentationCtx,
     trace_heights: Vec<u32>,
     memory_ctx: MemoryCtx<DEFAULT_PAGE_BITS>,
-    /// Per-address-space page buffers. Each entry = 1 u32 page id.
-    mem_page_buf: Vec<u32>,
-    pv_page_buf: Vec<u32>,
-    deferral_page_buf: Vec<u32>,
+    /// Per-address-space page buffers. Each entry = local page id + leaf mask.
+    mem_page_buf: Vec<PageAccess>,
+    pv_page_buf: Vec<PageAccess>,
+    deferral_page_buf: Vec<PageAccess>,
     address_height: u32,
-    addr_space_height: u32,
-    byte_space_leaf_bits: u32,
 }
 
 impl SegmentationState {
@@ -152,20 +143,15 @@ impl SegmentationState {
         let mem_config = &system_config.memory_config;
         let memory_dimensions = mem_config.memory_dimensions();
         let address_height = memory_dimensions.address_height as u32;
-        let addr_space_height = mem_config.addr_space_height as u32;
-        let byte_space_leaf_bits = (U16_CELL_SIZE_BITS + DIGEST_WIDTH_BITS) as u32;
-
         Self {
             config,
             segmentation_ctx,
             trace_heights,
             memory_ctx,
-            mem_page_buf: vec![0u32; MEM_PAGE_BUF_CAP],
-            pv_page_buf: vec![0u32; PV_PAGE_BUF_CAP],
-            deferral_page_buf: vec![0u32; DEFERRAL_PAGE_BUF_CAP],
+            mem_page_buf: vec![PageAccess::default(); MEM_PAGE_BUF_CAP],
+            pv_page_buf: vec![PageAccess::default(); PV_PAGE_BUF_CAP],
+            deferral_page_buf: vec![PageAccess::default(); DEFERRAL_PAGE_BUF_CAP],
             address_height,
-            addr_space_height,
-            byte_space_leaf_bits,
         }
     }
 
@@ -188,49 +174,23 @@ impl SegmentationState {
     }
 
     /// Get mutable pointer to the AS_MEMORY page buffer for the C tracer.
-    pub fn mem_page_buf_ptr(&mut self) -> *mut u32 {
+    pub fn mem_page_buf_ptr(&mut self) -> *mut PageAccess {
         self.mem_page_buf.as_mut_ptr()
     }
 
     /// Get mutable pointer to the AS_PUBLIC_VALUES page buffer for the C tracer.
-    pub fn pv_page_buf_ptr(&mut self) -> *mut u32 {
+    pub fn pv_page_buf_ptr(&mut self) -> *mut PageAccess {
         self.pv_page_buf.as_mut_ptr()
     }
 
     /// Get mutable pointer to the AS_DEFERRAL page buffer for the C tracer.
-    pub fn deferral_page_buf_ptr(&mut self) -> *mut u32 {
+    pub fn deferral_page_buf_ptr(&mut self) -> *mut PageAccess {
         self.deferral_page_buf.as_mut_ptr()
     }
 
-    /// Add initial register merkle height contributions (matches OpenVM's
-    /// `add_register_merkle_heights` + `update_boundary_merkle_heights`).
-    ///
-    /// OpenVM records pages for the entire register space
-    /// (AS=1, ptr=0, size=32*8=256) at init and after each segment boundary.
-    fn add_register_merkle_heights(&mut self) {
-        const REG_SIZE: u32 = (RV64_NUM_REGISTERS * RV64_REGISTER_NUM_LIMBS) as u32;
-
-        let leaf_ptrs = 1u32 << self.byte_space_leaf_bits;
-        let num_blocks = (REG_SIZE + leaf_ptrs - 1) >> self.byte_space_leaf_bits;
-        let start_leaf_id = 0u32; // ptr=0
-                                  // label_to_index: ((addr_space - 1) << address_height) + leaf_id
-        let start_block_id =
-            ((RV64_REGISTER_AS as u64 - 1) << self.address_height) + start_leaf_id as u64;
-        let end_block_id = start_block_id + num_blocks as u64;
-        let start_page_id = start_block_id >> DEFAULT_PAGE_BITS;
-        let end_page_id = ((end_block_id - 1) >> DEFAULT_PAGE_BITS) + 1;
-
-        for page_id in start_page_id..end_page_id {
-            if self.memory_ctx.page_indices.insert(page_id as usize) {
-                self.memory_ctx.addr_space_access_count[RV64_REGISTER_AS as usize] += 1;
-            }
-        }
-    }
-
-    /// Flush all page buffers: convert local pages to global ids, deduplicate
-    /// via the BitSet, and update `addr_space_access_count` for each new page.
+    /// Flush all page buffers: convert local pages to global ids and append
+    /// their leaf masks to the shared memory metering checkpoint buffer.
     fn flush_page_buffer(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
-        let num_as = self.memory_ctx.addr_space_access_count.len();
         let page_shift = self.address_height as usize - DEFAULT_PAGE_BITS;
         for &(buf_len, addr_space) in &[
             (mem_len, RV64_MEMORY_AS),
@@ -238,67 +198,32 @@ impl SegmentationState {
             (deferral_len, DEFERRAL_AS),
         ] {
             let as_idx = addr_space as usize;
-            if as_idx >= num_as {
-                continue;
-            }
             let as_offset = (as_idx - 1) << page_shift;
             let buf = match addr_space {
                 RV64_MEMORY_AS => &self.mem_page_buf,
                 PUBLIC_VALUES_AS => &self.pv_page_buf,
                 _ => &self.deferral_page_buf,
             };
-            for &local_page in &buf[..buf_len as usize] {
-                if self
-                    .memory_ctx
-                    .page_indices
-                    .insert(as_offset + local_page as usize)
-                {
-                    self.memory_ctx.addr_space_access_count[as_idx] += 1;
-                }
+            for access in &buf[..buf_len as usize] {
+                let page_id = as_offset + access.page_id as usize;
+                self.memory_ctx
+                    .record_page_access(page_id as u32, access.leaf_mask);
             }
         }
     }
 
     /// Apply boundary and merkle height updates from accumulated page accesses.
     fn apply_height_updates(&mut self) {
-        let page_access_count: u32 = self.memory_ctx.addr_space_access_count.iter().sum();
-        let leaves = page_access_count << DEFAULT_PAGE_BITS;
-
-        let trace_heights = &mut self.trace_heights;
-        let poseidon2_idx = trace_heights.len() - 2;
-
-        let merkle_height = self.addr_space_height as usize + self.address_height as usize;
-        let nodes_per_page =
-            (((1usize << DEFAULT_PAGE_BITS) - 1) + (merkle_height - DEFAULT_PAGE_BITS)) as u32;
-
-        // Boundary chip: 2 rows per leaf (init + final)
-        trace_heights[BOUNDARY_AIR_ID] += leaves * 2;
-        // Merkle tree + Poseidon2
-        trace_heights[MERKLE_AIR_ID] += nodes_per_page * page_access_count * 2;
-        trace_heights[poseidon2_idx] += leaves * 2 + nodes_per_page * page_access_count * 2;
-
-        self.memory_ctx.addr_space_access_count.fill(0);
+        self.memory_ctx
+            .lazy_update_boundary_heights(&mut self.trace_heights);
     }
 
-    fn initialize_segment_memory(&mut self, mem_len: u32, pv_len: u32, deferral_len: u32) {
-        let poseidon2_idx = self.trace_heights.len() - 2;
-        self.trace_heights[BOUNDARY_AIR_ID] = 0;
-        self.trace_heights[MERKLE_AIR_ID] = 0;
-        self.trace_heights[poseidon2_idx] = 0;
-
-        self.memory_ctx.page_indices.clear();
-        self.memory_ctx.addr_space_access_count.fill(0);
-        self.memory_ctx.page_indices_since_checkpoint_len = 0;
-
+    fn initialize_segment_memory(&mut self) {
         // RVR can only suspend at block boundaries, so segmentation uses the
         // last safe checkpoint. The pages accumulated since that checkpoint
         // belong to the next segment and must seed its memory trace heights
         // after the previous segment's heights are subtracted.
-        self.flush_page_buffer(mem_len, pv_len, deferral_len);
-        self.apply_height_updates();
-
-        self.add_register_merkle_heights();
-        self.apply_height_updates();
+        self.memory_ctx.initialize_segment(&mut self.trace_heights);
     }
 
     /// Called on each periodic check (approximately every `segment_check_insns` instructions).
@@ -331,7 +256,7 @@ impl SegmentationState {
                 &mut self.trace_heights,
                 &self.config.is_trace_height_constant,
             );
-            self.initialize_segment_memory(mem_len, pv_len, deferral_len);
+            self.initialize_segment_memory();
 
             self.segmentation_ctx.warn_if_exceeds_limits(
                 instret,
@@ -342,6 +267,7 @@ impl SegmentationState {
 
         self.segmentation_ctx
             .update_checkpoint(instret, &self.trace_heights);
+        self.memory_ctx.update_checkpoint();
 
         did_segment
     }
@@ -556,13 +482,23 @@ mod tests {
     #[test]
     fn test_initialize_segment_memory_replays_checkpoint_pages() {
         let mut with_interval_buffer = make_segmentation_state();
-        with_interval_buffer.mem_page_buf[0] = 7;
-        with_interval_buffer.pv_page_buf[0] = 3;
-        with_interval_buffer.deferral_page_buf[0] = 2;
-        with_interval_buffer.initialize_segment_memory(1, 1, 1);
+        with_interval_buffer.mem_page_buf[0] = PageAccess {
+            page_id: 7,
+            leaf_mask: 1,
+        };
+        with_interval_buffer.pv_page_buf[0] = PageAccess {
+            page_id: 3,
+            leaf_mask: 1,
+        };
+        with_interval_buffer.deferral_page_buf[0] = PageAccess {
+            page_id: 2,
+            leaf_mask: 1,
+        };
+        with_interval_buffer.flush_page_buffer(1, 1, 1);
+        with_interval_buffer.initialize_segment_memory();
 
         let mut clean = make_segmentation_state();
-        clean.initialize_segment_memory(0, 0, 0);
+        clean.initialize_segment_memory();
 
         assert!(
             with_interval_buffer.trace_heights[BOUNDARY_AIR_ID]


### PR DESCRIPTION
## Summary

Resolves INT-8554.

This PR tightens metered memory-height accounting for the memory boundary, memory Merkle, and Poseidon2 AIRs.

Metering records which leaves inside each 64-leaf memory page were touched, then counts the Merkle work from those masks at checkpoint and segment boundaries. RVR and interpreted metering use the same Rust accounting path.

## Before

The estimate was page-oriented. If a few leaves inside a page were touched, the estimate charged page-level work from page-level state.

```text
one memory page = 64 Merkle leaves

leaf index:  0  1  2  3  4  5  ... 63
accesses:    .  x  .  x  .  .  ... .

page-oriented estimate:

   [page subtree]
      /     \
    ...     ...        page was touched,
   /  \     /  \       estimate used page-level state
  L0  L1   L2  L3
      x        x
```

Shared upper-tree ancestors across nearby pages were also charged along each page path.

```text
page A -> P -> G -> root
page B -> P -> G -> root
          ^    ^    ^
          shared ancestors
```

That made the estimate safe, but it could overshoot the rows needed by `MemoryMerkleAir` and the related Poseidon2 hashes.

## Now

Each memory page is exactly 64 Merkle leaves. The page-local leaf occupancy is stored in one `u64` mask.

```text
full memory tree

        [root]
        /    \
      ...    ...              ancestors above pages are shared
      /        \
   [page]    [page]
   / ... \   / ... \
 L0 ... L63 L0 ... L63        each page stores one u64 leaf mask
```

For each access, metering records a page-table index and a per-page leaf mask:

```text
field      type   meaning
page_id    u32    index into page_masks
leaf_mask  u64    one occupancy bit per leaf in that 64-leaf page
```

`page_masks[page_id]` stores the accumulated `leaf_mask` for that page.

```text
page_masks: Box<[u64]>

page_id ----------+
                  v
page_masks[page_id] = accumulated u64 occupancy mask for that page
```

Across pages, upper-tree ancestors are tracked with a separate bitset of ancestor node ids.

```text
new estimate for two nearby pages

        root              counted once in upper_nodes bitset
         |
         G                counted once in upper_nodes bitset
         |
         P                counted once in upper_nodes bitset
        / \
   page A page B          page-local work counted from each u64 mask
```

## Counting

For leaves, the update is bit operations on one `u64`:

```text
old page mask:       00001000
incoming access:     00101000
new page mask:       00101000  = old | incoming
newly touched bits:  00100000  = incoming & !old
new leaves:          popcnt(newly touched bits)
```

For internal nodes inside a 64-leaf page, the code uses two page-local paths.

Single-leaf path:

```text
leaf = trailing_zeros(added_mask)
```

For that leaf, the code checks the aligned groups that map to the page-local ancestor levels:

```text
2-leaf group   -> level 1 ancestor
4-leaf group   -> level 2 ancestor
8-leaf group   -> level 3 ancestor
16-leaf group  -> level 4 ancestor
32-leaf group  -> level 5 ancestor
64-leaf page   -> page root
```

For a group size `G`, the group containing `leaf` is checked with:

```text
group_start = leaf & !(G - 1)
group_mask  = ((1 << G) - 1) << group_start
is_new_node = (old_mask & group_mask) == 0
```

The first touched leaf in an aligned group creates that group's ancestor node. Later leaves in the same group reuse the counted ancestor. The first touched leaf in the page creates the page root.

Multi-leaf path:

```text
old_mask    = previous page occupancy
added_mask  = newly touched leaves

for each of the 6 page-local levels:
    old_mask   = OR-reduce old_mask into parent groups
    added_mask = OR-reduce added_mask into parent groups
    new_nodes += popcnt(added_mask & !old_mask)
```

The OR-reduction step is a fixed shift/mask operation:

```text
children:    0 1   1 0   0 0   1 1
next level:    1     1     0     1

mask = (mask | (mask >> shift)) & representative_bit_mask
```

This counts parent groups that have at least one newly added leaf and had no old leaf under that group. A 64-leaf page has six levels up to the page root, so the multi-leaf path is a fixed six-level sequence with `count_ones()` at each level.

The resulting height updates are:

```text
Boundary rows = 2 * new_leaves
Merkle rows   = 2 * new_merkle_nodes
Poseidon2     = 2 * new_leaves + 2 * new_merkle_nodes
```

The Poseidon2 count remains a safe upper bound because trace generation can deduplicate equal hash inputs by value.

## RVR

The RVR tracer records the same page/leaf-mask information in generated C and applies it through the same `MemoryCtx` logic.

```text
generated C tracer
        |
        v
page/leaf-mask buffers
        |
        v
Rust MemoryCtx accounting
        |
        v
same height updates as interpreted metering
```

The normal memory fast path coalesces consecutive accesses to the same page before flushing to Rust. That keeps the common path cheap while keeping RVR and interpreted metering on the same estimate.

## Performance

This PR also removes avoidable overhead from metered execution:

- the interpreter countdown fast path uses a lightweight decrement before the full segmentation check
- repeated same-page memory accesses are coalesced before checkpoint replay
- single-leaf updates use a small aligned-group check
- multi-leaf updates use a fixed six-level `added_mask` OR-reduction
- call sites use the real height-update operation directly

## Testing

- `cargo +nightly fmt --all -- --check`
- `RUSTC_WRAPPER= cargo test -p openvm-circuit arch::execution_mode::metered --lib`
- `RUSTC_WRAPPER= cargo test -p openvm-circuit --features rvr rvr_metered_ctx_parts_roundtrip_preserves_execution_state --lib`
- `RUSTC_WRAPPER= cargo check --profile fast -p openvm-circuit --features rvr`
- `RUSTC_WRAPPER= cargo check --profile fast -p rvr-openvm`
- `git diff --check`
- [reth benchmark comparison](https://github.com/axiom-crypto/openvm-eth/actions/runs/28176871048)
