### PR TITLE
perf: small-copy fast path in guest memcpy

### DIFF
--- a/crates/toolchain/openvm/src/memcpy.s
+++ b/crates/toolchain/openvm/src/memcpy.s
@@ -2,6 +2,11 @@
 //
 // src/string/memcpy.c
 //
+// with one OpenVM addition (not in musl): a jump-table fast path
+// for n <= 32 byte copies, injected into the source before
+// compilation. See FASTPATH_MEMCPY in the generator script for
+// the exact code and rationale.
+//
 // This was compiled into assembly with:
 //
 //     clang -target riscv64 -march=rv64im -O3 -S memcpy.c -nostdlib -fno-builtin -funroll-loops
@@ -215,15 +220,123 @@
 	.type	memcpy,@function
 memcpy:                                 # @memcpy
 # %bb.0:
-	andi	a3, a1, 3
-	beqz	a3, .LBBmemcpy0_16
+	li	a3, 33
+	bgeu	a2, a3, .LBBmemcpy0_34
 # %bb.1:
-	beqz	a2, .LBBmemcpy0_5
+	addi	a2, a2, -1
+	li	a3, 31
+	bltu	a3, a2, .LBBmemcpy0_69
 # %bb.2:
+	slli	a2, a2, 2
+	lui	a3, %hi(.LJTImemcpy0_0)
+	addi	a3, a3, %lo(.LJTImemcpy0_0)
+	add	a2, a3, a2
+	lw	a2, 0(a2)
+	mv	a3, a0
+	jr	a2
+.LBBmemcpy0_3:
+	lbu	a2, 31(a1)
+	sb	a2, 31(a0)
+.LBBmemcpy0_4:
+	lbu	a2, 30(a1)
+	sb	a2, 30(a0)
+.LBBmemcpy0_5:
+	lbu	a2, 29(a1)
+	sb	a2, 29(a0)
+.LBBmemcpy0_6:
+	lbu	a2, 28(a1)
+	sb	a2, 28(a0)
+.LBBmemcpy0_7:
+	lbu	a2, 27(a1)
+	sb	a2, 27(a0)
+.LBBmemcpy0_8:
+	lbu	a2, 26(a1)
+	sb	a2, 26(a0)
+.LBBmemcpy0_9:
+	lbu	a2, 25(a1)
+	sb	a2, 25(a0)
+.LBBmemcpy0_10:
+	lbu	a2, 24(a1)
+	sb	a2, 24(a0)
+.LBBmemcpy0_11:
+	lbu	a2, 23(a1)
+	sb	a2, 23(a0)
+.LBBmemcpy0_12:
+	lbu	a2, 22(a1)
+	sb	a2, 22(a0)
+.LBBmemcpy0_13:
+	lbu	a2, 21(a1)
+	sb	a2, 21(a0)
+.LBBmemcpy0_14:
+	lbu	a2, 20(a1)
+	sb	a2, 20(a0)
+.LBBmemcpy0_15:
+	lbu	a2, 19(a1)
+	sb	a2, 19(a0)
+.LBBmemcpy0_16:
+	lbu	a2, 18(a1)
+	sb	a2, 18(a0)
+.LBBmemcpy0_17:
+	lbu	a2, 17(a1)
+	sb	a2, 17(a0)
+.LBBmemcpy0_18:
+	lbu	a2, 16(a1)
+	sb	a2, 16(a0)
+.LBBmemcpy0_19:
+	lbu	a2, 15(a1)
+	sb	a2, 15(a0)
+.LBBmemcpy0_20:
+	lbu	a2, 14(a1)
+	sb	a2, 14(a0)
+.LBBmemcpy0_21:
+	lbu	a2, 13(a1)
+	sb	a2, 13(a0)
+.LBBmemcpy0_22:
+	lbu	a2, 12(a1)
+	sb	a2, 12(a0)
+.LBBmemcpy0_23:
+	lbu	a2, 11(a1)
+	sb	a2, 11(a0)
+.LBBmemcpy0_24:
+	lbu	a2, 10(a1)
+	sb	a2, 10(a0)
+.LBBmemcpy0_25:
+	lbu	a2, 9(a1)
+	sb	a2, 9(a0)
+.LBBmemcpy0_26:
+	lbu	a2, 8(a1)
+	sb	a2, 8(a0)
+.LBBmemcpy0_27:
+	lbu	a2, 7(a1)
+	sb	a2, 7(a0)
+.LBBmemcpy0_28:
+	lbu	a2, 6(a1)
+	sb	a2, 6(a0)
+.LBBmemcpy0_29:
+	lbu	a2, 5(a1)
+	sb	a2, 5(a0)
+.LBBmemcpy0_30:
+	lbu	a2, 4(a1)
+	sb	a2, 4(a0)
+.LBBmemcpy0_31:
+	lbu	a2, 3(a1)
+	sb	a2, 3(a0)
+.LBBmemcpy0_32:
+	lbu	a2, 2(a1)
+	sb	a2, 2(a0)
+.LBBmemcpy0_33:
+	lbu	a2, 1(a1)
+	sb	a2, 1(a0)
+	mv	a3, a0
+	j	.LBBmemcpy0_68
+.LBBmemcpy0_34:
+	andi	a3, a1, 3
+	beqz	a3, .LBBmemcpy0_43
+# %bb.35:
 	addi	a4, a1, 1
 	li	a5, 1
 	mv	a3, a0
