### PR TITLE
refactor: rvr extensions remove code duplication

### DIFF
--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -68,15 +68,25 @@ impl<T: KnownFieldArith> FieldArith for T {
     }
 
     #[inline(always)]
-    fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a + b }
+    fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
+        a + b
+    }
     #[inline(always)]
-    fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a - b }
+    fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
+        a - b
+    }
     #[inline(always)]
-    fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a * b }
+    fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
+        a * b
+    }
     #[inline(always)]
-    fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a * b.invert().unwrap() }
+    fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
+        a * b.invert().unwrap()
+    }
     #[inline(always)]
-    fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool { a == b }
+    fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool {
+        a == b
+    }
 }
 
 // ── 256-bit / 384-bit field I/O ─────────────────────────────────────────────
@@ -265,9 +275,10 @@ macro_rules! unknown_field_op_fn {
             num_limbs: u32,
             modulus_ptr: *const u8,
         ) {
-            let modulus = ::num_bigint::BigUint::from_bytes_le(
-                ::std::slice::from_raw_parts(modulus_ptr, num_limbs as usize),
-            );
+            let modulus = ::num_bigint::BigUint::from_bytes_le(::std::slice::from_raw_parts(
+                modulus_ptr,
+                num_limbs as usize,
+            ));
             let f = $field_ty { modulus, num_limbs };
             $crate::exec_op(&f, state, rd_ptr, rs1_ptr, rs2_ptr, |f, a, b| f.$op(a, b));
         }

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -251,7 +251,9 @@ macro_rules! known_field_op_fn {
             rs2: u64,
         ) {
             let f = $wrapper::<$field>(::std::marker::PhantomData);
-            $crate::exec_op(&f, state, rd, rs1, rs2, |f, a, b| f.$op(a, b));
+            $crate::exec_op(&f, state, rd, rs1, rs2, |f, a, b| {
+                $crate::FieldArith::$op(f, a, b)
+            });
         }
     };
 }
@@ -280,7 +282,9 @@ macro_rules! unknown_field_op_fn {
                 num_limbs as usize,
             ));
             let f = $field_ty { modulus, num_limbs };
-            $crate::exec_op(&f, state, rd_ptr, rs1_ptr, rs2_ptr, |f, a, b| f.$op(a, b));
+            $crate::exec_op(&f, state, rd_ptr, rs1_ptr, rs2_ptr, |f, a, b| {
+                $crate::FieldArith::$op(f, a, b)
+            });
         }
     };
 }

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -182,6 +182,36 @@ pub fn mod_inverse(a: &BigUint, p: &BigUint) -> BigUint {
         .unwrap()
 }
 
+// ── FFI generation macro (shared by modular and fp2) ────────────────────────
+
+/// Generate a generic (unknown-modulus) field-op FFI function.
+///
+/// `$field_ty` must be a struct with `modulus: BigUint` and `num_limbs: u32`
+/// fields that implements [`FieldArith`].
+#[macro_export]
+macro_rules! unknown_field_op_fn {
+    ($name:ident, $field_ty:ident, $op:ident) => {
+        /// # Safety
+        /// `state` must be a valid `RvState` pointer. `modulus_ptr` must point
+        /// to `num_limbs` bytes.
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(
+            state: *mut ::std::ffi::c_void,
+            rd_ptr: u64,
+            rs1_ptr: u64,
+            rs2_ptr: u64,
+            num_limbs: u32,
+            modulus_ptr: *const u8,
+        ) {
+            let modulus = ::num_bigint::BigUint::from_bytes_le(
+                ::std::slice::from_raw_parts(modulus_ptr, num_limbs as usize),
+            );
+            let f = $field_ty { modulus, num_limbs };
+            $crate::exec_op(&f, state, rd_ptr, rs1_ptr, rs2_ptr, |f, a, b| f.$op(a, b));
+        }
+    };
+}
+
 // ── Instruction execution helper ─────────────────────────────────────────────
 
 /// Read both operands, apply `op`, write the result.

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -224,7 +224,27 @@ pub fn mod_inverse(a: &BigUint, p: &BigUint) -> BigUint {
         .unwrap()
 }
 
-// ── FFI generation macro (shared by modular and fp2) ────────────────────────
+// ── FFI generation macros (shared by modular and fp2) ───────────────────────
+
+/// Generate a known-field FFI function. `$wrapper` must be a
+/// `PhantomData`-newtype that implements [`KnownFieldArith`] for `$field`.
+#[macro_export]
+macro_rules! known_field_op_fn {
+    ($name:ident, $wrapper:ident, $field:ty, $op:ident) => {
+        /// # Safety
+        /// `state` must be a valid `RvState` pointer.
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(
+            state: *mut ::std::ffi::c_void,
+            rd: u64,
+            rs1: u64,
+            rs2: u64,
+        ) {
+            let f = $wrapper::<$field>(::std::marker::PhantomData);
+            $crate::exec_op(&f, state, rd, rs1, rs2, |f, a, b| f.$op(a, b));
+        }
+    };
+}
 
 /// Generate a generic (unknown-modulus) field-op FFI function.
 ///

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::c_void;
 
-use halo2curves_axiom::ff::PrimeField;
+use halo2curves_axiom::ff::{Field, PrimeField};
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced, WORD_SIZE};
@@ -35,6 +35,48 @@ pub trait FieldArith {
     fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem;
     fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem;
     fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool;
+}
+
+// ── KnownFieldArith trait ─────────────────────────────────────────────────────
+
+/// Narrower trait for known (native) field types whose element type supports
+/// standard arithmetic via operator overloads. Implementing this trait
+/// automatically provides a full [`FieldArith`] impl via a blanket impl —
+/// only `read_elem` and `write_elem` need to be supplied.
+pub trait KnownFieldArith {
+    type Elem: Field;
+
+    /// # Safety
+    /// `state` must be a valid pointer to the C `RvState` struct.
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem;
+    /// # Safety
+    /// `state` must be a valid pointer to the C `RvState` struct.
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem);
+}
+
+impl<T: KnownFieldArith> FieldArith for T {
+    type Elem = T::Elem;
+
+    #[inline(always)]
+    unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
+        KnownFieldArith::read_elem(self, state, ptr)
+    }
+
+    #[inline(always)]
+    unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
+        KnownFieldArith::write_elem(self, state, ptr, val)
+    }
+
+    #[inline(always)]
+    fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a + b }
+    #[inline(always)]
+    fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a - b }
+    #[inline(always)]
+    fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a * b }
+    #[inline(always)]
+    fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem { a * b.invert().unwrap() }
+    #[inline(always)]
+    fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool { a == b }
 }
 
 // ── 256-bit / 384-bit field I/O ─────────────────────────────────────────────

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -7,11 +7,10 @@
 
 use std::{ffi::c_void, marker::PhantomData};
 
-use halo2curves_axiom::ff::Field;
 use num_bigint::BigUint;
 use rvr_openvm_ext_algebra_ffi_common::{
     exec_op, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256, write_bigint,
-    write_bls12_381_fq, write_field_256, FieldArith,
+    write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
     rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
@@ -31,7 +30,7 @@ struct UnknownComplexField {
 
 // ── KnownComplexField impls ─────────────────────────────────────────────────
 
-impl FieldArith for KnownComplexField<halo2curves_axiom::bn256::Fq2> {
+impl KnownFieldArith for KnownComplexField<halo2curves_axiom::bn256::Fq2> {
     type Elem = halo2curves_axiom::bn256::Fq2;
 
     #[inline(always)]
@@ -47,30 +46,9 @@ impl FieldArith for KnownComplexField<halo2curves_axiom::bn256::Fq2> {
         write_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr, &val.c0);
         write_field_256::<halo2curves_axiom::bn256::Fq>(state, ptr + FIELD_256_BYTES, &val.c1);
     }
-
-    #[inline(always)]
-    fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a + b
-    }
-    #[inline(always)]
-    fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a - b
-    }
-    #[inline(always)]
-    fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b
-    }
-    #[inline(always)]
-    fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b.invert().unwrap()
-    }
-    #[inline(always)]
-    fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool {
-        a == b
-    }
 }
 
