### PR TITLE
chore: update word size or limb related comments in rvr

### DIFF
--- a/crates/rvr/rvr-openvm-lift/src/opcode.rs
+++ b/crates/rvr/rvr-openvm-lift/src/opcode.rs
@@ -359,8 +359,6 @@ fn lift_muldiv<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: MulDivOp) ->
     body(pc, Instr::MulDiv { op, rd, rs1, rs2 })
 }
 
-/// Lift load instruction.
-/// OpenVM encoding: rd=a/4, rs1=b/4, imm low16=c, sign=g!=0
 #[inline]
 fn is_memory_instruction<F: PrimeField32>(insn: &Instruction<F>) -> bool {
     field_to_u32(insn.d) == AS_REGISTER && field_to_u32(insn.e) == AS_MEMORY
@@ -383,6 +381,8 @@ fn lift_public_values_store<F: PrimeField32>(
     }
 }
 
+/// Lift load instruction.
+/// OpenVM encoding: rd=a/8, rs1=b/8, imm low16=c, sign=g!=0
 fn lift_load<F: PrimeField32>(
     insn: &Instruction<F>,
     pc: u64,
@@ -413,7 +413,7 @@ fn lift_load<F: PrimeField32>(
 }
 
 /// Lift store instruction.
-/// OpenVM encoding: rs2=a/4, rs1=b/4, imm low16=c, sign=g!=0
+/// OpenVM encoding: rs2=a/8, rs1=b/8, imm low16=c, sign=g!=0
 fn lift_store<F: PrimeField32>(
     insn: &Instruction<F>,
     pc: u64,
@@ -439,7 +439,7 @@ fn lift_store<F: PrimeField32>(
 }
 
 /// Lift branch instruction.
-/// OpenVM encoding: rs1=a/4, rs2=b/4, offset=c as signed (BabyBear modular)
+/// OpenVM encoding: rs1=a/8, rs2=b/8, offset=c as signed (BabyBear modular)
 fn lift_branch<F: PrimeField32>(insn: &Instruction<F>, pc: u64, cond: BranchCond) -> LiftedInstr {
     let rs1 = decode_reg(insn.a);
     let rs2 = decode_reg(insn.b);
@@ -458,7 +458,7 @@ fn lift_branch<F: PrimeField32>(insn: &Instruction<F>, pc: u64, cond: BranchCond
 }
 
 /// Lift JAL instruction.
-/// OpenVM encoding: rd=a/4, offset=c as signed (BabyBear modular)
+/// OpenVM encoding: rd=a/8, offset=c as signed (BabyBear modular)
 fn lift_jal<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let offset = field_to_i32(insn.c);
@@ -469,7 +469,7 @@ fn lift_jal<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
 }
 
 /// Lift JALR instruction.
-/// OpenVM encoding: rd=a/4, rs1=b/4, imm low16=c, sign=g!=0
+/// OpenVM encoding: rd=a/8, rs1=b/8, imm low16=c, sign=g!=0
 fn lift_jalr<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
@@ -488,7 +488,7 @@ fn lift_jalr<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
 }
 
 /// Lift LUI instruction.
-/// OpenVM encoding: rd=a/4, upper20=c << 12
+/// OpenVM encoding: rd=a/8, upper20=c << 12
 fn lift_lui<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let upper = field_to_u32(insn.c);
@@ -501,7 +501,7 @@ fn lift_lui<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
 }
 
 /// Lift AUIPC instruction.
