### PR TITLE
refactor(v2.1): cleanup rvr shared constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,7 +4812,6 @@ dependencies = [
  "rand 0.9.2",
  "rustc-hash 2.1.1",
  "rvr-openvm-ext-deferral",
- "rvr-openvm-ext-ffi-common",
  "rvr-openvm-lift",
  "serde",
 ]
@@ -7342,7 +7341,6 @@ dependencies = [
  "openvm-deferral-transpiler",
  "openvm-instructions",
  "openvm-stark-backend",
- "rvr-openvm-ext-ffi-common",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
 ]
@@ -7377,9 +7375,6 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-ffi-common"
 version = "2.0.0"
-dependencies = [
- "openvm-instructions",
-]
 
 [[package]]
 name = "rvr-openvm-ext-keccak"

--- a/crates/rvr/rvr-openvm-ffi-common/Cargo.toml
+++ b/crates/rvr/rvr-openvm-ffi-common/Cargo.toml
@@ -6,6 +6,3 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
-
-[dependencies]
-openvm-instructions.workspace = true

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -2,9 +2,7 @@
 //!
 //! Extension staticlibs call these non-inline wrappers (defined in
 //! `rvr_ext_wrappers.c`) for traced memory access and chip cost tracking.
-//! Register access is handled in
-//! the generated C code; resolved register values are passed to extension
-//! FFI entry points as parameters.
+//! Register access stays in generated C; resolved values are passed to extension FFI entry points.
 //!
 //! The `state` parameter is always an opaque `*mut c_void` pointing
 //! to the C `RvState` struct.

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -1,8 +1,8 @@
 //! FFI declarations for the C tracing wrapper functions.
 //!
 //! Extension staticlibs call these non-inline wrappers (defined in
-//! `rvr_ext_wrappers.c`) for traced memory access, instruction dispatch,
-//! chip cost tracking, and block metering. Register access is handled in
+//! `rvr_ext_wrappers.c`) for traced memory access and chip cost tracking.
+//! Register access is handled in
 //! the generated C code; resolved register values are passed to extension
 //! FFI entry points as parameters.
 //!
@@ -11,21 +11,9 @@
 
 use std::ffi::c_void;
 
