### PR TITLE
ci(v2.1): tune SDK proof coverage and runner capacity

### DIFF
--- a/.github/actions/rust-cache-cuda/action.yml
+++ b/.github/actions/rust-cache-cuda/action.yml
@@ -18,15 +18,18 @@ runs:
       id: gpu-arch
       shell: bash
       run: |
+        CUDA_ARCH=no-gpu
         if command -v nvidia-smi &> /dev/null; then
           # Get compute capability (e.g., "8.9" -> "89")
-          CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.' || echo "unknown")
-          echo "cuda_arch=$CUDA_ARCH" >> $GITHUB_OUTPUT
+          detected_arch=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.' || true)
+          if [[ "$detected_arch" =~ ^[0-9]+$ ]]; then
+            CUDA_ARCH="$detected_arch"
+          fi
           echo "Detected CUDA architecture: $CUDA_ARCH"
         else
-          echo "cuda_arch=no-gpu" >> $GITHUB_OUTPUT
           echo "No GPU detected"
         fi
+        echo "cuda_arch=$CUDA_ARCH" >> "$GITHUB_OUTPUT"
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -9,7 +9,9 @@ images:
 runners:
   # runners for running tests
   test-gpu-nvidia:
-    family: ["g7e.2xlarge", "g7.2xlarge", "g6e.2xlarge"]
+    family: ["g7e.*", "g7.*", "g6e.*"]
+    cpu: [8, 16]
+    ram: [64]
     image: ubuntu24-gpu-x64
     spot: capacity-optimized
     extras: s3-cache

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -9,12 +9,11 @@ images:
 runners:
   # runners for running tests
   test-gpu-nvidia:
-    family: ["g6.*", "g5", "g4dn", "g6e"]
+    family: ["g7e.2xlarge", "g7.2xlarge", "g6e.2xlarge"]
     image: ubuntu24-gpu-x64
-    cpu: [4, 8, 16, 32]
     spot: capacity-optimized
     extras: s3-cache
     preinstall: |
       nvidia-smi
       nvidia-smi -L
-      echo 'CUDA_ARCH=75,86,89' >> $GITHUB_ENV
+      echo 'CUDA_ARCH=86,89,120' >> $GITHUB_ENV

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -9,13 +9,9 @@ images:
 runners:
   # runners for running tests
   test-gpu-nvidia:
-    family: ["g7e.*", "g7.*", "g6e.*"]
-    cpu: [8, 16]
-    ram: [64]
+    family: ["g7.4xlarge", "g6.4xlarge"]
     image: ubuntu24-gpu-x64
     spot: capacity-optimized
     extras: s3-cache
     preinstall: |
-      nvidia-smi
-      nvidia-smi -L
       echo 'CUDA_ARCH=86,89,120' >> $GITHUB_ENV

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -9,9 +9,9 @@ images:
 runners:
   # runners for running tests
   test-gpu-nvidia:
-    family: ["g7.4xlarge", "g6.4xlarge"]
+    family: ["g7.4xlarge", "g6.4xlarge", "g5.4xlarge"]
     image: ubuntu24-gpu-x64
-    spot: capacity-optimized
+    spot: price-capacity-optimized
     extras: s3-cache
     preinstall: |
       echo 'CUDA_ARCH=86,89,120' >> $GITHUB_ENV

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   tests-cuda:
     runs-on:
-      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache # ensure 24G vram for async test
+      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache # ensure 24G vram for async test
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   tests-cuda:
     runs-on:
-      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g6.*+g5/cpu=4+32/volume=40gb/spot=capacity-optimized/extras=s3-cache # ensure 24G vram for async test
+      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache # ensure 24G vram for async test
 
     steps:
       - uses: runs-on/action@v2
@@ -40,6 +40,11 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   tests-cuda:
     runs-on:
-      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache # ensure 24G vram for async test
+      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache # ensure 24G vram for async test
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/base-tests.cuda.yml
+++ b/.github/workflows/base-tests.cuda.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   tests-cuda:
     runs-on:
