### PR TITLE
ci: right-size cpu runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -35,8 +35,13 @@ runners:
         "c8i-flex.4xlarge",
         "c8i.4xlarge",
         "c8a.4xlarge",
+        "m8i-flex.4xlarge",
+        "m8i.4xlarge",
+        "m8a.4xlarge",
         "c7i.4xlarge",
         "c7a.4xlarge",
+        "m7i.4xlarge",
+        "m7a.4xlarge",
       ]
     image: ubuntu24-full-x64
     volume: 80gb
@@ -47,8 +52,13 @@ runners:
         "c8i-flex.8xlarge",
         "c8i.8xlarge",
         "c8a.8xlarge",
+        "m8i-flex.8xlarge",
+        "m8i.8xlarge",
+        "m8a.8xlarge",
         "c7i.8xlarge",
         "c7a.8xlarge",
+        "m7i.8xlarge",
+        "m7a.8xlarge",
       ]
     image: ubuntu24-full-x64
     volume: 80gb

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -7,6 +7,52 @@ images:
     ami: "ami-040a96edd406c9478"
 
 runners:
+  cpu-small-arm64:
+    family:
+      [
+        "c9g.4xlarge",
+        "c8g.4xlarge",
+        "m9g.4xlarge",
+        "m8g.4xlarge",
+      ]
+    image: ubuntu24-full-arm64
+    volume: 80gb
+
+  cpu-medium-arm64:
+    family:
+      [
+        "c9g.8xlarge",
+        "c8g.8xlarge",
+        "m9g.8xlarge",
+        "m8g.8xlarge",
+      ]
+    image: ubuntu24-full-arm64
+    volume: 80gb
+
+  cpu-small-x64:
+    family:
+      [
+        "c8i-flex.4xlarge",
+        "c8i.4xlarge",
+        "c8a.4xlarge",
+        "c7i.4xlarge",
+        "c7a.4xlarge",
+      ]
+    image: ubuntu24-full-x64
+    volume: 80gb
+
+  cpu-medium-x64:
+    family:
+      [
+        "c8i-flex.8xlarge",
+        "c8i.8xlarge",
+        "c8a.8xlarge",
+        "c7i.8xlarge",
+        "c7a.8xlarge",
+      ]
+    image: ubuntu24-full-x64
+    volume: 80gb
+
   # runners for running tests
   test-gpu-nvidia:
     family: ["g7.4xlarge", "g6.4xlarge", "g5.4xlarge"]

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     branches: ["**"]
     paths: *benchmark_paths
   workflow_dispatch:
@@ -37,7 +37,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow_ref }}-benchmarks-${{ github.event.action == 'labeled' && github.event.label.name != 'run-benchmark' && github.event.label.name != 'run-benchmark-e2e' && github.run_id || github.event.pull_request.number || github.sha }}
+  group: benchmarks-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     name: Cargo build
     runs-on:
-      - runs-on=${{ github.run_id }}/family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - name: Load SSH key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     name: Cargo build
     runs-on:
-      - runs-on=${{ github.run_id }}/volume=80gb/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - name: Load SSH key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     name: Cargo build
     runs-on:
-      - runs-on=${{ github.run_id }}/family=m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - name: Load SSH key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     name: Cargo build
     runs-on:
-      - runs-on=${{ github.run_id }}/family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}/family=m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
       - name: Load SSH key

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/extension-tests.group.yml
     with:
       runner_id: cpu-${{ strategy.job-index }}
-      machine_type: family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/volume=80gb
+      machine_type: ${{ matrix.extension == 'algebra' && (matrix.mode == 'aot' && 'family=c8i-flex.4xlarge+c8i.4xlarge+c8a.4xlarge+c7i.4xlarge+c7a.4xlarge/image=ubuntu24-full-x64/volume=80gb' || 'family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb') || (matrix.mode == 'aot' && 'family=c8i-flex.8xlarge+c8i.8xlarge+c8a.8xlarge+c7i.8xlarge+c7a.8xlarge/image=ubuntu24-full-x64/volume=80gb' || 'family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb') }}
       extensions: ${{ matrix.extension }}
       mode: ${{ matrix.mode }}
     secrets: inherit

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/extension-tests.group.yml
     with:
       runner_id: cpu-${{ strategy.job-index }}
-      machine_type: ${{ matrix.extension == 'algebra' && (matrix.mode == 'aot' && 'family=c8i-flex.4xlarge+c8i.4xlarge+c8a.4xlarge+c7i.4xlarge+c7a.4xlarge/image=ubuntu24-full-x64/volume=80gb' || 'family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb') || (matrix.mode == 'aot' && 'family=c8i-flex.8xlarge+c8i.8xlarge+c8a.8xlarge+c7i.8xlarge+c7a.8xlarge/image=ubuntu24-full-x64/volume=80gb' || 'family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb') }}
+      machine_type: ${{ matrix.extension == 'algebra' && (matrix.mode == 'aot' && 'family=c8i-flex.4xlarge+c8i.4xlarge+c8a.4xlarge+m8i-flex.4xlarge+m8i.4xlarge+m8a.4xlarge+c7i.4xlarge+c7a.4xlarge+m7i.4xlarge+m7a.4xlarge/image=ubuntu24-full-x64/volume=80gb' || 'family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb') || (matrix.mode == 'aot' && 'family=c8i-flex.8xlarge+c8i.8xlarge+c8a.8xlarge+m8i-flex.8xlarge+m8i.8xlarge+m8a.8xlarge+c7i.8xlarge+c7a.8xlarge+m7i.8xlarge+m7a.8xlarge/image=ubuntu24-full-x64/volume=80gb' || 'family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb') }}
       extensions: ${{ matrix.extension }}
       mode: ${{ matrix.mode }}
     secrets: inherit

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/guest-lib-tests.group.yml
     with:
       runner_id: cpu-${{ strategy.job-index }}
