### PR TITLE
refactor(rvr): move ext_hint_stream_set function from RV64I extension to core rvr

### DIFF
--- a/crates/rvr/rvr-openvm/c/openvm_io.c
+++ b/crates/rvr/rvr-openvm/c/openvm_io.c
@@ -11,3 +11,15 @@ static void* g_io_ctx;
 void register_openvm_io_ctx(void* ctx) { g_io_ctx = ctx; }
 
 void* openvm_get_io_ctx(void) { return g_io_ctx; }
+
+/* NOT thread-safe: installs one process-global hint-stream writer. */
+static void (*g_hint_stream_set_fn)(void* ctx, const uint8_t* data,
+                                    uint32_t len);
+
+void register_hint_stream_set_fn(void (*fn)(void*, const uint8_t*, uint32_t)) {
+  g_hint_stream_set_fn = fn;
+}
+
+void ext_hint_stream_set(const uint8_t* data, uint32_t len) {
+  g_hint_stream_set_fn(g_io_ctx, data, len);
+}

--- a/crates/rvr/rvr-openvm/c/openvm_io.h
+++ b/crates/rvr/rvr-openvm/c/openvm_io.h
@@ -1,6 +1,14 @@
 #ifndef OPENVM_IO_H
 #define OPENVM_IO_H
 
+#include <stdint.h>
+
 void* openvm_get_io_ctx(void);
+
+/* Called once at execute-start to install the field-typed hint-stream writer. */
+void register_hint_stream_set_fn(void (*fn)(void*, const uint8_t*, uint32_t));
+
+/* Replace the hint stream contents. Called by extension FFI staticlibs. */
+void ext_hint_stream_set(const uint8_t* data, uint32_t len);
 
 #endif /* OPENVM_IO_H */

--- a/crates/rvr/rvr-openvm/c/openvm_io.h
+++ b/crates/rvr/rvr-openvm/c/openvm_io.h
@@ -5,9 +5,6 @@
 
 void* openvm_get_io_ctx(void);
 
-/* Called once at execute-start to install the field-typed hint-stream writer. */
-void register_hint_stream_set_fn(void (*fn)(void*, const uint8_t*, uint32_t));
-
 /* Replace the hint stream contents. Called by extension FFI staticlibs. */
 void ext_hint_stream_set(const uint8_t* data, uint32_t len);
 

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -17,7 +17,7 @@ use super::{
         write_rv64_registers,
     },
     compile::RvrCompiled,