-      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache # ensure 24G vram for async test
+      - runs-on=${{ github.run_id }}-base-tests-cuda-${{ github.run_attempt }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache # ensure 24G vram for async test
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -11,7 +11,7 @@ on:
         type: string
         required: false
         description: The AWS instance type or family (e.g., m8g.16xlarge)
-        default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
+        default: g7e.2xlarge+g7.4xlarge+g6e.2xlarge
       memory_allocator:
         type: string
         required: false
@@ -44,7 +44,7 @@ on:
         type: string
         required: false
         description: The AWS instance type or family (e.g., m8g.16xlarge)
-        default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
+        default: g7e.2xlarge+g7.4xlarge+g6e.2xlarge
       memory_allocator:
         type: string
         required: false

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -10,7 +10,7 @@ on:
       instance_type:
         type: string
         required: false
-        description: The AWS instance type or family (e.g., m7g.16xlarge)
+        description: The AWS instance type or family (e.g., m8g.16xlarge)
         default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
       memory_allocator:
         type: string
@@ -43,7 +43,7 @@ on:
       instance_type:
         type: string
         required: false
-        description: The AWS instance type or family (e.g., m7g.16xlarge)
+        description: The AWS instance type or family (e.g., m8g.16xlarge)
         default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
       memory_allocator:
         type: string

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -11,7 +11,7 @@ on:
         type: string
         required: false
         description: The AWS instance type or family (e.g., m7g.16xlarge)
-        default: g6.2xlarge
+        default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
       memory_allocator:
         type: string
         required: false
@@ -44,7 +44,7 @@ on:
         type: string
         required: false
         description: The AWS instance type or family (e.g., m7g.16xlarge)
-        default: g6.2xlarge
+        default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
       memory_allocator:
         type: string
         required: false
@@ -110,6 +110,12 @@ jobs:
           rm -rf ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu || true
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        if: ${{ startsWith(inputs.instance_type || github.event.inputs.instance_type, 'g') }}
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
@@ -121,6 +127,7 @@ jobs:
 
       - name: Display workflow inputs
         run: echo "${{ toJSON(inputs) }}"
+
       - name: "Feature flags: memory allocator + e2e"
         run: |
           ALLOCATOR=${{ inputs.memory_allocator || github.event.inputs.memory_allocator }}

--- a/.github/workflows/benchmark-call.yml
+++ b/.github/workflows/benchmark-call.yml
@@ -11,7 +11,7 @@ on:
         type: string
         required: false
         description: The AWS instance type or family (e.g., m8g.16xlarge)
-        default: g7e.2xlarge+g7.4xlarge+g6e.2xlarge
+        default: g7.4xlarge
       memory_allocator:
         type: string
         required: false
@@ -44,7 +44,7 @@ on:
         type: string
         required: false
         description: The AWS instance type or family (e.g., m8g.16xlarge)
-        default: g7e.2xlarge+g7.4xlarge+g6e.2xlarge
+        default: g7.4xlarge
       memory_allocator:
         type: string
         required: false

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,7 @@ permissions:
 jobs:
   create-matrix:
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64
+      - runs-on=${{ github.run_id }}/family=c8i-flex.2xlarge+c8i.2xlarge+c8a.2xlarge+c7i.2xlarge+c7a.2xlarge/image=ubuntu24-full-x64
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:
@@ -141,7 +141,7 @@ jobs:
   summarize:
     needs: [create-matrix, benchmark]
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=c8i-flex.2xlarge+c8i.2xlarge+c8a.2xlarge+c7i.2xlarge+c7a.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,7 @@ permissions:
 jobs:
   create-matrix:
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:
@@ -141,9 +141,7 @@ jobs:
   summarize:
     needs: [create-matrix, benchmark]
     runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=8cpu-linux-x64
-      - extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -192,8 +190,10 @@ jobs:
 
       - name: Set github pages path for dispatch
         if: github.event_name == 'workflow_dispatch'
+        env:
+          BENCHMARK_REF: ${{ github.head_ref || github.ref }}
         run: |
-          BENCHMARK_RESULTS_PATH="benchmarks-dispatch/${{ github.head_ref || github.ref }}"
+          BENCHMARK_RESULTS_PATH="benchmarks-dispatch/${BENCHMARK_REF}"
           echo "BENCHMARK_RESULTS_PATH=${BENCHMARK_RESULTS_PATH}" >> $GITHUB_ENV
 
       - name: Set github pages path for PR

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,7 @@ permissions:
 jobs:
   create-matrix:
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
     steps:
@@ -141,7 +141,7 @@ jobs:
   summarize:
     needs: [create-matrix, benchmark]
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     name: Build
     runs-on:
-      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - name: Load SSH key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     name: Build
     runs-on:
-      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/volume=80gb/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - name: Load SSH key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     name: Build
     runs-on:
-      - runs-on=${{ github.run_id }}/volume=80gb/runner=64cpu-linux-x64/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - name: Load SSH key

--- a/.github/workflows/cli.cuda.yml
+++ b/.github/workflows/cli.cuda.yml
@@ -25,8 +25,8 @@ on:
       instance_family:
         type: string
         required: false
-        description: Runner instance family, or multiple families joined with "+" (e.g. g7e.2xlarge+g7.4xlarge+g6e.2xlarge)
-        default: g7e.2xlarge+g7.4xlarge+g6e.2xlarge
+        description: Runner instance family, or multiple families joined with "+" (e.g. g7.4xlarge+g6e.2xlarge)
+        default: g7.4xlarge+g6e.2xlarge
   push:
     branches: ["main"]
   pull_request:
@@ -48,7 +48,7 @@ jobs:
   cli-cuda-tests:
     name: cli cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=${{ inputs.instance_family || github.event.inputs.instance_family || 'g7e.2xlarge+g7.4xlarge+g6e.2xlarge' }}/volume=80gb/tag=cli-cuda-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/extras=s3-cache/spot=false
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=${{ inputs.instance_family || github.event.inputs.instance_family || 'g7.4xlarge+g6e.2xlarge' }}/volume=80gb/tag=cli-cuda-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/extras=s3-cache/spot=false
 
     steps:
       - uses: runs-on/action@v2
@@ -166,7 +166,7 @@ jobs:
   verify-stark-examples:
     name: verify-stark examples
     runs-on:
-      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/cli.cuda.yml
+++ b/.github/workflows/cli.cuda.yml
@@ -166,7 +166,7 @@ jobs:
   verify-stark-examples:
     name: verify-stark examples
     runs-on:
-      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=80gb/spot=price-capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/cli.cuda.yml
+++ b/.github/workflows/cli.cuda.yml
@@ -25,8 +25,8 @@ on:
       instance_family:
         type: string
         required: false
-        description: Runner instance family, or multiple families joined with "+" (e.g. g6+g5)
-        default: g6e.2xlarge
+        description: Runner instance family, or multiple families joined with "+" (e.g. g7e.2xlarge+g7.2xlarge+g6e.2xlarge)
+        default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
   push:
     branches: ["main"]
   pull_request:
@@ -48,7 +48,7 @@ jobs:
   cli-cuda-tests:
     name: cli cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=${{ inputs.instance_family || github.event.inputs.instance_family || 'g6e.2xlarge' }}/volume=80gb/tag=cli-cuda-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/extras=s3-cache/spot=false
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=${{ inputs.instance_family || github.event.inputs.instance_family || 'g7e.2xlarge+g7.2xlarge+g6e.2xlarge' }}/volume=80gb/tag=cli-cuda-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/extras=s3-cache/spot=false
 
     steps:
       - uses: runs-on/action@v2
@@ -59,6 +59,11 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
 
@@ -161,7 +166,7 @@ jobs:
   verify-stark-examples:
     name: verify-stark examples
     runs-on:
-      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -177,6 +182,11 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/cli.cuda.yml
+++ b/.github/workflows/cli.cuda.yml
@@ -25,8 +25,8 @@ on:
       instance_family:
         type: string
         required: false
-        description: Runner instance family, or multiple families joined with "+" (e.g. g7e.2xlarge+g7.2xlarge+g6e.2xlarge)
-        default: g7e.2xlarge+g7.2xlarge+g6e.2xlarge
+        description: Runner instance family, or multiple families joined with "+" (e.g. g7e.2xlarge+g7.4xlarge+g6e.2xlarge)
+        default: g7e.2xlarge+g7.4xlarge+g6e.2xlarge
   push:
     branches: ["main"]
   pull_request:
@@ -48,7 +48,7 @@ jobs:
   cli-cuda-tests:
     name: cli cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=${{ inputs.instance_family || github.event.inputs.instance_family || 'g7e.2xlarge+g7.2xlarge+g6e.2xlarge' }}/volume=80gb/tag=cli-cuda-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/extras=s3-cache/spot=false
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=${{ inputs.instance_family || github.event.inputs.instance_family || 'g7e.2xlarge+g7.4xlarge+g6e.2xlarge' }}/volume=80gb/tag=cli-cuda-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/extras=s3-cache/spot=false
 
     steps:
       - uses: runs-on/action@v2
@@ -166,7 +166,7 @@ jobs:
   verify-stark-examples:
     name: verify-stark examples
     runs-on:
-      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-verify-stark-examples/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=80gb/spot=capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   cli-tests:
     runs-on:
-      - runs-on=${{ github.run_id }}/volume=80gb/runner=64cpu-linux-x64/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -142,7 +142,7 @@ jobs:
   app-level-cli-none-elf:
     name: app-level-cli (riscv64im-unknown-none-elf)
     runs-on:
-      - runs-on=${{ github.run_id }}/disk=large/runner=8cpu-linux-x64/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/disk=large/family=m8i-flex.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
     env:
       OPENVM_RUST_TOOLCHAIN: nightly-2026-01-18
       OPENVM_RUSTC_TARGET: riscv64im-unknown-none-elf

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   cli-tests:
     runs-on:
-      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/volume=80gb/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -142,7 +142,7 @@ jobs:
   app-level-cli-none-elf:
     name: app-level-cli (riscv64im-unknown-none-elf)
     runs-on:
-      - runs-on=${{ github.run_id }}/disk=large/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/disk=large/family=c8i-flex.2xlarge+c8i.2xlarge+c8a.2xlarge+c7i.2xlarge+c7a.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
     env:
       OPENVM_RUST_TOOLCHAIN: nightly-2026-01-18
       OPENVM_RUSTC_TARGET: riscv64im-unknown-none-elf

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   cli-tests:
     runs-on:
-      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/volume=80gb/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -142,7 +142,7 @@ jobs:
   app-level-cli-none-elf:
     name: app-level-cli (riscv64im-unknown-none-elf)
     runs-on:
-      - runs-on=${{ github.run_id }}/disk=large/family=m8i-flex.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/disk=large/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64/extras=s3-cache
     env:
       OPENVM_RUST_TOOLCHAIN: nightly-2026-01-18
       OPENVM_RUSTC_TARGET: riscv64im-unknown-none-elf

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -21,7 +21,7 @@ jobs:
   cuda-backend:
     name: continuations cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -21,7 +21,7 @@ jobs:
   cuda-backend:
     name: continuations cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -36,8 +36,14 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
+
       - name: Verify GPU setup
         run: |
           nvidia-smi

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -21,7 +21,7 @@ jobs:
   cuda-backend:
     name: continuations cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/continuations.cuda.yml
+++ b/.github/workflows/continuations.cuda.yml
@@ -21,7 +21,7 @@ jobs:
   cuda-backend:
     name: continuations cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/continuations.yml
+++ b/.github/workflows/continuations.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Recursion tests
     runs-on:
-      - runs-on=${{ github.run_id }}/family=c9g.4xlarge/image=ubuntu24-full-arm64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=c9g.4xlarge+c8g.4xlarge/image=ubuntu24-full-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/continuations.yml
+++ b/.github/workflows/continuations.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Recursion tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=c9g.4xlarge/image=ubuntu24-full-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=32/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -45,6 +45,9 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       - uses: ./.github/actions/sccache
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
       - name: Verify GPU setup
         run: |
           nvidia-smi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       machine_type:
-        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized)"
+        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized)"
         required: false
