### PR TITLE
release: v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,7 +1775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2536,7 +2536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2918,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "halo2-axiom-gpu"
 version = "1.0.0"
-source = "git+https://github.com/axiom-crypto/halo2-gpu.git?tag=v1.0.0-rc.3#d1dd6d0bf96d49669f6afd813646e9d971f9f820"
+source = "git+https://github.com/axiom-crypto/halo2-gpu.git?tag=v1.0.0#97ef2d02aa3348fc04b520c3c2562a9c13b57126"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "halo2-base"
 version = "0.5.4"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#088dfe83ef4c1cdab233cb18d3a5c9637a6383ed"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#a69fdee77f41bdd48ad658b69673dea5a0815db4"
 dependencies = [
  "getset",
  "halo2-axiom",
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.5.4"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#088dfe83ef4c1cdab233cb18d3a5c9637a6383ed"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#a69fdee77f41bdd48ad658b69673dea5a0815db4"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",
@@ -3553,7 +3553,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4230,7 +4230,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7010,7 +7010,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7460,7 +7460,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "snark-verifier"
 version = "0.2.6"
-source = "git+https://github.com/axiom-crypto/snark-verifier.git?tag=v0.2.6#5d90b95d64a82c34322ccf3ca18b5cfa8cd4a938"
+source = "git+https://github.com/axiom-crypto/snark-verifier.git?tag=v0.2.6#364e82654c746b063aff528d8cb660890908278a"
 dependencies = [
  "halo2-base",
  "halo2-ecc",
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "snark-verifier-sdk"
 version = "0.2.6"
-source = "git+https://github.com/axiom-crypto/snark-verifier.git?tag=v0.2.6#5d90b95d64a82c34322ccf3ca18b5cfa8cd4a938"
+source = "git+https://github.com/axiom-crypto/snark-verifier.git?tag=v0.2.6#364e82654c746b063aff528d8cb660890908278a"
 dependencies = [
  "bincode",
  "ethereum-types",
@@ -7706,7 +7706,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8430,7 +8430,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,61 +123,61 @@ openvm-cuda-builder = { version = "2.0.0", git = "https://github.com/openvm-org/
 openvm-cuda-common = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
 
 # OpenVM
-openvm-mod-circuit-builder = { path = "crates/circuits/mod-builder", default-features = false }
-openvm-poseidon2-air = { path = "crates/circuits/poseidon2-air", default-features = false }
-openvm-sha2-air = { path = "crates/circuits/sha2-air", default-features = false }
-openvm-circuit-primitives = { path = "crates/circuits/primitives", default-features = false }
-openvm-circuit-primitives-derive = { path = "crates/circuits/primitives/derive", default-features = false }
-openvm = { path = "crates/toolchain/openvm", default-features = false }
-openvm-build = { path = "crates/toolchain/build", default-features = false }
-openvm-instructions = { path = "crates/toolchain/instructions", default-features = false }
-openvm-instructions-derive = { path = "crates/toolchain/instructions/derive", default-features = false }
-openvm-macros-common = { path = "crates/toolchain/macros", default-features = false }
-openvm-platform = { path = "crates/toolchain/platform", default-features = false }
-openvm-transpiler = { path = "crates/toolchain/transpiler", default-features = false }
+openvm-mod-circuit-builder = { version = "2.0.0", path = "crates/circuits/mod-builder", default-features = false }
+openvm-poseidon2-air = { version = "2.0.0", path = "crates/circuits/poseidon2-air", default-features = false }
+openvm-sha2-air = { version = "2.0.0", path = "crates/circuits/sha2-air", default-features = false }
+openvm-circuit-primitives = { version = "2.0.0", path = "crates/circuits/primitives", default-features = false }
+openvm-circuit-primitives-derive = { version = "2.0.0", path = "crates/circuits/primitives/derive", default-features = false }
+openvm = { version = "2.0.0", path = "crates/toolchain/openvm", default-features = false }
+openvm-build = { version = "2.0.0", path = "crates/toolchain/build", default-features = false }
+openvm-instructions = { version = "2.0.0", path = "crates/toolchain/instructions", default-features = false }
+openvm-instructions-derive = { version = "2.0.0", path = "crates/toolchain/instructions/derive", default-features = false }
+openvm-macros-common = { version = "2.0.0", path = "crates/toolchain/macros", default-features = false }
+openvm-platform = { version = "2.0.0", path = "crates/toolchain/platform", default-features = false }
+openvm-transpiler = { version = "2.0.0", path = "crates/toolchain/transpiler", default-features = false }
 openvm-toolchain-tests = { path = "crates/toolchain/tests", default-features = false }
-openvm-custom-insn = { path = "crates/toolchain/custom_insn", default-features = false }
-openvm-circuit = { path = "crates/vm", default-features = false }
-openvm-circuit-derive = { path = "crates/vm/derive", default-features = false }
-openvm-recursion-circuit = { path = "crates/recursion", default-features = false }
-openvm-recursion-circuit-derive = { path = "crates/recursion/derive", default-features = false }
-openvm-continuations = { path = "crates/continuations", default-features = false }
-openvm-verify-stark-host = { path = "crates/verify", default-features = false }
-openvm-static-verifier = { path = "crates/static-verifier", default-features = false }
-openvm-sdk = { path = "crates/sdk", default-features = false }
-openvm-sdk-config = { path = "crates/sdk-config", default-features = false }
-cargo-openvm = { path = "crates/cli", default-features = false }
+openvm-custom-insn = { version = "0.1.0", path = "crates/toolchain/custom_insn", default-features = false }
+openvm-circuit = { version = "2.0.0", path = "crates/vm", default-features = false }
+openvm-circuit-derive = { version = "2.0.0", path = "crates/vm/derive", default-features = false }
+openvm-recursion-circuit = { version = "2.0.0", path = "crates/recursion", default-features = false }
+openvm-recursion-circuit-derive = { version = "2.0.0", path = "crates/recursion/derive", default-features = false }
+openvm-continuations = { version = "2.0.0", path = "crates/continuations", default-features = false }
+openvm-verify-stark-host = { version = "2.0.0", path = "crates/verify", default-features = false }
+openvm-static-verifier = { version = "2.0.0", path = "crates/static-verifier", default-features = false }
+openvm-sdk = { version = "2.0.0", path = "crates/sdk", default-features = false }
+openvm-sdk-config = { version = "2.0.0", path = "crates/sdk-config", default-features = false }
+cargo-openvm = { version = "2.0.0", path = "crates/cli", default-features = false }
 
 # Extensions
-openvm-rv32im-circuit = { path = "extensions/rv32im/circuit", default-features = false }
-openvm-rv32im-transpiler = { path = "extensions/rv32im/transpiler", default-features = false }
-openvm-rv32im-guest = { path = "extensions/rv32im/guest", default-features = false }
-openvm-rv32-adapters = { path = "extensions/rv32-adapters", default-features = false }
-openvm-keccak256-circuit = { path = "extensions/keccak256/circuit", default-features = false }
-openvm-keccak256-transpiler = { path = "extensions/keccak256/transpiler", default-features = false }
-openvm-keccak256-guest = { path = "extensions/keccak256/guest", default-features = false }
-openvm-sha2-circuit = { path = "extensions/sha2/circuit", default-features = false }
-openvm-sha2-transpiler = { path = "extensions/sha2/transpiler", default-features = false }
-openvm-sha2-guest = { path = "extensions/sha2/guest", default-features = false }
-openvm-bigint-circuit = { path = "extensions/bigint/circuit", default-features = false }
-openvm-bigint-transpiler = { path = "extensions/bigint/transpiler", default-features = false }
-openvm-bigint-guest = { path = "extensions/bigint/guest", default-features = false }
-openvm-algebra-circuit = { path = "extensions/algebra/circuit", default-features = false }
-openvm-algebra-transpiler = { path = "extensions/algebra/transpiler", default-features = false }
-openvm-algebra-guest = { path = "extensions/algebra/guest", default-features = false }
-openvm-algebra-moduli-macros = { path = "extensions/algebra/moduli-macros", default-features = false }
-openvm-algebra-complex-macros = { path = "extensions/algebra/complex-macros", default-features = false }
-openvm-ecc-circuit = { path = "extensions/ecc/circuit", default-features = false }
-openvm-ecc-transpiler = { path = "extensions/ecc/transpiler", default-features = false }
-openvm-ecc-guest = { path = "extensions/ecc/guest", default-features = false }
-openvm-ecc-sw-macros = { path = "extensions/ecc/sw-macros", default-features = false }
-openvm-pairing-circuit = { path = "extensions/pairing/circuit", default-features = false }
-openvm-pairing-transpiler = { path = "extensions/pairing/transpiler", default-features = false }
-openvm-pairing-guest = { path = "extensions/pairing/guest", default-features = false }
-openvm-verify-stark-circuit = { path = "guest-libs/verify-stark/circuit", default-features = false }
-openvm-deferral-circuit = { path = "extensions/deferral/circuit", default-features = false }
-openvm-deferral-guest = { path = "extensions/deferral/guest", default-features = false }
-openvm-deferral-transpiler = { path = "extensions/deferral/transpiler", default-features = false }
+openvm-rv32im-circuit = { version = "2.0.0", path = "extensions/rv32im/circuit", default-features = false }
+openvm-rv32im-transpiler = { version = "2.0.0", path = "extensions/rv32im/transpiler", default-features = false }
+openvm-rv32im-guest = { version = "2.0.0", path = "extensions/rv32im/guest", default-features = false }
+openvm-rv32-adapters = { version = "2.0.0", path = "extensions/rv32-adapters", default-features = false }
+openvm-keccak256-circuit = { version = "2.0.0", path = "extensions/keccak256/circuit", default-features = false }
+openvm-keccak256-transpiler = { version = "2.0.0", path = "extensions/keccak256/transpiler", default-features = false }
+openvm-keccak256-guest = { version = "2.0.0", path = "extensions/keccak256/guest", default-features = false }
+openvm-sha2-circuit = { version = "2.0.0", path = "extensions/sha2/circuit", default-features = false }
+openvm-sha2-transpiler = { version = "2.0.0", path = "extensions/sha2/transpiler", default-features = false }
+openvm-sha2-guest = { version = "2.0.0", path = "extensions/sha2/guest", default-features = false }
+openvm-bigint-circuit = { version = "2.0.0", path = "extensions/bigint/circuit", default-features = false }
+openvm-bigint-transpiler = { version = "2.0.0", path = "extensions/bigint/transpiler", default-features = false }
+openvm-bigint-guest = { version = "2.0.0", path = "extensions/bigint/guest", default-features = false }
+openvm-algebra-circuit = { version = "2.0.0", path = "extensions/algebra/circuit", default-features = false }
+openvm-algebra-transpiler = { version = "2.0.0", path = "extensions/algebra/transpiler", default-features = false }
+openvm-algebra-guest = { version = "2.0.0", path = "extensions/algebra/guest", default-features = false }
+openvm-algebra-moduli-macros = { version = "2.0.0", path = "extensions/algebra/moduli-macros", default-features = false }
+openvm-algebra-complex-macros = { version = "2.0.0", path = "extensions/algebra/complex-macros", default-features = false }
+openvm-ecc-circuit = { version = "2.0.0", path = "extensions/ecc/circuit", default-features = false }
+openvm-ecc-transpiler = { version = "2.0.0", path = "extensions/ecc/transpiler", default-features = false }
+openvm-ecc-guest = { version = "2.0.0", path = "extensions/ecc/guest", default-features = false }
+openvm-ecc-sw-macros = { version = "2.0.0", path = "extensions/ecc/sw-macros", default-features = false }
+openvm-pairing-circuit = { version = "2.0.0", path = "extensions/pairing/circuit", default-features = false }
+openvm-pairing-transpiler = { version = "2.0.0", path = "extensions/pairing/transpiler", default-features = false }
+openvm-pairing-guest = { version = "2.0.0", path = "extensions/pairing/guest", default-features = false }
+openvm-verify-stark-circuit = { version = "2.0.0", path = "guest-libs/verify-stark/circuit", default-features = false }
+openvm-deferral-circuit = { version = "2.0.0", path = "extensions/deferral/circuit", default-features = false }
+openvm-deferral-guest = { version = "2.0.0", path = "extensions/deferral/guest", default-features = false }
+openvm-deferral-transpiler = { version = "2.0.0", path = "extensions/deferral/transpiler", default-features = false }
 
 # Benchmarking
 openvm-benchmarks-utils = { path = "benchmarks/utils", default-features = false }
@@ -195,11 +195,11 @@ p3-poseidon2-air = { version = "=0.4.3", default-features = false }
 p3-symmetric = { version = "=0.4.3", default-features = false }
 
 zkhash = { package = "zkhash-axiom", version = "0.2.0" }
-snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", tag = "v0.2.6", default-features = false, features = [
+snark-verifier-sdk = { version = "0.2.6", git = "https://github.com/axiom-crypto/snark-verifier.git", tag = "v0.2.6", default-features = false, features = [
   "loader_halo2",
 ] }
-halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.5.4", default-features = false }
-halo2curves-axiom = { git = "https://github.com/axiom-crypto/halo2curves.git", tag = "v0.7.2" }
+halo2-base = { version = "0.5.4", git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.5.4", default-features = false }
+halo2curves-axiom = { version = "0.7.2", git = "https://github.com/axiom-crypto/halo2curves.git", tag = "v0.7.2" }
 struct-reflection = "0.1.0"
 
 cargo_metadata = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,8 @@ incremental = true
 lto = "thin"
 
 [workspace.dependencies]
-openvm-stark-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false } # Stark Backend
+# Stark Backend
+openvm-stark-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
 openvm-stark-sdk = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
 openvm-cpu-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
 openvm-cuda-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }

--- a/benchmarks/execute/Cargo.toml
+++ b/benchmarks/execute/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openvm-benchmarks-execute"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/benchmarks/prove/Cargo.toml
+++ b/benchmarks/prove/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openvm-benchmarks-prove"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/benchmarks/utils/Cargo.toml
+++ b/benchmarks/utils/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openvm-benchmarks-utils"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/crates/circuits/mod-builder/Cargo.toml
+++ b/crates/circuits/mod-builder/Cargo.toml
@@ -4,6 +4,7 @@ description = "Modular arithmetic framework for building OpenVM circuits."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -25,10 +26,10 @@ tracing.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
-openvm-circuit-primitives = { workspace = true }
-openvm-pairing-guest = { workspace = true, features = ["halo2curves"] }
+openvm-circuit-primitives = { path = "../primitives", default-features = false }
+openvm-pairing-guest = { path = "../../../extensions/pairing/guest", default-features = false, features = ["halo2curves"] }
 halo2curves-axiom = { workspace = true }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = "../../vm", default-features = false, features = ["test-utils"] }
 rand08 = { package = "rand", version = "0.8.5", features = ["std_rng"] }
 
 [features]

--- a/crates/circuits/poseidon2-air/Cargo.toml
+++ b/crates/circuits/poseidon2-air/Cargo.toml
@@ -4,6 +4,7 @@ description = "Wrapper for the Plonky3 Poseidon2 AIR."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/circuits/primitives/Cargo.toml
+++ b/crates/circuits/primitives/Cargo.toml
@@ -4,6 +4,7 @@ description = "Library of plonky3 primitives for general purpose use in other ZK
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/circuits/primitives/derive/Cargo.toml
+++ b/crates/circuits/primitives/derive/Cargo.toml
@@ -4,6 +4,7 @@ description = "Procedural macros for writing circuits as AIRs."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/circuits/sha2-air/Cargo.toml
+++ b/crates/circuits/sha2-air/Cargo.toml
@@ -3,6 +3,10 @@ name = "openvm-sha2-air"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-circuit-primitives = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/continuations/Cargo.toml
+++ b/crates/continuations/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "openvm-continuations"
+description = "Continuation AIRs and utilities"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Continuation AIRs and utilities"
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 p3-air = { workspace = true }
@@ -34,11 +38,11 @@ openvm-cuda-common = { workspace = true, optional = true }
 openvm-cuda-backend = { workspace = true, optional = true }
 
 [dev-dependencies]
-openvm-rv32im-circuit = { workspace = true, features = ["test-utils"] }
-openvm-rv32im-transpiler = { workspace = true }
-openvm-deferral-circuit = { workspace = true }
-openvm-deferral-transpiler = { workspace = true }
-openvm-transpiler = { workspace = true }
+openvm-rv32im-circuit = { path = "../../extensions/rv32im/circuit", default-features = false, features = ["test-utils"] }
+openvm-rv32im-transpiler = { path = "../../extensions/rv32im/transpiler", default-features = false }
+openvm-deferral-circuit = { path = "../../extensions/deferral/circuit", default-features = false }
+openvm-deferral-transpiler = { path = "../../extensions/deferral/transpiler", default-features = false }
+openvm-transpiler = { path = "../toolchain/transpiler", default-features = false }
 test-case = { workspace = true }
 
 [features]

--- a/crates/prof/Cargo.toml
+++ b/crates/prof/Cargo.toml
@@ -2,9 +2,9 @@
 name = "openvm-prof"
 description = "OpenVM profiling tools"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/recursion/Cargo.toml
+++ b/crates/recursion/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "openvm-recursion-circuit"
+description = "OpenVM STARK recursion (sub-)circuit"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "OpenVM STARK recursion (sub-)circuit"
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 p3-maybe-rayon.workspace = true

--- a/crates/recursion/derive/Cargo.toml
+++ b/crates/recursion/derive/Cargo.toml
@@ -4,6 +4,10 @@ description = "Procedural macros for writing circuits as AIRs."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/sdk-config/Cargo.toml
+++ b/crates/sdk-config/Cargo.toml
@@ -3,6 +3,10 @@ name = "openvm-sdk-config"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -3,6 +3,7 @@ name = "openvm-sdk"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/static-verifier/Cargo.toml
+++ b/crates/static-verifier/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "openvm-static-verifier"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-sdk = { workspace = true, features = ["baby-bear-bn254-poseidon2"] }

--- a/crates/toolchain/build/Cargo.toml
+++ b/crates/toolchain/build/Cargo.toml
@@ -4,6 +4,7 @@ description = "OpenVM build tools"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/toolchain/custom_insn/Cargo.toml
+++ b/crates/toolchain/custom_insn/Cargo.toml
@@ -2,6 +2,10 @@
 name = "openvm-custom-insn"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }

--- a/crates/toolchain/instructions/Cargo.toml
+++ b/crates/toolchain/instructions/Cargo.toml
@@ -3,6 +3,7 @@ name = "openvm-instructions"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/toolchain/instructions/derive/Cargo.toml
+++ b/crates/toolchain/instructions/derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "openvm-instructions-derive"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -17,7 +18,7 @@ quote = "1.0"
 [dev-dependencies]
 strum.workspace = true
 strum_macros.workspace = true
-openvm-instructions.workspace = true
+openvm-instructions = { path = "..", default-features = false }
 
 [package.metadata.cargo-shear]
 ignored = ["strum"]

--- a/crates/toolchain/macros/Cargo.toml
+++ b/crates/toolchain/macros/Cargo.toml
@@ -3,8 +3,10 @@ name = "openvm-macros-common"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }

