### PR TITLE
perf(v2.1): specialize the rvr generated runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7371,6 +7371,9 @@ dependencies = [
 [[package]]
 name = "rvr-openvm-ext-ffi-common"
 version = "2.0.0"
+dependencies = [
+ "openvm-platform",
+]
 
 [[package]]
 name = "rvr-openvm-ext-keccak"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7380,6 +7380,7 @@ version = "2.0.0"
 dependencies = [
  "openvm-instructions",
  "openvm-keccak256-transpiler",
+ "p3-keccak-air",
  "rvr-openvm-build",
  "rvr-openvm-ir",
  "rvr-openvm-lift",
@@ -7437,6 +7438,7 @@ name = "rvr-openvm-ext-sha2"
 version = "2.0.0"
 dependencies = [
  "openvm-instructions",
+ "openvm-sha2-air",
  "openvm-sha2-transpiler",
  "rvr-openvm-build",
  "rvr-openvm-ir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7290,7 +7290,6 @@ version = "2.0.0"
 dependencies = [
  "halo2curves-axiom 0.7.3",
  "num-bigint 0.4.6",
- "openvm-instructions",
  "paste",
  "rvr-openvm-ext-algebra-ffi-common",
  "rvr-openvm-ext-ffi-common",
@@ -7303,7 +7302,6 @@ dependencies = [
  "halo2curves-axiom 0.7.3",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-instructions",
  "openvm-platform",
  "paste",
  "rvr-openvm-ext-algebra-ffi-common",

--- a/crates/rvr/rvr-openvm-ffi-common/Cargo.toml
+++ b/crates/rvr/rvr-openvm-ffi-common/Cargo.toml
@@ -6,3 +6,6 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
+
+[dependencies]
+openvm-platform.workspace = true

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -9,9 +9,13 @@
 
 use std::ffi::c_void;
 
+use openvm_platform::{memory::MEM_SIZE, WORD_SIZE};
+
+const _: () = assert!(MEM_SIZE / WORD_SIZE <= u32::MAX as usize);
+
 extern "C" {
-    fn read_mem_u64_execution_input_wrapper(state: *mut c_void, addr: u64) -> u64;
-    fn read_mem_u64_range_execution_input_wrapper(
+    fn peek_mem_u64_wrapper(state: *mut c_void, addr: u64) -> u64;
+    fn peek_mem_u64_range_wrapper(
         state: *mut c_void,
         base_addr: u64,
         out: *mut u64,
@@ -86,7 +90,10 @@ pub fn u64s_as_bytes_mut(words: &mut [u64]) -> &mut [u8] {
 #[inline(always)]
 fn memory_word_count(len: usize) -> u32 {
     debug_assert!(len > 0, "memory word range must be non-empty");
-    debug_assert!(u32::try_from(len).is_ok());
+    debug_assert!(
+        len <= MEM_SIZE / WORD_SIZE,
+        "memory word range must fit in guest memory"
+    );
     len as u32
 }
 
@@ -99,7 +106,7 @@ fn memory_word_count(len: usize) -> u32 {
 ///
 /// # Safety
 ///
-/// `state` must point to a valid `RvState`. `out.len()` must fit in `u32`, and
+/// `state` must point to a valid `RvState`, and
 /// `[base_addr, base_addr + out.len() * WORD_SIZE)` must fit in guest memory.
 pub unsafe fn read_mem_words(state: *mut c_void, base_addr: u64, out: &mut [u64]) {
     let num_words = memory_word_count(out.len());
@@ -112,7 +119,7 @@ pub unsafe fn read_mem_words(state: *mut c_void, base_addr: u64, out: &mut [u64]
 ///
 /// # Safety
 ///
-/// `state` must point to a valid `RvState`. `vals.len()` must fit in `u32`, and
+/// `state` must point to a valid `RvState`, and
 /// `[base_addr, base_addr + vals.len() * WORD_SIZE)` must fit in guest memory.
 pub unsafe fn write_mem_words(state: *mut c_void, base_addr: u64, vals: &[u64]) {
     let num_words = memory_word_count(vals.len());
@@ -124,8 +131,8 @@ pub unsafe fn write_mem_words(state: *mut c_void, base_addr: u64, vals: &[u64]) 
 /// # Safety
 /// `state` must point to a valid `RvState`, and `addr` must address one u64 in
 /// guest memory.
-pub unsafe fn read_mem_u64_execution_input(state: *mut c_void, addr: u64) -> u64 {
-    read_mem_u64_execution_input_wrapper(state, addr)
+pub unsafe fn peek_mem_u64(state: *mut c_void, addr: u64) -> u64 {
+    peek_mem_u64_wrapper(state, addr)
 }
 
 /// Read guest words whose values affect execution but are not VM memory
@@ -134,9 +141,9 @@ pub unsafe fn read_mem_u64_execution_input(state: *mut c_void, addr: u64) -> u64
 /// # Safety
 /// `state` must point to a valid `RvState`. `out` must be non-empty, and its
 /// guest-memory range must be valid.
-pub unsafe fn read_mem_words_execution_input(state: *mut c_void, base_addr: u64, out: &mut [u64]) {
+pub unsafe fn peek_mem_words(state: *mut c_void, base_addr: u64, out: &mut [u64]) {
     let num_words = memory_word_count(out.len());
-    read_mem_u64_range_execution_input_wrapper(state, base_addr, out.as_mut_ptr(), num_words);
+    peek_mem_u64_range_wrapper(state, base_addr, out.as_mut_ptr(), num_words);
 }
 
 /// Record the pages touched by `num_words` consecutive words in `addr_space`.

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -1,7 +1,7 @@
-//! FFI declarations for the C tracing wrapper functions.
+//! Memory and host-I/O helpers shared by Rust RVR extensions.
 //!
-//! Extension staticlibs call these non-inline wrappers (defined in
-//! `rvr_ext_wrappers.c`) for traced memory access.
+//! Extension staticlibs call the C functions defined in `rvr_ext_wrappers.c`
+//! for execution-mode-specific memory access.
 //! Register access stays in generated C; resolved values are passed to extension FFI entry points.
 //!
 //! The `state` parameter is always an opaque `*mut c_void` pointing
@@ -10,41 +10,30 @@
 use std::ffi::c_void;
 
 extern "C" {
-    // ── Memory access (single u64 word, data) ─────────────────────────
-    pub fn rd_mem_u64_wrapper(state: *mut c_void, addr: u64) -> u64;
-
-    // ── Memory access (u64-word ranges, data) ───────────────────────
-    pub fn rd_mem_u64_range_wrapper(
+    fn read_mem_u64_execution_input_wrapper(state: *mut c_void, addr: u64) -> u64;
+    fn read_mem_u64_range_execution_input_wrapper(
         state: *mut c_void,
         base_addr: u64,
         out: *mut u64,
         num_words: u32,
     );
-    pub fn wr_mem_u64_range_wrapper(
+    fn read_mem_u64_range_wrapper(
+        state: *mut c_void,
+        base_addr: u64,
+        out: *mut u64,
+        num_words: u32,
+    );
+    fn write_mem_u64_range_wrapper(
         state: *mut c_void,
         base_addr: u64,
         vals: *const u64,
         num_words: u32,
     );
-    pub fn trace_mem_access_u64_range_wrapper(
+    fn record_page_access_u64_range_wrapper(
         state: *mut c_void,
         base_addr: u64,
         num_words: u32,
         addr_space: u32,
-    );
-
-    // ── Memory access (u64-word ranges, trace-only) ───────────────────
-    pub fn trace_rd_mem_u64_range_wrapper(
-        state: *mut c_void,
-        base_addr: u64,
-        vals: *const u64,
-        num_words: u32,
-    );
-    pub fn trace_wr_mem_u64_range_wrapper(
-        state: *mut c_void,
-        base_addr: u64,
-        vals: *const u64,
-        num_words: u32,
     );
 
     // ── Hint stream (for extension phantom instructions) ──────────────
@@ -74,58 +63,90 @@ pub fn u64s_as_u32s_mut(lanes: &mut [u64]) -> &mut [u32] {
     unsafe { std::slice::from_raw_parts_mut(lanes.as_mut_ptr().cast::<u32>(), len) }
 }
 
+/// View u64 words as their little-endian bytes without copying.
+#[inline(always)]
+pub fn u64s_as_bytes(words: &[u64]) -> &[u8] {
+    let len = core::mem::size_of_val(words);
+    // SAFETY: u8 has alignment 1, the byte length matches the source slice,
+    // and the supported little-endian host layout matches guest word order.
+    unsafe { std::slice::from_raw_parts(words.as_ptr().cast::<u8>(), len) }
+}
+
+/// View mutable u64 words as their little-endian bytes without copying.
+#[inline(always)]
+pub fn u64s_as_bytes_mut(words: &mut [u64]) -> &mut [u8] {
+    let len = core::mem::size_of_val(words);
+    // SAFETY: the same layout argument as [`u64s_as_bytes`] applies, and the
+    // mutable borrow keeps the returned byte slice exclusive.
+    unsafe { std::slice::from_raw_parts_mut(words.as_mut_ptr().cast::<u8>(), len) }
+}
+
 // ── Ergonomic batched memory helpers ─────────────────────────────────────
 
-/// Read `out.len()` consecutive u64 words from guest memory into `out`,
-/// then trace each as a memory read.
+#[inline(always)]
+fn memory_word_count(len: usize) -> u32 {
+    debug_assert!(len > 0, "memory word range must be non-empty");
+    debug_assert!(u32::try_from(len).is_ok());
+    len as u32
+}
+
+/// Read `out.len()` consecutive u64 words as VM memory accesses.
 ///
-/// `out` must be non-empty; the C trace functions assume `num_words >= 1`
+/// `out` must be non-empty; the mode-specific functions assume `num_words >= 1`
 /// to avoid an underflow check on the hot path. Callers handling
 /// guest-supplied dynamic sizes (e.g. xorin with `len = 0`) must guard
 /// the empty case themselves.
 ///
 /// # Safety
-/// `state` must be a valid `RvState` pointer; `out.len()` must fit in `u32`, and
-/// the byte range `[base_addr, base_addr + out.len() * WORD_SIZE)` must lie within guest memory.
-pub unsafe fn rd_mem_words_traced(state: *mut c_void, base_addr: u64, out: &mut [u64]) {
-    debug_assert!(
-        !out.is_empty(),
-        "rd_mem_words_traced requires a non-empty range"
-    );
-    debug_assert!(u32::try_from(out.len()).is_ok());
-    let n = out.len() as u32;
-    rd_mem_u64_range_wrapper(state, base_addr, out.as_mut_ptr(), n);
-    trace_rd_mem_u64_range_wrapper(state, base_addr, out.as_ptr(), n);
+///
+/// `state` must point to a valid `RvState`. `out.len()` must fit in `u32`, and
+/// `[base_addr, base_addr + out.len() * WORD_SIZE)` must fit in guest memory.
+pub unsafe fn read_mem_words(state: *mut c_void, base_addr: u64, out: &mut [u64]) {
+    let num_words = memory_word_count(out.len());
+    read_mem_u64_range_wrapper(state, base_addr, out.as_mut_ptr(), num_words);
 }
 
-/// Trace each value in `vals` as a write to guest memory, then write them.
-/// Trace-before-write so future tracers can read the old value before it is
-/// overwritten.
+/// Write `vals` as VM memory accesses.
 ///
-/// `vals` must be non-empty; see [`rd_mem_words_traced`] for rationale.
+/// `vals` must be non-empty; see [`read_mem_words`] for rationale.
 ///
 /// # Safety
-/// `state` must be a valid `RvState` pointer; `vals.len()` must fit in `u32`, and
-/// the byte range `[base_addr, base_addr + vals.len() * WORD_SIZE)` must lie within guest memory.
-pub unsafe fn wr_mem_words_traced(state: *mut c_void, base_addr: u64, vals: &[u64]) {
-    debug_assert!(
-        !vals.is_empty(),
-        "wr_mem_words_traced requires a non-empty range"
-    );
-    debug_assert!(u32::try_from(vals.len()).is_ok());
-    let n = vals.len() as u32;
-    trace_wr_mem_u64_range_wrapper(state, base_addr, vals.as_ptr(), n);
-    wr_mem_u64_range_wrapper(state, base_addr, vals.as_ptr(), n);
+///
+/// `state` must point to a valid `RvState`. `vals.len()` must fit in `u32`, and
+/// `[base_addr, base_addr + vals.len() * WORD_SIZE)` must fit in guest memory.
+pub unsafe fn write_mem_words(state: *mut c_void, base_addr: u64, vals: &[u64]) {
+    let num_words = memory_word_count(vals.len());
+    write_mem_u64_range_wrapper(state, base_addr, vals.as_ptr(), num_words);
 }
 
-/// Trace `num_words` consecutive memory-access notifications (no value)
-/// at `addr_space`, one per WORD_SIZE step from `base_addr`.
+/// Read one u64 whose value affects execution but is not a VM memory access.
 ///
-/// `num_words` must be `>= 1`; see [`rd_mem_words_traced`] for rationale.
+/// # Safety
+/// `state` must point to a valid `RvState`, and `addr` must address one u64 in
+/// guest memory.
+pub unsafe fn read_mem_u64_execution_input(state: *mut c_void, addr: u64) -> u64 {
+    read_mem_u64_execution_input_wrapper(state, addr)
+}
+
+/// Read guest words whose values affect execution but are not VM memory
+/// accesses.
+///
+/// # Safety
+/// `state` must point to a valid `RvState`. `out` must be non-empty, and its
+/// guest-memory range must be valid.
+pub unsafe fn read_mem_words_execution_input(state: *mut c_void, base_addr: u64, out: &mut [u64]) {
+    let num_words = memory_word_count(out.len());
+    read_mem_u64_range_execution_input_wrapper(state, base_addr, out.as_mut_ptr(), num_words);
+}
+
+/// Record the pages touched by `num_words` consecutive words in `addr_space`.
+/// This is metering data only; it does not record the accessed values.
+///
+/// `num_words` must be `>= 1`; see [`read_mem_words`] for rationale.
 ///
 /// # Safety
 /// `state` must be a valid `RvState` pointer.
-pub unsafe fn trace_mem_access_range(
+pub unsafe fn record_page_access_range(
     state: *mut c_void,
     base_addr: u64,
     num_words: u32,
@@ -133,7 +154,7 @@ pub unsafe fn trace_mem_access_range(
 ) {
     debug_assert!(
         num_words >= 1,
-        "trace_mem_access_range requires num_words >= 1"
+        "record_page_access_range requires num_words >= 1"
     );
-    trace_mem_access_u64_range_wrapper(state, base_addr, num_words, addr_space);
+    record_page_access_u64_range_wrapper(state, base_addr, num_words, addr_space);
 }

--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! FFI declarations for the C tracing wrapper functions.
 //!
 //! Extension staticlibs call these non-inline wrappers (defined in
-//! `rvr_ext_wrappers.c`) for traced memory access and chip cost tracking.
+//! `rvr_ext_wrappers.c`) for traced memory access.
 //! Register access stays in generated C; resolved values are passed to extension FFI entry points.
 //!
 //! The `state` parameter is always an opaque `*mut c_void` pointing
@@ -46,9 +46,6 @@ extern "C" {
         vals: *const u64,
         num_words: u32,
     );
-
-    // ── Chip cost ─────────────────────────────────────────────────────
-    pub fn trace_chip_wrapper(state: *mut c_void, chip_idx: u32, count: u32);
 
     // ── Hint stream (for extension phantom instructions) ──────────────
     /// Replace the hint stream contents. Forwarded through `openvm_io.c`

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -62,6 +62,14 @@ pub trait ExtEmitCtx {
         args: &[&str],
     ) -> Option<String>;
 
+    /// Emit a stateful call returning `bool` and trap when it reports failure.
+    fn emit_checked_call(&mut self, name: &str, args: &[&str]) {
+        let result = self.emit_call_expr("bool", name, args);
+        self.write_line(&format!("if (unlikely(!{result})) {{"));
+        self.emit_trap();
+        self.write_line("}");
+    }
+
     /// Emit a no-flush call returning `bool` and trap when it reports failure.
     fn emit_checked_call_without_page_flush(&mut self, name: &str, args: &[&str]) {
         self.write_line(&format!("if (unlikely(!{name}({}))) {{", args.join(", ")));

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -1,8 +1,7 @@
-/// A fixed trace-height contribution made by an extension instruction.
+/// Extra trace rows added by one extension instruction.
 ///
-/// The instruction's primary chip row is accounted for separately through its
-/// PC-to-chip mapping. This describes only additional rows whose count is known
-/// while generating the native artifact.
+/// The PC-to-chip mapping already counts the instruction's main row. This
+/// records any other rows whose count is known when the C code is generated.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FixedTraceRows {
     /// AIR index whose trace height increases.
@@ -13,28 +12,26 @@ pub struct FixedTraceRows {
 
 /// Trait abstracting the code-generation context for extension instructions.
 ///
-/// Extensions use this to read/write registers (with tracing handled in the
-/// generated C code) and emit C lines, instead of writing raw C into a buffer.
+/// Extensions use this context to read or write registers and emit C. The
+/// emission mode decides whether register accesses are traced.
 /// Register access stays on the C side so the FFI boundary only carries
 /// resolved values and memory.
 pub trait ExtEmitCtx {
-    /// Read a register with tracing. Returns a C expression for the value.
+    /// Read a register as an AIR-visible memory access.
     fn read_reg(&mut self, idx: u8) -> String;
 
-    /// Read a register without tracing (for phantom instructions).
-    fn read_reg_raw(&mut self, idx: u8) -> String;
+    /// Read a register whose value affects execution but is not an AIR memory
+    /// access. Value tracing records the value without advancing the memory
+    /// timestamp.
+    fn read_reg_execution_input(&mut self, idx: u8) -> String;
 
-    /// Write a register with tracing.
+    /// Write a register, tracing it when required by the emission mode.
     fn write_reg(&mut self, idx: u8, val: &str);
-
-    /// Write a register without tracing (for phantom instructions).
-    fn write_reg_raw(&mut self, idx: u8, val: &str);
 
     /// Append a line of C code (indented).
     fn write_line(&mut self, s: &str);
 
-    /// End the current block through the RVR trap path while preserving
-    /// execution-mode state.
+    /// Save execution-mode state and end the block through the shared RVR trap.
     fn emit_trap(&mut self);
 
     /// Read guest memory and return a C expression for the loaded value.
@@ -43,16 +40,17 @@ pub trait ExtEmitCtx {
     /// Write guest memory.
     fn write_mem(&mut self, base: &str, offset: i16, val: &str, width: u8);
 
-    /// Emit an opaque C call, flushing page-local metering state around it.
+    /// Flush local page state, emit a C call, then reload the page state.
     fn emit_call(&mut self, name: &str, args: &[&str]);
 
-    /// Emit a C call that cannot access RVR state and needs no page-local flush.
+    /// Emit a C call that cannot access RVR state, without flushing page state.
     fn emit_call_without_page_flush(&mut self, name: &str, args: &[&str]);
 
-    /// Emit an opaque C call that returns a value, flushing page-local metering state around it.
+    /// Flush local page state, emit a C call that returns a value, then reload
+    /// the page state.
     fn emit_call_expr(&mut self, ret_ty: &str, name: &str, args: &[&str]) -> String;
 
-    /// Emit a call and materialize its result only when chip tracing is active.
+    /// Emit a call and save its result only when chip tracing needs it.
     ///
     /// Pure execution emits the call as a statement and returns `None`.
     fn emit_call_with_trace_result(
@@ -62,7 +60,7 @@ pub trait ExtEmitCtx {
         args: &[&str],
     ) -> Option<String>;
 
-    /// Emit a stateful call returning `bool` and trap when it reports failure.
+    /// Emit a call that can access RVR state and trap if it returns `false`.
     fn emit_checked_call(&mut self, name: &str, args: &[&str]) {
         let result = self.emit_call_expr("bool", name, args);
         self.write_line(&format!("if (unlikely(!{result})) {{"));
@@ -70,7 +68,7 @@ pub trait ExtEmitCtx {
         self.write_line("}");
     }
 
-    /// Emit a no-flush call returning `bool` and trap when it reports failure.
+    /// Emit a call without flushing page state and trap if it returns `false`.
     fn emit_checked_call_without_page_flush(&mut self, name: &str, args: &[&str]) {
         self.write_line(&format!("if (unlikely(!{name}({}))) {{", args.join(", ")));
         self.emit_trap();
@@ -83,11 +81,15 @@ pub trait ExtEmitCtx {
     /// Emit a chip-height update only when `count_expr` is nonzero.
     fn trace_chip_if_nonzero(&mut self, chip_idx: u32, count_expr: &str);
 
-    /// Emit a single memory-page trace.
-    fn trace_mem_access(&mut self, addr: &str, addr_space: u32);
+    /// Record the pages containing one fixed-width access for metering.
+    ///
+    /// This records the address, not the accessed value.
+    fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32);
 
-    /// Emit a dword-range memory-page trace (rv64: each unit is 8 bytes).
-    fn trace_mem_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32);
+    /// Record pages touched by a dword range for metering (one dword is 8 bytes).
+    ///
+    /// This records the address range, not the accessed values.
+    fn trace_page_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32);
 }
 
 /// Trait for extension IR nodes. Implemented by each extension's instruction types.
@@ -126,10 +128,10 @@ pub trait ExtInstr: std::fmt::Debug + Send + Sync {
         true
     }
 
-    /// Additional chip rows with a count fixed at artifact-generation time.
+    /// Extra chip rows whose count is known when the artifact is generated.
     ///
-    /// These are folded into the block's batched metering update instead of
-    /// being recorded on the extension's runtime path.
+    /// The generator adds them to the block's metering update, so the extension
+    /// does not record them at runtime.
     fn fixed_trace_rows(&self) -> Vec<FixedTraceRows> {
         Vec::new()
     }

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -1,3 +1,16 @@
+/// A fixed trace-height contribution made by an extension instruction.
+///
+/// The instruction's primary chip row is accounted for separately through its
+/// PC-to-chip mapping. This describes only additional rows whose count is known
+/// while generating the native artifact.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FixedTraceRows {
+    /// AIR index whose trace height increases.
+    pub chip_idx: u32,
+    /// Number of additional rows contributed by one instruction.
+    pub count: u32,
+}
+
 /// Trait abstracting the code-generation context for extension instructions.
 ///
 /// Extensions use this to read/write registers (with tracing handled in the
@@ -39,6 +52,16 @@ pub trait ExtEmitCtx {
     /// Emit an opaque C call that returns a value, flushing page-local metering state around it.
     fn emit_call_expr(&mut self, ret_ty: &str, name: &str, args: &[&str]) -> String;
 
+    /// Emit a call and materialize its result only when chip tracing is active.
+    ///
+    /// Pure execution emits the call as a statement and returns `None`.
+    fn emit_call_with_trace_result(
+        &mut self,
+        ret_ty: &str,
+        name: &str,
+        args: &[&str],
+    ) -> Option<String>;
+
     /// Emit a no-flush call returning `bool` and trap when it reports failure.
     fn emit_checked_call_without_page_flush(&mut self, name: &str, args: &[&str]) {
         self.write_line(&format!("if (unlikely(!{name}({}))) {{", args.join(", ")));
@@ -48,6 +71,9 @@ pub trait ExtEmitCtx {
 
     /// Emit a chip-height update.
     fn trace_chip(&mut self, chip_idx: u32, count_expr: &str);
+
+    /// Emit a chip-height update only when `count_expr` is nonzero.
+    fn trace_chip_if_nonzero(&mut self, chip_idx: u32, count_expr: &str);
 
     /// Emit a single memory-page trace.
     fn trace_mem_access(&mut self, addr: &str, addr_space: u32);
@@ -90,6 +116,14 @@ pub trait ExtInstr: std::fmt::Debug + Send + Sync {
     /// extension FFIs read or write main memory through `state`.
     fn accesses_memory(&self) -> bool {
         true
+    }
+
+    /// Additional chip rows with a count fixed at artifact-generation time.
+    ///
+    /// These are folded into the block's batched metering update instead of
+    /// being recorded on the extension's runtime path.
+    fn fixed_trace_rows(&self) -> Vec<FixedTraceRows> {
+        Vec::new()
     }
 
     /// Clone into a new boxed trait object.

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -1,3 +1,5 @@
+use crate::MemWidth;
+
 /// Extra trace rows added by one extension instruction.
 ///
 /// The PC-to-chip mapping already counts the instruction's main row. This
@@ -20,10 +22,9 @@ pub trait ExtEmitCtx {
     /// Read a register as an AIR-visible memory access.
     fn read_reg(&mut self, idx: u8) -> String;
 
-    /// Read a register whose value affects execution but is not an AIR memory
-    /// access. Value tracing records the value without advancing the memory
-    /// timestamp.
-    fn read_reg_execution_input(&mut self, idx: u8) -> String;
+    /// Get a register value without creating an AIR memory access. Value
+    /// tracing records the value without advancing the memory timestamp.
+    fn peek_reg(&mut self, idx: u8) -> String;
 
     /// Write a register, tracing it when required by the emission mode.
     fn write_reg(&mut self, idx: u8, val: &str);
@@ -84,7 +85,7 @@ pub trait ExtEmitCtx {
     /// Record the pages containing one fixed-width access for metering.
     ///
     /// This records the address, not the accessed value.
-    fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32);
+    fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: u32);
 
     /// Record pages touched by a dword range for metering (one dword is 8 bytes).
     ///

--- a/crates/rvr/rvr-openvm-lift/src/cfg.rs
+++ b/crates/rvr/rvr-openvm-lift/src/cfg.rs
@@ -709,8 +709,8 @@ fn worklist(
     let mut unresolved_dynamic_jumps: HashSet<u64> = HashSet::new();
     let mut resolved_jumps: HashMap<u64, HashSet<u64>> = HashMap::new();
 
-    // Internal targets receive state from their real predecessors. An unknown seed would discard
-    // constants used to resolve dynamic jumps.
+    // Do not seed internal targets with unknown register values. Their actual
+    // predecessors may provide constants needed to resolve dynamic jumps.
     for addr in function_entries {
         if in_work.insert(*addr) {
             states.insert(*addr, RegisterState::new());

--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use openvm_instructions::{LocalOpcode, VmOpcode};
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_ir::LiftedInstr;
+use rvr_openvm_ir::{FixedTraceRows, LiftedInstr};
 
 use crate::RvrInstruction;
 
@@ -48,6 +48,18 @@ pub enum TraceChipIndex {
 #[inline]
 pub fn air_index_to_c(idx: Option<AirIndex>) -> u32 {
     idx.map_or(u32::MAX, AirIndex::as_u32)
+}
+
+/// Build fixed-row metadata when AIR indices are available for metering.
+#[inline]
+pub fn fixed_trace_rows_for_chip(idx: Option<AirIndex>, count: u32) -> Vec<FixedTraceRows> {
+    idx.map(|idx| {
+        vec![FixedTraceRows {
+            chip_idx: idx.as_u32(),
+            count,
+        }]
+    })
+    .unwrap_or_default()
 }
 
 /// Data needed by extension crates to resolve opcode/chip metadata when

--- a/crates/rvr/rvr-openvm-lift/src/extension.rs
+++ b/crates/rvr/rvr-openvm-lift/src/extension.rs
@@ -50,7 +50,7 @@ pub fn air_index_to_c(idx: Option<AirIndex>) -> u32 {
     idx.map_or(u32::MAX, AirIndex::as_u32)
 }
 
-/// Build fixed-row metadata when AIR indices are available for metering.
+/// Return extra fixed rows when this extension has an AIR index.
 #[inline]
 pub fn fixed_trace_rows_for_chip(idx: Option<AirIndex>, count: u32) -> Vec<FixedTraceRows> {
     idx.map(|idx| {
@@ -161,11 +161,16 @@ pub trait RvrExtension: Send + Sync {
         Vec::new()
     }
 
-    /// Vendored C source files compiled as separate translation units.
+    /// Whether this extension's static library calls the shared memory wrappers.
+    fn uses_memory_wrappers(&self) -> bool {
+        false
+    }
+
+    /// Third-party C source files compiled separately.
     ///
-    /// These are built without OpenVM's warning policy. Headers or C files
-    /// included by an OpenVM-owned translation unit should instead be supplied
-    /// through [`Self::extra_c_include_files`] and an `-isystem` include path.
+    /// OpenVM warning flags do not apply to these files. If OpenVM-owned C
+    /// includes a third-party file, provide it through
+    /// [`Self::extra_c_include_files`] and use an `-isystem` include path.
     fn vendored_c_sources(&self) -> Vec<(&'static str, &'static str)> {
         vec![]
     }
@@ -177,9 +182,8 @@ pub trait RvrExtension: Send + Sync {
         vec![]
     }
 
-    /// Additional CFLAGS for compiling owned and vendored extension C sources
-    /// (e.g., `-I` paths for submodule headers). Passed to the Makefile as
-    /// EXT_CFLAGS.
+    /// Extra compiler flags for extension C, such as include paths for
+    /// submodule headers. The Makefile receives them as `EXT_CFLAGS`.
     fn extra_cflags(&self) -> Vec<String> {
         vec![]
     }
@@ -265,7 +269,12 @@ impl ExtensionRegistry {
             .collect()
     }
 
-    /// Collect vendored C source files from all extensions.
+    /// Whether any registered extension needs the shared memory wrappers.
+    pub fn uses_memory_wrappers(&self) -> bool {
+        self.extensions.iter().any(|ext| ext.uses_memory_wrappers())
+    }
+
+    /// Collect third-party C source files from all extensions.
     pub fn vendored_c_sources(&self) -> Vec<(&'static str, &'static str)> {
         self.extensions
             .iter()
@@ -287,11 +296,6 @@ impl ExtensionRegistry {
             .iter()
             .flat_map(|ext| ext.extra_cflags())
             .collect()
-    }
-
-    /// Whether any extensions are registered.
-    pub fn is_empty(&self) -> bool {
-        self.extensions.is_empty()
     }
 }
 

--- a/crates/rvr/rvr-openvm-lift/src/lib.rs
+++ b/crates/rvr/rvr-openvm-lift/src/lib.rs
@@ -22,8 +22,9 @@ pub use convert::{
     ConvertError,
 };
 pub use extension::{
-    air_index_to_c, opcode_air_idx, AirIndex, ExtensionError, ExtensionRegistry, RvrExtension,
-    RvrExtensionCtx, RvrExtensions, RvrRuntimeExtension, TraceChipIndex, VmRvrExtension,
+    air_index_to_c, fixed_trace_rows_for_chip, opcode_air_idx, AirIndex, ExtensionError,
+    ExtensionRegistry, RvrExtension, RvrExtensionCtx, RvrExtensions, RvrRuntimeExtension,
+    TraceChipIndex, VmRvrExtension,
 };
 pub use helpers::{decode_imm_cg, decode_reg};
 pub use instruction::RvrInstruction;

--- a/crates/rvr/rvr-openvm/c/Makefile
+++ b/crates/rvr/rvr-openvm/c/Makefile
@@ -9,13 +9,12 @@ WARNINGS += -Wno-c++-compat -Wno-c++98-compat \
 	-Wno-pre-c11-compat -Wno-pre-c23-compat -Wno-pre-c2y-compat \
 	-Wno-declaration-after-statement
 
-# Vendored translation units are outside OpenVM's warning policy. Compiler
-# errors remain fatal, but diagnostics from third-party C are suppressed.
+# Do not apply OpenVM warning flags to third-party C. Compiler errors still
+# fail the build.
 VENDOR_WARNINGS = -Wno-everything
-# The core runtime implements VM memory using raw buffers behind explicit
-# bounds and invariant contracts. Clang's diagnostic is a migration heuristic
-# for moving raw pointers to checked container APIs, which is not applicable
-# to these low-level translation units.
+# The core runtime uses raw buffers with explicit bounds checks. Clang raises
+# this warning when raw pointers could be replaced with checked containers, so
+# it is not useful for these low-level files.
 CORE_WARNINGS = -Wno-unsafe-buffer-usage
 CFLAGS = -std=c2y $(OPT) $(DEBUG) $(WARNINGS) -fPIC -march=native -falign-functions=32
 LTO ?=
@@ -24,8 +23,8 @@ LDFLAGS ?=
 LDFLAGS += -fuse-ld=$(LINKER)
 LDLIBS ?=
 
-# On ELF platforms, force eager symbol binding to prevent the PLT lazy
-# resolver from clobbering preserve_none argument registers (r11 on x86_64).
+# On ELF platforms, bind symbols when the library loads. Lazy PLT binding can
+# overwrite `preserve_none` argument registers such as r11 on x86_64.
 HOST_OS ?= $(shell uname -s)
 ifeq ($(HOST_OS),Linux)
 LDFLAGS += -Wl,-z,now

--- a/crates/rvr/rvr-openvm/c/block/openvm_block_metered.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_metered.h
@@ -7,7 +7,7 @@
 
 #include "openvm_state.h"
 
-[[maybe_unused]] static __attribute__((preserve_most, cold, noinline)) uint32_t
+static __attribute__((preserve_most, cold, noinline)) uint32_t
 metered_checkpoint(RvState* restrict state, uint32_t check_counter) {
   MeteringState* metering = &state->mode_state;
   metering->check_counter = check_counter;

--- a/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
@@ -10,10 +10,12 @@
 typedef struct MeteredSegmentCheckpointResult {
   uint32_t check_counter;
   uint8_t suspend_signal;
+  /* Keep the returned aggregate fully initialized. */
+  uint8_t reserved[3];
 } MeteredSegmentCheckpointResult;
 
-[[maybe_unused]] static __attribute__((preserve_most, cold,
-                                       noinline)) MeteredSegmentCheckpointResult
+static __attribute__((preserve_most, cold,
+                     noinline)) MeteredSegmentCheckpointResult
 metered_segment_checkpoint(RvState* restrict state, uint32_t check_counter) {
   MeteringState* metering = &state->mode_state;
   metering->check_counter = check_counter;
@@ -21,6 +23,7 @@ metered_segment_checkpoint(RvState* restrict state, uint32_t check_counter) {
   return (MeteredSegmentCheckpointResult){
       .check_counter = metering->check_counter,
       .suspend_signal = suspend_signal,
+      .reserved = {0},
   };
 }
 

--- a/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
+++ b/crates/rvr/rvr-openvm/c/block/openvm_block_metered_segment.h
@@ -9,9 +9,7 @@
 
 typedef struct MeteredSegmentCheckpointResult {
   uint32_t check_counter;
-  uint8_t suspend_signal;
-  /* Keep the returned aggregate fully initialized. */
-  uint8_t reserved[3];
+  uint32_t suspend_signal;
 } MeteredSegmentCheckpointResult;
 
 static __attribute__((preserve_most, cold,
@@ -19,11 +17,10 @@ static __attribute__((preserve_most, cold,
 metered_segment_checkpoint(RvState* restrict state, uint32_t check_counter) {
   MeteringState* metering = &state->mode_state;
   metering->check_counter = check_counter;
-  uint8_t suspend_signal = metering->on_check(metering);
+  uint32_t suspend_signal = metering->on_check(metering);
   return (MeteredSegmentCheckpointResult){
       .check_counter = metering->check_counter,
       .suspend_signal = suspend_signal,
-      .reserved = {0},
   };
 }
 

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -59,6 +59,7 @@ static __attribute__((always_inline)) inline bool rv_pc_is_dispatchable(
 
 /* Guard regions immediately before and after guest memory catch accesses
  * that cross either boundary.
+ * TODO: Mask addr with MEMORY_MASK as an extra safety measure.
  * Clang cannot prove the bounds used by these low-level memory and fixed-size
  * register-array helpers. */
 #pragma clang unsafe_buffer_usage begin

--- a/crates/rvr/rvr-openvm/c/openvm_state.h
+++ b/crates/rvr/rvr-openvm/c/openvm_state.h
@@ -59,9 +59,8 @@ static __attribute__((always_inline)) inline bool rv_pc_is_dispatchable(
 
 /* Guard regions immediately before and after guest memory catch accesses
  * that cross either boundary.
- * TODO: addr &= MEMORY_MASK for defense-in-depth.
- * Clang's C unsafe-buffer heuristic cannot model the bounds assumptions used
- * by these low-level memory and fixed-register-array helpers. */
+ * Clang cannot prove the bounds used by these low-level memory and fixed-size
+ * register-array helpers. */
 #pragma clang unsafe_buffer_usage begin
 static __attribute__((always_inline)) inline uint8_t* mem_ptr(
     uint8_t* restrict memory, uint64_t addr) {
@@ -84,19 +83,19 @@ static __attribute__((always_inline)) inline void reg_write(
 
 /* ── Per-width memory reads ──────────────────────────────────────── */
 
-static __attribute__((always_inline)) inline uint8_t rd_mem_u8(
+static __attribute__((always_inline)) inline uint8_t read_mem_u8(
     uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u8(addr);
   return *mem_ptr(memory, addr);
 }
 
-static __attribute__((always_inline)) inline int8_t rd_mem_i8(
+static __attribute__((always_inline)) inline int8_t read_mem_i8(
     uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_i8(addr);
   return (int8_t)*mem_ptr(memory, addr);
 }
 
-static __attribute__((always_inline)) inline uint16_t rd_mem_u16(
+static __attribute__((always_inline)) inline uint16_t read_mem_u16(
     uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u16(addr);
   uint16_t v;
@@ -104,7 +103,7 @@ static __attribute__((always_inline)) inline uint16_t rd_mem_u16(
   return v;
 }
 
-static __attribute__((always_inline)) inline int16_t rd_mem_i16(
+static __attribute__((always_inline)) inline int16_t read_mem_i16(
     uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_i16(addr);
   int16_t v;
@@ -112,7 +111,7 @@ static __attribute__((always_inline)) inline int16_t rd_mem_i16(
   return v;
 }
 
-static __attribute__((always_inline)) inline int32_t rd_mem_i32(
+static __attribute__((always_inline)) inline int32_t read_mem_i32(
     uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u32(addr);
   int32_t v;
@@ -120,7 +119,7 @@ static __attribute__((always_inline)) inline int32_t rd_mem_i32(
   return v;
 }
 
-static __attribute__((always_inline)) inline uint32_t rd_mem_u32(
+static __attribute__((always_inline)) inline uint32_t read_mem_u32(
     uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u32(addr);
   uint32_t v;
@@ -128,7 +127,7 @@ static __attribute__((always_inline)) inline uint32_t rd_mem_u32(
   return v;
 }
 
-static __attribute__((always_inline)) inline uint64_t rd_mem_u64(
+static __attribute__((always_inline)) inline uint64_t read_mem_u64(
     uint8_t* restrict memory, uint64_t addr) {
   check_mem_bounds_u64(addr);
   uint64_t v;
@@ -138,25 +137,25 @@ static __attribute__((always_inline)) inline uint64_t rd_mem_u64(
 
 /* ── Per-width memory writes ─────────────────────────────────────── */
 
-static __attribute__((always_inline)) inline void wr_mem_u8(
+static __attribute__((always_inline)) inline void write_mem_u8(
     uint8_t* restrict memory, uint64_t addr, uint8_t val) {
   check_mem_bounds_u8(addr);
   *mem_ptr(memory, addr) = val;
 }
 
-static __attribute__((always_inline)) inline void wr_mem_u16(
+static __attribute__((always_inline)) inline void write_mem_u16(
     uint8_t* restrict memory, uint64_t addr, uint16_t val) {
   check_mem_bounds_u16(addr);
   memcpy(mem_ptr(memory, addr), &val, sizeof(val));
 }
 
-static __attribute__((always_inline)) inline void wr_mem_u32(
+static __attribute__((always_inline)) inline void write_mem_u32(
     uint8_t* restrict memory, uint64_t addr, uint32_t val) {
   check_mem_bounds_u32(addr);
   memcpy(mem_ptr(memory, addr), &val, sizeof(val));
 }
 
-static __attribute__((always_inline)) inline void wr_mem_u64(
+static __attribute__((always_inline)) inline void write_mem_u64(
     uint8_t* restrict memory, uint64_t addr, uint64_t val) {
   check_mem_bounds_u64(addr);
   memcpy(mem_ptr(memory, addr), &val, sizeof(val));
@@ -164,144 +163,25 @@ static __attribute__((always_inline)) inline void wr_mem_u64(
 
 /* ── Word-aligned range memory access ────────────────────────────── */
 
-/* `base_addr` is word-aligned; the guest pointer is word-aligned too,
- * so these lower to a single memcpy. */
-static __attribute__((always_inline)) inline void rd_mem_u64_range(
+/* Data-only range helpers used to implement the execution-mode interfaces.
+ * `base_addr` and the guest pointer are word-aligned, so these lower to one
+ * memcpy. */
+static __attribute__((always_inline)) inline void read_mem_u64_range_raw(
     RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
     uint32_t num_words) {
   check_mem_bounds_u64_range(base_addr, num_words);
-  const void* p =
-      __builtin_assume_aligned(mem_ptr(state->memory, base_addr), sizeof(uint64_t));
+  const void* p = __builtin_assume_aligned(mem_ptr(state->memory, base_addr),
+                                           sizeof(uint64_t));
   memcpy(out, p, (size_t)num_words * sizeof(uint64_t));
 }
 
-static __attribute__((always_inline)) inline void wr_mem_u64_range(
+static __attribute__((always_inline)) inline void write_mem_u64_range_raw(
     RvState* restrict state, uint64_t base_addr, const uint64_t* restrict vals,
     uint32_t num_words) {
   check_mem_bounds_u64_range(base_addr, num_words);
-  void* p =
-      __builtin_assume_aligned(mem_ptr(state->memory, base_addr), sizeof(uint64_t));
+  void* p = __builtin_assume_aligned(mem_ptr(state->memory, base_addr),
+                                     sizeof(uint64_t));
   memcpy(p, vals, (size_t)num_words * sizeof(uint64_t));
-}
-
-/* ── Traced memory helpers ───────────────────────────────────────── */
-
-static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state, uint64_t addr, uint8_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state, uint64_t addr, int8_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state, uint64_t addr, uint16_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state, uint64_t addr, int16_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state, uint64_t addr, uint32_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state, uint64_t addr, int32_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state, uint64_t addr, uint64_t val);
-static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state, uint64_t addr, uint8_t val);
-static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state, uint64_t addr, uint16_t val);
-static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state, uint64_t addr, uint32_t val);
-static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state, uint64_t addr, uint64_t val);
-static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
-    uint32_t num_words);
-static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state, uint64_t base_addr, const uint64_t* vals,
-    uint32_t num_words);
-
-/* Per-width traced reads return a 32-bit C type; callers widen to uint64_t at
- * register assignment via C implicit promotion. */
-static __attribute__((always_inline)) inline uint32_t rd_mem_u8_traced(
-    RvState* restrict state, uint64_t addr) {
-  uint8_t v = rd_mem_u8(state->memory, addr);
-  trace_rd_mem_u8(state, addr, v);
-  return v;
-}
-
-static __attribute__((always_inline)) inline int32_t rd_mem_i8_traced(
-    RvState* restrict state, uint64_t addr) {
-  int8_t v = rd_mem_i8(state->memory, addr);
-  trace_rd_mem_i8(state, addr, v);
-  return v;
-}
-
-static __attribute__((always_inline)) inline uint32_t rd_mem_u16_traced(
-    RvState* restrict state, uint64_t addr) {
-  uint16_t v = rd_mem_u16(state->memory, addr);
-  trace_rd_mem_u16(state, addr, v);
-  return v;
-}
-
-static __attribute__((always_inline)) inline int32_t rd_mem_i16_traced(
-    RvState* restrict state, uint64_t addr) {
-  int16_t v = rd_mem_i16(state->memory, addr);
-  trace_rd_mem_i16(state, addr, v);
-  return v;
-}
-
-static __attribute__((always_inline)) inline int32_t rd_mem_i32_traced(
-    RvState* restrict state, uint64_t addr) {
-  int32_t v = rd_mem_i32(state->memory, addr);
-  trace_rd_mem_i32(state, addr, v);
-  return v;
-}
-
-static __attribute__((always_inline)) inline uint32_t rd_mem_u32_traced(
-    RvState* restrict state, uint64_t addr) {
-  uint32_t v = rd_mem_u32(state->memory, addr);
-  trace_rd_mem_u32(state, addr, v);
-  return v;
-}
-
-static __attribute__((always_inline)) inline uint64_t rd_mem_u64_traced(
-    RvState* restrict state, uint64_t addr) {
-  uint64_t v = rd_mem_u64(state->memory, addr);
-  trace_rd_mem_u64(state, addr, v);
-  return v;
-}
-
-static __attribute__((always_inline)) inline void wr_mem_u8_traced(
-    RvState* restrict state, uint64_t addr, uint8_t val) {
-  trace_wr_mem_u8(state, addr, val);
-  wr_mem_u8(state->memory, addr, val);
-}
-
-static __attribute__((always_inline)) inline void wr_mem_u16_traced(
-    RvState* restrict state, uint64_t addr, uint16_t val) {
-  trace_wr_mem_u16(state, addr, val);
-  wr_mem_u16(state->memory, addr, val);
-}
-
-static __attribute__((always_inline)) inline void wr_mem_u32_traced(
-    RvState* restrict state, uint64_t addr, uint32_t val) {
-  trace_wr_mem_u32(state, addr, val);
-  wr_mem_u32(state->memory, addr, val);
-}
-
-static __attribute__((always_inline)) inline void wr_mem_u64_traced(
-    RvState* restrict state, uint64_t addr, uint64_t val) {
-  trace_wr_mem_u64(state, addr, val);
-  wr_mem_u64(state->memory, addr, val);
-}
-
-static __attribute__((always_inline)) inline void rd_mem_u64_range_traced(
-    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
-    uint32_t num_words) {
-  rd_mem_u64_range(state, base_addr, out, num_words);
-  trace_rd_mem_u64_range(state, base_addr, out, num_words);
-}
-
-static __attribute__((always_inline)) inline void wr_mem_u64_range_traced(
-    RvState* restrict state, uint64_t base_addr, const uint64_t* restrict vals,
-    uint32_t num_words) {
-  trace_wr_mem_u64_range(state, base_addr, vals, num_words);
-  wr_mem_u64_range(state, base_addr, vals, num_words);
 }
 
 #endif /* OPENVM_STATE_H */

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -16,15 +16,13 @@
 
 /* ── Extension memory boundary ─────────────────────────────────────── */
 
-uint64_t read_mem_u64_execution_input_wrapper(RvState* state, uint64_t addr) {
-  return read_mem_u64_execution_input(state, addr);
+uint64_t peek_mem_u64_wrapper(RvState* state, uint64_t addr) {
+  return peek_mem_u64(state, addr);
 }
 
-void read_mem_u64_range_execution_input_wrapper(RvState* state,
-                                                uint64_t base_addr,
-                                                uint64_t* out,
-                                                uint32_t num_words) {
-  read_mem_u64_range_execution_input(state, base_addr, out, num_words);
+void peek_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                uint64_t* out, uint32_t num_words) {
+  peek_mem_u64_range(state, base_addr, out, num_words);
 }
 
 void read_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -1,10 +1,10 @@
 /*
- * rvr_ext_wrappers.c — Non-inline wrappers around static inline tracing
+ * rvr_ext_wrappers.c — Non-inline wrappers around static inline memory
  * functions.
  *
- * Extension FFI code (implemented in Rust as staticlibs) calls these wrappers
- * for traced memory access and chip cost. The wrappers delegate to the static
- * inline functions defined in the tracer headers.
+ * Extension FFI code (implemented in Rust as staticlibs) calls these functions
+ * for memory access. They delegate to the static inline functions selected by
+ * the execution mode.
  * Register access stays in generated C; extensions receive resolved register
  * values as function parameters.
  *
@@ -14,34 +14,31 @@
 #include "openvm.h"
 #include "rvr_ext_wrappers.h"
 
-/* ── Memory access (single word) ───────────────────────────────────── */
+/* ── Extension memory boundary ─────────────────────────────────────── */
 
-uint64_t rd_mem_u64_wrapper(RvState* s, uint64_t addr) {
-  return rd_mem_u64(s->memory, addr);
+uint64_t read_mem_u64_execution_input_wrapper(RvState* state, uint64_t addr) {
+  return read_mem_u64_execution_input(state, addr);
 }
 
-void rd_mem_u64_range_wrapper(RvState* s, uint64_t base_addr, uint64_t* out,
-                              uint32_t num_words) {
-  rd_mem_u64_range(s, base_addr, out, num_words);
+void read_mem_u64_range_execution_input_wrapper(RvState* state,
+                                                uint64_t base_addr,
+                                                uint64_t* out,
+                                                uint32_t num_words) {
+  read_mem_u64_range_execution_input(state, base_addr, out, num_words);
 }
 
-void wr_mem_u64_range_wrapper(RvState* s, uint64_t base_addr,
-                              const uint64_t* vals, uint32_t num_words) {
-  wr_mem_u64_range(s, base_addr, vals, num_words);
+void read_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                uint64_t* out, uint32_t num_words) {
+  read_mem_u64_range(state, base_addr, out, num_words);
 }
 
-void trace_rd_mem_u64_range_wrapper(RvState* s, uint64_t base_addr,
-                                    const uint64_t* vals, uint32_t num_words) {
-  trace_rd_mem_u64_range(s, base_addr, vals, num_words);
+void write_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                 const uint64_t* vals, uint32_t num_words) {
+  write_mem_u64_range(state, base_addr, vals, num_words);
 }
 
-void trace_wr_mem_u64_range_wrapper(RvState* s, uint64_t base_addr,
-                                    const uint64_t* vals, uint32_t num_words) {
-  trace_wr_mem_u64_range(s, base_addr, vals, num_words);
-}
-
-void trace_mem_access_u64_range_wrapper(RvState* s, uint64_t base_addr,
-                                        uint32_t num_words,
-                                        uint32_t addr_space) {
-  trace_mem_access_u64_range(s, base_addr, num_words, addr_space);
+void record_page_access_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                          uint32_t num_words,
+                                          uint32_t addr_space) {
+  trace_page_access_u64_range(state, base_addr, num_words, addr_space);
 }

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -45,26 +45,3 @@ void trace_mem_access_u64_range_wrapper(RvState* s, uint64_t base_addr,
                                         uint32_t addr_space) {
   trace_mem_access_u64_range(s, base_addr, num_words, addr_space);
 }
-
-/* ── Chip cost ─────────────────────────────────────────────────────── */
-
-/* Extension FFI staticlibs use this to add chip rows on top of what the
- * per-block chip accounting in the generated `block_*` functions has already
- * counted.
- *
- * The block-entry update assigns +1 per instruction to that instruction's PC
- * chip (from `pc_to_chip`). So when an extension call needs to add MORE rows
- * to *its own* PC chip, it should pass `count - 1` (e.g. deferral OUTPUT).
- * When it needs to add rows to a DIFFERENT chip — which is the common case
- * for inner sub-chips like Sha2BlockHasher or the Poseidon2 chip used by
- * deferral CALL/OUTPUT — it should pass the full count for that other chip,
- * since the block-entry update never touched it.
- *
- * Extensions whose entry points are compiled directly into the generated
- * native project (e.g. `crates/extensions/keccak/c/rvr_ext_keccak.c`) call
- * the inline `trace_chip` directly; only out-of-line staticlib FFIs need
- * this wrapper. See callers in
- * `crates/extensions/{sha2,deferral}/ffi/src/lib.rs`. */
-void trace_chip_wrapper(RvState* s, uint32_t chip_idx, uint32_t count) {
-  trace_chip(s, chip_idx, count);
-}

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
@@ -5,16 +5,16 @@
 
 #include "openvm_state.h"
 
-uint64_t rd_mem_u64_wrapper(RvState* state, uint64_t addr);
-void rd_mem_u64_range_wrapper(RvState* state, uint64_t base_addr, uint64_t* out,
-                              uint32_t num_words);
-void wr_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
-                              const uint64_t* vals, uint32_t num_words);
-void trace_rd_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
-                                    const uint64_t* vals, uint32_t num_words);
-void trace_wr_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
-                                    const uint64_t* vals, uint32_t num_words);
-void trace_mem_access_u64_range_wrapper(RvState* state, uint64_t base_addr,
-                                        uint32_t num_words,
-                                        uint32_t addr_space);
+uint64_t read_mem_u64_execution_input_wrapper(RvState* state, uint64_t addr);
+void read_mem_u64_range_execution_input_wrapper(RvState* state,
+                                                uint64_t base_addr,
+                                                uint64_t* out,
+                                                uint32_t num_words);
+void read_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                uint64_t* out, uint32_t num_words);
+void write_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                 const uint64_t* vals, uint32_t num_words);
+void record_page_access_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                          uint32_t num_words,
+                                          uint32_t addr_space);
 #endif /* RVR_EXT_WRAPPERS_H */

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
@@ -17,6 +17,4 @@ void trace_wr_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
 void trace_mem_access_u64_range_wrapper(RvState* state, uint64_t base_addr,
                                         uint32_t num_words,
                                         uint32_t addr_space);
-void trace_chip_wrapper(RvState* state, uint32_t chip_idx, uint32_t count);
-
 #endif /* RVR_EXT_WRAPPERS_H */

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
@@ -5,11 +5,9 @@
 
 #include "openvm_state.h"
 
-uint64_t read_mem_u64_execution_input_wrapper(RvState* state, uint64_t addr);
-void read_mem_u64_range_execution_input_wrapper(RvState* state,
-                                                uint64_t base_addr,
-                                                uint64_t* out,
-                                                uint32_t num_words);
+uint64_t peek_mem_u64_wrapper(RvState* state, uint64_t addr);
+void peek_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
+                                uint64_t* out, uint32_t num_words);
 void read_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
                                 uint64_t* out, uint32_t num_words);
 void write_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -350,15 +350,15 @@ static __attribute__((always_inline)) inline void write_mem_u64_range(
   write_mem_u64_range_raw(state, base_addr, vals, num_words);
 }
 
-/* Execution inputs do not create VM memory accesses. */
-static __attribute__((always_inline)) inline uint64_t
-read_mem_u64_execution_input(RvState* restrict state, uint64_t addr) {
+/* Peeking at a value does not create a VM memory access. */
+static __attribute__((always_inline)) inline uint64_t peek_mem_u64(
+    RvState* restrict state, uint64_t addr) {
   return read_mem_u64(state->memory, addr);
 }
 
-static __attribute__((always_inline)) inline void
-read_mem_u64_range_execution_input(RvState* restrict state, uint64_t base_addr,
-                                   uint64_t* restrict out, uint32_t num_words) {
+static __attribute__((always_inline)) inline void peek_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
   read_mem_u64_range_raw(state, base_addr, out, num_words);
 }
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -12,8 +12,8 @@
 
 #include "openvm_state.h"
 
-/* Page buffers are fixed-capacity arrays whose lengths are maintained and
- * checked by the metering state; Clang's C heuristic cannot model that. */
+/* The metering state checks the lengths of these fixed-capacity page buffers,
+ * but Clang cannot prove those bounds. */
 #pragma clang unsafe_buffer_usage begin
 
 static constexpr uint32_t NO_LAST_PAGE = UINT32_MAX;
@@ -22,17 +22,18 @@ static constexpr uint32_t TRACER_BYTES_PER_LEAF =
 static constexpr uint32_t TRACER_LEAF_BYTE_OFFSET_MASK =
     TRACER_BYTES_PER_LEAF - 1u;
 
-static constexpr uint32_t MAX_PV_PAGES_PER_INSN = 1;
 static_assert(
     TRACER_MEM_PAGE_BUF_CAP >=
         TRACER_SEGMENT_CHECK_INSNS * TRACER_MAX_MEM_PAGES_PER_INSN,
     "MEM_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 static_assert(
     TRACER_PV_PAGE_BUF_CAP >=
-        TRACER_SEGMENT_CHECK_INSNS * MAX_PV_PAGES_PER_INSN,
+        TRACER_SEGMENT_CHECK_INSNS * TRACER_MAX_PV_PAGES_PER_INSN,
     "PV_PAGE_BUF_CAP too small for worst-case pages per flush interval");
-/* No static assert for DEFERRAL — justifying the capacity is a TODO
- * (see DEFERRAL_PAGE_BUF_CAP in metered.rs). */
+static_assert(
+    TRACER_DEFERRAL_PAGE_BUF_CAP >=
+        TRACER_SEGMENT_CHECK_INSNS * TRACER_MAX_DEFERRAL_PAGES_PER_INSN,
+    "DEFERRAL_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 
 typedef struct PageTouch {
   /* Page table index plus a 64-bit leaf mask for that page. */
@@ -53,15 +54,15 @@ typedef struct TraceMemory {
 
 /* ── Page tracking ─────────────────────────────────────────────────── */
 
-/* Valid configured VM pointers fit in uint32_t. XLEN-wide operands must be
- * bounds-checked before reaching these narrowing helpers. */
+/* Valid VM pointers fit in uint32_t. Check full RV64 operands before calling
+ * these helpers. */
 static __attribute__((always_inline)) inline uint32_t byte_addr_to_local_leaf(
     uint64_t ptr) {
   return (uint32_t)(ptr >> TRACER_BYTE_SPACE_PTRS_PER_LEAF_BITS);
 }
 
-static __attribute__((always_inline)) inline uint32_t deferral_addr_to_local_leaf(
-    uint64_t ptr) {
+static __attribute__((always_inline)) inline uint32_t
+deferral_addr_to_local_leaf(uint64_t ptr) {
   return (uint32_t)(ptr >> TRACER_DEFERRAL_PTRS_PER_LEAF_BITS);
 }
 
@@ -73,8 +74,7 @@ static __attribute__((always_inline)) inline uint32_t addr_to_local_leaf(
   return deferral_addr_to_local_leaf(ptr);
 }
 
-static __attribute__((always_inline)) inline uint64_t leaf_mask(
-    uint32_t leaf) {
+static __attribute__((always_inline)) inline uint64_t leaf_mask(uint32_t leaf) {
   return 1ull << (leaf & ((1u << TRACER_PAGE_BITS) - 1u));
 }
 
@@ -82,8 +82,7 @@ static __attribute__((always_inline)) inline uint64_t leaf_mask_range(
     uint32_t first_leaf, uint32_t last_leaf) {
   /* Convert an inclusive leaf range within one page into an occupancy mask. */
   assume(first_leaf <= last_leaf);
-  assume((first_leaf >> TRACER_PAGE_BITS) ==
-         (last_leaf >> TRACER_PAGE_BITS));
+  assume((first_leaf >> TRACER_PAGE_BITS) == (last_leaf >> TRACER_PAGE_BITS));
   uint32_t start = first_leaf & ((1u << TRACER_PAGE_BITS) - 1u);
   uint32_t end = last_leaf & ((1u << TRACER_PAGE_BITS) - 1u);
   return (UINT64_MAX << start) &
@@ -108,7 +107,8 @@ static __attribute__((always_inline)) inline void append_page_touch_range(
   for (uint32_t page = first_page; page <= last_page; page++) {
     uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
     uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
-    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
+    uint32_t start =
+        first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
     uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
     append_page_touch(buf, len, page, leaf_mask_range(start, end));
   }
@@ -118,7 +118,8 @@ static __attribute__((always_inline)) inline void append_page_touch_range(
 static __attribute__((always_inline)) inline void record_mem_page(
     MeteringState* metering, uint32_t page, uint64_t leaf_mask) {
   if (likely(page == metering->last_mem_page)) {
-    metering->mem_page_buf[metering->mem_page_buf_len - 1u].leaf_mask |= leaf_mask;
+    metering->mem_page_buf[metering->mem_page_buf_len - 1u].leaf_mask |=
+        leaf_mask;
     return;
   }
   metering->last_mem_page = page;
@@ -132,9 +133,10 @@ static __attribute__((always_inline)) inline void record_mem_page_range(
   uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   if (likely(first_page == metering->last_mem_page)) {
     metering->mem_page_buf[metering->mem_page_buf_len - 1u].leaf_mask |=
-        leaf_mask_range(first_leaf, first_page == last_page
-                                        ? last_leaf
-                                        : ((first_page + 1u) << TRACER_PAGE_BITS) - 1u);
+        leaf_mask_range(first_leaf,
+                        first_page == last_page
+                            ? last_leaf
+                            : ((first_page + 1u) << TRACER_PAGE_BITS) - 1u);
     if (first_page == last_page) {
       return;
     }
@@ -144,9 +146,11 @@ static __attribute__((always_inline)) inline void record_mem_page_range(
   for (uint32_t page = first_page; page <= last_page; page++) {
     uint32_t page_first_leaf = page << TRACER_PAGE_BITS;
     uint32_t page_last_leaf = page_first_leaf + (1u << TRACER_PAGE_BITS) - 1u;
-    uint32_t start = first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
+    uint32_t start =
+        first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
     uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    append_page_touch(metering->mem_page_buf, &len, page, leaf_mask_range(start, end));
+    append_page_touch(metering->mem_page_buf, &len, page,
+                      leaf_mask_range(start, end));
   }
   metering->mem_page_buf_len = len;
   metering->last_mem_page = last_page;
@@ -155,7 +159,8 @@ static __attribute__((always_inline)) inline void record_mem_page_range(
 /* No bounds check — see PV_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_pv_page(
     MeteringState* metering, uint32_t page, uint64_t leaf_mask) {
-  append_page_touch(metering->pv_page_buf, &metering->pv_page_buf_len, page, leaf_mask);
+  append_page_touch(metering->pv_page_buf, &metering->pv_page_buf_len, page,
+                    leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_pv_page_range(
@@ -168,13 +173,15 @@ static __attribute__((always_inline)) inline void record_pv_page_range(
 /* No bounds check — see DEFERRAL_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_deferral_page(
     MeteringState* metering, uint32_t page, uint64_t leaf_mask) {
-  append_page_touch(metering->deferral_page_buf, &metering->deferral_page_buf_len, page, leaf_mask);
+  append_page_touch(metering->deferral_page_buf,
+                    &metering->deferral_page_buf_len, page, leaf_mask);
 }
 
 static __attribute__((always_inline)) inline void record_deferral_page_range(
     MeteringState* metering, uint32_t first_leaf, uint32_t last_leaf) {
   uint32_t len = metering->deferral_page_buf_len;
-  append_page_touch_range(metering->deferral_page_buf, &len, first_leaf, last_leaf);
+  append_page_touch_range(metering->deferral_page_buf, &len, first_leaf,
+                          last_leaf);
   metering->deferral_page_buf_len = len;
 }
 
@@ -188,19 +195,22 @@ static __attribute__((always_inline)) inline void record_page(
   uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   if (likely(addr_space == AS_MEMORY)) {
     if (likely(first_page == last_page)) {
-      record_mem_page(metering, first_page, leaf_mask_range(first_leaf, last_leaf));
+      record_mem_page(metering, first_page,
+                      leaf_mask_range(first_leaf, last_leaf));
     } else {
       record_mem_page_range(metering, first_leaf, last_leaf);
     }
   } else if (addr_space == AS_PUBLIC_VALUES) {
     if (first_page == last_page) {
-      record_pv_page(metering, first_page, leaf_mask_range(first_leaf, last_leaf));
+      record_pv_page(metering, first_page,
+                     leaf_mask_range(first_leaf, last_leaf));
     } else {
       record_pv_page_range(metering, first_leaf, last_leaf);
     }
   } else {
     if (first_page == last_page) {
-      record_deferral_page(metering, first_page, leaf_mask_range(first_leaf, last_leaf));
+      record_deferral_page(metering, first_page,
+                           leaf_mask_range(first_leaf, last_leaf));
     } else {
       record_deferral_page_range(metering, first_leaf, last_leaf);
     }
@@ -210,7 +220,8 @@ static __attribute__((always_inline)) inline void record_page(
 /* Record leaves touched by [first_addr, last_addr]. Duplicates are fine —
  * Rust-side checkpoint processing deduplicates by page mask. */
 static __attribute__((always_inline)) inline void record_page_range(
-    MeteringState* metering, uint32_t addr_space, uint64_t first_addr, uint64_t last_addr) {
+    MeteringState* metering, uint32_t addr_space, uint64_t first_addr,
+    uint64_t last_addr) {
   uint32_t first_leaf = addr_to_local_leaf(addr_space, first_addr);
   uint32_t last_leaf = addr_to_local_leaf(addr_space, last_addr);
   if (likely(addr_space == AS_MEMORY)) {
@@ -244,7 +255,7 @@ static __attribute__((always_inline)) inline void trace_memory_drain(
     return;
   }
   append_page_touch(memory->mem_page_buf, &memory->mem_page_buf_len,
-                     memory->last_mem_page, memory->last_mem_leaf_mask);
+                    memory->last_mem_page, memory->last_mem_leaf_mask);
   memory->last_mem_page = NO_LAST_PAGE;
   memory->last_mem_leaf_mask = 0;
 }
@@ -315,113 +326,57 @@ static __attribute__((always_inline)) inline void trace_memory_access_span(
   }
 }
 
-/* ── Trace-only register access (no-ops in metered mode) ─────────── */
+/* Extension range access includes page accounting in metered mode. */
 
-static __attribute__((always_inline)) inline void trace_reg_read(
-    RvState* restrict state [[maybe_unused]], uint8_t idx [[maybe_unused]],
-    uint64_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_reg_write(
-    RvState* restrict state [[maybe_unused]], uint8_t idx [[maybe_unused]],
-    uint64_t new_val [[maybe_unused]]) {}
-
-/* ── Trace-only memory reads (record page in metered mode) ───────── */
-
-static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state, uint64_t addr, uint8_t val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint8_t));
-}
-
-static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state, uint64_t addr, int8_t val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(int8_t));
-}
-
-static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state, uint64_t addr, uint16_t val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint16_t));
-}
-
-static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state, uint64_t addr, int16_t val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(int16_t));
-}
-
-static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state, uint64_t addr, uint32_t val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint32_t));
-}
-
-static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state, uint64_t addr, int32_t val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(int32_t));
-}
-
-static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state, uint64_t addr, uint64_t val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint64_t));
-}
-
-/* ── Trace-only memory writes (record page in metered mode) ──────── */
-
-static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state, uint64_t addr, uint8_t new_val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint8_t));
-}
-
-static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state, uint64_t addr, uint16_t new_val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint16_t));
-}
-
-static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state, uint64_t addr, uint32_t new_val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint32_t));
-}
-
-static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state, uint64_t addr, uint64_t new_val [[maybe_unused]]) {
-  record_page(&state->mode_state, AS_MEMORY, addr, sizeof(uint64_t));
-}
-
-/* ── Trace-only word-range memory access ──────────────────────────── */
-
-/* Precondition for all *_range trace functions: num_words >= 1.
+/* Precondition for all range functions: num_words >= 1.
  * Callers are responsible for guarding empty ranges (e.g. xorin with len=0)
  * so we can skip the branch on the hot path. */
 
-static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state, uint64_t base_addr,
-    const uint64_t* vals [[maybe_unused]], uint32_t num_words) {
+static __attribute__((always_inline)) inline void read_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
+  read_mem_u64_range_raw(state, base_addr, out, num_words);
   assume(num_words > 0);
   uint64_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
   record_page_range(&state->mode_state, AS_MEMORY, base_addr, last_addr);
 }
 
-static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state, uint64_t base_addr,
-    const uint64_t* vals [[maybe_unused]], uint32_t num_words) {
+static __attribute__((always_inline)) inline void write_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, const uint64_t* restrict vals,
+    uint32_t num_words) {
   assume(num_words > 0);
   uint64_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
   record_page_range(&state->mode_state, AS_MEMORY, base_addr, last_addr);
+  write_mem_u64_range_raw(state, base_addr, vals, num_words);
 }
 
-/* ── Trace-only operations ────────────────────────────────────────── */
-
-static __attribute__((always_inline)) inline void trace_mem_access(
-    RvState* restrict state, uint64_t addr, uint32_t addr_space) {
-  record_page(&state->mode_state, addr_space, addr, WORD_SIZE);
+/* Execution inputs do not create VM memory accesses. */
+static __attribute__((always_inline)) inline uint64_t
+read_mem_u64_execution_input(RvState* restrict state, uint64_t addr) {
+  return read_mem_u64(state->memory, addr);
 }
 
-static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
+static __attribute__((always_inline)) inline void
+read_mem_u64_range_execution_input(RvState* restrict state, uint64_t base_addr,
+                                   uint64_t* restrict out, uint32_t num_words) {
+  read_mem_u64_range_raw(state, base_addr, out, num_words);
+}
+
+/* ── Page accounting ──────────────────────────────────────────────── */
+
+static __attribute__((always_inline)) inline void trace_page_access(
+    RvState* restrict state, uint64_t addr, uint32_t size,
+    uint32_t addr_space) {
+  record_page(&state->mode_state, addr_space, addr, size);
+}
+
+static __attribute__((always_inline)) inline void trace_page_access_u64_range(
     RvState* restrict state, uint64_t base_addr, uint64_t num_dwords,
     uint32_t addr_space) {
   assume(num_dwords > 0);
   uint64_t last_addr = base_addr + num_dwords * WORD_SIZE - 1u;
   record_page_range(&state->mode_state, addr_space, base_addr, last_addr);
 }
-
-static __attribute__((always_inline)) inline void trace_pc(
-    RvState* restrict state [[maybe_unused]], uint64_t pc [[maybe_unused]]) {}
 
 #pragma clang unsafe_buffer_usage end
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -423,10 +423,6 @@ static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
 static __attribute__((always_inline)) inline void trace_pc(
     RvState* restrict state [[maybe_unused]], uint64_t pc [[maybe_unused]]) {}
 
-static __attribute__((always_inline)) inline void trace_chip(
-    RvState* restrict state, uint32_t chip_idx, uint32_t count) {
-  (*state->mode_state.trace_heights)[chip_idx] += count;
-}
 #pragma clang unsafe_buffer_usage end
 
 #endif /* OPENVM_TRACER_METERED_H */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -18,15 +18,15 @@ static __attribute__((always_inline)) inline void write_mem_u64_range(
   write_mem_u64_range_raw(state, base_addr, vals, num_words);
 }
 
-/* Execution inputs do not contribute to scalar metered cost. */
-static __attribute__((always_inline)) inline uint64_t
-read_mem_u64_execution_input(RvState* restrict state, uint64_t addr) {
+/* Peeking at a value does not contribute to scalar metered cost. */
+static __attribute__((always_inline)) inline uint64_t peek_mem_u64(
+    RvState* restrict state, uint64_t addr) {
   return read_mem_u64(state->memory, addr);
 }
 
-static __attribute__((always_inline)) inline void
-read_mem_u64_range_execution_input(RvState* restrict state, uint64_t base_addr,
-                                   uint64_t* restrict out, uint32_t num_words) {
+static __attribute__((always_inline)) inline void peek_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
   read_mem_u64_range_raw(state, base_addr, out, num_words);
 }
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -1,86 +1,39 @@
-/* OpenVM metered-cost tracing helpers.
- *
- * Accumulates scalar trace cell cost matching OpenVM's MeteredCostCtx.
- * Instruction retirement is counted directly at generated block boundaries.
- *
- * All functions are static inline for zero-overhead inlining.
- */
+/* OpenVM metered-cost execution helpers. */
 
 #ifndef OPENVM_TRACER_METERED_COST_H
 #define OPENVM_TRACER_METERED_COST_H
 
-#include <stdint.h>
-
 #include "openvm_state.h"
 
-/* ── Trace-only register access (no-ops in metered cost mode) ────── */
+/* Memory page accounting does not contribute to scalar metered cost. */
+static __attribute__((always_inline)) inline void read_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
+  read_mem_u64_range_raw(state, base_addr, out, num_words);
+}
 
-static __attribute__((always_inline)) inline void trace_reg_read(
-    RvState* restrict state [[maybe_unused]], uint8_t idx [[maybe_unused]],
-    uint64_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_reg_write(
-    RvState* restrict state [[maybe_unused]], uint8_t idx [[maybe_unused]],
-    uint64_t new_val [[maybe_unused]]) {}
+static __attribute__((always_inline)) inline void write_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, const uint64_t* restrict vals,
+    uint32_t num_words) {
+  write_mem_u64_range_raw(state, base_addr, vals, num_words);
+}
 
-/* ── Trace-only memory reads (no-ops in metered cost mode) ───────── */
+/* Execution inputs do not contribute to scalar metered cost. */
+static __attribute__((always_inline)) inline uint64_t
+read_mem_u64_execution_input(RvState* restrict state, uint64_t addr) {
+  return read_mem_u64(state->memory, addr);
+}
 
-static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint8_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    int8_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint16_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    int16_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint32_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    int32_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint64_t val [[maybe_unused]]) {}
+static __attribute__((always_inline)) inline void
+read_mem_u64_range_execution_input(RvState* restrict state, uint64_t base_addr,
+                                   uint64_t* restrict out, uint32_t num_words) {
+  read_mem_u64_range_raw(state, base_addr, out, num_words);
+}
 
-/* ── Trace-only memory writes (no-ops in metered cost mode) ──────── */
-
-static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint8_t new_val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint16_t new_val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint32_t new_val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint64_t new_val [[maybe_unused]]) {}
-
-/* ── Trace-only word-range memory access (no-ops in metered cost mode) */
-
-static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state [[maybe_unused]], uint64_t base_addr [[maybe_unused]],
-    const uint64_t* vals [[maybe_unused]], uint32_t num_words [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state [[maybe_unused]], uint64_t base_addr [[maybe_unused]],
-    const uint64_t* vals [[maybe_unused]], uint32_t num_words [[maybe_unused]]) {}
-
-/* ── Trace-only operations ────────────────────────────────────────── */
-
-static __attribute__((always_inline)) inline void trace_mem_access(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
+/* Page locations do not affect scalar metered cost. */
+static __attribute__((always_inline)) inline void trace_page_access_u64_range(
+    RvState* restrict state [[maybe_unused]],
+    uint64_t base_addr [[maybe_unused]], uint64_t num_dwords [[maybe_unused]],
     uint32_t addr_space [[maybe_unused]]) {}
-
-static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
-    RvState* restrict state [[maybe_unused]], uint64_t base_addr [[maybe_unused]],
-    uint64_t num_dwords [[maybe_unused]], uint32_t addr_space [[maybe_unused]]) {}
-
-static __attribute__((always_inline)) inline void trace_pc(
-    RvState* restrict state [[maybe_unused]], uint64_t pc [[maybe_unused]]) {}
 
 #endif /* OPENVM_TRACER_METERED_COST_H */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -83,12 +83,4 @@ static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
 static __attribute__((always_inline)) inline void trace_pc(
     RvState* restrict state [[maybe_unused]], uint64_t pc [[maybe_unused]]) {}
 
-/* chip_idx is assigned from the bounded executor-to-AIR mapping. */
-#pragma clang unsafe_buffer_usage begin
-static __attribute__((always_inline)) inline void trace_chip(
-    RvState* restrict state, uint32_t chip_idx, uint32_t count) {
-  state->mode_state.cost += state->mode_state.chip_widths[chip_idx] * (uint64_t)count;
-}
-#pragma clang unsafe_buffer_usage end
-
 #endif /* OPENVM_TRACER_METERED_COST_H */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -1,84 +1,40 @@
-/* OpenVM pure tracing helpers.
- *
- * All trace functions are identity/no-ops. Pure instruction-limit handling,
- * when selected, is emitted directly at generated block boundaries.
- */
+/* OpenVM pure execution helpers. */
 
 #ifndef OPENVM_TRACER_PURE_H
 #define OPENVM_TRACER_PURE_H
 
-#include <stdint.h>
-
 #include "openvm_state.h"
 
-/* ── Trace-only register access (no-ops in pure mode) ────────────── */
+/* Extension memory operations use one interface in every execution mode.
+ * Pure execution performs only the requested memory access. */
+static __attribute__((always_inline)) inline void read_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
+  read_mem_u64_range_raw(state, base_addr, out, num_words);
+}
 
-static __attribute__((always_inline)) inline void trace_reg_read(
-    RvState* restrict state [[maybe_unused]], uint8_t idx [[maybe_unused]],
-    uint64_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_reg_write(
-    RvState* restrict state [[maybe_unused]], uint8_t idx [[maybe_unused]],
-    uint64_t new_val [[maybe_unused]]) {}
+static __attribute__((always_inline)) inline void write_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, const uint64_t* restrict vals,
+    uint32_t num_words) {
+  write_mem_u64_range_raw(state, base_addr, vals, num_words);
+}
 
-/* ── Trace-only memory reads (no-ops in pure mode) ───────────────── */
+/* Execution inputs do not create VM memory accesses. */
+static __attribute__((always_inline)) inline uint64_t
+read_mem_u64_execution_input(RvState* restrict state, uint64_t addr) {
+  return read_mem_u64(state->memory, addr);
+}
 
-static __attribute__((always_inline)) inline void trace_rd_mem_u8(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint8_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_i8(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    int8_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_u16(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint16_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_i16(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    int16_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_u32(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint32_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_i32(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    int32_t val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_rd_mem_u64(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint64_t val [[maybe_unused]]) {}
+static __attribute__((always_inline)) inline void
+read_mem_u64_range_execution_input(RvState* restrict state, uint64_t base_addr,
+                                   uint64_t* restrict out, uint32_t num_words) {
+  read_mem_u64_range_raw(state, base_addr, out, num_words);
+}
 
-/* ── Trace-only memory writes (no-ops in pure mode) ──────────────── */
-
-static __attribute__((always_inline)) inline void trace_wr_mem_u8(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint8_t new_val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u16(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint16_t new_val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u32(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint32_t new_val [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u64(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
-    uint64_t new_val [[maybe_unused]]) {}
-
-/* ── Trace-only word-range memory access (no-ops in pure mode) ───── */
-
-static __attribute__((always_inline)) inline void trace_rd_mem_u64_range(
-    RvState* restrict state [[maybe_unused]], uint64_t base_addr [[maybe_unused]],
-    const uint64_t* vals [[maybe_unused]], uint32_t num_words [[maybe_unused]]) {}
-static __attribute__((always_inline)) inline void trace_wr_mem_u64_range(
-    RvState* restrict state [[maybe_unused]], uint64_t base_addr [[maybe_unused]],
-    const uint64_t* vals [[maybe_unused]], uint32_t num_words [[maybe_unused]]) {}
-
-/* ── Trace-only operations (no-ops in pure mode) ──────────────────── */
-
-static __attribute__((always_inline)) inline void trace_mem_access(
-    RvState* restrict state [[maybe_unused]], uint64_t addr [[maybe_unused]],
+/* Some extension callbacks report page-only accesses through a shared ABI. */
+static __attribute__((always_inline)) inline void trace_page_access_u64_range(
+    RvState* restrict state [[maybe_unused]],
+    uint64_t base_addr [[maybe_unused]], uint64_t num_dwords [[maybe_unused]],
     uint32_t addr_space [[maybe_unused]]) {}
-
-static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
-    RvState* restrict state [[maybe_unused]], uint64_t base_addr [[maybe_unused]],
-    uint64_t num_dwords [[maybe_unused]], uint32_t addr_space [[maybe_unused]]) {}
-
-static __attribute__((always_inline)) inline void trace_pc(
-    RvState* restrict state [[maybe_unused]], uint64_t pc [[maybe_unused]]) {}
 
 #endif /* OPENVM_TRACER_PURE_H */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -81,8 +81,4 @@ static __attribute__((always_inline)) inline void trace_mem_access_u64_range(
 static __attribute__((always_inline)) inline void trace_pc(
     RvState* restrict state [[maybe_unused]], uint64_t pc [[maybe_unused]]) {}
 
-static __attribute__((always_inline)) inline void trace_chip(
-    RvState* restrict state [[maybe_unused]], uint32_t chip_idx [[maybe_unused]],
-    uint32_t count [[maybe_unused]]) {}
-
 #endif /* OPENVM_TRACER_PURE_H */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -19,15 +19,15 @@ static __attribute__((always_inline)) inline void write_mem_u64_range(
   write_mem_u64_range_raw(state, base_addr, vals, num_words);
 }
 
-/* Execution inputs do not create VM memory accesses. */
-static __attribute__((always_inline)) inline uint64_t
-read_mem_u64_execution_input(RvState* restrict state, uint64_t addr) {
+/* Peeking at a value does not create a VM memory access. */
+static __attribute__((always_inline)) inline uint64_t peek_mem_u64(
+    RvState* restrict state, uint64_t addr) {
   return read_mem_u64(state->memory, addr);
 }
 
-static __attribute__((always_inline)) inline void
-read_mem_u64_range_execution_input(RvState* restrict state, uint64_t base_addr,
-                                   uint64_t* restrict out, uint32_t num_words) {
+static __attribute__((always_inline)) inline void peek_mem_u64_range(
+    RvState* restrict state, uint64_t base_addr, uint64_t* restrict out,
+    uint32_t num_words) {
   read_mem_u64_range_raw(state, base_addr, out, num_words);
 }
 

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -33,7 +33,7 @@ pub const MEM_PAGE_BUF_CAP: usize = 1 << 16;
 const MAX_PV_PAGES_PER_INSN: usize = 2;
 
 /// Maximum AS_PUBLIC_VALUES page buffer entries per segment check interval.
-/// No bounds checks in C. An unaligned reveal can cross one page boundary.
+/// The C tracer does not bounds-check this buffer. A reveal can span two pages.
 pub const PV_PAGE_BUF_CAP: usize = 1 << 12;
 
 /// Maximum AS_DEFERRAL page buffer entries per segment check interval.
@@ -64,6 +64,7 @@ static constexpr uint32_t AS_MEMORY = {RV64_MEMORY_AS};
 static constexpr uint32_t AS_PUBLIC_VALUES = {PUBLIC_VALUES_AS};
 static constexpr uint32_t AS_DEFERRAL = {DEFERRAL_AS};
 static constexpr uint32_t WORD_SIZE = {WORD_SIZE};
+static_assert(WORD_SIZE == sizeof(uint64_t), \"OpenVM word size must match uint64_t\");
 static constexpr uint32_t DEFERRAL_DIGEST_SIZE = {VM_DIGEST_WIDTH};
 static constexpr uint64_t RV_TEXT_START = 0x{text_start:08x}ull;
 static constexpr uint64_t RV_TEXT_END = 0x{text_end:08x}ull;

--- a/crates/rvr/rvr-openvm/src/constants.rs
+++ b/crates/rvr/rvr-openvm/src/constants.rs
@@ -29,14 +29,17 @@ pub const MAX_MEM_PAGES_PER_INSN: usize = {
 /// verifies this capacity against `MAX_MEM_PAGES_PER_INSN`.
 pub const MEM_PAGE_BUF_CAP: usize = 1 << 16;
 
+/// Worst-case AS_PUBLIC_VALUES pages a fixed-width reveal can touch.
+const MAX_PV_PAGES_PER_INSN: usize = 2;
+
 /// Maximum AS_PUBLIC_VALUES page buffer entries per segment check interval.
-/// No bounds checks in C. At most 1 page per instruction (reveal/publish).
+/// No bounds checks in C. An unaligned reveal can cross one page boundary.
 pub const PV_PAGE_BUF_CAP: usize = 1 << 12;
 
 /// Maximum AS_DEFERRAL page buffer entries per segment check interval.
-/// No bounds checks in C.
-// TODO: justify this bound (audit max deferral pages per instruction).
-pub const DEFERRAL_PAGE_BUF_CAP: usize = 1 << 16;
+/// No bounds checks in C. Deferral CALL records two reads and two writes.
+const MAX_DEFERRAL_PAGES_PER_INSN: usize = 4;
+pub const DEFERRAL_PAGE_BUF_CAP: usize = 1 << 12;
 
 /// Generate the `openvm_constants.h` content with compile-time constants
 /// for the C tracing headers.
@@ -73,6 +76,8 @@ static constexpr uint32_t TRACER_PV_PAGE_BUF_CAP = {PV_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_DEFERRAL_PAGE_BUF_CAP = {DEFERRAL_PAGE_BUF_CAP};
 static constexpr uint32_t TRACER_SEGMENT_CHECK_INSNS = {SEGMENT_CHECK_INSNS};
 static constexpr uint32_t TRACER_MAX_MEM_PAGES_PER_INSN = {MAX_MEM_PAGES_PER_INSN};
+static constexpr uint32_t TRACER_MAX_PV_PAGES_PER_INSN = {MAX_PV_PAGES_PER_INSN};
+static constexpr uint32_t TRACER_MAX_DEFERRAL_PAGES_PER_INSN = {MAX_DEFERRAL_PAGES_PER_INSN};
 "
     );
     if let Some(num_airs) = num_airs {

--- a/crates/rvr/rvr-openvm/src/emit/codegen.rs
+++ b/crates/rvr/rvr-openvm/src/emit/codegen.rs
@@ -9,7 +9,7 @@ use super::context::EmitContext;
 /// Trait for instructions that can emit their own C code.
 pub trait InstrCodegen {
     /// Emit the C body for this instruction into the buffer.
-    /// `ctx` provides traced helpers for register/memory access.
+    /// `ctx` handles register and memory access for the current execution mode.
     fn emit_c(&self, ctx: &mut EmitContext);
 }
 
@@ -169,6 +169,10 @@ pub fn emit_terminator(ctx: &mut EmitContext, term: &Terminator, pc: u64, tc: &T
             target,
         } => {
             if let Some(taken) = constant_branch_result(*cond, *rs1, *rs2) {
+                if ctx.traces_values() {
+                    ctx.read_reg(*rs1);
+                    ctx.read_reg(*rs2);
+                }
                 let destination = if taken { *target } else { next_pc };
                 emit_tail_call(ctx, destination, &args, tc.valid_blocks);
                 return;
@@ -211,7 +215,7 @@ fn static_tail_call(target: u64, args: &str, valid_blocks: &HashSet<u64>) -> Str
     if valid_blocks.contains(&target) {
         format!("[[clang::musttail]] return block_0x{target:08x}({args});")
     } else {
-        format!("[[clang::musttail]] return rv_trap({args});")
+        format!("state->pc = 0x{target:016x}ull; [[clang::musttail]] return rv_trap({args});")
     }
 }
 

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -5,6 +5,21 @@ use rvr_openvm_ir::MemWidth;
 
 use super::codegen::hex_u32;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("chip index {chip_idx} is outside AIR count {num_airs}")]
+pub(crate) struct InvalidChipIndex {
+    pub chip_idx: u32,
+    pub num_airs: u32,
+}
+
+pub(crate) fn validate_chip_index(chip_idx: u32, num_airs: u32) -> Result<(), InvalidChipIndex> {
+    if chip_idx < num_airs {
+        Ok(())
+    } else {
+        Err(InvalidChipIndex { chip_idx, num_airs })
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) enum EmitMode {
     /// Emit ordered register, PC, and memory-value hooks.
@@ -87,6 +102,8 @@ pub struct EmitContext<'a> {
     mode: EmitMode,
     block_abi: BlockAbi,
     chip_widths: Option<&'a [u64]>,
+    num_airs: Option<u32>,
+    invalid_chip_index: Option<InvalidChipIndex>,
 }
 
 impl<'a> EmitContext<'a> {
@@ -95,6 +112,7 @@ impl<'a> EmitContext<'a> {
         mode: EmitMode,
         block_abi: BlockAbi,
         chip_widths: Option<&'a [u64]>,
+        num_airs: Option<u32>,
     ) -> Self {
         debug_assert_eq!(matches!(mode, EmitMode::MeteredCost), chip_widths.is_some());
         Self {
@@ -106,6 +124,8 @@ impl<'a> EmitContext<'a> {
             mode,
             block_abi,
             chip_widths,
+            num_airs,
+            invalid_chip_index: None,
         }
     }
 
@@ -422,6 +442,15 @@ impl<'a> EmitContext<'a> {
         if chip_idx == u32::MAX {
             return;
         }
+        if !matches!(self.mode, EmitMode::ValueTrace | EmitMode::Direct) {
+            let num_airs = self
+                .num_airs
+                .expect("metered code generation requires the AIR count");
+            if let Err(error) = validate_chip_index(chip_idx, num_airs) {
+                self.invalid_chip_index.get_or_insert(error);
+                return;
+            }
+        }
         match self.mode {
             EmitMode::ValueTrace | EmitMode::Direct => {}
             EmitMode::Metered { .. } => {
@@ -441,6 +470,10 @@ impl<'a> EmitContext<'a> {
                 }
             }
         }
+    }
+
+    pub(crate) fn invalid_chip_index(&self) -> Option<InvalidChipIndex> {
+        self.invalid_chip_index
     }
 
     pub fn trace_chip_if_nonzero(&mut self, chip_idx: u32, count_expr: &str) {
@@ -628,6 +661,7 @@ mod tests {
             },
             BlockAbi::Metered,
             None,
+            Some(1),
         )
     }
 

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -14,6 +14,8 @@ pub(crate) enum EmitMode {
     Direct,
     /// Metered block ABI. Blocks with memory ops record AS_MEMORY pages locally.
     Metered { trace_memory_pages: bool },
+    /// Metered-cost execution with chip widths specialized into generated C.
+    MeteredCost,
 }
 
 /// Extra values carried between generated blocks through the `preserve_none`
@@ -40,10 +42,6 @@ impl BlockAbi {
 }
 
 impl EmitMode {
-    fn has_metered_abi(self) -> bool {
-        matches!(self, Self::Metered { .. })
-    }
-
     fn traces_memory_values(self) -> bool {
         matches!(self, Self::ValueTrace)
     }
@@ -69,7 +67,7 @@ impl EmitMode {
 }
 
 /// Code generation context. Holds a mutable buffer and tracks hot registers.
-pub struct EmitContext {
+pub struct EmitContext<'a> {
     buf: String,
     hot_regs: HashSet<u8>,
     /// Base indentation level (in 4-space units) for emitted lines.
@@ -79,10 +77,17 @@ pub struct EmitContext {
     uses_raw_memory: bool,
     mode: EmitMode,
     block_abi: BlockAbi,
+    chip_widths: Option<&'a [u64]>,
 }
 
-impl EmitContext {
-    pub(crate) fn new(hot_regs: HashSet<u8>, mode: EmitMode, block_abi: BlockAbi) -> Self {
+impl<'a> EmitContext<'a> {
+    pub(crate) fn new(
+        hot_regs: HashSet<u8>,
+        mode: EmitMode,
+        block_abi: BlockAbi,
+        chip_widths: Option<&'a [u64]>,
+    ) -> Self {
+        debug_assert_eq!(matches!(mode, EmitMode::MeteredCost), chip_widths.is_some());
         Self {
             buf: String::with_capacity(1024),
             hot_regs,
@@ -91,6 +96,7 @@ impl EmitContext {
             uses_raw_memory: false,
             mode,
             block_abi,
+            chip_widths,
         }
     }
 
@@ -386,15 +392,52 @@ impl EmitContext {
         tmp
     }
 
+    pub fn emit_call_with_trace_result(
+        &mut self,
+        ret_ty: &str,
+        name: &str,
+        args: &[&str],
+    ) -> Option<String> {
+        if matches!(self.mode, EmitMode::ValueTrace | EmitMode::Direct) {
+            self.emit_call(name, args);
+            None
+        } else {
+            Some(self.emit_call_expr(ret_ty, name, args))
+        }
+    }
+
     pub fn trace_chip(&mut self, chip_idx: u32, count_expr: &str) {
         if chip_idx == u32::MAX {
             return;
         }
-        if self.mode.has_metered_abi() {
-            self.write_line(&format!("(*trace_heights)[{chip_idx}] += {count_expr};"));
-        } else {
-            self.write_line(&format!("trace_chip(state, {chip_idx}u, {count_expr});"));
+        match self.mode {
+            EmitMode::ValueTrace | EmitMode::Direct => {}
+            EmitMode::Metered { .. } => {
+                self.write_line(&format!("(*trace_heights)[{chip_idx}] += {count_expr};"));
+            }
+            EmitMode::MeteredCost => {
+                let width = self
+                    .chip_widths
+                    .unwrap()
+                    .get(chip_idx as usize)
+                    .copied()
+                    .expect("extension chip index exceeds chip-width table");
+                if width != 0 {
+                    self.write_line(&format!(
+                        "state->mode_state.cost += {width}ull * (uint64_t)({count_expr});"
+                    ));
+                }
+            }
         }
+    }
+
+    pub fn trace_chip_if_nonzero(&mut self, chip_idx: u32, count_expr: &str) {
+        if chip_idx == u32::MAX || matches!(self.mode, EmitMode::ValueTrace | EmitMode::Direct) {
+            return;
+        }
+        self.write_line(&format!("if (({count_expr}) != 0u) {{"));
+        self.trace_chip(chip_idx, count_expr);
+        self.write_line("}");
     }
 
     pub fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {
@@ -475,7 +518,7 @@ impl EmitContext {
     }
 }
 
-impl rvr_openvm_ir::ExtEmitCtx for EmitContext {
+impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
     fn read_reg(&mut self, idx: u8) -> String {
         EmitContext::read_reg(self, idx)
     }
@@ -520,8 +563,21 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext {
         EmitContext::emit_call_expr(self, ret_ty, name, args)
     }
 
+    fn emit_call_with_trace_result(
+        &mut self,
+        ret_ty: &str,
+        name: &str,
+        args: &[&str],
+    ) -> Option<String> {
+        EmitContext::emit_call_with_trace_result(self, ret_ty, name, args)
+    }
+
     fn trace_chip(&mut self, chip_idx: u32, count_expr: &str) {
         EmitContext::trace_chip(self, chip_idx, count_expr);
+    }
+
+    fn trace_chip_if_nonzero(&mut self, chip_idx: u32, count_expr: &str) {
+        EmitContext::trace_chip_if_nonzero(self, chip_idx, count_expr);
     }
 
     fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {
@@ -539,13 +595,14 @@ mod tests {
 
     use super::{BlockAbi, EmitContext, EmitMode};
 
-    fn metered_memory_ctx() -> EmitContext {
+    fn metered_memory_ctx() -> EmitContext<'static> {
         EmitContext::new(
             HashSet::new(),
             EmitMode::Metered {
                 trace_memory_pages: true,
             },
             BlockAbi::Metered,
+            None,
         )
     }
 

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, fmt::Write};
 
 use openvm_instructions::riscv::RV64_MEMORY_AS;
+use rvr_openvm_ir::MemWidth;
 
 use super::codegen::hex_u32;
 
@@ -9,8 +10,6 @@ pub(crate) enum EmitMode {
     /// Emit ordered register, PC, and memory-value hooks.
     ///
     /// Page hooks are separate because they record only addresses for metering.
-    /// No current artifact kind selects this mode; selecting it also requires a
-    /// tracer header that defines the emitted hooks.
     #[allow(dead_code)]
     ValueTrace,
     /// Memory accesses use direct helpers and do not emit memory trace events.
@@ -73,7 +72,7 @@ impl EmitMode {
 #[derive(Clone, Copy)]
 enum RegisterReadKind {
     MemoryAccess,
-    ExecutionInput,
+    Peek,
 }
 
 /// Code generation context. Holds a mutable buffer and tracks hot registers.
@@ -224,7 +223,7 @@ impl<'a> EmitContext<'a> {
         if self.mode.traces_values() {
             let trace_fn = match kind {
                 RegisterReadKind::MemoryAccess => "trace_reg_read",
-                RegisterReadKind::ExecutionInput => "trace_reg_execution_input",
+                RegisterReadKind::Peek => "trace_reg_peek",
             };
             self.write_line(&format!("{trace_fn}(state, {idx}, {value});"));
         }
@@ -237,9 +236,9 @@ impl<'a> EmitContext<'a> {
         self.read_reg_impl(idx, RegisterReadKind::MemoryAccess)
     }
 
-    /// Read a register used by execution without creating a VM memory access.
-    pub fn read_reg_execution_input(&mut self, idx: u8) -> String {
-        self.read_reg_impl(idx, RegisterReadKind::ExecutionInput)
+    /// Get a register value without creating a VM memory access.
+    pub fn peek_reg(&mut self, idx: u8) -> String {
+        self.read_reg_impl(idx, RegisterReadKind::Peek)
     }
 
     /// Write a register with tracing when value tracing is enabled.
@@ -453,7 +452,7 @@ impl<'a> EmitContext<'a> {
         self.write_line("}");
     }
 
-    pub fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32) {
+    pub fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: u32) {
         assert!(
             !self.mode.traces_values(),
             "page-only access is invalid when values are being traced"
@@ -465,6 +464,7 @@ impl<'a> EmitContext<'a> {
         if touches_memory {
             self.flush_page_locals();
         }
+        let size = width.bytes();
         self.write_line(&format!(
             "trace_page_access(state, {addr}, {size}u, {addr_space}u);"
         ));
@@ -552,8 +552,8 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
         EmitContext::read_reg(self, idx)
     }
 
-    fn read_reg_execution_input(&mut self, idx: u8) -> String {
-        EmitContext::read_reg_execution_input(self, idx)
+    fn peek_reg(&mut self, idx: u8) -> String {
+        EmitContext::peek_reg(self, idx)
     }
 
     fn write_reg(&mut self, idx: u8, val: &str) {
@@ -605,8 +605,8 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
         EmitContext::trace_chip_if_nonzero(self, chip_idx, count_expr);
     }
 
-    fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32) {
-        EmitContext::trace_page_access(self, addr, size, addr_space);
+    fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: u32) {
+        EmitContext::trace_page_access(self, addr, width, addr_space);
     }
 
     fn trace_page_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32) {

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -6,7 +6,11 @@ use super::codegen::hex_u32;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) enum EmitMode {
-    /// Memory accesses go through `*_traced` helpers so tracing sees values.
+    /// Emit ordered register, PC, and memory-value hooks.
+    ///
+    /// Page hooks are separate because they record only addresses for metering.
+    /// No current artifact kind selects this mode; selecting it also requires a
+    /// tracer header that defines the emitted hooks.
     #[allow(dead_code)]
     ValueTrace,
     /// Memory accesses use direct helpers and do not emit memory trace events.
@@ -14,7 +18,7 @@ pub(crate) enum EmitMode {
     Direct,
     /// Metered block ABI. Blocks with memory ops record AS_MEMORY pages locally.
     Metered { trace_memory_pages: bool },
-    /// Metered-cost execution with chip widths specialized into generated C.
+    /// Metered-cost execution with chip widths written into generated C.
     MeteredCost,
 }
 
@@ -42,7 +46,7 @@ impl BlockAbi {
 }
 
 impl EmitMode {
-    fn traces_memory_values(self) -> bool {
+    fn traces_values(self) -> bool {
         matches!(self, Self::ValueTrace)
     }
 
@@ -64,6 +68,12 @@ impl EmitMode {
             }
         )
     }
+}
+
+#[derive(Clone, Copy)]
+enum RegisterReadKind {
+    MemoryAccess,
+    ExecutionInput,
 }
 
 /// Code generation context. Holds a mutable buffer and tracks hot registers.
@@ -143,7 +153,7 @@ impl<'a> EmitContext<'a> {
         self.buf.push('\n');
     }
 
-    /// Flush block-local metering state and tail-call the shared RVR trap.
+    /// Save local metering state and tail-call the shared RVR trap.
     pub fn emit_trap(&mut self) {
         self.flush_page_locals();
         let args = self.tail_call_args();
@@ -193,59 +203,66 @@ impl<'a> EmitContext<'a> {
         }
     }
 
-    /// Read a register with tracing. Returns a C expression for the value.
-    pub fn read_reg(&mut self, idx: u8) -> String {
+    pub(crate) fn traces_values(&self) -> bool {
+        self.mode.traces_values()
+    }
+
+    fn read_reg_impl(&mut self, idx: u8, kind: RegisterReadKind) -> String {
         if idx == 0 {
             return "0ull".to_string();
         }
-        if self.hot_regs.contains(&idx) {
+
+        let value = if self.hot_regs.contains(&idx) {
             let name = Self::abi_name(idx);
-            self.write_line(&format!("trace_reg_read(state, {idx}, {name});"));
             name.to_string()
         } else {
             let var = self.next_var();
             self.write_line(&format!("uint64_t {var} = reg_read(state, {idx});"));
-            self.write_line(&format!("trace_reg_read(state, {idx}, {var});"));
             var
+        };
+
+        if self.mode.traces_values() {
+            let trace_fn = match kind {
+                RegisterReadKind::MemoryAccess => "trace_reg_read",
+                RegisterReadKind::ExecutionInput => "trace_reg_execution_input",
+            };
+            self.write_line(&format!("{trace_fn}(state, {idx}, {value});"));
         }
+
+        value
     }
 
-    /// Read a register WITHOUT tracing (for phantom instructions).
-    pub fn read_reg_raw(&mut self, idx: u8) -> String {
-        if idx == 0 {
-            return "0ull".to_string();
-        }
-        if self.hot_regs.contains(&idx) {
-            Self::abi_name(idx).to_string()
-        } else {
-            format!("state->regs[{idx}]")
-        }
+    /// Read an AIR-visible register value.
+    pub fn read_reg(&mut self, idx: u8) -> String {
+        self.read_reg_impl(idx, RegisterReadKind::MemoryAccess)
     }
 
-    /// Write a register with tracing. Trace before write so the helper can read
-    /// the old value from state if needed.
-    ///
-    /// `val` is materialized into a temporary first so it is evaluated exactly
-    /// once even when interpolated into both the trace and the data write
-    /// statements. This matters when `val` is an opaque function call (e.g.
-    /// an `rvr_ext_*` extension entry point) that the C compiler cannot CSE.
+    /// Read a register used by execution without creating a VM memory access.
+    pub fn read_reg_execution_input(&mut self, idx: u8) -> String {
+        self.read_reg_impl(idx, RegisterReadKind::ExecutionInput)
+    }
+
+    /// Write a register with tracing when value tracing is enabled.
     pub fn write_reg(&mut self, idx: u8, val: &str) {
         if idx == 0 {
             return;
         }
-        let tmp = self.next_var();
-        self.write_line(&format!("uint64_t {tmp} = (uint64_t)({val});"));
-        self.write_line(&format!("trace_reg_write(state, {idx}, {tmp});"));
-        if self.hot_regs.contains(&idx) {
-            let name = Self::abi_name(idx);
-            self.write_line(&format!("{name} = {tmp};"));
-        } else {
-            self.write_line(&format!("reg_write(state, {idx}, {tmp});"));
+        if self.mode.traces_values() {
+            let tmp = self.next_var();
+            self.write_line(&format!("uint64_t {tmp} = (uint64_t)({val});"));
+            self.write_line(&format!("trace_reg_write(state, {idx}, {tmp});"));
+            if self.hot_regs.contains(&idx) {
+                let name = Self::abi_name(idx);
+                self.write_line(&format!("{name} = {tmp};"));
+            } else {
+                self.write_line(&format!("reg_write(state, {idx}, {tmp});"));
+            }
+            return;
         }
+        self.write_reg_direct(idx, &format!("(uint64_t)({val})"));
     }
 
-    /// Write a register WITHOUT tracing (for phantom instructions).
-    pub fn write_reg_raw(&mut self, idx: u8, val: &str) {
+    fn write_reg_direct(&mut self, idx: u8, val: &str) {
         if idx == 0 {
             return;
         }
@@ -267,31 +284,27 @@ impl<'a> EmitContext<'a> {
         }
     }
 
-    fn read_mem_helper(width: u8, signed: bool, traced: bool) -> (&'static str, &'static str) {
-        let (raw_func, traced_func, var_ty) = match (width, signed) {
-            (1, false) => ("rd_mem_u8", "rd_mem_u8_traced", "uint32_t"),
-            (1, true) => ("rd_mem_i8", "rd_mem_i8_traced", "int32_t"),
-            (2, false) => ("rd_mem_u16", "rd_mem_u16_traced", "uint32_t"),
-            (2, true) => ("rd_mem_i16", "rd_mem_i16_traced", "int32_t"),
-            (4, false) => ("rd_mem_u32", "rd_mem_u32_traced", "uint32_t"),
-            (4, true) => ("rd_mem_i32", "rd_mem_i32_traced", "int32_t"),
-            (8, _) => ("rd_mem_u64", "rd_mem_u64_traced", "uint64_t"),
+    fn read_mem_helper(width: u8, signed: bool) -> (&'static str, &'static str, &'static str) {
+        match (width, signed) {
+            (1, false) => ("read_mem_u8", "trace_read_mem_u8", "uint32_t"),
+            (1, true) => ("read_mem_i8", "trace_read_mem_i8", "int32_t"),
+            (2, false) => ("read_mem_u16", "trace_read_mem_u16", "uint32_t"),
+            (2, true) => ("read_mem_i16", "trace_read_mem_i16", "int32_t"),
+            (4, false) => ("read_mem_u32", "trace_read_mem_u32", "uint32_t"),
+            (4, true) => ("read_mem_i32", "trace_read_mem_i32", "int32_t"),
+            (8, _) => ("read_mem_u64", "trace_read_mem_u64", "uint64_t"),
             _ => unreachable!("invalid memory width {width}"),
-        };
-        let func = if traced { traced_func } else { raw_func };
-        (func, var_ty)
+        }
     }
 
-    fn write_mem_helper(width: u8, traced: bool) -> (&'static str, &'static str) {
-        let (raw_func, traced_func, cast_ty) = match width {
-            1 => ("wr_mem_u8", "wr_mem_u8_traced", "uint8_t"),
-            2 => ("wr_mem_u16", "wr_mem_u16_traced", "uint16_t"),
-            4 => ("wr_mem_u32", "wr_mem_u32_traced", "uint32_t"),
-            8 => ("wr_mem_u64", "wr_mem_u64_traced", "uint64_t"),
+    fn write_mem_helper(width: u8) -> (&'static str, &'static str, &'static str) {
+        match width {
+            1 => ("write_mem_u8", "trace_write_mem_u8", "uint8_t"),
+            2 => ("write_mem_u16", "trace_write_mem_u16", "uint16_t"),
+            4 => ("write_mem_u32", "trace_write_mem_u32", "uint32_t"),
+            8 => ("write_mem_u64", "trace_write_mem_u64", "uint64_t"),
             _ => unreachable!("invalid memory width {width}"),
-        };
-        let func = if traced { traced_func } else { raw_func };
-        (func, cast_ty)
+        }
     }
 
     /// Read guest memory. Metered hot blocks record the memory page separately.
@@ -302,16 +315,13 @@ impl<'a> EmitContext<'a> {
         );
         let addr = Self::addr_expr(base, offset);
         let var = self.next_var();
-        let value_traced = self.mode.traces_memory_values();
-        let (data_func, var_ty) = Self::read_mem_helper(width, signed, value_traced);
-        let data_arg = if value_traced { "state" } else { "memory" };
-        if !value_traced {
-            self.uses_raw_memory = true;
-        }
+        let (read_func, trace_func, var_ty) = Self::read_mem_helper(width, signed);
+        self.uses_raw_memory = true;
 
-        self.write_line(&format!(
-            "{var_ty} {var} = {data_func}({data_arg}, {addr});"
-        ));
+        self.write_line(&format!("{var_ty} {var} = {read_func}(memory, {addr});"));
+        if self.mode.traces_values() {
+            self.write_line(&format!("{trace_func}(state, {addr}, {var});"));
+        }
         if self.mode.traces_memory_pages() {
             self.emit_inline_page_record(&addr, width);
         }
@@ -327,19 +337,22 @@ impl<'a> EmitContext<'a> {
             "metered memory write emitted without page tracking"
         );
         let addr = Self::addr_expr(base, offset);
-        let value_traced = self.mode.traces_memory_values();
-        let (wr_func, cast_ty) = Self::write_mem_helper(width, value_traced);
-        let data_arg = if value_traced { "state" } else { "memory" };
-        if !value_traced {
-            self.uses_raw_memory = true;
-        }
+        let (write_func, trace_func, cast_ty) = Self::write_mem_helper(width);
+        self.uses_raw_memory = true;
 
         if self.mode.traces_memory_pages() {
             self.emit_inline_page_record(&addr, width);
         }
-        self.write_line(&format!(
-            "{wr_func}({data_arg}, {addr}, ({cast_ty})({val}));"
-        ));
+        if self.mode.traces_values() {
+            let value = self.next_var();
+            self.write_line(&format!("{cast_ty} {value} = ({cast_ty})({val});"));
+            self.write_line(&format!("{trace_func}(state, {addr}, {value});"));
+            self.write_line(&format!("{write_func}(memory, {addr}, {value});"));
+        } else {
+            self.write_line(&format!(
+                "{write_func}(memory, {addr}, ({cast_ty})({val}));"
+            ));
+        }
     }
 
     fn emit_inline_page_record(&mut self, addr: &str, width: u8) {
@@ -364,11 +377,11 @@ impl<'a> EmitContext<'a> {
         }
     }
 
-    /// Emit a trace_pc call. Per-instruction chip accounting is rolled into
-    /// the per-block chip update emitted at block entry by
-    /// `CProject::emit_block_function`, not here.
+    /// Emit a PC read when value tracing is enabled.
     pub fn trace_pc(&mut self, pc: u64) {
-        self.write_line(&format!("trace_pc(state, 0x{pc:08x}ull);"));
+        if self.mode.traces_values() {
+            self.write_line(&format!("trace_pc(state, 0x{pc:08x}ull);"));
+        }
     }
 
     pub fn emit_call(&mut self, name: &str, args: &[&str]) {
@@ -440,29 +453,45 @@ impl<'a> EmitContext<'a> {
         self.write_line("}");
     }
 
-    pub fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {
-        let touches_memory = addr_space == RV64_MEMORY_AS;
-        if touches_memory {
-            self.flush_page_locals();
+    pub fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32) {
+        assert!(
+            !self.mode.traces_values(),
+            "page-only access is invalid when values are being traced"
+        );
+        if !matches!(self.mode, EmitMode::Metered { .. }) {
+            return;
         }
-        self.write_line(&format!("trace_mem_access(state, {addr}, {addr_space}u);"));
-        if touches_memory {
-            self.reload_page_locals();
-        }
-    }
-
-    pub fn trace_mem_access_u64_range(
-        &mut self,
-        base_addr: &str,
-        num_dwords: &str,
-        addr_space: u32,
-    ) {
         let touches_memory = addr_space == RV64_MEMORY_AS;
         if touches_memory {
             self.flush_page_locals();
         }
         self.write_line(&format!(
-            "trace_mem_access_u64_range(state, {base_addr}, {num_dwords}, {addr_space}u);"
+            "trace_page_access(state, {addr}, {size}u, {addr_space}u);"
+        ));
+        if touches_memory {
+            self.reload_page_locals();
+        }
+    }
+
+    pub fn trace_page_access_u64_range(
+        &mut self,
+        base_addr: &str,
+        num_dwords: &str,
+        addr_space: u32,
+    ) {
+        assert!(
+            !self.mode.traces_values(),
+            "page-only access is invalid when values are being traced"
+        );
+        if !matches!(self.mode, EmitMode::Metered { .. }) {
+            return;
+        }
+        let touches_memory = addr_space == RV64_MEMORY_AS;
+        if touches_memory {
+            self.flush_page_locals();
+        }
+        self.write_line(&format!(
+            "trace_page_access_u64_range(state, {base_addr}, {num_dwords}, {addr_space}u);"
         ));
         if touches_memory {
             self.reload_page_locals();
@@ -523,16 +552,12 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
         EmitContext::read_reg(self, idx)
     }
 
-    fn read_reg_raw(&mut self, idx: u8) -> String {
-        EmitContext::read_reg_raw(self, idx)
+    fn read_reg_execution_input(&mut self, idx: u8) -> String {
+        EmitContext::read_reg_execution_input(self, idx)
     }
 
     fn write_reg(&mut self, idx: u8, val: &str) {
         EmitContext::write_reg(self, idx, val)
-    }
-
-    fn write_reg_raw(&mut self, idx: u8, val: &str) {
-        EmitContext::write_reg_raw(self, idx, val)
     }
 
     fn write_line(&mut self, s: &str) {
@@ -580,12 +605,12 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
         EmitContext::trace_chip_if_nonzero(self, chip_idx, count_expr);
     }
 
-    fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {
-        EmitContext::trace_mem_access(self, addr, addr_space);
+    fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32) {
+        EmitContext::trace_page_access(self, addr, size, addr_space);
     }
 
-    fn trace_mem_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32) {
-        EmitContext::trace_mem_access_u64_range(self, base_addr, num_dwords, addr_space);
+    fn trace_page_access_u64_range(&mut self, base_addr: &str, num_dwords: &str, addr_space: u32) {
+        EmitContext::trace_page_access_u64_range(self, base_addr, num_dwords, addr_space);
     }
 }
 

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -188,7 +188,7 @@ pub struct CProject {
     pub blocks_per_partition: usize,
     /// Enable thin LTO for the generated C code.
     pub enable_lto: bool,
-    /// Per-PC primary chip index for emitted block-level row accounting.
+    /// Main chip index for each PC, used to count rows once per block.
     /// Index i = chip for PC = pc_base + i*4.
     /// `None` in pure mode (no chip metadata requested); must be set in metered modes.
     pub pc_to_chip: Option<Vec<TraceChipIndex>>,
@@ -196,7 +196,7 @@ pub struct CProject {
     pub pc_base: u64,
     /// Per-AIR widths for MeteredCost precomputation. Indexed by chip index.
     pub chip_widths: Option<Vec<u64>>,
-    /// Number of AIRs in metered artifacts. Emitted into the generated C ABI.
+    /// Number of AIRs written into a metered artifact's C ABI.
     pub num_airs: Option<u32>,
     /// Compile with native debug info (`-g -fno-omit-frame-pointer`).
     pub native_debug_info: bool,
@@ -325,15 +325,15 @@ impl CProject {
     }
 
     /// C function parameter list entries.
-    fn param_list_items(&self, include_names: bool) -> Vec<String> {
+    fn param_list_items(&self, include_names: bool, unused_trace_heights: bool) -> Vec<String> {
         let mut params = vec![if include_names {
-            "RvState* restrict state [[maybe_unused]]".to_string()
+            "RvState* restrict state".to_string()
         } else {
             "RvState* restrict".to_string()
         }];
         for &(_, name) in &self.sorted_hot_regs() {
             params.push(if include_names {
-                format!("uint64_t {name} [[maybe_unused]]")
+                format!("uint64_t {name}")
             } else {
                 "uint64_t".to_string()
             });
@@ -341,18 +341,23 @@ impl CProject {
         match self.block_abi() {
             BlockAbi::Plain => {}
             BlockAbi::InstretCountdown => params.push(if include_names {
-                "uint64_t instret_remaining [[maybe_unused]]".to_string()
+                "uint64_t instret_remaining".to_string()
             } else {
                 "uint64_t".to_string()
             }),
             BlockAbi::Metered => {
                 params.push(if include_names {
-                    "uint32_t check_counter [[maybe_unused]]".to_string()
+                    "uint32_t check_counter".to_string()
                 } else {
                     "uint32_t".to_string()
                 });
                 params.push(if include_names {
-                    "TraceHeights* restrict trace_heights [[maybe_unused]]".to_string()
+                    let attribute = if unused_trace_heights {
+                        " [[maybe_unused]]"
+                    } else {
+                        ""
+                    };
+                    format!("TraceHeights* restrict trace_heights{attribute}")
                 } else {
                     "TraceHeights* restrict".to_string()
                 });
@@ -361,8 +366,8 @@ impl CProject {
         params
     }
 
-    fn block_signature(&self, prefix: &str, name: &str) -> String {
-        let params = self.param_list_items(true);
+    fn function_signature(&self, prefix: &str, name: &str, unused_trace_heights: bool) -> String {
+        let params = self.param_list_items(true, unused_trace_heights);
         let mut out = format!("{prefix} {name}(\n");
         for (idx, param) in params.iter().enumerate() {
             let suffix = if idx + 1 == params.len() { "" } else { "," };
@@ -372,8 +377,12 @@ impl CProject {
         out
     }
 
+    fn block_signature(&self, prefix: &str, name: &str) -> String {
+        self.function_signature(prefix, name, false)
+    }
+
     fn trap_signature(&self) -> String {
-        self.block_signature("__attribute__((preserve_none, cold)) void", "rv_trap")
+        self.function_signature("__attribute__((preserve_none, cold)) void", "rv_trap", true)
     }
 
     fn emit_trap_declaration(&self, out: &mut String) {
@@ -410,7 +419,7 @@ impl CProject {
 
     /// C typedef parameter types: "RvState*, uint32_t, uint32_t".
     fn typedef_params(&self) -> String {
-        self.param_list_items(false).join(", ")
+        self.param_list_items(false, false).join(", ")
     }
 
     /// Call to save hot registers back to state before returning.
@@ -597,9 +606,6 @@ impl CProject {
             self.execution_kind.trace_header_filename()
         )
         .unwrap();
-        if self.execution_kind.metered_block_header_content().is_some() {
-            writeln!(openvm_h, "#include \"openvm_block.h\"").unwrap();
-        }
         writeln!(openvm_h, "#include \"openvm_io.h\"").unwrap();
         fs::write(self.output_dir.join("openvm.h"), openvm_h)?;
 
@@ -615,8 +621,7 @@ impl CProject {
         self.write_embedded_files(extensions.vendored_c_sources(), &mut created_dirs)?;
         self.write_embedded_files(extensions.extra_c_include_files(), &mut created_dirs)?;
 
-        // Write wrapper functions if any extensions are registered
-        if !extensions.is_empty() {
+        if extensions.uses_memory_wrappers() {
             self.write_ext_wrappers()?;
         }
 
@@ -662,9 +667,6 @@ impl CProject {
 
         // Mode-specific tracing helpers include openvm_state.h internally.
         writeln!(h, "#include \"{trace_header}\"").unwrap();
-        if self.execution_kind.metered_block_header_content().is_some() {
-            writeln!(h, "#include \"openvm_block.h\"").unwrap();
-        }
         writeln!(h).unwrap();
 
         // Block function type and dispatch table (for JumpDyn tail calls).
@@ -682,7 +684,7 @@ impl CProject {
             );
             writeln!(h, "{signature};").unwrap();
         }
-        // Hidden visibility keeps this cross-TU dispatch table non-interposable.
+        // Keep this table private to the library so the linker can address it directly.
         writeln!(
             h,
             "extern __attribute__((visibility(\"hidden\"))) BlockFn const dispatch_table[RV_DISPATCH_TABLE_SIZE];"
@@ -746,6 +748,9 @@ impl CProject {
             let first_pc = partition[0].start_pc;
             let mut src = String::with_capacity(64 * 1024);
             writeln!(src, "#include \"{name}.h\"").unwrap();
+            if self.execution_kind.metered_block_header_content().is_some() {
+                writeln!(src, "#include \"openvm_block.h\"").unwrap();
+            }
             writeln!(src).unwrap();
 
             for block in partition {
@@ -1258,11 +1263,8 @@ impl CProject {
             args.push(format!("VENDOR_SRCS={}", vendor_sources.join(" ")));
         }
         if !ext_staticlibs.is_empty() {
-            // `make` receives `VAR=value` assignments as single argv entries,
-            // but `$(EXT_LIBS)` and `$(EXT_CFLAGS)` are later expanded by
-            // splitting on spaces. Static library paths, `-I...` paths, and
-            // copied source filenames in `$(EXT_SRCS)` and `$(VENDOR_SRCS)`
-            // therefore must not contain spaces.
+            // Make expands these space-separated paths, so extension filenames
+            // cannot contain spaces.
             let libs: Vec<String> = ext_staticlibs
                 .iter()
                 .map(|p| p.display().to_string())
@@ -1390,7 +1392,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_kinds_have_distinct_markers_and_suffixes() {
+    fn execution_kinds_have_distinct_suffixes_and_round_trip_markers() {
         let kinds = [
             RvrExecutionKind::Pure,
             RvrExecutionKind::PureWithInstretTracking,
@@ -1398,10 +1400,8 @@ mod tests {
             RvrExecutionKind::Metered,
             RvrExecutionKind::MeteredSegment,
         ];
-        let mut markers = HashSet::new();
         let mut suffixes = HashSet::new();
         for kind in kinds {
-            assert!(markers.insert(kind as u32));
             assert!(suffixes.insert(kind.artifact_suffix()));
             assert_eq!(RvrExecutionKind::try_from(kind as u32), Ok(kind));
         }

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -1046,10 +1046,14 @@ impl CProject {
             }
             RvrExecutionKind::MeteredCost => {
                 let widths = self.chip_widths.as_ref().unwrap();
-                let total: u64 = chip_counts
-                    .iter()
-                    .map(|(&chip, &count)| widths[chip as usize] * count as u64)
-                    .sum();
+                let total = chip_counts.iter().fold(0u64, |total, (&chip, &count)| {
+                    let contribution = widths[chip as usize]
+                        .checked_mul(u64::from(count))
+                        .expect("per-block metered cost contribution overflow");
+                    total
+                        .checked_add(contribution)
+                        .expect("per-block metered cost total overflow")
+                });
                 if total > 0 {
                     writeln!(out, "        state->mode_state.cost += {total}ull;").unwrap();
                 }

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -12,7 +12,7 @@ use rvr_openvm_lift::{ExtensionRegistry, TraceChipIndex};
 
 use super::{
     codegen::{emit_terminator, InstrCodegen, TermCtx},
-    context::{BlockAbi, EmitContext, EmitMode},
+    context::{validate_chip_index, BlockAbi, EmitContext, EmitMode, InvalidChipIndex},
 };
 use crate::constants::constants_header;
 
@@ -755,7 +755,8 @@ impl CProject {
 
             for block in partition {
                 self.emit_block_checkpoint_function(&mut src, block);
-                self.emit_block_function(&mut src, block, &valid_blocks);
+                self.emit_block_function(&mut src, block, &valid_blocks)
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
             }
 
             let path = self.output_dir.join(format!("{name}_0x{first_pc:08x}.c"));
@@ -765,7 +766,12 @@ impl CProject {
         Ok(())
     }
 
-    fn emit_block_function(&self, out: &mut String, block: &Block, valid_blocks: &HashSet<u64>) {
+    fn emit_block_function(
+        &self,
+        out: &mut String,
+        block: &Block,
+        valid_blocks: &HashSet<u64>,
+    ) -> Result<(), InvalidChipIndex> {
         let pc = block.start_pc;
         let end_pc = self.block_end_pc(block);
         let insn_count = block.insn_count();
@@ -782,7 +788,13 @@ impl CProject {
             EmitMode::MeteredCost => self.chip_widths.as_deref(),
             _ => None,
         };
-        let mut ctx = EmitContext::new(self.hot_regs.clone(), mode, self.block_abi(), chip_widths);
+        let mut ctx = EmitContext::new(
+            self.hot_regs.clone(),
+            mode,
+            self.block_abi(),
+            chip_widths,
+            self.num_airs,
+        );
         let mut body = String::new();
 
         if matches!(
@@ -799,7 +811,7 @@ impl CProject {
         }
 
         self.emit_block_boundary(&mut body, block);
-        self.emit_per_block_chip_updates(&mut body, block);
+        self.emit_per_block_chip_updates(&mut body, block)?;
 
         for instr_at in &block.instructions {
             self.emit_source_annotation(
@@ -829,6 +841,10 @@ impl CProject {
         let tc = TermCtx { valid_blocks };
         emit_terminator(&mut ctx, &block.terminator, block.terminator_pc, &tc);
         Self::emit_context_scope(&mut body, &mut ctx);
+
+        if let Some(error) = ctx.invalid_chip_index() {
+            return Err(error);
+        }
 
         let self_tail_call = format!("return block_0x{pc:08x}(");
         let has_direct_self_tail_call = body.contains(&self_tail_call);
@@ -860,6 +876,7 @@ impl CProject {
             writeln!(out, "#pragma clang diagnostic pop").unwrap();
         }
         writeln!(out).unwrap();
+        Ok(())
     }
 
     fn emit_block_checkpoint_function(&self, out: &mut String, block: &Block) {
@@ -999,46 +1016,57 @@ impl CProject {
     ///   - MeteredCost: `state->mode_state.cost += <constant>;` where the constant is
     ///     `sum(width[chip]
     ///     * count)` precomputed at emit time from `self.chip_widths`.
-    fn emit_per_block_chip_updates(&self, out: &mut String, block: &Block) {
+    fn emit_per_block_chip_updates(
+        &self,
+        out: &mut String,
+        block: &Block,
+    ) -> Result<(), InvalidChipIndex> {
         if matches!(
             self.execution_kind,
             RvrExecutionKind::Pure | RvrExecutionKind::PureWithInstretTracking
         ) {
-            return;
+            return Ok(());
         }
 
+        let num_airs = self
+            .num_airs
+            .expect("metered code generation requires the AIR count");
         let mut chip_counts: BTreeMap<u32, u32> = BTreeMap::new();
         let add_rows = |chip_counts: &mut BTreeMap<u32, u32>, chip_idx, count| {
+            validate_chip_index(chip_idx, num_airs)?;
             let current = chip_counts.entry(chip_idx).or_default();
             *current = current
                 .checked_add(count)
                 .expect("per-block trace-height increment overflow");
+            Ok::<(), InvalidChipIndex>(())
         };
         let add_base_row = |chip_counts: &mut BTreeMap<u32, u32>, pc: u64| {
             if let TraceChipIndex::Chip(chip) = self.chip_idx_for_pc(pc) {
-                add_rows(chip_counts, chip.as_u32(), 1);
+                add_rows(chip_counts, chip.as_u32(), 1)?;
             }
+            Ok::<(), InvalidChipIndex>(())
         };
         let add_extension_rows = |chip_counts: &mut BTreeMap<u32, u32>,
                                   extension: &dyn ExtInstr| {
             for rows in extension.fixed_trace_rows() {
-                add_rows(chip_counts, rows.chip_idx, rows.count);
+                add_rows(chip_counts, rows.chip_idx, rows.count)?;
             }
+            Ok::<(), InvalidChipIndex>(())
         };
         for instr_at in &block.instructions {
-            add_base_row(&mut chip_counts, instr_at.pc);
+            add_base_row(&mut chip_counts, instr_at.pc)?;
             if let Instr::Ext(extension) = &instr_at.instr {
-                add_extension_rows(&mut chip_counts, extension.as_ref());
+                add_extension_rows(&mut chip_counts, extension.as_ref())?;
             }
         }
         if !matches!(block.terminator, Terminator::FallThrough) {
-            add_base_row(&mut chip_counts, block.terminator_pc);
+            add_base_row(&mut chip_counts, block.terminator_pc)?;
             if let Terminator::Extension(extension) = &block.terminator {
-                add_extension_rows(&mut chip_counts, extension.as_ref());
+                add_extension_rows(&mut chip_counts, extension.as_ref())?;
             }
         }
         if chip_counts.is_empty() {
-            return;
+            return Ok(());
         }
 
         writeln!(out, "    {{").unwrap();
@@ -1065,6 +1093,7 @@ impl CProject {
             }
         }
         writeln!(out, "    }}").unwrap();
+        Ok(())
     }
 
     /// Emit PC/opname comment and `#line` directive for source attribution.
@@ -1305,7 +1334,7 @@ fn block_accesses_memory(block: &Block) -> bool {
 mod tests {
     use std::{collections::HashSet, path::Path};
 
-    use rvr_openvm_ir::{Block, Terminator};
+    use rvr_openvm_ir::{Block, ExtEmitCtx, ExtInstr, Instr, InstrAt, Terminator};
 
     use super::{CProject, RvrExecutionKind};
 
@@ -1317,6 +1346,19 @@ mod tests {
             terminator: Terminator::Exit { code: 0 },
             terminator_pc: 0x100,
             terminator_source_loc: None,
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct InvalidTraceChipInstr;
+
+    impl ExtInstr for InvalidTraceChipInstr {
+        fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+            ctx.trace_chip(1, "1u");
+        }
+
+        fn clone_box(&self) -> Box<dyn ExtInstr> {
+            Box::new(self.clone())
         }
     }
 
@@ -1379,6 +1421,35 @@ mod tests {
         let error = project.validate_block_abi().unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
         assert!(error.to_string().contains("preserve_none supports"));
+    }
+
+    #[test]
+    fn metered_codegen_rejects_extension_chip_outside_air_count() {
+        let mut project = CProject::new(Path::new("unused"), "test", RvrExecutionKind::Metered);
+        project.pc_base = 0x100;
+        project.num_airs = Some(1);
+        project.pc_to_chip = Some(vec![
+            rvr_openvm_lift::TraceChipIndex::NoChip,
+            rvr_openvm_lift::TraceChipIndex::NoChip,
+        ]);
+        let block = Block {
+            start_pc: 0x100,
+            end_pc: 0x108,
+            instructions: vec![InstrAt {
+                pc: 0x100,
+                instr: Instr::Ext(Box::new(InvalidTraceChipInstr)),
+                source_loc: None,
+            }],
+            terminator: Terminator::Exit { code: 0 },
+            terminator_pc: 0x104,
+            terminator_source_loc: None,
+        };
+
+        let error = project
+            .emit_block_function(&mut String::new(), &block, &HashSet::new())
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "chip index 1 is outside AIR count 1");
     }
 
     #[test]

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -107,7 +107,6 @@ impl RvrExecutionKind {
                 writeln!(out, "typedef struct MeteredCostState {{").unwrap();
                 writeln!(out, "  uint64_t instret;").unwrap();
                 writeln!(out, "  uint64_t cost;").unwrap();
-                writeln!(out, "  const uint64_t* chip_widths;").unwrap();
                 writeln!(out, "}} MeteredCostState;").unwrap();
             }
             Self::Metered | Self::MeteredSegment => {
@@ -189,7 +188,7 @@ pub struct CProject {
     pub blocks_per_partition: usize,
     /// Enable thin LTO for the generated C code.
     pub enable_lto: bool,
-    /// Per-PC chip index for hardcoded trace_chip calls.
+    /// Per-PC primary chip index for emitted block-level row accounting.
     /// Index i = chip for PC = pc_base + i*4.
     /// `None` in pure mode (no chip metadata requested); must be set in metered modes.
     pub pc_to_chip: Option<Vec<TraceChipIndex>>,
@@ -454,9 +453,8 @@ impl CProject {
             RvrExecutionKind::Metered | RvrExecutionKind::MeteredSegment => EmitMode::Metered {
                 trace_memory_pages: block_accesses_memory(block),
             },
-            RvrExecutionKind::Pure
-            | RvrExecutionKind::PureWithInstretTracking
-            | RvrExecutionKind::MeteredCost => EmitMode::Direct,
+            RvrExecutionKind::MeteredCost => EmitMode::MeteredCost,
+            RvrExecutionKind::Pure | RvrExecutionKind::PureWithInstretTracking => EmitMode::Direct,
         }
     }
 
@@ -684,7 +682,12 @@ impl CProject {
             );
             writeln!(h, "{signature};").unwrap();
         }
-        writeln!(h, "extern BlockFn dispatch_table[RV_DISPATCH_TABLE_SIZE];").unwrap();
+        // Hidden visibility keeps this cross-TU dispatch table non-interposable.
+        writeln!(
+            h,
+            "extern __attribute__((visibility(\"hidden\"))) BlockFn const dispatch_table[RV_DISPATCH_TABLE_SIZE];"
+        )
+        .unwrap();
         writeln!(h).unwrap();
 
         // Block function declarations.
@@ -770,7 +773,11 @@ impl CProject {
         )
         .unwrap();
         // Body instructions (each in its own scope to avoid variable collisions).
-        let mut ctx = EmitContext::new(self.hot_regs.clone(), mode, self.block_abi());
+        let chip_widths = match mode {
+            EmitMode::MeteredCost => self.chip_widths.as_deref(),
+            _ => None,
+        };
+        let mut ctx = EmitContext::new(self.hot_regs.clone(), mode, self.block_abi(), chip_widths);
         let mut body = String::new();
 
         if matches!(
@@ -996,15 +1003,34 @@ impl CProject {
         }
 
         let mut chip_counts: BTreeMap<u32, u32> = BTreeMap::new();
-        let mut increment_chip_count = |pc: u64| match self.chip_idx_for_pc(pc) {
-            TraceChipIndex::Chip(chip) => *chip_counts.entry(chip.as_u32()).or_insert(0) += 1,
-            TraceChipIndex::NoChip => {}
+        let add_rows = |chip_counts: &mut BTreeMap<u32, u32>, chip_idx, count| {
+            let current = chip_counts.entry(chip_idx).or_default();
+            *current = current
+                .checked_add(count)
+                .expect("per-block trace-height increment overflow");
+        };
+        let add_base_row = |chip_counts: &mut BTreeMap<u32, u32>, pc: u64| {
+            if let TraceChipIndex::Chip(chip) = self.chip_idx_for_pc(pc) {
+                add_rows(chip_counts, chip.as_u32(), 1);
+            }
+        };
+        let add_extension_rows = |chip_counts: &mut BTreeMap<u32, u32>,
+                                  extension: &dyn ExtInstr| {
+            for rows in extension.fixed_trace_rows() {
+                add_rows(chip_counts, rows.chip_idx, rows.count);
+            }
         };
         for instr_at in &block.instructions {
-            increment_chip_count(instr_at.pc);
+            add_base_row(&mut chip_counts, instr_at.pc);
+            if let Instr::Ext(extension) = &instr_at.instr {
+                add_extension_rows(&mut chip_counts, extension.as_ref());
+            }
         }
         if !matches!(block.terminator, Terminator::FallThrough) {
-            increment_chip_count(block.terminator_pc);
+            add_base_row(&mut chip_counts, block.terminator_pc);
+            if let Terminator::Extension(extension) = &block.terminator {
+                add_extension_rows(&mut chip_counts, extension.as_ref());
+            }
         }
         if chip_counts.is_empty() {
             return;
@@ -1025,7 +1051,7 @@ impl CProject {
                     .map(|(&chip, &count)| widths[chip as usize] * count as u64)
                     .sum();
                 if total > 0 {
-                    writeln!(out, "        state->mode_state.cost += {total}u;").unwrap();
+                    writeln!(out, "        state->mode_state.cost += {total}ull;").unwrap();
                 }
             }
         }
@@ -1116,7 +1142,11 @@ impl CProject {
         let block_starts: std::collections::HashMap<u64, u64> =
             blocks.iter().map(|b| (b.start_pc, b.start_pc)).collect();
 
-        writeln!(src, "BlockFn dispatch_table[RV_DISPATCH_TABLE_SIZE] = {{").unwrap();
+        writeln!(
+            src,
+            "BlockFn const dispatch_table[RV_DISPATCH_TABLE_SIZE] = {{"
+        )
+        .unwrap();
         for i in 0..table_size {
             let pc = text_start + (i as u64) * 4;
             if block_starts.contains_key(&pc) {
@@ -1136,6 +1166,27 @@ impl CProject {
             writeln!(src, "__attribute__((visibility(\"default\"), used))").unwrap();
             writeln!(src, "uint32_t rv_num_airs(void) {{").unwrap();
             writeln!(src, "    return RV_NUM_AIRS;").unwrap();
+            writeln!(src, "}}").unwrap();
+            writeln!(src).unwrap();
+        }
+        if self.execution_kind == RvrExecutionKind::MeteredCost {
+            let widths = self
+                .chip_widths
+                .as_ref()
+                .expect("metered-cost artifact requires chip widths");
+            writeln!(
+                src,
+                "static constexpr uint64_t RV_CHIP_WIDTHS[RV_NUM_AIRS] = {{"
+            )
+            .unwrap();
+            for width in widths {
+                writeln!(src, "    {width}ull,").unwrap();
+            }
+            writeln!(src, "}};").unwrap();
+            writeln!(src, "const uint64_t* rv_chip_widths(void);").unwrap();
+            writeln!(src, "__attribute__((visibility(\"default\"), used))").unwrap();
+            writeln!(src, "const uint64_t* rv_chip_widths(void) {{").unwrap();
+            writeln!(src, "    return RV_CHIP_WIDTHS;").unwrap();
             writeln!(src, "}}").unwrap();
             writeln!(src).unwrap();
         }

--- a/crates/rvr/rvr-state/src/state.rs
+++ b/crates/rvr/rvr-state/src/state.rs
@@ -23,7 +23,7 @@ pub struct RvState<ModeState = ()> {
     pub pc: u64,
     pub status: u8,
     pub exit_code: u8,
-    /// Keeps `memory` naturally aligned and makes the shared Rust/C layout explicit.
+    /// Keeps `memory` aligned and matches the C layout.
     pub padding: [u8; 6],
     pub memory: *mut u8,
     pub mode_state: ModeState,

--- a/crates/toolchain/platform/src/lib.rs
+++ b/crates/toolchain/platform/src/lib.rs
@@ -20,13 +20,7 @@ pub mod rust_rt;
 
 /// Size of a zkVM machine word in bytes.
 /// 8 bytes (i.e. 64 bits) as the zkVM is an implementation of the rv64im ISA.
-pub const WORD_SIZE_U32: u32 = u64::BITS / 8;
-/// `usize` form for array lengths and indexing.
-pub const WORD_SIZE: usize = WORD_SIZE_U32 as usize;
-
-// OpenVM targets support at least 32-bit pointers, so VM indices and counts
-// represented as u32 can be converted to usize without truncation.
-const _: () = assert!(usize::BITS >= u32::BITS);
+pub const WORD_SIZE: usize = core::mem::size_of::<u64>();
 
 /// Standard IO file descriptors for use with sys_read and sys_write.
 pub mod fileno {

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -56,11 +56,11 @@ pub enum ExecutionError {
     HintOutOfBounds { pc: u32 },
     #[error("at pc {pc}, hint buffer num_words is zero")]
     HintBufferZeroWords { pc: u32 },
-    #[error("at pc {pc}, hint buffer num_words {num_words} exceeds MAX_HINT_BUFFER_WORDS {max_hint_buffer_words}")]
+    #[error("at pc {pc}, hint buffer num_words {num_words} exceeds MAX_HINT_BUFFER_DWORDS {max_hint_buffer_words}")]
     HintBufferTooLarge {
         pc: u32,
         num_words: u64,
-        max_hint_buffer_words: u32,
+        max_hint_buffer_words: u64,
     },
     #[error("at pc {pc}, tried to publish into index {public_value_index} when num_public_values = {num_public_values}")]
     PublicValueIndexOutOfBounds {

--- a/crates/vm/src/arch/hint_stream.rs
+++ b/crates/vm/src/arch/hint_stream.rs
@@ -58,8 +58,9 @@ impl HintStream {
         len: usize,
         bytes: impl IntoIterator<Item = u8>,
     ) -> Result<(), TryReserveError> {
+        let additional = len.saturating_sub(self.bytes.len());
+        self.bytes.try_reserve(additional)?;
         self.clear();
-        self.bytes.try_reserve(len)?;
         self.bytes.extend(bytes);
         Ok(())
     }

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -252,9 +252,9 @@ pub enum CompileError {
     ChipMappingLengthMismatch { expected: usize, actual: usize },
     #[error("chip index {chip_idx} at pc {pc:#x} is outside the {num_airs} AIRs")]
     ChipIndexOutOfBounds {
-        pc: u64,
+        pc: u32,
         chip_idx: u32,
-        num_airs: usize,
+        num_airs: u32,
     },
     #[error("invalid compile options: {0}")]
     InvalidOptions(&'static str),
@@ -273,6 +273,15 @@ pub struct ChipMapping {
     pub chip_widths: Option<Vec<u64>>,
 }
 
+fn pc_for_instruction_index(pc_base: u32, instruction_index: usize) -> Result<u32, CompileError> {
+    let instruction_index_u32 = u32::try_from(instruction_index)
+        .map_err(|_| CompileError::ProgramCounterOutOfBounds { instruction_index })?;
+    instruction_index_u32
+        .checked_mul(DEFAULT_PC_STEP)
+        .and_then(|offset| pc_base.checked_add(offset))
+        .ok_or(CompileError::ProgramCounterOutOfBounds { instruction_index })
+}
+
 pub fn build_pc_to_chip<F, E>(
     exe: &VmExe<F>,
     inventory: &ExecutorInventory<E>,
@@ -284,16 +293,7 @@ pub fn build_pc_to_chip<F, E>(
         .iter()
         .enumerate()
         .map(|(i, slot)| {
-            let instruction_index =
-                u32::try_from(i).map_err(|_| CompileError::ProgramCounterOutOfBounds {
-                    instruction_index: i,
-                })?;
-            let pc = instruction_index
-                .checked_mul(DEFAULT_PC_STEP)
-                .and_then(|offset| exe.program.pc_base.checked_add(offset))
-                .ok_or(CompileError::ProgramCounterOutOfBounds {
-                    instruction_index: i,
-                })?;
+            let pc = pc_for_instruction_index(exe.program.pc_base, i)?;
             let Some((inst, _)) = slot else {
                 return Ok(TraceChipIndex::NoChip);
             };
@@ -544,16 +544,16 @@ fn compile_impl<F: PrimeField32>(
             let chips = opts.chips.ok_or(CompileError::InvalidOptions(
                 "metered rvr compile requires ChipMapping",
             ))?;
-            project.num_airs = Some(u32::try_from(chips.num_airs).map_err(|_| {
-                CompileError::AirCountOutOfBounds {
+            let num_airs =
+                u32::try_from(chips.num_airs).map_err(|_| CompileError::AirCountOutOfBounds {
                     num_airs: chips.num_airs,
-                }
-            })?);
-            if project.num_airs == Some(0) {
+                })?;
+            if num_airs == 0 {
                 return Err(CompileError::InvalidOptions(
                     "metered rvr compile requires at least one AIR",
                 ));
             }
+            project.num_airs = Some(num_airs);
             let expected_slots = exe.program.instructions_and_debug_infos.len();
             if chips.pc_to_chip.len() != expected_slots {
                 return Err(CompileError::ChipMappingLengthMismatch {
@@ -565,12 +565,11 @@ fn compile_impl<F: PrimeField32>(
                 let TraceChipIndex::Chip(chip) = chip else {
                     continue;
                 };
-                if chip.as_u32() as usize >= chips.num_airs {
+                if chip.as_u32() >= num_airs {
                     return Err(CompileError::ChipIndexOutOfBounds {
-                        pc: u64::from(exe.program.pc_base)
-                            + slot as u64 * u64::from(DEFAULT_PC_STEP),
+                        pc: pc_for_instruction_index(exe.program.pc_base, slot)?,
                         chip_idx: chip.as_u32(),
-                        num_airs: chips.num_airs,
+                        num_airs,
                     });
                 }
             }

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -31,7 +31,7 @@ pub struct RvrCompiled {
     artifact_dir: Option<ArtifactDir>,
     /// Generated state, tracing, and block ABI family baked into this artifact.
     execution_kind: RvrExecutionKind,
-    /// Number of AIRs baked into metered artifacts.
+    /// Number of AIRs stored in a metered artifact.
     num_airs: Option<u32>,
 }
 
@@ -71,7 +71,7 @@ impl RvrCompiled {
         )))
     }
 
-    /// Verify the exact chip widths specialized into a metered-cost artifact.
+    /// Check that a metered-cost artifact contains the expected chip widths.
     pub(crate) fn require_chip_widths(&self, expected: &[usize]) -> Result<(), CompileError> {
         self.require_execution_kind(&[RvrExecutionKind::MeteredCost])?;
         let num_airs = self.num_airs.ok_or_else(|| {
@@ -104,8 +104,8 @@ impl RvrCompiled {
                 "rv_chip_widths marker returned null".to_string(),
             ));
         }
-        // SAFETY: the artifact exports a static RV_NUM_AIRS-element array, and
-        // its declared AIR count was checked against `expected` above.
+        // SAFETY: the symbol points to `RV_NUM_AIRS` elements, and that count
+        // was checked against `expected` above.
         let actual = unsafe { std::slice::from_raw_parts(actual_ptr, num_airs) };
         for (chip_idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
             let expected = u64::try_from(expected).map_err(|_| {
@@ -248,6 +248,14 @@ pub enum CompileError {
     AirIndexOutOfBounds { pc: u32, air_idx: usize },
     #[error("AIR count {num_airs} exceeds the generated C u32 domain")]
     AirCountOutOfBounds { num_airs: usize },
+    #[error("chip mapping has {actual} entries, but the program has {expected} instruction slots")]
+    ChipMappingLengthMismatch { expected: usize, actual: usize },
+    #[error("chip index {chip_idx} at pc {pc:#x} is outside the {num_airs} AIRs")]
+    ChipIndexOutOfBounds {
+        pc: u64,
+        chip_idx: u32,
+        num_airs: usize,
+    },
     #[error("invalid compile options: {0}")]
     InvalidOptions(&'static str),
 }
@@ -259,9 +267,9 @@ pub struct ChipMapping {
     pub num_airs: usize,
     /// Per-PC chip index. Index i = chip for PC = pc_base + i*4.
     pub pc_to_chip: Vec<TraceChipIndex>,
-    /// Per-AIR widths (MeteredCost mode only). The emitter specializes these
-    /// into cost updates and records them as artifact metadata for load-time
-    /// compatibility validation. Generated execution performs no table lookup.
+    /// Width of each AIR in metered-cost mode. The generator writes each width
+    /// into its cost update and stores the list in the artifact for validation
+    /// when it is loaded. Execution does not look up widths at runtime.
     pub chip_widths: Option<Vec<u64>>,
 }
 
@@ -545,6 +553,26 @@ fn compile_impl<F: PrimeField32>(
                 return Err(CompileError::InvalidOptions(
                     "metered rvr compile requires at least one AIR",
                 ));
+            }
+            let expected_slots = exe.program.instructions_and_debug_infos.len();
+            if chips.pc_to_chip.len() != expected_slots {
+                return Err(CompileError::ChipMappingLengthMismatch {
+                    expected: expected_slots,
+                    actual: chips.pc_to_chip.len(),
+                });
+            }
+            for (slot, chip) in chips.pc_to_chip.iter().copied().enumerate() {
+                let TraceChipIndex::Chip(chip) = chip else {
+                    continue;
+                };
+                if chip.as_u32() as usize >= chips.num_airs {
+                    return Err(CompileError::ChipIndexOutOfBounds {
+                        pc: u64::from(exe.program.pc_base)
+                            + slot as u64 * u64::from(DEFAULT_PC_STEP),
+                        chip_idx: chip.as_u32(),
+                        num_airs: chips.num_airs,
+                    });
+                }
             }
             project.pc_to_chip = Some(chips.pc_to_chip.clone());
             project.chip_widths = chips.chip_widths.clone();

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -71,6 +71,57 @@ impl RvrCompiled {
         )))
     }
 
+    /// Verify the exact chip widths specialized into a metered-cost artifact.
+    pub(crate) fn require_chip_widths(&self, expected: &[usize]) -> Result<(), CompileError> {
+        self.require_execution_kind(&[RvrExecutionKind::MeteredCost])?;
+        let num_airs = self.num_airs.ok_or_else(|| {
+            CompileError::LibLoad(
+                "compiled metered-cost artifact does not declare its AIR count".to_string(),
+            )
+        })? as usize;
+        if expected.len() != num_airs {
+            return Err(CompileError::LibLoad(format!(
+                "chip-width table has {} entries, but the compiled artifact expects {num_airs}",
+                expected.len()
+            )));
+        }
+
+        type ChipWidthsFn = unsafe extern "C" fn() -> *const u64;
+        let chip_widths_fn: ChipWidthsFn = unsafe {
+            *self
+                .lib
+                .get::<ChipWidthsFn>(b"rv_chip_widths")
+                .map_err(|error| {
+                    CompileError::LibLoad(format!(
+                        "missing metered-cost rv_chip_widths marker: {error}"
+                    ))
+                })?
+        };
+        // SAFETY: the loaded symbol has the declared zero-argument C ABI.
+        let actual_ptr = unsafe { chip_widths_fn() };
+        if actual_ptr.is_null() {
+            return Err(CompileError::LibLoad(
+                "rv_chip_widths marker returned null".to_string(),
+            ));
+        }
+        // SAFETY: the artifact exports a static RV_NUM_AIRS-element array, and
+        // its declared AIR count was checked against `expected` above.
+        let actual = unsafe { std::slice::from_raw_parts(actual_ptr, num_airs) };
+        for (chip_idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+            let expected = u64::try_from(expected).map_err(|_| {
+                CompileError::LibLoad(format!(
+                    "chip width at AIR {chip_idx} exceeds the artifact u64 domain"
+                ))
+            })?;
+            if actual != expected {
+                return Err(CompileError::LibLoad(format!(
+                    "chip width mismatch at AIR {chip_idx}: artifact has {actual}, current VM has {expected}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Path to the directory holding generated C sources and build artifacts,
     /// if this library was compiled (rather than loaded from an existing path).
     /// Valid while the returned [`RvrCompiled`] is alive.
@@ -208,10 +259,9 @@ pub struct ChipMapping {
     pub num_airs: usize,
     /// Per-PC chip index. Index i = chip for PC = pc_base + i*4.
     pub pc_to_chip: Vec<TraceChipIndex>,
-    /// Per-AIR widths (MeteredCost mode only). When present, the emitter
-    /// precomputes `sum(width[chip] * count)` per block so the generated C
-    /// increments `cost` by a single constant instead of loading from the
-    /// `chip_widths` array at runtime.
+    /// Per-AIR widths (MeteredCost mode only). The emitter specializes these
+    /// into cost updates and records them as artifact metadata for load-time
+    /// compatibility validation. Generated execution performs no table lookup.
     pub chip_widths: Option<Vec<u64>>,
 }
 
@@ -498,6 +548,32 @@ fn compile_impl<F: PrimeField32>(
             }
             project.pc_to_chip = Some(chips.pc_to_chip.clone());
             project.chip_widths = chips.chip_widths.clone();
+            match opts.execution_kind {
+                RvrExecutionKind::MeteredCost => {
+                    let widths =
+                        project
+                            .chip_widths
+                            .as_ref()
+                            .ok_or(CompileError::InvalidOptions(
+                                "metered-cost rvr compile requires chip widths",
+                            ))?;
+                    if widths.len() != chips.num_airs {
+                        return Err(CompileError::InvalidOptions(
+                            "metered-cost chip widths must match the AIR count",
+                        ));
+                    }
+                }
+                RvrExecutionKind::Metered | RvrExecutionKind::MeteredSegment => {
+                    if project.chip_widths.is_some() {
+                        return Err(CompileError::InvalidOptions(
+                            "per-chip metered rvr compile does not use chip widths",
+                        ));
+                    }
+                }
+                RvrExecutionKind::Pure | RvrExecutionKind::PureWithInstretTracking => {
+                    unreachable!()
+                }
+            }
         }
     }
 

--- a/crates/vm/src/arch/rvr/execute.rs
+++ b/crates/vm/src/arch/rvr/execute.rs
@@ -288,16 +288,13 @@ pub(super) fn execute_metered_cost(
     compiled: &RvrCompiled,
     runtime_hooks: &[Box<dyn RvrRuntimeExtension>],
     vm_state: &mut VmState<GuestMemory>,
-    widths: &[u64],
 ) -> Result<RvrMeteredCostResult, ExecuteError> {
     require_execution_kind(compiled, "MeteredCost", &[RvrExecutionKind::MeteredCost])?;
-    require_num_airs(compiled, widths.len(), "chip-width table")?;
     let pc = vm_state.pc();
     let initial_regs = read_rv64_registers(vm_state);
 
     let mut state: MeteredCostRvState = init_rvr_state(vm_state, pc);
     state.regs = initial_regs;
-    state.mode_state.chip_widths = widths.as_ptr();
 
     run_and_finalize(compiled, runtime_hooks, vm_state, &mut state, false)
         .inspect_err(|error| tracing::warn!(%error, "rvr metered-cost execution failed"))?;

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -23,8 +23,8 @@ pub struct OpenVmIoState<'a> {
     pub deferrals: &'a mut Vec<DeferralState>,
 }
 
-/// Convert an RV64 memory range to host indices if it fits within AS_MEMORY
-/// (`MEM_SIZE` bytes).
+/// Return host indices for an RV64 range that fits in `AS_MEMORY` (`MEM_SIZE`
+/// bytes).
 #[cfg(not(feature = "unprotected"))]
 #[inline(always)]
 pub fn checked_mem_bounds_range(start: u64, num_bytes: u64) -> Option<Range<usize>> {
@@ -52,5 +52,28 @@ pub unsafe extern "C" fn host_hint_stream_set(ctx: *mut c_void, data: *const u8,
         io.hint_stream.set_hint_from_slice(slice);
     } else {
         io.hint_stream.clear();
+    }
+}
+
+#[cfg(all(test, not(feature = "unprotected")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_memory_range_accepts_end_boundary() {
+        assert_eq!(
+            checked_mem_bounds_range(MEM_SIZE as u64 - 8, 8),
+            Some(MEM_SIZE - 8..MEM_SIZE)
+        );
+        assert_eq!(
+            checked_mem_bounds_range(MEM_SIZE as u64, 0),
+            Some(MEM_SIZE..MEM_SIZE)
+        );
+    }
+
+    #[test]
+    fn checked_memory_range_rejects_out_of_bounds_and_overflow() {
+        assert_eq!(checked_mem_bounds_range(MEM_SIZE as u64, 1), None);
+        assert_eq!(checked_mem_bounds_range(u64::MAX, 1), None);
     }
 }

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -75,7 +75,7 @@ pub struct MeteringState {
     pub check_counter: u32,
     /// Dedup cache for AS_MEMORY pages. `u32::MAX` = none. Reset on flush.
     pub last_mem_page: u32,
-    /// Fills the otherwise implicit tail padding required by the struct's pointer alignment.
+    /// Explicit tail padding that keeps the Rust and C layouts the same.
     pub padding: u32,
 }
 

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -24,9 +24,6 @@ pub struct RvrMeteredCostInstance<'a> {
     pub(crate) initial_image: RvrInitialImage,
     pub(crate) runtime_hooks: Vec<Box<dyn RvrRuntimeExtension>>,
     pub(crate) compiled: RvrCompiled,
-    /// Must match the widths baked into `compiled` so per-block constants and
-    /// extension `trace_chip` calls compute cost against the same values.
-    pub(crate) widths: Vec<u64>,
 }
 
 /// C-compatible state for metered-cost execution.
@@ -37,7 +34,6 @@ pub struct RvrMeteredCostInstance<'a> {
 pub struct MeteredCostState {
     pub instret: u64,
     pub cost: u64,
-    pub chip_widths: *const u64,
 }
 
 impl Default for MeteredCostState {
@@ -45,7 +41,6 @@ impl Default for MeteredCostState {
         Self {
             instret: 0,
             cost: 0,
-            chip_widths: std::ptr::null(),
         }
     }
 }
@@ -80,14 +75,7 @@ impl RvrMeteredCostInstance<'_> {
         #[cfg(feature = "metrics")]
         let metrics = ExecutionMetricTimer::start(ExecutionMetric::MeteredCost);
         let result = tracing::info_span!("execute_metered_cost")
-            .in_scope(|| {
-                execute_metered_cost(
-                    &self.compiled,
-                    &self.runtime_hooks,
-                    &mut vm_state,
-                    &self.widths,
-                )
-            })
+            .in_scope(|| execute_metered_cost(&self.compiled, &self.runtime_hooks, &mut vm_state))
             .map_err(map_rvr_execute_error)?;
         #[cfg(feature = "metrics")]
         {

--- a/crates/vm/src/arch/rvr/metered_cost.rs
+++ b/crates/vm/src/arch/rvr/metered_cost.rs
@@ -30,19 +30,10 @@ pub struct RvrMeteredCostInstance<'a> {
 ///
 /// Layout must exactly match the generated C `MeteredCostState` struct.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct MeteredCostState {
     pub instret: u64,
     pub cost: u64,
-}
-
-impl Default for MeteredCostState {
-    fn default() -> Self {
-        Self {
-            instret: 0,
-            cost: 0,
-        }
-    }
 }
 
 impl RvrMeteredCostInstance<'_> {

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -533,8 +533,8 @@ where
     }
 
     /// Load a previously saved metered-cost-mode artifact. Its generated
-    /// execution kind is validated; the caller supplies matching `exe`,
-    /// `executor_idx_to_air_idx`, and `widths`.
+    /// execution kind and emitted chip widths are validated; the caller
+    /// supplies matching `exe`, `executor_idx_to_air_idx`, and `widths`.
     pub fn load_metered_cost_instance(
         &self,
         lib_path: &std::path::Path,
@@ -542,21 +542,19 @@ where
         executor_idx_to_air_idx: &[usize],
         widths: &[usize],
     ) -> Result<RvrMeteredCostInstance<'_>, StaticProgramError> {
+        let compiled = load_compiled_from_path(lib_path).map_err(map_rvr_compile_error)?;
+        compiled
+            .require_chip_widths(widths)
+            .map_err(map_rvr_compile_error)?;
         let runtime_hooks = self
             .build_rvr_extensions(Some(executor_idx_to_air_idx))
             .into_runtime_hooks();
-        let widths: Vec<u64> = widths.iter().map(|&w| w as u64).collect();
-        let compiled = load_compiled_from_path(lib_path).map_err(map_rvr_compile_error)?;
-        compiled
-            .require_execution_kind(&[RvrExecutionKind::MeteredCost])
-            .map_err(map_rvr_compile_error)?;
 
         Ok(RvrMeteredCostInstance {
             system_config: self.inventory.config(),
             initial_image: RvrInitialImage::from(exe),
             runtime_hooks,
             compiled,
-            widths,
         })
     }
 
@@ -571,12 +569,12 @@ where
         let _compilation_span =
             tracing::info_span!("compile_metered_cost", backend = "rvr").entered();
         let extensions = self.build_rvr_extensions(Some(executor_idx_to_air_idx));
-        let widths: Vec<u64> = widths.iter().map(|&w| w as u64).collect();
+        let emitted_widths: Vec<u64> = widths.iter().map(|&width| width as u64).collect();
         let chips = ChipMapping {
-            num_airs: widths.len(),
+            num_airs: emitted_widths.len(),
             pc_to_chip: build_pc_to_chip(exe, &self.inventory, executor_idx_to_air_idx)
                 .map_err(map_rvr_compile_error)?,
-            chip_widths: Some(widths.clone()),
+            chip_widths: Some(emitted_widths),
         };
         let compiled = compile_metered_cost(exe, extensions.lifters(), &chips, guest_debug_map)
             .map_err(map_rvr_compile_error)?;
@@ -587,7 +585,6 @@ where
             initial_image: RvrInitialImage::from(exe),
             runtime_hooks,
             compiled,
-            widths,
         })
     }
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -532,9 +532,9 @@ where
         ))
     }
 
-    /// Load a previously saved metered-cost-mode artifact. Its generated
-    /// execution kind and emitted chip widths are validated; the caller
-    /// supplies matching `exe`, `executor_idx_to_air_idx`, and `widths`.
+    /// Load a saved metered-cost artifact and check its execution kind and chip
+    /// widths. The caller must provide matching `exe`,
+    /// `executor_idx_to_air_idx`, and `widths`.
     pub fn load_metered_cost_instance(
         &self,
         lib_path: &std::path::Path,

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -31,9 +31,8 @@ use crate::{
 // and removing from MemoryConfig.
 // This is the max bit width of AS-native OpenVM memory pointers.
 pub const POINTER_MAX_BITS: usize = MEM_BITS - size_of::<u16>().ilog2() as usize;
-// RVR metering stores valid byte pointers and derived leaf indices as `u32`.
-// This only proves the configured pointer domain fits; XLEN-wide guest
-// operands still require runtime bounds checks before metering.
+// Valid RVR memory pointers and leaf indices fit in `u32`. Guest operands stay
+// `u64` until a runtime bounds check proves that they are valid pointers.
 const _: () = assert!(MEM_BITS <= u32::BITS as usize);
 
 #[derive(PartialEq, Copy, Clone, Debug, Eq)]

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -436,7 +436,7 @@ impl GuestMemory {
         self.memory.get_u8_slice(addr_space, byte_ptr as usize, len)
     }
 
-    /// Reads a raw byte range addressed by full RV64 register values.
+    /// Read a byte range addressed by full RV64 register values.
     pub fn checked_u8_slice(
         &self,
         addr_space: u32,

--- a/extensions/algebra/rvr/build.rs
+++ b/extensions/algebra/rvr/build.rs
@@ -47,6 +47,8 @@ fn main() {
     println!("cargo:rerun-if-changed=ffi/modular/src/lib.rs");
     println!("cargo:rerun-if-changed=ffi/fp2/Cargo.toml");
     println!("cargo:rerun-if-changed=ffi/fp2/src/lib.rs");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/Cargo.toml");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/src");
 }
 
 fn build_blst_staticlib(manifest_dir: &Path, out_dir: &Path) -> PathBuf {

--- a/extensions/algebra/rvr/c/rvr_ext_fp2.h
+++ b/extensions/algebra/rvr/c/rvr_ext_fp2.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 /* Direct C functions use preserve_most so generated block functions keep live
  * values in registers across calls. Rust functions use the standard C ABI. */
@@ -22,8 +22,8 @@ extern void rvr_ext_fp2_div(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, u
                             uint32_t num_limbs, const uint8_t* modulus);
 
 /* Fp2 SETUP extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_fp2_setup(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
-                              uint32_t num_limbs);
+extern bool rvr_ext_fp2_setup(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
+                              uint32_t num_limbs, const uint8_t* modulus);
 
 /* ── Specialized per-curve fp2 FFI ─────────────────────────────────────── */
 

--- a/extensions/algebra/rvr/c/rvr_ext_mod.h
+++ b/extensions/algebra/rvr/c/rvr_ext_mod.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 /* Direct C functions use preserve_most so generated block functions keep live
  * values in registers across calls. Rust functions use the standard C ABI. */
@@ -21,13 +21,15 @@ extern void rvr_ext_mod_mul(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, u
 extern void rvr_ext_mod_div(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
                             uint32_t num_limbs, const uint8_t* modulus);
 
-/* Modular IS_EQ extension FFI entry point (implemented in Rust). */
+/* Modular IS_EQ function implemented in Rust. */
 extern bool rvr_ext_mod_iseq(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr,
                              uint32_t num_limbs, const uint8_t* modulus);
 
 /* Modular SETUP extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_mod_setup(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
-                              uint32_t num_limbs);
+extern bool rvr_ext_mod_setup(RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr,
+                              uint32_t num_limbs, const uint8_t* modulus);
+extern uint8_t rvr_ext_mod_setup_iseq(RvState* state, uint64_t rs1_ptr, uint64_t rs2_ptr,
+                                      uint32_t num_limbs, const uint8_t* modulus);
 
 /* HintSqrt phantom: computes sqrt hint and sets hint stream (implemented in
  * Rust). */

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -5,7 +5,7 @@ use std::ffi::c_void;
 use halo2curves_axiom::ff::{Field, PrimeField};
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
-use openvm_platform::{WORD_SIZE, WORD_SIZE_U32};
+use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced};
 
 /// Size of a 256-bit field element in bytes.
@@ -141,11 +141,11 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
 #[inline]
 pub fn limb_bytes_to_words(num_limbs: u32) -> u32 {
     assert_eq!(
-        num_limbs % WORD_SIZE_U32,
+        num_limbs % WORD_SIZE as u32,
         0,
         "limb byte count must be a multiple of WORD_SIZE"
     );
-    num_limbs / WORD_SIZE_U32
+    num_limbs / WORD_SIZE as u32
 }
 
 /// Read a `num_limbs`-byte little-endian BigUint from guest memory (traced).

--- a/extensions/algebra/rvr/ffi/common/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/common/src/lib.rs
@@ -6,7 +6,7 @@ use halo2curves_axiom::ff::{Field, PrimeField};
 use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use openvm_platform::WORD_SIZE;
-use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced};
+use rvr_openvm_ext_ffi_common::{read_mem_words, write_mem_words};
 
 /// Size of a 256-bit field element in bytes.
 pub const FIELD_256_BYTES: usize = 32;
@@ -89,14 +89,14 @@ impl<T: KnownFieldArith> FieldArith for T {
 
 // ── 256-bit field I/O ───────────────────────────────────────────────────────
 
-/// Read a 256-bit field element from guest memory (traced).
+/// Read a 256-bit field element through the VM memory interface.
 ///
 /// # Safety
 /// `state` must be a valid pointer to the C `RvState` struct.
 #[inline(always)]
 pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void, ptr: u64) -> F {
     let mut words = [0u64; FIELD_256_WORDS];
-    rd_mem_words_traced(state, ptr, &mut words);
+    read_mem_words(state, ptr, &mut words);
     let mut bytes = [0u8; FIELD_256_BYTES];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -113,7 +113,7 @@ pub unsafe fn read_field_256<F: PrimeField<Repr = [u8; 32]>>(state: *mut c_void,
     })
 }
 
-/// Write a 256-bit field element to guest memory (traced).
+/// Write a 256-bit field element through the VM memory interface.
 ///
 /// # Safety
 /// `state` must be a valid pointer to the C `RvState` struct.
@@ -132,12 +132,12 @@ pub unsafe fn write_field_256<F: PrimeField<Repr = [u8; 32]>>(
                 .unwrap(),
         );
     }
-    wr_mem_words_traced(state, ptr, &words);
+    write_mem_words(state, ptr, &words);
 }
 
 // ── BigUint helpers (for unknown-modulus fallbacks) ──────────────────────────
 
-/// Convert a byte-sized limb count into RV64 words.
+/// Convert a limb count in bytes to RV64 words.
 #[inline]
 pub fn limb_bytes_to_words(num_limbs: u32) -> u32 {
     assert_eq!(
@@ -148,7 +148,7 @@ pub fn limb_bytes_to_words(num_limbs: u32) -> u32 {
     num_limbs / WORD_SIZE as u32
 }
 
-/// Read a `num_limbs`-byte little-endian BigUint from guest memory (traced).
+/// Read a `num_limbs`-byte little-endian BigUint through the VM memory interface.
 ///
 /// # Safety
 /// `state` must be a valid `RvState` pointer; `num_limbs` must be a multiple
@@ -157,7 +157,7 @@ pub fn limb_bytes_to_words(num_limbs: u32) -> u32 {
 pub unsafe fn read_bigint(state: *mut c_void, ptr: u64, num_limbs: u32) -> BigUint {
     let num_words = limb_bytes_to_words(num_limbs) as usize;
     let mut words = vec![0u64; num_words];
-    rd_mem_words_traced(state, ptr, &mut words);
+    read_mem_words(state, ptr, &mut words);
     let mut bytes = vec![0u8; num_limbs as usize];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -165,7 +165,7 @@ pub unsafe fn read_bigint(state: *mut c_void, ptr: u64, num_limbs: u32) -> BigUi
     BigUint::from_bytes_le(&bytes)
 }
 
-/// Write a BigUint to guest memory (traced), zero-padded to `num_limbs` bytes.
+/// Write a zero-padded BigUint through the VM memory interface.
 ///
 /// # Safety
 /// `state` must be a valid `RvState` pointer; `num_limbs` must be a multiple
@@ -183,7 +183,7 @@ pub unsafe fn write_bigint(state: *mut c_void, ptr: u64, value: &BigUint, num_li
                 .unwrap(),
         );
     }
-    wr_mem_words_traced(state, ptr, &words);
+    write_mem_words(state, ptr, &words);
 }
 
 /// Modular inverse of `a` modulo `p` via extended GCD. Caller must ensure

--- a/extensions/algebra/rvr/ffi/fp2/Cargo.toml
+++ b/extensions/algebra/rvr/ffi/fp2/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 crate-type = ["staticlib"]
 
 [dependencies]
-openvm-instructions.workspace = true
 rvr-openvm-ext-algebra-ffi-common.workspace = true
 rvr-openvm-ext-ffi-common.workspace = true
 

--- a/extensions/algebra/rvr/ffi/fp2/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/fp2/src/lib.rs
@@ -8,12 +8,13 @@
 use std::{ffi::c_void, marker::PhantomData};
 
 use num_bigint::BigUint;
-use openvm_instructions::riscv::RV64_MEMORY_AS;
 use rvr_openvm_ext_algebra_ffi_common::{
     known_field_op_fn, limb_bytes_to_words, mod_inverse, read_bigint, read_field_256, write_bigint,
     write_field_256, FieldArith, KnownFieldArith,
 };
-use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, trace_mem_access_range, wr_mem_words_traced};
+use rvr_openvm_ext_ffi_common::{
+    read_mem_words, u64s_as_bytes, u64s_as_bytes_mut, write_mem_words,
+};
 
 const FIELD_256_BYTES: u64 = rvr_openvm_ext_algebra_ffi_common::FIELD_256_BYTES as u64;
 
@@ -126,7 +127,8 @@ unknown_field_op_fn!(rvr_ext_fp2_mul, UnknownComplexField, mul);
 unknown_field_op_fn!(rvr_ext_fp2_div, UnknownComplexField, div);
 
 /// # Safety
-/// `state` must be a valid `RvState` pointer.
+/// `state` must be a valid `RvState` pointer. `modulus_ptr` must point to
+/// `num_limbs` bytes.
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_fp2_setup(
     state: *mut c_void,
@@ -134,14 +136,25 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     rs1_ptr: u64,
     rs2_ptr: u64,
     num_limbs: u32,
-) {
+    modulus_ptr: *const u8,
+) -> bool {
     let total_limbs = num_limbs.checked_mul(2).expect("Fp2 limb count overflow");
     let num_words = limb_bytes_to_words(total_limbs);
     debug_assert!(num_words >= 1);
 
-    let mut input_words = vec![0u64; num_words as usize];
-    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
-    trace_mem_access_range(state, rs2_ptr, num_words, RV64_MEMORY_AS);
+    let mut words = vec![0u64; num_words as usize];
+    read_mem_words(state, rs1_ptr, &mut words);
+    let num_limbs = num_limbs as usize;
+    let modulus_bytes = std::slice::from_raw_parts(modulus_ptr, num_limbs);
+    let input_bytes = u64s_as_bytes(&words);
+    let modulus_matches = &input_bytes[..num_limbs] == modulus_bytes;
+    let second_input = BigUint::from_bytes_le(&input_bytes[num_limbs..2 * num_limbs]);
+
+    // SETUP reads both inputs before it validates the configured modulus.
+    read_mem_words(state, rs2_ptr, &mut words);
+    if !modulus_matches {
+        return false;
+    }
 
     // Setup validates that the guest-provided base-field modulus and setup
     // inputs match the constants configured into this chip.
@@ -149,6 +162,11 @@ pub unsafe extern "C" fn rvr_ext_fp2_setup(
     // In mod-builder, `Input(0)` means the first input slot. For setup, that
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so each setup coordinate writes p % p = 0.
-    let output_words = vec![0u64; num_words as usize];
-    wr_mem_words_traced(state, rd_ptr, &output_words);
+    let modulus = BigUint::from_bytes_le(modulus_bytes);
+    let second_output = (second_input % modulus).to_bytes_le();
+    let mut output_words = vec![0u64; num_words as usize];
+    let output_bytes = u64s_as_bytes_mut(&mut output_words);
+    output_bytes[num_limbs..num_limbs + second_output.len()].copy_from_slice(&second_output);
+    write_mem_words(state, rd_ptr, &output_words);
+    true
 }

--- a/extensions/algebra/rvr/ffi/modular/Cargo.toml
+++ b/extensions/algebra/rvr/ffi/modular/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 crate-type = ["staticlib"]
 
 [dependencies]
-openvm-instructions.workspace = true
 openvm-platform.workspace = true
 rvr-openvm-ext-algebra-ffi-common.workspace = true
 rvr-openvm-ext-ffi-common.workspace = true

--- a/extensions/algebra/rvr/ffi/modular/c/rvr_ext_bls12_381.c
+++ b/extensions/algebra/rvr/ffi/modular/c/rvr_ext_bls12_381.c
@@ -19,7 +19,7 @@ static constexpr uint32_t BLS12_381_FR_WORDS = BLS12_381_FR_BYTES / RVR_WORD_SIZ
 
 static inline blst_fp fp_read(RvState *restrict state, uint64_t ptr) {
     uint64_t words[BLS12_381_FP_WORDS];
-    rd_mem_u64_range_traced(state, ptr, words, BLS12_381_FP_WORDS);
+    read_mem_u64_range(state, ptr, words, BLS12_381_FP_WORDS);
     blst_fp r;
     blst_fp_from_lendian(&r, (const uint8_t *)words);
     return r;
@@ -28,7 +28,7 @@ static inline blst_fp fp_read(RvState *restrict state, uint64_t ptr) {
 static inline void fp_write(RvState *restrict state, uint64_t ptr, const blst_fp *val) {
     uint64_t words[BLS12_381_FP_WORDS];
     blst_lendian_from_fp((uint8_t *)words, val);
-    wr_mem_u64_range_traced(state, ptr, words, BLS12_381_FP_WORDS);
+    write_mem_u64_range(state, ptr, words, BLS12_381_FP_WORDS);
 }
 
 static inline blst_fp fp_add(const blst_fp *a, const blst_fp *b) {
@@ -87,7 +87,7 @@ static inline int fp2_is_zero(const blst_fp2 *a) {
 
 static inline blst_fr fr_read(RvState *restrict state, uint64_t ptr) {
     uint64_t words[BLS12_381_FR_WORDS];
-    rd_mem_u64_range_traced(state, ptr, words, BLS12_381_FR_WORDS);
+    read_mem_u64_range(state, ptr, words, BLS12_381_FR_WORDS);
     blst_scalar s;
     blst_scalar_from_lendian(&s, (const uint8_t *)words);
     blst_fr r;
@@ -100,7 +100,7 @@ static inline void fr_write(RvState *restrict state, uint64_t ptr, const blst_fr
     blst_scalar_from_fr(&s, val);
     uint64_t words[BLS12_381_FR_WORDS];
     blst_lendian_from_scalar((uint8_t *)words, &s);
-    wr_mem_u64_range_traced(state, ptr, words, BLS12_381_FR_WORDS);
+    write_mem_u64_range(state, ptr, words, BLS12_381_FR_WORDS);
 }
 
 static inline int fr_eq(const blst_fr *a, const blst_fr *b) {

--- a/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
+++ b/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
@@ -8,17 +8,16 @@
 #include <string.h>
 
 #include "openvm.h"
+#include "rvr_ext_mod.h"
 
 #if !defined(__BYTE_ORDER__) || __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
 #error "k256 guest limb codecs require a little-endian host"
 #endif
 
-// TODO(follow-up): add some kind of checker during build time to ensure that
-//    RVR_WORD_SIZE and OpenVM WORD_SIZE don't differ from each other
-static constexpr uint32_t RVR_WORD_SIZE = 8;
 static constexpr uint32_t SECP256K1_ELEM_BYTES = 32;
+static_assert(WORD_SIZE == sizeof(uint64_t), "OpenVM word size must match uint64_t");
 static constexpr uint32_t SECP256K1_ELEM_WORDS =
-    SECP256K1_ELEM_BYTES / RVR_WORD_SIZE;
+    SECP256K1_ELEM_BYTES / WORD_SIZE;
 
 /* ── libsecp256k1 amalgamation (ECC modules always enabled) ──────────── */
 #include "secp256k1.c"
@@ -42,7 +41,7 @@ static inline void bytes_reverse_32(
 
 static inline secp256k1_fe fe_read(RvState* state, uint64_t ptr) {
   uint64_t words[SECP256K1_ELEM_WORDS];
-  rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  read_mem_u64_range(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
   memcpy(le, words, SECP256K1_ELEM_BYTES);
   uint8_t be[SECP256K1_ELEM_BYTES];
@@ -63,7 +62,7 @@ static inline void fe_write(RvState* state, uint64_t ptr,
   bytes_reverse_32(le, be);
   uint64_t words[SECP256K1_ELEM_WORDS];
   memcpy(words, le, SECP256K1_ELEM_BYTES);
-  wr_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  write_mem_u64_range(state, ptr, words, SECP256K1_ELEM_WORDS);
 }
 
 static inline secp256k1_fe fe_add(secp256k1_fe a, const secp256k1_fe* b) {
@@ -105,7 +104,7 @@ static inline int fe_is_zero(const secp256k1_fe* a) {
 
 static inline secp256k1_scalar scalar_read(RvState* state, uint64_t ptr) {
   uint64_t words[SECP256K1_ELEM_WORDS];
-  rd_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  read_mem_u64_range(state, ptr, words, SECP256K1_ELEM_WORDS);
   uint8_t le[SECP256K1_ELEM_BYTES];
   memcpy(le, words, SECP256K1_ELEM_BYTES);
   uint8_t be[SECP256K1_ELEM_BYTES];
@@ -123,7 +122,7 @@ static inline void scalar_write(RvState* state, uint64_t ptr,
   bytes_reverse_32(le, be);
   uint64_t words[SECP256K1_ELEM_WORDS];
   memcpy(words, le, SECP256K1_ELEM_BYTES);
-  wr_mem_u64_range_traced(state, ptr, words, SECP256K1_ELEM_WORDS);
+  write_mem_u64_range(state, ptr, words, SECP256K1_ELEM_WORDS);
 }
 
 /* ── Modular arithmetic: secp256k1 coordinate field (mod p) ──────────── */
@@ -222,10 +221,13 @@ __attribute__((preserve_most)) bool rvr_ext_mod_iseq_k256_scalar(
 /* ── EC ops: secp256k1 (always present in modular, regardless of whether
  * the ECC extension is configured at lift time) ──────────────────────── */
 
-__attribute__((preserve_most)) void rvr_ext_ec_add_ne_k256(
-    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr, uint64_t rs2_ptr);
-__attribute__((preserve_most)) void rvr_ext_ec_double_k256(
-    RvState* state, uint64_t rd_ptr, uint64_t rs1_ptr);
+__attribute__((preserve_most)) void rvr_ext_ec_add_ne_k256(RvState* state,
+                                                           uint64_t rd_ptr,
+                                                           uint64_t rs1_ptr,
+                                                           uint64_t rs2_ptr);
+__attribute__((preserve_most)) void rvr_ext_ec_double_k256(RvState* state,
+                                                           uint64_t rd_ptr,
+                                                           uint64_t rs1_ptr);
 
 __attribute__((preserve_most)) void rvr_ext_ec_add_ne_k256(RvState* state,
                                                            uint64_t rd_ptr,

--- a/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
+++ b/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
@@ -25,8 +25,9 @@ static constexpr uint32_t SECP256K1_ELEM_WORDS =
 
 /* ── k256 field (mod p) helpers ──────────────────────────────────────── */
 
-static inline void bytes_reverse_32(uint8_t out[SECP256K1_ELEM_BYTES],
-                                    const uint8_t in[SECP256K1_ELEM_BYTES]) {
+static inline void bytes_reverse_32(
+    uint8_t out[static const SECP256K1_ELEM_BYTES],
+    const uint8_t in[static const SECP256K1_ELEM_BYTES]) {
   _Static_assert(SECP256K1_ELEM_BYTES == 4 * sizeof(uint64_t), "");
   uint64_t words[4];
   memcpy(words, in, sizeof(words));

--- a/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
+++ b/extensions/algebra/rvr/ffi/modular/c/rvr_ext_modular.c
@@ -15,7 +15,6 @@
 #endif
 
 static constexpr uint32_t SECP256K1_ELEM_BYTES = 32;
-static_assert(WORD_SIZE == sizeof(uint64_t), "OpenVM word size must match uint64_t");
 static constexpr uint32_t SECP256K1_ELEM_WORDS =
     SECP256K1_ELEM_BYTES / WORD_SIZE;
 

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -17,8 +17,7 @@ use rvr_openvm_ext_algebra_ffi_common::{
     write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
-    ext_hint_stream_set, read_mem_words, read_mem_words_execution_input, u64s_as_bytes,
-    write_mem_words,
+    ext_hint_stream_set, peek_mem_words, read_mem_words, u64s_as_bytes, write_mem_words,
 };
 
 // ── Field structs ────────────────────────────────────────────────────────────
@@ -276,7 +275,7 @@ pub unsafe extern "C" fn rvr_ext_algebra_hint_sqrt(
 
     let num_words = limb_bytes_to_words(num_limbs);
     let mut words = vec![0u64; num_words as usize];
-    read_mem_words_execution_input(state, rs1_ptr, &mut words);
+    peek_mem_words(state, rs1_ptr, &mut words);
     let mut x_bytes = vec![0u8; num_limbs_usize];
     for (i, &w) in words.iter().enumerate() {
         x_bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());

--- a/extensions/algebra/rvr/ffi/modular/src/lib.rs
+++ b/extensions/algebra/rvr/ffi/modular/src/lib.rs
@@ -11,15 +11,14 @@ use std::{ffi::c_void, marker::PhantomData};
 use halo2curves_axiom::ff::PrimeField;
 use num_bigint::BigUint;
 use num_traits::One;
-use openvm_instructions::riscv::RV64_MEMORY_AS;
 use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{
     known_field_op_fn, limb_bytes_to_words, mod_inverse, read_bigint, read_field_256, write_bigint,
     write_field_256, FieldArith, KnownFieldArith,
 };
 use rvr_openvm_ext_ffi_common::{
-    ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_words_traced, trace_mem_access_range,
-    wr_mem_words_traced,
+    ext_hint_stream_set, read_mem_words, read_mem_words_execution_input, u64s_as_bytes,
+    write_mem_words,
 };
 
 // ── Field structs ────────────────────────────────────────────────────────────
@@ -141,7 +140,8 @@ pub unsafe extern "C" fn rvr_ext_mod_iseq(
 }
 
 /// # Safety
-/// `state` must be a valid `RvState` pointer.
+/// `state` must be a valid `RvState` pointer. `modulus_ptr` must point to
+/// `num_limbs` bytes.
 #[no_mangle]
 pub unsafe extern "C" fn rvr_ext_mod_setup(
     state: *mut c_void,
@@ -149,13 +149,23 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     rs1_ptr: u64,
     rs2_ptr: u64,
     num_limbs: u32,
-) {
+    modulus_ptr: *const u8,
+) -> bool {
     let num_words = limb_bytes_to_words(num_limbs);
     debug_assert!(num_words >= 1);
 
-    let mut input_words = vec![0u64; num_words as usize];
-    rd_mem_words_traced(state, rs1_ptr, &mut input_words);
-    trace_mem_access_range(state, rs2_ptr, num_words, RV64_MEMORY_AS);
+    let mut words = vec![0u64; num_words as usize];
+    read_mem_words(state, rs1_ptr, &mut words);
+    let num_limbs = num_limbs as usize;
+    let modulus = std::slice::from_raw_parts(modulus_ptr, num_limbs);
+    let modulus_matches = &u64s_as_bytes(&words)[..num_limbs] == modulus;
+
+    // SETUP reads both inputs even though only the configured modulus affects
+    // the result.
+    read_mem_words(state, rs2_ptr, &mut words);
+    if !modulus_matches {
+        return false;
+    }
 
     // Setup validates that the guest-provided modulus and setup inputs match
     // the constants configured into this chip.
@@ -164,7 +174,39 @@ pub unsafe extern "C" fn rvr_ext_mod_setup(
     // slot is the modulus p read from rs1. VM evaluates inputs modulo p,
     // so the setup output is p % p = 0.
     let output_words = vec![0u64; num_words as usize];
-    wr_mem_words_traced(state, rd_ptr, &output_words);
+    write_mem_words(state, rd_ptr, &output_words);
+    true
+}
+
+/// # Safety
+/// `state` must be a valid `RvState` pointer. `modulus_ptr` must point to
+/// `num_limbs` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn rvr_ext_mod_setup_iseq(
+    state: *mut c_void,
+    rs1_ptr: u64,
+    rs2_ptr: u64,
+    num_limbs: u32,
+    modulus_ptr: *const u8,
+) -> u8 {
+    const INVALID_MODULUS: u8 = 2;
+
+    let num_words = limb_bytes_to_words(num_limbs);
+    debug_assert!(num_words >= 1);
+    let num_limbs = num_limbs as usize;
+    let modulus = std::slice::from_raw_parts(modulus_ptr, num_limbs);
+
+    let mut rs1_words = vec![0u64; num_words as usize];
+    read_mem_words(state, rs1_ptr, &mut rs1_words);
+    let modulus_matches = &u64s_as_bytes(&rs1_words)[..num_limbs] == modulus;
+
+    let mut rs2_words = vec![0u64; num_words as usize];
+    read_mem_words(state, rs2_ptr, &mut rs2_words);
+    if !modulus_matches {
+        return INVALID_MODULUS;
+    }
+
+    u8::from(u64s_as_bytes(&rs1_words)[..num_limbs] == u64s_as_bytes(&rs2_words)[..num_limbs])
 }
 
 // ── Phantom: HintSqrt ────────────────────────────────────────────────────────
@@ -234,8 +276,7 @@ pub unsafe extern "C" fn rvr_ext_algebra_hint_sqrt(
 
     let num_words = limb_bytes_to_words(num_limbs);
     let mut words = vec![0u64; num_words as usize];
-    rd_mem_u64_range_wrapper(state, rs1_ptr, words.as_mut_ptr(), num_words);
-    // Note: no trace here — this is a phantom (hint) instruction, reads are not traced
+    read_mem_words_execution_input(state, rs1_ptr, &mut words);
     let mut x_bytes = vec![0u8; num_limbs_usize];
     for (i, &w) in words.iter().enumerate() {
         x_bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());

--- a/extensions/algebra/rvr/src/common.rs
+++ b/extensions/algebra/rvr/src/common.rs
@@ -92,7 +92,7 @@ impl<K: IsEqKind> FieldIsEqInstr<K> {
     }
 }
 
-/// Generic IR node for field setup (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
+/// Generic IR node for field setup (SETUP_ADDSUB and SETUP_MULDIV).
 /// The C function name is derived from `K::c_prefix()` as `rvr_ext_{prefix}_setup`.
 /// Use the type aliases [`crate::ModSetupInstr`] / [`crate::Fp2SetupInstr`]
 /// rather than naming this type directly.
@@ -103,16 +103,18 @@ pub(crate) struct FieldSetupInstr<K: SetupKind> {
     pub rs1_reg: Reg,
     pub rs2_reg: Reg,
     pub num_limbs: u32,
+    pub modulus: Vec<u8>,
 }
 
 impl<K: SetupKind> FieldSetupInstr<K> {
-    pub fn new(rd_reg: Reg, rs1_reg: Reg, rs2_reg: Reg, num_limbs: u32) -> Self {
+    pub fn new(rd_reg: Reg, rs1_reg: Reg, rs2_reg: Reg, num_limbs: u32, modulus: Vec<u8>) -> Self {
         Self {
             _kind: PhantomData,
             rd_reg,
             rs1_reg,
             rs2_reg,
             num_limbs,
+            modulus,
         }
     }
 }
@@ -127,8 +129,12 @@ impl<K: SetupKind> ExtInstr for FieldSetupInstr<K> {
         let rs1 = ctx.read_reg(self.rs1_reg);
         let rs2 = ctx.read_reg(self.rs2_reg);
         let num_limbs = format!("{}u", self.num_limbs);
+        let mod_literal = format_c_byte_array(&self.modulus);
         let name = format!("rvr_ext_{}_setup", K::c_prefix());
-        ctx.emit_call(&name, &["state", &rd, &rs1, &rs2, &num_limbs]);
+        ctx.write_line("{");
+        ctx.write_line(&format!("static constexpr uint8_t mod_[] = {mod_literal};"));
+        ctx.emit_checked_call(&name, &["state", &rd, &rs1, &rs2, &num_limbs, "mod_"]);
+        ctx.write_line("}");
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -94,6 +94,10 @@ impl RvrExtension for Fp2RvrExtension {
             include_bytes!(env!("RVR_ALGEBRA_FP2_FFI_STATICLIB")),
         )]
     }
+
+    fn uses_memory_wrappers(&self) -> bool {
+        true
+    }
 }
 
 impl Fp2RvrExtension {
@@ -117,48 +121,55 @@ impl Fp2RvrExtension {
         let rs1_reg = decode_reg(insn.b);
         let rs2_reg = decode_reg(insn.c);
 
-        let instr: Instr =
-            match local {
-                x if x == Fp2Opcode::ADD as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
-                    ModOp::Add,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    info.num_limbs,
-                    info.modulus_bytes.clone(),
-                ))),
-                x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
-                    ModOp::Sub,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    info.num_limbs,
-                    info.modulus_bytes.clone(),
-                ))),
-                x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(
-                    Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
-                )),
-                x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
-                    ModOp::Mul,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    info.num_limbs,
-                    info.modulus_bytes.clone(),
-                ))),
-                x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
-                    ModOp::Div,
-                    rd_reg,
-                    rs1_reg,
-                    rs2_reg,
-                    info.num_limbs,
-                    info.modulus_bytes.clone(),
-                ))),
-                x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(
-                    Fp2SetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
-                )),
-                _ => return None,
-            };
+        let instr: Instr = match local {
+            x if x == Fp2Opcode::ADD as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                ModOp::Add,
+                rd_reg,
+                rs1_reg,
+                rs2_reg,
+                info.num_limbs,
+                info.modulus_bytes.clone(),
+            ))),
+            x if x == Fp2Opcode::SUB as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                ModOp::Sub,
+                rd_reg,
+                rs1_reg,
+                rs2_reg,
+                info.num_limbs,
+                info.modulus_bytes.clone(),
+            ))),
+            x if x == Fp2Opcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(Fp2SetupInstr::new(
+                rd_reg,
+                rs1_reg,
+                rs2_reg,
+                info.num_limbs,
+                info.modulus_bytes.clone(),
+            ))),
+            x if x == Fp2Opcode::MUL as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                ModOp::Mul,
+                rd_reg,
+                rs1_reg,
+                rs2_reg,
+                info.num_limbs,
+                info.modulus_bytes.clone(),
+            ))),
+            x if x == Fp2Opcode::DIV as usize => Instr::Ext(Box::new(Fp2ArithInstr::new(
+                ModOp::Div,
+                rd_reg,
+                rs1_reg,
+                rs2_reg,
+                info.num_limbs,
+                info.modulus_bytes.clone(),
+            ))),
+            x if x == Fp2Opcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(Fp2SetupInstr::new(
+                rd_reg,
+                rs1_reg,
+                rs2_reg,
+                info.num_limbs,
+                info.modulus_bytes.clone(),
+            ))),
+            _ => return None,
+        };
 
         Some(LiftedInstr::Body(InstrAt {
             pc,

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -177,7 +177,7 @@ impl ExtInstr for HintSqrtInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rs1 = ctx.read_reg_execution_input(self.rs1_reg);
+        let rs1 = ctx.peek_reg(self.rs1_reg);
         let mod_literal = format_c_byte_array(&self.modulus);
         let nqr_literal = format_c_byte_array(&self.non_qr_bytes);
         ctx.write_line("{");

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -86,8 +86,46 @@ pub(crate) type ModArithInstr = FieldArithInstr<ModArithKind>;
 /// IR node for modular IS_EQ.
 pub(crate) type ModIsEqInstr = FieldIsEqInstr<ModArithKind>;
 
-/// IR node for modular SETUP (SETUP_ADDSUB, SETUP_MULDIV, SETUP_ISEQ).
+/// IR node for modular SETUP (SETUP_ADDSUB and SETUP_MULDIV).
 pub(crate) type ModSetupInstr = FieldSetupInstr<ModArithKind>;
+
+#[derive(Debug, Clone)]
+struct ModSetupIsEqInstr {
+    rd_reg: Reg,
+    rs1_reg: Reg,
+    rs2_reg: Reg,
+    num_limbs: u32,
+    modulus: Vec<u8>,
+}
+
+impl ExtInstr for ModSetupIsEqInstr {
+    fn opname(&self) -> &str {
+        "mod_setup_iseq"
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        let rs1 = ctx.read_reg(self.rs1_reg);
+        let rs2 = ctx.read_reg(self.rs2_reg);
+        let mod_literal = format_c_byte_array(&self.modulus);
+        let num_limbs = format!("{}u", self.num_limbs);
+        ctx.write_line("{");
+        ctx.write_line(&format!("static constexpr uint8_t mod_[] = {mod_literal};"));
+        let result = ctx.emit_call_expr(
+            "uint8_t",
+            "rvr_ext_mod_setup_iseq",
+            &["state", &rs1, &rs2, &num_limbs, "mod_"],
+        );
+        ctx.write_line(&format!("if (unlikely({result} > 1u)) {{"));
+        ctx.emit_trap();
+        ctx.write_line("}");
+        ctx.write_reg(self.rd_reg, &result);
+        ctx.write_line("}");
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+}
 
 // ── Phantom instructions (HintNonQr, HintSqrt) ──────────────────────────────
 
@@ -139,7 +177,7 @@ impl ExtInstr for HintSqrtInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rs1 = ctx.read_reg(self.rs1_reg);
+        let rs1 = ctx.read_reg_execution_input(self.rs1_reg);
         let mod_literal = format_c_byte_array(&self.modulus);
         let nqr_literal = format_c_byte_array(&self.non_qr_bytes);
         ctx.write_line("{");
@@ -228,6 +266,10 @@ impl RvrExtension for ModularRvrExtension {
                 include_bytes!(env!("RVR_ALGEBRA_BLST_STATICLIB")),
             ),
         ]
+    }
+
+    fn uses_memory_wrappers(&self) -> bool {
+        true
     }
 
     fn vendored_c_sources(&self) -> Vec<(&'static str, &'static str)> {
@@ -322,9 +364,15 @@ impl ModularRvrExtension {
                     info.modulus_bytes.clone(),
                 )))
             }
-            x if x == Rv64ModularArithmeticOpcode::SETUP_ADDSUB as usize => Instr::Ext(Box::new(
-                ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
-            )),
+            x if x == Rv64ModularArithmeticOpcode::SETUP_ADDSUB as usize => {
+                Instr::Ext(Box::new(ModSetupInstr::new(
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                )))
+            }
             x if x == Rv64ModularArithmeticOpcode::MUL as usize => {
                 Instr::Ext(Box::new(ModArithInstr::new(
                     ModOp::Mul,
@@ -345,9 +393,15 @@ impl ModularRvrExtension {
                     info.modulus_bytes.clone(),
                 )))
             }
-            x if x == Rv64ModularArithmeticOpcode::SETUP_MULDIV as usize => Instr::Ext(Box::new(
-                ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
-            )),
+            x if x == Rv64ModularArithmeticOpcode::SETUP_MULDIV as usize => {
+                Instr::Ext(Box::new(ModSetupInstr::new(
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    info.num_limbs,
+                    info.modulus_bytes.clone(),
+                )))
+            }
             x if x == Rv64ModularArithmeticOpcode::IS_EQ as usize => {
                 Instr::Ext(Box::new(ModIsEqInstr::new(
                     rd_reg,
@@ -357,9 +411,15 @@ impl ModularRvrExtension {
                     info.modulus_bytes.clone(),
                 )))
             }
-            x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => Instr::Ext(Box::new(
-                ModSetupInstr::new(rd_reg, rs1_reg, rs2_reg, info.num_limbs),
-            )),
+            x if x == Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize => {
+                Instr::Ext(Box::new(ModSetupIsEqInstr {
+                    rd_reg,
+                    rs1_reg,
+                    rs2_reg,
+                    num_limbs: info.num_limbs,
+                    modulus: info.modulus_bytes.clone(),
+                }))
+            }
             _ => return None,
         };
 

--- a/extensions/bigint/rvr/build.rs
+++ b/extensions/bigint/rvr/build.rs
@@ -28,4 +28,6 @@ fn main() {
     );
     println!("cargo:rerun-if-changed=ffi/Cargo.toml");
     println!("cargo:rerun-if-changed=ffi/src");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/Cargo.toml");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/src");
 }

--- a/extensions/bigint/rvr/c/rvr_ext_bigint.h
+++ b/extensions/bigint/rvr/c/rvr_ext_bigint.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 /* 256-bit ALU operations (implemented in Rust). One specialized FFI entry
  * point per opcode so the C compiler does not see a runtime `op` switch. */

--- a/extensions/bigint/rvr/ffi/src/lib.rs
+++ b/extensions/bigint/rvr/ffi/src/lib.rs
@@ -8,7 +8,7 @@
 use std::ffi::c_void;
 
 use openvm_platform::WORD_SIZE;
-use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced};
+use rvr_openvm_ext_ffi_common::{read_mem_words, write_mem_words};
 
 /// Number of bytes in a 256-bit integer.
 const INT256_BYTES: usize = 32;
@@ -44,7 +44,7 @@ const SIGN_BIT_MASK: u8 = 1 << SIGN_BIT_SHIFT;
 #[inline]
 unsafe fn read_int256(state: *mut c_void, ptr: u64) -> [u8; INT256_BYTES] {
     let mut words = [0u64; INT256_WORDS];
-    rd_mem_words_traced(state, ptr, &mut words);
+    read_mem_words(state, ptr, &mut words);
     let mut bytes = [0u8; INT256_BYTES];
     for (i, w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -63,7 +63,7 @@ unsafe fn write_int256(state: *mut c_void, ptr: u64, bytes: &[u8; INT256_BYTES])
                 .unwrap(),
         );
     }
-    wr_mem_words_traced(state, ptr, &words);
+    write_mem_words(state, ptr, &words);
 }
 
 // ── Byte-level helpers ──────────────────────────────────────────────────────
@@ -327,7 +327,7 @@ int256_alu_fn!(rvr_ext_int256_slt, u256_slt);
 int256_alu_fn!(rvr_ext_int256_sltu, u256_sltu);
 int256_alu_fn!(rvr_ext_int256_mul, u256_mul);
 
-/// Defines an `extern "C"` branch predicate.
+/// Define an `extern "C"` branch predicate.
 macro_rules! int256_branch_fn {
     ($name:ident, $cond:expr) => {
         /// # Safety

--- a/extensions/bigint/rvr/src/lib.rs
+++ b/extensions/bigint/rvr/src/lib.rs
@@ -93,10 +93,7 @@ pub struct Int256AluInstr {
     pub rs2_reg: Reg,
     /// The ALU operation to perform (selects the FFI function at codegen time).
     pub op: Int256AluOp,
-    /// Chip index for metering. Currently not consumed by the FFI (each
-    /// instruction is one row already counted by the per-block chip update
-    /// emitted at block entry), kept on the IR for parity with other
-    /// extensions and future trace-chip use.
+    /// AIR index associated with this instruction.
     pub chip_idx: Option<AirIndex>,
 }
 

--- a/extensions/bigint/rvr/src/lib.rs
+++ b/extensions/bigint/rvr/src/lib.rs
@@ -419,6 +419,10 @@ impl RvrExtension for Int256Extension {
             include_bytes!(env!("RVR_BIGINT_FFI_STATICLIB")),
         )]
     }
+
+    fn uses_memory_wrappers(&self) -> bool {
+        true
+    }
 }
 
 impl Int256Extension {

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -35,8 +35,7 @@ void register_deferral_callbacks(const DeferralHostCallbacks* cb) {
 
 /* Deferral CALL: read input_commit, look up output_key, write it. */
 void rvr_ext_deferral_call(RvState* restrict state, uint64_t output_ptr,
-                           uint64_t input_ptr, uint32_t def_idx,
-                           uint32_t poseidon2_chip_idx) {
+                           uint64_t input_ptr, uint32_t def_idx) {
   /* Read input_commit (COMMIT_WORDS words) from guest memory. */
   uint64_t commit_words[COMMIT_WORDS];
   rd_mem_u64_range_traced(state, input_ptr, commit_words, COMMIT_WORDS);
@@ -66,15 +65,11 @@ void rvr_ext_deferral_call(RvState* restrict state, uint64_t output_ptr,
                              AS_DEFERRAL);
   trace_mem_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
                              AS_DEFERRAL);
-
-  trace_chip(state, poseidon2_chip_idx, 2);
 }
 
 /* Deferral OUTPUT: read output_key, look up raw output, write it. */
-void rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
-                             uint64_t input_ptr, uint32_t def_idx,
-                             uint32_t output_chip_idx,
-                             uint32_t poseidon2_chip_idx) {
+uint32_t rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
+                                 uint64_t input_ptr, uint32_t def_idx) {
   /* Read output_key (OUTPUT_KEY_WORDS words) from guest memory. */
   uint64_t key_words[OUTPUT_KEY_WORDS];
   rd_mem_u64_range_traced(state, input_ptr, key_words, OUTPUT_KEY_WORDS);
@@ -108,8 +103,5 @@ void rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
   free(output_raw);
 
   uint32_t num_rows = num_data_rows + 1;
-  if (num_rows > 1) {
-    trace_chip(state, output_chip_idx, num_rows - 1);
-  }
-  trace_chip(state, poseidon2_chip_idx, num_rows);
+  return num_rows;
 }

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "openvm.h"
+#include "rvr_ext_deferral.h"
 
 /* Byte-layout constants derived from the generated digest and word sizes. */
 // TODO(rvr): update to better formula/solution instead of defining field element size here
@@ -38,19 +39,16 @@ void rvr_ext_deferral_call(RvState* restrict state, uint64_t output_ptr,
                            uint64_t input_ptr, uint32_t def_idx) {
   /* Read input_commit (COMMIT_WORDS words) from guest memory. */
   uint64_t commit_words[COMMIT_WORDS];
-  rd_mem_u64_range_traced(state, input_ptr, commit_words, COMMIT_WORDS);
+  read_mem_u64_range(state, input_ptr, commit_words, COMMIT_WORDS);
 
-  /* Trace DEFERRAL_AS reads (old input_acc + old output_acc). Slot offsets
-   * are in field-element units.
-   * TODO: deferral address space elements are field elements, not u32.
-   * Page tracking currently assumes u32 cells — verify that the page and
-   * chunk geometry is correct for field-element-typed cells. */
+  /* Trace DEFERRAL_AS reads (old input_acc + old output_acc). Addresses and
+   * span sizes are both expressed in field-element units. */
   uint64_t input_acc_ptr = 2u * def_idx * DEFERRAL_DIGEST_SIZE;
   uint64_t output_acc_ptr = input_acc_ptr + DEFERRAL_DIGEST_SIZE;
-  trace_mem_access_u64_range(state, input_acc_ptr, DIGEST_MEMORY_OPS,
-                             AS_DEFERRAL);
-  trace_mem_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
-                             AS_DEFERRAL);
+  trace_page_access_u64_range(state, input_acc_ptr, DIGEST_MEMORY_OPS,
+                              AS_DEFERRAL);
+  trace_page_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
+                              AS_DEFERRAL);
 
   /* Look up output_key + update accumulators (Rust side, on byte buffers). */
   uint64_t key_words[OUTPUT_KEY_WORDS];
@@ -58,13 +56,13 @@ void rvr_ext_deferral_call(RvState* restrict state, uint64_t output_ptr,
                          (const uint8_t*)commit_words, (uint8_t*)key_words);
 
   /* Write output_key (OUTPUT_KEY_WORDS words) to guest memory. */
-  wr_mem_u64_range_traced(state, output_ptr, key_words, OUTPUT_KEY_WORDS);
+  write_mem_u64_range(state, output_ptr, key_words, OUTPUT_KEY_WORDS);
 
   /* Trace DEFERRAL_AS writes (new input_acc + new output_acc). */
-  trace_mem_access_u64_range(state, input_acc_ptr, DIGEST_MEMORY_OPS,
-                             AS_DEFERRAL);
-  trace_mem_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
-                             AS_DEFERRAL);
+  trace_page_access_u64_range(state, input_acc_ptr, DIGEST_MEMORY_OPS,
+                              AS_DEFERRAL);
+  trace_page_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
+                              AS_DEFERRAL);
 }
 
 /* Deferral OUTPUT: read output_key, look up raw output, write it. */
@@ -72,17 +70,21 @@ uint32_t rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
                                  uint64_t input_ptr, uint32_t def_idx) {
   /* Read output_key (OUTPUT_KEY_WORDS words) from guest memory. */
   uint64_t key_words[OUTPUT_KEY_WORDS];
-  rd_mem_u64_range_traced(state, input_ptr, key_words, OUTPUT_KEY_WORDS);
+  read_mem_u64_range(state, input_ptr, key_words, OUTPUT_KEY_WORDS);
 
   /* output_len is the u64 LE stored right after the commit. */
-  /* The output AIR encodes the length in its low four bytes. Ignore the
-   * unconstrained upper bytes exactly as the reference executor does. */
+  /* The AIR stores the length in the low four bytes. The upper bytes are
+   * unconstrained, so ignore them as the reference executor does. */
   uint32_t output_len = (uint32_t)key_words[COMMIT_WORDS];
 
   /* Look up the raw output into a heap buffer sized to output_len. The
    * output_commit is the leading DEFERRAL_COMMIT_NUM_BYTES of output_key. */
-  uint8_t* output_raw = (uint8_t*)malloc((size_t)output_len);
-  if (!output_raw && output_len > 0) abort();
+  uint8_t empty_output;
+  uint8_t* output_raw = &empty_output;
+  if (output_len > 0) {
+    output_raw = (uint8_t*)malloc((size_t)output_len);
+    if (!output_raw) abort();
+  }
   g_deferral.output_lookup(g_deferral.ctx, openvm_get_io_ctx(), def_idx,
                            (const uint8_t*)key_words, output_raw,
                            (uint32_t)output_len);
@@ -93,16 +95,16 @@ uint32_t rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
   uint64_t row_words[DIGEST_MEMORY_OPS];
   for (uint64_t row_idx = 0; row_idx < num_data_rows; row_idx++) {
     uint64_t row_byte_base = row_idx * DEFERRAL_DIGEST_SIZE;
-    /* output_raw has output_len bytes and row_idx is bounded by
-     * output_len / DEFERRAL_DIGEST_SIZE. */
+    /* row_idx is less than output_len / DEFERRAL_DIGEST_SIZE, so this slice
+     * stays within output_raw. */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
     memcpy(row_words, output_raw + row_byte_base, DEFERRAL_DIGEST_SIZE);
 #pragma clang diagnostic pop
-    wr_mem_u64_range_traced(state, output_ptr + row_byte_base, row_words,
-                            DIGEST_MEMORY_OPS);
+    write_mem_u64_range(state, output_ptr + row_byte_base, row_words,
+                        DIGEST_MEMORY_OPS);
   }
-  free(output_raw);
+  if (output_len > 0) free(output_raw);
 
   uint32_t num_rows = num_data_rows + 1;
   return num_rows;

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -75,7 +75,9 @@ uint32_t rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
   rd_mem_u64_range_traced(state, input_ptr, key_words, OUTPUT_KEY_WORDS);
 
   /* output_len is the u64 LE stored right after the commit. */
-  uint64_t output_len = key_words[COMMIT_WORDS];
+  /* The output AIR encodes the length in its low four bytes. Ignore the
+   * unconstrained upper bytes exactly as the reference executor does. */
+  uint32_t output_len = (uint32_t)key_words[COMMIT_WORDS];
 
   /* Look up the raw output into a heap buffer sized to output_len. The
    * output_commit is the leading DEFERRAL_COMMIT_NUM_BYTES of output_key. */
@@ -87,7 +89,7 @@ uint32_t rvr_ext_deferral_output(RvState* restrict state, uint64_t output_ptr,
 
   /* Write raw output to guest memory in DEFERRAL_DIGEST_SIZE-byte rows. Each
    * row is an independent batched write (the trace API is per-row). */
-  uint32_t num_data_rows = (uint32_t)(output_len / DEFERRAL_DIGEST_SIZE);
+  uint32_t num_data_rows = output_len / DEFERRAL_DIGEST_SIZE;
   uint64_t row_words[DIGEST_MEMORY_OPS];
   for (uint64_t row_idx = 0; row_idx < num_data_rows; row_idx++) {
     uint64_t row_byte_base = row_idx * DEFERRAL_DIGEST_SIZE;

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.h
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 typedef struct DeferralHostCallbacks {
   void* ctx;

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.h
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.h
@@ -18,13 +18,10 @@ void register_deferral_callbacks(const DeferralHostCallbacks* cb);
 
 /* Deferral CALL extension entry point (defined in rvr_ext_deferral.c). */
 extern void rvr_ext_deferral_call(RvState* state, uint64_t output_ptr,
-                                  uint64_t input_ptr, uint32_t def_idx,
-                                  uint32_t poseidon2_chip_idx);
+                                  uint64_t input_ptr, uint32_t def_idx);
 
 /* Deferral OUTPUT extension entry point (defined in rvr_ext_deferral.c). */
-extern void rvr_ext_deferral_output(RvState* state, uint64_t output_ptr,
-                                    uint64_t input_ptr, uint32_t def_idx,
-                                    uint32_t output_chip_idx,
-                                    uint32_t poseidon2_chip_idx);
+extern uint32_t rvr_ext_deferral_output(RvState* state, uint64_t output_ptr,
+                                        uint64_t input_ptr, uint32_t def_idx);
 
 #endif /* RVR_EXT_DEFERRAL_H */

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -15,10 +15,10 @@ use openvm_circuit::arch::{
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{LocalOpcode, VM_DIGEST_WIDTH};
 use openvm_stark_backend::p3_field::PrimeField32;
-use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
+use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, FixedTraceRows, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
-    RvrExtensionCtx, RvrInstruction, RvrRuntimeExtension,
+    air_index_to_c, decode_reg, fixed_trace_rows_for_chip, opcode_air_idx, AirIndex,
+    ExtensionError, RvrExtension, RvrExtensionCtx, RvrInstruction, RvrRuntimeExtension,
 };
 
 /// Size in bytes of a serialized deferral commitment.
@@ -75,13 +75,12 @@ impl ExtInstr for DeferralCallInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let rd = ctx.read_reg(self.rd_reg);
         let rs = ctx.read_reg(self.rs_reg);
-        let poseidon2 = air_index_to_c(self.poseidon2_chip_idx);
         let def_idx = format!("{}u", self.def_idx);
-        let poseidon2 = format!("{poseidon2}u");
-        ctx.emit_call(
-            "rvr_ext_deferral_call",
-            &["state", &rd, &rs, &def_idx, &poseidon2],
-        );
+        ctx.emit_call("rvr_ext_deferral_call", &["state", &rd, &rs, &def_idx]);
+    }
+
+    fn fixed_trace_rows(&self) -> Vec<FixedTraceRows> {
+        fixed_trace_rows_for_chip(self.poseidon2_chip_idx, 2)
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -114,12 +113,15 @@ impl ExtInstr for DeferralOutputInstr {
         let output = air_index_to_c(self.output_chip_idx);
         let poseidon2 = air_index_to_c(self.poseidon2_chip_idx);
         let def_idx = format!("{}u", self.def_idx);
-        let output = format!("{output}u");
-        let poseidon2 = format!("{poseidon2}u");
-        ctx.emit_call(
+        let num_rows = ctx.emit_call_with_trace_result(
+            "uint32_t",
             "rvr_ext_deferral_output",
-            &["state", &rd, &rs, &def_idx, &output, &poseidon2],
+            &["state", &rd, &rs, &def_idx],
         );
+        if let Some(num_rows) = num_rows {
+            ctx.trace_chip_if_nonzero(output, &format!("{num_rows} - 1u"));
+            ctx.trace_chip(poseidon2, &num_rows);
+        }
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {

--- a/extensions/ecc/rvr/build.rs
+++ b/extensions/ecc/rvr/build.rs
@@ -27,4 +27,6 @@ fn main() {
     );
     println!("cargo:rerun-if-changed=ffi/Cargo.toml");
     println!("cargo:rerun-if-changed=ffi/src");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/Cargo.toml");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/src");
 }

--- a/extensions/ecc/rvr/c/rvr_ext_ecc.h
+++ b/extensions/ecc/rvr/c/rvr_ext_ecc.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 /* Direct C functions use preserve_most so generated block functions keep live
  * values in registers across calls. Rust functions use the standard C ABI. */

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -11,7 +11,7 @@ use num_bigint::BigUint;
 use openvm_circuit_primitives::var_range::VariableRangeCheckerBus;
 use openvm_ecc_circuit::{ec_add_ne_expr, ec_double_ne_expr};
 use openvm_mod_circuit_builder::{run_field_expression_precomputed, ExprBuilderConfig};
-use openvm_platform::{WORD_SIZE, WORD_SIZE_U32};
+use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{
     read_field_256, write_field_256, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
 };
@@ -103,7 +103,7 @@ unsafe fn ec_double_256<F: halo2curves_axiom::ff::PrimeField<Repr = [u8; FIELD_2
 const P256_A_ABS: u64 = 3;
 
 unsafe fn trace_read_bytes(state: *mut c_void, ptr: u64, len: u32) -> Vec<u8> {
-    debug_assert_eq!(len % WORD_SIZE_U32, 0);
+    debug_assert_eq!(len % WORD_SIZE as u32, 0);
     let num_words = (len as usize) / WORD_SIZE;
     let mut words = vec![0u64; num_words];
     rd_mem_words_traced(state, ptr, &mut words);

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -15,7 +15,7 @@ use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{
     read_field_256, write_field_256, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
 };
-use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, wr_mem_words_traced};
+use rvr_openvm_ext_ffi_common::{read_mem_words, write_mem_words};
 
 /// BN254 base field element size in bytes, as `u64` for address arithmetic.
 const BN254_FQ_BYTES: u64 = FIELD_256_BYTES as u64;
@@ -106,7 +106,7 @@ unsafe fn trace_read_bytes(state: *mut c_void, ptr: u64, len: u32) -> Vec<u8> {
     debug_assert_eq!(len % WORD_SIZE as u32, 0);
     let num_words = (len as usize) / WORD_SIZE;
     let mut words = vec![0u64; num_words];
-    rd_mem_words_traced(state, ptr, &mut words);
+    read_mem_words(state, ptr, &mut words);
     let mut bytes = Vec::with_capacity(len as usize);
     for &w in &words {
         bytes.extend_from_slice(&w.to_le_bytes());
@@ -120,7 +120,7 @@ unsafe fn trace_write_bytes(state: *mut c_void, ptr: u64, bytes: &[u8]) {
         .chunks_exact(WORD_SIZE)
         .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
         .collect();
-    wr_mem_words_traced(state, ptr, &words);
+    write_mem_words(state, ptr, &words);
 }
 
 fn ecc_setup_expr(point_bytes: u32, setup_bytes: &[u8], is_double: bool) -> Vec<u8> {

--- a/extensions/ecc/rvr/src/lib.rs
+++ b/extensions/ecc/rvr/src/lib.rs
@@ -227,4 +227,8 @@ impl RvrExtension for EccExtension {
             include_bytes!(env!("RVR_ECC_FFI_STATICLIB")),
         )]
     }
+
+    fn uses_memory_wrappers(&self) -> bool {
+        true
+    }
 }

--- a/extensions/keccak256/rvr/Cargo.toml
+++ b/extensions/keccak256/rvr/Cargo.toml
@@ -13,6 +13,7 @@ rvr-openvm-lift.workspace = true
 
 openvm-instructions.workspace = true
 openvm-keccak256-transpiler.workspace = true
+p3-keccak-air.workspace = true
 
 [build-dependencies]
 rvr-openvm-build.workspace = true

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.c
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.c
@@ -1,25 +1,25 @@
-/* Keccak extension FFI: traced memory ops + dispatch into the keccak-ffi
+/* Keccak extension FFI: memory access + dispatch into the keccak-ffi
  * staticlib's `rvr_keccak_f1600` (asm backend selected at FFI-crate build
  * time). Compiled into the generated native project so clang can inline the
  * tracer helpers. */
 
 #include "openvm.h"
+#include "rvr_ext_keccak.h"
 
 static constexpr uint32_t KECCAK_WIDTH_BYTES = 200;
 static constexpr uint32_t KECCAK_WIDTH_WORDS = KECCAK_WIDTH_BYTES / WORD_SIZE;
 static constexpr uint64_t KECCAK_RATE_BYTES = 136;
 
-extern void rvr_keccak_f1600(
-    uint64_t state[static const KECCAK_WIDTH_WORDS]);
+extern void rvr_keccak_f1600(uint64_t state[static const KECCAK_WIDTH_WORDS]);
 
 __attribute__((preserve_most)) void rvr_ext_keccakf(RvState* restrict state,
                                                     uint64_t buffer_ptr) {
   uint64_t st[KECCAK_WIDTH_WORDS];
   static_assert(sizeof(st) == KECCAK_WIDTH_BYTES, "keccak state size mismatch");
 
-  rd_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
+  read_mem_u64_range(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
   rvr_keccak_f1600(st);
-  wr_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
+  write_mem_u64_range(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
 }
 
 __attribute__((preserve_most)) bool rvr_ext_xorin(RvState* restrict state,
@@ -29,7 +29,8 @@ __attribute__((preserve_most)) bool rvr_ext_xorin(RvState* restrict state,
   if (unlikely(len > KECCAK_RATE_BYTES)) {
     return false;
   }
-  /* The bound limits this to 17; uint32_t matches the traced range-helper ABI. */
+  /* len is at most 136, so this is at most 17. uint32_t matches the range
+   * helper. */
   uint32_t num_words = (uint32_t)((len + WORD_SIZE - 1) / WORD_SIZE);
   if (unlikely(num_words == 0)) {
     return true;
@@ -39,16 +40,16 @@ __attribute__((preserve_most)) bool rvr_ext_xorin(RvState* restrict state,
   uint64_t input[KECCAK_WIDTH_WORDS];
   assume(num_words <= KECCAK_WIDTH_WORDS);
 
-  rd_mem_u64_range_traced(state, buffer_ptr, buffer, num_words);
-  rd_mem_u64_range_traced(state, input_ptr, input, num_words);
-  /* Both local arrays have KECCAK_WIDTH_WORDS elements and num_words is
-   * bounded above; Clang's C unsafe-buffer heuristic cannot express that. */
+  read_mem_u64_range(state, buffer_ptr, buffer, num_words);
+  read_mem_u64_range(state, input_ptr, input, num_words);
+  /* Both arrays have KECCAK_WIDTH_WORDS elements, and the check above bounds
+   * num_words. Clang cannot prove these bounds. */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
   for (uint32_t i = 0; i < num_words; i++) {
     buffer[i] ^= input[i];
   }
 #pragma clang diagnostic pop
-  wr_mem_u64_range_traced(state, buffer_ptr, buffer, num_words);
+  write_mem_u64_range(state, buffer_ptr, buffer, num_words);
   return true;
 }

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.c
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.c
@@ -8,32 +8,24 @@
 static constexpr uint32_t KECCAK_WIDTH_BYTES = 200;
 static constexpr uint32_t KECCAK_WIDTH_WORDS = KECCAK_WIDTH_BYTES / WORD_SIZE;
 static constexpr uint64_t KECCAK_RATE_BYTES = 136;
-static constexpr uint32_t KECCAK_NUM_ROUNDS = 24;
 
-extern void rvr_keccak_f1600(uint64_t state[static KECCAK_WIDTH_WORDS]);
+extern void rvr_keccak_f1600(
+    uint64_t state[static const KECCAK_WIDTH_WORDS]);
 
 __attribute__((preserve_most)) void rvr_ext_keccakf(RvState* restrict state,
-                                                    uint64_t buffer_ptr,
-                                                    uint32_t /* op_chip_idx */,
-                                                    uint32_t perm_chip_idx) {
+                                                    uint64_t buffer_ptr) {
   uint64_t st[KECCAK_WIDTH_WORDS];
   static_assert(sizeof(st) == KECCAK_WIDTH_BYTES, "keccak state size mismatch");
 
   rd_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
   rvr_keccak_f1600(st);
   wr_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
-
-  /* KeccakfOp cost (1 row) is covered by the per-block chip update emitted
-   * at block entry; only the additional KeccakfPerm rows (24 per
-   * permutation) need trace_chip. */
-  trace_chip(state, perm_chip_idx, KECCAK_NUM_ROUNDS);
 }
 
 __attribute__((preserve_most)) void rvr_ext_xorin(RvState* restrict state,
                                                   uint64_t buffer_ptr,
                                                   uint64_t input_ptr,
-                                                  uint64_t len,
-                                                  uint32_t /* chip_idx */) {
+                                                  uint64_t len) {
   assume(len <= KECCAK_RATE_BYTES);
   /* The bound limits this to 17; uint32_t matches the traced range-helper ABI. */
   uint32_t num_words = (uint32_t)((len + WORD_SIZE - 1) / WORD_SIZE);

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.c
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.c
@@ -22,15 +22,17 @@ __attribute__((preserve_most)) void rvr_ext_keccakf(RvState* restrict state,
   wr_mem_u64_range_traced(state, buffer_ptr, st, KECCAK_WIDTH_WORDS);
 }
 
-__attribute__((preserve_most)) void rvr_ext_xorin(RvState* restrict state,
+__attribute__((preserve_most)) bool rvr_ext_xorin(RvState* restrict state,
                                                   uint64_t buffer_ptr,
                                                   uint64_t input_ptr,
                                                   uint64_t len) {
-  assume(len <= KECCAK_RATE_BYTES);
+  if (unlikely(len > KECCAK_RATE_BYTES)) {
+    return false;
+  }
   /* The bound limits this to 17; uint32_t matches the traced range-helper ABI. */
   uint32_t num_words = (uint32_t)((len + WORD_SIZE - 1) / WORD_SIZE);
   if (unlikely(num_words == 0)) {
-    return;
+    return true;
   }
 
   uint64_t buffer[KECCAK_WIDTH_WORDS];
@@ -48,4 +50,5 @@ __attribute__((preserve_most)) void rvr_ext_xorin(RvState* restrict state,
   }
 #pragma clang diagnostic pop
   wr_mem_u64_range_traced(state, buffer_ptr, buffer, num_words);
+  return true;
 }

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.h
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.h
@@ -13,7 +13,7 @@ struct RvState;
 extern __attribute__((preserve_most)) void rvr_ext_keccakf(
     RvState* state, uint64_t buffer_ptr);
 
-extern __attribute__((preserve_most)) void rvr_ext_xorin(RvState* state,
+extern __attribute__((preserve_most)) bool rvr_ext_xorin(RvState* state,
                                                          uint64_t buffer_ptr,
                                                          uint64_t input_ptr,
                                                          uint64_t len);

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.h
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.h
@@ -11,13 +11,11 @@ struct RvState;
  * caller convention. */
 
 extern __attribute__((preserve_most)) void rvr_ext_keccakf(
-    RvState* state, uint64_t buffer_ptr, uint32_t op_chip_idx,
-    uint32_t perm_chip_idx);
+    RvState* state, uint64_t buffer_ptr);
 
 extern __attribute__((preserve_most)) void rvr_ext_xorin(RvState* state,
                                                          uint64_t buffer_ptr,
                                                          uint64_t input_ptr,
-                                                         uint64_t len,
-                                                         uint32_t chip_idx);
+                                                         uint64_t len);
 
 #endif /* RVR_EXT_KECCAK_H */

--- a/extensions/keccak256/rvr/c/rvr_ext_keccak.h
+++ b/extensions/keccak256/rvr/c/rvr_ext_keccak.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 /* Cold FFI entry points use the preserve_most calling convention so that
  * hot block callers keep their live state in registers across the call.

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -83,7 +83,7 @@ pub struct KeccakExtension {
 
 impl KeccakExtension {
     pub fn new(ctx: Option<&RvrExtensionCtx>) -> Result<Self, ExtensionError> {
-        let _ = opcode_air_idx(ctx, XorinOpcode::XORIN)?;
+        opcode_air_idx(ctx, XorinOpcode::XORIN)?;
         let keccakf_op_chip_idx = opcode_air_idx(ctx, KeccakfOpcode::KECCAKF)?;
         // KeccakfPerm is registered adjacent to KeccakfOp and assigned the next
         // AIR index (keccakf_op_chip_idx + 1) due to reverse registration order.

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -7,18 +7,19 @@
 
 use openvm_instructions::LocalOpcode;
 use openvm_keccak256_transpiler::{KeccakfOpcode, XorinOpcode};
-use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
+use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, FixedTraceRows, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
+    decode_reg, fixed_trace_rows_for_chip, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
     RvrExtensionCtx, RvrInstruction,
 };
+
+const KECCAK_NUM_ROUNDS: u32 = p3_keccak_air::NUM_ROUNDS as u32;
+const _: () = assert!(KECCAK_NUM_ROUNDS as usize == p3_keccak_air::NUM_ROUNDS);
 
 /// keccak-f\[1600\]: read 200 bytes via `buffer_ptr_reg`, permute in place.
 #[derive(Debug, Clone)]
 pub struct KeccakfInstr {
     pub buffer_ptr_reg: Reg,
-    /// KeccakfOp chip (1 row per instruction).
-    pub op_chip_idx: Option<AirIndex>,
     /// KeccakfPerm chip (24 rows per instruction).
     pub perm_chip_idx: Option<AirIndex>,
 }
@@ -30,11 +31,11 @@ impl ExtInstr for KeccakfInstr {
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let buf = ctx.read_reg(self.buffer_ptr_reg);
-        let op = air_index_to_c(self.op_chip_idx);
-        let perm = air_index_to_c(self.perm_chip_idx);
-        let op = format!("{op}u");
-        let perm = format!("{perm}u");
-        ctx.emit_call("rvr_ext_keccakf", &["state", &buf, &op, &perm]);
+        ctx.emit_call("rvr_ext_keccakf", &["state", &buf]);
+    }
+
+    fn fixed_trace_rows(&self) -> Vec<FixedTraceRows> {
+        fixed_trace_rows_for_chip(self.perm_chip_idx, KECCAK_NUM_ROUNDS)
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -52,8 +53,6 @@ pub struct XorinInstr {
     pub buffer_ptr_reg: Reg,
     pub input_ptr_reg: Reg,
     pub len_reg: Reg,
-    /// Xorin chip (1 row per instruction).
-    pub chip_idx: Option<AirIndex>,
 }
 
 impl ExtInstr for XorinInstr {
@@ -65,9 +64,7 @@ impl ExtInstr for XorinInstr {
         let buf_ptr = ctx.read_reg(self.buffer_ptr_reg);
         let input = ctx.read_reg(self.input_ptr_reg);
         let len = ctx.read_reg(self.len_reg);
-        let chip = air_index_to_c(self.chip_idx);
-        let chip = format!("{chip}u");
-        ctx.emit_call("rvr_ext_xorin", &["state", &buf_ptr, &input, &len, &chip]);
+        ctx.emit_call("rvr_ext_xorin", &["state", &buf_ptr, &input, &len]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -81,22 +78,18 @@ impl ExtInstr for XorinInstr {
 
 /// Keccak-256 extension. Register with the `ExtensionRegistry`.
 pub struct KeccakExtension {
-    xorin_chip_idx: Option<AirIndex>,
-    keccakf_op_chip_idx: Option<AirIndex>,
     keccakf_perm_chip_idx: Option<AirIndex>,
 }
 
 impl KeccakExtension {
     pub fn new(ctx: Option<&RvrExtensionCtx>) -> Result<Self, ExtensionError> {
-        let xorin_chip_idx = opcode_air_idx(ctx, XorinOpcode::XORIN)?;
+        let _ = opcode_air_idx(ctx, XorinOpcode::XORIN)?;
         let keccakf_op_chip_idx = opcode_air_idx(ctx, KeccakfOpcode::KECCAKF)?;
         // KeccakfPerm is registered adjacent to KeccakfOp and assigned the next
         // AIR index (keccakf_op_chip_idx + 1) due to reverse registration order.
         let keccakf_perm_chip_idx = keccakf_op_chip_idx.map(AirIndex::next);
 
         Ok(Self {
-            xorin_chip_idx,
-            keccakf_op_chip_idx,
             keccakf_perm_chip_idx,
         })
     }
@@ -112,7 +105,6 @@ impl RvrExtension for KeccakExtension {
                 pc,
                 instr: Instr::Ext(Box::new(KeccakfInstr {
                     buffer_ptr_reg,
-                    op_chip_idx: self.keccakf_op_chip_idx,
                     perm_chip_idx: self.keccakf_perm_chip_idx,
                 })),
                 source_loc: None,
@@ -129,7 +121,6 @@ impl RvrExtension for KeccakExtension {
                     buffer_ptr_reg,
                     input_ptr_reg,
                     len_reg,
-                    chip_idx: self.xorin_chip_idx,
                 })),
                 source_loc: None,
             }));

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -64,7 +64,7 @@ impl ExtInstr for XorinInstr {
         let buf_ptr = ctx.read_reg(self.buffer_ptr_reg);
         let input = ctx.read_reg(self.input_ptr_reg);
         let len = ctx.read_reg(self.len_reg);
-        ctx.emit_call("rvr_ext_xorin", &["state", &buf_ptr, &input, &len]);
+        ctx.emit_checked_call("rvr_ext_xorin", &["state", &buf_ptr, &input, &len]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {

--- a/extensions/pairing/rvr/build.rs
+++ b/extensions/pairing/rvr/build.rs
@@ -27,4 +27,6 @@ fn main() {
     );
     println!("cargo:rerun-if-changed=ffi/Cargo.toml");
     println!("cargo:rerun-if-changed=ffi/src");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/Cargo.toml");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/src");
 }

--- a/extensions/pairing/rvr/c/rvr_ext_pairing.h
+++ b/extensions/pairing/rvr/c/rvr_ext_pairing.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 /* HintFinalExp phantom: computes pairing final exponentiation hint and
  * sets the hint stream (implemented in Rust). */

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -17,15 +17,17 @@ use openvm_pairing_guest::{
 use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{BLS12_381_ELEM_BYTES, FIELD_256_BYTES};
 use rvr_openvm_ext_ffi_common::{
-    ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_u64_wrapper,
+    ext_hint_stream_set, read_mem_u64_execution_input, read_mem_words_execution_input,
 };
 
 /// BN254 base field element size in bytes.
 const BN254_FQ_BYTES: u64 = FIELD_256_BYTES as u64;
 const BN254_FQ_BYTES_USIZE: usize = FIELD_256_BYTES;
+const BN254_FQ_WORDS: usize = BN254_FQ_BYTES_USIZE / WORD_SIZE;
 /// BLS12-381 base field element size in bytes.
 const BLS12_381_FQ_BYTES: u64 = BLS12_381_ELEM_BYTES as u64;
 const BLS12_381_FQ_BYTES_USIZE: usize = BLS12_381_ELEM_BYTES;
+const BLS12_381_FQ_WORDS: usize = BLS12_381_FQ_BYTES_USIZE / WORD_SIZE;
 /// G1 affine point: two field coordinates (x, y).
 const G1_AFFINE_COORDS: u64 = 2;
 /// G2 affine point: two Fp2 coordinates, each containing two Fp elements.
@@ -44,22 +46,13 @@ unsafe fn clear_hint_stream() {
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-/// Read `N` bytes from guest memory (untraced, word-aligned reads).
-unsafe fn read_bytes<const N: usize>(state: *mut c_void, ptr: u64) -> [u8; N] {
+/// Read `N` execution-input bytes from guest memory.
+unsafe fn read_bytes<const N: usize, const WORDS: usize>(state: *mut c_void, ptr: u64) -> [u8; N] {
     const {
-        assert!(
-            N.is_multiple_of(WORD_SIZE),
-            "N must be a multiple of WORD_SIZE"
-        );
+        assert!(N == WORDS * WORD_SIZE, "word count must cover N bytes");
     }
-    let num_words = N / WORD_SIZE;
-    let mut words = vec![0u64; num_words];
-    rd_mem_u64_range_wrapper(
-        state,
-        ptr,
-        words.as_mut_ptr(),
-        u32::try_from(num_words).unwrap(),
-    );
+    let mut words = [0u64; WORDS];
+    read_mem_words_execution_input(state, ptr, &mut words);
     let mut bytes = [0u8; N];
     for (i, &w) in words.iter().enumerate() {
         bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
@@ -69,13 +62,13 @@ unsafe fn read_bytes<const N: usize>(state: *mut c_void, ptr: u64) -> [u8; N] {
 
 /// Read an Fq element from guest memory for BN254.
 unsafe fn read_bn254_fq(state: *mut c_void, ptr: u64) -> Option<bn256::Fq> {
-    let bytes = read_bytes::<BN254_FQ_BYTES_USIZE>(state, ptr);
+    let bytes = read_bytes::<BN254_FQ_BYTES_USIZE, BN254_FQ_WORDS>(state, ptr);
     Option::from(bn256::Fq::from_repr(bytes))
 }
 
 /// Read an Fq element from guest memory for BLS12-381.
 unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u64) -> Option<bls12_381::Fq> {
-    let bytes = read_bytes::<BLS12_381_FQ_BYTES_USIZE>(state, ptr);
+    let bytes = read_bytes::<BLS12_381_FQ_BYTES_USIZE, BLS12_381_FQ_WORDS>(state, ptr);
     Option::from(bls12_381::Fq::from_repr(bytes.into()))
 }
 
@@ -101,10 +94,10 @@ unsafe fn read_pairing_points<Fq: Field, Fq2: Field>(
     read_fq: impl Fn(*mut c_void, u64) -> Option<Fq>,
     make_fq2: impl Fn(Fq, Fq) -> Fq2,
 ) -> Option<PairingPoints<Fq, Fq2>> {
-    let p_ptr = rd_mem_u64_wrapper(state, rs1_val);
-    let p_len = rd_mem_u64_wrapper(state, rs1_val + SLICE_LEN_OFFSET);
-    let q_ptr = rd_mem_u64_wrapper(state, rs2_val);
-    let q_len = rd_mem_u64_wrapper(state, rs2_val + SLICE_LEN_OFFSET);
+    let p_ptr = read_mem_u64_execution_input(state, rs1_val);
+    let p_len = read_mem_u64_execution_input(state, rs1_val + SLICE_LEN_OFFSET);
+    let q_ptr = read_mem_u64_execution_input(state, rs2_val);
+    let q_len = read_mem_u64_execution_input(state, rs2_val + SLICE_LEN_OFFSET);
 
     if p_len != q_len {
         return None;

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -16,18 +16,14 @@ use openvm_pairing_guest::{
 };
 use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{BLS12_381_ELEM_BYTES, FIELD_256_BYTES};
-use rvr_openvm_ext_ffi_common::{
-    ext_hint_stream_set, read_mem_u64_execution_input, read_mem_words_execution_input,
-};
+use rvr_openvm_ext_ffi_common::{ext_hint_stream_set, peek_mem_u64, peek_mem_words};
 
 /// BN254 base field element size in bytes.
 const BN254_FQ_BYTES: u64 = FIELD_256_BYTES as u64;
-const BN254_FQ_BYTES_USIZE: usize = FIELD_256_BYTES;
-const BN254_FQ_WORDS: usize = BN254_FQ_BYTES_USIZE / WORD_SIZE;
+const BN254_FQ_WORDS: usize = FIELD_256_BYTES / WORD_SIZE;
 /// BLS12-381 base field element size in bytes.
 const BLS12_381_FQ_BYTES: u64 = BLS12_381_ELEM_BYTES as u64;
-const BLS12_381_FQ_BYTES_USIZE: usize = BLS12_381_ELEM_BYTES;
-const BLS12_381_FQ_WORDS: usize = BLS12_381_FQ_BYTES_USIZE / WORD_SIZE;
+const BLS12_381_FQ_WORDS: usize = BLS12_381_ELEM_BYTES / WORD_SIZE;
 /// G1 affine point: two field coordinates (x, y).
 const G1_AFFINE_COORDS: u64 = 2;
 /// G2 affine point: two Fp2 coordinates, each containing two Fp elements.
@@ -46,29 +42,29 @@ unsafe fn clear_hint_stream() {
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-/// Read `N` execution-input bytes from guest memory.
+/// Peek at `N` bytes in guest memory.
 unsafe fn read_bytes<const N: usize, const WORDS: usize>(state: *mut c_void, ptr: u64) -> [u8; N] {
     const {
         assert!(N == WORDS * WORD_SIZE, "word count must cover N bytes");
     }
     let mut words = [0u64; WORDS];
-    read_mem_words_execution_input(state, ptr, &mut words);
+    peek_mem_words(state, ptr, &mut words);
     let mut bytes = [0u8; N];
-    for (i, &w) in words.iter().enumerate() {
-        bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_le_bytes());
+    for (i, &word) in words.iter().enumerate() {
+        bytes[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&word.to_le_bytes());
     }
     bytes
 }
 
 /// Read an Fq element from guest memory for BN254.
 unsafe fn read_bn254_fq(state: *mut c_void, ptr: u64) -> Option<bn256::Fq> {
-    let bytes = read_bytes::<BN254_FQ_BYTES_USIZE, BN254_FQ_WORDS>(state, ptr);
+    let bytes = read_bytes::<FIELD_256_BYTES, BN254_FQ_WORDS>(state, ptr);
     Option::from(bn256::Fq::from_repr(bytes))
 }
 
 /// Read an Fq element from guest memory for BLS12-381.
 unsafe fn read_bls12_381_fq(state: *mut c_void, ptr: u64) -> Option<bls12_381::Fq> {
-    let bytes = read_bytes::<BLS12_381_FQ_BYTES_USIZE, BLS12_381_FQ_WORDS>(state, ptr);
+    let bytes = read_bytes::<BLS12_381_ELEM_BYTES, BLS12_381_FQ_WORDS>(state, ptr);
     Option::from(bls12_381::Fq::from_repr(bytes.into()))
 }
 
@@ -94,10 +90,10 @@ unsafe fn read_pairing_points<Fq: Field, Fq2: Field>(
     read_fq: impl Fn(*mut c_void, u64) -> Option<Fq>,
     make_fq2: impl Fn(Fq, Fq) -> Fq2,
 ) -> Option<PairingPoints<Fq, Fq2>> {
-    let p_ptr = read_mem_u64_execution_input(state, rs1_val);
-    let p_len = read_mem_u64_execution_input(state, rs1_val + SLICE_LEN_OFFSET);
-    let q_ptr = read_mem_u64_execution_input(state, rs2_val);
-    let q_len = read_mem_u64_execution_input(state, rs2_val + SLICE_LEN_OFFSET);
+    let p_ptr = peek_mem_u64(state, rs1_val);
+    let p_len = peek_mem_u64(state, rs1_val + SLICE_LEN_OFFSET);
+    let q_ptr = peek_mem_u64(state, rs2_val);
+    let q_len = peek_mem_u64(state, rs2_val + SLICE_LEN_OFFSET);
 
     if p_len != q_len {
         return None;

--- a/extensions/pairing/rvr/ffi/src/lib.rs
+++ b/extensions/pairing/rvr/ffi/src/lib.rs
@@ -14,7 +14,7 @@ use openvm_pairing_guest::{
     halo2curves_shims::{bls12_381::Bls12_381, bn254::Bn254},
     pairing::{FinalExp, MultiMillerLoop},
 };
-use openvm_platform::{WORD_SIZE, WORD_SIZE_U32};
+use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{BLS12_381_ELEM_BYTES, FIELD_256_BYTES};
 use rvr_openvm_ext_ffi_common::{
     ext_hint_stream_set, rd_mem_u64_range_wrapper, rd_mem_u64_wrapper,
@@ -31,7 +31,7 @@ const G1_AFFINE_COORDS: u64 = 2;
 /// G2 affine point: two Fp2 coordinates, each containing two Fp elements.
 const G2_AFFINE_COORDS: u64 = 4;
 /// Offset of `len` in a guest slice header `(data_ptr, len)`.
-const SLICE_LEN_OFFSET: u64 = WORD_SIZE_U32 as u64;
+const SLICE_LEN_OFFSET: u64 = WORD_SIZE as u64;
 
 unsafe fn set_hint_stream(bytes: &[u8]) {
     let len = u64::try_from(bytes.len()).unwrap();

--- a/extensions/pairing/rvr/src/lib.rs
+++ b/extensions/pairing/rvr/src/lib.rs
@@ -52,8 +52,8 @@ impl ExtInstr for HintFinalExpInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rs1 = ctx.read_reg_execution_input(self.rs1_reg);
-        let rs2 = ctx.read_reg_execution_input(self.rs2_reg);
+        let rs1 = ctx.peek_reg(self.rs1_reg);
+        let rs2 = ctx.peek_reg(self.rs2_reg);
         ctx.emit_call(self.curve.ffi_symbol(), &["state", &rs1, &rs2]);
     }
 

--- a/extensions/pairing/rvr/src/lib.rs
+++ b/extensions/pairing/rvr/src/lib.rs
@@ -52,8 +52,8 @@ impl ExtInstr for HintFinalExpInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let rs1 = ctx.read_reg(self.rs1_reg);
-        let rs2 = ctx.read_reg(self.rs2_reg);
+        let rs1 = ctx.read_reg_execution_input(self.rs1_reg);
+        let rs2 = ctx.read_reg_execution_input(self.rs2_reg);
         ctx.emit_call(self.curve.ffi_symbol(), &["state", &rs1, &rs2]);
     }
 
@@ -123,5 +123,9 @@ impl RvrExtension for PairingExtension {
             "librvr_openvm_ext_pairing_ffi.a",
             include_bytes!(env!("RVR_PAIRING_FFI_STATICLIB")),
         )]
+    }
+
+    fn uses_memory_wrappers(&self) -> bool {
+        true
     }
 }

--- a/extensions/riscv/circuit/src/hintstore/mod.rs
+++ b/extensions/riscv/circuit/src/hintstore/mod.rs
@@ -72,7 +72,7 @@ fn validate_hint_buffer_num_words(pc: u32, num_words: u64) -> Result<u16, Execut
             ExecutionError::HintBufferTooLarge {
                 pc,
                 num_words,
-                max_hint_buffer_words: MAX_HINT_BUFFER_DWORDS as u32,
+                max_hint_buffer_words: MAX_HINT_BUFFER_DWORDS as u64,
             }
         });
     }

--- a/extensions/riscv/guest/src/lib.rs
+++ b/extensions/riscv/guest/src/lib.rs
@@ -31,7 +31,7 @@ pub const CSRRW_FUNCT3: u8 = 0b001;
 // For the constraints, they are configured for a range of MAX_HINT_BUFFER_DWORDS_BITS between
 // [8,16)
 pub const MAX_HINT_BUFFER_DWORDS_BITS: usize = 10;
-// RVR narrows a validated HINT_BUFFER count to `u16` at its host callback ABI.
+// RVR checks the HINT_BUFFER count before passing it to the host as `u16`.
 const _: () = assert!(MAX_HINT_BUFFER_DWORDS_BITS <= u16::BITS as usize);
 /// Maximum number of dwords that can be read in a single HINT_BUFFER instruction.
 /// AIR constraint requires rem_dwords < 2^MAX_HINT_BUFFER_DWORDS_BITS, so max is one less

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -37,7 +37,7 @@ impl ExtInstr for HintStoreWInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg(self.ptr_reg);
         ctx.emit_checked_call_without_page_flush("openvm_hint_storew", &[&ptr]);
-        ctx.trace_page_access(&ptr, RV64_REGISTER_BYTES as u8, RV64_MEMORY_AS);
+        ctx.trace_page_access(&ptr, MemWidth::Double, RV64_MEMORY_AS);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -113,7 +113,7 @@ impl ExtInstr for RevealInstr {
         };
         let width = format!("{}u", self.width.bytes());
         ctx.emit_checked_call_without_page_flush("openvm_reveal", &[&src, &addr, &width]);
-        ctx.trace_page_access(&addr, self.width.bytes(), PUBLIC_VALUES_AS);
+        ctx.trace_page_access(&addr, self.width, PUBLIC_VALUES_AS);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -152,8 +152,8 @@ impl ExtInstr for PrintStrInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let ptr = ctx.read_reg_execution_input(self.ptr_reg);
-        let len = ctx.read_reg_execution_input(self.len_reg);
+        let ptr = ctx.peek_reg(self.ptr_reg);
+        let len = ctx.peek_reg(self.len_reg);
         ctx.emit_checked_call_without_page_flush("openvm_print_str", &[&ptr, &len]);
     }
 
@@ -175,7 +175,7 @@ impl ExtInstr for HintRandomInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let n = ctx.read_reg_execution_input(self.num_words_reg);
+        let n = ctx.peek_reg(self.num_words_reg);
         ctx.emit_checked_call_without_page_flush("openvm_hint_random", &[&n]);
     }
 
@@ -538,7 +538,7 @@ mod tests {
             format!("r{idx}")
         }
 
-        fn read_reg_execution_input(&mut self, idx: u8) -> String {
+        fn peek_reg(&mut self, idx: u8) -> String {
             format!("r{idx}")
         }
 
@@ -597,7 +597,8 @@ mod tests {
             self.write_line("}");
         }
 
-        fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32) {
+        fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: u32) {
+            let size = width.bytes();
             self.write_line(&format!(
                 "trace_page_access(state, {addr}, {size}u, {addr_space}u);"
             ));

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -36,8 +36,8 @@ impl ExtInstr for HintStoreWInstr {
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg(self.ptr_reg);
-        ctx.trace_mem_access(&ptr, RV64_MEMORY_AS);
         ctx.emit_checked_call_without_page_flush("openvm_hint_storew", &[&ptr]);
+        ctx.trace_mem_access(&ptr, RV64_MEMORY_AS);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -67,14 +67,14 @@ impl ExtInstr for HintBufferInstr {
         ));
         ctx.emit_trap();
         ctx.write_line("}");
+        let callback_count = format!("(uint16_t)({n})");
+        ctx.emit_checked_call_without_page_flush("openvm_hint_buffer", &[&ptr, &callback_count]);
         // Block-entry already credits a static +1; emit the runtime
         // `(n - 1)` correction only when there is more than one row.
         let chip_idx = air_index_to_c(self.chip_idx);
         // The guard above proves this correction is at most 1022.
         ctx.trace_chip_if_nonzero(chip_idx, &format!("(uint32_t)({n} - 1ull)"));
         ctx.trace_mem_access_u64_range(&ptr, &n, RV64_MEMORY_AS);
-        let n = format!("(uint16_t)({n})");
-        ctx.emit_checked_call_without_page_flush("openvm_hint_buffer", &[&ptr, &n]);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -111,9 +111,9 @@ impl ExtInstr for RevealInstr {
             std::cmp::Ordering::Equal => ptr,
             std::cmp::Ordering::Greater => format!("({ptr} + 0x{:08x}ull)", self.offset),
         };
-        ctx.trace_mem_access(&addr, PUBLIC_VALUES_AS);
         let width = format!("{}u", self.width.bytes());
         ctx.emit_checked_call_without_page_flush("openvm_reveal", &[&src, &addr, &width]);
+        ctx.trace_mem_access(&addr, PUBLIC_VALUES_AS);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -426,6 +426,9 @@ pub extern "C" fn host_print_str(ctx: *mut c_void, ptr: u64, len: u64) -> bool {
         }
         let slice =
             unsafe { std::slice::from_raw_parts(io.memory_ptr.add(range.start), range.len()) };
+        if std::str::from_utf8(slice).is_err() {
+            return false;
+        }
         let _ = std::io::stdout().write_all(slice);
         let _ = std::io::stdout().flush();
     }
@@ -464,7 +467,7 @@ fn hint_random_byte_len(num_words: u64) -> Result<usize, &'static str> {
 pub extern "C" fn host_hint_storew(ctx: *mut c_void, dest_addr: u64) -> bool {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     if io.hint_stream.remaining() < RV64_REGISTER_NUM_LIMBS || io.memory_ptr.is_null() {
-        return true;
+        return false;
     }
     let Some(range) = checked_mem_bounds_range(dest_addr, RV64_REGISTER_BYTES) else {
         return false;
@@ -483,7 +486,7 @@ pub extern "C" fn host_hint_buffer(ctx: *mut c_void, dest_addr: u64, num_words: 
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     let nbytes = num_words * RV64_REGISTER_NUM_LIMBS;
     if io.hint_stream.remaining() < nbytes || io.memory_ptr.is_null() {
-        return true;
+        return false;
     }
     let Some(range) = checked_mem_bounds_range(dest_addr, num_bytes) else {
         return false;
@@ -642,7 +645,7 @@ mod tests {
         let mut ctx = TestEmitCtx::default();
         instr.emit_c(&mut ctx);
         assert_eq!(
-            ctx.lines[1],
+            ctx.lines[0],
             format!("if (unlikely(!openvm_reveal(r1, r2, {width}u))) {{")
         );
     }
@@ -698,11 +701,11 @@ mod tests {
 
         assert_eq!(
             ctx.lines[0],
-            format!("trace_mem_access(state, (r10 + 0x0000000cull), {PUBLIC_VALUES_AS}u);")
+            "if (unlikely(!openvm_reveal(r5, (r10 + 0x0000000cull), 4u))) {"
         );
         assert_eq!(
-            ctx.lines[1],
-            "if (unlikely(!openvm_reveal(r5, (r10 + 0x0000000cull), 4u))) {"
+            ctx.lines[3],
+            format!("trace_mem_access(state, (r10 + 0x0000000cull), {PUBLIC_VALUES_AS}u);")
         );
     }
 
@@ -832,6 +835,63 @@ mod tests {
         assert_eq!(&memory[17..], &[0; 7]);
         assert_eq!(io.hint_stream.remaining(), 0);
         assert!(io.input_stream.is_empty());
+    }
+
+    #[test]
+    fn host_hint_writes_reject_short_stream_without_mutation() {
+        let mut input_stream = VecDeque::new();
+        let mut hint_stream = HintStream::default();
+        hint_stream.set_hint(vec![1, 2, 3, 4, 5, 6, 7]);
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut memory = vec![0xa5; 16];
+        let original_memory = memory.clone();
+        let mut public_values = Vec::new();
+        let mut deferrals = Vec::new();
+        let mut io = OpenVmIoState {
+            input_stream: &mut input_stream,
+            hint_stream: &mut hint_stream,
+            rng: &mut rng,
+            memory_ptr: memory.as_mut_ptr(),
+            public_values: &mut public_values,
+            deferral_memory: std::ptr::null_mut(),
+            deferral_memory_len_bytes: 0,
+            deferrals: &mut deferrals,
+        };
+        let ctx = &mut io as *mut OpenVmIoState<'_> as *mut c_void;
+
+        assert!(!host_hint_storew(ctx, 0));
+        assert!(!host_hint_buffer(ctx, 0, 1));
+        assert_eq!(io.hint_stream.remaining(), 7);
+        let mut hint = [0; 7];
+        io.hint_stream.copy_to_slice(&mut hint);
+        assert_eq!(hint, [1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(memory, original_memory);
+    }
+
+    #[test]
+    fn host_print_str_rejects_invalid_utf8() {
+        let mut input_stream = VecDeque::new();
+        let mut hint_stream = HintStream::default();
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut memory = vec![0xff];
+        let mut public_values = Vec::new();
+        let mut deferrals = Vec::new();
+        let mut io = OpenVmIoState {
+            input_stream: &mut input_stream,
+            hint_stream: &mut hint_stream,
+            rng: &mut rng,
+            memory_ptr: memory.as_mut_ptr(),
+            public_values: &mut public_values,
+            deferral_memory: std::ptr::null_mut(),
+            deferral_memory_len_bytes: 0,
+            deferrals: &mut deferrals,
+        };
+
+        assert!(!host_print_str(
+            &mut io as *mut OpenVmIoState<'_> as *mut c_void,
+            0,
+            1,
+        ));
     }
 
     #[test_case(u64::from(u32::MAX) + 1; "nonzero_upper_bits")]

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -37,7 +37,7 @@ impl ExtInstr for HintStoreWInstr {
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
         let ptr = ctx.read_reg(self.ptr_reg);
         ctx.emit_checked_call_without_page_flush("openvm_hint_storew", &[&ptr]);
-        ctx.trace_mem_access(&ptr, RV64_MEMORY_AS);
+        ctx.trace_page_access(&ptr, RV64_REGISTER_BYTES as u8, RV64_MEMORY_AS);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -72,9 +72,9 @@ impl ExtInstr for HintBufferInstr {
         // Block-entry already credits a static +1; emit the runtime
         // `(n - 1)` correction only when there is more than one row.
         let chip_idx = air_index_to_c(self.chip_idx);
-        // The guard above proves this correction is at most 1022.
+        // After the check above, n - 1 is at most 1022.
         ctx.trace_chip_if_nonzero(chip_idx, &format!("(uint32_t)({n} - 1ull)"));
-        ctx.trace_mem_access_u64_range(&ptr, &n, RV64_MEMORY_AS);
+        ctx.trace_page_access_u64_range(&ptr, &n, RV64_MEMORY_AS);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -113,7 +113,7 @@ impl ExtInstr for RevealInstr {
         };
         let width = format!("{}u", self.width.bytes());
         ctx.emit_checked_call_without_page_flush("openvm_reveal", &[&src, &addr, &width]);
-        ctx.trace_mem_access(&addr, PUBLIC_VALUES_AS);
+        ctx.trace_page_access(&addr, self.width.bytes(), PUBLIC_VALUES_AS);
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -152,8 +152,8 @@ impl ExtInstr for PrintStrInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let ptr = ctx.read_reg_raw(self.ptr_reg);
-        let len = ctx.read_reg_raw(self.len_reg);
+        let ptr = ctx.read_reg_execution_input(self.ptr_reg);
+        let len = ctx.read_reg_execution_input(self.len_reg);
         ctx.emit_checked_call_without_page_flush("openvm_print_str", &[&ptr, &len]);
     }
 
@@ -175,7 +175,7 @@ impl ExtInstr for HintRandomInstr {
     }
 
     fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
-        let n = ctx.read_reg_raw(self.num_words_reg);
+        let n = ctx.read_reg_execution_input(self.num_words_reg);
         ctx.emit_checked_call_without_page_flush("openvm_hint_random", &[&n]);
     }
 
@@ -498,7 +498,7 @@ pub extern "C" fn host_hint_buffer(ctx: *mut c_void, dest_addr: u64, num_words: 
 }
 
 /// Host callback for stores to `PUBLIC_VALUES_AS`.
-/// Cost corrections are handled in generated C.
+/// Generated C adds the trace-row cost.
 pub extern "C" fn host_reveal(ctx: *mut c_void, src_val: u64, addr: u64, width: u8) -> bool {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     let width = match width {
@@ -538,13 +538,11 @@ mod tests {
             format!("r{idx}")
         }
 
-        fn read_reg_raw(&mut self, idx: u8) -> String {
+        fn read_reg_execution_input(&mut self, idx: u8) -> String {
             format!("r{idx}")
         }
 
         fn write_reg(&mut self, _idx: u8, _val: &str) {}
-
-        fn write_reg_raw(&mut self, _idx: u8, _val: &str) {}
 
         fn write_line(&mut self, s: &str) {
             self.lines.push(s.to_string());
@@ -599,18 +597,20 @@ mod tests {
             self.write_line("}");
         }
 
-        fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {
-            self.write_line(&format!("trace_mem_access(state, {addr}, {addr_space}u);"));
+        fn trace_page_access(&mut self, addr: &str, size: u8, addr_space: u32) {
+            self.write_line(&format!(
+                "trace_page_access(state, {addr}, {size}u, {addr_space}u);"
+            ));
         }
 
-        fn trace_mem_access_u64_range(
+        fn trace_page_access_u64_range(
             &mut self,
             base_addr: &str,
             num_dwords: &str,
             addr_space: u32,
         ) {
             self.write_line(&format!(
-                "trace_mem_access_u64_range(state, {base_addr}, {num_dwords}, {addr_space}u);"
+                "trace_page_access_u64_range(state, {base_addr}, {num_dwords}, {addr_space}u);"
             ));
         }
     }
@@ -689,7 +689,7 @@ mod tests {
     }
 
     #[test]
-    fn reveal_traces_the_offset_public_values_address() {
+    fn reveal_accounts_for_the_offset_public_values_page() {
         let mut ctx = TestEmitCtx::default();
         RevealInstr {
             src_reg: 5,
@@ -705,7 +705,7 @@ mod tests {
         );
         assert_eq!(
             ctx.lines[3],
-            format!("trace_mem_access(state, (r10 + 0x0000000cull), {PUBLIC_VALUES_AS}u);")
+            format!("trace_page_access(state, (r10 + 0x0000000cull), 4u, {PUBLIC_VALUES_AS}u);")
         );
     }
 

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -70,10 +70,8 @@ impl ExtInstr for HintBufferInstr {
         // Block-entry already credits a static +1; emit the runtime
         // `(n - 1)` correction only when there is more than one row.
         let chip_idx = air_index_to_c(self.chip_idx);
-        ctx.write_line(&format!("if ({n} > 1) {{"));
         // The guard above proves this correction is at most 1022.
-        ctx.trace_chip(chip_idx, &format!("(uint32_t)({n} - 1ull)"));
-        ctx.write_line("}");
+        ctx.trace_chip_if_nonzero(chip_idx, &format!("(uint32_t)({n} - 1ull)"));
         ctx.trace_mem_access_u64_range(&ptr, &n, RV64_MEMORY_AS);
         let n = format!("(uint16_t)({n})");
         ctx.emit_checked_call_without_page_flush("openvm_hint_buffer", &[&ptr, &n]);
@@ -579,8 +577,23 @@ mod tests {
             tmp
         }
 
+        fn emit_call_with_trace_result(
+            &mut self,
+            ret_ty: &str,
+            name: &str,
+            args: &[&str],
+        ) -> Option<String> {
+            Some(self.emit_call_expr(ret_ty, name, args))
+        }
+
         fn trace_chip(&mut self, chip_idx: u32, count_expr: &str) {
             self.write_line(&format!("trace_chip(state, {chip_idx}u, {count_expr});"));
+        }
+
+        fn trace_chip_if_nonzero(&mut self, chip_idx: u32, count_expr: &str) {
+            self.write_line(&format!("if (({count_expr}) != 0u) {{"));
+            self.trace_chip(chip_idx, count_expr);
+            self.write_line("}");
         }
 
         fn trace_mem_access(&mut self, addr: &str, addr_space: u32) {

--- a/extensions/riscv/tests/programs/examples/rvr_embedded_text_data.rs
+++ b/extensions/riscv/tests/programs/examples/rvr_embedded_text_data.rs
@@ -10,6 +10,12 @@ openvm::entry!(main);
 
 pub fn main() {
     unsafe {
-        asm!("j 2f", ".word 0x0020006f", "2:", options(nomem, nostack),);
+        asm!(
+            "j 2f",
+            // This invalid JAL encoding is data and must not become a CFG edge.
+            ".word 0x0020006f",
+            "2:",
+            options(nomem, nostack),
+        );
     }
 }

--- a/extensions/riscv/tests/programs/examples/rvr_hint_buffer_oversized.rs
+++ b/extensions/riscv/tests/programs/examples/rvr_hint_buffer_oversized.rs
@@ -4,18 +4,23 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
 use core::arch::asm;
 
 openvm::entry!(main);
 
 pub fn main() {
-    let mut output = [0u64; 1];
-    unsafe {
-        asm!(
-            ".insn i 0x0b, 1, {output}, {num_words}, 1",
-            output = in(reg) output.as_mut_ptr(),
-            num_words = in(reg) 1024u64,
-            options(nostack),
-        );
+    #[cfg(any(openvm_intrinsics, target_os = "openvm"))]
+    {
+        openvm_riscv_guest::hint_input();
+        let mut output = [0u64; 1024];
+        unsafe {
+            asm!(
+                ".insn i 0x0b, 1, {output}, {num_words}, 1",
+                output = in(reg) output.as_mut_ptr(),
+                num_words = in(reg) 1024u64,
+                options(nostack),
+            );
+        }
     }
 }

--- a/extensions/riscv/tests/programs/examples/rvr_invalid_branch_fallthrough.rs
+++ b/extensions/riscv/tests/programs/examples/rvr_invalid_branch_fallthrough.rs
@@ -4,13 +4,20 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
 use core::arch::asm;
 
 openvm::entry!(main);
 
 pub fn main() {
+    #[cfg(any(openvm_intrinsics, target_os = "openvm"))]
     unsafe {
-        // bne x0, x0, +2: the invalid target is never taken.
-        asm!(".word 0x00001163", options(nomem, nostack));
+        // beq a0, a1, +2: unequal values leave the invalid target untaken.
+        asm!(
+            ".word 0x00b50163",
+            in("a0") 1u64,
+            in("a1") 2u64,
+            options(nomem, nostack),
+        );
     }
 }

--- a/extensions/riscv/tests/programs/examples/rvr_invalid_branch_taken.rs
+++ b/extensions/riscv/tests/programs/examples/rvr_invalid_branch_taken.rs
@@ -4,13 +4,20 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
 use core::arch::asm;
 
 openvm::entry!(main);
 
 pub fn main() {
+    #[cfg(any(openvm_intrinsics, target_os = "openvm"))]
     unsafe {
-        // beq x0, x0, +2: taking the invalid target must trap.
-        asm!(".word 0x00000163", options(nomem, nostack));
+        // beq a0, a1, +2: equal values in distinct registers take the invalid target.
+        asm!(
+            ".word 0x00b50163",
+            in("a0") 1u64,
+            in("a1") 1u64,
+            options(nomem, nostack),
+        );
     }
 }

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -89,6 +89,7 @@ mod tests {
 
     #[test_case("rvr_invalid_branch_taken"; "invalid_branch_taken")]
     #[test_case("out_of_bound_reveal"; "out_of_bound_reveal")]
+    #[test_case("rvr_hint_buffer_zero"; "hint_buffer_zero")]
     #[cfg(feature = "rvr")]
     fn test_rvr_example_traps(program_name: &str) {
         assert_rvr_example_traps(program_name);
@@ -191,11 +192,25 @@ mod tests {
 
     #[cfg(feature = "rvr")]
     fn assert_rvr_example_traps(program_name: &str) {
-        assert_rvr_example_with_config_traps(program_name, test_rv64im_config());
+        assert_rvr_example_with_config_and_input_traps(program_name, test_rv64im_config(), vec![]);
     }
 
     #[cfg(feature = "rvr")]
     fn assert_rvr_example_with_config_traps(program_name: &str, config: Rv64ImConfig) {
+        assert_rvr_example_with_config_and_input_traps(program_name, config, vec![]);
+    }
+
+    #[cfg(feature = "rvr")]
+    fn assert_rvr_example_traps_with_input(program_name: &str, input: Vec<Vec<u8>>) {
+        assert_rvr_example_with_config_and_input_traps(program_name, test_rv64im_config(), input);
+    }
+
+    #[cfg(feature = "rvr")]
+    fn assert_rvr_example_with_config_and_input_traps(
+        program_name: &str,
+        config: Rv64ImConfig,
+        input: Vec<Vec<u8>>,
+    ) {
         let elf =
             build_example_program_at_path(get_programs_dir!(), program_name, &config).unwrap();
         let exe = VmExe::from_elf(
@@ -207,7 +222,7 @@ mod tests {
         )
         .unwrap();
         let executor = VmExecutor::new(config).unwrap();
-        let result = executor.instance(&exe).unwrap().execute(vec![]);
+        let result = executor.instance(&exe).unwrap().execute(input);
 
         match result {
             Err(ExecutionError::RvrExecution(message)) => {
@@ -644,12 +659,16 @@ mod tests {
         assert_child_aborts("tests::test_out_of_bound_mem_access");
     }
 
-    #[test_case("rvr_hint_buffer_zero"; "zero")]
-    #[test_case("rvr_hint_buffer_oversized"; "oversized")]
     #[test_case("out_of_bound_print_str"; "print_str_out_of_bounds")]
     #[cfg(all(feature = "rvr", not(feature = "unprotected")))]
     fn test_rvr_protected_execution_traps(program_name: &str) {
         assert_rvr_example_traps(program_name);
+    }
+
+    #[test]
+    #[cfg(feature = "rvr")]
+    fn test_rvr_hint_buffer_rejects_oversized_count() {
+        assert_rvr_example_traps_with_input("rvr_hint_buffer_oversized", vec![vec![0u8; 8192]]);
     }
 
     #[test_case("getrandom", vec!["getrandom", "getrandom-unsupported"])]

--- a/extensions/sha2/rvr/Cargo.toml
+++ b/extensions/sha2/rvr/Cargo.toml
@@ -12,6 +12,7 @@ rvr-openvm-ir.workspace = true
 rvr-openvm-lift.workspace = true
 
 openvm-instructions.workspace = true
+openvm-sha2-air.workspace = true
 openvm-sha2-transpiler.workspace = true
 
 [build-dependencies]

--- a/extensions/sha2/rvr/build.rs
+++ b/extensions/sha2/rvr/build.rs
@@ -28,4 +28,6 @@ fn main() {
     );
     println!("cargo:rerun-if-changed=ffi/Cargo.toml");
     println!("cargo:rerun-if-changed=ffi/src");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/Cargo.toml");
+    println!("cargo:rerun-if-changed=../../../crates/rvr/rvr-openvm-ffi-common/src");
 }

--- a/extensions/sha2/rvr/c/rvr_ext_sha2.h
+++ b/extensions/sha2/rvr/c/rvr_ext_sha2.h
@@ -6,11 +6,11 @@
 struct RvState;
 
 /* SHA-256 compress extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_sha256(RvState* state, uint64_t dst_ptr, uint64_t state_ptr, uint64_t input_ptr,
-                           uint32_t main_chip_idx, uint32_t block_hasher_chip_idx);
+extern void rvr_ext_sha256(RvState* state, uint64_t dst_ptr,
+                           uint64_t state_ptr, uint64_t input_ptr);
 
 /* SHA-512 compress extension FFI entry point (implemented in Rust). */
-extern void rvr_ext_sha512(RvState* state, uint64_t dst_ptr, uint64_t state_ptr, uint64_t input_ptr,
-                           uint32_t main_chip_idx, uint32_t block_hasher_chip_idx);
+extern void rvr_ext_sha512(RvState* state, uint64_t dst_ptr,
+                           uint64_t state_ptr, uint64_t input_ptr);
 
 #endif /* RVR_EXT_SHA2_H */

--- a/extensions/sha2/rvr/c/rvr_ext_sha2.h
+++ b/extensions/sha2/rvr/c/rvr_ext_sha2.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-struct RvState;
+typedef struct RvState RvState;
 
 /* SHA-256 compress extension FFI entry point (implemented in Rust). */
 extern void rvr_ext_sha256(RvState* state, uint64_t dst_ptr,

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -1,15 +1,14 @@
 //! FFI functions for the SHA-2 extension (SHA-256 + SHA-512).
 //!
-//! These Rust functions are called from generated C code. They receive resolved
-//! register values and the state as an opaque pointer. Memory reads/writes,
-//! and SHA-2 computation go through double FFI; register access stays on the C
-//! side. Fixed chip-row accounting is folded into generated block metering.
+//! Generated C calls these Rust functions, which call back into C for memory
+//! access. Register access stays in generated C. The generator adds fixed chip
+//! rows to each block's metering update.
 
 use std::ffi::c_void;
 
 use generic_array::GenericArray;
 use openvm_platform::WORD_SIZE;
-use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, u64s_as_u32s_mut, wr_mem_words_traced};
+use rvr_openvm_ext_ffi_common::{read_mem_words, u64s_as_u32s_mut, write_mem_words};
 use sha2::{compress256, compress512};
 
 // SHA-256: 32-byte state (4 u64s / 8 u32s), 64-byte block (8 u64s)
@@ -49,19 +48,19 @@ pub unsafe extern "C" fn rvr_ext_sha256(
 ) {
     // Read state as 4 u64s (32 bytes); view as [u32; 8] for compress256.
     let mut state_words = [0u64; SHA256_STATE_WORDS];
-    rd_mem_words_traced(state, state_ptr, &mut state_words);
+    read_mem_words(state, state_ptr, &mut state_words);
     let state_u32s: &mut [u32; 8] = u64s_as_u32s_mut(&mut state_words).try_into().unwrap();
 
     // Read block as 8 u64s (64 bytes); view as bytes for compress256.
     let mut block_words = [0u64; SHA256_BLOCK_WORDS];
-    rd_mem_words_traced(state, input_ptr, &mut block_words);
+    read_mem_words(state, input_ptr, &mut block_words);
     let block_array: &GenericArray<u8, _> =
         GenericArray::from_slice(u64_words_as_bytes(&block_words));
 
     compress256(state_u32s, &[*block_array]);
     // state_u32s borrow ends here; state_words now holds the compressed state.
 
-    wr_mem_words_traced(state, dst_ptr, &state_words);
+    write_mem_words(state, dst_ptr, &state_words);
 }
 
 /// SHA-512 compress FFI entry point.
@@ -81,15 +80,15 @@ pub unsafe extern "C" fn rvr_ext_sha512(
 ) {
     // SHA-512 state is naturally [u64; 8]; read directly.
     let mut state_u64s = [0u64; SHA512_STATE_WORDS];
-    rd_mem_words_traced(state, state_ptr, &mut state_u64s);
+    read_mem_words(state, state_ptr, &mut state_u64s);
 
     // Read block as 16 u64s (128 bytes); view as bytes for compress512.
     let mut block_words = [0u64; SHA512_BLOCK_WORDS];
-    rd_mem_words_traced(state, input_ptr, &mut block_words);
+    read_mem_words(state, input_ptr, &mut block_words);
     let block_array: &GenericArray<u8, _> =
         GenericArray::from_slice(u64_words_as_bytes(&block_words));
 
     compress512(&mut state_u64s, &[*block_array]);
 
-    wr_mem_words_traced(state, dst_ptr, &state_u64s);
+    write_mem_words(state, dst_ptr, &state_u64s);
 }

--- a/extensions/sha2/rvr/ffi/src/lib.rs
+++ b/extensions/sha2/rvr/ffi/src/lib.rs
@@ -2,16 +2,14 @@
 //!
 //! These Rust functions are called from generated C code. They receive resolved
 //! register values and the state as an opaque pointer. Memory reads/writes,
-//! SHA-2 computation, and chip tracing go through double FFI; register access
-//! stays on the C side.
+//! and SHA-2 computation go through double FFI; register access stays on the C
+//! side. Fixed chip-row accounting is folded into generated block metering.
 
 use std::ffi::c_void;
 
 use generic_array::GenericArray;
 use openvm_platform::WORD_SIZE;
-use rvr_openvm_ext_ffi_common::{
-    rd_mem_words_traced, trace_chip_wrapper, u64s_as_u32s_mut, wr_mem_words_traced,
-};
+use rvr_openvm_ext_ffi_common::{rd_mem_words_traced, u64s_as_u32s_mut, wr_mem_words_traced};
 use sha2::{compress256, compress512};
 
 // SHA-256: 32-byte state (4 u64s / 8 u32s), 64-byte block (8 u64s)
@@ -19,14 +17,12 @@ const SHA256_STATE_BYTES: usize = 32;
 const SHA256_BLOCK_BYTES: usize = 64;
 const SHA256_STATE_WORDS: usize = SHA256_STATE_BYTES / WORD_SIZE;
 const SHA256_BLOCK_WORDS: usize = SHA256_BLOCK_BYTES / WORD_SIZE;
-const SHA256_ROWS_PER_BLOCK: u32 = 17;
 
 // SHA-512: 64-byte state (8 u64s), 128-byte block (16 u64s)
 const SHA512_STATE_BYTES: usize = 64;
 const SHA512_BLOCK_BYTES: usize = 128;
 const SHA512_STATE_WORDS: usize = SHA512_STATE_BYTES / WORD_SIZE;
 const SHA512_BLOCK_WORDS: usize = SHA512_BLOCK_BYTES / WORD_SIZE;
-const SHA512_ROWS_PER_BLOCK: u32 = 21;
 
 #[inline(always)]
 fn u64_words_as_bytes(words: &[u64]) -> &[u8] {
@@ -39,8 +35,7 @@ fn u64_words_as_bytes(words: &[u64]) -> &[u8] {
 /// SHA-256 compress FFI entry point.
 ///
 /// Reads `SHA256_STATE_BYTES` of state and `SHA256_BLOCK_BYTES` of input block,
-/// applies SHA-256 compression, writes new state to `dst_ptr`. Reports chip
-/// heights for metering.
+/// applies SHA-256 compression, and writes new state to `dst_ptr`.
 ///
 /// # Safety
 ///
@@ -51,8 +46,6 @@ pub unsafe extern "C" fn rvr_ext_sha256(
     dst_ptr: u64,
     state_ptr: u64,
     input_ptr: u64,
-    _main_chip_idx: u32,
-    block_hasher_chip_idx: u32,
 ) {
     // Read state as 4 u64s (32 bytes); view as [u32; 8] for compress256.
     let mut state_words = [0u64; SHA256_STATE_WORDS];
@@ -69,14 +62,12 @@ pub unsafe extern "C" fn rvr_ext_sha256(
     // state_u32s borrow ends here; state_words now holds the compressed state.
 
     wr_mem_words_traced(state, dst_ptr, &state_words);
-    trace_chip_wrapper(state, block_hasher_chip_idx, SHA256_ROWS_PER_BLOCK);
 }
 
 /// SHA-512 compress FFI entry point.
 ///
 /// Reads `SHA512_STATE_BYTES` of state and `SHA512_BLOCK_BYTES` of input block,
-/// applies SHA-512 compression, writes new state to `dst_ptr`. Reports chip
-/// heights for metering.
+/// applies SHA-512 compression, and writes new state to `dst_ptr`.
 ///
 /// # Safety
 ///
@@ -87,8 +78,6 @@ pub unsafe extern "C" fn rvr_ext_sha512(
     dst_ptr: u64,
     state_ptr: u64,
     input_ptr: u64,
-    _main_chip_idx: u32,
-    block_hasher_chip_idx: u32,
 ) {
     // SHA-512 state is naturally [u64; 8]; read directly.
     let mut state_u64s = [0u64; SHA512_STATE_WORDS];
@@ -103,5 +92,4 @@ pub unsafe extern "C" fn rvr_ext_sha512(
     compress512(&mut state_u64s, &[*block_array]);
 
     wr_mem_words_traced(state, dst_ptr, &state_u64s);
-    trace_chip_wrapper(state, block_hasher_chip_idx, SHA512_ROWS_PER_BLOCK);
 }

--- a/extensions/sha2/rvr/src/lib.rs
+++ b/extensions/sha2/rvr/src/lib.rs
@@ -178,4 +178,8 @@ impl RvrExtension for Sha2Extension {
             include_bytes!(env!("RVR_SHA2_FFI_STATICLIB")),
         )]
     }
+
+    fn uses_memory_wrappers(&self) -> bool {
+        true
+    }
 }

--- a/extensions/sha2/rvr/src/lib.rs
+++ b/extensions/sha2/rvr/src/lib.rs
@@ -4,12 +4,24 @@
 //! `Sha2Extension` for lifting and executing them via double FFI.
 
 use openvm_instructions::LocalOpcode;
+use openvm_sha2_air::{Sha256Config, Sha2BlockHasherSubairConfig, Sha512Config};
 use openvm_sha2_transpiler::Rv64Sha2Opcode;
-use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, Instr, InstrAt, LiftedInstr, Reg};
+use rvr_openvm_ir::{ExtEmitCtx, ExtInstr, FixedTraceRows, Instr, InstrAt, LiftedInstr, Reg};
 use rvr_openvm_lift::{
-    air_index_to_c, decode_reg, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
+    decode_reg, fixed_trace_rows_for_chip, opcode_air_idx, AirIndex, ExtensionError, RvrExtension,
     RvrExtensionCtx, RvrInstruction,
 };
+
+const fn rows_to_u32(rows: usize) -> u32 {
+    let rows_u32 = rows as u32;
+    assert!(rows_u32 as usize == rows);
+    rows_u32
+}
+
+const SHA256_ROWS_PER_BLOCK: u32 =
+    rows_to_u32(<Sha256Config as Sha2BlockHasherSubairConfig>::ROWS_PER_BLOCK);
+const SHA512_ROWS_PER_BLOCK: u32 =
+    rows_to_u32(<Sha512Config as Sha2BlockHasherSubairConfig>::ROWS_PER_BLOCK);
 
 /// IR node for a SHA-256 compress instruction.
 ///
@@ -23,8 +35,6 @@ pub struct Sha256Instr {
     pub state_ptr_reg: Reg,
     /// Register index holding input pointer (message block).
     pub input_ptr_reg: Reg,
-    /// AIR index of the SHA-256 main chip (1 row per instruction).
-    pub main_chip_idx: Option<AirIndex>,
     /// AIR index of the SHA-256 block hasher chip (ROWS_PER_BLOCK rows per instruction).
     pub block_hasher_chip_idx: Option<AirIndex>,
 }
@@ -38,11 +48,11 @@ impl ExtInstr for Sha256Instr {
         let dst = ctx.read_reg(self.dst_ptr_reg);
         let st = ctx.read_reg(self.state_ptr_reg);
         let inp = ctx.read_reg(self.input_ptr_reg);
-        let main = air_index_to_c(self.main_chip_idx);
-        let block = air_index_to_c(self.block_hasher_chip_idx);
-        let main = format!("{main}u");
-        let block = format!("{block}u");
-        ctx.emit_call("rvr_ext_sha256", &["state", &dst, &st, &inp, &main, &block]);
+        ctx.emit_call("rvr_ext_sha256", &["state", &dst, &st, &inp]);
+    }
+
+    fn fixed_trace_rows(&self) -> Vec<FixedTraceRows> {
+        fixed_trace_rows_for_chip(self.block_hasher_chip_idx, SHA256_ROWS_PER_BLOCK)
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -66,8 +76,6 @@ pub struct Sha512Instr {
     pub state_ptr_reg: Reg,
     /// Register index holding input pointer (message block).
     pub input_ptr_reg: Reg,
-    /// AIR index of the SHA-512 main chip (1 row per instruction).
-    pub main_chip_idx: Option<AirIndex>,
     /// AIR index of the SHA-512 block hasher chip (ROWS_PER_BLOCK rows per instruction).
     pub block_hasher_chip_idx: Option<AirIndex>,
 }
@@ -81,11 +89,11 @@ impl ExtInstr for Sha512Instr {
         let dst = ctx.read_reg(self.dst_ptr_reg);
         let st = ctx.read_reg(self.state_ptr_reg);
         let inp = ctx.read_reg(self.input_ptr_reg);
-        let main = air_index_to_c(self.main_chip_idx);
-        let block = air_index_to_c(self.block_hasher_chip_idx);
-        let main = format!("{main}u");
-        let block = format!("{block}u");
-        ctx.emit_call("rvr_ext_sha512", &["state", &dst, &st, &inp, &main, &block]);
+        ctx.emit_call("rvr_ext_sha512", &["state", &dst, &st, &inp]);
+    }
+
+    fn fixed_trace_rows(&self) -> Vec<FixedTraceRows> {
+        fixed_trace_rows_for_chip(self.block_hasher_chip_idx, SHA512_ROWS_PER_BLOCK)
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -100,9 +108,7 @@ impl ExtInstr for Sha512Instr {
 /// The SHA-2 extension (SHA-256 + SHA-512 opcodes).
 /// Register this with the `ExtensionRegistry`.
 pub struct Sha2Extension {
-    sha256_main_chip_idx: Option<AirIndex>,
     sha256_block_hasher_chip_idx: Option<AirIndex>,
-    sha512_main_chip_idx: Option<AirIndex>,
     sha512_block_hasher_chip_idx: Option<AirIndex>,
 }
 
@@ -117,9 +123,7 @@ impl Sha2Extension {
         let sha512_block_hasher_chip_idx = sha512_main_chip_idx.map(AirIndex::next);
 
         Ok(Self {
-            sha256_main_chip_idx,
             sha256_block_hasher_chip_idx,
-            sha512_main_chip_idx,
             sha512_block_hasher_chip_idx,
         })
     }
@@ -139,7 +143,6 @@ impl RvrExtension for Sha2Extension {
                     dst_ptr_reg,
                     state_ptr_reg,
                     input_ptr_reg,
-                    main_chip_idx: self.sha256_main_chip_idx,
                     block_hasher_chip_idx: self.sha256_block_hasher_chip_idx,
                 })),
                 source_loc: None,
@@ -156,7 +159,6 @@ impl RvrExtension for Sha2Extension {
                     dst_ptr_reg,
                     state_ptr_reg,
                     input_ptr_reg,
-                    main_chip_idx: self.sha512_main_chip_idx,
                     block_hasher_chip_idx: self.sha512_block_hasher_chip_idx,
                 })),
                 source_loc: None,


### PR DESCRIPTION
- fold fixed chip costs and extension rows into generated code
- omit tracing that an execution mode does not use
- tighten callback and chip-mapping validation without adding hot-path checks

Resolves INT-8837