-        default: image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized
+        default: image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized
 
 concurrency:
   group: ${{ github.workflow_ref }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
@@ -36,7 +36,7 @@ jobs:
           - "riscv"
           - "keccak256 sha2 bigint algebra ecc pairing deferral"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized' }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized' }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       machine_type:
-        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g6.*+g6e/cpu=8+32/volume=40gb/spot=capacity-optimized)"
+        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized)"
         required: false
-        default: image=ubuntu24-gpu-x64/family=g6+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized
+        default: image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized
 
 concurrency:
   group: ${{ github.workflow_ref }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
@@ -36,7 +36,7 @@ jobs:
           - "riscv"
           - "keccak256 sha2 bigint algebra ecc pairing deferral"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g6.*+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized' }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized' }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -101,6 +101,11 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       machine_type:
-        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized)"
+        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized)"
         required: false
-        default: image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized
+        default: image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized
 
 concurrency:
   group: ${{ github.workflow_ref }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
@@ -36,7 +36,7 @@ jobs:
           - "riscv"
           - "keccak256 sha2 bigint algebra ecc pairing deferral"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized' }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized' }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       machine_type:
-        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized)"
+        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized)"
         required: false
-        default: image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized
+        default: image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized
 
 concurrency:
   group: ${{ github.workflow_ref }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
@@ -36,7 +36,7 @@ jobs:
           - "riscv"
           - "keccak256 sha2 bigint algebra ecc pairing deferral"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized' }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized' }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/extension-tests.cuda.yml
+++ b/.github/workflows/extension-tests.cuda.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       machine_type:
-        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized)"
+        description: "Runner label fragment (e.g. image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized)"
         required: false
-        default: image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized
+        default: image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized
 
 concurrency:
   group: ${{ github.workflow_ref }}-extension-tests-cuda-${{ github.event.pull_request.number || github.sha }}
@@ -36,7 +36,7 @@ jobs:
           - "riscv"
           - "keccak256 sha2 bigint algebra ecc pairing deferral"
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized' }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.machine_type || 'image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized' }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -54,12 +54,12 @@ jobs:
           - { name: "pairing", path: "pairing", aot: false, rvr: true }
           - { name: "deferral", path: "deferral", aot: false, rvr: true }
         platform:
-          - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
       fail-fast: false
 
     runs-on:
-      - runs-on=${{ github.run_id }}-extension-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-extension-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/volume=80gb/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -54,7 +54,7 @@ jobs:
           - { name: "pairing", path: "pairing", aot: false, rvr: true }
           - { name: "deferral", path: "deferral", aot: false, rvr: true }
         platform:
-          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
       fail-fast: false
 

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -54,7 +54,7 @@ jobs:
           - { name: "pairing", path: "pairing", aot: false, rvr: true }
           - { name: "deferral", path: "deferral", aot: false, rvr: true }
         platform:
-          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
       fail-fast: false
 

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -34,7 +34,7 @@ jobs:
           - { names: "k256 p256" }
           - { names: "ff_derive pairing" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -34,7 +34,7 @@ jobs:
           - { names: "k256 p256" }
           - { names: "ff_derive pairing" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -34,7 +34,7 @@ jobs:
           - { names: "k256 p256" }
           - { names: "ff_derive pairing" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/cpu=8+32/family=g6.*+g5+g6e/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -104,7 +104,7 @@ jobs:
 
           # Skip if neither common nor any crate in this matrix group changed
           if [[ "$COMMON_CHANGED" != "true" && "$ANY_CRATE_CHANGED" != "true" ]]; then
-            echo "No relevant changes for crates [${{ matrix.crates }}], skipping tests."
+            echo "No relevant changes for crates [${{ matrix.crates.names }}], skipping tests."
             exit 0
           fi
 
@@ -112,6 +112,11 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -34,7 +34,7 @@ jobs:
           - { names: "k256 p256" }
           - { names: "ff_derive pairing" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.cuda.yml
+++ b/.github/workflows/guest-lib-tests.cuda.yml
@@ -34,7 +34,7 @@ jobs:
           - { names: "k256 p256" }
           - { names: "ff_derive pairing" }
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-cuda-${{ github.run_attempt }}-${{ strategy.job-index }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6.4xlarge+g5.4xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -43,7 +43,7 @@ jobs:
           - { name: "p256", path: "p256", rvr: true }
           - { name: "pairing", path: "pairing", rvr: true }
         platform:
-          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
       fail-fast: false
 

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -43,7 +43,7 @@ jobs:
           - { name: "p256", path: "p256", rvr: true }
           - { name: "pairing", path: "pairing", rvr: true }
         platform:
-          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
       fail-fast: false
 

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -43,12 +43,12 @@ jobs:
           - { name: "p256", path: "p256", rvr: true }
           - { name: "pairing", path: "pairing", rvr: true }
         platform:
-          - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
       # Ensure tests run in parallel even if one fails
       fail-fast: false
 
     runs-on:
-      - runs-on=${{ github.run_id }}-guest-lib-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-guest-lib-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -157,7 +157,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.cuda == 'true' }}
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=8/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -176,6 +176,9 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -157,7 +157,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.cuda == 'true' }}
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -37,7 +37,7 @@ jobs:
   lint:
     name: Lint
     runs-on:
-      - runs-on=${{ github.run_id }}-cpu/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cpu/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -119,7 +119,7 @@ jobs:
   docs:
     name: Check Docs
     runs-on:
-      - runs-on=${{ github.run_id }}-docs/family=m8i-flex.8xlarge+m8i.8xlarge+m8a.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}-docs/family=c8i-flex.8xlarge+c8i.8xlarge+c8a.8xlarge+c7i.8xlarge+c7a.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -37,7 +37,7 @@ jobs:
   lint:
     name: Lint
     runs-on:
-      - runs-on=${{ github.run_id }}-cpu/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cpu/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -119,7 +119,7 @@ jobs:
   docs:
     name: Check Docs
     runs-on:
-      - runs-on=${{ github.run_id }}-docs/family=m8i-flex.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}-docs/family=m8i-flex.8xlarge+m8i.8xlarge+m8a.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -37,7 +37,7 @@ jobs:
   lint:
     name: Lint
     runs-on:
-      - runs-on=${{ github.run_id }}-cpu/runner=64cpu-linux-x64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cpu/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -119,7 +119,7 @@ jobs:
   docs:
     name: Check Docs
     runs-on:
-      - runs-on=${{ github.run_id }}-docs/runner=32cpu-linux-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}-docs/family=m8i-flex.8xlarge/image=ubuntu24-full-x64/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -157,7 +157,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.cuda == 'true' }}
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -157,7 +157,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.cuda == 'true' }}
     runs-on:
-      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cuda/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/openvm-tags.yml
+++ b/.github/workflows/openvm-tags.yml
@@ -24,7 +24,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64
     steps:
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/openvm-tags.yml
+++ b/.github/workflows/openvm-tags.yml
@@ -24,7 +24,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64
+      - runs-on=${{ github.run_id }}/family=c8i-flex.2xlarge+c8i.2xlarge+c8a.2xlarge+c7i.2xlarge+c7a.2xlarge/image=ubuntu24-full-x64
     steps:
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/openvm-tags.yml
+++ b/.github/workflows/openvm-tags.yml
@@ -24,7 +24,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow_ref }}-docs-${{ github.ref }}
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64
     steps:
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,7 @@ jobs:
   conventional-title:
     name: Validate PR title is Conventional Commit
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=8cpu-linux-x64
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,7 @@ jobs:
   conventional-title:
     name: Validate PR title is Conventional Commit
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64
+      - runs-on=${{ github.run_id }}/family=c8i-flex.2xlarge+c8i.2xlarge+c8a.2xlarge+c7i.2xlarge+c7a.2xlarge/image=ubuntu24-full-x64
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,7 @@ jobs:
   conventional-title:
     name: Validate PR title is Conventional Commit
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge/image=ubuntu24-full-x64
+      - runs-on=${{ github.run_id }}/family=m8i-flex.2xlarge+m8i.2xlarge+m8a.2xlarge/image=ubuntu24-full-x64
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
 
     runs-on:
