### PR TITLE
perf(vm): pinned host-memory pool for dense record arenas

### DIFF
--- a/crates/vm/src/arch/cuda/mod.rs
+++ b/crates/vm/src/arch/cuda/mod.rs
@@ -1,0 +1,3 @@
+//! CUDA-specific support for the VM architecture layer.
+
+pub(crate) mod pinned;

--- a/crates/vm/src/arch/cuda/pinned.rs
+++ b/crates/vm/src/arch/cuda/pinned.rs
@@ -1,0 +1,167 @@
+//! Page-locked (pinned) buffer pool for
+//! [`DenseRecordArena`](crate::arch::record_arena::DenseRecordArena).
+//!
+//! Record arenas are allocated fresh for every chip in every segment and their
+//! contents are copied host-to-device at trace generation time. Copies from
+//! pageable memory run at a fraction of PCIe bandwidth, but page-locking a
+//! buffer is itself expensive (~1-2 GB/s), and arenas are provisioned at full
+//! trace size while typically only partially written, so neither registration
+//! nor re-zeroing may sit on the preflight critical path. Dropped buffers are
+//! therefore handed to a background cleaner thread which registers them once
+//! (`cudaHostRegister`), zeroes the prefix the previous owner wrote, and only
+//! then returns them to the pool. [`take`] hands out ready (registered,
+//! all-zero) buffers on a pool hit; on a miss it falls back to a fresh
+//! pageable allocation — exactly the pre-pool behavior — so the worst case (no
+//! CUDA device, cleaner not yet caught up) matches the status quo. Capacities
+//! are rounded up to the next power of two so recurring per-chip arenas of
+//! varying heights share pool entries.
+//!
+//! Lifetime hazard: `cudaMemcpyAsync` from *pageable* memory returns only
+//! after the source has been staged, so the pre-pool code could free an arena
+//! right after enqueueing its copy. From *pinned* memory the call returns
+//! immediately with the DMA still in flight, so a returned buffer must not be
+//! zeroed or reused until previously enqueued work has drained. The cleaner
+//! therefore calls `cudaDeviceSynchronize` (batched over every buffer waiting
+//! in its queue) before touching buffer contents.
+
+use std::{
+    collections::BTreeMap,
+    ffi::c_void,
+    sync::{mpsc, Mutex, OnceLock},
+};
+
+/// A dropped arena buffer together with its dirty-prefix length.
+type ReturnedBuffer = (Vec<u8>, usize);
+
+extern "C" {
+    fn cudaHostRegister(ptr: *mut c_void, size: usize, flags: u32) -> i32;
+    fn cudaHostUnregister(ptr: *mut c_void) -> i32;
+    fn cudaDeviceSynchronize() -> i32;
+}
+
+/// Registered, all-zero buffers ready for reuse, keyed by allocation size.
+fn pool() -> &'static Mutex<BTreeMap<usize, Vec<Vec<u8>>>> {
+    static POOL: OnceLock<Mutex<BTreeMap<usize, Vec<Vec<u8>>>>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Base pointers of buffers whose `cudaHostRegister` succeeded.
+fn registered() -> &'static Mutex<std::collections::HashSet<usize>> {
+    static REGISTERED: OnceLock<Mutex<std::collections::HashSet<usize>>> = OnceLock::new();
+    REGISTERED.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Cleaner thread: registers (first cycle) and re-zeroes buffers off the
+/// critical path, then makes them available to [`take`].
+fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
+    static TX: OnceLock<Mutex<mpsc::Sender<ReturnedBuffer>>> = OnceLock::new();
+    TX.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<ReturnedBuffer>();
+        std::thread::Builder::new()
+            .name("record-arena-pinner".into())
+            .spawn(move || {
+                while let Ok(first) = rx.recv() {
+                    // Coalesce the per-segment burst of arena drops behind
+                    // one device sync; repeated device-wide syncs stall
+                    // concurrent kernel launches. Buffers are not needed
+                    // again before the next segment's preflight, so a
+                    // short idle window costs nothing.
+                    let mut batch = vec![first];
+                    while batch.len() < 64 {
+                        match rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                            Ok(next) => batch.push(next),
+                            Err(_) => break,
+                        }
+                    }
+                    // The H2D copies reading these buffers were enqueued
+                    // before the owning arenas dropped; wait for them (and
+                    // anything else in flight) before touching contents.
+                    let rc = unsafe { cudaDeviceSynchronize() };
+                    if rc != 0 {
+                        // No usable CUDA context (teardown or no device):
+                        // the buffers cannot be proven idle; drop them.
+                        tracing::debug!(
+                            "cudaDeviceSynchronize failed with {rc}; \
+                             dropping {} record arena buffers",
+                            batch.len()
+                        );
+                        continue;
+                    }
+                    for (mut buffer, dirty_len) in batch {
+                        let ptr = buffer.as_mut_ptr();
+                        let is_new = !registered().lock().unwrap().contains(&(ptr as usize));
+                        if is_new {
+                            // SAFETY: the buffer is a live allocation of `len`
+                            // bytes; the pool keeps it alive while registered.
+                            let rc =
+                                unsafe { cudaHostRegister(ptr as *mut c_void, buffer.len(), 0) };
+                            if rc != 0 {
+                                // Out of pinnable memory: drop the buffer,
+                                // never pool it.
+                                tracing::debug!(
+                                    "cudaHostRegister failed with {rc}; \
+                                     record arena buffer stays pageable"
+                                );
+                                continue;
+                            }
+                            registered().lock().unwrap().insert(ptr as usize);
+                        }
+                        // Restore the fresh-arena invariant (all zero). Bytes
+                        // past the dirty prefix were never written or were
+                        // cleared on an earlier cycle.
+                        let dirty_len = dirty_len.min(buffer.len());
+                        buffer[..dirty_len].fill(0);
+                        pool()
+                            .lock()
+                            .unwrap()
+                            .entry(buffer.len())
+                            .or_default()
+                            .push(buffer);
+                    }
+                }
+            })
+            .expect("failed to spawn record-arena pinner thread");
+        Mutex::new(tx)
+    })
+}
+
+pub(crate) fn take(min_size: usize) -> Vec<u8> {
+    let size = min_size.next_power_of_two();
+    if let Some(buffer) = pool()
+        .lock()
+        .unwrap()
+        .get_mut(&size)
+        .and_then(|bufs| bufs.pop())
+    {
+        debug_assert_eq!(buffer.len(), size);
+        return buffer;
+    }
+    // Pool miss: pageable memory, zeroed lazily by the kernel, exactly as
+    // without the pool. The buffer becomes pinned when first given back.
+    vec![0u8; size]
+}
+
+/// `dirty_len` is an upper bound on the prefix of `buffer` that may have
+/// been written since it left [`take`]; the rest must still be zero.
+pub(crate) fn give_back(buffer: Vec<u8>, dirty_len: usize) {
+    if buffer.is_empty() || !buffer.len().is_power_of_two() {
+        return; // not a pool-shaped buffer; drop normally
+    }
+    // The cleaner owning the receiver never exits, so send only fails if
+    // the buffer raced process teardown; dropping it then is fine.
+    let _ = cleaner().lock().unwrap().send((buffer, dirty_len));
+}
+
+/// Unregisters and frees all pooled buffers (test hygiene; optional).
+#[allow(dead_code)]
+pub(crate) fn clear() {
+    let mut pool = pool().lock().unwrap();
+    let mut reg = registered().lock().unwrap();
+    for (_, bufs) in pool.iter_mut() {
+        for mut buf in bufs.drain(..) {
+            reg.remove(&(buf.as_ptr() as usize));
+            unsafe { cudaHostUnregister(buf.as_mut_ptr() as *mut c_void) };
+        }
+    }
+    pool.clear();
+}

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -1,4 +1,7 @@
 mod config;
