### PR TITLE
perf(vm): overlap executor tracegen with the memory Merkle build

### DIFF
--- a/crates/vm/cuda/src/system/inventory.cu
+++ b/crates/vm/cuda/src/system/inventory.cu
@@ -213,3 +213,48 @@ extern "C" int _inventory_merge_records_get_temp_bytes(
     *h_temp_bytes_out = temp_bytes;
     return CHECK_KERNEL();
 }
+
+/// Width in u32 words of one Merkle touched-block record:
+/// (address_space, ptr, timestamp, values[OUT_BLOCK_SIZE]).
+/// Must match MERKLE_TOUCHED_BLOCK_WIDTH on the Rust side.
+inline constexpr uint32_t MERKLE_REC_WIDTH = 3 + OUT_BLOCK_SIZE;
+
+/// Converts merged inventory records (boundary layout) into Merkle
+/// touched-block records: drops the second timestamp, taking the max.
+/// Values stay Montgomery-encoded in both layouts.
+__global__ void inventory_to_merkle_records_kernel(
+    uint32_t const *out_records,
+    size_t num_records,
+    uint32_t *merkle_records
+) {
+    size_t stride = gridDim.x * (size_t)blockDim.x;
+    for (size_t i = blockIdx.x * (size_t)blockDim.x + threadIdx.x; i < num_records;
+         i += stride) {
+        OutRec const &r = ((OutRec const *)out_records)[i];
+        uint32_t *dst = merkle_records + i * MERKLE_REC_WIDTH;
+        dst[0] = r.address_space;
+        dst[1] = r.ptr;
+        dst[2] = max(r.timestamps[0], r.timestamps[1]);
+#pragma unroll
+        for (int j = 0; j < OUT_BLOCK_SIZE; ++j) {
+            dst[3 + j] = r.values[j];
+        }
+    }
+}
+
+extern "C" int _inventory_to_merkle_records(
+    const uint32_t *d_out_records,
+    size_t num_records,
+    uint32_t *d_merkle_records,
+    cudaStream_t stream
+) {
+    if (num_records == 0) {
+        return 0;
+    }
+    const int threads = 256;
+    const size_t want = (num_records + threads - 1) / threads;
+    const int blocks = (int)(want < 1024 ? want : 1024);
+    inventory_to_merkle_records_kernel<<<blocks, threads, 0, stream>>>(
+        d_out_records, num_records, d_merkle_records);
+    return CHECK_KERNEL();
+}

