### PR TITLE
perf(vm): drop the hidden stream sync in CPU-to-GPU ctx transport

### DIFF
--- a/crates/circuits/primitives/src/hybrid_chip.rs
+++ b/crates/circuits/primitives/src/hybrid_chip.rs
@@ -2,11 +2,10 @@ use std::marker::PhantomData;
 
 use openvm_cpu_backend::CpuBackend;
 use openvm_cuda_backend::{
-    base::DeviceMatrix, data_transporter::transport_matrix_h2d_col_major,
-    hash_scheme::GpuHashScheme, prelude::SC, GenericGpuBackend, GpuBackend,
+    base::DeviceMatrix, hash_scheme::GpuHashScheme, prelude::SC, GenericGpuBackend, GpuBackend,
 };
-use openvm_cuda_common::stream::GpuDeviceCtx;
-use openvm_stark_backend::prover::{AirProvingContext, ColMajorMatrix};
+use openvm_cuda_common::{copy::MemCopyH2D, stream::GpuDeviceCtx};
+use openvm_stark_backend::prover::{AirProvingContext, ColMajorMatrix, MatrixDimensions};
 
 use crate::Chip;
 
@@ -51,7 +50,16 @@ pub fn cpu_proving_ctx_to_gpu<HS: GpuHashScheme>(
         "CPU to GPU transfer of cached traces not supported"
     );
     let cm = ColMajorMatrix::from_row_major(&cpu_ctx.common_main);
-    let trace = transport_matrix_h2d_col_major(&cm, device_ctx).unwrap();
+    // Copy without `transport_matrix_h2d_col_major`: that helper ends with a
+    // full stream sync, which stalls the host until every previously enqueued
+    // kernel and copy has drained (measured >1s per segment on reth-sized
+    // workloads when this runs mid-tracegen). The sync is unnecessary for the
+    // source's lifetime: an async copy from pageable memory returns only once
+    // the source has been consumed by the staging pipeline, and all later
+    // reads of the destination are ordered by the stream.
+    let (height, width) = (cm.height(), cm.width());
+    let buffer = cm.values.to_device_on(device_ctx).unwrap();
+    let trace = DeviceMatrix::new(std::sync::Arc::new(buffer), height, width);
     AirProvingContext {
         cached_mains: vec![],
         common_main: trace,


### PR DESCRIPTION
Stacked on #2999 (review the last commit only).

## Problem

`cpu_proving_ctx_to_gpu` (used by every `HybridChip` and the continuation
circuits' trace conversion) calls `transport_matrix_h2d_col_major`, which ends
with a **full stream sync**. The connector chip's two-row trace conversion runs
mid-tracegen, right after the executor phase has filled the stream with ~0.5 GB
of record copies and tracegen kernels per segment — so this one call was
measured at **1,122 ms per block** (`connector_trace_gen_time_ms`), stalling the
host on the entire stream drain 78 times. (Earlier revisions of this stack saw
the same conserved wait surface at the program chip; it moved here when that
path went async.)

## Change

The sync is unnecessary for the temporary column-major buffer's lifetime: an
async copy from pageable memory returns only once the source has been consumed
by the staging pipeline, and all later reads of the destination are
stream-ordered. The transport is now the plain async copy; the temporary
drops safely on return.

With no serializing call left between the executor phase and the memory
inventory, the stream drain surfaces at the Merkle update's public-values
readback instead — after the merge pipeline's host driving has already run,
which is the packing improvement this buys.

## Measured

openvm-eth reth benchmark, block 23992138, RTX Pro 6000 (VPMM 15 GiB), full
stack, same host class (CPU control within 0.8%); proof verifies (rc=0).
Measured together with the copy-stream PR stacked on this one:

| metric | before | after |
|---|---|---|
| `connector_trace_gen_time_ms` | 1,122 | **1** |
| `merkle_update_time_ms` (drain relocates here, after merge driving) | 161 | 873 |
| `trace_gen_time_ms` | 2,952 | **2,714** |
