### PR TITLE
perf(v2.1): cache SP-relative pages separately in rvr

### DIFF
--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -74,8 +74,22 @@ pub trait ExtEmitCtx {
     /// Read guest memory and return a C expression for the loaded value.
     fn read_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String;
 
+    /// Read guest memory through the SP-relative metering cache.
+    ///
+    /// Contexts without a specialized cache can use the regular memory path.
+    fn read_sp_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String {
+        self.read_mem(base, offset, width, signed)
+    }
+
     /// Write guest memory.
     fn write_mem(&mut self, base: &str, offset: i16, val: &str, width: u8);
+
+    /// Write guest memory through the SP-relative metering cache.
+    ///
+    /// Contexts without a specialized cache can use the regular memory path.
+    fn write_sp_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
+        self.write_mem(base, offset, val, width)
+    }
 
     /// Write one naturally aligned eight-byte main-memory block.
     ///

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -49,12 +49,22 @@ typedef struct PageTouch {
   uint64_t leaf_mask;
 } PageTouch;
 
+/* Direct SP-relative accesses use a separate pending page so alternating
+ * access patterns do not repeatedly evict the default pending page. */
+typedef enum TraceMemoryCache {
+  TRACE_MEMORY_CACHE_DEFAULT,
+  TRACE_MEMORY_CACHE_SP_RELATIVE,
+  TRACE_MEMORY_CACHE_COUNT,
+} TraceMemoryCache;
+
 /* One page buffer per address space stores local page ids and leaf masks.
  * AS_REGISTER pages are handled entirely on the Rust side at init. */
 typedef struct TraceMemory {
-  uint32_t last_mem_page;
+  uint32_t last_page[TRACE_MEMORY_CACHE_COUNT];
   uint32_t mem_page_buf_len;
-  uint64_t last_mem_leaf_mask;
+  /* Align last_leaf_mask and make the padding explicit. */
+  uint32_t _padding;
+  uint64_t last_leaf_mask[TRACE_MEMORY_CACHE_COUNT];
   PageTouch* mem_page_buf;
 } TraceMemory;
 