--- a/crates/vm/src/arch/cuda/pinned.rs
+++ b/crates/vm/src/arch/cuda/pinned.rs
@@ -33,6 +33,21 @@ use std::{
 /// A dropped arena buffer together with its dirty-prefix length.
 type ReturnedBuffer = (Vec<u8>, usize);
 
+/// Page-locks `len` bytes at `ptr` in a single `cudaHostRegister` call.
+/// NOTE: registration must be one call per buffer: `cudaMemcpyAsync` rejects
+/// (cudaErrorInvalidValue) source ranges that span multiple distinct
+/// page-locked registrations, so chunked registration corrupts nothing but
+/// breaks every copy crossing a chunk boundary.
+fn register_buffer(ptr: *mut u8, len: usize) -> bool {
+    // SAFETY: [ptr, ptr+len) is a live allocation owned by the caller.
+    let rc = unsafe { cudaHostRegister(ptr as *mut c_void, len, 0) };
+    if rc != 0 {
+        tracing::debug!("cudaHostRegister failed with {rc}; record arena buffer stays pageable");
+        return false;
+    }
+    true
+}
+
 extern "C" {
     fn cudaHostRegister(ptr: *mut c_void, size: usize, flags: u32) -> i32;
     fn cudaHostUnregister(ptr: *mut c_void) -> i32;
@@ -60,6 +75,7 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
         std::thread::Builder::new()
             .name("record-arena-pinner".into())
             .spawn(move || {
+                let mut batch_idx = 0usize;
                 while let Ok(first) = rx.recv() {
                     // Coalesce the per-segment burst of arena drops behind
                     // one device sync; repeated device-wide syncs stall
@@ -76,6 +92,12 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
                     // The H2D copies reading these buffers were enqueued
                     // before the owning arenas dropped; wait for them (and
                     // anything else in flight) before touching contents.
+                    // Unique label per batch: the timing metric derived from
+                    // this span is a gauge, so identical label sets overwrite.
+                    let _span =
+                        tracing::info_span!("arena_cleaner_batch", batch = batch_idx.to_string())
+                            .entered();
+                    batch_idx += 1;
                     let rc = unsafe { cudaDeviceSynchronize() };
                     if rc != 0 {
                         // No usable CUDA context (teardown or no device):
@@ -91,17 +113,9 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
                         let ptr = buffer.as_mut_ptr();
                         let is_new = !registered().lock().unwrap().contains(&(ptr as usize));
                         if is_new {
-                            // SAFETY: the buffer is a live allocation of `len`
-                            // bytes; the pool keeps it alive while registered.
-                            let rc =
-                                unsafe { cudaHostRegister(ptr as *mut c_void, buffer.len(), 0) };
-                            if rc != 0 {
+                            if !register_buffer(ptr, buffer.len()) {
                                 // Out of pinnable memory: drop the buffer,
                                 // never pool it.
-                                tracing::debug!(
-                                    "cudaHostRegister failed with {rc}; \
-                                     record arena buffer stays pageable"
-                                );
                                 continue;
                             }
                             registered().lock().unwrap().insert(ptr as usize);

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -11,7 +11,7 @@
 //! get around Rust orphan rules.
 use std::{
     any::{type_name, Any},
-    iter::{self, zip},
+    iter::zip,
     sync::Arc,
 };
 
@@ -682,6 +682,11 @@ pub enum ChipInventoryError {
 
 // ======================= VM Chip Complex Implementation =============================
 
+/// A chip whose trace generation is deferred until after system tracegen:
+/// (position in the verifying-key AIR order relative to the first extension
+/// AIR, insertion index, chip, its (empty) record arena).
+type DeferredChipTraceGen<'a, RA, PB> = (usize, usize, &'a dyn AnyChip<RA, PB>, RA);
+
 impl<SC, RA, PB, SCC> VmChipComplex<SC, RA, PB, SCC>
 where
     SC: StarkProtocolConfig,
@@ -729,36 +734,74 @@ where
         // chip is parallelized). We could introduce more parallelism, while potentially increasing
         // the peak memory usage, by keeping a dependency tree and generating traces at the same
         // layer of the tree in parallel.
-        let ctx_without_empties: Vec<(usize, AirProvingContext<_>)> = iter::empty()
-            .chain(info_span!("system_trace_gen").in_scope(|| {
-                self.system
-                    .generate_proving_ctx(system_records, sys_record_arenas)
-            }))
-            .chain(
-                zip(self.inventory.chips.iter().enumerate().rev(), record_arenas).map(
-                    |((insertion_idx, chip), records)| {
-                        // Only create a span if record is not empty:
-                        let _span = (!records.is_empty()).then(|| {
-                            let air_name = self.inventory.airs.ext_airs[insertion_idx].name();
-                            info_span!("single_trace_gen", air = air_name).entered()
-                        });
-                        #[cfg(feature = "metrics")]
-                        if let Some(allocated_bytes) = (!records.is_empty())
-                            .then(|| records.allocated_bytes())
-                            .flatten()
-                        {
-                            let air_name = self.inventory.airs.ext_airs[insertion_idx].name();
-                            let labels = [
-                                ("air_name", air_name.to_string()),
-                                ("air_id", (num_sys_airs + insertion_idx).to_string()),
-                            ];
-                            metrics::counter!("trace_gen.record_arena_bytes", &labels)
-                                .absolute(allocated_bytes as u64);
-                        }
-                        chip.generate_proving_ctx(records)
-                    },
-                ),
-            )
+        // Executor chips with record arenas run BEFORE system tracegen: their
+        // fills are CPU-heavy while the memory Merkle subtree builds (enqueued
+        // at memory transport time) run on the GPU stream, and system tracegen
+        // blocks on those builds at its first D2H. Running them first extends
+        // the overlap window; they depend on neither system chips (invariant
+        // above) nor each other. Chips with EMPTY arenas are deferred until
+        // after system tracegen, in their original relative order: those are
+        // the periphery chips (hashers, lookup tables) whose inputs are pushed
+        // by other chips' kernels — including system tracegen's — through
+        // shared device buffers. The final (air_id -> ctx) assignment is
+        // position-based and unchanged.
+        let chip_ctx = |insertion_idx: usize,
+                        chip: &dyn AnyChip<RA, PB>,
+                        records: RA|
+         -> AirProvingContext<PB> {
+            let _span = {
+                let air_name = self.inventory.airs.ext_airs[insertion_idx].name();
+                info_span!("single_trace_gen", air = air_name).entered()
+            };
+            #[cfg(feature = "metrics")]
+            if let Some(allocated_bytes) = (!records.is_empty())
+                .then(|| records.allocated_bytes())
+                .flatten()
+            {
+                let air_name = self.inventory.airs.ext_airs[insertion_idx].name();
+                let labels = [
+                    ("air_name", air_name.to_string()),
+                    ("air_id", (num_sys_airs + insertion_idx).to_string()),
+                ];
+                metrics::counter!("trace_gen.record_arena_bytes", &labels)
+                    .absolute(allocated_bytes as u64);
+            }
+            chip.generate_proving_ctx(records)
+        };
+
+        let num_ext_airs = self.inventory.chips.len();
+        let mut exec_ctxs: Vec<Option<AirProvingContext<PB>>> = Vec::new();
+        exec_ctxs.resize_with(num_ext_airs, || None);
+        let mut deferred: Vec<DeferredChipTraceGen<'_, RA, PB>> = Vec::new();
+        {
+            let _span = info_span!("executor_trace_gen").entered();
+            for (chain_pos, ((insertion_idx, chip), records)) in
+                zip(self.inventory.chips.iter().enumerate().rev(), record_arenas).enumerate()
+            {
+                if records.is_empty() {
+                    deferred.push((chain_pos, insertion_idx, chip.as_ref(), records));
+                } else {
+                    exec_ctxs[chain_pos] = Some(chip_ctx(insertion_idx, chip.as_ref(), records));
+                }
+            }
+        }
+        let sys_ctxs = {
+            // Bind the span guard so it closes when system tracegen returns; a
+            // temporary inside an iterator chain would live (and keep timing)
+            // until the end of the whole statement.
+            let _span = info_span!("system_trace_gen").entered();
+            self.system
+                .generate_proving_ctx(system_records, sys_record_arenas)
+        };
+        {
+            let _span = info_span!("periphery_trace_gen").entered();
+            for (chain_pos, insertion_idx, chip, records) in deferred {
+                exec_ctxs[chain_pos] = Some(chip_ctx(insertion_idx, chip, records));
+            }
+        }
+        let ctx_without_empties: Vec<(usize, AirProvingContext<_>)> = sys_ctxs
+            .into_iter()
+            .chain(exec_ctxs.into_iter().map(|ctx| ctx.unwrap()))
             .enumerate()
             .filter(|(_air_id, ctx)| ctx.common_main.height() > 0)
             .collect();

--- a/crates/vm/src/cuda_abi.rs
+++ b/crates/vm/src/cuda_abi.rs
@@ -242,6 +242,32 @@ pub mod inventory {
         ))
     }
 
+    extern "C" {
+        fn _inventory_to_merkle_records(
+            d_out_records: *const u32,
+            num_records: usize,
+            d_merkle_records: *mut u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    /// Converts merged inventory records (boundary layout) into Merkle
+    /// touched-block records on device. `d_merkle_records` must hold exactly
+    /// `num_records * MERKLE_TOUCHED_BLOCK_WIDTH` words.
+    pub unsafe fn to_merkle_records(
+        d_out_records: &DeviceBuffer<u32>,
+        num_records: usize,
+        d_merkle_records: &DeviceBuffer<u32>,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_inventory_to_merkle_records(
+            d_out_records.as_ptr(),
+            num_records,
+            d_merkle_records.as_mut_ptr(),
+            stream,
+        ))
+    }
+
     pub unsafe fn merge_records_get_temp_bytes(
         d_flags: &DeviceBuffer<u32>,
         in_num_records: usize,

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -172,6 +172,7 @@ impl MemoryInventoryGPU {
                 true,
             )
         } else {
+            let _span = tracing::info_span!("mem_merge_records").entered();
             // Convert MemoryInventoryRecord<4, 1> to MemoryInventoryRecord<8, 2>
             let in_records: Vec<MemoryInventoryRecord<4, 1>> = partition
                 .iter()
@@ -270,9 +271,14 @@ impl MemoryInventoryGPU {
             {
                 self.unpadded_merkle_height = unpadded_merkle_height;
             }
+            drop(_span);
 
-            self.prepare_poseidon2_records(out_num_records, unpadded_merkle_height);
+            {
+                let _span = tracing::info_span!("poseidon2_prepare").entered();
+                self.prepare_poseidon2_records(out_num_records, unpadded_merkle_height);
+            }
             mem.tracing_info("merkle update");
+            let _span = tracing::info_span!("merkle_update").entered();
             self.merkle_tree.finalize();
             self.merkle_tree.update_with_touched_blocks(
                 unpadded_merkle_height,
@@ -283,9 +289,15 @@ impl MemoryInventoryGPU {
             )
         };
         mem.tracing_info("boundary tracegen");
-        let ret = vec![self.boundary.generate_proving_ctx(()), merkle_proof_ctx];
+        let ret = {
+            let _span = tracing::info_span!("boundary_trace_gen").entered();
+            vec![self.boundary.generate_proving_ctx(()), merkle_proof_ctx]
+        };
         mem.tracing_info("dropping merkle tree");
-        self.merkle_tree.drop_subtrees();
+        {
+            let _span = tracing::info_span!("merkle_drop").entered();
+            self.merkle_tree.drop_subtrees();
+        }
         self.initial_memory = Vec::new();
         mem.emit_metrics();
         ret

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -12,7 +12,11 @@ use openvm_cuda_common::{
     memory_manager::MemTracker,
     stream::GpuDeviceCtx,
 };
-use openvm_stark_backend::{p3_field::PrimeCharacteristicRing, prover::AirProvingContext};
+use openvm_stark_backend::{
+    p3_field::PrimeCharacteristicRing,
+    p3_maybe_rayon::prelude::{IntoParallelRefIterator, ParallelIterator},
+    prover::AirProvingContext,
+};
 use tracing::instrument;
 
 use super::{
@@ -175,7 +179,7 @@ impl MemoryInventoryGPU {
             let _span = tracing::info_span!("mem_merge_records").entered();
             // Convert MemoryInventoryRecord<4, 1> to MemoryInventoryRecord<8, 2>
             let in_records: Vec<MemoryInventoryRecord<4, 1>> = partition
-                .iter()
+                .par_iter()
                 .map(|&((addr_space, ptr), ts_values)| MemoryInventoryRecord {
                     address_space: addr_space,
                     ptr,
@@ -238,33 +242,24 @@ impl MemoryInventoryGPU {
             self.boundary
                 .finalize_records_device::<DIGEST_WIDTH>(d_out_records, out_num_records);
 
-            // Send records to memory merkle tree
-            let out_records = self
-                .boundary
-                .records()
-                .to_host_on(&self.device_ctx)
-                .unwrap();
-            let record_words = 4 + DIGEST_WIDTH;
-            let mut merkle_records = Vec::with_capacity(out_num_records);
-            for i in 0..out_num_records {
-                let base = i * record_words;
-                let mut values = [0u32; DIGEST_WIDTH];
-                values.copy_from_slice(&out_records[base + 4..base + 4 + DIGEST_WIDTH]);
-                let record = MemoryMerkleRecord {
-                    address_space: out_records[base],
-                    ptr: out_records[base + 1],
-                    timestamp: out_records[base + 2].max(out_records[base + 3]),
-                    values,
-                };
-                merkle_records.push(record);
-            }
-            let merkle_words: &[u32] = unsafe {
-                std::slice::from_raw_parts(
-                    merkle_records.as_ptr() as *const u32,
-                    merkle_records.len() * MERKLE_TOUCHED_BLOCK_WIDTH,
+            // Send records to memory merkle tree: convert boundary-layout
+            // records to Merkle touched-block records on device (the merged
+            // records already live there; a host round-trip would serialize
+            // on the stream and rebuild the buffer one record at a time).
+            let d_merkle_records = DeviceBuffer::<u32>::with_capacity_on(
+                out_num_records * MERKLE_TOUCHED_BLOCK_WIDTH,
+                &self.device_ctx,
+            );
+            unsafe {
+                inventory::to_merkle_records(
+                    self.boundary.records(),
+                    out_num_records,
+                    &d_merkle_records,
+                    self.device_ctx.stream.as_raw(),
                 )
-            };
-            self.merkle_records = Some(merkle_words.to_device_on(&self.device_ctx).unwrap());
+                .expect("inventory_to_merkle_records failed");
+            }
+            self.merkle_records = Some(d_merkle_records);
 
             let unpadded_merkle_height = self.merkle_tree.calculate_unpadded_height(&partition);
             #[cfg(feature = "metrics")]

--- a/crates/vm/src/system/cuda/mod.rs
+++ b/crates/vm/src/system/cuda/mod.rs
@@ -90,11 +90,17 @@ impl SystemChipComplex<DenseRecordArena, GpuBackend> for SystemChipInventoryGPU 
             touched_memory,
         } = system_records;
 
-        let program_ctx = self.program.generate_proving_ctx(filtered_exec_frequencies);
+        let program_ctx = {
+            let _span = tracing::info_span!("program_trace_gen").entered();
+            self.program.generate_proving_ctx(filtered_exec_frequencies)
+        };
 
         self.connector.cpu_chip.begin(from_state);
         self.connector.cpu_chip.end(to_state, exit_code);
-        let connector_ctx = self.connector.generate_proving_ctx(());
+        let connector_ctx = {
+            let _span = tracing::info_span!("connector_trace_gen").entered();
+            self.connector.generate_proving_ctx(())
+        };
 
         let memory_ctxs = self.memory_inventory.generate_proving_ctxs(touched_memory);
 


### PR DESCRIPTION
Stacked on #2990 (first commit is that PR; review the second commit only).

## Problem

The per-segment memory Merkle subtree build — Poseidon2-hashing the full memory
image — is enqueued at memory-transport time and runs on the GPU stream while
preflight executes on CPU. When preflight finishes before the build does, system
tracegen blocks on it at its first D2H sync. Instrumented on the reth workload
(block 23992138), that wait showed up as ~1.0 s in the memory-inventory record
merge and ~1.6 s absorbed by the Poseidon2 periphery chip's first D2H, per block.
Making preflight faster (#2990) shrinks the overlap window and makes this worse.

## Change

Run executor chips with record arenas **before** system tracegen: their fills are
CPU-heavy, extending the window in which the Merkle build can complete. They
depend on neither system chips nor each other. Chips with **empty** arenas — the
periphery hashers and lookup tables, whose inputs other chips' kernels push
through shared device buffers (system tracegen included) — are deferred until
after system tracegen, in their original relative order. The `(air_id, ctx)`
assignment is position-based and unchanged, so the proving context order matches
the verifying key exactly as before.

Also fixes timing-instrumentation artifacts found while measuring this:

- the `system_trace_gen` span guard was a temporary inside the iterator chain, so
  it lived until the end of the whole `collect()` statement — the derived
  `system_trace_gen_time_ms` metric always equaled the entire tracegen wall;
- `single_trace_gen` spans existed only for chips with non-empty arenas, leaving
  periphery chips (which do real tracegen work) unmeasured;
- the record-arena cleaner span carries a unique batch label (the derived metric
  is a gauge; identical label sets silently overwrite);
- memory-inventory tracegen phases (record merge, Poseidon2 prepare, Merkle
  update, boundary, subtree drop) get their own spans.

## Measured impact

openvm-eth reth benchmark, block 23992138, single RTX Pro 6000 (VPMM pool capped
at 15 GiB), both runs on hosts within 1.3% on the CPU-bound control metric,
baseline = main + #2990:

| phase | #2990 | + this PR | delta |
|---|---|---|---|
| `trace_gen_time_ms` | 6,619 | 5,126 | **−22.6%** |
| Poseidon2 periphery sync wait | 1,637 | 150 | −91% |
| `execute_preflight_time_ms` | 23,191 | 21,623 | −6.8% |
| `total_proof_time_ms` | 85,728 | 81,278 | **−5.2%** |

The preflight gain is a second-order effect: arenas drop earlier in tracegen, so
the pinned-buffer pool is replenished before the next segment's preflight
allocates, raising the pool hit rate.

The remaining ~2 s of executor-phase tracegen is the CPU fill cost of the
mod-builder (FieldExpression) chips, which #2989 moves to GPU; these changes
compose.