-      - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -52,12 +52,12 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Set CPU tests environment variables
-        if: ${{ !contains(matrix.platform.runner, 'gpu') }}
+        if: ${{ !contains(matrix.platform.image, 'gpu') }}
         run: |
           echo "NEXTEST_ARGS=--cargo-profile fast --features parallel" >> $GITHUB_ENV
 
       - name: Check CUDA status and set environment variables
-        if: contains(matrix.platform.runner, 'gpu')
+        if: contains(matrix.platform.image, 'gpu')
         run: |
           nvcc --version
           echo "NEXTEST_ARGS=cuda --features parallel,cuda,touchemall" >> $GITHUB_ENV
@@ -74,13 +74,13 @@ jobs:
 
       # sha2-air has no tests; skipping to avoid upstream openvm-cpu-backend parallel compilation issue
       # - name: Run tests for sha2-air
-      #   if: ${{ !contains(matrix.platform.runner, 'gpu') }}
+      #   if: ${{ !contains(matrix.platform.image, 'gpu') }}
       #   working-directory: crates/circuits/sha2-air
       #   run: |
       #     cargo nextest run ${{ env.NEXTEST_ARGS }}
 
       - name: Run tests for mod-builder
-        if: ${{ !contains(matrix.platform.runner, 'gpu') }}
+        if: ${{ !contains(matrix.platform.image, 'gpu') }}
         working-directory: crates/circuits/mod-builder
         run: |
           cargo nextest run ${{ env.NEXTEST_ARGS }}

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
 
     runs-on:
       - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/extras=s3-cache

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge", image: "ubuntu24-full-x64" }
 
     runs-on:
       - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/extras=s3-cache

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -20,7 +20,7 @@ jobs:
   cuda-backend:
     name: recursion cuda tracegen tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -20,7 +20,7 @@ jobs:
   cuda-backend:
     name: recursion cuda tracegen tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -20,7 +20,7 @@ jobs:
   cuda-backend:
     name: recursion cuda tracegen tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/recursion.cuda.yml
+++ b/.github/workflows/recursion.cuda.yml
@@ -20,7 +20,7 @@ jobs:
   cuda-backend:
     name: recursion cuda tracegen tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -35,8 +35,14 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
+
       - name: Verify GPU setup
         run: |
           nvidia-smi

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Recursion tests
     runs-on:
-      - runs-on=${{ github.run_id }}/family=c9g.4xlarge/image=ubuntu24-full-arm64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=c9g.4xlarge+c8g.4xlarge/image=ubuntu24-full-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Recursion tests
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=c9g.4xlarge/image=ubuntu24-full-arm64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -104,7 +104,7 @@ jobs:
   build-linux-cuda-release:
     name: Build x86_64-unknown-linux-gnu CUDA ${{ matrix.cuda_version }}
     runs-on:
-      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -104,7 +104,7 @@ jobs:
   build-linux-cuda-release:
     name: Build x86_64-unknown-linux-gnu CUDA ${{ matrix.cuda_version }}
     runs-on:
-      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=80gb/spot=price-capacity-optimized/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -35,11 +35,11 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: linux-x64
-            family: m8i-flex.16xlarge
+            family: m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge
             image: ubuntu24-full-x64
           - target: aarch64-unknown-linux-gnu
             arch: linux-arm64
-            family: c9g.4xlarge
+            family: c9g.4xlarge+c8g.4xlarge
             image: ubuntu24-full-arm64
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -35,7 +35,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: linux-x64
-            family: m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge
+            family: c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge
             image: ubuntu24-full-x64
           - target: aarch64-unknown-linux-gnu
             arch: linux-arm64
@@ -129,14 +129,14 @@ jobs:
         with:
           targets: x86_64-unknown-linux-gnu
       - uses: ./.github/actions/sccache
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          key: release-cuda-${{ matrix.cuda_version }}
-
       # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
       - name: Setup GPU driver
         run: bash ./scripts/gpu_driver_setup.sh
+
+      - uses: ./.github/actions/rust-cache-cuda
+        with:
+          cache-on-failure: true
+          key: release-cuda-${{ matrix.cuda_version }}
 
       - name: Set package version
         id: meta

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -104,7 +104,7 @@ jobs:
   build-linux-cuda-release:
     name: Build x86_64-unknown-linux-gnu CUDA ${{ matrix.cuda_version }}
     runs-on:
-      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=80gb/spot=capacity-optimized/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -28,18 +28,18 @@ jobs:
   build-linux-release:
     name: Build ${{ matrix.target }}
     runs-on:
-      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-${{ matrix.arch }}/runner=${{ matrix.runner }}/image=${{ matrix.image }}/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-${{ matrix.arch }}/family=${{ matrix.family }}/image=${{ matrix.image }}/volume=80gb/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: linux-x64
-            runner: 64cpu-linux-x64
+            family: m8i-flex.16xlarge
             image: ubuntu24-full-x64
           - target: aarch64-unknown-linux-gnu
             arch: linux-arm64
-            runner: 16cpu-linux-arm64
+            family: c9g.4xlarge
             image: ubuntu24-full-arm64
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -104,7 +104,7 @@ jobs:
   build-linux-cuda-release:
     name: Build x86_64-unknown-linux-gnu CUDA ${{ matrix.cuda_version }}
     runs-on:
-      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-cargo-openvm-linux-x64-cuda-${{ matrix.cuda_package_version }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
     strategy:
       fail-fast: false
       matrix:
@@ -133,6 +133,10 @@ jobs:
         with:
           cache-on-failure: true
           key: release-cuda-${{ matrix.cuda_version }}
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
 
       - name: Set package version
         id: meta

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -31,12 +31,12 @@ jobs:
         platform:
           # TODO(aot): restore `features: "aot"`
           - {
-              labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
+              labels: "family=m8i-flex.16xlarge/image=ubuntu24-full-x64",
               image: "ubuntu24-full-x64",
               features: "",
             }
           - {
-              labels: "runner=64cpu-linux-x64/image=ubuntu24-full-x64",
+              labels: "family=m8i-flex.16xlarge/image=ubuntu24-full-x64",
               image: "ubuntu24-full-x64",
               features: "rvr",
             }

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -41,7 +41,7 @@ jobs:
               features: "rvr",
             }
           - {
-              labels: "image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized",
+              labels: "image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge+g5.2xlarge/volume=40gb/spot=price-capacity-optimized",
               image: "ubuntu24-gpu-x64",
               features: "cuda,touchemall",
             }

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -41,7 +41,7 @@ jobs:
               features: "rvr",
             }
           - {
-              labels: "image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized",
+              labels: "image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized",
               image: "ubuntu24-gpu-x64",
               features: "cuda,touchemall",
             }
