### PR TITLE
refactor(vm): use instance instead of interpreter for instance returning methods in VirtualMachine

### DIFF
--- a/crates/toolchain/tests/tests/riscv_test_vectors.rs
+++ b/crates/toolchain/tests/tests/riscv_test_vectors.rs
@@ -39,14 +39,14 @@ fn test_rv64im_riscv_vector_runtime() -> Result<()> {
                         .with_extension(Rv64IoTranspilerExtension),
                 )?;
                 let executor = VmExecutor::new(config.clone())?;
-                let interpreter = executor.instance(&exe)?;
+                let instance = executor.instance(&exe)?;
                 #[allow(unused_variables)]
-                let state = interpreter.execute(vec![], None)?;
+                let state = instance.execute(vec![], None)?;
 
                 #[cfg(any(feature = "aot", feature = "rvr"))]
                 {
-                    let naive_interpreter = executor.interpreter_instance(&exe)?;
-                    let naive_state = naive_interpreter.execute(vec![], None)?;
+                    let interpreter_instance = executor.interpreter_instance(&exe)?;
+                    let naive_state = interpreter_instance.execute(vec![], None)?;
                     let system_config: &SystemConfig = config.as_ref();
                     assert_vm_states_equivalent(
                         &state,

--- a/crates/toolchain/tests/tests/transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/transpiler_tests.rs
@@ -79,8 +79,8 @@ fn test_rv64im_aot_pure_runtime(elf_path: &str) -> Result<()> {
     let config = Rv64ImConfig::default();
     let executor = VmExecutor::new(config.clone())?;
 
-    let interpreter = executor.instance(&exe)?;
-    let _interp_state = interpreter.execute(vec![], None)?;
+    let instance = executor.instance(&exe)?;
+    let _interp_state = instance.execute(vec![], None)?;
 
     Ok(())
 }
@@ -101,8 +101,8 @@ fn test_rv64im_aot_pure_runtime_with_path(elf_path: &str) -> Result<()> {
     let config = Rv64ImConfig::default();
     let executor = VmExecutor::new(config.clone())?;
 
-    let interpreter = executor.instance(&exe)?;
-    let interp_state = interpreter.execute(vec![], None)?;
+    let instance = executor.instance(&exe)?;
+    let interp_state = instance.execute(vec![], None)?;
 
     let asm_name = String::from("asm_test_name");
     let mut aot_instance = executor.aot_instance_with_asm_name(&exe, &asm_name)?;
@@ -128,8 +128,8 @@ fn test_rv64im_runtime(elf_path: &str) -> Result<()> {
     )?;
     let config = Rv64ImConfig::default();
     let executor = VmExecutor::new(config)?;
-    let interpreter = executor.instance(&exe)?;
-    interpreter.execute(vec![], None)?;
+    let instance = executor.instance(&exe)?;
+    instance.execute(vec![], None)?;
     Ok(())
 }
 
@@ -192,8 +192,8 @@ fn test_intrinsic_runtime(elf_path: &str) -> Result<()> {
             .with_extension(Fp2TranspilerExtension),
     )?;
     let executor = VmExecutor::new(config)?;
-    let interpreter = executor.instance(&openvm_exe)?;
-    interpreter.execute(vec![], None)?;
+    let instance = executor.instance(&openvm_exe)?;
+    instance.execute(vec![], None)?;
     Ok(())
 }
 

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -689,7 +689,7 @@ where
         &self.executor.config
     }
 
-    /// Pure interpreter.
+    /// Pure execution instance.
     #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     pub fn instance(
         &self,

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -691,7 +691,7 @@ where
 
     /// Pure interpreter.
     #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