-      machine_type: family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb
+      machine_type: ${{ (matrix.crate == 'pairing' || matrix.crate == 'sha2' || matrix.crate == 'keccak256') && 'family=c8i-flex.4xlarge+c8i.4xlarge+c8a.4xlarge+m8i-flex.4xlarge+m8i.4xlarge+m8a.4xlarge+c7i.4xlarge+c7a.4xlarge+m7i.4xlarge+m7a.4xlarge/image=ubuntu24-full-x64/volume=80gb' || 'family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb' }}
       crates: ${{ matrix.crate }}
       mode: ${{ matrix.mode }}
     secrets: inherit

--- a/.github/workflows/guest-lib-tests.yml
+++ b/.github/workflows/guest-lib-tests.yml
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/guest-lib-tests.group.yml
     with:
       runner_id: cpu-${{ strategy.job-index }}
-      machine_type: family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/volume=80gb
+      machine_type: family=c9g.4xlarge+c8g.4xlarge+m9g.4xlarge+m8g.4xlarge/image=ubuntu24-full-arm64/volume=80gb
       crates: ${{ matrix.crate }}
       mode: ${{ matrix.mode }}
     secrets: inherit

--- a/.github/workflows/label-overrides.yml
+++ b/.github/workflows/label-overrides.yml
@@ -1,0 +1,28 @@
+name: Label overrides
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  benchmarks:
+    if: ${{ github.event.label.name == 'run-benchmark' || github.event.label.name == 'run-benchmark-e2e' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/benchmarks.yml
+    secrets: inherit
+
+  sdk:
+    if: ${{ github.event.label.name == 'run-sdk-tests' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/sdk.yml
+    secrets: inherit
+
+  sdk-cuda:
+    if: ${{ github.event.label.name == 'run-sdk-tests' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/sdk.cuda.yml
+    secrets: inherit

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -39,7 +39,7 @@ jobs:
   lint:
     name: Lint
     runs-on:
-      - runs-on=${{ github.run_id }}-cpu/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-cpu/family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/primitives.yml
+++ b/.github/workflows/primitives.yml
@@ -28,7 +28,7 @@ jobs:
     name: CPU (parallel)
 
     runs-on:
-      - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-primitives-${{ github.run_attempt }}/family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -43,7 +43,7 @@ jobs:
         platform:
           - {
               name: "runtime (AOT)",
-              labels: "family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/volume=80gb",
+              labels: "family=c8i-flex.8xlarge+c8i.8xlarge+c8a.8xlarge+c7i.8xlarge+c7a.8xlarge/image=ubuntu24-full-x64/volume=80gb",
               image: "ubuntu24-full-x64",
               features: "aot",
             }

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -43,7 +43,7 @@ jobs:
         platform:
           - {
               name: "runtime (AOT)",
-              labels: "family=c8i-flex.8xlarge+c8i.8xlarge+c8a.8xlarge+c7i.8xlarge+c7a.8xlarge/image=ubuntu24-full-x64/volume=80gb",
+              labels: "family=c8i-flex.8xlarge+c8i.8xlarge+c8a.8xlarge+m8i-flex.8xlarge+m8i.8xlarge+m8a.8xlarge+c7i.8xlarge+c7a.8xlarge+m7i.8xlarge+m7a.8xlarge/image=ubuntu24-full-x64/volume=80gb",
               image: "ubuntu24-full-x64",
               features: "aot",
             }

--- a/.github/workflows/sdk.cuda.yml
+++ b/.github/workflows/sdk.cuda.yml
@@ -1,6 +1,7 @@
 name: SDK Tests (CUDA)
 
 on:
+  workflow_call:
   push:
     branches: ["main"]
   pull_request:
@@ -19,7 +20,7 @@ on:
       - ".github/workflows/sdk.cuda.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: sdk-cuda-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -18,11 +18,11 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     branches: ["**"]
 
 concurrency:
-  group: ${{ github.workflow_ref }}-sdk-${{ github.event.action == 'labeled' && github.event.label.name != 'run-sdk-tests' && github.run_id || github.event.pull_request.number || github.sha }}
+  group: sdk-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -28,7 +28,7 @@ jobs:
     name: CPU (parallel, basic-memory)
 
     runs-on:
-      - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}/family=c8i-flex.16xlarge+c8i.16xlarge+c8a.16xlarge+c7i.16xlarge+c7a.16xlarge/image=ubuntu24-full-x64/volume=80gb/extras=s3-cache
+      - runs-on=${{ github.run_id }}-vm-tests-${{ github.run_attempt }}/family=c9g.8xlarge+c8g.8xlarge+m9g.8xlarge+m8g.8xlarge/image=ubuntu24-full-arm64/volume=80gb/extras=s3-cache
 
     steps:
       - uses: runs-on/action@v2


### PR DESCRIPTION
Right-sizes CPU CI runners from 16xlarge to workload-specific 4xlarge and 8xlarge pools.

- Uses Graviton C/M pools for ARM-compatible test jobs.
- Runs the cold workspace build on 128 GiB M8/M9 8xlarge instances; its concurrent linker fanout exceeds the 64 GiB available on C8/C9 8xlarge.
- Keeps AOT and asm-dependent jobs on x64 C/M pools.
- Adds reusable CPU runner aliases for follow-up workflow cleanup.
- Makes benchmark and SDK labels override path filters without launching duplicate target workflows; `run-sdk-tests` also runs the CUDA SDK suite.

Workflows use explicit labels in this PR because RunsOn reads public-repository configuration from the default branch; the aliases can be adopted after this merges.