-.LBBmemcpy0_3:                                # =>This Inner Loop Header: Depth=1
+.LBBmemcpy0_36:                               # =>This Inner Loop Header: Depth=1
 	lbu	a7, 0(a1)
 	mv	a6, a2
 	addi	a1, a1, 1
@@ -231,37 +344,75 @@ memcpy:                                 # @memcpy
 	sb	a7, 0(a3)
 	addi	a3, a3, 1
 	addi	a2, a2, -1
-	beqz	t0, .LBBmemcpy0_6
-# %bb.4:                                #   in Loop: Header=BB0_3 Depth=1
+	beqz	t0, .LBBmemcpy0_38
+# %bb.37:                               #   in Loop: Header=BB0_36 Depth=1
 	addi	a4, a4, 1
-	bne	a6, a5, .LBBmemcpy0_3
-	j	.LBBmemcpy0_6
-.LBBmemcpy0_5:
-	mv	a3, a0
-.LBBmemcpy0_6:
+	bne	a6, a5, .LBBmemcpy0_36
+.LBBmemcpy0_38:
 	andi	a5, a3, 3
-	beqz	a5, .LBBmemcpy0_17
-.LBBmemcpy0_7:
+	beqz	a5, .LBBmemcpy0_44
+.LBBmemcpy0_39:
 	li	a4, 32
-	bgeu	a2, a4, .LBBmemcpy0_11
-# %bb.8:
+	bgeu	a2, a4, .LBBmemcpy0_51
+# %bb.40:
 	li	a4, 16
-	bgeu	a2, a4, .LBBmemcpy0_30
-.LBBmemcpy0_9:
+	bgeu	a2, a4, .LBBmemcpy0_62
+.LBBmemcpy0_41:
 	andi	a4, a2, 8
-	bnez	a4, .LBBmemcpy0_31
-.LBBmemcpy0_10:
+	bnez	a4, .LBBmemcpy0_63
+.LBBmemcpy0_42:
 	andi	a4, a2, 4
