### PR TITLE
perf(vm): pinned staging for the per-segment memory-image upload

### DIFF
--- a/crates/vm/src/arch/cuda/pinned.rs
+++ b/crates/vm/src/arch/cuda/pinned.rs
@@ -38,7 +38,7 @@ type ReturnedBuffer = (Vec<u8>, usize);
 /// (cudaErrorInvalidValue) source ranges that span multiple distinct
 /// page-locked registrations, so chunked registration corrupts nothing but
 /// breaks every copy crossing a chunk boundary.
-fn register_buffer(ptr: *mut u8, len: usize) -> bool {
+pub(crate) fn register_region(ptr: *mut u8, len: usize) -> bool {
     // SAFETY: [ptr, ptr+len) is a live allocation owned by the caller.
     let rc = unsafe { cudaHostRegister(ptr as *mut c_void, len, 0) };
     if rc != 0 {
@@ -52,6 +52,13 @@ extern "C" {
     fn cudaHostRegister(ptr: *mut c_void, size: usize, flags: u32) -> i32;
     fn cudaHostUnregister(ptr: *mut c_void) -> i32;
     fn cudaDeviceSynchronize() -> i32;
+}
+
+/// Reverses a successful [`register_region`]. The caller must ensure no copy
+/// from the region is still in flight.
+pub(crate) fn unregister_region(ptr: *mut u8) {
+    // SAFETY: mirrors a successful registration of the same base pointer.
+    unsafe { cudaHostUnregister(ptr as *mut c_void) };
 }
 
 /// Registered, all-zero buffers ready for reuse, keyed by allocation size.
@@ -113,7 +120,7 @@ fn cleaner() -> &'static Mutex<mpsc::Sender<ReturnedBuffer>> {
                         let ptr = buffer.as_mut_ptr();
                         let is_new = !registered().lock().unwrap().contains(&(ptr as usize));
                         if is_new {
-                            if !register_buffer(ptr, buffer.len()) {
+                            if !register_region(ptr, buffer.len()) {
                                 // Out of pinnable memory: drop the buffer,
                                 // never pool it.
                                 continue;

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -1,7 +1,7 @@
 mod config;
 /// CUDA-specific support (pinned host-memory pool for record arenas).
 #[cfg(feature = "cuda")]
-mod cuda;
+pub(crate) mod cuda;
 /// Streams-like deferral state
 pub mod deferral;
 /// Instruction execution traits and types.

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -14,9 +14,15 @@ use openvm_cuda_common::{
 };
 use openvm_stark_backend::{
     p3_field::PrimeCharacteristicRing,
-    p3_maybe_rayon::prelude::{IntoParallelRefIterator, ParallelIterator},
+    p3_maybe_rayon::prelude::{
+        IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator, ParallelSlice,
+        ParallelSliceMut,
+    },
     prover::AirProvingContext,
 };
+
+/// Chunk size for the parallel pack into the upload staging buffer.
+const UPLOAD_PACK_CHUNK: usize = 8 << 20;
 use tracing::instrument;
 
 use super::{
@@ -33,8 +39,53 @@ pub struct MemoryInventoryGPU {
     pub hasher_chip: Arc<Poseidon2PeripheryChipGPU>,
     pub initial_memory: Vec<DeviceBuffer<u8>>,
     pub merkle_records: Option<DeviceBuffer<u32>>,
+    upload_staging: PinnedStaging,
     #[cfg(feature = "metrics")]
     pub(super) unpadded_merkle_height: usize,
+}
+
+/// Page-locked host staging for the per-segment memory-image upload.
+///
+/// Copies from pageable memory run at staging-pipeline speed and only return
+/// once the source is consumed; copies from registered memory take the DMA
+/// fast path (~2x) and return immediately. Registering the guest memory
+/// itself would tie a registration to an allocation this module does not own
+/// (freed-while-registered is undefined), so the image is packed into this
+/// owned, once-registered buffer instead: the pack memcpy is parallel and
+/// fully consumes the guest memory before returning, so preflight may mutate
+/// it right away, while the DMA reads the staging asynchronously.
+#[derive(Default)]
+struct PinnedStaging {
+    buf: Vec<u8>,
+    registered: bool,
+}
+
+impl PinnedStaging {
+    /// Returns a staging slice of exactly `len` bytes, growing and
+    /// re-registering the underlying buffer if needed.
+    fn ensure(&mut self, len: usize) -> &mut [u8] {
+        if self.buf.len() < len {
+            if self.registered {
+                crate::arch::cuda::pinned::unregister_region(self.buf.as_mut_ptr());
+                self.registered = false;
+            }
+            self.buf = vec![0u8; len];
+            self.registered =
+                crate::arch::cuda::pinned::register_region(self.buf.as_mut_ptr(), len);
+            if !self.registered {
+                tracing::debug!("memory-image staging stays pageable ({len} bytes)");
+            }
+        }
+        &mut self.buf[..len]
+    }
+}
+
+impl Drop for PinnedStaging {
+    fn drop(&mut self) {
+        if self.registered {
+            crate::arch::cuda::pinned::unregister_region(self.buf.as_mut_ptr());
+        }
+    }
 }
 
 #[repr(C)]
@@ -73,6 +124,7 @@ impl MemoryInventoryGPU {
             hasher_chip,
             initial_memory: Vec::new(),
             merkle_records: None,
+            upload_staging: PinnedStaging::default(),
             #[cfg(feature = "metrics")]
             unpadded_merkle_height: 0,
         }
@@ -81,12 +133,15 @@ impl MemoryInventoryGPU {
     #[instrument(name = "set_initial_memory", skip_all)]
     pub fn set_initial_memory(&mut self, initial_memory: &AddressMap) {
         let mem = MemTracker::start("set initial memory");
-        for (addr_sp, raw_mem) in initial_memory
+        let slices: Vec<&[u8]> = initial_memory
             .get_memory()
             .iter()
             .map(|mem| mem.as_slice())
-            .enumerate()
-        {
+            .collect();
+        let total: usize = slices.iter().map(|s| s.len()).sum();
+        let staging = self.upload_staging.ensure(total);
+        let mut offset = 0usize;
+        for (addr_sp, raw_mem) in slices.into_iter().enumerate() {
             tracing::debug!(
                 "Setting initial memory for address space {}: {} bytes",
                 addr_sp,
@@ -95,7 +150,14 @@ impl MemoryInventoryGPU {
             self.initial_memory.push(if raw_mem.is_empty() {
                 DeviceBuffer::new()
             } else {
-                raw_mem
+                let dst = &mut staging[offset..offset + raw_mem.len()];
+                offset += raw_mem.len();
+                // Parallel pack: fully consumes the guest memory before the
+                // async DMA from the (registered) staging is enqueued.
+                dst.par_chunks_mut(UPLOAD_PACK_CHUNK)
+                    .zip(raw_mem.par_chunks(UPLOAD_PACK_CHUNK))
+                    .for_each(|(d, s)| d.copy_from_slice(s));
+                (*dst)
                     .to_device_on(&self.device_ctx)
                     .expect("failed to copy memory to device")
             });


### PR DESCRIPTION
Stacked on #2994 (review the last commit only).

## Problem

The initial memory image (~3 GB on reth workloads) is uploaded to device at the
start of **every segment**, from pageable guest memory. Pageable copies run at
staging-pipeline speed (~11 GB/s) and occupy the stream before the first Merkle
subtree build kernel can start — so ~250 ms/segment of upload counts against the
window in which preflight can hide the build (see #2994).

## Change

Pack the image (parallel memcpy, 8 MiB chunks) into a page-locked staging buffer
owned by `MemoryInventoryGPU` and registered once; the device copy then takes the
DMA fast path (~2x pageable) and returns immediately.

Why staging instead of registering the guest memory directly:
- registration would be tied to an allocation this module does not own; a guest
  memory freed while registered is undefined behavior, and the lifecycle (per
  block, across segments) is invisible from here;
- an async DMA reading guest memory directly would race preflight, which starts
  mutating that memory immediately after transport — the same lifetime hazard
  class as the record-arena race caught by CI on #2990. The pack fully consumes
  the guest memory before returning; the DMA reads only the owned staging.

The staging buffer registers once (~1.5 s for 3 GB, amortized over all segments
of all blocks in the process) and unregisters on drop. Registration failure
degrades to a pageable staging buffer, i.e. the status quo.

## Measured impact

openvm-eth reth benchmark, block 23992138, RTX Pro 6000 (VPMM 15 GiB), measured
on the full stack (#2990+#2994+#2989+this), same host class as baseline (CPU
control metric within 0.7%):

| metric | before | after | delta |
|---|---|---|---|
| `vm.transport_init_memory_time_ms` | 5,281 | 886 | **−83%** |
| `total_proof_time_ms` | 87,129 | 83,340 | **−4.3%** |

The win is larger than the stream-occupancy estimate because the pageable copy
also blocked the *host* inside transport for ~68 ms/segment (~5.3 s/block of
wall time between segments); the pack + async-DMA path returns in ~11 ms.
Proof verifies (rc=0); peak VRAM unchanged.
