### PR TITLE
ci(v2.1): speed up crate docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,21 +54,10 @@ jobs:
           nvidia-smi -L
           echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
 
-      - name: Cargo check
-        run: cargo check
-
       - name: Build documentation
-        run: cargo +nightly-2026-01-18 doc --workspace --exclude "openvm-benchmarks" --exclude "*-tests" --exclude "*-test" --features "cuda"
-
-      # We only want the index page to display workspace crates, so we build
-      # separately and copy over the index as a hack
-      - name: Build index page
-        run: |
-          cargo +nightly-2026-01-18 doc --workspace --no-deps --exclude "openvm-benchmarks" --exclude "*-tests" --exclude "*-test" --target-dir target/doc-nodeps
-          cp target/doc-nodeps/doc/index.html target/doc/
-          cp target/doc-nodeps/doc/crates.js target/doc/
+        run: cargo +nightly-2026-01-18 doc --workspace --no-deps --exclude "openvm-benchmarks*" --exclude "*-tests" --features "cuda"
         env:
-          RUSTDOCFLAGS: --enable-index-page -Zunstable-options
+          RUSTDOCFLAGS: -D warnings --enable-index-page -Zunstable-options
 
       - name: Install s5cmd
         run: |
@@ -80,21 +69,21 @@ jobs:
         if: github.ref_type == 'branch' && github.ref == 'refs/heads/main'
         env:
           S3_BUCKET: ${{ vars.CRATE_DOCS_S3_BUCKET }}
-        run: s5cmd sync . s3://${S3_BUCKET%/}/static/
+        run: s5cmd sync --delete . s3://${S3_BUCKET%/}/static/
 
       - name: Sync tagged version S3 bucket
         working-directory: target/doc
         if: github.ref_type == 'tag'
         env:
           S3_BUCKET: ${{ vars.CRATE_DOCS_S3_BUCKET }}
-        run: s5cmd sync . s3://${S3_BUCKET%/}/${{ github.ref_name }}/
+        run: s5cmd sync --delete . s3://${S3_BUCKET%/}/${{ github.ref_name }}/
 
       - name: Sync tagged version S3 bucket
         working-directory: target/doc
         if: github.event_name == 'workflow_dispatch'
         env:
           S3_BUCKET: ${{ vars.CRATE_DOCS_S3_BUCKET }}
-        run: s5cmd sync . s3://${S3_BUCKET%/}/${{ github.event.inputs.tag }}/
+        run: s5cmd sync --delete . s3://${S3_BUCKET%/}/${{ github.event.inputs.tag }}/
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -142,7 +142,6 @@ jobs:
           key: v1
 
       - name: Generate docs
-        # full docs with dependencies are built by docs.yml on main/tags
         run: |
           cargo doc --workspace --no-deps --exclude "openvm-benchmarks*" --exclude "*-tests"
         env:

--- a/crates/circuits/primitives/src/var_range/cuda.rs
+++ b/crates/circuits/primitives/src/var_range/cuda.rs
@@ -16,8 +16,8 @@ pub struct VariableRangeCheckerChipGPU {
     pub cpu_chip: Option<Arc<VariableRangeCheckerChip>>,
 }
 
-/// [value, bits] are in preprocessed trace
-/// generate_trace returns [count]
+/// `[value, bits]` are in the preprocessed trace.
+/// `generate_trace` returns `[count]`.
 impl VariableRangeCheckerChipGPU {
     pub fn new(bus: VariableRangeCheckerBus, device_ctx: GpuDeviceCtx) -> Self {
         let num_rows = (1 << (bus.range_max_bits + 1)) as usize;


### PR DESCRIPTION
## Summary
- build workspace docs once with `--no-deps`, avoiding dependency docs and the second index pass
- deny rustdoc warnings and keep published S3 prefixes aligned with generated output

## Validation
- CUDA workspace docs build with warnings denied
- `actionlint .github/workflows/docs.yml .github/workflows/lints.yml`