-	bnez	a4, .LBBmemcpy0_32
-	j	.LBBmemcpy0_33
-.LBBmemcpy0_11:
+	bnez	a4, .LBBmemcpy0_64
+	j	.LBBmemcpy0_65
+.LBBmemcpy0_43:
+	mv	a3, a0
+	andi	a5, a0, 3
+	bnez	a5, .LBBmemcpy0_39
+.LBBmemcpy0_44:
+	li	a4, 16
+	bltu	a2, a4, .LBBmemcpy0_47
+# %bb.45:
+	li	a4, 15
+.LBBmemcpy0_46:                               # =>This Inner Loop Header: Depth=1
+	lw	a5, 0(a1)
+	lw	a6, 4(a1)
+	lw	a7, 8(a1)
+	lw	t0, 12(a1)
+	addi	a1, a1, 16
+	addi	a2, a2, -16
+	sw	a5, 0(a3)
+	sw	a6, 4(a3)
+	sw	a7, 8(a3)
+	sw	t0, 12(a3)
+	addi	a3, a3, 16
+	bltu	a4, a2, .LBBmemcpy0_46
+.LBBmemcpy0_47:
+	li	a4, 8
+	bltu	a2, a4, .LBBmemcpy0_49
+# %bb.48:
+	lw	a4, 0(a1)
+	lw	a5, 4(a1)
+	sw	a4, 0(a3)
+	sw	a5, 4(a3)
+	addi	a3, a3, 8
+	addi	a1, a1, 8
+.LBBmemcpy0_49:
+	andi	a4, a2, 4
+	beqz	a4, .LBBmemcpy0_65
+# %bb.50:
+	lw	a4, 0(a1)
+	addi	a1, a1, 4
+	sw	a4, 0(a3)
+	addi	a3, a3, 4
+	j	.LBBmemcpy0_65
+.LBBmemcpy0_51:
 	lw	a4, 0(a1)
 	li	a6, 3
-	beq	a5, a6, .LBBmemcpy0_24
-# %bb.12:
+	beq	a5, a6, .LBBmemcpy0_56
+# %bb.52:
 	li	a6, 2
-	bne	a5, a6, .LBBmemcpy0_27
-# %bb.13:
+	bne	a5, a6, .LBBmemcpy0_59
+# %bb.53:
 	srli	a5, a4, 8
 	addi	a2, a2, -2
 	addi	a1, a1, 16
@@ -269,7 +420,7 @@ memcpy:                                 # @memcpy
 	sb	a5, 1(a3)
 	addi	a3, a3, 2
 	li	a5, 17
-.LBBmemcpy0_14:                               # =>This Inner Loop Header: Depth=1
+.LBBmemcpy0_54:                               # =>This Inner Loop Header: Depth=1
 	srliw	a6, a4, 16
 	lw	a7, -12(a1)
 	lw	t0, -8(a1)
@@ -293,60 +444,19 @@ memcpy:                                 # @memcpy
 	sw	t1, 12(a3)
 	addi	a3, a3, 16
 	addi	a1, a1, 16
-	bltu	a5, a2, .LBBmemcpy0_14
-# %bb.15:
+	bltu	a5, a2, .LBBmemcpy0_54
+# %bb.55:
 	addi	a1, a1, -14
 	li	a4, 16