@@ -75,6 +75,11 @@ jobs:
           git submodule update --init --depth 1 extensions/keccak256/rvr/ffi/openssl
           git submodule update --init --depth 1 extensions/algebra/rvr/ffi/modular/secp256k1
       - uses: ./.github/actions/sccache
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        if: contains(matrix.platform.features, 'cuda')
+        run: bash ./scripts/gpu_driver_setup.sh
 
       - name: Set feature flags
         run: |

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -31,12 +31,12 @@ jobs:
         platform:
           # TODO(aot): restore `features: "aot"`
           - {
-              labels: "family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64",
+              labels: "family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64",
               image: "ubuntu24-full-x64",
               features: "",
             }
           - {
-              labels: "family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64",
+              labels: "family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64",
               image: "ubuntu24-full-x64",
               features: "rvr",
             }

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -31,12 +31,12 @@ jobs:
         platform:
           # TODO(aot): restore `features: "aot"`
           - {
-              labels: "family=m8i-flex.16xlarge/image=ubuntu24-full-x64",
+              labels: "family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64",
               image: "ubuntu24-full-x64",
               features: "",
             }
           - {
-              labels: "family=m8i-flex.16xlarge/image=ubuntu24-full-x64",
+              labels: "family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64",
               image: "ubuntu24-full-x64",
               features: "rvr",
             }

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -41,7 +41,7 @@ jobs:
               features: "rvr",
             }
           - {
-              labels: "image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized",
+              labels: "image=ubuntu24-gpu-x64/family=g7.2xlarge+g6.2xlarge/volume=40gb/spot=capacity-optimized",
               image: "ubuntu24-gpu-x64",
               features: "cuda,touchemall",
             }

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -41,7 +41,7 @@ jobs:
               features: "rvr",
             }
           - {
-              labels: "image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=40gb/spot=capacity-optimized",
+              labels: "image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=40gb/spot=capacity-optimized",
               image: "ubuntu24-gpu-x64",
               features: "cuda,touchemall",
             }

--- a/.github/workflows/sdk-sweep.yml
+++ b/.github/workflows/sdk-sweep.yml
@@ -7,7 +7,7 @@ name: SDK Parameter Sweep
 # sdk.cuda.yml.
 #
 # NOTE: `family` and `arch` must be consistent — `x86`/`arm` require a matching
-# CPU EC2 family (e.g. `m8a.24xlarge` / `c9g.4xlarge`), and `x86-gpu` requires
+# CPU EC2 family (e.g. `m8a.24xlarge+m8i.24xlarge` / `c9g.4xlarge+c8g.4xlarge`), and `x86-gpu` requires
 # a GPU family (e.g. `g7e.2xlarge+g7.2xlarge+g6e.2xlarge`).
 
 on:

--- a/.github/workflows/sdk-sweep.yml
+++ b/.github/workflows/sdk-sweep.yml
@@ -7,8 +7,8 @@ name: SDK Parameter Sweep
 # sdk.cuda.yml.
 #
 # NOTE: `family` and `arch` must be consistent — `x86`/`arm` require a matching
-# CPU EC2 family (e.g. `m7a.24xlarge` / `c8g.24xlarge`), and `x86-gpu` requires
-# a GPU family (e.g. `g6e.2xlarge`).
+# CPU EC2 family (e.g. `m8a.24xlarge` / `c8g.24xlarge`), and `x86-gpu` requires
+# a GPU family (e.g. `g7e.2xlarge+g7.2xlarge+g6e.2xlarge`).
 
 on:
   workflow_dispatch:
@@ -32,7 +32,7 @@ on:
       family:
         description: "EC2 instance family (must match selected arch)"
         type: string
-        default: "g6e.2xlarge"
+        default: "g7e.2xlarge+g7.2xlarge+g6e.2xlarge"
       test_name:
         description: "Comma-separated test filters passed to --test-name"
         type: string
@@ -111,6 +111,12 @@ jobs:
         if: ${{ matrix.mode != 'cuda' }}
         with:
           cache-on-failure: true
+
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        if: ${{ matrix.mode == 'cuda' }}
+        run: bash ./scripts/gpu_driver_setup.sh
+
       - uses: ./.github/actions/rust-cache-cuda
         if: ${{ matrix.mode == 'cuda' }}
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/sdk-sweep.yml
+++ b/.github/workflows/sdk-sweep.yml
@@ -8,7 +8,7 @@ name: SDK Parameter Sweep
 #
 # NOTE: `family` and `arch` must be consistent — `x86`/`arm` require a matching
 # CPU EC2 family (e.g. `m8a.24xlarge+m8i.24xlarge` / `c9g.4xlarge+c8g.4xlarge`), and `x86-gpu` requires
-# a GPU family (e.g. `g7e.2xlarge+g7.2xlarge+g6e.2xlarge`).
+# a GPU family (e.g. `g7e.2xlarge+g7.4xlarge+g6e.2xlarge`).
 
 on:
   workflow_dispatch:
@@ -32,7 +32,7 @@ on:
       family:
         description: "EC2 instance family (must match selected arch)"
         type: string
-        default: "g7e.2xlarge+g7.2xlarge+g6e.2xlarge"
+        default: "g7e.2xlarge+g7.4xlarge+g6e.2xlarge"
       test_name:
         description: "Comma-separated test filters passed to --test-name"
         type: string

--- a/.github/workflows/sdk-sweep.yml
+++ b/.github/workflows/sdk-sweep.yml
@@ -7,7 +7,7 @@ name: SDK Parameter Sweep
 # sdk.cuda.yml.
 #
 # NOTE: `family` and `arch` must be consistent — `x86`/`arm` require a matching
-# CPU EC2 family (e.g. `m8a.24xlarge` / `c8g.24xlarge`), and `x86-gpu` requires
+# CPU EC2 family (e.g. `m8a.24xlarge` / `c9g.4xlarge`), and `x86-gpu` requires
 # a GPU family (e.g. `g7e.2xlarge+g7.2xlarge+g6e.2xlarge`).
 
 on:

--- a/.github/workflows/sdk-sweep.yml
+++ b/.github/workflows/sdk-sweep.yml
@@ -8,7 +8,7 @@ name: SDK Parameter Sweep
 #
 # NOTE: `family` and `arch` must be consistent — `x86`/`arm` require a matching
 # CPU EC2 family (e.g. `m8a.24xlarge+m8i.24xlarge` / `c9g.4xlarge+c8g.4xlarge`), and `x86-gpu` requires
-# a GPU family (e.g. `g7e.2xlarge+g7.4xlarge+g6e.2xlarge`).
+# a GPU family (e.g. `g7.4xlarge+g6e.2xlarge`).
 
 on:
   workflow_dispatch:
@@ -32,7 +32,7 @@ on:
       family:
         description: "EC2 instance family (must match selected arch)"
         type: string
-        default: "g7e.2xlarge+g7.4xlarge+g6e.2xlarge"
+        default: "g7.4xlarge+g6e.2xlarge"
       test_name:
         description: "Comma-separated test filters passed to --test-name"
         type: string

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -47,6 +47,10 @@ jobs:
           source ci/scripts/utils.sh
           install_s5cmd
 
