### PR TITLE
perf(v2.1): move input payload into zero-copy hint stream

### DIFF
--- a/crates/vm/src/arch/hint_stream.rs
+++ b/crates/vm/src/arch/hint_stream.rs
@@ -1,0 +1,186 @@
+use openvm_platform::WORD_SIZE;
+
+/// The byte stream read by guest hint-store instructions.
+///
+/// ```text
+/// Input record: [8-byte little-endian payload length | payload | zero padding]
+/// Hint:         [hint bytes]
+/// ```
+///
+/// The payload is padded with zeros to a multiple of 8 bytes.
+#[derive(Clone, Default)]
+pub struct HintStream {
+    /// The current input payload or hint.
+    bytes: Vec<u8>,
+    /// Offset of the next unread byte in the stream exposed to the guest.
+    position: usize,
+    /// Whether `bytes` contains an input payload rather than a hint.
+    is_input: bool,
+}
+
+impl HintStream {
+    /// Sets an input payload, taking ownership of its bytes without copying them.
+    #[inline]
+    pub fn set_input(&mut self, bytes: Vec<u8>) {
+        self.bytes = bytes;
+        self.position = 0;
+        self.is_input = true;
+    }
+
+    /// Sets a hint, taking ownership of its bytes without copying them.
+    #[inline]
+    pub fn set_hint(&mut self, bytes: Vec<u8>) {
+        self.bytes = bytes;
+        self.position = 0;
+        self.is_input = false;
+    }
+
+    /// Copies hint bytes from a slice, reusing existing capacity when possible.
+    #[inline]
+    pub fn set_hint_from_slice(&mut self, bytes: &[u8]) {
+        self.clear();
+        self.bytes.extend_from_slice(bytes);
+    }
+
+    /// Replaces the hint with bytes from an iterator, reusing existing capacity when possible.
+    #[inline]
+    pub fn set_hint_from_iter(&mut self, bytes: impl IntoIterator<Item = u8>) {
+        self.clear();
+        self.bytes.extend(bytes);
+    }
+
+    /// Removes all bytes and resets the stream.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.bytes.clear();
+        self.position = 0;
+        self.is_input = false;
+    }
+
+    /// Returns the number of unread bytes.
+    ///
+    /// For input records, this includes the payload-length prefix and padding.
+    #[inline]
+    pub fn remaining(&self) -> usize {
+        let stream_len = if self.is_input {
+            // Input reads begin with the payload length and end on a word boundary.
+            WORD_SIZE + self.bytes.len().next_multiple_of(WORD_SIZE)
+        } else {
+            self.bytes.len()
+        };
+        stream_len.saturating_sub(self.position)
+    }
+
+    /// Copies exactly `dst.len()` bytes into `dst` and advances the stream.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the stream contains fewer than `dst.len()` bytes.
+    #[inline]
+    pub fn copy_to_slice(&mut self, dst: &mut [u8]) {
+        assert!(self.remaining() >= dst.len());
+
+        let end_position = self.position + dst.len();
+        if !self.is_input {
+            dst.copy_from_slice(&self.bytes[self.position..end_position]);
+            self.position = end_position;
+            return;
+        }
+
+        let mut position = self.position;
+        let mut dst = dst;
+
+        // Copy any unread bytes from the payload-length prefix.
+        if position < WORD_SIZE {
+            let payload_length = (self.bytes.len() as u64).to_le_bytes();
+            let count = (WORD_SIZE - position).min(dst.len());
+            dst[..count].copy_from_slice(&payload_length[position..position + count]);
+            position += count;
+            dst = &mut dst[count..];
+        }
+
+        // Input positions include the length prefix before the payload.
+        let input_payload_end = WORD_SIZE + self.bytes.len();
+        if !dst.is_empty() && position < input_payload_end {
+            let payload_offset = position - WORD_SIZE;
+            let count = (input_payload_end - position).min(dst.len());
+            dst[..count].copy_from_slice(&self.bytes[payload_offset..payload_offset + count]);
+            dst = &mut dst[count..];
+        }
+
+        // After the prefix and payload, any requested bytes are zero padding.
+        dst.fill(0);
+        self.position = end_position;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HintStream;
+
+    fn expected_input_bytes(payload: &[u8]) -> Vec<u8> {
+        let mut expected = Vec::with_capacity(8 + payload.len().next_multiple_of(8));
+        expected.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        expected.extend_from_slice(payload);
+        expected.resize(expected.len().next_multiple_of(8), 0);
+        expected
+    }
+
+    #[test]
+    fn input_is_not_copied_and_includes_length_and_padding() {
+        for length in [0, 1, 7, 8, 9, 8_191, 8_192] {
+            let payload = (0..length).map(|i| (i % 251) as u8).collect::<Vec<_>>();
+            let payload_ptr = payload.as_ptr();
+            let expected = expected_input_bytes(&payload);
+            let mut stream = HintStream::default();
+
+            stream.set_input(payload);
+
+            assert_eq!(stream.bytes.as_ptr(), payload_ptr);
+            let mut actual = Vec::with_capacity(expected.len());
+            for chunk_size in [1, 3, 8, 13].into_iter().cycle() {
+                if actual.len() == expected.len() {
+                    break;
+                }
+                let count = chunk_size.min(expected.len() - actual.len());
+                let mut chunk = vec![0xa5; count];
+                stream.copy_to_slice(&mut chunk);
+                actual.extend(chunk);
+            }
+            assert_eq!(actual, expected);
+            assert_eq!(stream.remaining(), 0);
+        }
+    }
+
+    #[test]
+    fn setting_a_hint_discards_the_partially_read_input() {
+        let mut stream = HintStream::default();
+        stream.set_input(vec![1, 2, 3]);
+        stream.copy_to_slice(&mut [0; 5]);
+
+        stream.set_hint(vec![9, 8, 7]);
+
+        let mut actual = [0; 3];
+        stream.copy_to_slice(&mut actual);
+        assert_eq!(actual, [9, 8, 7]);
+        assert_eq!(stream.remaining(), 0);
+    }
+
+    #[test]
+    fn cloned_streams_advance_independently() {
+        let payload = (1u8..=9).collect::<Vec<_>>();
+        let expected = expected_input_bytes(&payload);
+        let mut original = HintStream::default();
+        original.set_input(payload);
+        original.copy_to_slice(&mut [0; 10]);
+
+        let mut cloned = original.clone();
+        let mut original_suffix = vec![0; original.remaining()];
+        original.copy_to_slice(&mut original_suffix);
+        let mut cloned_chunk = [0; 3];
+        cloned.copy_to_slice(&mut cloned_chunk);
+
+        assert_eq!(original_suffix, expected[10..]);
+        assert_eq!(cloned_chunk, expected[10..13]);
+    }
+}