-	bltu	a2, a4, .LBBmemcpy0_9
-	j	.LBBmemcpy0_30
-.LBBmemcpy0_16:
-	mv	a3, a0
-	andi	a5, a0, 3
-	bnez	a5, .LBBmemcpy0_7
-.LBBmemcpy0_17:
-	li	a4, 16
-	bltu	a2, a4, .LBBmemcpy0_20
-# %bb.18:
-	li	a4, 15
-.LBBmemcpy0_19:                               # =>This Inner Loop Header: Depth=1
-	lw	a5, 0(a1)
-	lw	a6, 4(a1)
-	lw	a7, 8(a1)
-	lw	t0, 12(a1)
-	addi	a1, a1, 16
-	addi	a2, a2, -16
-	sw	a5, 0(a3)
-	sw	a6, 4(a3)
-	sw	a7, 8(a3)
-	sw	t0, 12(a3)
-	addi	a3, a3, 16
-	bltu	a4, a2, .LBBmemcpy0_19
-.LBBmemcpy0_20:
-	li	a4, 8
-	bltu	a2, a4, .LBBmemcpy0_22
-# %bb.21:
-	lw	a4, 0(a1)
-	lw	a5, 4(a1)
-	sw	a4, 0(a3)
-	sw	a5, 4(a3)
-	addi	a3, a3, 8
-	addi	a1, a1, 8
-.LBBmemcpy0_22:
-	andi	a4, a2, 4
-	beqz	a4, .LBBmemcpy0_33
-# %bb.23:
-	lw	a4, 0(a1)
-	addi	a1, a1, 4
-	sw	a4, 0(a3)
-	addi	a3, a3, 4
-	j	.LBBmemcpy0_33
-.LBBmemcpy0_24:
+	bltu	a2, a4, .LBBmemcpy0_41
+	j	.LBBmemcpy0_62
+.LBBmemcpy0_56:
 	sb	a4, 0(a3)
 	addi	a2, a2, -1
 	addi	a3, a3, 1
 	addi	a1, a1, 16
 	li	a5, 18
-.LBBmemcpy0_25:                               # =>This Inner Loop Header: Depth=1
+.LBBmemcpy0_57:                               # =>This Inner Loop Header: Depth=1
 	srliw	a6, a4, 8
 	lw	a7, -12(a1)
 	lw	t0, -8(a1)
@@ -370,13 +480,13 @@ memcpy:                                 # @memcpy
 	sw	t1, 12(a3)
 	addi	a3, a3, 16
 	addi	a1, a1, 16
-	bltu	a5, a2, .LBBmemcpy0_25
-# %bb.26:
+	bltu	a5, a2, .LBBmemcpy0_57
+# %bb.58:
 	addi	a1, a1, -15
 	li	a4, 16
-	bltu	a2, a4, .LBBmemcpy0_9
-	j	.LBBmemcpy0_30
-.LBBmemcpy0_27:
+	bltu	a2, a4, .LBBmemcpy0_41
+	j	.LBBmemcpy0_62
+.LBBmemcpy0_59:
 	srli	a5, a4, 8
 	srli	a6, a4, 16
 	addi	a2, a2, -3
@@ -386,7 +496,7 @@ memcpy:                                 # @memcpy
 	sb	a6, 2(a3)
 	addi	a3, a3, 3
 	li	a5, 16
-.LBBmemcpy0_28:                               # =>This Inner Loop Header: Depth=1
+.LBBmemcpy0_60:                               # =>This Inner Loop Header: Depth=1
 	srliw	a6, a4, 24
 	lw	a7, -12(a1)
 	lw	t0, -8(a1)
@@ -410,12 +520,12 @@ memcpy:                                 # @memcpy
 	sw	t1, 12(a3)
 	addi	a3, a3, 16
 	addi	a1, a1, 16
-	bltu	a5, a2, .LBBmemcpy0_28
-# %bb.29:
+	bltu	a5, a2, .LBBmemcpy0_60
+# %bb.61:
 	addi	a1, a1, -13
 	li	a4, 16
-	bltu	a2, a4, .LBBmemcpy0_9
-.LBBmemcpy0_30:
+	bltu	a2, a4, .LBBmemcpy0_41
+.LBBmemcpy0_62:
 	lbu	a4, 0(a1)
 	lbu	a5, 1(a1)
 	lbu	a6, 2(a1)
@@ -452,8 +562,8 @@ memcpy:                                 # @memcpy
 	sb	t3, 15(a3)
 	mv	a3, a4
 	andi	a4, a2, 8
-	beqz	a4, .LBBmemcpy0_10
-.LBBmemcpy0_31:
+	beqz	a4, .LBBmemcpy0_42
+.LBBmemcpy0_63:
 	lbu	a4, 0(a1)
 	lbu	a5, 1(a1)
 	lbu	a6, 2(a1)