+      - name: Install solc
+        # The SDK EVM/Halo2 verification tests shell out to solc when generating verifiers.
+        run: (hash svm 2>/dev/null || cargo install --locked --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
+
       - name: Verify GPU setup
         run: |
           nvidia-smi

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -22,7 +22,7 @@ jobs:
   cuda-backend:
     name: sdk cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -80,7 +80,7 @@ jobs:
         working-directory: crates/sdk
         run: |
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
-          cargo nextest run --cargo-profile=fast --features cuda,root-prover,evm-verify,halo2-gpu --test-threads=1
+          cargo nextest run --cargo-profile=fast --features cuda,root-prover,evm-verify,halo2-gpu --test-threads=2
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -22,7 +22,7 @@ jobs:
   cuda-backend:
     name: sdk cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=40gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=80gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -39,6 +39,11 @@ jobs:
       - uses: ./.github/actions/sccache
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
+      - name: Install architecture specific tools
+        run: |
+          source ci/scripts/utils.sh
+          install_s5cmd
+
       - name: Verify GPU setup
         run: |
           nvidia-smi
@@ -59,11 +64,16 @@ jobs:
             exit 1
           fi
 
+      - name: Setup halo2
+        working-directory: crates/sdk
+        run: |
+          bash ../../scripts/trusted_setup_s3.sh
+
       - name: Run SDK CUDA tests
         working-directory: crates/sdk
         run: |
           "$GITHUB_WORKSPACE/ci/install-openvm-toolchain.sh"
-          cargo nextest run --cargo-profile=fast --features cuda,root-prover --test-threads=1
+          cargo nextest run --cargo-profile=fast --features cuda,root-prover,evm-verify,halo2-gpu --test-threads=1
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -22,7 +22,7 @@ jobs:
   cuda-backend:
     name: sdk cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=80gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -22,7 +22,7 @@ jobs:
   cuda-backend:
     name: sdk cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.*+g7.*+g6e.*/cpu=8+16/ram=64/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7.4xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -22,7 +22,7 @@ jobs:
   cuda-backend:
     name: sdk cuda tests
     runs-on:
-      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g6.*+g5+g6e/cpu=4+32/volume=80gb/spot=capacity-optimized/extras=s3-cache
+      - runs-on=${{ github.run_id }}/image=ubuntu24-gpu-x64/family=g7e.2xlarge+g7.2xlarge+g6e.2xlarge/volume=80gb/spot=capacity-optimized/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:
@@ -37,6 +37,9 @@ jobs:
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"
       - uses: ./.github/actions/sccache
+      # TODO: remove once https://github.com/runs-on/runner-images-for-aws/issues/55 is fixed
+      - name: Setup GPU driver
+        run: bash ./scripts/gpu_driver_setup.sh
       - uses: ./.github/actions/rust-cache-cuda
       - uses: taiki-e/install-action@nextest
       - name: Install architecture specific tools

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           export RUST_BACKTRACE=1
           export RUST_MIN_STACK=8388608
-          FEATURES="parallel,root-prover,evm-verify,skip-heavy-sdk-proof-tests"
+          FEATURES="parallel,root-prover,evm-verify"
           if [[ "${{ matrix.mode }}" == "default" ]]; then
             : # no additional features
           elif [[ "${{ matrix.mode }}" == "rvr" ]]; then

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-sdk-tests') }}
     strategy:
       matrix:
-        mode: ["default", "ignored", "rvr"]
+        mode: ["default", "rvr"]
 
     runs-on:
       - runs-on=${{ github.run_id }}-sdk-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ inputs.family || 'm7a.24xlarge' }}/image=${{ (inputs.arch || 'x86') == 'arm' && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/volume=80gb/extras=s3-cache
@@ -106,12 +106,11 @@ jobs:
           diff -u expected_abi_sorted.json compiled_abi.json
 
       - name: Run openvm-sdk crate tests (${{ matrix.mode }})
-        if: ${{ matrix.mode != 'ignored' }}
         working-directory: crates/sdk
         run: |
           export RUST_BACKTRACE=1
           export RUST_MIN_STACK=8388608
-          FEATURES="parallel,root-prover,evm-verify"
+          FEATURES="parallel,root-prover,evm-verify,skip-heavy-sdk-proof-tests"
           if [[ "${{ matrix.mode }}" == "default" ]]; then
             : # no additional features
           elif [[ "${{ matrix.mode }}" == "rvr" ]]; then
@@ -119,20 +118,13 @@ jobs:
           else
             echo "Unknown matrix mode: ${{ matrix.mode }}" && exit 1
           fi
-          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo nextest run --release --features "$FEATURES" --test-threads=1
+          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo nextest run --release --features "$FEATURES"
 
       - name: Build openvm-sdk examples
         if: ${{ matrix.mode == 'default' }}
         working-directory: crates/sdk
         run: |
           cargo build --release --examples --features parallel,root-prover,evm-verify
-
-      - name: Run ignored tests
-        if: ${{ matrix.mode == 'ignored' }}
-        working-directory: crates/sdk
-        # if: ${{ github.event_name == 'push' }}
-        run: |
-          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true cargo nextest run --release --features parallel,root-prover,evm-verify --run-ignored=only --no-tests pass
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -14,7 +14,7 @@ on:
       family:
         description: "EC2 instance family (must match selected arch)"
         type: string
-        default: "m7a.24xlarge"
+        default: "m8a.24xlarge"
   push:
     branches: ["main"]
   pull_request:
@@ -36,7 +36,7 @@ jobs:
         mode: ["default", "rvr"]
 
     runs-on:
-      - runs-on=${{ github.run_id }}-sdk-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ inputs.family || 'm7a.24xlarge' }}/image=${{ (inputs.arch || 'x86') == 'arm' && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-sdk-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ inputs.family || 'm8a.24xlarge' }}/image=${{ (inputs.arch || 'x86') == 'arm' && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/volume=80gb/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -14,7 +14,7 @@ on:
       family:
         description: "EC2 instance family (must match selected arch)"
         type: string
-        default: "m8a.24xlarge"
+        default: "m8a.24xlarge+m8i.24xlarge"
   push:
     branches: ["main"]
   pull_request:
@@ -36,7 +36,7 @@ jobs:
         mode: ["default", "rvr"]
 
     runs-on:
-      - runs-on=${{ github.run_id }}-sdk-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ inputs.family || 'm8a.24xlarge' }}/image=${{ (inputs.arch || 'x86') == 'arm' && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-sdk-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ inputs.family || 'm8a.24xlarge+m8i.24xlarge' }}/image=${{ (inputs.arch || 'x86') == 'arm' && 'ubuntu24-full-arm64' || 'ubuntu24-full-x64' }}/volume=80gb/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/static-verifier.yml
+++ b/.github/workflows/static-verifier.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Static verifier tests
     runs-on:
-      - runs-on=${{ github.run_id }}-static-verifier-${{ github.run_attempt }}/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}-static-verifier-${{ github.run_attempt }}/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/static-verifier.yml
+++ b/.github/workflows/static-verifier.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Static verifier tests
     runs-on:
-      - runs-on=${{ github.run_id }}-static-verifier-${{ github.run_attempt }}/runner=64cpu-linux-x64/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}-static-verifier-${{ github.run_attempt }}/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/static-verifier.yml
+++ b/.github/workflows/static-verifier.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     name: Static verifier tests
     runs-on:
-      - runs-on=${{ github.run_id }}-static-verifier-${{ github.run_attempt }}/family=m8i-flex.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}-static-verifier-${{ github.run_attempt }}/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/upload-setup-artifacts.yml
+++ b/.github/workflows/upload-setup-artifacts.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   upload-setup:
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/extras=s3-cache/volume=80gb
+      - runs-on=${{ github.run_id }}/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/extras=s3-cache/volume=80gb
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/upload-setup-artifacts.yml
+++ b/.github/workflows/upload-setup-artifacts.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   upload-setup:
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=64cpu-linux-x64/extras=s3-cache/volume=80gb
+      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge/extras=s3-cache/volume=80gb
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/upload-setup-artifacts.yml
+++ b/.github/workflows/upload-setup-artifacts.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   upload-setup:
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge/extras=s3-cache/volume=80gb
+      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/extras=s3-cache/volume=80gb
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   verify-versioning:
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/extras=s3-cache/volume=80gb
+      - runs-on=${{ github.run_id }}/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/extras=s3-cache/volume=80gb
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   verify-versioning:
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge/extras=s3-cache/volume=80gb
+      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge/extras=s3-cache/volume=80gb
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   verify-versioning:
     runs-on:
-      - runs-on=${{ github.run_id }}/runner=64cpu-linux-x64/extras=s3-cache/volume=80gb
+      - runs-on=${{ github.run_id }}/family=m8i-flex.16xlarge/extras=s3-cache/volume=80gb
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
 
     runs-on:
       - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/extras=s3-cache

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -25,10 +25,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { runner: "64cpu-linux-x64", image: "ubuntu24-full-x64" }
+          - { family: "m8i-flex.16xlarge", image: "ubuntu24-full-x64" }
 
     runs-on:
-      - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/runner=${{ matrix.platform.runner }}/image=${{ matrix.platform.image }}/extras=s3-cache
+      - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2
@@ -51,12 +51,12 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Set CPU tests environment variables
-        if: ${{ !contains(matrix.platform.runner, 'gpu') }}
+        if: ${{ !contains(matrix.platform.image, 'gpu') }}
         run: |
           echo "NEXTEST_ARGS=--cargo-profile fast --features parallel" >> $GITHUB_ENV
 
       - name: Check CUDA status and set environment variables
-        if: contains(matrix.platform.runner, 'gpu')
+        if: contains(matrix.platform.image, 'gpu')
         run: |
           nvcc --version
           echo "NEXTEST_ARGS=cuda --features parallel,cuda,touchemall" >> $GITHUB_ENV
@@ -67,7 +67,7 @@ jobs:
           cargo nextest run ${{ env.NEXTEST_ARGS }}
 
       - name: Run vm crate tests with basic memory
-        if: ${{ !contains(matrix.platform.runner, 'gpu') }}
+        if: ${{ !contains(matrix.platform.image, 'gpu') }}
         working-directory: crates/vm
         run: |
           cargo nextest run --cargo-profile=fast --features parallel,basic-memory

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { family: "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge", image: "ubuntu24-full-x64" }
+          - { family: "c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge", image: "ubuntu24-full-x64" }
 
     runs-on:
       - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}-${{ strategy.job-index }}/family=${{ matrix.platform.family }}/image=${{ matrix.platform.image }}/extras=s3-cache

--- a/ci/benchmark-config.example.json
+++ b/ci/benchmark-config.example.json
@@ -7,7 +7,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -21,7 +21,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -35,7 +35,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "m8i-flex.16xlarge",
+          "instance_type": "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge",
           "memory_allocator": "jemalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -49,7 +49,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -63,7 +63,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -77,7 +77,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2,
@@ -93,7 +93,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -107,7 +107,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -121,7 +121,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge",
+          "instance_type": "c9g.16xlarge+c8g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2

--- a/ci/benchmark-config.example.json
+++ b/ci/benchmark-config.example.json
@@ -7,7 +7,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -21,7 +21,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -35,7 +35,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "m8i-flex.16xlarge+m8i.16xlarge+m8a.16xlarge",
+          "instance_type": "m8i.16xlarge",
           "memory_allocator": "jemalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -49,7 +49,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -63,7 +63,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -77,7 +77,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2,
@@ -93,7 +93,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -107,7 +107,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -121,7 +121,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "c9g.16xlarge+c8g.16xlarge",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2

--- a/ci/benchmark-config.example.json
+++ b/ci/benchmark-config.example.json
@@ -7,7 +7,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -21,7 +21,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -35,7 +35,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-x64",
+          "instance_type": "m8i-flex.16xlarge",
           "memory_allocator": "jemalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -49,7 +49,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -63,7 +63,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -77,7 +77,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2,
@@ -93,7 +93,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -107,7 +107,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2
@@ -121,7 +121,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "64cpu-linux-arm64",
+          "instance_type": "c9g.16xlarge",
           "memory_allocator": "mimalloc",
           "app_log_blowup": 2,
           "leaf_log_blowup": 2

--- a/ci/benchmark-config.json
+++ b/ci/benchmark-config.json
@@ -7,7 +7,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -19,7 +19,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -31,7 +31,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -43,7 +43,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -55,7 +55,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -67,7 +67,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -79,7 +79,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -91,7 +91,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -103,7 +103,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -115,7 +115,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -127,7 +127,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -139,7 +139,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]

--- a/ci/benchmark-config.json
+++ b/ci/benchmark-config.json
@@ -7,7 +7,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -19,7 +19,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -31,7 +31,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -43,7 +43,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -55,7 +55,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -67,7 +67,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -79,7 +79,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -91,7 +91,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -103,7 +103,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -115,7 +115,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -127,7 +127,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -139,7 +139,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g7e.2xlarge+g7.4xlarge+g6e.2xlarge",
+          "instance_type": "g7.4xlarge",
           "memory_allocator": "jemalloc"
         }
       ]

