### PR TITLE
feat: config for deferral-aware but not active SDK

### DIFF
--- a/crates/continuations/src/circuit/inner/unset/trace.rs
+++ b/crates/continuations/src/circuit/inner/unset/trace.rs
@@ -30,5 +30,11 @@ pub fn generate_proving_ctx(
         cols.proof_idx = F::from_usize(*proof_idx);
     }
 
+    for proof_idx in num_valid..height {
+        let chunk = chunks.next().unwrap();
+        let cols: &mut UnsetPvsCols<F> = chunk.borrow_mut();
+        cols.proof_idx = F::from_usize(proof_idx);
+    }
+
     AirProvingContext::simple_no_pis(RowMajorMatrix::new(trace, width))
 }

--- a/crates/sdk/src/builder.rs
+++ b/crates/sdk/src/builder.rs
@@ -27,8 +27,8 @@ use {
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig},
     keygen::{AggProvingKey, AppProvingKey, SdkCachedProvingKey},
-    prover::{AggProver, DeferralAggProver, MultiDeferralCircuitProver},
-    GenericSdk, SdkError, F, SC,
+    prover::{AggProver, DeferralAggProver, DeferralHookCommits, MultiDeferralCircuitProver},
+    DeferralSetup, GenericSdk, SdkError, F, SC,
 };
 
 enum AppSource<VC> {
@@ -44,6 +44,7 @@ enum AggSource {
 
 #[allow(clippy::large_enum_variant)]
 enum DeferralSource {
+    HookCommits(DeferralHookCommits),
     MultiCircuitProver(MultiDeferralCircuitProver),
     AggProver(DeferralAggProver),
 }
@@ -359,22 +360,22 @@ where
             .map_err(|e| SdkError::Vm(e.into()))?;
         let agg_tree_config = agg_tree_config.unwrap_or_default();
 
-        let def_agg_prover = match deferral_source {
-            Some(DeferralSource::MultiCircuitProver(multi_deferral_circuit_prover)) => Some(
-                Self::build_deferral_agg_prover(&agg_config, multi_deferral_circuit_prover),
-            ),
-            Some(DeferralSource::AggProver(deferral_agg_prover)) => {
-                Some(Arc::new(deferral_agg_prover))
+        let deferral_setup = match deferral_source {
+            Some(DeferralSource::HookCommits(commits)) => DeferralSetup::Aware(commits),
+            Some(DeferralSource::MultiCircuitProver(multi_deferral_circuit_prover)) => {
+                DeferralSetup::Active(Self::build_deferral_agg_prover(
+                    &agg_config,
+                    multi_deferral_circuit_prover,
+                ))
             }
-            None => None,
+            Some(DeferralSource::AggProver(deferral_agg_prover)) => {
+                DeferralSetup::Active(Arc::new(deferral_agg_prover))
+            }
+            None => DeferralSetup::Disabled,
         };
-        let def_hook_cached_commit = def_agg_prover
-            .as_ref()
-            .map(|def_agg_prover| def_agg_prover.def_hook_cached_commit());
+        let def_hook_cached_commit = deferral_setup.hook_cached_commit();
         #[cfg(feature = "root-prover")]
-        let def_hook_commit = def_agg_prover
-            .as_ref()
-            .map(|def_agg_prover| def_agg_prover.def_hook_commit());
+        let def_hook_commit = deferral_setup.hook_commit();
 
         let app_vm_vk = app_pk_seed
             .as_ref()
@@ -443,7 +444,7 @@ where
             agg_prover: Self::init_once_lock(agg_prover_seed, "agg_prover"),
             #[cfg(feature = "root-prover")]
             root_prover: Self::init_once_lock(root_prover_seed, "root_prover"),
-            def_agg_prover,
+            deferral_setup,
             #[cfg(feature = "evm-prove")]
             halo2_params_reader,
             #[cfg(feature = "evm-prove")]
@@ -468,10 +469,27 @@ where
         self.build_without_transpiler()
     }
 
+    /// Enables deferral-aware aggregation without configuring a prover for non-empty deferral
+    /// inputs.
+    ///
+    /// This is mutually exclusive with [`Self::multi_deferral_circuit_prover`] and
+    /// [`Self::deferral_agg_prover`].
+    pub fn deferral_hook_commits(mut self, commits: DeferralHookCommits) -> Self {
+        Self::set_once(
+            &mut self.deferral_source,
+            "deferral_source",
+            DeferralSource::HookCommits(commits),
+        );
+        self
+    }
+
     /// Enables deferrals in this SDK build. The [`MultiDeferralCircuitProver`] must be created
     /// ahead of time because the [`openvm_sdk_config::deferral::DeferralConfig`] should be created
     /// using [`MultiDeferralCircuitProver::make_config`], which generates the `def_circuit_commits`
     /// needed by the VM config.
+    ///
+    /// This is mutually exclusive with [`Self::deferral_hook_commits`] and
+    /// [`Self::deferral_agg_prover`].
     pub fn multi_deferral_circuit_prover(
         mut self,
         multi_deferral_circuit_prover: MultiDeferralCircuitProver,
@@ -486,9 +504,9 @@ where
 
     /// Enables deferrals in this SDK build using a pre-built [`DeferralAggProver`].
     ///
-    /// This is mutually exclusive with [`Self::multi_deferral_circuit_prover`]. Use this when the
-    /// deferral aggregation path has already been constructed, for example by
-    /// [`DeferralAggProver::verify_stark`].
+    /// This is mutually exclusive with [`Self::deferral_hook_commits`] and
+    /// [`Self::multi_deferral_circuit_prover`]. Use this when the deferral aggregation path
+    /// has already been constructed, for example by [`DeferralAggProver::verify_stark`].
     pub fn deferral_agg_prover(mut self, deferral_agg_prover: DeferralAggProver) -> Self {
         Self::set_once(
             &mut self.deferral_source,

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -5,31 +5,41 @@ use openvm_circuit::arch::{
     instructions::{
         exe::VmExe, instruction::Instruction, program::Program, LocalOpcode, SystemOpcode,
     },
-    Executor, MeteredExecutor, PreflightExecutor, SystemConfig, VmBuilder, VmExecutionConfig,
+    SystemConfig,
 };
 use openvm_continuations::{prover::engine_device_ctx, RootSC};
+use openvm_sdk_config::SdkVmBuilder;
 use openvm_stark_backend::{
-    keygen::types::MultiStarkProvingKey, p3_field::PrimeField32, prover::ProvingContext,
-    StarkEngine, SystemParams, Val,
+    keygen::types::MultiStarkProvingKey, prover::ProvingContext, StarkEngine, SystemParams,
 };
+use openvm_stark_sdk::config::{app_params_with_100_bits_security, MAX_APP_LOG_STACKED_HEIGHT};
 #[cfg(feature = "evm-prove")]
 use {
-    crate::prover::{EvmProver, RootProver},
-    openvm_stark_backend::proof::Proof,
+    crate::{
+        prover::{vm::types::VmProvingKey, EvmProver, RootProver},
+        SC,
+    },
+    openvm_circuit::arch::{
+        Executor, MeteredExecutor, PreflightExecutor, VmBuilder, VmExecutionConfig,
+    },
+    openvm_stark_backend::{p3_field::PrimeField32, proof::Proof, Val},
 };
 
 use crate::{
-    prover::{vm::types::VmProvingKey, AggProver, DeferralAggProver, StarkProver},
-    StdIn, F, SC,
+    config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig},
+    keygen::AppProvingKey,
+    prover::{AggProver, StarkProver},
+    DeferralSetup, StdIn, F,
 };
+
+type CpuRootE =
+    openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
-        use openvm_continuations::prover::RootGpuProver as RootInnerProver;
-        type RootE = openvm_cuda_backend::BabyBearBn254Poseidon2GpuEngine;
+        type ChildE = openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
     } else {
-        use openvm_continuations::prover::RootCpuProver as RootInnerProver;
-        type RootE = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
+        type ChildE = openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2CpuEngine;
     }
 }
 
@@ -45,40 +55,45 @@ fn dummy_terminate_exe() -> Arc<VmExe<F>> {
     Arc::new(VmExe::new(dummy_program))
 }
 
-pub fn compute_root_proof_heights<E, VB>(
-    vm_builder: VB,
-    app_vm_pk: &VmProvingKey<VB::VmConfig>,
-    agg_prover: Arc<AggProver>,
+pub(crate) fn compute_root_proof_heights(
+    system_config: SystemConfig,
+    agg_params: AggregationSystemParams,
+    agg_tree_config: AggregationTreeConfig,
     root_params: SystemParams,
-    def_prover: Option<Arc<DeferralAggProver>>,
-) -> Result<(Vec<usize>, Arc<MultiStarkProvingKey<RootSC>>)>
-where
-    E: StarkEngine<SC = SC>,
-    VB: VmBuilder<E>,
-    VB::VmConfig: VmExecutionConfig<F> + AsRef<SystemConfig>,
-    Val<SC>: PrimeField32,
-    <VB::VmConfig as VmExecutionConfig<F>>::Executor:
-        Executor<F> + MeteredExecutor<F> + PreflightExecutor<F, VB::RecordArena>,
-{
+    deferral_setup: DeferralSetup,
+) -> Result<(Vec<usize>, Arc<MultiStarkProvingKey<RootSC>>)> {
     let dummy_exe = dummy_terminate_exe();
 
-    let system_config = app_vm_pk.vm_config.as_ref();
     let memory_dimensions = system_config.memory_config.memory_dimensions();
     let num_user_pvs = system_config.num_public_values;
 
-    let def_hook_commit = def_prover.as_ref().map(|p| p.def_hook_commit().into());
+    let mut app_config = AppConfig::riscv32(app_params_with_100_bits_security(
+        MAX_APP_LOG_STACKED_HEIGHT,
+    ));
+    app_config.app_vm_config.system.config = system_config;
 
-    let mut stark_prover = StarkProver::<E, VB>::new(
-        vm_builder,
-        app_vm_pk,
+    let def_hook_cached_commit = deferral_setup.hook_cached_commit();
+    let def_hook_commit = deferral_setup.hook_commit().map(Into::into);
+
+    let app_pk = AppProvingKey::keygen(app_config)?;
+
+    let agg_prover = Arc::new(AggProver::new(
+        Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()),
+        AggregationConfig { params: agg_params },
+        agg_tree_config,
+        def_hook_cached_commit,
+    ));
+
+    let mut stark_prover = StarkProver::<ChildE, SdkVmBuilder>::new(
+        Default::default(),
+        &app_pk.app_vm_pk,
         dummy_exe,
         agg_prover.clone(),
-        def_prover,
+        deferral_setup,
     )?;
-    stark_prover.set_program_name("root_keygen");
     let (agg_proof, _) = stark_prover.prove(StdIn::default(), &[])?;
 
-    let root_prover = RootInnerProver::new::<RootE>(
+    let root_prover = openvm_continuations::prover::RootCpuProver::new::<CpuRootE>(
         agg_prover.internal_recursive_prover.get_vk(),
         agg_prover
             .internal_recursive_prover
@@ -92,9 +107,8 @@ where
         def_hook_commit,
         None,
     );
-
-    let engine = root_prover.create_engine::<RootE>();
-    let root_proving_ctx: ProvingContext<<RootE as StarkEngine>::PB> = root_prover
+    let engine = root_prover.create_engine::<CpuRootE>();
+    let root_proving_ctx: ProvingContext<<CpuRootE as StarkEngine>::PB> = root_prover
         .generate_proving_ctx(
             agg_proof.inner,
             &agg_proof.user_pvs_proof,
@@ -119,7 +133,7 @@ pub fn generate_dummy_root_proof<E, VB>(
     vm_builder: VB,
     app_vm_pk: &VmProvingKey<VB::VmConfig>,
     agg_prover: Arc<AggProver>,
-    def_agg_prover: Option<Arc<DeferralAggProver>>,
+    deferral_setup: DeferralSetup,
     root_prover: Arc<RootProver>,
 ) -> Proof<RootSC>
 where
@@ -136,7 +150,7 @@ where
         app_vm_pk,
         dummy_exe,
         agg_prover,
-        def_agg_prover,
+        deferral_setup,
         root_prover,
         None,
     )

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -91,6 +91,7 @@ pub(crate) fn compute_root_proof_heights(
         agg_prover.clone(),
         deferral_setup,
     )?;
+    stark_prover.set_program_name("root_keygen");
     let (agg_proof, _) = stark_prover.prove(StdIn::default(), &[])?;
 
     let root_prover = openvm_continuations::prover::RootCpuProver::new::<CpuRootE>(

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -45,7 +45,7 @@ use openvm_verify_stark_host::{
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
     keygen::{AggPrefixProvingKey, AggProvingKey, SdkCachedProvingKey},
-    prover::{AggProver, AppProver, DeferralAggProver, StarkProver},
+    prover::{AggProver, AppProver, DeferralAggProver, DeferralHookCommits, StarkProver},
     types::{AppExecutionCommit, ExecutableFormat},
 };
 #[cfg(feature = "evm-prove")]
@@ -152,7 +152,7 @@ where
     #[cfg(feature = "root-prover")]
     root_prover: OnceLock<Arc<RootProver>>,
 
-    def_agg_prover: Option<Arc<DeferralAggProver>>,
+    deferral_setup: DeferralSetup,
 
     #[cfg(feature = "evm-prove")]
     #[getset(get = "pub")]
@@ -161,6 +161,45 @@ where
     halo2_prover: OnceLock<Halo2Prover>,
 
     _phantom: PhantomData<E>,
+}
+
+#[derive(Clone, Default)]
+pub enum DeferralSetup {
+    #[default]
+    /// Deferrals are disabled for this GenericSdk. The STARK, root, and halo2 vks are deferral-
+    /// unaware, and trying to prove with def_inputs set causes an error.
+    Disabled,
+    /// The STARK, root, and halo2 vks are deferral-aware (i.e. are equivalent to Active), but
+    /// trying to prove with def_inputs set still causes an error.
+    Aware(DeferralHookCommits),
+    /// The STARK, root, and halo2 vks are deferral-aware (i.e. are equivalent to Aware), and
+    /// deferral inputs can be used and proved.
+    Active(Arc<DeferralAggProver>),
+}
+
+impl DeferralSetup {
+    pub fn hook_cached_commit(&self) -> Option<Digest> {
+        match self {
+            Self::Disabled => None,
+            Self::Aware(commits) => Some(commits.hook_cached_commit),
+            Self::Active(prover) => Some(prover.def_hook_cached_commit()),
+        }
+    }
+
+    pub fn hook_commit(&self) -> Option<Digest> {
+        match self {
+            Self::Disabled => None,
+            Self::Aware(commits) => Some(commits.hook_commit),
+            Self::Active(prover) => Some(prover.def_hook_commit()),
+        }
+    }
+
+    pub fn prover(&self) -> Option<Arc<DeferralAggProver>> {
+        match self {
+            Self::Active(prover) => Some(prover.clone()),
+            Self::Disabled | Self::Aware(_) => None,
+        }
+    }
 }
 
 pub type CpuSdk = GenericSdk<BabyBearPoseidon2Engine, SdkVmCpuBuilder>;
@@ -238,14 +277,17 @@ where
 
     /// Returns the def_hook_prover cached commit.
     pub fn def_hook_cached_commit(&self) -> Option<Digest> {
-        self.def_agg_prover
-            .as_ref()
-            .map(|p| p.def_hook_cached_commit())
+        self.deferral_setup.hook_cached_commit()
     }
 
     /// Returns the deferral hook commit derived from the deferral aggregation path.
     pub fn def_hook_commit(&self) -> Option<Digest> {
-        self.def_agg_prover.as_ref().map(|p| p.def_hook_commit())
+        self.deferral_setup.hook_commit()
+    }
+
+    /// Returns the deferral aggregation prover when this SDK can prove non-empty deferral inputs.
+    pub fn deferral_agg_prover(&self) -> Option<Arc<DeferralAggProver>> {
+        self.deferral_setup.prover()
     }
 
     /// Returns serde-serializable proving keys for this SDK.
@@ -265,6 +307,7 @@ where
             .agg_prover
             .get()
             .ok_or_else(|| SdkError::Other(eyre::eyre!("agg_pk is not generated")))?;
+        let deferral_prover = self.deferral_setup.prover();
         Ok(SdkCachedProvingKey {
             app_pk,
             agg_pk: AggProvingKey {
@@ -274,12 +317,10 @@ where
                 },
                 internal_recursive: agg_prover.internal_recursive_prover.get_pk(),
             },
-            deferral_pk: self
-                .def_agg_prover
+            deferral_pk: deferral_prover
                 .as_ref()
                 .map(|def_agg_prover| def_agg_prover.multi_deferral_circuit_prover.get_pk()),
-            deferral_agg_pk: self
-                .def_agg_prover
+            deferral_agg_pk: deferral_prover
                 .as_ref()
                 .map(|def_agg_prover| def_agg_prover.get_pk()),
             #[cfg(feature = "root-prover")]
@@ -507,7 +548,7 @@ where
             &app_pk.app_vm_pk,
             app_exe,
             self.agg_prover(),
-            self.def_agg_prover.clone(),
+            self.deferral_setup.clone(),
         )?;
         Ok(stark_prover)
     }
@@ -526,7 +567,7 @@ where
             &app_pk.app_vm_pk,
             app_exe,
             self.agg_prover(),
-            self.def_agg_prover.clone(),
+            self.deferral_setup.clone(),
             self.root_prover(),
             #[cfg(feature = "evm-prove")]
             None,
@@ -573,15 +614,14 @@ where
             .get_or_init(|| {
                 let system_config = self.app_config.app_vm_config.as_ref();
                 let root_params = self.root_params.clone();
-                let app_pk = self.app_pk();
                 let agg_prover = self.agg_prover();
 
-                let (trace_heights, root_pk) = compute_root_proof_heights::<E, VB>(
-                    self.app_vm_builder.clone(),
-                    &app_pk.app_vm_pk,
-                    agg_prover.clone(),
+                let (trace_heights, root_pk) = compute_root_proof_heights(
+                    system_config.clone(),
+                    self.agg_config.params.clone(),
+                    self.agg_tree_config,
                     root_params.clone(),
-                    self.def_agg_prover.clone(),
+                    self.deferral_setup.clone(),
                 )
                 .expect("Trace heights did not generate properly");
 
@@ -622,7 +662,7 @@ where
                     self.app_vm_builder.clone(),
                     &self.app_pk().app_vm_pk,
                     agg_prover.clone(),
-                    self.def_agg_prover.clone(),
+                    self.deferral_setup.clone(),
                     root_prover,
                 );
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -170,7 +170,8 @@ pub enum DeferralSetup {
     /// unaware, and trying to prove with def_inputs set causes an error.
     Disabled,
     /// The STARK, root, and halo2 vks are deferral-aware (i.e. are equivalent to Active), but
-    /// trying to prove with def_inputs set still causes an error.
+    /// trying to prove with def_inputs set still causes an error. Use this when a program that
+    /// doesn't use deferrals must be verified by a deferral-aware vk.
     Aware(DeferralHookCommits),
     /// The STARK, root, and halo2 vks are deferral-aware (i.e. are equivalent to Aware), and
     /// deferral inputs can be used and proved.

--- a/crates/sdk/src/prover/deferral/agg.rs
+++ b/crates/sdk/src/prover/deferral/agg.rs
@@ -10,6 +10,7 @@ use openvm_continuations::{
 use openvm_sdk_config::deferral::{DeferralConfig, SupportedDeferral};
 use openvm_stark_backend::{keygen::types::MultiStarkVerifyingKey, proof::Proof, SystemParams};
 use openvm_stark_sdk::config::baby_bear_poseidon2::Digest;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig},
@@ -26,6 +27,21 @@ cfg_if::cfg_if! {
         use openvm_verify_stark_circuit::prover::DeferredVerifyCpuProver as VerifyProver;
         use openvm_verify_stark_circuit::prover::DeferredVerifyCpuCircuitProver as VerifyCircuitProver;
         type E = openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2CpuEngine;
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeferralHookCommits {
+    pub hook_cached_commit: Digest,
+    pub hook_commit: Digest,
+}
+
+impl DeferralHookCommits {
+    pub fn from_system_params(
+        agg_params: &AggregationSystemParams,
+        hook_params: SystemParams,
+    ) -> Self {
+        deferral_hook_artifacts_from_system_params(agg_params, hook_params).commits
     }
 }
 
@@ -182,28 +198,12 @@ impl DeferralAggProver {
         memory_dimensions: MemoryDimensions,
         num_user_pvs: usize,
     ) -> Self {
-        // Derive the deferral path's fixed-point artifacts with a cheap dummy deferral circuit.
-        let dummy = DummyDefCircuitProver {
-            vk: dummy_deferral_circuit_vk::<E>(agg_params.internal.clone()),
-        };
+        let hook_artifacts =
+            deferral_hook_artifacts_from_system_params(agg_params, hook_params.clone());
         let agg_config = AggregationConfig {
             params: agg_params.clone(),
         };
-        let dummy_multi_deferral_circuit_prover =
-            MultiDeferralCircuitProver::new(dummy, agg_config.clone(), hook_params.clone());
-
-        // Construct the deferral-path AggProver, which can aggregate hook proofs from both the
-        // dummy MultiDeferralCircuitProver above and the verify-stark one below.
-        let agg_prover = Arc::new(AggProver::new(
-            dummy_multi_deferral_circuit_prover.def_hook_prover.get_vk(),
-            agg_config.clone(),
-            AggregationTreeConfig::deferral(),
-            Some(
-                dummy_multi_deferral_circuit_prover
-                    .def_hook_prover
-                    .get_cached_commit(),
-            ),
-        ));
+        let agg_prover = hook_artifacts.agg_prover;
 
         // The deferral-path aggregation tree's internal-recursive vk is a universal copy of the VM
         // internal-recursive vk that a verify-stark circuit verifies.
@@ -214,7 +214,6 @@ impl DeferralAggProver {
             .expect("internal-recursive prover must expose its self vk pcs data")
             .commitment
             .into();
-        let def_hook_commit = agg_prover.vm_or_hook_commit();
 
         // Construct the verify-stark MultiDeferralCircuitProver, which should have the same hook vk
         // and cached commit as the dummy one.
@@ -224,7 +223,7 @@ impl DeferralAggProver {
             agg_params.internal.clone(),
             memory_dimensions,
             num_user_pvs,
-            Some(def_hook_commit.into()),
+            Some(hook_artifacts.commits.hook_commit.into()),
             0,
         );
         let verify_stark_prover = VerifyCircuitProver::new(deferred_verify_prover);
@@ -236,18 +235,13 @@ impl DeferralAggProver {
                 .def_hook_prover
                 .get_vk()
                 .pre_hash,
-            dummy_multi_deferral_circuit_prover
-                .def_hook_prover
-                .get_vk()
-                .pre_hash
+            hook_artifacts.hook_vk.pre_hash
         );
         assert_eq!(
             multi_deferral_circuit_prover
                 .def_hook_prover
                 .get_cached_commit(),
-            dummy_multi_deferral_circuit_prover
-                .def_hook_prover
-                .get_cached_commit()
+            hook_artifacts.commits.hook_cached_commit
         );
 
         // Return the deferral-enabled verify-stark DeferralAggProver.
@@ -276,6 +270,44 @@ fn supported_deferral_circuit_prover_from_pk(
         SupportedDeferral::Other(name) => Err(eyre!(
             "custom deferral circuit provers need to be manually created for deferral `{name}`"
         )),
+    }
+}
+
+struct DeferralHookArtifacts {
+    commits: DeferralHookCommits,
+    hook_vk: Arc<MultiStarkVerifyingKey<SC>>,
+    agg_prover: Arc<AggProver>,
+}
+
+fn deferral_hook_artifacts_from_system_params(
+    agg_params: &AggregationSystemParams,
+    hook_params: SystemParams,
+) -> DeferralHookArtifacts {
+    let dummy = DummyDefCircuitProver {
+        vk: dummy_deferral_circuit_vk::<E>(agg_params.internal.clone()),
+    };
+    let agg_config = AggregationConfig {
+        params: agg_params.clone(),
+    };
+    let dummy_multi_deferral_circuit_prover =
+        MultiDeferralCircuitProver::new(dummy, agg_config.clone(), hook_params);
+    let hook_vk = dummy_multi_deferral_circuit_prover.def_hook_prover.get_vk();
+    let hook_cached_commit = dummy_multi_deferral_circuit_prover
+        .def_hook_prover
+        .get_cached_commit();
+    let agg_prover = Arc::new(AggProver::new(
+        hook_vk.clone(),
+        agg_config,
+        AggregationTreeConfig::deferral(),
+        Some(hook_cached_commit),
+    ));
+    DeferralHookArtifacts {
+        commits: DeferralHookCommits {
+            hook_cached_commit,
+            hook_commit: agg_prover.vm_or_hook_commit(),
+        },
+        hook_vk,
+        agg_prover,
     }
 }
 

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -12,11 +12,8 @@ use openvm_verify_stark_host::VmStarkProof;
 #[cfg(feature = "evm-prove")]
 use crate::prover::Halo2Prover;
 use crate::{
-    prover::{
-        vm::types::VmProvingKey, AggProver, DeferralAggProver, InternalLayerMetadata, RootProver,
-        StarkProver,
-    },
-    DeferralInput, StdIn, SC,
+    prover::{vm::types::VmProvingKey, AggProver, InternalLayerMetadata, RootProver, StarkProver},
+    DeferralInput, DeferralSetup, StdIn, SC,
 };
 
 /// EVM prover that produces a root STARK proof with Halo2 wrapping.
@@ -48,12 +45,18 @@ where
         app_vm_pk: &VmProvingKey<VB::VmConfig>,
         app_exe: Arc<VmExe<Val<SC>>>,
         agg_prover: Arc<AggProver>,
-        def_prover: Option<Arc<DeferralAggProver>>,
+        deferral_setup: DeferralSetup,
         root_prover: Arc<RootProver>,
         #[cfg(feature = "evm-prove")] halo2_prover: Option<Halo2Prover>,
     ) -> Result<Self> {
         Ok(Self {
-            stark_prover: StarkProver::new(vm_builder, app_vm_pk, app_exe, agg_prover, def_prover)?,
+            stark_prover: StarkProver::new(
+                vm_builder,
+                app_vm_pk,
+                app_exe,
+                agg_prover,
+                deferral_setup,
+            )?,
             root_prover,
             #[cfg(feature = "evm-prove")]
             halo2_prover,

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -1,52 +1,25 @@
 use std::sync::Arc;
 
 use eyre::Result;
-use openvm_circuit::{
-    arch::{
-        instructions::{
-            exe::VmExe, instruction::Instruction, program::Program, LocalOpcode, SystemOpcode,
-        },
-        SystemConfig,
-    },
-    system::memory::dimensions::MemoryDimensions,
-};
+use openvm_circuit::system::memory::dimensions::MemoryDimensions;
 use openvm_continuations::{prover::engine_device_ctx, CommitBytes, RootSC, SC};
-use openvm_sdk_config::SdkVmBuilder;
 use openvm_stark_backend::{
     keygen::types::{MultiStarkProvingKey, MultiStarkVerifyingKey},
     proof::Proof,
     prover::ProvingContext,
     StarkEngine, SystemParams,
 };
-use openvm_stark_sdk::config::{
-    app_params_with_100_bits_security,
-    baby_bear_poseidon2::{Digest, F},
-    MAX_APP_LOG_STACKED_HEIGHT,
-};
+use openvm_stark_sdk::config::baby_bear_poseidon2::Digest;
 use openvm_verify_stark_host::VmStarkProof;
 use tracing::info_span;
-
-use crate::{
-    config::{AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig},
-    keygen::AppProvingKey,
-    prover::{AggProver, DeferralAggProver, StarkProver},
-    StdIn,
-};
-
-// CPU engine used for `compute_root_proof_heights` — trace heights are structural
-// and backend-independent, so we always use the faster CPU engine for that step.
-type CpuRootE =
-    openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "cuda")] {
         use openvm_continuations::prover::RootGpuProver as RootInnerProver;
         type E = openvm_cuda_backend::BabyBearBn254Poseidon2GpuEngine;
-        type ChildE = openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
     } else {
         use openvm_continuations::prover::RootCpuProver as RootInnerProver;
         type E = openvm_stark_sdk::config::baby_bear_bn254_poseidon2::BabyBearBn254Poseidon2CpuEngine;
-        type ChildE = openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2CpuEngine;
     }
 }
 
@@ -164,83 +137,4 @@ impl RootProver {
 
         self.prove_from_ctx(ctx, engine)
     }
-}
-
-pub fn compute_root_proof_heights(
-    system_config: SystemConfig,
-    agg_params: AggregationSystemParams,
-    agg_tree_config: AggregationTreeConfig,
-    root_params: SystemParams,
-    def_prover: Option<Arc<DeferralAggProver>>,
-) -> Result<Vec<usize>> {
-    let dummy_program = Program::<F>::from_instructions(&[Instruction::from_isize(
-        SystemOpcode::TERMINATE.global_opcode(),
-        0,
-        0,
-        0,
-        0,
-        0,
-    )]);
-    let dummy_exe = Arc::new(VmExe::new(dummy_program));
-
-    let memory_dimensions = system_config.memory_config.memory_dimensions();
-    let num_user_pvs = system_config.num_public_values;
-
-    let mut app_config = AppConfig::riscv32(app_params_with_100_bits_security(
-        MAX_APP_LOG_STACKED_HEIGHT,
-    ));
-    app_config.app_vm_config.system.config = system_config;
-
-    let def_hook_cached_commit = def_prover.as_ref().map(|p| p.def_hook_cached_commit());
-    let def_hook_commit = def_prover.as_ref().map(|p| p.def_hook_commit().into());
-
-    let app_pk = AppProvingKey::keygen(app_config)?;
-
-    let agg_prover = Arc::new(AggProver::new(
-        Arc::new(app_pk.app_vm_pk.vm_pk.get_vk()),
-        AggregationConfig { params: agg_params },
-        agg_tree_config,
-        def_hook_cached_commit,
-    ));
-
-    let mut stark_prover = StarkProver::<ChildE, SdkVmBuilder>::new(
-        Default::default(),
-        &app_pk.app_vm_pk,
-        dummy_exe,
-        agg_prover.clone(),
-        def_prover,
-    )?;
-    let (agg_proof, _) = stark_prover.prove(StdIn::default(), &[])?;
-
-    // Use the CPU engine for root keygen + tracegen: trace heights are structural
-    // and backend-independent, so we avoid expensive GPU BN254 keygen here.
-    let root_prover = openvm_continuations::prover::RootCpuProver::new::<CpuRootE>(
-        agg_prover.internal_recursive_prover.get_vk(),
-        agg_prover
-            .internal_recursive_prover
-            .get_self_vk_pcs_data()
-            .unwrap()
-            .commitment
-            .into(),
-        root_params,
-        memory_dimensions,
-        num_user_pvs,
-        def_hook_commit,
-        None,
-    );
-    let engine = root_prover.create_engine::<CpuRootE>();
-    let root_proving_ctx: ProvingContext<<CpuRootE as StarkEngine>::PB> = root_prover
-        .generate_proving_ctx(
-            agg_proof.inner,
-            &agg_proof.user_pvs_proof,
-            agg_proof.deferral_merkle_proofs.as_ref(),
-            engine_device_ctx(&engine),
-        )
-        .unwrap();
-
-    let ret = root_proving_ctx
-        .into_iter()
-        .map(|(_, air_ctx)| air_ctx.height())
-        .collect();
-    Ok(ret)
 }

--- a/crates/sdk/src/prover/stark.rs
+++ b/crates/sdk/src/prover/stark.rs
@@ -18,11 +18,10 @@ use openvm_verify_stark_host::{
 
 use crate::{
     prover::{
-        deferral::{compute_deferral_merkle_proofs, DeferralAggProver},
-        vm::types::VmProvingKey,
-        AggProver, AppProver, InternalLayerMetadata,
+        deferral::compute_deferral_merkle_proofs, vm::types::VmProvingKey, AggProver, AppProver,
+        InternalLayerMetadata,
     },
-    DeferralInput, StdIn, SC,
+    DeferralInput, DeferralSetup, StdIn, SC,
 };
 
 pub struct StarkProver<E, VB>
@@ -32,7 +31,7 @@ where
 {
     pub app_prover: AppProver<E, VB>,
     pub agg_prover: Arc<AggProver>,
-    pub def_prover: Option<Arc<DeferralAggProver>>,
+    pub deferral_setup: DeferralSetup,
 }
 
 impl<E, VB> StarkProver<E, VB>
@@ -46,12 +45,12 @@ where
         app_vm_pk: &VmProvingKey<VB::VmConfig>,
         app_exe: Arc<VmExe<Val<SC>>>,
         agg_prover: Arc<AggProver>,
-        def_prover: Option<Arc<DeferralAggProver>>,
+        deferral_setup: DeferralSetup,
     ) -> Result<Self> {
         Ok(Self {
             app_prover: AppProver::new(vm_builder, app_vm_pk, app_exe)?,
             agg_prover,
-            def_prover,
+            deferral_setup,
         })
     }
 
@@ -75,7 +74,7 @@ where
             + MeteredExecutor<Val<SC>>
             + PreflightExecutor<Val<SC>, VB::RecordArena>,
     {
-        let has_deferrals = self.def_prover.is_some();
+        let has_deferrals = self.deferral_setup.hook_commit().is_some();
         let memory_dimensions = self.app_prover.memory_dimensions();
 
         // Build the initial memory merkle tree before proving (needed for deferral proofs).
@@ -103,7 +102,9 @@ where
             self.agg_prover.prove_vm(continuation_proof)?;
 
         if !def_inputs.is_empty() {
-            let def_agg_prover = self.def_prover.as_ref().unwrap();
+            let def_agg_prover = self.deferral_setup.prover().ok_or_else(|| {
+                eyre::eyre!("non-empty deferral inputs require a deferral aggregation prover")
+            })?;
             let def_hook_proofs = def_agg_prover
                 .multi_deferral_circuit_prover
                 .prove(def_inputs)?;
@@ -173,7 +174,7 @@ where
                 .agg_prover
                 .internal_recursive_prover
                 .get_vk_commit(true),
-            expected_def_hook_commit: self.def_prover.as_ref().map(|dp| dp.def_hook_commit()),
+            expected_def_hook_commit: self.deferral_setup.hook_commit(),
         }
     }
 

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -238,22 +238,15 @@ fn make_verify_stark_inputs(
 ///   * neither: STARK proof via `sdk.prove`, verified with the aggregation VK
 ///   * `root-prover` without `evm-verify`: root proof via `evm_prover_without_halo2`
 ///   * `evm-verify`: EVM proof via `sdk.prove_evm`, verified against the halo2 verifier
-///
-/// When `check_deferral_merkle_proofs` is set, asserts `deferral_merkle_proofs.is_some()` on the
-/// STARK proof (only meaningful in the STARK path).
-fn prove_and_verify_end_to_end(
+fn prove_and_verify_e2e(
     sdk: &Sdk,
     exe: Arc<VmExe<F>>,
     stdin: StdIn,
     def_inputs: &[DeferralInput],
-    #[allow(unused_variables)] check_deferral_merkle_proofs: bool,
 ) -> Result<()> {
     #[cfg(not(feature = "root-prover"))]
     {
         let (proof, baseline) = sdk.prove(exe, stdin, def_inputs)?;
-        if check_deferral_merkle_proofs {
-            assert!(proof.deferral_merkle_proofs.is_some());
-        }
         Sdk::verify_proof((*sdk.agg_vk()).clone(), baseline, &proof)?;
     }
     #[cfg(all(feature = "root-prover", not(feature = "evm-verify")))]
@@ -356,7 +349,7 @@ fn test_sdk_fibonacci() -> Result<()> {
     let mut stdin = StdIn::default();
     stdin.write(&n);
 
-    prove_and_verify_end_to_end(&sdk, app_exe, stdin, &[], false)
+    prove_and_verify_e2e(&sdk, app_exe, stdin, &[])
 }
 
 #[test]
@@ -373,7 +366,7 @@ fn test_verify_stark_deferral() -> Result<()> {
     )?;
     let vs_exe = vs_sdk.convert_to_exe(vs_elf)?;
 
-    prove_and_verify_end_to_end(&vs_sdk, vs_exe, vs_stdin, &[def_input], false)
+    prove_and_verify_e2e(&vs_sdk, vs_exe, vs_stdin, &[def_input])
 }
 
 #[test]
@@ -403,7 +396,7 @@ fn test_verify_many_deferrals() -> Result<()> {
     )?;
     let vs_exe = vs_sdk.convert_to_exe(vs_elf)?;
 
-    prove_and_verify_end_to_end(&vs_sdk, vs_exe, vs_stdin, &def_inputs, true)
+    prove_and_verify_e2e(&vs_sdk, vs_exe, vs_stdin, &def_inputs)
 }
 
 #[test]
@@ -429,7 +422,7 @@ fn test_verify_stark_path_sdk_can_verify_own_proofs() -> Result<()> {
     Sdk::verify_proof(agg_vk.clone(), vs_baseline.clone(), &vs_proof)?;
 
     let (vs2_stdin, vs2_def_input) = make_verify_stark_inputs(&sdk, &vs_proof, vs_baseline)?;
-    prove_and_verify_end_to_end(&sdk, vs_exe, vs2_stdin, &[vs2_def_input], true)
+    prove_and_verify_e2e(&sdk, vs_exe, vs2_stdin, &[vs2_def_input])
 }
 
 #[test]
@@ -448,7 +441,40 @@ fn test_deferrals_enabled_without_usage() -> Result<()> {
     let mut stdin = StdIn::default();
     stdin.write(&n);
 
-    prove_and_verify_end_to_end(&sdk, app_exe, stdin, &[], false)
+    prove_and_verify_e2e(&sdk, app_exe, stdin, &[])
+}
+
+#[test]
+fn test_deferral_aware_sdk_with_odd_children() -> Result<()> {
+    setup_tracing();
+    let n_stack = 15;
+    let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
+    let agg_params = AggregationSystemParams::default();
+    let hook_commits =
+        DeferralHookCommits::from_system_params(&agg_params, hook_params_with_100_bits_security());
+    let aware_sdk = Sdk::builder()
+        .app_config(AppConfig::riscv32(app_params))
+        .agg_params(agg_params)
+        .agg_tree_config(AggregationTreeConfig {
+            num_children_leaf: 1,
+            num_children_internal: 3,
+        })
+        .deferral_hook_commits(hook_commits)
+        .build()?;
+
+    let elf = Elf::decode(
+        include_bytes!("../programs/examples/fibonacci.elf"),
+        MEM_SIZE as u32,
+    )?;
+    let app_exe = aware_sdk.convert_to_exe(elf)?;
+
+    let mut stdin = StdIn::default();
+    stdin.write(&(1u64 << 17));
+
+    let (_, segments) = aware_sdk.execute_metered(app_exe.clone(), stdin.clone())?;
+    assert!(segments.len() >= 3, "expected >= 3 segments");
+
+    prove_and_verify_e2e(&aware_sdk, app_exe, stdin, &[])
 }
 
 #[test]
@@ -507,41 +533,6 @@ fn test_verify_stark_with_deferral_child() -> Result<()> {
     let vk = nested_verify_circuit_prover.get_vk();
     let engine = E::new(vk.inner.params.clone());
     engine.verify(&vk, &nested_def_proof)?;
-
-    Ok(())
-}
-
-#[test]
-fn test_deferral_aware_sdk_with_odd_children() -> Result<()> {
-    setup_tracing();
-    let n_stack = 15;
-    let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
-    let agg_params = AggregationSystemParams::default();
-    let hook_commits =
-        DeferralHookCommits::from_system_params(&agg_params, hook_params_with_100_bits_security());
-    let aware_sdk = Sdk::builder()
-        .app_config(AppConfig::riscv32(app_params))
-        .agg_params(agg_params)
-        .agg_tree_config(AggregationTreeConfig {
-            num_children_leaf: 1,
-            num_children_internal: 3,
-        })
-        .deferral_hook_commits(hook_commits)
-        .build()?;
-
-    let elf = Elf::decode(
-        include_bytes!("../programs/examples/fibonacci.elf"),
-        MEM_SIZE as u32,
-    )?;
-    let app_exe = aware_sdk.convert_to_exe(elf)?;
-
-    let mut stdin = StdIn::default();
-    stdin.write(&(1u64 << 17));
-
-    let (_, segments) = aware_sdk.execute_metered(app_exe.clone(), stdin.clone())?;
-    assert!(segments.len() >= 3, "expected >= 3 segments");
-
-    aware_sdk.prove(app_exe, stdin, &[])?;
 
     Ok(())
 }

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -27,7 +27,7 @@ use openvm_verify_stark_host::{
 use crate::{
     builder::GenericSdkBuilder,
     config::{AggregationConfig, AggregationSystemParams, AppConfig, DEFAULT_APP_L_SKIP},
-    prover::{DeferralAggProver, DeferralProof, MultiDeferralCircuitProver},
+    prover::{DeferralAggProver, DeferralHookCommits, DeferralProof, MultiDeferralCircuitProver},
     DeferralInput, Sdk, StdIn, F,
 };
 
@@ -531,7 +531,9 @@ fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
     // internal_recursive layer is needed to fully aggregate its proof.
     assert_eq!(internal_layer_metadata.internal_recursive_layer, 1);
 
-    let def_prover = vs_sdk.def_agg_prover.unwrap();
+    let def_prover = vs_sdk
+        .deferral_agg_prover()
+        .expect("deferral-enabled SDK should expose a deferral prover");
     let def_hook_proofs = def_prover
         .multi_deferral_circuit_prover
         .prove(&[def_input])?;
@@ -579,6 +581,29 @@ fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_deferral_aware_and_active_have_equivalent_vks() -> Result<()> {
+    setup_tracing();
+    let n_stack = 19;
+    let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
+    let agg_params = AggregationSystemParams::default();
+    let active_sdk = make_verify_stark_path_sdk(app_params.clone(), agg_params.clone())?;
+    let hook_commits = DeferralHookCommits {
+        hook_cached_commit: active_sdk.def_hook_cached_commit().unwrap(),
+        hook_commit: active_sdk.def_hook_commit().unwrap(),
+    };
+    let aware_sdk = Sdk::builder()
+        .app_config(active_sdk.app_config().clone())
+        .agg_params(agg_params)
+        .deferral_hook_commits(hook_commits)
+        .build()?;
+    assert_eq!(
+        active_sdk.agg_vk().as_ref().pre_hash,
+        aware_sdk.agg_vk().as_ref().pre_hash
+    );
+    Ok(())
+}
+
 /// Cell-count profiling test for the static verifier circuit using a production root proof.
 ///
 /// Root verifier params match `pipeline_cell_count_profiling` in static-verifier crate.
@@ -612,7 +637,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
         config::{AggregationSystemParams, DEFAULT_APP_L_SKIP},
         keygen::dummy::compute_root_proof_heights,
         prover::{EvmProver, RootProver},
-        Sdk, StdIn,
+        DeferralSetup, Sdk, StdIn,
     };
 
     // Root verifier params matching pipeline_cell_count_profiling in static-verifier
@@ -654,12 +679,12 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
             // Compute trace heights for root prover with profiling params
             let system_config = sdk.app_config().app_vm_config.as_ref();
             let agg_prover = sdk.agg_prover();
-            let (trace_heights, root_pk) = compute_root_proof_heights::<E, _>(
-                sdk.app_vm_builder().clone(),
-                &sdk.app_pk().app_vm_pk,
-                agg_prover.clone(),
+            let (trace_heights, root_pk) = compute_root_proof_heights(
+                system_config.clone(),
+                sdk.agg_config().params.clone(),
+                sdk.agg_tree_config(),
                 root_params.clone(),
-                None,
+                DeferralSetup::Disabled,
             )?;
 
             let ir_vk = agg_prover.internal_recursive_prover.get_vk();
@@ -688,7 +713,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
                 &sdk.app_pk().app_vm_pk,
                 app_exe,
                 agg_prover,
-                None,
+                DeferralSetup::Disabled,
                 root_prover.clone(),
                 None,
             )?;

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -720,7 +720,7 @@ fn sdk_static_verifier_cell_profiling() -> Result<()> {
             let (trace_heights, root_pk) = compute_root_proof_heights(
                 system_config.clone(),
                 sdk.agg_config().params.clone(),
-                sdk.agg_tree_config(),
+                sdk.agg_tree_config().clone(),
                 root_params.clone(),
                 DeferralSetup::Disabled,
             )?;

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -26,7 +26,10 @@ use openvm_verify_stark_host::{
 
 use crate::{
     builder::GenericSdkBuilder,
-    config::{AggregationConfig, AggregationSystemParams, AppConfig, DEFAULT_APP_L_SKIP},
+    config::{
+        AggregationConfig, AggregationSystemParams, AggregationTreeConfig, AppConfig,
+        DEFAULT_APP_L_SKIP,
+    },
     prover::{DeferralAggProver, DeferralHookCommits, DeferralProof, MultiDeferralCircuitProver},
     DeferralInput, Sdk, StdIn, F,
 };
@@ -504,6 +507,41 @@ fn test_verify_stark_with_deferral_child() -> Result<()> {
     let vk = nested_verify_circuit_prover.get_vk();
     let engine = E::new(vk.inner.params.clone());
     engine.verify(&vk, &nested_def_proof)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_deferral_aware_sdk_with_odd_children() -> Result<()> {
+    setup_tracing();
+    let n_stack = 15;
+    let app_params = app_params_with_100_bits_security(DEFAULT_APP_L_SKIP + n_stack);
+    let agg_params = AggregationSystemParams::default();
+    let hook_commits =
+        DeferralHookCommits::from_system_params(&agg_params, hook_params_with_100_bits_security());
+    let aware_sdk = Sdk::builder()
+        .app_config(AppConfig::riscv32(app_params))
+        .agg_params(agg_params)
+        .agg_tree_config(AggregationTreeConfig {
+            num_children_leaf: 1,
+            num_children_internal: 3,
+        })
+        .deferral_hook_commits(hook_commits)
+        .build()?;
+
+    let elf = Elf::decode(
+        include_bytes!("../programs/examples/fibonacci.elf"),
+        MEM_SIZE as u32,
+    )?;
+    let app_exe = aware_sdk.convert_to_exe(elf)?;
+
+    let mut stdin = StdIn::default();
+    stdin.write(&(1u64 << 17));
+
+    let (_, segments) = aware_sdk.execute_metered(app_exe.clone(), stdin.clone())?;
+    assert!(segments.len() >= 3, "expected >= 3 segments");
+
+    aware_sdk.prove(app_exe, stdin, &[])?;
 
     Ok(())
 }


### PR DESCRIPTION
Resolves INT-8570.

## Overview

This branch adds a deferral-aware-but-not-active SDK mode. SDK users can now build STARK/root/Halo2 verifying material that is bound to deferral hook commits without also supplying a deferral prover capable of proving non-empty deferral inputs.

The branch also fixes `UnsetPvsAir` trace generation for padding rows and tightens root keygen/dummy-proving behavior used for root trace-height discovery.

Base: `origin/develop-v2.0.0-rc.3`

Commits in scope:

- `20f1ac38b0 feat: config for deferral-aware but not active SDK`
- `7802fde0cf fix: UnsetPvsAir tracegen fills all proof_idx columns`
- `f4e2f426b5 fix: compute_root_proof_heights uses keygen group`

## SDK Deferral Setup

Files:

- `crates/sdk/src/lib.rs`
- `crates/sdk/src/builder.rs`
- `crates/sdk/src/prover/stark.rs`
- `crates/sdk/src/prover/evm.rs`

The SDK now stores deferral configuration as `DeferralSetup` instead of `Option<Arc<DeferralAggProver>>`.

Modes:

- `Disabled`: no deferral hook commits; non-empty deferral inputs are rejected.
- `Aware(DeferralHookCommits)`: vkeys/baselines/root/Halo2 material are deferral-aware, but non-empty deferral inputs are rejected because no prover is present.
- `Active(Arc<DeferralAggProver>)`: deferral-aware and can prove non-empty deferral inputs.

Reviewer focus:

- `DeferralSetup::hook_cached_commit`, `hook_commit`, and `prover` are now the common access points for SDK, STARK, root, and EVM prover setup.
- `StarkProver::prove` treats both `Aware` and `Active` as deferral-enabled for baseline/merkle-proof shape, but only `Active` can handle non-empty `def_inputs`.
- `GenericSdk::deferral_agg_prover()` exposes the active prover only when present.
- `GenericSdkBuilder::deferral_hook_commits` is mutually exclusive with the existing deferral prover entry points.

## Deferral Hook Commit Derivation

File:

- `crates/sdk/src/prover/deferral/agg.rs`

Adds serializable `DeferralHookCommits` and `DeferralHookCommits::from_system_params`.

The hook commit derivation logic is factored into `deferral_hook_artifacts_from_system_params`, which constructs the dummy deferral hook path once and returns:

- hook cached commit,
- hook commit,
- hook VK,
- deferral aggregation prover seeded by that hook VK.

`DeferralAggProver::verify_stark` now reuses those artifacts, then checks that the real verify-stark deferral hook VK/preprocessed commit matches the dummy-derived fixed point.

Reviewer focus:

- The aware-only path must produce the same aggregation VK as the active verify-stark path when supplied with matching commits.
- Cached SDK proving keys still include deferral proving keys only for active deferral setups.

## Root Keygen And Dummy Proofs

Files:

- `crates/sdk/src/keygen/dummy.rs`
- `crates/sdk/src/prover/root.rs`
- `crates/sdk/src/lib.rs`

`compute_root_proof_heights` moved from `prover/root.rs` to `keygen/dummy.rs` and now returns both root trace heights and the generated root proving key.

The function now:

- takes structural SDK inputs (`SystemConfig`, aggregation params/tree config, root params, `DeferralSetup`) rather than an existing app proving key and aggregation prover,
- builds a trivial `TERMINATE` app proving key and aggregation prover internally,
- uses the CPU root engine for root keygen/trace-height discovery,
- labels the dummy app proof metrics as `root_keygen`.

`GenericSdk::root_prover` uses the returned trace heights and root proving key to construct the cached `RootProver`.

Reviewer focus:

- Root trace heights remain tied to the same system config, aggregation params, aggregation tree config, and deferral hook commits as the SDK being built.
- The dummy proof metrics should not appear as an `app_proof` benchmark group.

## Continuations Tracegen Fix

File:

- `crates/continuations/src/circuit/inner/unset/trace.rs`

`UnsetPvsAir` trace generation now fills `proof_idx` for padding rows from `num_valid..height`, not only for valid rows.

Reviewer focus:

- Padding rows now have deterministic `proof_idx` values instead of leaving that column unset.

## Tests

File:

- `crates/sdk/src/tests.rs`

Added coverage:

- `test_deferral_aware_sdk_with_odd_children`: builds an aware-only SDK with odd aggregation tree children and proves with empty deferral inputs.
- `test_deferral_aware_and_active_have_equivalent_vks`: checks that aware-only and active verify-stark SDKs produce equivalent aggregation VKs when using the same hook commits.

Adjusted coverage:

- Deferral prover access now goes through `deferral_agg_prover()`.
- Static verifier profiling setup uses the new `compute_root_proof_heights` signature and `DeferralSetup::Disabled`.