### PR TITLE
feat(v2.1): configurable metered RS code matrix caching

### DIFF
--- a/crates/sdk/src/compiled.rs
+++ b/crates/sdk/src/compiled.rs
@@ -10,7 +10,10 @@ use openvm_circuit::arch::execution_mode::{MeteredCostCtx, MeteredCtx};
 #[cfg(not(feature = "rvr"))]
 use openvm_circuit::arch::{execution_mode::ExecutionCtx, InterpretedInstance};
 #[cfg(feature = "rvr")]
-use openvm_circuit::arch::{execution_mode::MeteredCtxConfig, rvr::CompileError};
+use openvm_circuit::arch::{
+    execution_mode::{MeteredCtxConfig, SegmentationConfig},
+    rvr::CompileError,
+};
 #[cfg(feature = "rvr")]
 use serde::{Deserialize, Serialize};
 
@@ -55,6 +58,7 @@ pub struct CompiledExeMeteredCost<'a> {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MeteredArtifactMetadata {
     pub metered_ctx_config: MeteredCtxConfig,
+    pub segmentation_config: SegmentationConfig,
     pub executor_idx_to_air_idx: Vec<usize>,
 }
 
@@ -78,6 +82,7 @@ impl CompiledExeMetered<'_> {
         let lib_path = self.instance.save(dir)?;
         let metadata = MeteredArtifactMetadata {
             metered_ctx_config: self.ctx.config.clone(),
+            segmentation_config: self.ctx.segmentation_ctx.config().clone(),
             executor_idx_to_air_idx: self.executor_idx_to_air_idx.clone(),
         };
         let metadata_path = metered_artifact_metadata_path(&lib_path);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -506,8 +506,11 @@ where
     ) -> Result<CompiledExeMetered<'_>, SdkError> {
         let metadata = load_metered_artifact_metadata(lib_path).map_err(SdkError::Other)?;
         let exe = self.convert_to_exe(app_exe)?;
-        let ctx =
-            MeteredCtx::from_config(metadata.metered_ctx_config, self.executor.config.as_ref());
+        let ctx = MeteredCtx::from_config(
+            metadata.metered_ctx_config,
+            metadata.segmentation_config,
+            self.executor.config.as_ref(),
+        );
         let instance = self
             .executor
             .load_metered_instance(lib_path, &exe, &metadata.executor_idx_to_air_idx)

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -119,6 +119,24 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         self
     }
 