--- a/ci/benchmark-config.json
+++ b/ci/benchmark-config.json
@@ -7,7 +7,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -19,7 +19,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -31,7 +31,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -43,7 +43,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -55,7 +55,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -67,7 +67,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -79,7 +79,7 @@
       "e2e_bench": false,
       "run_params": [
         {
-          "instance_type": "g6.2xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -91,7 +91,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g6e.4xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -103,7 +103,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g6e.4xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -115,7 +115,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g6e.4xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -127,7 +127,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g6e.4xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]
@@ -139,7 +139,7 @@
       "e2e_bench": true,
       "run_params": [
         {
-          "instance_type": "g6e.4xlarge",
+          "instance_type": "g7e.2xlarge+g7.2xlarge+g6e.2xlarge",
           "memory_allocator": "jemalloc"
         }
       ]

--- a/ci/scripts/bench.py
+++ b/ci/scripts/bench.py
@@ -1,7 +1,21 @@
 import argparse
 import os
+import re
 import shutil
 import subprocess
+
+
+def resolve_native_target_cpu(toolchain):
+    target_cpus = subprocess.run(
+        ["rustc", toolchain, "--print", "target-cpus"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    match = re.search(r"^\s*native.*\(currently ([^)]+)\)", target_cpus, re.MULTILINE)
+    if match is None:
+        raise RuntimeError(f"failed to resolve native CPU using rustc {toolchain}")
+    return match.group(1)
 
 
 def run_cargo_command(
@@ -54,7 +68,12 @@ def run_cargo_command(
     # Prepare the environment variables
     env = os.environ.copy()  # Copy current environment variables
     env["OUTPUT_PATH"] = output_path
-    env["RUSTFLAGS"] = "-Ctarget-cpu=native"
+    rustflags = env.get("RUSTFLAGS", "").strip()
+    if "target-cpu" not in rustflags:
+        target_cpu = resolve_native_target_cpu(toolchain)
+        print(f"Resolved target CPU: {target_cpu}")
+        rustflags = f"{rustflags} -Ctarget-cpu={target_cpu}".strip()
+    env["RUSTFLAGS"] = rustflags
     if "perf-metrics" in feature_flags:
         env["GUEST_SYMBOLS_PATH"] = os.path.splitext(output_path)[0] + ".syms"
 

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -110,6 +110,9 @@ cuda = [
 ]
 halo2-gpu = ["cuda", "openvm-static-verifier?/halo2-gpu"]
 cell-profiling = ["evm-prove", "openvm-static-verifier/cell-profiling"]
+# Compiles the full EVM/Halo2 feature surface while skipping expensive
+# end-to-end proof tests that are covered by the CUDA+Halo2 SDK test lane.
+skip-heavy-sdk-proof-tests = []
 
 [[example]]
 name = "sdk_app"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -110,9 +110,6 @@ cuda = [
 ]
 halo2-gpu = ["cuda", "openvm-static-verifier?/halo2-gpu"]
 cell-profiling = ["evm-prove", "openvm-static-verifier/cell-profiling"]
-# Compiles the full EVM/Halo2 feature surface while skipping expensive
-# end-to-end proof tests that are covered by the CUDA+Halo2 SDK test lane.
-skip-heavy-sdk-proof-tests = []
 
 [[example]]
 name = "sdk_app"

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -377,10 +377,6 @@ fn prove_and_verify_e2e(
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_sdk_fibonacci() -> Result<()> {
     setup_tracing();
     let (sdk, _, _) = make_fib_sdk();
@@ -398,10 +394,6 @@ fn test_sdk_fibonacci() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_verify_stark_deferral() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -420,10 +412,6 @@ fn test_verify_stark_deferral() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_verify_many_deferrals() -> Result<()> {
     setup_tracing();
     const NUM_DEFERRAL_CIRCUITS: usize = 5;
@@ -458,10 +446,6 @@ fn test_verify_many_deferrals() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_verify_stark_path_sdk_can_verify_own_proofs() -> Result<()> {
     setup_tracing();
     let (app_params, agg_params, _) = get_params();
@@ -488,10 +472,6 @@ fn test_verify_stark_path_sdk_can_verify_own_proofs() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_deferrals_enabled_without_usage() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -635,10 +615,6 @@ fn test_sdk_compiled_metered_cost_execute() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_deferral_aware_sdk_with_odd_children() -> Result<()> {
     setup_tracing();
     let n_stack = 16;
@@ -678,10 +654,6 @@ fn test_deferral_aware_sdk_with_odd_children() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_verify_stark_with_deferral_child() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -738,10 +710,6 @@ fn test_verify_stark_with_deferral_child() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -816,10 +784,6 @@ fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(
-    feature = "skip-heavy-sdk-proof-tests",
-    ignore = "covered by the CUDA+Halo2 SDK test lane"
-)]
 fn test_deferral_aware_and_active_have_equivalent_vks() -> Result<()> {
     setup_tracing();
     let n_stack = 19;

--- a/crates/sdk/src/tests.rs
+++ b/crates/sdk/src/tests.rs
@@ -377,6 +377,10 @@ fn prove_and_verify_e2e(
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_sdk_fibonacci() -> Result<()> {
     setup_tracing();
     let (sdk, _, _) = make_fib_sdk();
@@ -394,6 +398,10 @@ fn test_sdk_fibonacci() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_verify_stark_deferral() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -412,6 +420,10 @@ fn test_verify_stark_deferral() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_verify_many_deferrals() -> Result<()> {
     setup_tracing();
     const NUM_DEFERRAL_CIRCUITS: usize = 5;
@@ -446,6 +458,10 @@ fn test_verify_many_deferrals() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_verify_stark_path_sdk_can_verify_own_proofs() -> Result<()> {
     setup_tracing();
     let (app_params, agg_params, _) = get_params();
@@ -472,6 +488,10 @@ fn test_verify_stark_path_sdk_can_verify_own_proofs() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_deferrals_enabled_without_usage() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -615,6 +635,10 @@ fn test_sdk_compiled_metered_cost_execute() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_deferral_aware_sdk_with_odd_children() -> Result<()> {
     setup_tracing();
     let n_stack = 16;
@@ -654,6 +678,10 @@ fn test_deferral_aware_sdk_with_odd_children() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_verify_stark_with_deferral_child() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -710,6 +738,10 @@ fn test_verify_stark_with_deferral_child() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
     setup_tracing();
     let (fib_sdk, app_params, agg_params) = make_fib_sdk();
@@ -784,6 +816,10 @@ fn test_prove_mixed_vm_def_depth_mismatch() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "skip-heavy-sdk-proof-tests",
+    ignore = "covered by the CUDA+Halo2 SDK test lane"
+)]
 fn test_deferral_aware_and_active_have_equivalent_vks() -> Result<()> {
     setup_tracing();
     let n_stack = 19;

--- a/scripts/gpu_driver_setup.sh
+++ b/scripts/gpu_driver_setup.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Ensures a working NVIDIA driver, switching to the open kernel module flavor
+# if needed. Blackwell GPUs require open kernel modules.
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi
+    exit 0
+fi
+
+KERNEL_RELEASE="$(uname -r)"
+
+installed_nvidia_packages() {
+    dpkg-query -W -f='${binary:Package}\n' 2>/dev/null || true
+}
+
+detect_driver_series() {
+    local package series
+
+    if [[ -n "${NVIDIA_DRIVER_SERIES:-}" ]]; then
+        echo "$NVIDIA_DRIVER_SERIES"
+        return
+    fi
+
+    while IFS= read -r package; do
+        if [[ "$package" == linux-modules-nvidia-*-open-"$KERNEL_RELEASE" ||
+              "$package" == linux-modules-nvidia-*-"$KERNEL_RELEASE" ]]; then
+            series="${package#linux-modules-nvidia-}"
+            series="${series%-"$KERNEL_RELEASE"}"
+            series="${series%-open}"
+            if [[ "$series" =~ ^[0-9]+$ ]]; then
+                echo "$series"
+                return
+            fi
+        fi
+    done < <(installed_nvidia_packages)
+
+    installed_nvidia_packages |
+        sed -nE 's/^(nvidia-utils|nvidia-driver|nvidia-dkms|linux-modules-nvidia)-([0-9]+)(-.+)?$/\2/p' |
+        sort -V |
+        tail -n1
+}
+
+DRIVER_SERIES="$(detect_driver_series)"
+if ! [[ "$DRIVER_SERIES" =~ ^[0-9]+$ ]]; then
+    echo "Unable to detect installed NVIDIA driver series; set NVIDIA_DRIVER_SERIES to a numeric series." >&2
+    exit 1
+fi
+
+OPEN_MODULE_PKG="linux-modules-nvidia-${DRIVER_SERIES}-open-${KERNEL_RELEASE}"
+
+remove_closed_kernel_modules() {
+    mapfile -t closed_pkgs < <(
+        installed_nvidia_packages |
+            awk -v series="$DRIVER_SERIES" '
+                $0 ~ "^(nvidia-driver|nvidia-dkms|nvidia-kernel-source)-" series "($|-)" && $0 !~ "-open($|-)" {
+                    print
+                    next
+                }
+                $0 ~ "^linux-modules-nvidia-" series "($|-)" && $0 !~ "-open($|-)" {
+                    print
+                }
+            '
+    )
+
+    if ((${#closed_pkgs[@]})); then
+        sudo apt-get remove -y "${closed_pkgs[@]}"
+    fi
+}
+
+has_apt_candidate() {
+    local package="$1"
+    local candidate
+    candidate="$(apt-cache policy "$package" | awk '/Candidate:/ { print $2; exit }')"
+    [[ -n "$candidate" && "$candidate" != "(none)" ]]
+}
+
+echo "nvidia-smi not functional; switching to open kernel module driver flavor..."
+set -ex
+sudo apt-get update -qq
+remove_closed_kernel_modules
+
+# Prefer the prebuilt open modules for the running kernel. Installing the
+# nvidia-driver-*-open meta package here pulls DKMS, which conflicts with the
+# same .ko files shipped by the prebuilt linux-modules package.
+if has_apt_candidate "$OPEN_MODULE_PKG"; then
+    sudo apt-get install -y --no-install-recommends "$OPEN_MODULE_PKG"
+else
+    sudo apt-get install -y --no-install-recommends \
+        "nvidia-driver-${DRIVER_SERIES}-open" \
+        "nvidia-dkms-${DRIVER_SERIES}-open" \
+        "linux-headers-${KERNEL_RELEASE}"
+fi
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+    sudo apt-get install -y --no-install-recommends "nvidia-utils-${DRIVER_SERIES}"
+fi
+
+sudo rmmod nvidia_uvm nvidia_drm nvidia_modeset nvidia 2>/dev/null || true
+sudo modprobe nvidia
+sudo modprobe nvidia_uvm
+nvidia-smi


### PR DESCRIPTION
## Summary

- Runs the complete SDK EVM/Halo2 proof suite on both CPU configurations (`default` and `rvr`) without ignored proof tests.
- Runs the SDK CUDA lane with `cuda`, `root-prover`, `evm-verify`, and `halo2-gpu`, including `solc`, trusted setup, GPU driver repair, and CUDA architecture-aware Rust caching.
- Runs two SDK CUDA tests concurrently on the bounded `g7e.2xlarge+g6e.2xlarge` pool. Both options have 8 vCPUs, 64 GiB host memory, and at least 48 GB GPU memory.
- Uses bounded, same-size CPU and GPU fallback pools across workflows. Ordinary CUDA jobs use price-capacity-optimized allocation; the latency-sensitive SDK and CLI lanes retain their specialized allocation strategies.
- Keeps benchmark runs on a fixed `g7.4xlarge` baseline and resolves `target-cpu=native` to the concrete host CPU so cached artifacts remain valid and results remain comparable.
- Repairs the CUDA driver before architecture-sensitive cache setup, applies the same cache path to CUDA release builds, and keeps GPU validation after driver setup.