--- a/crates/toolchain/openvm/Cargo.toml
+++ b/crates/toolchain/openvm/Cargo.toml
@@ -4,6 +4,7 @@ description = "OpenVM standard Rust library for guest programs."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/toolchain/platform/Cargo.toml
+++ b/crates/toolchain/platform/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM Rust platform definitions."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-custom-insn.workspace = true

--- a/crates/toolchain/tests/Cargo.toml
+++ b/crates/toolchain/tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openvm-toolchain-tests"
 description = "Tests for the OpenVM toolchain starting from Rust"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -16,15 +17,15 @@ eyre.workspace = true
 [dev-dependencies]
 openvm-stark-backend.workspace = true
 openvm-stark-sdk.workspace = true
-openvm-circuit = { workspace = true, features = ["test-utils"] }
-openvm-algebra-transpiler.workspace = true
-openvm-bigint-circuit.workspace = true
-openvm-rv32im-circuit.workspace = true
-openvm-rv32im-transpiler.workspace = true
-openvm-algebra-circuit.workspace = true
-openvm-ecc-circuit = { workspace = true }
-openvm-instructions = { workspace = true }
-openvm-platform = { workspace = true }
+openvm-circuit = { path = "../../vm", default-features = false, features = ["test-utils"] }
+openvm-algebra-transpiler = { path = "../../../extensions/algebra/transpiler", default-features = false }
+openvm-bigint-circuit = { path = "../../../extensions/bigint/circuit", default-features = false }
+openvm-rv32im-circuit = { path = "../../../extensions/rv32im/circuit", default-features = false }
+openvm-rv32im-transpiler = { path = "../../../extensions/rv32im/transpiler", default-features = false }
+openvm-algebra-circuit = { path = "../../../extensions/algebra/circuit", default-features = false }
+openvm-ecc-circuit = { path = "../../../extensions/ecc/circuit", default-features = false }
+openvm-instructions = { path = "../instructions", default-features = false }
+openvm-platform = { path = "../platform", default-features = false }
 test-case.workspace = true
 rand = { workspace = true }
 serde = { workspace = true, features = ["alloc"] }