-    pub fn interpreter(
+    pub fn instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<InterpretedInstance<'_, Val<E::SC>, ExecutionCtx>, StaticProgramError>
@@ -703,7 +703,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    pub fn interpreter(
+    pub fn instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<RvrPureInstance<'_, Val<E::SC>>, StaticProgramError>
@@ -728,7 +728,7 @@ where
 
     // Pure AOT / RVR execution
     #[cfg(any(feature = "aot", feature = "rvr"))]
-    pub fn naive_interpreter(
+    pub fn interpreter_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<InterpretedInstance<'_, Val<E::SC>, ExecutionCtx>, StaticProgramError>
@@ -741,7 +741,7 @@ where
 
     // Pure AOT execution
     #[cfg(feature = "aot")]
-    pub fn interpreter(
+    pub fn instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<AotInstance<'_, Val<E::SC>, ExecutionCtx>, StaticProgramError>
@@ -765,7 +765,7 @@ where
     }
 
     #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
-    pub fn metered_interpreter(
+    pub fn metered_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<InterpretedInstance<'_, Val<E::SC>, MeteredCtx>, StaticProgramError>
@@ -779,7 +779,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    pub fn metered_interpreter(
+    pub fn metered_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<RvrMeteredInstance<'_, Val<E::SC>>, StaticProgramError>
@@ -821,7 +821,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    pub fn load_metered_interpreter(
+    pub fn load_metered_instance(
         &self,
         lib_path: &std::path::Path,
         exe: &VmExe<Val<E::SC>>,
@@ -836,7 +836,7 @@ where
     }
 
     #[cfg(feature = "aot")]
-    pub fn metered_interpreter(
+    pub fn metered_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<AotInstance<'_, Val<E::SC>, MeteredCtx>, StaticProgramError>
@@ -865,7 +865,7 @@ where
     }
 
     #[cfg(any(feature = "aot", feature = "rvr"))]
-    pub fn naive_metered_interpreter(
+    pub fn metered_interpreter_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<InterpretedInstance<'_, Val<E::SC>, MeteredCtx>, StaticProgramError>
@@ -879,7 +879,7 @@ where
     }
 
     #[cfg(not(feature = "rvr"))]
-    pub fn metered_cost_interpreter(
+    pub fn metered_cost_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<InterpretedInstance<'_, Val<E::SC>, MeteredCostCtx>, StaticProgramError>
@@ -893,7 +893,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    pub fn metered_cost_interpreter(
+    pub fn metered_cost_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
     ) -> Result<RvrMeteredCostInstance<'_, Val<E::SC>>, StaticProgramError>
@@ -925,7 +925,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    pub fn load_metered_cost_interpreter(
+    pub fn load_metered_cost_instance(
         &self,
         lib_path: &std::path::Path,
         exe: &VmExe<Val<E::SC>>,
@@ -1479,8 +1479,8 @@ where
         self.reset_state(input.clone());
         let vm = &mut self.vm;
         let metered_ctx = vm.build_metered_ctx(&self.exe);
-        let metered_interpreter = vm.metered_interpreter(&self.exe)?;
-        let (segments, _) = metered_interpreter.execute_metered(input, metered_ctx)?;
+        let metered_instance = vm.metered_instance(&self.exe)?;
+        let (segments, _) = metered_instance.execute_metered(input, metered_ctx)?;
         let mut proofs = Vec::with_capacity(segments.len());
         let mut state = self.state.take();
         for (seg_idx, segment) in segments.into_iter().enumerate() {

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -129,7 +129,7 @@ where
     */
     {
         let interp_state_pure = vm
-            .naive_interpreter(exe)?
+            .interpreter_instance(exe)?
             .execute(input.clone(), None)
             .expect("Failed to execute");
 
@@ -151,7 +151,7 @@ where
             .execute_metered(input.clone(), metered_ctx.clone())?;
 
         let (segments, interp_state_metered) = vm
-            .naive_metered_interpreter(exe)?
+            .metered_interpreter_instance(exe)?
             .execute_metered(input.clone(), metered_ctx.clone())?;
 
         check_vm_state_eq(&interp_state_metered, &aot_state_metered)?;
@@ -233,7 +233,7 @@ where
     */
     {
         let interp_state_pure = vm
-            .naive_interpreter(exe)?
+            .interpreter_instance(exe)?
             .execute(input.clone(), None)
             .expect("Failed to execute");
 
@@ -285,7 +285,7 @@ where
             .execute_metered(input.clone(), metered_ctx.clone())?;
 
         let (interp_segments, _interp_state_metered) = vm
-            .naive_metered_interpreter(exe)?
+            .metered_interpreter_instance(exe)?
             .execute_metered(input.clone(), metered_ctx.clone())?;
 
         let interp_total: u64 = interp_segments.iter().map(|s| s.num_insns).sum();
@@ -377,7 +377,7 @@ where
     check_rvr_equivalence(&vm, &exe, &input)?;
 
     let (segments, _) = vm
-        .metered_interpreter(&exe)?
+        .metered_instance(&exe)?
         .execute_metered(input.clone(), metered_ctx.clone())?;
 
     let cached_program_trace = vm.commit_program_on_device(&exe.program);

--- a/extensions/riscv/circuit/src/jalr/tests.rs
+++ b/extensions/riscv/circuit/src/jalr/tests.rs
@@ -603,10 +603,10 @@ fn run_jalr_program(instructions: Vec<Instruction<F>>) -> (VmState<F>, VmState<F
     let memory_dimensions = config.rv64i.system.memory_config.memory_dimensions();
     let executor = VmExecutor::new(config.clone()).expect("failed to create Rv64IM executor");
 
-    let interpreter = executor
+    let interpreter_instance = executor
         .interpreter_instance(&exe)
         .expect("interpreter build must succeed");
-    let interp_state = interpreter
+    let interp_state = interpreter_instance
         .execute(vec![], None)
         .expect("interpreter execution must succeed");
 

--- a/extensions/riscv/circuit/src/mul/tests.rs
+++ b/extensions/riscv/circuit/src/mul/tests.rs
@@ -317,10 +317,10 @@ fn run_mul_program(instructions: Vec<Instruction<F>>) -> (VmState<F>, VmState<F>
     let memory_dimensions = config.rv64i.system.memory_config.memory_dimensions();
     let executor = VmExecutor::new(config.clone()).expect("failed to create Rv64IM executor");
 
-    let interpreter = executor
+    let interpreter_instance = executor
         .interpreter_instance(&exe)
         .expect("interpreter build must succeed");
-    let interp_state = interpreter
+    let interp_state = interpreter_instance
         .execute(vec![], None)
         .expect("interpreter execution must succeed");
 

--- a/extensions/riscv/circuit/src/mul_w/tests.rs
+++ b/extensions/riscv/circuit/src/mul_w/tests.rs
@@ -421,10 +421,10 @@ fn run_mul_program(instructions: Vec<Instruction<F>>) -> (VmState<F>, VmState<F>
     let memory_dimensions = config.rv64i.system.memory_config.memory_dimensions();
     let executor = VmExecutor::new(config.clone()).expect("failed to create Rv64IM executor");
 
-    let interpreter = executor
+    let interpreter_instance = executor
         .interpreter_instance(&exe)
         .expect("interpreter build must succeed");
-    let interp_state = interpreter
+    let interp_state = interpreter_instance
         .execute(vec![], None)
         .expect("interpreter execution must succeed");
 

--- a/extensions/riscv/circuit/src/mulh/tests.rs
+++ b/extensions/riscv/circuit/src/mulh/tests.rs
@@ -526,10 +526,10 @@ fn run_mul_program(instructions: Vec<Instruction<F>>) -> (VmState<F>, VmState<F>
     let memory_dimensions = config.rv64i.system.memory_config.memory_dimensions();
     let executor = VmExecutor::new(config.clone()).expect("failed to create Rv64IM executor");
 
-    let interpreter = executor
+    let interpreter_instance = executor
         .interpreter_instance(&exe)
         .expect("interpreter build must succeed");
-    let interp_state = interpreter
+    let interp_state = interpreter_instance
         .execute(vec![], None)
         .expect("interpreter execution must succeed");
 

--- a/guest-libs/keccak256/tests/lib.rs
+++ b/guest-libs/keccak256/tests/lib.rs
@@ -93,14 +93,14 @@ mod tests {
             air_test_with_min_segments(TestBuilder, config, openvm_exe, stdin, 1);
         } else {
             let executor = VmExecutor::new(config.clone())?;
-            let interpreter = executor.instance(&openvm_exe)?;
+            let instance = executor.instance(&openvm_exe)?;
             #[allow(unused_variables)]
-            let state = interpreter.execute(stdin.clone(), None)?;
+            let state = instance.execute(stdin.clone(), None)?;
 
             #[cfg(any(feature = "aot", feature = "rvr"))]
             {
-                let naive_interpreter = executor.interpreter_instance(&openvm_exe)?;
-                let naive_state = naive_interpreter.execute(stdin, None)?;
+                let interpreter_instance = executor.interpreter_instance(&openvm_exe)?;
+                let naive_state = interpreter_instance.execute(stdin, None)?;
                 let system_config: &SystemConfig = config.as_ref();
                 assert_vm_states_equivalent(
                     &state,

--- a/guest-libs/sha2/tests/lib.rs
+++ b/guest-libs/sha2/tests/lib.rs
@@ -98,14 +98,14 @@ mod tests {
             air_test_with_min_segments(Sha2Rv64Builder, config, openvm_exe, stdin, 1);
         } else {
             let executor = VmExecutor::new(config.clone())?;
-            let interpreter = executor.instance(&openvm_exe)?;
+            let instance = executor.instance(&openvm_exe)?;
             #[allow(unused_variables)]
-            let state = interpreter.execute(stdin.clone(), None)?;
+            let state = instance.execute(stdin.clone(), None)?;
 
             #[cfg(any(feature = "aot", feature = "rvr"))]
             {
-                let naive_interpreter = executor.interpreter_instance(&openvm_exe)?;
-                let naive_state = naive_interpreter.execute(stdin, None)?;
+                let interpreter_instance = executor.interpreter_instance(&openvm_exe)?;
+                let naive_state = interpreter_instance.execute(stdin, None)?;
                 let system_config: &SystemConfig = config.as_ref();
                 assert_vm_states_equivalent(
                     &state,
@@ -136,14 +136,14 @@ mod tests {
 
         let stdin = StdIn::default();
         let executor = VmExecutor::new(config.clone())?;
-        let interpreter = executor.instance(&openvm_exe)?;
+        let instance = executor.instance(&openvm_exe)?;
         #[allow(unused_variables)]
-        let state = interpreter.execute(stdin.clone(), None)?;
+        let state = instance.execute(stdin.clone(), None)?;
 
         #[cfg(any(feature = "aot", feature = "rvr"))]
         {
-            let naive_interpreter = executor.interpreter_instance(&openvm_exe)?;
-            let naive_state = naive_interpreter.execute(stdin, None)?;
+            let interpreter_instance = executor.interpreter_instance(&openvm_exe)?;
+            let naive_state = interpreter_instance.execute(stdin, None)?;
             let system_config: &SystemConfig = config.as_ref();
             assert_vm_states_equivalent(
                 &state,


### PR DESCRIPTION
use `instance` instead of `interpreter` for instance returning methods in `VirtualMachine`.

`interpreter` and `naive_interpreter` methods were updated to `instance` and `interpreter_instance` respectively. Also, the changes were applied to `metered` and `metered_cost` related methods.

resolves INT-7653