-impl FieldArith for KnownComplexField<blstrs::Fp2> {
+impl KnownFieldArith for KnownComplexField<blstrs::Fp2> {
     type Elem = blstrs::Fp2;
 
     #[inline(always)]
@@ -85,27 +63,6 @@ impl FieldArith for KnownComplexField<blstrs::Fp2> {
     unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_bls12_381_fq(state, ptr, &val.c0());
         write_bls12_381_fq(state, ptr + BLS12_381_ELEM_BYTES, &val.c1());
-    }
-
-    #[inline(always)]
-    fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a + b
-    }
-    #[inline(always)]
-    fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a - b
-    }
-    #[inline(always)]
-    fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b
-    }
-    #[inline(always)]
-    fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b.invert().unwrap()
-    }
-    #[inline(always)]
-    fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool {
-        a == b
     }
 }
 

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -9,8 +9,8 @@ use std::{ffi::c_void, marker::PhantomData};
 
 use num_bigint::BigUint;
 use rvr_openvm_ext_algebra_ffi_common::{
-    exec_op, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256, write_bigint,
-    write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
+    known_field_op_fn, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256,
+    write_bigint, write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
     rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced, AS_MEMORY, WORD_SIZE,
@@ -118,25 +118,13 @@ impl FieldArith for UnknownComplexField {
 
 // ── Macros ──────────────────────────────────────────────────────────────────
 
-macro_rules! field_op_fn {
-    ($name:ident, $field:ty, $op:ident) => {
-        /// # Safety
-        /// `state` must be a valid `RvState` pointer.
-        #[no_mangle]
-        pub unsafe extern "C" fn $name(state: *mut c_void, rd: u64, rs1: u64, rs2: u64) {
-            let f = KnownComplexField::<$field>(PhantomData);
-            exec_op(&f, state, rd, rs1, rs2, |f, a, b| f.$op(a, b));
-        }
-    };
-}
-
 macro_rules! define_fp2_ffi {
     ($field:ty, $suffix:ident) => {
         paste::paste! {
-            field_op_fn!([<rvr_ext_fp2_add_ $suffix>], $field, add);
-            field_op_fn!([<rvr_ext_fp2_sub_ $suffix>], $field, sub);
-            field_op_fn!([<rvr_ext_fp2_mul_ $suffix>], $field, mul);
-            field_op_fn!([<rvr_ext_fp2_div_ $suffix>], $field, div);
+            known_field_op_fn!([<rvr_ext_fp2_add_ $suffix>], KnownComplexField, $field, add);
+            known_field_op_fn!([<rvr_ext_fp2_sub_ $suffix>], KnownComplexField, $field, sub);
+            known_field_op_fn!([<rvr_ext_fp2_mul_ $suffix>], KnownComplexField, $field, mul);
+            known_field_op_fn!([<rvr_ext_fp2_div_ $suffix>], KnownComplexField, $field, div);
         }
     };
 }

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -9,8 +9,8 @@ use std::{ffi::c_void, marker::PhantomData};
 
 use num_bigint::BigUint;
 use rvr_openvm_ext_algebra_ffi_common::{
-    known_field_op_fn, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256,
-    write_bigint, write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
+    known_field_op_fn, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256, write_bigint,
+    write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
     rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced, AS_MEMORY, WORD_SIZE,

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -189,32 +189,12 @@ define_fp2_ffi!(blstrs::Fp2, bls12_381);
 
 // ── Generic FFI (fallback for unknown moduli) ────────────────────────────────
 
-macro_rules! unknown_field_op_fn {
-    ($name:ident, $op:ident) => {
-        /// # Safety
-        /// `state` must be a valid `RvState` pointer. `modulus_ptr` must point
-        /// to `num_limbs` bytes.
-        #[no_mangle]
-        pub unsafe extern "C" fn $name(
-            state: *mut c_void,
-            rd_ptr: u64,
-            rs1_ptr: u64,
-            rs2_ptr: u64,
-            num_limbs: u32,
-            modulus_ptr: *const u8,
-        ) {
-            let modulus =
-                BigUint::from_bytes_le(std::slice::from_raw_parts(modulus_ptr, num_limbs as usize));
-            let f = UnknownComplexField { modulus, num_limbs };
-            exec_op(&f, state, rd_ptr, rs1_ptr, rs2_ptr, |f, a, b| f.$op(a, b));
-        }
-    };
-}
+use rvr_openvm_ext_algebra_ffi_common::unknown_field_op_fn;
 
-unknown_field_op_fn!(rvr_ext_fp2_add, add);
-unknown_field_op_fn!(rvr_ext_fp2_sub, sub);
-unknown_field_op_fn!(rvr_ext_fp2_mul, mul);
-unknown_field_op_fn!(rvr_ext_fp2_div, div);
+unknown_field_op_fn!(rvr_ext_fp2_add, UnknownComplexField, add);
+unknown_field_op_fn!(rvr_ext_fp2_sub, UnknownComplexField, sub);
+unknown_field_op_fn!(rvr_ext_fp2_mul, UnknownComplexField, mul);
+unknown_field_op_fn!(rvr_ext_fp2_div, UnknownComplexField, div);
 
 /// # Safety
 /// `state` must be a valid `RvState` pointer.

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -12,12 +12,12 @@
 
 use std::{ffi::c_void, marker::PhantomData};
 
-use halo2curves_axiom::ff::{Field, PrimeField};
+use halo2curves_axiom::ff::PrimeField;
 use num_bigint::BigUint;
 use num_traits::One;
 use rvr_openvm_ext_algebra_ffi_common::{
     exec_op, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256, write_bigint,
-    write_bls12_381_fq, write_field_256, FieldArith,
+    write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
     ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_words_traced, trace_mem_access_range,
@@ -45,7 +45,7 @@ struct UnknownPrimeField {
 
 // ── KnownPrimeField impl (256-bit via generic bound) ────────────────────────
 
-impl<F: PrimeField<Repr = [u8; 32]>> FieldArith for KnownPrimeField<F> {
+impl<F: PrimeField<Repr = [u8; 32]>> KnownFieldArith for KnownPrimeField<F> {
     type Elem = F;
     #[inline(always)]
     unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
@@ -55,31 +55,11 @@ impl<F: PrimeField<Repr = [u8; 32]>> FieldArith for KnownPrimeField<F> {
     unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_field_256(state, ptr, val)
     }
-    #[inline(always)]
-    fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a + b
-    }
-    #[inline(always)]
-    fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a - b
-    }
-    #[inline(always)]
-    fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b
-    }
-    #[inline(always)]
-    fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b.invert().unwrap()
-    }
-    #[inline(always)]
-    fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool {
-        a == b
-    }
 }
 
 // ── KnownPrimeField impl (BLS12-381 Fq, 48 bytes) ──────────────────────────
 
-impl FieldArith for KnownPrimeField<Bls12381Fq> {
+impl KnownFieldArith for KnownPrimeField<Bls12381Fq> {
     type Elem = blstrs::Fp;
     #[inline(always)]
     unsafe fn read_elem(&self, state: *mut c_void, ptr: u64) -> Self::Elem {
@@ -88,26 +68,6 @@ impl FieldArith for KnownPrimeField<Bls12381Fq> {
     #[inline(always)]
     unsafe fn write_elem(&self, state: *mut c_void, ptr: u64, val: &Self::Elem) {
         write_bls12_381_fq(state, ptr, val)
-    }
-    #[inline(always)]
-    fn add(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a + b
-    }
-    #[inline(always)]
-    fn sub(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a - b
-    }
-    #[inline(always)]
-    fn mul(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b
-    }
-    #[inline(always)]
-    fn div(&self, a: Self::Elem, b: Self::Elem) -> Self::Elem {
-        a * b.invert().unwrap()
-    }
-    #[inline(always)]
-    fn is_eq(&self, a: &Self::Elem, b: &Self::Elem) -> bool {
-        a == b
     }
 }
 

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -16,8 +16,8 @@ use halo2curves_axiom::ff::PrimeField;
 use num_bigint::BigUint;
 use num_traits::One;
 use rvr_openvm_ext_algebra_ffi_common::{
-    known_field_op_fn, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256,
-    write_bigint, write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
+    known_field_op_fn, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256, write_bigint,
+    write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
     ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_words_traced, trace_mem_access_range,

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -203,32 +203,12 @@ define_mod_ffi!(halo2curves_axiom::bls12_381::Fr, bls12_381_fr);
 
 // ── Generic FFI (fallback for unknown moduli) ────────────────────────────────
 
-macro_rules! unknown_field_op_fn {
-    ($name:ident, $op:ident) => {
-        /// # Safety
-        /// `state` must be a valid `RvState` pointer. `modulus_ptr` must point
-        /// to `num_limbs` bytes.
-        #[no_mangle]
-        pub unsafe extern "C" fn $name(
-            state: *mut c_void,
-            rd_ptr: u64,
-            rs1_ptr: u64,
-            rs2_ptr: u64,
-            num_limbs: u32,
-            modulus_ptr: *const u8,
-        ) {
-            let modulus =
-                BigUint::from_bytes_le(std::slice::from_raw_parts(modulus_ptr, num_limbs as usize));
-            let f = UnknownPrimeField { modulus, num_limbs };
-            exec_op(&f, state, rd_ptr, rs1_ptr, rs2_ptr, |f, a, b| f.$op(a, b));
-        }
-    };
-}
+use rvr_openvm_ext_algebra_ffi_common::unknown_field_op_fn;
 
-unknown_field_op_fn!(rvr_ext_mod_add, add);
-unknown_field_op_fn!(rvr_ext_mod_sub, sub);
-unknown_field_op_fn!(rvr_ext_mod_mul, mul);
-unknown_field_op_fn!(rvr_ext_mod_div, div);
+unknown_field_op_fn!(rvr_ext_mod_add, UnknownPrimeField, add);
+unknown_field_op_fn!(rvr_ext_mod_sub, UnknownPrimeField, sub);
+unknown_field_op_fn!(rvr_ext_mod_mul, UnknownPrimeField, mul);
+unknown_field_op_fn!(rvr_ext_mod_div, UnknownPrimeField, div);
 
 /// # Safety
 /// `state` must be a valid `RvState` pointer. `modulus_ptr` must point to `num_limbs` bytes.

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -16,8 +16,8 @@ use halo2curves_axiom::ff::PrimeField;
 use num_bigint::BigUint;
 use num_traits::One;
 use rvr_openvm_ext_algebra_ffi_common::{
-    exec_op, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256, write_bigint,
-    write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
+    known_field_op_fn, mod_inverse, read_bigint, read_bls12_381_fq, read_field_256,
+    write_bigint, write_bls12_381_fq, write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
     ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_words_traced, trace_mem_access_range,
@@ -121,25 +121,13 @@ unsafe fn exec_iseq<F: FieldArith>(f: &F, state: *mut c_void, rs1_ptr: u64, rs2_
 
 // ── FFI generation macros ────────────────────────────────────────────────────
 
-macro_rules! field_op_fn {
-    ($name:ident, $field:ty, $op:ident) => {
-        /// # Safety
-        /// `state` must be a valid `RvState` pointer.
-        #[no_mangle]
-        pub unsafe extern "C" fn $name(state: *mut c_void, rd: u64, rs1: u64, rs2: u64) {
-            let f = KnownPrimeField::<$field>(PhantomData);
-            exec_op(&f, state, rd, rs1, rs2, |f, a, b| f.$op(a, b));
-        }
-    };
-}
-
 macro_rules! define_mod_ffi {
     ($field:ty, $suffix:ident) => {
         paste::paste! {
-            field_op_fn!([<rvr_ext_mod_add_ $suffix>], $field, add);
-            field_op_fn!([<rvr_ext_mod_sub_ $suffix>], $field, sub);
-            field_op_fn!([<rvr_ext_mod_mul_ $suffix>], $field, mul);
-            field_op_fn!([<rvr_ext_mod_div_ $suffix>], $field, div);
+            known_field_op_fn!([<rvr_ext_mod_add_ $suffix>], KnownPrimeField, $field, add);
+            known_field_op_fn!([<rvr_ext_mod_sub_ $suffix>], KnownPrimeField, $field, sub);
+            known_field_op_fn!([<rvr_ext_mod_mul_ $suffix>], KnownPrimeField, $field, mul);
+            known_field_op_fn!([<rvr_ext_mod_div_ $suffix>], KnownPrimeField, $field, div);
             /// # Safety
             /// `state` must be a valid `RvState` pointer.
             #[no_mangle]

--- a/extensions/algebra/rvr/src/common.rs
+++ b/extensions/algebra/rvr/src/common.rs
@@ -6,7 +6,7 @@ use crate::{detect_known_field, format_c_byte_array, KnownField, ModOp};
 
 /// Marker trait implemented by zero-sized types that parameterize
 /// [`FieldArithInstr`], supplying the C prefix and known-field suffix lookup.
-pub trait ArithKind: Clone + Debug + Send + Sync + 'static {
+pub(crate) trait ArithKind: Clone + Debug + Send + Sync + 'static {
     fn opname() -> &'static str;
     fn c_prefix() -> &'static str;
     /// Returns the C suffix for a known field, or `None` to fall through to the
@@ -18,7 +18,7 @@ pub trait ArithKind: Clone + Debug + Send + Sync + 'static {
 /// Use the type aliases [`crate::ModArithInstr`] / [`crate::Fp2ArithInstr`]
 /// rather than naming this type directly.
 #[derive(Debug, Clone)]
-pub struct FieldArithInstr<K: ArithKind> {
+pub(crate) struct FieldArithInstr<K: ArithKind> {
     _kind: PhantomData<K>,
     pub op: ModOp,
     pub rd_reg: Reg,
@@ -38,6 +38,69 @@ impl<K: ArithKind> FieldArithInstr<K> {
         modulus: Vec<u8>,
     ) -> Self {
         Self { _kind: PhantomData, op, rd_reg, rs1_reg, rs2_reg, num_limbs, modulus }
+    }
+}
+
+/// Generic IR node for field IS_EQ.
+/// Use the type alias [`crate::ModIsEqInstr`] rather than naming this type directly.
+#[derive(Debug, Clone)]
+pub(crate) struct FieldIsEqInstr<K: ArithKind> {
+    _kind: PhantomData<K>,
+    pub rd_reg: Reg,
+    pub rs1_reg: Reg,
+    pub rs2_reg: Reg,
+    pub num_limbs: u32,
+    pub modulus: Vec<u8>,
+}
+
+impl<K: ArithKind> FieldIsEqInstr<K> {
+    pub fn new(
+        rd_reg: Reg,
+        rs1_reg: Reg,
+        rs2_reg: Reg,
+        num_limbs: u32,
+        modulus: Vec<u8>,
+    ) -> Self {
+        Self { _kind: PhantomData, rd_reg, rs1_reg, rs2_reg, num_limbs, modulus }
+    }
+}
+
+impl<K: ArithKind> ExtInstr for FieldIsEqInstr<K> {
+    fn opname(&self) -> &str {
+        "iseq_opname"
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let rs1 = ctx.read_reg(self.rs1_reg);
+        let rs2 = ctx.read_reg(self.rs2_reg);
+        let prefix = K::c_prefix();
+        let known_suffix = detect_known_field(&self.modulus).and_then(K::known_suffix);
+        if let Some(suffix) = known_suffix {
+            let name = format!("rvr_ext_{prefix}_iseq_{suffix}");
+            let val = ctx.extern_call_expr("uint32_t", &name, &["state", &rs1, &rs2]);
+            ctx.write_reg(self.rd_reg, &val);
+        } else {
+            let mod_literal = format_c_byte_array(&self.modulus);
+            ctx.write_line("{");
+            ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
+            let name = format!("rvr_ext_{prefix}_iseq");
+            let num_limbs = format!("{}u", self.num_limbs);
+            let val = ctx.extern_call_expr(
+                "uint32_t",
+                &name,
+                &["state", &rs1, &rs2, &num_limbs, "mod_"],
+            );
+            ctx.write_reg(self.rd_reg, &val);
+            ctx.write_line("}");
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+
+    fn is_block_end(&self) -> bool {
+        false
     }
 }
 

--- a/extensions/algebra/rvr/src/common.rs
+++ b/extensions/algebra/rvr/src/common.rs
@@ -4,14 +4,32 @@ use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Reg};
 
 use crate::{detect_known_field, format_c_byte_array, KnownField, ModOp};
 
-/// Marker trait implemented by zero-sized types that parameterize
-/// [`FieldArithInstr`], supplying the C prefix and known-field suffix lookup.
-pub(crate) trait ArithKind: Clone + Debug + Send + Sync + 'static {
-    fn opname() -> &'static str;
+/// Base trait for zero-sized marker types that identify a field kind (modular
+/// or Fp2). Provides the C function prefix and known-field suffix lookup used
+/// by all three instruction families (arith, iseq, setup).
+pub(crate) trait FieldKind: Clone + Debug + Send + Sync + 'static {
     fn c_prefix() -> &'static str;
     /// Returns the C suffix for a known field, or `None` to fall through to the
     /// generic path.
     fn known_suffix(field: KnownField) -> Option<&'static str>;
+}
+
+/// Extension of [`FieldKind`] for the arithmetic instruction family. Adds the
+/// IR opname used by [`FieldArithInstr`].
+pub(crate) trait ArithKind: FieldKind {
+    fn opname() -> &'static str;
+}
+
+/// Extension of [`FieldKind`] for the setup instruction family. Adds the
+/// IR opname used by [`FieldSetupInstr`].
+pub(crate) trait SetupKind: FieldKind {
+    fn opname() -> &'static str;
+}
+
+/// Extension of [`FieldKind`] for the IS_EQ instruction family. Adds the
+/// IR opname used by [`FieldIsEqInstr`]. Not implemented for Fp2 — fp2 has no IS_EQ.
+pub(crate) trait IsEqKind: FieldKind {
+    fn opname() -> &'static str;
 }
 
 /// Generic IR node for field arithmetic (ADD, SUB, MUL, DIV).
@@ -44,7 +62,7 @@ impl<K: ArithKind> FieldArithInstr<K> {
 /// Generic IR node for field IS_EQ.
 /// Use the type alias [`crate::ModIsEqInstr`] rather than naming this type directly.
 #[derive(Debug, Clone)]
-pub(crate) struct FieldIsEqInstr<K: ArithKind> {
+pub(crate) struct FieldIsEqInstr<K: IsEqKind> {
     _kind: PhantomData<K>,
     pub rd_reg: Reg,
     pub rs1_reg: Reg,
@@ -53,7 +71,7 @@ pub(crate) struct FieldIsEqInstr<K: ArithKind> {
     pub modulus: Vec<u8>,
 }
 
-impl<K: ArithKind> FieldIsEqInstr<K> {
+impl<K: IsEqKind> FieldIsEqInstr<K> {
     pub fn new(
         rd_reg: Reg,
         rs1_reg: Reg,
@@ -65,9 +83,51 @@ impl<K: ArithKind> FieldIsEqInstr<K> {
     }
 }
 
-impl<K: ArithKind> ExtInstr for FieldIsEqInstr<K> {
+/// Generic IR node for field setup (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
+/// The C function name is derived from `K::c_prefix()` as `rvr_ext_{prefix}_setup`.
+/// Use the type aliases [`crate::ModSetupInstr`] / [`crate::Fp2SetupInstr`]
+/// rather than naming this type directly.
+#[derive(Debug, Clone)]
+pub(crate) struct FieldSetupInstr<K: SetupKind> {
+    _kind: PhantomData<K>,
+    pub rd_reg: Reg,
+    pub rs1_reg: Reg,
+    pub rs2_reg: Reg,
+    pub num_limbs: u32,
+}
+
+impl<K: SetupKind> FieldSetupInstr<K> {
+    pub fn new(rd_reg: Reg, rs1_reg: Reg, rs2_reg: Reg, num_limbs: u32) -> Self {
+        Self { _kind: PhantomData, rd_reg, rs1_reg, rs2_reg, num_limbs }
+    }
+}
+
+impl<K: SetupKind> ExtInstr for FieldSetupInstr<K> {
     fn opname(&self) -> &str {
-        "iseq_opname"
+        K::opname()
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let rd = ctx.read_reg(self.rd_reg);
+        let rs1 = ctx.read_reg(self.rs1_reg);
+        let rs2 = ctx.read_reg(self.rs2_reg);
+        let num_limbs = format!("{}u", self.num_limbs);
+        let name = format!("rvr_ext_{}_setup", K::c_prefix());
+        ctx.extern_call(&name, &["state", &rd, &rs1, &rs2, &num_limbs]);
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+
+    fn is_block_end(&self) -> bool {
+        false
+    }
+}
+
+impl<K: IsEqKind> ExtInstr for FieldIsEqInstr<K> {
+    fn opname(&self) -> &str {
+        K::opname()
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
@@ -93,46 +153,6 @@ impl<K: ArithKind> ExtInstr for FieldIsEqInstr<K> {
             ctx.write_reg(self.rd_reg, &val);
             ctx.write_line("}");
         }
-    }
-
-    fn clone_box(&self) -> Box<dyn ExtInstr> {
-        Box::new(self.clone())
-    }
-
-    fn is_block_end(&self) -> bool {
-        false
-    }
-}
-
-/// Generic IR node for field setup (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
-/// Use the type aliases [`crate::ModSetupInstr`] / [`crate::Fp2SetupInstr`]
-/// rather than naming this type directly.
-#[derive(Debug, Clone)]
-pub struct FieldSetupInstr {
-    c_fn: &'static str,
-    pub rd_reg: Reg,
-    pub rs1_reg: Reg,
-    pub rs2_reg: Reg,
-    pub num_limbs: u32,
-}
-
-impl FieldSetupInstr {
-    pub fn new(c_fn: &'static str, rd_reg: Reg, rs1_reg: Reg, rs2_reg: Reg, num_limbs: u32) -> Self {
-        Self { c_fn, rd_reg, rs1_reg, rs2_reg, num_limbs }
-    }
-}
-
-impl ExtInstr for FieldSetupInstr {
-    fn opname(&self) -> &str {
-        &self.c_fn["rvr_ext_".len()..]
-    }
-
-    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rd = ctx.read_reg(self.rd_reg);
-        let rs1 = ctx.read_reg(self.rs1_reg);
-        let rs2 = ctx.read_reg(self.rs2_reg);
-        let num_limbs = format!("{}u", self.num_limbs);
-        ctx.extern_call(self.c_fn, &["state", &rd, &rs1, &rs2, &num_limbs]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {

--- a/extensions/algebra/rvr/src/common.rs
+++ b/extensions/algebra/rvr/src/common.rs
@@ -41,6 +41,46 @@ impl<K: ArithKind> FieldArithInstr<K> {
     }
 }
 
+/// Generic IR node for field setup (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
+/// Use the type aliases [`crate::ModSetupInstr`] / [`crate::Fp2SetupInstr`]
+/// rather than naming this type directly.
+#[derive(Debug, Clone)]
+pub struct FieldSetupInstr {
+    c_fn: &'static str,
+    pub rd_reg: Reg,
+    pub rs1_reg: Reg,
+    pub rs2_reg: Reg,
+    pub num_limbs: u32,
+}
+
+impl FieldSetupInstr {
+    pub fn new(c_fn: &'static str, rd_reg: Reg, rs1_reg: Reg, rs2_reg: Reg, num_limbs: u32) -> Self {
+        Self { c_fn, rd_reg, rs1_reg, rs2_reg, num_limbs }
+    }
+}
+
+impl ExtInstr for FieldSetupInstr {
+    fn opname(&self) -> &str {
+        &self.c_fn["rvr_ext_".len()..]
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let rd = ctx.read_reg(self.rd_reg);
+        let rs1 = ctx.read_reg(self.rs1_reg);
+        let rs2 = ctx.read_reg(self.rs2_reg);
+        let num_limbs = format!("{}u", self.num_limbs);
+        ctx.extern_call(self.c_fn, &["state", &rd, &rs1, &rs2, &num_limbs]);
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+
+    fn is_block_end(&self) -> bool {
+        false
+    }
+}
+
 impl<K: ArithKind> ExtInstr for FieldArithInstr<K> {
     fn opname(&self) -> &str {
         K::opname()

--- a/extensions/algebra/rvr/src/common.rs
+++ b/extensions/algebra/rvr/src/common.rs
@@ -55,7 +55,15 @@ impl<K: ArithKind> FieldArithInstr<K> {
         num_limbs: u32,
         modulus: Vec<u8>,
     ) -> Self {
-        Self { _kind: PhantomData, op, rd_reg, rs1_reg, rs2_reg, num_limbs, modulus }
+        Self {
+            _kind: PhantomData,
+            op,
+            rd_reg,
+            rs1_reg,
+            rs2_reg,
+            num_limbs,
+            modulus,
+        }
     }
 }
 
@@ -72,14 +80,15 @@ pub(crate) struct FieldIsEqInstr<K: IsEqKind> {
 }
 
 impl<K: IsEqKind> FieldIsEqInstr<K> {
-    pub fn new(
-        rd_reg: Reg,
-        rs1_reg: Reg,
-        rs2_reg: Reg,
-        num_limbs: u32,
-        modulus: Vec<u8>,
-    ) -> Self {
-        Self { _kind: PhantomData, rd_reg, rs1_reg, rs2_reg, num_limbs, modulus }
+    pub fn new(rd_reg: Reg, rs1_reg: Reg, rs2_reg: Reg, num_limbs: u32, modulus: Vec<u8>) -> Self {
+        Self {
+            _kind: PhantomData,
+            rd_reg,
+            rs1_reg,
+            rs2_reg,
+            num_limbs,
+            modulus,
+        }
     }
 }
 
@@ -98,7 +107,13 @@ pub(crate) struct FieldSetupInstr<K: SetupKind> {
 
 impl<K: SetupKind> FieldSetupInstr<K> {
     pub fn new(rd_reg: Reg, rs1_reg: Reg, rs2_reg: Reg, num_limbs: u32) -> Self {
-        Self { _kind: PhantomData, rd_reg, rs1_reg, rs2_reg, num_limbs }
+        Self {
+            _kind: PhantomData,
+            rd_reg,
+            rs1_reg,
+            rs2_reg,
+            num_limbs,
+        }
     }
 }
 

--- a/extensions/algebra/rvr/src/field_arith.rs
+++ b/extensions/algebra/rvr/src/field_arith.rs
@@ -1,0 +1,77 @@
+use std::{fmt::Debug, marker::PhantomData};
+
+use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Reg};
+
+use crate::{detect_known_field, format_c_byte_array, KnownField, ModOp};
+
+/// Marker trait implemented by zero-sized types that parameterize
+/// [`FieldArithInstr`], supplying the C prefix and known-field suffix lookup.
+pub trait ArithKind: Clone + Debug + Send + Sync + 'static {
+    fn opname() -> &'static str;
+    fn c_prefix() -> &'static str;
+    /// Returns the C suffix for a known field, or `None` to fall through to the
+    /// generic path.
+    fn known_suffix(field: KnownField) -> Option<&'static str>;
+}
+
+/// Generic IR node for field arithmetic (ADD, SUB, MUL, DIV).
+/// Use the type aliases [`crate::ModArithInstr`] / [`crate::Fp2ArithInstr`]
+/// rather than naming this type directly.
+#[derive(Debug, Clone)]
+pub struct FieldArithInstr<K: ArithKind> {
+    _kind: PhantomData<K>,
+    pub op: ModOp,
+    pub rd_reg: Reg,
+    pub rs1_reg: Reg,
+    pub rs2_reg: Reg,
+    pub num_limbs: u32,
+    pub modulus: Vec<u8>,
+}
+
+impl<K: ArithKind> FieldArithInstr<K> {
+    pub fn new(
+        op: ModOp,
+        rd_reg: Reg,
+        rs1_reg: Reg,
+        rs2_reg: Reg,
+        num_limbs: u32,
+        modulus: Vec<u8>,
+    ) -> Self {
+        Self { _kind: PhantomData, op, rd_reg, rs1_reg, rs2_reg, num_limbs, modulus }
+    }
+}
+
+impl<K: ArithKind> ExtInstr for FieldArithInstr<K> {
+    fn opname(&self) -> &str {
+        K::opname()
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let rd = ctx.read_reg(self.rd_reg);
+        let rs1 = ctx.read_reg(self.rs1_reg);
+        let rs2 = ctx.read_reg(self.rs2_reg);
+        let op_name = self.op.c_name();
+        let prefix = K::c_prefix();
+        let known_suffix = detect_known_field(&self.modulus).and_then(K::known_suffix);
+        if let Some(suffix) = known_suffix {
+            let name = format!("rvr_ext_{prefix}_{op_name}_{suffix}");
+            ctx.extern_call(&name, &["state", &rd, &rs1, &rs2]);
+        } else {
+            let mod_literal = format_c_byte_array(&self.modulus);
+            ctx.write_line("{");
+            ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
+            let name = format!("rvr_ext_{prefix}_{op_name}");
+            let num_limbs = format!("{}u", self.num_limbs);
+            ctx.extern_call(&name, &["state", &rd, &rs1, &rs2, &num_limbs, "mod_"]);
+            ctx.write_line("}");
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+
+    fn is_block_end(&self) -> bool {
+        false
+    }
+}

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -8,7 +8,7 @@ use rvr_openvm_ir::{Instr, InstrAt, LiftedInstr};
 use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
-use crate::{pad_modulus, ArithKind, FieldArithInstr, FieldSetupInstr, KnownField, ModOp};
+use crate::{pad_modulus, ArithKind, FieldArithInstr, FieldKind, FieldSetupInstr, KnownField, ModOp, SetupKind};
 
 /// Per-modulus info for the Fp2 extension. Fp2 lifting never consults a
 /// non-QR, so we only carry the padded modulus and limb count.
@@ -34,10 +34,7 @@ fn make_modulus_info(modulus: BigUint) -> ModulusInfo {
 #[derive(Debug, Clone)]
 pub(crate) struct Fp2ArithKind;
 
-impl ArithKind for Fp2ArithKind {
-    fn opname() -> &'static str {
-        "fp2_arith"
-    }
+impl FieldKind for Fp2ArithKind {
     fn c_prefix() -> &'static str {
         "fp2"
     }
@@ -46,11 +43,23 @@ impl ArithKind for Fp2ArithKind {
     }
 }
 
+impl ArithKind for Fp2ArithKind {
+    fn opname() -> &'static str {
+        "fp2_arith"
+    }
+}
+
+impl SetupKind for Fp2ArithKind {
+    fn opname() -> &'static str {
+        "fp2_setup"
+    }
+}
+
 /// IR node for Fp2 arithmetic (ADD, SUB, MUL, DIV).
 pub(crate) type Fp2ArithInstr = FieldArithInstr<Fp2ArithKind>;
 
 /// IR node for Fp2 SETUP (SETUP_ADDSUB, SETUP_MULDIV).
-pub type Fp2SetupInstr = FieldSetupInstr;
+pub(crate) type Fp2SetupInstr = FieldSetupInstr<Fp2ArithKind>;
 
 // ── Fp2 extension ────────────────────────────────────────────────────────────
 
@@ -120,14 +129,14 @@ impl Fp2RvrExtension {
             x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(
                 Fp2ArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
-            x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(Fp2SetupInstr::new("rvr_ext_fp2_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
+            x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
             x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(
                 Fp2ArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
             x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(
                 Fp2ArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
-            x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(Fp2SetupInstr::new("rvr_ext_fp2_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
+            x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
             _ => return None,
         };
 

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -32,7 +32,7 @@ fn make_modulus_info(modulus: BigUint) -> ModulusInfo {
 // ── Fp2 arithmetic IR ────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
-pub struct Fp2ArithKind;
+pub(crate) struct Fp2ArithKind;
 
 impl ArithKind for Fp2ArithKind {
     fn opname() -> &'static str {
@@ -47,7 +47,7 @@ impl ArithKind for Fp2ArithKind {
 }
 
 /// IR node for Fp2 arithmetic (ADD, SUB, MUL, DIV).
-pub type Fp2ArithInstr = FieldArithInstr<Fp2ArithKind>;
+pub(crate) type Fp2ArithInstr = FieldArithInstr<Fp2ArithKind>;
 
 /// IR node for Fp2 SETUP (SETUP_ADDSUB, SETUP_MULDIV).
 pub type Fp2SetupInstr = FieldSetupInstr;

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -35,9 +35,9 @@ fn make_modulus_info(modulus: BigUint) -> ModulusInfo {
 // ── Fp2 arithmetic IR ────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
-pub(crate) struct Fp2ArithKind;
+pub(crate) struct Fp2Kind;
 
-impl FieldKind for Fp2ArithKind {
+impl FieldKind for Fp2Kind {
     fn c_prefix() -> &'static str {
         "fp2"
     }
@@ -46,23 +46,23 @@ impl FieldKind for Fp2ArithKind {
     }
 }
 
-impl ArithKind for Fp2ArithKind {
+impl ArithKind for Fp2Kind {
     fn opname() -> &'static str {
         "fp2_arith"
     }
 }
 
-impl SetupKind for Fp2ArithKind {
+impl SetupKind for Fp2Kind {
     fn opname() -> &'static str {
         "fp2_setup"
     }
 }
 
 /// IR node for Fp2 arithmetic (ADD, SUB, MUL, DIV).
-pub(crate) type Fp2ArithInstr = FieldArithInstr<Fp2ArithKind>;
+pub(crate) type Fp2ArithInstr = FieldArithInstr<Fp2Kind>;
 
 /// IR node for Fp2 SETUP (SETUP_ADDSUB, SETUP_MULDIV).
-pub(crate) type Fp2SetupInstr = FieldSetupInstr<Fp2ArithKind>;
+pub(crate) type Fp2SetupInstr = FieldSetupInstr<Fp2Kind>;
 
 // ── Fp2 extension ────────────────────────────────────────────────────────────
 

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -4,11 +4,11 @@ use num_bigint::BigUint;
 use openvm_algebra_transpiler::Fp2Opcode;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
+use rvr_openvm_ir::{Instr, InstrAt, LiftedInstr};
 use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
-use crate::{pad_modulus, ArithKind, FieldArithInstr, KnownField, ModOp};
+use crate::{pad_modulus, ArithKind, FieldArithInstr, FieldSetupInstr, KnownField, ModOp};
 
 /// Per-modulus info for the Fp2 extension. Fp2 lifting never consults a
 /// non-QR, so we only carry the padded modulus and limb count.
@@ -50,35 +50,7 @@ impl ArithKind for Fp2ArithKind {
 pub type Fp2ArithInstr = FieldArithInstr<Fp2ArithKind>;
 
 /// IR node for Fp2 SETUP (SETUP_ADDSUB, SETUP_MULDIV).
-#[derive(Debug, Clone)]
-pub struct Fp2SetupInstr {
-    pub rd_reg: Reg,
-    pub rs1_reg: Reg,
-    pub rs2_reg: Reg,
-    pub num_limbs: u32,
-}
-
-impl ExtInstr for Fp2SetupInstr {
-    fn opname(&self) -> &str {
-        "fp2_setup"
-    }
-
-    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rd = ctx.read_reg(self.rd_reg);
-        let rs1 = ctx.read_reg(self.rs1_reg);
-        let rs2 = ctx.read_reg(self.rs2_reg);
-        let num_limbs = format!("{}u", self.num_limbs);
-        ctx.extern_call("rvr_ext_fp2_setup", &["state", &rd, &rs1, &rs2, &num_limbs]);
-    }
-
-    fn clone_box(&self) -> Box<dyn ExtInstr> {
-        Box::new(self.clone())
-    }
-
-    fn is_block_end(&self) -> bool {
-        false
-    }
-}
+pub type Fp2SetupInstr = FieldSetupInstr;
 
 // ── Fp2 extension ────────────────────────────────────────────────────────────
 
@@ -148,24 +120,14 @@ impl Fp2RvrExtension {
             x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(
                 Fp2ArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
-            x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(Fp2SetupInstr {
-                rd_reg,
-                rs1_reg,
-                rs2_reg,
-                num_limbs: info.num_limbs,
-            })),
+            x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(Fp2SetupInstr::new("rvr_ext_fp2_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
             x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(
                 Fp2ArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
             x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(
                 Fp2ArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
-            x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(Fp2SetupInstr {
-                rd_reg,
-                rs1_reg,
-                rs2_reg,
-                num_limbs: info.num_limbs,
-            })),
+            x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(Fp2SetupInstr::new("rvr_ext_fp2_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
             _ => return None,
         };
 

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -8,7 +8,7 @@ use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
-use crate::{detect_known_field, format_c_byte_array, pad_modulus, ModOp};
+use crate::{pad_modulus, ArithKind, FieldArithInstr, KnownField, ModOp};
 
 /// Per-modulus info for the Fp2 extension. Fp2 lifting never consults a
 /// non-QR, so we only carry the padded modulus and limb count.
@@ -31,50 +31,23 @@ fn make_modulus_info(modulus: BigUint) -> ModulusInfo {
 
 // ── Fp2 arithmetic IR ────────────────────────────────────────────────────────
 
-/// IR node for Fp2 arithmetic (ADD, SUB, MUL, DIV).
 #[derive(Debug, Clone)]
-pub struct Fp2ArithInstr {
-    pub op: ModOp,
-    pub rd_reg: Reg,
-    pub rs1_reg: Reg,
-    pub rs2_reg: Reg,
-    pub num_limbs: u32,
-    pub modulus: Vec<u8>,
-}
+pub struct Fp2ArithKind;
 
-impl ExtInstr for Fp2ArithInstr {
-    fn opname(&self) -> &str {
+impl ArithKind for Fp2ArithKind {
+    fn opname() -> &'static str {
         "fp2_arith"
     }
-
-    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rd = ctx.read_reg(self.rd_reg);
-        let rs1 = ctx.read_reg(self.rs1_reg);
-        let rs2 = ctx.read_reg(self.rs2_reg);
-        let op_name = self.op.c_name();
-        let fp2_suffix = detect_known_field(&self.modulus).and_then(|f| f.fp2_c_suffix());
-        if let Some(suffix) = fp2_suffix {
-            let name = format!("rvr_ext_fp2_{op_name}_{suffix}");
-            ctx.extern_call(&name, &["state", &rd, &rs1, &rs2]);
-        } else {
-            let mod_literal = format_c_byte_array(&self.modulus);
-            ctx.write_line("{");
-            ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
-            let name = format!("rvr_ext_fp2_{op_name}");
-            let num_limbs = format!("{}u", self.num_limbs);
-            ctx.extern_call(&name, &["state", &rd, &rs1, &rs2, &num_limbs, "mod_"]);
-            ctx.write_line("}");
-        }
+    fn c_prefix() -> &'static str {
+        "fp2"
     }
-
-    fn clone_box(&self) -> Box<dyn ExtInstr> {
-        Box::new(self.clone())
-    }
-
-    fn is_block_end(&self) -> bool {
-        false
+    fn known_suffix(field: KnownField) -> Option<&'static str> {
+        field.fp2_c_suffix()
     }
 }
+
+/// IR node for Fp2 arithmetic (ADD, SUB, MUL, DIV).
+pub type Fp2ArithInstr = FieldArithInstr<Fp2ArithKind>;
 
 /// IR node for Fp2 SETUP (SETUP_ADDSUB, SETUP_MULDIV).
 #[derive(Debug, Clone)]
@@ -169,44 +142,24 @@ impl Fp2RvrExtension {
         let rs2_reg = decode_reg(insn.c);
 
         let instr: Instr = match local {
-            x if x == Fp2Opcode::ADD as usize => Instr::Ext(Box::new(Fp2ArithInstr {
-                op: ModOp::Add,
-                rd_reg,
-                rs1_reg,
-                rs2_reg,
-                num_limbs: info.num_limbs,
-                modulus: info.modulus_bytes.clone(),
-            })),
-            x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(Fp2ArithInstr {
-                op: ModOp::Sub,
-                rd_reg,
-                rs1_reg,
-                rs2_reg,
-                num_limbs: info.num_limbs,
-                modulus: info.modulus_bytes.clone(),
-            })),
+            x if x == Fp2Opcode::ADD as usize => Instr::Ext(Box::new(
+                Fp2ArithInstr::new(ModOp::Add, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
+            x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(
+                Fp2ArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
             x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(Fp2SetupInstr {
                 rd_reg,
                 rs1_reg,
                 rs2_reg,
                 num_limbs: info.num_limbs,
             })),
-            x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(Fp2ArithInstr {
-                op: ModOp::Mul,
-                rd_reg,
-                rs1_reg,
-                rs2_reg,
-                num_limbs: info.num_limbs,
-                modulus: info.modulus_bytes.clone(),
-            })),
-            x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(Fp2ArithInstr {
-                op: ModOp::Div,
-                rd_reg,
-                rs1_reg,
-                rs2_reg,
-                num_limbs: info.num_limbs,
-                modulus: info.modulus_bytes.clone(),
-            })),
+            x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(
+                Fp2ArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
+            x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(
+                Fp2ArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
             x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(Fp2SetupInstr {
                 rd_reg,
                 rs1_reg,

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -8,7 +8,7 @@ use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
-use crate::{detect_known_field, format_c_byte_array, ModOp};
+use crate::{detect_known_field, format_c_byte_array, pad_modulus, ModOp};
 
 /// Per-modulus info for the Fp2 extension. Fp2 lifting never consults a
 /// non-QR, so we only carry the padded modulus and limb count.
@@ -22,14 +22,7 @@ fn make_moduli(moduli: Vec<BigUint>) -> Vec<ModulusInfo> {
 }
 
 fn make_modulus_info(modulus: BigUint) -> ModulusInfo {
-    let bytes = modulus.bits().div_ceil(8) as usize;
-    assert!(
-        bytes <= 48,
-        "modulus exceeds maximum supported size of 384 bits"
-    );
-    let num_limbs = if bytes <= 32 { 32u32 } else { 48u32 };
-    let mut modulus_bytes = modulus.to_bytes_le();
-    modulus_bytes.resize(num_limbs as usize, 0);
+    let (modulus_bytes, num_limbs) = pad_modulus(&modulus);
     ModulusInfo {
         modulus_bytes,
         num_limbs,

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -8,7 +8,10 @@ use rvr_openvm_ir::{Instr, InstrAt, LiftedInstr};
 use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
-use crate::{pad_modulus, ArithKind, FieldArithInstr, FieldKind, FieldSetupInstr, KnownField, ModOp, SetupKind};
+use crate::{
+    pad_modulus, ArithKind, FieldArithInstr, FieldKind, FieldSetupInstr, KnownField, ModOp,
+    SetupKind,
+};
 
 /// Per-modulus info for the Fp2 extension. Fp2 lifting never consults a
 /// non-QR, so we only carry the padded modulus and limb count.
@@ -122,23 +125,48 @@ impl Fp2RvrExtension {
         let rs1_reg = decode_reg(insn.b);
         let rs2_reg = decode_reg(insn.c);
 
-        let instr: Instr = match local {
-            x if x == Fp2Opcode::ADD as usize => Instr::Ext(Box::new(
-                Fp2ArithInstr::new(ModOp::Add, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(
-                Fp2ArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
-            x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(
-                Fp2ArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(
-                Fp2ArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs))),
-            _ => return None,
-        };
+        let instr: Instr =
+            match local {
+                x if x == Fp2Opcode::ADD as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                    ModOp::Add,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                ))),
+                x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                    ModOp::Sub,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                ))),
+                x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(
+                    Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
+                )),
+                x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                    ModOp::Mul,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                ))),
+                x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                    ModOp::Div,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                ))),
+                x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(
+                    Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
+                )),
+                _ => return None,
+            };
 
         Some(LiftedInstr::Body(InstrAt {
             pc,

--- a/extensions/algebra/rvr/src/lib.rs
+++ b/extensions/algebra/rvr/src/lib.rs
@@ -6,14 +6,18 @@
 //! (modular + phantoms; ships the lift-time C and libsecp256k1 inputs for
 //! k256) and [`Fp2RvrExtension`] (fp2 ops only; Rust-only).
 
+mod field_arith;
 mod fp2;
 mod modular;
 
-pub use fp2::{Fp2ArithInstr, Fp2RvrExtension, Fp2SetupInstr};
-pub use modular::{
-    HintNonQrInstr, HintSqrtInstr, ModArithInstr, ModIsEqInstr, ModSetupInstr, ModularRvrExtension,
-};
 use num_bigint::BigUint;
+
+pub use field_arith::{ArithKind, FieldArithInstr};
+pub use fp2::{Fp2ArithInstr, Fp2ArithKind, Fp2RvrExtension, Fp2SetupInstr};
+pub use modular::{
+    HintNonQrInstr, HintSqrtInstr, ModArithInstr, ModArithKind, ModIsEqInstr, ModSetupInstr,
+    ModularRvrExtension,
+};
 
 /// Zero-pad `modulus` to the canonical limb boundary (32 or 48 bytes).
 ///
@@ -58,7 +62,7 @@ impl ModOp {
 
 /// Known field types that have optimized native FFI implementations.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum KnownField {
+pub enum KnownField {
     K256Coord,
     K256Scalar,
     P256Coord,

--- a/extensions/algebra/rvr/src/lib.rs
+++ b/extensions/algebra/rvr/src/lib.rs
@@ -12,10 +12,9 @@ mod modular;
 
 use num_bigint::BigUint;
 
-pub(crate) use common::{ArithKind, FieldArithInstr, FieldIsEqInstr};
-pub use common::FieldSetupInstr;
-pub use fp2::{Fp2RvrExtension, Fp2SetupInstr};
-pub use modular::{HintNonQrInstr, HintSqrtInstr, ModSetupInstr, ModularRvrExtension};
+pub(crate) use common::{ArithKind, FieldArithInstr, FieldIsEqInstr, FieldKind, FieldSetupInstr, IsEqKind, SetupKind};
+pub use fp2::Fp2RvrExtension;
+pub use modular::{HintNonQrInstr, HintSqrtInstr, ModularRvrExtension};
 
 /// Zero-pad `modulus` to the canonical limb boundary (32 or 48 bytes).
 ///

--- a/extensions/algebra/rvr/src/lib.rs
+++ b/extensions/algebra/rvr/src/lib.rs
@@ -12,12 +12,10 @@ mod modular;
 
 use num_bigint::BigUint;
 
-pub use common::{ArithKind, FieldArithInstr, FieldSetupInstr};
-pub use fp2::{Fp2ArithInstr, Fp2ArithKind, Fp2RvrExtension, Fp2SetupInstr};
-pub use modular::{
-    HintNonQrInstr, HintSqrtInstr, ModArithInstr, ModArithKind, ModIsEqInstr, ModSetupInstr,
-    ModularRvrExtension,
-};
+pub(crate) use common::{ArithKind, FieldArithInstr, FieldIsEqInstr};
+pub use common::FieldSetupInstr;
+pub use fp2::{Fp2RvrExtension, Fp2SetupInstr};
+pub use modular::{HintNonQrInstr, HintSqrtInstr, ModSetupInstr, ModularRvrExtension};
 
 /// Zero-pad `modulus` to the canonical limb boundary (32 or 48 bytes).
 ///
@@ -62,7 +60,7 @@ impl ModOp {
 
 /// Known field types that have optimized native FFI implementations.
 #[derive(Debug, Clone, Copy)]
-pub enum KnownField {
+pub(crate) enum KnownField {
     K256Coord,
     K256Scalar,
     P256Coord,

--- a/extensions/algebra/rvr/src/lib.rs
+++ b/extensions/algebra/rvr/src/lib.rs
@@ -10,11 +10,12 @@ mod common;
 mod fp2;
 mod modular;
 
-use num_bigint::BigUint;
-
-pub(crate) use common::{ArithKind, FieldArithInstr, FieldIsEqInstr, FieldKind, FieldSetupInstr, IsEqKind, SetupKind};
+pub(crate) use common::{
+    ArithKind, FieldArithInstr, FieldIsEqInstr, FieldKind, FieldSetupInstr, IsEqKind, SetupKind,
+};
 pub use fp2::Fp2RvrExtension;
 pub use modular::{HintNonQrInstr, HintSqrtInstr, ModularRvrExtension};
+use num_bigint::BigUint;
 
 /// Zero-pad `modulus` to the canonical limb boundary (32 or 48 bytes).
 ///

--- a/extensions/algebra/rvr/src/lib.rs
+++ b/extensions/algebra/rvr/src/lib.rs
@@ -13,6 +13,22 @@ pub use fp2::{Fp2ArithInstr, Fp2RvrExtension, Fp2SetupInstr};
 pub use modular::{
     HintNonQrInstr, HintSqrtInstr, ModArithInstr, ModIsEqInstr, ModSetupInstr, ModularRvrExtension,
 };
+use num_bigint::BigUint;
+
+/// Zero-pad `modulus` to the canonical limb boundary (32 or 48 bytes).
+///
+/// Returns `(padded_bytes_le, num_limbs)`. Panics if the modulus exceeds 384 bits.
+fn pad_modulus(modulus: &BigUint) -> (Vec<u8>, u32) {
+    let bytes = modulus.bits().div_ceil(8) as usize;
+    assert!(
+        bytes <= 48,
+        "modulus exceeds maximum supported size of 384 bits"
+    );
+    let num_limbs = if bytes <= 32 { 32u32 } else { 48u32 };
+    let mut modulus_bytes = modulus.to_bytes_le();
+    modulus_bytes.resize(num_limbs as usize, 0);
+    (modulus_bytes, num_limbs)
+}
 
 // ── Modular arithmetic operations ────────────────────────────────────────────
 

--- a/extensions/algebra/rvr/src/lib.rs
+++ b/extensions/algebra/rvr/src/lib.rs
@@ -6,13 +6,13 @@
 //! (modular + phantoms; ships the lift-time C and libsecp256k1 inputs for
 //! k256) and [`Fp2RvrExtension`] (fp2 ops only; Rust-only).
 
-mod field_arith;
+mod common;
 mod fp2;
 mod modular;
 
 use num_bigint::BigUint;
 
-pub use field_arith::{ArithKind, FieldArithInstr};
+pub use common::{ArithKind, FieldArithInstr, FieldSetupInstr};
 pub use fp2::{Fp2ArithInstr, Fp2ArithKind, Fp2RvrExtension, Fp2SetupInstr};
 pub use modular::{
     HintNonQrInstr, HintSqrtInstr, ModArithInstr, ModArithKind, ModIsEqInstr, ModSetupInstr,

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -12,8 +12,8 @@ use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
 use crate::{
-    detect_known_field, format_c_byte_array, pad_modulus, ArithKind, FieldArithInstr, KnownField,
-    ModOp,
+    detect_known_field, format_c_byte_array, pad_modulus, ArithKind, FieldArithInstr,
+    FieldSetupInstr, KnownField, ModOp,
 };
 
 include!(concat!(env!("OUT_DIR"), "/secp256k1_files.rs"));
@@ -117,35 +117,7 @@ impl ExtInstr for ModIsEqInstr {
 }
 
 /// IR node for modular SETUP (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
-#[derive(Debug, Clone)]
-pub struct ModSetupInstr {
-    pub rd_reg: Reg,
-    pub rs1_reg: Reg,
-    pub rs2_reg: Reg,
-    pub num_limbs: u32,
-}
-
-impl ExtInstr for ModSetupInstr {
-    fn opname(&self) -> &str {
-        "mod_setup"
-    }
-
-    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rd = ctx.read_reg(self.rd_reg);
-        let rs1 = ctx.read_reg(self.rs1_reg);
-        let rs2 = ctx.read_reg(self.rs2_reg);
-        let num_limbs = format!("{}u", self.num_limbs);
-        ctx.extern_call("rvr_ext_mod_setup", &["state", &rd, &rs1, &rs2, &num_limbs]);
-    }
-
-    fn clone_box(&self) -> Box<dyn ExtInstr> {
-        Box::new(self.clone())
-    }
-
-    fn is_block_end(&self) -> bool {
-        false
-    }
-}
+pub type ModSetupInstr = FieldSetupInstr;
 
 // ── Phantom instructions (HintNonQr, HintSqrt) ──────────────────────────────
 
@@ -341,7 +313,7 @@ impl ModularRvrExtension {
                 ModArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
             x if x == Rv64ModularArithmeticOpcode::SETUP_ADDSUB as usize => {
-                Instr::Ext(Box::new(ModSetupInstr { rd_reg, rs1_reg, rs2_reg, num_limbs: info.num_limbs }))
+                Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
             }
             x if x == Rv64ModularArithmeticOpcode::MUL as usize => Instr::Ext(Box::new(
                 ModArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
@@ -350,7 +322,7 @@ impl ModularRvrExtension {
                 ModArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
             x if x == Rv64ModularArithmeticOpcode::SETUP_MULDIV as usize => {
-                Instr::Ext(Box::new(ModSetupInstr { rd_reg, rs1_reg, rs2_reg, num_limbs: info.num_limbs }))
+                Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
             }
             x if x == Rv64ModularArithmeticOpcode::IS_EQ as usize => {
                 Instr::Ext(Box::new(ModIsEqInstr {
@@ -362,7 +334,7 @@ impl ModularRvrExtension {
                 }))
             }
             x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => {
-                Instr::Ext(Box::new(ModSetupInstr { rd_reg, rs1_reg, rs2_reg, num_limbs: info.num_limbs }))
+                Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
             }
             _ => return None,
         };

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -12,8 +12,8 @@ use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
 use crate::{
-    format_c_byte_array, pad_modulus, ArithKind, FieldArithInstr, FieldIsEqInstr, FieldSetupInstr,
-    KnownField, ModOp,
+    format_c_byte_array, pad_modulus, ArithKind, FieldArithInstr, FieldIsEqInstr, FieldKind,
+    FieldSetupInstr, IsEqKind, KnownField, ModOp, SetupKind,
 };
 
 include!(concat!(env!("OUT_DIR"), "/secp256k1_files.rs"));
@@ -54,15 +54,30 @@ fn make_modulus_info(modulus: &BigUint, rng: &mut StdRng) -> ModulusInfo {
 #[derive(Debug, Clone)]
 pub(crate) struct ModArithKind;
 
-impl ArithKind for ModArithKind {
-    fn opname() -> &'static str {
-        "mod_arith"
-    }
+impl FieldKind for ModArithKind {
     fn c_prefix() -> &'static str {
         "mod"
     }
     fn known_suffix(field: KnownField) -> Option<&'static str> {
         Some(field.c_suffix())
+    }
+}
+
+impl ArithKind for ModArithKind {
+    fn opname() -> &'static str {
+        "mod_arith"
+    }
+}
+
+impl SetupKind for ModArithKind {
+    fn opname() -> &'static str {
+        "mod_setup"
+    }
+}
+
+impl IsEqKind for ModArithKind {
+    fn opname() -> &'static str {
+        "mod_iseq"
     }
 }
 
@@ -73,7 +88,7 @@ pub(crate) type ModArithInstr = FieldArithInstr<ModArithKind>;
 pub(crate) type ModIsEqInstr = FieldIsEqInstr<ModArithKind>;
 
 /// IR node for modular SETUP (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
-pub type ModSetupInstr = FieldSetupInstr;
+pub(crate) type ModSetupInstr = FieldSetupInstr<ModArithKind>;
 
 // ── Phantom instructions (HintNonQr, HintSqrt) ──────────────────────────────
 
@@ -269,7 +284,7 @@ impl ModularRvrExtension {
                 ModArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
             x if x == Rv64ModularArithmeticOpcode::SETUP_ADDSUB as usize => {
-                Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
+                Instr::Ext(Box::new(ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
             }
             x if x == Rv64ModularArithmeticOpcode::MUL as usize => Instr::Ext(Box::new(
                 ModArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
@@ -278,7 +293,7 @@ impl ModularRvrExtension {
                 ModArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
             )),
             x if x == Rv64ModularArithmeticOpcode::SETUP_MULDIV as usize => {
-                Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
+                Instr::Ext(Box::new(ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
             }
             x if x == Rv64ModularArithmeticOpcode::IS_EQ as usize => {
                 Instr::Ext(Box::new(ModIsEqInstr::new(
@@ -290,7 +305,7 @@ impl ModularRvrExtension {
                 )))
             }
             x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => {
-                Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
+                Instr::Ext(Box::new(ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
             }
             _ => return None,
         };

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -11,7 +11,7 @@ use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
-use crate::{detect_known_field, format_c_byte_array, ModOp};
+use crate::{detect_known_field, format_c_byte_array, pad_modulus, ModOp};
 
 include!(concat!(env!("OUT_DIR"), "/secp256k1_files.rs"));
 
@@ -35,14 +35,7 @@ fn make_moduli(moduli: Vec<BigUint>) -> Vec<ModulusInfo> {
 }
 
 fn make_modulus_info(modulus: &BigUint, rng: &mut StdRng) -> ModulusInfo {
-    let bytes = modulus.bits().div_ceil(8) as usize;
-    assert!(
-        bytes <= 48,
-        "modulus exceeds maximum supported size of 384 bits"
-    );
-    let num_limbs = if bytes <= 32 { 32u32 } else { 48u32 };
-    let mut modulus_bytes = modulus.to_bytes_le();
-    modulus_bytes.resize(num_limbs as usize, 0);
+    let (modulus_bytes, num_limbs) = pad_modulus(modulus);
     let non_qr = find_non_qr(modulus, rng);
     let mut non_qr_bytes = non_qr.to_bytes_le();
     non_qr_bytes.resize(num_limbs as usize, 0);

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -277,24 +277,52 @@ impl ModularRvrExtension {
         let rs2_reg = decode_reg(insn.c);
 
         let instr: Instr = match local {
-            x if x == Rv64ModularArithmeticOpcode::ADD as usize => Instr::Ext(Box::new(
-                ModArithInstr::new(ModOp::Add, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Rv64ModularArithmeticOpcode::SUB as usize => Instr::Ext(Box::new(
-                ModArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Rv64ModularArithmeticOpcode::SETUP_ADDSUB as usize => {
-                Instr::Ext(Box::new(ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
+            x if x == Rv64ModularArithmeticOpcode::ADD as usize => {
+                Instr::Ext(Box::new(ModArithInstr::new(
+                    ModOp::Add,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                )))
             }
-            x if x == Rv64ModularArithmeticOpcode::MUL as usize => Instr::Ext(Box::new(
-                ModArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Rv64ModularArithmeticOpcode::DIV as usize => Instr::Ext(Box::new(
-                ModArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
-            )),
-            x if x == Rv64ModularArithmeticOpcode::SETUP_MULDIV as usize => {
-                Instr::Ext(Box::new(ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
+            x if x == Rv64ModularArithmeticOpcode::SUB as usize => {
+                Instr::Ext(Box::new(ModArithInstr::new(
+                    ModOp::Sub,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                )))
             }
+            x if x == Rv64ModularArithmeticOpcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(
+                ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
+            )),
+            x if x == Rv64ModularArithmeticOpcode::MUL as usize => {
+                Instr::Ext(Box::new(ModArithInstr::new(
+                    ModOp::Mul,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                )))
+            }
+            x if x == Rv64ModularArithmeticOpcode::DIV as usize => {
+                Instr::Ext(Box::new(ModArithInstr::new(
+                    ModOp::Div,
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                )))
+            }
+            x if x == Rv64ModularArithmeticOpcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(
+                ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
+            )),
             x if x == Rv64ModularArithmeticOpcode::IS_EQ as usize => {
                 Instr::Ext(Box::new(ModIsEqInstr::new(
                     rd_reg,
@@ -304,9 +332,9 @@ impl ModularRvrExtension {
                     info.modulus_bytes.clone(),
                 )))
             }
-            x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => {
-                Instr::Ext(Box::new(ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
-            }
+            x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => Instr::Ext(Box::new(
+                ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
+            )),
             _ => return None,
         };
 

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -11,7 +11,10 @@ use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
-use crate::{detect_known_field, format_c_byte_array, pad_modulus, ModOp};
+use crate::{
+    detect_known_field, format_c_byte_array, pad_modulus, ArithKind, FieldArithInstr, KnownField,
+    ModOp,
+};
 
 include!(concat!(env!("OUT_DIR"), "/secp256k1_files.rs"));
 
@@ -48,50 +51,23 @@ fn make_modulus_info(modulus: &BigUint, rng: &mut StdRng) -> ModulusInfo {
 
 // ── Modular arithmetic IR ────────────────────────────────────────────────────
 
-/// IR node for modular arithmetic (ADD, SUB, MUL, DIV).
 #[derive(Debug, Clone)]
-pub struct ModArithInstr {
-    pub op: ModOp,
-    pub rd_reg: Reg,
-    pub rs1_reg: Reg,
-    pub rs2_reg: Reg,
-    pub num_limbs: u32,
-    pub modulus: Vec<u8>,
-}
+pub struct ModArithKind;
 
-impl ExtInstr for ModArithInstr {
-    fn opname(&self) -> &str {
+impl ArithKind for ModArithKind {
+    fn opname() -> &'static str {
         "mod_arith"
     }
-
-    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rd = ctx.read_reg(self.rd_reg);
-        let rs1 = ctx.read_reg(self.rs1_reg);
-        let rs2 = ctx.read_reg(self.rs2_reg);
-        let op_name = self.op.c_name();
-        if let Some(field) = detect_known_field(&self.modulus) {
-            let suffix = field.c_suffix();
-            let name = format!("rvr_ext_mod_{op_name}_{suffix}");
-            ctx.extern_call(&name, &["state", &rd, &rs1, &rs2]);
-        } else {
-            let mod_literal = format_c_byte_array(&self.modulus);
-            ctx.write_line("{");
-            ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
-            let name = format!("rvr_ext_mod_{op_name}");
-            let num_limbs = format!("{}u", self.num_limbs);
-            ctx.extern_call(&name, &["state", &rd, &rs1, &rs2, &num_limbs, "mod_"]);
-            ctx.write_line("}");
-        }
+    fn c_prefix() -> &'static str {
+        "mod"
     }
-
-    fn clone_box(&self) -> Box<dyn ExtInstr> {
-        Box::new(self.clone())
-    }
-
-    fn is_block_end(&self) -> bool {
-        false
+    fn known_suffix(field: KnownField) -> Option<&'static str> {
+        Some(field.c_suffix())
     }
 }
+
+/// IR node for modular arithmetic (ADD, SUB, MUL, DIV).
+pub type ModArithInstr = FieldArithInstr<ModArithKind>;
 
 /// IR node for modular IS_EQ.
 #[derive(Debug, Clone)]
@@ -358,61 +334,23 @@ impl ModularRvrExtension {
         let rs2_reg = decode_reg(insn.c);
 
         let instr: Instr = match local {
-            x if x == Rv64ModularArithmeticOpcode::ADD as usize => {
-                Instr::Ext(Box::new(ModArithInstr {
-                    op: ModOp::Add,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    num_limbs: info.num_limbs,
-                    modulus: info.modulus_bytes.clone(),
-                }))
-            }
-            x if x == Rv64ModularArithmeticOpcode::SUB as usize => {
-                Instr::Ext(Box::new(ModArithInstr {
-                    op: ModOp::Sub,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    num_limbs: info.num_limbs,
-                    modulus: info.modulus_bytes.clone(),
-                }))
-            }
+            x if x == Rv64ModularArithmeticOpcode::ADD as usize => Instr::Ext(Box::new(
+                ModArithInstr::new(ModOp::Add, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
+            x if x == Rv64ModularArithmeticOpcode::SUB as usize => Instr::Ext(Box::new(
+                ModArithInstr::new(ModOp::Sub, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
             x if x == Rv64ModularArithmeticOpcode::SETUP_ADDSUB as usize => {
-                Instr::Ext(Box::new(ModSetupInstr {
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    num_limbs: info.num_limbs,
-                }))
+                Instr::Ext(Box::new(ModSetupInstr { rd_reg, rs1_reg, rs2_reg, num_limbs: info.num_limbs }))
             }
-            x if x == Rv64ModularArithmeticOpcode::MUL as usize => {
-                Instr::Ext(Box::new(ModArithInstr {
-                    op: ModOp::Mul,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    num_limbs: info.num_limbs,
-                    modulus: info.modulus_bytes.clone(),
-                }))
-            }
-            x if x == Rv64ModularArithmeticOpcode::DIV as usize => {
-                Instr::Ext(Box::new(ModArithInstr {
-                    op: ModOp::Div,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    num_limbs: info.num_limbs,
-                    modulus: info.modulus_bytes.clone(),
-                }))
-            }
+            x if x == Rv64ModularArithmeticOpcode::MUL as usize => Instr::Ext(Box::new(
+                ModArithInstr::new(ModOp::Mul, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
+            x if x == Rv64ModularArithmeticOpcode::DIV as usize => Instr::Ext(Box::new(
+                ModArithInstr::new(ModOp::Div, rd_reg, rs1_reg, rs2_reg, info.num_limbs, info.modulus_bytes.clone()),
+            )),
             x if x == Rv64ModularArithmeticOpcode::SETUP_MULDIV as usize => {
-                Instr::Ext(Box::new(ModSetupInstr {
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    num_limbs: info.num_limbs,
-                }))
+                Instr::Ext(Box::new(ModSetupInstr { rd_reg, rs1_reg, rs2_reg, num_limbs: info.num_limbs }))
             }
             x if x == Rv64ModularArithmeticOpcode::IS_EQ as usize => {
                 Instr::Ext(Box::new(ModIsEqInstr {
@@ -424,12 +362,7 @@ impl ModularRvrExtension {
                 }))
             }
             x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => {
-                Instr::Ext(Box::new(ModSetupInstr {
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    num_limbs: info.num_limbs,
-                }))
+                Instr::Ext(Box::new(ModSetupInstr { rd_reg, rs1_reg, rs2_reg, num_limbs: info.num_limbs }))
             }
             _ => return None,
         };

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -12,8 +12,8 @@ use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
 use strum::EnumCount;
 
 use crate::{
-    detect_known_field, format_c_byte_array, pad_modulus, ArithKind, FieldArithInstr,
-    FieldSetupInstr, KnownField, ModOp,
+    format_c_byte_array, pad_modulus, ArithKind, FieldArithInstr, FieldIsEqInstr, FieldSetupInstr,
+    KnownField, ModOp,
 };
 
 include!(concat!(env!("OUT_DIR"), "/secp256k1_files.rs"));
@@ -52,7 +52,7 @@ fn make_modulus_info(modulus: &BigUint, rng: &mut StdRng) -> ModulusInfo {
 // ── Modular arithmetic IR ────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
-pub struct ModArithKind;
+pub(crate) struct ModArithKind;
 
 impl ArithKind for ModArithKind {
     fn opname() -> &'static str {
@@ -67,54 +67,10 @@ impl ArithKind for ModArithKind {
 }
 
 /// IR node for modular arithmetic (ADD, SUB, MUL, DIV).
-pub type ModArithInstr = FieldArithInstr<ModArithKind>;
+pub(crate) type ModArithInstr = FieldArithInstr<ModArithKind>;
 
 /// IR node for modular IS_EQ.
-#[derive(Debug, Clone)]
-pub struct ModIsEqInstr {
-    pub rd_reg: Reg,
-    pub rs1_reg: Reg,
-    pub rs2_reg: Reg,
-    pub num_limbs: u32,
-    pub modulus: Vec<u8>,
-}
-
-impl ExtInstr for ModIsEqInstr {
-    fn opname(&self) -> &str {
-        "mod_iseq"
-    }
-
-    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rs1 = ctx.read_reg(self.rs1_reg);
-        let rs2 = ctx.read_reg(self.rs2_reg);
-        if let Some(field) = detect_known_field(&self.modulus) {
-            let suffix = field.c_suffix();
-            let name = format!("rvr_ext_mod_iseq_{suffix}");
-            let val = ctx.extern_call_expr("uint32_t", &name, &["state", &rs1, &rs2]);
-            ctx.write_reg(self.rd_reg, &val);
-        } else {
-            let mod_literal = format_c_byte_array(&self.modulus);
-            ctx.write_line("{");
-            ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
-            let num_limbs = format!("{}u", self.num_limbs);
-            let val = ctx.extern_call_expr(
-                "uint32_t",
-                "rvr_ext_mod_iseq",
-                &["state", &rs1, &rs2, &num_limbs, "mod_"],
-            );
-            ctx.write_reg(self.rd_reg, &val);
-            ctx.write_line("}");
-        }
-    }
-
-    fn clone_box(&self) -> Box<dyn ExtInstr> {
-        Box::new(self.clone())
-    }
-
-    fn is_block_end(&self) -> bool {
-        false
-    }
-}
+pub(crate) type ModIsEqInstr = FieldIsEqInstr<ModArithKind>;
 
 /// IR node for modular SETUP (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
 pub type ModSetupInstr = FieldSetupInstr;
@@ -325,13 +281,13 @@ impl ModularRvrExtension {
                 Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))
             }
             x if x == Rv64ModularArithmeticOpcode::IS_EQ as usize => {
-                Instr::Ext(Box::new(ModIsEqInstr {
+                Instr::Ext(Box::new(ModIsEqInstr::new(
                     rd_reg,
                     rs1_reg,
                     rs2_reg,
-                    num_limbs: info.num_limbs,
-                    modulus: info.modulus_bytes.clone(),
-                }))
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                )))
             }
             x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => {
                 Instr::Ext(Box::new(ModSetupInstr::new("rvr_ext_mod_setup", rd_reg, rs1_reg, rs2_reg, info.num_limbs)))

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -6,7 +6,10 @@
 use std::ffi::c_void;
 
 use halo2curves_axiom::{bls12_381, bn256, ff::PrimeField};
-use openvm_ecc_guest::{algebra::field::FieldExtension, AffinePoint};
+use openvm_ecc_guest::{
+    algebra::{field::FieldExtension, Field},
+    AffinePoint,
+};
 use openvm_pairing_guest::{
     halo2curves_shims::{bls12_381::Bls12_381, bn254::Bn254},
     pairing::{FinalExp, MultiMillerLoop},
@@ -73,9 +76,21 @@ fn point_base(ptr: u64, idx: u64, words_per_point: u64) -> Option<u64> {
     ptr.checked_add(offset)
 }
 
-// ── BN254 pairing hint ──────────────────────────────────────────────────
+// ── Shared scaffolding ──────────────────────────────────────────────────
 
-unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
+/// Read G1 and G2 point vectors from guest memory.
+///
+/// `read_fq` reads one base-field element. `make_fq2` constructs an Fq2
+/// from two consecutive Fq elements; use `Fq2::new` or `|c0, c1| Fq2 { c0, c1 }`
+/// depending on the curve's API.
+unsafe fn read_pairing_points<Fq: Field, Fq2: Field>(
+    state: *mut c_void,
+    rs1_val: u64,
+    rs2_val: u64,
+    fq_bytes: u64,
+    read_fq: impl Fn(*mut c_void, u64) -> Option<Fq>,
+    make_fq2: impl Fn(Fq, Fq) -> Fq2,
+) -> Option<(Vec<AffinePoint<Fq>>, Vec<AffinePoint<Fq2>>)> {
     let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
     let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
     let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
@@ -87,38 +102,42 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<V
 
     let p: Vec<_> = (0..p_len)
         .map(|i| {
-            let base = point_base(p_ptr, i, G1_AFFINE_COORDS * BN254_FQ_BYTES)?;
+            let base = point_base(p_ptr, i, G1_AFFINE_COORDS * fq_bytes)?;
             Some(AffinePoint::new(
-                read_bn254_fq(state, base)?,
-                read_bn254_fq(state, base + BN254_FQ_BYTES)?,
+                read_fq(state, base)?,
+                read_fq(state, base + fq_bytes)?,
             ))
         })
         .collect::<Option<_>>()?;
 
     let q: Vec<_> = (0..q_len)
         .map(|i| {
-            let base = point_base(q_ptr, i, G2_AFFINE_COORDS * BN254_FQ_BYTES)?;
-            // BN254 Fq2 exposes a constructor helper.
-            let x = bn256::Fq2::new(
-                read_bn254_fq(state, base)?,
-                read_bn254_fq(state, base + BN254_FQ_BYTES)?,
-            );
-            let y = bn256::Fq2::new(
-                read_bn254_fq(state, base + 2 * BN254_FQ_BYTES)?,
-                read_bn254_fq(state, base + 3 * BN254_FQ_BYTES)?,
+            let base = point_base(q_ptr, i, G2_AFFINE_COORDS * fq_bytes)?;
+            let x = make_fq2(read_fq(state, base)?, read_fq(state, base + fq_bytes)?);
+            let y = make_fq2(
+                read_fq(state, base + 2 * fq_bytes)?,
+                read_fq(state, base + 3 * fq_bytes)?,
             );
             Some(AffinePoint::new(x, y))
         })
         .collect::<Option<_>>()?;
 
+    Some((p, q))
+}
+
+// ── BN254 pairing hint ──────────────────────────────────────────────────
+
+unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
+    let (p, q) = read_pairing_points(
+        state, rs1_val, rs2_val,
+        BN254_FQ_BYTES,
+        |s, ptr| unsafe { read_bn254_fq(s, ptr) },
+        bn256::Fq2::new,
+    )?;
     let f: bn256::Fq12 = Bn254::multi_miller_loop(&p, &q);
     let (c, u) = Bn254::final_exp_hint(&f);
-
-    // Serialize hint: c (Fp12) then u (Fp12), each as 12 Fq elements
     Some(
-        c.to_coeffs()
-            .into_iter()
-            .chain(u.to_coeffs())
+        c.to_coeffs().into_iter().chain(u.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
             .collect(),
@@ -128,48 +147,16 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<V
 // ── BLS12-381 pairing hint ──────────────────────────────────────────────
 
 unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
-    let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
-    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
-    let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
-    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
-
-    if p_len != q_len {
-        return None;
-    }
-
-    let p: Vec<_> = (0..p_len)
-        .map(|i| {
-            let base = point_base(p_ptr, i, G1_AFFINE_COORDS * BLS12_381_FQ_BYTES)?;
-            Some(AffinePoint::new(
-                read_bls12_381_fq(state, base)?,
-                read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES)?,
-            ))
-        })
-        .collect::<Option<_>>()?;
-
-    let q: Vec<_> = (0..q_len)
-        .map(|i| {
-            let base = point_base(q_ptr, i, G2_AFFINE_COORDS * BLS12_381_FQ_BYTES)?;
-            // BLS12-381 Fq2 uses struct fields instead of an `Fq2::new` helper.
-            let x = bls12_381::Fq2 {
-                c0: read_bls12_381_fq(state, base)?,
-                c1: read_bls12_381_fq(state, base + BLS12_381_FQ_BYTES)?,
-            };
-            let y = bls12_381::Fq2 {
-                c0: read_bls12_381_fq(state, base + 2 * BLS12_381_FQ_BYTES)?,
-                c1: read_bls12_381_fq(state, base + 3 * BLS12_381_FQ_BYTES)?,
-            };
-            Some(AffinePoint::new(x, y))
-        })
-        .collect::<Option<_>>()?;
-
+    let (p, q) = read_pairing_points(
+        state, rs1_val, rs2_val,
+        BLS12_381_FQ_BYTES,
+        |s, ptr| unsafe { read_bls12_381_fq(s, ptr) },
+        |c0, c1| bls12_381::Fq2 { c0, c1 },
+    )?;
     let f: bls12_381::Fq12 = Bls12_381::multi_miller_loop(&p, &q);
     let (c, u) = Bls12_381::final_exp_hint(&f);
-
     Some(
-        c.to_coeffs()
-            .into_iter()
-            .chain(u.to_coeffs())
+        c.to_coeffs().into_iter().chain(u.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
             .collect(),

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -78,6 +78,8 @@ fn point_base(ptr: u64, idx: u64, words_per_point: u64) -> Option<u64> {
 
 // ── Shared scaffolding ──────────────────────────────────────────────────
 
+type PairingPoints<Fq, Fq2> = (Vec<AffinePoint<Fq>>, Vec<AffinePoint<Fq2>>);
+
 /// Read G1 and G2 point vectors from guest memory.
 ///
 /// `read_fq` reads one base-field element. `make_fq2` constructs an Fq2
@@ -90,7 +92,7 @@ unsafe fn read_pairing_points<Fq: Field, Fq2: Field>(
     fq_bytes: u64,
     read_fq: impl Fn(*mut c_void, u64) -> Option<Fq>,
     make_fq2: impl Fn(Fq, Fq) -> Fq2,
-) -> Option<(Vec<AffinePoint<Fq>>, Vec<AffinePoint<Fq2>>)> {
+) -> Option<PairingPoints<Fq, Fq2>> {
     let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
     let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
     let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
@@ -129,7 +131,9 @@ unsafe fn read_pairing_points<Fq: Field, Fq2: Field>(
 
 unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
     let (p, q) = read_pairing_points(
-        state, rs1_val, rs2_val,
+        state,
+        rs1_val,
+        rs2_val,
         BN254_FQ_BYTES,
         |s, ptr| unsafe { read_bn254_fq(s, ptr) },
         bn256::Fq2::new,
@@ -137,7 +141,9 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<V
     let f: bn256::Fq12 = Bn254::multi_miller_loop(&p, &q);
     let (c, u) = Bn254::final_exp_hint(&f);
     Some(
-        c.to_coeffs().into_iter().chain(u.to_coeffs())
+        c.to_coeffs()
+            .into_iter()
+            .chain(u.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
             .collect(),
@@ -148,7 +154,9 @@ unsafe fn hint_bn254(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<V
 
 unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Option<Vec<u8>> {
     let (p, q) = read_pairing_points(
-        state, rs1_val, rs2_val,
+        state,
+        rs1_val,
+        rs2_val,
         BLS12_381_FQ_BYTES,
         |s, ptr| unsafe { read_bls12_381_fq(s, ptr) },
         |c0, c1| bls12_381::Fq2 { c0, c1 },
@@ -156,7 +164,9 @@ unsafe fn hint_bls12_381(state: *mut c_void, rs1_val: u64, rs2_val: u64) -> Opti
     let f: bls12_381::Fq12 = Bls12_381::multi_miller_loop(&p, &q);
     let (c, u) = Bls12_381::final_exp_hint(&f);
     Some(
-        c.to_coeffs().into_iter().chain(u.to_coeffs())
+        c.to_coeffs()
+            .into_iter()
+            .chain(u.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
             .collect(),


### PR DESCRIPTION
Refactor rvr algebra extension to remove code duplication. Also removes code duplication between Algebra/ECC/Pairing extensions for common computation.

Changes:
1. Create common pad_modulus function for padding in algebra extension.
2. Create common FieldArithInstr IR for modular and fp2 in algebra extension. Add ArithKind trait for modular and fp2 to implement.
3. Create common FieldSetupInstr IR for modular and fp2 in algebra extension. Add SetupKind trait; C function name derived from kind prefix.
4. Create common FieldIsEqInstr IR for modular in algebra extension. Add IsEqKind trait; not implemented for fp2.
5. Create common macro for unknown field in FFI.
6. Reduce code duplication for known field arithmetics in algebra extension.

resolves INT-7215