--- a/crates/toolchain/transpiler/Cargo.toml
+++ b/crates/toolchain/transpiler/Cargo.toml
@@ -3,8 +3,10 @@ name = "openvm-transpiler"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend.workspace = true

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "openvm-verify-stark-host"
+description = "Lightweight crate to verify a STARK proof for an OpenVM virtual machine."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Lightweight crate to verify a STARK proof for an OpenVM virtual machine."
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuits"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 p3-baby-bear = { workspace = true }
@@ -57,7 +59,7 @@ test-case.workspace = true
 
 openvm-stark-backend = { workspace = true, features = ["test-utils"] }
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = ".", default-features = false, features = ["test-utils"] }
 
 [features]
 default = ["parallel", "jemalloc"]

--- a/crates/vm/derive/Cargo.toml
+++ b/crates/vm/derive/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "openvm-circuit-derive"
-version.workspace = true
-edition.workspace = true
-authors.workspace = true
 description = "Procedural macros for OpenVM circuits."
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license.workspace = true
 
 [lib]

--- a/extensions/algebra/circuit/Cargo.toml
+++ b/extensions/algebra/circuit/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuit extension for algebra (modular arithmetic)"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-circuit-primitives = { workspace = true }
@@ -39,10 +41,10 @@ halo2curves-axiom = { workspace = true }
 blstrs = { workspace = true, features = ["__private_bench"] }
 
 [dev-dependencies]
