### PR TITLE
perf(v2.1): remove redundant AddSubW range check

### DIFF
--- a/extensions/bigint/circuit/cuda/src/bigint.cu
+++ b/extensions/bigint/circuit/cuda/src/bigint.cu
@@ -289,7 +289,7 @@ extern "C" int _less_than256_tracegen(
 }
 
 using AddSub256CoreRecord = AddSubCoreRecord<INT256_NUM_U16_LIMBS>;
-using AddSub256Core = AddSubCore<INT256_NUM_U16_LIMBS, U16_BITS>;
+using AddSub256Core = AddSubCore<INT256_NUM_U16_LIMBS, U16_BITS, true>;
 template <typename T> using AddSub256CoreCols = AddSubCoreCols<T, INT256_NUM_U16_LIMBS>;
 
 template <typename T> struct AddSub256Cols {

--- a/extensions/bigint/circuit/src/lib.rs
+++ b/extensions/bigint/circuit/src/lib.rs
@@ -125,7 +125,7 @@ type BranchAdapterExecutor = VecToFlatBranchAdapterExecutor<
 
 /// AddSub256 — u16 limbs, range checker (shares the AluU16 adapter with LessThan256)
 pub type Rv64AddSub256Air =
-    VmAirWrapper<AluU16AdapterAir, AddSubCoreAir<INT256_NUM_U16_LIMBS, U16_BITS>>;
+    VmAirWrapper<AluU16AdapterAir, AddSubCoreAir<INT256_NUM_U16_LIMBS, U16_BITS, true>>;
 #[derive(Clone, PreflightExecutor)]
 pub struct Rv64AddSub256Executor(
     AddSubExecutor<AluU16AdapterExecutor, INT256_NUM_U16_LIMBS, U16_BITS>,
@@ -136,6 +136,7 @@ pub type Rv64AddSub256Chip<F> = VmChipWrapper<
         Rv64VecHeapU16AdapterFiller<NUM_READS, INT256_NUM_MEMORY_BLOCKS, INT256_NUM_MEMORY_BLOCKS>,
         INT256_NUM_U16_LIMBS,
         U16_BITS,
+        true,
     >,
 >;
 

--- a/extensions/riscv/circuit/cuda/include/riscv/cores/add_sub.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/cores/add_sub.cuh
@@ -57,7 +57,7 @@ template <typename T, size_t NUM_LIMBS> struct AddSubCoreCols {
     T opcode_sub_flag;
 };
 
-template <size_t NUM_LIMBS, size_t LIMB_BITS> struct AddSubCore {
+template <size_t NUM_LIMBS, size_t LIMB_BITS, bool RANGE_CHECK_TOP_LIMB> struct AddSubCore {
     VariableRangeChecker range_checker;
 
     template <typename T> using Cols = AddSubCoreCols<T, NUM_LIMBS>;
@@ -82,9 +82,9 @@ template <size_t NUM_LIMBS, size_t LIMB_BITS> struct AddSubCore {
         COL_WRITE_VALUE(row, Cols, opcode_sub_flag, record.local_opcode == 1);
 
 #pragma unroll
-        for (size_t i = 0; i < NUM_LIMBS; i++) {
-            // The carry constraints only bound a[i] mod 2^LIMB_BITS; the written cells
-            // must be canonical. b and c are pinned by the memory bus.
+        for (size_t i = 0; i < NUM_LIMBS - !RANGE_CHECK_TOP_LIMB; i++) {
+            // The carry constraints only bound a[i] mod 2^LIMB_BITS. Every output limb not
+            // constrained by the adapter must be canonicalized here.
             range_checker.add_count(a[i], LIMB_BITS);
         }
     }

--- a/extensions/riscv/circuit/cuda/src/add_sub.cu
+++ b/extensions/riscv/circuit/cuda/src/add_sub.cu
@@ -11,7 +11,7 @@ using namespace riscv;
 
 // Concrete type aliases for RV64
 using Rv64AddSubCoreRecord = AddSubCoreRecord<BLOCK_FE_WIDTH>;
-using Rv64AddSubCore = AddSubCore<BLOCK_FE_WIDTH, U16_BITS>;
+using Rv64AddSubCore = AddSubCore<BLOCK_FE_WIDTH, U16_BITS, true>;
 template <typename T> using Rv64AddSubCoreCols = AddSubCoreCols<T, BLOCK_FE_WIDTH>;
 
 template <typename T> struct Rv64AddSubCols {

--- a/extensions/riscv/circuit/cuda/src/add_sub_w.cu
+++ b/extensions/riscv/circuit/cuda/src/add_sub_w.cu
@@ -12,7 +12,7 @@ using namespace riscv;
 // Concrete type aliases for the 32-bit word variant on RV64. The low word is two u16 limbs and
 // reuses the add_sub core; the adapter rebuilds the sign-extended 64-bit register write.
 using Rv64AddSubWCoreRecord = AddSubCoreRecord<RV64_WORD_U16_LIMBS>;
-using Rv64AddSubWCore = AddSubCore<RV64_WORD_U16_LIMBS, U16_BITS>;
+using Rv64AddSubWCore = AddSubCore<RV64_WORD_U16_LIMBS, U16_BITS, false>;
 template <typename T> using Rv64AddSubWCoreCols = AddSubCoreCols<T, RV64_WORD_U16_LIMBS>;
 
 template <typename T> struct Rv64AddSubWCols {

--- a/extensions/riscv/circuit/src/adapters/alu_w_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_w_u16.rs
@@ -161,10 +161,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv64BaseAluWU16AdapterAir {
             )
             .eval(builder, local.rs2_as);
 
-        // Sign-extend the 32-bit result to 64 bits: `result_sign` is bit 15 of the most
-        // significant low-word limb. Decompose that limb as `low15 + result_sign * 2^15` and
-        // range-check `low15` to 15 bits; combined with the core's per-limb 16-bit range check,
-        // this forces `result_sign` to equal the limb's top bit.
+        // Sign-extend the 32-bit result to 64 bits. Decomposing the top result limb as
+        // `low15 + result_sign * 2^15`, with a 15-bit range check on `low15`, both proves that
+        // the limb is a canonical u16 and forces `result_sign` to equal its top bit.
         builder.assert_bool(local.result_sign);
         let result_high = ctx.writes[0][RV64_WORD_U16_LIMBS - 1].clone();
         let sign_weight = AB::Expr::from_u32(1 << (U16_BITS - 1));

--- a/extensions/riscv/circuit/src/add_sub/core.rs
+++ b/extensions/riscv/circuit/src/add_sub/core.rs
@@ -32,27 +32,41 @@ pub struct AddSubCoreCols<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub opcode_sub_flag: T,
 }
 
+/// If `RANGE_CHECK_TOP_LIMB` is false, the adapter must constrain the top output limb to
+/// `[0, 2^LIMB_BITS)`.
 #[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
 #[columns_via(AddSubCoreCols<u8, NUM_LIMBS, LIMB_BITS>)]
-pub struct AddSubCoreAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct AddSubCoreAir<
+    const NUM_LIMBS: usize,
+    const LIMB_BITS: usize,
+    const RANGE_CHECK_TOP_LIMB: bool,
+> {
     pub range_bus: VariableRangeCheckerBus,
     pub offset: usize,
 }
 
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAir<F>
-    for AddSubCoreAir<NUM_LIMBS, LIMB_BITS>
+impl<
+        F: Field,
+        const NUM_LIMBS: usize,
+        const LIMB_BITS: usize,
+        const RANGE_CHECK_TOP_LIMB: bool,
+    > BaseAir<F> for AddSubCoreAir<NUM_LIMBS, LIMB_BITS, RANGE_CHECK_TOP_LIMB>
 {
     fn width(&self) -> usize {
         AddSubCoreCols::<F, NUM_LIMBS, LIMB_BITS>::width()
     }
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublicValues<F>
-    for AddSubCoreAir<NUM_LIMBS, LIMB_BITS>
+impl<
+        F: Field,
+        const NUM_LIMBS: usize,
+        const LIMB_BITS: usize,
+        const RANGE_CHECK_TOP_LIMB: bool,
+    > BaseAirWithPublicValues<F> for AddSubCoreAir<NUM_LIMBS, LIMB_BITS, RANGE_CHECK_TOP_LIMB>
 {
 }
 
-impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
-    for AddSubCoreAir<NUM_LIMBS, LIMB_BITS>
+impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize, const RANGE_CHECK_TOP_LIMB: bool>
+    VmCoreAir<AB, I> for AddSubCoreAir<NUM_LIMBS, LIMB_BITS, RANGE_CHECK_TOP_LIMB>
 where
     AB: InteractionBuilder,
     I: VmAdapterInterface<AB::Expr>,
@@ -116,7 +130,8 @@ where
         // Range check a to [0, 2^LIMB_BITS): the carry constraints above only prove
         // a[i] = (b[i] op c[i]) mod 2^LIMB_BITS given this bound, and `a` is written to
         // memory, which requires canonical u16 cells.
-        for &a_limb in a.iter() {
+        let range_limb_count = NUM_LIMBS - usize::from(!RANGE_CHECK_TOP_LIMB);
+        for &a_limb in &a[..range_limb_count] {
             self.range_bus
                 .range_check(a_limb, LIMB_BITS)
                 .eval(builder, is_valid.clone());
@@ -161,7 +176,12 @@ pub struct AddSubExecutor<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
 }
 
 #[derive(derive_new::new)]
-pub struct AddSubFiller<A, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
+pub struct AddSubFiller<
+    A,
+    const NUM_LIMBS: usize,
+    const LIMB_BITS: usize,
+    const RANGE_CHECK_TOP_LIMB: bool,
+> {
     adapter: A,
     pub range_checker_chip: SharedVariableRangeCheckerChip,
 }
@@ -220,8 +240,8 @@ where
     }
 }
 
-impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize> TraceFiller<F>
-    for AddSubFiller<A, NUM_LIMBS, LIMB_BITS>
+impl<F, A, const NUM_LIMBS: usize, const LIMB_BITS: usize, const RANGE_CHECK_TOP_LIMB: bool>
+    TraceFiller<F> for AddSubFiller<A, NUM_LIMBS, LIMB_BITS, RANGE_CHECK_TOP_LIMB>
 where
     F: PrimeField32,
     A: 'static + AdapterTraceFiller<F>,
@@ -250,7 +270,8 @@ where
         core_row.opcode_sub_flag = F::from_bool(record.local_opcode == BaseAluOpcode::SUB as u8);
         core_row.opcode_add_flag = F::from_bool(record.local_opcode == BaseAluOpcode::ADD as u8);
 
-        for a_val in a {
+        let range_limb_count = NUM_LIMBS - usize::from(!RANGE_CHECK_TOP_LIMB);
+        for &a_val in &a[..range_limb_count] {
             self.range_checker_chip.add_count(a_val as u32, LIMB_BITS);
         }
         core_row.c = record.c.map(F::from_u16);

--- a/extensions/riscv/circuit/src/add_sub/mod.rs
+++ b/extensions/riscv/circuit/src/add_sub/mod.rs
@@ -18,8 +18,8 @@ pub use cuda::*;
 mod tests;
 
 pub type Rv64AddSubAir =
-    VmAirWrapper<Rv64BaseAluRegU16AdapterAir, AddSubCoreAir<BLOCK_FE_WIDTH, U16_BITS>>;
+    VmAirWrapper<Rv64BaseAluRegU16AdapterAir, AddSubCoreAir<BLOCK_FE_WIDTH, U16_BITS, true>>;
 pub type Rv64AddSubExecutor =
     AddSubExecutor<Rv64BaseAluRegU16AdapterExecutor, BLOCK_FE_WIDTH, U16_BITS>;
 pub type Rv64AddSubChip<F> =
-    VmChipWrapper<F, AddSubFiller<Rv64BaseAluRegU16AdapterFiller, BLOCK_FE_WIDTH, U16_BITS>>;
+    VmChipWrapper<F, AddSubFiller<Rv64BaseAluRegU16AdapterFiller, BLOCK_FE_WIDTH, U16_BITS, true>>;

--- a/extensions/riscv/circuit/src/add_sub_w/mod.rs
+++ b/extensions/riscv/circuit/src/add_sub_w/mod.rs
@@ -12,8 +12,8 @@ mod execution;
 mod preflight;
 pub use preflight::*;
 
-pub type AddSubWCoreAir = AddSubCoreAir<RV64_WORD_U16_LIMBS, U16_BITS>;
-pub type AddSubWFiller<A> = AddSubFiller<A, RV64_WORD_U16_LIMBS, U16_BITS>;
+pub type AddSubWCoreAir = AddSubCoreAir<RV64_WORD_U16_LIMBS, U16_BITS, false>;
+pub type AddSubWFiller<A> = AddSubFiller<A, RV64_WORD_U16_LIMBS, U16_BITS, false>;
 
 #[cfg(feature = "cuda")]
 mod cuda;


### PR DESCRIPTION
## Summary

Skips the AddSub core range interaction for the top output limb in word operations because the W adapter already proves that limb is a canonical u16 while extracting its sign bit. Full per-limb range checks remain enabled for regular RV64 and bigint AddSub users, with the same specialization applied to CUDA trace generation.