+    pub fn set_cache_rs_code_matrix(&mut self, cache_rs_code_matrix: bool) {
+        self.segmentation_ctx
+            .set_cache_rs_code_matrix(cache_rs_code_matrix);
+        self.config
+            .segmentation
+            .set_cache_rs_code_matrix(cache_rs_code_matrix);
+    }
+
+    pub fn with_cache_rs_code_matrix(mut self, cache_rs_code_matrix: bool) -> Self {
+        self.set_cache_rs_code_matrix(cache_rs_code_matrix);
+        self
+    }
+
+    #[inline(always)]
+    pub fn cache_rs_code_matrix(&self) -> bool {
+        self.segmentation_ctx.cache_rs_code_matrix()
+    }
+
     pub fn from_config(config: MeteredCtxConfig, system_config: &SystemConfig) -> Self {
         let segmentation_ctx = SegmentationCtx::from_config(config.segmentation.clone());
         let mut memory_ctx = MemoryCtx::new(system_config, segmentation_ctx.segment_check_insns());
@@ -327,7 +345,7 @@ mod tests {
             vec![0; num_airs],
             vec![false; num_airs],
             SegmentationLimits {
-                max_trace_height_bits: 4,
+                max_trace_height_bits: 12,
                 max_memory: usize::MAX,
                 max_interactions: u32::MAX,
             },
@@ -340,7 +358,7 @@ mod tests {
         memory_ctx.addr_space_access_count[1] = 7;
         memory_ctx.page_indices_since_checkpoint_len = 3;
 
-        let ctx = MeteredCtx::<DEFAULT_PAGE_BITS> {
+        let mut ctx = MeteredCtx::<DEFAULT_PAGE_BITS> {
             config: MeteredCtxConfig {
                 initial_trace_heights: vec![1, 2, 3, 4, 5, 6],
                 is_trace_height_constant: vec![false, true, false, true, false, true],
@@ -351,9 +369,14 @@ mod tests {
             memory_ctx,
             segmentation_ctx,
         };
+        ctx.set_cache_rs_code_matrix(false);
+
+        assert!(!ctx.cache_rs_code_matrix());
+        assert!(!ctx.config.segmentation.cache_rs_code_matrix());
 
         let restored = MeteredCtx::from_parts(ctx.into_parts());
 
+        assert!(!restored.cache_rs_code_matrix());
         assert_eq!(restored.trace_heights, vec![1, 2, 3, 4, 5, 6]);
         assert_eq!(
             restored.config.is_trace_height_constant,

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -21,7 +21,6 @@ pub const DEFAULT_PAGE_BITS: usize = 6;
 pub struct MeteredCtxConfig {
     pub initial_trace_heights: Vec<u32>,
     pub is_trace_height_constant: Vec<bool>,
-    pub segmentation: SegmentationConfig,
     // TODO: Remove this once segmented execution is selected by typed executor entry points across
     // all backends. RVR already treats the compiled suspender policy as the source of truth.
     pub suspend_on_segment: bool,
@@ -97,7 +96,6 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
             config: MeteredCtxConfig {
                 initial_trace_heights: trace_heights.clone(),
                 is_trace_height_constant,
-                segmentation: segmentation_ctx.config().clone(),
                 suspend_on_segment: false,
             },
             trace_heights,
@@ -115,15 +113,11 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
     pub fn with_max_memory(mut self, max_memory: usize) -> Self {
         self.segmentation_ctx.set_max_memory(max_memory);
-        self.config.segmentation.set_max_memory(max_memory);
         self
     }
 
     pub fn set_cache_rs_code_matrix(&mut self, cache_rs_code_matrix: bool) {
         self.segmentation_ctx
-            .set_cache_rs_code_matrix(cache_rs_code_matrix);
-        self.config
-            .segmentation
             .set_cache_rs_code_matrix(cache_rs_code_matrix);
     }
 
@@ -137,8 +131,12 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         self.segmentation_ctx.cache_rs_code_matrix()
     }
 
-    pub fn from_config(config: MeteredCtxConfig, system_config: &SystemConfig) -> Self {
-        let segmentation_ctx = SegmentationCtx::from_config(config.segmentation.clone());
+    pub fn from_config(
+        config: MeteredCtxConfig,
+        segmentation_config: SegmentationConfig,
+        system_config: &SystemConfig,
+    ) -> Self {
+        let segmentation_ctx = SegmentationCtx::from_config(segmentation_config);
         let mut memory_ctx = MemoryCtx::new(system_config, segmentation_ctx.segment_check_insns());
         let mut trace_heights = config.initial_trace_heights.clone();
         memory_ctx.add_register_merkle_heights();
@@ -362,7 +360,6 @@ mod tests {
             config: MeteredCtxConfig {
                 initial_trace_heights: vec![1, 2, 3, 4, 5, 6],
                 is_trace_height_constant: vec![false, true, false, true, false, true],
-                segmentation: segmentation_ctx.config().clone(),
                 suspend_on_segment: true,
             },
             trace_heights: vec![1, 2, 3, 4, 5, 6],
@@ -372,8 +369,6 @@ mod tests {
         ctx.set_cache_rs_code_matrix(false);
 
         assert!(!ctx.cache_rs_code_matrix());
-        assert!(!ctx.config.segmentation.cache_rs_code_matrix());
-
         let restored = MeteredCtx::from_parts(ctx.into_parts());
 
         assert!(!restored.cache_rs_code_matrix());

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -107,6 +107,15 @@ impl SegmentationConfig {
         self.max_memory = max_memory;
     }
 
+    pub fn set_cache_rs_code_matrix(&mut self, cache_rs_code_matrix: bool) {
+        self.memory_config.cache_rs_code_matrix = cache_rs_code_matrix;
+    }
+
+    #[inline(always)]
+    pub fn cache_rs_code_matrix(&self) -> bool {
+        self.memory_config.cache_rs_code_matrix
+    }
+
     #[inline(always)]
     pub fn max_memory(&self) -> usize {
         self.max_memory
@@ -218,6 +227,15 @@ impl SegmentationCtx {
 
     pub fn set_max_memory(&mut self, max_memory: usize) {
         self.config.set_max_memory(max_memory);
+    }
+
+    pub fn set_cache_rs_code_matrix(&mut self, cache_rs_code_matrix: bool) {
+        self.config.set_cache_rs_code_matrix(cache_rs_code_matrix);
+    }
+
+    #[inline(always)]
+    pub fn cache_rs_code_matrix(&self) -> bool {
+        self.config.cache_rs_code_matrix()
     }
 
     pub fn config(&self) -> &SegmentationConfig {

--- a/crates/vm/src/arch/execution_mode/mod.rs
+++ b/crates/vm/src/arch/execution_mode/mod.rs
@@ -7,7 +7,7 @@ mod pure;
 
 pub use metered::{
     ctx::{MeteredCtx, MeteredCtxConfig, MeteredCtxInputs},
-    segment_ctx::{Segment, SegmentationLimits},
+    segment_ctx::{Segment, SegmentationConfig, SegmentationLimits},
 };
 pub use metered_cost::MeteredCostCtx;
 pub use preflight::PreflightCtx;


### PR DESCRIPTION
## Summary
- add a way for callers to turn `cache_rs_code_matrix` on or off for metered execution
- keep the segmentation settings in one place instead of storing a second copy in `MeteredCtxConfig`
- save and reload those segmentation settings with compiled metered artifacts so the chosen cache setting is preserved

## Testing
- `git diff --check`
- `RUSTC_WRAPPER= cargo test -p openvm-circuit rvr_metered_ctx_parts_roundtrip_preserves_execution_state --features rvr`
- `RUSTC_WRAPPER= cargo check -p openvm-sdk --features rvr`