-use openvm_instructions::DIGEST_WIDTH;
-
-/// Commit size in bytes.
-const F_NUM_BYTES: usize = 4;
-pub const DEFERRAL_COMMIT_NUM_BYTES: usize = DIGEST_WIDTH * F_NUM_BYTES;
-
-/// Output key size in bytes (commit + u64 length).
-pub const DEFERRAL_OUTPUT_KEY_BYTES: usize = DEFERRAL_COMMIT_NUM_BYTES + 8;
-
 extern "C" {
     // ── Memory access (single u64 word, data) ─────────────────────────
     pub fn rd_mem_u64_wrapper(state: *mut c_void, addr: u64) -> u64;
-
-    // ── Memory access (single u64 word, trace-only) ───────────────────
-    pub fn trace_rd_mem_u64_wrapper(state: *mut c_void, addr: u64, val: u64);
 
     // ── Memory access (u64-word ranges, data) ───────────────────────
     pub fn rd_mem_u64_range_wrapper(
@@ -61,12 +49,8 @@ extern "C" {
         num_words: u32,
     );
 
-    // ── Instruction dispatch / chip cost ──────────────────────────────
-    pub fn trace_pc_wrapper(state: *mut c_void, pc: u64);
+    // ── Chip cost ─────────────────────────────────────────────────────
     pub fn trace_chip_wrapper(state: *mut c_void, chip_idx: u32, count: u32);
-
-    // ── Block metering ────────────────────────────────────────────────
-    pub fn trace_block_wrapper(state: *mut c_void, pc: u64, block_insn_count: u32);
 
     // ── Hint stream (for extension phantom instructions) ──────────────
     /// Replace the hint stream contents. Forwarded through `openvm_io.c`

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -7,8 +7,8 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP as INSTR_SIZE, riscv::RV64_NUM_REGISTERS as NUM_REGS,
-    DEFAULT_SEGMENT_CHECK_INSNS,
+    metering::MAX_METERED_BLOCK_INSNS, program::DEFAULT_PC_STEP as INSTR_SIZE,
+    riscv::RV64_NUM_REGISTERS as NUM_REGS,
 };
 use rvr_openvm_ir::{AluOp, Block, Instr, InstrAt, LiftedInstr, MulDivOp, Terminator};
 
@@ -1297,7 +1297,7 @@ fn build_block_list(
 ) -> Vec<Block> {
     // Max block size; used to flush periodically so the segmentation check in
     // metered mode (which fires at block boundaries) stays granular enough.
-    const MAX_BLOCK_INSNS: u32 = DEFAULT_SEGMENT_CHECK_INSNS;
+    const MAX_BLOCK_INSNS: u32 = MAX_METERED_BLOCK_INSNS;
     let mut blocks: Vec<Block> = Vec::new();
 
     // Accumulate body instructions for the current block.

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -3,7 +3,7 @@
  * functions.
  *
  * Extension FFI code (implemented in Rust as staticlibs) calls these wrappers
- * for traced memory access, chip cost, and block metering. The wrappers
+ * for traced memory access and chip cost. The wrappers
  * delegate to the static inline functions defined in the tracer headers.
  * Register access stays in generated C; extensions receive resolved register
  * values as function parameters.
@@ -17,9 +17,6 @@
 
 uint64_t rd_mem_u64_wrapper(RvState* s, uint64_t addr) {
   return rd_mem_u64(s->memory, addr);
-}
-void trace_rd_mem_u64_wrapper(RvState* s, uint64_t addr, uint64_t val) {
-  trace_rd_mem_u64(s, addr, val);
 }
 
 void rd_mem_u64_range_wrapper(RvState* s, uint64_t base_addr, uint64_t* out,
@@ -48,9 +45,7 @@ void trace_mem_access_u64_range_wrapper(RvState* s, uint64_t base_addr,
   trace_mem_access_u64_range(s, base_addr, num_words, addr_space);
 }
 
-/* ── Instruction dispatch / chip cost ──────────────────────────────── */
-
-void trace_pc_wrapper(RvState* s, uint64_t pc) { trace_pc(s, pc); }
+/* ── Chip cost ─────────────────────────────────────────────────────── */
 
 /* Extension FFI staticlibs use this to add chip rows on top of what the
  * per-block chip accounting in the generated `block_*` functions has already
@@ -71,10 +66,4 @@ void trace_pc_wrapper(RvState* s, uint64_t pc) { trace_pc(s, pc); }
  * `crates/extensions/{sha2,deferral}/ffi/src/lib.rs`. */
 void trace_chip_wrapper(RvState* s, uint32_t chip_idx, uint32_t count) {
   trace_chip(s, chip_idx, count);
-}
-
-/* ── Block metering ────────────────────────────────────────────────── */
-
-void trace_block_wrapper(RvState* s, uint64_t pc, uint32_t block_insn_count) {
-  trace_block(s, pc, block_insn_count);
 }

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -17,13 +17,11 @@ static constexpr uint32_t NO_LAST_PAGE = UINT32_MAX;
 static constexpr uint32_t MAX_PV_PAGES_PER_INSN = 1;
 static_assert(
     TRACER_MEM_PAGE_BUF_CAP >=
-        (TRACER_SEGMENT_CHECK_INSNS + TRACER_MAX_BLOCK_INSNS) *
-            TRACER_MAX_MEM_PAGES_PER_INSN,
+        TRACER_SEGMENT_CHECK_INSNS * TRACER_MAX_MEM_PAGES_PER_INSN,
     "MEM_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 static_assert(
     TRACER_PV_PAGE_BUF_CAP >=
-        (TRACER_SEGMENT_CHECK_INSNS + TRACER_MAX_BLOCK_INSNS) *
-            MAX_PV_PAGES_PER_INSN,
+        TRACER_SEGMENT_CHECK_INSNS * MAX_PV_PAGES_PER_INSN,
     "PV_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 /* No static assert for DEFERRAL — justifying the capacity is a TODO
  * (see DEFERRAL_PAGE_BUF_CAP in metered.rs). */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -16,10 +16,14 @@ static constexpr uint32_t NO_LAST_PAGE = UINT32_MAX;
 
 static constexpr uint32_t MAX_PV_PAGES_PER_INSN = 1;
 static_assert(
-    TRACER_MEM_PAGE_BUF_CAP >= 2 * TRACER_SEGMENT_CHECK_INSNS * TRACER_MAX_MEM_PAGES_PER_INSN,
+    TRACER_MEM_PAGE_BUF_CAP >=
+        (TRACER_SEGMENT_CHECK_INSNS + TRACER_MAX_BLOCK_INSNS) *
+            TRACER_MAX_MEM_PAGES_PER_INSN,
     "MEM_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 static_assert(
-    TRACER_PV_PAGE_BUF_CAP >= 2 * TRACER_SEGMENT_CHECK_INSNS * MAX_PV_PAGES_PER_INSN,
+    TRACER_PV_PAGE_BUF_CAP >=
+        (TRACER_SEGMENT_CHECK_INSNS + TRACER_MAX_BLOCK_INSNS) *
+            MAX_PV_PAGES_PER_INSN,
     "PV_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 /* No static assert for DEFERRAL — justifying the capacity is a TODO
  * (see DEFERRAL_PAGE_BUF_CAP in metered.rs). */

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -3,13 +3,13 @@
 use openvm_instructions::{
     metering::{PAGE_MASK_LEAF_BITS, SEGMENT_CHECK_INSNS},
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
-    DEFERRAL_AS, MEMORY_DIGEST_WIDTH, PUBLIC_VALUES_AS,
+    DEFERRAL_AS, PUBLIC_VALUES_AS, VM_DIGEST_WIDTH,
 };
 use openvm_platform::{memory::MEM_SIZE, WORD_SIZE};
 use openvm_riscv_guest::MAX_HINT_BUFFER_DWORDS;
 
-const BYTE_SPACE_PTRS_PER_LEAF: usize = core::mem::size_of::<u16>() * MEMORY_DIGEST_WIDTH;
-const DEFERRAL_PTRS_PER_LEAF: usize = MEMORY_DIGEST_WIDTH;
+const BYTE_SPACE_PTRS_PER_LEAF: usize = core::mem::size_of::<u16>() * VM_DIGEST_WIDTH;
+const DEFERRAL_PTRS_PER_LEAF: usize = VM_DIGEST_WIDTH;
 
 /// Worst-case AS_MEMORY pages a single instruction can touch.
 ///
@@ -56,7 +56,7 @@ static constexpr uint32_t AS_MEMORY = {RV64_MEMORY_AS};
 static constexpr uint32_t AS_PUBLIC_VALUES = {PUBLIC_VALUES_AS};
 static constexpr uint32_t AS_DEFERRAL = {DEFERRAL_AS};
 static constexpr uint32_t WORD_SIZE = {WORD_SIZE};
-static constexpr uint32_t DEFERRAL_DIGEST_SIZE = {MEMORY_DIGEST_WIDTH};
+static constexpr uint32_t DEFERRAL_DIGEST_SIZE = {VM_DIGEST_WIDTH};
 static constexpr uint64_t RV_TEXT_START = 0x{text_start:08x}ull;
 static constexpr uint64_t RV_TEXT_END = 0x{text_end:08x}ull;
 static constexpr uint32_t RV_DISPATCH_TABLE_SIZE = {dispatch_table_size}u;

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -1,8 +1,4 @@
-//! Compile-time constants emitted into generated native tracer headers.
-//!
-//! The buffer-capacity constants here are the single source of truth for
-//! both the C tracer struct layout and the Rust-side `SegmentationState`
-//! buffer allocations — they must match byte-for-byte.
+//! Constants shared by Rust metering state and generated C tracers.
 
 use openvm_instructions::{
     metering::{PAGE_MASK_LEAF_BITS, SEGMENT_CHECK_INSNS},
@@ -29,12 +25,8 @@ pub const MAX_MEM_PAGES_PER_INSN: usize = {
 
 /// Maximum AS_MEMORY page buffer entries per segment check interval.
 ///
-/// **No bounds checks in C — capacity must be sufficient.**
-///
-/// Flushed before a block that would cross `SEGMENT_CHECK_INSNS`, so buffered
-/// accesses cover at most one complete check interval.
-/// Worst-case unique pages per instruction: ~10 (ECC setup / HINT_BUFFER, HINT_BUFFER is taken as
-/// worst-case). `SEGMENT_CHECK_INSNS * MAX_MEM_PAGES_PER_INSN` is well under 65 536.
+/// The C tracer flushes before crossing `SEGMENT_CHECK_INSNS` and statically
+/// verifies this capacity against `MAX_MEM_PAGES_PER_INSN`.
 pub const MEM_PAGE_BUF_CAP: usize = 1 << 16;
 
 /// Maximum AS_PUBLIC_VALUES page buffer entries per segment check interval.

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -5,23 +5,24 @@
 //! buffer allocations — they must match byte-for-byte.
 
 use openvm_instructions::{
+    metering::{DEFAULT_SEGMENT_CHECK_INSNS, MAX_METERED_BLOCK_INSNS, PAGE_MASK_LEAF_BITS},
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
-    DEFAULT_SEGMENT_CHECK_INSNS, DEFERRAL_AS, DIGEST_WIDTH, MEMORY_PAGE_BITS, PUBLIC_VALUES_AS,
+    DEFERRAL_AS, MEMORY_DIGEST_WIDTH, PUBLIC_VALUES_AS,
 };
 use openvm_platform::{memory::MEM_SIZE, WORD_SIZE};
 use openvm_riscv_guest::MAX_HINT_BUFFER_DWORDS;
 
-const BYTE_SPACE_PTRS_PER_LEAF: usize = core::mem::size_of::<u16>() * DIGEST_WIDTH;
-const DEFERRAL_PTRS_PER_LEAF: usize = DIGEST_WIDTH;
+const BYTE_SPACE_PTRS_PER_LEAF: usize = core::mem::size_of::<u16>() * MEMORY_DIGEST_WIDTH;
+const DEFERRAL_PTRS_PER_LEAF: usize = MEMORY_DIGEST_WIDTH;
 
 /// Worst-case AS_MEMORY pages a single instruction can touch.
 ///
 /// Bound is set by `HINT_BUFFER`, which writes up to
 /// `MAX_HINT_BUFFER_DWORDS * WORD_SIZE` contiguous bytes. One AS_MEMORY page
-/// covers `BYTE_SPACE_PTRS_PER_LEAF * 2^MEMORY_PAGE_BITS` bytes. The `+1` covers worst-case
-/// misalignment of the range across page boundaries.
+/// covers `BYTE_SPACE_PTRS_PER_LEAF * 2^PAGE_MASK_LEAF_BITS` bytes. The `+1`
+/// covers worst-case misalignment of the range across page boundaries.
 pub const MAX_MEM_PAGES_PER_INSN: usize = {
-    let page_bytes = BYTE_SPACE_PTRS_PER_LEAF * (1 << MEMORY_PAGE_BITS);
+    let page_bytes = BYTE_SPACE_PTRS_PER_LEAF * (1 << PAGE_MASK_LEAF_BITS);
     let max_bytes = MAX_HINT_BUFFER_DWORDS * WORD_SIZE;
     max_bytes.div_ceil(page_bytes) + 1
 };
@@ -30,9 +31,9 @@ pub const MAX_MEM_PAGES_PER_INSN: usize = {
 ///
 /// **No bounds checks in C — capacity must be sufficient.**
 ///
-/// Flushed at most every 2 × `DEFAULT_SEGMENT_CHECK_INSNS` instructions
-/// (block-granular check can overshoot by up to one block, which is at
-/// most `DEFAULT_SEGMENT_CHECK_INSNS` instructions).
+/// Flushed after at most `DEFAULT_SEGMENT_CHECK_INSNS + MAX_METERED_BLOCK_INSNS`
+/// instructions because a block-granular check can overshoot its interval by
+/// one complete generated block.
 /// Worst-case unique pages per instruction: ~10 (ECC setup / HINT_BUFFER, HINT_BUFFER is taken as
 /// worst-case). 2000 insns × 10 pages = 20 000 — well under 65 536.
 pub const MEM_PAGE_BUF_CAP: usize = 1 << 16;
@@ -64,17 +65,18 @@ static constexpr uint32_t AS_MEMORY = {RV64_MEMORY_AS};
 static constexpr uint32_t AS_PUBLIC_VALUES = {PUBLIC_VALUES_AS};
 static constexpr uint32_t AS_DEFERRAL = {DEFERRAL_AS};
 static constexpr uint32_t WORD_SIZE = {WORD_SIZE};
-static constexpr uint32_t DEFERRAL_DIGEST_SIZE = {DIGEST_WIDTH};
+static constexpr uint32_t DEFERRAL_DIGEST_SIZE = {MEMORY_DIGEST_WIDTH};
 static constexpr uint64_t RV_TEXT_START = 0x{text_start:08x}ull;
 static constexpr uint64_t RV_TEXT_END = 0x{text_end:08x}ull;
 static constexpr uint32_t RV_DISPATCH_TABLE_SIZE = {dispatch_table_size}u;
 static constexpr uint32_t TRACER_BYTE_SPACE_PTRS_PER_LEAF_BITS = {byte_space_ptrs_per_leaf_bits};
 static constexpr uint32_t TRACER_DEFERRAL_PTRS_PER_LEAF_BITS = {deferral_ptrs_per_leaf_bits};
-static constexpr uint32_t TRACER_PAGE_BITS = {MEMORY_PAGE_BITS};
+static constexpr uint32_t TRACER_PAGE_BITS = {PAGE_MASK_LEAF_BITS};
 static constexpr uint32_t TRACER_MEM_PAGE_BUF_CAP = {MEM_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_PV_PAGE_BUF_CAP = {PV_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_DEFERRAL_PAGE_BUF_CAP = {DEFERRAL_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_SEGMENT_CHECK_INSNS = {DEFAULT_SEGMENT_CHECK_INSNS};
+static constexpr uint32_t TRACER_MAX_BLOCK_INSNS = {MAX_METERED_BLOCK_INSNS};
 static constexpr uint32_t TRACER_MAX_MEM_PAGES_PER_INSN = {MAX_MEM_PAGES_PER_INSN};
 "
     )

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -5,7 +5,7 @@
 //! buffer allocations — they must match byte-for-byte.
 
 use openvm_instructions::{
-    metering::{DEFAULT_SEGMENT_CHECK_INSNS, MAX_METERED_BLOCK_INSNS, PAGE_MASK_LEAF_BITS},
+    metering::{PAGE_MASK_LEAF_BITS, SEGMENT_CHECK_INSNS},
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
     DEFERRAL_AS, MEMORY_DIGEST_WIDTH, PUBLIC_VALUES_AS,
 };
@@ -31,11 +31,10 @@ pub const MAX_MEM_PAGES_PER_INSN: usize = {
 ///
 /// **No bounds checks in C — capacity must be sufficient.**
 ///
-/// Flushed after at most `DEFAULT_SEGMENT_CHECK_INSNS + MAX_METERED_BLOCK_INSNS`
-/// instructions because a block-granular check can overshoot its interval by
-/// one complete generated block.
+/// Flushed before a block that would cross `SEGMENT_CHECK_INSNS`, so buffered
+/// accesses cover at most one complete check interval.
 /// Worst-case unique pages per instruction: ~10 (ECC setup / HINT_BUFFER, HINT_BUFFER is taken as
-/// worst-case). 2000 insns × 10 pages = 20 000 — well under 65 536.
+/// worst-case). `SEGMENT_CHECK_INSNS * MAX_MEM_PAGES_PER_INSN` is well under 65 536.
 pub const MEM_PAGE_BUF_CAP: usize = 1 << 16;
 
 /// Maximum AS_PUBLIC_VALUES page buffer entries per segment check interval.
@@ -75,8 +74,7 @@ static constexpr uint32_t TRACER_PAGE_BITS = {PAGE_MASK_LEAF_BITS};
 static constexpr uint32_t TRACER_MEM_PAGE_BUF_CAP = {MEM_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_PV_PAGE_BUF_CAP = {PV_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_DEFERRAL_PAGE_BUF_CAP = {DEFERRAL_PAGE_BUF_CAP};
-static constexpr uint32_t TRACER_SEGMENT_CHECK_INSNS = {DEFAULT_SEGMENT_CHECK_INSNS};
-static constexpr uint32_t TRACER_MAX_BLOCK_INSNS = {MAX_METERED_BLOCK_INSNS};
+static constexpr uint32_t TRACER_SEGMENT_CHECK_INSNS = {SEGMENT_CHECK_INSNS};
 static constexpr uint32_t TRACER_MAX_MEM_PAGES_PER_INSN = {MAX_MEM_PAGES_PER_INSN};
 "
     )

--- a/crates/toolchain/instructions/src/lib.rs
+++ b/crates/toolchain/instructions/src/lib.rs
@@ -9,6 +9,7 @@ use strum_macros::{EnumCount, EnumIter, FromRepr};
 
 pub mod exe;
 pub mod instruction;
+pub mod metering;
 mod phantom;
 pub mod program;
 /// Module with traits and constants for RISC-V instruction definitions for custom OpenVM
@@ -23,11 +24,7 @@ pub const PUBLIC_VALUES_AS: u32 = 3;
 /// Deferral output address space.
 pub const DEFERRAL_AS: u32 = 4;
 /// Field elements in an OpenVM memory Merkle digest and deferral commitment.
-pub const DIGEST_WIDTH: usize = 8;
-/// Number of bits needed to index the leaves represented by one `u64` page mask.
-pub const MEMORY_PAGE_BITS: usize = u64::BITS.ilog2() as usize;
-/// Default interval between metered-execution segment checks.
-pub const DEFAULT_SEGMENT_CHECK_INSNS: u32 = 1000;
+pub const MEMORY_DIGEST_WIDTH: usize = 8;
 
 pub trait LocalOpcode {
     const CLASS_OFFSET: usize;

--- a/crates/toolchain/instructions/src/lib.rs
+++ b/crates/toolchain/instructions/src/lib.rs
@@ -23,8 +23,8 @@ pub use phantom::*;
 pub const PUBLIC_VALUES_AS: u32 = 3;
 /// Deferral output address space.
 pub const DEFERRAL_AS: u32 = 4;
-/// Field elements in an OpenVM memory Merkle digest and deferral commitment.
-pub const MEMORY_DIGEST_WIDTH: usize = 8;
+/// Field elements in an OpenVM VM-level digest, including memory roots and commitments.
+pub const VM_DIGEST_WIDTH: usize = 8;
 
 pub trait LocalOpcode {
     const CLASS_OFFSET: usize;

--- a/crates/toolchain/instructions/src/metering.rs
+++ b/crates/toolchain/instructions/src/metering.rs
@@ -5,14 +5,15 @@ pub const PAGE_MASK_LEAF_BITS: usize = u64::BITS.ilog2() as usize;
 
 /// Maximum number of instructions in one generated metered RVR block.
 ///
-/// Segment checks happen only at block boundaries, so tracer buffer-capacity
-/// bounds must accommodate this many instructions beyond a check interval.
+/// Segment checks happen at block boundaries. This must not exceed
+/// [`SEGMENT_CHECK_INSNS`], so a freshly reset check interval can accommodate
+/// every generated block.
 pub const MAX_METERED_BLOCK_INSNS: u32 = 1000;
 
-/// Default interval between metered-execution segment checks.
+/// Interval between metered-execution segment checks.
 ///
-/// This currently matches [`MAX_METERED_BLOCK_INSNS`] so the default check
-/// interval and generated-block granularity share one source of truth. Buffer
-/// capacities must account for both values because a check can overshoot by
-/// one complete block.
-pub const DEFAULT_SEGMENT_CHECK_INSNS: u32 = MAX_METERED_BLOCK_INSNS;
+/// The tracer checks before executing a block that would cross the remaining
+/// interval. It therefore never starts a block with an insufficient countdown.
+pub const SEGMENT_CHECK_INSNS: u32 = 1000;
+
+const _: () = assert!(SEGMENT_CHECK_INSNS >= MAX_METERED_BLOCK_INSNS);

--- a/crates/toolchain/instructions/src/metering.rs
+++ b/crates/toolchain/instructions/src/metering.rs
@@ -1,0 +1,18 @@
+//! Constants shared by metered execution and native RVR tracing.
+
+/// Number of Merkle-tree levels represented by one `u64` metering page mask.
+pub const PAGE_MASK_LEAF_BITS: usize = u64::BITS.ilog2() as usize;
+
+/// Maximum number of instructions in one generated metered RVR block.
+///
+/// Segment checks happen only at block boundaries, so tracer buffer-capacity
+/// bounds must accommodate this many instructions beyond a check interval.
+pub const MAX_METERED_BLOCK_INSNS: u32 = 1000;
+
+/// Default interval between metered-execution segment checks.
+///
+/// This currently matches [`MAX_METERED_BLOCK_INSNS`] so the default check
+/// interval and generated-block granularity share one source of truth. Buffer
+/// capacities must account for both values because a check can overshoot by
+/// one complete block.
+pub const DEFAULT_SEGMENT_CHECK_INSNS: u32 = MAX_METERED_BLOCK_INSNS;

--- a/crates/toolchain/instructions/src/metering.rs
+++ b/crates/toolchain/instructions/src/metering.rs
@@ -3,17 +3,10 @@
 /// Number of Merkle-tree levels represented by one `u64` metering page mask.
 pub const PAGE_MASK_LEAF_BITS: usize = u64::BITS.ilog2() as usize;
 
-/// Maximum number of instructions in one generated metered RVR block.
-///
-/// Segment checks happen at block boundaries. This must not exceed
-/// [`SEGMENT_CHECK_INSNS`], so a freshly reset check interval can accommodate
-/// every generated block.
+/// Maximum number of instructions in a generated metered RVR block.
 pub const MAX_METERED_BLOCK_INSNS: u32 = 1000;
 
 /// Interval between metered-execution segment checks.
-///
-/// The tracer checks before executing a block that would cross the remaining
-/// interval. It therefore never starts a block with an insufficient countdown.
 pub const SEGMENT_CHECK_INSNS: u32 = 1000;
 
 const _: () = assert!(SEGMENT_CHECK_INSNS >= MAX_METERED_BLOCK_INSNS);

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -9,7 +9,7 @@ use derive_new::new;
 use getset::{Setters, WithSetters};
 use openvm_instructions::{
     riscv::{RV64_IMM_AS, RV64_MEMORY_AS, RV64_REGISTER_AS},
-    DEFERRAL_AS, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH, PUBLIC_VALUES_AS,
+    DEFERRAL_AS, PUBLIC_VALUES_AS, VM_DIGEST_WIDTH,
 };
 use openvm_platform::memory::MEM_SIZE;
 use openvm_poseidon2_air::Poseidon2Config;
@@ -44,7 +44,7 @@ pub const DEFAULT_MAX_NUM_PUBLIC_VALUES: usize = 32;
 /// Max number of deferral address space cells
 pub const DEFAULT_DEFERRAL_ADDR_SPACE_CELLS: usize = 1 << 14;
 /// Width of Poseidon2 VM uses.
-pub const POSEIDON2_WIDTH: usize = 2 * DIGEST_WIDTH;
+pub const POSEIDON2_WIDTH: usize = 2 * VM_DIGEST_WIDTH;
 /// Offset for address space indices. This is used to distinguish between different memory spaces.
 pub const ADDR_SPACE_OFFSET: u32 = 1;
 
@@ -63,7 +63,7 @@ pub const OPENVM_DEFAULT_INIT_FILE_NAME: &str = "openvm_init.rs";
 //   Cell    one storage word in an address space.
 //   Block   the unit of one memory-bus message: BLOCK_FE_WIDTH cells =
 //           MEMORY_BLOCK_BYTES bytes.
-//   Digest  the output of one Poseidon2 compression (DIGEST_WIDTH cells); also
+//   Digest  the output of one Poseidon2 compression (VM_DIGEST_WIDTH cells); also
 //           one merkle leaf.
 
 /// Host byte width of one u16-celled storage cell.
@@ -306,7 +306,7 @@ impl SystemConfig {
             memory_config.timestamp_max_bits <= 29,
             "Timestamp max bits must be <= 29 for LessThan to work in 31-bit field"
         );
-        assert_public_values_shape::<DIGEST_WIDTH>(num_public_values);
+        assert_public_values_shape::<VM_DIGEST_WIDTH>(num_public_values);
         memory_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = num_public_values;
         Self {
             max_constraint_degree,
@@ -325,7 +325,7 @@ impl SystemConfig {
     }
 
     pub fn with_public_values(mut self, num_public_values: usize) -> Self {
-        assert_public_values_shape::<DIGEST_WIDTH>(num_public_values);
+        assert_public_values_shape::<VM_DIGEST_WIDTH>(num_public_values);
         self.num_public_values = num_public_values;
         self.memory_config.addr_spaces[PUBLIC_VALUES_AS as usize].num_cells = num_public_values;
         self

--- a/crates/vm/src/arch/config.rs
+++ b/crates/vm/src/arch/config.rs
@@ -9,7 +9,7 @@ use derive_new::new;
 use getset::{Setters, WithSetters};
 use openvm_instructions::{
     riscv::{RV64_IMM_AS, RV64_MEMORY_AS, RV64_REGISTER_AS},
-    DEFERRAL_AS, DIGEST_WIDTH, PUBLIC_VALUES_AS,
+    DEFERRAL_AS, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH, PUBLIC_VALUES_AS,
 };
 use openvm_platform::memory::MEM_SIZE;
 use openvm_poseidon2_air::Poseidon2Config;

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use openvm_instructions::{
     exe::SparseMemoryImage,
+    metering::SEGMENT_CHECK_INSNS,
     riscv::{RV64_IMM_AS, RV64_REGISTER_AS},
 };
 use openvm_stark_backend::memory_metering::ProvingMemoryConfig;
@@ -71,7 +72,7 @@ impl MeteredCtx {
             inputs.segmentation_limits,
             memory_config,
         );
-        let memory_ctx = MemoryCtx::new(config, segmentation_ctx.segment_check_insns());
+        let memory_ctx = MemoryCtx::new(config);
 
         // Assert that the indices are correct
         let air_names = segmentation_ctx.air_names();
@@ -141,7 +142,7 @@ impl MeteredCtx {
         system_config: &SystemConfig,
     ) -> Self {
         let segmentation_ctx = SegmentationCtx::from_config(segmentation_config);
-        let mut memory_ctx = MemoryCtx::new(system_config, segmentation_ctx.segment_check_insns());
+        let mut memory_ctx = MemoryCtx::new(system_config);
         let mut trace_heights = config.initial_trace_heights.clone();
         memory_ctx.add_register_merkle_heights();
         memory_ctx.apply_height_updates(&mut trace_heights);
@@ -182,9 +183,8 @@ impl MeteredCtx {
         if self.segmentation_ctx.instrets_until_check > 0 {
             return false;
         }
-        let segment_check_insns = self.segmentation_ctx.segment_check_insns();
-        self.segmentation_ctx.instrets_until_check = segment_check_insns;
-        self.segmentation_ctx.instret += segment_check_insns;
+        self.segmentation_ctx.instrets_until_check = u64::from(SEGMENT_CHECK_INSNS);
+        self.segmentation_ctx.instret += u64::from(SEGMENT_CHECK_INSNS);
 
         self.memory_ctx
             .apply_height_updates(&mut self.trace_heights);

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -2,8 +2,9 @@ use std::mem::size_of;
 
 use openvm_instructions::{
     exe::SparseMemoryImage,
+    metering::PAGE_MASK_LEAF_BITS,
     riscv::{RV64_NUM_REGISTERS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
-    DEFERRAL_AS, DIGEST_WIDTH, MEMORY_PAGE_BITS,
+    DEFERRAL_AS, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
 };
 #[cfg(test)]
 use openvm_instructions::{riscv::RV64_MEMORY_AS, PUBLIC_VALUES_AS};
@@ -65,7 +66,7 @@ impl MemoryCtx {
         let memory_dimensions = config.memory_config.memory_dimensions();
         let merkle_height = memory_dimensions.overall_height();
 
-        let upper_height = merkle_height.saturating_sub(MEMORY_PAGE_BITS);
+        let upper_height = merkle_height.saturating_sub(PAGE_MASK_LEAF_BITS);
         let checkpoint_capacity = Self::initial_checkpoint_capacity(segment_check_insns);
 
         Self {
@@ -139,12 +140,12 @@ impl MemoryCtx {
     #[inline(always)]
     fn mark_existing_memory_range(&mut self, address_space: u32, ptr: u32, size: u32) {
         let (start_leaf_id, end_leaf_id) = self.leaf_id_range(address_space, ptr, size);
-        let start_page_id = start_leaf_id >> MEMORY_PAGE_BITS;
-        let end_page_id = ((end_leaf_id - 1) >> MEMORY_PAGE_BITS) + 1;
+        let start_page_id = start_leaf_id >> PAGE_MASK_LEAF_BITS;
+        let end_page_id = ((end_leaf_id - 1) >> PAGE_MASK_LEAF_BITS) + 1;
 
         for page_id in start_page_id..end_page_id {
-            let page_start = page_id << MEMORY_PAGE_BITS;
-            let page_end = page_start + (1 << MEMORY_PAGE_BITS);
+            let page_start = page_id << PAGE_MASK_LEAF_BITS;
+            let page_end = page_start + (1 << PAGE_MASK_LEAF_BITS);
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
@@ -165,19 +166,19 @@ impl MemoryCtx {
     ) {
         let (start_leaf_id, end_leaf_id) = self.leaf_id_range(address_space, ptr, size);
         let num_leaves = end_leaf_id - start_leaf_id;
-        let start_page_id = start_leaf_id >> MEMORY_PAGE_BITS;
+        let start_page_id = start_leaf_id >> PAGE_MASK_LEAF_BITS;
 
         if num_leaves == 1 {
             push_page_touch(
                 &mut self.page_indices_since_checkpoint,
                 start_page_id,
-                1u64 << (start_leaf_id & ((1 << MEMORY_PAGE_BITS) - 1)),
+                1u64 << (start_leaf_id & ((1 << PAGE_MASK_LEAF_BITS) - 1)),
             );
             self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
             return;
         }
 
-        let end_page_id = ((end_leaf_id - 1) >> MEMORY_PAGE_BITS) + 1;
+        let end_page_id = ((end_leaf_id - 1) >> PAGE_MASK_LEAF_BITS) + 1;
         let num_pages = (end_page_id - start_page_id) as usize;
         assert!(
             num_pages <= MAX_MEM_PAGE_OPS_PER_INSN,
@@ -188,8 +189,8 @@ impl MemoryCtx {
         }
 
         for page_id in start_page_id..end_page_id {
-            let page_start = page_id << MEMORY_PAGE_BITS;
-            let page_end = page_start + (1 << MEMORY_PAGE_BITS);
+            let page_start = page_id << PAGE_MASK_LEAF_BITS;
+            let page_end = page_start + (1 << PAGE_MASK_LEAF_BITS);
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
@@ -429,7 +430,7 @@ mod tests {
         ctx.apply_height_updates(&mut trace_heights);
 
         let page_id = ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize
-            >> MEMORY_PAGE_BITS;
+            >> PAGE_MASK_LEAF_BITS;
         assert_eq!(ctx.baseline_memory.page_mask(page_id), 0);
     }
 
@@ -437,9 +438,10 @@ mod tests {
     fn test_address_spaces_map_to_distinct_pages() {
         let system_config = crate::utils::test_system_config();
         let ctx = MemoryCtx::new(&system_config, 1);
-        let memory_page = ctx.leaf_id_range(RV64_MEMORY_AS, 0, 1).0 >> MEMORY_PAGE_BITS;
-        let public_values_page = ctx.leaf_id_range(PUBLIC_VALUES_AS, 0, 1).0 >> MEMORY_PAGE_BITS;
-        let deferral_page = ctx.leaf_id_range(DEFERRAL_AS, 0, 1).0 >> MEMORY_PAGE_BITS;
+        let memory_page = ctx.leaf_id_range(RV64_MEMORY_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
+        let public_values_page =
+            ctx.leaf_id_range(PUBLIC_VALUES_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
+        let deferral_page = ctx.leaf_id_range(DEFERRAL_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
 
         assert_ne!(memory_page, public_values_page);
         assert_ne!(memory_page, deferral_page);
@@ -479,7 +481,7 @@ mod tests {
         let merkle_before = trace_heights[MERKLE_AIR_ID];
         let poseidon2_idx = trace_heights.len() - 2;
         let poseidon_before = trace_heights[poseidon2_idx];
-        let next_page_ptr = ((1 << MEMORY_PAGE_BITS) * U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+        let next_page_ptr = ((1 << PAGE_MASK_LEAF_BITS) * U16_CELL_SIZE * DIGEST_WIDTH) as u32;
 
         ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, next_page_ptr, 1);
         ctx.apply_height_updates(&mut trace_heights);
@@ -487,11 +489,11 @@ mod tests {
         assert_eq!(trace_heights[BOUNDARY_AIR_ID] - boundary_before, 2);
         assert_eq!(
             trace_heights[MERKLE_AIR_ID] - merkle_before,
-            2 * MEMORY_PAGE_BITS as u32
+            2 * PAGE_MASK_LEAF_BITS as u32
         );
         assert_eq!(
             trace_heights[poseidon2_idx] - poseidon_before,
-            1 + MEMORY_PAGE_BITS as u32
+            1 + PAGE_MASK_LEAF_BITS as u32
         );
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -2,7 +2,7 @@ use std::mem::size_of;
 
 use openvm_instructions::{
     exe::SparseMemoryImage,
-    metering::PAGE_MASK_LEAF_BITS,
+    metering::{PAGE_MASK_LEAF_BITS, SEGMENT_CHECK_INSNS},
     riscv::{RV64_NUM_REGISTERS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
     DEFERRAL_AS, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
 };
@@ -62,12 +62,12 @@ pub struct MemoryCtx {
 }
 
 impl MemoryCtx {
-    pub fn new(config: &SystemConfig, segment_check_insns: u64) -> Self {
+    pub fn new(config: &SystemConfig) -> Self {
         let memory_dimensions = config.memory_config.memory_dimensions();
         let merkle_height = memory_dimensions.overall_height();
 
         let upper_height = merkle_height.saturating_sub(PAGE_MASK_LEAF_BITS);
-        let checkpoint_capacity = Self::initial_checkpoint_capacity(segment_check_insns);
+        let checkpoint_capacity = Self::initial_checkpoint_capacity();
 
         Self {
             memory_dimensions,
@@ -85,8 +85,8 @@ impl MemoryCtx {
     }
 
     #[inline(always)]
-    fn initial_checkpoint_capacity(segment_check_insns: u64) -> usize {
-        segment_check_insns as usize * INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN
+    fn initial_checkpoint_capacity() -> usize {
+        SEGMENT_CHECK_INSNS as usize * INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN
     }
 
     #[inline(always)]
@@ -405,8 +405,8 @@ mod tests {
     #[test]
     fn test_range_insertion_matches_explicit_leaves() {
         let system_config = crate::utils::test_system_config();
-        let mut range_ctx = MemoryCtx::new(&system_config, 1);
-        let mut explicit_ctx = MemoryCtx::new(&system_config, 1);
+        let mut range_ctx = MemoryCtx::new(&system_config);
+        let mut explicit_ctx = MemoryCtx::new(&system_config);
 
         range_ctx.update_boundary_merkle_heights(2, 0, 17);
         for ptr in [0, 16] {
@@ -423,7 +423,7 @@ mod tests {
     #[test]
     fn test_tentative_apply_does_not_commit_occupancy() {
         let system_config = crate::utils::test_system_config();
-        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut ctx = MemoryCtx::new(&system_config);
         let mut trace_heights = vec![0; 6];
 
         ctx.update_boundary_merkle_heights(2, 0, 1);
@@ -437,7 +437,7 @@ mod tests {
     #[test]
     fn test_address_spaces_map_to_distinct_pages() {
         let system_config = crate::utils::test_system_config();
-        let ctx = MemoryCtx::new(&system_config, 1);
+        let ctx = MemoryCtx::new(&system_config);
         let memory_page = ctx.leaf_id_range(RV64_MEMORY_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
         let public_values_page =
             ctx.leaf_id_range(PUBLIC_VALUES_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
@@ -451,7 +451,7 @@ mod tests {
     #[test]
     fn test_first_touches_poseidon_rows_dedup_by_default_bucket() {
         let system_config = crate::utils::test_system_config();
-        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
         let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
 
@@ -470,7 +470,7 @@ mod tests {
     #[test]
     fn test_default_poseidon_rows_dedup_across_checkpoints() {
         let system_config = crate::utils::test_system_config();
-        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut ctx = MemoryCtx::new(&system_config);
         let mut trace_heights = vec![0; 6];
 
         ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 1);
@@ -500,7 +500,7 @@ mod tests {
     #[test]
     fn test_initial_zero_bytes_do_not_seed_occupancy() {
         let system_config = crate::utils::test_system_config();
-        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
         ctx.seed_initial_memory(&SparseMemoryImage::from([((2, 0), 0)]));
         let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
@@ -518,7 +518,7 @@ mod tests {
     #[test]
     fn test_initial_nonzero_bytes_seed_occupancy() {
         let system_config = crate::utils::test_system_config();
-        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
         let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
         ctx.seed_initial_memory(&SparseMemoryImage::from([
@@ -539,7 +539,7 @@ mod tests {
     #[test]
     fn test_initial_deferral_bytes_seed_occupancy() {
         let system_config = crate::utils::test_system_config();
-        let mut ctx = MemoryCtx::new(&system_config, 1);
+        let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
         let second_leaf_ptr = DIGEST_WIDTH as u32;
         let second_leaf_byte_ptr = second_leaf_ptr * FIELD_ELEMENT_BYTES;

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -439,8 +439,7 @@ mod tests {
         let system_config = crate::utils::test_system_config();
         let ctx = MemoryCtx::new(&system_config);
         let memory_page = ctx.leaf_id_range(RV64_MEMORY_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
-        let public_values_page =
-            ctx.leaf_id_range(PUBLIC_VALUES_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
+        let public_values_page = ctx.leaf_id_range(PUBLIC_VALUES_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
         let deferral_page = ctx.leaf_id_range(DEFERRAL_AS, 0, 1).0 >> PAGE_MASK_LEAF_BITS;
 
         assert_ne!(memory_page, public_values_page);
@@ -481,8 +480,7 @@ mod tests {
         let merkle_before = trace_heights[MERKLE_AIR_ID];
         let poseidon2_idx = trace_heights.len() - 2;
         let poseidon_before = trace_heights[poseidon2_idx];
-        let next_page_ptr =
-            ((1 << PAGE_MASK_LEAF_BITS) * U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
+        let next_page_ptr = ((1 << PAGE_MASK_LEAF_BITS) * U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
 
         ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, next_page_ptr, 1);
         ctx.apply_height_updates(&mut trace_heights);

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -4,7 +4,7 @@ use openvm_instructions::{
     exe::SparseMemoryImage,
     metering::{PAGE_MASK_LEAF_BITS, SEGMENT_CHECK_INSNS},
     riscv::{RV64_NUM_REGISTERS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
-    DEFERRAL_AS, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
+    DEFERRAL_AS, VM_DIGEST_WIDTH,
 };
 #[cfg(test)]
 use openvm_instructions::{riscv::RV64_MEMORY_AS, PUBLIC_VALUES_AS};
@@ -26,8 +26,8 @@ const MAX_MEM_PAGE_OPS_PER_INSN: usize = 1 << 16;
 // count for the common scalar-access path.
 const INITIAL_CHECKPOINT_PAGE_ACCESSES_PER_INSN: usize = 16;
 // Shift amounts from address-space pointer units to memory Merkle leaves.
-const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * DIGEST_WIDTH).ilog2();
-const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = DIGEST_WIDTH.ilog2();
+const BYTE_PTRS_PER_LEAF_BITS: u32 = (U16_CELL_SIZE * VM_DIGEST_WIDTH).ilog2();
+const DEFERRAL_PTRS_PER_LEAF_BITS: u32 = VM_DIGEST_WIDTH.ilog2();
 const FIELD_ELEMENT_BYTES: u32 = size_of::<u32>() as u32;
 
 /// Tracks which parts of memory contribute rows to the current segment.
@@ -453,7 +453,7 @@ mod tests {
         let system_config = crate::utils::test_system_config();
         let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
-        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+        let second_leaf_ptr = (U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
 
         ctx.update_boundary_merkle_heights(2, 0, 1);
         ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
@@ -481,7 +481,8 @@ mod tests {
         let merkle_before = trace_heights[MERKLE_AIR_ID];
         let poseidon2_idx = trace_heights.len() - 2;
         let poseidon_before = trace_heights[poseidon2_idx];
-        let next_page_ptr = ((1 << PAGE_MASK_LEAF_BITS) * U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+        let next_page_ptr =
+            ((1 << PAGE_MASK_LEAF_BITS) * U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
 
         ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, next_page_ptr, 1);
         ctx.apply_height_updates(&mut trace_heights);
@@ -503,7 +504,7 @@ mod tests {
         let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
         ctx.seed_initial_memory(&SparseMemoryImage::from([((2, 0), 0)]));
-        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+        let second_leaf_ptr = (U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
 
         ctx.update_boundary_merkle_heights(2, 0, 1);
         ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
@@ -520,7 +521,7 @@ mod tests {
         let system_config = crate::utils::test_system_config();
         let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
-        let second_leaf_ptr = (U16_CELL_SIZE * DIGEST_WIDTH) as u32;
+        let second_leaf_ptr = (U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
         ctx.seed_initial_memory(&SparseMemoryImage::from([
             ((2, 0), 1),
             ((2, second_leaf_ptr), 1),
@@ -541,7 +542,7 @@ mod tests {
         let system_config = crate::utils::test_system_config();
         let mut ctx = MemoryCtx::new(&system_config);
         let height = ctx.memory_dimensions.overall_height() as u32;
-        let second_leaf_ptr = DIGEST_WIDTH as u32;
+        let second_leaf_ptr = VM_DIGEST_WIDTH as u32;
         let second_leaf_byte_ptr = second_leaf_ptr * FIELD_ELEMENT_BYTES;
         ctx.seed_initial_memory(&SparseMemoryImage::from([
             ((DEFERRAL_AS, 0), 1),

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -1,4 +1,4 @@
-use openvm_instructions::MEMORY_PAGE_BITS;
+use openvm_instructions::metering::PAGE_MASK_LEAF_BITS;
 
 // Masks with the first bit set in each aligned group of leaves. These represent
 // group occupancy at each page-local Merkle level.
@@ -101,9 +101,9 @@ struct BitSet {
 ///        /    \
 ///      ...    ...
 ///      /        \
-///   [page]    [page]         h - MEMORY_PAGE_BITS nodes above each page
+///   [page]    [page]         h - PAGE_MASK_LEAF_BITS nodes above each page
 ///   / .. \
-///  L  ..  L                  MEMORY_PAGE_BITS levels inside a 64-leaf page
+///  L  ..  L                  PAGE_MASK_LEAF_BITS levels inside a 64-leaf page
 /// ```
 ///
 /// The tracker counts each newly touched leaf once, each newly required
@@ -389,7 +389,7 @@ impl SegmentMemoryTracker {
         let mut count = 0;
         let mut first_touches = FirstTouchCounts::default();
         let mut node = (1usize << self.upper_height) + page_id;
-        let mut height = MEMORY_PAGE_BITS + 1;
+        let mut height = PAGE_MASK_LEAF_BITS + 1;
         while node > 1 {
             node >>= 1;
             if self.segment_upper_nodes.insert_clearable(node) {
@@ -555,7 +555,7 @@ fn local_merkle_nodes_added_leaf(segment_leaf_mask: u64, leaf: u32) -> u32 {
     debug_assert!(leaf < u64::BITS);
 
     if segment_leaf_mask == 0 {
-        return MEMORY_PAGE_BITS as u32;
+        return PAGE_MASK_LEAF_BITS as u32;
     }
 
     // For one new leaf, each aligned group that was empty creates exactly one
@@ -597,11 +597,11 @@ fn local_merkle_nodes_added_leaf_with_first_touches(
 
     if segment_leaf_mask == 0 && baseline_leaf_mask == 0 {
         return (
-            MEMORY_PAGE_BITS as u32,
+            PAGE_MASK_LEAF_BITS as u32,
             FirstTouchCounts {
                 leaves: 0,
-                merkle_nodes: MEMORY_PAGE_BITS as u32,
-                max_merkle_height: MEMORY_PAGE_BITS as u32,
+                merkle_nodes: PAGE_MASK_LEAF_BITS as u32,
+                max_merkle_height: PAGE_MASK_LEAF_BITS as u32,
             },
         );
     }
@@ -643,7 +643,7 @@ fn local_merkle_nodes_added_leaf_with_first_touches(
         nodes += 1;
         if baseline_leaf_mask == 0 {
             first_touches.merkle_nodes += 1;
-            first_touches.max_merkle_height = MEMORY_PAGE_BITS as u32;
+            first_touches.max_merkle_height = PAGE_MASK_LEAF_BITS as u32;
         }
     }
 
@@ -737,7 +737,7 @@ mod tests {
     fn reference_local_merkle_nodes(mask: u64) -> u32 {
         let mut nodes = 0;
         let mut level_mask = mask;
-        for _ in 0..MEMORY_PAGE_BITS {
+        for _ in 0..PAGE_MASK_LEAF_BITS {
             level_mask = reference_parent_mask(level_mask);
             nodes += level_mask.count_ones();
         }
@@ -866,7 +866,7 @@ mod tests {
         let baseline_memory = BaselineMemoryTracker::new(3);
         tracker.insert(0, 1, &baseline_memory);
         let second = tracker.insert(1, 1, &baseline_memory);
-        assert_eq!(second.segment_merkle_nodes, MEMORY_PAGE_BITS as u32);
+        assert_eq!(second.segment_merkle_nodes, PAGE_MASK_LEAF_BITS as u32);
     }
 
     #[test]

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -1,5 +1,5 @@
 use bytesize::ByteSize;
-use openvm_instructions::DEFAULT_SEGMENT_CHECK_INSNS;
+use openvm_instructions::metering::DEFAULT_SEGMENT_CHECK_INSNS;
 #[cfg(feature = "metrics")]
 use openvm_stark_backend::memory_metering::INTERACTION_MEMORY_OVERHEAD;
 use openvm_stark_backend::memory_metering::{ProvingMemoryConfig, ProvingMemoryCounts};

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -1,5 +1,5 @@
 use bytesize::ByteSize;
-use openvm_instructions::metering::DEFAULT_SEGMENT_CHECK_INSNS;
+use openvm_instructions::metering::SEGMENT_CHECK_INSNS;
 #[cfg(feature = "metrics")]
 use openvm_stark_backend::memory_metering::INTERACTION_MEMORY_OVERHEAD;
 use openvm_stark_backend::memory_metering::{ProvingMemoryConfig, ProvingMemoryCounts};
@@ -45,7 +45,6 @@ pub struct SegmentationConfig {
     max_interactions: u32,
     #[serde(with = "ProvingMemoryConfigSerde")]
     memory_config: ProvingMemoryConfig,
-    segment_check_insns: u64,
 }
 
 impl SegmentationConfig {
@@ -70,8 +69,8 @@ impl SegmentationConfig {
             .checked_shl(u32::from(limits.max_trace_height_bits))
             .expect("max_trace_height_bits must fit in u32 trace height");
         assert!(
-            u64::from(max_trace_height) >= 2 * u64::from(DEFAULT_SEGMENT_CHECK_INSNS),
-            "max_trace_height must be at least twice DEFAULT_SEGMENT_CHECK_INSNS"
+            u64::from(max_trace_height) >= 2 * u64::from(SEGMENT_CHECK_INSNS),
+            "max_trace_height must be at least twice SEGMENT_CHECK_INSNS"
         );
 
         Self {
@@ -83,7 +82,6 @@ impl SegmentationConfig {
             max_memory: limits.max_memory,
             max_interactions: limits.max_interactions,
             memory_config,
-            segment_check_insns: u64::from(DEFAULT_SEGMENT_CHECK_INSNS),
         }
     }
 
@@ -95,11 +93,6 @@ impl SegmentationConfig {
     #[inline(always)]
     pub fn widths(&self) -> &[usize] {
         &self.widths
-    }
-
-    #[inline(always)]
-    pub fn segment_check_insns(&self) -> u64 {
-        self.segment_check_insns
     }
 
     pub fn set_max_memory(&mut self, max_memory: usize) {
@@ -201,7 +194,7 @@ impl SegmentationCtx {
         );
         Self {
             segments: Vec::new(),
-            instrets_until_check: config.segment_check_insns,
+            instrets_until_check: u64::from(SEGMENT_CHECK_INSNS),
             config,
             instret: 0,
             checkpoint_trace_heights: vec![0; num_airs],
@@ -217,11 +210,6 @@ impl SegmentationCtx {
     #[inline(always)]
     pub(crate) fn widths(&self) -> &[usize] {
         &self.config.widths
-    }
-
-    #[inline(always)]
-    pub(crate) fn segment_check_insns(&self) -> u64 {
-        self.config.segment_check_insns
     }
 
     pub fn set_max_memory(&mut self, max_memory: usize) {
@@ -245,7 +233,7 @@ impl SegmentationCtx {
         let num_airs = config.air_names.len();
         Self {
             segments: Vec::new(),
-            instrets_until_check: config.segment_check_insns,
+            instrets_until_check: u64::from(SEGMENT_CHECK_INSNS),
             config,
             instret: 0,
             checkpoint_trace_heights: vec![0; num_airs],
@@ -620,8 +608,8 @@ impl SegmentationCtx {
     /// Try segment if there is at least one instruction
     #[inline(always)]
     pub fn create_final_segment(&mut self, trace_heights: &[u32]) {
-        self.instret += self.config.segment_check_insns - self.instrets_until_check;
-        self.instrets_until_check = self.config.segment_check_insns;
+        self.instret += u64::from(SEGMENT_CHECK_INSNS) - self.instrets_until_check;
+        self.instrets_until_check = u64::from(SEGMENT_CHECK_INSNS);
         let instret_start = self
             .segments
             .last()

--- a/crates/vm/src/arch/hasher/poseidon2.rs
+++ b/crates/vm/src/arch/hasher/poseidon2.rs
@@ -3,7 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_poseidon2_air::p3_symmetric::Permutation;
 use openvm_stark_backend::p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
@@ -27,13 +27,17 @@ pub struct Poseidon2Hasher<F: Clone> {
     _marker: PhantomData<F>,
 }
 
-impl<F: PrimeField32> Hasher<{ DIGEST_WIDTH }, F> for Poseidon2Hasher<F> {
-    fn compress(&self, lhs: &[F; DIGEST_WIDTH], rhs: &[F; DIGEST_WIDTH]) -> [F; DIGEST_WIDTH] {
+impl<F: PrimeField32> Hasher<{ VM_DIGEST_WIDTH }, F> for Poseidon2Hasher<F> {
+    fn compress(
+        &self,
+        lhs: &[F; VM_DIGEST_WIDTH],
+        rhs: &[F; VM_DIGEST_WIDTH],
+    ) -> [F; VM_DIGEST_WIDTH] {
         let mut state = from_fn(|i| {
-            if i < DIGEST_WIDTH {
+            if i < VM_DIGEST_WIDTH {
                 BabyBear::from_u32(lhs[i].as_canonical_u32())
             } else {
-                BabyBear::from_u32(rhs[i - DIGEST_WIDTH].as_canonical_u32())
+                BabyBear::from_u32(rhs[i - VM_DIGEST_WIDTH].as_canonical_u32())
             }
         });
         self.poseidon2.permute_mut(&mut state);

--- a/crates/vm/src/arch/hasher/poseidon2.rs
+++ b/crates/vm/src/arch/hasher/poseidon2.rs
@@ -3,7 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_poseidon2_air::p3_symmetric::Permutation;
 use openvm_stark_backend::p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};

--- a/crates/vm/src/arch/rvr/abi_consts.rs
+++ b/crates/vm/src/arch/rvr/abi_consts.rs
@@ -1,8 +1,8 @@
 //! Compatibility guards for constants owned by external configurations.
 
 #[cfg(any(feature = "test-utils", feature = "cuda"))]
-use openvm_instructions::MEMORY_DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 
 #[cfg(any(feature = "test-utils", feature = "cuda"))]
 const _: () =
-    assert!(MEMORY_DIGEST_WIDTH == openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE,);
+    assert!(VM_DIGEST_WIDTH == openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE,);

--- a/crates/vm/src/arch/rvr/abi_consts.rs
+++ b/crates/vm/src/arch/rvr/abi_consts.rs
@@ -1,7 +1,8 @@
 //! Compatibility guards for constants owned by external configurations.
 
 #[cfg(any(feature = "test-utils", feature = "cuda"))]
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH;
 
 #[cfg(any(feature = "test-utils", feature = "cuda"))]
-const _: () = assert!(DIGEST_WIDTH == openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE,);
+const _: () =
+    assert!(MEMORY_DIGEST_WIDTH == openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE,);

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -282,13 +282,6 @@ fn execute_metered_impl(
                 seg_state.ctx.segmentation_ctx.instrets_until_check
             ))
         })?;
-    let _ = u32::try_from(seg_state.ctx.segmentation_ctx.segment_check_insns()).map_err(|_| {
-        ExecuteError::InvalidMeteredContext(format!(
-            "segment_check_insns {} exceeds rvr tracer u32 counter",
-            seg_state.ctx.segmentation_ctx.segment_check_insns()
-        ))
-    })?;
-
     state.tracer.trace_heights = seg_state.trace_heights_ptr();
     state.tracer.mem_page_buf = seg_state.mem_page_buf_ptr();
     state.tracer.pv_page_buf = seg_state.pv_page_buf_ptr();

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -6,7 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use openvm_instructions::{riscv::RV64_MEMORY_AS, DEFERRAL_AS, MEMORY_PAGE_BITS, PUBLIC_VALUES_AS};
+use openvm_instructions::{
+    metering::PAGE_MASK_LEAF_BITS, riscv::RV64_MEMORY_AS, DEFERRAL_AS, PUBLIC_VALUES_AS,
+};
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::RvrRuntimeExtension;
 
@@ -178,7 +180,7 @@ impl SegmentationState {
         // C buffers use page ids local to one address space. `MemoryCtx`
         // deduplicates against one global memory tree, so convert to global
         // page ids before applying the leaf masks.
-        let page_shift = address_height as usize - MEMORY_PAGE_BITS;
+        let page_shift = address_height as usize - PAGE_MASK_LEAF_BITS;
         let page_offset = ((addr_space as usize - ADDR_SPACE_OFFSET as usize) << page_shift) as u32;
         memory_ctx.apply_page_touches_with_offset(page_offset, &buffer[..len as usize]);
     }
@@ -604,7 +606,7 @@ mod tests {
 
         assert_eq!(
             seg_state.ctx.trace_heights[poseidon2_idx] - poseidon_before,
-            1 + MEMORY_PAGE_BITS as u32
+            1 + PAGE_MASK_LEAF_BITS as u32
         );
     }
 

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -7,7 +7,9 @@ use std::{
 };
 
 use openvm_instructions::{
-    metering::PAGE_MASK_LEAF_BITS, riscv::RV64_MEMORY_AS, DEFERRAL_AS, PUBLIC_VALUES_AS,
+    metering::{PAGE_MASK_LEAF_BITS, SEGMENT_CHECK_INSNS},
+    riscv::RV64_MEMORY_AS,
+    DEFERRAL_AS, PUBLIC_VALUES_AS,
 };
 use rvr_openvm::{DEFERRAL_PAGE_BUF_CAP, MEM_PAGE_BUF_CAP, PV_PAGE_BUF_CAP};
 use rvr_openvm_lift::RvrRuntimeExtension;
@@ -231,7 +233,7 @@ impl SegmentationState {
             .apply_height_updates(&mut self.ctx.trace_heights);
     }
 
-    /// Called on each periodic check (approximately every `segment_check_insns` instructions).
+    /// Called on each periodic check (approximately every `SEGMENT_CHECK_INSNS` instructions).
     /// Invoked from the C tracer's `trace_block` callback when the block-level
     /// countdown crosses zero. Returns true if a segment boundary was created.
     pub fn on_periodic_check(
@@ -241,7 +243,7 @@ impl SegmentationState {
         deferral_len: u32,
         remaining_counter: u32,
     ) -> bool {
-        let seg_check_insns = self.ctx.segmentation_ctx.segment_check_insns();
+        let seg_check_insns = u64::from(SEGMENT_CHECK_INSNS);
         let insns_since_last_check = seg_check_insns - remaining_counter as u64;
         let instret = self.ctx.segmentation_ctx.instret + insns_since_last_check;
         self.ctx.segmentation_ctx.instret = instret;
@@ -326,16 +328,10 @@ pub unsafe extern "C" fn metered_periodic_check(t: *mut MeteredTracerData) -> u8
     let did_segment =
         seg_state.on_periodic_check(mem_len, pv_len, deferral_len, tracer.check_counter);
 
-    let segment_check_insns = seg_state.ctx.segmentation_ctx.segment_check_insns() as u32;
-    debug_assert_eq!(
-        u64::from(segment_check_insns),
-        seg_state.ctx.segmentation_ctx.segment_check_insns()
-    );
-
     // We are at the start of a block that would cross the old countdown.
     // `remaining_counter` was used to record this block start as the metering
     // boundary, so the next interval starts here with a full countdown.
-    tracer.check_counter = segment_check_insns;
+    tracer.check_counter = SEGMENT_CHECK_INSNS;
     did_segment as u8
 }
 
@@ -647,19 +643,27 @@ mod tests {
 
     #[test]
     fn test_periodic_check_records_block_boundary_instret() {
+        let remaining = SEGMENT_CHECK_INSNS / 4;
         let mut seg_state = make_segmentation_state();
-        seg_state.ctx.segmentation_ctx.instrets_until_check = 1000;
+        seg_state.ctx.segmentation_ctx.instrets_until_check = u64::from(SEGMENT_CHECK_INSNS);
 
-        assert!(!seg_state.on_periodic_check(0, 0, 0, 250));
+        assert!(!seg_state.on_periodic_check(0, 0, 0, remaining));
 
-        assert_eq!(seg_state.ctx.segmentation_ctx.instret, 750);
-        assert_eq!(seg_state.ctx.segmentation_ctx.instrets_until_check, 1000);
+        assert_eq!(
+            seg_state.ctx.segmentation_ctx.instret,
+            u64::from(SEGMENT_CHECK_INSNS - remaining)
+        );
+        assert_eq!(
+            seg_state.ctx.segmentation_ctx.instrets_until_check,
+            u64::from(SEGMENT_CHECK_INSNS)
+        );
     }
 
     #[test]
     fn test_periodic_callback_starts_next_interval_at_block_boundary() {
+        let remaining = SEGMENT_CHECK_INSNS / 4;
         let mut seg_state = make_segmentation_state();
-        seg_state.ctx.segmentation_ctx.instrets_until_check = 1000;
+        seg_state.ctx.segmentation_ctx.instrets_until_check = u64::from(SEGMENT_CHECK_INSNS);
         let mut tracer = MeteredTracerData {
             trace_heights: seg_state.trace_heights_ptr(),
             mem_page_buf: seg_state.mem_page_buf_ptr(),
@@ -670,21 +674,25 @@ mod tests {
             mem_page_buf_len: 0,
             pv_page_buf_len: 0,
             deferral_page_buf_len: 0,
-            check_counter: 250,
+            check_counter: remaining,
             last_mem_page: NO_LAST_PAGE,
         };
 
         let did_segment = unsafe { metered_periodic_check(&mut tracer) };
 
         assert_eq!(did_segment, 0);
-        assert_eq!(tracer.check_counter, 1000);
-        assert_eq!(seg_state.ctx.segmentation_ctx.instret, 750);
+        assert_eq!(tracer.check_counter, SEGMENT_CHECK_INSNS);
+        assert_eq!(
+            seg_state.ctx.segmentation_ctx.instret,
+            u64::from(SEGMENT_CHECK_INSNS - remaining)
+        );
     }
 
     #[test]
     fn test_periodic_callback_starts_next_interval_when_suspending() {
+        let remaining = SEGMENT_CHECK_INSNS / 4;
         let mut seg_state = make_segmentation_state();
-        seg_state.ctx.segmentation_ctx.instrets_until_check = 1000;
+        seg_state.ctx.segmentation_ctx.instrets_until_check = u64::from(SEGMENT_CHECK_INSNS);
         *seg_state.ctx.trace_heights.last_mut().unwrap() = 4096;
         let mut tracer = MeteredTracerData {
             trace_heights: seg_state.trace_heights_ptr(),
@@ -696,14 +704,17 @@ mod tests {
             mem_page_buf_len: 0,
             pv_page_buf_len: 0,
             deferral_page_buf_len: 0,
-            check_counter: 250,
+            check_counter: remaining,
             last_mem_page: NO_LAST_PAGE,
         };
 
         let did_segment = unsafe { metered_periodic_check(&mut tracer) };
 
         assert_eq!(did_segment, 1);
-        assert_eq!(tracer.check_counter, 1000);
-        assert_eq!(seg_state.ctx.segmentation_ctx.instret, 750);
+        assert_eq!(tracer.check_counter, SEGMENT_CHECK_INSNS);
+        assert_eq!(
+            seg_state.ctx.segmentation_ctx.instret,
+            u64::from(SEGMENT_CHECK_INSNS - remaining)
+        );
     }
 }

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -233,9 +233,7 @@ impl SegmentationState {
             .apply_height_updates(&mut self.ctx.trace_heights);
     }
 
-    /// Called on each periodic check (approximately every `SEGMENT_CHECK_INSNS` instructions).
-    /// Invoked from the C tracer's `trace_block` callback when the block-level
-    /// countdown crosses zero. Returns true if a segment boundary was created.
+    /// Applies a periodic block-boundary check and returns whether a segment was created.
     pub fn on_periodic_check(
         &mut self,
         mem_len: u32,

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -15,7 +15,7 @@ use openvm_circuit::system::program::trace::compute_exe_commit;
 use openvm_instructions::{
     exe::{SparseMemoryImage, VmExe},
     program::Program,
-    DIGEST_WIDTH,
+    MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
 };
 #[cfg(any(debug_assertions, feature = "test-utils", feature = "stark-debug"))]
 use openvm_stark_backend::AirRef;

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -15,7 +15,7 @@ use openvm_circuit::system::program::trace::compute_exe_commit;
 use openvm_instructions::{
     exe::{SparseMemoryImage, VmExe},
     program::Program,
-    MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
+    VM_DIGEST_WIDTH,
 };
 #[cfg(any(debug_assertions, feature = "test-utils", feature = "stark-debug"))]
 use openvm_stark_backend::AirRef;
@@ -573,8 +573,8 @@ pub enum VmVerificationError<SC: StarkProtocolConfig> {
 
     #[error("exe commit mismatch (expected: {expected:?}, actual: {actual:?})")]
     ExeCommitMismatch {
-        expected: [u32; DIGEST_WIDTH],
-        actual: [u32; DIGEST_WIDTH],
+        expected: [u32; VM_DIGEST_WIDTH],
+        actual: [u32; VM_DIGEST_WIDTH],
     },
 
     #[error("initial pc mismatch (initial: {initial}, prev_final: {prev_final})")]
@@ -1235,7 +1235,7 @@ where
     }
 
     /// See [`SystemChipComplex::memory_top_tree`].
-    pub fn memory_top_tree(&self) -> Option<&[[Val<E::SC>; DIGEST_WIDTH]]> {
+    pub fn memory_top_tree(&self) -> Option<&[[Val<E::SC>; VM_DIGEST_WIDTH]]> {
         self.chip_complex.system.memory_top_tree()
     }
 
@@ -1378,7 +1378,7 @@ mod tests {
 ))]
 pub struct ContinuationVmProof<SC: StarkProtocolConfig> {
     pub per_segment: Vec<Proof<SC>>,
-    pub user_public_values: UserPublicValuesProof<{ DIGEST_WIDTH }, Val<SC>>,
+    pub user_public_values: UserPublicValuesProof<{ VM_DIGEST_WIDTH }, Val<SC>>,
 }
 
 /// Prover for a specific exe in a specific continuation VM using a specific Stark config.
@@ -1545,9 +1545,9 @@ pub struct VerifiedExecutionPayload<F> {
     ///
     /// The Merklelization uses Poseidon2 as a cryptographic hash function (for the leaves)
     /// and a cryptographic compression function (for internal nodes).
-    pub exe_commit: [F; DIGEST_WIDTH],
+    pub exe_commit: [F; VM_DIGEST_WIDTH],
     /// The Merkle root of the final memory state.
-    pub final_memory_root: [F; DIGEST_WIDTH],
+    pub final_memory_root: [F; VM_DIGEST_WIDTH],
 }
 
 /// Verify segment proofs with boundary condition checks for continuation between segments.
@@ -1574,7 +1574,7 @@ pub fn verify_segments<E>(
 where
     E: StarkEngine,
     Val<E::SC>: PrimeField32,
-    Com<E::SC>: Into<[Val<E::SC>; DIGEST_WIDTH]>,
+    Com<E::SC>: Into<[Val<E::SC>; VM_DIGEST_WIDTH]>,
 {
     if proofs.is_empty() {
         return Err(VmVerificationError::ProofNotFound);
@@ -1661,7 +1661,7 @@ where
                 }
             } else if air_idx == MERKLE_AIR_ID {
                 merkle_air_present = true;
-                let pvs: &MemoryMerklePvs<_, DIGEST_WIDTH> = pvs.as_slice().borrow();
+                let pvs: &MemoryMerklePvs<_, VM_DIGEST_WIDTH> = pvs.as_slice().borrow();
 
                 // Check that initial root matches the previous final root.
                 if i != 0 {

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -5,7 +5,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::Chip;
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
 use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_stark_backend::prover::{AirProvingContext, MatrixDimensions};
 
 use super::poseidon2::SharedBuffer;

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -5,7 +5,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::Chip;
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
 use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::prover::{AirProvingContext, MatrixDimensions};
 
 use super::poseidon2::SharedBuffer;
@@ -23,7 +23,7 @@ pub struct BoundaryChipGPU {
     pub trace_width: Option<usize>,
 }
 
-const BLOCKS_PER_LEAF: usize = DIGEST_WIDTH / BLOCK_FE_WIDTH;
+const BLOCKS_PER_LEAF: usize = VM_DIGEST_WIDTH / BLOCK_FE_WIDTH;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -32,7 +32,7 @@ pub struct PersistentBoundaryRecord {
     /// AS-native pointer to the first cell of this Merkle leaf.
     pub ptr: u32,
     pub timestamps: [u32; BLOCKS_PER_LEAF],
-    pub values: [F; DIGEST_WIDTH],
+    pub values: [F; VM_DIGEST_WIDTH],
 }
 
 impl BoundaryChipGPU {

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -15,7 +15,7 @@ use openvm_cuda_common::{
     memory_manager::MemTracker,
     stream::GpuDeviceCtx,
 };
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_stark_backend::{p3_field::PrimeCharacteristicRing, prover::AirProvingContext};
 use tracing::instrument;
 

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -15,7 +15,7 @@ use openvm_cuda_common::{
     memory_manager::MemTracker,
     stream::GpuDeviceCtx,
 };
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::{p3_field::PrimeCharacteristicRing, prover::AirProvingContext};
 use tracing::instrument;
 
@@ -28,10 +28,10 @@ use crate::{cuda_abi::inventory, system::memory::online::LinearMemory};
 
 // The CUDA merge kernel in `inventory.cu` is hardcoded to a 2-way merge of
 // `<IN_BLOCK_SIZE=4, 1>` records into `<OUT_BLOCK_SIZE=8, 2>` records, so the only
-// supported `(BLOCK_FE_WIDTH, DIGEST_WIDTH)` shape is `(4, 8)`.
+// supported `(BLOCK_FE_WIDTH, VM_DIGEST_WIDTH)` shape is `(4, 8)`.
 const _: () = assert!(
-    BLOCK_FE_WIDTH == 4 && DIGEST_WIDTH == 8,
-    "CUDA memory inventory only supports (BLOCK_FE_WIDTH, DIGEST_WIDTH) == (4, 8)"
+    BLOCK_FE_WIDTH == 4 && VM_DIGEST_WIDTH == 8,
+    "CUDA memory inventory only supports (BLOCK_FE_WIDTH, VM_DIGEST_WIDTH) == (4, 8)"
 );
 
 pub struct MemoryInventoryGPU {
@@ -60,7 +60,7 @@ struct MemoryMerkleRecord {
     address_space: u32,
     ptr: u32,
     timestamp: u32,
-    values: [u32; DIGEST_WIDTH],
+    values: [u32; VM_DIGEST_WIDTH],
 }
 
 impl MemoryInventoryGPU {
@@ -149,14 +149,14 @@ impl MemoryInventoryGPU {
         let partition = touched_memory;
         let boundary_records = if partition.is_empty() {
             let leftmost_values = 'left: {
-                let mut res = [F::ZERO; DIGEST_WIDTH];
+                let mut res = [F::ZERO; VM_DIGEST_WIDTH];
                 if self.initial_memory[ADDR_SPACE_OFFSET as usize].is_empty() {
                     break 'left res;
                 }
                 let layout =
                     &self.merkle_tree.mem_config().addr_spaces[ADDR_SPACE_OFFSET as usize].layout;
                 let one_cell_size = layout.size();
-                let mut values = vec![0u8; one_cell_size * DIGEST_WIDTH];
+                let mut values = vec![0u8; one_cell_size * VM_DIGEST_WIDTH];
                 unsafe {
                     cuda_memcpy_on::<true, false>(
                         values.as_mut_ptr() as *mut std::ffi::c_void,
@@ -166,7 +166,7 @@ impl MemoryInventoryGPU {
                         &self.device_ctx,
                     )
                     .unwrap();
-                    for i in 0..DIGEST_WIDTH {
+                    for i in 0..VM_DIGEST_WIDTH {
                         res[i] = layout.to_field::<F>(&values[i * one_cell_size..]);
                     }
                 }
@@ -189,7 +189,8 @@ impl MemoryInventoryGPU {
             };
             self.merkle_records = Some(merkle_words.to_device_on(&self.device_ctx).unwrap());
 
-            self.boundary.finalize_records::<DIGEST_WIDTH>(Vec::new());
+            self.boundary
+                .finalize_records::<VM_DIGEST_WIDTH>(Vec::new());
             0
         } else {
             // `inventory.cu` merges 4-cell block records into 8-cell leaf records.
@@ -204,7 +205,7 @@ impl MemoryInventoryGPU {
                 .collect();
             let in_num_records = in_records.len();
             let out_words = in_num_records
-                * (std::mem::size_of::<MemoryInventoryRecord<DIGEST_WIDTH, BLOCKS_PER_LEAF>>()
+                * (std::mem::size_of::<MemoryInventoryRecord<VM_DIGEST_WIDTH, BLOCKS_PER_LEAF>>()
                     / std::mem::size_of::<u32>());
             let d_in_records = in_records
                 .to_device_on(&self.device_ctx)
@@ -256,7 +257,7 @@ impl MemoryInventoryGPU {
             // Send records to boundary chip
             let out_num_records = d_out_num_records.to_host_on(&self.device_ctx).unwrap()[0];
             self.boundary
-                .finalize_records_device::<DIGEST_WIDTH>(d_out_records, out_num_records);
+                .finalize_records_device::<VM_DIGEST_WIDTH>(d_out_records, out_num_records);
 
             // Send records to memory merkle tree
             let out_records = self
@@ -264,14 +265,14 @@ impl MemoryInventoryGPU {
                 .records()
                 .to_host_on(&self.device_ctx)
                 .unwrap();
-            let record_words = 2 + BLOCKS_PER_LEAF + DIGEST_WIDTH;
+            let record_words = 2 + BLOCKS_PER_LEAF + VM_DIGEST_WIDTH;
             let mut merkle_records = Vec::with_capacity(out_num_records);
             for i in 0..out_num_records {
                 let base = i * record_words;
-                let mut values = [0u32; DIGEST_WIDTH];
+                let mut values = [0u32; VM_DIGEST_WIDTH];
                 values.copy_from_slice(
                     &out_records
-                        [base + 2 + BLOCKS_PER_LEAF..base + 2 + BLOCKS_PER_LEAF + DIGEST_WIDTH],
+                        [base + 2 + BLOCKS_PER_LEAF..base + 2 + BLOCKS_PER_LEAF + VM_DIGEST_WIDTH],
                 );
                 let timestamp = *out_records[base + 2..base + 2 + BLOCKS_PER_LEAF]
                     .iter()
@@ -368,9 +369,9 @@ mod tests {
     use super::*;
 
     /// CPU reference Merkle root, for cross-checking the GPU root.
-    fn cpu_merkle_root(memory: &AddressMap, mem_config: &MemoryConfig) -> [F; DIGEST_WIDTH] {
+    fn cpu_merkle_root(memory: &AddressMap, mem_config: &MemoryConfig) -> [F; VM_DIGEST_WIDTH] {
         let cpu_hasher = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);
-        let cpu_merkle_tree = MerkleTree::<F, DIGEST_WIDTH>::from_memory(
+        let cpu_merkle_tree = MerkleTree::<F, VM_DIGEST_WIDTH>::from_memory(
             memory,
             &mem_config.memory_dimensions(),
             &cpu_hasher,
@@ -397,13 +398,13 @@ mod tests {
 
     /// Extracts the Merkle root: the merkle chip is the one emitting at least two public-value
     /// digests, and the root is the last one.
-    fn gpu_merkle_root(ctxs: &[AirProvingContext<GpuBackend>]) -> [F; DIGEST_WIDTH] {
+    fn gpu_merkle_root(ctxs: &[AirProvingContext<GpuBackend>]) -> [F; VM_DIGEST_WIDTH] {
         let merkle_ctx = ctxs
             .iter()
-            .find(|ctx| ctx.public_values.len() >= 2 * DIGEST_WIDTH)
+            .find(|ctx| ctx.public_values.len() >= 2 * VM_DIGEST_WIDTH)
             .expect("missing merkle ctx");
         let gpu_root_slice =
-            &merkle_ctx.public_values[merkle_ctx.public_values.len() - DIGEST_WIDTH..];
+            &merkle_ctx.public_values[merkle_ctx.public_values.len() - VM_DIGEST_WIDTH..];
         gpu_root_slice.try_into().unwrap()
     }
 
@@ -411,8 +412,8 @@ mod tests {
     fn single_block_setup() -> (MemoryConfig, GuestMemory) {
         let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
         for addr_space in [RV64_REGISTER_AS, RV64_MEMORY_AS] {
-            // num_cells is in u16 cells; allocate 2 * DIGEST_WIDTH = 16 cells.
-            addr_spaces[addr_space as usize].num_cells = 2 * DIGEST_WIDTH;
+            // num_cells is in u16 cells; allocate 2 * VM_DIGEST_WIDTH = 16 cells.
+            addr_spaces[addr_space as usize].num_cells = 2 * VM_DIGEST_WIDTH;
         }
         let mem_config = MemoryConfig::new(2, addr_spaces, ptr_bits_from_address_height(1), 29, 17);
 
@@ -511,11 +512,11 @@ mod tests {
         const NUM_PAGES: usize = 4;
         // U16 memory cells (2 bytes), so one PAGE_SIZE-byte page is PAGE_SIZE / 2 cells.
         let num_cells = NUM_PAGES * (PAGE_SIZE / 2);
-        // 2^address_height leaf labels per AS must cover num_cells / DIGEST_WIDTH leaves.
-        let address_height = (num_cells / DIGEST_WIDTH).ilog2() as usize;
+        // 2^address_height leaf labels per AS must cover num_cells / VM_DIGEST_WIDTH leaves.
+        let address_height = (num_cells / VM_DIGEST_WIDTH).ilog2() as usize;
 
         let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
-        addr_spaces[RV64_REGISTER_AS as usize].num_cells = 2 * DIGEST_WIDTH;
+        addr_spaces[RV64_REGISTER_AS as usize].num_cells = 2 * VM_DIGEST_WIDTH;
         addr_spaces[RV64_MEMORY_AS as usize].num_cells = num_cells;
         let mem_config = MemoryConfig::new(
             2,

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     error::CudaError,
     stream::{cudaStream_t, GpuDeviceCtx},
 };
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use tracing::instrument;
 
 use super::{SharedBuffer, MERKLE_TOUCHED_BLOCK_WIDTH};

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -7,7 +7,7 @@ use openvm_cuda_common::{
     error::CudaError,
     stream::{cudaStream_t, GpuDeviceCtx},
 };
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use tracing::instrument;
 
 use super::{SharedBuffer, MERKLE_TOUCHED_BLOCK_WIDTH};
@@ -163,8 +163,8 @@ pub mod merkle_tree {
     pub unsafe fn update_merkle_tree<T>(
         trace: &DeviceMatrix<T>,
         subtree_ptrs: &DeviceBuffer<usize>,
-        top_roots: &DeviceBuffer<[T; DIGEST_WIDTH]>,
-        zero_hash: &DeviceBuffer<[T; DIGEST_WIDTH]>,
+        top_roots: &DeviceBuffer<[T; VM_DIGEST_WIDTH]>,
+        zero_hash: &DeviceBuffer<[T; VM_DIGEST_WIDTH]>,
         touched_blocks: &DeviceBuffer<u32>,
         subtree_height: usize,
         actual_heights: &[usize],

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -11,7 +11,7 @@ use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     stream::{CudaEvent, GpuDeviceCtx},
 };
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::{
     p3_maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator},
     p3_util::log2_ceil_usize,
@@ -24,13 +24,13 @@ use super::{poseidon2::SharedBuffer, Poseidon2PeripheryChipGPU};
 pub mod cuda;
 use cuda::merkle_tree::*;
 
-type H = [F; DIGEST_WIDTH];
+type H = [F; VM_DIGEST_WIDTH];
 /// Width of `((u32, u32), TimestampedValues<F, BLOCK_FE_WIDTH>)` in u32 units.
 /// = 2 (key) + 1 (timestamp) + BLOCK_FE_WIDTH (values)
 pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + BLOCK_FE_WIDTH;
-/// Width of `((u32, u32), TimestampedValues<F, DIGEST_WIDTH>)` in u32 units.
-/// = 2 (key) + 1 (timestamp) + DIGEST_WIDTH (values)
-pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + DIGEST_WIDTH;
+/// Width of `((u32, u32), TimestampedValues<F, VM_DIGEST_WIDTH>)` in u32 units.
+/// = 2 (key) + 1 (timestamp) + VM_DIGEST_WIDTH (values)
+pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + VM_DIGEST_WIDTH;
 pub(crate) const OMITTED_BOTTOM_LEVELS: usize = 3;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -263,10 +263,10 @@ impl MemoryMerkleTree {
             .iter()
             .map(|ashc| {
                 assert!(
-                    ashc.num_cells % DIGEST_WIDTH == 0,
-                    "the number of cells must be divisible by `DIGEST_WIDTH`"
+                    ashc.num_cells % VM_DIGEST_WIDTH == 0,
+                    "the number of cells must be divisible by `VM_DIGEST_WIDTH`"
                 );
-                ashc.num_cells / DIGEST_WIDTH
+                ashc.num_cells / VM_DIGEST_WIDTH
             })
             .collect::<Vec<_>>();
         assert!(!(addr_space_sizes.is_empty()), "Invalid config");
@@ -326,7 +326,7 @@ impl MemoryMerkleTree {
         let addr_space_idx = addr_space - ADDR_SPACE_OFFSET as usize;
         if addr_space < self.mem_config.addr_spaces.len() && addr_space_idx == self.subtrees.len() {
             let mut subtree = MemoryMerkleSubTree::new(
-                self.mem_config.addr_spaces[addr_space].num_cells / DIGEST_WIDTH,
+                self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH,
                 1 << (self.zero_hash.len() - 1), /* label_max_bits */
                 &self.device_ctx,
             );
@@ -370,7 +370,7 @@ impl MemoryMerkleTree {
 
     /// Updates the tree and returns the merkle trace.
     ///
-    /// `d_touched_blocks` consists of `(as, ptr, ts, [F; DIGEST_WIDTH])`.
+    /// `d_touched_blocks` consists of `(as, ptr, ts, [F; VM_DIGEST_WIDTH])`.
     pub fn update_with_touched_blocks(
         &mut self,
         unpadded_height: usize,
@@ -384,7 +384,7 @@ impl MemoryMerkleTree {
             subtree.build_completion_event = None;
         }
         let merkle_trace = {
-            let width = MemoryMerkleCols::<u8, DIGEST_WIDTH>::width();
+            let width = MemoryMerkleCols::<u8, VM_DIGEST_WIDTH>::width();
             let padded_height = next_power_of_two_or_zero(unpadded_height);
             let output =
                 DeviceMatrix::<F>::with_capacity_on(padded_height, width, &self.device_ctx);
@@ -454,7 +454,7 @@ impl MemoryMerkleTree {
     ) -> usize {
         let md = self.mem_config.memory_dimensions();
         let tree_height = md.overall_height();
-        let shift_address = |(sp, ptr): (u32, u32)| (sp, ptr / DIGEST_WIDTH as u32);
+        let shift_address = |(sp, ptr): (u32, u32)| (sp, ptr / VM_DIGEST_WIDTH as u32);
         2 * if touched_memory.is_empty() {
             tree_height
         } else {
@@ -507,7 +507,7 @@ mod tests {
     };
     use openvm_instructions::{
         riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
-        DEFERRAL_AS, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
+        DEFERRAL_AS, VM_DIGEST_WIDTH,
     };
     use openvm_stark_backend::{interaction::PermutationCheckBus, prover::MatrixDimensions};
     use openvm_stark_sdk::utils::create_seeded_rng;
@@ -646,7 +646,7 @@ mod tests {
         gpu_merkle_tree.finalize();
 
         let cpu_hasher_chip = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);
-        let mut cpu_merkle_tree = MerkleTree::<F, DIGEST_WIDTH>::from_memory(
+        let mut cpu_merkle_tree = MerkleTree::<F, VM_DIGEST_WIDTH>::from_memory(
             &initial_memory.memory,
             &mem_config.memory_dimensions(),
             &cpu_hasher_chip,
@@ -677,9 +677,9 @@ mod tests {
             .enumerate()
             .flat_map(|(i, cnf)| {
                 let mut ptrs = Vec::new();
-                for j in 0..(cnf.num_cells / DIGEST_WIDTH) {
+                for j in 0..(cnf.num_cells / VM_DIGEST_WIDTH) {
                     if rng.random_bool(0.333) {
-                        ptrs.push((i as u32, (j * DIGEST_WIDTH) as u32));
+                        ptrs.push((i as u32, (j * VM_DIGEST_WIDTH) as u32));
                     }
                 }
                 ptrs
@@ -688,7 +688,7 @@ mod tests {
         let new_data = touched_ptrs
             .iter()
             .map(|_| std::array::from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32))))
-            .collect::<Vec<[F; DIGEST_WIDTH]>>();
+            .collect::<Vec<[F; VM_DIGEST_WIDTH]>>();
         assert!(!touched_ptrs.is_empty());
         cpu_merkle_tree.finalize(
             &cpu_hasher_chip,
@@ -842,9 +842,9 @@ mod tests {
             .enumerate()
             .flat_map(|(i, cnf)| {
                 let mut ptrs = Vec::new();
-                for j in 0..(cnf.num_cells / DIGEST_WIDTH) {
+                for j in 0..(cnf.num_cells / VM_DIGEST_WIDTH) {
                     if rng.random_bool(0.333) {
-                        ptrs.push((i as u32, (j * DIGEST_WIDTH) as u32));
+                        ptrs.push((i as u32, (j * VM_DIGEST_WIDTH) as u32));
                     }
                 }
                 ptrs
@@ -853,18 +853,18 @@ mod tests {
         let new_data = touched_ptrs
             .iter()
             .map(|_| std::array::from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32))))
-            .collect::<Vec<[F; DIGEST_WIDTH]>>();
+            .collect::<Vec<[F; VM_DIGEST_WIDTH]>>();
         assert!(!touched_ptrs.is_empty());
 
         // Build the canonical CPU trace from the same initial memory and touched blocks, using a
         // Poseidon2 hasher equivalent to the GPU one.
         let cpu_hasher_chip = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);
-        let mut cpu_merkle_chip = MemoryMerkleChip::<DIGEST_WIDTH, F>::new(
+        let mut cpu_merkle_chip = MemoryMerkleChip::<VM_DIGEST_WIDTH, F>::new(
             mem_config.memory_dimensions(),
             PermutationCheckBus::new(MEMORY_MERKLE_BUS),
             PermutationCheckBus::new(POSEIDON2_DIRECT_BUS),
         );
-        let final_partition: BTreeMap<(u32, u32), [F; DIGEST_WIDTH]> = touched_ptrs
+        let final_partition: BTreeMap<(u32, u32), [F; VM_DIGEST_WIDTH]> = touched_ptrs
             .iter()
             .copied()
             .zip(new_data.iter().copied())

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -11,7 +11,7 @@ use openvm_cuda_common::{
     d_buffer::DeviceBuffer,
     stream::{CudaEvent, GpuDeviceCtx},
 };
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_stark_backend::{
     p3_maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator},
     p3_util::log2_ceil_usize,
@@ -507,7 +507,7 @@ mod tests {
     };
     use openvm_instructions::{
         riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
-        DEFERRAL_AS, DIGEST_WIDTH,
+        DEFERRAL_AS, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
     };
     use openvm_stark_backend::{interaction::PermutationCheckBus, prover::MatrixDimensions};
     use openvm_stark_sdk::utils::create_seeded_rng;

--- a/crates/vm/src/system/cuda/mod.rs
+++ b/crates/vm/src/system/cuda/mod.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
 use openvm_cuda_backend::{prelude::F, GpuBackend};
 use openvm_cuda_common::stream::GpuDeviceCtx;
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_stark_backend::prover::{AirProvingContext, CommittedTraceData};
 use poseidon2::Poseidon2PeripheryChipGPU;
 use program::ProgramChipGPU;

--- a/crates/vm/src/system/cuda/mod.rs
+++ b/crates/vm/src/system/cuda/mod.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
 use openvm_cuda_backend::{prelude::F, GpuBackend};
 use openvm_cuda_common::stream::GpuDeviceCtx;
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::prover::{AirProvingContext, CommittedTraceData};
 use poseidon2::Poseidon2PeripheryChipGPU;
 use program::ProgramChipGPU;
@@ -101,7 +101,7 @@ impl SystemChipComplex<DenseRecordArena, GpuBackend> for SystemChipInventoryGPU 
             .collect()
     }
 
-    fn memory_top_tree(&self) -> Option<&[[F; DIGEST_WIDTH]]> {
+    fn memory_top_tree(&self) -> Option<&[[F; VM_DIGEST_WIDTH]]> {
         let top_tree = &self.memory_inventory.merkle_tree.top_roots_host;
         (!top_tree.is_empty()).then_some(top_tree.as_slice())
     }

--- a/crates/vm/src/system/memory/controller/interface.rs
+++ b/crates/vm/src/system/memory/controller/interface.rs
@@ -1,4 +1,4 @@
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::{interaction::PermutationCheckBus, p3_field::PrimeField32};
 
 use crate::system::memory::{
@@ -9,13 +9,13 @@ use crate::system::memory::{
 
 #[derive(Clone)]
 pub struct MemoryInterfaceAirs {
-    pub boundary: PersistentBoundaryAir<DIGEST_WIDTH>,
-    pub merkle: MemoryMerkleAir<DIGEST_WIDTH>,
+    pub boundary: PersistentBoundaryAir<VM_DIGEST_WIDTH>,
+    pub merkle: MemoryMerkleAir<VM_DIGEST_WIDTH>,
 }
 
 pub struct MemoryInterface<F> {
-    pub boundary_chip: PersistentBoundaryChip<F, DIGEST_WIDTH>,
-    pub merkle_chip: MemoryMerkleChip<DIGEST_WIDTH, F>,
+    pub boundary_chip: PersistentBoundaryChip<F, VM_DIGEST_WIDTH>,
+    pub merkle_chip: MemoryMerkleChip<VM_DIGEST_WIDTH, F>,
     pub initial_memory: MemoryImage,
 }
 

--- a/crates/vm/src/system/memory/controller/interface.rs
+++ b/crates/vm/src/system/memory/controller/interface.rs
@@ -1,4 +1,4 @@
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_stark_backend::{interaction::PermutationCheckBus, p3_field::PrimeField32};
 
 use crate::system::memory::{

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -10,7 +10,7 @@ use openvm_circuit_primitives::{
     Chip, TraceSubRowGenerator,
 };
 use openvm_cpu_backend::CpuBackend;
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_stark_backend::{
     interaction::PermutationCheckBus, p3_field::PrimeField32, prover::AirProvingContext,
     StarkProtocolConfig,

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -10,7 +10,7 @@ use openvm_circuit_primitives::{
     Chip, TraceSubRowGenerator,
 };
 use openvm_cpu_backend::CpuBackend;
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::{
     interaction::PermutationCheckBus, p3_field::PrimeField32, prover::AirProvingContext,
     StarkProtocolConfig,
@@ -35,11 +35,11 @@ use crate::{
 pub mod dimensions;
 pub mod interface;
 
-pub const DIGEST_WIDTH_BITS: usize = const_log2_strict_usize(DIGEST_WIDTH);
+pub const DIGEST_WIDTH_BITS: usize = const_log2_strict_usize(VM_DIGEST_WIDTH);
 
 const _: () = assert!(
-    DIGEST_WIDTH.is_multiple_of(BLOCK_FE_WIDTH),
-    "DIGEST_WIDTH must be divisible by BLOCK_FE_WIDTH so BLOCKS_PER_LEAF is integer-valued"
+    VM_DIGEST_WIDTH.is_multiple_of(BLOCK_FE_WIDTH),
+    "VM_DIGEST_WIDTH must be divisible by BLOCK_FE_WIDTH so BLOCKS_PER_LEAF is integer-valued"
 );
 
 /// The offset of the Merkle AIR in AIRs of MemoryController.
@@ -184,12 +184,12 @@ impl<F: VmField> MemoryController<F> {
         let final_memory_by_leaf = group_touched_memory_by_leaf(&final_memory);
         boundary_chip.finalize(initial_memory, &final_memory_by_leaf, hasher.as_ref());
 
-        // Regroup BLOCK_FE_WIDTH-cell blocks into DIGEST_WIDTH-cell leaves for merkle_chip.
+        // Regroup BLOCK_FE_WIDTH-cell blocks into VM_DIGEST_WIDTH-cell leaves for merkle_chip.
         // The equipartition key is (addr_space, ptr).
-        let final_memory_values: Equipartition<F, DIGEST_WIDTH> = final_memory_by_leaf
+        let final_memory_values: Equipartition<F, VM_DIGEST_WIDTH> = final_memory_by_leaf
             .iter()
             .map(|((addr_space, leaf_label), blocks)| {
-                let ptr = leaf_label * DIGEST_WIDTH as u32;
+                let ptr = leaf_label * VM_DIGEST_WIDTH as u32;
                 let mut values = std::array::from_fn(|i| unsafe {
                     initial_memory.get_f::<F>(*addr_space, ptr + i as u32)
                 });

--- a/crates/vm/src/system/memory/merkle/public_values.rs
+++ b/crates/vm/src/system/memory/merkle/public_values.rs
@@ -266,7 +266,7 @@ fn extract_public_value_cells<F: Field>(
 
 #[cfg(test)]
 mod tests {
-    use openvm_instructions::{MEMORY_DIGEST_WIDTH as DIGEST_WIDTH, PUBLIC_VALUES_AS};
+    use openvm_instructions::{PUBLIC_VALUES_AS, VM_DIGEST_WIDTH};
     use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
@@ -284,7 +284,7 @@ mod tests {
         vm_config.memory_config.addr_space_height = addr_space_height;
         vm_config.memory_config.pointer_max_bits = 5;
         let memory_dimensions = vm_config.memory_config.memory_dimensions();
-        let num_public_values = DIGEST_WIDTH;
+        let num_public_values = VM_DIGEST_WIDTH;
         let vm_config = vm_config.with_public_values(num_public_values);
         let mut addr_spaces_config = MemoryConfig::empty_address_space_configs(4);
         addr_spaces_config[PUBLIC_VALUES_AS as usize].num_cells = num_public_values;
@@ -304,7 +304,7 @@ mod tests {
         let hasher = vm_poseidon2_hasher();
         let tree = MerkleTree::from_memory(&memory.memory, &memory_dimensions, &hasher);
         let top_tree = tree.top_tree(addr_space_height);
-        let pv_proof = UserPublicValuesProof::<{ DIGEST_WIDTH }, F>::compute(
+        let pv_proof = UserPublicValuesProof::<{ VM_DIGEST_WIDTH }, F>::compute(
             &vm_config,
             &hasher,
             &memory.memory,

--- a/crates/vm/src/system/memory/merkle/public_values.rs
+++ b/crates/vm/src/system/memory/merkle/public_values.rs
@@ -266,7 +266,7 @@ fn extract_public_value_cells<F: Field>(
 
 #[cfg(test)]
 mod tests {
-    use openvm_instructions::{DIGEST_WIDTH, PUBLIC_VALUES_AS};
+    use openvm_instructions::{MEMORY_DIGEST_WIDTH as DIGEST_WIDTH, PUBLIC_VALUES_AS};
     use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
 

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use openvm_circuit_primitives::Chip;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::{
     interaction::{PermutationCheckBus, PermutationInteractionType},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
@@ -31,7 +32,7 @@ use crate::{
                 MemoryMerkleChip, MemoryMerkleCols, MerkleTree,
             },
             online::{GuestMemory, LinearMemory},
-            ptr_bits_from_address_height, AddressMap, MemoryImage, DIGEST_WIDTH,
+            ptr_bits_from_address_height, AddressMap, MemoryImage,
         },
         poseidon2::Poseidon2PeripheryChip,
     },
@@ -62,9 +63,9 @@ fn test(
                 initial_memory.get_f::<F>(address_space as u32, pointer as u32)
                     != final_memory.get_f(address_space as u32, pointer as u32)
             } {
-                let label = (pointer / DIGEST_WIDTH) as u32;
+                let label = (pointer / VM_DIGEST_WIDTH) as u32;
                 assert!(address_space - (ADDR_SPACE_OFFSET as usize) < (1 << addr_space_height));
-                assert!(pointer < (DIGEST_WIDTH << address_height));
+                assert!(pointer < (VM_DIGEST_WIDTH << address_height));
                 assert!(touched_labels.contains(&(address_space as u32, label)));
             }
         }
@@ -76,21 +77,21 @@ fn test(
         MerkleTree::from_memory(final_memory, &memory_dimensions, &hash_test_chip);
 
     let mut chip =
-        MemoryMerkleChip::<DIGEST_WIDTH, _>::new(memory_dimensions, merkle_bus, COMPRESSION_BUS);
-    let final_partition: BTreeMap<_, [F; DIGEST_WIDTH]> =
-        memory_to_vec_partition::<F, DIGEST_WIDTH>(final_memory, &memory_dimensions)
+        MemoryMerkleChip::<VM_DIGEST_WIDTH, _>::new(memory_dimensions, merkle_bus, COMPRESSION_BUS);
+    let final_partition: BTreeMap<_, [F; VM_DIGEST_WIDTH]> =
+        memory_to_vec_partition::<F, VM_DIGEST_WIDTH>(final_memory, &memory_dimensions)
             .into_iter()
             .map(|(idx, values)| {
                 let address_space =
                     (idx >> memory_dimensions.address_height) as u32 + ADDR_SPACE_OFFSET;
                 let label = (idx & ((1 << memory_dimensions.address_height) - 1)) as u32;
-                ((address_space, label * (DIGEST_WIDTH as u32)), values)
+                ((address_space, label * (VM_DIGEST_WIDTH as u32)), values)
             })
             .collect();
     let final_partition = final_partition
         .into_iter()
         .filter(|((address_space, pointer), _)| {
-            touched_labels.contains(&(*address_space, pointer / DIGEST_WIDTH as u32))
+            touched_labels.contains(&(*address_space, pointer / VM_DIGEST_WIDTH as u32))
         })
         .collect();
     chip.finalize(initial_memory, &final_partition, &hash_test_chip);
@@ -101,14 +102,15 @@ fn test(
     );
     let chip_api = chip.generate_proving_ctx();
 
-    let dummy_interaction_air = DummyInteractionAir::new(4 + DIGEST_WIDTH, true, merkle_bus.index);
+    let dummy_interaction_air =
+        DummyInteractionAir::new(4 + VM_DIGEST_WIDTH, true, merkle_bus.index);
     let mut dummy_interaction_trace_rows = vec![];
     let mut interaction = |interaction_type: PermutationInteractionType,
                            is_compress: bool,
                            height: usize,
                            as_label: u32,
                            address_label: u32,
-                           hash: [BabyBear; DIGEST_WIDTH]| {
+                           hash: [BabyBear; VM_DIGEST_WIDTH]| {
         let expand_direction = if is_compress {
             BabyBear::NEG_ONE
         } else {
@@ -132,7 +134,7 @@ fn test(
             array::from_fn(|i| {
                 initial_memory.get((
                     address_space,
-                    address_label * DIGEST_WIDTH as u32 + i as u32,
+                    address_label * VM_DIGEST_WIDTH as u32 + i as u32,
                 ))
             })
         };
@@ -146,7 +148,7 @@ fn test(
             initial_values,
         );
         let final_values = *final_partition
-            .get(&(address_space, address_label * (DIGEST_WIDTH as u32)))
+            .get(&(address_space, address_label * (VM_DIGEST_WIDTH as u32)))
             .unwrap();
         interaction(
             PermutationInteractionType::Send,
@@ -202,11 +204,11 @@ fn random_test(
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::F { size: 4 },
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::F { size: 4 },
             },
         ],
@@ -224,7 +226,7 @@ fn random_test(
     while num_initial_addresses != 0 || num_touched_addresses != 0 {
         let address_space = (next_u32() & 1) + 1;
         let label = next_u32() % (1 << height);
-        let pointer = label * DIGEST_WIDTH as u32 + (next_u32() % DIGEST_WIDTH as u32);
+        let pointer = label * VM_DIGEST_WIDTH as u32 + (next_u32() % VM_DIGEST_WIDTH as u32);
 
         if seen.insert(pointer) {
             let is_initial = next_u32() & 1 == 0;
@@ -291,11 +293,11 @@ fn expand_test_no_accesses() {
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::F { size: 4 },
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::F { size: 4 },
             },
         ],
@@ -307,7 +309,7 @@ fn expand_test_no_accesses() {
 
     let memory = AddressMap::from_mem_config(&mem_config);
 
-    let mut chip: MemoryMerkleChip<DIGEST_WIDTH, _> = MemoryMerkleChip::new(
+    let mut chip: MemoryMerkleChip<VM_DIGEST_WIDTH, _> = MemoryMerkleChip::new(
         md,
         PermutationCheckBus::new(MEMORY_MERKLE_BUS),
         COMPRESSION_BUS,
@@ -336,11 +338,11 @@ fn expand_test_negative() {
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::F { size: 4 },
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::F { size: 4 },
             },
         ],
@@ -352,7 +354,7 @@ fn expand_test_negative() {
 
     let memory = AddressMap::from_mem_config(&mem_config);
 
-    let mut chip: MemoryMerkleChip<DIGEST_WIDTH, _> = MemoryMerkleChip::new(
+    let mut chip: MemoryMerkleChip<VM_DIGEST_WIDTH, _> = MemoryMerkleChip::new(
         md,
         PermutationCheckBus::new(MEMORY_MERKLE_BUS),
         COMPRESSION_BUS,
@@ -362,7 +364,7 @@ fn expand_test_negative() {
     let mut chip_ctx = chip.generate_proving_ctx();
     {
         for row in chip_ctx.common_main.rows_mut() {
-            let row: &mut MemoryMerkleCols<_, DIGEST_WIDTH> = row.borrow_mut();
+            let row: &mut MemoryMerkleCols<_, VM_DIGEST_WIDTH> = row.borrow_mut();
             if row.expand_direction == BabyBear::NEG_ONE {
                 row.left_direction_different = BabyBear::ZERO;
                 row.right_direction_different = BabyBear::ZERO;
@@ -381,7 +383,7 @@ fn expand_test_negative() {
 const BELOW_LEAF_PATH_LEN: usize = 31;
 const COUNTEREXAMPLE_TRACE_HEIGHT: usize = 256;
 
-fn counterexample_digest(seed: u32) -> [BabyBear; DIGEST_WIDTH] {
+fn counterexample_digest(seed: u32) -> [BabyBear; VM_DIGEST_WIDTH] {
     array::from_fn(|i| BabyBear::from_u32(seed.wrapping_add(17 * i as u32)))
 }
 
@@ -404,24 +406,24 @@ fn final_direction_different(direction: BabyBear, child_has_expansion: bool) -> 
 fn build_below_leaf_swap_subtree(
     hasher: &Poseidon2PeripheryChip<BabyBear>,
     direction: BabyBear,
-    alpha_digest: [BabyBear; DIGEST_WIDTH],
-    beta_digest: [BabyBear; DIGEST_WIDTH],
+    alpha_digest: [BabyBear; VM_DIGEST_WIDTH],
+    beta_digest: [BabyBear; VM_DIGEST_WIDTH],
     swap_digests: bool,
 ) -> (
-    [BabyBear; DIGEST_WIDTH],
-    Vec<MemoryMerkleCols<BabyBear, DIGEST_WIDTH>>,
+    [BabyBear; VM_DIGEST_WIDTH],
+    Vec<MemoryMerkleCols<BabyBear, VM_DIGEST_WIDTH>>,
 ) {
     #[allow(clippy::too_many_arguments)]
     fn rec(
         hasher: &Poseidon2PeripheryChip<BabyBear>,
-        rows: &mut Vec<MemoryMerkleCols<BabyBear, DIGEST_WIDTH>>,
+        rows: &mut Vec<MemoryMerkleCols<BabyBear, VM_DIGEST_WIDTH>>,
         direction: BabyBear,
-        alpha_digest: [BabyBear; DIGEST_WIDTH],
-        beta_digest: [BabyBear; DIGEST_WIDTH],
+        alpha_digest: [BabyBear; VM_DIGEST_WIDTH],
+        beta_digest: [BabyBear; VM_DIGEST_WIDTH],
         swap_digests: bool,
         depth: usize,
         prefix: u32,
-    ) -> [BabyBear; DIGEST_WIDTH] {
+    ) -> [BabyBear; VM_DIGEST_WIDTH] {
         let alpha_path = 0;
         let beta_path = BabyBear::ORDER_U32;
 
@@ -528,10 +530,10 @@ fn build_below_leaf_swap_subtree(
 }
 
 fn counterexample_zero_node_hash(
-    hasher: &impl Hasher<DIGEST_WIDTH, BabyBear>,
+    hasher: &impl Hasher<VM_DIGEST_WIDTH, BabyBear>,
     height: usize,
-) -> [BabyBear; DIGEST_WIDTH] {
-    let mut hash = hasher.hash(&[BabyBear::ZERO; DIGEST_WIDTH]);
+) -> [BabyBear; VM_DIGEST_WIDTH] {
+    let mut hash = hasher.hash(&[BabyBear::ZERO; VM_DIGEST_WIDTH]);
     for _ in 0..height {
         hash = hasher.compress(&hash, &hash);
     }
@@ -558,8 +560,8 @@ fn counterexample_parent_labels(
 #[derive(Clone, Copy)]
 struct CounterexampleLeafUpdate {
     index: u64,
-    initial_hash: [BabyBear; DIGEST_WIDTH],
-    final_hash: [BabyBear; DIGEST_WIDTH],
+    initial_hash: [BabyBear; VM_DIGEST_WIDTH],
+    final_hash: [BabyBear; VM_DIGEST_WIDTH],
 }
 
 fn build_counterexample_canonical_rows(
@@ -567,9 +569,9 @@ fn build_counterexample_canonical_rows(
     memory_dimensions: MemoryDimensions,
     leaf_updates: &[CounterexampleLeafUpdate],
 ) -> (
-    [BabyBear; DIGEST_WIDTH],
-    [BabyBear; DIGEST_WIDTH],
-    Vec<MemoryMerkleCols<BabyBear, DIGEST_WIDTH>>,
+    [BabyBear; VM_DIGEST_WIDTH],
+    [BabyBear; VM_DIGEST_WIDTH],
+    Vec<MemoryMerkleCols<BabyBear, VM_DIGEST_WIDTH>>,
 ) {
     let mut current = BTreeMap::new();
     for update in leaf_updates {
@@ -669,11 +671,11 @@ fn build_hidden_leaf_expansion_row(
     direction: BabyBear,
     address_space_label: u32,
     leaf_label: u32,
-    below_leaf_root: [BabyBear; DIGEST_WIDTH],
-    unchanged_sibling_hash: [BabyBear; DIGEST_WIDTH],
+    below_leaf_root: [BabyBear; VM_DIGEST_WIDTH],
+    unchanged_sibling_hash: [BabyBear; VM_DIGEST_WIDTH],
 ) -> (
-    [BabyBear; DIGEST_WIDTH],
-    MemoryMerkleCols<BabyBear, DIGEST_WIDTH>,
+    [BabyBear; VM_DIGEST_WIDTH],
+    MemoryMerkleCols<BabyBear, VM_DIGEST_WIDTH>,
 ) {
     let parent_hash = hasher.compress_and_record(&below_leaf_root, &unchanged_sibling_hash);
     (
@@ -747,7 +749,7 @@ fn build_below_leaf_swap_fraud_merkle(
         ADDR_SPACE_OFFSET + hidden_address_space_label,
         hidden_leaf_label,
     ));
-    let hidden_unchanged_sibling_hash = [BabyBear::ZERO; DIGEST_WIDTH];
+    let hidden_unchanged_sibling_hash = [BabyBear::ZERO; VM_DIGEST_WIDTH];
     let (initial_hidden_leaf_hash, initial_hidden_leaf_row) = build_hidden_leaf_expansion_row(
         &poseidon2_chip,
         BabyBear::ONE,
@@ -815,15 +817,15 @@ fn build_below_leaf_swap_fraud_merkle(
             is_root: BabyBear::ZERO,
             parent_as_label: BabyBear::ZERO,
             parent_address_label: BabyBear::ZERO,
-            parent_hash: [BabyBear::ZERO; DIGEST_WIDTH],
-            left_child_hash: [BabyBear::ZERO; DIGEST_WIDTH],
-            right_child_hash: [BabyBear::ZERO; DIGEST_WIDTH],
+            parent_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
+            left_child_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
+            right_child_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
             left_direction_different: BabyBear::ZERO,
             right_direction_different: BabyBear::ZERO,
         });
     }
 
-    let merkle_width = MemoryMerkleCols::<BabyBear, DIGEST_WIDTH>::width();
+    let merkle_width = MemoryMerkleCols::<BabyBear, VM_DIGEST_WIDTH>::width();
     let mut merkle_trace = BabyBear::zero_vec(merkle_width * trace_height);
     for (trace_row, row) in merkle_trace.chunks_exact_mut(merkle_width).zip(rows) {
         *trace_row.borrow_mut() = row;
@@ -954,11 +956,11 @@ fn expand_test_label_rebinding_attack() {
                 layout: MemoryCellType::Null,
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::field32(),
             },
             AddressSpaceHostConfig {
-                num_cells: DIGEST_WIDTH << height,
+                num_cells: VM_DIGEST_WIDTH << height,
                 layout: MemoryCellType::field32(),
             },
         ],
@@ -970,27 +972,32 @@ fn expand_test_label_rebinding_attack() {
 
     let mut memory = GuestMemory::new(AddressMap::from_mem_config(&mem_config));
     unsafe {
-        memory.write(1, fake_label * DIGEST_WIDTH as u32, [BabyBear::from_u8(69)]);
+        memory.write(
+            1,
+            fake_label * VM_DIGEST_WIDTH as u32,
+            [BabyBear::from_u8(69)],
+        );
     }
 
     let touched_labels_for_chip = BTreeSet::from([(1u32, fake_label)]);
     let touched_labels_for_dummy = BTreeSet::from([(1u32, claimed_label)]);
 
-    let final_partition_for_chip: BTreeMap<_, [BabyBear; DIGEST_WIDTH]> =
-        memory_to_vec_partition::<BabyBear, DIGEST_WIDTH>(&memory.memory, &md)
+    let final_partition_for_chip: BTreeMap<_, [BabyBear; VM_DIGEST_WIDTH]> =
+        memory_to_vec_partition::<BabyBear, VM_DIGEST_WIDTH>(&memory.memory, &md)
             .into_iter()
             .map(|(idx, values)| {
                 let address_space = (idx >> md.address_height) as u32 + ADDR_SPACE_OFFSET;
                 let label = (idx & ((1 << md.address_height) - 1)) as u32;
-                ((address_space, label * (DIGEST_WIDTH as u32)), values)
+                ((address_space, label * (VM_DIGEST_WIDTH as u32)), values)
             })
             .filter(|((address_space, pointer), _)| {
-                touched_labels_for_chip.contains(&(*address_space, pointer / DIGEST_WIDTH as u32))
+                touched_labels_for_chip
+                    .contains(&(*address_space, pointer / VM_DIGEST_WIDTH as u32))
             })
             .collect();
 
     let merkle_bus = PermutationCheckBus::new(MEMORY_MERKLE_BUS);
-    let mut chip = MemoryMerkleChip::<DIGEST_WIDTH, _>::new(md, merkle_bus, COMPRESSION_BUS);
+    let mut chip = MemoryMerkleChip::<VM_DIGEST_WIDTH, _>::new(md, merkle_bus, COMPRESSION_BUS);
     chip.finalize(&memory.memory, &final_partition_for_chip, &hash_test_chip);
     let mut chip_ctx = chip.generate_proving_ctx();
 
@@ -1016,7 +1023,7 @@ fn expand_test_label_rebinding_attack() {
         }
 
         for row in chip_ctx.common_main.rows_mut() {
-            let row: &mut MemoryMerkleCols<BabyBear, DIGEST_WIDTH> = row.borrow_mut();
+            let row: &mut MemoryMerkleCols<BabyBear, VM_DIGEST_WIDTH> = row.borrow_mut();
             if row.expand_direction == BabyBear::ZERO {
                 continue;
             }
@@ -1025,14 +1032,15 @@ fn expand_test_label_rebinding_attack() {
         }
     }
 
-    let dummy_interaction_air = DummyInteractionAir::new(4 + DIGEST_WIDTH, true, merkle_bus.index);
+    let dummy_interaction_air =
+        DummyInteractionAir::new(4 + VM_DIGEST_WIDTH, true, merkle_bus.index);
     let mut dummy_interaction_trace_rows = vec![];
     let mut interaction = |interaction_type: PermutationInteractionType,
                            is_compress: bool,
                            height: usize,
                            as_label: u32,
                            address_label: u32,
-                           hash: [BabyBear; DIGEST_WIDTH]| {
+                           hash: [BabyBear; VM_DIGEST_WIDTH]| {
         let expand_direction = if is_compress {
             BabyBear::NEG_ONE
         } else {
@@ -1054,9 +1062,10 @@ fn expand_test_label_rebinding_attack() {
     for (address_space, address_label) in touched_labels_for_dummy {
         let values = unsafe {
             array::from_fn(|i| {
-                memory
-                    .memory
-                    .get((address_space, fake_label * DIGEST_WIDTH as u32 + i as u32))
+                memory.memory.get((
+                    address_space,
+                    fake_label * VM_DIGEST_WIDTH as u32 + i as u32,
+                ))
             })
         };
         let as_label = address_space - ADDR_SPACE_OFFSET;

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -2,7 +2,7 @@ use std::{mem::size_of, sync::Arc};
 
 use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_platform::memory::MEM_BITS;
 use openvm_stark_backend::{interaction::PermutationCheckBus, StarkProtocolConfig};
 
@@ -82,12 +82,12 @@ impl MemoryAirInventory {
     ) -> Self {
         let memory_bus = bridge.memory_bus();
         let memory_dims = mem_config.memory_dimensions();
-        let boundary = PersistentBoundaryAir::<DIGEST_WIDTH> {
+        let boundary = PersistentBoundaryAir::<VM_DIGEST_WIDTH> {
             memory_bus,
             merkle_bus,
             compression_bus,
         };
-        let merkle = MemoryMerkleAir::<DIGEST_WIDTH> {
+        let merkle = MemoryMerkleAir::<VM_DIGEST_WIDTH> {
             memory_dimensions: memory_dims,
             merkle_bus,
             compression_bus,

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -2,7 +2,7 @@ use std::{mem::size_of, sync::Arc};
 
 use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_platform::memory::MEM_BITS;
 use openvm_stark_backend::{interaction::PermutationCheckBus, StarkProtocolConfig};
 

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
-use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
+use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, PermutationCheckBus},
     p3_air::{Air, AirBuilder, BaseAir},
@@ -29,7 +29,7 @@ use crate::{
 };
 
 /// Number of memory-bus blocks covered by one merkle leaf.
-pub const BLOCKS_PER_LEAF: usize = DIGEST_WIDTH / BLOCK_FE_WIDTH;
+pub const BLOCKS_PER_LEAF: usize = VM_DIGEST_WIDTH / BLOCK_FE_WIDTH;
 
 /// The values describe one merkle leaf (`DIGEST_WIDTH` cells)---the data together with the
 /// last accessed timestamp---in either the initial or final memory state.
@@ -166,8 +166,8 @@ pub(crate) fn group_touched_memory_by_leaf<F: Copy + Send + Sync>(
     let mut enriched: Vec<EnrichedEntry<F>> = final_memory
         .par_iter()
         .map(|&((addr_space, ptr), ts_values)| {
-            let leaf_label = ptr / DIGEST_WIDTH as u32;
-            let block_idx = ((ptr % DIGEST_WIDTH as u32) / BLOCK_FE_WIDTH as u32) as usize;
+            let leaf_label = ptr / VM_DIGEST_WIDTH as u32;
+            let block_idx = ((ptr % VM_DIGEST_WIDTH as u32) / BLOCK_FE_WIDTH as u32) as usize;
             let key = (addr_space, leaf_label);
             let block_info = (block_idx, ts_values.timestamp, ts_values.values);
             (key, block_info)

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -7,7 +7,7 @@ use std::{
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
-use openvm_instructions::DIGEST_WIDTH;
+use openvm_instructions::MEMORY_DIGEST_WIDTH as DIGEST_WIDTH;
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, PermutationCheckBus},
     p3_air::{Air, AirBuilder, BaseAir},

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -13,7 +13,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_cpu_backend::{CpuBackend, CpuDevice};
 use openvm_instructions::{
-    LocalOpcode, PhantomDiscriminant, SysPhantom, SystemOpcode, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
+    LocalOpcode, PhantomDiscriminant, SysPhantom, SystemOpcode, VM_DIGEST_WIDTH,
 };
 use openvm_stark_backend::{
     interaction::{LookupBus, PermutationCheckBus},
@@ -94,7 +94,7 @@ pub trait SystemChipComplex<RA, PB: ProverBackend> {
     /// This function **must** return `Some` if called after
     /// [`generate_proving_ctx`](Self::generate_proving_ctx) and may return `None` if called before
     /// that.
-    fn memory_top_tree(&self) -> Option<&[[PB::Val; DIGEST_WIDTH]]>;
+    fn memory_top_tree(&self) -> Option<&[[PB::Val; VM_DIGEST_WIDTH]]>;
 }
 
 /// Trait meant to be implemented on a SystemChipComplex.
@@ -377,7 +377,7 @@ where
             .collect()
     }
 
-    fn memory_top_tree(&self) -> Option<&[[Val<SC>; DIGEST_WIDTH]]> {
+    fn memory_top_tree(&self) -> Option<&[[Val<SC>; VM_DIGEST_WIDTH]]> {
         let top_tree = &self.memory_controller.interface_chip.merkle_chip.top_tree;
         (!top_tree.is_empty()).then_some(top_tree.as_slice())
     }

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -13,7 +13,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_cpu_backend::{CpuBackend, CpuDevice};
 use openvm_instructions::{
-    LocalOpcode, PhantomDiscriminant, SysPhantom, SystemOpcode, DIGEST_WIDTH,
+    LocalOpcode, PhantomDiscriminant, SysPhantom, SystemOpcode, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
 };
 use openvm_stark_backend::{
     interaction::{LookupBus, PermutationCheckBus},

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -6,7 +6,7 @@ use openvm_cpu_backend::CpuBackend;
 use openvm_instructions::{
     exe::VmExe,
     program::{Program, DEFAULT_PC_STEP},
-    LocalOpcode, SystemOpcode, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
+    LocalOpcode, SystemOpcode, VM_DIGEST_WIDTH,
 };
 use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
@@ -64,10 +64,10 @@ impl<SC: StarkProtocolConfig> Chip<(), CpuBackend<SC>> for ProgramChip<SC> {
 ///
 /// **Note**: This function recomputes the Merkle tree for the initial memory image.
 pub fn compute_exe_commit_from_mem_config<F: PrimeField32>(
-    program_commitment: &[F; DIGEST_WIDTH],
+    program_commitment: &[F; VM_DIGEST_WIDTH],
     exe: &VmExe<F>,
     memory_config: &MemoryConfig,
-) -> [F; DIGEST_WIDTH] {
+) -> [F; VM_DIGEST_WIDTH] {
     let hasher = vm_poseidon2_hasher();
     let memory_dimensions = memory_config.memory_dimensions();
     let mut memory_image = AddressMap::new(memory_config.addr_spaces.clone());
@@ -91,11 +91,11 @@ pub fn compute_exe_commit_from_mem_config<F: PrimeField32>(
 /// and a cryptographic compression function (for internal nodes).
 pub fn compute_exe_commit<F: PrimeField32>(
     hasher: &Poseidon2Hasher<F>,
-    program_commit: &[F; DIGEST_WIDTH],
-    init_memory_root: &[F; DIGEST_WIDTH],
+    program_commit: &[F; VM_DIGEST_WIDTH],
+    init_memory_root: &[F; VM_DIGEST_WIDTH],
     pc_start: F,
-) -> [F; DIGEST_WIDTH] {
-    let mut padded_pc_start = [F::ZERO; DIGEST_WIDTH];
+) -> [F; VM_DIGEST_WIDTH] {
+    let mut padded_pc_start = [F::ZERO; VM_DIGEST_WIDTH];
     padded_pc_start[0] = pc_start;
     let program_hash = hasher.hash(program_commit);
     let memory_hash = hasher.hash(init_memory_root);

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -6,7 +6,7 @@ use openvm_cpu_backend::CpuBackend;
 use openvm_instructions::{
     exe::VmExe,
     program::{Program, DEFAULT_PC_STEP},
-    LocalOpcode, SystemOpcode, DIGEST_WIDTH,
+    LocalOpcode, SystemOpcode, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH,
 };
 use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -1,5 +1,5 @@
 use openvm_circuit_primitives::utils::next_power_of_two_or_zero;
-use openvm_instructions::{exe::VmExe, DIGEST_WIDTH};
+use openvm_instructions::{exe::VmExe, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH};
 use openvm_stark_backend::{
     keygen::types::MultiStarkVerifyingKey, p3_field::PrimeField32, proof::Proof,
     prover::ProvingContext, Com, StarkEngine, SystemParams, Val,

--- a/crates/vm/src/utils/stark_utils.rs
+++ b/crates/vm/src/utils/stark_utils.rs
@@ -1,5 +1,5 @@
 use openvm_circuit_primitives::utils::next_power_of_two_or_zero;
-use openvm_instructions::{exe::VmExe, MEMORY_DIGEST_WIDTH as DIGEST_WIDTH};
+use openvm_instructions::{exe::VmExe, VM_DIGEST_WIDTH};
 use openvm_stark_backend::{
     keygen::types::MultiStarkVerifyingKey, p3_field::PrimeField32, proof::Proof,
     prover::ProvingContext, Com, StarkEngine, SystemParams, Val,
@@ -122,7 +122,7 @@ where
     <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>
         + MeteredExecutor<Val<E::SC>>
         + PreflightExecutor<Val<E::SC>, VB::RecordArena>,
-    Com<E::SC>: Into<[Val<E::SC>; DIGEST_WIDTH]> + From<[Val<E::SC>; DIGEST_WIDTH]>,
+    Com<E::SC>: Into<[Val<E::SC>; VM_DIGEST_WIDTH]> + From<[Val<E::SC>; VM_DIGEST_WIDTH]>,
 {
     /*
     Assertions for Pure Execution AOT
@@ -223,7 +223,7 @@ where
     <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>
         + MeteredExecutor<Val<E::SC>>
         + PreflightExecutor<Val<E::SC>, VB::RecordArena>,
-    Com<E::SC>: Into<[Val<E::SC>; DIGEST_WIDTH]> + From<[Val<E::SC>; DIGEST_WIDTH]>,
+    Com<E::SC>: Into<[Val<E::SC>; VM_DIGEST_WIDTH]> + From<[Val<E::SC>; VM_DIGEST_WIDTH]>,
 {
     /*
     Assertions for Pure Execution RVR
@@ -357,7 +357,7 @@ where
     <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>
         + MeteredExecutor<Val<E::SC>>
         + PreflightExecutor<Val<E::SC>, VB::RecordArena>,
-    Com<E::SC>: Into<[Val<E::SC>; DIGEST_WIDTH]> + From<[Val<E::SC>; DIGEST_WIDTH]>,
+    Com<E::SC>: Into<[Val<E::SC>; VM_DIGEST_WIDTH]> + From<[Val<E::SC>; VM_DIGEST_WIDTH]>,
 {
     setup_tracing();
     let engine = E::new(params);

--- a/extensions/deferral/circuit/Cargo.toml
+++ b/extensions/deferral/circuit/Cargo.toml
@@ -23,7 +23,6 @@ openvm-riscv-circuit = { workspace = true }
 openvm-deferral-transpiler = { workspace = true }
 rvr-openvm-lift = { workspace = true, optional = true }
 rvr-openvm-ext-deferral = { workspace = true, optional = true }
-rvr-openvm-ext-ffi-common = { workspace = true, optional = true }
 
 openvm-cuda-backend = { workspace = true, optional = true }
 openvm-cuda-common = { workspace = true, optional = true }
@@ -53,7 +52,6 @@ rvr = [
     "dep:rvr-openvm-lift",
     "dep:rvr-openvm-ext-deferral",
     "rvr-openvm-ext-deferral/rvr",
-    "dep:rvr-openvm-ext-ffi-common",
     "openvm-riscv-circuit/rvr",
 ]
 jemalloc = ["openvm-circuit/jemalloc"]

--- a/extensions/deferral/circuit/src/runtime.rs
+++ b/extensions/deferral/circuit/src/runtime.rs
@@ -1,8 +1,7 @@
 //! F-typed builder for the rvr deferral output hasher.
 
 use openvm_circuit::arch::VmField;
-use rvr_openvm_ext_deferral::{DeferralCompressFn, DeferralHashFn};
-use rvr_openvm_ext_ffi_common::DEFERRAL_COMMIT_NUM_BYTES;
+use rvr_openvm_ext_deferral::{DeferralCompressFn, DeferralHashFn, DEFERRAL_COMMIT_NUM_BYTES};
 
 use crate::{def_fn::hash_output_raw, poseidon2::deferral_poseidon2_chip};
 

--- a/extensions/deferral/rvr/Cargo.toml
+++ b/extensions/deferral/rvr/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-rvr-openvm-ext-ffi-common = { workspace = true, optional = true }
 rvr-openvm-ir = { workspace = true, optional = true }
 rvr-openvm-lift = { workspace = true, optional = true }
 
@@ -21,7 +20,6 @@ libloading = { workspace = true, optional = true }
 [features]
 default = []
 rvr = [
-    "dep:rvr-openvm-ext-ffi-common",
     "dep:rvr-openvm-ir",
     "dep:rvr-openvm-lift",
     "dep:openvm-circuit",

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -14,9 +14,7 @@
 
 #include "openvm.h"
 
-/* DEFERRAL_DIGEST_SIZE (digest size in field elements) and WORD_SIZE come from
- * openvm_constants.h via openvm.h. The byte-layout constants are derived here
- * to match rvr-openvm-ext-deferral. */
+/* Byte-layout constants derived from the generated digest and word sizes. */
 // TODO(rvr): update to better formula/solution instead of defining field element size here
 static constexpr uint32_t F_NUM_BYTES = 4;
 static constexpr uint32_t DEFERRAL_COMMIT_NUM_BYTES =

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -15,8 +15,8 @@
 #include "openvm.h"
 
 /* DEFERRAL_DIGEST_SIZE (digest size in field elements) and WORD_SIZE come from
- * openvm_constants.h via openvm.h. The rest are derived here, mirroring
- * rvr-openvm-ffi-common. */
+ * openvm_constants.h via openvm.h. The byte-layout constants are derived here
+ * to match rvr-openvm-ext-deferral. */
 // TODO(rvr): update to better formula/solution instead of defining field element size here
 static constexpr uint32_t F_NUM_BYTES = 4;
 static constexpr uint32_t DEFERRAL_COMMIT_NUM_BYTES =

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -13,22 +13,30 @@ use openvm_circuit::arch::{
     rvr::io::OpenVmIoState,
 };
 use openvm_deferral_transpiler::DeferralOpcode;
-use openvm_instructions::{LocalOpcode, DIGEST_WIDTH};
+use openvm_instructions::{LocalOpcode, MEMORY_DIGEST_WIDTH};
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_ext_ffi_common::{DEFERRAL_COMMIT_NUM_BYTES, DEFERRAL_OUTPUT_KEY_BYTES};
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
     air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
     RvrExtensionCtx, RvrInstruction, RvrRuntimeExtension,
 };
 
+/// Size in bytes of a serialized deferral commitment.
+pub const DEFERRAL_COMMIT_NUM_BYTES: usize = MEMORY_DIGEST_WIDTH * core::mem::size_of::<u32>();
+/// Size in bytes of a deferral output key: commitment followed by output length.
+pub const DEFERRAL_OUTPUT_KEY_BYTES: usize =
+    DEFERRAL_COMMIT_NUM_BYTES + core::mem::size_of::<u64>();
+
 /// `(def_idx, output_raw) → output_commit` hasher registered by the host.
 pub type DeferralHashFn = Box<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYTES] + Send + Sync>;
 
 /// Poseidon2 compression over deferral accumulator field elements.
 /// Values cross the crate boundary as canonical u32s.
-pub type DeferralCompressFn =
-    Box<dyn Fn([u32; DIGEST_WIDTH], [u32; DIGEST_WIDTH]) -> [u32; DIGEST_WIDTH] + Send + Sync>;
+pub type DeferralCompressFn = Box<
+    dyn Fn([u32; MEMORY_DIGEST_WIDTH], [u32; MEMORY_DIGEST_WIDTH]) -> [u32; MEMORY_DIGEST_WIDTH]
+        + Send
+        + Sync,
+>;
 
 pub struct DeferralCtx {
     pub fns: Vec<Arc<DeferralFn>>,
@@ -255,8 +263,10 @@ impl RvrRuntimeExtension for DeferralRuntimeHooks {
 //
 // CALL writes new `(input_acc, output_acc)` values to DEFERRAL_AS.
 
-fn commit_bytes_to_field_values(bytes: &[u8; DEFERRAL_COMMIT_NUM_BYTES]) -> [u32; DIGEST_WIDTH] {
-    let mut out = [0u32; DIGEST_WIDTH];
+fn commit_bytes_to_field_values(
+    bytes: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
+) -> [u32; MEMORY_DIGEST_WIDTH] {
+    let mut out = [0u32; MEMORY_DIGEST_WIDTH];
     for (dst, chunk) in out.iter_mut().zip(bytes.chunks_exact(4)) {
         *dst = u32::from_le_bytes(chunk.try_into().unwrap());
     }
@@ -282,8 +292,11 @@ unsafe fn deferral_memory<'a, F: PrimeField32>(io: &'a mut OpenVmIoState<'_>) ->
     }
 }
 
-fn read_deferral_digest<F: PrimeField32>(memory: &[F], ptr: usize) -> Option<[u32; DIGEST_WIDTH]> {
-    let end = ptr.checked_add(DIGEST_WIDTH)?;
+fn read_deferral_digest<F: PrimeField32>(
+    memory: &[F],
+    ptr: usize,
+) -> Option<[u32; MEMORY_DIGEST_WIDTH]> {
+    let end = ptr.checked_add(MEMORY_DIGEST_WIDTH)?;
     let values = memory.get(ptr..end)?;
     Some(std::array::from_fn(|i| values[i].as_canonical_u32()))
 }
@@ -291,9 +304,9 @@ fn read_deferral_digest<F: PrimeField32>(memory: &[F], ptr: usize) -> Option<[u3
 fn write_deferral_digest<F: PrimeField32>(
     memory: &mut [F],
     ptr: usize,
-    values: [u32; DIGEST_WIDTH],
+    values: [u32; MEMORY_DIGEST_WIDTH],
 ) -> bool {
-    let Some(end) = ptr.checked_add(DIGEST_WIDTH) else {
+    let Some(end) = ptr.checked_add(MEMORY_DIGEST_WIDTH) else {
         return false;
     };
     let Some(dst) = memory.get_mut(ptr..end) else {
@@ -315,8 +328,8 @@ unsafe fn update_deferral_accumulators<F: PrimeField32>(
     output_commit: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
 ) -> bool {
     let memory = unsafe { deferral_memory::<F>(io) };
-    let input_acc_ptr = 2 * def_idx as usize * DIGEST_WIDTH;
-    let output_acc_ptr = input_acc_ptr + DIGEST_WIDTH;
+    let input_acc_ptr = 2 * def_idx as usize * MEMORY_DIGEST_WIDTH;
+    let output_acc_ptr = input_acc_ptr + MEMORY_DIGEST_WIDTH;
     let Some(old_input_acc) = read_deferral_digest(memory, input_acc_ptr) else {
         return false;
     };

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -13,7 +13,7 @@ use openvm_circuit::arch::{
     rvr::io::OpenVmIoState,
 };
 use openvm_deferral_transpiler::DeferralOpcode;
-use openvm_instructions::{LocalOpcode, MEMORY_DIGEST_WIDTH};
+use openvm_instructions::{LocalOpcode, VM_DIGEST_WIDTH};
 use openvm_stark_backend::p3_field::PrimeField32;
 use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
@@ -22,7 +22,7 @@ use rvr_openvm_lift::{
 };
 
 /// Size in bytes of a serialized deferral commitment.
-pub const DEFERRAL_COMMIT_NUM_BYTES: usize = MEMORY_DIGEST_WIDTH * core::mem::size_of::<u32>();
+pub const DEFERRAL_COMMIT_NUM_BYTES: usize = VM_DIGEST_WIDTH * core::mem::size_of::<u32>();
 /// Size in bytes of a deferral output key: commitment followed by output length.
 pub const DEFERRAL_OUTPUT_KEY_BYTES: usize =
     DEFERRAL_COMMIT_NUM_BYTES + core::mem::size_of::<u64>();
@@ -33,9 +33,7 @@ pub type DeferralHashFn = Box<dyn Fn(u32, &[u8]) -> [u8; DEFERRAL_COMMIT_NUM_BYT
 /// Poseidon2 compression over deferral accumulator field elements.
 /// Values cross the crate boundary as canonical u32s.
 pub type DeferralCompressFn = Box<
-    dyn Fn([u32; MEMORY_DIGEST_WIDTH], [u32; MEMORY_DIGEST_WIDTH]) -> [u32; MEMORY_DIGEST_WIDTH]
-        + Send
-        + Sync,
+    dyn Fn([u32; VM_DIGEST_WIDTH], [u32; VM_DIGEST_WIDTH]) -> [u32; VM_DIGEST_WIDTH] + Send + Sync,
 >;
 
 pub struct DeferralCtx {
@@ -263,10 +261,8 @@ impl RvrRuntimeExtension for DeferralRuntimeHooks {
 //
 // CALL writes new `(input_acc, output_acc)` values to DEFERRAL_AS.
 
-fn commit_bytes_to_field_values(
-    bytes: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
-) -> [u32; MEMORY_DIGEST_WIDTH] {
-    let mut out = [0u32; MEMORY_DIGEST_WIDTH];
+fn commit_bytes_to_field_values(bytes: &[u8; DEFERRAL_COMMIT_NUM_BYTES]) -> [u32; VM_DIGEST_WIDTH] {
+    let mut out = [0u32; VM_DIGEST_WIDTH];
     for (dst, chunk) in out.iter_mut().zip(bytes.chunks_exact(4)) {
         *dst = u32::from_le_bytes(chunk.try_into().unwrap());
     }
@@ -295,8 +291,8 @@ unsafe fn deferral_memory<'a, F: PrimeField32>(io: &'a mut OpenVmIoState<'_>) ->
 fn read_deferral_digest<F: PrimeField32>(
     memory: &[F],
     ptr: usize,
-) -> Option<[u32; MEMORY_DIGEST_WIDTH]> {
-    let end = ptr.checked_add(MEMORY_DIGEST_WIDTH)?;
+) -> Option<[u32; VM_DIGEST_WIDTH]> {
+    let end = ptr.checked_add(VM_DIGEST_WIDTH)?;
     let values = memory.get(ptr..end)?;
     Some(std::array::from_fn(|i| values[i].as_canonical_u32()))
 }
@@ -304,9 +300,9 @@ fn read_deferral_digest<F: PrimeField32>(
 fn write_deferral_digest<F: PrimeField32>(
     memory: &mut [F],
     ptr: usize,
-    values: [u32; MEMORY_DIGEST_WIDTH],
+    values: [u32; VM_DIGEST_WIDTH],
 ) -> bool {
-    let Some(end) = ptr.checked_add(MEMORY_DIGEST_WIDTH) else {
+    let Some(end) = ptr.checked_add(VM_DIGEST_WIDTH) else {
         return false;
     };
     let Some(dst) = memory.get_mut(ptr..end) else {
@@ -328,8 +324,8 @@ unsafe fn update_deferral_accumulators<F: PrimeField32>(
     output_commit: &[u8; DEFERRAL_COMMIT_NUM_BYTES],
 ) -> bool {
     let memory = unsafe { deferral_memory::<F>(io) };
-    let input_acc_ptr = 2 * def_idx as usize * MEMORY_DIGEST_WIDTH;
-    let output_acc_ptr = input_acc_ptr + MEMORY_DIGEST_WIDTH;
+    let input_acc_ptr = 2 * def_idx as usize * VM_DIGEST_WIDTH;
+    let output_acc_ptr = input_acc_ptr + VM_DIGEST_WIDTH;
     let Some(old_input_acc) = read_deferral_digest(memory, input_acc_ptr) else {
         return false;
     };

--- a/extensions/riscv/circuit/src/common/mod.rs
+++ b/extensions/riscv/circuit/src/common/mod.rs
@@ -15,7 +15,7 @@ mod aot {
     };
     use openvm_instructions::{
         riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
-        DIGEST_WIDTH, PUBLIC_VALUES_AS,
+        MEMORY_DIGEST_WIDTH as DIGEST_WIDTH, PUBLIC_VALUES_AS,
     };
 
     /// The minimum block size is 4, but RISC-V `lb` only requires alignment of 1 and `lh` only

--- a/extensions/riscv/circuit/src/common/mod.rs
+++ b/extensions/riscv/circuit/src/common/mod.rs
@@ -15,7 +15,7 @@ mod aot {
     };
     use openvm_instructions::{
         riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
-        MEMORY_DIGEST_WIDTH as DIGEST_WIDTH, PUBLIC_VALUES_AS,
+        PUBLIC_VALUES_AS, VM_DIGEST_WIDTH,
     };
 
     /// The minimum block size is 4, but RISC-V `lb` only requires alignment of 1 and `lh` only


### PR DESCRIPTION
## Summary

- centralize the VM digest width and metering constants in `openvm-instructions`
- keep generated-block size and segment-check interval as distinct fixed constants with a compile-time invariant
- move deferral layout constants to their owning crate and remove unused FFI wrappers and dependencies

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo shear`
- `cargo nextest run --cargo-profile fast --features parallel` on Linux x86_64
- `cargo nextest run --cargo-profile=fast --features parallel,basic-memory` on Linux x86_64
- targeted RVR and deferral tests on Linux x86_64

Resolves INT-8501