### PR TITLE
perf(v2.1): improve poseidon2 memory metering

### DIFF
--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -29,6 +29,11 @@ pub trait ExtEmitCtx {
     /// Emit an opaque C call that may update state observed by the tracer.
     fn extern_call(&mut self, name: &str, args: &[&str]);
 
+    /// Emit a C call whose body preserves tracer buffers.
+    fn extern_call_preserving_tracer(&mut self, name: &str, args: &[&str]) {
+        self.extern_call(name, args);
+    }
+
     /// Emit an opaque C call that returns a value.
     fn extern_call_expr(&mut self, ret_ty: &str, name: &str, args: &[&str]) -> String;
 

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -29,8 +29,8 @@ pub trait ExtEmitCtx {
     /// Emit an opaque C call that may update state observed by the tracer.
     fn extern_call(&mut self, name: &str, args: &[&str]);
 
-    /// Emit a C call whose body preserves tracer buffers.
-    fn extern_call_preserving_tracer(&mut self, name: &str, args: &[&str]) {
+    /// Emit a C call that does not require flushing local page trace state.
+    fn extern_call_without_page_flush(&mut self, name: &str, args: &[&str]) {
         self.extern_call(name, args);
     }
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -24,19 +24,19 @@ static_assert(
 /* No static assert for DEFERRAL — justifying the capacity is a TODO
  * (see DEFERRAL_PAGE_BUF_CAP in metered.rs). */
 
-typedef struct PageAccess {
+typedef struct PageTouch {
   /* Page table index plus a 64-bit leaf mask for that page. */
   uint32_t page_id;
   uint64_t leaf_mask;
-} PageAccess;
+} PageTouch;
 
 /* One page buffer per address space stores local page ids and leaf masks.
  * AS_REGISTER pages are handled entirely on the Rust side at init. */
 typedef struct Tracer {
   uint32_t* trace_heights;
-  PageAccess* mem_page_buf;
-  PageAccess* pv_page_buf;
-  PageAccess* deferral_page_buf;
+  PageTouch* mem_page_buf;
+  PageTouch* pv_page_buf;
+  PageTouch* deferral_page_buf;
   /* Always initialized by Rust; called unconditionally on the cold checkpoint
    * path to avoid a hot-path null check. */
   uint8_t (*on_check)(struct Tracer*);
@@ -46,8 +46,7 @@ typedef struct Tracer {
   uint32_t deferral_page_buf_len;
   uint32_t check_counter;
   /* Dedup cache: skip consecutive accesses to the same AS_MEMORY page.
-   * Reset to NO_LAST_PAGE on every buffer flush (required for correctness
-   * across segment boundaries that clear the global BitSet). */
+   * Reset on every buffer flush because the buffered entry is no longer live. */
   uint32_t last_mem_page;
 } Tracer;
 
@@ -55,7 +54,7 @@ typedef struct TraceMemory {
   uint32_t last_mem_page;
   uint32_t mem_page_buf_len;
   uint64_t last_mem_leaf_mask;
-  PageAccess* mem_page_buf;
+  PageTouch* mem_page_buf;
 } TraceMemory;
 
 /* ── Page tracking ─────────────────────────────────────────────────── */
@@ -90,16 +89,16 @@ static __attribute__((always_inline)) inline uint64_t leaf_mask_range(
 
 /* ── Per-address-space page recording ─────────────────────────────── */
 
-static __attribute__((always_inline)) inline void append_page_access(
-    PageAccess* restrict buf, uint32_t* restrict len, uint32_t page,
+static __attribute__((always_inline)) inline void append_page_touch(
+    PageTouch* restrict buf, uint32_t* restrict len, uint32_t page,
     uint64_t leaf_mask) {
-  PageAccess* slot = &buf[(*len)++];
+  PageTouch* slot = &buf[(*len)++];
   slot->page_id = page;
   slot->leaf_mask = leaf_mask;
 }
 
-static __attribute__((always_inline)) inline void append_page_access_range(
-    PageAccess* restrict buf, uint32_t* restrict len, uint32_t first_leaf,
+static __attribute__((always_inline)) inline void append_page_touch_range(
+    PageTouch* restrict buf, uint32_t* restrict len, uint32_t first_leaf,
     uint32_t last_leaf) {
   uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
   uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
@@ -108,7 +107,7 @@ static __attribute__((always_inline)) inline void append_page_access_range(
     uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
     uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
     uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    append_page_access(buf, len, page, leaf_mask_range(start, end));
+    append_page_touch(buf, len, page, leaf_mask_range(start, end));
   }
 }
 
@@ -120,7 +119,7 @@ static __attribute__((always_inline)) inline void record_mem_page(
     return;
   }
   t->last_mem_page = page;
-  append_page_access(t->mem_page_buf, &t->mem_page_buf_len, page, leaf_mask);
+  append_page_touch(t->mem_page_buf, &t->mem_page_buf_len, page, leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_mem_page_range(
@@ -143,7 +142,7 @@ static __attribute__((always_inline)) inline void record_mem_page_range(
     uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
     uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
     uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    append_page_access(t->mem_page_buf, &len, page, leaf_mask_range(start, end));
+    append_page_touch(t->mem_page_buf, &len, page, leaf_mask_range(start, end));
   }
   t->mem_page_buf_len = len;
   t->last_mem_page = last_page;
@@ -152,26 +151,26 @@ static __attribute__((always_inline)) inline void record_mem_page_range(
 /* No bounds check — see PV_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_pv_page(
     Tracer* t, uint32_t page, uint64_t leaf_mask) {
-  append_page_access(t->pv_page_buf, &t->pv_page_buf_len, page, leaf_mask);
+  append_page_touch(t->pv_page_buf, &t->pv_page_buf_len, page, leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_pv_page_range(
     Tracer* t, uint32_t first_leaf, uint32_t last_leaf) {
   uint32_t len = t->pv_page_buf_len;
-  append_page_access_range(t->pv_page_buf, &len, first_leaf, last_leaf);
+  append_page_touch_range(t->pv_page_buf, &len, first_leaf, last_leaf);
   t->pv_page_buf_len = len;
 }
 
 /* No bounds check — see DEFERRAL_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_deferral_page(
     Tracer* t, uint32_t page, uint64_t leaf_mask) {
-  append_page_access(t->deferral_page_buf, &t->deferral_page_buf_len, page, leaf_mask);
+  append_page_touch(t->deferral_page_buf, &t->deferral_page_buf_len, page, leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_deferral_page_range(
     Tracer* t, uint32_t first_leaf, uint32_t last_leaf) {
   uint32_t len = t->deferral_page_buf_len;
-  append_page_access_range(t->deferral_page_buf, &len, first_leaf, last_leaf);
+  append_page_touch_range(t->deferral_page_buf, &len, first_leaf, last_leaf);
   t->deferral_page_buf_len = len;
 }
 
@@ -240,7 +239,7 @@ static __attribute__((always_inline)) inline void trace_memory_drain(
     memory->last_mem_leaf_mask = 0;
     return;
   }
-  append_page_access(memory->mem_page_buf, &memory->mem_page_buf_len,
+  append_page_touch(memory->mem_page_buf, &memory->mem_page_buf_len,
                      memory->last_mem_page, memory->last_mem_leaf_mask);
   memory->last_mem_page = NO_LAST_PAGE;
   memory->last_mem_leaf_mask = 0;

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -281,26 +281,6 @@ static __attribute__((always_inline)) inline void trace_memory_access_leaf(
                            1ull << (leaf & ((1u << TRACER_PAGE_BITS) - 1u)));
 }
 
-static __attribute__((always_inline)) inline void trace_memory_access_bytes(
-    TraceMemory* restrict memory, uint32_t addr, uint32_t size) {
-  uint32_t first_leaf = byte_addr_to_local_leaf(addr);
-  uint32_t last_leaf = byte_addr_to_local_leaf(addr + size - 1u);
-  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
-  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
-  if (likely(first_page == last_page)) {
-    trace_memory_access_page(memory, first_page,
-                             leaf_mask_range(first_leaf, last_leaf));
-    return;
-  }
-  for (uint32_t page = first_page; page <= last_page; page++) {
-    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
-    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
-    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
-    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    trace_memory_access_page(memory, page, leaf_mask_range(start, end));
-  }
-}
-
 /* ── Trace-only register access (no-ops in metered mode) ─────────── */
 
 static __attribute__((always_inline)) inline void trace_reg_read(

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -281,6 +281,26 @@ static __attribute__((always_inline)) inline void trace_memory_access_leaf(
                            1ull << (leaf & ((1u << TRACER_PAGE_BITS) - 1u)));
 }
 
+static __attribute__((always_inline)) inline void trace_memory_access_bytes(
+    TraceMemory* restrict memory, uint32_t addr, uint32_t size) {
+  uint32_t first_leaf = byte_addr_to_local_leaf(addr);
+  uint32_t last_leaf = byte_addr_to_local_leaf(addr + size - 1u);
+  uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
+  uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
+  if (likely(first_page == last_page)) {
+    trace_memory_access_page(memory, first_page,
+                             leaf_mask_range(first_leaf, last_leaf));
+    return;
+  }
+  for (uint32_t page = first_page; page <= last_page; page++) {
+    uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
+    uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
+    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
+    uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
+    trace_memory_access_page(memory, page, leaf_mask_range(start, end));
+  }
+}
+
 /* ── Trace-only register access (no-ops in metered mode) ─────────── */
 
 static __attribute__((always_inline)) inline void trace_reg_read(

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -322,7 +322,7 @@ impl EmitContext {
         self.reload_page_locals();
     }
 
-    pub fn extern_call_preserving_tracer(&mut self, name: &str, args: &[&str]) {
+    pub fn extern_call_without_page_flush(&mut self, name: &str, args: &[&str]) {
         let args_str = args.join(", ");
         self.write_line(&format!("{name}({args_str});"));
     }
@@ -448,8 +448,8 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext {
         EmitContext::extern_call(self, name, args);
     }
 
-    fn extern_call_preserving_tracer(&mut self, name: &str, args: &[&str]) {
-        EmitContext::extern_call_preserving_tracer(self, name, args);
+    fn extern_call_without_page_flush(&mut self, name: &str, args: &[&str]) {
+        EmitContext::extern_call_without_page_flush(self, name, args);
     }
 
     fn extern_call_expr(&mut self, ret_ty: &str, name: &str, args: &[&str]) -> String {

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashSet, fmt::Write};
 
+use openvm_instructions::riscv::RV64_MEMORY_AS;
+
 use super::codegen::hex_u32;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -52,6 +54,9 @@ pub struct EmitContext {
     /// Counter for unique variable names.
     var_counter: u32,
     mode: EmitMode,
+    /// True when block-local `TraceMemory` has a pending AS_MEMORY page that
+    /// has not been drained back into the shared tracer buffer.
+    trace_memory_dirty: bool,
 }
 
 impl EmitContext {
@@ -62,6 +67,7 @@ impl EmitContext {
             indent: 2,
             var_counter: 0,
             mode,
+            trace_memory_dirty: false,
         }
     }
 
@@ -292,17 +298,20 @@ impl EmitContext {
 
     fn emit_inline_page_record(&mut self, addr: &str) {
         self.write_line(&format!("trace_memory_access_leaf(&trace_memory, {addr});"));
+        self.trace_memory_dirty = true;
     }
 
     pub fn flush_page_locals(&mut self) {
-        if self.mode.traces_memory_pages() {
+        if self.mode.traces_memory_pages() && self.trace_memory_dirty {
             self.write_line("trace_memory_flush(state->tracer, &trace_memory);");
+            self.trace_memory_dirty = false;
         }
     }
 
     pub fn reload_page_locals(&mut self) {
         if self.mode.traces_memory_pages() {
             self.write_line("trace_memory_reload(state->tracer, &trace_memory);");
+            self.trace_memory_dirty = false;
         }
     }
 
@@ -318,6 +327,11 @@ impl EmitContext {
         let args_str = args.join(", ");
         self.write_line(&format!("{name}({args_str});"));
         self.reload_page_locals();
+    }
+
+    pub fn extern_call_preserving_tracer(&mut self, name: &str, args: &[&str]) {
+        let args_str = args.join(", ");
+        self.write_line(&format!("{name}({args_str});"));
     }
 
     pub fn extern_call_expr(&mut self, ret_ty: &str, name: &str, args: &[&str]) -> String {
@@ -341,9 +355,14 @@ impl EmitContext {
     }
 
     pub fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {
-        self.flush_page_locals();
+        let touches_memory = addr_space == RV64_MEMORY_AS;
+        if touches_memory {
+            self.flush_page_locals();
+        }
         self.write_line(&format!("trace_mem_access(state, {addr}, {addr_space}u);"));
-        self.reload_page_locals();
+        if touches_memory {
+            self.reload_page_locals();
+        }
     }
 
     pub fn trace_mem_access_u64_range(
@@ -352,11 +371,16 @@ impl EmitContext {
         num_dwords: &str,
         addr_space: u32,
     ) {
-        self.flush_page_locals();
+        let touches_memory = addr_space == RV64_MEMORY_AS;
+        if touches_memory {
+            self.flush_page_locals();
+        }
         self.write_line(&format!(
             "trace_mem_access_u64_range(state, {base_addr}, {num_dwords}, {addr_space}u);"
         ));
-        self.reload_page_locals();
+        if touches_memory {
+            self.reload_page_locals();
+        }
     }
 
     fn sorted_hot_regs(&self) -> Vec<u8> {
@@ -429,6 +453,10 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext {
 
     fn extern_call(&mut self, name: &str, args: &[&str]) {
         EmitContext::extern_call(self, name, args);
+    }
+
+    fn extern_call_preserving_tracer(&mut self, name: &str, args: &[&str]) {
+        EmitContext::extern_call_preserving_tracer(self, name, args);
     }
 
     fn extern_call_expr(&mut self, ret_ty: &str, name: &str, args: &[&str]) -> String {

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -270,7 +270,7 @@ impl EmitContext {
             "{var_ty} {var} = {data_func}({data_arg}, {addr});"
         ));
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr);
+            self.emit_inline_page_record(&addr, width);
         }
         var
     }
@@ -289,15 +289,21 @@ impl EmitContext {
         let data_arg = if value_traced { "state" } else { "memory" };
 
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr);
+            self.emit_inline_page_record(&addr, width);
         }
         self.write_line(&format!(
             "{wr_func}({data_arg}, {addr}, ({cast_ty})({val}));"
         ));
     }
 
-    fn emit_inline_page_record(&mut self, addr: &str) {
-        self.write_line(&format!("trace_memory_access_leaf(&trace_memory, {addr});"));
+    fn emit_inline_page_record(&mut self, addr: &str, width: u8) {
+        if width == 1 {
+            self.write_line(&format!("trace_memory_access_leaf(&trace_memory, {addr});"));
+        } else {
+            self.write_line(&format!(
+                "trace_memory_access_bytes(&trace_memory, {addr}, {width}u);"
+            ));
+        }
         self.trace_memory_dirty = true;
     }
 
@@ -473,5 +479,41 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext {
 
     fn trace_mem_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32) {
         EmitContext::trace_mem_access_u64_range(self, base_addr, num_dwords, addr_space);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::{EmitContext, EmitMode};
+
+    fn metered_memory_ctx() -> EmitContext {
+        EmitContext::new(
+            HashSet::new(),
+            EmitMode::Metered {
+                trace_memory_pages: true,
+            },
+        )
+    }
+
+    #[test]
+    fn byte_memory_access_uses_single_leaf_trace() {
+        let mut ctx = metered_memory_ctx();
+        ctx.write_mem("addr", 0, "val", 1);
+
+        let emitted = ctx.buf();
+        assert!(emitted.contains("trace_memory_access_leaf(&trace_memory, addr);"));
+        assert!(!emitted.contains("trace_memory_access_bytes"));
+    }
+
+    #[test]
+    fn multibyte_memory_access_traces_full_width() {
+        let mut ctx = metered_memory_ctx();
+        ctx.read_mem("addr", 0, 8, false);
+
+        assert!(ctx
+            .buf()
+            .contains("trace_memory_access_bytes(&trace_memory, addr, 8u);"));
     }
 }

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -266,7 +266,7 @@ impl EmitContext {
             "{var_ty} {var} = {data_func}({data_arg}, {addr});"
         ));
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width);
+            self.emit_inline_page_record(&addr);
         }
         var
     }
@@ -285,21 +285,15 @@ impl EmitContext {
         let data_arg = if value_traced { "state" } else { "memory" };
 
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width);
+            self.emit_inline_page_record(&addr);
         }
         self.write_line(&format!(
             "{wr_func}({data_arg}, {addr}, ({cast_ty})({val}));"
         ));
     }
 
-    fn emit_inline_page_record(&mut self, addr: &str, width: u8) {
-        if width == 1 {
-            self.write_line(&format!("trace_memory_access_leaf(&trace_memory, {addr});"));
-        } else {
-            self.write_line(&format!(
-                "trace_memory_access_bytes(&trace_memory, {addr}, {width}u);"
-            ));
-        }
+    fn emit_inline_page_record(&mut self, addr: &str) {
+        self.write_line(&format!("trace_memory_access_leaf(&trace_memory, {addr});"));
     }
 
     pub fn flush_page_locals(&mut self) {
@@ -491,12 +485,12 @@ mod tests {
     }
 
     #[test]
-    fn multibyte_memory_access_traces_full_width() {
+    fn aligned_memory_access_uses_single_leaf_trace() {
         let mut ctx = metered_memory_ctx();
         ctx.read_mem("addr", 0, 8, false);
 
         assert!(ctx
             .buf()
-            .contains("trace_memory_access_bytes(&trace_memory, addr, 8u);"));
+            .contains("trace_memory_access_leaf(&trace_memory, addr);"));
     }
 }

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -54,9 +54,6 @@ pub struct EmitContext {
     /// Counter for unique variable names.
     var_counter: u32,
     mode: EmitMode,
-    /// True when block-local `TraceMemory` has a pending AS_MEMORY page that
-    /// has not been drained back into the shared tracer buffer.
-    trace_memory_dirty: bool,
 }
 
 impl EmitContext {
@@ -67,7 +64,6 @@ impl EmitContext {
             indent: 2,
             var_counter: 0,
             mode,
-            trace_memory_dirty: false,
         }
     }
 
@@ -304,20 +300,17 @@ impl EmitContext {
                 "trace_memory_access_bytes(&trace_memory, {addr}, {width}u);"
             ));
         }
-        self.trace_memory_dirty = true;
     }
 
     pub fn flush_page_locals(&mut self) {
-        if self.mode.traces_memory_pages() && self.trace_memory_dirty {
+        if self.mode.traces_memory_pages() {
             self.write_line("trace_memory_flush(state->tracer, &trace_memory);");
-            self.trace_memory_dirty = false;
         }
     }
 
     pub fn reload_page_locals(&mut self) {
         if self.mode.traces_memory_pages() {
             self.write_line("trace_memory_reload(state->tracer, &trace_memory);");
-            self.trace_memory_dirty = false;
         }
     }
 
@@ -495,16 +488,6 @@ mod tests {
                 trace_memory_pages: true,
             },
         )
-    }
-
-    #[test]
-    fn byte_memory_access_uses_single_leaf_trace() {
-        let mut ctx = metered_memory_ctx();
-        ctx.write_mem("addr", 0, "val", 1);
-
-        let emitted = ctx.buf();
-        assert!(emitted.contains("trace_memory_access_leaf(&trace_memory, addr);"));
-        assert!(!emitted.contains("trace_memory_access_bytes"));
     }
 
     #[test]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -609,11 +609,12 @@ where
     ) -> Result<CompiledExeMetered<'_>, SdkError> {
         let metadata = load_metered_artifact_metadata(lib_path).map_err(SdkError::Other)?;
         let exe = self.convert_to_exe(app_exe)?;
-        let ctx = MeteredCtx::from_config(
+        let mut ctx = MeteredCtx::from_config(
             metadata.metered_ctx_config,
             metadata.segmentation_config,
             self.executor.config.as_ref(),
         );
+        ctx.seed_initial_memory(&exe.init_memory);
         let instance = self
             .executor
             .load_metered_instance(lib_path, &exe, &metadata.executor_idx_to_air_idx)

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -85,6 +85,13 @@ impl MeteredCtx {
             "air_name={}",
             air_names[MERKLE_AIR_ID]
         );
+        debug_assert!(air_names.len() >= 2);
+        let poseidon2_idx = air_names.len() - 2;
+        debug_assert!(
+            air_names[poseidon2_idx].contains("Poseidon"),
+            "air_name={}",
+            air_names[poseidon2_idx]
+        );
         let mut ctx = Self {
             config: MeteredCtxConfig {
                 initial_trace_heights: trace_heights.clone(),

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -1,5 +1,8 @@
 use itertools::Itertools;
-use openvm_instructions::riscv::{RV64_IMM_AS, RV64_REGISTER_AS};
+use openvm_instructions::{
+    exe::SparseMemoryImage,
+    riscv::{RV64_IMM_AS, RV64_REGISTER_AS},
+};
 use openvm_stark_backend::memory_metering::ProvingMemoryConfig;
 use serde::{Deserialize, Serialize};
 
@@ -96,6 +99,7 @@ impl MeteredCtx {
         // Add merkle height contributions for all registers
         ctx.memory_ctx.add_register_merkle_heights();
         ctx.memory_ctx.apply_height_updates(&mut ctx.trace_heights);
+        ctx.memory_ctx.update_checkpoint();
 
         ctx
     }
@@ -103,6 +107,10 @@ impl MeteredCtx {
     pub fn with_max_memory(mut self, max_memory: usize) -> Self {
         self.segmentation_ctx.set_max_memory(max_memory);
         self
+    }
+
+    pub fn seed_initial_memory(&mut self, initial_memory: &SparseMemoryImage) {
+        self.memory_ctx.seed_initial_memory(initial_memory);
     }
 
     pub fn set_cache_rs_code_matrix(&mut self, cache_rs_code_matrix: bool) {
@@ -130,6 +138,7 @@ impl MeteredCtx {
         let mut trace_heights = config.initial_trace_heights.clone();
         memory_ctx.add_register_merkle_heights();
         memory_ctx.apply_height_updates(&mut trace_heights);
+        memory_ctx.update_checkpoint();
         Self {
             trace_heights,
             config,

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -55,6 +55,7 @@ fn push_page_access(accesses: &mut Vec<PageAccess>, page_id: u32, leaf_mask: u64
 }
 #[derive(Clone, Debug)]
 pub struct MemoryCtx {
+    /// Memory tree dimensions used to map address-space ranges into global leaf ids.
     memory_dimensions: MemoryDimensions,
     /// Segment-local occupancy. Cleared at segment boundaries; it prevents
     /// charging the same leaf or Merkle node twice inside one segment.
@@ -62,15 +63,20 @@ pub struct MemoryCtx {
     /// Committed occupancy at the last safe checkpoint, seeded with nonzero
     /// initial memory. This tells us whether an old value is canonical default.
     occupancy_tracker: CommittedMemoryOccupancyTracker,
+    /// Page masks recorded since the last safe checkpoint by the normal metered path.
     pub page_indices_since_checkpoint: Vec<PageAccess>,
+    /// Length mirror used by generated metered code that appends through the raw buffer.
     pub page_indices_since_checkpoint_len: usize,
+    /// Number of checkpoint-buffer entries already reflected in `trace_heights`.
     page_indices_applied_len: usize,
-    /// New leaves already reflected in `trace_heights` and queued for the next
-    /// checkpoint commit. Segment replay clears this queue and recomputes
-    /// heights from `page_indices_since_checkpoint`.
+    /// Newly charged leaf masks queued for the next checkpoint commit. Segment
+    /// replay clears this queue and recomputes it from `page_indices_since_checkpoint`.
     pending_occupancy_updates: Vec<PageAccess>,
+    /// New boundary leaves accumulated by direct page-buffer application.
     pending_leaves: u32,
+    /// New Merkle nodes accumulated by direct page-buffer application.
     pending_merkle_nodes: u32,
+    /// Old-side default leaves and nodes paired with the pending height deltas.
     pending_default_old: DefaultOldAccounting,
 }
 

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -7,7 +7,8 @@ use openvm_instructions::{
 };
 
 use super::page_tracker::{
-    leaf_mask_range, DefaultOldCounts, MemoryOccupancyTracker, MemoryPageTracker,
+    leaf_mask_range, CommittedMemoryOccupancyTracker, DefaultOldAccounting,
+    SegmentMemoryPageTracker,
 };
 pub use super::page_tracker::PageAccess;
 use crate::{
@@ -57,10 +58,10 @@ pub struct MemoryCtx {
     memory_dimensions: MemoryDimensions,
     /// Segment-local occupancy. Cleared at segment boundaries; it prevents
     /// charging the same leaf or Merkle node twice inside one segment.
-    page_tracker: MemoryPageTracker,
+    page_tracker: SegmentMemoryPageTracker,
     /// Committed occupancy at the last safe checkpoint, seeded with nonzero
     /// initial memory. This tells us whether an old value is canonical default.
-    occupancy_tracker: MemoryOccupancyTracker,
+    occupancy_tracker: CommittedMemoryOccupancyTracker,
     pub page_indices_since_checkpoint: Vec<PageAccess>,
     pub page_indices_since_checkpoint_len: usize,
     page_indices_applied_len: usize,
@@ -70,7 +71,7 @@ pub struct MemoryCtx {
     pending_occupancy_updates: Vec<PageAccess>,
     pending_leaves: u32,
     pending_merkle_nodes: u32,
-    pending_default_old: DefaultOldCounts,
+    pending_default_old: DefaultOldAccounting,
 }
 
 impl MemoryCtx {
@@ -83,15 +84,15 @@ impl MemoryCtx {
 
         Self {
             memory_dimensions,
-            page_tracker: MemoryPageTracker::new(upper_height),
-            occupancy_tracker: MemoryOccupancyTracker::new(upper_height),
+            page_tracker: SegmentMemoryPageTracker::new(upper_height),
+            occupancy_tracker: CommittedMemoryOccupancyTracker::new(upper_height),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
             page_indices_applied_len: 0,
             pending_occupancy_updates: Vec::with_capacity(checkpoint_capacity),
             pending_leaves: 0,
             pending_merkle_nodes: 0,
-            pending_default_old: DefaultOldCounts::default(),
+            pending_default_old: DefaultOldAccounting::default(),
         }
     }
 
@@ -228,13 +229,13 @@ impl MemoryCtx {
                 access.leaf_mask,
                 &self.occupancy_tracker,
             );
-            if delta.added_mask != 0 {
-                self.pending_leaves += delta.leaves;
-                self.pending_merkle_nodes += delta.merkle_nodes;
+            if delta.newly_charged_leaf_mask != 0 {
+                self.pending_leaves += delta.new_leaves;
+                self.pending_merkle_nodes += delta.new_merkle_nodes;
                 push_page_access(
                     &mut self.pending_occupancy_updates,
                     page_id,
-                    delta.added_mask,
+                    delta.newly_charged_leaf_mask,
                 );
                 self.pending_default_old.add(delta.default_old);
             }
@@ -251,7 +252,7 @@ impl MemoryCtx {
         self.pending_occupancy_updates.clear();
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldCounts::default();
+        self.pending_default_old = DefaultOldAccounting::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -274,7 +275,7 @@ impl MemoryCtx {
         self.pending_occupancy_updates.clear();
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldCounts::default();
+        self.pending_default_old = DefaultOldAccounting::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -306,7 +307,7 @@ impl MemoryCtx {
         self.pending_occupancy_updates.clear();
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldCounts::default();
+        self.pending_default_old = DefaultOldAccounting::default();
     }
 
     /// Applies memory height deltas recorded since the last checkpoint.
@@ -324,7 +325,7 @@ impl MemoryCtx {
         let mut default_old = self.pending_default_old;
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldCounts::default();
+        self.pending_default_old = DefaultOldAccounting::default();
 
         let len = self.page_indices_since_checkpoint.len();
         let ptr = self.page_indices_since_checkpoint.as_ptr();
@@ -336,13 +337,13 @@ impl MemoryCtx {
                 access.leaf_mask,
                 &self.occupancy_tracker,
             );
-            if delta.added_mask != 0 {
-                leaves += delta.leaves;
-                merkle_nodes += delta.merkle_nodes;
+            if delta.newly_charged_leaf_mask != 0 {
+                leaves += delta.new_leaves;
+                merkle_nodes += delta.new_merkle_nodes;
                 push_page_access(
                     &mut self.pending_occupancy_updates,
                     access.page_id,
-                    delta.added_mask,
+                    delta.newly_charged_leaf_mask,
                 );
                 default_old.add(delta.default_old);
             }
@@ -356,8 +357,8 @@ impl MemoryCtx {
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
         let old_default_poseidon_rows = default_old.estimated_poseidon_rows();
-        let old_nondefault_poseidon_rows =
-            (leaves + merkle_nodes).saturating_sub(default_old.leaves + default_old.merkle_nodes);
+        let old_nondefault_poseidon_rows = (leaves + merkle_nodes)
+            .saturating_sub(default_old.default_leaves + default_old.default_merkle_nodes);
         let poseidon2_rows =
             leaves + merkle_nodes + old_nondefault_poseidon_rows + old_default_poseidon_rows;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -97,6 +97,7 @@ impl MemoryCtx {
         );
     }
 
+    /// Marks leaves containing nonzero program data as present before execution starts.
     pub(crate) fn seed_initial_memory(&mut self, initial_memory: &SparseMemoryImage) {
         for (&(addr_space, ptr), &byte) in initial_memory {
             if byte == 0 {
@@ -303,11 +304,17 @@ impl MemoryCtx {
     ///
     /// - BOUNDARY_AIR: `2 * segment_leaves` rows
     /// - MERKLE_AIR:   `2 * segment_merkle_nodes` rows
-    /// - Poseidon2:    final-side hashes plus initial-side hashes
+    /// - Poseidon2:    hashes at the end of the segment plus hashes at its start
     ///
-    /// A first touch relative to the baseline has a canonical default initial-side value.
-    /// Default leaves share one Poseidon2 row. Default internal nodes share one
-    /// Poseidon2 row per Merkle height.
+    /// A leaf or node absent at the checkpoint starts from the hash of zero-filled memory. Equal
+    /// starting hashes share a row: one for all zero leaves and one for each internal-node height.
+    /// Therefore:
+    ///
+    /// ```text
+    /// Poseidon2 rows = end-of-segment hashes
+    ///                + nonzero checkpoint hashes
+    ///                + shared zero-filled hashes
+    /// ```
     #[inline(always)]
     pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_segment_leaves;

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -1,4 +1,7 @@
+use std::mem::size_of;
+
 use openvm_instructions::{
+    exe::SparseMemoryImage,
     riscv::{RV64_NUM_REGISTERS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
     DEFERRAL_AS, DIGEST_WIDTH, MEMORY_PAGE_BITS,
 };
@@ -26,6 +29,30 @@ const FIRST_BIT_PER_BYTE: u64 = 0x0101_0101_0101_0101;
 const FIRST_BIT_PER_U16: u64 = 0x0001_0001_0001_0001;
 const FIRST_BIT_PER_U32: u64 = 0x0000_0001_0000_0001;
 const FIRST_BIT_PER_U64: u64 = 0x0000_0000_0000_0001;
+const FIELD_ELEMENT_BYTES: u32 = size_of::<u32>() as u32;
+
+// Counts old-side leaves and Merkle nodes whose subtrees are still canonical
+// default values at the start of the segment.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct DefaultOldCounts {
+    leaves: u32,
+    merkle_nodes: u32,
+    merkle_node_levels: u64,
+}
+
+impl DefaultOldCounts {
+    #[inline(always)]
+    fn add(&mut self, other: Self) {
+        self.leaves += other.leaves;
+        self.merkle_nodes += other.merkle_nodes;
+        self.merkle_node_levels |= other.merkle_node_levels;
+    }
+
+    #[inline(always)]
+    fn estimated_poseidon_rows(self) -> u32 {
+        u32::from(self.leaves != 0) + self.merkle_node_levels.count_ones()
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct BitSet {
@@ -60,6 +87,18 @@ impl BitSet {
         }
         *word = old_word | mask;
         !was_set
+    }
+
+    #[inline(always)]
+    fn contains(&self, index: usize) -> bool {
+        let word_index = index >> 6;
+        let bit_index = index & 63;
+        let mask = 1u64 << bit_index;
+
+        debug_assert!(word_index < self.words.len(), "BitSet index out of bounds");
+
+        // SAFETY: word_index is derived from a valid memory tree node index.
+        unsafe { (*self.words.get_unchecked(word_index) & mask) != 0 }
     }
 
     /// Set all bits within [start, end) to 1, return the number of flipped bits.
@@ -155,6 +194,14 @@ pub struct PageAccess {
     pub leaf_mask: u64,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct MemoryHeightDelta {
+    leaves: u32,
+    merkle_nodes: u32,
+    added_mask: u64,
+    default_old: DefaultOldCounts,
+}
+
 #[derive(Clone, Debug)]
 pub struct MemoryPageTracker {
     page_masks: Box<[u64]>,
@@ -192,7 +239,12 @@ impl MemoryPageTracker {
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, page_id: usize, leaf_mask: u64) -> (u32, u32) {
+    fn insert(
+        &mut self,
+        page_id: usize,
+        leaf_mask: u64,
+        occupancy_tracker: &MemoryOccupancyTracker,
+    ) -> MemoryHeightDelta {
         debug_assert!(page_id < self.page_masks.len());
         debug_assert!(leaf_mask != 0);
 
@@ -200,7 +252,7 @@ impl MemoryPageTracker {
         let old_mask = *page_mask;
         let new_mask = old_mask | leaf_mask;
         if new_mask == old_mask {
-            return (0, 0);
+            return MemoryHeightDelta::default();
         }
 
         *page_mask = new_mask;
@@ -210,38 +262,135 @@ impl MemoryPageTracker {
         // Newly set bits are the only leaves that can add boundary rows or new
         // page-local Merkle nodes.
         let added_mask = leaf_mask & !old_mask;
+        let committed_mask = occupancy_tracker.page_mask(page_id);
+        let default_leaf_mask = added_mask & !committed_mask;
         let leaves = added_mask.count_ones();
-        let mut merkle_nodes = if leaves == 1 {
-            // Single-leaf path: test the aligned 2/4/8/16/32/64-leaf groups
-            // containing that leaf.
-            local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros())
+
+        let (mut merkle_nodes, mut default_old) = if default_leaf_mask == 0 {
+            (
+                local_merkle_nodes_delta(old_mask, added_mask),
+                DefaultOldCounts::default(),
+            )
         } else {
             // Multi-leaf path: walk old and added occupancy up the six
             // page-local levels, then count groups newly occupied by added leaves.
-            local_merkle_nodes_delta(old_mask, added_mask)
+            local_merkle_nodes_delta_with_default(old_mask, added_mask, committed_mask)
         };
+        default_old.leaves = default_leaf_mask.count_ones();
         self.leaves += leaves;
 
         if old_mask == 0 {
-            merkle_nodes += self.insert_upper_path(page_id);
+            if committed_mask == 0 {
+                let (upper_nodes, upper_default_old) =
+                    self.insert_upper_path(page_id, occupancy_tracker);
+                merkle_nodes += upper_nodes;
+                default_old.add(upper_default_old);
+            } else {
+                merkle_nodes += self.insert_upper_path_count_only(page_id);
+            }
         }
         self.merkle_nodes += merkle_nodes;
-        (leaves, merkle_nodes)
+        MemoryHeightDelta {
+            leaves,
+            merkle_nodes,
+            added_mask,
+            default_old,
+        }
     }
 
     #[inline(always)]
-    fn insert_upper_path(&mut self, page_id: usize) -> u32 {
+    fn insert_upper_path(
+        &mut self,
+        page_id: usize,
+        occupancy_tracker: &MemoryOccupancyTracker,
+    ) -> (u32, DefaultOldCounts) {
         // Called only when a page first becomes non-empty in this segment.
         // `upper_nodes` makes nearby pages share already-counted ancestors.
         let mut count = 0;
+        let mut default_old = DefaultOldCounts::default();
         let mut node = (1usize << self.upper_height) + page_id;
+        let mut height = MEMORY_PAGE_BITS + 1;
         while node > 1 {
             node >>= 1;
             if self.upper_nodes.insert(node) {
                 count += 1;
+                if !occupancy_tracker.upper_contains(node) {
+                    default_old.merkle_nodes += 1;
+                    default_old.merkle_node_levels |= 1u64 << height;
+                }
             }
+            height += 1;
+        }
+        (count, default_old)
+    }
+
+    #[inline(always)]
+    fn insert_upper_path_count_only(&mut self, page_id: usize) -> u32 {
+        let mut count = 0;
+        let mut node = (1usize << self.upper_height) + page_id;
+        while node > 1 {
+            node >>= 1;
+            count += u32::from(self.upper_nodes.insert(node));
         }
         count
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MemoryOccupancyTracker {
+    page_masks: Box<[u64]>,
+    upper_nodes: BitSet,
+    upper_height: usize,
+}
+
+impl MemoryOccupancyTracker {
+    pub fn new(upper_height: usize) -> Self {
+        let num_pages = 1 << upper_height;
+        Self {
+            page_masks: vec![0; num_pages].into_boxed_slice(),
+            upper_nodes: BitSet::new(num_pages),
+            upper_height,
+        }
+    }
+
+    #[inline(always)]
+    fn page_mask(&self, page_id: usize) -> u64 {
+        debug_assert!(page_id < self.page_masks.len());
+        unsafe { *self.page_masks.get_unchecked(page_id) }
+    }
+
+    #[inline(always)]
+    fn upper_contains(&self, node: usize) -> bool {
+        self.upper_nodes.contains(node)
+    }
+
+    #[inline(always)]
+    fn mark_existing_page(&mut self, page_id: usize, leaf_mask: u64) {
+        debug_assert!(page_id < self.page_masks.len());
+        debug_assert!(leaf_mask != 0);
+
+        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
+        let old_mask = *page_mask;
+        *page_mask = old_mask | leaf_mask;
+        if old_mask == 0 {
+            self.mark_upper_path(page_id);
+        }
+    }
+
+    #[inline(always)]
+    fn commit_page_accesses(&mut self, accesses: &[PageAccess]) {
+        for &access in accesses {
+            self.mark_existing_page(access.page_id as usize, access.leaf_mask);
+        }
+    }
+
+    #[inline(always)]
+    fn mark_upper_path(&mut self, page_id: usize) {
+        let mut node = (1usize << self.upper_height) + page_id;
+        while node > 1 {
+            node >>= 1;
+            self.upper_nodes.insert(node);
+        }
     }
 }
 
@@ -285,42 +434,94 @@ fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
 }
 
 #[inline(always)]
-fn aligned_group_is_empty<const GROUP_SIZE: u32>(old_mask: u64, leaf: u32) -> bool {
-    // The ancestor at this level covers the aligned group containing `leaf`.
-    // If the old mask has no bit in that group, adding `leaf` creates it.
-    let group_start = leaf & !(GROUP_SIZE - 1);
-    let group_mask = ((1u64 << GROUP_SIZE) - 1) << group_start;
-    old_mask & group_mask == 0
+fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64>(
+    old_mask: &mut u64,
+    added_mask: &mut u64,
+    committed_mask: &mut u64,
+    level: usize,
+    default_old: &mut DefaultOldCounts,
+) -> u32 {
+    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
+    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
+    *committed_mask = (*committed_mask | (*committed_mask >> SHIFT)) & MASK;
+    let new_nodes = *added_mask & !*old_mask;
+    let default_nodes = new_nodes & !*committed_mask;
+    if default_nodes != 0 {
+        default_old.merkle_nodes += default_nodes.count_ones();
+        default_old.merkle_node_levels |= 1u64 << level;
+    }
+    new_nodes.count_ones()
 }
 
 #[inline(always)]
-fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
-    debug_assert!(leaf < u64::BITS);
+fn local_merkle_nodes_delta_with_default(
+    mut old_mask: u64,
+    mut added_mask: u64,
+    mut committed_mask: u64,
+) -> (u32, DefaultOldCounts) {
+    debug_assert_ne!(added_mask, 0);
+    debug_assert_eq!(old_mask & added_mask, 0);
 
-    if old_mask == 0 {
-        return MEMORY_PAGE_BITS as u32;
-    }
-
+    let mut default_old = DefaultOldCounts::default();
     let mut nodes = 0;
-    // Group sizes 2..32 are the page-local ancestor levels below the
-    // 64-leaf page root. The page root already exists for a non-empty page.
-    nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
-    nodes
+    nodes += add_level_delta_with_default::<1, FIRST_BIT_PER_PAIR>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        1,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<2, FIRST_BIT_PER_NIBBLE>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        2,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<4, FIRST_BIT_PER_BYTE>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        3,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<8, FIRST_BIT_PER_U16>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        4,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<16, FIRST_BIT_PER_U32>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        5,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<32, FIRST_BIT_PER_U64>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        6,
+        &mut default_old,
+    );
+
+    (nodes, default_old)
 }
 
 #[derive(Clone, Debug)]
 pub struct MemoryCtx {
     memory_dimensions: MemoryDimensions,
     pub page_tracker: MemoryPageTracker,
+    occupancy_tracker: MemoryOccupancyTracker,
     pub page_indices_since_checkpoint: Vec<PageAccess>,
     pub page_indices_since_checkpoint_len: usize,
     page_indices_applied_len: usize,
+    pending_occupancy_updates: Vec<PageAccess>,
     pending_leaves: u32,
     pending_merkle_nodes: u32,
+    pending_default_old: DefaultOldCounts,
 }
 
 impl MemoryCtx {
@@ -334,11 +535,14 @@ impl MemoryCtx {
         Self {
             memory_dimensions,
             page_tracker: MemoryPageTracker::new(upper_height),
+            occupancy_tracker: MemoryOccupancyTracker::new(upper_height),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
             page_indices_applied_len: 0,
+            pending_occupancy_updates: Vec::with_capacity(checkpoint_capacity),
             pending_leaves: 0,
             pending_merkle_nodes: 0,
+            pending_default_old: DefaultOldCounts::default(),
         }
     }
 
@@ -354,6 +558,50 @@ impl MemoryCtx {
             0,
             (RV64_NUM_REGISTERS * RV64_REGISTER_NUM_LIMBS) as u32,
         );
+    }
+
+    pub(crate) fn seed_initial_memory(&mut self, initial_memory: &SparseMemoryImage) {
+        for (&(addr_space, ptr), &byte) in initial_memory {
+            if byte == 0 {
+                continue;
+            }
+            // The sparse image is byte-addressed. One nonzero byte is enough
+            // to make the containing Merkle leaf non-default.
+            if addr_space == DEFERRAL_AS {
+                self.mark_existing_memory_range(addr_space, ptr / FIELD_ELEMENT_BYTES, 1);
+            } else {
+                self.mark_existing_memory_range(addr_space, ptr, 1);
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn mark_existing_memory_range(&mut self, address_space: u32, ptr: u32, size: u32) {
+        let end_ptr = ptr + size - 1;
+        let leaf_bits = if address_space == DEFERRAL_AS {
+            DEFERRAL_PTRS_PER_LEAF_BITS
+        } else {
+            BYTE_PTRS_PER_LEAF_BITS
+        };
+        let leaf_label = ptr >> leaf_bits;
+        let end_leaf_label = end_ptr >> leaf_bits;
+        let num_leaves = end_leaf_label - leaf_label + 1;
+        let address_space_offset = (((address_space - ADDR_SPACE_OFFSET) as u64)
+            << self.memory_dimensions.address_height) as u32;
+        let start_leaf_id = address_space_offset + leaf_label;
+        let end_leaf_id = start_leaf_id + num_leaves;
+        let start_page_id = start_leaf_id >> MEMORY_PAGE_BITS;
+        let end_page_id = ((end_leaf_id - 1) >> MEMORY_PAGE_BITS) + 1;
+
+        for page_id in start_page_id..end_page_id {
+            let page_start = page_id << MEMORY_PAGE_BITS;
+            let page_end = page_start + (1 << MEMORY_PAGE_BITS);
+            let start = start_leaf_id.max(page_start) - page_start;
+            let end = end_leaf_id.min(page_end) - page_start;
+            let leaf_mask = leaf_mask_range(start, end);
+            self.occupancy_tracker
+                .mark_existing_page(page_id as usize, leaf_mask);
+        }
     }
 
     /// Records the memory-tree pages touched by `[ptr, ptr + size)`.
@@ -448,6 +696,33 @@ impl MemoryCtx {
         }
     }
 
+    #[inline(always)]
+    fn record_pending_occupancy_update(&mut self, page_id: u32, leaf_mask: u64) {
+        debug_assert!(leaf_mask != 0);
+        let len = self.pending_occupancy_updates.len();
+        if len != 0 {
+            // SAFETY: len is non-zero, so len - 1 is in bounds.
+            let prev = unsafe { self.pending_occupancy_updates.get_unchecked_mut(len - 1) };
+            if prev.page_id == page_id {
+                prev.leaf_mask |= leaf_mask;
+                return;
+            }
+        }
+
+        if len == self.pending_occupancy_updates.capacity() {
+            self.pending_occupancy_updates.reserve(1);
+        }
+
+        // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
+        unsafe {
+            self.pending_occupancy_updates
+                .as_mut_ptr()
+                .add(len)
+                .write(PageAccess { page_id, leaf_mask });
+            self.pending_occupancy_updates.set_len(len + 1);
+        }
+    }
+
     #[cfg(feature = "rvr")]
     #[inline(always)]
     pub(crate) fn apply_page_accesses_with_offset(
@@ -462,10 +737,17 @@ impl MemoryCtx {
             let access = unsafe { *ptr.add(i) };
             debug_assert!(access.leaf_mask != 0);
             let page_id = page_offset + access.page_id;
-            let (leaves, merkle_nodes) =
-                self.page_tracker.insert(page_id as usize, access.leaf_mask);
-            self.pending_leaves += leaves;
-            self.pending_merkle_nodes += merkle_nodes;
+            let delta = self.page_tracker.insert(
+                page_id as usize,
+                access.leaf_mask,
+                &self.occupancy_tracker,
+            );
+            if delta.added_mask != 0 {
+                self.pending_leaves += delta.leaves;
+                self.pending_merkle_nodes += delta.merkle_nodes;
+                self.record_pending_occupancy_update(page_id, delta.added_mask);
+                self.pending_default_old.add(delta.default_old);
+            }
         }
     }
 
@@ -476,8 +758,10 @@ impl MemoryCtx {
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
         self.page_indices_applied_len = 0;
+        self.pending_occupancy_updates.clear();
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
+        self.pending_default_old = DefaultOldCounts::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -497,8 +781,10 @@ impl MemoryCtx {
     pub(crate) fn initialize_segment(&mut self, trace_heights: &mut [u32]) {
         self.page_tracker.clear();
         self.page_indices_applied_len = 0;
+        self.pending_occupancy_updates.clear();
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
+        self.pending_default_old = DefaultOldCounts::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -522,11 +808,15 @@ impl MemoryCtx {
     /// Updates the checkpoint with current safe state
     #[inline(always)]
     pub(crate) fn update_checkpoint(&mut self) {
+        self.occupancy_tracker
+            .commit_page_accesses(&self.pending_occupancy_updates);
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
         self.page_indices_applied_len = 0;
+        self.pending_occupancy_updates.clear();
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
+        self.pending_default_old = DefaultOldCounts::default();
     }
 
     /// Applies boundary and Merkle height deltas for the page/leaf masks recorded
@@ -553,33 +843,51 @@ impl MemoryCtx {
     ///
     /// - BOUNDARY_AIR: `2 * new_leaves` rows
     /// - MERKLE_AIR:   `2 * new_merkle_nodes` rows
-    /// - Poseidon2:    `2 * new_leaves + 2 * new_merkle_nodes` hashes
+    /// - Poseidon2:    final-side hashes plus old-side hashes
     ///
-    /// The Poseidon2 count is still an upper bound because tracegen may
-    /// deduplicate equal hash inputs by value.
+    /// Old leaves and internal nodes that were definitely default before the
+    /// segment use canonical default Poseidon2 inputs. Default leaves share
+    /// one input, and default internal nodes share one input per Merkle height.
+    /// Other old-side hashes are counted structurally.
     #[inline(always)]
     pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_leaves;
         let mut merkle_nodes = self.pending_merkle_nodes;
+        let mut default_old = self.pending_default_old;
         self.pending_leaves = 0;
         self.pending_merkle_nodes = 0;
+        self.pending_default_old = DefaultOldCounts::default();
 
-        for &access in &self.page_indices_since_checkpoint[self.page_indices_applied_len..] {
-            let (new_leaves, new_merkle_nodes) = self
-                .page_tracker
-                .insert(access.page_id as usize, access.leaf_mask);
-            leaves += new_leaves;
-            merkle_nodes += new_merkle_nodes;
+        let len = self.page_indices_since_checkpoint.len();
+        let ptr = self.page_indices_since_checkpoint.as_ptr();
+        for i in self.page_indices_applied_len..len {
+            // SAFETY: i is bounded by page_indices_since_checkpoint.len().
+            let access = unsafe { *ptr.add(i) };
+            let delta = self.page_tracker.insert(
+                access.page_id as usize,
+                access.leaf_mask,
+                &self.occupancy_tracker,
+            );
+            if delta.added_mask != 0 {
+                leaves += delta.leaves;
+                merkle_nodes += delta.merkle_nodes;
+                self.record_pending_occupancy_update(access.page_id, delta.added_mask);
+                default_old.add(delta.default_old);
+            }
         }
-        self.page_indices_applied_len = self.page_indices_since_checkpoint.len();
+        self.page_indices_applied_len = len;
 
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
+        let old_default_poseidon_rows = default_old.estimated_poseidon_rows();
+        let old_nondefault_poseidon_rows =
+            (leaves + merkle_nodes).saturating_sub(default_old.leaves + default_old.merkle_nodes);
+        let poseidon2_rows =
+            leaves + merkle_nodes + old_nondefault_poseidon_rows + old_default_poseidon_rows;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
         unsafe {
             *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves * 2;
-            // Poseidon2: 2 hashes per leaf (compression) + 2 per internal node (init + final tree)
-            *trace_heights.get_unchecked_mut(poseidon2_idx) += leaves * 2 + merkle_nodes * 2;
+            *trace_heights.get_unchecked_mut(poseidon2_idx) += poseidon2_rows;
             // Merkle AIR: 2 rows per internal node (init + final tree)
             *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += merkle_nodes * 2;
         }
@@ -637,11 +945,12 @@ mod tests {
     #[test]
     fn test_local_merkle_nodes_doc_example() {
         let mut tracker = MemoryPageTracker::new(0);
-        tracker.insert(0, 1 << 0);
+        let occupancy = MemoryOccupancyTracker::new(0);
+        tracker.insert(0, 1 << 0, &occupancy);
         assert_eq!(tracker.merkle_nodes, 6);
-        tracker.insert(0, 1 << 4);
+        tracker.insert(0, 1 << 4, &occupancy);
         assert_eq!(tracker.merkle_nodes, 8);
-        tracker.insert(0, 1 << 2);
+        tracker.insert(0, 1 << 2, &occupancy);
         assert_eq!(tracker.merkle_nodes, 9);
     }
 
@@ -666,12 +975,6 @@ mod tests {
                 let added_mask = new_mask ^ old_mask;
                 let expected =
                     reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
-                if added_mask.count_ones() == 1 {
-                    assert_eq!(
-                        local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros()),
-                        expected
-                    );
-                }
                 assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
                 old_mask = new_mask;
             }
@@ -684,12 +987,6 @@ mod tests {
                 let added_mask = new_mask ^ old_mask;
                 let expected =
                     reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
-                if added_mask.count_ones() == 1 {
-                    assert_eq!(
-                        local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros()),
-                        expected
-                    );
-                }
                 assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
                 old_mask = new_mask;
             }
@@ -718,10 +1015,11 @@ mod tests {
     #[test]
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
         let mut tracker = MemoryPageTracker::new(3);
-        tracker.insert(0, 1 << 0);
+        let occupancy = MemoryOccupancyTracker::new(3);
+        tracker.insert(0, 1 << 0, &occupancy);
         let leaves = tracker.leaves;
         let nodes = tracker.merkle_nodes;
-        tracker.insert(0, 1 << 0);
+        tracker.insert(0, 1 << 0, &occupancy);
         assert_eq!(tracker.leaves, leaves);
         assert_eq!(tracker.merkle_nodes, nodes);
     }
@@ -729,8 +1027,9 @@ mod tests {
     #[test]
     fn test_memory_page_tracker_clear_resets_touched_state() {
         let mut tracker = MemoryPageTracker::new(3);
-        tracker.insert(0, 1 << 0);
-        tracker.insert(7, 1 << 63);
+        let occupancy = MemoryOccupancyTracker::new(3);
+        tracker.insert(0, 1 << 0, &occupancy);
+        tracker.insert(7, 1 << 63, &occupancy);
         assert!(tracker.leaves > 0);
         assert!(tracker.merkle_nodes > 0);
 
@@ -738,7 +1037,7 @@ mod tests {
         assert_eq!(tracker.leaves, 0);
         assert_eq!(tracker.merkle_nodes, 0);
 
-        tracker.insert(0, 1 << 0);
+        tracker.insert(0, 1 << 0, &occupancy);
         assert_eq!(tracker.leaves, 1);
         assert!(tracker.merkle_nodes > 0);
     }
@@ -746,9 +1045,10 @@ mod tests {
     #[test]
     fn test_adjacent_pages_share_upper_ancestors() {
         let mut tracker = MemoryPageTracker::new(3);
-        tracker.insert(0, 1);
+        let occupancy = MemoryOccupancyTracker::new(3);
+        tracker.insert(0, 1, &occupancy);
         let first = tracker.merkle_nodes;
-        tracker.insert(1, 1);
+        tracker.insert(1, 1, &occupancy);
         assert_eq!(tracker.merkle_nodes - first, MEMORY_PAGE_BITS as u32);
     }
 
@@ -768,5 +1068,151 @@ mod tests {
         range_ctx.apply_height_updates(&mut range_heights);
         explicit_ctx.apply_height_updates(&mut explicit_heights);
         assert_eq!(range_heights, explicit_heights);
+    }
+
+    #[test]
+    fn test_tentative_apply_does_not_commit_occupancy() {
+        let system_config = crate::utils::test_system_config();
+        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut trace_heights = vec![0; 6];
+
+        ctx.update_boundary_merkle_heights(2, 0, 1);
+        ctx.apply_height_updates(&mut trace_heights);
+
+        let page_id = ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize
+            >> MEMORY_PAGE_BITS;
+        assert_eq!(ctx.occupancy_tracker.page_mask(page_id), 0);
+    }
+
+    #[test]
+    fn test_checkpoint_commit_keeps_occupied_counts() {
+        let mut occupancy = MemoryOccupancyTracker::new(1);
+        let mut tracker = MemoryPageTracker::new(1);
+
+        let first = tracker.insert(0, 1, &occupancy).default_old;
+        occupancy.commit_page_accesses(&[PageAccess {
+            page_id: 0,
+            leaf_mask: 1,
+        }]);
+        tracker.clear();
+        let second = tracker.insert(0, 1, &occupancy).default_old;
+
+        assert!(first.leaves > 0);
+        assert_eq!(second, DefaultOldCounts::default());
+    }
+
+    #[test]
+    fn test_default_old_poseidon_rows_dedup_by_default_bucket() {
+        let system_config = crate::utils::test_system_config();
+        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let height = ctx.memory_dimensions.overall_height() as u32;
+        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+
+        ctx.update_boundary_merkle_heights(2, 0, 1);
+        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
+
+        let mut trace_heights = vec![0; 6];
+        ctx.apply_height_updates(&mut trace_heights);
+
+        let poseidon2_idx = trace_heights.len() - 2;
+        assert_eq!(trace_heights[BOUNDARY_AIR_ID], 4);
+        assert_eq!(trace_heights[MERKLE_AIR_ID], 2 * height);
+        assert_eq!(trace_heights[poseidon2_idx], 2 * height + 3);
+    }
+
+    #[test]
+    fn test_initial_zero_bytes_do_not_seed_occupancy() {
+        let system_config = crate::utils::test_system_config();
+        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let height = ctx.memory_dimensions.overall_height() as u32;
+        ctx.seed_initial_memory(&SparseMemoryImage::from([((2, 0), 0)]));
+        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+
+        ctx.update_boundary_merkle_heights(2, 0, 1);
+        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
+
+        let mut trace_heights = vec![0; 6];
+        ctx.apply_height_updates(&mut trace_heights);
+
+        let poseidon2_idx = trace_heights.len() - 2;
+        assert_eq!(trace_heights[poseidon2_idx], 2 * height + 3);
+    }
+
+    #[test]
+    fn test_initial_nonzero_bytes_seed_occupancy() {
+        let system_config = crate::utils::test_system_config();
+        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let height = ctx.memory_dimensions.overall_height() as u32;
+        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+        ctx.seed_initial_memory(&SparseMemoryImage::from([
+            ((2, 0), 1),
+            ((2, second_leaf_ptr), 1),
+        ]));
+
+        ctx.update_boundary_merkle_heights(2, 0, 1);
+        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
+
+        let mut trace_heights = vec![0; 6];
+        ctx.apply_height_updates(&mut trace_heights);
+
+        let poseidon2_idx = trace_heights.len() - 2;
+        assert_eq!(trace_heights[poseidon2_idx], 2 * height + 4);
+    }
+
+    #[test]
+    fn test_initial_deferral_bytes_seed_occupancy() {
+        let system_config = crate::utils::test_system_config();
+        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let height = ctx.memory_dimensions.overall_height() as u32;
+        let second_leaf_ptr = DIGEST_WIDTH as u32;
+        let second_leaf_byte_ptr = second_leaf_ptr * FIELD_ELEMENT_BYTES;
+        ctx.seed_initial_memory(&SparseMemoryImage::from([
+            ((DEFERRAL_AS, 0), 1),
+            ((DEFERRAL_AS, second_leaf_byte_ptr), 1),
+        ]));
+
+        ctx.update_boundary_merkle_heights(DEFERRAL_AS, 0, 1);
+        ctx.update_boundary_merkle_heights(DEFERRAL_AS, second_leaf_ptr, 1);
+
+        let mut trace_heights = vec![0; 6];
+        ctx.apply_height_updates(&mut trace_heights);
+
+        let poseidon2_idx = trace_heights.len() - 2;
+        assert_eq!(trace_heights[poseidon2_idx], 2 * height + 4);
+    }
+
+    #[test]
+    fn test_initialize_segment_replays_with_default_occupancy() {
+        let system_config = crate::utils::test_system_config();
+        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+
+        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut trace_heights = vec![0; 6];
+        ctx.add_register_merkle_heights();
+        ctx.apply_height_updates(&mut trace_heights);
+        ctx.update_checkpoint();
+
+        ctx.update_boundary_merkle_heights(2, 0, 1);
+        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
+
+        let poseidon2_idx = trace_heights.len() - 2;
+        ctx.apply_height_updates(&mut trace_heights);
+
+        ctx.initialize_segment(&mut trace_heights);
+
+        let mut clean_ctx = MemoryCtx::new(&system_config, 1);
+        let mut clean_trace_heights = vec![0; 6];
+        clean_ctx.add_register_merkle_heights();
+        clean_ctx.apply_height_updates(&mut clean_trace_heights);
+        clean_ctx.update_checkpoint();
+        clean_ctx.initialize_segment(&mut clean_trace_heights);
+
+        let replayed_poseidon_rows =
+            trace_heights[poseidon2_idx] - clean_trace_heights[poseidon2_idx];
+        let replayed_leaves =
+            (trace_heights[BOUNDARY_AIR_ID] - clean_trace_heights[BOUNDARY_AIR_ID]) / 2;
+        let replayed_merkle_nodes =
+            (trace_heights[MERKLE_AIR_ID] - clean_trace_heights[MERKLE_AIR_ID]) / 2;
+        assert!(replayed_poseidon_rows > replayed_leaves + replayed_merkle_nodes);
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -208,8 +208,6 @@ pub struct MemoryPageTracker {
     dirty_pages: Vec<usize>,
     upper_nodes: BitSet,
     upper_height: usize,
-    merkle_nodes: u32,
-    leaves: u32,
 }
 
 impl MemoryPageTracker {
@@ -220,8 +218,6 @@ impl MemoryPageTracker {
             dirty_pages: Vec::new(),
             upper_nodes: BitSet::new(num_pages),
             upper_height,
-            merkle_nodes: 0,
-            leaves: 0,
         }
     }
 
@@ -234,8 +230,6 @@ impl MemoryPageTracker {
             }
         }
         self.upper_nodes.clear();
-        self.merkle_nodes = 0;
-        self.leaves = 0;
     }
 
     #[inline(always)]
@@ -268,7 +262,11 @@ impl MemoryPageTracker {
 
         let (mut merkle_nodes, mut default_old) = if default_leaf_mask == 0 {
             (
-                local_merkle_nodes_delta(old_mask, added_mask),
+                if leaves == 1 {
+                    local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros())
+                } else {
+                    local_merkle_nodes_delta(old_mask, added_mask)
+                },
                 DefaultOldCounts::default(),
             )
         } else {
@@ -276,8 +274,9 @@ impl MemoryPageTracker {
             // page-local levels, then count groups newly occupied by added leaves.
             local_merkle_nodes_delta_with_default(old_mask, added_mask, committed_mask)
         };
-        default_old.leaves = default_leaf_mask.count_ones();
-        self.leaves += leaves;
+        if default_leaf_mask != 0 {
+            default_old.leaves = default_leaf_mask.count_ones();
+        }
 
         if old_mask == 0 {
             if committed_mask == 0 {
@@ -289,7 +288,6 @@ impl MemoryPageTracker {
                 merkle_nodes += self.insert_upper_path_count_only(page_id);
             }
         }
-        self.merkle_nodes += merkle_nodes;
         MemoryHeightDelta {
             leaves,
             merkle_nodes,
@@ -318,6 +316,8 @@ impl MemoryPageTracker {
                     default_old.merkle_nodes += 1;
                     default_old.merkle_node_levels |= 1u64 << height;
                 }
+            } else {
+                break;
             }
             height += 1;
         }
@@ -330,7 +330,11 @@ impl MemoryPageTracker {
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
             node >>= 1;
-            count += u32::from(self.upper_nodes.insert(node));
+            if self.upper_nodes.insert(node) {
+                count += 1;
+            } else {
+                break;
+            }
         }
         count
     }
@@ -430,6 +434,30 @@ fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
     nodes += add_level_delta::<16, FIRST_BIT_PER_U32>(&mut old_mask, &mut added_mask);
     nodes += add_level_delta::<32, FIRST_BIT_PER_U64>(&mut old_mask, &mut added_mask);
 
+    nodes
+}
+
+#[inline(always)]
+fn aligned_group_is_empty<const GROUP_SIZE: u32>(old_mask: u64, leaf: u32) -> bool {
+    let group_start = leaf & !(GROUP_SIZE - 1);
+    let group_mask = ((1u64 << GROUP_SIZE) - 1) << group_start;
+    old_mask & group_mask == 0
+}
+
+#[inline(always)]
+fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
+    debug_assert!(leaf < u64::BITS);
+
+    if old_mask == 0 {
+        return MEMORY_PAGE_BITS as u32;
+    }
+
+    let mut nodes = 0;
+    nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
     nodes
 }
 
@@ -946,12 +974,13 @@ mod tests {
     fn test_local_merkle_nodes_doc_example() {
         let mut tracker = MemoryPageTracker::new(0);
         let occupancy = MemoryOccupancyTracker::new(0);
-        tracker.insert(0, 1 << 0, &occupancy);
-        assert_eq!(tracker.merkle_nodes, 6);
-        tracker.insert(0, 1 << 4, &occupancy);
-        assert_eq!(tracker.merkle_nodes, 8);
-        tracker.insert(0, 1 << 2, &occupancy);
-        assert_eq!(tracker.merkle_nodes, 9);
+        let mut nodes = 0;
+        nodes += tracker.insert(0, 1 << 0, &occupancy).merkle_nodes;
+        assert_eq!(nodes, 6);
+        nodes += tracker.insert(0, 1 << 4, &occupancy).merkle_nodes;
+        assert_eq!(nodes, 8);
+        nodes += tracker.insert(0, 1 << 2, &occupancy).merkle_nodes;
+        assert_eq!(nodes, 9);
     }
 
     #[test]
@@ -1016,30 +1045,24 @@ mod tests {
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
         let mut tracker = MemoryPageTracker::new(3);
         let occupancy = MemoryOccupancyTracker::new(3);
-        tracker.insert(0, 1 << 0, &occupancy);
-        let leaves = tracker.leaves;
-        let nodes = tracker.merkle_nodes;
-        tracker.insert(0, 1 << 0, &occupancy);
-        assert_eq!(tracker.leaves, leaves);
-        assert_eq!(tracker.merkle_nodes, nodes);
+        assert_ne!(tracker.insert(0, 1 << 0, &occupancy).added_mask, 0);
+        assert_eq!(tracker.insert(0, 1 << 0, &occupancy), MemoryHeightDelta::default());
     }
 
     #[test]
     fn test_memory_page_tracker_clear_resets_touched_state() {
         let mut tracker = MemoryPageTracker::new(3);
         let occupancy = MemoryOccupancyTracker::new(3);
-        tracker.insert(0, 1 << 0, &occupancy);
-        tracker.insert(7, 1 << 63, &occupancy);
-        assert!(tracker.leaves > 0);
-        assert!(tracker.merkle_nodes > 0);
+        let first = tracker.insert(0, 1 << 0, &occupancy);
+        let second = tracker.insert(7, 1 << 63, &occupancy);
+        assert!(first.leaves + second.leaves > 0);
+        assert!(first.merkle_nodes + second.merkle_nodes > 0);
 
         tracker.clear();
-        assert_eq!(tracker.leaves, 0);
-        assert_eq!(tracker.merkle_nodes, 0);
 
-        tracker.insert(0, 1 << 0, &occupancy);
-        assert_eq!(tracker.leaves, 1);
-        assert!(tracker.merkle_nodes > 0);
+        let after_clear = tracker.insert(0, 1 << 0, &occupancy);
+        assert_eq!(after_clear.leaves, 1);
+        assert!(after_clear.merkle_nodes > 0);
     }
 
     #[test]
@@ -1047,9 +1070,8 @@ mod tests {
         let mut tracker = MemoryPageTracker::new(3);
         let occupancy = MemoryOccupancyTracker::new(3);
         tracker.insert(0, 1, &occupancy);
-        let first = tracker.merkle_nodes;
-        tracker.insert(1, 1, &occupancy);
-        assert_eq!(tracker.merkle_nodes - first, MEMORY_PAGE_BITS as u32);
+        let second = tracker.insert(1, 1, &occupancy);
+        assert_eq!(second.merkle_nodes, MEMORY_PAGE_BITS as u32);
     }
 
     #[test]

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -49,6 +49,11 @@ impl DefaultOldCounts {
     }
 
     #[inline(always)]
+    fn is_empty(self) -> bool {
+        self.leaves == 0 && self.merkle_nodes == 0 && self.merkle_node_levels == 0
+    }
+
+    #[inline(always)]
     fn estimated_poseidon_rows(self) -> u32 {
         u32::from(self.leaves != 0) + self.merkle_node_levels.count_ones()
     }
@@ -70,6 +75,16 @@ impl BitSet {
 
     #[inline(always)]
     pub fn insert(&mut self, index: usize) -> bool {
+        self.insert_impl::<true>(index)
+    }
+
+    #[inline(always)]
+    fn insert_persistent(&mut self, index: usize) -> bool {
+        self.insert_impl::<false>(index)
+    }
+
+    #[inline(always)]
+    fn insert_impl<const TRACK_DIRTY: bool>(&mut self, index: usize) -> bool {
         let word_index = index >> 6;
         let bit_index = index & 63;
         let mask = 1u64 << bit_index;
@@ -82,11 +97,14 @@ impl BitSet {
         let word = unsafe { self.words.get_unchecked_mut(word_index) };
         let old_word = *word;
         let was_set = (old_word & mask) != 0;
-        if old_word == 0 {
+        if was_set {
+            return false;
+        }
+        if TRACK_DIRTY && old_word == 0 {
             self.dirty_words.push(word_index);
         }
         *word = old_word | mask;
-        !was_set
+        true
     }
 
     #[inline(always)]
@@ -258,16 +276,27 @@ impl MemoryPageTracker {
         let added_mask = leaf_mask & !old_mask;
         let committed_mask = occupancy_tracker.page_mask(page_id);
         let default_leaf_mask = added_mask & !committed_mask;
-        let leaves = added_mask.count_ones();
+        let single_added_leaf = added_mask.is_power_of_two();
+        let leaves = if single_added_leaf {
+            1
+        } else {
+            added_mask.count_ones()
+        };
 
         let (mut merkle_nodes, mut default_old) = if default_leaf_mask == 0 {
             (
-                if leaves == 1 {
+                if single_added_leaf {
                     local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros())
                 } else {
                     local_merkle_nodes_delta(old_mask, added_mask)
                 },
                 DefaultOldCounts::default(),
+            )
+        } else if single_added_leaf {
+            local_merkle_nodes_added_leaf_with_default(
+                old_mask,
+                added_mask.trailing_zeros(),
+                committed_mask,
             )
         } else {
             // Multi-leaf path: walk old and added occupancy up the six
@@ -275,7 +304,11 @@ impl MemoryPageTracker {
             local_merkle_nodes_delta_with_default(old_mask, added_mask, committed_mask)
         };
         if default_leaf_mask != 0 {
-            default_old.leaves = default_leaf_mask.count_ones();
+            default_old.leaves = if single_added_leaf {
+                1
+            } else {
+                default_leaf_mask.count_ones()
+            };
         }
 
         if old_mask == 0 {
@@ -393,7 +426,9 @@ impl MemoryOccupancyTracker {
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
             node >>= 1;
-            self.upper_nodes.insert(node);
+            if !self.upper_nodes.insert_persistent(node) {
+                break;
+            }
         }
     }
 }
@@ -462,6 +497,78 @@ fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
 }
 
 #[inline(always)]
+fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32>(
+    old_mask: u64,
+    committed_mask: u64,
+    leaf: u32,
+    level: usize,
+    default_old: &mut DefaultOldCounts,
+) -> u32 {
+    if aligned_group_is_empty::<GROUP_SIZE>(old_mask, leaf) {
+        if aligned_group_is_empty::<GROUP_SIZE>(committed_mask, leaf) {
+            default_old.merkle_nodes += 1;
+            default_old.merkle_node_levels |= 1u64 << level;
+        }
+        1
+    } else {
+        0
+    }
+}
+
+#[inline(always)]
+fn local_merkle_nodes_added_leaf_with_default(
+    old_mask: u64,
+    leaf: u32,
+    committed_mask: u64,
+) -> (u32, DefaultOldCounts) {
+    debug_assert!(leaf < u64::BITS);
+
+    if old_mask == 0 && committed_mask == 0 {
+        return (
+            PAGE_BITS as u32,
+            DefaultOldCounts {
+                leaves: 0,
+                merkle_nodes: PAGE_BITS as u32,
+                merkle_node_levels: (1u64 << (PAGE_BITS + 1)) - 2,
+            },
+        );
+    }
+
+    let mut default_old = DefaultOldCounts::default();
+    let mut nodes = 0;
+    nodes +=
+        add_leaf_level_delta_with_default::<2>(old_mask, committed_mask, leaf, 1, &mut default_old);
+    nodes +=
+        add_leaf_level_delta_with_default::<4>(old_mask, committed_mask, leaf, 2, &mut default_old);
+    nodes +=
+        add_leaf_level_delta_with_default::<8>(old_mask, committed_mask, leaf, 3, &mut default_old);
+    nodes += add_leaf_level_delta_with_default::<16>(
+        old_mask,
+        committed_mask,
+        leaf,
+        4,
+        &mut default_old,
+    );
+    nodes += add_leaf_level_delta_with_default::<32>(
+        old_mask,
+        committed_mask,
+        leaf,
+        5,
+        &mut default_old,
+    );
+
+    if old_mask == 0 {
+        nodes += 1;
+        if committed_mask == 0 {
+            default_old.merkle_nodes += 1;
+            default_old.merkle_node_levels |= 1u64 << PAGE_BITS;
+        }
+    }
+
+    (nodes, default_old)
+}
+
+#[inline(always)]
 fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64>(
     old_mask: &mut u64,
     added_mask: &mut u64,
@@ -474,10 +581,8 @@ fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64>(
     *committed_mask = (*committed_mask | (*committed_mask >> SHIFT)) & MASK;
     let new_nodes = *added_mask & !*old_mask;
     let default_nodes = new_nodes & !*committed_mask;
-    if default_nodes != 0 {
-        default_old.merkle_nodes += default_nodes.count_ones();
-        default_old.merkle_node_levels |= 1u64 << level;
-    }
+    default_old.merkle_nodes += default_nodes.count_ones();
+    default_old.merkle_node_levels |= u64::from(default_nodes != 0) << level;
     new_nodes.count_ones()
 }
 
@@ -905,6 +1010,10 @@ impl MemoryCtx {
         }
         self.page_indices_applied_len = len;
 
+        if leaves == 0 && merkle_nodes == 0 && default_old.is_empty() {
+            return;
+        }
+
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
         let old_default_poseidon_rows = default_old.estimated_poseidon_rows();
@@ -1042,11 +1151,38 @@ mod tests {
     }
 
     #[test]
+    fn test_default_single_leaf_matches_dense_delta() {
+        for leaf in 0..u64::BITS {
+            let added = 1u64 << leaf;
+            let old_patterns = [0, 1, 0x5555_5555_5555_5555, 0xaaaa_aaaa_aaaa_aaaa, u64::MAX];
+            let committed_patterns = [0, 1, 0x3333_3333_3333_3333, 0xcccc_cccc_cccc_cccc, u64::MAX];
+
+            for old_mask in old_patterns {
+                let old_mask = old_mask & !added;
+                for committed_mask in committed_patterns {
+                    let committed_mask = committed_mask & !added;
+                    let dense =
+                        local_merkle_nodes_delta_with_default(old_mask, added, committed_mask);
+                    let sparse =
+                        local_merkle_nodes_added_leaf_with_default(old_mask, leaf, committed_mask);
+                    assert_eq!(
+                        sparse, dense,
+                        "leaf={leaf} old={old_mask:x} committed={committed_mask:x}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
         let mut tracker = MemoryPageTracker::new(3);
         let occupancy = MemoryOccupancyTracker::new(3);
         assert_ne!(tracker.insert(0, 1 << 0, &occupancy).added_mask, 0);
-        assert_eq!(tracker.insert(0, 1 << 0, &occupancy), MemoryHeightDelta::default());
+        assert_eq!(
+            tracker.insert(0, 1 << 0, &occupancy),
+            MemoryHeightDelta::default()
+        );
     }
 
     #[test]

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -6,6 +6,10 @@ use openvm_instructions::{
     DEFERRAL_AS, DIGEST_WIDTH, MEMORY_PAGE_BITS,
 };
 
+use super::page_tracker::{
+    leaf_mask_range, DefaultOldCounts, MemoryOccupancyTracker, MemoryPageTracker,
+};
+pub use super::page_tracker::PageAccess;
 use crate::{
     arch::{SystemConfig, ADDR_SPACE_OFFSET, BOUNDARY_AIR_ID, MERKLE_AIR_ID, U16_CELL_SIZE},
     system::memory::dimensions::MemoryDimensions,
@@ -20,637 +24,49 @@ const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
 // Shift amounts from address-space pointer units to memory Merkle leaves.
 const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
 const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
-
-// Masks with the first bit set in each aligned group of leaves. These represent
-// group occupancy at each page-local Merkle level.
-const FIRST_BIT_PER_PAIR: u64 = 0x5555_5555_5555_5555;
-const FIRST_BIT_PER_NIBBLE: u64 = 0x1111_1111_1111_1111;
-const FIRST_BIT_PER_BYTE: u64 = 0x0101_0101_0101_0101;
-const FIRST_BIT_PER_U16: u64 = 0x0001_0001_0001_0001;
-const FIRST_BIT_PER_U32: u64 = 0x0000_0001_0000_0001;
-const FIRST_BIT_PER_U64: u64 = 0x0000_0000_0000_0001;
 const FIELD_ELEMENT_BYTES: u32 = size_of::<u32>() as u32;
 
-// Counts old-side leaves and Merkle nodes whose subtrees are still canonical
-// default values at the start of the segment.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct DefaultOldCounts {
-    leaves: u32,
-    merkle_nodes: u32,
-    merkle_node_levels: u64,
-}
-
-impl DefaultOldCounts {
-    #[inline(always)]
-    fn add(&mut self, other: Self) {
-        self.leaves += other.leaves;
-        self.merkle_nodes += other.merkle_nodes;
-        self.merkle_node_levels |= other.merkle_node_levels;
-    }
-
-    #[inline(always)]
-    fn is_empty(self) -> bool {
-        self.leaves == 0 && self.merkle_nodes == 0 && self.merkle_node_levels == 0
-    }
-
-    #[inline(always)]
-    fn estimated_poseidon_rows(self) -> u32 {
-        u32::from(self.leaves != 0) + self.merkle_node_levels.count_ones()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct BitSet {
-    words: Box<[u64]>,
-    dirty_words: Vec<usize>,
-}
-
-impl BitSet {
-    pub fn new(num_bits: usize) -> Self {
-        Self {
-            words: vec![0; num_bits.div_ceil(u64::BITS as usize)].into_boxed_slice(),
-            dirty_words: Vec::new(),
-        }
-    }
-
-    #[inline(always)]
-    pub fn insert(&mut self, index: usize) -> bool {
-        self.insert_impl::<true>(index)
-    }
-
-    #[inline(always)]
-    fn insert_persistent(&mut self, index: usize) -> bool {
-        self.insert_impl::<false>(index)
-    }
-
-    #[inline(always)]
-    fn insert_impl<const TRACK_DIRTY: bool>(&mut self, index: usize) -> bool {
-        let word_index = index >> 6;
-        let bit_index = index & 63;
-        let mask = 1u64 << bit_index;
-
-        debug_assert!(word_index < self.words.len(), "BitSet index out of bounds");
-
-        // SAFETY: word_index is derived from a memory address that is bounds-checked
-        //         during memory access. The bitset is sized to accommodate all valid
-        //         memory addresses, so word_index is always within bounds.
-        let word = unsafe { self.words.get_unchecked_mut(word_index) };
-        let old_word = *word;
-        let was_set = (old_word & mask) != 0;
-        if was_set {
-            return false;
-        }
-        if TRACK_DIRTY && old_word == 0 {
-            self.dirty_words.push(word_index);
-        }
-        *word = old_word | mask;
-        true
-    }
-
-    #[inline(always)]
-    fn contains(&self, index: usize) -> bool {
-        let word_index = index >> 6;
-        let bit_index = index & 63;
-        let mask = 1u64 << bit_index;
-
-        debug_assert!(word_index < self.words.len(), "BitSet index out of bounds");
-
-        // SAFETY: word_index is derived from a valid memory tree node index.
-        unsafe { (*self.words.get_unchecked(word_index) & mask) != 0 }
-    }
-
-    /// Set all bits within [start, end) to 1, return the number of flipped bits.
-    /// Assumes start < end and end <= self.words.len() * 64.
-    #[inline(always)]
-    pub fn insert_range(&mut self, start: usize, end: usize) -> usize {
-        debug_assert!(start < end);
-        debug_assert!(end <= self.words.len() * 64, "BitSet range out of bounds");
-
-        let mut ret = 0;
-        let start_word_index = start >> 6;
-        let end_word_index = (end - 1) >> 6;
-        let start_bit = (start & 63) as u32;
-
-        if start_word_index == end_word_index {
-            let end_bit = ((end - 1) & 63) as u32 + 1;
-            let mask_bits = end_bit - start_bit;
-            let mask = (u64::MAX >> (64 - mask_bits)) << start_bit;
-            // SAFETY: Caller ensures start < end and end <= self.words.len() * 64,
-            // so start_word_index < self.words.len()
-            let word = unsafe { self.words.get_unchecked_mut(start_word_index) };
-            let old_word = *word;
-            ret += mask_bits - (old_word & mask).count_ones();
-            if old_word == 0 {
-                self.dirty_words.push(start_word_index);
-            }
-            *word = old_word | mask;
-        } else {
-            let end_bit = (end & 63) as u32;
-            let mask_bits = 64 - start_bit;
-            let mask = u64::MAX << start_bit;
-            // SAFETY: Caller ensures start < end and end <= self.words.len() * 64,
-            // so start_word_index < self.words.len()
-            let start_word = unsafe { self.words.get_unchecked_mut(start_word_index) };
-            let old_start_word = *start_word;
-            ret += mask_bits - (old_start_word & mask).count_ones();
-            if old_start_word == 0 {
-                self.dirty_words.push(start_word_index);
-            }
-            *start_word = old_start_word | mask;
-
-            let mask_bits = end_bit;
-            let mask = if end_bit == 0 {
-                0
-            } else {
-                u64::MAX >> (64 - end_bit)
-            };
-            // SAFETY: Caller ensures end <= self.words.len() * 64, so
-            // end_word_index < self.words.len()
-            let end_word = unsafe { self.words.get_unchecked_mut(end_word_index) };
-            let old_end_word = *end_word;
-            ret += mask_bits - (old_end_word & mask).count_ones();
-            if mask != 0 && old_end_word == 0 {
-                self.dirty_words.push(end_word_index);
-            }
-            *end_word = old_end_word | mask;
-        }
-
-        if start_word_index + 1 < end_word_index {
-            for i in (start_word_index + 1)..end_word_index {
-                // SAFETY: Caller ensures proper start and end, so i is within bounds
-                // of self.words.len()
-                let word = unsafe { self.words.get_unchecked_mut(i) };
-                let old_word = *word;
-                ret += old_word.count_zeros();
-                if old_word == 0 {
-                    self.dirty_words.push(i);
-                }
-                *word = u64::MAX;
-            }
-        }
-        ret as usize
-    }
-
-    #[inline(always)]
-    pub fn clear(&mut self) {
-        for word_index in self.dirty_words.drain(..) {
-            // SAFETY: dirty_words entries are word indices previously written by this BitSet.
-            unsafe {
-                *self.words.get_unchecked_mut(word_index) = 0;
-            }
-        }
-    }
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PageAccess {
-    /// Index into the page table. The leaf occupancy for this page is stored
-    /// in `leaf_mask`.
-    pub page_id: u32,
-    /// Bit `i` is set when leaf `i` inside this 64-leaf page was touched.
-    pub leaf_mask: u64,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct MemoryHeightDelta {
-    leaves: u32,
-    merkle_nodes: u32,
-    added_mask: u64,
-    default_old: DefaultOldCounts,
-}
-
-#[derive(Clone, Debug)]
-pub struct MemoryPageTracker {
-    page_masks: Box<[u64]>,
-    dirty_pages: Vec<usize>,
-    upper_nodes: BitSet,
-    upper_height: usize,
-}
-
-impl MemoryPageTracker {
-    pub fn new(upper_height: usize) -> Self {
-        let num_pages = 1 << upper_height;
-        Self {
-            page_masks: vec![0; num_pages].into_boxed_slice(),
-            dirty_pages: Vec::new(),
-            upper_nodes: BitSet::new(num_pages),
-            upper_height,
-        }
-    }
-
-    #[inline(always)]
-    pub fn clear(&mut self) {
-        for page_id in self.dirty_pages.drain(..) {
-            // SAFETY: dirty_pages entries are page indices previously written by this tracker.
-            unsafe {
-                *self.page_masks.get_unchecked_mut(page_id) = 0;
-            }
-        }
-        self.upper_nodes.clear();
-    }
-
-    #[inline(always)]
-    fn insert(
-        &mut self,
-        page_id: usize,
-        leaf_mask: u64,
-        occupancy_tracker: &MemoryOccupancyTracker,
-    ) -> MemoryHeightDelta {
-        debug_assert!(page_id < self.page_masks.len());
-        debug_assert!(leaf_mask != 0);
-
-        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
-        let old_mask = *page_mask;
-        let new_mask = old_mask | leaf_mask;
-        if new_mask == old_mask {
-            return MemoryHeightDelta::default();
-        }
-
-        *page_mask = new_mask;
-        if old_mask == 0 {
-            self.dirty_pages.push(page_id);
-        }
-        // Newly set bits are the only leaves that can add boundary rows or new
-        // page-local Merkle nodes.
-        let added_mask = leaf_mask & !old_mask;
-        let committed_mask = occupancy_tracker.page_mask(page_id);
-        let default_leaf_mask = added_mask & !committed_mask;
-        let single_added_leaf = added_mask.is_power_of_two();
-        let leaves = if single_added_leaf {
-            1
-        } else {
-            added_mask.count_ones()
-        };
-
-        let (mut merkle_nodes, mut default_old) = if default_leaf_mask == 0 {
-            (
-                if single_added_leaf {
-                    local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros())
-                } else {
-                    local_merkle_nodes_delta(old_mask, added_mask)
-                },
-                DefaultOldCounts::default(),
-            )
-        } else if single_added_leaf {
-            local_merkle_nodes_added_leaf_with_default(
-                old_mask,
-                added_mask.trailing_zeros(),
-                committed_mask,
-            )
-        } else {
-            // Multi-leaf path: walk old and added occupancy up the six
-            // page-local levels, then count groups newly occupied by added leaves.
-            local_merkle_nodes_delta_with_default(old_mask, added_mask, committed_mask)
-        };
-        if default_leaf_mask != 0 {
-            default_old.leaves = if single_added_leaf {
-                1
-            } else {
-                default_leaf_mask.count_ones()
-            };
-        }
-
-        if old_mask == 0 {
-            if committed_mask == 0 {
-                let (upper_nodes, upper_default_old) =
-                    self.insert_upper_path(page_id, occupancy_tracker);
-                merkle_nodes += upper_nodes;
-                default_old.add(upper_default_old);
-            } else {
-                merkle_nodes += self.insert_upper_path_count_only(page_id);
-            }
-        }
-        MemoryHeightDelta {
-            leaves,
-            merkle_nodes,
-            added_mask,
-            default_old,
-        }
-    }
-
-    #[inline(always)]
-    fn insert_upper_path(
-        &mut self,
-        page_id: usize,
-        occupancy_tracker: &MemoryOccupancyTracker,
-    ) -> (u32, DefaultOldCounts) {
-        // Called only when a page first becomes non-empty in this segment.
-        // `upper_nodes` makes nearby pages share already-counted ancestors.
-        let mut count = 0;
-        let mut default_old = DefaultOldCounts::default();
-        let mut node = (1usize << self.upper_height) + page_id;
-        let mut height = MEMORY_PAGE_BITS + 1;
-        while node > 1 {
-            node >>= 1;
-            if self.upper_nodes.insert(node) {
-                count += 1;
-                if !occupancy_tracker.upper_contains(node) {
-                    default_old.merkle_nodes += 1;
-                    default_old.merkle_node_levels |= 1u64 << height;
-                }
-            } else {
-                break;
-            }
-            height += 1;
-        }
-        (count, default_old)
-    }
-
-    #[inline(always)]
-    fn insert_upper_path_count_only(&mut self, page_id: usize) -> u32 {
-        let mut count = 0;
-        let mut node = (1usize << self.upper_height) + page_id;
-        while node > 1 {
-            node >>= 1;
-            if self.upper_nodes.insert(node) {
-                count += 1;
-            } else {
-                break;
-            }
-        }
-        count
-    }
-}
-
-#[derive(Clone, Debug)]
-struct MemoryOccupancyTracker {
-    page_masks: Box<[u64]>,
-    upper_nodes: BitSet,
-    upper_height: usize,
-}
-
-impl MemoryOccupancyTracker {
-    pub fn new(upper_height: usize) -> Self {
-        let num_pages = 1 << upper_height;
-        Self {
-            page_masks: vec![0; num_pages].into_boxed_slice(),
-            upper_nodes: BitSet::new(num_pages),
-            upper_height,
-        }
-    }
-
-    #[inline(always)]
-    fn page_mask(&self, page_id: usize) -> u64 {
-        debug_assert!(page_id < self.page_masks.len());
-        unsafe { *self.page_masks.get_unchecked(page_id) }
-    }
-
-    #[inline(always)]
-    fn upper_contains(&self, node: usize) -> bool {
-        self.upper_nodes.contains(node)
-    }
-
-    #[inline(always)]
-    fn mark_existing_page(&mut self, page_id: usize, leaf_mask: u64) {
-        debug_assert!(page_id < self.page_masks.len());
-        debug_assert!(leaf_mask != 0);
-
-        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
-        let old_mask = *page_mask;
-        *page_mask = old_mask | leaf_mask;
-        if old_mask == 0 {
-            self.mark_upper_path(page_id);
-        }
-    }
-
-    #[inline(always)]
-    fn commit_page_accesses(&mut self, accesses: &[PageAccess]) {
-        for &access in accesses {
-            self.mark_existing_page(access.page_id as usize, access.leaf_mask);
-        }
-    }
-
-    #[inline(always)]
-    fn mark_upper_path(&mut self, page_id: usize) {
-        let mut node = (1usize << self.upper_height) + page_id;
-        while node > 1 {
-            node >>= 1;
-            if !self.upper_nodes.insert_persistent(node) {
-                break;
-            }
-        }
-    }
-}
-
 #[inline(always)]
-fn leaf_mask_range(start: u32, end: u32) -> u64 {
-    debug_assert!(start < end);
-    debug_assert!(end <= 64);
-    let width = end - start;
-    let mask = if width == 64 {
-        u64::MAX
-    } else {
-        (1u64 << width) - 1
-    };
-    mask << start
-}
-
-#[inline(always)]
-fn add_level_delta<const SHIFT: u32, const MASK: u64>(
-    old_mask: &mut u64,
-    added_mask: &mut u64,
-) -> u32 {
-    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
-    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
-    (*added_mask & !*old_mask).count_ones()
-}
-
-#[inline(always)]
-fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
-    debug_assert_ne!(added_mask, 0);
-    debug_assert_eq!(old_mask & added_mask, 0);
-
-    let mut nodes = 0;
-    nodes += add_level_delta::<1, FIRST_BIT_PER_PAIR>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<2, FIRST_BIT_PER_NIBBLE>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<4, FIRST_BIT_PER_BYTE>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<8, FIRST_BIT_PER_U16>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<16, FIRST_BIT_PER_U32>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<32, FIRST_BIT_PER_U64>(&mut old_mask, &mut added_mask);
-
-    nodes
-}
-
-#[inline(always)]
-fn aligned_group_is_empty<const GROUP_SIZE: u32>(old_mask: u64, leaf: u32) -> bool {
-    let group_start = leaf & !(GROUP_SIZE - 1);
-    let group_mask = ((1u64 << GROUP_SIZE) - 1) << group_start;
-    old_mask & group_mask == 0
-}
-
-#[inline(always)]
-fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
-    debug_assert!(leaf < u64::BITS);
-
-    if old_mask == 0 {
-        return MEMORY_PAGE_BITS as u32;
-    }
-
-    let mut nodes = 0;
-    nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
-    nodes
-}
-
-#[inline(always)]
-fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32>(
-    old_mask: u64,
-    committed_mask: u64,
-    leaf: u32,
-    level: usize,
-    default_old: &mut DefaultOldCounts,
-) -> u32 {
-    if aligned_group_is_empty::<GROUP_SIZE>(old_mask, leaf) {
-        if aligned_group_is_empty::<GROUP_SIZE>(committed_mask, leaf) {
-            default_old.merkle_nodes += 1;
-            default_old.merkle_node_levels |= 1u64 << level;
-        }
-        1
-    } else {
-        0
-    }
-}
-
-#[inline(always)]
-fn local_merkle_nodes_added_leaf_with_default(
-    old_mask: u64,
-    leaf: u32,
-    committed_mask: u64,
-) -> (u32, DefaultOldCounts) {
-    debug_assert!(leaf < u64::BITS);
-
-    if old_mask == 0 && committed_mask == 0 {
-        return (
-            PAGE_BITS as u32,
-            DefaultOldCounts {
-                leaves: 0,
-                merkle_nodes: PAGE_BITS as u32,
-                merkle_node_levels: (1u64 << (PAGE_BITS + 1)) - 2,
-            },
-        );
-    }
-
-    let mut default_old = DefaultOldCounts::default();
-    let mut nodes = 0;
-    nodes +=
-        add_leaf_level_delta_with_default::<2>(old_mask, committed_mask, leaf, 1, &mut default_old);
-    nodes +=
-        add_leaf_level_delta_with_default::<4>(old_mask, committed_mask, leaf, 2, &mut default_old);
-    nodes +=
-        add_leaf_level_delta_with_default::<8>(old_mask, committed_mask, leaf, 3, &mut default_old);
-    nodes += add_leaf_level_delta_with_default::<16>(
-        old_mask,
-        committed_mask,
-        leaf,
-        4,
-        &mut default_old,
-    );
-    nodes += add_leaf_level_delta_with_default::<32>(
-        old_mask,
-        committed_mask,
-        leaf,
-        5,
-        &mut default_old,
-    );
-
-    if old_mask == 0 {
-        nodes += 1;
-        if committed_mask == 0 {
-            default_old.merkle_nodes += 1;
-            default_old.merkle_node_levels |= 1u64 << PAGE_BITS;
+fn push_page_access(accesses: &mut Vec<PageAccess>, page_id: u32, leaf_mask: u64) {
+    debug_assert!(leaf_mask != 0);
+    let len = accesses.len();
+    if len != 0 {
+        // SAFETY: len is non-zero, so len - 1 is in bounds.
+        let prev = unsafe { accesses.get_unchecked_mut(len - 1) };
+        if prev.page_id == page_id {
+            prev.leaf_mask |= leaf_mask;
+            return;
         }
     }
 
-    (nodes, default_old)
+    if len == accesses.capacity() {
+        accesses.reserve(1);
+    }
+
+    // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
+    unsafe {
+        accesses
+            .as_mut_ptr()
+            .add(len)
+            .write(PageAccess { page_id, leaf_mask });
+        accesses.set_len(len + 1);
+    }
 }
-
-#[inline(always)]
-fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64>(
-    old_mask: &mut u64,
-    added_mask: &mut u64,
-    committed_mask: &mut u64,
-    level: usize,
-    default_old: &mut DefaultOldCounts,
-) -> u32 {
-    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
-    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
-    *committed_mask = (*committed_mask | (*committed_mask >> SHIFT)) & MASK;
-    let new_nodes = *added_mask & !*old_mask;
-    let default_nodes = new_nodes & !*committed_mask;
-    default_old.merkle_nodes += default_nodes.count_ones();
-    default_old.merkle_node_levels |= u64::from(default_nodes != 0) << level;
-    new_nodes.count_ones()
-}
-
-#[inline(always)]
-fn local_merkle_nodes_delta_with_default(
-    mut old_mask: u64,
-    mut added_mask: u64,
-    mut committed_mask: u64,
-) -> (u32, DefaultOldCounts) {
-    debug_assert_ne!(added_mask, 0);
-    debug_assert_eq!(old_mask & added_mask, 0);
-
-    let mut default_old = DefaultOldCounts::default();
-    let mut nodes = 0;
-    nodes += add_level_delta_with_default::<1, FIRST_BIT_PER_PAIR>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
-        1,
-        &mut default_old,
-    );
-    nodes += add_level_delta_with_default::<2, FIRST_BIT_PER_NIBBLE>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
-        2,
-        &mut default_old,
-    );
-    nodes += add_level_delta_with_default::<4, FIRST_BIT_PER_BYTE>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
-        3,
-        &mut default_old,
-    );
-    nodes += add_level_delta_with_default::<8, FIRST_BIT_PER_U16>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
-        4,
-        &mut default_old,
-    );
-    nodes += add_level_delta_with_default::<16, FIRST_BIT_PER_U32>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
-        5,
-        &mut default_old,
-    );
-    nodes += add_level_delta_with_default::<32, FIRST_BIT_PER_U64>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
-        6,
-        &mut default_old,
-    );
-
-    (nodes, default_old)
-}
-
 #[derive(Clone, Debug)]
 pub struct MemoryCtx {
     memory_dimensions: MemoryDimensions,
-    pub page_tracker: MemoryPageTracker,
+    /// Segment-local occupancy. Cleared at segment boundaries; it prevents
+    /// charging the same leaf or Merkle node twice inside one segment.
+    page_tracker: MemoryPageTracker,
+    /// Committed occupancy at the last safe checkpoint, seeded with nonzero
+    /// initial memory. This tells us whether an old value is canonical default.
     occupancy_tracker: MemoryOccupancyTracker,
     pub page_indices_since_checkpoint: Vec<PageAccess>,
     pub page_indices_since_checkpoint_len: usize,
     page_indices_applied_len: usize,
+    /// New leaves already reflected in `trace_heights` and queued for the next
+    /// checkpoint commit. Segment replay clears this queue and recomputes
+    /// heights from `page_indices_since_checkpoint`.
     pending_occupancy_updates: Vec<PageAccess>,
     pending_leaves: u32,
     pending_merkle_nodes: u32,
@@ -709,7 +125,7 @@ impl MemoryCtx {
     }
 
     #[inline(always)]
-    fn mark_existing_memory_range(&mut self, address_space: u32, ptr: u32, size: u32) {
+    fn leaf_id_range(&self, address_space: u32, ptr: u32, size: u32) -> (u32, u32) {
         let end_ptr = ptr + size - 1;
         let leaf_bits = if address_space == DEFERRAL_AS {
             DEFERRAL_PTRS_PER_LEAF_BITS
@@ -719,10 +135,21 @@ impl MemoryCtx {
         let leaf_label = ptr >> leaf_bits;
         let end_leaf_label = end_ptr >> leaf_bits;
         let num_leaves = end_leaf_label - leaf_label + 1;
+        debug_assert!(
+            leaf_label < (1 << self.memory_dimensions.address_height),
+            "leaf_label={leaf_label} exceeds address_height={}",
+            self.memory_dimensions.address_height
+        );
         let address_space_offset = (((address_space - ADDR_SPACE_OFFSET) as u64)
             << self.memory_dimensions.address_height) as u32;
         let start_leaf_id = address_space_offset + leaf_label;
         let end_leaf_id = start_leaf_id + num_leaves;
+        (start_leaf_id, end_leaf_id)
+    }
+
+    #[inline(always)]
+    fn mark_existing_memory_range(&mut self, address_space: u32, ptr: u32, size: u32) {
+        let (start_leaf_id, end_leaf_id) = self.leaf_id_range(address_space, ptr, size);
         let start_page_id = start_leaf_id >> MEMORY_PAGE_BITS;
         let end_page_id = ((end_leaf_id - 1) >> MEMORY_PAGE_BITS) + 1;
 
@@ -747,28 +174,13 @@ impl MemoryCtx {
         ptr: u32,
         size: u32,
     ) {
-        let end_ptr = ptr + size - 1;
-        let leaf_bits = if address_space == DEFERRAL_AS {
-            DEFERRAL_PTRS_PER_LEAF_BITS
-        } else {
-            BYTE_PTRS_PER_LEAF_BITS
-        };
-        let leaf_label = ptr >> leaf_bits;
-        let end_leaf_label = end_ptr >> leaf_bits;
-        let num_leaves = end_leaf_label - leaf_label + 1;
-        debug_assert!(
-            leaf_label < (1 << self.memory_dimensions.address_height),
-            "leaf_label={leaf_label} exceeds address_height={}",
-            self.memory_dimensions.address_height
-        );
-        let address_space_offset = (((address_space - ADDR_SPACE_OFFSET) as u64)
-            << self.memory_dimensions.address_height) as u32;
-        let start_leaf_id = address_space_offset + leaf_label;
-        let end_leaf_id = start_leaf_id + num_leaves;
+        let (start_leaf_id, end_leaf_id) = self.leaf_id_range(address_space, ptr, size);
+        let num_leaves = end_leaf_id - start_leaf_id;
         let start_page_id = start_leaf_id >> MEMORY_PAGE_BITS;
 
         if num_leaves == 1 {
-            self.record_page_access_no_len_update(
+            push_page_access(
+                &mut self.page_indices_since_checkpoint,
                 start_page_id,
                 1u64 << (start_leaf_id & ((1 << MEMORY_PAGE_BITS) - 1)),
             );
@@ -792,68 +204,9 @@ impl MemoryCtx {
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
-            self.record_page_access_no_len_update(page_id, leaf_mask);
+            push_page_access(&mut self.page_indices_since_checkpoint, page_id, leaf_mask);
         }
         self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
-    }
-
-    #[inline(always)]
-    fn record_page_access_no_len_update(&mut self, page_id: u32, leaf_mask: u64) {
-        debug_assert!(leaf_mask != 0);
-        let len = self.page_indices_since_checkpoint.len();
-        if len != 0 {
-            // SAFETY: len is non-zero, so len - 1 is in bounds.
-            let prev = unsafe {
-                self.page_indices_since_checkpoint
-                    .get_unchecked_mut(len - 1)
-            };
-            if prev.page_id == page_id {
-                // Consecutive accesses to the same page merge in-place; the
-                // tracker later deduplicates non-consecutive repeats.
-                prev.leaf_mask |= leaf_mask;
-                return;
-            }
-        }
-
-        if len == self.page_indices_since_checkpoint.capacity() {
-            self.page_indices_since_checkpoint.reserve(1);
-        }
-
-        // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
-        unsafe {
-            self.page_indices_since_checkpoint
-                .as_mut_ptr()
-                .add(len)
-                .write(PageAccess { page_id, leaf_mask });
-            self.page_indices_since_checkpoint.set_len(len + 1);
-        }
-    }
-
-    #[inline(always)]
-    fn record_pending_occupancy_update(&mut self, page_id: u32, leaf_mask: u64) {
-        debug_assert!(leaf_mask != 0);
-        let len = self.pending_occupancy_updates.len();
-        if len != 0 {
-            // SAFETY: len is non-zero, so len - 1 is in bounds.
-            let prev = unsafe { self.pending_occupancy_updates.get_unchecked_mut(len - 1) };
-            if prev.page_id == page_id {
-                prev.leaf_mask |= leaf_mask;
-                return;
-            }
-        }
-
-        if len == self.pending_occupancy_updates.capacity() {
-            self.pending_occupancy_updates.reserve(1);
-        }
-
-        // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
-        unsafe {
-            self.pending_occupancy_updates
-                .as_mut_ptr()
-                .add(len)
-                .write(PageAccess { page_id, leaf_mask });
-            self.pending_occupancy_updates.set_len(len + 1);
-        }
     }
 
     #[cfg(feature = "rvr")]
@@ -878,7 +231,11 @@ impl MemoryCtx {
             if delta.added_mask != 0 {
                 self.pending_leaves += delta.leaves;
                 self.pending_merkle_nodes += delta.merkle_nodes;
-                self.record_pending_occupancy_update(page_id, delta.added_mask);
+                push_page_access(
+                    &mut self.pending_occupancy_updates,
+                    page_id,
+                    delta.added_mask,
+                );
                 self.pending_default_old.add(delta.default_old);
             }
         }
@@ -952,36 +309,14 @@ impl MemoryCtx {
         self.pending_default_old = DefaultOldCounts::default();
     }
 
-    /// Applies boundary and Merkle height deltas for the page/leaf masks recorded
-    /// since the last checkpoint.
-    ///
-    /// Memory leaves form a sparse Merkle tree. Each page contains the 64 leaves
-    /// represented by one `u64` leaf mask:
-    ///
-    /// ```text
-    ///        [root]              height h
-    ///        /    \
-    ///      ...    ...
-    ///      /        \
-    ///   [page]    [page]         (h - MEMORY_PAGE_BITS) nodes above each page
-    ///   / .. \
-    ///  L  ..  L                  MEMORY_PAGE_BITS levels inside a 64-leaf page
-    /// ```
-    ///
-    /// `MemoryPageTracker` counts each newly touched leaf once, each newly
-    /// required internal node inside that page once, and each shared ancestor
-    /// above the page once across all pages in the segment. Each segment has an
-    /// initial and final memory tree, so boundary and Merkle row counts are
-    /// doubled.
+    /// Applies memory height deltas recorded since the last checkpoint.
     ///
     /// - BOUNDARY_AIR: `2 * new_leaves` rows
     /// - MERKLE_AIR:   `2 * new_merkle_nodes` rows
     /// - Poseidon2:    final-side hashes plus old-side hashes
     ///
-    /// Old leaves and internal nodes that were definitely default before the
-    /// segment use canonical default Poseidon2 inputs. Default leaves share
-    /// one input, and default internal nodes share one input per Merkle height.
-    /// Other old-side hashes are counted structurally.
+    /// Old-side default leaves share one Poseidon2 input. Old-side default
+    /// internal nodes share one input per Merkle height.
     #[inline(always)]
     pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_leaves;
@@ -1004,13 +339,17 @@ impl MemoryCtx {
             if delta.added_mask != 0 {
                 leaves += delta.leaves;
                 merkle_nodes += delta.merkle_nodes;
-                self.record_pending_occupancy_update(access.page_id, delta.added_mask);
+                push_page_access(
+                    &mut self.pending_occupancy_updates,
+                    access.page_id,
+                    delta.added_mask,
+                );
                 default_old.add(delta.default_old);
             }
         }
         self.page_indices_applied_len = len;
 
-        if leaves == 0 && merkle_nodes == 0 && default_old.is_empty() {
+        if leaves == 0 && merkle_nodes == 0 {
             return;
         }
 
@@ -1034,181 +373,6 @@ impl MemoryCtx {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn reference_parent_mask(mut mask: u64) -> u64 {
-        let mut parents = 0;
-        while mask != 0 {
-            let bit = mask.trailing_zeros();
-            parents |= 1u64 << (bit >> 1);
-            mask &= mask - 1;
-        }
-        parents
-    }
-
-    fn reference_local_merkle_nodes(mask: u64) -> u32 {
-        let mut nodes = 0;
-        let mut level_mask = mask;
-        for _ in 0..MEMORY_PAGE_BITS {
-            level_mask = reference_parent_mask(level_mask);
-            nodes += level_mask.count_ones();
-        }
-        nodes
-    }
-
-    #[test]
-    fn test_bitset_insert_range() {
-        // 513 bits
-        let mut bit_set = BitSet::new(8 * 64 + 1);
-        let num_flips = bit_set.insert_range(2, 29);
-        assert_eq!(num_flips, 27);
-        let num_flips = bit_set.insert_range(1, 31);
-        assert_eq!(num_flips, 3);
-
-        let num_flips = bit_set.insert_range(32, 65);
-        assert_eq!(num_flips, 33);
-        let num_flips = bit_set.insert_range(0, 66);
-        assert_eq!(num_flips, 3);
-        let num_flips = bit_set.insert_range(0, 66);
-        assert_eq!(num_flips, 0);
-
-        let num_flips = bit_set.insert_range(256, 320);
-        assert_eq!(num_flips, 64);
-        let num_flips = bit_set.insert_range(256, 377);
-        assert_eq!(num_flips, 57);
-        let num_flips = bit_set.insert_range(100, 513);
-        assert_eq!(num_flips, 413 - 121);
-    }
-
-    #[test]
-    fn test_local_merkle_nodes_doc_example() {
-        let mut tracker = MemoryPageTracker::new(0);
-        let occupancy = MemoryOccupancyTracker::new(0);
-        let mut nodes = 0;
-        nodes += tracker.insert(0, 1 << 0, &occupancy).merkle_nodes;
-        assert_eq!(nodes, 6);
-        nodes += tracker.insert(0, 1 << 4, &occupancy).merkle_nodes;
-        assert_eq!(nodes, 8);
-        nodes += tracker.insert(0, 1 << 2, &occupancy).merkle_nodes;
-        assert_eq!(nodes, 9);
-    }
-
-    #[test]
-    fn test_local_merkle_nodes_added_matches_reference_delta() {
-        let mut old_mask = 0u64;
-        let additions = [
-            1u64 << 0,
-            1u64 << 1,
-            1u64 << 4,
-            1u64 << 17,
-            1u64 << 31,
-            1u64 << 32,
-            1u64 << 63,
-            0x5555_0000_0000_0000,
-            0xaaaa_ffff_0000_0000,
-            u64::MAX,
-        ];
-        for leaf_mask in additions {
-            let new_mask = old_mask | leaf_mask;
-            if new_mask != old_mask {
-                let added_mask = new_mask ^ old_mask;
-                let expected =
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
-                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
-                old_mask = new_mask;
-            }
-        }
-
-        old_mask = 1;
-        for leaf_mask in additions {
-            let new_mask = old_mask | leaf_mask;
-            if new_mask != old_mask {
-                let added_mask = new_mask ^ old_mask;
-                let expected =
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
-                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
-                old_mask = new_mask;
-            }
-        }
-
-        let mut seed = 0x9e37_79b9_7f4a_7c15u64;
-        for _ in 0..1024 {
-            seed ^= seed << 7;
-            seed ^= seed >> 9;
-            seed ^= seed << 8;
-            let old_mask = seed;
-            seed ^= seed << 7;
-            seed ^= seed >> 9;
-            seed ^= seed << 8;
-            let new_mask = old_mask | seed;
-            if new_mask != old_mask {
-                let added_mask = new_mask ^ old_mask;
-                assert_eq!(
-                    local_merkle_nodes_delta(old_mask, added_mask),
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_default_single_leaf_matches_dense_delta() {
-        for leaf in 0..u64::BITS {
-            let added = 1u64 << leaf;
-            let old_patterns = [0, 1, 0x5555_5555_5555_5555, 0xaaaa_aaaa_aaaa_aaaa, u64::MAX];
-            let committed_patterns = [0, 1, 0x3333_3333_3333_3333, 0xcccc_cccc_cccc_cccc, u64::MAX];
-
-            for old_mask in old_patterns {
-                let old_mask = old_mask & !added;
-                for committed_mask in committed_patterns {
-                    let committed_mask = committed_mask & !added;
-                    let dense =
-                        local_merkle_nodes_delta_with_default(old_mask, added, committed_mask);
-                    let sparse =
-                        local_merkle_nodes_added_leaf_with_default(old_mask, leaf, committed_mask);
-                    assert_eq!(
-                        sparse, dense,
-                        "leaf={leaf} old={old_mask:x} committed={committed_mask:x}"
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_page_mask_duplicate_leaf_does_not_change_counts() {
-        let mut tracker = MemoryPageTracker::new(3);
-        let occupancy = MemoryOccupancyTracker::new(3);
-        assert_ne!(tracker.insert(0, 1 << 0, &occupancy).added_mask, 0);
-        assert_eq!(
-            tracker.insert(0, 1 << 0, &occupancy),
-            MemoryHeightDelta::default()
-        );
-    }
-
-    #[test]
-    fn test_memory_page_tracker_clear_resets_touched_state() {
-        let mut tracker = MemoryPageTracker::new(3);
-        let occupancy = MemoryOccupancyTracker::new(3);
-        let first = tracker.insert(0, 1 << 0, &occupancy);
-        let second = tracker.insert(7, 1 << 63, &occupancy);
-        assert!(first.leaves + second.leaves > 0);
-        assert!(first.merkle_nodes + second.merkle_nodes > 0);
-
-        tracker.clear();
-
-        let after_clear = tracker.insert(0, 1 << 0, &occupancy);
-        assert_eq!(after_clear.leaves, 1);
-        assert!(after_clear.merkle_nodes > 0);
-    }
-
-    #[test]
-    fn test_adjacent_pages_share_upper_ancestors() {
-        let mut tracker = MemoryPageTracker::new(3);
-        let occupancy = MemoryOccupancyTracker::new(3);
-        tracker.insert(0, 1, &occupancy);
-        let second = tracker.insert(1, 1, &occupancy);
-        assert_eq!(second.merkle_nodes, MEMORY_PAGE_BITS as u32);
-    }
 
     #[test]
     fn test_range_insertion_matches_explicit_leaves() {
@@ -1237,26 +401,9 @@ mod tests {
         ctx.update_boundary_merkle_heights(2, 0, 1);
         ctx.apply_height_updates(&mut trace_heights);
 
-        let page_id = ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize
-            >> MEMORY_PAGE_BITS;
+        let page_id =
+            ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize >> MEMORY_PAGE_BITS;
         assert_eq!(ctx.occupancy_tracker.page_mask(page_id), 0);
-    }
-
-    #[test]
-    fn test_checkpoint_commit_keeps_occupied_counts() {
-        let mut occupancy = MemoryOccupancyTracker::new(1);
-        let mut tracker = MemoryPageTracker::new(1);
-
-        let first = tracker.insert(0, 1, &occupancy).default_old;
-        occupancy.commit_page_accesses(&[PageAccess {
-            page_id: 0,
-            leaf_mask: 1,
-        }]);
-        tracker.clear();
-        let second = tracker.insert(0, 1, &occupancy).default_old;
-
-        assert!(first.leaves > 0);
-        assert_eq!(second, DefaultOldCounts::default());
     }
 
     #[test]
@@ -1337,40 +484,5 @@ mod tests {
 
         let poseidon2_idx = trace_heights.len() - 2;
         assert_eq!(trace_heights[poseidon2_idx], 2 * height + 4);
-    }
-
-    #[test]
-    fn test_initialize_segment_replays_with_default_occupancy() {
-        let system_config = crate::utils::test_system_config();
-        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
-
-        let mut ctx = MemoryCtx::new(&system_config, 1);
-        let mut trace_heights = vec![0; 6];
-        ctx.add_register_merkle_heights();
-        ctx.apply_height_updates(&mut trace_heights);
-        ctx.update_checkpoint();
-
-        ctx.update_boundary_merkle_heights(2, 0, 1);
-        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
-
-        let poseidon2_idx = trace_heights.len() - 2;
-        ctx.apply_height_updates(&mut trace_heights);
-
-        ctx.initialize_segment(&mut trace_heights);
-
-        let mut clean_ctx = MemoryCtx::new(&system_config, 1);
-        let mut clean_trace_heights = vec![0; 6];
-        clean_ctx.add_register_merkle_heights();
-        clean_ctx.apply_height_updates(&mut clean_trace_heights);
-        clean_ctx.update_checkpoint();
-        clean_ctx.initialize_segment(&mut clean_trace_heights);
-
-        let replayed_poseidon_rows =
-            trace_heights[poseidon2_idx] - clean_trace_heights[poseidon2_idx];
-        let replayed_leaves =
-            (trace_heights[BOUNDARY_AIR_ID] - clean_trace_heights[BOUNDARY_AIR_ID]) / 2;
-        let replayed_merkle_nodes =
-            (trace_heights[MERKLE_AIR_ID] - clean_trace_heights[MERKLE_AIR_ID]) / 2;
-        assert!(replayed_poseidon_rows > replayed_leaves + replayed_merkle_nodes);
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -5,10 +5,13 @@ use openvm_instructions::{
     riscv::{RV64_NUM_REGISTERS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
     DEFERRAL_AS, DIGEST_WIDTH, MEMORY_PAGE_BITS,
 };
+#[cfg(test)]
+use openvm_instructions::{riscv::RV64_MEMORY_AS, PUBLIC_VALUES_AS};
 
-pub use super::memory_tracker::PageAccess;
+pub use super::memory_tracker::PageTouch;
 use super::memory_tracker::{
-    leaf_mask_range, GlobalFirstTouchCounts, GlobalMemoryTracker, SegmentMemoryTracker,
+    leaf_mask_range, BaselineMemoryTracker, DefaultPoseidonRowTracker, FirstTouchCounts,
+    SegmentMemoryTracker,
 };
 use crate::{
     arch::{SystemConfig, ADDR_SPACE_OFFSET, BOUNDARY_AIR_ID, MERKLE_AIR_ID, U16_CELL_SIZE},
@@ -16,7 +19,7 @@ use crate::{
 };
 
 /// Upper bound on number of memory pages accessed per instruction. Used for buffer allocation.
-pub const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
+const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
 // Initial allocation only. Correctness is preserved by `Vec::reserve` for large
 // range accesses; this avoids preallocating the worst-case per-instruction page
 // count for the common scalar-access path.
@@ -26,29 +29,35 @@ const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
 const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
 const FIELD_ELEMENT_BYTES: u32 = size_of::<u32>() as u32;
 
+/// Tracks which parts of memory contribute rows to the current segment.
+///
+/// It separately remembers what the current segment has used and what memory existed at the last
+/// safe checkpoint. If the segment ends at that checkpoint, later touches are replayed into the
+/// next segment. Repeated touches in one segment are counted only once.
 #[derive(Clone, Debug)]
 pub struct MemoryCtx {
     /// Memory tree dimensions used to map address-space ranges into global leaf ids.
     memory_dimensions: MemoryDimensions,
     /// Memory leaves and nodes already counted in the current segment.
     segment_memory: SegmentMemoryTracker,
-    /// Memory leaves and nodes present in the global baseline at the last checkpoint.
-    global_memory: GlobalMemoryTracker,
-    /// Page masks recorded since the last safe checkpoint by the normal metered path.
-    pub page_indices_since_checkpoint: Vec<PageAccess>,
+    /// Memory leaves and nodes present in the baseline at the last checkpoint.
+    baseline_memory: BaselineMemoryTracker,
+    /// Touches since the last safe checkpoint, kept so they can be replayed into a new segment.
+    pub page_indices_since_checkpoint: Vec<PageTouch>,
     /// Length mirror used by generated metered code that appends through the raw buffer.
     pub page_indices_since_checkpoint_len: usize,
-    /// Number of checkpoint-buffer entries already reflected in `trace_heights`.
+    /// Number of buffered touches already included in the current row estimates.
     page_indices_applied_len: usize,
-    /// New segment leaf masks queued for the next checkpoint. Segment
-    /// replay clears this queue and recomputes it from `page_indices_since_checkpoint`.
-    pending_global_updates: Vec<PageAccess>,
-    /// New segment leaves accumulated by direct page-buffer application.
+    /// Newly used leaves that will become part of the baseline at the next safe checkpoint.
+    pending_baseline_updates: Vec<PageTouch>,
+    /// Newly used leaves waiting to be added to the Boundary row estimate.
     pending_segment_leaves: u32,
-    /// New segment Merkle nodes accumulated by direct page-buffer application.
+    /// Newly needed tree nodes waiting to be added to the Merkle row estimate.
     pending_segment_merkle_nodes: u32,
-    /// Global first touches paired with the pending height deltas.
-    pending_global_first_touches: GlobalFirstTouchCounts,
+    /// Pending leaves and nodes that were absent at the last checkpoint.
+    pending_first_touches: FirstTouchCounts,
+    /// Reusable default-hash rows already charged in the current segment.
+    default_poseidon_rows: DefaultPoseidonRowTracker,
 }
 
 impl MemoryCtx {
@@ -62,14 +71,15 @@ impl MemoryCtx {
         Self {
             memory_dimensions,
             segment_memory: SegmentMemoryTracker::new(upper_height),
-            global_memory: GlobalMemoryTracker::new(upper_height),
+            baseline_memory: BaselineMemoryTracker::new(upper_height),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
             page_indices_applied_len: 0,
-            pending_global_updates: Vec::with_capacity(checkpoint_capacity),
+            pending_baseline_updates: Vec::with_capacity(checkpoint_capacity),
             pending_segment_leaves: 0,
             pending_segment_merkle_nodes: 0,
-            pending_global_first_touches: GlobalFirstTouchCounts::default(),
+            pending_first_touches: FirstTouchCounts::default(),
+            default_poseidon_rows: DefaultPoseidonRowTracker::default(),
         }
     }
 
@@ -137,7 +147,7 @@ impl MemoryCtx {
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
-            self.global_memory
+            self.baseline_memory
                 .mark_existing_page(page_id as usize, leaf_mask);
         }
     }
@@ -157,7 +167,7 @@ impl MemoryCtx {
         let start_page_id = start_leaf_id >> MEMORY_PAGE_BITS;
 
         if num_leaves == 1 {
-            push_page_access(
+            push_page_touch(
                 &mut self.page_indices_since_checkpoint,
                 start_page_id,
                 1u64 << (start_leaf_id & ((1 << MEMORY_PAGE_BITS) - 1)),
@@ -182,38 +192,39 @@ impl MemoryCtx {
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
-            push_page_access(&mut self.page_indices_since_checkpoint, page_id, leaf_mask);
+            push_page_touch(&mut self.page_indices_since_checkpoint, page_id, leaf_mask);
         }
         self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
     }
 
     #[cfg(feature = "rvr")]
     #[inline(always)]
-    pub(crate) fn apply_page_accesses_with_offset(
+    pub(crate) fn apply_page_touches_with_offset(
         &mut self,
         page_offset: u32,
-        accesses: &[PageAccess],
+        touches: &[PageTouch],
     ) {
-        let len = accesses.len();
-        let ptr = accesses.as_ptr();
+        let len = touches.len();
+        let ptr = touches.as_ptr();
         for i in 0..len {
-            // SAFETY: i is bounded by accesses.len().
-            let access = unsafe { *ptr.add(i) };
-            debug_assert!(access.leaf_mask != 0);
-            let page_id = page_offset + access.page_id;
-            let delta =
-                self.segment_memory
-                    .insert(page_id as usize, access.leaf_mask, &self.global_memory);
+            // SAFETY: i is bounded by touches.len().
+            let touch = unsafe { *ptr.add(i) };
+            debug_assert!(touch.leaf_mask != 0);
+            let page_id = page_offset + touch.page_id;
+            let delta = self.segment_memory.insert(
+                page_id as usize,
+                touch.leaf_mask,
+                &self.baseline_memory,
+            );
             if delta.new_segment_leaf_mask != 0 {
                 self.pending_segment_leaves += delta.segment_leaves;
                 self.pending_segment_merkle_nodes += delta.segment_merkle_nodes;
-                push_page_access(
-                    &mut self.pending_global_updates,
+                push_page_touch(
+                    &mut self.pending_baseline_updates,
                     page_id,
                     delta.new_segment_leaf_mask,
                 );
-                self.pending_global_first_touches
-                    .add(delta.global_first_touches);
+                self.pending_first_touches.add(delta.first_touches);
             }
         }
     }
@@ -225,10 +236,11 @@ impl MemoryCtx {
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
         self.page_indices_applied_len = 0;
-        self.pending_global_updates.clear();
+        self.pending_baseline_updates.clear();
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
-        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
+        self.pending_first_touches = FirstTouchCounts::default();
+        self.default_poseidon_rows = DefaultPoseidonRowTracker::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -248,10 +260,11 @@ impl MemoryCtx {
     pub(crate) fn initialize_segment(&mut self, trace_heights: &mut [u32]) {
         self.segment_memory.clear();
         self.page_indices_applied_len = 0;
-        self.pending_global_updates.clear();
+        self.pending_baseline_updates.clear();
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
-        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
+        self.pending_first_touches = FirstTouchCounts::default();
+        self.default_poseidon_rows = DefaultPoseidonRowTracker::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -272,18 +285,18 @@ impl MemoryCtx {
         self.apply_height_updates(trace_heights);
     }
 
-    /// Adds pending segment updates to the global memory baseline.
+    /// Adds pending segment updates to the baseline.
     #[inline(always)]
     pub(crate) fn update_checkpoint(&mut self) {
-        self.global_memory
-            .add_page_accesses(&self.pending_global_updates);
+        self.baseline_memory
+            .add_page_touches(&self.pending_baseline_updates);
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
         self.page_indices_applied_len = 0;
-        self.pending_global_updates.clear();
+        self.pending_baseline_updates.clear();
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
-        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
+        self.pending_first_touches = FirstTouchCounts::default();
     }
 
     /// Applies memory height deltas recorded since the last checkpoint.
@@ -292,37 +305,37 @@ impl MemoryCtx {
     /// - MERKLE_AIR:   `2 * segment_merkle_nodes` rows
     /// - Poseidon2:    final-side hashes plus initial-side hashes
     ///
-    /// A global first touch means the initial-side value is canonical default.
+    /// A first touch relative to the baseline has a canonical default initial-side value.
     /// Default leaves share one Poseidon2 row. Default internal nodes share one
     /// Poseidon2 row per Merkle height.
     #[inline(always)]
     pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_segment_leaves;
         let mut merkle_nodes = self.pending_segment_merkle_nodes;
-        let mut global_first_touches = self.pending_global_first_touches;
+        let mut first_touches = self.pending_first_touches;
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
-        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
+        self.pending_first_touches = FirstTouchCounts::default();
 
         let len = self.page_indices_since_checkpoint.len();
         let ptr = self.page_indices_since_checkpoint.as_ptr();
         for i in self.page_indices_applied_len..len {
             // SAFETY: i is bounded by page_indices_since_checkpoint.len().
-            let access = unsafe { *ptr.add(i) };
+            let touch = unsafe { *ptr.add(i) };
             let delta = self.segment_memory.insert(
-                access.page_id as usize,
-                access.leaf_mask,
-                &self.global_memory,
+                touch.page_id as usize,
+                touch.leaf_mask,
+                &self.baseline_memory,
             );
             if delta.new_segment_leaf_mask != 0 {
                 leaves += delta.segment_leaves;
                 merkle_nodes += delta.segment_merkle_nodes;
-                push_page_access(
-                    &mut self.pending_global_updates,
-                    access.page_id,
+                push_page_touch(
+                    &mut self.pending_baseline_updates,
+                    touch.page_id,
                     delta.new_segment_leaf_mask,
                 );
-                global_first_touches.add(delta.global_first_touches);
+                first_touches.add(delta.first_touches);
             }
         }
         self.page_indices_applied_len = len;
@@ -333,9 +346,9 @@ impl MemoryCtx {
 
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
-        let initial_default_poseidon_rows = global_first_touches.estimated_default_poseidon_rows();
+        let initial_default_poseidon_rows = self.default_poseidon_rows.count_new(first_touches);
         let initial_nondefault_poseidon_rows = (leaves + merkle_nodes)
-            .saturating_sub(global_first_touches.leaves + global_first_touches.merkle_nodes);
+            .saturating_sub(first_touches.leaves + first_touches.merkle_nodes);
         let poseidon2_rows = leaves
             + merkle_nodes
             + initial_nondefault_poseidon_rows
@@ -351,29 +364,29 @@ impl MemoryCtx {
 }
 
 #[inline(always)]
-fn push_page_access(accesses: &mut Vec<PageAccess>, page_id: u32, leaf_mask: u64) {
+fn push_page_touch(touches: &mut Vec<PageTouch>, page_id: u32, leaf_mask: u64) {
     debug_assert!(leaf_mask != 0);
-    let len = accesses.len();
+    let len = touches.len();
     if len != 0 {
         // SAFETY: len is non-zero, so len - 1 is in bounds.
-        let prev = unsafe { accesses.get_unchecked_mut(len - 1) };
+        let prev = unsafe { touches.get_unchecked_mut(len - 1) };
         if prev.page_id == page_id {
             prev.leaf_mask |= leaf_mask;
             return;
         }
     }
 
-    if len == accesses.capacity() {
-        accesses.reserve(1);
+    if len == touches.capacity() {
+        touches.reserve(1);
     }
 
-    // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
+    // SAFETY: capacity was checked above. PageTouch is Copy and has no drop glue.
     unsafe {
-        accesses
+        touches
             .as_mut_ptr()
             .add(len)
-            .write(PageAccess { page_id, leaf_mask });
-        accesses.set_len(len + 1);
+            .write(PageTouch { page_id, leaf_mask });
+        touches.set_len(len + 1);
     }
 }
 
@@ -410,11 +423,24 @@ mod tests {
 
         let page_id = ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize
             >> MEMORY_PAGE_BITS;
-        assert_eq!(ctx.global_memory.page_mask(page_id), 0);
+        assert_eq!(ctx.baseline_memory.page_mask(page_id), 0);
     }
 
     #[test]
-    fn test_global_first_touches_poseidon_rows_dedup_by_default_bucket() {
+    fn test_address_spaces_map_to_distinct_pages() {
+        let system_config = crate::utils::test_system_config();
+        let ctx = MemoryCtx::new(&system_config, 1);
+        let memory_page = ctx.leaf_id_range(RV64_MEMORY_AS, 0, 1).0 >> MEMORY_PAGE_BITS;
+        let public_values_page = ctx.leaf_id_range(PUBLIC_VALUES_AS, 0, 1).0 >> MEMORY_PAGE_BITS;
+        let deferral_page = ctx.leaf_id_range(DEFERRAL_AS, 0, 1).0 >> MEMORY_PAGE_BITS;
+
+        assert_ne!(memory_page, public_values_page);
+        assert_ne!(memory_page, deferral_page);
+        assert_ne!(public_values_page, deferral_page);
+    }
+
+    #[test]
+    fn test_first_touches_poseidon_rows_dedup_by_default_bucket() {
         let system_config = crate::utils::test_system_config();
         let mut ctx = MemoryCtx::new(&system_config, 1);
         let height = ctx.memory_dimensions.overall_height() as u32;
@@ -430,6 +456,36 @@ mod tests {
         assert_eq!(trace_heights[BOUNDARY_AIR_ID], 4);
         assert_eq!(trace_heights[MERKLE_AIR_ID], 2 * height);
         assert_eq!(trace_heights[poseidon2_idx], 2 * height + 3);
+    }
+
+    #[test]
+    fn test_default_poseidon_rows_dedup_across_checkpoints() {
+        let system_config = crate::utils::test_system_config();
+        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut trace_heights = vec![0; 6];
+
+        ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 1);
+        ctx.apply_height_updates(&mut trace_heights);
+        ctx.update_checkpoint();
+
+        let boundary_before = trace_heights[BOUNDARY_AIR_ID];
+        let merkle_before = trace_heights[MERKLE_AIR_ID];
+        let poseidon2_idx = trace_heights.len() - 2;
+        let poseidon_before = trace_heights[poseidon2_idx];
+        let next_page_ptr = ((1 << MEMORY_PAGE_BITS) * U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+
+        ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, next_page_ptr, 1);
+        ctx.apply_height_updates(&mut trace_heights);
+
+        assert_eq!(trace_heights[BOUNDARY_AIR_ID] - boundary_before, 2);
+        assert_eq!(
+            trace_heights[MERKLE_AIR_ID] - merkle_before,
+            2 * MEMORY_PAGE_BITS as u32
+        );
+        assert_eq!(
+            trace_heights[poseidon2_idx] - poseidon_before,
+            1 + MEMORY_PAGE_BITS as u32
+        );
     }
 
     #[test]

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -27,32 +27,6 @@ const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
 const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
 const FIELD_ELEMENT_BYTES: u32 = size_of::<u32>() as u32;
 
-#[inline(always)]
-fn push_page_access(accesses: &mut Vec<PageAccess>, page_id: u32, leaf_mask: u64) {
-    debug_assert!(leaf_mask != 0);
-    let len = accesses.len();
-    if len != 0 {
-        // SAFETY: len is non-zero, so len - 1 is in bounds.
-        let prev = unsafe { accesses.get_unchecked_mut(len - 1) };
-        if prev.page_id == page_id {
-            prev.leaf_mask |= leaf_mask;
-            return;
-        }
-    }
-
-    if len == accesses.capacity() {
-        accesses.reserve(1);
-    }
-
-    // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
-    unsafe {
-        accesses
-            .as_mut_ptr()
-            .add(len)
-            .write(PageAccess { page_id, leaf_mask });
-        accesses.set_len(len + 1);
-    }
-}
 #[derive(Clone, Debug)]
 pub struct MemoryCtx {
     /// Memory tree dimensions used to map address-space ranges into global leaf ids.
@@ -374,6 +348,33 @@ impl MemoryCtx {
             // Merkle AIR: 2 rows per internal node (init + final tree)
             *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += merkle_nodes * 2;
         }
+    }
+}
+
+#[inline(always)]
+fn push_page_access(accesses: &mut Vec<PageAccess>, page_id: u32, leaf_mask: u64) {
+    debug_assert!(leaf_mask != 0);
+    let len = accesses.len();
+    if len != 0 {
+        // SAFETY: len is non-zero, so len - 1 is in bounds.
+        let prev = unsafe { accesses.get_unchecked_mut(len - 1) };
+        if prev.page_id == page_id {
+            prev.leaf_mask |= leaf_mask;
+            return;
+        }
+    }
+
+    if len == accesses.capacity() {
+        accesses.reserve(1);
+    }
+
+    // SAFETY: capacity was checked above. PageAccess is Copy and has no drop glue.
+    unsafe {
+        accesses
+            .as_mut_ptr()
+            .add(len)
+            .write(PageAccess { page_id, leaf_mask });
+        accesses.set_len(len + 1);
     }
 }
 

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -6,11 +6,10 @@ use openvm_instructions::{
     DEFERRAL_AS, DIGEST_WIDTH, MEMORY_PAGE_BITS,
 };
 
-use super::page_tracker::{
-    leaf_mask_range, CommittedMemoryOccupancyTracker, DefaultOldAccounting,
-    SegmentMemoryPageTracker,
+pub use super::memory_tracker::PageAccess;
+use super::memory_tracker::{
+    leaf_mask_range, GlobalFirstTouchCounts, GlobalMemoryTracker, SegmentMemoryTracker,
 };
-pub use super::page_tracker::PageAccess;
 use crate::{
     arch::{SystemConfig, ADDR_SPACE_OFFSET, BOUNDARY_AIR_ID, MERKLE_AIR_ID, U16_CELL_SIZE},
     system::memory::dimensions::MemoryDimensions,
@@ -31,27 +30,25 @@ const FIELD_ELEMENT_BYTES: u32 = size_of::<u32>() as u32;
 pub struct MemoryCtx {
     /// Memory tree dimensions used to map address-space ranges into global leaf ids.
     memory_dimensions: MemoryDimensions,
-    /// Segment-local occupancy. Cleared at segment boundaries; it prevents
-    /// charging the same leaf or Merkle node twice inside one segment.
-    page_tracker: SegmentMemoryPageTracker,
-    /// Committed occupancy at the last safe checkpoint, seeded with nonzero
-    /// initial memory. This tells us whether an old value is canonical default.
-    occupancy_tracker: CommittedMemoryOccupancyTracker,
+    /// Memory leaves and nodes already counted in the current segment.
+    segment_memory: SegmentMemoryTracker,
+    /// Memory leaves and nodes present in the global baseline at the last checkpoint.
+    global_memory: GlobalMemoryTracker,
     /// Page masks recorded since the last safe checkpoint by the normal metered path.
     pub page_indices_since_checkpoint: Vec<PageAccess>,
     /// Length mirror used by generated metered code that appends through the raw buffer.
     pub page_indices_since_checkpoint_len: usize,
     /// Number of checkpoint-buffer entries already reflected in `trace_heights`.
     page_indices_applied_len: usize,
-    /// Newly charged leaf masks queued for the next checkpoint commit. Segment
+    /// New segment leaf masks queued for the next checkpoint. Segment
     /// replay clears this queue and recomputes it from `page_indices_since_checkpoint`.
-    pending_occupancy_updates: Vec<PageAccess>,
-    /// New boundary leaves accumulated by direct page-buffer application.
-    pending_leaves: u32,
-    /// New Merkle nodes accumulated by direct page-buffer application.
-    pending_merkle_nodes: u32,
-    /// Old-side default leaves and nodes paired with the pending height deltas.
-    pending_default_old: DefaultOldAccounting,
+    pending_global_updates: Vec<PageAccess>,
+    /// New segment leaves accumulated by direct page-buffer application.
+    pending_segment_leaves: u32,
+    /// New segment Merkle nodes accumulated by direct page-buffer application.
+    pending_segment_merkle_nodes: u32,
+    /// Global first touches paired with the pending height deltas.
+    pending_global_first_touches: GlobalFirstTouchCounts,
 }
 
 impl MemoryCtx {
@@ -64,15 +61,15 @@ impl MemoryCtx {
 
         Self {
             memory_dimensions,
-            page_tracker: SegmentMemoryPageTracker::new(upper_height),
-            occupancy_tracker: CommittedMemoryOccupancyTracker::new(upper_height),
+            segment_memory: SegmentMemoryTracker::new(upper_height),
+            global_memory: GlobalMemoryTracker::new(upper_height),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
             page_indices_applied_len: 0,
-            pending_occupancy_updates: Vec::with_capacity(checkpoint_capacity),
-            pending_leaves: 0,
-            pending_merkle_nodes: 0,
-            pending_default_old: DefaultOldAccounting::default(),
+            pending_global_updates: Vec::with_capacity(checkpoint_capacity),
+            pending_segment_leaves: 0,
+            pending_segment_merkle_nodes: 0,
+            pending_global_first_touches: GlobalFirstTouchCounts::default(),
         }
     }
 
@@ -140,7 +137,7 @@ impl MemoryCtx {
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
-            self.occupancy_tracker
+            self.global_memory
                 .mark_existing_page(page_id as usize, leaf_mask);
         }
     }
@@ -204,20 +201,19 @@ impl MemoryCtx {
             let access = unsafe { *ptr.add(i) };
             debug_assert!(access.leaf_mask != 0);
             let page_id = page_offset + access.page_id;
-            let delta = self.page_tracker.insert(
-                page_id as usize,
-                access.leaf_mask,
-                &self.occupancy_tracker,
-            );
-            if delta.newly_charged_leaf_mask != 0 {
-                self.pending_leaves += delta.new_leaves;
-                self.pending_merkle_nodes += delta.new_merkle_nodes;
+            let delta =
+                self.segment_memory
+                    .insert(page_id as usize, access.leaf_mask, &self.global_memory);
+            if delta.new_segment_leaf_mask != 0 {
+                self.pending_segment_leaves += delta.segment_leaves;
+                self.pending_segment_merkle_nodes += delta.segment_merkle_nodes;
                 push_page_access(
-                    &mut self.pending_occupancy_updates,
+                    &mut self.pending_global_updates,
                     page_id,
-                    delta.newly_charged_leaf_mask,
+                    delta.new_segment_leaf_mask,
                 );
-                self.pending_default_old.add(delta.default_old);
+                self.pending_global_first_touches
+                    .add(delta.global_first_touches);
             }
         }
     }
@@ -225,14 +221,14 @@ impl MemoryCtx {
     #[cfg(feature = "rvr")]
     #[inline(always)]
     pub(crate) fn reset_segment_without_replay(&mut self, trace_heights: &mut [u32]) {
-        self.page_tracker.clear();
+        self.segment_memory.clear();
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
         self.page_indices_applied_len = 0;
-        self.pending_occupancy_updates.clear();
-        self.pending_leaves = 0;
-        self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldAccounting::default();
+        self.pending_global_updates.clear();
+        self.pending_segment_leaves = 0;
+        self.pending_segment_merkle_nodes = 0;
+        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -250,12 +246,12 @@ impl MemoryCtx {
     /// Initialize state for a new segment
     #[inline(always)]
     pub(crate) fn initialize_segment(&mut self, trace_heights: &mut [u32]) {
-        self.page_tracker.clear();
+        self.segment_memory.clear();
         self.page_indices_applied_len = 0;
-        self.pending_occupancy_updates.clear();
-        self.pending_leaves = 0;
-        self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldAccounting::default();
+        self.pending_global_updates.clear();
+        self.pending_segment_leaves = 0;
+        self.pending_segment_merkle_nodes = 0;
+        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
 
         // Reset trace heights for memory chips as 0
         // SAFETY: BOUNDARY_AIR_ID and MERKLE_AIR_ID are compile-time constants within bounds
@@ -276,56 +272,57 @@ impl MemoryCtx {
         self.apply_height_updates(trace_heights);
     }
 
-    /// Updates the checkpoint with current safe state
+    /// Adds pending segment updates to the global memory baseline.
     #[inline(always)]
     pub(crate) fn update_checkpoint(&mut self) {
-        self.occupancy_tracker
-            .commit_page_accesses(&self.pending_occupancy_updates);
+        self.global_memory
+            .add_page_accesses(&self.pending_global_updates);
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
         self.page_indices_applied_len = 0;
-        self.pending_occupancy_updates.clear();
-        self.pending_leaves = 0;
-        self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldAccounting::default();
+        self.pending_global_updates.clear();
+        self.pending_segment_leaves = 0;
+        self.pending_segment_merkle_nodes = 0;
+        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
     }
 
     /// Applies memory height deltas recorded since the last checkpoint.
     ///
-    /// - BOUNDARY_AIR: `2 * new_leaves` rows
-    /// - MERKLE_AIR:   `2 * new_merkle_nodes` rows
-    /// - Poseidon2:    final-side hashes plus old-side hashes
+    /// - BOUNDARY_AIR: `2 * segment_leaves` rows
+    /// - MERKLE_AIR:   `2 * segment_merkle_nodes` rows
+    /// - Poseidon2:    final-side hashes plus initial-side hashes
     ///
-    /// Old-side default leaves share one Poseidon2 input. Old-side default
-    /// internal nodes share one input per Merkle height.
+    /// A global first touch means the initial-side value is canonical default.
+    /// Default leaves share one Poseidon2 row. Default internal nodes share one
+    /// Poseidon2 row per Merkle height.
     #[inline(always)]
     pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
-        let mut leaves = self.pending_leaves;
-        let mut merkle_nodes = self.pending_merkle_nodes;
-        let mut default_old = self.pending_default_old;
-        self.pending_leaves = 0;
-        self.pending_merkle_nodes = 0;
-        self.pending_default_old = DefaultOldAccounting::default();
+        let mut leaves = self.pending_segment_leaves;
+        let mut merkle_nodes = self.pending_segment_merkle_nodes;
+        let mut global_first_touches = self.pending_global_first_touches;
+        self.pending_segment_leaves = 0;
+        self.pending_segment_merkle_nodes = 0;
+        self.pending_global_first_touches = GlobalFirstTouchCounts::default();
 
         let len = self.page_indices_since_checkpoint.len();
         let ptr = self.page_indices_since_checkpoint.as_ptr();
         for i in self.page_indices_applied_len..len {
             // SAFETY: i is bounded by page_indices_since_checkpoint.len().
             let access = unsafe { *ptr.add(i) };
-            let delta = self.page_tracker.insert(
+            let delta = self.segment_memory.insert(
                 access.page_id as usize,
                 access.leaf_mask,
-                &self.occupancy_tracker,
+                &self.global_memory,
             );
-            if delta.newly_charged_leaf_mask != 0 {
-                leaves += delta.new_leaves;
-                merkle_nodes += delta.new_merkle_nodes;
+            if delta.new_segment_leaf_mask != 0 {
+                leaves += delta.segment_leaves;
+                merkle_nodes += delta.segment_merkle_nodes;
                 push_page_access(
-                    &mut self.pending_occupancy_updates,
+                    &mut self.pending_global_updates,
                     access.page_id,
-                    delta.newly_charged_leaf_mask,
+                    delta.new_segment_leaf_mask,
                 );
-                default_old.add(delta.default_old);
+                global_first_touches.add(delta.global_first_touches);
             }
         }
         self.page_indices_applied_len = len;
@@ -336,11 +333,13 @@ impl MemoryCtx {
 
         debug_assert!(trace_heights.len() >= 2);
         let poseidon2_idx = trace_heights.len() - 2;
-        let old_default_poseidon_rows = default_old.estimated_poseidon_rows();
-        let old_nondefault_poseidon_rows = (leaves + merkle_nodes)
-            .saturating_sub(default_old.default_leaves + default_old.default_merkle_nodes);
-        let poseidon2_rows =
-            leaves + merkle_nodes + old_nondefault_poseidon_rows + old_default_poseidon_rows;
+        let initial_default_poseidon_rows = global_first_touches.estimated_default_poseidon_rows();
+        let initial_nondefault_poseidon_rows = (leaves + merkle_nodes)
+            .saturating_sub(global_first_touches.leaves + global_first_touches.merkle_nodes);
+        let poseidon2_rows = leaves
+            + merkle_nodes
+            + initial_nondefault_poseidon_rows
+            + initial_default_poseidon_rows;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
         unsafe {
             *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves * 2;
@@ -409,13 +408,13 @@ mod tests {
         ctx.update_boundary_merkle_heights(2, 0, 1);
         ctx.apply_height_updates(&mut trace_heights);
 
-        let page_id =
-            ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize >> MEMORY_PAGE_BITS;
-        assert_eq!(ctx.occupancy_tracker.page_mask(page_id), 0);
+        let page_id = ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize
+            >> MEMORY_PAGE_BITS;
+        assert_eq!(ctx.global_memory.page_mask(page_id), 0);
     }
 
     #[test]
-    fn test_default_old_poseidon_rows_dedup_by_default_bucket() {
+    fn test_global_first_touches_poseidon_rows_dedup_by_default_bucket() {
         let system_config = crate::utils::test_system_config();
         let mut ctx = MemoryCtx::new(&system_config, 1);
         let height = ctx.memory_dimensions.overall_height() as u32;

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -9,45 +9,72 @@ const FIRST_LEAF_PER_16_LEAVES: u64 = 0x0001_0001_0001_0001;
 const FIRST_LEAF_PER_32_LEAVES: u64 = 0x0000_0001_0000_0001;
 const FIRST_LEAF_PER_64_LEAVES: u64 = 0x0000_0000_0000_0001;
 
+/// Leaves touched within one 64-leaf page.
+///
+/// `page_id` selects the page and bit `i` in `leaf_mask` selects leaf `i` in that page.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PageAccess {
-    /// Index into the page table. The leaf occupancy for this page is stored
-    /// in `leaf_mask`.
+pub struct PageTouch {
+    /// Index of the 64-leaf page in the memory tree.
     pub page_id: u32,
-    /// Bit `i` is set when leaf `i` inside this 64-leaf page was touched.
+    /// Leaves touched in this page, with one bit per leaf.
     pub leaf_mask: u64,
 }
 
-/// Newly counted leaves and nodes that were absent from global memory.
+/// Leaves and tree nodes that must be created because they were absent at the last checkpoint.
 ///
-/// A global first touch has a canonical default initial-side value. These
-/// counts let `MemoryCtx` estimate Poseidon2 rows after default-row dedup.
+/// An absent leaf starts as zero. An absent internal node starts as the hash of a zero-filled
+/// subtree. Equal starting hashes share a Poseidon2 row, so we need both the total number of new
+/// nodes and the highest tree level at which one appeared.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct GlobalFirstTouchCounts {
-    /// New segment leaves whose initial-side value is the canonical default leaf.
+pub(super) struct FirstTouchCounts {
+    /// Newly used leaves that were absent at the last checkpoint.
     pub(super) leaves: u32,
-    /// New segment internal nodes whose initial-side value is a canonical default node.
+    /// Newly needed internal nodes that were absent at the last checkpoint.
     pub(super) merkle_nodes: u32,
-    /// Bit `h` is set when height `h` has at least one first-touch internal node.
-    merkle_height_mask: u64,
+    /// Highest level containing a new node; every lower level also contains one.
+    max_merkle_height: u32,
 }
 
-/// New contribution from one page access to the current segment.
+/// Remembers which zero-filled-tree hashes have already been added to this segment's trace.
 ///
-/// Counts are in leaves/internal nodes. `MemoryCtx` maps them to trace rows.
+/// ```text
+///                 hash₂
+///                /     \
+///             hash₁   hash₁
+///             /  \     /  \
+///            0    0   0    0
+/// ```
+///
+/// All zero leaves share one row. All `hash₁` nodes share another row, and all `hash₂` nodes share
+/// another. Therefore the tracker only needs to remember whether the leaf row was added and the
+/// highest internal-node level added so far. A checkpoint does not reset it because the trace still
+/// belongs to the same segment.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct DefaultPoseidonRowTracker {
+    /// Whether the row for a zero leaf has already been added.
+    seen_leaf: bool,
+    /// Highest zero-filled internal-node level already added; lower levels are implied.
+    max_merkle_height: u32,
+}
+
+/// Additional tree work caused by one page touch.
+///
+/// The first two counts determine the new Boundary and Merkle rows. `first_touches` is the part
+/// that starts from zero rather than from memory already present at the last checkpoint.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct SegmentMemoryDelta {
-    /// Boundary leaves newly counted in the current segment.
+    /// Leaves not previously touched in this segment.
     pub(super) segment_leaves: u32,
-    /// Merkle internal nodes newly counted in the current segment.
+    /// Internal nodes not previously needed in this segment.
     pub(super) segment_merkle_nodes: u32,
-    /// Subset of the inserted leaf mask that became newly counted in this segment.
+    /// Bits from the input touch that were new to this segment.
     pub(super) new_segment_leaf_mask: u64,
-    /// New segment leaves and nodes that are absent from global memory.
-    pub(super) global_first_touches: GlobalFirstTouchCounts,
+    /// New leaves and nodes that were also absent at the last checkpoint.
+    pub(super) first_touches: FirstTouchCounts,
 }
 
+/// Fixed-size bit set that can clear only the words changed during a segment.
 #[derive(Clone, Debug)]
 struct BitSet {
     /// Packed occupancy bits.
@@ -56,11 +83,10 @@ struct BitSet {
     dirty_words: Vec<usize>,
 }
 
-/// Memory already counted in the current segment.
+/// Leaves and tree nodes already counted in the current segment.
 ///
-/// This tracker is cleared whenever a new segment starts. It prevents counting
-/// the same leaf or Merkle node twice inside one segment. `GlobalMemoryTracker`
-/// is passed into `insert` only to detect global first touches.
+/// This is cleared when a new segment starts. It prevents repeated reads or writes from adding the
+/// same leaf or tree node to the trace more than once.
 ///
 /// Memory leaves form one sparse Merkle tree. Each page contains the 64 leaves
 /// represented by one `u64` leaf mask:
@@ -90,32 +116,41 @@ pub(super) struct SegmentMemoryTracker {
     upper_height: usize,
 }
 
-/// Memory present in the global baseline at the last checkpoint.
+/// Leaves and tree nodes present at the last safe checkpoint.
 ///
-/// This tracker persists across segment replays and is advanced only by
-/// `MemoryCtx::update_checkpoint`. It is seeded from nonzero initial memory.
-/// A leaf or node missing from this tracker is a global first touch.
+/// If execution must end the current segment at that checkpoint, the next segment starts from this
+/// state. Unlike `SegmentMemoryTracker`, this survives the segment change. It is updated only after
+/// a safe checkpoint and is initially populated from nonzero program memory.
 #[derive(Clone, Debug)]
-pub(super) struct GlobalMemoryTracker {
-    /// Leaf masks present in the global baseline, stored by page.
-    global_leaf_masks: Box<[u64]>,
-    /// Upper-tree ancestors present in the global baseline.
-    global_upper_nodes: BitSet,
+pub(super) struct BaselineMemoryTracker {
+    /// Leaf masks present in the baseline, stored by page.
+    baseline_leaf_masks: Box<[u64]>,
+    /// Upper-tree ancestors present in the baseline.
+    baseline_upper_nodes: BitSet,
     /// Number of Merkle levels above the 64-leaf page layer.
     upper_height: usize,
 }
 
-impl GlobalFirstTouchCounts {
+impl FirstTouchCounts {
     #[inline(always)]
     pub(super) fn add(&mut self, other: Self) {
         self.leaves += other.leaves;
         self.merkle_nodes += other.merkle_nodes;
-        self.merkle_height_mask |= other.merkle_height_mask;
+        self.max_merkle_height = self.max_merkle_height.max(other.max_merkle_height);
     }
+}
 
+impl DefaultPoseidonRowTracker {
     #[inline(always)]
-    pub(super) fn estimated_default_poseidon_rows(self) -> u32 {
-        u32::from(self.leaves != 0) + self.merkle_height_mask.count_ones()
+    pub(super) fn count_new(&mut self, first_touches: FirstTouchCounts) -> u32 {
+        let new_leaf_row = u32::from(first_touches.leaves != 0 && !self.seen_leaf);
+        self.seen_leaf |= first_touches.leaves != 0;
+
+        let new_merkle_rows = first_touches
+            .max_merkle_height
+            .saturating_sub(self.max_merkle_height);
+        self.max_merkle_height = self.max_merkle_height.max(first_touches.max_merkle_height);
+        new_leaf_row + new_merkle_rows
     }
 }
 
@@ -135,8 +170,8 @@ impl BitSet {
     }
 
     #[inline(always)]
-    fn insert_global(&mut self, index: usize) -> bool {
-        // Global memory is monotonic and persists across checkpoints.
+    fn insert_baseline(&mut self, index: usize) -> bool {
+        // Baseline memory is monotonic and persists across checkpoints.
         self.insert_impl::<false>(index)
     }
 
@@ -214,7 +249,7 @@ impl SegmentMemoryTracker {
         &mut self,
         page_id: usize,
         leaf_mask: u64,
-        global_memory: &GlobalMemoryTracker,
+        baseline_memory: &BaselineMemoryTracker,
     ) -> SegmentMemoryDelta {
         debug_assert!(page_id < self.segment_leaf_masks.len());
         debug_assert!(leaf_mask != 0);
@@ -232,8 +267,8 @@ impl SegmentMemoryTracker {
         }
 
         let new_segment_leaf_mask = leaf_mask & !segment_leaf_mask_before;
-        let global_leaf_mask = global_memory.page_mask(page_id);
-        let first_touch_leaf_mask = new_segment_leaf_mask & !global_leaf_mask;
+        let baseline_leaf_mask = baseline_memory.page_mask(page_id);
+        let first_touch_leaf_mask = new_segment_leaf_mask & !baseline_leaf_mask;
         let single_added_leaf = new_segment_leaf_mask.is_power_of_two();
         let segment_leaves = if single_added_leaf {
             1
@@ -241,7 +276,7 @@ impl SegmentMemoryTracker {
             new_segment_leaf_mask.count_ones()
         };
 
-        let (mut segment_merkle_nodes, mut global_first_touches) = if first_touch_leaf_mask == 0 {
+        let (mut segment_merkle_nodes, mut first_touches) = if first_touch_leaf_mask == 0 {
             let nodes = if single_added_leaf {
                 local_merkle_nodes_added_leaf(
                     segment_leaf_mask_before,
@@ -250,22 +285,22 @@ impl SegmentMemoryTracker {
             } else {
                 local_merkle_nodes_delta(segment_leaf_mask_before, new_segment_leaf_mask)
             };
-            (nodes, GlobalFirstTouchCounts::default())
+            (nodes, FirstTouchCounts::default())
         } else if single_added_leaf {
-            local_merkle_nodes_added_leaf_with_global_first_touches(
+            local_merkle_nodes_added_leaf_with_first_touches(
                 segment_leaf_mask_before,
                 new_segment_leaf_mask.trailing_zeros(),
-                global_leaf_mask,
+                baseline_leaf_mask,
             )
         } else {
-            local_merkle_nodes_delta_with_global_first_touches(
+            local_merkle_nodes_delta_with_first_touches(
                 segment_leaf_mask_before,
                 new_segment_leaf_mask,
-                global_leaf_mask,
+                baseline_leaf_mask,
             )
         };
         if first_touch_leaf_mask != 0 {
-            global_first_touches.leaves = if single_added_leaf {
+            first_touches.leaves = if single_added_leaf {
                 1
             } else {
                 first_touch_leaf_mask.count_ones()
@@ -273,11 +308,11 @@ impl SegmentMemoryTracker {
         }
 
         if segment_leaf_mask_before == 0 {
-            if global_leaf_mask == 0 {
-                let (upper_nodes, upper_global_first_touches) =
-                    self.insert_upper_path_with_global_first_touches(page_id, global_memory);
+            if baseline_leaf_mask == 0 {
+                let (upper_nodes, upper_first_touches) =
+                    self.insert_upper_path_with_first_touches(page_id, baseline_memory);
                 segment_merkle_nodes += upper_nodes;
-                global_first_touches.add(upper_global_first_touches);
+                first_touches.add(upper_first_touches);
             } else {
                 segment_merkle_nodes += self.insert_upper_path(page_id);
             }
@@ -286,34 +321,34 @@ impl SegmentMemoryTracker {
             segment_leaves,
             segment_merkle_nodes,
             new_segment_leaf_mask,
-            global_first_touches,
+            first_touches,
         }
     }
 
     #[inline(always)]
-    fn insert_upper_path_with_global_first_touches(
+    fn insert_upper_path_with_first_touches(
         &mut self,
         page_id: usize,
-        global_memory: &GlobalMemoryTracker,
-    ) -> (u32, GlobalFirstTouchCounts) {
+        baseline_memory: &BaselineMemoryTracker,
+    ) -> (u32, FirstTouchCounts) {
         let mut count = 0;
-        let mut global_first_touches = GlobalFirstTouchCounts::default();
+        let mut first_touches = FirstTouchCounts::default();
         let mut node = (1usize << self.upper_height) + page_id;
         let mut height = MEMORY_PAGE_BITS + 1;
         while node > 1 {
             node >>= 1;
             if self.segment_upper_nodes.insert_clearable(node) {
                 count += 1;
-                if !global_memory.upper_contains(node) {
-                    global_first_touches.merkle_nodes += 1;
-                    global_first_touches.merkle_height_mask |= 1u64 << height;
+                if !baseline_memory.upper_contains(node) {
+                    first_touches.merkle_nodes += 1;
+                    first_touches.max_merkle_height = height as u32;
                 }
             } else {
                 break;
             }
             height += 1;
         }
-        (count, global_first_touches)
+        (count, first_touches)
     }
 
     #[inline(always)]
@@ -332,44 +367,44 @@ impl SegmentMemoryTracker {
     }
 }
 
-impl GlobalMemoryTracker {
+impl BaselineMemoryTracker {
     pub(super) fn new(upper_height: usize) -> Self {
         let num_pages = 1 << upper_height;
         Self {
-            global_leaf_masks: vec![0; num_pages].into_boxed_slice(),
-            global_upper_nodes: BitSet::new(num_pages),
+            baseline_leaf_masks: vec![0; num_pages].into_boxed_slice(),
+            baseline_upper_nodes: BitSet::new(num_pages),
             upper_height,
         }
     }
 
     #[inline(always)]
     pub(super) fn page_mask(&self, page_id: usize) -> u64 {
-        debug_assert!(page_id < self.global_leaf_masks.len());
-        unsafe { *self.global_leaf_masks.get_unchecked(page_id) }
+        debug_assert!(page_id < self.baseline_leaf_masks.len());
+        unsafe { *self.baseline_leaf_masks.get_unchecked(page_id) }
     }
 
     #[inline(always)]
     fn upper_contains(&self, node: usize) -> bool {
-        self.global_upper_nodes.contains(node)
+        self.baseline_upper_nodes.contains(node)
     }
 
     #[inline(always)]
     pub(super) fn mark_existing_page(&mut self, page_id: usize, leaf_mask: u64) {
-        debug_assert!(page_id < self.global_leaf_masks.len());
+        debug_assert!(page_id < self.baseline_leaf_masks.len());
         debug_assert!(leaf_mask != 0);
 
-        let global_leaf_mask = unsafe { self.global_leaf_masks.get_unchecked_mut(page_id) };
-        let global_leaf_mask_before = *global_leaf_mask;
-        *global_leaf_mask = global_leaf_mask_before | leaf_mask;
-        if global_leaf_mask_before == 0 {
+        let baseline_leaf_mask = unsafe { self.baseline_leaf_masks.get_unchecked_mut(page_id) };
+        let baseline_leaf_mask_before = *baseline_leaf_mask;
+        *baseline_leaf_mask = baseline_leaf_mask_before | leaf_mask;
+        if baseline_leaf_mask_before == 0 {
             self.mark_upper_path(page_id);
         }
     }
 
     #[inline(always)]
-    pub(super) fn add_page_accesses(&mut self, accesses: &[PageAccess]) {
-        for &access in accesses {
-            self.mark_existing_page(access.page_id as usize, access.leaf_mask);
+    pub(super) fn add_page_touches(&mut self, touches: &[PageTouch]) {
+        for &touch in touches {
+            self.mark_existing_page(touch.page_id as usize, touch.leaf_mask);
         }
     }
 
@@ -378,7 +413,7 @@ impl GlobalMemoryTracker {
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
             node >>= 1;
-            if !self.global_upper_nodes.insert_global(node) {
+            if !self.baseline_upper_nodes.insert_baseline(node) {
                 break;
             }
         }
@@ -478,16 +513,16 @@ fn local_merkle_nodes_added_leaf(segment_leaf_mask: u64, leaf: u32) -> u32 {
 }
 
 #[inline(always)]
-fn add_leaf_level_delta_with_global_first_touch<const GROUP_SIZE: u32, const LEVEL: usize>(
+fn add_leaf_level_delta_with_first_touch<const GROUP_SIZE: u32, const LEVEL: u32>(
     segment_leaf_mask: u64,
-    global_leaf_mask: u64,
+    baseline_leaf_mask: u64,
     leaf: u32,
-    global_first_touches: &mut GlobalFirstTouchCounts,
+    first_touches: &mut FirstTouchCounts,
 ) -> u32 {
     if aligned_group_is_empty::<GROUP_SIZE>(segment_leaf_mask, leaf) {
-        if aligned_group_is_empty::<GROUP_SIZE>(global_leaf_mask, leaf) {
-            global_first_touches.merkle_nodes += 1;
-            global_first_touches.merkle_height_mask |= 1u64 << LEVEL;
+        if aligned_group_is_empty::<GROUP_SIZE>(baseline_leaf_mask, leaf) {
+            first_touches.merkle_nodes += 1;
+            first_touches.max_merkle_height = LEVEL;
         }
         1
     } else {
@@ -496,138 +531,136 @@ fn add_leaf_level_delta_with_global_first_touch<const GROUP_SIZE: u32, const LEV
 }
 
 #[inline(always)]
-fn local_merkle_nodes_added_leaf_with_global_first_touches(
+fn local_merkle_nodes_added_leaf_with_first_touches(
     segment_leaf_mask: u64,
     leaf: u32,
-    global_leaf_mask: u64,
-) -> (u32, GlobalFirstTouchCounts) {
+    baseline_leaf_mask: u64,
+) -> (u32, FirstTouchCounts) {
     debug_assert!(leaf < u64::BITS);
 
-    if segment_leaf_mask == 0 && global_leaf_mask == 0 {
+    if segment_leaf_mask == 0 && baseline_leaf_mask == 0 {
         return (
             MEMORY_PAGE_BITS as u32,
-            GlobalFirstTouchCounts {
+            FirstTouchCounts {
                 leaves: 0,
                 merkle_nodes: MEMORY_PAGE_BITS as u32,
-                merkle_height_mask: (1u64 << (MEMORY_PAGE_BITS + 1)) - 2,
+                max_merkle_height: MEMORY_PAGE_BITS as u32,
             },
         );
     }
 
-    let mut global_first_touches = GlobalFirstTouchCounts::default();
+    let mut first_touches = FirstTouchCounts::default();
     let mut nodes = 0;
-    nodes += add_leaf_level_delta_with_global_first_touch::<2, 1>(
+    nodes += add_leaf_level_delta_with_first_touch::<2, 1>(
         segment_leaf_mask,
-        global_leaf_mask,
+        baseline_leaf_mask,
         leaf,
-        &mut global_first_touches,
+        &mut first_touches,
     );
-    nodes += add_leaf_level_delta_with_global_first_touch::<4, 2>(
+    nodes += add_leaf_level_delta_with_first_touch::<4, 2>(
         segment_leaf_mask,
-        global_leaf_mask,
+        baseline_leaf_mask,
         leaf,
-        &mut global_first_touches,
+        &mut first_touches,
     );
-    nodes += add_leaf_level_delta_with_global_first_touch::<8, 3>(
+    nodes += add_leaf_level_delta_with_first_touch::<8, 3>(
         segment_leaf_mask,
-        global_leaf_mask,
+        baseline_leaf_mask,
         leaf,
-        &mut global_first_touches,
+        &mut first_touches,
     );
-    nodes += add_leaf_level_delta_with_global_first_touch::<16, 4>(
+    nodes += add_leaf_level_delta_with_first_touch::<16, 4>(
         segment_leaf_mask,
-        global_leaf_mask,
+        baseline_leaf_mask,
         leaf,
-        &mut global_first_touches,
+        &mut first_touches,
     );
-    nodes += add_leaf_level_delta_with_global_first_touch::<32, 5>(
+    nodes += add_leaf_level_delta_with_first_touch::<32, 5>(
         segment_leaf_mask,
-        global_leaf_mask,
+        baseline_leaf_mask,
         leaf,
-        &mut global_first_touches,
+        &mut first_touches,
     );
 
     if segment_leaf_mask == 0 {
         nodes += 1;
-        if global_leaf_mask == 0 {
-            global_first_touches.merkle_nodes += 1;
-            global_first_touches.merkle_height_mask |= 1u64 << MEMORY_PAGE_BITS;
+        if baseline_leaf_mask == 0 {
+            first_touches.merkle_nodes += 1;
+            first_touches.max_merkle_height = MEMORY_PAGE_BITS as u32;
         }
     }
 
-    (nodes, global_first_touches)
+    (nodes, first_touches)
 }
 
 #[inline(always)]
-fn add_level_delta_with_global_first_touches<
-    const SHIFT: u32,
-    const MASK: u64,
-    const LEVEL: usize,
->(
+fn add_level_delta_with_first_touches<const SHIFT: u32, const MASK: u64, const LEVEL: u32>(
     segment_mask: &mut u64,
     new_segment_mask: &mut u64,
-    global_level_mask: &mut u64,
-    global_first_touches: &mut GlobalFirstTouchCounts,
+    baseline_level_mask: &mut u64,
+    first_touches: &mut FirstTouchCounts,
 ) -> u32 {
     *segment_mask = (*segment_mask | (*segment_mask >> SHIFT)) & MASK;
     *new_segment_mask = (*new_segment_mask | (*new_segment_mask >> SHIFT)) & MASK;
-    *global_level_mask = (*global_level_mask | (*global_level_mask >> SHIFT)) & MASK;
+    *baseline_level_mask = (*baseline_level_mask | (*baseline_level_mask >> SHIFT)) & MASK;
     let new_nodes = *new_segment_mask & !*segment_mask;
-    let first_touch_nodes = new_nodes & !*global_level_mask;
-    global_first_touches.merkle_nodes += first_touch_nodes.count_ones();
-    global_first_touches.merkle_height_mask |= u64::from(first_touch_nodes != 0) << LEVEL;
+    let first_touch_nodes = new_nodes & !*baseline_level_mask;
+    first_touches.merkle_nodes += first_touch_nodes.count_ones();
+    if first_touch_nodes != 0 {
+        first_touches.max_merkle_height = LEVEL;
+    }
     new_nodes.count_ones()
 }
 
 #[inline(always)]
-fn local_merkle_nodes_delta_with_global_first_touches(
+fn local_merkle_nodes_delta_with_first_touches(
     mut segment_leaf_mask: u64,
     mut new_segment_leaf_mask: u64,
-    mut global_leaf_mask: u64,
-) -> (u32, GlobalFirstTouchCounts) {
+    mut baseline_leaf_mask: u64,
+) -> (u32, FirstTouchCounts) {
     debug_assert_ne!(new_segment_leaf_mask, 0);
     debug_assert_eq!(segment_leaf_mask & new_segment_leaf_mask, 0);
 
-    let mut global_first_touches = GlobalFirstTouchCounts::default();
+    let mut first_touches = FirstTouchCounts::default();
     let mut nodes = 0;
-    nodes += add_level_delta_with_global_first_touches::<1, FIRST_LEAF_PER_2_LEAVES, 1>(
+    nodes += add_level_delta_with_first_touches::<1, FIRST_LEAF_PER_2_LEAVES, 1>(
         &mut segment_leaf_mask,
         &mut new_segment_leaf_mask,
-        &mut global_leaf_mask,
-        &mut global_first_touches,
+        &mut baseline_leaf_mask,
+        &mut first_touches,
     );
-    nodes += add_level_delta_with_global_first_touches::<2, FIRST_LEAF_PER_4_LEAVES, 2>(
+    nodes += add_level_delta_with_first_touches::<2, FIRST_LEAF_PER_4_LEAVES, 2>(
         &mut segment_leaf_mask,
         &mut new_segment_leaf_mask,
-        &mut global_leaf_mask,
-        &mut global_first_touches,
+        &mut baseline_leaf_mask,
+        &mut first_touches,
     );
-    nodes += add_level_delta_with_global_first_touches::<4, FIRST_LEAF_PER_8_LEAVES, 3>(
+    nodes += add_level_delta_with_first_touches::<4, FIRST_LEAF_PER_8_LEAVES, 3>(
         &mut segment_leaf_mask,
         &mut new_segment_leaf_mask,
-        &mut global_leaf_mask,
-        &mut global_first_touches,
+        &mut baseline_leaf_mask,
+        &mut first_touches,
     );
-    nodes += add_level_delta_with_global_first_touches::<8, FIRST_LEAF_PER_16_LEAVES, 4>(
+    nodes += add_level_delta_with_first_touches::<8, FIRST_LEAF_PER_16_LEAVES, 4>(
         &mut segment_leaf_mask,
         &mut new_segment_leaf_mask,
-        &mut global_leaf_mask,
-        &mut global_first_touches,
+        &mut baseline_leaf_mask,
+        &mut first_touches,
     );
-    nodes += add_level_delta_with_global_first_touches::<16, FIRST_LEAF_PER_32_LEAVES, 5>(
+    nodes += add_level_delta_with_first_touches::<16, FIRST_LEAF_PER_32_LEAVES, 5>(
         &mut segment_leaf_mask,
         &mut new_segment_leaf_mask,
-        &mut global_leaf_mask,
-        &mut global_first_touches,
+        &mut baseline_leaf_mask,
+        &mut first_touches,
     );
-    nodes += add_level_delta_with_global_first_touches::<32, FIRST_LEAF_PER_64_LEAVES, 6>(
+    nodes += add_level_delta_with_first_touches::<32, FIRST_LEAF_PER_64_LEAVES, 6>(
         &mut segment_leaf_mask,
         &mut new_segment_leaf_mask,
-        &mut global_leaf_mask,
-        &mut global_first_touches,
+        &mut baseline_leaf_mask,
+        &mut first_touches,
     );
 
-    (nodes, global_first_touches)
+    (nodes, first_touches)
 }
 
 #[cfg(test)]
@@ -657,18 +690,18 @@ mod tests {
     #[test]
     fn test_local_merkle_nodes_doc_example() {
         let mut tracker = SegmentMemoryTracker::new(0);
-        let global_memory = GlobalMemoryTracker::new(0);
+        let baseline_memory = BaselineMemoryTracker::new(0);
         let mut nodes = 0;
         nodes += tracker
-            .insert(0, 1 << 0, &global_memory)
+            .insert(0, 1 << 0, &baseline_memory)
             .segment_merkle_nodes;
         assert_eq!(nodes, 6);
         nodes += tracker
-            .insert(0, 1 << 4, &global_memory)
+            .insert(0, 1 << 4, &baseline_memory)
             .segment_merkle_nodes;
         assert_eq!(nodes, 8);
         nodes += tracker
-            .insert(0, 1 << 2, &global_memory)
+            .insert(0, 1 << 2, &baseline_memory)
             .segment_merkle_nodes;
         assert_eq!(nodes, 9);
     }
@@ -741,15 +774,15 @@ mod tests {
     #[test]
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
         let mut tracker = SegmentMemoryTracker::new(3);
-        let global_memory = GlobalMemoryTracker::new(3);
+        let baseline_memory = BaselineMemoryTracker::new(3);
         assert_ne!(
             tracker
-                .insert(0, 1 << 0, &global_memory)
+                .insert(0, 1 << 0, &baseline_memory)
                 .new_segment_leaf_mask,
             0
         );
         assert_eq!(
-            tracker.insert(0, 1 << 0, &global_memory),
+            tracker.insert(0, 1 << 0, &baseline_memory),
             SegmentMemoryDelta::default()
         );
     }
@@ -757,15 +790,15 @@ mod tests {
     #[test]
     fn test_segment_memory_clear_resets_touched_state() {
         let mut tracker = SegmentMemoryTracker::new(3);
-        let global_memory = GlobalMemoryTracker::new(3);
-        let first = tracker.insert(0, 1 << 0, &global_memory);
-        let second = tracker.insert(7, 1 << 63, &global_memory);
+        let baseline_memory = BaselineMemoryTracker::new(3);
+        let first = tracker.insert(0, 1 << 0, &baseline_memory);
+        let second = tracker.insert(7, 1 << 63, &baseline_memory);
         assert!(first.segment_leaves + second.segment_leaves > 0);
         assert!(first.segment_merkle_nodes + second.segment_merkle_nodes > 0);
 
         tracker.clear();
 
-        let after_clear = tracker.insert(0, 1 << 0, &global_memory);
+        let after_clear = tracker.insert(0, 1 << 0, &baseline_memory);
         assert_eq!(after_clear.segment_leaves, 1);
         assert!(after_clear.segment_merkle_nodes > 0);
     }
@@ -773,26 +806,55 @@ mod tests {
     #[test]
     fn test_adjacent_pages_share_upper_ancestors() {
         let mut tracker = SegmentMemoryTracker::new(3);
-        let global_memory = GlobalMemoryTracker::new(3);
-        tracker.insert(0, 1, &global_memory);
-        let second = tracker.insert(1, 1, &global_memory);
+        let baseline_memory = BaselineMemoryTracker::new(3);
+        tracker.insert(0, 1, &baseline_memory);
+        let second = tracker.insert(1, 1, &baseline_memory);
         assert_eq!(second.segment_merkle_nodes, MEMORY_PAGE_BITS as u32);
     }
 
     #[test]
-    fn test_global_memory_suppresses_second_first_touch() {
-        let mut global_memory = GlobalMemoryTracker::new(1);
+    fn test_baseline_memory_suppresses_second_first_touch() {
+        let mut baseline_memory = BaselineMemoryTracker::new(1);
         let mut tracker = SegmentMemoryTracker::new(1);
 
-        let first = tracker.insert(0, 1, &global_memory).global_first_touches;
-        global_memory.add_page_accesses(&[PageAccess {
+        let first = tracker.insert(0, 1, &baseline_memory).first_touches;
+        baseline_memory.add_page_touches(&[PageTouch {
             page_id: 0,
             leaf_mask: 1,
         }]);
         tracker.clear();
-        let second = tracker.insert(0, 1, &global_memory).global_first_touches;
+        let second = tracker.insert(0, 1, &baseline_memory).first_touches;
 
         assert!(first.leaves > 0);
-        assert_eq!(second, GlobalFirstTouchCounts::default());
+        assert_eq!(second, FirstTouchCounts::default());
+    }
+
+    #[test]
+    fn test_default_poseidon_rows_only_charge_new_buckets() {
+        let mut rows = DefaultPoseidonRowTracker::default();
+        assert_eq!(
+            rows.count_new(FirstTouchCounts {
+                leaves: 1,
+                merkle_nodes: 6,
+                max_merkle_height: 6,
+            }),
+            7
+        );
+        assert_eq!(
+            rows.count_new(FirstTouchCounts {
+                leaves: 2,
+                merkle_nodes: 3,
+                max_merkle_height: 3,
+            }),
+            0
+        );
+        assert_eq!(
+            rows.count_new(FirstTouchCounts {
+                leaves: 0,
+                merkle_nodes: 2,
+                max_merkle_height: 8,
+            }),
+            2
+        );
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -33,8 +33,11 @@ pub(super) struct GlobalFirstTouchCounts {
     merkle_height_mask: u64,
 }
 
+/// New contribution from one page access to the current segment.
+///
+/// Counts are in leaves/internal nodes. `MemoryCtx` maps them to trace rows.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct MemoryInsertDelta {
+pub(super) struct SegmentMemoryDelta {
     /// Boundary leaves newly counted in the current segment.
     pub(super) segment_leaves: u32,
     /// Merkle internal nodes newly counted in the current segment.
@@ -212,7 +215,7 @@ impl SegmentMemoryTracker {
         page_id: usize,
         leaf_mask: u64,
         global_memory: &GlobalMemoryTracker,
-    ) -> MemoryInsertDelta {
+    ) -> SegmentMemoryDelta {
         debug_assert!(page_id < self.segment_leaf_masks.len());
         debug_assert!(leaf_mask != 0);
 
@@ -220,7 +223,7 @@ impl SegmentMemoryTracker {
         let segment_leaf_mask_before = *segment_leaf_mask;
         let segment_leaf_mask_after = segment_leaf_mask_before | leaf_mask;
         if segment_leaf_mask_after == segment_leaf_mask_before {
-            return MemoryInsertDelta::default();
+            return SegmentMemoryDelta::default();
         }
 
         *segment_leaf_mask = segment_leaf_mask_after;
@@ -279,7 +282,7 @@ impl SegmentMemoryTracker {
                 segment_merkle_nodes += self.insert_upper_path(page_id);
             }
         }
-        MemoryInsertDelta {
+        SegmentMemoryDelta {
             segment_leaves,
             segment_merkle_nodes,
             new_segment_leaf_mask,
@@ -747,7 +750,7 @@ mod tests {
         );
         assert_eq!(
             tracker.insert(0, 1 << 0, &global_memory),
-            MemoryInsertDelta::default()
+            SegmentMemoryDelta::default()
         );
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -19,28 +19,30 @@ pub struct PageAccess {
     pub leaf_mask: u64,
 }
 
-/// Old-side leaves and Merkle nodes that were still canonical default values
-/// when the current segment started.
+/// Newly counted leaves and nodes that were absent from global memory.
+///
+/// A global first touch has a canonical default initial-side value. These
+/// counts let `MemoryCtx` estimate Poseidon2 rows after default-row dedup.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct DefaultOldAccounting {
-    /// Newly charged leaves whose old value is the canonical default leaf.
-    pub(super) default_leaves: u32,
-    /// Newly charged internal nodes whose old value is a canonical default node.
-    pub(super) default_merkle_nodes: u32,
-    /// Bit `h` is set when at least one default old node appears at Merkle height `h`.
-    merkle_level_mask: u64,
+pub(super) struct GlobalFirstTouchCounts {
+    /// New segment leaves whose initial-side value is the canonical default leaf.
+    pub(super) leaves: u32,
+    /// New segment internal nodes whose initial-side value is a canonical default node.
+    pub(super) merkle_nodes: u32,
+    /// Bit `h` is set when height `h` has at least one first-touch internal node.
+    merkle_height_mask: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct MemoryAccountingDelta {
-    /// Boundary leaves newly charged in the current segment.
-    pub(super) new_leaves: u32,
-    /// Merkle internal nodes newly charged in the current segment.
-    pub(super) new_merkle_nodes: u32,
-    /// Subset of the inserted leaf mask that became newly charged in this segment.
-    pub(super) newly_charged_leaf_mask: u64,
-    /// Old-side default values among the newly charged leaves and nodes.
-    pub(super) default_old: DefaultOldAccounting,
+pub(super) struct MemoryInsertDelta {
+    /// Boundary leaves newly counted in the current segment.
+    pub(super) segment_leaves: u32,
+    /// Merkle internal nodes newly counted in the current segment.
+    pub(super) segment_merkle_nodes: u32,
+    /// Subset of the inserted leaf mask that became newly counted in this segment.
+    pub(super) new_segment_leaf_mask: u64,
+    /// New segment leaves and nodes that are absent from global memory.
+    pub(super) global_first_touches: GlobalFirstTouchCounts,
 }
 
 #[derive(Clone, Debug)]
@@ -51,12 +53,11 @@ struct BitSet {
     dirty_words: Vec<usize>,
 }
 
-/// Segment-local page accounting.
+/// Memory already counted in the current segment.
 ///
-/// This tracker is cleared whenever a new segment starts. It answers: "which
-/// leaves and Merkle nodes have already been charged in this segment?"
-/// `CommittedMemoryOccupancyTracker` is passed into `insert` only to classify
-/// old-side nodes as default or non-default.
+/// This tracker is cleared whenever a new segment starts. It prevents counting
+/// the same leaf or Merkle node twice inside one segment. `GlobalMemoryTracker`
+/// is passed into `insert` only to detect global first touches.
 ///
 /// Memory leaves form one sparse Merkle tree. Each page contains the 64 leaves
 /// represented by one `u64` leaf mask:
@@ -75,43 +76,43 @@ struct BitSet {
 /// page-local internal node once, and each upper-tree ancestor once across all
 /// pages in the segment.
 #[derive(Clone, Debug)]
-pub(super) struct SegmentMemoryPageTracker {
-    /// Segment-local touched leaf masks by page.
+pub(super) struct SegmentMemoryTracker {
+    /// Touched leaf masks by page for the current segment.
     segment_leaf_masks: Box<[u64]>,
     /// Pages written since the segment started.
     dirty_page_ids: Vec<usize>,
-    /// Upper-tree ancestors already charged in the current segment.
+    /// Upper-tree ancestors already counted in the current segment.
     segment_upper_nodes: BitSet,
     /// Number of Merkle levels above the 64-leaf page layer.
     upper_height: usize,
 }
 
-/// Occupancy committed at the last safe checkpoint.
+/// Memory present in the global baseline at the last checkpoint.
 ///
-/// This tracker persists across segment-local replays and is advanced only by
-/// `MemoryCtx::update_checkpoint`. It is seeded from nonzero initial memory, so
-/// pages or ancestors missing here are known canonical default old values.
+/// This tracker persists across segment replays and is advanced only by
+/// `MemoryCtx::update_checkpoint`. It is seeded from nonzero initial memory.
+/// A leaf or node missing from this tracker is a global first touch.
 #[derive(Clone, Debug)]
-pub(super) struct CommittedMemoryOccupancyTracker {
-    /// Leaves known occupied at the last safe checkpoint, stored by page.
-    committed_leaf_masks: Box<[u64]>,
-    /// Upper-tree ancestors known occupied at the last safe checkpoint.
-    committed_upper_nodes: BitSet,
+pub(super) struct GlobalMemoryTracker {
+    /// Leaf masks present in the global baseline, stored by page.
+    global_leaf_masks: Box<[u64]>,
+    /// Upper-tree ancestors present in the global baseline.
+    global_upper_nodes: BitSet,
     /// Number of Merkle levels above the 64-leaf page layer.
     upper_height: usize,
 }
 
-impl DefaultOldAccounting {
+impl GlobalFirstTouchCounts {
     #[inline(always)]
     pub(super) fn add(&mut self, other: Self) {
-        self.default_leaves += other.default_leaves;
-        self.default_merkle_nodes += other.default_merkle_nodes;
-        self.merkle_level_mask |= other.merkle_level_mask;
+        self.leaves += other.leaves;
+        self.merkle_nodes += other.merkle_nodes;
+        self.merkle_height_mask |= other.merkle_height_mask;
     }
 
     #[inline(always)]
-    pub(super) fn estimated_poseidon_rows(self) -> u32 {
-        u32::from(self.default_leaves != 0) + self.merkle_level_mask.count_ones()
+    pub(super) fn estimated_default_poseidon_rows(self) -> u32 {
+        u32::from(self.leaves != 0) + self.merkle_height_mask.count_ones()
     }
 }
 
@@ -131,8 +132,8 @@ impl BitSet {
     }
 
     #[inline(always)]
-    fn insert_committed(&mut self, index: usize) -> bool {
-        // Committed occupancy is monotonic and persists across checkpoints.
+    fn insert_global(&mut self, index: usize) -> bool {
+        // Global memory is monotonic and persists across checkpoints.
         self.insert_impl::<false>(index)
     }
 
@@ -148,15 +149,15 @@ impl BitSet {
         //         during memory access. The bitset is sized to accommodate all valid
         //         memory addresses, so word_index is always within bounds.
         let word = unsafe { self.words.get_unchecked_mut(word_index) };
-        let old_word = *word;
-        let was_set = (old_word & mask) != 0;
+        let previous_word = *word;
+        let was_set = (previous_word & mask) != 0;
         if was_set {
             return false;
         }
-        if TRACK_DIRTY && old_word == 0 {
+        if TRACK_DIRTY && previous_word == 0 {
             self.dirty_words.push(word_index);
         }
-        *word = old_word | mask;
+        *word = previous_word | mask;
         true
     }
 
@@ -183,7 +184,7 @@ impl BitSet {
     }
 }
 
-impl SegmentMemoryPageTracker {
+impl SegmentMemoryTracker {
     pub(super) fn new(upper_height: usize) -> Self {
         let num_pages = 1 << upper_height;
         Self {
@@ -210,8 +211,8 @@ impl SegmentMemoryPageTracker {
         &mut self,
         page_id: usize,
         leaf_mask: u64,
-        occupancy_tracker: &CommittedMemoryOccupancyTracker,
-    ) -> MemoryAccountingDelta {
+        global_memory: &GlobalMemoryTracker,
+    ) -> MemoryInsertDelta {
         debug_assert!(page_id < self.segment_leaf_masks.len());
         debug_assert!(leaf_mask != 0);
 
@@ -219,7 +220,7 @@ impl SegmentMemoryPageTracker {
         let segment_leaf_mask_before = *segment_leaf_mask;
         let segment_leaf_mask_after = segment_leaf_mask_before | leaf_mask;
         if segment_leaf_mask_after == segment_leaf_mask_before {
-            return MemoryAccountingDelta::default();
+            return MemoryInsertDelta::default();
         }
 
         *segment_leaf_mask = segment_leaf_mask_after;
@@ -227,95 +228,93 @@ impl SegmentMemoryPageTracker {
             self.dirty_page_ids.push(page_id);
         }
 
-        let newly_charged_leaf_mask = leaf_mask & !segment_leaf_mask_before;
-        let committed_leaf_mask = occupancy_tracker.page_mask(page_id);
-        let default_old_leaf_mask = newly_charged_leaf_mask & !committed_leaf_mask;
-        let single_added_leaf = newly_charged_leaf_mask.is_power_of_two();
-        let new_leaves = if single_added_leaf {
+        let new_segment_leaf_mask = leaf_mask & !segment_leaf_mask_before;
+        let global_leaf_mask = global_memory.page_mask(page_id);
+        let first_touch_leaf_mask = new_segment_leaf_mask & !global_leaf_mask;
+        let single_added_leaf = new_segment_leaf_mask.is_power_of_two();
+        let segment_leaves = if single_added_leaf {
             1
         } else {
-            newly_charged_leaf_mask.count_ones()
+            new_segment_leaf_mask.count_ones()
         };
 
-        let (mut new_merkle_nodes, mut default_old) = if default_old_leaf_mask == 0 {
-            (
-                if single_added_leaf {
-                    local_merkle_nodes_added_leaf(
-                        segment_leaf_mask_before,
-                        newly_charged_leaf_mask.trailing_zeros(),
-                    )
-                } else {
-                    local_merkle_nodes_delta(segment_leaf_mask_before, newly_charged_leaf_mask)
-                },
-                DefaultOldAccounting::default(),
-            )
+        let (mut segment_merkle_nodes, mut global_first_touches) = if first_touch_leaf_mask == 0 {
+            let nodes = if single_added_leaf {
+                local_merkle_nodes_added_leaf(
+                    segment_leaf_mask_before,
+                    new_segment_leaf_mask.trailing_zeros(),
+                )
+            } else {
+                local_merkle_nodes_delta(segment_leaf_mask_before, new_segment_leaf_mask)
+            };
+            (nodes, GlobalFirstTouchCounts::default())
         } else if single_added_leaf {
-            local_merkle_nodes_added_leaf_with_default(
+            local_merkle_nodes_added_leaf_with_global_first_touches(
                 segment_leaf_mask_before,
-                newly_charged_leaf_mask.trailing_zeros(),
-                committed_leaf_mask,
+                new_segment_leaf_mask.trailing_zeros(),
+                global_leaf_mask,
             )
         } else {
-            local_merkle_nodes_delta_with_default(
+            local_merkle_nodes_delta_with_global_first_touches(
                 segment_leaf_mask_before,
-                newly_charged_leaf_mask,
-                committed_leaf_mask,
+                new_segment_leaf_mask,
+                global_leaf_mask,
             )
         };
-        if default_old_leaf_mask != 0 {
-            default_old.default_leaves = if single_added_leaf {
+        if first_touch_leaf_mask != 0 {
+            global_first_touches.leaves = if single_added_leaf {
                 1
             } else {
-                default_old_leaf_mask.count_ones()
+                first_touch_leaf_mask.count_ones()
             };
         }
 
         if segment_leaf_mask_before == 0 {
-            if committed_leaf_mask == 0 {
-                let (upper_nodes, upper_default_old) =
-                    self.insert_upper_path_with_default_old(page_id, occupancy_tracker);
-                new_merkle_nodes += upper_nodes;
-                default_old.add(upper_default_old);
+            if global_leaf_mask == 0 {
+                let (upper_nodes, upper_global_first_touches) =
+                    self.insert_upper_path_with_global_first_touches(page_id, global_memory);
+                segment_merkle_nodes += upper_nodes;
+                global_first_touches.add(upper_global_first_touches);
             } else {
-                new_merkle_nodes += self.insert_upper_path_without_default_old(page_id);
+                segment_merkle_nodes += self.insert_upper_path(page_id);
             }
         }
-        MemoryAccountingDelta {
-            new_leaves,
-            new_merkle_nodes,
-            newly_charged_leaf_mask,
-            default_old,
+        MemoryInsertDelta {
+            segment_leaves,
+            segment_merkle_nodes,
+            new_segment_leaf_mask,
+            global_first_touches,
         }
     }
 
     #[inline(always)]
-    fn insert_upper_path_with_default_old(
+    fn insert_upper_path_with_global_first_touches(
         &mut self,
         page_id: usize,
-        occupancy_tracker: &CommittedMemoryOccupancyTracker,
-    ) -> (u32, DefaultOldAccounting) {
+        global_memory: &GlobalMemoryTracker,
+    ) -> (u32, GlobalFirstTouchCounts) {
         let mut count = 0;
-        let mut default_old = DefaultOldAccounting::default();
+        let mut global_first_touches = GlobalFirstTouchCounts::default();
         let mut node = (1usize << self.upper_height) + page_id;
         let mut height = MEMORY_PAGE_BITS + 1;
         while node > 1 {
             node >>= 1;
             if self.segment_upper_nodes.insert_clearable(node) {
                 count += 1;
-                if !occupancy_tracker.upper_contains(node) {
-                    default_old.default_merkle_nodes += 1;
-                    default_old.merkle_level_mask |= 1u64 << height;
+                if !global_memory.upper_contains(node) {
+                    global_first_touches.merkle_nodes += 1;
+                    global_first_touches.merkle_height_mask |= 1u64 << height;
                 }
             } else {
                 break;
             }
             height += 1;
         }
-        (count, default_old)
+        (count, global_first_touches)
     }
 
     #[inline(always)]
-    fn insert_upper_path_without_default_old(&mut self, page_id: usize) -> u32 {
+    fn insert_upper_path(&mut self, page_id: usize) -> u32 {
         let mut count = 0;
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
@@ -330,42 +329,42 @@ impl SegmentMemoryPageTracker {
     }
 }
 
-impl CommittedMemoryOccupancyTracker {
+impl GlobalMemoryTracker {
     pub(super) fn new(upper_height: usize) -> Self {
         let num_pages = 1 << upper_height;
         Self {
-            committed_leaf_masks: vec![0; num_pages].into_boxed_slice(),
-            committed_upper_nodes: BitSet::new(num_pages),
+            global_leaf_masks: vec![0; num_pages].into_boxed_slice(),
+            global_upper_nodes: BitSet::new(num_pages),
             upper_height,
         }
     }
 
     #[inline(always)]
     pub(super) fn page_mask(&self, page_id: usize) -> u64 {
-        debug_assert!(page_id < self.committed_leaf_masks.len());
-        unsafe { *self.committed_leaf_masks.get_unchecked(page_id) }
+        debug_assert!(page_id < self.global_leaf_masks.len());
+        unsafe { *self.global_leaf_masks.get_unchecked(page_id) }
     }
 
     #[inline(always)]
     fn upper_contains(&self, node: usize) -> bool {
-        self.committed_upper_nodes.contains(node)
+        self.global_upper_nodes.contains(node)
     }
 
     #[inline(always)]
     pub(super) fn mark_existing_page(&mut self, page_id: usize, leaf_mask: u64) {
-        debug_assert!(page_id < self.committed_leaf_masks.len());
+        debug_assert!(page_id < self.global_leaf_masks.len());
         debug_assert!(leaf_mask != 0);
 
-        let committed_leaf_mask = unsafe { self.committed_leaf_masks.get_unchecked_mut(page_id) };
-        let committed_leaf_mask_before = *committed_leaf_mask;
-        *committed_leaf_mask = committed_leaf_mask_before | leaf_mask;
-        if committed_leaf_mask_before == 0 {
+        let global_leaf_mask = unsafe { self.global_leaf_masks.get_unchecked_mut(page_id) };
+        let global_leaf_mask_before = *global_leaf_mask;
+        *global_leaf_mask = global_leaf_mask_before | leaf_mask;
+        if global_leaf_mask_before == 0 {
             self.mark_upper_path(page_id);
         }
     }
 
     #[inline(always)]
-    pub(super) fn commit_page_accesses(&mut self, accesses: &[PageAccess]) {
+    pub(super) fn add_page_accesses(&mut self, accesses: &[PageAccess]) {
         for &access in accesses {
             self.mark_existing_page(access.page_id as usize, access.leaf_mask);
         }
@@ -376,7 +375,7 @@ impl CommittedMemoryOccupancyTracker {
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
             node >>= 1;
-            if !self.committed_upper_nodes.insert_committed(node) {
+            if !self.global_upper_nodes.insert_global(node) {
                 break;
             }
         }
@@ -399,51 +398,51 @@ pub(super) fn leaf_mask_range(start: u32, end: u32) -> u64 {
 #[inline(always)]
 fn add_level_delta<const SHIFT: u32, const MASK: u64>(
     segment_mask: &mut u64,
-    newly_charged_mask: &mut u64,
+    new_segment_mask: &mut u64,
 ) -> u32 {
     *segment_mask = (*segment_mask | (*segment_mask >> SHIFT)) & MASK;
-    *newly_charged_mask = (*newly_charged_mask | (*newly_charged_mask >> SHIFT)) & MASK;
-    (*newly_charged_mask & !*segment_mask).count_ones()
+    *new_segment_mask = (*new_segment_mask | (*new_segment_mask >> SHIFT)) & MASK;
+    (*new_segment_mask & !*segment_mask).count_ones()
 }
 
 #[inline(always)]
-fn local_merkle_nodes_delta(mut segment_leaf_mask: u64, mut newly_charged_leaf_mask: u64) -> u32 {
-    debug_assert_ne!(newly_charged_leaf_mask, 0);
-    debug_assert_eq!(segment_leaf_mask & newly_charged_leaf_mask, 0);
+fn local_merkle_nodes_delta(mut segment_leaf_mask: u64, mut new_segment_leaf_mask: u64) -> u32 {
+    debug_assert_ne!(new_segment_leaf_mask, 0);
+    debug_assert_eq!(segment_leaf_mask & new_segment_leaf_mask, 0);
 
     // At each level, collapse child occupancy into one representative bit per
-    // parent group, then count groups reached by added leaves that were empty
-    // in the old segment-local mask.
+    // parent group, then count groups reached by new segment leaves that were
+    // empty in the segment mask.
     //
     // ```text
     // leaves:       0 1   1 0   0 0   1 1
     // parents:       1     1     0     1
-    // new parents:   (added_parent_bits & !old_parent_bits).count_ones()
+    // new parents:   (added_parent_bits & !segment_parent_bits).count_ones()
     // ```
     let mut nodes = 0;
     nodes += add_level_delta::<1, FIRST_LEAF_PER_2_LEAVES>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
+        &mut new_segment_leaf_mask,
     );
     nodes += add_level_delta::<2, FIRST_LEAF_PER_4_LEAVES>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
+        &mut new_segment_leaf_mask,
     );
     nodes += add_level_delta::<4, FIRST_LEAF_PER_8_LEAVES>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
+        &mut new_segment_leaf_mask,
     );
     nodes += add_level_delta::<8, FIRST_LEAF_PER_16_LEAVES>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
+        &mut new_segment_leaf_mask,
     );
     nodes += add_level_delta::<16, FIRST_LEAF_PER_32_LEAVES>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
+        &mut new_segment_leaf_mask,
     );
     nodes += add_level_delta::<32, FIRST_LEAF_PER_64_LEAVES>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
+        &mut new_segment_leaf_mask,
     );
 
     nodes
@@ -476,16 +475,16 @@ fn local_merkle_nodes_added_leaf(segment_leaf_mask: u64, leaf: u32) -> u32 {
 }
 
 #[inline(always)]
-fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32, const LEVEL: usize>(
+fn add_leaf_level_delta_with_global_first_touch<const GROUP_SIZE: u32, const LEVEL: usize>(
     segment_leaf_mask: u64,
-    committed_leaf_mask: u64,
+    global_leaf_mask: u64,
     leaf: u32,
-    default_old: &mut DefaultOldAccounting,
+    global_first_touches: &mut GlobalFirstTouchCounts,
 ) -> u32 {
     if aligned_group_is_empty::<GROUP_SIZE>(segment_leaf_mask, leaf) {
-        if aligned_group_is_empty::<GROUP_SIZE>(committed_leaf_mask, leaf) {
-            default_old.default_merkle_nodes += 1;
-            default_old.merkle_level_mask |= 1u64 << LEVEL;
+        if aligned_group_is_empty::<GROUP_SIZE>(global_leaf_mask, leaf) {
+            global_first_touches.merkle_nodes += 1;
+            global_first_touches.merkle_height_mask |= 1u64 << LEVEL;
         }
         1
     } else {
@@ -494,134 +493,138 @@ fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32, const LEVEL: usize>(
 }
 
 #[inline(always)]
-fn local_merkle_nodes_added_leaf_with_default(
+fn local_merkle_nodes_added_leaf_with_global_first_touches(
     segment_leaf_mask: u64,
     leaf: u32,
-    committed_leaf_mask: u64,
-) -> (u32, DefaultOldAccounting) {
+    global_leaf_mask: u64,
+) -> (u32, GlobalFirstTouchCounts) {
     debug_assert!(leaf < u64::BITS);
 
-    if segment_leaf_mask == 0 && committed_leaf_mask == 0 {
+    if segment_leaf_mask == 0 && global_leaf_mask == 0 {
         return (
             MEMORY_PAGE_BITS as u32,
-            DefaultOldAccounting {
-                default_leaves: 0,
-                default_merkle_nodes: MEMORY_PAGE_BITS as u32,
-                merkle_level_mask: (1u64 << (MEMORY_PAGE_BITS + 1)) - 2,
+            GlobalFirstTouchCounts {
+                leaves: 0,
+                merkle_nodes: MEMORY_PAGE_BITS as u32,
+                merkle_height_mask: (1u64 << (MEMORY_PAGE_BITS + 1)) - 2,
             },
         );
     }
 
-    let mut default_old = DefaultOldAccounting::default();
+    let mut global_first_touches = GlobalFirstTouchCounts::default();
     let mut nodes = 0;
-    nodes += add_leaf_level_delta_with_default::<2, 1>(
+    nodes += add_leaf_level_delta_with_global_first_touch::<2, 1>(
         segment_leaf_mask,
-        committed_leaf_mask,
+        global_leaf_mask,
         leaf,
-        &mut default_old,
+        &mut global_first_touches,
     );
-    nodes += add_leaf_level_delta_with_default::<4, 2>(
+    nodes += add_leaf_level_delta_with_global_first_touch::<4, 2>(
         segment_leaf_mask,
-        committed_leaf_mask,
+        global_leaf_mask,
         leaf,
-        &mut default_old,
+        &mut global_first_touches,
     );
-    nodes += add_leaf_level_delta_with_default::<8, 3>(
+    nodes += add_leaf_level_delta_with_global_first_touch::<8, 3>(
         segment_leaf_mask,
-        committed_leaf_mask,
+        global_leaf_mask,
         leaf,
-        &mut default_old,
+        &mut global_first_touches,
     );
-    nodes += add_leaf_level_delta_with_default::<16, 4>(
+    nodes += add_leaf_level_delta_with_global_first_touch::<16, 4>(
         segment_leaf_mask,
-        committed_leaf_mask,
+        global_leaf_mask,
         leaf,
-        &mut default_old,
+        &mut global_first_touches,
     );
-    nodes += add_leaf_level_delta_with_default::<32, 5>(
+    nodes += add_leaf_level_delta_with_global_first_touch::<32, 5>(
         segment_leaf_mask,
-        committed_leaf_mask,
+        global_leaf_mask,
         leaf,
-        &mut default_old,
+        &mut global_first_touches,
     );
 
     if segment_leaf_mask == 0 {
         nodes += 1;
-        if committed_leaf_mask == 0 {
-            default_old.default_merkle_nodes += 1;
-            default_old.merkle_level_mask |= 1u64 << MEMORY_PAGE_BITS;
+        if global_leaf_mask == 0 {
+            global_first_touches.merkle_nodes += 1;
+            global_first_touches.merkle_height_mask |= 1u64 << MEMORY_PAGE_BITS;
         }
     }
 
-    (nodes, default_old)
+    (nodes, global_first_touches)
 }
 
 #[inline(always)]
-fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64, const LEVEL: usize>(
+fn add_level_delta_with_global_first_touches<
+    const SHIFT: u32,
+    const MASK: u64,
+    const LEVEL: usize,
+>(
     segment_mask: &mut u64,
-    newly_charged_mask: &mut u64,
-    committed_level_mask: &mut u64,
-    default_old: &mut DefaultOldAccounting,
+    new_segment_mask: &mut u64,
+    global_level_mask: &mut u64,
+    global_first_touches: &mut GlobalFirstTouchCounts,
 ) -> u32 {
     *segment_mask = (*segment_mask | (*segment_mask >> SHIFT)) & MASK;
-    *newly_charged_mask = (*newly_charged_mask | (*newly_charged_mask >> SHIFT)) & MASK;
-    *committed_level_mask = (*committed_level_mask | (*committed_level_mask >> SHIFT)) & MASK;
-    let new_nodes = *newly_charged_mask & !*segment_mask;
-    let default_nodes = new_nodes & !*committed_level_mask;
-    default_old.default_merkle_nodes += default_nodes.count_ones();
-    default_old.merkle_level_mask |= u64::from(default_nodes != 0) << LEVEL;
+    *new_segment_mask = (*new_segment_mask | (*new_segment_mask >> SHIFT)) & MASK;
+    *global_level_mask = (*global_level_mask | (*global_level_mask >> SHIFT)) & MASK;
+    let new_nodes = *new_segment_mask & !*segment_mask;
+    let first_touch_nodes = new_nodes & !*global_level_mask;
+    global_first_touches.merkle_nodes += first_touch_nodes.count_ones();
+    global_first_touches.merkle_height_mask |= u64::from(first_touch_nodes != 0) << LEVEL;
     new_nodes.count_ones()
 }
 
 #[inline(always)]
-fn local_merkle_nodes_delta_with_default(
+fn local_merkle_nodes_delta_with_global_first_touches(
     mut segment_leaf_mask: u64,
-    mut newly_charged_leaf_mask: u64,
-    mut committed_leaf_mask: u64,
-) -> (u32, DefaultOldAccounting) {
-    debug_assert_ne!(newly_charged_leaf_mask, 0);
-    debug_assert_eq!(segment_leaf_mask & newly_charged_leaf_mask, 0);
+    mut new_segment_leaf_mask: u64,
+    mut global_leaf_mask: u64,
+) -> (u32, GlobalFirstTouchCounts) {
+    debug_assert_ne!(new_segment_leaf_mask, 0);
+    debug_assert_eq!(segment_leaf_mask & new_segment_leaf_mask, 0);
 
-    let mut default_old = DefaultOldAccounting::default();
+    let mut global_first_touches = GlobalFirstTouchCounts::default();
     let mut nodes = 0;
-    nodes += add_level_delta_with_default::<1, FIRST_LEAF_PER_2_LEAVES, 1>(
+    nodes += add_level_delta_with_global_first_touches::<1, FIRST_LEAF_PER_2_LEAVES, 1>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
-        &mut committed_leaf_mask,
-        &mut default_old,
+        &mut new_segment_leaf_mask,
+        &mut global_leaf_mask,
+        &mut global_first_touches,
     );
-    nodes += add_level_delta_with_default::<2, FIRST_LEAF_PER_4_LEAVES, 2>(
+    nodes += add_level_delta_with_global_first_touches::<2, FIRST_LEAF_PER_4_LEAVES, 2>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
-        &mut committed_leaf_mask,
-        &mut default_old,
+        &mut new_segment_leaf_mask,
+        &mut global_leaf_mask,
+        &mut global_first_touches,
     );
-    nodes += add_level_delta_with_default::<4, FIRST_LEAF_PER_8_LEAVES, 3>(
+    nodes += add_level_delta_with_global_first_touches::<4, FIRST_LEAF_PER_8_LEAVES, 3>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
-        &mut committed_leaf_mask,
-        &mut default_old,
+        &mut new_segment_leaf_mask,
+        &mut global_leaf_mask,
+        &mut global_first_touches,
     );
-    nodes += add_level_delta_with_default::<8, FIRST_LEAF_PER_16_LEAVES, 4>(
+    nodes += add_level_delta_with_global_first_touches::<8, FIRST_LEAF_PER_16_LEAVES, 4>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
-        &mut committed_leaf_mask,
-        &mut default_old,
+        &mut new_segment_leaf_mask,
+        &mut global_leaf_mask,
+        &mut global_first_touches,
     );
-    nodes += add_level_delta_with_default::<16, FIRST_LEAF_PER_32_LEAVES, 5>(
+    nodes += add_level_delta_with_global_first_touches::<16, FIRST_LEAF_PER_32_LEAVES, 5>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
-        &mut committed_leaf_mask,
-        &mut default_old,
+        &mut new_segment_leaf_mask,
+        &mut global_leaf_mask,
+        &mut global_first_touches,
     );
-    nodes += add_level_delta_with_default::<32, FIRST_LEAF_PER_64_LEAVES, 6>(
+    nodes += add_level_delta_with_global_first_touches::<32, FIRST_LEAF_PER_64_LEAVES, 6>(
         &mut segment_leaf_mask,
-        &mut newly_charged_leaf_mask,
-        &mut committed_leaf_mask,
-        &mut default_old,
+        &mut new_segment_leaf_mask,
+        &mut global_leaf_mask,
+        &mut global_first_touches,
     );
 
-    (nodes, default_old)
+    (nodes, global_first_touches)
 }
 
 #[cfg(test)]
@@ -650,20 +653,20 @@ mod tests {
 
     #[test]
     fn test_local_merkle_nodes_doc_example() {
-        let mut tracker = SegmentMemoryPageTracker::new(0);
-        let committed_occupancy = CommittedMemoryOccupancyTracker::new(0);
+        let mut tracker = SegmentMemoryTracker::new(0);
+        let global_memory = GlobalMemoryTracker::new(0);
         let mut nodes = 0;
         nodes += tracker
-            .insert(0, 1 << 0, &committed_occupancy)
-            .new_merkle_nodes;
+            .insert(0, 1 << 0, &global_memory)
+            .segment_merkle_nodes;
         assert_eq!(nodes, 6);
         nodes += tracker
-            .insert(0, 1 << 4, &committed_occupancy)
-            .new_merkle_nodes;
+            .insert(0, 1 << 4, &global_memory)
+            .segment_merkle_nodes;
         assert_eq!(nodes, 8);
         nodes += tracker
-            .insert(0, 1 << 2, &committed_occupancy)
-            .new_merkle_nodes;
+            .insert(0, 1 << 2, &global_memory)
+            .segment_merkle_nodes;
         assert_eq!(nodes, 9);
     }
 
@@ -685,11 +688,11 @@ mod tests {
         for leaf_mask in additions {
             let segment_leaf_mask_after = segment_leaf_mask | leaf_mask;
             if segment_leaf_mask_after != segment_leaf_mask {
-                let newly_charged_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
+                let new_segment_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
                 let expected = reference_local_merkle_nodes(segment_leaf_mask_after)
                     - reference_local_merkle_nodes(segment_leaf_mask);
                 assert_eq!(
-                    local_merkle_nodes_delta(segment_leaf_mask, newly_charged_leaf_mask),
+                    local_merkle_nodes_delta(segment_leaf_mask, new_segment_leaf_mask),
                     expected
                 );
                 segment_leaf_mask = segment_leaf_mask_after;
@@ -700,11 +703,11 @@ mod tests {
         for leaf_mask in additions {
             let segment_leaf_mask_after = segment_leaf_mask | leaf_mask;
             if segment_leaf_mask_after != segment_leaf_mask {
-                let newly_charged_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
+                let new_segment_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
                 let expected = reference_local_merkle_nodes(segment_leaf_mask_after)
                     - reference_local_merkle_nodes(segment_leaf_mask);
                 assert_eq!(
-                    local_merkle_nodes_delta(segment_leaf_mask, newly_charged_leaf_mask),
+                    local_merkle_nodes_delta(segment_leaf_mask, new_segment_leaf_mask),
                     expected
                 );
                 segment_leaf_mask = segment_leaf_mask_after;
@@ -722,9 +725,9 @@ mod tests {
             seed ^= seed << 8;
             let segment_leaf_mask_after = segment_leaf_mask | seed;
             if segment_leaf_mask_after != segment_leaf_mask {
-                let newly_charged_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
+                let new_segment_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
                 assert_eq!(
-                    local_merkle_nodes_delta(segment_leaf_mask, newly_charged_leaf_mask),
+                    local_merkle_nodes_delta(segment_leaf_mask, new_segment_leaf_mask),
                     reference_local_merkle_nodes(segment_leaf_mask_after)
                         - reference_local_merkle_nodes(segment_leaf_mask)
                 );
@@ -734,59 +737,59 @@ mod tests {
 
     #[test]
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
-        let mut tracker = SegmentMemoryPageTracker::new(3);
-        let committed_occupancy = CommittedMemoryOccupancyTracker::new(3);
+        let mut tracker = SegmentMemoryTracker::new(3);
+        let global_memory = GlobalMemoryTracker::new(3);
         assert_ne!(
             tracker
-                .insert(0, 1 << 0, &committed_occupancy)
-                .newly_charged_leaf_mask,
+                .insert(0, 1 << 0, &global_memory)
+                .new_segment_leaf_mask,
             0
         );
         assert_eq!(
-            tracker.insert(0, 1 << 0, &committed_occupancy),
-            MemoryAccountingDelta::default()
+            tracker.insert(0, 1 << 0, &global_memory),
+            MemoryInsertDelta::default()
         );
     }
 
     #[test]
-    fn test_memory_page_tracker_clear_resets_touched_state() {
-        let mut tracker = SegmentMemoryPageTracker::new(3);
-        let committed_occupancy = CommittedMemoryOccupancyTracker::new(3);
-        let first = tracker.insert(0, 1 << 0, &committed_occupancy);
-        let second = tracker.insert(7, 1 << 63, &committed_occupancy);
-        assert!(first.new_leaves + second.new_leaves > 0);
-        assert!(first.new_merkle_nodes + second.new_merkle_nodes > 0);
+    fn test_segment_memory_clear_resets_touched_state() {
+        let mut tracker = SegmentMemoryTracker::new(3);
+        let global_memory = GlobalMemoryTracker::new(3);
+        let first = tracker.insert(0, 1 << 0, &global_memory);
+        let second = tracker.insert(7, 1 << 63, &global_memory);
+        assert!(first.segment_leaves + second.segment_leaves > 0);
+        assert!(first.segment_merkle_nodes + second.segment_merkle_nodes > 0);
 
         tracker.clear();
 
-        let after_clear = tracker.insert(0, 1 << 0, &committed_occupancy);
-        assert_eq!(after_clear.new_leaves, 1);
-        assert!(after_clear.new_merkle_nodes > 0);
+        let after_clear = tracker.insert(0, 1 << 0, &global_memory);
+        assert_eq!(after_clear.segment_leaves, 1);
+        assert!(after_clear.segment_merkle_nodes > 0);
     }
 
     #[test]
     fn test_adjacent_pages_share_upper_ancestors() {
-        let mut tracker = SegmentMemoryPageTracker::new(3);
-        let committed_occupancy = CommittedMemoryOccupancyTracker::new(3);
-        tracker.insert(0, 1, &committed_occupancy);
-        let second = tracker.insert(1, 1, &committed_occupancy);
-        assert_eq!(second.new_merkle_nodes, MEMORY_PAGE_BITS as u32);
+        let mut tracker = SegmentMemoryTracker::new(3);
+        let global_memory = GlobalMemoryTracker::new(3);
+        tracker.insert(0, 1, &global_memory);
+        let second = tracker.insert(1, 1, &global_memory);
+        assert_eq!(second.segment_merkle_nodes, MEMORY_PAGE_BITS as u32);
     }
 
     #[test]
-    fn test_checkpoint_commit_keeps_occupied_counts() {
-        let mut committed_occupancy = CommittedMemoryOccupancyTracker::new(1);
-        let mut tracker = SegmentMemoryPageTracker::new(1);
+    fn test_global_memory_suppresses_second_first_touch() {
+        let mut global_memory = GlobalMemoryTracker::new(1);
+        let mut tracker = SegmentMemoryTracker::new(1);
 
-        let first = tracker.insert(0, 1, &committed_occupancy).default_old;
-        committed_occupancy.commit_page_accesses(&[PageAccess {
+        let first = tracker.insert(0, 1, &global_memory).global_first_touches;
+        global_memory.add_page_accesses(&[PageAccess {
             page_id: 0,
             leaf_mask: 1,
         }]);
         tracker.clear();
-        let second = tracker.insert(0, 1, &committed_occupancy).default_old;
+        let second = tracker.insert(0, 1, &global_memory).global_first_touches;
 
-        assert!(first.default_leaves > 0);
-        assert_eq!(second, DefaultOldAccounting::default());
+        assert!(first.leaves > 0);
+        assert_eq!(second, GlobalFirstTouchCounts::default());
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -12,6 +12,11 @@ const FIRST_LEAF_PER_64_LEAVES: u64 = 0x0000_0000_0000_0001;
 /// Leaves touched within one 64-leaf page.
 ///
 /// `page_id` selects the page and bit `i` in `leaf_mask` selects leaf `i` in that page.
+///
+/// ```text
+/// leaf in page:  0  1  2  3  ... 63
+/// mask bit:      1  0  1  0  ...  0
+/// ```
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PageTouch {

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -74,8 +74,8 @@ pub(super) struct SegmentMemoryDelta {
     pub(super) first_touches: FirstTouchCounts,
 }
 
-/// Fixed-size bit set that can clear only the words changed during a segment.
-#[derive(Clone, Debug)]
+/// Fixed-size bit set that records which words are nonzero.
+#[derive(Debug)]
 struct BitSet {
     /// Packed occupancy bits.
     words: Box<[u64]>,
@@ -104,7 +104,7 @@ struct BitSet {
 /// The tracker counts each newly touched leaf once, each newly required
 /// page-local internal node once, and each upper-tree ancestor once across all
 /// pages in the segment.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) struct SegmentMemoryTracker {
     /// Touched leaf masks by page for the current segment.
     segment_leaf_masks: Box<[u64]>,
@@ -121,10 +121,12 @@ pub(super) struct SegmentMemoryTracker {
 /// If execution must end the current segment at that checkpoint, the next segment starts from this
 /// state. Unlike `SegmentMemoryTracker`, this survives the segment change. It is updated only after
 /// a safe checkpoint and is initially populated from nonzero program memory.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) struct BaselineMemoryTracker {
     /// Leaf masks present in the baseline, stored by page.
     baseline_leaf_masks: Box<[u64]>,
+    /// Indices of pages containing at least one baseline leaf.
+    nonempty_page_ids: Vec<usize>,
     /// Upper-tree ancestors present in the baseline.
     baseline_upper_nodes: BitSet,
     /// Number of Merkle levels above the 64-leaf page layer.
@@ -166,17 +168,17 @@ impl BitSet {
     fn insert_clearable(&mut self, index: usize) -> bool {
         // Segment-local sets use dirty-word tracking so `clear` only touches
         // words written in the segment.
-        self.insert_impl::<true>(index)
+        self.insert_impl(index)
     }
 
     #[inline(always)]
     fn insert_baseline(&mut self, index: usize) -> bool {
         // Baseline memory is monotonic and persists across checkpoints.
-        self.insert_impl::<false>(index)
+        self.insert_impl(index)
     }
 
     #[inline(always)]
-    fn insert_impl<const TRACK_DIRTY: bool>(&mut self, index: usize) -> bool {
+    fn insert_impl(&mut self, index: usize) -> bool {
         let word_index = index >> 6;
         let bit_index = index & 63;
         let mask = 1u64 << bit_index;
@@ -192,7 +194,7 @@ impl BitSet {
         if was_set {
             return false;
         }
-        if TRACK_DIRTY && previous_word == 0 {
+        if previous_word == 0 {
             self.dirty_words.push(word_index);
         }
         *word = previous_word | mask;
@@ -214,11 +216,59 @@ impl BitSet {
     #[inline(always)]
     fn clear(&mut self) {
         for word_index in self.dirty_words.drain(..) {
-            // SAFETY: dirty_words entries are word indices previously written by this BitSet.
+            // SAFETY: dirty_words contains indices previously written in this BitSet.
             unsafe {
                 *self.words.get_unchecked_mut(word_index) = 0;
             }
         }
+    }
+}
+
+impl BitSet {
+    fn clone_populated(&self) -> Self {
+        let mut cloned = Self {
+            words: vec![0; self.words.len()].into_boxed_slice(),
+            dirty_words: self.dirty_words.clone(),
+        };
+        for &word_index in &self.dirty_words {
+            // SAFETY: dirty_words contains indices previously written in this BitSet.
+            unsafe {
+                *cloned.words.get_unchecked_mut(word_index) = *self.words.get_unchecked(word_index);
+            }
+        }
+        cloned
+    }
+}
+
+impl Clone for SegmentMemoryTracker {
+    fn clone(&self) -> Self {
+        let mut cloned = Self::new(self.upper_height);
+        cloned.dirty_page_ids = self.dirty_page_ids.clone();
+        for &page_id in &self.dirty_page_ids {
+            // SAFETY: dirty_page_ids contains indices previously written in this tracker.
+            unsafe {
+                *cloned.segment_leaf_masks.get_unchecked_mut(page_id) =
+                    *self.segment_leaf_masks.get_unchecked(page_id);
+            }
+        }
+        cloned.segment_upper_nodes = self.segment_upper_nodes.clone_populated();
+        cloned
+    }
+}
+
+impl Clone for BaselineMemoryTracker {
+    fn clone(&self) -> Self {
+        let mut cloned = Self::new(self.upper_height);
+        cloned.nonempty_page_ids = self.nonempty_page_ids.clone();
+        for &page_id in &self.nonempty_page_ids {
+            // SAFETY: nonempty_page_ids contains indices previously written in this tracker.
+            unsafe {
+                *cloned.baseline_leaf_masks.get_unchecked_mut(page_id) =
+                    *self.baseline_leaf_masks.get_unchecked(page_id);
+            }
+        }
+        cloned.baseline_upper_nodes = self.baseline_upper_nodes.clone_populated();
+        cloned
     }
 }
 
@@ -372,6 +422,7 @@ impl BaselineMemoryTracker {
         let num_pages = 1 << upper_height;
         Self {
             baseline_leaf_masks: vec![0; num_pages].into_boxed_slice(),
+            nonempty_page_ids: Vec::new(),
             baseline_upper_nodes: BitSet::new(num_pages),
             upper_height,
         }
@@ -397,6 +448,7 @@ impl BaselineMemoryTracker {
         let baseline_leaf_mask_before = *baseline_leaf_mask;
         *baseline_leaf_mask = baseline_leaf_mask_before | leaf_mask;
         if baseline_leaf_mask_before == 0 {
+            self.nonempty_page_ids.push(page_id);
             self.mark_upper_path(page_id);
         }
     }
@@ -827,6 +879,47 @@ mod tests {
 
         assert!(first.leaves > 0);
         assert_eq!(second, FirstTouchCounts::default());
+    }
+
+    #[test]
+    fn test_segment_tracker_clone_preserves_populated_entries() {
+        let baseline_memory = BaselineMemoryTracker::new(3);
+        let mut tracker = SegmentMemoryTracker::new(3);
+        tracker.insert(0, 1, &baseline_memory);
+        tracker.insert(7, 1 << 63, &baseline_memory);
+
+        let mut cloned = tracker.clone();
+        assert_eq!(
+            cloned.insert(0, 1, &baseline_memory),
+            SegmentMemoryDelta::default()
+        );
+        assert_eq!(
+            cloned.insert(7, 1 << 63, &baseline_memory),
+            SegmentMemoryDelta::default()
+        );
+        assert_eq!(
+            cloned.insert(1, 1, &baseline_memory),
+            tracker.insert(1, 1, &baseline_memory)
+        );
+    }
+
+    #[test]
+    fn test_baseline_tracker_clone_preserves_populated_entries() {
+        let mut baseline_memory = BaselineMemoryTracker::new(1);
+        baseline_memory.mark_existing_page(0, 1);
+        baseline_memory.mark_existing_page(0, 2);
+        assert_eq!(baseline_memory.nonempty_page_ids, [0]);
+
+        let cloned = baseline_memory.clone();
+        let mut tracker = SegmentMemoryTracker::new(1);
+        assert_eq!(
+            tracker.insert(0, 0b11, &cloned).first_touches,
+            FirstTouchCounts::default()
+        );
+        assert_ne!(
+            tracker.insert(1, 1, &cloned).first_touches,
+            FirstTouchCounts::default()
+        );
     }
 
     #[test]

--- a/crates/vm/src/arch/execution_mode/metered/mod.rs
+++ b/crates/vm/src/arch/execution_mode/metered/mod.rs
@@ -1,3 +1,4 @@
 pub mod ctx;
 pub mod memory_ctx;
+mod page_tracker;
 pub mod segment_ctx;

--- a/crates/vm/src/arch/execution_mode/metered/mod.rs
+++ b/crates/vm/src/arch/execution_mode/metered/mod.rs
@@ -1,4 +1,4 @@
 pub mod ctx;
 pub mod memory_ctx;
-mod page_tracker;
+mod memory_tracker;
 pub mod segment_ctx;

--- a/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
@@ -1,0 +1,725 @@
+use openvm_instructions::MEMORY_PAGE_BITS;
+
+// Masks with the first bit set in each aligned group of leaves. These represent
+// group occupancy at each page-local Merkle level.
+const FIRST_BIT_PER_PAIR: u64 = 0x5555_5555_5555_5555;
+const FIRST_BIT_PER_NIBBLE: u64 = 0x1111_1111_1111_1111;
+const FIRST_BIT_PER_BYTE: u64 = 0x0101_0101_0101_0101;
+const FIRST_BIT_PER_U16: u64 = 0x0001_0001_0001_0001;
+const FIRST_BIT_PER_U32: u64 = 0x0000_0001_0000_0001;
+const FIRST_BIT_PER_U64: u64 = 0x0000_0000_0000_0001;
+
+/// Old-side leaves and Merkle nodes that were still canonical default values
+/// when the current segment started.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct DefaultOldCounts {
+    pub(super) leaves: u32,
+    pub(super) merkle_nodes: u32,
+    merkle_node_levels: u64,
+}
+
+impl DefaultOldCounts {
+    #[inline(always)]
+    pub(super) fn add(&mut self, other: Self) {
+        self.leaves += other.leaves;
+        self.merkle_nodes += other.merkle_nodes;
+        self.merkle_node_levels |= other.merkle_node_levels;
+    }
+
+    #[inline(always)]
+    pub(super) fn estimated_poseidon_rows(self) -> u32 {
+        u32::from(self.leaves != 0) + self.merkle_node_levels.count_ones()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BitSet {
+    words: Box<[u64]>,
+    dirty_words: Vec<usize>,
+}
+
+impl BitSet {
+    fn new(num_bits: usize) -> Self {
+        Self {
+            words: vec![0; num_bits.div_ceil(u64::BITS as usize)].into_boxed_slice(),
+            dirty_words: Vec::new(),
+        }
+    }
+
+    #[inline(always)]
+    fn insert(&mut self, index: usize) -> bool {
+        // Segment-local sets use dirty-word tracking so `clear` only touches
+        // words written in the segment.
+        self.insert_impl::<true>(index)
+    }
+
+    #[inline(always)]
+    fn insert_persistent(&mut self, index: usize) -> bool {
+        // Committed occupancy is monotonic and persists across checkpoints.
+        self.insert_impl::<false>(index)
+    }
+
+    #[inline(always)]
+    fn insert_impl<const TRACK_DIRTY: bool>(&mut self, index: usize) -> bool {
+        let word_index = index >> 6;
+        let bit_index = index & 63;
+        let mask = 1u64 << bit_index;
+
+        debug_assert!(word_index < self.words.len(), "BitSet index out of bounds");
+
+        // SAFETY: word_index is derived from a memory address that is bounds-checked
+        //         during memory access. The bitset is sized to accommodate all valid
+        //         memory addresses, so word_index is always within bounds.
+        let word = unsafe { self.words.get_unchecked_mut(word_index) };
+        let old_word = *word;
+        let was_set = (old_word & mask) != 0;
+        if was_set {
+            return false;
+        }
+        if TRACK_DIRTY && old_word == 0 {
+            self.dirty_words.push(word_index);
+        }
+        *word = old_word | mask;
+        true
+    }
+
+    #[inline(always)]
+    fn contains(&self, index: usize) -> bool {
+        let word_index = index >> 6;
+        let bit_index = index & 63;
+        let mask = 1u64 << bit_index;
+
+        debug_assert!(word_index < self.words.len(), "BitSet index out of bounds");
+
+        // SAFETY: word_index is derived from a valid memory tree node index.
+        unsafe { (*self.words.get_unchecked(word_index) & mask) != 0 }
+    }
+
+    #[inline(always)]
+    fn clear(&mut self) {
+        for word_index in self.dirty_words.drain(..) {
+            // SAFETY: dirty_words entries are word indices previously written by this BitSet.
+            unsafe {
+                *self.words.get_unchecked_mut(word_index) = 0;
+            }
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PageAccess {
+    /// Index into the page table. The leaf occupancy for this page is stored
+    /// in `leaf_mask`.
+    pub page_id: u32,
+    /// Bit `i` is set when leaf `i` inside this 64-leaf page was touched.
+    pub leaf_mask: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct MemoryHeightDelta {
+    pub(super) leaves: u32,
+    pub(super) merkle_nodes: u32,
+    pub(super) added_mask: u64,
+    pub(super) default_old: DefaultOldCounts,
+}
+
+/// Segment-local page accounting.
+///
+/// This tracker is cleared whenever a new segment starts. It answers: "which
+/// leaves and Merkle nodes have already been charged in this segment?"
+/// `MemoryOccupancyTracker` is passed into `insert` only to classify old-side
+/// nodes as default or non-default.
+///
+/// Memory leaves form one sparse Merkle tree. Each page contains the 64 leaves
+/// represented by one `u64` leaf mask:
+///
+/// ```text
+///        [root]              height h
+///        /    \
+///      ...    ...
+///      /        \
+///   [page]    [page]         h - MEMORY_PAGE_BITS nodes above each page
+///   / .. \
+///  L  ..  L                  MEMORY_PAGE_BITS levels inside a 64-leaf page
+/// ```
+///
+/// The tracker counts each newly touched leaf once, each newly required
+/// page-local internal node once, and each upper-tree ancestor once across all
+/// pages in the segment.
+#[derive(Clone, Debug)]
+pub(super) struct MemoryPageTracker {
+    page_masks: Box<[u64]>,
+    dirty_pages: Vec<usize>,
+    upper_nodes: BitSet,
+    upper_height: usize,
+}
+
+impl MemoryPageTracker {
+    pub(super) fn new(upper_height: usize) -> Self {
+        let num_pages = 1 << upper_height;
+        Self {
+            page_masks: vec![0; num_pages].into_boxed_slice(),
+            dirty_pages: Vec::new(),
+            upper_nodes: BitSet::new(num_pages),
+            upper_height,
+        }
+    }
+
+    #[inline(always)]
+    pub(super) fn clear(&mut self) {
+        for page_id in self.dirty_pages.drain(..) {
+            // SAFETY: dirty_pages entries are page indices previously written by this tracker.
+            unsafe {
+                *self.page_masks.get_unchecked_mut(page_id) = 0;
+            }
+        }
+        self.upper_nodes.clear();
+    }
+
+    #[inline(always)]
+    pub(super) fn insert(
+        &mut self,
+        page_id: usize,
+        leaf_mask: u64,
+        occupancy_tracker: &MemoryOccupancyTracker,
+    ) -> MemoryHeightDelta {
+        debug_assert!(page_id < self.page_masks.len());
+        debug_assert!(leaf_mask != 0);
+
+        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
+        let old_mask = *page_mask;
+        let new_mask = old_mask | leaf_mask;
+        if new_mask == old_mask {
+            return MemoryHeightDelta::default();
+        }
+
+        *page_mask = new_mask;
+        if old_mask == 0 {
+            self.dirty_pages.push(page_id);
+        }
+
+        let added_mask = leaf_mask & !old_mask;
+        let committed_mask = occupancy_tracker.page_mask(page_id);
+        let default_leaf_mask = added_mask & !committed_mask;
+        let single_added_leaf = added_mask.is_power_of_two();
+        let leaves = if single_added_leaf {
+            1
+        } else {
+            added_mask.count_ones()
+        };
+
+        let (mut merkle_nodes, mut default_old) = if default_leaf_mask == 0 {
+            (
+                if single_added_leaf {
+                    local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros())
+                } else {
+                    local_merkle_nodes_delta(old_mask, added_mask)
+                },
+                DefaultOldCounts::default(),
+            )
+        } else if single_added_leaf {
+            local_merkle_nodes_added_leaf_with_default(
+                old_mask,
+                added_mask.trailing_zeros(),
+                committed_mask,
+            )
+        } else {
+            local_merkle_nodes_delta_with_default(old_mask, added_mask, committed_mask)
+        };
+        if default_leaf_mask != 0 {
+            default_old.leaves = if single_added_leaf {
+                1
+            } else {
+                default_leaf_mask.count_ones()
+            };
+        }
+
+        if old_mask == 0 {
+            if committed_mask == 0 {
+                let (upper_nodes, upper_default_old) =
+                    self.insert_upper_path(page_id, occupancy_tracker);
+                merkle_nodes += upper_nodes;
+                default_old.add(upper_default_old);
+            } else {
+                merkle_nodes += self.insert_upper_path_count_only(page_id);
+            }
+        }
+        MemoryHeightDelta {
+            leaves,
+            merkle_nodes,
+            added_mask,
+            default_old,
+        }
+    }
+
+    #[inline(always)]
+    fn insert_upper_path(
+        &mut self,
+        page_id: usize,
+        occupancy_tracker: &MemoryOccupancyTracker,
+    ) -> (u32, DefaultOldCounts) {
+        let mut count = 0;
+        let mut default_old = DefaultOldCounts::default();
+        let mut node = (1usize << self.upper_height) + page_id;
+        let mut height = MEMORY_PAGE_BITS + 1;
+        while node > 1 {
+            node >>= 1;
+            if self.upper_nodes.insert(node) {
+                count += 1;
+                if !occupancy_tracker.upper_contains(node) {
+                    default_old.merkle_nodes += 1;
+                    default_old.merkle_node_levels |= 1u64 << height;
+                }
+            } else {
+                break;
+            }
+            height += 1;
+        }
+        (count, default_old)
+    }
+
+    #[inline(always)]
+    fn insert_upper_path_count_only(&mut self, page_id: usize) -> u32 {
+        let mut count = 0;
+        let mut node = (1usize << self.upper_height) + page_id;
+        while node > 1 {
+            node >>= 1;
+            if self.upper_nodes.insert(node) {
+                count += 1;
+            } else {
+                break;
+            }
+        }
+        count
+    }
+}
+
+/// Occupancy committed at the last safe checkpoint.
+///
+/// This tracker persists across segment-local replays and is advanced only by
+/// `MemoryCtx::update_checkpoint`. It is seeded from nonzero initial memory, so
+/// pages or ancestors missing here are known canonical default old values.
+#[derive(Clone, Debug)]
+pub(super) struct MemoryOccupancyTracker {
+    page_masks: Box<[u64]>,
+    upper_nodes: BitSet,
+    upper_height: usize,
+}
+
+impl MemoryOccupancyTracker {
+    pub(super) fn new(upper_height: usize) -> Self {
+        let num_pages = 1 << upper_height;
+        Self {
+            page_masks: vec![0; num_pages].into_boxed_slice(),
+            upper_nodes: BitSet::new(num_pages),
+            upper_height,
+        }
+    }
+
+    #[inline(always)]
+    pub(super) fn page_mask(&self, page_id: usize) -> u64 {
+        debug_assert!(page_id < self.page_masks.len());
+        unsafe { *self.page_masks.get_unchecked(page_id) }
+    }
+
+    #[inline(always)]
+    fn upper_contains(&self, node: usize) -> bool {
+        self.upper_nodes.contains(node)
+    }
+
+    #[inline(always)]
+    pub(super) fn mark_existing_page(&mut self, page_id: usize, leaf_mask: u64) {
+        debug_assert!(page_id < self.page_masks.len());
+        debug_assert!(leaf_mask != 0);
+
+        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
+        let old_mask = *page_mask;
+        *page_mask = old_mask | leaf_mask;
+        if old_mask == 0 {
+            self.mark_upper_path(page_id);
+        }
+    }
+
+    #[inline(always)]
+    pub(super) fn commit_page_accesses(&mut self, accesses: &[PageAccess]) {
+        for &access in accesses {
+            self.mark_existing_page(access.page_id as usize, access.leaf_mask);
+        }
+    }
+
+    #[inline(always)]
+    fn mark_upper_path(&mut self, page_id: usize) {
+        let mut node = (1usize << self.upper_height) + page_id;
+        while node > 1 {
+            node >>= 1;
+            if !self.upper_nodes.insert_persistent(node) {
+                break;
+            }
+        }
+    }
+}
+
+#[inline(always)]
+pub(super) fn leaf_mask_range(start: u32, end: u32) -> u64 {
+    debug_assert!(start < end);
+    debug_assert!(end <= 64);
+    let width = end - start;
+    let mask = if width == 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    };
+    mask << start
+}
+
+#[inline(always)]
+fn add_level_delta<const SHIFT: u32, const MASK: u64>(
+    old_mask: &mut u64,
+    added_mask: &mut u64,
+) -> u32 {
+    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
+    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
+    (*added_mask & !*old_mask).count_ones()
+}
+
+#[inline(always)]
+fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
+    debug_assert_ne!(added_mask, 0);
+    debug_assert_eq!(old_mask & added_mask, 0);
+
+    // At each level, collapse child occupancy into one representative bit per
+    // parent group, then count groups reached by added leaves that were empty
+    // in the old segment-local mask.
+    let mut nodes = 0;
+    nodes += add_level_delta::<1, FIRST_BIT_PER_PAIR>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<2, FIRST_BIT_PER_NIBBLE>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<4, FIRST_BIT_PER_BYTE>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<8, FIRST_BIT_PER_U16>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<16, FIRST_BIT_PER_U32>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<32, FIRST_BIT_PER_U64>(&mut old_mask, &mut added_mask);
+
+    nodes
+}
+
+#[inline(always)]
+fn aligned_group_is_empty<const GROUP_SIZE: u32>(old_mask: u64, leaf: u32) -> bool {
+    let group_start = leaf & !(GROUP_SIZE - 1);
+    let group_mask = ((1u64 << GROUP_SIZE) - 1) << group_start;
+    old_mask & group_mask == 0
+}
+
+#[inline(always)]
+fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
+    debug_assert!(leaf < u64::BITS);
+
+    if old_mask == 0 {
+        return MEMORY_PAGE_BITS as u32;
+    }
+
+    // For one new leaf, each aligned group that was empty creates exactly one
+    // new ancestor at that group size.
+    let mut nodes = 0;
+    nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
+    nodes
+}
+
+#[inline(always)]
+fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32>(
+    old_mask: u64,
+    committed_mask: u64,
+    leaf: u32,
+    level: usize,
+    default_old: &mut DefaultOldCounts,
+) -> u32 {
+    if aligned_group_is_empty::<GROUP_SIZE>(old_mask, leaf) {
+        if aligned_group_is_empty::<GROUP_SIZE>(committed_mask, leaf) {
+            default_old.merkle_nodes += 1;
+            default_old.merkle_node_levels |= 1u64 << level;
+        }
+        1
+    } else {
+        0
+    }
+}
+
+#[inline(always)]
+fn local_merkle_nodes_added_leaf_with_default(
+    old_mask: u64,
+    leaf: u32,
+    committed_mask: u64,
+) -> (u32, DefaultOldCounts) {
+    debug_assert!(leaf < u64::BITS);
+
+    if old_mask == 0 && committed_mask == 0 {
+        return (
+            MEMORY_PAGE_BITS as u32,
+            DefaultOldCounts {
+                leaves: 0,
+                merkle_nodes: MEMORY_PAGE_BITS as u32,
+                merkle_node_levels: (1u64 << (MEMORY_PAGE_BITS + 1)) - 2,
+            },
+        );
+    }
+
+    let mut default_old = DefaultOldCounts::default();
+    let mut nodes = 0;
+    nodes +=
+        add_leaf_level_delta_with_default::<2>(old_mask, committed_mask, leaf, 1, &mut default_old);
+    nodes +=
+        add_leaf_level_delta_with_default::<4>(old_mask, committed_mask, leaf, 2, &mut default_old);
+    nodes +=
+        add_leaf_level_delta_with_default::<8>(old_mask, committed_mask, leaf, 3, &mut default_old);
+    nodes += add_leaf_level_delta_with_default::<16>(
+        old_mask,
+        committed_mask,
+        leaf,
+        4,
+        &mut default_old,
+    );
+    nodes += add_leaf_level_delta_with_default::<32>(
+        old_mask,
+        committed_mask,
+        leaf,
+        5,
+        &mut default_old,
+    );
+
+    if old_mask == 0 {
+        nodes += 1;
+        if committed_mask == 0 {
+            default_old.merkle_nodes += 1;
+            default_old.merkle_node_levels |= 1u64 << MEMORY_PAGE_BITS;
+        }
+    }
+
+    (nodes, default_old)
+}
+
+#[inline(always)]
+fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64>(
+    old_mask: &mut u64,
+    added_mask: &mut u64,
+    committed_mask: &mut u64,
+    level: usize,
+    default_old: &mut DefaultOldCounts,
+) -> u32 {
+    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
+    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
+    *committed_mask = (*committed_mask | (*committed_mask >> SHIFT)) & MASK;
+    let new_nodes = *added_mask & !*old_mask;
+    let default_nodes = new_nodes & !*committed_mask;
+    default_old.merkle_nodes += default_nodes.count_ones();
+    default_old.merkle_node_levels |= u64::from(default_nodes != 0) << level;
+    new_nodes.count_ones()
+}
+
+#[inline(always)]
+fn local_merkle_nodes_delta_with_default(
+    mut old_mask: u64,
+    mut added_mask: u64,
+    mut committed_mask: u64,
+) -> (u32, DefaultOldCounts) {
+    debug_assert_ne!(added_mask, 0);
+    debug_assert_eq!(old_mask & added_mask, 0);
+
+    let mut default_old = DefaultOldCounts::default();
+    let mut nodes = 0;
+    nodes += add_level_delta_with_default::<1, FIRST_BIT_PER_PAIR>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        1,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<2, FIRST_BIT_PER_NIBBLE>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        2,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<4, FIRST_BIT_PER_BYTE>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        3,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<8, FIRST_BIT_PER_U16>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        4,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<16, FIRST_BIT_PER_U32>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        5,
+        &mut default_old,
+    );
+    nodes += add_level_delta_with_default::<32, FIRST_BIT_PER_U64>(
+        &mut old_mask,
+        &mut added_mask,
+        &mut committed_mask,
+        6,
+        &mut default_old,
+    );
+
+    (nodes, default_old)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reference_parent_mask(mut mask: u64) -> u64 {
+        let mut parents = 0;
+        while mask != 0 {
+            let bit = mask.trailing_zeros();
+            parents |= 1u64 << (bit >> 1);
+            mask &= mask - 1;
+        }
+        parents
+    }
+
+    fn reference_local_merkle_nodes(mask: u64) -> u32 {
+        let mut nodes = 0;
+        let mut level_mask = mask;
+        for _ in 0..MEMORY_PAGE_BITS {
+            level_mask = reference_parent_mask(level_mask);
+            nodes += level_mask.count_ones();
+        }
+        nodes
+    }
+
+    #[test]
+    fn test_local_merkle_nodes_doc_example() {
+        let mut tracker = MemoryPageTracker::new(0);
+        let occupancy = MemoryOccupancyTracker::new(0);
+        let mut nodes = 0;
+        nodes += tracker.insert(0, 1 << 0, &occupancy).merkle_nodes;
+        assert_eq!(nodes, 6);
+        nodes += tracker.insert(0, 1 << 4, &occupancy).merkle_nodes;
+        assert_eq!(nodes, 8);
+        nodes += tracker.insert(0, 1 << 2, &occupancy).merkle_nodes;
+        assert_eq!(nodes, 9);
+    }
+
+    #[test]
+    fn test_local_merkle_nodes_added_matches_reference_delta() {
+        let mut old_mask = 0u64;
+        let additions = [
+            1u64 << 0,
+            1u64 << 1,
+            1u64 << 4,
+            1u64 << 17,
+            1u64 << 31,
+            1u64 << 32,
+            1u64 << 63,
+            0x5555_0000_0000_0000,
+            0xaaaa_ffff_0000_0000,
+            u64::MAX,
+        ];
+        for leaf_mask in additions {
+            let new_mask = old_mask | leaf_mask;
+            if new_mask != old_mask {
+                let added_mask = new_mask ^ old_mask;
+                let expected =
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
+                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
+                old_mask = new_mask;
+            }
+        }
+
+        old_mask = 1;
+        for leaf_mask in additions {
+            let new_mask = old_mask | leaf_mask;
+            if new_mask != old_mask {
+                let added_mask = new_mask ^ old_mask;
+                let expected =
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
+                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
+                old_mask = new_mask;
+            }
+        }
+
+        let mut seed = 0x9e37_79b9_7f4a_7c15u64;
+        for _ in 0..1024 {
+            seed ^= seed << 7;
+            seed ^= seed >> 9;
+            seed ^= seed << 8;
+            let old_mask = seed;
+            seed ^= seed << 7;
+            seed ^= seed >> 9;
+            seed ^= seed << 8;
+            let new_mask = old_mask | seed;
+            if new_mask != old_mask {
+                let added_mask = new_mask ^ old_mask;
+                assert_eq!(
+                    local_merkle_nodes_delta(old_mask, added_mask),
+                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_page_mask_duplicate_leaf_does_not_change_counts() {
+        let mut tracker = MemoryPageTracker::new(3);
+        let occupancy = MemoryOccupancyTracker::new(3);
+        assert_ne!(tracker.insert(0, 1 << 0, &occupancy).added_mask, 0);
+        assert_eq!(
+            tracker.insert(0, 1 << 0, &occupancy),
+            MemoryHeightDelta::default()
+        );
+    }
+
+    #[test]
+    fn test_memory_page_tracker_clear_resets_touched_state() {
+        let mut tracker = MemoryPageTracker::new(3);
+        let occupancy = MemoryOccupancyTracker::new(3);
+        let first = tracker.insert(0, 1 << 0, &occupancy);
+        let second = tracker.insert(7, 1 << 63, &occupancy);
+        assert!(first.leaves + second.leaves > 0);
+        assert!(first.merkle_nodes + second.merkle_nodes > 0);
+
+        tracker.clear();
+
+        let after_clear = tracker.insert(0, 1 << 0, &occupancy);
+        assert_eq!(after_clear.leaves, 1);
+        assert!(after_clear.merkle_nodes > 0);
+    }
+
+    #[test]
+    fn test_adjacent_pages_share_upper_ancestors() {
+        let mut tracker = MemoryPageTracker::new(3);
+        let occupancy = MemoryOccupancyTracker::new(3);
+        tracker.insert(0, 1, &occupancy);
+        let second = tracker.insert(1, 1, &occupancy);
+        assert_eq!(second.merkle_nodes, MEMORY_PAGE_BITS as u32);
+    }
+
+    #[test]
+    fn test_checkpoint_commit_keeps_occupied_counts() {
+        let mut occupancy = MemoryOccupancyTracker::new(1);
+        let mut tracker = MemoryPageTracker::new(1);
+
+        let first = tracker.insert(0, 1, &occupancy).default_old;
+        occupancy.commit_page_accesses(&[PageAccess {
+            page_id: 0,
+            leaf_mask: 1,
+        }]);
+        tracker.clear();
+        let second = tracker.insert(0, 1, &occupancy).default_old;
+
+        assert!(first.leaves > 0);
+        assert_eq!(second, DefaultOldCounts::default());
+    }
+}

--- a/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
@@ -391,6 +391,12 @@ fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
     // At each level, collapse child occupancy into one representative bit per
     // parent group, then count groups reached by added leaves that were empty
     // in the old segment-local mask.
+    //
+    // ```text
+    // leaves:       0 1   1 0   0 0   1 1
+    // parents:       1     1     0     1
+    // new parents:   (added_parent_bits & !old_parent_bits).count_ones()
+    // ```
     let mut nodes = 0;
     nodes += add_level_delta::<1, FIRST_BIT_PER_PAIR>(&mut old_mask, &mut added_mask);
     nodes += add_level_delta::<2, FIRST_BIT_PER_NIBBLE>(&mut old_mask, &mut added_mask);

--- a/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
@@ -13,8 +13,11 @@ const FIRST_LEAF_PER_64_LEAVES: u64 = 0x0000_0000_0000_0001;
 /// when the current segment started.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct DefaultOldAccounting {
+    /// Newly charged leaves whose old value is the canonical default leaf.
     pub(super) default_leaves: u32,
+    /// Newly charged internal nodes whose old value is a canonical default node.
     pub(super) default_merkle_nodes: u32,
+    /// Bit `h` is set when at least one default old node appears at Merkle height `h`.
     merkle_level_mask: u64,
 }
 
@@ -34,7 +37,9 @@ impl DefaultOldAccounting {
 
 #[derive(Clone, Debug)]
 struct BitSet {
+    /// Packed occupancy bits.
     words: Box<[u64]>,
+    /// Word indices written since the last `clear`.
     dirty_words: Vec<usize>,
 }
 
@@ -118,9 +123,13 @@ pub struct PageAccess {
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct MemoryAccountingDelta {
+    /// Boundary leaves newly charged in the current segment.
     pub(super) new_leaves: u32,
+    /// Merkle internal nodes newly charged in the current segment.
     pub(super) new_merkle_nodes: u32,
+    /// Subset of the inserted leaf mask that became newly charged in this segment.
     pub(super) newly_charged_leaf_mask: u64,
+    /// Old-side default values among the newly charged leaves and nodes.
     pub(super) default_old: DefaultOldAccounting,
 }
 
@@ -149,9 +158,13 @@ pub(super) struct MemoryAccountingDelta {
 /// pages in the segment.
 #[derive(Clone, Debug)]
 pub(super) struct SegmentMemoryPageTracker {
+    /// Segment-local touched leaf masks by page.
     segment_leaf_masks: Box<[u64]>,
+    /// Pages written since the segment started.
     dirty_page_ids: Vec<usize>,
+    /// Upper-tree ancestors already charged in the current segment.
     segment_upper_nodes: BitSet,
+    /// Number of Merkle levels above the 64-leaf page layer.
     upper_height: usize,
 }
 
@@ -309,8 +322,11 @@ impl SegmentMemoryPageTracker {
 /// pages or ancestors missing here are known canonical default old values.
 #[derive(Clone, Debug)]
 pub(super) struct CommittedMemoryOccupancyTracker {
+    /// Leaves known occupied at the last safe checkpoint, stored by page.
     committed_leaf_masks: Box<[u64]>,
+    /// Upper-tree ancestors known occupied at the last safe checkpoint.
     committed_upper_nodes: BitSet,
+    /// Number of Merkle levels above the 64-leaf page layer.
     upper_height: usize,
 }
 

--- a/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
@@ -9,6 +9,16 @@ const FIRST_LEAF_PER_16_LEAVES: u64 = 0x0001_0001_0001_0001;
 const FIRST_LEAF_PER_32_LEAVES: u64 = 0x0000_0001_0000_0001;
 const FIRST_LEAF_PER_64_LEAVES: u64 = 0x0000_0000_0000_0001;
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PageAccess {
+    /// Index into the page table. The leaf occupancy for this page is stored
+    /// in `leaf_mask`.
+    pub page_id: u32,
+    /// Bit `i` is set when leaf `i` inside this 64-leaf page was touched.
+    pub leaf_mask: u64,
+}
+
 /// Old-side leaves and Merkle nodes that were still canonical default values
 /// when the current segment started.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -19,6 +29,76 @@ pub(super) struct DefaultOldAccounting {
     pub(super) default_merkle_nodes: u32,
     /// Bit `h` is set when at least one default old node appears at Merkle height `h`.
     merkle_level_mask: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct MemoryAccountingDelta {
+    /// Boundary leaves newly charged in the current segment.
+    pub(super) new_leaves: u32,
+    /// Merkle internal nodes newly charged in the current segment.
+    pub(super) new_merkle_nodes: u32,
+    /// Subset of the inserted leaf mask that became newly charged in this segment.
+    pub(super) newly_charged_leaf_mask: u64,
+    /// Old-side default values among the newly charged leaves and nodes.
+    pub(super) default_old: DefaultOldAccounting,
+}
+
+#[derive(Clone, Debug)]
+struct BitSet {
+    /// Packed occupancy bits.
+    words: Box<[u64]>,
+    /// Word indices written since the last `clear`.
+    dirty_words: Vec<usize>,
+}
+
+/// Segment-local page accounting.
+///
+/// This tracker is cleared whenever a new segment starts. It answers: "which
+/// leaves and Merkle nodes have already been charged in this segment?"
+/// `CommittedMemoryOccupancyTracker` is passed into `insert` only to classify
+/// old-side nodes as default or non-default.
+///
+/// Memory leaves form one sparse Merkle tree. Each page contains the 64 leaves
+/// represented by one `u64` leaf mask:
+///
+/// ```text
+///        [root]              height h
+///        /    \
+///      ...    ...
+///      /        \
+///   [page]    [page]         h - MEMORY_PAGE_BITS nodes above each page
+///   / .. \
+///  L  ..  L                  MEMORY_PAGE_BITS levels inside a 64-leaf page
+/// ```
+///
+/// The tracker counts each newly touched leaf once, each newly required
+/// page-local internal node once, and each upper-tree ancestor once across all
+/// pages in the segment.
+#[derive(Clone, Debug)]
+pub(super) struct SegmentMemoryPageTracker {
+    /// Segment-local touched leaf masks by page.
+    segment_leaf_masks: Box<[u64]>,
+    /// Pages written since the segment started.
+    dirty_page_ids: Vec<usize>,
+    /// Upper-tree ancestors already charged in the current segment.
+    segment_upper_nodes: BitSet,
+    /// Number of Merkle levels above the 64-leaf page layer.
+    upper_height: usize,
+}
+
+/// Occupancy committed at the last safe checkpoint.
+///
+/// This tracker persists across segment-local replays and is advanced only by
+/// `MemoryCtx::update_checkpoint`. It is seeded from nonzero initial memory, so
+/// pages or ancestors missing here are known canonical default old values.
+#[derive(Clone, Debug)]
+pub(super) struct CommittedMemoryOccupancyTracker {
+    /// Leaves known occupied at the last safe checkpoint, stored by page.
+    committed_leaf_masks: Box<[u64]>,
+    /// Upper-tree ancestors known occupied at the last safe checkpoint.
+    committed_upper_nodes: BitSet,
+    /// Number of Merkle levels above the 64-leaf page layer.
+    upper_height: usize,
 }
 
 impl DefaultOldAccounting {
@@ -33,14 +113,6 @@ impl DefaultOldAccounting {
     pub(super) fn estimated_poseidon_rows(self) -> u32 {
         u32::from(self.default_leaves != 0) + self.merkle_level_mask.count_ones()
     }
-}
-
-#[derive(Clone, Debug)]
-struct BitSet {
-    /// Packed occupancy bits.
-    words: Box<[u64]>,
-    /// Word indices written since the last `clear`.
-    dirty_words: Vec<usize>,
 }
 
 impl BitSet {
@@ -109,63 +181,6 @@ impl BitSet {
             }
         }
     }
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PageAccess {
-    /// Index into the page table. The leaf occupancy for this page is stored
-    /// in `leaf_mask`.
-    pub page_id: u32,
-    /// Bit `i` is set when leaf `i` inside this 64-leaf page was touched.
-    pub leaf_mask: u64,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct MemoryAccountingDelta {
-    /// Boundary leaves newly charged in the current segment.
-    pub(super) new_leaves: u32,
-    /// Merkle internal nodes newly charged in the current segment.
-    pub(super) new_merkle_nodes: u32,
-    /// Subset of the inserted leaf mask that became newly charged in this segment.
-    pub(super) newly_charged_leaf_mask: u64,
-    /// Old-side default values among the newly charged leaves and nodes.
-    pub(super) default_old: DefaultOldAccounting,
-}
-
-/// Segment-local page accounting.
-///
-/// This tracker is cleared whenever a new segment starts. It answers: "which
-/// leaves and Merkle nodes have already been charged in this segment?"
-/// `CommittedMemoryOccupancyTracker` is passed into `insert` only to classify
-/// old-side nodes as default or non-default.
-///
-/// Memory leaves form one sparse Merkle tree. Each page contains the 64 leaves
-/// represented by one `u64` leaf mask:
-///
-/// ```text
-///        [root]              height h
-///        /    \
-///      ...    ...
-///      /        \
-///   [page]    [page]         h - MEMORY_PAGE_BITS nodes above each page
-///   / .. \
-///  L  ..  L                  MEMORY_PAGE_BITS levels inside a 64-leaf page
-/// ```
-///
-/// The tracker counts each newly touched leaf once, each newly required
-/// page-local internal node once, and each upper-tree ancestor once across all
-/// pages in the segment.
-#[derive(Clone, Debug)]
-pub(super) struct SegmentMemoryPageTracker {
-    /// Segment-local touched leaf masks by page.
-    segment_leaf_masks: Box<[u64]>,
-    /// Pages written since the segment started.
-    dirty_page_ids: Vec<usize>,
-    /// Upper-tree ancestors already charged in the current segment.
-    segment_upper_nodes: BitSet,
-    /// Number of Merkle levels above the 64-leaf page layer.
-    upper_height: usize,
 }
 
 impl SegmentMemoryPageTracker {
@@ -313,21 +328,6 @@ impl SegmentMemoryPageTracker {
         }
         count
     }
-}
-
-/// Occupancy committed at the last safe checkpoint.
-///
-/// This tracker persists across segment-local replays and is advanced only by
-/// `MemoryCtx::update_checkpoint`. It is seeded from nonzero initial memory, so
-/// pages or ancestors missing here are known canonical default old values.
-#[derive(Clone, Debug)]
-pub(super) struct CommittedMemoryOccupancyTracker {
-    /// Leaves known occupied at the last safe checkpoint, stored by page.
-    committed_leaf_masks: Box<[u64]>,
-    /// Upper-tree ancestors known occupied at the last safe checkpoint.
-    committed_upper_nodes: BitSet,
-    /// Number of Merkle levels above the 64-leaf page layer.
-    upper_height: usize,
 }
 
 impl CommittedMemoryOccupancyTracker {

--- a/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
@@ -2,33 +2,33 @@ use openvm_instructions::MEMORY_PAGE_BITS;
 
 // Masks with the first bit set in each aligned group of leaves. These represent
 // group occupancy at each page-local Merkle level.
-const FIRST_BIT_PER_PAIR: u64 = 0x5555_5555_5555_5555;
-const FIRST_BIT_PER_NIBBLE: u64 = 0x1111_1111_1111_1111;
-const FIRST_BIT_PER_BYTE: u64 = 0x0101_0101_0101_0101;
-const FIRST_BIT_PER_U16: u64 = 0x0001_0001_0001_0001;
-const FIRST_BIT_PER_U32: u64 = 0x0000_0001_0000_0001;
-const FIRST_BIT_PER_U64: u64 = 0x0000_0000_0000_0001;
+const FIRST_LEAF_PER_2_LEAVES: u64 = 0x5555_5555_5555_5555;
+const FIRST_LEAF_PER_4_LEAVES: u64 = 0x1111_1111_1111_1111;
+const FIRST_LEAF_PER_8_LEAVES: u64 = 0x0101_0101_0101_0101;
+const FIRST_LEAF_PER_16_LEAVES: u64 = 0x0001_0001_0001_0001;
+const FIRST_LEAF_PER_32_LEAVES: u64 = 0x0000_0001_0000_0001;
+const FIRST_LEAF_PER_64_LEAVES: u64 = 0x0000_0000_0000_0001;
 
 /// Old-side leaves and Merkle nodes that were still canonical default values
 /// when the current segment started.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct DefaultOldCounts {
-    pub(super) leaves: u32,
-    pub(super) merkle_nodes: u32,
-    merkle_node_levels: u64,
+pub(super) struct DefaultOldAccounting {
+    pub(super) default_leaves: u32,
+    pub(super) default_merkle_nodes: u32,
+    merkle_level_mask: u64,
 }
 
-impl DefaultOldCounts {
+impl DefaultOldAccounting {
     #[inline(always)]
     pub(super) fn add(&mut self, other: Self) {
-        self.leaves += other.leaves;
-        self.merkle_nodes += other.merkle_nodes;
-        self.merkle_node_levels |= other.merkle_node_levels;
+        self.default_leaves += other.default_leaves;
+        self.default_merkle_nodes += other.default_merkle_nodes;
+        self.merkle_level_mask |= other.merkle_level_mask;
     }
 
     #[inline(always)]
     pub(super) fn estimated_poseidon_rows(self) -> u32 {
-        u32::from(self.leaves != 0) + self.merkle_node_levels.count_ones()
+        u32::from(self.default_leaves != 0) + self.merkle_level_mask.count_ones()
     }
 }
 
@@ -47,14 +47,14 @@ impl BitSet {
     }
 
     #[inline(always)]
-    fn insert(&mut self, index: usize) -> bool {
+    fn insert_clearable(&mut self, index: usize) -> bool {
         // Segment-local sets use dirty-word tracking so `clear` only touches
         // words written in the segment.
         self.insert_impl::<true>(index)
     }
 
     #[inline(always)]
-    fn insert_persistent(&mut self, index: usize) -> bool {
+    fn insert_committed(&mut self, index: usize) -> bool {
         // Committed occupancy is monotonic and persists across checkpoints.
         self.insert_impl::<false>(index)
     }
@@ -117,19 +117,19 @@ pub struct PageAccess {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct MemoryHeightDelta {
-    pub(super) leaves: u32,
-    pub(super) merkle_nodes: u32,
-    pub(super) added_mask: u64,
-    pub(super) default_old: DefaultOldCounts,
+pub(super) struct MemoryAccountingDelta {
+    pub(super) new_leaves: u32,
+    pub(super) new_merkle_nodes: u32,
+    pub(super) newly_charged_leaf_mask: u64,
+    pub(super) default_old: DefaultOldAccounting,
 }
 
 /// Segment-local page accounting.
 ///
 /// This tracker is cleared whenever a new segment starts. It answers: "which
 /// leaves and Merkle nodes have already been charged in this segment?"
-/// `MemoryOccupancyTracker` is passed into `insert` only to classify old-side
-/// nodes as default or non-default.
+/// `CommittedMemoryOccupancyTracker` is passed into `insert` only to classify
+/// old-side nodes as default or non-default.
 ///
 /// Memory leaves form one sparse Merkle tree. Each page contains the 64 leaves
 /// represented by one `u64` leaf mask:
@@ -148,33 +148,33 @@ pub(super) struct MemoryHeightDelta {
 /// page-local internal node once, and each upper-tree ancestor once across all
 /// pages in the segment.
 #[derive(Clone, Debug)]
-pub(super) struct MemoryPageTracker {
-    page_masks: Box<[u64]>,
-    dirty_pages: Vec<usize>,
-    upper_nodes: BitSet,
+pub(super) struct SegmentMemoryPageTracker {
+    segment_leaf_masks: Box<[u64]>,
+    dirty_page_ids: Vec<usize>,
+    segment_upper_nodes: BitSet,
     upper_height: usize,
 }
 
-impl MemoryPageTracker {
+impl SegmentMemoryPageTracker {
     pub(super) fn new(upper_height: usize) -> Self {
         let num_pages = 1 << upper_height;
         Self {
-            page_masks: vec![0; num_pages].into_boxed_slice(),
-            dirty_pages: Vec::new(),
-            upper_nodes: BitSet::new(num_pages),
+            segment_leaf_masks: vec![0; num_pages].into_boxed_slice(),
+            dirty_page_ids: Vec::new(),
+            segment_upper_nodes: BitSet::new(num_pages),
             upper_height,
         }
     }
 
     #[inline(always)]
     pub(super) fn clear(&mut self) {
-        for page_id in self.dirty_pages.drain(..) {
-            // SAFETY: dirty_pages entries are page indices previously written by this tracker.
+        for page_id in self.dirty_page_ids.drain(..) {
+            // SAFETY: dirty_page_ids entries are page indices previously written by this tracker.
             unsafe {
-                *self.page_masks.get_unchecked_mut(page_id) = 0;
+                *self.segment_leaf_masks.get_unchecked_mut(page_id) = 0;
             }
         }
-        self.upper_nodes.clear();
+        self.segment_upper_nodes.clear();
     }
 
     #[inline(always)]
@@ -182,94 +182,101 @@ impl MemoryPageTracker {
         &mut self,
         page_id: usize,
         leaf_mask: u64,
-        occupancy_tracker: &MemoryOccupancyTracker,
-    ) -> MemoryHeightDelta {
-        debug_assert!(page_id < self.page_masks.len());
+        occupancy_tracker: &CommittedMemoryOccupancyTracker,
+    ) -> MemoryAccountingDelta {
+        debug_assert!(page_id < self.segment_leaf_masks.len());
         debug_assert!(leaf_mask != 0);
 
-        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
-        let old_mask = *page_mask;
-        let new_mask = old_mask | leaf_mask;
-        if new_mask == old_mask {
-            return MemoryHeightDelta::default();
+        let segment_leaf_mask = unsafe { self.segment_leaf_masks.get_unchecked_mut(page_id) };
+        let segment_leaf_mask_before = *segment_leaf_mask;
+        let segment_leaf_mask_after = segment_leaf_mask_before | leaf_mask;
+        if segment_leaf_mask_after == segment_leaf_mask_before {
+            return MemoryAccountingDelta::default();
         }
 
-        *page_mask = new_mask;
-        if old_mask == 0 {
-            self.dirty_pages.push(page_id);
+        *segment_leaf_mask = segment_leaf_mask_after;
+        if segment_leaf_mask_before == 0 {
+            self.dirty_page_ids.push(page_id);
         }
 
-        let added_mask = leaf_mask & !old_mask;
-        let committed_mask = occupancy_tracker.page_mask(page_id);
-        let default_leaf_mask = added_mask & !committed_mask;
-        let single_added_leaf = added_mask.is_power_of_two();
-        let leaves = if single_added_leaf {
+        let newly_charged_leaf_mask = leaf_mask & !segment_leaf_mask_before;
+        let committed_leaf_mask = occupancy_tracker.page_mask(page_id);
+        let default_old_leaf_mask = newly_charged_leaf_mask & !committed_leaf_mask;
+        let single_added_leaf = newly_charged_leaf_mask.is_power_of_two();
+        let new_leaves = if single_added_leaf {
             1
         } else {
-            added_mask.count_ones()
+            newly_charged_leaf_mask.count_ones()
         };
 
-        let (mut merkle_nodes, mut default_old) = if default_leaf_mask == 0 {
+        let (mut new_merkle_nodes, mut default_old) = if default_old_leaf_mask == 0 {
             (
                 if single_added_leaf {
-                    local_merkle_nodes_added_leaf(old_mask, added_mask.trailing_zeros())
+                    local_merkle_nodes_added_leaf(
+                        segment_leaf_mask_before,
+                        newly_charged_leaf_mask.trailing_zeros(),
+                    )
                 } else {
-                    local_merkle_nodes_delta(old_mask, added_mask)
+                    local_merkle_nodes_delta(segment_leaf_mask_before, newly_charged_leaf_mask)
                 },
-                DefaultOldCounts::default(),
+                DefaultOldAccounting::default(),
             )
         } else if single_added_leaf {
             local_merkle_nodes_added_leaf_with_default(
-                old_mask,
-                added_mask.trailing_zeros(),
-                committed_mask,
+                segment_leaf_mask_before,
+                newly_charged_leaf_mask.trailing_zeros(),
+                committed_leaf_mask,
             )
         } else {
-            local_merkle_nodes_delta_with_default(old_mask, added_mask, committed_mask)
+            local_merkle_nodes_delta_with_default(
+                segment_leaf_mask_before,
+                newly_charged_leaf_mask,
+                committed_leaf_mask,
+            )
         };
-        if default_leaf_mask != 0 {
-            default_old.leaves = if single_added_leaf {
+        if default_old_leaf_mask != 0 {
+            default_old.default_leaves = if single_added_leaf {
                 1
             } else {
-                default_leaf_mask.count_ones()
+                default_old_leaf_mask.count_ones()
             };
         }
 
-        if old_mask == 0 {
-            if committed_mask == 0 {
+        if segment_leaf_mask_before == 0 {
+            if committed_leaf_mask == 0 {
                 let (upper_nodes, upper_default_old) =
-                    self.insert_upper_path(page_id, occupancy_tracker);
-                merkle_nodes += upper_nodes;
+                    self.insert_upper_path_with_default_old(page_id, occupancy_tracker);
+                new_merkle_nodes += upper_nodes;
                 default_old.add(upper_default_old);
             } else {
-                merkle_nodes += self.insert_upper_path_count_only(page_id);
+                new_merkle_nodes += self.insert_upper_path_without_default_old(page_id);
             }
         }
-        MemoryHeightDelta {
-            leaves,
-            merkle_nodes,
-            added_mask,
+        MemoryAccountingDelta {
+            new_leaves,
+            new_merkle_nodes,
+            newly_charged_leaf_mask,
             default_old,
         }
     }
 
     #[inline(always)]
-    fn insert_upper_path(
+    fn insert_upper_path_with_default_old(
         &mut self,
         page_id: usize,
-        occupancy_tracker: &MemoryOccupancyTracker,
-    ) -> (u32, DefaultOldCounts) {
+        occupancy_tracker: &CommittedMemoryOccupancyTracker,
+    ) -> (u32, DefaultOldAccounting) {
         let mut count = 0;
-        let mut default_old = DefaultOldCounts::default();
+        let mut default_old = DefaultOldAccounting::default();
         let mut node = (1usize << self.upper_height) + page_id;
         let mut height = MEMORY_PAGE_BITS + 1;
         while node > 1 {
             node >>= 1;
-            if self.upper_nodes.insert(node) {
+            if self.segment_upper_nodes.insert_clearable(node) {
                 count += 1;
                 if !occupancy_tracker.upper_contains(node) {
-                    default_old.merkle_nodes += 1;
-                    default_old.merkle_node_levels |= 1u64 << height;
+                    default_old.default_merkle_nodes += 1;
+                    default_old.merkle_level_mask |= 1u64 << height;
                 }
             } else {
                 break;
@@ -280,12 +287,12 @@ impl MemoryPageTracker {
     }
 
     #[inline(always)]
-    fn insert_upper_path_count_only(&mut self, page_id: usize) -> u32 {
+    fn insert_upper_path_without_default_old(&mut self, page_id: usize) -> u32 {
         let mut count = 0;
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
             node >>= 1;
-            if self.upper_nodes.insert(node) {
+            if self.segment_upper_nodes.insert_clearable(node) {
                 count += 1;
             } else {
                 break;
@@ -301,42 +308,42 @@ impl MemoryPageTracker {
 /// `MemoryCtx::update_checkpoint`. It is seeded from nonzero initial memory, so
 /// pages or ancestors missing here are known canonical default old values.
 #[derive(Clone, Debug)]
-pub(super) struct MemoryOccupancyTracker {
-    page_masks: Box<[u64]>,
-    upper_nodes: BitSet,
+pub(super) struct CommittedMemoryOccupancyTracker {
+    committed_leaf_masks: Box<[u64]>,
+    committed_upper_nodes: BitSet,
     upper_height: usize,
 }
 
-impl MemoryOccupancyTracker {
+impl CommittedMemoryOccupancyTracker {
     pub(super) fn new(upper_height: usize) -> Self {
         let num_pages = 1 << upper_height;
         Self {
-            page_masks: vec![0; num_pages].into_boxed_slice(),
-            upper_nodes: BitSet::new(num_pages),
+            committed_leaf_masks: vec![0; num_pages].into_boxed_slice(),
+            committed_upper_nodes: BitSet::new(num_pages),
             upper_height,
         }
     }
 
     #[inline(always)]
     pub(super) fn page_mask(&self, page_id: usize) -> u64 {
-        debug_assert!(page_id < self.page_masks.len());
-        unsafe { *self.page_masks.get_unchecked(page_id) }
+        debug_assert!(page_id < self.committed_leaf_masks.len());
+        unsafe { *self.committed_leaf_masks.get_unchecked(page_id) }
     }
 
     #[inline(always)]
     fn upper_contains(&self, node: usize) -> bool {
-        self.upper_nodes.contains(node)
+        self.committed_upper_nodes.contains(node)
     }
 
     #[inline(always)]
     pub(super) fn mark_existing_page(&mut self, page_id: usize, leaf_mask: u64) {
-        debug_assert!(page_id < self.page_masks.len());
+        debug_assert!(page_id < self.committed_leaf_masks.len());
         debug_assert!(leaf_mask != 0);
 
-        let page_mask = unsafe { self.page_masks.get_unchecked_mut(page_id) };
-        let old_mask = *page_mask;
-        *page_mask = old_mask | leaf_mask;
-        if old_mask == 0 {
+        let committed_leaf_mask = unsafe { self.committed_leaf_masks.get_unchecked_mut(page_id) };
+        let committed_leaf_mask_before = *committed_leaf_mask;
+        *committed_leaf_mask = committed_leaf_mask_before | leaf_mask;
+        if committed_leaf_mask_before == 0 {
             self.mark_upper_path(page_id);
         }
     }
@@ -353,7 +360,7 @@ impl MemoryOccupancyTracker {
         let mut node = (1usize << self.upper_height) + page_id;
         while node > 1 {
             node >>= 1;
-            if !self.upper_nodes.insert_persistent(node) {
+            if !self.committed_upper_nodes.insert_committed(node) {
                 break;
             }
         }
@@ -375,18 +382,18 @@ pub(super) fn leaf_mask_range(start: u32, end: u32) -> u64 {
 
 #[inline(always)]
 fn add_level_delta<const SHIFT: u32, const MASK: u64>(
-    old_mask: &mut u64,
-    added_mask: &mut u64,
+    segment_mask: &mut u64,
+    newly_charged_mask: &mut u64,
 ) -> u32 {
-    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
-    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
-    (*added_mask & !*old_mask).count_ones()
+    *segment_mask = (*segment_mask | (*segment_mask >> SHIFT)) & MASK;
+    *newly_charged_mask = (*newly_charged_mask | (*newly_charged_mask >> SHIFT)) & MASK;
+    (*newly_charged_mask & !*segment_mask).count_ones()
 }
 
 #[inline(always)]
-fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
-    debug_assert_ne!(added_mask, 0);
-    debug_assert_eq!(old_mask & added_mask, 0);
+fn local_merkle_nodes_delta(mut segment_leaf_mask: u64, mut newly_charged_leaf_mask: u64) -> u32 {
+    debug_assert_ne!(newly_charged_leaf_mask, 0);
+    debug_assert_eq!(segment_leaf_mask & newly_charged_leaf_mask, 0);
 
     // At each level, collapse child occupancy into one representative bit per
     // parent group, then count groups reached by added leaves that were empty
@@ -398,53 +405,71 @@ fn local_merkle_nodes_delta(mut old_mask: u64, mut added_mask: u64) -> u32 {
     // new parents:   (added_parent_bits & !old_parent_bits).count_ones()
     // ```
     let mut nodes = 0;
-    nodes += add_level_delta::<1, FIRST_BIT_PER_PAIR>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<2, FIRST_BIT_PER_NIBBLE>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<4, FIRST_BIT_PER_BYTE>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<8, FIRST_BIT_PER_U16>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<16, FIRST_BIT_PER_U32>(&mut old_mask, &mut added_mask);
-    nodes += add_level_delta::<32, FIRST_BIT_PER_U64>(&mut old_mask, &mut added_mask);
+    nodes += add_level_delta::<1, FIRST_LEAF_PER_2_LEAVES>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+    );
+    nodes += add_level_delta::<2, FIRST_LEAF_PER_4_LEAVES>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+    );
+    nodes += add_level_delta::<4, FIRST_LEAF_PER_8_LEAVES>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+    );
+    nodes += add_level_delta::<8, FIRST_LEAF_PER_16_LEAVES>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+    );
+    nodes += add_level_delta::<16, FIRST_LEAF_PER_32_LEAVES>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+    );
+    nodes += add_level_delta::<32, FIRST_LEAF_PER_64_LEAVES>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+    );
 
     nodes
 }
 
 #[inline(always)]
-fn aligned_group_is_empty<const GROUP_SIZE: u32>(old_mask: u64, leaf: u32) -> bool {
+fn aligned_group_is_empty<const GROUP_SIZE: u32>(leaf_mask: u64, leaf: u32) -> bool {
     let group_start = leaf & !(GROUP_SIZE - 1);
     let group_mask = ((1u64 << GROUP_SIZE) - 1) << group_start;
-    old_mask & group_mask == 0
+    leaf_mask & group_mask == 0
 }
 
 #[inline(always)]
-fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
+fn local_merkle_nodes_added_leaf(segment_leaf_mask: u64, leaf: u32) -> u32 {
     debug_assert!(leaf < u64::BITS);
 
-    if old_mask == 0 {
+    if segment_leaf_mask == 0 {
         return MEMORY_PAGE_BITS as u32;
     }
 
     // For one new leaf, each aligned group that was empty creates exactly one
     // new ancestor at that group size.
     let mut nodes = 0;
-    nodes += u32::from(aligned_group_is_empty::<2>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<4>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<8>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<16>(old_mask, leaf));
-    nodes += u32::from(aligned_group_is_empty::<32>(old_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<2>(segment_leaf_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<4>(segment_leaf_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<8>(segment_leaf_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<16>(segment_leaf_mask, leaf));
+    nodes += u32::from(aligned_group_is_empty::<32>(segment_leaf_mask, leaf));
     nodes
 }
 
 #[inline(always)]
 fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32, const LEVEL: usize>(
-    old_mask: u64,
-    committed_mask: u64,
+    segment_leaf_mask: u64,
+    committed_leaf_mask: u64,
     leaf: u32,
-    default_old: &mut DefaultOldCounts,
+    default_old: &mut DefaultOldAccounting,
 ) -> u32 {
-    if aligned_group_is_empty::<GROUP_SIZE>(old_mask, leaf) {
-        if aligned_group_is_empty::<GROUP_SIZE>(committed_mask, leaf) {
-            default_old.merkle_nodes += 1;
-            default_old.merkle_node_levels |= 1u64 << LEVEL;
+    if aligned_group_is_empty::<GROUP_SIZE>(segment_leaf_mask, leaf) {
+        if aligned_group_is_empty::<GROUP_SIZE>(committed_leaf_mask, leaf) {
+            default_old.default_merkle_nodes += 1;
+            default_old.merkle_level_mask |= 1u64 << LEVEL;
         }
         1
     } else {
@@ -454,49 +479,61 @@ fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32, const LEVEL: usize>(
 
 #[inline(always)]
 fn local_merkle_nodes_added_leaf_with_default(
-    old_mask: u64,
+    segment_leaf_mask: u64,
     leaf: u32,
-    committed_mask: u64,
-) -> (u32, DefaultOldCounts) {
+    committed_leaf_mask: u64,
+) -> (u32, DefaultOldAccounting) {
     debug_assert!(leaf < u64::BITS);
 
-    if old_mask == 0 && committed_mask == 0 {
+    if segment_leaf_mask == 0 && committed_leaf_mask == 0 {
         return (
             MEMORY_PAGE_BITS as u32,
-            DefaultOldCounts {
-                leaves: 0,
-                merkle_nodes: MEMORY_PAGE_BITS as u32,
-                merkle_node_levels: (1u64 << (MEMORY_PAGE_BITS + 1)) - 2,
+            DefaultOldAccounting {
+                default_leaves: 0,
+                default_merkle_nodes: MEMORY_PAGE_BITS as u32,
+                merkle_level_mask: (1u64 << (MEMORY_PAGE_BITS + 1)) - 2,
             },
         );
     }
 
-    let mut default_old = DefaultOldCounts::default();
+    let mut default_old = DefaultOldAccounting::default();
     let mut nodes = 0;
-    nodes +=
-        add_leaf_level_delta_with_default::<2, 1>(old_mask, committed_mask, leaf, &mut default_old);
-    nodes +=
-        add_leaf_level_delta_with_default::<4, 2>(old_mask, committed_mask, leaf, &mut default_old);
-    nodes +=
-        add_leaf_level_delta_with_default::<8, 3>(old_mask, committed_mask, leaf, &mut default_old);
+    nodes += add_leaf_level_delta_with_default::<2, 1>(
+        segment_leaf_mask,
+        committed_leaf_mask,
+        leaf,
+        &mut default_old,
+    );
+    nodes += add_leaf_level_delta_with_default::<4, 2>(
+        segment_leaf_mask,
+        committed_leaf_mask,
+        leaf,
+        &mut default_old,
+    );
+    nodes += add_leaf_level_delta_with_default::<8, 3>(
+        segment_leaf_mask,
+        committed_leaf_mask,
+        leaf,
+        &mut default_old,
+    );
     nodes += add_leaf_level_delta_with_default::<16, 4>(
-        old_mask,
-        committed_mask,
+        segment_leaf_mask,
+        committed_leaf_mask,
         leaf,
         &mut default_old,
     );
     nodes += add_leaf_level_delta_with_default::<32, 5>(
-        old_mask,
-        committed_mask,
+        segment_leaf_mask,
+        committed_leaf_mask,
         leaf,
         &mut default_old,
     );
 
-    if old_mask == 0 {
+    if segment_leaf_mask == 0 {
         nodes += 1;
-        if committed_mask == 0 {
-            default_old.merkle_nodes += 1;
-            default_old.merkle_node_levels |= 1u64 << MEMORY_PAGE_BITS;
+        if committed_leaf_mask == 0 {
+            default_old.default_merkle_nodes += 1;
+            default_old.merkle_level_mask |= 1u64 << MEMORY_PAGE_BITS;
         }
     }
 
@@ -505,66 +542,66 @@ fn local_merkle_nodes_added_leaf_with_default(
 
 #[inline(always)]
 fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64, const LEVEL: usize>(
-    old_mask: &mut u64,
-    added_mask: &mut u64,
-    committed_mask: &mut u64,
-    default_old: &mut DefaultOldCounts,
+    segment_mask: &mut u64,
+    newly_charged_mask: &mut u64,
+    committed_level_mask: &mut u64,
+    default_old: &mut DefaultOldAccounting,
 ) -> u32 {
-    *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
-    *added_mask = (*added_mask | (*added_mask >> SHIFT)) & MASK;
-    *committed_mask = (*committed_mask | (*committed_mask >> SHIFT)) & MASK;
-    let new_nodes = *added_mask & !*old_mask;
-    let default_nodes = new_nodes & !*committed_mask;
-    default_old.merkle_nodes += default_nodes.count_ones();
-    default_old.merkle_node_levels |= u64::from(default_nodes != 0) << LEVEL;
+    *segment_mask = (*segment_mask | (*segment_mask >> SHIFT)) & MASK;
+    *newly_charged_mask = (*newly_charged_mask | (*newly_charged_mask >> SHIFT)) & MASK;
+    *committed_level_mask = (*committed_level_mask | (*committed_level_mask >> SHIFT)) & MASK;
+    let new_nodes = *newly_charged_mask & !*segment_mask;
+    let default_nodes = new_nodes & !*committed_level_mask;
+    default_old.default_merkle_nodes += default_nodes.count_ones();
+    default_old.merkle_level_mask |= u64::from(default_nodes != 0) << LEVEL;
     new_nodes.count_ones()
 }
 
 #[inline(always)]
 fn local_merkle_nodes_delta_with_default(
-    mut old_mask: u64,
-    mut added_mask: u64,
-    mut committed_mask: u64,
-) -> (u32, DefaultOldCounts) {
-    debug_assert_ne!(added_mask, 0);
-    debug_assert_eq!(old_mask & added_mask, 0);
+    mut segment_leaf_mask: u64,
+    mut newly_charged_leaf_mask: u64,
+    mut committed_leaf_mask: u64,
+) -> (u32, DefaultOldAccounting) {
+    debug_assert_ne!(newly_charged_leaf_mask, 0);
+    debug_assert_eq!(segment_leaf_mask & newly_charged_leaf_mask, 0);
 
-    let mut default_old = DefaultOldCounts::default();
+    let mut default_old = DefaultOldAccounting::default();
     let mut nodes = 0;
-    nodes += add_level_delta_with_default::<1, FIRST_BIT_PER_PAIR, 1>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
+    nodes += add_level_delta_with_default::<1, FIRST_LEAF_PER_2_LEAVES, 1>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+        &mut committed_leaf_mask,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<2, FIRST_BIT_PER_NIBBLE, 2>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
+    nodes += add_level_delta_with_default::<2, FIRST_LEAF_PER_4_LEAVES, 2>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+        &mut committed_leaf_mask,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<4, FIRST_BIT_PER_BYTE, 3>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
+    nodes += add_level_delta_with_default::<4, FIRST_LEAF_PER_8_LEAVES, 3>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+        &mut committed_leaf_mask,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<8, FIRST_BIT_PER_U16, 4>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
+    nodes += add_level_delta_with_default::<8, FIRST_LEAF_PER_16_LEAVES, 4>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+        &mut committed_leaf_mask,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<16, FIRST_BIT_PER_U32, 5>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
+    nodes += add_level_delta_with_default::<16, FIRST_LEAF_PER_32_LEAVES, 5>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+        &mut committed_leaf_mask,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<32, FIRST_BIT_PER_U64, 6>(
-        &mut old_mask,
-        &mut added_mask,
-        &mut committed_mask,
+    nodes += add_level_delta_with_default::<32, FIRST_LEAF_PER_64_LEAVES, 6>(
+        &mut segment_leaf_mask,
+        &mut newly_charged_leaf_mask,
+        &mut committed_leaf_mask,
         &mut default_old,
     );
 
@@ -597,20 +634,26 @@ mod tests {
 
     #[test]
     fn test_local_merkle_nodes_doc_example() {
-        let mut tracker = MemoryPageTracker::new(0);
-        let occupancy = MemoryOccupancyTracker::new(0);
+        let mut tracker = SegmentMemoryPageTracker::new(0);
+        let committed_occupancy = CommittedMemoryOccupancyTracker::new(0);
         let mut nodes = 0;
-        nodes += tracker.insert(0, 1 << 0, &occupancy).merkle_nodes;
+        nodes += tracker
+            .insert(0, 1 << 0, &committed_occupancy)
+            .new_merkle_nodes;
         assert_eq!(nodes, 6);
-        nodes += tracker.insert(0, 1 << 4, &occupancy).merkle_nodes;
+        nodes += tracker
+            .insert(0, 1 << 4, &committed_occupancy)
+            .new_merkle_nodes;
         assert_eq!(nodes, 8);
-        nodes += tracker.insert(0, 1 << 2, &occupancy).merkle_nodes;
+        nodes += tracker
+            .insert(0, 1 << 2, &committed_occupancy)
+            .new_merkle_nodes;
         assert_eq!(nodes, 9);
     }
 
     #[test]
     fn test_local_merkle_nodes_added_matches_reference_delta() {
-        let mut old_mask = 0u64;
+        let mut segment_leaf_mask = 0u64;
         let additions = [
             1u64 << 0,
             1u64 << 1,
@@ -624,25 +667,31 @@ mod tests {
             u64::MAX,
         ];
         for leaf_mask in additions {
-            let new_mask = old_mask | leaf_mask;
-            if new_mask != old_mask {
-                let added_mask = new_mask ^ old_mask;
-                let expected =
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
-                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
-                old_mask = new_mask;
+            let segment_leaf_mask_after = segment_leaf_mask | leaf_mask;
+            if segment_leaf_mask_after != segment_leaf_mask {
+                let newly_charged_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
+                let expected = reference_local_merkle_nodes(segment_leaf_mask_after)
+                    - reference_local_merkle_nodes(segment_leaf_mask);
+                assert_eq!(
+                    local_merkle_nodes_delta(segment_leaf_mask, newly_charged_leaf_mask),
+                    expected
+                );
+                segment_leaf_mask = segment_leaf_mask_after;
             }
         }
 
-        old_mask = 1;
+        segment_leaf_mask = 1;
         for leaf_mask in additions {
-            let new_mask = old_mask | leaf_mask;
-            if new_mask != old_mask {
-                let added_mask = new_mask ^ old_mask;
-                let expected =
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask);
-                assert_eq!(local_merkle_nodes_delta(old_mask, added_mask), expected);
-                old_mask = new_mask;
+            let segment_leaf_mask_after = segment_leaf_mask | leaf_mask;
+            if segment_leaf_mask_after != segment_leaf_mask {
+                let newly_charged_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
+                let expected = reference_local_merkle_nodes(segment_leaf_mask_after)
+                    - reference_local_merkle_nodes(segment_leaf_mask);
+                assert_eq!(
+                    local_merkle_nodes_delta(segment_leaf_mask, newly_charged_leaf_mask),
+                    expected
+                );
+                segment_leaf_mask = segment_leaf_mask_after;
             }
         }
 
@@ -651,16 +700,17 @@ mod tests {
             seed ^= seed << 7;
             seed ^= seed >> 9;
             seed ^= seed << 8;
-            let old_mask = seed;
+            let segment_leaf_mask = seed;
             seed ^= seed << 7;
             seed ^= seed >> 9;
             seed ^= seed << 8;
-            let new_mask = old_mask | seed;
-            if new_mask != old_mask {
-                let added_mask = new_mask ^ old_mask;
+            let segment_leaf_mask_after = segment_leaf_mask | seed;
+            if segment_leaf_mask_after != segment_leaf_mask {
+                let newly_charged_leaf_mask = segment_leaf_mask_after ^ segment_leaf_mask;
                 assert_eq!(
-                    local_merkle_nodes_delta(old_mask, added_mask),
-                    reference_local_merkle_nodes(new_mask) - reference_local_merkle_nodes(old_mask)
+                    local_merkle_nodes_delta(segment_leaf_mask, newly_charged_leaf_mask),
+                    reference_local_merkle_nodes(segment_leaf_mask_after)
+                        - reference_local_merkle_nodes(segment_leaf_mask)
                 );
             }
         }
@@ -668,54 +718,59 @@ mod tests {
 
     #[test]
     fn test_page_mask_duplicate_leaf_does_not_change_counts() {
-        let mut tracker = MemoryPageTracker::new(3);
-        let occupancy = MemoryOccupancyTracker::new(3);
-        assert_ne!(tracker.insert(0, 1 << 0, &occupancy).added_mask, 0);
+        let mut tracker = SegmentMemoryPageTracker::new(3);
+        let committed_occupancy = CommittedMemoryOccupancyTracker::new(3);
+        assert_ne!(
+            tracker
+                .insert(0, 1 << 0, &committed_occupancy)
+                .newly_charged_leaf_mask,
+            0
+        );
         assert_eq!(
-            tracker.insert(0, 1 << 0, &occupancy),
-            MemoryHeightDelta::default()
+            tracker.insert(0, 1 << 0, &committed_occupancy),
+            MemoryAccountingDelta::default()
         );
     }
 
     #[test]
     fn test_memory_page_tracker_clear_resets_touched_state() {
-        let mut tracker = MemoryPageTracker::new(3);
-        let occupancy = MemoryOccupancyTracker::new(3);
-        let first = tracker.insert(0, 1 << 0, &occupancy);
-        let second = tracker.insert(7, 1 << 63, &occupancy);
-        assert!(first.leaves + second.leaves > 0);
-        assert!(first.merkle_nodes + second.merkle_nodes > 0);
+        let mut tracker = SegmentMemoryPageTracker::new(3);
+        let committed_occupancy = CommittedMemoryOccupancyTracker::new(3);
+        let first = tracker.insert(0, 1 << 0, &committed_occupancy);
+        let second = tracker.insert(7, 1 << 63, &committed_occupancy);
+        assert!(first.new_leaves + second.new_leaves > 0);
+        assert!(first.new_merkle_nodes + second.new_merkle_nodes > 0);
 
         tracker.clear();
 
-        let after_clear = tracker.insert(0, 1 << 0, &occupancy);
-        assert_eq!(after_clear.leaves, 1);
-        assert!(after_clear.merkle_nodes > 0);
+        let after_clear = tracker.insert(0, 1 << 0, &committed_occupancy);
+        assert_eq!(after_clear.new_leaves, 1);
+        assert!(after_clear.new_merkle_nodes > 0);
     }
 
     #[test]
     fn test_adjacent_pages_share_upper_ancestors() {
-        let mut tracker = MemoryPageTracker::new(3);
-        let occupancy = MemoryOccupancyTracker::new(3);
-        tracker.insert(0, 1, &occupancy);
-        let second = tracker.insert(1, 1, &occupancy);
-        assert_eq!(second.merkle_nodes, MEMORY_PAGE_BITS as u32);
+        let mut tracker = SegmentMemoryPageTracker::new(3);
+        let committed_occupancy = CommittedMemoryOccupancyTracker::new(3);
+        tracker.insert(0, 1, &committed_occupancy);
+        let second = tracker.insert(1, 1, &committed_occupancy);
+        assert_eq!(second.new_merkle_nodes, MEMORY_PAGE_BITS as u32);
     }
 
     #[test]
     fn test_checkpoint_commit_keeps_occupied_counts() {
-        let mut occupancy = MemoryOccupancyTracker::new(1);
-        let mut tracker = MemoryPageTracker::new(1);
+        let mut committed_occupancy = CommittedMemoryOccupancyTracker::new(1);
+        let mut tracker = SegmentMemoryPageTracker::new(1);
 
-        let first = tracker.insert(0, 1, &occupancy).default_old;
-        occupancy.commit_page_accesses(&[PageAccess {
+        let first = tracker.insert(0, 1, &committed_occupancy).default_old;
+        committed_occupancy.commit_page_accesses(&[PageAccess {
             page_id: 0,
             leaf_mask: 1,
         }]);
         tracker.clear();
-        let second = tracker.insert(0, 1, &occupancy).default_old;
+        let second = tracker.insert(0, 1, &committed_occupancy).default_old;
 
-        assert!(first.leaves > 0);
-        assert_eq!(second, DefaultOldCounts::default());
+        assert!(first.default_leaves > 0);
+        assert_eq!(second, DefaultOldAccounting::default());
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/page_tracker.rs
@@ -435,17 +435,16 @@ fn local_merkle_nodes_added_leaf(old_mask: u64, leaf: u32) -> u32 {
 }
 
 #[inline(always)]
-fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32>(
+fn add_leaf_level_delta_with_default<const GROUP_SIZE: u32, const LEVEL: usize>(
     old_mask: u64,
     committed_mask: u64,
     leaf: u32,
-    level: usize,
     default_old: &mut DefaultOldCounts,
 ) -> u32 {
     if aligned_group_is_empty::<GROUP_SIZE>(old_mask, leaf) {
         if aligned_group_is_empty::<GROUP_SIZE>(committed_mask, leaf) {
             default_old.merkle_nodes += 1;
-            default_old.merkle_node_levels |= 1u64 << level;
+            default_old.merkle_node_levels |= 1u64 << LEVEL;
         }
         1
     } else {
@@ -475,23 +474,21 @@ fn local_merkle_nodes_added_leaf_with_default(
     let mut default_old = DefaultOldCounts::default();
     let mut nodes = 0;
     nodes +=
-        add_leaf_level_delta_with_default::<2>(old_mask, committed_mask, leaf, 1, &mut default_old);
+        add_leaf_level_delta_with_default::<2, 1>(old_mask, committed_mask, leaf, &mut default_old);
     nodes +=
-        add_leaf_level_delta_with_default::<4>(old_mask, committed_mask, leaf, 2, &mut default_old);
+        add_leaf_level_delta_with_default::<4, 2>(old_mask, committed_mask, leaf, &mut default_old);
     nodes +=
-        add_leaf_level_delta_with_default::<8>(old_mask, committed_mask, leaf, 3, &mut default_old);
-    nodes += add_leaf_level_delta_with_default::<16>(
+        add_leaf_level_delta_with_default::<8, 3>(old_mask, committed_mask, leaf, &mut default_old);
+    nodes += add_leaf_level_delta_with_default::<16, 4>(
         old_mask,
         committed_mask,
         leaf,
-        4,
         &mut default_old,
     );
-    nodes += add_leaf_level_delta_with_default::<32>(
+    nodes += add_leaf_level_delta_with_default::<32, 5>(
         old_mask,
         committed_mask,
         leaf,
-        5,
         &mut default_old,
     );
 
@@ -507,11 +504,10 @@ fn local_merkle_nodes_added_leaf_with_default(
 }
 
 #[inline(always)]
-fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64>(
+fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64, const LEVEL: usize>(
     old_mask: &mut u64,
     added_mask: &mut u64,
     committed_mask: &mut u64,
-    level: usize,
     default_old: &mut DefaultOldCounts,
 ) -> u32 {
     *old_mask = (*old_mask | (*old_mask >> SHIFT)) & MASK;
@@ -520,7 +516,7 @@ fn add_level_delta_with_default<const SHIFT: u32, const MASK: u64>(
     let new_nodes = *added_mask & !*old_mask;
     let default_nodes = new_nodes & !*committed_mask;
     default_old.merkle_nodes += default_nodes.count_ones();
-    default_old.merkle_node_levels |= u64::from(default_nodes != 0) << level;
+    default_old.merkle_node_levels |= u64::from(default_nodes != 0) << LEVEL;
     new_nodes.count_ones()
 }
 
@@ -535,46 +531,40 @@ fn local_merkle_nodes_delta_with_default(
 
     let mut default_old = DefaultOldCounts::default();
     let mut nodes = 0;
-    nodes += add_level_delta_with_default::<1, FIRST_BIT_PER_PAIR>(
+    nodes += add_level_delta_with_default::<1, FIRST_BIT_PER_PAIR, 1>(
         &mut old_mask,
         &mut added_mask,
         &mut committed_mask,
-        1,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<2, FIRST_BIT_PER_NIBBLE>(
+    nodes += add_level_delta_with_default::<2, FIRST_BIT_PER_NIBBLE, 2>(
         &mut old_mask,
         &mut added_mask,
         &mut committed_mask,
-        2,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<4, FIRST_BIT_PER_BYTE>(
+    nodes += add_level_delta_with_default::<4, FIRST_BIT_PER_BYTE, 3>(
         &mut old_mask,
         &mut added_mask,
         &mut committed_mask,
-        3,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<8, FIRST_BIT_PER_U16>(
+    nodes += add_level_delta_with_default::<8, FIRST_BIT_PER_U16, 4>(
         &mut old_mask,
         &mut added_mask,
         &mut committed_mask,
-        4,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<16, FIRST_BIT_PER_U32>(
+    nodes += add_level_delta_with_default::<16, FIRST_BIT_PER_U32, 5>(
         &mut old_mask,
         &mut added_mask,
         &mut committed_mask,
-        5,
         &mut default_old,
     );
-    nodes += add_level_delta_with_default::<32, FIRST_BIT_PER_U64>(
+    nodes += add_level_delta_with_default::<32, FIRST_BIT_PER_U64, 6>(
         &mut old_mask,
         &mut added_mask,
         &mut committed_mask,
-        6,
         &mut default_old,
     );
 

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -435,15 +435,16 @@ impl SegmentationCtx {
         let mut main_cnt_with_rot = 0usize;
         let mut main_cnt_no_rot = 0usize;
         let mut interaction_cells = 0usize;
-        for (i, ((((padded_height, width), interactions), is_constant), &need_rot)) in trace_heights
+        let mut total_interactions = 0u64;
+        for (i, ((((&height, &width), &interactions), is_constant), &need_rot)) in trace_heights
             .iter()
-            .map(|&height| next_power_of_two_or_zero(height as usize) as u32)
             .zip(self.config.widths.iter())
             .zip(self.config.interactions.iter())
             .zip(is_trace_height_constant.iter())
             .zip(self.config.need_rot.iter())
             .enumerate()
         {
+            let padded_height = next_power_of_two_or_zero(height as usize) as u32;
             // Only segment if the height is not constant and exceeds the maximum height after
             // padding
             if !is_constant && padded_height > self.config.max_trace_height {
@@ -468,6 +469,7 @@ impl SegmentationCtx {
                 main_cnt_no_rot += main_cells;
             }
             interaction_cells += padded_height as usize * interactions;
+            total_interactions += add_one_or_zero(height) as u64 * interactions as u64;
         }
 
         let (total_memory, main_memory, interaction_memory) =
@@ -484,7 +486,6 @@ impl SegmentationCtx {
             return Some(SegmentationTrigger::Memory);
         }
 
-        let total_interactions = self.calculate_total_interactions(trace_heights);
         if total_interactions > u64::from(self.config.max_interactions) {
             tracing::info!(
                 "overshoot: instret {:10} | total interactions ({:10}) > max ({:10})",

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -22,12 +22,12 @@ use crate::{
     arch::{
         execution_mode::{
             metered::{
-                memory_ctx::{MemoryCtx, PageAccess},
+                memory_ctx::{MemoryCtx, PageTouch},
                 segment_ctx::Segment,
             },
             MeteredCtx,
         },
-        ExecutionError, Streams, SystemConfig, VmState,
+        ExecutionError, Streams, SystemConfig, VmState, ADDR_SPACE_OFFSET,
     },
     system::memory::online::GuestMemory,
 };
@@ -65,9 +65,9 @@ pub struct RvrMeteredResult {
 #[derive(Clone, Copy)]
 pub struct MeteredTracerData {
     pub trace_heights: *mut u32,
-    pub mem_page_buf: *mut PageAccess,
-    pub pv_page_buf: *mut PageAccess,
-    pub deferral_page_buf: *mut PageAccess,
+    pub mem_page_buf: *mut PageTouch,
+    pub pv_page_buf: *mut PageTouch,
+    pub deferral_page_buf: *mut PageTouch,
     /// Periodic-check callback. Always initialized; generated C calls it
     /// unconditionally to keep the hot metered path branch-free.
     pub on_check: unsafe extern "C" fn(*mut MeteredTracerData) -> u8,
@@ -117,9 +117,9 @@ pub struct SegmentationState {
     /// and segmentation logic.
     pub ctx: MeteredCtx,
     /// Per-address-space page buffers. Each entry = local page id + leaf mask.
-    mem_page_buf: Vec<PageAccess>,
-    pv_page_buf: Vec<PageAccess>,
-    deferral_page_buf: Vec<PageAccess>,
+    mem_page_buf: Vec<PageTouch>,
+    pv_page_buf: Vec<PageTouch>,
+    deferral_page_buf: Vec<PageTouch>,
     address_height: u32,
 }
 
@@ -129,9 +129,9 @@ impl SegmentationState {
         let address_height = memory_dimensions.address_height as u32;
         Self {
             ctx,
-            mem_page_buf: vec![PageAccess::default(); MEM_PAGE_BUF_CAP],
-            pv_page_buf: vec![PageAccess::default(); PV_PAGE_BUF_CAP],
-            deferral_page_buf: vec![PageAccess::default(); DEFERRAL_PAGE_BUF_CAP],
+            mem_page_buf: vec![PageTouch::default(); MEM_PAGE_BUF_CAP],
+            pv_page_buf: vec![PageTouch::default(); PV_PAGE_BUF_CAP],
+            deferral_page_buf: vec![PageTouch::default(); DEFERRAL_PAGE_BUF_CAP],
             address_height,
         }
     }
@@ -150,17 +150,17 @@ impl SegmentationState {
     }
 
     /// Get mutable pointer to the AS_MEMORY page buffer for the C tracer.
-    pub fn mem_page_buf_ptr(&mut self) -> *mut PageAccess {
+    pub fn mem_page_buf_ptr(&mut self) -> *mut PageTouch {
         self.mem_page_buf.as_mut_ptr()
     }
 
     /// Get mutable pointer to the AS_PUBLIC_VALUES page buffer for the C tracer.
-    pub fn pv_page_buf_ptr(&mut self) -> *mut PageAccess {
+    pub fn pv_page_buf_ptr(&mut self) -> *mut PageTouch {
         self.pv_page_buf.as_mut_ptr()
     }
 
     /// Get mutable pointer to the AS_DEFERRAL page buffer for the C tracer.
-    pub fn deferral_page_buf_ptr(&mut self) -> *mut PageAccess {
+    pub fn deferral_page_buf_ptr(&mut self) -> *mut PageTouch {
         self.deferral_page_buf.as_mut_ptr()
     }
 
@@ -169,7 +169,7 @@ impl SegmentationState {
         memory_ctx: &mut MemoryCtx,
         address_height: u32,
         addr_space: u32,
-        buffer: &[PageAccess],
+        buffer: &[PageTouch],
         len: u32,
     ) {
         if len == 0 {
@@ -179,8 +179,8 @@ impl SegmentationState {
         // deduplicates against one global memory tree, so convert to global
         // page ids before applying the leaf masks.
         let page_shift = address_height as usize - MEMORY_PAGE_BITS;
-        let page_offset = ((addr_space as usize - 1) << page_shift) as u32;
-        memory_ctx.apply_page_accesses_with_offset(page_offset, &buffer[..len as usize]);
+        let page_offset = ((addr_space as usize - ADDR_SPACE_OFFSET as usize) << page_shift) as u32;
+        memory_ctx.apply_page_touches_with_offset(page_offset, &buffer[..len as usize]);
     }
 
     /// Apply all page buffers: convert local pages to global ids and update
@@ -318,8 +318,7 @@ pub unsafe extern "C" fn metered_periodic_check(t: *mut MeteredTracerData) -> u8
     tracer.mem_page_buf_len = 0;
     tracer.pv_page_buf_len = 0;
     tracer.deferral_page_buf_len = 0;
-    // Reset dedup cache — required for correctness across segment boundaries
-    // that clear the global BitSet.
+    // The cleared buffer no longer contains the entry cached by last_mem_page.
     tracer.last_mem_page = NO_LAST_PAGE;
 
     let did_segment =
@@ -526,6 +525,7 @@ mod tests {
             .collect::<Vec<_>>();
         air_names[BOUNDARY_AIR_ID] = "Memory Boundary".to_string();
         air_names[MERKLE_AIR_ID] = "Memory Merkle".to_string();
+        air_names[num_airs - 2] = "Poseidon2".to_string();
         let constant_trace_heights = vec![None; num_airs];
         let widths = vec![1; num_airs];
         let interactions = vec![0; num_airs];
@@ -553,15 +553,15 @@ mod tests {
     #[test]
     fn test_initialize_segment_memory_replays_page_buffers() {
         let mut with_interval_buffer = make_segmentation_state();
-        with_interval_buffer.mem_page_buf[0] = PageAccess {
+        with_interval_buffer.mem_page_buf[0] = PageTouch {
             page_id: 7,
             leaf_mask: 1,
         };
-        with_interval_buffer.pv_page_buf[0] = PageAccess {
+        with_interval_buffer.pv_page_buf[0] = PageTouch {
             page_id: 3,
             leaf_mask: 1,
         };
-        with_interval_buffer.deferral_page_buf[0] = PageAccess {
+        with_interval_buffer.deferral_page_buf[0] = PageTouch {
             page_id: 2,
             leaf_mask: 1,
         };
@@ -586,9 +586,32 @@ mod tests {
     }
 
     #[test]
+    fn test_periodic_checks_share_default_poseidon_rows() {
+        let mut seg_state = make_segmentation_state();
+        seg_state.mem_page_buf[0] = PageTouch {
+            page_id: 0,
+            leaf_mask: 1,
+        };
+        assert!(!seg_state.on_periodic_check(1, 0, 0, 0));
+
+        let poseidon2_idx = seg_state.ctx.trace_heights.len() - 2;
+        let poseidon_before = seg_state.ctx.trace_heights[poseidon2_idx];
+        seg_state.mem_page_buf[0] = PageTouch {
+            page_id: 1,
+            leaf_mask: 1,
+        };
+        assert!(!seg_state.on_periodic_check(1, 0, 0, 0));
+
+        assert_eq!(
+            seg_state.ctx.trace_heights[poseidon2_idx] - poseidon_before,
+            1 + MEMORY_PAGE_BITS as u32
+        );
+    }
+
+    #[test]
     fn test_memory_page_buffer_applies_cross_leaf_mask() {
         let mut buffered = make_segmentation_state();
-        buffered.mem_page_buf[0] = PageAccess {
+        buffered.mem_page_buf[0] = PageTouch {
             page_id: 0,
             leaf_mask: 0b11,
         };

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -596,24 +596,27 @@ mod tests {
 
         let mut explicit = make_segmentation_state();
         explicit
+            .ctx
             .memory_ctx
             .update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 17);
         explicit
+            .ctx
             .memory_ctx
-            .apply_height_updates(&mut explicit.trace_heights);
-        explicit.segmentation_ctx.instrets_until_check = 0;
+            .apply_height_updates(&mut explicit.ctx.trace_heights);
+        explicit.ctx.segmentation_ctx.instrets_until_check = 0;
         explicit
+            .ctx
             .segmentation_ctx
-            .create_final_segment(&explicit.trace_heights);
+            .create_final_segment(&explicit.ctx.trace_heights);
 
-        assert_eq!(buffered.trace_heights, explicit.trace_heights);
+        assert_eq!(buffered.ctx.trace_heights, explicit.ctx.trace_heights);
         assert_eq!(
-            buffered.segmentation_ctx.segments.len(),
-            explicit.segmentation_ctx.segments.len()
+            buffered.ctx.segmentation_ctx.segments.len(),
+            explicit.ctx.segmentation_ctx.segments.len()
         );
         assert_eq!(
-            buffered.segmentation_ctx.segments[0].trace_heights,
-            explicit.segmentation_ctx.segments[0].trace_heights
+            buffered.ctx.segmentation_ctx.segments[0].trace_heights,
+            explicit.ctx.segmentation_ctx.segments[0].trace_heights
         );
     }
 

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -586,6 +586,38 @@ mod tests {
     }
 
     #[test]
+    fn test_memory_page_buffer_applies_cross_leaf_mask() {
+        let mut buffered = make_segmentation_state();
+        buffered.mem_page_buf[0] = PageAccess {
+            page_id: 0,
+            leaf_mask: 0b11,
+        };
+        buffered.on_termination(1, 0, 0, 0);
+
+        let mut explicit = make_segmentation_state();
+        explicit
+            .memory_ctx
+            .update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 17);
+        explicit
+            .memory_ctx
+            .apply_height_updates(&mut explicit.trace_heights);
+        explicit.segmentation_ctx.instrets_until_check = 0;
+        explicit
+            .segmentation_ctx
+            .create_final_segment(&explicit.trace_heights);
+
+        assert_eq!(buffered.trace_heights, explicit.trace_heights);
+        assert_eq!(
+            buffered.segmentation_ctx.segments.len(),
+            explicit.segmentation_ctx.segments.len()
+        );
+        assert_eq!(
+            buffered.segmentation_ctx.segments[0].trace_heights,
+            explicit.segmentation_ctx.segments[0].trace_heights
+        );
+    }
+
+    #[test]
     fn test_periodic_check_records_block_boundary_instret() {
         let mut seg_state = make_segmentation_state();
         seg_state.ctx.segmentation_ctx.instrets_until_check = 1000;

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -1302,7 +1302,7 @@ where
             .log_stacked_height()
             .try_into()
             .expect("log_stacked_height must fit in u8");
-        self.executor().build_metered_ctx(
+        let mut ctx = self.executor().build_metered_ctx(
             MeteredCtxInputs {
                 constant_trace_heights: &constant_trace_heights,
                 air_names: &air_names,
@@ -1316,7 +1316,9 @@ where
                 },
             },
             self.engine.proving_memory_config(),
-        )
+        );
+        ctx.seed_initial_memory(&exe.init_memory);
+        ctx
     }
 
     /// Convenience method to construct a [MeteredCostCtx] using data from the stored proving key.

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -34,7 +34,7 @@ impl ExtInstr for HintStoreWInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg(self.ptr_reg);
         ctx.trace_mem_access(&ptr, RV64_MEMORY_AS);
-        ctx.extern_call_preserving_tracer("openvm_hint_storew", &[&ptr]);
+        ctx.extern_call_without_page_flush("openvm_hint_storew", &[&ptr]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -68,7 +68,7 @@ impl ExtInstr for HintBufferInstr {
         ctx.write_line(&format!("if ({n} > 0) {{"));
         ctx.trace_mem_access_u64_range(&ptr, &n, RV64_MEMORY_AS);
         ctx.write_line("}");
-        ctx.extern_call_preserving_tracer("openvm_hint_buffer", &[&ptr, &n]);
+        ctx.extern_call_without_page_flush("openvm_hint_buffer", &[&ptr, &n]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -106,7 +106,7 @@ impl ExtInstr for RevealInstr {
         ctx.trace_mem_access(&addr, PUBLIC_VALUES_AS);
         let offset = format!("0x{:08x}u", self.offset);
         let width = self.width.bytes().to_string();
-        ctx.extern_call_preserving_tracer("openvm_reveal", &[&src, &ptr, &offset, &width]);
+        ctx.extern_call_without_page_flush("openvm_reveal", &[&src, &ptr, &offset, &width]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -124,7 +124,7 @@ impl ExtInstr for HintInputInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        ctx.extern_call_preserving_tracer("openvm_hint_input", &[]);
+        ctx.extern_call_without_page_flush("openvm_hint_input", &[]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -147,7 +147,7 @@ impl ExtInstr for PrintStrInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg_raw(self.ptr_reg);
         let len = ctx.read_reg_raw(self.len_reg);
-        ctx.extern_call_preserving_tracer("openvm_print_str", &[&ptr, &len]);
+        ctx.extern_call_without_page_flush("openvm_print_str", &[&ptr, &len]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -169,7 +169,7 @@ impl ExtInstr for HintRandomInstr {
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let n = ctx.read_reg_raw(self.num_words_reg);
-        ctx.extern_call_preserving_tracer("openvm_hint_random", &[&n]);
+        ctx.extern_call_without_page_flush("openvm_hint_random", &[&n]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -34,7 +34,7 @@ impl ExtInstr for HintStoreWInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg(self.ptr_reg);
         ctx.trace_mem_access(&ptr, RV64_MEMORY_AS);
-        ctx.extern_call("openvm_hint_storew", &[&ptr]);
+        ctx.extern_call_preserving_tracer("openvm_hint_storew", &[&ptr]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -68,7 +68,7 @@ impl ExtInstr for HintBufferInstr {
         ctx.write_line(&format!("if ({n} > 0) {{"));
         ctx.trace_mem_access_u64_range(&ptr, &n, RV64_MEMORY_AS);
         ctx.write_line("}");
-        ctx.extern_call("openvm_hint_buffer", &[&ptr, &n]);
+        ctx.extern_call_preserving_tracer("openvm_hint_buffer", &[&ptr, &n]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -106,7 +106,7 @@ impl ExtInstr for RevealInstr {
         ctx.trace_mem_access(&addr, PUBLIC_VALUES_AS);
         let offset = format!("0x{:08x}u", self.offset);
         let width = self.width.bytes().to_string();
-        ctx.extern_call("openvm_reveal", &[&src, &ptr, &offset, &width]);
+        ctx.extern_call_preserving_tracer("openvm_reveal", &[&src, &ptr, &offset, &width]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -124,7 +124,7 @@ impl ExtInstr for HintInputInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        ctx.extern_call("openvm_hint_input", &[]);
+        ctx.extern_call_preserving_tracer("openvm_hint_input", &[]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -147,7 +147,7 @@ impl ExtInstr for PrintStrInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg_raw(self.ptr_reg);
         let len = ctx.read_reg_raw(self.len_reg);
-        ctx.extern_call("openvm_print_str", &[&ptr, &len]);
+        ctx.extern_call_preserving_tracer("openvm_print_str", &[&ptr, &len]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -169,7 +169,7 @@ impl ExtInstr for HintRandomInstr {
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let n = ctx.read_reg_raw(self.num_words_reg);
-        ctx.extern_call("openvm_hint_random", &[&n]);
+        ctx.extern_call_preserving_tracer("openvm_hint_random", &[&n]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {


### PR DESCRIPTION
## Summary

This PR makes Poseidon2 memory metering closer to the rows that trace generation actually emits.

A memory segment has two trees: the memory tree at the start of the segment and the memory tree at the end of the segment. Metering already counts the leaves and Merkle nodes touched by the segment. This PR also checks whether each touched leaf or node was already non-default at the latest checkpoint.

That matters for Poseidon2 because default memory values share hash inputs. If many old leaves or old internal nodes are still default, trace generation can reuse the same Poseidon2 row for those default inputs instead of emitting one row per node.

## Model

The code uses two memory trackers:

```text
segment_memory
    clears at segment start
    counts leaves and Merkle nodes touched by this segment

global_memory
    persists across checkpoints
    tracks memory that is already known to be non-default
```

Each memory page stores one `u64` leaf mask:

```text
one page = 64 memory leaves

leaf index:   0  1  2  3  ... 63
leaf_mask:    1  0  1  0  ...  0
```

For each leaf or Merkle node counted in the segment, the trackers answer two questions:

```text
segment_memory: is this new in the current segment?
global_memory:  was this already non-default at the checkpoint?
```

The result is:

```text
new in segment + already non-default -> count one old Poseidon2 row for this node
new in segment + still default       -> count it in the shared default bucket
```

A first touch looks like this:

```text
checkpoint / old side              segment end / new side

          D3                                X3
        /    \                            /    \
      D2      D2          write         X2      D2
     /  \    /  \        ------>       /  \    /  \
   D1   D1 D1   D1                    X1  D1 D1   D1
   |                                  |
default leaf                       touched leaf

D = default node input shared with other default nodes at the same height
X = node changed by this segment and counted normally
```

Default rows are shared by value:

```text
default leaves                     -> 1 old Poseidon2 row
default internal nodes at height h -> 1 old Poseidon2 row for that height
```

So the estimate is:

```text
new_rows           = segment_leaves + segment_merkle_nodes
old_nondefault     = new_rows - first_touch_default_nodes
old_default_rows   = has_default_leaf + count(default_internal_heights)

Poseidon2 rows = new_rows + old_nondefault + old_default_rows
```

`first_touch_default_nodes` means leaves and Merkle nodes that are touched in this segment and were still default at the checkpoint. `default_internal_heights` is a bit mask of Merkle heights that had at least one such default internal node.

## Initial Memory

The global tracker is seeded from the executable's sparse initial memory image:

```text
nonzero initial byte -> containing memory leaf is non-default
zero initial byte    -> leaf stays default
```

For `DEFERRAL_AS`, sparse image bytes are converted back to deferral field-cell units before mapping them to Merkle leaves.

## RVR

RVR uses the same Rust accounting path as the interpreter.

```text
generated C page buffers
        |
        v
PageAccess { page_id, leaf_mask }
        |
        v
MemoryCtx
        |
        +--> segment_memory: Boundary/Merkle rows for this segment
        +--> global_memory: old Poseidon2 rows for default vs non-default memory
```

The generated C hot path is kept narrow:

- aligned normal memory loads/stores record one memory leaf directly
- page buffers pass `PageAccess { page_id, leaf_mask }` into Rust
- extension calls that already trace their memory do not flush and reload local page state again
- public-values and deferral tracing skip normal-memory tracer work when the address space is not `AS_MEMORY`

## Performance

RVR reth benchmark comparison for block `23992138`:

```text
latest origin/develop-v2.1.0-rv64: 75 segments, compile 266.322s, execute 1.999s
this branch:                         74 segments, compile 266.230s, execute 1.932s
```

The branch reduces the segment count by one on this benchmark without increasing compile-metered time.

## Testing

- `RUSTC_WRAPPER= cargo test --profile fast -p rvr-openvm aligned_memory_access_uses_single_leaf_trace --lib`
- `RUSTC_WRAPPER= cargo test --profile fast -p openvm-circuit metered --lib`
- `git diff --check`
- RVR reth metered benchmark against latest `origin/develop-v2.1.0-rv64`

Resolves INT-8554