--- a/crates/vm/src/arch/mod.rs
+++ b/crates/vm/src/arch/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod execution_metrics;
 /// Execution context types for different execution modes.
 pub mod execution_mode;
 mod extensions;
+mod hint_stream;
 /// Traits and wrappers to facilitate VM chip integration
 mod integration_api;
 /// [RecordArena] trait definitions and implementations. Currently there are two concrete
@@ -34,6 +35,7 @@ pub use config::*;
 pub use execution::*;
 pub use execution_mode::{ExecutionCtxTrait, MeteredExecutionCtxTrait};
 pub use extensions::*;
+pub use hint_stream::HintStream;
 pub use integration_api::*;
 pub use interpreter::InterpretedInstance;
 pub use openvm_circuit_derive::create_handler;

--- a/crates/vm/src/arch/rvr/io.rs
+++ b/crates/vm/src/arch/rvr/io.rs
@@ -6,7 +6,7 @@ use std::{collections::VecDeque, ffi::c_void};
 use openvm_platform::memory::MEM_SIZE;
 use rand::rngs::StdRng;
 
-use crate::arch::deferral::DeferralState;
+use crate::arch::{deferral::DeferralState, HintStream};
 
 /// IO execution state borrowed from the host `VmState` for the duration of
 /// one rvr call. Streams, rng, and the public-values byte slice are mutable
