### PR TITLE
refactor(v2.1): separate field expression execution from air metadata

### DIFF
--- a/crates/circuits/mod-builder/src/README.md
+++ b/crates/circuits/mod-builder/src/README.md
@@ -85,7 +85,8 @@ The `ExprBuilder` struct stores the constraints and computes associated to a sin
 Every `FieldVariable` stores a shared reference to an `ExprBuilder` and it mutates the builder as needed.
 
 When we are done building the circuit, the `ExprBuilder` has all the data necessary to build the circuit.
-We can pass the `ExprBuilder` into the `FieldExpr` constructor to build an AIR.
+We first finalize it as a `FieldExpressionProgram`, which can be executed without AIR metadata.
+Passing that program and a range bus to `FieldExpr::new` builds the AIR.
 
 ## The Select operation
 
@@ -97,8 +98,8 @@ Select is implemented as $s x + (1 - s) y$.
 
 Some chips have a setup instruction that verifies the modulus, along with any other relevant constants.
 Mod Builder supports chips with setup instructions.
-- If you call `FieldExpr::new` with `needs_setup = true` then the chip will have a setup instruction that verifies the modulus.
-- If you call `FieldExpr::new_with_setup_values` with `needs_setup = true` and pass in a `Vec` of setup values, then the chip will have a setup instruction that verifies the modulus as well as the values of the constants provided in the constructor as setup values.
+- If you call `FieldExpressionProgram::new` with `needs_setup = true`, the program has a setup instruction that verifies the modulus.
+- If you call `FieldExpressionProgram::new_with_setup_values` with `needs_setup = true` and pass in a `Vec` of setup values, the setup instruction also verifies those values.
 
 ## Notes on flags and setup
 