+/// CUDA-specific support (pinned host-memory pool for record arenas).
+#[cfg(feature = "cuda")]
+mod cuda;
 /// Streams-like deferral state
 pub mod deferral;
 /// Instruction execution traits and types.

--- a/crates/vm/src/arch/record_arena.rs
+++ b/crates/vm/src/arch/record_arena.rs
@@ -11,6 +11,11 @@ use openvm_stark_backend::{
     p3_matrix::dense::RowMajorMatrix,
 };
 
+/// Pinned host-memory pool backing [DenseRecordArena] buffers under CUDA; see
+/// that module for the design and the async-copy lifetime hazard it handles.
+#[cfg(feature = "cuda")]
+use super::cuda::pinned;
+
 pub trait Arena {
     /// Currently `width` always refers to the main trace width.
     fn with_capacity(height: usize, width: usize) -> Self;
@@ -174,9 +179,20 @@ pub struct DenseRecordArena {
 const MAX_ALIGNMENT: usize = 32;
 
 impl DenseRecordArena {
+    fn new_buffer(size_bytes: usize) -> Vec<u8> {
+        #[cfg(feature = "cuda")]
+        {
+            pinned::take(size_bytes + MAX_ALIGNMENT)
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            vec![0; size_bytes + MAX_ALIGNMENT]
+        }
+    }
+
     /// Creates a new [DenseRecordArena] with the given capacity in bytes.
     pub fn with_byte_capacity(size_bytes: usize) -> Self {
-        let buffer = vec![0; size_bytes + MAX_ALIGNMENT];
+        let buffer = Self::new_buffer(size_bytes);
         let offset = (MAX_ALIGNMENT - (buffer.as_ptr() as usize % MAX_ALIGNMENT)) % MAX_ALIGNMENT;
         let mut cursor = Cursor::new(buffer);
         cursor.set_position(offset as u64);
@@ -186,10 +202,15 @@ impl DenseRecordArena {
     }
 
     pub fn set_byte_capacity(&mut self, size_bytes: usize) {
-        let buffer = vec![0; size_bytes + MAX_ALIGNMENT];
+        let buffer = Self::new_buffer(size_bytes);
         let offset = (MAX_ALIGNMENT - (buffer.as_ptr() as usize % MAX_ALIGNMENT)) % MAX_ALIGNMENT;
         let mut cursor = Cursor::new(buffer);
         cursor.set_position(offset as u64);
+        #[cfg(feature = "cuda")]
+        {
+            let dirty_len = self.records_buffer.position() as usize;
+            pinned::give_back(std::mem::take(self.records_buffer.get_mut()), dirty_len);
+        }
         self.records_buffer = cursor;
     }
 
@@ -249,6 +270,14 @@ impl DenseRecordArena {
     // Returns a [RecordSeeker] on the allocated buffer
     pub fn get_record_seeker<R, L>(&mut self) -> RecordSeeker<'_, DenseRecordArena, R, L> {
         RecordSeeker::new(self.allocated_mut())
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl Drop for DenseRecordArena {
+    fn drop(&mut self) {
+        let dirty_len = self.records_buffer.position() as usize;
+        pinned::give_back(std::mem::take(self.records_buffer.get_mut()), dirty_len);
     }
 }
 


### PR DESCRIPTION
Record arenas (`DenseRecordArena`) are freshly allocated per chip per segment and their
contents are copied host-to-device at trace-generation time. Measured on the reth
workload (mainnet block 23992138): ~40 GB of records per block copied at ~11 GB/s —
pageable-memory PCIe throughput — costing ~3.5 s of `trace_gen.h2d_records_time_ms`
per block, i.e. the majority of the remaining (non-kernel) tracegen wall time.

## Change

Pin arena buffers with `cudaHostRegister` and recycle them across segments through a
size-classed pool (capacities rounded up to the next power of two so recurring
per-chip arenas of varying heights share pool entries). Copies from registered memory
take the DMA fast path automatically, so no call sites change anywhere.

Both page-locking (~1-2 GB/s) and re-zeroing cost seconds per proof if done on the
preflight critical path — arenas are provisioned at full trace size but only
partially written — so dropped buffers are handed to a background cleaner thread
(`crates/vm/src/arch/cuda/pinned.rs`) that:

1. waits for in-flight device work with a `cudaDeviceSynchronize`, batched per burst
   of dropped arenas (see the lifetime hazard below);
2. registers the buffer on its first cycle (per-buffer registration is tracked by
   base pointer; unregistered buffers are never pooled);
3. zeroes the dirty prefix the previous owner wrote (cursor position at drop) —
   bytes past it are still zero from the previous cycle;
4. only then returns the buffer to the pool.

Pool misses fall back to a fresh pageable allocation, exactly the pre-pool behavior,
so the worst case (no CUDA context, cleaner not yet caught up) matches the status
quo. Everything is `#[cfg(feature = "cuda")]`; the non-CUDA path is byte-for-byte
unchanged. Host-memory overhead is bounded by one segment's worth of arenas per size
class (pool entries are reused, not accumulated, in steady state).

### Lifetime hazard (why the cleaner synchronizes)

`cudaMemcpyAsync` from *pageable* memory returns only after the source has been
staged, which is what made freeing an arena right after enqueueing its copy safe
before this PR. From *pinned* memory the call returns immediately with the DMA still
in flight, so a returned buffer must not be zeroed or reused until previously
enqueued work has drained. An earlier revision of this PR zeroed on drop without
synchronizing and corrupted records under load (caught by the fibonacci CI benchmark
as a `LogupZerocheck` failure); the batched device sync in the cleaner is the fix,
and it keeps the wait entirely off the preflight/tracegen critical path.

## Measured impact

openvm-eth reth benchmark, block 23992138, baseline `main` vs this branch, both
variants run back-to-back on the same RTX Pro 6000 sandbox (VPMM pool capped at
15 GiB; both proofs verify, peak VRAM unchanged):

| phase | main | this PR | delta |
|---|---|---|---|
| `execute_metered_time_ms` (control) | 4,051 | 3,968 | −2.0% |
| `execute_preflight_time_ms` | 20,635 | 15,342 | **−25.7%** |
| `trace_gen_time_ms` | 5,886 | 5,170 | **−12.2%** |
| `trace_gen.h2d_records_time_ms` | 1,459 | 118 | **−91.9%** |
| `stark_prove_excluding_trace_time_ms` | 43,868 | 45,277 | +3.2% |
| `total_proof_time_ms` | 72,016 | 67,644 | **−6.1%** |

The preflight win comes from reuse: pooled buffers are already resident, so record
writes stop paying the page-fault + kernel-zeroing cost of fresh allocations.
`h2d_records` measures the enqueue of the (now truly asynchronous) copies; the
residual 118 ms is the first segments' pageable copies before the pool warms up.

Note: the GPU-tracegen PRs (#2984, #2989) touch the same workload; this change is
independent of them (the arenas and copy path predate those PRs) and they will be
rebased on top of whichever lands first.