@@ -14,7 +14,7 @@ use crate::arch::deferral::DeferralState;
 /// (raw because the C engine accesses it directly via pointer).
 pub struct OpenVmIoState<'a> {
     pub input_stream: &'a mut VecDeque<Vec<u8>>,
-    pub hint_stream: &'a mut VecDeque<u8>,
+    pub hint_stream: &'a mut HintStream,
     pub rng: &'a mut StdRng,
     pub memory_ptr: *mut u8,
     pub public_values: &'a mut [u8],
@@ -49,9 +49,10 @@ pub fn check_mem_bounds_range(_start: u64, _num_bytes: usize) {}
 /// `ctx` must be a valid `OpenVmIoState` pointer. `data` must point to `len` bytes (or be null).
 pub unsafe extern "C" fn host_hint_stream_set(ctx: *mut c_void, data: *const u8, len: u32) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
-    io.hint_stream.clear();
     if len > 0 && !data.is_null() {
         let slice = unsafe { std::slice::from_raw_parts(data, len as usize) };
-        io.hint_stream.extend(slice);
+        io.hint_stream.set_hint_from_slice(slice);
+    } else {
+        io.hint_stream.clear();
     }
 }

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -53,6 +53,7 @@ use super::{
         SegmentationLimits,
     },
     hasher::poseidon2::vm_poseidon2_hasher,
+    hint_stream::HintStream,
     interpreter::InterpretedInstance,
     interpreter_preflight::PreflightInterpretedInstance,
     AirInventoryError, ChipInventoryError, ExecutionError, ExecutionState, Executor,
@@ -116,7 +117,7 @@ pub enum GenerationError {
 #[derive(Clone, Default)]
 pub struct Streams {
     pub input_stream: VecDeque<Vec<u8>>,
-    pub hint_stream: VecDeque<u8>,
+    pub hint_stream: HintStream,
     /// Cached deferred operation inputs and outputs. Each idx corresponds to a
     /// unique function that is constrained outside the VM in its own deferral circuit.
     pub deferrals: Vec<DeferralState>,
@@ -126,7 +127,7 @@ impl Streams {
     pub fn new(input_stream: impl Into<VecDeque<Vec<u8>>>) -> Self {
         Self {
             input_stream: input_stream.into(),
-            hint_stream: VecDeque::default(),
+            hint_stream: HintStream::default(),
             deferrals: Vec::default(),
         }
     }

--- a/extensions/algebra/circuit/src/extension/modular.rs
+++ b/extensions/algebra/circuit/src/extension/modular.rs
@@ -559,7 +559,7 @@ pub(crate) mod phantom {
                         .take(num_limbs),
                 )
                 .collect();
-            streams.hint_stream = hint_bytes;
+            streams.hint_stream.set_hint(hint_bytes);
             Ok(())
         }
     }
@@ -623,7 +623,7 @@ pub(crate) mod phantom {
                 .chain(repeat(0u8))
                 .take(num_limbs)
                 .collect();
-            streams.hint_stream = hint_bytes;
+            streams.hint_stream.set_hint(hint_bytes);
             Ok(())
         }
     }

