### PR TITLE
fix(v2-rc.3): account for retained prover memory in metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,7 +6036,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
 dependencies = [
  "cfg-if 1.0.1",
  "derive-new 0.7.0",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6135,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
 dependencies = [
  "cc",
  "glob",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
 dependencies = [
  "cfg-if 1.0.1",
  "derivative",
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,7 +6036,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#04611d9be14da52ac9a3fbba4a410f98056cbb18"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#04611d9be14da52ac9a3fbba4a410f98056cbb18"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
 dependencies = [
  "cfg-if 1.0.1",
  "derive-new 0.7.0",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#04611d9be14da52ac9a3fbba4a410f98056cbb18"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6135,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#04611d9be14da52ac9a3fbba4a410f98056cbb18"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
 dependencies = [
  "cc",
  "glob",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#04611d9be14da52ac9a3fbba4a410f98056cbb18"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#04611d9be14da52ac9a3fbba4a410f98056cbb18"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
 dependencies = [
  "cfg-if 1.0.1",
  "derivative",
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#04611d9be14da52ac9a3fbba4a410f98056cbb18"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#3cdbd6c9a3fc6d54882cc861796242e70c19bf06"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,7 +6036,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4246b8f7ff5bbaa6980854a78bb16828bb2eb211"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4246b8f7ff5bbaa6980854a78bb16828bb2eb211"
 dependencies = [
  "cfg-if 1.0.1",
  "derive-new 0.7.0",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4246b8f7ff5bbaa6980854a78bb16828bb2eb211"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6135,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4246b8f7ff5bbaa6980854a78bb16828bb2eb211"
 dependencies = [
  "cc",
  "glob",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4246b8f7ff5bbaa6980854a78bb16828bb2eb211"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4246b8f7ff5bbaa6980854a78bb16828bb2eb211"
 dependencies = [
  "cfg-if 1.0.1",
  "derivative",
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#bda353af62b32222f62c936e22830f4b7529ddba"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4246b8f7ff5bbaa6980854a78bb16828bb2eb211"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -30,7 +30,8 @@ pub struct MeteredCtx<const PAGE_BITS: usize = DEFAULT_PAGE_BITS> {
 pub struct MeteredCtxInputs<'a> {
     pub constant_trace_heights: &'a [Option<usize>],
     pub air_names: &'a [String],
-    pub widths: &'a [usize],
+    pub total_widths: &'a [usize],
+    pub stacked_main_widths: &'a [usize],
     pub interactions: &'a [usize],
     pub need_rot: &'a [bool],
     pub segmentation_limits: SegmentationLimits,
@@ -57,7 +58,8 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
 
         let segmentation_ctx = SegmentationCtx::new(
             inputs.air_names.to_vec(),
-            inputs.widths.to_vec(),
+            inputs.total_widths.to_vec(),
+            inputs.stacked_main_widths.to_vec(),
             inputs.interactions.to_vec(),
             inputs.need_rot.to_vec(),
             inputs.segmentation_limits,
@@ -168,16 +170,16 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         println!("{}", "-".repeat(80));
         println!("Segment {}", self.segmentation_ctx.segments.len() - 1);
         println!("{}", "-".repeat(80));
-        println!("{:>10} {:>10} {:<30}", "Width", "Height", "Air Name");
+        println!("{:>12} {:>10} {:<30}", "Total Width", "Height", "Air Name");
         println!("{}", "-".repeat(80));
         for ((&width, &height), air_name) in self
             .segmentation_ctx
-            .widths()
+            .total_widths()
             .iter()
             .zip_eq(self.trace_heights.iter())
             .zip_eq(self.segmentation_ctx.air_names().iter())
         {
-            println!("{:>10} {:>10} {:<30}", width, height, air_name.as_str());
+            println!("{:>12} {:>10} {:<30}", width, height, air_name.as_str());
         }
     }
 }

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -31,7 +31,7 @@ pub struct MeteredCtxInputs<'a> {
     pub constant_trace_heights: &'a [Option<usize>],
     pub air_names: &'a [String],
     pub total_widths: &'a [usize],
-    pub stacked_main_widths: &'a [usize],
+    pub common_main_widths: &'a [usize],
     pub interactions: &'a [usize],
     pub need_rot: &'a [bool],
     pub segmentation_limits: SegmentationLimits,
@@ -59,7 +59,7 @@ impl<const PAGE_BITS: usize> MeteredCtx<PAGE_BITS> {
         let segmentation_ctx = SegmentationCtx::new(
             inputs.air_names.to_vec(),
             inputs.total_widths.to_vec(),
-            inputs.stacked_main_widths.to_vec(),
+            inputs.common_main_widths.to_vec(),
             inputs.interactions.to_vec(),
             inputs.need_rot.to_vec(),
             inputs.segmentation_limits,

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -27,7 +27,8 @@ pub struct SegmentationLimits {
 #[derive(Clone, Debug)]
 struct SegmentationParams {
     air_names: Vec<String>,
-    widths: Vec<usize>,
+    total_widths: Vec<usize>,
+    stacked_main_widths: Vec<usize>,
     interactions: Vec<usize>,
     need_rot: Vec<bool>,
     max_trace_height: u32,
@@ -40,13 +41,15 @@ struct SegmentationParams {
 impl SegmentationParams {
     fn new(
         air_names: Vec<String>,
-        widths: Vec<usize>,
+        total_widths: Vec<usize>,
+        stacked_main_widths: Vec<usize>,
         interactions: Vec<usize>,
         need_rot: Vec<bool>,
         limits: SegmentationLimits,
         memory_config: ProvingMemoryConfig,
     ) -> Self {
-        assert_eq!(air_names.len(), widths.len());
+        assert_eq!(air_names.len(), total_widths.len());
+        assert_eq!(air_names.len(), stacked_main_widths.len());
         assert_eq!(air_names.len(), interactions.len());
         assert_eq!(air_names.len(), need_rot.len());
         assert!(
@@ -65,7 +68,8 @@ impl SegmentationParams {
 
         Self {
             air_names,
-            widths,
+            total_widths,
+            stacked_main_widths,
             interactions,
             need_rot,
             max_trace_height,
@@ -124,6 +128,10 @@ struct MeteredCounts {
     main_unpadded_no_rot: usize,
     /// Main trace cells for AIRs without next-row rotations, from padding rows.
     main_padding_no_rot: usize,
+    /// Stacked matrix slice cells before power-of-two padding.
+    stacked_unpadded_slice_cells: usize,
+    /// Stacked matrix slice cells from power-of-two padding.
+    stacked_padded_slice_cells: usize,
     /// Metered row-interaction slots before padding.
     interaction_cells_unpadded: usize,
     /// Metered row-interaction slots from padding rows.
@@ -140,7 +148,8 @@ struct MeteredMemoryBreakdown {
 impl SegmentationCtx {
     pub fn new(
         air_names: Vec<String>,
-        widths: Vec<usize>,
+        total_widths: Vec<usize>,
+        stacked_main_widths: Vec<usize>,
         interactions: Vec<usize>,
         need_rot: Vec<bool>,
         limits: SegmentationLimits,
@@ -149,7 +158,8 @@ impl SegmentationCtx {
         let num_airs = air_names.len();
         let params = SegmentationParams::new(
             air_names,
-            widths,
+            total_widths,
+            stacked_main_widths,
             interactions,
             need_rot,
             limits,
@@ -171,8 +181,8 @@ impl SegmentationCtx {
     }
 
     #[inline(always)]
-    pub(crate) fn widths(&self) -> &[usize] {
-        &self.params.widths
+    pub(crate) fn total_widths(&self) -> &[usize] {
+        &self.params.total_widths
     }
 
     #[inline(always)]
@@ -202,42 +212,70 @@ impl SegmentationCtx {
         &self,
         main_cnt_with_rot: usize,
         main_cnt_no_rot: usize,
+        main_stacked_cells: usize,
         interaction_cells: usize,
     ) -> (
         usize, /* memory */
         usize, /* main */
         usize, /* interaction */
     ) {
-        let estimate = self.params.memory_config.estimate(ProvingMemoryCounts::new(
-            main_cnt_with_rot,
-            main_cnt_no_rot,
-            interaction_cells,
-        ));
+        let estimate =
+            self.params
+                .memory_config
+                .estimate(ProvingMemoryCounts::new_with_stacked_cells(
+                    main_cnt_with_rot,
+                    main_cnt_no_rot,
+                    main_stacked_cells,
+                    interaction_cells,
+                ));
         (estimate.total, estimate.main, estimate.interaction)
     }
 
-    /// Sum padded main trace cells and interaction cells across all chips, splitting main
-    /// cells by per-AIR `need_rot`.
+    #[inline(always)]
+    fn stacked_main_cells_from_slice_cells(&self, stacked_slice_cells: usize) -> usize {
+        self.params
+            .memory_config
+            .stacked_matrix_cells(stacked_slice_cells)
+    }
+
+    #[inline(always)]
+    fn stacked_slice_cells(&self, height: usize, width: usize) -> usize {
+        if height == 0 {
+            return 0;
+        }
+        self.params.memory_config.stacked_slice_height(height) * width
+    }
+
+    /// Sum padded main trace cells, main columns included in the stacked-matrix estimate, and
+    /// interaction cells across all chips, splitting main cells by per-AIR `need_rot`.
     #[inline(always)]
     fn calculate_count_breakdown(&self, trace_heights: &[u32]) -> MeteredCounts {
-        debug_assert_eq!(trace_heights.len(), self.params.widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.total_widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.stacked_main_widths.len());
         debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
         let mut counts = MeteredCounts::default();
-        for (((&height, &width), &interactions), &need_rot) in trace_heights
-            .iter()
-            .zip(self.params.widths.iter())
-            .zip(self.params.interactions.iter())
-            .zip(self.params.need_rot.iter())
+        for ((((&height, &total_width), &stacked_main_width), &interactions), &need_rot) in
+            trace_heights
+                .iter()
+                .zip(self.params.total_widths.iter())
+                .zip(self.params.stacked_main_widths.iter())
+                .zip(self.params.interactions.iter())
+                .zip(self.params.need_rot.iter())
         {
             let padded_height = next_power_of_two_or_zero(height as usize);
             let unpadded_height = height as usize;
             let padding_height = padded_height - unpadded_height;
             counts.unpadded_rows += unpadded_height;
             counts.padding_rows += padding_height;
-            let main_unpadded_cells = unpadded_height * width;
-            let main_padding_cells = padding_height * width;
+            counts.stacked_unpadded_slice_cells +=
+                self.stacked_slice_cells(unpadded_height, stacked_main_width);
+            counts.stacked_padded_slice_cells += self
+                .stacked_slice_cells(padded_height, stacked_main_width)
+                - self.stacked_slice_cells(unpadded_height, stacked_main_width);
+            let main_unpadded_cells = unpadded_height * total_width;
+            let main_padding_cells = padding_height * total_width;
             if need_rot {
                 counts.main_unpadded_with_rot += main_unpadded_cells;
                 counts.main_padding_with_rot += main_padding_cells;
@@ -251,25 +289,30 @@ impl SegmentationCtx {
         counts
     }
 
-    /// Sum padded main trace cells and interaction cells across all chips, splitting main
-    /// cells by per-AIR `need_rot`.
+    /// Sum padded main trace cells, main columns included in the stacked-matrix estimate, and
+    /// interaction cells across all chips, splitting main cells by per-AIR `need_rot`.
     #[inline(always)]
-    fn calculate_cell_counts(&self, trace_heights: &[u32]) -> (usize, usize, usize) {
-        debug_assert_eq!(trace_heights.len(), self.params.widths.len());
+    fn calculate_cell_counts(&self, trace_heights: &[u32]) -> (usize, usize, usize, usize) {
+        debug_assert_eq!(trace_heights.len(), self.params.total_widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.stacked_main_widths.len());
         debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
         let mut main_cnt_with_rot = 0;
         let mut main_cnt_no_rot = 0;
+        let mut stacked_slice_cells = 0;
         let mut interaction_cells = 0;
-        for (((&height, &width), &interactions), &need_rot) in trace_heights
-            .iter()
-            .zip(self.params.widths.iter())
-            .zip(self.params.interactions.iter())
-            .zip(self.params.need_rot.iter())
+        for ((((&height, &total_width), &stacked_main_width), &interactions), &need_rot) in
+            trace_heights
+                .iter()
+                .zip(self.params.total_widths.iter())
+                .zip(self.params.stacked_main_widths.iter())
+                .zip(self.params.interactions.iter())
+                .zip(self.params.need_rot.iter())
         {
             let padded_height = next_power_of_two_or_zero(height as usize);
-            let main_cells = padded_height * width;
+            let main_cells = padded_height * total_width;
+            stacked_slice_cells += self.stacked_slice_cells(padded_height, stacked_main_width);
             if need_rot {
                 main_cnt_with_rot += main_cells;
             } else {
@@ -277,7 +320,12 @@ impl SegmentationCtx {
             }
             interaction_cells += padded_height * interactions;
         }
-        (main_cnt_with_rot, main_cnt_no_rot, interaction_cells)
+        (
+            main_cnt_with_rot,
+            main_cnt_no_rot,
+            self.stacked_main_cells_from_slice_cells(stacked_slice_cells),
+            interaction_cells,
+        )
     }
 
     /// Calculate total memory in bytes based on trace heights and widths.
@@ -290,23 +338,38 @@ impl SegmentationCtx {
         usize, /* main */
         usize, /* interaction */
     ) {
-        let (main_cnt_with_rot, main_cnt_no_rot, interaction_cells) =
+        let (main_cnt_with_rot, main_cnt_no_rot, main_stacked_cells, interaction_cells) =
             self.calculate_cell_counts(trace_heights);
-        self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cells)
+        self.counts_to_memory(
+            main_cnt_with_rot,
+            main_cnt_no_rot,
+            main_stacked_cells,
+            interaction_cells,
+        )
     }
 
     #[inline(always)]
     fn calculate_memory_breakdown(&self, counts: &MeteredCounts) -> MeteredMemoryBreakdown {
-        let unpadded = self.params.memory_config.estimate(ProvingMemoryCounts::new(
-            counts.main_unpadded_with_rot,
-            counts.main_unpadded_no_rot,
-            counts.interaction_cells_unpadded,
-        ));
-        let total = self.params.memory_config.estimate(ProvingMemoryCounts::new(
-            counts.main_unpadded_with_rot + counts.main_padding_with_rot,
-            counts.main_unpadded_no_rot + counts.main_padding_no_rot,
-            counts.interaction_cells_unpadded + counts.interaction_cells_padding,
-        ));
+        let unpadded =
+            self.params
+                .memory_config
+                .estimate(ProvingMemoryCounts::new_with_stacked_cells(
+                    counts.main_unpadded_with_rot,
+                    counts.main_unpadded_no_rot,
+                    self.stacked_main_cells_from_slice_cells(counts.stacked_unpadded_slice_cells),
+                    counts.interaction_cells_unpadded,
+                ));
+        let total =
+            self.params
+                .memory_config
+                .estimate(ProvingMemoryCounts::new_with_stacked_cells(
+                    counts.main_unpadded_with_rot + counts.main_padding_with_rot,
+                    counts.main_unpadded_no_rot + counts.main_padding_no_rot,
+                    self.stacked_main_cells_from_slice_cells(
+                        counts.stacked_unpadded_slice_cells + counts.stacked_padded_slice_cells,
+                    ),
+                    counts.interaction_cells_unpadded + counts.interaction_cells_padding,
+                ));
 
         MeteredMemoryBreakdown {
             total: total.total,
@@ -348,7 +411,8 @@ impl SegmentationCtx {
     ) -> Option<SegmentationTrigger> {
         debug_assert_eq!(trace_heights.len(), is_trace_height_constant.len());
         debug_assert_eq!(trace_heights.len(), self.params.air_names.len());
-        debug_assert_eq!(trace_heights.len(), self.params.widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.total_widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.stacked_main_widths.len());
         debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
@@ -365,11 +429,22 @@ impl SegmentationCtx {
 
         let mut main_cnt_with_rot = 0usize;
         let mut main_cnt_no_rot = 0usize;
+        let mut stacked_slice_cells = 0usize;
         let mut interaction_cells = 0usize;
-        for (i, ((((padded_height, width), interactions), is_constant), &need_rot)) in trace_heights
+        for (
+            i,
+            (
+                (
+                    (((padded_height, &total_width), &stacked_main_width), &interactions),
+                    is_constant,
+                ),
+                &need_rot,
+            ),
+        ) in trace_heights
             .iter()
             .map(|&height| next_power_of_two_or_zero(height as usize) as u32)
-            .zip(self.params.widths.iter())
+            .zip(self.params.total_widths.iter())
+            .zip(self.params.stacked_main_widths.iter())
             .zip(self.params.interactions.iter())
             .zip(is_trace_height_constant.iter())
             .zip(self.params.need_rot.iter())
@@ -392,7 +467,9 @@ impl SegmentationCtx {
                     air_id: i,
                 });
             }
-            let main_cells = padded_height as usize * width;
+            let main_cells = padded_height as usize * total_width;
+            stacked_slice_cells +=
+                self.stacked_slice_cells(padded_height as usize, stacked_main_width);
             if need_rot {
                 main_cnt_with_rot += main_cells;
             } else {
@@ -401,8 +478,12 @@ impl SegmentationCtx {
             interaction_cells += padded_height as usize * interactions;
         }
 
-        let (total_memory, main_memory, interaction_memory) =
-            self.counts_to_memory(main_cnt_with_rot, main_cnt_no_rot, interaction_cells);
+        let (total_memory, main_memory, interaction_memory) = self.counts_to_memory(
+            main_cnt_with_rot,
+            main_cnt_no_rot,
+            self.stacked_main_cells_from_slice_cells(stacked_slice_cells),
+            interaction_cells,
+        );
         if total_memory > self.params.max_memory {
             tracing::info!(
                 "overshoot: instret {:10} | total memory ({:5}) > max ({:5}) | main ({:5}) | interaction ({:5})",
@@ -651,13 +732,14 @@ impl SegmentationCtx {
     fn emit_metered_air_metrics(&self, segment: &str, trace_heights: &[u32]) {
         let memory_config = self.params.memory_config;
 
-        for (air_id, ((((&height, &width), &interactions), &need_rot), air_name)) in trace_heights
-            .iter()
-            .zip(self.params.widths.iter())
-            .zip(self.params.interactions.iter())
-            .zip(self.params.need_rot.iter())
-            .zip(self.params.air_names.iter())
-            .enumerate()
+        for (air_id, ((((&height, &total_width), &interactions), &need_rot), air_name)) in
+            trace_heights
+                .iter()
+                .zip(self.params.total_widths.iter())
+                .zip(self.params.interactions.iter())
+                .zip(self.params.need_rot.iter())
+                .zip(self.params.air_names.iter())
+                .enumerate()
         {
             let padded_height = next_power_of_two_or_zero(height as usize);
             let unpadded_height = height as usize;
@@ -670,8 +752,8 @@ impl SegmentationCtx {
                 ("air_id", air_id.to_string()),
                 ("segment", segment.to_string()),
             ];
-            let unpadded_cells = unpadded_height * width;
-            let padding_cells = padding_height * width;
+            let unpadded_cells = unpadded_height * total_width;
+            let padding_cells = padding_height * total_width;
             // One interaction cell is one metered row-interaction slot.
             let interaction_cells_unpadded = unpadded_height * interactions;
             let interaction_cells_padding = padding_height * interactions;

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -1,4 +1,5 @@
 use bytesize::ByteSize;
+use itertools::izip;
 #[cfg(feature = "metrics")]
 use openvm_stark_backend::memory_metering::INTERACTION_MEMORY_OVERHEAD;
 use openvm_stark_backend::memory_metering::{ProvingMemoryConfig, ProvingMemoryCounts};
@@ -83,10 +84,15 @@ impl SegmentationParams {
 
 #[derive(Clone, Copy)]
 struct AirMeteringParams {
+    /// Current trace height for this AIR.
     height: u32,
+    /// All main trace columns, used for total main trace memory.
     total_width: usize,
+    /// Main columns retained in the stacked matrix estimate.
     stacked_main_width: usize,
+    /// Row-interaction slots per row.
     interactions: usize,
+    /// Whether main trace memory includes next-row rotation overhead.
     need_rot: bool,
 }
 
@@ -265,7 +271,7 @@ impl SegmentationCtx {
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
         let mut counts = MeteredCounts::default();
-        let airs = itertools::izip!(
+        let airs = izip!(
             trace_heights,
             &self.params.total_widths,
             &self.params.stacked_main_widths,
@@ -323,7 +329,7 @@ impl SegmentationCtx {
         let mut main_cnt_no_rot = 0;
         let mut stacked_slice_cells = 0;
         let mut interaction_cells = 0;
-        let airs = itertools::izip!(
+        let airs = izip!(
             trace_heights,
             &self.params.total_widths,
             &self.params.stacked_main_widths,
@@ -464,7 +470,7 @@ impl SegmentationCtx {
         let mut main_cnt_no_rot = 0usize;
         let mut stacked_slice_cells = 0usize;
         let mut interaction_cells = 0usize;
-        let airs = itertools::izip!(
+        let airs = izip!(
             trace_heights,
             &self.params.total_widths,
             &self.params.stacked_main_widths,
@@ -767,15 +773,14 @@ impl SegmentationCtx {
     fn emit_metered_air_metrics(&self, segment: &str, trace_heights: &[u32]) {
         let memory_config = self.params.memory_config;
 
-        for (air_id, (&height, &total_width, &interactions, &need_rot, air_name)) in
-            itertools::izip!(
-                trace_heights,
-                &self.params.total_widths,
-                &self.params.interactions,
-                &self.params.need_rot,
-                &self.params.air_names,
-            )
-            .enumerate()
+        for (air_id, (&height, &total_width, &interactions, &need_rot, air_name)) in izip!(
+            trace_heights,
+            &self.params.total_widths,
+            &self.params.interactions,
+            &self.params.need_rot,
+            &self.params.air_names,
+        )
+        .enumerate()
         {
             let padded_height = next_power_of_two_or_zero(height as usize);
             let unpadded_height = height as usize;

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -81,6 +81,15 @@ impl SegmentationParams {
     }
 }
 
+#[derive(Clone, Copy)]
+struct AirMeteringParams {
+    height: u32,
+    total_width: usize,
+    stacked_main_width: usize,
+    interactions: usize,
+    need_rot: bool,
+}
+
 #[derive(Clone, Debug)]
 pub struct SegmentationCtx {
     pub segments: Vec<Segment>,
@@ -256,35 +265,47 @@ impl SegmentationCtx {
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
         let mut counts = MeteredCounts::default();
-        for ((((&height, &total_width), &stacked_main_width), &interactions), &need_rot) in
-            trace_heights
-                .iter()
-                .zip(self.params.total_widths.iter())
-                .zip(self.params.stacked_main_widths.iter())
-                .zip(self.params.interactions.iter())
-                .zip(self.params.need_rot.iter())
-        {
-            let padded_height = next_power_of_two_or_zero(height as usize);
-            let unpadded_height = height as usize;
+        let airs = itertools::izip!(
+            trace_heights,
+            &self.params.total_widths,
+            &self.params.stacked_main_widths,
+            &self.params.interactions,
+            &self.params.need_rot,
+        )
+        .map(
+            |(&height, &total_width, &stacked_main_width, &interactions, &need_rot)| {
+                AirMeteringParams {
+                    height,
+                    total_width,
+                    stacked_main_width,
+                    interactions,
+                    need_rot,
+                }
+            },
+        );
+
+        for air in airs {
+            let padded_height = next_power_of_two_or_zero(air.height as usize);
+            let unpadded_height = air.height as usize;
             let padding_height = padded_height - unpadded_height;
             counts.unpadded_rows += unpadded_height;
             counts.padding_rows += padding_height;
             counts.stacked_unpadded_slice_cells +=
-                self.stacked_slice_cells(unpadded_height, stacked_main_width);
+                self.stacked_slice_cells(unpadded_height, air.stacked_main_width);
             counts.stacked_padded_slice_cells += self
-                .stacked_slice_cells(padded_height, stacked_main_width)
-                - self.stacked_slice_cells(unpadded_height, stacked_main_width);
-            let main_unpadded_cells = unpadded_height * total_width;
-            let main_padding_cells = padding_height * total_width;
-            if need_rot {
+                .stacked_slice_cells(padded_height, air.stacked_main_width)
+                - self.stacked_slice_cells(unpadded_height, air.stacked_main_width);
+            let main_unpadded_cells = unpadded_height * air.total_width;
+            let main_padding_cells = padding_height * air.total_width;
+            if air.need_rot {
                 counts.main_unpadded_with_rot += main_unpadded_cells;
                 counts.main_padding_with_rot += main_padding_cells;
             } else {
                 counts.main_unpadded_no_rot += main_unpadded_cells;
                 counts.main_padding_no_rot += main_padding_cells;
             }
-            counts.interaction_cells_unpadded += unpadded_height * interactions;
-            counts.interaction_cells_padding += padding_height * interactions;
+            counts.interaction_cells_unpadded += unpadded_height * air.interactions;
+            counts.interaction_cells_padding += padding_height * air.interactions;
         }
         counts
     }
@@ -302,23 +323,35 @@ impl SegmentationCtx {
         let mut main_cnt_no_rot = 0;
         let mut stacked_slice_cells = 0;
         let mut interaction_cells = 0;
-        for ((((&height, &total_width), &stacked_main_width), &interactions), &need_rot) in
-            trace_heights
-                .iter()
-                .zip(self.params.total_widths.iter())
-                .zip(self.params.stacked_main_widths.iter())
-                .zip(self.params.interactions.iter())
-                .zip(self.params.need_rot.iter())
-        {
-            let padded_height = next_power_of_two_or_zero(height as usize);
-            let main_cells = padded_height * total_width;
-            stacked_slice_cells += self.stacked_slice_cells(padded_height, stacked_main_width);
-            if need_rot {
+        let airs = itertools::izip!(
+            trace_heights,
+            &self.params.total_widths,
+            &self.params.stacked_main_widths,
+            &self.params.interactions,
+            &self.params.need_rot,
+        )
+        .map(
+            |(&height, &total_width, &stacked_main_width, &interactions, &need_rot)| {
+                AirMeteringParams {
+                    height,
+                    total_width,
+                    stacked_main_width,
+                    interactions,
+                    need_rot,
+                }
+            },
+        );
+
+        for air in airs {
+            let padded_height = next_power_of_two_or_zero(air.height as usize);
+            let main_cells = padded_height * air.total_width;
+            stacked_slice_cells += self.stacked_slice_cells(padded_height, air.stacked_main_width);
+            if air.need_rot {
                 main_cnt_with_rot += main_cells;
             } else {
                 main_cnt_no_rot += main_cells;
             }
-            interaction_cells += padded_height * interactions;
+            interaction_cells += padded_height * air.interactions;
         }
         (
             main_cnt_with_rot,
@@ -431,25 +464,27 @@ impl SegmentationCtx {
         let mut main_cnt_no_rot = 0usize;
         let mut stacked_slice_cells = 0usize;
         let mut interaction_cells = 0usize;
-        for (
-            i,
-            (
-                (
-                    (((padded_height, &total_width), &stacked_main_width), &interactions),
-                    is_constant,
-                ),
-                &need_rot,
-            ),
-        ) in trace_heights
-            .iter()
-            .map(|&height| next_power_of_two_or_zero(height as usize) as u32)
-            .zip(self.params.total_widths.iter())
-            .zip(self.params.stacked_main_widths.iter())
-            .zip(self.params.interactions.iter())
-            .zip(is_trace_height_constant.iter())
-            .zip(self.params.need_rot.iter())
-            .enumerate()
-        {
+        let airs = itertools::izip!(
+            trace_heights,
+            &self.params.total_widths,
+            &self.params.stacked_main_widths,
+            &self.params.interactions,
+            &self.params.need_rot,
+        )
+        .map(
+            |(&height, &total_width, &stacked_main_width, &interactions, &need_rot)| {
+                AirMeteringParams {
+                    height,
+                    total_width,
+                    stacked_main_width,
+                    interactions,
+                    need_rot,
+                }
+            },
+        );
+
+        for (i, (air, &is_constant)) in airs.zip(is_trace_height_constant).enumerate() {
+            let padded_height = next_power_of_two_or_zero(air.height as usize) as u32;
             // Only segment if the height is not constant and exceeds the maximum height after
             // padding
             if !is_constant && padded_height > self.params.max_trace_height {
@@ -467,15 +502,15 @@ impl SegmentationCtx {
                     air_id: i,
                 });
             }
-            let main_cells = padded_height as usize * total_width;
+            let main_cells = padded_height as usize * air.total_width;
             stacked_slice_cells +=
-                self.stacked_slice_cells(padded_height as usize, stacked_main_width);
-            if need_rot {
+                self.stacked_slice_cells(padded_height as usize, air.stacked_main_width);
+            if air.need_rot {
                 main_cnt_with_rot += main_cells;
             } else {
                 main_cnt_no_rot += main_cells;
             }
-            interaction_cells += padded_height as usize * interactions;
+            interaction_cells += padded_height as usize * air.interactions;
         }
 
         let (total_memory, main_memory, interaction_memory) = self.counts_to_memory(
@@ -732,14 +767,15 @@ impl SegmentationCtx {
     fn emit_metered_air_metrics(&self, segment: &str, trace_heights: &[u32]) {
         let memory_config = self.params.memory_config;
 
-        for (air_id, ((((&height, &total_width), &interactions), &need_rot), air_name)) in
-            trace_heights
-                .iter()
-                .zip(self.params.total_widths.iter())
-                .zip(self.params.interactions.iter())
-                .zip(self.params.need_rot.iter())
-                .zip(self.params.air_names.iter())
-                .enumerate()
+        for (air_id, (&height, &total_width, &interactions, &need_rot, air_name)) in
+            itertools::izip!(
+                trace_heights,
+                &self.params.total_widths,
+                &self.params.interactions,
+                &self.params.need_rot,
+                &self.params.air_names,
+            )
+            .enumerate()
         {
             let padded_height = next_power_of_two_or_zero(height as usize);
             let unpadded_height = height as usize;

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -29,7 +29,7 @@ pub struct SegmentationLimits {
 struct SegmentationParams {
     air_names: Vec<String>,
     total_widths: Vec<usize>,
-    stacked_main_widths: Vec<usize>,
+    common_main_widths: Vec<usize>,
     interactions: Vec<usize>,
     need_rot: Vec<bool>,
     max_trace_height: u32,
@@ -43,14 +43,14 @@ impl SegmentationParams {
     fn new(
         air_names: Vec<String>,
         total_widths: Vec<usize>,
-        stacked_main_widths: Vec<usize>,
+        common_main_widths: Vec<usize>,
         interactions: Vec<usize>,
         need_rot: Vec<bool>,
         limits: SegmentationLimits,
         memory_config: ProvingMemoryConfig,
     ) -> Self {
         assert_eq!(air_names.len(), total_widths.len());
-        assert_eq!(air_names.len(), stacked_main_widths.len());
+        assert_eq!(air_names.len(), common_main_widths.len());
         assert_eq!(air_names.len(), interactions.len());
         assert_eq!(air_names.len(), need_rot.len());
         assert!(
@@ -70,7 +70,7 @@ impl SegmentationParams {
         Self {
             air_names,
             total_widths,
-            stacked_main_widths,
+            common_main_widths,
             interactions,
             need_rot,
             max_trace_height,
@@ -86,10 +86,10 @@ impl SegmentationParams {
 struct AirMeteringParams {
     /// Current trace height for this AIR.
     height: u32,
-    /// All main trace columns, used for total main trace memory.
+    /// Full trace width, including common main, cached, and preprocessed columns.
     total_width: usize,
-    /// Main columns retained in the stacked matrix estimate.
-    stacked_main_width: usize,
+    /// Common main columns retained in the stacked matrix estimate.
+    common_main_width: usize,
     /// Row-interaction slots per row.
     interactions: usize,
     /// Whether main trace memory includes next-row rotation overhead.
@@ -164,7 +164,7 @@ impl SegmentationCtx {
     pub fn new(
         air_names: Vec<String>,
         total_widths: Vec<usize>,
-        stacked_main_widths: Vec<usize>,
+        common_main_widths: Vec<usize>,
         interactions: Vec<usize>,
         need_rot: Vec<bool>,
         limits: SegmentationLimits,
@@ -174,7 +174,7 @@ impl SegmentationCtx {
         let params = SegmentationParams::new(
             air_names,
             total_widths,
-            stacked_main_widths,
+            common_main_widths,
             interactions,
             need_rot,
             limits,
@@ -261,12 +261,12 @@ impl SegmentationCtx {
         self.params.memory_config.stacked_slice_height(height) * width
     }
 
-    /// Sum padded main trace cells, main columns included in the stacked-matrix estimate, and
+    /// Sum padded main trace cells, common main cells included in the stacked-matrix estimate, and
     /// interaction cells across all chips, splitting main cells by per-AIR `need_rot`.
     #[inline(always)]
     fn calculate_count_breakdown(&self, trace_heights: &[u32]) -> MeteredCounts {
         debug_assert_eq!(trace_heights.len(), self.params.total_widths.len());
-        debug_assert_eq!(trace_heights.len(), self.params.stacked_main_widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.common_main_widths.len());
         debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
@@ -274,16 +274,16 @@ impl SegmentationCtx {
         let airs = izip!(
             trace_heights,
             &self.params.total_widths,
-            &self.params.stacked_main_widths,
+            &self.params.common_main_widths,
             &self.params.interactions,
             &self.params.need_rot,
         )
         .map(
-            |(&height, &total_width, &stacked_main_width, &interactions, &need_rot)| {
+            |(&height, &total_width, &common_main_width, &interactions, &need_rot)| {
                 AirMeteringParams {
                     height,
                     total_width,
-                    stacked_main_width,
+                    common_main_width,
                     interactions,
                     need_rot,
                 }
@@ -297,10 +297,10 @@ impl SegmentationCtx {
             counts.unpadded_rows += unpadded_height;
             counts.padding_rows += padding_height;
             counts.stacked_unpadded_slice_cells +=
-                self.stacked_slice_cells(unpadded_height, air.stacked_main_width);
+                self.stacked_slice_cells(unpadded_height, air.common_main_width);
             counts.stacked_padded_slice_cells += self
-                .stacked_slice_cells(padded_height, air.stacked_main_width)
-                - self.stacked_slice_cells(unpadded_height, air.stacked_main_width);
+                .stacked_slice_cells(padded_height, air.common_main_width)
+                - self.stacked_slice_cells(unpadded_height, air.common_main_width);
             let main_unpadded_cells = unpadded_height * air.total_width;
             let main_padding_cells = padding_height * air.total_width;
             if air.need_rot {
@@ -316,12 +316,12 @@ impl SegmentationCtx {
         counts
     }
 
-    /// Sum padded main trace cells, main columns included in the stacked-matrix estimate, and
+    /// Sum padded main trace cells, common main cells included in the stacked-matrix estimate, and
     /// interaction cells across all chips, splitting main cells by per-AIR `need_rot`.
     #[inline(always)]
     fn calculate_cell_counts(&self, trace_heights: &[u32]) -> (usize, usize, usize, usize) {
         debug_assert_eq!(trace_heights.len(), self.params.total_widths.len());
-        debug_assert_eq!(trace_heights.len(), self.params.stacked_main_widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.common_main_widths.len());
         debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
@@ -332,16 +332,16 @@ impl SegmentationCtx {
         let airs = izip!(
             trace_heights,
             &self.params.total_widths,
-            &self.params.stacked_main_widths,
+            &self.params.common_main_widths,
             &self.params.interactions,
             &self.params.need_rot,
         )
         .map(
-            |(&height, &total_width, &stacked_main_width, &interactions, &need_rot)| {
+            |(&height, &total_width, &common_main_width, &interactions, &need_rot)| {
                 AirMeteringParams {
                     height,
                     total_width,
-                    stacked_main_width,
+                    common_main_width,
                     interactions,
                     need_rot,
                 }
@@ -351,7 +351,7 @@ impl SegmentationCtx {
         for air in airs {
             let padded_height = next_power_of_two_or_zero(air.height as usize);
             let main_cells = padded_height * air.total_width;
-            stacked_slice_cells += self.stacked_slice_cells(padded_height, air.stacked_main_width);
+            stacked_slice_cells += self.stacked_slice_cells(padded_height, air.common_main_width);
             if air.need_rot {
                 main_cnt_with_rot += main_cells;
             } else {
@@ -451,7 +451,7 @@ impl SegmentationCtx {
         debug_assert_eq!(trace_heights.len(), is_trace_height_constant.len());
         debug_assert_eq!(trace_heights.len(), self.params.air_names.len());
         debug_assert_eq!(trace_heights.len(), self.params.total_widths.len());
-        debug_assert_eq!(trace_heights.len(), self.params.stacked_main_widths.len());
+        debug_assert_eq!(trace_heights.len(), self.params.common_main_widths.len());
         debug_assert_eq!(trace_heights.len(), self.params.interactions.len());
         debug_assert_eq!(trace_heights.len(), self.params.need_rot.len());
 
@@ -473,16 +473,16 @@ impl SegmentationCtx {
         let airs = izip!(
             trace_heights,
             &self.params.total_widths,
-            &self.params.stacked_main_widths,
+            &self.params.common_main_widths,
             &self.params.interactions,
             &self.params.need_rot,
         )
         .map(
-            |(&height, &total_width, &stacked_main_width, &interactions, &need_rot)| {
+            |(&height, &total_width, &common_main_width, &interactions, &need_rot)| {
                 AirMeteringParams {
                     height,
                     total_width,
-                    stacked_main_width,
+                    common_main_width,
                     interactions,
                     need_rot,
                 }
@@ -510,7 +510,7 @@ impl SegmentationCtx {
             }
             let main_cells = padded_height as usize * air.total_width;
             stacked_slice_cells +=
-                self.stacked_slice_cells(padded_height as usize, air.stacked_main_width);
+                self.stacked_slice_cells(padded_height as usize, air.common_main_width);
             if air.need_rot {
                 main_cnt_with_rot += main_cells;
             } else {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -861,7 +861,7 @@ where
             mut constant_trace_heights,
             air_names,
             total_widths,
-            stacked_main_widths,
+            common_main_widths,
             interactions,
             need_rot,
         ): (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = self
@@ -914,7 +914,7 @@ where
                 constant_trace_heights: &constant_trace_heights,
                 air_names: &air_names,
                 total_widths: &total_widths,
-                stacked_main_widths: &stacked_main_widths,
+                common_main_widths: &common_main_widths,
                 interactions: &interactions,
                 need_rot: &need_rot,
                 segmentation_limits: SegmentationLimits {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -857,26 +857,29 @@ where
     {
         let program_len = exe.program.num_defined_instructions();
 
-        let (mut constant_trace_heights, air_names, widths, interactions, need_rot): (
-            Vec<_>,
-            Vec<_>,
-            Vec<_>,
-            Vec<_>,
-            Vec<_>,
-        ) = self
+        let (
+            mut constant_trace_heights,
+            air_names,
+            total_widths,
+            stacked_main_widths,
+            interactions,
+            need_rot,
+        ): (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = self
             .pk
             .per_air
             .iter()
             .map(|pk| {
                 let constant_trace_height = pk.preprocessed_data.as_ref().map(|cd| cd.height());
                 let air_names = pk.air_name.clone();
-                let width = pk.vk.params.width.total_width();
+                let width = &pk.vk.params.width;
+                // The retained stacked matrix only stores the common main columns.
                 let num_interactions = pk.vk.symbolic_constraints.interactions.len();
                 let need_rot = pk.vk.params.need_rot;
                 (
                     constant_trace_height,
                     air_names,
-                    width,
+                    width.total_width(),
+                    width.common_main,
                     num_interactions,
                     need_rot,
                 )
@@ -910,7 +913,8 @@ where
             MeteredCtxInputs {
                 constant_trace_heights: &constant_trace_heights,
                 air_names: &air_names,
-                widths: &widths,
+                total_widths: &total_widths,
+                stacked_main_widths: &stacked_main_widths,
                 interactions: &interactions,
                 need_rot: &need_rot,
                 segmentation_limits: SegmentationLimits {


### PR DESCRIPTION
## Summary

Updates OpenVM metered segmentation so its memory estimate matches the current stark-backend metering API from openvm-org/stark-backend#367.

The estimate now:

- tracks total width and common-main width separately for each AIR
- uses total width for main trace cell counts, so common main, cached, and preprocessed columns contribute to the main trace estimate
- uses common-main width for retained stacked-matrix cells, so retained prover memory follows the common-main matrix shape used by the backend
- passes `main_stacked_cells` through `ProvingMemoryCounts::new_with_stacked_cells(...)`
- refreshes the lockfile to the merged `stark-backend/develop-v2` fix

The backend still owns the CUDA retained commitment, WHIR, and fractional-GKR memory details. This PR only changes the OpenVM-side counts that are passed into that backend estimator.

## Estimate Shape

For each AIR, metering now keeps two widths:

```text
total_width       = width.total_width()
common_main_width = width.common_main
```

Total main trace cells use the full width:

```text
padded_height = next_power_of_two_or_zero(height)
main_cells    = padded_height * total_width

if need_rot {
    main_cells_with_rot += main_cells
} else {
    main_cells_without_rot += main_cells
}
```

Retained stacked-matrix cells use only the common-main width and the backend stacking shape:

```text
stacked_slice_cells = stacked_slice_height(padded_height) * common_main_width
main_stacked_cells  = stacked_matrix_cells(sum(stacked_slice_cells))
```

Interactions keep the existing per-row slot count:

```text
interaction_cells += padded_height * num_interactions
```

The segment memory estimate is then delegated to stark-backend:

```text
estimate = ProvingMemoryCounts::new_with_stacked_cells(
    main_cells_with_rot,
    main_cells_without_rot,
    main_stacked_cells,
    interaction_cells,
)
```

The same split is used for unpadded versus padded metric reporting, so padding bytes include both total main trace padding and stacked-matrix padding under the backend estimator.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `RUSTC_WRAPPER= cargo metadata --locked --no-deps --format-version 1`
- `RUSTC_WRAPPER= cargo build --profile fast -p openvm-circuit`