-/// OpenVM encoding: rd=a/4, upper20 = c << 8 (from rrs.rs: c = (imm & 0xfffff000) >> 8)
+/// OpenVM encoding: rd=a/8, upper20 = c << 8 (from rrs.rs: c = (imm & 0xfffff000) >> 8)
 fn lift_auipc<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let shifted = field_to_u32(insn.c);

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -140,7 +140,7 @@ static __attribute__((always_inline)) inline int32_t rd_mem_i32(
 
 static __attribute__((always_inline)) inline uint32_t rd_mem_u32(
     uint8_t* restrict memory, uint32_t addr) {
-  /* TODO(rvr): handle unaligned RV32 word load/store semantics in opcode
+  /* TODO(rvr): handle unaligned 32-bit load/store semantics in opcode
    * codegen if needed; this generic helper assumes aligned callers. */
   check_mem_bounds_u32(addr);
   uint32_t v;
@@ -175,7 +175,7 @@ static __attribute__((always_inline)) inline void wr_mem_u16(
 
 static __attribute__((always_inline)) inline void wr_mem_u32(
     uint8_t* restrict memory, uint32_t addr, uint32_t val) {
-  /* TODO(rvr): handle unaligned RV32 word load/store semantics in opcode
+  /* TODO(rvr): handle unaligned word 32-bit load/store semantics in opcode
    * codegen if needed; this generic helper assumes aligned callers. */
   check_mem_bounds_u32(addr);
   void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(val));
@@ -242,7 +242,8 @@ static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
     RvState* restrict state, uint32_t base_addr, const uint64_t* vals,
     uint32_t num_words);
 
-/* Per-width traced reads widen to 32 bits. */
+/* Per-width traced reads return a 32-bit C type; callers widen to uint64_t at
+ * register assignment via C implicit promotion. */
 static __attribute__((always_inline)) inline uint32_t rd_mem_u8_traced(
     RvState* restrict state, uint32_t addr) {
   uint8_t v = rd_mem_u8(state->memory, addr);

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -175,7 +175,7 @@ static __attribute__((always_inline)) inline void wr_mem_u16(
 
 static __attribute__((always_inline)) inline void wr_mem_u32(
     uint8_t* restrict memory, uint32_t addr, uint32_t val) {
-  /* TODO(rvr): handle unaligned word 32-bit load/store semantics in opcode
+  /* TODO(rvr): handle unaligned 32-bit load/store semantics in opcode
    * codegen if needed; this generic helper assumes aligned callers. */
   check_mem_bounds_u32(addr);
   void* p = __builtin_assume_aligned(mem_ptr(memory, addr), sizeof(val));

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -94,7 +94,7 @@ unsafe fn register_openvm_io_ctx<F: PrimeField32>(
 /// # Safety
 ///
 /// - `compiled` must contain a valid rvr-compiled shared library exporting the `rv_execute` symbol.
-/// - `state_ptr` must point to a valid, mutable RV32 state struct whose tracer variant matches the
+/// - `state_ptr` must point to a valid, mutable RvState struct whose tracer variant matches the
 ///   one compiled into the shared library.
 pub unsafe fn rv_execute(
     compiled: &RvrCompiled,

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -94,8 +94,8 @@ unsafe fn register_openvm_io_ctx<F: PrimeField32>(
 /// # Safety
 ///
 /// - `compiled` must contain a valid rvr-compiled shared library exporting the `rv_execute` symbol.
-/// - `state_ptr` must point to a valid, mutable RvState struct whose tracer variant matches the
-///   one compiled into the shared library.
+/// - `state_ptr` must point to a valid, mutable RvState struct whose tracer variant matches the one
+///   compiled into the shared library.
 pub unsafe fn rv_execute(
     compiled: &RvrCompiled,
     state_ptr: *mut c_void,

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -158,7 +158,7 @@ impl ExtInstr for PrintStrInstr {
     }
 }
 
-/// HINT_RANDOM phantom: fill the hint stream with `reg[num_words_reg] * 4`
+/// HINT_RANDOM phantom: fill the hint stream with `reg[num_words_reg] * 8`
 /// random bytes drawn from the host's persistent RNG.
 #[derive(Debug, Clone)]
 pub struct HintRandomInstr {


### PR DESCRIPTION
Update word size or limb related comments in rvr. Since rvr was originally made for rv32, there are comments that still refer in 4 bytes.

Changes:
1) Update OpenVM encoding related comments to use 8 bytes
2) Remove RV32 and 32-bit word size related comments in rvr
3) Update HINT_RANDOM phantom instruction description to fill the hint stream with 8 instead of 4 multiplied by `reg[num_words_reg]`

resolves INT-8322