### PR TITLE
perf(vm): upload records on a dedicated copy stream

### DIFF
--- a/crates/vm/src/arch/cuda/copy_stream.rs
+++ b/crates/vm/src/arch/cuda/copy_stream.rs
@@ -1,0 +1,95 @@
+//! Dedicated host-to-device copy stream for record uploads.
+//!
+//! Record uploads and tracegen kernels have no cross-chip dependencies, but on
+//! a single stream they serialize: ~36 GB of records per reth block costs
+//! ~0.7 s of DMA that the stream cannot overlap with its own kernels. PCIe
+//! copy engines run concurrently with SM compute, so routing the uploads
+//! through a dedicated stream turns copy+kernel time from a sum into a max.
+//!
+//! Ordering with the VPMM allocator: allocations are stream-tagged, and a
+//! region freed on a stream may be reallocated to the same stream without
+//! synchronization (stream order makes that safe). A copy-stream write into a
+//! kernel-stream allocation therefore needs a two-event fence:
+//!
+//! 1. an event recorded on the kernel stream after allocation, waited by the copy stream — orders
+//!    the write after any prior kernel-stream work that used the reallocated region;
+//! 2. an event recorded on the copy stream after the copy, waited by the kernel stream — orders
+//!    every later kernel-stream read (and any future reallocation of this region) after the write.
+//!
+//! Host-side lifetime is unchanged: pinned sources return through the arena
+//! cleaner, which synchronizes the device (all streams) before reuse, and
+//! pageable sources are consumed by the staging pipeline before the copy call
+//! returns.
+
+use std::sync::OnceLock;
+
+use openvm_cuda_common::{
+    copy::cuda_memcpy_on,
+    d_buffer::DeviceBuffer,
+    error::MemCopyError,
+    stream::{CudaEvent, GpuDeviceCtx},
+};
+
+fn copy_ctx() -> Option<&'static GpuDeviceCtx> {
+    static CTX: OnceLock<Option<GpuDeviceCtx>> = OnceLock::new();
+    CTX.get_or_init(|| match GpuDeviceCtx::for_current_device() {
+        Ok(ctx) => Some(ctx),
+        Err(e) => {
+            tracing::debug!("no copy stream ({e:?}); record uploads use the kernel stream");
+            None
+        }
+    })
+    .as_ref()
+}
+
+/// Uploads `records` to a device buffer allocated on `kernel_ctx`, running the
+/// copy on the shared copy stream so it overlaps kernels already enqueued on
+/// `kernel_ctx`. All subsequent work on `kernel_ctx` is ordered after the
+/// copy. Falls back to a plain same-stream copy if the copy stream is
+/// unavailable.
+pub fn records_to_device(
+    records: &[u8],
+    kernel_ctx: &GpuDeviceCtx,
+) -> Result<DeviceBuffer<u8>, MemCopyError> {
+    let dst = DeviceBuffer::<u8>::with_capacity_on(records.len(), kernel_ctx);
+    let copy = match copy_ctx() {
+        Some(c) => c,
+        None => {
+            // SAFETY: `dst` holds `records.len()` bytes; same-stream copy.
+            unsafe {
+                cuda_memcpy_on::<false, true>(
+                    dst.as_mut_raw_ptr(),
+                    records.as_ptr() as *const std::ffi::c_void,
+                    records.len(),
+                    kernel_ctx,
+                )?;
+            }
+            return Ok(dst);
+        }
+    };
+    let alloc_done = CudaEvent::new().map_err(MemCopyError::from)?;
+    alloc_done
+        .record_on(&kernel_ctx.stream)
+        .map_err(MemCopyError::from)?;
+    copy.stream.wait(&alloc_done).map_err(MemCopyError::from)?;
+    // SAFETY: `dst` holds `records.len()` bytes; the copy stream is ordered
+    // after prior kernel-stream users of the region (alloc_done) and before
+    // later ones (copy_done).
+    unsafe {
+        cuda_memcpy_on::<false, true>(
+            dst.as_mut_raw_ptr(),
+            records.as_ptr() as *const std::ffi::c_void,
+            records.len(),
+            copy,
+        )?;
+    }
+    let copy_done = CudaEvent::new().map_err(MemCopyError::from)?;
+    copy_done
+        .record_on(&copy.stream)
+        .map_err(MemCopyError::from)?;
+    kernel_ctx
+        .stream
+        .wait(&copy_done)
+        .map_err(MemCopyError::from)?;
+    Ok(dst)
+}

--- a/crates/vm/src/arch/cuda/mod.rs
+++ b/crates/vm/src/arch/cuda/mod.rs
@@ -1,3 +1,4 @@
 //! CUDA-specific support for the VM architecture layer.
 
+pub mod copy_stream;
 pub(crate) mod pinned;

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -1,7 +1,8 @@
 mod config;