-    io::OpenVmIoState,
+    io::{host_hint_stream_set, OpenVmIoState},
     metered::{
         metered_periodic_check, MeteredTracerData, RvrMeteredResult, SegmentationState,
         NO_LAST_PAGE,
@@ -31,6 +31,8 @@ use super::{
 use crate::{arch::VmState, system::memory::online::GuestMemory};
 
 type RegisterIoCtxFn = unsafe extern "C" fn(*mut c_void);
+type RegisterHintStreamSetFn =
+    unsafe extern "C" fn(unsafe extern "C" fn(*mut c_void, *const u8, u32));
 type ExecuteFn = unsafe extern "C" fn(*mut c_void);
 
 /// Error during execution.
@@ -88,6 +90,16 @@ unsafe fn register_openvm_io_ctx<F: PrimeField32>(
         *sym
     };
     unsafe { register_fn(io_state as *mut OpenVmIoState<'_, F> as *mut c_void) };
+
+    let register_hint_fn: RegisterHintStreamSetFn = unsafe {
+        let sym = compiled
+            .lib
+            .get::<RegisterHintStreamSetFn>(b"register_hint_stream_set_fn")
+            .map_err(|e| ExecuteError::SymbolLookup(e.to_string()))?;
+        *sym
+    };
+    unsafe { register_hint_fn(host_hint_stream_set::<F>) };
+
     Ok(())
 }
 

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -75,9 +75,10 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
 
 /// # Safety
 ///
-/// `compiled` must contain a valid rvr-compiled shared library exporting the
-/// `register_openvm_io_ctx` symbol with the expected ABI. `io_state` must
-/// remain valid for the lifetime of the subsequent `rv_execute` call.
+/// `compiled` must contain a valid rvr-compiled shared library exporting both
+/// `register_openvm_io_ctx` and `register_hint_stream_set_fn` with the expected
+/// ABIs. `io_state` must remain valid for the lifetime of the subsequent
+/// `rv_execute` call.
 unsafe fn register_openvm_io_ctx<F: PrimeField32>(
     compiled: &RvrCompiled,
     io_state: &mut OpenVmIoState<'_, F>,

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -1,6 +1,6 @@
 //! OpenVM IO runtime: ctx (`OpenVmIoState`) borrowed from `VmState<F>`.
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, ffi::c_void};
 
 #[cfg(not(feature = "unprotected"))]
 use openvm_platform::memory::MEM_SIZE;
@@ -44,3 +44,23 @@ pub fn check_mem_bounds_range(start: u32, num_bytes: usize) {
 #[cfg(feature = "unprotected")]
 #[inline(always)]
 pub fn check_mem_bounds_range(_start: u32, _num_bytes: usize) {}
+
+/// Replace the hint stream contents. Called via `ext_hint_stream_set` from extension FFI.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `OpenVmIoState` pointer. `data` must point to `len` bytes (or be null).
+pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
+    ctx: *mut c_void,
+    data: *const u8,
+    len: u32,
+) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+    io.hint_stream.clear();
+    if len > 0 && !data.is_null() {
+        let slice = unsafe { std::slice::from_raw_parts(data, len as usize) };
+        for &b in slice {
+            io.hint_stream.push_back(F::from_u8(b));
+        }
+    }
+}

--- a/extensions/riscv/rvr/c/rv64i_phantom_callbacks.c
+++ b/extensions/riscv/rvr/c/rv64i_phantom_callbacks.c
@@ -1,7 +1,6 @@
 /*
  * Dispatch table and forwarding stubs for the Rv64I base IO operations: the
- * HINT_INPUT, PRINT_STR, HINT_RANDOM phantoms and the extension hint-stream
- * setter.
+ * HINT_INPUT, PRINT_STR, and HINT_RANDOM phantoms.
  */
 
 #include "rv64i_phantom_callbacks.h"
@@ -12,7 +11,6 @@ typedef struct {
   void (*hint_input)(void* ctx);
   void (*print_str)(void* ctx, uint32_t ptr, uint32_t len);
   void (*hint_random)(void* ctx, uint32_t num_words);
-  void (*hint_stream_set)(void* ctx, const uint8_t* data, uint32_t len);
 } Rv64IPhantomCallbacks;
 
 /* NOT thread-safe: installs one process-global callback table. */
@@ -30,8 +28,4 @@ void openvm_print_str(uint32_t ptr, uint32_t len) {
 
 void openvm_hint_random(uint32_t num_words) {
   g_rv64i_phantom_callbacks.hint_random(openvm_get_io_ctx(), num_words);
-}
-
-void ext_hint_stream_set(const uint8_t* data, uint32_t len) {
-  g_rv64i_phantom_callbacks.hint_stream_set(openvm_get_io_ctx(), data, len);
 }

--- a/extensions/riscv/rvr/c/rv64i_phantom_callbacks.h
+++ b/extensions/riscv/rvr/c/rv64i_phantom_callbacks.h
@@ -4,14 +4,10 @@
 #include <stdint.h>
 
 /* Forwarding stubs owned by the RISC-V base (Rv64I) extension: the IO phantoms
- * (HINT_INPUT, PRINT_STR, HINT_RANDOM) and the extension hint-stream setter.
- * Backed by a dispatch table installed by
- * `Rv64IExtension::register_host_callbacks`. */
+ * (HINT_INPUT, PRINT_STR, HINT_RANDOM). Backed by a dispatch table installed
+ * by `Rv64IExtension::register_host_callbacks`. */
 void openvm_hint_input(void);
 void openvm_print_str(uint32_t ptr, uint32_t len);
 void openvm_hint_random(uint32_t num_words);
-
-/* Extension hint stream access (called by extension FFI staticlibs). */
-void ext_hint_stream_set(const uint8_t* data, uint32_t len);
 
 #endif /* RV64I_PHANTOM_CALLBACKS_H */

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -343,7 +343,6 @@ impl<F: PrimeField32> RvrExtension<F> for Rv64IExtension {
             hint_input: host_hint_input::<F>,
             print_str: host_print_str::<F>,
             hint_random: host_hint_random::<F>,
-            hint_stream_set: host_hint_stream_set::<F>,
         };
         unsafe { register_fn(&callbacks) };
         Ok(())
@@ -359,7 +358,6 @@ pub struct Rv64IPhantomCallbacks {
     pub hint_input: extern "C" fn(*mut c_void),
     pub print_str: extern "C" fn(*mut c_void, u32, u32),
     pub hint_random: extern "C" fn(*mut c_void, u32),
-    pub hint_stream_set: unsafe extern "C" fn(*mut c_void, *const u8, u32),
 }
 
 /// Must match the C `Rv64IoHostCallbacks` layout in `rv64io_callbacks.c`.
@@ -473,25 +471,6 @@ pub extern "C" fn host_reveal<F: PrimeField32>(
     io.public_values[start..end].copy_from_slice(&src_val.to_le_bytes());
 }
 
-/// HINT_STREAM_SET: replace the hint stream contents (used by extension phantoms).
-///
-/// # Safety
-///
-/// `ctx` must be a valid `OpenVmIoState` pointer. `data` must point to `len` bytes (or be null).
-pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
-    ctx: *mut c_void,
-    data: *const u8,
-    len: u32,
-) {
-    let io = &mut *(ctx as *mut OpenVmIoState<'_, F>);
-    io.hint_stream.clear();
-    if len > 0 && !data.is_null() {
-        let slice = std::slice::from_raw_parts(data, len as usize);
-        for &b in slice {
-            io.hint_stream.push_back(F::from_u8(b));
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
move `ext_hint_stream_set` function from RV64I extension to core rvr. `ext_hint_stream_set` is also used by other extensions' phantom instructions, so it might be better to have it in core rvr.

Changes that were done:
1) move `host_hint_stream_set` into `crates/vm/src/arch/rvr/io` and `ext_hint_stream_set` into `openvm_io.c`
2) modify `register_openvm_io_ctx ` to register `host_hint_stream_set`.

resolves INT-8214