### PR TITLE
docs: note prove evm GPU acceleration via the halo2-gpu feature

### DIFF
--- a/docs/vocs/docs/pages/book/getting-started/install.mdx
+++ b/docs/vocs/docs/pages/book/getting-started/install.mdx
@@ -103,6 +103,8 @@ You will need all of the common prerequisites listed [above](#installation-prere
 - Nvidia GPU drivers [installed](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#)
 - CUDA toolkit [installed](https://docs.nvidia.com/cuda/archive/12.9.0/cuda-installation-guide-linux/index.html)
 
+EVM proofs (`prove evm`, built with the `halo2-gpu` feature) are the most memory-intensive step: the halo2 GPU prover needs noticeably more GPU and host memory than `prove app` or `prove stark`. Use a GPU and machine with more memory if you plan to generate EVM proofs.
+
 For machines running Ubuntu 24.04, you can install Nvidia drivers using
 
 :::code-group

--- a/docs/vocs/docs/pages/book/getting-started/install.mdx
+++ b/docs/vocs/docs/pages/book/getting-started/install.mdx
@@ -104,7 +104,7 @@ You will need all of the common prerequisites listed [above](#installation-prere
 - CUDA toolkit [installed](https://docs.nvidia.com/cuda/archive/12.9.0/cuda-installation-guide-linux/index.html)
 
 :::warning
-EVM proofs (`prove evm`, built with the `halo2-gpu` feature) are the most memory-intensive step. The halo2 GPU prover uses considerably more memory than `prove app` or `prove stark`; it was tested on a 32 GB GPU, with peak resident memory around 25 GB.
+CUDA EVM proving (`prove evm` built with the `halo2-gpu` feature) is the most memory-intensive part of the proving flow, using considerably more GPU memory than `prove app` or `prove stark`. Expect peak GPU memory usage to be at least 25 GB, and we recommend using a GPU with at least 32 GB of available memory.
 :::
 
 For machines running Ubuntu 24.04, you can install Nvidia drivers using

--- a/docs/vocs/docs/pages/book/getting-started/install.mdx
+++ b/docs/vocs/docs/pages/book/getting-started/install.mdx
@@ -103,7 +103,9 @@ You will need all of the common prerequisites listed [above](#installation-prere
 - Nvidia GPU drivers [installed](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#)
 - CUDA toolkit [installed](https://docs.nvidia.com/cuda/archive/12.9.0/cuda-installation-guide-linux/index.html)
 
-EVM proofs (`prove evm`, built with the `halo2-gpu` feature) are the most memory-intensive step: the halo2 GPU prover needs noticeably more GPU and host memory than `prove app` or `prove stark`. Use a GPU and machine with more memory if you plan to generate EVM proofs.
+:::warning
+EVM proofs (`prove evm`, built with the `halo2-gpu` feature) are the most memory-intensive step. The halo2 GPU prover uses considerably more memory than `prove app` or `prove stark`; it was tested on a 32 GB GPU, with peak resident memory around 25 GB.
+:::
 
 For machines running Ubuntu 24.04, you can install Nvidia drivers using
 

--- a/docs/vocs/docs/pages/book/getting-started/install.mdx
+++ b/docs/vocs/docs/pages/book/getting-started/install.mdx
@@ -95,7 +95,7 @@ cargo openvm --version
 
 It is possible to install the OpenVM CLI with support for Nvidia GPUs. This requires installation on a machine with an Nvidia GPU and associated drivers (see [Installation Prerequisites (CUDA)](#installation-prerequisites-cuda))
 
-With this version of the CLI, the `prove app` and `prove stark` commands will utilize the Nvidia GPU for hardware acceleration. Currently only single GPU support is available through the CLI.
+With this version of the CLI, the `prove app` and `prove stark` commands will utilize the Nvidia GPU for hardware acceleration. To also run the EVM proof (`prove evm`) on the GPU, build with the `halo2-gpu` feature in place of `cuda`. Currently only single GPU support is available through the CLI.
 
 ### Installation Prerequisites (CUDA)
 


### PR DESCRIPTION
Closes INT-7330
The GPU install section only mentioned prove app/prove stark. Adds one line noting that prove evm also runs on the GPU when built with the halo2-gpu feature (in place of cuda).