-/// CUDA-specific support (pinned host-memory pool for record arenas).
+/// CUDA-specific support (pinned host-memory pool for record arenas, record
+/// upload copy stream).
 #[cfg(feature = "cuda")]
-pub(crate) mod cuda;
+pub mod cuda;
 /// Streams-like deferral state
 pub mod deferral;
 /// Instruction execution traits and types.

--- a/extensions/bigint/circuit/src/cuda/mod.rs
+++ b/extensions/bigint/circuit/src/cuda/mod.rs
@@ -10,7 +10,6 @@ use openvm_circuit_primitives::{
     range_tuple::RangeTupleCheckerChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_rv32_adapters::{
     Rv32VecHeapAdapterCols, Rv32VecHeapAdapterRecord, Rv32VecHeapBranchAdapterCols,
     Rv32VecHeapBranchAdapterRecord,
@@ -68,7 +67,9 @@ impl Chip<DenseRecordArena, GpuBackend> for BaseAlu256ChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {
@@ -120,7 +121,9 @@ impl Chip<DenseRecordArena, GpuBackend> for BranchEqual256ChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {
@@ -183,7 +186,9 @@ impl Chip<DenseRecordArena, GpuBackend> for LessThan256ChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {
@@ -235,7 +240,9 @@ impl Chip<DenseRecordArena, GpuBackend> for BranchLessThan256ChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {
@@ -298,7 +305,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Shift256ChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {
@@ -363,7 +372,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Multiplication256ChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         let sizes = self.range_tuple_checker.sizes;

--- a/extensions/deferral/circuit/src/call/cuda.rs
+++ b/extensions/deferral/circuit/src/call/cuda.rs
@@ -6,7 +6,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer};
+use openvm_cuda_common::d_buffer::DeviceBuffer;
 use openvm_instructions::riscv::RV32_CELL_BITS;
 use openvm_stark_backend::prover::AirProvingContext;
 
@@ -44,7 +44,9 @@ impl Chip<DenseRecordArena, GpuBackend> for DeferralCallChipGpu {
             DeferralCallAdapterCols::<F>::width() + DeferralCallCoreCols::<F>::width();
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/deferral/circuit/src/output/cuda.rs
+++ b/extensions/deferral/circuit/src/output/cuda.rs
@@ -115,7 +115,9 @@ impl Chip<DenseRecordArena, GpuBackend> for DeferralOutputChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
         let trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
-        let d_raw_records = records.to_device_on(device_ctx).unwrap();
+        let d_raw_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_per_call = per_call.to_device_on(device_ctx).unwrap();
         let d_per_row = per_row.to_device_on(device_ctx).unwrap();
 

--- a/extensions/keccak256/circuit/src/cuda/mod.rs
+++ b/extensions/keccak256/circuit/src/cuda/mod.rs
@@ -9,7 +9,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
+use openvm_cuda_common::{d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
 use openvm_instructions::riscv::RV32_CELL_BITS;
 use openvm_stark_backend::prover::AirProvingContext;
 use p3_keccak_air::NUM_ROUNDS;
@@ -45,7 +45,9 @@ impl Chip<DenseRecordArena, GpuBackend> for XorinVmChipGpu {
         let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
         let device_ctx = &self.range_checker.device_ctx;
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {
@@ -111,7 +113,9 @@ impl Chip<DenseRecordArena, GpuBackend> for KeccakfOpChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         // Transfer records to GPU
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 
         unsafe {

--- a/extensions/rv32im/circuit/src/auipc/cuda.rs
+++ b/extensions/rv32im/circuit/src/auipc/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -36,7 +35,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32AuipcChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/base_alu/cuda.rs
+++ b/extensions/rv32im/circuit/src/base_alu/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -42,7 +41,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32BaseAluChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/branch_eq/cuda.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/cuda.rs
@@ -4,7 +4,6 @@ use derive_new::new;
 use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
 use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -37,7 +36,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32BranchEqualChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/branch_lt/cuda.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -43,7 +42,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32BranchLessThanChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/divrem/cuda.rs
+++ b/extensions/rv32im/circuit/src/divrem/cuda.rs
@@ -7,7 +7,6 @@ use openvm_circuit_primitives::{
     var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_instructions::riscv::{RV32_CELL_BITS, RV32_REGISTER_NUM_LIMBS};
 use openvm_stark_backend::prover::AirProvingContext;
 
@@ -48,7 +47,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32DivRemChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(padded_height, trace_width, device_ctx);
         unsafe {

--- a/extensions/rv32im/circuit/src/hintstore/cuda.rs
+++ b/extensions/rv32im/circuit/src/hintstore/cuda.rs
@@ -59,7 +59,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32HintStoreChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_record_offsets = offsets.to_device_on(device_ctx).unwrap();
 

--- a/extensions/rv32im/circuit/src/jal_lui/cuda.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -37,7 +36,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32JalLuiChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/jalr/cuda.rs
+++ b/extensions/rv32im/circuit/src/jalr/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -35,7 +34,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32JalrChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/less_than/cuda.rs
+++ b/extensions/rv32im/circuit/src/less_than/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -42,7 +41,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LessThanChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/cuda.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/cuda.rs
@@ -4,7 +4,6 @@ use derive_new::new;
 use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
 use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_instructions::riscv::RV32_REGISTER_NUM_LIMBS;
 use openvm_stark_backend::prover::AirProvingContext;
 
@@ -40,7 +39,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadSignExtendChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(padded_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/loadstore/cuda.rs
+++ b/extensions/rv32im/circuit/src/loadstore/cuda.rs
@@ -4,7 +4,6 @@ use derive_new::new;
 use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
 use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_instructions::riscv::RV32_REGISTER_NUM_LIMBS;
 use openvm_stark_backend::prover::AirProvingContext;
 
@@ -40,7 +39,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32LoadStoreChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(padded_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/mul/cuda.rs
+++ b/extensions/rv32im/circuit/src/mul/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     range_tuple::RangeTupleCheckerChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -47,7 +46,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32MultiplicationChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/mulh/cuda.rs
+++ b/extensions/rv32im/circuit/src/mulh/cuda.rs
@@ -7,7 +7,6 @@ use openvm_circuit_primitives::{
     var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -47,7 +46,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32MulHChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
 

--- a/extensions/rv32im/circuit/src/shift/cuda.rs
+++ b/extensions/rv32im/circuit/src/shift/cuda.rs
@@ -6,7 +6,6 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use crate::{
@@ -42,7 +41,9 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv32ShiftChipGpu {
         let device_ctx = &self.range_checker.device_ctx;
 
         let d_records = tracing::info_span!("trace_gen.h2d_records")
-            .in_scope(|| records.to_device_on(device_ctx))
+            .in_scope(|| {
+                openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+            })
             .unwrap();
         let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
         unsafe {

--- a/extensions/sha2/circuit/src/cuda/mod.rs
+++ b/extensions/sha2/circuit/src/cuda/mod.rs
@@ -80,7 +80,9 @@ where
         let trace =
             DeviceMatrix::<F>::with_capacity_on(trace_height, C::MAIN_CHIP_WIDTH, device_ctx);
 
-        let d_records = records.to_device_on(device_ctx).unwrap();
+        let d_records =
+            openvm_circuit::arch::cuda::copy_stream::records_to_device(records, device_ctx)
+                .unwrap();
         let d_record_offsets = record_offsets.to_device_on(device_ctx).unwrap();
 
         unsafe {


### PR DESCRIPTION
Stacked on #3001 (review the last commit only).

## Problem

Record uploads and tracegen kernels have no cross-chip dependencies, but on a
single stream they serialize: ~36 GiB of records per reth block
(`trace_gen.record_arena_bytes`) is ~0.7 s of DMA that the stream cannot
overlap with its own kernels — the largest single contributor to the stream
drain that the first blocking call after the executor phase absorbs. PCIe copy
engines run concurrently with SM compute, so this is sum where it could be max.

## Change

`records_to_device` (new, `crates/vm/src/arch/cuda/copy_stream.rs`): allocates
the destination on the kernel stream, runs the copy on a shared dedicated
stream, and fences with two events:

1. recorded on the kernel stream after allocation, waited by the copy stream —
   the VPMM allocator reuses same-stream regions without synchronization, so
   the write must be ordered after any prior kernel-stream user of a
   reallocated region;
2. recorded on the copy stream after the copy, waited by the kernel stream —
   ordering every later read (and any future reallocation) after the write.

The fences chain correctly across region reuses; host-side lifetimes are
unchanged (pinned sources return through the arena cleaner's device-wide sync,
pageable sources are consumed by staging before the call returns). Falls back
to a plain same-stream copy when a second stream is unavailable.

All per-segment record uploads switch to the helper (rv32im including
hint-store, keccak256, sha2, bigint, deferral); small metadata uploads
(offsets, moduli, blobs) stay on the kernel stream.

## Measured

openvm-eth reth benchmark, block 23992138, RTX Pro 6000 (VPMM 15 GiB), full
stack, same host class; proof verifies (rc=0) across all 78 segments,
validating the two-event fence under real VPMM region reuse. Measured together
with #3001 (the two compose; see its table): tracegen wall 2,952 → 2,714 ms.
The remaining ~0.9 s drain at the Merkle-update readback is the true GPU
tracegen execution; separating the copy-stream's overlap contribution from
#3001's packing gain needs an A/B this stack's benching cadence didn't
justify — happy to run one if reviewers want it isolated.
