### PR TITLE
perf(vm): trim the tracegen tail (merge inputs, sync order, span cost)

### DIFF
--- a/crates/vm/cuda/src/system/program.cu
+++ b/crates/vm/cuda/src/system/program.cu
@@ -58,3 +58,35 @@ extern "C" int _program_cached_tracegen(
     );
     return CHECK_KERNEL();
 }
+
+/// Converts raw u32 execution frequencies to field elements in place on
+/// device, zero-filling [filtered_len, height). Replaces a host-side serial
+/// map + pageable copy that cost ~15 ms per segment on large programs.
+__global__ void program_fill_frequencies(
+    const uint32_t *__restrict__ freqs,
+    size_t filtered_len,
+    Fp *__restrict__ out,
+    size_t height
+) {
+    size_t stride = gridDim.x * (size_t)blockDim.x;
+    for (size_t i = blockIdx.x * (size_t)blockDim.x + threadIdx.x; i < height; i += stride) {
+        out[i] = i < filtered_len ? Fp(freqs[i]) : Fp(0);
+    }
+}
+
+extern "C" int _program_fill_frequencies(
+    const uint32_t *d_freqs,
+    size_t filtered_len,
+    Fp *d_out,
+    size_t height,
+    cudaStream_t stream
+) {
+    if (height == 0) {
+        return 0;
+    }
+    const int threads = 256;
+    const size_t want = (height + threads - 1) / threads;
+    const int blocks = (int)(want < 2048 ? want : 2048);
+    program_fill_frequencies<<<blocks, threads, 0, stream>>>(d_freqs, filtered_len, d_out, height);
+    return CHECK_KERNEL();
+}

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -749,10 +749,15 @@ where
                         chip: &dyn AnyChip<RA, PB>,
                         records: RA|
          -> AirProvingContext<PB> {
-            let _span = {
+            // Span only for non-empty arenas: span + metric emission costs
+            // tens of microseconds each and most chips in a segment are
+            // empty. Chips doing real work from an empty arena (periphery
+            // hashers, lookup tables) are covered in aggregate by the
+            // periphery_trace_gen span.
+            let _span = (!records.is_empty()).then(|| {
                 let air_name = self.inventory.airs.ext_airs[insertion_idx].name();
                 info_span!("single_trace_gen", air = air_name).entered()
-            };
+            });
             #[cfg(feature = "metrics")]
             if let Some(allocated_bytes) = (!records.is_empty())
                 .then(|| records.allocated_bytes())

--- a/crates/vm/src/cuda_abi.rs
+++ b/crates/vm/src/cuda_abi.rs
@@ -287,6 +287,34 @@ pub mod program {
     use super::*;
 
     extern "C" {
+        fn _program_fill_frequencies(
+            d_freqs: *const u32,
+            filtered_len: usize,
+            d_out: *mut F,
+            height: usize,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    /// Converts raw u32 execution frequencies to field elements on device,
+    /// zero-filling `[filtered_len, height)`.
+    pub unsafe fn fill_frequencies(
+        d_freqs: &DeviceBuffer<u32>,
+        filtered_len: usize,
+        d_out: &DeviceBuffer<F>,
+        height: usize,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_program_fill_frequencies(
+            d_freqs.as_ptr(),
+            filtered_len,
+            d_out.as_mut_ptr(),
+            height,
+            stream,
+        ))
+    }
+
+    extern "C" {
         fn _program_cached_tracegen(
             d_trace: *mut F,
             height: usize,

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -15,8 +15,8 @@ use openvm_cuda_common::{
 use openvm_stark_backend::{
     p3_field::PrimeCharacteristicRing,
     p3_maybe_rayon::prelude::{
-        IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator, ParallelSlice,
-        ParallelSliceMut,
+        IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+        ParallelSlice, ParallelSliceMut,
     },
     prover::AirProvingContext,
 };
@@ -315,10 +315,25 @@ impl MemoryInventoryGPU {
                 .expect("merge_records failed");
             }
 
-            // Host work overlapping the merge kernels: the unpadded height
-            // scan needs only the partition, and the Poseidon2 records buffer
-            // can be sized by the input count (an upper bound on the merged
-            // count), so neither needs to wait for the merge to finish.
+            // The merged record count is a pure function of input adjacency
+            // (the device merge flags a record iff its (address_space,
+            // ptr / OUT_BLOCK) differs from its predecessor's, and the
+            // partition is sorted), so it can be computed here and the
+            // mid-merge D2H sync dropped entirely.
+            const OUT_BLOCK_CELLS: u32 = 8;
+            let out_num_records = 1
+                + (1..in_num_records)
+                    .into_par_iter()
+                    .filter(|&i| {
+                        let (a, p) = partition[i].0;
+                        let (pa, pp) = partition[i - 1].0;
+                        (a, p / OUT_BLOCK_CELLS) != (pa, pp / OUT_BLOCK_CELLS)
+                    })
+                    .count();
+
+            // Host work overlapping the merge kernels: neither the unpadded
+            // height scan nor the Poseidon2 records buffer depends on the
+            // merge kernels.
             let unpadded_merkle_height = self.merkle_tree.calculate_unpadded_height(&partition);
             #[cfg(feature = "metrics")]
             {
@@ -326,11 +341,18 @@ impl MemoryInventoryGPU {
             }
             {
                 let _span = tracing::info_span!("poseidon2_prepare").entered();
-                self.prepare_poseidon2_records(in_num_records, unpadded_merkle_height);
+                self.prepare_poseidon2_records(out_num_records, unpadded_merkle_height);
+            }
+
+            // Cross-check the host-computed count against the device merge in
+            // debug builds (a mismatch would corrupt the boundary trace).
+            #[cfg(debug_assertions)]
+            {
+                let device_count = d_out_num_records.to_host_on(&self.device_ctx).unwrap()[0];
+                assert_eq!(device_count, out_num_records, "merged-count mismatch");
             }
 
             // Send records to boundary chip
-            let out_num_records = d_out_num_records.to_host_on(&self.device_ctx).unwrap()[0];
             self.boundary
                 .finalize_records_device::<DIGEST_WIDTH>(d_out_records, out_num_records);
 

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -239,23 +239,39 @@ impl MemoryInventoryGPU {
             )
         } else {
             let _span = tracing::info_span!("mem_merge_records").entered();
-            // Convert MemoryInventoryRecord<4, 1> to MemoryInventoryRecord<8, 2>
-            let in_records: Vec<MemoryInventoryRecord<4, 1>> = partition
-                .par_iter()
-                .map(|&((addr_space, ptr), ts_values)| MemoryInventoryRecord {
-                    address_space: addr_space,
-                    ptr,
-                    timestamps: [ts_values.timestamp],
-                    values: ts_values.values.map(Self::field_to_raw_u32),
-                })
-                .collect();
-            let in_num_records = in_records.len();
+            // Convert to MemoryInventoryRecord<4, 1> layout, packing straight
+            // into a pooled page-locked buffer so the upload takes the DMA
+            // fast path; giving the buffer back routes through the arena
+            // cleaner, which synchronizes the device before reuse, so the
+            // in-flight copy is safe.
+            const IN_REC_WORDS: usize =
+                std::mem::size_of::<MemoryInventoryRecord<4, 1>>() / std::mem::size_of::<u32>();
+            let in_num_records = partition.len();
+            let mut h_in = crate::arch::cuda::pinned::take(in_num_records * IN_REC_WORDS * 4 + 4);
+            let align = h_in.as_ptr().align_offset(std::mem::size_of::<u32>());
+            let dirty_len = align + in_num_records * IN_REC_WORDS * 4;
+            // SAFETY: the slice is within the buffer and 4-aligned by `align`.
+            let in_words: &mut [u32] = unsafe {
+                std::slice::from_raw_parts_mut(
+                    h_in.as_mut_ptr().add(align) as *mut u32,
+                    in_num_records * IN_REC_WORDS,
+                )
+            };
+            in_words
+                .par_chunks_mut(IN_REC_WORDS)
+                .zip(partition.par_iter())
+                .for_each(|(w, &((addr_space, ptr), ts_values))| {
+                    w[0] = addr_space;
+                    w[1] = ptr;
+                    w[2] = ts_values.timestamp;
+                    for (dst, v) in w[3..].iter_mut().zip(ts_values.values) {
+                        *dst = Self::field_to_raw_u32(v);
+                    }
+                });
             let out_words = in_num_records
                 * (std::mem::size_of::<MemoryInventoryRecord<8, 2>>() / std::mem::size_of::<u32>());
-            let d_in_records = in_records
-                .to_device_on(&self.device_ctx)
-                .unwrap()
-                .as_buffer::<u32>();
+            let d_in_records = (*in_words).to_device_on(&self.device_ctx).unwrap();
+            crate::arch::cuda::pinned::give_back(h_in, dirty_len);
             let d_tmp_records = DeviceBuffer::<u32>::with_capacity_on(out_words, &self.device_ctx);
             let d_out_records = DeviceBuffer::<u32>::with_capacity_on(out_words, &self.device_ctx);
             let d_out_num_records = DeviceBuffer::<usize>::with_capacity_on(1, &self.device_ctx);
@@ -299,6 +315,20 @@ impl MemoryInventoryGPU {
                 .expect("merge_records failed");
             }
 
+            // Host work overlapping the merge kernels: the unpadded height
+            // scan needs only the partition, and the Poseidon2 records buffer
+            // can be sized by the input count (an upper bound on the merged
+            // count), so neither needs to wait for the merge to finish.
+            let unpadded_merkle_height = self.merkle_tree.calculate_unpadded_height(&partition);
+            #[cfg(feature = "metrics")]
+            {
+                self.unpadded_merkle_height = unpadded_merkle_height;
+            }
+            {
+                let _span = tracing::info_span!("poseidon2_prepare").entered();
+                self.prepare_poseidon2_records(in_num_records, unpadded_merkle_height);
+            }
+
             // Send records to boundary chip
             let out_num_records = d_out_num_records.to_host_on(&self.device_ctx).unwrap()[0];
             self.boundary
@@ -322,18 +352,8 @@ impl MemoryInventoryGPU {
                 .expect("inventory_to_merkle_records failed");
             }
             self.merkle_records = Some(d_merkle_records);
-
-            let unpadded_merkle_height = self.merkle_tree.calculate_unpadded_height(&partition);
-            #[cfg(feature = "metrics")]
-            {
-                self.unpadded_merkle_height = unpadded_merkle_height;
-            }
             drop(_span);
 
-            {
-                let _span = tracing::info_span!("poseidon2_prepare").entered();
-                self.prepare_poseidon2_records(out_num_records, unpadded_merkle_height);
-            }
             mem.tracing_info("merkle update");
             let _span = tracing::info_span!("merkle_update").entered();
             self.merkle_tree.finalize();

--- a/crates/vm/src/system/cuda/program.rs
+++ b/crates/vm/src/system/cuda/program.rs
@@ -108,19 +108,39 @@ impl Chip<Vec<u32>, GpuBackend> for ProgramChipGPU {
             filtered_len <= height,
             "filtered_exec_freqs len={filtered_len} > cached trace height={height}"
         );
-        let mut buffer: DeviceBuffer<F> = DeviceBuffer::with_capacity_on(height, &self.device_ctx);
+        let buffer: DeviceBuffer<F> = DeviceBuffer::with_capacity_on(height, &self.device_ctx);
 
-        filtered_exec_freqs
-            .into_iter()
-            .map(F::from_u32)
-            .collect::<Vec<_>>()
-            .copy_to_on(&mut buffer, &self.device_ctx)
-            .unwrap();
-        // Making sure to zero-out the untouched part of the buffer.
-        if filtered_len < height {
-            buffer
-                .fill_zero_suffix_on(filtered_len, &self.device_ctx)
-                .unwrap();
+        // Upload the raw u32 frequencies through a pooled pinned buffer and
+        // convert to field elements on device (also zero-filling the tail).
+        // The previous host-side serial map + pageable copy cost ~15 ms per
+        // segment on large programs. Returning the buffer routes through the
+        // arena cleaner, which synchronizes before reuse.
+        let bytes = filtered_len * std::mem::size_of::<u32>();
+        let mut h_freqs = crate::arch::cuda::pinned::take(bytes + std::mem::size_of::<u32>());
+        let off = h_freqs.as_ptr().align_offset(std::mem::size_of::<u32>());
+        // SAFETY: the ranges are in-bounds, disjoint allocations, and the
+        // destination is 4-aligned by `off`.
+        let words: &[u32] = unsafe {
+            std::ptr::copy_nonoverlapping(
+                filtered_exec_freqs.as_ptr() as *const u8,
+                h_freqs.as_mut_ptr().add(off),
+                bytes,
+            );
+            std::slice::from_raw_parts(h_freqs.as_ptr().add(off) as *const u32, filtered_len)
+        };
+        let d_freqs = words
+            .to_device_on(&self.device_ctx)
+            .expect("failed to copy exec frequencies to device");
+        crate::arch::cuda::pinned::give_back(h_freqs, off + bytes);
+        unsafe {
+            crate::cuda_abi::program::fill_frequencies(
+                &d_freqs,
+                filtered_len,
+                &buffer,
+                height,
+                self.device_ctx.stream.as_raw(),
+            )
+            .expect("program_fill_frequencies failed");
         }
 
         let common_main = DeviceMatrix::new(Arc::new(buffer), height, 1);


### PR DESCRIPTION
Stacked on #2996 (review the last commit only).

Trims the three largest residual costs measured after #2994/#2995/#2996, worth a
projected ~0.4–0.6 s/block of tracegen combined:

1. **Merge inputs pack into pinned memory (−150–250 ms).** The touched-memory
   records were converted on host into a fresh pageable Vec and staged to
   device at ~11 GB/s. They now pack straight into a pooled page-locked buffer
   (parallel, fixed 7-word stride) and upload on the DMA fast path. Returning
   the buffer goes through the record-arena cleaner, which synchronizes the
   device before any reuse — the same lifetime discipline as #2990.

2. **Host work hoisted above the merged-count sync (−~100 ms).** The
   unpadded-height scan needs only the partition, and the Poseidon2 records
   buffer can be sized by the input count (an upper bound on the merged
   count). Both now run while the merge kernels execute, so the 8-byte D2H
   sync waits on less.

3. **Per-chip spans gated on non-empty arenas (−100–200 ms).** Span + gauge
   emission costs tens of microseconds each; ~26 of ~40 chips are empty in a
   typical segment (~2,000 empty emissions per block). Periphery chips remain
   covered in aggregate by the `periphery_trace_gen` span introduced in #2994.

## Measured

openvm-eth reth benchmark, block 23992138, RTX Pro 6000 (VPMM 15 GiB), full
stack, on a host whose CPU control metric reads 4.4% slower than the baseline
run (gains below are therefore slightly understated); proof verifies (rc=0):

| metric | before | after |
|---|---|---|
| `mem_merge_records_time_ms` | 530 | 381 |
| `periphery_trace_gen_time_ms` | 726 | 592 |
| `trace_gen_time_ms` | 3,241 | **2,990** |


## Follow-up commits (measured, same rig)

**Host-side merged count** — the 8-byte D2H of the merged record count was the
last mid-merge sync; the device merge's group flag is a pure adjacency function
of `(address_space, ptr / OUT_BLOCK)` over the sorted partition, so the count is
now a parallel host scan and the memory-inventory path is enqueue-only until the
public-values readback. Debug builds cross-check host vs device counts.

**Exec frequencies converted on device** — profiling `poseidon2_mix` (L40S: 40
registers, no spills, full occupancy, ~3.5G perm/s) proved the per-segment
"build wait" at the program chip was never the Merkle build: it was the program
chip itself serially converting the multi-million-entry frequency vector on host
(`map(F::from_u32)`) plus a pageable copy, every segment. The raw u32s now
upload through a pooled pinned buffer and a device kernel does the conversion:
`program_trace_gen_time_ms` **1,206 → 59**.

Tracegen wall holds at ~2,980 ms: with all artificial stalls removed, the
remaining sync time is the genuine aggregate GPU tracegen kernel time on the
single stream, already overlapped with the available CPU work. Further wall
reduction requires cross-segment pipelining rather than more tracegen changes.
