### PR TITLE
fix(v2.1): emit `unimp` instruction for undecodable words

### DIFF
--- a/crates/toolchain/tests/tests/rv64_transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/rv64_transpiler_tests.rs
@@ -63,6 +63,30 @@ fn test_transpile_addi_immediate_boundaries(imm: i32, expected_c: u32) -> Result
     Ok(())
 }
 
+#[test]
+fn test_transpile_rv64_undecodable_word_as_unimp() -> Result<()> {
+    const ADDI_X3_X0_1: u32 = 0x0010_0193;
+    const UNDECODABLE_WORD: u32 = 0x1000_0200;
+
+    let words = [ADDI_X3_X0_1, UNDECODABLE_WORD, ADDI_X3_X0_1];
+    let program = rv64_transpiler().transpile(&words)?;
+
+    assert_eq!(program.len(), words.len());
+    assert_eq!(
+        program[0].as_ref().unwrap().opcode,
+        BaseAluImmOpcode::ADDI.global_opcode()
+    );
+    assert_eq!(
+        program[2].as_ref().unwrap().opcode,
+        BaseAluImmOpcode::ADDI.global_opcode()
+    );
+    let unimp = program[1].as_ref().expect("UNIMP should be emitted");
+    assert_eq!(unimp.opcode, SystemOpcode::TERMINATE.global_opcode());
+    assert_eq!(unimp.c.as_canonical_u32(), 2);
+
+    Ok(())
+}
+
 // To create ELF directly from .S file, `brew install riscv-gnu-toolchain` and run
 // `riscv64-unknown-elf-gcc -march=rv64im -mabi=lp64 -nostartfiles -e _start -Ttext 0x00200800
 // -Wl,-N <name>.S -o <name>-from-as`

--- a/crates/toolchain/transpiler/src/transpiler.rs
+++ b/crates/toolchain/transpiler/src/transpiler.rs
@@ -5,7 +5,7 @@ use openvm_instructions::{exe::SparseMemoryImage, instruction::Instruction};
 use openvm_stark_backend::p3_field::PrimeField32;
 use thiserror::Error;
 
-use crate::TranspilerExtension;
+use crate::{util::unimp, TranspilerExtension, TranspilerOutput};
 
 /// Collection of [`TranspilerExtension`]s.
 /// The transpiler can be configured to transpile any ELF in 32-bit chunks.
@@ -53,8 +53,8 @@ impl<F: PrimeField32> Transpiler<F> {
     /// applies every processor in the [`Transpiler`] to determine if one of them knows how to
     /// transpile the current instruction (and possibly a contiguous section of following
     /// instructions). If so, it advances the iterator by the amount specified by the processor.
-    /// The transpiler will panic if two different processors claim to know how to transpile the
-    /// same instruction to avoid ambiguity.
+    /// If no processor recognizes a word, the transpiler emits an `unimp` instruction for it. If
+    /// multiple processors recognize the same word, the transpiler returns an error.
     pub fn transpile(
         &self,
         instructions_u32: &[u32],
@@ -65,16 +65,16 @@ impl<F: PrimeField32> Transpiler<F> {
             let mut options = self
                 .processors
                 .iter()
-                .map(|proc| proc.process_custom(&instructions_u32[ptr..]))
-                .filter(|opt| opt.is_some())
+                .filter_map(|proc| proc.process_custom(&instructions_u32[ptr..]))
                 .collect::<Vec<_>>();
-            if options.is_empty() {
-                return Err(TranspilerError::ParseError(instructions_u32[ptr]));
-            }
             if options.len() > 1 {
                 return Err(TranspilerError::AmbiguousNextInstruction);
             }
-            let transpiler_output = options.pop().unwrap().unwrap();
+            let transpiler_output = options.pop().unwrap_or_else(|| {
+                // Executable segments may contain embedded data. Preserve its program slot and
+                // trap only if execution reaches it.
+                TranspilerOutput::one_to_one(unimp())
+            });
             instructions.extend(transpiler_output.instructions);
             ptr += transpiler_output.used_u32s;
         }


### PR DESCRIPTION
Executable ELF segments can contain embedded data such as jump tables or constant pools. Previously, transpilation failed whenever no registered extension could decode one of these words, even if it was never executed.

This change emits an `unimp` instruction at the corresponding program slot instead. The original word remains unchanged in initialized memory, so embedded data can still be read normally; the program terminates only if control flow reaches that slot. Ambiguous instruction decodings remain an error.

Includes a regression test with an undecodable word between valid RV64 instructions.

Resolves INT-8838