### PR TITLE
perf(vm): make TouchedBlock the GPU inventory-record layout

### DIFF
--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use openvm_circuit::{
     arch::{AddressSpaceHostLayout, MemoryConfig, ADDR_SPACE_OFFSET},
-    system::{memory::AddressMap, TouchedMemory},
+    system::{memory::AddressMap, TouchedBlock, TouchedMemory},
 };
 use openvm_circuit_primitives::Chip;
 use openvm_cuda_backend::{prelude::F, GpuBackend};
@@ -15,8 +15,8 @@ use openvm_cuda_common::{
 use openvm_stark_backend::{
     p3_field::PrimeCharacteristicRing,
     p3_maybe_rayon::prelude::{
-        IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-        ParallelSlice, ParallelSliceMut,
+        IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSlice,
+        ParallelSliceMut,
     },
     prover::AirProvingContext,
 };
@@ -222,7 +222,9 @@ impl MemoryInventoryGPU {
             };
             let d_merkle_touched_memory = merkle_words.to_device_on(&self.device_ctx).unwrap();
 
-            let unpadded_merkle_height = self.merkle_tree.calculate_unpadded_height(&partition);
+            let unpadded_merkle_height = self
+                .merkle_tree
+                .calculate_unpadded_height(&partition, |b| (b.address_space, b.ptr));
             #[cfg(feature = "metrics")]
             {
                 self.unpadded_merkle_height = unpadded_merkle_height;
@@ -239,38 +241,42 @@ impl MemoryInventoryGPU {
             )
         } else {
             let _span = tracing::info_span!("mem_merge_records").entered();
-            // Convert to MemoryInventoryRecord<4, 1> layout, packing straight
-            // into a pooled page-locked buffer so the upload takes the DMA
-            // fast path; giving the buffer back routes through the arena
-            // cleaner, which synchronizes the device before reuse, so the
-            // in-flight copy is safe.
+            // TouchedBlock is repr(C) with 4-byte fields and matches the
+            // device InRec layout exactly, so the partition uploads as raw
+            // bytes: bulk-copy into a pooled page-locked buffer so the copy
+            // takes the DMA fast path. Giving the buffer back routes through
+            // the arena cleaner, which synchronizes the device before reuse,
+            // so the in-flight copy is safe.
             const IN_REC_WORDS: usize =
-                std::mem::size_of::<MemoryInventoryRecord<4, 1>>() / std::mem::size_of::<u32>();
+                std::mem::size_of::<TouchedBlock<F>>() / std::mem::size_of::<u32>();
+            const _: () = assert!(std::mem::size_of::<TouchedBlock<F>>() == 28);
             let in_num_records = partition.len();
-            let mut h_in = crate::arch::cuda::pinned::take(in_num_records * IN_REC_WORDS * 4 + 4);
+            let in_bytes = in_num_records * IN_REC_WORDS * std::mem::size_of::<u32>();
+            let mut h_in = crate::arch::cuda::pinned::take(in_bytes + 4);
             let align = h_in.as_ptr().align_offset(std::mem::size_of::<u32>());
-            let dirty_len = align + in_num_records * IN_REC_WORDS * 4;
-            // SAFETY: the slice is within the buffer and 4-aligned by `align`.
-            let in_words: &mut [u32] = unsafe {
-                std::slice::from_raw_parts_mut(
-                    h_in.as_mut_ptr().add(align) as *mut u32,
+            let dirty_len = align + in_bytes;
+            {
+                // SAFETY: TouchedBlock is repr(C) with only 4-byte fields (F
+                // is the 4-byte BabyBear here), so its bytes are plain data;
+                // the destination is within the buffer.
+                let src: &[u8] = unsafe {
+                    std::slice::from_raw_parts(partition.as_ptr() as *const u8, in_bytes)
+                };
+                let dst = &mut h_in[align..align + in_bytes];
+                dst.par_chunks_mut(UPLOAD_PACK_CHUNK)
+                    .zip(src.par_chunks(UPLOAD_PACK_CHUNK))
+                    .for_each(|(d, s)| d.copy_from_slice(s));
+            }
+            // SAFETY: 4-aligned by `align`, within the buffer.
+            let in_words: &[u32] = unsafe {
+                std::slice::from_raw_parts(
+                    h_in.as_ptr().add(align) as *const u32,
                     in_num_records * IN_REC_WORDS,
                 )
             };
-            in_words
-                .par_chunks_mut(IN_REC_WORDS)
-                .zip(partition.par_iter())
-                .for_each(|(w, &((addr_space, ptr), ts_values))| {
-                    w[0] = addr_space;
-                    w[1] = ptr;
-                    w[2] = ts_values.timestamp;
-                    for (dst, v) in w[3..].iter_mut().zip(ts_values.values) {
-                        *dst = Self::field_to_raw_u32(v);
-                    }
-                });
             let out_words = in_num_records
                 * (std::mem::size_of::<MemoryInventoryRecord<8, 2>>() / std::mem::size_of::<u32>());
-            let d_in_records = (*in_words).to_device_on(&self.device_ctx).unwrap();
+            let d_in_records = in_words.to_device_on(&self.device_ctx).unwrap();
             crate::arch::cuda::pinned::give_back(h_in, dirty_len);
             let d_tmp_records = DeviceBuffer::<u32>::with_capacity_on(out_words, &self.device_ctx);
             let d_out_records = DeviceBuffer::<u32>::with_capacity_on(out_words, &self.device_ctx);
@@ -325,16 +331,18 @@ impl MemoryInventoryGPU {
                 + (1..in_num_records)
                     .into_par_iter()
                     .filter(|&i| {
-                        let (a, p) = partition[i].0;
-                        let (pa, pp) = partition[i - 1].0;
-                        (a, p / OUT_BLOCK_CELLS) != (pa, pp / OUT_BLOCK_CELLS)
+                        let (a, b) = (&partition[i], &partition[i - 1]);
+                        (a.address_space, a.ptr / OUT_BLOCK_CELLS)
+                            != (b.address_space, b.ptr / OUT_BLOCK_CELLS)
                     })
                     .count();
 
             // Host work overlapping the merge kernels: neither the unpadded
             // height scan nor the Poseidon2 records buffer depends on the
             // merge kernels.
-            let unpadded_merkle_height = self.merkle_tree.calculate_unpadded_height(&partition);
+            let unpadded_merkle_height = self
+                .merkle_tree
+                .calculate_unpadded_height(&partition, |b| (b.address_space, b.ptr));
             #[cfg(feature = "metrics")]
             {
                 self.unpadded_merkle_height = unpadded_merkle_height;
@@ -427,8 +435,9 @@ mod tests {
     use openvm_circuit::{
         arch::{vm_poseidon2_config, MemoryConfig},
         system::{
-            memory::{merkle::MerkleTree, online::GuestMemory, AddressMap, TimestampedValues},
+            memory::{merkle::MerkleTree, online::GuestMemory, AddressMap},
             poseidon2::Poseidon2PeripheryChip,
+            TouchedBlock,
         },
     };
     use openvm_cuda_backend::prelude::F;
@@ -542,20 +551,18 @@ mod tests {
         inventory.set_initial_memory(&memory.memory);
 
         let touched_memory = vec![
-            (
-                (RV32_MEMORY_AS, 0),
-                TimestampedValues {
-                    timestamp: 1,
-                    values: touched_bytes.map(F::from_u8),
-                },
-            ),
-            (
-                (RV32_MEMORY_AS, crate::arch::DEFAULT_BLOCK_SIZE as u32),
-                TimestampedValues {
-                    timestamp: 3,
-                    values: touched_bytes_late.map(F::from_u8),
-                },
-            ),
+            TouchedBlock {
+                address_space: RV32_MEMORY_AS,
+                ptr: 0,
+                timestamp: 1,
+                values: touched_bytes.map(F::from_u8),
+            },
+            TouchedBlock {
+                address_space: RV32_MEMORY_AS,
+                ptr: crate::arch::DEFAULT_BLOCK_SIZE as u32,
+                timestamp: 3,
+                values: touched_bytes_late.map(F::from_u8),
+            },
         ];
         let ctxs = inventory.generate_proving_ctxs(touched_memory);
         let boundary_ctx = ctxs.first().expect("missing boundary ctx");

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -2,7 +2,7 @@ use std::{ffi::c_void, sync::Arc};
 
 use openvm_circuit::{
     arch::{MemoryConfig, ADDR_SPACE_OFFSET, DEFAULT_BLOCK_SIZE},
-    system::memory::{merkle::MemoryMerkleCols, TimestampedEquipartition},
+    system::memory::merkle::MemoryMerkleCols,
     utils::next_power_of_two_or_zero,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
@@ -379,9 +379,10 @@ impl MemoryMerkleTree {
 
     /// An auxiliary function to calculate the required number of rows for the merkle trace.
     /// Generic over BLOCK_SIZE since only addresses are used, not values.
-    pub fn calculate_unpadded_height<const BLOCK_SIZE: usize>(
+    pub fn calculate_unpadded_height<A: Sync>(
         &self,
-        touched_memory: &TimestampedEquipartition<F, BLOCK_SIZE>,
+        touched_memory: &[A],
+        address: impl Fn(&A) -> (u32, u32) + Sync,
     ) -> usize {
         let md = self.mem_config.memory_dimensions();
         let tree_height = md.overall_height();
@@ -393,8 +394,8 @@ impl MemoryMerkleTree {
                 + (0..(touched_memory.len() - 1))
                     .into_par_iter()
                     .map(|i| {
-                        let x = md.label_to_index(shift_address(touched_memory[i].0));
-                        let y = md.label_to_index(shift_address(touched_memory[i + 1].0));
+                        let x = md.label_to_index(shift_address(address(&touched_memory[i])));
+                        let y = md.label_to_index(shift_address(address(&touched_memory[i + 1])));
                         let xor = x ^ y;
                         if xor == 0 {
                             0
@@ -617,7 +618,8 @@ mod tests {
             .to_device_on(&gpu_merkle_tree.device_ctx)
             .unwrap();
 
-        let unpadded_height = gpu_merkle_tree.calculate_unpadded_height(&touched_blocks);
+        let unpadded_height =
+            gpu_merkle_tree.calculate_unpadded_height(&touched_blocks, |(addr, _)| *addr);
         gpu_hasher_chip.prepare_records(unpadded_height);
         gpu_merkle_tree.update_with_touched_blocks(unpadded_height, &d_touched_blocks, false);
 

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 
 use crate::{
     arch::{AddressSpaceHostConfig, AddressSpaceHostLayout, MemoryConfig, DEFAULT_BLOCK_SIZE},
-    system::{memory::TimestampedValues, TouchedMemory},
+    system::TouchedMemory,
 };
 
 mod basic;
@@ -542,7 +542,12 @@ impl TracingMemory {
                             cell_size,
                         ))
                 });
-                ((addr_space, ptr), TimestampedValues { timestamp, values })
+                crate::system::TouchedBlock {
+                    address_space: addr_space,
+                    ptr,
+                    timestamp,
+                    values,
+                }
             })
             .collect()
     }

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -22,9 +22,9 @@ use super::{merkle::SerialReceiver, online::INITIAL_TIMESTAMP};
 use crate::{
     arch::{hasher::Hasher, ADDR_SPACE_OFFSET, DEFAULT_BLOCK_SIZE},
     primitives::Chip,
-    system::memory::{
-        controller::CHUNK, offline_checker::MemoryBus, MemoryAddress, MemoryImage,
-        TimestampedEquipartition,
+    system::{
+        memory::{controller::CHUNK, offline_checker::MemoryBus, MemoryAddress, MemoryImage},
+        TouchedMemory,
     },
 };
 
@@ -162,15 +162,15 @@ type EnrichedEntry<F> = ((u32, u32), BlockInfo<F>); // (chunk_key, block_info)
 pub(crate) type ChunkedTouchedMemory<F> = Vec<((u32, u32), Vec<BlockInfo<F>>)>;
 
 pub(crate) fn group_touched_memory_by_chunk<F: Copy + Send + Sync>(
-    final_memory: &TimestampedEquipartition<F, DEFAULT_BLOCK_SIZE>,
+    final_memory: &TouchedMemory<F>,
 ) -> ChunkedTouchedMemory<F> {
     let mut enriched: Vec<EnrichedEntry<F>> = final_memory
         .par_iter()
-        .map(|&((addr_space, ptr), ts_values)| {
-            let chunk_label = ptr / CHUNK as u32;
-            let block_idx = ((ptr % CHUNK as u32) / DEFAULT_BLOCK_SIZE as u32) as usize;
-            let key = (addr_space, chunk_label);
-            let block_info = (block_idx, ts_values.timestamp, ts_values.values);
+        .map(|block| {
+            let chunk_label = block.ptr / CHUNK as u32;
+            let block_idx = ((block.ptr % CHUNK as u32) / DEFAULT_BLOCK_SIZE as u32) as usize;
+            let key = (block.address_space, chunk_label);
+            let block_info = (block_idx, block.timestamp, block.values);
             (key, block_info)
         })
         .collect();
@@ -218,7 +218,7 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
         &mut self,
         initial_memory: &MemoryImage,
         // Touched stuff at DEFAULT_BLOCK_SIZE granularity
-        final_memory: &TimestampedEquipartition<F, DEFAULT_BLOCK_SIZE>,
+        final_memory: &TouchedMemory<F>,
         hasher: &H,
     ) where
         H: Hasher<CHUNK, F> + Sync + for<'a> SerialReceiver<&'a [F]>,

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -36,7 +36,7 @@ use crate::{
         memory::{
             offline_checker::{MemoryBridge, MemoryBus},
             online::GuestMemory,
-            MemoryAirInventory, MemoryController, TimestampedEquipartition, CHUNK,
+            MemoryAirInventory, MemoryController, CHUNK,
         },
         phantom::{
             CycleEndPhantomExecutor, CycleStartPhantomExecutor, NopPhantomExecutor, PhantomAir,
@@ -113,7 +113,24 @@ pub struct SystemRecords<F> {
     pub touched_memory: TouchedMemory<F>,
 }
 
-pub type TouchedMemory<F> = TimestampedEquipartition<F, DEFAULT_BLOCK_SIZE>;
+/// A memory block touched during a segment: final values and last-access
+/// timestamp at [DEFAULT_BLOCK_SIZE] granularity. The touched-memory list is
+/// sorted by `(address_space, ptr)`.
+///
+/// `repr(C)` with 4-byte fields: for a 4-byte field type this is exactly the
+/// GPU memory-inventory input-record layout (7 u32 words), so the device path
+/// uploads the vector's bytes without repacking. Keep in sync with `InRec` in
+/// `inventory.cu`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TouchedBlock<F> {
+    pub address_space: u32,
+    pub ptr: u32,
+    pub timestamp: u32,
+    pub values: [F; DEFAULT_BLOCK_SIZE],
+}
+
+pub type TouchedMemory<F> = Vec<TouchedBlock<F>>;
 
 #[derive(Clone, AnyEnum, Executor, MeteredExecutor, PreflightExecutor, From)]
 #[cfg_attr(feature = "aot", derive(AotExecutor, AotMeteredExecutor))]


### PR DESCRIPTION
Stacked on #2997 (review the last commit only).

## Change

`TouchedMemory` entries were `((u32, u32), TimestampedValues<F, 4>)` tuples that
the GPU memory inventory re-encoded field by field into the device merge's input
layout on every segment. The entry type is now:

```rust
#[repr(C)]
pub struct TouchedBlock<F> {
    pub address_space: u32,
    pub ptr: u32,
    pub timestamp: u32,
    pub values: [F; DEFAULT_BLOCK_SIZE],
}
```

For a 4-byte field type this is byte-identical to `InRec` in `inventory.cu`
(compile-time size assert at the transmute site), so:

- the GPU path bulk-copies the partition's bytes into the pinned upload buffer —
  no per-field packing;
- memory finalize emits the final layout directly — and so can any other
  producer of touched memory: the interface contract between execution and the
  memory argument is now "produce this exact buffer", with no conversion layer
  in between.

CPU-backend consumers (persistent boundary grouping) switch from tuple
destructuring to named fields; `calculate_unpadded_height` takes an address
accessor so test callers with other block widths keep working. No behavioral
change; workspace + tests compile clean, clippy clean.

## Measured

openvm-eth reth benchmark, block 23992138, RTX Pro 6000 (VPMM 15 GiB), full
stack, same host class as baseline (CPU control metric within 0.1%); proof
verifies (rc=0), confirming the layout identity end-to-end:

| metric | before | after |
|---|---|---|
| `mem_merge_records_time_ms` | 487 | 399 |
| `trace_gen_time_ms` | 2,982 | 2,952 |