@@ -474,8 +584,8 @@ memcpy:                                 # @memcpy
 	sb	t3, 7(a3)
 	mv	a3, a4
 	andi	a4, a2, 4
-	beqz	a4, .LBBmemcpy0_33
-.LBBmemcpy0_32:
+	beqz	a4, .LBBmemcpy0_65
+.LBBmemcpy0_64:
 	lbu	a4, 0(a1)
 	lbu	a5, 1(a1)
 	lbu	a6, 2(a1)
@@ -487,15 +597,10 @@ memcpy:                                 # @memcpy
 	sb	a6, 2(a3)
 	sb	a7, 3(a3)
 	mv	a3, t0
-.LBBmemcpy0_33:
+.LBBmemcpy0_65:
 	andi	a4, a2, 2
-	bnez	a4, .LBBmemcpy0_36
-# %bb.34:
-	andi	a2, a2, 1
-	bnez	a2, .LBBmemcpy0_37
-.LBBmemcpy0_35:
-	ret
-.LBBmemcpy0_36:
+	beqz	a4, .LBBmemcpy0_67
+# %bb.66:
 	lbu	a4, 0(a1)
 	lbu	a5, 1(a1)
 	addi	a1, a1, 2
@@ -503,14 +608,51 @@ memcpy:                                 # @memcpy
 	sb	a4, 0(a3)
 	sb	a5, 1(a3)
 	mv	a3, a6
+.LBBmemcpy0_67:
 	andi	a2, a2, 1
-	beqz	a2, .LBBmemcpy0_35
-.LBBmemcpy0_37:
+	beqz	a2, .LBBmemcpy0_69
+.LBBmemcpy0_68:
 	lbu	a1, 0(a1)
 	sb	a1, 0(a3)
+.LBBmemcpy0_69:
 	ret
 .Lmemcpyfunc_end0:
 	.size	memcpy, .Lmemcpyfunc_end0-memcpy
+	.section	.rodata,"a",@progbits
+	.p2align	2, 0x0
+.LJTImemcpy0_0:
+	.word	.LBBmemcpy0_68
+	.word	.LBBmemcpy0_33
+	.word	.LBBmemcpy0_32
+	.word	.LBBmemcpy0_31
+	.word	.LBBmemcpy0_30
+	.word	.LBBmemcpy0_29
+	.word	.LBBmemcpy0_28
+	.word	.LBBmemcpy0_27
+	.word	.LBBmemcpy0_26
+	.word	.LBBmemcpy0_25
+	.word	.LBBmemcpy0_24
+	.word	.LBBmemcpy0_23
+	.word	.LBBmemcpy0_22
+	.word	.LBBmemcpy0_21
+	.word	.LBBmemcpy0_20
+	.word	.LBBmemcpy0_19
+	.word	.LBBmemcpy0_18
+	.word	.LBBmemcpy0_17
+	.word	.LBBmemcpy0_16
+	.word	.LBBmemcpy0_15
+	.word	.LBBmemcpy0_14
+	.word	.LBBmemcpy0_13
+	.word	.LBBmemcpy0_12
+	.word	.LBBmemcpy0_11
+	.word	.LBBmemcpy0_10
+	.word	.LBBmemcpy0_9
+	.word	.LBBmemcpy0_8
+	.word	.LBBmemcpy0_7
+	.word	.LBBmemcpy0_6
+	.word	.LBBmemcpy0_5
+	.word	.LBBmemcpy0_4
+	.word	.LBBmemcpy0_3
                                         # -- End function
 	.section	".note.GNU-stack","",@progbits
 	.addrsig

