### PR TITLE
refactor: convert input and hint streams to byte-backed storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4476,7 +4476,6 @@ dependencies = [
  "openvm-stark-sdk",
  "openvm-transpiler",
  "openvm-verify-stark-host",
- "p3-field",
  "rand_chacha 0.3.1",
  "tiny-keccak",
  "tracing",

--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -287,10 +287,7 @@ trait BenchExecutor {
     fn execution_mode() -> &'static str;
     fn cache() -> &'static Cache<Self::Instance>;
     fn build_instance(exe: &VmExe<BabyBear>) -> Self::Instance;
-    fn run_execution(
-        instance: &Self::Instance,
-        input: Vec<Vec<BabyBear>>,
-    ) -> Result<(), ExecutionError>;
+    fn run_execution(instance: &Self::Instance, input: Vec<Vec<u8>>) -> Result<(), ExecutionError>;
 
     fn get_cached_instance(program: &str) -> Arc<Self::Instance> {
         let cache = Self::cache().get_or_init(|| Mutex::new(HashMap::new()));
@@ -318,7 +315,7 @@ trait BenchExecutor {
     fn benchmark(bencher: Bencher, program: &str) {
         let instance = Self::get_cached_instance(program);
         bencher
-            .with_inputs(Vec::<Vec<BabyBear>>::new)
+            .with_inputs(Vec::<Vec<u8>>::new)
             .bench_values(|input| match Self::run_execution(&instance, input) {
                 Ok(()) => report_program_success(Self::execution_mode(), program),
                 Err(err) => panic!(
@@ -355,10 +352,7 @@ impl BenchExecutor for PureExecution {
         Self::unwrap_instance(executor().instance(exe))
     }
 
-    fn run_execution(
-        instance: &Self::Instance,
-        input: Vec<Vec<BabyBear>>,
-    ) -> Result<(), ExecutionError> {
+    fn run_execution(instance: &Self::Instance, input: Vec<Vec<u8>>) -> Result<(), ExecutionError> {
         instance.execute(input, None).map(|_| ())
     }
 }
@@ -395,10 +389,7 @@ impl BenchExecutor for MeteredExecution {
         (instance, ctx)
     }
 
-    fn run_execution(
-        instance: &Self::Instance,
-        input: Vec<Vec<BabyBear>>,
-    ) -> Result<(), ExecutionError> {
+    fn run_execution(instance: &Self::Instance, input: Vec<Vec<u8>>) -> Result<(), ExecutionError> {
         let (instance, ctx) = instance;
         instance.execute_metered(input, ctx.clone()).map(|_| ())
     }
@@ -431,10 +422,7 @@ impl BenchExecutor for MeteredCostExecution {
         Self::unwrap_instance(result)
     }
 
-    fn run_execution(
-        instance: &Self::Instance,
-        input: Vec<Vec<BabyBear>>,
-    ) -> Result<(), ExecutionError> {
+    fn run_execution(instance: &Self::Instance, input: Vec<Vec<u8>>) -> Result<(), ExecutionError> {
         instance
             .execute_metered_cost(input, metered_cost_setup().0.clone())
             .map(|_| ())

--- a/benchmarks/prove/Cargo.toml
+++ b/benchmarks/prove/Cargo.toml
@@ -22,7 +22,6 @@ eyre.workspace = true
 tracing.workspace = true
 metrics.workspace = true
 zstd.workspace = true
-p3-field = { workspace = true }
 
 # for ecrecover benchmark
 rand_chacha = { version = "0.3", default-features = false }

--- a/benchmarks/prove/src/bin/ecrecover.rs
+++ b/benchmarks/prove/src/bin/ecrecover.rs
@@ -1,14 +1,12 @@
 use clap::Parser;
 use k256::ecdsa::{SigningKey, VerifyingKey};
 use openvm_benchmarks_prove::BenchmarkCli;
-use openvm_sdk::F;
 use openvm_sdk_config::SdkVmConfig;
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE};
-use p3_field::PrimeCharacteristicRing;
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
 use tiny_keccak::{Hasher, Keccak};
 
-fn make_input(signing_key: &SigningKey, msg: &[u8]) -> Vec<F> {
+fn make_input(signing_key: &SigningKey, msg: &[u8]) -> Vec<u8> {
     let mut hasher = Keccak::v256();
     hasher.update(msg);
     let mut prehash = [0u8; 32];
@@ -21,7 +19,7 @@ fn make_input(signing_key: &SigningKey, msg: &[u8]) -> Vec<F> {
     input.push(v);
     input.extend_from_slice(signature.to_bytes().as_ref());
 
-    input.into_iter().map(F::from_u8).collect()
+    input
 }
 
 fn main() -> eyre::Result<()> {
@@ -45,10 +43,7 @@ fn main() -> eyre::Result<()> {
     );
     hasher.finalize(&mut expected_address);
     expected_address[..12].fill(0); // 20 bytes as the address.
-    let mut input_stream = vec![expected_address
-        .into_iter()
-        .map(F::from_u8)
-        .collect::<Vec<_>>()];
+    let mut input_stream = vec![expected_address.to_vec()];
     let msg = ["Elliptic", "Curve", "Digital", "Signature", "Algorithm"];
     input_stream.extend(
         msg.iter()

--- a/crates/cli/src/input.rs
+++ b/crates/cli/src/input.rs
@@ -1,15 +1,15 @@
 use std::{fs::read, path::PathBuf, str::FromStr};
 
 use eyre::{Context, Result};
-use openvm_sdk::{StdIn, F};
-use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
+use openvm_sdk::StdIn;
 
 /// Input can be either:
 /// (1) one single hex string
 /// (2) A JSON file containing an array of hex strings.
 /// Each hex string (either in the file or the direct input) is either:
-/// - Hex strings of bytes, which is prefixed with 0x01
-/// - Hex strings of native field elements (represented as u32, little endian), prefixed with 0x02
+/// - Hex strings of bytes, prefixed with 0x01
+/// - Hex strings of little-endian u32 words (a whole number of 4-byte words), prefixed with 0x02;
+///   the words are written to the input stream as their raw little-endian bytes
 #[derive(Debug, Clone)]
 pub enum Input {
     FilePath(PathBuf),
@@ -52,7 +52,6 @@ pub fn decode_hex_string(s: &str) -> Result<Vec<u8>> {
 }
 
 pub fn read_bytes_into_stdin(stdin: &mut StdIn, bytes: &[u8]) -> Result<()> {
-    // should either write_bytes or write_field
     match bytes.first() {
         Some(0x01) => {
             stdin.write_bytes(&bytes[1..]);
@@ -65,12 +64,9 @@ pub fn read_bytes_into_stdin(stdin: &mut StdIn, bytes: &[u8]) -> Result<()> {
                     "Invalid input format: incorrect number of bytes"
                 ));
             }
-            let mut fields = Vec::with_capacity(data.len() / 4);
-            for chunk in data.chunks_exact(4) {
-                let value = u32::from_le_bytes(chunk.try_into().unwrap());
-                fields.push(F::from_u32(value));
-            }
-            stdin.write_field(&fields);
+            // 0x02 historically declared little-endian u32 field elements; they are now written
+            // as their raw little-endian bytes, matching how stream consumers read them.
+            stdin.write_bytes(data);
             Ok(())
         }
         _ => Err(eyre::eyre!(

--- a/crates/cli/src/input.rs
+++ b/crates/cli/src/input.rs
@@ -64,8 +64,6 @@ pub fn read_bytes_into_stdin(stdin: &mut StdIn, bytes: &[u8]) -> Result<()> {
                     "Invalid input format: incorrect number of bytes"
                 ));
             }
-            // 0x02 historically declared little-endian u32 field elements; they are now written
-            // as their raw little-endian bytes, matching how stream consumers read them.
             stdin.write_bytes(data);
             Ok(())
         }

--- a/crates/continuations/src/tests/e2e.rs
+++ b/crates/continuations/src/tests/e2e.rs
@@ -116,11 +116,10 @@ fn input_commit_to_f(commit: &[u8; 32]) -> [F; DIGEST_SIZE] {
     })
 }
 
-fn commit_to_stdin_fields(commit: &[u8; 32]) -> Vec<F> {
+fn commit_to_stdin_bytes(commit: &[u8; 32]) -> Vec<u8> {
     commit
         .iter()
         .flat_map(|b| [*b, 0, 0, 0, 0, 0, 0, 0])
-        .map(F::from_u8)
         .collect()
 }
 
@@ -357,16 +356,12 @@ fn test_deferral_e2e() -> Result<()> {
     let mut state2 = DeferralState::new(Vec::<DeferralResult>::new());
     state2.store_input(in_commit_0_bytes.to_vec(), INPUT_RAW_0.to_vec());
 
-    let streams = Streams {
-        input_stream: vec![
-            commit_to_stdin_fields(&in_commit_0_bytes),
-            commit_to_stdin_fields(&in_commit_1_bytes),
-            commit_to_stdin_fields(&in_commit_2_bytes),
-        ]
-        .into(),
-        deferrals: vec![state_unused, state1, state2],
-        ..Default::default()
-    };
+    let mut streams = Streams::new(vec![
+        commit_to_stdin_bytes(&in_commit_0_bytes),
+        commit_to_stdin_bytes(&in_commit_1_bytes),
+        commit_to_stdin_bytes(&in_commit_2_bytes),
+    ]);
+    streams.deferrals = vec![state_unused, state1, state2];
 
     // =========================================================================
     // SECTION 2: Run the VM, capture merkle proofs before and after execution.

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -141,10 +141,7 @@ pub(in crate::tests) fn run_leaf_aggregation(
             .with_extension(Rv64MTranspilerExtension)
             .with_extension(Rv64IoTranspilerExtension),
     )?;
-    let input = (1u64 << log_fib_input)
-        .to_le_bytes()
-        .map(F::from_u8)
-        .to_vec();
+    let input = (1u64 << log_fib_input).to_le_bytes().to_vec();
 
     let engine = Engine::new(app_system_params());
     let (vm, app_pk) = VirtualMachine::new_with_keygen(engine, Rv64ImBuilder, config)?;

--- a/crates/sdk/src/stdin.rs
+++ b/crates/sdk/src/stdin.rs
@@ -1,27 +1,37 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, marker::PhantomData};
 
 use itertools::Itertools;
 use openvm_circuit::arch::{deferral::DeferralState, Streams};
-use openvm_stark_backend::{
-    codec::{Decode, Encode},
-    p3_field::Field,
-};
+use openvm_stark_backend::codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Default, Serialize, Deserialize)]
+/// Program input. Both the input records and the derived hint stream are byte-backed;
+/// `F` is retained only so the type lines up with `Streams<F>` and the prover's field.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct StdIn<F = crate::F> {
-    pub buffer: VecDeque<Vec<F>>,
+    pub buffer: VecDeque<Vec<u8>>,
     pub deferrals: Vec<DeferralState>,
+    phantom: PhantomData<F>,
 }
 
-impl<F: Field> StdIn<F> {
+impl<F> Default for StdIn<F> {
+    fn default() -> Self {
+        Self {
+            buffer: VecDeque::default(),
+            deferrals: Vec::default(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F> StdIn<F> {
     pub fn from_bytes(data: &[u8]) -> Self {
         let mut ret = Self::default();
         ret.write_bytes(data);
         ret
     }
 
-    pub fn read(&mut self) -> Option<Vec<F>> {
+    pub fn read(&mut self) -> Option<Vec<u8>> {
         self.buffer.pop_front()
     }
 
@@ -32,18 +42,13 @@ impl<F: Field> StdIn<F> {
     }
 
     pub fn write_bytes(&mut self, data: &[u8]) {
-        let field_data = data.iter().map(|b| F::from_u8(*b)).collect();
-        self.buffer.push_back(field_data);
-    }
-
-    pub fn write_field(&mut self, data: &[F]) {
         self.buffer.push_back(data.to_vec());
     }
 }
 
-impl<F: Field> From<StdIn<F>> for Streams<F> {
+impl<F> From<StdIn<F>> for Streams<F> {
     fn from(mut std_in: StdIn<F>) -> Self {
-        let mut data = Vec::<Vec<F>>::new();
+        let mut data = Vec::<Vec<u8>>::new();
         while let Some(input) = std_in.read() {
             data.push(input);
         }
@@ -53,11 +58,11 @@ impl<F: Field> From<StdIn<F>> for Streams<F> {
     }
 }
 
-impl<F: Field> From<Vec<Vec<F>>> for StdIn<F> {
-    fn from(inputs: Vec<Vec<F>>) -> Self {
+impl<F> From<Vec<Vec<u8>>> for StdIn<F> {
+    fn from(inputs: Vec<Vec<u8>>) -> Self {
         let mut ret = StdIn::<F>::default();
         for input in inputs {
-            ret.write_field(&input);
+            ret.write_bytes(&input);
         }
         ret
     }

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -16,8 +16,8 @@ use crate::arch::deferral::DeferralState;
 ///
 /// `deferral_memory` aliases AS=4 as `F` cells for deferral accumulator updates.
 pub struct OpenVmIoState<'a, F: PrimeField32> {
-    pub input_stream: &'a mut VecDeque<Vec<F>>,
-    pub hint_stream: &'a mut VecDeque<F>,
+    pub input_stream: &'a mut VecDeque<Vec<u8>>,
+    pub hint_stream: &'a mut VecDeque<u8>,
     pub rng: &'a mut StdRng,
     pub memory_ptr: *mut u8,
     pub public_values: &'a mut [u8],
@@ -59,8 +59,6 @@ pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
     io.hint_stream.clear();
     if len > 0 && !data.is_null() {
         let slice = unsafe { std::slice::from_raw_parts(data, len as usize) };
-        for &b in slice {
-            io.hint_stream.push_back(F::from_u8(b));
-        }
+        io.hint_stream.extend(slice.iter().copied());
     }
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -115,19 +115,23 @@ pub enum GenerationError {
 
 #[derive(Clone)]
 pub struct Streams<F> {
-    pub input_stream: VecDeque<Vec<F>>,
-    pub hint_stream: VecDeque<F>,
+    pub input_stream: VecDeque<Vec<u8>>,
+    pub hint_stream: VecDeque<u8>,
     /// Cached deferred operation inputs and outputs. Each idx corresponds to a
     /// unique function that is constrained outside the VM in its own deferral circuit.
     pub deferrals: Vec<DeferralState>,
+    /// The input and hint streams are byte-backed; `F` is retained purely to thread the
+    /// field type through the execution state (`VmState<F>` and friends).
+    phantom: PhantomData<F>,
 }
 
 impl<F> Streams<F> {
-    pub fn new(input_stream: impl Into<VecDeque<Vec<F>>>) -> Self {
+    pub fn new(input_stream: impl Into<VecDeque<Vec<u8>>>) -> Self {
         Self {
             input_stream: input_stream.into(),
             hint_stream: VecDeque::default(),
             deferrals: Vec::default(),
+            phantom: PhantomData,
         }
     }
 }
@@ -138,14 +142,14 @@ impl<F> Default for Streams<F> {
     }
 }
 
-impl<F> From<VecDeque<Vec<F>>> for Streams<F> {
-    fn from(value: VecDeque<Vec<F>>) -> Self {
+impl<F> From<VecDeque<Vec<u8>>> for Streams<F> {
+    fn from(value: VecDeque<Vec<u8>>) -> Self {
         Streams::new(value)
     }
 }
 
-impl<F> From<Vec<Vec<F>>> for Streams<F> {
-    fn from(value: Vec<Vec<F>>) -> Self {
+impl<F> From<Vec<Vec<u8>>> for Streams<F> {
+    fn from(value: Vec<Vec<u8>>) -> Self {
         Streams::new(value)
     }
 }

--- a/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
+++ b/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
@@ -110,7 +110,7 @@ To run your program and see the public value output, you can do the following:
 
 ### Using `StdIn`
 
-The `StdIn` struct allows you to format any serializable type into a VM-readable format by passing in a reference to your struct into `StdIn::write` as above. You also have the option to pass in a `&[u8]` into `StdIn::write_bytes`, or a `&[F]` into `StdIn::write_field` where `F` is the `openvm_stark_sdk::p3_baby_bear::BabyBear` field type.
+The `StdIn` struct allows you to format any serializable type into a VM-readable format by passing in a reference to your struct into `StdIn::write` as above. You also have the option to pass in a `&[u8]` into `StdIn::write_bytes`.
 
 :::info
 **Generating CLI Bytes**

--- a/docs/vocs/docs/pages/specs/openvm/isa.mdx
+++ b/docs/vocs/docs/pages/specs/openvm/isa.mdx
@@ -167,9 +167,9 @@ the invariants of those address spaces. In particular, all instructions must res
 To enable user input and non-determinism in OpenVM programs, the host state maintains the following data
 structures during runtime execution:
 
-- `input_stream`: a private non-interactive queue of vectors of field elements which is provided at the start of runtime
+- `input_stream`: a private non-interactive queue of byte vectors which is provided at the start of runtime
   execution
-- `hint_stream`: a queue of values populated during runtime execution
+- `hint_stream`: a queue of bytes populated during runtime execution
   via [phantom sub-instructions](#phantom-sub-instructions) such as `Rv64HintInput`.
 - `deferrals`: a list of `DeferralState` objects, one per [deferral function](/specs/architecture/deferral). Each
   `DeferralState` maps input commitments to raw inputs (or output commitments) and output commitments to raw outputs,
@@ -467,7 +467,7 @@ The RV64IM extension defines the following phantom sub-instructions.
 
 | Name              | Discriminant | Operands | Description                                                                                                                                                                                                                                                    |
 |-------------------| ------------ | -------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Rv64HintInput     | 0x20         | `_`      | Pops a vector `hint` of field elements from the input stream and resets the hint stream to equal `[(hint.len() as u64).to_le_bytes(), hint, zero padding to 8-byte alignment].concat()`.                                                                       |
+| Rv64HintInput     | 0x20         | `_`      | Pops a byte vector `hint` from the input stream and resets the hint stream to equal `[(hint.len() as u64).to_le_bytes(), hint, zero padding to 8-byte alignment].concat()`.                                                                       |
 | Rv64PrintStr      | 0x21         | `a,b,_`  | Peeks at `[r64{0}(a)..r64{0}(a) + r64{0}(b)]_2`, tries to convert to byte array and then UTF-8 string and prints to host stdout. Prints error message if conversion fails. Does not change any VM state.                                                       |
 | Rv64HintRandom    | 0x22         | `a,_,_`  | Resets the hint stream to `8 * r64{0}(a)` random bytes. The source of randomness is deterministic using a fixed-seed RNG (`rand::rngs::StdRng`). Its result is not constrained in any way.                                                                     |
 

--- a/extensions/algebra/circuit/src/extension/modular.rs
+++ b/extensions/algebra/circuit/src/extension/modular.rs
@@ -557,14 +557,13 @@ pub(crate) mod phantom {
                 }
             };
 
-            let hint_bytes = once(F::from_bool(success))
-                .chain(repeat(F::ZERO))
+            let hint_bytes = once(u8::from(success))
+                .chain(repeat(0u8))
                 .take(RV64_REGISTER_NUM_LIMBS)
                 .chain(
                     sqrt.to_bytes_le()
                         .into_iter()
-                        .map(F::from_u8)
-                        .chain(repeat(F::ZERO))
+                        .chain(repeat(0u8))
                         .take(num_limbs),
                 )
                 .collect();
@@ -629,8 +628,7 @@ pub(crate) mod phantom {
             let hint_bytes = self.non_qrs[mod_idx]
                 .to_bytes_le()
                 .into_iter()
-                .map(F::from_u8)
-                .chain(repeat(F::ZERO))
+                .chain(repeat(0u8))
                 .take(num_limbs)
                 .collect();
             streams.hint_stream = hint_bytes;

--- a/extensions/deferral/tests/src/lib.rs
+++ b/extensions/deferral/tests/src/lib.rs
@@ -106,10 +106,8 @@ mod tests {
         state.store_input(INPUT_COMMIT_1.to_vec(), INPUT_RAW_1.to_vec());
         state.store_input(INPUT_COMMIT_2.to_vec(), INPUT_RAW_2.to_vec());
 
-        let streams = Streams {
-            deferrals: vec![state],
-            ..Default::default()
-        };
+        let mut streams = Streams::default();
+        streams.deferrals = vec![state];
         let config = make_config(1);
         run_test(config, "single", streams)
     }
@@ -124,10 +122,8 @@ mod tests {
         let mut state1 = DeferralState::new(Vec::<DeferralResult>::new());
         state1.store_input(INPUT_COMMIT_0.to_vec(), INPUT_RAW_0.to_vec());
 
-        let streams = Streams {
-            deferrals: vec![state0, state1],
-            ..Default::default()
-        };
+        let mut streams = Streams::default();
+        streams.deferrals = vec![state0, state1];
         let config = make_config(2);
         run_test(config, "multiple", streams)
     }

--- a/extensions/ecc/tests/src/lib.rs
+++ b/extensions/ecc/tests/src/lib.rs
@@ -22,8 +22,7 @@ mod tests {
     };
     use openvm_sdk::StdIn;
     use openvm_sdk_config::{SdkVmBuilder, SdkVmConfig, TranspilerConfig};
-    use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
-    use openvm_stark_sdk::{openvm_stark_backend, p3_baby_bear::BabyBear};
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
     use openvm_toolchain_tests::{
         build_example_program_at_path_with_features, get_programs_dir, NoInitFile,
     };
@@ -166,11 +165,7 @@ mod tests {
         let r_y: [u8; 32] =
             hex!("347E00859981D5446447075AA07543CDE6DF224CFB23F7B5886337BD00000000");
 
-        let coords = [p.x.to_bytes(), p.y.to_bytes(), q_x, q_y, r_x, r_y]
-            .concat()
-            .into_iter()
-            .map(PrimeCharacteristicRing::from_u8)
-            .collect();
+        let coords = [p.x.to_bytes(), p.y.to_bytes(), q_x, q_y, r_x, r_y].concat();
         air_test_with_min_segments(Rv64WeierstrassBuilder, config, openvm_exe, vec![coords], 1);
         Ok(())
     }

--- a/extensions/pairing/circuit/src/pairing_extension.rs
+++ b/extensions/pairing/circuit/src/pairing_extension.rs
@@ -166,9 +166,9 @@ pub(crate) mod phantom {
         }
     }
 
-    fn hint_pairing<F: Field>(
+    fn hint_pairing(
         memory: &GuestMemory,
-        hint_stream: &mut VecDeque<F>,
+        hint_stream: &mut VecDeque<u8>,
         rs1: u32,
         rs2: u32,
         c_upper: u16,
@@ -228,8 +228,7 @@ pub(crate) mod phantom {
                         .into_iter()
                         .chain(u.to_coeffs())
                         .flat_map(|fp2| fp2.to_coeffs())
-                        .flat_map(|fp| fp.to_bytes())
-                        .map(F::from_u8),
+                        .flat_map(|fp| fp.to_bytes()),
                 );
             }
             Some(PairingCurve::Bls12_381) => {
@@ -270,8 +269,7 @@ pub(crate) mod phantom {
                         .into_iter()
                         .chain(u.to_coeffs())
                         .flat_map(|fp2| fp2.to_coeffs())
-                        .flat_map(|fp| fp.to_bytes())
-                        .map(F::from_u8),
+                        .flat_map(|fp| fp.to_bytes()),
                 );
             }
             _ => {

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -1188,12 +1188,10 @@ mod phantom {
             };
             streams.hint_stream.clear();
             let hint_len = hint.len() as u64;
-            streams
-                .hint_stream
-                .extend(hint_len.to_le_bytes().iter().map(|b| F::from_u8(*b)));
+            streams.hint_stream.extend(hint_len.to_le_bytes());
             // Pad the hint payload to full dwords so RV64 `HINT_BUFFER` reads can consume it.
             let capacity = hint.len().div_ceil(HINT_DWORD_BYTES) * HINT_DWORD_BYTES;
-            hint.resize(capacity, F::ZERO);
+            hint.resize(capacity, 0u8);
             streams.hint_stream.extend(hint);
             Ok(())
         }
@@ -1219,7 +1217,7 @@ mod phantom {
             streams.hint_stream.clear();
             streams
                 .hint_stream
-                .extend(std::iter::repeat_with(|| F::from_u8(rng.random::<u8>())).take(byte_len));
+                .extend(std::iter::repeat_with(|| rng.random::<u8>()).take(byte_len));
             Ok(())
         }
     }

--- a/extensions/riscv/circuit/src/hintstore/execution.rs
+++ b/extensions/riscv/circuit/src/hintstore/execution.rs
@@ -192,14 +192,8 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait, const IS_HIN
     }
 
     for word_index in 0..num_words {
-        let data: [u8; RV64_REGISTER_NUM_LIMBS] = std::array::from_fn(|_| {
-            exec_state
-                .streams
-                .hint_stream
-                .pop_front()
-                .unwrap()
-                .as_canonical_u32() as u8
-        });
+        let data: [u8; RV64_REGISTER_NUM_LIMBS] =
+            std::array::from_fn(|_| exec_state.streams.hint_stream.pop_front().unwrap());
         exec_state.vm_write_bytes(
             RV64_MEMORY_AS,
             mem_ptr + (RV64_REGISTER_NUM_LIMBS as u32 * word_index),

--- a/extensions/riscv/circuit/src/hintstore/mod.rs
+++ b/extensions/riscv/circuit/src/hintstore/mod.rs
@@ -483,10 +483,8 @@ where
                 state.memory.increment_timestamp();
             }
 
-            let data_f: [F; RV64_REGISTER_NUM_LIMBS] =
-                std::array::from_fn(|_| state.streams.hint_stream.pop_front().unwrap());
             let data: [u8; RV64_REGISTER_NUM_LIMBS] =
-                data_f.map(|byte| byte.as_canonical_u32() as u8);
+                std::array::from_fn(|_| state.streams.hint_stream.pop_front().unwrap());
 
             record.var[idx].data = data;
 

--- a/extensions/riscv/circuit/src/hintstore/tests.rs
+++ b/extensions/riscv/circuit/src/hintstore/tests.rs
@@ -121,9 +121,10 @@ fn set_and_execute<RA: Arena, E: PreflightExecutor<F, RA>>(
 
     let mut input = Vec::with_capacity(num_words as usize * RV64_REGISTER_NUM_LIMBS);
     for _ in 0..num_words {
-        let data = rng.next_u64().to_le_bytes().map(F::from_u8);
+        let bytes = rng.next_u64().to_le_bytes();
+        let data = bytes.map(F::from_u8);
         input.extend(data);
-        tester.streams_mut().hint_stream.extend(data);
+        tester.streams_mut().hint_stream.extend(bytes);
     }
 
     tester.execute(
@@ -215,7 +216,7 @@ fn test_hint_buffer_exceeds_max_words() {
     );
 
     for _ in 0..num_words {
-        let data = rng.next_u64().to_le_bytes().map(F::from_u8);
+        let data = rng.next_u64().to_le_bytes();
         tester.streams_mut().hint_stream.extend(data);
     }
 
@@ -253,7 +254,7 @@ fn test_hint_buffer_rem_words_range_check() {
     );
 
     for _ in 0..num_words {
-        let data = rng.next_u64().to_le_bytes().map(F::from_u8);
+        let data = rng.next_u64().to_le_bytes();
         tester.streams_mut().hint_stream.extend(data);
     }
 
@@ -310,7 +311,7 @@ fn test_hint_buffer_mem_ptr_range_check() {
     );
 
     for _ in 0..num_words {
-        let data = rng.next_u64().to_le_bytes().map(F::from_u8);
+        let data = rng.next_u64().to_le_bytes();
         tester.streams_mut().hint_stream.extend(data);
     }
 
@@ -358,7 +359,7 @@ fn test_hintstore_rs1_upper_bytes_non_zero() {
     mem_ptr_limbs[4] = F::from_u8(1);
     tester.write_bytes(RV64_REGISTER_AS as usize, b, mem_ptr_limbs);
 
-    let data = rng.next_u64().to_le_bytes().map(F::from_u8);
+    let data = rng.next_u64().to_le_bytes();
     tester.streams_mut().hint_stream.extend(data);
 
     tester.execute(

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -394,7 +394,7 @@ pub struct Rv64IoHostCallbacks {
 
 /// HintInput: pop next input record from VmState's input_stream and overwrite
 /// the active hint stream with `[len: u64 LE][data][padding to 8-byte align]`,
-/// each byte stored as one field element.
+/// stored directly as bytes.
 pub extern "C" fn host_hint_input<F: PrimeField32>(ctx: *mut c_void) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
     io.hint_stream.clear();

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -401,11 +401,9 @@ pub extern "C" fn host_hint_input<F: PrimeField32>(ctx: *mut c_void) {
     if let Some(mut vec) = io.input_stream.pop_front() {
         let data_len = vec.len();
         let len_bytes = (data_len as u64).to_le_bytes();
-        for &b in &len_bytes {
-            io.hint_stream.push_back(F::from_u8(b));
-        }
+        io.hint_stream.extend(len_bytes);
         let padded_len = data_len.div_ceil(RV64_REGISTER_NUM_LIMBS) * RV64_REGISTER_NUM_LIMBS;
-        vec.resize(padded_len, F::ZERO);
+        vec.resize(padded_len, 0u8);
         io.hint_stream.extend(vec);
     }
 }
@@ -429,7 +427,7 @@ pub extern "C" fn host_hint_random<F: PrimeField32>(ctx: *mut c_void, num_words:
     let nbytes = num_words as usize * RV64_REGISTER_NUM_LIMBS;
     io.hint_stream.clear();
     for _ in 0..nbytes {
-        io.hint_stream.push_back(F::from_u8(io.rng.random::<u8>()));
+        io.hint_stream.push_back(io.rng.random::<u8>());
     }
 }
 
@@ -443,7 +441,7 @@ pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr:
     check_mem_bounds_range(dest_addr, RV64_REGISTER_NUM_LIMBS);
     let mut bytes = [0u8; RV64_REGISTER_NUM_LIMBS];
     for byte in &mut bytes {
-        *byte = io.hint_stream.pop_front().unwrap().as_canonical_u32() as u8;
+        *byte = io.hint_stream.pop_front().unwrap();
     }
     unsafe {
         std::ptr::copy_nonoverlapping(
@@ -454,8 +452,8 @@ pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr:
     }
 }
 
-/// HINT_BUFFER: pop `num_words * RV64_REGISTER_NUM_LIMBS` field elements from the hint stream
-/// and copy them as bytes into guest memory.
+/// HINT_BUFFER: pop `num_words * RV64_REGISTER_NUM_LIMBS` bytes from the hint stream
+/// and copy them into guest memory.
 pub extern "C" fn host_hint_buffer<F: PrimeField32>(
     ctx: *mut c_void,
     dest_addr: u64,
@@ -469,7 +467,7 @@ pub extern "C" fn host_hint_buffer<F: PrimeField32>(
     check_mem_bounds_range(dest_addr, nbytes);
     let dst = unsafe { io.memory_ptr.add(dest_addr as usize) };
     for i in 0..nbytes {
-        let byte = io.hint_stream.pop_front().unwrap().as_canonical_u32() as u8;
+        let byte = io.hint_stream.pop_front().unwrap();
         unsafe { *dst.add(i) = byte };
     }
 }

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -199,7 +199,7 @@ mod tests {
                 .with_extension(Rv64MTranspilerExtension)
                 .with_extension(Rv64IoTranspilerExtension),
         )?;
-        let input = vec![[0, 1, 2, 3].map(F::from_u8).to_vec()];
+        let input = vec![vec![0u8, 1, 2, 3]];
         air_test_with_min_segments(Rv64ImBuilder, config, exe, input, 1);
         Ok(())
     }
@@ -226,9 +226,7 @@ mod tests {
         let expected_len = expected_words * RV64_REGISTER_NUM_LIMBS;
 
         // Create data with a pattern that can be verified
-        let data: Vec<F> = (0..expected_len)
-            .map(|i| F::from_u8((i % 256) as u8))
-            .collect();
+        let data: Vec<u8> = (0..expected_len).map(|i| (i % 256) as u8).collect();
 
         let input = vec![data];
         air_test_with_min_segments(Rv64ImBuilder, config, exe, input, 1);
@@ -257,10 +255,9 @@ mod tests {
             baz: vec![0, 1, 2, 3],
         };
         let serialized_foo = openvm::serde::to_vec(&foo).unwrap();
-        let input = serialized_foo
+        let input: Vec<u8> = serialized_foo
             .into_iter()
             .flat_map(|w| w.to_le_bytes())
-            .map(F::from_u8)
             .collect();
         air_test_with_min_segments(Rv64ImBuilder, config, exe, vec![input], 1);
         Ok(())
@@ -396,7 +393,7 @@ mod tests {
 
         let executor = VmExecutor::new(config)?;
         let instance = executor.instance(&exe)?;
-        let input = vec![[0, 0, 0, 1].map(F::from_u8).to_vec()];
+        let input = vec![vec![0u8, 0, 0, 1]];
         match instance.execute(input.clone(), None) {
             Err(ExecutionError::FailedWithExitCode(_)) => Ok(()),
             Err(_) => panic!("should fail with `FailedWithExitCode`"),

--- a/guest-libs/pairing/tests/lib.rs
+++ b/guest-libs/pairing/tests/lib.rs
@@ -36,10 +36,7 @@ mod bn254 {
     use openvm_riscv_transpiler::{
         Rv64ITranspilerExtension, Rv64IoTranspilerExtension, Rv64MTranspilerExtension,
     };
-    use openvm_stark_sdk::{
-        openvm_stark_backend::{p3_field::PrimeCharacteristicRing, SystemParams},
-        p3_baby_bear::BabyBear,
-    };
+    use openvm_stark_sdk::{openvm_stark_backend::SystemParams, p3_baby_bear::BabyBear};
     use openvm_toolchain_tests::{build_example_program_at_path_with_features, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
     use rand08::SeedableRng;
@@ -121,7 +118,6 @@ mod bn254 {
             .into_iter()
             .flat_map(|fp12| fp12.to_coeffs())
             .flat_map(|fp2| fp2.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
@@ -165,7 +161,6 @@ mod bn254 {
             .chain(r0)
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         // Test mul_by_01234
@@ -177,7 +172,6 @@ mod bn254 {
             .chain(r1.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -218,7 +212,6 @@ mod bn254 {
         let io0 = [s.x, s.y, pt.x, pt.y, l.b, l.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         // Test miller_double_and_add_step
@@ -226,7 +219,6 @@ mod bn254 {
         let io1 = [s.x, s.y, q.x, q.y, pt.x, pt.y, l0.b, l0.c, l1.b, l1.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -270,7 +262,6 @@ mod bn254 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -279,7 +270,6 @@ mod bn254 {
             .chain(f.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -328,7 +318,6 @@ mod bn254 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -336,7 +325,6 @@ mod bn254 {
             .flat_map(|pt| [pt.x, pt.y].into_iter())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -385,7 +373,6 @@ mod bn254 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -393,7 +380,6 @@ mod bn254 {
             .flat_map(|pt| [pt.x, pt.y].into_iter())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -455,11 +441,7 @@ mod bn254 {
         let [c, s] = [c, s].map(|x| openvm_pairing::bn254::Fp12::from_bytes(&x.to_bytes()));
         let io = (ps, qs, (c, s));
         let io = openvm::serde::to_vec(&io).unwrap();
-        let io = io
-            .into_iter()
-            .flat_map(|w| w.to_le_bytes())
-            .map(F::from_u8)
-            .collect();
+        let io = io.into_iter().flat_map(|w| w.to_le_bytes()).collect();
         air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
         Ok(())
     }
@@ -506,10 +488,7 @@ mod bls12_381 {
     use openvm_riscv_transpiler::{
         Rv64ITranspilerExtension, Rv64IoTranspilerExtension, Rv64MTranspilerExtension,
     };
-    use openvm_stark_sdk::{
-        openvm_stark_backend::{p3_field::PrimeCharacteristicRing, SystemParams},
-        p3_baby_bear::BabyBear,
-    };
+    use openvm_stark_sdk::{openvm_stark_backend::SystemParams, p3_baby_bear::BabyBear};
     use openvm_toolchain_tests::{build_example_program_at_path_with_features, get_programs_dir};
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
     use rand08::SeedableRng;
@@ -597,7 +576,6 @@ mod bls12_381 {
             .into_iter()
             .flat_map(|fp12| fp12.to_coeffs())
             .flat_map(|fp2| fp2.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
@@ -641,7 +619,6 @@ mod bls12_381 {
             .chain(r0)
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         // Test mul_by_02345
@@ -654,7 +631,6 @@ mod bls12_381 {
             .chain(r1.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -695,7 +671,6 @@ mod bls12_381 {
         let io0 = [s.x, s.y, pt.x, pt.y, l.b, l.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         // Test miller_double_and_add_step
@@ -703,7 +678,6 @@ mod bls12_381 {
         let io1 = [s.x, s.y, q.x, q.y, pt.x, pt.y, l0.b, l0.c, l1.b, l1.c]
             .into_iter()
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -753,7 +727,6 @@ mod bls12_381 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -762,7 +735,6 @@ mod bls12_381 {
             .chain(f.to_coeffs())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -810,7 +782,6 @@ mod bls12_381 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -818,7 +789,6 @@ mod bls12_381 {
             .flat_map(|pt| [pt.x, pt.y].into_iter())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -867,7 +837,6 @@ mod bls12_381 {
         let io0 = s
             .into_iter()
             .flat_map(|pt| [pt.x, pt.y].into_iter().flat_map(|fp| fp.to_bytes()))
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io1 = q
@@ -875,7 +844,6 @@ mod bls12_381 {
             .flat_map(|pt| [pt.x, pt.y].into_iter())
             .flat_map(|fp2| fp2.to_coeffs())
             .flat_map(|fp| fp.to_bytes())
-            .map(F::from_u8)
             .collect::<Vec<_>>();
 
         let io_all = io0.into_iter().chain(io1).collect::<Vec<_>>();
@@ -937,11 +905,7 @@ mod bls12_381 {
         let [c, s] = [c, s].map(|x| openvm_pairing::bls12_381::Fp12::from_bytes(&x.to_bytes()));
         let io = (ps, qs, (c, s));
         let io = openvm::serde::to_vec(&io).unwrap();
-        let io = io
-            .into_iter()
-            .flat_map(|w| w.to_le_bytes())
-            .map(F::from_u8)
-            .collect();
+        let io = io.into_iter().flat_map(|w| w.to_le_bytes()).collect();
         air_test_with_min_segments(Rv64PairingBuilder, config, openvm_exe, vec![io], 1);
         Ok(())
     }

--- a/guest-libs/verify-stark/circuit/src/tests.rs
+++ b/guest-libs/verify-stark/circuit/src/tests.rs
@@ -41,7 +41,6 @@ use openvm_transpiler::{
     elf::Elf, openvm_platform::memory::MEM_SIZE, transpiler::Transpiler, FromElf,
 };
 use openvm_verify_stark_host::pvs::{VerifierBasePvs, VmPvs, VERIFIER_PVS_AIR_ID, VM_PVS_AIR_ID};
-use p3_field::PrimeCharacteristicRing;
 use test_case::test_case;
 use tracing::Level;
 
@@ -94,10 +93,7 @@ fn run_leaf_aggregation(
             .with_extension(Rv64MTranspilerExtension)
             .with_extension(Rv64IoTranspilerExtension),
     )?;
-    let input = (1u64 << log_fib_input)
-        .to_le_bytes()
-        .map(F::from_u8)
-        .to_vec();
+    let input = (1u64 << log_fib_input).to_le_bytes().to_vec();
 
     let engine = Engine::new(app_params_with_100_bits_security(21));
     let (vm, app_pk) = VirtualMachine::new_with_keygen(engine, Rv64ImBuilder, config)?;


### PR DESCRIPTION
Refactor input and hint stream to use byte-backed storage. The goal of this PR is to remove field-element typed streams since elements inside are still treated as bytes. The PR consist of following parts:
1. updating input and hint to byte-backed storage.
2. removing generic <F> from the Stream, Stdin and its associated structs. #2983
3. re-read documentation and ensure that it matches the updated code.

This PR, first one, mainly focused on updating `input_stream` to `VecDeque<Vec<u8>>` and `hint_stream` to `VecDeque<u8>`, updating relevant code and removing `F::from_u8`. Relevant documentation was also slightly updated to match the refactoring. `Rv64HintInput` description got also updated to match the refactoring.

`write_field` was deleted, as it might be redundant. If we interpret it as little endian, then I feel like there would be the almost no difference between `write_field` and `write_bytes`.

towards INT-8549