@@ -169,11 +170,11 @@ See the [examples section](#examples) for code examples to follow along with.
    Usually you don't need to do this because variables are auto-saved when there is a possibility of overflow (i.e. when the carry for any of the limbs overflows).
    But it gives greater control over how the expression is broken down into constraints, if that's needed.
 
-7. Finally, pull out a copy of the builder as follows: `let builder = builder.borrow().clone()`, and pass it into the appropriate `FieldExpr` constructor:
-    - If your chip has no setup instruction, use `FieldExpr::new(builder, range_bus, false)`.
-    - If your chip has a setup instruction that only checks if the modulus is correct, use `FieldExpr::new(builder, range_bus, true)`.
-    - If your chip has a setup instruction that checks the correctness of more than just the modulus, use `FieldExpr::new_with_setup_values(builder, range_bus, true, setup_values)` where `setup_values` is a `Vec<BigUint>` of values to be used in setup.
-     The setup row should be filled with the modulus followed by the values in `setup_values`.
+7. Finally, pull out a copy of the builder as follows: `let builder = builder.borrow().clone()`, finalize it as a `FieldExpressionProgram`, and pass the program to `FieldExpr::new(program, range_bus)`:
+    - If your chip has no setup instruction, use `FieldExpressionProgram::new(builder, false)`.
+    - If your chip has a setup instruction that only checks the modulus, use `FieldExpressionProgram::new(builder, true)`.
+    - If your chip has a setup instruction that checks additional constants, use `FieldExpressionProgram::new_with_setup_values(builder, true, setup_values)` where `setup_values` is a `Vec<BigUint>`.
+      The setup row should contain the modulus followed by the values in `setup_values`.
 
 ### Examples
 

--- a/crates/circuits/mod-builder/src/builder.rs
+++ b/crates/circuits/mod-builder/src/builder.rs
@@ -181,6 +181,16 @@ impl ExprBuilder {
         self.needs_setup
     }
 
+    pub fn execute(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {
+        assert!(self.is_finalized());
+        let mut vars = vec![BigUint::zero(); self.num_variables];
+        for i in 0..self.constraints.len() {
+            let value = self.computes[i].compute(inputs, &vars, flags, &self.prime);
+            vars[i] = value;
+        }
+        vars
+    }
+
     // Below functions are used when adding variables and constraints manually, need to be careful.
     // Number of variables, constraints and computes should be consistent,
     // so there should be same number of calls to the new_var, add_constraint and add_compute.
@@ -587,8 +597,6 @@ impl FieldExpr {
     }
 
     pub fn execute(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {
-        assert!(self.builder.is_finalized());
-
         #[cfg(debug_assertions)]
         {
             let is_setup = self.builder.needs_setup() && flags.iter().all(|&x| !x);
@@ -601,13 +609,7 @@ impl FieldExpr {
                 }
             }
         }
-
-        let mut vars = vec![BigUint::zero(); self.num_variables];
-        for i in 0..self.constraints.len() {
-            let r = self.computes[i].compute(inputs, &vars, flags, &self.prime);
-            vars[i] = r; // r is already owned, no clone needed
-        }
-        vars
+        self.builder.execute(inputs, flags)
     }
 
     pub fn execute_with_output(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {

--- a/crates/circuits/mod-builder/src/builder.rs
+++ b/crates/circuits/mod-builder/src/builder.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, cmp::min, iter, ops::Deref, rc::Rc};
+use std::{cell::RefCell, cmp::min, iter, rc::Rc};
 
 use itertools::{zip_eq, Itertools};
 use num_bigint::{BigInt, BigUint, Sign};
@@ -141,7 +141,7 @@ impl ExprBuilder {
         self.finalized
     }
 
-    pub fn finalize(&mut self, needs_setup: bool) {
+    fn finalize(&mut self, needs_setup: bool) {
         self.finalized = true;
         self.needs_setup = needs_setup;
 
@@ -181,7 +181,7 @@ impl ExprBuilder {
         self.needs_setup
     }
 
-    pub fn execute(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {
+    fn execute(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {
         assert!(self.is_finalized());
         let mut vars = vec![BigUint::zero(); self.num_variables];
         for i in 0..self.constraints.len() {
@@ -255,53 +255,54 @@ impl ExprBuilder {
     }
 }
 
+/// A finalized field expression that can be executed without AIR metadata.
 #[derive(Clone)]
-pub struct FieldExpr {
-    pub builder: ExprBuilder,
+pub struct FieldExpressionProgram {
+    builder: ExprBuilder,
 
-    pub check_carry_mod_to_zero: CheckCarryModToZeroSubAir,
-
-    pub range_bus: VariableRangeCheckerBus,
-
-    // any values other than the prime modulus that need to be checked at setup
-    pub setup_values: Vec<BigUint>,
+    // Any values other than the prime modulus that must be checked during setup.
+    setup_values: Vec<BigUint>,
 }
 
-impl FieldExpr {
-    pub fn new(
-        builder: ExprBuilder,
-        range_bus: VariableRangeCheckerBus,
-        needs_setup: bool,
-    ) -> Self {
-        let mut builder = builder;
-        builder.finalize(needs_setup);
-        let subair = CheckCarryModToZeroSubAir::new(
-            builder.prime.clone(),
-            builder.limb_bits,
-            range_bus.inner.index,
-            range_bus.range_max_bits,
-        );
-        FieldExpr {
-            builder,
-            check_carry_mod_to_zero: subair,
-            range_bus,
-            setup_values: vec![],
-        }
+impl FieldExpressionProgram {
+    pub fn new(builder: ExprBuilder, needs_setup: bool) -> Self {
+        Self::new_with_setup_values(builder, needs_setup, vec![])
     }
 
     pub fn new_with_setup_values(
-        builder: ExprBuilder,
-        range_bus: VariableRangeCheckerBus,
+        mut builder: ExprBuilder,
         needs_setup: bool,
         setup_values: Vec<BigUint>,
     ) -> Self {
-        let mut ret = Self::new(builder, range_bus, needs_setup);
-        ret.setup_values = setup_values;
-        ret
+        assert!(
+            needs_setup || setup_values.is_empty(),
+            "setup values require a setup operation"
+        );
+        builder.finalize(needs_setup);
+        assert!(
+            !needs_setup || setup_values.len() < builder.num_input,
+            "setup values must fit in the expression inputs"
+        );
+        Self {
+            builder,
+            setup_values,
+        }
     }
 
     pub fn num_inputs(&self) -> usize {
         self.builder.num_input
+    }
+
+    pub(crate) fn builder(&self) -> &ExprBuilder {
+        &self.builder
+    }
+
+    pub fn prime(&self) -> &BigUint {
+        &self.builder.prime
+    }
+
+    pub fn setup_values(&self) -> &[BigUint] {
+        &self.setup_values
     }
 
     pub fn num_vars(&self) -> usize {
@@ -315,13 +316,69 @@ impl FieldExpr {
     pub fn output_indices(&self) -> &[usize] {
         &self.builder.output_indices
     }
+
+    pub fn canonical_num_limbs(&self) -> usize {
+        self.builder.num_limbs
+    }
+
+    pub fn needs_setup(&self) -> bool {
+        self.builder.needs_setup()
+    }
+
+    pub(crate) fn width(&self) -> usize {
+        self.builder.num_limbs * (self.builder.num_input + self.builder.num_variables)
+            + self.builder.q_limbs.iter().sum::<usize>()
+            + self.builder.carry_limbs.iter().sum::<usize>()
+            + self.builder.num_flags
+            + 1 // is_valid
+    }
+
+    pub fn execute(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {
+        #[cfg(debug_assertions)]
+        {
+            let is_setup = self.needs_setup() && flags.iter().all(|&x| !x);
+            if is_setup {
+                assert_eq!(inputs[0], self.builder.prime);
+                assert!(inputs.len() > self.setup_values.len());
+                for (expected, actual) in self.setup_values.iter().zip(inputs.iter().skip(1)) {
+                    assert_eq!(expected, actual);
+                }
+            }
+        }
+        self.builder.execute(inputs, flags)
+    }
 }
 
-impl Deref for FieldExpr {
-    type Target = ExprBuilder;
+#[derive(Clone)]
+pub struct FieldExpr {
+    program: FieldExpressionProgram,
 
-    fn deref(&self) -> &ExprBuilder {
-        &self.builder
+    check_carry_mod_to_zero: CheckCarryModToZeroSubAir,
+
+    range_bus: VariableRangeCheckerBus,
+}
+
+impl FieldExpr {
+    pub fn new(program: FieldExpressionProgram, range_bus: VariableRangeCheckerBus) -> Self {
+        assert_eq!(
+            program.builder.range_checker_bits, range_bus.range_max_bits,
+            "expression and range bus must use the same range capacity"
+        );
+        let subair = CheckCarryModToZeroSubAir::new(
+            program.builder.prime.clone(),
+            program.builder.limb_bits,
+            range_bus.inner.index,
+            range_bus.range_max_bits,
+        );
+        FieldExpr {
+            program,
+            check_carry_mod_to_zero: subair,
+            range_bus,
+        }
+    }
+
+    pub fn program(&self) -> &FieldExpressionProgram {
+        &self.program
     }
 }
 
@@ -332,12 +389,8 @@ impl<F: Field> PartitionedBaseAir<F> for FieldExpr {}
 impl ColumnsAir for FieldExpr {}
 impl<F: Field> BaseAir<F> for FieldExpr {
     fn width(&self) -> usize {
-        assert!(self.builder.is_finalized());
-        self.num_limbs * (self.builder.num_input + self.builder.num_variables)
-            + self.builder.q_limbs.iter().sum::<usize>()
-            + self.builder.carry_limbs.iter().sum::<usize>()
-            + self.builder.num_flags
-            + 1 // is_valid
+        assert!(self.program.builder.is_finalized());
+        self.program.width()
     }
 }
 
@@ -363,7 +416,9 @@ impl<AB: InteractionBuilder> SubAir<AB> for FieldExpr {
         AB::Var: 'a,
         AB::Expr: 'a,
     {
-        assert!(self.builder.is_finalized());
+        let program = &self.program;
+        let expr = &program.builder;
+        assert!(expr.is_finalized());
         let FieldExprCols {
             is_valid,
             inputs,
@@ -375,7 +430,7 @@ impl<AB: InteractionBuilder> SubAir<AB> for FieldExpr {
 
         builder.assert_bool(is_valid);
 
-        if self.builder.needs_setup() {
+        if program.needs_setup() {
             let is_setup = flags.iter().fold(is_valid.into(), |acc, &x| acc - x);
             builder.assert_bool(is_setup.clone());
             // TODO[jpw]: currently we enforce at the program code level that:
@@ -386,13 +441,12 @@ impl<AB: InteractionBuilder> SubAir<AB> for FieldExpr {
 
             let expected = iter::empty()
                 .chain({
-                    let mut prime_limbs = self.builder.prime_limbs.clone();
-                    prime_limbs.resize(self.builder.num_limbs, 0);
+                    let mut prime_limbs = expr.prime_limbs.clone();
+                    prime_limbs.resize(expr.num_limbs, 0);
                     prime_limbs
                 })
-                .chain(self.setup_values.iter().flat_map(|x| {
-                    big_uint_to_num_limbs(x, self.builder.limb_bits, self.builder.num_limbs)
-                        .into_iter()
+                .chain(program.setup_values.iter().flat_map(|x| {
+                    big_uint_to_num_limbs(x, expr.limb_bits, expr.num_limbs).into_iter()
                 }))
                 .collect_vec();
 
@@ -411,9 +465,9 @@ impl<AB: InteractionBuilder> SubAir<AB> for FieldExpr {
             }
         }
 
-        let inputs = load_overflow::<AB>(inputs, self.limb_bits);
-        let vars = load_overflow::<AB>(vars, self.limb_bits);
-        let constants: Vec<_> = self
+        let inputs = load_overflow::<AB>(inputs, expr.limb_bits);
+        let vars = load_overflow::<AB>(vars, expr.limb_bits);
+        let constants: Vec<_> = expr
             .constants
             .iter()
             .map(|(_, limbs)| {
@@ -421,20 +475,20 @@ impl<AB: InteractionBuilder> SubAir<AB> for FieldExpr {
                     .iter()
                     .map(|limb| AB::Expr::from_usize(*limb))
                     .collect();
-                OverflowInt::from_unsigned_limbs(limbs_expr, self.limb_bits)
+                OverflowInt::from_unsigned_limbs(limbs_expr, expr.limb_bits)
             })
             .collect();
 
         for flag in flags.iter() {
             builder.assert_bool(*flag);
         }
-        for i in 0..self.constraints.len() {
-            let expr = self.constraints[i]
+        for i in 0..expr.constraints.len() {
+            let constraint = expr.constraints[i]
                 .evaluate_overflow_expr::<AB>(&inputs, &vars, &constants, &flags);
             self.check_carry_mod_to_zero.eval(
                 builder,
                 (
-                    expr,
+                    constraint,
                     CheckCarryModToZeroCols {
                         carries: carry_limbs[i].clone(),
                         quotient: q_limbs[i].clone(),
@@ -450,7 +504,7 @@ impl<AB: InteractionBuilder> SubAir<AB> for FieldExpr {
                     builder,
                     self.range_bus.inner.index,
                     self.range_bus.range_max_bits,
-                    self.limb_bits,
+                    expr.limb_bits,
                     limb.clone(),
                     is_valid,
                 );
@@ -479,77 +533,79 @@ impl<F: PrimeField64> TraceSubRowGenerator<F> for FieldExpr {
         (range_checker, inputs, flags): (&'a VariableRangeCheckerChip, Vec<BigUint>, Vec<bool>),
         sub_row: &'a mut [F],
     ) {
-        assert!(self.builder.is_finalized());
-        assert_eq!(inputs.len(), self.num_input);
-        assert_eq!(self.num_variables, self.constraints.len());
+        let program = &self.program;
+        let expr = &program.builder;
+        assert!(expr.is_finalized());
+        assert_eq!(inputs.len(), expr.num_input);
+        assert_eq!(expr.num_variables, expr.constraints.len());
 
-        assert_eq!(flags.len(), self.builder.num_flags);
+        assert_eq!(flags.len(), expr.num_flags);
 
-        let limb_bits = self.limb_bits;
-        let mut vars = vec![BigUint::zero(); self.num_variables];
+        let limb_bits = expr.limb_bits;
+        let mut vars = vec![BigUint::zero(); expr.num_variables];
 
         // BigInt type is required for computing the quotient.
         let input_bigint = inputs
             .iter()
             .map(|x| BigInt::from_biguint(Sign::Plus, x.clone()))
             .collect::<Vec<BigInt>>();
-        let mut vars_bigint = vec![BigInt::zero(); self.num_variables];
+        let mut vars_bigint = vec![BigInt::zero(); expr.num_variables];
 
         // OverflowInt type is required for computing the carries.
         let input_overflow = inputs
             .iter()
-            .map(|x| OverflowInt::<isize>::from_biguint(x, self.limb_bits, Some(self.num_limbs)))
+            .map(|x| OverflowInt::<isize>::from_biguint(x, expr.limb_bits, Some(expr.num_limbs)))
             .collect::<Vec<_>>();
         let zero = OverflowInt::<isize>::from_unsigned_limbs(vec![0], limb_bits);
-        let mut vars_overflow = vec![zero; self.num_variables];
+        let mut vars_overflow = vec![zero; expr.num_variables];
         // Note: in cases where the prime fits in less limbs than `num_limbs`, we use the smaller
         // number of limbs.
-        let prime_overflow = OverflowInt::<isize>::from_biguint(&self.prime, self.limb_bits, None);
+        let prime_overflow = OverflowInt::<isize>::from_biguint(&expr.prime, expr.limb_bits, None);
 
-        let constants: Vec<_> = self
+        let constants: Vec<_> = expr
             .constants
             .iter()
             .map(|(_, limbs)| {
                 let limbs_isize: Vec<_> = limbs.iter().map(|i| *i as isize).collect();
-                OverflowInt::from_unsigned_limbs(limbs_isize, self.limb_bits)
+                OverflowInt::from_unsigned_limbs(limbs_isize, expr.limb_bits)
             })
             .collect();
 
         let mut all_q = vec![];
         let mut all_carry = vec![];
-        for i in 0..self.constraints.len() {
-            let r = self.computes[i].compute(&inputs, &vars, &flags, &self.prime);
+        for i in 0..expr.constraints.len() {
+            let r = expr.computes[i].compute(&inputs, &vars, &flags, &expr.prime);
             vars[i] = r.clone();
             vars_bigint[i] = BigInt::from_biguint(Sign::Plus, r);
             vars_overflow[i] =
-                OverflowInt::<isize>::from_biguint(&vars[i], self.limb_bits, Some(self.num_limbs));
+                OverflowInt::<isize>::from_biguint(&vars[i], expr.limb_bits, Some(expr.num_limbs));
         }
         // We need to have all variables computed first because, e.g. constraints[2] might need
         // variables[3].
-        for i in 0..self.constraints.len() {
+        for i in 0..expr.constraints.len() {
             // expr = q * p
             let expr_bigint =
-                self.constraints[i].evaluate_bigint(&input_bigint, &vars_bigint, &flags);
-            let q = &expr_bigint / &self.prime_bigint;
+                expr.constraints[i].evaluate_bigint(&input_bigint, &vars_bigint, &flags);
+            let q = &expr_bigint / &expr.prime_bigint;
             // If this is not true then the evaluated constraint is not divisible by p.
-            debug_assert_eq!(expr_bigint, &q * &self.prime_bigint);
-            let q_limbs = big_int_to_num_limbs(&q, limb_bits, self.q_limbs[i]);
-            assert_eq!(q_limbs.len(), self.q_limbs[i]); // If this fails, the q_limbs estimate is wrong.
+            debug_assert_eq!(expr_bigint, &q * &expr.prime_bigint);
+            let q_limbs = big_int_to_num_limbs(&q, limb_bits, expr.q_limbs[i]);
+            assert_eq!(q_limbs.len(), expr.q_limbs[i]); // If this fails, the q_limbs estimate is wrong.
             for &q in q_limbs.iter() {
                 range_checker.add_count((q + (1 << limb_bits)) as u32, limb_bits + 1);
             }
             let q_overflow = OverflowInt::from_signed_limbs(q_limbs.clone(), limb_bits);
             // compute carries of (expr - q * p)
-            let expr = self.constraints[i].evaluate_overflow_isize(
+            let constraint = expr.constraints[i].evaluate_overflow_isize(
                 &input_overflow,
                 &vars_overflow,
                 &constants,
                 &flags,
             );
-            let expr = expr - q_overflow * prime_overflow.clone();
-            let carries = expr.calculate_carries(limb_bits);
-            assert_eq!(carries.len(), self.carry_limbs[i]); // If this fails, the carry limbs estimate is wrong.
-            let max_overflow_bits = expr.max_overflow_bits();
+            let constraint = constraint - q_overflow * prime_overflow.clone();
+            let carries = constraint.calculate_carries(limb_bits);
+            assert_eq!(carries.len(), expr.carry_limbs[i]); // If this fails, the carry limbs estimate is wrong.
+            let max_overflow_bits = constraint.max_overflow_bits();
             let (carry_min_abs, carry_bits) =
                 get_carry_max_abs_and_bits(max_overflow_bits, limb_bits);
             for &carry in carries.iter() {
@@ -588,64 +644,32 @@ impl<F: PrimeField64> TraceSubRowGenerator<F> for FieldExpr {
 }
 
 impl FieldExpr {
-    pub fn canonical_num_limbs(&self) -> usize {
-        self.builder.num_limbs
-    }
-
-    pub fn canonical_limb_bits(&self) -> usize {
-        self.builder.limb_bits
-    }
-
-    pub fn execute(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {
-        #[cfg(debug_assertions)]
-        {
-            let is_setup = self.builder.needs_setup() && flags.iter().all(|&x| !x);
-            if is_setup {
-                assert_eq!(inputs[0], self.builder.prime);
-                // Check that inputs.iter().skip(1) has all the setup values as a prefix
-                assert!(inputs.len() > self.setup_values.len());
-                for (expected, actual) in self.setup_values.iter().zip(inputs.iter().skip(1)) {
-                    assert_eq!(expected, actual);
-                }
-            }
-        }
-        self.builder.execute(inputs, flags)
-    }
-
-    pub fn execute_with_output(&self, inputs: &[BigUint], flags: &[bool]) -> Vec<BigUint> {
-        let vars = self.execute(inputs, flags);
-        self.builder
-            .output_indices
-            .iter()
-            .map(|i| vars[*i].clone())
-            .collect()
-    }
-
     pub fn load_vars<T: Clone>(&self, arr: &[T]) -> FieldExprCols<T> {
-        assert!(self.builder.is_finalized());
+        let expr = &self.program.builder;
+        assert!(expr.is_finalized());
         let is_valid = arr[0].clone();
         let mut idx = 1;
         let mut inputs = vec![];
-        for _ in 0..self.num_input {
-            inputs.push(arr[idx..idx + self.num_limbs].to_vec());
-            idx += self.num_limbs;
+        for _ in 0..expr.num_input {
+            inputs.push(arr[idx..idx + expr.num_limbs].to_vec());
+            idx += expr.num_limbs;
         }
         let mut vars = vec![];
-        for _ in 0..self.num_variables {
-            vars.push(arr[idx..idx + self.num_limbs].to_vec());
-            idx += self.num_limbs;
+        for _ in 0..expr.num_variables {
+            vars.push(arr[idx..idx + expr.num_limbs].to_vec());
+            idx += expr.num_limbs;
         }
         let mut q_limbs = vec![];
-        for q in self.q_limbs.iter() {
+        for q in &expr.q_limbs {
             q_limbs.push(arr[idx..idx + q].to_vec());
             idx += q;
         }
         let mut carry_limbs = vec![];
-        for c in self.carry_limbs.iter() {
+        for c in &expr.carry_limbs {
             carry_limbs.push(arr[idx..idx + c].to_vec());
             idx += c;
         }
-        let flags = arr[idx..idx + self.num_flags].to_vec();
+        let flags = arr[idx..idx + expr.num_flags].to_vec();
         FieldExprCols {
             is_valid,
             inputs,

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -22,9 +22,22 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     BaseAirWithPublicValues,
 };
-use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
-use crate::builder::{ExprBuilder, FieldExpr, FieldExprCols};
+use crate::builder::{ExprBuilder, FieldExpr, FieldExprCols, FieldExpressionProgram};
+
+fn normalize_opcode_flags(
+    needs_setup: bool,
+    local_opcode_idx: &[usize],
+    opcode_flag_idx: Vec<usize>,
+) -> Vec<usize> {
+    let opcode_flag_idx = if opcode_flag_idx.is_empty() && needs_setup {
+        vec![0]
+    } else {
+        opcode_flag_idx
+    };
+    assert_eq!(opcode_flag_idx.len(), local_opcode_idx.len() - 1);
+    opcode_flag_idx
+}
 
 #[derive(Clone)]
 pub struct FieldExpressionCoreAir {
@@ -61,14 +74,11 @@ impl FieldExpressionCoreAir {
         local_opcode_idx: Vec<usize>,
         opcode_flag_idx: Vec<usize>,
     ) -> Self {
-        let opcode_flag_idx = if opcode_flag_idx.is_empty() && expr.needs_setup() {
-            // single op chip that needs setup, so there is only one default flag, must be 0.
-            vec![0]
-        } else {
-            // multi ops chip or no-setup chip, use as is.
-            opcode_flag_idx
-        };
-        assert_eq!(opcode_flag_idx.len(), local_opcode_idx.len() - 1);
+        let opcode_flag_idx = normalize_opcode_flags(
+            expr.program().needs_setup(),
+            &local_opcode_idx,
+            opcode_flag_idx,
+        );
         Self {
             expr,
             offset,
@@ -78,19 +88,19 @@ impl FieldExpressionCoreAir {
     }
 
     pub fn num_inputs(&self) -> usize {
-        self.expr.builder.num_input
+        self.expr.program().num_inputs()
     }
 
     pub fn num_vars(&self) -> usize {
-        self.expr.builder.num_variables
+        self.expr.program().num_vars()
     }
 
     pub fn num_flags(&self) -> usize {
-        self.expr.builder.num_flags
+        self.expr.program().num_flags()
     }
 
     pub fn output_indices(&self) -> &[usize] {
-        &self.expr.builder.output_indices
+        self.expr.program().output_indices()
     }
 }
 
@@ -279,7 +289,7 @@ impl<'a> FieldExpressionCoreRecordMut<'a> {
 #[derive(Clone)]
 pub struct FieldExpressionExecutor<A> {
     adapter: A,
-    pub expr: FieldExpr,
+    program: FieldExpressionProgram,
     pub offset: usize,
     pub local_opcode_idx: Vec<usize>,
     pub opcode_flag_idx: Vec<usize>,
@@ -290,27 +300,21 @@ impl<A> FieldExpressionExecutor<A> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         adapter: A,
-        expr: FieldExpr,
+        program: FieldExpressionProgram,
         offset: usize,
         local_opcode_idx: Vec<usize>,
         opcode_flag_idx: Vec<usize>,
         name: &str,
     ) -> Self {
-        let opcode_flag_idx = if opcode_flag_idx.is_empty() && expr.needs_setup() {
-            // single op chip that needs setup, so there is only one default flag, must be 0.
-            vec![0]
-        } else {
-            // multi ops chip or no-setup chip, use as is.
-            opcode_flag_idx
-        };
-        assert_eq!(opcode_flag_idx.len(), local_opcode_idx.len() - 1);
+        let opcode_flag_idx =
+            normalize_opcode_flags(program.needs_setup(), &local_opcode_idx, opcode_flag_idx);
         tracing::debug!(
             "FieldExpressionCoreExecutor: opcode={name}, main_width={}",
-            BaseAir::<BabyBear>::width(&expr)
+            program.width()
         );
         Self {
             adapter,
-            expr,
+            program,
             offset,
             local_opcode_idx,
             opcode_flag_idx,
@@ -321,7 +325,7 @@ impl<A> FieldExpressionExecutor<A> {
     pub fn get_record_layout<F>(&self) -> FieldExpressionRecordLayout<F, A> {
         FieldExpressionRecordLayout {
             metadata: FieldExpressionMetadata::new(
-                self.expr.builder.num_input * self.expr.canonical_num_limbs(),
+                self.program.num_inputs() * self.program.canonical_num_limbs(),
             ),
         }
     }
@@ -330,6 +334,10 @@ impl<A> FieldExpressionExecutor<A> {
     #[inline]
     pub fn adapter(&self) -> &A {
         &self.adapter
+    }
+
+    pub fn program(&self) -> &FieldExpressionProgram {
+        &self.program
     }
 }
 
@@ -352,14 +360,11 @@ impl<A> FieldExpressionFiller<A> {
         range_checker: SharedVariableRangeCheckerChip,
         should_finalize: bool,
     ) -> Self {
-        let opcode_flag_idx = if opcode_flag_idx.is_empty() && expr.needs_setup() {
-            // single op chip that needs setup, so there is only one default flag, must be 0.
-            vec![0]
-        } else {
-            // multi ops chip or no-setup chip, use as is.
-            opcode_flag_idx
-        };
-        assert_eq!(opcode_flag_idx.len(), local_opcode_idx.len() - 1);
+        let opcode_flag_idx = normalize_opcode_flags(
+            expr.program().needs_setup(),
+            &local_opcode_idx,
+            opcode_flag_idx,
+        );
         Self {
             adapter,
             expr,
@@ -370,17 +375,17 @@ impl<A> FieldExpressionFiller<A> {
         }
     }
     pub fn num_inputs(&self) -> usize {
-        self.expr.builder.num_input
+        self.expr.program().num_inputs()
     }
 
     pub fn num_flags(&self) -> usize {
-        self.expr.builder.num_flags
+        self.expr.program().num_flags()
     }
 
     pub fn get_record_layout<F>(&self) -> FieldExpressionRecordLayout<F, A> {
         FieldExpressionRecordLayout {
             metadata: FieldExpressionMetadata::new(
-                self.num_inputs() * self.expr.canonical_num_limbs(),
+                self.num_inputs() * self.expr.program().canonical_num_limbs(),
             ),
         }
     }
@@ -417,7 +422,7 @@ where
         );
 
         let (writes, _, _) = run_field_expression(
-            &self.expr,
+            &self.program,
             &self.local_opcode_idx,
             &self.opcode_flag_idx,
             core_record.input_limbs,
@@ -461,7 +466,7 @@ where
             unsafe { get_record_from_slice(&mut core_row, self.get_record_layout::<F>()) };
 
         let (_, inputs, flags) = run_field_expression(
-            &self.expr,
+            self.expr.program(),
             &self.local_opcode_idx,
             &self.opcode_flag_idx,
             record.input_limbs,
@@ -491,17 +496,17 @@ where
 }
 
 fn run_field_expression(
-    expr: &FieldExpr,
+    program: &FieldExpressionProgram,
     local_opcode_flags: &[usize],
     opcode_flag_idx: &[usize],
     data: &[u8],
     local_opcode_idx: usize,
 ) -> (DynArray<u8>, Vec<BigUint>, Vec<bool>) {
-    let field_element_limbs = expr.canonical_num_limbs();
-    assert_eq!(data.len(), expr.builder.num_input * field_element_limbs);
+    let field_element_limbs = program.canonical_num_limbs();
+    assert_eq!(data.len(), program.num_inputs() * field_element_limbs);
 
-    let mut inputs = Vec::with_capacity(expr.builder.num_input);
-    for i in 0..expr.builder.num_input {
+    let mut inputs = Vec::with_capacity(program.num_inputs());
+    for i in 0..program.num_inputs() {
         let start = i * field_element_limbs;
         let end = start + field_element_limbs;
         let limb_slice = &data[start..end];
@@ -510,8 +515,8 @@ fn run_field_expression(
     }
 
     let mut flags = vec![];
-    if expr.needs_setup() {
-        flags = vec![false; expr.builder.num_flags];
+    if program.needs_setup() {
+        flags = vec![false; program.num_flags()];
 
         // Find which opcode this is in our local_opcode_idx list
         if let Some(opcode_position) = local_opcode_flags
@@ -528,14 +533,14 @@ fn run_field_expression(
         }
     }
 
-    let vars = expr.execute(&inputs, &flags);
-    assert_eq!(vars.len(), expr.builder.num_variables);
+    let vars = program.execute(&inputs, &flags);
+    assert_eq!(vars.len(), program.num_vars());
 
     // Write outputs directly to a pre-allocated buffer to avoid intermediate Vecs
-    let num_outputs = expr.builder.output_indices.len();
+    let num_outputs = program.output_indices().len();
     let total_output_bytes = num_outputs * field_element_limbs;
     let mut write_buffer = vec![0u8; total_output_bytes];
-    for (i, &var_idx) in expr.builder.output_indices.iter().enumerate() {
+    for (i, &var_idx) in program.output_indices().iter().enumerate() {
         let start = i * field_element_limbs;
         let bytes = vars[var_idx].to_bytes_le();
         let copy_len = bytes.len().min(field_element_limbs);
@@ -548,10 +553,12 @@ fn run_field_expression(
 }
 
 fn decode_precomputed_inputs<const NEEDS_SETUP: bool>(
-    builder: &ExprBuilder,
+    program: &FieldExpressionProgram,
     flag_idx: usize,
     data: &[u8],
 ) -> (Vec<BigUint>, Vec<bool>) {
+    debug_assert_eq!(NEEDS_SETUP, program.needs_setup());
+    let builder = program.builder();
     let field_element_limbs = builder.num_limbs;
     assert_eq!(data.len(), builder.num_input * field_element_limbs);
 
@@ -590,23 +597,12 @@ fn encode_precomputed_outputs(builder: &ExprBuilder, vars: &[BigUint]) -> DynArr
 }
 
 #[inline(always)]
-pub fn run_expr_builder_precomputed<const NEEDS_SETUP: bool>(
-    builder: &ExprBuilder,
-    flag_idx: usize,
-    data: &[u8],
-) -> DynArray<u8> {
-    let (inputs, flags) = decode_precomputed_inputs::<NEEDS_SETUP>(builder, flag_idx, data);
-    let vars = builder.execute(&inputs, &flags);
-    encode_precomputed_outputs(builder, &vars)
-}
-
-#[inline(always)]
 pub fn run_field_expression_precomputed<const NEEDS_SETUP: bool>(
-    expr: &FieldExpr,
+    program: &FieldExpressionProgram,
     flag_idx: usize,
     data: &[u8],
 ) -> DynArray<u8> {
-    let (inputs, flags) = decode_precomputed_inputs::<NEEDS_SETUP>(&expr.builder, flag_idx, data);
-    let vars = expr.execute(&inputs, &flags);
-    encode_precomputed_outputs(&expr.builder, &vars)
+    let (inputs, flags) = decode_precomputed_inputs::<NEEDS_SETUP>(program, flag_idx, data);
+    let vars = program.execute(&inputs, &flags);
+    encode_precomputed_outputs(program.builder(), &vars)
 }

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -24,7 +24,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
-use crate::builder::{FieldExpr, FieldExprCols};
+use crate::builder::{ExprBuilder, FieldExpr, FieldExprCols};
 
 #[derive(Clone)]
 pub struct FieldExpressionCoreAir {
@@ -547,46 +547,66 @@ fn run_field_expression(
     (writes, inputs, flags)
 }
 
-#[inline(always)]
-pub fn run_field_expression_precomputed<const NEEDS_SETUP: bool>(
-    expr: &FieldExpr,
+fn decode_precomputed_inputs<const NEEDS_SETUP: bool>(
+    builder: &ExprBuilder,
     flag_idx: usize,
     data: &[u8],
-) -> DynArray<u8> {
-    let field_element_limbs = expr.canonical_num_limbs();
-    assert_eq!(data.len(), expr.num_inputs() * field_element_limbs);
+) -> (Vec<BigUint>, Vec<bool>) {
+    let field_element_limbs = builder.num_limbs;
+    assert_eq!(data.len(), builder.num_input * field_element_limbs);
 
-    let mut inputs = Vec::with_capacity(expr.num_inputs());
-    for i in 0..expr.num_inputs() {
-        let start = i * expr.canonical_num_limbs();
-        let end = start + expr.canonical_num_limbs();
+    let mut inputs = Vec::with_capacity(builder.num_input);
+    for i in 0..builder.num_input {
+        let start = i * field_element_limbs;
+        let end = start + field_element_limbs;
         let limb_slice = &data[start..end];
         let input = BigUint::from_bytes_le(limb_slice);
         inputs.push(input);
     }
 
     let flags = if NEEDS_SETUP {
-        let mut flags = vec![false; expr.num_flags()];
-        if flag_idx < expr.num_flags() {
+        let mut flags = vec![false; builder.num_flags];
+        if flag_idx < builder.num_flags {
             flags[flag_idx] = true;
         }
         flags
     } else {
         vec![]
     };
+    (inputs, flags)
+}
 
-    let vars = expr.execute(&inputs, &flags);
-    assert_eq!(vars.len(), expr.num_vars());
-
-    // Write outputs directly to a pre-allocated buffer to avoid intermediate Vecs
-    let num_outputs = expr.output_indices().len();
-    let total_output_bytes = num_outputs * field_element_limbs;
+fn encode_precomputed_outputs(builder: &ExprBuilder, vars: &[BigUint]) -> DynArray<u8> {
+    assert_eq!(vars.len(), builder.num_variables);
+    let total_output_bytes = builder.output_indices.len() * builder.num_limbs;
     let mut write_buffer = vec![0u8; total_output_bytes];
-    for (i, &var_idx) in expr.output_indices().iter().enumerate() {
-        let start = i * field_element_limbs;
+    for (i, &var_idx) in builder.output_indices.iter().enumerate() {
+        let start = i * builder.num_limbs;
         let bytes = vars[var_idx].to_bytes_le();
-        let copy_len = bytes.len().min(field_element_limbs);
+        let copy_len = bytes.len().min(builder.num_limbs);
         write_buffer[start..start + copy_len].copy_from_slice(&bytes[..copy_len]);
     }
     write_buffer.into()
+}
+
+#[inline(always)]
+pub fn run_expr_builder_precomputed<const NEEDS_SETUP: bool>(
+    builder: &ExprBuilder,
+    flag_idx: usize,
+    data: &[u8],
+) -> DynArray<u8> {
+    let (inputs, flags) = decode_precomputed_inputs::<NEEDS_SETUP>(builder, flag_idx, data);
+    let vars = builder.execute(&inputs, &flags);
+    encode_precomputed_outputs(builder, &vars)
+}
+
+#[inline(always)]
+pub fn run_field_expression_precomputed<const NEEDS_SETUP: bool>(
+    expr: &FieldExpr,
+    flag_idx: usize,
+    data: &[u8],
+) -> DynArray<u8> {
+    let (inputs, flags) = decode_precomputed_inputs::<NEEDS_SETUP>(&expr.builder, flag_idx, data);
+    let vars = expr.execute(&inputs, &flags);
+    encode_precomputed_outputs(&expr.builder, &vars)
 }

--- a/crates/circuits/mod-builder/src/tests.rs
+++ b/crates/circuits/mod-builder/src/tests.rs
@@ -10,21 +10,35 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::{config::baby_bear_poseidon2::*, p3_baby_bear::BabyBear};
 
 use crate::{
-    test_utils::*, utils::biguint_to_limbs_vec, ExprBuilder, FieldExpr, FieldExprCols,
-    FieldExpressionCoreRecordMut, FieldVariable, SymbolicExpr,
+    test_utils::*, utils::biguint_to_limbs_vec, ExprBuilder, ExprBuilderConfig, FieldExpr,
+    FieldExprCols, FieldExpressionCoreRecordMut, FieldExpressionProgram, FieldVariable,
+    SymbolicExpr,
 };
 
 const LIMB_BITS: usize = 8;
 use std::sync::Arc;
 
-use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
+use openvm_circuit_primitives::var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip};
+
+#[test]
+#[should_panic(expected = "expression and range bus must use the same range capacity")]
+fn field_expr_rejects_mismatched_range_capacity() {
+    let config = ExprBuilderConfig {
+        modulus: secp256k1_coord_prime(),
+        num_limbs: 32,
+        limb_bits: 8,
+    };
+    let program = FieldExpressionProgram::new(ExprBuilder::new(config, 16), false);
+    FieldExpr::new(program, VariableRangeCheckerBus::new(0, 15));
+}
 
 fn create_field_expr_with_setup(
     builder: ExprBuilder,
 ) -> (FieldExpr, Arc<VariableRangeCheckerChip>, usize) {
     let prime = secp256k1_coord_prime();
     let (range_checker, _) = setup(&prime);
-    let expr = FieldExpr::new(builder, range_checker.bus(), false);
+    let program = FieldExpressionProgram::new(builder, false);
+    let expr = FieldExpr::new(program, range_checker.bus());
     let width = BaseAir::<BabyBear>::width(&expr);
     (expr, range_checker, width)
 }
@@ -34,7 +48,8 @@ fn create_field_expr_with_flags_setup(
 ) -> (FieldExpr, Arc<VariableRangeCheckerChip>, usize) {
     let prime = secp256k1_coord_prime();
     let (range_checker, _) = setup(&prime);
-    let expr = FieldExpr::new(builder, range_checker.bus(), true);
+    let program = FieldExpressionProgram::new(builder, true);
+    let expr = FieldExpr::new(program, range_checker.bus());
     let width = BaseAir::<BabyBear>::width(&expr);
     (expr, range_checker, width)
 }
@@ -62,17 +77,17 @@ fn generate_recorded_trace(
     let mut record = FieldExpressionCoreRecordMut::new_from_execution_data(
         &mut buffer,
         inputs,
-        expr.canonical_num_limbs(),
+        expr.program().canonical_num_limbs(),
     );
     let data: Vec<u8> = inputs
         .iter()
-        .flat_map(|x| biguint_to_limbs_vec(x, expr.canonical_num_limbs()))
+        .flat_map(|x| biguint_to_limbs_vec(x, expr.program().canonical_num_limbs()))
         .collect();
     record.fill_from_execution_data(0, &data);
 
     let reconstructed_inputs: Vec<BigUint> = record
         .input_limbs
-        .chunks(expr.canonical_num_limbs())
+        .chunks(expr.program().canonical_num_limbs())
         .map(BigUint::from_bytes_le)
         .collect();
 
@@ -435,11 +450,11 @@ fn test_recorded_execution_records() {
     let mut record = FieldExpressionCoreRecordMut::new_from_execution_data(
         &mut buffer,
         &inputs,
-        expr.canonical_num_limbs(),
+        expr.program().canonical_num_limbs(),
     );
     let data: Vec<u8> = inputs
         .iter()
-        .flat_map(|x| biguint_to_limbs_vec(x, expr.canonical_num_limbs()))
+        .flat_map(|x| biguint_to_limbs_vec(x, expr.program().canonical_num_limbs()))
         .collect();
     record.fill_from_execution_data(0, &data);
     assert_eq!(*record.opcode, 0);
@@ -447,7 +462,7 @@ fn test_recorded_execution_records() {
     // Verify input reconstruction preserves data
     let reconstructed_inputs: Vec<BigUint> = record
         .input_limbs
-        .chunks(expr.canonical_num_limbs())
+        .chunks(expr.program().canonical_num_limbs())
         .map(BigUint::from_bytes_le)
         .collect();
     assert_eq!(reconstructed_inputs.len(), inputs.len());
@@ -521,11 +536,11 @@ fn test_record_arena_allocation_patterns() {
     let mut record = FieldExpressionCoreRecordMut::new_from_execution_data(
         &mut buffer,
         &inputs,
-        expr.canonical_num_limbs(),
+        expr.program().canonical_num_limbs(),
     );
     let data: Vec<u8> = inputs
         .iter()
-        .flat_map(|x| biguint_to_limbs_vec(x, expr.canonical_num_limbs()))
+        .flat_map(|x| biguint_to_limbs_vec(x, expr.program().canonical_num_limbs()))
         .collect();
     record.fill_from_execution_data(0, &data);
     assert_eq!(*record.opcode, 0);
@@ -540,7 +555,7 @@ fn test_record_arena_allocation_patterns() {
     // Test input reconstruction
     let reconstructed_inputs: Vec<BigUint> = record
         .input_limbs
-        .chunks(expr.canonical_num_limbs())
+        .chunks(expr.program().canonical_num_limbs())
         .map(BigUint::from_bytes_le)
         .collect();
     assert_eq!(reconstructed_inputs.len(), inputs.len());
@@ -569,27 +584,27 @@ fn test_tracestep_tracefiller_roundtrip() {
         generate_random_biguint(&prime),
     ];
 
-    let vars_direct = expr.execute(&inputs, &[]);
+    let vars_direct = expr.program().execute(&inputs, &[]);
 
     // Test record creation and reconstruction roundtrip
     let mut buffer = vec![0u8; 1024];
     let mut record = FieldExpressionCoreRecordMut::new_from_execution_data(
         &mut buffer,
         &inputs,
-        expr.canonical_num_limbs(),
+        expr.program().canonical_num_limbs(),
     );
     let data: Vec<u8> = inputs
         .iter()
-        .flat_map(|x| biguint_to_limbs_vec(x, expr.canonical_num_limbs()))
+        .flat_map(|x| biguint_to_limbs_vec(x, expr.program().canonical_num_limbs()))
         .collect();
     record.fill_from_execution_data(0, &data);
 
     let reconstructed_inputs: Vec<BigUint> = record
         .input_limbs
-        .chunks(expr.canonical_num_limbs())
+        .chunks(expr.program().canonical_num_limbs())
         .map(BigUint::from_bytes_le)
         .collect();
-    let vars_reconstructed = expr.execute(&reconstructed_inputs, &[]);
+    let vars_reconstructed = expr.program().execute(&reconstructed_inputs, &[]);
 
     // All intermediate variables must be preserved
     assert_eq!(vars_direct.len(), vars_reconstructed.len());

--- a/extensions/algebra/circuit/src/execution.rs
+++ b/extensions/algebra/circuit/src/execution.rs
@@ -12,7 +12,7 @@ use openvm_instructions::{
     program::DEFAULT_PC_STEP,
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
 };
-use openvm_mod_circuit_builder::{run_field_expression_precomputed, FieldExpr};
+use openvm_mod_circuit_builder::{run_field_expression_precomputed, FieldExpressionProgram};
 use openvm_platform::memory::MEM_SIZE;
 use openvm_riscv_circuit::adapters::rv64_bytes_to_u32;
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -70,7 +70,7 @@ macro_rules! generate_fp2_dispatch {
 macro_rules! dispatch {
     ($execute_impl:ident,$execute_generic_impl:ident,$execute_setup_impl:ident,$pre_compute:ident,$op:ident) => {
         if let Some(op) = $op {
-            let modulus = &$pre_compute.expr.prime;
+            let modulus = $pre_compute.program.prime();
             if IS_FP2 {
                 if let Some(field_type) = get_fp2_field_type(modulus) {
                     generate_fp2_dispatch!(
@@ -145,7 +145,7 @@ macro_rules! dispatch {
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
 struct FieldExpressionPreCompute<'a> {
-    expr: &'a FieldExpr,
+    program: &'a FieldExpressionProgram,
     rs_addrs: [u8; 2],
     a: u8,
     flag_idx: u8,
@@ -179,8 +179,8 @@ impl<'a, const BLOCKS: usize, const IS_FP2: bool> FieldExprVecHeapExecutor<BLOCK
 
         let local_opcode = opcode.local_opcode_idx(self.inner.offset);
 
-        let needs_setup = self.inner.expr.needs_setup();
-        let mut flag_idx = self.inner.expr.num_flags() as u8;
+        let needs_setup = self.inner.program().needs_setup();
+        let mut flag_idx = self.inner.program().num_flags() as u8;
         if needs_setup {
             if let Some(opcode_position) = self
                 .inner
@@ -198,7 +198,7 @@ impl<'a, const BLOCKS: usize, const IS_FP2: bool> FieldExprVecHeapExecutor<BLOCK
         *data = FieldExpressionPreCompute {
             a: a as u8,
             rs_addrs,
-            expr: &self.inner.expr,
+            program: self.inner.program(),
             flag_idx,
         };
 
@@ -416,7 +416,7 @@ unsafe fn execute_e12_generic_impl<CTX: ExecutionCtxTrait, const BLOCKS: usize>(
     let read_data_dyn: DynArray<u8> = read_data.into();
 
     let writes = run_field_expression_precomputed::<true>(
-        pre_compute.expr,
+        pre_compute.program,
         pre_compute.flag_idx as usize,
         &read_data_dyn.0,
     );
@@ -466,7 +466,7 @@ unsafe fn execute_e12_setup_impl<
         BigUint::from_bytes_le(read_data[0].as_flattened())
     };
 
-    if input_prime != pre_compute.expr.prime {
+    if &input_prime != pre_compute.program.prime() {
         let err = ExecutionError::Fail {
             pc,
             msg: "ModularSetup: mismatched prime",
@@ -477,7 +477,7 @@ unsafe fn execute_e12_setup_impl<
     let read_data_dyn: DynArray<u8> = read_data.into();
 
     let writes = run_field_expression_precomputed::<true>(
-        pre_compute.expr,
+        pre_compute.program,
         pre_compute.flag_idx as usize,
         &read_data_dyn.0,
     );

--- a/extensions/algebra/circuit/src/extension/fp2.rs
+++ b/extensions/algebra/circuit/src/extension/fp2.rs
@@ -9,10 +9,10 @@ use openvm_circuit::{
     system::{memory::SharedMemoryHelper, SystemPort},
 };
 use openvm_circuit_derive::{AnyEnum, Executor, MeteredExecutor, PreflightExecutor};
-use openvm_circuit_primitives::var_range::VariableRangeCheckerBus;
 use openvm_cpu_backend::{CpuBackend, CpuDevice};
 use openvm_instructions::{LocalOpcode, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
+use openvm_riscv_circuit::adapters::U16_BITS;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
 use rvr_openvm_ext_algebra::Fp2RvrExtension;
@@ -97,8 +97,6 @@ impl VmExecutionExtension for Fp2Extension {
         inventory: &mut ExecutorInventoryBuilder<Fp2ExtensionExecutor>,
     ) -> Result<(), ExecutorInventoryError> {
         let byte_ptr_max_bits = to_byte_ptr_bits(inventory.pointer_max_bits());
-        // TODO: somehow get the range checker bus from `ExecutorInventory`
-        let dummy_range_checker_bus = VariableRangeCheckerBus::new(u16::MAX, 16);
         for (i, (_, modulus)) in self.supported_moduli.iter().enumerate() {
             // determine the number of bytes needed to represent a prime field element
             let bytes = modulus.bits().div_ceil(8) as usize;
@@ -112,7 +110,7 @@ impl VmExecutionExtension for Fp2Extension {
                 };
                 let addsub = get_fp2_addsub_executor(
                     config.clone(),
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );
@@ -123,12 +121,8 @@ impl VmExecutionExtension for Fp2Extension {
                         .map(|x| VmOpcode::from_usize(x + start_offset)),
                 )?;
 
-                let muldiv = get_fp2_muldiv_executor(
-                    config,
-                    dummy_range_checker_bus,
-                    byte_ptr_max_bits,
-                    start_offset,
-                );
+                let muldiv =
+                    get_fp2_muldiv_executor(config, U16_BITS, byte_ptr_max_bits, start_offset);
 
                 inventory.add_executor(
                     Fp2ExtensionExecutor::Fp2MulDivRv64_32(muldiv),
@@ -143,7 +137,7 @@ impl VmExecutionExtension for Fp2Extension {
                 };
                 let addsub = get_fp2_addsub_executor(
                     config.clone(),
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );
@@ -154,12 +148,8 @@ impl VmExecutionExtension for Fp2Extension {
                         .map(|x| VmOpcode::from_usize(x + start_offset)),
                 )?;
 
-                let muldiv = get_fp2_muldiv_executor(
-                    config,
-                    dummy_range_checker_bus,
-                    byte_ptr_max_bits,
-                    start_offset,
-                );
+                let muldiv =
+                    get_fp2_muldiv_executor(config, U16_BITS, byte_ptr_max_bits, start_offset);
 
                 inventory.add_executor(
                     Fp2ExtensionExecutor::Fp2MulDivRv64_48(muldiv),

--- a/extensions/algebra/circuit/src/extension/hybrid.rs
+++ b/extensions/algebra/circuit/src/extension/hybrid.rs
@@ -50,7 +50,7 @@ pub struct HybridModularChip<F, const BLOCKS: usize> {
 impl<const BLOCKS: usize> Chip<DenseRecordArena, GpuBackend> for HybridModularChip<F, BLOCKS> {
     fn generate_proving_ctx(&self, mut arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         let total_input_limbs =
-            self.cpu.inner.num_inputs() * self.cpu.inner.expr.canonical_num_limbs();
+            self.cpu.inner.num_inputs() * self.cpu.inner.expr.program().canonical_num_limbs();
         let layout = AdapterCoreLayout::with_metadata(FieldExpressionMetadata::<
             F,
             Rv64VecHeapAdapterExecutor<2, BLOCKS, BLOCKS>,
@@ -260,7 +260,7 @@ pub struct HybridFp2Chip<F, const BLOCKS: usize> {
 impl<const BLOCKS: usize> Chip<DenseRecordArena, GpuBackend> for HybridFp2Chip<F, BLOCKS> {
     fn generate_proving_ctx(&self, mut arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         let total_input_limbs =
-            self.cpu.inner.num_inputs() * self.cpu.inner.expr.canonical_num_limbs();
+            self.cpu.inner.num_inputs() * self.cpu.inner.expr.program().canonical_num_limbs();
         let layout = AdapterCoreLayout::with_metadata(FieldExpressionMetadata::<
             F,
             Rv64VecHeapAdapterExecutor<2, BLOCKS, BLOCKS>,

--- a/extensions/algebra/circuit/src/extension/modular.rs
+++ b/extensions/algebra/circuit/src/extension/modular.rs
@@ -14,9 +14,7 @@ use openvm_circuit::{
     system::{memory::SharedMemoryHelper, SystemPort},
 };
 use openvm_circuit_derive::{AnyEnum, Executor, MeteredExecutor, PreflightExecutor};
-use openvm_circuit_primitives::{
-    bigint::utils::big_uint_to_limbs, var_range::VariableRangeCheckerBus,
-};
+use openvm_circuit_primitives::bigint::utils::big_uint_to_limbs;
 use openvm_cpu_backend::{CpuBackend, CpuDevice};
 use openvm_instructions::{LocalOpcode, PhantomDiscriminant, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
@@ -92,8 +90,6 @@ impl VmExecutionExtension for ModularExtension {
         inventory: &mut ExecutorInventoryBuilder<ModularExtensionExecutor>,
     ) -> Result<(), ExecutorInventoryError> {
         let byte_ptr_max_bits = to_byte_ptr_bits(inventory.pointer_max_bits());
-        // TODO: somehow get the range checker bus from `ExecutorInventory`
-        let dummy_range_checker_bus = VariableRangeCheckerBus::new(u16::MAX, U16_BITS);
         for (i, modulus) in self.supported_moduli.iter().enumerate() {
             // determine the number of bytes needed to represent a prime field element
             let bytes = modulus.bits().div_ceil(8) as usize;
@@ -108,7 +104,7 @@ impl VmExecutionExtension for ModularExtension {
                 };
                 let addsub = get_modular_addsub_executor::<MODULAR_BLOCKS_32>(
                     config.clone(),
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );
@@ -122,7 +118,7 @@ impl VmExecutionExtension for ModularExtension {
 
                 let muldiv = get_modular_muldiv_executor::<MODULAR_BLOCKS_32>(
                     config,
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );
@@ -162,7 +158,7 @@ impl VmExecutionExtension for ModularExtension {
                 };
                 let addsub = get_modular_addsub_executor::<MODULAR_BLOCKS_48>(
                     config.clone(),
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );
@@ -176,7 +172,7 @@ impl VmExecutionExtension for ModularExtension {
 
                 let muldiv = get_modular_muldiv_executor::<MODULAR_BLOCKS_48>(
                     config,
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );

--- a/extensions/algebra/circuit/src/fp2.rs
+++ b/extensions/algebra/circuit/src/fp2.rs
@@ -182,7 +182,9 @@ mod tests {
     use halo2curves_axiom::bn256::Fq2;
     use num_bigint::BigUint;
     use openvm_circuit_primitives::TraceSubRowGenerator;
-    use openvm_mod_circuit_builder::{test_utils::*, FieldExpr, FieldExprCols};
+    use openvm_mod_circuit_builder::{
+        test_utils::*, FieldExpr, FieldExprCols, FieldExpressionProgram,
+    };
     use openvm_pairing_guest::bn254::BN254_MODULUS;
     use openvm_stark_backend::{
         any_air_arc_vec, p3_air::BaseAir, p3_field::PrimeCharacteristicRing,
@@ -217,7 +219,8 @@ mod tests {
         }
 
         let builder = builder.borrow().clone();
-        let air = FieldExpr::new(builder, range_checker.bus(), false);
+        let program = FieldExpressionProgram::new(builder, false);
+        let air = FieldExpr::new(program, range_checker.bus());
         let width = BaseAir::<BabyBear>::width(&air);
 
         let x_fp2 = bn254_fq2_random(1);
@@ -282,7 +285,8 @@ mod tests {
         // no need to save as div auto save.
 
         let builder = builder.borrow().clone();
-        let air = FieldExpr::new(builder, range_checker.bus(), false);
+        let program = FieldExpressionProgram::new(builder, false);
+        let air = FieldExpr::new(program, range_checker.bus());
         let width = BaseAir::<BabyBear>::width(&air);
 
         let x_fp2 = bn254_fq2_random(5);

--- a/extensions/algebra/circuit/src/fp2_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/addsub.rs
@@ -10,7 +10,7 @@ use openvm_circuit_primitives::var_range::{
 };
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
-    FieldExpressionFiller,
+    FieldExpressionFiller, FieldExpressionProgram,
 };
 use openvm_riscv_adapters::{
     Rv64VecHeapAdapterAir, Rv64VecHeapAdapterExecutor, Rv64VecHeapAdapterFiller,
@@ -23,8 +23,16 @@ pub fn fp2_addsub_expr(
     config: ExprBuilderConfig,
     range_bus: VariableRangeCheckerBus,
 ) -> (FieldExpr, usize, usize) {
+    let (program, is_add_flag, is_sub_flag) = fp2_addsub_program(config, range_bus.range_max_bits);
+    (FieldExpr::new(program, range_bus), is_add_flag, is_sub_flag)
+}
+
+fn fp2_addsub_program(
+    config: ExprBuilderConfig,
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, usize, usize) {
     config.check_valid();
-    let builder = ExprBuilder::new(config, range_bus.range_max_bits);
+    let builder = ExprBuilder::new(config, range_max_bits);
     let builder = Rc::new(RefCell::new(builder));
 
     let mut x = Fp2::new(builder.clone());
@@ -40,7 +48,7 @@ pub fn fp2_addsub_expr(
 
     let builder = builder.borrow().clone();
     (
-        FieldExpr::new(builder, range_bus, true),
+        FieldExpressionProgram::new(builder, true),
         is_add_flag,
         is_sub_flag,
     )
@@ -48,11 +56,11 @@ pub fn fp2_addsub_expr(
 
 // Input: Fp2 * 2
 // Output: Fp2
-fn gen_base_expr(
+fn gen_base_program(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
-) -> (FieldExpr, Vec<usize>, Vec<usize>) {
-    let (expr, is_add_flag, is_sub_flag) = fp2_addsub_expr(config, range_checker_bus);
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, Vec<usize>, Vec<usize>) {
+    let (program, is_add_flag, is_sub_flag) = fp2_addsub_program(config, range_max_bits);
 
     let local_opcode_idx = vec![
         Fp2Opcode::ADD as usize,
@@ -61,7 +69,7 @@ fn gen_base_expr(
     ];
     let opcode_flag_idx = vec![is_add_flag, is_sub_flag];
 
-    (expr, local_opcode_idx, opcode_flag_idx)
+    (program, local_opcode_idx, opcode_flag_idx)
 }
 
 pub fn get_fp2_addsub_air<const BLOCKS: usize>(
@@ -72,7 +80,9 @@ pub fn get_fp2_addsub_air<const BLOCKS: usize>(
     pointer_max_bits: usize,
     offset: usize,
 ) -> Fp2Air<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_checker_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_checker_bus);
     Fp2Air::new(
         Rv64VecHeapAdapterAir::new(exec_bridge, mem_bridge, range_checker_bus, pointer_max_bits),
         FieldExpressionCoreAir::new(expr, offset, local_opcode_idx, opcode_flag_idx),
@@ -81,15 +91,15 @@ pub fn get_fp2_addsub_air<const BLOCKS: usize>(
 
 pub fn get_fp2_addsub_executor<const BLOCKS: usize>(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
+    range_max_bits: usize,
     pointer_max_bits: usize,
     offset: usize,
 ) -> Fp2Executor<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) = gen_base_program(config, range_max_bits);
 
     FieldExprVecHeapExecutor::new(FieldExpressionExecutor::new(
         Rv64VecHeapAdapterExecutor::new(pointer_max_bits),
-        expr,
+        program,
         offset,
         local_opcode_idx,
         opcode_flag_idx,
@@ -103,7 +113,10 @@ pub fn get_fp2_addsub_chip<F, const BLOCKS: usize>(
     range_checker: SharedVariableRangeCheckerChip,
     pointer_max_bits: usize,
 ) -> Fp2Chip<F, BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker.bus());
+    let range_bus = range_checker.bus();
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_bus);
     Fp2Chip::new(
         FieldExpressionFiller::new(
             Rv64VecHeapAdapterFiller::new(pointer_max_bits, range_checker.clone()),

--- a/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/muldiv.rs
@@ -10,7 +10,7 @@ use openvm_circuit_primitives::var_range::{
 };
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
-    FieldExpressionFiller, SymbolicExpr,
+    FieldExpressionFiller, FieldExpressionProgram, SymbolicExpr,
 };
 use openvm_riscv_adapters::{
     Rv64VecHeapAdapterAir, Rv64VecHeapAdapterExecutor, Rv64VecHeapAdapterFiller,
@@ -23,8 +23,16 @@ pub fn fp2_muldiv_expr(
     config: ExprBuilderConfig,
     range_bus: VariableRangeCheckerBus,
 ) -> (FieldExpr, usize, usize) {
+    let (program, is_mul_flag, is_div_flag) = fp2_muldiv_program(config, range_bus.range_max_bits);
+    (FieldExpr::new(program, range_bus), is_mul_flag, is_div_flag)
+}
+
+fn fp2_muldiv_program(
+    config: ExprBuilderConfig,
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, usize, usize) {
     config.check_valid();
-    let builder = ExprBuilder::new(config, range_bus.range_max_bits);
+    let builder = ExprBuilder::new(config, range_max_bits);
     let builder = Rc::new(RefCell::new(builder));
 
     let x = Fp2::new(builder.clone());
@@ -79,7 +87,7 @@ pub fn fp2_muldiv_expr(
 
     let builder = builder.borrow().clone();
     (
-        FieldExpr::new(builder, range_bus, true),
+        FieldExpressionProgram::new(builder, true),
         is_mul_flag,
         is_div_flag,
     )
@@ -88,11 +96,11 @@ pub fn fp2_muldiv_expr(
 // Input: Fp2 * 2
 // Output: Fp2
 
-fn gen_base_expr(
+fn gen_base_program(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
-) -> (FieldExpr, Vec<usize>, Vec<usize>) {
-    let (expr, is_mul_flag, is_div_flag) = fp2_muldiv_expr(config, range_checker_bus);
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, Vec<usize>, Vec<usize>) {
+    let (program, is_mul_flag, is_div_flag) = fp2_muldiv_program(config, range_max_bits);
 
     let local_opcode_idx = vec![
         Fp2Opcode::MUL as usize,
@@ -101,7 +109,7 @@ fn gen_base_expr(
     ];
     let opcode_flag_idx = vec![is_mul_flag, is_div_flag];
 
-    (expr, local_opcode_idx, opcode_flag_idx)
+    (program, local_opcode_idx, opcode_flag_idx)
 }
 
 pub fn get_fp2_muldiv_air<const BLOCKS: usize>(
@@ -112,7 +120,9 @@ pub fn get_fp2_muldiv_air<const BLOCKS: usize>(
     pointer_max_bits: usize,
     offset: usize,
 ) -> Fp2Air<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_checker_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_checker_bus);
     Fp2Air::new(
         Rv64VecHeapAdapterAir::new(exec_bridge, mem_bridge, range_checker_bus, pointer_max_bits),
         FieldExpressionCoreAir::new(expr, offset, local_opcode_idx, opcode_flag_idx),
@@ -121,15 +131,15 @@ pub fn get_fp2_muldiv_air<const BLOCKS: usize>(
 
 pub fn get_fp2_muldiv_executor<const BLOCKS: usize>(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
+    range_max_bits: usize,
     pointer_max_bits: usize,
     offset: usize,
 ) -> Fp2Executor<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) = gen_base_program(config, range_max_bits);
 
     FieldExprVecHeapExecutor::new(FieldExpressionExecutor::new(
         Rv64VecHeapAdapterExecutor::new(pointer_max_bits),
-        expr,
+        program,
         offset,
         local_opcode_idx,
         opcode_flag_idx,
@@ -143,7 +153,10 @@ pub fn get_fp2_muldiv_chip<F, const BLOCKS: usize>(
     range_checker: SharedVariableRangeCheckerChip,
     pointer_max_bits: usize,
 ) -> Fp2Chip<F, BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker.bus());
+    let range_bus = range_checker.bus();
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_bus);
     Fp2Chip::new(
         FieldExpressionFiller::new(
             Rv64VecHeapAdapterFiller::new(pointer_max_bits, range_checker.clone()),

--- a/extensions/algebra/circuit/src/fp2_chip/tests.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/tests.rs
@@ -54,7 +54,7 @@ fn create_addsub_test_chips<const BLOCKS: usize>(
     );
     let executor = get_fp2_addsub_executor(
         config.clone(),
-        tester.range_checker().bus(),
+        tester.range_checker().bus().range_max_bits,
         tester.address_bits(),
         offset,
     );
@@ -82,7 +82,7 @@ fn create_muldiv_test_chips<const BLOCKS: usize>(
     );
     let executor = get_fp2_muldiv_executor(
         config.clone(),
-        tester.range_checker().bus(),
+        tester.range_checker().bus().range_max_bits,
         tester.address_bits(),
         offset,
     );
@@ -347,8 +347,12 @@ mod cuda_tests {
             tester.address_bits(),
             offset,
         );
-        let executor =
-            get_fp2_addsub_executor(config.clone(), range_bus, tester.address_bits(), offset);
+        let executor = get_fp2_addsub_executor(
+            config.clone(),
+            range_bus.range_max_bits,
+            tester.address_bits(),
+            offset,
+        );
 
         let cpu_chip = get_fp2_addsub_chip(
             config.clone(),
@@ -387,8 +391,12 @@ mod cuda_tests {
             tester.address_bits(),
             offset,
         );
-        let executor =
-            get_fp2_muldiv_executor(config.clone(), range_bus, tester.address_bits(), offset);
+        let executor = get_fp2_muldiv_executor(
+            config.clone(),
+            range_bus.range_max_bits,
+            tester.address_bits(),
+            offset,
+        );
 
         let cpu_chip = get_fp2_muldiv_chip(
             config.clone(),

--- a/extensions/algebra/circuit/src/lib.rs
+++ b/extensions/algebra/circuit/src/lib.rs
@@ -61,9 +61,9 @@ impl<const BLOCKS: usize, const IS_FP2: bool> FieldExprVecHeapExecutor<BLOCKS, I
         inner: FieldExpressionExecutor<Rv64VecHeapAdapterExecutor<2, BLOCKS, BLOCKS>>,
     ) -> Self {
         let cached_field_type = if IS_FP2 {
-            get_fp2_field_type(&inner.expr.prime)
+            get_fp2_field_type(inner.program().prime())
         } else {
-            get_field_type(&inner.expr.prime)
+            get_field_type(inner.program().prime())
         };
         Self {
             inner,

--- a/extensions/algebra/circuit/src/modular_chip/addsub.rs
+++ b/extensions/algebra/circuit/src/modular_chip/addsub.rs
@@ -10,7 +10,7 @@ use openvm_circuit_primitives::var_range::{
 };
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
-    FieldExpressionFiller, FieldVariable,
+    FieldExpressionFiller, FieldExpressionProgram, FieldVariable,
 };
 use openvm_riscv_adapters::{
     Rv64VecHeapAdapterAir, Rv64VecHeapAdapterExecutor, Rv64VecHeapAdapterFiller,
@@ -23,8 +23,16 @@ pub fn addsub_expr(
     config: ExprBuilderConfig,
     range_bus: VariableRangeCheckerBus,
 ) -> (FieldExpr, usize, usize) {
+    let (program, is_add_flag, is_sub_flag) = addsub_program(config, range_bus.range_max_bits);
+    (FieldExpr::new(program, range_bus), is_add_flag, is_sub_flag)
+}
+
+fn addsub_program(
+    config: ExprBuilderConfig,
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, usize, usize) {
     config.check_valid();
-    let builder = ExprBuilder::new(config, range_bus.range_max_bits);
+    let builder = ExprBuilder::new(config, range_max_bits);
     let builder = Rc::new(RefCell::new(builder));
 
     let x1 = ExprBuilder::new_input(builder.clone());
@@ -39,17 +47,17 @@ pub fn addsub_expr(
     let builder = (*builder).borrow().clone();
 
     (
-        FieldExpr::new(builder, range_bus, true),
+        FieldExpressionProgram::new(builder, true),
         is_add_flag,
         is_sub_flag,
     )
 }
 
-fn gen_base_expr(
+fn gen_base_program(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
-) -> (FieldExpr, Vec<usize>, Vec<usize>) {
-    let (expr, is_add_flag, is_sub_flag) = addsub_expr(config, range_checker_bus);
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, Vec<usize>, Vec<usize>) {
+    let (program, is_add_flag, is_sub_flag) = addsub_program(config, range_max_bits);
 
     let local_opcode_idx = vec![
         Rv64ModularArithmeticOpcode::ADD as usize,
@@ -58,7 +66,7 @@ fn gen_base_expr(
     ];
     let opcode_flag_idx = vec![is_add_flag, is_sub_flag];
 
-    (expr, local_opcode_idx, opcode_flag_idx)
+    (program, local_opcode_idx, opcode_flag_idx)
 }
 
 pub fn get_modular_addsub_air<const BLOCKS: usize>(
@@ -69,7 +77,9 @@ pub fn get_modular_addsub_air<const BLOCKS: usize>(
     pointer_max_bits: usize,
     offset: usize,
 ) -> ModularAir<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_checker_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_checker_bus);
     ModularAir::new(
         Rv64VecHeapAdapterAir::new(exec_bridge, mem_bridge, range_checker_bus, pointer_max_bits),
         FieldExpressionCoreAir::new(expr, offset, local_opcode_idx, opcode_flag_idx),
@@ -78,15 +88,15 @@ pub fn get_modular_addsub_air<const BLOCKS: usize>(
 
 pub fn get_modular_addsub_executor<const BLOCKS: usize>(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
+    range_max_bits: usize,
     pointer_max_bits: usize,
     offset: usize,
 ) -> ModularExecutor<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) = gen_base_program(config, range_max_bits);
 
     FieldExprVecHeapExecutor::new(FieldExpressionExecutor::new(
         Rv64VecHeapAdapterExecutor::new(pointer_max_bits),
-        expr,
+        program,
         offset,
         local_opcode_idx,
         opcode_flag_idx,
@@ -100,7 +110,10 @@ pub fn get_modular_addsub_chip<F, const BLOCKS: usize>(
     range_checker: SharedVariableRangeCheckerChip,
     pointer_max_bits: usize,
 ) -> ModularChip<F, BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker.bus());
+    let range_bus = range_checker.bus();
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_bus);
     ModularChip::new(
         FieldExpressionFiller::new(
             Rv64VecHeapAdapterFiller::new(pointer_max_bits, range_checker.clone()),

--- a/extensions/algebra/circuit/src/modular_chip/muldiv.rs
+++ b/extensions/algebra/circuit/src/modular_chip/muldiv.rs
@@ -10,7 +10,7 @@ use openvm_circuit_primitives::var_range::{
 };
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
-    FieldExpressionFiller, FieldVariable, SymbolicExpr,
+    FieldExpressionFiller, FieldExpressionProgram, FieldVariable, SymbolicExpr,
 };
 use openvm_riscv_adapters::{
     Rv64VecHeapAdapterAir, Rv64VecHeapAdapterExecutor, Rv64VecHeapAdapterFiller,
@@ -23,8 +23,16 @@ pub fn muldiv_expr(
     config: ExprBuilderConfig,
     range_bus: VariableRangeCheckerBus,
 ) -> (FieldExpr, usize, usize) {
+    let (program, is_mul_flag, is_div_flag) = muldiv_program(config, range_bus.range_max_bits);
+    (FieldExpr::new(program, range_bus), is_mul_flag, is_div_flag)
+}
+
+fn muldiv_program(
+    config: ExprBuilderConfig,
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, usize, usize) {
     config.check_valid();
-    let builder = ExprBuilder::new(config, range_bus.range_max_bits);
+    let builder = ExprBuilder::new(config, range_max_bits);
     let builder = Rc::new(RefCell::new(builder));
     let x = ExprBuilder::new_input(builder.clone());
     let y = ExprBuilder::new_input(builder.clone());
@@ -56,17 +64,17 @@ pub fn muldiv_expr(
     let builder = (*builder).borrow().clone();
 
     (
-        FieldExpr::new(builder, range_bus, true),
+        FieldExpressionProgram::new(builder, true),
         is_mul_flag,
         is_div_flag,
     )
 }
 
-fn gen_base_expr(
+fn gen_base_program(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
-) -> (FieldExpr, Vec<usize>, Vec<usize>) {
-    let (expr, is_mul_flag, is_div_flag) = muldiv_expr(config, range_checker_bus);
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, Vec<usize>, Vec<usize>) {
+    let (program, is_mul_flag, is_div_flag) = muldiv_program(config, range_max_bits);
 
     let local_opcode_idx = vec![
         Rv64ModularArithmeticOpcode::MUL as usize,
@@ -75,7 +83,7 @@ fn gen_base_expr(
     ];
     let opcode_flag_idx = vec![is_mul_flag, is_div_flag];
 
-    (expr, local_opcode_idx, opcode_flag_idx)
+    (program, local_opcode_idx, opcode_flag_idx)
 }
 
 pub fn get_modular_muldiv_air<const BLOCKS: usize>(
@@ -86,7 +94,9 @@ pub fn get_modular_muldiv_air<const BLOCKS: usize>(
     pointer_max_bits: usize,
     offset: usize,
 ) -> ModularAir<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_checker_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_checker_bus);
     ModularAir::new(
         Rv64VecHeapAdapterAir::new(exec_bridge, mem_bridge, range_checker_bus, pointer_max_bits),
         FieldExpressionCoreAir::new(expr, offset, local_opcode_idx, opcode_flag_idx),
@@ -95,15 +105,15 @@ pub fn get_modular_muldiv_air<const BLOCKS: usize>(
 
 pub fn get_modular_muldiv_executor<const BLOCKS: usize>(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
+    range_max_bits: usize,
     pointer_max_bits: usize,
     offset: usize,
 ) -> ModularExecutor<BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx, opcode_flag_idx) = gen_base_program(config, range_max_bits);
 
     FieldExprVecHeapExecutor::new(FieldExpressionExecutor::new(
         Rv64VecHeapAdapterExecutor::new(pointer_max_bits),
-        expr,
+        program,
         offset,
         local_opcode_idx,
         opcode_flag_idx,
@@ -117,7 +127,10 @@ pub fn get_modular_muldiv_chip<F, const BLOCKS: usize>(
     range_checker: SharedVariableRangeCheckerChip,
     pointer_max_bits: usize,
 ) -> ModularChip<F, BLOCKS> {
-    let (expr, local_opcode_idx, opcode_flag_idx) = gen_base_expr(config, range_checker.bus());
+    let range_bus = range_checker.bus();
+    let (program, local_opcode_idx, opcode_flag_idx) =
+        gen_base_program(config, range_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_bus);
     ModularChip::new(
         FieldExpressionFiller::new(
             Rv64VecHeapAdapterFiller::new(pointer_max_bits, range_checker.clone()),

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -76,7 +76,7 @@ mod addsub_tests {
         );
         let executor = get_modular_addsub_executor(
             config.clone(),
-            tester.range_checker().bus(),
+            tester.range_checker().bus().range_max_bits,
             tester.address_bits(),
             offset,
         );
@@ -117,8 +117,12 @@ mod addsub_tests {
             tester.address_bits(),
             offset,
         );
-        let executor =
-            get_modular_addsub_executor(config.clone(), range_bus, tester.address_bits(), offset);
+        let executor = get_modular_addsub_executor(
+            config.clone(),
+            range_bus.range_max_bits,
+            tester.address_bits(),
+            offset,
+        );
 
         let cpu_chip = get_modular_addsub_chip(
             config.clone(),
@@ -396,7 +400,7 @@ mod muldiv_tests {
 
         let executor = get_modular_muldiv_executor(
             config.clone(),
-            tester.range_checker().bus(),
+            tester.range_checker().bus().range_max_bits,
             tester.address_bits(),
             offset,
         );
@@ -438,8 +442,12 @@ mod muldiv_tests {
             tester.address_bits(),
             offset,
         );
-        let executor =
-            get_modular_muldiv_executor(config.clone(), range_bus, tester.address_bits(), offset);
+        let executor = get_modular_muldiv_executor(
+            config.clone(),
+            range_bus.range_max_bits,
+            tester.address_bits(),
+            offset,
+        );
 
         let cpu_chip = get_modular_muldiv_chip(
             config.clone(),

--- a/extensions/algebra/circuit/src/preflight.rs
+++ b/extensions/algebra/circuit/src/preflight.rs
@@ -232,10 +232,10 @@ where
                             None
                         }
                     })
-                    .unwrap_or_else(|| self.inner.expr.num_flags());
+                    .unwrap_or_else(|| self.inner.program().num_flags());
 
                 run_field_expression_precomputed::<true>(
-                    &self.inner.expr,
+                    self.inner.program(),
                     flag_idx,
                     read_data.as_flattened().as_flattened(),
                 )

--- a/extensions/ecc/circuit/src/extension/hybrid.rs
+++ b/extensions/ecc/circuit/src/extension/hybrid.rs
@@ -39,7 +39,7 @@ impl<const NUM_READS: usize, const BLOCKS: usize> Chip<DenseRecordArena, GpuBack
 {
     fn generate_proving_ctx(&self, mut arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
         let total_input_limbs =
-            self.cpu.inner.num_inputs() * self.cpu.inner.expr.canonical_num_limbs();
+            self.cpu.inner.num_inputs() * self.cpu.inner.expr.program().canonical_num_limbs();
         let layout = AdapterCoreLayout::with_metadata(FieldExpressionMetadata::<
             F,
             Rv64VecHeapAdapterExecutor<NUM_READS, BLOCKS, BLOCKS>,

--- a/extensions/ecc/circuit/src/extension/weierstrass.rs
+++ b/extensions/ecc/circuit/src/extension/weierstrass.rs
@@ -12,11 +12,11 @@ use openvm_circuit::{
     system::{memory::SharedMemoryHelper, SystemPort},
 };
 use openvm_circuit_derive::{AnyEnum, Executor, MeteredExecutor, PreflightExecutor};
-use openvm_circuit_primitives::var_range::VariableRangeCheckerBus;
 use openvm_cpu_backend::{CpuBackend, CpuDevice};
 use openvm_ecc_transpiler::Rv64WeierstrassOpcode;
 use openvm_instructions::{LocalOpcode, VmOpcode};
 use openvm_mod_circuit_builder::ExprBuilderConfig;
+use openvm_riscv_circuit::adapters::U16_BITS;
 use openvm_stark_backend::{p3_field::PrimeField32, StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
 use rvr_openvm_ext_ecc::EccExtension;
@@ -115,8 +115,6 @@ impl VmExecutionExtension for WeierstrassExtension {
         inventory: &mut ExecutorInventoryBuilder<WeierstrassExtensionExecutor>,
     ) -> Result<(), ExecutorInventoryError> {
         let byte_ptr_max_bits = to_byte_ptr_bits(inventory.pointer_max_bits());
-        // TODO: somehow get the range checker bus from `ExecutorInventory`
-        let dummy_range_checker_bus = VariableRangeCheckerBus::new(u16::MAX, 16);
         for (i, curve) in self.supported_curves.iter().enumerate() {
             let start_offset =
                 Rv64WeierstrassOpcode::CLASS_OFFSET + i * Rv64WeierstrassOpcode::COUNT;
@@ -130,7 +128,7 @@ impl VmExecutionExtension for WeierstrassExtension {
                 };
                 let addne = get_ec_addne_executor(
                     config.clone(),
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );
@@ -144,7 +142,7 @@ impl VmExecutionExtension for WeierstrassExtension {
 
                 let double = get_ec_double_executor(
                     config,
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                     curve.a.clone(),
@@ -164,7 +162,7 @@ impl VmExecutionExtension for WeierstrassExtension {
                 };
                 let addne = get_ec_addne_executor(
                     config.clone(),
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                 );
@@ -178,7 +176,7 @@ impl VmExecutionExtension for WeierstrassExtension {
 
                 let double = get_ec_double_executor(
                     config,
-                    dummy_range_checker_bus,
+                    U16_BITS,
                     byte_ptr_max_bits,
                     start_offset,
                     curve.a.clone(),

--- a/extensions/ecc/circuit/src/weierstrass_chip/add_ne/execution.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/add_ne/execution.rs
@@ -13,7 +13,7 @@ use openvm_instructions::{
     program::DEFAULT_PC_STEP,
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
 };
-use openvm_mod_circuit_builder::{run_field_expression_precomputed, FieldExpr};
+use openvm_mod_circuit_builder::{run_field_expression_precomputed, FieldExpressionProgram};
 use openvm_platform::memory::MEM_SIZE;
 use openvm_riscv_circuit::adapters::rv64_bytes_to_u32;
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -24,7 +24,7 @@ use crate::weierstrass_chip::curves::ec_add_ne;
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
 struct EcAddNePreCompute<'a> {
-    expr: &'a FieldExpr,
+    program: &'a FieldExpressionProgram,
     rs_addrs: [u8; 2],
     a: u8,
     flag_idx: u8,
@@ -60,8 +60,8 @@ impl<'a, const BLOCKS: usize> EcAddNeExecutor<BLOCKS> {
         let local_opcode = opcode.local_opcode_idx(self.offset);
 
         // Pre-compute flag_idx
-        let needs_setup = self.expr.needs_setup();
-        let mut flag_idx = self.expr.num_flags() as u8;
+        let needs_setup = self.program().needs_setup();
+        let mut flag_idx = self.program().num_flags() as u8;
         if needs_setup {
             // Find which opcode this is in our local_opcode_idx list
             if let Some(opcode_position) = self
@@ -78,7 +78,7 @@ impl<'a, const BLOCKS: usize> EcAddNeExecutor<BLOCKS> {
 
         let rs_addrs = from_fn(|i| if i == 0 { b } else { c } as u8);
         *data = EcAddNePreCompute {
-            expr: &self.expr,
+            program: self.program(),
             rs_addrs,
             a: a as u8,
             flag_idx,
@@ -94,7 +94,7 @@ impl<'a, const BLOCKS: usize> EcAddNeExecutor<BLOCKS> {
 macro_rules! dispatch {
     ($execute_impl:ident, $pre_compute:ident, $is_setup:ident) => {
         if let Some(field_type) = {
-            let modulus = &$pre_compute.expr.builder.prime;
+            let modulus = $pre_compute.program.prime();
             get_field_type(modulus)
         } {
             match ($is_setup, field_type) {
@@ -242,7 +242,7 @@ unsafe fn execute_e12_impl<
 
     if IS_SETUP {
         let input_prime = BigUint::from_bytes_le(read_data[0][..BLOCKS / 2].as_flattened());
-        if input_prime != pre_compute.expr.prime {
+        if &input_prime != pre_compute.program.prime() {
             let err = ExecutionError::Fail {
                 pc,
                 msg: "EcAddNe: mismatched prime",
@@ -254,7 +254,7 @@ unsafe fn execute_e12_impl<
     let output_data = if FIELD_TYPE == u8::MAX || IS_SETUP {
         let read_data: DynArray<u8> = read_data.into();
         run_field_expression_precomputed::<true>(
-            pre_compute.expr,
+            pre_compute.program,
             pre_compute.flag_idx as usize,
             &read_data.0,
         )

--- a/extensions/ecc/circuit/src/weierstrass_chip/add_ne/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/add_ne/mod.rs
@@ -15,7 +15,7 @@ use openvm_circuit_primitives::var_range::{
 use openvm_ecc_transpiler::Rv64WeierstrassOpcode;
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
-    FieldExpressionFiller,
+    FieldExpressionFiller, FieldExpressionProgram,
 };
 use openvm_riscv_adapters::{
     Rv64VecHeapAdapterAir, Rv64VecHeapAdapterExecutor, Rv64VecHeapAdapterFiller,
@@ -51,16 +51,16 @@ pub fn ec_add_ne_expr(
     range_bus: VariableRangeCheckerBus,
 ) -> FieldExpr {
     FieldExpr::new(
-        build_ec_add_ne_expr(config, range_bus.range_max_bits),
+        ec_add_ne_program(config, range_bus.range_max_bits),
         range_bus,
-        true,
     )
 }
 
-pub fn ec_add_ne_builder(config: ExprBuilderConfig, range_max_bits: usize) -> ExprBuilder {
-    let mut builder = build_ec_add_ne_expr(config, range_max_bits);
-    builder.finalize(true);
-    builder
+pub fn ec_add_ne_program(
+    config: ExprBuilderConfig,
+    range_max_bits: usize,
+) -> FieldExpressionProgram {
+    FieldExpressionProgram::new(build_ec_add_ne_expr(config, range_max_bits), true)
 }
 
 /// `BLOCKS` is the number of memory blocks needed to represent one input or output point.
@@ -75,7 +75,7 @@ impl<const BLOCKS: usize> EcAddNeExecutor<BLOCKS> {
     pub fn new(
         inner: FieldExpressionExecutor<Rv64VecHeapAdapterExecutor<2, BLOCKS, BLOCKS>>,
     ) -> Self {
-        let cached_field_type = get_field_type(&inner.expr.prime);
+        let cached_field_type = get_field_type(inner.program().prime());
         Self {
             inner,
             cached_field_type,
@@ -97,16 +97,16 @@ impl<const BLOCKS: usize> DerefMut for EcAddNeExecutor<BLOCKS> {
     }
 }
 
-fn gen_base_expr(
+fn gen_base_program(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
-) -> (FieldExpr, Vec<usize>) {
-    let expr = ec_add_ne_expr(config, range_checker_bus);
+    range_max_bits: usize,
+) -> (FieldExpressionProgram, Vec<usize>) {
+    let program = ec_add_ne_program(config, range_max_bits);
     let local_opcode_idx = vec![
         Rv64WeierstrassOpcode::EC_ADD_NE as usize,
         Rv64WeierstrassOpcode::SETUP_EC_ADD_NE as usize,
     ];
-    (expr, local_opcode_idx)
+    (program, local_opcode_idx)
 }
 
 pub fn get_ec_addne_air<const BLOCKS: usize>(
@@ -117,23 +117,24 @@ pub fn get_ec_addne_air<const BLOCKS: usize>(
     pointer_max_bits: usize,
     offset: usize,
 ) -> WeierstrassAir<2, BLOCKS> {
-    let (expr, local_opcode_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx) = gen_base_program(config, range_checker_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_checker_bus);
     WeierstrassAir::new(
         Rv64VecHeapAdapterAir::new(exec_bridge, mem_bridge, range_checker_bus, pointer_max_bits),
-        FieldExpressionCoreAir::new(expr.clone(), offset, local_opcode_idx.clone(), vec![]),
+        FieldExpressionCoreAir::new(expr, offset, local_opcode_idx, vec![]),
     )
 }
 
 pub fn get_ec_addne_executor<const BLOCKS: usize>(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
+    range_max_bits: usize,
     pointer_max_bits: usize,
     offset: usize,
 ) -> EcAddNeExecutor<BLOCKS> {
-    let (expr, local_opcode_idx) = gen_base_expr(config, range_checker_bus);
+    let (program, local_opcode_idx) = gen_base_program(config, range_max_bits);
     EcAddNeExecutor::new(FieldExpressionExecutor::new(
         Rv64VecHeapAdapterExecutor::new(pointer_max_bits),
-        expr,
+        program,
         offset,
         local_opcode_idx,
         vec![],
@@ -147,7 +148,9 @@ pub fn get_ec_addne_chip<F, const BLOCKS: usize>(
     range_checker: SharedVariableRangeCheckerChip,
     pointer_max_bits: usize,
 ) -> WeierstrassChip<F, 2, BLOCKS> {
-    let (expr, local_opcode_idx) = gen_base_expr(config, range_checker.bus());
+    let range_bus = range_checker.bus();
+    let (program, local_opcode_idx) = gen_base_program(config, range_bus.range_max_bits);
+    let expr = FieldExpr::new(program, range_bus);
     WeierstrassChip::new(
         FieldExpressionFiller::new(
             Rv64VecHeapAdapterFiller::new(pointer_max_bits, range_checker.clone()),

--- a/extensions/ecc/circuit/src/weierstrass_chip/add_ne/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/add_ne/mod.rs
@@ -27,12 +27,9 @@ mod execution;
 
 // Assumes that (x1, y1), (x2, y2) both lie on the curve and are not the identity point.
 // Further assumes that x1, x2 are not equal in the coordinate field.
-pub fn ec_add_ne_expr(
-    config: ExprBuilderConfig, // The coordinate field.
-    range_bus: VariableRangeCheckerBus,
-) -> FieldExpr {
+fn build_ec_add_ne_expr(config: ExprBuilderConfig, range_max_bits: usize) -> ExprBuilder {
     config.check_valid();
-    let builder = ExprBuilder::new(config, range_bus.range_max_bits);
+    let builder = ExprBuilder::new(config, range_max_bits);
     let builder = Rc::new(RefCell::new(builder));
 
     let x1 = ExprBuilder::new_input(builder.clone());
@@ -45,8 +42,25 @@ pub fn ec_add_ne_expr(
     let mut y3 = lambda * (x1 - x3.clone()) - y1;
     y3.save_output();
 
-    let builder = (*builder).borrow().clone();
-    FieldExpr::new(builder, range_bus, true)
+    let builder = builder.borrow().clone();
+    builder
+}
+
+pub fn ec_add_ne_expr(
+    config: ExprBuilderConfig, // The coordinate field.
+    range_bus: VariableRangeCheckerBus,
+) -> FieldExpr {
+    FieldExpr::new(
+        build_ec_add_ne_expr(config, range_bus.range_max_bits),
+        range_bus,
+        true,
+    )
+}
+
+pub fn ec_add_ne_builder(config: ExprBuilderConfig, range_max_bits: usize) -> ExprBuilder {
+    let mut builder = build_ec_add_ne_expr(config, range_max_bits);
+    builder.finalize(true);
+    builder
 }
 
 /// `BLOCKS` is the number of memory blocks needed to represent one input or output point.
@@ -88,12 +102,10 @@ fn gen_base_expr(
     range_checker_bus: VariableRangeCheckerBus,
 ) -> (FieldExpr, Vec<usize>) {
     let expr = ec_add_ne_expr(config, range_checker_bus);
-
     let local_opcode_idx = vec![
         Rv64WeierstrassOpcode::EC_ADD_NE as usize,
         Rv64WeierstrassOpcode::SETUP_EC_ADD_NE as usize,
     ];
-
     (expr, local_opcode_idx)
 }
 

--- a/extensions/ecc/circuit/src/weierstrass_chip/double/execution.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double/execution.rs
@@ -13,7 +13,7 @@ use openvm_instructions::{
     program::DEFAULT_PC_STEP,
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
 };
-use openvm_mod_circuit_builder::{run_field_expression_precomputed, FieldExpr};
+use openvm_mod_circuit_builder::{run_field_expression_precomputed, FieldExpressionProgram};
 use openvm_platform::memory::MEM_SIZE;
 use openvm_riscv_circuit::adapters::rv64_bytes_to_u32;
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -24,7 +24,7 @@ use crate::weierstrass_chip::curves::{ec_double, get_curve_type, CurveType};
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
 struct EcDoublePreCompute<'a> {
-    expr: &'a FieldExpr,
+    program: &'a FieldExpressionProgram,
     rs_addrs: [u8; 1],
     a: u8,
     flag_idx: u8,
@@ -53,8 +53,8 @@ impl<'a, const BLOCKS: usize> EcDoubleExecutor<BLOCKS> {
         let local_opcode = opcode.local_opcode_idx(self.offset);
 
         // Pre-compute flag_idx
-        let needs_setup = self.expr.needs_setup();
-        let mut flag_idx = self.expr.num_flags() as u8;
+        let needs_setup = self.program().needs_setup();
+        let mut flag_idx = self.program().num_flags() as u8;
         if needs_setup {
             // Find which opcode this is in our local_opcode_idx list
             if let Some(opcode_position) = self
@@ -71,7 +71,7 @@ impl<'a, const BLOCKS: usize> EcDoubleExecutor<BLOCKS> {
 
         let rs_addrs = [b as u8];
         *data = EcDoublePreCompute {
-            expr: &self.expr,
+            program: self.program(),
             rs_addrs,
             a: a as u8,
             flag_idx,
@@ -87,8 +87,8 @@ impl<'a, const BLOCKS: usize> EcDoubleExecutor<BLOCKS> {
 macro_rules! dispatch {
     ($execute_impl:ident,$pre_compute:ident,$is_setup:ident) => {
         if let Some(curve_type) = {
-            let modulus = &$pre_compute.expr.builder.prime;
-            let a_coeff = &$pre_compute.expr.setup_values[0];
+            let modulus = $pre_compute.program.prime();
+            let a_coeff = &$pre_compute.program.setup_values()[0];
             get_curve_type(modulus, a_coeff)
         } {
             match ($is_setup, curve_type) {
@@ -239,7 +239,7 @@ unsafe fn execute_e12_impl<
     if IS_SETUP {
         let input_prime = BigUint::from_bytes_le(read_data[..BLOCKS / 2].as_flattened());
 
-        if input_prime != pre_compute.expr.builder.prime {
+        if &input_prime != pre_compute.program.prime() {
             let err = ExecutionError::Fail {
                 pc,
                 msg: "EcDouble: mismatched prime",
@@ -249,7 +249,7 @@ unsafe fn execute_e12_impl<
 
         // Extract second field element as the a coefficient
         let input_a = BigUint::from_bytes_le(read_data[BLOCKS / 2..].as_flattened());
-        let coeff_a = &pre_compute.expr.setup_values[0];
+        let coeff_a = &pre_compute.program.setup_values()[0];
         if input_a != *coeff_a {
             let err = ExecutionError::Fail {
                 pc,
@@ -262,7 +262,7 @@ unsafe fn execute_e12_impl<
     let output_data = if CURVE_TYPE == u8::MAX || IS_SETUP {
         let read_data: DynArray<u8> = read_data.into();
         run_field_expression_precomputed::<true>(
-            pre_compute.expr,
+            pre_compute.program,
             pre_compute.flag_idx as usize,
             &read_data.0,
         )

--- a/extensions/ecc/circuit/src/weierstrass_chip/double/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double/mod.rs
@@ -29,13 +29,13 @@ use super::{
 
 mod execution;
 
-pub fn ec_double_ne_expr(
-    config: ExprBuilderConfig, // The coordinate field.
-    range_bus: VariableRangeCheckerBus,
-    a_biguint: BigUint,
-) -> FieldExpr {
+fn build_ec_double_ne_expr(
+    config: ExprBuilderConfig,
+    range_max_bits: usize,
+    a_biguint: &BigUint,
+) -> ExprBuilder {
     config.check_valid();
-    let builder = ExprBuilder::new(config, range_bus.range_max_bits);
+    let builder = ExprBuilder::new(config, range_max_bits);
     let builder = Rc::new(RefCell::new(builder));
 
     let mut x1 = ExprBuilder::new_input(builder.clone());
@@ -55,8 +55,31 @@ pub fn ec_double_ne_expr(
     let mut y3 = lambda * (x1 - x3.clone()) - y1;
     y3.save_output();
 
-    let builder = (*builder).borrow().clone();
-    FieldExpr::new_with_setup_values(builder, range_bus, true, vec![a_biguint])
+    let builder = builder.borrow().clone();
+    builder
+}
+
+pub fn ec_double_ne_expr(
+    config: ExprBuilderConfig,
+    range_bus: VariableRangeCheckerBus,
+    a_biguint: BigUint,
+) -> FieldExpr {
+    FieldExpr::new_with_setup_values(
+        build_ec_double_ne_expr(config, range_bus.range_max_bits, &a_biguint),
+        range_bus,
+        true,
+        vec![a_biguint],
+    )
+}
+
+pub fn ec_double_ne_builder(
+    config: ExprBuilderConfig,
+    range_max_bits: usize,
+    a_biguint: BigUint,
+) -> ExprBuilder {
+    let mut builder = build_ec_double_ne_expr(config, range_max_bits, &a_biguint);
+    builder.finalize(true);
+    builder
 }
 
 /// `BLOCKS` is the number of memory blocks needed to represent one input or output point.
@@ -103,12 +126,10 @@ fn gen_base_expr(
     a_biguint: BigUint,
 ) -> (FieldExpr, Vec<usize>) {
     let expr = ec_double_ne_expr(config, range_checker_bus, a_biguint);
-
     let local_opcode_idx = vec![
         Rv64WeierstrassOpcode::EC_DOUBLE as usize,
         Rv64WeierstrassOpcode::SETUP_EC_DOUBLE as usize,
     ];
-
     (expr, local_opcode_idx)
 }
 

--- a/extensions/ecc/circuit/src/weierstrass_chip/double/mod.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/double/mod.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives::var_range::{
 use openvm_ecc_transpiler::Rv64WeierstrassOpcode;
 use openvm_mod_circuit_builder::{
     ExprBuilder, ExprBuilderConfig, FieldExpr, FieldExpressionCoreAir, FieldExpressionExecutor,
-    FieldExpressionFiller, FieldVariable,
+    FieldExpressionFiller, FieldExpressionProgram, FieldVariable,
 };
 use openvm_riscv_adapters::{
     Rv64VecHeapAdapterAir, Rv64VecHeapAdapterExecutor, Rv64VecHeapAdapterFiller,
@@ -64,22 +64,22 @@ pub fn ec_double_ne_expr(
     range_bus: VariableRangeCheckerBus,
     a_biguint: BigUint,
 ) -> FieldExpr {
-    FieldExpr::new_with_setup_values(
-        build_ec_double_ne_expr(config, range_bus.range_max_bits, &a_biguint),
+    FieldExpr::new(
+        ec_double_ne_program(config, range_bus.range_max_bits, a_biguint),
         range_bus,
-        true,
-        vec![a_biguint],
     )
 }
 
-pub fn ec_double_ne_builder(
+pub fn ec_double_ne_program(
     config: ExprBuilderConfig,
     range_max_bits: usize,
     a_biguint: BigUint,
-) -> ExprBuilder {
-    let mut builder = build_ec_double_ne_expr(config, range_max_bits, &a_biguint);
-    builder.finalize(true);
-    builder
+) -> FieldExpressionProgram {
+    FieldExpressionProgram::new_with_setup_values(
+        build_ec_double_ne_expr(config, range_max_bits, &a_biguint),
+        true,
+        vec![a_biguint],
+    )
 }
 
 /// `BLOCKS` is the number of memory blocks needed to represent one input or output point.
@@ -95,10 +95,10 @@ impl<const BLOCKS: usize> EcDoubleExecutor<BLOCKS> {
         inner: FieldExpressionExecutor<Rv64VecHeapAdapterExecutor<1, BLOCKS, BLOCKS>>,
     ) -> Self {
         let cached_curve_type = inner
-            .expr
-            .setup_values
+            .program()
+            .setup_values()
             .first()
-            .and_then(|a| get_curve_type(&inner.expr.prime, a));
+            .and_then(|a| get_curve_type(inner.program().prime(), a));
         Self {
             inner,
             cached_curve_type,
@@ -120,17 +120,17 @@ impl<const BLOCKS: usize> DerefMut for EcDoubleExecutor<BLOCKS> {
     }
 }
 
-fn gen_base_expr(
+fn gen_base_program(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
+    range_max_bits: usize,
     a_biguint: BigUint,
-) -> (FieldExpr, Vec<usize>) {
-    let expr = ec_double_ne_expr(config, range_checker_bus, a_biguint);
+) -> (FieldExpressionProgram, Vec<usize>) {
+    let program = ec_double_ne_program(config, range_max_bits, a_biguint);
     let local_opcode_idx = vec![
         Rv64WeierstrassOpcode::EC_DOUBLE as usize,
         Rv64WeierstrassOpcode::SETUP_EC_DOUBLE as usize,
     ];
-    (expr, local_opcode_idx)
+    (program, local_opcode_idx)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -143,24 +143,26 @@ pub fn get_ec_double_air<const BLOCKS: usize>(
     offset: usize,
     a_biguint: BigUint,
 ) -> WeierstrassAir<1, BLOCKS> {
-    let (expr, local_opcode_idx) = gen_base_expr(config, range_checker_bus, a_biguint);
+    let (program, local_opcode_idx) =
+        gen_base_program(config, range_checker_bus.range_max_bits, a_biguint);
+    let expr = FieldExpr::new(program, range_checker_bus);
     WeierstrassAir::new(
         Rv64VecHeapAdapterAir::new(exec_bridge, mem_bridge, range_checker_bus, pointer_max_bits),
-        FieldExpressionCoreAir::new(expr.clone(), offset, local_opcode_idx.clone(), vec![]),
+        FieldExpressionCoreAir::new(expr, offset, local_opcode_idx, vec![]),
     )
 }
 
 pub fn get_ec_double_executor<const BLOCKS: usize>(
     config: ExprBuilderConfig,
-    range_checker_bus: VariableRangeCheckerBus,
+    range_max_bits: usize,
     pointer_max_bits: usize,
     offset: usize,
     a_biguint: BigUint,
 ) -> EcDoubleExecutor<BLOCKS> {
-    let (expr, local_opcode_idx) = gen_base_expr(config, range_checker_bus, a_biguint);
+    let (program, local_opcode_idx) = gen_base_program(config, range_max_bits, a_biguint);
     EcDoubleExecutor::new(FieldExpressionExecutor::new(
         Rv64VecHeapAdapterExecutor::new(pointer_max_bits),
-        expr,
+        program,
         offset,
         local_opcode_idx,
         vec![],
@@ -175,7 +177,9 @@ pub fn get_ec_double_chip<F, const BLOCKS: usize>(
     pointer_max_bits: usize,
     a_biguint: BigUint,
 ) -> WeierstrassChip<F, 1, BLOCKS> {
-    let (expr, local_opcode_idx) = gen_base_expr(config, range_checker.bus(), a_biguint);
+    let range_bus = range_checker.bus();
+    let (program, local_opcode_idx) = gen_base_program(config, range_bus.range_max_bits, a_biguint);
+    let expr = FieldExpr::new(program, range_bus);
     WeierstrassChip::new(
         FieldExpressionFiller::new(
             Rv64VecHeapAdapterFiller::new(pointer_max_bits, range_checker.clone()),

--- a/extensions/ecc/circuit/src/weierstrass_chip/preflight.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/preflight.rs
@@ -103,18 +103,18 @@ fn is_setup_opcode(local_opcode: usize) -> bool {
 /// Slow-path fallback for EC operations (used for SETUP opcodes and unknown field types).
 #[inline]
 fn compute_ec_slow<const BLOCKS: usize>(
-    expr: &openvm_mod_circuit_builder::FieldExpr,
+    program: &openvm_mod_circuit_builder::FieldExpressionProgram,
     local_opcode: usize,
     read_bytes: &[u8],
 ) -> [[u8; MEMORY_BLOCK_BYTES]; BLOCKS] {
     let flag_idx = if is_setup_opcode(local_opcode) {
         // SETUP operations: pass num_flags so no flag is set
-        expr.num_flags()
+        program.num_flags()
     } else {
         // Single operation chip, flag_idx = 0
         0
     };
-    run_field_expression_precomputed::<true>(expr, flag_idx, read_bytes).into()
+    run_field_expression_precomputed::<true>(program, flag_idx, read_bytes).into()
 }
 
 // Implementation for EcAddNeExecutor
@@ -160,7 +160,7 @@ where
             compute_ec_add_ne_fast::<BLOCKS>(self.cached_field_type, read_data).unwrap_or_else(
                 || {
                     compute_ec_slow::<BLOCKS>(
-                        &self.inner.expr,
+                        self.inner.program(),
                         local_opcode,
                         read_data.as_flattened().as_flattened(),
                     )
@@ -168,7 +168,7 @@ where
             )
         } else {
             compute_ec_slow::<BLOCKS>(
-                &self.inner.expr,
+                self.inner.program(),
                 local_opcode,
                 read_data.as_flattened().as_flattened(),
             )
@@ -230,14 +230,14 @@ where
             compute_ec_double_fast::<BLOCKS>(self.cached_curve_type, read_data).unwrap_or_else(
                 || {
                     compute_ec_slow::<BLOCKS>(
-                        &self.inner.expr,
+                        self.inner.program(),
                         local_opcode,
                         read_data.as_flattened(),
                     )
                 },
             )
         } else {
-            compute_ec_slow::<BLOCKS>(&self.inner.expr, local_opcode, read_data.as_flattened())
+            compute_ec_slow::<BLOCKS>(self.inner.program(), local_opcode, read_data.as_flattened())
         };
 
         self.inner

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -119,7 +119,7 @@ mod ec_addne_tests {
         );
         let executor = get_ec_addne_executor::<BLOCKS>(
             config.clone(),
-            tester.range_checker().bus(),
+            tester.range_checker().bus().range_max_bits,
             tester.address_bits(),
             offset,
         );
@@ -161,8 +161,12 @@ mod ec_addne_tests {
             tester.address_bits(),
             offset,
         );
-        let executor =
-            get_ec_addne_executor(config.clone(), range_bus, tester.address_bits(), offset);
+        let executor = get_ec_addne_executor(
+            config.clone(),
+            range_bus.range_max_bits,
+            tester.address_bits(),
+            offset,
+        );
 
         let cpu_chip = get_ec_addne_chip(
             config.clone(),
@@ -479,15 +483,17 @@ mod ec_addne_tests {
 
         let executor = get_ec_addne_executor::<{ ECC_BLOCKS_32 }>(
             config,
-            tester.range_checker().bus(),
+            tester.range_checker().bus().range_max_bits,
             tester.address_bits(),
             Rv64WeierstrassOpcode::CLASS_OFFSET,
         );
 
         let (p1_x, p1_y) = SampleEcPoints[0].clone();
         let (p2_x, p2_y) = SampleEcPoints[1].clone();
-        assert_eq!(executor.expr.builder.num_variables, 3); // lambda, x3, y3
-        let r = executor.expr.execute(&[p1_x, p1_y, p2_x, p2_y], &[true]);
+        assert_eq!(executor.program().num_vars(), 3); // lambda, x3, y3
+        let r = executor
+            .program()
+            .execute(&[p1_x, p1_y, p2_x, p2_y], &[true]);
 
         assert_eq!(r.len(), 3); // lambda, x3, y3
         assert_eq!(r[1], SampleEcPoints[2].0);
@@ -495,8 +501,10 @@ mod ec_addne_tests {
 
         let (p1_x, p1_y) = SampleEcPoints[2].clone();
         let (p2_x, p2_y) = SampleEcPoints[3].clone();
-        assert_eq!(executor.expr.builder.num_variables, 3); // lambda, x3, y3
-        let r = executor.expr.execute(&[p1_x, p1_y, p2_x, p2_y], &[true]);
+        assert_eq!(executor.program().num_vars(), 3); // lambda, x3, y3
+        let r = executor
+            .program()
+            .execute(&[p1_x, p1_y, p2_x, p2_y], &[true]);
 
         assert_eq!(r.len(), 3); // lambda, x3, y3
         assert_eq!(r[1], SampleEcPoints[4].0);
@@ -532,7 +540,7 @@ mod ec_double_tests {
         );
         let executor = get_ec_double_executor(
             config.clone(),
-            tester.range_checker().bus(),
+            tester.range_checker().bus().range_max_bits,
             tester.address_bits(),
             offset,
             a_biguint.clone(),
@@ -579,7 +587,7 @@ mod ec_double_tests {
         );
         let executor = get_ec_double_executor(
             config.clone(),
-            range_bus,
+            range_bus.range_max_bits,
             tester.address_bits(),
             offset,
             a_biguint.clone(),
@@ -970,7 +978,7 @@ mod ec_double_tests {
 
         let executor = get_ec_double_executor::<{ ECC_BLOCKS_32 }>(
             config,
-            tester.range_checker().bus(),
+            tester.range_checker().bus().range_max_bits,
             tester.address_bits(),
             Rv64WeierstrassOpcode::CLASS_OFFSET,
             BigUint::zero(),
@@ -978,9 +986,9 @@ mod ec_double_tests {
 
         let (p1_x, p1_y) = SampleEcPoints[1].clone();
 
-        assert_eq!(executor.expr.builder.num_variables, 3); // lambda, x3, y3
+        assert_eq!(executor.program().num_vars(), 3); // lambda, x3, y3
 
-        let r = executor.expr.execute(&[p1_x, p1_y], &[true]);
+        let r = executor.program().execute(&[p1_x, p1_y], &[true]);
         assert_eq!(r.len(), 3); // lambda, x3, y3
         assert_eq!(r[1], SampleEcPoints[3].0);
         assert_eq!(r[2], SampleEcPoints[3].1);
@@ -1002,7 +1010,7 @@ mod ec_double_tests {
 
         let executor = get_ec_double_executor::<{ ECC_BLOCKS_32 }>(
             config.clone(),
-            tester.range_checker().bus(),
+            tester.range_checker().bus().range_max_bits,
             tester.address_bits(),
             Rv64WeierstrassOpcode::CLASS_OFFSET,
             a.clone(),
@@ -1020,9 +1028,9 @@ mod ec_double_tests {
         )
         .unwrap();
 
-        assert_eq!(executor.expr.builder.num_variables, 3); // lambda, x3, y3
+        assert_eq!(executor.program().num_vars(), 3); // lambda, x3, y3
 
-        let r = executor.expr.execute(&[p1_x, p1_y], &[true]);
+        let r = executor.program().execute(&[p1_x, p1_y], &[true]);
         assert_eq!(r.len(), 3); // lambda, x3, y3
         let expected_double_x = BigUint::from_str_radix(
             "7CF27B188D034F7E8A52380304B51AC3C08969E277F21B35A60B48FC47669978",

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -8,9 +8,9 @@ use std::ffi::c_void;
 
 use halo2curves_axiom::ff::Field;
 use num_bigint::BigUint;
-use openvm_circuit_primitives::var_range::VariableRangeCheckerBus;
-use openvm_ecc_circuit::{ec_add_ne_expr, ec_double_ne_expr};
-use openvm_mod_circuit_builder::{run_field_expression_precomputed, ExprBuilderConfig};
+use openvm_circuit_primitives::U16_BITS;
+use openvm_ecc_circuit::{ec_add_ne_builder, ec_double_ne_builder};
+use openvm_mod_circuit_builder::{run_expr_builder_precomputed, ExprBuilderConfig};
 use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{
     read_field_256, write_field_256, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
@@ -131,25 +131,14 @@ fn ecc_setup_expr(point_bytes: u32, setup_bytes: &[u8], is_double: bool) -> Vec<
         num_limbs: coord_bytes,
         limb_bits: 8,
     };
-    let expr = if is_double {
+    let builder = if is_double {
         let a_biguint = BigUint::from_bytes_le(&setup_bytes[coord_bytes..point_bytes as usize]);
-        ec_double_ne_expr(
-            config,
-            // TODO: use a real range bus here, or remove the requirement entirely;
-            // OpenVM currently uses the same dummy bus.
-            VariableRangeCheckerBus::new(u16::MAX, 16),
-            a_biguint,
-        )
+        ec_double_ne_builder(config, U16_BITS, a_biguint)
     } else {
-        ec_add_ne_expr(
-            config,
-            // TODO: use a real range bus here, or remove the requirement entirely;
-            // OpenVM currently uses the same dummy bus.
-            VariableRangeCheckerBus::new(u16::MAX, 16),
-        )
+        ec_add_ne_builder(config, U16_BITS)
     };
-    let flag_idx = expr.num_flags();
-    let writes = run_field_expression_precomputed::<true>(&expr, flag_idx, setup_bytes);
+    let flag_idx = builder.num_flags;
+    let writes = run_expr_builder_precomputed::<true>(&builder, flag_idx, setup_bytes);
     writes.into()
 }
 

--- a/extensions/ecc/rvr/ffi/src/lib.rs
+++ b/extensions/ecc/rvr/ffi/src/lib.rs
@@ -9,8 +9,8 @@ use std::ffi::c_void;
 use halo2curves_axiom::ff::Field;
 use num_bigint::BigUint;
 use openvm_circuit_primitives::U16_BITS;
-use openvm_ecc_circuit::{ec_add_ne_builder, ec_double_ne_builder};
-use openvm_mod_circuit_builder::{run_expr_builder_precomputed, ExprBuilderConfig};
+use openvm_ecc_circuit::{ec_add_ne_program, ec_double_ne_program};
+use openvm_mod_circuit_builder::{run_field_expression_precomputed, ExprBuilderConfig};
 use openvm_platform::WORD_SIZE;
 use rvr_openvm_ext_algebra_ffi_common::{
     read_field_256, write_field_256, BLS12_381_ELEM_BYTES, FIELD_256_BYTES,
@@ -131,14 +131,14 @@ fn ecc_setup_expr(point_bytes: u32, setup_bytes: &[u8], is_double: bool) -> Vec<
         num_limbs: coord_bytes,
         limb_bits: 8,
     };
-    let builder = if is_double {
+    let program = if is_double {
         let a_biguint = BigUint::from_bytes_le(&setup_bytes[coord_bytes..point_bytes as usize]);
-        ec_double_ne_builder(config, U16_BITS, a_biguint)
+        ec_double_ne_program(config, U16_BITS, a_biguint)
     } else {
-        ec_add_ne_builder(config, U16_BITS)
+        ec_add_ne_program(config, U16_BITS)
     };
-    let flag_idx = builder.num_flags;
-    let writes = run_expr_builder_precomputed::<true>(&builder, flag_idx, setup_bytes);
+    let flag_idx = program.num_flags();
+    let writes = run_field_expression_precomputed::<true>(&program, flag_idx, setup_bytes);
     writes.into()
 }
 

--- a/extensions/pairing/circuit/src/fp12.rs
+++ b/extensions/pairing/circuit/src/fp12.rs
@@ -250,7 +250,8 @@ mod tests {
         let indices = r.save();
 
         let builder = builder.borrow().clone();
-        let air = FieldExpr::new(builder, range_checker.bus(), false);
+        let program = FieldExpressionProgram::new(builder, false);
+        let air = FieldExpr::new(program, range_checker.bus());
         let width = BaseAir::<BabyBear>::width(&air);
 
         let x_fq12 = x;


### PR DESCRIPTION
- store finalized field expression programs directly in executors
- keep range buses and carry checks in the air-only wrapper
- remove fake range buses from interpreter, preflight, hybrid, and rvr execution

Resolves INT-8194