--- a/extensions/pairing/circuit/src/pairing_extension.rs
+++ b/extensions/pairing/circuit/src/pairing_extension.rs
@@ -118,12 +118,10 @@ where
 }
 
 pub(crate) mod phantom {
-    use std::collections::VecDeque;
-
     use eyre::bail;
     use halo2curves_axiom::ff;
     use openvm_circuit::{
-        arch::{PhantomSubExecutor, Streams},
+        arch::{HintStream, PhantomSubExecutor, Streams},
         system::memory::online::GuestMemory,
     };
     use openvm_ecc_guest::{algebra::field::FieldExtension, AffinePoint};
@@ -162,7 +160,7 @@ pub(crate) mod phantom {
 
     fn hint_pairing(
         memory: &GuestMemory,
-        hint_stream: &mut VecDeque<u8>,
+        hint_stream: &mut HintStream,
         rs1: u32,
         rs2: u32,
         c_upper: u16,
@@ -216,13 +214,13 @@ pub(crate) mod phantom {
 
                 let f: Fq12 = Bn254::multi_miller_loop(&p, &q);
                 let (c, u) = Bn254::final_exp_hint(&f);
-                hint_stream.clear();
-                hint_stream.extend(
+                hint_stream.set_hint(
                     c.to_coeffs()
                         .into_iter()
                         .chain(u.to_coeffs())
                         .flat_map(|fp2| fp2.to_coeffs())
-                        .flat_map(|fp| fp.to_bytes()),
+                        .flat_map(|fp| fp.to_bytes())
+                        .collect(),
                 );
             }
             Some(PairingCurve::Bls12_381) => {
@@ -257,13 +255,13 @@ pub(crate) mod phantom {
 
                 let f: Fq12 = Bls12_381::multi_miller_loop(&p, &q);
                 let (c, u) = Bls12_381::final_exp_hint(&f);
-                hint_stream.clear();
-                hint_stream.extend(
+                hint_stream.set_hint(
                     c.to_coeffs()
                         .into_iter()
                         .chain(u.to_coeffs())
                         .flat_map(|fp2| fp2.to_coeffs())
-                        .flat_map(|fp| fp.to_bytes()),
+                        .flat_map(|fp| fp.to_bytes())
+                        .collect(),
                 );
             }
             _ => {

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -1230,6 +1230,8 @@ where
 
 /// Phantom sub-executors
 mod phantom {
+    use std::{iter::repeat_with, sync::Once};
+
     use eyre::bail;
     use openvm_circuit::{
         arch::{PhantomSubExecutor, Streams},
@@ -1257,19 +1259,13 @@ mod phantom {
             _: u32,
             _: u16,
         ) -> eyre::Result<()> {
-            let mut hint = match streams.input_stream.pop_front() {
-                Some(hint) => hint,
+            let input = match streams.input_stream.pop_front() {
+                Some(input) => input,
                 None => {
                     bail!("EndOfInputStream");
                 }
             };
-            streams.hint_stream.clear();
-            let hint_len = hint.len() as u64;
-            streams.hint_stream.extend(hint_len.to_le_bytes());
-            // Pad the hint payload to full dwords so RV64 `HINT_BUFFER` reads can consume it.
-            let capacity = hint.len().div_ceil(HINT_DWORD_BYTES) * HINT_DWORD_BYTES;
-            hint.resize(capacity, 0u8);
-            streams.hint_stream.extend(hint);
+            streams.hint_stream.set_input(input);
             Ok(())
         }
     }
@@ -1285,16 +1281,15 @@ mod phantom {
             _: u32,
             _: u16,
         ) -> eyre::Result<()> {
-            static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+            static WARN_ONCE: Once = Once::new();
             WARN_ONCE.call_once(|| {
                 eprintln!("WARNING: Using fixed-seed RNG for deterministic randomness. Consider security implications for your use case.");
             });
 
             let byte_len = read_rv64_register_as_u32(memory, a) as usize * HINT_DWORD_BYTES;
-            streams.hint_stream.clear();
             streams
                 .hint_stream
-                .extend(std::iter::repeat_with(|| rng.random::<u8>()).take(byte_len));
+                .set_hint_from_iter(repeat_with(|| rng.random::<u8>()).take(byte_len));
             Ok(())
         }
     }

--- a/extensions/riscv/circuit/src/hintstore/execution.rs
+++ b/extensions/riscv/circuit/src/hintstore/execution.rs
@@ -180,14 +180,15 @@ unsafe fn execute_e12_impl<CTX: ExecutionCtxTrait, const IS_HINT_STORED: bool>(
         });
     }
 
-    if exec_state.streams.hint_stream.len() < RV64_REGISTER_NUM_LIMBS * num_words as usize {
+    let num_bytes = RV64_REGISTER_NUM_LIMBS * num_words as usize;
+    if exec_state.streams.hint_stream.remaining() < num_bytes {
         let err = ExecutionError::HintOutOfBounds { pc };
         return Err(err);
     }
 
     for word_index in 0..num_words {
-        let data: [u8; RV64_REGISTER_NUM_LIMBS] =
-            std::array::from_fn(|_| exec_state.streams.hint_stream.pop_front().unwrap());
+        let mut data = [0; RV64_REGISTER_NUM_LIMBS];
+        exec_state.streams.hint_stream.copy_to_slice(&mut data);
         exec_state.vm_write_bytes(
             RV64_MEMORY_AS,
             mem_ptr + (RV64_REGISTER_NUM_LIMBS as u32 * word_index),

--- a/extensions/riscv/circuit/src/hintstore/mod.rs
+++ b/extensions/riscv/circuit/src/hintstore/mod.rs
@@ -473,7 +473,8 @@ where
             );
         };
 
-        if state.streams.hint_stream.len() < RV64_REGISTER_NUM_LIMBS * num_words as usize {
+        let num_bytes = RV64_REGISTER_NUM_LIMBS * num_words as usize;
+        if state.streams.hint_stream.remaining() < num_bytes {
             return Err(ExecutionError::HintOutOfBounds { pc: *state.pc });
         }
 
@@ -483,8 +484,8 @@ where
                 state.memory.increment_timestamp();
             }
 
-            let data: [u8; RV64_REGISTER_NUM_LIMBS] =
-                std::array::from_fn(|_| state.streams.hint_stream.pop_front().unwrap());
+            let mut data = [0; RV64_REGISTER_NUM_LIMBS];
+            state.streams.hint_stream.copy_to_slice(&mut data);
 
             record.var[idx].data = data;
 

--- a/extensions/riscv/circuit/src/hintstore/tests.rs
+++ b/extensions/riscv/circuit/src/hintstore/tests.rs
@@ -119,13 +119,17 @@ fn set_and_execute<RA: Arena, E: PreflightExecutor<F, RA>>(
         u64_to_rv64_limbs(mem_ptr.into()),
     );
 
-    let mut input = Vec::with_capacity(num_words as usize * RV64_REGISTER_NUM_LIMBS);
+    let num_bytes = num_words as usize * RV64_REGISTER_NUM_LIMBS;
+    let mut input = Vec::with_capacity(num_bytes);
+    let mut hint_bytes = Vec::with_capacity(num_bytes);
     for _ in 0..num_words {
         let bytes = rng.next_u64().to_le_bytes();
         let data = bytes.map(F::from_u8);
         input.extend(data);
-        tester.streams_mut().hint_stream.extend(bytes);
+        hint_bytes.extend(bytes);
     }
+    let streams = tester.streams_mut();
+    streams.hint_stream.set_hint(hint_bytes);
 
     tester.execute(
         executor,
@@ -215,10 +219,11 @@ fn test_hint_buffer_exceeds_max_words() {
         u64_to_rv64_limbs(mem_ptr.into()),
     );
 
-    for _ in 0..num_words {
-        let data = rng.next_u64().to_le_bytes();
-        tester.streams_mut().hint_stream.extend(data);
-    }
+    let hint_bytes = (0..num_words)
+        .flat_map(|_| rng.next_u64().to_le_bytes())
+        .collect();
+    let streams = tester.streams_mut();
+    streams.hint_stream.set_hint(hint_bytes);
 
     tester.execute(
         &mut harness.executor,
@@ -253,10 +258,11 @@ fn test_hint_buffer_rem_words_range_check() {
         u64_to_rv64_limbs(mem_ptr.into()),
     );
 
-    for _ in 0..num_words {
-        let data = rng.next_u64().to_le_bytes();
-        tester.streams_mut().hint_stream.extend(data);
-    }
+    let hint_bytes = (0..num_words)
+        .flat_map(|_| rng.next_u64().to_le_bytes())
+        .collect();
+    let streams = tester.streams_mut();
+    streams.hint_stream.set_hint(hint_bytes);
 
     tester.execute(
         &mut harness.executor,
@@ -310,10 +316,11 @@ fn test_hint_buffer_mem_ptr_range_check() {
         u64_to_rv64_limbs(mem_ptr.into()),
     );
 
-    for _ in 0..num_words {
-        let data = rng.next_u64().to_le_bytes();
-        tester.streams_mut().hint_stream.extend(data);
-    }
+    let hint_bytes = (0..num_words)
+        .flat_map(|_| rng.next_u64().to_le_bytes())
+        .collect();
+    let streams = tester.streams_mut();
+    streams.hint_stream.set_hint(hint_bytes);
 
     tester.execute(
         &mut harness.executor,
@@ -360,7 +367,8 @@ fn test_hintstore_rs1_upper_bytes_non_zero() {
     tester.write_bytes(RV64_REGISTER_AS as usize, b, mem_ptr_limbs);
 
     let data = rng.next_u64().to_le_bytes();
-    tester.streams_mut().hint_stream.extend(data);
+    let streams = tester.streams_mut();
+    streams.hint_stream.set_hint(data.to_vec());
 
     tester.execute(
         &mut harness.executor,

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -5,7 +5,7 @@
 //! extensions.
 #![cfg(feature = "rvr")]
 
-use std::{collections::VecDeque, ffi::c_void, io::Write};
+use std::{ffi::c_void, io::Write, iter::repeat_with};
 
 use openvm_circuit::arch::rvr::io::{check_mem_bounds_range, OpenVmIoState};
 use openvm_instructions::{
@@ -397,19 +397,13 @@ pub struct Rv64IoHostCallbacks {
 
 // ── Callback implementations ────────────────────────────────────────────────
 
-/// HintInput: pop next input record from VmState's input_stream and overwrite
-/// the active hint stream with `[len: u64 LE][data][padding to 8-byte align]`,
-/// stored directly as bytes.
+/// Makes the next input record available without copying its payload.
 pub extern "C" fn host_hint_input(ctx: *mut c_void) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
-    io.hint_stream.clear();
-    if let Some(mut vec) = io.input_stream.pop_front() {
-        let data_len = vec.len();
-        let len_bytes = (data_len as u64).to_le_bytes();
-        io.hint_stream.extend(len_bytes);
-        let padded_len = data_len.div_ceil(RV64_REGISTER_NUM_LIMBS) * RV64_REGISTER_NUM_LIMBS;
-        vec.resize(padded_len, 0u8);
-        io.hint_stream.extend(vec);
+    if let Some(bytes) = io.input_stream.pop_front() {
+        io.hint_stream.set_input(bytes);
+    } else {
+        io.hint_stream.clear();
     }
 }
 
@@ -430,34 +424,15 @@ pub extern "C" fn host_print_str(ctx: *mut c_void, ptr: u64, len: u32) {
 pub extern "C" fn host_hint_random(ctx: *mut c_void, num_words: u32) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     let nbytes = num_words as usize * RV64_REGISTER_NUM_LIMBS;
-    io.hint_stream.clear();
-    for _ in 0..nbytes {
-        io.hint_stream.push_back(io.rng.random::<u8>());
-    }
-}
-
-#[inline]
-fn drain_hint_stream_into(hint_stream: &mut VecDeque<u8>, dst: &mut [u8]) {
-    debug_assert!(hint_stream.len() >= dst.len());
-    let nbytes = dst.len();
-    // A wrapped VecDeque exposes its logical contents as two contiguous chunks.
-    let (front_chunk, wrapped_chunk) = hint_stream.as_slices();
-    if nbytes <= front_chunk.len() {
-        dst.copy_from_slice(&front_chunk[..nbytes]);
-    } else {
-        let (dst_front, dst_wrapped) = dst.split_at_mut(front_chunk.len());
-        dst_front.copy_from_slice(front_chunk);
-        dst_wrapped.copy_from_slice(&wrapped_chunk[..dst_wrapped.len()]);
-    }
-    // Draining a prefix advances the deque after its bytes have been copied.
-    drop(hint_stream.drain(..nbytes));
+    io.hint_stream
+        .set_hint_from_iter(repeat_with(|| io.rng.random::<u8>()).take(nbytes));
 }
 
 /// HINT_STOREW: pop one rv64 register-width word (8 bytes) from the hint stream
 /// and write it to guest memory at `dest_addr`.
 pub extern "C" fn host_hint_storew(ctx: *mut c_void, dest_addr: u64) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
-    if io.hint_stream.len() < RV64_REGISTER_NUM_LIMBS || io.memory_ptr.is_null() {
+    if io.hint_stream.remaining() < RV64_REGISTER_NUM_LIMBS || io.memory_ptr.is_null() {
         return;
     }
     check_mem_bounds_range(dest_addr, RV64_REGISTER_NUM_LIMBS);
@@ -467,7 +442,7 @@ pub extern "C" fn host_hint_storew(ctx: *mut c_void, dest_addr: u64) {
             RV64_REGISTER_NUM_LIMBS,
         )
     };
-    drain_hint_stream_into(io.hint_stream, dst);
+    io.hint_stream.copy_to_slice(dst);
 }
 
 /// HINT_BUFFER: pop `num_words * RV64_REGISTER_NUM_LIMBS` bytes from the hint stream
@@ -475,13 +450,13 @@ pub extern "C" fn host_hint_storew(ctx: *mut c_void, dest_addr: u64) {
 pub extern "C" fn host_hint_buffer(ctx: *mut c_void, dest_addr: u64, num_words: u32) {
     let io = unsafe { &mut *(ctx as *mut OpenVmIoState<'_>) };
     let nbytes = num_words as usize * RV64_REGISTER_NUM_LIMBS;
-    if io.hint_stream.len() < nbytes || io.memory_ptr.is_null() {
+    if io.hint_stream.remaining() < nbytes || io.memory_ptr.is_null() {
         return;
     }
     check_mem_bounds_range(dest_addr, nbytes);
     let dst =
         unsafe { std::slice::from_raw_parts_mut(io.memory_ptr.add(dest_addr as usize), nbytes) };
-    drain_hint_stream_into(io.hint_stream, dst);
+    io.hint_stream.copy_to_slice(dst);
 }
 
 /// Host callback for stores to `PUBLIC_VALUES_AS`.
@@ -501,8 +476,9 @@ pub extern "C" fn host_reveal(ctx: *mut c_void, src_val: u64, ptr: u64, offset: 
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
+    use std::{collections::VecDeque, ptr::null_mut};
 
+    use openvm_circuit::arch::HintStream;
     use openvm_instructions::instruction::Instruction;
     use p3_baby_bear::BabyBear;
     use rand::{rngs::StdRng, SeedableRng};
@@ -672,7 +648,7 @@ mod tests {
     #[test]
     fn host_reveal_writes_public_values_slice() {
         let mut input_stream = VecDeque::new();
-        let mut hint_stream = VecDeque::new();
+        let mut hint_stream = HintStream::default();
         let mut rng = StdRng::seed_from_u64(0);
         let mut memory = vec![0u8; 16];
         let mut public_values = vec![0u8; 16];
@@ -684,7 +660,7 @@ mod tests {
             rng: &mut rng,
             memory_ptr: memory.as_mut_ptr(),
             public_values: &mut public_values,
-            deferral_memory: std::ptr::null_mut(),
+            deferral_memory: null_mut(),
             deferral_memory_len_bytes: 0,
             deferrals: &mut deferrals,
         };
@@ -703,7 +679,7 @@ mod tests {
     #[test]
     fn host_reveal_honors_store_width() {
         let mut input_stream = VecDeque::new();
-        let mut hint_stream = VecDeque::new();
+        let mut hint_stream = HintStream::default();
         let mut rng = StdRng::seed_from_u64(0);
         let mut memory = vec![0u8; 16];
         let mut public_values = vec![0u8; 16];
@@ -715,7 +691,7 @@ mod tests {
             rng: &mut rng,
             memory_ptr: memory.as_mut_ptr(),
             public_values: &mut public_values,
-            deferral_memory: std::ptr::null_mut(),
+            deferral_memory: null_mut(),
             deferral_memory_len_bytes: 0,
             deferrals: &mut deferrals,
         };
@@ -752,14 +728,10 @@ mod tests {
     }
 
     #[test]
-    fn host_hint_buffer_bulk_copies_wrapped_stream() {
+    fn host_hint_buffer_copies_to_guest_memory() {
         let mut input_stream = VecDeque::new();
-        let mut hint_stream = VecDeque::with_capacity(16);
-        hint_stream.extend(0u8..14);
-        hint_stream.drain(..10);
-        hint_stream.extend(14u8..22);
-        let (first, second) = hint_stream.as_slices();
-        assert!(first.len() < RV64_REGISTER_NUM_LIMBS && !second.is_empty());
+        let mut hint_stream = HintStream::default();
+        hint_stream.set_hint((10u8..22).collect());
 
         let mut rng = StdRng::seed_from_u64(0);
         let mut memory = vec![0u8; 16];
@@ -771,7 +743,7 @@ mod tests {
             rng: &mut rng,
             memory_ptr: memory.as_mut_ptr(),
             public_values: &mut public_values,
-            deferral_memory: std::ptr::null_mut(),
+            deferral_memory: null_mut(),
             deferral_memory_len_bytes: 0,
             deferrals: &mut deferrals,
         };
@@ -779,9 +751,38 @@ mod tests {
         host_hint_buffer(&mut io as *mut OpenVmIoState<'_> as *mut c_void, 3, 1);
 
         assert_eq!(&memory[3..11], &(10u8..18).collect::<Vec<_>>());
-        assert_eq!(
-            io.hint_stream.iter().copied().collect::<Vec<_>>(),
-            (18u8..22).collect::<Vec<_>>()
-        );
+        assert_eq!(io.hint_stream.remaining(), 4);
+    }
+
+    #[test]
+    fn host_input_callbacks_expose_length_payload_and_padding() {
+        let payload = (1u8..=9).collect::<Vec<_>>();
+        let mut input_stream = VecDeque::from([payload.clone()]);
+        let mut hint_stream = HintStream::default();
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut memory = vec![0xa5; 24];
+        let mut public_values = vec![];
+        let mut deferrals = Vec::new();
+        let mut io = OpenVmIoState {
+            input_stream: &mut input_stream,
+            hint_stream: &mut hint_stream,
+            rng: &mut rng,
+            memory_ptr: memory.as_mut_ptr(),
+            public_values: &mut public_values,
+            deferral_memory: null_mut(),
+            deferral_memory_len_bytes: 0,
+            deferrals: &mut deferrals,
+        };
+        let ctx = &mut io as *mut OpenVmIoState<'_> as *mut c_void;
+
+        host_hint_input(ctx);
+        host_hint_storew(ctx, 0);
+        host_hint_buffer(ctx, 8, 2);
+
+        assert_eq!(&memory[..8], &(payload.len() as u64).to_le_bytes());
+        assert_eq!(&memory[8..17], payload);
+        assert_eq!(&memory[17..], &[0; 7]);
+        assert_eq!(io.hint_stream.remaining(), 0);
+        assert!(io.input_stream.is_empty());
     }
 }


### PR DESCRIPTION
- `hint_input` used to copy the whole input into another buffer before the guest could read it. This added an expensive `memcpy` for large Reth inputs.
- It now moves the input `Vec` into `HintStream`. The length prefix and zero padding are added as the guest reads the input.
- The interpreter and RVR use the same `HintStream`. Other hints are still returned unchanged.

[Benchmark comparison](https://github.com/openvm-org/rvr-openvm/actions/runs/29757990761)

Resolves INT-8835