### PR TITLE
refactor: replace on_check function pointer with direct extern call

### DIFF
--- a/crates/rvr/rvr-openvm/c/block/openvm_block_metered.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_metered.h
@@ -17,7 +17,7 @@ static __attribute__((preserve_most, cold, noinline)) uint32_t
 metered_checkpoint(RvState* restrict state, uint32_t check_counter) {
   Tracer* t = state->tracer;
   t->check_counter = check_counter;
-  t->on_check(t);
+  metered_periodic_check(t);
   return t->check_counter;
 }
 

--- a/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
@@ -22,7 +22,7 @@ static __attribute__((preserve_most, cold,
 metered_segment_checkpoint(RvState* restrict state, uint32_t check_counter) {
   Tracer* t = state->tracer;
   t->check_counter = check_counter;
-  uint8_t suspend_signal = t->on_check(t);
+  uint8_t suspend_signal = metered_periodic_check(t);
   return (MeteredSegmentCheckpointResult){
       .check_counter = t->check_counter,
       .suspend_signal = suspend_signal,

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -31,9 +31,6 @@ typedef struct Tracer {
   uint32_t* mem_page_buf;
   uint32_t* pv_page_buf;
   uint32_t* deferral_page_buf;
-  /* Always initialized by Rust; called unconditionally on the cold checkpoint
-   * path to avoid a hot-path null check. */
-  uint8_t (*on_check)(struct Tracer*);
   void* seg_state;
   uint32_t mem_page_buf_len;
   uint32_t pv_page_buf_len;
@@ -44,6 +41,11 @@ typedef struct Tracer {
    * across segment boundaries that clear the global BitSet). */
   uint32_t last_mem_page;
 } Tracer;
+
+/* Periodic segmentation check implemented in Rust. Called unconditionally on
+ * the cold checkpoint path; exported from the host binary so the generated
+ * shared library can reference it directly without a function-pointer field. */
+extern uint8_t metered_periodic_check(Tracer* t);
 
 typedef struct TraceMemory {
   uint32_t last_mem_page;
@@ -316,7 +318,7 @@ static __attribute__((always_inline)) inline void trace_chip(
 static __attribute__((always_inline)) inline void trace_block(
     RvState* restrict state, uint32_t pc, uint32_t block_insn_count) {
   if (unlikely(state->tracer->check_counter < block_insn_count)) {
-    state->tracer->on_check(state->tracer);
+    metered_periodic_check(state->tracer);
   }
   state->tracer->check_counter -= block_insn_count;
 }
@@ -325,7 +327,7 @@ static __attribute__((always_inline)) inline uint8_t
 trace_block_with_segment_check(RvState* restrict state, uint32_t pc,
                                uint32_t block_insn_count) {
   if (unlikely(state->tracer->check_counter < block_insn_count)) {
-    if (state->tracer->on_check(state->tracer)) {
+    if (metered_periodic_check(state->tracer)) {
       return 1;
     }
   }

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -18,10 +18,7 @@ use super::{
     },
     compile::RvrCompiled,
     io::OpenVmIoState,
-    metered::{
-        metered_periodic_check, MeteredTracerData, RvrMeteredResult, SegmentationState,
-        NO_LAST_PAGE,
-    },
+    metered::{MeteredTracerData, RvrMeteredResult, SegmentationState, NO_LAST_PAGE},
     metered_cost::{MeteredCostData, PureTracerData, RvrMeteredCostResult},
     pure::RvrPureResult,
     state::{
@@ -289,7 +286,6 @@ fn execute_metered_impl<F: PrimeField32>(
     state.tracer.deferral_page_buf_len = 0;
     state.tracer.last_mem_page = NO_LAST_PAGE;
     state.tracer.check_counter = check_counter;
-    state.tracer.on_check = metered_periodic_check;
     state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut c_void;
 
     let status = run_and_finalize(compiled, extensions, vm_state, &mut state, allow_suspended)

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -83,9 +83,6 @@ pub struct MeteredTracerData {
     pub mem_page_buf: *mut u32,
     pub pv_page_buf: *mut u32,
     pub deferral_page_buf: *mut u32,
-    /// Periodic-check callback. Always initialized; generated C calls it
-    /// unconditionally to keep the hot metered path branch-free.
-    pub on_check: unsafe extern "C" fn(*mut MeteredTracerData) -> u8,
     pub seg_state: *mut c_void,
     pub mem_page_buf_len: u32,
     pub pv_page_buf_len: u32,
@@ -105,7 +102,6 @@ impl Default for MeteredTracerData {
             mem_page_buf: std::ptr::null_mut(),
             pv_page_buf: std::ptr::null_mut(),
             deferral_page_buf: std::ptr::null_mut(),
-            on_check: metered_periodic_check,
             seg_state: std::ptr::null_mut(),
             mem_page_buf_len: 0,
             pv_page_buf_len: 0,
@@ -374,6 +370,7 @@ impl SegmentationState {
 /// # Safety
 /// `t` must point to a valid `MeteredTracerData` whose `seg_state` pointer
 /// references a live `SegmentationState`.
+#[no_mangle]
 pub unsafe extern "C" fn metered_periodic_check(t: *mut MeteredTracerData) -> u8 {
     let tracer = &mut *t;
     let seg_state = &mut *(tracer.seg_state as *mut SegmentationState);
@@ -597,7 +594,6 @@ mod tests {
             mem_page_buf: seg_state.mem_page_buf_ptr(),
             pv_page_buf: seg_state.pv_page_buf_ptr(),
             deferral_page_buf: seg_state.deferral_page_buf_ptr(),
-            on_check: metered_periodic_check,
             seg_state: &mut seg_state as *mut SegmentationState as *mut c_void,
             mem_page_buf_len: 0,
             pv_page_buf_len: 0,
@@ -623,7 +619,6 @@ mod tests {
             mem_page_buf: seg_state.mem_page_buf_ptr(),
             pv_page_buf: seg_state.pv_page_buf_ptr(),
             deferral_page_buf: seg_state.deferral_page_buf_ptr(),
-            on_check: metered_periodic_check,
             seg_state: &mut seg_state as *mut SegmentationState as *mut c_void,
             mem_page_buf_len: 0,
             pv_page_buf_len: 0,


### PR DESCRIPTION
Replace `on_check` function pointer in Tracer with direct extern call. Previously, a pointer to the function was stored in the struct and assigned at runtime.

By making it extern, the call site becomes a direct named call. The compiler can better understand and optimize.

resolves INT-7348