--- a/extensions/riscv/tests/programs/examples/memcpy.rs
+++ b/extensions/riscv/tests/programs/examples/memcpy.rs
@@ -1,0 +1,49 @@
+#![cfg_attr(not(feature = "std"), no_main)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern "C" {
+    fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
+}
+
+openvm::entry!(main);
+
+// Covers the fast small-copy switch (n <= 32), the aligned word path, the
+// shifted-word path for every src/dst alignment mismatch mod 8, and
+// head/tail handling around the 32-byte and word boundaries.
+const LENGTHS: [usize; 18] = [
+    0, 1, 2, 3, 4, 5, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 100, 255,
+];
+
+const CANARY: u8 = 0xCC;
+
+fn main() {
+    let mut src = [0u8; 272];
+    let mut dst = [0u8; 272];
+    let mut i = 0;
+    while i < src.len() {
+        src[i] = (i as u8).wrapping_mul(31).wrapping_add(7);
+        i += 1;
+    }
+
+    for src_off in 0..8 {
+        for dst_off in 0..8 {
+            for &n in LENGTHS.iter() {
+                for b in dst.iter_mut() {
+                    *b = CANARY;
+                }
+                let ret =
+                    unsafe { memcpy(dst.as_mut_ptr().add(dst_off), src.as_ptr().add(src_off), n) };
+                assert_eq!(ret as usize, dst.as_ptr() as usize + dst_off);
+                for &b in dst.iter().take(dst_off) {
+                    assert_eq!(b, CANARY);
+                }
+                for i in 0..n {
+                    assert_eq!(dst[dst_off + i], src[src_off + i]);
+                }
+                for &b in dst.iter().skip(dst_off + n) {
+                    assert_eq!(b, CANARY);
+                }
+            }
+        }
+    }
+}

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -150,6 +150,7 @@ mod tests {
 
     #[test_case("fibonacci", 1)]
     #[test_case("collatz", 1)]
+    #[test_case("memcpy", 1)]
     fn test_rv64im(example_name: &str, min_segments: usize) -> Result<()> {
         let config = test_rv64im_config();
         let elf = build_example_program_at_path(get_programs_dir!(), example_name, &config)?;

--- a/scripts/generate_libc_intrinsics.sh
+++ b/scripts/generate_libc_intrinsics.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Generates `crates/toolchain/openvm/src/memcpy.s` and `memset.s` from
-# musl-libc sources, deterministically.
+# musl-libc sources, deterministically. memcpy additionally gets an OpenVM
+# small-copy fast path (see FASTPATH_MEMCPY below) injected before compilation.
 #
 # Usage:
 #   scripts/generate_libc_intrinsics.sh                                  # use defaults (v1.2.6)
@@ -124,6 +125,61 @@ typedef unsigned long long uint64_t;
 EOF
 )
 
+# OpenVM addition to musl's memcpy (injected into the fetched source before
+# compilation, right after the `d`/`s` pointer declarations). Small copies
+# dominate memcpy call counts in zkVM guests, and musl's alignment dispatch
+# and head loops cost 20-90 instructions before the first byte moves. For
+# n <= 32 this switch compiles to a jump table into straight-line
+# constant-offset byte copies with no preamble. Cases fall through in
+# descending order: entering at case n copies bytes n-1..0.
+FASTPATH_MEMCPY=$(cat <<'EOF'
+	/* OpenVM addition (not in musl): small copies dominate call counts in
+	 * zkVM guests, and the paths below spend 20-90 instructions on alignment
+	 * dispatch and head loops before copying anything. For n <= 32 this
+	 * switch compiles to a jump table into straight-line constant-offset
+	 * byte copies (~2.4 instructions/byte, no preamble). Cases fall through
+	 * in descending order: entering at case n copies bytes n-1..0. */
+	if (n <= 32) {
+		switch (n) {
+	case 32: d[31] = s[31]; /* fallthrough */
+	case 31: d[30] = s[30]; /* fallthrough */
+	case 30: d[29] = s[29]; /* fallthrough */
+	case 29: d[28] = s[28]; /* fallthrough */
+	case 28: d[27] = s[27]; /* fallthrough */
+	case 27: d[26] = s[26]; /* fallthrough */
+	case 26: d[25] = s[25]; /* fallthrough */
+	case 25: d[24] = s[24]; /* fallthrough */
+	case 24: d[23] = s[23]; /* fallthrough */
+	case 23: d[22] = s[22]; /* fallthrough */
+	case 22: d[21] = s[21]; /* fallthrough */
+	case 21: d[20] = s[20]; /* fallthrough */
+	case 20: d[19] = s[19]; /* fallthrough */
+	case 19: d[18] = s[18]; /* fallthrough */
+	case 18: d[17] = s[17]; /* fallthrough */
+	case 17: d[16] = s[16]; /* fallthrough */
+	case 16: d[15] = s[15]; /* fallthrough */
+	case 15: d[14] = s[14]; /* fallthrough */
+	case 14: d[13] = s[13]; /* fallthrough */
+	case 13: d[12] = s[12]; /* fallthrough */
+	case 12: d[11] = s[11]; /* fallthrough */
+	case 11: d[10] = s[10]; /* fallthrough */
+	case 10: d[9] = s[9]; /* fallthrough */
+	case 9: d[8] = s[8]; /* fallthrough */
+	case 8: d[7] = s[7]; /* fallthrough */
+	case 7: d[6] = s[6]; /* fallthrough */
+	case 6: d[5] = s[5]; /* fallthrough */
+	case 5: d[4] = s[4]; /* fallthrough */
+	case 4: d[3] = s[3]; /* fallthrough */
+	case 3: d[2] = s[2]; /* fallthrough */
+	case 2: d[1] = s[1]; /* fallthrough */
+	case 1: d[0] = s[0]; /* fallthrough */
+	case 0:;
+		}
+		return dest;
+	}
+EOF
+)
+
 regen_one() {
   local fn="$1"        # memcpy | memset
   local typedefs="$2"  # block of typedef lines
@@ -141,6 +197,23 @@ regen_one() {
     printf '%s\n\n' "${typedefs}"
     curl -fsSL "${src_url}" | sed '/^#include /d'
   } > "${c}"
+
+  if [[ "${fn}" == memcpy ]]; then
+    echo "gen: injecting OpenVM small-copy fast path into memcpy.c"
+    local fp_anchor='	const unsigned char *s = src;'
+    local fp_count
+    fp_count="$(grep -cxF "${fp_anchor}" "${c}")" || true
+    if [[ "${fp_count}" != 1 ]]; then
+      echo "error: fast-path anchor found ${fp_count} times in memcpy.c (expected 1) — musl source changed; update FASTPATH_MEMCPY injection" >&2
+      exit 1
+    fi
+    printf '%s\n' "${FASTPATH_MEMCPY}" > "${TMP}/fastpath_memcpy.c"
+    awk -v anchor="${fp_anchor}" -v blockfile="${TMP}/fastpath_memcpy.c" '
+      { print }
+      $0 == anchor { print ""; while ((getline line < blockfile) > 0) print line }
+    ' "${c}" > "${c}.new"
+    mv "${c}.new" "${c}"
+  fi
 
   echo "gen: compiling ${fn}.c -> ${fn}.s (riscv64im, O3, -funroll-loops)"
   "${CLANG}" -target riscv64 -march=rv64im -O3 -S \
@@ -175,6 +248,13 @@ regen_one() {
     printf '//\n'
     printf '// src/string/%s.c\n' "${fn}"
     printf '//\n'
+    if [[ "${fn}" == memcpy ]]; then
+      printf '// with one OpenVM addition (not in musl): a jump-table fast path\n'
+      printf '// for n <= 32 byte copies, injected into the source before\n'
+      printf '// compilation. See FASTPATH_MEMCPY in the generator script for\n'
+      printf '// the exact code and rationale.\n'
+      printf '//\n'
+    fi
     printf '// This was compiled into assembly with:\n'
     printf '//\n'
     printf '//     clang -target riscv64 -march=rv64im -O3 -S %s.c -nostdlib -fno-builtin -funroll-loops\n' "${fn}"


### PR DESCRIPTION
## Motivation

Small copies dominate memcpy call counts in real guests (RLP fragments, hash outputs, field elements), and musl's alignment dispatch and head loops cost 20–90 instructions before the first byte moves. For n ≤ 32 a jump table into straight-line constant-offset byte copies has no preamble at all.

## Change

One commit, four files:

- `scripts/generate_libc_intrinsics.sh` — defines the fast-path C block (`FASTPATH_MEMCPY`, a descending fallthrough switch: entering at `case n` copies bytes n−1..0) and injects it into the fetched musl source right after the `d`/`s` pointer declarations, before compilation. The injection hard-fails if the anchor line isn't found exactly once, so a future musl change can't silently drop the fast path.
- `crates/toolchain/openvm/src/memcpy.s` — regenerated by the script. The header notes the addition.
- `extensions/riscv/tests/programs/examples/memcpy.rs` + registration — integration test exercising all 64 src/dst alignment combos mod 8 × 18 lengths with canary checks.

## How to review

The `.s` diff is machine output; don't read it — reproduce it:

```
scripts/generate_libc_intrinsics.sh && git diff --exit-code crates/toolchain/openvm/src/
```

(byte-identical output verified with Homebrew clang 22.1.0; the script strips `.ident`/`.file` so bytes depend only on LLVM codegen). The human-reviewable surface is the ~45-line C block and the injection step in the script.

## Correctness

- Differential fuzz of the old vs new checked-in `.s` on an rv64im text-assembly interpreter: 1780 cases (all 64 alignment combos × 20 lengths + 500 random), byte-exact copies, return value, canaries intact, no out-of-bounds writes, reads within ±8 of the source buffer.
- The new integration test proves the artifact inside the actual VM.
- `n > 32` takes the identical musl path as before (one extra dispatch branch).

## Instructions per call (rv64im emulator, avg over all 64 alignment combos)

| n | before | after |
|---|---|---|
| 0–3 | 30.1 | 15.2 |
| 4–8 | 44.9 | 27.0 |
| 9–16 | 63.3 | 45.5 |
| 17–32 | 83.8 | 67.9 |
| bulk (>32) | — | +0.1–0.3% |

Mutually-8-aligned small copies regress (e.g. n=32 both aligned: 41 → 79) because musl's word path was already cheap there; averaged over real alignment distributions the fast path wins by a wide margin, and mismatched/small copies dominate real call sites.

## End-to-end (reth block 24001988, prove-stark, GPU)

Compared base = develop-v2.1.0 tip vs this branch (one commit on top), via the reth compare-bench workflow:

| metric | base | this PR | delta |
|---|---|---|---|
| executed instructions | 887,243,325 | 886,658,744 | −0.07% |
| total cells (padded) | 72.30B | 72.32B | +0.03% |
| segments | 84 | 84 | 0 |
| total proof time | 84.31s | 84.27s | −0.05% |

The instruction delta is exact and deterministic; cells, segments, and proof time are all within run-to-run noise (no regression). The win is smaller here than the sub-1% seen on more RLP-heavy blocks: small copies are a smaller slice of this block, and the single `n <= 32` dispatch branch added to the bulk (`n > 32`) path offsets part of the gain when large copies dominate. This is a low-risk correctness-preserving change whose benefit scales with how small-copy-heavy the workload is, not a headline speedup.

## History

A previous revision targeted `main` (rv32): a reproducible regen of memcpy.s plus the same fast path, measured end-to-end at −0.65% executed instructions on an RLP-heavier block. After retargeting to `develop-v2.1.0`, the regen half was dropped as superseded by #2780's generator script, and the fast path was re-ported, re-fuzzed, and re-measured for rv64 on top of that script (table above).
