### PR TITLE
refactor(v2.1): remove generic `F` from rvr structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7242,7 +7242,6 @@ dependencies = [
  "openvm-instructions",
  "openvm-platform",
  "openvm-riscv-guest",
- "openvm-stark-backend",
  "rvr-openvm-build",
  "rvr-openvm-ext-ffi-common",
  "rvr-openvm-ir",
@@ -7262,7 +7261,6 @@ dependencies = [
  "openvm-algebra-transpiler",
  "openvm-algebra-utils",
  "openvm-instructions",
- "openvm-stark-backend",
  "rand 0.9.2",
  "rvr-openvm-build",
  "rvr-openvm-ir",
@@ -7313,7 +7311,6 @@ dependencies = [
  "openvm-bigint-transpiler",
  "openvm-instructions",
  "openvm-riscv-transpiler",
- "openvm-stark-backend",
  "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -7347,7 +7344,6 @@ version = "2.0.0"
 dependencies = [
  "openvm-ecc-transpiler",
  "openvm-instructions",
- "openvm-stark-backend",
  "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -7382,7 +7378,6 @@ version = "2.0.0"
 dependencies = [
  "openvm-instructions",
  "openvm-keccak256-transpiler",
- "openvm-stark-backend",
  "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -7402,7 +7397,6 @@ version = "2.0.0"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-transpiler",
- "openvm-stark-backend",
  "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -7427,7 +7421,6 @@ dependencies = [
  "openvm-circuit",
  "openvm-instructions",
  "openvm-riscv-transpiler",
- "openvm-stark-backend",
  "p3-baby-bear",
  "rand 0.9.2",
  "rvr-openvm-ext-ffi-common",
@@ -7441,7 +7434,6 @@ version = "2.0.0"
 dependencies = [
  "openvm-instructions",
  "openvm-sha2-transpiler",
- "openvm-stark-backend",
  "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",

--- a/benchmarks/execute/benches/execute.rs
+++ b/benchmarks/execute/benches/execute.rs
@@ -330,7 +330,7 @@ impl BenchExecutor for PureExecution {
     #[cfg(feature = "aot")]
     type Instance = AotInstance<'static, ExecutionCtx>;
     #[cfg(feature = "rvr")]
-    type Instance = RvrPureInstance<'static, BabyBear>;
+    type Instance = RvrPureInstance<'static>;
     #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     type Instance = InterpretedInstance<'static, ExecutionCtx>;
 
@@ -361,7 +361,7 @@ impl BenchExecutor for MeteredExecution {
     #[cfg(feature = "aot")]
     type Instance = (AotInstance<'static, MeteredCtx>, MeteredCtx);
     #[cfg(feature = "rvr")]
-    type Instance = (RvrMeteredInstance<'static, BabyBear>, MeteredCtx);
+    type Instance = (RvrMeteredInstance<'static>, MeteredCtx);
     #[cfg(all(not(feature = "aot"), not(feature = "rvr")))]
     type Instance = (InterpretedInstance<'static, MeteredCtx>, MeteredCtx);
 
@@ -394,7 +394,7 @@ impl BenchExecutor for MeteredExecution {
 
 impl BenchExecutor for MeteredCostExecution {
     #[cfg(feature = "rvr")]
-    type Instance = RvrMeteredCostInstance<'static, BabyBear>;
+    type Instance = RvrMeteredCostInstance<'static>;
     #[cfg(not(feature = "rvr"))]
     type Instance = InterpretedInstance<'static, MeteredCostCtx>;
 

--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 /// Default clang command used for RVR native C builds.
 pub const DEFAULT_CLANG_COMMAND: &str = "clang-22";
 
-/// Minimum supported LLVM clang major version (c23, preserve_none on AArch64).
+/// Minimum supported LLVM clang major version (c2y, preserve_none on AArch64).
 pub const MIN_CLANG_MAJOR: u32 = 19;
 
 /// Keg-only Homebrew LLVM locations (not on PATH by default).
@@ -93,7 +93,7 @@ pub fn ensure_rvr_clang_compiler(compiler: &str) -> Result<(), String> {
     if major < MIN_CLANG_MAJOR {
         return Err(format!(
             "selected compiler '{compiler}' is clang {major}, but RVR requires \
-             clang >= {MIN_CLANG_MAJOR} (c23, preserve_none); install a newer LLVM \
+             clang >= {MIN_CLANG_MAJOR} (c2y, preserve_none); install a newer LLVM \
              (e.g. clang-22) or set RVR_CC to a newer clang"
         ));
     }

--- a/crates/rvr/rvr-openvm-lift/src/convert.rs
+++ b/crates/rvr/rvr-openvm-lift/src/convert.rs
@@ -2,11 +2,11 @@
 
 use std::collections::HashSet;
 
-use openvm_instructions::exe::VmExe;
+use openvm_instructions::exe::{SparseMemoryImage, VmExe};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{LiftedInstr, SourceLoc};
 
-use crate::{extension::ExtensionRegistry, opcode::lift_instruction};
+use crate::{extension::ExtensionRegistry, opcode::lift_instruction, RvrInstruction};
 
 /// Error during VmExe to IR conversion.
 #[derive(Debug, thiserror::Error)]
@@ -18,7 +18,7 @@ pub enum ConvertError {
 /// Convert a VmExe to a vector of lifted IR instructions.
 pub fn convert_vmexe_to_ir<F: PrimeField32>(
     exe: &VmExe<F>,
-    extensions: &crate::extension::ExtensionRegistry<F>,
+    extensions: &crate::extension::ExtensionRegistry,
 ) -> Result<Vec<LiftedInstr>, ConvertError> {
     convert_vmexe_to_ir_with_debug(exe, extensions, |_| None)
 }
@@ -30,7 +30,7 @@ pub fn convert_vmexe_to_ir<F: PrimeField32>(
 /// boundary when guest debug info is available.
 pub fn convert_vmexe_to_ir_with_debug<F, G>(
     exe: &VmExe<F>,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
     mut source_lookup: G,
 ) -> Result<Vec<LiftedInstr>, ConvertError>
 where
@@ -38,8 +38,8 @@ where
     G: FnMut(u32) -> Option<SourceLoc>,
 {
     let mut lifted = Vec::new();
-
     for (pc, insn, _debug_info) in exe.program.enumerate_by_pc() {
+        let insn = RvrInstruction::from_field(&insn);
         match lift_instruction(&insn, u64::from(pc), extensions) {
             Some(mut li) => {
                 if let Some(loc) = source_lookup(pc) {
@@ -70,13 +70,13 @@ where
 /// Candidates are read at 4-byte-aligned addresses (RISC-V instruction width),
 /// not memory word (u64) boundaries. This discovers switch table entries,
 /// function pointer arrays, and other code pointers embedded in read-only data.
-pub fn scan_init_memory_for_code_pointers<F: PrimeField32>(
-    exe: &VmExe<F>,
+pub fn scan_init_memory_for_code_pointers(
+    init_memory: &SparseMemoryImage,
     valid_pcs: &HashSet<u64>,
 ) -> Vec<u64> {
     // Collect all bytes in address space 2 (main memory).
     let mut mem_bytes: std::collections::BTreeMap<u32, u8> = std::collections::BTreeMap::new();
-    for (&(addr_space, addr), &byte) in &exe.init_memory {
+    for (&(addr_space, addr), &byte) in init_memory {
         if addr_space == 2 {
             mem_bytes.insert(addr, byte);
         }

--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -2,9 +2,11 @@
 
 use std::collections::HashMap;
 
-use openvm_instructions::{instruction::Instruction, LocalOpcode, VmOpcode};
+use openvm_instructions::{LocalOpcode, VmOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::LiftedInstr;
+
+use crate::RvrInstruction;
 
 /// Real AIR index in the trace.
 ///
@@ -116,11 +118,11 @@ pub enum ExtensionError {
 
 /// Trait for an rvr-openvm extension. Each extension handles a range of opcodes
 /// and knows how to lift them to IR (with self-describing codegen via `ExtInstr::emit_c`).
-pub trait RvrExtension<F: PrimeField32>: Send + Sync {
+pub trait RvrExtension: Send + Sync {
     /// Try to lift an OpenVM instruction into IR.
     /// Return `None` if this extension doesn't handle the opcode.
     /// Chip indices are stored on the extension and baked into IR nodes.
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr>;
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr>;
 
     /// C header files for this extension, as `(filename, content)` pairs.
     /// Written to the output directory and `#include`d in the generated code.
@@ -159,32 +161,33 @@ pub trait RvrExtension<F: PrimeField32>: Send + Sync {
     fn extra_cflags(&self) -> Vec<String> {
         vec![]
     }
+}
 
-    /// Register host-side callbacks for this extension with the loaded `.so`.
-    /// Called after `register_openvm_io_ctx` and before `rv_execute`.
+/// Installs host callbacks for an rvr extension.
+pub trait RvrRuntimeExtension: Send + Sync {
+    /// Register host-side callbacks with the loaded `.so`. Called after the IO
+    /// context is installed and before `rv_execute`.
     ///
     /// # Safety
     ///
-    /// `lib` must be the rvr-compiled shared library this extension was lifted
-    /// into.
+    /// `lib` must be the rvr-compiled shared library containing the matching
+    /// extension code.
     unsafe fn register_host_callbacks(
         &self,
-        _lib: &libloading::Library,
-    ) -> Result<(), ExtensionError> {
-        Ok(())
-    }
+        lib: &libloading::Library,
+    ) -> Result<(), ExtensionError>;
 }
 
 /// Trait implemented by OpenVM extension owner types to contribute their rvr
 /// lifting/codegen extensions during config assembly.
 pub trait VmRvrExtension<F: PrimeField32> {
-    fn extend_rvr(&self, _registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {}
+    fn extend_rvr(&self, _extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {}
 }
 
 impl<F: PrimeField32, EXT: VmRvrExtension<F>> VmRvrExtension<F> for Option<EXT> {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: Option<&RvrExtensionCtx>) {
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, ctx: Option<&RvrExtensionCtx>) {
         if let Some(ext) = self {
-            ext.extend_rvr(registry, ctx);
+            ext.extend_rvr(extensions, ctx);
         }
     }
 }
@@ -192,26 +195,25 @@ impl<F: PrimeField32, EXT: VmRvrExtension<F>> VmRvrExtension<F> for Option<EXT> 
 // ── Extension registry ───────────────────────────────────────────────────────
 
 /// Registry of extensions, consulted during lifting and project generation.
-pub struct ExtensionRegistry<F: PrimeField32> {
-    extensions: Vec<Box<dyn RvrExtension<F>>>,
+#[derive(Default)]
+pub struct ExtensionRegistry {
+    extensions: Vec<Box<dyn RvrExtension>>,
 }
 
-impl<F: PrimeField32> ExtensionRegistry<F> {
+impl ExtensionRegistry {
     /// Create an empty registry (no extensions).
     pub fn new() -> Self {
-        Self {
-            extensions: Vec::new(),
-        }
+        Self::default()
     }
 
     /// Register an extension.
-    pub fn register(&mut self, ext: impl RvrExtension<F> + 'static) {
+    pub fn register(&mut self, ext: impl RvrExtension + 'static) {
         self.extensions.push(Box::new(ext));
     }
 
     /// Try to lift an instruction through all registered extensions.
     /// Returns the first successful lift, or `None`.
-    pub fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+    pub fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         self.extensions
             .iter()
             .find_map(|ext| ext.try_lift(insn, pc))
@@ -269,25 +271,33 @@ impl<F: PrimeField32> ExtensionRegistry<F> {
     pub fn is_empty(&self) -> bool {
         self.extensions.is_empty()
     }
-
-    /// Register host callbacks for every extension in the registry.
-    ///
-    /// # Safety
-    ///
-    /// Same requirements as [`RvrExtension::register_host_callbacks`].
-    pub unsafe fn register_host_callbacks(
-        &self,
-        lib: &libloading::Library,
-    ) -> Result<(), ExtensionError> {
-        for ext in &self.extensions {
-            unsafe { ext.register_host_callbacks(lib)? };
-        }
-        Ok(())
-    }
 }
 
-impl<F: PrimeField32> Default for ExtensionRegistry<F> {
-    fn default() -> Self {
-        Self::new()
+/// Rvr lifters and runtime hooks contributed by a VM configuration.
+#[derive(Default)]
+pub struct RvrExtensions {
+    lifters: ExtensionRegistry,
+    runtime_hooks: Vec<Box<dyn RvrRuntimeExtension>>,
+}
+
+impl RvrExtensions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn lifters(&self) -> &ExtensionRegistry {
+        &self.lifters
+    }
+
+    pub fn register_lifter(&mut self, ext: impl RvrExtension + 'static) {
+        self.lifters.register(ext);
+    }
+
+    pub fn register_runtime_hook(&mut self, hook: impl RvrRuntimeExtension + 'static) {
+        self.runtime_hooks.push(Box::new(hook));
+    }
+
+    pub fn into_runtime_hooks(self) -> Vec<Box<dyn RvrRuntimeExtension>> {
+        self.runtime_hooks
     }
 }

--- a/crates/rvr/rvr-openvm-lift/src/helpers.rs
+++ b/crates/rvr/rvr-openvm-lift/src/helpers.rs
@@ -1,11 +1,10 @@
-use openvm_instructions::{
-    instruction::Instruction, program::MAX_ALLOWED_PC, riscv::RV64_REGISTER_NUM_LIMBS,
-};
-use openvm_stark_backend::p3_field::PrimeField32;
+use openvm_instructions::{program::MAX_ALLOWED_PC, riscv::RV64_REGISTER_NUM_LIMBS};
+
+use crate::RvrInstruction;
 
 /// Decode register index from an OpenVM operand.
-pub fn decode_reg<F: PrimeField32>(f: F) -> u8 {
-    (f.as_canonical_u32() / RV64_REGISTER_NUM_LIMBS as u32) as u8
+pub fn decode_reg(value: u32) -> u8 {
+    (value / RV64_REGISTER_NUM_LIMBS as u32) as u8
 }
 
 /// Decode the immediate from the (c, g) field pair used by JALR, LOAD, STORE,
@@ -14,9 +13,9 @@ pub fn decode_reg<F: PrimeField32>(f: F) -> u8 {
 /// OpenVM stores the lower 16 bits of the sign-extended immediate in `c`, and
 /// the sign bit in `g`. The full 32-bit value is reconstructed as:
 ///   imm = (c & 0xFFFF) + g * 0xFFFF0000
-pub fn decode_imm_cg<F: PrimeField32>(insn: &Instruction<F>) -> u32 {
-    let low16 = insn.c.as_canonical_u32() & 0xffff;
-    let is_neg = insn.g.as_canonical_u32() != 0;
+pub fn decode_imm_cg(insn: &RvrInstruction) -> u32 {
+    let low16 = insn.c & 0xffff;
+    let is_neg = insn.g != 0;
     low16.wrapping_add(if is_neg { 0xFFFF0000 } else { 0 })
 }
 

--- a/crates/rvr/rvr-openvm-lift/src/instruction.rs
+++ b/crates/rvr/rvr-openvm-lift/src/instruction.rs
@@ -1,0 +1,107 @@
+use openvm_instructions::{instruction::Instruction, VmOpcode};
+use openvm_stark_backend::p3_field::PrimeField32;
+
+/// Canonical integer representation of an OpenVM instruction used by rvr lifting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RvrInstruction {
+    pub opcode: VmOpcode,
+    pub a: u32,
+    pub b: u32,
+    pub c: u32,
+    pub d: u32,
+    pub e: u32,
+    pub f: u32,
+    pub g: u32,
+    signed_c: i32,
+}
+
+impl RvrInstruction {
+    /// Lower an OpenVM instruction to its canonical integer representation.
+    #[inline]
+    pub fn from_field<F: PrimeField32>(insn: &Instruction<F>) -> Self {
+        Self {
+            opcode: insn.opcode,
+            a: insn.a.as_canonical_u32(),
+            b: insn.b.as_canonical_u32(),
+            c: insn.c.as_canonical_u32(),
+            d: insn.d.as_canonical_u32(),
+            e: insn.e.as_canonical_u32(),
+            f: insn.f.as_canonical_u32(),
+            g: insn.g.as_canonical_u32(),
+            signed_c: decode_signed(insn.c.as_canonical_u32(), F::ORDER_U32),
+        }
+    }
+
+    pub const fn from_canonical(
+        opcode: VmOpcode,
+        [a, b, c, d, e, f, g]: [u32; 7],
+        field_order: u32,
+    ) -> Self {
+        Self {
+            opcode,
+            a,
+            b,
+            c,
+            d,
+            e,
+            f,
+            g,
+            signed_c: decode_signed(c, field_order),
+        }
+    }
+
+    #[inline]
+    pub const fn operands(&self) -> [u32; 7] {
+        [self.a, self.b, self.c, self.d, self.e, self.f, self.g]
+    }
+
+    #[inline]
+    pub const fn signed_c(&self) -> i32 {
+        self.signed_c
+    }
+}
+
+const fn decode_signed(value: u32, field_order: u32) -> i32 {
+    if value > field_order / 2 {
+        value.wrapping_sub(field_order) as i32
+    } else {
+        value as i32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openvm_instructions::{instruction::Instruction, VmOpcode};
+    use p3_baby_bear::BabyBear;
+
+    use super::*;
+
+    #[test]
+    fn lowers_all_operands_to_canonical_u32() {
+        let insn = Instruction::<BabyBear>::from_isize(VmOpcode::from_usize(7), 1, -1, 3, -4, 5);
+        let lowered = RvrInstruction::from_field(&insn);
+
+        assert_eq!(lowered.opcode, insn.opcode);
+        assert_eq!(lowered.a, 1);
+        assert_eq!(lowered.b, BabyBear::ORDER_U32 - 1);
+        assert_eq!(lowered.c, 3);
+        assert_eq!(lowered.d, BabyBear::ORDER_U32 - 4);
+        assert_eq!(lowered.e, 5);
+        assert_eq!(lowered.f, 0);
+        assert_eq!(lowered.g, 0);
+    }
+
+    #[test]
+    fn signed_decoding_uses_source_field_order() {
+        let insn = RvrInstruction::from_canonical(VmOpcode::from_usize(0), [0; 7], 101);
+        assert_eq!(insn.signed_c(), 0);
+
+        let insn =
+            RvrInstruction::from_canonical(VmOpcode::from_usize(0), [0, 0, 51, 0, 0, 0, 0], 101);
+        assert_eq!(insn.signed_c(), -50);
+
+        let insn =
+            RvrInstruction::from_canonical(VmOpcode::from_usize(0), [0, 0, 100, 0, 0, 0, 0], 101);
+        assert_eq!(insn.signed_c(), -1);
+    }
+}

--- a/crates/rvr/rvr-openvm-lift/src/instruction.rs
+++ b/crates/rvr/rvr-openvm-lift/src/instruction.rs
@@ -12,6 +12,10 @@ pub struct RvrInstruction {
     pub e: u32,
     pub f: u32,
     pub g: u32,
+    /// `c` interpreted as a signed integer in the source field.
+    ///
+    /// Branch and JAL offsets use this interpretation, while other opcodes
+    /// still need the canonical value in `c`.
     signed_c: i32,
 }
 
@@ -19,16 +23,17 @@ impl RvrInstruction {
     /// Lower an OpenVM instruction to its canonical integer representation.
     #[inline]
     pub fn from_field<F: PrimeField32>(insn: &Instruction<F>) -> Self {
+        let c = insn.c.as_canonical_u32();
         Self {
             opcode: insn.opcode,
             a: insn.a.as_canonical_u32(),
             b: insn.b.as_canonical_u32(),
-            c: insn.c.as_canonical_u32(),
+            c,
             d: insn.d.as_canonical_u32(),
             e: insn.e.as_canonical_u32(),
             f: insn.f.as_canonical_u32(),
             g: insn.g.as_canonical_u32(),
-            signed_c: decode_signed(insn.c.as_canonical_u32(), F::ORDER_U32),
+            signed_c: decode_signed(c, F::ORDER_U32),
         }
     }
 

--- a/crates/rvr/rvr-openvm-lift/src/lib.rs
+++ b/crates/rvr/rvr-openvm-lift/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cfg;
 pub mod convert;
 pub mod extension;
 pub mod helpers;
+pub mod instruction;
 pub mod opcode;
 
 pub use cfg::{build_blocks, CfgError};
@@ -22,6 +23,7 @@ pub use convert::{
 };
 pub use extension::{
     air_index_to_c, opcode_air_idx, AirIndex, ExtensionError, ExtensionRegistry, RvrExtension,
-    RvrExtensionCtx, TraceChipIndex, VmRvrExtension,
+    RvrExtensionCtx, RvrExtensions, RvrRuntimeExtension, TraceChipIndex, VmRvrExtension,
 };
 pub use helpers::{decode_imm_cg, decode_reg};
+pub use instruction::RvrInstruction;

--- a/crates/rvr/rvr-openvm-lift/src/opcode.rs
+++ b/crates/rvr/rvr-openvm-lift/src/opcode.rs
@@ -9,8 +9,7 @@
 //!   extensions.
 
 use openvm_instructions::{
-    instruction::Instruction,
-    riscv::{RV64_IMM_AS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
+    riscv::{RV64_IMM_AS, RV64_REGISTER_NUM_LIMBS},
     LocalOpcode, SysPhantom, SystemOpcode,
 };
 use openvm_riscv_transpiler::{
@@ -19,7 +18,6 @@ use openvm_riscv_transpiler::{
     Rv64AuipcOpcode, Rv64JalLuiOpcode, Rv64JalrOpcode, Rv64LoadStoreOpcode, ShiftOpcode,
     ShiftWOpcode,
 };
-use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ext_ffi_common::{AS_MEMORY, AS_PUBLIC_VALUES, AS_REGISTER};
 use rvr_openvm_ir::{
     AluOp, BranchCond, Instr, InstrAt, LiftedInstr, MemWidth, MulDivOp, Terminator,
@@ -27,7 +25,7 @@ use rvr_openvm_ir::{
 
 use crate::{
     helpers::{decode_imm_cg, sext32},
-    ExtensionRegistry,
+    ExtensionRegistry, RvrInstruction,
 };
 
 const U24_MASK: u32 = (1 << 24) - 1;
@@ -36,16 +34,16 @@ const U24_MASK: u32 = (1 << 24) - 1;
 ///
 /// Returns `None` for unrecognized opcodes. If a registered extension handles
 /// the opcode, its `try_lift` is called.
-pub fn lift_instruction<F: PrimeField32>(
-    insn: &Instruction<F>,
+pub fn lift_instruction(
+    insn: &RvrInstruction,
     pc: u64,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
 ) -> Option<LiftedInstr> {
     let opcode = insn.opcode.as_usize();
 
     // System opcodes
     if opcode == SystemOpcode::TERMINATE.global_opcode_usize() {
-        let exit_code = field_to_u32(insn.c);
+        let exit_code = insn.c;
         return Some(LiftedInstr::Term {
             pc,
             terminator: Terminator::Exit { code: exit_code },
@@ -53,7 +51,7 @@ pub fn lift_instruction<F: PrimeField32>(
         });
     }
     if opcode == SystemOpcode::PHANTOM.global_opcode_usize() {
-        let discriminant = (field_to_u32(insn.c) & 0xffff) as u16;
+        let discriminant = (insn.c & 0xffff) as u16;
         if let Some(sys) = SysPhantom::from_repr(discriminant) {
             return Some(lift_phantom(sys, pc));
         }
@@ -63,6 +61,9 @@ pub fn lift_instruction<F: PrimeField32>(
         return None;
     }
 
+    // Decode the e field to determine R-type vs I-type
+    let e = insn.e;
+
     // BaseAlu: ADD=0x200, SUB=0x201, XOR=0x202, OR=0x203, AND=0x204, ADDW=0x270, SUBW=0x271
     if opcode == BaseAluOpcode::ADD.global_opcode_usize() {
         return lift_alu_reg(insn, pc, AluOp::Add);
@@ -71,7 +72,6 @@ pub fn lift_instruction<F: PrimeField32>(
         return lift_alu_reg(insn, pc, AluOp::Sub);
     }
 
-    let e = field_to_u32(insn.e);
     if opcode == BaseAluOpcode::XOR.global_opcode_usize() {
         return Some(lift_alu(insn, pc, e, AluOp::Xor));
     }
@@ -259,26 +259,9 @@ pub fn lift_instruction<F: PrimeField32>(
 
 // ============= Helpers =============
 
-/// Convert a field element to u32.
-pub fn field_to_u32<F: PrimeField32>(f: F) -> u32 {
-    f.as_canonical_u32()
-}
-
-/// Convert a field element to i32 using modular arithmetic.
-/// Values > p/2 are interpreted as negative (i.e. the field encoding of a negative integer).
-pub fn field_to_i32<F: PrimeField32>(f: F) -> i32 {
-    let v = f.as_canonical_u32();
-    let p = F::ORDER_U32;
-    if v > p / 2 {
-        v.wrapping_sub(p) as i32
-    } else {
-        v as i32
-    }
-}
-
 /// Decode register index from OpenVM operand (divided by RV64_REGISTER_NUM_LIMBS).
-pub fn decode_reg<F: PrimeField32>(f: F) -> u8 {
-    (field_to_u32(f) / RV64_REGISTER_NUM_LIMBS as u32) as u8
+pub fn decode_reg(value: u32) -> u8 {
+    (value / RV64_REGISTER_NUM_LIMBS as u32) as u8
 }
 
 /// Sign-extend a 12-bit immediate stored in the low 24 bits.
@@ -311,8 +294,8 @@ pub fn term(pc: u64, terminator: Terminator) -> LiftedInstr {
     }
 }
 
-fn lift_alu_reg<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: AluOp) -> Option<LiftedInstr> {
-    if field_to_u32(insn.d) != RV64_REGISTER_AS || field_to_u32(insn.e) != RV64_REGISTER_AS {
+fn lift_alu_reg(insn: &RvrInstruction, pc: u64, op: AluOp) -> Option<LiftedInstr> {
+    if insn.d != AS_REGISTER || insn.e != AS_REGISTER {
         return None;
     }
 
@@ -326,7 +309,7 @@ fn lift_alu_reg<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: AluOp) -> O
 }
 
 /// Lift ALU instruction (R-type when e!=0, I-type when e==0).
-fn lift_alu<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_alu(insn: &RvrInstruction, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -339,7 +322,7 @@ fn lift_alu<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) 
         body(pc, Instr::AluReg { op, rd, rs1, rs2 })
     } else {
         // I-type: immediate in c as u24, sign-extend from 12 bits
-        let raw_imm = field_to_u32(insn.c) & U24_MASK;
+        let raw_imm = insn.c & U24_MASK;
         let imm = sign_extend_12(raw_imm);
         if rd == 0 {
             return body(pc, Instr::Nop);
@@ -348,12 +331,12 @@ fn lift_alu<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) 
     }
 }
 
-fn lift_alu_imm<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: AluOp) -> Option<LiftedInstr> {
-    if field_to_u32(insn.d) != RV64_REGISTER_AS || field_to_u32(insn.e) != RV64_IMM_AS {
+fn lift_alu_imm(insn: &RvrInstruction, pc: u64, op: AluOp) -> Option<LiftedInstr> {
+    if insn.d != AS_REGISTER || insn.e != RV64_IMM_AS {
         return None;
     }
 
-    let raw_imm = field_to_u32(insn.c);
+    let raw_imm = insn.c;
     let imm = sign_extend_12(raw_imm);
     if raw_imm != (imm as u32 & U24_MASK) {
         return None;
@@ -368,7 +351,7 @@ fn lift_alu_imm<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: AluOp) -> O
 }
 
 /// Lift shift instruction (R-type when e!=0, I-type shamt when e==0).
-fn lift_shift<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_shift(insn: &RvrInstruction, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -381,7 +364,7 @@ fn lift_shift<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp
         body(pc, Instr::AluReg { op, rd, rs1, rs2 })
     } else {
         // I-type shamt: 6-bit for rv64 (registers are 64-bit wide)
-        let shamt = (field_to_u32(insn.c) & 0x3f) as u8;
+        let shamt = (insn.c & 0x3f) as u8;
         if rd == 0 {
             return body(pc, Instr::Nop);
         }
@@ -390,7 +373,7 @@ fn lift_shift<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp
 }
 
 /// Lift MUL/DIV/REM R-type instruction.
-fn lift_muldiv<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: MulDivOp) -> LiftedInstr {
+fn lift_muldiv(insn: &RvrInstruction, pc: u64, op: MulDivOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
     let rs2 = decode_reg(insn.c);
@@ -401,19 +384,19 @@ fn lift_muldiv<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: MulDivOp) ->
 }
 
 #[inline]
-fn is_memory_instruction<F: PrimeField32>(insn: &Instruction<F>) -> bool {
-    field_to_u32(insn.d) == AS_REGISTER && field_to_u32(insn.e) == AS_MEMORY
+fn is_memory_instruction(insn: &RvrInstruction) -> bool {
+    insn.d == AS_REGISTER && insn.e == AS_MEMORY
 }
 
 #[inline]
-fn is_public_values_instruction<F: PrimeField32>(insn: &Instruction<F>) -> bool {
-    field_to_u32(insn.d) == AS_REGISTER && field_to_u32(insn.e) == AS_PUBLIC_VALUES
+fn is_public_values_instruction(insn: &RvrInstruction) -> bool {
+    insn.d == AS_REGISTER && insn.e == AS_PUBLIC_VALUES
 }
 
-fn lift_public_values_store<F: PrimeField32>(
-    insn: &Instruction<F>,
+fn lift_public_values_store(
+    insn: &RvrInstruction,
     pc: u64,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
 ) -> Option<LiftedInstr> {
     if is_public_values_instruction(insn) {
         extensions.try_lift(insn, pc)
@@ -424,12 +407,7 @@ fn lift_public_values_store<F: PrimeField32>(
 
 /// Lift load instruction.
 /// OpenVM encoding: rd=a/8, rs1=b/8, imm low16=c, sign=g!=0
-fn lift_load<F: PrimeField32>(
-    insn: &Instruction<F>,
-    pc: u64,
-    width: MemWidth,
-    signed: bool,
-) -> Option<LiftedInstr> {
+fn lift_load(insn: &RvrInstruction, pc: u64, width: MemWidth, signed: bool) -> Option<LiftedInstr> {
     if !is_memory_instruction(insn) {
         return None;
     }
@@ -455,11 +433,7 @@ fn lift_load<F: PrimeField32>(
 
 /// Lift store instruction.
 /// OpenVM encoding: rs2=a/8, rs1=b/8, imm low16=c, sign=g!=0
-fn lift_store<F: PrimeField32>(
-    insn: &Instruction<F>,
-    pc: u64,
-    width: MemWidth,
-) -> Option<LiftedInstr> {
+fn lift_store(insn: &RvrInstruction, pc: u64, width: MemWidth) -> Option<LiftedInstr> {
     if !is_memory_instruction(insn) {
         return None;
     }
@@ -481,10 +455,10 @@ fn lift_store<F: PrimeField32>(
 
 /// Lift branch instruction.
 /// OpenVM encoding: rs1=a/8, rs2=b/8, offset=c as signed (BabyBear modular)
-fn lift_branch<F: PrimeField32>(insn: &Instruction<F>, pc: u64, cond: BranchCond) -> LiftedInstr {
+fn lift_branch(insn: &RvrInstruction, pc: u64, cond: BranchCond) -> LiftedInstr {
     let rs1 = decode_reg(insn.a);
     let rs2 = decode_reg(insn.b);
-    let offset = field_to_i32(insn.c);
+    let offset = insn.signed_c();
     let target = (pc as i64 + offset as i64) as u64;
 
     term(
@@ -500,9 +474,9 @@ fn lift_branch<F: PrimeField32>(insn: &Instruction<F>, pc: u64, cond: BranchCond
 
 /// Lift JAL instruction.
 /// OpenVM encoding: rd=a/8, offset=c as signed (BabyBear modular)
-fn lift_jal<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
+fn lift_jal(insn: &RvrInstruction, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
-    let offset = field_to_i32(insn.c);
+    let offset = insn.signed_c();
     let target = (pc as i64 + offset as i64) as u64;
 
     let link_rd = if rd != 0 { Some(rd) } else { None };
@@ -511,7 +485,7 @@ fn lift_jal<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
 
 /// Lift JALR instruction.
 /// OpenVM encoding: rd=a/8, rs1=b/8, imm low16=c, sign=g!=0
-fn lift_jalr<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
+fn lift_jalr(insn: &RvrInstruction, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
     let imm = decode_imm_cg(insn) as i32;
@@ -530,9 +504,9 @@ fn lift_jalr<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
 
 /// Lift LUI instruction.
 /// OpenVM encoding: rd=a/8, upper20=c << 12
-fn lift_lui<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
+fn lift_lui(insn: &RvrInstruction, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
-    let upper = field_to_u32(insn.c);
+    let upper = insn.c;
     let value = upper << 12;
 
     if rd == 0 {
@@ -543,9 +517,9 @@ fn lift_lui<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
 
 /// Lift AUIPC instruction.
 /// OpenVM encoding: rd=a/8, upper20 = c << 8 (from rrs.rs: c = (imm & 0xfffff000) >> 8)
-fn lift_auipc<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
+fn lift_auipc(insn: &RvrInstruction, pc: u64) -> LiftedInstr {
     let rd = decode_reg(insn.a);
-    let shifted = field_to_u32(insn.c);
+    let shifted = insn.c;
     let upper = shifted << 8; // reconstruct the upper 20 bits with low 12 zeros
     let value = pc.wrapping_add(sext32(upper));
 
@@ -557,7 +531,7 @@ fn lift_auipc<F: PrimeField32>(insn: &Instruction<F>, pc: u64) -> LiftedInstr {
 
 /// Lift W-suffix ALU instruction (R-type when e!=0, I-type when e==0).
 /// Result is the low 32 bits of the operation, sign-extended to 64 bits.
-fn lift_alu_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_alu_w(insn: &RvrInstruction, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -568,7 +542,7 @@ fn lift_alu_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp
         }
         body(pc, Instr::AluWReg { op, rd, rs1, rs2 })
     } else {
-        let raw_imm = field_to_u32(insn.c) & U24_MASK;
+        let raw_imm = insn.c & U24_MASK;
         let imm = sign_extend_12(raw_imm);
         if rd == 0 {
             return body(pc, Instr::Nop);
@@ -579,7 +553,7 @@ fn lift_alu_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp
 
 /// Lift W-suffix shift instruction (R-type when e!=0, I-type shamt when e==0).
 /// Shamt is 5-bit (W shifts operate on 32-bit values regardless of register width).
-fn lift_shift_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
+fn lift_shift_w(insn: &RvrInstruction, pc: u64, e: u32, op: AluOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
 
@@ -590,7 +564,7 @@ fn lift_shift_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: Alu
         }
         body(pc, Instr::AluWReg { op, rd, rs1, rs2 })
     } else {
-        let shamt = (field_to_u32(insn.c) & 0x1f) as u8;
+        let shamt = (insn.c & 0x1f) as u8;
         if rd == 0 {
             return body(pc, Instr::Nop);
         }
@@ -599,7 +573,7 @@ fn lift_shift_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, e: u32, op: Alu
 }
 
 /// Lift W-suffix MUL/DIV/REM R-type instruction.
-fn lift_muldiv_w<F: PrimeField32>(insn: &Instruction<F>, pc: u64, op: MulDivOp) -> LiftedInstr {
+fn lift_muldiv_w(insn: &RvrInstruction, pc: u64, op: MulDivOp) -> LiftedInstr {
     let rd = decode_reg(insn.a);
     let rs1 = decode_reg(insn.b);
     let rs2 = decode_reg(insn.c);
@@ -635,15 +609,25 @@ mod tests {
         LocalOpcode, DEFERRAL_AS, PUBLIC_VALUES_AS,
     };
     use openvm_riscv_transpiler::{
-        BaseAluImmOpcode, BaseAluOpcode, Rv64AuipcOpcode,
+        BaseAluImmOpcode, BaseAluOpcode, BranchEqualOpcode, Rv64AuipcOpcode, Rv64JalLuiOpcode,
         Rv64LoadStoreOpcode::{
             LOADB, LOADBU, LOADD, LOADH, LOADHU, LOADW, LOADWU, STOREB, STORED, STOREH, STOREW,
         },
     };
     use p3_baby_bear::BabyBear;
 
-    use super::{lift_instruction, AluOp, Instr, InstrAt, LiftedInstr, AS_MEMORY, AS_REGISTER};
-    use crate::ExtensionRegistry;
+    use super::{
+        lift_instruction, AluOp, Instr, InstrAt, LiftedInstr, Terminator, AS_MEMORY, AS_REGISTER,
+    };
+    use crate::{ExtensionRegistry, RvrInstruction};
+
+    fn lift_babybear(
+        insn: &Instruction<BabyBear>,
+        pc: u64,
+        extensions: &ExtensionRegistry,
+    ) -> Option<LiftedInstr> {
+        lift_instruction(&RvrInstruction::from_field(insn), pc, extensions)
+    }
 
     fn base_alu_reg_instruction(opcode: BaseAluOpcode, e: u32) -> Instruction<BabyBear> {
         Instruction::from_usize(
@@ -660,14 +644,14 @@ mod tests {
 
     #[test]
     fn add_sub_require_register_operands() {
-        let extensions = ExtensionRegistry::<BabyBear>::new();
+        let extensions = ExtensionRegistry::new();
 
         for (opcode, expected_op) in [
             (BaseAluOpcode::ADD, AluOp::Add),
             (BaseAluOpcode::SUB, AluOp::Sub),
         ] {
             let valid = base_alu_reg_instruction(opcode, RV64_REGISTER_AS);
-            match lift_instruction(&valid, 0x100, &extensions) {
+            match lift_babybear(&valid, 0x100, &extensions) {
                 Some(LiftedInstr::Body(InstrAt {
                     instr: Instr::AluReg { op, .. },
                     ..
@@ -676,13 +660,13 @@ mod tests {
             }
 
             let immediate = base_alu_reg_instruction(opcode, RV64_IMM_AS);
-            assert!(lift_instruction(&immediate, 0x100, &extensions).is_none());
+            assert!(lift_babybear(&immediate, 0x100, &extensions).is_none());
         }
     }
 
     #[test]
     fn addi_requires_canonical_immediate_encoding() {
-        let extensions = ExtensionRegistry::<BabyBear>::new();
+        let extensions = ExtensionRegistry::new();
         let valid = Instruction::<BabyBear>::from_usize(
             BaseAluImmOpcode::ADDI.global_opcode(),
             [
@@ -694,7 +678,7 @@ mod tests {
             ],
         );
 
-        match lift_instruction(&valid, 0x100, &extensions) {
+        match lift_babybear(&valid, 0x100, &extensions) {
             Some(LiftedInstr::Body(InstrAt {
                 instr:
                     Instr::AluImm {
@@ -718,7 +702,7 @@ mod tests {
                 RV64_REGISTER_AS as usize,
             ],
         );
-        assert!(lift_instruction(&register_operand, 0x100, &extensions).is_none());
+        assert!(lift_babybear(&register_operand, 0x100, &extensions).is_none());
 
         let noncanonical_immediate = Instruction::<BabyBear>::from_usize(
             BaseAluImmOpcode::ADDI.global_opcode(),
@@ -730,12 +714,12 @@ mod tests {
                 RV64_IMM_AS as usize,
             ],
         );
-        assert!(lift_instruction(&noncanonical_immediate, 0x100, &extensions).is_none());
+        assert!(lift_babybear(&noncanonical_immediate, 0x100, &extensions).is_none());
     }
 
     #[test]
     fn load_store_address_space_domain() {
-        let extensions = ExtensionRegistry::<BabyBear>::new();
+        let extensions = ExtensionRegistry::new();
 
         for opcode in [LOADD, LOADBU, LOADHU, LOADWU, LOADB, LOADH, LOADW] {
             let inst = Instruction::<BabyBear>::from_usize(
@@ -743,7 +727,7 @@ mod tests {
                 [8, 16, 0, 1, DEFERRAL_AS as usize, 1, 0],
             );
 
-            assert!(lift_instruction(&inst, 0x100, &extensions).is_none());
+            assert!(lift_babybear(&inst, 0x100, &extensions).is_none());
         }
 
         for opcode in [STORED, STOREW, STOREH, STOREB] {
@@ -751,19 +735,19 @@ mod tests {
                 opcode.global_opcode(),
                 [8, 16, 0, 1, DEFERRAL_AS as usize, 1, 0],
             );
-            assert!(lift_instruction(&deferral_inst, 0x100, &extensions).is_none());
+            assert!(lift_babybear(&deferral_inst, 0x100, &extensions).is_none());
 
             let public_values_inst = Instruction::<BabyBear>::from_usize(
                 opcode.global_opcode(),
                 [8, 16, 0, 1, PUBLIC_VALUES_AS as usize, 1, 0],
             );
-            assert!(lift_instruction(&public_values_inst, 0x100, &extensions).is_none());
+            assert!(lift_babybear(&public_values_inst, 0x100, &extensions).is_none());
         }
     }
 
     #[test]
     fn load_store_requires_register_destination_address_space() {
-        let extensions = ExtensionRegistry::<BabyBear>::new();
+        let extensions = ExtensionRegistry::new();
 
         for opcode in [LOADD, LOADBU, LOADHU, LOADWU, LOADB, LOADH, LOADW] {
             let inst = Instruction::<BabyBear>::from_usize(
@@ -771,7 +755,7 @@ mod tests {
                 [8, 16, 0, AS_MEMORY as usize, AS_MEMORY as usize, 1, 0],
             );
 
-            assert!(lift_instruction(&inst, 0x100, &extensions).is_none());
+            assert!(lift_babybear(&inst, 0x100, &extensions).is_none());
         }
 
         for opcode in [STORED, STOREW, STOREH, STOREB] {
@@ -779,7 +763,7 @@ mod tests {
                 opcode.global_opcode(),
                 [8, 16, 0, AS_MEMORY as usize, AS_MEMORY as usize, 1, 0],
             );
-            assert!(lift_instruction(&memory_inst, 0x100, &extensions).is_none());
+            assert!(lift_babybear(&memory_inst, 0x100, &extensions).is_none());
 
             let public_values_inst = Instruction::<BabyBear>::from_usize(
                 opcode.global_opcode(),
@@ -793,13 +777,13 @@ mod tests {
                     0,
                 ],
             );
-            assert!(lift_instruction(&public_values_inst, 0x100, &extensions).is_none());
+            assert!(lift_babybear(&public_values_inst, 0x100, &extensions).is_none());
 
             let valid_memory_inst = Instruction::<BabyBear>::from_usize(
                 opcode.global_opcode(),
                 [8, 16, 0, AS_REGISTER as usize, AS_MEMORY as usize, 1, 0],
             );
-            assert!(lift_instruction(&valid_memory_inst, 0x100, &extensions).is_some());
+            assert!(lift_babybear(&valid_memory_inst, 0x100, &extensions).is_some());
         }
     }
 
@@ -811,7 +795,7 @@ mod tests {
             [8, 0, 0x80_0000],
         );
 
-        let lifted = lift_instruction(&insn, pc, &ExtensionRegistry::default());
+        let lifted = lift_babybear(&insn, pc, &ExtensionRegistry::default());
         match lifted {
             Some(LiftedInstr::Body(InstrAt {
                 pc: lifted_pc,
@@ -822,6 +806,55 @@ mod tests {
                 assert_eq!(rd, 1);
                 assert_eq!(value, 0xffff_ffff_8000_1000);
             }
+            other => panic!("unexpected lift: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn jal_preserves_negative_field_encoded_offset() {
+        let pc = 0x1000;
+        let insn = Instruction::<BabyBear>::from_isize(
+            Rv64JalLuiOpcode::JAL.global_opcode(),
+            8,
+            0,
+            -12,
+            0,
+            0,
+        );
+
+        let lifted = lift_babybear(&insn, pc, &ExtensionRegistry::default());
+        match lifted {
+            Some(LiftedInstr::Term {
+                pc: lifted_pc,
+                terminator: Terminator::Jump { link_rd, target },
+                ..
+            }) => {
+                assert_eq!(lifted_pc, pc);
+                assert_eq!(link_rd, Some(1));
+                assert_eq!(target, pc - 12);
+            }
+            other => panic!("unexpected lift: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn branch_preserves_negative_field_encoded_offset() {
+        let pc = 0x1000;
+        let insn = Instruction::<BabyBear>::from_isize(
+            BranchEqualOpcode::BEQ.global_opcode(),
+            8,
+            16,
+            -12,
+            0,
+            0,
+        );
+
+        let lifted = lift_babybear(&insn, pc, &ExtensionRegistry::default());
+        match lifted {
+            Some(LiftedInstr::Term {
+                terminator: Terminator::Branch { target, .. },
+                ..
+            }) => assert_eq!(target, pc - 12),
             other => panic!("unexpected lift: {other:?}"),
         }
     }

--- a/crates/rvr/rvr-openvm/Cargo.toml
+++ b/crates/rvr/rvr-openvm/Cargo.toml
@@ -16,7 +16,6 @@ rvr-openvm-lift.workspace = true
 openvm-instructions.workspace = true
 openvm-platform.workspace = true
 openvm-riscv-guest = { workspace = true, default-features = false }
-openvm-stark-backend.workspace = true
 thiserror.workspace = true
 
 [features]

--- a/crates/rvr/rvr-openvm/c/Makefile
+++ b/crates/rvr/rvr-openvm/c/Makefile
@@ -2,7 +2,7 @@ CC ?= clang-22
 LINKER ?= lld
 OPT ?= -O3
 DEBUG ?=
-CFLAGS = -std=c23 $(OPT) $(DEBUG) -Wall -Wno-unused-variable -Wno-unused-function -Wno-unused-parameter -fPIC -march=native -falign-functions=32
+CFLAGS = -std=c2y $(OPT) $(DEBUG) -Wall -Wno-unused-variable -Wno-unused-function -Wno-unused-parameter -fPIC -march=native -falign-functions=32
 LTO ?=
 CFLAGS += $(LTO)
 LDFLAGS ?=

--- a/crates/rvr/rvr-openvm/c/openvm_io.c
+++ b/crates/rvr/rvr-openvm/c/openvm_io.c
@@ -5,16 +5,15 @@
 
 #include "openvm_io.h"
 
-/* NOT thread-safe: installs one process-global IO ctx pointer. */
-static void* g_io_ctx;
+static thread_local void* g_io_ctx;
 
 void register_openvm_io_ctx(void* ctx) { g_io_ctx = ctx; }
 
 void* openvm_get_io_ctx(void) { return g_io_ctx; }
 
-/* NOT thread-safe: installs one process-global hint-stream writer. */
-static void (*g_hint_stream_set_fn)(void* ctx, const uint8_t* data,
-                                    uint32_t len);
+static thread_local void (*g_hint_stream_set_fn)(void* ctx,
+                                                 const uint8_t* data,
+                                                 uint32_t len);
 
 void register_hint_stream_set_fn(void (*fn)(void*, const uint8_t*, uint32_t)) {
   g_hint_stream_set_fn = fn;

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -15,10 +15,10 @@
 static constexpr uint32_t NO_LAST_PAGE = UINT32_MAX;
 
 static constexpr uint32_t MAX_PV_PAGES_PER_INSN = 1;
-_Static_assert(
+static_assert(
     TRACER_MEM_PAGE_BUF_CAP >= 2 * TRACER_SEGMENT_CHECK_INSNS * TRACER_MAX_MEM_PAGES_PER_INSN,
     "MEM_PAGE_BUF_CAP too small for worst-case pages per flush interval");
-_Static_assert(
+static_assert(
     TRACER_PV_PAGE_BUF_CAP >= 2 * TRACER_SEGMENT_CHECK_INSNS * MAX_PV_PAGES_PER_INSN,
     "PV_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 /* No static assert for DEFERRAL — justifying the capacity is a TODO

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -7,7 +7,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::*;
 use rvr_openvm_lift::{ExtensionRegistry, TraceChipIndex};
 
@@ -373,12 +372,12 @@ impl CProject {
     }
 
     /// Write all C project files.
-    pub fn write_all<F: PrimeField32>(
+    pub fn write_all(
         &self,
         blocks: &[Block],
         entry_point: u64,
         text_start: u64,
-        extensions: &ExtensionRegistry<F>,
+        extensions: &ExtensionRegistry,
     ) -> io::Result<()> {
         let text_end = Self::dispatch_max_pc(blocks, entry_point, text_start);
         let table_size = Self::dispatch_table_size(text_start, text_end);
@@ -483,10 +482,7 @@ impl CProject {
 
     // ── Extension files ─────────────────────────────────────────────────
 
-    fn write_extension_files<F: PrimeField32>(
-        &self,
-        extensions: &ExtensionRegistry<F>,
-    ) -> io::Result<()> {
+    fn write_extension_files(&self, extensions: &ExtensionRegistry) -> io::Result<()> {
         let mut created_dirs = HashSet::new();
         self.write_embedded_files(extensions.c_headers(), &mut created_dirs)?;
         self.write_embedded_files(extensions.c_sources(), &mut created_dirs)?;

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -27,7 +27,7 @@ use openvm_stark_backend::{p3_field::Field, StarkEngine, StarkProtocolConfig, Va
 use openvm_stark_sdk::config::baby_bear_poseidon2::F;
 use openvm_transpiler::transpiler::Transpiler;
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::RvrExtensions;
 use serde::{Deserialize, Serialize};
 
 pub mod deferral;
@@ -351,7 +351,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    fn create_rvr_extensions(&self, air_idx: Option<&[usize]>) -> ExtensionRegistry<F>
+    fn create_rvr_extensions(&self, air_idx: Option<&[usize]>) -> RvrExtensions
     where
         F: PrimeField32,
     {

--- a/crates/sdk/src/compiled.rs
+++ b/crates/sdk/src/compiled.rs
@@ -17,17 +17,14 @@ use openvm_circuit::arch::{
 #[cfg(feature = "rvr")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "rvr")]
-use crate::F;
-
 cfg_if::cfg_if! {
     if #[cfg(feature = "rvr")] {
         use openvm_circuit::arch::rvr::{
             RvrMeteredCostInstance, RvrMeteredInstance, RvrPureInstance,
         };
-        pub type CompiledExePure<'a> = RvrPureInstance<'a, F>;
-        pub type MeteredInstance<'a> = RvrMeteredInstance<'a, F>;
-        pub type MeteredCostInstance<'a> = RvrMeteredCostInstance<'a, F>;
+        pub type CompiledExePure<'a> = RvrPureInstance<'a>;
+        pub type MeteredInstance<'a> = RvrMeteredInstance<'a>;
+        pub type MeteredCostInstance<'a> = RvrMeteredCostInstance<'a>;
     } else if #[cfg(feature = "aot")] {
         use openvm_circuit::arch::AotInstance;
         pub type CompiledExePure<'a> = AotInstance<'a, ExecutionCtx>;

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -925,7 +925,7 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
         extend_rvr.push(quote! {
             <#extension_ty as ::rvr_openvm_lift::VmRvrExtension<F>>::extend_rvr(
                 &self.#ext_field_name,
-                &mut registry,
+                &mut extensions,
                 ctx.as_ref(),
             );
         });
@@ -980,7 +980,7 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
             fn create_rvr_extensions(
                 &self,
                 air_idx: Option<&[usize]>,
-            ) -> ::rvr_openvm_lift::ExtensionRegistry<F>
+            ) -> ::rvr_openvm_lift::RvrExtensions
             {
                 let ctx = air_idx.map(|air_idx| {
                     let inventory = <Self as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_executors(self)
@@ -991,12 +991,12 @@ fn generate_config_traits_impl(name: &Ident, inner: &DataStruct) -> syn::Result<
                         .map(|(opcode, executor_idx)| (*opcode, *executor_idx as usize));
                     ::rvr_openvm_lift::RvrExtensionCtx::new(opcode_to_executor_idx, air_idx.to_vec())
                 });
-                let mut registry = <#source_field_ty as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_rvr_extensions(
+                let mut extensions = <#source_field_ty as ::openvm_circuit::arch::VmExecutionConfig<F>>::create_rvr_extensions(
                     &self.#source_name,
                     air_idx,
                 );
                 #(#extend_rvr)*
-                registry
+                extensions
             }
         }
 

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -18,7 +18,7 @@ use openvm_stark_backend::{
     p3_field::Field, EngineDeviceCtx, StarkEngine, StarkProtocolConfig, Val,
 };
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::RvrExtensions;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::{AnyEnum, VmChipComplex, BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, PROGRAM_AIR_ID};
@@ -139,7 +139,7 @@ pub trait VmExecutionConfig<F> {
         -> Result<ExecutorInventory<Self::Executor>, ExecutorInventoryError>;
 
     #[cfg(feature = "rvr")]
-    fn create_rvr_extensions(&self, air_idx: Option<&[usize]>) -> ExtensionRegistry<F>
+    fn create_rvr_extensions(&self, air_idx: Option<&[usize]>) -> RvrExtensions
     where
         F: PrimeField32;
 }

--- a/crates/vm/src/arch/rvr/bridge.rs
+++ b/crates/vm/src/arch/rvr/bridge.rs
@@ -5,8 +5,6 @@
 //! `Streams` and the host RNG are borrowed directly into [`OpenVmIoState`]
 //! and never converted upfront.
 
-use std::mem::{align_of, size_of};
-
 use openvm_instructions::{
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
     DEFERRAL_AS,
@@ -35,17 +33,9 @@ pub fn public_values_slice(memory: &mut AddressMap) -> &mut [u8] {
     memory.mem[PUBLIC_VALUES_AS as usize].as_mut_slice()
 }
 
-/// Raw alias of the `F`-typed DEFERRAL address space.
-/// The returned length is in `F` cells, not bytes.
-pub fn deferral_memory_ptr<F>(memory: &mut AddressMap) -> (*mut F, usize) {
+pub fn deferral_memory_ptr(memory: &mut AddressMap) -> (*mut u8, usize) {
     let bytes = memory.mem[DEFERRAL_AS as usize].as_mut_slice();
-    debug_assert_eq!(
-        bytes.as_mut_ptr().addr() % align_of::<F>(),
-        0,
-        "DEFERRAL_AS buffer must be aligned for F"
-    );
-    debug_assert_eq!(bytes.len() % size_of::<F>(), 0);
-    (bytes.as_mut_ptr().cast::<F>(), bytes.len() / size_of::<F>())
+    (bytes.as_mut_ptr(), bytes.len())
 }
 
 pub fn read_rv64_registers(vm_state: &VmState<GuestMemory>) -> [u64; NUM_REGS_I] {

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -184,10 +184,7 @@ pub fn build_pc_to_chip<F, E>(
     exe: &VmExe<F>,
     inventory: &ExecutorInventory<E>,
     executor_idx_to_air_idx: &[usize],
-) -> Result<Vec<TraceChipIndex>, CompileError>
-where
-    F: PrimeField32,
-{
+) -> Result<Vec<TraceChipIndex>, CompileError> {
     let terminate_opcode = SystemOpcode::TERMINATE.global_opcode();
     exe.program
         .instructions_and_debug_infos
@@ -215,11 +212,11 @@ where
 }
 
 /// Options for the compilation pipeline.
-pub struct CompileOptions<'a, F: PrimeField32> {
+pub struct CompileOptions<'a> {
     /// Base name for generated files and library artifact.
     pub base_name: Option<&'a str>,
     pub tracer_mode: TracerMode,
-    pub extensions: &'a ExtensionRegistry<F>,
+    pub extensions: &'a ExtensionRegistry,
     pub chips: Option<&'a ChipMapping>,
     /// Guest debug map: OpenVM PC -> SourceLoc.
     pub guest_debug_map: Option<&'a GuestDebugMap>,
@@ -232,7 +229,7 @@ pub struct CompileOptions<'a, F: PrimeField32> {
 
 pub fn compile_with_options<F: PrimeField32>(
     exe: &VmExe<F>,
-    opts: CompileOptions<'_, F>,
+    opts: CompileOptions<'_>,
 ) -> Result<RvrCompiled, CompileError> {
     compile_impl(exe, &opts)
 }
@@ -240,7 +237,7 @@ pub fn compile_with_options<F: PrimeField32>(
 /// Compile a VmExe into a shared library (pure execution, optional suspension).
 pub fn compile<F: PrimeField32>(
     exe: &VmExe<F>,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
     guest_debug_map: Option<&GuestDebugMap>,
 ) -> Result<RvrCompiled, CompileError> {
     compile_impl(
@@ -261,7 +258,7 @@ pub fn compile<F: PrimeField32>(
 /// Compile a VmExe with per-chip metered execution.
 pub fn compile_metered<F: PrimeField32>(
     exe: &VmExe<F>,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
     chips: &ChipMapping,
     guest_debug_map: Option<&GuestDebugMap>,
 ) -> Result<RvrCompiled, CompileError> {
@@ -283,7 +280,7 @@ pub fn compile_metered<F: PrimeField32>(
 /// Compile a VmExe with per-chip metered execution and segment-boundary suspension.
 pub fn compile_metered_segment_boundary<F: PrimeField32>(
     exe: &VmExe<F>,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
     chips: &ChipMapping,
     guest_debug_map: Option<&GuestDebugMap>,
 ) -> Result<RvrCompiled, CompileError> {
@@ -305,7 +302,7 @@ pub fn compile_metered_segment_boundary<F: PrimeField32>(
 /// Compile a VmExe with metered cost tracer.
 pub fn compile_metered_cost<F: PrimeField32>(
     exe: &VmExe<F>,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
     chips: &ChipMapping,
     guest_debug_map: Option<&GuestDebugMap>,
 ) -> Result<RvrCompiled, CompileError> {
@@ -348,7 +345,7 @@ pub fn load_compiled_from_path(lib_path: &Path) -> Result<RvrCompiled, CompileEr
 
 fn compile_impl<F: PrimeField32>(
     exe: &VmExe<F>,
-    opts: &CompileOptions<'_, F>,
+    opts: &CompileOptions<'_>,
 ) -> Result<RvrCompiled, CompileError> {
     let toolchain = ensure_toolchain_available()?;
 
@@ -360,7 +357,7 @@ fn compile_impl<F: PrimeField32>(
     })?;
 
     let valid_pcs: std::collections::HashSet<u64> = ir.iter().map(|li| li.pc()).collect();
-    let extra_targets = scan_init_memory_for_code_pointers(exe, &valid_pcs);
+    let extra_targets = scan_init_memory_for_code_pointers(&exe.init_memory, &valid_pcs);
     let blocks = build_blocks(&ir, &extra_targets)?;
 
     let temp_root = std::env::temp_dir();
@@ -474,9 +471,9 @@ pub fn ensure_toolchain_available() -> Result<rvr_openvm::RuntimeToolchain, Comp
     Ok(rvr_openvm::runtime_toolchain()?)
 }
 
-fn write_extension_staticlibs<F: PrimeField32>(
+fn write_extension_staticlibs(
     output_dir: &Path,
-    extensions: &ExtensionRegistry<F>,
+    extensions: &ExtensionRegistry,
 ) -> Result<Vec<PathBuf>, CompileError> {
     let mut paths = Vec::new();
     for (filename, content) in extensions.staticlib_files() {

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -7,8 +7,7 @@
 
 use std::ffi::c_void;
 
-use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_lift::{ExtensionError, ExtensionRegistry};
+use rvr_openvm_lift::{ExtensionError, RvrRuntimeExtension};
 use rvr_state::{ExecutionStatus, MemoryError, Rv64, RvState, SuspenderState, TracerState};
 
 use super::{
@@ -54,12 +53,10 @@ pub enum ExecuteError {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-fn build_io_state_borrowed<'a, F: PrimeField32>(
-    vm_state: &'a mut VmState<GuestMemory>,
-) -> OpenVmIoState<'a, F> {
+fn build_io_state_borrowed(vm_state: &mut VmState<GuestMemory>) -> OpenVmIoState<'_> {
     let memory_ptr = rv64_memory_ptr(vm_state);
-    let (deferral_memory, deferral_memory_len) =
-        deferral_memory_ptr::<F>(&mut vm_state.memory.memory);
+    let (deferral_memory, deferral_memory_len_bytes) =
+        deferral_memory_ptr(&mut vm_state.memory.memory);
     let streams = &mut vm_state.streams;
     OpenVmIoState {
         input_stream: &mut streams.input_stream,
@@ -68,7 +65,7 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
         memory_ptr,
         public_values: public_values_slice(&mut vm_state.memory.memory),
         deferral_memory,
-        deferral_memory_len,
+        deferral_memory_len_bytes,
         deferrals: &mut streams.deferrals,
     }
 }
@@ -79,9 +76,9 @@ fn build_io_state_borrowed<'a, F: PrimeField32>(
 /// `register_openvm_io_ctx` and `register_hint_stream_set_fn` with the expected
 /// ABIs. `io_state` must remain valid for the lifetime of the subsequent
 /// `rv_execute` call.
-unsafe fn register_openvm_io_ctx<F: PrimeField32>(
+unsafe fn register_openvm_io_ctx(
     compiled: &RvrCompiled,
-    io_state: &mut OpenVmIoState<'_, F>,
+    io_state: &mut OpenVmIoState<'_>,
 ) -> Result<(), ExecuteError> {
     let register_fn: RegisterIoCtxFn = unsafe {
         let sym = compiled
@@ -90,7 +87,7 @@ unsafe fn register_openvm_io_ctx<F: PrimeField32>(
             .map_err(|e| ExecuteError::SymbolLookup(e.to_string()))?;
         *sym
     };
-    unsafe { register_fn(io_state as *mut OpenVmIoState<'_, F> as *mut c_void) };
+    unsafe { register_fn(io_state as *mut OpenVmIoState<'_> as *mut c_void) };
 
     let register_hint_fn: RegisterHintStreamSetFn = unsafe {
         let sym = compiled
@@ -99,7 +96,7 @@ unsafe fn register_openvm_io_ctx<F: PrimeField32>(
             .map_err(|e| ExecuteError::SymbolLookup(e.to_string()))?;
         *sym
     };
-    unsafe { register_hint_fn(host_hint_stream_set::<F>) };
+    unsafe { register_hint_fn(host_hint_stream_set) };
 
     Ok(())
 }
@@ -130,22 +127,23 @@ pub unsafe fn rv_execute(
 ///
 /// `allow_suspended` permits `Suspended` as a successful outcome (the
 /// limit-armed callers pass `true`; unlimited callers pass `false`).
-fn run_and_finalize<F, T, S>(
+fn run_and_finalize<T, S>(
     compiled: &RvrCompiled,
-    extensions: &ExtensionRegistry<F>,
+    runtime_hooks: &[Box<dyn RvrRuntimeExtension>],
     vm_state: &mut VmState<GuestMemory>,
     state: &mut RvState<Rv64, T, S>,
     allow_suspended: bool,
 ) -> Result<ExecutionStatus, ExecuteError>
 where
-    F: PrimeField32,
     T: TracerState,
     S: SuspenderState,
 {
-    let mut io_state = build_io_state_borrowed::<F>(vm_state);
+    let mut io_state = build_io_state_borrowed(vm_state);
     unsafe {
         register_openvm_io_ctx(compiled, &mut io_state)?;
-        extensions.register_host_callbacks(&compiled.lib)?;
+        for hook in runtime_hooks {
+            hook.register_host_callbacks(&compiled.lib)?;
+        }
         rv_execute(compiled, state.as_void_ptr())?;
     }
 
@@ -181,9 +179,9 @@ where
 /// If `num_insns` is `Some(n)`, the suspender is armed at `n` instructions and
 /// a `Suspended` outcome is accepted as success; otherwise only `Terminated`
 /// (with exit-code 0) succeeds.
-pub fn execute<F: PrimeField32>(
+pub fn execute(
     compiled: &RvrCompiled,
-    extensions: &ExtensionRegistry<F>,
+    runtime_hooks: &[Box<dyn RvrRuntimeExtension>],
     vm_state: &mut VmState<GuestMemory>,
     num_insns: Option<u64>,
 ) -> Result<RvrPureResult, ExecuteError> {
@@ -200,7 +198,7 @@ pub fn execute<F: PrimeField32>(
 
     let status = run_and_finalize(
         compiled,
-        extensions,
+        runtime_hooks,
         vm_state,
         &mut state,
         num_insns.is_some(),
@@ -213,9 +211,9 @@ pub fn execute<F: PrimeField32>(
 }
 
 /// Execute a VmExe with metered cost tracking.
-pub fn execute_metered_cost<F: PrimeField32>(
+pub fn execute_metered_cost(
     compiled: &RvrCompiled,
-    extensions: &ExtensionRegistry<F>,
+    runtime_hooks: &[Box<dyn RvrRuntimeExtension>],
     vm_state: &mut VmState<GuestMemory>,
     widths: &[u64],
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
@@ -230,38 +228,38 @@ pub fn execute_metered_cost<F: PrimeField32>(
     state.tracer.chip_widths = widths.as_ptr();
     state.tracer.cost = 0;
 
-    run_and_finalize(compiled, extensions, vm_state, &mut state, false)
+    run_and_finalize(compiled, runtime_hooks, vm_state, &mut state, false)
         .inspect_err(|error| tracing::warn!(%error, "rvr metered-cost execution failed"))?;
     let cost = state.tracer.cost;
     Ok(RvrMeteredCostResult { state, cost })
 }
 
 /// Execute a VmExe with per-chip metered execution and segmentation.
-pub fn execute_metered<F: PrimeField32>(
+pub fn execute_metered(
     compiled: &RvrCompiled,
-    extensions: &ExtensionRegistry<F>,
+    runtime_hooks: &[Box<dyn RvrRuntimeExtension>],
     vm_state: &mut VmState<GuestMemory>,
     seg_state: SegmentationState,
 ) -> Result<SegmentationState, ExecuteError> {
-    execute_metered_impl(compiled, extensions, vm_state, seg_state, false).map(|result| {
+    execute_metered_impl(compiled, runtime_hooks, vm_state, seg_state, false).map(|result| {
         debug_assert!(!result.suspended);
         result.seg_state
     })
 }
 
 /// Execute a VmExe with per-chip metered execution until termination or a segment boundary.
-pub fn execute_metered_segment_boundary<F: PrimeField32>(
+pub fn execute_metered_segment_boundary(
     compiled: &RvrCompiled,
-    extensions: &ExtensionRegistry<F>,
+    runtime_hooks: &[Box<dyn RvrRuntimeExtension>],
     vm_state: &mut VmState<GuestMemory>,
     seg_state: SegmentationState,
 ) -> Result<RvrMeteredResult, ExecuteError> {
-    execute_metered_impl(compiled, extensions, vm_state, seg_state, true)
+    execute_metered_impl(compiled, runtime_hooks, vm_state, seg_state, true)
 }
 
-fn execute_metered_impl<F: PrimeField32>(
+fn execute_metered_impl(
     compiled: &RvrCompiled,
-    extensions: &ExtensionRegistry<F>,
+    runtime_hooks: &[Box<dyn RvrRuntimeExtension>],
     vm_state: &mut VmState<GuestMemory>,
     mut seg_state: SegmentationState,
     allow_suspended: bool,
@@ -305,8 +303,14 @@ fn execute_metered_impl<F: PrimeField32>(
     state.tracer.on_check = metered_periodic_check;
     state.tracer.seg_state = &mut seg_state as *mut SegmentationState as *mut c_void;
 
-    let status = run_and_finalize(compiled, extensions, vm_state, &mut state, allow_suspended)
-        .inspect_err(|error| tracing::warn!(%error, "rvr metered execution failed"))?;
+    let status = run_and_finalize(
+        compiled,
+        runtime_hooks,
+        vm_state,
+        &mut state,
+        allow_suspended,
+    )
+    .inspect_err(|error| tracing::warn!(%error, "rvr metered execution failed"))?;
 
     debug_assert!(matches!(
         status,

--- a/crates/vm/src/arch/rvr/initial_image.rs
+++ b/crates/vm/src/arch/rvr/initial_image.rs
@@ -1,0 +1,32 @@
+use openvm_instructions::exe::{SparseMemoryImage, VmExe};
+
+use crate::{
+    arch::{Streams, SystemConfig, VmState},
+    system::memory::online::GuestMemory,
+};
+
+/// State needed to initialize an rvr execution.
+#[derive(Clone, Debug)]
+pub struct RvrInitialImage {
+    pc_start: u32,
+    init_memory: SparseMemoryImage,
+}
+
+impl<F> From<&VmExe<F>> for RvrInitialImage {
+    fn from(exe: &VmExe<F>) -> Self {
+        Self {
+            pc_start: exe.pc_start,
+            init_memory: exe.init_memory.clone(),
+        }
+    }
+}
+
+impl RvrInitialImage {
+    pub(crate) fn create_vm_state(
+        &self,
+        system_config: &SystemConfig,
+        inputs: impl Into<Streams>,
+    ) -> VmState<GuestMemory> {
+        VmState::initial(system_config, &self.init_memory, self.pc_start, inputs)
+    }
+}

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -4,7 +4,6 @@ use std::{collections::VecDeque, ffi::c_void};
 
 #[cfg(not(feature = "unprotected"))]
 use openvm_platform::memory::MEM_SIZE;
-use openvm_stark_backend::p3_field::PrimeField32;
 use rand::rngs::StdRng;
 
 use crate::arch::deferral::DeferralState;
@@ -13,16 +12,14 @@ use crate::arch::deferral::DeferralState;
 /// one rvr call. Streams, rng, and the public-values byte slice are mutable
 /// borrows; `memory_ptr` is a raw alias of VmState's main memory buffer
 /// (raw because the C engine accesses it directly via pointer).
-///
-/// `deferral_memory` aliases AS=4 as `F` cells for deferral accumulator updates.
-pub struct OpenVmIoState<'a, F: PrimeField32> {
+pub struct OpenVmIoState<'a> {
     pub input_stream: &'a mut VecDeque<Vec<u8>>,
     pub hint_stream: &'a mut VecDeque<u8>,
     pub rng: &'a mut StdRng,
     pub memory_ptr: *mut u8,
     pub public_values: &'a mut [u8],
-    pub deferral_memory: *mut F,
-    pub deferral_memory_len: usize,
+    pub deferral_memory: *mut u8,
+    pub deferral_memory_len_bytes: usize,
     pub deferrals: &'a mut Vec<DeferralState>,
 }
 
@@ -50,12 +47,8 @@ pub fn check_mem_bounds_range(_start: u64, _num_bytes: usize) {}
 /// # Safety
 ///
 /// `ctx` must be a valid `OpenVmIoState` pointer. `data` must point to `len` bytes (or be null).
-pub unsafe extern "C" fn host_hint_stream_set<F: PrimeField32>(
-    ctx: *mut c_void,
-    data: *const u8,
-    len: u32,
-) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+pub unsafe extern "C" fn host_hint_stream_set(ctx: *mut c_void, data: *const u8, len: u32) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     io.hint_stream.clear();
     if len > 0 && !data.is_null() {
         let slice = unsafe { std::slice::from_raw_parts(data, len as usize) };

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -3,21 +3,18 @@
 
 use std::{
     ffi::c_void,
-    marker::PhantomData,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
-use openvm_instructions::{exe::VmExe, riscv::RV64_MEMORY_AS, DEFERRAL_AS};
-use openvm_stark_backend::p3_field::PrimeField32;
+use openvm_instructions::{riscv::RV64_MEMORY_AS, DEFERRAL_AS};
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::RvrRuntimeExtension;
 
 use super::{
     bridge::map_rvr_execute_error,
     execute_metered, execute_metered_segment_boundary,
     state::{TracerPayload, TracerPtr},
-    RvrCompiled,
+    RvrCompiled, RvrInitialImage,
 };
 #[cfg(feature = "metrics")]
 use crate::arch::execution_metrics::{ExecutionMetric, ExecutionMetricTimer};
@@ -35,27 +32,23 @@ use crate::{
     system::memory::{merkle::public_values::PUBLIC_VALUES_AS, online::GuestMemory},
 };
 
-pub struct RunToCompletion;
-
-pub struct SegmentBoundary;
-
-pub type RvrMeteredInstance<'a, F> = RvrMeteredInstanceWith<'a, F, RunToCompletion>;
-
-pub type RvrMeteredSegmentInstance<'a, F> = RvrMeteredInstanceWith<'a, F, SegmentBoundary>;
-
-pub struct RvrMeteredInstanceWith<'a, F: PrimeField32, S> {
-    pub(crate) system_config: &'a SystemConfig,
-    pub(crate) exe: Arc<VmExe<F>>,
-    pub(crate) extensions: ExtensionRegistry<F>,
-    pub(crate) compiled: RvrCompiled,
-    pub(crate) _mode: PhantomData<S>,
+struct RvrMeteredInstanceInner<'a> {
+    system_config: &'a SystemConfig,
+    initial_image: RvrInitialImage,
+    runtime_hooks: Vec<Box<dyn RvrRuntimeExtension>>,
+    compiled: RvrCompiled,
 }
 
-static_assertions::assert_impl_all!(RvrMeteredInstance<'static, p3_baby_bear::BabyBear>: Send, Sync);
-static_assertions::assert_impl_all!(
-    RvrMeteredSegmentInstance<'static, p3_baby_bear::BabyBear>: Send,
-    Sync
-);
+pub struct RvrMeteredInstance<'a> {
+    inner: RvrMeteredInstanceInner<'a>,
+}
+
+pub struct RvrMeteredSegmentInstance<'a> {
+    inner: RvrMeteredInstanceInner<'a>,
+}
+
+static_assertions::assert_impl_all!(RvrMeteredInstance<'static>: Send, Sync);
+static_assertions::assert_impl_all!(RvrMeteredSegmentInstance<'static>: Send, Sync);
 
 pub struct RvrMeteredResult {
     pub seg_state: SegmentationState,
@@ -345,31 +338,59 @@ pub unsafe extern "C" fn metered_periodic_check(t: *mut MeteredTracerData) -> u8
     did_segment as u8
 }
 
-impl<F: PrimeField32, S> RvrMeteredInstanceWith<'_, F, S> {
+impl RvrMeteredInstanceInner<'_> {
+    fn create_initial_vm_state(&self, inputs: impl Into<Streams>) -> VmState<GuestMemory> {
+        self.initial_image
+            .create_vm_state(self.system_config, inputs)
+    }
+
+    /// Persist the compiled shared library into `dir`. Returns the path to
+    /// the copied artifact. The user must re-supply `exe`, `executor_idx_to_air_idx`,
+    /// and any mode-specific data when loading.
+    fn save(&self, dir: &Path) -> Result<PathBuf, super::CompileError> {
+        let dest_lib = self.compiled.lib_file_name_with_suffix("metered")?;
+        self.compiled.save_artifact(&dir.join(dest_lib))
+    }
+
+    /// Persist generated C sources for inspection.
+    fn save_generated_sources(&self, dir: &Path) -> Result<(), super::CompileError> {
+        self.compiled.save_generated_sources(dir)
+    }
+}
+
+impl RvrMeteredInstance<'_> {
+    pub(crate) fn new(
+        system_config: &SystemConfig,
+        initial_image: RvrInitialImage,
+        runtime_hooks: Vec<Box<dyn RvrRuntimeExtension>>,
+        compiled: RvrCompiled,
+    ) -> RvrMeteredInstance<'_> {
+        RvrMeteredInstance {
+            inner: RvrMeteredInstanceInner {
+                system_config,
+                initial_image,
+                runtime_hooks,
+                compiled,
+            },
+        }
+    }
+
     pub fn create_initial_vm_state(&self, inputs: impl Into<Streams>) -> VmState<GuestMemory> {
-        VmState::initial(
-            self.system_config,
-            &self.exe.init_memory,
-            self.exe.pc_start,
-            inputs,
-        )
+        self.inner.create_initial_vm_state(inputs)
     }
 
     /// Persist the compiled shared library into `dir`. Returns the path to
     /// the copied artifact. The user must re-supply `exe`, `executor_idx_to_air_idx`,
     /// and any mode-specific data when loading.
     pub fn save(&self, dir: &Path) -> Result<PathBuf, super::CompileError> {
-        let dest_lib = self.compiled.lib_file_name_with_suffix("metered")?;
-        self.compiled.save_artifact(&dir.join(dest_lib))
+        self.inner.save(dir)
     }
 
     /// Persist generated C sources for inspection.
     pub fn save_generated_sources(&self, dir: &Path) -> Result<(), super::CompileError> {
-        self.compiled.save_generated_sources(dir)
+        self.inner.save_generated_sources(dir)
     }
-}
 
-impl<F: PrimeField32> RvrMeteredInstance<'_, F> {
     pub fn execute_metered(
         &self,
         inputs: impl Into<Streams>,
@@ -384,13 +405,18 @@ impl<F: PrimeField32> RvrMeteredInstance<'_, F> {
         mut vm_state: VmState<GuestMemory>,
         ctx: MeteredCtx,
     ) -> Result<(Vec<Segment>, VmState<GuestMemory>), ExecutionError> {
-        let seg_state = SegmentationState::new(ctx, self.system_config);
+        let seg_state = SegmentationState::new(ctx, self.inner.system_config);
 
         #[cfg(feature = "metrics")]
         let metrics = ExecutionMetricTimer::start(ExecutionMetric::Metered);
         let result_seg_state = tracing::info_span!("execute_metered")
             .in_scope(|| {
-                execute_metered(&self.compiled, &self.extensions, &mut vm_state, seg_state)
+                execute_metered(
+                    &self.inner.compiled,
+                    &self.inner.runtime_hooks,
+                    &mut vm_state,
+                    seg_state,
+                )
             })
             .map_err(map_rvr_execute_error)?;
         let result_seg_ctx = result_seg_state.ctx.segmentation_ctx;
@@ -404,7 +430,39 @@ impl<F: PrimeField32> RvrMeteredInstance<'_, F> {
     }
 }
 
-impl<F: PrimeField32> RvrMeteredSegmentInstance<'_, F> {
+impl RvrMeteredSegmentInstance<'_> {
+    pub(crate) fn new(
+        system_config: &SystemConfig,
+        initial_image: RvrInitialImage,
+        runtime_hooks: Vec<Box<dyn RvrRuntimeExtension>>,
+        compiled: RvrCompiled,
+    ) -> RvrMeteredSegmentInstance<'_> {
+        RvrMeteredSegmentInstance {
+            inner: RvrMeteredInstanceInner {
+                system_config,
+                initial_image,
+                runtime_hooks,
+                compiled,
+            },
+        }
+    }
+
+    pub fn create_initial_vm_state(&self, inputs: impl Into<Streams>) -> VmState<GuestMemory> {
+        self.inner.create_initial_vm_state(inputs)
+    }
+
+    /// Persist the compiled shared library into `dir`. Returns the path to
+    /// the copied artifact. The user must re-supply `exe`, `executor_idx_to_air_idx`,
+    /// and any mode-specific data when loading.
+    pub fn save(&self, dir: &Path) -> Result<PathBuf, super::CompileError> {
+        self.inner.save(dir)
+    }
+
+    /// Persist generated C sources for inspection.
+    pub fn save_generated_sources(&self, dir: &Path) -> Result<(), super::CompileError> {
+        self.inner.save_generated_sources(dir)
+    }
+
     /// Executes until termination or the next segment-boundary suspension.
     pub fn execute_metered_until_segment_boundary(
         &self,
@@ -424,12 +482,12 @@ impl<F: PrimeField32> RvrMeteredSegmentInstance<'_, F> {
         let metrics = ExecutionMetricTimer::start(ExecutionMetric::Metered);
         #[cfg(feature = "metrics")]
         let start_instret = ctx.segmentation_ctx.instret;
-        let seg_state = SegmentationState::new(ctx, self.system_config);
+        let seg_state = SegmentationState::new(ctx, self.inner.system_config);
 
         let result = tracing::info_span!("execute_metered").in_scope(|| {
             execute_metered_segment_boundary(
-                &self.compiled,
-                &self.extensions,
+                &self.inner.compiled,
+                &self.inner.runtime_hooks,
                 &mut vm_state,
                 seg_state,
             )

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -1,19 +1,14 @@
 //! Metered cost execution: per-chip trace cost tracking matching OpenVM's `MeteredCostCtx`.
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::{Path, PathBuf};
 
-use openvm_instructions::exe::VmExe;
-use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::RvrRuntimeExtension;
 
 use super::{
     bridge::map_rvr_execute_error,
     execute_metered_cost,
     state::{MeteredCostState, TracerPayload, TracerPtr},
-    RvrCompiled,
+    RvrCompiled, RvrInitialImage,
 };
 #[cfg(feature = "metrics")]
 use crate::arch::execution_metrics::{ExecutionMetric, ExecutionMetricTimer};
@@ -27,10 +22,10 @@ pub struct RvrMeteredCostResult {
     pub cost: u64,
 }
 
-pub struct RvrMeteredCostInstance<'a, F: PrimeField32> {
+pub struct RvrMeteredCostInstance<'a> {
     pub(crate) system_config: &'a SystemConfig,
-    pub(crate) exe: Arc<VmExe<F>>,
-    pub(crate) extensions: ExtensionRegistry<F>,
+    pub(crate) initial_image: RvrInitialImage,
+    pub(crate) runtime_hooks: Vec<Box<dyn RvrRuntimeExtension>>,
     pub(crate) compiled: RvrCompiled,
     /// Must match the widths baked into `compiled` so per-block constants and
     /// extension `trace_chip` calls compute cost against the same values.
@@ -76,7 +71,7 @@ impl TracerPayload for PureTracerData {
 
 pub type PureTracer = TracerPtr<PureTracerData>;
 
-impl<F: PrimeField32> RvrMeteredCostInstance<'_, F> {
+impl RvrMeteredCostInstance<'_> {
     /// Persist the compiled shared library into `dir`. Returns the path to
     /// the copied artifact. The user must re-supply `exe`, `executor_idx_to_air_idx`,
     /// and `widths` when loading.
@@ -90,12 +85,9 @@ impl<F: PrimeField32> RvrMeteredCostInstance<'_, F> {
         inputs: impl Into<Streams>,
         ctx: MeteredCostCtx,
     ) -> Result<(MeteredCostCtx, VmState<GuestMemory>), ExecutionError> {
-        let vm_state = VmState::initial(
-            self.system_config,
-            &self.exe.init_memory,
-            self.exe.pc_start,
-            inputs,
-        );
+        let vm_state = self
+            .initial_image
+            .create_vm_state(self.system_config, inputs);
         self.execute_metered_cost_from_state(vm_state, ctx)
     }
 
@@ -110,7 +102,7 @@ impl<F: PrimeField32> RvrMeteredCostInstance<'_, F> {
             .in_scope(|| {
                 execute_metered_cost(
                     &self.compiled,
-                    &self.extensions,
+                    &self.runtime_hooks,
                     &mut vm_state,
                     &self.widths,
                 )

--- a/crates/vm/src/arch/rvr/mod.rs
+++ b/crates/vm/src/arch/rvr/mod.rs
@@ -5,6 +5,7 @@ pub mod bridge;
 pub mod compile;
 pub mod debug;
 pub mod execute;
+mod initial_image;
 pub mod io;
 pub mod metered;
 pub mod metered_cost;
@@ -21,10 +22,8 @@ pub use execute::{
     execute, execute_metered, execute_metered_cost, execute_metered_segment_boundary, rv_execute,
     ExecuteError,
 };
-pub use metered::{
-    RunToCompletion, RvrMeteredInstance, RvrMeteredInstanceWith, RvrMeteredResult,
-    RvrMeteredSegmentInstance, SegmentBoundary,
-};
+pub use initial_image::RvrInitialImage;
+pub use metered::{RvrMeteredInstance, RvrMeteredResult, RvrMeteredSegmentInstance};
 pub use metered_cost::{
     MeteredCostData, MeteredCostMeter, PureTracer, PureTracerData, RvrMeteredCostInstance,
     RvrMeteredCostResult,

--- a/crates/vm/src/arch/rvr/pure.rs
+++ b/crates/vm/src/arch/rvr/pure.rs
@@ -1,15 +1,10 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::{Path, PathBuf};
 
-use openvm_instructions::exe::VmExe;
-use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::RvrRuntimeExtension;
 
 use super::{
     bridge::map_rvr_execute_error, compile::CompileError, execute::execute, state::PureState,
-    RvrCompiled,
+    RvrCompiled, RvrInitialImage,
 };
 #[cfg(feature = "metrics")]
 use crate::arch::execution_metrics::{ExecutionMetric, ExecutionMetricTimer};
@@ -24,26 +19,19 @@ pub struct RvrPureResult {
     pub suspended: bool,
 }
 
-pub struct RvrPureInstance<'a, F: PrimeField32> {
+pub struct RvrPureInstance<'a> {
     pub(crate) system_config: &'a SystemConfig,
-    pub(crate) exe: Arc<VmExe<F>>,
+    pub(crate) initial_image: RvrInitialImage,
     pub(crate) compiled: RvrCompiled,
-    pub(crate) extensions: ExtensionRegistry<F>,
+    pub(crate) runtime_hooks: Vec<Box<dyn RvrRuntimeExtension>>,
 }
 
-static_assertions::assert_impl_all!(RvrPureInstance<'static, p3_baby_bear::BabyBear>: Send, Sync);
+static_assertions::assert_impl_all!(RvrPureInstance<'static>: Send, Sync);
 
-impl<'a, F> RvrPureInstance<'a, F>
-where
-    F: PrimeField32,
-{
+impl RvrPureInstance<'_> {
     pub fn create_initial_vm_state(&self, inputs: impl Into<Streams>) -> VmState<GuestMemory> {
-        VmState::initial(
-            self.system_config,
-            &self.exe.init_memory,
-            self.exe.pc_start,
-            inputs,
-        )
+        self.initial_image
+            .create_vm_state(self.system_config, inputs)
     }
 
     pub fn execute(
@@ -64,7 +52,14 @@ where
         let metrics = ExecutionMetricTimer::start(ExecutionMetric::Pure);
         #[allow(unused_variables)]
         let result = tracing::info_span!("execute_pure")
-            .in_scope(|| execute(&self.compiled, &self.extensions, &mut vm_state, num_insns))
+            .in_scope(|| {
+                execute(
+                    &self.compiled,
+                    &self.runtime_hooks,
+                    &mut vm_state,
+                    num_insns,
+                )
+            })
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -7,8 +7,6 @@
 //!
 //! [VirtualMachine] will similarly be the struct that has done all the setup so it can
 //! execute+prove an arbitrary program for a fixed config - it will internally still hold VmExecutor
-#[cfg(feature = "rvr")]
-use std::marker::PhantomData;
 use std::{any::TypeId, borrow::Borrow, collections::VecDeque, sync::Arc};
 
 use getset::{Getters, MutGetters, Setters, WithSetters};
@@ -35,7 +33,7 @@ use openvm_stark_backend::{
 };
 use p3_baby_bear::BabyBear;
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::ExtensionRegistry;
+use rvr_openvm_lift::RvrExtensions;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{info_span, instrument};
@@ -46,8 +44,8 @@ use super::aot::AotInstance;
 use super::rvr::{
     bridge::map_rvr_compile_error, build_pc_to_chip, compile, compile_metered,
     compile_metered_cost, compile_metered_segment_boundary, load_compiled_from_path, ChipMapping,
-    GuestDebugMap, RunToCompletion, RvrMeteredCostInstance, RvrMeteredInstance,
-    RvrMeteredSegmentInstance, RvrPureInstance, SegmentBoundary,
+    GuestDebugMap, RvrInitialImage, RvrMeteredCostInstance, RvrMeteredInstance,
+    RvrMeteredSegmentInstance, RvrPureInstance,
 };
 use super::{
     execution_mode::{
@@ -251,7 +249,7 @@ where
     }
 
     #[cfg(feature = "rvr")]
-    pub fn instance(&self, exe: &VmExe<F>) -> Result<RvrPureInstance<'_, F>, StaticProgramError> {
+    pub fn instance(&self, exe: &VmExe<F>) -> Result<RvrPureInstance<'_>, StaticProgramError> {
         Self::rvr_instance(self, exe, None)
     }
 }
@@ -262,10 +260,7 @@ where
     F: PrimeField32,
     VC: VmExecutionConfig<F>,
 {
-    fn build_rvr_extensions(
-        &self,
-        executor_idx_to_air_idx: Option<&[usize]>,
-    ) -> ExtensionRegistry<F> {
+    fn build_rvr_extensions(&self, executor_idx_to_air_idx: Option<&[usize]>) -> RvrExtensions {
         self.config.create_rvr_extensions(executor_idx_to_air_idx)
     }
 }
@@ -281,17 +276,19 @@ where
         &self,
         exe: &VmExe<F>,
         guest_debug_map: Option<&GuestDebugMap>,
-    ) -> Result<RvrPureInstance<'_, F>, StaticProgramError> {
+    ) -> Result<RvrPureInstance<'_>, StaticProgramError> {
         #[cfg(feature = "metrics")]
         let _compilation_span = tracing::info_span!("compile_pure", backend = "rvr").entered();
         let extensions = self.build_rvr_extensions(None);
-        let compiled = compile(exe, &extensions, guest_debug_map).map_err(map_rvr_compile_error)?;
+        let compiled =
+            compile(exe, extensions.lifters(), guest_debug_map).map_err(map_rvr_compile_error)?;
+        let runtime_hooks = extensions.into_runtime_hooks();
 
         Ok(RvrPureInstance {
             system_config: self.inventory.config(),
-            exe: Arc::new(exe.clone()),
+            initial_image: RvrInitialImage::from(exe),
             compiled,
-            extensions,
+            runtime_hooks,
         })
     }
 
@@ -302,15 +299,15 @@ where
         &self,
         lib_path: &std::path::Path,
         exe: &VmExe<F>,
-    ) -> Result<RvrPureInstance<'_, F>, StaticProgramError> {
-        let extensions = self.build_rvr_extensions(None);
+    ) -> Result<RvrPureInstance<'_>, StaticProgramError> {
+        let runtime_hooks = self.build_rvr_extensions(None).into_runtime_hooks();
         let compiled = load_compiled_from_path(lib_path).map_err(map_rvr_compile_error)?;
 
         Ok(RvrPureInstance {
             system_config: self.inventory.config(),
-            exe: Arc::new(exe.clone()),
+            initial_image: RvrInitialImage::from(exe),
             compiled,
-            extensions,
+            runtime_hooks,
         })
     }
 }
@@ -422,7 +419,7 @@ where
         &self,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<RvrMeteredInstance<'_, F>, StaticProgramError> {
+    ) -> Result<RvrMeteredInstance<'_>, StaticProgramError> {
         self.metered_rvr_instance(exe, executor_idx_to_air_idx, None)
     }
 
@@ -431,7 +428,7 @@ where
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
         guest_debug_map: Option<&GuestDebugMap>,
-    ) -> Result<RvrMeteredInstance<'_, F>, StaticProgramError> {
+    ) -> Result<RvrMeteredInstance<'_>, StaticProgramError> {
         #[cfg(feature = "metrics")]
         let _compilation_span = tracing::info_span!("compile_metered", backend = "rvr").entered();
         let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
@@ -440,16 +437,16 @@ where
                 .map_err(map_rvr_compile_error)?,
             chip_widths: None,
         };
-        let compiled = compile_metered(exe, &extensions, &chips, guest_debug_map)
+        let compiled = compile_metered(exe, extensions.lifters(), &chips, guest_debug_map)
             .map_err(map_rvr_compile_error)?;
+        let runtime_hooks = extensions.into_runtime_hooks();
 
-        Ok(RvrMeteredInstance {
-            system_config: self.inventory.config(),
-            exe: Arc::new(exe.clone()),
-            extensions,
+        Ok(RvrMeteredInstance::new(
+            self.inventory.config(),
+            RvrInitialImage::from(exe),
+            runtime_hooks,
             compiled,
-            _mode: PhantomData::<RunToCompletion>,
-        })
+        ))
     }
 
     pub fn metered_segment_rvr_instance(
@@ -457,7 +454,7 @@ where
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
         guest_debug_map: Option<&GuestDebugMap>,
-    ) -> Result<RvrMeteredSegmentInstance<'_, F>, StaticProgramError> {
+    ) -> Result<RvrMeteredSegmentInstance<'_>, StaticProgramError> {
         #[cfg(feature = "metrics")]
         let _compilation_span =
             tracing::info_span!("compile_metered_segment", backend = "rvr").entered();
@@ -467,16 +464,17 @@ where
                 .map_err(map_rvr_compile_error)?,
             chip_widths: None,
         };
-        let compiled = compile_metered_segment_boundary(exe, &extensions, &chips, guest_debug_map)
-            .map_err(map_rvr_compile_error)?;
+        let compiled =
+            compile_metered_segment_boundary(exe, extensions.lifters(), &chips, guest_debug_map)
+                .map_err(map_rvr_compile_error)?;
+        let runtime_hooks = extensions.into_runtime_hooks();
 
-        Ok(RvrMeteredSegmentInstance {
-            system_config: self.inventory.config(),
-            exe: Arc::new(exe.clone()),
-            extensions,
+        Ok(RvrMeteredSegmentInstance::new(
+            self.inventory.config(),
+            RvrInitialImage::from(exe),
+            runtime_hooks,
             compiled,
-            _mode: PhantomData::<SegmentBoundary>,
-        })
+        ))
     }
 
     pub fn metered_cost_instance(
@@ -484,7 +482,7 @@ where
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
         widths: &[usize],
-    ) -> Result<RvrMeteredCostInstance<'_, F>, StaticProgramError> {
+    ) -> Result<RvrMeteredCostInstance<'_>, StaticProgramError> {
         self.metered_cost_rvr_instance(exe, executor_idx_to_air_idx, widths, None)
     }
 
@@ -495,17 +493,18 @@ where
         lib_path: &std::path::Path,
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
-    ) -> Result<RvrMeteredInstance<'_, F>, StaticProgramError> {
-        let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
+    ) -> Result<RvrMeteredInstance<'_>, StaticProgramError> {
+        let runtime_hooks = self
+            .build_rvr_extensions(Some(executor_idx_to_air_idx))
+            .into_runtime_hooks();
         let compiled = load_compiled_from_path(lib_path).map_err(map_rvr_compile_error)?;
 
-        Ok(RvrMeteredInstance {
-            system_config: self.inventory.config(),
-            exe: Arc::new(exe.clone()),
-            extensions,
+        Ok(RvrMeteredInstance::new(
+            self.inventory.config(),
+            RvrInitialImage::from(exe),
+            runtime_hooks,
             compiled,
-            _mode: PhantomData::<RunToCompletion>,
-        })
+        ))
     }
 
     /// Load a previously saved metered-cost-mode artifact. Caller supplies `exe`,
@@ -516,15 +515,17 @@ where
         exe: &VmExe<F>,
         executor_idx_to_air_idx: &[usize],
         widths: &[usize],
-    ) -> Result<RvrMeteredCostInstance<'_, F>, StaticProgramError> {
-        let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
+    ) -> Result<RvrMeteredCostInstance<'_>, StaticProgramError> {
+        let runtime_hooks = self
+            .build_rvr_extensions(Some(executor_idx_to_air_idx))
+            .into_runtime_hooks();
         let widths: Vec<u64> = widths.iter().map(|&w| w as u64).collect();
         let compiled = load_compiled_from_path(lib_path).map_err(map_rvr_compile_error)?;
 
         Ok(RvrMeteredCostInstance {
             system_config: self.inventory.config(),
-            exe: Arc::new(exe.clone()),
-            extensions,
+            initial_image: RvrInitialImage::from(exe),
+            runtime_hooks,
             compiled,
             widths,
         })
@@ -536,7 +537,7 @@ where
         executor_idx_to_air_idx: &[usize],
         widths: &[usize],
         guest_debug_map: Option<&GuestDebugMap>,
-    ) -> Result<RvrMeteredCostInstance<'_, F>, StaticProgramError> {
+    ) -> Result<RvrMeteredCostInstance<'_>, StaticProgramError> {
         #[cfg(feature = "metrics")]
         let _compilation_span =
             tracing::info_span!("compile_metered_cost", backend = "rvr").entered();
@@ -547,13 +548,14 @@ where
                 .map_err(map_rvr_compile_error)?,
             chip_widths: Some(widths.clone()),
         };
-        let compiled = compile_metered_cost(exe, &extensions, &chips, guest_debug_map)
+        let compiled = compile_metered_cost(exe, extensions.lifters(), &chips, guest_debug_map)
             .map_err(map_rvr_compile_error)?;
+        let runtime_hooks = extensions.into_runtime_hooks();
 
         Ok(RvrMeteredCostInstance {
             system_config: self.inventory.config(),
-            exe: Arc::new(exe.clone()),
-            extensions,
+            initial_image: RvrInitialImage::from(exe),
+            runtime_hooks,
             compiled,
             widths,
         })
@@ -700,7 +702,7 @@ where
     pub fn instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrPureInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrPureInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
@@ -712,7 +714,7 @@ where
     pub fn get_rvr_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrPureInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrPureInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>,
@@ -776,7 +778,7 @@ where
     pub fn metered_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrMeteredInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -790,7 +792,7 @@ where
     pub fn get_metered_rvr_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrMeteredInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -804,7 +806,7 @@ where
     pub fn get_metered_segment_rvr_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredSegmentInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrMeteredSegmentInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -819,7 +821,7 @@ where
         &self,
         lib_path: &std::path::Path,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrMeteredInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -890,7 +892,7 @@ where
     pub fn metered_cost_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredCostInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrMeteredCostInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -902,7 +904,7 @@ where
     pub fn get_metered_cost_rvr_instance(
         &self,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredCostInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrMeteredCostInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,
@@ -923,7 +925,7 @@ where
         &self,
         lib_path: &std::path::Path,
         exe: &VmExe<Val<E::SC>>,
-    ) -> Result<RvrMeteredCostInstance<'_, Val<E::SC>>, StaticProgramError>
+    ) -> Result<RvrMeteredCostInstance<'_>, StaticProgramError>
     where
         Val<E::SC>: PrimeField32,
         <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: MeteredExecutor<Val<E::SC>>,

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -223,11 +223,8 @@ impl<F: PrimeField32> VmExecutionConfig<F> for SystemConfig {
     }
 
     #[cfg(feature = "rvr")]
-    fn create_rvr_extensions(
-        &self,
-        _air_idx: Option<&[usize]>,
-    ) -> rvr_openvm_lift::ExtensionRegistry<F> {
-        rvr_openvm_lift::ExtensionRegistry::new()
+    fn create_rvr_extensions(&self, _air_idx: Option<&[usize]>) -> rvr_openvm_lift::RvrExtensions {
+        rvr_openvm_lift::RvrExtensions::new()
     }
 }
 

--- a/extensions/algebra/circuit/src/extension/fp2.rs
+++ b/extensions/algebra/circuit/src/extension/fp2.rs
@@ -15,7 +15,9 @@ use openvm_instructions::{LocalOpcode, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
+use rvr_openvm_ext_algebra::Fp2RvrExtension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use strum::EnumCount;
@@ -67,13 +69,13 @@ impl Fp2Extension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Fp2Extension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {
         let fp2_moduli = self
             .supported_moduli
             .iter()
             .map(|(_, m)| m.clone())
             .collect();
-        registry.register(rvr_openvm_ext_algebra::Fp2RvrExtension::new(fp2_moduli));
+        extensions.register_lifter(Fp2RvrExtension::new(fp2_moduli));
     }
 }
 

--- a/extensions/algebra/circuit/src/extension/modular.rs
+++ b/extensions/algebra/circuit/src/extension/modular.rs
@@ -26,7 +26,9 @@ use openvm_riscv_adapters::{
 use openvm_riscv_circuit::adapters::U16_BITS;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
+use rvr_openvm_ext_algebra::ModularRvrExtension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use strum::EnumCount;
@@ -65,10 +67,8 @@ impl ModularExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for ModularExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
-        registry.register(rvr_openvm_ext_algebra::ModularRvrExtension::new(
-            self.supported_moduli.clone(),
-        ));
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {
+        extensions.register_lifter(ModularRvrExtension::new(self.supported_moduli.clone()));
     }
 }
 

--- a/extensions/algebra/rvr/Cargo.toml
+++ b/extensions/algebra/rvr/Cargo.toml
@@ -14,7 +14,6 @@ rvr-openvm-lift.workspace = true
 openvm-algebra-transpiler.workspace = true
 openvm-algebra-utils.workspace = true
 openvm-instructions.workspace = true
-openvm-stark-backend.workspace = true
 
 num-bigint.workspace = true
 rand.workspace = true

--- a/extensions/algebra/rvr/src/common.rs
+++ b/extensions/algebra/rvr/src/common.rs
@@ -157,7 +157,7 @@ impl<K: IsEqKind> ExtInstr for FieldIsEqInstr<K> {
         } else {
             let mod_literal = format_c_byte_array(&self.modulus);
             ctx.write_line("{");
-            ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
+            ctx.write_line(&format!("static constexpr uint8_t mod_[] = {mod_literal};"));
             let name = format!("rvr_ext_{prefix}_iseq");
             let num_limbs = format!("{}u", self.num_limbs);
             let val = ctx.extern_call_expr(
@@ -197,7 +197,7 @@ impl<K: ArithKind> ExtInstr for FieldArithInstr<K> {
         } else {
             let mod_literal = format_c_byte_array(&self.modulus);
             ctx.write_line("{");
-            ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
+            ctx.write_line(&format!("static constexpr uint8_t mod_[] = {mod_literal};"));
             let name = format!("rvr_ext_{prefix}_{op_name}");
             let num_limbs = format!("{}u", self.num_limbs);
             ctx.extern_call(&name, &["state", &rd, &rs1, &rs2, &num_limbs, "mod_"]);

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -2,10 +2,9 @@
 
 use num_bigint::BigUint;
 use openvm_algebra_transpiler::Fp2Opcode;
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
-use openvm_stark_backend::p3_field::PrimeField32;
+use openvm_instructions::LocalOpcode;
 use rvr_openvm_ir::{Instr, InstrAt, LiftedInstr};
-use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
+use rvr_openvm_lift::{helpers::decode_reg, RvrExtension, RvrInstruction};
 use strum::EnumCount;
 
 use crate::{
@@ -81,8 +80,8 @@ impl Fp2RvrExtension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for Fp2RvrExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for Fp2RvrExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
         self.try_lift_fp2(insn, pc, opcode)
     }
@@ -100,12 +99,7 @@ impl<F: PrimeField32> RvrExtension<F> for Fp2RvrExtension {
 }
 
 impl Fp2RvrExtension {
-    fn try_lift_fp2<F: PrimeField32>(
-        &self,
-        insn: &Instruction<F>,
-        pc: u64,
-        opcode: usize,
-    ) -> Option<LiftedInstr> {
+    fn try_lift_fp2(&self, insn: &RvrInstruction, pc: u64, opcode: usize) -> Option<LiftedInstr> {
         let base_offset = Fp2Opcode::CLASS_OFFSET;
         let count = Fp2Opcode::COUNT;
 

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -4,11 +4,10 @@
 use num_bigint::BigUint;
 use openvm_algebra_transpiler::{ModularPhantom, Rv64ModularArithmeticOpcode};
 use openvm_algebra_utils::{find_non_qr, NQR_RNG_SEED};
-use openvm_instructions::{instruction::Instruction, LocalOpcode, SystemOpcode};
-use openvm_stark_backend::p3_field::PrimeField32;
+use openvm_instructions::{LocalOpcode, SystemOpcode};
 use rand::{rngs::StdRng, SeedableRng};
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
-use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
+use rvr_openvm_lift::{helpers::decode_reg, RvrExtension, RvrInstruction};
 use strum::EnumCount;
 
 use crate::{
@@ -110,7 +109,7 @@ impl ExtInstr for HintNonQrInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let literal = format_c_byte_array(&self.non_qr_bytes);
         ctx.write_line("{");
-        ctx.write_line(&format!("static const uint8_t nqr[] = {literal};"));
+        ctx.write_line(&format!("static constexpr uint8_t nqr[] = {literal};"));
         let len = format!("{}u", self.non_qr_bytes.len());
         ctx.extern_call("ext_hint_stream_set", &["nqr", &len]);
         ctx.write_line("}");
@@ -144,8 +143,8 @@ impl ExtInstr for HintSqrtInstr {
         let mod_literal = format_c_byte_array(&self.modulus);
         let nqr_literal = format_c_byte_array(&self.non_qr_bytes);
         ctx.write_line("{");
-        ctx.write_line(&format!("static const uint8_t mod_[] = {mod_literal};"));
-        ctx.write_line(&format!("static const uint8_t nqr[] = {nqr_literal};"));
+        ctx.write_line(&format!("static constexpr uint8_t mod_[] = {mod_literal};"));
+        ctx.write_line(&format!("static constexpr uint8_t nqr[] = {nqr_literal};"));
         let num_limbs = format!("{}u", self.num_limbs);
         ctx.extern_call(
             "rvr_ext_algebra_hint_sqrt",
@@ -181,8 +180,8 @@ impl ModularRvrExtension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for ModularRvrExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for ModularRvrExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if let Some(lifted) = self.try_lift_modular(insn, pc, opcode) {
@@ -251,9 +250,9 @@ impl<F: PrimeField32> RvrExtension<F> for ModularRvrExtension {
 }
 
 impl ModularRvrExtension {
-    fn try_lift_modular<F: PrimeField32>(
+    fn try_lift_modular(
         &self,
-        insn: &Instruction<F>,
+        insn: &RvrInstruction,
         pc: u64,
         opcode: usize,
     ) -> Option<LiftedInstr> {
@@ -345,12 +344,8 @@ impl ModularRvrExtension {
         }))
     }
 
-    fn try_lift_phantom<F: PrimeField32>(
-        &self,
-        insn: &Instruction<F>,
-        pc: u64,
-    ) -> Option<LiftedInstr> {
-        let c_val = insn.c.as_canonical_u32();
+    fn try_lift_phantom(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
+        let c_val = insn.c;
         let discriminant = (c_val & 0xffff) as u16;
         let mod_idx = (c_val >> 16) as usize;
 

--- a/extensions/bigint/circuit/src/extension/mod.rs
+++ b/extensions/bigint/circuit/src/extension/mod.rs
@@ -37,7 +37,9 @@ use openvm_riscv_circuit::Rv64ImCpuProverExt;
 use openvm_riscv_transpiler::{BaseAluOpcode, ShiftOpcode};
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::VmRvrExtension;
+use rvr_openvm_ext_bigint::Int256Extension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -82,14 +84,9 @@ fn default_range_tuple_checker_sizes() -> [u32; 2] {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Int256 {
-    fn extend_rvr(
-        &self,
-        registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
-        ctx: Option<&rvr_openvm_lift::RvrExtensionCtx>,
-    ) {
-        let ext = rvr_openvm_ext_bigint::Int256Extension::new(ctx)
-            .expect("failed to construct rvr Int256Extension");
-        registry.register(ext);
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, ctx: Option<&RvrExtensionCtx>) {
+        let ext = Int256Extension::new(ctx).expect("failed to construct rvr Int256Extension");
+        extensions.register_lifter(ext);
     }
 }
 

--- a/extensions/bigint/rvr/Cargo.toml
+++ b/extensions/bigint/rvr/Cargo.toml
@@ -14,7 +14,6 @@ rvr-openvm-lift.workspace = true
 openvm-bigint-transpiler.workspace = true
 openvm-instructions.workspace = true
 openvm-riscv-transpiler.workspace = true
-openvm-stark-backend.workspace = true
 
 strum.workspace = true
 

--- a/extensions/bigint/rvr/src/lib.rs
+++ b/extensions/bigint/rvr/src/lib.rs
@@ -8,15 +8,15 @@ use openvm_bigint_transpiler::{
     Rv64BaseAlu256Opcode, Rv64BranchEqual256Opcode, Rv64BranchLessThan256Opcode,
     Rv64LessThan256Opcode, Rv64Mul256Opcode, Rv64Shift256Opcode,
 };
-use openvm_instructions::{
-    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV64_REGISTER_NUM_LIMBS, LocalOpcode,
-};
+use openvm_instructions::{program::DEFAULT_PC_STEP, LocalOpcode};
 use openvm_riscv_transpiler::{
     BaseAluOpcode, BranchEqualOpcode, BranchLessThanOpcode, LessThanOpcode, MulOpcode, ShiftOpcode,
 };
-use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg, Terminator};
-use rvr_openvm_lift::{opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx};
+use rvr_openvm_lift::{
+    decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension, RvrExtensionCtx,
+    RvrInstruction,
+};
 use strum::EnumCount;
 
 // ── ALU / branch opcode enums ───────────────────────────────────────────────
@@ -299,24 +299,8 @@ impl Int256Extension {
     }
 }
 
-/// Decode register index from OpenVM operand (divided by RV64_REGISTER_NUM_LIMBS).
-fn decode_reg<F: PrimeField32>(f: F) -> u8 {
-    (f.as_canonical_u32() / RV64_REGISTER_NUM_LIMBS as u32) as u8
-}
-
-/// Decode a field element as a signed immediate (for branch offsets).
-fn decode_imm<F: PrimeField32>(f: F) -> i32 {
-    let v = f.as_canonical_u32();
-    let p = F::ORDER_U32;
-    if v > p / 2 {
-        v.wrapping_sub(p) as i32
-    } else {
-        v as i32
-    }
-}
-
-impl<F: PrimeField32> RvrExtension<F> for Int256Extension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for Int256Extension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         // ── ALU body instructions ───────────────────────────────────────
@@ -372,7 +356,7 @@ impl<F: PrimeField32> RvrExtension<F> for Int256Extension {
             let is_ne = opcode - beq_start == 1;
             let rs1_reg = decode_reg(insn.a);
             let rs2_reg = decode_reg(insn.b);
-            let imm = decode_imm(insn.c);
+            let imm = insn.signed_c();
             let target_pc = (pc as i64 + imm as i64) as u64;
             let fall_pc = pc + DEFAULT_PC_STEP as u64;
             let chip_idx = self.chip_idx_for_opcode(opcode);
@@ -403,7 +387,7 @@ impl<F: PrimeField32> RvrExtension<F> for Int256Extension {
             };
             let rs1_reg = decode_reg(insn.a);
             let rs2_reg = decode_reg(insn.b);
-            let imm = decode_imm(insn.c);
+            let imm = insn.signed_c();
             let target_pc = (pc as i64 + imm as i64) as u64;
             let fall_pc = pc + DEFAULT_PC_STEP as u64;
             let chip_idx = self.chip_idx_for_opcode(opcode);
@@ -439,12 +423,7 @@ impl<F: PrimeField32> RvrExtension<F> for Int256Extension {
 
 impl Int256Extension {
     /// Lift an R-type ALU instruction: a=rd, b=rs1, c=rs2.
-    fn lift_alu<F: PrimeField32>(
-        &self,
-        insn: &Instruction<F>,
-        pc: u64,
-        op: Int256AluOp,
-    ) -> LiftedInstr {
+    fn lift_alu(&self, insn: &RvrInstruction, pc: u64, op: Int256AluOp) -> LiftedInstr {
         let rd_reg = decode_reg(insn.a);
         let rs1_reg = decode_reg(insn.b);
         let rs2_reg = decode_reg(insn.c);
@@ -461,5 +440,37 @@ impl Int256Extension {
             })),
             source_loc: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instruction(opcode: impl LocalOpcode, c: u32) -> RvrInstruction {
+        RvrInstruction::from_canonical(opcode.global_opcode(), [8, 16, c, 0, 0, 0, 0], 101)
+    }
+
+    #[test]
+    fn bigint_branches_preserve_negative_field_encoded_offsets() {
+        let pc = 0x1000;
+        let ext = Int256Extension::new(None).unwrap();
+
+        for insn in [
+            instruction(Rv64BranchEqual256Opcode(BranchEqualOpcode::BEQ), 101 - 12),
+            instruction(
+                Rv64BranchLessThan256Opcode(BranchLessThanOpcode::BLT),
+                101 - 12,
+            ),
+        ] {
+            let lifted = ext.try_lift(&insn, pc).unwrap();
+            let LiftedInstr::Term { terminator, .. } = lifted else {
+                panic!("expected bigint branch terminator");
+            };
+            assert_eq!(
+                terminator.successors(pc + DEFAULT_PC_STEP as u64),
+                [pc - 12, pc + 4]
+            );
+        }
     }
 }

--- a/extensions/deferral/circuit/src/extension/mod.rs
+++ b/extensions/deferral/circuit/src/extension/mod.rs
@@ -23,9 +23,9 @@ use openvm_riscv_circuit::{
 };
 use openvm_stark_backend::{StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_ext_deferral::DeferralRvrExtension;
+use rvr_openvm_ext_deferral::{DeferralRuntimeHooks, DeferralRvrExtension};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "rvr")]
@@ -73,12 +73,16 @@ pub struct DeferralExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: VmField> VmRvrExtension<F> for DeferralExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: Option<&RvrExtensionCtx>) {
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, ctx: Option<&RvrExtensionCtx>) {
         let hash = make_deferral_hash::<F>();
         let compress = make_deferral_compress::<F>();
-        let ext = DeferralRvrExtension::new(ctx, self.fns.clone(), hash, compress)
-            .expect("failed to construct rvr DeferralRvrExtension");
-        registry.register(ext);
+        let lifter =
+            DeferralRvrExtension::new(ctx).expect("failed to construct rvr DeferralRvrExtension");
+        extensions.register_lifter(lifter);
+        // SAFETY: This extension and the VM state use the same field `F`.
+        extensions.register_runtime_hook(unsafe {
+            DeferralRuntimeHooks::new::<F>(self.fns.clone(), hash, compress)
+        });
     }
 }
 

--- a/extensions/deferral/circuit/src/runtime.rs
+++ b/extensions/deferral/circuit/src/runtime.rs
@@ -1,7 +1,5 @@
 //! F-typed builder for the rvr deferral output hasher.
 
-use std::sync::Arc;
-
 use openvm_circuit::arch::VmField;
 use rvr_openvm_ext_deferral::{DeferralCompressFn, DeferralHashFn};
 use rvr_openvm_ext_ffi_common::DEFERRAL_COMMIT_NUM_BYTES;
@@ -10,7 +8,7 @@ use crate::{def_fn::hash_output_raw, poseidon2::deferral_poseidon2_chip};
 
 pub fn make_deferral_hash<F: VmField>() -> DeferralHashFn {
     let hasher = deferral_poseidon2_chip::<F>();
-    Arc::new(
+    Box::new(
         move |def_idx: u32, output_raw: &[u8]| -> [u8; DEFERRAL_COMMIT_NUM_BYTES] {
             hash_output_raw(&hasher, def_idx, output_raw)
                 .as_slice()
@@ -24,7 +22,7 @@ pub fn make_deferral_hash<F: VmField>() -> DeferralHashFn {
 /// Inputs and outputs are canonical u32 field values.
 pub fn make_deferral_compress<F: VmField>() -> DeferralCompressFn {
     let hasher = deferral_poseidon2_chip::<F>();
-    Arc::new(move |lhs, rhs| {
+    Box::new(move |lhs, rhs| {
         let lhs_f = lhs.map(F::from_u32);
         let rhs_f = rhs.map(F::from_u32);
         hasher

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -38,8 +38,7 @@ typedef struct {
                         uint32_t expected_len);
 } DeferralHostCallbacks;
 
-/* NOT thread-safe: installs one process-global deferral callback set. */
-static DeferralHostCallbacks g_deferral;
+static thread_local DeferralHostCallbacks g_deferral;
 
 void register_deferral_callbacks(const DeferralHostCallbacks* cb) {
   g_deferral = *cb;

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -2,14 +2,18 @@
 //! `DeferralRvrExtension` for lifting them.
 #![cfg(feature = "rvr")]
 
-use std::{ffi::c_void, sync::Arc};
+use std::{
+    ffi::c_void,
+    mem::{align_of, size_of},
+    sync::Arc,
+};
 
 use openvm_circuit::arch::{
     deferral::{DeferralFn, InputMapVal},
     rvr::io::OpenVmIoState,
 };
 use openvm_deferral_transpiler::DeferralOpcode;
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::LocalOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ext_ffi_common::{
     DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_DIGEST_SIZE, DEFERRAL_OUTPUT_KEY_BYTES,
@@ -17,15 +21,15 @@ use rvr_openvm_ext_ffi_common::{
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
     air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
-    RvrExtensionCtx,
+    RvrExtensionCtx, RvrInstruction, RvrRuntimeExtension,
 };
 
 /// `(def_idx, output_raw) → output_commit` hasher registered by the host.
-pub type DeferralHashFn = Arc<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
+pub type DeferralHashFn = Box<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
 
 /// Poseidon2 compression over deferral accumulator field elements.
 /// Values cross the crate boundary as canonical u32s.
-pub type DeferralCompressFn = Arc<
+pub type DeferralCompressFn = Box<
     dyn Fn([u32; DEFERRAL_DIGEST_SIZE], [u32; DEFERRAL_DIGEST_SIZE]) -> [u32; DEFERRAL_DIGEST_SIZE]
         + Send
         + Sync,
@@ -130,20 +134,12 @@ impl ExtInstr for DeferralOutputInstr {
 
 /// The Deferral extension (CALL + OUTPUT opcodes).
 pub struct DeferralRvrExtension {
-    #[allow(dead_code)]
-    call_chip_idx: Option<AirIndex>,
     output_chip_idx: Option<AirIndex>,
     poseidon2_chip_idx: Option<AirIndex>,
-    deferral_ctx: DeferralCtx,
 }
 
 impl DeferralRvrExtension {
-    pub fn new(
-        ctx: Option<&RvrExtensionCtx>,
-        fns: Vec<Arc<DeferralFn>>,
-        hash: DeferralHashFn,
-        compress: DeferralCompressFn,
-    ) -> Result<Self, ExtensionError> {
+    pub fn new(ctx: Option<&RvrExtensionCtx>) -> Result<Self, ExtensionError> {
         let call_chip_idx = opcode_air_idx(ctx, DeferralOpcode::CALL)?;
         let output_chip_idx = opcode_air_idx(ctx, DeferralOpcode::OUTPUT)?;
         // The Poseidon2 hasher is registered adjacent to the CALL chip and
@@ -151,22 +147,20 @@ impl DeferralRvrExtension {
         let poseidon2_chip_idx = call_chip_idx.map(AirIndex::next);
 
         Ok(Self {
-            call_chip_idx,
             output_chip_idx,
             poseidon2_chip_idx,
-            deferral_ctx: DeferralCtx::new(fns, hash, compress),
         })
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for DeferralRvrExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == DeferralOpcode::CALL.global_opcode_usize() {
             let rd_reg = decode_reg(insn.a);
             let rs_reg = decode_reg(insn.b);
-            let def_idx = insn.c.as_canonical_u32();
+            let def_idx = insn.c;
             return Some(LiftedInstr::Body(InstrAt {
                 pc,
                 instr: Instr::Ext(Box::new(DeferralCallInstr {
@@ -182,7 +176,7 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
         if opcode == DeferralOpcode::OUTPUT.global_opcode_usize() {
             let rd_reg = decode_reg(insn.a);
             let rs_reg = decode_reg(insn.b);
-            let def_idx = insn.c.as_canonical_u32();
+            let def_idx = insn.c;
             return Some(LiftedInstr::Body(InstrAt {
                 pc,
                 instr: Instr::Ext(Box::new(DeferralOutputInstr {
@@ -212,7 +206,35 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
             include_str!("../c/rvr_ext_deferral.c"),
         )]
     }
+}
 
+type DeferralCallLookupFn = unsafe extern "C" fn(*mut c_void, *mut c_void, u32, *const u8, *mut u8);
+type DeferralOutputLookupFn =
+    unsafe extern "C" fn(*mut c_void, *mut c_void, u32, *const u8, *mut u8, u32);
+
+pub struct DeferralRuntimeHooks {
+    deferral_ctx: DeferralCtx,
+    call_lookup: DeferralCallLookupFn,
+}
+
+impl DeferralRuntimeHooks {
+    /// # Safety
+    ///
+    /// `F` must be the field used by the VM state whose deferral memory is
+    /// passed to these callbacks.
+    pub unsafe fn new<F: PrimeField32>(
+        fns: Vec<Arc<DeferralFn>>,
+        hash: DeferralHashFn,
+        compress: DeferralCompressFn,
+    ) -> Self {
+        Self {
+            deferral_ctx: DeferralCtx::new(fns, hash, compress),
+            call_lookup: host_deferral_call_lookup::<F>,
+        }
+    }
+}
+
+impl RvrRuntimeExtension for DeferralRuntimeHooks {
     unsafe fn register_host_callbacks(
         &self,
         lib: &libloading::Library,
@@ -226,8 +248,8 @@ impl<F: PrimeField32> RvrExtension<F> for DeferralRvrExtension {
         // `ctx` aliases `self.deferral_ctx`; the C side must not outlive `self`.
         let callbacks = DeferralHostCallbacks {
             ctx: &self.deferral_ctx as *const DeferralCtx as *mut c_void,
-            call_lookup: host_deferral_call_lookup::<F>,
-            output_lookup: host_deferral_output_lookup::<F>,
+            call_lookup: self.call_lookup,
+            output_lookup: host_deferral_output_lookup,
         };
         unsafe { register_fn(&callbacks) };
         Ok(())
@@ -248,48 +270,48 @@ fn commit_bytes_to_field_values(
     out
 }
 
-fn has_deferral_digest_range<F: PrimeField32>(io: &OpenVmIoState<'_, F>, ptr: usize) -> bool {
-    !io.deferral_memory.is_null()
-        && ptr
-            .checked_add(DEFERRAL_DIGEST_SIZE)
-            .is_some_and(|end| end <= io.deferral_memory_len)
+/// # Safety
+/// `io.deferral_memory` must point to a live DEFERRAL_AS buffer containing
+/// initialized native `F` values and have exclusive access for the returned
+/// slice's lifetime.
+unsafe fn deferral_memory<'a, F: PrimeField32>(io: &'a mut OpenVmIoState<'_>) -> &'a mut [F] {
+    assert_eq!(io.deferral_memory_len_bytes % size_of::<F>(), 0);
+    if io.deferral_memory_len_bytes == 0 {
+        return &mut [];
+    }
+    assert!(!io.deferral_memory.is_null());
+    assert_eq!(io.deferral_memory.addr() % align_of::<F>(), 0);
+    unsafe {
+        std::slice::from_raw_parts_mut(
+            io.deferral_memory.cast(),
+            io.deferral_memory_len_bytes / size_of::<F>(),
+        )
+    }
 }
 
-/// Reads one accumulator digest from DEFERRAL_AS as canonical u32 values.
-///
-/// # Safety
-/// Caller must ensure `io.deferral_memory` is a valid `*mut F` pointing into
-/// a live DEFERRAL_AS buffer with at least `io.deferral_memory_len` F slots.
-unsafe fn read_deferral_digest<F: PrimeField32>(
-    io: &OpenVmIoState<'_, F>,
+fn read_deferral_digest<F: PrimeField32>(
+    memory: &[F],
     ptr: usize,
 ) -> Option<[u32; DEFERRAL_DIGEST_SIZE]> {
-    if !has_deferral_digest_range(io, ptr) {
-        return None;
-    }
-    let mut out = [0u32; DEFERRAL_DIGEST_SIZE];
-    for (i, dst) in out.iter_mut().enumerate() {
-        *dst = (*io.deferral_memory.add(ptr + i)).as_canonical_u32();
-    }
-    Some(out)
+    let end = ptr.checked_add(DEFERRAL_DIGEST_SIZE)?;
+    let values = memory.get(ptr..end)?;
+    Some(std::array::from_fn(|i| values[i].as_canonical_u32()))
 }
 
-/// Writes one accumulator digest to DEFERRAL_AS.
-///
-/// # Safety
-/// See `read_deferral_digest`. Each canonical u32 is converted back to `F`
-/// before writing to AS=4.
-unsafe fn write_deferral_digest<F: PrimeField32>(
-    io: &mut OpenVmIoState<'_, F>,
+fn write_deferral_digest<F: PrimeField32>(
+    memory: &mut [F],
     ptr: usize,
     values: [u32; DEFERRAL_DIGEST_SIZE],
 ) -> bool {
-    if !has_deferral_digest_range(io, ptr) {
+    let Some(end) = ptr.checked_add(DEFERRAL_DIGEST_SIZE) else {
         return false;
-    }
-    for (i, value) in values.into_iter().enumerate() {
-        *io.deferral_memory.add(ptr + i) = F::from_u32(value);
-    }
+    };
+    let Some(dst) = memory.get_mut(ptr..end) else {
+        return false;
+    };
+    dst.iter_mut()
+        .zip(values)
+        .for_each(|(dst, value)| *dst = F::from_u32(value));
     true
 }
 
@@ -297,25 +319,26 @@ unsafe fn write_deferral_digest<F: PrimeField32>(
 /// Slot offsets are in F-element units.
 unsafe fn update_deferral_accumulators<F: PrimeField32>(
     deferral_ctx: &DeferralCtx,
-    io: &mut OpenVmIoState<'_, F>,
+    io: &mut OpenVmIoState<'_>,
     def_idx: u32,
     input_commit: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
     output_commit: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
 ) -> bool {
+    let memory = unsafe { deferral_memory::<F>(io) };
     let input_acc_ptr = 2 * def_idx as usize * DEFERRAL_DIGEST_SIZE;
     let output_acc_ptr = input_acc_ptr + DEFERRAL_DIGEST_SIZE;
-    let Some(old_input_acc) = read_deferral_digest(io, input_acc_ptr) else {
+    let Some(old_input_acc) = read_deferral_digest(memory, input_acc_ptr) else {
         return false;
     };
-    let Some(old_output_acc) = read_deferral_digest(io, output_acc_ptr) else {
+    let Some(old_output_acc) = read_deferral_digest(memory, output_acc_ptr) else {
         return false;
     };
     let new_input_acc =
         (deferral_ctx.compress)(old_input_acc, commit_bytes_to_field_values(input_commit));
     let new_output_acc =
         (deferral_ctx.compress)(old_output_acc, commit_bytes_to_field_values(output_commit));
-    write_deferral_digest(io, input_acc_ptr, new_input_acc)
-        && write_deferral_digest(io, output_acc_ptr, new_output_acc)
+    write_deferral_digest(memory, input_acc_ptr, new_input_acc)
+        && write_deferral_digest(memory, output_acc_ptr, new_output_acc)
 }
 
 // ── Host callbacks ──────────────────────────────────────────────────────────
@@ -326,8 +349,8 @@ type RegisterFn = unsafe extern "C" fn(*const DeferralHostCallbacks);
 #[repr(C)]
 pub struct DeferralHostCallbacks {
     pub ctx: *mut c_void,
-    pub call_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, u32, *const u8, *mut u8),
-    pub output_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, u32, *const u8, *mut u8, u32),
+    pub call_lookup: DeferralCallLookupFn,
+    pub output_lookup: DeferralOutputLookupFn,
 }
 
 /// Deferral CALL lookup. Panics if `def_idx` or the accumulator update is
@@ -336,7 +359,7 @@ pub struct DeferralHostCallbacks {
 /// # Safety
 ///
 /// `d_ctx` must point to a valid `DeferralCtx`. `io_ctx` must point to a valid
-/// `OpenVmIoState<'_, F>`.
+/// `OpenVmIoState` whose deferral memory contains native `F` values.
 /// `input_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
 /// `output_key_out` must point to `DEFERRAL_OUTPUT_KEY_BYTES` writable bytes.
 pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
@@ -347,7 +370,7 @@ pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
     output_key_out: *mut u8,
 ) {
     let deferral_ctx = unsafe { &*(d_ctx as *const DeferralCtx) };
-    let io = unsafe { &mut *(io_ctx as *mut OpenVmIoState<'_, F>) };
+    let io = unsafe { &mut *(io_ctx as *mut OpenVmIoState<'_>) };
 
     let mut input_commit = [0u8; DEFERRAL_COMMIT_NUM_BYTES];
     input_commit.copy_from_slice(unsafe {
@@ -382,7 +405,13 @@ pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
 
     assert!(
         unsafe {
-            update_deferral_accumulators(deferral_ctx, io, def_idx, &input_commit, &output_commit)
+            update_deferral_accumulators::<F>(
+                deferral_ctx,
+                io,
+                def_idx,
+                &input_commit,
+                &output_commit,
+            )
         },
         "deferral CALL lookup failed: accumulator update for def_idx={def_idx}"
     );
@@ -405,10 +434,10 @@ pub unsafe extern "C" fn host_deferral_call_lookup<F: PrimeField32>(
 /// # Safety
 ///
 /// `d_ctx` must point to a valid `DeferralCtx`. `io_ctx` must point to a
-/// valid `OpenVmIoState<'_, F>`.
+/// valid `OpenVmIoState`.
 /// `output_commit_raw` must point to `DEFERRAL_COMMIT_NUM_BYTES` readable bytes.
 /// `output_raw_out` must point to at least `expected_len` writable bytes.
-pub unsafe extern "C" fn host_deferral_output_lookup<F: PrimeField32>(
+pub unsafe extern "C" fn host_deferral_output_lookup(
     _d_ctx: *mut c_void,
     io_ctx: *mut c_void,
     def_idx: u32,
@@ -416,7 +445,7 @@ pub unsafe extern "C" fn host_deferral_output_lookup<F: PrimeField32>(
     output_raw_out: *mut u8,
     expected_len: u32,
 ) {
-    let io = unsafe { &*(io_ctx as *const OpenVmIoState<'_, F>) };
+    let io = unsafe { &*(io_ctx as *const OpenVmIoState<'_>) };
 
     let output_commit: Vec<u8> = unsafe {
         std::slice::from_raw_parts(output_commit_raw, DEFERRAL_COMMIT_NUM_BYTES).to_vec()

--- a/extensions/ecc/circuit/src/extension/weierstrass.rs
+++ b/extensions/ecc/circuit/src/extension/weierstrass.rs
@@ -19,7 +19,9 @@ use openvm_instructions::{LocalOpcode, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
+use rvr_openvm_ext_ecc::EccExtension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use strum::EnumCount;
@@ -85,15 +87,13 @@ impl WeierstrassExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for WeierstrassExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {
         let struct_names = self
             .supported_curves
             .iter()
             .map(|c| c.struct_name.clone())
             .collect();
-        registry.register(rvr_openvm_ext_ecc::EccExtension::new_from_struct_names(
-            struct_names,
-        ));
+        extensions.register_lifter(EccExtension::new_from_struct_names(struct_names));
     }
 }
 

--- a/extensions/ecc/rvr/Cargo.toml
+++ b/extensions/ecc/rvr/Cargo.toml
@@ -13,7 +13,6 @@ rvr-openvm-lift.workspace = true
 
 openvm-ecc-transpiler.workspace = true
 openvm-instructions.workspace = true
-openvm-stark-backend.workspace = true
 
 strum.workspace = true
 

--- a/extensions/ecc/rvr/src/lib.rs
+++ b/extensions/ecc/rvr/src/lib.rs
@@ -8,10 +8,9 @@
 use openvm_ecc_transpiler::Rv64WeierstrassOpcode::{
     self, EC_ADD_NE, EC_DOUBLE, SETUP_EC_ADD_NE, SETUP_EC_DOUBLE,
 };
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
-use openvm_stark_backend::p3_field::PrimeField32;
+use openvm_instructions::LocalOpcode;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
-use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
+use rvr_openvm_lift::{helpers::decode_reg, RvrExtension, RvrInstruction};
 use strum::EnumCount;
 
 #[derive(Debug, Clone, Copy)]
@@ -164,8 +163,8 @@ impl EccExtension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for EccExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for EccExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         let ecc_base = Rv64WeierstrassOpcode::CLASS_OFFSET;

--- a/extensions/keccak256/circuit/src/extension/mod.rs
+++ b/extensions/keccak256/circuit/src/extension/mod.rs
@@ -31,7 +31,9 @@ use openvm_stark_backend::{
     interaction::PermutationCheckBus, p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val,
 };
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::VmRvrExtension;
+use rvr_openvm_ext_keccak::KeccakExtension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
@@ -123,14 +125,9 @@ pub struct Keccak256;
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Keccak256 {
-    fn extend_rvr(
-        &self,
-        registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
-        ctx: Option<&rvr_openvm_lift::RvrExtensionCtx>,
-    ) {
-        let ext = rvr_openvm_ext_keccak::KeccakExtension::new(ctx)
-            .expect("failed to construct rvr KeccakExtension");
-        registry.register(ext);
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, ctx: Option<&RvrExtensionCtx>) {
+        let ext = KeccakExtension::new(ctx).expect("failed to construct rvr KeccakExtension");
+        extensions.register_lifter(ext);
     }
 }
 

--- a/extensions/keccak256/rvr/Cargo.toml
+++ b/extensions/keccak256/rvr/Cargo.toml
@@ -13,7 +13,6 @@ rvr-openvm-lift.workspace = true
 
 openvm-instructions.workspace = true
 openvm-keccak256-transpiler.workspace = true
-openvm-stark-backend.workspace = true
 
 [build-dependencies]
 rvr-openvm-build.workspace = true

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -5,13 +5,12 @@
 //! `.c` shim is emitted alongside generated code so clang can inline the
 //! tracer helpers across the call boundary.
 
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::LocalOpcode;
 use openvm_keccak256_transpiler::{KeccakfOpcode, XorinOpcode};
-use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
     air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
-    RvrExtensionCtx,
+    RvrExtensionCtx, RvrInstruction,
 };
 
 /// keccak-f\[1600\]: read 200 bytes via `buffer_ptr_reg`, permute in place.
@@ -103,8 +102,8 @@ impl KeccakExtension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for KeccakExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for KeccakExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == KeccakfOpcode::KECCAKF.global_opcode_usize() {

--- a/extensions/pairing/circuit/src/pairing_extension.rs
+++ b/extensions/pairing/circuit/src/pairing_extension.rs
@@ -23,7 +23,9 @@ use openvm_pairing_transpiler::PairingPhantom;
 use openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_backend::{StarkEngine, StarkProtocolConfig};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
+use rvr_openvm_ext_pairing::PairingExtension as PairingRvrExtension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 use strum::FromRepr;
 
@@ -70,8 +72,8 @@ pub struct PairingExtension {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for PairingExtension {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
-        registry.register(rvr_openvm_ext_pairing::PairingExtension::new());
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {
+        extensions.register_lifter(PairingRvrExtension::new());
     }
 }
 

--- a/extensions/pairing/rvr/Cargo.toml
+++ b/extensions/pairing/rvr/Cargo.toml
@@ -13,7 +13,6 @@ rvr-openvm-lift.workspace = true
 
 openvm-instructions.workspace = true
 openvm-pairing-transpiler.workspace = true
-openvm-stark-backend.workspace = true
 
 [build-dependencies]
 rvr-openvm-build.workspace = true

--- a/extensions/pairing/rvr/src/lib.rs
+++ b/extensions/pairing/rvr/src/lib.rs
@@ -3,11 +3,10 @@
 //! Provides an IR node for the `HintFinalExp` phantom instruction and the
 //! `PairingExtension` for lifting and executing it via FFI.
 
-use openvm_instructions::{instruction::Instruction, LocalOpcode, SystemOpcode};
+use openvm_instructions::{LocalOpcode, SystemOpcode};
 use openvm_pairing_transpiler::PairingPhantom;
-use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
-use rvr_openvm_lift::{helpers::decode_reg, RvrExtension};
+use rvr_openvm_lift::{helpers::decode_reg, RvrExtension, RvrInstruction};
 
 #[derive(Debug, Clone, Copy)]
 enum KnownPairingCurve {
@@ -83,15 +82,15 @@ impl Default for PairingExtension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for PairingExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for PairingExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode != SystemOpcode::PHANTOM.global_opcode_usize() {
             return None;
         }
 
-        let c_val = insn.c.as_canonical_u32();
+        let c_val = insn.c;
         let discriminant = (c_val & 0xffff) as u16;
         let curve_idx = (c_val >> 16) as u16;
 

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -32,9 +32,11 @@ use openvm_riscv_transpiler::{
 use openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_backend::{StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_ext_riscv::{Rv64IExtension, Rv64IoExtension};
+use rvr_openvm_ext_riscv::{
+    Rv64IExtension, Rv64IRuntimeHooks, Rv64IoExtension, Rv64IoRuntimeHooks,
+};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::{ExtensionRegistry, RvrExtensionCtx, VmRvrExtension};
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
@@ -89,16 +91,19 @@ fn default_range_tuple_checker_sizes() -> [u32; 2] {
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Rv64I {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, _ctx: Option<&RvrExtensionCtx>) {
-        registry.register(Rv64IExtension::new());
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {
+        extensions.register_lifter(Rv64IExtension::new());
+        extensions.register_runtime_hook(Rv64IRuntimeHooks);
     }
 }
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Rv64Io {
-    fn extend_rvr(&self, registry: &mut ExtensionRegistry<F>, ctx: Option<&RvrExtensionCtx>) {
-        registry
-            .register(Rv64IoExtension::new(ctx).expect("Rv64IoExtension chip resolution failed"));
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, ctx: Option<&RvrExtensionCtx>) {
+        extensions.register_lifter(
+            Rv64IoExtension::new(ctx).expect("Rv64IoExtension chip resolution failed"),
+        );
+        extensions.register_runtime_hook(Rv64IoRuntimeHooks);
     }
 }
 

--- a/extensions/riscv/rvr/Cargo.toml
+++ b/extensions/riscv/rvr/Cargo.toml
@@ -15,7 +15,6 @@ rvr-openvm-lift = { workspace = true, optional = true }
 openvm-circuit = { workspace = true, optional = true }
 openvm-instructions = { workspace = true, optional = true }
 openvm-riscv-transpiler = { workspace = true, optional = true }
-openvm-stark-backend = { workspace = true, optional = true }
 
 libloading = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
@@ -32,7 +31,6 @@ rvr = [
     "openvm-circuit/rvr",
     "dep:openvm-instructions",
     "dep:openvm-riscv-transpiler",
-    "dep:openvm-stark-backend",
     "dep:libloading",
     "dep:rand",
 ]

--- a/extensions/riscv/rvr/c/rv64i_phantom_callbacks.c
+++ b/extensions/riscv/rvr/c/rv64i_phantom_callbacks.c
@@ -13,8 +13,7 @@ typedef struct {
   void (*hint_random)(void* ctx, uint32_t num_words);
 } Rv64IPhantomCallbacks;
 
-/* NOT thread-safe: installs one process-global callback table. */
-static Rv64IPhantomCallbacks g_rv64i_phantom_callbacks;
+static thread_local Rv64IPhantomCallbacks g_rv64i_phantom_callbacks;
 
 void register_rv64i_phantom_callbacks(const Rv64IPhantomCallbacks* cb) {
   g_rv64i_phantom_callbacks = *cb;

--- a/extensions/riscv/rvr/c/rv64i_phantom_callbacks.h
+++ b/extensions/riscv/rvr/c/rv64i_phantom_callbacks.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 /* Forwarding stubs owned by the RISC-V base (Rv64I) extension: the IO phantoms
- * (HINT_INPUT, PRINT_STR, HINT_RANDOM). Backed by a dispatch table installed
- * by `Rv64IExtension::register_host_callbacks`. */
+ * (HINT_INPUT, PRINT_STR, HINT_RANDOM). Backed by a thread-local dispatch table
+ * installed at execution time by `Rv64IRuntimeHooks`. */
 void openvm_hint_input(void);
 void openvm_print_str(uint64_t ptr, uint32_t len);
 void openvm_hint_random(uint32_t num_words);

--- a/extensions/riscv/rvr/c/rv64io_callbacks.c
+++ b/extensions/riscv/rvr/c/rv64io_callbacks.c
@@ -14,8 +14,7 @@ typedef struct {
   void (*reveal)(void* ctx, uint64_t src_val, uint64_t ptr, uint32_t offset, uint32_t width);
 } Rv64IoHostCallbacks;
 
-/* NOT thread-safe: installs one process-global callback table. */
-static Rv64IoHostCallbacks g_rv64io_callbacks;
+static thread_local Rv64IoHostCallbacks g_rv64io_callbacks;
 
 void register_rv64io_callbacks(const Rv64IoHostCallbacks* cb) { g_rv64io_callbacks = *cb; }
 

--- a/extensions/riscv/rvr/c/rv64io_callbacks.h
+++ b/extensions/riscv/rvr/c/rv64io_callbacks.h
@@ -5,8 +5,8 @@
 
 /* Forwarding stubs owned by the RISC-V IO (Rv64Io) extension: the hint-store
  * consumers (HINT_STOREW, HINT_BUFFER) and public-values stores routed through
- * openvm_reveal. Backed by a dispatch table installed by
- * `Rv64IoExtension::register_host_callbacks`. */
+ * openvm_reveal. Backed by a thread-local dispatch table installed at execution
+ * time by `Rv64IoRuntimeHooks`. */
 void openvm_hint_storew(uint64_t dest_addr);
 void openvm_hint_buffer(uint64_t dest_addr, uint32_t num_words);
 void openvm_reveal(uint64_t src_val, uint64_t ptr, uint32_t offset, uint32_t width);

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -9,18 +9,16 @@ use std::{ffi::c_void, io::Write};
 
 use openvm_circuit::arch::rvr::io::{check_mem_bounds_range, OpenVmIoState};
 use openvm_instructions::{
-    instruction::Instruction,
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_NUM_LIMBS},
     LocalOpcode, SystemOpcode,
 };
 use openvm_riscv_transpiler::{Rv64HintStoreOpcode, Rv64LoadStoreOpcode, Rv64Phantom};
-use openvm_stark_backend::p3_field::PrimeField32;
 use rand::Rng;
 use rvr_openvm_ext_ffi_common::{AS_PUBLIC_VALUES, AS_REGISTER};
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, MemWidth, Reg};
 use rvr_openvm_lift::{
     air_index_to_c, decode_imm_cg, decode_reg, opcode_air_idx, AirIndex, ExtensionError,
-    RvrExtension, RvrExtensionCtx,
+    RvrExtension, RvrExtensionCtx, RvrInstruction, RvrRuntimeExtension,
 };
 
 /// HINT_STORED: pop one register word (8 bytes) from the hint stream into `mem[reg[ptr_reg]]`.
@@ -195,8 +193,8 @@ impl Rv64IoExtension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for Rv64IoExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for Rv64IoExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == Rv64HintStoreOpcode::HINT_STORED.global_opcode_usize() {
@@ -254,7 +252,11 @@ impl<F: PrimeField32> RvrExtension<F> for Rv64IoExtension {
             include_str!("../c/rv64io_callbacks.c"),
         )]
     }
+}
 
+pub struct Rv64IoRuntimeHooks;
+
+impl RvrRuntimeExtension for Rv64IoRuntimeHooks {
     unsafe fn register_host_callbacks(
         &self,
         lib: &libloading::Library,
@@ -266,17 +268,17 @@ impl<F: PrimeField32> RvrExtension<F> for Rv64IoExtension {
             *sym
         };
         let callbacks = Rv64IoHostCallbacks {
-            hint_storew: host_hint_storew::<F>,
-            hint_buffer: host_hint_buffer::<F>,
-            reveal: host_reveal::<F>,
+            hint_storew: host_hint_storew,
+            hint_buffer: host_hint_buffer,
+            reveal: host_reveal,
         };
         unsafe { register_fn(&callbacks) };
         Ok(())
     }
 }
 
-fn public_values_store_width<F: PrimeField32>(insn: &Instruction<F>) -> Option<MemWidth> {
-    if insn.d.as_canonical_u32() != AS_REGISTER || insn.e.as_canonical_u32() != AS_PUBLIC_VALUES {
+fn public_values_store_width(insn: &RvrInstruction) -> Option<MemWidth> {
+    if insn.d != AS_REGISTER || insn.e != AS_PUBLIC_VALUES {
         return None;
     }
 
@@ -313,12 +315,12 @@ impl Default for Rv64IExtension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for Rv64IExtension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for Rv64IExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         if insn.opcode.as_usize() != SystemOpcode::PHANTOM.global_opcode_usize() {
             return None;
         }
-        let discriminant = (insn.c.as_canonical_u32() & 0xffff) as u16;
+        let discriminant = (insn.c & 0xffff) as u16;
         let phantom = Rv64Phantom::from_repr(discriminant)?;
         let instr: Box<dyn ExtInstr> = match phantom {
             Rv64Phantom::HintInput => Box::new(HintInputInstr),
@@ -350,7 +352,11 @@ impl<F: PrimeField32> RvrExtension<F> for Rv64IExtension {
             include_str!("../c/rv64i_phantom_callbacks.c"),
         )]
     }
+}
 
+pub struct Rv64IRuntimeHooks;
+
+impl RvrRuntimeExtension for Rv64IRuntimeHooks {
     unsafe fn register_host_callbacks(
         &self,
         lib: &libloading::Library,
@@ -362,9 +368,9 @@ impl<F: PrimeField32> RvrExtension<F> for Rv64IExtension {
             *sym
         };
         let callbacks = Rv64IPhantomCallbacks {
-            hint_input: host_hint_input::<F>,
-            print_str: host_print_str::<F>,
-            hint_random: host_hint_random::<F>,
+            hint_input: host_hint_input,
+            print_str: host_print_str,
+            hint_random: host_hint_random,
         };
         unsafe { register_fn(&callbacks) };
         Ok(())
@@ -395,8 +401,8 @@ pub struct Rv64IoHostCallbacks {
 /// HintInput: pop next input record from VmState's input_stream and overwrite
 /// the active hint stream with `[len: u64 LE][data][padding to 8-byte align]`,
 /// stored directly as bytes.
-pub extern "C" fn host_hint_input<F: PrimeField32>(ctx: *mut c_void) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+pub extern "C" fn host_hint_input(ctx: *mut c_void) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     io.hint_stream.clear();
     if let Some(mut vec) = io.input_stream.pop_front() {
         let data_len = vec.len();
@@ -409,8 +415,8 @@ pub extern "C" fn host_hint_input<F: PrimeField32>(ctx: *mut c_void) {
 }
 
 /// PrintStr: read UTF-8 from guest memory and print to stdout.
-pub extern "C" fn host_print_str<F: PrimeField32>(ctx: *mut c_void, ptr: u64, len: u32) {
-    let io = unsafe { &*(ctx as *const OpenVmIoState<'_, F>) };
+pub extern "C" fn host_print_str(ctx: *mut c_void, ptr: u64, len: u32) {
+    let io = unsafe { &*(ctx as *const OpenVmIoState<'_>) };
     if len > 0 && !io.memory_ptr.is_null() {
         check_mem_bounds_range(ptr, len as usize);
         let slice =
@@ -422,8 +428,8 @@ pub extern "C" fn host_print_str<F: PrimeField32>(ctx: *mut c_void, ptr: u64, le
 
 /// HintRandom: refill the hint stream with `num_words * RV64_REGISTER_NUM_LIMBS` random
 /// bytes drawn from VmState's persistent RNG.
-pub extern "C" fn host_hint_random<F: PrimeField32>(ctx: *mut c_void, num_words: u32) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+pub extern "C" fn host_hint_random(ctx: *mut c_void, num_words: u32) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     let nbytes = num_words as usize * RV64_REGISTER_NUM_LIMBS;
     io.hint_stream.clear();
     for _ in 0..nbytes {
@@ -433,8 +439,8 @@ pub extern "C" fn host_hint_random<F: PrimeField32>(ctx: *mut c_void, num_words:
 
 /// HINT_STOREW: pop one rv64 register-width word (8 bytes) from the hint stream
 /// and write it to guest memory at `dest_addr`.
-pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr: u64) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+pub extern "C" fn host_hint_storew(ctx: *mut c_void, dest_addr: u64) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     if io.hint_stream.len() < RV64_REGISTER_NUM_LIMBS || io.memory_ptr.is_null() {
         return;
     }
@@ -454,12 +460,8 @@ pub extern "C" fn host_hint_storew<F: PrimeField32>(ctx: *mut c_void, dest_addr:
 
 /// HINT_BUFFER: pop `num_words * RV64_REGISTER_NUM_LIMBS` bytes from the hint stream
 /// and copy them into guest memory.
-pub extern "C" fn host_hint_buffer<F: PrimeField32>(
-    ctx: *mut c_void,
-    dest_addr: u64,
-    num_words: u32,
-) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+pub extern "C" fn host_hint_buffer(ctx: *mut c_void, dest_addr: u64, num_words: u32) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     let nbytes = num_words as usize * RV64_REGISTER_NUM_LIMBS;
     if io.hint_stream.len() < nbytes || io.memory_ptr.is_null() {
         return;
@@ -474,14 +476,8 @@ pub extern "C" fn host_hint_buffer<F: PrimeField32>(
 
 /// Host callback for stores to `PUBLIC_VALUES_AS`.
 /// Cost corrections are handled in generated C.
-pub extern "C" fn host_reveal<F: PrimeField32>(
-    ctx: *mut c_void,
-    src_val: u64,
-    ptr: u64,
-    offset: u32,
-    width: u32,
-) {
-    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_, F>) };
+pub extern "C" fn host_reveal(ctx: *mut c_void, src_val: u64, ptr: u64, offset: u32, width: u32) {
+    let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     let start = ptr as usize + offset as usize;
     let width = width as usize;
     let end = start + width;
@@ -497,6 +493,7 @@ pub extern "C" fn host_reveal<F: PrimeField32>(
 mod tests {
     use std::collections::VecDeque;
 
+    use openvm_instructions::instruction::Instruction;
     use p3_baby_bear::BabyBear;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -576,7 +573,7 @@ mod tests {
             (Rv64LoadStoreOpcode::STOREH, 2),
             (Rv64LoadStoreOpcode::STOREB, 1),
         ] {
-            let inst = Instruction::<BabyBear>::from_usize(
+            let inst = RvrInstruction::from_field(&Instruction::<BabyBear>::from_usize(
                 opcode.global_opcode(),
                 [
                     8,
@@ -587,7 +584,7 @@ mod tests {
                     1,
                     0,
                 ],
-            );
+            ));
             let lifted = ext.try_lift(&inst, 0x100).unwrap();
             let LiftedInstr::Body(InstrAt {
                 instr: Instr::Ext(instr),
@@ -609,7 +606,7 @@ mod tests {
     #[test]
     fn rv64io_rejects_public_values_store_with_non_register_d() {
         let ext = Rv64IoExtension::new(None).unwrap();
-        let inst = Instruction::<BabyBear>::from_usize(
+        let inst = RvrInstruction::from_field(&Instruction::<BabyBear>::from_usize(
             Rv64LoadStoreOpcode::STORED.global_opcode(),
             [
                 8,
@@ -620,7 +617,7 @@ mod tests {
                 1,
                 0,
             ],
-        );
+        ));
 
         assert!(ext.try_lift(&inst, 0x100).is_none());
     }
@@ -628,7 +625,7 @@ mod tests {
     #[test]
     fn rv64io_ignores_non_store_public_values_shaped_instruction() {
         let ext = Rv64IoExtension::new(None).unwrap();
-        let inst = Instruction::<BabyBear>::from_usize(
+        let inst = RvrInstruction::from_field(&Instruction::<BabyBear>::from_usize(
             SystemOpcode::TERMINATE.global_opcode(),
             [
                 8,
@@ -639,7 +636,7 @@ mod tests {
                 1,
                 0,
             ],
-        );
+        ));
 
         assert!(ext.try_lift(&inst, 0x100).is_none());
     }
@@ -671,19 +668,19 @@ mod tests {
         let mut public_values = vec![0u8; 16];
         let mut deferrals = Vec::new();
 
-        let mut io = OpenVmIoState::<BabyBear> {
+        let mut io = OpenVmIoState {
             input_stream: &mut input_stream,
             hint_stream: &mut hint_stream,
             rng: &mut rng,
             memory_ptr: memory.as_mut_ptr(),
             public_values: &mut public_values,
             deferral_memory: std::ptr::null_mut(),
-            deferral_memory_len: 0,
+            deferral_memory_len_bytes: 0,
             deferrals: &mut deferrals,
         };
 
-        host_reveal::<BabyBear>(
-            &mut io as *mut OpenVmIoState<'_, BabyBear> as *mut c_void,
+        host_reveal(
+            &mut io as *mut OpenVmIoState<'_> as *mut c_void,
             0x11223344,
             4,
             2,
@@ -702,19 +699,19 @@ mod tests {
         let mut public_values = vec![0u8; 16];
         let mut deferrals = Vec::new();
 
-        let mut io = OpenVmIoState::<BabyBear> {
+        let mut io = OpenVmIoState {
             input_stream: &mut input_stream,
             hint_stream: &mut hint_stream,
             rng: &mut rng,
             memory_ptr: memory.as_mut_ptr(),
             public_values: &mut public_values,
             deferral_memory: std::ptr::null_mut(),
-            deferral_memory_len: 0,
+            deferral_memory_len_bytes: 0,
             deferrals: &mut deferrals,
         };
 
-        host_reveal::<BabyBear>(
-            &mut io as *mut OpenVmIoState<'_, BabyBear> as *mut c_void,
+        host_reveal(
+            &mut io as *mut OpenVmIoState<'_> as *mut c_void,
             0x1122334455667788,
             3,
             0,

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -2,6 +2,8 @@
 mod tests {
     #[cfg(all(feature = "rvr", not(feature = "unprotected")))]
     use std::{env, process::Command};
+    #[cfg(feature = "rvr")]
+    use std::{sync::Barrier, thread};
 
     use eyre::Result;
     use openvm_circuit::{
@@ -73,6 +75,51 @@ mod tests {
     #[cfg(feature = "rvr")]
     fn test_rvr_fibonacci() {
         execute_rvr_example("fibonacci");
+    }
+
+    #[test]
+    #[cfg(feature = "rvr")]
+    fn test_rvr_concurrent_host_contexts() -> Result<()> {
+        const NUM_THREADS: usize = 8;
+        const NUM_RUNS: usize = 8;
+
+        let mut config = test_rv64im_config();
+        config.rv64i.system = config.rv64i.system.with_public_values_bytes(64);
+        let elf = build_example_program_at_path(get_programs_dir!(), "reveal", &config)?;
+        let exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv64ITranspilerExtension)
+                .with_extension(Rv64MTranspilerExtension)
+                .with_extension(Rv64IoTranspilerExtension),
+        )?;
+        let executor = VmExecutor::new(config)?;
+        let instance = executor.instance(&exe)?;
+        let barrier = Barrier::new(NUM_THREADS);
+        let expected_prefix = (0u8..32).collect::<Vec<_>>();
+
+        thread::scope(|scope| {
+            for _ in 0..NUM_THREADS {
+                scope.spawn(|| {
+                    barrier.wait();
+                    for _ in 0..NUM_RUNS {
+                        let state = instance.execute(vec![], None).unwrap();
+                        let public_values = extract_public_values(64, &state.memory.memory);
+                        assert_eq!(&public_values[..32], &expected_prefix);
+                        assert_eq!(
+                            u64::from_le_bytes(public_values[32..40].try_into().unwrap()),
+                            123
+                        );
+                        assert_eq!(
+                            u64::from_le_bytes(public_values[40..48].try_into().unwrap()),
+                            456
+                        );
+                    }
+                });
+            }
+        });
+
+        Ok(())
     }
 
     #[cfg(all(feature = "rvr", not(feature = "unprotected")))]

--- a/extensions/sha2/circuit/src/extension/mod.rs
+++ b/extensions/sha2/circuit/src/extension/mod.rs
@@ -29,7 +29,9 @@ use openvm_sha2_transpiler::Rv64Sha2Opcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_backend::{StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
-use rvr_openvm_lift::VmRvrExtension;
+use rvr_openvm_ext_sha2::Sha2Extension;
+#[cfg(feature = "rvr")]
+use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::{Sha2BlockHasherChip, Sha2BlockHasherVmAir, Sha2MainAir, Sha2MainChip, Sha2VmExecutor};
@@ -119,14 +121,9 @@ pub struct Sha2;
 
 #[cfg(feature = "rvr")]
 impl<F: PrimeField32> VmRvrExtension<F> for Sha2 {
-    fn extend_rvr(
-        &self,
-        registry: &mut rvr_openvm_lift::ExtensionRegistry<F>,
-        ctx: Option<&rvr_openvm_lift::RvrExtensionCtx>,
-    ) {
-        let ext = rvr_openvm_ext_sha2::Sha2Extension::new(ctx)
-            .expect("failed to construct rvr Sha2Extension");
-        registry.register(ext);
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, ctx: Option<&RvrExtensionCtx>) {
+        let ext = Sha2Extension::new(ctx).expect("failed to construct rvr Sha2Extension");
+        extensions.register_lifter(ext);
     }
 }
 

--- a/extensions/sha2/rvr/Cargo.toml
+++ b/extensions/sha2/rvr/Cargo.toml
@@ -13,7 +13,6 @@ rvr-openvm-lift.workspace = true
 
 openvm-instructions.workspace = true
 openvm-sha2-transpiler.workspace = true
-openvm-stark-backend.workspace = true
 
 [build-dependencies]
 rvr-openvm-build.workspace = true

--- a/extensions/sha2/rvr/src/lib.rs
+++ b/extensions/sha2/rvr/src/lib.rs
@@ -3,13 +3,12 @@
 //! Provides IR nodes for the SHA-256 and SHA-512 opcodes and the
 //! `Sha2Extension` for lifting and executing them via double FFI.
 
-use openvm_instructions::{instruction::Instruction, LocalOpcode};
+use openvm_instructions::LocalOpcode;
 use openvm_sha2_transpiler::Rv64Sha2Opcode;
-use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
     air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
-    RvrExtensionCtx,
+    RvrExtensionCtx, RvrInstruction,
 };
 
 /// IR node for a SHA-256 compress instruction.
@@ -126,8 +125,8 @@ impl Sha2Extension {
     }
 }
 
-impl<F: PrimeField32> RvrExtension<F> for Sha2Extension {
-    fn try_lift(&self, insn: &Instruction<F>, pc: u64) -> Option<LiftedInstr> {
+impl RvrExtension for Sha2Extension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
         let opcode = insn.opcode.as_usize();
 
         if opcode == Rv64Sha2Opcode::SHA256.global_opcode_usize() {


### PR DESCRIPTION
## Summary

This PR removes the proof-field generic `F` from RVR types that only work with native instructions, byte memory, streams, or compiled C artifacts.

`F` is kept only at the boundaries that still need it:

- converting `VmExe<F>` instructions into canonical integer operands during compilation
- reading and writing native field elements in the deferral address space

## What changed

- Converts each field-typed OpenVM instruction into a field-independent `RvrInstruction` before lifting it to RVR IR.
- Makes the RVR lifter registry, generated project, compiled artifact, IO state, and pure/metered instance types field-independent.
- Stops retaining the full `VmExe<F>` in RVR instances. Instances keep only the starting PC and sparse initial-memory image needed to create execution state.
- Keeps compile-time lifters separate from the small set of runtime host callbacks. Only the deferral callback remains specialized for `F`, because deferral memory stores native field elements.
- Removes now-unused field dependencies from the RVR extension crates and simplifies the SDK compiled-instance aliases.
- Uses thread-local C callback slots so concurrent RVR executions on different threads do not overwrite each other's host context.
- Builds the generated native C with the C2Y language mode.
- Adds coverage for canonical instruction lowering, signed offsets, current ADD/SUB/ADDI operand rules, and concurrent host contexts.

## Relation to earlier PRs

This is a follow-up to two already-merged cleanups:

- #2975 changed input and hint streams to store bytes directly.
- #2983 removed `F` from streams, stdin, execution contexts, and the other shared VM types that no longer depended on field elements.

With those changes merged, RVR was the remaining backend carrying `F` through native runtime types mostly because its old instruction and callback interfaces were still field-typed. This PR moves the field conversion to the compilation/deferral boundaries and removes that generic from the rest of the RVR path.

The branch is based directly on the merged #2983 commit and contains only the RVR follow-up changes.

## Validation

- Nightly rustfmt check
- Targeted RVR clippy checks with warnings denied
- `rvr-openvm-lift` tests
- RVR extension and SDK/circuit clippy checks
- Concurrent RVR host-context test

Resolves INT-8781