@@ -244,77 +254,94 @@ static __attribute__((always_inline)) inline void record_page_range(
 static __attribute__((always_inline)) inline TraceMemory trace_memory_setup(
     MeteringState* restrict metering) {
   TraceMemory memory = {
-      .last_mem_page = NO_LAST_PAGE,
+      .last_page = {NO_LAST_PAGE, NO_LAST_PAGE},
       .mem_page_buf_len = metering->mem_page_buf_len,
-      .last_mem_leaf_mask = 0,
+      ._padding = 0,
+      .last_leaf_mask = {0, 0},
       .mem_page_buf = metering->mem_page_buf,
   };
   return memory;
 }
 
-static __attribute__((always_inline)) inline void trace_memory_drain(
-    TraceMemory* restrict memory) {
-  if (memory->last_mem_page == NO_LAST_PAGE ||
-      memory->last_mem_leaf_mask == 0) {
-    memory->last_mem_page = NO_LAST_PAGE;
-    memory->last_mem_leaf_mask = 0;
+static __attribute__((always_inline)) inline void trace_memory_drain_impl(
+    TraceMemory* restrict memory, TraceMemoryCache cache) {
+  if (memory->last_page[cache] == NO_LAST_PAGE ||
+      memory->last_leaf_mask[cache] == 0) {
+    memory->last_page[cache] = NO_LAST_PAGE;
+    memory->last_leaf_mask[cache] = 0;
     return;
   }
   append_page_touch(memory->mem_page_buf, &memory->mem_page_buf_len,
-                    memory->last_mem_page, memory->last_mem_leaf_mask);
-  memory->last_mem_page = NO_LAST_PAGE;
-  memory->last_mem_leaf_mask = 0;
+                    memory->last_page[cache], memory->last_leaf_mask[cache]);
+  memory->last_page[cache] = NO_LAST_PAGE;
+  memory->last_leaf_mask[cache] = 0;
 }
 
 static __attribute__((always_inline)) inline void trace_memory_flush(
     MeteringState* restrict metering, TraceMemory* restrict memory) {
-  trace_memory_drain(memory);
-  metering->last_mem_page = memory->last_mem_page;
+  trace_memory_drain_impl(memory, TRACE_MEMORY_CACHE_DEFAULT);
+  trace_memory_drain_impl(memory, TRACE_MEMORY_CACHE_SP_RELATIVE);
+  metering->last_mem_page = NO_LAST_PAGE;
   metering->mem_page_buf_len = memory->mem_page_buf_len;
 }
 
 static __attribute__((always_inline)) inline void trace_memory_reload(
     MeteringState* restrict metering, TraceMemory* restrict memory) {
-  memory->last_mem_page = NO_LAST_PAGE;
+  memory->last_page[TRACE_MEMORY_CACHE_DEFAULT] = NO_LAST_PAGE;
+  memory->last_page[TRACE_MEMORY_CACHE_SP_RELATIVE] = NO_LAST_PAGE;
   memory->mem_page_buf_len = metering->mem_page_buf_len;
-  memory->last_mem_leaf_mask = 0;
+  memory->last_leaf_mask[TRACE_MEMORY_CACHE_DEFAULT] = 0;
+  memory->last_leaf_mask[TRACE_MEMORY_CACHE_SP_RELATIVE] = 0;
   memory->mem_page_buf = metering->mem_page_buf;
 }
 
-static __attribute__((always_inline)) inline void trace_memory_access_page(
-    TraceMemory* restrict memory, uint32_t page, uint64_t leaf_mask) {
+static __attribute__((always_inline)) inline void trace_memory_access_page_impl(
+    TraceMemory* restrict memory, TraceMemoryCache cache, uint32_t page,
+    uint64_t leaf_mask) {
   /* Keep one pending AS_MEMORY page in registers for the current generated
    * block. Consecutive accesses to that page merge by OR-ing leaf masks. */
-  if (likely(page == memory->last_mem_page)) {
-    memory->last_mem_leaf_mask |= leaf_mask;
+  if (likely(page == memory->last_page[cache])) {
+    memory->last_leaf_mask[cache] |= leaf_mask;
     return;
   }
-  trace_memory_drain(memory);
-  memory->last_mem_page = page;
-  memory->last_mem_leaf_mask = leaf_mask;
+  trace_memory_drain_impl(memory, cache);
+  memory->last_page[cache] = page;
+  memory->last_leaf_mask[cache] = leaf_mask;
+}
+
+static __attribute__((always_inline)) inline void trace_memory_access_leaf_impl(
+    TraceMemory* restrict memory, TraceMemoryCache cache, uint64_t addr) {
+  uint32_t leaf = byte_addr_to_local_leaf(addr);
+  trace_memory_access_page_impl(memory, cache, leaf >> TRACER_PAGE_BITS,
+                                leaf_mask(leaf));
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access_leaf(
     TraceMemory* restrict memory, uint64_t addr) {
-  uint32_t leaf = byte_addr_to_local_leaf(addr);
-  trace_memory_access_page(memory, leaf >> TRACER_PAGE_BITS, leaf_mask(leaf));
+  trace_memory_access_leaf_impl(memory, TRACE_MEMORY_CACHE_DEFAULT, addr);
+}
+
+static __attribute__((always_inline)) inline void trace_sp_memory_access_leaf(
+    TraceMemory* restrict memory, uint64_t addr) {
+  trace_memory_access_leaf_impl(memory, TRACE_MEMORY_CACHE_SP_RELATIVE, addr);
 }
 
 /* Record every memory leaf overlapped by [addr, addr + size). Generated
  * accesses are no wider than one leaf, so at most two leaves are touched. */
-static __attribute__((always_inline)) inline void trace_memory_access_span(
-    TraceMemory* restrict memory, uint64_t addr, uint32_t size) {
+static __attribute__((always_inline)) inline void trace_memory_access_span_impl(
+    TraceMemory* restrict memory, TraceMemoryCache cache, uint64_t addr,
+    uint32_t size) {
   assume(size != 0u && size <= TRACER_BYTES_PER_LEAF);
   assume((size & (size - 1u)) == 0u);
   if (likely((addr & (size - 1u)) == 0u)) {
-    trace_memory_access_leaf(memory, addr);
+    trace_memory_access_leaf_impl(memory, cache, addr);
     return;
   }
 
   uint32_t leaf_offset = addr & TRACER_LEAF_BYTE_OFFSET_MASK;
   uint32_t bytes_until_next_leaf = TRACER_BYTES_PER_LEAF - leaf_offset;
   if (likely(size <= bytes_until_next_leaf)) {
-    trace_memory_access_leaf(memory, addr);
+    trace_memory_access_leaf_impl(memory, cache, addr);
     return;
   }
 
@@ -325,11 +352,23 @@ static __attribute__((always_inline)) inline void trace_memory_access_span(
   uint64_t first_mask = leaf_mask(first_leaf);
   uint64_t last_mask = leaf_mask(last_leaf);
   if (likely(first_page == last_page)) {
-    trace_memory_access_page(memory, first_page, first_mask | last_mask);
+    trace_memory_access_page_impl(memory, cache, first_page,
+                                  first_mask | last_mask);
   } else {
-    trace_memory_access_page(memory, first_page, first_mask);
-    trace_memory_access_page(memory, last_page, last_mask);
+    trace_memory_access_page_impl(memory, cache, first_page, first_mask);
+    trace_memory_access_page_impl(memory, cache, last_page, last_mask);
   }
+}
+
+static __attribute__((always_inline)) inline void trace_memory_access_span(
+    TraceMemory* restrict memory, uint64_t addr, uint32_t size) {
+  trace_memory_access_span_impl(memory, TRACE_MEMORY_CACHE_DEFAULT, addr, size);
+}
+
+static __attribute__((always_inline)) inline void trace_sp_memory_access_span(
+    TraceMemory* restrict memory, uint64_t addr, uint32_t size) {
+  trace_memory_access_span_impl(memory, TRACE_MEMORY_CACHE_SP_RELATIVE, addr,
+                                size);
 }
 
 /* Extension range access includes page accounting in metered mode. */

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -405,7 +405,14 @@ impl<'a> EmitContext<'a> {
     fn emit_memory_bounds_trap(&mut self, _addr: &str, _width: u8) {}
 
     /// Read guest memory. Metered hot blocks record the memory page separately.
-    pub fn read_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String {
+    fn read_mem_impl(
+        &mut self,
+        base: &str,
+        offset: i16,
+        width: u8,
+        signed: bool,
+        sp_relative: bool,
+    ) -> String {
         assert!(
             !self.mode.is_metered_without_memory_pages(),
             "metered memory read emitted without page tracking"
@@ -419,15 +426,23 @@ impl<'a> EmitContext<'a> {
         self.write_line(&format!("{var_ty} {var} = {read_func}(memory, {addr});"));
         self.count_fixed_timestamp_slots(if width == 1 { 1 } else { 2 });
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width);
+            self.emit_inline_page_record(&addr, width, sp_relative);
         }
         var
+    }
+
+    pub fn read_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String {
+        self.read_mem_impl(base, offset, width, signed, false)
+    }
+
+    pub fn read_sp_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String {
+        self.read_mem_impl(base, offset, width, signed, true)
     }
 
     /// Emit a guest memory write. Metered hot blocks record the memory page
     /// through the block-local `TraceMemory` context, then use the raw memory
     /// helper so the common path avoids tracing calls.
-    pub fn write_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
+    fn write_mem_impl(&mut self, base: &str, offset: i16, val: &str, width: u8, sp_relative: bool) {
         assert!(
             !self.mode.is_metered_without_memory_pages(),
             "metered memory write emitted without page tracking"
@@ -438,7 +453,7 @@ impl<'a> EmitContext<'a> {
 
         self.emit_memory_bounds_trap(&addr, width);
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width);
+            self.emit_inline_page_record(&addr, width, sp_relative);
         }
         self.count_fixed_timestamp_slots(if width == 1 { 1 } else { 2 });
         self.write_line(&format!(
@@ -451,6 +466,14 @@ impl<'a> EmitContext<'a> {
         }
     }
 
+    pub fn write_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
+        self.write_mem_impl(base, offset, val, width, false)
+    }
+
+    pub fn write_sp_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
+        self.write_mem_impl(base, offset, val, width, true)
+    }
+
     /// Emit one naturally aligned main-memory block write.
     pub fn write_aligned_mem_block(&mut self, addr: &str, val: &str) {
         assert!(
@@ -461,7 +484,7 @@ impl<'a> EmitContext<'a> {
 
         self.emit_memory_bounds_trap(addr, MEMORY_BLOCK_BYTES as u8);
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(addr, MEMORY_BLOCK_BYTES as u8);
+            self.emit_inline_page_record(addr, MEMORY_BLOCK_BYTES as u8, false);
         }
         self.count_fixed_timestamp_slots(1);
         self.write_line(&format!(
@@ -617,12 +640,17 @@ impl<'a> EmitContext<'a> {
         self.write_line("}");
     }
 
-    fn emit_inline_page_record(&mut self, addr: &str, width: u8) {
+    fn emit_inline_page_record(&mut self, addr: &str, width: u8, sp_relative: bool) {
+        let prefix = if sp_relative {
+            "trace_sp_memory"
+        } else {
+            "trace_memory"
+        };
         if width == 1 {
-            self.write_line(&format!("trace_memory_access_leaf(&trace_memory, {addr});"));
+            self.write_line(&format!("{prefix}_access_leaf(&trace_memory, {addr});"));
         } else {
             self.write_line(&format!(
-                "trace_memory_access_span(&trace_memory, {addr}, {width}u);"
+                "{prefix}_access_span(&trace_memory, {addr}, {width}u);"
             ));
         }
     }
@@ -866,8 +894,16 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
         EmitContext::read_mem(self, base, offset, width, signed)
     }
 
+    fn read_sp_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String {
+        EmitContext::read_sp_mem(self, base, offset, width, signed)
+    }
+
     fn write_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
         EmitContext::write_mem(self, base, offset, val, width);
+    }
+
+    fn write_sp_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
+        EmitContext::write_sp_mem(self, base, offset, val, width);
     }
 
     fn write_aligned_mem_block(&mut self, addr: &str, val: &str) {
@@ -1298,5 +1334,21 @@ mod tests {
         assert!(ctx
             .buf()
             .contains("trace_memory_access_span(&trace_memory, addr, 8u);"));
+    }
+
+    #[test]
+    fn metered_sp_access_uses_the_sp_relative_cache() {
+        let mut ctx = metered_memory_ctx();
+        ctx.read_sp_mem("sp", 4, 1, false);
+        ctx.write_sp_mem("sp", -8, "value", 8);
+
+        assert!(ctx
+            .buf()
+            .contains("trace_sp_memory_access_leaf(&trace_memory, sp + 0x00000004u);"));
+        assert!(ctx
+            .buf()
+            .contains("trace_sp_memory_access_span(&trace_memory, sp - 0x00000008u, 8u);"));
+        assert!(!ctx.buf().contains("trace_memory_access_leaf(&trace_memory"));
+        assert!(!ctx.buf().contains("trace_memory_access_span(&trace_memory"));
     }
 }

--- a/extensions/riscv/rvr/src/i/instruction.rs
+++ b/extensions/riscv/rvr/src/i/instruction.rs
@@ -5,7 +5,7 @@ use rvr_openvm_ir::{
     ExtEmitCtx, ExtInstr, MemWidth,
 };
 
-use crate::instruction::{hex_u64, reg_operand, Reg, RA, ZERO};
+use crate::instruction::{hex_u64, reg_operand, Reg, RA, SP, ZERO};
 
 /// RV64I arithmetic or logical operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -203,8 +203,13 @@ impl ExtInstr for Rv64IInstr {
                 base,
                 offset,
             } => {
+                let is_sp_relative = *base == SP;
                 let base = ctx.read_var(*base);
-                let value = ctx.read_mem(&base, *offset, width.bytes(), *signed);
+                let value = if is_sp_relative {
+                    ctx.read_sp_mem(&base, *offset, width.bytes(), *signed)
+                } else {
+                    ctx.read_mem(&base, *offset, width.bytes(), *signed)
+                };
                 if *rd == ZERO {
                     // Pure execution still has to perform the potentially
                     // trapping load, but has no register write that would use
@@ -222,9 +227,14 @@ impl ExtInstr for Rv64IInstr {
                 src,
                 offset,
             } => {
+                let is_sp_relative = *base == SP;
                 let base = ctx.read_var(*base);
                 let value = ctx.read_var(*src);
-                ctx.write_mem(&base, *offset, &value, width.bytes());
+                if is_sp_relative {
+                    ctx.write_sp_mem(&base, *offset, &value, width.bytes());
+                } else {
+                    ctx.write_mem(&base, *offset, &value, width.bytes());
+                }
             }
             Self::Const { rd, value, .. } => ctx.write_var(*rd, &hex_u64(*value)),
         }
@@ -428,12 +438,26 @@ mod tests {
             unreachable!()
         }
 
-        fn read_mem(&mut self, _base: &str, _offset: i16, _width: u8, _signed: bool) -> String {
+        fn read_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String {
+            self.operations
+                .push(format!("read:{base}:{offset}:{width}:{signed}"));
             "loaded".to_string()
         }
 
-        fn write_mem(&mut self, _base: &str, _offset: i16, _val: &str, _width: u8) {
-            unreachable!()
+        fn read_sp_mem(&mut self, base: &str, offset: i16, width: u8, signed: bool) -> String {
+            self.operations
+                .push(format!("read-sp:{base}:{offset}:{width}:{signed}"));
+            "loaded".to_string()
+        }
+
+        fn write_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
+            self.operations
+                .push(format!("write:{base}:{offset}:{val}:{width}"));
+        }
+
+        fn write_sp_mem(&mut self, base: &str, offset: i16, val: &str, width: u8) {
+            self.operations
+                .push(format!("write-sp:{base}:{offset}:{val}:{width}"));
         }
 
         fn write_aligned_mem_block(&mut self, _addr: &str, _val: &str) {
@@ -502,10 +526,58 @@ mod tests {
     fn load_appends_only_architectural_destination_results() {
         let mut enabled = RecordingCtx::default();
         load(Reg::new(3)).emit_c(&mut enabled);
-        assert_eq!(enabled.operations, ["append:loaded", "write:r3=loaded"]);
+        assert_eq!(
+            enabled.operations,
+            ["read-sp:r2:4:4:true", "append:loaded", "write:r3=loaded"]
+        );
 
         let mut x0 = RecordingCtx::default();
         load(ZERO).emit_c(&mut x0);
-        assert_eq!(x0.operations, ["line:(void)loaded;", "write:r0=loaded"]);
+        assert_eq!(
+            x0.operations,
+            [
+                "read-sp:r2:4:4:true",
+                "line:(void)loaded;",
+                "write:r0=loaded"
+            ]
+        );
+    }
+
+    #[test]
+    fn memory_accesses_select_the_sp_cache_only_for_x2() {
+        let mut ctx = RecordingCtx::default();
+        Rv64IInstr::Load {
+            width: MemWidth::Byte,
+            signed: false,
+            rd: Reg::new(3),
+            base: Reg::new(4),
+            offset: -1,
+        }
+        .emit_c(&mut ctx);
+        Rv64IInstr::Store {
+            width: MemWidth::Double,
+            base: SP,
+            src: Reg::new(5),
+            offset: 8,
+        }
+        .emit_c(&mut ctx);
+        Rv64IInstr::Store {
+            width: MemWidth::Word,
+            base: Reg::new(6),
+            src: Reg::new(7),
+            offset: 12,
+        }
+        .emit_c(&mut ctx);
+
+        assert_eq!(
+            ctx.operations,
+            [
+                "read:r4:-1:1:false",
+                "append:loaded",
+                "write:r3=loaded",
+                "write-sp:r2:8:r5:8",
+                "write:r6:12:r7:4",
+            ]
+        );
     }
 }

--- a/extensions/riscv/rvr/src/instruction.rs
+++ b/extensions/riscv/rvr/src/instruction.rs
@@ -9,6 +9,8 @@ pub(crate) type Reg = Variable;
 
 pub(crate) const ZERO: Reg = Reg::new(0);
 pub(crate) const RA: Reg = Reg::new(1);
+// RISC-V register x2 is `sp`, the stack pointer.
+pub(crate) const SP: Reg = Reg::new(2);
 
 /// Decode an OpenVM RV64 register operand into its architectural register.
 pub(crate) fn decode_reg(value: u32) -> Reg {


### PR DESCRIPTION
- Metered RVR kept only one pending memory page per generated block. Alternating stack-pointer-relative and other memory accesses repeatedly evicted that page and appended redundant page-touch records.
- Direct RISC-V loads and stores based on `sp` now use a separate pending page and leaf mask; both caches are drained on flush and reset on reload.
- This only changes metered page bookkeeping. Memory access behavior and Rust-side checkpoint deduplication are unchanged, and extension-emitted memory accesses stay on the default cache.

Resolves INT-7482