-openvm-mod-circuit-builder = { workspace = true, features = ["test-utils"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
-openvm-rv32-adapters = { workspace = true, features = ["test-utils"] }
-openvm-pairing-guest = { workspace = true, features = ["halo2curves"] }
+openvm-mod-circuit-builder = { path = "../../../crates/circuits/mod-builder", default-features = false, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
+openvm-rv32-adapters = { path = "../../rv32-adapters", default-features = false, features = ["test-utils"] }
+openvm-pairing-guest = { path = "../../pairing/guest", default-features = false, features = ["halo2curves"] }
 test-case = { workspace = true }
 
 [features]

--- a/extensions/algebra/complex-macros/Cargo.toml
+++ b/extensions/algebra/complex-macros/Cargo.toml
@@ -2,10 +2,12 @@
 name = "openvm-algebra-complex-macros"
 description = "OpenVM algebra macros for complex ring extensions"
 version.workspace = true
-edition.workspace = true
 authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }

--- a/extensions/algebra/guest/Cargo.toml
+++ b/extensions/algebra/guest/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM guest library for algebra over rings and fields, including
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-algebra-moduli-macros = { workspace = true }

--- a/extensions/algebra/moduli-macros/Cargo.toml
+++ b/extensions/algebra/moduli-macros/Cargo.toml
@@ -2,10 +2,12 @@
 name = "openvm-algebra-moduli-macros"
 description = "OpenVM algebra macros for modular arithmetic"
 version.workspace = true
-edition.workspace = true
 authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }

--- a/extensions/algebra/tests/Cargo.toml
+++ b/extensions/algebra/tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openvm-algebra-tests"
 description = "Integration tests for the OpenVM algebra extension"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/extensions/algebra/transpiler/Cargo.toml
+++ b/extensions/algebra/transpiler/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM transpiler extension for algebra (modular arithmetic)"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/extensions/bigint/circuit/Cargo.toml
+++ b/extensions/bigint/circuit/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuit extension for uint256 and int256"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }
@@ -31,8 +33,8 @@ cfg-if.workspace = true
 
 [dev-dependencies]
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
-openvm-rv32-adapters = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
+openvm-rv32-adapters = { path = "../../rv32-adapters", default-features = false, features = ["test-utils"] }
 test-case.workspace = true
 alloy-primitives = { version = "1.2.1" }
 

--- a/extensions/bigint/guest/Cargo.toml
+++ b/extensions/bigint/guest/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM guest library for bigint"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-platform = { workspace = true }

--- a/extensions/bigint/transpiler/Cargo.toml
+++ b/extensions/bigint/transpiler/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM transpiler extension for bigint"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/extensions/deferral/circuit/Cargo.toml
+++ b/extensions/deferral/circuit/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuit extension for deferral instructions"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }
@@ -38,7 +40,7 @@ openvm-cuda-builder = { workspace = true, optional = true }
 
 [dev-dependencies]
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
 
 [features]
 default = ["parallel", "jemalloc"]

--- a/extensions/deferral/guest/Cargo.toml
+++ b/extensions/deferral/guest/Cargo.toml
@@ -3,8 +3,10 @@ name = "openvm-deferral-guest"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-custom-insn = { workspace = true }

--- a/extensions/deferral/tests/Cargo.toml
+++ b/extensions/deferral/tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openvm-deferral-integration-tests"
 description = "Integration tests for the OpenVM deferral extension"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/extensions/deferral/transpiler/Cargo.toml
+++ b/extensions/deferral/transpiler/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "openvm-deferral-transpiler"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-deferral-guest = { workspace = true }

--- a/extensions/ecc/circuit/Cargo.toml
+++ b/extensions/ecc/circuit/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuit extension for elliptic curve cryptography"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-circuit-primitives = { workspace = true }
@@ -39,11 +41,11 @@ halo2curves-axiom = { workspace = true }
 blstrs = { workspace = true }
 
 [dev-dependencies]
-openvm-pairing-guest = { workspace = true, features = ["halo2curves"] }
+openvm-pairing-guest = { path = "../../pairing/guest", default-features = false, features = ["halo2curves"] }
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-mod-circuit-builder = { workspace = true, features = ["test-utils"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
-openvm-rv32-adapters = { workspace = true, features = ["test-utils"] }
+openvm-mod-circuit-builder = { path = "../../../crates/circuits/mod-builder", default-features = false, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
+openvm-rv32-adapters = { path = "../../rv32-adapters", default-features = false, features = ["test-utils"] }
 lazy_static = { workspace = true }
 
 [features]

--- a/extensions/ecc/guest/Cargo.toml
+++ b/extensions/ecc/guest/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM guest library for elliptic curve cryptography"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm = { workspace = true }

--- a/extensions/ecc/sw-macros/Cargo.toml
+++ b/extensions/ecc/sw-macros/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM elliptic curve macros for short Weierstrass curves"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }

--- a/extensions/ecc/tests/Cargo.toml
+++ b/extensions/ecc/tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openvm-ecc-integration-tests"
 description = "Integration tests for the OpenVM ecc extension"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/extensions/ecc/transpiler/Cargo.toml
+++ b/extensions/ecc/transpiler/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM transpiler extension for elliptic curve cryptography"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/extensions/keccak256/circuit/Cargo.toml
+++ b/extensions/keccak256/circuit/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuit extension for keccak256"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }
@@ -33,7 +35,7 @@ serde.workspace = true
 
 [dev-dependencies]
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
 
 [build-dependencies]
 openvm-cuda-builder = { workspace = true, optional = true }

--- a/extensions/keccak256/guest/Cargo.toml
+++ b/extensions/keccak256/guest/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM guest library for keccak256"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-platform = { workspace = true }

--- a/extensions/keccak256/transpiler/Cargo.toml
+++ b/extensions/keccak256/transpiler/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM transpiler extension for keccak256"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/extensions/pairing/circuit/Cargo.toml
+++ b/extensions/pairing/circuit/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuit extension for elliptic curve pairing"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-circuit-primitives = { workspace = true }
@@ -47,11 +49,11 @@ openvm-pairing-guest = { workspace = true }
 
 [dev-dependencies]
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-mod-circuit-builder = { workspace = true, features = ["test-utils"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-mod-circuit-builder = { path = "../../../crates/circuits/mod-builder", default-features = false, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
 halo2curves-axiom = { workspace = true }
-openvm-ecc-guest = { workspace = true }
-openvm-pairing-guest = { workspace = true, features = [
+openvm-ecc-guest = { path = "../../ecc/guest", default-features = false }
+openvm-pairing-guest = { path = "../guest", default-features = false, features = [
     "halo2curves",
     "bls12_381",
     "bn254",

--- a/extensions/pairing/guest/Cargo.toml
+++ b/extensions/pairing/guest/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM guest library for elliptic curve pairing"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm = { workspace = true }

--- a/extensions/pairing/transpiler/Cargo.toml
+++ b/extensions/pairing/transpiler/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM transpiler extension for elliptic curve pairing"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/extensions/rv32-adapters/Cargo.toml
+++ b/extensions/rv32-adapters/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM adapters for rv32 intrinsics"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }
@@ -22,7 +24,7 @@ rand.workspace = true
 
 [dev-dependencies]
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = "../../crates/vm", default-features = false, features = ["test-utils"] }
 
 [features]
 default = ["parallel"]

--- a/extensions/rv32im/circuit/Cargo.toml
+++ b/extensions/rv32im/circuit/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM circuit extension for RISC-V 32-bit IM instruction set"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }
@@ -34,7 +36,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 
 [dev-dependencies]
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
 test-case.workspace = true
 
 [build-dependencies]

--- a/extensions/rv32im/guest/Cargo.toml
+++ b/extensions/rv32im/guest/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM guest library for RISC-V 32-bit IM instruction set"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-custom-insn = { workspace = true }

--- a/extensions/rv32im/tests/Cargo.toml
+++ b/extensions/rv32im/tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openvm-rv32im-integration-tests"
 description = "Integration tests for the OpenVM rv32im extension"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/extensions/rv32im/transpiler/Cargo.toml
+++ b/extensions/rv32im/transpiler/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM transpiler extension for RISC-V 32-bit IM instruction set"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/extensions/sha2/circuit/Cargo.toml
+++ b/extensions/sha2/circuit/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "openvm-sha2-circuit"
+description = "OpenVM circuit extension for SHA-2"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "OpenVM circuit extension for SHA-2"
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }
@@ -33,7 +37,7 @@ itertools = { workspace = true }
 [dev-dependencies]
 hex = { workspace = true }
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
-openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["test-utils"] }
 
 [build-dependencies]
 openvm-cuda-builder = { workspace = true, optional = true }

--- a/extensions/sha2/guest/Cargo.toml
+++ b/extensions/sha2/guest/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "openvm-sha2-guest"
+description = "Guest extension for SHA-2"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Guest extension for SHA-2"
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-platform = { workspace = true }

--- a/extensions/sha2/transpiler/Cargo.toml
+++ b/extensions/sha2/transpiler/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "openvm-sha2-transpiler"
+description = "Transpiler extension for SHA-2"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Transpiler extension for SHA-2"
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm-stark-backend = { workspace = true }

--- a/guest-libs/ff_derive/Cargo.toml
+++ b/guest-libs/ff_derive/Cargo.toml
@@ -2,9 +2,9 @@
 name = "openvm-ff-derive"
 description = "OpenVM fork of ff_derive for finite field arithmetic"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -28,14 +28,14 @@ quote = "1"
 syn = { version = "1", features = ["full"] }
 
 [dev-dependencies]
-openvm-instructions = { workspace = true }
+openvm-instructions = { path = "../../crates/toolchain/instructions", default-features = false }
 openvm-stark-sdk = { workspace = true }
-openvm-circuit = { workspace = true, features = ["test-utils", "parallel"]}
-openvm-transpiler = { workspace = true }
-openvm-algebra-transpiler = { workspace = true }
-openvm-algebra-circuit = { workspace = true }
-openvm-rv32im-transpiler = { workspace = true }
-openvm-toolchain-tests = { workspace = true }
+openvm-circuit = { path = "../../crates/vm", default-features = false, features = ["test-utils", "parallel"] }
+openvm-transpiler = { path = "../../crates/toolchain/transpiler", default-features = false }
+openvm-algebra-transpiler = { path = "../../extensions/algebra/transpiler", default-features = false }
+openvm-algebra-circuit = { path = "../../extensions/algebra/circuit", default-features = false }
+openvm-rv32im-transpiler = { path = "../../extensions/rv32im/transpiler", default-features = false }
+openvm-toolchain-tests = { path = "../../crates/toolchain/tests", default-features = false }
 
 eyre = { workspace = true }
 num-bigint = { workspace = true }

--- a/guest-libs/k256/Cargo.toml
+++ b/guest-libs/k256/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 # for patching purposes, the name must be the same as the original `k256` crate
 name = "k256"
+description = "OpenVM fork of k256"
 # for patching purposes, version must match that of original `k256` crate
 version = "0.13.4"
-description = "OpenVM fork of k256"
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -30,15 +30,15 @@ signature = { version = "2", optional = true }
 num-bigint = { workspace = true }
 
 [dev-dependencies]
-openvm-circuit = { workspace = true, features = ["test-utils", "parallel"] }
-openvm-transpiler.workspace = true
-openvm-algebra-transpiler.workspace = true
-openvm-ecc-transpiler.workspace = true
-openvm-ecc-circuit.workspace = true
-openvm-sha2-circuit.workspace = true
-openvm-sha2-transpiler.workspace = true
-openvm-rv32im-transpiler.workspace = true
-openvm-toolchain-tests.workspace = true
+openvm-circuit = { path = "../../crates/vm", default-features = false, features = ["test-utils", "parallel"] }
+openvm-transpiler = { path = "../../crates/toolchain/transpiler", default-features = false }
+openvm-algebra-transpiler = { path = "../../extensions/algebra/transpiler", default-features = false }
+openvm-ecc-transpiler = { path = "../../extensions/ecc/transpiler", default-features = false }
+openvm-ecc-circuit = { path = "../../extensions/ecc/circuit", default-features = false }
+openvm-sha2-circuit = { path = "../../extensions/sha2/circuit", default-features = false }
+openvm-sha2-transpiler = { path = "../../extensions/sha2/transpiler", default-features = false }
+openvm-rv32im-transpiler = { path = "../../extensions/rv32im/transpiler", default-features = false }
+openvm-toolchain-tests = { path = "../../crates/toolchain/tests", default-features = false }
 
 openvm-stark-backend.workspace = true
 openvm-cpu-backend = { workspace = true }

--- a/guest-libs/keccak256/Cargo.toml
+++ b/guest-libs/keccak256/Cargo.toml
@@ -2,9 +2,9 @@
 name = "openvm-keccak256"
 description = "OpenVM library for keccak256"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -18,15 +18,15 @@ spin = { workspace = true, features = ["mutex", "spin_mutex"] }
 
 [dev-dependencies]
 hex = { workspace = true }
-openvm-instructions = { workspace = true }
-openvm-sdk = { workspace = true }
+openvm-instructions = { path = "../../crates/toolchain/instructions", default-features = false }
+openvm-sdk = { path = "../../crates/sdk", default-features = false }
 openvm-stark-sdk = { workspace = true }
-openvm-circuit = { workspace = true, features = ["test-utils", "parallel"] }
-openvm-transpiler = { workspace = true }
-openvm-keccak256-transpiler = { workspace = true }
-openvm-keccak256-circuit = { workspace = true }
-openvm-rv32im-transpiler = { workspace = true }
-openvm-toolchain-tests = { workspace = true }
+openvm-circuit = { path = "../../crates/vm", default-features = false, features = ["test-utils", "parallel"] }
+openvm-transpiler = { path = "../../crates/toolchain/transpiler", default-features = false }
+openvm-keccak256-transpiler = { path = "../../extensions/keccak256/transpiler", default-features = false }
+openvm-keccak256-circuit = { path = "../../extensions/keccak256/circuit", default-features = false }
+openvm-rv32im-transpiler = { path = "../../extensions/rv32im/transpiler", default-features = false }
+openvm-toolchain-tests = { path = "../../crates/toolchain/tests", default-features = false }
 eyre = { workspace = true }
 
 [features]

--- a/guest-libs/p256/Cargo.toml
+++ b/guest-libs/p256/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 # for patching purposes, the name must be the same as the original `p256` crate
 name = "p256"
+description = "OpenVM fork of p256"
 # for patching purposes, version must match that of original `p256` crate
 version = "0.13.2"
-description = "OpenVM fork of p256"
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -27,15 +27,15 @@ hex-literal = { workspace = true }
 ff = { workspace = true }
 
 [dev-dependencies]
-openvm-circuit = { workspace = true, features = ["test-utils", "parallel"] }
-openvm-transpiler.workspace = true
-openvm-algebra-transpiler.workspace = true
-openvm-ecc-transpiler.workspace = true
-openvm-ecc-circuit.workspace = true
-openvm-sha2-circuit.workspace = true
-openvm-sha2-transpiler.workspace = true
-openvm-rv32im-transpiler.workspace = true
-openvm-toolchain-tests.workspace = true
+openvm-circuit = { path = "../../crates/vm", default-features = false, features = ["test-utils", "parallel"] }
+openvm-transpiler = { path = "../../crates/toolchain/transpiler", default-features = false }
+openvm-algebra-transpiler = { path = "../../extensions/algebra/transpiler", default-features = false }
+openvm-ecc-transpiler = { path = "../../extensions/ecc/transpiler", default-features = false }
+openvm-ecc-circuit = { path = "../../extensions/ecc/circuit", default-features = false }
+openvm-sha2-circuit = { path = "../../extensions/sha2/circuit", default-features = false }
+openvm-sha2-transpiler = { path = "../../extensions/sha2/transpiler", default-features = false }
+openvm-rv32im-transpiler = { path = "../../extensions/rv32im/transpiler", default-features = false }
+openvm-toolchain-tests = { path = "../../crates/toolchain/tests", default-features = false }
 
 openvm-stark-backend.workspace = true
 openvm-cpu-backend = { workspace = true }

--- a/guest-libs/pairing/Cargo.toml
+++ b/guest-libs/pairing/Cargo.toml
@@ -4,8 +4,10 @@ description = "OpenVM library for elliptic curve pairing"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
+license.workspace = true
 
 [dependencies]
 openvm = { workspace = true }
@@ -32,21 +34,21 @@ num-traits.workspace = true
 openvm-ecc-guest = { workspace = true }
 
 [dev-dependencies]
-openvm-instructions = { workspace = true }
+openvm-instructions = { path = "../../crates/toolchain/instructions", default-features = false }
 openvm-stark-sdk.workspace = true
-openvm-circuit = { workspace = true, features = ["test-utils", "parallel"] }
-openvm-transpiler.workspace = true
-openvm-algebra-circuit.workspace = true
-openvm-algebra-transpiler.workspace = true
-openvm-pairing-circuit.workspace = true
-openvm-pairing-transpiler.workspace = true
-openvm-pairing-guest.workspace = true
-openvm-ecc-circuit.workspace = true
-openvm-ecc-guest.workspace = true
-openvm-ecc-transpiler.workspace = true
-openvm-rv32im-transpiler.workspace = true
-openvm = { workspace = true }
-openvm-toolchain-tests = { workspace = true }
+openvm-circuit = { path = "../../crates/vm", default-features = false, features = ["test-utils", "parallel"] }
+openvm-transpiler = { path = "../../crates/toolchain/transpiler", default-features = false }
+openvm-algebra-circuit = { path = "../../extensions/algebra/circuit", default-features = false }
+openvm-algebra-transpiler = { path = "../../extensions/algebra/transpiler", default-features = false }
+openvm-pairing-circuit = { path = "../../extensions/pairing/circuit", default-features = false }
+openvm-pairing-transpiler = { path = "../../extensions/pairing/transpiler", default-features = false }
+openvm-pairing-guest = { path = "../../extensions/pairing/guest", default-features = false }
+openvm-ecc-circuit = { path = "../../extensions/ecc/circuit", default-features = false }
+openvm-ecc-guest = { path = "../../extensions/ecc/guest", default-features = false }
+openvm-ecc-transpiler = { path = "../../extensions/ecc/transpiler", default-features = false }
+openvm-rv32im-transpiler = { path = "../../extensions/rv32im/transpiler", default-features = false }
+openvm = { path = "../../crates/toolchain/openvm", default-features = false }
+openvm-toolchain-tests = { path = "../../crates/toolchain/tests", default-features = false }
 eyre.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true

--- a/guest-libs/sha2/Cargo.toml
+++ b/guest-libs/sha2/Cargo.toml
@@ -2,9 +2,9 @@
 name = "openvm-sha2"
 description = "OpenVM library for sha2"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -15,15 +15,15 @@ sha2 = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
 hex = { workspace = true }
-openvm-instructions = { workspace = true }
-openvm-sdk = { workspace = true }
+openvm-instructions = { path = "../../crates/toolchain/instructions", default-features = false }
+openvm-sdk = { path = "../../crates/sdk", default-features = false }
 openvm-stark-sdk = { workspace = true }
-openvm-circuit = { workspace = true, features = ["test-utils", "parallel"] }
-openvm-transpiler = { workspace = true }
-openvm-sha2-transpiler = { workspace = true }
-openvm-sha2-circuit = { workspace = true }
-openvm-rv32im-transpiler = { workspace = true }
-openvm-toolchain-tests = { workspace = true }
+openvm-circuit = { path = "../../crates/vm", default-features = false, features = ["test-utils", "parallel"] }
+openvm-transpiler = { path = "../../crates/toolchain/transpiler", default-features = false }
+openvm-sha2-transpiler = { path = "../../extensions/sha2/transpiler", default-features = false }
+openvm-sha2-circuit = { path = "../../extensions/sha2/circuit", default-features = false }
+openvm-rv32im-transpiler = { path = "../../extensions/rv32im/transpiler", default-features = false }
+openvm-toolchain-tests = { path = "../../crates/toolchain/tests", default-features = false }
 eyre = { workspace = true }
 
 [features]

--- a/guest-libs/verify-stark/circuit/Cargo.toml
+++ b/guest-libs/verify-stark/circuit/Cargo.toml
@@ -2,9 +2,9 @@
 name = "openvm-verify-stark-circuit"
 description = "OpenVM guest library for verifying STARKs"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -38,13 +38,13 @@ bitcode = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-openvm-continuations = { workspace = true }
-openvm-circuit = { workspace = true, features = ["parallel"] }
-openvm-rv32im-circuit = { workspace = true, features = ["test-utils"] }
-openvm-rv32im-transpiler = { workspace = true }
+openvm-continuations = { path = "../../../crates/continuations", default-features = false }
+openvm-circuit = { path = "../../../crates/vm", default-features = false, features = ["parallel"] }
+openvm-rv32im-circuit = { path = "../../../extensions/rv32im/circuit", default-features = false, features = ["test-utils"] }
+openvm-rv32im-transpiler = { path = "../../../extensions/rv32im/transpiler", default-features = false }
 openvm-stark-sdk = { workspace = true }
-openvm-transpiler = { workspace = true }
-openvm-verify-stark-host = { workspace = true }
+openvm-transpiler = { path = "../../../crates/toolchain/transpiler", default-features = false }
+openvm-verify-stark-host = { path = "../../../crates/verify", default-features = false }
 eyre.workspace = true
 test-case.workspace = true
 

--- a/guest-libs/verify-stark/guest/Cargo.toml
+++ b/guest-libs/verify-stark/guest/Cargo.toml
@@ -2,9 +2,9 @@
 name = "openvm-verify-stark-guest"
 description = "OpenVM guest library for verifying STARKs"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openvm-scripts"
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -41,4 +42,3 @@ required-features = ["cuda"]
 [[bin]]
 name = "generate-param-sweep"
 path = "bin/generate_param_sweep.rs"
-


### PR DESCRIPTION
# Workspace Publish Readiness Summary

  Assumption for publishable members: referenced dependencies already exist on crates.io at the requested versions. Dev-dependencies are excluded
  from the dependency-shape audit.

  ## Publish Disabled (9)

  - `openvm-benchmarks-execute`: `benchmarks/execute/Cargo.toml`
  - `openvm-benchmarks-prove`: `benchmarks/prove/Cargo.toml`
  - `openvm-benchmarks-utils`: `benchmarks/utils/Cargo.toml`
  - `openvm-toolchain-tests`: `crates/toolchain/tests/Cargo.toml`
  - `openvm-algebra-tests`: `extensions/algebra/tests/Cargo.toml`
  - `openvm-deferral-integration-tests`: `extensions/deferral/tests/Cargo.toml`
  - `openvm-ecc-integration-tests`: `extensions/ecc/tests/Cargo.toml`
  - `openvm-rv32im-integration-tests`: `extensions/rv32im/tests/Cargo.toml`
  - `openvm-scripts`: `scripts/Cargo.toml`

  ## Publishable Dependency Shape OK (60)

  All remaining workspace members are in this category.